### PR TITLE
fix(tui): clean up terminal on quit so mouse tracking doesn't leak to host shell

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -26,6 +26,12 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   exit" hint in the status bar); a second Ctrl+C within 1.5s exits.
   Matches the standard TUI muscle memory used by claude-code, fish,
   and ipython.
+- Quitting kobe (via Ctrl+C×2 or `q`) now restores the host terminal
+  cleanly — previously `process.exit(0)` skipped opentui's teardown,
+  leaving mouse tracking enabled (the host shell would receive a
+  stream of `\x1b[<…M` SGR mouse events from every cursor move) and
+  the alt-screen unrestored. The default `onQuit` now calls
+  `renderer.destroy()` first.
 
 ## [0.1.1] - 2026-05-09
 

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -202,7 +202,15 @@ export function useKobeKeybindings(opts: KobeKeybindingsOpts): void {
   const onQuit =
     opts.onQuit ??
     (() => {
-      renderer?.destroy()
+      // Defense in depth: if destroy() throws (FFI to native renderer
+      // can fail in odd states), the user who pressed Ctrl+C×2 must
+      // still get out — surface to stderr for the next shell prompt to
+      // see, then force-exit unconditionally.
+      try {
+        renderer?.destroy()
+      } catch (err) {
+        console.error("kobe: renderer.destroy() failed during quit:", err)
+      }
       process.exit(0)
     })
   const onFocusNext = opts.onFocusNext ?? (() => {})

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -192,7 +192,19 @@ export function useKobeKeybindings(opts: KobeKeybindingsOpts): void {
   const dialog: DialogContext = useDialog()
   const renderer = useRenderer()
 
-  const onQuit = opts.onQuit ?? (() => process.exit(0))
+  // process.exit() bypasses every opentui exit hook (`beforeExit`, signal
+  // listeners), so without first calling renderer.destroy() the terminal
+  // is left in TUI state on the way out: mouse tracking stays on (the
+  // shell sees a stream of \x1b[<...M sequences from every mouse move),
+  // alt-screen isn't restored, raw mode lingers. Tearing down the
+  // renderer first writes the disable sequences synchronously to stdout
+  // before exit() blocks Node.
+  const onQuit =
+    opts.onQuit ??
+    (() => {
+      renderer?.destroy()
+      process.exit(0)
+    })
   const onFocusNext = opts.onFocusNext ?? (() => {})
   const onFocusPrev = opts.onFocusPrev ?? (() => {})
 

--- a/packages/kobe/test/behavior/ctrl-c-quit.test.ts
+++ b/packages/kobe/test/behavior/ctrl-c-quit.test.ts
@@ -68,3 +68,45 @@ test("two Ctrl+C presses within the quit window exit kobe", async () => {
   }
   expect(kobe.closed).toBe(true)
 }, 30_000)
+
+test("double Ctrl+C exit cleans up the terminal (mouse tracking off, alt-screen restored)", async () => {
+  // Regression for the screenshot Jackson sent on 2026-05-10: after
+  // Ctrl+C×2, the host shell was being flooded with `\x1b[<...M` SGR
+  // mouse events because the previous default `onQuit = process.exit(0)`
+  // bypassed every opentui exit hook. The fix calls renderer.destroy()
+  // first, which writes the disable sequences synchronously through the
+  // native renderer before the process is killed.
+  kobe = await spawnKobe()
+  await kobe.waitFor((s) => s.includes("KobeCode") || s.includes("kobe"), 10_000)
+
+  await kobe.sendKeys("\x03")
+  await kobe.waitFor((s) => s.includes("Ctrl+C again"), 5_000)
+  await kobe.sendKeys("\x03")
+
+  const deadline = Date.now() + 5_000
+  while (!kobe.closed && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  expect(kobe.closed).toBe(true)
+
+  // After exit, the raw byte buffer should contain at least one of the
+  // mouse-tracking-disable sequences opentui emits on teardown:
+  //   \x1b[?1003l  any-event mouse off
+  //   \x1b[?1006l  SGR extended mouse off
+  //   \x1b[?1015l  urxvt-style mouse off
+  //   \x1b[?1000l  basic mouse off
+  // Any of them proves cleanup ran. Without renderer.destroy(), NONE
+  // of these sequences would be emitted.
+  const raw = kobe.captureRaw()
+  // Build the mouse-disable matcher from a string (avoids biome's
+  // noControlCharactersInRegex rule — ESC is intrinsic to ANSI matching
+  // here). \x1b followed by `[?` then any of the four mouse-mode codes
+  // followed by `l` (lowercase = disable).
+  const ESC = String.fromCharCode(0x1b)
+  const mouseDisable = new RegExp(`${ESC}\\[\\?(1000|1003|1006|1015)l`)
+  expect(raw).toMatch(mouseDisable)
+
+  // And alt-screen restored (`\x1b[?1049l`) — the user's host shell
+  // should be back, not stuck looking at TUI residue.
+  expect(raw).toContain(`${ESC}[?1049l`)
+}, 30_000)


### PR DESCRIPTION
## Summary

Follow-up to #4. After quitting kobe via Ctrl+C×2 (or `q`), the host shell receives a non-stop stream of `\x1b[<...M` SGR mouse events from every cursor move, and the alt-screen is left unrestored. Screenshot from this morning's bug report showed the host prompt buried under TUI residue plus a wall of mouse coordinate triples.

## Root cause

`useKobeKeybindings`'s default `onQuit` was `() => process.exit(0)`. `process.exit()` is a synchronous Node-level kill — it bypasses `beforeExit`, signal listeners, and every opentui exit hook. Without invoking `renderer.destroy()` first, the renderer never writes the terminal-restore sequences (`\x1b[?1003l`, `\x1b[?1006l`, `\x1b[?1049l`, `setRawMode(false)`) before stdout closes, so the TTY stays in raw + mouse-tracking mode.

Pre-#4 this never surfaced for Ctrl+C because opentui's built-in `exitOnCtrlC: true` handler called `destroy()` itself. Once #4 set `exitOnCtrlC: false` and routed Ctrl+C through `onQuit`, the unguarded `process.exit(0)` got hit. The `q` quit path has had this bug since day one (same default), but the confirm dialog masked it visually and most users wouldn't trigger it during heavy mouse activity.

## Fix

```diff
-  const onQuit = opts.onQuit ?? (() => process.exit(0))
+  const onQuit =
+    opts.onQuit ??
+    (() => {
+      renderer?.destroy()
+      process.exit(0)
+    })
```

`renderer.destroy()` walks `cleanupBeforeDestroy` → native `destroyRenderer`, which emits the disable sequences through stdout synchronously. They're flushed before `process.exit(0)` ends the loop, so the shell gets a clean TTY when control returns. Both Ctrl+C×2 and `q`-confirm paths fixed in one change since they share the default.

## Test

Adds a regression test to `test/behavior/ctrl-c-quit.test.ts`:

- Drives Ctrl+C×2, waits for pty close
- Asserts the raw byte buffer contains a mouse-disable sequence (any of `\x1b[?100Nl`) — would have NONE without `destroy()`
- Asserts alt-screen-exit (`\x1b[?1049l`) is present

Verified locally:
- [x] Old code (without `renderer.destroy()`) → new test fails (no mouse-disable in buffer)
- [x] New code → all 3 ctrl-c-quit tests pass
- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quitting the application (double Ctrl+C or 'q') now properly restores the terminal state, including disabling mouse tracking and restoring normal display mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/6)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->