### PR TITLE
feat: KOB-174 — nest subagent tool steps under parent chat row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ The engine adapter is the source of truth for **agent/product identity, capabili
 - Model catalogs and context-window math come from `EngineCapabilities`, keyed by the task's vendor when available. Do not infer a task's vendor solely from a model id unless the task has no vendor.
 - Persisted history is returned as an engine-owned `EngineHistory` (`messages` + `usageMetrics`). Claude Code may derive this from `~/.claude/projects/*.jsonl`; Codex may derive it from `~/.codex/sessions/**/rollout-*.jsonl`; callers should not know either format.
 - Token usage, context usage, and speed are engine-normalized data. The TUI may format `usageMetrics` for display, but it should not parse vendor transcript files or reconstruct speed from chat timestamps.
+- Subagent (Agent/Task) steps are engine-owned **nested** data, not transcript noise. The engine tags a subagent's internal tool events with a `parentId` (`EngineEvent.tool.start` / `tool.result`); the chat nests them under the parent Agent row's `children` rather than flattening them into the top-level transcript. A subagent's prose / `system` / terminal `result` are NOT surfaced — only its tool steps. kobe nests one level: deeper (grand-child) subagent steps are dropped at the parser, never mis-attached. History-replay nesting is KOB-177.
 - If a new pane needs engine-specific data, extend the engine contract first. Do not thread ad hoc vendor checks through TUI or orchestrator code.
 
 ### Diagrams in `docs/`: use Mermaid

