### PR TITLE
docs(claude.md): drop the "user is Jackson" assumption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The architecture decisions are not obvious from the code (the code is mostly emp
   - Run package scripts via `bun --filter @sma1lboy/kobe <script>` or `cd packages/kobe && bun <script>`.
   - Repo-wide tools at root: `biome.json`, `bun.lock`, `.github/workflows/`, `docs/`, `CLAUDE.md`, `HANDOFF.md`.
 - `refs/` contains study material (symlinks + clones), **gitignored**. **Never edit anything inside `refs/`.**
-- The user's name is Jackson (sma1lboy). Respond in the language they use (Chinese or English).
+- Respond in whatever language the current user is writing in. Don't assume their name — let them introduce themselves.
 - Tech stack is locked: **TypeScript + `@opentui/core` + `@opentui/solid` + Solid.js + Bun**. Do not re-litigate.
 
 ## Reference repos — clone before development


### PR DESCRIPTION
## Summary

The Conventions list in `CLAUDE.md` told Claude that whoever was running it was Jackson, so every fresh clone got `Hi Jackson!` on the first turn regardless of who was actually typing. Reproduced locally: clone the repo, `bun run dev`, send `hi` → assistant replied `Hi Jackson! What are we working on?`.

The fix replaces the hard-coded name with a neutral instruction. Project ownership is already obvious from `@sma1lboy/kobe`, the repo URL, and `CONTRIBUTING.md` (when it exists), so it doesn't need to be encoded in the system prompt.

## Change

```diff
-- The user's name is Jackson (sma1lboy). Respond in the language they use (Chinese or English).
++ Respond in whatever language the current user is writing in. Don't assume their name — let them introduce themselves.
```

## Test plan

- [x] After commit, fresh chat in a new worktree → assistant replied `Hey! What's up?` instead of `Hi Jackson! …`.
- [x] Language-adaptation still works (the instruction is preserved, just generalised beyond Chinese / English literals).
- [x] No code touched — pure prompt copy edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated communication guidelines to improve how the system interacts with users across different language preferences.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/13)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->