### PR TITLE
feat: kobe add 扫+导入 worktree + adopt 列表按最近活动排序

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -16,7 +16,12 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Added
 
+- **`kobe add` folds in a repo's existing worktrees** — saving a repo with `kobe add <path>` now also scans that repo's git worktrees and imports the ones not yet linked to a task, so an existing multi-worktree checkout shows up in kobe without a separate adopt step. Imports nothing for a plain repo; skips quietly if the daemon is unreachable (KOB-256).
 - **kobe detects the agent skill and nudges you to install it** — `kobe doctor` now reports whether the kobe agent skill (which teaches Claude Code to drive `kobe api`) is installed, and prints the `npx skills add …` command when it isn't. On startup, kobe shows the same install hint once if the skill is missing. Checks both the user (`~/.claude/skills/kobe/SKILL.md`) and project locations.
+
+### Changed
+
+- **Adoptable worktrees are ordered most-recently-active first** — the `kobe adopt` listing and the New Task → Adopt Worktree tab now sort discovered worktrees by their HEAD commit time (descending) instead of git's enumeration order, so the worktree you last touched leads the list (KOB-256).
 
 ## [0.6.5] - 2026-05-30
 

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -55,6 +55,46 @@ async function runAddSubcommand(arg: string | undefined): Promise<void> {
   } else {
     console.log(`already saved: ${result.path}`)
   }
+  // Fold in the repo's existing git worktrees: scan + adopt the ones not
+  // yet linked to a task, most-recently-active first (KOB-256). A plain
+  // repo with no extra worktrees imports nothing.
+  await adoptAllWorktrees(result.path)
+}
+
+/**
+ * Discover every unlinked git worktree of `repo` and adopt each as a
+ * task (discovery already sorts most-recently-active first). Used by
+ * `kobe add` to fold a repo's worktrees in on the way (KOB-256).
+ * Best-effort: an unreachable daemon just skips the scan with a note.
+ */
+async function adoptAllWorktrees(repo: string): Promise<void> {
+  const { connectOrStartDaemon } = await import("../client/daemon-process.ts")
+  let client: Awaited<ReturnType<typeof connectOrStartDaemon>>
+  try {
+    client = await connectOrStartDaemon()
+  } catch (err) {
+    console.error(`(skipped worktree scan — daemon unreachable: ${err instanceof Error ? err.message : String(err)})`)
+    return
+  }
+  try {
+    const { worktrees } = await client.request<{ worktrees: AdoptableWorktree[] }>("worktree.discoverAdoptable", {
+      repo,
+    })
+    if (worktrees.length === 0) return
+    console.log(`scanning ${repo}: ${worktrees.length} unlinked worktree(s) → importing`)
+    const vendor = coerceVendorId(undefined)
+    for (const w of worktrees) {
+      const { task } = await client.request<{ task: { id: string; title: string } }>("worktree.adopt", {
+        repo,
+        worktreePath: w.path,
+        branch: w.branch,
+        vendor,
+      })
+      console.log(`  adopted ${w.branch} → task ${task.id} (${task.title})`)
+    }
+  } finally {
+    client.close()
+  }
 }
 
 /**

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -262,9 +262,33 @@ export class GitWorktreeManager implements WorktreeManager {
         head: entry.head ?? "",
         dirty,
         kobeManaged: isKobeManagedPath(repo, entry.path),
+        lastActivityMs: this.lastActivityMs(entry.path),
       })
     }
+    // Most recently active first (KOB-256).
+    infos.sort((a, b) => b.lastActivityMs - a.lastActivityMs)
     return infos
+  }
+
+  /**
+   * Last-activity time of a worktree in epoch ms — the HEAD commit's
+   * committer time, falling back to the directory's mtime when the log
+   * read fails (e.g. an unborn branch). Best-effort: returns 0 on total
+   * failure so sorting still works. Used to order the adopt list.
+   */
+  private lastActivityMs(worktreePath: string): number {
+    try {
+      const out = git(["log", "-1", "--format=%ct"], { cwd: worktreePath })
+      const secs = Number.parseInt(out.stdout.trim(), 10)
+      if (Number.isFinite(secs) && secs > 0) return secs * 1000
+    } catch {
+      // no commits yet / not readable — fall through to mtime
+    }
+    try {
+      return fs.statSync(worktreePath).mtimeMs
+    } catch {
+      return 0
+    }
   }
 
   /**

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -38,6 +38,13 @@ export interface AdoptableWorktree {
   readonly head: string
   readonly dirty: boolean
   readonly kobeManaged: boolean
+  /**
+   * Last-activity time (epoch ms) — the worktree HEAD's commit time,
+   * falling back to the directory mtime. Discovery sorts by this
+   * descending so the most recently-touched worktree leads the list
+   * (KOB-256).
+   */
+  readonly lastActivityMs: number
 }
 
 /**


### PR DESCRIPTION
## Summary

KOB-256 的两个后续优化:

1. **`kobe add` 顺手扫+导入** — `kobe add <repo>` 保存 repo 后,扫描该 repo 的 git worktree,把未关联 task 的导入(adopt)进来。plain repo 不导入;daemon 不可达静默跳过。
2. **adopt 列表按最近活动倒序** — `AdoptableWorktree` 加 `lastActivityMs`(HEAD committer time,回退目录 mtime),`manager.listAll` 按此倒序,所以 `kobe adopt` 列表和 New Task → Adopt Worktree tab 里最近动过的 worktree 排在前面。

## Test plan
- [x] typecheck / lint / build 全绿
- [x] 单测 251 passed
- [ ] 手动:多 worktree 的 repo 跑 `kobe add`,确认 worktree 被导入且顺序按最近活动


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `kobe add` automatically discovers and imports existing Git worktrees as tasks
  * `kobe doctor` and startup messages detect missing agent skill and provide installation instructions
  * Adoptable worktrees are now sorted by most recent activity for better visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sma1lboy/kobe/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->