### PR TITLE
Show Gemini account status in settings

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project are documented here. The format follows [Kee
 
 - Hide the chat topbar session id label so internal engine ids no longer show in normal use.
 
+### Fixed
+
+- Show Gemini CLI login state in Settings → Accounts, including Google OAuth, Gemini API key, and Vertex AI environment auth modes.
+
 ## [0.5.3] - 2026-05-16
 
 ### Changed

--- a/packages/kobe/src/engine/account-detect.ts
+++ b/packages/kobe/src/engine/account-detect.ts
@@ -1,9 +1,9 @@
 /**
- * Read-only account detection for the two engines kobe drives:
- * `claude` (Anthropic) and `codex` (OpenAI).
+ * Read-only account detection for the engines kobe drives:
+ * `claude` (Anthropic), `codex` (OpenAI), and `gemini` (Google).
  *
  * The settings dialog's "Accounts" section calls these to show "is
- * `claude` / `codex` installed?" and "is there a local account?".
+ * `claude` / `codex` / `gemini` installed?" and "is there a local account?".
  * Future work (codex sub-login flows etc.) layers on top — the read
  * path stays the same, only the action set grows.
  *
@@ -22,6 +22,12 @@
  *         carries `email` and `https://api.openai.com/auth.chatgpt_plan_type`.
  *       - API-key login → `OPENAI_API_KEY` is a non-null string.
  *     Verified against the live file on Jackson's machine.
+ *
+ *   - **gemini**: `~/.gemini/oauth_creds.json` for Google login,
+ *     `GEMINI_API_KEY` for AI Studio API keys, and Vertex/ADC
+ *     environment variables for Vertex AI. The Gemini CLI docs describe
+ *     these three auth modes; local Google login caches credentials for
+ *     future sessions.
  *
  * The functions are pure — fs + env + binary discovery are injected
  * via {@link DetectDeps}, so tests pin every path and the production
@@ -42,6 +48,7 @@ import { homedir } from "node:os"
 import path from "node:path"
 import { ClaudeBinaryNotFoundError, findClaudeBinary } from "./claude-code-local/binary"
 import { CodexBinaryNotFoundError, findCodexBinary } from "./codex-local/binary"
+import { GeminiBinaryNotFoundError, findGeminiBinary } from "./gemini-local/binary"
 
 export type ClaudeAccount =
   | {
@@ -54,6 +61,12 @@ export type ClaudeAccount =
   | { kind: "none" }
 
 export type CodexAccount = { kind: "chatgpt"; email: string; plan?: string } | { kind: "apikey" } | { kind: "none" }
+
+export type GeminiAccount =
+  | { kind: "google"; email?: string; authType?: string }
+  | { kind: "apikey" }
+  | { kind: "vertex"; project?: string; location?: string }
+  | { kind: "none" }
 
 export type BinaryStatus = { found: true; path: string } | { found: false; error: string }
 
@@ -71,6 +84,7 @@ export interface DetectDeps {
   home(): string
   findClaudeBinary(): Promise<string>
   findCodexBinary(): Promise<string>
+  findGeminiBinary(): Promise<string>
 }
 
 const defaultDeps: DetectDeps = {
@@ -97,6 +111,9 @@ const defaultDeps: DetectDeps = {
   findCodexBinary() {
     return findCodexBinary()
   },
+  findGeminiBinary() {
+    return findGeminiBinary()
+  },
 }
 
 /** Resolve the path to claude-code's global config (`~/.claude.json` by default). */
@@ -111,6 +128,16 @@ export function codexAuthPath(env: (k: string) => string | undefined, home: stri
   const override = env("CODEX_HOME")?.trim()
   const dir = override ?? path.join(home, ".codex")
   return path.join(dir, "auth.json")
+}
+
+/** Resolve the path to Gemini CLI's OAuth credential cache. */
+export function geminiOauthCredsPath(home: string): string {
+  return path.join(home, ".gemini", "oauth_creds.json")
+}
+
+/** Resolve the path to Gemini CLI's user settings file. */
+export function geminiSettingsPath(home: string): string {
+  return path.join(home, ".gemini", "settings.json")
 }
 
 /**
@@ -141,7 +168,11 @@ async function probeBinary(probe: () => Promise<string>): Promise<BinaryStatus> 
     const p = await probe()
     return { found: true, path: p }
   } catch (err) {
-    if (err instanceof ClaudeBinaryNotFoundError || err instanceof CodexBinaryNotFoundError) {
+    if (
+      err instanceof ClaudeBinaryNotFoundError ||
+      err instanceof CodexBinaryNotFoundError ||
+      err instanceof GeminiBinaryNotFoundError
+    ) {
       return { found: false, error: "not found on PATH" }
     }
     return { found: false, error: err instanceof Error ? err.message : String(err) }
@@ -244,4 +275,101 @@ export async function detectCodexAccount(deps: DetectDeps = defaultDeps): Promis
     return { binary, account: { kind: "apikey" } }
   }
   return { binary, account: { kind: "none" } }
+}
+
+export async function detectGeminiAccount(deps: DetectDeps = defaultDeps): Promise<EngineAccountStatus<GeminiAccount>> {
+  const binary = await probeBinary(() => deps.findGeminiBinary())
+
+  const apiKey = deps.env("GEMINI_API_KEY")?.trim()
+  if (apiKey) return { binary, account: { kind: "apikey" } }
+
+  const useVertex = deps.env("GOOGLE_GENAI_USE_VERTEXAI")?.trim().toLowerCase()
+  const vertexProject = deps.env("GOOGLE_CLOUD_PROJECT")?.trim()
+  const vertexLocation = deps.env("GOOGLE_CLOUD_LOCATION")?.trim()
+  const vertexApiKey = deps.env("GOOGLE_API_KEY")?.trim()
+  const adcPath = deps.env("GOOGLE_APPLICATION_CREDENTIALS")?.trim()
+  if (useVertex === "true" || useVertex === "1" || vertexApiKey || adcPath) {
+    return {
+      binary,
+      account: {
+        kind: "vertex",
+        project: vertexProject || undefined,
+        location: vertexLocation || undefined,
+      },
+    }
+  }
+
+  let authType: string | undefined
+  const settingsPath = geminiSettingsPath(deps.home())
+  try {
+    const settingsRaw = deps.readFile(settingsPath)
+    if (settingsRaw !== null) {
+      const settings = JSON.parse(settingsRaw) as unknown
+      if (isRecord(settings)) {
+        const security = settings.security
+        const auth =
+          isRecord(security) && isRecord(security.auth)
+            ? security.auth
+            : isRecord(settings.auth)
+              ? settings.auth
+              : settings
+        const selectedType =
+          (isRecord(auth) && typeof auth.selectedType === "string" && auth.selectedType) ||
+          (typeof settings.selectedAuthType === "string" && settings.selectedAuthType)
+        if (selectedType) authType = selectedType
+      }
+    }
+  } catch {
+    // Settings are useful metadata, not the auth source. Credential
+    // parse/read errors below still surface as accountError.
+  }
+
+  const credsPath = geminiOauthCredsPath(deps.home())
+  let raw: string | null
+  try {
+    raw = deps.readFile(credsPath)
+  } catch (err) {
+    return {
+      binary,
+      account: { kind: "none" },
+      accountError: `read ${credsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+  if (raw === null) return { binary, account: { kind: "none" } }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    return {
+      binary,
+      account: { kind: "none" },
+      accountError: `parse ${credsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+
+  const obj = isRecord(parsed) ? parsed : {}
+  const idToken = typeof obj.id_token === "string" ? obj.id_token : undefined
+  if (idToken) {
+    const payload = decodeJwtPayload(idToken)
+    if (!payload) {
+      return {
+        binary,
+        account: { kind: "none" },
+        accountError: "gemini id_token: malformed JWT",
+      }
+    }
+    const email = typeof payload.email === "string" ? payload.email : undefined
+    return { binary, account: { kind: "google", email, authType } }
+  }
+
+  const accessToken = typeof obj.access_token === "string" ? obj.access_token : undefined
+  const refreshToken = typeof obj.refresh_token === "string" ? obj.refresh_token : undefined
+  if (accessToken || refreshToken) return { binary, account: { kind: "google", authType } }
+
+  return { binary, account: { kind: "none" } }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
 }

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -17,8 +17,10 @@ import {
   type ClaudeAccount,
   type CodexAccount,
   type EngineAccountStatus,
+  type GeminiAccount,
   detectClaudeAccount,
   detectCodexAccount,
+  detectGeminiAccount,
 } from "../../engine/account-detect"
 import { CODEX_BACKEND_KV_KEY, type CodexBackend } from "../../engine/codex-local/app-server"
 import type { KVContext } from "../context/kv"
@@ -74,6 +76,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
   const hasDaemon = hasRestartableDaemon(props.orchestrator)
   const [claudeStatus, setClaudeStatus] = createSignal<EngineAccountStatus<ClaudeAccount> | null>(null)
   const [codexStatus, setCodexStatus] = createSignal<EngineAccountStatus<CodexAccount> | null>(null)
+  const [geminiStatus, setGeminiStatus] = createSignal<EngineAccountStatus<GeminiAccount> | null>(null)
 
   onMount(() => {
     void detectClaudeAccount()
@@ -89,6 +92,13 @@ export function SettingsDialog(props: SettingsDialogProps) {
         // eslint-disable-next-line no-console
         console.error("kobe: detectCodexAccount threw:", err)
         setCodexStatus({ binary: { found: false, error: String(err) }, account: { kind: "none" } })
+      })
+    void detectGeminiAccount()
+      .then(setGeminiStatus)
+      .catch((err: unknown) => {
+        // eslint-disable-next-line no-console
+        console.error("kobe: detectGeminiAccount threw:", err)
+        setGeminiStatus({ binary: { found: false, error: String(err) }, account: { kind: "none" } })
       })
   })
 
@@ -261,7 +271,11 @@ export function SettingsDialog(props: SettingsDialogProps) {
             />
           </Show>
           <Show when={section() === "accounts"}>
-            <AccountsSettingsSection claudeStatus={claudeStatus} codexStatus={codexStatus} />
+            <AccountsSettingsSection
+              claudeStatus={claudeStatus}
+              codexStatus={codexStatus}
+              geminiStatus={geminiStatus}
+            />
           </Show>
           <Show when={section() === "codex"}>
             <CodexSettingsSection

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -1,6 +1,6 @@
 import { TextAttributes } from "@opentui/core"
 import { type Accessor, For, type Setter, Show } from "solid-js"
-import type { ClaudeAccount, CodexAccount, EngineAccountStatus } from "../../../engine/account-detect"
+import type { ClaudeAccount, CodexAccount, EngineAccountStatus, GeminiAccount } from "../../../engine/account-detect"
 import type { CodexBackend } from "../../../engine/codex-local/app-server"
 import { FOCUS_ACCENT_SLOTS, useTheme } from "../../context/theme"
 import {
@@ -241,6 +241,7 @@ export function GeneralSettingsSection(
 export function AccountsSettingsSection(props: {
   claudeStatus: Accessor<EngineAccountStatus<ClaudeAccount> | null>
   codexStatus: Accessor<EngineAccountStatus<CodexAccount> | null>
+  geminiStatus: Accessor<EngineAccountStatus<GeminiAccount> | null>
 }) {
   const { theme } = useTheme()
   return (
@@ -314,6 +315,53 @@ export function AccountsSettingsSection(props: {
                   )
                 }
                 if (a.kind === "apikey") return <text fg={theme.success}>● API key configured</text>
+                return <text fg={theme.textMuted}>○ Not logged in</text>
+              })()}
+              <Show when={s().accountError}>
+                {(err) => (
+                  <text fg={theme.warning} wrapMode="word">
+                    {`! ${err()}`}
+                  </text>
+                )}
+              </Show>
+            </box>
+          )}
+        </Show>
+      </box>
+      <box flexDirection="column" gap={0}>
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          gemini
+        </text>
+        <Show when={props.geminiStatus() === null}>
+          <text fg={theme.textMuted}>Checking…</text>
+        </Show>
+        <Show when={props.geminiStatus()}>
+          {(s) => (
+            <box flexDirection="column" gap={0}>
+              <text fg={s().binary.found ? theme.textMuted : theme.warning} wrapMode="word">
+                {s().binary.found
+                  ? `Binary: ${(s().binary as { path: string }).path}`
+                  : `Binary: ${(s().binary as { error: string }).error}`}
+              </text>
+              {(() => {
+                const a = s().account
+                if (a.kind === "google") {
+                  const tail = a.authType ? ` (${a.authType})` : ""
+                  return (
+                    <text fg={theme.success} wrapMode="word">
+                      {`● Google login${a.email ? `: ${a.email}` : ""}${tail}`}
+                    </text>
+                  )
+                }
+                if (a.kind === "apikey") return <text fg={theme.success}>● Gemini API key configured</text>
+                if (a.kind === "vertex") {
+                  const tail = [a.project, a.location].filter((x): x is string => !!x).join(" · ")
+                  return (
+                    <text fg={theme.success} wrapMode="word">
+                      {`● Vertex AI configured${tail ? ` (${tail})` : ""}`}
+                    </text>
+                  )
+                }
                 return <text fg={theme.textMuted}>○ Not logged in</text>
               })()}
               <Show when={s().accountError}>

--- a/packages/kobe/test/behavior/approval-flow.test.ts
+++ b/packages/kobe/test/behavior/approval-flow.test.ts
@@ -422,7 +422,7 @@ test("approval — ExitPlanMode click-through approves + emits the synthetic res
   // prompt is actually visible to the user as a normal user-row. This
   // is the load-bearing assertion: it proves user.inject fired with
   // the right text, which is what the model would see on `--resume`.
-  await kobe.waitFor((s) => s.includes("Plan approved. Please proceed"), 5_000)
+  await kobe.waitFor((s) => s.replace(/\s+/g, "").includes("Pleaseproceedwiththeimplementationasoutlined"), 5_000)
 
   await kobe.exit()
 }, 60_000)

--- a/packages/kobe/test/engine/account-detect.test.ts
+++ b/packages/kobe/test/engine/account-detect.test.ts
@@ -19,9 +19,13 @@ import {
   codexAuthPath,
   detectClaudeAccount,
   detectCodexAccount,
+  detectGeminiAccount,
+  geminiOauthCredsPath,
+  geminiSettingsPath,
 } from "@/engine/account-detect"
 import { ClaudeBinaryNotFoundError } from "@/engine/claude-code-local/binary"
 import { CodexBinaryNotFoundError } from "@/engine/codex-local/binary"
+import { GeminiBinaryNotFoundError } from "@/engine/gemini-local/binary"
 import { describe, expect, it } from "vitest"
 
 function makeDeps(overrides: Partial<DetectDeps> = {}): DetectDeps {
@@ -31,6 +35,7 @@ function makeDeps(overrides: Partial<DetectDeps> = {}): DetectDeps {
     home: () => "/home/user",
     findClaudeBinary: async () => "/usr/local/bin/claude",
     findCodexBinary: async () => "/usr/local/bin/codex",
+    findGeminiBinary: async () => "/usr/local/bin/gemini",
     ...overrides,
   }
 }
@@ -63,6 +68,13 @@ describe("codexAuthPath", () => {
     expect(codexAuthPath((k) => (k === "CODEX_HOME" ? "/elsewhere/codex" : undefined), "/home/user")).toBe(
       "/elsewhere/codex/auth.json",
     )
+  })
+})
+
+describe("gemini auth paths", () => {
+  it("uses ~/.gemini/oauth_creds.json and ~/.gemini/settings.json", () => {
+    expect(geminiOauthCredsPath("/home/user")).toBe("/home/user/.gemini/oauth_creds.json")
+    expect(geminiSettingsPath("/home/user")).toBe("/home/user/.gemini/settings.json")
   })
 })
 
@@ -233,5 +245,103 @@ describe("detectCodexAccount", () => {
       }),
     )
     expect(observed).toBe("/elsewhere/auth.json")
+  })
+})
+
+describe("detectGeminiAccount", () => {
+  it("reports binary path + 'none' when no credential file or env auth exists", async () => {
+    const r = await detectGeminiAccount(makeDeps())
+    expect(r.binary).toEqual({ found: true, path: "/usr/local/bin/gemini" })
+    expect(r.account).toEqual({ kind: "none" })
+    expect(r.accountError).toBeUndefined()
+  })
+
+  it("decodes Google login email from oauth_creds id_token and includes selected auth type", async () => {
+    const idToken = makeJwt({ email: "jane@example.com", email_verified: true })
+    const r = await detectGeminiAccount(
+      makeDeps({
+        readFile: (p) => {
+          if (p === "/home/user/.gemini/settings.json") {
+            return JSON.stringify({ security: { auth: { selectedType: "oauth-personal" } } })
+          }
+          if (p === "/home/user/.gemini/oauth_creds.json") {
+            return JSON.stringify({ id_token: idToken, token_type: "Bearer" })
+          }
+          return null
+        },
+      }),
+    )
+    expect(r.account).toEqual({ kind: "google", email: "jane@example.com", authType: "oauth-personal" })
+  })
+
+  it("supports legacy selectedAuthType settings", async () => {
+    const r = await detectGeminiAccount(
+      makeDeps({
+        readFile: (p) => {
+          if (p === "/home/user/.gemini/settings.json") return JSON.stringify({ selectedAuthType: "oauth-personal" })
+          if (p === "/home/user/.gemini/oauth_creds.json") return JSON.stringify({ refresh_token: "refresh" })
+          return null
+        },
+      }),
+    )
+    expect(r.account).toEqual({ kind: "google", authType: "oauth-personal" })
+  })
+
+  it("prefers GEMINI_API_KEY env auth before cached OAuth", async () => {
+    const r = await detectGeminiAccount(
+      makeDeps({
+        env: (k) => (k === "GEMINI_API_KEY" ? "test-key" : undefined),
+        readFile: () => JSON.stringify({ id_token: makeJwt({ email: "jane@example.com" }) }),
+      }),
+    )
+    expect(r.account).toEqual({ kind: "apikey" })
+  })
+
+  it("reports Vertex AI env auth", async () => {
+    const r = await detectGeminiAccount(
+      makeDeps({
+        env: (k) =>
+          ({
+            GOOGLE_GENAI_USE_VERTEXAI: "true",
+            GOOGLE_CLOUD_PROJECT: "my-project",
+            GOOGLE_CLOUD_LOCATION: "us-central1",
+          })[k],
+      }),
+    )
+    expect(r.account).toEqual({ kind: "vertex", project: "my-project", location: "us-central1" })
+  })
+
+  it("surfaces malformed Gemini JWT as accountError", async () => {
+    const r = await detectGeminiAccount(
+      makeDeps({
+        readFile: (p) => (p.endsWith("oauth_creds.json") ? JSON.stringify({ id_token: "not-a-jwt" }) : null),
+      }),
+    )
+    expect(r.account).toEqual({ kind: "none" })
+    expect(r.accountError).toMatch(/gemini id_token/)
+  })
+
+  it("surfaces JSON parse errors", async () => {
+    const r = await detectGeminiAccount(
+      makeDeps({
+        readFile: (p) => (p.endsWith("oauth_creds.json") ? "{ not json" : null),
+      }),
+    )
+    expect(r.account).toEqual({ kind: "none" })
+    expect(r.accountError).toMatch(/parse .*oauth_creds\.json/)
+  })
+
+  it("reports binary not-found cleanly without losing account detection", async () => {
+    const r = await detectGeminiAccount(
+      makeDeps({
+        findGeminiBinary: async () => {
+          throw new GeminiBinaryNotFoundError(["/nowhere"])
+        },
+        readFile: (p) =>
+          p.endsWith("oauth_creds.json") ? JSON.stringify({ id_token: makeJwt({ email: "jane@example.com" }) }) : null,
+      }),
+    )
+    expect(r.binary).toEqual({ found: false, error: "not found on PATH" })
+    expect(r.account).toEqual({ kind: "google", email: "jane@example.com", authType: undefined })
   })
 })


### PR DESCRIPTION
Adds Gemini CLI account detection to Settings → Accounts alongside Claude and Codex. The detector reports Google OAuth cache, GEMINI_API_KEY, and Vertex AI environment auth modes without exposing token values. This also adds regression coverage for Gemini account parsing and keeps the changelog current. A fragile approval behavior assertion was tightened so the full behavior suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gemini login status now visible in Settings → Accounts, displaying Google OAuth, API key, and Vertex AI authentication modes.

* **Bug Fixes**
  * Chat topbar no longer displays internal session ID labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->