### PR TITLE
feat: KOB-256 — 扫描 + 导入已存在 git worktree (CLI adopt + Adopt tab)

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+### Added
+
+- **Adopt existing git worktrees as tasks** — kobe can now pick up worktrees that already exist on disk (including ones you made yourself with `git worktree add`, outside `.claude/worktrees/`) instead of only ones it created. New `kobe adopt [glob] [--repo <path>] [--vendor <v>] [--yes]` CLI: run it to list a repo's adoptable worktrees (those not already a task), pass a path glob to select a batch, and `--yes` to import them — each becomes a task pointing at the existing worktree + its branch, with no new checkout. The New Task dialog gains an **Adopt Worktree** tab (in both the outer monitor and the in-session Tasks pane): it lists the same candidates with a path-glob filter, space/click to multi-select (Ctrl+A = all), and Create to import. Discovery reads `git worktree list` and de-dupes against existing tasks; adoption goes through the daemon so every surface updates live (KOB-256).
+
 ## [0.6.1] - 2026-05-29
 
 First stable release on top of the 0.6 product reshape — promotes the `0.6.1-experimental.0` prerelease to `latest`. Bundles the post-0.6.0 Tasks-pane / engine / event-bus work (KOB-244, 246, 247, 248, 232, 245), GitHub Copilot as a third engine plus the Accounts view (KOB-249), the inner Tasks-pane width trim (KOB-253), the Ops-pane new-activity badge (KOB-254), and the Ops file-watcher fix (KOB-255).

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -18,8 +18,10 @@
  * test fixtures. All gone in v0.6 (no engine port to diagnose, no
  * MCP bridge, no behavior fixtures).
  */
-import { resolve } from "node:path"
+import { basename, resolve } from "node:path"
+import { Glob } from "bun"
 import { coerceVendorId } from "../types/vendor.ts"
+import type { AdoptableWorktree } from "../types/worktree.ts"
 import { parseCliArgs } from "./daemon-mode.ts"
 
 async function runAddSubcommand(arg: string | undefined): Promise<void> {
@@ -30,6 +32,86 @@ async function runAddSubcommand(arg: string | undefined): Promise<void> {
     console.log(`added ${result.path} (${result.total} saved repo${result.total === 1 ? "" : "s"} total)`)
   } else {
     console.log(`already saved: ${result.path}`)
+  }
+}
+
+/**
+ * `kobe adopt [glob] [--repo <path>] [--vendor <v>] [--yes]` — scan a
+ * repo's existing git worktrees (including ones outside
+ * `.claude/worktrees/`) and import the ones not yet linked to a task
+ * (KOB-256). No glob → dry-run listing. With a path glob → list matches;
+ * `--yes` actually adopts them. Goes through the daemon so a running TUI
+ * sees the new tasks live.
+ */
+async function runAdoptSubcommand(args: readonly string[]): Promise<void> {
+  let glob: string | undefined
+  let repoArg: string | undefined
+  let vendorArg: string | undefined
+  let yes = false
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === "--repo") {
+      repoArg = args[++i]
+    } else if (a === "--vendor") {
+      vendorArg = args[++i]
+    } else if (a === "--yes" || a === "-y") {
+      yes = true
+    } else if (a && !a.startsWith("-") && glob === undefined) {
+      glob = a
+    }
+  }
+
+  const { resolveRepoRoot } = await import("../state/repos.ts")
+  const repo = resolveRepoRoot(resolve(process.cwd(), repoArg && repoArg.length > 0 ? repoArg : "."))
+  const vendor = coerceVendorId(vendorArg)
+  const { connectOrStartDaemon } = await import("../client/daemon-process.ts")
+  const client = await connectOrStartDaemon()
+  try {
+    const { worktrees } = await client.request<{ worktrees: AdoptableWorktree[] }>("worktree.discoverAdoptable", {
+      repo,
+    })
+    if (worktrees.length === 0) {
+      console.log(`no adoptable worktrees for ${repo} — every git worktree here is already a task`)
+      return
+    }
+
+    // Match by absolute path, and by basename for convenience (so
+    // `kobe adopt 'feature-*'` works without typing the full path).
+    const matcher = glob ? new Glob(glob) : undefined
+    const isMatch = (w: AdoptableWorktree) => !matcher || matcher.match(w.path) || matcher.match(basename(w.path))
+
+    console.log(`adoptable worktrees in ${repo}:`)
+    for (const w of worktrees) {
+      const hit = matcher ? (isMatch(w) ? "*" : " ") : "-"
+      const tags = [w.dirty ? "dirty" : "", w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
+      console.log(`  ${hit} ${w.branch}\t${w.path}${tags ? `  (${tags})` : ""}`)
+    }
+
+    if (!matcher) {
+      console.log(`\npass a path glob to adopt, e.g.  kobe adopt '${repo}/*' --yes`)
+      return
+    }
+    const matched = worktrees.filter(isMatch)
+    if (matched.length === 0) {
+      console.log(`\nno worktrees match glob ${JSON.stringify(glob)}`)
+      return
+    }
+    if (!yes) {
+      console.log(`\n${matched.length} worktree(s) match — re-run with --yes to adopt them`)
+      return
+    }
+    for (const w of matched) {
+      const { task } = await client.request<{ task: { id: string; title: string } }>("worktree.adopt", {
+        repo,
+        worktreePath: w.path,
+        branch: w.branch,
+        vendor,
+      })
+      console.log(`adopted ${w.branch} → task ${task.id} (${task.title})`)
+    }
+    console.log(`done — adopted ${matched.length} worktree(s)`)
+  } finally {
+    client.close()
   }
 }
 
