### PR TITLE
fix: run dev script directly in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "packageManager": "bun@1.3.13",
   "workspaces": ["packages/*"],
   "scripts": {
-    "dev": "bun --filter @sma1lboy/kobe dev",
+    "dev": "cd packages/kobe && bun run dev",
     "build": "bun --filter @sma1lboy/kobe build",
     "typecheck": "bun --filter @sma1lboy/kobe typecheck",
     "test": "bun --filter @sma1lboy/kobe test",

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -27,9 +27,11 @@ const result = await Bun.build({
   // `ensureSolidTransformPlugin` is what `--preload` uses for the dev
   // runtime, but Bun.build only honours plugins passed in this list.
   plugins: [createSolidTransformPlugin()],
-  // Keep node-pty / fs / etc. external — they're either Bun built-ins
-  // or native modules that don't bundle.
-  external: ["node-pty"],
+  // Keep native/runtime-resolved packages external. @opentui/core loads
+  // @opentui/core-${platform}-${arch} dynamically; bundling core moves
+  // that dynamic import into dist/index.js, where Bun can no longer
+  // resolve the optional platform package under isolated installs.
+  external: ["node-pty", "@opentui/core"],
 })
 
 if (!result.success) {


### PR DESCRIPTION
  ## Summary

  Fixes two terminal startup/build issues for Kobe:

  - Run root `bun run dev` by entering `packages/kobe` directly instead of using `bun --filter`, so OpenTUI owns the current TTY and does not leak terminal control
  sequences into the shell.
  - Keep `@opentui/core` external in production builds because it dynamically resolves `@opentui/core-${platform}-${arch}` at runtime. Bundling it moved that dynamic
  import into `dist/index.js`, where isolated installs could not resolve the platform package.

  ## Verification

  - `bun run typecheck`
  - `bun run build`
  - `./packages/kobe/dist/index.js diagnose`
  - short timeout launch of `./packages/kobe/dist/index.js`
