### PR TITLE
fix: KOB-99/100/101 — orphan subprocess + stale run/ leaks

### DIFF
--- a/packages/kobe/scripts/perf-stress.ts
+++ b/packages/kobe/scripts/perf-stress.ts
@@ -113,6 +113,39 @@ function ensureSpawnHelperExecutable(): void {
   }
 }
 
+/**
+ * Track every pty we spawn so a synchronous process.on("exit") hook
+ * can SIGKILL them on abrupt termination — Ctrl-C, parent SIGKILL,
+ * panic. Without this, a crashed perf-stress run leaves the kobe TUI
+ * inside its pty reparented to init; we found a 30-hour orphan in
+ * dev. Mirrors the cleanup in `test/behavior/driver.ts`.
+ */
+const liveTerms = new Set<pty.IPty>()
+let processExitHooksInstalled = false
+
+function ensurePtyProcessExitHooks(): void {
+  if (processExitHooksInstalled) return
+  processExitHooksInstalled = true
+  const killAll = (): void => {
+    for (const t of liveTerms) {
+      try {
+        t.kill("SIGKILL")
+      } catch {
+        /* already dead */
+      }
+    }
+    liveTerms.clear()
+  }
+  process.on("exit", killAll)
+  const forward = (sig: NodeJS.Signals) => () => {
+    killAll()
+    process.kill(process.pid, sig)
+  }
+  process.once("SIGINT", forward("SIGINT"))
+  process.once("SIGTERM", forward("SIGTERM"))
+  process.once("SIGHUP", forward("SIGHUP"))
+}
+
 function stripAnsi(input: string): string {
   let out = ""
   let i = 0
@@ -190,6 +223,7 @@ function normalizeScreen(raw: string): string {
 
 async function spawnKobe(opts: SpawnKobeOpts = {}): Promise<KobeHandle> {
   ensureSpawnHelperExecutable()
+  ensurePtyProcessExitHooks()
   const cwd = opts.cwd ?? REPO_ROOT
   const cols = opts.cols ?? DEFAULT_COLS
   const rows = opts.rows ?? DEFAULT_ROWS
@@ -209,6 +243,7 @@ async function spawnKobe(opts: SpawnKobeOpts = {}): Promise<KobeHandle> {
     ...(opts.env ?? {}),
   }
   const term = pty.spawn(command, args, { name: "xterm-256color", cols, rows, cwd, env })
+  liveTerms.add(term)
   let buffer = ""
   let closed = false
   term.onData((chunk) => {
@@ -217,6 +252,7 @@ async function spawnKobe(opts: SpawnKobeOpts = {}): Promise<KobeHandle> {
   })
   term.onExit(() => {
     closed = true
+    liveTerms.delete(term)
   })
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
   return {

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -60,6 +60,13 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
     worktrees,
     bridge,
     async close() {
+      // Order matters: stop live engine sessions BEFORE we tear down
+      // the bridge (so any final mcp-bridge tool call replies cleanly)
+      // and BEFORE dispose() drops the store subscription. Without
+      // this, a graceful daemon shutdown (`kobed stop`, SIGTERM) left
+      // claude/codex subprocesses orphaned to init, where they'd keep
+      // running models and writing transcript indefinitely.
+      await orchestrator.stopAllSessions()
       await bridge?.close()
       orchestrator.dispose()
     },

--- a/packages/kobe/src/orchestrator/bridge/index.ts
+++ b/packages/kobe/src/orchestrator/bridge/index.ts
@@ -16,7 +16,7 @@
  * desired behavior for now (no recursion guard yet).
  */
 
-import { mkdir, unlink, writeFile } from "node:fs/promises"
+import { mkdir, readdir, unlink, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -39,6 +39,45 @@ export function bridgeSocketPathForHome(home: string, pid = process.pid): string
   return fitSocketPath(join(runDir, `bridge-${pid}.sock`), home, "bridge", pid)
 }
 
+/**
+ * Best-effort sweep of `<home>/.kobe/run/` for `bridge-<pid>.sock` and
+ * `mcp-<pid>.json` entries whose owner PID is no longer alive. The
+ * normal close path unlinks both files, but SIGKILL'd kobe / kobed
+ * runs (oom-killer, terminal closed mid-shutdown, panic) leave them
+ * behind, and a single dev day can accumulate dozens of stale entries.
+ * Skip our own pid and anything we can't parse — we'd rather underclean
+ * than wipe a live peer's file. Errors swallowed: stale-file cleanup
+ * must never block daemon startup.
+ */
+async function sweepStaleRunFiles(runDir: string): Promise<void> {
+  let entries: string[]
+  try {
+    entries = await readdir(runDir)
+  } catch {
+    return
+  }
+  const self = process.pid
+  await Promise.all(
+    entries.map(async (name) => {
+      const match = name.match(/^(?:bridge|mcp)-(\d+)\.(?:sock|json)$/)
+      if (!match) return
+      const pid = Number(match[1])
+      if (!Number.isFinite(pid) || pid === self) return
+      try {
+        process.kill(pid, 0)
+        return // owner still alive
+      } catch {
+        // ESRCH (no such process) or EPERM — treat both as "safe to
+        // sweep." EPERM means we don't own the process, which on macOS
+        // happens for `pid 1` and other system pids; the run/ pid is
+        // ours, so EPERM almost certainly means "wraparound, different
+        // owner, ours is gone."
+      }
+      await unlink(join(runDir, name)).catch(() => {})
+    }),
+  )
+}
+
 export async function startBridge(orch: Orchestrator, opts: StartBridgeOpts = {}): Promise<BridgeHandles> {
   const home = opts.homeDir ?? process.env.KOBE_HOME_DIR ?? homedir()
   const runDir = join(home, ".kobe", "run")
@@ -55,6 +94,8 @@ export async function startBridge(orch: Orchestrator, opts: StartBridgeOpts = {}
   // socket fell back to $TMPDIR via fitSocketPath, the home-side runDir
   // still needs to exist for the mcp.json writeFile below.
   await mkdir(runDir, { recursive: true })
+
+  await sweepStaleRunFiles(runDir)
 
   const server: BridgeServer = await startBridgeServer(orch, socketPath)
   await mkdir(runDir, { recursive: true })

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -697,6 +697,40 @@ export class Orchestrator {
     this.unsubscribeStore()
   }
 
+  /**
+   * Stop every live engine session (SIGTERM → grace → SIGKILL per the
+   * engine's `stop()` contract). Mirrors `stopAllTabsForTask` but
+   * across *every* (task, tab) we currently hold a handle for, with
+   * stops issued in parallel — each handle's session id is unique so
+   * the engine registries don't contend.
+   *
+   * Used by `KobeCore.close()` so a graceful daemon SIGTERM doesn't
+   * leave claude/codex subprocesses reparented to init, where they'd
+   * keep running models and writing transcript until something else
+   * kills them. The earlier `dispose()` path only unhooked the store
+   * subscription, which left every live session orphaned — load-bearing
+   * for anyone running `kobed stop` / `kobed restart` while tasks are
+   * active. See KOB / Pre-1.0 整理 leak audit.
+   */
+  async stopAllSessions(): Promise<void> {
+    const entries = Array.from(this.handles.entries())
+    this.handles.clear()
+    await Promise.allSettled(
+      entries.map(async ([key, handle]) => {
+        const sep = key.indexOf(":")
+        if (sep === -1) return
+        const taskId = key.slice(0, sep) as TaskId
+        const tabId = key.slice(sep + 1)
+        try {
+          await this.engineForTaskTabId(taskId, tabId).stop(handle)
+        } catch {
+          // Best-effort — every other lifecycle path also swallows here.
+        }
+      }),
+    )
+    this.bumpRunState()
+  }
+
   /** Snapshot of the current task list. Defensive copy. */
   listTasks(): Task[] {
     return this.store.list()

--- a/packages/kobe/test/behavior/driver.ts
+++ b/packages/kobe/test/behavior/driver.ts
@@ -66,6 +66,47 @@ const DEFAULT_TIMEOUT_MS = 5_000
 /** Grace period between SIGTERM and SIGKILL during teardown. */
 const EXIT_GRACE_MS = 750
 
+/**
+ * Every pty we've ever spawned, regardless of whether the test called
+ * `exit()`. The vitest worker normally exits cleanly and our async
+ * teardown runs, but on Ctrl-C, an assertion that throws past the
+ * finally, or a CI hard-timeout SIGKILL'ing the worker, those exit
+ * paths never fire and the pty's spawn-helper gets reparented to init
+ * — we found a 30+ hour orphan in dev. This set + the synchronous
+ * `process.on("exit")` hook below guarantee a best-effort SIGKILL
+ * even on abrupt termination. SIGKILL because `exit` handlers only
+ * permit synchronous work; we cannot wait on graceful shutdown.
+ */
+const liveTerms = new Set<pty.IPty>()
+let processExitHooksInstalled = false
+
+function ensurePtyProcessExitHooks(): void {
+  if (processExitHooksInstalled) return
+  processExitHooksInstalled = true
+  const killAll = (): void => {
+    for (const t of liveTerms) {
+      try {
+        t.kill("SIGKILL")
+      } catch {
+        // already dead or never started
+      }
+    }
+    liveTerms.clear()
+  }
+  process.on("exit", killAll)
+  // Forwarding signals: kill children, then let Node take the default
+  // exit (we re-emit the signal to ourselves with the handler removed
+  // so the original signal disposition wins — `process.exit(N)` would
+  // mask which signal actually killed us, which matters for CI.)
+  const forward = (sig: NodeJS.Signals) => () => {
+    killAll()
+    process.kill(process.pid, sig)
+  }
+  process.once("SIGINT", forward("SIGINT"))
+  process.once("SIGTERM", forward("SIGTERM"))
+  process.once("SIGHUP", forward("SIGHUP"))
+}
+
 export interface SpawnKobeOpts {
   /** Working directory for the spawned kobe process. Defaults to repo root. */
   cwd?: string
@@ -147,6 +188,7 @@ function defaultCommand(cwd: string): { command: string; args: string[] } {
 
 export async function spawnKobe(opts: SpawnKobeOpts = {}): Promise<KobeHandle> {
   ensureSpawnHelperExecutable()
+  ensurePtyProcessExitHooks()
 
   const cwd = opts.cwd ?? PACKAGE_ROOT
   const cols = opts.cols ?? DEFAULT_COLS
@@ -181,6 +223,7 @@ export async function spawnKobe(opts: SpawnKobeOpts = {}): Promise<KobeHandle> {
     cwd,
     env,
   })
+  liveTerms.add(term)
 
   let buffer = ""
   let closed = false
@@ -197,6 +240,7 @@ export async function spawnKobe(opts: SpawnKobeOpts = {}): Promise<KobeHandle> {
   term.onExit(({ exitCode: code }) => {
     closed = true
     exitCode = code ?? null
+    liveTerms.delete(term)
   })
 
   /** Wait for `ms` milliseconds. */


### PR DESCRIPTION
## Summary

Three independent leak fixes surfaced during the KOB-98 audit (mcp-bridge PPID=1 zombies, PR #28). Each commit is one Linear issue, listed worst-first.

- **[KOB-99](https://linear.app/codesfox/issue/KOB-99)** (HIGH) — `KobeCore.close()` previously only dropped the store subscription. SIGTERM to `kobed` left every active claude/codex subprocess orphaned to init, still burning tokens and writing transcript. Adds `Orchestrator.stopAllSessions()` and awaits it before bridge teardown.
- **[KOB-100](https://linear.app/codesfox/issue/KOB-100)** (MEDIUM) — behavior driver + perf-stress only kill their pty when the test/script calls `exit()`. A vitest worker crash, CI hard-timeout SIGKILL, or Ctrl-C between assertions leaks a node-pty spawn-helper as a PPID=1 orphan running the kobe TUI (we found a 30+ hour orphan in dev). Adds `process.on("exit")` + signal forwarders that SIGKILL every tracked pty.
- **[KOB-101](https://linear.app/codesfox/issue/KOB-101)** (LOW) — graceful daemon close unlinks `bridge-<pid>.sock` + `mcp-<pid>.json`, but SIGKILL'd runs leak them. On `startBridge()`, sweep stale entries by `kill -0`-probing the owner pid.

## Test plan

- [x] `bun run test:fast` — 800 pass / 9 skipped
- [x] typecheck — clean
- [ ] After daemon restart with this code: spawn a task, `kobed stop`, confirm `pgrep claude` returns 0 (no live model-running orphans)
- [ ] Run a behavior test, SIGKILL the vitest worker mid-test, confirm `pgrep -f "bun --preload @opentui"` returns 0
- [ ] Restart daemon after an SIGKILL'd previous instance, confirm only the new daemon's `~/.kobe/run/` entries remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented orphaned terminal processes on abrupt termination by adding process-level PTY cleanup.
  * Ensured all active engine sessions are stopped before bridge shutdown for cleaner exits.
  * Added best-effort removal of stale runtime files during startup.
  * Improved handling of abrupt exits with forced teardown of dependent subprocesses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/30)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->