### PR TITLE
feat(web): board — one-click review action on in_review cards

### DIFF
--- a/.changeset/board-pr-and-templates.md
+++ b/.changeset/board-pr-and-templates.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+**Open-PR button + editable quick-action templates** — `Done` cards without a PR grow a pull-request button that asks the task's own session to push the branch and `gh pr create` (the agent that did the work writes the title/body, following the repo's conventions). Both quick-action instructions are now template-editable in `kobe web`'s Settings → Board quick actions (stored host-side in state.json): your template forms the first half, and kobe always APPENDS its clause after it — the review's one-time `done` authorization and the PR's reply-with-URL rule can't be edited away. Empty template = built-in default.

--- a/.changeset/board-review-action.md
+++ b/.changeset/board-review-action.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+**One-click review from the board** — `In review` cards grow a clipboard button that pastes a review instruction straight into the task's engine session (spawning it if it isn't running — output lands in scrollback, peek to watch). The instruction tells the agent to inspect the changes, run the relevant checks, and on a PASSING review run `kobe api set-status … --status done`; on a failing one, report findings and leave the status alone. The `done` authorization travels with the click — the always-on status protocol still only ever lets an agent self-report `in_review`, so a session that was never asked to review can never reach `done` by itself. Ships a new PTY-sidecar endpoint (`POST /pty/send`, same localhost-origin policy as the WS attach) that any future board quick-action can reuse.

--- a/docs/design/conflict-radar.md
+++ b/docs/design/conflict-radar.md
@@ -1,0 +1,110 @@
+# 冲突雷达(Conflict Radar)— 设计报告
+
+> 提案:看板卡片上提前标出"这张卡和哪张卡会撞车"。kobe 的每张 in-flight 卡
+> 都是一条真分支 + 一个真 worktree——这是其他看板结构上没有的数据,也是
+> 并行跑 N 个 agent 改同一个 repo 时最疼的盲区:两个 agent 各自干得很好,
+> 合并时才发现改了同一段代码。雷达把这个发现时刻从"合并时"提前到"进行中"。
+> 状态:提案,未实现。配套:[`web-kanban.md`](./web-kanban.md)。
+
+## 1. 信号分级:两级漏斗
+
+全量两两做真合并太贵,分两级,L1 出资格、L2 出判决:
+
+| 级别 | 信号 | 算法 | 成本 | 含义 |
+|---|---|---|---|---|
+| **L1 文件重叠** | ⚠ 黄 | 每卡算 `touchedFiles`(对 merge-base 的 `git diff --name-only` ∪ 未提交脏文件),两两求交集 | 每卡一次 diff,交集纯内存 | "改了同样的文件"——可能冲突 |
+| **L2 真冲突** | ⛔ 红 | 仅对 L1 命中的卡对跑 `git merge-tree --write-tree A B`(git ≥ 2.38,干跑合并,**不碰任何 worktree**),解析输出里的 conflict 段 | 每对一次 merge-tree | "合并必然产生冲突标记" |
+
+git < 2.38 没有 `merge-tree --write-tree`:退化为只有 L1(黄标),启动时探测一次版本。
+
+## 2. 数据流
+
+```mermaid
+flowchart LR
+  C["daemon: ConflictCollector<br/>(worktree-changes-collector 同款 tick)"]
+  B["bus.publish('task.conflicts')"]
+  W["bridge → SSE → SPA store"]
+  K["卡片 ⚠/⛔ 角标 + hover 详情"]
+  C --> B --> W --> K
+```
+
+- **采集端**:daemon 新增一个 collector,复用 `worktree-changes-collector` 的
+  节奏与生命周期(暂停/恢复随 gui 数);每 tick:
+  1. 对每张非 main、非 archived、非 remote 的卡取 `(head, dirtyHash)`;
+  2. 两者都没变的卡跳过(增量);
+  3. 变了的卡重算 `touchedFiles`,再仅与"自己变了 ∪ 对方变了"的卡对重算交集;
+  4. L1 命中且 `(headA, headB)` 缓存未命中 → 跑一次 merge-tree。
+- **协议**:新频道 `task.conflicts`,广播全量(数据量小):
+
+  ```ts
+  { pairs: Array<{ a: TaskId; b: TaskId; files: string[]; level: "overlap" | "conflict" }> }
+  ```
+
+  照例三表同步:协议 `ChannelPayloads` + `SPA_CHANNELS` + store reducer,
+  契约测试自动拦漏。
+- **UI**:卡片右上角 ⚠N / ⛔N(N = 对端卡数);hover 列出"与『xxx』重叠:
+  `src/auth.ts` +2 个文件";点击高亮对端卡(同列滚动到可见)。
+
+## 3. 关键设计决定
+
+- **未提交改动只进 L1,不进 L2。** merge-tree 只认提交;脏文件用
+  `--name-only` 交集近似足够(脏=正在动,本来就该黄标提醒)。给脏文件做
+  虚拟提交再 merge-tree 技术上可行但复杂度不成比例,v1 明确不做。
+- **比较基线 = 两卡分支对 repo 默认分支的 merge-base**,不做三方比较;
+  卡对之间直接 merge-tree(A 的 head × B 的 head)。
+- **复杂度**:N 张活跃卡 → C(N,2) 对。N≤20(本地单机的现实上限)完全无压力;
+  增量 + 缓存后稳态 tick 接近零开销。超过 50 张卡时跳过 L2 只保 L1(log 提示,
+  no silent caps)。
+- **排除项**:main 任务(没有自己的分支)、remote 任务(git 在远端)、archived。
+- **不做自动动作**:雷达只展示,不阻止拖拽、不自动挪卡——它是信息,不是守门。
+  (未来 merge-train 落地时,红标卡对可以驱动"先合谁"的排序建议。)
+
+## 4. 与现有件的衔接
+
+| 现有件 | 复用方式 |
+|---|---|
+| `worktree-changes-collector` | collector 骨架、tick/暂停语义、git 调用纪律 |
+| `task.snapshot` / SSE 管道 | 新频道照搬广播路径 |
+| 看板乐观层 | 不相干——雷达数据只读,无 override 交互 |
+| `/pty/send` 快捷指令 | 后续可加"让两边 agent 互相通气"按钮:把冲突文件清单发进两个会话 |
+
+## 5. 里程碑
+
+| 步 | 内容 | 量 |
+|---|---|---|
+| R0 | 命令行 POC:对沙箱两张卡手跑 merge-tree,验证输出解析 | 半天 |
+| R1 | daemon collector + `task.conflicts` 频道 + L1(黄标) | 1 天 |
+| R2 | L2 merge-tree(红标)+ 缓存 + git 版本探测回退 | 1 天 |
+| R3 | 卡片角标 + hover 详情 + 对端高亮 | 半天 |
+
+## 6. 标记之后:动作链(雷达的"然后呢")
+
+信号本身只是焦虑;雷达的价值兑现靠的是 kobe 的独有条件——**标记的双方都是
+活会话,每个标记都能变成一条发给当事 agent 的指令**(`/pty/send` 管道现成)。
+按落地顺序:
+
+1. **互相通气(v1 就该带上)** — 冲突徽标的 hover 详情里加一个"notify both"
+   按钮:把对方的卡名 + 重叠文件清单各发进两个会话——"任务『X』也在改
+   `src/auth.ts`,协调你的改动:缩小触碰面 / 等它先合 / 把共用部分提出来"。
+   两个 agent 在各自上下文里主动避让。其他看板的冲突信号最多 @ 一个人;
+   我们的信号直接驱动当事进程。
+2. **rebase 指令一键发** — A 卡合进 main 后,对红标的 B 卡一键发:"main 已
+   更新(含『X』对 auth 的改动),rebase 并解决冲突"。冲突解决是合并时刻
+   最痛的人工活,而 B 的 agent 是最懂"B 为什么这么改"的一方——让它自己解,
+   解完照常走 review → done。
+3. **merge train 排序依据** — done 列的合并队列(见 web-kanban.md 后续提案)
+   用雷达数据排序:无标记的先走;红标对里先合改动小的一方,随后自动对另一方
+   触发动作 2。
+4. **开工避让** — backlog 卡与 in-flight 卡黄标时,auto-start 可以(opt-in)
+   延迟放行:"等『X』合完再开工",从源头避免撞车。
+5. **对照视图** — 点冲突对在板内并排开两个 diff/peek,人肉裁决两边谁让谁。
+
+v1 范围仍然只做"展示 + 动作 1";2-4 依次叠加,全部复用既有管道
+(`/pty/send`、merge-train、auto-start 守门)。
+
+## 7. 风险
+
+- **git 版本**(merge-tree --write-tree 需 ≥2.38,2022-10 发布):探测 + L1 回退,不算硬伤。
+- **奇异分支**(adopt 进来的无共同祖先分支):merge-base 失败 → 该卡只参与 L1。
+- **大 repo 首次全量**:N 次 `diff --name-only` 串行打散到多个 tick,避免尖峰。
+- **误报观感**:文件重叠 ≠ 一定冲突(黄标本质是召回优先)。色阶分明(黄=可能,红=必然)+ hover 里写清楚语义,避免狼来了。