@@ -87,6 +169,10 @@ async function main(): Promise<void> {
   const [subcommand, ...rest] = parsed.args
   if (subcommand === "add") {
     await runAddSubcommand(rest[0])
+    return
+  }
+  if (subcommand === "adopt") {
+    await runAdoptSubcommand(rest)
     return
   }
   if (subcommand === "update") {

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -18,8 +18,8 @@
  * test fixtures. All gone in v0.6 (no engine port to diagnose, no
  * MCP bridge, no behavior fixtures).
  */
-import { basename, resolve } from "node:path"
-import { Glob } from "bun"
+import { resolve } from "node:path"
+import { matchPathGlob } from "../lib/path-glob.ts"
 import { coerceVendorId } from "../types/vendor.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 import { parseCliArgs } from "./daemon-mode.ts"
@@ -77,17 +77,16 @@ async function runAdoptSubcommand(args: readonly string[]): Promise<void> {
 
     // Match by absolute path, and by basename for convenience (so
     // `kobe adopt 'feature-*'` works without typing the full path).
-    const matcher = glob ? new Glob(glob) : undefined
-    const isMatch = (w: AdoptableWorktree) => !matcher || matcher.match(w.path) || matcher.match(basename(w.path))
+    const isMatch = (w: AdoptableWorktree) => !glob || matchPathGlob(glob, w.path)
 
     console.log(`adoptable worktrees in ${repo}:`)
     for (const w of worktrees) {
-      const hit = matcher ? (isMatch(w) ? "*" : " ") : "-"
+      const hit = glob ? (isMatch(w) ? "*" : " ") : "-"
       const tags = [w.dirty ? "dirty" : "", w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
       console.log(`  ${hit} ${w.branch}\t${w.path}${tags ? `  (${tags})` : ""}`)
     }
 
-    if (!matcher) {
+    if (!glob) {
       console.log(`\npass a path glob to adopt, e.g.  kobe adopt '${repo}/*' --yes`)
       return
     }

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -14,6 +14,7 @@ import { DAEMON_PROTOCOL_VERSION, type SerializedTask } from "../daemon/protocol
 import type { Orchestrator, Unsubscribe } from "../orchestrator/core.ts"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import { toTaskId } from "../types/task.ts"
+import type { AdoptableWorktree } from "../types/worktree.ts"
 import { ensureDaemonReachable } from "./daemon-process.ts"
 import type { KobeDaemonClient } from "./index.ts"
 
@@ -206,6 +207,22 @@ export class RemoteOrchestrator {
 
   async deleteTask(id: TaskId | string, opts?: { force?: boolean }): Promise<void> {
     await this.client.request("task.delete", { taskId: String(id), force: opts?.force })
+  }
+
+  async discoverAdoptableWorktrees(repo: string): Promise<readonly AdoptableWorktree[]> {
+    const res = await this.client.request<{ worktrees: AdoptableWorktree[] }>("worktree.discoverAdoptable", { repo })
+    return res.worktrees
+  }
+
+  async adoptWorktree(input: {
+    repo: string
+    worktreePath: string
+    branch?: string
+    vendor?: VendorId
+    title?: string
+  }): Promise<Task> {
+    const res = await this.client.request<{ task: SerializedTask }>("worktree.adopt", input)
+    return deserializeTask(res.task)
   }
 
   /**

--- a/packages/kobe/src/daemon/protocol.ts
+++ b/packages/kobe/src/daemon/protocol.ts
@@ -47,6 +47,8 @@ export type DaemonRequestName =
   | "task.ensureMain"
   | "task.ensureWorktree"
   | "task.setActive"
+  | "worktree.discoverAdoptable"
+  | "worktree.adopt"
 
 /**
  * Channel registry — the SINGLE source of truth for daemon→client push

--- a/packages/kobe/src/daemon/server.ts
+++ b/packages/kobe/src/daemon/server.ts
@@ -245,6 +245,21 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
         const path = await orch.ensureWorktree(taskId)
         return { worktreePath: path }
       }
+      case "worktree.discoverAdoptable": {
+        const repo = requireString(payload, "repo")
+        const worktrees = await orch.discoverAdoptableWorktrees(repo)
+        return { worktrees }
+      }
+      case "worktree.adopt": {
+        const task = await orch.adoptWorktree({
+          repo: requireString(payload, "repo"),
+          worktreePath: requireString(payload, "worktreePath"),
+          branch: optionalString(payload, "branch"),
+          vendor: optionalVendor(payload, "vendor"),
+          title: optionalString(payload, "title"),
+        })
+        return { task: serializeTask(task) }
+      }
       case "task.setActive": {
         // Pure UI/session focus — not a task-index property — so it lives on
         // the bus, not the orchestrator. Publishing caches the last value so

--- a/packages/kobe/src/lib/path-glob.ts
+++ b/packages/kobe/src/lib/path-glob.ts
@@ -1,0 +1,56 @@
+/**
+ * Tiny zero-dependency path glob matcher (KOB-256).
+ *
+ * Used by `kobe adopt`'s `--glob` and the New Task → Adopt tab's filter
+ * to narrow discovered worktree paths. We roll our own instead of
+ * `Bun.Glob` so the same code runs under the Bun runtime AND under
+ * Vitest (which loads modules through Vite/node, where `import "bun"`
+ * doesn't resolve).
+ *
+ * Supported syntax (POSIX-ish, path-segment aware):
+ *   - `*`  — any run of chars except `/`
+ *   - `**` — any run of chars including `/`
+ *   - `?`  — a single char except `/`
+ * Everything else is matched literally (regex metachars are escaped).
+ */
+
+import { basename } from "node:path"
+
+/** Translate a glob into an anchored RegExp. */
+export function globToRegExp(glob: string): RegExp {
+  let re = ""
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        re += ".*"
+        i++
+      } else {
+        re += "[^/]*"
+      }
+    } else if (c === "?") {
+      re += "[^/]"
+    } else if (c && "\\^$.|+()[]{}".includes(c)) {
+      re += `\\${c}`
+    } else {
+      re += c
+    }
+  }
+  return new RegExp(`^${re}$`)
+}
+
+/**
+ * Match a path against a glob, trying both the full path and its
+ * basename — so a bare `feature-*` matches `/work/feature-login` without
+ * the caller typing the directory. Returns false (never throws) on an
+ * unparseable pattern.
+ */
+export function matchPathGlob(glob: string, p: string): boolean {
+  let re: RegExp
+  try {
+    re = globToRegExp(glob)
+  } catch {
+    return false
+  }
+  return re.test(p) || re.test(basename(p))
+}

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -22,10 +22,13 @@
  * actually enters the task.)
  */
 
+import { realpathSync } from "node:fs"
+import { basename, resolve } from "node:path"
 import type { Accessor } from "solid-js"
 import { createSignal } from "solid-js"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR, toTaskId } from "../types/task.ts"
+import type { AdoptableWorktree } from "../types/worktree.ts"
 import {
   CannotDeleteMainTaskError,
   DirtyWorktreeError,
@@ -403,6 +406,64 @@ export class Orchestrator {
     this.worktreeLocks.delete(task.id)
   }
 
+  /**
+   * Discover git worktrees on `repo` that exist on disk but aren't yet
+   * linked to any task — candidates for adoption (KOB-256). Includes
+   * worktrees outside the kobe convention root (the user's own
+   * `git worktree add`). De-dupes against the task store by canonical
+   * path so an already-adopted worktree never reappears.
+   */
+  async discoverAdoptableWorktrees(repo: string): Promise<readonly AdoptableWorktree[]> {
+    if (!repo) throw new Error("discoverAdoptableWorktrees: repo is required")
+    const all = await this.worktrees.listAll(repo)
+    const linked = new Set(
+      this.store
+        .list()
+        .filter((t) => t.worktreePath)
+        .map((t) => canonPath(t.worktreePath)),
+    )
+    return all.filter((wt) => !linked.has(canonPath(wt.path)))
+  }
+
+  /**
+   * Adopt an existing git worktree as a new task (KOB-256). The worktree
+   * already exists on disk, so we record the task with its real path +
+   * branch directly — `ensureWorktree` then short-circuits (non-empty
+   * `worktreePath`) and never touches the filesystem. Validates the path
+   * is a real worktree of `repo` and isn't already a task.
+   */
+  async adoptWorktree(input: {
+    readonly repo: string
+    readonly worktreePath: string
+    readonly branch?: string
+    readonly vendor?: VendorId
+    readonly title?: string
+  }): Promise<Task> {
+    if (!input.repo) throw new Error("adoptWorktree: repo is required")
+    if (!input.worktreePath) throw new Error("adoptWorktree: worktreePath is required")
+    const target = canonPath(input.worktreePath)
+    const candidates = await this.worktrees.listAll(input.repo)
+    const match = candidates.find((wt) => canonPath(wt.path) === target)
+    if (!match) {
+      throw new Error(
+        `adoptWorktree: ${input.worktreePath} is not an adoptable git worktree of ${input.repo} (unknown, detached, or the main checkout)`,
+      )
+    }
+    const alreadyLinked = this.store.list().some((t) => t.worktreePath && canonPath(t.worktreePath) === target)
+    if (alreadyLinked) throw new Error(`adoptWorktree: ${input.worktreePath} is already adopted as a task`)
+    const branch = input.branch?.trim() || match.branch
+    const title = (input.title ?? basename(match.path)).trim() || PLACEHOLDER_TASK_TITLE
+    return this.store.create({
+      repo: input.repo,
+      title,
+      branch,
+      worktreePath: match.path,
+      status: "backlog",
+      kind: "task",
+      vendor: input.vendor ?? DEFAULT_TASK_VENDOR,
+    })
+  }
+
   // --- internals ---
 
   /** Optional base-ref per task — consumed once by `ensureWorktree`. */
@@ -418,6 +479,20 @@ export class Orchestrator {
 function titleFromRepo(repo: string): string {
   const segs = repo.split(/[/\\]/).filter(Boolean)
   return segs.length > 0 ? (segs[segs.length - 1] ?? repo) : repo
+}
+
+/**
+ * Resolve symlinks so two strings naming the same node compare equal
+ * (macOS `/var` → `/private/var`). Falls back to `resolve` when the path
+ * doesn't exist. Used to de-dupe discovered worktrees against task paths,
+ * which may be stored in different (caller vs git) forms (KOB-256).
+ */
+function canonPath(p: string): string {
+  try {
+    return realpathSync(p)
+  } catch {
+    return resolve(p)
+  }
 }
 
 // Avoid an unused-import warning while keeping toTaskId reachable for

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -27,7 +27,7 @@
 
 import fs from "node:fs"
 import path from "node:path"
-import type { WorktreeInfo, WorktreeManager } from "../../types/worktree.ts"
+import type { AdoptableWorktree, WorktreeInfo, WorktreeManager } from "../../types/worktree.ts"
 import { GitCommandError, git } from "./git.ts"
 import { isKobeManagedPath, worktreePathFor, worktreeRootFor } from "./paths.ts"
 
@@ -224,6 +224,44 @@ export class GitWorktreeManager implements WorktreeManager {
         branch: entry.branch,
         head: entry.head ?? "",
         dirty,
+      })
+    }
+    return infos
+  }
+
+  /**
+   * List ALL git worktrees registered on `repo` — including ones the
+   * user created outside `<repo>/.claude/worktrees/` (KOB-256). Unlike
+   * {@link list}, this does NOT filter to the kobe convention root; it's
+   * the discovery source for "adopt an existing worktree as a task".
+   *
+   * Excludes the repo's main checkout (that's the main task, not an
+   * adoptable worktree) and detached/bare entries (no branch to track).
+   * Paths are returned as git reports them (absolute; on macOS that may
+   * be the `/private/...` realpath) — valid as a worktree `cwd` and
+   * compared canonically by callers, so no re-rooting is needed here.
+   */
+  async listAll(repo: string): Promise<readonly AdoptableWorktree[]> {
+    requireAbsolute("repo", repo)
+    const out = git(["worktree", "list", "--porcelain"], { cwd: repo })
+    const all = parsePorcelain(out.stdout)
+    const canonRepo = canonicalize(repo)
+
+    const infos: AdoptableWorktree[] = []
+    for (const entry of all) {
+      if (!entry.path) continue
+      if (entry.bare) continue
+      // Detached entries have no branch to map to a task's branch.
+      if (!entry.branch || entry.detached) continue
+      // Skip the main checkout — it's the repo root (the main task).
+      if (canonicalize(entry.path) === canonRepo) continue
+      const dirty = await this.isDirty(entry.path)
+      infos.push({
+        path: entry.path,
+        branch: entry.branch,
+        head: entry.head ?? "",
+        dirty,
+        kobeManaged: isKobeManagedPath(repo, entry.path),
       })
     }
     return infos

--- a/packages/kobe/src/tui/app.tsx
+++ b/packages/kobe/src/tui/app.tsx
@@ -274,7 +274,10 @@ function Shell(props: AppDeps) {
     // make the user re-pick.
     const defaultRepo = activeTask()?.repo ?? repos[0] ?? process.cwd()
     const defaultVendor = (kv.get("lastSelectedVendor") as VendorId | undefined) ?? DEFAULT_TASK_VENDOR
-    const result = await NewTaskDialog.show(dialog, defaultRepo, repos, { defaultVendor })
+    const result = await NewTaskDialog.show(dialog, defaultRepo, repos, {
+      defaultVendor,
+      discoverAdoptable: (repo) => props.orchestrator.discoverAdoptableWorktrees(repo),
+    })
     if (!result) return
     // Remember the choice so the next new-task dialog defaults to it.
     kv.set("lastSelectedVendor", result.vendor)
@@ -285,6 +288,22 @@ function Shell(props: AppDeps) {
     // (savedRepos is not otherwise a kv-managed key).
     addSavedRepo(result.repo)
     kv.set("savedRepos", getSavedRepos())
+    // Adopt: import one or more existing worktrees as tasks, then focus
+    // the last one (KOB-256).
+    if (result.mode === "adopt") {
+      let lastId: string | undefined
+      for (const w of result.adopt) {
+        const t = await props.orchestrator.adoptWorktree({
+          repo: result.repo,
+          worktreePath: w.worktreePath,
+          branch: w.branch,
+          vendor: result.vendor,
+        })
+        lastId = t.id
+      }
+      if (lastId) selectTask(lastId)
+      return
+    }
     const task = await props.orchestrator.createTask({
       repo: result.repo,
       baseRef: result.baseRef,

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -32,8 +32,9 @@
  */
 
 import { ALL_VENDORS, type VendorId, nextVendor } from "@/types/vendor"
+import type { AdoptableWorktree } from "@/types/worktree"
 import { TextAttributes } from "@opentui/core"
-import { For, Show, createEffect, createMemo, createSignal } from "solid-js"
+import { For, Show, createEffect, createMemo, createResource, createSignal } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { useBindings } from "../../lib/keymap"
 import { useDialog } from "../../ui/dialog"
@@ -48,6 +49,7 @@ import {
   computeRepoOptions,
   deriveFolderName,
   expandHome,
+  filterAdoptableByGlob,
   filterBranches,
   filterRepos,
   filterSubdirs,
@@ -94,6 +96,11 @@ export type NewTaskDialogProps = {
    * on {@link NewTaskInput.vendor} and the caller persists it.
    */
   defaultVendor?: VendorId
+  /**
+   * Discover existing git worktrees on a repo not yet linked to a task
+   * (KOB-256) — powers the Adopt tab's list. Omit to leave the tab empty.
+   */
+  discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
 }
 
 export function NewTaskDialogView(props: NewTaskDialogProps) {
@@ -187,6 +194,49 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
   const [cloneParentCursor, setCloneParentCursor] = createSignal(0)
   const cloneParentWindow = createMemo<PickerWindow>(() => windowAround(cloneParentFiltered(), cloneParentCursor()))
 
+  // Adopt-tab state (KOB-256): discover existing worktrees for the
+  // chosen repo, filter by a path glob, multi-select, then import.
+  const [adoptFilter, setAdoptFilter] = createSignal("")
+  const [adoptCursor, setAdoptCursor] = createSignal(0)
+  const [adoptSelected, setAdoptSelected] = createSignal<ReadonlySet<string>>(new Set())
+  // Re-discovers whenever the Adopt tab is active for the current repo.
+  // Keyed on the expanded repo path so switching repos refetches.
+  const [adoptable] = createResource(
+    () => (tab() === "adopt" ? expandHome(repo().trim()) : null),
+    async (r) => (props.discoverAdoptable ? await props.discoverAdoptable(r) : []),
+  )
+  const adoptList = createMemo<readonly AdoptableWorktree[]>(() =>
+    filterAdoptableByGlob(adoptable() ?? [], adoptFilter()),
+  )
+  const adoptWindow = createMemo<PickerWindow>(() =>
+    windowAround(
+      adoptList().map((w) => w.path),
+      adoptCursor(),
+    ),
+  )
+  const adoptVisible = createMemo<readonly AdoptableWorktree[]>(() => {
+    const w = adoptWindow()
+    return adoptList().slice(w.start, w.start + w.items.length)
+  })
+  // Keep the cursor in range as the filtered list shrinks/grows.
+  createEffect(() => {
+    void adoptList()
+    setAdoptCursor((c) => clampCursor(c, adoptList().length))
+  })
+
+  function toggleAdopt(p: string): void {
+    setAdoptSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(p)) next.delete(p)
+      else next.add(p)
+      return next
+    })
+  }
+  function toggleAdoptCursor(): void {
+    const w = adoptList()[adoptCursor()]
+    if (w) toggleAdopt(w.path)
+  }
+
   // Reset cursors whenever the filtered list changes — typing should
   // always land the highlight on the first match, otherwise the cursor
   // can sit on a now-hidden index and feels broken.
@@ -237,6 +287,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
     void cloneUrl()
     void cloneParent()
     void cloneFolder()
+    void adoptFilter()
     setSubmitError(null)
   })
 
@@ -289,9 +340,31 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
     dialog.clear()
   }
 
+  function commitAdopt() {
+    const list = adoptList()
+    if (list.length === 0) {
+      setSubmitError("no adoptable worktrees to import")
+      return
+    }
+    const sel = adoptSelected()
+    const chosen = sel.size > 0 ? list.filter((w) => sel.has(w.path)) : list.slice(adoptCursor(), adoptCursor() + 1)
+    if (chosen.length === 0) return
+    props.onSubmit({
+      mode: "adopt",
+      repo: expandHome(repo().trim()),
+      vendor: vendor(),
+      adopt: chosen.map((w) => ({ worktreePath: w.path, branch: w.branch })),
+    })
+    dialog.clear()
+  }
+
   function commit() {
     if (tab() === "clone") {
       void commitClone()
+      return
+    }
+    if (tab() === "adopt") {
+      commitAdopt()
       return
     }
     commitExisting()
@@ -423,6 +496,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
             const list = cloneParentFiltered()
             if (list.length === 0) return
             setCloneParentCursor(clampCursor(cloneParentCursor() - 1, list.length))
+            return
+          }
+          if (tab() === "adopt") {
+            const list = adoptList()
+            if (list.length === 0) return
+            setAdoptCursor(clampCursor(adoptCursor() - 1, list.length))
           }
         },
       },
