### PR TITLE
fix: KOB-98 — mcp-bridge self-terminates when orphaned

### DIFF
--- a/packages/kobe/src/cli/mcp-bridge.ts
+++ b/packages/kobe/src/cli/mcp-bridge.ts
@@ -101,7 +101,7 @@ class SocketClient {
   private readonly pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>()
   private connected: Promise<void>
 
-  constructor(path: string) {
+  constructor(path: string, onClose?: () => void) {
     this.socket = connect(path)
     this.connected = new Promise<void>((resolve, reject) => {
       this.socket.once("connect", resolve)
@@ -113,6 +113,7 @@ class SocketClient {
         pending.reject(new Error("kobe bridge socket closed"))
       }
       this.pending.clear()
+      onClose?.()
     })
   }
 
@@ -261,6 +262,32 @@ export async function runMcpBridgeSubcommand(argv: readonly string[]): Promise<v
     process.stderr.write("mcp-bridge: --socket=<path> is required\n")
     process.exit(2)
   }
-  const client = new SocketClient(socketPath)
+
+  // Self-terminate when orphaned. claude spawns us as an MCP child;
+  // when claude is SIGKILLed by the orchestrator's session-stop path,
+  // our stdin pipe doesn't always EOF us (Bun runtime quirk), so we
+  // can survive indefinitely as a PPID=1 zombie. Without this watchdog,
+  // every spawn → kill cycle leaks one mcp-bridge — we observed 55
+  // accumulated over a few hours of dev iteration.
+  let exiting = false
+  const exitOnce = (code = 0) => {
+    if (exiting) return
+    exiting = true
+    process.exit(code)
+  }
+  const initialPpid = process.ppid
+  const ppidWatcher = setInterval(() => {
+    const current = process.ppid
+    if (current !== initialPpid || current === 1) exitOnce()
+  }, 1000)
+  ppidWatcher.unref?.()
+
+  process.stdin.once("end", () => exitOnce())
+  process.stdin.once("close", () => exitOnce())
+  process.once("SIGTERM", () => exitOnce())
+  process.once("SIGINT", () => exitOnce())
+
+  const client = new SocketClient(socketPath, () => exitOnce())
   await runMcpStdioLoop(client)
+  exitOnce()
 }

--- a/packages/kobe/src/orchestrator/bridge/index.ts
+++ b/packages/kobe/src/orchestrator/bridge/index.ts
@@ -16,7 +16,7 @@
  * desired behavior for now (no recursion guard yet).
  */
 
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, unlink, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -85,6 +85,7 @@ export async function startBridge(orch: Orchestrator, opts: StartBridgeOpts = {}
     mcpConfigPath,
     async close() {
       await server.close()
+      await unlink(mcpConfigPath).catch(() => {})
     },
   }
 }


### PR DESCRIPTION
## Summary

- Adds parent-death detection to `mcp-bridge`: PPID watchdog (1s) + explicit stdin/socket/signal exit paths. Without it, every claude spawn→kill cycle leaks one `mcp-bridge` as a PPID=1 zombie (observed 55 accumulated).
- Unlinks `mcp-<pid>.json` on bridge `close()` so `~/.kobe/run/` doesn't accumulate stale MCP configs alongside the existing socket cleanup.

Linear: [KOB-98](https://linear.app/codesfox/issue/KOB-98)

## Root cause

`claude` spawns `bun ... mcp-bridge --socket=...` as an MCP child via `--mcp-config`. `SessionRegistry.kill()` of claude doesn't cascade, and the bridge child sits in `for await (process.stdin)` — Bun's stdin pipe doesn't reliably EOF when claude is force-closed, so the bridge is reparented to init and lives forever.

## Test plan

- [x] `bun run test:fast` — 786 pass
- [x] Live cleanup: killed 53 orphaned PPID=1 bridges + 20 stale `~/.kobe/run/` entries (filtered by owner-PID liveness)
- [ ] After daemon restart with this code: run a few task spawn→kill cycles and confirm `pgrep mcp-bridge` returns 0 once tasks are stopped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process stability with enhanced lifecycle management for the MCP bridge, including proper handling of parent process changes and signal termination.
  * Added automatic cleanup of temporary configuration files when the bridge connection closes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->