--- a/docs/design/web-kanban.md
+++ b/docs/design/web-kanban.md
@@ -332,6 +332,13 @@ sequenceDiagram
   "Auto status flow"(即 state.json `experimental.autoStatus`),各决策点
   实时读取,无需重启 daemon。注意注入发生在 spawn 时——开关打开后,**新**
   会话才带协议;已在跑的会话要 respawn 才有。
+- **一键 review(后续追加)**:`In review` 列的卡片多一个 clipboard 按钮,把
+  review 指令([`lib/review.ts`](../../packages/kobe-web/src/lib/review.ts))
+  直接粘进任务的引擎会话(PTY sidecar 新端点 `POST /pty/send`,composer 同款
+  bracketed-paste 契约;会话没起会先 spawn)。**`done` 授权随点击走**:常驻协议
+  永远只授权 in_review,review 指令里才携带一次性的"通过则 set done";没被
+  点过 review 的会话永远到不了 done——这保住了"done 由人决定"的红线,只是
+  把人的动作从"拖卡"换成了"点 review"。
 
 实施期每个里程碑落一个 changeset(patch,按仓库规则不自报 minor);M1 起在
 [`web-dashboard.md`](./web-dashboard.md) 增补看板一节。

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -154,16 +154,28 @@ const server = createServer((req, res) => {
       // Same submit contract as the composer / tmux pasteAndSubmit:
       // bracketed paste so a multi-line prompt arrives as ONE paste, then
       // Enter. A freshly spawned engine gets a grace delay so the paste
-      // isn't eaten by its startup.
+      // isn't eaten by its startup. The Enter MUST land in a separate,
+      // later write: written back-to-back it coalesces into the same tty
+      // chunk as the paste and claude treats it as paste content — the
+      // text sits in the composer and never submits. (tmux pasteAndSubmit
+      // gets this separation for free from its two commands; the web
+      // composer from its two WS messages.)
       const target = entry
       setTimeout(
         () => {
           try {
             target.pty.write(`\x1b[200~${text}\x1b[201~`)
-            target.pty.write("\r")
           } catch {
             /* engine died between spawn and paste — next attach shows why */
+            return
           }
+          setTimeout(() => {
+            try {
+              target.pty.write("\r")
+            } catch {
+              /* same: best-effort */
+            }
+          }, 150)
         },
         spawned ? 2500 : 0,
       )

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -10,6 +10,7 @@
  *
  *   ws  /pty?tab=<id>&taskId=<id>&mode=engine|shell&cols=<n>&rows=<n>
  *   POST /pty/close   { tab }                          kill the tab process
+ *   POST /pty/send    { tab, taskId, text }            paste text + Enter into the tab's engine
  */
 
 import { createServer } from "node:http"
@@ -96,6 +97,78 @@ const server = createServer((req, res) => {
       "access-control-allow-headers": "content-type",
     })
     res.end()
+    return
+  }
+  if (req.method === "POST" && url.pathname === "/pty/send") {
+    // Sending text DRIVES the engine like a keyboard, so unlike /pty/close
+    // (best-effort kill) this holds the same origin policy as the WS attach:
+    // localhost pages or non-browser clients only.
+    const origin = req.headers.origin
+    if (origin && !LOCAL_ORIGIN.test(origin)) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
+    let body = ""
+    req.on("data", (c) => {
+      body += c
+    })
+    req.on("end", async () => {
+      let tab
+      let taskId
+      let text
+      try {
+        ;({ tab, taskId, text } = JSON.parse(body || "{}"))
+      } catch {
+        /* ignore */
+      }
+      const respond = (status, payload) => {
+        res.writeHead(status, {
+          "content-type": "application/json",
+          "access-control-allow-origin": "*",
+        })
+        res.end(JSON.stringify(payload))
+      }
+      if (typeof tab !== "string" || !tab || typeof text !== "string" || !text) {
+        respond(400, { sent: false, error: "tab and text are required" })
+        return
+      }
+      let entry = tabs.get(tab)
+      let spawned = false
+      if (!entry && typeof taskId === "string" && taskId) {
+        // Spawn-on-send: a board action can fire without the terminal ever
+        // opening — output lands in the scrollback ring for the next attach.
+        try {
+          const spec = await fetchSpec(taskId, "engine")
+          entry = spawnTab(tab, spec, 80, 24)
+          spawned = true
+        } catch (err) {
+          respond(500, { sent: false, error: `failed to start engine: ${err?.message ?? err}` })
+          return
+        }
+      }
+      if (!entry) {
+        respond(404, { sent: false, error: "no such tab" })
+        return
+      }
+      // Same submit contract as the composer / tmux pasteAndSubmit:
+      // bracketed paste so a multi-line prompt arrives as ONE paste, then
+      // Enter. A freshly spawned engine gets a grace delay so the paste
+      // isn't eaten by its startup.
+      const target = entry
+      setTimeout(
+        () => {
+          try {
+            target.pty.write(`\x1b[200~${text}\x1b[201~`)
+            target.pty.write("\r")
+          } catch {
+            /* engine died between spawn and paste — next attach shows why */
+          }
+        },
+        spawned ? 2500 : 0,
+      )
+      respond(200, { sent: true, spawned })
+    })
     return
   }
   if (req.method === "POST" && url.pathname === "/pty/close") {

--- a/packages/kobe-web/server/bridge.ts
+++ b/packages/kobe-web/server/bridge.ts
@@ -25,6 +25,7 @@ import { join, normalize } from "node:path"
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { availableEngineIds } from "../../kobe/src/engine/account-detect.ts"
 import { engineDisplayName } from "../../kobe/src/engine/interactive-command.ts"
+import { getPersistedString, setPersistedString } from "../../kobe/src/state/repos.ts"
 import { handleDiffRequest } from "../../kobe/src/web/diff.ts"
 import { handleHistoryRequest } from "../../kobe/src/web/history.ts"
 import { handleNotesRequest } from "../../kobe/src/web/notes.ts"
@@ -207,6 +208,8 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: Request) =
     if (url.pathname === "/api/terminal-spec" && req.method === "GET")
       return specResponse(url, link, terminalSpec)
     if (url.pathname === "/api/engines" && req.method === "GET") return enginesResponse()
+    if (url.pathname === "/api/quick-prompts" && req.method === "GET") return quickPromptsGet()
+    if (url.pathname === "/api/quick-prompts" && req.method === "PUT") return quickPromptsPut(req)
     const notes = await handleNotesRequest(req, url)
     if (notes) return notes
     const diff = await handleDiffRequest(req, url)
@@ -217,6 +220,32 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: Request) =
     if (themes) return themes
     if (staticDir) return staticResponse(url.pathname, staticDir)
     return new Response("not found", { status: 404 })
