### PR TITLE
feat: tui — `n` new-task auto-enters the created task

### DIFF
--- a/.changeset/new-task-auto-enter.md
+++ b/.changeset/new-task-auto-enter.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Creating a task with `n` now drops you straight into the new task's engine pane, ready to type the first prompt — instead of just landing the cursor on it in the Tasks list. The full new-task flow now mirrors the prompt-first `f` quick-create's jump on both surfaces (the dedicated `kobe new-task` tab and the in-pane overlay), and the repo's `init-prompt.md` fires as the engine's first message just as it does on a normal enter. Adopting existing worktrees enters the last one. The proven "build session + switch-client" jump is now a shared helper reused by quick-task, new-task, and the Tasks pane.

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -146,6 +146,14 @@ export interface CreateTaskContext extends TaskActionContext {
   readonly openCreateSurface?: (defaultRepo: string) => Promise<boolean>
   /** Land the host's cursor/selection on the created (or last adopted) task. */
   readonly selectTask?: (id: string) => void
+  /**
+   * Enter (switch into) the created (or last adopted) task right after
+   * creation — so `n` drops the user in the engine pane ready to type the
+   * first prompt, instead of just landing the cursor. The Tasks pane wires
+   * this to its `switchTo`; the chattab surface does its own jump and never
+   * reaches here.
+   */
+  readonly enterTask?: (id: string) => void | Promise<void>
 }
 
 export function nextActiveTask(tasks: readonly Task[], excludeId: string): Task | undefined {
@@ -461,6 +469,11 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     return
   }
   await ctx.reload?.()
-  // Land the cursor on the new task so Enter / click enters it next.
-  if (createdId) ctx.selectTask?.(createdId)
+  // Land the cursor on the new task, then enter it — `n` should drop the user
+  // straight into the engine pane ready to type, not just move the selection.
+  // (Hosts without `enterTask` fall back to cursor-only.)
+  if (createdId) {
+    ctx.selectTask?.(createdId)
+    await ctx.enterTask?.(createdId)
+  }
 }