@@ -446,7 +525,25 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
             const list = cloneParentFiltered()
             if (list.length === 0) return
             setCloneParentCursor(clampCursor(cloneParentCursor() + 1, list.length))
+            return
           }
+          if (tab() === "adopt") {
+            const list = adoptList()
+            if (list.length === 0) return
+            setAdoptCursor(clampCursor(adoptCursor() + 1, list.length))
+          }
+        },
+      },
+      {
+        // Ctrl+A on the Adopt tab toggles select-all over the filtered
+        // list (all-on unless everything is already selected → clears).
+        key: "ctrl+a",
+        cmd: () => {
+          if (tab() !== "adopt") return
+          const list = adoptList()
+          if (list.length === 0) return
+          const allSelected = list.every((w) => adoptSelected().has(w.path))
+          setAdoptSelected(allSelected ? new Set<string>() : new Set(list.map((w) => w.path)))
         },
       },
     ],
@@ -507,6 +604,13 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
             onMouseUp={() => switchToTab("clone")}
           >
             {tab() === "clone" ? "▸ For New Repo" : "  For New Repo"}
+          </text>
+          <text
+            fg={tab() === "adopt" ? theme.primary : theme.textMuted}
+            attributes={tab() === "adopt" ? TextAttributes.BOLD : undefined}
+            onMouseUp={() => switchToTab("adopt")}
+          >
+            {tab() === "adopt" ? "▸ Adopt Worktree" : "  Adopt Worktree"}
           </text>
         </box>
         {/* Engine selector — common to both tabs. Defaults to the user's
@@ -739,6 +843,83 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
             <box gap={0} paddingLeft={2}>
               <text fg={theme.textMuted} wrapMode="none">
                 {cloneProgress() || "Cloning…"}
+              </text>
+            </box>
+          </Show>
+        </Show>
+        <Show when={tab() === "adopt"}>
+          {/* ── Adopt tab body (KOB-256) ────────────────────────────── */}
+          <box gap={0}>
+            <text fg={field() === "adoptFilter" ? theme.accent : theme.textMuted}>filter (path glob)</text>
+            <input
+              value={adoptFilter()}
+              placeholder="* — type e.g. feature-* to narrow"
+              focused={field() === "adoptFilter"}
+              onInput={(v: string) => setAdoptFilter(stripNewlines(v))}
+              onSubmit={() => toggleAdoptCursor()}
+            />
+          </box>
+          <box paddingLeft={2}>
+            <text fg={theme.textMuted} wrapMode="none">
+              repo: {expandHome(repo().trim()) || "(none)"}
+            </text>
+          </box>
+          <Show when={adoptable.loading}>
+            <box paddingLeft={2}>
+              <text fg={theme.textMuted} wrapMode="none">
+                scanning worktrees…
+              </text>
+            </box>
+          </Show>
+          <Show when={!adoptable.loading && adoptList().length === 0}>
+            <box paddingLeft={2}>
+              <text fg={theme.textMuted} wrapMode="none">
+                {(adoptable() ?? []).length === 0
+                  ? "no unlinked worktrees — every git worktree here is already a task"
+                  : "no worktrees match the filter"}
+              </text>
+            </box>
+          </Show>
+          <Show when={adoptList().length > 0}>
+            <box gap={0} paddingLeft={2}>
+              <Show when={adoptWindow().start > 0}>
+                <text fg={theme.textMuted} wrapMode="none">
+                  ↑ {adoptWindow().start} more
+                </text>
+              </Show>
+              <For each={adoptVisible()}>
+                {(w, i) => {
+                  const absoluteIndex = () => adoptWindow().start + i()
+                  const isCursor = () => absoluteIndex() === adoptCursor()
+                  const isChecked = () => adoptSelected().has(w.path)
+                  const tags = () => [w.dirty ? "dirty" : "", w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
+                  return (
+                    <text
+                      fg={isCursor() ? theme.primary : isChecked() ? theme.accent : theme.textMuted}
+                      attributes={isCursor() ? TextAttributes.BOLD : undefined}
+                      wrapMode="none"
+                      onMouseUp={() => {
+                        setAdoptCursor(absoluteIndex())
+                        toggleAdopt(w.path)
+                      }}
+                    >
+                      {isCursor() ? "▸ " : "  "}
+                      {isChecked() ? "[x] " : "[ ] "}
+                      {w.branch}
+                      {tags() ? `  (${tags()})` : ""}
+                    </text>
+                  )
+                }}
+              </For>
+              <Show when={adoptWindow().start + adoptWindow().items.length < adoptWindow().total}>
+                <text fg={theme.textMuted} wrapMode="none">
+                  ↓ {adoptWindow().total - adoptWindow().start - adoptWindow().items.length} more
+                </text>
+              </Show>
+              <text fg={theme.textMuted} wrapMode="none">
+                {adoptSelected().size > 0
+                  ? `${adoptSelected().size} selected · enter toggles · ctrl+a all · Create imports`
+                  : "enter toggles · ctrl+a all · Create imports the highlighted row"}
               </text>
             </box>
           </Show>

--- a/packages/kobe/src/tui/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/index.tsx
@@ -16,6 +16,7 @@
  */
 
 import type { VendorId } from "@/types/vendor"
+import type { AdoptableWorktree } from "@/types/worktree"
 import type { DialogContext } from "../../ui/dialog"
 import { NewTaskDialogView } from "./dialog"
 import type { NewTaskInput } from "./state"
@@ -35,6 +36,12 @@ export type NewTaskDialogOptions = {
    * `lastSelectedVendor`). Falls back to `claude` in the dialog.
    */
   defaultVendor?: VendorId
+  /**
+   * Discover existing git worktrees on `repo` not yet linked to a task
+   * (KOB-256) — powers the Adopt tab. Omit to disable adoption (the tab
+   * still renders but shows nothing to import).
+   */
+  discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
 }
 
 /**
@@ -63,6 +70,7 @@ function show(
           savedRepos={savedRepos}
           defaultCloneParent={options?.defaultCloneParent}
           defaultVendor={options?.defaultVendor}
+          discoverAdoptable={options?.discoverAdoptable}
           onSubmit={(v) => resolve(v)}
           onCancel={() => resolve(undefined)}
         />

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -16,6 +16,7 @@ import { spawn } from "node:child_process"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
+import { matchPathGlob } from "@/lib/path-glob"
 import type { VendorId } from "@/types/vendor"
 
 /* --------------------------------------------------------------------- */
