### PR TITLE
fix: /clear no longer pops model picker

### DIFF
--- a/packages/kobe/src/tui/panes/chat/Chat.tsx
+++ b/packages/kobe/src/tui/panes/chat/Chat.tsx
@@ -407,18 +407,16 @@ export function Chat(props: ChatProps) {
   /**
    * Open the model picker for the active tab.
    *
-   * `forceVendorLock` pins the picker to the active tab's vendor even
-   * when no session is live — used by the `/clear` path. `/clear` is a
-   * reset of the chat tab, not an engine switch: the user should pick a
-   * model for the *same* engine, not jump to a different vendor. The
-   * session has just been dropped (so the default `activeTabHasSession`
-   * gate would unlock the vendor), hence the explicit force.
+   * Vendor is locked to the active tab's engine while a session is live
+   * (`activeTabHasSession()`). After `/clear` the session is dropped
+   * (`sessionId = null`), so the lock lifts and the user can freely pick
+   * any engine on the next manual open.
    */
-  async function chooseModel(forceVendorLock = false): Promise<void> {
+  async function chooseModel(): Promise<void> {
     const id = props.taskId()
     if (!id) return
     const tabId = activeTabId() ?? undefined
-    const lockedVendor = forceVendorLock || activeTabHasSession() ? activeVendor() : undefined
+    const lockedVendor = activeTabHasSession() ? activeVendor() : undefined
     const result = await ModelPicker.show(dialog, modelId(), modelEffort(), activeVendor(), lockedVendor)
     if (result === undefined) return
     await props.orchestrator.setModel(id, result.id, tabId, result.effort, result.vendor).catch((err: unknown) => {
@@ -658,7 +656,6 @@ export function Chat(props: ChatProps) {
         patchActiveState((s) => pushSystemError(s, `/clear failed: ${stringifyErr(err)}`))
         return
       }
-      await chooseModel(true)
       return
     }
 


### PR DESCRIPTION
## Summary
- `/clear` was calling `chooseModel(true)` after resetting the tab, which caused the model picker dialog to pop up every time the user typed `/clear`
- Removed that call — `/clear` now just resets the conversation and returns, no popup
- After clear, `sessionId` is null → `activeTabHasSession()` is false → the vendor lock lifts, so the user can freely switch engines via the manual model picker on the next turn
- Dropped the now-unused `forceVendorLock` param from `chooseModel` and updated its doc comment

## Test plan
- [x] typecheck passes
- [ ] Type `/clear` → confirm no model picker popup, conversation resets
- [ ] After `/clear`, open model picker via button → confirm can switch between engines (not locked)
- [ ] With an active session (not cleared), open model picker → confirm vendor is still locked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined model selection behavior to properly account for active session state.
* Updated the clear command to no longer automatically trigger the model picker after clearing chat history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->