--- a/packages/kobe/src/tui/lib/task-enter.ts
+++ b/packages/kobe/src/tui/lib/task-enter.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared "build a fresh task's session + jump the attached client into it"
+ * helpers. Extracted from the quick-task page so the full `n` new-task flow
+ * can auto-enter the task it just created (drop the user in the engine pane,
+ * ready to type the first prompt) without duplicating the proven jump.
+ *
+ * Two consumers, two prompt policies:
+ *   - quick-task (`f`): the user typed a prompt, so it builds with the init
+ *     SCRIPT only and delivers the typed prompt itself — `includeInitPrompt`
+ *     stays false so the repo's init-prompt isn't ALSO pasted.
+ *   - new-task (`n`): no typed prompt, so it builds with `includeInitPrompt`
+ *     true and lets the repo's init-prompt fire as the engine's first message
+ *     (the same fire-and-forget delivery `ensureSession`'s create path runs).
+ */
+
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
+import { interactiveEngineCommand } from "../../engine/interactive-command.ts"
+import { runTmux, sessionExists, tmuxSessionName } from "../../tmux/client.ts"
+import type { Task, VendorId } from "../../types/task.ts"
+
+/**
+ * Ensure the task's tmux session exists, building it on demand. Mirrors `kobe
+ * api add`'s deliver path: ensure the worktree, then build the session. Pass
+ * `includeInitPrompt` to let the repo's init-prompt fire as the engine's first
+ * message; omit it when the caller delivers its own first prompt. Returns true
+ * when the session already existed (no build), false when freshly built.
+ */
+export async function ensureTaskSession(
+  orch: RemoteOrchestrator,
+  task: Task,
+  repo: string,
+  vendor: VendorId,
+  opts: { includeInitPrompt?: boolean } = {},
+): Promise<boolean> {
+  const session = tmuxSessionName(task.id)
+  if (await sessionExists(session)) return true
+  let worktree = task.worktreePath
+  if (!worktree) worktree = await orch.ensureWorktree(task.id)
+  if (!worktree) throw new Error(`task ${task.id} has no worktree`)
+  const { ensureSession } = await import("../panes/terminal/tmux.ts")
+  const { resolveRepoInit } = await import("../../state/repo-init.ts")
+  const init = resolveRepoInit(repo, worktree)
+  const ok = await ensureSession({
+    name: session,
+    cwd: worktree,
+    command: interactiveEngineCommand(vendor),
+    taskId: task.id,
+    vendor,
+    repo,
+    initScript: init.initScript,
+    initPrompt: opts.includeInitPrompt ? init.initPrompt : undefined,
+  })
+  if (!ok) throw new Error(`failed to start tmux session for ${task.id}`)
+  return false // freshly built
+}
+
+/**
+ * Jump the attached client to the task: mark it active and `switch-client` to
+ * its tmux session (building the session first if a caller hasn't already).
+ * The calling page then exits; the client is already on the new task's
+ * session, so closing the old window doesn't disturb it.
+ */
+export async function jumpToTask(orch: RemoteOrchestrator, task: Task, repo: string, vendor: VendorId): Promise<void> {
+  await ensureTaskSession(orch, task, repo, vendor) // no-op if already built
+  await orch.setActiveTask(task.id).catch(() => {})
+  // Fit + heal the target to THIS client before switching in, so it doesn't
+  // reflow on screen — the calling window's stdout is its own pane, not the
+  // full terminal (see prepareWindowForSwitch).
+  const { prepareWindowForSwitch } = await import("../panes/terminal/tmux.ts")
+  await prepareWindowForSwitch(tmuxSessionName(task.id))
+  await runTmux(["switch-client", "-t", `=${tmuxSessionName(task.id)}`])
+}

--- a/packages/kobe/src/tui/lib/task-enter.ts
+++ b/packages/kobe/src/tui/lib/task-enter.ts
@@ -4,13 +4,15 @@
  * can auto-enter the task it just created (drop the user in the engine pane,
  * ready to type the first prompt) without duplicating the proven jump.
  *
- * Two consumers, two prompt policies:
- *   - quick-task (`f`): the user typed a prompt, so it builds with the init
- *     SCRIPT only and delivers the typed prompt itself — `includeInitPrompt`
- *     stays false so the repo's init-prompt isn't ALSO pasted.
- *   - new-task (`n`): no typed prompt, so it builds with `includeInitPrompt`
- *     true and lets the repo's init-prompt fire as the engine's first message
- *     (the same fire-and-forget delivery `ensureSession`'s create path runs).
+ * `includeInitPrompt` controls whether the repo's init-prompt fires as the
+ * engine's first message on a freshly-built session:
+ *   - quick-task (`f`): false — the user typed a prompt, delivered separately,
+ *     so the repo's init-prompt isn't ALSO pasted.
+ *   - new-task create (`n`): true — no typed prompt, so let the repo's
+ *     init-prompt fire (the same fire-and-forget `ensureSession`'s create path
+ *     runs).
+ *   - new-task adopt: false — an adopted worktree is existing work being
+ *     imported, not a fresh start, so don't paste a first-run prompt into it.
  */
 
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
@@ -56,12 +58,21 @@ export async function ensureTaskSession(
 
 /**
  * Jump the attached client to the task: mark it active and `switch-client` to
- * its tmux session (building the session first if a caller hasn't already).
- * The calling page then exits; the client is already on the new task's
- * session, so closing the old window doesn't disturb it.
+ * its tmux session, building the session first if a caller hasn't already.
+ * Pass `includeInitPrompt` through to that build for the common case where the
+ * caller hasn't pre-built the session (e.g. `n` new-task); when the session
+ * already exists (quick-task pre-built it to deliver a typed prompt) the option
+ * is a harmless no-op. The calling page then exits; the client is already on
+ * the new task's session, so closing the old window doesn't disturb it.
  */
-export async function jumpToTask(orch: RemoteOrchestrator, task: Task, repo: string, vendor: VendorId): Promise<void> {
-  await ensureTaskSession(orch, task, repo, vendor) // no-op if already built
+export async function jumpToTask(
+  orch: RemoteOrchestrator,
+  task: Task,
+  repo: string,
+  vendor: VendorId,
+  opts: { includeInitPrompt?: boolean } = {},
+): Promise<void> {
+  await ensureTaskSession(orch, task, repo, vendor, opts) // builds if needed; no-op if already built
   await orch.setActiveTask(task.id).catch(() => {})
   // Fit + heal the target to THIS client before switching in, so it doesn't
   // reflow on screen — the calling window's stdout is its own pane, not the

--- a/packages/kobe/src/tui/new-task/host.tsx
+++ b/packages/kobe/src/tui/new-task/host.tsx
@@ -11,11 +11,13 @@
  *
  * Unlike the overlay — which resolves a result the Tasks pane then acts
  * on — this page is its own process, so it performs the create / adopt
- * against its own daemon connection and then exits. tmux closes the
- * window and returns to the previous tab; the new task shows up in every
- * Tasks pane via the daemon subscribe. The create/adopt branch mirrors
- * the Tasks pane's `createTask` exactly so the two surfaces stay in
- * lockstep.
+ * against its own daemon connection, then JUMPS the attached client into
+ * the new (or last-adopted) task — building its session so the user lands
+ * in the engine pane ready to type the first prompt — and exits. tmux
+ * closes this window; the client is already on the new task's session. The
+ * new task also shows up in every Tasks pane via the daemon subscribe. The
+ * create/adopt + auto-enter branch mirrors the Tasks pane's `createTask`
+ * (and `quick-task`'s jump) so the surfaces stay in lockstep.
  */
 
 import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
@@ -23,10 +25,11 @@ import { onMount } from "solid-js"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { availableEngineIds } from "../../engine/account-detect.ts"
 import { addSavedRepo, getPersistedString, getSavedRepos, setPersistedString } from "../../state/repos.ts"
-import { DEFAULT_TASK_VENDOR, type VendorId } from "../../types/task.ts"
+import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import { NewTaskDialog } from "../component/new-task-dialog"
 import { useTheme } from "../context/theme"
 import { bootPaneHost } from "../lib/host-boot"
+import { ensureTaskSession, jumpToTask } from "../lib/task-enter.ts"
 import { useDialog } from "../ui/dialog"
 
 export interface NewTaskHostArgs {
@@ -70,10 +73,13 @@ export function NewTaskPage(props: NewTaskHostArgs & { orchestrator: RemoteOrche
       process.exit(1)
     }
 
+    let entered: Task | undefined
     try {
       if (result.mode === "adopt") {
+        // Adopt one or more existing worktrees; enter the LAST one (mirrors the
+        // Tasks pane's "focus the last adopted" — KOB-256).
         for (const w of result.adopt) {
-          await orch.adoptWorktree({
+          entered = await orch.adoptWorktree({
             repo: result.repo,
             worktreePath: w.worktreePath,
             branch: w.branch,
@@ -81,7 +87,7 @@ export function NewTaskPage(props: NewTaskHostArgs & { orchestrator: RemoteOrche
           })
         }
       } else {
-        await orch.createTask({
+        entered = await orch.createTask({
           repo: result.repo,
           baseRef: result.baseRef,
           vendor: result.vendor,
@@ -90,6 +96,22 @@ export function NewTaskPage(props: NewTaskHostArgs & { orchestrator: RemoteOrche
     } catch (err) {
       console.error("[kobe new-task] task.create/adopt failed:", err)
       process.exit(1)
+    }
+
+    // Auto-enter the new (or last-adopted) task: build its session — letting
+    // the repo's init-prompt fire as the engine's first message — and jump the
+    // attached client into it, landing the user in the engine pane ready to
+    // type. Then exit; the client is already on the new session, so closing
+    // this window doesn't disturb it. Non-fatal: the task is already created,
+    // so a jump failure (e.g. run outside a kobe tmux session) still exits 0 —
+    // the user can enter it from any Tasks pane.
+    if (entered) {
+      try {
+        await ensureTaskSession(orch, entered, result.repo, result.vendor, { includeInitPrompt: true })
+        await jumpToTask(orch, entered, result.repo, result.vendor)
+      } catch (err) {
+        console.error("[kobe new-task] auto-enter failed:", err)
+      }
     }
     process.exit(0)
   }

--- a/packages/kobe/src/tui/new-task/host.tsx
+++ b/packages/kobe/src/tui/new-task/host.tsx
@@ -29,7 +29,7 @@ import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.
 import { NewTaskDialog } from "../component/new-task-dialog"
 import { useTheme } from "../context/theme"
 import { bootPaneHost } from "../lib/host-boot"
-import { ensureTaskSession, jumpToTask } from "../lib/task-enter.ts"
+import { jumpToTask } from "../lib/task-enter.ts"
 import { useDialog } from "../ui/dialog"
 
 export interface NewTaskHostArgs {
@@ -98,17 +98,19 @@ export function NewTaskPage(props: NewTaskHostArgs & { orchestrator: RemoteOrche
       process.exit(1)
     }
 
-    // Auto-enter the new (or last-adopted) task: build its session — letting
-    // the repo's init-prompt fire as the engine's first message — and jump the
+    // Auto-enter the new (or last-adopted) task: build its session and jump the
     // attached client into it, landing the user in the engine pane ready to
-    // type. Then exit; the client is already on the new session, so closing
+    // type. A create lets the repo's init-prompt fire as the engine's first
+    // message; an adopt imports existing work, so it doesn't paste a first-run
+    // prompt. Then exit; the client is already on the new session, so closing
     // this window doesn't disturb it. Non-fatal: the task is already created,
     // so a jump failure (e.g. run outside a kobe tmux session) still exits 0 —
     // the user can enter it from any Tasks pane.
     if (entered) {
       try {
-        await ensureTaskSession(orch, entered, result.repo, result.vendor, { includeInitPrompt: true })
-        await jumpToTask(orch, entered, result.repo, result.vendor)
+        await jumpToTask(orch, entered, result.repo, result.vendor, {
+          includeInitPrompt: result.mode !== "adopt",
+        })
       } catch (err) {
         console.error("[kobe new-task] auto-enter failed:", err)
       }

--- a/packages/kobe/src/tui/quick-task/host.tsx
+++ b/packages/kobe/src/tui/quick-task/host.tsx
@@ -29,9 +29,9 @@ import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-proces
 import { onMount } from "solid-js"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { availableEngineIds } from "../../engine/account-detect.ts"
-import { engineDisplayName, interactiveEngineCommand } from "../../engine/interactive-command.ts"
+import { engineDisplayName } from "../../engine/interactive-command.ts"
 import { addSavedRepo, getPersistedString, getSavedRepos, setPersistedString } from "../../state/repos.ts"
-import { getSessionOptions, runTmux, sessionExists, tmuxSessionName } from "../../tmux/client.ts"
+import { getSessionOptions, tmuxSessionName } from "../../tmux/client.ts"
 import { pasteAndSubmit, waitForEnginePane } from "../../tmux/prompt-delivery.ts"
 import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import { QuickTaskComposer } from "../component/quick-task-composer"
@@ -39,6 +39,7 @@ import { useTheme } from "../context/theme"
 import { DEFAULT_BASE_REF, getCurrentBranch } from "../lib/git-snapshot.ts"
 import { bootPaneHost } from "../lib/host-boot"
 import { expandHome } from "../lib/path-helpers.ts"
+import { ensureTaskSession, jumpToTask } from "../lib/task-enter.ts"
 import { NewTaskPage } from "../new-task/host.tsx"
 import { repoBasename } from "../panes/sidebar/groups"
 import { useDialog } from "../ui/dialog"
@@ -92,37 +93,10 @@ async function resolveQuickTaskContext(
 
 /**
  * Deliver a freshly-created task's first prompt. Mirrors `kobe api add`'s
- * deliver path: ensure the worktree, build the session with the init SCRIPT
- * only (no init-prompt, so this typed prompt isn't double-pasted), wait for
- * the engine pane, then bracketed-paste + submit. Best-effort on the pane.
+ * deliver path: build the session with the init SCRIPT only (no init-prompt,
+ * so this typed prompt isn't double-pasted — `ensureTaskSession`'s default),
+ * wait for the engine pane, then bracketed-paste + submit. Best-effort.
  */
-async function ensureTaskSession(
-  orch: RemoteOrchestrator,
-  task: Task,
-  repo: string,
-  vendor: VendorId,
-): Promise<boolean> {
-  const session = tmuxSessionName(task.id)
-  if (await sessionExists(session)) return true
-  let worktree = task.worktreePath
-  if (!worktree) worktree = await orch.ensureWorktree(task.id)
-  if (!worktree) throw new Error(`task ${task.id} has no worktree`)
-  const { ensureSession } = await import("../panes/terminal/tmux.ts")
-  const { resolveRepoInit } = await import("../../state/repo-init.ts")
-  const init = resolveRepoInit(repo, worktree)
-  const ok = await ensureSession({
-    name: session,
-    cwd: worktree,
-    command: interactiveEngineCommand(vendor),
-    taskId: task.id,
-    vendor,
-    repo,
-    initScript: init.initScript,
-  })
-  if (!ok) throw new Error(`failed to start tmux session for ${task.id}`)
-  return false // freshly built
-}
-
 async function deliverFirstPromptToTask(
   orch: RemoteOrchestrator,
   task: Task,
@@ -134,24 +108,6 @@ async function deliverFirstPromptToTask(
   const session = tmuxSessionName(task.id)
   const { pane } = await waitForEnginePane(session, !existed)
   if (pane) await pasteAndSubmit(pane, prompt)
-}
-
-/**
- * Jump the attached client to the freshly-created task: mark it active and
- * `switch-client` to its tmux session (the session already exists — deliver
- * built it). Mirrors the Tasks pane's `switchTo`. The quick-task window then
- * exits; the client is already on the new task's session, so closing the old
- * window doesn't disturb it.
- */
-async function jumpToTask(orch: RemoteOrchestrator, task: Task, repo: string, vendor: VendorId): Promise<void> {
-  await ensureTaskSession(orch, task, repo, vendor) // no-op if deliver already built it
-  await orch.setActiveTask(task.id).catch(() => {})
-  // Fit + heal the target to THIS client before switching in, so it doesn't
-  // reflow on screen — the quick-task window's stdout is its own pane, not the
-  // full terminal (see prepareWindowForSwitch).
-  const { prepareWindowForSwitch } = await import("../panes/terminal/tmux.ts")
-  await prepareWindowForSwitch(tmuxSessionName(task.id))
-  await runTmux(["switch-client", "-t", `=${tmuxSessionName(task.id)}`])
 }
 
 function QuickTaskPage(props: { ctx: QuickTaskContext; orchestrator: RemoteOrchestrator | null }) {

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -281,6 +281,10 @@ function TasksShell(props: {
     // Land the cursor on the new task so Enter / click enters it next.
     // (The daemon subscribe pushes the new task into the list momentarily.)
     selectTask: (id) => setSelectedId(id),
+    // Then enter it: `n` drops the user straight into the new task's engine
+    // pane (the same enter loop Enter/click runs), ready to type the first
+    // prompt — not just a moved cursor.
+    enterTask: (id) => switchTo(id),
   }
 
   // `n` creates a new task using the SAME NewTaskDialog (and now the same


### PR DESCRIPTION
## What

Creating a task with the full **`n` new-task flow** now drops you straight into the new task's engine pane — ready to type the first prompt — instead of just landing the Tasks-list cursor on it.

Previously only the prompt-first `f` quick-create jumped into the task; `n` created the task and either returned to the previous tab (default `chattab` surface) or only moved the sidebar cursor (in-pane overlay). This closes that gap so both `n` surfaces match `f`.

## How

- **New shared helper `src/tui/lib/task-enter.ts`** — extracts the proven "build session + `switch-client` jump" (`ensureTaskSession` + `jumpToTask`) out of `quick-task`, generalized with an `includeInitPrompt` flag.
- **`new-task/host.tsx` (default `chattab` tab)** — after create/adopt, builds the new task's session (letting the repo's `init-prompt.md` fire as the engine's first message) and jumps the attached client into it, then exits. Adopt enters the **last** worktree. Jump failures (e.g. run outside a kobe tmux session) are non-fatal — the task is already created.
- **`task-actions.ts` + `tasks-pane/host.tsx` (in-pane overlay)** — `createTaskFlow` gains an optional `enterTask`, wired to the Tasks pane's existing `switchTo` (the same enter loop Enter/click runs).
- **`quick-task/host.tsx`** — refactored to reuse the shared helpers (no behavior change).

## Verification

- `typecheck` ✅ `lint` ✅
- Test suite: **1012 pass / 31 fail**, identical to the clean baseline on this branch — the 31 failures are all pre-existing environmental issues (file mtime, npm registry, file watchers under WSL). **Zero regressions.**

Changeset: `patch`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creating a task with `n` now immediately opens the task's engine pane for prompt entry instead of landing in the Tasks list.
  * New task workflow consistently triggers initial prompt setup across quick-create, new-task tab, and Tasks pane.
  * Unified task entry experience with automatic session setup and seamless client switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->