### PR TITLE
fix: F1 opens a full-window help tab; dialog cards stay opaque in transparent mode

### DIFF
--- a/.changeset/fullscreen-help-opaque-dialogs.md
+++ b/.changeset/fullscreen-help-opaque-dialogs.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+F1 help now opens as a dedicated full-window tab instead of an overlay squeezed into the narrow Tasks rail. The keybindings page sits alongside your chat tabs (same surface as Settings) and closes with q / esc / F1, returning to the previous tab. When no tmux session can be resolved, F1 falls back to the in-pane overlay as before. Also, dialogs are no longer translucent in transparent-background mode — the modal card now stays fully opaque so settings, confirms, and help stay readable; transparency keeps applying to the chrome around content only.

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -521,6 +521,15 @@ async function main(): Promise<void> {
     await startSettingsHost()
     return
   }
+  if (subcommand === "help-page") {
+    // The F1 keybindings help as a standalone full-window surface
+    // (distinct from `kobe help`, which prints CLI usage). Opened by
+    // `openHelpTab` as a new tmux window; reuses the same HelpDialog
+    // the in-pane overlay uses.
+    const { startHelpHost } = await import("../tui/help/host.tsx")
+    await startHelpHost()
+    return
+  }
   if (subcommand === "new-task") {
     // The new-task flow as a standalone full-window page (the default
     // `chattab` settings surface). Opened by `openNewTaskTab`; reuses the

--- a/packages/kobe/src/tui/component/help-dialog.tsx
+++ b/packages/kobe/src/tui/component/help-dialog.tsx
@@ -62,10 +62,13 @@ function groupBindings(keymap: readonly KobeBinding[]): { category: string; rows
   return order.map((cat) => ({ category: cat, rows: groups.get(cat)! }))
 }
 
-export function HelpDialog() {
+export function HelpDialog(props: { onClose?: () => void } = {}) {
   const dialog = useDialog()
   const { theme } = useTheme()
   const grouped = () => groupBindings(KobeKeymap)
+  // Standalone full-window page (`kobe help-page`) passes its own exit;
+  // the in-pane overlay closes by clearing the dialog stack.
+  const close = () => (props.onClose ? props.onClose() : dialog.clear())
 
   // Resolve the user's real tmux prefix so `prefix f` shows as e.g. `⌃B F`
   // (their actual prefix, not a guess). Falls back to the `⌃B` default when
@@ -85,7 +88,7 @@ export function HelpDialog() {
     bindings: [
       {
         key: "?",
-        cmd: () => dialog.clear(),
+        cmd: close,
       },
     ],
   }))
@@ -96,7 +99,7 @@ export function HelpDialog() {
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
           {HELP_DIALOG_TITLE}
         </text>
-        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+        <text fg={theme.textMuted} onMouseUp={close}>
           esc
         </text>
       </box>

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -131,7 +131,7 @@ export const KobeKeymap: readonly KobeBinding[] = [
     scope: "global",
     keys: ["f1"],
     category: "Global",
-    description: "Show this help dialog",
+    description: "Show keybindings help",
     hint: { keys: "F1", label: "help", pin: "right" },
   },
   {

--- a/packages/kobe/src/tui/context/theme.tsx
+++ b/packages/kobe/src/tui/context/theme.tsx
@@ -218,11 +218,6 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light" = "dark"):
   return { ...fallback, ...out } as Theme
 }
 
-function withAlpha(color: RGBA, alpha: number): RGBA {
-  const [r, g, b] = color.toInts()
-  return RGBA.fromInts(r ?? 0, g ?? 0, b ?? 0, alpha)
-}
-
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
   init: (props: { mode?: "dark" | "light"; theme?: string }) => {
@@ -260,11 +255,14 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       const v: Theme = { ...base, focusAccent }
       if (!store.transparentBackground) return v
       const transparent = RGBA.fromInts(0, 0, 0, 0)
+      // `backgroundDialog` deliberately stays OPAQUE: a translucent modal
+      // card lets the pane content bleed through the dialog text, which
+      // makes settings/help/confirm dialogs unreadable. Transparency is
+      // for the chrome around content, never for an overlay you must read.
       return {
         ...v,
         background: transparent,
         backgroundPanel: transparent,
-        backgroundDialog: withAlpha(v.backgroundDialog, 128),
       }
     })
 

--- a/packages/kobe/src/tui/help/host.tsx
+++ b/packages/kobe/src/tui/help/host.tsx
@@ -1,0 +1,59 @@
+/**
+ * `kobe help-page` — the F1 keybindings help rendered as a standalone
+ * full-window surface, mirroring `kobe settings` (settings/host.tsx).
+ *
+ * This is the SAME `HelpDialog` component the in-pane overlay pushes onto
+ * the dialog stack — reused verbatim — only here it fills its own tmux
+ * window instead of squeezing into the narrow Tasks rail. Opened by
+ * `openHelpTab`, which spawns this as a new window via `kobe help-page`;
+ * closing it (q / esc / F1 / ? / Ctrl+C) exits the process, so tmux
+ * closes the window and returns to the previous tab.
+ *
+ * Purely read-only (it renders the static `KobeKeymap` table), so it
+ * needs no daemon connection and no KV/Focus providers.
+ */
+
+import { HelpDialog } from "../component/help-dialog"
+import { useTheme } from "../context/theme"
+import { bootPaneHost } from "../lib/host-boot"
+import { useBindings } from "../lib/keymap"
+import { useDialog } from "../ui/dialog"
+
+function HelpPage() {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+
+  function exit(): void {
+    process.exit(0)
+  }
+
+  // Page-level close keys. In the overlay surface the dialog stack owns
+  // esc/Ctrl+C; here there's no enclosing stack, so the page binds them
+  // itself — plus `q` (the page is not a text input) and `f1` so the
+  // opening chord also toggles the page closed. `?` is bound inside
+  // HelpDialog via its onClose prop.
+  useBindings(() => ({
+    enabled: dialog.stack.length === 0,
+    bindings: [
+      { key: "escape", cmd: exit },
+      { key: "q", cmd: exit },
+      { key: "f1", cmd: exit },
+      { key: "ctrl+c", cmd: exit },
+    ],
+  }))
+
+  return (
+    // The component sizes itself with an internal scrollbox; give it the
+    // full window height so tall keymaps scroll instead of clipping.
+    <box flexGrow={1} backgroundColor={theme.background} paddingTop={1}>
+      <HelpDialog onClose={exit} />
+    </box>
+  )
+}
+
+export async function startHelpHost(): Promise<void> {
+  await bootPaneHost({
+    providers: { kv: false, focus: false },
+    setup: () => ({ root: () => <HelpPage /> }),
+  })
+}

--- a/packages/kobe/src/tui/panes/terminal/chattab.ts
+++ b/packages/kobe/src/tui/panes/terminal/chattab.ts
@@ -299,6 +299,24 @@ export async function openSettingsTab(session: string): Promise<void> {
 }
 
 /**
+ * Open the F1 keybindings help as a dedicated chat-tab window in an
+ * existing task session (mirroring {@link openSettingsTab}). A single
+ * full-window `kobe help-page` — the in-pane HelpDialog overlay only had
+ * the narrow Tasks rail to render in, which truncated every row. Not
+ * `keepAlive`-wrapped: closing the page (q / esc / F1) exits the process,
+ * tmux closes the window and returns to the previous tab.
+ */
+export async function openHelpTab(session: string): Promise<void> {
+  if (!(await sessionExists(session))) return
+  const sessionOptions = await getSessionOptions(session, ["@kobe_worktree"])
+  const cwd = sessionOptions["@kobe_worktree"] || process.cwd()
+  const inv = kobeCliInvocation()
+  const envPrefix = inheritedEnvPrefix()
+  const command = `${envPrefix}${inv.map(shellQuote).join(" ")} help-page`
+  await newWindow(session, { cwd: localSpawnCwd(cwd), command, name: "help" })
+}
+
+/**
  * Open the new-task flow as a dedicated chat-tab window in an existing
  * task session (the `chattab` settings surface, mirroring
  * {@link openSettingsTab}). A single full-window `kobe new-task` page

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -117,6 +117,7 @@ export {
   chatTabSwitchBindings,
   kobeStatusRight,
   newChatTab,
+  openHelpTab,
   openNewTaskTab,
   openSettingsTab,
   openUpdateTab,

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -86,6 +86,7 @@ import type { TaskSortMode } from "../panes/sidebar/groups"
 import {
   captureGlobalLayout,
   ensureSession,
+  openHelpTab,
   openNewTaskTab,
   openSettingsTab,
   openUpdateTab,
@@ -290,6 +291,20 @@ function TasksShell(props: {
     }
   }
 
+  // F1 help opens as a dedicated full-window tab (like Settings) — the
+  // in-pane HelpDialog overlay only had the narrow Tasks rail to render
+  // in, which truncated every keybinding row. Fall back to the overlay
+  // when we can't resolve our tmux session (e.g. running outside a kobe
+  // pane).
+  async function openHelp(): Promise<void> {
+    const session = await currentSessionName()
+    if (session) {
+      await openHelpTab(session)
+      return
+    }
+    HelpDialog.show(dialog)
+  }
+
   async function openUpdate(): Promise<void> {
     const info = updateInfo()
     if (!info?.hasUpdate) {
@@ -395,13 +410,11 @@ function TasksShell(props: {
     // Chords come from KobeKeymap via bindByIds (f1=help.open, n=task.new,
     // s=settings.open.sidebar, u=tasks.update, o/b/v=tasks.*) so user
     // overrides from ~/.kobe/settings/keybindings.yaml apply here too.
-    // F1 → the shared HelpDialog (#8). In the real direct-tmux flow the
-    // global `help.open` (app.tsx outer monitor) never runs, so F1 was dead
-    // in the Tasks pane. The pane has its own DialogProvider (mounted in
-    // startTasksPane), so we open it the same way app.tsx does. Gated on an
-    // empty dialog stack so it doesn't `replace` an open dialog.
+    // F1 → the full-window help tab (openHelp), with the shared HelpDialog
+    // as the no-session fallback. Gated on an empty dialog stack so it
+    // doesn't `replace` an open dialog.
     bindings: bindByIds({
-      "help.open": () => HelpDialog.show(dialog),
+      "help.open": () => void openHelp(),
       "task.new": () => void createTask(),
       "settings.open.sidebar": () => void openSettings(),
       "tasks.update": () => void openUpdate(),

--- a/packages/kobe/src/tui/ui/dialog.tsx
+++ b/packages/kobe/src/tui/ui/dialog.tsx
@@ -113,9 +113,9 @@ export function Dialog(
         // cards hit the cap and clip (children that need scrolling —
         // F1 help, settings — wrap their own scrollbox).
         flexGrow={0}
-        // In transparent mode the card keeps the theme's dialog tint
-        // but uses 50% alpha; the backdrop is also lighter so two
-        // stacked translucent layers do not black out the terminal.
+        // The card is ALWAYS opaque — even in transparent mode (where
+        // only the backdrop lightens). A translucent card lets pane
+        // content bleed through the dialog text and becomes unreadable.
         backgroundColor={theme.backgroundDialog}
         paddingTop={1}
       >


### PR DESCRIPTION
## What

Two UX fixes:

**F1 help → full-window tab.** F1 used to push the HelpDialog onto the Tasks pane's own dialog stack, so the keybindings list rendered inside the narrow Tasks rail and every row was truncated. F1 now opens a dedicated full-window `kobe help-page` tab (mirroring the Settings chattab surface): new `openHelpTab()` in `chattab.ts`, a new standalone host at `src/tui/help/host.tsx` that reuses the same `HelpDialog` component, and a `help-page` CLI subcommand. Closing the page (q / esc / F1 / ? / Ctrl+C) exits the process and tmux returns to the previous tab. When no tmux session can be resolved (running outside a kobe pane), F1 falls back to the in-pane overlay as before.

**Opaque dialogs in transparent mode.** `theme.tsx` forced `backgroundDialog` to 50% alpha when transparent background was on, so pane content bled through dialog text and settings/help/confirm dialogs were unreadable. The modal card now stays fully opaque; transparency keeps applying to `background` / `backgroundPanel` (the chrome around content) only, and the full-screen backdrop behind the card is still translucent so the overall transparent look is unchanged.

## Notes

- `HelpDialog` gained an optional `onClose` prop so the standalone page can exit the process while the overlay keeps clearing the dialog stack.
- Measured time-to-render for the new page from the packaged bundle: ~240–300ms (dev mode is ~0.7s because Bun transpiles the TS graph per process — same as every other kobe page).
- Patch changeset included.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run test` (111 tests) all green.
- End-to-end: spawned `kobe help-page` in a throwaway tmux session and verified the keybindings content renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * F1 help moved from overlay to dedicated full-window tab positioned alongside chat tabs
  * Help page dismissible via `q`, `esc`, or `F1` to return to previously active tab
  * Falls back to in-pane overlay behavior if app cannot resolve tmux session

* **Improvements**
  * Dialog cards now fully opaque in transparent-background mode to improve text readability; transparency applies only to surrounding chrome

<!-- end of auto-generated comment: release notes by coderabbit.ai -->