### PR TITLE
fix: file-tree editor (`e`) follow-ups — key-swallow, scroll, custom auto-switch, file-named window

### DIFF
--- a/.changeset/file-editor-launch-fixes.md
+++ b/.changeset/file-editor-launch-fixes.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+File-tree editor (`e`) follow-up fixes:
+
+- **Custom command was un-typeable on the standalone Settings page** — the dialog's `j/k/l/h/t` navigation kept firing under the open text input and swallowed those letters (you couldn't type the `l` in `{file}`). The dialog now suspends its own key bindings while a sub-dialog is open.
+- **A custom command typed while the kind was still `vim` was silently ignored** — setting a non-empty custom command now auto-switches the editor kind to `custom` so it actually takes effect.
+- **The editor kind row was unlabelled** (`< vim >`), easy to miss above the custom-command row — it now reads `editor: < vim >  (enter to change)`.
+- **The standalone Settings page jumbled its text** when the content was taller than the window — the page now scrolls instead of compressing the rows.
+- The editor opens in a tmux window named after the **file** being edited (matching the preview window) so several open files are easy to tell apart.

--- a/packages/kobe/src/tmux/editor-launch.ts
+++ b/packages/kobe/src/tmux/editor-launch.ts
@@ -109,6 +109,16 @@ export async function openInEditor(session: string, worktree: string, absPath: s
   const resolved = resolveEditorCommand(absPath)
   if (!resolved) return false
   if (!(await binaryAvailable(resolved.bin))) return false
-  await newWindow(session, { cwd: worktree, command: resolved.command, name: "edit" })
+  // Name the window after the FILE being edited (its basename), matching
+  // the read-only preview window's labelling. With several files open this
+  // is what tells the tmux window list apart; which editor it is, is
+  // obvious from the editor's own UI.
+  await newWindow(session, { cwd: worktree, command: resolved.command, name: editorWindowLabel(absPath) })
   return true
+}
+
+/** Basename of the file path, for the tmux window label (the edited file). */
+export function editorWindowLabel(absPath: string): string {
+  const base = absPath.slice(absPath.lastIndexOf("/") + 1).trim()
+  return base.length > 0 ? base : "edit"
 }

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -76,6 +76,19 @@ export type SettingsDialogProps = {
   orchestrator?: KobeOrchestrator
   onVisualPrefsChange?: () => void
   onClose: () => void
+  /**
+   * True when this dialog is the standalone page surface (`kobe settings`),
+   * rendered OUTSIDE the dialog stack rather than pushed onto it. The page
+   * mounts this component permanently, so when it opens a sub-dialog (the
+   * engine-command / custom-editor text input) this component stays mounted
+   * underneath. Without a guard its `j/k/l/h/t` navigation bindings would
+   * keep firing and swallow those letters from the text input (the `{file}`
+   * "l-is-eaten" bug). When standalone we therefore disable our own key
+   * bindings whenever the dialog stack is non-empty — mirroring the page's
+   * own esc/q guard. In the overlay surface this dialog IS the stack entry
+   * and unmounts when a sub-dialog replaces it, so no guard is needed.
+   */
+  standalone?: boolean
 }
 
 export function SettingsDialog(props: SettingsDialogProps) {
@@ -243,7 +256,13 @@ export function SettingsDialog(props: SettingsDialogProps) {
       dialogTitle: "Custom editor command (use {file} for the path)",
     })
     if (next === undefined) return
