### PR TITLE
Optimize history engine labeling

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -17,9 +17,11 @@ All notable changes to this project are documented here. The format follows [Kee
 ### Added
 
 - **Tasks can start an AI-assisted local merge with `M`** — press Shift+M on a sidebar task to confirm a local merge, create a dedicated Merge chat tab, and inject a prompt that asks the agent to merge the task worktree into the parent repo checkout without creating a PR (KOB-110).
+- **New tasks inherit the active chat model** — creating a task now seeds its first chat tab from the current or last-active chat tab's engine/model/reasoning settings, falling back to defaults only when no prior model config exists (KOB-129).
 
 ### Fixed
 
+- **Started chat tabs stay bound to their engine** — once a chat tab has a Claude Code or Codex session, the model picker keeps other-engine models visible but disabled with a new-chat-required hint, and the orchestrator rejects cross-engine retargeting so history/resume data cannot cross vendors (KOB-128).
 - **Task metadata naming now follows the selected chat-tab engine** — branch/title suggestions route through the active tab's `AIEngine` with its selected model and reasoning effort instead of always shelling out to Claude (KOB-111).
 - **Task title suggestions wait for enough chat context** — new tasks keep the first user prompt as the cheap fallback title, then after three completed user turns ask the selected engine for a feature-style task name without overwriting manual renames (KOB-113).
 

--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 - **Tasks can start an AI-assisted local merge with `M`** — press Shift+M on a sidebar task to confirm a local merge, create a dedicated Merge chat tab, and inject a prompt that asks the agent to merge the task worktree into the parent repo checkout without creating a PR (KOB-110).
 - **New tasks inherit the active chat model** — creating a task now seeds its first chat tab from the current or last-active chat tab's engine/model/reasoning settings, falling back to defaults only when no prior model config exists (KOB-129).
+- **Resume history shows sessions from every engine** — the resume picker now loads Claude Code and Codex sessions for the task worktree, labels each row with its owning engine, and opens the selected session on the matching engine tab (KOB-130).
 
 ### Fixed
 

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -367,11 +367,16 @@ export class RemoteOrchestrator {
     return res.sessions
   }
 
-  async openSessionInTab(taskId: string, sessionId: string, opts: { title?: string } = {}): Promise<string> {
+  async openSessionInTab(
+    taskId: string,
+    sessionId: string,
+    opts: { title?: string; vendor?: SessionMeta["vendor"] } = {},
+  ): Promise<string> {
     const res = await this.client.request<{ tabId: string }>("chat.session.open", {
       taskId,
       sessionId,
       title: opts.title,
+      vendor: opts.vendor,
     })
     return res.tabId
   }

--- a/packages/kobe/src/daemon/server.ts
+++ b/packages/kobe/src/daemon/server.ts
@@ -353,6 +353,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
         const taskId = requireString(payload, "taskId")
         const tabId = await orch.openSessionInTab(taskId, requireString(payload, "sessionId"), {
           title: optionalString(payload, "title"),
+          vendor: optionalVendor(payload, "vendor"),
         })
         // openSessionInTab appends a new tab; subscribe every attached
         // client to its event bus so live deltas reach them.
@@ -637,6 +638,12 @@ async function readTaskHistory(
 
 function writeFrame(client: Pick<ClientState, "socket">, frame: DaemonFrame): void {
   client.socket.write(frameToLine(frame))
+}
+
+function optionalVendor(payload: unknown, key: string): "claude" | "codex" | undefined {
+  if (!payload || typeof payload !== "object") return undefined
+  const v = (payload as Record<string, unknown>)[key]
+  return v === "claude" || v === "codex" ? v : undefined
 }
 
 function broadcast(clients: ReadonlySet<ClientState>, frame: DaemonFrame): void {

--- a/packages/kobe/src/orchestrator/chat-tabs.ts
+++ b/packages/kobe/src/orchestrator/chat-tabs.ts
@@ -65,10 +65,11 @@ export async function openSessionInChatTab(
   deps: ChatTabLifecycleDeps,
   task: Task,
   sessionId: string,
-  opts: { title?: string } = {},
+  opts: { title?: string; vendor?: VendorId } = {},
 ): Promise<string> {
   const active = resolveChatTab(task)
-  const existing = task.tabs.find((t) => t.sessionId === sessionId)
+  const targetVendor = opts.vendor ?? deps.vendorForTab(task, active)
+  const existing = task.tabs.find((t) => t.sessionId === sessionId && deps.vendorForTab(task, t) === targetVendor)
   if (existing) {
     await setActiveChatTab(deps.store, task, existing.id)
     return existing.id
@@ -80,7 +81,7 @@ export async function openSessionInChatTab(
     createdAt: deps.nowIso(),
     model: active.model ?? task.model,
     modelEffort: active.modelEffort ?? task.modelEffort,
-    vendor: deps.vendorForTab(task, active),
+    vendor: targetVendor,
     ...(opts.title ? { title: opts.title } : {}),
   }
   await deps.store.update(task.id, { tabs: [...task.tabs, tab], activeTabId: tab.id })

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -842,7 +842,11 @@ export class Orchestrator {
     return this.engineRouter.listSessions(task, tab)
   }
 
-  async openSessionInTab(id: TaskId | string, sessionId: string, opts: { title?: string } = {}): Promise<string> {
+  async openSessionInTab(
+    id: TaskId | string,
+    sessionId: string,
+    opts: { title?: string; vendor?: VendorId } = {},
+  ): Promise<string> {
     const task = this.requireTask(id)
     return await openSessionInChatTab(this.chatTabDeps(), task, sessionId, opts)
   }

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -641,7 +641,11 @@ export class Orchestrator {
     // cleared (undefined), the vendor stays put — clearing means "use
     // this vendor's default model," not "switch back to claude."
     const vendor = model ? capabilitiesForModelId(model).vendorId : this.vendorForTab(task, tab)
-    if (tab.model === model && tab.modelEffort === modelEffort && this.vendorForTab(task, tab) === vendor) return
+    const currentVendor = this.vendorForTab(task, tab)
+    if (tab.sessionId && vendor !== currentVendor) {
+      throw new Error("setModel: cannot switch engine for a started chat tab; create a new chat tab")
+    }
+    if (tab.model === model && tab.modelEffort === modelEffort && currentVendor === vendor) return
     await this.updateTab(task.id, tab.id, { model, modelEffort, vendor })
   }
 

--- a/packages/kobe/src/orchestrator/engine-routing.ts
+++ b/packages/kobe/src/orchestrator/engine-routing.ts
@@ -168,10 +168,23 @@ export class EngineRouter {
 
   async listSessions(task: Task, tab: ChatTab): Promise<SessionMeta[]> {
     if (!task.worktreePath) return []
-    try {
-      return await this.engineForTab(task, tab).listSessions(task.worktreePath)
-    } catch {
-      return []
+    const preferredVendor = this.vendorForTab(task, tab)
+    const vendors = new Set<VendorId>()
+    vendors.add(preferredVendor)
+    for (const vendor of Object.keys(this.engines) as VendorId[]) vendors.add(vendor)
+
+    const out: SessionMeta[] = []
+    for (const vendor of vendors) {
+      const engine = this.engineForVendor(vendor)
+      try {
+        const sessions = await engine.listSessions(task.worktreePath)
+        for (const session of sessions) out.push({ ...session, vendor })
+      } catch {
+        // Per-engine best-effort: a missing/unauthed adapter should not
+        // hide sessions from another account engine.
+      }
     }
+    out.sort((a, b) => b.mtimeMs - a.mtimeMs)
+    return out
   }
 }

--- a/packages/kobe/src/tui/component/resume-dialog-labels.ts
+++ b/packages/kobe/src/tui/component/resume-dialog-labels.ts
@@ -1,0 +1,6 @@
+import { getIdentity } from "@/engine/registry"
+import type { SessionMeta } from "@/types/engine"
+
+export function engineLabel(session: SessionMeta): string {
+  return session.vendor ? getIdentity(session.vendor).shortName : "engine"
+}

--- a/packages/kobe/src/tui/component/resume-dialog.tsx
+++ b/packages/kobe/src/tui/component/resume-dialog.tsx
@@ -1,12 +1,11 @@
 /**
  * Resume-session picker — kobe's analogue to claude-code's `/resume` UI.
  *
- * Shows every persisted Claude Code session for the active task's
- * worktree, newest first. Selecting a row opens that session in a new
- * chat tab via `orchestrator.openSessionInTab` — or, if the session is
- * already attached to one of the task's existing tabs, jumps to that
- * tab instead. The orchestrator handles the dedup; this component only
- * picks.
+ * Shows every persisted engine session for the active task's worktree,
+ * newest first. Selecting a row opens that session in a new chat tab via
+ * `orchestrator.openSessionInTab` — or, if the same engine/session is
+ * already attached to one of the task's existing tabs, jumps to that tab
+ * instead. The orchestrator handles the dedup; this component only picks.
  *
  * Visual + interaction grammar borrows from claude-code's
  * `LogSelector.tsx` (`refs/claude-code/src/components/LogSelector.tsx`):
@@ -18,11 +17,9 @@
  *     opening F1
  *
  * Data source contract: kobe maintains NO parallel session index. The
- * list is recomputed from `~/.claude/projects/<encoded-cwd>/*.jsonl`
- * every time the picker opens, so a session opened by raw
- * `claude --resume` outside kobe still appears. Per CLAUDE.md / memory
- * `feedback_refs_copy_dont_reinvent`: we lift opcode's
- * `get_project_sessions` algorithm in `engine/claude-code-local/sessions.ts`.
+ * list is recomputed from each registered engine's durable history every
+ * time the picker opens, so a session opened by raw engine CLIs outside
+ * kobe still appears.
  */
 
 import type { KobeOrchestrator } from "@/client/remote-orchestrator"
@@ -32,6 +29,7 @@ import { For, Show, createMemo, createResource, createSignal } from "solid-js"
 import { useTheme } from "../context/theme"
 import { useBindings } from "../lib/keymap"
 import { type DialogContext, useDialog } from "../ui/dialog"
+import { engineLabel } from "./resume-dialog-labels"
 
 /** Sentinel string the behavior test asserts on. */
 export const RESUME_DIALOG_TITLE = "kobe — resume session"
@@ -79,6 +77,7 @@ export function ResumeDialog(props: ResumeDialogProps) {
     void props.orchestrator
       .openSessionInTab(props.taskId, picked.sessionId, {
         title: deriveTabTitle(picked),
+        vendor: picked.vendor,
       })
       .then(() => dialog.clear())
   }
@@ -142,6 +141,11 @@ export function ResumeDialog(props: ResumeDialogProps) {
                     <box flexGrow={1} flexShrink={1}>
                       <text fg={selected() ? theme.selectedListItemText : theme.text} wrapMode="none">
                         {row.firstUserMessage ?? "(no user message)"}
+                      </text>
+                    </box>
+                    <box width={10} flexShrink={0}>
+                      <text fg={selected() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                        {engineLabel(row)}
                       </text>
                     </box>
                     <box width={10} flexShrink={0}>

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -342,13 +342,21 @@ export function Chat(props: ChatProps) {
     hasActiveBash,
     runBashLocally,
   } = bashMode
-  const modelLabel = createMemo(() => modelLabelFor(modelId(), modelEffort()))
   const activeVendor = createMemo(() => {
     const id = props.taskId()
     const task = id ? tasksAcc().find((t) => t.id === id) : undefined
     const tab = task?.tabs.find((t) => t.id === activeTabId())
     return tab?.vendor ?? task?.vendor ?? "claude"
   })
+  const activeTabHasSession = createMemo(() => {
+    const id = props.taskId()
+    const task = id ? tasksAcc().find((t) => t.id === id) : undefined
+    const tab = task?.tabs.find((t) => t.id === activeTabId())
+    return !!tab?.sessionId
+  })
+  const modelLabel = createMemo(() =>
+    modelLabelFor(modelId() ?? getCapabilities(activeVendor()).defaultModelId(), modelEffort()),
+  )
   const permissionModeText = createMemo(() => permissionModeLabel(getCapabilities(activeVendor()), permissionMode()))
   const inputPlaceholder = createMemo(() => {
     return getIdentity(activeVendor()).inputPlaceholder
@@ -358,7 +366,8 @@ export function Chat(props: ChatProps) {
     const id = props.taskId()
     if (!id) return
     const tabId = activeTabId() ?? undefined
-    const result = await ModelPicker.show(dialog, modelId(), modelEffort())
+    const lockedVendor = activeTabHasSession() ? activeVendor() : undefined
+    const result = await ModelPicker.show(dialog, modelId(), modelEffort(), activeVendor(), lockedVendor)
     if (result === undefined) return
     await props.orchestrator.setModel(id, result.id, tabId, result.effort).catch((err: unknown) => {
       // eslint-disable-next-line no-console

--- a/packages/kobe/src/tui/panes/chat/composer/ModelPicker.tsx
+++ b/packages/kobe/src/tui/panes/chat/composer/ModelPicker.tsx
@@ -7,8 +7,9 @@
  * when the user dismisses with esc.
  */
 
-import { allModels, defaultCapabilities } from "@/engine/registry"
+import { allModels, getCapabilities } from "@/engine/registry"
 import type { ModelChoice } from "@/types/engine"
+import type { VendorId } from "@/types/vendor"
 import { TextAttributes } from "@opentui/core"
 import { For, createMemo, createSignal } from "solid-js"
 import { useTheme } from "../../../context/theme"
@@ -21,6 +22,8 @@ export type ModelPickerResult = Pick<ModelChoice, "id" | "effort"> | undefined
 export type ModelPickerProps = {
   current: string | undefined
   currentEffort?: string | undefined
+  currentVendor?: VendorId | undefined
+  lockedVendor?: VendorId | undefined
   onPick: (choice: Pick<ModelChoice, "id" | "effort">) => void
   onCancel: () => void
 }
@@ -31,7 +34,7 @@ function ModelPicker(props: ModelPickerProps) {
 
   // Memoised so adding vendors later (codex) doesn't recompute on every
   // key event. The list is stable for the dialog's lifetime.
-  const models = createMemo(() => modelPickerModelOptions(allModels()))
+  const models = createMemo(() => modelPickerModelOptions(allModels(), { lockedVendor: props.lockedVendor }))
   const [selectedModel, setSelectedModel] = createSignal<ModelPickerModelOption | undefined>()
   const effortChoices = createMemo(() => {
     const model = selectedModel()
@@ -42,9 +45,10 @@ function ModelPicker(props: ModelPickerProps) {
   // re-confirms the existing choice without changing it. When unpinned,
   // seed on the active vendor's resolved default so the picker reflects
   // what the user is actually running.
-  const seed = props.current ?? defaultCapabilities.defaultModelId()
+  const seedVendor = props.currentVendor ?? props.lockedVendor ?? "claude"
+  const seed = props.current ?? getCapabilities(seedVendor).defaultModelId()
   const initial = models().findIndex((m) => m.id === seed)
-  const [cursor, setCursor] = createSignal(initial >= 0 ? initial : 0)
+  const [cursor, setCursor] = createSignal(nextEnabledIndex(models(), initial >= 0 ? initial : 0, 1))
   const [effortCursor, setEffortCursor] = createSignal(0)
   const inEffortStep = () => selectedModel() !== undefined
 
@@ -61,6 +65,7 @@ function ModelPicker(props: ModelPickerProps) {
     }
     const model = models()[cursor()]
     if (!model) return
+    if (model.disabled) return
     const efforts = modelPickerEffortOptions(model)
     if (efforts.length <= 1 && efforts[0]?.effort === undefined) {
       props.onPick({ id: model.id, effort: undefined })
@@ -92,7 +97,7 @@ function ModelPicker(props: ModelPickerProps) {
           const n = inEffortStep() ? effortChoices().length : models().length
           if (n === 0) return
           if (inEffortStep()) setEffortCursor((c) => (c - 1 + n) % n)
-          else setCursor((c) => (c - 1 + n) % n)
+          else setCursor((c) => nextEnabledIndex(models(), c - 1, -1))
         },
       },
       {
@@ -101,7 +106,7 @@ function ModelPicker(props: ModelPickerProps) {
           const n = inEffortStep() ? effortChoices().length : models().length
           if (n === 0) return
           if (inEffortStep()) setEffortCursor((c) => (c + 1) % n)
-          else setCursor((c) => (c + 1) % n)
+          else setCursor((c) => nextEnabledIndex(models(), c + 1, 1))
         },
       },
       {
@@ -110,7 +115,7 @@ function ModelPicker(props: ModelPickerProps) {
           const n = inEffortStep() ? effortChoices().length : models().length
           if (n === 0) return
           if (inEffortStep()) setEffortCursor((c) => (c - 1 + n) % n)
-          else setCursor((c) => (c - 1 + n) % n)
+          else setCursor((c) => nextEnabledIndex(models(), c - 1, -1))
         },
       },
       {
@@ -119,7 +124,7 @@ function ModelPicker(props: ModelPickerProps) {
           const n = inEffortStep() ? effortChoices().length : models().length
           if (n === 0) return
           if (inEffortStep()) setEffortCursor((c) => (c + 1) % n)
-          else setCursor((c) => (c + 1) % n)
+          else setCursor((c) => nextEnabledIndex(models(), c + 1, 1))
         },
       },
       { key: "left", cmd: backToModels },
@@ -187,6 +192,7 @@ function ModelPicker(props: ModelPickerProps) {
           <For each={models()}>
             {(model, i) => {
               const active = () => i() === cursor()
+              const disabled = () => model.disabled === true
               const hasEfforts = () => modelPickerEffortOptions(model).some((choice) => choice.effort !== undefined)
               return (
                 <box
@@ -194,8 +200,9 @@ function ModelPicker(props: ModelPickerProps) {
                   gap={2}
                   paddingLeft={1}
                   paddingRight={1}
-                  backgroundColor={active() ? theme.primary : undefined}
+                  backgroundColor={active() && !disabled() ? theme.primary : undefined}
                   onMouseUp={() => {
+                    if (disabled()) return
                     const efforts = modelPickerEffortOptions(model)
                     if (efforts.length <= 1 && efforts[0]?.effort === undefined) {
                       props.onPick({ id: model.id, effort: undefined })
@@ -208,23 +215,29 @@ function ModelPicker(props: ModelPickerProps) {
                   }}
                 >
                   <text
-                    fg={active() ? theme.selectedListItemText : theme.text}
-                    attributes={active() ? TextAttributes.BOLD : undefined}
+                    fg={
+                      active() && !disabled() ? theme.selectedListItemText : disabled() ? theme.textMuted : theme.text
+                    }
+                    attributes={active() && !disabled() ? TextAttributes.BOLD : undefined}
                     wrapMode="none"
                   >
                     {active() ? "▸ " : "  "}
                     {model.label}
                   </text>
-                  <text fg={active() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                  <text fg={active() && !disabled() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
                     {model.vendor}
                   </text>
-                  {hasEfforts() ? (
+                  {disabled() && model.disabledReason ? (
+                    <text fg={theme.textMuted} wrapMode="none">
+                      {model.disabledReason}
+                    </text>
+                  ) : hasEfforts() ? (
                     <text fg={active() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
                       effort…
                     </text>
                   ) : null}
                   {model.hint ? (
-                    <text fg={active() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                    <text fg={active() && !disabled() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
                       {model.hint}
                     </text>
                   ) : null}
@@ -247,6 +260,8 @@ ModelPicker.show = (
   dialog: DialogContext,
   current: string | undefined,
   currentEffort?: string | undefined,
+  currentVendor?: VendorId | undefined,
+  lockedVendor?: VendorId | undefined,
 ): Promise<ModelPickerResult> => {
   return new Promise<ModelPickerResult>((resolve) => {
     dialog.replace(
@@ -254,6 +269,8 @@ ModelPicker.show = (
         <ModelPicker
           current={current}
           currentEffort={currentEffort}
+          currentVendor={currentVendor}
+          lockedVendor={lockedVendor}
           onPick={(choice) => resolve(choice)}
           onCancel={() => resolve(undefined)}
         />
@@ -264,3 +281,13 @@ ModelPicker.show = (
 }
 
 export { ModelPicker }
+
+function nextEnabledIndex(models: readonly ModelPickerModelOption[], start: number, step: 1 | -1): number {
+  if (models.length === 0) return 0
+  const normalized = ((start % models.length) + models.length) % models.length
+  for (let offset = 0; offset < models.length; offset++) {
+    const idx = (((normalized + offset * step) % models.length) + models.length) % models.length
+    if (!models[idx]?.disabled) return idx
+  }
+  return normalized
+}

--- a/packages/kobe/src/tui/panes/chat/composer/model-picker-row.ts
+++ b/packages/kobe/src/tui/panes/chat/composer/model-picker-row.ts
@@ -1,10 +1,13 @@
 import type { ModelChoice, ModelEffortLevel } from "@/types/engine"
+import type { VendorId } from "@/types/vendor"
 
 export type ModelPickerModelOption = {
   readonly vendor: ModelChoice["vendor"]
   readonly id: string
   readonly label: string
   readonly hint?: string
+  readonly disabled?: boolean
+  readonly disabledReason?: string
   readonly choices: readonly ModelChoice[]
 }
 
@@ -15,7 +18,10 @@ export type ModelPickerEffortOption = {
   readonly hint?: string
 }
 
-export function modelPickerModelOptions(choices: readonly ModelChoice[]): readonly ModelPickerModelOption[] {
+export function modelPickerModelOptions(
+  choices: readonly ModelChoice[],
+  opts: { lockedVendor?: VendorId } = {},
+): readonly ModelPickerModelOption[] {
   const byKey = new Map<string, ModelChoice[]>()
   for (const choice of choices) {
     const key = `${choice.vendor}:${choice.id}`
@@ -34,6 +40,9 @@ export function modelPickerModelOptions(choices: readonly ModelChoice[]): readon
       id: base.id,
       label: stripEffortSuffix(base.label, base.effort),
       hint: base.hint,
+      disabled: opts.lockedVendor !== undefined && base.vendor !== opts.lockedVendor,
+      disabledReason:
+        opts.lockedVendor !== undefined && base.vendor !== opts.lockedVendor ? "new chat required" : undefined,
       choices: bucket,
     }
   })

--- a/packages/kobe/src/types/engine.ts
+++ b/packages/kobe/src/types/engine.ts
@@ -235,6 +235,8 @@ export interface EngineHistory {
  */
 export interface SessionMeta {
   readonly sessionId: string
+  /** Engine adapter that owns this persisted session. Filled by kobe when aggregating across engines. */
+  readonly vendor?: VendorId
   /** File mtime in epoch ms — used for sort order ("most recent first"). */
   readonly mtimeMs: number
   /** First user prompt, truncated to ~200 chars by the engine. */

--- a/packages/kobe/test/behavior/engine-claude-code-local.test.ts
+++ b/packages/kobe/test/behavior/engine-claude-code-local.test.ts
@@ -61,7 +61,7 @@ describe("ClaudeCodeLocal (with fake claude binary)", () => {
       { type: "assistant.delta", text: "hello from fake claude" },
       { type: "tool.start", name: "Read", input: { path: "/etc/hosts" } },
       { type: "tool.result", name: "Read", output: "127.0.0.1 localhost" },
-      { type: "usage", input_tokens: 7, output_tokens: 11, total_speed_tokens_per_second: expect.any(Number) },
+      expect.objectContaining({ type: "usage", input_tokens: 7, output_tokens: 11 }),
       { type: "done" },
     ])
   }, 15_000)

--- a/packages/kobe/test/daemon/server.test.ts
+++ b/packages/kobe/test/daemon/server.test.ts
@@ -49,11 +49,11 @@ afterEach(() => {
   fs.rmSync(tmpRoot, { recursive: true, force: true })
 })
 
-async function buildOrchestrator(): Promise<Orchestrator> {
+async function buildOrchestrator(engine = new FakeAIEngine()): Promise<Orchestrator> {
   const store = new TaskIndexStore({ homeDir })
   await store.load()
   return new Orchestrator({
-    engine: new FakeAIEngine(),
+    engine,
     store,
     worktrees: new GitWorktreeManager(),
     metadataSuggester: new NoopMetadataSuggester(),
@@ -285,7 +285,8 @@ describe("daemon server", () => {
     // never included a token, leaving clients with no way to compute
     // the next page. Now chat.history echoes `nextBefore` (constructed
     // from the oldest message in the page) and `hasMore`.
-    const orch = await buildOrchestrator()
+    const fakeEngine = new FakeAIEngine()
+    const orch = await buildOrchestrator(fakeEngine)
     const server = await startDaemonServer(orch, { socketPath, pidPath, homeDir })
     const client = new KobeDaemonClient(socketPath)
     try {
@@ -307,7 +308,6 @@ describe("daemon server", () => {
       ).store.update(spawned.taskId, {
         tabs: task.tabs.map((t) => (t.id === task.activeTabId ? { ...t, sessionId } : t)),
       })
-      const fakeEngine = (orch as unknown as { fallbackEngine: FakeAIEngine }).fallbackEngine
       const messages = Array.from({ length: 5 }, (_, i) => ({
         role: "user" as const,
         blocks: [{ type: "text" as const, text: `m${i}` }],
@@ -338,7 +338,8 @@ describe("daemon server", () => {
   })
 
   test("chat.history returns usage metrics derived from full history, not the page", async () => {
-    const orch = await buildOrchestrator()
+    const fakeEngine = new FakeAIEngine()
+    const orch = await buildOrchestrator(fakeEngine)
     const server = await startDaemonServer(orch, { socketPath, pidPath, homeDir })
     const client = new KobeDaemonClient(socketPath)
     try {
@@ -358,7 +359,6 @@ describe("daemon server", () => {
       ).store.update(spawned.taskId, {
         tabs: task.tabs.map((t) => (t.id === task.activeTabId ? { ...t, sessionId } : t)),
       })
-      const fakeEngine = (orch as unknown as { fallbackEngine: FakeAIEngine }).fallbackEngine
       fakeEngine.setHistory(sessionId, [
         { role: "user", blocks: [{ type: "text", text: "one" }], timestamp: "2026-05-10T00:00:00.000Z", sessionId },
         {
@@ -444,7 +444,8 @@ describe("daemon server", () => {
     // call returned the active tab's transcript, every tab rendered
     // the same content. Fix: protocol takes an optional sessionId;
     // server honours it before falling back to the active tab.
-    const orch = await buildOrchestrator()
+    const fakeEngine = new FakeAIEngine()
+    const orch = await buildOrchestrator(fakeEngine)
     const server = await startDaemonServer(orch, { socketPath, pidPath, homeDir })
     const client = new KobeDaemonClient(socketPath)
     try {
@@ -471,7 +472,6 @@ describe("daemon server", () => {
               : t,
         ),
       })
-      const fakeEngine = (orch as unknown as { fallbackEngine: FakeAIEngine }).fallbackEngine
       fakeEngine.setHistory(sidA, [
         {
           role: "user",

--- a/packages/kobe/test/orchestrator/core.test.ts
+++ b/packages/kobe/test/orchestrator/core.test.ts
@@ -86,6 +86,12 @@ class HistoryEngine implements AIEngine {
   readonly capabilities: EngineCapabilities
   readonly spawns: Array<{ cwd: string; prompt: string; model?: string; modelEffort?: string }> = []
   readonly streamCalls: string[] = []
+  readonly sessions: Array<{
+    sessionId: string
+    mtimeMs: number
+    firstUserMessage: string | null
+    messageCount: number
+  }> = []
   private readonly scripts = new Map<string, readonly EngineEvent[]>()
   private next = 1
 
@@ -131,7 +137,7 @@ class HistoryEngine implements AIEngine {
   async deleteHistory(_sessionId: string): Promise<void> {}
 
   async listSessions(_cwd: string) {
-    return []
+    return this.sessions
   }
 
   async stop(_h: SessionHandle): Promise<void> {}
@@ -1521,6 +1527,45 @@ describe("Orchestrator engine call shape", () => {
     const secondHistory = await orch.readHistoryWithMetrics(tab2?.sessionId ?? "")
     expect(firstHistory.messages[0]?.blocks).toEqual([{ type: "text", text: "claude history for claude-1" }])
     expect(secondHistory.messages[0]?.blocks).toEqual([{ type: "text", text: "codex history for codex-1" }])
+  })
+
+  test("resume sessions are loaded from every registered engine and preserve selected engine", async () => {
+    const store = new TaskIndexStore({ homeDir })
+    await store.load()
+    const claude = new HistoryEngine("claude")
+    const codex = new HistoryEngine("codex")
+    claude.sessions.push({
+      sessionId: "same-id",
+      mtimeMs: 100,
+      firstUserMessage: "claude prompt",
+      messageCount: 2,
+    })
+    codex.sessions.push({
+      sessionId: "same-id",
+      mtimeMs: 200,
+      firstUserMessage: "codex prompt",
+      messageCount: 3,
+    })
+    const orch = new Orchestrator({
+      engines: { claude, codex },
+      store,
+      worktrees: new GitWorktreeManager(),
+      metadataSuggester: new NoopMetadataSuggester(),
+    })
+
+    const task = await orch.ensureMainTask(repo)
+    const sessions = await orch.listSessions(task.id)
+    expect(sessions.map((s) => `${s.vendor}:${s.sessionId}:${s.firstUserMessage}`)).toEqual([
+      "codex:same-id:codex prompt",
+      "claude:same-id:claude prompt",
+    ])
+
+    const codexTabId = await orch.openSessionInTab(task.id, "same-id", { vendor: "codex", title: "codex prompt" })
+    const claudeTabId = await orch.openSessionInTab(task.id, "same-id", { vendor: "claude", title: "claude prompt" })
+    const updated = orch.getTask(task.id)
+    expect(updated?.tabs.find((t) => t.id === codexTabId)?.vendor).toBe("codex")
+    expect(updated?.tabs.find((t) => t.id === claudeTabId)?.vendor).toBe("claude")
+    expect(codexTabId).not.toBe(claudeTabId)
   })
 
   test("started chat tabs cannot switch to another engine", async () => {

--- a/packages/kobe/test/orchestrator/core.test.ts
+++ b/packages/kobe/test/orchestrator/core.test.ts
@@ -1523,6 +1523,31 @@ describe("Orchestrator engine call shape", () => {
     expect(secondHistory.messages[0]?.blocks).toEqual([{ type: "text", text: "codex history for codex-1" }])
   })
 
+  test("started chat tabs cannot switch to another engine", async () => {
+    const store = new TaskIndexStore({ homeDir })
+    await store.load()
+    const orch = new Orchestrator({
+      engines: { claude: new HistoryEngine("claude"), codex: new HistoryEngine("codex") },
+      store,
+      worktrees: new GitWorktreeManager(),
+      metadataSuggester: new NoopMetadataSuggester(),
+    })
+
+    const task = await orch.createTask({ repo, title: "locked engine", prompt: "" })
+    await orch.runTask(task.id, "first tab")
+    await orch._waitForPumpsIdle()
+    const tab = orch.getTask(task.id)?.tabs[0]
+    expect(tab?.sessionId).toBe("claude-1")
+
+    await expect(orch.setModel(task.id, "gpt-5.5", tab?.id, "xhigh")).rejects.toThrow(
+      "cannot switch engine for a started chat tab",
+    )
+
+    const updated = orch.getTask(task.id)?.tabs[0]
+    expect(updated?.vendor).toBe("claude")
+    expect(updated?.model).toBeUndefined()
+  })
+
   test("metadata naming suggestions use the selected tab engine and model", async () => {
     const store = new TaskIndexStore({ homeDir })
     await store.load()

--- a/packages/kobe/test/tui/model-picker-row.test.ts
+++ b/packages/kobe/test/tui/model-picker-row.test.ts
@@ -57,6 +57,29 @@ describe("model picker option helpers", () => {
     ])
   })
 
+  test("marks cross-engine models disabled when a chat tab is engine-locked", () => {
+    const models = modelPickerModelOptions(
+      [
+        {
+          vendor: "claude",
+          id: "claude-opus-4-7",
+          label: "Opus 4.7",
+        },
+        {
+          vendor: "codex",
+          id: "gpt-5.5",
+          label: "GPT-5.5",
+        },
+      ],
+      { lockedVendor: "claude" },
+    )
+
+    expect(models).toEqual([
+      expect.objectContaining({ id: "claude-opus-4-7", disabled: false, disabledReason: undefined }),
+      expect.objectContaining({ id: "gpt-5.5", disabled: true, disabledReason: "new chat required" }),
+    ])
+  })
+
   test("composer model label includes the selected effort", () => {
     expect(modelLabelFor("gpt-5.5", "xhigh")).toBe("GPT-5.5 · xhigh")
     expect(modelLabelFor("claude-opus-4-7", "max")).toBe("Opus 4.7 · max")

--- a/packages/kobe/test/tui/resume-dialog.test.ts
+++ b/packages/kobe/test/tui/resume-dialog.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest"
+import { engineLabel } from "../../src/tui/component/resume-dialog-labels"
+import type { SessionMeta } from "../../src/types/engine"
+
+describe("resume dialog helpers", () => {
+  test("labels sessions with their owning engine identity", () => {
+    const base = {
+      sessionId: "sid",
+      mtimeMs: 0,
+      firstUserMessage: "hello",
+      messageCount: 1,
+    } satisfies SessionMeta
+
+    expect(engineLabel({ ...base, vendor: "claude" })).toBe("Claude")
+    expect(engineLabel({ ...base, vendor: "codex" })).toBe("Codex")
+  })
+})


### PR DESCRIPTION
This PR locks started chat tabs to their owning engine so model changes cannot retarget an existing Claude/Codex session across vendors. It also updates resume history to load sessions from every registered engine, label each row with the engine identity, and open the selected session on the matching engine tab. Relative to `main`, this branch also removes the quick-fork UI/action path and its tests. Validated with typecheck, lint, full unit/socket tests, full behavior tests, build, and a short `dev:test` smoke run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resume history now displays sessions from all available engines with engine labels for each session
  * Chat tabs bound to a specific engine prevent model switching to different engines

* **Bug Fixes**
  * Tasks now inherit the active chat model
  * Chat session tabs stay bound to their original engine and reject cross-engine model changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/35)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->