### PR TITLE
feat(web): conflict radar — yarn lines connect truly-conflicting board cards

### DIFF
--- a/.changeset/witty-yarns-collide.md
+++ b/.changeset/witty-yarns-collide.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+**Conflict radar on the board** — cards whose branches truly collide are now connected by colored yarn lines on `/board`: the daemon dry-runs `git merge-tree --write-tree` between in-flight task heads (after a cheap touched-file-overlap prescreen), publishes pairs over a new `task.conflicts` channel, and the board draws a drooping line per conflicting pair with a hover tooltip naming both tasks and the clashing files; overlapping/conflicting cards also carry a ⚠ badge. Every radar git call is strictly non-blocking — async spawns with `GIT_OPTIONAL_LOCKS=0` (never takes `.git/index.lock` from under an engine's own commit), a global cap of 3 concurrent git children, per-card adaptive scheduling with timeout + backoff, and merge probes cached by head pair so they rerun only on new commits. On git < 2.38 the radar degrades to file-overlap badges (no yarn) instead of erroring.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -11,6 +11,7 @@
     "./client/daemon-process": "./src/client/daemon-process.ts",
     "./daemon/activity-registry": "./src/daemon/activity-registry.ts",
     "./daemon/auto-title-poller": "./src/daemon/auto-title-poller.ts",
+    "./daemon/conflict-collector": "./src/daemon/conflict-collector.ts",
     "./daemon/crash-log": "./src/daemon/crash-log.ts",
     "./daemon/cwd-task": "./src/daemon/cwd-task.ts",
     "./daemon/event-bus": "./src/daemon/event-bus.ts",

--- a/packages/kobe-daemon/src/daemon/conflict-collector.ts
+++ b/packages/kobe-daemon/src/daemon/conflict-collector.ts
@@ -1,0 +1,409 @@
+/**
+ * Daemon-side conflict radar collector (docs/design/conflict-radar.md).
+ *
+ * Two-tier signal over the in-flight worktree tasks of each repo:
+ *
+ *   - L1 `overlap` — the cards' touched-file sets intersect. Per card ONE
+ *     cheap footprint (HEAD + dirty paths + committed paths vs the repo's
+ *     default ref); the pairwise part is pure in-memory set intersection,
+ *     so the O(N²) lands on the free operation.
+ *   - L2 `conflict` — for L1 pairs only, a `git merge-tree --write-tree`
+ *     DRY-RUN of the two heads (never touches any worktree). Cached by the
+ *     head pair, so it reruns only when someone commits.
+ *
+ * Non-blocking discipline (the whole point — these run beside the agents'
+ * own git activity, often in BULK):
+ *   - every git call is an async spawn through {@link spawnCapture} — the
+ *     daemon's event loop never blocks;
+ *   - `GIT_OPTIONAL_LOCKS=0` on every read, so the radar never takes
+ *     `.git/index.lock` from under an engine's own commit;
+ *   - a global {@link GitGate} caps concurrent git children across ALL
+ *     cards and merge-tree probes — a 30-card board queues, never stampedes;
+ *   - per-card scheduling rides `@/lib/poll-scheduling` (in-flight dedupe,
+ *     timeout + SIGKILL, hard backoff, adaptive cadence) — the exact guards
+ *     that fixed the 30GB-repo freeze for worktree-changes;
+ *   - footprints republish on change only, and the consumer gate skips the
+ *     whole pass while nobody is subscribed.
+ *
+ * `git merge-tree --write-tree` needs git ≥ 2.38; an unsupported git is
+ * detected once and the radar degrades to L1-only (log, not error).
+ */
+
+import {
+  type PollCadenceConfig,
+  type PollScheduleState,
+  maybeStartScheduledRun,
+  spawnCapture,
+} from "@/lib/poll-scheduling"
+import { isRemoteRepoKey } from "@/state/repos"
+import type { Task } from "@/types/task"
+import { logDaemonError } from "./crash-log.ts"
+import type { DaemonEventBus } from "./event-bus.ts"
+import type { ConflictPair, ConflictsPayload } from "./protocol.ts"
+import type { TaskLister } from "./worktree-changes-collector.ts"
+
+/** Conflicts move slower than dirty counts — a relaxed tick is plenty. */
+export const DEFAULT_CONFLICTS_TICK_MS = 5_000
+export const CONFLICTS_TIMEOUT_MS = 5_000
+export const CONFLICTS_SLOW_RETRY_MS = 60_000
+export const CONFLICTS_MIN_INTERVAL_MS = 10_000
+/** Ceiling on concurrent git children across the whole radar. */
+const MAX_CONCURRENT_GIT = 3
+/** merge-tree gets its own (generous) leash — it's rarer and heavier. */
+const MERGE_TREE_TIMEOUT_MS = 8_000
+
+/** Tiny FIFO semaphore — bounds the radar's git process fan-out. */
+export class GitGate {
+  private active = 0
+  private readonly waiters: Array<() => void> = []
+  constructor(private readonly limit: number = MAX_CONCURRENT_GIT) {}
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.active >= this.limit) {
+      await new Promise<void>((resolve) => this.waiters.push(resolve))
+    }
+    this.active += 1
+    try {
+      return await fn()
+    } finally {
+      this.active -= 1
+      this.waiters.shift()?.()
+    }
+  }
+}
+
+/** One card's git footprint: where its head is and which files it touches. */
+export interface CardFootprint {
+  readonly repo: string
+  readonly head: string
+  readonly files: ReadonlySet<string>
+}
+
+const LOCK_FREE_ENV = { GIT_OPTIONAL_LOCKS: "0" }
+
+async function git(
+  cwd: string,
+  args: string[],
+  signal: AbortSignal,
+  gate: GitGate,
+): Promise<{ status: number | null; stdout: string }> {
+  return gate.run(() => spawnCapture("git", args, { cwd, env: { ...process.env, ...LOCK_FREE_ENV }, signal }))
+}
+
+/** Dirty paths from porcelain v1 — both sides of a rename count. */
+export function parsePorcelainPaths(stdout: string): string[] {
+  const paths: string[] = []
+  for (const line of stdout.split("\n")) {
+    if (line.length < 4) continue
+    const rest = line.slice(3)
+    const arrow = rest.indexOf(" -> ")
+    if (arrow >= 0) {
+      paths.push(rest.slice(0, arrow), rest.slice(arrow + 4))
+    } else {
+      paths.push(rest)
+    }
+  }
+  return paths
+}
+
+/** Candidate base refs, in resolution order, for "what this branch adds". */
+const BASE_REF_CANDIDATES = ["origin/HEAD", "origin/main", "origin/master", "main", "master"]
+
+/** Resolve the repo's default ref name (first verifiable candidate). */
+export async function resolveBaseRef(worktree: string, signal: AbortSignal, gate: GitGate): Promise<string | null> {
+  for (const ref of BASE_REF_CANDIDATES) {
+    const res = await git(worktree, ["rev-parse", "--verify", "--quiet", ref], signal, gate)
+    if (res.status === 0) return ref
+  }
+  return null
+}
+
+/**
+ * One card's footprint: HEAD sha, plus dirty paths ∪ committed paths
+ * relative to the merge-base with `baseRef` (three-dot diff — one call,
+ * no explicit merge-base step). `baseRef === null` → dirty paths only.
+ */
+export async function collectFootprint(
+  worktree: string,
+  repo: string,
+  baseRef: string | null,
+  signal: AbortSignal,
+  gate: GitGate,
+): Promise<CardFootprint> {
+  const head = await git(worktree, ["rev-parse", "HEAD"], signal, gate)
+  if (head.status !== 0) throw new Error("rev-parse HEAD failed")
+  const files = new Set<string>()
+  const status = await git(worktree, ["status", "--porcelain=v1"], signal, gate)
+  if (status.status !== 0) throw new Error("git status failed")
+  for (const p of parsePorcelainPaths(status.stdout)) files.add(p)
+  if (baseRef) {
+    const diff = await git(worktree, ["diff", "--name-only", `${baseRef}...HEAD`], signal, gate)
+    // A branch with no merge-base (exotic adopt) just contributes dirty
+    // paths — L1-only for that card, never an error.
+    if (diff.status === 0) {
+      for (const p of diff.stdout.split("\n")) if (p) files.add(p)
+    }
+  }
+  return { repo, head: head.stdout.trim(), files }
+}
+
+export function sameFootprint(a: CardFootprint, b: CardFootprint): boolean {
+  if (a.head !== b.head || a.files.size !== b.files.size) return false
+  for (const f of a.files) if (!b.files.has(f)) return false
+  return true
+}
+
+/** The radar's population: in-flight worktree tasks on this machine. */
+export function trackedConflictTasks(tasks: readonly Task[]): Task[] {
+  return tasks.filter(
+    (t) =>
+      !t.archived &&
+      (t.kind ?? "task") !== "main" &&
+      !!t.worktreePath &&
+      !isRemoteRepoKey(t.repo) &&
+      !isRemoteRepoKey(t.worktreePath),
+  )
+}
+
+/** L1: same-repo pairs whose file sets intersect. Pure; ids sorted. */
+export function overlapPairs(cards: ReadonlyMap<string, CardFootprint>): ConflictPair[] {
+  const ids = [...cards.keys()].sort()
+  const pairs: ConflictPair[] = []
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const a = cards.get(ids[i] as string) as CardFootprint
+      const b = cards.get(ids[j] as string) as CardFootprint
+      if (a.repo !== b.repo) continue
+      const files = [...a.files].filter((f) => b.files.has(f)).sort()
+      if (files.length === 0) continue
+      pairs.push({ a: ids[i] as string, b: ids[j] as string, files, level: "overlap" })
+    }
+  }
+  return pairs
+}
+
+/** Conflicted filenames from `merge-tree --write-tree --name-only` output:
+ *  line 0 is the tree OID, then conflicted names until the blank line. */
+export function parseMergeTreeNames(stdout: string): string[] {
+  const lines = stdout.split("\n")
+  const names: string[] = []
+  for (const line of lines.slice(1)) {
+    if (!line) break
+    names.push(line)
+  }
+  return names
+}
+
+export function samePairs(a: readonly ConflictPair[], b: readonly ConflictPair[]): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+interface CardEntry extends PollScheduleState {
+  value?: CardFootprint
+}
+
+type MergeProbe = { state: "pending" } | { state: "clean" } | { state: "conflict"; files: readonly string[] }
+
+export interface ConflictCollectorOptions {
+  readonly cadence?: PollCadenceConfig
+  /** Injectable footprint runner — tests avoid real git/worktrees. */
+  readonly footprint?: (task: Task, signal: AbortSignal) => Promise<CardFootprint>
+  /** Injectable merge-tree prober. Resolve `null` for "unsupported". */
+  readonly probeMerge?: (
+    worktree: string,
+    headA: string,
+    headB: string,
+  ) => Promise<{ conflict: boolean; files: string[] } | null>
+  readonly hasSubscribers?: () => boolean
+}
+
+/**
+ * Tick-driven, same contract as {@link WorktreeChangesCollector}: `tick()`
+ * never throws, prunes dropped tasks, schedules guarded footprint runs,
+ * recomputes pairs in memory as results land, and publishes the full pair
+ * list on change only.
+ */
+export class ConflictCollector {
+  private readonly entries = new Map<string, CardEntry>()
+  private readonly baseRefs = new Map<string, Promise<string | null>>()
+  private readonly mergeProbes = new Map<string, MergeProbe>()
+  private readonly gate = new GitGate()
+  private mergeTreeUnsupported = false
+  // Seeded empty so a no-conflict recompute on boot publishes nothing —
+  // every consumer already defaults to "no pairs".
+  private lastPublished: ConflictPair[] = []
+  private stopped = false
+
+  constructor(
+    private readonly orch: TaskLister,
+    private readonly bus: DaemonEventBus,
+    private readonly options: ConflictCollectorOptions = {},
+  ) {}
+
+  tick(): void {
+    if (this.stopped) return
+    if (this.options.hasSubscribers && !this.options.hasSubscribers()) return
+    try {
+      const tracked = trackedConflictTasks(this.orch.listTasks())
+      const trackedIds = new Set(tracked.map((t) => t.id as string))
+      let pruned = false
+      for (const id of this.entries.keys()) {
+        if (trackedIds.has(id)) continue
+        if (this.entries.get(id)?.value) pruned = true
+        this.entries.delete(id)
+      }
+      if (pruned) this.recompute()
+      for (const task of tracked) this.maybeCollect(task)
+    } catch (err) {
+      logDaemonError("conflict-radar", err)
+    }
+  }
+
+  stop(): void {
+    this.stopped = true
+  }
+
+  private maybeCollect(task: Task): void {
+    const id = task.id as string
+    let entry = this.entries.get(id)
+    if (!entry) {
+      entry = { inFlight: false, nextAllowedAt: 0 }
+      this.entries.set(id, entry)
+    }
+    const cadence = this.options.cadence ?? {
+      timeoutMs: CONFLICTS_TIMEOUT_MS,
+      slowRetryMs: CONFLICTS_SLOW_RETRY_MS,
+      minIntervalMs: CONFLICTS_MIN_INTERVAL_MS,
+    }
+    const run =
+      this.options.footprint ??
+      (async (t: Task, signal: AbortSignal) => {
+        const baseRef = await this.baseRefFor(t.worktreePath, signal)
+        return collectFootprint(t.worktreePath, t.repo, baseRef, signal, this.gate)
+      })
+    maybeStartScheduledRun(
+      entry,
+      cadence,
+      (signal) => run(task, signal),
+      (value) => {
+        if (this.stopped) return
+        if (this.entries.get(id) !== entry) return
+        if (entry.value && sameFootprint(entry.value, value)) return
+        entry.value = value
+        this.recompute()
+      },
+    )
+  }
+
+  /** Default-ref name per repo, resolved once (promise-cached). */
+  private baseRefFor(worktree: string, signal: AbortSignal): Promise<string | null> {
+    const cached = this.baseRefs.get(worktree)
+    if (cached) return cached
+    const promise = resolveBaseRef(worktree, signal, this.gate).catch(() => null)
+    this.baseRefs.set(worktree, promise)
+    return promise
+  }
+
+  /** Rebuild the pair list from current footprints; schedule L2 probes for
+   *  overlap pairs whose head-pair hasn't been judged yet. */
+  private recompute(): void {
+    const cards = new Map<string, CardFootprint>()
+    for (const [id, entry] of this.entries) {
+      if (entry.value) cards.set(id, entry.value)
+    }
+    const pairs = overlapPairs(cards)
+    const resolved: ConflictPair[] = []
+    for (const pair of pairs) {
+      const a = cards.get(pair.a) as CardFootprint
+      const b = cards.get(pair.b) as CardFootprint
+      const key = [a.repo, ...[a.head, b.head].sort()].join("\0")
+      const probe = this.mergeProbes.get(key)
+      if (probe?.state === "conflict") {
+        resolved.push({
+          ...pair,
+          level: "conflict",
+          // merge-tree's conflicted names are the precise set; fall back to
+          // the overlap files when the parse came up empty.
+          files: probe.files.length > 0 ? probe.files : pair.files,
+        })
+        continue
+      }
+      resolved.push(pair)
+      if (!probe && !this.mergeTreeUnsupported && a.head !== b.head) {
+        this.scheduleMergeProbe(key, cards, pair)
+      }
+    }
+    if (samePairs(this.lastPublished, resolved)) return
+    this.lastPublished = resolved
+    const payload: ConflictsPayload = { pairs: resolved }
+    this.bus.publish("task.conflicts", payload)
+  }
+
+  private scheduleMergeProbe(key: string, cards: ReadonlyMap<string, CardFootprint>, pair: ConflictPair): void {
+    const a = cards.get(pair.a) as CardFootprint
+    const b = cards.get(pair.b) as CardFootprint
+    this.mergeProbes.set(key, { state: "pending" })
+    // Any worktree of the repo sees the shared object store; use a's.
+    const worktree = this.worktreeOf(pair.a)
+    const probe =
+      this.options.probeMerge ??
+      (async (wt: string, headA: string, headB: string) => {
+        const res = await git(
+          wt,
+          ["merge-tree", "--write-tree", "--name-only", headA, headB],
+          AbortSignal.timeout(MERGE_TREE_TIMEOUT_MS),
+          this.gate,
+        )
+        if (res.status === 0) return { conflict: false, files: [] }
+        if (res.status === 1) return { conflict: true, files: parseMergeTreeNames(res.stdout) }
+        return null // unsupported git / no merge base — degrade to L1
+      })
+    if (!worktree) {
+      this.mergeProbes.delete(key)
+      return
+    }
+    void probe(worktree, a.head, b.head)
+      .then((result) => {
+        if (this.stopped) return
+        if (result === null) {
+          if (!this.mergeTreeUnsupported) {
+            this.mergeTreeUnsupported = true
+            console.log(
+              "[conflict-radar] merge-tree dry-run unavailable (git < 2.38 or no merge base) — radar degrades to file-overlap only",
+            )
+          }
+          this.mergeProbes.delete(key)
+          return
+        }
+        this.mergeProbes.set(key, result.conflict ? { state: "conflict", files: result.files } : { state: "clean" })
+        this.recompute()
+      })
+      .catch((err) => {
+        this.mergeProbes.delete(key)
+        logDaemonError("conflict-radar", err)
+      })
+  }
+
+  private worktreeOf(taskId: string): string | undefined {
+    const task = this.orch.listTasks().find((t) => t.id === taskId)
+    return task?.worktreePath || undefined
+  }
+}
+
+/** Production interval binding — same conventions as the other collectors:
+ *  `tickMs <= 0` disables, `hasSubscribers` is the idle-daemon gate. */
+export function startConflictCollector(
+  orch: TaskLister,
+  bus: DaemonEventBus,
+  tickMs: number = DEFAULT_CONFLICTS_TICK_MS,
+  hasSubscribers?: () => boolean,
+): () => void {
+  if (tickMs <= 0) return () => {}
+  const collector = new ConflictCollector(orch, bus, { hasSubscribers })
+  collector.tick()
+  const timer = setInterval(() => collector.tick(), tickMs)
+  timer.unref?.()
+  return () => {
+    clearInterval(timer)
+    collector.stop()
+  }
+}

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -255,11 +255,32 @@ export interface ChannelPayloads {
   "worktree.changes": {
     changes: Record<string, { added: number; deleted: number }>
   }
+  /**
+   * Conflict radar (docs/design/conflict-radar.md): pairs of in-flight
+   * tasks whose branches touch the same files (`overlap`) or whose heads
+   * demonstrably conflict under a dry-run merge (`conflict`,
+   * `git merge-tree`). Daemon-collected on a guarded tick; the board draws
+   * yarn between `conflict` pairs and badges both cards. Full list,
+   * republished on change only.
+   */
+  "task.conflicts": { pairs: ConflictPair[] }
   // Add a channel ↓ then `bus.publish(name, payload)` in the daemon and
   // `client.onChannel(name, …)` in a consumer — that's the whole recipe:
   // "cost": { taskId: string; usd: number; tokens: number }
   // "pr-status": { taskId: string; state: "open" | "merged" | "closed" | "none" }
 }
