### PR TITLE
refactor: kobe add worktree 扫描不再副作用式启动 daemon (KOB-256)

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Added
 
-- **`kobe add` folds in a repo's existing worktrees** — saving a repo with `kobe add <path>` now also scans that repo's git worktrees and imports the ones not yet linked to a task, so an existing multi-worktree checkout shows up in kobe without a separate adopt step. Imports nothing for a plain repo; skips quietly if the daemon is unreachable (KOB-256).
+- **`kobe add` folds in a repo's existing worktrees** — saving a repo with `kobe add <path>` now also scans that repo's git worktrees and imports the ones not yet linked to a task, so an existing multi-worktree checkout shows up in kobe without a separate adopt step. The scan runs in-process (`git worktree list` + a `tasks.json` read) so a plain repo with no extra worktrees stays instant and `kobe add` never boots a daemon as a side effect; when there are worktrees to import, a running daemon takes the writes over RPC (a live TUI updates) and an in-process write is used otherwise (KOB-256).
 - **kobe detects the agent skill and nudges you to install it** — `kobe doctor` now reports whether the kobe agent skill (which teaches Claude Code to drive `kobe api`) is installed, and prints the `npx skills add …` command when it isn't. On startup, kobe shows the same install hint once if the skill is missing. Checks both the user (`~/.claude/skills/kobe/SKILL.md`) and project locations.
 
 ### Changed

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -63,37 +63,55 @@ async function runAddSubcommand(arg: string | undefined): Promise<void> {
 
 /**
  * Discover every unlinked git worktree of `repo` and adopt each as a
- * task (discovery already sorts most-recently-active first). Used by
- * `kobe add` to fold a repo's worktrees in on the way (KOB-256).
- * Best-effort: an unreachable daemon just skips the scan with a note.
+ * task (discovery sorts most-recently-active first). Used by `kobe add`
+ * to fold a repo's worktrees in on the way (KOB-256).
+ *
+ * Discovery runs IN-PROCESS — `git worktree list` + a `tasks.json` read,
+ * no daemon — so a plain repo with no extra worktrees stays instant and
+ * never boots a daemon as a side effect of `kobe add`. Only when there's
+ * something to import do we touch the daemon: a running one gets the
+ * writes over RPC (so a live TUI updates and the on-disk index isn't
+ * split-brained); with no daemon running we write in-process and a later
+ * `kobe` launch reads the result. Best-effort throughout — a scan/adopt
+ * failure is reported, not fatal to `kobe add`.
  */
 async function adoptAllWorktrees(repo: string): Promise<void> {
-  const { connectOrStartDaemon } = await import("../client/daemon-process.ts")
-  let client: Awaited<ReturnType<typeof connectOrStartDaemon>>
+  const { TaskIndexStore } = await import("../orchestrator/index/store.ts")
+  const { GitWorktreeManager } = await import("../orchestrator/worktree/manager.ts")
+  const { Orchestrator } = await import("../orchestrator/core.ts")
+  const store = new TaskIndexStore()
+  await store.load()
+  const orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+
+  let candidates: readonly AdoptableWorktree[]
   try {
-    client = await connectOrStartDaemon()
+    candidates = await orch.discoverAdoptableWorktrees(repo)
   } catch (err) {
-    console.error(`(skipped worktree scan — daemon unreachable: ${err instanceof Error ? err.message : String(err)})`)
+    console.error(`(skipped worktree scan: ${err instanceof Error ? err.message : String(err)})`)
     return
   }
+  if (candidates.length === 0) return
+
+  console.log(`scanning ${repo}: ${candidates.length} unlinked worktree(s) → importing`)
+  const vendor = coerceVendorId(undefined)
+  const { connectIfRunning } = await import("../client/daemon-process.ts")
+  const client = await connectIfRunning()
   try {
-    const { worktrees } = await client.request<{ worktrees: AdoptableWorktree[] }>("worktree.discoverAdoptable", {
-      repo,
-    })
-    if (worktrees.length === 0) return
-    console.log(`scanning ${repo}: ${worktrees.length} unlinked worktree(s) → importing`)
-    const vendor = coerceVendorId(undefined)
-    for (const w of worktrees) {
-      const { task } = await client.request<{ task: { id: string; title: string } }>("worktree.adopt", {
-        repo,
-        worktreePath: w.path,
-        branch: w.branch,
-        vendor,
-      })
-      console.log(`  adopted ${w.branch} → task ${task.id} (${task.title})`)
+    for (const w of candidates) {
+      const adopted = client
+        ? (
+            await client.request<{ task: { id: string; title: string } }>("worktree.adopt", {
+              repo,
+              worktreePath: w.path,
+              branch: w.branch,
+              vendor,
+            })
+          ).task
+        : await orch.adoptWorktree({ repo, worktreePath: w.path, branch: w.branch, vendor })
+      console.log(`  adopted ${w.branch} → task ${adopted.id} (${adopted.title})`)
     }
   } finally {
-    client.close()
+    client?.close()
   }
 }
 

--- a/packages/kobe/src/client/daemon-process.ts
+++ b/packages/kobe/src/client/daemon-process.ts
@@ -95,6 +95,21 @@ export async function connectOrStartDaemon(): Promise<KobeDaemonClient> {
 }
 
 /**
+ * Connect to the daemon ONLY if one is already running and responsive —
+ * never spawn one. Returns `null` when the daemon is absent or wedged.
+ * For side-effect-light commands (e.g. `kobe add`'s worktree scan) that
+ * want to sync with a live daemon when present but must not boot one as
+ * a side effect.
+ */
+export async function connectIfRunning(): Promise<KobeDaemonClient | null> {
+  const socketPath = defaultDaemonSocketPath()
+  if (!(await testDaemonResponds(socketPath))) return null
+  const client = new KobeDaemonClient(socketPath)
+  await client.connect()
+  return client
+}
+
+/**
  * Start a daemon owned by the current TUI process.
  *
  * Unlike {@link connectOrStartDaemon}, this never reuses the stable


### PR DESCRIPTION
## Summary

KOB-256 工程优化:`kobe add` 的 worktree 扫描不再副作用式启动 daemon。

之前 `kobe add` 用 `connectOrStartDaemon`,即使一个 plain repo(没有额外 worktree)也会拉起一个 daemon,给本来瞬时的命令加延迟 + 意外副作用。

现在:
- **发现走进程内**(`git worktree list` + `tasks.json` 读),plain repo 无可导入项时保持瞬时、不碰 daemon。
- 有可导入 worktree 时才接触 daemon:**已在跑** → 走 RPC(实时同步,不 split-brain on-disk index);**没在跑** → 进程内写 `tasks.json`(下次启动读到)。
- 新增 `connectIfRunning()`(只在 daemon 已响应时连,绝不 spawn)。

## Test plan
- [x] typecheck / lint / build 全绿
- [x] 单测 79 passed(orchestrator + cli)
- [ ] 手动:无额外 worktree 的 repo `kobe add .` 确认不启动 daemon;多 worktree repo 在 kobe 未运行 / 运行两种情况下各验导入
