### PR TITLE
fix(preview): wrap long lines in file view

### DIFF
--- a/packages/kobe/src/tui/panes/preview/DiffLine.tsx
+++ b/packages/kobe/src/tui/panes/preview/DiffLine.tsx
@@ -68,7 +68,7 @@ export function FileLine(props: { text: string }) {
   const { theme } = useTheme()
   return (
     <box paddingLeft={1} paddingRight={1}>
-      <text fg={theme.text} wrapMode="none">
+      <text fg={theme.text} wrapMode="word">
         {props.text || " "}
       </text>
     </box>


### PR DESCRIPTION
## Summary

`FileLine` had `wrapMode=\"none\"`, so opening a file with long lines (e.g. a markdown doc with one paragraph per line) showed the line truncated at the pane edge with no way to read the rest. Switch to `wrapMode=\"word\"` so the body wraps inside the preview pane.

`DiffLine` itself keeps `wrapMode=\"none\"` because diff rows must stay 1:1 with source lines for the +/- column to read correctly; wrapping there would shift everything below a long line out of alignment.

## Test plan

- [ ] Open a file with long lines (e.g. \`docs/DESIGN.md\`) in the preview pane → long lines wrap by word
- [ ] Toggle to Diff view on a file with a long modified line → diff rows still align 1:1 with source, no wrap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced text wrapping in the diff preview pane to wrap at word boundaries for improved readability and layout consistency, reducing horizontal overflow and making long lines easier to scan while preserving existing visual theming and blank-line behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/10)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->