### PR TITLE
fix: ship pty-scrollback.mjs next to the packaged PTY server

### DIFF
--- a/.changeset/cool-pugs-build.md
+++ b/.changeset/cool-pugs-build.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+**Fix `kobe web` crashing at startup in the packaged build** — the PTY server in `dist/web-ui/` imports its sibling `pty-scrollback.mjs` (the bounded-scrollback ring from 0.7.22), but the build script only copied `pty-server.mjs`, so the npm-installed `kobe web` died with `ERR_MODULE_NOT_FOUND` before serving anything. The build now ships every sibling module the PTY server imports.

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -49,7 +49,12 @@ async function copyWebUi(): Promise<void> {
   await rm(WEB_OUT_DIR, { recursive: true, force: true })
   await mkdir(WEB_OUT_DIR, { recursive: true })
   await cp(WEB_DIST_DIR, WEB_OUT_DIR, { recursive: true, force: true })
-  await cp(`${WEB_PACKAGE_DIR}/pty-server.mjs`, `${WEB_OUT_DIR}/pty-server.mjs`, { force: true })
+  // The PTY server runs unbundled under Node, so every sibling module it
+  // imports must ship next to it (missing one = ERR_MODULE_NOT_FOUND at
+  // `kobe web` startup in the packaged build).
+  for (const file of ["pty-server.mjs", "pty-scrollback.mjs"]) {
+    await cp(`${WEB_PACKAGE_DIR}/${file}`, `${WEB_OUT_DIR}/${file}`, { force: true })
+  }
 }
 
 await buildWebUi()


### PR DESCRIPTION
## Problem

`kobe web` in the packaged (npm-installed) build crashes at startup with `ERR_MODULE_NOT_FOUND`: `dist/web-ui/pty-server.mjs` imports its sibling `./pty-scrollback.mjs`, which never ships.

The bounded-scrollback perf change (25faf9c, 0.7.22) split the PTY scrollback ring into a separate `pty-scrollback.mjs` module, but `packages/kobe/scripts/build.ts` `copyWebUi` still copied only `pty-server.mjs` into `dist/web-ui/`. The PTY server runs unbundled under Node, so the missing sibling fails module resolution before the server can listen — `kobe web` reports "PTY server exited" immediately.

## Fix

`copyWebUi` now copies an explicit sibling list (`pty-server.mjs`, `pty-scrollback.mjs`), with a comment explaining that every module the unbundled PTY server imports must ship next to it. Verified locally: `bun run build` puts both files in `dist/web-ui/` and the import resolves.

Includes a patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `kobe web` crashing at startup in packaged builds by ensuring all required PTY server dependencies are properly included in the distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->