### PR TITLE
fix: tui — kill first-open layout jump + preserve manual pane drags

### DIFF
--- a/.changeset/chat-panel-layout-switch-fit.md
+++ b/.changeset/chat-panel-layout-switch-fit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix the workspace layout flashing to the aligned size the first time you open a task from the Tasks list — the target window is now fit + healed to your terminal before the switch lands, so it no longer reflows on screen. A manual Tasks-rail / right-column drag is also captured live, so it's no longer discarded when you then resize the terminal, and live-resize layout healing is coalesced so a drag-resize no longer thrashes.

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -509,9 +509,11 @@ async function main(): Promise<void> {
     //
     // `window-layout-changed` ALSO fires on a terminal-resize reflow (and on
     // the heal's own `resize-pane`), where the rail is proportionally blown up
-    // and must NOT be captured. The `genAgeMs(..., "heal")` guard skips capture
-    // while a resize is in flight (its `heal-layout` stamped the heal gen);
-    // `captureGlobalLayoutOnDrag`'s own gate excludes zoom / half-built layouts.
+    // and must NOT be captured. The `genAgeMs(..., "resize")` guard skips
+    // capture while a resize/heal is in flight — every heal path stamps the
+    // `resize` recency marker (healWorkspaceLayout + the pre-switch/attach
+    // resizes), not just the coalesced hook. `captureGlobalLayoutOnDrag`'s own
+    // gate excludes zoom / half-built layouts.
     const flags = parseOpsFlags(rest)
     const session = flags.session
     if (!session) {
@@ -523,7 +525,7 @@ async function main(): Promise<void> {
     await coalesceLayoutWork(session, "capture", async () => {
       // Re-check AFTER winning the debounce: a resize may have begun during the
       // trailing wait, in which case its heal owns the geometry — not us.
-      if (genAgeMs(session, "heal") < RESIZE_GUARD_MS) return
+      if (genAgeMs(session, "resize") < RESIZE_GUARD_MS) return
       await captureGlobalLayoutOnDrag(session)
     })
     return

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -25,8 +25,8 @@
  *
  * Internal subcommands fired by tmux key bindings inside a task session
  * (not meant for direct use): `new-chattab`, `quick-create`, `quick-task`,
- * `focus-tasks`, `heal-layout`, `tasks`, `ops` — each takes the session/worktree
- * as flags.
+ * `focus-tasks`, `heal-layout`, `capture-layout`, `tasks`, `ops` — each takes
+ * the session/worktree as flags.
  * `hook` is fired by an engine's own hooks inside a worktree to report
  * activity events.
  *
@@ -484,6 +484,12 @@ async function main(): Promise<void> {
     // reflow (the first session is built before any client is attached, so tmux
     // reflows its panes when `attach` lands the real terminal size) and any live
     // terminal resize. No-op for the home/role-less session. Reads `--session`.
+    //
+    // A live resize fires this hook many times in a burst; `coalesceLayoutWork`
+    // trailing-debounces so the burst collapses to ONE heal (no concurrent
+    // `-b` thrash, no per-event tmux round-trip storm). The pre-attach heal in
+    // `prepareWindowForAttach` is a DIRECT call, so the first frame is still
+    // synchronous — the debounce only affects the live-resize hook path.
     const flags = parseOpsFlags(rest)
     const session = flags.session
     if (!session) {
@@ -491,7 +497,35 @@ async function main(): Promise<void> {
       process.exit(2)
     }
     const { healSessionLayout } = await import("../tui/panes/terminal/tmux.ts")
-    await healSessionLayout(session)
+    const { coalesceLayoutWork } = await import("../tui/panes/terminal/layout-coord.ts")
+    await coalesceLayoutWork(session, "heal", () => healSessionLayout(session))
+    return
+  }
+  if (subcommand === "capture-layout") {
+    // `window-layout-changed` tmux hook handler: persist a manual rail /
+    // right-column drag into the shared global the moment it happens, so a
+    // later terminal resize (whose `heal-layout` re-pins to the global) can't
+    // discard a drag the user hadn't yet committed by switching tasks.
+    //
+    // `window-layout-changed` ALSO fires on a terminal-resize reflow (and on
+    // the heal's own `resize-pane`), where the rail is proportionally blown up
+    // and must NOT be captured. The `genAgeMs(..., "heal")` guard skips capture
+    // while a resize is in flight (its `heal-layout` stamped the heal gen);
+    // `captureGlobalLayoutOnDrag`'s own gate excludes zoom / half-built layouts.
+    const flags = parseOpsFlags(rest)
+    const session = flags.session
+    if (!session) {
+      console.error("kobe capture-layout: --session <name> is required")
+      process.exit(2)
+    }
+    const { captureGlobalLayoutOnDrag } = await import("../tui/panes/terminal/tmux.ts")
+    const { coalesceLayoutWork, genAgeMs, RESIZE_GUARD_MS } = await import("../tui/panes/terminal/layout-coord.ts")
+    await coalesceLayoutWork(session, "capture", async () => {
+      // Re-check AFTER winning the debounce: a resize may have begun during the
+      // trailing wait, in which case its heal owns the geometry — not us.
+      if (genAgeMs(session, "heal") < RESIZE_GUARD_MS) return
+      await captureGlobalLayoutOnDrag(session)
+    })
     return
   }
   if (subcommand === "quick-task") {

--- a/packages/kobe/src/tui/panes/terminal/layout-coord.ts
+++ b/packages/kobe/src/tui/panes/terminal/layout-coord.ts
@@ -25,21 +25,30 @@
  *
  * Exactly one firing of a burst survives to do the work (the last one), so
  * there is never a concurrent heal, and the work lands once the geometry has
- * settled. The gen file's timestamp doubles as a "when did the last resize
- * happen" signal that the capture hook reads ({@link genAgeMs}) to keep a
- * terminal-resize reflow from being mis-captured as a manual drag.
+ * settled. A separate `resize` recency stamp (bumped by every heal path) lets
+ * the capture hook read "did a resize/heal just happen" ({@link genAgeMs}) to
+ * keep a terminal-resize reflow from being mis-captured as a manual drag.
  *
  * All fs failures degrade to "proceed" (run the work), i.e. to the
  * pre-coordination always-run behaviour — never to a silent no-op.
  */
 
 import { createHash, randomUUID } from "node:crypto"
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { kobeStateDir } from "@/env"
 
-/** The two coordinated geometry operations, used as the gen-file suffix. */
-export type LayoutCoordKind = "heal" | "capture"
+/**
+ * Gen-file suffixes. `heal` / `capture` are coalesce-nonce protocols (one per
+ * trailing-debounce). `resize` is a pure recency timestamp — stamped by EVERY
+ * heal path (the `healWorkspaceLayout` choke point + the direct pre-switch /
+ * pre-attach resizes), read by the capture guard ({@link genAgeMs}) so a
+ * terminal-resize reflow is never mis-captured as a manual drag. Keeping it a
+ * SEPARATE kind from `heal` is deliberate: the `heal` nonce file is rewritten by
+ * the coalesce protocol, so reusing it for recency would let a re-stamp clobber
+ * an in-flight coalesce decision.
+ */
+export type LayoutCoordKind = "heal" | "capture" | "resize"
 
 /**
  * Trailing-debounce window. A hook firing waits this long for a quieter
@@ -49,7 +58,7 @@ export type LayoutCoordKind = "heal" | "capture"
 export const LAYOUT_COALESCE_MS = 120
 
 /**
- * How long after the last `window-resized` stamp a `window-layout-changed`
+ * How long after the last `resize` recency stamp a `window-layout-changed`
  * capture treats the geometry as "owned by an in-flight resize" and skips.
  * Must exceed {@link LAYOUT_COALESCE_MS} plus a heal's run time so the brief
  * post-settle / pre-heal window (where the rail is still reflow-corrupted) is
@@ -69,12 +78,20 @@ function genPath(session: string, kind: LayoutCoordKind): string {
   return join(coordDir(), `${hash}.${kind}`)
 }
 
-/** Stamp a fresh `<ms>\n<nonce>` into the gen file and return the nonce. */
+/**
+ * Stamp a fresh `<ms>\n<nonce>` into the gen file and return the nonce. Written
+ * atomically (temp + rename) so a concurrent reader — many `kobe` hook
+ * processes write the same file under `-b` — never observes a torn (truncated /
+ * interleaved) file; rename on the same fs is atomic.
+ */
 export function recordGen(session: string, kind: LayoutCoordKind): string {
   const nonce = randomUUID()
   try {
     mkdirSync(coordDir(), { recursive: true })
-    writeFileSync(genPath(session, kind), `${Date.now()}\n${nonce}`)
+    const path = genPath(session, kind)
+    const tmp = `${path}.${nonce}.tmp`
+    writeFileSync(tmp, `${Date.now()}\n${nonce}`)
+    renameSync(tmp, path)
   } catch {
     // fs unavailable → caller still proceeds (isLatestGen degrades to true).
   }

--- a/packages/kobe/src/tui/panes/terminal/layout-coord.ts
+++ b/packages/kobe/src/tui/panes/terminal/layout-coord.ts
@@ -1,0 +1,122 @@
+/**
+ * Coalescing + trailing-debounce coordination for the two tmux geometry
+ * hooks that re-pin / capture a session's layout (`window-resized` →
+ * heal, `window-layout-changed` → capture).
+ *
+ * Why this exists. Both hooks fire as tmux `run-shell -b` commands, so
+ * every event spawns a fresh `kobe` CLI process. During a continuous
+ * terminal drag or rail drag tmux fires the hook many times in a burst.
+ * The pre-coordination heal did its full work (server-option read +
+ * `list-panes` + a `resize-pane` sequence — several tmux round-trips) on
+ * EVERY one of those processes, and `-b` let them run concurrently and
+ * thrash each other. The cold `bun` start per hook firing is unavoidable
+ * (tmux hooks can only run a shell command), but the heavy work and the
+ * concurrency are not: a file-based generation marker lets a burst of N
+ * firings collapse to ONE actual heal/capture, run AFTER the burst settles.
+ *
+ * The mechanism is a trailing debounce with no lock:
+ *
+ *   1. Each firing stamps a fresh nonce (+ wall-clock ms) into a per-session
+ *      gen file and remembers its own nonce.
+ *   2. It sleeps `debounceMs`.
+ *   3. It re-reads the gen file. If the nonce changed, a LATER firing
+ *      superseded it → it bails and does no work. If the nonce is still its
+ *      own, it was the last firing of the burst → it runs the work once.
+ *
+ * Exactly one firing of a burst survives to do the work (the last one), so
+ * there is never a concurrent heal, and the work lands once the geometry has
+ * settled. The gen file's timestamp doubles as a "when did the last resize
+ * happen" signal that the capture hook reads ({@link genAgeMs}) to keep a
+ * terminal-resize reflow from being mis-captured as a manual drag.
+ *
+ * All fs failures degrade to "proceed" (run the work), i.e. to the
+ * pre-coordination always-run behaviour — never to a silent no-op.
+ */
+
+import { createHash, randomUUID } from "node:crypto"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { kobeStateDir } from "@/env"
+
+/** The two coordinated geometry operations, used as the gen-file suffix. */
+export type LayoutCoordKind = "heal" | "capture"
+
+/**
+ * Trailing-debounce window. A hook firing waits this long for a quieter
+ * firing to supersede it before doing work — long enough to swallow a drag's
+ * event burst, short enough that the settle feels immediate.
+ */
+export const LAYOUT_COALESCE_MS = 120
+
+/**
+ * How long after the last `window-resized` stamp a `window-layout-changed`
+ * capture treats the geometry as "owned by an in-flight resize" and skips.
+ * Must exceed {@link LAYOUT_COALESCE_MS} plus a heal's run time so the brief
+ * post-settle / pre-heal window (where the rail is still reflow-corrupted) is
+ * covered; after it, the heal has re-pinned to the global, so a late capture
+ * would only re-capture the global (a no-op) anyway.
+ */
+export const RESIZE_GUARD_MS = 400
+
+/** `<home>/.kobe/layout-coord/` — gen files live here, cleaned by `kobe reset`. */
+function coordDir(): string {
+  return join(kobeStateDir(), "layout-coord")
+}
+
+/** Per-session, per-kind gen file. Session name is hashed so it is path-safe. */
+function genPath(session: string, kind: LayoutCoordKind): string {
+  const hash = createHash("sha1").update(session).digest("hex").slice(0, 16)
+  return join(coordDir(), `${hash}.${kind}`)
+}
+
+/** Stamp a fresh `<ms>\n<nonce>` into the gen file and return the nonce. */
+export function recordGen(session: string, kind: LayoutCoordKind): string {
+  const nonce = randomUUID()
+  try {
+    mkdirSync(coordDir(), { recursive: true })
+    writeFileSync(genPath(session, kind), `${Date.now()}\n${nonce}`)
+  } catch {
+    // fs unavailable → caller still proceeds (isLatestGen degrades to true).
+  }
+  return nonce
+}
+
+/**
+ * True when `nonce` is still the latest stamp (no later firing superseded
+ * this one). Unreadable gen file → `true` (proceed): a duplicate heal is
+ * idempotent, a skipped one is not.
+ */
+export function isLatestGen(session: string, kind: LayoutCoordKind, nonce: string): boolean {
+  try {
+    return readFileSync(genPath(session, kind), "utf8").split("\n")[1]?.trim() === nonce
+  } catch {
+    return true
+  }
+}
+
+/** ms since the last stamp of `kind` (`Infinity` if never stamped / unreadable). */
+export function genAgeMs(session: string, kind: LayoutCoordKind, now: number = Date.now()): number {
+  try {
+    const ts = Number.parseInt(readFileSync(genPath(session, kind), "utf8").split("\n")[0] ?? "", 10)
+    return Number.isFinite(ts) ? now - ts : Number.POSITIVE_INFINITY
+  } catch {
+    return Number.POSITIVE_INFINITY
+  }
+}
+
+/**
+ * Run `work` only if this firing is the last of its burst (trailing debounce).
+ * Stamps the gen, waits `debounceMs`, and runs `work` once iff no later firing
+ * stamped over it. `debounceMs <= 0` skips the wait (test seam).
+ */
+export async function coalesceLayoutWork(
+  session: string,
+  kind: LayoutCoordKind,
+  work: () => Promise<void>,
+  debounceMs: number = LAYOUT_COALESCE_MS,
+): Promise<void> {
+  const nonce = recordGen(session, kind)
+  if (debounceMs > 0) await new Promise((resolve) => setTimeout(resolve, debounceMs))
+  if (!isLatestGen(session, kind, nonce)) return
+  await work()
+}

--- a/packages/kobe/src/tui/panes/terminal/pane-heal.ts
+++ b/packages/kobe/src/tui/panes/terminal/pane-heal.ts
@@ -435,6 +435,57 @@ export async function captureGlobalLayout(session: string): Promise<void> {
 }
 
 /**
+ * Decide whether a `window-layout-changed` firing is a genuine USER drag we
+ * should capture, from a `#{@kobe_role}\t#{window_zoomed_flag}` listing of the
+ * active window. Pure so the gate is unit-testable without a tmux server.
+ *
+ * Capture only when the layout change is safe to read as the user's intended
+ * geometry:
+ *   - NOT zoomed — a zoomed pane reports the full-window grid, so the rail /
+ *     right-column widths read back as garbage; capturing them would poison
+ *     the global until the next real drag.
+ *   - the full kobe role set is present (`tasks` + `ops`) — excludes the
+ *     transient half-built layouts that pane splits emit during a session
+ *     build / respawn, where the geometry isn't the user's to keep.
+ *
+ * The resize-reflow case (where the rail is proportionally blown up and must
+ * NOT be captured) is excluded earlier by the caller's resize-recency guard
+ * ({@link genAgeMs}); this gate only covers what a stable-size layout change
+ * can still get wrong.
+ */
+export function shouldCaptureDrag(stdout: string): boolean {
+  const rows = stdout
+    .split("\n")
+    .map((line) => line.split("\t"))
+    .filter((cols) => (cols[0]?.trim() ?? "") !== "")
+  if (rows.length === 0) return false
+  if (rows.some((cols) => cols[1]?.trim() === "1")) return false // any pane zoomed
+  const roles = new Set(rows.map((cols) => cols[0]?.trim()))
+  return roles.has("tasks") && roles.has("ops")
+}
+
+/**
+ * Capture the active window's geometry as the new global layout ONLY when the
+ * `window-layout-changed` that triggered us is a genuine user drag — see
+ * {@link shouldCaptureDrag}. This is the live counterpart to the switch-away
+ * {@link captureGlobalLayout}: it persists a rail / right-column drag the
+ * MOMENT it happens, so a later terminal resize (whose `window-resized` heal
+ * re-pins every pane to the global) can't silently discard a drag the user
+ * made but hadn't yet "committed" by switching tasks.
+ */
+export async function captureGlobalLayoutOnDrag(session: string): Promise<void> {
+  const { code, stdout } = await runTmuxCapturing([
+    "list-panes",
+    "-t",
+    `=${session}`,
+    "-F",
+    "#{@kobe_role}\t#{window_zoomed_flag}",
+  ])
+  if (code !== 0 || !shouldCaptureDrag(stdout)) return
+  await captureGlobalLayout(session)
+}
+
+/**
  * Settings changes are read by each kobe-owned pane process at startup.
  * After the full-window Settings page exits, the existing Tasks/Ops panes
  * in sibling ChatTabs are still alive, so respawn only those helper panes

--- a/packages/kobe/src/tui/panes/terminal/pane-heal.ts
+++ b/packages/kobe/src/tui/panes/terminal/pane-heal.ts
@@ -55,6 +55,7 @@ import {
 import { applyTmuxPaneBorderTheme } from "@/tui/lib/tmux-border-theme"
 import { CURRENT_VERSION } from "@/version"
 import { inheritedEnvPrefix, wrapEngineLaunch } from "./launch"
+import { recordGen } from "./layout-coord"
 
 /** Pane user-option tagging which kobe version spawned a kobe-owned pane. */
 export const PANE_VERSION_OPTION = "@kobe_pane_version"
@@ -337,6 +338,12 @@ export async function healWorkspaceLayout(
   session: string,
   versions?: { cwd: string; taskId: string | undefined; vendor: string | undefined; vendorChanged?: boolean },
 ): Promise<void> {
+  // Stamp the `resize` recency marker before this heal's `resize-pane` fires
+  // `window-layout-changed`: the capture hook's guard (genAgeMs(session,
+  // "resize")) then sees a fresh stamp and skips, so a reflow this heal is
+  // fixing is never mis-captured as a manual drag. This is the single choke
+  // point every heal path funnels through (hook, reuse, pre-switch/attach).
+  recordGen(session, "resize")
   const { tasksWidth, rcArgs } = await globalLayoutPrefs()
   const rows = await listKobePanes(session)
   if (!rows) return

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -86,6 +86,7 @@ import {
   kobeStatusRight,
 } from "./chattab"
 import { REMOTE_KEY_OPTION, inheritedEnvPrefix, wrapEngineLaunch } from "./launch"
+import { recordGen } from "./layout-coord"
 import { healWorkspaceLayout, relaunchEngineInAllWindows } from "./pane-heal"
 
 // Re-export the shared identity/lifecycle helpers so existing importers
@@ -157,6 +158,10 @@ function positiveInt(value: unknown): number | undefined {
  * when the terminal dimensions are unknown (degrades to today's behaviour).
  */
 export async function prepareWindowForAttach(session: string): Promise<void> {
+  // Stamp `resize` BEFORE the resize-window so a `window-layout-changed` capture
+  // it triggers skips this in-flight resize (healWorkspaceLayout re-stamps too;
+  // this closes the gap before that runs). See healWorkspaceLayout / layout-coord.
+  recordGen(session, "resize")
   const sizeArgs = tmuxInitialSizeArgs()
   if (sizeArgs.length > 0) await runTmux(["resize-window", "-t", `=${session}`, ...sizeArgs])
   await healWorkspaceLayout(session)
@@ -201,6 +206,10 @@ async function attachedWindowSizeArgs(): Promise<string[]> {
  * on screen — makes the switch cause NO reflow. No-op size when not in tmux.
  */
 export async function prepareWindowForSwitch(session: string): Promise<void> {
+  // Stamp `resize` BEFORE the resize-window so a `window-layout-changed` capture
+  // it triggers skips this in-flight resize (healWorkspaceLayout re-stamps too;
+  // this closes the gap before that runs). See healWorkspaceLayout / layout-coord.
+  recordGen(session, "resize")
   const sizeArgs = await attachedWindowSizeArgs()
   if (sizeArgs.length > 0) await runTmux(["resize-window", "-t", `=${session}`, ...sizeArgs])
   await healWorkspaceLayout(session)

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -123,6 +123,7 @@ export {
 export {
   PANE_VERSION_OPTION,
   captureGlobalLayout,
+  captureGlobalLayoutOnDrag,
   healSessionLayout,
   refreshKobeWorkspacePanes,
 } from "./pane-heal"
@@ -157,6 +158,50 @@ function positiveInt(value: unknown): number | undefined {
  */
 export async function prepareWindowForAttach(session: string): Promise<void> {
   const sizeArgs = tmuxInitialSizeArgs()
+  if (sizeArgs.length > 0) await runTmux(["resize-window", "-t", `=${session}`, ...sizeArgs])
+  await healWorkspaceLayout(session)
+}
+
+/**
+ * Width/height args for the tmux client THIS process is attached inside, read
+ * from the current window's CONTENT size (`window_width`/`window_height` —
+ * already net of the status bar). The in-tmux counterpart to
+ * {@link tmuxInitialSizeArgs}: a pane host (the Tasks pane, the quick-task
+ * window) has its `process.stdout` sized to its OWN narrow pane, so stdout
+ * would fit the target window to the wrong (pane) size. The attached client's
+ * window dims are exactly the size tmux gives the target window when this same
+ * client `switch-client`s to it. Empty when not inside tmux / size unreadable.
+ */
+async function attachedWindowSizeArgs(): Promise<string[]> {
+  const { code, stdout } = await runTmuxCapturing(["display-message", "-p", "#{window_width}\t#{window_height}"])
+  if (code !== 0) return []
+  const [w, h] = stdout
+    .trim()
+    .split("\t")
+    .map((s) => Number.parseInt(s, 10))
+  return Number.isInteger(w) && w > 0 && Number.isInteger(h) && h > 0 ? ["-x", `${w}`, "-y", `${h}`] : []
+}
+
+/**
+ * Fit + heal a session's window to the CURRENTLY ATTACHED client BEFORE a
+ * `switch-client` lands on it — the switch counterpart to
+ * {@link prepareWindowForAttach}.
+ *
+ * `prepareWindowForAttach` fits to `process.stdout`, correct when attaching
+ * from OUTSIDE tmux (stdout is the real terminal — `direct.ts`). The Tasks-pane
+ * "open task" path is different: it runs INSIDE a tmux pane, so `process.stdout`
+ * is the host pane's narrow pty, and it never fit/healed the target at all
+ * before switching. The target session — built detached at that wrong pane size
+ * (its `new-session -x/-y` also read the narrow stdout), or sitting at a stale
+ * size — then reflows PROPORTIONALLY the instant the full-terminal client
+ * switches to it: the absolute Tasks rail blows up and the `window-resized` hook
+ * only snaps it back a beat later. That snap is the visible "first open jumps
+ * from a default size to the aligned size". Sizing the window to the attached
+ * client's dims and healing here — while the target is still detached, nothing
+ * on screen — makes the switch cause NO reflow. No-op size when not in tmux.
+ */
+export async function prepareWindowForSwitch(session: string): Promise<void> {
+  const sizeArgs = await attachedWindowSizeArgs()
   if (sizeArgs.length > 0) await runTmux(["resize-window", "-t", `=${session}`, ...sizeArgs])
   await healWorkspaceLayout(session)
 }
@@ -562,6 +607,17 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
   // can't re-trigger the hook. `heal-layout` is a no-op for role-less sessions.
   const healLayoutCommand = `${envStr}${invStr} heal-layout --session '#{session_name}'`
   const healLayoutTmuxCommand = `run-shell -b ${shellQuote(healLayoutCommand)}`
+  // Capture a manual rail / right-column drag the moment it happens, on
+  // `window-layout-changed` (which fires on a pane resize, unlike
+  // `window-resized`). Without this, a drag was only persisted into the global
+  // on switch-away, so dragging the rail and THEN resizing the terminal lost
+  // the drag — the resize's `window-resized` heal re-pinned every pane to the
+  // STALE global before the drag was ever captured. `capture-layout` is gated
+  // (resize-recency + not-zoomed + full role set) so it captures only genuine
+  // drags, never a resize reflow or a half-built layout. Both hooks coalesce
+  // their event bursts to one run (see layout-coord.ts).
+  const captureLayoutCommand = `${envStr}${invStr} capture-layout --session '#{session_name}'`
+  const captureLayoutTmuxCommand = `run-shell -b ${shellQuote(captureLayoutCommand)}`
   // `<prefix> f` = quick-create: open the prompt-only quick-task page (the
   // v0.5 quick-fork chord, KOB-74, reborn in the tmux world). `kobe
   // quick-create` opens `kobe quick-task` in its own window, which asks for
@@ -630,6 +686,7 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     ],
     ["set-option", "-g", "mouse", "on"],
     ["set-hook", "-g", "window-resized", healLayoutTmuxCommand],
+    ["set-hook", "-g", "window-layout-changed", captureLayoutTmuxCommand],
     ...unbinds,
     // Two-stage: on the Tasks pane → detach (the old exit); anywhere else →
     // focus the current window's Tasks pane first. `#{@kobe_role}` is the

--- a/packages/kobe/src/tui/quick-task/host.tsx
+++ b/packages/kobe/src/tui/quick-task/host.tsx
@@ -146,6 +146,11 @@ async function deliverFirstPromptToTask(
 async function jumpToTask(orch: RemoteOrchestrator, task: Task, repo: string, vendor: VendorId): Promise<void> {
   await ensureTaskSession(orch, task, repo, vendor) // no-op if deliver already built it
   await orch.setActiveTask(task.id).catch(() => {})
+  // Fit + heal the target to THIS client before switching in, so it doesn't
+  // reflow on screen — the quick-task window's stdout is its own pane, not the
+  // full terminal (see prepareWindowForSwitch).
+  const { prepareWindowForSwitch } = await import("../panes/terminal/tmux.ts")
+  await prepareWindowForSwitch(tmuxSessionName(task.id))
   await runTmux(["switch-client", "-t", `=${tmuxSessionName(task.id)}`])
 }
 

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -92,6 +92,7 @@ import {
   openNewTaskTab,
   openSettingsTab,
   openUpdateTab,
+  prepareWindowForSwitch,
   refreshKobeWorkspacePanes,
 } from "../panes/terminal/tmux.ts"
 import { useDialog } from "../ui/dialog"
@@ -551,6 +552,10 @@ function TasksShell(props: {
           initPrompt: init.initPrompt,
         })
       }
+      // Fit + heal the target to THIS client before switching in, so it doesn't
+      // reflow on screen (see prepareWindowForSwitch — this is the in-tmux
+      // counterpart to direct.ts's pre-attach fit).
+      await prepareWindowForSwitch(name)
       await runTmux(["switch-client", "-t", `=${name}`])
       void props.orch?.setActiveTask(id).catch(() => {})
       return
@@ -593,6 +598,10 @@ function TasksShell(props: {
       notifyError("Couldn't start this task's session")
       return
     }
+    // Fit + heal to THIS client before switching in (see prepareWindowForSwitch):
+    // the session was just built detached at the host pane's narrow stdout size,
+    // so without this the full-terminal switch reflows it on screen.
+    await prepareWindowForSwitch(name)
     await runTmux(["switch-client", "-t", `=${name}`])
     void props.orch?.setActiveTask(id).catch(() => {})
   }

--- a/packages/kobe/test/tui/layout-coord.test.ts
+++ b/packages/kobe/test/tui/layout-coord.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the geometry-hook coordination primitives
+ * (`src/tui/panes/terminal/layout-coord.ts`) and the drag gate
+ * (`pane-heal.ts` `shouldCaptureDrag`).
+ *
+ * These guard the two behaviours the live hooks depend on:
+ *   - a burst of `window-resized` / `window-layout-changed` firings collapses
+ *     to ONE run (trailing debounce, last firing wins);
+ *   - a `window-layout-changed` is captured as a drag only when it is safe to
+ *     (not zoomed, full role set) — the resize-recency half is the caller's.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { shouldCaptureDrag } from "../../src/tui/panes/terminal/pane-heal"
+
+let home: string
+let prevHome: string | undefined
+
+beforeEach(() => {
+  prevHome = process.env.KOBE_HOME_DIR
+  home = mkdtempSync(join(tmpdir(), "kobe-coord-"))
+  process.env.KOBE_HOME_DIR = home
+})
+
+afterEach(() => {
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = prevHome
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe("recordGen / isLatestGen", () => {
+  test("a fresh stamp supersedes an earlier one for the same session+kind", async () => {
+    const { recordGen, isLatestGen } = await import("../../src/tui/panes/terminal/layout-coord")
+    const first = recordGen("kobe-a", "heal")
+    expect(isLatestGen("kobe-a", "heal", first)).toBe(true)
+    const second = recordGen("kobe-a", "heal")
+    expect(isLatestGen("kobe-a", "heal", first)).toBe(false) // first superseded
+    expect(isLatestGen("kobe-a", "heal", second)).toBe(true)
+  })
+
+  test("session and kind are isolated", async () => {
+    const { recordGen, isLatestGen } = await import("../../src/tui/panes/terminal/layout-coord")
+    const a = recordGen("kobe-a", "heal")
+    recordGen("kobe-b", "heal") // different session
+    recordGen("kobe-a", "capture") // different kind
+    expect(isLatestGen("kobe-a", "heal", a)).toBe(true)
+  })
+
+  test("never-stamped nonce reads as latest (degrade to proceed)", async () => {
+    const { isLatestGen } = await import("../../src/tui/panes/terminal/layout-coord")
+    expect(isLatestGen("kobe-missing", "heal", "whatever")).toBe(true)
+  })
+})
+
+describe("genAgeMs", () => {
+  test("is small right after a stamp and Infinity when never stamped", async () => {
+    const { recordGen, genAgeMs } = await import("../../src/tui/panes/terminal/layout-coord")
+    expect(genAgeMs("kobe-x", "heal")).toBe(Number.POSITIVE_INFINITY)
+    recordGen("kobe-x", "heal")
+    expect(genAgeMs("kobe-x", "heal")).toBeLessThan(1000)
+  })
+
+  test("reports the elapsed time against an injected clock", async () => {
+    const { recordGen, genAgeMs } = await import("../../src/tui/panes/terminal/layout-coord")
+    recordGen("kobe-x", "heal")
+    const age = genAgeMs("kobe-x", "heal", Date.now() + 5000)
+    expect(age).toBeGreaterThanOrEqual(5000)
+    expect(age).toBeLessThan(6000)
+  })
+})
+
+describe("coalesceLayoutWork", () => {
+  test("runs the work when no later firing supersedes it", async () => {
+    const { coalesceLayoutWork } = await import("../../src/tui/panes/terminal/layout-coord")
+    let ran = 0
+    await coalesceLayoutWork(
+      "kobe-s",
+      "heal",
+      async () => {
+        ran++
+      },
+      0,
+    )
+    expect(ran).toBe(1)
+  })
+
+  test("a superseded firing does no work (trailing debounce)", async () => {
+    const { coalesceLayoutWork, recordGen } = await import("../../src/tui/panes/terminal/layout-coord")
+    let ran = 0
+    // Start a firing with a real debounce window, then supersede it mid-wait.
+    const inflight = coalesceLayoutWork(
+      "kobe-s",
+      "heal",
+      async () => {
+        ran++
+      },
+      40,
+    )
+    recordGen("kobe-s", "heal") // a later firing stamps over the inflight one
+    await inflight
+    expect(ran).toBe(0)
+  })
+})
+
+describe("shouldCaptureDrag", () => {
+  test("captures a stable drag with the full role set, no zoom", () => {
+    expect(shouldCaptureDrag("tasks\t0\nclaude\t0\nops\t0\nshell\t0\n")).toBe(true)
+  })
+
+  test("skips when any pane is zoomed (geometry reads as garbage)", () => {
+    expect(shouldCaptureDrag("tasks\t0\nclaude\t1\nops\t0\nshell\t0\n")).toBe(false)
+  })
+
+  test("skips a half-built layout missing a role (no ops yet)", () => {
+    expect(shouldCaptureDrag("tasks\t0\nclaude\t0\n")).toBe(false)
+  })
+
+  test("skips an empty / role-less listing", () => {
+    expect(shouldCaptureDrag("")).toBe(false)
+    expect(shouldCaptureDrag("\t0\n\t0\n")).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Three related workspace-layout fixes for the tmux-native TUI.

### 1. First-open layout jump (the main fix)
Opening a task from the Tasks list ran `ensureSession` + `switch-client` with **no pre-switch fit/heal**. The Tasks-pane host runs *inside* a narrow tmux pane, so its `process.stdout` sized the detached window wrong (≈ the pane width / a default), and the full-terminal `switch-client` then reflowed every pane on screen — the absolute Tasks rail blew up and the `window-resized` hook only snapped it back a beat later. That snap is the visible "first open jumps from a default size to the aligned size".

Fix: add `prepareWindowForSwitch(session)` — the in-tmux counterpart to `direct.ts`'s `prepareWindowForAttach`. It fits the target window to the **attached client's** dims (`display-message #{window_width}/#{window_height}`, not the host pane's stdout) and heals, **while the target is still detached**, so the switch causes no reflow. Wired into both Tasks-pane switch branches and the quick-task jump.

### 2. Manual pane drags no longer lost
A rail / right-column drag was only persisted into the global on switch-away, so dragging then resizing the terminal discarded it (the resize's heal re-pinned to the stale global first). Added a `window-layout-changed` → `capture-layout` hook that captures a genuine drag live, gated by resize-recency + not-zoomed + full role set so a resize reflow / half-built layout never poisons the global.

### 3. Resize heal coalesced
The `window-resized` heal fired a fresh `kobe` process per event with no debounce, thrashing under `-b` during a drag-resize. New `layout-coord.ts` gen-file **trailing debounce** collapses a burst to one heal. (Kept in the CLI, not the daemon — the hook spawns a process either way, so the daemon buys no cold-start saving; documented inline.)

## Test
- `bun run typecheck` clean; `bun run test:fast` 907 passing (incl. new `test/tui/layout-coord.test.ts`).
- Live-verified by hand: first open from the Tasks list no longer jumps.

## Notes
- `prepareWindowForAttach` (the `direct.ts` first-launch path) is unchanged.
- The new `window-layout-changed` hook fires often; its three gates are the main thing to watch — a regression would show as the rail width drifting to a wrong value that persists across tasks (it's a server-scoped option).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace layout flashing when opening tasks from the Tasks list.
  * Improved task/session switching with a “fit + heal” step to prevent screen reflow.
  * Manual pane adjustments are now preserved across terminal resizes.
  * Layout capture during manual drag is now more reliable, reducing layout thrash during rapid resize events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->