### PR TITLE
Dedupe Tasks pane project rows

### DIFF
--- a/.changeset/two-kobes-one-project.md
+++ b/.changeset/two-kobes-one-project.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+The Tasks pane now shows only one PROJECTS row for a saved repo even if older state contains duplicate `main` task records, and `ensureMainTask` now dedupes repo-root, subdirectory, symlink-resolved, and trailing-slash variants before creating a new project row.

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -26,7 +26,7 @@ import { realpathSync } from "node:fs"
 import { basename, resolve } from "node:path"
 import type { Accessor } from "solid-js"
 import { createSignal } from "solid-js"
-import { getRemoteRepoConfig } from "../state/repos.ts"
+import { getRemoteRepoConfig, isRemoteRepoKey, resolveRepoRoot } from "../state/repos.ts"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR, toTaskId } from "../types/task.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
@@ -230,28 +230,29 @@ export class Orchestrator {
    * and lives at the top of the sidebar.
    */
   async ensureMainTask(repo: string): Promise<Task> {
-    const existing = this.store.list().find((t) => t.kind === "main" && t.repo === repo)
+    const { repo: normalizedRepo, key } = normalizeMainRepo(repo)
+    const existing = this.store.list().find((t) => t.kind === "main" && normalizeMainRepo(t.repo).key === key)
     if (existing) return existing
-    const inflight = this.mainTaskLocks.get(repo)
+    const inflight = this.mainTaskLocks.get(key)
     if (inflight) return inflight
     const promise = (async () => {
       const created = await this.store.create({
-        repo,
-        title: titleFromRepo(repo),
+        repo: normalizedRepo,
+        title: titleFromRepo(normalizedRepo),
         branch: "",
         // Remote main task lives at the remote basePath, not the ssh:// key.
-        worktreePath: repoWorkingDir(repo),
+        worktreePath: repoWorkingDir(normalizedRepo),
         status: "backlog",
         kind: "main",
         vendor: DEFAULT_TASK_VENDOR,
       })
       return created
     })()
-    this.mainTaskLocks.set(repo, promise)
+    this.mainTaskLocks.set(key, promise)
     try {
       return await promise
     } finally {
-      this.mainTaskLocks.delete(repo)
+      this.mainTaskLocks.delete(key)
     }
   }
 
@@ -607,6 +608,14 @@ export class Orchestrator {
 function titleFromRepo(repo: string): string {
   const segs = repo.split(/[/\\]/).filter(Boolean)
   return segs.length > 0 ? (segs[segs.length - 1] ?? repo) : repo
+}
+
+function normalizeMainRepo(repo: string): { repo: string; key: string } {
+  const normalized = resolveRepoRoot(repo)
+  return {
+    repo: normalized,
+    key: isRemoteRepoKey(normalized) ? normalized : canonPath(normalized),
+  }
 }
 
 /**

--- a/packages/kobe/src/tui/panes/sidebar/groups.ts
+++ b/packages/kobe/src/tui/panes/sidebar/groups.ts
@@ -103,9 +103,16 @@ export function buildRows(
   const main: Task[] = []
   const pinnedRegular: Task[] = []
   const regular: Task[] = []
+  const seenMainRepos = new Set<string>()
   for (const t of filtered) {
-    if (t.kind === "main") main.push(t)
-    else if (t.pinned === true) pinnedRegular.push(t)
+    if (t.kind === "main") {
+      const key = sidebarProjectKey(t.repo)
+      if (seenMainRepos.has(key)) continue
+      seenMainRepos.add(key)
+      main.push(t)
+      continue
+    }
+    if (t.pinned === true) pinnedRegular.push(t)
     else regular.push(t)
   }
   // Projects "sit tight": always alphabetised by repo basename so two repos
@@ -157,6 +164,11 @@ function taskTime(task: Task): number {
 export function repoBasename(repo: string): string {
   const segments = repo.split("/").filter(Boolean)
   return segments[segments.length - 1] ?? repo
+}
+
+function sidebarProjectKey(repo: string): string {
+  const trimmed = repo.trim().replace(/[\\/]+$/, "")
+  return trimmed || repo
 }
 
 /** Extract the flat list of navigable task ids. */

--- a/packages/kobe/test/orchestrator/main-task.test.ts
+++ b/packages/kobe/test/orchestrator/main-task.test.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
+
+let tmpRoot: string
+let repo: string
+let orch: Orchestrator
+
+beforeEach(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-main-task-"))
+  repo = path.join(tmpRoot, "repo")
+  const r = spawnSync("bash", [REPO_INIT, repo], { encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}\n${r.stdout}`)
+  const store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  await store.load()
+  orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+describe("ensureMainTask", () => {
+  test("dedupes repo-root and subdirectory inputs to one main task", async () => {
+    const subdir = path.join(repo, "packages", "kobe")
+    fs.mkdirSync(subdir, { recursive: true })
+
+    const first = await orch.ensureMainTask(repo)
+    const second = await orch.ensureMainTask(subdir)
+    const mainRows = orch.listTasks().filter((t) => t.kind === "main")
+
+    expect(second.id).toBe(first.id)
+    expect(mainRows).toHaveLength(1)
+    expect(mainRows[0]?.repo).toBe(first.repo)
+  })
+
+  test("dedupes concurrent equivalent repo inputs before either create settles", async () => {
+    const subdir = path.join(repo, "src")
+    fs.mkdirSync(subdir)
+
+    const [first, second] = await Promise.all([orch.ensureMainTask(repo), orch.ensureMainTask(subdir)])
+
+    expect(second.id).toBe(first.id)
+    expect(orch.listTasks().filter((t) => t.kind === "main")).toHaveLength(1)
+  })
+})

--- a/packages/kobe/test/tui/sidebar-groups.test.ts
+++ b/packages/kobe/test/tui/sidebar-groups.test.ts
@@ -85,6 +85,35 @@ describe("sidebar task ordering", () => {
     // alpha before zeta despite zeta being more recent.
     expect(ids(rows)).toEqual(["a", "z", "reg"])
   })
+
+  it("shows one project row when stale duplicate main tasks share a repo", () => {
+    const rows = buildRows(
+      [
+        task({ id: "project-a", title: "kobe", kind: "main", repo: "/repo/kobe" }),
+        task({ id: "project-b", title: "kobe copy", kind: "main", repo: "/repo/kobe/" }),
+        task({ id: "regular", title: "task" }),
+      ],
+      "active",
+      "",
+      "default",
+    )
+
+    expect(ids(rows)).toEqual(["project-a", "regular"])
+  })
+
+  it("does not collapse distinct projects just because their basenames match", () => {
+    const rows = buildRows(
+      [
+        task({ id: "project-a", title: "kobe", kind: "main", repo: "/repo/a/kobe" }),
+        task({ id: "project-b", title: "kobe", kind: "main", repo: "/repo/b/kobe" }),
+      ],
+      "active",
+      "",
+      "default",
+    )
+
+    expect(ids(rows)).toEqual(["project-a", "project-b"])
+  })
 })
 
 /**


### PR DESCRIPTION
## Summary
- normalize main-task repo identity in `ensureMainTask` so repo-root/subdirectory/trailing-slash variants do not create duplicate project rows
- collapse stale duplicate `main` rows in the Tasks sidebar render path
- add unit coverage for both the orchestrator write path and sidebar old-state display

## Tests
- `bun vitest run test/orchestrator/main-task.test.ts test/tui/sidebar-groups.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run test:behavior`
- `script -q /tmp/kobe-smoke.log bash -lc 'cd /Users/narwhal/proj/kobe && timeout 5 bun run dev:sandbox'`\n\n## Notes\n- Restarted `kobe daemon` after the orchestrator change.\n