### PR TITLE
fix(daemon): broadcast task.updated after chat.send → runTask

### DIFF
--- a/packages/kobe/src/daemon/server.ts
+++ b/packages/kobe/src/daemon/server.ts
@@ -410,6 +410,15 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
         // dodge the check. Now the wire allows undefined.
         const text = optionalString(payload, "text")
         await orch.runTask(taskId, text, tabId)
+        // First-message runs allocate the worktree lazily inside
+        // `runTask`: empty `worktreePath` flips to the real path, and
+        // `branch` / `status` change too. Without this broadcast, the
+        // TUI's RemoteOrchestrator never learns — Files / Terminal
+        // panes key off `worktreePath` and stay stuck on the placeholder
+        // "no task" state forever. Symptoms: the user types "hi" in a
+        // fresh task, sees the worktree-allocated system.info row in
+        // chat, but the right column never lights up.
+        broadcastTaskUpdated(orch, clients, taskId)
         const task = orch.getTask(taskId)
         if (task)
           broadcast(clients, {


### PR DESCRIPTION
## Problem

The `chat.send` handler invokes `orch.runTask`, which lazily allocates a task's worktree on the first user message. That allocation flips `worktreePath` from `""` to the real path, populates `branch`, and changes `status`. After the call returns, the handler emitted only `engine.status`, but **not** `task.updated`. The TUI's `RemoteOrchestrator` never learned the task fields had changed, so its local `tasks` signal stayed stale.

**Symptom:** user presses `n`, types "hi" in chat, sees the `worktree: …` system.info row in the chat pane — but the right column (Files + Terminal) is stuck on `"(no task — press n to create)"` because both panes key off `activeTask().worktreePath`, which TUI-side is still `""`.

Restarting kobe + the daemon doesn't help: every subsequent first message takes the same code path. This regressed when the lazy-worktree refactor moved worktree allocation out of `createTask` into `runTask`.

## Fix

One line: `broadcastTaskUpdated(orch, clients, taskId)` after the `await orch.runTask(...)` call. Mirrors what every other task-mutating handler already does (`task.pin` / `task.permissionMode` / `task.model` / `chat.tab.*` / etc.).

## Test plan

- [x] `bun typecheck`
- [x] `bun test test/daemon` — 42 cases pass
- [ ] Manual: kill any running `kobed`, `bun run dev`, press `n`, type "hi" — Files + Terminal panes should activate as soon as the worktree-allocated `system.info` row lands in chat.
- [ ] Manual: same flow but with an explicit `baseRef` that exists in the repo (e.g. `master` if the repo doesn't have `main`) — same expected result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where connected clients were not receiving proper status updates after sending the first message. Clients now correctly display the worktree path and current status instead of remaining in a placeholder state.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->