### PR TITLE
refactor: web — architecture deepening (repo-key, board view-model, tab-kind registry)

### DIFF
--- a/.changeset/web-board-view-model.md
+++ b/.changeset/web-board-view-model.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Internal: the Board's derivation logic — flattening loaded issue state across repos, folding in the optimistic pending-link, deriving the project chips, applying the chip + text filter, and assembling the per-project columns — was ~40 lines of pure logic trapped inside the 780-line `Board` component, only exercisable by rendering it. It now lives behind one `buildBoardView(input) → view` function in `lib/board` (with `collectBoardIssues` / `deriveRepoChips` / `filterBoardCards` underneath), each unit-tested directly; the component just calls it in one memo and renders. No behavior change.

--- a/.changeset/web-repo-key-module.md
+++ b/.changeset/web-repo-key-module.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Internal: the issue-snapshot repo-key aliasing — which path variants (`/repo`, `/repo/`, a worktree checkout) a snapshot is cached under — was copy-pasted in three places (the SPA store, the bridge's daemon-link mirror, and the issues hook's `normalize`), so a fix in one could silently diverge and only one copy was tested. It now lives in a single dependency-free `lib/repo-key` module (`normalizeRepoPath` + `repoSnapshotAliases`) with one test that pins the contract, consumed by all three. No behavior change.

--- a/.changeset/web-tab-kinds-registry.md
+++ b/.changeset/web-tab-kinds-registry.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Internal: a workspace tab's kind drove two cross-cutting facts by string-matching scattered across the code — whether it owns a server-side PTY (the `kind === "vendor" || kind === "terminal"` guard appeared three times: reset-layout, prune-missing-tasks, and tab close) and how a fresh tab is titled (`Vendor N` / `Terminal N` / `Chat` / `New tab` built in five different helpers). Both now come from one `lib/tab-kinds` registry (`tabHasPty` + `nextTabTitle`), unit-tested in isolation, so a new tab kind declares its PTY-ness and title rule in one place instead of being threaded through every guard. The per-kind render stays a type-narrowed switch (the discriminated union keeps it type-safe). No behavior change.

--- a/packages/kobe-web/server/daemon-link.ts
+++ b/packages/kobe-web/server/daemon-link.ts
@@ -27,6 +27,7 @@ import {
   MIN_COMPATIBLE_PROTOCOL_VERSION,
   type SerializedTask,
 } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { repoSnapshotAliases } from "../src/lib/repo-key.ts"
 import { SPA_CHANNEL_SET, SPA_CHANNELS } from "./spa-channels.ts"
 
 const RECONNECT_INTERVAL_MS = 500
@@ -71,32 +72,6 @@ export interface ChannelEventOut {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-/** Drop trailing slashes (but keep a lone `/`) so path comparisons are stable. */
-function normalizedPath(path: string): string {
-  return path.length > 1 ? path.replace(/\/+$/, "") : path
-}
-
-/**
- * The set of paths a repo's `issue.snapshot` should be mirrored under. The
- * daemon keys issues by the repo's main-worktree root, but the SPA may look up
- * a snapshot by a task's `repo` OR its `worktreePath` — so alias the snapshot
- * across every path that resolves to the same repo. Always includes the raw
- * `repoRoot`.
- */
-function issueSnapshotAliases(tasks: readonly SerializedTask[], repoRoot: string): string[] {
-  const root = normalizedPath(repoRoot)
-  const aliases = new Set<string>([repoRoot])
-  for (const task of tasks) {
-    const taskRepo = normalizedPath(task.repo)
-    const taskWorktree = normalizedPath(task.worktreePath)
-    if (taskRepo === root || taskWorktree === root) {
-      if (task.repo) aliases.add(task.repo)
-      if (task.worktreePath) aliases.add(task.worktreePath)
-    }
-  }
-  return [...aliases]
 }
 
 /**
@@ -289,7 +264,7 @@ export class DaemonLink {
       case "issue.snapshot": {
         const state = payload as IssueSnapshotPayload
         const next = { ...this.issueSnapshots }
-        for (const alias of issueSnapshotAliases(this.tasks, state.repoRoot)) {
+        for (const alias of repoSnapshotAliases(this.tasks, state.repoRoot)) {
           next[alias] = { ...state, repoRoot: alias }
         }
         this.issueSnapshots = next

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -32,12 +32,10 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import {
-  type BoardCard as BoardCardData,
   type BoardColumn,
   boardCardCount,
-  buildProjectBoards,
+  buildBoardView,
   isLinkedIssue,
-  labelRepo,
   type ProjectBoard,
 } from "../lib/board.ts"
 import {
@@ -230,26 +228,23 @@ export function Board() {
     refresh: refreshIssues,
   } = useRepoIssues(issueRepos)
 
-  // The flat issue list (across every repo), each tagged with its source repo,
-  // with the optimistic pending-link applied so a just-started issue already
-  // carries its taskId (→ In progress) before the daemon snapshot lands.
-  // Only `exists` repos contribute; a missing issue file is empty, not error.
-  const allIssues = useMemo(() => {
-    const out: Array<{ repo: string; issue: Issue }> = []
-    for (const repo of issueRepos) {
-      const state = issueData[repo]
-      if (!state || !state.exists) continue
-      for (const issue of state.issues) {
-        const pending = pendingLinks.get(`${repo}:${issue.id}`)
-        out.push(
-          pending && !issue.taskId
-            ? { repo, issue: { ...issue, taskId: pending.taskId } }
-            : { repo, issue },
-        )
-      }
-    }
-    return out
-  }, [issueRepos, issueData, pendingLinks])
+  // The whole derived view (flat issue list + chips + project boards + counts)
+  // is one pure call into lib/board — the component holds no board-derivation
+  // logic of its own, so that logic is unit-tested via buildBoardView, not the
+  // DOM. `allIssues` is UNfiltered (drives chips + peek lookups + the empty
+  // check); `projectBoards`/`shownCount` are post-filter.
+  const { allIssues, repoChips, projectBoards, shownCount, hasAnyCard } =
+    useMemo(
+      () =>
+        buildBoardView({
+          issueData,
+          issueRepos,
+          pendingLinks,
+          query,
+          repoFilter,
+        }),
+      [issueData, issueRepos, pendingLinks, query, repoFilter],
+    )
 
   // Drop a pending optimistic-link once the daemon confirms it: the issue now
   // carries a taskId from the snapshot, so the local hint is redundant.
@@ -307,61 +302,18 @@ export function Board() {
     return () => window.removeEventListener("keydown", onKey)
   }, [query, peek, creatingRepo, confirmDelete])
 
-  // Project chips: the distinct repos that have any issues. Computed from the
-  // UNfiltered list so chips (and their counts) don't vanish while one is
-  // selected or a text query narrows the view.
-  const repos = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const { repo } of allIssues) {
-      counts.set(repo, (counts.get(repo) ?? 0) + 1)
-    }
-    const keys = [...counts.keys()]
-    return keys
-      .map((repo) => ({
-        repo,
-        label: labelRepo(repo, keys),
-        count: counts.get(repo) ?? 0,
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-  }, [allIssues])
   // A selected project can disappear entirely (last issue deleted) — snap back
-  // to All rather than showing a permanently empty board.
+  // to All rather than showing a permanently empty board. Chips are derived from
+  // the UNfiltered set (in buildBoardView), so they don't vanish under a filter.
   useEffect(() => {
-    if (repoFilter && !repos.some((option) => option.repo === repoFilter)) {
+    if (repoFilter && !repoChips.some((option) => option.repo === repoFilter)) {
       setBoardRepo(null)
     }
-  }, [repos, repoFilter])
+  }, [repoChips, repoFilter])
 
-  // The DISPLAY issue set: repo chip + text query.
-  const boardIssues = useMemo<BoardCardData[]>(() => {
-    const q = query.trim().toLowerCase()
-    return allIssues
-      .filter(({ repo, issue }) => {
-        if (repoFilter && repo !== repoFilter) return false
-        if (!q) return true
-        const haystack =
-          `#${issue.id} ${issue.title} ${issue.body}`.toLowerCase()
-        return haystack.includes(q)
-      })
-      .map(({ repo, issue }) => ({ repo, issue }))
-  }, [allIssues, query, repoFilter])
-
-  const projectBoards = useMemo(
-    () => buildProjectBoards(boardIssues),
-    [boardIssues],
-  )
   const single = projectBoards.length === 1
-  const shownCount = useMemo(
-    () =>
-      projectBoards.reduce(
-        (sum, board) => sum + boardCardCount(board.columns),
-        0,
-      ),
-    [projectBoards],
-  )
   // A no-match (chips/query narrowed every issue away) vs the genuinely-empty
   // board: the empty branch differs (clear-filters vs new-issue affordance).
-  const hasAnyCard = allIssues.length > 0
   const filtered = Boolean(query) || Boolean(repoFilter)
 
   // Open a linked issue's task workspace/session.
@@ -491,7 +443,7 @@ export function Board() {
         {/* Project chips: scope the board to one project. Hidden for a
             single-project board — no point paying header space for a
             filter with one value. Click the active chip to deselect. */}
