### PR TITLE
feat: file-tree enter — one-key open in nvim/vim diff, drop e

### DIFF
--- a/.changeset/file-tree-enter-nvim-diff.md
+++ b/.changeset/file-tree-enter-nvim-diff.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+**`enter` in the file tree now opens the file directly in nvim/vim** — a changed file (vs HEAD) opens in side-by-side `nvim -d` diff mode with the committed version read-only on the left and the live editable file on the right; an unchanged file opens for plain editing. The HEAD blob is materialised to a tmp file (the `sh -c` safe stand-in for `<(git show …)`) and removed on exit, touching neither your nvim config nor the repo. When no nvim/vim is installed it falls back to the built-in read-only opentui preview, so `enter` is never a dead key. The separate `e` (edit) key is removed — `enter` is the single open action.

--- a/packages/kobe/src/tmux/editor-launch.ts
+++ b/packages/kobe/src/tmux/editor-launch.ts
@@ -20,6 +20,17 @@
  * editor's exit code — a `:cq` / non-zero quit is a real edit session,
  * not a launch failure, and must not bounce to preview.
  *
+ * nvim/vim diff mode: when the resolved editor is a PLAIN nvim/vim open
+ * (`<bin> <file>`, no custom flags) AND the file differs from HEAD, `e`
+ * upgrades to side-by-side diff mode — the committed HEAD blob read-only
+ * on the left, the live editable file on the right. This is the sh-`-c`
+ * safe form of `nvim -d <file> <(git show HEAD:<file>)`: tmux runs the
+ * window via `sh -c`, which has no `<(…)` process substitution, so the
+ * HEAD blob is dumped to a tmp file (the explicit stand-in for the
+ * process-substitution fd) and `rm`-ed when the editor exits. Nothing
+ * touches the user's nvim config or the repo — zero-install, zero-config.
+ * A custom command with its own flags is never rewritten.
+ *
  * Settings (shared `state.json`, read cross-process via getPersistedString
  * since the Ops host is its own process):
  *   - `editor.kind`          "vim" | "nano" | "custom"   (default "vim")