+
+/** One radar pair: `a` < `b` (sorted task ids), the overlapping files, and
+ *  the strongest proven signal level. */
+export interface ConflictPair {
+  readonly a: string
+  readonly b: string
+  readonly files: readonly string[]
+  readonly level: "overlap" | "conflict"
+}
+
+/** The `task.conflicts` channel payload. */
+export type ConflictsPayload = ChannelPayloads["task.conflicts"]
 
 /** The `ui-prefs` channel payload — the persisted visual prefs snapshot. */
 export type UiPrefsPayload = ChannelPayloads["ui-prefs"]
@@ -283,6 +304,7 @@ export const CHANNEL_NAMES: readonly ChannelName[] = [
   "keybindings",
   "task.jobs",
   "worktree.changes",
+  "task.conflicts",
 ]
 
 const CHANNEL_NAME_SET: ReadonlySet<string> = new Set<string>(CHANNEL_NAMES)

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -19,6 +19,7 @@ import type { Orchestrator } from "@/orchestrator/core"
 import { type UpdateInfo, checkLatestVersion } from "@/version"
 import { DaemonActivityRegistry } from "./activity-registry.ts"
 import { DEFAULT_AUTO_TITLE_POLL_MS, startAutoTitlePoller } from "./auto-title-poller.ts"
