### PR TITLE
feat: TUI polish — sidebar search count, spinner fix, remove Checks tab, git legend, tab key hints

### DIFF
--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -550,6 +550,7 @@ export const KobeKeymap: readonly KobeBinding[] = [
     keys: ["ctrl+t"],
     category: "Workspace",
     description: "New chat tab",
+    hint: { keys: "ctrl+t", label: "new tab" },
   },
   {
     // KOB-74. Quick-fork: from a focused chat tab, spin up a child
@@ -593,6 +594,7 @@ export const KobeKeymap: readonly KobeBinding[] = [
     keys: ["ctrl+w"],
     category: "Workspace",
     description: "Close chat tab",
+    hint: { keys: "ctrl+w", label: "close tab" },
   },
   {
     // Rename the active chat tab. F2 is the cross-OS / cross-IDE
@@ -703,16 +705,14 @@ export const KobeKeymap: readonly KobeBinding[] = [
     hint: { keys: "enter", label: "open" },
   },
   {
-    // `[` / `]` cycle the All / Changes / Checks tabs. Single-digit
-    // 1/2/3 used to be the chord but it conflicted with composer
-    // typing once focus crossed panes, and the bracket pair matches
+    // `[` / `]` cycle the All / Changes tabs. Bracket pair matches
     // the sidebar's Working/Archives view-switcher so the muscle
     // memory is consistent across panes.
     id: "files.tab",
     scope: "files",
     keys: ["[", "]"],
     category: "Files",
-    description: "Switch tab (cycle All / Changes / Checks)",
+    description: "Switch tab (cycle All / Changes)",
     hint: { keys: "[/]", label: "tab" },
   },
   {

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -6,7 +6,7 @@
  * filtering/scoping:
  *
  *   ┌────────────────────────────────────────┐
- *   │  All   Changes   Checks                │  ← tabs (1/2/3)
+ *   │  All   Changes                         │  ← tabs ([/])
  *   ├────────────────────────────────────────┤
  *   │  .prettierrc                            │
  *   │  bun.lock                               │
@@ -142,7 +142,7 @@ function statusToken(s: FileStatus): "warning" | "success" | "error" | "textMute
  * The tabs in render order. `as const` so TypeScript keeps the
  * literal-tuple narrowing for downstream `.map()` callers.
  */
-const TABS = ["all", "changes", "checks"] as const satisfies readonly FileTreeTab[]
+const TABS = ["all", "changes"] as const satisfies readonly FileTreeTab[]
 
 /**
  * Boil a raw `git ls-files` / `git status` error down to a single
@@ -167,7 +167,6 @@ export function summarizeGitError(raw: string): string {
 const TAB_LABEL: Record<FileTreeTab, string> = {
   all: "All",
   changes: "Changes",
-  checks: "Checks",
 }
 
 export function FileTree(props: FileTreeProps) {
@@ -220,7 +219,6 @@ export function FileTree(props: FileTreeProps) {
         if (seq !== fetchSeq || props.worktreePath() !== path) return
         setChanges(entries)
       }
-      // `checks` has no data to fetch in v1.
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       if (seq === fetchSeq && props.worktreePath() === path) setError(message)
@@ -346,7 +344,6 @@ export function FileTree(props: FileTreeProps) {
         deleted: e.deleted,
       }))
     }
-    // checks tab — no rows in v1
     return []
   })
 
@@ -526,11 +523,23 @@ export function FileTree(props: FileTreeProps) {
          "f file · d diff · ctrl+w close" strip in the preview pane.
          Highlights `o` so users discover the OS-default-app opener
          without having to remember it from the help dialog. */}
-      <box flexDirection="row" paddingBottom={1} flexShrink={0}>
+      <box flexDirection="row" paddingBottom={0} flexShrink={0}>
         <text fg={theme.textMuted} wrapMode="none">
           enter open · o open externally · r refresh
         </text>
       </box>
+      {/* Status legend — only shown on the Changes tab so users can
+         decode single-char git status codes without leaving the TUI. */}
+      <Show when={tab() === "changes"}>
+        <box flexDirection="row" paddingBottom={1} flexShrink={0}>
+          <text fg={theme.textMuted} wrapMode="none">
+            M modified · A added · D deleted · ? untracked
+          </text>
+        </box>
+      </Show>
+      <Show when={tab() !== "changes"}>
+        <box flexDirection="row" paddingBottom={1} flexShrink={0} />
+      </Show>
 
       {/* Body: scrollable list. Scrollbar styled subtle — track blends
          into the panel bg, thumb is muted text color. */}
@@ -564,17 +573,10 @@ export function FileTree(props: FileTreeProps) {
           </box>
         </Show>
 
-        <Show when={props.worktreePath() != null && error() == null && tab() === "checks"}>
-          <box paddingTop={1} paddingLeft={1}>
-            <text fg={theme.textMuted}>(checks not yet implemented)</text>
-          </box>
-        </Show>
-
         <Show
           when={
             props.worktreePath() != null &&
             error() == null &&
-            tab() !== "checks" &&
             rows().length === 0 &&
             ((tab() === "all" && allFiles() != null) || (tab() === "changes" && changes() != null))
           }

--- a/packages/kobe/src/tui/panes/filetree/keys.ts
+++ b/packages/kobe/src/tui/panes/filetree/keys.ts
@@ -33,10 +33,10 @@ import { useBindings } from "../../lib/keymap"
 /** Tab identifiers — kept here so `keys.ts` doesn't import from the
  * component file (which would create a circular import once `FileTree.tsx`
  * imports the hook from here). */
-export type FileTreeTab = "all" | "changes" | "checks"
+export type FileTreeTab = "all" | "changes"
 
 /** Tab order for `[`/`]` cycling. Same source-order as the visible chips. */
-export const TAB_ORDER: readonly FileTreeTab[] = ["all", "changes", "checks"]
+export const TAB_ORDER: readonly FileTreeTab[] = ["all", "changes"]
 
 export type FileTreeBindingsOpts = {
   /** Whether the pane should respond to keys. Default `() => true`. */

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -308,6 +308,8 @@ export function Sidebar(props: SidebarProps) {
   // we don't keep filtering against stale query text after esc-cancel.
   const rows = createMemo(() => buildRows(props.tasks(), view(), searchMode() ? searchQuery() : ""))
   const flatIds = createMemo(() => flattenIds(rows()))
+  // Total unfiltered count for the active view — used to show "N/total" in search mode.
+  const totalRows = createMemo(() => flattenIds(buildRows(props.tasks(), view(), "")).length)
 
   const [cursorIndex, setCursorIndex] = createSignal<number>(-1)
 
@@ -459,6 +461,12 @@ export function Sidebar(props: SidebarProps) {
               fuzzy filter
             </text>
           </Show>
+          <Show when={searchQuery().length > 0}>
+            <text fg={theme.textMuted} wrapMode="none">
+              {" "}
+              {flatIds().length}/{totalRows()}
+            </text>
+          </Show>
         </box>
       </Show>
 
@@ -501,8 +509,25 @@ export function Sidebar(props: SidebarProps) {
               const isSelected = () => task.id === props.selectedId()
               const isMain = task.kind === "main"
               const badge = STATUS_BADGE[task.status]
+              // "Is this task actually streaming a turn right now?"
+              // True when the orchestrator holds a live engine handle for
+              // ANY of this task's tabs — covers multi-tab tasks where the
+              // running tab is not the active one. Spinner fires on isLive,
+              // not on task.status, so it stops immediately on interrupt
+              // (the handle drops) without waiting for the lifecycle to settle.
+              const isLive = createMemo(() => {
+                const map = props.chatRunState?.()
+                if (!map) return false
+                const prefix = `${task.id}:`
+                for (const [key, state] of map) {
+                  if (state === "running" && key.startsWith(prefix)) return true
+                }
+                return false
+              })
               const badgeColor = () => {
                 if (isMain) return theme.primary
+                // Any live tab → use primary (spinner) colour.
+                if (isLive()) return theme.primary
                 switch (badge.tone) {
                   case "success":
                     return theme.success
@@ -539,24 +564,6 @@ export function Sidebar(props: SidebarProps) {
                 branchTick()
                 return readWorktreeChanges(task.worktreePath)
               })
-              // "Is this task actually streaming a turn right now?"
-              // True only when the orchestrator holds a live engine
-              // handle for at least one of this task's tabs. Decouples
-              // the *animated* spinner from `task.status` — the user's
-              // mental model is "the dots should stop when I press
-              // esc", but `task.status === "in_progress"` only flips
-              // when the lifecycle ends (done / canceled / error /
-              // archived), not when the current turn aborts. Without
-              // this check the spinner kept spinning post-interrupt.
-              const isLive = createMemo(() => {
-                const map = props.chatRunState?.()
-                if (!map) return false
-                const prefix = `${task.id}:`
-                for (const [key, state] of map) {
-                  if (state === "running" && key.startsWith(prefix)) return true
-                }
-                return false
-              })
               const titleText = isMain ? repoBasename(task.repo) : task.title
               return (
                 <box
@@ -574,11 +581,11 @@ export function Sidebar(props: SidebarProps) {
                   >
                     {isMain
                       ? "★"
-                      : task.status === "in_progress"
-                        ? isLive()
-                          ? (IN_PROGRESS_SPINNER[spinnerFrame()] ?? IN_PROGRESS_SPINNER[0])
-                          : "●"
-                        : badge.glyph}
+                      : isLive()
+                        ? (IN_PROGRESS_SPINNER[spinnerFrame()] ?? IN_PROGRESS_SPINNER[0])
+                        : task.status === "in_progress"
+                          ? "●"
+                          : badge.glyph}
                   </text>
                   <text
                     fg={isCursor() ? theme.selectedListItemText : theme.text}
@@ -643,7 +650,7 @@ export function Sidebar(props: SidebarProps) {
             <box paddingTop={1} paddingLeft={1}>
               <text fg={theme.textMuted}>
                 {searchMode() && searchQuery().trim().length > 0
-                  ? "No matching tasks."
+                  ? "No matching tasks — esc to clear."
                   : view() === "active"
                     ? "No active tasks."
                     : "No archived tasks."}


### PR DESCRIPTION
## Summary

**Sidebar**
- Search now shows a match ratio: `/auth █ 3/12` next to the cursor when a query is active. A `totalRows` memo counts unfiltered tasks in the current view so the denominator is always accurate and reactive.
- Empty search result text changed from "No matching tasks." to "No matching tasks — esc to clear." so there's a clear escape affordance.
- Sidebar spinner now fires on `isLive()` (any tab of the task has a live engine handle) regardless of `task.status`. Previously the spinner only appeared when `task.status === "in_progress"`, which missed cases where a non-active tab was running. `isLive` moved above `badgeColor` in the row closure, and `badgeColor` also returns `theme.primary` when live.

**FileTree**
- Removed the "Checks" tab — it was a dead-end placeholder (`(checks not yet implemented)`) with no data source. Removed from `FileTreeTab` type, `TAB_ORDER`, `TABS`, `TAB_LABEL`, the fetch branch, and the render block.
- Added a compact git status legend on the Changes tab: `M modified · A added · D deleted · ? untracked`. Shown only on Changes so the All tab stays uncluttered.

**Keybindings**
- `chat.tab.new` (`ctrl+t`) and `chat.tab.close` (`ctrl+w`) now have `hint` entries — they appear in the status bar's Chat: left column when the workspace pane is focused.
- `files.tab` description updated to "cycle All / Changes".

## Test plan
- [x] `bun typecheck` passes
- [ ] Sidebar: open search with `/`, type a query — should show `N/total` beside cursor
- [ ] Sidebar: in a task with multiple chat tabs, start a session on a non-active tab — spinner should appear on the sidebar row
- [ ] FileTree: `[`/`]` cycles between All and Changes only (no Checks)
- [ ] FileTree: switching to Changes tab shows the `M · A · D · ?` legend line
- [ ] Status bar: focus the workspace pane — `[ctrl+t] new tab` and `[ctrl+w] close tab` should appear in the left hints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * File tree pane now displays only "All" and "Changes" tabs; tab cycling with bracket keys alternates between these two views
  * Search interface enhanced with row count display for the current view
  * Task progress indicators now dynamically reflect live running state in real-time
  * Improved search UI with clearer exit guidance ("esc to clear")

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->