### PR TITLE
Store task worktrees under kobe home

### DIFF
--- a/.changeset/kobe-worktree-root.md
+++ b/.changeset/kobe-worktree-root.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-kobe-created task worktrees now live under `<repo>/.kobe/worktrees/<slug>/` instead of `<repo>/.claude/worktrees/<slug>/`, so the task filesystem layout is no longer named after a single CLI engine. Existing `.claude/worktrees` tasks remain recognized by listing, slug allocation, and daemon auto-adoption, so current task records keep working without migration.
+kobe-created task worktrees now live under `~/.kobe/worktrees/<repo-key>/<slug>/` instead of a hidden directory inside the source repo, so users no longer need repo-level `.gitignore` entries for kobe runtime worktrees. Existing repo-local `.kobe/worktrees` and `.claude/worktrees` tasks remain recognized by listing, slug allocation, and daemon auto-adoption, so current task records keep working without migration.

--- a/.changeset/kobe-worktree-root.md
+++ b/.changeset/kobe-worktree-root.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+kobe-created task worktrees now live under `<repo>/.kobe/worktrees/<slug>/` instead of `<repo>/.claude/worktrees/<slug>/`, so the task filesystem layout is no longer named after a single CLI engine. Existing `.claude/worktrees` tasks remain recognized by listing, slug allocation, and daemon auto-adoption, so current task records keep working without migration.

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "packages/kobe": {
       "name": "@sma1lboy/kobe",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "bin": {
         "kobe": "dist/cli/index.js",
       },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ state lives in dedicated dirs we own.
 | `~/.kobe/<lockfile>` | `src/orchestrator/index/lockfile.ts` | Multi-process safety for the manifest |
 | `~/.config/kobe/state.json` | `src/tui/context/kv.tsx` (`KVProvider`) | Per-user UI state — selected theme, transparent-bg toggle, pane sizes, last-open task, expanded sidebar groups |
 | `~/.claude/projects/<encoded-cwd>/<sessionUUID>.jsonl` | Claude Code itself; we *read* via `engine.readHistory()` and *delete* via `engine.deleteHistory()` | Full message history per session. kobe never writes here. |
-| `<repo>/.claude/worktrees/<task-id>/` | `GitWorktreeManager` (`src/orchestrator/worktree/manager.ts`) | Per-task git worktree. Lives inside the source repo so users don't have two hidden dirs to gitignore. Convention defined at `src/orchestrator/worktree/paths.ts:30` (do NOT move back to `.kobe/worktrees/`) |
+| `<repo>/.kobe/worktrees/<slug>/` | `GitWorktreeManager` (`src/orchestrator/worktree/manager.ts`) | Per-task git worktree for new kobe-created tasks. Convention defined at `src/orchestrator/worktree/paths.ts:30`; legacy `<repo>/.claude/worktrees/<slug>/` paths remain recognized for existing tasks. |
 | `<worktreePath>/.kobe/pr-instructions.md` | Read by `src/orchestrator/pr/instructions.ts` | Optional per-repo override for the PR-creation prompt |
 
 What's deliberately NOT persisted:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -394,7 +394,7 @@ state lives in dedicated dirs we own.
 | `~/.kobe/<lockfile>` | `src/orchestrator/index/lockfile.ts` | Multi-process safety for the manifest |
 | `~/.config/kobe/state.json` | `src/tui/context/kv.tsx` (`KVProvider`) | Per-user UI state — selected theme, transparent-bg toggle, pane sizes, last-open task, expanded sidebar groups |
 | `~/.claude/projects/<encoded-cwd>/<sessionUUID>.jsonl` | Claude Code itself; we *read* via `engine.readHistory()` and *delete* via `engine.deleteHistory()` | Full message history per session. kobe never writes here. |
-| `<repo>/.kobe/worktrees/<slug>/` | `GitWorktreeManager` (`src/orchestrator/worktree/manager.ts`) | Per-task git worktree for new kobe-created tasks. Convention defined at `src/orchestrator/worktree/paths.ts:30`; legacy `<repo>/.claude/worktrees/<slug>/` paths remain recognized for existing tasks. |
+| `~/.kobe/worktrees/<repo-key>/<slug>/` | `GitWorktreeManager` (`src/orchestrator/worktree/manager.ts`) | Per-task git worktree for new kobe-created tasks. Convention defined at `src/orchestrator/worktree/paths.ts:30`; repo-local `<repo>/.kobe/worktrees/<slug>/` and legacy `<repo>/.claude/worktrees/<slug>/` paths remain recognized for existing tasks. |
 | `<worktreePath>/.kobe/pr-instructions.md` | Read by `src/orchestrator/pr/instructions.ts` | Optional per-repo override for the PR-creation prompt |
 
 What's deliberately NOT persisted:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -347,7 +347,7 @@ Messages are **not** in this index. Messages live in Claude Code's JSONL files; 
 
 1. ~~**Tech stack lock-in**: TS + opentui + Solid + Bun.~~ ✅ Locked 2026-05-08.
 2. **City codename → real name**: when do we rename `kobe`?
-3. ~~**Worktree root**~~ ✅ Updated 2026-06-06: new kobe-created worktrees live at `<repo>/.kobe/worktrees/<slug>/`; legacy `<repo>/.claude/worktrees/<slug>/` tasks remain supported. The earlier Claude-shared root was retired once kobe became multi-engine.
+3. ~~**Worktree root**~~ ✅ Updated 2026-06-06: new kobe-created worktrees live at `~/.kobe/worktrees/<repo-key>/<slug>/`; repo-local `<repo>/.kobe/worktrees/<slug>/` and legacy `<repo>/.claude/worktrees/<slug>/` tasks remain supported. The earlier repo-local roots were retired so users do not need repo-level `.gitignore` entries for kobe runtime worktrees.
 4. **Branch naming**: auto-generate (`kobe/<slug>-<id>`) or prompt? Conductor auto-generates from task title.
 5. **Concurrency cap**: max simultaneous running tasks? (Claude Code rate-limits; we should respect.) Suggestion: 4 concurrent, configurable. **OPEN**.
 6. **Phase 2 ref repo**: when does the Conductor-backend reference repo land in `refs/`?

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -347,7 +347,7 @@ Messages are **not** in this index. Messages live in Claude Code's JSONL files; 
 
 1. ~~**Tech stack lock-in**: TS + opentui + Solid + Bun.~~ ✅ Locked 2026-05-08.
 2. **City codename → real name**: when do we rename `kobe`?
-3. ~~**Worktree root**~~ ✅ Resolved Wave 4: `<repo>/.claude/worktrees/<task-id>/` — per-repo, adjacent to source, shared namespace with Claude Code's own agent-spawn worktrees so users don't have two separate hidden dirs to gitignore. Do NOT move back to `.kobe/worktrees/`.
+3. ~~**Worktree root**~~ ✅ Updated 2026-06-06: new kobe-created worktrees live at `<repo>/.kobe/worktrees/<slug>/`; legacy `<repo>/.claude/worktrees/<slug>/` tasks remain supported. The earlier Claude-shared root was retired once kobe became multi-engine.
 4. **Branch naming**: auto-generate (`kobe/<slug>-<id>`) or prompt? Conductor auto-generates from task title.
 5. **Concurrency cap**: max simultaneous running tasks? (Claude Code rate-limits; we should respect.) Suggestion: 4 concurrent, configurable. **OPEN**.
 6. **Phase 2 ref repo**: when does the Conductor-backend reference repo land in `refs/`?

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -104,7 +104,7 @@ work in an area, ping the listed owner first to avoid stomping.
 | **Preview / diff** | `src/tui/panes/preview/` | Jackson | "open*" diff naming TBD — `opendiff` / `claudediff` candidates. |
 | **Engine (subprocess)** | `src/engine/claude-code-local/` | Jackson | Algorithmically ported from `refs/opcode/src-tauri/.../claude.rs`. Mirror opcode's stream-json parser when extending. |
 | **Orchestrator / task state** | `src/orchestrator/`, `src/state/` | Jackson | State definition recently simplified (5 states removed). Spec doc forthcoming. |
-| **Worktrees** | `.claude/worktrees/`, orchestrator integration | Jackson | Always `.claude/worktrees/`, never `.kobe/worktrees/`. |
+| **Worktrees** | `.kobe/worktrees/`, orchestrator integration | Jackson | New kobe-created tasks use `.kobe/worktrees/`; legacy `.claude/worktrees/` paths remain supported. |
 | **Behavior tests** | `test/behavior/` | Jackson | PTY driven (`docs/HARNESS.md`). Local-only — CI runs unit + typecheck only. |
 | **General triage** | — | Allen | First responder for "saw a bug, fix it" — small fixes go through Allen. |
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -104,7 +104,7 @@ work in an area, ping the listed owner first to avoid stomping.
 | **Preview / diff** | `src/tui/panes/preview/` | Jackson | "open*" diff naming TBD — `opendiff` / `claudediff` candidates. |
 | **Engine (subprocess)** | `src/engine/claude-code-local/` | Jackson | Algorithmically ported from `refs/opcode/src-tauri/.../claude.rs`. Mirror opcode's stream-json parser when extending. |
 | **Orchestrator / task state** | `src/orchestrator/`, `src/state/` | Jackson | State definition recently simplified (5 states removed). Spec doc forthcoming. |
-| **Worktrees** | `.kobe/worktrees/`, orchestrator integration | Jackson | New kobe-created tasks use `.kobe/worktrees/`; legacy `.claude/worktrees/` paths remain supported. |
+| **Worktrees** | `~/.kobe/worktrees/`, orchestrator integration | Jackson | New kobe-created tasks use `~/.kobe/worktrees/<repo-key>/`; repo-local `.kobe/worktrees/` and legacy `.claude/worktrees/` paths remain supported. |
 | **Behavior tests** | `test/behavior/` | Jackson | PTY driven (`docs/HARNESS.md`). Local-only — CI runs unit + typecheck only. |
 | **General triage** | — | Allen | First responder for "saw a bug, fix it" — small fixes go through Allen. |
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -219,13 +219,13 @@ After G0. All four can ship without seeing each other.
 - `manager.ts` — `class GitWorktreeManager implements WorktreeManager`
 - Methods: `create(repo, branch, path)`, `remove(path, { force })`, `list(repo)`, `isDirty(path)`, `currentBranch(path)`
 - Use `bun.spawn` or Node `execFile` for git calls; never shell-string-concatenate.
-- Per task convention from DESIGN.md §11.3 (resolved: `<repo>/.claude/worktrees/<task-id>/`, shared with Claude Code's own agent-spawn root)
+- Per task convention from DESIGN.md §11.3 (current: `<repo>/.kobe/worktrees/<slug>/` for new tasks; legacy `.claude/worktrees` recognized)
 - Tests: in `test/fixtures/`, init a tiny repo, create + remove worktrees, assert state.
 
 **Done when**: All methods green in unit tests; round-trip create→remove leaves no orphan files or branches.
 
 **Agent prompt seed**:
-> Implement `GitWorktreeManager` per `src/types/worktree.ts`. Use `git worktree` subcommands via `bun.spawn` (no shell concat — pass args as array). Per DESIGN.md §11.3, default worktree root is `<repo>/.claude/worktrees/<task-id>/` (shared namespace with Claude Code's own agent-spawn worktrees). Read `refs/vibe-kanban/crates/worktree-manager/` for invariants on cleanup and dirty-state detection. Tests must use a real fixture repo (`test/fixtures/repo-init.sh`); no mocking git. ~300 LoC.
+> Implement `GitWorktreeManager` per `src/types/worktree.ts`. Use `git worktree` subcommands via `bun.spawn` (no shell concat — pass args as array). Per DESIGN.md §11.3, default worktree root is `<repo>/.kobe/worktrees/<slug>/` for new tasks, with legacy `<repo>/.claude/worktrees/<slug>/` recognized. Read `refs/vibe-kanban/crates/worktree-manager/` for invariants on cleanup and dirty-state detection. Tests must use a real fixture repo (`test/fixtures/repo-init.sh`); no mocking git. ~300 LoC.
 
 ---
 
@@ -514,7 +514,7 @@ Constraint: each stream agent gets one focus area. **No cross-stream commits.** 
 | # | Decision | Stream | Resolution |
 |---|---|---|---|
 | 1 | Default theme | D | **`tokyonight`** (matches agent-deck's Tokyo Night palette; already lifted from opencode) |
-| 2 | Worktree root | B | **`<repo>/.claude/worktrees/<task-id>/`** (per-repo, gitignored, shared namespace with Claude Code's own agent-spawn worktrees — Wave 4 resolution; do not move back to `.kobe/`) |
+| 2 | Worktree root | B | **Updated 2026-06-06: `<repo>/.kobe/worktrees/<slug>/` for new kobe-created tasks; legacy `<repo>/.claude/worktrees/<slug>/` remains recognized.** The earlier Claude-shared root was retired after multi-engine support made vendor-named task storage misleading. |
 | 3 | Branch naming | E | **Auto** `kobe/<slug>-<ulid-suffix>`; user can override per-task |
 | 4 | Concurrency cap | E | **4** simultaneous running tasks; configurable via `~/.kobe/config.json` later |
 | 5 | Terminal pane | J | **One pty per task**, kept alive while task is `in_progress`, killed on archive |

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -219,13 +219,13 @@ After G0. All four can ship without seeing each other.
 - `manager.ts` — `class GitWorktreeManager implements WorktreeManager`
 - Methods: `create(repo, branch, path)`, `remove(path, { force })`, `list(repo)`, `isDirty(path)`, `currentBranch(path)`
 - Use `bun.spawn` or Node `execFile` for git calls; never shell-string-concatenate.
-- Per task convention from DESIGN.md §11.3 (current: `<repo>/.kobe/worktrees/<slug>/` for new tasks; legacy `.claude/worktrees` recognized)
+- Per task convention from DESIGN.md §11.3 (current: `~/.kobe/worktrees/<repo-key>/<slug>/` for new tasks; repo-local `.kobe/worktrees` and legacy `.claude/worktrees` recognized)
 - Tests: in `test/fixtures/`, init a tiny repo, create + remove worktrees, assert state.
 
 **Done when**: All methods green in unit tests; round-trip create→remove leaves no orphan files or branches.
 
 **Agent prompt seed**:
-> Implement `GitWorktreeManager` per `src/types/worktree.ts`. Use `git worktree` subcommands via `bun.spawn` (no shell concat — pass args as array). Per DESIGN.md §11.3, default worktree root is `<repo>/.kobe/worktrees/<slug>/` for new tasks, with legacy `<repo>/.claude/worktrees/<slug>/` recognized. Read `refs/vibe-kanban/crates/worktree-manager/` for invariants on cleanup and dirty-state detection. Tests must use a real fixture repo (`test/fixtures/repo-init.sh`); no mocking git. ~300 LoC.
+> Implement `GitWorktreeManager` per `src/types/worktree.ts`. Use `git worktree` subcommands via `bun.spawn` (no shell concat — pass args as array). Per DESIGN.md §11.3, default worktree root is `~/.kobe/worktrees/<repo-key>/<slug>/` for new tasks, with repo-local `<repo>/.kobe/worktrees/<slug>/` and legacy `<repo>/.claude/worktrees/<slug>/` recognized. Read `refs/vibe-kanban/crates/worktree-manager/` for invariants on cleanup and dirty-state detection. Tests must use a real fixture repo (`test/fixtures/repo-init.sh`); no mocking git. ~300 LoC.
 
 ---
 
@@ -514,7 +514,7 @@ Constraint: each stream agent gets one focus area. **No cross-stream commits.** 
 | # | Decision | Stream | Resolution |
 |---|---|---|---|
 | 1 | Default theme | D | **`tokyonight`** (matches agent-deck's Tokyo Night palette; already lifted from opencode) |
-| 2 | Worktree root | B | **Updated 2026-06-06: `<repo>/.kobe/worktrees/<slug>/` for new kobe-created tasks; legacy `<repo>/.claude/worktrees/<slug>/` remains recognized.** The earlier Claude-shared root was retired after multi-engine support made vendor-named task storage misleading. |
+| 2 | Worktree root | B | **Updated 2026-06-06: `~/.kobe/worktrees/<repo-key>/<slug>/` for new kobe-created tasks; repo-local `.kobe/worktrees` and legacy `.claude/worktrees` remain recognized.** Repo-local roots were retired so users do not need `.gitignore` entries for kobe runtime worktrees. |
 | 3 | Branch naming | E | **Auto** `kobe/<slug>-<ulid-suffix>`; user can override per-task |
 | 4 | Concurrency cap | E | **4** simultaneous running tasks; configurable via `~/.kobe/config.json` later |
 | 5 | Terminal pane | J | **One pty per task**, kept alive while task is `in_progress`, killed on archive |

--- a/docs/design/tasks.md
+++ b/docs/design/tasks.md
@@ -70,7 +70,7 @@ guarantee comes from giving each Task its own git worktree.
 
 Concretely:
 
-- Task `01HX...` lives at `<repo>/.claude/worktrees/01HX.../` checked
+- Task `panda` lives at `<repo>/.kobe/worktrees/panda/` checked
   out to whatever branch the task owns.
 - Edits made in one task's worktree do not appear in another's until
   the user merges branches.
@@ -78,13 +78,13 @@ Concretely:
   worktree persists across kobe restarts; it persists across the task
   going to `done`; it persists across archiving. The user removes
   worktrees explicitly, never as a side effect.
-- The worktree root is shared with Claude Code's own agent-spawn root
-  (`.claude/worktrees/`, **not** `.kobe/worktrees/`). One hidden dir,
-  both tools' worktrees inside, one mental model.
+- kobe owns its worktree root (`.kobe/worktrees/`). Older tasks created
+  under `.claude/worktrees/` stay valid and are still listed/adopted, but
+  new kobe-created worktrees are engine-neutral.
 
 The single source of truth for the path is
 [`worktreePathFor(repo, taskId)`](../../packages/kobe/src/orchestrator/worktree/paths.ts).
-Nothing else should concatenate `repo + '/.claude/worktrees/' + id`.
+Nothing else should concatenate `repo + '/.kobe/worktrees/' + id`.
 
 ### Boundary: the orchestrator does not coordinate writes inside a worktree
 
@@ -243,7 +243,7 @@ setting describes "this particular conversation," it's tab-level.
 | What                          | Where                                                  | Format                       |
 |-------------------------------|--------------------------------------------------------|------------------------------|
 | Task index                    | `~/.kobe/tasks.json`                                   | `TaskIndex` (versioned)      |
-| Per-task worktree             | `<repo>/.claude/worktrees/<task-id>/`                  | git worktree                 |
+| Per-task worktree             | `<repo>/.kobe/worktrees/<slug>/`                       | git worktree                 |
 | Per-tab conversation          | Claude Code's JSONL store (read via `AIEngine`)        | JSONL                        |
 | Spawned-engine resume cwd     | typed `opts.cwd` on `engine.resume()` (+ legacy env var) | string                     |
 
@@ -293,9 +293,9 @@ When the schema changes again:
   conversation title, transcript).
 - **Sharing one worktree across tasks.** Defeats the entire model.
   Every task gets its own worktree.
-- **Hardcoding the worktree path.** Use `worktreePathFor`. The
-  `.claude/worktrees/` convention is settled; the `.kobe/worktrees/`
-  proposal is dead and any survivors are drift.
+- **Hardcoding the worktree path.** Use `worktreePathFor`. New kobe
+  worktrees use `.kobe/worktrees/`, while path recognition also supports
+  legacy `.claude/worktrees/`.
 - **Storing conversation history in `tasks.json`.** It's a manifest,
   not a database. JSONL via the engine is the source of truth.
 - **Auto-deleting worktrees on archive / done / cancel.** kobe never

--- a/docs/design/tasks.md
+++ b/docs/design/tasks.md
@@ -70,7 +70,7 @@ guarantee comes from giving each Task its own git worktree.
 
 Concretely:
 
-- Task `panda` lives at `<repo>/.kobe/worktrees/panda/` checked
+- Task `panda` lives at `~/.kobe/worktrees/<repo-key>/panda/` checked
   out to whatever branch the task owns.
 - Edits made in one task's worktree do not appear in another's until
   the user merges branches.
@@ -78,13 +78,15 @@ Concretely:
   worktree persists across kobe restarts; it persists across the task
   going to `done`; it persists across archiving. The user removes
   worktrees explicitly, never as a side effect.
-- kobe owns its worktree root (`.kobe/worktrees/`). Older tasks created
-  under `.claude/worktrees/` stay valid and are still listed/adopted, but
-  new kobe-created worktrees are engine-neutral.
+- kobe owns its worktree root under its state dir (`~/.kobe/worktrees/`,
+  or `$KOBE_HOME_DIR/.kobe/worktrees/` in isolated dev/test homes). Older
+  tasks created under repo-local `.kobe/worktrees/` or `.claude/worktrees/`
+  stay valid and are still listed/adopted, but new kobe-created worktrees
+  no longer require a repo-level `.gitignore` entry.
 
 The single source of truth for the path is
 [`worktreePathFor(repo, taskId)`](../../packages/kobe/src/orchestrator/worktree/paths.ts).
-Nothing else should concatenate `repo + '/.kobe/worktrees/' + id`.
+Nothing else should concatenate a worktree root by hand.
 
 ### Boundary: the orchestrator does not coordinate writes inside a worktree
 
@@ -243,7 +245,7 @@ setting describes "this particular conversation," it's tab-level.
 | What                          | Where                                                  | Format                       |
 |-------------------------------|--------------------------------------------------------|------------------------------|
 | Task index                    | `~/.kobe/tasks.json`                                   | `TaskIndex` (versioned)      |
-| Per-task worktree             | `<repo>/.kobe/worktrees/<slug>/`                       | git worktree                 |
+| Per-task worktree             | `~/.kobe/worktrees/<repo-key>/<slug>/`                 | git worktree                 |
 | Per-tab conversation          | Claude Code's JSONL store (read via `AIEngine`)        | JSONL                        |
 | Spawned-engine resume cwd     | typed `opts.cwd` on `engine.resume()` (+ legacy env var) | string                     |
 
@@ -294,8 +296,8 @@ When the schema changes again:
 - **Sharing one worktree across tasks.** Defeats the entire model.
   Every task gets its own worktree.
 - **Hardcoding the worktree path.** Use `worktreePathFor`. New kobe
-  worktrees use `.kobe/worktrees/`, while path recognition also supports
-  legacy `.claude/worktrees/`.
+  worktrees use `~/.kobe/worktrees/<repo-key>/`, while path recognition
+  also supports repo-local `.kobe/worktrees/` and legacy `.claude/worktrees/`.
 - **Storing conversation history in `tasks.json`.** It's a manifest,
   not a database. JSONL via the engine is the source of truth.
 - **Auto-deleting worktrees on archive / done / cancel.** kobe never

--- a/docs/design/v2-tmux-handover.md
+++ b/docs/design/v2-tmux-handover.md
@@ -116,7 +116,7 @@ kobe v0.5 把 `claude` 当 stream-json 子进程驱动 (`engine/claude-code-loca
 
 ## 8. 不变的契约
 
-- worktree 路径仍是 `<repo>/.claude/worktrees/<task-id>/` (KOB-19 拍的, 不改)
+- worktree 路径现在是 `<repo>/.kobe/worktrees/<slug>/`；旧的 `<repo>/.claude/worktrees/<slug>/` 任务继续兼容。
 - 任务索引仍是 `~/.kobe/tasks.json` 单 JSON 文件
 - claude history 仍读 `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`
 - `tmux -L kobe` 独占 socket (KOB-225 拍的, 不污染用户自己的 tmux)

--- a/docs/design/v2-tmux-handover.md
+++ b/docs/design/v2-tmux-handover.md
@@ -116,7 +116,7 @@ kobe v0.5 把 `claude` 当 stream-json 子进程驱动 (`engine/claude-code-loca
 
 ## 8. 不变的契约
 
-- worktree 路径现在是 `<repo>/.kobe/worktrees/<slug>/`；旧的 `<repo>/.claude/worktrees/<slug>/` 任务继续兼容。
+- worktree 路径现在是 `~/.kobe/worktrees/<repo-key>/<slug>/`；repo-local `.kobe/worktrees` 和旧的 `<repo>/.claude/worktrees/<slug>/` 任务继续兼容。
 - 任务索引仍是 `~/.kobe/tasks.json` 单 JSON 文件
 - claude history 仍读 `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`
 - `tmux -L kobe` 独占 socket (KOB-225 拍的, 不污染用户自己的 tmux)

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -138,8 +138,8 @@ async function adoptWorktreesInto(
 
 /**
  * `kobe adopt [glob] [--repo <path>] [--vendor <v>] [--yes]` — scan a
- * repo's existing git worktrees (including ones outside
- * `.claude/worktrees/`) and import the ones not yet linked to a task
+ * repo's existing git worktrees (including ones outside kobe-managed
+ * roots) and import the ones not yet linked to a task
  * (KOB-256). No glob → dry-run listing. With a path glob → list matches;
  * `--yes` actually adopts them. Goes through the daemon so a running TUI
  * sees the new tasks live.

--- a/packages/kobe/src/cli/maintenance.ts
+++ b/packages/kobe/src/cli/maintenance.ts
@@ -260,9 +260,9 @@ async function removeStateFile(path: string, label: string): Promise<void> {
  * `kobe reset [--hard] [--yes]` — the packaged equivalent of
  * `dev:sandbox:reset`. Tears down the daemon + all kobe tmux sessions so a
  * fresh `kobe` launch starts clean. `--hard` additionally wipes the task
- * index + UI state. Git worktrees (and everything under
- * `.claude/worktrees/`) are NEVER touched. Does not respawn the daemon —
- * relaunch kobe for that.
+ * index + UI state. Git worktrees (and everything under `.kobe/worktrees/`
+ * or legacy `.claude/worktrees/`) are NEVER touched. Does not respawn the
+ * daemon — relaunch kobe for that.
  *
  * Confirmation: interactive y/N on a TTY; `--yes`/`-y` skips it; on a
  * non-TTY without `--yes` it prints the plan and exits without acting.
@@ -317,7 +317,7 @@ export async function runResetSubcommand(argv: readonly string[]): Promise<void>
     console.log(`  • DELETE the task index${count === null ? "" : ` (${count} task(s))`} — ${tasksPath}`)
     console.log(`  • DELETE the UI state — ${statePath}`)
   }
-  console.log("  • NOT touch your git worktrees or any code under .claude/worktrees/")
+  console.log("  • NOT touch your git worktrees or any code under .kobe/worktrees/ or .claude/worktrees/")
   if (!hard) {
     console.log("  (your task list & worktrees are kept — add --hard to also wipe the task index + UI state)")
   }

--- a/packages/kobe/src/cli/maintenance.ts
+++ b/packages/kobe/src/cli/maintenance.ts
@@ -260,9 +260,9 @@ async function removeStateFile(path: string, label: string): Promise<void> {
  * `kobe reset [--hard] [--yes]` — the packaged equivalent of
  * `dev:sandbox:reset`. Tears down the daemon + all kobe tmux sessions so a
  * fresh `kobe` launch starts clean. `--hard` additionally wipes the task
- * index + UI state. Git worktrees (and everything under `.kobe/worktrees/`
- * or legacy `.claude/worktrees/`) are NEVER touched. Does not respawn the
- * daemon — relaunch kobe for that.
+ * index + UI state. Git worktrees (under `~/.kobe/worktrees/` or legacy
+ * repo-local roots) are NEVER touched. Does not respawn the daemon — relaunch
+ * kobe for that.
  *
  * Confirmation: interactive y/N on a TTY; `--yes`/`-y` skips it; on a
  * non-TTY without `--yes` it prints the plan and exits without acting.
@@ -317,7 +317,7 @@ export async function runResetSubcommand(argv: readonly string[]): Promise<void>
     console.log(`  • DELETE the task index${count === null ? "" : ` (${count} task(s))`} — ${tasksPath}`)
     console.log(`  • DELETE the UI state — ${statePath}`)
   }
-  console.log("  • NOT touch your git worktrees or any code under .kobe/worktrees/ or .claude/worktrees/")
+  console.log("  • NOT touch your git worktrees under ~/.kobe/worktrees/ or legacy repo-local roots")
   if (!hard) {
     console.log("  (your task list & worktrees are kept — add --hard to also wipe the task index + UI state)")
   }

--- a/packages/kobe/src/daemon/cwd-task.ts
+++ b/packages/kobe/src/daemon/cwd-task.ts
@@ -8,15 +8,16 @@
  * whose `worktreePath` is the cwd or the LONGEST path-prefix of it.
  *
  * Longest-prefix matters because task worktrees live UNDER a repo root
- * (`<repo>/.claude/worktrees/<id>`), and a `main` task's worktreePath IS that
- * repo root — so a sub-task's cwd prefix-matches both. The more specific
- * (longer) worktree wins, so a sub-task is never misattributed to the project.
+ * (`<repo>/.kobe/worktrees/<id>` or legacy `.claude/worktrees/<id>`), and a
+ * `main` task's worktreePath IS that repo root — so a sub-task's cwd
+ * prefix-matches both. The more specific (longer) worktree wins, so a sub-task
+ * is never misattributed to the project.
  *
  * cwds that match no task (an unrelated repo, a project root with no main task)
  * return undefined → the event is dropped.
  */
 
-import { KOBE_WORKTREE_ROOT_SUBPATH } from "../orchestrator/worktree/paths.ts"
+import { KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS } from "../orchestrator/worktree/paths.ts"
 
 export interface CwdMatchTask {
   readonly id: string
@@ -81,10 +82,11 @@ export function matchRepoByCwd(tasks: ReadonlyArray<CwdMatchTask>, cwd: string):
 
 /**
  * Detect a `cwd` that is an UNADOPTED git worktree under a tracked repo's
- * `.claude/worktrees/` dir — the replacement for the removed WorktreeCreate
- * hook. When an external `claude --worktree` (or a manual `git worktree add`)
- * lands a worktree in `<repo>/.claude/worktrees/<seg>` for a repo kobe already
- * has tasks in, the daemon adopts it as a task on the engine's `session-start`.
+ * managed worktree roots — the replacement for the removed WorktreeCreate
+ * hook. When an external engine worktree (or a manual `git worktree add`) lands
+ * in `<repo>/.kobe/worktrees/<seg>` or legacy `<repo>/.claude/worktrees/<seg>`
+ * for a repo kobe already has tasks in, the daemon adopts it as a task on the
+ * engine's `session-start`.
  *
  * Pure + git-free (string paths only, bounded to known repos): returns the
  * `{ repo, worktreePath }` to adopt, or undefined when `cwd` isn't under any
@@ -103,17 +105,18 @@ export function findAdoptableWorktree(
     if (t.repo) repos.add(normalize(t.repo))
     if (t.worktreePath) known.add(normalize(t.worktreePath))
   }
-  const seg = `/${KOBE_WORKTREE_ROOT_SUBPATH}/`
   for (const repo of repos) {
-    const prefix = `${repo}${seg}`
-    if (!target.startsWith(prefix)) continue
-    // First path segment after `<repo>/.claude/worktrees/` is the worktree dir.
-    const rest = target.slice(prefix.length)
-    const name = rest.split("/")[0]
-    if (!name) continue
-    const worktreePath = `${prefix}${name}`
-    if (known.has(worktreePath)) return undefined // already a task → nothing to adopt
-    return { repo, worktreePath }
+    for (const subpath of KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS) {
+      const prefix = `${repo}/${subpath}/`
+      if (!target.startsWith(prefix)) continue
+      // First path segment after the managed root is the worktree dir.
+      const rest = target.slice(prefix.length)
+      const name = rest.split("/")[0]
+      if (!name) continue
+      const worktreePath = `${prefix}${name}`
+      if (known.has(worktreePath)) return undefined // already a task → nothing to adopt
+      return { repo, worktreePath }
+    }
   }
   return undefined
 }

--- a/packages/kobe/src/daemon/cwd-task.ts
+++ b/packages/kobe/src/daemon/cwd-task.ts
@@ -7,17 +7,16 @@
  * (or an ancestor of it, if the engine cd'd into a subdir), so we take the task
  * whose `worktreePath` is the cwd or the LONGEST path-prefix of it.
  *
- * Longest-prefix matters because task worktrees live UNDER a repo root
- * (`<repo>/.kobe/worktrees/<id>` or legacy `.claude/worktrees/<id>`), and a
- * `main` task's worktreePath IS that repo root — so a sub-task's cwd
- * prefix-matches both. The more specific (longer) worktree wins, so a sub-task
- * is never misattributed to the project.
+ * Longest-prefix matters because legacy task worktrees can live under a repo
+ * root (`<repo>/.kobe/worktrees/<id>` or `.claude/worktrees/<id>`), and a
+ * `main` task's worktreePath IS that repo root. The more specific (longer)
+ * worktree wins, so a sub-task is never misattributed to the project.
  *
  * cwds that match no task (an unrelated repo, a project root with no main task)
  * return undefined → the event is dropped.
  */
 
-import { KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS } from "../orchestrator/worktree/paths.ts"
+import { managedWorktreeRootsFor } from "../orchestrator/worktree/paths.ts"
 
 export interface CwdMatchTask {
   readonly id: string
@@ -83,10 +82,9 @@ export function matchRepoByCwd(tasks: ReadonlyArray<CwdMatchTask>, cwd: string):
 /**
  * Detect a `cwd` that is an UNADOPTED git worktree under a tracked repo's
  * managed worktree roots — the replacement for the removed WorktreeCreate
- * hook. When an external engine worktree (or a manual `git worktree add`) lands
- * in `<repo>/.kobe/worktrees/<seg>` or legacy `<repo>/.claude/worktrees/<seg>`
- * for a repo kobe already has tasks in, the daemon adopts it as a task on the
- * engine's `session-start`.
+ * hook. When an engine starts in a worktree under `~/.kobe/worktrees/<repo-key>`
+ * or a legacy repo-local root for a repo kobe already has tasks in, the daemon
+ * adopts it as a task on the engine's `session-start`.
  *
  * Pure + git-free (string paths only, bounded to known repos): returns the
  * `{ repo, worktreePath }` to adopt, or undefined when `cwd` isn't under any
@@ -106,8 +104,8 @@ export function findAdoptableWorktree(
     if (t.worktreePath) known.add(normalize(t.worktreePath))
   }
   for (const repo of repos) {
-    for (const subpath of KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS) {
-      const prefix = `${repo}/${subpath}/`
+    for (const root of managedWorktreeRootsFor(repo).map(normalize)) {
+      const prefix = `${root}/`
       if (!target.startsWith(prefix)) continue
       // First path segment after the managed root is the worktree dir.
       const rest = target.slice(prefix.length)

--- a/packages/kobe/src/daemon/paths.ts
+++ b/packages/kobe/src/daemon/paths.ts
@@ -12,7 +12,7 @@ import { join } from "node:path"
  * We use a conservative 100-byte ceiling so even the longest reasonable
  * `bridge-<pid>.sock` suffix has room. Hitting this matters for
  * `bun run dev:sandbox` inside a deeply-nested worktree
- * (`/Users/.../.claude/worktrees/<ULID>/packages/kobe/.dev-sandbox/...`)
+ * (`/Users/.../.kobe/worktrees/<ULID>/packages/kobe/.dev-sandbox/...`)
  * where the natural `~/.kobe/.../daemon.sock` form blows past 104 chars
  * and `listen()` rejects silently.
  */

--- a/packages/kobe/src/daemon/server.ts
+++ b/packages/kobe/src/daemon/server.ts
@@ -534,7 +534,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
         const cwd = optionalString(payload, "cwd")
         // External-worktree sync (replaces the removed WorktreeCreate hook): a
         // session starting in an unadopted worktree under a tracked repo's
-        // `.claude/worktrees/` is auto-adopted as a task, so the cwd then maps
+        // a managed worktree root is auto-adopted as a task, so the cwd then maps
         // to it below. Gated to `session-start` to bound the work; the path
         // check is git-free and `adoptWorktree` is idempotent + git-validated
         // (a bogus dir just throws → caught → dropped).

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -18,7 +18,7 @@
  *     "I lost my changes because kobe deleted the worktree" must be
  *     impossible without explicit consent.
  *   - `list()` only returns worktrees inside kobe-managed roots
- *     (`<repo>/.kobe/worktrees/` plus legacy `<repo>/.claude/worktrees/`).
+ *     (`~/.kobe/worktrees/<repo-key>/` plus repo-local compatibility roots).
  *     Worktrees the user created outside these roots are invisible to kobe.
  *
  * Reference (read, not ported): `refs/vibe-kanban/crates/worktree-manager/`
@@ -75,7 +75,7 @@ export class GitWorktreeManager implements WorktreeManager {
       throw new Error(`create(): ${worktreePath} exists but is not a registered git worktree`)
     }
 
-    // Make sure the parent dir exists (`.kobe/worktrees/` may be the
+    // Make sure the parent dir exists (`~/.kobe/worktrees/...` may be the
     // first time we write into the repo).
     fs.mkdirSync(path.dirname(worktreePath), { recursive: true })
 
@@ -359,7 +359,7 @@ export class GitWorktreeManager implements WorktreeManager {
     if (!match || !match.path || !match.branch || match.detached) return null
     return {
       // Return the caller's requested path verbatim — they passed in
-      // `<repo>/.kobe/worktrees/<id>` (or a persisted legacy path) and may compare against that
+      // `~/.kobe/worktrees/<repo-key>/<id>` (or a persisted legacy path) and may compare against that
       // exact string later. Returning git's macOS-resolved
       // `/private/...` form would surprise them.
       path: worktreePath,

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -17,9 +17,9 @@
  *     true. The single most important safety property of this module:
  *     "I lost my changes because kobe deleted the worktree" must be
  *     impossible without explicit consent.
- *   - `list()` only returns worktrees inside `<repo>/.claude/worktrees/`
- *     (the convention from DESIGN.md §11 / PLAN.md §B). Worktrees the
- *     user created outside this root are invisible to kobe.
+ *   - `list()` only returns worktrees inside kobe-managed roots
+ *     (`<repo>/.kobe/worktrees/` plus legacy `<repo>/.claude/worktrees/`).
+ *     Worktrees the user created outside these roots are invisible to kobe.
  *
  * Reference (read, not ported): `refs/vibe-kanban/crates/worktree-manager/`
  * for cleanup invariants and dirty-state semantics.
@@ -29,7 +29,7 @@ import fs from "node:fs"
 import path from "node:path"
 import type { AdoptableWorktree, WorktreeInfo, WorktreeManager } from "../../types/worktree.ts"
 import { GitCommandError, git } from "./git.ts"
-import { isKobeManagedPath, worktreePathFor, worktreeRootFor } from "./paths.ts"
+import { isKobeManagedPath, managedWorktreeRootForPath, worktreePathFor } from "./paths.ts"
 
 export class GitWorktreeManager implements WorktreeManager {
   /**
@@ -75,7 +75,7 @@ export class GitWorktreeManager implements WorktreeManager {
       throw new Error(`create(): ${worktreePath} exists but is not a registered git worktree`)
     }
 
-    // Make sure the parent dir exists (`.claude/worktrees/` may be the
+    // Make sure the parent dir exists (`.kobe/worktrees/` may be the
     // first time we write into the repo).
     fs.mkdirSync(path.dirname(worktreePath), { recursive: true })
 
@@ -193,28 +193,28 @@ export class GitWorktreeManager implements WorktreeManager {
    * List kobe-managed worktrees under `repo`.
    *
    * Parses `git worktree list --porcelain` and filters to entries
-   * whose path lives inside `<repo>/.claude/worktrees/`. Worktrees the
-   * user created elsewhere are invisible to kobe — we don't enumerate
-   * the whole world.
+   * whose path lives inside a kobe-managed root. Worktrees the user
+   * created elsewhere are invisible to kobe — we don't enumerate the
+   * whole world.
    */
   async list(repo: string): Promise<readonly WorktreeInfo[]> {
     requireAbsolute("repo", repo)
     const out = git(["worktree", "list", "--porcelain"], { cwd: repo })
     const all = parsePorcelain(out.stdout)
 
-    // Re-root paths into the caller's form. Git on macOS reports
-    // `/private/var/...` but the caller passed in `/var/...`; we hand
-    // back paths that satisfy `path.startsWith(worktreeRootFor(repo))`
-    // so callers can use string ops without surprise.
-    const callerRoot = worktreeRootFor(repo)
-    const canonRoot = canonicalize(callerRoot)
-
     const infos: WorktreeInfo[] = []
     for (const entry of all) {
       if (!entry.path) continue
-      if (!isKobeManagedPath(repo, entry.path)) continue
+      const callerRoot = managedWorktreeRootForPath(repo, entry.path)
+      if (!callerRoot) continue
       // Detached / bare entries don't have a branch we care about.
       if (!entry.branch || entry.detached) continue
+      // Re-root paths into the caller's form. Git on macOS reports
+      // `/private/var/...` but the caller passed in `/var/...`; we hand
+      // back paths that satisfy `path.startsWith(callerRoot)` so callers
+      // can use string ops without surprise. Legacy paths stay under the
+      // legacy root instead of being rewritten to the primary root.
+      const canonRoot = canonicalize(callerRoot)
       const canonEntry = canonicalize(entry.path)
       const rel = path.relative(canonRoot, canonEntry)
       const callerPath = path.join(callerRoot, rel)
@@ -231,7 +231,7 @@ export class GitWorktreeManager implements WorktreeManager {
 
   /**
    * List ALL git worktrees registered on `repo` — including ones the
-   * user created outside `<repo>/.claude/worktrees/` (KOB-256). Unlike
+   * user created outside kobe-managed roots (KOB-256). Unlike
    * {@link list}, this does NOT filter to the kobe convention root; it's
    * the discovery source for "adopt an existing worktree as a task".
    *
@@ -359,7 +359,7 @@ export class GitWorktreeManager implements WorktreeManager {
     if (!match || !match.path || !match.branch || match.detached) return null
     return {
       // Return the caller's requested path verbatim — they passed in
-      // `<repo>/.claude/worktrees/<id>` and may compare against that
+      // `<repo>/.kobe/worktrees/<id>` (or a persisted legacy path) and may compare against that
       // exact string later. Returning git's macOS-resolved
       // `/private/...` form would surprise them.
       path: worktreePath,

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -1,14 +1,15 @@
 /**
  * Canonical filesystem layout for kobe-managed worktrees.
  *
- * Per DESIGN.md §11.3 (resolved) the worktree root is per-repo and lives
- * adjacent to the source tree at `<repo>/.claude/worktrees/<slug>/`.
- * `<slug>` is an animal-name slug (KOB-65) for tasks created after the
- * switch, or the task's ULID for legacy worktrees. Shared namespace
- * with Claude Code's own agent-spawn worktrees — one hidden dir, both
- * tools' worktrees inside. Do NOT move this back to `.kobe/worktrees/`;
- * that proposal pre-dates Jackson's resolution and keeps cropping up
- * in stale comments / test fixtures.
+ * The worktree root is per-repo and lives adjacent to the source tree
+ * at `<repo>/.kobe/worktrees/<slug>/`. `<slug>` is an animal-name slug
+ * (KOB-65) for tasks created after the switch, or the task's ULID for
+ * older records whose path is already persisted.
+ *
+ * Backwards compatibility: kobe used `<repo>/.claude/worktrees/<slug>/`
+ * before it supported multiple engines. Existing tasks there remain
+ * managed and discoverable, but new kobe-created tasks use `.kobe` so
+ * neutral task storage is not named after one engine vendor.
  *
  * Keeping this in one place means the orchestrator, the worktree
  * manager, the task index, and any future "list all kobe worktrees"
@@ -28,19 +29,40 @@ import path from "node:path"
  * its enumeration to "kobe-managed only" without reaching into another
  * module's private constant.
  */
-export const KOBE_WORKTREE_ROOT_SUBPATH = ".claude/worktrees"
+export const KOBE_WORKTREE_ROOT_SUBPATH = ".kobe/worktrees"
+export const LEGACY_KOBE_WORKTREE_ROOT_SUBPATH = ".claude/worktrees"
+
+/**
+ * Managed worktree roots, primary first. Creation uses only
+ * {@link KOBE_WORKTREE_ROOT_SUBPATH}; recognition/listing checks both.
+ */
+export const KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
+  KOBE_WORKTREE_ROOT_SUBPATH,
+  LEGACY_KOBE_WORKTREE_ROOT_SUBPATH,
+] as const
 
 /**
  * Absolute path of the worktree root for a given repo.
  *
  * Example: `worktreeRootFor("/Users/x/proj")` →
- * `/Users/x/proj/.claude/worktrees`.
+ * `/Users/x/proj/.kobe/worktrees`.
  */
 export function worktreeRootFor(repo: string): string {
   if (!path.isAbsolute(repo)) {
     throw new Error(`worktreeRootFor: repo must be an absolute path, got: ${repo}`)
   }
   return path.join(repo, KOBE_WORKTREE_ROOT_SUBPATH)
+}
+
+/**
+ * Absolute paths of every worktree root kobe recognizes for `repo`.
+ * Primary root is first; legacy roots follow for existing task records.
+ */
+export function managedWorktreeRootsFor(repo: string): readonly string[] {
+  if (!path.isAbsolute(repo)) {
+    throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
+  }
+  return KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath))
 }
 
 /**
@@ -63,44 +85,60 @@ export function worktreePathFor(repo: string, slug: string): string {
 }
 
 /**
- * Immediate child directory names under {@link worktreeRootFor}`(repo)`.
+ * Immediate child directory names under every managed root for `repo`.
  *
- * Returns an empty array when the root doesn't exist yet (the very
+ * Returns an empty array when no root exists yet (the very
  * first task in a repo) or can't be read. Used by the slug allocator
  * to discover on-disk-occupied slugs (so a stale dir from an aborted
  * task still counts as taken) and by `diagnose` to reconcile the task
  * index against disk state. Symlinks are not followed.
  */
 export function listWorktreeDirNames(repo: string): string[] {
-  const root = worktreeRootFor(repo)
-  try {
-    return fs
-      .readdirSync(root, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name)
-  } catch {
-    return []
+  const names = new Set<string>()
+  for (const root of managedWorktreeRootsFor(repo)) {
+    try {
+      for (const e of fs.readdirSync(root, { withFileTypes: true })) {
+        if (e.isDirectory()) names.add(e.name)
+      }
+    } catch {
+      // A missing/unreadable root simply contributes no occupied names.
+    }
   }
+  return [...names]
 }
 
 /**
- * True iff `candidate` lives inside the kobe-managed worktree root for
- * `repo`. Used by `list()` to filter out worktrees the user (or another
- * tool) created via plain `git worktree add`.
+ * Return the caller-form managed root that contains `candidate`, or
+ * null when `candidate` is not inside any kobe-managed worktree root
+ * for `repo`.
  *
  * Canonicalizes both sides via `fs.realpathSync` when possible so that
  * macOS's `/tmp` ↔ `/private/tmp` symlink aliasing doesn't cause us to
- * miss our own worktrees (git reports the resolved form,
- * `worktreeRootFor()` returns the caller's form).
+ * miss our own worktrees (git reports the resolved form, helpers return
+ * the caller's form).
+ */
+export function managedWorktreeRootForPath(repo: string, candidate: string): string | null {
+  if (!path.isAbsolute(repo) || !path.isAbsolute(candidate)) return null
+  const target = canonicalize(candidate)
+  for (const rootPath of managedWorktreeRootsFor(repo)) {
+    const root = canonicalize(rootPath)
+    const rel = path.relative(root, target)
+    // path.relative returns ".." prefix when outside; an absolute path
+    // when on a different drive (Windows). Either rules it out.
+    if (rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel)) {
+      return rootPath
+    }
+  }
+  return null
+}
+
+/**
+ * True iff `candidate` lives inside a kobe-managed worktree root for
+ * `repo`. Used by `list()` to filter out worktrees the user (or another
+ * tool) created via plain `git worktree add`.
  */
 export function isKobeManagedPath(repo: string, candidate: string): boolean {
-  if (!path.isAbsolute(repo) || !path.isAbsolute(candidate)) return false
-  const root = canonicalize(worktreeRootFor(repo))
-  const target = canonicalize(candidate)
-  const rel = path.relative(root, target)
-  // path.relative returns ".." prefix when outside; an absolute path
-  // when on a different drive (Windows). Either rules it out.
-  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel)
+  return managedWorktreeRootForPath(repo, candidate) !== null
 }
 
 function canonicalize(p: string): string {

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -1,15 +1,17 @@
 /**
  * Canonical filesystem layout for kobe-managed worktrees.
  *
- * The worktree root is per-repo and lives adjacent to the source tree
- * at `<repo>/.kobe/worktrees/<slug>/`. `<slug>` is an animal-name slug
- * (KOB-65) for tasks created after the switch, or the task's ULID for
- * older records whose path is already persisted.
+ * The worktree root is per-repo and lives in kobe's state dir at
+ * `~/.kobe/worktrees/<repo-key>/<slug>/` (or under `$KOBE_HOME_DIR`
+ * when overridden). `<slug>` is an animal-name slug (KOB-65) for tasks
+ * created after the switch, or the task's ULID for older records whose
+ * path is already persisted.
  *
- * Backwards compatibility: kobe used `<repo>/.claude/worktrees/<slug>/`
- * before it supported multiple engines. Existing tasks there remain
- * managed and discoverable, but new kobe-created tasks use `.kobe` so
- * neutral task storage is not named after one engine vendor.
+ * Backwards compatibility: kobe briefly used repo-local
+ * `<repo>/.kobe/worktrees/<slug>/`, and before multi-engine support it
+ * used `<repo>/.claude/worktrees/<slug>/`. Existing tasks in both roots
+ * remain managed and discoverable, but new kobe-created tasks use the
+ * global kobe state dir so no repo-level `.gitignore` entry is needed.
  *
  * Keeping this in one place means the orchestrator, the worktree
  * manager, the task index, and any future "list all kobe worktrees"
@@ -19,25 +21,28 @@
  * `<repo>` is always absolute. Callers must normalize before invoking.
  */
 
+import { createHash } from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
+import { kobeStateDir } from "../../env.ts"
 
 /**
- * Directory under each repo where kobe stores all of its worktrees.
+ * Directory under kobe's state dir where kobe stores all of its worktrees.
  *
  * Exposed so the worktree manager's `list()` implementation can scope
  * its enumeration to "kobe-managed only" without reaching into another
  * module's private constant.
  */
-export const KOBE_WORKTREE_ROOT_SUBPATH = ".kobe/worktrees"
+export const KOBE_WORKTREE_ROOT_DIR = "worktrees"
+export const REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH = ".kobe/worktrees"
 export const LEGACY_KOBE_WORKTREE_ROOT_SUBPATH = ".claude/worktrees"
 
 /**
- * Managed worktree roots, primary first. Creation uses only
- * {@link KOBE_WORKTREE_ROOT_SUBPATH}; recognition/listing checks both.
+ * Repo-local compatibility roots. Creation does not use these; recognition and
+ * listing keep old task records working.
  */
-export const KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
-  KOBE_WORKTREE_ROOT_SUBPATH,
+export const REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
+  REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH,
   LEGACY_KOBE_WORKTREE_ROOT_SUBPATH,
 ] as const
 
@@ -45,13 +50,13 @@ export const KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
  * Absolute path of the worktree root for a given repo.
  *
  * Example: `worktreeRootFor("/Users/x/proj")` →
- * `/Users/x/proj/.kobe/worktrees`.
+ * `/Users/x/.kobe/worktrees/proj-a1b2c3d4e5f6`.
  */
 export function worktreeRootFor(repo: string): string {
   if (!path.isAbsolute(repo)) {
     throw new Error(`worktreeRootFor: repo must be an absolute path, got: ${repo}`)
   }
-  return path.join(repo, KOBE_WORKTREE_ROOT_SUBPATH)
+  return path.join(kobeStateDir(), KOBE_WORKTREE_ROOT_DIR, repoWorktreeDirName(repo))
 }
 
 /**
@@ -62,7 +67,10 @@ export function managedWorktreeRootsFor(repo: string): readonly string[] {
   if (!path.isAbsolute(repo)) {
     throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
   }
-  return KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath))
+  return [
+    worktreeRootFor(repo),
+    ...REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath)),
+  ]
 }
 
 /**
@@ -147,4 +155,11 @@ function canonicalize(p: string): string {
   } catch {
     return path.resolve(p)
   }
+}
+
+function repoWorktreeDirName(repo: string): string {
+  const base = path.basename(repo) || "repo"
+  const safeBase = base.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "repo"
+  const hash = createHash("sha1").update(path.resolve(repo)).digest("hex").slice(0, 12)
+  return `${safeBase}-${hash}`
 }

--- a/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
+++ b/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
@@ -4,8 +4,8 @@
  * Replaces the old "directory = task ULID" scheme (which produced 26-
  * char dir names that overflowed the terminal pane). The new shape is:
  *
- *   <repo>/.kobe/worktrees/panda/
- *   <repo>/.kobe/worktrees/panda-v2/   # if `panda` was recycled
+ *   ~/.kobe/worktrees/<repo-key>/panda/
+ *   ~/.kobe/worktrees/<repo-key>/panda-v2/   # if `panda` was recycled
  *
  * Mechanism (mirrors Conductor's city-name scheme, KOB-65):
  *   1. Build the "occupied" set: every slug currently held by a

--- a/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
+++ b/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
@@ -4,13 +4,13 @@
  * Replaces the old "directory = task ULID" scheme (which produced 26-
  * char dir names that overflowed the terminal pane). The new shape is:
  *
- *   <repo>/.claude/worktrees/panda/
- *   <repo>/.claude/worktrees/panda-v2/   # if `panda` was recycled
+ *   <repo>/.kobe/worktrees/panda/
+ *   <repo>/.kobe/worktrees/panda-v2/   # if `panda` was recycled
  *
  * Mechanism (mirrors Conductor's city-name scheme, KOB-65):
  *   1. Build the "occupied" set: every slug currently held by a
  *      non-archived task in the store, PLUS every directory name
- *      already present on disk under `<repo>/.claude/worktrees/`,
+ *      already present on disk under kobe-managed worktree roots,
  *      PLUS any slugs picked for the same repo by an earlier
  *      `allocate()` call that haven't yet been committed (race window
  *      between picking and persisting to the store).

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -90,8 +90,9 @@ export interface Task {
    * `"main"` tasks are pinned to a saved repo's root checkout (no
    * `git worktree add`); they set `worktreePath === repo` and
    * `branch === ""`. Regular `"task"` tasks live in a per-task
-   * worktree under `<repo>/.claude/worktrees/<id>/`. Optional on
-   * disk: records without it normalize to `"task"` at load time.
+   * worktree under `<repo>/.kobe/worktrees/<slug>/` (or legacy
+   * `.claude/worktrees` for older records). Optional on disk: records
+   * without it normalize to `"task"` at load time.
    */
   readonly kind?: "main" | "task"
   readonly status: TaskStatus

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -90,9 +90,9 @@ export interface Task {
    * `"main"` tasks are pinned to a saved repo's root checkout (no
    * `git worktree add`); they set `worktreePath === repo` and
    * `branch === ""`. Regular `"task"` tasks live in a per-task
-   * worktree under `<repo>/.kobe/worktrees/<slug>/` (or legacy
-   * `.claude/worktrees` for older records). Optional on disk: records
-   * without it normalize to `"task"` at load time.
+   * worktree under `~/.kobe/worktrees/<repo-key>/<slug>/` (or repo-local
+   * `.kobe/worktrees` / legacy `.claude/worktrees` for older records).
+   * Optional on disk: records without it normalize to `"task"` at load time.
    */
   readonly kind?: "main" | "task"
   readonly status: TaskStatus

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -2,8 +2,9 @@
  * Worktree manager — kobe's wrapper around `git worktree`.
  *
  * See DESIGN.md §5.3 (orchestrator owns worktree manager) and §11.3
- * (resolved: worktree root is `<repo>/.claude/worktrees/<task-id>/`,
- * shared namespace with Claude Code's own agent-spawn worktrees).
+ * (resolved: new kobe-created worktrees use
+ * `<repo>/.kobe/worktrees/<slug>/`; legacy `.claude/worktrees` task
+ * paths remain supported).
  *
  * The orchestrator depends on this interface; `GitWorktreeManager` is
  * the production implementation. The orchestrator must never shell out
@@ -28,7 +29,7 @@ export interface WorktreeInfo {
 /**
  * A git worktree discovered on disk that COULD be adopted as a kobe
  * task (KOB-256). Unlike {@link WorktreeInfo} (kobe-managed only), this
- * includes worktrees the user created outside `<repo>/.claude/worktrees/`
+ * includes worktrees the user created outside kobe-managed worktree roots
  * via plain `git worktree add`. `kobeManaged` marks whether the path
  * lives under the kobe convention root, so the UI can label its origin.
  */

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -3,8 +3,8 @@
  *
  * See DESIGN.md §5.3 (orchestrator owns worktree manager) and §11.3
  * (resolved: new kobe-created worktrees use
- * `<repo>/.kobe/worktrees/<slug>/`; legacy `.claude/worktrees` task
- * paths remain supported).
+ * `~/.kobe/worktrees/<repo-key>/<slug>/`; repo-local `.kobe/worktrees`
+ * and legacy `.claude/worktrees` task paths remain supported).
  *
  * The orchestrator depends on this interface; `GitWorktreeManager` is
  * the production implementation. The orchestrator must never shell out

--- a/packages/kobe/test/daemon/cwd-task.test.ts
+++ b/packages/kobe/test/daemon/cwd-task.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, it } from "vitest"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { findAdoptableWorktree, matchRepoByCwd, matchTaskByCwd } from "../../src/daemon/cwd-task.ts"
+import { REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH, worktreeRootFor } from "../../src/orchestrator/worktree/paths.ts"
+
+let prevHome: string | undefined
+
+beforeEach(() => {
+  prevHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = "/home/kobe-test"
+})
+
+afterEach(() => {
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = prevHome
+})
 
 describe("matchTaskByCwd", () => {
   const main = { id: "main", worktreePath: "/repo" }
-  const sub = { id: "sub", worktreePath: "/repo/.kobe/worktrees/snipe" }
+  const sub = { id: "sub", worktreePath: "/repo/.claude/worktrees/snipe" }
   const other = { id: "other", worktreePath: "/elsewhere/proj" }
   const tasks = [main, sub, other]
 
@@ -18,8 +32,14 @@ describe("matchTaskByCwd", () => {
   it("prefers the longest (most specific) worktree — sub-task over its repo root", () => {
     // A sub-task's worktree lives UNDER the main task's repo root, so the cwd
     // prefix-matches both; the longer path must win.
-    expect(matchTaskByCwd(tasks, "/repo/.kobe/worktrees/snipe")).toBe("sub")
-    expect(matchTaskByCwd(tasks, "/repo/.kobe/worktrees/snipe/pkg")).toBe("sub")
+    expect(matchTaskByCwd(tasks, "/repo/.claude/worktrees/snipe")).toBe("sub")
+    expect(matchTaskByCwd(tasks, "/repo/.claude/worktrees/snipe/pkg")).toBe("sub")
+  })
+
+  it("matches a global kobe-state worktree", () => {
+    const wt = path.join(worktreeRootFor("/repo"), "snipe")
+    expect(matchTaskByCwd([{ id: "sub", worktreePath: wt }], wt)).toBe("sub")
+    expect(matchTaskByCwd([{ id: "sub", worktreePath: wt }], path.join(wt, "pkg"))).toBe("sub")
   })
 
   it("falls back to the repo-root (main) task for a cwd not under any sub-worktree", () => {
@@ -48,7 +68,7 @@ describe("matchTaskByCwd", () => {
 describe("matchRepoByCwd", () => {
   const tasks = [
     { id: "main", repo: "/repo", worktreePath: "/repo" },
-    { id: "sub", repo: "/repo", worktreePath: "/repo/.kobe/worktrees/known" },
+    { id: "sub", repo: "/repo", worktreePath: "/repo/.claude/worktrees/known" },
     { id: "other", repo: "/elsewhere/proj", worktreePath: "/elsewhere/proj" },
   ]
 
@@ -60,7 +80,7 @@ describe("matchRepoByCwd", () => {
     expect(matchRepoByCwd(tasks, "/repo/src/deep")).toBe("/repo")
     // A `git worktree add` run from inside an existing worktree still resolves
     // to the tracked repo root (the longest repo prefix).
-    expect(matchRepoByCwd(tasks, "/repo/.kobe/worktrees/known")).toBe("/repo")
+    expect(matchRepoByCwd(tasks, "/repo/.claude/worktrees/known")).toBe("/repo")
   })
 
   it("prefers the longest (most specific) repo when repos nest", () => {
@@ -86,49 +106,61 @@ describe("matchRepoByCwd", () => {
 
 describe("findAdoptableWorktree", () => {
   // kobe tracks repo "/repo" (main task) + one sub-task worktree.
-  const tasks = [
+  const tasks = () => [
     { id: "main", repo: "/repo", worktreePath: "/repo" },
-    { id: "sub", repo: "/repo", worktreePath: "/repo/.kobe/worktrees/known" },
+    { id: "sub", repo: "/repo", worktreePath: path.join(worktreeRootFor("/repo"), "known") },
+    { id: "repo-local", repo: "/repo", worktreePath: `/repo/${REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH}/local` },
     { id: "legacy", repo: "/repo", worktreePath: "/repo/.claude/worktrees/old" },
   ]
 
-  it("adopts an external worktree under a tracked repo's .kobe/worktrees", () => {
-    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/external")).toEqual({
+  it("adopts an external worktree under the global kobe state worktree root", () => {
+    const wt = path.join(worktreeRootFor("/repo"), "external")
+    expect(findAdoptableWorktree(tasks(), wt)).toEqual({
+      repo: "/repo",
+      worktreePath: wt,
+    })
+  })
+
+  it("still adopts repo-local .kobe/worktrees from the brief-lived layout", () => {
+    expect(findAdoptableWorktree(tasks(), "/repo/.kobe/worktrees/external")).toEqual({
       repo: "/repo",
       worktreePath: "/repo/.kobe/worktrees/external",
     })
   })
 
   it("still adopts legacy external worktrees under a tracked repo's .claude/worktrees", () => {
-    expect(findAdoptableWorktree(tasks, "/repo/.claude/worktrees/external")).toEqual({
+    expect(findAdoptableWorktree(tasks(), "/repo/.claude/worktrees/external")).toEqual({
       repo: "/repo",
       worktreePath: "/repo/.claude/worktrees/external",
     })
   })
 
   it("derives the worktree dir even when cwd is a subdir of it", () => {
-    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/external/src/deep")).toEqual({
+    const wt = path.join(worktreeRootFor("/repo"), "external")
+    expect(findAdoptableWorktree(tasks(), path.join(wt, "src/deep"))).toEqual({
       repo: "/repo",
-      worktreePath: "/repo/.kobe/worktrees/external",
+      worktreePath: wt,
     })
   })
 
   it("returns undefined when that worktree is already a task", () => {
-    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/known")).toBeUndefined()
-    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/known/pkg")).toBeUndefined()
-    expect(findAdoptableWorktree(tasks, "/repo/.claude/worktrees/old")).toBeUndefined()
+    const wt = path.join(worktreeRootFor("/repo"), "known")
+    expect(findAdoptableWorktree(tasks(), wt)).toBeUndefined()
+    expect(findAdoptableWorktree(tasks(), path.join(wt, "pkg"))).toBeUndefined()
+    expect(findAdoptableWorktree(tasks(), "/repo/.kobe/worktrees/local")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks(), "/repo/.claude/worktrees/old")).toBeUndefined()
   })
 
   it("ignores a cwd at the repo root or in a normal subdir (not a worktree)", () => {
-    expect(findAdoptableWorktree(tasks, "/repo")).toBeUndefined()
-    expect(findAdoptableWorktree(tasks, "/repo/src")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks(), "/repo")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks(), "/repo/src")).toBeUndefined()
   })
 
   it("ignores a cwd under an UNtracked repo", () => {
-    expect(findAdoptableWorktree(tasks, "/other/.kobe/worktrees/x")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks(), path.join(worktreeRootFor("/other"), "x"))).toBeUndefined()
   })
 
   it("ignores a sibling-prefix repo (/repo vs /repo-other)", () => {
-    expect(findAdoptableWorktree(tasks, "/repo-other/.kobe/worktrees/x")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks(), "/repo-other/.kobe/worktrees/x")).toBeUndefined()
   })
 })

--- a/packages/kobe/test/daemon/cwd-task.test.ts
+++ b/packages/kobe/test/daemon/cwd-task.test.ts
@@ -3,7 +3,7 @@ import { findAdoptableWorktree, matchRepoByCwd, matchTaskByCwd } from "../../src
 
 describe("matchTaskByCwd", () => {
   const main = { id: "main", worktreePath: "/repo" }
-  const sub = { id: "sub", worktreePath: "/repo/.claude/worktrees/snipe" }
+  const sub = { id: "sub", worktreePath: "/repo/.kobe/worktrees/snipe" }
   const other = { id: "other", worktreePath: "/elsewhere/proj" }
   const tasks = [main, sub, other]
 
@@ -18,8 +18,8 @@ describe("matchTaskByCwd", () => {
   it("prefers the longest (most specific) worktree — sub-task over its repo root", () => {
     // A sub-task's worktree lives UNDER the main task's repo root, so the cwd
     // prefix-matches both; the longer path must win.
-    expect(matchTaskByCwd(tasks, "/repo/.claude/worktrees/snipe")).toBe("sub")
-    expect(matchTaskByCwd(tasks, "/repo/.claude/worktrees/snipe/pkg")).toBe("sub")
+    expect(matchTaskByCwd(tasks, "/repo/.kobe/worktrees/snipe")).toBe("sub")
+    expect(matchTaskByCwd(tasks, "/repo/.kobe/worktrees/snipe/pkg")).toBe("sub")
   })
 
   it("falls back to the repo-root (main) task for a cwd not under any sub-worktree", () => {
@@ -48,7 +48,7 @@ describe("matchTaskByCwd", () => {
 describe("matchRepoByCwd", () => {
   const tasks = [
     { id: "main", repo: "/repo", worktreePath: "/repo" },
-    { id: "sub", repo: "/repo", worktreePath: "/repo/.claude/worktrees/known" },
+    { id: "sub", repo: "/repo", worktreePath: "/repo/.kobe/worktrees/known" },
     { id: "other", repo: "/elsewhere/proj", worktreePath: "/elsewhere/proj" },
   ]
 
@@ -60,7 +60,7 @@ describe("matchRepoByCwd", () => {
     expect(matchRepoByCwd(tasks, "/repo/src/deep")).toBe("/repo")
     // A `git worktree add` run from inside an existing worktree still resolves
     // to the tracked repo root (the longest repo prefix).
-    expect(matchRepoByCwd(tasks, "/repo/.claude/worktrees/known")).toBe("/repo")
+    expect(matchRepoByCwd(tasks, "/repo/.kobe/worktrees/known")).toBe("/repo")
   })
 
   it("prefers the longest (most specific) repo when repos nest", () => {
@@ -88,10 +88,18 @@ describe("findAdoptableWorktree", () => {
   // kobe tracks repo "/repo" (main task) + one sub-task worktree.
   const tasks = [
     { id: "main", repo: "/repo", worktreePath: "/repo" },
-    { id: "sub", repo: "/repo", worktreePath: "/repo/.claude/worktrees/known" },
+    { id: "sub", repo: "/repo", worktreePath: "/repo/.kobe/worktrees/known" },
+    { id: "legacy", repo: "/repo", worktreePath: "/repo/.claude/worktrees/old" },
   ]
 
-  it("adopts an external worktree under a tracked repo's .claude/worktrees", () => {
+  it("adopts an external worktree under a tracked repo's .kobe/worktrees", () => {
+    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/external")).toEqual({
+      repo: "/repo",
+      worktreePath: "/repo/.kobe/worktrees/external",
+    })
+  })
+
+  it("still adopts legacy external worktrees under a tracked repo's .claude/worktrees", () => {
     expect(findAdoptableWorktree(tasks, "/repo/.claude/worktrees/external")).toEqual({
       repo: "/repo",
       worktreePath: "/repo/.claude/worktrees/external",
@@ -99,15 +107,16 @@ describe("findAdoptableWorktree", () => {
   })
 
   it("derives the worktree dir even when cwd is a subdir of it", () => {
-    expect(findAdoptableWorktree(tasks, "/repo/.claude/worktrees/external/src/deep")).toEqual({
+    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/external/src/deep")).toEqual({
       repo: "/repo",
-      worktreePath: "/repo/.claude/worktrees/external",
+      worktreePath: "/repo/.kobe/worktrees/external",
     })
   })
 
   it("returns undefined when that worktree is already a task", () => {
-    expect(findAdoptableWorktree(tasks, "/repo/.claude/worktrees/known")).toBeUndefined()
-    expect(findAdoptableWorktree(tasks, "/repo/.claude/worktrees/known/pkg")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/known")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks, "/repo/.kobe/worktrees/known/pkg")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks, "/repo/.claude/worktrees/old")).toBeUndefined()
   })
 
   it("ignores a cwd at the repo root or in a normal subdir (not a worktree)", () => {
@@ -116,10 +125,10 @@ describe("findAdoptableWorktree", () => {
   })
 
   it("ignores a cwd under an UNtracked repo", () => {
-    expect(findAdoptableWorktree(tasks, "/other/.claude/worktrees/x")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks, "/other/.kobe/worktrees/x")).toBeUndefined()
   })
 
   it("ignores a sibling-prefix repo (/repo vs /repo-other)", () => {
-    expect(findAdoptableWorktree(tasks, "/repo-other/.claude/worktrees/x")).toBeUndefined()
+    expect(findAdoptableWorktree(tasks, "/repo-other/.kobe/worktrees/x")).toBeUndefined()
   })
 })

--- a/packages/kobe/test/orchestrator/branch-follow.test.ts
+++ b/packages/kobe/test/orchestrator/branch-follow.test.ts
@@ -22,18 +22,23 @@ const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
 let tmpRoot: string
 let repo: string
 let orch: Orchestrator
+let prevHome: string | undefined
 
 beforeEach(async () => {
+  prevHome = process.env.KOBE_HOME_DIR
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-branchfollow-"))
+  process.env.KOBE_HOME_DIR = path.join(tmpRoot, "home")
   repo = path.join(tmpRoot, "repo")
   const r = spawnSync("bash", [REPO_INIT, repo], { encoding: "utf8" })
   if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}\n${r.stdout}`)
-  const store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  const store = new TaskIndexStore({ homeDir: process.env.KOBE_HOME_DIR })
   await store.load()
   orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
 })
 
 afterEach(() => {
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = prevHome
   try {
     fs.rmSync(tmpRoot, { recursive: true, force: true })
   } catch {

--- a/packages/kobe/test/orchestrator/slug-allocator.test.ts
+++ b/packages/kobe/test/orchestrator/slug-allocator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { SlugAllocator } from "../../src/orchestrator/worktree/slug-allocator.ts"
 
-// A repo path with no `.claude/worktrees/` on disk → listWorktreeDirNames
+// A repo path with no managed worktree roots on disk → listWorktreeDirNames
 // returns [], so "occupied" reduces to active + pending slugs and the
 // allocator's pure logic can be exercised without touching the filesystem.
 const REPO = "/tmp/kobe-slug-test-does-not-exist"

--- a/packages/kobe/test/orchestrator/worktree.test.ts
+++ b/packages/kobe/test/orchestrator/worktree.test.ts
@@ -10,7 +10,7 @@
  *
  * Each test gets a fresh tmp repo built by
  * `test/behavior/fixtures/repo-init.sh`. We tear it down explicitly so
- * macOS's `/var/folders` doesn't fill up with stale `.kobe/worktrees`
+ * macOS's `/var/folders` doesn't fill up with stale test worktrees
  * trees if a run is interrupted.
  */
 
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
 import {
   LEGACY_KOBE_WORKTREE_ROOT_SUBPATH,
+  REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH,
   worktreePathFor,
   worktreeRootFor,
 } from "../../src/orchestrator/worktree/paths.ts"
@@ -30,9 +31,12 @@ const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
 
 let tmpRoot: string
 let repo: string
+let prevHome: string | undefined
 
 beforeEach(() => {
+  prevHome = process.env.KOBE_HOME_DIR
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-worktree-"))
+  process.env.KOBE_HOME_DIR = path.join(tmpRoot, "home")
   repo = path.join(tmpRoot, "repo")
   const result = spawnSync("bash", [REPO_INIT, repo], { encoding: "utf8" })
   if (result.status !== 0) {
@@ -41,6 +45,8 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = prevHome
   // Best-effort cleanup. We don't fail the test if the rm trips —
   // some platforms leave file handles momentarily after git operations.
   try {
@@ -63,7 +69,7 @@ describe("GitWorktreeManager.create", () => {
     expect(info.dirty).toBe(false)
     expect(fs.existsSync(target)).toBe(true)
     expect(fs.existsSync(path.join(target, "README.md"))).toBe(true)
-    expect(target.startsWith(path.join(repo, ".kobe", "worktrees"))).toBe(true)
+    expect(target.startsWith(path.join(tmpRoot, "home", ".kobe", "worktrees"))).toBe(true)
   })
 
   test("is idempotent: second call with the same args returns equivalent info", async () => {
@@ -117,6 +123,15 @@ describe("GitWorktreeManager.list", () => {
 
     const list = await mgr.list(repo)
     expect(list.find((w) => w.branch === "kobe/legacy")?.path).toBe(legacyTarget)
+  })
+
+  test("still lists repo-local .kobe/worktrees tasks without rewriting their paths", async () => {
+    const mgr = new GitWorktreeManager()
+    const localTarget = path.join(repo, REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH, "local")
+    await mgr.create(repo, "kobe/local", localTarget)
+
+    const list = await mgr.list(repo)
+    expect(list.find((w) => w.branch === "kobe/local")?.path).toBe(localTarget)
   })
 })
 
@@ -261,7 +276,7 @@ describe("createForTask helper", () => {
 describe("GitWorktreeManager.listAll (KOB-256)", () => {
   test("includes external worktrees + excludes main checkout, with kobeManaged flags", async () => {
     const mgr = new GitWorktreeManager()
-    // kobe-managed worktree under <repo>/.kobe/worktrees/
+    // kobe-managed worktree under KOBE_HOME_DIR/.kobe/worktrees/
     const managed = await mgr.createForTask({ repo, slug: "managed-wt", branch: "kobe/managed" })
     // external worktree created by the user OUTSIDE the convention root
     const extPath = path.join(tmpRoot, "external-wt")

--- a/packages/kobe/test/orchestrator/worktree.test.ts
+++ b/packages/kobe/test/orchestrator/worktree.test.ts
@@ -10,7 +10,7 @@
  *
  * Each test gets a fresh tmp repo built by
  * `test/behavior/fixtures/repo-init.sh`. We tear it down explicitly so
- * macOS's `/var/folders` doesn't fill up with stale `.claude/worktrees`
+ * macOS's `/var/folders` doesn't fill up with stale `.kobe/worktrees`
  * trees if a run is interrupted.
  */
 
@@ -20,7 +20,11 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
-import { worktreePathFor, worktreeRootFor } from "../../src/orchestrator/worktree/paths.ts"
+import {
+  LEGACY_KOBE_WORKTREE_ROOT_SUBPATH,
+  worktreePathFor,
+  worktreeRootFor,
+} from "../../src/orchestrator/worktree/paths.ts"
 
 const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
 
@@ -59,6 +63,7 @@ describe("GitWorktreeManager.create", () => {
     expect(info.dirty).toBe(false)
     expect(fs.existsSync(target)).toBe(true)
     expect(fs.existsSync(path.join(target, "README.md"))).toBe(true)
+    expect(target.startsWith(path.join(repo, ".kobe", "worktrees"))).toBe(true)
   })
 
   test("is idempotent: second call with the same args returns equivalent info", async () => {
@@ -103,6 +108,15 @@ describe("GitWorktreeManager.list", () => {
     for (const w of list) {
       expect(w.path.startsWith(worktreeRootFor(repo))).toBe(true)
     }
+  })
+
+  test("still lists legacy .claude/worktrees tasks without rewriting their paths", async () => {
+    const mgr = new GitWorktreeManager()
+    const legacyTarget = path.join(repo, LEGACY_KOBE_WORKTREE_ROOT_SUBPATH, "legacy")
+    await mgr.create(repo, "kobe/legacy", legacyTarget)
+
+    const list = await mgr.list(repo)
+    expect(list.find((w) => w.branch === "kobe/legacy")?.path).toBe(legacyTarget)
   })
 })
 
@@ -247,7 +261,7 @@ describe("createForTask helper", () => {
 describe("GitWorktreeManager.listAll (KOB-256)", () => {
   test("includes external worktrees + excludes main checkout, with kobeManaged flags", async () => {
     const mgr = new GitWorktreeManager()
-    // kobe-managed worktree under <repo>/.claude/worktrees/
+    // kobe-managed worktree under <repo>/.kobe/worktrees/
     const managed = await mgr.createForTask({ repo, slug: "managed-wt", branch: "kobe/managed" })
     // external worktree created by the user OUTSIDE the convention root
     const extPath = path.join(tmpRoot, "external-wt")


### PR DESCRIPTION
New kobe-created task worktrees now live under `~/.kobe/worktrees/<repo-key>/<slug>/`, keeping kobe runtime worktrees out of source repos so users do not need repo-level `.gitignore` rules. Existing repo-local `.kobe/worktrees` and legacy `.claude/worktrees` tasks remain recognized by listing, slug allocation, and daemon cwd auto-adoption, so no migration is required. Docs, type comments, reset/help copy, and tests were updated to describe the new primary root plus compatibility roots. The branch also syncs `bun.lock` to the existing 0.7.12 package version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and design documentation to reflect new centralized worktree storage location under `~/.kobe/worktrees/`

* **Refactor**
  * Reorganized worktree storage to use centralized global location while maintaining backwards compatibility with existing repo-local and legacy paths

* **Tests**
  * Updated tests to verify worktree organization across new and legacy storage locations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->