### PR TITLE
feat: file tree — `e` opens the highlighted file in an editor

### DIFF
--- a/.changeset/file-tree-edit-key.md
+++ b/.changeset/file-tree-edit-key.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": minor
+---
+
+File tree: `e` opens the highlighted file in your editor. `enter` stays the read-only preview/diff; the new `e` key opens the file in a fresh tmux window running your editor, and the window closes back to kobe when you quit it. Pick the editor under Settings → General → Editor: `vim`, `nano`, or a `custom` command (e.g. `code -w`, `subl -w`, `emacsclient`; use `{file}` to place the path, otherwise it's appended). An empty custom command falls back to `$VISUAL`/`$EDITOR`. If the chosen editor isn't installed, `e` falls back to the preview so it's never a dead key. The file pane footer shows `↵ preview · e edit`.

--- a/packages/kobe/src/tmux/editor-launch.ts
+++ b/packages/kobe/src/tmux/editor-launch.ts
@@ -1,0 +1,114 @@
+/**
+ * External-editor launch for the Ops pane's file tree (`e` key).
+ *
+ * The file tree has two open actions:
+ *   - `enter` → the in-TUI read-only preview/diff window (`openPreview`).
+ *   - `e`     → THIS: open the file in the user's real editor (vim / nano
+ *               / a custom command) in a fresh tmux window. When the
+ *               editor exits, tmux closes the window and switches back —
+ *               same transient-window pattern as the Settings page.
+ *
+ * Why shell out instead of editing in-pane: the preview is an opentui
+ * `<code>`/`<diff>` renderer with no cursor/insert/save. A real editable
+ * buffer would mean reimplementing a text editor in the TUI; launching
+ * vim/nano/$EDITOR is what lazygit/gitui do and it's strictly better.
+ *
+ * Fallback chain (KOB — file-editor-launch): if the configured editor's
+ * binary isn't on PATH (or `custom` is empty with no `$EDITOR`), this
+ * returns `false` and the caller falls back to the read-only preview, so
+ * `e` is never a dead key. We gate on "binary missing", NOT on the
+ * editor's exit code — a `:cq` / non-zero quit is a real edit session,
+ * not a launch failure, and must not bounce to preview.
+ *
+ * Settings (shared `state.json`, read cross-process via getPersistedString
+ * since the Ops host is its own process):
+ *   - `editor.kind`          "vim" | "nano" | "custom"   (default "vim")
+ *   - `editor.customCommand` e.g. `code -w` / `emacsclient` / `subl -w {file}`
+ */
+
+import { getPersistedString } from "@/state/repos"
+import { EDITOR_CUSTOM_KEY, EDITOR_KIND_KEY, type EditorKind, normalizeEditorKind } from "@/tui/lib/editor-prefs"
+import { newWindow } from "./client"
+import { shellQuote } from "./session-layout"
+
+/** Token replaced with the (shell-quoted) file path in a custom command. */
+const FILE_PLACEHOLDER = "{file}"
+
+/** First whitespace-delimited token of a command (the binary to probe). */
+function firstToken(cmd: string): string {
+  return cmd.trim().split(/\s+/)[0] ?? ""
+}
+
+/**
+ * Pure: build the shell command that opens `absPath` in the chosen editor.
+ * Returns `null` when nothing usable is configured (caller → preview).
+ *
+ * - vim / nano → `<bin> '<abs>'`
+ * - custom     → `customCommand`, with `{file}` substituted by the quoted
+ *                path, or the quoted path appended when no placeholder is
+ *                present. Empty custom falls back to `envEditor`
+ *                (`$VISUAL` / `$EDITOR`), then `null`.
+ *
+ * Kept pure (inputs in, strings out — no IO) so the quoting / substitution
+ * / fallback policy is unit-testable without a state.json, the same way
+ * `session-layout.ts` pulls its command builders out of the imperative
+ * tmux calls.
+ */
+export function buildEditorCommand(
+  kind: EditorKind,
+  customCommand: string,
+  absPath: string,
+  envEditor?: string,
+): { bin: string; command: string } | null {
+  const file = shellQuote(absPath)
+  if (kind === "vim") return { bin: "vim", command: `vim ${file}` }
+  if (kind === "nano") return { bin: "nano", command: `nano ${file}` }
+
+  const tmpl = (customCommand.trim() || (envEditor ?? "").trim()).trim()
+  if (!tmpl) return null
+  const bin = firstToken(tmpl)
+  if (!bin) return null
+  const command = tmpl.includes(FILE_PLACEHOLDER) ? tmpl.split(FILE_PLACEHOLDER).join(file) : `${tmpl} ${file}`
+  return { bin, command }
+}
+
+/**
+ * Resolve the editor command from persisted settings + env (the IO wrapper
+ * around {@link buildEditorCommand}). Read cross-process via
+ * getPersistedString since the Ops host is its own process.
+ */
+export function resolveEditorCommand(absPath: string): { bin: string; command: string } | null {
+  const kind = normalizeEditorKind(getPersistedString(EDITOR_KIND_KEY))
+  const custom = getPersistedString(EDITOR_CUSTOM_KEY) ?? ""
+  const env = process.env.VISUAL ?? process.env.EDITOR ?? ""
+  return buildEditorCommand(kind, custom, absPath, env)
+}
+
+/** Is `bin` resolvable on PATH (or as an absolute path)? Pre-flight for fallback. */
+export async function binaryAvailable(bin: string): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["sh", "-c", `command -v ${shellQuote(bin)} >/dev/null 2>&1`], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    })
+    return (await proc.exited) === 0
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Open `absPath` in the configured editor in a new tmux window of
+ * `session`. Returns `true` if the editor was launched, `false` if it
+ * couldn't be resolved / isn't installed (caller should fall back to the
+ * read-only preview). Not keep-alive-wrapped: when the editor exits, tmux
+ * closes the window and returns to the previous one.
+ */
+export async function openInEditor(session: string, worktree: string, absPath: string): Promise<boolean> {
+  const resolved = resolveEditorCommand(absPath)
+  if (!resolved) return false
+  if (!(await binaryAvailable(resolved.bin))) return false
+  await newWindow(session, { cwd: worktree, command: resolved.command, name: "edit" })
+  return true
+}

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -27,6 +27,14 @@ import type { VendorId } from "../../types/task"
 import { ALL_VENDORS } from "../../types/vendor"
 import type { KVContext } from "../context/kv"
 import { FOCUS_ACCENT_SLOTS, type FocusAccentSlot, useTheme } from "../context/theme"
