### PR TITLE
Fix Settings transparency persistence

### DIFF
--- a/.changeset/quiet-settings-apply.md
+++ b/.changeset/quiet-settings-apply.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix Settings transparent-background changes so they persist and apply after closing the Settings page. The Settings page now flushes UI state before exit and refreshes only kobe-owned Tasks/Ops panes when visual preferences changed, leaving engine and shell panes untouched.

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/kobe": {
       "name": "@sma1lboy/kobe",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "bin": {
         "kobe": "dist/cli/index.js",
       },

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -26,7 +26,7 @@ import { VENDOR_LABEL, defaultEngineCommand, engineCommandKey } from "../../engi
 import type { VendorId } from "../../types/task"
 import { ALL_VENDORS } from "../../types/vendor"
 import type { KVContext } from "../context/kv"
-import { FOCUS_ACCENT_SLOTS, useTheme } from "../context/theme"
+import { FOCUS_ACCENT_SLOTS, type FocusAccentSlot, useTheme } from "../context/theme"
 import { useBindings } from "../lib/keymap"
 import {
   DEFAULT_SETTINGS_SURFACE,
@@ -64,6 +64,7 @@ export type SettingsDialogProps = {
    * button only when we're attached to a daemon (RemoteOrchestrator).
    */
   orchestrator?: KobeOrchestrator
+  onVisualPrefsChange?: () => void
   onClose: () => void
 }
 
@@ -135,6 +136,31 @@ export function SettingsDialog(props: SettingsDialogProps) {
 
   function settingsSurface(): SettingsSurface {
     return normalizeSettingsSurface(props.kv.get(SETTINGS_SURFACE_KEY, DEFAULT_SETTINGS_SURFACE))
+  }
+
+  function selectTheme(name: string): void {
+    if (themeCtx.selected === name) return
+    if (!themeCtx.set(name)) return
+    props.kv.set("activeTheme", name)
+    props.onVisualPrefsChange?.()
+  }
+
+  function setTransparentBackground(next: boolean): void {
+    if (themeCtx.transparentBackground === next) return
+    themeCtx.setTransparentBackground(next)
+    props.kv.set("transparentBackground", next)
+    props.onVisualPrefsChange?.()
+  }
+
+  function toggleTransparent(): void {
+    setTransparentBackground(!themeCtx.transparentBackground)
+  }
+
+  function selectFocusAccent(slot: FocusAccentSlot): void {
+    if (themeCtx.focusAccent === slot) return
+    themeCtx.setFocusAccent(slot)
+    props.kv.set("focusAccent", slot)
+    props.onVisualPrefsChange?.()
   }
 
   function selectSurface(surface: SettingsSurface): void {
@@ -213,13 +239,13 @@ export function SettingsDialog(props: SettingsDialogProps) {
   function activateBodyRow(): void {
     if (section() === "general") {
       if (isTransparentRow()) {
-        themeCtx.setTransparentBackground(!themeCtx.transparentBackground)
+        toggleTransparent()
         return
       }
       const focusIdx = currentFocusAccentRow()
       if (focusIdx !== null) {
         const slot = FOCUS_ACCENT_SLOTS[focusIdx]
-        if (slot) themeCtx.setFocusAccent(slot)
+        if (slot) selectFocusAccent(slot)
         return
       }
       if (isToastRow()) {
@@ -239,7 +265,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
         return
       }
       const name = themeNames()[bodyRow()]
-      if (name) themeCtx.set(name)
+      if (name) selectTheme(name)
       return
     }
     if (section() === "engines") {
@@ -276,7 +302,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
       },
       {
         key: "t",
-        cmd: () => themeCtx.setTransparentBackground(!themeCtx.transparentBackground),
+        cmd: toggleTransparent,
       },
     ],
   }))
@@ -302,6 +328,9 @@ export function SettingsDialog(props: SettingsDialogProps) {
               setBodyRow={setBodyRow}
               themeNames={themeNames}
               setThemeCursor={setThemeCursor}
+              selectTheme={selectTheme}
+              toggleTransparent={toggleTransparent}
+              selectFocusAccent={selectFocusAccent}
               toastEnabled={toastEnabled}
               soundEnabled={soundEnabled}
               toggleToast={toggleToast}

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -378,11 +378,25 @@ export function SettingsDialog(props: SettingsDialogProps) {
   )
 }
 
-SettingsDialog.show = (dialog: DialogContext, kv: KVContext, orchestrator?: KobeOrchestrator): Promise<void> => {
-  return new Promise<void>((resolve) => {
+SettingsDialog.show = (
+  dialog: DialogContext,
+  kv: KVContext,
+  orchestrator?: KobeOrchestrator,
+): Promise<{ visualPrefsChanged: boolean }> => {
+  let visualPrefsChanged = false
+  return new Promise<{ visualPrefsChanged: boolean }>((resolve) => {
     dialog.replace(
-      () => <SettingsDialog kv={kv} orchestrator={orchestrator} onClose={() => resolve()} />,
-      () => resolve(),
+      () => (
+        <SettingsDialog
+          kv={kv}
+          orchestrator={orchestrator}
+          onVisualPrefsChange={() => {
+            visualPrefsChanged = true
+          }}
+          onClose={() => resolve({ visualPrefsChanged })}
+        />
+      ),
+      () => resolve({ visualPrefsChanged }),
     )
   })
 }

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -62,6 +62,9 @@ export function GeneralSettingsSection(
     bodyRow: Accessor<number>
     themeNames: Accessor<readonly string[]>
     setThemeCursor: Setter<number>
+    selectTheme: (name: string) => void
+    toggleTransparent: () => void
+    selectFocusAccent: (slot: (typeof FOCUS_ACCENT_SLOTS)[number]) => void
     toastEnabled: Accessor<boolean>
     soundEnabled: Accessor<boolean>
     toggleToast: () => void
@@ -104,7 +107,7 @@ export function GeneralSettingsSection(
                   props.setLevel("body")
                   props.setBodyRow(i())
                   props.setThemeCursor(i())
-                  themeCtx.set(name)
+                  props.selectTheme(name)
                 }}
               >
                 <text
@@ -135,7 +138,7 @@ export function GeneralSettingsSection(
           onMouseUp={() => {
             props.setLevel("body")
             props.setBodyRow(transparentRowIndex(props.themeNames().length))
-            themeCtx.setTransparentBackground(!themeCtx.transparentBackground)
+            props.toggleTransparent()
           }}
         >
           <text
@@ -175,7 +178,7 @@ export function GeneralSettingsSection(
                 onMouseUp={() => {
                   props.setLevel("body")
                   props.setBodyRow(rowIndex())
-                  themeCtx.setFocusAccent(slot)
+                  props.selectFocusAccent(slot)
                 }}
               >
                 <text

--- a/packages/kobe/src/tui/context/kv.tsx
+++ b/packages/kobe/src/tui/context/kv.tsx
@@ -44,16 +44,18 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
     const [store, setStore] = createStore<Record<string, unknown>>(loadInitial())
 
     let writeTimer: ReturnType<typeof setTimeout> | null = null
-    function writeNow(label: string): void {
+    function writeNow(label: string): boolean {
       const statePath = kvStatePath()
       try {
         mkdirSync(dirname(statePath), { recursive: true })
         const tmp = `${statePath}.tmp`
         writeFileSync(tmp, JSON.stringify(store, null, 2), "utf8")
         renameSync(tmp, statePath)
+        return true
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error(`[kobe] kv ${label} failed:`, err)
+        return false
       }
     }
 
@@ -88,12 +90,12 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
        * before process.exit(), where the normal debounced write may not
        * get a chance to run.
        */
-      flush() {
+      flush(): boolean {
         if (writeTimer) {
           clearTimeout(writeTimer)
           writeTimer = null
         }
-        writeNow("flush")
+        return writeNow("flush")
       },
       /**
        * Wipe every persisted key and synchronously flush the now-empty

--- a/packages/kobe/src/tui/context/kv.tsx
+++ b/packages/kobe/src/tui/context/kv.tsx
@@ -44,20 +44,24 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
     const [store, setStore] = createStore<Record<string, unknown>>(loadInitial())
 
     let writeTimer: ReturnType<typeof setTimeout> | null = null
+    function writeNow(label: string): void {
+      const statePath = kvStatePath()
+      try {
+        mkdirSync(dirname(statePath), { recursive: true })
+        const tmp = `${statePath}.tmp`
+        writeFileSync(tmp, JSON.stringify(store, null, 2), "utf8")
+        renameSync(tmp, statePath)
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(`[kobe] kv ${label} failed:`, err)
+      }
+    }
+
     function scheduleWrite(): void {
       if (writeTimer) clearTimeout(writeTimer)
       writeTimer = setTimeout(() => {
         writeTimer = null
-        const statePath = kvStatePath()
-        try {
-          mkdirSync(dirname(statePath), { recursive: true })
-          const tmp = `${statePath}.tmp`
-          writeFileSync(tmp, JSON.stringify(store, null, 2), "utf8")
-          renameSync(tmp, statePath)
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.error("[kobe] kv write failed:", err)
-        }
+        writeNow("write")
       }, WRITE_DEBOUNCE_MS)
     }
 
@@ -78,6 +82,18 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
       set(key: string, value: unknown) {
         setStore(key, value)
         scheduleWrite()
+      },
+      /**
+       * Synchronously flush pending state. Standalone pages call this
+       * before process.exit(), where the normal debounced write may not
+       * get a chance to run.
+       */
+      flush() {
+        if (writeTimer) {
+          clearTimeout(writeTimer)
+          writeTimer = null
+        }
+        writeNow("flush")
       },
       /**
        * Wipe every persisted key and synchronously flush the now-empty

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -69,6 +69,7 @@ import { CURRENT_VERSION } from "@/version"
 // (`app.tsx`, `LivePreview`, `fullscreen.tsx`) keep their `./tmux` path.
 export {
   attachArgv,
+  currentSessionName,
   killSession,
   sessionExists,
   switchClientBeforeKill,
@@ -547,6 +548,80 @@ async function healKobePaneVersions(
     }
 
     if (opsPane && claudePane && opsPane.version !== CURRENT_VERSION) {
+      commands.push(
+        [
+          "respawn-pane",
+          "-k",
+          "-t",
+          opsPane.paneId,
+          "-c",
+          cwd,
+          keepAlive(
+            envPrefix +
+              opsPaneCommand({
+                cwd,
+                taskId,
+                claudePaneId: claudePane,
+                cliInvocation: inv,
+                vendor,
+              }),
+          ),
+        ],
+        ["set-option", "-p", "-t", opsPane.paneId, "@kobe_role", "ops"],
+        ["set-option", "-p", "-t", opsPane.paneId, PANE_VERSION_OPTION, CURRENT_VERSION],
+      )
+    }
+  }
+
+  if (commands.length > 0) await runTmuxSequence(commands)
+}
+
+/**
+ * Settings changes like transparent background are read by each kobe-owned
+ * pane process at startup. After the full-window Settings page exits, the
+ * existing Tasks/Ops panes in sibling ChatTabs are still alive, so respawn
+ * only those helper panes in place to make the new UI prefs visible without
+ * touching the user's engine or shell panes.
+ */
+export async function refreshKobeWorkspacePanes(session: string): Promise<void> {
+  const sessionOptions = await getSessionOptions(session, ["@kobe_worktree", "@kobe_task", "@kobe_vendor"])
+  const cwd = sessionOptions["@kobe_worktree"] || process.cwd()
+  const taskId = sessionOptions["@kobe_task"] || undefined
+  const vendor = sessionOptions["@kobe_vendor"] || undefined
+  const inv = kobeCliInvocation()
+  const envPrefix = inheritedEnvPrefix()
+  const { code, stdout } = await runTmuxCapturing([
+    "list-panes",
+    "-s",
+    "-t",
+    `=${session}`,
+    "-F",
+    `#{window_id}\t#{pane_id}\t#{@kobe_role}\t#{${PANE_VERSION_OPTION}}`,
+  ])
+  if (code !== 0) return
+
+  const byWindow = new Map<string, KobePaneRow[]>()
+  for (const row of parseKobePaneRows(stdout)) {
+    const panes = byWindow.get(row.windowId) ?? []
+    panes.push(row)
+    byWindow.set(row.windowId, panes)
+  }
+
+  const commands: (readonly string[])[] = []
+  for (const panes of byWindow.values()) {
+    const claudePane = panes.find((pane) => pane.role === "claude")?.paneId
+    const tasksPane = panes.find((pane) => pane.role === "tasks")
+    const opsPane = panes.find((pane) => pane.role === "ops")
+
+    if (tasksPane) {
+      commands.push(
+        ["respawn-pane", "-k", "-t", tasksPane.paneId, "-c", cwd, keepAlive(envPrefix + tasksPaneCommand(inv))],
+        ["set-option", "-p", "-t", tasksPane.paneId, "@kobe_role", "tasks"],
+        ["set-option", "-p", "-t", tasksPane.paneId, PANE_VERSION_OPTION, CURRENT_VERSION],
+      )
+    }
+
+    if (opsPane && claudePane) {
       commands.push(
         [
           "respawn-pane",

--- a/packages/kobe/src/tui/settings/host.tsx
+++ b/packages/kobe/src/tui/settings/host.tsx
@@ -53,8 +53,8 @@ function SettingsPage(props: {
     if (exiting) return
     exiting = true
     try {
-      kv.flush()
-      if (visualPrefsChanged) {
+      const flushed = kv.flush()
+      if (flushed && visualPrefsChanged) {
         const session = await currentSessionName()
         if (session) await refreshKobeWorkspacePanes(session)
       }

--- a/packages/kobe/src/tui/settings/host.tsx
+++ b/packages/kobe/src/tui/settings/host.tsx
@@ -27,6 +27,7 @@ import { ThemeProvider, addTheme, useTheme } from "../context/theme"
 import { loadUserThemes } from "../context/theme/loader"
 import { useBindings } from "../lib/keymap"
 import { readPersistedUiPrefs } from "../lib/persisted-ui-prefs"
+import { currentSessionName, refreshKobeWorkspacePanes } from "../panes/terminal/tmux"
 import { DialogProvider, useDialog } from "../ui/dialog"
 
 const FALLBACK_THEME = "claude"
@@ -40,14 +41,28 @@ function SettingsPage(props: {
   const dialog = useDialog()
   const themeCtx = useTheme()
   const { theme } = themeCtx
+  let visualPrefsChanged = false
+  let exiting = false
 
   onMount(() => {
     themeCtx.setTransparentBackground(props.transparent)
     if (props.focusAccent) themeCtx.setFocusAccent(props.focusAccent)
   })
 
-  function exit(): void {
-    process.exit(0)
+  async function exit(): Promise<void> {
+    if (exiting) return
+    exiting = true
+    try {
+      kv.flush()
+      if (visualPrefsChanged) {
+        const session = await currentSessionName()
+        if (session) await refreshKobeWorkspacePanes(session)
+      }
+    } catch (err) {
+      console.error("[kobe settings] failed to refresh workspace panes:", err)
+    } finally {
+      process.exit(0)
+    }
   }
 
   // Page-level close keys. In the dialog (`taskpanel`) surface the dialog
@@ -66,7 +81,14 @@ function SettingsPage(props: {
 
   return (
     <box flexDirection="column" flexGrow={1} backgroundColor={theme.background} paddingTop={1}>
-      <SettingsDialog kv={kv} orchestrator={props.orchestrator ?? undefined} onClose={exit} />
+      <SettingsDialog
+        kv={kv}
+        orchestrator={props.orchestrator ?? undefined}
+        onVisualPrefsChange={() => {
+          visualPrefsChanged = true
+        }}
+        onClose={exit}
+      />
     </box>
   )
 }

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -69,7 +69,13 @@ import { readPersistedUiPrefs } from "../lib/persisted-ui-prefs"
 import { DEFAULT_SETTINGS_SURFACE, SETTINGS_SURFACE_KEY, normalizeSettingsSurface } from "../lib/settings-surface"
 import { detectWorktreeOpener, openWorktree } from "../lib/worktree-opener"
 import { Sidebar } from "../panes/sidebar/Sidebar"
-import { ensureSession, openNewTaskTab, openSettingsTab, openUpdateTab } from "../panes/terminal/tmux.ts"
+import {
+  ensureSession,
+  openNewTaskTab,
+  openSettingsTab,
+  openUpdateTab,
+  refreshKobeWorkspacePanes,
+} from "../panes/terminal/tmux.ts"
 import { DialogProvider, useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
 
@@ -228,7 +234,15 @@ function TasksShell(props: {
         return
       }
     }
-    void SettingsDialog.show(dialog, kv, props.orch ?? undefined)
+    const result = await SettingsDialog.show(dialog, kv, props.orch ?? undefined)
+    if (!result.visualPrefsChanged) return
+    if (!kv.flush()) return
+    try {
+      const session = await currentSessionName()
+      if (session) await refreshKobeWorkspacePanes(session)
+    } catch (err) {
+      console.error("[kobe tasks] failed to refresh workspace panes:", err)
+    }
   }
 
   async function openUpdate(): Promise<void> {


### PR DESCRIPTION
Fixes Settings visual preferences so theme, focus accent, and transparent background write through to persisted UI state from both keyboard and mouse paths. The standalone Settings page now flushes state before exit and refreshes only kobe-owned Tasks/Ops panes when visual preferences actually changed, leaving engine and shell panes untouched. Adds a patch changeset and syncs bun.lock with the current package version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual preferences (theme, transparent background, focus accent) not persisting after closing the Settings page
  * Settings now properly save and persist changes to disk before exit
  * Visual preference changes now correctly apply only to relevant UI panels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->