@@ -84,6 +95,45 @@ export function buildEditorCommand(
 }
 
 /**
+ * Pure: the sh command that opens `absPath` in nvim/vim's built-in diff
+ * mode (`-d`) against its committed HEAD version.
+ *
+ * tmux runs the window via `sh -c`, which has no `<(…)` process
+ * substitution, so we materialise bash's `<(git show HEAD:<file>)` as a
+ * mktemp file: dump the HEAD blob into it, `nvim -d "$tmp" <file>` (HEAD
+ * read-only on the LEFT, live editable file on the RIGHT, cursor parked on
+ * the right), then `rm` it on exit. A single sh layer — every path is
+ * `shellQuote`d here, with no second shell-in-nvim parse to re-escape.
+ *
+ * `relPath` is worktree-relative; `HEAD:./<rel>` pins the blob lookup to
+ * the worktree cwd. If the HEAD blob can't be read (e.g. a race removed
+ * the diff between the check and the launch), it falls back to a plain
+ * `<bin> <file>` open so `e` still lands in an editor.
+ */
+export function buildNvimDiffCommand(bin: string, absPath: string, relPath: string): string {
+  const file = shellQuote(absPath)
+  const head = shellQuote(`HEAD:./${relPath}`)
+  return [
+    "f=$(mktemp 2>/dev/null)",
+    `if [ -n "$f" ] && git show ${head} > "$f" 2>/dev/null; then`,
+    `  ${bin} -d "$f" ${file} -c 'setlocal nomodifiable' -c 'wincmd l'; r=$?`,
+    "else",
+    `  ${bin} ${file}; r=$?`,
+    "fi",
+    'rm -f "$f" 2>/dev/null; exit $r',
+  ].join("\n")
+}
+
+/**
+ * Worktree-relative form of `absPath`, or `null` when it isn't under
+ * `worktree` (then the diff upgrade is skipped and we just open the file).
+ */
+export function relativeToWorktree(worktree: string, absPath: string): string | null {
+  const prefix = worktree.endsWith("/") ? worktree : `${worktree}/`
+  return absPath.startsWith(prefix) ? absPath.slice(prefix.length) : null
+}
+
+/**
  * Resolve the editor command from persisted settings + env (the IO wrapper
  * around {@link buildEditorCommand}). Read cross-process via
  * getPersistedString since the Ops host is its own process.
@@ -123,6 +173,31 @@ export async function binaryAvailable(bin: string): Promise<boolean> {
 }
 
 /**
+ * Does `relPath` differ from its HEAD version? Gate for the nvim/vim diff
+ * upgrade. `git diff --quiet` exits 1 on differences, 0 on none; we treat
+ * ONLY exit 1 as "has diff" so an untracked/new file (exit 0 — no HEAD
+ * blob to diff) or a git error (other codes) opens plain, not in diff mode.
+ *
+ * `GIT_OPTIONAL_LOCKS=0` keeps it lock-free, matching the read-only preview
+ * (`tui/ops/host.tsx` gitDiff) — it must not take `.git/index.lock` and
+ * race the worktree's engine commits.
+ */
+export async function fileHasDiff(worktree: string, relPath: string): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["git", "diff", "--quiet", "HEAD", "--", relPath], {
+      cwd: worktree,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+    })
+    return (await proc.exited) === 1
+  } catch {
+    return false
+  }
+}
+
+/**
  * Open `absPath` in the configured editor in a new tmux window of
  * `session`. Returns `true` if the editor was launched, `false` if it
  * couldn't be resolved / isn't installed (caller should fall back to the
@@ -133,12 +208,38 @@ export async function openInEditor(session: string, worktree: string, absPath: s
   const resolved = await resolveEditorCommand(absPath)
   if (!resolved) return false
   if (!(await binaryAvailable(resolved.bin))) return false
+  const command = await maybeDiffCommand(resolved, worktree, absPath)
   // Name the window after the FILE being edited (its basename), matching
   // the read-only preview window's labelling. With several files open this
   // is what tells the tmux window list apart; which editor it is, is
   // obvious from the editor's own UI.
-  await newWindow(session, { cwd: worktree, command: resolved.command, name: editorWindowLabel(absPath) })
+  await newWindow(session, { cwd: worktree, command, name: editorWindowLabel(absPath) })
   return true
+}
+
+/**
+ * Upgrade a resolved editor command to nvim/vim side-by-side diff mode when
+ * it's a PLAIN nvim/vim open of a file that differs from HEAD; otherwise
+ * return it unchanged.
+ *
+ * Gated on the command being EXACTLY the simple `<bin> <file>` form: an
+ * explicit `vim`/`nvim` kind, an auto-detected one, or `$EDITOR=nvim` all
+ * resolve to that, while a custom command carrying its own flags
+ * (`nvim -u … {file}`) does not match and is left untouched — we never
+ * rewrite a user's deliberate invocation.
+ */
+async function maybeDiffCommand(
+  resolved: { bin: string; command: string },
+  worktree: string,
+  absPath: string,
+): Promise<string> {
+  const { bin, command } = resolved
+  if (bin !== "nvim" && bin !== "vim") return command
+  if (command !== `${bin} ${shellQuote(absPath)}`) return command
+  const rel = relativeToWorktree(worktree, absPath)
+  if (!rel) return command
+  if (!(await fileHasDiff(worktree, rel))) return command
+  return buildNvimDiffCommand(bin, absPath, rel)
 }
 
 /** Basename of the file path, for the tmux window label (the edited file). */

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -644,25 +644,16 @@ export const KobeKeymap: readonly KobeBinding[] = [
     hint: { keys: "h/l", label: "level" },
   },
   {
+    // enter → one-key "just open it": opens the file in the user's
+    // nvim/vim (side-by-side `nvim -d` diff vs HEAD when changed, a plain
+    // editable open otherwise), falling back to our own opentui read-only
+    // preview only when no nvim/vim is installed.
     id: "files.open",
     scope: "files",
     keys: ["return"],
     category: "Files",
-    description: "Open file read-only preview",
-    hint: { keys: "enter", label: "preview" },
-  },
-  {
-    // `e` → open the current file in the configured editor (vim / nano /
-    // custom) in a new tmux window. Separate, deliberate action from the
-    // `enter` read-only preview — no preview→edit bridge. Plain letter,
-    // files-scoped per the keybinding-boundaries rule (docs/KEYBINDINGS.md)
-    // so it can't collide with composer typing.
-    id: "files.edit",
-    scope: "files",
-    keys: ["e"],
-    category: "Files",
-    description: "Open file in the configured editor (vim / nano / custom)",
-    hint: { keys: "e", label: "edit" },
+    description: "Open file in nvim (diff vs HEAD when changed)",
+    hint: { keys: "enter", label: "open" },
   },
   {
     // `[` / `]` cycle the All / Changes tabs. Bracket pair matches

--- a/packages/kobe/src/tui/ops/host.tsx
+++ b/packages/kobe/src/tui/ops/host.tsx
@@ -3,13 +3,15 @@
  * session (v0.6 / KOB-233).
  *
  * Reuses the v0.5 `FileTree` to browse the worktree. Activating a file
- * (enter / click) opens a **full-width preview window** — a fresh tmux
- * window running `kobe ops --preview <file>`, which renders opentui's
- * `<diff>` / `<code>` (tree-sitter syntax highlighting + line numbers,
- * zero external deps). Reviewing a diff wants the whole terminal width,
- * which the narrow Ops pane can't give; a new window does, and `q`
- * closes it back to the three-pane layout. If that launch fails the
- * window falls back to the user's own pager (`delta`/`bat`/`less`).
+ * (enter / click) is a one-key "just open it": it opens the file in the
+ * user's nvim/vim in a fresh tmux window — side-by-side `nvim -d` diff vs
+ * HEAD when the file has changes, a plain editable open when it doesn't.
+ * Only when no nvim/vim is installed does it fall back to our own built-in
+ * **full-width preview window** — a fresh tmux window running
+ * `kobe ops --preview <file>`, which renders opentui's `<diff>` / `<code>`
+ * (tree-sitter syntax highlighting + line numbers, zero external deps),
+ * closed with `q` back to the three-pane layout. So nvim is the primary
+ * surface and the opentui preview is the last-resort fallback.
  *
  * Runs in its own OS process inside the tmux pane (separate opentui
  * render loop from the outer kobe TUI). It can't share the outer TUI's
@@ -203,14 +205,14 @@ function OpsShell(props: OpsHostArgs & { prefs: ThemePrefs }) {
     })
   }
 
