### PR TITLE
feat: live auto-title — daemon poller names placeholder tasks from transcript

### DIFF
--- a/packages/kobe/CHANGELOG.md
+++ b/packages/kobe/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+### Changed
+
+- **A new task auto-names itself while you're still in it** — previously a task kept its `(new task)` placeholder for the whole session and only picked up a title from your first prompt once you detached back to the task list. The daemon now watches each still-unnamed task's engine transcript and renames it from your first message a few seconds after you send it, so the sidebar updates live without leaving the session. It only ever replaces the placeholder, so a manual rename is never overwritten; the detach-time naming stays as a fallback when no daemon is running.
+
 ## [0.6.8] - 2026-05-31
 
 ### Fixed

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -8,11 +8,7 @@
   "bin": {
     "kobe": "dist/cli/index.js"
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/kobe/src/daemon/auto-title-poller.ts
+++ b/packages/kobe/src/daemon/auto-title-poller.ts
@@ -1,0 +1,96 @@
+/**
+ * Daemon-side live auto-title poller (KOB — auto-name live).
+ *
+ * In the v0.6 tmux model a freshly-created task keeps its placeholder
+ * title `(new task)` until the user DETACHES and the outer monitor's
+ * return path (`tui/app.tsx` / `tui/direct.ts`) reads the transcript and
+ * renames. While attached, kobe's renderer is suspended and never sees
+ * the interactive prompt — so the title used to stay `(new task)` for the
+ * whole session.
+ *
+ * The engine still writes the conversation to its OWN on-disk transcript
+ * (the same JSONL the Ops activity badge in `monitor/activity.ts` watches).
+ * This poller reads that store on an interval for every still-placeholder
+ * task and renames as soon as the first user message lands — no detach
+ * required. The rename flows through `orch.setTitle` → `store.update` →
+ * the `task.snapshot` broadcast, so every attached Tasks pane updates live.
+ *
+ * Self-limiting: only placeholder tasks touch disk (`deriveTitleFromSession`
+ * returns `""` and the task keeps its placeholder when no usable user
+ * message exists yet); once a task is named it's skipped on every later
+ * tick. Best-effort: a per-task failure is logged, never fatal, and never
+ * blocks the other tasks in the same tick.
+ *
+ * The detach-time rename in `tui/app.tsx` / `tui/direct.ts` stays as a
+ * belt-and-suspenders path for the case where the daemon isn't running
+ * (e.g. a `kobe` started without a live daemon).
+ */
+
+import { deriveTitleFromSession } from "@/monitor/auto-title"
+import type { Orchestrator } from "@/orchestrator/core"
+import { PLACEHOLDER_TASK_TITLE } from "@/orchestrator/core"
+import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
+import { logDaemonError } from "./crash-log"
+
+/** Default re-scan cadence; responsive without hammering disk. */
+export const DEFAULT_AUTO_TITLE_POLL_MS = 4000
+
+/**
+ * Resolve a task's first-user-prompt title from its on-disk transcript.
+ * Injectable so the pass logic (placeholder filter, re-check guard, error
+ * isolation) can be tested without a real worktree + transcript on disk.
+ */
+export type TitleDeriver = (worktree: string, vendor: VendorId) => Promise<string>
+
+/**
+ * Run one pass: rename every still-placeholder task that now has a
+ * usable first-user-prompt title. Sequential (gentle on disk) and
+ * best-effort per task. Returns the number of tasks renamed (for tests).
+ */
+export async function runAutoTitlePass(
+  orch: Orchestrator,
+  derive: TitleDeriver = deriveTitleFromSession,
+): Promise<number> {
+  let renamed = 0
+  for (const task of orch.listTasks()) {
+    if (task.title !== PLACEHOLDER_TASK_TITLE || !task.worktreePath) continue
+    try {
+      const title = await derive(task.worktreePath, task.vendor ?? DEFAULT_TASK_VENDOR)
+      if (!title) continue
+      // Re-check under the live store: the user may have manually renamed
+      // (or the detach-time path may have named it) between the snapshot
+      // above and this await. `setTitle` is also a no-op if unchanged.
+      const current = orch.getTask(task.id)
+      if (!current || current.title !== PLACEHOLDER_TASK_TITLE) continue
+      await orch.setTitle(task.id, title)
+      renamed++
+    } catch (err) {
+      logDaemonError("auto-title-poller", err)
+    }
+  }
+  return renamed
+}
+
+/**
+ * Start the poller. Returns a `stop()` that clears the interval. Pass
+ * `intervalMs <= 0` to disable (returns a no-op stop) — tests that don't
+ * want a live timer use this.
+ */
+export function startAutoTitlePoller(orch: Orchestrator, intervalMs: number = DEFAULT_AUTO_TITLE_POLL_MS): () => void {
+  if (intervalMs <= 0) return () => {}
+  let running = false
+  const tick = (): void => {
+    // Skip if a previous pass is still in flight so a slow disk read can't
+    // pile up overlapping scans.
+    if (running) return
+    running = true
+    void runAutoTitlePass(orch)
+      .catch((err) => logDaemonError("auto-title-poller", err))
+      .finally(() => {
+        running = false
+      })
+  }
+  const timer = setInterval(tick, intervalMs)
+  timer.unref?.()
+  return () => clearInterval(timer)
+}

--- a/packages/kobe/src/daemon/server.ts
+++ b/packages/kobe/src/daemon/server.ts
@@ -18,6 +18,7 @@ import { dirname } from "node:path"
 import type { Orchestrator } from "../orchestrator/core.ts"
 import type { Task, VendorId } from "../types/task.ts"
 import { type UpdateInfo, checkLatestVersion } from "../version.ts"
+import { DEFAULT_AUTO_TITLE_POLL_MS, startAutoTitlePoller } from "./auto-title-poller.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { DaemonEventBus } from "./event-bus.ts"
 import { defaultDaemonPidPath, defaultDaemonSocketPath } from "./paths.ts"
@@ -59,6 +60,8 @@ export interface DaemonServerOptions {
   readonly checkUpdate?: () => Promise<UpdateInfo | null>
   /** Re-check interval in ms; `0` disables the poller. Defaults to 6h. */
   readonly updatePollMs?: number
+  /** Auto-title re-scan interval in ms; `0` disables. Defaults to {@link DEFAULT_AUTO_TITLE_POLL_MS}. */
+  readonly autoTitlePollMs?: number
 }
 
 export interface DaemonServer {
@@ -193,6 +196,14 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
     updateTimer.unref?.()
   }
 
+  // Live auto-title (KOB): rename still-placeholder tasks from their
+  // engine transcript on an interval, so a name appears WHILE attached —
+  // the detach-time path in tui/app.tsx / tui/direct.ts only fires on
+  // return. The rename broadcasts via the `task.snapshot` channel above,
+  // so every attached Tasks pane updates without a detach.
+  const autoTitlePollMs = options.autoTitlePollMs ?? DEFAULT_AUTO_TITLE_POLL_MS
+  const stopAutoTitlePoller = startAutoTitlePoller(orch, autoTitlePollMs)
+
   const serverApi: DaemonServer = {
     socketPath,
     pidPath,
@@ -203,6 +214,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
       cancelIdleTimer()
       unsubscribeStore()
       if (updateTimer) clearInterval(updateTimer)
+      stopAutoTitlePoller()
       // tmux is intentionally untouched here: closing the daemon never tears
       // down task sessions. Session teardown lives ONLY in `kobe reset` /
       // `kobe kill-sessions` (`tmux -L kobe kill-server`). Keep it that way.

--- a/packages/kobe/test/daemon/auto-title-poller.test.ts
+++ b/packages/kobe/test/daemon/auto-title-poller.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Live auto-title poller (KOB). Drives the pass logic against a REAL
+ * Orchestrator + on-disk store, with an injected title-deriver so no real
+ * worktree / transcript is needed — the seam under test is the placeholder
+ * filter, the re-check-before-rename guard, and per-task error isolation.
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { runAutoTitlePass } from "../../src/daemon/auto-title-poller.ts"
+import { Orchestrator, PLACEHOLDER_TASK_TITLE } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+let tmpRoot: string
+let store: TaskIndexStore
+let orch: Orchestrator
+
+beforeEach(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-autotitle-"))
+  store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  await store.load()
+  orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+/** Create a task, then stamp a worktreePath on it (createTask leaves it empty). */
+async function makeTask(opts: { title?: string; worktree?: string }) {
+  const task = await orch.createTask({ repo: "/repo", title: opts.title })
+  if (opts.worktree !== undefined) await store.update(task.id, { worktreePath: opts.worktree })
+  return task.id
+}
+
+describe("runAutoTitlePass", () => {
+  test("renames only placeholder tasks that have a worktree", async () => {
+    const placeholderWithWorktree = await makeTask({ worktree: "/wt/a" })
+    const alreadyNamed = await makeTask({ title: "Fix login 500", worktree: "/wt/b" })
+    const placeholderNoWorktree = await makeTask({ worktree: undefined })
+
+    const renamed = await runAutoTitlePass(orch, async (worktree) => `title-for-${worktree}`)
+
+    expect(renamed).toBe(1)
+    expect(orch.getTask(placeholderWithWorktree)?.title).toBe("title-for-/wt/a")
+    expect(orch.getTask(alreadyNamed)?.title).toBe("Fix login 500")
+    expect(orch.getTask(placeholderNoWorktree)?.title).toBe(PLACEHOLDER_TASK_TITLE)
+  })
+
+  test("leaves the placeholder when the deriver yields no title", async () => {
+    const id = await makeTask({ worktree: "/wt/a" })
+    const renamed = await runAutoTitlePass(orch, async () => "")
+    expect(renamed).toBe(0)
+    expect(orch.getTask(id)?.title).toBe(PLACEHOLDER_TASK_TITLE)
+  })
+
+  test("a failing task does not block the others", async () => {
+    const boom = await makeTask({ worktree: "/wt/boom" })
+    const ok = await makeTask({ worktree: "/wt/ok" })
+
+    const renamed = await runAutoTitlePass(orch, async (worktree) => {
+      if (worktree === "/wt/boom") throw new Error("disk read failed")
+      return `title-for-${worktree}`
+    })
+
+    expect(renamed).toBe(1)
+    expect(orch.getTask(boom)?.title).toBe(PLACEHOLDER_TASK_TITLE)
+    expect(orch.getTask(ok)?.title).toBe("title-for-/wt/ok")
+  })
+
+  test("does not overwrite a manual rename that lands during the disk read", async () => {
+    const id = await makeTask({ worktree: "/wt/a" })
+
+    // Simulate the user renaming mid-read: the deriver (standing in for the
+    // slow transcript read) renames the task before returning its own title.
+    const renamed = await runAutoTitlePass(orch, async () => {
+      await orch.setTitle(id, "User chose this")
+      return "derived-title"
+    })
+
+    expect(renamed).toBe(0)
+    expect(orch.getTask(id)?.title).toBe("User chose this")
+  })
+})


### PR DESCRIPTION
## What

A new task used to keep its `(new task)` placeholder for the entire session — it was only renamed from its first prompt when you **detached** back to the task list (the `tui/app.tsx` / `tui/direct.ts` return path). While attached and chatting, kobe's outer renderer is suspended and never sees the interactive prompt, so the title stayed `(new task)` the whole time.

This adds a **daemon-side poller** that renames still-placeholder tasks live, without a detach.

## How

- `src/daemon/auto-title-poller.ts` — every few seconds (`DEFAULT_AUTO_TITLE_POLL_MS = 4000`) scans `orch.listTasks()`, picks tasks whose title is still the placeholder **and** have a worktree, reads the first user prompt from the engine transcript via the existing `deriveTitleFromSession()` (the same on-disk JSONL `monitor/activity.ts` already watches), and calls `orch.setTitle()`.
- The rename flows through `store.update` → `subscribeTasks` → the existing `task.snapshot` broadcast, so every attached Tasks pane updates **live**.
- Wired into `startDaemonServer` mirroring the `update-poller` pattern: configurable `autoTitlePollMs` option, `unref`'d timer, cleared in `close()`.

## Safety / guarantees

- **Self-limiting** — only placeholder tasks touch disk; once named they're skipped on every later tick.
- **Never overwrites a manual rename** — guarded by `title === PLACEHOLDER` and re-checked under the live store right before `setTitle` (covers a rename landing during the disk read).
- **Best-effort** — per-task `try/catch` with `logDaemonError("auto-title-poller", err)`; one failing task never blocks the others, never fatal.
- The detach-time naming stays as a **fallback** for when no daemon is running.

## Tests

`test/daemon/auto-title-poller.test.ts` (4 cases, all green): renames only placeholder tasks with a worktree; leaves the placeholder when the deriver yields no title; a failing task doesn't block the others; a manual rename landing during the read is not overwritten.

Verified live in the sandbox: a freshly restarted daemon's first tick renamed an existing `(new task)` to its first prompt ~4s after start.

## Notes

- No new daemon RPC method; no manual-rename flag (the placeholder guard suffices).
- The matching Linear issue could not be filed — the workspace hit its free issue limit. To be filed once quota is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks are now automatically named based on their content shortly after the first message, eliminating the need for manual renaming. Manual renames are preserved, and the feature is configurable with fallback naming when the auto-naming service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->