### PR TITLE
fix: pane render-crash safety net (delete no longer red-stacks Tasks/Ops)

### DIFF
--- a/.changeset/pane-error-boundary.md
+++ b/.changeset/pane-error-boundary.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Tasks and Ops panes no longer hard-crash into a red error dump. A transient render throw — e.g. a frame during a task delete where a reactive lookup briefly hits the just-removed task — used to take the whole `kobe tasks` / `kobe ops` pane down to opentui's raw red stack, since neither pane had an error boundary. Both panes now wrap their render tree in a self-healing boundary: the error is logged and shown as a calm one-line state, the Tasks pane resets automatically on the next task snapshot (so a delete-frame transient clears itself), and a capped timer retry covers cases without a snapshot signal.

--- a/.changeset/tasks-pane-home-highlight.md
+++ b/.changeset/tasks-pane-home-highlight.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Entering a freshly-built task no longer leaves the Tasks pane highlight stuck on the first row. When a task's tmux session is built from scratch, its `kobe tasks` pane starts as a new process and could miss the `active-task` broadcast that races its subscribe, so its cursor defaulted to the first task. The pane now reads the task its own session belongs to (the session's `@kobe_task` tag) before first render and uses that as the initial highlight, so the cursor lands on the task you entered. The shared active-task focus still follows live cross-session switches.

--- a/packages/kobe/src/tui/ops/host.tsx
+++ b/packages/kobe/src/tui/ops/host.tsx
@@ -33,6 +33,7 @@ import { useBindings } from "../lib/keymap"
 import { type PersistedUiPrefs, readPersistedUiPrefs } from "../lib/persisted-ui-prefs"
 import { FileTree } from "../panes/filetree"
 import { DialogProvider } from "../ui/dialog"
+import { PaneErrorBoundary } from "../ui/error-boundary"
 import { buildPRPrompt } from "./pr-prompt"
 
 const FALLBACK_THEME = "claude"
