### PR TITLE
docs: surface `kobe web` in help + READMEs

### DIFF
--- a/.changeset/document-kobe-web.md
+++ b/.changeset/document-kobe-web.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Make the `kobe web` browser dashboard discoverable. It now appears in `kobe --help` / `kobe -h` (it was fully functional but absent from the top-level usage, so the only way to find it was guessing the subcommand or reading the source). Both READMEs gain a "Browser dashboard" section showing `kobe web` / `kobe web --port` and pointing at `docs/design/web-dashboard.md`.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ First task: press `n`, choose a repo/base branch/engine, then prompt the engine 
 
 More: [`docs/KEYBINDINGS.md`](./docs/KEYBINDINGS.md).
 
+## Browser dashboard
+
+Prefer a browser? The same tasks, sessions, and terminals are available in a local web UI:
+
+```bash
+kobe web                 # http://localhost:5173
+kobe web --port 5180
+```
+
+It talks to the same daemon as the TUI, so tasks created in either surface show up in both. Architecture lives in [`docs/design/web-dashboard.md`](./docs/design/web-dashboard.md).
+
 ## Fan out
 
 ```bash

--- a/packages/kobe/README.md
+++ b/packages/kobe/README.md
@@ -118,6 +118,21 @@ export KOBE_OPEN_EDITOR=/Applications/Cursor.app/Contents/Resources/app/bin/curs
 
 For the full feature manifest, see [`CHANGELOG.md`](./CHANGELOG.md).
 
+## Browser dashboard
+
+kobe also ships a local web UI over the same tasks and sessions, for when you'd
+rather drive things from a browser than the TUI:
+
+```bash
+kobe web                 # serves http://localhost:5173
+kobe web --port 5180     # pick a different port
+kobe web --help          # all options (--bridge-only, --no-takeover, …)
+```
+
+It connects to the same daemon as the TUI, so tasks created in either surface
+appear in both. The process model, routes, and security posture are documented
+in [`docs/design/web-dashboard.md`](../../docs/design/web-dashboard.md).
+
 ## Custom themes
 
 kobe ships a handful of bundled themes (`claude` is the default), and any JSON

--- a/packages/kobe/src/cli/usage.ts
+++ b/packages/kobe/src/cli/usage.ts
@@ -18,6 +18,7 @@ export function topLevelUsage(): string {
     "Run with no command to launch the TUI.",
     "",
     "Commands:",
+    "  web [options]           Launch the browser dashboard (default http://localhost:5173)",
     "  add [path]              Save a repo path for the new-task picker",
     "  adopt [glob]            Import existing git worktrees as tasks",
     "  repo <verb>             Per-repo init script + first prompt (show|set|unset)",

--- a/packages/kobe/test/cli/usage.test.ts
+++ b/packages/kobe/test/cli/usage.test.ts
@@ -11,6 +11,7 @@ describe("topLevelUsage", () => {
 
   it("lists every public subcommand, including api", () => {
     for (const cmd of [
+      "web",
       "add",
       "adopt",
       "repo",


### PR DESCRIPTION
## Why

The `kobe web` browser dashboard is fully functional but was **undiscoverable**: it was missing from top-level `kobe --help` / `kobe -h`, and neither the root README nor the package README mentioned a web UI exists. The only way to find it was guessing the subcommand or reading the source. The root README was actively misleading — it advertised "no browser, VNC, or desktop app; the terminal is the product."

## Changes

- **`packages/kobe/src/cli/usage.ts`** — add `web [options]` to the top-level command list.
- **`packages/kobe/test/cli/usage.test.ts`** — pin `web` in the public-subcommand assertion so it can't silently drop out again.
- **`README.md`** — add a "Browser dashboard" section (`kobe web` / `--port`).
- **`packages/kobe/README.md`** — same, plus `--help` and a link to the architecture doc.
- **`.changeset/document-kobe-web.md`** — `patch`.

The command's own `kobe web --help`, `docs/design/web-dashboard.md`, and `packages/kobe-web/README.md` were already thorough — this PR only closes the discoverability gap from the places a user looks first.

## Test

`bun run vitest run test/cli/usage.test.ts` — 4/4 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Browser dashboard" section to project documentation with examples and configuration options.
  * Updated CLI help text to surface the `kobe web` command for launching the browser dashboard.
  * Documented how the web UI connects to the same daemon as the TUI for unified task visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->