### PR TITLE
fix(tui): don't steal focus from sidebar on cold boot

### DIFF
--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -220,6 +220,17 @@ export function Composer(props: ComposerProps) {
     setSlashCursor((cur) => (len === 0 ? 0 : Math.min(cur, len - 1)))
   })
 
+  // Mirror the workspace pane's focus state onto the textarea. Without
+  // this, Tab-ing into the workspace highlights the rail but keystrokes
+  // still go to whichever pane previously held opentui focus, and
+  // Tab-ing away leaves the textarea greedily eating keys it shouldn't.
+  createEffect(() => {
+    const ref = textareaRef
+    if (!ref) return
+    if (props.focused?.()) ref.focus()
+    else ref.blur()
+  })
+
   // Slash dropdown windowing — claude-code's autocomplete shows ~8 rows
   // and scrolls the window so the cursor stays visible. Without this,
   // typing `/` with 70+ commands paints the whole list and overflows
@@ -703,10 +714,12 @@ export function Composer(props: ComposerProps) {
                     // string is also fine — it's a no-op when content
                     // matches.
                     if (props.draft) r.setText(props.draft)
-                    // Auto-focus so the user can start typing immediately
-                    // after the chat pane mounts. This mirrors the prior
-                    // <input focused={true}> behavior.
-                    r.focus()
+                    // Only grab keyboard focus when the workspace pane
+                    // owns focus. On cold boot the sidebar is the
+                    // default focused pane (see FocusProvider) — stealing
+                    // focus here would desync the StatusBar label from
+                    // who actually receives keystrokes.
+                    if (props.focused?.()) r.focus()
                   }}
                   placeholder={resolvePlaceholder({
                     isStreaming: props.isStreaming,


### PR DESCRIPTION
## Summary
- The chat composer's textarea unconditionally called `r.focus()` in its ref callback, hijacking keyboard input on startup even though `FocusProvider` defaults the focused pane to `"sidebar"` — the StatusBar correctly showed `Tasks:` while keystrokes went to the composer.
- Composer now only grabs keyboard focus when `props.focused?.()` is true, and a new `createEffect` mirrors that signal so Tab in/out of the workspace pane drives `focus()` / `blur()` on the textarea.

## Test plan
- [ ] Launch kobe; verify the sidebar receives keys on cold boot and the StatusBar's `Tasks:` label matches actual focus.
- [ ] Tab into the workspace pane — composer should accept input; Tab away — sidebar/files/terminal should regain key handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect focus behavior where the composer would capture keyboard input when switching between panes, ensuring keystrokes are properly routed to the active pane.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/8)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->