### PR TITLE
fix: sidebar Tasks list scrolls to follow the cursor

### DIFF
--- a/.changeset/sidebar-cursor-scroll-follow.md
+++ b/.changeset/sidebar-cursor-scroll-follow.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+The Tasks sidebar now scrolls when the task list is taller than the pane. Previously, once you had more tasks than fit on screen, pressing j/k (or the arrow keys) moved the selection but the list never scrolled — the highlighted task walked off the bottom edge and navigation looked frozen. Two things were wrong: the rail's outer box had its `flexShrink` silently forced to 0 by opentui's width setter, so it grew to its full content height instead of shrinking to the pane (leaving the inner scrollbox with nothing to scroll), and there was no effect to keep the cursor row in view. The rail is now bounded to the pane height and the viewport follows the cursor, matching the file-tree pane.

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -75,7 +75,7 @@
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
 import type { Task } from "@/types/task"
 import type { KeyEvent } from "@opentui/core"
-import { TextAttributes } from "@opentui/core"
+import { type BoxRenderable, type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { type Accessor, For, Show, createEffect, createMemo, createSignal, on, onCleanup, untrack } from "solid-js"
 import { useTheme as _useTheme } from "../../context/theme"
@@ -506,6 +506,52 @@ export function Sidebar(props: SidebarProps) {
 
   const [cursorIndex, setCursorIndex] = createSignal<number>(-1)
 
+  // Renderable refs for the scroll machinery below.
+  let scrollRef: ScrollBoxRenderable | undefined
+  let outerBoxRef: BoxRenderable | undefined
+  const rowEls = new Map<number, BoxRenderable>()
+
+  // Apply the rail width imperatively, then restore flexShrink/minHeight in the
+  // SAME effect. opentui's width setter force-zeroes flexShrink, which would
+  // stop the rail shrinking to its bounded host parent and break list
+  // scrolling (see the outer box's ref/comment below). Doing both here
+  // guarantees flexShrink wins regardless of prop-application order, and the
+  // effect re-runs on live pane resizes so a resize can't re-zero it.
+  createEffect(() => {
+    const w = props.width ? props.width() : SIDEBAR_WIDTH
+    const el = outerBoxRef
+    if (!el) return
+    el.width = w
+    el.flexShrink = 1
+    el.minHeight = 0
+  })
+
+  // ---------- viewport follow ----------
+  // Without this, j/k moved the cursor index but the scrollbox never
+  // followed: once the list outgrew the pane height the highlight walked
+  // straight off the bottom edge and navigation *looked* dead — the
+  // selection was changing, just out of sight. FileTree solves the same
+  // problem by mapping cursorIndex → a y-offset, but it can assume each
+  // row is height-1; our rows vary (project cards are 2 lines, task cards
+  // 3, plus section headers), so index ≠ y. Instead we capture each
+  // rendered row body keyed by its `flatIndex` and lean on the
+  // scrollbox's own geometry-based `scrollChildIntoView`, which reads the
+  // laid-out child/viewport rects and scrolls the minimum needed to bring
+  // the cursor row back inside the window (a no-op when it's already
+  // visible). `rowEls` keys on `flatIndex` for the same reason the row
+  // closures capture it non-reactively: reconcileSidebarRows only reuses a
+  // row element when its flatIndex is unchanged, so the ref re-fires
+  // whenever a row's position actually moves.
+  createEffect(
+    on([cursorIndex, rows], ([i]) => {
+      if (!scrollRef) return
+      if (scrollRef.viewport.height <= 0) return
+      const el = rowEls.get(i)
+      if (!el) return
+      scrollRef.scrollChildIntoView(el.id)
+    }),
+  )
+
   // Sync cursor from external selectedId. Deps are *only* the selected
   // id and the flat id list — we read `cursorIndex()` inside via
   // `untrack` so cursor moves from j/k don't refire this effect (which
@@ -629,8 +675,23 @@ export function Sidebar(props: SidebarProps) {
 
   return (
     <box
-      width={props.width ? props.width() : SIDEBAR_WIDTH}
-      flexShrink={0}
+      // width + flexShrink are applied together via `outerBoxRef` below, NOT as
+      // props here. This is load-bearing and was the whole reason the task list
+      // wouldn't scroll: opentui's `width` setter force-zeroes flexShrink (it
+      // assumes an explicitly-sized box shouldn't flex). With flexShrink=0 this
+      // rail refuses to shrink to its height-bounded host parent and sizes to
+      // its FULL content height; the inner scrollbox inherits that height, so
+      // opentui sees no overflow and the list never scrolls — j/k just walks
+      // the cursor off the bottom edge. Setting width then restoring
+      // flexShrink={1} in one effect (so order is guaranteed) re-bounds the box
+      // to the pane, which lets the scrollbox clip + the viewport-follow effect
+      // scroll. FileTree's outer box has no explicit width, so it kept the
+      // shrink default and never hit this.
+      ref={(r: BoxRenderable) => {
+        outerBoxRef = r
+      }}
+      flexGrow={1}
+      minHeight={0}
       flexDirection="column"
       paddingTop={1}
       paddingBottom={1}
@@ -776,7 +837,11 @@ export function Sidebar(props: SidebarProps) {
       {/* Body: scrollable flat task list. Stretches with flexGrow so
          the footer always sits at the bottom. */}
       <scrollbox
+        ref={(r: ScrollBoxRenderable) => {
+          scrollRef = r
+        }}
         flexGrow={1}
+        minHeight={0}
         verticalScrollbarOptions={{
           trackOptions: {
             foregroundColor: "transparent",
@@ -923,6 +988,12 @@ export function Sidebar(props: SidebarProps) {
                       row reads even when the fill is suppressed. */}
                   {/* biome-ignore lint/a11y/useKeyWithMouseEvents: opentui terminal UI has no DOM focus model — hover here is a pointer-only affordance backed by keyboard nav (j/k + the detail always reachable by selecting the row), so onFocus/onBlur don't apply. */}
                   <box
+                    ref={(r: BoxRenderable) => {
+                      rowEls.set(flatIndex, r)
+                      onCleanup(() => {
+                        if (rowEls.get(flatIndex) === r) rowEls.delete(flatIndex)
+                      })
+                    }}
                     flexDirection="column"
                     gap={0}
                     backgroundColor={isCursor() ? theme.backgroundElement : undefined}


### PR DESCRIPTION
## Problem

The Tasks sidebar never scrolled once the task list grew taller than the pane. Pressing `j`/`k` (or the arrow keys) moved the selection, but the list stayed put — the highlighted task walked off the bottom edge and navigation *looked* frozen, even though the cursor and selection were changing out of sight.

## Root cause

Two issues, one primary:

1. **The rail couldn't shrink (the real bug).** opentui's `width` setter **force-zeroes `flexShrink`** on any box given an explicit width. The Sidebar's outer box sets `width={props.width()}`, so it silently became `flexShrink: 0` → it refused to shrink to its height-bounded host parent and sized to its **full content height** instead. The inner `<scrollbox>` inherited that full height, so opentui saw no overflow and never scrolled. (FileTree's outer box has no explicit width, so it kept the shrink default and never hit this.)
2. **No viewport follow.** Even once scrollable, nothing kept the cursor row in view as it moved.

## Fix (`Sidebar.tsx`)

- Apply the rail `width` imperatively via a ref-effect and **restore `flexShrink={1}` / `minHeight={0}` in the same effect** (guaranteed order; re-runs on live pane resize). This re-bounds the rail to the pane so the scrollbox can clip + scroll.
- Add a viewport-follow effect that calls the scrollbox's geometry-based `scrollChildIntoView` on cursor moves — robust to the sidebar's variable row heights (project cards 2 lines, task cards 3, plus section headers).

## Verification

Reproduced and confirmed the fix with a headless `testRender` harness (30 tasks, 20-row viewport): before, the list stayed pinned to `ZTITLE00–04`; after, navigating down scrolls so the cursor row (`ZTITLE29`) is visible with the scrollbar thumb. The layout chain went from an overflowing `outer=h97` to a bounded `outer=h20`.

- `bun run typecheck` ✅
- `biome check` ✅
- `bun run test:fast` — 891/891 ✅

A changeset is included (`patch`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tasks sidebar scrolling behavior: the sidebar now automatically scrolls to keep the selected task in view when navigating through a long task list, instead of letting the selection move off-screen. Layout constraints were also corrected to enable proper scrolling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->