+import {
+  DEFAULT_EDITOR_KIND,
+  EDITOR_CUSTOM_KEY,
+  EDITOR_KINDS,
+  EDITOR_KIND_KEY,
+  type EditorKind,
+  normalizeEditorKind,
+} from "../lib/editor-prefs"
 import { useBindings } from "../lib/keymap"
 import {
   DEFAULT_SETTINGS_SURFACE,
@@ -42,6 +50,8 @@ import {
   SECTIONS,
   type SectionId,
   bodyRowCount as countBodyRows,
+  editorCustomRowIndex,
+  editorKindRowIndex,
   focusAccentRowIndex,
   soundRowIndex,
   surfaceChattabRowIndex,
@@ -134,6 +144,14 @@ export function SettingsDialog(props: SettingsDialogProps) {
     )
   }
 
+  function isEditorKindRow(): boolean {
+    return section() === "general" && bodyRow() === editorKindRowIndex(themeNames().length, FOCUS_ACCENT_SLOTS.length)
+  }
+
+  function isEditorCustomRow(): boolean {
+    return section() === "general" && bodyRow() === editorCustomRowIndex(themeNames().length, FOCUS_ACCENT_SLOTS.length)
+  }
+
   function settingsSurface(): SettingsSurface {
     return normalizeSettingsSurface(props.kv.get(SETTINGS_SURFACE_KEY, DEFAULT_SETTINGS_SURFACE))
   }
@@ -204,6 +222,30 @@ export function SettingsDialog(props: SettingsDialogProps) {
     props.kv.set(engineCommandKey(vendor), next.trim())
   }
 
+  // Editor preference: which editor the file tree's `e` key launches.
+  // `editor.kind` cycles vim → nano → custom on enter; the custom command
+  // is a free-text field (reused RenameTaskDialog) used only when
+  // kind === "custom". Read cross-process by tmux/editor-launch.
+  function editorKind(): EditorKind {
+    return normalizeEditorKind(props.kv.get(EDITOR_KIND_KEY, DEFAULT_EDITOR_KIND))
+  }
+  function cycleEditorKind(): void {
+    const i = EDITOR_KINDS.indexOf(editorKind())
+    const next = EDITOR_KINDS[(i + 1) % EDITOR_KINDS.length]
+    if (next) props.kv.set(EDITOR_KIND_KEY, next)
+  }
+  function editorCustomCommand(): string {
+    const v = props.kv.get(EDITOR_CUSTOM_KEY, "")
+    return typeof v === "string" ? v : ""
+  }
+  async function editEditorCustom(): Promise<void> {
+    const next = await RenameTaskDialog.show(dialog, editorCustomCommand(), {
+      dialogTitle: "Custom editor command (use {file} for the path)",
+    })
+    if (next === undefined) return
+    props.kv.set(EDITOR_CUSTOM_KEY, next.trim())
+  }
+
   function enterBody(): void {
     if (level() !== "sidebar" || bodyRowCount() === 0) return
     setLevel("body")
@@ -262,6 +304,14 @@ export function SettingsDialog(props: SettingsDialogProps) {
       }
       if (isSurfaceTaskpanelRow()) {
         selectSurface("taskpanel")
+        return
+      }
+      if (isEditorKindRow()) {
+        cycleEditorKind()
+        return
+      }
+      if (isEditorCustomRow()) {
+        void editEditorCustom()
         return
       }
       const name = themeNames()[bodyRow()]
@@ -337,6 +387,10 @@ export function SettingsDialog(props: SettingsDialogProps) {
               toggleSound={toggleSound}
               settingsSurface={settingsSurface}
               selectSurface={selectSurface}
+              editorKind={editorKind}
+              cycleEditorKind={cycleEditorKind}
+              editorCustomCommand={editorCustomCommand}
+              editEditorCustom={() => void editEditorCustom()}
             />
           </Show>
           <Show when={section() === "engines"}>

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -39,7 +39,8 @@ export function devRowCount(hasDaemon: boolean): number {
 export function generalRowCount(themeCount: number, focusAccentCount: number): number {
   // themes + transparent(1) + focus accents + toast(1) + sound(1)
   //   + settings surface: ChatTab(1) + Task panel(1)
-  return themeCount + 1 + focusAccentCount + 4
+  //   + editor: kind select(1) + custom command(1)
+  return themeCount + 1 + focusAccentCount + 6
 }
 
 export function bodyRowCount(
@@ -85,4 +86,17 @@ export function surfaceChattabRowIndex(themeCount: number, focusAccentCount: num
 
 export function surfaceTaskpanelRowIndex(themeCount: number, focusAccentCount: number): number {
   return surfaceChattabRowIndex(themeCount, focusAccentCount) + 1
+}
+
+/**
+ * Editor preference rows at the very end of the General section: the
+ * kind select (vim / nano / custom), then the custom-command field. Kept
+ * last so adding them doesn't shift any existing row index.
+ */
+export function editorKindRowIndex(themeCount: number, focusAccentCount: number): number {
+  return surfaceTaskpanelRowIndex(themeCount, focusAccentCount) + 1
+}
+
+export function editorCustomRowIndex(themeCount: number, focusAccentCount: number): number {
+  return editorKindRowIndex(themeCount, focusAccentCount) + 1
 }

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -4,12 +4,15 @@ import type { ClaudeAccount, CodexAccount, CopilotAccount, EngineAccountStatus }
 import { VENDOR_LABEL } from "../../../engine/interactive-command"
 import type { VendorId } from "../../../types/task"
 import { FOCUS_ACCENT_SLOTS, useTheme } from "../../context/theme"
+import type { EditorKind } from "../../lib/editor-prefs"
 import type { SettingsSurface } from "../../lib/settings-surface"
 import {
   FOCUS_ACCENT_LABEL,
   type NavLevel,
   SECTIONS,
   type SectionId,
+  editorCustomRowIndex,
+  editorKindRowIndex,
   soundRowIndex,
   surfaceChattabRowIndex,
   surfaceTaskpanelRowIndex,
@@ -71,6 +74,10 @@ export function GeneralSettingsSection(
     toggleSound: () => void
     settingsSurface: Accessor<SettingsSurface>
     selectSurface: (surface: SettingsSurface) => void
+    editorKind: Accessor<EditorKind>
+    cycleEditorKind: () => void
+    editorCustomCommand: Accessor<string>
+    editEditorCustom: () => void
   },
 ) {
   const themeCtx = useTheme()
@@ -79,11 +86,15 @@ export function GeneralSettingsSection(
   const soundRow = () => soundRowIndex(props.themeNames().length, FOCUS_ACCENT_SLOTS.length)
   const surfaceChattabRow = () => surfaceChattabRowIndex(props.themeNames().length, FOCUS_ACCENT_SLOTS.length)
   const surfaceTaskpanelRow = () => surfaceTaskpanelRowIndex(props.themeNames().length, FOCUS_ACCENT_SLOTS.length)
+  const editorKindRow = () => editorKindRowIndex(props.themeNames().length, FOCUS_ACCENT_SLOTS.length)
+  const editorCustomRow = () => editorCustomRowIndex(props.themeNames().length, FOCUS_ACCENT_SLOTS.length)
   const isTransparentRow = () => props.bodyRow() === transparentRowIndex(props.themeNames().length)
   const isToastRow = () => props.bodyRow() === toastRow()
   const isSoundRow = () => props.bodyRow() === soundRow()
   const isSurfaceChattabRow = () => props.bodyRow() === surfaceChattabRow()
   const isSurfaceTaskpanelRow = () => props.bodyRow() === surfaceTaskpanelRow()
+  const isEditorKindRow = () => props.bodyRow() === editorKindRow()
+  const isEditorCustomRow = () => props.bodyRow() === editorCustomRow()
 
   return (
     <box flexDirection="column" gap={1}>
@@ -301,6 +312,60 @@ export function GeneralSettingsSection(
             wrapMode="none"
           >
             {props.settingsSurface() === "taskpanel" ? "[x]" : "[ ]"} Task panel (in-pane overlay)
+          </text>
+        </box>
+      </box>
+      <box flexDirection="column" gap={0} paddingTop={1}>
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Editor
+        </text>
+        <text fg={theme.textMuted} wrapMode="word">
+          What `e` opens a file with in the file tree (enter stays the read-only preview). enter cycles vim / nano /
+          custom; if the editor isn't installed it falls back to the preview.
+        </text>
+        <box
+          flexDirection="row"
+          gap={1}
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={isEditorKindRow() ? theme.primary : undefined}
+          onMouseUp={() => {
+            props.setLevel("body")
+            props.setBodyRow(editorKindRow())
+            props.cycleEditorKind()
+          }}
+        >
+          <text
+            fg={isEditorKindRow() ? theme.selectedListItemText : theme.accent}
+            attributes={TextAttributes.BOLD}
+            wrapMode="none"
+          >
+            {`< ${props.editorKind()} >`}
+          </text>
+        </box>
+        <box
+          flexDirection="row"
+          gap={1}
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={isEditorCustomRow() ? theme.primary : undefined}
+          onMouseUp={() => {
+            props.setLevel("body")
+            props.setBodyRow(editorCustomRow())
+            props.editEditorCustom()
+          }}
+        >
+          <text
+            fg={
+              isEditorCustomRow()
+                ? theme.selectedListItemText
+                : props.editorKind() === "custom"
+                  ? theme.text
+                  : theme.textMuted
+            }
+            wrapMode="none"
+          >
+            {`custom: ${props.editorCustomCommand().trim() || "(unset — enter to edit)"}`}
           </text>
         </box>
       </box>

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -648,8 +648,21 @@ export const KobeKeymap: readonly KobeBinding[] = [
     scope: "files",
     keys: ["return"],
     category: "Files",
-    description: "Open file",
-    hint: { keys: "enter", label: "open" },
+    description: "Open file read-only preview",
+    hint: { keys: "enter", label: "preview" },
+  },
+  {
+    // `e` → open the current file in the configured editor (vim / nano /
+    // custom) in a new tmux window. Separate, deliberate action from the
+    // `enter` read-only preview — no preview→edit bridge. Plain letter,
+    // files-scoped per the keybinding-boundaries rule (docs/KEYBINDINGS.md)
+    // so it can't collide with composer typing.
+    id: "files.edit",
+    scope: "files",
+    keys: ["e"],
+    category: "Files",
+    description: "Open file in the configured editor (vim / nano / custom)",
+    hint: { keys: "e", label: "edit" },
   },
   {
     // `[` / `]` cycle the All / Changes tabs. Bracket pair matches

--- a/packages/kobe/src/tui/lib/editor-prefs.ts
+++ b/packages/kobe/src/tui/lib/editor-prefs.ts
@@ -1,0 +1,29 @@
+/**
+ * Editor preference — pure constants + normalization, no IO / no tmux.
+ *
+ * Split out (mirroring `settings-surface.ts`) so the Settings dialog can
+ * read/write the editor prefs via its reactive `kv` WITHOUT importing
+ * `tmux/editor-launch.ts` (which pulls in the tmux client). The launcher
+ * imports these same constants so both sides agree on the keys.
+ *
+ * `e` in the file tree opens the current file in this editor; `editor.kind`
+ * picks which, `editor.customCommand` is the command for `kind === "custom"`.
+ */
+
+/** Which editor the file tree's `e` key launches. */
+export type EditorKind = "vim" | "nano" | "custom"
+
+/** Cycle order for the Settings select row. */
+export const EDITOR_KINDS: readonly EditorKind[] = ["vim", "nano", "custom"]
+
+/** Shared `state.json` keys. */
+export const EDITOR_KIND_KEY = "editor.kind"
+export const EDITOR_CUSTOM_KEY = "editor.customCommand"
+
+/** Default when unset: the most universally-present terminal editor. */
+export const DEFAULT_EDITOR_KIND: EditorKind = "vim"
+
+/** Coerce an unknown persisted value to a valid kind (default vim). */
+export function normalizeEditorKind(value: unknown): EditorKind {
+  return value === "nano" || value === "custom" || value === "vim" ? value : DEFAULT_EDITOR_KIND
+}

--- a/packages/kobe/src/tui/ops/host.tsx
+++ b/packages/kobe/src/tui/ops/host.tsx
@@ -22,6 +22,7 @@ import { kobeCliInvocation } from "@/cli/invocation"
 import { type ChatTabTurnState, createEngineTurnDetector } from "@/engine/turn-detector"
 import { latestTranscriptMtime } from "@/monitor/activity"
 import { capturePaneById, newWindow, sendKeyName, sendKeys, setWindowOption, tmuxSessionName } from "@/tmux/client"
+import { openInEditor } from "@/tmux/editor-launch"
 import { previewWindowCommand } from "@/tmux/session-layout"
 import type { VendorId } from "@/types/task"
 import { SyntaxStyle } from "@opentui/core"
@@ -176,6 +177,24 @@ function OpsShell(props: OpsHostArgs & { prefs: ThemePrefs }) {
     })
   }
 
+  // `e` on a file → open it in the user's editor (vim / nano / custom) in
+  // a fresh tmux window. Read-only preview (enter) and editor (e) are
+  // separate, deliberate actions — no preview→edit bridge. If the editor
+  // can't launch (binary missing / nothing configured), fall back to the
+  // read-only preview so `e` is never a dead key. Same phantom-session
+  // guard as `openPreview`: a standalone `kobe ops` (no task id) has no
+  // session to open a window in, so just preview.
+  function openEditor(rel: string): void {
+    if (!props.taskId) {
+      openPreview(rel)
+      return
+    }
+    const abs = `${props.worktree}/${rel}`
+    void openInEditor(tmuxSessionName(props.taskId), props.worktree, abs).then((launched) => {
+      if (!launched) openPreview(rel)
+    })
+  }
+
   // `a` on a file → inject `@<path> ` into the engine pane via tmux
   // send-keys (KOB-232). `targetPane` is the claude/codex pane id passed
   // by the launcher (`opsPaneCommand --target-pane`). Literal send (the
@@ -201,6 +220,7 @@ function OpsShell(props: OpsHostArgs & { prefs: ThemePrefs }) {
         worktreePath={() => props.worktree}
         focused={() => true}
         onOpenFile={openPreview}
+        onEditFile={openEditor}
         onMention={injectMention}
         onCreatePR={() => void createPR()}
         cornerBadge={cornerBadge}

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -91,6 +91,14 @@ export type FileTreeProps = {
    */
   onOpenFile: (relPath: string) => void
   /**
+   * Fires when the user requests to EDIT the current file (the `e` key) —
+   * the Ops host opens it in the configured editor (vim / nano / custom)
+   * in a new tmux window. Distinct from `onOpenFile` (enter), which is the
+   * read-only preview. Omit it elsewhere (the key no-ops on dirs / when
+   * unwired).
+   */
+  onEditFile?: (relPath: string) => void
+  /**
    * Fires when the user requests an `@<path>` mention of the current
    * file (the `a` key). The Ops host wires this to a tmux send-keys
    * injection into the engine pane; omit it elsewhere (the key no-ops).
@@ -480,6 +488,15 @@ export function FileTree(props: FileTreeProps) {
     if (!row || row.kind === "dir") return
     props.onMention?.(row.path)
   }
+  function editCurrent(): void {
+    const r = rows()
+    const i = cursorIndex()
+    if (i < 0 || i >= r.length) return
+    const row = r[i]
+    // Only files open in an editor; dirs are ignored (enter toggles them).
+    if (!row || row.kind === "dir") return
+    props.onEditFile?.(row.path)
+  }
   function refresh(): void {
     setRefreshTick((n) => n + 1)
     props.onRefresh?.()
@@ -504,6 +521,7 @@ export function FileTree(props: FileTreeProps) {
     currentTab: tab,
     openCurrent,
     mentionCurrent,
+    editCurrent,
     createPR: props.onCreatePR,
     openExternal,
     refresh,
@@ -748,6 +766,18 @@ export function FileTree(props: FileTreeProps) {
           </box>
         </Show>
       </scrollbox>
+
+      {/* Footer hint — the two file-open actions. `enter` is the read-only
+         preview/diff; `e` opens the file in the configured editor
+         (vim / nano / custom) in a new tmux window. Shown only when a
+         worktree is loaded so the "no task" placeholder stays clean. */}
+      <Show when={props.worktreePath() != null}>
+        <box flexDirection="row" paddingTop={1} flexShrink={0}>
+          <text fg={theme.textMuted} wrapMode="none">
+            ↵ preview · e edit
+          </text>
+        </box>
+      </Show>
     </box>
   )
 }

--- a/packages/kobe/src/tui/panes/filetree/keys.ts
+++ b/packages/kobe/src/tui/panes/filetree/keys.ts
@@ -5,7 +5,8 @@
  *   - `j` / `down`         next row
  *   - `k` / `up`           previous row
  *   - `1` / `2` / `3`      switch to All / Changes / Checks tab
- *   - `enter` / `return`   open current file (calls `onOpenFile`)
+ *   - `enter` / `return`   open current file read-only preview (calls `onOpenFile`)
+ *   - `e`                  open current file in the editor (calls `onEditFile`)
  *   - `a`                  inject current file as `@<path>` (calls `onMention`)
  *   - `p`                  create PR prompt (Ops host only)
  *   - `r`                  refresh (re-run git commands)
@@ -56,6 +57,8 @@ export type FileTreeBindingsOpts = {
   openCurrent: () => void
   /** `a` — inject the current file as an `@<path>` mention (Ops host only). */
   mentionCurrent?: () => void
+  /** `e` — open the current file in the configured editor (Ops host only). */
+  editCurrent?: () => void
   /** `p` — inject the Create PR prompt into the engine pane (Ops host only). */
   createPR?: () => void
   /** Hand the current row off to the OS default app (audio, video, PDF). */
@@ -95,6 +98,7 @@ export function useFileTreeBindings(opts: FileTreeBindingsOpts): void {
         if (next) opts.setTab(next)
       },
       "files.open": () => opts.openCurrent(),
+      "files.edit": () => opts.editCurrent?.(),
       "files.mention": () => opts.mentionCurrent?.(),
       "files.createPR": () => opts.createPR?.(),
       "files.openExternal": () => opts.openExternal(),

--- a/packages/kobe/test/tmux/editor-launch.test.ts
+++ b/packages/kobe/test/tmux/editor-launch.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { buildEditorCommand } from "../../src/tmux/editor-launch.ts"
+import { DEFAULT_EDITOR_KIND, normalizeEditorKind } from "../../src/tui/lib/editor-prefs.ts"
+
+describe("buildEditorCommand", () => {
+  it("vim / nano open the shell-quoted path", () => {
+    expect(buildEditorCommand("vim", "", "/wt/src/a.ts")).toEqual({ bin: "vim", command: "vim '/wt/src/a.ts'" })
+    expect(buildEditorCommand("nano", "", "/wt/b.md")).toEqual({ bin: "nano", command: "nano '/wt/b.md'" })
+  })
+
+  it("vim / nano ignore any custom command", () => {
+    expect(buildEditorCommand("vim", "code -w", "/wt/a.ts")?.command).toBe("vim '/wt/a.ts'")
+  })
+
+  it("custom appends the quoted path when there's no {file} placeholder", () => {
+    expect(buildEditorCommand("custom", "code -w", "/wt/a.ts")).toEqual({
+      bin: "code",
+      command: "code -w '/wt/a.ts'",
+    })
+  })
+
+  it("custom substitutes {file} in place (every occurrence)", () => {
+    expect(buildEditorCommand("custom", "emacsclient {file}", "/wt/a.ts")?.command).toBe("emacsclient '/wt/a.ts'")
+    expect(buildEditorCommand("custom", "diff {file} {file}", "/wt/a.ts")?.command).toBe("diff '/wt/a.ts' '/wt/a.ts'")
+  })
+
+  it("custom binary token is the first word (for the PATH pre-flight)", () => {
+    expect(buildEditorCommand("custom", "subl -w -n", "/wt/a.ts")?.bin).toBe("subl")
+  })
+
+  it("empty custom falls back to $VISUAL/$EDITOR", () => {
+    expect(buildEditorCommand("custom", "", "/wt/a.ts", "hx")).toEqual({ bin: "hx", command: "hx '/wt/a.ts'" })
+    expect(buildEditorCommand("custom", "   ", "/wt/a.ts", "code -w {file}")?.command).toBe("code -w '/wt/a.ts'")
+  })
+
+  it("returns null when custom is empty and no env editor is set (caller → preview)", () => {
+    expect(buildEditorCommand("custom", "", "/wt/a.ts")).toBeNull()
+    expect(buildEditorCommand("custom", "", "/wt/a.ts", "")).toBeNull()
+  })
+
+  it("shell-escapes a path with spaces and quotes", () => {
+    expect(buildEditorCommand("vim", "", "/wt/a b/it's.ts")?.command).toBe("vim '/wt/a b/it'\\''s.ts'")
+  })
+})
+
+describe("normalizeEditorKind", () => {
+  it("passes through valid kinds", () => {
+    expect(normalizeEditorKind("vim")).toBe("vim")
+    expect(normalizeEditorKind("nano")).toBe("nano")
+    expect(normalizeEditorKind("custom")).toBe("custom")
+  })
+
+  it("defaults to vim for unset / unknown values", () => {
+    expect(normalizeEditorKind(undefined)).toBe(DEFAULT_EDITOR_KIND)
+    expect(normalizeEditorKind("emacs")).toBe("vim")
+    expect(normalizeEditorKind(42)).toBe("vim")
+  })
+})


### PR DESCRIPTION
## What

The file tree gets a second open action. `enter` stays the read-only preview/diff; the new **`e`** key opens the highlighted file in the user's editor in a fresh tmux window that closes back to kobe when you quit it.

Two keys, two deliberate actions — no preview→edit bridge. The pane footer shows `↵ preview · e edit`.

## Editor selection

Settings → **General → Editor**:
- `editor.kind`: `vim` / `nano` / `custom` (cycles on enter; default `vim`)
- `editor.customCommand`: e.g. `code -w`, `subl -w`, `emacsclient`. Use `{file}` to place the path, otherwise it's appended. Empty custom falls back to `$VISUAL`/`$EDITOR`.

## Fallback

If the chosen editor's binary isn't on PATH (or `custom` is empty with no `$EDITOR`), `e` falls back to the read-only preview, so it's never a dead key. The gate is **"binary missing"**, not the editor's exit code — a `:cq` / non-zero quit is a real edit session and must not bounce to preview.

## How it works

- `tmux/editor-launch.ts` — pure `buildEditorCommand(kind, custom, abs, env)` (quoting + `{file}` substitution + fallback policy, unit-tested like `session-layout.ts`), wrapped by `resolveEditorCommand` (reads state.json cross-process) + a PATH pre-flight. Launches via `newWindow` with no keep-alive, so tmux closes the window on editor exit (same pattern as the Settings page).
- `tui/lib/editor-prefs.ts` — pure constants/type/normalize, split out so the Settings dialog reads the prefs without importing the tmux client.
- Ops host routes `e` → `openEditor` → editor-or-preview; `FileTree` gains `onEditFile` + the footer hint; `files.edit` registered as a files-scoped `e` (no collision — follows the existing `a`/`o`/`p`/`r` plain-letter pattern).
- Settings General section gains the kind-select + custom-command rows (custom reuses `RenameTaskDialog` for free-text).

## Tests

- `test/tmux/editor-launch.test.ts` — 10 cases: vim/nano, custom append vs `{file}`, first-token binary, `$EDITOR` fallback, null (→ preview), shell-escaping; plus `normalizeEditorKind`.
- typecheck clean · biome clean · full fast suite **292 passing** (+10).

## Manual QA suggestion

`bun run dev:sandbox`, file tree → `e` opens vim; Settings → custom = a nonexistent command → `e` falls back to preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Open files directly in your configured editor from the file tree using the `e` key
  * Add editor preferences in settings to choose between vim, nano, or custom editor

* **UI Updates**
  * Updated file tree keybindings: press `enter` for read-only preview or `e` to open in editor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->