### PR TITLE
feat: persist manual ChatTab rename across tmux server restart

### DIFF
--- a/.changeset/chat-tab-manual-rename-persist.md
+++ b/.changeset/chat-tab-manual-rename-persist.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+ChatTab: a manual `F2` rename of the origin tab now survives a tmux server restart. The name is captured into `tasks.json` (`Task.chatTabName`) and restored when the window is rebuilt fresh — previously it was held only in tmux memory, so `kobe reset` / a reboot dropped it and the auto-namer re-derived the first-prompt title over your name. The daemon's chat-tab namer tells your `F2` rename apart from its own auto name via a new `@kobe_auto_name` window option, so it never re-captures the auto name as a manual override. Only the origin tab is persisted (extra Ctrl+T tabs aren't rebuilt across a server restart, so they keep the pure auto-name behaviour).

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -320,6 +320,22 @@ export class Orchestrator {
   }
 
   /**
+   * Persist the user's manual name for a task's ORIGIN ChatTab window (the
+   * tmux F2 rename). The window holds the name while its tmux server is alive;
+   * this durable copy lets the chat-tab namer restore it after a server
+   * restart rebuilds the window fresh — otherwise it reverts to the
+   * auto-derived first-prompt name. An empty name clears the override (the
+   * window falls back to auto-naming). No tmux work here — the caller has
+   * already renamed the live window; this only records the durable copy.
+   */
+  async setChatTabName(id: TaskId | string, name: string): Promise<void> {
+    const trimmed = name.trim()
+    const task = this.requireTask(id)
+    if ((task.chatTabName ?? "") === trimmed) return
+    await this.store.update(task.id, { chatTabName: trimmed || undefined })
+  }
+
+  /**
    * Rename a task's branch. For a materialised worktree this renames
    * the real git branch (`git branch -m`, which also moves HEAD on the
    * checked-out worktree so a running session keeps streaming); for a

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -340,6 +340,7 @@ function coerceTask(value: unknown): Task | null {
     pinned: typeof v.pinned === "boolean" ? v.pinned : false,
     kind: v.kind === "main" ? "main" : "task",
     vendor: isVendorId(v.vendor) ? v.vendor : DEFAULT_TASK_VENDOR,
+    ...(typeof v.chatTabName === "string" && v.chatTabName.trim() ? { chatTabName: v.chatTabName } : {}),
     prStatus: coercePRStatus(v.prStatus),
     createdAt: v.createdAt,
     updatedAt: v.updatedAt,

--- a/packages/kobe/src/tmux/chat-tab-naming.ts
+++ b/packages/kobe/src/tmux/chat-tab-naming.ts
@@ -23,11 +23,27 @@
  * Self-limiting like the title poller: once a window is renamed its
  * automatic-rename is off, so later ticks skip it; windows with no prompt yet
  * derive `""` and stay until their first message lands.
+ *
+ * Manual-rename persistence (origin window only): a user's F2 rename lives in
+ * tmux and dies with the server. tmux can't tell our auto rename from a user's
+ * (both flip `automatic-rename off`), so we stamp the name WE set as
+ * `@kobe_auto_name`; a window that is named-off with a different `window_name`
+ * was renamed by the user. We CAPTURE that into `Task.chatTabName` (durable in
+ * tasks.json) and, after a server restart rebuilds the origin window fresh,
+ * RESTORE it ahead of the auto-derive. Only the origin survives a rebuild, so
+ * only it gets a stored name (keyed by the task); extra Ctrl+T tabs aren't
+ * persisted and keep the pure auto-name behaviour.
  */
 
 import { deriveTitleFromSession, deriveTitleFromSessionId } from "@/monitor/auto-title"
 import type { Orchestrator } from "@/orchestrator/core"
-import { CHAT_TAB_SESSION_ID_OPTION, runTmux, runTmuxCapturing, tmuxSessionName } from "@/tmux/client"
+import {
+  CHAT_TAB_AUTO_NAME_OPTION,
+  CHAT_TAB_SESSION_ID_OPTION,
+  runTmux,
+  runTmuxCapturing,
+  tmuxSessionName,
+} from "@/tmux/client"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
 
 /** Seam for tests — the real implementation shells `tmux` via the client. */
