### PR TITLE
feat(terminal): cd to task worktree on first paint

### DIFF
--- a/packages/kobe/src/tui/panes/terminal/pty.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty.ts
@@ -220,6 +220,20 @@ export class BunTerminalTaskPty implements TaskPtyLike {
   private cols: number
   private rows: number
   private refreshQueued = false
+  /**
+   * Explicit-cd guard. We pass `cwd` to `Bun.spawn`, which puts the
+   * shell process in the worktree to start with — but the user's
+   * `.bashrc` / `.zshrc` can change directory after that (some configs
+   * unconditionally `cd $HOME`, or use `chpwd`/`zshrc` hooks that
+   * resolve symlinks). And without an explicit `cd` line in the
+   * scrollback, it's not obvious to the user which directory the
+   * terminal is in — especially with minimal prompts.
+   *
+   * After the shell's first paint (so we don't race the rc-file
+   * output), we write `cd "<cwd>"\n` once, then flip this flag so
+   * subsequent paints don't re-issue it.
+   */
+  private initialCdSent = false
 
   constructor(opts: TaskPtyOpts) {
     this.taskId = opts.taskId
@@ -316,6 +330,16 @@ export class BunTerminalTaskPty implements TaskPtyLike {
     if (this._killed) return
     const chunk = typeof data === "string" ? data : Buffer.from(data).toString("utf8")
     this.term.write(chunk, () => this.queueRefresh())
+    // First paint is our signal that the shell finished its rc-file
+    // phase and is now interactive. Drop in an explicit `cd` so the
+    // terminal lands in the task's worktree even when the rc-file
+    // would have moved it elsewhere — and the user can see in the
+    // scrollback which directory this terminal belongs to.
+    if (!this.initialCdSent && this.cwd) {
+      this.initialCdSent = true
+      const escaped = this.cwd.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\$/g, "\\$").replace(/`/g, "\\`")
+      this.write(`cd "${escaped}"\n`)
+    }
   }
 
   private queueRefresh(): void {


### PR DESCRIPTION
## Summary

- `Bun.spawn` already passes `cwd: worktreePath` to the PTY's shell, but the user's `.bashrc`/`.zshrc` can override that (some configs `cd $HOME` unconditionally; others use `chpwd` hooks). Even when cwd took, a minimal prompt doesn't surface the directory, so it isn't obvious which task this terminal belongs to.
- After the shell's first paint (so we don't race the rc-file output) write `cd "<cwd>"\n` once per PTY. An `initialCdSent` flag fires exactly once, so switching away and back to a cached PTY within the same kobe session keeps the user wherever they last cd'd.
- Shell-safe quoting on the path: escape `\\`, `"`, `$`, `` ` `` so a worktree path with unusual characters can't break out of the quoted form.

## Test plan

- [x] `bun typecheck`
- [x] `bun test test/tui/terminal.test.tsx` — 28 cases pass
- [ ] Manual: open a new task → terminal pane shows `cd "<worktree-path>"` line and the prompt updates to that directory
- [ ] Manual: cd elsewhere inside the terminal, switch to another pane, switch back — terminal stays where you left it (no re-cd)
- [ ] Manual: re-open kobe (or new kobe session) on the same task → terminal re-cd's to the worktree (per-PTY-spawn behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal now correctly initializes in the working directory on startup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->