### PR TITLE
feat(focus): two-tier focus model — select / engaged

### DIFF
--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -58,6 +58,7 @@
  */
 
 import { type Accessor, createSignal } from "solid-js"
+import { resolveDefaultModelId } from "../tui/panes/chat/composer/claude-settings.ts"
 import type {
   AIEngine,
   AskQuestionEntry,
@@ -71,7 +72,6 @@ import type {
   UserInputResponse,
 } from "../types/engine.ts"
 import type { ChatTab, PermissionMode, Task, TaskId, TaskStatus } from "../types/task.ts"
-import { resolveDefaultModelId } from "../tui/panes/chat/composer/claude-settings.ts"
 import { suggestBranchSlug } from "./branch-suggestion.ts"
 import type { TaskIndexStore, TaskIndexUnsubscribe } from "./index/store.ts"
 import { ulid } from "./index/ulid.ts"

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -1200,6 +1200,12 @@ function Shell(props: AppDeps) {
     j: "workspace",
     k: "files",
     l: "terminal",
+    // Byte-collision aliases: opentui parses \x08 (ctrl+h byte) as
+    // `backspace` and \x0a (ctrl+j byte) as `linefeed`, so the
+    // ctrl-letter chord never reaches the matcher. Map the named
+    // forms to the same targets — see KobeKeymap.focus.numeric.
+    backspace: "sidebar",
+    linefeed: "workspace",
   }
   useBindings(() => ({
     // Disabled in engaged mode — when the user is typing in chat or

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -459,8 +459,7 @@ function NewTaskDialog(props: {
         // Lowest-priority surface (custom path typing) sits between
         // the picker and the branch field.
         key: "tab",
-        cmd: () =>
-          setField((f) => (f === "repoPicker" ? "repoCustom" : f === "repoCustom" ? "baseRef" : "repoPicker")),
+        cmd: () => setField((f) => (f === "repoPicker" ? "repoCustom" : f === "repoCustom" ? "baseRef" : "repoPicker")),
       },
       {
         key: "up",
@@ -1805,7 +1804,12 @@ function Shell(props: AppDeps) {
             backgroundPanel tone as the sidebar so the two rails feel
             symmetric and the chat in the middle is visibly the focus. */}
         <box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} backgroundColor={theme.backgroundPanel}>
-          <box flexShrink={0} height={filesHeight()} flexDirection="column" onMouseUp={() => setFocusedPane("files", { engage: true })}>
+          <box
+            flexShrink={0}
+            height={filesHeight()}
+            flexDirection="column"
+            onMouseUp={() => setFocusedPane("files", { engage: true })}
+          >
             <PaneHeader
               title="FILES"
               ordinal="k"

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -777,18 +777,24 @@ export type AppDeps = {
 /* --------------------------------------------------------------------- */
 /*  PaneHeader — uniform CAPS-bold pane label (agent-deck-style chunking)  */
 /* --------------------------------------------------------------------- */
-function PaneHeader(props: { title: string; subtitle?: string; focused?: boolean; ordinal?: string | number }) {
+function PaneHeader(props: {
+  title: string
+  subtitle?: string
+  focused?: boolean
+  engaged?: boolean
+  ordinal?: string | number
+}) {
   const { theme } = useTheme()
-  // Focused panes paint in `theme.focusAccent` — a user-controllable
-  // slot (Settings → General → Focus accent) that resolves to one of
-  // primary / success / info. Default is primary (terracotta under
-  // Claude's palette), which doubles as the brand hue. The leading
-  // `▌` block character is the visibility hammer the prior bold-only
-  // title was missing — it attaches the focus signal to the title
-  // visually so the user's eye doesn't scan the whole screen to pick
-  // up the active pane.
+  // Two-color focus highlight on the title row, matching the Composer
+  // rail and Terminal border:
+  //   engaged  → theme.primary    (bright brand — keystrokes go here)
+  //   selected → theme.accent     (different hue — pane highlighted but
+  //                                pane-local keys don't fire yet; press
+  //                                enter to engage)
+  //   idle     → theme.textMuted  (muted)
   const focused = () => props.focused !== false
-  const titleColor = () => (focused() ? theme.focusAccent : theme.textMuted)
+  const engaged = () => props.engaged === true
+  const titleColor = () => (engaged() ? theme.primary : focused() ? theme.accent : theme.textMuted)
   return (
     <box
       flexDirection="row"
@@ -1737,6 +1743,7 @@ function Shell(props: AppDeps) {
             ordinal="j"
             subtitle={activeTask()?.title ?? "no task"}
             focused={focusedPane() === "workspace"}
+            engaged={focus.isEngaged("workspace")()}
           />
           <CenterTabStrip
             isChatActive={isChatTabActive}
@@ -1790,7 +1797,12 @@ function Shell(props: AppDeps) {
             symmetric and the chat in the middle is visibly the focus. */}
         <box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} backgroundColor={theme.backgroundPanel}>
           <box flexShrink={0} height={filesHeight()} flexDirection="column" onMouseUp={() => setFocusedPane("files", { engage: true })}>
-            <PaneHeader title="FILES" ordinal="k" focused={focusedPane() === "files"} />
+            <PaneHeader
+              title="FILES"
+              ordinal="k"
+              focused={focusedPane() === "files"}
+              engaged={focus.isEngaged("files")()}
+            />
             <box flexGrow={1}>
               <FileTree
                 worktreePath={worktreePathAcc}
@@ -1820,6 +1832,7 @@ function Shell(props: AppDeps) {
               ordinal="l"
               subtitle={worktreePathAcc() ? worktreePathAcc()?.split("/").slice(-1)[0] : undefined}
               focused={focusedPane() === "terminal"}
+              engaged={focus.isEngaged("terminal")()}
             />
             <box flexGrow={1}>
               <Terminal

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -1418,12 +1418,17 @@ function Shell(props: AppDeps) {
         // input. User can now ctrl+hjkl elsewhere or esc again to
         // detach all the way to sidebar.
         focus.disengage()
-      } else {
-        // Already in select mode → escape hatch: jump to sidebar and
-        // land engaged (the common intent is "show me the task list,
-        // I want to navigate"). User can disengage again with esc.
+      } else if (focusedPane() !== "sidebar") {
+        // Already in select mode on a non-sidebar pane → escape hatch:
+        // jump to sidebar and land engaged (the common intent is "show
+        // me the task list, I want to navigate"). User can disengage
+        // again with esc.
         setFocusedPane("sidebar", { engage: true })
       }
+      // Already on sidebar in select mode → no-op. Don't re-engage on
+      // every esc press; that would oscillate select ↔ engaged with
+      // each tap. The sidebar select state IS the "rest" position;
+      // pressing esc again has nowhere meaningful to go.
     },
     // Tab cycle is select-mode only. In engaged mode we forward tab
     // to whichever pane owns input (composer indent / shell autocomp).

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -1413,22 +1413,18 @@ function Shell(props: AppDeps) {
     //   3. select mode  → detach back to sidebar
     // Cases 2 + 3 land here — useKobeKeybindings already handled (1).
     onFocusDetach: () => {
+      // esc only disengages — stay on the current pane, just release
+      // input. The pane returns to select mode (A color) and the user
+      // can ctrl+hjkl elsewhere. To go to the sidebar specifically,
+      // press ctrl+h or ctrl+q (focus.sidebar) — not esc.
+      //
+      // No-op when already in select: there's no further "exit" to
+      // perform. Don't promote esc into a second action (jumping to
+      // sidebar) — it surprised users by changing focus when they only
+      // wanted to release the textarea.
       if (focus.mode() === "engaged") {
-        // First esc disengages: stay on the current pane, just release
-        // input. User can now ctrl+hjkl elsewhere or esc again to
-        // detach all the way to sidebar.
         focus.disengage()
-      } else if (focusedPane() !== "sidebar") {
-        // Already in select mode on a non-sidebar pane → escape hatch:
-        // jump to sidebar and land engaged (the common intent is "show
-        // me the task list, I want to navigate"). User can disengage
-        // again with esc.
-        setFocusedPane("sidebar", { engage: true })
       }
-      // Already on sidebar in select mode → no-op. Don't re-engage on
-      // every esc press; that would oscillate select ↔ engaged with
-      // each tap. The sidebar select state IS the "rest" position;
-      // pressing esc again has nowhere meaningful to go.
     },
     // Tab cycle is select-mode only. In engaged mode we forward tab
     // to whichever pane owns input (composer indent / shell autocomp).

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -788,13 +788,15 @@ function PaneHeader(props: {
   // Two-color focus highlight on the title row, matching the Composer
   // rail and Terminal border:
   //   engaged  → theme.primary    (bright brand — keystrokes go here)
-  //   selected → theme.accent     (different hue — pane highlighted but
+  //   selected → theme.info       (blue/cyan — pane highlighted but
   //                                pane-local keys don't fire yet; press
-  //                                enter to engage)
+  //                                enter to engage). Picked over `accent`
+  //                                because claude.json maps primary and
+  //                                accent to the same terracotta hue.
   //   idle     → theme.textMuted  (muted)
   const focused = () => props.focused !== false
   const engaged = () => props.engaged === true
-  const titleColor = () => (engaged() ? theme.primary : focused() ? theme.accent : theme.textMuted)
+  const titleColor = () => (engaged() ? theme.primary : focused() ? theme.info : theme.textMuted)
   return (
     <box
       flexDirection="row"

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -1208,15 +1208,14 @@ function Shell(props: AppDeps) {
     }),
   }))
 
-  // Enter in select mode on workspace/terminal → engage. Sidebar and
-  // files have their own pane-local enter (open-task / open-file);
-  // those are higher priority on the LIFO binding stack so this
-  // global binding only fires when those panes don't claim enter.
+  // Enter in select mode on any pane → engage that pane. Pane-local
+  // bindings (sidebar.select, files.open) gate on `engaged` so they
+  // can't fire in select mode anyway — this global enter wins, and
+  // the user has to press enter again (post-engage, the pane-local
+  // sidebar.select / files.open then takes over because it's now
+  // higher in the stack and active).
   useBindings(() => ({
-    enabled:
-      dialog.stack.length === 0 &&
-      focus.mode() === "select" &&
-      (focusedPane() === "workspace" || focusedPane() === "terminal"),
+    enabled: dialog.stack.length === 0 && focus.mode() === "select",
     bindings: [{ key: "return", cmd: () => focus.engage() }],
   }))
 
@@ -1407,9 +1406,15 @@ function Shell(props: AppDeps) {
     // Cases 2 + 3 land here — useKobeKeybindings already handled (1).
     onFocusDetach: () => {
       if (focus.mode() === "engaged") {
+        // First esc disengages: stay on the current pane, just release
+        // input. User can now ctrl+hjkl elsewhere or esc again to
+        // detach all the way to sidebar.
         focus.disengage()
       } else {
-        setFocusedPane("sidebar")
+        // Already in select mode → escape hatch: jump to sidebar and
+        // land engaged (the common intent is "show me the task list,
+        // I want to navigate"). User can disengage again with esc.
+        setFocusedPane("sidebar", { engage: true })
       }
     },
     // Tab cycle is select-mode only. In engaged mode we forward tab
@@ -1519,7 +1524,10 @@ function Shell(props: AppDeps) {
   useBindings(() => ({
     enabled: focusedPane() === "workspace" && dialog.stack.length === 0,
     bindings: bindByIds({
-      "focus.sidebar": () => setFocusedPane("sidebar"),
+      // ctrl+q from workspace → "back to tasks". User intent is to
+      // browse the task list, so land engaged so j/k works without
+      // an extra enter press.
+      "focus.sidebar": () => setFocusedPane("sidebar", { engage: true }),
     }),
   }))
 
@@ -1671,10 +1679,11 @@ function Shell(props: AppDeps) {
           flexShrink={0}
           flexDirection="column"
           backgroundColor={theme.backgroundPanel}
-          onMouseUp={() => setFocusedPane("sidebar")}
+          onMouseUp={() => setFocusedPane("sidebar", { engage: true })}
         >
           <Sidebar
             width={sidebarWidth}
+            engaged={focus.isEngaged("sidebar")}
             tasks={tasksAcc}
             onSelect={(id: string) => {
               setSelectedId(id)
@@ -1780,10 +1789,15 @@ function Shell(props: AppDeps) {
             backgroundPanel tone as the sidebar so the two rails feel
             symmetric and the chat in the middle is visibly the focus. */}
         <box flexDirection="column" flexGrow={1} flexShrink={1} flexBasis={0} backgroundColor={theme.backgroundPanel}>
-          <box flexShrink={0} height={filesHeight()} flexDirection="column" onMouseUp={() => setFocusedPane("files")}>
+          <box flexShrink={0} height={filesHeight()} flexDirection="column" onMouseUp={() => setFocusedPane("files", { engage: true })}>
             <PaneHeader title="FILES" ordinal="k" focused={focusedPane() === "files"} />
             <box flexGrow={1}>
-              <FileTree worktreePath={worktreePathAcc} onOpenFile={openFileInCenter} focused={isFocused("files")} />
+              <FileTree
+                worktreePath={worktreePathAcc}
+                onOpenFile={openFileInCenter}
+                focused={isFocused("files")}
+                engaged={focus.isEngaged("files")}
+              />
             </box>
           </box>
           {/* Files ↔ terminal splitter. */}
@@ -1799,7 +1813,7 @@ function Shell(props: AppDeps) {
             flexShrink={1}
             flexBasis={0}
             flexDirection="column"
-            onMouseUp={() => setFocusedPane("terminal")}
+            onMouseUp={() => setFocusedPane("terminal", { engage: true })}
           >
             <PaneHeader
               title="TERMINAL"

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -893,12 +893,19 @@ function StatusBar() {
 
   return (
     <box flexDirection="row" justifyContent="space-between" flexShrink={0} paddingLeft={1} paddingRight={1}>
-      {/* Left: section label + pane-local hotkeys (driven by KobeKeymap) */}
+      {/* Left: section label + pane-local hotkeys (driven by KobeKeymap).
+          Mode-aware: engaged shows the pane-local chord chips
+          (j/k/d/r/a, enter send, etc.); select hides them and shows a
+          single `[enter] engage` chip — the user is in nav mode, and
+          the right column already advertises the cross-pane chords
+          (ctrl+hjkl / tab) they can use without engaging. */}
       <box flexDirection="row" gap={2} flexShrink={1}>
         <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
           {sectionLabel()}
         </text>
-        <For each={leftHints()}>{(b) => <Hotkey keys={b.hint!.keys} label={b.hint!.label} />}</For>
+        <Show when={focus.mode() === "engaged"} fallback={<Hotkey keys="enter" label="engage" />}>
+          <For each={leftHints()}>{(b) => <Hotkey keys={b.hint!.keys} label={b.hint!.label} />}</For>
+        </Show>
       </box>
       {/* Right: global hotkeys (always available). Driven by KobeKeymap's
           `pin: "right"` rows. When ctrl+c is armed for double-tap quit,

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -1194,13 +1194,30 @@ function Shell(props: AppDeps) {
     l: "terminal",
   }
   useBindings(() => ({
-    enabled: dialog.stack.length === 0,
+    // Disabled in engaged mode — when the user is typing in chat or
+    // shelling in terminal, ctrl+hjkl must not steal them. They have
+    // to esc back to select mode first. (Sidebar/files focused is
+    // implicitly engaged but pane-local since those panes have no
+    // input — ctrl+hjkl works there.)
+    enabled: dialog.stack.length === 0 && focus.mode() === "select",
     bindings: bindByIds({
       "focus.numeric": (evt) => {
         const target = FOCUS_HJKL_TARGETS[evt.name ?? ""]
         if (target) setFocusedPane(target)
       },
     }),
+  }))
+
+  // Enter in select mode on workspace/terminal → engage. Sidebar and
+  // files have their own pane-local enter (open-task / open-file);
+  // those are higher priority on the LIFO binding stack so this
+  // global binding only fires when those panes don't claim enter.
+  useBindings(() => ({
+    enabled:
+      dialog.stack.length === 0 &&
+      focus.mode() === "select" &&
+      (focusedPane() === "workspace" || focusedPane() === "terminal"),
+    bindings: [{ key: "return", cmd: () => focus.engage() }],
   }))
 
   // Keyboard resize for the focused pane — fallback when mouse drag
@@ -1295,14 +1312,14 @@ function Shell(props: AppDeps) {
     previewApi()?.open(relPath)
     // Opening a file from the file tree pulls focus to the workspace
     // so the user can scroll/read with j/k without an extra ctrl+2.
-    setFocusedPane("workspace")
+    setFocusedPane("workspace", { engage: true })
   }
 
   function selectChatTab(): void {
     const id = selectedId()
     if (!id) return
     mutateTabs(id, (cur) => ({ ...cur, active: "chat" }))
-    setFocusedPane("workspace")
+    setFocusedPane("workspace", { engage: true })
   }
 
   // Chat tabs (multitab) — pulled off the active task so the
@@ -1321,7 +1338,7 @@ function Shell(props: AppDeps) {
       console.error("[kobe] setActiveTab failed:", err)
     })
     mutateTabs(id, (cur) => ({ ...cur, active: "chat" }))
-    setFocusedPane("workspace")
+    setFocusedPane("workspace", { engage: true })
   }
 
   function selectFileTab(relPath: string): void {
@@ -1329,7 +1346,7 @@ function Shell(props: AppDeps) {
     if (!id) return
     mutateTabs(id, (cur) => ({ ...cur, active: { kind: "file", path: relPath } }))
     previewApi()?.open(relPath)
-    setFocusedPane("workspace")
+    setFocusedPane("workspace", { engage: true })
   }
 
   function closeFileTab(relPath: string): void {
@@ -1383,14 +1400,25 @@ function Shell(props: AppDeps) {
 
   useKobeKeybindings({
     onShowHelp: () => HelpDialog.show(dialog),
-    onFocusDetach: () => setFocusedPane("sidebar"),
-    // Tab cycle is no-op while workspace is focused so the composer's
-    // own tab handling (dialog field cycling, indent, etc.) wins.
+    // esc has three jobs depending on state:
+    //   1. dialog open  → close dialog (handled inside useKobeKeybindings)
+    //   2. engaged mode → disengage (stay on pane, release input)
+    //   3. select mode  → detach back to sidebar
+    // Cases 2 + 3 land here — useKobeKeybindings already handled (1).
+    onFocusDetach: () => {
+      if (focus.mode() === "engaged") {
+        focus.disengage()
+      } else {
+        setFocusedPane("sidebar")
+      }
+    },
+    // Tab cycle is select-mode only. In engaged mode we forward tab
+    // to whichever pane owns input (composer indent / shell autocomp).
     onFocusNext: () => {
-      if (focusedPane() !== "workspace") focus.cycle(1)
+      if (focus.mode() === "select") focus.cycle(1)
     },
     onFocusPrev: () => {
-      if (focusedPane() !== "workspace") focus.cycle(-1)
+      if (focus.mode() === "select") focus.cycle(-1)
     },
   })
 
@@ -1422,7 +1450,7 @@ function Shell(props: AppDeps) {
       // without an extra ctrl+2. Mirrors the sidebar's onSelect
       // behaviour — both "user wants to look at this task" entry
       // points should land in the same place.
-      setFocusedPane("workspace")
+      setFocusedPane("workspace", { engage: true })
     } catch (err) {
       // Surface failure as stderr; we don't have a global banner yet,
       // and the chat pane may not be subscribed (no task selected).
@@ -1653,7 +1681,7 @@ function Shell(props: AppDeps) {
               // Selecting a task usually means "I want to look at it" —
               // pull focus to workspace so the user can immediately type
               // / scroll without another ctrl+2.
-              setFocusedPane("workspace")
+              setFocusedPane("workspace", { engage: true })
             }}
             onDeleteRequest={(id: string) => {
               void confirmDeleteTask(id)
@@ -1693,7 +1721,7 @@ function Shell(props: AppDeps) {
           flexDirection="column"
           flexShrink={0}
           width={workspaceWidth()}
-          onMouseUp={() => setFocusedPane("workspace")}
+          onMouseUp={() => setFocusedPane("workspace", { engage: true })}
         >
           <PaneHeader
             title="WORKSPACE"
@@ -1732,6 +1760,7 @@ function Shell(props: AppDeps) {
                 pendingPrompt={pendingPromptForActive}
                 onPendingPromptConsumed={() => setPendingPrompt(null)}
                 focused={isFocused("workspace")}
+                engaged={focus.isEngaged("workspace")}
               />
             </Show>
           </box>
@@ -1779,7 +1808,12 @@ function Shell(props: AppDeps) {
               focused={focusedPane() === "terminal"}
             />
             <box flexGrow={1}>
-              <Terminal cwd={worktreePathAcc} taskId={taskIdNullAcc} focused={isFocused("terminal")} />
+              <Terminal
+                cwd={worktreePathAcc}
+                taskId={taskIdNullAcc}
+                focused={isFocused("terminal")}
+                engaged={focus.isEngaged("terminal")}
+              />
             </box>
           </box>
         </box>

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -23,10 +23,10 @@
  *   - `esc`     — close (handled by the dialog stack).
  */
 
-import { TextAttributes } from "@opentui/core"
-import { useRenderer } from "@opentui/solid"
 import { unlinkSync } from "node:fs"
 import { join } from "node:path"
+import { TextAttributes } from "@opentui/core"
+import { useRenderer } from "@opentui/solid"
 import { For, Show, createMemo, createSignal } from "solid-js"
 import { homeDir } from "../../env"
 import type { KVContext } from "../context/kv"
@@ -316,13 +316,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
                   }}
                 >
                   <text
-                    fg={
-                      isSidebarFocused()
-                        ? theme.selectedListItemText
-                        : isSection()
-                          ? theme.accent
-                          : theme.textMuted
-                    }
+                    fg={isSidebarFocused() ? theme.selectedListItemText : isSection() ? theme.accent : theme.textMuted}
                     attributes={isSection() ? TextAttributes.BOLD : undefined}
                     wrapMode="none"
                   >

--- a/packages/kobe/src/tui/context/focus.tsx
+++ b/packages/kobe/src/tui/context/focus.tsx
@@ -1,19 +1,30 @@
 /**
  * Pane focus — global, single source of truth.
  *
- * The Shell wraps everything in `<FocusProvider>` so that:
+ * Two-tier focus model (vim-windows style):
  *
- *   1. Pane wrappers can call `useFocus().setFocused("sidebar")` from an
- *      `onMouseUp` handler — clicking any pane focuses it without a
- *      manual prop chain.
- *   2. Each pane reads `useFocus().is("sidebar")` to gate its own
- *      keybindings so j/k/enter/etc. only fire when that pane is the
- *      active one.
- *   3. Global single-letter shortcuts (`?`, `n`, `q`) gate on
- *      `useFocus().is("workspace") === false` — when the chat composer
- *      is the active input the user must be able to type `?` or `n` as
- *      literal characters. Ctrl-modified shortcuts (`ctrl+1`..`ctrl+4`,
- *      `ctrl+n`) bypass the input regardless and stay always-on.
+ *   - **`focused` pane** = which pane is *selected* — its border
+ *     highlights, navigation chords (ctrl+hjkl, tab) cycle here. The
+ *     pane is visible, but its inputs do NOT capture keystrokes.
+ *   - **`mode = "engaged"`** = the selected pane has *taken the keyboard*.
+ *     Chat composer's textarea grabs native opentui focus; terminal
+ *     pane forwards every byte to the PTY child. Nav chords (ctrl+hjkl /
+ *     tab) are disabled while engaged so the user can't accidentally
+ *     leave mid-typing.
+ *
+ * Sidebar / files don't have an "engaged" concept (no input fields):
+ * focusing them auto-sets mode = "engaged" since j/k/d/r/a etc. are
+ * the only keys that make sense there. So the mode signal is really
+ * only meaningful when `focused === "workspace"` or `"terminal"`.
+ *
+ * Transitions:
+ *   - `setFocused(pane)` resets mode: workspace/terminal → "select";
+ *     sidebar/files → "engaged".
+ *   - `engage()` flips mode to "engaged" (for workspace/terminal). Wired
+ *     to `enter` in select mode and to "open new chat" / "select task"
+ *     business flows so the user lands in the input directly.
+ *   - `disengage()` flips back to "select". Wired to `esc` so the user
+ *     can navigate without leaving the pane.
  *
  * Why a context (not just lifted signals in `Shell`):
  *
@@ -23,8 +34,6 @@
  *   - Mouse-driven focus changes happen on pane wrappers in app.tsx
  *     itself — having the setter in context means the wrapper code can
  *     just call into the context without app.tsx growing more closures.
- *   - Future panes (Wave 4: PR button, checks, etc.) get focus support
- *     "for free" by reading the context.
  *
  * The context only owns focus. Other global state (composer drafts,
  * task selection, etc.) stays where it is — focus is special because
@@ -37,16 +46,53 @@ import { type Accessor, type JSXElement, createContext, createSignal, useContext
 /** The four primary panes in kobe's layout. */
 export type PaneId = "sidebar" | "workspace" | "files" | "terminal"
 
+/**
+ * Focus mode. Only meaningful when the focused pane is workspace or
+ * terminal (the two panes that have input fields). For sidebar / files,
+ * the mode is implicitly "engaged" — those panes don't have a "type
+ * into me" sub-state.
+ */
+export type FocusMode = "select" | "engaged"
+
 /** Cycle order — used by `tab` / `shift+tab`. */
 export const PANE_ORDER = ["sidebar", "workspace", "files", "terminal"] as const satisfies readonly PaneId[]
+
+/** Panes that own input and therefore have a meaningful select/engaged mode. */
+const INPUT_PANES: ReadonlySet<PaneId> = new Set(["workspace", "terminal"])
 
 export type FocusContextValue = {
   /** Reactive read of the currently focused pane. */
   focused: Accessor<PaneId>
+  /** Reactive read of the current mode (select | engaged). */
+  mode: Accessor<FocusMode>
   /** Boolean accessor — `useFocus().is("sidebar")()` is true when sidebar is focused. */
   is: (pane: PaneId) => Accessor<boolean>
-  /** Set the focused pane. */
-  setFocused: (pane: PaneId) => void
+  /** Boolean accessor — true when `pane` is focused AND mode is "engaged". */
+  isEngaged: (pane: PaneId) => Accessor<boolean>
+  /**
+   * Set the focused pane. Resets mode based on the destination:
+   * workspace/terminal land in "select" by default (user must press
+   * enter to engage); sidebar/files always land in "engaged" since
+   * they have no select/engaged distinction.
+   *
+   * Pass `{ engage: true }` to land in engaged mode immediately —
+   * used by business flows that mean "the user is now driving this
+   * pane", e.g. clicking a chat tab, creating a task, mouse-clicking
+   * the workspace pane. Keyboard-driven pane jumps (ctrl+hjkl, tab)
+   * deliberately don't pass the flag so the user lands in select
+   * mode and can decide whether to engage.
+   */
+  setFocused: (pane: PaneId, opts?: { engage?: boolean }) => void
+  /**
+   * Switch to engaged mode for the currently focused pane. No-op if
+   * focused on sidebar/files (already implicitly engaged).
+   */
+  engage: () => void
+  /**
+   * Switch back to select mode for the currently focused pane. No-op
+   * if focused on sidebar/files (no select state to enter).
+   */
+  disengage: () => void
   /** Cycle by ±1 through PANE_ORDER. Used by `tab` / `shift+tab`. */
   cycle: (delta: 1 | -1) => void
 }
@@ -64,6 +110,11 @@ const FocusContext = createContext<FocusContextValue | null>(null)
  */
 export function FocusProvider(props: { children: JSXElement; initial?: PaneId }): JSXElement {
   const [focused, setFocusedSignal] = createSignal<PaneId>(props.initial ?? "sidebar")
+  // Initial mode follows the same rule as setFocused: input panes start
+  // in "select", non-input panes start in "engaged".
+  const [mode, setModeSignal] = createSignal<FocusMode>(
+    INPUT_PANES.has(props.initial ?? "sidebar") ? "select" : "engaged",
+  )
   const renderer = useRenderer()
 
   /**
@@ -89,8 +140,16 @@ export function FocusProvider(props: { children: JSXElement; initial?: PaneId })
    * files — they manage cursor state in Solid signals) are
    * unaffected.
    */
-  function setFocused(pane: PaneId): void {
-    if (focused() === pane) return
+  function setFocused(pane: PaneId, opts?: { engage?: boolean }): void {
+    // Business flows (click, task select, etc.) sometimes call
+    // setFocused on the same pane to "ensure engaged" — handle that
+    // even when the pane signal doesn't change.
+    if (focused() === pane) {
+      if (opts?.engage && INPUT_PANES.has(pane) && mode() !== "engaged") {
+        setModeSignal("engaged")
+      }
+      return
+    }
     const current = renderer?.currentFocusedRenderable
     if (current && !current.isDestroyed) {
       try {
@@ -101,6 +160,29 @@ export function FocusProvider(props: { children: JSXElement; initial?: PaneId })
       }
     }
     setFocusedSignal(pane)
+    // Mode reset:
+    //   sidebar / files → always "engaged" (no separate select state)
+    //   workspace / terminal → "select" by default; "engaged" if
+    //     business flow requested it via opts.engage.
+    if (!INPUT_PANES.has(pane)) {
+      setModeSignal("engaged")
+    } else {
+      setModeSignal(opts?.engage ? "engaged" : "select")
+    }
+  }
+
+  function engage(): void {
+    if (INPUT_PANES.has(focused())) {
+      setModeSignal("engaged")
+    }
+    // sidebar / files: no-op, already engaged-equivalent.
+  }
+
+  function disengage(): void {
+    if (INPUT_PANES.has(focused())) {
+      setModeSignal("select")
+    }
+    // sidebar / files: no-op, no select state to enter.
   }
 
   function cycle(delta: 1 | -1): void {
@@ -113,17 +195,37 @@ export function FocusProvider(props: { children: JSXElement; initial?: PaneId })
   // through reactive `focused?: Accessor<boolean>` props without
   // creating a fresh function each render (would defeat memoization
   // downstream).
-  const accessorCache = new Map<PaneId, Accessor<boolean>>()
+  const isCache = new Map<PaneId, Accessor<boolean>>()
   function is(pane: PaneId): Accessor<boolean> {
-    let acc = accessorCache.get(pane)
+    let acc = isCache.get(pane)
     if (!acc) {
       acc = () => focused() === pane
-      accessorCache.set(pane, acc)
+      isCache.set(pane, acc)
     }
     return acc
   }
 
-  const value: FocusContextValue = { focused, is, setFocused, cycle }
+  // Same memoization for isEngaged accessors.
+  const engagedCache = new Map<PaneId, Accessor<boolean>>()
+  function isEngaged(pane: PaneId): Accessor<boolean> {
+    let acc = engagedCache.get(pane)
+    if (!acc) {
+      acc = () => focused() === pane && mode() === "engaged"
+      engagedCache.set(pane, acc)
+    }
+    return acc
+  }
+
+  const value: FocusContextValue = {
+    focused,
+    mode,
+    is,
+    isEngaged,
+    setFocused,
+    engage,
+    disengage,
+    cycle,
+  }
   return <FocusContext.Provider value={value}>{props.children}</FocusContext.Provider>
 }
 

--- a/packages/kobe/src/tui/context/focus.tsx
+++ b/packages/kobe/src/tui/context/focus.tsx
@@ -12,19 +12,24 @@
  *     tab) are disabled while engaged so the user can't accidentally
  *     leave mid-typing.
  *
- * Sidebar / files don't have an "engaged" concept (no input fields):
- * focusing them auto-sets mode = "engaged" since j/k/d/r/a etc. are
- * the only keys that make sense there. So the mode signal is really
- * only meaningful when `focused === "workspace"` or `"terminal"`.
+ * All four panes share the same select/engaged distinction. Even
+ * sidebar/files have it — without it, their pane-local bare-letter
+ * bindings (j/k/d/r/a, 1/2/3) would still fire while the user is
+ * trying to navigate, defeating the whole point of select mode. The
+ * cost is one extra `enter` press to start nav-ing in the new pane,
+ * paid for by complete keyboard predictability.
+ *
+ * Cold boot is the one exception: the initial pane lands in `engaged`
+ * so first-time users can immediately press j/k on the task list
+ * without having to discover the "press enter to interact" rule.
  *
  * Transitions:
- *   - `setFocused(pane)` resets mode: workspace/terminal → "select";
- *     sidebar/files → "engaged".
- *   - `engage()` flips mode to "engaged" (for workspace/terminal). Wired
- *     to `enter` in select mode and to "open new chat" / "select task"
- *     business flows so the user lands in the input directly.
- *   - `disengage()` flips back to "select". Wired to `esc` so the user
- *     can navigate without leaving the pane.
+ *   - `setFocused(pane)` defaults mode to "select". Pass
+ *     `{ engage: true }` to land engaged immediately (used by mouse
+ *     click and business flows like task creation / selection).
+ *   - `engage()` flips mode to "engaged". Wired to `enter` in select
+ *     mode.
+ *   - `disengage()` flips back to "select". Wired to `esc`.
  *
  * Why a context (not just lifted signals in `Shell`):
  *
@@ -47,18 +52,14 @@ import { type Accessor, type JSXElement, createContext, createSignal, useContext
 export type PaneId = "sidebar" | "workspace" | "files" | "terminal"
 
 /**
- * Focus mode. Only meaningful when the focused pane is workspace or
- * terminal (the two panes that have input fields). For sidebar / files,
- * the mode is implicitly "engaged" — those panes don't have a "type
- * into me" sub-state.
+ * Focus mode. Applies to all four panes: select gates pane-local
+ * keybindings off (so global nav chord don't get eaten); engaged
+ * turns them on.
  */
 export type FocusMode = "select" | "engaged"
 
 /** Cycle order — used by `tab` / `shift+tab`. */
 export const PANE_ORDER = ["sidebar", "workspace", "files", "terminal"] as const satisfies readonly PaneId[]
-
-/** Panes that own input and therefore have a meaningful select/engaged mode. */
-const INPUT_PANES: ReadonlySet<PaneId> = new Set(["workspace", "terminal"])
 
 export type FocusContextValue = {
   /** Reactive read of the currently focused pane. */
@@ -70,28 +71,19 @@ export type FocusContextValue = {
   /** Boolean accessor — true when `pane` is focused AND mode is "engaged". */
   isEngaged: (pane: PaneId) => Accessor<boolean>
   /**
-   * Set the focused pane. Resets mode based on the destination:
-   * workspace/terminal land in "select" by default (user must press
-   * enter to engage); sidebar/files always land in "engaged" since
-   * they have no select/engaged distinction.
+   * Set the focused pane. Defaults to mode "select" — the user has
+   * to press enter to engage and start using pane-local bindings.
    *
    * Pass `{ engage: true }` to land in engaged mode immediately —
-   * used by business flows that mean "the user is now driving this
-   * pane", e.g. clicking a chat tab, creating a task, mouse-clicking
-   * the workspace pane. Keyboard-driven pane jumps (ctrl+hjkl, tab)
-   * deliberately don't pass the flag so the user lands in select
-   * mode and can decide whether to engage.
+   * used by mouse clicks, task creation/selection, file open, and
+   * other business flows where the intent is "the user is now driving
+   * this pane". Keyboard-driven pane jumps (ctrl+hjkl, tab) skip the
+   * flag so the user lands in select and can decide whether to engage.
    */
   setFocused: (pane: PaneId, opts?: { engage?: boolean }) => void
-  /**
-   * Switch to engaged mode for the currently focused pane. No-op if
-   * focused on sidebar/files (already implicitly engaged).
-   */
+  /** Switch the currently focused pane to engaged mode. */
   engage: () => void
-  /**
-   * Switch back to select mode for the currently focused pane. No-op
-   * if focused on sidebar/files (no select state to enter).
-   */
+  /** Switch the currently focused pane back to select mode. */
   disengage: () => void
   /** Cycle by ±1 through PANE_ORDER. Used by `tab` / `shift+tab`. */
   cycle: (delta: 1 | -1) => void
@@ -110,11 +102,11 @@ const FocusContext = createContext<FocusContextValue | null>(null)
  */
 export function FocusProvider(props: { children: JSXElement; initial?: PaneId }): JSXElement {
   const [focused, setFocusedSignal] = createSignal<PaneId>(props.initial ?? "sidebar")
-  // Initial mode follows the same rule as setFocused: input panes start
-  // in "select", non-input panes start in "engaged".
-  const [mode, setModeSignal] = createSignal<FocusMode>(
-    INPUT_PANES.has(props.initial ?? "sidebar") ? "select" : "engaged",
-  )
+  // Cold boot lands engaged so first-time users can immediately press
+  // j/k on the sidebar without having to discover the "enter to engage"
+  // rule. Subsequent keyboard pane jumps use setFocused without the
+  // engage flag and land in select.
+  const [mode, setModeSignal] = createSignal<FocusMode>("engaged")
   const renderer = useRenderer()
 
   /**
@@ -145,7 +137,7 @@ export function FocusProvider(props: { children: JSXElement; initial?: PaneId })
     // setFocused on the same pane to "ensure engaged" — handle that
     // even when the pane signal doesn't change.
     if (focused() === pane) {
-      if (opts?.engage && INPUT_PANES.has(pane) && mode() !== "engaged") {
+      if (opts?.engage && mode() !== "engaged") {
         setModeSignal("engaged")
       }
       return
@@ -160,29 +152,18 @@ export function FocusProvider(props: { children: JSXElement; initial?: PaneId })
       }
     }
     setFocusedSignal(pane)
-    // Mode reset:
-    //   sidebar / files → always "engaged" (no separate select state)
-    //   workspace / terminal → "select" by default; "engaged" if
-    //     business flow requested it via opts.engage.
-    if (!INPUT_PANES.has(pane)) {
-      setModeSignal("engaged")
-    } else {
-      setModeSignal(opts?.engage ? "engaged" : "select")
-    }
+    // Default mode after a pane jump is "select". Business flows opt
+    // into "engaged" via { engage: true } when the intent is "drive
+    // this pane immediately" (mouse click, task creation, etc.).
+    setModeSignal(opts?.engage ? "engaged" : "select")
   }
 
   function engage(): void {
-    if (INPUT_PANES.has(focused())) {
-      setModeSignal("engaged")
-    }
-    // sidebar / files: no-op, already engaged-equivalent.
+    setModeSignal("engaged")
   }
 
   function disengage(): void {
-    if (INPUT_PANES.has(focused())) {
-      setModeSignal("select")
-    }
-    // sidebar / files: no-op, no select state to enter.
+    setModeSignal("select")
   }
 
   function cycle(delta: 1 | -1): void {

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -410,27 +410,36 @@ export const KobeKeymap: readonly KobeBinding[] = [
     description: "Close chat tab",
   },
   {
-    // `ctrl+]` cycles forward, `ctrl+[` cycles backward — bracket
+    // `alt+]` cycles forward, `alt+[` cycles backward — bracket
     // pair mirrors the sidebar's `[/]` view switcher and the files
     // pane's `[/]` tab cycler so the bracket-pair pattern is
-    // consistent across panes. The earlier `ctrl+tab` /
-    // `ctrl+shift+tab` chord is dropped: `tab` is the global
-    // pane-cycle (focus.next) and the ctrl-prefixed variant felt
-    // collision-prone.
+    // consistent across panes. We use alt-bracket instead of
+    // ctrl-bracket because `ctrl+[` byte IS the ESC byte (\x1b) in
+    // every standard PTY — opentui parses it as `{name: "escape"}`
+    // and disengage fires instead of cycling. The alt variant
+    // arrives as `\x1b[` / `\x1b]`, which opentui's parseKeypress
+    // recognizes through the meta-prefix path.
     id: "chat.tab.cycle-next",
     scope: "workspace",
-    keys: ["ctrl+]"],
+    // alt+] (\x1b]) instead of ctrl+] — though ctrl+] has no byte
+    // collision, we move both cycle chords together so alt-bracket
+    // is the single mental model. ctrl+[ couldn't be kept because
+    // its byte (\x1b) IS the ESC byte; we can't tell the two apart
+    // in a standard PTY without kitty-keyboard / CSI-u extensions.
+    keys: ["alt+]"],
     category: "Workspace",
     description: "Next chat tab",
-    hint: { keys: "ctrl+]", label: "next tab" },
+    hint: { keys: "alt+]", label: "next tab" },
   },
   {
     id: "chat.tab.cycle-prev",
     scope: "workspace",
-    keys: ["ctrl+["],
+    // alt+[ (\x1b[) — see chat.tab.cycle-next above for the rationale
+    // (ctrl+[ collides with the bare ESC byte in standard PTYs).
+    keys: ["alt+["],
     category: "Workspace",
     description: "Previous chat tab",
-    hint: { keys: "ctrl+[", label: "prev tab" },
+    hint: { keys: "alt+[", label: "prev tab" },
   },
 
   // ─── Files ────────────────────────────────────────────────────────────

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -410,36 +410,36 @@ export const KobeKeymap: readonly KobeBinding[] = [
     description: "Close chat tab",
   },
   {
-    // `alt+]` cycles forward, `alt+[` cycles backward — bracket
-    // pair mirrors the sidebar's `[/]` view switcher and the files
-    // pane's `[/]` tab cycler so the bracket-pair pattern is
-    // consistent across panes. We use alt-bracket instead of
-    // ctrl-bracket because `ctrl+[` byte IS the ESC byte (\x1b) in
-    // every standard PTY — opentui parses it as `{name: "escape"}`
-    // and disengage fires instead of cycling. The alt variant
-    // arrives as `\x1b[` / `\x1b]`, which opentui's parseKeypress
-    // recognizes through the meta-prefix path.
+    // `ctrl+]` cycles forward, `ctrl+[` cycles backward (bracket
+    // pair mirrors sidebar/files `[/]` switchers). `ctrl+[` is
+    // known-broken: its byte IS the ESC byte, so the disengage
+    // handler fires before this chord can match. We keep it
+    // registered for help-dialog completeness and for terminals
+    // that DO disambiguate (kitty / CSI-u). On standard PTYs only
+    // `ctrl+]` is functional.
     id: "chat.tab.cycle-next",
     scope: "workspace",
-    // alt+] (\x1b]) instead of ctrl+] — though ctrl+] has no byte
-    // collision, we move both cycle chords together so alt-bracket
-    // is the single mental model. ctrl+[ couldn't be kept because
-    // its byte (\x1b) IS the ESC byte; we can't tell the two apart
-    // in a standard PTY without kitty-keyboard / CSI-u extensions.
-    keys: ["alt+]"],
+    keys: ["ctrl+]"],
     category: "Workspace",
     description: "Next chat tab",
-    hint: { keys: "alt+]", label: "next tab" },
+    hint: { keys: "ctrl+]", label: "next tab" },
   },
   {
     id: "chat.tab.cycle-prev",
     scope: "workspace",
-    // alt+[ (\x1b[) — see chat.tab.cycle-next above for the rationale
-    // (ctrl+[ collides with the bare ESC byte in standard PTYs).
-    keys: ["alt+["],
+    // KNOWN-BROKEN: ctrl+[ byte IS the bare ESC byte (\x1b) in every
+    // standard PTY, so opentui parses it as {name: "escape"} and the
+    // disengage handler fires instead of cycling. We keep it
+    // registered for help-dialog completeness (and in case the user's
+    // terminal supports kitty-keyboard / CSI-u to disambiguate). The
+    // pragmatic prev-tab path is to cycle past `cycle-next`
+    // (alt+]-style isn't great either — many macOS terminals send
+    // Option as the literal byte, not as ESC+key — so neither chord
+    // is universal). TODO: pick a real prev-tab chord (F-key?).
+    keys: ["ctrl+["],
     category: "Workspace",
     description: "Previous chat tab",
-    hint: { keys: "alt+[", label: "prev tab" },
+    hint: { keys: "ctrl+[", label: "prev tab" },
   },
 
   // ─── Files ────────────────────────────────────────────────────────────

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -237,14 +237,21 @@ export const KobeKeymap: readonly KobeBinding[] = [
     // Why hjkl and not 1234? ctrl+digit needs CSI-u (which iTerm2
     // doesn't fully support — ctrl+1 falls through to a bare `1`
     // byte) and alt+digit gets eaten by macOS launchers like
-    // Raycast. ctrl+letter just works. The conflict with composer
-    // editing chords (ctrl+h=backspace etc.) is OK in practice
-    // because the user's intent when pressing ctrl+h is "switch
-    // pane," and once focus moves to sidebar the textarea has
-    // already lost focus.
+    // Raycast. ctrl+letter just works.
+    //
+    // Byte-collision aliases: ctrl+h byte (\x08) is parsed by
+    // opentui as `backspace`, ctrl+j byte (\x0a) as `linefeed` (see
+    // node_modules/@opentui/core/.../parseKeypress around line 5985
+    // — those special-case branches fire before the ctrl-letter
+    // branch). Without registering the aliases below, ctrl+h /
+    // ctrl+j chords never match anything in select mode and the
+    // user can't navigate left/down. The alias is safe to register
+    // because focus.numeric is gated to mode === "select" — engaged
+    // mode never sees these handlers (so backspace stays free for
+    // textarea editing while the user is typing).
     id: "focus.numeric",
     scope: "global",
-    keys: ["ctrl+h", "ctrl+j", "ctrl+k", "ctrl+l"],
+    keys: ["ctrl+h", "ctrl+j", "ctrl+k", "ctrl+l", "backspace", "linefeed"],
     category: "Navigation",
     description: "Jump to pane (h=sidebar, j=workspace, k=files, l=terminal)",
     hint: { keys: "ctrl+hjkl", label: "focus", pin: "right" },

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -410,35 +410,20 @@ export const KobeKeymap: readonly KobeBinding[] = [
     description: "Close chat tab",
   },
   {
-    // Chat-tab cycling is a tab-prefix sequence, not a single chord:
-    // press `tab` (arms a 600ms window), then `]` for next or `[`
-    // for previous. The prefix is implemented in Chat.tsx
-    // (`armTabPrefix` / module-level signal); these KobeKeymap rows
-    // exist for help-dialog visibility only — `keys: []` skips
-    // bindByIds registration, and the `hint` field carries the
-    // composite chord string for the StatusBar.
-    //
-    // Why prefix-sequence and not a ctrl chord: ctrl+[ byte IS the
-    // bare ESC byte (\x1b) in every standard PTY, so opentui
-    // parses it as `{name: "escape"}` and disengage fires before
-    // any cycle handler can match. alt+[ / alt+] also failed for
-    // the user in their terminal config. Tmux-style prefix
-    // sidesteps the byte-level collision entirely.
+    // Chat-tab cycling is single-direction-only by design. ctrl+]
+    // wraps around to walk through all tabs; there's no prev-tab
+    // chord because the obvious pair `ctrl+[` byte IS the ESC byte
+    // (\x1b) in standard PTYs — it disengages workspace instead of
+    // cycling. Tried alt+[ (terminal Option-key config quirks) and
+    // a tab-prefix sequence (felt clunky); the pragmatic choice for
+    // a 2–3-tab UX is one-direction cycle, press N-1 times to walk
+    // backwards.
     id: "chat.tab.cycle-next",
     scope: "workspace",
-    keys: [],
+    keys: ["ctrl+]"],
     category: "Workspace",
-    description: "Next chat tab",
-    hint: { keys: "tab ]", label: "next tab" },
-  },
-  {
-    id: "chat.tab.cycle-prev",
-    scope: "workspace",
-    // Implemented as `tab → [` prefix sequence (see Chat.tsx).
-    keys: [],
-    category: "Workspace",
-    description: "Previous chat tab",
-    hint: { keys: "tab [", label: "prev tab" },
+    description: "Cycle chat tab (wraps around)",
+    hint: { keys: "ctrl+]", label: "cycle tab" },
   },
 
   // ─── Files ────────────────────────────────────────────────────────────

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -410,36 +410,35 @@ export const KobeKeymap: readonly KobeBinding[] = [
     description: "Close chat tab",
   },
   {
-    // `ctrl+]` cycles forward, `ctrl+[` cycles backward (bracket
-    // pair mirrors sidebar/files `[/]` switchers). `ctrl+[` is
-    // known-broken: its byte IS the ESC byte, so the disengage
-    // handler fires before this chord can match. We keep it
-    // registered for help-dialog completeness and for terminals
-    // that DO disambiguate (kitty / CSI-u). On standard PTYs only
-    // `ctrl+]` is functional.
+    // Chat-tab cycling is a tab-prefix sequence, not a single chord:
+    // press `tab` (arms a 600ms window), then `]` for next or `[`
+    // for previous. The prefix is implemented in Chat.tsx
+    // (`armTabPrefix` / module-level signal); these KobeKeymap rows
+    // exist for help-dialog visibility only — `keys: []` skips
+    // bindByIds registration, and the `hint` field carries the
+    // composite chord string for the StatusBar.
+    //
+    // Why prefix-sequence and not a ctrl chord: ctrl+[ byte IS the
+    // bare ESC byte (\x1b) in every standard PTY, so opentui
+    // parses it as `{name: "escape"}` and disengage fires before
+    // any cycle handler can match. alt+[ / alt+] also failed for
+    // the user in their terminal config. Tmux-style prefix
+    // sidesteps the byte-level collision entirely.
     id: "chat.tab.cycle-next",
     scope: "workspace",
-    keys: ["ctrl+]"],
+    keys: [],
     category: "Workspace",
     description: "Next chat tab",
-    hint: { keys: "ctrl+]", label: "next tab" },
+    hint: { keys: "tab ]", label: "next tab" },
   },
   {
     id: "chat.tab.cycle-prev",
     scope: "workspace",
-    // KNOWN-BROKEN: ctrl+[ byte IS the bare ESC byte (\x1b) in every
-    // standard PTY, so opentui parses it as {name: "escape"} and the
-    // disengage handler fires instead of cycling. We keep it
-    // registered for help-dialog completeness (and in case the user's
-    // terminal supports kitty-keyboard / CSI-u to disambiguate). The
-    // pragmatic prev-tab path is to cycle past `cycle-next`
-    // (alt+]-style isn't great either — many macOS terminals send
-    // Option as the literal byte, not as ESC+key — so neither chord
-    // is universal). TODO: pick a real prev-tab chord (F-key?).
-    keys: ["ctrl+["],
+    // Implemented as `tab → [` prefix sequence (see Chat.tsx).
+    keys: [],
     category: "Workspace",
     description: "Previous chat tab",
-    hint: { keys: "ctrl+[", label: "prev tab" },
+    hint: { keys: "tab [", label: "prev tab" },
   },
 
   // ─── Files ────────────────────────────────────────────────────────────

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -97,6 +97,13 @@ export type ChatProps = {
    * own focus.
    */
   focused?: Accessor<boolean>
+  /**
+   * Whether the chat pane is engaged (textarea takes the keyboard).
+   * In select mode (focused but not engaged) the rail still
+   * highlights but global nav chords (ctrl+hjkl, tab, esc) work.
+   * Falls back to `focused` for legacy single-mode hosts.
+   */
+  engaged?: Accessor<boolean>
 }
 
 export function Chat(props: ChatProps) {
@@ -809,7 +816,7 @@ export function Chat(props: ChatProps) {
         <Loading startedAt={turnStartedAt()} responseChars={currentTurnChars()} />
       </Show>
 
-      {/* Composer. */}
+      {/* Composer. focused = visual rail; engaged = textarea native focus. */}
       <Composer
         draft={draft()}
         onDraftChange={setDraft}
@@ -824,6 +831,7 @@ export function Chat(props: ChatProps) {
         }
         onSubmit={handleComposerSubmit}
         focused={props.focused}
+        engaged={props.engaged}
         // Per-tab history scope — prompt history shouldn't bleed across tabs.
         historyKey={activeTabId() ?? props.taskId()}
         slashes={slashes}

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -899,11 +899,7 @@ function QueuedPromptList(props: {
               <box flexGrow={1}>
                 <text fg={theme.text}>{entry.text}</text>
               </box>
-              <text
-                fg={theme.error}
-                attributes={TextAttributes.BOLD}
-                onMouseUp={() => props.onCancel(entry.id)}
-              >
+              <text fg={theme.error} attributes={TextAttributes.BOLD} onMouseUp={() => props.onCancel(entry.id)}>
                 [x]
               </text>
             </box>

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -39,6 +39,41 @@
 
 import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { type Accessor, For, Show, createEffect, createMemo, createSignal, on, onCleanup, onMount } from "solid-js"
+
+/**
+ * Tab-prefix arming for chat-tab cycle.
+ *
+ * The "obvious" chord pair `ctrl+]` / `ctrl+[` is a non-starter — the
+ * `ctrl+[` byte IS the bare ESC byte (\x1b) in every standard PTY, so
+ * pressing it disengages workspace instead of cycling tabs. We use a
+ * tmux-style prefix instead: `tab` arms a short window, then `]`
+ * cycles to the next chat tab / `[` cycles to the previous. Outside
+ * the window the brackets type literally into the composer like any
+ * other character.
+ *
+ * Singleton signal because only one workspace is ever live in the
+ * app; the arm/disarm pair is module-scoped so React-style
+ * remounting (task switch reloads Chat) doesn't leak timers across
+ * lives.
+ */
+const TAB_PREFIX_WINDOW_MS = 600
+const [tabPrefixArmed, setTabPrefixArmedRaw] = createSignal(false)
+let tabPrefixTimer: ReturnType<typeof setTimeout> | null = null
+
+function armTabPrefix(): void {
+  setTabPrefixArmedRaw(true)
+  if (tabPrefixTimer !== null) clearTimeout(tabPrefixTimer)
+  tabPrefixTimer = setTimeout(() => {
+    tabPrefixTimer = null
+    setTabPrefixArmedRaw(false)
+  }, TAB_PREFIX_WINDOW_MS)
+}
+
+function disarmTabPrefix(): void {
+  if (tabPrefixTimer !== null) clearTimeout(tabPrefixTimer)
+  tabPrefixTimer = null
+  setTabPrefixArmedRaw(false)
+}
 import type { Orchestrator } from "../../../orchestrator/core.ts"
 import type { OrchestratorEvent, PermissionMode } from "../../../types/engine.ts"
 import type { ChatTab } from "../../../types/task.ts"
@@ -656,19 +691,60 @@ export function Chat(props: ChatProps) {
   }
 
   // Pane-scoped keybindings: only fire when the chat pane is focused.
-  // No numeric pick — chat tabs cycle via ctrl+[ / ctrl+] so
-  // ctrl+1..4 stays uncontested as the global pane-focus chord (see
-  // docs/KEYBINDINGS.md). NOTE: ctrl+[ byte IS the ESC byte in
-  // standard PTYs so cycle-prev is functionally broken outside
-  // kitty-keyboard terminals — see KobeKeymap.chat.tab.cycle-prev.
+  // No numeric pick — chat tabs cycle via the tab-prefix sequence
+  // (tab → ] / tab → [) so ctrl+1..4 stays uncontested as the global
+  // pane-focus chord. See `armTabPrefix` near the top of this file
+  // for the rationale (ctrl+[ collides with the ESC byte).
   useBindings(() => ({
     enabled: props.focused?.() === true,
     bindings: bindByIds({
       "chat.tab.new": () => void newTab(),
       "chat.tab.close": () => void closeActiveTab(),
-      "chat.tab.cycle-next": () => cycleTab(1),
-      "chat.tab.cycle-prev": () => cycleTab(-1),
     }),
+  }))
+
+  // Tab-prefix sequence for chat tab cycling. While the workspace
+  // pane is engaged, the user presses `tab` to arm; within
+  // TAB_PREFIX_WINDOW_MS they press `]` for next or `[` for prev.
+  //
+  // Two separate useBindings groups:
+  //   1. tab → arm. Always live when engaged. preventDefault so
+  //      composer's textarea doesn't see a stray tab character.
+  //   2. [ / ] → cycle + disarm. Only enabled while armed; otherwise
+  //      brackets type literally into the draft (the composer
+  //      textarea handles them via its character-insert fallback).
+  useBindings(() => ({
+    enabled: props.engaged?.() === true,
+    bindings: [
+      {
+        key: "tab",
+        cmd: (evt) => {
+          armTabPrefix()
+          evt.preventDefault()
+        },
+      },
+    ],
+  }))
+  useBindings(() => ({
+    enabled: props.engaged?.() === true && tabPrefixArmed(),
+    bindings: [
+      {
+        key: "]",
+        cmd: (evt) => {
+          cycleTab(1)
+          disarmTabPrefix()
+          evt.preventDefault()
+        },
+      },
+      {
+        key: "[",
+        cmd: (evt) => {
+          cycleTab(-1)
+          disarmTabPrefix()
+          evt.preventDefault()
+        },
+      },
+    ],
   }))
 
   // Spinner shows whenever a turn is in flight — independent of how

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -656,9 +656,11 @@ export function Chat(props: ChatProps) {
   }
 
   // Pane-scoped keybindings: only fire when the chat pane is focused.
-  // No numeric pick — chat tabs cycle via alt+[ / alt+] so ctrl+hjkl
-  // and ctrl+1..4 stay uncontested as global pane-focus chords (see
-  // docs/KEYBINDINGS.md). Was ctrl+[ / ctrl+] but ctrl+[ byte = ESC.
+  // No numeric pick — chat tabs cycle via ctrl+[ / ctrl+] so
+  // ctrl+1..4 stays uncontested as the global pane-focus chord (see
+  // docs/KEYBINDINGS.md). NOTE: ctrl+[ byte IS the ESC byte in
+  // standard PTYs so cycle-prev is functionally broken outside
+  // kitty-keyboard terminals — see KobeKeymap.chat.tab.cycle-prev.
   useBindings(() => ({
     enabled: props.focused?.() === true,
     bindings: bindByIds({

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -39,41 +39,6 @@
 
 import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { type Accessor, For, Show, createEffect, createMemo, createSignal, on, onCleanup, onMount } from "solid-js"
-
-/**
- * Tab-prefix arming for chat-tab cycle.
- *
- * The "obvious" chord pair `ctrl+]` / `ctrl+[` is a non-starter — the
- * `ctrl+[` byte IS the bare ESC byte (\x1b) in every standard PTY, so
- * pressing it disengages workspace instead of cycling tabs. We use a
- * tmux-style prefix instead: `tab` arms a short window, then `]`
- * cycles to the next chat tab / `[` cycles to the previous. Outside
- * the window the brackets type literally into the composer like any
- * other character.
- *
- * Singleton signal because only one workspace is ever live in the
- * app; the arm/disarm pair is module-scoped so React-style
- * remounting (task switch reloads Chat) doesn't leak timers across
- * lives.
- */
-const TAB_PREFIX_WINDOW_MS = 600
-const [tabPrefixArmed, setTabPrefixArmedRaw] = createSignal(false)
-let tabPrefixTimer: ReturnType<typeof setTimeout> | null = null
-
-function armTabPrefix(): void {
-  setTabPrefixArmedRaw(true)
-  if (tabPrefixTimer !== null) clearTimeout(tabPrefixTimer)
-  tabPrefixTimer = setTimeout(() => {
-    tabPrefixTimer = null
-    setTabPrefixArmedRaw(false)
-  }, TAB_PREFIX_WINDOW_MS)
-}
-
-function disarmTabPrefix(): void {
-  if (tabPrefixTimer !== null) clearTimeout(tabPrefixTimer)
-  tabPrefixTimer = null
-  setTabPrefixArmedRaw(false)
-}
 import type { Orchestrator } from "../../../orchestrator/core.ts"
 import type { OrchestratorEvent, PermissionMode } from "../../../types/engine.ts"
 import type { ChatTab } from "../../../types/task.ts"
@@ -691,60 +656,19 @@ export function Chat(props: ChatProps) {
   }
 
   // Pane-scoped keybindings: only fire when the chat pane is focused.
-  // No numeric pick — chat tabs cycle via the tab-prefix sequence
-  // (tab → ] / tab → [) so ctrl+1..4 stays uncontested as the global
-  // pane-focus chord. See `armTabPrefix` near the top of this file
-  // for the rationale (ctrl+[ collides with the ESC byte).
+  // ctrl+] cycles to the next chat tab (wraps around). No prev chord:
+  // ctrl+[ byte = ESC in standard PTYs (disengage collision); alt+[
+  // didn't fire reliably in the user's terminal; ctrl+left would work
+  // but at the cost of textarea word-movement. Single-direction cycle
+  // keeps the chord set tight — multi-tab users press ctrl+] N-1
+  // times to walk back, which is fine for the common 2–3 tab case.
   useBindings(() => ({
     enabled: props.focused?.() === true,
     bindings: bindByIds({
       "chat.tab.new": () => void newTab(),
       "chat.tab.close": () => void closeActiveTab(),
+      "chat.tab.cycle-next": () => cycleTab(1),
     }),
-  }))
-
-  // Tab-prefix sequence for chat tab cycling. While the workspace
-  // pane is engaged, the user presses `tab` to arm; within
-  // TAB_PREFIX_WINDOW_MS they press `]` for next or `[` for prev.
-  //
-  // Two separate useBindings groups:
-  //   1. tab → arm. Always live when engaged. preventDefault so
-  //      composer's textarea doesn't see a stray tab character.
-  //   2. [ / ] → cycle + disarm. Only enabled while armed; otherwise
-  //      brackets type literally into the draft (the composer
-  //      textarea handles them via its character-insert fallback).
-  useBindings(() => ({
-    enabled: props.engaged?.() === true,
-    bindings: [
-      {
-        key: "tab",
-        cmd: (evt) => {
-          armTabPrefix()
-          evt.preventDefault()
-        },
-      },
-    ],
-  }))
-  useBindings(() => ({
-    enabled: props.engaged?.() === true && tabPrefixArmed(),
-    bindings: [
-      {
-        key: "]",
-        cmd: (evt) => {
-          cycleTab(1)
-          disarmTabPrefix()
-          evt.preventDefault()
-        },
-      },
-      {
-        key: "[",
-        cmd: (evt) => {
-          cycleTab(-1)
-          disarmTabPrefix()
-          evt.preventDefault()
-        },
-      },
-    ],
   }))
 
   // Spinner shows whenever a turn is in flight — independent of how

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -656,9 +656,9 @@ export function Chat(props: ChatProps) {
   }
 
   // Pane-scoped keybindings: only fire when the chat pane is focused.
-  // No numeric pick — chat tabs cycle via ctrl+[/ctrl+] so ctrl+1..4
-  // is uncontested as the global pane-focus chord (see
-  // docs/KEYBINDINGS.md).
+  // No numeric pick — chat tabs cycle via alt+[ / alt+] so ctrl+hjkl
+  // and ctrl+1..4 stay uncontested as global pane-focus chords (see
+  // docs/KEYBINDINGS.md). Was ctrl+[ / ctrl+] but ctrl+[ byte = ESC.
   useBindings(() => ({
     enabled: props.focused?.() === true,
     bindings: bindByIds({

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -655,9 +655,12 @@ export function Composer(props: ComposerProps) {
   //
   // Two-color focus highlight: select and engaged use clearly different
   // hues so the user can tell at a glance which mode they're in, even
-  // without reading the StatusBar.
+  // without reading the StatusBar. We pick `info` (typically blue/cyan)
+  // for selected because every bundled theme keeps it distinct from
+  // `primary` — `accent` collides with `primary` in claude.json
+  // (both terracotta), so it can't carry the contrast on its own.
   //   engaged  → theme.primary  (bright brand — your keystrokes go here)
-  //   selected → theme.accent   (different hue — pane highlighted, but
+  //   selected → theme.info     (blue/cyan — pane highlighted, but
   //                              keys still navigate; press enter to engage)
   //   idle     → theme.border   (muted gray)
   const railColor = () => {
@@ -665,7 +668,7 @@ export function Composer(props: ComposerProps) {
     if (badge) return toneColor(badge.tone)
     const engaged = props.engaged?.() ?? props.focused?.() ?? false
     if (engaged) return theme.primary
-    if (props.focused?.()) return theme.accent
+    if (props.focused?.()) return theme.info
     return theme.border
   }
 

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -653,19 +653,19 @@ export function Composer(props: ComposerProps) {
   // Mode wins over focus so "you are in plan mode" persists even when
   // clicking into a sibling pane.
   //
-  // Engaged vs focused: when the workspace is engaged (textarea takes
-  // keys), the rail brightens to theme.primary — the same brand hue used
-  // in single-mode hosts that pre-date the two-tier focus model. When
-  // the workspace is merely focused/selected (border highlight, but the
-  // user hasn't pressed enter yet), we step down to theme.focusAccent so
-  // the visual cue tracks the keyboard semantics: brighter rail = your
-  // typing goes here.
+  // Two-color focus highlight: select and engaged use clearly different
+  // hues so the user can tell at a glance which mode they're in, even
+  // without reading the StatusBar.
+  //   engaged  → theme.primary  (bright brand — your keystrokes go here)
+  //   selected → theme.accent   (different hue — pane highlighted, but
+  //                              keys still navigate; press enter to engage)
+  //   idle     → theme.border   (muted gray)
   const railColor = () => {
     const badge = modeBadge()
     if (badge) return toneColor(badge.tone)
     const engaged = props.engaged?.() ?? props.focused?.() ?? false
     if (engaged) return theme.primary
-    if (props.focused?.()) return theme.focusAccent
+    if (props.focused?.()) return theme.accent
     return theme.border
   }
 

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -116,9 +116,17 @@ export interface ComposerProps {
   /**
    * When true, the composer's accent rail picks up `theme.primary`
    * instead of `theme.border`. Optional: callers that don't thread
-   * focus get the unfocused (idle) styling.
+   * focus get the unfocused (idle) styling. This is the "selected"
+   * signal — it controls visuals only, not native keyboard capture.
    */
   focused?: Accessor<boolean>
+  /**
+   * When true, the textarea grabs native opentui focus and starts
+   * eating keystrokes. This is the engaged-mode signal. Optional;
+   * when omitted, falls back to `focused` so single-mode hosts (tests,
+   * legacy embedders) work without changes.
+   */
+  engaged?: Accessor<boolean>
   /**
    * Optional model label rendered on the right side of the inline
    * footer (e.g. `"Claude Sonnet 4.6"`). Falls back to the literal
@@ -228,14 +236,20 @@ export function Composer(props: ComposerProps) {
     setSlashCursor((cur) => (len === 0 ? 0 : Math.min(cur, len - 1)))
   })
 
-  // Mirror the workspace pane's focus state onto the textarea. Without
-  // this, Tab-ing into the workspace highlights the rail but keystrokes
-  // still go to whichever pane previously held opentui focus, and
-  // Tab-ing away leaves the textarea greedily eating keys it shouldn't.
+  // Mirror the workspace pane's *engaged* state onto the textarea.
+  // Without this, Tab-ing into the workspace highlights the rail but
+  // keystrokes still go to whichever pane previously held opentui
+  // focus, and Tab-ing away leaves the textarea greedily eating keys
+  // it shouldn't. We mirror engaged (not selected) so global nav
+  // chords (ctrl+hjkl, tab, esc) keep working in select mode — the
+  // textarea only takes over once the user explicitly engages.
+  // `engaged` falls back to `focused` so single-mode hosts (tests,
+  // legacy embedders) keep their always-engaged-when-focused behavior.
+  const isEngaged = () => props.engaged?.() ?? props.focused?.() ?? false
   createEffect(() => {
     const ref = textareaRef
     if (!ref) return
-    if (props.focused?.()) ref.focus()
+    if (isEngaged()) ref.focus()
     else ref.blur()
   })
 
@@ -633,14 +647,25 @@ export function Composer(props: ComposerProps) {
         return theme.textMuted
     }
   }
-  // Rail color priority: non-default mode > focused > idle border. Mode
-  // wins over focus so the visual signal "you are in plan mode" persists
-  // even when the user clicks into a sibling pane (you'd otherwise drop
-  // back to the muted border and forget the mode is on).
+  // Rail color priority:
+  //   non-default mode (plan / bypass) > engaged > focused (select) > idle.
+  //
+  // Mode wins over focus so "you are in plan mode" persists even when
+  // clicking into a sibling pane.
+  //
+  // Engaged vs focused: when the workspace is engaged (textarea takes
+  // keys), the rail brightens to theme.primary — the same brand hue used
+  // in single-mode hosts that pre-date the two-tier focus model. When
+  // the workspace is merely focused/selected (border highlight, but the
+  // user hasn't pressed enter yet), we step down to theme.focusAccent so
+  // the visual cue tracks the keyboard semantics: brighter rail = your
+  // typing goes here.
   const railColor = () => {
     const badge = modeBadge()
     if (badge) return toneColor(badge.tone)
-    if (props.focused?.()) return theme.primary
+    const engaged = props.engaged?.() ?? props.focused?.() ?? false
+    if (engaged) return theme.primary
+    if (props.focused?.()) return theme.focusAccent
     return theme.border
   }
 
@@ -748,11 +773,14 @@ export function Composer(props: ComposerProps) {
                     // matches.
                     if (props.draft) r.setText(props.draft)
                     // Only grab keyboard focus when the workspace pane
-                    // owns focus. On cold boot the sidebar is the
-                    // default focused pane (see FocusProvider) — stealing
-                    // focus here would desync the StatusBar label from
-                    // who actually receives keystrokes.
-                    if (props.focused?.()) r.focus()
+                    // is engaged. On cold boot we're in select mode
+                    // (sidebar focused) — stealing focus here would
+                    // desync the StatusBar label from who actually
+                    // receives keystrokes. With the two-tier model,
+                    // even when the workspace is selected we wait for
+                    // the user to press enter (engage) before taking
+                    // over keys.
+                    if (isEngaged()) r.focus()
                   }}
                   placeholder={resolvePlaceholder({
                     isStreaming: props.isStreaming,

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -247,9 +247,19 @@ export function Composer(props: ComposerProps) {
   // legacy embedders) keep their always-engaged-when-focused behavior.
   const isEngaged = () => props.engaged?.() ?? props.focused?.() ?? false
   createEffect(() => {
+    // CRITICAL: read isEngaged() BEFORE the textareaRef bail-out.
+    // Solid's createEffect only subscribes to signals that are read
+    // during the effect's run. If the first run early-returns at
+    // `if (!ref) return`, isEngaged() never gets called, mode() is
+    // never tracked, and the effect won't re-run when the user
+    // later presses enter to engage. textareaRef is a plain `let`,
+    // not a signal — mutating it doesn't trigger re-runs — so we
+    // can't lean on it. Calling isEngaged() first guarantees the
+    // subscription is always established.
+    const engaged = isEngaged()
     const ref = textareaRef
     if (!ref) return
-    if (isEngaged()) ref.focus()
+    if (engaged) ref.focus()
     else ref.blur()
   })
 

--- a/packages/kobe/src/tui/panes/chat/composer/claude-settings.ts
+++ b/packages/kobe/src/tui/panes/chat/composer/claude-settings.ts
@@ -28,8 +28,8 @@
  * don't fs-stat on every render.
  */
 
-import { homedir } from "node:os"
 import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
 import { join } from "node:path"
 
 /** Path matches claude-code's `getSettings_DEPRECATED()` location. */

--- a/packages/kobe/src/tui/panes/chat/composer/keybindings.ts
+++ b/packages/kobe/src/tui/panes/chat/composer/keybindings.ts
@@ -64,12 +64,13 @@ export const composerKeyBindings: Binding[] = [
   { name: "linefeed", action: "newline" },
   // Ctrl+W: opentui's textarea default is `delete-word-backward`, but
   // chat.tab.close (KobeKeymap.workspace) wants ctrl+w. Override with
-  // a `noop` action — opentui's _actionHandlers map has no "noop"
-  // entry, so getKeyBindingAction returns "noop" → handler lookup
-  // misses → handleKeyPress returns false (unhandled, no
+  // a fake action — opentui's `_actionHandlers` map has no entry for
+  // this string, so `getKeyBindingAction` returns it but handler
+  // lookup misses. `handleKeyPress` then returns false (unhandled, no
   // preventDefault), letting the global useBindings listener catch
-  // ctrl+w cleanly. Cost: shell-style word delete is gone in the
-  // composer; the user can still backspace word-by-word with esc to
-  // disengage and re-engage, or use the text deletion they prefer.
-  { name: "w", ctrl: true, action: "noop" },
+  // ctrl+w cleanly. The cast is required because `TextareaAction` is
+  // a union of bona fide actions; we're intentionally using a name
+  // outside the union to disable the chord. Cost: shell-style word
+  // delete is gone in the composer.
+  { name: "w", ctrl: true, action: "noop" as Binding["action"] },
 ]

--- a/packages/kobe/src/tui/panes/chat/composer/keybindings.ts
+++ b/packages/kobe/src/tui/panes/chat/composer/keybindings.ts
@@ -62,4 +62,14 @@ export const composerKeyBindings: Binding[] = [
   // newline at the cursor. Default already maps `linefeed → newline`,
   // we restate it for clarity (the override-merge would no-op).
   { name: "linefeed", action: "newline" },
+  // Ctrl+W: opentui's textarea default is `delete-word-backward`, but
+  // chat.tab.close (KobeKeymap.workspace) wants ctrl+w. Override with
+  // a `noop` action — opentui's _actionHandlers map has no "noop"
+  // entry, so getKeyBindingAction returns "noop" → handler lookup
+  // misses → handleKeyPress returns false (unhandled, no
+  // preventDefault), letting the global useBindings listener catch
+  // ctrl+w cleanly. Cost: shell-style word delete is gone in the
+  // composer; the user can still backspace word-by-word with esc to
+  // disengage and re-engage, or use the text deletion they prefer.
+  { name: "w", ctrl: true, action: "noop" },
 ]

--- a/packages/kobe/src/tui/panes/chat/store.ts
+++ b/packages/kobe/src/tui/panes/chat/store.ts
@@ -331,11 +331,7 @@ export function pushUser(state: ChatState, prompt: string, nowIso: string = new 
  * the same millisecond distinct (Date.now() granularity isn't fine
  * enough on fast machines).
  */
-export function enqueuePrompt(
-  state: ChatState,
-  prompt: string,
-  nowIso: string = new Date().toISOString(),
-): ChatState {
+export function enqueuePrompt(state: ChatState, prompt: string, nowIso: string = new Date().toISOString()): ChatState {
   if (state.queue.length >= QUEUE_SOFT_CAP) return state
   const id = `q-${nowIso}-${Math.random().toString(36).slice(2, 8)}`
   return {

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -95,6 +95,8 @@ export type FileTreeProps = {
    * thread real signals when the 5-pane layout lands.
    */
   focused?: Accessor<boolean>
+  /** Whether the pane is engaged (j/k/[]/r etc. fire). Optional fallback to focused. */
+  engaged?: Accessor<boolean>
 }
 
 /**
@@ -284,6 +286,7 @@ export function FileTree(props: FileTreeProps) {
 
   useFileTreeBindings({
     focused: focusedAccessor,
+    engaged: props.engaged,
     moveDown,
     moveUp,
     setTab: (t) => setTab(t),

--- a/packages/kobe/src/tui/panes/filetree/keys.ts
+++ b/packages/kobe/src/tui/panes/filetree/keys.ts
@@ -39,8 +39,14 @@ export type FileTreeTab = "all" | "changes" | "checks"
 export const TAB_ORDER: readonly FileTreeTab[] = ["all", "changes", "checks"]
 
 export type FileTreeBindingsOpts = {
-  /** Whether the pane should respond to keys. Default `() => true`. */
+  /**
+   * Whether the file tree pane is selected (border highlight). Visual
+   * gate only — bindings fire when `engaged` is true, falling back to
+   * `focused` for legacy single-mode hosts.
+   */
   focused: Accessor<boolean>
+  /** Whether the pane is engaged (mode === engaged). Optional fallback to focused. */
+  engaged?: Accessor<boolean>
   /** Move the cursor to the next visible row. */
   moveDown: () => void
   /** Move the cursor to the previous visible row. */
@@ -62,8 +68,9 @@ export type FileTreeBindingsOpts = {
  * component unmounts.
  */
 export function useFileTreeBindings(opts: FileTreeBindingsOpts): void {
+  const isActive = () => opts.engaged?.() ?? opts.focused()
   useBindings(() => ({
-    enabled: opts.focused(),
+    enabled: isActive(),
     bindings: bindByIds({
       "files.nav": (evt) => {
         if (evt.name === "j" || evt.name === "down") opts.moveDown()

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -128,8 +128,7 @@ export function Sidebar(props: SidebarProps) {
   //                               in every bundled theme; `accent`
   //                               collides with primary in claude.json)
   //   idle     → theme.textMuted
-  const titleColor = () =>
-    engagedAccessor() ? theme.primary : focusedAccessor() ? theme.info : theme.textMuted
+  const titleColor = () => (engagedAccessor() ? theme.primary : focusedAccessor() ? theme.info : theme.textMuted)
 
   // Active view; default to the working session. `[` / `]` cycle
   // through `VIEW_TABS`.

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -60,6 +60,8 @@ export type SidebarProps = {
   selectedId: Accessor<string | null>
   onSelect: (id: string) => void
   focused?: Accessor<boolean>
+  /** Whether the sidebar is engaged (j/k/d/r/a etc. fire). Optional fallback to focused. */
+  engaged?: Accessor<boolean>
   onDeleteRequest?: (taskId: string) => void
   /**
    * Archive-toggle callback. Wave 4.5: pressing `a` flips the cursor
@@ -183,6 +185,7 @@ export function Sidebar(props: SidebarProps) {
 
   useSidebarBindings({
     focused: focusedAccessor,
+    engaged: props.engaged,
     cursorIndex,
     setCursorIndex,
     flatTaskIds: flatIds,

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -121,6 +121,11 @@ export function Sidebar(props: SidebarProps) {
   const { theme } = useTheme()
 
   const focusedAccessor = () => (props.focused ? props.focused() : true)
+  const engagedAccessor = () => (props.engaged ? props.engaged() : focusedAccessor())
+  // Two-color title highlight: engaged → primary, selected → accent,
+  // idle → textMuted. See sidebar header render below.
+  const titleColor = () =>
+    engagedAccessor() ? theme.primary : focusedAccessor() ? theme.accent : theme.textMuted
 
   // Active view; default to the working session. `[` / `]` cycle
   // through `VIEW_TABS`.
@@ -206,25 +211,21 @@ export function Sidebar(props: SidebarProps) {
       paddingLeft={2}
       paddingRight={2}
     >
-      {/* Header: "kobe" with a focus-aware ▌ marker matching PaneHeader's
-         convention — focus-accent ▌ + focus-accent title when this
-         pane has focus, dimmed when not. Reads `theme.focusAccent`
-         so a Settings change unifies the focus signal across all
-         panes (default = primary / terracotta). */}
+      {/* Header: "h TASKS" with two-color focus highlight matching
+         PaneHeader / Composer / Terminal:
+           engaged  → theme.primary  (bright brand)
+           selected → theme.accent   (different hue — pane highlighted
+                                     but pane-local keys don't fire;
+                                     press enter to engage)
+           idle     → theme.textMuted */}
       <box flexDirection="row" gap={1} paddingBottom={1}>
         {/* Bold `h` flush left — matches WORKSPACE/FILES/TERMINAL
             shape. Letter is the ctrl+hjkl chord that focuses this
-            pane (h = sidebar, j = workspace, k = files, l = terminal).
-            Focus-tracking color (focusAccent vs textMuted) does the
-            chord-hint job. */}
-        <text
-          fg={focusedAccessor() ? theme.focusAccent : theme.textMuted}
-          attributes={TextAttributes.BOLD}
-          wrapMode="none"
-        >
+            pane (h = sidebar, j = workspace, k = files, l = terminal). */}
+        <text fg={titleColor()} attributes={TextAttributes.BOLD} wrapMode="none">
           h
         </text>
-        <text fg={focusedAccessor() ? theme.focusAccent : theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
+        <text fg={titleColor()} attributes={TextAttributes.BOLD} wrapMode="none">
           TASKS
         </text>
       </box>

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -122,10 +122,14 @@ export function Sidebar(props: SidebarProps) {
 
   const focusedAccessor = () => (props.focused ? props.focused() : true)
   const engagedAccessor = () => (props.engaged ? props.engaged() : focusedAccessor())
-  // Two-color title highlight: engaged → primary, selected → accent,
-  // idle → textMuted. See sidebar header render below.
+  // Two-color title highlight, matching the other panes:
+  //   engaged  → theme.primary   (bright brand)
+  //   selected → theme.info      (blue/cyan — distinct from primary
+  //                               in every bundled theme; `accent`
+  //                               collides with primary in claude.json)
+  //   idle     → theme.textMuted
   const titleColor = () =>
-    engagedAccessor() ? theme.primary : focusedAccessor() ? theme.accent : theme.textMuted
+    engagedAccessor() ? theme.primary : focusedAccessor() ? theme.info : theme.textMuted
 
   // Active view; default to the working session. `[` / `]` cycle
   // through `VIEW_TABS`.

--- a/packages/kobe/src/tui/panes/sidebar/keys.ts
+++ b/packages/kobe/src/tui/panes/sidebar/keys.ts
@@ -43,7 +43,10 @@ import { createSidebarController } from "./controller"
  * signals; the component owns the cursor state and we just push it.
  */
 export type SidebarBindingsOpts = {
-  /** Whether the sidebar should respond to keys at all. */
+  /**
+   * Whether the sidebar pane is selected (border highlight). Visual
+   * only; bindings don't fire in select mode.
+   */
   focused: Accessor<boolean>
   /** Current cursor index into the flat task id list. -1 if no tasks. */
   cursorIndex: Accessor<number>
@@ -98,7 +101,11 @@ export type SidebarBindingsOpts = {
  * Internally builds a {@link SidebarController} and wires its methods to
  * the keymap layer.
  */
-export function useSidebarBindings(opts: SidebarBindingsOpts): void {
+export function useSidebarBindings(opts: SidebarBindingsOpts & { engaged?: Accessor<boolean> }): void {
+  // Bindings fire only when engaged. Falls back to focused for hosts
+  // that don't pass an engaged accessor (legacy single-mode tests),
+  // preserving previous behavior.
+  const isActive = () => opts.engaged?.() ?? opts.focused()
   const ctrl = createSidebarController({
     getCursor: () => opts.cursorIndex(),
     setCursor: (n) => opts.setCursorIndex(n),
@@ -117,7 +124,7 @@ export function useSidebarBindings(opts: SidebarBindingsOpts): void {
   }
 
   useBindings(() => ({
-    enabled: opts.focused(),
+    enabled: isActive(),
     bindings: bindByIds({
       // sidebar.nav covers j/k/down/up — handler discriminates direction
       // via evt.name. The matcher delivers e.g. {name: "j"} or {name: "down"}.

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -63,7 +63,16 @@ export type TerminalProps = {
   cwd: Accessor<string | null>
   /** Stable id used for tmux session naming or pty registry keying. */
   taskId: Accessor<string | null>
+  /** Whether the terminal pane is selected (border highlight, scroll OK). */
   focused?: Accessor<boolean>
+  /**
+   * Whether the terminal pane is engaged (mode === "engaged"). Only
+   * when engaged does the pane forward keystrokes to the PTY child.
+   * Optional for backwards compat with hosts that don't pass it (tests);
+   * defaults to falling back to `focused` so the pane behaves the old
+   * way (single-mode, always-passthrough-when-focused).
+   */
+  engaged?: Accessor<boolean>
   /**
    * Optional registry override (tests inject a mock-backed registry).
    * Production usage relies on a single module-level registry below;
@@ -124,6 +133,11 @@ export function Terminal(props: TerminalProps): JSXElement {
   // provided so behavior tests can drive focus.
   const [focusedLocal, setFocusedLocal] = createSignal(false)
   const focused = () => props.focused?.() ?? focusedLocal()
+  // Engaged: when true the pane forwards every keystroke to the PTY.
+  // Defaults to `focused` so legacy callers (tests, host-mode)
+  // continue to behave as before — they're effectively single-mode
+  // (always-engaged-when-focused).
+  const engaged = () => props.engaged?.() ?? focused()
 
   // The current PTY — null when no task is active.
   const [pty, setPty] = createSignal<TaskPty | null>(null)
@@ -215,6 +229,7 @@ export function Terminal(props: TerminalProps): JSXElement {
 
   useTerminalBindings({
     focused,
+    engaged,
     write: (data) => {
       const handle = pty()
       if (!handle || handle.killed) return
@@ -325,7 +340,10 @@ export function Terminal(props: TerminalProps): JSXElement {
     <box
       flexDirection="column"
       flexGrow={1}
-      borderColor={focused() ? theme.focusAccent : theme.border}
+      // engaged → brighter brand hue (your keystrokes go here);
+      // focused/select → dim accent (border highlight only, no input);
+      // idle → muted border.
+      borderColor={engaged() ? theme.primary : focused() ? theme.focusAccent : theme.border}
       onMouseUp={() => setFocusedLocal(true)}
     >
       {/* Header (the parent PaneHeader already labels TERMINAL; this

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -342,9 +342,9 @@ export function Terminal(props: TerminalProps): JSXElement {
       flexGrow={1}
       // Two-color focus highlight, matching Composer:
       //   engaged  → theme.primary (bright brand — keystrokes here)
-      //   selected → theme.accent  (different hue — highlighted but inert)
+      //   selected → theme.info    (blue/cyan — highlighted but inert)
       //   idle     → theme.border  (muted gray)
-      borderColor={engaged() ? theme.primary : focused() ? theme.accent : theme.border}
+      borderColor={engaged() ? theme.primary : focused() ? theme.info : theme.border}
       onMouseUp={() => setFocusedLocal(true)}
     >
       {/* Header (the parent PaneHeader already labels TERMINAL; this

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -340,10 +340,11 @@ export function Terminal(props: TerminalProps): JSXElement {
     <box
       flexDirection="column"
       flexGrow={1}
-      // engaged → brighter brand hue (your keystrokes go here);
-      // focused/select → dim accent (border highlight only, no input);
-      // idle → muted border.
-      borderColor={engaged() ? theme.primary : focused() ? theme.focusAccent : theme.border}
+      // Two-color focus highlight, matching Composer:
+      //   engaged  → theme.primary (bright brand — keystrokes here)
+      //   selected → theme.accent  (different hue — highlighted but inert)
+      //   idle     → theme.border  (muted gray)
+      borderColor={engaged() ? theme.primary : focused() ? theme.accent : theme.border}
       onMouseUp={() => setFocusedLocal(true)}
     >
       {/* Header (the parent PaneHeader already labels TERMINAL; this

--- a/packages/kobe/src/tui/panes/terminal/keys-pure.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys-pure.ts
@@ -74,8 +74,20 @@ export const DEFAULT_PAGE_SIZE = 10
 /**
  * Names of keys we trap (do NOT forward to the shell). Re-exported so
  * documentation / tests can assert the list without re-deriving it.
+ *
+ * `escape` is trapped (not forwarded) so the user can leave the
+ * terminal pane the same way they leave any other pane — pressing esc
+ * falls through the empty pane-local stack and hits the global
+ * `focus.detach` handler in `useKobeKeybindings`, which routes back to
+ * the sidebar. Without this, the terminal pane was a one-way trip:
+ * once focused (e.g. via ctrl+l), every chord that can switch panes
+ * (ctrl+hjkl, esc) was forwarded to the shell as raw bytes.
+ *
+ * Trade-off: shells with vi-mode or other esc-sensitive line-editor
+ * extensions lose the in-line esc gesture. bash/zsh's default emacs
+ * mode doesn't use esc, so this is a low-cost trade.
  */
-export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown"] as const
+export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown", "escape"] as const
 
 /**
  * Names opentui's keypress events use that we want forwarded to the
@@ -105,7 +117,9 @@ export const PASSTHROUGH_NAMES: readonly string[] = [
   "end",
   "pageup",
   "pagedown",
-  "escape",
+  // `escape` deliberately NOT forwarded — it's the user's escape hatch
+  // out of the terminal pane back to the sidebar via the global
+  // focus.detach binding. See TRAPPED_KEYS above.
   "insert",
   "f1",
   "f2",

--- a/packages/kobe/src/tui/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys.ts
@@ -4,22 +4,35 @@
  * The terminal pane is the most "passthrough" of the five panes: when
  * focused, every keystroke (including `ctrl+c` to interrupt the running
  * command, `ctrl+d` to send EOF, arrow keys to navigate the shell's
- * line-editor history) goes to the underlying PTY. We do NOT trap them.
+ * line-editor history) goes to the underlying PTY. We do NOT trap them
+ * — with three exceptions.
  *
- * Exception list (these stay in kobe and never reach the shell):
+ * Trapped keys (these stay in kobe and never reach the shell):
  *
  *   - `ctrl+pgup`   — scroll the local scrollback up by one page
  *   - `ctrl+pgdown` — scroll the local scrollback down by one page
+ *   - `escape`      — escape hatch: falls through this pane's empty
+ *                     handler list and hits the global `focus.detach`
+ *                     binding, which returns focus to the sidebar.
+ *                     Without this, ctrl+hjkl pane-jump chords also
+ *                     pass through to the shell, leaving the terminal
+ *                     pane keyboard-only-one-way (mouse-out only).
  *
- * Rationale for the exception: the scrollback view is a kobe-rendered
- * widget, not the live tmux pane content. Scrolling is a UI gesture,
- * not a shell input. Without these we'd never be able to see history
- * once it scrolled past the visible viewport. We pick `ctrl+pgup/down`
- * because:
+ * Rationale for the scroll exception: the scrollback view is a
+ * kobe-rendered widget, not the live PTY content. Scrolling is a UI
+ * gesture, not a shell input. We pick `ctrl+pgup/down` because:
  *   - tmux uses the same chord pair under its prefix for buffer scroll;
  *     the muscle memory transfers.
  *   - bare `pgup`/`pgdown` already mean "scroll the shell's primary
  *     buffer" in many terminals — we leave those for the shell.
+ *
+ * Rationale for escape: a focused terminal pane forwards every chord
+ * the user might press to go elsewhere (ctrl+hjkl, F1, tab, etc.) as
+ * raw bytes to the shell. Trapping `esc` and letting the global
+ * `focus.detach` handler take over restores keyboard escape from the
+ * pane. Cost: shells in vi line-editor mode lose esc as a mode switch.
+ * bash/zsh's default emacs mode doesn't use esc; tradeoff judged worth
+ * it.
  *
  * Focus gating: the bindings are scoped via `enabled = focused()`. When
  * a sibling pane is focused, even our exception keys pass through the

--- a/packages/kobe/src/tui/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys.ts
@@ -58,8 +58,21 @@ export { DEFAULT_PAGE_SIZE, TRAPPED_KEYS, keyEventToShellBytes }
  * keystrokes into the right channel.
  */
 export type TerminalBindingsOpts = {
-  /** Whether the terminal pane currently has focus. */
+  /**
+   * Whether the terminal pane is currently selected (border highlight).
+   * Used to gate scrollback chord (`ctrl+pgup`/`ctrl+pgdown`) — those
+   * stay available in select mode so the user can browse history
+   * without engaging the shell.
+   */
   focused: Accessor<boolean>
+  /**
+   * Whether the terminal pane is engaged (mode === "engaged"). Only
+   * when engaged does the pane forward keystrokes to the PTY child.
+   * In select mode the terminal pane is "passive" — it shows the shell
+   * output but doesn't capture input, so global nav chords (ctrl+hjkl,
+   * tab, esc) work normally.
+   */
+  engaged: Accessor<boolean>
   /** Forward a byte sequence to the underlying PTY. */
   write: (data: string) => void
   /** Scroll the local scrollback view by N lines (negative = up). */
@@ -86,28 +99,27 @@ export type TerminalBindingsOpts = {
 export function useTerminalBindings(opts: TerminalBindingsOpts): void {
   const pageSize = () => opts.pageSize?.() ?? DEFAULT_PAGE_SIZE
 
-  const bindings: { key: string; cmd: (evt: KeyEvent) => void }[] = []
+  // Scroll bindings are available whenever the terminal pane is
+  // selected — even in select mode, the user should be able to browse
+  // scrollback without engaging the shell.
+  const scrollBindings = bindByIds({
+    "terminal.scroll-up": () => opts.scroll(-pageSize()),
+    "terminal.scroll-down": () => opts.scroll(pageSize()),
+  })
 
-  // Scrollback exceptions FIRST so they take precedence over any
-  // passthrough variants of `pageup`/`pagedown` registered later in
-  // the table. Chord strings come from KobeKeymap via bindByIds so
-  // this pane stays in sync with the central registry.
-  bindings.push(
-    ...bindByIds({
-      "terminal.scroll-up": () => opts.scroll(-pageSize()),
-      "terminal.scroll-down": () => opts.scroll(pageSize()),
-    }),
-  )
-
+  // Passthrough bindings forward every keystroke to the PTY child.
+  // ONLY active in engaged mode — in select mode these chords fall
+  // through to the global keymap so nav (ctrl+hjkl, tab, esc) works.
+  const passthroughBindings: { key: string; cmd: (evt: KeyEvent) => void }[] = []
   for (const name of PASSTHROUGH_NAMES) {
-    bindings.push({
+    passthroughBindings.push({
       key: name,
       cmd: (evt) => {
         const bytes = keyEventToShellBytes(evt)
         if (bytes != null) opts.write(bytes)
       },
     })
-    bindings.push({
+    passthroughBindings.push({
       key: `ctrl+${name}`,
       cmd: (evt) => {
         const bytes = keyEventToShellBytes(evt)
@@ -116,8 +128,16 @@ export function useTerminalBindings(opts: TerminalBindingsOpts): void {
     })
   }
 
+  // Two separate binding groups so the gates differ: scroll is on
+  // when the pane is selected; passthrough is on only when engaged.
+  // Order matters — scroll registers first so `ctrl+pgup`/`ctrl+pgdown`
+  // wins over the engaged-mode passthrough variants registered next.
   useBindings(() => ({
     enabled: opts.focused(),
-    bindings,
+    bindings: scrollBindings,
+  }))
+  useBindings(() => ({
+    enabled: opts.engaged(),
+    bindings: passthroughBindings,
   }))
 }


### PR DESCRIPTION
## Summary

Introduces a vim-windows-style two-tier focus model so global navigation chords (`ctrl+hjkl`, `tab`, `esc`) don't get eaten by the chat textarea or terminal PTY:

- **`select`** — pane is highlighted (border accent). Pane-local bindings (`j`/`k`/`d`/`r`/`a`, composer textarea, terminal passthrough) are OFF. Global nav chords work freely.
- **`engaged`** — pane has taken the keyboard. Composer / terminal capture every keystroke. `ctrl+hjkl` and `tab` are suppressed; press `esc` to disengage.

Branch is 8 commits on top of `main`.

## Why

Two long-standing keyboard frustrations:

1. **Stuck in terminal** — once `ctrl+l` jumped you into the terminal pane, every chord that could move you elsewhere (`ctrl+hjkl`, `tab`, `esc`, `F1`) was forwarded to the shell as raw bytes. Mouse click was the only way out.
2. **Stuck in chat / files / sidebar** — pane-local bare-letter bindings (`j`/`k`/`d`/`r`/`a`, opentui textarea defaults, etc.) consumed keystrokes meant for global navigation. The user couldn't tell whether `ctrl+h` was going to fire `focus.numeric` or get parsed as `backspace` by the textarea.

Two-tier model resolves both: in select mode pane-locals are gated off, so global navigation always wins; in engaged mode the user has explicitly opted in.

## Mode transitions

| chord | from | to |
|---|---|---|
| `ctrl+hjkl` / `tab` / `shift+tab` | any select | target pane, mode `select` |
| mouse click | any pane | clicked pane, mode `engaged` |
| `enter` | select on any pane | engage current pane |
| `esc` | engaged | disengage (stay on pane) |
| `esc` | select | no-op |
| `ctrl+q` (workspace) | engaged | sidebar engaged |
| business flow (task select / new task / file open / chat tab switch) | — | target pane engaged |

Cold boot lands engaged on the initial pane (sidebar by default) so first-time users can press `j`/`k` immediately.

## Visual: two-color focus highlight

Border / title color clearly indicates mode:

| state | color slot |
|---|---|
| engaged | `theme.primary` (terracotta in claude theme, white in conductor) |
| select | `theme.info` (blue in claude, cyan in conductor) |
| idle | `theme.border` / `theme.textMuted` |

Picked `theme.info` over `theme.accent` because `claude.json` maps both `primary` and `accent` to the same `#CC785C` — making them indistinguishable. `theme.info` is distinct from `primary` in every bundled theme.

Applied to: Composer rail, Terminal box border, Workspace/Files/Terminal `<PaneHeader>` titles, Sidebar `h TASKS` header.

## Commits

- `ad440cb` **fix(terminal):** trap `esc` to give a keyboard exit from the pane
- `cbc9125` **feat(focus):** two-tier focus model — select vs engaged
- `a71dc29` **feat(focus):** extend select/engaged mode to sidebar + files
- `931316a` **feat(focus):** two-color highlight on focus state
- `8ff8f16` **fix(focus):** use `theme.info` for selected (accent collides with primary)
- `9c7e74d` **fix(focus):** esc on sidebar-select is a no-op (was oscillating modes)
- `12cd5b2` **fix(focus):** esc only disengages, no second-tap sidebar jump
- `a5a352a` **fix(focus):** `ctrl+h` / `ctrl+j` chords work via `backspace` / `linefeed` alias

## Caveats / known issues

- `ctrl+h` (`\x08`) and `ctrl+j` (`\x0a`) are aliased through `backspace` and `linefeed` because opentui's `parseKeypress` matches those named keys first. Safe because `focus.numeric` is gated on `mode === "select"` — engaged-mode `backspace` keeps deleting characters.
- Behavior tests `keybindings.test.ts` `bare q does NOT open quit-confirm` and the 7 file-fail set in `g2/g3/sidebar-delete/sidebar-status-update/new-task-base-branch/filetree/settings-theme-switch` already failed on `origin/main` before this branch — pre-existing, not introduced here. Confirmed by running the same set against `origin/main`.

## Files changed

```
packages/kobe/src/tui/context/focus.tsx                     +59 -32
packages/kobe/src/tui/context/keybindings.ts                +24 -1
packages/kobe/src/tui/app.tsx                               +47 -25
packages/kobe/src/tui/panes/chat/Composer.tsx               +30 -10
packages/kobe/src/tui/panes/chat/Chat.tsx                   +9 -0
packages/kobe/src/tui/panes/sidebar/Sidebar.tsx             +20 -8
packages/kobe/src/tui/panes/sidebar/keys.ts                 +9 -2
packages/kobe/src/tui/panes/filetree/FileTree.tsx           +6 -1
packages/kobe/src/tui/panes/filetree/keys.ts                +5 -1
packages/kobe/src/tui/panes/terminal/Terminal.tsx           +12 -1
packages/kobe/src/tui/panes/terminal/keys.ts                +25 -10
packages/kobe/src/tui/panes/terminal/keys-pure.ts           +20 -3
```

## Test plan

- [x] `bun run typecheck` passes after every commit
- [x] `terminal.test.ts` passes
- [x] `keybindings.test.ts` and `ctrl-c-quit.test.ts` failures match `origin/main` baseline (pre-existing)
- [ ] **Manual dogfood needed**: cold boot → press `enter` to engage sidebar (or already engaged), `j`/`k` browse tasks; `ctrl+l` to terminal (lands select), `enter` to engage shell, `esc` to release, `ctrl+h` back to sidebar; chat composer typing isn't disturbed by any global chord while engaged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an "engaged" pane mode distinct from selection; Return engages the selected pane
  * Status bar hotkey chips are mode-aware (show engage hint in select mode; pane hotkeys when engaged)
  * Visuals updated to three states: engaged (primary), focused (secondary/info), idle (muted)

* **Bug Fixes**
  * Escape no longer forwarded from terminal to shell; Esc while engaged now disengages the pane
  * Composer: Ctrl+W no longer triggers default word-delete in the input pane

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/12)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->