### PR TITLE
fix: KOB-151 — composer up-arrow restores bash mode on !-prefixed history

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Fixed
 
+- **Up-arrow history recall restores bash mode for `!`-prefixed entries** — recalling a previous `!cmd` submission now flips the composer back into bash mode and strips the `!` prefix, mirroring how the entry was originally submitted. Previously the `!` came back as literal text and the user had to re-trigger bash mode by hand (KOB-151).
 - **Started chat tabs stay bound to their engine** — once a chat tab has a Claude Code or Codex session, the model picker keeps other-engine models visible but disabled with a new-chat-required hint, and the orchestrator rejects cross-engine retargeting so history/resume data cannot cross vendors (KOB-128).
 - **Task metadata naming now follows the selected chat-tab engine** — branch/title suggestions route through the active tab's `AIEngine` with its selected model and reasoning effort instead of always shelling out to Claude (KOB-111).
 - **Task title suggestions wait for enough chat context** — new tasks keep the first user prompt as the cheap fallback title, then after three completed user turns ask the selected engine for a feature-style task name without overwriting manual renames (KOB-113).

--- a/packages/kobe/src/tui/panes/chat/Composer.tsx
+++ b/packages/kobe/src/tui/panes/chat/Composer.tsx
@@ -236,10 +236,33 @@ export function Composer(props: ComposerProps) {
   // (c) directly calling `setText`/`focus`/`submit` from handlers.
   let textareaRef: TextareaRenderable | undefined
 
+  // History recall is bash-mode-aware: the live-draft snapshot encodes
+  // bash mode as a leading `!` (the same on-disk shape submit uses, see
+  // handleSubmit's `pushHistory(key, \`!${command}\`)`). The setter
+  // mirrors that — a recalled `!`-prefixed entry strips the `!`, sets
+  // the buffer to the rest, and flips bash mode back on so the user
+  // gets the same visual state as when they originally submitted.
+  // Without this, up-arrow on a `!ls`-style entry just dumps the raw
+  // `!ls` into the textarea as a normal prompt and the user has to
+  // re-trigger bash mode by hand. Gated on `bashAvailable()` so a
+  // composer without `onBashCommand` shows the `!` verbatim (the
+  // history could have been seeded by a prior composer that had bash
+  // wired up — better to expose the raw text than silently swallow it).
   const historyNav = new PromptHistoryNavigator(
     () => getHistory(props.historyKey ?? "global"),
-    () => textareaRef?.plainText ?? "",
-    setBuffer,
+    () => {
+      const text = textareaRef?.plainText ?? ""
+      return bashMode() ? `!${text}` : text
+    },
+    (recalled: string) => {
+      if (recalled.startsWith("!") && bashAvailable()) {
+        setBuffer(recalled.slice(1))
+        setBashMode(true)
+        return
+      }
+      setBuffer(recalled)
+      setBashMode(false)
+    },
   )
 
   // Per-composer image-paste registry. Owns disk writes for pasted


### PR DESCRIPTION
## Summary

Recalling a previous `!cmd` submission from the composer's prompt history now flips the composer back into bash mode and strips the `!` prefix, instead of dumping the literal `!` into the textarea as a normal prompt.

The bug had been latent since bash mode shipped: `handleSubmit` already pushed `!command` into the per-key history ring with the explicit intent of "future history-replay can restore the bash-mode visual" (`Composer.tsx:691-693`), but the `PromptHistoryNavigator` setter was a plain `setBuffer(recalled)` that never touched `bashMode`. Up-arrowing onto a `!ls` entry just dropped `!ls` into the textarea as text, and the user had to delete it and retype `!` to re-enter CMD mode.

Fix (`Composer.tsx:239-266`):

- The `liveDraft` snapshot now encodes bash mode the same way submit does — leading `!` — so walking forward off the end of history restores the original mode symmetrically.
- The setter strips the `!` and calls `setBashMode(true)` on recall; non-`!` entries clear bash mode.
- Gated on `bashAvailable()`: a composer without `onBashCommand` shows the `!` verbatim (the history could have been seeded by a prior composer that had bash wired up — better to expose the raw text than silently swallow it).

`composer/history-nav.ts` is untouched; the bash-mode awareness lives entirely in the wiring.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 897 unit tests + 49 daemon/bridge tests passing
- [ ] Manual: in `dev:test`, type `!ls<enter>`, then `!pwd<enter>`, then press up arrow twice — composer should flash bash mode and show `ls` / `pwd` with the `!` glyph in the prefix, not literal `!ls` / `!pwd` text.

Linear: https://linear.app/codesfox/issue/KOB-151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed history navigation for commands in bash mode. When using up-arrow to recall previously entered commands, the system now correctly restores the appropriate bash mode state and properly processes command prefixes. Recalled commands are now restored as originally intended rather than being treated as literal text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/42)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->