-    props.kv.set(EDITOR_CUSTOM_KEY, next.trim())
+    const cmd = next.trim()
+    props.kv.set(EDITOR_CUSTOM_KEY, cmd)
+    // If the user bothered to type a command here, they want it used —
+    // flip the kind to `custom` so it actually takes effect. Without this,
+    // a command typed while kind is still `vim` is silently ignored (you'd
+    // set `code -w` / `nano` and still get vim), which reads as a bug.
+    if (cmd) props.kv.set(EDITOR_KIND_KEY, "custom")
   }
 
   function enterBody(): void {
@@ -330,6 +349,12 @@ export function SettingsDialog(props: SettingsDialogProps) {
   }
 
   useBindings(() => ({
+    // On the standalone page, suspend our navigation keys while a
+    // sub-dialog (the engine-command / custom-editor text input) is open
+    // so `l`/`t`/`j`/`k`/`h` reach the input instead of being eaten by
+    // this dialog's nav. The overlay surface unmounts us when covered, so
+    // there it's always enabled.
+    enabled: !props.standalone || dialog.stack.length === 0,
     bindings: [
       { key: "down", cmd: () => moveCursor(1) },
       { key: "up", cmd: () => moveCursor(-1) },

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -320,8 +320,8 @@ export function GeneralSettingsSection(
           Editor
         </text>
         <text fg={theme.textMuted} wrapMode="word">
-          What `e` opens a file with in the file tree (enter stays the read-only preview). enter cycles vim / nano /
-          custom; if the editor isn't installed it falls back to the preview.
+          What `e` opens a file with in the file tree (enter stays the read-only preview). enter on the row below cycles
+          vim / nano / custom; if the editor isn't installed it falls back to the preview.
         </text>
         <box
           flexDirection="row"
@@ -340,7 +340,7 @@ export function GeneralSettingsSection(
             attributes={TextAttributes.BOLD}
             wrapMode="none"
           >
-            {`< ${props.editorKind()} >`}
+            {`editor: < ${props.editorKind()} >  (enter to change)`}
           </text>
         </box>
         <box

--- a/packages/kobe/src/tui/settings/host.tsx
+++ b/packages/kobe/src/tui/settings/host.tsx
@@ -80,16 +80,27 @@ function SettingsPage(props: {
   }))
 
   return (
-    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background} paddingTop={1}>
+    // Scroll, don't compress. The full-window page has no fixed-height card
+    // like the overlay's Dialog, so when the section content is taller than
+    // the tmux window Yoga shrinks the flex rows and they overlap into an
+    // unreadable jumble. A scrollbox gives the content its natural height
+    // and scrolls the overflow instead, so every section row stays legible.
+    <scrollbox
+      flexGrow={1}
+      backgroundColor={theme.background}
+      paddingTop={1}
+      verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
+    >
       <SettingsDialog
         kv={kv}
         orchestrator={props.orchestrator ?? undefined}
+        standalone={true}
         onVisualPrefsChange={() => {
           visualPrefsChanged = true
         }}
         onClose={exit}
       />
-    </box>
+    </scrollbox>
   )
 }
 

--- a/packages/kobe/test/tmux/editor-launch.test.ts
+++ b/packages/kobe/test/tmux/editor-launch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { buildEditorCommand } from "../../src/tmux/editor-launch.ts"
+import { buildEditorCommand, editorWindowLabel } from "../../src/tmux/editor-launch.ts"
 import { DEFAULT_EDITOR_KIND, normalizeEditorKind } from "../../src/tui/lib/editor-prefs.ts"
 
 describe("buildEditorCommand", () => {
@@ -40,6 +40,19 @@ describe("buildEditorCommand", () => {
 
   it("shell-escapes a path with spaces and quotes", () => {
     expect(buildEditorCommand("vim", "", "/wt/a b/it's.ts")?.command).toBe("vim '/wt/a b/it'\\''s.ts'")
+  })
+})
+
+describe("editorWindowLabel", () => {
+  it("labels the tmux window with the edited file's name (basename)", () => {
+    expect(editorWindowLabel("/wt/src/index.ts")).toBe("index.ts")
+    expect(editorWindowLabel("/wt/a b/it's.md")).toBe("it's.md")
+    expect(editorWindowLabel("README")).toBe("README")
+  })
+
+  it("falls back to 'edit' for an empty path", () => {
+    expect(editorWindowLabel("")).toBe("edit")
+    expect(editorWindowLabel("  ")).toBe("edit")
   })
 })
 

--- a/packages/kobe/test/tui/keymap-dispatch.test.ts
+++ b/packages/kobe/test/tui/keymap-dispatch.test.ts
@@ -94,6 +94,33 @@ describe("dispatchKeyEvent", () => {
     expect(evt.defaultPrevented).toBe(true)
   })
 
+  test("a disabled matching group lets the key fall through (the settings `{file}` l-eaten fix)", () => {
+    // Repro of the bug: the standalone Settings page kept `l`=enterBody
+    // active under an open text input, swallowing the `l` in `{file}`.
+    // The fix disables that nav group while a sub-dialog is open; with it
+    // disabled and no other group binding `l`, dispatch must return false
+    // so the native <input> receives the keystroke.
+    let navFired = false
+    const stack: RegisteredBinding[] = [
+      makeReg(
+        1,
+        "l",
+        () => {
+          navFired = true
+        },
+        /* enabled */ false,
+      ), // settings nav, suspended while the input dialog is open
+      makeReg(2, "escape", () => {}), // the input dialog only binds escape
+    ]
+    const evt = makeEvt("l")
+
+    const handled = dispatchKeyEvent(stack, evt)
+
+    expect(handled).toBe(false)
+    expect(navFired).toBe(false)
+    expect(evt.defaultPrevented).toBe(false)
+  })
+
   test("an already-prevented event short-circuits without firing anything", () => {
     let fired = false
     const stack: RegisteredBinding[] = [


### PR DESCRIPTION
Follow-up fixes for the file-tree editor (`e`) shipped in #90. #90 merged the **first commit only**, so these polish/bug fixes never made it to main. This PR adds them on top of current main, touching only the editor files.

## Fixes

- **Custom command was un-typeable on the standalone Settings page.** The dialog's `j/k/l/h/t` navigation kept firing under the open text input and swallowed those letters — you couldn't type the `l` in `{file}` (or the `l` in `claude` when editing an engine command). The dialog now suspends its own key bindings while a sub-dialog is open, on the standalone page surface. (`settings-dialog.tsx` `standalone` + guard; `settings/host.tsx`.)
- **A custom command typed while kind was still `vim` was silently ignored** (you'd set `nano`/`code` and still get vim — reads as a bug). Setting a non-empty custom command now auto-switches `editor.kind` to `custom`.
- **The editor kind row was unlabelled** (`< vim >`), easy to miss above the custom row. Now `editor: < vim >  (enter to change)`.
- **The standalone Settings page jumbled its text** when content was taller than the window (Yoga compressed the flex rows into overlap). The page now scrolls.
- **Editor window is named after the file** being edited (matching the preview window) so multiple open files are distinguishable.

## Tests

- `editor-launch.test.ts`: `editorWindowLabel` now tests file-basename labelling.
- `keymap-dispatch.test.ts`: a disabled matching group lets the key fall through to the native input (the `{file}` l-eaten invariant).
- typecheck clean · biome clean · fast suite passing.

## Note

main's #90 is the partial/buggy first commit; per the author's call we keep it and layer these fixes rather than revert. The pending `revert-90` branch is independent.