### PR TITLE
[codex] theme tmux statusbar chrome

### DIFF
--- a/.changeset/tall-status-bars-tell.md
+++ b/.changeset/tall-status-bars-tell.md
@@ -3,3 +3,5 @@
 ---
 
 Theme the full kobe tmux chrome instead of only pane borders. The dedicated `-L kobe` tmux server now derives the bottom status/window bar, status-left/right styles, command prompts, copy-mode selection, pane picker colors, and pane borders from the active kobe theme, so switching themes fully restyles the ChatTab bar without touching the user's real tmux server.
+
+Make live theme propagation reliable when Settings writes the shared state file. The daemon now polls the tiny UI prefs file as a safety net for missed `fs.watch` tmp+rename events, so the selected-theme marker and already-running Tasks/Ops panes converge on the same theme as tmux chrome.

--- a/.changeset/tall-status-bars-tell.md
+++ b/.changeset/tall-status-bars-tell.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Theme the full kobe tmux chrome instead of only pane borders. The dedicated `-L kobe` tmux server now derives the bottom status/window bar, status-left/right styles, command prompts, copy-mode selection, pane picker colors, and pane borders from the active kobe theme, so switching themes fully restyles the ChatTab bar without touching the user's real tmux server.

--- a/bun.lock
+++ b/bun.lock
@@ -627,7 +627,7 @@
 
     "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.5", "", { "dependencies": { "@tanstack/devtools": "0.12.2" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-orVsRJ7oAXFb7oyafQCgx9YuK44jpILh5T/ddYuxAsolNfN5DZBr5/NLrWErD7HCGIzvYzg1TZI4sPxmiKvtvA=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.170.15", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.167.0", "", { "dependencies": { "@tanstack/router-devtools-core": "1.168.0" }, "peerDependencies": { "@tanstack/react-router": "^1.170.0", "@tanstack/router-core": "^1.170.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w=="],
 

--- a/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
+++ b/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
@@ -17,6 +17,10 @@
  *     tmp + rename, which swaps the file's inode — an `fs.watch` on the
  *     file itself goes dead after the first atomic write. Watching the
  *     parent dir and filtering on the filename survives every rename.
+ *   - **Poll as a safety net.** Bun/macOS can miss that tmp+rename edge in
+ *     a long-lived daemon even when the directory watch is alive. The state
+ *     file is tiny and publishes are changed-only, so a low-frequency poll
+ *     turns the live theme path from best-effort into reliable fan-out.
  *   - **Debounce.** A write burst (KVProvider flush + a `setPersisted*`
  *     call) collapses into one read ~{@link DEFAULT_UI_PREFS_DEBOUNCE_MS}
  *     later.
@@ -42,6 +46,9 @@ import type { UiPrefsPayload } from "./protocol.ts"
 
 /** Default debounce between a state-file event and the read+publish. */
 export const DEFAULT_UI_PREFS_DEBOUNCE_MS = 200
+
+/** Safety-net poll cadence for missed fs.watch events. */
+export const DEFAULT_UI_PREFS_POLL_MS = 250
 
 /**
  * Focus-accent slots the TUI understands — mirror of `FOCUS_ACCENT_SLOTS`
@@ -115,17 +122,24 @@ export interface UiPrefsWatcherOptions {
    * same disable convention as the server's other pollers.
    */
   readonly debounceMs?: number
+  /**
+   * Poll fallback cadence in ms. `<= 0` disables only the fallback poll;
+   * the directory watcher still runs. Defaults to
+   * {@link DEFAULT_UI_PREFS_POLL_MS}.
+   */
+  readonly pollMs?: number
 }
 
 /**
  * Start the watcher: publish the current prefs immediately (replay seed),
- * then re-read + publish-on-change after every debounced state-file
- * event. Returns a `stop()` that closes the fs watcher and clears any
- * pending debounce.
+ * then re-read + publish-on-change after every debounced state-file event
+ * and on a small polling fallback. Returns a `stop()` that closes the fs
+ * watcher and clears pending timers.
  */
 export function startUiPrefsWatcher(bus: DaemonEventBus, options: UiPrefsWatcherOptions = {}): () => void {
   const debounceMs = options.debounceMs ?? DEFAULT_UI_PREFS_DEBOUNCE_MS
   if (debounceMs <= 0) return () => {}
+  const pollMs = options.pollMs ?? DEFAULT_UI_PREFS_POLL_MS
   const statePath = options.statePath ?? defaultUiPrefsStatePath()
   const stateDir = dirname(statePath)
   const stateFile = basename(statePath)
@@ -134,8 +148,7 @@ export function startUiPrefsWatcher(bus: DaemonEventBus, options: UiPrefsWatcher
   bus.publish("ui-prefs", last)
 
   let timer: ReturnType<typeof setTimeout> | null = null
-  const readAndPublish = (): void => {
-    timer = null
+  const publishIfChanged = (): void => {
     try {
       const next = readUiPrefsFromStateFile(statePath)
       if (samePrefs(last, next)) return
@@ -145,8 +158,17 @@ export function startUiPrefsWatcher(bus: DaemonEventBus, options: UiPrefsWatcher
       logDaemonError("ui-prefs-watcher", err)
     }
   }
+  const schedulePublish = (): void => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      publishIfChanged()
+    }, debounceMs)
+    timer.unref?.()
+  }
 
   let watcher: FSWatcher | null = null
+  let poll: ReturnType<typeof setInterval> | null = null
   try {
     // The dir may not exist yet on a fresh home (the State Store mkdirs at
     // its first write); create it so `watch` has something to attach to.
@@ -157,9 +179,7 @@ export function startUiPrefsWatcher(bus: DaemonEventBus, options: UiPrefsWatcher
       // filename (platforms that omit it) conservatively counts as a match
       // — the debounce + changed-only publish make the extra read cheap.
       if (filename !== null && filename !== stateFile) return
-      if (timer) clearTimeout(timer)
-      timer = setTimeout(readAndPublish, debounceMs)
-      timer.unref?.()
+      schedulePublish()
     })
     watcher.on("error", (err) => logDaemonError("ui-prefs-watcher", err))
   } catch (err) {
@@ -168,11 +188,19 @@ export function startUiPrefsWatcher(bus: DaemonEventBus, options: UiPrefsWatcher
     // serves the at-start value to subscribers.
     logDaemonError("ui-prefs-watcher", err)
   }
+  if (pollMs > 0) {
+    poll = setInterval(publishIfChanged, pollMs)
+    poll.unref?.()
+  }
 
   return () => {
     if (timer) {
       clearTimeout(timer)
       timer = null
+    }
+    if (poll) {
+      clearInterval(poll)
+      poll = null
     }
     watcher?.close()
     watcher = null

--- a/packages/kobe/src/tui/direct.ts
+++ b/packages/kobe/src/tui/direct.ts
@@ -23,7 +23,7 @@ import {
 } from "../state/repos.ts"
 import { ensureFallbackSession } from "../tmux/client.ts"
 import type { Task } from "../types/task.ts"
-import { applyTmuxPaneBorderTheme } from "./lib/tmux-border-theme.ts"
+import { applyTmuxChromeTheme } from "./lib/tmux-border-theme.ts"
 import {
   attachArgv,
   ensureSession,
@@ -125,8 +125,8 @@ export async function startDirectTmux(): Promise<void> {
       // auto-title pass, so we attach and return directly.
       const home = await ensureFallbackSession()
       // Fallback sessions skip ensureSession's server-nicety block, so
-      // apply the theme-matched borders here before attaching.
-      await applyTmuxPaneBorderTheme()
+      // apply the theme-matched tmux chrome here before attaching.
+      await applyTmuxChromeTheme()
       // Fit + heal the window before attaching so the first frame is correct
       // (no reflow flash on attach — see prepareWindowForAttach).
       await prepareWindowForAttach(home)
@@ -159,9 +159,9 @@ export async function startDirectTmux(): Promise<void> {
     }
 
     // ensureSession's reuse path skips the server-nicety block where the
-    // create path applies border styling, and the user may have switched
+    // create path applies tmux chrome styling, and the user may have switched
     // themes since the server last saw an apply — refresh before attach.
-    await applyTmuxPaneBorderTheme()
+    await applyTmuxChromeTheme()
 
     // Fit the window to this terminal and heal the layout BEFORE attaching, so
     // the first painted frame is already correct — no reflow "flash" where the

--- a/packages/kobe/src/tui/lib/host-boot.tsx
+++ b/packages/kobe/src/tui/lib/host-boot.tsx
@@ -201,11 +201,10 @@ function HostProviders(props: {
  * back; `applyUiPrefs` compares before every set, so identical values are
  * a no-op.
  *
- * tmux borders are deliberately NOT re-applied here — the two border
- * options are server-global, so the settings-exit flow's single
- * `refreshKobeWorkspacePanes` → `applyTmuxPaneBorderTheme` call already
- * covers every session; doing it from N panes would just race the same
- * `set-option`s.
+ * tmux chrome is deliberately NOT re-applied here — the status/window bar
+ * and border options are server-global, so the settings-exit flow's single
+ * `refreshKobeWorkspacePanes` → `applyTmuxChromeTheme` call already covers
+ * every session; doing it from N panes would just race the same `set-option`s.
  */
 function UiPrefsSync(props: { boot: PersistedUiPrefs }) {
   const themeCtx = useTheme()

--- a/packages/kobe/src/tui/lib/tmux-border-theme.ts
+++ b/packages/kobe/src/tui/lib/tmux-border-theme.ts
@@ -1,32 +1,38 @@
 /**
- * Theme-matched tmux pane borders.
+ * Theme-matched tmux chrome.
  *
  * kobe's opentui panes are fully themed, but the 1-cell separator lines
- * BETWEEN panes are drawn by tmux with its stock style — terminal-default
- * foreground for `pane-border-style`, `fg=green` for the active border.
- * Under dark themes the stock line blends into the pane background and
- * the workspace loses its visible pane boundaries (and the only focus
- * cue tmux offers). This module derives the two border styles from the
- * active kobe theme and injects them as server-global options on the
- * `-L kobe` socket:
+ * BETWEEN panes and the bottom status/window bar are drawn by tmux with
+ * its stock styles — terminal-default foreground for `pane-border-style`,
+ * `fg=green` for the active border, and `bg=green,fg=black` for
+ * `status-style`. Under dark themes those defaults clash with kobe's
+ * panes and make the workspace read as two unrelated UIs. This module
+ * derives the tmux-owned chrome from the active kobe theme and injects
+ * it as global options on the `-L kobe` socket:
  *
  *   pane-border-style        fg=<theme.border>
  *   pane-active-border-style fg=<theme.focusAccent slot>   (focus signal,
  *                            same slot the in-pane focus indicators use)
+ *   status-style             bg=<theme.backgroundPanel> fg=<theme.textMuted>
+ *   window-status-*          inactive / current / activity / bell styles
+ *   status-left/right-style  bg=<status bg> fg=<theme.textMuted>
+ *   message/mode/display-*   tmux prompts, copy-mode, pane-picker overlays
  *
- * PRECEDENCE: kobe owns these two options on its own socket. The `-L
+ * PRECEDENCE: kobe owns these options on its own socket. The `-L
  * kobe` socket loads the user's `~/.tmux.conf`, but that config was
  * written for their own tmux — popular setups (e.g. oh-my-tmux's
- * `#303030` border) are exactly what makes the kobe workspace borders
- * invisible, so yielding to it would leave the bug in place for the
- * people who hit it. Forcing the option on kobe's socket is the same
+ * `#303030` border and tmux's stock green status bar) are exactly what
+ * makes the kobe workspace look unthemed, so yielding to it would leave
+ * the bug in place for the people who hit it. Forcing the option on kobe's
+ * socket is the same
  * stance the server-nicety block already takes for `mouse on` and
  * `status-right`; the user's real tmux server is never touched. The
- * escape hatch is `"tmuxBorderTheme": "off"` in `state.json`, which
+ * escape hatch is `"tmuxChromeTheme": "off"` in `state.json` (or the
+ * legacy `"tmuxBorderTheme": "off"`), which
  * releases the options back to whatever the server would otherwise
  * have (tmux stock until the user's conf reloads on the next server).
  *
- * The `@kobe_border_theme` marker records which options kobe wrote so
+ * The legacy `@kobe_border_theme` marker records which options kobe wrote so
  * the off-switch (or a theme slot resolving to null) unsets only what
  * kobe set and never clobbers an option it never owned. Pure planning
  * is split from IO so the rules are unit-tested without a tmux server.
@@ -40,8 +46,15 @@ import { BUNDLED_THEME_JSONS } from "../context/theme/bundled"
 import { resolveThemeSlotHex } from "../context/theme/hex"
 import { loadUserThemes } from "../context/theme/loader"
 
-/** Server-global user option recording which border options kobe wrote. */
-export const BORDER_THEME_MARKER_OPTION = "@kobe_border_theme"
+/**
+ * Server-global user option recording which tmux chrome options kobe wrote.
+ * The old name is intentionally kept so upgrades can release/extend options
+ * claimed by the previous pane-border-only implementation.
+ */
+export const TMUX_CHROME_THEME_MARKER_OPTION = "@kobe_border_theme"
+
+/** Back-compat alias for older tests/callers. */
+export const BORDER_THEME_MARKER_OPTION = TMUX_CHROME_THEME_MARKER_OPTION
 
 /**
  * Mirror of `FOCUS_ACCENT_SLOTS` in `theme.tsx` — not imported because
@@ -50,10 +63,10 @@ export const BORDER_THEME_MARKER_OPTION = "@kobe_border_theme"
  */
 const FOCUS_ACCENT_SLOT_NAMES = ["primary", "success", "info"] as const
 
-interface BorderPrefs {
+interface TmuxChromePrefs {
   readonly themeName: string
   readonly focusAccentSlot: string
-  /** `"tmuxBorderTheme": "off"` in state.json disables the injection. */
+  /** `"tmuxChromeTheme": "off"` in state.json disables the injection. */
   readonly enabled: boolean
 }
 
@@ -63,7 +76,7 @@ interface BorderPrefs {
  * the Solid theme registry (`hasTheme`), which would pull the TUI
  * runtime into every `ensureSession` caller.
  */
-function readBorderPrefs(): BorderPrefs {
+function readTmuxChromePrefs(): TmuxChromePrefs {
   try {
     const parsed = JSON.parse(readFileSync(kvStatePath(), "utf8")) as Record<string, unknown>
     const themeName = typeof parsed.activeTheme === "string" && parsed.activeTheme ? parsed.activeTheme : "claude"
@@ -72,7 +85,11 @@ function readBorderPrefs(): BorderPrefs {
       (FOCUS_ACCENT_SLOT_NAMES as readonly string[]).includes(parsed.focusAccent)
         ? parsed.focusAccent
         : "primary"
-    return { themeName, focusAccentSlot, enabled: parsed.tmuxBorderTheme !== "off" }
+    return {
+      themeName,
+      focusAccentSlot,
+      enabled: parsed.tmuxChromeTheme !== "off" && parsed.tmuxBorderTheme !== "off",
+    }
   } catch {
     return { themeName: "claude", focusAccentSlot: "primary", enabled: true }
   }
@@ -94,13 +111,70 @@ export function resolveBorderHexes(
   theme: ThemeJson,
   focusAccentSlot: string,
 ): { border: string | null; active: string | null } {
-  const border = resolveThemeSlotHex(theme, "border") ?? resolveThemeSlotHex(theme, "text")
-  const active =
-    resolveThemeSlotHex(theme, focusAccentSlot) ??
-    resolveThemeSlotHex(theme, "primary") ??
-    resolveThemeSlotHex(theme, "borderActive") ??
-    border
+  const hexes = resolveTmuxChromeHexes(theme, focusAccentSlot)
+  const border = hexes.border
+  const active = hexes.activeBorder
   return { border, active }
+}
+
+export interface TmuxChromeHexes {
+  readonly border: string | null
+  readonly activeBorder: string | null
+  readonly statusBg: string | null
+  readonly statusFg: string | null
+  readonly statusMutedFg: string | null
+  readonly windowFg: string | null
+  readonly currentWindowBg: string | null
+  readonly currentWindowFg: string | null
+  readonly activityFg: string | null
+  readonly bellFg: string | null
+  readonly messageBg: string | null
+  readonly messageFg: string | null
+  readonly messageCommandFg: string | null
+  readonly modeBg: string | null
+  readonly modeFg: string | null
+}
+
+function firstHex(theme: ThemeJson, ...slots: string[]): string | null {
+  for (const slot of slots) {
+    const hex = resolveThemeSlotHex(theme, slot)
+    if (hex) return hex
+  }
+  return null
+}
+
+/**
+ * All colors needed for tmux-owned chrome. The fallback chains mirror
+ * `resolveTheme()` where possible, but return null when a whole category
+ * cannot be derived so the planner releases instead of painting black.
+ */
+export function resolveTmuxChromeHexes(theme: ThemeJson, focusAccentSlot: string): TmuxChromeHexes {
+  const text = firstHex(theme, "text")
+  const background = firstHex(theme, "background")
+  const textMuted = firstHex(theme, "textMuted", "text")
+  const backgroundPanel = firstHex(theme, "backgroundPanel", "background")
+  const backgroundElement = firstHex(theme, "backgroundElement", "backgroundPanel", "background")
+  const backgroundMenu = firstHex(theme, "backgroundMenu", "backgroundElement", "backgroundPanel", "background")
+  const selectedListItemText = firstHex(theme, "selectedListItemText", "background")
+  const primary = firstHex(theme, focusAccentSlot, "primary", "borderActive", "border", "text")
+
+  return {
+    border: firstHex(theme, "border", "text"),
+    activeBorder: primary,
+    statusBg: backgroundPanel,
+    statusFg: textMuted,
+    statusMutedFg: textMuted,
+    windowFg: textMuted,
+    currentWindowBg: backgroundElement,
+    currentWindowFg: primary,
+    activityFg: firstHex(theme, "info", "primary", "text"),
+    bellFg: firstHex(theme, "warning", "error", "primary", "text"),
+    messageBg: backgroundMenu,
+    messageFg: text,
+    messageCommandFg: primary,
+    modeBg: primary,
+    modeFg: selectedListItemText ?? background,
+  }
 }
 
 export interface BorderThemePlanInput {
@@ -158,6 +232,208 @@ export function planBorderTheme(input: BorderThemePlanInput): string[][] {
   return commands
 }
 
+export type TmuxChromeOptionKey =
+  | "border"
+  | "active"
+  | "status"
+  | "status-left"
+  | "status-right"
+  | "window"
+  | "current-window"
+  | "activity-window"
+  | "bell-window"
+  | "last-window"
+  | "message"
+  | "message-command"
+  | "mode"
+  | "display-panes"
+  | "display-panes-active"
+
+interface TmuxChromeOptionValue {
+  readonly key: TmuxChromeOptionKey
+  readonly option: string
+  readonly showFlag: "-gqv" | "-gwqv"
+  readonly setFlag: "-g" | "-gw"
+  readonly unsetFlag: "-gu" | "-gwu"
+  readonly value: string | null
+}
+
+function style(parts: { bg?: string | null; fg?: string | null; attrs?: readonly string[] }): string | null {
+  const chunks: string[] = []
+  if (parts.bg) chunks.push(`bg=${parts.bg}`)
+  if (parts.fg) chunks.push(`fg=${parts.fg}`)
+  if (chunks.length === 0) return null
+  if (parts.attrs) chunks.push(...parts.attrs)
+  return chunks.join(",")
+}
+
+function tmuxChromeOptionValues(hexes: TmuxChromeHexes): TmuxChromeOptionValue[] {
+  const statusStyle = style({ bg: hexes.statusBg, fg: hexes.statusFg })
+  const statusMutedStyle = style({ bg: hexes.statusBg, fg: hexes.statusMutedFg })
+  const windowStyle = style({ bg: hexes.statusBg, fg: hexes.windowFg })
+  return [
+    {
+      key: "border",
+      option: "pane-border-style",
+      showFlag: "-gwqv",
+      setFlag: "-gw",
+      unsetFlag: "-gwu",
+      value: style({ fg: hexes.border }),
+    },
+    {
+      key: "active",
+      option: "pane-active-border-style",
+      showFlag: "-gwqv",
+      setFlag: "-gw",
+      unsetFlag: "-gwu",
+      value: style({ fg: hexes.activeBorder }),
+    },
+    {
+      key: "status",
+      option: "status-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: statusStyle,
+    },
+    {
+      key: "status-left",
+      option: "status-left-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: statusMutedStyle,
+    },
+    {
+      key: "status-right",
+      option: "status-right-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: statusMutedStyle,
+    },
+    {
+      key: "window",
+      option: "window-status-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: windowStyle,
+    },
+    {
+      key: "current-window",
+      option: "window-status-current-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: style({ bg: hexes.currentWindowBg, fg: hexes.currentWindowFg, attrs: ["bold"] }),
+    },
+    {
+      key: "activity-window",
+      option: "window-status-activity-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: style({ bg: hexes.statusBg, fg: hexes.activityFg }),
+    },
+    {
+      key: "bell-window",
+      option: "window-status-bell-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: style({ bg: hexes.statusBg, fg: hexes.bellFg, attrs: ["bold"] }),
+    },
+    {
+      key: "last-window",
+      option: "window-status-last-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: style({ bg: hexes.statusBg, fg: hexes.statusFg }),
+    },
+    {
+      key: "message",
+      option: "message-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: style({ bg: hexes.messageBg, fg: hexes.messageFg }),
+    },
+    {
+      key: "message-command",
+      option: "message-command-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: style({ bg: hexes.messageBg, fg: hexes.messageCommandFg, attrs: ["bold"] }),
+    },
+    {
+      key: "mode",
+      option: "mode-style",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: style({ bg: hexes.modeBg, fg: hexes.modeFg }),
+    },
+    {
+      key: "display-panes",
+      option: "display-panes-colour",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: hexes.border,
+    },
+    {
+      key: "display-panes-active",
+      option: "display-panes-active-colour",
+      showFlag: "-gqv",
+      setFlag: "-g",
+      unsetFlag: "-gu",
+      value: hexes.activeBorder,
+    },
+  ]
+}
+
+export interface TmuxChromeThemePlanInput {
+  readonly marker: string
+  readonly current: Partial<Record<TmuxChromeOptionKey, string>>
+  readonly hexes: TmuxChromeHexes
+}
+
+/** Plan theme writes for pane borders, status/window bar, prompts, copy-mode, and pane-picker overlays. */
+export function planTmuxChromeTheme(input: TmuxChromeThemePlanInput): string[][] {
+  const owned = new Set(
+    input.marker
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  )
+  const commands: string[][] = []
+  const nextOwned: string[] = []
+
+  for (const item of tmuxChromeOptionValues(input.hexes)) {
+    if (item.value) {
+      if ((input.current[item.key] ?? "") !== item.value) {
+        commands.push(["set-option", item.setFlag, item.option, item.value])
+      }
+      nextOwned.push(item.key)
+    } else if (owned.has(item.key)) {
+      commands.push(["set-option", item.unsetFlag, item.option])
+    }
+  }
+
+  const nextMarker = nextOwned.join(",")
+  if (nextMarker !== input.marker) {
+    commands.push(
+      nextMarker
+        ? ["set-option", "-g", TMUX_CHROME_THEME_MARKER_OPTION, nextMarker]
+        : ["set-option", "-gu", TMUX_CHROME_THEME_MARKER_OPTION],
+    )
+  }
+  return commands
+}
+
 async function readOption(args: string[]): Promise<string> {
   const { code, stdout } = await runTmuxCapturing(args)
   return code === 0 ? stdout.trim() : ""
@@ -170,22 +446,33 @@ async function readOption(args: string[]): Promise<string> {
  * the caller (launch, settings exit).
  */
 export async function applyTmuxPaneBorderTheme(): Promise<void> {
+  await applyTmuxChromeTheme()
+}
+
+/**
+ * Resolve the active theme's tmux chrome colors and apply them to the kobe
+ * tmux server. Best-effort and idempotent: no server / no theme / disabled
+ * theme injection all reduce to a no-op or a release, and failures never
+ * block the caller (launch, settings exit).
+ */
+export async function applyTmuxChromeTheme(): Promise<void> {
   try {
-    const prefs = readBorderPrefs()
+    const prefs = readTmuxChromePrefs()
     const themeJson = prefs.enabled ? lookupThemeJson(prefs.themeName) : null
     // Disabled or unknown theme → null hexes, which release (never set)
     // the options below; a marker-less server then plans zero commands.
-    const { border, active } = themeJson
-      ? resolveBorderHexes(themeJson, prefs.focusAccentSlot)
-      : { border: null, active: null }
+    const hexes = themeJson
+      ? resolveTmuxChromeHexes(themeJson, prefs.focusAccentSlot)
+      : resolveTmuxChromeHexes({ theme: {} }, prefs.focusAccentSlot)
     // `-q` keeps an unset option (notably the marker on a fresh server)
     // from logging an "invalid option" error line through runTmuxCapturing.
-    const [currentBorder, currentActive, marker] = await Promise.all([
-      readOption(["show-options", "-gwqv", "pane-border-style"]),
-      readOption(["show-options", "-gwqv", "pane-active-border-style"]),
-      readOption(["show-options", "-gqv", BORDER_THEME_MARKER_OPTION]),
+    const options = tmuxChromeOptionValues(hexes)
+    const [marker, ...values] = await Promise.all([
+      readOption(["show-options", "-gqv", TMUX_CHROME_THEME_MARKER_OPTION]),
+      ...options.map((item) => readOption(["show-options", item.showFlag, item.option])),
     ])
-    const commands = planBorderTheme({ marker, currentBorder, currentActive, borderHex: border, activeHex: active })
+    const current = Object.fromEntries(options.map((item, i) => [item.key, values[i] ?? ""]))
+    const commands = planTmuxChromeTheme({ marker, current, hexes })
     if (commands.length > 0) await runTmuxSequence(commands)
   } catch {
     // cosmetic — never surface to the launch / settings flows

--- a/packages/kobe/src/tui/panes/terminal/chattab.ts
+++ b/packages/kobe/src/tui/panes/terminal/chattab.ts
@@ -7,7 +7,7 @@
  * "a window in the session" rather than "the session build itself":
  *
  *   - the window-list presentation (`CHAT_TAB_STATUS_*` formats, the
- *     `@kobe_tab_state` activity tag, the muted `status-right` hint), and
+ *     `@kobe_tab_state` activity tag, the themed `status-right` hint), and
  *     the chat-tab key-binding builders the `ensureSession` applier
  *     installs (`chatTab*Binding(s)` — KEY halves come from the
  *     user-resolvable tmux key set, COMMAND halves are fixed here);
@@ -114,9 +114,9 @@ function tmuxKeyCap(key: string): string {
  * escape-hatch chords, so we surface the three most useful ones. `^h` (the
  * focus-left key) returns to or restores the Tasks pane, `^q` is detach,
  * `^t` opens a new chat tab. Built from the RESOLVED key set so user overrides
- * show their own chords; an unbound key drops its segment. Dimmed with
- * `fg=brightblack` so it reads as a muted hint rather than fighting the user's
- * theme; the trailing space keeps it off the terminal's right edge.
+ * show their own chords; an unbound key drops its segment. The themed
+ * `status-right-style` supplies the muted foreground; the trailing space keeps
+ * it off the terminal's right edge.
  */
 export function kobeStatusRight(keys: {
   focusLeft: string | null
@@ -132,7 +132,7 @@ export function kobeStatusRight(keys: {
     keys.layoutSplits ? `prefix ${keys.layoutSplits} splits` : null,
     keys.layoutPanes ? `prefix ${keys.layoutPanes} panes` : null,
   ].filter((s): s is string => s !== null)
-  return `#[fg=brightblack]${segments.join("  ")} `
+  return `${segments.join("  ")} `
 }
 
 export const CHAT_TAB_STATE_OPTION = "@kobe_tab_state"

--- a/packages/kobe/src/tui/panes/terminal/pane-heal.ts
+++ b/packages/kobe/src/tui/panes/terminal/pane-heal.ts
@@ -54,7 +54,7 @@ import {
   shellQuoteArgv,
   tasksPaneCommand,
 } from "@/tmux/session-layout"
-import { applyTmuxPaneBorderTheme } from "@/tui/lib/tmux-border-theme"
+import { applyTmuxChromeTheme } from "@/tui/lib/tmux-border-theme"
 import { CURRENT_VERSION } from "@/version"
 import { inheritedEnvPrefix, wrapEngineLaunch } from "./launch"
 import { recordGen } from "./layout-coord"
@@ -527,10 +527,10 @@ export async function captureGlobalLayoutOnDrag(session: string): Promise<void> 
  * because it still serves everything else: NON-visual prefs each pane's
  * KVProvider snapshotted at boot (notification toggles, settings surface,
  * editor kind, …) and the no-daemon degraded mode. It also remains the
- * single owner of the tmux border re-style below — the two border options
- * are server-global, so this one call after a Settings exit covers every
- * session; applying them from each pane's live-prefs hook would just race
- * the same `set-option`s.
+ * single owner of the tmux chrome re-style below — the tmux status/window
+ * bar and border options are server-global, so this one call after a Settings
+ * exit covers every session; applying them from each pane's live-prefs hook
+ * would just race the same `set-option`s.
  */
 export async function refreshKobeWorkspacePanes(session: string): Promise<void> {
   const sessionOptions = await getSessionOptions(session, ["@kobe_worktree", "@kobe_task", "@kobe_vendor"])
@@ -546,8 +546,8 @@ export async function refreshKobeWorkspacePanes(session: string): Promise<void> 
   })
   if (commands.length > 0) await runTmuxSequence(commands)
 
-  // The Appearance prefs the respawned panes just re-read also drive the
-  // tmux border colors — re-derive those in the same pass so a theme
-  // switch restyles the pane separators without a new session build.
-  await applyTmuxPaneBorderTheme()
+  // The Appearance prefs the respawned panes just re-read also drive tmux
+  // chrome — re-derive those in the same pass so a theme switch restyles
+  // the status/window bar and pane separators without a new session build.
+  await applyTmuxChromeTheme()
 }

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -76,7 +76,7 @@ import {
 import { deliverFirstPrompt } from "@/tmux/prompt-delivery"
 import { type ObservedSession, decideSessionAction } from "@/tmux/session-decision"
 import { HIDDEN_TASKS_PANE_OPTION, engineLaunchLine, shellQuote, shellQuoteArgv } from "@/tmux/session-layout"
-import { applyTmuxPaneBorderTheme } from "@/tui/lib/tmux-border-theme"
+import { applyTmuxChromeTheme } from "@/tui/lib/tmux-border-theme"
 import {
   CHAT_TAB_STATUS_CURRENT_FORMAT,
   CHAT_TAB_STATUS_FORMAT,
@@ -537,18 +537,18 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
   // set `on` (not just "leave default") so a server that an older
   // kobe turned OFF flips back.
   //
-  // We deliberately do NOT set status-style / status-left: the `-L
-  // kobe` socket still loads the user's `~/.tmux.conf` (the `-L` flag
-  // only changes the socket path, not the config file), so the user's
-  // own status-bar theme applies. The session name (`kobe-<task-id>`,
-  // shown via the user's default `#S` in status-left) is the only
-  // identity we impose on the left.
+  // The status/window bar content is set here, while its theme is applied
+  // below by applyTmuxChromeTheme(). The `-L kobe` socket still loads the
+  // user's `~/.tmux.conf`, but kobe owns visual chrome on its own isolated
+  // socket so the bottom ChatTab switcher matches the active kobe theme.
+  // The session name (`kobe-<task-id>`, shown via the user's default `#S`
+  // in status-left) remains the only identity we impose on the left.
   //
-  // status-right IS set — but minimally: from inside the engine/shell
+  // status-right is set minimally: from inside the engine/shell
   // pane the user otherwise has zero on-screen hint for kobe's
   // escape-hatch chords (get back to Tasks, detach, new tab). We show
-  // the three most useful ones, dimmed (`fg=brightblack`) so they read
-  // as a muted hint and don't fight the user's theme. Server-scoped on
+  // the most useful ones; `status-right-style` supplies the themed muted
+  // foreground. Server-scoped on
   // the isolated `-L kobe` socket, so the user's real tmux status-right
   // is never touched.
   // Window-status format: a compact activity icon in each ChatTab label.
@@ -765,11 +765,12 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     ["bind-key", "f", "run-shell", `${envStr}${invStr} quick-create --session '#{session_name}'`],
   ])
 
-  // Theme-matched pane borders. The border tmux would otherwise use
-  // (stock default, or a user tmux.conf gray) disappears against dark
-  // kobe themes; derive both border styles from the active theme
-  // instead. Precedence + the off-switch live in tmux-border-theme.ts.
-  await applyTmuxPaneBorderTheme()
+  // Theme-matched tmux chrome. The tmux defaults (stock green status
+  // bar, green active pane border, or a user's tmux.conf gray) clash
+  // with kobe themes; derive the status/window bar, prompts, mode
+  // selection, pane picker, and borders from the active theme instead.
+  // Precedence + the off-switch live in tmux-border-theme.ts.
+  await applyTmuxChromeTheme()
 
   // Focus the claude pane on first attach. Subsequent attaches keep
   // whatever pane tmux remembered — so a user who detached from Ops

--- a/packages/kobe/test/tui/terminal-tmux.test.ts
+++ b/packages/kobe/test/tui/terminal-tmux.test.ts
@@ -251,12 +251,12 @@ describe("kobeStatusRight", () => {
         layoutSplits: "s/x/r",
         layoutPanes: "a/o/z",
       }),
-    ).toBe("#[fg=brightblack]^h tasks  ^q detach  ^t tab  prefix s/x/r splits  prefix a/o/z panes ")
+    ).toBe("^h tasks  ^q detach  ^t tab  prefix s/x/r splits  prefix a/o/z panes ")
   })
 
   test("shows overridden chords and drops unbound segments", () => {
     expect(kobeStatusRight({ focusLeft: null, detach: "M-d", newTab: "C-y", layoutSplits: null })).toBe(
-      "#[fg=brightblack]M-d detach  ^y tab ",
+      "M-d detach  ^y tab ",
     )
   })
 })

--- a/packages/kobe/test/tui/tmux-border-theme.test.ts
+++ b/packages/kobe/test/tui/tmux-border-theme.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "vitest"
 import type { ThemeJson } from "../../src/tui/context/theme"
-import { BORDER_THEME_MARKER_OPTION, planBorderTheme, resolveBorderHexes } from "../../src/tui/lib/tmux-border-theme"
+import {
+  BORDER_THEME_MARKER_OPTION,
+  TMUX_CHROME_THEME_MARKER_OPTION,
+  planBorderTheme,
+  planTmuxChromeTheme,
+  resolveBorderHexes,
+  resolveTmuxChromeHexes,
+} from "../../src/tui/lib/tmux-border-theme"
 
 describe("resolveBorderHexes", () => {
   test("uses border + the focus-accent slot", () => {
@@ -18,6 +25,64 @@ describe("resolveBorderHexes", () => {
 
   test("an empty theme yields nulls (caller releases)", () => {
     expect(resolveBorderHexes({ theme: {} }, "primary")).toEqual({ border: null, active: null })
+  })
+})
+
+describe("resolveTmuxChromeHexes", () => {
+  test("derives border, statusbar, prompt, mode, and overlay colors from the active theme", () => {
+    const theme: ThemeJson = {
+      theme: {
+        border: "#333333",
+        primary: "#cc5544",
+        info: "#3377cc",
+        warning: "#ddaa33",
+        text: "#eeeeee",
+        textMuted: "#999999",
+        background: "#111111",
+        backgroundPanel: "#181818",
+        backgroundElement: "#222222",
+        backgroundMenu: "#2a2a2a",
+        selectedListItemText: "#101010",
+      },
+    }
+
+    expect(resolveTmuxChromeHexes(theme, "primary")).toEqual({
+      border: "#333333",
+      activeBorder: "#cc5544",
+      statusBg: "#181818",
+      statusFg: "#999999",
+      statusMutedFg: "#999999",
+      windowFg: "#999999",
+      currentWindowBg: "#222222",
+      currentWindowFg: "#cc5544",
+      activityFg: "#3377cc",
+      bellFg: "#ddaa33",
+      messageBg: "#2a2a2a",
+      messageFg: "#eeeeee",
+      messageCommandFg: "#cc5544",
+      modeBg: "#cc5544",
+      modeFg: "#101010",
+    })
+  })
+
+  test("an empty theme yields nulls so the caller releases owned tmux options", () => {
+    expect(resolveTmuxChromeHexes({ theme: {} }, "primary")).toEqual({
+      border: null,
+      activeBorder: null,
+      statusBg: null,
+      statusFg: null,
+      statusMutedFg: null,
+      windowFg: null,
+      currentWindowBg: null,
+      currentWindowFg: null,
+      activityFg: null,
+      bellFg: null,
+      messageBg: null,
+      messageFg: null,
+      messageCommandFg: null,
+      modeBg: null,
+      modeFg: null,
+    })
   })
 })
 
@@ -119,5 +184,107 @@ describe("planBorderTheme", () => {
       activeHex: null,
     })
     expect(commands).toEqual([])
+  })
+})
+
+describe("planTmuxChromeTheme", () => {
+  const hexes = {
+    border: "#333333",
+    activeBorder: "#cc5544",
+    statusBg: "#181818",
+    statusFg: "#999999",
+    statusMutedFg: "#999999",
+    windowFg: "#999999",
+    currentWindowBg: "#222222",
+    currentWindowFg: "#cc5544",
+    activityFg: "#3377cc",
+    bellFg: "#ddaa33",
+    messageBg: "#2a2a2a",
+    messageFg: "#eeeeee",
+    messageCommandFg: "#cc5544",
+    modeBg: "#cc5544",
+    modeFg: "#101010",
+  }
+
+  test("claims pane borders plus the full tmux status/window chrome on a stock server", () => {
+    const commands = planTmuxChromeTheme({ marker: "", current: {}, hexes })
+    expect(commands).toEqual([
+      ["set-option", "-gw", "pane-border-style", "fg=#333333"],
+      ["set-option", "-gw", "pane-active-border-style", "fg=#cc5544"],
+      ["set-option", "-g", "status-style", "bg=#181818,fg=#999999"],
+      ["set-option", "-g", "status-left-style", "bg=#181818,fg=#999999"],
+      ["set-option", "-g", "status-right-style", "bg=#181818,fg=#999999"],
+      ["set-option", "-g", "window-status-style", "bg=#181818,fg=#999999"],
+      ["set-option", "-g", "window-status-current-style", "bg=#222222,fg=#cc5544,bold"],
+      ["set-option", "-g", "window-status-activity-style", "bg=#181818,fg=#3377cc"],
+      ["set-option", "-g", "window-status-bell-style", "bg=#181818,fg=#ddaa33,bold"],
+      ["set-option", "-g", "window-status-last-style", "bg=#181818,fg=#999999"],
+      ["set-option", "-g", "message-style", "bg=#2a2a2a,fg=#eeeeee"],
+      ["set-option", "-g", "message-command-style", "bg=#2a2a2a,fg=#cc5544,bold"],
+      ["set-option", "-g", "mode-style", "bg=#cc5544,fg=#101010"],
+      ["set-option", "-g", "display-panes-colour", "#333333"],
+      ["set-option", "-g", "display-panes-active-colour", "#cc5544"],
+      [
+        "set-option",
+        "-g",
+        TMUX_CHROME_THEME_MARKER_OPTION,
+        "border,active,status,status-left,status-right,window,current-window,activity-window,bell-window,last-window,message,message-command,mode,display-panes,display-panes-active",
+      ],
+    ])
+  })
+
+  test("does not rewrite statusbar options that are already themed", () => {
+    const marker =
+      "border,active,status,status-left,status-right,window,current-window,activity-window,bell-window,last-window,message,message-command,mode,display-panes,display-panes-active"
+    const commands = planTmuxChromeTheme({
+      marker,
+      current: {
+        border: "fg=#333333",
+        active: "fg=#cc5544",
+        status: "bg=#181818,fg=#999999",
+        "status-left": "bg=#181818,fg=#999999",
+        "status-right": "bg=#181818,fg=#999999",
+        window: "bg=#181818,fg=#999999",
+        "current-window": "bg=#222222,fg=#cc5544,bold",
+        "activity-window": "bg=#181818,fg=#3377cc",
+        "bell-window": "bg=#181818,fg=#ddaa33,bold",
+        "last-window": "bg=#181818,fg=#999999",
+        message: "bg=#2a2a2a,fg=#eeeeee",
+        "message-command": "bg=#2a2a2a,fg=#cc5544,bold",
+        mode: "bg=#cc5544,fg=#101010",
+        "display-panes": "#333333",
+        "display-panes-active": "#cc5544",
+      },
+      hexes,
+    })
+    expect(commands).toEqual([])
+  })
+
+  test("disabling releases every tmux chrome option kobe owns", () => {
+    const marker =
+      "border,active,status,status-left,status-right,window,current-window,activity-window,bell-window,last-window,message,message-command,mode,display-panes,display-panes-active"
+    const commands = planTmuxChromeTheme({
+      marker,
+      current: {},
+      hexes: resolveTmuxChromeHexes({ theme: {} }, "primary"),
+    })
+    expect(commands).toEqual([
+      ["set-option", "-gwu", "pane-border-style"],
+      ["set-option", "-gwu", "pane-active-border-style"],
+      ["set-option", "-gu", "status-style"],
+      ["set-option", "-gu", "status-left-style"],
+      ["set-option", "-gu", "status-right-style"],
+      ["set-option", "-gu", "window-status-style"],
+      ["set-option", "-gu", "window-status-current-style"],
+      ["set-option", "-gu", "window-status-activity-style"],
+      ["set-option", "-gu", "window-status-bell-style"],
+      ["set-option", "-gu", "window-status-last-style"],
+      ["set-option", "-gu", "message-style"],
+      ["set-option", "-gu", "message-command-style"],
+      ["set-option", "-gu", "mode-style"],
+      ["set-option", "-gu", "display-panes-colour"],
+      ["set-option", "-gu", "display-panes-active-colour"],
+      ["set-option", "-gu", TMUX_CHROME_THEME_MARKER_OPTION],
+    ])
   })
 })


### PR DESCRIPTION
## What changed

- Extends the existing tmux theme pass from pane borders to the full kobe-owned tmux chrome on the isolated `-L kobe` socket.
- Themes `status-style`, `status-left/right-style`, window status variants, tmux prompts, copy-mode selection, pane picker colors, and pane borders from the active kobe theme.
- Removes the hardcoded `brightblack` inline style from `status-right` so the right-side hint follows `status-right-style`.
- Adds a patch changeset for `@sma1lboy/kobe`.

## Root cause

kobe previously applied theme colors only to `pane-border-style` and `pane-active-border-style`. The bottom ChatTab/status bar was deliberately left to tmux defaults or the user's `~/.tmux.conf`, so it could stay green/black or use an unrelated tmux theme even when kobe panes were themed.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run test:behavior`
- `timeout 5 bun run dev:sandbox`
- Isolated real-tmux smoke against `tmux -L kobe-statusbar-test` confirmed the new status/window/message/mode/border options are accepted and set to theme colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comprehensive tmux theming now applies full visual styling (status/window bars, borders, command prompts, copy-mode selection, and pane picker overlays) derived from your active theme.

* **Improvements**
  * Enhanced live theme propagation with a polling fallback mechanism to reliably detect theme changes and prevent missed updates, ensuring consistent styling across all running tasks and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->