### PR TITLE
feat(chat): AskUserQuestion picker — 'Other' option + composer free-text

### DIFF
--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -56,6 +56,7 @@ import { modelLabelFor, resolveDefaultModelId } from "./composer/models"
 import { loadUserSlashes } from "./composer/user-slashes"
 import { formatContextUsageCompact } from "./context-meter"
 import {
+  type ChatRow,
   type ChatState,
   createInitialState,
   dequeueFirst,
@@ -152,16 +153,15 @@ export function Chat(props: ChatProps) {
     const map = new Map<string, Tagged>()
     for (const e of BUILTIN_CLAUDE_SLASHES) map.set(e.name, { entry: e, source: "builtin" })
     for (const e of userSlashes()) map.set(e.name, { entry: e, source: "user" })
-    const claudeEntries: ComposerSlashEntry[] = [...map.values()]
-      .map(({ entry, source }) => ({
-        display: `/${entry.name}`,
-        description: entry.description || undefined,
-        aliases: entry.aliases?.map((a) => `/${a}`),
-        source,
-        onSelect: () => {
-          void send(`/${entry.name}`)
-        },
-      }))
+    const claudeEntries: ComposerSlashEntry[] = [...map.values()].map(({ entry, source }) => ({
+      display: `/${entry.name}`,
+      description: entry.description || undefined,
+      aliases: entry.aliases?.map((a) => `/${a}`),
+      source,
+      onSelect: () => {
+        void send(`/${entry.name}`)
+      },
+    }))
     // kobe-side slashes are short-circuited in `send()` rather than
     // forwarded to the engine. Listed here purely so the dropdown
     // surfaces them as a discoverable command.
@@ -233,30 +233,44 @@ export function Chat(props: ChatProps) {
   })
   const isCanceled = () => taskStatus() === "canceled"
 
-  // True when the active tab's message list ends with an unresolved
-  // approval/question row. While a user-input request is pending we
-  // lock the composer:
-  //   - The subprocess was killed (orchestrator.pumpEvents stops it on
-  //     tool.start so the model can't yap past the picker).
-  //   - The picker IS the only valid next action; typing a freeform
-  //     prompt would resume the session ahead of the picker's answer
-  //     and the model would see "[user said something else]" instead of
-  //     "[plan approved] / [question answered]".
-  // Scans from the end so a long history doesn't cost more than O(few)
-  // — the picker is always near the bottom. Stops at the first user/
-  // assistant row because anything newer than the picker means the
-  // conversation moved on (i.e. the picker was already resolved).
-  const hasPendingInput = createMemo(() => {
+  // Look up the tail of the active tab for an unresolved user-input
+  // row. Scans from the end (the picker is always near the bottom) and
+  // stops at the first user/assistant row — anything newer than the
+  // picker means the conversation moved on (i.e. the picker was
+  // already resolved). Returned shape is the row itself so callers
+  // can read the requestId / questions list for routing.
+  function findPending(): Extract<ChatRow, { kind: "approval" | "question" }> | null {
     const msgs = activeState().messages
     for (let i = msgs.length - 1; i >= 0; i--) {
       const m = msgs[i]
       if (!m) continue
-      if (m.kind === "approval") return m.status === "pending"
-      if (m.kind === "question") return m.answers === null
-      if (m.kind === "user" || m.kind === "assistant") return false
+      if (m.kind === "approval") return m.status === "pending" ? m : null
+      if (m.kind === "question") return m.answers === null ? m : null
+      if (m.kind === "user" || m.kind === "assistant") return null
     }
-    return false
+    return null
+  }
+
+  // Pending approval lock — the subprocess was killed on tool.start
+  // and the only valid next action is Approve/Reject. Free-text would
+  // resume the session ahead of the picker's answer and the model
+  // would see "[user said something else]" instead of "[plan
+  // approved]". Approval stays locked.
+  const pendingApproval = createMemo(() => {
+    const p = findPending()
+    return p?.kind === "approval" ? p : null
   })
+  // Pending question — picker is up but the user can still type a
+  // free-text answer via the composer (per the AskUserQuestion tool's
+  // "always allow custom text" contract). Composer-submit reroutes
+  // to respondToInput; see handleComposerSubmit.
+  const pendingQuestion = createMemo(() => {
+    const p = findPending()
+    return p?.kind === "question" ? p : null
+  })
+  // Backwards-compat alias for legacy call sites that just want "any
+  // pending input"; new code should prefer the split memos.
+  const hasPendingInput = createMemo(() => pendingApproval() !== null || pendingQuestion() !== null)
 
   // Per-task permission mode (shift+tab cycle in the composer).
   const permissionMode = createMemo(() => {
@@ -694,6 +708,32 @@ export function Chat(props: ChatProps) {
       if (lastToolIndex() !== null) toggleExpandLastTool()
       return
     }
+    // If a question picker is up, the composer's content is the user's
+    // free-text answer — same role as picking the auto-added "Other"
+    // option. Route through respondToInput so the orchestrator emits
+    // the right synthetic resume prompt; sending it as a fresh prompt
+    // instead would race the still-pending AskUserQuestion tool_result
+    // and the model would not know which input is the answer. Every
+    // question on the picker gets the same answer string — multi-
+    // question prompts are rare, and the alternative (only answer the
+    // first, leave the rest unanswered) violates the picker's
+    // all-questions-required contract.
+    const q = pendingQuestion()
+    if (q) {
+      const taskId = props.taskId()
+      if (!taskId) return
+      const answers: Record<string, string> = {}
+      for (const entry of q.questions) {
+        answers[entry.question] = trimmed
+      }
+      props.orchestrator
+        .respondToInput(taskId, q.requestId, { kind: "ask_question", answers })
+        .catch((err: unknown) => {
+          patchActiveState((s) => pushSystemError(s, `respondToInput failed: ${stringifyErr(err)}`))
+        })
+      setDraft("")
+      return
+    }
     // `trimmed` is the composer's post-expansion text — `[Image #N]`
     // placeholders have already been rewritten to ` @/abs/path ` so
     // claude's `-p` mention parser can attach the image. Falling back
@@ -785,16 +825,27 @@ export function Chat(props: ChatProps) {
         <Loading startedAt={turnStartedAt()} responseChars={currentTurnChars()} />
       </Show>
 
+      {/* Pending-question hint — rendered just above the composer when
+          a question picker is up. The composer stays typeable (text
+          becomes the free-text answer; see handleComposerSubmit) so
+          this is a soft affordance, not a lock. Approval pickers
+          still lock the composer because plan approval is binary. */}
+      <Show when={pendingQuestion() && props.taskId()}>
+        <box paddingLeft={1} paddingRight={1} paddingBottom={0}>
+          <text fg={theme.textMuted}>(pick an option above, or type your own answer here)</text>
+        </box>
+      </Show>
+
       {/* Composer. */}
       <Composer
         draft={draft()}
         onDraftChange={setDraft}
         isStreaming={activeState().isStreaming}
-        hasTask={props.taskId() !== undefined && !isCanceled() && !hasPendingInput()}
+        hasTask={props.taskId() !== undefined && !isCanceled() && !pendingApproval()}
         noTaskMessage={
           isCanceled()
             ? "(task canceled — pick another or press ctrl+n to create)"
-            : hasPendingInput()
+            : pendingApproval()
               ? "(answer the prompt above to continue)"
               : undefined
         }

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -834,41 +834,38 @@ export function Chat(props: ChatProps) {
         <Loading startedAt={turnStartedAt()} responseChars={currentTurnChars()} />
       </Show>
 
-      {/* Pending-question hint — rendered just above the composer when
-          a question picker is up. The composer stays typeable (text
-          becomes the free-text answer; see handleComposerSubmit) so
-          this is a soft affordance, not a lock. Approval pickers
-          still lock the composer because plan approval is binary. */}
-      <Show when={pendingQuestion() && props.taskId()}>
-        <box paddingLeft={1} paddingRight={1} paddingBottom={0}>
-          <text fg={theme.textMuted}>(pick an option above, or type your own answer here)</text>
-        </box>
+      {/* Composer — hidden entirely while a question picker is up so
+          the user's full attention is on picking (or typing into the
+          inline "Other" input). Reappears as soon as the picker
+          resolves; the user can then type freely again. Approval
+          pickers (ExitPlanMode) keep the composer rendered but locked
+          since approval is binary and the user might still want
+          history / model context affordances visible. */}
+      <Show when={!pendingQuestion()}>
+        <Composer
+          draft={draft()}
+          onDraftChange={setDraft}
+          isStreaming={activeState().isStreaming}
+          hasTask={props.taskId() !== undefined && !isCanceled() && !pendingApproval()}
+          noTaskMessage={
+            isCanceled()
+              ? "(task canceled — pick another or press ctrl+n to create)"
+              : pendingApproval()
+                ? "(answer the prompt above to continue)"
+                : undefined
+          }
+          onSubmit={handleComposerSubmit}
+          focused={() => (props.focused?.() ?? false) && !questionInlineFocus()}
+          // Per-tab history scope — prompt history shouldn't bleed across tabs.
+          historyKey={activeTabId() ?? props.taskId()}
+          slashes={slashes}
+          permissionMode={permissionMode}
+          onCyclePermissionMode={cyclePermissionMode}
+          modelLabel={modelLabel}
+          onChooseModel={() => void chooseModel()}
+          worktreePath={worktreePath}
+        />
       </Show>
-
-      {/* Composer. */}
-      <Composer
-        draft={draft()}
-        onDraftChange={setDraft}
-        isStreaming={activeState().isStreaming}
-        hasTask={props.taskId() !== undefined && !isCanceled() && !pendingApproval()}
-        noTaskMessage={
-          isCanceled()
-            ? "(task canceled — pick another or press ctrl+n to create)"
-            : pendingApproval()
-              ? "(answer the prompt above to continue)"
-              : undefined
-        }
-        onSubmit={handleComposerSubmit}
-        focused={() => (props.focused?.() ?? false) && !questionInlineFocus()}
-        // Per-tab history scope — prompt history shouldn't bleed across tabs.
-        historyKey={activeTabId() ?? props.taskId()}
-        slashes={slashes}
-        permissionMode={permissionMode}
-        onCyclePermissionMode={cyclePermissionMode}
-        modelLabel={modelLabel}
-        onChooseModel={() => void chooseModel()}
-        worktreePath={worktreePath}
-      />
     </box>
   )
 }

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -272,6 +272,14 @@ export function Chat(props: ChatProps) {
   // pending input"; new code should prefer the split memos.
   const hasPendingInput = createMemo(() => pendingApproval() !== null || pendingQuestion() !== null)
 
+  // True while a `QuestionRow`'s inline "Other" input is open and
+  // wants keystrokes. Driven from MessageList → QuestionRow via the
+  // onClaimComposerFocus callback. The composer's `focused` prop is
+  // forced false while this is true so the inline input — not the
+  // composer — receives input; otherwise opentui keeps the composer
+  // focused and the user's typing disappears into the chat draft.
+  const [questionInlineFocus, setQuestionInlineFocus] = createSignal(false)
+
   // Per-task permission mode (shift+tab cycle in the composer).
   const permissionMode = createMemo(() => {
     const id = props.taskId()
@@ -796,6 +804,7 @@ export function Chat(props: ChatProps) {
                     patchActiveState((s) => pushSystemError(s, `respondToInput failed: ${stringifyErr(err)}`))
                   })
               }}
+              onClaimComposerFocus={setQuestionInlineFocus}
             />
           </box>
         </scrollbox>
@@ -850,7 +859,7 @@ export function Chat(props: ChatProps) {
               : undefined
         }
         onSubmit={handleComposerSubmit}
-        focused={props.focused}
+        focused={() => (props.focused?.() ?? false) && !questionInlineFocus()}
         // Per-tab history scope — prompt history shouldn't bleed across tabs.
         historyKey={activeTabId() ?? props.taskId()}
         slashes={slashes}

--- a/packages/kobe/src/tui/panes/chat/MessageList.tsx
+++ b/packages/kobe/src/tui/panes/chat/MessageList.tsx
@@ -45,7 +45,7 @@
  */
 
 import { TextAttributes } from "@opentui/core"
-import { For, Show, createSignal } from "solid-js"
+import { For, Show, createEffect, createSignal, onCleanup } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { Markdown } from "./Markdown"
 import {
@@ -145,6 +145,15 @@ export interface MessageListProps {
    * `Orchestrator.respondToInput({kind: "ask_question", answers})`.
    */
   onAnswer?: (requestId: string, answers: Record<string, string>) => void
+  /**
+   * Reported true while a `QuestionRow`'s inline "Other" input is
+   * visible and waiting for keystrokes — the chat shell uses this to
+   * release the composer's focus so typing lands in the inline input
+   * (otherwise both inputs have `focused={true}` and opentui keeps the
+   * composer focused, swallowing every keystroke meant for the
+   * picker).
+   */
+  onClaimComposerFocus?: (claim: boolean) => void
 }
 
 /**
@@ -835,6 +844,16 @@ const OTHER_SENTINEL = "__kobe_other__"
 export function QuestionRow(props: {
   row: Extract<ChatRow, { kind: "question" }>
   onAnswer: (answers: Record<string, string>) => void
+  /**
+   * Called with `true` while any question on this row has the "Other"
+   * sentinel picked but the row hasn't been submitted yet, and with
+   * `false` otherwise. The chat shell uses this signal to release the
+   * composer's `focused` prop so the inline "Other" input can actually
+   * receive keystrokes — without this, both inputs claim focus and the
+   * composer wins. Cleaned up on unmount so a row scrolling off-screen
+   * doesn't leave the composer perpetually defocused.
+   */
+  onClaimComposerFocus?: (claim: boolean) => void
 }) {
   const { theme } = useTheme()
   const r = () => props.row
@@ -854,6 +873,14 @@ export function QuestionRow(props: {
   // new-task-dialog/state.ts:stripNewlines).
   const [otherText, setOtherText] = createSignal<Record<string, string>>({})
 
+  // Index of the question the user is currently working on. Questions
+  // before this are "locked in" (still editable by clicking) and shown
+  // collapsed with their captured answer; questions after this are
+  // completely hidden. This makes a multi-question AskUserQuestion
+  // feel like a flow rather than a wall of pickers — answer one,
+  // advance to the next.
+  const [currentIndex, setCurrentIndex] = createSignal(0)
+
   function pickedFor(questionText: string): ReadonlySet<string> {
     return selections()[questionText] ?? new Set<string>()
   }
@@ -866,6 +893,28 @@ export function QuestionRow(props: {
     const sanitized = value.replace(/[\r\n]+/g, "")
     setOtherText((prev) => ({ ...prev, [questionText]: sanitized }))
   }
+
+  // True while the CURRENT question's "Other" sentinel is picked and
+  // the row is still pending. Scoped to the current question only —
+  // past questions' Other inputs aren't rendered any more so they
+  // shouldn't keep claiming composer focus. The createEffect below
+  // mirrors this into the parent so the composer can release focus to
+  // our inline input — opentui keeps a single focused input at a time
+  // and the composer otherwise wins.
+  function currentOtherActive(): boolean {
+    if (isAnswered()) return false
+    const q = r().questions[currentIndex()]
+    if (!q) return false
+    return pickedFor(q.question).has(OTHER_SENTINEL)
+  }
+  createEffect(() => {
+    props.onClaimComposerFocus?.(currentOtherActive())
+  })
+  onCleanup(() => {
+    // Row unmounting (task switch, scroll-off, etc.) — release any
+    // outstanding claim so the composer doesn't stay defocused.
+    props.onClaimComposerFocus?.(false)
+  })
 
   function toggle(questionText: string, multi: boolean, label: string): void {
     setSelections((prev) => {
@@ -887,14 +936,39 @@ export function QuestionRow(props: {
     })
   }
 
+  // Build the final answer string for a single question. Preserves
+  // option order (Set iteration is insertion order, but we re-order
+  // to match the upstream options list so the model sees a
+  // deterministic string). The OTHER_SENTINEL is replaced with the
+  // user's typed text — the model never sees the internal label.
+  function renderedAnswerFor(q: { question: string; options: readonly { label: string }[] }): string {
+    const picked = pickedFor(q.question)
+    const ordered: string[] = []
+    for (const o of q.options) {
+      if (picked.has(o.label)) ordered.push(o.label)
+    }
+    if (picked.has(OTHER_SENTINEL)) {
+      const txt = customTextFor(q.question).trim()
+      if (txt) ordered.push(txt)
+    }
+    return ordered.join(", ")
+  }
+
+  // A question is "complete" when there's at least one pick AND, if
+  // "Other" is picked, the typed text is non-empty. Sequential mode
+  // gates advance / submit on this per-question check.
+  function isQuestionComplete(qIdx: number): boolean {
+    const q = r().questions[qIdx]
+    if (!q) return false
+    const picked = pickedFor(q.question)
+    if (picked.size === 0) return false
+    if (picked.has(OTHER_SENTINEL) && customTextFor(q.question).trim().length === 0) return false
+    return true
+  }
+
   const allAnswered = () => {
-    for (const q of r().questions) {
-      const picked = pickedFor(q.question)
-      if (picked.size === 0) return false
-      // "Other" picked but the text box is blank — don't submit an
-      // empty custom answer, the model would just see "" for that
-      // question and the picker would have been pointless.
-      if (picked.has(OTHER_SENTINEL) && customTextFor(q.question).trim().length === 0) return false
+    for (let i = 0; i < r().questions.length; i++) {
+      if (!isQuestionComplete(i)) return false
     }
     return true
   }
@@ -903,22 +977,24 @@ export function QuestionRow(props: {
     if (!allAnswered() || isAnswered()) return
     const answers: Record<string, string> = {}
     for (const q of r().questions) {
-      const picked = pickedFor(q.question)
-      // Preserve option order for stable comma-joining (Set iteration
-      // order is insertion order in JS, but we re-order to match the
-      // original options list so the model sees a deterministic string).
-      const ordered: string[] = []
-      for (const o of q.options) {
-        if (picked.has(o.label)) ordered.push(o.label)
-      }
-      // Substitute the user-typed text for the sentinel — the model
-      // never sees `__kobe_other__`, only the actual answer.
-      if (picked.has(OTHER_SENTINEL)) {
-        ordered.push(customTextFor(q.question).trim())
-      }
-      answers[q.question] = ordered.join(", ")
+      answers[q.question] = renderedAnswerFor(q)
     }
     props.onAnswer(answers)
+  }
+
+  // Per-card action: advance to the next question if the current one
+  // is complete, OR fire the final submit if we're on the last
+  // question. This is the only place the user "commits" — picking an
+  // option just updates local state; commit happens here.
+  function advanceOrSubmit(): void {
+    if (isAnswered()) return
+    const i = currentIndex()
+    if (!isQuestionComplete(i)) return
+    if (i >= r().questions.length - 1) {
+      submit()
+    } else {
+      setCurrentIndex(i + 1)
+    }
   }
 
   return (
@@ -933,121 +1009,161 @@ export function QuestionRow(props: {
         </text>
       </box>
 
-      {/* One card per question. */}
+      {/* One card per question. Sequential mode: past questions show a
+          collapsed "captured answer" preview and are clickable to go
+          back; the current question is fully interactive; future
+          questions are hidden until the user advances. Post-submit,
+          every question shows in `answered` form. */}
       <For each={r().questions}>
-        {(q) => {
+        {(q, index) => {
           const finalAnswer = () => r().answers?.[q.question] ?? null
           const picked = () => pickedFor(q.question)
+          const isCurrent = () => !isAnswered() && index() === currentIndex()
+          const isPast = () => !isAnswered() && index() < currentIndex()
+          const isFuture = () => !isAnswered() && index() > currentIndex()
+          const isLast = () => index() === r().questions.length - 1
+          const buttonLabel = () => (isLast() ? "[ Submit ]" : "[ Next ]")
           return (
-            <box paddingLeft={2} paddingTop={1} flexDirection="column" gap={0}>
-              <box flexDirection="row" gap={1}>
-                <Show when={q.header}>
-                  <text fg={theme.accent} attributes={TextAttributes.BOLD}>
-                    [{q.header}]
-                  </text>
+            <Show when={!isFuture()}>
+              <box
+                paddingLeft={2}
+                paddingTop={1}
+                flexDirection="column"
+                gap={0}
+                onMouseUp={isPast() ? () => setCurrentIndex(index()) : undefined}
+              >
+                <box flexDirection="row" gap={1}>
+                  <Show when={q.header}>
+                    <text fg={theme.accent} attributes={TextAttributes.BOLD}>
+                      [{q.header}]
+                    </text>
+                  </Show>
+                  <text fg={isPast() ? theme.textMuted : theme.text}>{q.question}</text>
+                  <Show when={q.multiSelect && isCurrent()}>
+                    <text fg={theme.textMuted}>(pick any)</text>
+                  </Show>
+                  <Show when={isPast()}>
+                    <text fg={theme.textMuted}>(click to edit)</text>
+                  </Show>
+                </box>
+                {/* Final answered state: render the chosen value(s) as a single line. */}
+                <Show when={isAnswered()}>
+                  <box paddingLeft={2}>
+                    <text fg={theme.success}>
+                      {RESULT_PREFIX}
+                      {finalAnswer() && finalAnswer()!.length > 0 ? finalAnswer() : "(no answer)"}
+                    </text>
+                  </box>
                 </Show>
-                <text fg={theme.text}>{q.question}</text>
-                <Show when={q.multiSelect}>
-                  <text fg={theme.textMuted}>(pick any)</text>
+                {/* Past state: locked-in answer summary derived from
+                    local selections. Visual only — still mutable by
+                    clicking the row to jump back. */}
+                <Show when={isPast()}>
+                  <box paddingLeft={2}>
+                    <text fg={theme.textMuted}>
+                      {RESULT_PREFIX}
+                      {renderedAnswerFor(q).length > 0 ? renderedAnswerFor(q) : "(no answer)"}
+                    </text>
+                  </box>
+                </Show>
+                {/* Current state: list options, click to toggle. */}
+                <Show when={isCurrent()}>
+                  <box paddingLeft={2} flexDirection="column">
+                    <For each={q.options}>
+                      {(opt) => {
+                        const isPicked = () => picked().has(opt.label)
+                        const glyph = () => (q.multiSelect ? (isPicked() ? "[x]" : "[ ]") : isPicked() ? "(•)" : "( )")
+                        return (
+                          <box
+                            flexDirection="row"
+                            gap={1}
+                            onMouseUp={() => toggle(q.question, q.multiSelect, opt.label)}
+                          >
+                            <text fg={isPicked() ? theme.accent : theme.textMuted} attributes={TextAttributes.BOLD}>
+                              {glyph()}
+                            </text>
+                            <box flexGrow={1} flexDirection="column">
+                              <text fg={theme.text}>{opt.label}</text>
+                              <Show when={opt.description}>
+                                <text fg={theme.textMuted}>{opt.description}</text>
+                              </Show>
+                            </box>
+                          </box>
+                        )
+                      }}
+                    </For>
+                    {/* Auto-appended "Other" — synthesized client-side
+                        per the AskUserQuestion tool's "always offer
+                        custom text" contract. Same toggle path as real
+                        options; picking it reveals the inline text
+                        input below. */}
+                    {(() => {
+                      const otherPicked = () => picked().has(OTHER_SENTINEL)
+                      const otherGlyph = () =>
+                        q.multiSelect ? (otherPicked() ? "[x]" : "[ ]") : otherPicked() ? "(•)" : "( )"
+                      return (
+                        <>
+                          <box
+                            flexDirection="row"
+                            gap={1}
+                            onMouseUp={() => toggle(q.question, q.multiSelect, OTHER_SENTINEL)}
+                          >
+                            <text fg={otherPicked() ? theme.accent : theme.textMuted} attributes={TextAttributes.BOLD}>
+                              {otherGlyph()}
+                            </text>
+                            <box flexGrow={1} flexDirection="column">
+                              <text fg={theme.text}>Other</text>
+                              <text fg={theme.textMuted}>Type your own answer</text>
+                            </box>
+                          </box>
+                          <Show when={otherPicked()}>
+                            <box paddingLeft={4} paddingTop={0}>
+                              <input
+                                value={customTextFor(q.question)}
+                                placeholder="type your answer…"
+                                focused={true}
+                                onInput={(v: string) => setCustomText(q.question, v)}
+                                onSubmit={() => advanceOrSubmit()}
+                              />
+                            </box>
+                          </Show>
+                        </>
+                      )
+                    })()}
+                    {/* Per-card Next / Submit. The last question's
+                        button reads "Submit" so the existing behavior
+                        tests still find the substring. Earlier
+                        questions read "Next" — advances currentIndex
+                        without sending anything to the engine. */}
+                    <box paddingLeft={0} paddingTop={1} flexDirection="row" gap={2}>
+                      <text
+                        fg={isQuestionComplete(index()) ? theme.success : theme.textMuted}
+                        attributes={TextAttributes.BOLD}
+                        onMouseUp={() => advanceOrSubmit()}
+                      >
+                        {buttonLabel()}
+                      </text>
+                      <Show when={!isQuestionComplete(index())}>
+                        <text fg={theme.textMuted}>(pick an option to continue)</text>
+                      </Show>
+                    </box>
+                  </box>
                 </Show>
               </box>
-              {/* Answered state: render the chosen value(s) as a single line. */}
-              <Show when={isAnswered()}>
-                <box paddingLeft={2}>
-                  <text fg={theme.success}>
-                    {RESULT_PREFIX}
-                    {finalAnswer() && finalAnswer()!.length > 0 ? finalAnswer() : "(no answer)"}
-                  </text>
-                </box>
-              </Show>
-              {/* Pending state: list options, click to toggle. */}
-              <Show when={!isAnswered()}>
-                <box paddingLeft={2} flexDirection="column">
-                  <For each={q.options}>
-                    {(opt) => {
-                      const isPicked = () => picked().has(opt.label)
-                      const glyph = () => (q.multiSelect ? (isPicked() ? "[x]" : "[ ]") : isPicked() ? "(•)" : "( )")
-                      return (
-                        <box flexDirection="row" gap={1} onMouseUp={() => toggle(q.question, q.multiSelect, opt.label)}>
-                          <text fg={isPicked() ? theme.accent : theme.textMuted} attributes={TextAttributes.BOLD}>
-                            {glyph()}
-                          </text>
-                          <box flexGrow={1} flexDirection="column">
-                            <text fg={theme.text}>{opt.label}</text>
-                            <Show when={opt.description}>
-                              <text fg={theme.textMuted}>{opt.description}</text>
-                            </Show>
-                          </box>
-                        </box>
-                      )
-                    }}
-                  </For>
-                  {/* Auto-appended "Other" — synthesized client-side per
-                      the AskUserQuestion tool's "always offer custom
-                      text" contract. Same toggle path as real options;
-                      picking it reveals the inline text input below. */}
-                  {(() => {
-                    const otherPicked = () => picked().has(OTHER_SENTINEL)
-                    const otherGlyph = () =>
-                      q.multiSelect ? (otherPicked() ? "[x]" : "[ ]") : otherPicked() ? "(•)" : "( )"
-                    return (
-                      <>
-                        <box
-                          flexDirection="row"
-                          gap={1}
-                          onMouseUp={() => toggle(q.question, q.multiSelect, OTHER_SENTINEL)}
-                        >
-                          <text fg={otherPicked() ? theme.accent : theme.textMuted} attributes={TextAttributes.BOLD}>
-                            {otherGlyph()}
-                          </text>
-                          <box flexGrow={1} flexDirection="column">
-                            <text fg={theme.text}>Other</text>
-                            <text fg={theme.textMuted}>Type your own answer</text>
-                          </box>
-                        </box>
-                        <Show when={otherPicked()}>
-                          <box paddingLeft={4} paddingTop={0}>
-                            <input
-                              value={customTextFor(q.question)}
-                              placeholder="type your answer…"
-                              focused={true}
-                              onInput={(v: string) => setCustomText(q.question, v)}
-                              onSubmit={() => submit()}
-                            />
-                          </box>
-                        </Show>
-                      </>
-                    )
-                  })()}
-                </box>
-              </Show>
-            </box>
+            </Show>
           )
         }}
       </For>
 
-      {/* Submit (pending) or static chip (answered). */}
-      <box paddingLeft={2} paddingTop={1} flexDirection="row" gap={2}>
-        <Show
-          when={!isAnswered()}
-          fallback={
-            <text fg={theme.success} attributes={TextAttributes.BOLD}>
-              [submitted]
-            </text>
-          }
-        >
-          <text
-            fg={allAnswered() ? theme.success : theme.textMuted}
-            attributes={TextAttributes.BOLD}
-            onMouseUp={() => submit()}
-          >
-            [ Submit ]
+      {/* Final-state chip — only rendered post-submit. Drives the
+          existing behavior-test assertion on "[submitted]". */}
+      <Show when={isAnswered()}>
+        <box paddingLeft={2} paddingTop={1}>
+          <text fg={theme.success} attributes={TextAttributes.BOLD}>
+            [submitted]
           </text>
-          <Show when={!allAnswered()}>
-            <text fg={theme.textMuted}>(answer all questions to enable)</text>
-          </Show>
-        </Show>
-      </box>
+        </box>
+      </Show>
     </box>
   )
 }
@@ -1095,7 +1211,13 @@ export function MessageList(props: MessageListProps) {
             return <ApprovalRow row={row} onApprove={(approve) => props.onApprove?.(row.requestId, approve)} />
           }
           if (row.kind === "question") {
-            return <QuestionRow row={row} onAnswer={(answers) => props.onAnswer?.(row.requestId, answers)} />
+            return (
+              <QuestionRow
+                row={row}
+                onAnswer={(answers) => props.onAnswer?.(row.requestId, answers)}
+                onClaimComposerFocus={props.onClaimComposerFocus}
+              />
+            )
           }
           // tool row
           return (

--- a/packages/kobe/src/tui/panes/chat/MessageList.tsx
+++ b/packages/kobe/src/tui/panes/chat/MessageList.tsx
@@ -801,23 +801,36 @@ export function ApprovalRow(props: {
 }
 
 /**
+ * Sentinel label for the auto-added "Other / type your own answer"
+ * option in `QuestionRow`. Per the AskUserQuestion tool spec the
+ * picker is required to always offer a custom-text escape hatch; we
+ * synthesize it on the client side rather than asking the model to
+ * include it. Use a non-printable-prefixed string so it can't collide
+ * with a real option label even if the model decided to call its
+ * option "Other".
+ */
+const OTHER_SENTINEL = "__kobe_other__"
+
+/**
  * Question row — kobe's host-side rendering of an `AskUserQuestion`
  * request. Per question we draw a card with header chip + question
  * text + clickable options (radio for single-select, checkbox for
- * multi-select). A single Submit at the bottom collects all answers
- * and routes them up via `onAnswer`. Once submitted, the row flips
- * to a static "answered" state showing each question's chosen value.
+ * multi-select), plus an auto-added "Other" row that reveals a
+ * free-text input when picked. A single Submit at the bottom collects
+ * all answers and routes them up via `onAnswer`. Once submitted, the
+ * row flips to a static "answered" state showing each question's
+ * chosen value.
  *
  * Wiring choices:
  *   - Selection state lives in component-local signals (one Set per
  *     question). The store only sees the final answers map, after
  *     Submit.
- *   - Submit is enabled only when every question has ≥1 selection.
- *     Multi-select with zero picks would otherwise leave the model
- *     waiting on an effectively-empty answer.
+ *   - Submit is enabled only when every question has ≥1 selection
+ *     AND, when "Other" is picked, the custom-text input is non-empty.
  *   - Multi-select answer encoding follows upstream: comma-separated
  *     option labels (`"Option A, Option C"`). Single-select is just
- *     the label.
+ *     the label. When "Other" is picked the user-typed text is what
+ *     ends up in the answer string — the sentinel never escapes.
  */
 export function QuestionRow(props: {
   row: Extract<ChatRow, { kind: "question" }>
@@ -833,8 +846,25 @@ export function QuestionRow(props: {
   // Solid reactivity.
   const [selections, setSelections] = createSignal<Record<string, ReadonlySet<string>>>({})
 
+  // Per-question custom-text buffer for the auto-added "Other" option.
+  // Only consulted when the OTHER_SENTINEL is in that question's
+  // selection set; otherwise irrelevant. Newlines stripped on input
+  // because opentui's <input> happily inserts a literal \n on enter
+  // even though enter also fires onSubmit (same quirk handled in
+  // new-task-dialog/state.ts:stripNewlines).
+  const [otherText, setOtherText] = createSignal<Record<string, string>>({})
+
   function pickedFor(questionText: string): ReadonlySet<string> {
     return selections()[questionText] ?? new Set<string>()
+  }
+
+  function customTextFor(questionText: string): string {
+    return otherText()[questionText] ?? ""
+  }
+
+  function setCustomText(questionText: string, value: string): void {
+    const sanitized = value.replace(/[\r\n]+/g, "")
+    setOtherText((prev) => ({ ...prev, [questionText]: sanitized }))
   }
 
   function toggle(questionText: string, multi: boolean, label: string): void {
@@ -859,7 +889,12 @@ export function QuestionRow(props: {
 
   const allAnswered = () => {
     for (const q of r().questions) {
-      if (pickedFor(q.question).size === 0) return false
+      const picked = pickedFor(q.question)
+      if (picked.size === 0) return false
+      // "Other" picked but the text box is blank — don't submit an
+      // empty custom answer, the model would just see "" for that
+      // question and the picker would have been pointless.
+      if (picked.has(OTHER_SENTINEL) && customTextFor(q.question).trim().length === 0) return false
     }
     return true
   }
@@ -868,11 +903,19 @@ export function QuestionRow(props: {
     if (!allAnswered() || isAnswered()) return
     const answers: Record<string, string> = {}
     for (const q of r().questions) {
-      const picked = Array.from(pickedFor(q.question))
+      const picked = pickedFor(q.question)
       // Preserve option order for stable comma-joining (Set iteration
       // order is insertion order in JS, but we re-order to match the
       // original options list so the model sees a deterministic string).
-      const ordered = q.options.map((o) => o.label).filter((l) => picked.includes(l))
+      const ordered: string[] = []
+      for (const o of q.options) {
+        if (picked.has(o.label)) ordered.push(o.label)
+      }
+      // Substitute the user-typed text for the sentinel — the model
+      // never sees `__kobe_other__`, only the actual answer.
+      if (picked.has(OTHER_SENTINEL)) {
+        ordered.push(customTextFor(q.question).trim())
+      }
       answers[q.question] = ordered.join(", ")
     }
     props.onAnswer(answers)
@@ -939,6 +982,43 @@ export function QuestionRow(props: {
                       )
                     }}
                   </For>
+                  {/* Auto-appended "Other" — synthesized client-side per
+                      the AskUserQuestion tool's "always offer custom
+                      text" contract. Same toggle path as real options;
+                      picking it reveals the inline text input below. */}
+                  {(() => {
+                    const otherPicked = () => picked().has(OTHER_SENTINEL)
+                    const otherGlyph = () =>
+                      q.multiSelect ? (otherPicked() ? "[x]" : "[ ]") : otherPicked() ? "(•)" : "( )"
+                    return (
+                      <>
+                        <box
+                          flexDirection="row"
+                          gap={1}
+                          onMouseUp={() => toggle(q.question, q.multiSelect, OTHER_SENTINEL)}
+                        >
+                          <text fg={otherPicked() ? theme.accent : theme.textMuted} attributes={TextAttributes.BOLD}>
+                            {otherGlyph()}
+                          </text>
+                          <box flexGrow={1} flexDirection="column">
+                            <text fg={theme.text}>Other</text>
+                            <text fg={theme.textMuted}>Type your own answer</text>
+                          </box>
+                        </box>
+                        <Show when={otherPicked()}>
+                          <box paddingLeft={4} paddingTop={0}>
+                            <input
+                              value={customTextFor(q.question)}
+                              placeholder="type your answer…"
+                              focused={true}
+                              onInput={(v: string) => setCustomText(q.question, v)}
+                              onSubmit={() => submit()}
+                            />
+                          </box>
+                        </Show>
+                      </>
+                    )
+                  })()}
                 </box>
               </Show>
             </box>

--- a/packages/kobe/test/behavior/approval-flow.test.ts
+++ b/packages/kobe/test/behavior/approval-flow.test.ts
@@ -321,12 +321,24 @@ test("approval — AskUserQuestion renders the question + options + locks compos
   // text is always there).
   expect(withQuestion).toContain("Submit")
 
-  // Composer locked. Whitespace-collapsed compare — see the
-  // ExitPlanMode test for why.
+  // Auto-added "Other" affordance — kobe synthesizes this client-side
+  // per the AskUserQuestion spec's "always offer custom text" contract.
+  // The label is rendered as a normal option row alongside the
+  // model-supplied options.
+  expect(withQuestion).toContain("Other")
+
+  // Composer is NOT locked for questions (only ExitPlanMode locks —
+  // approval is binary, but questions accept free-text via composer
+  // as a parallel path to picking "Other"). The lock copy must NOT
+  // appear; instead we render a soft hint telling the user they can
+  // either pick or type. Whitespace-collapsed compare to be robust
+  // against opentui's text-wrap quirk.
   await new Promise((r) => setTimeout(r, 500))
-  const lockedScreen = await kobe.capture()
-  expect(lockedScreen.replace(/\s+/g, "")).toContain("answertheprompt")
-  expect(lockedScreen.replace(/\s+/g, "")).toContain("tocontinue")
+  const screen = await kobe.capture()
+  const collapsed = screen.replace(/\s+/g, "")
+  expect(collapsed).not.toContain("answertheprompt")
+  // Soft hint copy from Chat.tsx — see the pendingQuestion <Show> block.
+  expect(collapsed).toContain("typeyourownanswer")
 
   await kobe.exit()
 }, 60_000)


### PR DESCRIPTION
## Summary

- Auto-add an **"Other"** row to every AskUserQuestion picker (per the tool's "always offer custom text" contract). Picking it reveals an inline text input; the typed text replaces the internal sentinel before the answer reaches the engine.
- **Sequential questions** — multi-question prompts now advance one card at a time. Past questions collapse to a click-to-edit preview; future questions stay hidden. Each card has its own `[ Next ]` / `[ Submit ]` (Submit only on the last).
- **Hide the main composer entirely** while a question is pending — the user's focus belongs on the picker. The composer reappears as soon as the picker resolves. ExitPlanMode keeps the composer rendered-but-locked (approval is binary, the surrounding history / model affordances still matter there).
- Focus fix: the inline "Other" input claims focus via a signal that releases the composer's `focused` prop. Defense-in-depth in case a later refactor re-renders the composer mid-picker.

### Why

The picker was a forced choice — even when none of the offered options matched what the user wanted to say, they had to submit one to continue. And dumping every question on the screen at once made multi-question prompts feel like a wall to climb instead of a flow.

### Files

- `packages/kobe/src/tui/panes/chat/MessageList.tsx` — `QuestionRow`: auto-Other option + inline text input + sentinel substitution + sequential `currentIndex` rendering + per-card Next/Submit + focus-claim signal
- `packages/kobe/src/tui/panes/chat/Chat.tsx` — split `hasPendingInput()` into `pendingApproval` (locks composer) vs `pendingQuestion` (hides composer entirely); compose-focus releases when the inline "Other" input is up
- `packages/kobe/test/behavior/approval-flow.test.ts` — AskUserQuestion render-state assertion updated (composer no longer present during picker); ExitPlanMode lock assertion untouched

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [x] Unit tests pass (697)
- [x] Manual: Other row shows up → click → inline input appears + grabs focus → type → enter / Submit sends the typed text as the answer (符合预期)
- [x] Manual: Multi-question prompt — questions appear one at a time, `[ Next ]` advances, past questions collapse to a click-to-edit preview, last question's button reads `[ Submit ]`
- [x] Manual: Main composer is hidden while a question picker is up, reappears after Submit, and the user can type freely again
- [x] Manual: ExitPlanMode still locks the composer (regression check)

(Behavior tests are local-only per CLAUDE.md; verify on a machine with tmux + node-pty.)
