### PR TITLE
Confirm archive and delete sidebar actions

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Added
 
+- **Sidebar archive/delete actions now require an explicit confirmation choice** — pressing `a` opens an Archive/Unarchive confirm before moving a task between Working session and Archives, and destructive delete/remove-saved-repo confirms now default to Cancel so a stray Enter cannot commit the action (KOB-133).
 - **Tasks can start an AI-assisted local merge with `M`** — press Shift+M on a sidebar task to confirm a local merge, create a dedicated Merge chat tab, and inject a prompt that asks the agent to merge the task worktree into the parent repo checkout without creating a PR (KOB-110).
 - **New tasks inherit the active chat model** — creating a task now seeds its first chat tab from the current or last-active chat tab's engine/model/reasoning settings, falling back to defaults only when no prior model config exists (KOB-129).
 - **Resume history shows sessions from every engine** — the resume picker now loads Claude Code and Codex sessions for the task worktree, labels each row with its owning engine, and opens the selected session on the matching engine tab (KOB-130).

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -449,6 +449,7 @@ function Shell(props: AppDeps) {
     confirmRenameTask,
     confirmRenameChatTab,
     confirmDeleteTask,
+    confirmArchiveTask,
     confirmLocalMergeTask,
   } = useTaskActions({
     orchestrator: props.orchestrator,
@@ -563,10 +564,7 @@ function Shell(props: AppDeps) {
               void confirmDeleteTask(id)
             }}
             onArchiveRequest={(id: string) => {
-              void props.orchestrator.setArchived(id).catch((err) => {
-                // eslint-disable-next-line no-console
-                console.error("[kobe] setArchived failed:", err)
-              })
+              void confirmArchiveTask(id)
             }}
             onLocalMergeRequest={(id: string) => {
               void confirmLocalMergeTask(id)

--- a/packages/kobe/src/tui/lib/use-task-actions.ts
+++ b/packages/kobe/src/tui/lib/use-task-actions.ts
@@ -22,6 +22,8 @@
  *   - `confirmDeleteTask(taskId)` — confirms via DialogConfirm; for
  *     pinned "main" tasks it removes the saved-repos entry instead of
  *     deleting the worktree (KOB-15).
+ *   - `confirmArchiveTask(taskId)` — confirms before toggling a task
+ *     between Working session and Archives.
  *   - `confirmLocalMergeTask(taskId)` — confirms the local-merge intent,
  *     then asks the orchestrator to create a Merge chat tab and inject
  *     the merge prompt.
@@ -61,6 +63,7 @@ export type TaskActions = {
   confirmRenameTask: (taskId: string) => Promise<void>
   confirmRenameChatTab: (tabId: string) => Promise<void>
   confirmDeleteTask: (taskId: string) => Promise<void>
+  confirmArchiveTask: (taskId: string) => Promise<void>
   confirmLocalMergeTask: (taskId: string) => Promise<void>
 }
 
@@ -276,6 +279,8 @@ export function useTaskActions(deps: TaskActionsDeps): TaskActions {
         `Remove '${repoLabel}' from saved repos?`,
         `This will remove '${repoLabel}' from your saved repos. The directory and its files stay on disk.`,
         "cancel",
+        "remove",
+        { initialActive: "cancel" },
       )
       if (ok !== true) return
       try {
@@ -293,6 +298,8 @@ export function useTaskActions(deps: TaskActionsDeps): TaskActions {
       `Delete '${task.title}'?`,
       `Removes the worktree at ${task.worktreePath}, deletes the chat history, and removes the task. This cannot be undone. The git branch is kept.`,
       "cancel",
+      "delete",
+      { initialActive: "cancel" },
     )
     if (ok !== true) return
     try {
@@ -303,6 +310,37 @@ export function useTaskActions(deps: TaskActionsDeps): TaskActions {
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error("[kobe] deleteTask failed:", err)
+    }
+  }
+
+  /**
+   * Confirm + archive/unarchive a task. Archive is intentionally
+   * non-destructive, but it hides the row from the default Working
+   * session view, so it still gets an explicit confirmation.
+   */
+  async function confirmArchiveTask(taskId: string): Promise<void> {
+    const task = orchestrator.getTask(taskId)
+    if (!task) return
+    const nextArchived = !task.archived
+    const verb = nextArchived ? "Archive" : "Unarchive"
+    const view = nextArchived ? "Archives" : "Working session"
+    const ok = await DialogConfirm.show(
+      dialog,
+      `${verb} '${task.title}'?`,
+      nextArchived
+        ? "Moves this task to Archives. The worktree, git branch, and chat history stay on disk."
+        : "Moves this task back to Working session.",
+      "cancel",
+      verb.toLowerCase(),
+      { initialActive: "cancel" },
+    )
+    if (ok !== true) return
+    try {
+      await orchestrator.setArchived(taskId, nextArchived)
+      if (!nextArchived) setSelectedId(taskId)
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[kobe] move task to ${view} failed:`, err)
     }
   }
 
@@ -339,6 +377,7 @@ export function useTaskActions(deps: TaskActionsDeps): TaskActions {
     confirmRenameTask,
     confirmRenameChatTab,
     confirmDeleteTask,
+    confirmArchiveTask,
     confirmLocalMergeTask,
   }
 }

--- a/packages/kobe/src/tui/ui/dialog-confirm.tsx
+++ b/packages/kobe/src/tui/ui/dialog-confirm.tsx
@@ -32,14 +32,19 @@ export type DialogConfirmProps = {
   label?: string
   /** Custom label for the confirm button (default: `confirm`). Titlecased on render. */
   confirmLabel?: string
+  /** Which button receives initial keyboard focus (default: `confirm`). */
+  initialActive?: "confirm" | "cancel"
 }
 
 export type DialogConfirmResult = boolean | undefined
+export type DialogConfirmOptions = {
+  initialActive?: "confirm" | "cancel"
+}
 
 export function DialogConfirm(props: DialogConfirmProps) {
   const dialog = useDialog()
   const { theme } = useTheme()
-  const [store, setStore] = createStore({ active: "confirm" as "confirm" | "cancel" })
+  const [store, setStore] = createStore({ active: props.initialActive ?? ("confirm" as "confirm" | "cancel") })
 
   useBindings(() => ({
     bindings: [
@@ -108,6 +113,7 @@ DialogConfirm.show = (
   message: string,
   label?: string,
   confirmLabel?: string,
+  options?: DialogConfirmOptions,
 ): Promise<DialogConfirmResult> => {
   return new Promise<DialogConfirmResult>((resolve) => {
     dialog.replace(
@@ -119,6 +125,7 @@ DialogConfirm.show = (
           onCancel={() => resolve(false)}
           label={label}
           confirmLabel={confirmLabel}
+          initialActive={options?.initialActive}
         />
       ),
       () => resolve(undefined),

--- a/packages/kobe/test/behavior/sidebar-delete.test.ts
+++ b/packages/kobe/test/behavior/sidebar-delete.test.ts
@@ -214,14 +214,18 @@ test("pressing `d` on the sidebar cursor + confirm deletes the task and removes 
   // app.tsx Shell.confirmDeleteTask.
   await kobe.waitFor((s) => s.includes(`Delete '${TITLE}'?`), 10_000)
 
-  // ---- confirm ------------------------------------------------
-  // The DialogConfirm's default `active` is `confirm` (see
-  // src/tui/ui/dialog-confirm.tsx — `active: "confirm"`). app.tsx
-  // passes `"cancel"` as the *label* (button text override), but
-  // does NOT change the default-focused button. Pressing Enter
-  // immediately fires the confirm path. We don't navigate; the
-  // straight-through happy path is what `d` users will hit.
+  // ---- cancel-default guard -----------------------------------
+  // Destructive sidebar confirms default to Cancel. A fast `d` +
+  // Enter must not delete anything.
   await new Promise((r) => setTimeout(r, 100))
+  await kobe.sendKeys("\r")
+  await new Promise((r) => setTimeout(r, 250))
+  expect(fs.existsSync(created.worktreePath)).toBe(true)
+
+  // ---- confirm ------------------------------------------------
+  await kobe.sendKeys("d")
+  await kobe.waitFor((s) => s.includes(`Delete '${TITLE}'?`), 10_000)
+  await kobe.sendKeys("\x1b[C") // right arrow: Cancel -> Delete
   await kobe.sendKeys("\r")
 
   // ---- assertions ---------------------------------------------
@@ -246,6 +250,88 @@ test("pressing `d` on the sidebar cursor + confirm deletes the task and removes 
   const afterRaw = fs.readFileSync(manifestPath, "utf8")
   const after = JSON.parse(afterRaw) as { tasks: { id: string }[] }
   expect(after.tasks.find((t) => t.id === created.id)).toBeUndefined()
+
+  await kobe.exit()
+  expect(kobe.closed).toBe(true)
+}, 90_000)
+
+test("pressing `a` confirms before archiving a task", async () => {
+  // ---- fixtures ------------------------------------------------
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-sidebar-archive-"))
+  homeDir = path.join(tmpRoot, "home")
+  fs.mkdirSync(homeDir, { recursive: true })
+  repo = path.join(tmpRoot, "my-frontend")
+  const initResult = spawnSync("bash", [REPO_INIT, repo], { encoding: "utf8" })
+  if (initResult.status !== 0) {
+    throw new Error(`repo-init.sh failed: ${initResult.stderr}\n${initResult.stdout}`)
+  }
+  const port = await pickFreePort()
+
+  // ---- spawn kobe ----------------------------------------------
+  kobe = await spawnKobe({
+    env: {
+      KOBE_TEST_ENGINE: "fake",
+      KOBE_TEST_FAKE_PORT: String(port),
+      KOBE_HOME_DIR: homeDir,
+    },
+    cols: 120,
+    rows: 30,
+  })
+
+  await kobe.waitFor((s) => s.includes("KobeCode"), 10_000)
+  await waitForFakeServer(port)
+
+  await scriptEngine(port, "/script", {
+    sessionId: "fake-1",
+    events: [{ type: "done" }],
+  })
+  await scriptEngine(port, "/finish", { sessionId: "fake-1" })
+
+  const TITLE = "archive-me"
+  await kobe.createTask(repo)
+  await new Promise((r) => setTimeout(r, 250))
+  await kobe.typeText(TITLE)
+  await kobe.sendKeys("\r")
+  await kobe.waitFor((s) => s.includes(TITLE), 15_000)
+
+  const manifestPath = path.join(homeDir, ".kobe", "tasks.json")
+  await waitForManifestPopulated(manifestPath, 15_000)
+  const created = JSON.parse(fs.readFileSync(manifestPath, "utf8")).tasks[0] as { id: string; archived: boolean }
+  expect(created.archived).toBe(false)
+
+  // Focus sidebar, then open archive confirm on the selected task.
+  await kobe.sendKeys("\x11")
+  await new Promise((r) => setTimeout(r, 250))
+  await kobe.sendKeys("a")
+  await kobe.waitFor((s) => s.includes(`Archive '${TITLE}'?`), 10_000)
+  const dialogScreen = await kobe.capture()
+  expect(dialogScreen).toContain("Moves this task to Archives")
+
+  // Enter defaults to Cancel, so the task stays in Working session.
+  await kobe.sendKeys("\r")
+  await new Promise((r) => setTimeout(r, 250))
+  let after = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+    tasks: { id: string; archived: boolean }[]
+  }
+  expect(after.tasks.find((t) => t.id === created.id)?.archived).toBe(false)
+
+  // Explicitly move focus to the Archive button, then confirm.
+  await kobe.sendKeys("a")
+  await kobe.waitFor((s) => s.includes(`Archive '${TITLE}'?`), 10_000)
+  await kobe.sendKeys("\x1b[C")
+  await kobe.sendKeys("\r")
+  await waitForCondition(() => {
+    try {
+      const data = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+        tasks: { id: string; archived: boolean }[]
+      }
+      return data.tasks.find((t) => t.id === created.id)?.archived === true
+    } catch {
+      return false
+    }
+  }, 10_000)
+  after = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as { tasks: { id: string; archived: boolean }[] }
+  expect(after.tasks.find((t) => t.id === created.id)?.archived).toBe(true)
 
   await kobe.exit()
   expect(kobe.closed).toBe(true)


### PR DESCRIPTION
Adds explicit confirmation before sidebar archive/unarchive and makes destructive delete/remove-saved-repo confirmations default to Cancel so a stray Enter cannot commit the action.
The behavior test now covers both cancel-default and explicit-confirm paths for delete and archive.
This branch is based before KOB-132, so the current PR diff also removes the GitHub PR readiness tracking/status plumbing that exists on main.
Validated with typecheck, lint, targeted sidebar behavior tests, use-task-actions unit tests, build, and a TUI smoke launch.