--- a/bun.lock
+++ b/bun.lock
@@ -25,10 +25,9 @@
     },
     "packages/kobe": {
       "name": "@sma1lboy/kobe",
-      "version": "0.5.21",
+      "version": "0.5.23",
       "bin": {
         "kobe": "dist/cli/index.js",
-        "kobed": "dist/bin/kobed.js",
       },
       "dependencies": {
         "@ansi-tools/parser": "^1.0.15",

--- a/packages/kobe/src/engine/claude-code-local/stream.ts
+++ b/packages/kobe/src/engine/claude-code-local/stream.ts
@@ -94,16 +94,26 @@ export async function* parseStreamJson(lines: LineSource, opts: ParseStreamJsonO
     if (!type) continue
 
     // Subagent events carry `parent_tool_use_id` set to the parent's
-    // Agent/Task tool_use id. Their assistant text/tool_use and user
-    // tool_result blocks are the subagent's *internal* work — the
-    // parent's chat already sees the Agent tool_use (input) and its
-    // matching tool_result (the subagent's final summary). Letting the
-    // internal blocks through would interleave the subagent's Glob /
-    // Read / Bash banners with the parent's transcript and bury the
-    // Agent row under noise. Drop them at the parser. Only events with
-    // `parent_tool_use_id: null` (or absent) belong to the top-level
-    // session.
-    if ("parent_tool_use_id" in msg && msg.parent_tool_use_id != null) continue
+    // Agent/Task tool_use id. We surface the subagent's *tool steps*
+    // (its Read / Grep / Bash calls) so the chat can nest them under
+    // the parent Agent row — the user watches the subagent's progress
+    // live instead of staring at an opaque Agent spinner. What we do
+    // NOT surface from a subagent:
+    //   - its assistant text / reasoning — that's the subagent's
+    //     internal prose; flattening it into the parent transcript is
+    //     the pollution the nesting is meant to avoid.
+    //   - its `system` (a separate session_id we must not capture as
+    //     the parent's) and its terminal `result` (would fire a
+    //     top-level `done` and kill the *parent* stream).
+    // So a subagent contributes only `assistant` tool_use blocks and
+    // `user` tool_result blocks, each tagged with `parentId`. Events
+    // with `parent_tool_use_id: null` (or absent) belong to the
+    // top-level session and pass through normally.
+    const parentToolUseId =
+      "parent_tool_use_id" in msg && typeof msg.parent_tool_use_id === "string"
+        ? (msg.parent_tool_use_id as string)
+        : undefined
+    if (parentToolUseId != null && type !== "assistant" && type !== "user") continue
 
     if (type === "system") {
       const subtype = typeof msg.subtype === "string" ? (msg.subtype as string) : undefined
@@ -124,6 +134,8 @@ export async function* parseStreamJson(lines: LineSource, opts: ParseStreamJsonO
         if (!isObject(block)) continue
         const blockType = typeof block.type === "string" ? (block.type as string) : undefined
         if (blockType === "text") {
+          // Subagent prose stays internal — only its tool steps surface.
+          if (parentToolUseId != null) continue
           const text = typeof block.text === "string" ? (block.text as string) : ""
           if (text) yield { type: "assistant.delta", text }
         } else if (blockType === "tool_use") {
@@ -131,7 +143,13 @@ export async function* parseStreamJson(lines: LineSource, opts: ParseStreamJsonO
           const id = typeof block.id === "string" ? (block.id as string) : undefined
           if (id) toolNameById.set(id, name)
           const input = "input" in block ? block.input : undefined
-          yield { type: "tool.start", name, input }
+          yield {
+            type: "tool.start",
+            name,
+            input,
+            ...(id ? { id } : {}),
+            ...(parentToolUseId != null ? { parentId: parentToolUseId } : {}),
+          }
         }
       }
       continue
@@ -146,7 +164,12 @@ export async function* parseStreamJson(lines: LineSource, opts: ParseStreamJsonO
           const id = typeof block.tool_use_id === "string" ? (block.tool_use_id as string) : undefined
           const name = (id && toolNameById.get(id)) || "tool"
           const output = "content" in block ? block.content : undefined
-          yield { type: "tool.result", name, output }
+          yield {
+            type: "tool.result",
+            name,
+            output,
+            ...(parentToolUseId != null ? { parentId: parentToolUseId } : {}),
+          }
         }
       }
       continue

--- a/packages/kobe/src/tui/panes/chat/ToolRow.tsx
+++ b/packages/kobe/src/tui/panes/chat/ToolRow.tsx
@@ -18,9 +18,10 @@ import {
   formatWriteDiff,
 } from "./edit-diff"
 import { BLACK_CIRCLE, RESULT_PREFIX } from "./message-figures"
-import type { ChatRow } from "./store"
+import type { ChatRow, ToolChildRow } from "./store"
 import { summarizeGlob, summarizeGrep, summarizeRead } from "./tool-banners"
-import { lookupToolMeta } from "./tool-registry"
+import { type ToolCounts, summarizeToolRun } from "./tool-fold"
+import { classifyTool, lookupToolMeta } from "./tool-registry"
 
 /**
  * One-line input preview for tool-call banners. Mirrors
@@ -97,12 +98,16 @@ export function ToolRow(props: {
   const isMultiEdit = () => meta().body === "multi-edit-diff"
   const isBash = () => meta().banner === "bash"
   const isReadGrepGlob = () => meta().banner === "read-grep-glob"
+  const isSubagent = () => meta().body === "subagent"
   /** Tools whose banner replaces the generic `tool(arg-preview)` chip. */
   const usesCustomBanner = () => meta().banner !== "default" || meta().body !== "default"
   /** Tools whose body renders inline so the generic preview/expanded
    *  blocks below should be suppressed. */
   const usesCustomBody = () =>
-    meta().body === "edit-diff" || meta().body === "multi-edit-diff" || meta().body === "bash-output"
+    meta().body === "edit-diff" ||
+    meta().body === "multi-edit-diff" ||
+    meta().body === "bash-output" ||
+    meta().body === "subagent"
   const diff = (): FormattedDiff | null => {
     if (r().name === "Edit") return formatEditDiff(r().input)
     if (r().name === "Write") return formatWriteDiff(r().input)
@@ -121,24 +126,31 @@ export function ToolRow(props: {
         </text>
         <box flexGrow={1}>
           <Show
-            when={isReadGrepGlob()}
+            when={isSubagent()}
             fallback={
               <Show
-                when={isBash()}
+                when={isReadGrepGlob()}
                 fallback={
-                  <text fg={theme.text}>
-                    <span style={{ attributes: TextAttributes.BOLD }}>{r().name}</span>
-                    <Show when={!usesCustomBanner()}>
-                      <span style={{ fg: theme.textMuted }}>({previewToolInput(r().input)})</span>
-                    </Show>
-                  </text>
+                  <Show
+                    when={isBash()}
+                    fallback={
+                      <text fg={theme.text}>
+                        <span style={{ attributes: TextAttributes.BOLD }}>{r().name}</span>
+                        <Show when={!usesCustomBanner()}>
+                          <span style={{ fg: theme.textMuted }}>({previewToolInput(r().input)})</span>
+                        </Show>
+                      </text>
+                    }
+                  >
+                    <BashBanner row={r()} />
+                  </Show>
                 }
               >
-                <BashBanner row={r()} />
+                <ReadGrepGlobBanner row={r()} />
               </Show>
             }
           >
-            <ReadGrepGlobBanner row={r()} />
+            <SubagentBanner row={r()} />
           </Show>
         </box>
       </box>
@@ -161,6 +173,12 @@ export function ToolRow(props: {
           Bash calls (no output to render yet) and for empty output. */}
       <Show when={isBash() && r().done}>
         <BashOutputBlock output={r().output} expanded={props.expanded} onToggle={props.onToggle} />
+      </Show>
+      {/* Subagent (Agent/Task) — nested tool-step progress. Collapsed:
+          a one-line "Searching 2 patterns, reading 3 files…" summary.
+          Expanded: the per-step list. */}
+      <Show when={isSubagent()}>
+        <SubagentBody row={r()} expanded={props.expanded} onToggle={props.onToggle} />
       </Show>
       {/* Result preview — collapsed view shows one indented line.
           Suppressed for tools with custom bodies (Edit/Write/MultiEdit/
@@ -428,5 +446,108 @@ function ReadGrepGlobBanner(props: { row: Extract<ChatRow, { kind: "tool" }> }) 
         <span style={{ fg: theme.textMuted }}>{` ${summary()}`}</span>
       </Show>
     </text>
+  )
+}
+
+/**
+ * Pull the human-readable description out of an Agent/Task tool input.
+ * Claude's Task tool takes `{ description, prompt, subagent_type }`;
+ * `description` is the short label the parent agent gave the subagent.
+ */
+function subagentDescription(input: unknown): string {
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    const d = (input as Record<string, unknown>).description
+    if (typeof d === "string" && d.trim().length > 0) return d.trim()
+  }
+  return ""
+}
+
+/**
+ * Banner for an Agent/Task (subagent) tool row — bold tool name plus
+ * the dim `(description)` the parent gave the subagent. Mirrors the
+ * `ReadGrepGlobBanner` shape so all the "named activity" rows read the
+ * same.
+ */
+function SubagentBanner(props: { row: Extract<ChatRow, { kind: "tool" }> }) {
+  const { theme } = useTheme()
+  const desc = () => subagentDescription(props.row.input)
+  return (
+    <text fg={theme.text} wrapMode="none">
+      <span style={{ attributes: TextAttributes.BOLD }}>{props.row.name}</span>
+      <Show when={desc().length > 0}>
+        <span style={{ fg: theme.textMuted }}>{` (${desc()})`}</span>
+      </Show>
+    </text>
+  )
+}
+
+/**
+ * Body for an Agent/Task (subagent) tool row — shows the subagent's
+ * nested tool steps (collected on `row.children` from `parentId`-tagged
+ * engine events). This is the "watch the subagent work" surface: kobe
+ * deliberately does NOT flatten the subagent's Read/Grep/Bash calls
+ * into the parent transcript (that's noise), so this nested block is
+ * the only place they appear.
+ *
+ *   - Collapsed: one dim progress line — `Searching 2 patterns, reading
+ *     3 files` while in flight, `Searched …, read …` once the subagent
+ *     finishes. Reuses `summarizeToolRun`, the same summary the
+ *     top-level tool-fold uses, so the vocabulary is consistent.
+ *   - Expanded: the per-step list, each step a `● name(args)` line with
+ *     a running/done glyph.
+ */
+function SubagentBody(props: {
+  row: Extract<ChatRow, { kind: "tool" }>
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const { theme } = useTheme()
+  const children = (): readonly ToolChildRow[] => props.row.children ?? []
+  const counts = (): ToolCounts => {
+    const c: ToolCounts = { search: 0, read: 0, list: 0, bash: 0, other: 0 }
+    for (const ch of children()) c[classifyTool(ch.name)]++
+    return c
+  }
+  const anyInFlight = () => children().some((ch) => !ch.done)
+  const summary = (): string => {
+    if (children().length === 0) return props.row.done ? "No tool steps" : "Starting…"
+    return summarizeToolRun(counts(), anyInFlight())
+  }
+  return (
+    <box paddingLeft={2} flexDirection="column" onMouseUp={() => props.onToggle()}>
+      <Show when={!props.expanded}>
+        <text fg={theme.textMuted} wrapMode="none">
+          {RESULT_PREFIX}
+          {summary()}
+        </text>
+      </Show>
+      <Show when={props.expanded}>
+        <Show
+          when={children().length > 0}
+          fallback={
+            <text fg={theme.textMuted} wrapMode="none">
+              {RESULT_PREFIX}
+              {summary()}
+            </text>
+          }
+        >
+          <For each={children()}>
+            {(ch) => (
+              <box flexDirection="row" gap={1}>
+                <text fg={ch.done ? theme.success : theme.warning} attributes={TextAttributes.BOLD}>
+                  {ch.done ? BLACK_CIRCLE : "✻"}
+                </text>
+                <box flexGrow={1}>
+                  <text fg={theme.text} wrapMode="none">
+                    <span style={{ attributes: TextAttributes.BOLD }}>{ch.name}</span>
+                    <span style={{ fg: theme.textMuted }}>{`(${previewToolInput(ch.input)})`}</span>
+                  </text>
+                </box>
+              </box>
+            )}
+          </For>
+        </Show>
+      </Show>
+    </box>
   )
 }

--- a/packages/kobe/src/tui/panes/chat/store.ts
+++ b/packages/kobe/src/tui/panes/chat/store.ts
@@ -107,6 +107,31 @@ export function cleanChatText(text: string): string {
 
 export type { QueuedPrompt } from "./queue.ts"
 
+/**
+ * One nested tool step run *inside* a subagent (Agent/Task) tool call.
+ *
+ * The engine reports a subagent's internal Read/Grep/Bash calls with a
+ * `parentId` pointing at the Agent row's `toolUseId` (see
+ * {@link EngineEvent} `tool.start`). Rather than appending those to the
+ * top-level transcript — which would bury the Agent row in noise — the
+ * chat collects them here, on the parent tool row's {@link ChatRow}
+ * `children`, and the renderer shows them nested + collapsible under
+ * the Agent banner. This mirrors Claude Code's own TUI, where a Task's
+ * sub-steps render indented beneath it.
+ *
+ * Deliberately lighter than a full tool ChatRow: no `ts`, no nested
+ * `children` (kobe flattens grandchild subagents — a subagent that
+ * itself spawns a subagent has those deeper steps dropped at the
+ * parser rather than mis-attached). Just enough to render the step
+ * banner + a done/running glyph.
+ */
+export interface ToolChildRow {
+  readonly name: string
+  readonly input: unknown
+  readonly output?: unknown
+  readonly done: boolean
+}
+
 /** One chronological row in the chat. The renderer maps these to JSX. */
 export type ChatRow =
   | { readonly kind: "user"; readonly text: string; readonly ts: string }
@@ -126,9 +151,22 @@ export type ChatRow =
        * case — which is fine in-stream where one call rarely overlaps
        * with another of the same name, but breaks for replay where
        * the full session is on disk and parallel same-name calls are
-       * common). Optional: live tool rows leave it undefined.
+       * common). Optional: history-hydrated rows always set it; live
+       * rows set it whenever the engine event carried an `id` (the
+       * Claude path always does) so subagent child steps can be paired
+       * to this row by `parentId === toolUseId`.
        */
       readonly toolUseId?: string
+      /**
+       * Nested tool steps run inside this call when it is a subagent
+       * (Agent/Task) invocation. Populated live from `tool.start` /
+       * `tool.result` events carrying a `parentId` equal to this row's
+       * `toolUseId`. Absent for ordinary (non-subagent) tool rows and
+       * for history-hydrated rows (replay nesting is a follow-up —
+       * subagents persist to a separate JSONL the history reader
+       * doesn't load).
+       */
+      readonly children?: readonly ToolChildRow[]
     }
   | { readonly kind: "system"; readonly text: string; readonly ts: string }
   /**
@@ -363,15 +401,60 @@ export function applyEvent(
         messages: capMessages([...state.messages, { kind: "assistant", text: ev.text, ts: nowIso }], nowIso),
       }
     }
-    case "tool.start":
+    case "tool.start": {
+      // Subagent child step: nest it under the parent Agent/Task row
+      // instead of appending to the top-level transcript. Match the
+      // parent by `toolUseId === ev.parentId`. If no parent row exists
+      // (a grandchild — a subagent that itself spawned a subagent;
+      // kobe nests one level only), drop it rather than pollute the
+      // top-level chat.
+      if (ev.parentId != null) {
+        const pidx = findLastIndex(state.messages, (m) => m.kind === "tool" && m.toolUseId === ev.parentId)
+        if (pidx < 0) return state
+        const parent = state.messages[pidx] as Extract<ChatRow, { kind: "tool" }>
+        const child: ToolChildRow = { name: ev.name, input: ev.input, done: false }
+        const patched: ChatRow = { ...parent, children: [...(parent.children ?? []), child] }
+        const next = state.messages.slice()
+        next[pidx] = patched
+        // In-place patch — no length change, cap not needed.
+        return { ...state, messages: next }
+      }
       return {
         ...state,
         messages: capMessages(
-          [...state.messages, { kind: "tool", name: ev.name, input: ev.input, done: false, ts: nowIso }],
+          [
+            ...state.messages,
+            {
+              kind: "tool",
+              name: ev.name,
+              input: ev.input,
+              done: false,
+              ts: nowIso,
+              ...(ev.id ? { toolUseId: ev.id } : {}),
+            },
+          ],
           nowIso,
         ),
       }
+    }
     case "tool.result": {
+      // Subagent child result: patch the matching child on its parent
+      // Agent/Task row. Same parent lookup as `tool.start`; same
+      // grandchild-drop rule.
+      if (ev.parentId != null) {
+        const pidx = findLastIndex(state.messages, (m) => m.kind === "tool" && m.toolUseId === ev.parentId)
+        if (pidx < 0) return state
+        const parent = state.messages[pidx] as Extract<ChatRow, { kind: "tool" }>
+        const kids = parent.children ?? []
+        const cidx = findLastIndex(kids, (c) => !c.done && c.name === ev.name)
+        if (cidx < 0) return state
+        const nextKids = kids.slice()
+        nextKids[cidx] = { ...(kids[cidx] as ToolChildRow), output: ev.output, done: true }
+        const patched: ChatRow = { ...parent, children: nextKids }
+        const next = state.messages.slice()
+        next[pidx] = patched
+        return { ...state, messages: next }
+      }
       // Find the most recent unfinished tool row with this name and
       // patch it. If none, append a standalone result row.
       const idx = findLastIndex(state.messages, (m) => m.kind === "tool" && !m.done && m.name === ev.name)

--- a/packages/kobe/src/tui/panes/chat/store.ts
+++ b/packages/kobe/src/tui/panes/chat/store.ts
@@ -162,7 +162,7 @@ export type ChatRow =
        * (Agent/Task) invocation. Populated live from `tool.start` /
        * `tool.result` events carrying a `parentId` equal to this row's
        * `toolUseId`. Absent for ordinary (non-subagent) tool rows and
-       * for history-hydrated rows (replay nesting is a follow-up —
+       * for history-hydrated rows (replay nesting is KOB-177 —
        * subagents persist to a separate JSONL the history reader
        * doesn't load).
        */

--- a/packages/kobe/src/tui/panes/chat/tool-fold.tsx
+++ b/packages/kobe/src/tui/panes/chat/tool-fold.tsx
@@ -1,9 +1,19 @@
 import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../../context/theme"
 import type { ChatRow } from "./store"
-import { classifyTool } from "./tool-registry"
+import { classifyTool, isSubagentTool } from "./tool-registry"
 
-type ToolCounts = { search: number; read: number; list: number; bash: number; other: number }
+export type ToolCounts = { search: number; read: number; list: number; bash: number; other: number }
+
+/**
+ * A tool row is foldable into the "Searched N…, read M…" summary unless
+ * it is a subagent (Agent/Task) row — those carry their own nested
+ * progress UI and must render standalone. Non-tool rows are never
+ * foldable.
+ */
+function isFoldableTool(row: ChatRow | undefined): boolean {
+  return row?.kind === "tool" && !isSubagentTool(row.name)
+}
 
 export type MessageRenderItem =
   | { kind: "row"; row: ChatRow; index: number }
@@ -19,13 +29,13 @@ export function groupRenderItems(
   let i = 0
   while (i < messages.length) {
     const row = messages[i]
-    if (!row || row.kind !== "tool") {
+    if (!isFoldableTool(row)) {
       if (row) items.push({ kind: "row", row, index: i })
       i++
       continue
     }
     let j = i
-    while (j < messages.length && messages[j]?.kind === "tool") j++
+    while (j < messages.length && isFoldableTool(messages[j])) j++
     if (j - i >= TOOL_FOLD_THRESHOLD) {
       const counts: ToolCounts = { search: 0, read: 0, list: 0, bash: 0, other: 0 }
       let inFlight = 0

--- a/packages/kobe/src/tui/panes/chat/tool-registry.ts
+++ b/packages/kobe/src/tui/panes/chat/tool-registry.ts
@@ -51,8 +51,17 @@ export type ToolBannerStrategy = "default" | "bash" | "read-grep-glob"
  *   - `bash-output` — stdout/stderr block under the Bash banner.
  *   - `read-grep-glob` — banner already carries the summary; expanded
  *     view shows the raw output dump but no input block.
+ *   - `subagent` — Agent/Task invocation. Body renders the subagent's
+ *     nested tool steps (collected on the row's `children`): a
+ *     collapsed progress summary, expandable to the per-step list.
  */
-export type ToolBodyStrategy = "default" | "edit-diff" | "multi-edit-diff" | "bash-output" | "read-grep-glob"
+export type ToolBodyStrategy =
+  | "default"
+  | "edit-diff"
+  | "multi-edit-diff"
+  | "bash-output"
+  | "read-grep-glob"
+  | "subagent"
 
 export interface ToolMeta {
   readonly bucket: ToolBucket
@@ -78,6 +87,11 @@ const claudeRegistry: Readonly<Record<string, ToolMeta>> = {
   Grep: { bucket: "search", banner: "read-grep-glob", body: "read-grep-glob" },
   Glob: { bucket: "list", banner: "read-grep-glob", body: "read-grep-glob" },
   LS: { bucket: "list", banner: "default", body: "default" },
+  // Subagent invocation. Claude Code names the tool `Task`; older
+  // builds / docs also use `Agent` — register both so either spelling
+  // gets the nested-steps body.
+  Task: { bucket: "other", banner: "default", body: "subagent" },
+  Agent: { bucket: "other", banner: "default", body: "subagent" },
 }
 
 const registries: Readonly<Record<VendorId, Readonly<Record<string, ToolMeta>>>> = {
@@ -104,4 +118,16 @@ export function lookupToolMeta(name: string, vendor: VendorId = "claude"): ToolM
 /** Convenience alias kept for `groupRenderItems` (the fold-summary call site). */
 export function classifyTool(name: string, vendor: VendorId = "claude"): ToolBucket {
   return lookupToolMeta(name, vendor).bucket
+}
+
+/**
+ * True for Agent/Task tools that own nested subagent steps. The chat's
+ * tool-fold groups consecutive tool rows into a single summary; a
+ * subagent row carries its own progress UI and must stay un-folded, so
+ * `groupRenderItems` treats it as a fold boundary. Lives here (not as a
+ * literal name check in `tool-fold`) to keep vendor strings in the
+ * registry.
+ */
+export function isSubagentTool(name: string, vendor: VendorId = "claude"): boolean {
+  return lookupToolMeta(name, vendor).body === "subagent"
 }

--- a/packages/kobe/src/types/engine.ts
+++ b/packages/kobe/src/types/engine.ts
@@ -264,10 +264,29 @@ export type EngineEvent =
   | { readonly type: "assistant.delta"; readonly text: string }
   /** Streaming chunk of model reasoning / summary text. Empty chunks are ignored by the UI. */
   | { readonly type: "reasoning.delta"; readonly text: string }
-  /** A tool call has begun. `input` is the parsed tool args (engine-shaped). */
-  | { readonly type: "tool.start"; readonly name: string; readonly input: unknown }
-  /** A tool call completed. `output` is the parsed tool result. */
-  | { readonly type: "tool.result"; readonly name: string; readonly output: unknown }
+  /**
+   * A tool call has begun. `input` is the parsed tool args (engine-shaped).
+   *
+   * `id` is the engine's tool_use id when known (the live Claude path
+   * always has it; history replay does not plumb it here). `parentId`,
+   * when set, means this call is a *subagent's internal step* — the
+   * engine ran it inside an Agent/Task tool whose own id equals
+   * `parentId`. The chat nests these under the parent Agent row instead
+   * of appending them to the top-level transcript.
+   */
+  | {
+      readonly type: "tool.start"
+      readonly name: string
+      readonly input: unknown
+      readonly id?: string
+      readonly parentId?: string
+    }
+  /**
+   * A tool call completed. `output` is the parsed tool result.
+   * `parentId` carries the same subagent-nesting meaning as on
+   * {@link EngineEvent} `tool.start`.
+   */
+  | { readonly type: "tool.result"; readonly name: string; readonly output: unknown; readonly parentId?: string }
   /**
    * Token usage report; emitted at least once per turn (typically on the
    * terminal `result` frame). Optional cache fields mirror Anthropic's API

--- a/packages/kobe/test/engine/stream.test.ts
+++ b/packages/kobe/test/engine/stream.test.ts
@@ -90,7 +90,7 @@ describe("parseStreamJson", () => {
       ),
     )
     expect(events).toEqual([
-      { type: "tool.start", name: "Read", input: { path: "foo" } },
+      { type: "tool.start", name: "Read", input: { path: "foo" }, id: "tu_1" },
       { type: "tool.result", name: "Read", output: "file contents" },
       { type: "done" },
     ])
@@ -206,13 +206,15 @@ describe("parseStreamJson", () => {
     expect(events).toEqual([{ type: "done" }])
   })
 
-  it("filters subagent events by parent_tool_use_id so internal Glob/Read banners don't leak into the parent transcript", async () => {
+  it("surfaces subagent tool steps tagged with parentId, but not the subagent's prose", async () => {
     // Real shape captured from `claude -p ... --output-format stream-json`
     // with the Agent tool. Parent's Agent tool_use has parent_tool_use_id:
     // null. The subagent's own assistant tool_use (Glob) and user
     // tool_result both carry parent_tool_use_id: <parent's Agent id>.
-    // The parser must drop the subagent blocks; only the parent's Agent
-    // tool.start / tool.result should reach the chat.
+    // The parser surfaces the subagent's *tool steps* tagged with
+    // `parentId` (so the chat nests them under the Agent row) but drops
+    // the subagent's text/prose — only tool activity, not internal
+    // reasoning, reaches the parent.
     const parentAgentId = "toolu_018ZVWhh"
     const events = await collect(
       parseStreamJson(
@@ -271,7 +273,18 @@ describe("parseStreamJson", () => {
         type: "tool.start",
         name: "Agent",
         input: { description: "find md files", subagent_type: "Explore", prompt: "find" },
+        id: parentAgentId,
       },
+      // subagent Glob — surfaced, tagged with the parent Agent's id.
+      {
+        type: "tool.start",
+        name: "Glob",
+        input: { pattern: "*.md" },
+        id: "toolu_glob",
+        parentId: parentAgentId,
+      },
+      { type: "tool.result", name: "Glob", output: "a.md\nb.md", parentId: parentAgentId },
+      // subagent's `user` text block ("find md files") is NOT emitted.
       { type: "tool.result", name: "Agent", output: "found 2 .md files" },
       { type: "done" },
     ])

--- a/packages/kobe/test/tui/chat.test.tsx
+++ b/packages/kobe/test/tui/chat.test.tsx
@@ -681,6 +681,44 @@ describe("applyEvent — tool.start / tool.result", () => {
     expect(s.messages[0]).toMatchObject({ done: false, input: 1 })
     expect(s.messages[1]).toMatchObject({ done: true, input: 2, output: "for-2" })
   })
+
+  test("tool.start carries the engine id onto the row as toolUseId", () => {
+    const s = applyEvent(
+      createInitialState(),
+      { type: "tool.start", name: "Agent", input: {}, id: "toolu_p" },
+      FIXED_TS,
+    )
+    expect(s.messages[0]).toMatchObject({ kind: "tool", name: "Agent", toolUseId: "toolu_p" })
+  })
+})
+
+describe("applyEvent — subagent nesting (parentId)", () => {
+  test("a parentId tool.start nests under the matching Agent row, not the top level", () => {
+    let s = createInitialState()
+    s = applyEvent(s, { type: "tool.start", name: "Agent", input: {}, id: "toolu_p" }, FIXED_TS)
+    s = applyEvent(s, { type: "tool.start", name: "Read", input: { path: "a" }, parentId: "toolu_p" }, FIXED_TS)
+    // Still one top-level row — the child did not append to the transcript.
+    expect(s.messages).toHaveLength(1)
+    const parent = s.messages[0] as Extract<(typeof s.messages)[number], { kind: "tool" }>
+    expect(parent.children).toHaveLength(1)
+    expect(parent.children?.[0]).toMatchObject({ name: "Read", done: false })
+  })
+
+  test("a parentId tool.result patches the matching child step", () => {
+    let s = createInitialState()
+    s = applyEvent(s, { type: "tool.start", name: "Agent", input: {}, id: "toolu_p" }, FIXED_TS)
+    s = applyEvent(s, { type: "tool.start", name: "Grep", input: { pattern: "x" }, parentId: "toolu_p" }, FIXED_TS)
+    s = applyEvent(s, { type: "tool.result", name: "Grep", output: "3 matches", parentId: "toolu_p" }, FIXED_TS)
+    const parent = s.messages[0] as Extract<(typeof s.messages)[number], { kind: "tool" }>
+    expect(parent.children?.[0]).toMatchObject({ name: "Grep", done: true, output: "3 matches" })
+  })
+
+  test("a parentId event with no matching Agent row is dropped, never flattened (grandchild guard)", () => {
+    let s = createInitialState()
+    s = applyEvent(s, { type: "tool.start", name: "Read", input: {}, parentId: "toolu_unknown" }, FIXED_TS)
+    s = applyEvent(s, { type: "tool.result", name: "Read", output: "x", parentId: "toolu_unknown" }, FIXED_TS)
+    expect(s.messages).toHaveLength(0)
+  })
 })
 
 describe("applyEvent — reasoning.delta", () => {


### PR DESCRIPTION
## Summary
- Claude Code 的 subagent(Agent/Task 工具)调用此前在 kobe 里是黑盒:`stream.ts` 看到带 `parent_tool_use_id` 的事件直接丢弃,用户只能看到一个 `Agent(...)` 行 + 最终结果,看不到子代理跑到哪一步。
- 改为参考 Claude Code 原版 TUI 的「归属 + 嵌套折叠」:子代理的内部工具步骤(Read/Grep/Bash…)带 `parentId` 透出,挂在父 Agent 行的 `children` 下,缩进折叠展示。主线不被污染 —— 子代理的 prose / `system` / 终止 `result` 仍不透出(`result` 若透出会误杀父流)。
- 范围限实时流。历史回放保持现状(新版 Claude Code 把 subagent 存独立文件 `<sessionId>/subagents/agent-*.jsonl`,`readHistory` 不读)—— 非回归。历史回放嵌套是 follow-up **KOB-177**。
- kobe 只嵌套一层:孙级 subagent 步骤在 parser/store 处丢弃,绝不错误平铺污染顶层。

## 改动
- `types/engine.ts` — `EngineEvent.tool.start` 加 `id?`/`parentId?`,`tool.result` 加 `parentId?`
- `engine/claude-code-local/stream.ts` — subagent 的 tool_use/tool_result 带 `parentId` 透出
- `tui/panes/chat/store.ts` — `ChatRow` tool 行加 `children`;`applyEvent` 嵌套归属 + 孙级守卫
- `tui/panes/chat/tool-registry.ts` — 注册 `Task`/`Agent` + `subagent` body 策略 + `isSubagentTool()`
- `tui/panes/chat/tool-fold.tsx` — subagent 行不参与 3+ 工具折叠
- `tui/panes/chat/ToolRow.tsx` — `SubagentBanner` + `SubagentBody`(折叠态进度摘要 / 展开态逐步列表)

## Test plan
- [x] `bun run typecheck` 通过
- [x] `bun run test` —— 1010 passed(更新 `stream.test.ts` subagent 用例;`chat.test.tsx` 覆盖嵌套归属 + 孙级守卫)
- [x] `bun run build` 通过
- [ ] reviewer:`kobed restart` 后跑一个发起 subagent 的真实任务,确认实时嵌套进度展示