### PR TITLE
feat: auto-name follows onto the branch + every ChatTab

### DIFF
--- a/packages/kobe/src/daemon/auto-title-poller.ts
+++ b/packages/kobe/src/daemon/auto-title-poller.ts
@@ -29,6 +29,7 @@
 import { deriveTitleFromSession } from "@/monitor/auto-title"
 import type { Orchestrator } from "@/orchestrator/core"
 import { PLACEHOLDER_TASK_TITLE } from "@/orchestrator/core"
+import { renameOriginChatTab } from "@/tmux/chat-tab-naming"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
 import { logDaemonError } from "./crash-log"
 
@@ -42,16 +43,24 @@ export const DEFAULT_AUTO_TITLE_POLL_MS = 4000
  */
 export type TitleDeriver = (worktree: string, vendor: VendorId) => Promise<string>
 
+/** A task that this pass renamed, plus the title it was given. */
+export interface AutoTitled {
+  readonly id: string
+  readonly title: string
+}
+
 /**
  * Run one pass: rename every still-placeholder task that now has a
  * usable first-user-prompt title. Sequential (gentle on disk) and
- * best-effort per task. Returns the number of tasks renamed (for tests).
+ * best-effort per task. Returns the tasks it renamed (id + new title) —
+ * the live poller uses that to also rename each task's origin ChatTab
+ * window; tests assert on the list. Pure orchestrator work, no tmux.
  */
 export async function runAutoTitlePass(
   orch: Orchestrator,
   derive: TitleDeriver = deriveTitleFromSession,
-): Promise<number> {
-  let renamed = 0
+): Promise<AutoTitled[]> {
+  const renamed: AutoTitled[] = []
   for (const task of orch.listTasks()) {
     if (task.title !== PLACEHOLDER_TASK_TITLE || !task.worktreePath) continue
     try {
@@ -63,7 +72,7 @@ export async function runAutoTitlePass(
       const current = orch.getTask(task.id)
       if (!current || current.title !== PLACEHOLDER_TASK_TITLE) continue
       await orch.setTitle(task.id, title)
-      renamed++
+      renamed.push({ id: task.id, title })
     } catch (err) {
       logDaemonError("auto-title-poller", err)
     }
@@ -85,6 +94,14 @@ export function startAutoTitlePoller(orch: Orchestrator, intervalMs: number = DE
     if (running) return
     running = true
     void runAutoTitlePass(orch)
+      .then(async (renamed) => {
+        // Mirror the new title onto each task's origin ChatTab window so the
+        // tab strip stops reading `claude`/`zsh`. Best-effort and only the
+        // first tab; skipped silently when the session/window is gone.
+        for (const { id, title } of renamed) {
+          await renameOriginChatTab(id, title).catch((err) => logDaemonError("auto-title-poller", err))
+        }
+      })
       .catch((err) => logDaemonError("auto-title-poller", err))
       .finally(() => {
         running = false

--- a/packages/kobe/src/daemon/auto-title-poller.ts
+++ b/packages/kobe/src/daemon/auto-title-poller.ts
@@ -29,7 +29,7 @@
 import { deriveTitleFromSession } from "@/monitor/auto-title"
 import type { Orchestrator } from "@/orchestrator/core"
 import { PLACEHOLDER_TASK_TITLE } from "@/orchestrator/core"
-import { renameOriginChatTab } from "@/tmux/chat-tab-naming"
+import { runChatTabNamingPass } from "@/tmux/chat-tab-naming"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
 import { logDaemonError } from "./crash-log"
 
@@ -93,15 +93,11 @@ export function startAutoTitlePoller(orch: Orchestrator, intervalMs: number = DE
     // pile up overlapping scans.
     if (running) return
     running = true
+    // Two independent passes: (1) name still-placeholder TASKS from their
+    // first prompt; (2) name still-default ChatTab WINDOWS from each tab's own
+    // first prompt. Both are best-effort and self-limiting.
     void runAutoTitlePass(orch)
-      .then(async (renamed) => {
-        // Mirror the new title onto each task's origin ChatTab window so the
-        // tab strip stops reading `claude`/`zsh`. Best-effort and only the
-        // first tab; skipped silently when the session/window is gone.
-        for (const { id, title } of renamed) {
-          await renameOriginChatTab(id, title).catch((err) => logDaemonError("auto-title-poller", err))
-        }
-      })
+      .then(() => runChatTabNamingPass(orch))
       .catch((err) => logDaemonError("auto-title-poller", err))
       .finally(() => {
         running = false

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -23,6 +23,7 @@
  * the built-in default.
  */
 
+import { randomUUID } from "node:crypto"
 import { getPersistedString } from "@/state/repos"
 import type { VendorId } from "@/types/task"
 
@@ -72,4 +73,33 @@ export function interactiveEngineCommand(vendor: VendorId | undefined): readonly
     if (argv.length > 0) return argv
   }
   return defaultEngineCommand(v)
+}
+
+/**
+ * Claude flags that already pin / fork the conversation's session. If the
+ * launch command carries one of these, we must NOT also append our own
+ * `--session-id` (claude would reject two, or our id would lose to the
+ * resumed one). Covers both long and short forms.
+ */
+const CLAUDE_SESSION_CONTROL_FLAGS = new Set(["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"])
+
+/**
+ * For a Claude launch, append a kobe-generated `--session-id <uuid>` so the
+ * tmux window it runs in can be mapped to its transcript (recorded as the
+ * `@kobe_session_id` window option) and auto-named from its first prompt
+ * (KOB — per-tab naming). Returns `{ argv, sessionId }` where `sessionId`
+ * is the forced UUID, or `null` when not applicable:
+ *   - the vendor isn't Claude (Codex/Copilot can't take a caller-set id), or
+ *   - the command already controls its session (`--resume`/`--continue`/…).
+ * `--session-id` is a documented Claude flag (`<uuid>` required); we leave a
+ * non-default custom command that pins its own session untouched.
+ */
+export function withClaudeSessionId(
+  argv: readonly string[],
+  vendor: string | undefined,
+): { argv: readonly string[]; sessionId: string | null } {
+  if ((vendor ?? "claude") !== "claude") return { argv, sessionId: null }
+  if (argv.some((a) => CLAUDE_SESSION_CONTROL_FLAGS.has(a))) return { argv, sessionId: null }
+  const sessionId = randomUUID()
+  return { argv: [...argv, "--session-id", sessionId], sessionId }
 }

--- a/packages/kobe/src/monitor/auto-title.ts
+++ b/packages/kobe/src/monitor/auto-title.ts
@@ -25,6 +25,13 @@ import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
 
 const MAX_SESSIONS_SCANNED = 8
 
+/** The vendor's `readHistory(sessionId)` reader. */
+function readerFor(vendor: VendorId): (sessionId: string) => Promise<Message[]> {
+  if (vendor === "codex") return codexHistory.readHistory
+  if (vendor === "copilot") return copilotHistory.readHistory
+  return claudeHistory.readHistory
+}
+
 /** Origin session ids (oldest-first) + the vendor's history reader. */
 async function originSessions(
   worktree: string,
@@ -39,6 +46,17 @@ async function originSessions(
   const files = await claudeHistory.listSessionFilesForWorktree(worktree)
   const ids = [...files].sort((a, b) => a.mtimeMs - b.mtimeMs).map((f) => f.sessionId)
   return { ids, read: claudeHistory.readHistory }
+}
+
+/** First user message's text, truncated to a title, or `""` if none yet. */
+function titleFromMessages(messages: Message[]): string {
+  const firstUser = messages.find((m) => m.role === "user")
+  if (!firstUser) return ""
+  const text = firstUser.blocks
+    .filter((b): b is { type: "text"; text: string } => b.type === "text")
+    .map((b) => b.text)
+    .join(" ")
+  return deriveTitleFromPrompt(text)
 }
 
 /**
@@ -60,15 +78,24 @@ export async function deriveTitleFromSession(
   // give an empty title. Capped so a busy worktree doesn't read dozens
   // of transcripts.
   for (const sessionId of ids.slice(0, MAX_SESSIONS_SCANNED)) {
-    const messages = await read(sessionId)
-    const firstUser = messages.find((m) => m.role === "user")
-    if (!firstUser) continue
-    const text = firstUser.blocks
-      .filter((b): b is { type: "text"; text: string } => b.type === "text")
-      .map((b) => b.text)
-      .join(" ")
-    const title = deriveTitleFromPrompt(text)
+    const title = titleFromMessages(await read(sessionId))
     if (title) return title
   }
   return ""
+}
+
+/**
+ * The truncated first-user-prompt title for ONE specific engine session,
+ * or `""` when that session has no usable user message yet. Used by the
+ * per-ChatTab auto-namer, which knows exactly which session id runs in each
+ * window (claude `--session-id`); `readHistory` finds the transcript by id
+ * across project dirs, so no worktree is needed. Never throws.
+ */
+export async function deriveTitleFromSessionId(vendor: VendorId, sessionId: string): Promise<string> {
+  if (!sessionId) return ""
+  try {
+    return titleFromMessages(await readerFor(vendor)(sessionId))
+  } catch {
+    return ""
+  }
 }

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -292,6 +292,31 @@ export class Orchestrator {
     const task = this.requireTask(id)
     if (task.title === trimmed) return
     await this.store.update(task.id, { title: trimmed })
+    await this.followBranchToTitle(task, trimmed)
+  }
+
+  /**
+   * Keep a materialised task's branch in lockstep with its title WHILE the
+   * branch is still the placeholder-derived default (`kobe/new-task-<id>`).
+   * This is what lets a task auto-named from its first prompt also pick up a
+   * meaningful branch instead of staying `kobe/new-task-…`. It fires at most
+   * once: after the first rename the branch no longer matches the placeholder
+   * derivation, so a later title change (or a manual `setBranch`) is never
+   * clobbered. Skipped for `main` (no branch) and for not-yet-materialised
+   * tasks (their branch is derived fresh from the title in {@link ensureWorktree},
+   * so no rename is needed). Best-effort: a git rename failure is logged, not
+   * thrown — the title update already committed and must stand.
+   */
+  private async followBranchToTitle(taskBefore: Task, newTitle: string): Promise<void> {
+    if (taskBefore.kind === "main" || !taskBefore.worktreePath) return
+    if (taskBefore.branch !== autoBranch(PLACEHOLDER_TASK_TITLE, taskBefore.id)) return
+    const nextBranch = autoBranch(newTitle, taskBefore.id)
+    if (nextBranch === taskBefore.branch) return
+    try {
+      await this.setBranch(taskBefore.id, nextBranch)
+    } catch (err) {
+      console.error(`[kobe] follow-branch-to-title failed for ${taskBefore.id}:`, err)
+    }
   }
 
   /**

--- a/packages/kobe/src/tmux/chat-tab-naming.ts
+++ b/packages/kobe/src/tmux/chat-tab-naming.ts
@@ -1,29 +1,34 @@
 /**
- * Auto-name a task's first ChatTab window (KOB).
+ * Auto-name every ChatTab window from its own first prompt (KOB).
  *
- * Companion to the daemon's live task auto-title (`daemon/auto-title-poller.ts`):
- * when a task is named from its first prompt, we also rename the task's
- * ORIGIN ChatTab window (the first tmux window of its session) to the same
- * title, so the tab strip stops reading `claude` / `zsh`. Scope is
- * deliberately the first tab only — additional Ctrl+T tabs keep tmux's
- * default name.
+ * Companion to the daemon's live task auto-title (`daemon/auto-title-poller.ts`).
+ * Each ChatTab is a tmux window running its own engine session; for a claude
+ * launch we force a known session id at spawn (`--session-id`) and stash it on
+ * the window as `@kobe_session_id` (see `tui/panes/terminal/tmux.ts`). This
+ * pass walks every task's windows, reads that id, derives the window's first
+ * user prompt from THAT transcript, and renames the window to it — so a
+ * Ctrl+T tab gets its own name, not the task's.
  *
- * Two tmux facts this leans on (verified on tmux 3.5a):
- *   - The origin window is NOT index 0. kobe runs with `base-index 1`, so
- *     the first `new-session` window is index 1 and any `:0` target fails.
- *     We list windows and take the lowest index — the origin ChatTab is
- *     created first (at `new-session`); Ctrl+T tabs and the special
- *     settings/new-task/update windows are all appended at higher indices.
- *   - `rename-window` flips that window's `automatic-rename` to `off` and
- *     the name sticks (this is also why F2 rename sticks). So an untouched
- *     origin window inherits the global `automatic-rename on`, while a
- *     window someone already named (F2, or a prior run) reads `off`. We use
- *     that as the "don't clobber a manual rename" guard — the
- *     `#{automatic_rename}` FORMAT variable is empty on 3.5a, so we query
- *     the option instead.
+ * Per window:
+ *   - Skip if it was named manually. `rename-window` (and F2) flips a window's
+ *     `automatic-rename` to `off`; an untouched window inherits the global
+ *     `on`. So `automatic-rename off` == "already named" — our don't-clobber
+ *     guard. (The `#{automatic_rename}` FORMAT variable is empty on tmux 3.5a,
+ *     so we query the option, not a format.)
+ *   - With a recorded session id → name from that session (claude tabs).
+ *   - Without one, only the ORIGIN (lowest-index) window is named, from the
+ *     task's first session — the codex/legacy fallback, since codex can't take
+ *     a caller-set session id and pre-change windows have no id stashed.
+ *
+ * Self-limiting like the title poller: once a window is renamed its
+ * automatic-rename is off, so later ticks skip it; windows with no prompt yet
+ * derive `""` and stay until their first message lands.
  */
 
-import { runTmux, runTmuxCapturing, tmuxSessionName } from "./client.ts"
+import { deriveTitleFromSession, deriveTitleFromSessionId } from "@/monitor/auto-title"
+import type { Orchestrator } from "@/orchestrator/core"
+import { CHAT_TAB_SESSION_ID_OPTION, runTmux, runTmuxCapturing, tmuxSessionName } from "@/tmux/client"
+import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
 
 /** Seam for tests — the real implementation shells `tmux` via the client. */
 export interface TmuxRunner {
@@ -33,35 +38,89 @@ export interface TmuxRunner {
 
 const realRunner: TmuxRunner = { capture: runTmuxCapturing, run: runTmux }
 
-/**
- * Rename the origin ChatTab window of `taskId`'s session to `title`.
- * Returns true if a rename was issued. No-ops (returns false) when the
- * session is gone, has no windows, or the origin window was already named
- * manually. Best-effort: never throws — a tmux failure just returns false.
- */
-export async function renameOriginChatTab(
-  taskId: string,
-  title: string,
-  runner: TmuxRunner = realRunner,
-): Promise<boolean> {
-  const trimmed = title.trim()
-  if (!trimmed) return false
-  const session = tmuxSessionName(taskId)
-  try {
-    const list = await runner.capture(["list-windows", "-t", `=${session}`, "-F", "#{window_index}"])
-    if (list.code !== 0) return false
-    const origin = list.stdout
-      .split("\n")
-      .map((l) => Number.parseInt(l.trim(), 10))
-      .filter((n) => Number.isInteger(n))
-      .sort((a, b) => a - b)[0]
-    if (origin === undefined) return false
-    const target = `=${session}:${origin}`
-    // Skip a window someone already named (F2 sets automatic-rename off).
-    const opt = await runner.capture(["show-window-options", "-t", target, "automatic-rename"])
-    if (opt.code === 0 && /\boff\b/.test(opt.stdout)) return false
-    return (await runner.run(["rename-window", "-t", target, "--", trimmed])) === 0
-  } catch {
-    return false
+/** One ChatTab window: its tmux index and the engine session id stashed on it. */
+export interface ChatTabWindow {
+  readonly index: number
+  /** `@kobe_session_id` value, or `""` when none was recorded (codex/legacy). */
+  readonly sessionId: string
+}
+
+/** List a session's windows with their recorded engine session id. `[]` when the session is gone. */
+export async function listChatTabWindows(session: string, runner: TmuxRunner = realRunner): Promise<ChatTabWindow[]> {
+  const { code, stdout } = await runner.capture([
+    "list-windows",
+    "-t",
+    `=${session}`,
+    "-F",
+    `#{window_index}\t#{${CHAT_TAB_SESSION_ID_OPTION}}`,
+  ])
+  if (code !== 0) return []
+  const out: ChatTabWindow[] = []
+  for (const line of stdout.split("\n")) {
+    const tab = line.indexOf("\t")
+    const index = Number.parseInt((tab >= 0 ? line.slice(0, tab) : line).trim(), 10)
+    if (!Number.isInteger(index)) continue
+    out.push({ index, sessionId: tab >= 0 ? line.slice(tab + 1).trim() : "" })
   }
+  return out
+}
+
+/** True when a window was named manually (F2 / `-n`): its automatic-rename is off. */
+async function windowNamedManually(session: string, index: number, runner: TmuxRunner): Promise<boolean> {
+  const { code, stdout } = await runner.capture([
+    "show-window-options",
+    "-t",
+    `=${session}:${index}`,
+    "automatic-rename",
+  ])
+  return code === 0 && /\boff\b/.test(stdout)
+}
+
+/** Rename one window. Returns true on success. */
+async function renameWindow(session: string, index: number, title: string, runner: TmuxRunner): Promise<boolean> {
+  return (await runner.run(["rename-window", "-t", `=${session}:${index}`, "--", title])) === 0
+}
+
+/** Injectable title derivers so the pass is testable without disk transcripts. */
+export interface ChatTabNamingDeps {
+  runner: TmuxRunner
+  titleFromSessionId(vendor: VendorId, sessionId: string): Promise<string>
+  titleFromWorktree(worktree: string, vendor: VendorId): Promise<string>
+}
+
+const realDeps: ChatTabNamingDeps = {
+  runner: realRunner,
+  titleFromSessionId: deriveTitleFromSessionId,
+  titleFromWorktree: deriveTitleFromSession,
+}
+
+/**
+ * One pass: name every still-default ChatTab window across all tasks. Returns
+ * the number of windows renamed (for tests). Best-effort per window — a tmux
+ * or read failure on one window never blocks the others.
+ */
+export async function runChatTabNamingPass(orch: Orchestrator, deps: ChatTabNamingDeps = realDeps): Promise<number> {
+  let renamed = 0
+  for (const task of orch.listTasks()) {
+    if (task.kind === "main" || !task.worktreePath) continue
+    const session = tmuxSessionName(task.id)
+    const windows = await listChatTabWindows(session, deps.runner)
+    if (windows.length === 0) continue
+    const originIndex = windows.reduce((min, w) => Math.min(min, w.index), Number.POSITIVE_INFINITY)
+    const vendor = task.vendor ?? DEFAULT_TASK_VENDOR
+    for (const w of windows) {
+      try {
+        if (await windowNamedManually(session, w.index, deps.runner)) continue
+        const title = w.sessionId
+          ? await deps.titleFromSessionId(vendor, w.sessionId)
+          : w.index === originIndex
+            ? await deps.titleFromWorktree(task.worktreePath, vendor)
+            : ""
+        if (title && (await renameWindow(session, w.index, title, deps.runner))) renamed++
+      } catch {
+        // best-effort: skip this window, keep going
+      }
+    }
+  }
+  return renamed
 }

--- a/packages/kobe/src/tmux/chat-tab-naming.ts
+++ b/packages/kobe/src/tmux/chat-tab-naming.ts
@@ -1,0 +1,67 @@
+/**
+ * Auto-name a task's first ChatTab window (KOB).
+ *
+ * Companion to the daemon's live task auto-title (`daemon/auto-title-poller.ts`):
+ * when a task is named from its first prompt, we also rename the task's
+ * ORIGIN ChatTab window (the first tmux window of its session) to the same
+ * title, so the tab strip stops reading `claude` / `zsh`. Scope is
+ * deliberately the first tab only — additional Ctrl+T tabs keep tmux's
+ * default name.
+ *
+ * Two tmux facts this leans on (verified on tmux 3.5a):
+ *   - The origin window is NOT index 0. kobe runs with `base-index 1`, so
+ *     the first `new-session` window is index 1 and any `:0` target fails.
+ *     We list windows and take the lowest index — the origin ChatTab is
+ *     created first (at `new-session`); Ctrl+T tabs and the special
+ *     settings/new-task/update windows are all appended at higher indices.
+ *   - `rename-window` flips that window's `automatic-rename` to `off` and
+ *     the name sticks (this is also why F2 rename sticks). So an untouched
+ *     origin window inherits the global `automatic-rename on`, while a
+ *     window someone already named (F2, or a prior run) reads `off`. We use
+ *     that as the "don't clobber a manual rename" guard — the
+ *     `#{automatic_rename}` FORMAT variable is empty on 3.5a, so we query
+ *     the option instead.
+ */
+
+import { runTmux, runTmuxCapturing, tmuxSessionName } from "./client.ts"
+
+/** Seam for tests — the real implementation shells `tmux` via the client. */
+export interface TmuxRunner {
+  capture(args: string[]): Promise<{ code: number; stdout: string }>
+  run(args: string[]): Promise<number>
+}
+
+const realRunner: TmuxRunner = { capture: runTmuxCapturing, run: runTmux }
+
+/**
+ * Rename the origin ChatTab window of `taskId`'s session to `title`.
+ * Returns true if a rename was issued. No-ops (returns false) when the
+ * session is gone, has no windows, or the origin window was already named
+ * manually. Best-effort: never throws — a tmux failure just returns false.
+ */
+export async function renameOriginChatTab(
+  taskId: string,
+  title: string,
+  runner: TmuxRunner = realRunner,
+): Promise<boolean> {
+  const trimmed = title.trim()
+  if (!trimmed) return false
+  const session = tmuxSessionName(taskId)
+  try {
+    const list = await runner.capture(["list-windows", "-t", `=${session}`, "-F", "#{window_index}"])
+    if (list.code !== 0) return false
+    const origin = list.stdout
+      .split("\n")
+      .map((l) => Number.parseInt(l.trim(), 10))
+      .filter((n) => Number.isInteger(n))
+      .sort((a, b) => a - b)[0]
+    if (origin === undefined) return false
+    const target = `=${session}:${origin}`
+    // Skip a window someone already named (F2 sets automatic-rename off).
+    const opt = await runner.capture(["show-window-options", "-t", target, "automatic-rename"])
+    if (opt.code === 0 && /\boff\b/.test(opt.stdout)) return false
+    return (await runner.run(["rename-window", "-t", target, "--", trimmed])) === 0
+  } catch {
+    return false
+  }
+}

--- a/packages/kobe/src/tmux/client.ts
+++ b/packages/kobe/src/tmux/client.ts
@@ -205,6 +205,14 @@ export async function tagPaneRole(paneId: string, role: string): Promise<void> {
   await runTmux(["set-option", "-p", "-t", paneId, PANE_ROLE_OPTION, role])
 }
 
+/**
+ * Window-scoped user option holding the engine session UUID that runs in
+ * this ChatTab window (set at launch via claude's `--session-id`). Lets the
+ * auto-namer map a window → its transcript → its first prompt. Readable as
+ * the `#{@kobe_session_id}` format variable in `list-windows`.
+ */
+export const CHAT_TAB_SESSION_ID_OPTION = "@kobe_session_id"
+
 /** Set a window-scoped user option, targeting any pane/window inside it. */
 export async function setWindowOption(target: string, option: string, value: string): Promise<void> {
   await runTmux(["set-window-option", "-t", target, option, value])

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -32,9 +32,10 @@
  */
 
 import { kobeCliInvocation } from "@/cli/invocation"
-import { interactiveEngineCommand } from "@/engine/interactive-command"
+import { interactiveEngineCommand, withClaudeSessionId } from "@/engine/interactive-command"
 import { worktreeInitMarkerPath } from "@/env"
 import {
+  CHAT_TAB_SESSION_ID_OPTION,
   claudePaneIdStrict,
   getSessionOptions,
   newWindow,
@@ -46,6 +47,7 @@ import {
   sendKeys,
   sessionExists,
   setSessionOption,
+  setWindowOption,
   windowCount,
 } from "@/tmux/client"
 import { deliverFirstPrompt } from "@/tmux/prompt-delivery"
@@ -276,6 +278,10 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
   // in KOB-233). Pane ids (`%N`) are server-global and immune to
   // `base-index`, so we always target by id.
   const inv = kobeCliInvocation()
+  // Force a known session id for a claude launch so this window can be mapped
+  // to its transcript and auto-named from its first prompt (KOB). No-op for
+  // codex/copilot or a command that already pins its session.
+  const launch = withClaudeSessionId(opts.command, opts.vendor)
   const r0 = await runTmuxCapturing([
     "new-session",
     "-d",
@@ -289,7 +295,7 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     "#{pane_id}",
     // Weave the per-repo init script before the engine (once-per-worktree
     // via a marker under <home>/.kobe/). Plain keepAlive when there's none.
-    engineLaunchLine(shellQuoteArgv(opts.command), {
+    engineLaunchLine(shellQuoteArgv(launch.argv), {
       initScript: opts.initScript,
       markerPath: opts.initScript ? worktreeInitMarkerPath(opts.cwd) : undefined,
     }),
@@ -299,6 +305,7 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     console.error("[kobe tmux] new-session returned no pane id; session creation failed")
     return false
   }
+  if (launch.sessionId) await setWindowOption(pane0, CHAT_TAB_SESSION_ID_OPTION, launch.sessionId)
 
   // Tag the session with the task id + worktree so `kobe new-chattab`
   // (the Ctrl+T handler) can rebuild the same workspace in a new window.
@@ -696,6 +703,9 @@ export async function newChatTab(session: string, vendorOverride?: VendorId): Pr
   const vendor = vendorOverride ?? (sessionOptions["@kobe_vendor"] as VendorId | undefined)
   if (vendorOverride) await rememberSessionVendor(session, taskId, vendorOverride)
   const command = interactiveEngineCommand(vendor)
+  // Same forced-session-id mapping as the first window, so a Ctrl+T tab is
+  // auto-named from its OWN first prompt (KOB).
+  const launch = withClaudeSessionId(command, vendor)
   const inv = kobeCliInvocation()
   const r = await runTmuxCapturing([
     "new-window",
@@ -706,10 +716,11 @@ export async function newChatTab(session: string, vendorOverride?: VendorId): Pr
     "-P",
     "-F",
     "#{pane_id}",
-    keepAlive(shellQuoteArgv(command)),
+    keepAlive(shellQuoteArgv(launch.argv)),
   ])
   const claudePane = r.stdout.trim()
   if (!claudePane) return
+  if (launch.sessionId) await setWindowOption(claudePane, CHAT_TAB_SESSION_ID_OPTION, launch.sessionId)
   await buildPanesAround(claudePane, { cwd, taskId, inv, vendor })
 }
 

--- a/packages/kobe/test/daemon/auto-title-poller.test.ts
+++ b/packages/kobe/test/daemon/auto-title-poller.test.ts
@@ -48,7 +48,8 @@ describe("runAutoTitlePass", () => {
 
     const renamed = await runAutoTitlePass(orch, async (worktree) => `title-for-${worktree}`)
 
-    expect(renamed).toBe(1)
+    expect(renamed.map((r) => r.id)).toEqual([placeholderWithWorktree])
+    expect(renamed[0]?.title).toBe("title-for-/wt/a")
     expect(orch.getTask(placeholderWithWorktree)?.title).toBe("title-for-/wt/a")
     expect(orch.getTask(alreadyNamed)?.title).toBe("Fix login 500")
     expect(orch.getTask(placeholderNoWorktree)?.title).toBe(PLACEHOLDER_TASK_TITLE)
@@ -57,7 +58,7 @@ describe("runAutoTitlePass", () => {
   test("leaves the placeholder when the deriver yields no title", async () => {
     const id = await makeTask({ worktree: "/wt/a" })
     const renamed = await runAutoTitlePass(orch, async () => "")
-    expect(renamed).toBe(0)
+    expect(renamed).toEqual([])
     expect(orch.getTask(id)?.title).toBe(PLACEHOLDER_TASK_TITLE)
   })
 
@@ -70,7 +71,7 @@ describe("runAutoTitlePass", () => {
       return `title-for-${worktree}`
     })
 
-    expect(renamed).toBe(1)
+    expect(renamed.map((r) => r.id)).toEqual([ok])
     expect(orch.getTask(boom)?.title).toBe(PLACEHOLDER_TASK_TITLE)
     expect(orch.getTask(ok)?.title).toBe("title-for-/wt/ok")
   })
@@ -85,7 +86,7 @@ describe("runAutoTitlePass", () => {
       return "derived-title"
     })
 
-    expect(renamed).toBe(0)
+    expect(renamed).toEqual([])
     expect(orch.getTask(id)?.title).toBe("User chose this")
   })
 })

--- a/packages/kobe/test/orchestrator/branch-follow.test.ts
+++ b/packages/kobe/test/orchestrator/branch-follow.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Branch-follows-title (KOB). When a task's branch is still the
+ * placeholder-derived default (`kobe/new-task-<id>`), renaming the title
+ * — including the auto-name from the first prompt — renames the real git
+ * branch in lockstep. A manually-set branch, or a branch derived from a
+ * non-placeholder title, is never clobbered. Real git + real store on
+ * disk; mirrors the harness in `adopt.test.ts` / `worktree.test.ts`.
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { autoBranch } from "../../src/orchestrator/title.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
+
+let tmpRoot: string
+let repo: string
+let orch: Orchestrator
+
+beforeEach(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-branchfollow-"))
+  repo = path.join(tmpRoot, "repo")
+  const r = spawnSync("bash", [REPO_INIT, repo], { encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}\n${r.stdout}`)
+  const store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  await store.load()
+  orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+/** Local branch names in the fixture repo. */
+function gitBranches(): string[] {
+  const r = spawnSync("git", ["branch", "--format=%(refname:short)"], { cwd: repo, encoding: "utf8" })
+  return r.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+describe("branch follows title", () => {
+  test("renames the placeholder-derived branch when the title is set", async () => {
+    const task = await orch.createTask({ repo })
+    await orch.ensureWorktree(task.id)
+
+    const placeholderBranch = autoBranch("(new task)", task.id)
+    expect(orch.getTask(task.id)?.branch).toBe(placeholderBranch)
+    expect(gitBranches()).toContain(placeholderBranch)
+
+    await orch.setTitle(task.id, "Fix login flow")
+
+    const expected = autoBranch("Fix login flow", task.id)
+    expect(expected).not.toBe(placeholderBranch)
+    expect(orch.getTask(task.id)?.branch).toBe(expected)
+    // The real git branch moved, not just the recorded name.
+    expect(gitBranches()).toContain(expected)
+    expect(gitBranches()).not.toContain(placeholderBranch)
+  })
+
+  test("does not touch a manually-set branch", async () => {
+    const task = await orch.createTask({ repo })
+    await orch.ensureWorktree(task.id)
+    await orch.setBranch(task.id, "feature/custom")
+    expect(gitBranches()).toContain("feature/custom")
+
+    await orch.setTitle(task.id, "Some new title")
+
+    // Branch was no longer the placeholder default, so it stays put.
+    expect(orch.getTask(task.id)?.branch).toBe("feature/custom")
+    expect(gitBranches()).toContain("feature/custom")
+  })
+
+  test("only follows once — a second rename leaves the branch alone", async () => {
+    const task = await orch.createTask({ repo })
+    await orch.ensureWorktree(task.id)
+
+    await orch.setTitle(task.id, "First name")
+    const afterFirst = autoBranch("First name", task.id)
+    expect(orch.getTask(task.id)?.branch).toBe(afterFirst)
+
+    await orch.setTitle(task.id, "Second name")
+    // Branch is no longer the placeholder default, so the second rename
+    // does not move it — it tracks the first non-placeholder title.
+    expect(orch.getTask(task.id)?.branch).toBe(afterFirst)
+    expect(gitBranches()).toContain(afterFirst)
+  })
+
+  test("a not-yet-materialised task derives its branch from the new title on ensureWorktree", async () => {
+    const task = await orch.createTask({ repo })
+    // No worktree yet: setTitle records the title, the branch stays empty.
+    await orch.setTitle(task.id, "Pre-materialise name")
+    expect(orch.getTask(task.id)?.branch).toBe("")
+
+    await orch.ensureWorktree(task.id)
+    expect(orch.getTask(task.id)?.branch).toBe(autoBranch("Pre-materialise name", task.id))
+  })
+})

--- a/packages/kobe/test/tmux/chat-tab-naming.test.ts
+++ b/packages/kobe/test/tmux/chat-tab-naming.test.ts
@@ -1,74 +1,175 @@
 /**
- * Origin-ChatTab auto-naming (KOB). Drives `renameOriginChatTab` with a
- * fake TmuxRunner so the window-selection + manual-rename guard logic is
- * tested without a live tmux server (those live in the behavior suite).
+ * Per-ChatTab auto-naming (KOB). Drives `runChatTabNamingPass` with a fake
+ * TmuxRunner + injected title derivers, against a real Orchestrator + store,
+ * so window selection, the recorded-session-id path, the origin fallback, and
+ * the manual-rename guard are tested without a live tmux server or on-disk
+ * transcripts (those live in the behavior suite).
  */
 
-import { describe, expect, it } from "vitest"
-import { type TmuxRunner, renameOriginChatTab } from "../../src/tmux/chat-tab-naming.ts"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import {
+  type ChatTabNamingDeps,
+  type TmuxRunner,
+  listChatTabWindows,
+  runChatTabNamingPass,
+} from "../../src/tmux/chat-tab-naming.ts"
 
-/** Records tmux argv and replies from a scripted map keyed by the command. */
-function fakeRunner(replies: {
-  windows?: { code: number; stdout: string }
-  autoRename?: { code: number; stdout: string }
-  renameCode?: number
-}): { runner: TmuxRunner; calls: string[][] } {
-  const calls: string[][] = []
+let tmpRoot: string
+let store: TaskIndexStore
+let orch: Orchestrator
+
+beforeEach(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-chattab-"))
+  store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  await store.load()
+  orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+async function makeTask(worktree: string | undefined): Promise<string> {
+  const task = await orch.createTask({ repo: "/repo" })
+  if (worktree !== undefined) await store.update(task.id, { worktreePath: worktree })
+  return task.id
+}
+
+/**
+ * Fake runner. `windows` is the list-windows reply (one `index\tsessionId`
+ * per line); `autoRenameOff` is the set of window indices whose
+ * automatic-rename reads off (manually named). Records every rename-window.
+ */
+function fakeDeps(opts: {
+  windows: string
+  autoRenameOff?: number[]
+  titleFromSessionId?: (vendor: string, sessionId: string) => string
+  titleFromWorktree?: (worktree: string, vendor: string) => string
+}): { deps: ChatTabNamingDeps; renames: Array<{ index: string; title: string }> } {
+  const renames: Array<{ index: string; title: string }> = []
+  const off = new Set(opts.autoRenameOff ?? [])
   const runner: TmuxRunner = {
     async capture(args) {
-      calls.push(args)
-      if (args[0] === "list-windows") return replies.windows ?? { code: 0, stdout: "" }
-      if (args[0] === "show-window-options") return replies.autoRename ?? { code: 0, stdout: "" }
+      if (args[0] === "list-windows") return { code: 0, stdout: opts.windows }
+      if (args[0] === "show-window-options") {
+        const target = args[args.indexOf("-t") + 1] // =session:index
+        const index = Number.parseInt(target.split(":")[1] ?? "", 10)
+        return { code: 0, stdout: off.has(index) ? "automatic-rename off\n" : "" }
+      }
       return { code: 1, stdout: "" }
     },
     async run(args) {
-      calls.push(args)
-      return replies.renameCode ?? 0
+      if (args[0] === "rename-window") {
+        const target = args[args.indexOf("-t") + 1]
+        renames.push({ index: target.split(":")[1] ?? "", title: args[args.length - 1] })
+      }
+      return 0
     },
   }
-  return { runner, calls }
+  return {
+    deps: {
+      runner,
+      titleFromSessionId: async (v, s) => opts.titleFromSessionId?.(v, s) ?? "",
+      titleFromWorktree: async (w, v) => opts.titleFromWorktree?.(w, v) ?? "",
+    },
+    renames,
+  }
 }
 
-describe("renameOriginChatTab", () => {
-  it("renames the lowest-index window (base-index 1, ignores higher tabs)", async () => {
-    const { runner, calls } = fakeRunner({ windows: { code: 0, stdout: "3\n1\n2\n" } })
-
-    const ok = await renameOriginChatTab("01TASK", "你好吗", runner)
-
-    expect(ok).toBe(true)
-    const rename = calls.find((c) => c[0] === "rename-window")
-    expect(rename).toEqual(["rename-window", "-t", "=kobe-01TASK:1", "--", "你好吗"])
+describe("listChatTabWindows", () => {
+  it("parses index + recorded session id, tolerating empty ids", async () => {
+    const runner: TmuxRunner = {
+      async capture() {
+        return { code: 0, stdout: "1\tabc-123\n2\t\n3\tdef-456\n" }
+      },
+      async run() {
+        return 0
+      },
+    }
+    expect(await listChatTabWindows("kobe-x", runner)).toEqual([
+      { index: 1, sessionId: "abc-123" },
+      { index: 2, sessionId: "" },
+      { index: 3, sessionId: "def-456" },
+    ])
   })
 
-  it("skips a window already named manually (automatic-rename off)", async () => {
-    const { runner, calls } = fakeRunner({
-      windows: { code: 0, stdout: "1\n" },
-      autoRename: { code: 0, stdout: "automatic-rename off\n" },
+  it("returns [] when the session is gone", async () => {
+    const runner: TmuxRunner = {
+      async capture() {
+        return { code: 1, stdout: "" }
+      },
+      async run() {
+        return 0
+      },
+    }
+    expect(await listChatTabWindows("kobe-x", runner)).toEqual([])
+  })
+})
+
+describe("runChatTabNamingPass", () => {
+  it("names each window with a recorded session id from its own transcript", async () => {
+    await makeTask("/wt/a")
+    const { deps, renames } = fakeDeps({
+      windows: "1\tsess-1\n2\tsess-2\n",
+      titleFromSessionId: (_v, s) => (s === "sess-1" ? "first tab" : "second tab"),
     })
 
-    const ok = await renameOriginChatTab("01TASK", "Derived", runner)
+    const n = await runChatTabNamingPass(orch, deps)
 
-    expect(ok).toBe(false)
-    expect(calls.some((c) => c[0] === "rename-window")).toBe(false)
+    expect(n).toBe(2)
+    expect(renames).toEqual([
+      { index: "1", title: "first tab" },
+      { index: "2", title: "second tab" },
+    ])
   })
 
-  it("proceeds when automatic-rename is inherited (empty option output)", async () => {
-    const { runner } = fakeRunner({
-      windows: { code: 0, stdout: "1\n" },
-      autoRename: { code: 0, stdout: "" },
+  it("skips a window that was named manually (automatic-rename off)", async () => {
+    await makeTask("/wt/a")
+    const { deps, renames } = fakeDeps({
+      windows: "1\tsess-1\n2\tsess-2\n",
+      autoRenameOff: [1],
+      titleFromSessionId: (_v, s) => `title-${s}`,
     })
-    expect(await renameOriginChatTab("01TASK", "Derived", runner)).toBe(true)
+
+    await runChatTabNamingPass(orch, deps)
+
+    expect(renames).toEqual([{ index: "2", title: "title-sess-2" }])
   })
 
-  it("no-ops when the session is gone (list-windows fails)", async () => {
-    const { runner, calls } = fakeRunner({ windows: { code: 1, stdout: "" } })
-    expect(await renameOriginChatTab("01TASK", "Derived", runner)).toBe(false)
-    expect(calls.some((c) => c[0] === "rename-window")).toBe(false)
+  it("falls back to the task's first session for the origin window without a recorded id (codex)", async () => {
+    await makeTask("/wt/a")
+    const { deps, renames } = fakeDeps({
+      windows: "2\t\n3\t\n", // no recorded ids; lowest index (2) is the origin
+      titleFromWorktree: () => "task first prompt",
+    })
+
+    await runChatTabNamingPass(orch, deps)
+
+    // Only the origin (index 2) is named; the non-origin id-less window is left.
+    expect(renames).toEqual([{ index: "2", title: "task first prompt" }])
   })
 
-  it("no-ops on an empty title without touching tmux", async () => {
-    const { runner, calls } = fakeRunner({})
-    expect(await renameOriginChatTab("01TASK", "   ", runner)).toBe(false)
-    expect(calls).toEqual([])
+  it("does not rename when the derived title is empty (no prompt yet)", async () => {
+    await makeTask("/wt/a")
+    const { deps, renames } = fakeDeps({ windows: "1\tsess-1\n", titleFromSessionId: () => "" })
+    expect(await runChatTabNamingPass(orch, deps)).toBe(0)
+    expect(renames).toEqual([])
+  })
+
+  it("skips a task that has no worktree yet", async () => {
+    await makeTask(undefined) // a task with no worktree yet
+    const { deps, renames } = fakeDeps({ windows: "1\tsess-1\n", titleFromSessionId: () => "should not run" })
+    await runChatTabNamingPass(orch, deps)
+    expect(renames).toEqual([])
   })
 })

--- a/packages/kobe/test/tmux/chat-tab-naming.test.ts
+++ b/packages/kobe/test/tmux/chat-tab-naming.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Origin-ChatTab auto-naming (KOB). Drives `renameOriginChatTab` with a
+ * fake TmuxRunner so the window-selection + manual-rename guard logic is
+ * tested without a live tmux server (those live in the behavior suite).
+ */
+
+import { describe, expect, it } from "vitest"
+import { type TmuxRunner, renameOriginChatTab } from "../../src/tmux/chat-tab-naming.ts"
+
+/** Records tmux argv and replies from a scripted map keyed by the command. */
+function fakeRunner(replies: {
+  windows?: { code: number; stdout: string }
+  autoRename?: { code: number; stdout: string }
+  renameCode?: number
+}): { runner: TmuxRunner; calls: string[][] } {
+  const calls: string[][] = []
+  const runner: TmuxRunner = {
+    async capture(args) {
+      calls.push(args)
+      if (args[0] === "list-windows") return replies.windows ?? { code: 0, stdout: "" }
+      if (args[0] === "show-window-options") return replies.autoRename ?? { code: 0, stdout: "" }
+      return { code: 1, stdout: "" }
+    },
+    async run(args) {
+      calls.push(args)
+      return replies.renameCode ?? 0
+    },
+  }
+  return { runner, calls }
+}
+
+describe("renameOriginChatTab", () => {
+  it("renames the lowest-index window (base-index 1, ignores higher tabs)", async () => {
+    const { runner, calls } = fakeRunner({ windows: { code: 0, stdout: "3\n1\n2\n" } })
+
+    const ok = await renameOriginChatTab("01TASK", "你好吗", runner)
+
+    expect(ok).toBe(true)
+    const rename = calls.find((c) => c[0] === "rename-window")
+    expect(rename).toEqual(["rename-window", "-t", "=kobe-01TASK:1", "--", "你好吗"])
+  })
+
+  it("skips a window already named manually (automatic-rename off)", async () => {
+    const { runner, calls } = fakeRunner({
+      windows: { code: 0, stdout: "1\n" },
+      autoRename: { code: 0, stdout: "automatic-rename off\n" },
+    })
+
+    const ok = await renameOriginChatTab("01TASK", "Derived", runner)
+
+    expect(ok).toBe(false)
+    expect(calls.some((c) => c[0] === "rename-window")).toBe(false)
+  })
+
+  it("proceeds when automatic-rename is inherited (empty option output)", async () => {
+    const { runner } = fakeRunner({
+      windows: { code: 0, stdout: "1\n" },
+      autoRename: { code: 0, stdout: "" },
+    })
+    expect(await renameOriginChatTab("01TASK", "Derived", runner)).toBe(true)
+  })
+
+  it("no-ops when the session is gone (list-windows fails)", async () => {
+    const { runner, calls } = fakeRunner({ windows: { code: 1, stdout: "" } })
+    expect(await renameOriginChatTab("01TASK", "Derived", runner)).toBe(false)
+    expect(calls.some((c) => c[0] === "rename-window")).toBe(false)
+  })
+
+  it("no-ops on an empty title without touching tmux", async () => {
+    const { runner, calls } = fakeRunner({})
+    expect(await renameOriginChatTab("01TASK", "   ", runner)).toBe(false)
+    expect(calls).toEqual([])
+  })
+})


### PR DESCRIPTION
Follow-ups to the live auto-title that shipped in #86 (the daemon poller that names a task from its first prompt). Rebased onto current `main` (post-Changesets); a changeset is included.

## What

When a task is auto-named from its first prompt:

1. **The branch follows** — a still-default `kobe/new-task-<id>` branch is renamed in lockstep with the title (real `git branch -m` via `setBranch`). Guarded so it only fires while the branch is the placeholder-derived default; a branch you renamed yourself is never touched. Branch slugs stay ASCII, so a non-Latin title (e.g. Chinese) falls back to `kobe/task-<id>`.

2. **Every ChatTab names itself from its OWN first prompt** — each ChatTab window stops reading `claude`/`zsh` and is renamed to the first message sent in it, so a task with several Ctrl+T tabs shows what each is about.
   - **Deterministic mapping for claude**: kobe launches claude with a kobe-generated `--session-id <uuid>` (a documented flag) and stashes it as the `@kobe_session_id` window option, so a poller pass can read back *that tab's own* transcript. Respects an existing `--resume`/`--continue`/custom command (no injection then).
   - **Codex** can't take a caller-set session id, so it names only its first (origin) tab from the task's first session.
   - A tab named manually with **F2** is never overwritten — the guard is the window's `automatic-rename` flipping to `off`.

## How

- `withClaudeSessionId(argv, vendor)` (`engine/interactive-command.ts`) appends the forced id; both window-spawn sites (`tui/panes/terminal/tmux.ts` first window + `newChatTab`) set the `@kobe_session_id` window option.
- `deriveTitleFromSessionId(vendor, sessionId)` (`monitor/auto-title.ts`) reads one specific session's first prompt (`readHistory` finds it by id across project dirs).
- `runChatTabNamingPass(orch)` (`tmux/chat-tab-naming.ts`) walks each task's windows, names id-mapped windows from their own session and the origin window from the task's first session (codex/legacy fallback), skipping any window whose `automatic-rename` is off. The daemon poller runs it each tick alongside the task-title pass.
- `Orchestrator.setTitle` gains a guarded branch-follow (`orchestrator/core.ts`).

## Tests

- `test/orchestrator/branch-follow.test.ts` (real git, 4 cases): placeholder branch renamed; manual branch untouched; follows once; pre-materialise derives from new title.
- `test/tmux/chat-tab-naming.test.ts` (fake tmux runner + injected derivers, 7 cases): window parsing; per-session naming; F2-guard skip; codex origin fallback; empty-title no-op; no-worktree skip.
- `test/daemon/auto-title-poller.test.ts` updated for the `AutoTitled[]` return.
- Local: typecheck, biome (full repo), `test:fast` (293), `test:socket` (51), build — all green.

## Notes

- Branch built on current `main`; the already-merged poller (#86) and the package.json lint fix are not re-included.
- Linear issue still couldn't be filed (workspace free-issue limit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat window tabs in tmux are now automatically named based on session content
  * Session tracking for Claude interactive command launches
  * Task branches automatically synchronize with updated task titles
  * Improved automatic task title generation from session messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->