+import { DEFAULT_CONFLICTS_TICK_MS, startConflictCollector } from "./conflict-collector.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import { DaemonEventBus } from "./event-bus.ts"
 import { createDaemonHandlerRegistry, dispatchDaemonRequest, objectPayload, shapeDaemonError } from "./handlers.ts"
@@ -79,6 +80,8 @@ export interface DaemonServerOptions {
   readonly keybindingsDebounceMs?: number
   /** Worktree-changes collector tick in ms; `0` disables. Defaults to {@link DEFAULT_WORKTREE_CHANGES_TICK_MS}. */
   readonly worktreeChangesTickMs?: number
+  /** Conflict-radar collector tick in ms; `0` disables. Defaults to {@link DEFAULT_CONFLICTS_TICK_MS}. */
+  readonly conflictsTickMs?: number
 }
 
 export interface DaemonServer {
@@ -315,6 +318,17 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
     hasSubscribers,
   )
 
+  // Conflict radar (docs/design/conflict-radar.md): pairwise file-overlap +
+  // merge-tree dry-runs over in-flight worktree tasks, published on
+  // `task.conflicts`. Same guarded-poll + consumer-gate discipline as the
+  // worktree-changes collector above.
+  const stopConflictCollector = startConflictCollector(
+    orch,
+    bus,
+    options.conflictsTickMs ?? DEFAULT_CONFLICTS_TICK_MS,
+    hasSubscribers,
+  )
+
   const serverApi: DaemonServer = {
     socketPath,
     pidPath,
@@ -329,6 +343,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
       stopUiPrefsWatcher()
       stopKeybindingsWatcher()
       stopWorktreeChangesCollector()
+      stopConflictCollector()
       activity.close()
       // tmux is intentionally untouched here: closing the daemon never tears
       // down task sessions. Session teardown lives ONLY in `kobe reset` /

--- a/packages/kobe-web/server/daemon-link.ts
+++ b/packages/kobe-web/server/daemon-link.ts
@@ -50,6 +50,8 @@ export interface BridgeSnapshotState {
   jobs: Record<string, TaskJobPayload>
   /** worktreePath → uncommitted +added/−deleted counts (daemon-collected). */
   worktreeChanges: WorktreeChangeCounts
+  /** Conflict-radar pairs (file overlap / proven merge conflict). */
+  conflicts: ChannelPayloads["task.conflicts"]["pairs"]
   /** The user's persisted visual prefs (theme/sort) — null until replayed. */
   uiPrefs: UiPrefsPayload | null
   connected: boolean
@@ -88,6 +90,7 @@ export class DaemonLink {
   private update: ChannelPayloads["update"]["info"] = null
   private jobs: Record<string, TaskJobPayload> = {}
   private worktreeChanges: WorktreeChangeCounts = {}
+  private conflicts: ChannelPayloads["task.conflicts"]["pairs"] = []
   private uiPrefs: UiPrefsPayload | null = null
 
   /**
@@ -108,6 +111,7 @@ export class DaemonLink {
       update: this.update,
       jobs: this.jobs,
       worktreeChanges: this.worktreeChanges,
+      conflicts: this.conflicts,
       uiPrefs: this.uiPrefs,
       connected: this.connected,
     }
@@ -247,6 +251,9 @@ export class DaemonLink {
       }
       case "worktree.changes":
         this.worktreeChanges = (payload as ChannelPayloads["worktree.changes"]).changes
+        break
+      case "task.conflicts":
+        this.conflicts = (payload as ChannelPayloads["task.conflicts"]).pairs
         break
       case "ui-prefs":
         this.uiPrefs = payload as UiPrefsPayload

--- a/packages/kobe-web/server/spa-channels.ts
+++ b/packages/kobe-web/server/spa-channels.ts
@@ -25,6 +25,7 @@ export const SPA_CHANNELS: readonly ChannelName[] = [
   "update",
   "task.jobs",
   "worktree.changes",
+  "task.conflicts",
   "ui-prefs",
 ]
 

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -120,11 +120,13 @@ function ConflictYarn({
       const next: Array<{ id: string; d: string; color: string; tip: string }> =
         []
       conflictPairs.forEach((pair, index) => {
+        // window.CSS, not the bare identifier — the dnd-kit `CSS` transform
+        // helper imported above shadows the global and has no .escape.
         const ea = container.querySelector(
-          `[data-task-id="${CSS.escape(pair.a)}"]`,
+          `[data-task-id="${window.CSS.escape(pair.a)}"]`,
         )
         const eb = container.querySelector(
-          `[data-task-id="${CSS.escape(pair.b)}"]`,
+          `[data-task-id="${window.CSS.escape(pair.b)}"]`,
         )
         if (!ea || !eb) return // a hidden endpoint (filter/cap/fold) = no yarn
         const ra = ea.getBoundingClientRect()
@@ -162,18 +164,27 @@ function ConflictYarn({
       className="pointer-events-none absolute inset-0 z-10 h-full w-full overflow-visible"
     >
       {lines.map((line) => (
-        <path
-          key={line.id}
-          d={line.d}
-          fill="none"
-          stroke={line.color}
-          strokeWidth={2}
-          strokeOpacity={0.65}
-          strokeLinecap="round"
-          style={{ pointerEvents: "stroke" }}
-        >
-          <title>{line.tip}</title>
-        </path>
+        <g key={line.id}>
+          <path
+            d={line.d}
+            fill="none"
+            stroke={line.color}
+            strokeWidth={2}
+            strokeOpacity={0.65}
+            strokeLinecap="round"
+          />
+          {/* Invisible fat twin — a 14px hit corridor so the tooltip
+              doesn't demand pixel-perfect aim at a 2px thread. */}
+          <path
+            d={line.d}
+            fill="none"
+            stroke="transparent"
+            strokeWidth={14}
+            style={{ pointerEvents: "stroke" }}
+          >
+            <title>{line.tip}</title>
+          </path>
+        </g>
       ))}
     </svg>
   )
@@ -188,6 +199,10 @@ const PRIMARY_COLUMNS = BOARD_COLUMNS.filter((spec) => spec.alwaysVisible)
  *  `title` takes a beat to appear, and one-glyph buttons need names. */
 const TIP_ABOVE =
   "after:pointer-events-none after:absolute after:right-0 after:bottom-full after:z-10 after:mb-1 after:hidden after:whitespace-nowrap after:border after:border-line after:bg-menu after:px-1.5 after:py-0.5 after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
