### PR TITLE
chore: fix double requireString in merge.local.request + clean stale wave refs

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Fixed
 
+- **`merge.local.request` daemon handler no longer calls `requireString(payload, "taskId")` twice** — the taskId is now extracted once and reused, eliminating the redundant payload read.
 - **PR status lifecycle resets to "creating" when no GitHub PR is found** — previously, when `gh pr view` returned no data (PR deleted or closed without merging), the lifecycle field was preserved from the previous poll, leaving the merge button incorrectly enabled. It now resets to `"creating"` so the button returns to its default "open PR" state.
 - **Gemini `listCommands()` now matches the `AIEngine` interface signature** — the Gemini adapter was missing the `opts?: EngineCommandDiscoveryOpts` parameter, which meant cwd-scoped command discovery hints were silently ignored.
 - **`/clear` no longer opens a model picker** — `/clear` is a conversation reset; after clearing, the session is dropped so the vendor lock lifts automatically and the user can freely switch engines via the manual model picker on the next turn. The automatic post-clear model picker popup is removed entirely.

--- a/packages/kobe/src/daemon/server.ts
+++ b/packages/kobe/src/daemon/server.ts
@@ -439,8 +439,9 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
         return {}
       }
       case "merge.local.request": {
-        await orch.requestLocalMerge(requireString(payload, "taskId"))
-        const task = orch.getTask(requireString(payload, "taskId"))
+        const taskId = requireString(payload, "taskId")
+        await orch.requestLocalMerge(taskId)
+        const task = orch.getTask(taskId)
         if (task) {
           broadcastTaskUpdated(orch, clients, task.id)
           broadcast(clients, {

--- a/packages/kobe/src/tui/context/focus.tsx
+++ b/packages/kobe/src/tui/context/focus.tsx
@@ -23,8 +23,7 @@
  *   - Mouse-driven focus changes happen on pane wrappers in app.tsx
  *     itself — having the setter in context means the wrapper code can
  *     just call into the context without app.tsx growing more closures.
- *   - Future panes (Wave 4: PR button, checks, etc.) get focus support
- *     "for free" by reading the context.
+ *   - New panes get focus support "for free" by reading the context.
  *
  * The context only owns focus. Other global state (composer drafts,
  * task selection, etc.) stays where it is — focus is special because

--- a/packages/kobe/src/tui/context/sync.tsx
+++ b/packages/kobe/src/tui/context/sync.tsx
@@ -3,14 +3,11 @@
  *
  * Opencode's `useSync` is the reactive mirror of its server state — sessions,
  * messages, agents, providers, MCP, LSP, vcs, etc. — all populated by SDK
- * calls and event subscriptions. None of that exists in kobe; the orchestrator
- * (Wave 1 Stream E) will publish its own `Task`/`Message` reactive store
- * later.
- *
- * We keep `useSync` as a no-op shim so any lifted component that imports
- * `@tui/context/sync` typechecks and renders. Every accessor returns an
- * empty array / undefined / "complete" — the equivalent of "nothing
- * happening, but loading is done."
+ * calls and event subscriptions. kobe's orchestrator uses its own reactive
+ * pattern instead; this shim exists so any lifted opencode component that
+ * imports `@tui/context/sync` typechecks and renders without modification.
+ * Every accessor returns an empty array / undefined / "complete" — the
+ * equivalent of "nothing happening, but loading is done."
  */
 
 import { createSimpleContext } from "./helper"

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -5,11 +5,11 @@
  * (resolved: worktree root is `<repo>/.claude/worktrees/<task-id>/`,
  * shared namespace with Claude Code's own agent-spawn worktrees).
  *
- * The orchestrator depends on this interface; Stream B (Wave 1) will
- * ship `GitWorktreeManager` against it. The orchestrator must never
- * shell out to `git worktree` directly — always go through this seam,
- * so error handling, dirty detection, and path conventions live in
- * exactly one place.
+ * The orchestrator depends on this interface; `GitWorktreeManager` is
+ * the production implementation. The orchestrator must never shell out
+ * to `git worktree` directly — always go through this seam, so error
+ * handling, dirty detection, and path conventions live in exactly one
+ * place.
  */
 
 /**


### PR DESCRIPTION
## Summary
- `daemon/server.ts` `merge.local.request` case called `requireString(payload, "taskId")` twice — once to pass to `requestLocalMerge` and again to pass to `getTask`. Extracted to a single `const taskId` at the top of the case.
- Removed three stale future-tense wave/stream references from doc comments (`types/worktree.ts`, `tui/context/focus.tsx`, `tui/context/sync.tsx`) — all of the referenced work shipped in Wave 1–4 and the comments read as unfinished planning notes rather than architecture docs.

## Test plan
- [x] `bun typecheck` passes
- [x] The change is mechanical — one variable extraction + comment cleanup