### PR TITLE
fix: PR lifecycle stale state + Gemini listCommands signature

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Fixed
 
+- **PR status lifecycle resets to "creating" when no GitHub PR is found** — previously, when `gh pr view` returned no data (PR deleted or closed without merging), the lifecycle field was preserved from the previous poll, leaving the merge button incorrectly enabled. It now resets to `"creating"` so the button returns to its default "open PR" state.
+- **Gemini `listCommands()` now matches the `AIEngine` interface signature** — the Gemini adapter was missing the `opts?: EngineCommandDiscoveryOpts` parameter, which meant cwd-scoped command discovery hints were silently ignored.
 - **`/clear` no longer opens a model picker** — `/clear` is a conversation reset; after clearing, the session is dropped so the vendor lock lifts automatically and the user can freely switch engines via the manual model picker on the next turn. The automatic post-clear model picker popup is removed entirely.
 - **deleteTask no longer leaks engine handles when pauseTask fails** — the fallback cleanup path in the delete-task error branch now calls the same `stopAllTabsForTask` helper used everywhere else, which iterates composite `taskId:tabId` handle keys; the previous code passed a bare `taskId` that matched no key and left stale handles in the map.
 - **Vendor validation error now includes the invalid value** — passing an unrecognized vendor string to daemon API calls now reports `"vendor 'xyz' is not a supported vendor (expected: claude, codex, gemini)"` instead of the opaque `"vendor must be a supported vendor"`.

--- a/packages/kobe/src/engine/gemini-local/index.ts
+++ b/packages/kobe/src/engine/gemini-local/index.ts
@@ -2,6 +2,8 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process"
 import type {
   AIEngine,
   EngineCapabilities,
+  EngineCommandDiscoveryOpts,
+  EngineCommandEntry,
   EngineEvent,
   EngineHistory,
   EngineIdentity,
@@ -87,7 +89,7 @@ export class GeminiLocal implements AIEngine {
     return listSessionsForCwd(cwd)
   }
 
-  async listCommands() {
+  async listCommands(_opts?: EngineCommandDiscoveryOpts): Promise<readonly EngineCommandEntry[]> {
     return []
   }
 

--- a/packages/kobe/src/orchestrator/pr/status.ts
+++ b/packages/kobe/src/orchestrator/pr/status.ts
@@ -69,7 +69,7 @@ export async function refreshPRStatus(task: Task): Promise<TaskPRStatus | undefi
   if (!json) {
     return {
       provider: "github",
-      lifecycle: task.prStatus?.provider === "github" ? task.prStatus.lifecycle : "creating",
+      lifecycle: "creating",
       checkState: "unknown",
       lastCheckedAt: new Date().toISOString(),
       lastError: "No GitHub PR found for this branch yet.",


### PR DESCRIPTION
## Summary
- **PR status lifecycle** (`pr/status.ts`) — when `gh pr view` returns no data (PR deleted or closed without merging), the `lifecycle` field was preserved from the previous poll. If the task had previously reached `ready_to_merge`, the merge button stayed enabled with no PR behind it. Now always resets to `"creating"` when no PR JSON is returned.
- **Gemini `listCommands()` signature** (`gemini-local/index.ts`) — the method was missing the `opts?: EngineCommandDiscoveryOpts` parameter defined in the `AIEngine` interface. The cwd hint was silently ignored. Fixed to match the interface contract (Gemini still returns `[]` but the param is now accepted).
- **CHANGELOG** — two new bullets in `[Unreleased]`.

## Test plan
- [x] typecheck passes
- [ ] Close/delete a GitHub PR mid-session, wait for the 30s poll → confirm the PR chip returns to "open PR" state instead of staying "ready to merge"
- [ ] Verify Gemini engine loads and `listCommands()` typechecks against the interface