### PR TITLE
feat: KOB-172 — prompt model picker after /clear

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,10 +25,9 @@
     },
     "packages/kobe": {
       "name": "@sma1lboy/kobe",
-      "version": "0.5.21",
+      "version": "0.5.23",
       "bin": {
         "kobe": "dist/cli/index.js",
-        "kobed": "dist/bin/kobed.js",
       },
       "dependencies": {
         "@ansi-tools/parser": "^1.0.15",

--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -185,7 +185,7 @@ export function Chat(props: ChatProps) {
     const kobeEntries: ComposerSlashEntry[] = [
       {
         display: "/clear",
-        description: "Reset this chat tab (drops session, keeps history on disk)",
+        description: "Reset this chat tab (drops session, then pick a model for the new one)",
         source: "builtin",
         onSelect: () => {
           void send("/clear")
@@ -399,11 +399,19 @@ export function Chat(props: ChatProps) {
     return getIdentity(activeVendor()).inputPlaceholder
   })
 
-  async function chooseModel(): Promise<void> {
+  /**
+   * Open the model picker for the active tab.
+   *
+   * `forceVendorUnlock` skips the active-session vendor lock — used by
+   * the `/clear` path, which has just dropped the session but whose
+   * `sessionId: null` update arrives over the socket asynchronously, so
+   * `activeTabHasSession()` may still read stale `true` at call time.
+   */
+  async function chooseModel(forceVendorUnlock = false): Promise<void> {
     const id = props.taskId()
     if (!id) return
     const tabId = activeTabId() ?? undefined
-    const lockedVendor = activeTabHasSession() ? activeVendor() : undefined
+    const lockedVendor = !forceVendorUnlock && activeTabHasSession() ? activeVendor() : undefined
     const result = await ModelPicker.show(dialog, modelId(), modelEffort(), activeVendor(), lockedVendor)
     if (result === undefined) return
     await props.orchestrator.setModel(id, result.id, tabId, result.effort, result.vendor).catch((err: unknown) => {
@@ -622,7 +630,9 @@ export function Chat(props: ChatProps) {
         await props.orchestrator.clearTab(taskId, tabId)
       } catch (err) {
         patchActiveState((s) => pushSystemError(s, `/clear failed: ${stringifyErr(err)}`))
+        return
       }
+      await chooseModel(true)
       return
     }
 


### PR DESCRIPTION
## Summary
- `/clear` now opens the ModelPicker once the tab session is dropped, pre-selected on the current model so Enter/Esc keeps it — the user can also switch to a different model or engine instead of being locked into the old vendor.
- Added a `forceVendorUnlock` arg so the `/clear` path skips the active-session vendor lock, since `sessionId: null` arrives over the socket asynchronously and would otherwise leave `activeTabHasSession()` reading stale `true`.
- Synced `bun.lock` with the v0.5.23 release.

## Test plan
- [x] `bun run typecheck`
- [ ] Spot-check `/clear` in a live tab: picker opens on the current model, vendor selectable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `/clear` command now properly drops the session and prompts for model re-selection.
  * Improved error handling for the clear operation.
  * Fixed model selection logic to use current session state instead of stale cached information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->