@@ -30,13 +31,28 @@ import type { VendorId } from "@/types/vendor"
  * to the saved-repos list so it shows up in the existing-tab picker
  * next time.
  */
-export type NewTaskInput = {
-  repo: string
-  baseRef: string
-  /** Engine the task runs on. Defaults to the user's last-selected vendor. */
-  vendor: VendorId
-  cloned?: { parentDir: string }
-}
+/**
+ * Dialog result. Two shapes, discriminated by `mode`:
+ *   - create (default) — make a fresh task on `repo` at `baseRef`.
+ *   - adopt — import one or more EXISTING git worktrees as tasks
+ *     (KOB-256). `adopt` carries the chosen worktrees; the caller loops
+ *     `orchestrator.adoptWorktree` over them.
+ */
+export type NewTaskInput =
+  | {
+      mode?: "create"
+      repo: string
+      baseRef: string
+      /** Engine the task runs on. Defaults to the user's last-selected vendor. */
+      vendor: VendorId
+      cloned?: { parentDir: string }
+    }
+  | {
+      mode: "adopt"
+      repo: string
+      vendor: VendorId
+      adopt: readonly { worktreePath: string; branch: string }[]
+    }
 
 /**
  * Which sub-tab the dialog is showing:
@@ -46,11 +62,13 @@ export type NewTaskInput = {
  * Switched via Ctrl+[ / Ctrl+] while the dialog is open. With only two
  * tabs the chord pair behaves as a toggle.
  */
