### PR TITLE
fix: enable Ops file watcher

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Ops pane file watcher actually starts in task sessions** — the v0.6 Ops pane reused FileTree's opt-in watcher, but the tmux launch command never set the opt-in env var, so file changes only appeared after pressing `r`; task-launched `kobe ops` now enables `KOBE_FILETREE_WATCH=1` for that process while leaving other FileTree uses manual-refresh by default (KOB-255).
+
 ## [0.6.1-experimental.0] - 2026-05-29
 
 Experimental line on top of the 0.6 product reshape — published under the npm `experimental` dist-tag, not `latest`. Bundles the post-0.6.0 Tasks-pane / engine / event-bus work (KOB-244, 246, 247, 248, 232, 245, 249) plus GitHub Copilot as a third engine and the Accounts view (KOB-249).

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -149,7 +149,7 @@ export function opsPaneCommand(args: {
     const inv = args.cliInvocation.map(shellQuote).join(" ")
     const vendorFlag = args.vendor ? ` --vendor ${shellQuote(args.vendor)}` : ""
     return (
-      `${inv} ops --task-id ${shellQuote(args.taskId)} --worktree ${shellQuote(args.cwd)} ` +
+      `KOBE_FILETREE_WATCH=1 ${inv} ops --task-id ${shellQuote(args.taskId)} --worktree ${shellQuote(args.cwd)} ` +
       `--target-pane ${shellQuote(args.claudePaneId)}${vendorFlag} || { ${fallbackOpsScript(args.cwd)}; }`
     )
   }

--- a/packages/kobe/test/tmux/session-layout.test.ts
+++ b/packages/kobe/test/tmux/session-layout.test.ts
@@ -48,7 +48,7 @@ describe("opsPaneCommand", () => {
       claudePaneId: "%3",
       cliInvocation: ["kobe"],
     })
-    expect(cmd).toContain("'kobe' ops")
+    expect(cmd).toContain("KOBE_FILETREE_WATCH=1 'kobe' ops")
     expect(cmd).toContain("--task-id 't1'")
     expect(cmd).toContain("--worktree '/wt'")
     expect(cmd).toContain("--target-pane '%3'")
@@ -64,9 +64,11 @@ describe("opsPaneCommand", () => {
       claudePaneId: "%3",
       cliInvocation: ["/bin/bun", "--preload", "/abs/preload.ts", "--conditions=browser", "/abs/cli.ts"],
     })
-    expect(cmd.startsWith("'/bin/bun' '--preload' '/abs/preload.ts' '--conditions=browser' '/abs/cli.ts' ops")).toBe(
-      true,
-    )
+    expect(
+      cmd.startsWith(
+        "KOBE_FILETREE_WATCH=1 '/bin/bun' '--preload' '/abs/preload.ts' '--conditions=browser' '/abs/cli.ts' ops",
+      ),
+    ).toBe(true)
   })
 
   test("threads the engine vendor through as --vendor when given", () => {


### PR DESCRIPTION
## Summary

Fix the v0.6 Ops pane file-change watcher not starting in task tmux sessions.

Root cause: `FileTree` only installs its recursive `fs.watch` when `KOBE_FILETREE_WATCH=1`, but `opsPaneCommand()` launched task-scoped `kobe ops` without that env var. The pane rendered and manual `r` refresh worked, but disk changes did not auto-refresh.

Change:
- Prefix task-launched `kobe ops` commands with `KOBE_FILETREE_WATCH=1`.
- Keep standalone / fallback file tree behavior manual-refresh by default.
- Update tmux command-builder tests to lock the env propagation.

## Verification

- Live check on `~/projects/demos/tiny3dworld/.claude/worktrees/shark`: after respawning only the Ops pane with the watcher env, Changes showed both `test1.txt` and `test2.txt`.
- `bun --filter @sma1lboy/kobe typecheck`
- `bun --filter @sma1lboy/kobe lint`
- `bun --filter @sma1lboy/kobe test`
- `timeout 5 bun --filter @sma1lboy/kobe dev` exited 124 as expected.

## Linear

KOB-255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ops pane file watcher initialization in task sessions—file changes now appear automatically without requiring manual refresh.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->