### PR TITLE
feat: KOB-250 — 首次使用按 N 直接打开 New task 面板,移除强制 kobe add

### DIFF
--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -29,7 +29,7 @@ import { Orchestrator, PLACEHOLDER_TASK_TITLE } from "../orchestrator/core.ts"
 import { DIRTY_WORKTREE_CODE } from "../orchestrator/errors.ts"
 import { TaskIndexStore } from "../orchestrator/index/store.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
-import { getSavedRepos, normalizeSavedRepos } from "../state/repos.ts"
+import { addSavedRepo, getSavedRepos, normalizeSavedRepos } from "../state/repos.ts"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "../types/task.ts"
 import { type UpdateInfo, checkLatestVersion } from "../version.ts"
 import { HelpDialog } from "./component/help-dialog"
@@ -266,24 +266,25 @@ function Shell(props: AppDeps) {
   // Sidebar callbacks.
   async function newTask(): Promise<void> {
     const repos = getSavedRepos()
-    if (repos.length === 0) {
-      await DialogConfirm.show(
-        dialog,
-        "No saved repos.",
-        "Run `kobe add <path>` from a shell first to register a repo, then come back here.",
-        "",
-        "ok",
-      )
-      return
-    }
-    // Default to the active task's repo when one is selected so the
-    // common "spawn a sibling" flow doesn't make the user re-pick.
-    const defaultRepo = activeTask()?.repo ?? repos[0] ?? ""
+    // First run (no saved repos): instead of bouncing the user to a
+    // shell for `kobe add`, open the dialog defaulted to the cwd so they
+    // pick a path in-TUI (the picker's saved mode preselects it; typing
+    // `/` flips to the directory browser). Otherwise default to the
+    // active task's repo so the common "spawn a sibling" flow doesn't
+    // make the user re-pick.
+    const defaultRepo = activeTask()?.repo ?? repos[0] ?? process.cwd()
     const defaultVendor = (kv.get("lastSelectedVendor") as VendorId | undefined) ?? DEFAULT_TASK_VENDOR
     const result = await NewTaskDialog.show(dialog, defaultRepo, repos, { defaultVendor })
     if (!result) return
     // Remember the choice so the next new-task dialog defaults to it.
     kv.set("lastSelectedVendor", result.vendor)
+    // Auto-save the chosen repo so the saved list self-populates and
+    // `kobe add` stays optional. addSavedRepo normalizes to the git
+    // root + dedupes on disk; mirror the fresh list into the kv store so
+    // its debounced whole-store flush doesn't clobber the write
+    // (savedRepos is not otherwise a kv-managed key).
+    addSavedRepo(result.repo)
+    kv.set("savedRepos", getSavedRepos())
     const task = await props.orchestrator.createTask({
       repo: result.repo,
       baseRef: result.baseRef,

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -42,7 +42,7 @@ import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { interactiveEngineCommand } from "../../engine/interactive-command.ts"
 import { homeDir } from "../../env.ts"
 import { TaskIndexStore } from "../../orchestrator/index/store.ts"
-import { getPersistedString, getSavedRepos, setPersistedString } from "../../state/repos.ts"
+import { addSavedRepo, getPersistedString, getSavedRepos, setPersistedString } from "../../state/repos.ts"
 import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import { nextVendor } from "../../types/vendor.ts"
 import { NewTaskDialog } from "../component/new-task-dialog"
@@ -55,7 +55,6 @@ import { readPersistedUiPrefs } from "../lib/persisted-ui-prefs"
 import { Sidebar } from "../panes/sidebar/Sidebar"
 import { ensureSession } from "../panes/terminal/tmux.ts"
 import { DialogProvider, useDialog } from "../ui/dialog"
-import { DialogConfirm } from "../ui/dialog-confirm"
 
 const FALLBACK_THEME = "claude"
 const RELOAD_MS = 1500
@@ -111,25 +110,24 @@ function TasksShell(props: {
     // (`maxWidth = dimensions().width - 2`), so it renders fine in the
     // ~22%-wide pane — just narrower — and the other panes stay visible.
     const repos = getSavedRepos()
-    if (repos.length === 0) {
-      await DialogConfirm.show(
-        dialog,
-        "No saved repos.",
-        "Run `kobe add <path>` from a shell first to register a repo, then come back here.",
-        "",
-        "ok",
-      )
-      return
-    }
     const list = props.tasks()
     const cursorRepo = (list.find((t) => t.id === selectedId()) ?? list[0])?.repo
-    const defaultRepo = cursorRepo ?? repos[0] ?? ""
+    // First run (no saved repos): default the dialog to the cwd so the
+    // user picks a path in-TUI instead of being sent to a shell for
+    // `kobe add` (saved mode preselects it; typing `/` flips to the
+    // directory browser). Otherwise default to the cursor task's repo
+    // (the "spawn a sibling" default).
+    const defaultRepo = cursorRepo ?? repos[0] ?? process.cwd()
     const defaultVendor = (getPersistedString("lastSelectedVendor") as VendorId | undefined) ?? DEFAULT_TASK_VENDOR
     const result = await NewTaskDialog.show(dialog, defaultRepo, repos, { defaultVendor })
     if (!result) return
     // Remember the choice (shared kv state.json) so the next new-task
     // dialog — here or in the outer monitor — defaults to it.
     setPersistedString("lastSelectedVendor", result.vendor)
+    // Auto-save the chosen repo so the saved list self-populates and
+    // `kobe add` stays optional. This pane uses disk-only persistence
+    // (no in-process kv store), so the atomic disk write is sufficient.
+    addSavedRepo(result.repo)
     if (!props.orch) {
       console.error("[kobe tasks] no daemon; cannot create task")
       return

--- a/packages/kobe/test/tui/new-task-dialog/state.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/state.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for new-task-dialog pure helpers (`src/tui/component/
+ * new-task-dialog/state.ts`).
+ *
+ * Focus: the picker mode logic the first-run flow leans on (KOB-250).
+ * With no saved repos the dialog defaults to the cwd — saved mode
+ * preselects it, and typing a `/` flips the picker into browse mode so
+ * the user drills into directories in-TUI instead of running `kobe add`
+ * from a shell. We pin:
+ *   - `pickerModeFor` returns "saved" for an exact saved-repo match
+ *     (the cwd-preselected state) and "browse" once the input looks
+ *     like a path.
+ *   - `splitPathForDirSuggest` splits a typed path into the directory to
+ *     readdir + the partial leaf to filter — including the trailing-slash
+ *     case that lists a directory's own children.
+ *   - `computeRepoOptions` always surfaces the cwd even with no saved
+ *     repos, so the first-run picker is never empty.
+ */
+
+import { computeRepoOptions, pickerModeFor, splitPathForDirSuggest } from "@/tui/component/new-task-dialog/state"
+import { describe, expect, it } from "vitest"
+
+describe("pickerModeFor", () => {
+  it("stays in saved mode when the input exactly matches a saved repo", () => {
+    const cwd = "/home/me/proj"
+    expect(pickerModeFor(cwd, [cwd])).toBe("saved")
+  })
+
+  it("flips to browse mode once the input looks like a path", () => {
+    expect(pickerModeFor("/home/me/proj/", ["/home/me/proj"])).toBe("browse")
+    expect(pickerModeFor("~/code", [])).toBe("browse")
+  })
+
+  it("treats a short non-path query as saved (substring filter)", () => {
+    expect(pickerModeFor("proj", ["/home/me/proj"])).toBe("saved")
+  })
+})
+
+describe("splitPathForDirSuggest", () => {
+  it("lists a directory's own children when the input ends in a slash", () => {
+    const split = splitPathForDirSuggest("/home/me/proj/")
+    expect(split.base).toBe("/home/me/proj/")
+    expect(split.filter).toBe("")
+  })
+
+  it("splits a partially-typed leaf off the base directory", () => {
+    const split = splitPathForDirSuggest("/home/me/pr")
+    expect(split.base).toBe("/home/me/")
+    expect(split.filter).toBe("pr")
+  })
+})
+
+describe("computeRepoOptions", () => {
+  it("surfaces the cwd even with no saved repos (first-run picker is never empty)", () => {
+    const cwd = "/home/me/proj"
+    expect(computeRepoOptions(cwd, [])).toEqual([cwd])
+  })
+
+  it("dedupes the cwd against the saved list and keeps it first", () => {
+    const cwd = "/home/me/proj"
+    expect(computeRepoOptions(cwd, [cwd, "/home/me/other"])).toEqual([cwd, "/home/me/other"])
+  })
+})


### PR DESCRIPTION
无 saved repo 时不再弹"先去 shell 跑 kobe add"的拦截框,而是把对话框默认到 cwd 让用户在 TUI 内选路径(saved 模式预选,敲 / 进目录浏览);创建任务后
addSavedRepo 自动收藏所选 repo,收藏列表自此自我填充。app.tsx 与内层 Tasks pane(host.tsx)两处同款入口一并处理,kobe add 退化为可选快捷方式。