### PR TITLE
fix: handle leak + vendor error message + changelog

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/clear` no longer opens a model picker** — `/clear` is a conversation reset; after clearing, the session is dropped so the vendor lock lifts automatically and the user can freely switch engines via the manual model picker on the next turn. The automatic post-clear model picker popup is removed entirely.
+- **deleteTask no longer leaks engine handles when pauseTask fails** — the fallback cleanup path in the delete-task error branch now calls the same `stopAllTabsForTask` helper used everywhere else, which iterates composite `taskId:tabId` handle keys; the previous code passed a bare `taskId` that matched no key and left stale handles in the map.
+- **Vendor validation error now includes the invalid value** — passing an unrecognized vendor string to daemon API calls now reports `"vendor 'xyz' is not a supported vendor (expected: claude, codex, gemini)"` instead of the opaque `"vendor must be a supported vendor"`.
+
 ## [0.5.25] - 2026-05-17
 
 ### Added

--- a/packages/kobe/src/daemon/server.ts
+++ b/packages/kobe/src/daemon/server.ts
@@ -732,7 +732,7 @@ function optionalModelEffort(payload: Record<string, unknown>, key: string): Mod
 function optionalVendor(payload: Record<string, unknown>, key: string): VendorId | undefined {
   const value = optionalString(payload, key)
   if (value !== undefined && value !== "claude" && value !== "codex" && value !== "gemini") {
-    throw new Error(`${key} must be a supported vendor`)
+    throw new Error(`${key} '${value}' is not a supported vendor (expected: claude, codex, gemini)`)
   }
   return value
 }

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -861,12 +861,12 @@ export class Orchestrator {
         await this.pauseTask(task.id)
       } catch (err) {
         // The engine may already be torn down (a `done` event arrived
-        // mid-flight). Log and proceed — the user's intent is to
-        // discard, not to babysit the engine state.
+        // mid-flight). Force-clear all composite-key handles for this
+        // task so the map stays consistent; stopAllTabsForTask is
+        // best-effort and calls bumpRunState() internally.
         // eslint-disable-next-line no-console
         console.error(`[kobe orchestrator] deleteTask: pauseTask failed for ${task.id}:`, err)
-        this.handles.delete(task.id)
-        this.bumpRunState()
+        await this.stopAllTabsForTask(task.id)
       }
     }
 


### PR DESCRIPTION
## Summary

Three fixes from a codebase audit session.

- **deleteTask handle leak** (`core.ts:868`) — the `pauseTask` error fallback called `this.handles.delete(task.id)` but the handles map uses composite `taskId:tabId` keys, so the delete was a no-op and stale handles accumulated until process restart. Fixed by replacing with `await this.stopAllTabsForTask(task.id)` which iterates the correct keys and calls `bumpRunState()` internally.
- **Vendor validation error message** (`server.ts:735`) — `optionalVendor()` threw `"vendor must be a supported vendor"` with no indication of what value was actually passed, making daemon API debugging painful. Now reads: `"vendor 'xyz' is not a supported vendor (expected: claude, codex, gemini)"`.
- **CHANGELOG** — Added `[Unreleased]` entries for today's `/clear` fix (from PR #59) and these two fixes so the next release notes are current.

## Test plan
- [x] typecheck passes
- [ ] Delete an in-progress task while its engine is mid-stream → confirm handles map is clean after (no `taskId:tabId` keys leftover)
- [ ] Send an invalid vendor string to daemon API → confirm error message includes the bad value