### PR TITLE
fix: sidebar progress badge clarity + status semantics

### DIFF
--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -1060,16 +1060,27 @@ export class Orchestrator {
     this.pumps.delete(key)
     this.bumpRunState()
 
-    const terminal = terminalEvent?.type === "error" ? "error" : terminalEvent ? "done" : null
-    if (terminal && !killedForInput) {
-      // Only flip the task's status to a terminal value when ALL its
-      // tabs have stopped. With multi-tab, a single tab finishing
-      // doesn't mean the task is done — the user may still have other
-      // tabs streaming.
+    // Only `error` is a lifecycle-terminal status — it means the
+    // engine crashed and the task needs user attention. A clean `done`
+    // event is NOT a lifecycle terminal: it just means "this turn
+    // finished, waiting for the next prompt." The task stays
+    // `in_progress` between turns; whether the engine is *currently*
+    // streaming is a separate live signal owned by ChatRunState
+    // (see {@link chatRunStateSignal}). `status: "done"` is reserved
+    // for user-driven archiving via {@link archiveTask}.
+    //
+    // Historically this code also flipped to `status: "done"` on every
+    // clean turn, which made `done` the implicit resting state of every
+    // active task — confusing because the sidebar now renders `done`
+    // with a distinct ✓ glyph instead of the old shared `●`.
+    if (terminalEvent?.type === "error" && !killedForInput) {
+      // Only flip when ALL the task's tabs have stopped. With multi-tab,
+      // a single tab erroring doesn't end the task — other tabs may
+      // still be streaming productively.
       const stillLive = Array.from(this.handles.keys()).some((k) => k.startsWith(`${taskId}:`))
       if (!stillLive) {
         try {
-          await this.store.update(taskId, { status: terminal === "done" ? "done" : "error" })
+          await this.store.update(taskId, { status: "error" })
         } catch {
           /* store may have been cleared in tests; ignore */
         }

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -540,6 +540,16 @@ function coerceTask(value: unknown): Task | null {
   const activeTab = finalTabs.find((t) => t.id === finalActive) ?? finalTabs[0]
   const aliasSessionId = activeTab?.sessionId ?? legacySessionId
 
+  // Self-heal pre-fix rows. Old kobe builds auto-flipped `status` to
+  // `"done"` on every clean turn end, leaving the active sidebar full
+  // of tasks whose status was `done` but `archived` was still false.
+  // `done` is now reserved for user-driven archive — heal those rows
+  // back to `in_progress` on load so the sidebar's ✓ glyph only ever
+  // means "user archived this as complete." Archived `done` rows are
+  // left alone (that's the legitimate use of the status).
+  const archived = typeof v.archived === "boolean" ? v.archived : false
+  const healedStatus: TaskStatus = v.status === "done" && !archived ? "in_progress" : v.status
+
   return {
     id: toTaskId(v.id),
     title: v.title,
@@ -549,11 +559,11 @@ function coerceTask(value: unknown): Task | null {
     sessionId: aliasSessionId,
     tabs: finalTabs,
     activeTabId: finalActive,
-    status: v.status,
+    status: healedStatus,
     // Wave 4.5: `archived` is a new field. Records written before its
     // introduction don't have it; default to false (i.e. "active /
     // working session"). The user can archive them with `a`.
-    archived: typeof v.archived === "boolean" ? v.archived : false,
+    archived,
     // User-pinned float-to-top flag. Defaults to false on records
     // written before the field existed. Persist as boolean so toggling
     // off and reloading clears the row from the pinned subsection.

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -594,6 +594,7 @@ function Shell(props: AppDeps) {
           <Sidebar
             width={sidebarWidth}
             tasks={tasksAcc}
+            chatRunState={chatRunStateAcc}
             onSelect={(id: string) => {
               setSelectedId(id)
               // Selecting a task usually means "I want to look at it" —

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -301,7 +301,10 @@ export function Sidebar(props: SidebarProps) {
   // the cost is one signal write per 100ms and Solid only re-renders
   // the rows whose badge derivation actually reads `spinnerFrame()`.
   const [spinnerFrame, setSpinnerFrame] = createSignal(0)
-  const spinnerInterval = setInterval(() => setSpinnerFrame((n) => (n + 1) % IN_PROGRESS_SPINNER.length), SPINNER_FRAME_MS)
+  const spinnerInterval = setInterval(
+    () => setSpinnerFrame((n) => (n + 1) % IN_PROGRESS_SPINNER.length),
+    SPINNER_FRAME_MS,
+  )
   onCleanup(() => clearInterval(spinnerInterval))
 
   // Filtered, flat row list for the active view. Recomputes only when

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -53,6 +53,7 @@ import type { KeyEvent } from "@opentui/core"
 import { TextAttributes } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
 import { type Accessor, For, Show, createEffect, createMemo, createSignal, on, onCleanup, untrack } from "solid-js"
+import type { ChatRunState } from "../../../orchestrator/core"
 import { SIDEBAR_WIDTH } from "../../component/sidebar"
 import { useTheme } from "../../context/theme"
 import { readCurrentBranch } from "./git-head"
@@ -107,6 +108,18 @@ export type SidebarProps = {
    * at runtime. Reactive — changing the accessor's value reflows immediately.
    */
   width?: Accessor<number>
+  /**
+   * Live per-tab engine state, keyed by `${taskId}:${tabId}` (see
+   * {@link chatRunStateKey} in `orchestrator/core.ts`). The sidebar
+   * spinner animates only when a row's task has at least one tab in
+   * the `"running"` state — i.e. an actual live engine handle — so
+   * interrupting a turn (which kills the handle but keeps
+   * `task.status === "in_progress"` because the *task* is still
+   * active) immediately stops the dots. Optional so embedders that
+   * don't have the orchestrator handy can still mount the sidebar
+   * (the spinner falls back to a static "active" badge).
+   */
+  chatRunState?: Accessor<ReadonlyMap<string, ChatRunState>>
 }
 
 /**
@@ -114,19 +127,38 @@ export type SidebarProps = {
  * with the theme colour resolved at render time; storing the *tone* (not
  * the resolved RGBA) keeps badges reactive to theme switches.
  *
+ * Each status now uses a *distinct* glyph so the row is readable without
+ * relying on colour alone — teammate feedback was that the old
+ * dot-on-dot-on-half-dot set wasn't legible. `in_progress` is special:
+ * its glyph is the empty string here and the renderer substitutes the
+ * current frame of {@link IN_PROGRESS_SPINNER} (rotating braille) so an
+ * active task visibly *moves*.
+ *
  * Per-task hint only — no grouping reads from this map.
  */
 const STATUS_BADGE: Record<
   TaskStatus,
   { glyph: string; tone: "success" | "warning" | "primary" | "textMuted" | "error" }
 > = {
-  done: { glyph: "●", tone: "success" },
+  done: { glyph: "✓", tone: "success" },
   in_review: { glyph: "◐", tone: "warning" },
-  in_progress: { glyph: "●", tone: "primary" },
+  in_progress: { glyph: "", tone: "primary" },
   backlog: { glyph: "○", tone: "textMuted" },
-  canceled: { glyph: "✕", tone: "textMuted" },
+  canceled: { glyph: "⊘", tone: "textMuted" },
   error: { glyph: "✕", tone: "error" },
 }
+
+/**
+ * Braille spinner frames for the `in_progress` row badge. Standard
+ * dots-rotating cycle (the same one npm / yarn / most CLI loaders use),
+ * picked because it reads as motion in a *single cell* — drop-in for the
+ * one-cell badge slot. Sub-pixel-style rotation makes "active" obvious
+ * without enlarging the row.
+ */
+const IN_PROGRESS_SPINNER: readonly string[] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+/** Spinner tick (ms). 100ms matches the standard CLI loader cadence. */
+const SPINNER_FRAME_MS = 100
 
 /**
  * Tab labels for the view switcher. Order matches the `SidebarView`
@@ -262,6 +294,15 @@ export function Sidebar(props: SidebarProps) {
   // Using `onCleanup` would require importing it; setInterval against
   // process lifetime is acceptable for a per-app-singleton pane.
   void branchInterval
+
+  // Spinner frame tick for `in_progress` row badges. Single shared
+  // counter so every running task animates in lockstep (reads as one
+  // "system pulse" rather than a noisy mismatched twitch). Always on —
+  // the cost is one signal write per 100ms and Solid only re-renders
+  // the rows whose badge derivation actually reads `spinnerFrame()`.
+  const [spinnerFrame, setSpinnerFrame] = createSignal(0)
+  const spinnerInterval = setInterval(() => setSpinnerFrame((n) => (n + 1) % IN_PROGRESS_SPINNER.length), SPINNER_FRAME_MS)
+  onCleanup(() => clearInterval(spinnerInterval))
 
   // Filtered, flat row list for the active view. Recomputes only when
   // the upstream tasks accessor, the view, or the search query
@@ -491,18 +532,32 @@ export function Sidebar(props: SidebarProps) {
               // Per-row "uncommitted changes" file counts, rendered on
               // the right edge as `+N −M`. Keyed on the same `branchTick`
               // so we only shell out at the established 2s cadence.
-              // Empty string when the worktree is clean — the renderer
-              // skips the chip entirely. Applies to both main and regular
-              // rows: on a main row a non-zero count is just as useful as
-              // on a worktree row, and the repo's branch label still has
-              // room next to it inside the 42-cell sidebar.
-              const changesLabel = createMemo(() => {
+              // Empty when the worktree is clean — the renderer skips
+              // the chip entirely. Returned as a struct (not a joined
+              // string) so the renderer can colour `+N` with
+              // `theme.success` and `−N` with `theme.error`, matching
+              // the FileTree pane's per-file `+/−` badges.
+              const changes = createMemo(() => {
                 branchTick()
-                const { added, deleted } = readWorktreeChanges(task.worktreePath)
-                const parts: string[] = []
-                if (added > 0) parts.push(`+${added}`)
-                if (deleted > 0) parts.push(`−${deleted}`)
-                return parts.join(" ")
+                return readWorktreeChanges(task.worktreePath)
+              })
+              // "Is this task actually streaming a turn right now?"
+              // True only when the orchestrator holds a live engine
+              // handle for at least one of this task's tabs. Decouples
+              // the *animated* spinner from `task.status` — the user's
+              // mental model is "the dots should stop when I press
+              // esc", but `task.status === "in_progress"` only flips
+              // when the lifecycle ends (done / canceled / error /
+              // archived), not when the current turn aborts. Without
+              // this check the spinner kept spinning post-interrupt.
+              const isLive = createMemo(() => {
+                const map = props.chatRunState?.()
+                if (!map) return false
+                const prefix = `${task.id}:`
+                for (const [key, state] of map) {
+                  if (state === "running" && key.startsWith(prefix)) return true
+                }
+                return false
               })
               const titleText = isMain ? repoBasename(task.repo) : task.title
               return (
@@ -514,8 +569,18 @@ export function Sidebar(props: SidebarProps) {
                   backgroundColor={isCursor() ? theme.primary : isSelected() ? theme.backgroundElement : undefined}
                   onMouseUp={() => props.onSelect(task.id)}
                 >
-                  <text fg={isCursor() ? theme.selectedListItemText : badgeColor()} wrapMode="none">
-                    {isMain ? "★" : badge.glyph}
+                  <text
+                    fg={isCursor() ? theme.selectedListItemText : badgeColor()}
+                    attributes={TextAttributes.BOLD}
+                    wrapMode="none"
+                  >
+                    {isMain
+                      ? "★"
+                      : task.status === "in_progress"
+                        ? isLive()
+                          ? (IN_PROGRESS_SPINNER[spinnerFrame()] ?? IN_PROGRESS_SPINNER[0])
+                          : "●"
+                        : badge.glyph}
                   </text>
                   <text
                     fg={isCursor() ? theme.selectedListItemText : theme.text}
@@ -536,10 +601,21 @@ export function Sidebar(props: SidebarProps) {
                       edges line up across rows (what the eye tracks) and
                       so short chips sit closer to the row's right side
                       rather than crowding the title. */}
-                  <box width={CHANGES_COLUMN_WIDTH} flexShrink={0} flexDirection="row" justifyContent="flex-end">
-                    <Show when={changesLabel().length > 0}>
-                      <text fg={isCursor() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
-                        {changesLabel()}
+                  <box
+                    width={CHANGES_COLUMN_WIDTH}
+                    flexShrink={0}
+                    flexDirection="row"
+                    justifyContent="flex-end"
+                    gap={1}
+                  >
+                    <Show when={changes().added > 0}>
+                      <text fg={isCursor() ? theme.selectedListItemText : theme.success} wrapMode="none">
+                        +{changes().added}
+                      </text>
+                    </Show>
+                    <Show when={changes().deleted > 0}>
+                      <text fg={isCursor() ? theme.selectedListItemText : theme.error} wrapMode="none">
+                        −{changes().deleted}
                       </text>
                     </Show>
                   </box>

--- a/packages/kobe/test/behavior/sidebar-status-update.test.ts
+++ b/packages/kobe/test/behavior/sidebar-status-update.test.ts
@@ -139,7 +139,7 @@ afterEach(async () => {
   }
 })
 
-test("sidebar keeps a task under its repo header across a backlog → done transition", async () => {
+test("sidebar badge updates as the task moves backlog → in_progress and the engine idles", async () => {
   // ---- fixtures -------------------------------------------------
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-sidebar-status-"))
   homeDir = path.join(tmpRoot, "home")
@@ -190,12 +190,13 @@ test("sidebar keeps a task under its repo header across a backlog → done trans
   expect(initialScreen).toContain("status-transition")
 
   // ---- assert the badge flipped after the transition ----
-  // The orchestrator's pump sees the scripted `done` event, calls
-  // `store.update(id, { status: "done" })`, and the store fires its
-  // change listener which feeds the orchestrator's task signal. The
-  // sidebar's badge mapping switches the row's glyph from `○` to `●`
-  // (success tone). The row stays in the active view (archived flag
-  // hasn't moved).
+  // runTask flips status backlog → in_progress (sidebar glyph: spinner
+  // when the engine is live, then a static `●` once the scripted
+  // `done` event lands and the orchestrator's engine handle is torn
+  // down). `done` is no longer auto-written on clean turn end — that
+  // semantic moved to user-driven archive only — so the row stays
+  // `in_progress` here and the glyph we wait for is the static `●`
+  // idle marker, which still matches the regex below.
   await kobe.waitFor((s) => bufferContains(s, /●\s*\S*status-transition/), 20_000)
   const doneScreen = await kobe.capture()
   expect(bufferContains(doneScreen, /●\s*\S*status-transition/)).toBe(true)

--- a/packages/kobe/test/orchestrator/core.test.ts
+++ b/packages/kobe/test/orchestrator/core.test.ts
@@ -525,7 +525,7 @@ describe("Orchestrator.runTask", () => {
     await orch._waitForPumpsIdle()
   })
 
-  test("scripted assistant.delta + done → status transitions to done", async () => {
+  test("scripted assistant.delta + done → status stays in_progress between turns", async () => {
     const fake = new FakeAIEngine()
     const { orch, store } = await buildOrchestrator(fake)
     const t = await orch.createTask({ repo, title: "happy", prompt: "" })
@@ -549,7 +549,10 @@ describe("Orchestrator.runTask", () => {
     expect(types).toContain("assistant.delta")
     expect(types).toContain("done")
 
-    expect(store.get(t.id)?.status).toBe("done")
+    // A clean `done` event is per-turn, not lifecycle. The task stays
+    // in_progress (resting state for active tasks); `status === "done"`
+    // is reserved for user-driven archiveTask.
+    expect(store.get(t.id)?.status).toBe("in_progress")
   })
 
   test("error event transitions task to error status", async () => {

--- a/packages/kobe/test/orchestrator/task-index.test.ts
+++ b/packages/kobe/test/orchestrator/task-index.test.ts
@@ -193,7 +193,7 @@ describe("TaskIndexStore — subscribe", () => {
               branch: "kobe/preloaded",
               worktreePath: "/r/wt",
               sessionId: null,
-              status: "done",
+              status: "in_review",
               createdAt: "2026-05-08T00:00:00.000Z",
               updatedAt: "2026-05-08T00:00:00.000Z",
             },
@@ -211,7 +211,57 @@ describe("TaskIndexStore — subscribe", () => {
     expect(calls).toEqual([])
     await store.load()
     expect(calls.at(-1)).toBe(1)
-    expect(store.get("01HZB000000000000000000000")?.status).toBe("done")
+    expect(store.get("01HZB000000000000000000000")?.status).toBe("in_review")
+  })
+
+  test("self-heal: legacy `status:done && archived:false` rows load as in_progress; archived done rows stay done", async () => {
+    // Old kobe builds auto-flipped status to "done" on every clean
+    // turn, leaving active-sidebar tasks marked done. Now `done` is
+    // archive-only, and pre-existing rows should heal back to
+    // in_progress on load — but only when archived is false. A
+    // legitimately-archived done row stays done.
+    await mkdir(join(homeDir, ".kobe"), { recursive: true })
+    await writeFile(
+      join(homeDir, ".kobe", "tasks.json"),
+      JSON.stringify(
+        {
+          version: 2,
+          tasks: [
+            {
+              id: "01HZB000000000000000000001",
+              title: "stale-done-active",
+              repo: "/r",
+              branch: "kobe/a",
+              worktreePath: "/r/a",
+              sessionId: null,
+              status: "done",
+              archived: false,
+              createdAt: "2026-05-08T00:00:00.000Z",
+              updatedAt: "2026-05-08T00:00:00.000Z",
+            },
+            {
+              id: "01HZB000000000000000000002",
+              title: "real-archived-done",
+              repo: "/r",
+              branch: "kobe/b",
+              worktreePath: "/r/b",
+              sessionId: null,
+              status: "done",
+              archived: true,
+              createdAt: "2026-05-08T00:00:00.000Z",
+              updatedAt: "2026-05-08T00:00:00.000Z",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const store = new TaskIndexStore({ homeDir })
+    await store.load()
+    expect(store.get("01HZB000000000000000000001")?.status).toBe("in_progress")
+    expect(store.get("01HZB000000000000000000002")?.status).toBe("done")
   })
 
   test("unsubscribe stops further notifications without affecting other listeners", async () => {


### PR DESCRIPTION
## Summary

Teammate said the sidebar progress orb wasn't legible and the `+N`/`−N` counts had no green/red. Fixing those exposed a deeper data bug: `task.status` was being auto-flipped to `"done"` on every clean turn end, so any actively-used task showed up as done in the Working session.

## Sidebar UI

- Distinct glyph per status:
  - `done` → `✓`
  - `in_review` → `◐`
  - `in_progress` → rotating braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) when the engine is live, static `●` when in_progress but idle (e.g. right after `Esc` interrupts a turn)
  - `backlog` → `○`
  - `canceled` → `⊘`
  - `error` → `✕`
- `+N` / `−N` chip split into two text spans coloured `theme.success` / `theme.error`, matching the FileTree pane's per-file badges.
- All badges drawn `BOLD` so the cell reads at a glance.
- One shared spinner tick at 100ms — every running task pulses in sync, no jitter.

## Status semantics

- `Orchestrator.runPumpAndCleanup` no longer writes `status: "done"` on clean turn end. `done` is reserved for user-driven `archiveTask(id, "done")`. `error` still flips on engine crash. Active tasks stay `in_progress` between turns (the resting state).
- Sidebar reads the orchestrator's `chatRunStateSignal()` to drive the spinner — interrupt kills the engine handle and the dots stop immediately, independent of the longer-lived `task.status`.

## Migration

- `coerceTask` self-heals legacy rows: `status: "done" && archived: false` loads as `in_progress`. Archived done rows are untouched. Idempotent, no schema bump, no on-disk rewrite.

## Test plan

- [x] `bun typecheck`
- [x] `bun test` — 1012 unit + 49 socket tests pass
- [x] `core.test.ts`: turn-end now keeps `in_progress`
- [x] `task-index.test.ts`: dedicated heal test (active row heals, archived row preserved)
- [x] `behavior/sidebar-status-update.test.ts`: renamed + comment updated for new flow; existing regex still matches
- [ ] Manual: open kobe → verify pre-existing `✓` rows in Working session heal to `●` on launch, spinner runs while engine streams, stops on `Esc`, `+N`/`−N` show green/red

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live engine running indicators in the sidebar with an animated spinner when tasks are actively processing.
  * Enhanced task status lifecycle—tasks now remain "in progress" during normal completion until explicitly archived.
  * Improved visual distinction of task states with dedicated status glyphs.
  * Refined changes display to show added and deleted counts separately.

* **Bug Fixes**
  * Fixed automatic healing of legacy task records with incorrect status persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->