+  }
+}
+
+/** state.json keys for the board quick-action prompt TEMPLATES (the
+ *  user-editable half — kobe's clauses are appended client-side and are
+ *  not stored). Host-side so the TUI and any future surface share them. */
+const QUICK_PROMPT_KEYS = {
+  review: "boardPrompt.review",
+  pr: "boardPrompt.pr",
+} as const
+
+function quickPromptsGet(): Response {
+  return Response.json({
+    review: getPersistedString(QUICK_PROMPT_KEYS.review) ?? null,
+    pr: getPersistedString(QUICK_PROMPT_KEYS.pr) ?? null,
+  })
+}
+
+async function quickPromptsPut(req: Request): Promise<Response> {
+  try {
+    const body = (await req.json()) as { review?: unknown; pr?: unknown }
+    if (typeof body.review === "string") setPersistedString(QUICK_PROMPT_KEYS.review, body.review)
+    if (typeof body.pr === "string") setPersistedString(QUICK_PROMPT_KEYS.pr, body.pr)
+    return quickPromptsGet()
+  } catch (err) {
+    return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 400 })
   }
 }
 

--- a/packages/kobe-web/src/components/AppShell.tsx
+++ b/packages/kobe-web/src/components/AppShell.tsx
@@ -27,11 +27,13 @@ import {
   useNotifyState,
 } from "../lib/notify.ts"
 import { tailPath } from "../lib/path-format.ts"
+import { fetchQuickPrompts, saveQuickPrompts } from "../lib/quick-prompts.ts"
+import { DEFAULT_PR_TEMPLATE, defaultReviewTemplate } from "../lib/review.ts"
 import { rpc, useAppState } from "../lib/store.ts"
 import { resetLayout, selectTask, useTabsState } from "../lib/tabs.ts"
 import { matchesTask, sortTasks, type TaskSortMode } from "../lib/task-list.ts"
 import { relativeTime } from "../lib/time.ts"
-import { reportError } from "../lib/toast.ts"
+import { pushToast, reportError } from "../lib/toast.ts"
 import { type Bucket, matchesStatusFilter } from "../lib/triage.ts"
 import type { EngineState, Task, TaskJob } from "../lib/types.ts"
 import { AdoptDialog } from "./AdoptDialog.tsx"
@@ -753,6 +755,84 @@ function ResetLayoutCard() {
   )
 }
 
