### PR TITLE
feat(KOB-83): !shell bash command mode in chat composer

### DIFF
--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -439,7 +439,16 @@ export function Chat(props: ChatProps) {
    * session id — engine logs "claude session ended:
    * error_during_execution" for each loser.
    */
-  let dispatching = false
+  // Reactive lock so the effect re-fires when a bash drain finishes.
+  // The earlier plain-variable lock worked for the prompt-only path
+  // because `runTask` flipped `isStreaming` true→false via user.inject
+  // / done events, and each toggle re-triggered the effect to drain
+  // the next item. Bash items don't touch `isStreaming`, so without a
+  // tracked lock the effect doesn't see `dispatching` flip back to
+  // false after `await runBashLocally`, and any items behind a bash
+  // entry in the queue would sit there until the user manually pokes
+  // some other reactive state (KOB-83 queue-chain regression).
+  const [dispatching, setDispatching] = createSignal(false)
   createEffect(() => {
     const taskId = props.taskId()
     const tabId = activeTabId()
@@ -448,15 +457,15 @@ export function Chat(props: ChatProps) {
     if (state.isStreaming) return
     if (state.queue.length === 0) return
     if (hasPendingInput()) return
-    if (dispatching) return
+    if (dispatching()) return
     // Dequeue inside a microtask so the createEffect's reactive read
     // graph is settled before we mutate state. Without the defer, the
     // patch races the effect's tracking and we can miss the next tick.
     queueMicrotask(async () => {
-      if (dispatching) return
+      if (dispatching()) return
       const cur = activeState()
       if (cur.isStreaming || cur.queue.length === 0) return
-      dispatching = true
+      setDispatching(true)
       try {
         let head: QueuedPrompt | null = null
         patchActiveState((s) => {
@@ -509,7 +518,7 @@ export function Chat(props: ChatProps) {
           patchActiveState((s) => pushSystemError(s, `queued runTask failed: ${stringifyErr(err)}`))
         }
       } finally {
-        dispatching = false
+        setDispatching(false)
       }
     })
   })
@@ -718,8 +727,8 @@ export function Chat(props: ChatProps) {
       // concurrent runTasks fighting for the same session id. Bail if
       // another dispatch already owns the lock; the user can re-click
       // rather than queue another race.
-      if (dispatching) return
-      dispatching = true
+      if (dispatching()) return
+      setDispatching(true)
       try {
         // steerTask owns the interrupt + run-with-merged-prompt
         // sequence atomically on the orchestrator side. Critically,
@@ -734,7 +743,7 @@ export function Chat(props: ChatProps) {
           patchActiveState((s) => pushSystemError(s, `steer failed: ${stringifyErr(err)}`))
         }
       } finally {
-        dispatching = false
+        setDispatching(false)
       }
       return
     }

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -59,9 +59,11 @@ import { formatContextUsageCompact } from "./context-meter"
 import {
   type ChatRow,
   type ChatState,
+  type QueuedPrompt,
   createInitialState,
   dequeueFirst,
   drainPendingBashContext,
+  enqueueBashCommand,
   enqueuePrompt,
   formatBashContextPrefix,
   patchBashRow,
@@ -456,20 +458,42 @@ export function Chat(props: ChatProps) {
       if (cur.isStreaming || cur.queue.length === 0) return
       dispatching = true
       try {
-        let head: { id: string; text: string; ts: string } | null = null
+        let head: QueuedPrompt | null = null
         patchActiveState((s) => {
           const [next, popped] = dequeueFirst(s)
           head = popped
           return next
         })
+        // The `as` cast is load-bearing: TS doesn't trust that the
+        // patchActiveState callback ran synchronously, so it narrows
+        // `head` to `null` (its initialization value) and the kind
+        // check below collapses to `never`. The original (pre-bash)
+        // code carried the same cast for the same reason.
+        const dispatched = head as QueuedPrompt | null
+        if (!dispatched) return
+        // Route by kind. Bash items run locally via runBashLocally
+        // (which awaits the subprocess) — serial with whatever else
+        // is queued. Prompt items run the engine turn with bash
+        // context prepended. Mirrors claude-code's drain in
+        // `executeUserInput`: each queued command goes through
+        // `processUserInput`, which forks on `mode === 'bash'` vs
+        // prompt without breaking the queue's FIFO semantics.
+        if (dispatched.kind === "bash") {
+          // Awaiting here keeps the queue serial — the effect re-runs
+          // on the next reactive tick and drains the next item only
+          // after this bash exits. A long-running command (`!sleep 60`)
+          // blocks subsequent prompts until it finishes or the user
+          // Escs the abort.
+          await runBashLocally(dispatched.command)
+          return
+        }
         // The user row appears via the orchestrator's user.inject
         // event fired at the start of runTask. Pushing it locally
         // here used to be the source of truth, but that bypassed
         // the daemon's broadcast so other attached TUIs never saw
         // the user message — leaving their chat looking like one
         // long unbroken assistant ramble.
-        const dispatched = head as { id: string; text: string; ts: string } | null
-        if (!dispatched) return
+        //
         // Drain pending !bash context HERE (at dispatch time), not at
         // enqueue time. A bash command that runs WHILE a prompt sits
         // in the queue should attach its context to that prompt (the
@@ -519,8 +543,26 @@ export function Chat(props: ChatProps) {
    * has already stripped the `!`; we own pushing the bash row, streaming
    * output into it, and stashing the completed interaction so the next
    * regular prompt can fold it into the model context as XML.
+   *
+   * Streaming-state routing mirrors claude-code's `handlePromptSubmit`
+   * (`refs/claude-code/src/utils/handlePromptSubmit.ts:313-350`): an
+   * engine turn in flight → enqueue and wait. The queue-drain microtask
+   * runs the bash command serially with whatever else is queued so
+   * shell output doesn't race the engine writing into the same worktree
+   * (e.g. claude editing a file while user `!cat`s it would otherwise
+   * see partial state). Idle path runs immediately, same as before.
    */
   function handleBashCommand(command: string): void {
+    if (activeState().isStreaming) {
+      const tabId = activeTabId()
+      if (!tabId) return
+      if (queueIsFull(activeState())) {
+        patchActiveState((s) => pushSystemError(s, `queue is full (max ${activeState().queue.length})`))
+        return
+      }
+      patchActiveState((s) => enqueueBashCommand(s, command))
+      return
+    }
     void runBashLocally(command)
   }
 
@@ -744,6 +786,14 @@ export function Chat(props: ChatProps) {
     const entry = activeState().queue.find((q) => q.id === id)
     if (!entry) return
     patchActiveState((s) => removeFromQueue(s, id))
+    if (entry.kind === "bash") {
+      // Bash items in the queue can't "steer" — there's no engine turn
+      // to interrupt for a local shell call. Promote to immediate
+      // execution instead; aborts whatever bash is currently in-flight
+      // for the tab (matches the abort-prior rule in runBashLocally).
+      void runBashLocally(entry.command)
+      return
+    }
     void send(entry.text, "steer")
   }
 

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -470,8 +470,17 @@ export function Chat(props: ChatProps) {
         // long unbroken assistant ramble.
         const dispatched = head as { id: string; text: string; ts: string } | null
         if (!dispatched) return
+        // Drain pending !bash context HERE (at dispatch time), not at
+        // enqueue time. A bash command that runs WHILE a prompt sits
+        // in the queue should attach its context to that prompt (the
+        // model sees the bash output immediately preceding the user's
+        // intent), not drift to the prompt after. Mirrors claude-code's
+        // conversation semantics where bash messages join history at
+        // the moment they execute.
+        const bashPrefix = drainBashContextPrefix()
+        const finalText = bashPrefix.length > 0 ? bashPrefix + dispatched.text : dispatched.text
         try {
-          await props.orchestrator.runTask(taskId, dispatched.text, tabId)
+          await props.orchestrator.runTask(taskId, finalText, tabId)
         } catch (err) {
           patchActiveState((s) => pushSystemError(s, `queued runTask failed: ${stringifyErr(err)}`))
         }
@@ -495,6 +504,16 @@ export function Chat(props: ChatProps) {
   // processes were killed when the runtime exited the closure.
   const bashAbortsByTab = new Map<string, AbortController>()
 
+  // On Chat unmount, abort every in-flight bash. Without this, a Chat
+  // that gets swapped out (file preview opening, app exit) leaves
+  // child processes running up to their 30-min timeout, each one
+  // writing into a ChatState that's already been GC'd by
+  // useChatSession's teardown.
+  onCleanup(() => {
+    for (const ac of bashAbortsByTab.values()) ac.abort()
+    bashAbortsByTab.clear()
+  })
+
   /**
    * Fire-and-forget entry for the composer's `!cmd` submit. The composer
    * has already stripped the `!`; we own pushing the bash row, streaming
@@ -511,7 +530,7 @@ export function Chat(props: ChatProps) {
     if (!taskId || !tabId) return
     const cwd = worktreePath()
     if (!cwd) {
-      patchActiveState((s) => pushSystemError(s, "bash: task has no worktree yet"))
+      patchStateForTab(tabId, (s) => pushSystemError(s, "bash: task has no worktree yet"))
       return
     }
     // One bash at a time per tab — abort the prior run if still active.
@@ -521,7 +540,15 @@ export function Chat(props: ChatProps) {
     bashAbortsByTab.set(tabId, ac)
 
     const id = `bash-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
-    patchActiveState((s) => pushBashRow(s, { id, command }))
+    // CRITICAL: every patch below uses `patchStateForTab(tabId, …)`, not
+    // `patchActiveState`. The bash runs asynchronously; if the user
+    // switches tabs mid-run, `activeTabId()` no longer points at this
+    // bash's tab, so a `patchActiveState` call would (a) silently miss
+    // the row on the new active tab (id mismatch) and (b) attach the
+    // completed `pendingBashContext` to the wrong tab's next prompt.
+    // The `tabId` captured at the top of this function is the source
+    // of truth for the duration of the run.
+    patchStateForTab(tabId, (s) => pushBashRow(s, { id, command }))
 
     // Accumulate output locally so we don't have to fish the final
     // stdout/stderr back out of the reducer state at completion time
@@ -534,21 +561,23 @@ export function Chat(props: ChatProps) {
         cwd,
         onStdout: (chunk) => {
           stdoutAcc += chunk
-          patchActiveState((s) => patchBashRow(s, id, { stdoutAppend: chunk }))
+          patchStateForTab(tabId, (s) => patchBashRow(s, id, { stdoutAppend: chunk }))
         },
         onStderr: (chunk) => {
           stderrAcc += chunk
-          patchActiveState((s) => patchBashRow(s, id, { stderrAppend: chunk }))
+          patchStateForTab(tabId, (s) => patchBashRow(s, id, { stderrAppend: chunk }))
         },
         signal: ac.signal,
       })
-      patchActiveState((s) => patchBashRow(s, id, { done: true, exitCode: result.exitCode, signal: result.signal }))
+      patchStateForTab(tabId, (s) =>
+        patchBashRow(s, id, { done: true, exitCode: result.exitCode, signal: result.signal }),
+      )
       // Skip pending-context stash on a user-initiated abort — Esc /
       // Ctrl-C cancelled the run, the model shouldn't see a half-baked
       // output as context. Timeouts still stash (exitCode === -1,
       // signal === null) so the model can reason about the failure.
       if (!ac.signal.aborted) {
-        patchActiveState((s) =>
+        patchStateForTab(tabId, (s) =>
           pushPendingBashContext(s, {
             command,
             stdout: stdoutAcc,
@@ -558,8 +587,8 @@ export function Chat(props: ChatProps) {
         )
       }
     } catch (err) {
-      patchActiveState((s) => patchBashRow(s, id, { done: true, exitCode: -1, signal: null }))
-      patchActiveState((s) => pushSystemError(s, `bash failed: ${stringifyErr(err)}`))
+      patchStateForTab(tabId, (s) => patchBashRow(s, id, { done: true, exitCode: -1, signal: null }))
+      patchStateForTab(tabId, (s) => pushSystemError(s, `bash failed: ${stringifyErr(err)}`))
     } finally {
       if (bashAbortsByTab.get(tabId) === ac) bashAbortsByTab.delete(tabId)
     }
@@ -628,11 +657,14 @@ export function Chat(props: ChatProps) {
 
     const streaming = activeState().isStreaming
 
-    // Drain any pending `!bash` interactions into an XML prefix. The
-    // prefix is concatenated with `text` before dispatch on every path
-    // (steer / queue / idle) so the model sees the bash context no
-    // matter how the user submitted. Empty when nothing pending.
-    const bashPrefix = drainBashContextPrefix()
+    // Drain `!bash` context here for the IMMEDIATE-dispatch paths (idle
+    // and steer). Queue path defers the drain to the queue-drain
+    // microtask above so bash commands that complete WHILE the prompt
+    // sits in the queue still attach to that prompt, not the one after
+    // — matches claude-code's "bash messages join conversation history
+    // at the moment they execute" semantics.
+    const immediate = !streaming || mode === "steer"
+    const bashPrefix = immediate ? drainBashContextPrefix() : ""
     const dispatched = bashPrefix.length > 0 ? bashPrefix + text : text
 
     if (streaming && mode === "steer") {
@@ -673,7 +705,11 @@ export function Chat(props: ChatProps) {
         return
       }
       setDraft("")
-      patchActiveState((s) => enqueuePrompt(s, dispatched))
+      // Stash the user's RAW text; the queue-drain microtask folds in
+      // whatever bash context is pending at dispatch time. Storing
+      // `dispatched` (with prefix) would freeze stale context onto the
+      // queued prompt.
+      patchActiveState((s) => enqueuePrompt(s, text))
       return
     }
 
@@ -732,6 +768,11 @@ export function Chat(props: ChatProps) {
     const tabId = activeTabId()
     if (!taskId || !tabId) return
     if (tabs().length <= 1) return
+    // Abort any in-flight bash for this tab BEFORE the orchestrator
+    // tears it down. Otherwise the subprocess keeps running up to the
+    // 30-minute timeout, writing into an orphaned ChatState that's
+    // about to be GC'd by syncTabSubs.
+    bashAbortsByTab.get(tabId)?.abort()
     try {
       const nextActive = await props.orchestrator.closeTab(taskId, tabId)
       // The controller's syncTabSubs drops the orphan tab's state +

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -51,6 +51,7 @@ import { useDialog } from "../../ui/dialog"
 import { Composer, type ComposerSlashEntry } from "./Composer"
 import { Loading } from "./Loading"
 import { MessageList } from "./MessageList"
+import { runBashCommand } from "./bash-mode"
 import { ModelPicker } from "./composer/ModelPicker"
 import { BUILTIN_CLAUDE_SLASHES, type BuiltinSlash } from "./composer/builtin-slashes"
 import { loadUserSlashes } from "./composer/user-slashes"
@@ -60,7 +61,12 @@ import {
   type ChatState,
   createInitialState,
   dequeueFirst,
+  drainPendingBashContext,
   enqueuePrompt,
+  formatBashContextPrefix,
+  patchBashRow,
+  pushBashRow,
+  pushPendingBashContext,
   pushSystemError,
   queueIsFull,
   removeFromQueue,
@@ -250,7 +256,7 @@ export function Chat(props: ChatProps) {
       if (!m) continue
       if (m.kind === "approval") return m.status === "pending" ? m : null
       if (m.kind === "question") return m.answers === null ? m : null
-      if (m.kind === "user" || m.kind === "assistant") return null
+      if (m.kind === "user" || m.kind === "assistant" || m.kind === "bash") return null
     }
     return null
   }
@@ -477,6 +483,106 @@ export function Chat(props: ChatProps) {
 
   // Subscription teardown is owned by useChatSession's own onCleanup.
 
+  // ── Bash mode (KOB-83) ──────────────────────────────────────────────
+  //
+  // `!shell` runs locally in the TUI process (not via the orchestrator
+  // event bus, so multi-attach clients won't see the row in v1). Tracked
+  // per tab so each tab can have at most one in-flight bash command;
+  // re-submitting cancels the prior one. The map lives on this closure
+  // — not in module scope like statesByTab — because an AbortController
+  // is only meaningful while the original component is mounted; on
+  // remount we'd want fresh controllers anyway since the prior child
+  // processes were killed when the runtime exited the closure.
+  const bashAbortsByTab = new Map<string, AbortController>()
+
+  /**
+   * Fire-and-forget entry for the composer's `!cmd` submit. The composer
+   * has already stripped the `!`; we own pushing the bash row, streaming
+   * output into it, and stashing the completed interaction so the next
+   * regular prompt can fold it into the model context as XML.
+   */
+  function handleBashCommand(command: string): void {
+    void runBashLocally(command)
+  }
+
+  async function runBashLocally(command: string): Promise<void> {
+    const taskId = props.taskId()
+    const tabId = activeTabId()
+    if (!taskId || !tabId) return
+    const cwd = worktreePath()
+    if (!cwd) {
+      patchActiveState((s) => pushSystemError(s, "bash: task has no worktree yet"))
+      return
+    }
+    // One bash at a time per tab — abort the prior run if still active.
+    // Pragmatic v1: claude-code allows only one concurrent !cmd too.
+    bashAbortsByTab.get(tabId)?.abort()
+    const ac = new AbortController()
+    bashAbortsByTab.set(tabId, ac)
+
+    const id = `bash-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+    patchActiveState((s) => pushBashRow(s, { id, command }))
+
+    // Accumulate output locally so we don't have to fish the final
+    // stdout/stderr back out of the reducer state at completion time
+    // (racy — patch ordering vs. signal read).
+    let stdoutAcc = ""
+    let stderrAcc = ""
+    try {
+      const result = await runBashCommand({
+        command,
+        cwd,
+        onStdout: (chunk) => {
+          stdoutAcc += chunk
+          patchActiveState((s) => patchBashRow(s, id, { stdoutAppend: chunk }))
+        },
+        onStderr: (chunk) => {
+          stderrAcc += chunk
+          patchActiveState((s) => patchBashRow(s, id, { stderrAppend: chunk }))
+        },
+        signal: ac.signal,
+      })
+      patchActiveState((s) => patchBashRow(s, id, { done: true, exitCode: result.exitCode, signal: result.signal }))
+      // Skip pending-context stash on a user-initiated abort — Esc /
+      // Ctrl-C cancelled the run, the model shouldn't see a half-baked
+      // output as context. Timeouts still stash (exitCode === -1,
+      // signal === null) so the model can reason about the failure.
+      if (!ac.signal.aborted) {
+        patchActiveState((s) =>
+          pushPendingBashContext(s, {
+            command,
+            stdout: stdoutAcc,
+            stderr: stderrAcc,
+            exitCode: result.exitCode,
+          }),
+        )
+      }
+    } catch (err) {
+      patchActiveState((s) => patchBashRow(s, id, { done: true, exitCode: -1, signal: null }))
+      patchActiveState((s) => pushSystemError(s, `bash failed: ${stringifyErr(err)}`))
+    } finally {
+      if (bashAbortsByTab.get(tabId) === ac) bashAbortsByTab.delete(tabId)
+    }
+  }
+
+  /**
+   * Drain the active tab's pending bash context and format it as an
+   * XML prefix to fold into the next prompt. Returns the prefix string
+   * (empty when nothing pending) — `send()` prepends this to the text
+   * before handing off to runTask/steerTask/enqueuePrompt so all three
+   * paths give the model the same context.
+   */
+  function drainBashContextPrefix(): string {
+    const ctxs = activeState().pendingBashContext ?? []
+    if (ctxs.length === 0) return ""
+    const prefix = formatBashContextPrefix(ctxs)
+    patchActiveState((s) => {
+      const [next] = drainPendingBashContext(s)
+      return next
+    })
+    return prefix
+  }
+
   /**
    * Submit a prompt to the active tab.
    *
@@ -522,6 +628,13 @@ export function Chat(props: ChatProps) {
 
     const streaming = activeState().isStreaming
 
+    // Drain any pending `!bash` interactions into an XML prefix. The
+    // prefix is concatenated with `text` before dispatch on every path
+    // (steer / queue / idle) so the model sees the bash context no
+    // matter how the user submitted. Empty when nothing pending.
+    const bashPrefix = drainBashContextPrefix()
+    const dispatched = bashPrefix.length > 0 ? bashPrefix + text : text
+
     if (streaming && mode === "steer") {
       setDraft("")
       // Claim the dispatch lock BEFORE awaiting steer. Without this,
@@ -542,7 +655,7 @@ export function Chat(props: ChatProps) {
         // its own, so a naive interrupt+resume would drop the
         // abandoned prompt entirely.
         try {
-          await props.orchestrator.steerTask(taskId, text, tabId)
+          await props.orchestrator.steerTask(taskId, dispatched, tabId)
         } catch (err) {
           patchActiveState((s) => pushSystemError(s, `steer failed: ${stringifyErr(err)}`))
         }
@@ -560,7 +673,7 @@ export function Chat(props: ChatProps) {
         return
       }
       setDraft("")
-      patchActiveState((s) => enqueuePrompt(s, text))
+      patchActiveState((s) => enqueuePrompt(s, dispatched))
       return
     }
 
@@ -568,7 +681,7 @@ export function Chat(props: ChatProps) {
     // user row lands via the event bus (no local pushUser).
     setDraft("")
     try {
-      await props.orchestrator.runTask(taskId, text, tabId)
+      await props.orchestrator.runTask(taskId, dispatched, tabId)
     } catch (err) {
       patchActiveState((s) => pushSystemError(s, `runTask failed: ${stringifyErr(err)}`))
     }
@@ -677,15 +790,36 @@ export function Chat(props: ChatProps) {
     }),
   }))
 
-  // Esc-to-interrupt while streaming. Gated on `streaming` so an idle
-  // ESC is a no-op (the global "back to sidebar" detach was removed
-  // because it pulled focus out from under the user mid-edit; use
-  // `ctrl+q` for an explicit detach). Gated on `!dialog.stack.length`
-  // so DialogProvider's esc (close top dialog) isn't shadowed.
+  // True while a `!bash` subprocess is in flight for the active tab.
+  // Derived from messages (the last bash row's `done` flag) rather
+  // than the AbortController map so Solid reruns dependent UI on the
+  // exact tick the row flips to `done: true`. Scans from the tail
+  // because in-flight bash rows are always recent.
+  const hasActiveBash = createMemo(() => {
+    const msgs = activeState().messages
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i]
+      if (!m) continue
+      if (m.kind === "bash") return !m.done
+    }
+    return false
+  })
+
+  // Esc-to-interrupt while streaming OR while a `!bash` command is
+  // running. Gated on at least one of those being true so an idle ESC
+  // is a no-op (the global "back to sidebar" detach was removed because
+  // it pulled focus out from under the user mid-edit; use `ctrl+q` for
+  // an explicit detach). Gated on `!dialog.stack.length` so
+  // DialogProvider's esc (close top dialog) isn't shadowed.
   async function interruptStream(): Promise<void> {
     const taskId = props.taskId()
     const tabId = activeTabId()
     if (!taskId || !tabId) return
+    // Abort any in-flight bash for this tab first — local, synchronous.
+    // The runBashLocally handler watches signal.aborted and skips the
+    // pending-context stash, so the cancelled run doesn't leak into the
+    // next prompt.
+    bashAbortsByTab.get(tabId)?.abort()
     if (!activeState().isStreaming) return
     try {
       await props.orchestrator.interruptTask(taskId, tabId)
@@ -694,7 +828,7 @@ export function Chat(props: ChatProps) {
     }
   }
   useBindings(() => ({
-    enabled: props.focused?.() === true && activeState().isStreaming && dialog.stack.length === 0,
+    enabled: props.focused?.() === true && (activeState().isStreaming || hasActiveBash()) && dialog.stack.length === 0,
     bindings: [{ key: "escape", cmd: () => void interruptStream() }],
   }))
 
@@ -935,6 +1069,7 @@ export function Chat(props: ChatProps) {
           queue={() => activeState().queue}
           onCancelQueued={cancelQueued}
           onSendQueuedNow={sendQueuedNow}
+          onBashCommand={handleBashCommand}
         />
       </Show>
     </box>

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -190,12 +190,22 @@ export interface ComposerProps {
    */
   worktreePath?: Accessor<string | undefined>
   /**
-   * Mid-stream queued prompts (FIFO, head fires next). Rendered as a
+   * Mid-stream queued items (FIFO, head fires next). Rendered as a
    * muted list inside the composer rail, immediately above the textarea
    * row, so the queue shares the same bordered block as the input it
    * will feed. Empty list = nothing renders.
+   *
+   * Discriminated by `kind`: prompt items show plain text, bash items
+   * (Claude-Code `!cmd` parity, queued during streaming) render with a
+   * leading `!` in theme.warning so the user can tell at a glance which
+   * are queued shell commands vs queued model prompts.
    */
-  queue?: Accessor<readonly { readonly id: string; readonly text: string }[]>
+  queue?: Accessor<
+    readonly (
+      | { readonly id: string; readonly kind: "prompt"; readonly text: string }
+      | { readonly id: string; readonly kind: "bash"; readonly command: string }
+    )[]
+  >
   /** Drop a queued prompt by id (cancel button). */
   onCancelQueued?: (id: string) => void
   /**
@@ -1317,8 +1327,13 @@ export function Composer(props: ComposerProps) {
                     <text fg={theme.textMuted} wrapMode="none">
                       queued{idx() === 0 ? " (next)" : ""}:
                     </text>
+                    <Show when={entry.kind === "bash"}>
+                      <text fg={theme.warning} attributes={TextAttributes.BOLD} wrapMode="none">
+                        !
+                      </text>
+                    </Show>
                     <box flexGrow={1}>
-                      <text fg={theme.text}>{entry.text}</text>
+                      <text fg={theme.text}>{entry.kind === "bash" ? entry.command : entry.text}</text>
                     </box>
                     <text
                       fg={theme.primary}

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -204,6 +204,16 @@ export interface ComposerProps {
    * and routes through the steer path.
    */
   onSendQueuedNow?: (id: string) => void
+
+  /**
+   * Submit a `!shell` command (Claude-Code-style bash mode). Fires on
+   * enter when the buffer starts with `!`; the composer strips the
+   * prefix before calling. Parent runs the command locally (not via
+   * the engine), streams output into a bash row, and stashes the
+   * interaction so the next regular submit prepends it as XML
+   * context. Omit to disable bash mode for this composer instance.
+   */
+  onBashCommand?: (command: string) => void
 }
 
 /**
@@ -277,6 +287,17 @@ export function Composer(props: ComposerProps) {
   // content change) don't refresh this; the dropdown stays open in
   // that edge case, dismissable with Esc — matches opcode's behavior.
   const [liveCursor, setLiveCursor] = createSignal(props.draft?.length ?? 0)
+
+  // Bash-mode detection — mirrors claude-code's `getModeFromInput` in
+  // `refs/claude-code/src/components/PromptInput/inputModes.ts`. We
+  // peek at the live buffer (not props.draft) so the visual updates on
+  // every keystroke without waiting for the parent's clear-on-submit
+  // roundtrip. Gated on `onBashCommand` being supplied — without a
+  // handler the visual swap would be a lie. The `! ` two-char check is
+  // a usability concession: a buffer of just `!` (no command yet) still
+  // counts as bash mode so the user sees the indicator engage as soon
+  // as they type the prefix, matching upstream.
+  const bashMode = createMemo(() => props.onBashCommand != null && liveBuffer().startsWith("!"))
 
   // Slash dropdown state. Cursor indexes into `slashMatches()`; reset
   // to 0 whenever the match list changes (e.g. user typed another char
@@ -945,6 +966,27 @@ export function Composer(props: ComposerProps) {
     if (!ref) return
     const raw = ref.plainText
     const trimmed = raw.trim()
+    // Bash-mode short-circuit (Claude-Code `!cmd` parity). The buffer
+    // starts with `!` AND the parent supplied `onBashCommand` → strip
+    // the prefix, hand the command to the parent for local shell
+    // execution, and bypass the engine entirely. Push the raw text
+    // (including the `!`) into prompt history so up-arrow recall
+    // restores the bash mode visual on recall.
+    if (bashMode() && trimmed.length > 1) {
+      const command = trimmed.slice(1).trim()
+      if (command.length === 0) return // bare `!` with no command — no-op
+      pushHistory(props.historyKey ?? "global", trimmed)
+      // Clear the textarea synchronously so the indicator turns off
+      // before the command starts streaming. Parent will also clear
+      // via the draft round-trip, but this avoids a one-tick flicker.
+      ref.setText("")
+      setBuffer("")
+      setLiveBuffer("")
+      props.onDraftChange("")
+      resetHistoryNav()
+      props.onBashCommand?.(command)
+      return
+    }
     // Slash short-circuit: if the dropdown is open and there's at
     // least one match, run the highlighted entry, clear the buffer,
     // and bypass the engine submit. Falls through if the user typed
@@ -1003,6 +1045,7 @@ export function Composer(props: ComposerProps) {
   const streamingNotice = () => {
     if (!props.hasTask) return ""
     if (props.isStreaming) return "enter queue · ctrl+enter steer"
+    if (bashMode()) return "bash mode · enter to run · esc to cancel"
     return ""
   }
   // Footer hint slot: paste-related feedback (e.g. "no image on
@@ -1260,7 +1303,19 @@ export function Composer(props: ComposerProps) {
             </box>
           </Show>
           <box flexDirection="row" gap={1} alignItems="flex-start">
-            <text fg={props.isStreaming ? theme.accent : theme.primary}>{props.isStreaming ? "…" : ">"}</text>
+            {/* Prompt glyph — three modes:
+                streaming → `…` (theme.accent)
+                bash      → `!` (theme.warning, claude-code parity)
+                idle      → `>` (theme.primary)
+                Streaming dominates because you can't submit anything
+                while it's true; bash beats idle when the user has typed
+                `!` as the first char. */}
+            <text
+              fg={props.isStreaming ? theme.accent : bashMode() ? theme.warning : theme.primary}
+              attributes={bashMode() ? TextAttributes.BOLD : undefined}
+            >
+              {props.isStreaming ? "…" : bashMode() ? "!" : ">"}
+            </text>
             <box flexGrow={1} flexShrink={1} maxHeight={COMPOSER_MAX_LINES} minHeight={COMPOSER_MIN_LINES}>
               <Show
                 when={props.hasTask}

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -1045,7 +1045,7 @@ export function Composer(props: ComposerProps) {
   const streamingNotice = () => {
     if (!props.hasTask) return ""
     if (props.isStreaming) return "enter queue · ctrl+enter steer"
-    if (bashMode()) return "bash mode · enter to run · esc to cancel"
+    if (bashMode()) return "bash mode · enter to run"
     return ""
   }
   // Footer hint slot: paste-related feedback (e.g. "no image on

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -288,16 +288,23 @@ export function Composer(props: ComposerProps) {
   // that edge case, dismissable with Esc — matches opcode's behavior.
   const [liveCursor, setLiveCursor] = createSignal(props.draft?.length ?? 0)
 
-  // Bash-mode detection — mirrors claude-code's `getModeFromInput` in
-  // `refs/claude-code/src/components/PromptInput/inputModes.ts`. We
-  // peek at the live buffer (not props.draft) so the visual updates on
-  // every keystroke without waiting for the parent's clear-on-submit
-  // roundtrip. Gated on `onBashCommand` being supplied — without a
-  // handler the visual swap would be a lie. The `! ` two-char check is
-  // a usability concession: a buffer of just `!` (no command yet) still
-  // counts as bash mode so the user sees the indicator engage as soon
-  // as they type the prefix, matching upstream.
-  const bashMode = createMemo(() => props.onBashCommand != null && liveBuffer().startsWith("!"))
+  // Bash-mode state — mirrors claude-code's `isInputModeCharacter`
+  // pattern in `refs/claude-code/src/components/PromptInput/inputModes.ts`,
+  // where typing `!` on an empty buffer SWITCHES MODES instead of
+  // inserting the character. Modeling this as a signal (not a memo over
+  // `liveBuffer().startsWith("!")`) keeps the `!` out of the textarea —
+  // an earlier draft used the prefix-check approach and the user saw
+  // `!!` (prompt glyph `!` + buffer `!`). Now the buffer holds the
+  // command verbatim and the glyph carries the mode.
+  //
+  // Entry:  empty buffer + `!` keystroke → swallow, setBashMode(true).
+  // Exit:   backspace / esc on an empty buffer → setBashMode(false).
+  // Reset:  on submit (so the next prompt starts in prompt mode).
+  //
+  // Gated on `onBashCommand` being supplied — without a handler the
+  // mode toggle would be a lie.
+  const [bashMode, setBashMode] = createSignal(false)
+  const bashAvailable = (): boolean => props.onBashCommand != null
 
   // Slash dropdown state. Cursor indexes into `slashMatches()`; reset
   // to 0 whenever the match list changes (e.g. user typed another char
@@ -791,6 +798,44 @@ export function Composer(props: ComposerProps) {
    * `handleKeyPress` too).
    */
   function handleKeyDown(key: KeyEvent): void {
+    // Bash-mode entry — empty buffer + `!` keystroke flips us into bash
+    // mode and SWALLOWS the `!` so it doesn't end up in the textarea.
+    // Mirrors claude-code's `isInputModeCharacter` check. Modifier
+    // gate: ctrl/meta/super out (those are chord prefixes); shift
+    // stays in scope because most US layouts produce `!` via shift+1
+    // and ship the shift modifier in the keypress event. We key off
+    // `sequence === "!"` instead of `name === "!"` because some
+    // terminals name the key by base-code (e.g. "1") and only the
+    // sequence reflects the rendered character.
+    if (
+      bashAvailable() &&
+      !bashMode() &&
+      liveBuffer().length === 0 &&
+      key.sequence === "!" &&
+      !key.ctrl &&
+      !key.meta &&
+      !key.super
+    ) {
+      setBashMode(true)
+      key.preventDefault()
+      return
+    }
+    // Bash-mode exit — backspace or escape on an empty bash buffer
+    // pops us back into prompt mode. Empty-buffer gate matters: in
+    // bash mode with a half-typed command, backspace deletes a char
+    // (and escape falls through to the textarea / dropdown handlers).
+    if (
+      bashMode() &&
+      liveBuffer().length === 0 &&
+      (key.name === "backspace" || key.name === "escape") &&
+      !key.ctrl &&
+      !key.meta &&
+      !key.super
+    ) {
+      setBashMode(false)
+      key.preventDefault()
+      return
+    }
     // ctrl+enter — steer. Submits the current buffer with mode='steer'
     // so the chat shell asks the orchestrator to interrupt the
     // in-flight subprocess before running the new prompt. We intercept
@@ -966,23 +1011,25 @@ export function Composer(props: ComposerProps) {
     if (!ref) return
     const raw = ref.plainText
     const trimmed = raw.trim()
-    // Bash-mode short-circuit (Claude-Code `!cmd` parity). The buffer
-    // starts with `!` AND the parent supplied `onBashCommand` → strip
-    // the prefix, hand the command to the parent for local shell
-    // execution, and bypass the engine entirely. Push the raw text
-    // (including the `!`) into prompt history so up-arrow recall
-    // restores the bash mode visual on recall.
-    if (bashMode() && trimmed.length > 1) {
-      const command = trimmed.slice(1).trim()
-      if (command.length === 0) return // bare `!` with no command — no-op
-      pushHistory(props.historyKey ?? "global", trimmed)
-      // Clear the textarea synchronously so the indicator turns off
-      // before the command starts streaming. Parent will also clear
-      // via the draft round-trip, but this avoids a one-tick flicker.
+    // Bash-mode short-circuit (Claude-Code `!cmd` parity). In bash mode
+    // the buffer holds the command verbatim — the `!` was swallowed
+    // at the keystroke that toggled the mode, not stored as a prefix.
+    // Push the `!`-prefixed form into history so up-arrow recall can
+    // distinguish bash entries from prompts later (and so a future
+    // history-replay can restore the bash-mode visual). Parent owns
+    // the actual shell exec via onBashCommand.
+    if (bashMode()) {
+      const command = trimmed
+      if (command.length === 0) return // bash mode with empty buffer — no-op
+      pushHistory(props.historyKey ?? "global", `!${command}`)
+      // Clear synchronously so the bash indicator drops before the
+      // command starts streaming. Parent's draft round-trip will also
+      // clear; this avoids a one-tick flicker.
       ref.setText("")
       setBuffer("")
       setLiveBuffer("")
       props.onDraftChange("")
+      setBashMode(false)
       resetHistoryNav()
       props.onBashCommand?.(command)
       return

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -1387,9 +1387,7 @@ export function Composer(props: ComposerProps) {
                 <Show
                   when={bashMode() && props.isStreaming}
                   fallback={
-                    <text fg={props.isStreaming ? theme.accent : theme.primary}>
-                      {props.isStreaming ? "…" : ">"}
-                    </text>
+                    <text fg={props.isStreaming ? theme.accent : theme.primary}>{props.isStreaming ? "…" : ">"}</text>
                   }
                 >
                   <box flexDirection="row">

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -197,8 +197,8 @@ export interface ComposerProps {
    *
    * Discriminated by `kind`: prompt items show plain text, bash items
    * (Claude-Code `!cmd` parity, queued during streaming) render with a
-   * leading `!` in theme.warning so the user can tell at a glance which
-   * are queued shell commands vs queued model prompts.
+   * leading `(bash)` label in theme.warning so the user can tell at a
+   * glance which are queued shell commands vs queued model prompts.
    */
   queue?: Accessor<
     readonly (
@@ -1333,8 +1333,8 @@ export function Composer(props: ComposerProps) {
                       queued{idx() === 0 ? " (next)" : ""}:
                     </text>
                     <Show when={entry.kind === "bash"}>
-                      <text fg={theme.warning} attributes={TextAttributes.BOLD} wrapMode="none">
-                        !
+                      <text fg={theme.warning} wrapMode="none">
+                        (bash)
                       </text>
                     </Show>
                     <box flexGrow={1}>

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -1101,8 +1101,13 @@ export function Composer(props: ComposerProps) {
   // keeps only the mode + model badges.
   const streamingNotice = () => {
     if (!props.hasTask) return ""
+    // bash mode dominates the footer regardless of streaming so the
+    // user can SEE they're in bash mode while a turn is in flight —
+    // otherwise the "enter queue · ctrl+enter steer" hint masked the
+    // mode signal and the user couldn't tell they were about to queue
+    // a shell command vs a regular prompt.
+    if (bashMode()) return props.isStreaming ? "bash mode · enter to queue" : "bash mode · enter to run"
     if (props.isStreaming) return "enter queue · ctrl+enter steer"
-    if (bashMode()) return "bash mode · enter to run"
     return ""
   }
   // Footer hint slot: paste-related feedback (e.g. "no image on
@@ -1365,19 +1370,41 @@ export function Composer(props: ComposerProps) {
             </box>
           </Show>
           <box flexDirection="row" gap={1} alignItems="flex-start">
-            {/* Prompt glyph — three modes:
-                streaming → `…` (theme.accent)
-                bash      → `!` (theme.warning, claude-code parity)
-                idle      → `>` (theme.primary)
-                Streaming dominates because you can't submit anything
-                while it's true; bash beats idle when the user has typed
-                `!` as the first char. */}
-            <text
-              fg={props.isStreaming ? theme.accent : bashMode() ? theme.warning : theme.primary}
-              attributes={bashMode() ? TextAttributes.BOLD : undefined}
+            {/* Prompt glyph — four states:
+                idle               → `>` (theme.primary)
+                idle + bash        → `!` (theme.warning, BOLD)
+                streaming          → `…` (theme.accent)
+                streaming + bash   → `…!` (accent dots + warning `!`)
+                bash mode must remain visible while streaming or the
+                user can't tell whether their next Enter queues a
+                prompt or a !cmd. Earlier the streaming `…` glyph
+                masked the bash indicator entirely. Two adjacent
+                glyphs costs one extra cell and resolves the
+                ambiguity unambiguously. */}
+            <Show
+              when={bashMode() && !props.isStreaming}
+              fallback={
+                <Show
+                  when={bashMode() && props.isStreaming}
+                  fallback={
+                    <text fg={props.isStreaming ? theme.accent : theme.primary}>
+                      {props.isStreaming ? "…" : ">"}
+                    </text>
+                  }
+                >
+                  <box flexDirection="row">
+                    <text fg={theme.accent}>…</text>
+                    <text fg={theme.warning} attributes={TextAttributes.BOLD}>
+                      !
+                    </text>
+                  </box>
+                </Show>
+              }
             >
-              {props.isStreaming ? "…" : bashMode() ? "!" : ">"}
-            </text>
+              <text fg={theme.warning} attributes={TextAttributes.BOLD}>
+                !
+              </text>
+            </Show>
             <box flexGrow={1} flexShrink={1} maxHeight={COMPOSER_MAX_LINES} minHeight={COMPOSER_MIN_LINES}>
               <Show
                 when={props.hasTask}

--- a/packages/kobe/src/tui/panes/chat/MessageList.tsx
+++ b/packages/kobe/src/tui/panes/chat/MessageList.tsx
@@ -703,6 +703,94 @@ function ReadGrepGlobBanner(props: { row: Extract<ChatRow, { kind: "tool" }> }) 
 }
 
 /**
+ * `!shell` (bash mode) row — user-initiated shell command, rendered as
+ * `! <command>` banner + indented stdout/stderr block + completion chip
+ * (exit code or "interrupted"). Distinct from the model-initiated
+ * `BashBanner` / `BashOutputBlock` pair (which use a `$` chip in
+ * theme.accent) so the user can tell at a glance which side ran the
+ * command. Color mirrors Claude Code's `bashBorder` semantic via
+ * theme.warning since kobe doesn't have a dedicated bash color.
+ *
+ * Streaming: stdout/stderr live as separate strings on the row and are
+ * concatenated as the child process emits chunks. `splitBashOutput`
+ * caps the collapsed view at {@link BASH_OUTPUT_COLLAPSED_CAP} lines
+ * each so a `find /` doesn't dominate the scroll. The `done: false`
+ * variant shows a "running…" hint instead of the exit chip.
+ */
+function BashRow(props: { row: Extract<ChatRow, { kind: "bash" }> }) {
+  const { theme } = useTheme()
+  const r = () => props.row
+  const stdoutView = (): BashOutputView => splitBashOutput(r().stdout, BASH_OUTPUT_COLLAPSED_CAP)
+  const stderrView = (): BashOutputView => splitBashOutput(r().stderr, BASH_OUTPUT_COLLAPSED_CAP)
+  const statusText = (): string => {
+    if (!r().done) return "running…"
+    if (r().signal !== null) return `interrupted (${r().signal})`
+    const code = r().exitCode
+    if (code === null) return "(no exit code)"
+    if (code === 0) return "done"
+    return `exit ${code}`
+  }
+  const statusColor = () => {
+    if (!r().done) return theme.textMuted
+    if (r().signal !== null) return theme.error
+    const code = r().exitCode
+    if (code === 0) return theme.success
+    return theme.error
+  }
+  return (
+    <box paddingTop={1} flexDirection="column">
+      <box flexDirection="row" gap={1}>
+        <text fg={theme.warning} attributes={TextAttributes.BOLD} wrapMode="none">
+          !
+        </text>
+        <box flexGrow={1}>
+          <text fg={theme.text} wrapMode="none">
+            {r().command || "(empty command)"}
+          </text>
+        </box>
+      </box>
+      <Show when={stdoutView().totalLines > 0}>
+        <box paddingLeft={2} flexDirection="column">
+          <For each={stdoutView().visible}>
+            {(line) => (
+              <text fg={theme.textMuted} wrapMode="none">
+                {line || " "}
+              </text>
+            )}
+          </For>
+          <Show when={stdoutView().hidden > 0}>
+            <text fg={theme.textMuted}>
+              {`  … ${stdoutView().hidden} more ${stdoutView().hidden === 1 ? "line" : "lines"}`}
+            </text>
+          </Show>
+        </box>
+      </Show>
+      <Show when={stderrView().totalLines > 0}>
+        <box paddingLeft={2} flexDirection="column">
+          <For each={stderrView().visible}>
+            {(line) => (
+              <text fg={theme.error} wrapMode="none">
+                {line || " "}
+              </text>
+            )}
+          </For>
+          <Show when={stderrView().hidden > 0}>
+            <text fg={theme.error}>
+              {`  … ${stderrView().hidden} more ${stderrView().hidden === 1 ? "line" : "lines"}`}
+            </text>
+          </Show>
+        </box>
+      </Show>
+      <box paddingLeft={2}>
+        <text fg={statusColor()} attributes={TextAttributes.DIM}>
+          {statusText()}
+        </text>
+      </box>
+    </box>
+  )
+}
+
+/**
  * System / error row.
  *
  * Mirrors Claude Code's `SystemTextMessage` "away_summary" / API-error
@@ -1291,6 +1379,7 @@ export function MessageList(props: MessageListProps) {
           if (row.kind === "user") return <UserRow text={row.text} />
           if (row.kind === "assistant") return <AssistantRow text={row.text} />
           if (row.kind === "system") return <SystemRow text={row.text} />
+          if (row.kind === "bash") return <BashRow row={row} />
           if (row.kind === "approval") {
             return <ApprovalRow row={row} onApprove={(approve) => props.onApprove?.(row.requestId, approve)} />
           }

--- a/packages/kobe/src/tui/panes/chat/MessageList.tsx
+++ b/packages/kobe/src/tui/panes/chat/MessageList.tsx
@@ -722,19 +722,21 @@ function BashRow(props: { row: Extract<ChatRow, { kind: "bash" }> }) {
   const r = () => props.row
   const stdoutView = (): BashOutputView => splitBashOutput(r().stdout, BASH_OUTPUT_COLLAPSED_CAP)
   const stderrView = (): BashOutputView => splitBashOutput(r().stderr, BASH_OUTPUT_COLLAPSED_CAP)
-  const statusText = (): string => {
+  // Successful exits suppress the status footer entirely — the
+  // command + its output is enough signal that it ran. We still
+  // surface non-success states (running, interrupted, non-zero exit,
+  // missing exit code) where the user benefits from knowing.
+  const statusText = (): string | null => {
     if (!r().done) return "running…"
     if (r().signal !== null) return `interrupted (${r().signal})`
     const code = r().exitCode
     if (code === null) return "(no exit code)"
-    if (code === 0) return "done"
+    if (code === 0) return null
     return `exit ${code}`
   }
   const statusColor = () => {
     if (!r().done) return theme.textMuted
     if (r().signal !== null) return theme.error
-    const code = r().exitCode
-    if (code === 0) return theme.success
     return theme.error
   }
   return (
@@ -781,11 +783,13 @@ function BashRow(props: { row: Extract<ChatRow, { kind: "bash" }> }) {
           </Show>
         </box>
       </Show>
-      <box paddingLeft={2}>
-        <text fg={statusColor()} attributes={TextAttributes.DIM}>
-          {statusText()}
-        </text>
-      </box>
+      <Show when={statusText() != null}>
+        <box paddingLeft={2}>
+          <text fg={statusColor()} attributes={TextAttributes.DIM}>
+            {statusText()}
+          </text>
+        </box>
+      </Show>
     </box>
   )
 }

--- a/packages/kobe/src/tui/panes/chat/MessageList.tsx
+++ b/packages/kobe/src/tui/panes/chat/MessageList.tsx
@@ -720,8 +720,13 @@ function ReadGrepGlobBanner(props: { row: Extract<ChatRow, { kind: "tool" }> }) 
 function BashRow(props: { row: Extract<ChatRow, { kind: "bash" }> }) {
   const { theme } = useTheme()
   const r = () => props.row
-  const stdoutView = (): BashOutputView => splitBashOutput(r().stdout, BASH_OUTPUT_COLLAPSED_CAP)
-  const stderrView = (): BashOutputView => splitBashOutput(r().stderr, BASH_OUTPUT_COLLAPSED_CAP)
+  // No line-count truncation. claude-code's `OutputLine` renders every
+  // line of bash output (only per-line column truncation, never a
+  // "show first N lines" cap). We mirror that — `splitBashOutput(_, -1)`
+  // means "no cap" and yields `hidden: 0`, so the trailing "… N more
+  // lines" tail never renders.
+  const stdoutView = (): BashOutputView => splitBashOutput(r().stdout, -1)
+  const stderrView = (): BashOutputView => splitBashOutput(r().stderr, -1)
   // Successful exits suppress the status footer entirely — the
   // command + its output is enough signal that it ran. We still
   // surface non-success states (running, interrupted, non-zero exit,
@@ -760,11 +765,6 @@ function BashRow(props: { row: Extract<ChatRow, { kind: "bash" }> }) {
               </text>
             )}
           </For>
-          <Show when={stdoutView().hidden > 0}>
-            <text fg={theme.textMuted}>
-              {`  … ${stdoutView().hidden} more ${stdoutView().hidden === 1 ? "line" : "lines"}`}
-            </text>
-          </Show>
         </box>
       </Show>
       <Show when={stderrView().totalLines > 0}>
@@ -776,11 +776,6 @@ function BashRow(props: { row: Extract<ChatRow, { kind: "bash" }> }) {
               </text>
             )}
           </For>
-          <Show when={stderrView().hidden > 0}>
-            <text fg={theme.error}>
-              {`  … ${stderrView().hidden} more ${stderrView().hidden === 1 ? "line" : "lines"}`}
-            </text>
-          </Show>
         </box>
       </Show>
       <Show when={statusText() != null}>

--- a/packages/kobe/src/tui/panes/chat/bash-mode.ts
+++ b/packages/kobe/src/tui/panes/chat/bash-mode.ts
@@ -82,20 +82,27 @@ export async function runBashCommand(opts: RunBashCommandOpts): Promise<RunBashC
       return
     }
 
+    // Declared up front (with later assignment) so `finish` can safely
+    // `clearTimeout` even if it's called before the timeout is wired —
+    // e.g. a synchronous `error` event under a mocked child. The
+    // runtime-visible TDZ window otherwise depended on Node emitting
+    // events asynchronously, which is load-bearing in a fragile way.
+    // biome-ignore lint/style/useConst: reassigned at line 152 after listener wiring; biome doesn't see the second write across this distance.
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+
     let settled = false
     const finish = (result: RunBashCommandResult): void => {
       if (settled) return
       settled = true
-      clearTimeout(timeoutHandle)
+      if (timeoutHandle) clearTimeout(timeoutHandle)
       opts.signal.removeEventListener("abort", onAbort)
       resolve(result)
     }
 
-    // Stream stdout/stderr as UTF-8 text. The Buffer→string conversion
-    // is async-safe (each `data` callback gets a complete chunk that
-    // arrived in one read), but cross-chunk UTF-8 sequences would
-    // mojibake on the boundary. Matches upstream's pragmatic choice;
-    // CJK-heavy output may show a `�` at chunk seams.
+    // Node's Readable.setEncoding('utf8') buffers partial multi-byte
+    // sequences across chunks via a StringDecoder — chunk seams do
+    // NOT corrupt CJK / emoji. (The earlier draft of this comment
+    // claimed otherwise; the StringDecoder docs are the source.)
     child.stdout?.setEncoding("utf8")
     child.stderr?.setEncoding("utf8")
     child.stdout?.on("data", (chunk: string) => {
@@ -143,7 +150,7 @@ export async function runBashCommand(opts: RunBashCommandOpts): Promise<RunBashC
     }
 
     const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
-    const timeoutHandle = setTimeout(() => {
+    timeoutHandle = setTimeout(() => {
       if (settled) return
       opts.onStderr(`(kobe: command timed out after ${Math.round(timeoutMs / 1000)}s)\n`)
       try {
@@ -151,6 +158,18 @@ export async function runBashCommand(opts: RunBashCommandOpts): Promise<RunBashC
       } catch {
         /* exit handler will fire */
       }
+      // Escalate to SIGKILL if SIGTERM is ignored — same 500ms grace
+      // the abort path uses. Without this a child that traps SIGTERM
+      // (or a shell wrapper that doesn't propagate it) runs forever
+      // even though the timeout already "fired".
+      setTimeout(() => {
+        if (settled) return
+        try {
+          child.kill("SIGKILL")
+        } catch {
+          /* exit handler will fire */
+        }
+      }, 500).unref()
     }, timeoutMs)
     timeoutHandle.unref()
   })

--- a/packages/kobe/src/tui/panes/chat/bash-mode.ts
+++ b/packages/kobe/src/tui/panes/chat/bash-mode.ts
@@ -1,0 +1,177 @@
+/**
+ * Composer `!shell` command runner — local subprocess for the
+ * Claude-Code-style bash mode. Lifted in spirit from
+ * `refs/claude-code/src/utils/Shell.ts` (single-shot exec, stdin closed,
+ * stdout/stderr piped, abort-signal cancels via SIGTERM→SIGKILL).
+ *
+ * Scope (v1, KOB-83):
+ *   - Runs the user's shell — `$SHELL` if it's bash/zsh, else falls
+ *     back to `/bin/bash`. PowerShell unsupported; Windows untested.
+ *   - Streams stdout/stderr separately so the chat row can render them
+ *     in different colors.
+ *   - CWD is the task's worktree path (passed in by the caller).
+ *   - No PTY — interactive commands that prompt for input will hang
+ *     until the user Ctrl-Cs. Matches Claude Code's choice; same
+ *     limitation.
+ *   - Hard 30-minute timeout (matches upstream).
+ *
+ * `node:child_process` (not `Bun.spawn`) for the same reason the
+ * orchestrator's git helpers use it — kobe tests host under vitest /
+ * Node where `Bun` is undefined. The streaming API is identical
+ * enough between the two that switching later is a one-line change.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process"
+
+/** Default timeout, matches `refs/claude-code/src/utils/Shell.ts` `DEFAULT_TIMEOUT`. */
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000
+
+/** Sentinel exit code for "the child was killed via abort signal". Mirrors
+ *  upstream's `interrupted: true` convention without inventing a new
+ *  field — the renderer keys off `signal != null` to decide what to
+ *  show. -1 is portable: no real exit code is negative. */
+const ABORT_EXIT_CODE = -1
+
+export interface RunBashCommandOpts {
+  /** The literal command line (after `!` stripping). */
+  readonly command: string
+  /** Working directory. Required — no implicit default. */
+  readonly cwd: string
+  /** Streamed stdout chunks. Called zero or more times before resolution. */
+  readonly onStdout: (chunk: string) => void
+  /** Streamed stderr chunks. Called zero or more times before resolution. */
+  readonly onStderr: (chunk: string) => void
+  /** Cancels the child. Sends SIGTERM, then SIGKILL after a short grace. */
+  readonly signal: AbortSignal
+  /** Optional override; defaults to {@link DEFAULT_TIMEOUT_MS}. */
+  readonly timeoutMs?: number
+}
+
+export interface RunBashCommandResult {
+  /** Process exit code; `null` if killed by a signal. */
+  readonly exitCode: number | null
+  /** Signal name if the process exited via signal (`SIGTERM`, `SIGKILL`). */
+  readonly signal: string | null
+}
+
+/**
+ * Spawn a shell, stream output, await exit. Throws only for catastrophic
+ * setup failures (e.g. shell binary not found) — non-zero exit codes
+ * resolve normally so the caller can render the row with the failed
+ * status instead of surfacing a runtime error.
+ */
+export async function runBashCommand(opts: RunBashCommandOpts): Promise<RunBashCommandResult> {
+  const shell = resolveShell()
+
+  return await new Promise<RunBashCommandResult>((resolve, reject) => {
+    let child: ChildProcess
+    try {
+      child = spawn(shell, ["-c", opts.command], {
+        cwd: opts.cwd,
+        // Closed stdin (no PTY). stdout/stderr piped so we can stream.
+        // Inherit env so the user's $PATH, etc. flow through.
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+        // Detached: false — we don't want our SIGINT cascade onto the
+        // child (the parent TUI handles its own Ctrl-C). Default is
+        // false on POSIX; setting explicitly for self-documentation.
+        detached: false,
+      })
+    } catch (err) {
+      reject(err)
+      return
+    }
+
+    let settled = false
+    const finish = (result: RunBashCommandResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutHandle)
+      opts.signal.removeEventListener("abort", onAbort)
+      resolve(result)
+    }
+
+    // Stream stdout/stderr as UTF-8 text. The Buffer→string conversion
+    // is async-safe (each `data` callback gets a complete chunk that
+    // arrived in one read), but cross-chunk UTF-8 sequences would
+    // mojibake on the boundary. Matches upstream's pragmatic choice;
+    // CJK-heavy output may show a `�` at chunk seams.
+    child.stdout?.setEncoding("utf8")
+    child.stderr?.setEncoding("utf8")
+    child.stdout?.on("data", (chunk: string) => {
+      opts.onStdout(chunk)
+    })
+    child.stderr?.on("data", (chunk: string) => {
+      opts.onStderr(chunk)
+    })
+
+    child.on("error", (err) => {
+      // Spawn-time failure — typically ENOENT for a missing shell. Resolve
+      // with a synthetic non-zero code rather than rejecting so the chat
+      // row renders the error message via onStderr.
+      opts.onStderr(`(kobe: failed to spawn ${shell}: ${(err as Error).message})\n`)
+      finish({ exitCode: ABORT_EXIT_CODE, signal: null })
+    })
+
+    child.on("exit", (code, signal) => {
+      finish({ exitCode: code, signal: signal ?? null })
+    })
+
+    // Abort wiring — SIGTERM, then SIGKILL after 500 ms if the child
+    // ignored the polite kill. Matches Claude Code's
+    // wrapSpawn-in-Shell.ts cancel sequence.
+    const onAbort = (): void => {
+      if (settled) return
+      try {
+        child.kill("SIGTERM")
+      } catch {
+        // Already dead — fall through to finish via the exit handler.
+      }
+      setTimeout(() => {
+        if (settled) return
+        try {
+          child.kill("SIGKILL")
+        } catch {
+          // Same as above.
+        }
+      }, 500).unref()
+    }
+    if (opts.signal.aborted) {
+      onAbort()
+    } else {
+      opts.signal.addEventListener("abort", onAbort, { once: true })
+    }
+
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const timeoutHandle = setTimeout(() => {
+      if (settled) return
+      opts.onStderr(`(kobe: command timed out after ${Math.round(timeoutMs / 1000)}s)\n`)
+      try {
+        child.kill("SIGTERM")
+      } catch {
+        /* exit handler will fire */
+      }
+    }, timeoutMs)
+    timeoutHandle.unref()
+  })
+}
+
+/**
+ * Resolve which shell binary to invoke. Mirrors upstream's
+ * `findSuitableShell` precedence:
+ *   1. `$KOBE_BASH_SHELL` (kobe-specific escape hatch)
+ *   2. `$SHELL` if it's bash or zsh
+ *   3. `/bin/bash` fallback
+ *
+ * Anything else (fish, nu, …) won't accept the `-c` invocation
+ * predictably, so we punt to bash. The user can override via env.
+ */
+function resolveShell(): string {
+  const override = process.env.KOBE_BASH_SHELL
+  if (override && override.length > 0) return override
+  const userShell = process.env.SHELL ?? ""
+  // Last path segment (handles `/usr/local/bin/zsh`, `/bin/bash`, …).
+  const base = userShell.split("/").pop() ?? ""
+  if (base === "bash" || base === "zsh") return userShell
+  return "/bin/bash"
+}

--- a/packages/kobe/src/tui/panes/chat/store.ts
+++ b/packages/kobe/src/tui/panes/chat/store.ts
@@ -245,6 +245,34 @@ export type ChatRow =
       readonly answers: Readonly<Record<string, string>> | null
       readonly ts: string
     }
+  /**
+   * User-initiated `!shell` command (Claude-Code-style bash mode). Runs
+   * locally in the TUI process — not via the engine subprocess — and
+   * streams stdout/stderr into the row as it executes. On completion the
+   * interaction is appended to {@link ChatState.pendingBashContext} so the
+   * next regular prompt prepends `<bash-input>` / `<bash-stdout>` /
+   * `<bash-stderr>` XML to give the model the context.
+   *
+   * Local-only by design (v1): not broadcast over the orchestrator event
+   * bus, so other TUIs attached to the same daemon don't see the row.
+   * Persistence: the bash row itself doesn't survive a kobe restart
+   * (lives in module-scoped ChatState), but its XML context lands in
+   * claude-code's JSONL via the subsequent regular prompt, so the model
+   * retains visibility across a restart.
+   */
+  | {
+      readonly kind: "bash"
+      readonly id: string
+      readonly command: string
+      readonly stdout: string
+      readonly stderr: string
+      /** `null` while running. Set on exit (or to a sentinel like -1 on signal). */
+      readonly exitCode: number | null
+      /** `null` unless the process exited via signal (e.g. "SIGINT" on Ctrl-C). */
+      readonly signal: string | null
+      readonly done: boolean
+      readonly ts: string
+    }
 
 export interface ChatState {
   /** All messages in chronological order. Render in array order. */
@@ -275,6 +303,23 @@ export interface ChatState {
    * a daemon restart or full TUI quit still drops the queue.
    */
   readonly queue: readonly QueuedPrompt[]
+  /**
+   * Completed `!shell` interactions waiting to be injected into the
+   * next regular user prompt as `<bash-input>` / `<bash-stdout>` /
+   * `<bash-stderr>` XML. FIFO; drained on the next non-bash submit.
+   * Cleared on `/clear` and tab close. Like {@link queue}, not
+   * persisted — but the resulting XML-prefixed prompt IS persisted by
+   * the engine, so the model retains the context across restarts.
+   */
+  readonly pendingBashContext?: readonly PendingBashContext[]
+}
+
+/** One completed bash interaction waiting to be folded into the next prompt. */
+export interface PendingBashContext {
+  readonly command: string
+  readonly stdout: string
+  readonly stderr: string
+  readonly exitCode: number | null
 }
 
 /** Build the initial state. Used at mount and on task switch. */
@@ -402,6 +447,136 @@ export function removeFromQueue(state: ChatState, id: string): ChatState {
 export function clearQueue(state: ChatState): ChatState {
   if (state.queue.length === 0) return state
   return { ...state, queue: [] }
+}
+
+/* --------------------------------------------------------------------- */
+/*  Bash mode — !shell command rows + pending context                     */
+/* --------------------------------------------------------------------- */
+
+/**
+ * Append a fresh `bash` row for an in-flight `!shell` command. The row
+ * starts with empty stdout/stderr and `done: false`; subsequent
+ * {@link patchBashRow} calls stream output into it as the child process
+ * emits data. `id` is a caller-generated stable token (used to patch
+ * the row by reference without a name-based fallback like
+ * {@link applyEvent}'s tool-result path).
+ */
+export function pushBashRow(
+  state: ChatState,
+  args: { id: string; command: string },
+  nowIso: string = new Date().toISOString(),
+): ChatState {
+  return {
+    ...state,
+    messages: capMessages(
+      [
+        ...state.messages,
+        {
+          kind: "bash",
+          id: args.id,
+          command: args.command,
+          stdout: "",
+          stderr: "",
+          exitCode: null,
+          signal: null,
+          done: false,
+          ts: nowIso,
+        },
+      ],
+      nowIso,
+    ),
+  }
+}
+
+/**
+ * Patch an in-flight bash row by id. Used to (a) append streamed bytes
+ * to `stdout` / `stderr`, and (b) flip `done: true` with the final
+ * `exitCode` / `signal` on process exit. No-op if the row isn't found
+ * (e.g. truncated by the scrollback cap mid-stream).
+ */
+export function patchBashRow(
+  state: ChatState,
+  id: string,
+  patch: {
+    stdoutAppend?: string
+    stderrAppend?: string
+    exitCode?: number | null
+    signal?: string | null
+    done?: boolean
+  },
+): ChatState {
+  const idx = findLastIndex(state.messages, (m) => m.kind === "bash" && m.id === id)
+  if (idx < 0) return state
+  const target = state.messages[idx] as Extract<ChatRow, { kind: "bash" }>
+  const next = state.messages.slice()
+  next[idx] = {
+    ...target,
+    stdout: patch.stdoutAppend ? target.stdout + patch.stdoutAppend : target.stdout,
+    stderr: patch.stderrAppend ? target.stderr + patch.stderrAppend : target.stderr,
+    exitCode: patch.exitCode !== undefined ? patch.exitCode : target.exitCode,
+    signal: patch.signal !== undefined ? patch.signal : target.signal,
+    done: patch.done !== undefined ? patch.done : target.done,
+  }
+  return { ...state, messages: next }
+}
+
+/**
+ * Append a completed bash interaction to the pending-context FIFO. The
+ * next regular (non-bash) submit drains this and prepends the entries
+ * as XML to the prompt sent to the engine.
+ */
+export function pushPendingBashContext(state: ChatState, ctx: PendingBashContext): ChatState {
+  const prev = state.pendingBashContext ?? []
+  return { ...state, pendingBashContext: [...prev, ctx] }
+}
+
+/**
+ * Drain the pending bash-context FIFO. Returns the cleared state and
+ * the drained entries so the caller can format them into a prompt
+ * prefix. Empty input returns `[state, []]` without allocating.
+ */
+export function drainPendingBashContext(state: ChatState): [ChatState, readonly PendingBashContext[]] {
+  const list = state.pendingBashContext ?? []
+  if (list.length === 0) return [state, []]
+  // Re-spread without the field rather than `delete`-on-copy — biome's
+  // `noDelete` flags the latter for the runtime hidden-class penalty
+  // even though copies pay it once.
+  const { pendingBashContext: _drop, ...rest } = state
+  void _drop
+  return [{ ...rest }, list]
+}
+
+/**
+ * Format a list of completed bash interactions as the XML prefix
+ * Claude-Code adds to the next regular user prompt. Matches upstream's
+ * tags so the model parses the bytes the same way — kobe's chat UI
+ * strips these via {@link cleanChatText} on history replay, so the
+ * prefix is invisible in the transcript but visible to the model.
+ *
+ * Empty list → empty string (zero allocation).
+ */
+export function formatBashContextPrefix(entries: readonly PendingBashContext[]): string {
+  if (entries.length === 0) return ""
+  const parts: string[] = []
+  for (const e of entries) {
+    parts.push(`<bash-input>${escapeXml(e.command)}</bash-input>`)
+    if (e.stdout.length > 0) parts.push(`<bash-stdout>${escapeXml(e.stdout)}</bash-stdout>`)
+    if (e.stderr.length > 0) parts.push(`<bash-stderr>${escapeXml(e.stderr)}</bash-stderr>`)
+  }
+  parts.push("") // trailing blank line separating context from the actual prompt
+  return parts.join("\n")
+}
+
+/** Escape the five XML metacharacters. Minimal — kobe never round-trips
+ *  this through an XML parser; the model just sees the bytes. */
+function escapeXml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    if (c === "&") return "&amp;"
+    if (c === "<") return "&lt;"
+    if (c === ">") return "&gt;"
+    if (c === '"') return "&quot;"
+    return "&apos;"
+  })
 }
 
 /**

--- a/packages/kobe/src/tui/panes/chat/store.ts
+++ b/packages/kobe/src/tui/panes/chat/store.ts
@@ -679,15 +679,33 @@ export function applyEvent(
           nowIso,
         ),
       }
-    case "user.inject":
+    case "user.inject": {
+      // Strip claude-code wrapper tags (e.g. `<bash-input>` from the
+      // KOB-83 bash-mode prefix, `<command-name>` from a slash command,
+      // `<system-reminder>` from harness injections) so the user row
+      // shows only the human-meaningful text. The history-replay path
+      // (`appendRowsFromMessage` → `cleanChatText`) already does this;
+      // mirror it on the live event path so a freshly-dispatched
+      // user.inject doesn't render the raw XML before the next mount.
+      const cleaned = cleanChatText(ev.text)
+      // Drop the row entirely when stripping leaves nothing — bash mode
+      // can fire the bash-context prefix WITHOUT any trailing user text
+      // (e.g. follow-up `!cmd` while a prompt is queued). Adding an
+      // empty user row would render a bare `>` chip with nothing next
+      // to it, matching the same suppression `cleanChatText` applies
+      // during history hydration.
+      if (cleaned.length === 0) {
+        return { ...state, isStreaming: true, error: null, lastUsage: undefined, activeTurnStartedAt: nowIso }
+      }
       return {
         ...state,
         isStreaming: true,
         error: null,
         lastUsage: undefined,
         activeTurnStartedAt: nowIso,
-        messages: capMessages([...state.messages, { kind: "user", text: ev.text, ts: nowIso }], nowIso),
+        messages: capMessages([...state.messages, { kind: "user", text: cleaned, ts: nowIso }], nowIso),
       }
+    }
     case "system.info":
       // Dim status note from the orchestrator (worktree allocated,
       // branch renamed, etc). Renders as a `system` row in muted

--- a/packages/kobe/src/tui/panes/chat/store.ts
+++ b/packages/kobe/src/tui/panes/chat/store.ts
@@ -188,7 +188,21 @@ export function cleanChatText(text: string): string {
  * live alongside `messages` in {@link ChatState} and are drained by
  * the chat shell when streaming flips false.
  */
-export type QueuedPrompt = { readonly id: string; readonly text: string; readonly ts: string }
+/**
+ * Queued user-initiated work pending dispatch when streaming ends.
+ * Discriminated by `kind` so the chat shell can route the head item
+ * to the right consumer (prompt → engine, bash → local subprocess) —
+ * matches claude-code's queue-by-mode behavior in
+ * `refs/claude-code/src/utils/handlePromptSubmit.ts:336` where a mid-
+ * stream `!cmd` enqueues with `mode: 'bash'` and the drain runs
+ * `processBashCommand` instead of `processTextPrompt`. The two shapes
+ * carry different payload fields (`text` vs `command`) because
+ * conflating them under a single `text` slot lost the type discriminator
+ * downstream — the drain needed an explicit kind to fork on.
+ */
+export type QueuedPrompt =
+  | { readonly id: string; readonly kind: "prompt"; readonly text: string; readonly ts: string }
+  | { readonly id: string; readonly kind: "bash"; readonly command: string; readonly ts: string }
 
 /** One chronological row in the chat. The renderer maps these to JSX. */
 export type ChatRow =
@@ -414,7 +428,28 @@ export function enqueuePrompt(state: ChatState, prompt: string, nowIso: string =
   const id = `q-${nowIso}-${Math.random().toString(36).slice(2, 8)}`
   return {
     ...state,
-    queue: [...state.queue, { id, text: prompt, ts: nowIso }],
+    queue: [...state.queue, { id, kind: "prompt", text: prompt, ts: nowIso }],
+  }
+}
+
+/**
+ * Append a `!shell` command to the queue. Same FIFO + cap rules as
+ * {@link enqueuePrompt}. Used by the bash submit path when the engine
+ * is already streaming — the command waits until the current turn
+ * finishes, then the queue-drain microtask runs it locally (no model
+ * query). Mirrors claude-code's `enqueue({ mode: 'bash', ... })` in
+ * `refs/claude-code/src/utils/handlePromptSubmit.ts`.
+ */
+export function enqueueBashCommand(
+  state: ChatState,
+  command: string,
+  nowIso: string = new Date().toISOString(),
+): ChatState {
+  if (state.queue.length >= QUEUE_SOFT_CAP) return state
+  const id = `q-${nowIso}-${Math.random().toString(36).slice(2, 8)}`
+  return {
+    ...state,
+    queue: [...state.queue, { id, kind: "bash", command, ts: nowIso }],
   }
 }
 

--- a/packages/kobe/test/tui/chat.test.tsx
+++ b/packages/kobe/test/tui/chat.test.tsx
@@ -676,6 +676,34 @@ describe("applyEvent — user.inject", () => {
     expect((s.messages[2] as { text: string }).text).toContain("Follow these steps")
     expect(s.isStreaming).toBe(true)
   })
+
+  test("strips KOB-83 bash-context XML prefix so the user row shows only the human text", () => {
+    // The KOB-83 bash mode prepends <bash-input>/<bash-stdout> XML to
+    // the next prompt sent to runTask; orchestrator dispatches the
+    // FULL prefixed text as a user.inject event. Without the live-path
+    // strip the chat shows the raw XML alongside the actual prompt
+    // (see the screenshot in the KOB-83 PR review pass).
+    const prefixed =
+      "<bash-input>ls</bash-input>\n<bash-stdout>foo\nbar</bash-stdout>\n\nexplain what the listing shows"
+    const s = applyEvent(createInitialState(), { type: "user.inject", text: prefixed }, FIXED_TS)
+    expect(s.messages).toHaveLength(1)
+    const row = s.messages[0]
+    if (row?.kind !== "user") throw new Error("type narrowing")
+    expect(row.text).toBe("explain what the listing shows")
+    expect(s.isStreaming).toBe(true)
+  })
+
+  test("suppresses the user row entirely when only XML noise remains after stripping", () => {
+    // A bash interaction can fire mid-stream and produce a user.inject
+    // whose payload is just the XML wrapper (no trailing user text).
+    // Adding an empty user row would render as a bare `>` chip — the
+    // history-replay path already drops these via cleanChatText;
+    // mirror it here.
+    const xmlOnly = "<bash-input>pwd</bash-input>\n<bash-stdout>/tmp</bash-stdout>\n"
+    const s = applyEvent(createInitialState(), { type: "user.inject", text: xmlOnly }, FIXED_TS)
+    expect(s.messages).toEqual([])
+    expect(s.isStreaming).toBe(true)
+  })
 })
 
 describe("applyEvent — purity", () => {

--- a/packages/kobe/test/tui/chat.test.tsx
+++ b/packages/kobe/test/tui/chat.test.tsx
@@ -32,6 +32,7 @@ import {
   createInitialState,
   dequeueFirst,
   drainPendingBashContext,
+  enqueueBashCommand,
   enqueuePrompt,
   formatBashContextPrefix,
   patchBashRow,
@@ -71,9 +72,11 @@ describe("queue reducers", () => {
 
     const s1 = enqueuePrompt(s0, "queued one", FIXED_TS)
     expect(s1.queue).toHaveLength(1)
-    expect(s1.queue[0]?.text).toBe("queued one")
-    expect(s1.queue[0]?.ts).toBe(FIXED_TS)
-    expect(s1.queue[0]?.id).toMatch(/^q-/)
+    const head = s1.queue[0]
+    if (head?.kind !== "prompt") throw new Error("type narrowing")
+    expect(head.text).toBe("queued one")
+    expect(head.ts).toBe(FIXED_TS)
+    expect(head.id).toMatch(/^q-/)
     // pushUser side effects intact
     expect(s1.messages).toEqual(s0.messages)
     expect(s1.isStreaming).toBe(true)
@@ -111,13 +114,18 @@ describe("queue reducers", () => {
     s = enqueuePrompt(s, "b", FIXED_TS)
     s = enqueuePrompt(s, "c", FIXED_TS)
 
+    const promptText = (q: { kind: "prompt"; text: string } | { kind: "bash"; command: string }) =>
+      q.kind === "prompt" ? q.text : `!${q.command}`
+
     const [s1, h1] = dequeueFirst(s)
-    expect(h1?.text).toBe("a")
-    expect(s1.queue.map((q) => q.text)).toEqual(["b", "c"])
+    if (h1?.kind !== "prompt") throw new Error("type narrowing")
+    expect(h1.text).toBe("a")
+    expect(s1.queue.map(promptText)).toEqual(["b", "c"])
 
     const [s2, h2] = dequeueFirst(s1)
-    expect(h2?.text).toBe("b")
-    expect(s2.queue.map((q) => q.text)).toEqual(["c"])
+    if (h2?.kind !== "prompt") throw new Error("type narrowing")
+    expect(h2.text).toBe("b")
+    expect(s2.queue.map(promptText)).toEqual(["c"])
   })
 
   test("removeFromQueue drops the matching entry, leaves siblings intact", () => {
@@ -128,7 +136,7 @@ describe("queue reducers", () => {
     const targetId = s.queue[1]?.id
     expect(targetId).toBeDefined()
     const next = removeFromQueue(s, targetId as string)
-    expect(next.queue.map((q) => q.text)).toEqual(["a", "c"])
+    expect(next.queue.map((q) => (q.kind === "prompt" ? q.text : `!${q.command}`))).toEqual(["a", "c"])
   })
 
   test("removeFromQueue with an unknown id is a no-op (identity preserved)", () => {
@@ -162,6 +170,52 @@ describe("queue reducers", () => {
     const next = applyEvent(s, { type: "done" }, FIXED_TS)
     expect(next.isStreaming).toBe(false)
     expect(next.queue).toEqual(s.queue) // queue intact — drain happens at the chat-shell layer
+  })
+})
+
+describe("bash mode queue reducers (KOB-83 mid-stream parity)", () => {
+  // claude-code's handlePromptSubmit enqueues bash commands with
+  // mode='bash' when a turn is mid-flight; kobe mirrors that with
+  // a discriminated `QueuedPrompt` union so the drain microtask can
+  // fork on `kind`. These tests pin that contract.
+
+  test("enqueueBashCommand appends a bash entry with kind=bash + command", () => {
+    const s = enqueueBashCommand(createInitialState(), "ls -la", FIXED_TS)
+    expect(s.queue).toHaveLength(1)
+    const head = s.queue[0]
+    if (head?.kind !== "bash") throw new Error("type narrowing")
+    expect(head.command).toBe("ls -la")
+    expect(head.kind).toBe("bash")
+    expect(head.ts).toBe(FIXED_TS)
+    expect(head.id).toMatch(/^q-/)
+  })
+
+  test("enqueueBashCommand and enqueuePrompt share FIFO order", () => {
+    let s = createInitialState()
+    s = enqueuePrompt(s, "explain", FIXED_TS)
+    s = enqueueBashCommand(s, "ls", FIXED_TS)
+    s = enqueuePrompt(s, "and after", FIXED_TS)
+    expect(s.queue.map((q) => q.kind)).toEqual(["prompt", "bash", "prompt"])
+  })
+
+  test("enqueueBashCommand honors QUEUE_SOFT_CAP", () => {
+    let s = createInitialState()
+    for (let i = 0; i < QUEUE_SOFT_CAP; i++) s = enqueueBashCommand(s, `cmd${i}`, FIXED_TS)
+    expect(queueIsFull(s)).toBe(true)
+    const refused = enqueueBashCommand(s, "overflow", FIXED_TS)
+    expect(refused).toBe(s)
+  })
+
+  test("dequeueFirst on a mixed-kind queue pops bash and prompt items in order", () => {
+    let s = createInitialState()
+    s = enqueueBashCommand(s, "ls", FIXED_TS)
+    s = enqueuePrompt(s, "explain", FIXED_TS)
+    const [s1, h1] = dequeueFirst(s)
+    if (h1?.kind !== "bash") throw new Error("type narrowing")
+    expect(h1.command).toBe("ls")
+    const [, h2] = dequeueFirst(s1)
+    if (h2?.kind !== "prompt") throw new Error("type narrowing")
+    expect(h2.text).toBe("explain")
   })
 })
 
@@ -228,9 +282,7 @@ describe("bash mode reducers (KOB-83)", () => {
   })
 
   test("formatBashContextPrefix wraps each interaction in <bash-*> XML tags", () => {
-    const prefix = formatBashContextPrefix([
-      { command: "echo hi", stdout: "hi\n", stderr: "", exitCode: 0 },
-    ])
+    const prefix = formatBashContextPrefix([{ command: "echo hi", stdout: "hi\n", stderr: "", exitCode: 0 }])
     expect(prefix).toContain("<bash-input>echo hi</bash-input>")
     expect(prefix).toContain("<bash-stdout>hi\n</bash-stdout>")
     expect(prefix).not.toContain("<bash-stderr>")
@@ -239,18 +291,14 @@ describe("bash mode reducers (KOB-83)", () => {
   })
 
   test("formatBashContextPrefix omits empty stderr/stdout sections", () => {
-    const prefix = formatBashContextPrefix([
-      { command: "true", stdout: "", stderr: "", exitCode: 0 },
-    ])
+    const prefix = formatBashContextPrefix([{ command: "true", stdout: "", stderr: "", exitCode: 0 }])
     expect(prefix).toContain("<bash-input>true</bash-input>")
     expect(prefix).not.toContain("<bash-stdout>")
     expect(prefix).not.toContain("<bash-stderr>")
   })
 
   test("formatBashContextPrefix escapes XML metacharacters in command + output", () => {
-    const prefix = formatBashContextPrefix([
-      { command: "echo '<x>&amp;'", stdout: "</tag>", stderr: "", exitCode: 0 },
-    ])
+    const prefix = formatBashContextPrefix([{ command: "echo '<x>&amp;'", stdout: "</tag>", stderr: "", exitCode: 0 }])
     expect(prefix).toContain("&lt;x&gt;")
     expect(prefix).toContain("&amp;amp;")
     expect(prefix).toContain("&lt;/tag&gt;")
@@ -264,9 +312,7 @@ describe("bash mode reducers (KOB-83)", () => {
     // The prefix lands in the engine's JSONL via the next prompt; on
     // history hydration kobe's noise-tag filter must hide it from the
     // chat UI, matching upstream claude-code's behavior.
-    const prefix = formatBashContextPrefix([
-      { command: "ls", stdout: "foo\nbar", stderr: "", exitCode: 0 },
-    ])
+    const prefix = formatBashContextPrefix([{ command: "ls", stdout: "foo\nbar", stderr: "", exitCode: 0 }])
     const masquerading = `${prefix}what just happened?`
     expect(cleanChatText(masquerading)).toBe("what just happened?")
   })

--- a/packages/kobe/test/tui/chat.test.tsx
+++ b/packages/kobe/test/tui/chat.test.tsx
@@ -31,7 +31,12 @@ import {
   clearQueue,
   createInitialState,
   dequeueFirst,
+  drainPendingBashContext,
   enqueuePrompt,
+  formatBashContextPrefix,
+  patchBashRow,
+  pushBashRow,
+  pushPendingBashContext,
   pushSystemError,
   pushUser,
   queueIsFull,
@@ -157,6 +162,113 @@ describe("queue reducers", () => {
     const next = applyEvent(s, { type: "done" }, FIXED_TS)
     expect(next.isStreaming).toBe(false)
     expect(next.queue).toEqual(s.queue) // queue intact — drain happens at the chat-shell layer
+  })
+})
+
+describe("bash mode reducers (KOB-83)", () => {
+  test("pushBashRow appends a bash row with done=false and the given id", () => {
+    const s0 = createInitialState()
+    const s1 = pushBashRow(s0, { id: "bash-1", command: "ls" }, FIXED_TS)
+    expect(s1.messages).toHaveLength(1)
+    const row = s1.messages[0]
+    expect(row?.kind).toBe("bash")
+    if (row?.kind !== "bash") throw new Error("type narrowing")
+    expect(row.id).toBe("bash-1")
+    expect(row.command).toBe("ls")
+    expect(row.stdout).toBe("")
+    expect(row.stderr).toBe("")
+    expect(row.done).toBe(false)
+    expect(row.exitCode).toBeNull()
+    expect(row.signal).toBeNull()
+  })
+
+  test("patchBashRow appends to stdout/stderr without replacing", () => {
+    let s = pushBashRow(createInitialState(), { id: "b1", command: "echo hi" }, FIXED_TS)
+    s = patchBashRow(s, "b1", { stdoutAppend: "hi" })
+    s = patchBashRow(s, "b1", { stdoutAppend: "\nworld" })
+    s = patchBashRow(s, "b1", { stderrAppend: "oh no" })
+    const row = s.messages[0]
+    if (row?.kind !== "bash") throw new Error("type narrowing")
+    expect(row.stdout).toBe("hi\nworld")
+    expect(row.stderr).toBe("oh no")
+    expect(row.done).toBe(false)
+  })
+
+  test("patchBashRow flips done with exitCode/signal", () => {
+    let s = pushBashRow(createInitialState(), { id: "b1", command: "ls" }, FIXED_TS)
+    s = patchBashRow(s, "b1", { done: true, exitCode: 0, signal: null })
+    const row = s.messages[0]
+    if (row?.kind !== "bash") throw new Error("type narrowing")
+    expect(row.done).toBe(true)
+    expect(row.exitCode).toBe(0)
+    expect(row.signal).toBeNull()
+  })
+
+  test("patchBashRow no-ops when id is unknown", () => {
+    const s = pushBashRow(createInitialState(), { id: "b1", command: "ls" }, FIXED_TS)
+    const next = patchBashRow(s, "b-other", { stdoutAppend: "ignored" })
+    expect(next).toBe(s)
+  })
+
+  test("pushPendingBashContext + drainPendingBashContext is a FIFO round-trip", () => {
+    let s: ChatState = createInitialState()
+    s = pushPendingBashContext(s, { command: "ls", stdout: "a\n", stderr: "", exitCode: 0 })
+    s = pushPendingBashContext(s, { command: "pwd", stdout: "/tmp\n", stderr: "", exitCode: 0 })
+    expect(s.pendingBashContext).toHaveLength(2)
+    const [next, drained] = drainPendingBashContext(s)
+    expect(drained.map((d) => d.command)).toEqual(["ls", "pwd"])
+    expect(next.pendingBashContext).toBeUndefined()
+  })
+
+  test("drainPendingBashContext on empty state returns the input identity-stable", () => {
+    const s = createInitialState()
+    const [next, drained] = drainPendingBashContext(s)
+    expect(next).toBe(s)
+    expect(drained).toEqual([])
+  })
+
+  test("formatBashContextPrefix wraps each interaction in <bash-*> XML tags", () => {
+    const prefix = formatBashContextPrefix([
+      { command: "echo hi", stdout: "hi\n", stderr: "", exitCode: 0 },
+    ])
+    expect(prefix).toContain("<bash-input>echo hi</bash-input>")
+    expect(prefix).toContain("<bash-stdout>hi\n</bash-stdout>")
+    expect(prefix).not.toContain("<bash-stderr>")
+    // Trailing blank line separating context from the prompt body.
+    expect(prefix.endsWith("\n")).toBe(true)
+  })
+
+  test("formatBashContextPrefix omits empty stderr/stdout sections", () => {
+    const prefix = formatBashContextPrefix([
+      { command: "true", stdout: "", stderr: "", exitCode: 0 },
+    ])
+    expect(prefix).toContain("<bash-input>true</bash-input>")
+    expect(prefix).not.toContain("<bash-stdout>")
+    expect(prefix).not.toContain("<bash-stderr>")
+  })
+
+  test("formatBashContextPrefix escapes XML metacharacters in command + output", () => {
+    const prefix = formatBashContextPrefix([
+      { command: "echo '<x>&amp;'", stdout: "</tag>", stderr: "", exitCode: 0 },
+    ])
+    expect(prefix).toContain("&lt;x&gt;")
+    expect(prefix).toContain("&amp;amp;")
+    expect(prefix).toContain("&lt;/tag&gt;")
+  })
+
+  test("formatBashContextPrefix on an empty list is the empty string", () => {
+    expect(formatBashContextPrefix([])).toBe("")
+  })
+
+  test("cleanChatText still strips <bash-input>/<bash-stdout>/<bash-stderr> on history replay", () => {
+    // The prefix lands in the engine's JSONL via the next prompt; on
+    // history hydration kobe's noise-tag filter must hide it from the
+    // chat UI, matching upstream claude-code's behavior.
+    const prefix = formatBashContextPrefix([
+      { command: "ls", stdout: "foo\nbar", stderr: "", exitCode: 0 },
+    ])
+    const masquerading = `${prefix}what just happened?`
+    expect(cleanChatText(masquerading)).toBe("what just happened?")
   })
 })
 


### PR DESCRIPTION
## Summary

Claude-Code parity for the `!`-prefix bash mode. Typing `!cmd` in the chat composer detects on every keystroke, swaps the prompt glyph to a warning-toned `!`, runs the command via `\$SHELL -c` in the active task's worktree, and streams stdout/stderr into a new bash row. Completed runs stash per-tab and prepend as `<bash-input>` / `<bash-stdout>` / `<bash-stderr>` XML to the next regular prompt so the model has context. Esc aborts.

Closes [KOB-83](https://linear.app/codesfox/issue/KOB-83/composer-bash-command-mode-claude-code-parity).

## What ships

- **Detection + visual** — Composer detects `!` on every keystroke, glyph becomes bold `!` in `theme.warning`, footer hint reads "bash mode · enter to run".
- **Execution** — `bash-mode.ts` wraps `node:child_process.spawn(\$SHELL, ['-c', cmd])` with streaming callbacks, AbortSignal (SIGTERM → 500ms grace → SIGKILL), 30-min timeout (also escalates to SIGKILL on timeout). \$SHELL falls back to `/bin/bash` when not bash/zsh; `\$KOBE_BASH_SHELL` overrides.
- **Transcript** — new `kind: "bash"` ChatRow + `BashRow` renderer (banner + indented stdout/stderr + done/exit/interrupted status).
- **Next-turn context injection** — completed runs land in `ChatState.pendingBashContext`; idle and steer paths drain at submit time, queue path drains at dispatch time (so a `!cmd` that completes while a prompt sits in the queue still attaches to that prompt). The existing `cleanChatText` already strips these tags on history replay — UI invisible, model visible.
- **Cleanup** — `onCleanup` aborts every in-flight bash on Chat unmount; `closeActiveTab` aborts the closing tab's bash before delegating to the orchestrator.
- **11 new unit tests** covering the store helpers + round-trip with `cleanChatText`.

## Review pass (commit b9df2ad)

Adversarial review caught five real issues that landed as a fixup commit:

| Issue | Fix |
|---|---|
| Async callbacks used `patchActiveState` — switching tabs mid-run wrote to the wrong tab | `patchStateForTab(tabId, …)` everywhere in `runBashLocally` |
| `bashAbortsByTab` had no teardown — closing a tab left subprocesses running up to 30 min | onCleanup + abort in `closeActiveTab` |
| Queue path drained bash context at enqueue time — fresh bash output drifted to the next prompt | Drain moved into the queue-drain microtask |
| `timeoutHandle` referenced in `finish()` closure was load-bearing on Node async event emission | Declared up front, null-checked in `finish` |
| Timeout only sent SIGTERM — children that trap it ran forever despite the 30-min limit | SIGKILL escalation after 500ms grace, mirroring the abort path |

Plus a stale UTF-8 comment fixed and a misleading composer footer hint reworded.

## Out of scope (follow-ups)

- Daemon-side execution + multi-attach broadcast — v1 runs in the TUI process; bash rows aren't broadcast to other attached clients.
- PTY for interactive commands.
- Windows / PowerShell.
- Cross-tab bash visibility (active bash on tab A is invisible to Esc when user is on tab B).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean for my files (4 pre-existing warnings in test/engine/codex-local.real.test.ts are unrelated)
- [x] `bun run test:fast` — 743 passed (+11 new bash-mode tests)
- [ ] Manual smoke: `bun run dev:sandbox`, type `!ls`, verify glyph + execution + transcript row + that next regular prompt sees the bash context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local shell mode: press `!` to enter bash mode; run local commands with live stdout/stderr streamed into chat rows, status/exit info shown, and completed runs attached to the next prompt. Composer queues bash entries alongside prompts.

* **Bug Fixes**
  * ESC reliably interrupts running shell commands and streaming; running commands are aborted when closing a tab. Pending bash context is drained and attached at dispatch time to avoid output drift.

* **Tests**
  * Added coverage for bash-row lifecycle, queueing/draining behavior, formatting, and history replay.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/23)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->