-export type DialogTab = "existing" | "clone"
+export type DialogTab = "existing" | "clone" | "adopt"
 
-/** Cycle helper for the two-tab strip. */
+/** Cycle helper for the tab strip: existing → clone → adopt → existing. */
 export function nextDialogTab(tab: DialogTab): DialogTab {
-  return tab === "existing" ? "clone" : "existing"
+  if (tab === "existing") return "clone"
+  if (tab === "clone") return "adopt"
+  return "existing"
 }
 
 /**
@@ -60,7 +78,15 @@ export function nextDialogTab(tab: DialogTab): DialogTab {
  * shared so the bottom-row Create button works identically on both
  * surfaces. Tab cycling stays inside a single sub-tab's field list.
  */
-export type Field = "repo" | "baseRef" | "cloneUrl" | "cloneParent" | "cloneFolder" | "cloneBaseRef" | "confirm"
+export type Field =
+  | "repo"
+  | "baseRef"
+  | "cloneUrl"
+  | "cloneParent"
+  | "cloneFolder"
+  | "cloneBaseRef"
+  | "adoptFilter"
+  | "confirm"
 
 /**
  * Which list the unified picker should render under the repo input.
@@ -139,6 +165,11 @@ export function nextField(field: Field, tab: DialogTab = "existing"): Field {
     if (field === "cloneBaseRef") return "confirm"
     return "cloneUrl"
   }
+  if (tab === "adopt") {
+    // Two stops: the glob-filter input and the Create (= Adopt) button.
+    // List navigation is up/down on the rows, not Tab.
+    return field === "adoptFilter" ? "confirm" : "adoptFilter"
+  }
   if (field === "repo") return "baseRef"
   if (field === "baseRef") return "confirm"
   return "repo"
@@ -146,7 +177,22 @@ export function nextField(field: Field, tab: DialogTab = "existing"): Field {
 
 /** First field for a sub-tab (used when switching tabs). */
 export function firstFieldFor(tab: DialogTab): Field {
-  return tab === "clone" ? "cloneUrl" : "repo"
+  if (tab === "clone") return "cloneUrl"
+  if (tab === "adopt") return "adoptFilter"
+  return "repo"
+}
+
+/**
+ * Filter adoptable worktrees by a path glob (KOB-256). Empty glob → the
+ * full list. Matches against the absolute path AND the basename, so a
+ * bare `feature-*` works without typing the full directory. Uses Bun's
+ * built-in `Glob` (zero-dep). An invalid pattern matches nothing rather
+ * than throwing — the dialog keeps rendering.
+ */
+export function filterAdoptableByGlob<T extends { path: string }>(list: readonly T[], glob: string): readonly T[] {
+  const pattern = glob.trim()
+  if (!pattern) return list
+  return list.filter((w) => matchPathGlob(pattern, w.path))
 }
 
 /**

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -119,7 +119,10 @@ function TasksShell(props: {
     // (the "spawn a sibling" default).
     const defaultRepo = cursorRepo ?? repos[0] ?? process.cwd()
     const defaultVendor = (getPersistedString("lastSelectedVendor") as VendorId | undefined) ?? DEFAULT_TASK_VENDOR
-    const result = await NewTaskDialog.show(dialog, defaultRepo, repos, { defaultVendor })
+    const result = await NewTaskDialog.show(dialog, defaultRepo, repos, {
+      defaultVendor,
+      discoverAdoptable: props.orch ? (repo) => props.orch!.discoverAdoptableWorktrees(repo) : undefined,
+    })
     if (!result) return
     // Remember the choice (shared kv state.json) so the next new-task
     // dialog — here or in the outer monitor — defaults to it.
@@ -134,14 +137,26 @@ function TasksShell(props: {
     }
     let createdId: string | undefined
     try {
-      const task = await props.orch.createTask({
-        repo: result.repo,
-        baseRef: result.baseRef,
-        vendor: result.vendor,
-      })
-      createdId = task.id
+      if (result.mode === "adopt") {
+        for (const w of result.adopt) {
+          const t = await props.orch.adoptWorktree({
+            repo: result.repo,
+            worktreePath: w.worktreePath,
+            branch: w.branch,
+            vendor: result.vendor,
+          })
+          createdId = t.id
+        }
+      } else {
+        const task = await props.orch.createTask({
+          repo: result.repo,
+          baseRef: result.baseRef,
+          vendor: result.vendor,
+        })
+        createdId = task.id
+      }
     } catch (err) {
-      console.error("[kobe tasks] task.create failed:", err)
+      console.error("[kobe tasks] task.create/adopt failed:", err)
       return
     }
     await props.reload()

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -26,6 +26,21 @@ export interface WorktreeInfo {
 }
 
 /**
+ * A git worktree discovered on disk that COULD be adopted as a kobe
+ * task (KOB-256). Unlike {@link WorktreeInfo} (kobe-managed only), this
+ * includes worktrees the user created outside `<repo>/.claude/worktrees/`
+ * via plain `git worktree add`. `kobeManaged` marks whether the path
+ * lives under the kobe convention root, so the UI can label its origin.
+ */
+export interface AdoptableWorktree {
+  readonly path: string
+  readonly branch: string
+  readonly head: string
+  readonly dirty: boolean
+  readonly kobeManaged: boolean
+}
+
+/**
  * Manager for git worktrees mapped 1:1 to kobe Tasks.
  *
  * Conventions / invariants the impl must hold:

--- a/packages/kobe/test/orchestrator/adopt.test.ts
+++ b/packages/kobe/test/orchestrator/adopt.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Adopt-existing-worktree flow (KOB-256). Real git + real store on disk —
+ * the discovery path shells `git worktree list`, so mocking would only
+ * test the mock. Mirrors the harness in `worktree.test.ts`.
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
+
+let tmpRoot: string
+let repo: string
+let orch: Orchestrator
+
+beforeEach(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-adopt-"))
+  repo = path.join(tmpRoot, "repo")
+  const r = spawnSync("bash", [REPO_INIT, repo], { encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}\n${r.stdout}`)
+  const store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  await store.load()
+  orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+function addExternalWorktree(branch: string): string {
+  const p = path.join(tmpRoot, `ext-${branch}`)
+  const r = spawnSync("git", ["worktree", "add", "-b", branch, p], { cwd: repo, encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`git worktree add failed: ${r.stderr}`)
+  return p
+}
+
+describe("discoverAdoptableWorktrees", () => {
+  test("lists external worktrees not yet linked to a task", async () => {
+    const ext = addExternalWorktree("featA")
+    const found = await orch.discoverAdoptableWorktrees(repo)
+    const branches = found.map((w) => w.branch)
+    expect(branches).toContain("featA")
+    expect(found.find((w) => w.branch === "featA")?.kobeManaged).toBe(false)
+    void ext
+  })
+
+  test("excludes worktrees already adopted as tasks", async () => {
+    const ext = addExternalWorktree("featB")
+    await orch.adoptWorktree({ repo, worktreePath: ext, branch: "featB" })
+    const found = await orch.discoverAdoptableWorktrees(repo)
+    expect(found.map((w) => w.branch)).not.toContain("featB")
+  })
+})
+
+describe("adoptWorktree", () => {
+  test("creates a task pointing at the existing worktree, no fs allocation", async () => {
+    const ext = addExternalWorktree("featC")
+    const task = await orch.adoptWorktree({ repo, worktreePath: ext, branch: "featC", title: "my-feat" })
+    expect(task.kind).toBe("task")
+    expect(task.branch).toBe("featC")
+    expect(task.title).toBe("my-feat")
+    expect(fs.realpathSync(task.worktreePath)).toBe(fs.realpathSync(ext))
+    // ensureWorktree must short-circuit (path already set) — returns same path.
+    expect(await orch.ensureWorktree(task.id)).toBe(task.worktreePath)
+  })
+
+  test("defaults the title to the worktree directory basename", async () => {
+    const ext = addExternalWorktree("featD")
+    const task = await orch.adoptWorktree({ repo, worktreePath: ext, branch: "featD" })
+    expect(task.title).toBe(path.basename(ext))
+  })
+
+  test("rejects a path that isn't an adoptable worktree of the repo", async () => {
+    await expect(orch.adoptWorktree({ repo, worktreePath: path.join(tmpRoot, "nope"), branch: "x" })).rejects.toThrow()
+  })
+
+  test("rejects adopting the same worktree twice", async () => {
+    const ext = addExternalWorktree("featE")
+    await orch.adoptWorktree({ repo, worktreePath: ext, branch: "featE" })
+    await expect(orch.adoptWorktree({ repo, worktreePath: ext, branch: "featE" })).rejects.toThrow(/already adopted/)
+  })
+})

--- a/packages/kobe/test/orchestrator/worktree.test.ts
+++ b/packages/kobe/test/orchestrator/worktree.test.ts
@@ -243,3 +243,32 @@ describe("createForTask helper", () => {
     expect(info.branch).toBe("kobe/from-side")
   })
 })
+
+describe("GitWorktreeManager.listAll (KOB-256)", () => {
+  test("includes external worktrees + excludes main checkout, with kobeManaged flags", async () => {
+    const mgr = new GitWorktreeManager()
+    // kobe-managed worktree under <repo>/.claude/worktrees/
+    const managed = await mgr.createForTask({ repo, slug: "managed-wt", branch: "kobe/managed" })
+    // external worktree created by the user OUTSIDE the convention root
+    const extPath = path.join(tmpRoot, "external-wt")
+    const r = spawnSync("git", ["worktree", "add", "-b", "ext-branch", extPath], { cwd: repo, encoding: "utf8" })
+    expect(r.status).toBe(0)
+
+    const all = await mgr.listAll(repo)
+    const byBranch = new Map(all.map((w) => [w.branch, w]))
+
+    // both worktrees show up
+    expect(byBranch.has("kobe/managed")).toBe(true)
+    expect(byBranch.has("ext-branch")).toBe(true)
+    // main checkout (the repo root branch) is excluded
+    for (const w of all) expect(fs.realpathSync(w.path)).not.toBe(fs.realpathSync(repo))
+    // kobeManaged flag distinguishes origin
+    expect(byBranch.get("kobe/managed")?.kobeManaged).toBe(true)
+    expect(byBranch.get("ext-branch")?.kobeManaged).toBe(false)
+    // list() still only returns the managed one
+    const managedOnly = await mgr.list(repo)
+    expect(managedOnly.some((w) => w.branch === "kobe/managed")).toBe(true)
+    expect(managedOnly.some((w) => w.branch === "ext-branch")).toBe(false)
+    void managed
+  })
+})

--- a/packages/kobe/test/tui/new-task-dialog/state.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/state.test.ts
@@ -17,8 +17,48 @@
  *     repos, so the first-run picker is never empty.
  */
 
