### PR TITLE
feat: KOB-149 — sidebar fuzzy search (/ to filter tasks)

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -61,6 +61,7 @@ site — they should agree.
 | `tab`            | pane cycle vs textarea focus actions    | `useKobeKeybindings` no-ops `tab` when workspace has focus so the composer's own tab handling (slash completion, indent) wins.                                                      |
 | `[` / `]`        | sidebar view switch vs files tab cycle  | Both pane-scoped (different scopes), so the focused pane wins.                                                                                                                      |
 | `ctrl+[` / `ctrl+]` | chat tab cycle vs new-task dialog sub-tab cycle | Dialog-local handler wins while the New Task dialog is open. App-level workspace bindings are gated `enabled: dialog.stack.length === 0`, so the dialog's `useBindings` registration intercepts the chord first and toggles between the "For Existing" and "For New Repo" sub-tabs. Closing the dialog restores the chat-tab cycle. |
+| sidebar letter chords (`j`/`k`/`g`/`G`/`d`/`a`/`r`/`P`/`m`) vs `/`-search typing | Letter chords are registered in a sidebar-scoped `useBindings` block gated `enabled: focused() && !searchMode()`. When `/` enters search mode the block de-registers, so subsequent letter keys fall through to the inline search input as literal text. `[` / `]` view switch lives in a separate always-on block and keeps firing during search. A second search-only block registers `up`/`down` (filtered-list nav), `enter` (commit), and `esc` (cancel + restore prior selection). |
 
 ## tmux passthrough
 

--- a/packages/kobe/src/tui/app-keymap.tsx
+++ b/packages/kobe/src/tui/app-keymap.tsx
@@ -83,6 +83,15 @@ export type AppKeymapDeps = {
   activeTask: Accessor<Task | undefined>
   /** Open the active task's worktree in the detected editor. */
   openActiveTaskInEditor: () => void
+  /**
+   * Whether the sidebar's `/`-search filter is currently active. Gates
+   * the plain-letter sidebar chords (`n` / `s` / `q`) off — without
+   * this, typing those letters into the search query would fire the
+   * chord and steal the keystroke from the inline search input.
+   * Optional so embedders that don't mount the sidebar (tests) just
+   * get the unconditional behavior.
+   */
+  sidebarSearchActive?: Accessor<boolean>
 }
 
 /* --------------------------------------------------------------------- */
