### PR TITLE
chore: clean up stale scaffolding and wave references

### DIFF
--- a/packages/kobe/src/tui/component/sidebar.tsx
+++ b/packages/kobe/src/tui/component/sidebar.tsx
@@ -1,16 +1,9 @@
 /**
- * Sidebar primitive.
+ * Sidebar primitive — Phase 0.2 scaffolding, kept per no-deletion rule.
  *
- * Adapted from `refs/opencode/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx`.
- * The opencode version reads from `useSync` (sessions, workspace info,
- * version metadata) and exposes plugin slots via `TuiPluginRuntime.Slot`. We
- * drop both: kobe doesn't have a plugin runtime in 0.2, and the sync store is
- * an empty stub. The sidebar here is a layout shell — fixed 42-char width,
- * scrollable body, footer — with a small `entries` API the future task list
- * (Wave 2 Stream F) will plug into.
- *
- * This is intentionally not the final task-grouped sidebar. It's the layout
- * frame so the lifted shell renders something sidebar-shaped on day 0.2.
+ * The real task sidebar lives in `panes/sidebar/Sidebar.tsx`. This file
+ * is only imported by the dead `index.tsx` shell (Banner/Shell) and by
+ * `panes/sidebar/Sidebar.tsx` for the `SIDEBAR_WIDTH` constant.
  */
 
 import { TextAttributes } from "@opentui/core"
@@ -54,7 +47,7 @@ export function Sidebar(props: SidebarProps) {
     <box
       backgroundColor={theme.backgroundPanel}
       width={SIDEBAR_WIDTH}
-      height="100%"
+      flexGrow={1}
       paddingTop={1}
       paddingBottom={1}
       paddingLeft={2}

--- a/packages/kobe/src/tui/index.tsx
+++ b/packages/kobe/src/tui/index.tsx
@@ -1,26 +1,12 @@
 /**
  * kobe TUI bootstrap.
  *
- * Wave 2 Stream E: this file used to render a themed banner with a stub
- * sidebar (Foundation 0.2 scaffolding). It now delegates to `app.tsx`,
- * which wires the Orchestrator + Sidebar + chat placeholder for the G2
- * end-to-end demo. The banner shell below (`Banner`, `Shell`) is kept
- * for reference (CLAUDE.md hard rule: no deletion) but is no longer the
- * mount target.
+ * Thin entry point — delegates immediately to `app.tsx`, which owns the
+ * full 5-pane layout, orchestrator wiring, and keybindings.
  *
- * Default theme is `tokyonight` — matches agent-deck's Tokyo Night palette
- * (Stream D resolved decision in PLAN.md). Switch via `theme.set("nord")`
- * once a runtime config is wired (Wave 4-ish).
- *
- * Global keybindings (registered by `useKobeKeybindings`):
- *   - `cmd+k` / `ctrl+k` — open the command palette
- *   - `?` — open the help dialog (full bindings table)
- *   - `tab` / `shift+tab` — focus next/prev pane (no-op until Wave 3)
- *   - `q` — confirm-quit
- *   - `esc` — universal close-top-dialog
- *
- * Pane-local bindings (composer, sidebar nav, palette arrows) register
- * themselves inside their components — this file only owns globals.
+ * The `Banner`/`Shell`/`App` functions below are Phase 0 scaffolding kept
+ * per the no-deletion rule but are never mounted. `startTui` calls
+ * `startApp` directly.
  */
 
 import { TextAttributes } from "@opentui/core"
@@ -36,7 +22,7 @@ import { SyncProvider } from "./context/sync"
 import { ThemeProvider, useTheme } from "./context/theme"
 import { DialogProvider, useDialog } from "./ui/dialog"
 
-/** Default theme name. Picked at boot; runtime override lands in a later stream. */
+/** Dead — kept with the unused Banner/Shell below. Real default is in app.tsx. */
 const DEFAULT_THEME = "tokyonight"
 
 const KOBE_BANNER = ["k o b e", "─────────"]
@@ -91,7 +77,7 @@ function Shell() {
     <box flexDirection="row" flexGrow={1}>
       <Sidebar
         title="kobe"
-        emptyMessage="No tasks yet. Wave 2 Stream F will populate this pane."
+        emptyMessage="No tasks yet."
         footer={
           <text fg={theme.textMuted}>
             <span style={{ fg: theme.success }}>•</span> ready

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -24,8 +24,7 @@
  *     (gitignore respected). Flat list of paths, alphabetically sorted.
  *   - `Changes`: `git status --porcelain`, with a single-char status
  *     prefix coloured per the theme tokens.
- *   - `Checks`: placeholder ("No checks yet (Wave 4)") — Stream K owns
- *     the real implementation.
+ *   - `Checks`: placeholder — CI/test integration not yet implemented.
  *
  * State lives where it lives (DESIGN.md §2.5): files come from disk via
  * git, not from a separate cache. We re-fetch on:
@@ -567,7 +566,7 @@ export function FileTree(props: FileTreeProps) {
 
         <Show when={props.worktreePath() != null && error() == null && tab() === "checks"}>
           <box paddingTop={1} paddingLeft={1}>
-            <text fg={theme.textMuted}>(no checks yet — wave 4)</text>
+            <text fg={theme.textMuted}>(checks not yet implemented)</text>
           </box>
         </Show>
 


### PR DESCRIPTION
## Summary
- **FileTree Checks tab** (`FileTree.tsx:570`) — placeholder text said "(no checks yet — wave 4)"; Wave 4 closed months ago. Changed to "(checks not yet implemented)" — honest about state without referencing a completed internal milestone.
- **`index.tsx`** — replaced the verbose Phase 0 banner comment with a short note; removed "Wave 2 Stream F will populate this pane" from the dead `Shell` component (that wave shipped long ago).
- **`component/sidebar.tsx`** — `height="100%"` → `flexGrow={1}` per the flex-first layout rule; tightened the doc comment to make clear this is Phase 0 dead scaffolding kept by the no-deletion rule.

## Test plan
- [x] typecheck passes
- [ ] `bun run dev` boots normally — no visual regression (none of these are in live code paths)