### PR TITLE
fix: friendlier non-git-repo error with a concrete fix

### DIFF
--- a/.changeset/non-git-repo-task-message.md
+++ b/.changeset/non-git-repo-task-message.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Friendlier, actionable error when a task's folder isn't a git repo. Instead of leaking git's bare `fatal: not a git repository`, both the new-task dialog's inline validation and the worktree-creation toast now explain why a task needs a git repo and hand over the exact fix (`git init && git add -A && git commit -m "init"`), noting that non-git folders will be supported later.

--- a/packages/kobe/src/tui/lib/git-snapshot.ts
+++ b/packages/kobe/src/tui/lib/git-snapshot.ts
@@ -40,6 +40,19 @@ export const DEFAULT_BASE_REF = "main"
  *      both "exists but not a repo" and "exists but git is unhappy"
  *      with a single check.
  */
+/**
+ * Friendly reason for the "exists but isn't a git repo" case. A task is a
+ * `git worktree + engine session + branch`, so for now the source dir must
+ * already be a git repo — `git worktree add` has nothing to branch from
+ * otherwise. Non-git project roots are a planned follow-up; until then we
+ * explain the why and hand the user the exact fix instead of leaking git's
+ * `fatal: not a git repository`. Rendered with word-wrap, so a full
+ * sentence + command is fine here.
+ */
+function notAGitRepoReason(path: string): string {
+  return `This folder isn't a git repository yet, and a task needs a git branch to work in. To fix it, turn ${path} into a repo:  git init && git add -A && git commit -m "init"  — then create the task again. (Working in non-git folders is coming soon.)`
+}
+
 export function validateRepoPath(repo: string): string | null {
   const trimmed = repo.trim()
   if (!trimmed) return "repo path is required"
@@ -58,9 +71,9 @@ export function validateRepoPath(repo: string): string | null {
       timeout: 2000,
       stdio: ["ignore", "pipe", "ignore"],
     })
-    if (out.status !== 0) return `not a git repository: ${trimmed}`
+    if (out.status !== 0) return notAGitRepoReason(trimmed)
   } catch {
-    return `not a git repository: ${trimmed}`
+    return notAGitRepoReason(trimmed)
   }
   return null
 }

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -109,6 +109,22 @@ function worktreeCwdUsable(cwd: string | undefined): cwd is string {
   return !!cwd && worktreeUsable(cwd)
 }
 
+/**
+ * Toast text for a failed `ensureWorktree`. The new-task dialog blocks
+ * non-git repos pre-submit, but tasks created via other entry points (CLI,
+ * adopted state) can still reach here with a bare `fatal: not a git
+ * repository`. Translate that into the real reason — a task is a git
+ * worktree + branch, so for now the project must already be a git repo
+ * (non-git roots are a planned follow-up) — instead of leaking git's stderr.
+ */
+function worktreeErrorToast(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err)
+  if (/not a git repository/i.test(raw)) {
+    return "This project isn't a git repo yet — a task needs a git branch. Run `git init` (+ a first commit) in the project, then open the task. Non-git support is coming."
+  }
+  return `Couldn't create the worktree: ${raw}`
+}
+
 function TasksShell(props: {
   tasks: Accessor<readonly Task[]>
   initialTaskId?: string
@@ -395,7 +411,7 @@ function TasksShell(props: {
         worktree = await props.orch.ensureWorktree(id)
       } catch (err) {
         console.error("[kobe tasks] task.ensureWorktree failed:", err)
-        notifyError(`Couldn't create worktree: ${err instanceof Error ? err.message : String(err)}`)
+        notifyError(worktreeErrorToast(err))
         return
       }
       await props.reload()
@@ -589,7 +605,7 @@ function TasksShell(props: {
         cwd = await props.orch.ensureWorktree(id)
       } catch (err) {
         console.error("[kobe tasks] task.ensureWorktree failed:", err)
-        notifyError(`Couldn't create worktree: ${err instanceof Error ? err.message : String(err)}`)
+        notifyError(worktreeErrorToast(err))
         return
       }
       await props.reload()

--- a/packages/kobe/test/tui/lib/git-snapshot.test.ts
+++ b/packages/kobe/test/tui/lib/git-snapshot.test.ts
@@ -55,7 +55,10 @@ describe("validateRepoPath", () => {
     expect(validateRepoPath("")).toBe("repo path is required")
     expect(validateRepoPath(path.join(root, "missing"))).toContain("path does not exist")
     expect(validateRepoPath(plainFile)).toContain("not a directory")
-    expect(validateRepoPath(notRepo)).toContain("not a git repository")
+    // Non-repo: friendly copy that explains the why and hands over the fix.
+    const nonRepo = validateRepoPath(notRepo)
+    expect(nonRepo).toContain("isn't a git repository")
+    expect(nonRepo).toContain("git init")
   })
 
   it("returns null for a usable git repo", () => {


### PR DESCRIPTION
## Summary
- Creating a task in a folder that isn't a git repo used to surface git's bare `fatal: not a git repository`. Now both surfaces explain *why* a task needs a git repo (a task is a worktree + branch) and hand over the exact fix.
- New-task dialog inline validation (word-wrapped, room for prose): explains the problem and gives the copy-paste fix `git init && git add -A && git commit -m "init"`, plus a note that non-git folders are coming.
- Worktree-creation toast (`ensureWorktree` failure path, both catch sites in `tasks-pane/host.tsx`): catch-all for tasks reaching git via non-dialog entry points (CLI, adopted state); rewrites the `not a git repository` case into the same friendly guidance via a shared `worktreeErrorToast()` helper.

## Test plan
- [x] `bun run typecheck` (kobe)
- [x] `bun test test/tui/lib/git-snapshot.test.ts` — 7 pass (assertions updated to the new copy)
- [x] root `bun run lint` clean
- [ ] Spot-check: create a task pointing at a non-git folder → see the friendly dialog message + toast