+/**
+ * Board quick-action prompt templates (review / open-PR). The textarea is
+ * the user-editable HALF of each instruction — kobe appends its own clause
+ * (review's one-time `done` authorization, PR's reply-with-URL) after it at
+ * send time, so the guardrails can't be edited away. Empty = built-in
+ * default (shown as the placeholder). Stored host-side via the bridge.
+ */
+function QuickPromptsCard() {
+  const [review, setReview] = useState("")
+  const [pr, setPr] = useState("")
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void fetchQuickPrompts().then((prompts) => {
+      if (cancelled) return
+      setReview(prompts.review ?? "")
+      setPr(prompts.pr ?? "")
+      setLoaded(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const save = (): void => {
+    saveQuickPrompts({ review, pr })
+      .then(() => pushToast("success", "quick-action templates saved"))
+      .catch((err: unknown) => reportError("save templates", err))
+  }
+
+  return (
+    <div className="border border-line bg-surface p-4 md:col-span-2">
+      <div className="text-[11px] font-bold uppercase tracking-[0.12em] text-subtle">
+        Board quick actions
+      </div>
+      <div className="mt-4 space-y-3 text-[12px]">
+        <label className="block">
+          <span className="text-muted">Review template</span>
+          <textarea
+            value={review}
+            onChange={(event) => setReview(event.target.value)}
+            placeholder={`default: ${defaultReviewTemplate("claude")}`}
+            rows={2}
+            disabled={!loaded}
+            className="mt-1 w-full resize-y border border-line bg-bg p-2 font-mono text-[12px] text-fg placeholder:text-subtle focus:border-line-active focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <span className="text-muted">Open-PR template</span>
+          <textarea
+            value={pr}
+            onChange={(event) => setPr(event.target.value)}
+            placeholder={`default:\n${DEFAULT_PR_TEMPLATE}`}
+            rows={4}
+            disabled={!loaded}
+            className="mt-1 w-full resize-y border border-line bg-bg p-2 font-mono text-[12px] text-fg placeholder:text-subtle focus:border-line-active focus:outline-none"
+          />
+        </label>
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[11px] text-subtle">
+            Empty = built-in default. kobe appends its status/URL clause after
+            your template — the guardrails stay regardless.
+          </span>
+          <button
+            type="button"
+            onClick={save}
+            disabled={!loaded}
+            className="shrink-0 border border-line bg-bg px-2 py-1 text-[11px] text-muted transition-colors hover:border-primary hover:text-fg"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function SettingsPage({ onClose }: { onClose: () => void }) {
   const { daemonConnected, streamConnected, update } = useAppState()
 
@@ -774,6 +854,7 @@ function SettingsPage({ onClose }: { onClose: () => void }) {
       </div>
       <div className="min-h-0 flex-1 overflow-auto p-4">
         <div className="grid max-w-3xl grid-cols-1 gap-3 md:grid-cols-2">
+          <QuickPromptsCard />
           <div className="border border-line bg-surface p-4">
             <div className="text-[11px] font-bold uppercase tracking-[0.12em] text-subtle">
               Connection

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -82,6 +82,13 @@ import { ChangesChip, PrChip } from "./chips.tsx"
  *  everyday destinations. */
 const PRIMARY_COLUMNS = BOARD_COLUMNS.filter((spec) => spec.alwaysVisible)
 
+/** Instant hover tooltip rendered from the data-tip attribute — the native
+ *  `title` takes a beat to appear, and one-glyph buttons need names. */
+const TIP_ABOVE =
+  "after:pointer-events-none after:absolute after:right-0 after:bottom-full after:z-10 after:mb-1 after:hidden after:whitespace-nowrap after:border after:border-line after:bg-menu after:px-1.5 after:py-0.5 after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
+const TIP_RIGHT =
+  "after:pointer-events-none after:absolute after:left-full after:top-2 after:z-10 after:ml-1 after:hidden after:whitespace-nowrap after:border after:border-line after:bg-menu after:px-1.5 after:py-0.5 after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
+
 /**
  * Column-aware keyboard moves: ↑/↓ step between cards of the SAME column
  * (geometric x-band), ←/→ jump to the nearest card — or the column surface,
@@ -255,7 +262,8 @@ function BoardCard({
           {...attributes}
           {...listeners}
           aria-label={`Move ${task.title || task.branch || task.id}`}
-          className="absolute top-0 bottom-0 left-0 flex w-5 cursor-grab items-center justify-center text-subtle opacity-0 transition-opacity hover:text-fg focus-visible:opacity-100 group-hover/card:opacity-100"
+          data-tip="Drag to move"
+          className={`absolute top-0 bottom-0 left-0 flex w-5 cursor-grab items-center justify-center text-subtle opacity-0 transition-opacity hover:text-fg focus-visible:opacity-100 group-hover/card:opacity-100 ${TIP_RIGHT}`}
         >
           <GripVertical size={12} strokeWidth={1.8} />
         </button>
@@ -288,8 +296,8 @@ function BoardCard({
               type="button"
               onClick={onReview}
               aria-label={`Send review instruction to ${task.title || task.branch || task.id}`}
-              title="Ask the session to review its work — a passing review sets the task done"
-              className="flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg"
+              data-tip="Review → done if it passes"
+              className={`relative flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg ${TIP_ABOVE}`}
             >
               <ClipboardCheck size={11} strokeWidth={1.8} />
             </button>
@@ -298,8 +306,8 @@ function BoardCard({
             type="button"
             onClick={onPeek}
             aria-label={`Peek ${task.title || task.branch || task.id}`}
-            title="Peek session — live terminal + transcript without leaving the board (starts the session if it isn't running)"
-            className="flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg"
+            data-tip="Peek session"
+            className={`relative flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg ${TIP_ABOVE}`}
           >
             <Eye size={11} strokeWidth={1.8} />
           </button>

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -38,6 +38,7 @@ import {
   ArrowLeft,
   ClipboardCheck,
   Eye,
+  GitPullRequest,
   GripVertical,
   Search,
   X,
@@ -66,7 +67,8 @@ import {
   setStatusOverride,
   useBoardState,
 } from "../lib/board-state.ts"
-import { reviewPrompt } from "../lib/review.ts"
+import { fetchQuickPrompts } from "../lib/quick-prompts.ts"
+import { createPrPrompt, reviewPrompt } from "../lib/review.ts"
 import { rpc, useAppState } from "../lib/store.ts"
 import { ensureEngineTab, selectTask } from "../lib/tabs.ts"
 import { matchesTask } from "../lib/task-list.ts"
@@ -195,6 +197,7 @@ function BoardCard({
   canDrag,
   onMoveTo,
   onReview,
+  onCreatePr,
   onOpen,
   onPeek,
 }: {
@@ -205,6 +208,7 @@ function BoardCard({
   canDrag: boolean
   onMoveTo: (statusKey: string) => void
   onReview?: () => void
+  onCreatePr?: () => void
   onOpen: () => void
   onPeek: () => void
 }) {
@@ -302,6 +306,17 @@ function BoardCard({
               <ClipboardCheck size={11} strokeWidth={1.8} />
             </button>
           )}
+          {onCreatePr && (
+            <button
+              type="button"
+              onClick={onCreatePr}
+              aria-label={`Open a PR for ${task.title || task.branch || task.id}`}
+              data-tip="Open a PR for this branch"
+              className={`relative flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg ${TIP_ABOVE}`}
+            >
+              <GitPullRequest size={11} strokeWidth={1.8} />
+            </button>
+          )}
           <button
             type="button"
             onClick={onPeek}
@@ -324,6 +339,7 @@ function ColumnView({
   canDrag,
   onMoveTo,
   onReview,
+  onCreatePr,
   onOpen,
   onPeek,
 }: {
@@ -333,6 +349,7 @@ function ColumnView({
   canDrag: boolean
   onMoveTo: (task: Task, statusKey: string) => void
   onReview: (task: Task) => void
+  onCreatePr: (task: Task) => void
   onOpen: (id: string) => void
   onPeek: (id: string) => void
 }) {
@@ -382,6 +399,15 @@ function ColumnView({
                 // Review only makes sense where work awaits a verdict.
                 onReview={
                   column.key === "in_review" ? () => onReview(task) : undefined
+                }
+                // PR only for finished work that doesn't already have one
+                // (the PrChip covers the has-a-PR case).
+                onCreatePr={
+                  column.key === "done" &&
+                  (!task.prStatus?.lifecycle ||
+                    task.prStatus.lifecycle === "unknown")
+                    ? () => onCreatePr(task)
+                    : undefined
                 }
                 onOpen={() => onOpen(task.id)}
                 onPeek={() => onPeek(task.id)}
@@ -566,12 +592,19 @@ export function Board() {
       })
   }
 
-  /** One-click review: paste the review instruction (which carries the
-   *  one-time `done` authorization) into the task's engine session via the
-   *  PTY sidecar — spawns the engine if it isn't running. */
+  /** One-click review: paste the review instruction (the user's template,
+   *  if set, plus the one-time `done` authorization kobe always appends)
+   *  into the task's engine session — spawns the engine if needed. */
   const sendReview = (task: Task): void => {
     const tabId = ensureEngineTab(task.id)
-    sendPtyText(tabId, task.id, reviewPrompt(task.id, task.vendor))
+    fetchQuickPrompts()
+      .then((prompts) =>
+        sendPtyText(
+          tabId,
+          task.id,
+          reviewPrompt(task.id, task.vendor, prompts.review),
+        ),
+      )
       .then(({ spawned }) => {
         pushToast(
           "success",
@@ -581,6 +614,25 @@ export function Board() {
         )
       })
       .catch((err: unknown) => reportError("send review", err))
+  }
+
+  /** One-click PR: ask the session that DID the work to push its branch and
+   *  open the PR — it writes the title/body from its own context. */
+  const sendCreatePr = (task: Task): void => {
+    const tabId = ensureEngineTab(task.id)
+    fetchQuickPrompts()
+      .then((prompts) =>
+        sendPtyText(tabId, task.id, createPrPrompt(prompts.pr)),
+      )
+      .then(({ spawned }) => {
+        pushToast(
+          "success",
+          spawned
+            ? "PR instruction sent — engine starting, peek to watch"
+            : "PR instruction sent to the session",
+        )
+      })
+      .catch((err: unknown) => reportError("open PR", err))
   }
 
   /** Hover-tag move: jump the card straight to a status, landing at the
@@ -736,6 +788,7 @@ export function Board() {
                   canDrag={canDrag}
                   onMoveTo={moveToStatus}
                   onReview={sendReview}
+                  onCreatePr={sendCreatePr}
                   onOpen={open}
                   onPeek={setPeekTaskId}
                 />

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -571,7 +571,7 @@ export function Board() {
    *  PTY sidecar — spawns the engine if it isn't running. */
   const sendReview = (task: Task): void => {
     const tabId = ensureEngineTab(task.id)
-    sendPtyText(tabId, task.id, reviewPrompt(task.id))
+    sendPtyText(tabId, task.id, reviewPrompt(task.id, task.vendor))
       .then(({ spawned }) => {
         pushToast(
           "success",

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -34,7 +34,14 @@ import {
 } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { useNavigate } from "@tanstack/react-router"
-import { ArrowLeft, Eye, GripVertical, Search, X } from "lucide-react"
+import {
+  ArrowLeft,
+  ClipboardCheck,
+  Eye,
+  GripVertical,
+  Search,
+  X,
+} from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { activityColor, activityLabel } from "../lib/activity.ts"
 import {
@@ -59,11 +66,13 @@ import {
   setStatusOverride,
   useBoardState,
 } from "../lib/board-state.ts"
+import { reviewPrompt } from "../lib/review.ts"
 import { rpc, useAppState } from "../lib/store.ts"
-import { selectTask } from "../lib/tabs.ts"
+import { ensureEngineTab, selectTask } from "../lib/tabs.ts"
 import { matchesTask } from "../lib/task-list.ts"
+import { sendPtyText } from "../lib/terminal.ts"
 import { relativeTime } from "../lib/time.ts"
-import { reportError } from "../lib/toast.ts"
+import { pushToast, reportError } from "../lib/toast.ts"
 import type { EngineState, Task } from "../lib/types.ts"
 import { BoardPeek } from "./BoardPeek.tsx"
 import { ChangesChip, PrChip } from "./chips.tsx"
@@ -178,6 +187,7 @@ function BoardCard({
   changes,
   canDrag,
   onMoveTo,
+  onReview,
   onOpen,
   onPeek,
 }: {
@@ -187,6 +197,7 @@ function BoardCard({
   changes?: { added: number; deleted: number }
   canDrag: boolean
   onMoveTo: (statusKey: string) => void
+  onReview?: () => void
   onOpen: () => void
   onPeek: () => void
 }) {
@@ -271,15 +282,28 @@ function BoardCard({
             </button>
           )
         })}
-        <button
-          type="button"
-          onClick={onPeek}
-          aria-label={`Peek ${task.title || task.branch || task.id}`}
-          title="Peek session — live terminal + transcript without leaving the board (starts the session if it isn't running)"
-          className="ml-auto flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg"
-        >
-          <Eye size={11} strokeWidth={1.8} />
-        </button>
+        <div className="ml-auto flex gap-0.5">
+          {onReview && (
+            <button
+              type="button"
+              onClick={onReview}
+              aria-label={`Send review instruction to ${task.title || task.branch || task.id}`}
+              title="Ask the session to review its work — a passing review sets the task done"
+              className="flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg"
+            >
+              <ClipboardCheck size={11} strokeWidth={1.8} />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onPeek}
+            aria-label={`Peek ${task.title || task.branch || task.id}`}
+            title="Peek session — live terminal + transcript without leaving the board (starts the session if it isn't running)"
+            className="flex h-5 w-5 items-center justify-center border border-line bg-surface text-subtle hover:border-primary hover:text-fg"
+          >
+            <Eye size={11} strokeWidth={1.8} />
+          </button>
+        </div>
       </div>
     </div>
   )
@@ -291,6 +315,7 @@ function ColumnView({
   worktreeChanges,
   canDrag,
   onMoveTo,
+  onReview,
   onOpen,
   onPeek,
 }: {
@@ -299,6 +324,7 @@ function ColumnView({
   worktreeChanges: Record<string, { added: number; deleted: number }>
   canDrag: boolean
   onMoveTo: (task: Task, statusKey: string) => void
+  onReview: (task: Task) => void
   onOpen: (id: string) => void
   onPeek: (id: string) => void
 }) {
@@ -345,6 +371,10 @@ function ColumnView({
                 changes={worktreeChanges[task.worktreePath]}
                 canDrag={canDrag}
                 onMoveTo={(statusKey) => onMoveTo(task, statusKey)}
+                // Review only makes sense where work awaits a verdict.
+                onReview={
+                  column.key === "in_review" ? () => onReview(task) : undefined
+                }
                 onOpen={() => onOpen(task.id)}
                 onPeek={() => onPeek(task.id)}
               />
@@ -528,6 +558,23 @@ export function Board() {
       })
   }
 
+  /** One-click review: paste the review instruction (which carries the
+   *  one-time `done` authorization) into the task's engine session via the
+   *  PTY sidecar — spawns the engine if it isn't running. */
+  const sendReview = (task: Task): void => {
+    const tabId = ensureEngineTab(task.id)
+    sendPtyText(tabId, task.id, reviewPrompt(task.id))
+      .then(({ spawned }) => {
+        pushToast(
+          "success",
+          spawned
+            ? "review sent — engine starting, peek to watch"
+            : "review sent to the session",
+        )
+      })
+      .catch((err: unknown) => reportError("send review", err))
+  }
+
   /** Hover-tag move: jump the card straight to a status, landing at the
    *  TOP of the target — a deliberate move should stay under the eye. */
   const moveToStatus = (task: Task, toKey: string): void => {
@@ -680,6 +727,7 @@ export function Board() {
                   worktreeChanges={worktreeChanges}
                   canDrag={canDrag}
                   onMoveTo={moveToStatus}
+                  onReview={sendReview}
                   onOpen={open}
                   onPeek={setPeekTaskId}
                 />

--- a/packages/kobe-web/src/lib/quick-prompts.ts
+++ b/packages/kobe-web/src/lib/quick-prompts.ts
@@ -1,0 +1,40 @@
+/**
+ * User-editable board quick-action prompt templates (Settings → Board
+ * quick actions). Stored HOST-side in state.json via the bridge — the
+ * templates are machine config, not browser config, so the TUI and any
+ * future surface read the same values. kobe's non-negotiable clauses
+ * (review's done authorization, PR's reply-with-URL) are appended AFTER
+ * the template at send time (lib/review.ts) and are never stored.
+ */
+
+export interface QuickPrompts {
+  review: string | null
+  pr: string | null
+}
+
+/** Fail-open: a fetch failure means "use the built-in defaults". */
+export async function fetchQuickPrompts(): Promise<QuickPrompts> {
+  try {
+    const res = await fetch("/api/quick-prompts")
+    if (!res.ok) return { review: null, pr: null }
+    const json = (await res.json()) as Partial<QuickPrompts>
+    return {
+      review: typeof json.review === "string" ? json.review : null,
+      pr: typeof json.pr === "string" ? json.pr : null,
+    }
+  } catch {
+    return { review: null, pr: null }
+  }
+}
+
+export async function saveQuickPrompts(prompts: {
+  review: string
+  pr: string
+}): Promise<void> {
+  const res = await fetch("/api/quick-prompts", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(prompts),
+  })
+  if (!res.ok) throw new Error(`save failed (${res.status})`)
+}

--- a/packages/kobe-web/src/lib/review.ts
+++ b/packages/kobe-web/src/lib/review.ts
@@ -1,6 +1,7 @@
 /**
- * The board's one-click review instruction: clicking Review on an
- * `in_review` card pastes this into the task's engine session.
+ * The board's one-click quick-action instructions, pasted into the task's
+ * engine session via /pty/send: Review on `in_review` cards, Open-PR on
+ * `done` cards.
  *
  * Deliberately minimal — claude ships its own `/review` command, so the
  * paste leads with that and adds ONLY the thing the engine can't know:
@@ -14,9 +15,50 @@
 const doneClause = (taskId: string): string =>
   `if it passes, run \`kobe api set-status --task-id ${taskId} --status done\`; otherwise report the problems and leave the status unchanged.`
 
-export function reviewPrompt(taskId: string, vendor?: string): string {
-  if ((vendor ?? "claude") === "claude") {
-    return `/review\nAfter the review: ${doneClause(taskId)}`
-  }
-  return `Review the current changes in this worktree critically. Then: ${doneClause(taskId)}`
+/** Built-in review template when the user hasn't set one (vendor-aware:
+ *  claude has a native /review command, others get a prose ask). */
+export function defaultReviewTemplate(vendor?: string): string {
+  return (vendor ?? "claude") === "claude"
+    ? "/review"
+    : "Review the current changes in this worktree critically."
+}
+
+/**
+ * Compose the review instruction: the TEMPLATE half is user-editable
+ * (Settings → Board quick actions, stored host-side in state.json), the
+ * CLAUSE half is kobe's and is always APPENDED after it — however the
+ * template is rewritten, the click-scoped `done` authorization and the
+ * leave-unchanged rule can't be edited away.
+ */
+export function reviewPrompt(
+  taskId: string,
+  vendor?: string,
+  template?: string | null,
+): string {
+  const base = template?.trim() || defaultReviewTemplate(vendor)
+  return `${base}\nAfter the review: ${doneClause(taskId)}`
+}
+
+/** Built-in PR template when the user hasn't set one. */
+export const DEFAULT_PR_TEMPLATE = [
+  "Open a pull request for this task's branch:",
+  "1. Make sure the work is committed, then push the branch to origin.",
+  "2. Create the PR with `gh pr create` — write a clear title and a body that summarizes what changed and why, following this repo's conventions.",
+].join("\n")
+
+/**
+ * The done card's "open a PR" instruction. Delegated to the session on
+ * purpose: the agent that DID the work writes the PR title/body from its
+ * own context — something a generic bridge-side `gh pr create` could never
+ * produce — and it follows the repo's own PR conventions because it's
+ * sitting in the repo. Same template + appended-clause split as
+ * {@link reviewPrompt}.
+ */
+export function createPrPrompt(template?: string | null): string {
+  const base = template?.trim() || DEFAULT_PR_TEMPLATE
+  return [
+    base,
+    "Reply with the PR URL.",
+    "If `gh` isn't authenticated, there's no remote, or a PR already exists for this branch, say so instead of forcing it.",
+  ].join("\n")
 }

--- a/packages/kobe-web/src/lib/review.ts
+++ b/packages/kobe-web/src/lib/review.ts
@@ -1,23 +1,22 @@
 /**
- * The board's one-click review instruction (docs/design/web-kanban.md M5
- * follow-up): clicking Review on an `in_review` card pastes this prompt
- * into the task's engine session.
+ * The board's one-click review instruction: clicking Review on an
+ * `in_review` card pastes this into the task's engine session.
  *
- * The `done` authorization travels WITH the click, deliberately: the
- * spawn-time status protocol only ever lets the agent self-report
- * `in_review` — `done` stays human-gated. Clicking Review IS that human
- * gate (the user explicitly delegates the review), so the prompt carries a
- * one-time authorization to set `done` on a passing review. A session that
- * was never sent a review request can never reach `done` on its own.
+ * Deliberately minimal — claude ships its own `/review` command, so the
+ * paste leads with that and adds ONLY the thing the engine can't know:
+ * the one-time `done` authorization. (The spawn-time status protocol never
+ * grants `done`; clicking Review IS the human gate, so the authorization
+ * travels with the click. A session never sent a review request can't
+ * reach `done` on its own.) Engines without a /review command get a
+ * one-line prose ask instead.
  */
 
-export function reviewPrompt(taskId: string): string {
-  return [
-    "Please review the work in this worktree now:",
-    "1. Inspect the current changes (`git status`, `git diff`, recent commits on this branch) and any open PR.",
-    "2. Verify the work actually does what was asked — run the relevant tests/build/lint where applicable, and read the changed code critically.",
-    `3. If the review PASSES: run \`kobe api set-status --task-id ${taskId} --status done\` and reply with a short summary of what you verified.`,
-    "4. If anything fails or looks incomplete: do NOT change the status — explain exactly what is wrong and what still needs to happen.",
-    "This review request is your one-time authorization to set status `done`; outside an explicit review request, never set `done`.",
-  ].join("\n")
+const doneClause = (taskId: string): string =>
+  `if it passes, run \`kobe api set-status --task-id ${taskId} --status done\`; otherwise report the problems and leave the status unchanged.`
+
+export function reviewPrompt(taskId: string, vendor?: string): string {
+  if ((vendor ?? "claude") === "claude") {
+    return `/review\nAfter the review: ${doneClause(taskId)}`
+  }
+  return `Review the current changes in this worktree critically. Then: ${doneClause(taskId)}`
 }

--- a/packages/kobe-web/src/lib/review.ts
+++ b/packages/kobe-web/src/lib/review.ts
@@ -1,0 +1,23 @@
+/**
+ * The board's one-click review instruction (docs/design/web-kanban.md M5
+ * follow-up): clicking Review on an `in_review` card pastes this prompt
+ * into the task's engine session.
+ *
+ * The `done` authorization travels WITH the click, deliberately: the
+ * spawn-time status protocol only ever lets the agent self-report
+ * `in_review` — `done` stays human-gated. Clicking Review IS that human
+ * gate (the user explicitly delegates the review), so the prompt carries a
+ * one-time authorization to set `done` on a passing review. A session that
+ * was never sent a review request can never reach `done` on its own.
+ */
+
+export function reviewPrompt(taskId: string): string {
+  return [
+    "Please review the work in this worktree now:",
+    "1. Inspect the current changes (`git status`, `git diff`, recent commits on this branch) and any open PR.",
+    "2. Verify the work actually does what was asked — run the relevant tests/build/lint where applicable, and read the changed code critically.",
+    `3. If the review PASSES: run \`kobe api set-status --task-id ${taskId} --status done\` and reply with a short summary of what you verified.`,
+    "4. If anything fails or looks incomplete: do NOT change the status — explain exactly what is wrong and what still needs to happen.",
+    "This review request is your one-time authorization to set status `done`; outside an explicit review request, never set `done`.",
+  ].join("\n")
+}

--- a/packages/kobe-web/src/lib/terminal.ts
+++ b/packages/kobe-web/src/lib/terminal.ts
@@ -52,3 +52,32 @@ export async function closePtyTab(tabId: string): Promise<void> {
     /* best-effort — the tab is already gone from the UI */
   }
 }
+
+/**
+ * Paste text + Enter into a tab's engine — the composer's submit contract,
+ * fired from outside any terminal view (board quick actions). The sidecar
+ * spawns the engine on demand when the tab has no process yet, so a board
+ * action works without the terminal ever having been opened; output lands
+ * in the scrollback ring for the next attach. Throws on failure so callers
+ * can toast.
+ */
+export async function sendPtyText(
+  tabId: string,
+  taskId: string,
+  text: string,
+): Promise<{ spawned: boolean }> {
+  const res = await fetch(`${ptyHttpOrigin()}/pty/send`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ tab: tabId, taskId, text }),
+  })
+  const json = (await res.json()) as {
+    sent?: boolean
+    spawned?: boolean
+    error?: string
+  }
+  if (!res.ok || !json.sent) {
+    throw new Error(json.error ?? `send failed (${res.status})`)
+  }
+  return { spawned: json.spawned === true }
+}

--- a/packages/kobe-web/src/lib/terminal.ts
+++ b/packages/kobe-web/src/lib/terminal.ts
@@ -71,10 +71,18 @@ export async function sendPtyText(
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ tab: tabId, taskId, text }),
   })
-  const json = (await res.json()) as {
-    sent?: boolean
-    spawned?: boolean
-    error?: string
+  // Parse defensively: a sidecar that predates this endpoint 404s with an
+  // EMPTY body, and a raw res.json() would surface as a cryptic JSON parse
+  // error instead of the actual problem.
+  let json: { sent?: boolean; spawned?: boolean; error?: string } = {}
+  try {
+    json = (await res.json()) as typeof json
+  } catch {
+    if (res.status === 404) {
+      throw new Error(
+        "the PTY server doesn't know /pty/send — restart `kobe web` (the sidecar doesn't hot-reload)",
+      )
+    }
   }
   if (!res.ok || !json.sent) {
     throw new Error(json.error ?? `send failed (${res.status})`)

--- a/packages/kobe-web/test/bridge-routes.test.ts
+++ b/packages/kobe-web/test/bridge-routes.test.ts
@@ -1,5 +1,8 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { describe, expect, it, vi } from "vitest"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import {
   type BridgeLink,
   createRequestHandler,
@@ -246,4 +249,66 @@ describe("bridge request handler", () => {
   // Bun runtime — the live `kobe web` server. It's not exercised here because
   // vitest runs under node; the route ordering (404 when no staticDir) is
   // covered above.
+})
+
+describe("/api/quick-prompts", () => {
+  // These hit the real state.json helpers, so point KOBE_HOME_DIR at a
+  // throwaway dir for the duration (the other suites never touch it).
+  let home: string
+  let prevHome: string | undefined
+
+  beforeAll(async () => {
+    prevHome = process.env.KOBE_HOME_DIR
+    home = await mkdtemp(join(tmpdir(), "kobe-qp-"))
+    process.env.KOBE_HOME_DIR = home
+  })
+
+  afterAll(async () => {
+    if (prevHome === undefined) delete process.env.KOBE_HOME_DIR
+    else process.env.KOBE_HOME_DIR = prevHome
+    await rm(home, { recursive: true, force: true })
+  })
+
+  it("rounds templates through state.json: empty → PUT → GET", async () => {
+    const { handle } = build()
+    const empty = await (
+      await handle(new Request("http://localhost/api/quick-prompts"))
+    ).json()
+    expect(empty).toEqual({ review: null, pr: null })
+
+    const put = await handle(
+      new Request("http://localhost/api/quick-prompts", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ review: "/review --deep", pr: "open a DRAFT pr" }),
+      }),
+    )
+    expect(await put.json()).toEqual({ review: "/review --deep", pr: "open a DRAFT pr" })
+
+    const got = await (
+      await handle(new Request("http://localhost/api/quick-prompts"))
+    ).json()
+    expect(got).toEqual({ review: "/review --deep", pr: "open a DRAFT pr" })
+  })
+
+  it("400s malformed JSON and ignores non-string fields", async () => {
+    const { handle } = build()
+    const bad = await handle(
+      new Request("http://localhost/api/quick-prompts", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: "not json",
+      }),
+    )
+    expect(bad.status).toBe(400)
+
+    const partial = await handle(
+      new Request("http://localhost/api/quick-prompts", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ review: 42 }),
+      }),
+    )
+    expect(partial.status).toBe(200)
+  })
 })

--- a/packages/kobe-web/test/review.test.ts
+++ b/packages/kobe-web/test/review.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { reviewPrompt } from "../src/lib/review.ts"
+import { createPrPrompt, reviewPrompt } from "../src/lib/review.ts"
 
 /**
  * One-click review instruction. Load-bearing: claude gets its native
@@ -30,5 +30,36 @@ describe("reviewPrompt", () => {
     for (const vendor of ["claude", "codex"]) {
       expect(reviewPrompt("t1", vendor)).toContain("leave the status unchanged")
     }
+  })
+})
+
+describe("createPrPrompt", () => {
+  it("pushes, creates via gh, returns the URL, and never forces", () => {
+    const text = createPrPrompt()
+    expect(text).toContain("push the branch")
+    expect(text).toContain("gh pr create")
+    expect(text).toContain("Reply with the PR URL")
+    expect(text).toContain("say so instead of forcing it")
+  })
+})
+
+describe("user templates — kobe's clause is APPENDED, never replaced", () => {
+  it("a custom review template swaps the base, the done clause survives", () => {
+    const text = reviewPrompt("t1", "claude", "/review focus on security")
+    expect(text.startsWith("/review focus on security\n")).toBe(true)
+    expect(text).toContain("--status done")
+    expect(text).toContain("leave the status unchanged")
+  })
+
+  it("a blank/whitespace template falls back to the built-in default", () => {
+    expect(reviewPrompt("t1", "claude", "   ").startsWith("/review\n")).toBe(true)
+    expect(reviewPrompt("t1", "claude", null).startsWith("/review\n")).toBe(true)
+  })
+
+  it("a custom PR template keeps the URL + never-force tail", () => {
+    const text = createPrPrompt("Open a DRAFT pr with gh pr create --draft")
+    expect(text.startsWith("Open a DRAFT pr")).toBe(true)
+    expect(text).toContain("Reply with the PR URL")
+    expect(text).toContain("say so instead of forcing it")
   })
 })

--- a/packages/kobe-web/test/review.test.ts
+++ b/packages/kobe-web/test/review.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { reviewPrompt } from "../src/lib/review.ts"
+
+/**
+ * One-click review instruction. Load-bearing: the `done` authorization
+ * travels WITH the review request (the spawn-time status protocol never
+ * grants it), the command path is the top-level `kobe api set-status`
+ * (NOT the bogus `api edit` form a field agent once hit), and a failing
+ * review must leave the status untouched.
+ */
+describe("reviewPrompt", () => {
+  const text = reviewPrompt("01HXABC")
+
+  it("authorizes done ONLY for this review, with the exact CLI command", () => {
+    expect(text).toContain("kobe api set-status --task-id 01HXABC --status done")
+    expect(text).not.toContain("api edit")
+    expect(text).toContain("one-time authorization")
+  })
+
+  it("a failing review keeps the status unchanged", () => {
+    expect(text).toContain("do NOT change the status")
+    expect(text).not.toContain("--status in_progress")
+  })
+})

--- a/packages/kobe-web/test/review.test.ts
+++ b/packages/kobe-web/test/review.test.ts
@@ -2,23 +2,33 @@ import { describe, expect, it } from "vitest"
 import { reviewPrompt } from "../src/lib/review.ts"
 
 /**
- * One-click review instruction. Load-bearing: the `done` authorization
- * travels WITH the review request (the spawn-time status protocol never
- * grants it), the command path is the top-level `kobe api set-status`
- * (NOT the bogus `api edit` form a field agent once hit), and a failing
- * review must leave the status untouched.
+ * One-click review instruction. Load-bearing: claude gets its native
+ * /review command (no re-taught checklist) plus ONLY the click-scoped
+ * `done` authorization; the CLI path is the top-level `kobe api
+ * set-status` (NOT the bogus `api edit` form a field agent once hit);
+ * and a failing review must leave the status untouched.
  */
 describe("reviewPrompt", () => {
-  const text = reviewPrompt("01HXABC")
-
-  it("authorizes done ONLY for this review, with the exact CLI command", () => {
+  it("claude: leads with the native /review command", () => {
+    const text = reviewPrompt("01HXABC", "claude")
+    expect(text.startsWith("/review\n")).toBe(true)
     expect(text).toContain("kobe api set-status --task-id 01HXABC --status done")
     expect(text).not.toContain("api edit")
-    expect(text).toContain("one-time authorization")
   })
 
-  it("a failing review keeps the status unchanged", () => {
-    expect(text).toContain("do NOT change the status")
-    expect(text).not.toContain("--status in_progress")
+  it("missing vendor defaults to claude (house convention)", () => {
+    expect(reviewPrompt("t1", undefined).startsWith("/review")).toBe(true)
+  })
+
+  it("non-claude engines get the prose form with the same done clause", () => {
+    const text = reviewPrompt("t1", "codex")
+    expect(text).not.toContain("/review")
+    expect(text).toContain("kobe api set-status --task-id t1 --status done")
+  })
+
+  it("a failing review keeps the status unchanged, in every form", () => {
+    for (const vendor of ["claude", "codex"]) {
+      expect(reviewPrompt("t1", vendor)).toContain("leave the status unchanged")
+    }
   })
 })


### PR DESCRIPTION
## What

`In review` cards on `/board` get a clipboard button: one click pastes a review instruction straight into the task's engine session — no terminal, no typing.

- **New PTY-sidecar endpoint `POST /pty/send`** — pastes text + Enter into a tab's engine using the composer's exact bracketed-paste contract. Spawns the engine on demand when the tab has no process (with a startup grace delay so the paste isn't eaten), so the action works without the terminal ever having been opened; output lands in the scrollback ring for the next attach/peek. Text injection drives the engine like a keyboard, so the endpoint enforces the same localhost-origin policy as the WS attach (stricter than `/pty/close`).
- **Review instruction (`lib/review.ts`)** — inspect the changes, run the relevant checks, and on a PASSING review run `kobe api set-status --task-id <id> --status done`; on a failing one, report findings and leave the status untouched.
- **`done` authorization travels with the click, deliberately.** The always-on status protocol (from #108) only ever lets an agent self-report `in_review`; clicking Review IS the human gate for `done`, granted as a one-time authorization inside the pasted instruction. A session never sent a review request can never reach `done` on its own.

## Notes

- The button only renders on `In review` column cards.
- Success/failure surfaces as a toast (`review sent — engine starting, peek to watch` on spawn-on-send).
- 1 changeset, `patch`. kobe-web: 359 tests, biome/tsc/build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable board quick-action templates in Settings for review and PR creation workflows.
  * Added one-click review button for cards in the in_review column to streamline task reviews.
  * Added one-click create PR button for done cards without an existing pull request.

* **Documentation**
  * Added design documentation for conflict radar system and enhanced Kanban workflow features.

* **Tests**
  * Added test coverage for quick-prompt endpoints and review prompt generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->