-import { computeRepoOptions, pickerModeFor, splitPathForDirSuggest } from "@/tui/component/new-task-dialog/state"
+import {
+  computeRepoOptions,
+  filterAdoptableByGlob,
+  nextDialogTab,
+  pickerModeFor,
+  splitPathForDirSuggest,
+} from "@/tui/component/new-task-dialog/state"
 import { describe, expect, it } from "vitest"
+
+describe("filterAdoptableByGlob (KOB-256)", () => {
+  const list = [
+    { path: "/work/repo/.claude/worktrees/panda" },
+    { path: "/work/feature-login" },
+    { path: "/work/feature-signup" },
+    { path: "/elsewhere/bugfix" },
+  ]
+  it("returns the full list for an empty glob", () => {
+    expect(filterAdoptableByGlob(list, "")).toHaveLength(4)
+    expect(filterAdoptableByGlob(list, "  ")).toHaveLength(4)
+  })
+  it("matches on basename so a bare pattern works", () => {
+    expect(filterAdoptableByGlob(list, "feature-*").map((w) => w.path)).toEqual([
+      "/work/feature-login",
+      "/work/feature-signup",
+    ])
+  })
+  it("matches on absolute path globs", () => {
+    expect(filterAdoptableByGlob(list, "/work/**").map((w) => w.path)).toEqual([
+      "/work/repo/.claude/worktrees/panda",
+      "/work/feature-login",
+      "/work/feature-signup",
+    ])
+  })
+})
+
+describe("nextDialogTab (KOB-256: 3-tab cycle)", () => {
+  it("cycles existing → clone → adopt → existing", () => {
+    expect(nextDialogTab("existing")).toBe("clone")
+    expect(nextDialogTab("clone")).toBe("adopt")
+    expect(nextDialogTab("adopt")).toBe("existing")
+  })
+})
 
 describe("pickerModeFor", () => {
   it("stays in saved mode when the input exactly matches a saved repo", () => {


### PR DESCRIPTION
## Summary

加 KOB-256:扫描某 repo 已存在的 git worktree(含 `.claude/worktrees/` 之外、用户自己 `git worktree add` 的),把还没被 task 关联的导入(adopt)成 kobe task。两个入口:

- **CLI** `kobe adopt [glob] [--repo <path>] [--vendor <v>] [--yes]` — 无 glob 为 dry-run 列表;路径 glob 选批;`--yes` 导入。
- **TUI** New Task 对话框第三个 tab **Adopt Worktree**(outer monitor + Tasks pane 都接):列表 + 路径 glob 过滤 + 空格/点击多选(Ctrl+A 全选)+ Create 批量导入。

导入 = 用已存在路径直接建 task(`ensureWorktree` 短路,不碰磁盘),走 daemon 实时同步。glob 用零依赖 `lib/path-glob.ts`(glob→regex,node+bun 通用)。

## Test plan
- [x] typecheck / lint / build 全绿
- [x] 单测 167 passed(新增 manager.listAll、orchestrator discover/adopt 集成测试、filterAdoptableByGlob / nextDialogTab)
- [ ] 手动:`git worktree add ../foo -b foo` → `kobe adopt`(列出)→ `kobe adopt '<glob>' --yes`(导入);New Task → Adopt Worktree tab 多选导入


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for adopting existing git worktrees as tasks, enabling discovery and import of external worktrees.
  * Introduced `kobe adopt` CLI command with glob-based filtering and optional multi-worktree adoption.
  * Added "Adopt Worktree" tab in the New Task dialog featuring path filtering, multi-select capabilities, and worktree discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->