### PR TITLE
feat(web): board project chips — filter the kanban by repo

### DIFF
--- a/.changeset/proud-chips-partition.md
+++ b/.changeset/proud-chips-partition.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+**The board splits by project** — when tasks from 2+ repos share the board, a chip row appears in the header (one chip per project, labeled by path basename with `parent/basename` disambiguation on collisions, plus a card count); clicking a chip filters every column to that project, clicking it again (or `all`) clears the filter. The chip filter composes with the `/` text filter, survives route changes like the text filter does, and snaps back to `all` if the selected project's last card disappears. Single-project boards are unchanged — the row only renders when there is something to partition.

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -57,6 +57,7 @@ import {
   isBoardTask,
   isDroppableColumn,
   planColumnDrop,
+  repoOptions,
   yarnColor,
 } from "../lib/board.ts"
 import {
@@ -65,6 +66,7 @@ import {
   clearStatusOverride,
   reconcileBoardOverrides,
   setBoardQuery,
+  setBoardRepo,
   setPositionOverride,
   setPositionOverrides,
   setStatusOverride,
@@ -622,7 +624,7 @@ export function Board() {
     daemonConnected,
     streamConnected,
   } = useAppState()
-  const { query, overrides } = useBoardState()
+  const { query, repo: repoFilter, overrides } = useBoardState()
   const navigate = useNavigate()
   const yarnContainerRef = useRef<HTMLDivElement>(null)
   const filterRef = useRef<HTMLInputElement>(null)
@@ -684,12 +686,25 @@ export function Board() {
     return () => window.removeEventListener("keydown", onKey)
   }, [query, peekTaskId])
 
+  // Project chips: the distinct repos with board cards. Computed from the
+  // UNfiltered list so chips (and their counts) don't vanish while one is
+  // selected or a text query narrows the view.
+  const repos = useMemo(() => repoOptions(tasks), [tasks])
+  // A selected project can disappear entirely (last card archived/deleted)
+  // — snap back to All rather than showing a permanently empty board.
+  useEffect(() => {
+    if (repoFilter && !repos.some((option) => option.repo === repoFilter)) {
+      setBoardRepo(null)
+    }
+  }, [repos, repoFilter])
+
   const boardTasks = useMemo(
     () =>
-      applyBoardOverrides(tasks, overrides).filter((task) =>
-        matchesTask(task, query),
+      applyBoardOverrides(tasks, overrides).filter(
+        (task) =>
+          (!repoFilter || task.repo === repoFilter) && matchesTask(task, query),
       ),
-    [tasks, overrides, query],
+    [tasks, overrides, query, repoFilter],
   )
   const columns = useMemo(() => buildBoard(boardTasks), [boardTasks])
   const shownCount = boardCardCount(columns)
@@ -971,6 +986,49 @@ export function Board() {
             </button>
           )}
         </label>
+        {/* Project chips: partition the board by repo. Hidden for a
+            single-project board — no point paying header space for a
+            filter with one value. Click the active chip to deselect. */}
+        {repos.length >= 2 && (
+          <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto">
+            <button
+              type="button"
+              onClick={() => setBoardRepo(null)}
+              className={`shrink-0 border px-1.5 py-0.5 font-mono text-[10px] transition-colors ${
+                repoFilter === null
+                  ? "border-line-active bg-inset text-fg"
+                  : "border-line text-subtle hover:text-fg"
+              }`}
+            >
+              all
+            </button>
+            {repos.map((option) => (
+              <button
+                key={option.repo}
+                type="button"
+                title={option.repo}
+                onClick={() =>
+                  setBoardRepo(repoFilter === option.repo ? null : option.repo)
+                }
+                className={`shrink-0 border px-1.5 py-0.5 font-mono text-[10px] transition-colors ${
+                  repoFilter === option.repo
+                    ? "border-line-active bg-inset text-fg"
+                    : "border-line text-subtle hover:text-fg"
+                }`}
+              >
+                {option.label}
+                <span
+                  className={
+                    repoFilter === option.repo ? "text-muted" : "text-subtle"
+                  }
+                >
+                  {" "}
+                  {option.count}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
         <div className="ml-auto flex items-center gap-3 font-mono text-[11px] text-subtle">
           {!canDrag && hydrated && (
             <span className="text-kobe-yellow">read-only (offline)</span>

--- a/packages/kobe-web/src/lib/board-state.ts
+++ b/packages/kobe-web/src/lib/board-state.ts
@@ -15,11 +15,13 @@ import type { Task } from "./types.ts"
 interface BoardState {
   /** Free-text card filter (matchesTask semantics). */
   query: string
+  /** Project chip filter: a repo key, or null = all projects. */
+  repo: string | null
   /** Pending optimistic drops: taskId → expected fields (board.ts R4). */
   overrides: BoardOverrides
 }
 
-let state: BoardState = { query: "", overrides: {} }
+let state: BoardState = { query: "", repo: null, overrides: {} }
 const listeners = new Set<() => void>()
 
 function set(next: Partial<BoardState>): void {
@@ -49,6 +51,11 @@ export function useBoardState(): BoardState {
 
 export function setBoardQuery(query: string): void {
   if (query !== state.query) set({ query })
+}
+
+/** Select a project chip (null = all). Composes with the text query. */
+export function setBoardRepo(repo: string | null): void {
+  if (repo !== state.repo) set({ repo })
 }
 
 /** Record an optimistic status drop — the card paints into its target
@@ -140,5 +147,5 @@ export function reconcileBoardOverrides(tasks: Task[]): void {
 
 /** Test-only reset so cases don't leak filter state into each other. */
 export function resetBoardStateForTest(): void {
-  state = { query: "", overrides: {} }
+  state = { query: "", repo: null, overrides: {} }
 }

--- a/packages/kobe-web/src/lib/board.ts
+++ b/packages/kobe-web/src/lib/board.ts
@@ -340,6 +340,47 @@ export function isDroppableColumn(key: string): boolean {
   return BOARD_COLUMNS.some((spec) => spec.key === key)
 }
 
+/* ----- project (repo) filter --------------------------------------------- */
+
+export interface RepoOption {
+  /** Full repo key (local path or remote key) — the filter value. */
+  readonly repo: string
+  /** Short display name: path basename, parent/basename on collision. */
+  readonly label: string
+  /** Board cards (non-archived, non-main) currently in this repo. */
+  readonly count: number
+}
+
+function repoBasename(repo: string): string {
+  const trimmed = repo.replace(/\/+$/, "")
+  return trimmed.split("/").pop() || trimmed
+}
+
+/**
+ * Distinct projects among the board's cards, for the filter-chip row.
+ * Labels are path basenames; two repos sharing a basename are
+ * disambiguated to `parent/basename`. Sorted by label so chips don't
+ * reorder as card counts shift.
+ */
+export function repoOptions(tasks: readonly Task[]): RepoOption[] {
+  const counts = new Map<string, number>()
+  for (const task of tasks) {
+    if (!isBoardTask(task)) continue
+    counts.set(task.repo, (counts.get(task.repo) ?? 0) + 1)
+  }
+  const repos = [...counts.keys()]
+  const label = (repo: string): string => {
+    const base = repoBasename(repo)
+    const collides = repos.some((r) => r !== repo && repoBasename(r) === base)
+    if (!collides) return base
+    const parts = repo.replace(/\/+$/, "").split("/")
+    return parts.slice(-2).join("/")
+  }
+  return repos
+    .map((repo) => ({ repo, label: label(repo), count: counts.get(repo) ?? 0 }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+}
+
 /* ----- conflict radar (docs/design/conflict-radar.md) -------------------- */
 
 /** The radar pairs touching one task. */

--- a/packages/kobe-web/test/board.test.ts
+++ b/packages/kobe-web/test/board.test.ts
@@ -15,6 +15,7 @@ import {
   positionBetween,
   reconcileOverrides,
   renormalizedMoves,
+  repoOptions,
   TERMINAL_COLUMN_CAP,
   YARN_COLORS,
   yarnColor,
@@ -453,3 +454,41 @@ describe("isDroppableColumn", () => {
   })
 })
 
+
+describe("repoOptions — project chips", () => {
+  it("counts board cards only: archived and main rows don't register a project", () => {
+    const tasks = [
+      task({ id: "a", repo: "/u/proj/kobe" }),
+      task({ id: "b", repo: "/u/proj/kobe" }),
+      task({ id: "m", repo: "/u/proj/kobe", kind: "main" }),
+      task({ id: "x", repo: "/u/proj/old", archived: true }),
+    ]
+    expect(repoOptions(tasks)).toEqual([
+      { repo: "/u/proj/kobe", label: "kobe", count: 2 },
+    ])
+  })
+
+  it("labels are basenames, sorted; colliding basenames get parent/basename", () => {
+    const tasks = [
+      task({ id: "a", repo: "/u/work/api" }),
+      task({ id: "b", repo: "/u/personal/api" }),
+      task({ id: "c", repo: "/u/proj/zeta" }),
+    ]
+    expect(repoOptions(tasks)).toEqual([
+      { repo: "/u/personal/api", label: "personal/api", count: 1 },
+      { repo: "/u/work/api", label: "work/api", count: 1 },
+      { repo: "/u/proj/zeta", label: "zeta", count: 1 },
+    ])
+  })
+
+  it("handles trailing slashes and remote-style repo keys", () => {
+    const tasks = [
+      task({ id: "a", repo: "/u/proj/kobe/" }),
+      task({ id: "b", repo: "ssh://host/srv/repos/widget" }),
+    ]
+    expect(repoOptions(tasks)).toEqual([
+      { repo: "/u/proj/kobe/", label: "kobe", count: 1 },
+      { repo: "ssh://host/srv/repos/widget", label: "widget", count: 1 },
+    ])
+  })
+})


### PR DESCRIPTION
Stacked on #110 (`feat/conflict-radar`). The board previously mixed every repo's cards into the same status columns; the only project affordance was typing a repo path into the text filter.

## What

- **`repoOptions(tasks)`** (`src/lib/board.ts`) — pure helper: distinct repos among board cards (archived/main excluded), labeled by path basename with `parent/basename` disambiguation when two repos share a basename, sorted by label, each with a card count. Works for trailing-slash paths and remote-style (`ssh://…`) repo keys.
- **Chip row in the board header** — rendered only when 2+ projects have board cards (single-project boards pay no UI tax): `all` + one chip per project with its count. Click to filter every column to that project; click the active chip (or `all`) to clear. Composes with the `/` text filter.
- **Selection lives in the board-state module store** (same pattern as the text query), so it survives board → task → board navigation; a `useEffect` snaps it back to `all` when the selected project's last card disappears.
- Drag-drop correctness is inherited: the repo filter applies at the same visible layer as the text filter, while `planColumnDrop` keeps planning over the unfiltered full column.

## Tests

`test/board.test.ts` — `repoOptions`: board-card-only counting (main/archived excluded), basename labels + collision disambiguation + sort, trailing slashes and remote repo keys. Full battery green: 373 web tests, biome, build.