### PR TITLE
fix: filepane git polling drops optional index.lock to stop racing engine commits

### DIFF
--- a/.changeset/filepane-git-optional-locks.md
+++ b/.changeset/filepane-git-optional-locks.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Stop the file/changes panes from racing the engine for `.git/index.lock`.
+
+The sidebar's per-row `+N −M` chip polls `git status` every 2s, and the file-tree and Ops panes run `git status`/`git diff` on demand. Those commands aren't purely read-only — git opportunistically rewrites `.git/index`'s stat cache, which takes `.git/index.lock`. Running on a poll across every worktree (and across multiple ChatTab pane processes) meant they could collide with the worktree's own engine `git commit`/`git add`, surfacing as intermittent `fatal: Unable to create '.git/index.lock': File exists` errors.
+
+All pane-side inspection git calls now run with `GIT_OPTIONAL_LOCKS=0`, so they inspect without writing the index or taking the lock. Real writes (engine commits, worktree create/remove, branch rename) are unaffected and still lock as they should.

--- a/packages/kobe/src/tui/ops/host.tsx
+++ b/packages/kobe/src/tui/ops/host.tsx
@@ -299,6 +299,11 @@ async function gitDiff(worktree: string, relPath: string): Promise<string> {
       stdin: "ignore",
       stdout: "pipe",
       stderr: "ignore",
+      // Read-only diff for the preview. `git diff` would otherwise
+      // rewrite `.git/index`'s stat cache and take `.git/index.lock`,
+      // racing the worktree's engine commits for the lock.
+      // `GIT_OPTIONAL_LOCKS=0` keeps it lock-free.
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
     })
     const text = await new Response(proc.stdout).text()
     await proc.exited

--- a/packages/kobe/src/tui/ops/pr-prompt.ts
+++ b/packages/kobe/src/tui/ops/pr-prompt.ts
@@ -36,6 +36,11 @@ function git(cwd: string, args: readonly string[]): string | null {
       cwd,
       encoding: "utf8",
       timeout: GIT_TIMEOUT_MS,
+      // Read-only inspection (`status`, `rev-parse`, `symbolic-ref`).
+      // `git status` would otherwise rewrite `.git/index`'s stat cache
+      // and take `.git/index.lock`, racing the worktree's engine commits
+      // for the lock. `GIT_OPTIONAL_LOCKS=0` keeps it lock-free.
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
     })
     if (out.error) return null
     if (out.status !== 0) return null

--- a/packages/kobe/src/tui/panes/filetree/git.ts
+++ b/packages/kobe/src/tui/panes/filetree/git.ts
@@ -80,6 +80,12 @@ export const gitWrapper = {
         cwd,
         shell: false,
         stdio: ["ignore", "pipe", "pipe"],
+        // All callers here are read-only inspection (`status`, `diff`,
+        // `ls-files`). `git status`/`diff` would otherwise rewrite
+        // `.git/index`'s stat cache and take `.git/index.lock`, racing
+        // the worktree's engine commits and the sidebar poll for the
+        // lock. `GIT_OPTIONAL_LOCKS=0` suppresses that optional write.
+        env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
       })
       let stdout = ""
       let stderr = ""

--- a/packages/kobe/src/tui/panes/sidebar/git-head.ts
+++ b/packages/kobe/src/tui/panes/sidebar/git-head.ts
@@ -49,6 +49,11 @@ export function readCurrentBranch(repo: string): string {
       cwd: repo,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      // Uniform pane-side policy: read-only git inspection never takes
+      // optional locks. `symbolic-ref`/`rev-parse` don't write the index
+      // today, but setting this keeps every pane git call lock-free so a
+      // future command swap can't reintroduce `.git/index.lock` races.
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
     })
     if (out.status === 0 && out.stdout) {
       const name = out.stdout.trim()
@@ -60,6 +65,7 @@ export function readCurrentBranch(repo: string): string {
       cwd: repo,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
     })
     if (head.status === 0) return "(detached)"
     return ""

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
@@ -53,6 +53,12 @@ export function readWorktreeChanges(worktreePath: string): WorktreeChanges {
       cwd: worktreePath,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      // `git status` opportunistically rewrites `.git/index` (refreshed
+      // stat cache), which takes `.git/index.lock`. This runs on a 2s
+      // poll for every row, so it would race the worktree's engine
+      // commits and other panes for the lock. `GIT_OPTIONAL_LOCKS=0`
+      // makes this read-only: inspect, don't write, never take the lock.
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
     })
     if (out.status !== 0 || !out.stdout) return ZERO
     return parsePorcelain(out.stdout)


### PR DESCRIPTION
## Problem

The sidebar's per-row `+N −M` chip polls `git status` every 2s, and the file-tree / Ops panes run `git status` / `git diff` on demand. These commands aren't purely read-only — git opportunistically rewrites `.git/index`'s stat cache, which takes `.git/index.lock`.

Running on a poll across every worktree (and across multiple ChatTab pane *processes*) meant they could collide with the worktree's own engine `git commit` / `git add`, surfacing as intermittent:

```
fatal: Unable to create '.../.git/index.lock': File exists.
```

A lock collision needs two parties contending for the same lock. The engine's commits *must* take the lock (real writes). The high-frequency read-only pollers took it *gratuitously*, so they were the avoidable side.

## Fix

Inject `GIT_OPTIONAL_LOCKS=0` into every pane-side read-only git spawn so they inspect without writing the index or taking the lock — the same approach VS Code / lazygit use. Five spawn sites:

| File | git command |
|---|---|
| `sidebar/worktree-changes.ts` | `git status` (2s poll — main offender) |
| `sidebar/git-head.ts` ×2 | `symbolic-ref` / `rev-parse` (pure reads; set for uniform pane policy) |
| `filetree/git.ts` | `gitWrapper.spawn` — covers `status` / `diff` / `ls-files` |
| `ops/pr-prompt.ts` | `git()` helper — `status` / `rev-parse` / `symbolic-ref` |
| `ops/host.tsx` | `git diff HEAD -- <path>` |

Real writes — engine commits, `git worktree add/remove`, `git branch -m` — are untouched and still lock as they should.

## Test

- `tsc --noEmit` clean
- Full unit + daemon/bridge suite green (39 files / 306 + 7 files / 54)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed intermittent file inspection failures in the pane UI that occurred when Git operations raced with concurrent engine commits, preventing "index.lock" file contention errors during Git status and diff operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->