+/** Conflict-badge variant: instant, multi-line (pre-line honors the \n-joined
+ *  pair list), wide enough for "CONFLICTS with <task>: file, file, …". */
+const TIP_BADGE =
+  "after:pointer-events-none after:absolute after:top-full after:right-0 after:z-20 after:mt-0.5 after:hidden after:w-max after:max-w-[320px] after:whitespace-pre-line after:border after:border-line after:bg-menu after:px-2 after:py-1 after:text-left after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
 const TIP_RIGHT =
   "after:pointer-events-none after:absolute after:left-full after:top-2 after:z-10 after:ml-1 after:hidden after:whitespace-nowrap after:border after:border-line after:bg-menu after:px-1.5 after:py-0.5 after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
 
@@ -274,10 +289,10 @@ function CardBody({
         </span>
         {badge && (
           <span
-            title={badge.tip}
-            className={`shrink-0 font-mono text-[10px] ${
+            data-tip={badge.tip}
+            className={`relative -my-1.5 shrink-0 cursor-help px-1.5 py-1.5 font-mono text-[10px] ${
               badge.level === "conflict" ? "text-kobe-red" : "text-kobe-yellow"
-            }`}
+            } ${TIP_BADGE}`}
           >
             ⚠{badge.count}
           </span>

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -44,6 +44,7 @@ import {
   X,
 } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { activityColor, activityLabel } from "../lib/activity.ts"
 import {
   applyBoardOverrides,
@@ -119,15 +120,19 @@ function ConflictYarn({
       const base = container.getBoundingClientRect()
       const next: Array<{ id: string; d: string; color: string; tip: string }> =
         []
+      // window.CSS, not the bare identifier — the dnd-kit `CSS` transform
+      // helper imported above shadows the global and has no .escape.
+      // A card being dragged is anchored at its DragOverlay clone (portaled
+      // to <body>, riding the pointer) so the yarn follows the drag live;
+      // viewport-rect math stays valid across the portal boundary.
+      const anchor = (id: string): Element | null =>
+        document.querySelector(
+          `[data-yarn-anchor="${window.CSS.escape(id)}"]`,
+        ) ??
+        container.querySelector(`[data-task-id="${window.CSS.escape(id)}"]`)
       conflictPairs.forEach((pair, index) => {
-        // window.CSS, not the bare identifier — the dnd-kit `CSS` transform
-        // helper imported above shadows the global and has no .escape.
-        const ea = container.querySelector(
-          `[data-task-id="${window.CSS.escape(pair.a)}"]`,
-        )
-        const eb = container.querySelector(
-          `[data-task-id="${window.CSS.escape(pair.b)}"]`,
-        )
+        const ea = anchor(pair.a)
+        const eb = anchor(pair.b)
         if (!ea || !eb) return // a hidden endpoint (filter/cap/fold) = no yarn
         const ra = ea.getBoundingClientRect()
         const rb = eb.getBoundingClientRect()
@@ -199,10 +204,6 @@ const PRIMARY_COLUMNS = BOARD_COLUMNS.filter((spec) => spec.alwaysVisible)
  *  `title` takes a beat to appear, and one-glyph buttons need names. */
 const TIP_ABOVE =
   "after:pointer-events-none after:absolute after:right-0 after:bottom-full after:z-10 after:mb-1 after:hidden after:whitespace-nowrap after:border after:border-line after:bg-menu after:px-1.5 after:py-0.5 after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
-/** Conflict-badge variant: instant, multi-line (pre-line honors the \n-joined
- *  pair list), wide enough for "CONFLICTS with <task>: file, file, …". */
-const TIP_BADGE =
-  "after:pointer-events-none after:absolute after:top-full after:right-0 after:z-20 after:mt-0.5 after:hidden after:w-max after:max-w-[320px] after:whitespace-pre-line after:border after:border-line after:bg-menu after:px-2 after:py-1 after:text-left after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
 const TIP_RIGHT =
   "after:pointer-events-none after:absolute after:left-full after:top-2 after:z-10 after:ml-1 after:hidden after:whitespace-nowrap after:border after:border-line after:bg-menu after:px-1.5 after:py-0.5 after:text-[10px] after:text-fg after:content-[attr(data-tip)] hover:after:block"
 
@@ -264,6 +265,65 @@ const boardKeyboardCoordinates: KeyboardCoordinateGetter = (
   return target ? { x: target.left, y: target.top } : undefined
 }
 
+/**
+ * ⚠N conflict badge with an instant tooltip PORTALED to <body> — the column
+ * lists are overflow-y scrollers, which forces overflow-x to clip too, so an
+ * absolutely-positioned tooltip inside the card gets cut at the column edge.
+ * Fixed positioning at body level escapes every scroll container; any scroll
+ * while open just dismisses it (the anchor rect went stale).
+ */
+function ConflictBadge({
+  badge,
+}: {
+  badge: { level: "overlap" | "conflict"; count: number; tip: string }
+}) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [pos, setPos] = useState<{ top: number; right: number } | null>(null)
+  useEffect(() => {
+    if (!pos) return
+    const close = (): void => setPos(null)
+    window.addEventListener("scroll", close, true)
+    return () => window.removeEventListener("scroll", close, true)
+  }, [pos])
+  const show = (): void => {
+    const rect = ref.current?.getBoundingClientRect()
+    if (rect)
+      setPos({
+        top: rect.bottom + 2,
+        right: Math.max(8, window.innerWidth - rect.right),
+      })
+  }
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: hover-only tooltip trigger inside the card's open button — not an action of its own.
+    <span
+      ref={ref}
+      onMouseEnter={show}
+      onMouseLeave={() => setPos(null)}
+      className={`-my-1.5 relative shrink-0 cursor-help px-1.5 py-1.5 font-mono text-[10px] ${
+        badge.level === "conflict" ? "text-kobe-red" : "text-kobe-yellow"
+      }`}
+    >
+      ⚠{badge.count}
+      {pos &&
+        createPortal(
+          <div
+            style={{
+              position: "fixed",
+              top: pos.top,
+              right: pos.right,
+              maxWidth: 380,
+              overflowWrap: "anywhere",
+            }}
+            className="pointer-events-none z-50 whitespace-pre-line border border-line bg-menu px-2 py-1 text-left font-mono text-[10px] text-fg"
+          >
+            {badge.tip}
+          </div>,
+          document.body,
+        )}
+    </span>
+  )
+}
+
 function CardBody({
   task,
   engine,
@@ -287,16 +347,7 @@ function CardBody({
         <span className="min-w-0 flex-1 truncate text-[13px] text-fg">
           {task.title || task.branch || task.id}
         </span>
-        {badge && (
-          <span
-            data-tip={badge.tip}
-            className={`relative -my-1.5 shrink-0 cursor-help px-1.5 py-1.5 font-mono text-[10px] ${
-              badge.level === "conflict" ? "text-kobe-red" : "text-kobe-yellow"
-            } ${TIP_BADGE}`}
-          >
-            ⚠{badge.count}
-          </span>
-        )}
+        {badge && <ConflictBadge badge={badge} />}
         <PrChip pr={task.prStatus} />
         {task.pinned && (
           <span className="shrink-0 text-[10px] text-subtle">PIN</span>
@@ -972,7 +1023,10 @@ export function Board() {
             </div>
             <DragOverlay>
               {dragTask ? (
-                <div className="flex w-72 flex-col gap-1.5 border border-line-active bg-inset p-3 pl-6 shadow-lg">
+                <div
+                  data-yarn-anchor={dragTask.id}
+                  className="flex w-72 flex-col gap-1.5 border border-line-active bg-inset p-3 pl-6 shadow-lg"
+                >
                   <CardBody
                     task={dragTask}
                     engine={engineStates[dragTask.id]}

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -52,9 +52,11 @@ import {
   boardCardCount,
   buildBoard,
   compareCards,
+  conflictBadge,
   isBoardTask,
   isDroppableColumn,
   planColumnDrop,
+  yarnColor,
 } from "../lib/board.ts"
 import {
   clearPositionOverride,
@@ -75,9 +77,117 @@ import { matchesTask } from "../lib/task-list.ts"
 import { sendPtyText } from "../lib/terminal.ts"
 import { relativeTime } from "../lib/time.ts"
 import { pushToast, reportError } from "../lib/toast.ts"
-import type { EngineState, Task } from "../lib/types.ts"
+import type { ConflictPair, EngineState, Task } from "../lib/types.ts"
 import { BoardPeek } from "./BoardPeek.tsx"
 import { ChangesChip, PrChip } from "./chips.tsx"
+
+/**
+ * Conflict yarn — one sagging colored thread per PROVEN conflict pair,
+ * strung between the two cards (the detective-board look). Lines live in
+ * an SVG overlay inside the horizontally-scrolling column wrapper, so they
+ * scroll with the columns; endpoints re-measure on resize, any inner
+ * scroll (capture — column lists scroll independently), and layout
+ * changes. The overlay never intercepts the pointer except on the thread
+ * itself (2px stroke), which exists only to carry the tooltip.
+ */
+function ConflictYarn({
+  pairs,
+  layoutKey,
+  titles,
+  containerRef,
+}: {
+  pairs: ConflictPair[]
+  /** Changes whenever card positions could have moved (membership/order). */
+  layoutKey: string
+  titles: ReadonlyMap<string, string>
+  containerRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const [lines, setLines] = useState<
+    Array<{ id: string; d: string; color: string; tip: string }>
+  >([])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: layoutKey is the deliberate re-measure trigger (card membership/order moved), not a read dependency.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    let raf = 0
+    const measure = (): void => {
+      raf = 0
+      const base = container.getBoundingClientRect()
+      const next: Array<{ id: string; d: string; color: string; tip: string }> =
+        []
+      pairs
+        .filter((pair) => pair.level === "conflict")
+        .forEach((pair, index) => {
+          const ea = container.querySelector(
+            `[data-task-id="${CSS.escape(pair.a)}"]`,
+          )
+          const eb = container.querySelector(
+            `[data-task-id="${CSS.escape(pair.b)}"]`,
+          )
+          if (!ea || !eb) return // a hidden endpoint (filter/cap/fold) = no yarn
+          const ra = ea.getBoundingClientRect()
+          const rb = eb.getBoundingClientRect()
+          const x1 = ra.left + ra.width / 2 - base.left
+          const y1 = ra.bottom - 4 - base.top
+          const x2 = rb.left + rb.width / 2 - base.left
+          const y2 = rb.bottom - 4 - base.top
+          // Quadratic droop — yarn, not a laser.
+          const sag = Math.min(120, Math.abs(x2 - x1) / 4 + 28)
+          const d = `M ${x1} ${y1} Q ${(x1 + x2) / 2} ${Math.max(y1, y2) + sag} ${x2} ${y2}`
+          const names = `${titles.get(pair.a) ?? pair.a} ⇄ ${titles.get(pair.b) ?? pair.b}`
+          const files = pair.files.slice(0, 6).join(", ")
+          next.push({
+            id: `${pair.a}|${pair.b}`,
+            d,
+            color: yarnColor(index),
+            tip: `${names}\nconflicts: ${files}${pair.files.length > 6 ? ", …" : ""}`,
+          })
+        })
+      setLines((prev) =>
+        JSON.stringify(prev) === JSON.stringify(next) ? prev : next,
+      )
+    }
+    const schedule = (): void => {
+      if (!raf) raf = requestAnimationFrame(measure)
+    }
+    schedule()
+    window.addEventListener("resize", schedule)
+    container.addEventListener("scroll", schedule, true)
+    const observer = new ResizeObserver(schedule)
+    observer.observe(container)
+    return () => {
+      window.removeEventListener("resize", schedule)
+      container.removeEventListener("scroll", schedule, true)
+      observer.disconnect()
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [pairs, layoutKey, titles, containerRef])
+
+  if (lines.length === 0) return null
+  return (
+    // biome-ignore lint/a11y/noSvgWithoutTitle: decorative overlay (aria-hidden); the per-path <title> elements carry the hover tooltips.
+    <svg
+      aria-hidden
+      className="pointer-events-none absolute inset-0 z-10 h-full w-full overflow-visible"
+    >
+      {lines.map((line) => (
+        <path
+          key={line.id}
+          d={line.d}
+          fill="none"
+          stroke={line.color}
+          strokeWidth={2}
+          strokeOpacity={0.65}
+          strokeLinecap="round"
+          style={{ pointerEvents: "stroke" }}
+        >
+          <title>{line.tip}</title>
+        </path>
+      ))}
+    </svg>
+  )
+}
 
 /** The hover bar's jump targets: the four always-visible lifecycle columns.
  *  error/canceled stay drag-only — they're fold-away exception states, not
@@ -153,10 +263,13 @@ function CardBody({
   task,
   engine,
   changes,
+  badge,
 }: {
   task: Task
   engine?: EngineState
   changes?: { added: number; deleted: number }
+  /** Conflict-radar summary: ⚠ overlap (yellow) / proven conflict (red). */
+  badge?: { level: "overlap" | "conflict"; count: number; tip: string }
 }) {
   const label = activityLabel(engine?.state)
   const updated = relativeTime(task.updatedAt || task.createdAt)
@@ -169,6 +282,16 @@ function CardBody({
         <span className="min-w-0 flex-1 truncate text-[13px] text-fg">
           {task.title || task.branch || task.id}
         </span>
+        {badge && (
+          <span
+            title={badge.tip}
+            className={`shrink-0 font-mono text-[10px] ${
+              badge.level === "conflict" ? "text-kobe-red" : "text-kobe-yellow"
+            }`}
+          >
+            ⚠{badge.count}
+          </span>
+        )}
         <PrChip pr={task.prStatus} />
         {task.pinned && (
           <span className="shrink-0 text-[10px] text-subtle">PIN</span>
@@ -194,6 +317,7 @@ function BoardCard({
   columnKey,
   engine,
   changes,
+  badge,
   canDrag,
   onMoveTo,
   onReview,
@@ -205,6 +329,7 @@ function BoardCard({
   columnKey: string
   engine?: EngineState
   changes?: { added: number; deleted: number }
+  badge?: { level: "overlap" | "conflict"; count: number; tip: string }
   canDrag: boolean
   onMoveTo: (statusKey: string) => void
   onReview?: () => void
@@ -257,7 +382,7 @@ function BoardCard({
         onClick={open}
         className="flex w-full cursor-pointer flex-col gap-1.5 border border-line bg-surface p-3 pl-6 text-left transition-colors hover:border-primary hover:bg-inset"
       >
-        <CardBody task={task} engine={engine} changes={changes} />
+        <CardBody task={task} engine={engine} changes={changes} badge={badge} />
       </button>
       {canDrag && (
         <button
@@ -336,6 +461,7 @@ function ColumnView({
   column,
   engineStates,
   worktreeChanges,
+  badges,
   canDrag,
   onMoveTo,
   onReview,
@@ -346,6 +472,10 @@ function ColumnView({
   column: BoardColumn
   engineStates: Record<string, EngineState>
   worktreeChanges: Record<string, { added: number; deleted: number }>
+  badges: ReadonlyMap<
+    string,
+    { level: "overlap" | "conflict"; count: number; tip: string }
+  >
   canDrag: boolean
   onMoveTo: (task: Task, statusKey: string) => void
   onReview: (task: Task) => void
@@ -394,6 +524,7 @@ function ColumnView({
                 columnKey={column.key}
                 engine={engineStates[task.id]}
                 changes={worktreeChanges[task.worktreePath]}
+                badge={badges.get(task.id)}
                 canDrag={canDrag}
                 onMoveTo={(statusKey) => onMoveTo(task, statusKey)}
                 // Review only makes sense where work awaits a verdict.
@@ -430,12 +561,14 @@ export function Board() {
     tasks,
     engineStates,
     worktreeChanges,
+    conflicts,
     hydrated,
     daemonConnected,
     streamConnected,
   } = useAppState()
   const { query, overrides } = useBoardState()
   const navigate = useNavigate()
+  const yarnContainerRef = useRef<HTMLDivElement>(null)
   const filterRef = useRef<HTMLInputElement>(null)
   const [dragTaskId, setDragTaskId] = useState<string | null>(null)
   const [peekTaskId, setPeekTaskId] = useState<string | null>(null)
@@ -507,6 +640,46 @@ export function Board() {
   const dragTask = dragTaskId
     ? boardTasks.find((t) => t.id === dragTaskId)
     : undefined
+
+  // Conflict radar: per-card badge summaries + display titles for the yarn
+  // tooltips, plus a layout fingerprint that re-measures the yarn whenever
+  // card membership/order shifts.
+  const taskTitles = useMemo(
+    () =>
+      new Map(tasks.map((t) => [t.id, t.title || t.branch || t.id] as const)),
+    [tasks],
+  )
+  const conflictBadges = useMemo(() => {
+    const badges = new Map<
+      string,
+      { level: "overlap" | "conflict"; count: number; tip: string }
+    >()
+    const ids = new Set(conflicts.flatMap((pair) => [pair.a, pair.b]))
+    for (const id of ids) {
+      const summary = conflictBadge(conflicts, id)
+      if (!summary) continue
+      const tip = conflicts
+        .filter((pair) => pair.a === id || pair.b === id)
+        .map((pair) => {
+          const other = pair.a === id ? pair.b : pair.a
+          const verb = pair.level === "conflict" ? "CONFLICTS with" : "overlaps"
+          return `${verb} ${taskTitles.get(other) ?? other}: ${pair.files.slice(0, 4).join(", ")}${pair.files.length > 4 ? ", …" : ""}`
+        })
+        .join("\n")
+      badges.set(id, { ...summary, tip })
+    }
+    return badges
+  }, [conflicts, taskTitles])
+  const yarnLayoutKey = useMemo(
+    () =>
+      columns
+        .map(
+          (column) =>
+            `${column.key}:${column.tasks.map((t) => t.id).join(",")}`,
+        )
+        .join("|"),
+    [columns],
+  )
 
   const open = (id: string): void => {
     selectTask(id)
@@ -778,13 +951,17 @@ export function Board() {
             onDragEnd={onDragEnd}
             onDragCancel={() => setDragTaskId(null)}
           >
-            <div className="flex h-full min-w-max gap-4">
+            <div
+              ref={yarnContainerRef}
+              className="relative flex h-full min-w-max gap-4"
+            >
               {columns.map((column) => (
                 <ColumnView
                   key={column.key}
                   column={column}
                   engineStates={engineStates}
                   worktreeChanges={worktreeChanges}
+                  badges={conflictBadges}
                   canDrag={canDrag}
                   onMoveTo={moveToStatus}
                   onReview={sendReview}
@@ -793,6 +970,12 @@ export function Board() {
                   onPeek={setPeekTaskId}
                 />
               ))}
+              <ConflictYarn
+                pairs={conflicts}
+                layoutKey={yarnLayoutKey}
+                titles={taskTitles}
+                containerRef={yarnContainerRef}
+              />
             </div>
             <DragOverlay>
               {dragTask ? (

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -85,20 +85,21 @@ import { ChangesChip, PrChip } from "./chips.tsx"
  * Conflict yarn — one sagging colored thread per PROVEN conflict pair,
  * strung between the two cards (the detective-board look). Lines live in
  * an SVG overlay inside the horizontally-scrolling column wrapper, so they
- * scroll with the columns; endpoints re-measure on resize, any inner
- * scroll (capture — column lists scroll independently), and layout
- * changes. The overlay never intercepts the pointer except on the thread
- * itself (2px stroke), which exists only to carry the tooltip.
+ * scroll with the columns. Endpoints are ANCHORED by a per-frame rAF loop
+ * (alive only while proven pairs exist): re-measuring every frame is the
+ * one approach that tracks dnd-kit's mid-drag transforms, the post-drop
+ * settle transition, and inner column scrolls without enumerating event
+ * sources. Cost is a couple of rect reads per pair per frame, the state
+ * update is equality-guarded, and rAF pauses in background tabs. The
+ * overlay never intercepts the pointer except on the thread itself
+ * (2px stroke), which exists only to carry the tooltip.
  */
 function ConflictYarn({
   pairs,
-  layoutKey,
   titles,
   containerRef,
 }: {
   pairs: ConflictPair[]
-  /** Changes whenever card positions could have moved (membership/order). */
-  layoutKey: string
   titles: ReadonlyMap<string, string>
   containerRef: React.RefObject<HTMLDivElement | null>
 }) {
@@ -106,63 +107,52 @@ function ConflictYarn({
     Array<{ id: string; d: string; color: string; tip: string }>
   >([])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: layoutKey is the deliberate re-measure trigger (card membership/order moved), not a read dependency.
   useEffect(() => {
     const container = containerRef.current
-    if (!container) return
+    const conflictPairs = pairs.filter((pair) => pair.level === "conflict")
+    if (!container || conflictPairs.length === 0) {
+      setLines((prev) => (prev.length === 0 ? prev : []))
+      return
+    }
     let raf = 0
     const measure = (): void => {
-      raf = 0
       const base = container.getBoundingClientRect()
       const next: Array<{ id: string; d: string; color: string; tip: string }> =
         []
-      pairs
-        .filter((pair) => pair.level === "conflict")
-        .forEach((pair, index) => {
-          const ea = container.querySelector(
-            `[data-task-id="${CSS.escape(pair.a)}"]`,
-          )
-          const eb = container.querySelector(
-            `[data-task-id="${CSS.escape(pair.b)}"]`,
-          )
-          if (!ea || !eb) return // a hidden endpoint (filter/cap/fold) = no yarn
-          const ra = ea.getBoundingClientRect()
-          const rb = eb.getBoundingClientRect()
-          const x1 = ra.left + ra.width / 2 - base.left
-          const y1 = ra.bottom - 4 - base.top
-          const x2 = rb.left + rb.width / 2 - base.left
-          const y2 = rb.bottom - 4 - base.top
-          // Quadratic droop — yarn, not a laser.
-          const sag = Math.min(120, Math.abs(x2 - x1) / 4 + 28)
-          const d = `M ${x1} ${y1} Q ${(x1 + x2) / 2} ${Math.max(y1, y2) + sag} ${x2} ${y2}`
-          const names = `${titles.get(pair.a) ?? pair.a} ⇄ ${titles.get(pair.b) ?? pair.b}`
-          const files = pair.files.slice(0, 6).join(", ")
-          next.push({
-            id: `${pair.a}|${pair.b}`,
-            d,
-            color: yarnColor(index),
-            tip: `${names}\nconflicts: ${files}${pair.files.length > 6 ? ", …" : ""}`,
-          })
+      conflictPairs.forEach((pair, index) => {
+        const ea = container.querySelector(
+          `[data-task-id="${CSS.escape(pair.a)}"]`,
+        )
+        const eb = container.querySelector(
+          `[data-task-id="${CSS.escape(pair.b)}"]`,
+        )
+        if (!ea || !eb) return // a hidden endpoint (filter/cap/fold) = no yarn
+        const ra = ea.getBoundingClientRect()
+        const rb = eb.getBoundingClientRect()
+        const x1 = ra.left + ra.width / 2 - base.left
+        const y1 = ra.bottom - 4 - base.top
+        const x2 = rb.left + rb.width / 2 - base.left
+        const y2 = rb.bottom - 4 - base.top
+        // Quadratic droop — yarn, not a laser.
+        const sag = Math.min(120, Math.abs(x2 - x1) / 4 + 28)
+        const d = `M ${x1} ${y1} Q ${(x1 + x2) / 2} ${Math.max(y1, y2) + sag} ${x2} ${y2}`
+        const names = `${titles.get(pair.a) ?? pair.a} ⇄ ${titles.get(pair.b) ?? pair.b}`
+        const files = pair.files.slice(0, 6).join(", ")
+        next.push({
+          id: `${pair.a}|${pair.b}`,
+          d,
+          color: yarnColor(index),
+          tip: `${names}\nconflicts: ${files}${pair.files.length > 6 ? ", …" : ""}`,
         })
+      })
       setLines((prev) =>
         JSON.stringify(prev) === JSON.stringify(next) ? prev : next,
       )
+      raf = requestAnimationFrame(measure)
     }
-    const schedule = (): void => {
-      if (!raf) raf = requestAnimationFrame(measure)
-    }
-    schedule()
-    window.addEventListener("resize", schedule)
-    container.addEventListener("scroll", schedule, true)
-    const observer = new ResizeObserver(schedule)
-    observer.observe(container)
-    return () => {
-      window.removeEventListener("resize", schedule)
-      container.removeEventListener("scroll", schedule, true)
-      observer.disconnect()
-      if (raf) cancelAnimationFrame(raf)
-    }
-  }, [pairs, layoutKey, titles, containerRef])
+    raf = requestAnimationFrame(measure)
+    return () => cancelAnimationFrame(raf)
+  }, [pairs, titles, containerRef])
 
   if (lines.length === 0) return null
   return (
@@ -670,17 +660,6 @@ export function Board() {
     }
     return badges
   }, [conflicts, taskTitles])
-  const yarnLayoutKey = useMemo(
-    () =>
-      columns
-        .map(
-          (column) =>
-            `${column.key}:${column.tasks.map((t) => t.id).join(",")}`,
-        )
-        .join("|"),
-    [columns],
-  )
-
   const open = (id: string): void => {
     selectTask(id)
     void rpc("task.setActive", { taskId: id }).catch(() => {})
@@ -972,7 +951,6 @@ export function Board() {
               ))}
               <ConflictYarn
                 pairs={conflicts}
-                layoutKey={yarnLayoutKey}
                 titles={taskTitles}
                 containerRef={yarnContainerRef}
               />

--- a/packages/kobe-web/src/lib/board.ts
+++ b/packages/kobe-web/src/lib/board.ts
@@ -10,7 +10,7 @@
  * precedent).
  */
 
-import type { Task } from "./types.ts"
+import type { ConflictPair, Task } from "./types.ts"
 
 export interface BoardColumnSpec {
   key: string
@@ -338,4 +338,45 @@ export function reconcileOverrides(
  *  column renders cards but is not a drag target. */
 export function isDroppableColumn(key: string): boolean {
   return BOARD_COLUMNS.some((spec) => spec.key === key)
+}
+
+/* ----- conflict radar (docs/design/conflict-radar.md) -------------------- */
+
+/** The radar pairs touching one task. */
+export function conflictsForTask(
+  pairs: readonly ConflictPair[],
+  taskId: string,
+): ConflictPair[] {
+  return pairs.filter((pair) => pair.a === taskId || pair.b === taskId)
+}
+
+/** Card badge summary: the strongest level + how many counterparts. */
+export function conflictBadge(
+  pairs: readonly ConflictPair[],
+  taskId: string,
+): { level: "overlap" | "conflict"; count: number } | null {
+  const mine = conflictsForTask(pairs, taskId)
+  if (mine.length === 0) return null
+  return {
+    level: mine.some((pair) => pair.level === "conflict")
+      ? "conflict"
+      : "overlap",
+    count: mine.length,
+  }
+}
+
+/** Yarn palette — one distinct kobe hue per conflict pair, cycling. The
+ *  pair's index in the (sorted, stable) pair list picks the color, so a
+ *  pair keeps its yarn color as long as the pair exists. */
+export const YARN_COLORS: readonly string[] = [
+  "var(--color-kobe-orange)",
+  "var(--color-kobe-blue)",
+  "var(--color-kobe-violet)",
+  "var(--color-kobe-yellow)",
+  "var(--color-kobe-green)",
+  "var(--color-kobe-red)",
+]
+
+export function yarnColor(index: number): string {
+  return YARN_COLORS[index % YARN_COLORS.length] as string
 }

--- a/packages/kobe-web/src/lib/store.ts
+++ b/packages/kobe-web/src/lib/store.ts
@@ -12,6 +12,7 @@ import { applyThemeFromPrefs } from "./theme.ts"
 import type {
   BridgeEvent,
   BridgeSnapshot,
+  ConflictPair,
   EngineState,
   Task,
   TaskJob,
@@ -29,6 +30,8 @@ export interface AppState {
   jobs: Record<string, TaskJob>
   /** worktreePath → uncommitted +added/−deleted counts. */
   worktreeChanges: WorktreeChangeCounts
+  /** Conflict-radar pairs (daemon-collected; board yarn + badges). */
+  conflicts: ConflictPair[]
   /** Persisted visual prefs shared with the TUI (theme, sort mode). */
   uiPrefs: UiPrefs | null
   /** True once the first snapshot has hydrated the store. */
@@ -46,6 +49,7 @@ const initial: AppState = {
   update: null,
   jobs: {},
   worktreeChanges: {},
+  conflicts: [],
   uiPrefs: null,
   hydrated: false,
   daemonConnected: false,
@@ -149,6 +153,9 @@ function applyEvent(event: BridgeEvent): void {
     case "worktree.changes":
       set({ worktreeChanges: event.payload.changes })
       break
+    case "task.conflicts":
+      set({ conflicts: event.payload.pairs })
+      break
     case "ui-prefs":
       set({ uiPrefs: event.payload })
       applyThemeFromPrefs(event.payload.theme)
@@ -171,6 +178,7 @@ function ensureStream(): void {
       update: snap.update,
       jobs: snap.jobs ?? {},
       worktreeChanges: snap.worktreeChanges ?? {},
+      conflicts: snap.conflicts ?? [],
       uiPrefs: snap.uiPrefs ?? null,
       hydrated: true,
       daemonConnected: snap.connected,

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -80,6 +80,15 @@ export type WorktreeChangeCounts = Record<
   { added: number; deleted: number }
 >
 
+/** One conflict-radar pair (`a` < `b`, sorted task ids): the overlapping
+ *  files and the strongest proven signal level. */
+export interface ConflictPair {
+  a: string
+  b: string
+  files: string[]
+  level: "overlap" | "conflict"
+}
+
 /** The user's persisted visual prefs, fanned out by the daemon's
  *  state.json watcher (mirror of the `ui-prefs` channel payload). */
 export interface UiPrefs {
@@ -98,6 +107,7 @@ export type BridgeEvent =
   | { channel: "update"; payload: { info: UpdateInfo | null } }
   | { channel: "task.jobs"; payload: TaskJob }
   | { channel: "worktree.changes"; payload: { changes: WorktreeChangeCounts } }
+  | { channel: "task.conflicts"; payload: { pairs: ConflictPair[] } }
   | { channel: "ui-prefs"; payload: UiPrefs }
 
 /** Full bootstrap state the bridge sends on connect. */
@@ -109,6 +119,8 @@ export interface BridgeSnapshot {
   /** taskId → in-flight job (running only; bridge drops terminal phases). */
   jobs?: Record<string, TaskJob>
   worktreeChanges?: WorktreeChangeCounts
+  /** Conflict-radar pairs (file overlap / proven merge conflict). */
+  conflicts?: ConflictPair[]
   uiPrefs?: UiPrefs | null
   connected: boolean
 }

--- a/packages/kobe-web/test/board.test.ts
+++ b/packages/kobe-web/test/board.test.ts
@@ -5,6 +5,8 @@ import {
   boardCardCount,
   buildBoard,
   compareCards,
+  conflictBadge,
+  conflictsForTask,
   effectivePosition,
   isBoardTask,
   isDroppableColumn,
@@ -14,6 +16,8 @@ import {
   reconcileOverrides,
   renormalizedMoves,
   TERMINAL_COLUMN_CAP,
+  YARN_COLORS,
+  yarnColor,
 } from "../src/lib/board.ts"
 import {
   clearPositionOverride,
@@ -296,6 +300,31 @@ describe("buildBoard — terminal-column cap", () => {
     expect(doneCol?.hiddenCount).toBe(5)
     expect(activeCol?.tasks).toHaveLength(TERMINAL_COLUMN_CAP + 5)
     expect(activeCol?.hiddenCount).toBe(0)
+  })
+})
+
+describe("conflict radar helpers", () => {
+  const pairs = [
+    { a: "a", b: "b", files: ["src/x.ts"], level: "conflict" as const },
+    { a: "a", b: "c", files: ["src/y.ts"], level: "overlap" as const },
+  ]
+
+  it("conflictsForTask returns pairs touching the task", () => {
+    expect(conflictsForTask(pairs, "a")).toHaveLength(2)
+    expect(conflictsForTask(pairs, "b")).toHaveLength(1)
+    expect(conflictsForTask(pairs, "zzz")).toHaveLength(0)
+  })
+
+  it("conflictBadge takes the strongest level and counts counterparts", () => {
+    expect(conflictBadge(pairs, "a")).toEqual({ level: "conflict", count: 2 })
+    expect(conflictBadge(pairs, "c")).toEqual({ level: "overlap", count: 1 })
+    expect(conflictBadge(pairs, "zzz")).toBeNull()
+  })
+
+  it("yarnColor is stable per index and cycles the palette", () => {
+    expect(yarnColor(0)).toBe(YARN_COLORS[0])
+    expect(yarnColor(YARN_COLORS.length)).toBe(YARN_COLORS[0])
+    expect(yarnColor(1)).not.toBe(yarnColor(2))
   })
 })
 

--- a/packages/kobe-web/test/spa-channels.test.ts
+++ b/packages/kobe-web/test/spa-channels.test.ts
@@ -19,6 +19,7 @@ const SPA_CONSUMED = [
   "update",
   "task.jobs",
   "worktree.changes",
+  "task.conflicts",
   "ui-prefs",
 ] as const
 

--- a/packages/kobe/test/daemon/conflict-collector.test.ts
+++ b/packages/kobe/test/daemon/conflict-collector.test.ts
@@ -1,0 +1,201 @@
+import {
+  type CardFootprint,
+  ConflictCollector,
+  GitGate,
+  overlapPairs,
+  parseMergeTreeNames,
+  parsePorcelainPaths,
+  sameFootprint,
+  trackedConflictTasks,
+} from "@sma1lboy/kobe-daemon/daemon/conflict-collector"
+import type { ConflictPair } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { describe, expect, it } from "vitest"
+import type { Task } from "../../src/types/task.ts"
+
+/**
+ * Conflict radar (docs/design/conflict-radar.md). Load-bearing rules: the
+ * O(N²) part is pure in-memory intersection (no git); merge-tree probes run
+ * only for L1-hit pairs and are cached by head pair; everything publishes
+ * on change only; a pruned task drops its pairs.
+ */
+
+const task = (over: Partial<Omit<Task, "id">> & { id?: string }): Task =>
+  ({
+    id: "t",
+    title: "demo",
+    repo: "/repo",
+    branch: "kobe/demo",
+    worktreePath: "/repo/.kobe/worktrees/demo",
+    kind: "task",
+    status: "in_progress",
+    archived: false,
+    createdAt: "2026-06-01T00:00:00Z",
+    updatedAt: "2026-06-01T00:00:00Z",
+    ...over,
+  }) as Task
+
+const fp = (repo: string, head: string, files: string[]): CardFootprint => ({
+  repo,
+  head,
+  files: new Set(files),
+})
+
+describe("pure helpers", () => {
+  it("parsePorcelainPaths takes both sides of a rename", () => {
+    const out = ' M src/a.ts\nR  src/old.ts -> src/new.ts\n?? "x"\n'
+    expect(parsePorcelainPaths(out)).toEqual(["src/a.ts", "src/old.ts", "src/new.ts", '"x"'])
+  })
+
+  it("overlapPairs intersects same-repo cards only, sorted ids, sorted files", () => {
+    const cards = new Map<string, CardFootprint>([
+      ["b", fp("/r1", "h2", ["src/x.ts", "src/y.ts"])],
+      ["a", fp("/r1", "h1", ["src/y.ts", "src/z.ts"])],
+      ["c", fp("/r2", "h3", ["src/y.ts"])], // other repo — never pairs
+      ["d", fp("/r1", "h4", ["docs/readme.md"])], // no intersection
+    ])
+    expect(overlapPairs(cards)).toEqual([{ a: "a", b: "b", files: ["src/y.ts"], level: "overlap" }])
+  })
+
+  it("parseMergeTreeNames reads names between the OID line and the blank", () => {
+    expect(parseMergeTreeNames("abc123\nsrc/a.ts\nsrc/b.ts\n\nAuto-merging src/a.ts\n")).toEqual([
+      "src/a.ts",
+      "src/b.ts",
+    ])
+    expect(parseMergeTreeNames("abc123\n")).toEqual([])
+  })
+
+  it("sameFootprint compares head + file membership", () => {
+    expect(sameFootprint(fp("/r", "h", ["a"]), fp("/r", "h", ["a"]))).toBe(true)
+    expect(sameFootprint(fp("/r", "h", ["a"]), fp("/r", "h", ["b"]))).toBe(false)
+    expect(sameFootprint(fp("/r", "h1", ["a"]), fp("/r", "h2", ["a"]))).toBe(false)
+  })
+
+  it("trackedConflictTasks excludes main/archived/remote/worktree-less", () => {
+    const tasks = [
+      task({ id: "ok" }),
+      task({ id: "main", kind: "main" }),
+      task({ id: "arch", archived: true }),
+      task({ id: "remote", repo: "ssh://host/repo" }),
+      task({ id: "nowt", worktreePath: "" }),
+    ]
+    expect(trackedConflictTasks(tasks).map((t) => t.id)).toEqual(["ok"])
+  })
+
+  it("GitGate caps concurrency FIFO", async () => {
+    const gate = new GitGate(1)
+    const order: number[] = []
+    await Promise.all([
+      gate.run(async () => {
+        order.push(1)
+        await new Promise((r) => setTimeout(r, 10))
+        order.push(2)
+      }),
+      gate.run(async () => {
+        order.push(3)
+      }),
+    ])
+    expect(order).toEqual([1, 2, 3])
+  })
+})
+
+function fakeBus(): { published: ConflictPair[][]; bus: { publish: (ch: string, p: unknown) => void } } {
+  const published: ConflictPair[][] = []
+  return {
+    published,
+    bus: {
+      publish: (channel: string, payload: unknown) => {
+        if (channel === "task.conflicts") published.push((payload as { pairs: ConflictPair[] }).pairs)
+      },
+    },
+  }
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 0))
+
+describe("ConflictCollector", () => {
+  const tasks = [task({ id: "a", worktreePath: "/r/wa" }), task({ id: "b", worktreePath: "/r/wb" })]
+  const footprints: Record<string, CardFootprint> = {
+    a: fp("/repo", "ha", ["src/auth.ts", "src/db.ts"]),
+    b: fp("/repo", "hb", ["src/auth.ts"]),
+  }
+
+  function make(opts: {
+    probe?: (wt: string, a: string, b: string) => Promise<{ conflict: boolean; files: string[] } | null>
+    list?: Task[]
+  }) {
+    const { published, bus } = fakeBus()
+    const probes: string[] = []
+    const collector = new ConflictCollector({ listTasks: () => opts.list ?? tasks }, bus as never, {
+      cadence: { timeoutMs: 1_000, slowRetryMs: 1_000, minIntervalMs: 0 },
+      footprint: async (t) => footprints[t.id as string] as CardFootprint,
+      probeMerge:
+        opts.probe ??
+        (async (_wt, h1, h2) => {
+          probes.push(`${h1}|${h2}`)
+          return { conflict: true, files: ["src/auth.ts"] }
+        }),
+    })
+    return { collector, published, probes }
+  }
+
+  it("publishes overlap, then upgrades to conflict when the probe lands", async () => {
+    const { collector, published } = make({})
+    collector.tick()
+    await settle()
+    await settle()
+    const last = published[published.length - 1]
+    expect(last).toEqual([{ a: "a", b: "b", files: ["src/auth.ts"], level: "conflict" }])
+    // The first publish (before the probe resolved) was the L1 overlap.
+    expect(published[0]?.[0]?.level).toBe("overlap")
+  })
+
+  it("caches the merge probe by head pair — a re-tick with unchanged heads never re-probes", async () => {
+    const { collector, probes } = make({})
+    collector.tick()
+    await settle()
+    await settle()
+    const count = probes.length
+    expect(count).toBe(1)
+    collector.tick()
+    await settle()
+    await settle()
+    expect(probes.length).toBe(count)
+  })
+
+  it("a clean dry-run keeps the pair at overlap", async () => {
+    const { collector, published } = make({
+      probe: async () => ({ conflict: false, files: [] }),
+    })
+    collector.tick()
+    await settle()
+    await settle()
+    const last = published[published.length - 1]
+    expect(last?.[0]?.level).toBe("overlap")
+  })
+
+  it("an unsupported merge-tree (null) degrades to L1 without erroring", async () => {
+    const { collector, published } = make({ probe: async () => null })
+    collector.tick()
+    await settle()
+    await settle()
+    expect(published[published.length - 1]?.[0]?.level).toBe("overlap")
+  })
+
+  it("pruning a task drops its pairs and republishes", async () => {
+    const { published, bus } = fakeBus()
+    let list = tasks
+    const collector = new ConflictCollector({ listTasks: () => list }, bus as never, {
+      cadence: { timeoutMs: 1_000, slowRetryMs: 1_000, minIntervalMs: 0 },
+      footprint: async (t) => footprints[t.id as string] as CardFootprint,
+      probeMerge: async () => ({ conflict: true, files: ["src/auth.ts"] }),
+    })
+    collector.tick()
+    await settle()
+    await settle()
+    expect(published.length).toBeGreaterThan(0)
+    list = [tasks[0] as Task]
+    collector.tick()
+    await settle()
+    expect(published[published.length - 1]).toEqual([])
+  })
+})


### PR DESCRIPTION
Stacked on #109 (`feat/board-review-action`). Implements the conflict radar designed in `docs/design/conflict-radar.md`.

## What

- **Daemon `ConflictCollector`** (`packages/kobe-daemon/src/daemon/conflict-collector.ts`) — two-tier signal over in-flight worktree tasks per repo:
  - **L1 `overlap`**: one cheap footprint per card (HEAD sha + porcelain dirty paths + `git diff --name-only <base>...HEAD`); the O(N²) pairwise part is pure in-memory set intersection — zero git.
  - **L2 `conflict`**: for L1 pairs only, a `git merge-tree --write-tree --name-only` **dry-run** of the two heads (never touches a worktree), cached by sorted head pair so it reruns only when someone commits. git < 2.38 is detected once and degrades to L1-only.
- **New `task.conflicts` channel** (protocol → bridge mirror/snapshot → SPA store), publish-on-change only.
- **Board yarn overlay** — one colored sagging SVG curve per *true* conflict pair, endpoints re-measured via rAF on resize/scroll/layout changes; hover tooltip names both tasks and the clashing files. Cards in any pair get a ⚠ badge (red = conflict, yellow = overlap) with a tooltip.

## Non-blocking git discipline (the volume concern)

These probes run beside the agents' own git activity, often in bulk, so:

- every call is an async `spawnCapture` — the daemon event loop never blocks;
- `GIT_OPTIONAL_LOCKS=0` on every read — the radar never takes `.git/index.lock` from under an engine's commit;
- a global FIFO `GitGate` caps concurrent git children at 3 across all cards + probes — a 30-card board queues, never stampedes;
- per-card scheduling rides `@/lib/poll-scheduling` (in-flight dedupe, timeout + SIGKILL, hard backoff, adaptive cadence) — the same guards that fixed the 30GB-repo freeze;
- consumer gate: the whole pass is skipped while no GUI is subscribed;
- merge probes are cached by head pair; footprints republish on change only.

## Tests

- `packages/kobe/test/daemon/conflict-collector.test.ts` — pure helpers (porcelain parse incl. renames, overlap pairing, merge-tree output parse, footprint equality, task filtering, gate FIFO) + collector behavior (overlap→conflict upgrade, probe cache by head pair, clean dry-run stays overlap, unsupported merge-tree degrades, pruned task drops pairs).
- `packages/kobe-web/test/board.test.ts` — badge/color helpers; `spa-channels.test.ts` pins the new channel into the consumed partition.
- Full battery green: kobe typecheck + 881 fast + 156 socket; kobe-web 370 tests + biome + build; root lint.