### PR TITLE
feat: render TodoWrite v1 + Task v2 checklists inline (KOB-204)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/kobe": {
       "name": "@sma1lboy/kobe",
-      "version": "0.5.23",
+      "version": "0.5.26",
       "bin": {
         "kobe": "dist/cli/index.js",
       },

--- a/packages/kobe/src/tui/panes/chat/ChatView.tsx
+++ b/packages/kobe/src/tui/panes/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
-import type { Accessor } from "solid-js"
+import { type Accessor, createMemo } from "solid-js"
 import { Show } from "solid-js"
 import type { PermissionMode } from "../../../types/engine"
 import type { BackgroundTaskRow } from "../../component/background-tasks-parts"
@@ -8,7 +8,9 @@ import { BackgroundRunsLine } from "./BackgroundRunsLine"
 import { Composer, type ComposerSlashEntry } from "./Composer"
 import { Loading } from "./Loading"
 import { MessageList } from "./MessageList"
+import { TodoStatusLine } from "./TodoStatusLine"
 import type { ChatRow, QueuedPrompt } from "./store"
+import { computeRoundedSnapshots } from "./todo-render"
 
 export interface ChatViewProps {
   readonly theme: Theme
@@ -67,6 +69,13 @@ export interface ChatViewProps {
 
 export function ChatView(props: ChatViewProps) {
   const theme = props.theme
+  // Cross-row "rounded" snapshots — `Map<rowIndex, items[]>` where each
+  // entry is the slice of the snapshot row's items that belong to its
+  // round (older rounds filtered out). Computed once here and threaded
+  // into MessageList (for inline ToolRow rendering) and TodoStatusLine
+  // (for the composer-pinned panel) so both surfaces agree on what
+  // counts as "this round" without duplicating the scan.
+  const roundedSnapshots = createMemo(() => computeRoundedSnapshots(props.messages))
   return (
     <box flexGrow={1} flexDirection="column" paddingLeft={1} paddingRight={1}>
       <Show when={!props.hasTaskId}>
@@ -88,6 +97,7 @@ export function ChatView(props: ChatViewProps) {
           <box paddingRight={1} gap={0}>
             <MessageList
               messages={props.messages}
+              roundedSnapshots={roundedSnapshots()}
               expandedToolIndex={props.expandedToolIndex}
               onToggleTool={props.onToggleTool}
               expandedFoldStartIndex={props.expandedFoldStartIndex}
@@ -98,12 +108,21 @@ export function ChatView(props: ChatViewProps) {
               onClaimComposerFocus={props.onClaimComposerFocus}
               chatFocused={props.chatFocused}
             />
+            {/* Loading spinner + todo panel live **inside** the scrollbox
+                so they flow with the transcript instead of being pinned
+                above the composer. They land right after the last
+                message row, scroll with the chat, and disappear when
+                their visibility predicates flip — matches Claude Code
+                where the spinner + `TaskListV2` block scrolls with the
+                conversation rather than docking to the input bar. */}
+            <Show when={props.showThinking && props.hasTaskId}>
+              <Loading startedAt={props.loadingStartedAt} responseChars={props.currentTurnChars} />
+            </Show>
+            <Show when={props.hasTaskId}>
+              <TodoStatusLine messages={props.messages} roundedSnapshots={roundedSnapshots()} />
+            </Show>
           </box>
         </scrollbox>
-      </Show>
-
-      <Show when={props.showThinking && props.hasTaskId}>
-        <Loading startedAt={props.loadingStartedAt} responseChars={props.currentTurnChars} />
       </Show>
 
       <Show when={props.error}>

--- a/packages/kobe/src/tui/panes/chat/MessageList.tsx
+++ b/packages/kobe/src/tui/panes/chat/MessageList.tsx
@@ -50,6 +50,7 @@ import { AssistantRow, BashRow, ReasoningRow, SystemRow, UserRow } from "./Messa
 import { ToolRow } from "./ToolRow"
 import { ApprovalRow, QuestionRow } from "./UserInputRows"
 import type { ChatRow } from "./store"
+import type { SnapshotItem } from "./todo-render"
 import { type MessageRenderItem, ToolFoldRow, groupRenderItems, summarizeToolRun } from "./tool-fold"
 import { classifyTool } from "./tool-registry"
 
@@ -72,6 +73,15 @@ function foldItemsEqual(a: FoldItem, b: FoldItem): boolean {
 export interface MessageListProps {
   /** Chronological list of chat rows. Render in array order. */
   messages: readonly ChatRow[]
+  /**
+   * Per-row "rounded" snapshot items — `Map<rowIndex, items[]>` keyed
+   * by the snapshot row's index in `messages`. Threaded down to
+   * `ToolRow` so its `TodoSnapshotBanner / TodoSnapshotBody` show only
+   * this round's tasks (the previous round's completed tasks have
+   * already been baselined out of the slice). Computed once at the
+   * `ChatView` level — see {@link computeRoundedSnapshots}.
+   */
+  roundedSnapshots: ReadonlyMap<number, readonly SnapshotItem[]>
   /** Index of the tool row currently shown expanded, or null. */
   expandedToolIndex: number | null
   /** Toggle the expand/collapse state for the tool at `index`. */
@@ -231,6 +241,7 @@ export function MessageList(props: MessageListProps) {
               row={row}
               index={i}
               expanded={props.expandedToolIndex === i}
+              roundedItems={props.roundedSnapshots.get(i)}
               onToggle={() => props.onToggleTool(i)}
             />
           )

--- a/packages/kobe/src/tui/panes/chat/TodoStatusLine.tsx
+++ b/packages/kobe/src/tui/panes/chat/TodoStatusLine.tsx
@@ -1,0 +1,186 @@
+/**
+ * Todo-status panel — pinned directly above the chat composer, shows
+ * the current task-tracking snapshot (verbose header + per-task list,
+ * always expanded — matches Claude Code's TaskListV2 `isStandalone`
+ * mode rather than the collapsible `ctrl+t` panel).
+ *
+ * Data source: the most-recent task-snapshot tool row in the transcript
+ * — `TodoWrite` (v1, list on input) or `TaskList` (v2, list on output).
+ * The chat-stream renderer (`ToolRow`'s `TodoSnapshotBody`) shows the
+ * same data inline so users can scroll back through historical
+ * snapshots; this panel is the "current plan" indicator that doesn't
+ * scroll away.
+ *
+ * Self-hides when:
+ *   - the transcript has no snapshot yet,
+ *   - the snapshot is empty (v1 TodoWrite cleared its store when every
+ *     item completed — `TodoWriteTool.ts:70` `allDone ? [] : todos`),
+ *   - or the plan is all-done and the {@link ALL_DONE_GRACE_MS} grace
+ *     window has elapsed (mirrors Claude Code's recent-completed TTL).
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { useTheme } from "../../context/theme"
+import type { ChatRow } from "./store"
+import { type SnapshotItem, TODO_GLYPH, type TaskStatus, countTodos } from "./todo-render"
+
+export interface TodoStatusLineProps {
+  /**
+   * Kept on the props even though the panel only reads `roundedSnapshots`
+   * directly — `messages` is the cheapest way to make the reactive memo
+   * here re-run when chat rows change without sharing a separate
+   * "latest snapshot index" signal across the tree.
+   */
+  readonly messages: readonly ChatRow[]
+  /**
+   * Per-row "rounded" snapshot items computed once at the ChatView level
+   * (see {@link computeRoundedSnapshots}). The panel displays the
+   * **last** entry — i.e. the current round's tasks, with older rounds
+   * already filtered out.
+   */
+  readonly roundedSnapshots: ReadonlyMap<number, readonly SnapshotItem[]>
+}
+
+/**
+ * Grace window after the plan goes all-done before the panel hides
+ * itself. Matches Claude Code's `HIDE_DELAY_MS = 5_000` in
+ * `refs/claude-code/src/hooks/useTasksV2.ts:16` — the actual "clear the
+ * panel" delay. (CC's other 30s constant, `RECENT_COMPLETED_TTL_MS`, is
+ * for *visual ordering* of recently completed tasks, not for hiding.)
+ */
+const ALL_DONE_GRACE_MS = 5_000
+
+export function TodoStatusLine(props: TodoStatusLineProps) {
+  const { theme } = useTheme()
+
+  // Current-round items = the last entry in the rounded-snapshots map
+  // (newest snapshot row). The cross-row baseline pass already
+  // filtered out previous rounds' completed tasks, so what comes out
+  // here is "this round only" — same shape CC's `useTasksV2` returns
+  // after `resetTaskList` fires.
+  const items = createMemo<readonly SnapshotItem[]>(() => {
+    // Force reactivity on messages (the map is recomputed from it at
+    // the ChatView level, but accessing `props.roundedSnapshots`
+    // directly under Solid's tracking is enough; the messages read is
+    // belt-and-braces in case ChatView passes a stable map reference).
+    void props.messages
+    const snapshots = props.roundedSnapshots
+    let latest: readonly SnapshotItem[] = []
+    for (const entry of snapshots.values()) latest = entry
+    return latest
+  })
+
+  // True when the round has tasks but every one is completed/deleted.
+  const allDone = createMemo<boolean>(() => {
+    const list = items()
+    if (list.length === 0) return false
+    return list.every((t) => t.status === "completed" || t.status === "deleted")
+  })
+
+  // 5s grace timer — when `allDone` flips to true, hide the panel
+  // after the window elapses. If the round regains work (a new
+  // pending / in_progress task) before then, `allDone` flips back and
+  // `onCleanup` cancels the timer so the panel stays visible.
+  const [graceExpired, setGraceExpired] = createSignal(false)
+  createEffect(() => {
+    if (!allDone()) {
+      setGraceExpired(false)
+      return
+    }
+    setGraceExpired(false)
+    const handle = setTimeout(() => setGraceExpired(true), ALL_DONE_GRACE_MS)
+    onCleanup(() => clearTimeout(handle))
+  })
+
+  const visible = () => items().length > 0 && !(allDone() && graceExpired())
+
+  // Stable id-asc ordering — `[...tasks].sort(byIdAsc)` from CC's
+  // TaskListV2.tsx:167 for the un-truncated case (kobe terminal rows
+  // usually exceed CC's `maxDisplay=10`, so priority sort + truncation
+  // isn't needed yet).
+  const sortedItems = createMemo<readonly SnapshotItem[]>(() => {
+    return [...items()].sort((a, b) => {
+      const an = Number.parseInt(a.key, 10)
+      const bn = Number.parseInt(b.key, 10)
+      if (!Number.isNaN(an) && !Number.isNaN(bn)) return an - bn
+      return a.key.localeCompare(b.key)
+    })
+  })
+
+  // Status counts for the header — mirrors CC TaskListV2.tsx:129-131
+  // (`inProgressCount = tasks.length - completedCount - pendingCount`).
+  const counts = createMemo(() => countTodos(items()))
+
+  // Strip the `subject [#id]` decoration that the chat-stream snapshot
+  // body adds — panel mode (this surface) keeps the subject clean like
+  // CC's TaskItem; the in-chat surface keeps `[#id]` because it helps
+  // users tie a row back to a later `TaskUpdate #N` event.
+  const cleanText = (item: SnapshotItem): string => item.displayText.replace(/\s+\[#[^\]]+\]\s*$/, "")
+
+  // CC's icon colors (refs/claude-code/src/components/TaskListV2.tsx:225-239):
+  //   completed → success ; in_progress → "claude" (no kobe theme key,
+  //   fall back to accent) ; pending → undefined (default text color).
+  const iconColor = (status: TaskStatus) =>
+    status === "completed"
+      ? theme.success
+      : status === "in_progress"
+        ? theme.accent
+        : status === "deleted"
+          ? theme.error
+          : theme.text
+
+  // Subject attribute combo, lifted from CC's TaskItem (line 313):
+  //   `<Text bold={isInProgress} strikethrough={isCompleted} dimColor={isCompleted || isBlocked}>`.
+  // kobe doesn't track `blockedBy` on SnapshotItem yet so the blocked
+  // branch is just "deleted" for now (also dim+strike).
+  const subjectAttrs = (status: TaskStatus) => {
+    if (status === "completed" || status === "deleted") return TextAttributes.DIM | TextAttributes.STRIKETHROUGH
+    if (status === "in_progress") return TextAttributes.BOLD
+    return TextAttributes.NONE
+  }
+
+  return (
+    <Show when={visible()}>
+      {/* CC's TaskListV2 isStandalone wrapper: `flexDirection="column"
+          marginTop={1} marginLeft={2}`. opentui takes `paddingTop` /
+          `paddingLeft` instead of margin* — same visual effect since
+          the parent has no background. */}
+      <box flexDirection="column" flexShrink={0} paddingLeft={2} paddingTop={1}>
+        {/* Header — mirrors CC TaskListV2.tsx:192-208. Numbers bold,
+            rest dim. The "in progress" segment is omitted when
+            `inProgressCount === 0` so an all-done-or-pending plan reads
+            "3 tasks (0 done, 3 open)" (no stray ", 0 in progress,"). */}
+        <text fg={theme.textMuted}>
+          <span style={{ attributes: TextAttributes.BOLD }}>{counts().total}</span>
+          {" tasks ("}
+          <span style={{ attributes: TextAttributes.BOLD }}>{counts().done}</span>
+          {" done, "}
+          <Show when={counts().inProgress > 0}>
+            <span style={{ attributes: TextAttributes.BOLD }}>{counts().inProgress}</span>
+            {" in progress, "}
+          </Show>
+          <span style={{ attributes: TextAttributes.BOLD }}>{counts().pending}</span>
+          {" open)"}
+        </text>
+        <For each={sortedItems()}>
+          {(t) => (
+            <box flexDirection="row" gap={1}>
+              <box width={1} height={1}>
+                <text fg={iconColor(t.status)}>{TODO_GLYPH[t.status]}</text>
+              </box>
+              <box flexGrow={1}>
+                <text
+                  fg={t.status === "pending" ? theme.text : iconColor(t.status)}
+                  attributes={subjectAttrs(t.status)}
+                >
+                  {cleanText(t)}
+                </text>
+              </box>
+            </box>
+          )}
+        </For>
+      </box>
+    </Show>
+  )
+}

--- a/packages/kobe/src/tui/panes/chat/ToolRow.tsx
+++ b/packages/kobe/src/tui/panes/chat/ToolRow.tsx
@@ -19,6 +19,16 @@ import {
 } from "./edit-diff"
 import { BLACK_CIRCLE, RESULT_PREFIX } from "./message-figures"
 import type { ChatRow, ToolChildRow } from "./store"
+import {
+  type SnapshotItem,
+  TODO_GLYPH,
+  type TaskStatus,
+  countTodos,
+  parseTaskCreateInput,
+  parseTaskUpdateInput,
+  parseTaskUpdateOutput,
+  summarizeTodos,
+} from "./todo-render"
 import { summarizeGlob, summarizeGrep, summarizeRead } from "./tool-banners"
 import { type ToolCounts, summarizeToolRun } from "./tool-fold"
 import { classifyTool, lookupToolMeta } from "./tool-registry"
@@ -84,12 +94,29 @@ export function ToolRow(props: {
   row: Extract<ChatRow, { kind: "tool" }>
   index: number
   expanded: boolean
+  /**
+   * "Rounded" snapshot items for this row — only the tasks that belong
+   * to *this round* (older rounds' completed tasks filtered out by the
+   * cross-row pass in {@link computeRoundedSnapshots}). `undefined` for
+   * non-snapshot tool rows and for rows the pass didn't visit yet.
+   */
+  roundedItems?: readonly SnapshotItem[]
   onToggle: () => void
 }) {
   const { theme } = useTheme()
   const r = () => props.row
-  const prefixGlyph = () => (r().done ? BLACK_CIRCLE : "✻")
-  const prefixColor = () => (r().done ? theme.success : theme.warning)
+  // Snapshot rows (TodoWrite/TaskList) get a green expand triangle as
+  // their prefix glyph instead of the usual ● / ✻ status dot — the
+  // row's body is collapsible, and the triangle is the standard "click
+  // to expand / collapse" affordance.
+  const prefixGlyph = () => {
+    if (isTodoSnapshot()) return props.expanded ? "▼" : "▶"
+    return r().done ? BLACK_CIRCLE : "✻"
+  }
+  const prefixColor = () => {
+    if (isTodoSnapshot()) return theme.success
+    return r().done ? theme.success : theme.warning
+  }
   // Render strategy comes from the per-vendor tool registry. The
   // string-literal name comparisons that used to live here moved to
   // `tool-registry.ts` so that adding a Codex tool only edits one place.
@@ -99,6 +126,8 @@ export function ToolRow(props: {
   const isBash = () => meta().banner === "bash"
   const isReadGrepGlob = () => meta().banner === "read-grep-glob"
   const isSubagent = () => meta().body === "subagent"
+  const isTodoSnapshot = () => meta().body === "todo-snapshot"
+  const isTaskAction = () => meta().banner === "task-action"
   /** Tools whose banner replaces the generic `tool(arg-preview)` chip. */
   const usesCustomBanner = () => meta().banner !== "default" || meta().body !== "default"
   /** Tools whose body renders inline so the generic preview/expanded
@@ -107,7 +136,8 @@ export function ToolRow(props: {
     meta().body === "edit-diff" ||
     meta().body === "multi-edit-diff" ||
     meta().body === "bash-output" ||
-    meta().body === "subagent"
+    meta().body === "subagent" ||
+    meta().body === "todo-snapshot"
   const diff = (): FormattedDiff | null => {
     if (r().name === "Edit") return formatEditDiff(r().input)
     if (r().name === "Write") return formatWriteDiff(r().input)
@@ -129,24 +159,38 @@ export function ToolRow(props: {
             when={isSubagent()}
             fallback={
               <Show
-                when={isReadGrepGlob()}
+                when={isTodoSnapshot()}
                 fallback={
                   <Show
-                    when={isBash()}
+                    when={isTaskAction()}
                     fallback={
-                      <text fg={theme.text}>
-                        <span style={{ attributes: TextAttributes.BOLD }}>{r().name}</span>
-                        <Show when={!usesCustomBanner()}>
-                          <span style={{ fg: theme.textMuted }}>({previewToolInput(r().input)})</span>
-                        </Show>
-                      </text>
+                      <Show
+                        when={isReadGrepGlob()}
+                        fallback={
+                          <Show
+                            when={isBash()}
+                            fallback={
+                              <text fg={theme.text}>
+                                <span style={{ attributes: TextAttributes.BOLD }}>{r().name}</span>
+                                <Show when={!usesCustomBanner()}>
+                                  <span style={{ fg: theme.textMuted }}>({previewToolInput(r().input)})</span>
+                                </Show>
+                              </text>
+                            }
+                          >
+                            <BashBanner row={r()} />
+                          </Show>
+                        }
+                      >
+                        <ReadGrepGlobBanner row={r()} />
+                      </Show>
                     }
                   >
-                    <BashBanner row={r()} />
+                    <TaskActionBanner row={r()} />
                   </Show>
                 }
               >
-                <ReadGrepGlobBanner row={r()} />
+                <TodoSnapshotBanner items={props.roundedItems ?? []} name={r().name} />
               </Show>
             }
           >
@@ -179,6 +223,13 @@ export function ToolRow(props: {
           Expanded: the per-step list. */}
       <Show when={isSubagent()}>
         <SubagentBody row={r()} expanded={props.expanded} onToggle={props.onToggle} />
+      </Show>
+      {/* Task-snapshot tools (TodoWrite v1 / TaskList v2) — checklist
+          body. Always collapsed by default (panel above the composer is
+          the canonical "current plan" surface); click the banner to
+          expand and see the historical round snapshot. */}
+      <Show when={isTodoSnapshot()}>
+        <TodoSnapshotBody items={props.roundedItems ?? []} expanded={props.expanded} onToggle={props.onToggle} />
       </Show>
       {/* Result preview — collapsed view shows one indented line.
           Suppressed for tools with custom bodies (Edit/Write/MultiEdit/
@@ -549,5 +600,125 @@ function SubagentBody(props: {
         </Show>
       </Show>
     </box>
+  )
+}
+
+/**
+ * Banner for a task-snapshot row (TodoWrite v1 / TaskList v2) — bold
+ * tool name + dim status-count chip (`6 todos · ✓3 ◼1 ◻2`). The
+ * row-level prefix glyph (`▶`/`▼`, green) carries the expand
+ * affordance, so no inline chip is needed here. Reflects the
+ * **rounded** slice (this round only — see
+ * {@link computeRoundedSnapshots}) so the count matches the body's
+ * checklist when the user expands it.
+ */
+function TodoSnapshotBanner(props: { items: readonly SnapshotItem[]; name: string }) {
+  const { theme } = useTheme()
+  const summary = () => summarizeTodos(countTodos(props.items))
+  return (
+    <text fg={theme.text} wrapMode="none">
+      <span style={{ attributes: TextAttributes.BOLD }}>{props.name}</span>
+      <span style={{ fg: theme.textMuted }}>{` · ${summary()}`}</span>
+    </text>
+  )
+}
+
+/**
+ * Body for a task-snapshot row — the inline checklist. Default state
+ * is **collapsed** (banner only); the always-on `TodoStatusLine` above
+ * the composer is the canonical "current plan" surface, so listing the
+ * same tasks again inline right under the banner is pure redundancy.
+ * Click the banner to expand and see this round's snapshot (older
+ * rounds' completed items are already filtered out by the cross-row
+ * pass in {@link computeRoundedSnapshots}).
+ */
+function TodoSnapshotBody(props: { items: readonly SnapshotItem[]; expanded: boolean; onToggle: () => void }) {
+  const { theme } = useTheme()
+  const items = (): readonly SnapshotItem[] => props.items
+  const show = () => props.expanded
+  const colorFor = (status: TaskStatus) =>
+    status === "completed"
+      ? theme.success
+      : status === "in_progress"
+        ? theme.accent
+        : status === "deleted"
+          ? theme.error
+          : theme.textMuted
+  // Matches Claude Code's TaskListV2 attribute combo:
+  //   completed → dim + strikethrough; in_progress → bold; pending → plain.
+  const subjectAttrs = (status: TaskStatus) => {
+    if (status === "completed" || status === "deleted") return TextAttributes.DIM | TextAttributes.STRIKETHROUGH
+    if (status === "in_progress") return TextAttributes.BOLD
+    return TextAttributes.NONE
+  }
+  return (
+    <Show when={show() && items().length > 0}>
+      <box paddingLeft={2} flexDirection="column" onMouseUp={() => props.onToggle()}>
+        <For each={items()}>
+          {(t) => (
+            <box flexDirection="row" gap={1}>
+              <text fg={colorFor(t.status)} wrapMode="none">
+                {TODO_GLYPH[t.status]}
+              </text>
+              <box flexGrow={1}>
+                <text fg={t.status === "pending" ? theme.text : colorFor(t.status)} attributes={subjectAttrs(t.status)}>
+                  {t.displayText}
+                </text>
+              </box>
+            </box>
+          )}
+        </For>
+      </box>
+    </Show>
+  )
+}
+
+/**
+ * Banner for v2 task-action tools (`TaskCreate / TaskUpdate / TaskGet`).
+ * These are single-item operations against an internal task store, so
+ * the banner does the work — body falls back to the default collapsed
+ * preview / expanded-JSON renderer.
+ *
+ *   - `TaskCreate · "<subject>"` — taken from input.subject.
+ *   - `TaskUpdate · #<id> · <fromStatus → toStatus>` (status change),
+ *     `· updated: <fields>` (other fields), or `· deleted` (deleted
+ *     status). Falls back to `#<id>` if neither input nor output gives
+ *     enough information.
+ *   - `TaskGet · #<id>` — bare id chip.
+ */
+function TaskActionBanner(props: { row: Extract<ChatRow, { kind: "tool" }> }) {
+  const { theme } = useTheme()
+  const summary = (): string => {
+    const row = props.row
+    if (row.name === "TaskCreate") {
+      const input = parseTaskCreateInput(row.input)
+      return input ? `"${input.subject}"` : ""
+    }
+    if (row.name === "TaskUpdate") {
+      const input = parseTaskUpdateInput(row.input)
+      const output = parseTaskUpdateOutput(row.output)
+      const id = input?.taskId ?? output?.taskId ?? ""
+      const idChip = id ? `#${id}` : ""
+      if (output?.error) return `${idChip} · ${output.error}`
+      if (output?.statusChange) return `${idChip} · ${output.statusChange.from} → ${output.statusChange.to}`
+      if (input?.status === "deleted") return `${idChip} · deleted`
+      if (input?.status) return `${idChip} · → ${input.status}`
+      if (output?.updatedFields.length) return `${idChip} · updated: ${output.updatedFields.join(", ")}`
+      return idChip
+    }
+    if (row.name === "TaskGet") {
+      const input = row.input as { taskId?: unknown } | null
+      const id = input && typeof input === "object" && typeof input.taskId === "string" ? input.taskId : ""
+      return id ? `#${id}` : ""
+    }
+    return ""
+  }
+  return (
+    <text fg={theme.text} wrapMode="none">
+      <span style={{ attributes: TextAttributes.BOLD }}>{props.row.name}</span>
+      <Show when={summary().length > 0}>
+        <span style={{ fg: theme.textMuted }}>{` · ${summary()}`}</span>
+      </Show>
+    </text>
   )
 }

--- a/packages/kobe/src/tui/panes/chat/todo-render.ts
+++ b/packages/kobe/src/tui/panes/chat/todo-render.ts
@@ -1,0 +1,540 @@
+/**
+ * Parsing + summary helpers for Claude Code's two generations of
+ * task-tracking tools:
+ *
+ *   - **TodoWrite (v1)** — ships `{ todos: [{ content, status, activeForm }] }`
+ *     and is the full snapshot each call. Schema:
+ *     `refs/claude-code/src/utils/todo/types.ts`.
+ *   - **Task v2** — four tools (`TaskCreate / TaskUpdate / TaskList /
+ *     TaskGet`) that work against an internal task store. Individual
+ *     calls are incremental (one task added / one task changed); only
+ *     `TaskList` returns the full set. Schemas:
+ *     `refs/claude-code/src/tools/Task{Create,Update,List,Get}Tool/`.
+ *
+ * In Claude Code's own Ink TUI both generations hide their tool-use
+ * banners (`renderToolUseMessage() => null`) and render the task list
+ * in a `ctrl+t`-toggled panel. kobe takes a different shape: render the
+ * full list **inline** in the chat stream (so users can scroll back
+ * through how the agent's plan evolved), backed by:
+ *
+ *   - "snapshot" tools (TodoWrite, TaskList) — most-recent one renders
+ *     full; earlier ones collapse to a status-count chip
+ *     (see ToolRow's `TodoListBody`).
+ *   - "action" tools (TaskCreate / TaskUpdate / TaskGet) — single-line
+ *     custom banner; no inline list body.
+ *
+ * This module is parsing + formatting only — no JSX, so it can be
+ * imported from any layer.
+ */
+
+// =============================================================================
+// Shared status type
+// =============================================================================
+
+/**
+ * Task v1 had three statuses; v2 adds `"deleted"` as a TaskUpdate action.
+ * Deleted tasks normally do not appear in a `TaskList` result (the
+ * underlying store drops them), but the parser tolerates the value so a
+ * malformed-but-typed payload doesn't crash.
+ */
+export type TaskStatus = "pending" | "in_progress" | "completed" | "deleted"
+
+/** Backwards-compatible alias for the v1 callers in this file. */
+export type TodoStatus = Exclude<TaskStatus, "deleted">
+
+const TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatus>(["pending", "in_progress", "completed", "deleted"])
+const V1_STATUSES: ReadonlySet<TodoStatus> = new Set<TodoStatus>(["pending", "in_progress", "completed"])
+
+/**
+ * Glyphs for the inline checklist — matches Claude Code's TaskListV2
+ * choices (`refs/claude-code/src/components/TaskListV2.tsx:225-239`):
+ *
+ *   - completed → `figures.tick` (✓)
+ *   - in_progress → `figures.squareSmallFilled` (◼)
+ *   - pending → `figures.squareSmall` (◻)
+ *
+ * `deleted` is kobe-only — TaskList output normally strips deleted rows,
+ * but if one slips through we mark it with `✗` so the parser stays
+ * lossless.
+ */
+export const TODO_GLYPH = {
+  completed: "✓",
+  in_progress: "◼",
+  pending: "◻",
+  deleted: "✗",
+} as const satisfies Record<TaskStatus, string>
+
+// =============================================================================
+// v1 — TodoWrite
+// =============================================================================
+
+export interface TodoItem {
+  readonly content: string
+  readonly status: TodoStatus
+  readonly activeForm: string
+}
+
+/**
+ * Best-effort parse of a TodoWrite tool input. Returns `[]` for anything
+ * we can't make sense of so a malformed payload renders as an empty
+ * list instead of crashing the row.
+ */
+export function parseTodos(input: unknown): readonly TodoItem[] {
+  if (input == null || typeof input !== "object") return []
+  const todos = (input as { todos?: unknown }).todos
+  if (!Array.isArray(todos)) return []
+  const out: TodoItem[] = []
+  for (const t of todos) {
+    if (!t || typeof t !== "object") continue
+    const obj = t as Record<string, unknown>
+    const content = typeof obj.content === "string" ? obj.content : ""
+    const activeForm = typeof obj.activeForm === "string" ? obj.activeForm : content
+    const status =
+      typeof obj.status === "string" && V1_STATUSES.has(obj.status as TodoStatus)
+        ? (obj.status as TodoStatus)
+        : "pending"
+    if (content.length === 0) continue
+    out.push({ content, status, activeForm })
+  }
+  return out
+}
+
+/** Text to render for a todo row — activeForm while in flight, content otherwise. */
+export function todoDisplayText(t: TodoItem): string {
+  return t.status === "in_progress" ? t.activeForm : t.content
+}
+
+// =============================================================================
+// v2 — Task* tools
+// =============================================================================
+
+export interface TaskV2Item {
+  readonly id: string
+  readonly subject: string
+  readonly status: TaskStatus
+  readonly owner?: string
+  readonly blockedBy?: readonly string[]
+}
+
+function parseTaskStatus(raw: unknown): TaskStatus {
+  return typeof raw === "string" && TASK_STATUSES.has(raw as TaskStatus) ? (raw as TaskStatus) : "pending"
+}
+
+function parseTaskItem(obj: Record<string, unknown>): TaskV2Item | null {
+  const id = typeof obj.id === "string" ? obj.id : ""
+  const subject = typeof obj.subject === "string" ? obj.subject : ""
+  if (!id || !subject) return null
+  return {
+    id,
+    subject,
+    status: parseTaskStatus(obj.status),
+    owner: typeof obj.owner === "string" ? obj.owner : undefined,
+    blockedBy: Array.isArray(obj.blockedBy)
+      ? obj.blockedBy.filter((x): x is string => typeof x === "string")
+      : undefined,
+  }
+}
+
+export interface TaskCreateInput {
+  readonly subject: string
+  readonly description: string
+  readonly activeForm: string
+}
+
+export function parseTaskCreateInput(input: unknown): TaskCreateInput | null {
+  if (input == null || typeof input !== "object") return null
+  const obj = input as Record<string, unknown>
+  const subject = typeof obj.subject === "string" ? obj.subject : ""
+  if (!subject) return null
+  const description = typeof obj.description === "string" ? obj.description : ""
+  const activeForm = typeof obj.activeForm === "string" ? obj.activeForm : subject
+  return { subject, description, activeForm }
+}
+
+export interface TaskUpdateInput {
+  readonly taskId: string
+  readonly status?: TaskStatus
+  readonly subject?: string
+  readonly activeForm?: string
+  readonly owner?: string
+}
+
+export function parseTaskUpdateInput(input: unknown): TaskUpdateInput | null {
+  if (input == null || typeof input !== "object") return null
+  const obj = input as Record<string, unknown>
+  const taskId = typeof obj.taskId === "string" ? obj.taskId : ""
+  if (!taskId) return null
+  return {
+    taskId,
+    status:
+      typeof obj.status === "string" && TASK_STATUSES.has(obj.status as TaskStatus)
+        ? (obj.status as TaskStatus)
+        : undefined,
+    subject: typeof obj.subject === "string" ? obj.subject : undefined,
+    activeForm: typeof obj.activeForm === "string" ? obj.activeForm : undefined,
+    owner: typeof obj.owner === "string" ? obj.owner : undefined,
+  }
+}
+
+export interface TaskUpdateOutput {
+  readonly success: boolean
+  readonly taskId: string
+  readonly updatedFields: readonly string[]
+  readonly statusChange?: { readonly from: string; readonly to: string }
+  readonly error?: string
+}
+
+export function parseTaskUpdateOutput(output: unknown): TaskUpdateOutput | null {
+  if (output == null || typeof output !== "object") return null
+  const obj = output as Record<string, unknown>
+  const taskId = typeof obj.taskId === "string" ? obj.taskId : ""
+  if (!taskId) return null
+  const updatedFields = Array.isArray(obj.updatedFields)
+    ? obj.updatedFields.filter((x): x is string => typeof x === "string")
+    : []
+  const sc = obj.statusChange
+  const statusChange =
+    sc &&
+    typeof sc === "object" &&
+    typeof (sc as Record<string, unknown>).from === "string" &&
+    typeof (sc as Record<string, unknown>).to === "string"
+      ? { from: (sc as Record<string, string>).from, to: (sc as Record<string, string>).to }
+      : undefined
+  return {
+    success: obj.success === true,
+    taskId,
+    updatedFields,
+    statusChange,
+    error: typeof obj.error === "string" ? obj.error : undefined,
+  }
+}
+
+/**
+ * Parses `TaskList`'s tool result. Returns `[]` for anything malformed.
+ *
+ * Claude Code v2 ships TaskList through the standard tool-result
+ * surface: `mapToolResultToToolResultBlockParam` formats the tasks into
+ * a multi-line **string** (`#1 [completed] Subject\n#2 [pending] …`)
+ * and that's what kobe's stream parser hands us as `row.output`. The
+ * structured `{tasks: [...]}` form is the internal `outputSchema`, not
+ * what crosses the tool-result boundary.
+ *
+ * To stay robust we accept both shapes:
+ *   - String / Anthropic content-block array → parse the line format.
+ *   - `{tasks: [...]}` object → use the structured fields (defensive
+ *     fallback in case a future build pipes structured output through).
+ */
+export function parseTaskListOutput(output: unknown): readonly TaskV2Item[] {
+  const text = coerceToolResultText(output)
+  if (text != null) return parseTaskListText(text)
+  if (output != null && typeof output === "object") {
+    const tasks = (output as { tasks?: unknown }).tasks
+    if (Array.isArray(tasks)) {
+      const out: TaskV2Item[] = []
+      for (const t of tasks) {
+        if (!t || typeof t !== "object") continue
+        const parsed = parseTaskItem(t as Record<string, unknown>)
+        if (parsed) out.push(parsed)
+      }
+      return out
+    }
+  }
+  return []
+}
+
+/**
+ * Best-effort coercion of `row.output` (whatever the stream parser put
+ * there) into a single text blob. Handles the two shapes the Anthropic
+ * tool_result `content` field can take:
+ *   - string — already text.
+ *   - array of content blocks — concatenate the `text` blocks.
+ * Returns `null` for anything else so the caller can try the structured
+ * path.
+ */
+function coerceToolResultText(output: unknown): string | null {
+  if (typeof output === "string") return output
+  if (Array.isArray(output)) {
+    const parts: string[] = []
+    for (const b of output) {
+      if (b && typeof b === "object" && (b as Record<string, unknown>).type === "text") {
+        const t = (b as Record<string, unknown>).text
+        if (typeof t === "string") parts.push(t)
+      }
+    }
+    if (parts.length > 0) return parts.join("\n")
+  }
+  return null
+}
+
+/**
+ * Parses the line format Claude Code v2's TaskList tool emits:
+ *
+ *   `#<id> [<status>] <subject>[ (<owner>)][ [blocked by #X, #Y]]`
+ *
+ * Strips the optional `(owner)` and `[blocked by ...]` suffixes so the
+ * `subject` field matches the structured-schema form. Skips lines that
+ * don't match (header text, blank lines, etc.) so a future Claude Code
+ * build adding a preamble doesn't break the parse.
+ */
+function parseTaskListText(text: string): TaskV2Item[] {
+  const out: TaskV2Item[] = []
+  const lineRe = /^#(\S+)\s+\[(pending|in_progress|completed|deleted)\]\s+(.+)$/
+  const blockedRe = /\s+\[blocked by [^\]]+\]\s*$/
+  const ownerRe = /\s+\(([^)]+)\)\s*$/
+  for (const raw of text.split("\n")) {
+    const line = raw.trim()
+    if (!line) continue
+    const m = lineRe.exec(line)
+    if (!m) continue
+    const id = m[1] ?? ""
+    const status = m[2] as TaskStatus
+    let rest = m[3] ?? ""
+    const blocked = blockedRe.exec(rest)
+    const blockedBy: string[] = []
+    if (blocked) {
+      const inner = blocked[0].match(/#(\S+?)(?=[,\]])/g) ?? []
+      for (const tag of inner) blockedBy.push(tag.slice(1))
+      rest = rest.slice(0, blocked.index).trim()
+    }
+    let owner: string | undefined
+    const ownerM = ownerRe.exec(rest)
+    if (ownerM) {
+      owner = ownerM[1]
+      rest = rest.slice(0, ownerM.index).trim()
+    }
+    if (!id || !rest) continue
+    out.push({
+      id,
+      subject: rest,
+      status,
+      owner,
+      blockedBy: blockedBy.length > 0 ? blockedBy : undefined,
+    })
+  }
+  return out
+}
+
+export interface TaskGetOutput {
+  readonly task: TaskV2Item | null
+}
+
+export function parseTaskGetOutput(output: unknown): TaskGetOutput {
+  if (output == null || typeof output !== "object") return { task: null }
+  const raw = (output as { task?: unknown }).task
+  if (!raw || typeof raw !== "object") return { task: null }
+  return { task: parseTaskItem(raw as Record<string, unknown>) }
+}
+
+// =============================================================================
+// Shared counting + summary
+// =============================================================================
+
+export interface TodoCounts {
+  readonly done: number
+  readonly inProgress: number
+  readonly pending: number
+  readonly total: number
+}
+
+/**
+ * Counts statuses in a v1 todo list or a v2 TaskList output. `deleted`
+ * tasks are excluded from the total — they don't render in the inline
+ * list either, so the chip summary stays consistent.
+ */
+export function countTodos(items: readonly { status: TaskStatus }[]): TodoCounts {
+  let done = 0
+  let inProgress = 0
+  let pending = 0
+  let total = 0
+  for (const t of items) {
+    if (t.status === "deleted") continue
+    total++
+    if (t.status === "completed") done++
+    else if (t.status === "in_progress") inProgress++
+    else pending++
+  }
+  return { done, inProgress, pending, total }
+}
+
+/**
+ * Compact glyph summary — `6 todos · ✓3 ◼1 ◻2`. Used in the in-chat
+ * banner (next to the tool name), where chat width is precious and the
+ * symbol form reads faster than the verbose form.
+ */
+export function summarizeTodos(c: TodoCounts): string {
+  if (c.total === 0) return "0 todos"
+  const noun = c.total === 1 ? "todo" : "todos"
+  return `${c.total} ${noun} · ${TODO_GLYPH.completed}${c.done} ${TODO_GLYPH.in_progress}${c.inProgress} ${TODO_GLYPH.pending}${c.pending}`
+}
+
+/**
+ * Verbose CC-style summary — `3 tasks (1 done, 1 in progress, 1 open)`.
+ * Used by the composer-pinned `TodoStatusLine`, where matching Claude
+ * Code's TaskListV2 header (`3 tasks (1 done, 1 in progress, 1 open)`)
+ * keeps the muscle memory.
+ */
+export function summarizeTodosVerbose(c: TodoCounts): string {
+  if (c.total === 0) return "0 tasks"
+  const noun = c.total === 1 ? "task" : "tasks"
+  const parts = [`${c.done} done`]
+  if (c.inProgress > 0) parts.push(`${c.inProgress} in progress`)
+  parts.push(`${c.pending} open`)
+  return `${c.total} ${noun} (${parts.join(", ")})`
+}
+
+// =============================================================================
+// Unified "snapshot item" view (consumed by ToolRow + TodoStatusLine)
+// =============================================================================
+
+/**
+ * Render-friendly shape that hides the v1/v2 schema difference from the
+ * UI: both `TodoWrite` (v1 input) and `TaskList` (v2 output) reduce to
+ * the same `{ key, status, displayText }` row.
+ *
+ *   - v1: `displayText` is `activeForm` while in flight, else `content`.
+ *   - v2: `displayText` is `subject [#id]` so the user can tie a row
+ *     back to a later `TaskUpdate #N` event.
+ */
+export interface SnapshotItem {
+  readonly key: string
+  readonly status: TaskStatus
+  readonly displayText: string
+}
+
+/**
+ * Extract the **raw** snapshot items from a tool-row's input/output —
+ * i.e. exactly what the tool returned, no cross-row filtering. For the
+ * "rounded" view that hides items belonging to earlier rounds, use
+ * {@link computeRoundedSnapshots}.
+ *
+ * Important: for `TaskList` (v2) the list lives in the **output**, so
+ * we wait for `row.done` before parsing; an in-flight `TaskList` row
+ * returns `[]` to keep the chip / list from briefly flashing empty
+ * before the result comes back.
+ */
+export function extractSnapshotItems(row: {
+  name: string
+  input?: unknown
+  output?: unknown
+  done: boolean
+}): readonly SnapshotItem[] {
+  if (row.name === "TodoWrite") {
+    return parseTodos(row.input).map(
+      (t: TodoItem, i): SnapshotItem => ({
+        key: `${i}`,
+        status: t.status,
+        displayText: todoDisplayText(t),
+      }),
+    )
+  }
+  if (row.name === "TaskList") {
+    if (!row.done) return []
+    return parseTaskListOutput(row.output).map(
+      (t: TaskV2Item): SnapshotItem => ({
+        key: t.id,
+        status: t.status,
+        displayText: `${t.subject} [#${t.id}]`,
+      }),
+    )
+  }
+  return []
+}
+
+/**
+ * Minimal `ChatRow` shape the rounding pass needs. Defined here (instead
+ * of importing the real `ChatRow` type from `./store`) so `todo-render`
+ * stays pane-agnostic — `ChatView` happens to call it with the real
+ * shape and TypeScript narrows on the `"tool"` discriminator.
+ */
+interface RoundingRow {
+  readonly kind: string
+  readonly name?: string
+  readonly input?: unknown
+  readonly output?: unknown
+  readonly done?: boolean
+}
+
+/**
+ * Cross-row "rounding" pass — for each task-snapshot row in `messages`,
+ * compute the items that belong to **its round** rather than the full
+ * accumulated store.
+ *
+ * Why this exists: v2 `TaskList` returns every task in the session
+ * store. Claude Code's TUI hides older rounds by physically clearing
+ * the store 5s after the plan goes all-done (`useTasksV2.ts:165`
+ * `resetTaskList`). kobe spawns `claude -p` and never runs that hook,
+ * so each new TaskList row drags every previously-completed task back
+ * onto the screen — both in the inline chat row body and in the
+ * composer-pinned panel.
+ *
+ * The fix: walk the chat row list once, maintain a `baseline` of task
+ * ids that have already been "rounded off", and for each snapshot row
+ * record only the non-baselined items as the row's *visible* slice.
+ *
+ * Round boundary heuristic (matches kobe's earlier in-component check):
+ *   - Look at the row's raw items.
+ *   - If they contain both completed and active items AND
+ *     `max(completed.id) < min(active.id)`, the user has clearly moved
+ *     on — every completed id below the active-id range is a previous
+ *     round. Add them to `baseline` so this row's visible slice (and
+ *     every later row's slice) drops them.
+ *
+ * Edge cases:
+ *   - All-completed snapshot with no active items → nothing to round
+ *     off (no "next round" has started yet). The row's visible slice is
+ *     the same as raw. Once a later row introduces a new id higher than
+ *     this round's max, that *later* row triggers the baseline update,
+ *     and that row's slice is clean.
+ *   - Non-numeric ids (theoretically possible from `parseTaskListText`
+ *     if Claude Code adopts a new id scheme) → the heuristic falls back
+ *     to "no rounding," which degrades to the pre-rounding behavior.
+ */
+export function computeRoundedSnapshots(
+  messages: readonly RoundingRow[],
+): ReadonlyMap<number, readonly SnapshotItem[]> {
+  const result = new Map<number, readonly SnapshotItem[]>()
+  const baseline = new Set<string>()
+  for (let i = 0; i < messages.length; i++) {
+    const r = messages[i]
+    if (!r || r.kind !== "tool") continue
+    if (r.name !== "TodoWrite" && r.name !== "TaskList") continue
+    const raw = extractSnapshotItems({
+      name: r.name,
+      input: r.input,
+      output: r.output,
+      done: r.done === true,
+    })
+    if (raw.length === 0) {
+      result.set(i, [])
+      continue
+    }
+
+    // Round-boundary check on the **raw** snapshot — if this row's
+    // contents already show "old completed + new active," promote the
+    // completed half to baseline before slicing so this row's visible
+    // items skip them too. Operating on raw (not the post-baseline
+    // view) is intentional: a fresh TaskList output is the canonical
+    // way kobe learns about a round transition.
+    const rawCompleted: SnapshotItem[] = []
+    const rawActive: SnapshotItem[] = []
+    for (const t of raw) {
+      if (t.status === "completed" || t.status === "deleted") rawCompleted.push(t)
+      else rawActive.push(t)
+    }
+    if (rawCompleted.length > 0 && rawActive.length > 0) {
+      const completedIds = rawCompleted.map((t) => Number.parseInt(t.key, 10)).filter((n) => !Number.isNaN(n))
+      const activeIds = rawActive.map((t) => Number.parseInt(t.key, 10)).filter((n) => !Number.isNaN(n))
+      if (
+        completedIds.length === rawCompleted.length &&
+        activeIds.length === rawActive.length &&
+        Math.max(...completedIds) < Math.min(...activeIds)
+      ) {
+        for (const t of rawCompleted) baseline.add(t.key)
+      }
+    }
+
+    const visible = raw.filter((t) => !baseline.has(t.key))
+    result.set(i, visible)
+  }
+  return result
+}

--- a/packages/kobe/src/tui/panes/chat/tool-fold.tsx
+++ b/packages/kobe/src/tui/panes/chat/tool-fold.tsx
@@ -1,18 +1,22 @@
 import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../../context/theme"
 import type { ChatRow } from "./store"
-import { classifyTool, isSubagentTool } from "./tool-registry"
+import { classifyTool, isSubagentTool, isTodoSnapshotTool } from "./tool-registry"
 
 export type ToolCounts = { search: number; read: number; list: number; bash: number; other: number }
 
 /**
  * A tool row is foldable into the "Searched N…, read M…" summary unless
- * it is a subagent (Agent/Task) row — those carry their own nested
- * progress UI and must render standalone. Non-tool rows are never
- * foldable.
+ * it is a subagent (Agent/Task) row or a task-snapshot row (TodoWrite /
+ * TaskList) — both carry their own per-row UI (nested step list /
+ * inline checklist) and must render standalone. `TaskCreate /
+ * TaskUpdate / TaskGet` carry their own per-row banner but no list body,
+ * so they remain foldable (a burst of `TaskUpdate`s rolls up into the
+ * "Used N other tools" chip). Non-tool rows are never foldable.
  */
 function isFoldableTool(row: ChatRow | undefined): boolean {
-  return row?.kind === "tool" && !isSubagentTool(row.name)
+  if (row?.kind !== "tool") return false
+  return !isSubagentTool(row.name) && !isTodoSnapshotTool(row.name)
 }
 
 export type MessageRenderItem =

--- a/packages/kobe/src/tui/panes/chat/tool-registry.ts
+++ b/packages/kobe/src/tui/panes/chat/tool-registry.ts
@@ -38,8 +38,12 @@ export type ToolBucket = "search" | "read" | "list" | "bash" | "other"
  *   - `bash` — multi-line banner showing `$ <command>` (see `BashBanner`).
  *   - `read-grep-glob` — banner shows the target / pattern (see
  *     `ReadGrepGlobBanner`).
+ *   - `task-action` — Claude Code v2 TaskCreate / TaskUpdate / TaskGet.
+ *     One-line summary derived from input/output (e.g.
+ *     `TaskCreate · "Run tests"`, `TaskUpdate · #42 · pending → in_progress`).
+ *     Body falls back to `default` (collapsed preview + expand for full JSON).
  */
-export type ToolBannerStrategy = "default" | "bash" | "read-grep-glob"
+export type ToolBannerStrategy = "default" | "bash" | "read-grep-glob" | "task-action"
 
 /**
  * Render strategy for a tool's body (what comes under the banner).
@@ -54,6 +58,12 @@ export type ToolBannerStrategy = "default" | "bash" | "read-grep-glob"
  *   - `subagent` — Agent/Task invocation. Body renders the subagent's
  *     nested tool steps (collected on the row's `children`): a
  *     collapsed progress summary, expandable to the per-step list.
+ *   - `todo-snapshot` — Claude Code's task-tracking "full snapshot" tools
+ *     (v1 `TodoWrite`'s input + v2 `TaskList`'s output). Banner shows a
+ *     status-count chip; the most-recent snapshot in the transcript
+ *     renders the full checkbox list, earlier ones collapse to the chip
+ *     alone (click to expand). Driven by `MessageList`'s `isLatestTodo`
+ *     prop.
  */
 export type ToolBodyStrategy =
   | "default"
@@ -62,6 +72,7 @@ export type ToolBodyStrategy =
   | "bash-output"
   | "read-grep-glob"
   | "subagent"
+  | "todo-snapshot"
 
 export interface ToolMeta {
   readonly bucket: ToolBucket
@@ -92,6 +103,19 @@ const claudeRegistry: Readonly<Record<string, ToolMeta>> = {
   // gets the nested-steps body.
   Task: { bucket: "other", banner: "default", body: "subagent" },
   Agent: { bucket: "other", banner: "default", body: "subagent" },
+  // TodoWrite (v1) — Claude Code hides this in its own Ink TUI; we
+  // render the checklist inline so the user can watch the agent's plan
+  // evolve.
+  TodoWrite: { bucket: "other", banner: "default", body: "todo-snapshot" },
+  // Task v2 — replaced TodoWrite in modern Claude Code builds (Todo v2
+  // growthbook flag). `TaskList` returns the full snapshot in its
+  // *output*, so it gets the same snapshot-style body as TodoWrite.
+  // `TaskCreate / TaskUpdate / TaskGet` are per-item actions: a custom
+  // one-line banner that surfaces the operation is enough.
+  TaskList: { bucket: "other", banner: "default", body: "todo-snapshot" },
+  TaskCreate: { bucket: "other", banner: "task-action", body: "default" },
+  TaskUpdate: { bucket: "other", banner: "task-action", body: "default" },
+  TaskGet: { bucket: "other", banner: "task-action", body: "default" },
 }
 
 const registries: Readonly<Record<VendorId, Readonly<Record<string, ToolMeta>>>> = {
@@ -130,4 +154,15 @@ export function classifyTool(name: string, vendor: VendorId = "claude"): ToolBuc
  */
 export function isSubagentTool(name: string, vendor: VendorId = "claude"): boolean {
   return lookupToolMeta(name, vendor).body === "subagent"
+}
+
+/**
+ * True for task-tracking "full snapshot" tools (`TodoWrite` v1 input,
+ * `TaskList` v2 output) that render an inline checklist. Like subagent
+ * rows, these own a per-row UI (latest-vs-collapsed) and must not be
+ * folded into the generic "Used N other tools" summary —
+ * `groupRenderItems` treats them as a fold boundary.
+ */
+export function isTodoSnapshotTool(name: string, vendor: VendorId = "claude"): boolean {
+  return lookupToolMeta(name, vendor).body === "todo-snapshot"
 }


### PR DESCRIPTION
## Summary

Stop dumping raw JSON for Claude Code's task-tracking tool calls (\`TodoWrite\` and the v2 \`TaskCreate/Update/List/Get\` family) and render a Claude-Code-style checklist:

- **\`TodoStatusLine\`** — a CC \`TaskListV2 isStandalone\` style panel ("\`N tasks (a done, b in progress, c open)\` " + per-task rows) that **flows inside the scrollbox** next to the thinking spinner, never docked to the composer.
- **Per-row banner in chat** — \`▶ TaskList · 3 todos · ✓1 ◼1 ◻1\` (green ▶ / ▼ expand affordance, click to reveal that round's checklist).
- **CC-faithful markup** — \`figures.tick / squareSmallFilled / squareSmall\` (✓ ◼ ◻), completed = \`DIM | STRIKETHROUGH\`, in_progress = \`BOLD\`, bold counts in the header.

## Across-row rounding

v2's \`TaskList\` returns the entire session store every time; CC's \`useTasksV2\` (\`refs/claude-code/src/hooks/useTasksV2.ts\`) papers over this by physically clearing the store 5s after the plan goes all-done. kobe spawns \`claude -p\` and never runs that hook, so each new TaskList drag every previously-completed task back into view.

\`computeRoundedSnapshots(messages)\` is the client-side equivalent: a single forward pass over the chat row list maintains a \`baseline\` Set, and each snapshot row's *visible* items are the raw output minus the baseline. New rounds are detected when \`max(completed.id) < min(active.id)\` — promote the completed ids into the baseline so this row and every later row drop them. Wired in at \`ChatView\` and threaded into both \`MessageList → ToolRow\` and \`TodoStatusLine\`.

## Hide / grace

The \`TodoStatusLine\` panel mirrors CC's 5s \`HIDE_DELAY_MS\` — once the round goes all-done the panel hides itself after the grace window, and the next \`TaskCreate\` starts a fresh visible round.

## Engine adapter

Output parsing is best-effort and handles both shapes the tool-result content can take (string vs Anthropic content-block array), plus the line format CC's \`TaskListTool\` emits (\`#N [status] subject (@owner) [blocked by #X]\`).

## Test plan

- [x] \`bun typecheck\` clean
- [x] \`bun lint\` clean
- [x] \`bun test\` — 1029 + 63 passing, 0 regressions
- [ ] Manual UI verification (covered live during this PR — restart kobe to load new code; trigger TaskCreate/TaskUpdate/TaskList in any task)

## Follow-ups (separate Linear issue)

- KOB-205-ish: orchestrator-level plan-state accumulator so a \`TaskUpdate\` alone (without a follow-up \`TaskList\`) refreshes the panel.
- \`isConcurrencySafe=true\` race between \`TaskUpdate\` write and \`TaskList\` read — also present in CC; not a kobe bug.