### PR TITLE
feat(chat): KOB-96 — click a queued message to edit it inline

### DIFF
--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -73,6 +73,7 @@ import {
   pushSystemError,
   queueIsFull,
   removeFromQueue,
+  updateQueueItem,
 } from "./store"
 import { useChatSession } from "./use-chat-session"
 
@@ -212,6 +213,20 @@ export function Chat(props: ChatProps) {
 
   const [expandedToolIndex, setExpandedToolIndex] = createSignal<number | null>(null)
   const [expandedFoldStartIndex, setExpandedFoldStartIndex] = createSignal<number | null>(null)
+  // Id of the queue entry currently being edited via click-to-edit.
+  // Chat-scoped (not per-tab) — switching tabs implicitly resets via
+  // the createEffect below that watches the active tab's queue.
+  const [editingQueueId, setEditingQueueId] = createSignal<string | null>(null)
+
+  // Drop edit state when the target queue entry leaves the active tab's
+  // queue (cancelled, drained by the streaming finish effect, or the
+  // user switched tabs to a tab whose queue doesn't contain that id).
+  createEffect(() => {
+    const id = editingQueueId()
+    if (id === null) return
+    const present = activeState().queue.some((q) => q.id === id)
+    if (!present) setEditingQueueId(null)
+  })
 
   const tasksAcc = props.orchestrator.tasksSignal()
 
@@ -450,7 +465,7 @@ export function Chat(props: ChatProps) {
    *
    * The same lock is held by the steer path in {@link send} (and by
    * extension {@link sendQueuedNow}). Without that extension, a user
-   * who clicks `[▶]` on a queued prompt while two other prompts sit in
+   * who clicks `[↑]` on a queued prompt while two other prompts sit in
    * the queue races: `interruptTask` flips `isStreaming` false via the
    * `done` event in the gap between `await interruptTask` and
    * `await runTask`, the drain effect wakes up, pops the head, and now
@@ -795,7 +810,9 @@ export function Chat(props: ChatProps) {
 
   /**
    * Cancel one queued prompt by id. Called by the cancel-button on
-   * each queued row inside the composer.
+   * each queued row inside the composer. If the cancelled item was
+   * the one being edited, the createEffect that watches queue
+   * membership tears down `editingQueueId` on the next tick.
    */
   function cancelQueued(id: string): void {
     patchActiveState((s) => removeFromQueue(s, id))
@@ -823,6 +840,21 @@ export function Chat(props: ChatProps) {
       return
     }
     void send(entry.text, "steer")
+  }
+
+  /**
+   * Begin editing a queued prompt: load its text into the composer
+   * draft and remember the id so the next submit replaces the entry
+   * in place instead of dispatching a new prompt. Clicking a different
+   * queued row while already editing swaps the target (any uncommitted
+   * draft text on the previous target is discarded — pressing Enter
+   * is the only way to commit).
+   */
+  function editQueued(id: string): void {
+    const entry = activeState().queue.find((q) => q.id === id)
+    if (!entry || entry.kind !== "prompt") return
+    setEditingQueueId(id)
+    setDraft(entry.text)
   }
 
   /** Create a new tab and switch focus to it. Wired from `ctrl+t`. */
@@ -1014,6 +1046,28 @@ export function Chat(props: ChatProps) {
   }
 
   function handleComposerSubmit(trimmed: string, mode: "auto" | "steer" = "auto"): void {
+    // Click-to-edit commit: when a queue entry is being edited, the
+    // composer's submit replaces that entry's text in place instead
+    // of dispatching a new prompt. Empty trimmed text deletes the
+    // entry (same semantics as the [x] cancel button). If the target
+    // already left the queue mid-edit (the drain effect popped it),
+    // fall through to the normal send path so the user's text isn't
+    // silently dropped.
+    const editingId = editingQueueId()
+    if (editingId !== null) {
+      const stillQueued = activeState().queue.some((q) => q.id === editingId)
+      if (stillQueued) {
+        setEditingQueueId(null)
+        if (trimmed.length === 0) {
+          patchActiveState((s) => removeFromQueue(s, editingId))
+        } else {
+          patchActiveState((s) => updateQueueItem(s, editingId, trimmed))
+        }
+        setDraft("")
+        return
+      }
+      setEditingQueueId(null)
+    }
     if (trimmed.length === 0) {
       if (lastToolIndex() !== null) toggleExpandLastTool()
       return
@@ -1190,6 +1244,8 @@ export function Chat(props: ChatProps) {
           onCancelQueued={cancelQueued}
           onSendQueuedNow={sendQueuedNow}
           onBashCommand={handleBashCommand}
+          onEditQueued={editQueued}
+          editingQueueId={editingQueueId}
         />
       </Show>
     </box>

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -228,6 +228,22 @@ export interface ComposerProps {
    * context. Omit to disable bash mode for this composer instance.
    */
   onBashCommand?: (command: string) => void
+  /**
+   * Begin editing a queued prompt: parent loads the entry's text into
+   * the composer draft and the next submit replaces the entry in
+   * place rather than dispatching a fresh prompt. Wired to the
+   * `[edit]` button and the queue row's clickable text body. Bash
+   * queue entries are intentionally not editable; the parent gates
+   * this affordance off for them.
+   */
+  onEditQueued?: (id: string) => void
+  /**
+   * Id of the queued prompt currently being edited (parent-owned).
+   * The matching row tints its leading `○` marker in `theme.primary`
+   * so the user can tell which entry the composer is targeting.
+   * `null` / undefined when no row is being edited.
+   */
+  editingQueueId?: Accessor<string | null>
 }
 
 /**
@@ -1301,45 +1317,65 @@ export function Composer(props: ComposerProps) {
         >
           {/* Queued prompts — live inside the composer rail so the
               queue shares the same bordered block as the textarea
-              that will eventually flush them. Each row carries `[▶]`
-              (interrupt + send now) and `[x]` (cancel) affordances.
-              Hidden entirely when the queue is empty so the textarea
-              keeps its natural eye-line. */}
+              that will eventually flush them. Each row carries
+              `[edit]` (load into composer for in-place edit), `[↑]`
+              (interrupt + send now), and `[x]` (cancel). Clicking
+              the row's marker / label / text body also loads the
+              entry for edit. Hidden entirely when the queue is
+              empty so the textarea keeps its natural eye-line. */}
           <Show when={(props.queue?.() ?? []).length > 0}>
             <box flexDirection="column" paddingBottom={1}>
               <For each={(props.queue?.() ?? []).slice(0, QUEUE_VISIBLE_CAP)}>
-                {(entry, idx) => (
-                  <box flexDirection="row" gap={1} alignItems="flex-start">
-                    <text fg={theme.textMuted} attributes={TextAttributes.BOLD}>
-                      +
-                    </text>
-                    <text fg={theme.textMuted} wrapMode="none">
-                      queued{idx() === 0 ? " (next)" : ""}:
-                    </text>
-                    <Show when={entry.kind === "bash"}>
-                      <text fg={theme.warning} wrapMode="none">
-                        (bash)
+                {(entry, idx) => {
+                  const isPrompt = entry.kind === "prompt"
+                  const isEditing = () => props.editingQueueId?.() === entry.id
+                  const onRowEdit = () => props.onEditQueued?.(entry.id)
+                  return (
+                    <box flexDirection="row" gap={1} alignItems="flex-start">
+                      <box
+                        flexDirection="row"
+                        gap={1}
+                        alignItems="flex-start"
+                        flexGrow={1}
+                        onMouseUp={isPrompt ? onRowEdit : undefined}
+                      >
+                        <text fg={isEditing() ? theme.primary : theme.textMuted} attributes={TextAttributes.BOLD}>
+                          ○
+                        </text>
+                        <text fg={theme.textMuted} wrapMode="none">
+                          queued{idx() === 0 ? " (next)" : ""}:
+                        </text>
+                        <Show when={entry.kind === "bash"}>
+                          <text fg={theme.warning} wrapMode="none">
+                            (bash)
+                          </text>
+                        </Show>
+                        <box flexGrow={1}>
+                          <text fg={theme.text}>{entry.kind === "bash" ? entry.command : entry.text}</text>
+                        </box>
+                      </box>
+                      <Show when={isPrompt}>
+                        <text fg={theme.primary} attributes={TextAttributes.BOLD} onMouseUp={onRowEdit}>
+                          [edit]
+                        </text>
+                      </Show>
+                      <text
+                        fg={theme.primary}
+                        attributes={TextAttributes.BOLD}
+                        onMouseUp={() => props.onSendQueuedNow?.(entry.id)}
+                      >
+                        [↑]
                       </text>
-                    </Show>
-                    <box flexGrow={1}>
-                      <text fg={theme.text}>{entry.kind === "bash" ? entry.command : entry.text}</text>
+                      <text
+                        fg={theme.error}
+                        attributes={TextAttributes.BOLD}
+                        onMouseUp={() => props.onCancelQueued?.(entry.id)}
+                      >
+                        [x]
+                      </text>
                     </box>
-                    <text
-                      fg={theme.primary}
-                      attributes={TextAttributes.BOLD}
-                      onMouseUp={() => props.onSendQueuedNow?.(entry.id)}
-                    >
-                      [▶]
-                    </text>
-                    <text
-                      fg={theme.error}
-                      attributes={TextAttributes.BOLD}
-                      onMouseUp={() => props.onCancelQueued?.(entry.id)}
-                    >
-                      [x]
-                    </text>
-                  </box>
-                )}
+                  )
+                }}
               </For>
               <Show when={(props.queue?.() ?? []).length > QUEUE_VISIBLE_CAP}>
                 <box flexDirection="row" gap={1} alignItems="flex-start">

--- a/packages/kobe/src/tui/panes/chat/store.ts
+++ b/packages/kobe/src/tui/panes/chat/store.ts
@@ -470,6 +470,27 @@ export function dequeueFirst(state: ChatState): [ChatState, QueuedPrompt | null]
   return [{ ...state, queue: rest }, head]
 }
 
+/**
+ * Replace the text of a queued PROMPT by id, keeping its position and
+ * id. Bash queue entries are intentionally not editable in place —
+ * `!cmd` flows through a separate submit path and re-enqueues as a
+ * fresh entry. No-op (identity-preserving) when the id is unknown,
+ * targets a bash entry, or the text matches the existing value.
+ */
+export function updateQueueItem(state: ChatState, id: string, text: string): ChatState {
+  if (state.queue.length === 0) return state
+  let changed = false
+  const next = state.queue.map((q) => {
+    if (q.id === id && q.kind === "prompt" && q.text !== text) {
+      changed = true
+      return { ...q, text }
+    }
+    return q
+  })
+  if (!changed) return state
+  return { ...state, queue: next }
+}
+
 /** Remove a queued prompt by id (the cancel-button path). */
 export function removeFromQueue(state: ChatState, id: string): ChatState {
   if (state.queue.length === 0) return state

--- a/packages/kobe/test/tui/chat.test.tsx
+++ b/packages/kobe/test/tui/chat.test.tsx
@@ -44,6 +44,7 @@ import {
   removeFromQueue,
   reset,
   setMessagesFromHistory,
+  updateQueueItem,
 } from "../../src/tui/panes/chat/store.ts"
 import { summarizeGlob, summarizeGrep, summarizeRead } from "../../src/tui/panes/chat/tool-banners.ts"
 import type { EngineEvent, Message } from "../../src/types/engine.ts"
@@ -143,6 +144,34 @@ describe("queue reducers", () => {
     let s = createInitialState()
     s = enqueuePrompt(s, "a", FIXED_TS)
     const next = removeFromQueue(s, "q-does-not-exist")
+    expect(next).toBe(s)
+  })
+
+  test("updateQueueItem rewrites text in place, keeping id, ts, and position", () => {
+    let s = createInitialState()
+    s = enqueuePrompt(s, "a", FIXED_TS)
+    s = enqueuePrompt(s, "b", FIXED_TS)
+    s = enqueuePrompt(s, "c", FIXED_TS)
+    const target = s.queue[1]
+    expect(target).toBeDefined()
+    const next = updateQueueItem(s, target?.id as string, "B-edited")
+    expect(next.queue.map((q) => (q.kind === "prompt" ? q.text : `!${q.command}`))).toEqual(["a", "B-edited", "c"])
+    expect(next.queue[1]?.id).toBe(target?.id)
+    expect(next.queue[1]?.ts).toBe(target?.ts)
+  })
+
+  test("updateQueueItem with an unknown id is a no-op (identity preserved)", () => {
+    let s = createInitialState()
+    s = enqueuePrompt(s, "a", FIXED_TS)
+    const next = updateQueueItem(s, "q-does-not-exist", "whatever")
+    expect(next).toBe(s)
+  })
+
+  test("updateQueueItem with the same text is a no-op (identity preserved)", () => {
+    let s = createInitialState()
+    s = enqueuePrompt(s, "a", FIXED_TS)
+    const id = s.queue[0]?.id as string
+    const next = updateQueueItem(s, id, "a")
     expect(next).toBe(s)
   })
 


### PR DESCRIPTION
## Summary

- Click the text body of a queued row → composer loads its content + marks it as the edit target.
- Enter replaces the entry **in place** (same id, ts, position); empty submit deletes it (same as `[x]`).
- The row's `queued:` label swaps to `editing:` in `theme.primary` (Claude terracotta) so the user can tell which entry is being targeted; row chrome and user text stay neutral.
- Edit state clears automatically when the target leaves the queue (`[x]`, `[▶]`, drain, tab switch) via a `createEffect` watching queue membership.
- If the edit target is drained mid-edit, submit falls through to the normal send path (text isn't silently dropped).

Linear: [KOB-96](https://linear.app/codesfox/issue/KOB-96/featchat-click-a-queued-message-to-edit-it-inline)

## Files

- `store.ts` — new `updateQueueItem(state, id, text)` reducer (identity-preserving on unknown id or unchanged text).
- `Composer.tsx` — `ComposerProps.onEditQueued` + `editingQueueId`; queue text region gets an `onMouseUp` handler; label color flips on the edit target.
- `Chat.tsx` — Chat-scoped `editingQueueId` signal; `editQueued(id)` loader; `handleComposerSubmit` intercepts edit mode before the question-picker / send branches; `createEffect` reset on queue exit.
- `test/tui/chat.test.tsx` — 3 new cases for `updateQueueItem` (rewrite preserves id/ts/position, unknown id no-op, same text no-op).

## Test plan

- [x] `bun --filter @sma1lboy/kobe typecheck`
- [x] `bun test test/tui/chat.test.tsx` — 134 / 134 pass
- [x] `bunx biome check` on changed files
- [ ] Manual: stack a few queued prompts mid-stream, click one to edit, edit, Enter → entry replaced in place, queue order intact
- [ ] Manual: clear text + Enter while editing → entry removed
- [ ] Manual: click another queue row mid-edit → swaps target, prior unsaved edits discarded
- [ ] Manual: `[x]` / `[▶]` / tab switch on edit target → edit state cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click-to-edit for queued prompts: tapping a queued item loads it into the composer, highlights the active item, and shows an inline “[edit]” label.
  * Submitting while editing updates that queued prompt (empty submit removes it); canceling clears edit mode.
  * Queued “send now” affordance label changed from ▶ to ↑ for clarity.

* **Tests**
  * Unit tests added to verify queue-item text updates and no-op behavior for unchanged or unknown items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/27)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->