### PR TITLE
feat: KOB-150 — sidebar +N −M chip for uncommitted changes

### DIFF
--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -56,6 +56,7 @@ import { useTheme } from "../../context/theme"
 import { readCurrentBranch } from "./git-head"
 import { type SidebarView, buildRows, flattenIds, repoBasename } from "./groups"
 import { useSidebarBindings } from "./keys"
+import { readWorktreeChanges } from "./worktree-changes"
 
 export type SidebarProps = {
   tasks: Accessor<readonly Task[]>
@@ -135,6 +136,21 @@ const VIEW_TABS: ReadonlyArray<{ view: SidebarView; label: string }> = [
  * call generator on every redraw frame. Exported for tests.
  */
 export const MAIN_BRANCH_POLL_MS = 2_000
+
+/**
+ * Reserved width (cells) for the per-row "uncommitted changes" chip
+ * (`+N −M`). Sized to fit the common `+9 −9` (5 cell) case exactly;
+ * the chip is right-aligned inside the column so longer chips (e.g.
+ * `+12 −3`, 6 char) extend slightly leftward toward the title rather
+ * than cluttering the row's right edge with reserved padding. Even
+ * longer chips (`+99 −99`, 7 char) clip on the left — rare in practice
+ * and the right edge stays aligned, which is what the eye tracks.
+ * Keeping the column reserved even when empty is the whole point of
+ * this — the eye should land on the same x for every row's chip
+ * regardless of how short or long the title above it is. Exported for
+ * tests.
+ */
+export const CHANGES_COLUMN_WIDTH = 5
 
 export function Sidebar(props: SidebarProps) {
   const { theme } = useTheme()
@@ -337,6 +353,22 @@ export function Sidebar(props: SidebarProps) {
                 branchTick()
                 return readCurrentBranch(task.repo)
               })
+              // Per-row "uncommitted changes" file counts, rendered on
+              // the right edge as `+N −M`. Keyed on the same `branchTick`
+              // so we only shell out at the established 2s cadence.
+              // Empty string when the worktree is clean — the renderer
+              // skips the chip entirely. Applies to both main and regular
+              // rows: on a main row a non-zero count is just as useful as
+              // on a worktree row, and the repo's branch label still has
+              // room next to it inside the 42-cell sidebar.
+              const changesLabel = createMemo(() => {
+                branchTick()
+                const { added, deleted } = readWorktreeChanges(task.worktreePath)
+                const parts: string[] = []
+                if (added > 0) parts.push(`+${added}`)
+                if (deleted > 0) parts.push(`−${deleted}`)
+                return parts.join(" ")
+              })
               const titleText = isMain ? repoBasename(task.repo) : task.title
               return (
                 <box
@@ -360,15 +392,39 @@ export function Sidebar(props: SidebarProps) {
                   >
                     {titleText}
                   </text>
-                  <Show when={isMain && branchLabel().length > 0}>
-                    <text fg={isCursor() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
-                      {branchLabel()}
-                    </text>
-                  </Show>
-                  <Show when={!isMain && task.pinned === true}>
-                    <text fg={isCursor() ? theme.selectedListItemText : theme.warning} wrapMode="none">
-                      ▴
-                    </text>
+                  {/* Changes column — fixed width so the chip aligns
+                      across rows like a table column rather than floating
+                      against each title's right edge. Stays present (and
+                      empty) on rows with a clean worktree, which is the
+                      whole point: the eye should land on the same x for
+                      every row's chip. Right-aligned so the digits' right
+                      edges line up across rows (what the eye tracks) and
+                      so short chips sit closer to the row's right side
+                      rather than crowding the title. */}
+                  <box width={CHANGES_COLUMN_WIDTH} flexShrink={0} flexDirection="row" justifyContent="flex-end">
+                    <Show when={changesLabel().length > 0}>
+                      <text fg={isCursor() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                        {changesLabel()}
+                      </text>
+                    </Show>
+                  </box>
+                  {/* Branch label + pin marker — wrapped so they don't
+                      collide with the changes column on the left, and so
+                      the row stays clean (no empty container) when there
+                      is nothing to show. */}
+                  <Show when={(isMain && branchLabel().length > 0) || (!isMain && task.pinned === true)}>
+                    <box flexDirection="row" gap={1} paddingLeft={1}>
+                      <Show when={isMain && branchLabel().length > 0}>
+                        <text fg={isCursor() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                          {branchLabel()}
+                        </text>
+                      </Show>
+                      <Show when={!isMain && task.pinned === true}>
+                        <text fg={isCursor() ? theme.selectedListItemText : theme.warning} wrapMode="none">
+                          ▴
+                        </text>
+                      </Show>
+                    </box>
                   </Show>
                 </box>
               )

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
@@ -1,0 +1,81 @@
+/**
+ * Tiny worktree-changes helper for the sidebar's per-row `+N −M` chip.
+ *
+ * Each task row renders a status badge + title; this helper feeds the
+ * right-edge "uncommitted file counts" chip:
+ *
+ *   `+N` — files added, modified, renamed, copied, or untracked
+ *   `−M` — files deleted (in index or worktree)
+ *
+ * Shows up next to the task title only when the worktree is dirty —
+ * a clean tracked branch contributes nothing, so the row reads as it
+ * always has.
+ *
+ * Implementation: a single synchronous `git status --porcelain=v1`
+ * call, classified per row (any `D` in either column → `−`, anything
+ * else → `+`). Falls back to all-zeros for any failure mode (missing
+ * repo, EACCES, git not on PATH, worktree gone) so the chip is hidden
+ * rather than showing a confusing error state. Never throws — the
+ * sidebar must always render.
+ *
+ * Caching: the caller (Sidebar.tsx) wraps this in a `createMemo` keyed
+ * on the existing `branchTick` + the worktree path so we don't shell
+ * out on every redraw frame. Tick advances every ~2s — same cadence
+ * as the main-row branch refresh.
+ *
+ * Why a separate file rather than reaching into
+ * `src/orchestrator/worktree/manager.ts#isDirty`: that one is `async`,
+ * boolean-only, and throws. The sidebar is sync, needs counts, and
+ * tolerates every failure mode. Same trade-off `git-head.ts` and
+ * `src/tui/panes/filetree/git.ts` made — pane-side git wrappers are
+ * intentionally separate from the orchestrator's stricter ones.
+ */
+
+import { spawnSync } from "node:child_process"
+
+export interface WorktreeChanges {
+  /** Files added, modified, renamed, copied, or untracked. */
+  readonly added: number
+  /** Files deleted (in index or worktree). */
+  readonly deleted: number
+}
+
+const ZERO: WorktreeChanges = { added: 0, deleted: 0 }
+
+/**
+ * Read worktree change counts for `worktreePath`. Never throws —
+ * returns zeros for any failure mode so the renderer skips the chip.
+ */
+export function readWorktreeChanges(worktreePath: string): WorktreeChanges {
+  if (!worktreePath) return ZERO
+  try {
+    const out = spawnSync("git", ["status", "--porcelain=v1"], {
+      cwd: worktreePath,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    if (out.status !== 0 || !out.stdout) return ZERO
+    return parsePorcelain(out.stdout)
+  } catch {
+    return ZERO
+  }
+}
+
+/** Exported for unit tests. */
+export function parsePorcelain(text: string): WorktreeChanges {
+  let added = 0
+  let deleted = 0
+  for (const line of text.split("\n")) {
+    if (!line || line.startsWith("##")) continue
+    // Porcelain v1 entries are `XY <path>` where X is the index status
+    // and Y is the worktree status. `??` is untracked. We classify a
+    // row as `deleted` if either column is `D`; everything else (M, A,
+    // R, C, T, U, ??) counts as `added`. Renames appear on a single
+    // line — still one file event, so a single count.
+    const x = line.charAt(0)
+    const y = line.charAt(1)
+    if (x === "D" || y === "D") deleted += 1
+    else added += 1
+  }
+  return { added, deleted }
+}

--- a/packages/kobe/test/tui/worktree-changes.test.ts
+++ b/packages/kobe/test/tui/worktree-changes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest"
+import { parsePorcelain } from "../../src/tui/panes/sidebar/worktree-changes"
+
+describe("parsePorcelain", () => {
+  test("returns zeros for empty input", () => {
+    expect(parsePorcelain("")).toEqual({ added: 0, deleted: 0 })
+  })
+
+  test("counts modified, added, untracked as `added`", () => {
+    const text = [" M src/a.ts", "M  src/b.ts", "A  src/c.ts", "?? src/d.ts", ""].join("\n")
+    expect(parsePorcelain(text)).toEqual({ added: 4, deleted: 0 })
+  })
+
+  test("counts deletions in either column as `deleted`", () => {
+    const text = [" D src/a.ts", "D  src/b.ts", "AD src/c.ts", ""].join("\n")
+    expect(parsePorcelain(text)).toEqual({ added: 0, deleted: 3 })
+  })
+
+  test("ignores branch-header line if present", () => {
+    const text = ["## main...origin/main [ahead 2, behind 1]", " M src/a.ts", " D src/b.ts", ""].join("\n")
+    expect(parsePorcelain(text)).toEqual({ added: 1, deleted: 1 })
+  })
+
+  test("clean tree yields zeros", () => {
+    expect(parsePorcelain("\n")).toEqual({ added: 0, deleted: 0 })
+  })
+})


### PR DESCRIPTION
## Summary

Each task row in the sidebar now shows a `+N −M` file-count chip on the right when the task's worktree has uncommitted changes. The chip lives inside a fixed 5-cell right-aligned column, so digits line up across rows; clean worktrees leave the column empty so the eye can scan down to spot tasks with pending work.

- New helper `worktree-changes.ts` runs `git status --porcelain=v1`, classifies each row as `+` or `−`, never throws.
- Sidebar reuses the existing 2s `branchTick` for polling — no second interval.
- Iterations rejected (documented on KOB-150): top-bar `+N −M ↑X ↓Y` chip, ringed `●` → `◎` glyph swap.

Linear: https://linear.app/codesfox/issue/KOB-150

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run vitest run` — 851 passed / 9 skipped
- [x] 5 new parser tests in `test/tui/worktree-changes.test.ts`
- [x] Smoke-checked helper against dev fixture (alpha → `+3 −1`, beta → empty)
- [ ] Eyeball in `bun run dev:test`