@@ -38,29 +54,33 @@ export interface TmuxRunner {
 
 const realRunner: TmuxRunner = { capture: runTmuxCapturing, run: runTmux }
 
-/** One ChatTab window: its tmux index and the engine session id stashed on it. */
+/** One ChatTab window: its tmux index, the engine session id, current name, and our last auto name. */
 export interface ChatTabWindow {
   readonly index: number
   /** `@kobe_session_id` value, or `""` when none was recorded (codex/legacy). */
   readonly sessionId: string
+  /** Current `#{window_name}` — what the status bar shows. */
+  readonly name: string
+  /** `@kobe_auto_name` — the name WE last auto-set, used to spot a user F2 rename. `""` when unset. */
+  readonly autoName: string
 }
 
-/** List a session's windows with their recorded engine session id. `[]` when the session is gone. */
+/** List a session's windows with their session id, current name, and recorded auto name. `[]` when gone. */
 export async function listChatTabWindows(session: string, runner: TmuxRunner = realRunner): Promise<ChatTabWindow[]> {
   const { code, stdout } = await runner.capture([
     "list-windows",
     "-t",
     `=${session}`,
     "-F",
-    `#{window_index}\t#{${CHAT_TAB_SESSION_ID_OPTION}}`,
+    `#{window_index}\t#{${CHAT_TAB_SESSION_ID_OPTION}}\t#{window_name}\t#{${CHAT_TAB_AUTO_NAME_OPTION}}`,
   ])
   if (code !== 0) return []
   const out: ChatTabWindow[] = []
   for (const line of stdout.split("\n")) {
-    const tab = line.indexOf("\t")
-    const index = Number.parseInt((tab >= 0 ? line.slice(0, tab) : line).trim(), 10)
+    const parts = line.split("\t")
+    const index = Number.parseInt((parts[0] ?? "").trim(), 10)
     if (!Number.isInteger(index)) continue
-    out.push({ index, sessionId: tab >= 0 ? line.slice(tab + 1).trim() : "" })
+    out.push({ index, sessionId: (parts[1] ?? "").trim(), name: parts[2] ?? "", autoName: parts[3] ?? "" })
   }
   return out
 }
@@ -76,9 +96,25 @@ async function windowNamedManually(session: string, index: number, runner: TmuxR
   return code === 0 && /\boff\b/.test(stdout)
 }
 
-/** Rename one window. Returns true on success. */
-async function renameWindow(session: string, index: number, title: string, runner: TmuxRunner): Promise<boolean> {
-  return (await runner.run(["rename-window", "-t", `=${session}:${index}`, "--", title])) === 0
+/**
+ * Rename one window. Returns true on success. When `stampAuto`, also record the
+ * name as `@kobe_auto_name` so a later pass can tell this auto name apart from a
+ * user's F2 rename. A RESTORE of a stored manual name passes `stampAuto: false`
+ * (it isn't our auto name), so the option stays unset and the capture branch
+ * leaves it alone.
+ */
+async function renameWindow(
+  session: string,
+  index: number,
+  title: string,
+  runner: TmuxRunner,
+  stampAuto = false,
+): Promise<boolean> {
+  const ok = (await runner.run(["rename-window", "-t", `=${session}:${index}`, "--", title])) === 0
+  if (ok && stampAuto) {
+    await runner.run(["set-window-option", "-t", `=${session}:${index}`, CHAT_TAB_AUTO_NAME_OPTION, title])
+  }
+  return ok
 }
 
 /** Injectable title derivers so the pass is testable without disk transcripts. */
@@ -108,15 +144,50 @@ export async function runChatTabNamingPass(orch: Orchestrator, deps: ChatTabNami
     if (windows.length === 0) continue
     const originIndex = windows.reduce((min, w) => Math.min(min, w.index), Number.POSITIVE_INFINITY)
     const vendor = task.vendor ?? DEFAULT_TASK_VENDOR
+    const storedName = (task.chatTabName ?? "").trim()
     for (const w of windows) {
       try {
-        if (await windowNamedManually(session, w.index, deps.runner)) continue
+        const namedManually = await windowNamedManually(session, w.index, deps.runner)
+        const isOrigin = w.index === originIndex
+
+        // ORIGIN window: durable manual-name handling. Only the origin survives
+        // a tmux server restart (extra Ctrl+T tabs aren't rebuilt), so it's the
+        // only window whose user rename we persist (keyed by the task) and
+        // restore.
+        if (isOrigin) {
+          if (!namedManually) {
+            // automatic-rename is ON → the window is unnamed/default this
+            // session. A stored manual name means the server was restarted and
+            // the window reverted: RESTORE it (wins over auto-derive). Don't
+            // stamp @kobe_auto_name — this is the user's name, not ours.
+            if (storedName) {
+              if (await renameWindow(session, w.index, storedName, deps.runner)) renamed++
+              continue
+            }
+            // else: no override yet → fall through to auto-derive below.
+          } else {
+            // automatic-rename is OFF → something named it. Tell our own auto
+            // name (@kobe_auto_name) apart from a user's F2 rename and CAPTURE
+            // the latter so it survives a future restart. (A legacy window with
+            // no @kobe_auto_name over-captures its stable first-prompt title —
+            // benign.)
+            const userNamed = w.name.length > 0 && w.name !== w.autoName
+            if (userNamed && w.name !== storedName) await orch.setChatTabName(task.id, w.name)
+            continue
+          }
+        } else if (namedManually) {
+          continue
+        }
+
+        // Auto-derive: the origin without a stored override, or any non-origin
+        // window. Stamp @kobe_auto_name so the next pass won't mistake it for a
+        // user rename.
         const title = w.sessionId
           ? await deps.titleFromSessionId(vendor, w.sessionId)
-          : w.index === originIndex
+          : isOrigin
             ? await deps.titleFromWorktree(task.worktreePath, vendor)
             : ""
-        if (title && (await renameWindow(session, w.index, title, deps.runner))) renamed++
+        if (title && (await renameWindow(session, w.index, title, deps.runner, true))) renamed++
       } catch {
         // best-effort: skip this window, keep going
       }

--- a/packages/kobe/src/tmux/client.ts
+++ b/packages/kobe/src/tmux/client.ts
@@ -213,6 +213,15 @@ export async function tagPaneRole(paneId: string, role: string): Promise<void> {
  */
 export const CHAT_TAB_SESSION_ID_OPTION = "@kobe_session_id"
 
+/**
+ * Window-scoped user option recording the name the auto-namer last set on a
+ * window. Lets the chat-tab namer tell its OWN auto name apart from a user's
+ * F2 rename — both flip tmux's `automatic-rename` to `off`, so that flag alone
+ * can't distinguish them. Lost on a tmux server restart, which is fine: the
+ * durable manual name lives in `tasks.json` (`Task.chatTabName`), not here.
+ */
+export const CHAT_TAB_AUTO_NAME_OPTION = "@kobe_auto_name"
+
 /** Set a window-scoped user option, targeting any pane/window inside it. */
 export async function setWindowOption(target: string, option: string, value: string): Promise<void> {
   await runTmux(["set-window-option", "-t", target, option, value])

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -111,6 +111,16 @@ export interface Task {
    * missing values normalize to {@link DEFAULT_TASK_VENDOR}.
    */
   readonly vendor?: VendorId
+  /**
+   * User's manual name for the ORIGIN ChatTab window (the tmux F2 rename).
+   * The window itself holds the name while its tmux server is alive; this
+   * durable copy lets the chat-tab namer restore it after a server restart
+   * rebuilds the window fresh — otherwise it would revert to the auto-derived
+   * first-prompt name. Only the origin window is durable (extra Ctrl+T tabs
+   * aren't persisted), so a single per-task field is enough. Empty / unset
+   * means "no manual override; use the auto-derived name."
+   */
+  readonly chatTabName?: string
   readonly prStatus?: TaskPRStatus
   readonly createdAt: string
   readonly updatedAt: string

--- a/packages/kobe/test/tmux/chat-tab-naming.test.ts
+++ b/packages/kobe/test/tmux/chat-tab-naming.test.ts
@@ -87,19 +87,20 @@ function fakeDeps(opts: {
 }
 
 describe("listChatTabWindows", () => {
-  it("parses index + recorded session id, tolerating empty ids", async () => {
+  it("parses index + session id + name + auto name, tolerating missing columns", async () => {
     const runner: TmuxRunner = {
       async capture() {
-        return { code: 0, stdout: "1\tabc-123\n2\t\n3\tdef-456\n" }
+        // line 1: all four columns; line 2: only index+sessionId; line 3: index+id+name
+        return { code: 0, stdout: "1\tabc-123\tFirst Tab\tFirst Tab\n2\t\n3\tdef-456\tmy rename\n" }
       },
       async run() {
         return 0
       },
     }
     expect(await listChatTabWindows("kobe-x", runner)).toEqual([
-      { index: 1, sessionId: "abc-123" },
-      { index: 2, sessionId: "" },
-      { index: 3, sessionId: "def-456" },
+      { index: 1, sessionId: "abc-123", name: "First Tab", autoName: "First Tab" },
+      { index: 2, sessionId: "", name: "", autoName: "" },
+      { index: 3, sessionId: "def-456", name: "my rename", autoName: "" },
     ])
   })
 
@@ -170,6 +171,66 @@ describe("runChatTabNamingPass", () => {
     await makeTask(undefined) // a task with no worktree yet
     const { deps, renames } = fakeDeps({ windows: "1\tsess-1\n", titleFromSessionId: () => "should not run" })
     await runChatTabNamingPass(orch, deps)
+    expect(renames).toEqual([])
+  })
+
+  it("restores a stored manual name on the origin window ahead of the auto-derive", async () => {
+    const id = await makeTask("/wt/a")
+    await orch.setChatTabName(id, "My Tab")
+    // Origin window (index 1) is auto-rename ON — a fresh rebuild after a server
+    // restart. The stored name must win over the transcript-derived title.
+    const { deps, renames } = fakeDeps({
+      windows: "1\tsess-1\tnode\t",
+      titleFromSessionId: () => "auto title",
+    })
+
+    const n = await runChatTabNamingPass(orch, deps)
+
+    expect(n).toBe(1)
+    expect(renames).toEqual([{ index: "1", title: "My Tab" }])
+  })
+
+  it("captures a user's F2 rename of the origin window into the task", async () => {
+    const id = await makeTask("/wt/a")
+    // Origin window named-off (manual) with a name that differs from our
+    // recorded auto name (empty here) → a user rename.
+    const { deps, renames } = fakeDeps({
+      windows: "1\tsess-1\tUser Name\t",
+      autoRenameOff: [1],
+      titleFromSessionId: () => "auto title",
+    })
+
+    await runChatTabNamingPass(orch, deps)
+
+    expect(orch.getTask(id)?.chatTabName).toBe("User Name")
+    expect(renames).toEqual([]) // capture only — the live window already has the name
+  })
+
+  it("does not capture our own auto name as a manual override", async () => {
+    const id = await makeTask("/wt/a")
+    // Named-off, but window_name === @kobe_auto_name → this is OUR auto name.
+    const { deps } = fakeDeps({
+      windows: "1\tsess-1\tAuto Title\tAuto Title",
+      autoRenameOff: [1],
+    })
+
+    await runChatTabNamingPass(orch, deps)
+
+    expect(orch.getTask(id)?.chatTabName).toBeUndefined()
+  })
+
+  it("captures a fresh user rename even when a different name is already stored", async () => {
+    const id = await makeTask("/wt/a")
+    await orch.setChatTabName(id, "Old")
+    // User renamed again (named-off, new name) — must update, never revert.
+    const { deps, renames } = fakeDeps({
+      windows: "1\tsess-1\tNew\t",
+      autoRenameOff: [1],
+    })
+
+    await runChatTabNamingPass(orch, deps)
+
+    expect(orch.getTask(id)?.chatTabName).toBe("New")
     expect(renames).toEqual([])
   })
 })


### PR DESCRIPTION
## 问题

ChatTab 的 `F2` 手动改名只存在 tmux 内存里,从不落盘。`kobe reset` / `kobe kill-sessions` / 机器重启把 tmux server 干掉后:

1. 手动名**彻底丢失**(`window_name` + `automatic-rename off` 标记全随 server 蒸发);
2. 重建的 origin 窗口 `automatic-rename` 复位成 `on`,daemon 的 auto-namer 又用 transcript 首句 prompt **把名字盖回去**。

净效果:用户精心改的 tab 名不仅没了,还被强制改回机器派生的名字,而 kobe 从没记录过"用户改过名",**零恢复依据**。

## 方案

复用现有的 daemon auto-namer poller(4s 巡检),加 **捕获 + 重建恢复**,不动 `F2` 绑定、不加 RPC、不引入第二个 `tasks.json` 写者。

- **持久化**:新增 `Task.chatTabName`,落盘到 `tasks.json`。
- **捕获**:poller 巡检 origin 窗口,检测到用户 F2 改名 → 写入 `chatTabName`。
- **恢复**:kill-server 后窗口重建、`automatic-rename` 复位为 `on` 时,用存盘名 restore,**优先于自动派生**。
- **区分自动名 vs 手动名**:两者都会把 `automatic-rename` 翻成 `off`,tmux 自己分不清。新增窗口选项 `@kobe_auto_name` 记录"我们自动设的名";`window_name != @kobe_auto_name` 才算用户改的 → 才捕获,避免把自动名误存成手动覆盖。

### 设计取舍

- **只持久化 origin 窗口**:kill-server 后只有 origin 会被重建(额外 Ctrl+T tab 不持久),所以按 `taskId` 存单字段即可;额外 tab 保持纯自动命名行为。
- **不让自动名走同一条持久化路子**:自动名是"会话内容描述",claude 重启后开的是全新空会话(裸 `claude`,无 `--resume`),restore 旧自动名只会给一个描述死会话的过期名字。手动名是"用户给槽位贴的标签",跨会话 restore 才成立。

## 测试

- `bun run typecheck` ✅
- `biome check`(改动文件)✅
- `vitest run` 全 310 单测 ✅(chat-tab-naming 新增 4 个测试:恢复 / 捕获 / 不误存自动名 / 重复改名不回滚)

含 changeset(`patch`)。