-        {repos.length >= 2 && (
+        {repoChips.length >= 2 && (
           <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto">
             <button
               type="button"
@@ -504,7 +456,7 @@ export function Board() {
             >
               all
             </button>
-            {repos.map((option) => (
+            {repoChips.map((option) => (
               <button
                 key={option.repo}
                 type="button"

--- a/packages/kobe-web/src/components/WorkspaceTabs.tsx
+++ b/packages/kobe-web/src/components/WorkspaceTabs.tsx
@@ -9,6 +9,7 @@ import { Bot, MessagesSquare, Terminal } from "lucide-react"
 import type { DragEvent, ReactNode } from "react"
 import { lazy, Suspense, useState } from "react"
 import { useAppState } from "../lib/store.ts"
+import { tabHasPty } from "../lib/tab-kinds.ts"
 import {
   addEmptyTab,
   clearSplitTab,
@@ -221,8 +222,7 @@ export function WorkspaceTabs() {
     if (!selectedTaskId) return
     const tab = tabs.find((t) => t.id === tabId)
     closeTab(selectedTaskId, tabId)
-    if (tab?.kind === "vendor" || tab?.kind === "terminal")
-      void closePtyTab(tabId)
+    if (tab && tabHasPty(tab.kind)) void closePtyTab(tabId)
   }
 
   const activeTab = tabs.find((t) => t.id === active) ?? tabs[0]

--- a/packages/kobe-web/src/lib/board.ts
+++ b/packages/kobe-web/src/lib/board.ts
@@ -13,7 +13,7 @@
  * affordance) but the task itself is NOT a card here (docs/design/web-kanban.md).
  */
 
-import type { Issue } from "./types.ts"
+import type { Issue, RepoIssues } from "./types.ts"
 
 /**
  * One card on the board: always an issue, carrying its source `repo` so
@@ -204,4 +204,133 @@ export function labelRepo(repo: string, repos: readonly string[]): string {
   const collides = repos.some((r) => r !== repo && repoBasename(r) === base)
   if (!collides) return base
   return repo.replace(/\/+$/, "").split("/").slice(-2).join("/")
+}
+
+/* ----- board view-model --------------------------------------------------- */
+
+/**
+ * The Board's optimistic pending-link map: `${repo}:${issueId}` → the taskId a
+ * just-started issue should carry before its `issue.snapshot` link lands. Only
+ * `taskId` is read here; the component keeps the fuller record.
+ */
+export type PendingLinks = ReadonlyMap<string, { readonly taskId: string }>
+
+/** A project chip: a repo with its display label and UNfiltered issue count. */
+export interface RepoChip {
+  readonly repo: string
+  readonly label: string
+  readonly count: number
+}
+
+export interface BoardViewInput {
+  /** repo key → loaded issue state (from `useRepoIssues`). */
+  readonly issueData: Record<string, RepoIssues>
+  /** Canonical repo keys to read, in order. */
+  readonly issueRepos: readonly string[]
+  /** Optimistic links folded in (issue → In progress before the snapshot). */
+  readonly pendingLinks: PendingLinks
+  /** Text filter, matched against `#id title body`. */
+  readonly query: string
+  /** Project-chip filter, or null for all projects. */
+  readonly repoFilter: string | null
+}
+
+export interface BoardView {
+  /** Every issue across all repos, source-repo tagged, pending-links applied —
+   *  UNfiltered. Drives the chips, the peek lookups, and the empty check. */
+  readonly allIssues: BoardCard[]
+  /** Project chips from the UNfiltered set so they don't vanish under a
+   *  narrowing filter. Sorted by label. */
+  readonly repoChips: RepoChip[]
+  /** Filtered, project-grouped, column-bucketed boards. */
+  readonly projectBoards: ProjectBoard[]
+  /** Cards shown after filtering — the header count. */
+  readonly shownCount: number
+  /** Any issue exists pre-filter — distinguishes a narrowed-away board from a
+   *  genuinely empty one. */
+  readonly hasAnyCard: boolean
+}
+
+/**
+ * Flatten loaded issue state across repos into source-tagged cards, applying the
+ * optimistic pending-link so a just-started issue already carries its taskId
+ * (→ In progress) before the daemon snapshot lands. Only `exists` repos
+ * contribute; a missing issue file is empty, not an error.
+ */
+export function collectBoardIssues(
+  issueData: Record<string, RepoIssues>,
+  issueRepos: readonly string[],
+  pendingLinks: PendingLinks,
+): BoardCard[] {
+  const out: BoardCard[] = []
+  for (const repo of issueRepos) {
+    const state = issueData[repo]
+    if (!state || !state.exists) continue
+    for (const issue of state.issues) {
+      const pending = pendingLinks.get(`${repo}:${issue.id}`)
+      out.push(
+        pending && !issue.taskId
+          ? { repo, issue: { ...issue, taskId: pending.taskId } }
+          : { repo, issue },
+      )
+    }
+  }
+  return out
+}
+
+/** Project chips from the UNfiltered card set: distinct repos, disambiguated
+ *  labels, issue counts, sorted by label. */
+export function deriveRepoChips(cards: readonly BoardCard[]): RepoChip[] {
+  const counts = new Map<string, number>()
+  for (const { repo } of cards) counts.set(repo, (counts.get(repo) ?? 0) + 1)
+  const keys = [...counts.keys()]
+  return keys
+    .map((repo) => ({
+      repo,
+      label: labelRepo(repo, keys),
+      count: counts.get(repo) ?? 0,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+}
+
+/** Apply the chip + text filter to the card set (text matches `#id title body`,
+ *  case-insensitive). */
+export function filterBoardCards(
+  cards: readonly BoardCard[],
+  query: string,
+  repoFilter: string | null,
+): BoardCard[] {
+  const q = query.trim().toLowerCase()
+  return cards.filter(({ repo, issue }) => {
+    if (repoFilter && repo !== repoFilter) return false
+    if (!q) return true
+    return `#${issue.id} ${issue.title} ${issue.body}`.toLowerCase().includes(q)
+  })
+}
+
+/**
+ * The whole Board view-model: one function from raw issue state + filters to
+ * everything the Board renders. The interface is the test surface — the Board
+ * component holds no derivation logic of its own, only React state + effects.
+ */
+export function buildBoardView(input: BoardViewInput): BoardView {
+  const allIssues = collectBoardIssues(
+    input.issueData,
+    input.issueRepos,
+    input.pendingLinks,
+  )
+  const repoChips = deriveRepoChips(allIssues)
+  const boardIssues = filterBoardCards(allIssues, input.query, input.repoFilter)
+  const projectBoards = buildProjectBoards(boardIssues)
+  const shownCount = projectBoards.reduce(
+    (sum, board) => sum + boardCardCount(board.columns),
+    0,
+  )
+  return {
+    allIssues,
+    repoChips,
+    projectBoards,
+    shownCount,
+    hasAnyCard: allIssues.length > 0,
+  }
 }

--- a/packages/kobe-web/src/lib/repo-key.ts
+++ b/packages/kobe-web/src/lib/repo-key.ts
@@ -1,0 +1,60 @@
+/**
+ * repo-key — repo-path identity for the issue-snapshot cache, shared by BOTH
+ * the SPA (`src/`) and the bridge (`server/`).
+ *
+ * The daemon keys an `issue.snapshot` by the repo's git common-dir (its
+ * main-worktree root). But a task may reference that same repo by its `repo`
+ * path OR its `worktreePath`, and either can carry a trailing slash. So a
+ * snapshot must be mirrored under every path that resolves to the same repo —
+ * otherwise `/repo`, `/repo/`, and a worktree checkout split the UI cache and a
+ * push lands under a key the board never reads.
+ *
+ * This was the SAME logic copy-pasted three times — `src/lib/store.ts`,
+ * `server/daemon-link.ts`, and `src/lib/use-repo-issues.ts` (as a bare
+ * `normalize`). A fix in one would silently diverge from the others, and only
+ * the store copy carried a test. It lives here so the repo-key contract is in
+ * ONE place with ONE test (`test/repo-key.test.ts`).
+ *
+ * Deliberately DEPENDENCY-FREE: it imports nothing and touches neither the DOM
+ * nor node, so the bridge (Bun) and the SPA (browser) can both consume it
+ * across the `src/`↔`server/` boundary without dragging runtime-specific code
+ * either way. It takes a STRUCTURAL task shape ({@link RepoPaths}) so both the
+ * SPA's `Task` and the daemon's `SerializedTask` satisfy it without a shared
+ * nominal type.
+ */
+
+/** Drop a trailing slash (but keep a bare "/") so `/repo` and `/repo/` collapse
+ *  to one key. */
+export function normalizeRepoPath(path: string): string {
+  return path.length > 1 ? path.replace(/\/+$/, "") : path
+}
+
+/** The two path fields repo-key reads off a task. The SPA `Task` and the daemon
+ *  `SerializedTask` both satisfy this structurally. */
+export interface RepoPaths {
+  readonly repo: string
+  readonly worktreePath: string
+}
+
+/**
+ * The repo keys a single `issue.snapshot` for `repoRoot` should be cached under:
+ * the raw `repoRoot`, plus every task `repo`/`worktreePath` that normalizes to
+ * the same path. The raw (un-normalized) variants are kept so a caller that
+ * stores by exact path (e.g. a trailing-slash `repo`) still gets a hit.
+ */
+export function repoSnapshotAliases(
+  tasks: readonly RepoPaths[],
+  repoRoot: string,
+): string[] {
+  const root = normalizeRepoPath(repoRoot)
+  const aliases = new Set<string>([repoRoot])
+  for (const task of tasks) {
+    const taskRepo = normalizeRepoPath(task.repo)
+    const taskWorktree = normalizeRepoPath(task.worktreePath)
+    if (taskRepo === root || taskWorktree === root) {
+      if (task.repo) aliases.add(task.repo)
+      if (task.worktreePath) aliases.add(task.worktreePath)
+    }
+  }
+  return [...aliases]
+}

--- a/packages/kobe-web/src/lib/store.ts
+++ b/packages/kobe-web/src/lib/store.ts
@@ -8,6 +8,7 @@
 import { useSyncExternalStore } from "react"
 import { deliverToSession } from "./dispatch-delivery.ts"
 import { notifyEngineTransition } from "./notify.ts"
+import { repoSnapshotAliases } from "./repo-key.ts"
 import { pruneMissingTasks } from "./tabs.ts"
 import { applyThemeFromPrefs } from "./theme.ts"
 import type {
@@ -109,40 +110,14 @@ export function applyJobEvent(
   return rest
 }
 
-function normalizedPath(path: string): string {
-  return path.length > 1 ? path.replace(/\/+$/, "") : path
-}
-
-/** The repo keys a single `issue.snapshot` should be cached under. A snapshot's
- *  `repoRoot` is the daemon's git common-dir for the source repo; a task may
- *  reference that same repo by its worktree path (or a trailing-slash variant),
- *  so we mirror the snapshot under every matching task repo/worktree alias —
- *  this keeps `/repo` and `/repo/` (and a worktree checkout) from splitting the
- *  UI cache. Exported for tests. */
-export function issueSnapshotAliases(
-  tasks: readonly Task[],
-  repoRoot: string,
-): string[] {
-  const root = normalizedPath(repoRoot)
-  const aliases = new Set<string>([repoRoot])
-  for (const task of tasks) {
-    const taskRepo = normalizedPath(task.repo)
-    const taskWorktree = normalizedPath(task.worktreePath)
-    if (taskRepo === root || taskWorktree === root) {
-      if (task.repo) aliases.add(task.repo)
-      if (task.worktreePath) aliases.add(task.worktreePath)
-    }
-  }
-  return [...aliases]
-}
-
 function applyIssueSnapshotEvent(
   snapshots: Record<string, RepoIssues>,
   tasks: readonly Task[],
   snapshot: RepoIssues,
 ): Record<string, RepoIssues> {
   const next = { ...snapshots }
-  for (const alias of issueSnapshotAliases(tasks, snapshot.repoRoot)) {
+  // repo-key owns the aliasing contract (shared with the bridge + the hook).
+  for (const alias of repoSnapshotAliases(tasks, snapshot.repoRoot)) {
     next[alias] = { ...snapshot, repoRoot: alias }
   }
   return next

--- a/packages/kobe-web/src/lib/tab-kinds.ts
+++ b/packages/kobe-web/src/lib/tab-kinds.ts
@@ -1,0 +1,73 @@
+/**
+ * tab-kinds — the single registry of workspace tab kinds.
+ *
+ * A tab's kind drives two cross-cutting facts that were previously string-matched
+ * in many places: whether it owns a server-side PTY (so closing or pruning the
+ * tab must tear that PTY down) and how a fresh tab of the kind is titled. Both
+ * lived as scattered `kind === "vendor" || kind === "terminal"` guards (three
+ * copies) and count-based title strings spread across five tab-mutation helpers.
+ * They live here now, so adding or changing a kind is one registry entry and the
+ * rules are unit-tested in isolation.
+ *
+ * Pure + React-free: the per-kind RENDER (a component) stays in WorkspaceTabs'
+ * type-narrowing switch, where the discriminated union keeps it type-safe — a
+ * render dispatch table would trade that safety for indirection. This registry
+ * owns the DATA about a kind, not its UI.
+ */
+
+export type WorkspaceTabKind =
+  | "empty"
+  | "vendor"
+  | "terminal"
+  | "transcript"
+  | "file"
+
+/** How a fresh tab of a kind is titled. */
+type TitleMode =
+  /** `${label} N`, where N = (existing tabs of this kind) + 1. */
+  | "count"
+  /** the fixed label. */
+  | "static"
+  /** the caller supplies the title (file: derived from its path). */
+  | "derived"
+
+interface TabKindSpec {
+  /** Owns a server-side PTY — closing/pruning the tab must close that PTY. */
+  readonly hasPty: boolean
+  readonly titleMode: TitleMode
+  readonly label: string
+}
+
+export const TAB_KINDS: Record<WorkspaceTabKind, TabKindSpec> = {
+  empty: { hasPty: false, titleMode: "static", label: "New tab" },
+  vendor: { hasPty: true, titleMode: "count", label: "Vendor" },
+  terminal: { hasPty: true, titleMode: "count", label: "Terminal" },
+  transcript: { hasPty: false, titleMode: "static", label: "Chat" },
+  file: { hasPty: false, titleMode: "derived", label: "File" },
+}
+
+/**
+ * Does a tab of this kind own a server-side PTY that must be torn down when the
+ * tab is closed or its task pruned? Replaces the scattered
+ * `kind === "vendor" || kind === "terminal"` guards.
+ */
+export function tabHasPty(kind: WorkspaceTabKind): boolean {
+  return TAB_KINDS[kind].hasPty
+}
+
+/**
+ * The title for a fresh tab of `kind`, given the task's existing tabs (for the
+ * per-kind count). `derived`-titled kinds (file) return their bare label — the
+ * caller titles those from their own data (e.g. the file basename).
+ */
+export function nextTabTitle(
+  kind: WorkspaceTabKind,
+  existing: readonly { kind: WorkspaceTabKind }[],
+): string {
+  const spec = TAB_KINDS[kind]
+  if (spec.titleMode === "count") {
+    const n = existing.filter((tab) => tab.kind === kind).length + 1
+    return `${spec.label} ${n}`
+  }
+  return spec.label
+}

--- a/packages/kobe-web/src/lib/tabs.ts
+++ b/packages/kobe-web/src/lib/tabs.ts
@@ -8,16 +8,12 @@
  */
 
 import { useSyncExternalStore } from "react"
+import { nextTabTitle, tabHasPty, type WorkspaceTabKind } from "./tab-kinds.ts"
 import { closePtyTab } from "./terminal.ts"
 
 const KEY = "kobe-web.tabs"
 
-export type WorkspaceTabKind =
-  | "empty"
-  | "vendor"
-  | "terminal"
-  | "transcript"
-  | "file"
+export type { WorkspaceTabKind }
 
 export interface EmptyTab {
   id: string
@@ -76,7 +72,7 @@ const EMPTY: TabsState = {
 }
 
 function emptyTab(): EmptyTab {
-  return { id: newId(), kind: "empty", title: "New tab" }
+  return { id: newId(), kind: "empty", title: nextTabTitle("empty", []) }
 }
 
 /**
@@ -211,8 +207,7 @@ export function consumePendingPrompt(taskId: string): string | null {
 export function resetLayout(): void {
   for (const tabs of Object.values(state.tabsByTask)) {
     for (const tab of tabs) {
-      if (tab.kind === "vendor" || tab.kind === "terminal")
-        void closePtyTab(tab.id)
+      if (tabHasPty(tab.kind)) void closePtyTab(tab.id)
     }
   }
   set({ ...EMPTY })
@@ -234,8 +229,7 @@ export function pruneMissingTasks(liveTaskIds: ReadonlySet<string>): void {
   if (dead.length === 0 && !selectionDead) return
   for (const taskId of dead) {
     for (const tab of state.tabsByTask[taskId] ?? []) {
-      if (tab.kind === "vendor" || tab.kind === "terminal")
-        void closePtyTab(tab.id)
+      if (tabHasPty(tab.kind)) void closePtyTab(tab.id)
     }
   }
   const tabsByTask = { ...state.tabsByTask }
@@ -262,11 +256,10 @@ export function clearSelectedTask(): void {
 export function addTab(taskId: string): string {
   const list = state.tabsByTask[taskId] ?? []
   const id = newId()
-  const vendorCount = list.filter((tab) => tab.kind === "vendor").length
   const tab: VendorTab = {
     id,
     kind: "vendor",
-    title: `Vendor ${vendorCount + 1}`,
+    title: nextTabTitle("vendor", list),
   }
   set({
     ...state,
@@ -292,11 +285,10 @@ export function ensureEngineTab(taskId: string): string {
   const existing = list.find((tab) => tab.kind === "vendor")
   if (existing) return existing.id
   const id = newId()
-  const vendorCount = list.filter((tab) => tab.kind === "vendor").length
   const tab: VendorTab = {
     id,
     kind: "vendor",
-    title: `Vendor ${vendorCount + 1}`,
+    title: nextTabTitle("vendor", list),
   }
   set({
     ...state,
@@ -326,21 +318,23 @@ export function configureTab(
   const next = list.map((tab) => {
     if (tab.id !== tabId) return tab
     if (kind === "vendor") {
-      const vendorCount = list.filter((item) => item.kind === "vendor").length
       return {
         id: tabId,
         kind,
-        title: `Vendor ${vendorCount + 1}`,
+        title: nextTabTitle("vendor", list),
       } satisfies VendorTab
     }
     if (kind === "transcript") {
-      return { id: tabId, kind, title: "Chat" } satisfies TranscriptTab
+      return {
+        id: tabId,
+        kind,
+        title: nextTabTitle("transcript", list),
+      } satisfies TranscriptTab
     }
-    const terminalCount = list.filter((item) => item.kind === "terminal").length
     return {
       id: tabId,
       kind,
-      title: `Terminal ${terminalCount + 1}`,
+      title: nextTabTitle("terminal", list),
     } satisfies TerminalTab
   })
   set({

--- a/packages/kobe-web/src/lib/use-repo-issues.ts
+++ b/packages/kobe-web/src/lib/use-repo-issues.ts
@@ -17,11 +17,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { fetchIssues, type RepoIssues } from "./issues.ts"
+import { normalizeRepoPath } from "./repo-key.ts"
 import { useAppState } from "./store.ts"
-
-function normalize(root: string): string {
-  return root.length > 1 ? root.replace(/\/+$/, "") : root
-}
 
 export interface RepoIssuesResult {
   /** repoRoot → loaded issue state (GET + live pushes, seq-guarded). */
@@ -119,12 +116,12 @@ export function useRepoIssues(repos: readonly string[]): RepoIssuesResult {
   useEffect(() => {
     const byNormalized = new Map(
       Object.values(issueSnapshots).map((state) => [
-        normalize(state.repoRoot),
+        normalizeRepoPath(state.repoRoot),
         state,
       ]),
     )
     for (const repo of repoKey ? repoKey.split("\n") : []) {
-      const pushed = byNormalized.get(normalize(repo))
+      const pushed = byNormalized.get(normalizeRepoPath(repo))
       if (!pushed) continue
       const seq = beginRequest(repo)
       applyState(pushed, seq, repo)

--- a/packages/kobe-web/test/board.test.ts
+++ b/packages/kobe-web/test/board.test.ts
@@ -4,11 +4,16 @@ import {
   type BoardCard,
   boardCardCount,
   buildBoard,
+  buildBoardView,
   buildProjectBoards,
+  collectBoardIssues,
   compareCards,
+  deriveRepoChips,
+  filterBoardCards,
   isLinkedIssue,
   issueColumnKey,
   labelRepo,
+  type PendingLinks,
   TERMINAL_COLUMN_CAP,
 } from "../src/lib/board.ts"
 import {
@@ -17,7 +22,7 @@ import {
   setBoardQuery,
   setBoardRepo,
 } from "../src/lib/board-state.ts"
-import type { Issue } from "../src/lib/types.ts"
+import type { Issue, RepoIssues } from "../src/lib/types.ts"
 
 /**
  * Issues-only kanban column math. The load-bearing rules: the board renders
@@ -218,6 +223,167 @@ describe("labelRepo — shared basename/parent labeler", () => {
     expect(
       labelRepo("ssh://host/srv/repos/widget", ["ssh://host/srv/repos/widget"]),
     ).toBe("widget")
+  })
+})
+
+/** A loaded RepoIssues state for a repo. */
+const repoState = (
+  issues: Issue[],
+  over: Partial<RepoIssues> = {},
+): RepoIssues => ({
+  repoRoot: "/u/kobe",
+  exists: true,
+  nextId: issues.length + 1,
+  issues,
+  ...over,
+})
+const noPending: PendingLinks = new Map()
+
+describe("collectBoardIssues — flatten + optimistic pending-link", () => {
+  it("flattens every exists repo's issues, source-repo tagged", () => {
+    const data: Record<string, RepoIssues> = {
+      "/u/kobe": repoState([issue({ id: 1 })], { repoRoot: "/u/kobe" }),
+      "/u/web": repoState([issue({ id: 2 })], { repoRoot: "/u/web" }),
+    }
+    const cards = collectBoardIssues(data, ["/u/kobe", "/u/web"], noPending)
+    expect(cards.map((c) => `${c.repo}#${c.issue.id}`)).toEqual([
+      "/u/kobe#1",
+      "/u/web#2",
+    ])
+  })
+
+  it("skips a repo with no state or exists:false (missing file = empty)", () => {
+    const data: Record<string, RepoIssues> = {
+      "/u/kobe": repoState([issue({ id: 1 })]),
+      "/u/gone": repoState([issue({ id: 9 })], { exists: false }),
+    }
+    const cards = collectBoardIssues(data, ["/u/kobe", "/u/gone", "/u/never"], noPending)
+    expect(cards.map((c) => c.issue.id)).toEqual([1])
+  })
+
+  it("applies a pending link → the issue carries the optimistic taskId", () => {
+    const data = { "/u/kobe": repoState([issue({ id: 1, status: "open" })]) }
+    const pending: PendingLinks = new Map([["/u/kobe:1", { taskId: "t9" }]])
+    const [card] = collectBoardIssues(data, ["/u/kobe"], pending)
+    expect(card.issue.taskId).toBe("t9")
+    expect(issueColumnKey(card.issue)).toBe("in_progress")
+  })
+
+  it("never overrides an issue that already carries a real taskId", () => {
+    const data = { "/u/kobe": repoState([issue({ id: 1, taskId: "real" })]) }
+    const pending: PendingLinks = new Map([["/u/kobe:1", { taskId: "stale" }]])
+    const [card] = collectBoardIssues(data, ["/u/kobe"], pending)
+    expect(card.issue.taskId).toBe("real")
+  })
+})
+
+describe("deriveRepoChips — unfiltered project chips", () => {
+  it("counts issues per repo and sorts by label", () => {
+    const chips = deriveRepoChips([
+      ic("/u/proj/zeta", issue({ id: 1 })),
+      ic("/u/proj/alpha", issue({ id: 2 })),
+      ic("/u/proj/alpha", issue({ id: 3 })),
+    ])
+    expect(chips).toEqual([
+      { repo: "/u/proj/alpha", label: "alpha", count: 2 },
+      { repo: "/u/proj/zeta", label: "zeta", count: 1 },
+    ])
+  })
+})
+
+describe("filterBoardCards — chip + text filter (AND)", () => {
+  const cards = [
+    ic("/u/kobe", issue({ id: 1, title: "fix auth bug" })),
+    ic("/u/kobe", issue({ id: 2, title: "docs", body: "auth notes" })),
+    ic("/u/web", issue({ id: 3, title: "layout" })),
+  ]
+
+  it("with no filters returns everything", () => {
+    expect(filterBoardCards(cards, "", null).map((c) => c.issue.id)).toEqual([
+      1, 2, 3,
+    ])
+  })
+
+  it("repoFilter scopes to one project", () => {
+    expect(
+      filterBoardCards(cards, "", "/u/web").map((c) => c.issue.id),
+    ).toEqual([3])
+  })
+
+  it("text query matches #id, title, and body", () => {
+    expect(filterBoardCards(cards, "auth", null).map((c) => c.issue.id)).toEqual(
+      [1, 2],
+    )
+    expect(filterBoardCards(cards, "#3", null).map((c) => c.issue.id)).toEqual([
+      3,
+    ])
+  })
+
+  it("ANDs the chip and the query", () => {
+    expect(
+      filterBoardCards(cards, "auth", "/u/kobe").map((c) => c.issue.id),
+    ).toEqual([1, 2])
+  })
+})
+
+describe("buildBoardView — the whole board view-model", () => {
+  const data: Record<string, RepoIssues> = {
+    "/u/kobe": repoState(
+      [
+        issue({ id: 1, status: "open", title: "auth" }),
+        issue({ id: 2, status: "done" }),
+      ],
+      { repoRoot: "/u/kobe" },
+    ),
+    "/u/web": repoState([issue({ id: 3, status: "open" })], {
+      repoRoot: "/u/web",
+    }),
+  }
+  const repos = ["/u/kobe", "/u/web"]
+
+  it("chips come from the UNfiltered set; boards + count are post-filter", () => {
+    const view = buildBoardView({
+      issueData: data,
+      issueRepos: repos,
+      pendingLinks: noPending,
+      query: "auth",
+      repoFilter: null,
+    })
+    // Chips never shrink under a query — both projects still listed.
+    expect(view.repoChips.map((c) => c.repo).sort()).toEqual([
+      "/u/kobe",
+      "/u/web",
+    ])
+    // Only issue #1 matches "auth", so one shown card, one project board.
+    expect(view.shownCount).toBe(1)
+    expect(view.projectBoards.map((b) => b.repo)).toEqual(["/u/kobe"])
+    expect(view.hasAnyCard).toBe(true)
+  })
+
+  it("a pending link promotes an issue into In progress in the built board", () => {
+    const view = buildBoardView({
+      issueData: { "/u/kobe": repoState([issue({ id: 1, status: "open" })]) },
+      issueRepos: ["/u/kobe"],
+      pendingLinks: new Map([["/u/kobe:1", { taskId: "t9" }]]),
+      query: "",
+      repoFilter: null,
+    })
+    const board = view.projectBoards[0]
+    expect(
+      board.columns.find((c) => c.key === "in_progress")?.cards,
+    ).toHaveLength(1)
+  })
+
+  it("hasAnyCard is false for an empty / non-exists board", () => {
+    const view = buildBoardView({
+      issueData: { "/u/kobe": repoState([], { exists: false }) },
+      issueRepos: ["/u/kobe"],
+      pendingLinks: noPending,
+      query: "",
+      repoFilter: null,
+    })
+    expect(view.hasAnyCard).toBe(false)
+    expect(view.shownCount).toBe(0)
   })
 })
 

--- a/packages/kobe-web/test/repo-key.test.ts
+++ b/packages/kobe-web/test/repo-key.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import {
+  normalizeRepoPath,
+  type RepoPaths,
+  repoSnapshotAliases,
+} from "../src/lib/repo-key.ts"
+
+/**
+ * repo-key is the single home for the issue-snapshot aliasing contract that
+ * used to be copy-pasted across store.ts, daemon-link.ts, and use-repo-issues.ts.
+ * These tests pin the contract so the three consumers can't silently diverge.
+ */
+
+describe("normalizeRepoPath", () => {
+  it("drops a trailing slash", () => {
+    expect(normalizeRepoPath("/repo/")).toBe("/repo")
+  })
+
+  it("collapses repeated trailing slashes", () => {
+    expect(normalizeRepoPath("/repo///")).toBe("/repo")
+  })
+
+  it("leaves a path without a trailing slash untouched", () => {
+    expect(normalizeRepoPath("/repo")).toBe("/repo")
+  })
+
+  it("keeps a lone root slash", () => {
+    expect(normalizeRepoPath("/")).toBe("/")
+  })
+})
+
+describe("repoSnapshotAliases", () => {
+  const tasks: RepoPaths[] = [
+    {
+      repo: "/Users/narwhal/proj/kobe/",
+      worktreePath: "/Users/narwhal/.kobe/worktrees/kobe/bovid",
+    },
+  ]
+
+  it("maps a worktree issue push back to its source repo key", () => {
+    expect(
+      repoSnapshotAliases(tasks, "/Users/narwhal/.kobe/worktrees/kobe/bovid"),
+    ).toEqual([
+      "/Users/narwhal/.kobe/worktrees/kobe/bovid",
+      "/Users/narwhal/proj/kobe/",
+    ])
+  })
+
+  it("maps a source repo issue push to known worktree keys too", () => {
+    expect(repoSnapshotAliases(tasks, "/Users/narwhal/proj/kobe")).toEqual([
+      "/Users/narwhal/proj/kobe",
+      "/Users/narwhal/proj/kobe/",
+      "/Users/narwhal/.kobe/worktrees/kobe/bovid",
+    ])
+  })
+
+  it("matches across a trailing-slash difference (the cache-split bug)", () => {
+    // A push under `/repo` must still alias to a task that stored `/repo/`.
+    expect(repoSnapshotAliases(tasks, "/Users/narwhal/proj/kobe/")).toContain(
+      "/Users/narwhal/.kobe/worktrees/kobe/bovid",
+    )
+  })
+
+  it("returns just the raw repoRoot when no task matches", () => {
+    expect(repoSnapshotAliases(tasks, "/some/other/repo")).toEqual([
+      "/some/other/repo",
+    ])
+  })
+
+  it("accepts the structural shape — extra task fields are ignored", () => {
+    // Proves both the SPA `Task` and the daemon `SerializedTask` satisfy it:
+    // only `repo` + `worktreePath` are read.
+    const wide = [
+      {
+        id: "t1",
+        title: "x",
+        repo: "/p",
+        worktreePath: "/w",
+        status: "backlog",
+      },
+    ]
+    expect(repoSnapshotAliases(wide, "/p")).toEqual(["/p", "/w"])
+  })
+})

--- a/packages/kobe-web/test/store-reducer.test.ts
+++ b/packages/kobe-web/test/store-reducer.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest"
 import {
   applyJobEvent,
   isOrphanIdleEngineState,
-  issueSnapshotAliases,
 } from "../src/lib/store.ts"
 import type { Task, TaskJob } from "../src/lib/types.ts"
 
@@ -87,41 +86,5 @@ describe("applyJobEvent", () => {
     const snapshot = { ...before }
     applyJobEvent(before, job("t1", "done"))
     expect(before).toEqual(snapshot)
-  })
-})
-
-describe("issueSnapshotAliases", () => {
-  it("maps a worktree issue push back to its source repo key", () => {
-    const tasks = [
-      {
-        id: "t1",
-        repo: "/Users/narwhal/proj/kobe/",
-        worktreePath: "/Users/narwhal/.kobe/worktrees/kobe/bovid",
-      },
-    ] as Task[]
-    expect(
-      issueSnapshotAliases(
-        tasks,
-        "/Users/narwhal/.kobe/worktrees/kobe/bovid",
-      ),
-    ).toEqual([
-      "/Users/narwhal/.kobe/worktrees/kobe/bovid",
-      "/Users/narwhal/proj/kobe/",
-    ])
-  })
-
-  it("maps a source repo issue push to known worktree keys too", () => {
-    const tasks = [
-      {
-        id: "t1",
-        repo: "/Users/narwhal/proj/kobe/",
-        worktreePath: "/Users/narwhal/.kobe/worktrees/kobe/bovid",
-      },
-    ] as Task[]
-    expect(issueSnapshotAliases(tasks, "/Users/narwhal/proj/kobe")).toEqual([
-      "/Users/narwhal/proj/kobe",
-      "/Users/narwhal/proj/kobe/",
-      "/Users/narwhal/.kobe/worktrees/kobe/bovid",
-    ])
   })
 })

--- a/packages/kobe-web/test/tab-kinds.test.ts
+++ b/packages/kobe-web/test/tab-kinds.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import {
+  TAB_KINDS,
+  tabHasPty,
+  nextTabTitle,
+  type WorkspaceTabKind,
+} from "../src/lib/tab-kinds.ts"
+
+/**
+ * tab-kinds is the single source of truth for the two cross-cutting facts a
+ * tab's kind drives: whether it owns a PTY (so close/prune tears it down) and
+ * how a fresh tab of the kind is titled. These tests pin both so a new kind
+ * can't silently miss a PTY-cleanup guard or a title rule.
+ */
+
+const ALL: WorkspaceTabKind[] = [
+  "empty",
+  "vendor",
+  "terminal",
+  "transcript",
+  "file",
+]
+
+describe("tabHasPty — which kinds own a server-side PTY", () => {
+  it("only vendor and terminal have PTYs", () => {
+    expect(tabHasPty("vendor")).toBe(true)
+    expect(tabHasPty("terminal")).toBe(true)
+    expect(tabHasPty("empty")).toBe(false)
+    expect(tabHasPty("transcript")).toBe(false)
+    expect(tabHasPty("file")).toBe(false)
+  })
+
+  it("every kind declares a hasPty (registry is complete)", () => {
+    for (const kind of ALL) {
+      expect(typeof TAB_KINDS[kind].hasPty).toBe("boolean")
+    }
+  })
+})
+
+describe("nextTabTitle — fresh-tab titling", () => {
+  it("static kinds use their fixed label", () => {
+    expect(nextTabTitle("empty", [])).toBe("New tab")
+    expect(nextTabTitle("transcript", [])).toBe("Chat")
+  })
+
+  it("count kinds number off the existing tabs of that kind", () => {
+    expect(nextTabTitle("vendor", [])).toBe("Vendor 1")
+    expect(
+      nextTabTitle("vendor", [
+        { kind: "vendor" },
+        { kind: "terminal" },
+        { kind: "vendor" },
+      ]),
+    ).toBe("Vendor 3")
+    expect(nextTabTitle("terminal", [{ kind: "terminal" }])).toBe("Terminal 2")
+  })
+
+  it("the count ignores other kinds", () => {
+    // Two transcripts + an empty don't bump the vendor count.
+    expect(
+      nextTabTitle("vendor", [
+        { kind: "transcript" },
+        { kind: "empty" },
+        { kind: "transcript" },
+      ]),
+    ).toBe("Vendor 1")
+  })
+
+  it("derived kinds (file) fall back to their bare label — the caller titles them", () => {
+    expect(nextTabTitle("file", [])).toBe("File")
+  })
+})


### PR DESCRIPTION
## Summary

Three internal architecture-deepening refactors of the `kobe-web` dashboard — turning shallow/scattered logic into deep, single-source, unit-tested modules. **No behavior change**; the user-visible dashboard is identical. Output of an `/improve-codebase-architecture` review (#4 of the reviewed set, the PTY/session seam, is deliberately deferred to its own pass — it touches a live path and needs live-PTY QA).

- **repo-key module** (`fe0b6fd`) — the issue-snapshot path aliasing (which path variants — `/repo`, `/repo/`, a worktree checkout — a snapshot is cached under) was copy-pasted in `store.ts`, `server/daemon-link.ts`, and the issues hook's `normalize`; a fix in one could silently diverge and only one copy was tested. Consolidated into a dependency-free `lib/repo-key.ts` (`normalizeRepoPath` + `repoSnapshotAliases`, a structural task shape so both the SPA `Task` and the daemon `SerializedTask` satisfy it across the `src`↔`server` boundary), with one test pinning the contract.
- **board view-model** (`094301a`) — ~40 lines of pure derivation (flatten issue state across repos, apply the optimistic pending-link, derive project chips, filter by chip+query, assemble columns) were trapped in the 780-line `Board` component, only testable by rendering it. Now behind one `buildBoardView(input) → view` in `lib/board` (`collectBoardIssues` / `deriveRepoChips` / `filterBoardCards`), each unit-tested; the component calls it in one memo.
- **tab-kind registry** (`7981ec7`) — "does this kind own a PTY" (`kind === "vendor" || "terminal"`, string-matched in 3 places) and fresh-tab titling (5 helpers) now resolve through one `lib/tab-kinds.ts` (`tabHasPty` + `nextTabTitle`); adding a tab kind is one registry entry. The per-kind render stays a type-narrowed switch.

## Test plan

- [x] `typecheck` + biome `check` + `bun run test` (481 web tests) + `bun run build` — all green on each commit
- [x] `/browse` QA per wave: board renders + filter round-trip; workspace tab select + empty-tab titling; no console errors
- [ ] reviewer: confirm no behavior change vs `main` on the board / workspace tabs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated internal board view derivation logic for improved maintainability.
  * Centralized repository path normalization and aliasing logic across components.
  * Unified workspace tab kind behavior and metadata into a single registry.

* **Tests**
  * Added comprehensive test coverage for board view derivation, repository key handling, and tab kind behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->