-  // `e` on a file → open it in the user's editor (vim / nano / custom) in
-  // a fresh tmux window. Read-only preview (enter) and editor (e) are
-  // separate, deliberate actions — no preview→edit bridge. If the editor
-  // can't launch (binary missing / nothing configured), fall back to the
-  // read-only preview so `e` is never a dead key. Same phantom-session
-  // guard as `openPreview`: a standalone `kobe ops` (no task id) has no
-  // session to open a window in, so just preview.
-  function openEditor(rel: string): void {
+  // enter on a file → one-key "just open it". Open it in the user's
+  // nvim/vim in a fresh tmux window (side-by-side `nvim -d` diff vs HEAD
+  // when changed, plain editable open otherwise). Only when no editor can
+  // launch (no nvim/vim installed / nothing configured) do we fall back to
+  // our own read-only opentui preview — so enter is never a dead key.
+  // Phantom-session guard: a standalone `kobe ops` (no task id) has no
+  // session to open an editor window in, so it just previews.
+  function openFile(rel: string): void {
     if (!props.taskId) {
       openPreview(rel)
       return
@@ -245,8 +247,7 @@ function OpsShell(props: OpsHostArgs & { prefs: ThemePrefs }) {
       <FileTree
         worktreePath={() => props.worktree}
         focused={() => true}
-        onOpenFile={openPreview}
-        onEditFile={openEditor}
+        onOpenFile={openFile}
         onMention={injectMention}
         onCreatePR={() => void createPR()}
         cornerBadge={cornerBadge}

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -92,14 +92,6 @@ export type FileTreeProps = {
    */
   onOpenFile: (relPath: string) => void
   /**
-   * Fires when the user requests to EDIT the current file (the `e` key) —
-   * the Ops host opens it in the configured editor (vim / nano / custom)
-   * in a new tmux window. Distinct from `onOpenFile` (enter), which is the
-   * read-only preview. Omit it elsewhere (the key no-ops on dirs / when
-   * unwired).
-   */
-  onEditFile?: (relPath: string) => void
-  /**
    * Fires when the user requests an `@<path>` mention of the current
    * file (the `a` key). The Ops host wires this to a tmux send-keys
    * injection into the engine pane; omit it elsewhere (the key no-ops).
@@ -518,15 +510,6 @@ export function FileTree(props: FileTreeProps) {
     if (!row || row.kind === "dir") return
     props.onMention?.(row.path)
   }
-  function editCurrent(): void {
-    const r = rows()
-    const i = cursorIndex()
-    if (i < 0 || i >= r.length) return
-    const row = r[i]
-    // Only files open in an editor; dirs are ignored (enter toggles them).
-    if (!row || row.kind === "dir") return
-    props.onEditFile?.(row.path)
-  }
   function refresh(): void {
     setRefreshTick((n) => n + 1)
     props.onRefresh?.()
@@ -551,7 +534,6 @@ export function FileTree(props: FileTreeProps) {
     currentTab: tab,
     openCurrent,
     mentionCurrent,
-    editCurrent,
     createPR: props.onCreatePR,
     openExternal,
     refresh,
@@ -811,14 +793,14 @@ export function FileTree(props: FileTreeProps) {
         </Show>
       </scrollbox>
 
-      {/* Footer hint — the two file-open actions. `enter` is the read-only
-         preview/diff; `e` opens the file in the configured editor
-         (vim / nano / custom) in a new tmux window. Shown only when a
-         worktree is loaded so the "no task" placeholder stays clean. */}
+      {/* Footer hint — `enter` opens the file (nvim diff vs HEAD when
+         changed, plain edit otherwise; opentui preview if no nvim/vim).
+         Shown only when a worktree is loaded so the "no task" placeholder
+         stays clean. */}
       <Show when={props.worktreePath() != null}>
         <box flexDirection="row" paddingTop={1} flexShrink={0}>
           <text fg={theme.textMuted} wrapMode="none">
-            ↵ preview · e edit
+            ↵ open
           </text>
         </box>
       </Show>

--- a/packages/kobe/src/tui/panes/filetree/keys.ts
+++ b/packages/kobe/src/tui/panes/filetree/keys.ts
@@ -5,8 +5,9 @@
  *   - `j` / `down`         next row
  *   - `k` / `up`           previous row
  *   - `1` / `2` / `3`      switch to All / Changes / Checks tab
- *   - `enter` / `return`   open current file read-only preview (calls `onOpenFile`)
- *   - `e`                  open current file in the editor (calls `onEditFile`)
+ *   - `enter` / `return`   open current file in nvim/vim — `-d` diff vs HEAD
+ *                          when changed, plain edit otherwise; falls back to
+ *                          our opentui read-only preview (calls `onOpenFile`)
  *   - `a`                  inject current file as `@<path>` (calls `onMention`)
  *   - `p`                  create PR prompt (Ops host only)
  *   - `r`                  refresh (re-run git commands)
@@ -57,8 +58,6 @@ export type FileTreeBindingsOpts = {
   openCurrent: () => void
   /** `a` — inject the current file as an `@<path>` mention (Ops host only). */
   mentionCurrent?: () => void
-  /** `e` — open the current file in the configured editor (Ops host only). */
-  editCurrent?: () => void
   /** `p` — inject the Create PR prompt into the engine pane (Ops host only). */
   createPR?: () => void
   /** Hand the current row off to the OS default app (audio, video, PDF). */
@@ -98,7 +97,6 @@ export function useFileTreeBindings(opts: FileTreeBindingsOpts): void {
         if (next) opts.setTab(next)
       },
       "files.open": () => opts.openCurrent(),
-      "files.edit": () => opts.editCurrent?.(),
       "files.mention": () => opts.mentionCurrent?.(),
       "files.createPR": () => opts.createPR?.(),
       "files.openExternal": () => opts.openExternal(),

--- a/packages/kobe/test/tmux/editor-launch.test.ts
+++ b/packages/kobe/test/tmux/editor-launch.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { buildEditorCommand, editorWindowLabel } from "../../src/tmux/editor-launch.ts"
+import {
+  buildEditorCommand,
+  buildNvimDiffCommand,
+  editorWindowLabel,
+  relativeToWorktree,
+} from "../../src/tmux/editor-launch.ts"
 import { DEFAULT_EDITOR_KIND, normalizeEditorKind } from "../../src/tui/lib/editor-prefs.ts"
 
 describe("buildEditorCommand", () => {
@@ -42,6 +47,48 @@ describe("buildEditorCommand", () => {
 
   it("shell-escapes a path with spaces and quotes", () => {
     expect(buildEditorCommand("vim", "", "/wt/a b/it's.ts")?.command).toBe("vim '/wt/a b/it'\\''s.ts'")
+  })
+})
+
+describe("relativeToWorktree", () => {
+  it("strips the worktree prefix (with or without a trailing slash)", () => {
+    expect(relativeToWorktree("/wt", "/wt/src/a.ts")).toBe("src/a.ts")
+    expect(relativeToWorktree("/wt/", "/wt/src/a.ts")).toBe("src/a.ts")
+  })
+
+  it("returns null when the path isn't under the worktree (skips diff upgrade)", () => {
+    expect(relativeToWorktree("/wt", "/other/a.ts")).toBeNull()
+    // a sibling dir sharing a name prefix must not match
+    expect(relativeToWorktree("/wt", "/wt-2/a.ts")).toBeNull()
+  })
+})
+
+describe("buildNvimDiffCommand", () => {
+  it("dumps HEAD to a tmp file and diffs it read-only against the live file", () => {
+    const cmd = buildNvimDiffCommand("nvim", "/wt/src/a.ts", "src/a.ts")
+    // process-substitution stand-in: mktemp + git show into it
+    expect(cmd).toContain("f=$(mktemp 2>/dev/null)")
+    expect(cmd).toContain("git show 'HEAD:./src/a.ts' > \"$f\"")
+    // HEAD blob on the LEFT (first -d arg), live editable file on the RIGHT
+    expect(cmd).toContain("nvim -d \"$f\" '/wt/src/a.ts' -c 'setlocal nomodifiable' -c 'wincmd l'")
+    // tmp file is always cleaned up, exit code preserved
+    expect(cmd).toContain('rm -f "$f" 2>/dev/null; exit $r')
+  })
+
+  it("falls back to a plain open when the HEAD blob can't be read", () => {
+    const cmd = buildNvimDiffCommand("nvim", "/wt/a.ts", "a.ts")
+    expect(cmd).toContain("else\n  nvim '/wt/a.ts'; r=$?")
+  })
+
+  it("honours vim as the diff binary too", () => {
+    const cmd = buildNvimDiffCommand("vim", "/wt/a.ts", "a.ts")
+    expect(cmd).toContain("vim -d \"$f\" '/wt/a.ts'")
+  })
+
+  it("shell-escapes paths with spaces and quotes on both sh layers", () => {
+    const cmd = buildNvimDiffCommand("nvim", "/wt/a b/it's.ts", "a b/it's.ts")
+    expect(cmd).toContain("git show 'HEAD:./a b/it'\\''s.ts'")
+    expect(cmd).toContain("nvim -d \"$f\" '/wt/a b/it'\\''s.ts'")
   })
 })
 


### PR DESCRIPTION
## What

`enter` in the file tree (Files / Ops pane) becomes a one-key "just open it":

- **Changed file (vs HEAD)** → side-by-side `nvim -d` diff: committed HEAD version read-only on the left, the live editable file on the right (cursor parked on the right).
- **Unchanged file** → plain editable `nvim`/`vim` open.
- **No nvim/vim installed** → falls back to the built-in read-only opentui preview, so `enter` is never a dead key.
- The separate **`e` (edit)** key is removed — `enter` is the single open action. Its keybinding registration, the footer hint (`↵ preview · e edit` → `↵ open`), and the FileTree wiring are all gone.

## How

The HEAD blob is the `sh -c` safe stand-in for bash's `<(git show HEAD:<file>)` process substitution (tmux opens windows via `sh -c`, which has no `<(…)`): dump the blob to a `mktemp` file, `nvim -d "$tmp" <file>`, `rm` it on exit. One sh layer, every path `shellQuote`d — no second shell-in-nvim parse, no temp left behind, nothing touching the user's nvim config or the repo. The diff upgrade is gated on the resolved command being exactly the simple `<bin> <file>` form, so a custom editor command with its own flags is never rewritten; untracked/new files (no HEAD blob) open plain.

## Tests

- `test/tmux/editor-launch.test.ts` — new coverage for `buildNvimDiffCommand` (tmp-file diff layout, vim binary, two-layer shell escaping of paths with spaces/quotes) and `relativeToWorktree`.
- typecheck + biome clean; full unit suite green (the one `kobe-sandbox` socket failure seen locally is a stray `KOBE_TMUX_SOCKET` env var, unrelated).
- Real `sh -n` + `git show 'HEAD:./<rel>'` verification that the generated script parses and resolves the HEAD blob under the worktree cwd.

## Note on base

This branch is 9 commits behind `main`, but the 5 touched source files have **zero** changes on `main`, so the three-dot diff is clean and merges without conflict. Hit "Update branch" if you want it rebased onto latest before merge.

Changeset: `patch` (`.changeset/file-tree-enter-nvim-diff.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File tree now opens files directly in nvim/vim on `enter`, with automatic side-by-side diff view against the committed version for modified files
  * Falls back to built-in read-only preview when nvim/vim is unavailable

* **Removed Features**
  * The separate `e` (edit) key has been removed; `enter` is now the sole file open action

<!-- end of auto-generated comment: release notes by coderabbit.ai -->