@@ -149,8 +158,10 @@ export function useAppKeymap(deps: AppKeymapDeps): void {
   // the SIDEBAR is focused — single-letter chords would otherwise
   // collide with composer typing. Once on the sidebar, `n` opens
   // the new-task dialog, `q` opens quit-confirm, `s` opens settings.
+  // Also gated off while the sidebar's `/`-search is active so the
+  // letters reach the inline search input as literal text.
   useBindings(() => ({
-    enabled: focusedPane() === "sidebar" && dialog.stack.length === 0,
+    enabled: focusedPane() === "sidebar" && dialog.stack.length === 0 && !(deps.sidebarSearchActive?.() ?? false),
     bindings: bindByIds({
       "task.new": () => {
         void deps.openNewTaskFlow()

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -466,6 +466,13 @@ function Shell(props: AppDeps) {
   // app-keymap.tsx so the priority stack + scope rationale are
   // visible in one place. See that file for the registration order
   // and the rule about plain-letter vs modifier-prefixed chords.
+  // Mirror of the sidebar's `/`-search active flag, lifted here so the
+  // app keymap can gate the sidebar-scope plain-letter chords (n/s/q)
+  // off while the user is typing in the search input. The Sidebar
+  // component still owns the underlying signal; this is a one-way
+  // observer wired via its `onSearchActiveChange` callback.
+  const [sidebarSearchActive, setSidebarSearchActive] = createSignal(false)
+
   useAppKeymap({
     dialog,
     focusedPane,
@@ -480,6 +487,7 @@ function Shell(props: AppDeps) {
     onQuit: quit,
     activeTask,
     openActiveTaskInEditor,
+    sidebarSearchActive,
   })
 
   // Per-ChatTab completion notifications.
@@ -579,6 +587,7 @@ function Shell(props: AppDeps) {
               })
             }}
             onAddTask={() => void openNewTaskFlow()}
+            onSearchActiveChange={(active: boolean) => setSidebarSearchActive(active)}
             selectedId={selectedId}
             focused={isFocused("sidebar")}
           />

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -393,6 +393,48 @@ export const KobeKeymap: readonly KobeBinding[] = [
     description: "Delete task (with confirm)",
     hint: { keys: "d", label: "delete" },
   },
+  {
+    // `/`-search filter. Enters an inline search mode rendered at the
+    // top of the sidebar: typed text fuzz-matches against task title +
+    // repo basename, up/down navigates the filtered list, enter selects
+    // + exits, esc cancels + restores. While search is active the
+    // single-letter sidebar chords (j/k/g/G/d/a/r/P/m) are
+    // de-registered so they fall through to the input as literal text.
+    // `[` / `]` view switch keeps working so the user can search inside
+    // Archives.
+    id: "sidebar.search.enter",
+    scope: "sidebar",
+    keys: ["/"],
+    category: "Sidebar",
+    description: "Search tasks (fuzzy filter)",
+    hint: { keys: "/", label: "search" },
+  },
+  {
+    // Search-mode nav. Only fires while the search input is focused —
+    // j/k are intentionally NOT bound here so they reach the input.
+    id: "sidebar.search.nav",
+    scope: "sidebar",
+    keys: ["down", "up"],
+    category: "Sidebar",
+    description: "Move highlight in search results",
+  },
+  {
+    // Search-mode submit: select highlighted match and leave search.
+    id: "sidebar.search.submit",
+    scope: "sidebar",
+    keys: ["return"],
+    category: "Sidebar",
+    description: "Select search match and exit search",
+  },
+  {
+    // Search-mode cancel. Only registered while searching; outside
+    // search there is no sidebar-scope esc handler.
+    id: "sidebar.search.cancel",
+    scope: "sidebar",
+    keys: ["escape"],
+    category: "Sidebar",
+    description: "Cancel search (restore prior selection)",
+  },
 
   // ─── Workspace (chat) ─────────────────────────────────────────────────
   {

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -145,6 +145,40 @@ export function Sidebar(props: SidebarProps) {
   // through `VIEW_TABS`.
   const [view, setView] = createSignal<SidebarView>("active")
 
+  // `/`-search state. `searchMode` flips on when the user presses `/`
+  // and back off when they press enter (commits a selection) or esc
+  // (cancels). The query is fuzz-matched against task title + repo
+  // basename inside `buildRows`. While the mode is on, the inline
+  // input row is rendered above the view switcher and the sidebar's
+  // single-letter chords are de-registered (see keys.ts) so typed
+  // letters reach the input rather than firing j/k/g/d/a/r/P/m.
+  //
+  // `prevSelectedIdBeforeSearch` is snapshotted on enter so esc can
+  // restore the user to the task they were looking at before they
+  // started searching — otherwise the cursor would drift to wherever
+  // the last filtered match left it.
+  const [searchMode, setSearchMode] = createSignal(false)
+  const [searchQuery, setSearchQuery] = createSignal("")
+  let prevSelectedIdBeforeSearch: string | null = null
+
+  function enterSearch(): void {
+    prevSelectedIdBeforeSearch = props.selectedId()
+    setSearchQuery("")
+    setSearchMode(true)
+  }
+  function exitSearch(select: boolean): void {
+    setSearchMode(false)
+    setSearchQuery("")
+    // On esc-cancel, re-select the task that was active before the user
+    // entered search mode. On enter-commit (`select=true`),
+    // ctrl.selectCurrent() already fired in the keys handler so the
+    // parent's selectedId is up to date — leave it alone.
+    if (!select && prevSelectedIdBeforeSearch !== null) {
+      props.onSelect(prevSelectedIdBeforeSearch)
+    }
+    prevSelectedIdBeforeSearch = null
+  }
+
   // Tick that busts each main row's branch-name memo on a fixed
   // interval. Cheap (one signal write per tick); the actual git call
   // only happens when a row is visible and re-renders. We deliberately
@@ -161,8 +195,10 @@ export function Sidebar(props: SidebarProps) {
   void branchInterval
 
   // Filtered, flat row list for the active view. Recomputes only when
-  // the upstream tasks accessor or the view changes.
-  const rows = createMemo(() => buildRows(props.tasks(), view()))
+  // the upstream tasks accessor, the view, or the search query
+  // changes. Search query is only applied when `searchMode` is on so
+  // we don't keep filtering against stale query text after esc-cancel.
+  const rows = createMemo(() => buildRows(props.tasks(), view(), searchMode() ? searchQuery() : ""))
   const flatIds = createMemo(() => flattenIds(rows()))
 
   const [cursorIndex, setCursorIndex] = createSignal<number>(-1)
@@ -199,6 +235,17 @@ export function Sidebar(props: SidebarProps) {
     }),
   )
 
+  // Reset cursor to 0 on every search query keystroke — keeps the
+  // highlight landed on the top match instead of stranding it on a
+  // now-hidden row. Only runs while search mode is on.
+  createEffect(
+    on([searchMode, searchQuery], () => {
+      if (!searchMode()) return
+      const ids = flatIds()
+      setCursorIndex(ids.length > 0 ? 0 : -1)
+    }),
+  )
+
   /**
    * Cycle the view by `delta` (-1 = `[` / left, +1 = `]` / right). Wraps:
    * `[` from the leftmost lands on the rightmost and vice versa. Today
@@ -229,6 +276,9 @@ export function Sidebar(props: SidebarProps) {
     onRenameRequest: (id) => props.onRenameRequest?.(id),
     onPinRequest: (id) => props.onPinRequest?.(id),
     onViewSwitch: (delta) => cycleView(delta),
+    searchMode,
+    onSearchEnter: () => enterSearch(),
+    onSearchExit: (select) => exitSearch(select),
   })
 
   return (
@@ -271,6 +321,26 @@ export function Sidebar(props: SidebarProps) {
           TASKS
         </text>
       </box>
+
+      {/* Inline `/`-search input. Only rendered while searchMode is on
+         (entered via `/`); de-rendering on exit keeps the row count
+         stable for users not using search. The input is auto-focused
+         so the user can start typing immediately; up/down/enter/esc
+         are handled by the sidebar-scope search bindings in keys.ts,
+         not by the input itself. */}
+      <Show when={searchMode()}>
+        <box flexDirection="row" gap={0} paddingBottom={1} paddingLeft={1}>
+          <text fg={theme.info} wrapMode="none">
+            /
+          </text>
+          <input
+            value={searchQuery()}
+            placeholder="fuzzy filter"
+            focused={true}
+            onInput={(v: string) => setSearchQuery(v.replace(/[\r\n]+/g, ""))}
+          />
+        </box>
+      </Show>
 
       {/* View switcher: tab strip with the active view bracketed +
          emphasized. `[` / `]` toggles. */}
@@ -376,7 +446,13 @@ export function Sidebar(props: SidebarProps) {
           </For>
           <Show when={flatIds().length === 0}>
             <box paddingTop={1} paddingLeft={1}>
-              <text fg={theme.textMuted}>{view() === "active" ? "No active tasks." : "No archived tasks."}</text>
+              <text fg={theme.textMuted}>
+                {searchMode() && searchQuery().trim().length > 0
+                  ? "No matching tasks."
+                  : view() === "active"
+                    ? "No active tasks."
+                    : "No archived tasks."}
+              </text>
             </box>
           </Show>
         </box>

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -351,30 +351,41 @@ export function Sidebar(props: SidebarProps) {
          so the user can start typing immediately; up/down/enter/esc
          are handled by the sidebar-scope search bindings in keys.ts,
          not by the input itself. */}
-      <Show when={searchMode()}>
-        <box flexDirection="row" gap={0} paddingBottom={1} paddingLeft={1}>
+      {/* Inline `/`-search row. The input is ALWAYS mounted so opentui's
+         keyboard-focus tree already knows about it when `searchMode`
+         flips on — `focused={searchMode()}` then synchronously calls
+         `node.focus()` via opentui-solid's prop binding before the
+         user's next keystroke arrives. Earlier versions wrapped the
+         input in `<Show>` and the mount-and-focus happened in the
+         same tick as the `/` keystroke; the next char (e.g. `g`)
+         arrived before opentui had wired focus to the freshly-mounted
+         element, so it landed on no focused element and was dropped.
+         Now the row is height-collapsed to 0 when search is off and
+         the input is blurred — same visual result without the race. */}
+      <box
+        flexDirection="row"
+        gap={0}
+        paddingBottom={searchMode() ? 1 : 0}
+        paddingLeft={1}
+        height={searchMode() ? 1 : 0}
+        overflow="hidden"
+      >
+        <Show when={searchMode()}>
           <text fg={theme.info} wrapMode="none">
             /
           </text>
-          <input
-            ref={(el: { focus(): void } | undefined) => {
-              searchInputEl = el
-              // Eager focus on first mount. The queueMicrotask path in
-              // enterSearch() handles the race when this ref fires
-              // before opentui has wired the new element into its
-              // keyboard-focus tree; calling .focus() here as well is
-              // a no-op when the input already has focus, but covers
-              // the case where Solid's commit happens before
-              // queueMicrotask drains.
-              el?.focus()
-            }}
-            value={searchQuery()}
-            placeholder="fuzzy filter"
-            focused={true}
-            onInput={(v: string) => setSearchQuery(v.replace(/[\r\n]+/g, ""))}
-          />
-        </box>
-      </Show>
+        </Show>
+        <input
+          ref={(el: { focus(): void } | undefined) => {
+            searchInputEl = el
+            if (searchMode()) el?.focus()
+          }}
+          value={searchQuery()}
+          placeholder="fuzzy filter"
+          focused={searchMode()}
+          onInput={(v: string) => setSearchQuery(v.replace(/[\r\n]+/g, ""))}
+        />
+      </box>
 
       {/* View switcher: tab strip with the active view bracketed +
          emphasized. `[` / `]` toggles. */}

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -49,8 +49,10 @@
  */
 
 import type { Task, TaskStatus } from "@/types/task"
+import type { KeyEvent } from "@opentui/core"
 import { TextAttributes } from "@opentui/core"
-import { type Accessor, For, Show, createEffect, createMemo, createSignal, on, untrack } from "solid-js"
+import { useRenderer } from "@opentui/solid"
+import { type Accessor, For, Show, createEffect, createMemo, createSignal, on, onCleanup, untrack } from "solid-js"
 import { SIDEBAR_WIDTH } from "../../component/sidebar"
 import { useTheme } from "../../context/theme"
 import { readCurrentBranch } from "./git-head"
@@ -168,41 +170,67 @@ export function Sidebar(props: SidebarProps) {
   // the last filtered match left it.
   const [searchMode, setSearchMode] = createSignal(false)
   const [searchQuery, setSearchQuery] = createSignal("")
-  let prevSelectedIdBeforeSearch: string | null = null
-  // Imperative handle on the inline search input. We DON'T bind the
-  // `value` prop reactively (`value={searchQuery()}`): each keystroke
-  // would round-trip user-type → insertText → emit input → onInput
-  // → setSearchQuery → Solid re-render → node.value setter with the
-  // same string. In practice that round-trip dropped the visible
-  // typed text on the renderer's next paint — placeholder vanished
-  // (so the keystroke was processed) but the typed char never showed
-  // up. opentui's InputRenderable owns its own buffer; we read from
-  // it via `onInput` and write to it imperatively via this ref (only
-  // when clearing on enterSearch / exitSearch).
-  let searchInputEl: ({ focus(): void } & { value: string }) | undefined
 
   function enterSearch(): void {
-    prevSelectedIdBeforeSearch = props.selectedId()
     setSearchQuery("")
-    if (searchInputEl) searchInputEl.value = ""
     setSearchMode(true)
     props.onSearchActiveChange?.(true)
-    queueMicrotask(() => searchInputEl?.focus())
   }
-  function exitSearch(select: boolean): void {
+  function exitSearch(_select: boolean): void {
+    // Both enter (`select=true`) and esc (`select=false`) just close
+    // the search row. On enter, ctrl.selectCurrent has already fired
+    // in keys.ts and set selectedId to the highlighted match; on esc
+    // we leave selectedId alone — only the cursor moved during the
+    // search, and the cursor-sync effect will glide back to the
+    // already-selected task once `flatIds` returns to the unfiltered
+    // list. We DON'T call props.onSelect on exit because the host
+    // (app.tsx) pulls focus to the workspace on every select, which
+    // is wrong for an esc — the user wanted to stay in the sidebar.
     setSearchMode(false)
     setSearchQuery("")
-    if (searchInputEl) searchInputEl.value = ""
-    // On esc-cancel, re-select the task that was active before the user
-    // entered search mode. On enter-commit (`select=true`),
-    // ctrl.selectCurrent() already fired in the keys handler so the
-    // parent's selectedId is up to date — leave it alone.
-    if (!select && prevSelectedIdBeforeSearch !== null) {
-      props.onSelect(prevSelectedIdBeforeSearch)
-    }
-    prevSelectedIdBeforeSearch = null
     props.onSearchActiveChange?.(false)
   }
+
+  // Search-mode keystroke capture. We render the query as a plain
+  // `<text>` rather than using opentui's `<input>` element — earlier
+  // attempts with `<input>` ran into a stack of issues we couldn't
+  // pin down (chars eaten on mount-race; reactive value prop wiping
+  // the buffer on every keystroke; placeholder leaking into the
+  // workspace after exit). A custom text-based input bypasses all of
+  // it: when search mode is on, we subscribe to the renderer's
+  // global keypress event, append printable chars to `searchQuery`,
+  // and let `<text>{searchQuery()}</text>` re-render via Solid.
+  //
+  // The listener runs AFTER the keymap dispatch (which registers
+  // first), so chords that already fired `preventDefault` are
+  // skipped. Non-printable / modifier-prefixed keys are ignored.
+  // Backspace pops the last char.
+  createEffect(() => {
+    if (!searchMode()) return
+    const r = useRenderer()
+    if (!r) return
+    const listener = (evt: KeyEvent): void => {
+      if (evt.defaultPrevented) return
+      if (!focusedAccessor()) return
+      if (evt.ctrl || evt.meta || evt.option) return
+      if (evt.name === "backspace") {
+        setSearchQuery((q) => q.slice(0, -1))
+        return
+      }
+      // Printable single chars only — opentui's KeyEvent.sequence
+      // holds the raw byte that arrived; non-printables (esc, arrows,
+      // function keys) have multi-byte sequences or names like
+      // "escape" / "return" / "up" that we already handle through
+      // Block C bindings.
+      const seq = evt.sequence
+      if (!seq || seq.length !== 1) return
+      const code = seq.charCodeAt(0)
+      if (code < 32 || code === 127) return
+      setSearchQuery((q) => q + seq)
+    }
+    r.keyInput.on("keypress", listener)
+    onCleanup(() => r.keyInput.off("keypress", listener))
+  })
 
   // Tick that busts each main row's branch-name memo on a fixed
   // interval. Cheap (one signal write per tick); the actual git call
@@ -353,29 +381,29 @@ export function Sidebar(props: SidebarProps) {
          so the user can start typing immediately; up/down/enter/esc
          are handled by the sidebar-scope search bindings in keys.ts,
          not by the input itself. */}
-      {/* Inline `/`-search row. Fully `<Show>`'d so the input element
-         is unmounted while search is inactive — earlier always-mount
-         + height=0 left the placeholder bleeding into the workspace
-         below because opentui doesn't fully suppress a zero-height
-         input's layout box. The first-char-after-`/` race that
-         originally pushed us to always-mount turned out to be a
-         different bug (a reactive `value` prop double-writing the
-         buffer); with that prop removed the ref-based imperative
-         focus is enough. */}
+      {/* Inline `/`-search row. Rendered as plain text rather than
+         an opentui `<input>` element so the typed query is fully
+         controlled by our `searchQuery` signal — see the
+         createEffect above that captures keystrokes from the global
+         keypress event. Avoids the focus/value-prop quirks of
+         InputRenderable in a conditionally-mounted slot. */}
       <Show when={searchMode()}>
         <box flexDirection="row" gap={0} paddingBottom={1} paddingLeft={1}>
           <text fg={theme.info} wrapMode="none">
             /
           </text>
-          <input
-            ref={(el: ({ focus(): void } & { value: string }) | undefined) => {
-              searchInputEl = el
-              el?.focus()
-            }}
-            placeholder="fuzzy filter"
-            focused={true}
-            onInput={(v: string) => setSearchQuery(v.replace(/[\r\n]+/g, ""))}
-          />
+          <text fg={theme.text} wrapMode="none">
+            {searchQuery()}
+          </text>
+          <text fg={theme.info} attributes={TextAttributes.BLINK} wrapMode="none">
+            █
+          </text>
+          <Show when={searchQuery().length === 0}>
+            <text fg={theme.textMuted} wrapMode="none">
+              {" "}
+              fuzzy filter
+            </text>
+          </Show>
         </box>
       </Show>
 

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -169,21 +169,22 @@ export function Sidebar(props: SidebarProps) {
   const [searchMode, setSearchMode] = createSignal(false)
   const [searchQuery, setSearchQuery] = createSignal("")
   let prevSelectedIdBeforeSearch: string | null = null
-  // Imperative handle on the inline search input so we can call
-  // `.focus()` after the input mounts. opentui's declarative
-  // `focused={true}` prop wasn't enough on its own: the `<Show>`
-  // wrapper meant the input mounted on the same tick that `/`
-  // triggered enterSearch(), and opentui's keyboard focus didn't
-  // propagate to the new element before the user's next keystroke
-  // arrived — the first char after `/` got dropped because nothing
-  // was holding focus. Calling focus() through this ref on the
-  // microtask queue lets Solid commit the mount first, then forces
-  // focus before the next stdin event lands.
-  let searchInputEl: { focus(): void } | undefined
+  // Imperative handle on the inline search input. We DON'T bind the
+  // `value` prop reactively (`value={searchQuery()}`): each keystroke
+  // would round-trip user-type → insertText → emit input → onInput
+  // → setSearchQuery → Solid re-render → node.value setter with the
+  // same string. In practice that round-trip dropped the visible
+  // typed text on the renderer's next paint — placeholder vanished
+  // (so the keystroke was processed) but the typed char never showed
+  // up. opentui's InputRenderable owns its own buffer; we read from
+  // it via `onInput` and write to it imperatively via this ref (only
+  // when clearing on enterSearch / exitSearch).
+  let searchInputEl: ({ focus(): void } & { value: string }) | undefined
 
   function enterSearch(): void {
     prevSelectedIdBeforeSearch = props.selectedId()
     setSearchQuery("")
+    if (searchInputEl) searchInputEl.value = ""
     setSearchMode(true)
     props.onSearchActiveChange?.(true)
     queueMicrotask(() => searchInputEl?.focus())
@@ -191,6 +192,7 @@ export function Sidebar(props: SidebarProps) {
   function exitSearch(select: boolean): void {
     setSearchMode(false)
     setSearchQuery("")
+    if (searchInputEl) searchInputEl.value = ""
     // On esc-cancel, re-select the task that was active before the user
     // entered search mode. On enter-commit (`select=true`),
     // ctrl.selectCurrent() already fired in the keys handler so the
@@ -376,11 +378,10 @@ export function Sidebar(props: SidebarProps) {
           </text>
         </Show>
         <input
-          ref={(el: { focus(): void } | undefined) => {
+          ref={(el: ({ focus(): void } & { value: string }) | undefined) => {
             searchInputEl = el
             if (searchMode()) el?.focus()
           }}
-          value={searchQuery()}
           placeholder="fuzzy filter"
           focused={searchMode()}
           onInput={(v: string) => setSearchQuery(v.replace(/[\r\n]+/g, ""))}

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -169,12 +169,24 @@ export function Sidebar(props: SidebarProps) {
   const [searchMode, setSearchMode] = createSignal(false)
   const [searchQuery, setSearchQuery] = createSignal("")
   let prevSelectedIdBeforeSearch: string | null = null
+  // Imperative handle on the inline search input so we can call
+  // `.focus()` after the input mounts. opentui's declarative
+  // `focused={true}` prop wasn't enough on its own: the `<Show>`
+  // wrapper meant the input mounted on the same tick that `/`
+  // triggered enterSearch(), and opentui's keyboard focus didn't
+  // propagate to the new element before the user's next keystroke
+  // arrived — the first char after `/` got dropped because nothing
+  // was holding focus. Calling focus() through this ref on the
+  // microtask queue lets Solid commit the mount first, then forces
+  // focus before the next stdin event lands.
+  let searchInputEl: { focus(): void } | undefined
 
   function enterSearch(): void {
     prevSelectedIdBeforeSearch = props.selectedId()
     setSearchQuery("")
     setSearchMode(true)
     props.onSearchActiveChange?.(true)
+    queueMicrotask(() => searchInputEl?.focus())
   }
   function exitSearch(select: boolean): void {
     setSearchMode(false)
@@ -345,6 +357,17 @@ export function Sidebar(props: SidebarProps) {
             /
           </text>
           <input
+            ref={(el: { focus(): void } | undefined) => {
+              searchInputEl = el
+              // Eager focus on first mount. The queueMicrotask path in
+              // enterSearch() handles the race when this ref fires
+              // before opentui has wired the new element into its
+              // keyboard-focus tree; calling .focus() here as well is
+              // a no-op when the input already has focus, but covers
+              // the case where Solid's commit happens before
+              // queueMicrotask drains.
+              el?.focus()
+            }}
             value={searchQuery()}
             placeholder="fuzzy filter"
             focused={true}

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -90,6 +90,15 @@ export type SidebarProps = {
    */
   onAddTask?: () => void
   /**
+   * Fires when the `/`-search filter opens or closes. Lifted out of
+   * the sidebar so the app-level Shell can gate its sidebar-scoped
+   * plain-letter bindings (`n` / `s` / `q` in app-keymap.tsx) on
+   * `!sidebarSearchActive()` — otherwise typing `n` / `s` / `q` into
+   * the search query would fire those chords and steal the
+   * keystroke before it could reach the input.
+   */
+  onSearchActiveChange?: (active: boolean) => void
+  /**
    * Optional width override. When omitted, falls back to {@link SIDEBAR_WIDTH}.
    * Wired by the Shell so the sidebar↔workspace splitter can resize the pane
    * at runtime. Reactive — changing the accessor's value reflows immediately.
@@ -165,6 +174,7 @@ export function Sidebar(props: SidebarProps) {
     prevSelectedIdBeforeSearch = props.selectedId()
     setSearchQuery("")
     setSearchMode(true)
+    props.onSearchActiveChange?.(true)
   }
   function exitSearch(select: boolean): void {
     setSearchMode(false)
@@ -177,6 +187,7 @@ export function Sidebar(props: SidebarProps) {
       props.onSelect(prevSelectedIdBeforeSearch)
     }
     prevSelectedIdBeforeSearch = null
+    props.onSearchActiveChange?.(false)
   }
 
   // Tick that busts each main row's branch-name memo on a fixed

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -353,40 +353,31 @@ export function Sidebar(props: SidebarProps) {
          so the user can start typing immediately; up/down/enter/esc
          are handled by the sidebar-scope search bindings in keys.ts,
          not by the input itself. */}
-      {/* Inline `/`-search row. The input is ALWAYS mounted so opentui's
-         keyboard-focus tree already knows about it when `searchMode`
-         flips on — `focused={searchMode()}` then synchronously calls
-         `node.focus()` via opentui-solid's prop binding before the
-         user's next keystroke arrives. Earlier versions wrapped the
-         input in `<Show>` and the mount-and-focus happened in the
-         same tick as the `/` keystroke; the next char (e.g. `g`)
-         arrived before opentui had wired focus to the freshly-mounted
-         element, so it landed on no focused element and was dropped.
-         Now the row is height-collapsed to 0 when search is off and
-         the input is blurred — same visual result without the race. */}
-      <box
-        flexDirection="row"
-        gap={0}
-        paddingBottom={searchMode() ? 1 : 0}
-        paddingLeft={1}
-        height={searchMode() ? 1 : 0}
-        overflow="hidden"
-      >
-        <Show when={searchMode()}>
+      {/* Inline `/`-search row. Fully `<Show>`'d so the input element
+         is unmounted while search is inactive — earlier always-mount
+         + height=0 left the placeholder bleeding into the workspace
+         below because opentui doesn't fully suppress a zero-height
+         input's layout box. The first-char-after-`/` race that
+         originally pushed us to always-mount turned out to be a
+         different bug (a reactive `value` prop double-writing the
+         buffer); with that prop removed the ref-based imperative
+         focus is enough. */}
+      <Show when={searchMode()}>
+        <box flexDirection="row" gap={0} paddingBottom={1} paddingLeft={1}>
           <text fg={theme.info} wrapMode="none">
             /
           </text>
-        </Show>
-        <input
-          ref={(el: ({ focus(): void } & { value: string }) | undefined) => {
-            searchInputEl = el
-            if (searchMode()) el?.focus()
-          }}
-          placeholder="fuzzy filter"
-          focused={searchMode()}
-          onInput={(v: string) => setSearchQuery(v.replace(/[\r\n]+/g, ""))}
-        />
-      </box>
+          <input
+            ref={(el: ({ focus(): void } & { value: string }) | undefined) => {
+              searchInputEl = el
+              el?.focus()
+            }}
+            placeholder="fuzzy filter"
+            focused={true}
+            onInput={(v: string) => setSearchQuery(v.replace(/[\r\n]+/g, ""))}
+          />
+        </box>
+      </Show>
 
       {/* View switcher: tab strip with the active view bracketed +
          emphasized. `[` / `]` toggles. */}

--- a/packages/kobe/src/tui/panes/sidebar/fuzzy.ts
+++ b/packages/kobe/src/tui/panes/sidebar/fuzzy.ts
@@ -1,0 +1,26 @@
+/**
+ * Fuzzy match for the sidebar's `/`-search.
+ *
+ * Algorithm: case-insensitive subsequence test. Every character of the
+ * query must appear in the haystack in order, gaps allowed. No scoring
+ * — the caller preserves the original ordering of survivors, which
+ * matches the sidebar's existing "main → pinned → regular" partition.
+ *
+ *   fuzzyMatch("kbe", "kobe")              → true
+ *   fuzzyMatch("kbe", "berserk")           → false  (order matters)
+ *   fuzzyMatch("CSK", "closure-stack-k8s") → true   (case-insensitive)
+ *   fuzzyMatch("", anything)               → true   (empty query passes)
+ *
+ * Pure: no Solid, no opentui, no fs. Unit-tested at
+ * `test/tui/sidebar/fuzzy.test.ts`.
+ */
+export function fuzzyMatch(query: string, haystack: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  const h = haystack.toLowerCase()
+  let qi = 0
+  for (let hi = 0; hi < h.length && qi < q.length; hi++) {
+    if (h.charCodeAt(hi) === q.charCodeAt(qi)) qi++
+  }
+  return qi === q.length
+}

--- a/packages/kobe/src/tui/panes/sidebar/groups.ts
+++ b/packages/kobe/src/tui/panes/sidebar/groups.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Task } from "@/types/task"
+import { fuzzyMatch } from "./fuzzy"
 
 /**
  * Which sidebar view is active. Rendered as a tab strip at the top of
@@ -60,6 +61,12 @@ export function filterByView(tasks: readonly Task[], view: SidebarView): Task[] 
  * Archived view: same structure (main rows the user archived float to
  * the top of the archives list), still ordered by repo basename.
  *
+ * `searchQuery` — optional case-insensitive subsequence filter applied
+ * after view filtering, before grouping. Haystack per task is
+ * `title + " " + basename(repo)`. Empty / undefined query is a no-op.
+ * Search preserves the main → pinned → regular ordering so users
+ * filtering inside a long list still see the same predictable shape.
+ *
  * Why two passes rather than a single sort: the regular-task ordering
  * is owned by the orchestrator (createdAt-derived ULID order), and
  * sorting both groups together would scramble it. A stable partition
@@ -72,8 +79,12 @@ export function filterByView(tasks: readonly Task[], view: SidebarView): Task[] 
  * Pure: no Solid, no opentui. Component code calls this inside a memo;
  * tests call it directly.
  */
-export function buildRows(tasks: readonly Task[], view: SidebarView): SidebarRow[] {
-  const filtered = filterByView(tasks, view)
+export function buildRows(tasks: readonly Task[], view: SidebarView, searchQuery?: string): SidebarRow[] {
+  const filteredByView = filterByView(tasks, view)
+  const q = searchQuery?.trim() ?? ""
+  const filtered = q
+    ? filteredByView.filter((t) => fuzzyMatch(q, `${t.title} ${repoBasename(t.repo)}`))
+    : filteredByView
   const main: Task[] = []
   const pinnedRegular: Task[] = []
   const regular: Task[] = []

--- a/packages/kobe/src/tui/panes/sidebar/keys.ts
+++ b/packages/kobe/src/tui/panes/sidebar/keys.ts
@@ -103,6 +103,30 @@ export type SidebarBindingsOpts = {
    * (+1, "next view"). The parent owns the active-view signal.
    */
   onViewSwitch?: (delta: -1 | 1) => void
+  /**
+   * Whether the `/`-search filter is currently active. When true, the
+   * sidebar's single-letter chords (j/k/g/G/d/a/r/P/m) are de-registered
+   * so the user's typing fills the search query input instead of
+   * triggering chords. Non-letter chords (`[`, `]` view switch) keep
+   * firing — the user is allowed to switch view while searching.
+   * Defaults to () => false; sidebars that don't wire search just get
+   * the legacy behaviour.
+   */
+  searchMode?: Accessor<boolean>
+  /**
+   * Fires when the user presses `/` while not in search mode. The
+   * parent flips `searchMode` to true and renders the inline filter
+   * input.
+   */
+  onSearchEnter?: () => void
+  /**
+   * Fires when the user commits or cancels a search:
+   *   - `select: true`  → user pressed `enter` on a filtered match.
+   *     The parent should keep the new selection and exit search mode.
+   *   - `select: false` → user pressed `esc`. The parent should exit
+   *     search mode and restore the previously-selected task.
+   */
+  onSearchExit?: (select: boolean) => void
 }
 
 /**
@@ -131,8 +155,13 @@ export function useSidebarBindings(opts: SidebarBindingsOpts): void {
     return ids[idx]
   }
 
+  const searchModeAccessor = (): boolean => opts.searchMode?.() ?? false
+
+  // Block A — letter chords + `/` to enter search. Disabled while the
+  // user is typing in the search input so typed letters reach the
+  // input instead of firing j/k/g/G/d/a/r/P/m chords.
   useBindings(() => ({
-    enabled: opts.focused(),
+    enabled: opts.focused() && !searchModeAccessor(),
     bindings: bindByIds({
       // sidebar.nav covers j/k/down/up — handler discriminates direction
       // via evt.name. The matcher delivers e.g. {name: "j"} or {name: "down"}.
@@ -175,12 +204,44 @@ export function useSidebarBindings(opts: SidebarBindingsOpts): void {
         const id = cursorTaskId()
         if (id !== undefined) opts.onPinRequest?.(id)
       },
-      // `[` and `]` both register against sidebar.view; handler routes
-      // by chord. `]` = +1 ("next view"), `[` = -1.
+      "sidebar.search.enter": () => opts.onSearchEnter?.(),
+    }),
+  }))
+
+  // Block B — view switcher. Always on (even during search) so the
+  // user can flip between Working session / Archives while filtering.
+  // `[` / `]` aren't letters that go into the search query, so keeping
+  // them live doesn't collide with typing.
+  useBindings(() => ({
+    enabled: opts.focused(),
+    bindings: bindByIds({
       "sidebar.view": (evt) => {
         if (evt.name === "]") opts.onViewSwitch?.(1)
         else opts.onViewSwitch?.(-1)
       },
+    }),
+  }))
+
+  // Block C — search-mode chords. Only registered while the search
+  // input is showing, so they don't shadow the normal sidebar chords
+  // outside search mode (no esc / no return-as-search-commit).
+  useBindings(() => ({
+    enabled: opts.focused() && searchModeAccessor(),
+    bindings: bindByIds({
+      // Up/down nav over the filtered rows. j/k are intentionally
+      // excluded here — they need to fall through to the input as
+      // literal text.
+      "sidebar.search.nav": (evt) => {
+        if (evt.name === "down") ctrl.moveDown()
+        else if (evt.name === "up") ctrl.moveUp()
+      },
+      // Enter commits: select the highlighted task AND exit search.
+      "sidebar.search.submit": () => {
+        ctrl.selectCurrent()
+        opts.onSearchExit?.(true)
+      },
+      // Esc cancels: exit search and restore the prior selection.
+      "sidebar.search.cancel": () => opts.onSearchExit?.(false),
     }),
   }))
 }

--- a/packages/kobe/test/tui/sidebar/fuzzy.test.ts
+++ b/packages/kobe/test/tui/sidebar/fuzzy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest"
+import { fuzzyMatch } from "../../../src/tui/panes/sidebar/fuzzy"
+
+describe("fuzzyMatch — case-insensitive subsequence test", () => {
+  test("empty query is a universal match", () => {
+    expect(fuzzyMatch("", "anything")).toBe(true)
+    expect(fuzzyMatch("", "")).toBe(true)
+  })
+
+  test("subsequence (gaps allowed) — characters in order", () => {
+    expect(fuzzyMatch("kbe", "kobe")).toBe(true)
+    expect(fuzzyMatch("csk", "closure-stack-k8s")).toBe(true)
+    expect(fuzzyMatch("abc", "axbxc")).toBe(true)
+  })
+
+  test("substring is a special case of subsequence", () => {
+    expect(fuzzyMatch("obe", "kobe")).toBe(true)
+    expect(fuzzyMatch("stack", "closure-stack-k8s")).toBe(true)
+  })
+
+  test("order matters — chars present but reordered don't match", () => {
+    expect(fuzzyMatch("ekb", "kobe")).toBe(false)
+    expect(fuzzyMatch("xba", "abcde")).toBe(false)
+  })
+
+  test("case-insensitive on both sides", () => {
+    expect(fuzzyMatch("CSK", "closure-stack-k8s")).toBe(true)
+    expect(fuzzyMatch("kbe", "KOBE")).toBe(true)
+    expect(fuzzyMatch("aB", "AaBb")).toBe(true)
+  })
+
+  test("missing chars → no match", () => {
+    expect(fuzzyMatch("xyz", "kobe")).toBe(false)
+    expect(fuzzyMatch("kobex", "kobe")).toBe(false)
+  })
+
+  test("query longer than haystack → no match unless query is empty-ish", () => {
+    expect(fuzzyMatch("kobe-fork", "kobe")).toBe(false)
+  })
+
+  test("whitespace counts as a literal char (not stripped)", () => {
+    // We intentionally don't trim the query — callers can if they want.
+    expect(fuzzyMatch("k b", "k b")).toBe(true)
+    expect(fuzzyMatch("k b", "kb")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Press \`/\` in the sidebar to open an inline filter input above the view switcher. Typed text fuzz-matches (case-insensitive subsequence, fzf-style, no scoring) against \`title + \" \" + basename(repo)\` for every task in the active view.
- \`up\` / \`down\` navigates the filtered list, \`enter\` selects + exits search, \`esc\` cancels and restores whatever task was selected before search began.
- While search is active the sidebar's single-letter chords (\`j\`/\`k\`/\`g\`/\`G\`/\`d\`/\`a\`/\`r\`/\`P\`/\`m\`) are de-registered so typed letters reach the input as literal text. \`[\` / \`]\` view switch keeps working — the user can search within Archives.
- Original task order (main → pinned → regular) is preserved across filtering; no score-based reranking in v1.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run test\` — 935 pass / 9 skipped (8 new \`fuzzy.test.ts\` cases)
- [x] \`bun run build\` clean
- [ ] Manual: \`/\` opens search input, type \`kbe\` → matches both \`kobe\` and any task whose title contains those chars in order
- [ ] Manual: \`esc\` exits search and restores the previously-selected task
- [ ] Manual: \`enter\` on a filtered match selects + exits
- [ ] Manual: \`[\` / \`]\` while in search flips between Working session ↔ Archives without exiting search

## Notes / out of scope
- Score-based ranking (so \`kobe\` returns before \`kobe-fork\` for the query \`kbe\`) — v1 keeps original order.
- Chat tab title / file path search inside a task — v1 is task-level only.
- \`n\` (new task) is currently *not* gated on search mode (it lives in \`app.tsx\`, not the sidebar component). Typing \`n\` while searching opens the new-task dialog. Minor rough edge; can be tightened in a follow-up if it bites in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar now includes `/`-triggered inline search for real-time fuzzy filtering of tasks by name and repository. Navigate filtered results with arrow keys, select matches with Enter, and cancel with Esc to restore your prior selection.

* **Documentation**
  * Updated keybindings documentation with detailed search mode behavior, including clarification on how sidebar bindings interact with search mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/40)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->