@@ -223,7 +224,9 @@ function OpsApp(props: OpsHostArgs & { prefs: ThemePrefs }) {
   return (
     <ThemeProvider mode="dark" theme={props.prefs.theme}>
       <DialogProvider>
-        <OpsShell {...props} />
+        <PaneErrorBoundary label="ops">
+          <OpsShell {...props} />
+        </PaneErrorBoundary>
       </DialogProvider>
     </ThemeProvider>
   )

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -72,6 +72,7 @@ import { Sidebar } from "../panes/sidebar/Sidebar"
 import { ensureSession, openNewTaskTab, openSettingsTab, openUpdateTab } from "../panes/terminal/tmux.ts"
 import { DialogProvider, useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
+import { PaneErrorBoundary } from "../ui/error-boundary"
 
 const FALLBACK_THEME = "claude"
 const RELOAD_MS = 1500
@@ -679,13 +680,15 @@ export async function startTasksPane(): Promise<void> {
         <KVProvider>
           <FocusProvider initial="sidebar">
             <DialogProvider>
-              <TasksShell
-                tasks={tasks}
-                orch={orch}
-                transparent={prefs.transparent}
-                focusAccent={prefs.focusAccent}
-                reload={reload}
-              />
+              <PaneErrorBoundary label="tasks" resetOn={tasks}>
+                <TasksShell
+                  tasks={tasks}
+                  orch={orch}
+                  transparent={prefs.transparent}
+                  focusAccent={prefs.focusAccent}
+                  reload={reload}
+                />
+              </PaneErrorBoundary>
             </DialogProvider>
           </FocusProvider>
         </KVProvider>

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -82,6 +82,14 @@ function TasksShell(props: {
   transparent: boolean
   focusAccent: ReturnType<typeof readPersistedUiPrefs>["focusAccent"]
   /**
+   * The task this pane's tmux session belongs to (its `@kobe_task` tag),
+   * resolved before render. Used as the initial highlight so a freshly-built
+   * session lands the cursor on the task you entered — not the first row —
+   * even when the `active-task` broadcast races the pane's subscribe. The
+   * shared active-task effect still follows live cross-session switches.
+   */
+  ownTaskId: string | null
+  /**
    * The shared task-state framework: one daemon-backed RemoteOrchestrator
    * used for BOTH the live subscribe (reads) and every mutation (writes),
    * so the Tasks pane goes through the same single source of truth as the
@@ -96,7 +104,7 @@ function TasksShell(props: {
   const { theme } = themeCtx
   const dialog = useDialog()
   const kv = useKV()
-  const [selectedId, setSelectedId] = createSignal<string | null>(props.tasks()[0]?.id ?? null)
+  const [selectedId, setSelectedId] = createSignal<string | null>(props.ownTaskId ?? props.tasks()[0]?.id ?? null)
   const [updateInfo, setUpdateInfo] = createSignal<UpdateInfo | null>(null)
   // The Tasks pane OWNS its whole tmux pane (unlike the outer monitor, where the
   // Sidebar is a fixed-width rail beside the workspace). So the embedded Sidebar
@@ -664,6 +672,13 @@ export async function startTasksPane(): Promise<void> {
     console.error("[kobe tasks] daemon subscribe unavailable, polling tasks.json:", err)
   }
 
+  // The task this pane's tmux session belongs to — read once before render so
+  // the initial highlight lands on it (a from-scratch session build otherwise
+  // raced the active-task broadcast and defaulted the cursor to the first row).
+  let ownTaskId: string | null = null
+  const sessionName = await currentSessionName()
+  if (sessionName) ownTaskId = (await getSessionOption(sessionName, "@kobe_task")) || null
+
   const tasks: Accessor<readonly Task[]> = orch ? orch.tasksSignal() : fileTasks
   const reload = async (): Promise<void> => {
     // Subscribe keeps the list live; reload only matters in the polling
@@ -684,6 +699,7 @@ export async function startTasksPane(): Promise<void> {
                 <TasksShell
                   tasks={tasks}
                   orch={orch}
+                  ownTaskId={ownTaskId}
                   transparent={prefs.transparent}
                   focusAccent={prefs.focusAccent}
                   reload={reload}

--- a/packages/kobe/src/tui/ui/error-boundary.tsx
+++ b/packages/kobe/src/tui/ui/error-boundary.tsx
@@ -1,0 +1,92 @@
+/**
+ * Render-error safety net for a pane's component tree (KOB).
+ *
+ * The v0.6 panes (`kobe tasks`, `kobe ops`) each run their own opentui/solid
+ * render loop with NO error boundary — so a single throw in render (e.g. a
+ * transient frame during a task delete, where a reactive lookup briefly hits a
+ * just-removed task) crashed the whole pane into opentui's raw red error dump.
+ *
+ * This wraps a subtree, logs the error (so it's still diagnosable in the pane /
+ * daemon log), shows a calm one-line state, and SELF-HEALS:
+ *   - resets when `resetOn` changes — the next `task.snapshot` settles the
+ *     transient, so the pane re-renders cleanly without user action;
+ *   - as a backstop, retries on a short timer up to a cap, so a one-frame
+ *     transient clears even without a `resetOn` signal.
+ * A persistent error stops retrying (no busy-loop) and just shows the message.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { ErrorBoundary, type JSX, createEffect, createSignal, on, onCleanup, untrack } from "solid-js"
+import { useTheme } from "../context/theme"
+
+const RETRY_MS = 400
+const MAX_TIMED_RETRIES = 5
+
+export function PaneErrorBoundary(props: {
+  /** Short name for the log line + fallback copy (e.g. "tasks", "ops"). */
+  label?: string
+  /**
+   * Reactive dependency whose change means "upstream data updated — retry the
+   * render". Wire it to the live task snapshot so a delete-frame transient
+   * heals as soon as the next snapshot arrives.
+   */
+  resetOn?: () => unknown
+  children: JSX.Element
+}): JSX.Element {
+  // Lives in the boundary's scope (not the fallback closure) so the retry
+  // budget persists across repeated fallback re-renders and a hard error
+  // can't loop forever.
+  const [timedRetries, setTimedRetries] = createSignal(0)
+  return (
+    <ErrorBoundary
+      fallback={(err, reset) => {
+        console.error(`[kobe ${props.label ?? "pane"}] render error:`, err)
+        // Heal on the next upstream update; clears the retry budget so a later,
+        // unrelated transient gets a fresh set of retries.
+        if (props.resetOn) {
+          createEffect(
+            on(
+              props.resetOn,
+              () => {
+                setTimedRetries(0)
+                reset()
+              },
+              { defer: true },
+            ),
+          )
+        }
+        // Backstop timer — capped so a genuine, persistent bug shows the
+        // message instead of flashing on a reset loop.
+        if (untrack(timedRetries) < MAX_TIMED_RETRIES) {
+          const t = setTimeout(() => {
+            setTimedRetries((n) => n + 1)
+            reset()
+          }, RETRY_MS)
+          onCleanup(() => clearTimeout(t))
+        }
+        return <ErrorFallback label={props.label} message={errorMessage(err)} />
+      }}
+    >
+      {props.children}
+    </ErrorBoundary>
+  )
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name
+  return String(err)
+}
+
+function ErrorFallback(props: { label?: string; message: string }): JSX.Element {
+  const { theme } = useTheme()
+  return (
+    <box flexDirection="column" flexGrow={1} padding={1} backgroundColor={theme.background}>
+      <text fg={theme.error} attributes={TextAttributes.BOLD} wrapMode="none">
+        ⚠ {props.label ?? "pane"} hit a render error — recovering…
+      </text>
+      <text fg={theme.textMuted} wrapMode="word">
+        {props.message}
+      </text>
+    </box>
+  )
+}


### PR DESCRIPTION
## Bugs reported

1. **Delete sometimes red-stacks the Tasks pane and Ops/file pane** (confirmed: a big red stack / crash, not a graceful message).
2. **New task: switching in triggers a full redraw** ("不知道是崩溃了还是什么").

## Root cause (bug 1)

The v0.6 panes (`kobe tasks`, `kobe ops`) each run their own opentui/solid render loop and the codebase had **no `ErrorBoundary` anywhere**. A transient render throw — most plausibly a frame during a delete where a reactive lookup briefly references the just-removed task (the snapshot shrinks before `selectedId` settles) — took the whole pane down to opentui's raw red error dump.

## Fix

Add a reusable `PaneErrorBoundary` (`src/tui/ui/error-boundary.tsx`) and wrap the Tasks pane (`TasksShell`) and Ops pane (`OpsShell`) render trees:

- Logs the error (still diagnosable) and renders a calm one-line "recovering…" state instead of a red stack.
- **Self-heals**: the Tasks pane resets on the next `task.snapshot` (`resetOn={tasks}`), so a delete-frame transient clears itself with no user action.
- **Capped timer retry** as a backstop for panes without a snapshot signal (Ops), so a one-frame transient clears without busy-looping a genuine, persistent bug.

## On bug 2 (new-task redraw)

Traced the Tasks-pane enter path (`switchTo` → `ensureWorktree` → `ensureSession`). A **first** switch into a never-entered task legitimately *builds* the tmux session from scratch (a full draw — expected). Re-entry reuses the healthy session (`worktreeOk` holds) and only `switch-client`s — I found **no code path that rebuilds a healthy session on re-entry**. So the "redraw" is most likely the normal first-build, or a transient pane crash during that build — which this boundary now catches and recovers. Needs a repro to confirm if it's something else (does it happen every time, or only the first enter?).

## Tests / checks

- typecheck, biome (full repo, 192 files), `test:fast` (282) — all green.
- The boundary is render-only behavior (no unit test in the fast suite; the panes need a live tmux/opentui render to exercise).

Branch off current `main`; changeset included.
