### PR TITLE
Hide topbar session id

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+### Changed
+
+- Hide the chat topbar session id label so internal engine ids no longer show in normal use.
+
 ## [0.5.3] - 2026-05-16
 
 ### Changed

--- a/packages/kobe/src/tui/component/top-bar-helpers.ts
+++ b/packages/kobe/src/tui/component/top-bar-helpers.ts
@@ -1,10 +1,5 @@
 import type { Task } from "../../types/task.ts"
 
-export function formatSessionIdLabel(sessionId: string | null | undefined): string | null {
-  if (!sessionId) return null
-  return `sid ${sessionId}`
-}
-
 export function activeTaskSessionId(task: Task | undefined, activeChatTabId: string | null | undefined): string | null {
   if (!task) return null
   const tabId = activeChatTabId ?? task.activeTabId

--- a/packages/kobe/src/tui/component/top-bar.tsx
+++ b/packages/kobe/src/tui/component/top-bar.tsx
@@ -28,7 +28,6 @@ import { DialogConfirm } from "../ui/dialog-confirm"
 import { CreatePRButton } from "./create-pr-button"
 import { OpenWorktreeButton } from "./open-worktree-button"
 import { RcBridgeDialog } from "./rc-bridge-dialog"
-import { activeTaskSessionId, formatSessionIdLabel } from "./top-bar-helpers"
 import { UpdateDialog } from "./update-dialog"
 
 export function TopBar(props: {
@@ -61,9 +60,6 @@ export function TopBar(props: {
   const remoteOrch = props.orchestrator instanceof RemoteOrchestrator ? props.orchestrator : null
   const rcBridge = props.orchestrator.rcBridgeSignal()
   const isBridgeOn = () => rcBridge().state === "running" || rcBridge().state === "starting"
-  const sessionIdLabel = createMemo(() =>
-    formatSessionIdLabel(activeTaskSessionId(props.activeTask(), props.activeChatTabId?.())),
-  )
 
   async function confirmUpdate(): Promise<void> {
     const info = props.updateInfo()
@@ -162,18 +158,9 @@ export function TopBar(props: {
           }
         >
           <Show when={props.activeTask() !== undefined}>
-            <box flexDirection="row" gap={2} justifyContent="center">
-              <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
-                {props.activeTask()?.branch}
-              </text>
-              <Show when={sessionIdLabel()}>
-                {(label) => (
-                  <text fg={theme.textMuted} wrapMode="none">
-                    {label()}
-                  </text>
-                )}
-              </Show>
-            </box>
+            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
+              {props.activeTask()?.branch}
+            </text>
           </Show>
         </Show>
       </box>

--- a/packages/kobe/test/behavior/top-bar-session-id.test.ts
+++ b/packages/kobe/test/behavior/top-bar-session-id.test.ts
@@ -27,7 +27,7 @@ afterEach(async () => {
   tmpRoot = null
 })
 
-test("top bar shows the active chat tab session id", async () => {
+test("top bar hides the active chat tab session id", async () => {
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-topbar-sid-"))
   const homeDir = path.join(tmpRoot, "home")
   const repo = path.join(tmpRoot, "repo")
@@ -72,7 +72,7 @@ test("top bar shows the active chat tab session id", async () => {
     rows: 30,
   })
 
-  const screen = await kobe.waitFor((s) => s.includes("sid fake-1"), 10_000)
+  const screen = await kobe.waitFor((s) => s.includes("kobe/session-id"), 10_000)
   expect(screen).toContain("kobe/session-id")
-  expect(screen).toContain("sid fake-1")
+  expect(screen).not.toContain("sid fake-1")
 })

--- a/packages/kobe/test/tui/top-bar-helpers.test.ts
+++ b/packages/kobe/test/tui/top-bar-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { activeTaskSessionId, formatSessionIdLabel } from "../../src/tui/component/top-bar-helpers"
+import { activeTaskSessionId } from "../../src/tui/component/top-bar-helpers"
 import { type Task, toTaskId } from "../../src/types/task"
 
 function taskWithTabs(activeTabId: string): Task {
@@ -21,21 +21,6 @@ function taskWithTabs(activeTabId: string): Task {
     updatedAt: "2026-05-12T00:00:00.000Z",
   }
 }
-
-describe("formatSessionIdLabel", () => {
-  test("returns null before a session exists", () => {
-    expect(formatSessionIdLabel(null)).toBeNull()
-    expect(formatSessionIdLabel(undefined)).toBeNull()
-  })
-
-  test("keeps long ids intact so the current session is copyable", () => {
-    expect(formatSessionIdLabel("1234567890abcdef")).toBe("sid 1234567890abcdef")
-  })
-
-  test("keeps short ids intact", () => {
-    expect(formatSessionIdLabel("fake-1")).toBe("sid fake-1")
-  })
-})
 
 describe("activeTaskSessionId", () => {
   test("uses the active chat tab session id", () => {


### PR DESCRIPTION
Removes the debug-oriented `sid ...` label from the chat topbar while keeping the branch name visible as the task signal. Updates the topbar behavior test to assert session ids stay hidden and trims the old sid label formatter coverage. Adds an Unreleased changelog note for the visible UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed internal session ID display from the chat topbar. Previously, session identifiers were shown alongside the branch information; the topbar now displays only the branch identifier to prevent unintended exposure of internal engine IDs during normal chat operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->