### PR TITLE
feat: add `kobe export` (task list as JSON / CSV / table)

### DIFF
--- a/.changeset/export-task-list.md
+++ b/.changeset/export-task-list.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Add `kobe export` to dump the task list to stdout without a running daemon. It reads `~/.kobe/tasks.json` in process and prints JSON (default), CSV (`--csv`), or an aligned table (`--format table`), so you can pipe tasks into `jq`, open them in a spreadsheet, or glance at them in the terminal — complementing `kobe api list`, which is JSON-only and requires the daemon.

--- a/packages/kobe/src/cli/export-cmd.ts
+++ b/packages/kobe/src/cli/export-cmd.ts
@@ -1,0 +1,141 @@
+/**
+ * `kobe export [--json|--csv|--format=<json|csv|table>]` — dump the task
+ * list to stdout in a machine- or human-readable shape.
+ *
+ * Read-only and DAEMON-FREE: it loads `~/.kobe/tasks.json` in-process via
+ * {@link TaskIndexStore} (the canonical manifest owner — no re-parsing of
+ * the file here) and prints. This complements `kobe api list`, which is
+ * JSON-only and needs a running daemon; `export` works with the daemon
+ * down and adds CSV / aligned-table output for piping into scripts,
+ * spreadsheets, or a quick terminal glance.
+ *
+ * Output contract:
+ *   - `--json` (default) → a JSON array of task rows (parses with `jq`).
+ *   - `--csv`            → RFC-4180-style CSV with a header row.
+ *   - `--format=table`   → aligned, human-readable columns.
+ * Mutates nothing; exit 0 on success, exit 2 on a bad flag/format.
+ */
+
+import type { Task } from "../types/task.ts"
+import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
+
+type ExportFormat = "json" | "csv" | "table"
+
+const EXPORT_USAGE = [
+  "Usage: kobe export [--json | --csv | --format <json|csv|table>]",
+  "",
+  "Print the task list (from ~/.kobe/tasks.json) to stdout. Read-only and",
+  "daemon-free — works with the kobe daemon down.",
+  "",
+  "Options:",
+  "  --json                  JSON array of tasks (default)",
+  "  --csv                   CSV with a header row",
+  "  --format <fmt>          One of: json, csv, table",
+  "  -h, --help              Print this help",
+  "",
+].join("\n")
+
+/** Columns emitted per task, in order. The single source of truth for
+ *  every format's field set + header labels. */
+const COLUMNS = ["id", "title", "status", "archived", "vendor", "branch", "repo", "worktreePath"] as const
+type Column = (typeof COLUMNS)[number]
+
+/** Flatten one task to the exported row (vendor normalized to the default). */
+function toRow(task: Task): Record<Column, string> {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    archived: String(task.archived),
+    vendor: task.vendor ?? DEFAULT_TASK_VENDOR,
+    branch: task.branch,
+    repo: task.repo,
+    worktreePath: task.worktreePath,
+  }
+}
+
+function usageError(message: string): never {
+  process.stderr.write(`kobe export: ${message}\n\n${EXPORT_USAGE}\n`)
+  process.exit(2)
+}
+
+/** Parse `kobe export` argv into a single output format (later flag wins). */
+function parseFormat(args: readonly string[]): ExportFormat {
+  let format: ExportFormat = "json"
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === "--json") format = "json"
+    else if (a === "--csv") format = "csv"
+    else if (a === "--format") {
+      const v = args[++i]
+      if (v === undefined) usageError("--format requires a value (json, csv, or table)")
+      format = coerceFormat(v)
+    } else if (a.startsWith("--format=")) {
+      format = coerceFormat(a.slice("--format=".length))
+    } else {
+      usageError(`unexpected argument "${a}"`)
+    }
+  }
+  return format
+}
+
+function coerceFormat(value: string): ExportFormat {
+  if (value === "json" || value === "csv" || value === "table") return value
+  usageError(`unknown format "${value}" (expected json, csv, or table)`)
+}
+
+/** Quote a CSV field per RFC 4180 when it contains a delimiter, quote, or newline. */
+function csvCell(value: string): string {
+  if (/[",\r\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`
+  return value
+}
+
+function renderCsv(rows: readonly Record<Column, string>[]): string {
+  const lines = [COLUMNS.join(",")]
+  for (const row of rows) {
+    lines.push(COLUMNS.map((c) => csvCell(row[c])).join(","))
+  }
+  return lines.join("\n")
+}
+
+/** Render aligned columns; widths fit the header and every cell. */
+function renderTable(rows: readonly Record<Column, string>[]): string {
+  const widths = {} as Record<Column, number>
+  for (const c of COLUMNS) widths[c] = Math.max(c.length, ...rows.map((r) => r[c].length))
+  const line = (cells: Record<Column, string>) =>
+    COLUMNS.map((c) => cells[c].padEnd(widths[c]))
+      .join("  ")
+      .trimEnd()
+  const header = {} as Record<Column, string>
+  for (const c of COLUMNS) header[c] = c
+  return [line(header), ...rows.map(line)].join("\n")
+}
+
+/** Build the export text for a given format (exported for unit tests). */
+export function renderExport(tasks: readonly Task[], format: ExportFormat): string {
+  const rows = tasks.map(toRow)
+  if (format === "json") return JSON.stringify(rows, null, 2)
+  if (format === "csv") return renderCsv(rows)
+  return renderTable(rows)
+}
+
+export async function runExportSubcommand(args: readonly string[]): Promise<void> {
+  if (args.includes("--help") || args.includes("-h") || args.includes("help")) {
+    process.stdout.write(`${EXPORT_USAGE}\n`)
+    return
+  }
+  const format = parseFormat(args)
+
+  // Read tasks.json directly through its owner — no daemon, no socket.
+  const { TaskIndexStore } = await import("../orchestrator/index/store.ts")
+  const store = new TaskIndexStore()
+  await store.load()
+  const tasks = store.list()
+
+  // A table with no rows would print only a header; keep that explicit for humans.
+  if (tasks.length === 0 && format === "table") {
+    process.stdout.write("no tasks\n")
+    return
+  }
+  process.stdout.write(`${renderExport(tasks, format)}\n`)
+}

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -6,6 +6,7 @@
  *   - `kobe`                    Launch the TUI (default).
  *   - `kobe add [path]`         Save a repo path for the new-task picker.
  *   - `kobe adopt [glob]`       Import existing git worktrees as tasks.
+ *   - `kobe export [--csv]`     Print the task list (json/csv/table; daemon-free).
  *   - `kobe api <verb>`         Scriptable RPC surface for agents (fan-out).
  *   - `kobe daemon <verb>`      Manage the long-lived daemon (start / stop / status / restart).
  *   - `kobe theme <verb>`       Manage user themes.
@@ -330,6 +331,11 @@ async function main(): Promise<void> {
   }
   if (subcommand === "adopt") {
     await runAdoptSubcommand(rest)
+    return
+  }
+  if (subcommand === "export") {
+    const { runExportSubcommand } = await import("./export-cmd.ts")
+    await runExportSubcommand(rest)
     return
   }
   if (subcommand === "repo") {

--- a/packages/kobe/src/cli/usage.ts
+++ b/packages/kobe/src/cli/usage.ts
@@ -21,6 +21,7 @@ export function topLevelUsage(): string {
     "  web [options]           Launch the browser dashboard",
     "  add [path]              Save a repo path for the new-task picker",
     "  adopt [glob]            Import existing git worktrees as tasks",
+    "  export [--csv|--json]   Print the task list (json/csv/table; daemon-free)",
     "  repo <verb>             Per-repo init script + first prompt (show|set|unset)",
     "  api <verb>              Scriptable RPC surface for agents (see `kobe api --help`)",
     "  daemon <verb>           Manage the daemon (start|stop|status|restart)",

--- a/packages/kobe/test/cli/export-cmd.test.ts
+++ b/packages/kobe/test/cli/export-cmd.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { renderExport } from "../../src/cli/export-cmd.ts"
+import { type Task, toTaskId } from "../../src/types/task.ts"
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId("01HZ0000000000000000000001"),
+    title: "Fix the thing",
+    repo: "/home/u/repo",
+    branch: "kobe/fix-thing-01",
+    worktreePath: "/home/u/.kobe/worktrees/repo/fix-thing-01",
+    status: "in_progress",
+    archived: false,
+    vendor: "claude",
+    createdAt: "2026-06-23T00:00:00.000Z",
+    updatedAt: "2026-06-23T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("renderExport", () => {
+  it("emits a JSON array that round-trips and carries the documented fields", () => {
+    const parsed = JSON.parse(renderExport([task()], "json"))
+    expect(Array.isArray(parsed)).toBe(true)
+    expect(parsed[0]).toMatchObject({
+      id: "01HZ0000000000000000000001",
+      title: "Fix the thing",
+      status: "in_progress",
+      archived: "false",
+      vendor: "claude",
+      branch: "kobe/fix-thing-01",
+      repo: "/home/u/repo",
+      worktreePath: "/home/u/.kobe/worktrees/repo/fix-thing-01",
+    })
+  })
+
+  it("defaults a missing vendor to the task default", () => {
+    const parsed = JSON.parse(renderExport([task({ vendor: undefined })], "json"))
+    expect(parsed[0].vendor).toBe("claude")
+  })
+
+  it("writes a CSV header plus one row per task", () => {
+    const csv = renderExport([task(), task({ id: toTaskId("01HZ0000000000000000000002") })], "csv")
+    const lines = csv.split("\n")
+    expect(lines[0]).toBe("id,title,status,archived,vendor,branch,repo,worktreePath")
+    expect(lines).toHaveLength(3)
+  })
+
+  it("quotes and escapes CSV fields containing commas or quotes", () => {
+    const csv = renderExport([task({ title: 'a, "b"' })], "csv")
+    expect(csv.split("\n")[1]).toContain('"a, ""b"""')
+  })
+
+  it("renders an aligned table with a header row", () => {
+    const table = renderExport([task()], "table")
+    const lines = table.split("\n")
+    expect(lines[0].startsWith("id")).toBe(true)
+    expect(lines[1]).toContain("Fix the thing")
+  })
+
+  it("handles an empty task list per format", () => {
+    expect(renderExport([], "json")).toBe("[]")
+    expect(renderExport([], "csv")).toBe("id,title,status,archived,vendor,branch,repo,worktreePath")
+  })
+})


### PR DESCRIPTION
## Direction

Open GitHub issue (#139). Picked over the other open "good first issue" enhancements because it's the tightest, fully-verifiable slice with a clear gap.

## Problem

kobe's task data lives in `~/.kobe/tasks.json`, but there's no daemon-free, machine-readable way to get it out. `kobe api list` exists, but it is JSON-only **and requires a running daemon** (it goes through `task.list` RPC). With the daemon down — or when you just want CSV/columns for a spreadsheet or a quick glance — there was nothing.

## Fix

Adds a read-only `kobe export` subcommand:

- `kobe export` / `kobe export --json` (default) — JSON array of task rows (parses with `jq`).
- `kobe export --csv` — RFC-4180-style CSV with a header row (quotes/escapes commas, quotes, newlines).
- `kobe export --format table` — aligned, human-readable columns.

It loads `~/.kobe/tasks.json` **in process** through `TaskIndexStore` (the canonical manifest owner — no re-parsing of the file) so it never starts or needs the daemon. Mutates nothing; exit 0 on success, exit 2 on a bad flag/format with a friendly usage error.

Fields per task: `id`, `title`, `status`, `archived`, `vendor`, `branch`, `repo`, `worktreePath`. (Added `archived` to the issue's listed set so archived and active tasks are distinguishable in a flat dump — every status, including archived, is exported, matching `kobe api list`.) Missing `vendor` normalizes to the task default.

Wired into the `cli/index.ts` dispatch chain and `cli/usage.ts` help text.

## How verified

- `bun run typecheck` and `bun run lint` — both green.
- New unit test `test/cli/export-cmd.test.ts` (6 cases: JSON round-trip + documented fields, vendor defaulting, CSV header/rows, CSV escaping, table header, empty-list per format) and existing `usage.test.ts` — all green.
- End-to-end smoke against a throwaway `$HOME` with a 2-task `tasks.json` (one with embedded `,`/`"` in the title, one archived): JSON, CSV, and table all render correctly; `--format yaml` exits 2 with usage; empty store prints `no tasks` for the table.

## Follow-ups (deliberately deferred)

- No `--archived`/status filtering flag yet — export is the full list, like `api list`. Easy to add later if wanted.
- Other open good-first-issues (#136 completions, #137 doctor `--report`, #138 `kobe config`) are untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ws4K9UFYspNdfHqb5JdH7c)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `kobe export` command to output your task list in multiple formats: JSON (default), CSV, or aligned table
  * Works independently without requiring a daemon to run
  * Supports `--csv` and `--format table` flags for output customization

* **Documentation**
  * Updated CLI help text to document the new export command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->