### PR TITLE
Show active task repo in top bar

### DIFF
--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -47,7 +47,6 @@ import { ResizableEdge } from "./component/resizable-edge"
 import { StatusBar } from "./component/status-bar"
 import { ToastOverlay } from "./component/toast-overlay"
 import { TopBar } from "./component/top-bar"
-import { activeTaskRepoBranchLabel } from "./component/top-bar-helpers"
 import { CommandPaletteProvider, useCommandPalette } from "./context/command-palette"
 import { FocusProvider, type PaneId, useFocus } from "./context/focus"
 import { useKobeKeybindings } from "./context/keybindings"
@@ -620,7 +619,7 @@ function Shell(props: AppDeps) {
           <PaneHeader
             title="WORKSPACE"
             ordinal="j"
-            subtitle={activeTaskRepoBranchLabel(activeTask())}
+            subtitle={activeTask()?.title ?? "no task"}
             asideRight={workspaceAsideRight()}
             focused={focusedPane() === "workspace"}
           />

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -47,6 +47,7 @@ import { ResizableEdge } from "./component/resizable-edge"
 import { StatusBar } from "./component/status-bar"
 import { ToastOverlay } from "./component/toast-overlay"
 import { TopBar } from "./component/top-bar"
+import { activeTaskRepoBranchLabel } from "./component/top-bar-helpers"
 import { CommandPaletteProvider, useCommandPalette } from "./context/command-palette"
 import { FocusProvider, type PaneId, useFocus } from "./context/focus"
 import { useKobeKeybindings } from "./context/keybindings"
@@ -619,7 +620,7 @@ function Shell(props: AppDeps) {
           <PaneHeader
             title="WORKSPACE"
             ordinal="j"
-            subtitle={activeTask()?.title ?? "no task"}
+            subtitle={activeTaskRepoBranchLabel(activeTask())}
             asideRight={workspaceAsideRight()}
             focused={focusedPane() === "workspace"}
           />

--- a/packages/kobe/src/tui/component/top-bar-helpers.ts
+++ b/packages/kobe/src/tui/component/top-bar-helpers.ts
@@ -6,13 +6,17 @@ export function activeTaskSessionId(task: Task | undefined, activeChatTabId: str
   return task.tabs.find((tab) => tab.id === tabId)?.sessionId ?? null
 }
 
-export function activeTaskTopBarLabel(task: Task | undefined): string | null {
+export type ActiveTaskTopBarParts = {
+  readonly repoName: string
+  readonly branch: string
+}
+
+export function activeTaskTopBarParts(task: Task | undefined): ActiveTaskTopBarParts | null {
   if (!task) return null
   const repoName = repoBasename(task.repo)
   const branch = task.branch.trim()
-  if (!repoName) return branch || null
-  if (!branch) return repoName
-  return `${repoName} / ${branch}`
+  if (!repoName && !branch) return null
+  return { repoName, branch }
 }
 
 function repoBasename(repo: string): string {

--- a/packages/kobe/src/tui/component/top-bar-helpers.ts
+++ b/packages/kobe/src/tui/component/top-bar-helpers.ts
@@ -5,17 +5,3 @@ export function activeTaskSessionId(task: Task | undefined, activeChatTabId: str
   const tabId = activeChatTabId ?? task.activeTabId
   return task.tabs.find((tab) => tab.id === tabId)?.sessionId ?? null
 }
-
-export function activeTaskRepoBranchLabel(task: Task | undefined): string {
-  if (!task) return "no task"
-  const repoName = repoBasename(task.repo)
-  const branch = task.branch.trim()
-  if (!repoName) return branch || task.title || "untitled"
-  if (!branch) return repoName
-  return `${repoName} / ${branch}`
-}
-
-function repoBasename(repo: string): string {
-  const segments = repo.split(/[\\/]+/).filter(Boolean)
-  return segments[segments.length - 1] ?? repo
-}

--- a/packages/kobe/src/tui/component/top-bar-helpers.ts
+++ b/packages/kobe/src/tui/component/top-bar-helpers.ts
@@ -5,3 +5,17 @@ export function activeTaskSessionId(task: Task | undefined, activeChatTabId: str
   const tabId = activeChatTabId ?? task.activeTabId
   return task.tabs.find((tab) => tab.id === tabId)?.sessionId ?? null
 }
+
+export function activeTaskTopBarLabel(task: Task | undefined): string | null {
+  if (!task) return null
+  const repoName = repoBasename(task.repo)
+  const branch = task.branch.trim()
+  if (!repoName) return branch || null
+  if (!branch) return repoName
+  return `${repoName} / ${branch}`
+}
+
+function repoBasename(repo: string): string {
+  const segments = repo.split(/[\\/]+/).filter(Boolean)
+  return segments[segments.length - 1] ?? repo
+}

--- a/packages/kobe/src/tui/component/top-bar-helpers.ts
+++ b/packages/kobe/src/tui/component/top-bar-helpers.ts
@@ -5,3 +5,17 @@ export function activeTaskSessionId(task: Task | undefined, activeChatTabId: str
   const tabId = activeChatTabId ?? task.activeTabId
   return task.tabs.find((tab) => tab.id === tabId)?.sessionId ?? null
 }
+
+export function activeTaskRepoBranchLabel(task: Task | undefined): string {
+  if (!task) return "no task"
+  const repoName = repoBasename(task.repo)
+  const branch = task.branch.trim()
+  if (!repoName) return branch || task.title || "untitled"
+  if (!branch) return repoName
+  return `${repoName} / ${branch}`
+}
+
+function repoBasename(repo: string): string {
+  const segments = repo.split(/[\\/]+/).filter(Boolean)
+  return segments[segments.length - 1] ?? repo
+}

--- a/packages/kobe/src/tui/component/top-bar.tsx
+++ b/packages/kobe/src/tui/component/top-bar.tsx
@@ -4,10 +4,7 @@
  * right PR button width.
  *
  *   - Left:   `KobeCode vX.Y.Z` + optional `↑ update available` chip.
- *   - Center: active task's branch name (no "Repo <name>" prefix —
- *             kobe spans many repos so a single repo label in the
- *             topbar is misleading; the active branch alone is the
- *             useful per-task signal).
+ *   - Center: active task's repo basename + branch (`repo / branch`).
  *   - Right:  CreatePRButton.
  *
  * Extracted from `src/tui/app.tsx` during the Shell refactor.
@@ -28,6 +25,7 @@ import { DialogConfirm } from "../ui/dialog-confirm"
 import { CreatePRButton } from "./create-pr-button"
 import { OpenWorktreeButton } from "./open-worktree-button"
 import { RcBridgeDialog } from "./rc-bridge-dialog"
+import { activeTaskTopBarLabel } from "./top-bar-helpers"
 import { UpdateDialog } from "./update-dialog"
 
 export function TopBar(props: {
@@ -159,7 +157,7 @@ export function TopBar(props: {
         >
           <Show when={props.activeTask() !== undefined}>
             <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
-              {props.activeTask()?.branch}
+              {activeTaskTopBarLabel(props.activeTask())}
             </text>
           </Show>
         </Show>

--- a/packages/kobe/src/tui/component/top-bar.tsx
+++ b/packages/kobe/src/tui/component/top-bar.tsx
@@ -25,7 +25,7 @@ import { DialogConfirm } from "../ui/dialog-confirm"
 import { CreatePRButton } from "./create-pr-button"
 import { OpenWorktreeButton } from "./open-worktree-button"
 import { RcBridgeDialog } from "./rc-bridge-dialog"
-import { activeTaskTopBarLabel } from "./top-bar-helpers"
+import { activeTaskTopBarParts } from "./top-bar-helpers"
 import { UpdateDialog } from "./update-dialog"
 
 export function TopBar(props: {
@@ -58,6 +58,7 @@ export function TopBar(props: {
   const remoteOrch = props.orchestrator instanceof RemoteOrchestrator ? props.orchestrator : null
   const rcBridge = props.orchestrator.rcBridgeSignal()
   const isBridgeOn = () => rcBridge().state === "running" || rcBridge().state === "starting"
+  const activeLabel = createMemo(() => activeTaskTopBarParts(props.activeTask()))
 
   async function confirmUpdate(): Promise<void> {
     const info = props.updateInfo()
@@ -155,10 +156,30 @@ export function TopBar(props: {
             </text>
           }
         >
-          <Show when={props.activeTask() !== undefined}>
-            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
-              {activeTaskTopBarLabel(props.activeTask())}
-            </text>
+          <Show when={activeLabel()}>
+            {(label) => (
+              <box flexDirection="row" gap={1} justifyContent="center">
+                <Show when={label().repoName}>
+                  <text
+                    fg={label().branch ? theme.textMuted : theme.text}
+                    attributes={label().branch ? undefined : TextAttributes.BOLD}
+                    wrapMode="none"
+                  >
+                    {label().repoName}
+                  </text>
+                </Show>
+                <Show when={label().repoName && label().branch}>
+                  <text fg={theme.textMuted} wrapMode="none">
+                    /
+                  </text>
+                </Show>
+                <Show when={label().branch}>
+                  <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
+                    {label().branch}
+                  </text>
+                </Show>
+              </box>
+            )}
           </Show>
         </Show>
       </box>

--- a/packages/kobe/test/tui/top-bar-helpers.test.ts
+++ b/packages/kobe/test/tui/top-bar-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { activeTaskSessionId } from "../../src/tui/component/top-bar-helpers"
+import { activeTaskRepoBranchLabel, activeTaskSessionId } from "../../src/tui/component/top-bar-helpers"
 import { type Task, toTaskId } from "../../src/types/task"
 
 function taskWithTabs(activeTabId: string): Task {
@@ -33,5 +33,25 @@ describe("activeTaskSessionId", () => {
 
   test("does not fall back to the legacy task session id when the active tab is missing", () => {
     expect(activeTaskSessionId(taskWithTabs("missing"), "missing")).toBeNull()
+  })
+})
+
+describe("activeTaskRepoBranchLabel", () => {
+  test("renders repo basename and branch for regular tasks", () => {
+    expect(activeTaskRepoBranchLabel(taskWithTabs("tab-a"))).toBe("repo / kobe/demo")
+  })
+
+  test("handles trailing slashes in repo paths", () => {
+    expect(activeTaskRepoBranchLabel({ ...taskWithTabs("tab-a"), repo: "/Users/jacksonc/i/kobe/" })).toBe(
+      "kobe / kobe/demo",
+    )
+  })
+
+  test("omits the slash when branch is not allocated yet", () => {
+    expect(activeTaskRepoBranchLabel({ ...taskWithTabs("tab-a"), branch: "" })).toBe("repo")
+  })
+
+  test("returns no task without an active task", () => {
+    expect(activeTaskRepoBranchLabel(undefined)).toBe("no task")
   })
 })

--- a/packages/kobe/test/tui/top-bar-helpers.test.ts
+++ b/packages/kobe/test/tui/top-bar-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { activeTaskSessionId } from "../../src/tui/component/top-bar-helpers"
+import { activeTaskSessionId, activeTaskTopBarLabel } from "../../src/tui/component/top-bar-helpers"
 import { type Task, toTaskId } from "../../src/types/task"
 
 function taskWithTabs(activeTabId: string): Task {
@@ -33,5 +33,25 @@ describe("activeTaskSessionId", () => {
 
   test("does not fall back to the legacy task session id when the active tab is missing", () => {
     expect(activeTaskSessionId(taskWithTabs("missing"), "missing")).toBeNull()
+  })
+})
+
+describe("activeTaskTopBarLabel", () => {
+  test("renders repo basename and branch for regular tasks", () => {
+    expect(activeTaskTopBarLabel(taskWithTabs("tab-a"))).toBe("repo / kobe/demo")
+  })
+
+  test("handles trailing slashes in repo paths", () => {
+    expect(activeTaskTopBarLabel({ ...taskWithTabs("tab-a"), repo: "/Users/jacksonc/i/kobe/" })).toBe(
+      "kobe / kobe/demo",
+    )
+  })
+
+  test("uses repo basename when branch is not allocated yet", () => {
+    expect(activeTaskTopBarLabel({ ...taskWithTabs("tab-a"), branch: "" })).toBe("repo")
+  })
+
+  test("returns null without an active task", () => {
+    expect(activeTaskTopBarLabel(undefined)).toBeNull()
   })
 })

--- a/packages/kobe/test/tui/top-bar-helpers.test.ts
+++ b/packages/kobe/test/tui/top-bar-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { activeTaskSessionId, activeTaskTopBarLabel } from "../../src/tui/component/top-bar-helpers"
+import { activeTaskSessionId, activeTaskTopBarParts } from "../../src/tui/component/top-bar-helpers"
 import { type Task, toTaskId } from "../../src/types/task"
 
 function taskWithTabs(activeTabId: string): Task {
@@ -36,22 +36,23 @@ describe("activeTaskSessionId", () => {
   })
 })
 
-describe("activeTaskTopBarLabel", () => {
-  test("renders repo basename and branch for regular tasks", () => {
-    expect(activeTaskTopBarLabel(taskWithTabs("tab-a"))).toBe("repo / kobe/demo")
+describe("activeTaskTopBarParts", () => {
+  test("returns repo basename and branch for regular tasks", () => {
+    expect(activeTaskTopBarParts(taskWithTabs("tab-a"))).toEqual({ repoName: "repo", branch: "kobe/demo" })
   })
 
   test("handles trailing slashes in repo paths", () => {
-    expect(activeTaskTopBarLabel({ ...taskWithTabs("tab-a"), repo: "/Users/jacksonc/i/kobe/" })).toBe(
-      "kobe / kobe/demo",
-    )
+    expect(activeTaskTopBarParts({ ...taskWithTabs("tab-a"), repo: "/Users/jacksonc/i/kobe/" })).toEqual({
+      repoName: "kobe",
+      branch: "kobe/demo",
+    })
   })
 
   test("uses repo basename when branch is not allocated yet", () => {
-    expect(activeTaskTopBarLabel({ ...taskWithTabs("tab-a"), branch: "" })).toBe("repo")
+    expect(activeTaskTopBarParts({ ...taskWithTabs("tab-a"), branch: "" })).toEqual({ repoName: "repo", branch: "" })
   })
 
   test("returns null without an active task", () => {
-    expect(activeTaskTopBarLabel(undefined)).toBeNull()
+    expect(activeTaskTopBarParts(undefined)).toBeNull()
   })
 })

--- a/packages/kobe/test/tui/top-bar-helpers.test.ts
+++ b/packages/kobe/test/tui/top-bar-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { activeTaskRepoBranchLabel, activeTaskSessionId } from "../../src/tui/component/top-bar-helpers"
+import { activeTaskSessionId } from "../../src/tui/component/top-bar-helpers"
 import { type Task, toTaskId } from "../../src/types/task"
 
 function taskWithTabs(activeTabId: string): Task {
@@ -33,25 +33,5 @@ describe("activeTaskSessionId", () => {
 
   test("does not fall back to the legacy task session id when the active tab is missing", () => {
     expect(activeTaskSessionId(taskWithTabs("missing"), "missing")).toBeNull()
-  })
-})
-
-describe("activeTaskRepoBranchLabel", () => {
-  test("renders repo basename and branch for regular tasks", () => {
-    expect(activeTaskRepoBranchLabel(taskWithTabs("tab-a"))).toBe("repo / kobe/demo")
-  })
-
-  test("handles trailing slashes in repo paths", () => {
-    expect(activeTaskRepoBranchLabel({ ...taskWithTabs("tab-a"), repo: "/Users/jacksonc/i/kobe/" })).toBe(
-      "kobe / kobe/demo",
-    )
-  })
-
-  test("omits the slash when branch is not allocated yet", () => {
-    expect(activeTaskRepoBranchLabel({ ...taskWithTabs("tab-a"), branch: "" })).toBe("repo")
-  })
-
-  test("returns no task without an active task", () => {
-    expect(activeTaskRepoBranchLabel(undefined)).toBe("no task")
   })
 })


### PR DESCRIPTION
## Summary
- Shows the active task repo context in the top bar by rendering the repo basename next to the existing branch label.
- Keeps the WORKSPACE header focused on the task title, and styles the repo as muted context while branch stays primary.
- Adds helper coverage for active top-bar label parts, including branchless tasks and trailing slash repo paths.

## Tests
- `bun --filter @sma1lboy/kobe test test/tui/top-bar-helpers.test.ts`
- `bun --filter @sma1lboy/kobe typecheck`
- `bun --filter @sma1lboy/kobe lint`
- `bun --filter @sma1lboy/kobe build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the active task display in the top bar to show both repository name and branch information, improving visibility of the currently active task context.

* **Tests**
  * Added comprehensive test coverage for the new top-bar display logic, including edge cases for missing branches and inactive tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->