### PR TITLE
ci: switch PR review to pr-review-toolkit with kobe house rules

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,9 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write # needed to post the consolidated review comment
       issues: read
       id-token: write
+      actions: read # let the reviewer read this PR's CI results
 
     steps:
       - name: Checkout repository
@@ -39,7 +40,23 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          plugins: 'pr-review-toolkit@claude-code-plugins'
+          additional_permissions: |
+            actions: read
+          prompt: |
+            Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Run the pr-review-toolkit's specialized review agents across this PR's diff and synthesize their findings: code-reviewer (general correctness + project guidelines), silent-failure-hunter (swallowed errors / error handling), pr-test-analyzer (test coverage + quality), type-design-analyzer (type design / invariants), comment-analyzer (comment accuracy), and code-simplifier (simplification opportunities).
+
+            First read `CLAUDE.md` and `packages/kobe/CLAUDE.md`, then ALSO hold this PR to kobe's house rules and flag any violation:
+            - No `Co-Authored-By: Claude` / AI / Anthropic / "Generated with Claude Code" attribution anywhere in commits or the PR body.
+            - A user-facing change to the published package must ship a Changeset (`.changeset/*.md`); the bump must be `patch` unless the PR explicitly states otherwise — flag stray minor/major.
+            - Layout must be flex-first (`flexGrow`/`flexShrink`/`flexBasis`); a hardcoded `width={N}`/`height={N}` needs a documented rationale (sidebar rail, fixed terminal glyph, modal overlay).
+            - Engine-owned UI data: neutral TUI/web/orchestrator layers must NOT hard-code Claude/Codex strings — name/label/model/capability data comes from the engine registry.
+            - No placeholder/stub/TODO implementations; no deletion of files/branches/worktrees unless clearly intended.
+
+            Then assess the PR along these directions and note gaps: (a) correctness/bugs, (b) does it actually resolve the issue/user-story it claims, (c) architecture & code-health fit, (d) feature/UX quality, (e) shipped behavior vs stated intent.
+
+            Post ONE consolidated review as a PR comment: a one-line verdict, then findings grouped by severity (Blocking / Should-fix / Nit), each with `file:line` and a concrete suggestion. Be concise and skip empty sections. Do NOT approve, merge, or push changes.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## What
Swaps the CI Claude review (`claude-code-review.yml`) from the generic `code-review` plugin to anthropics' **`pr-review-toolkit`** — six specialized agents (code-reviewer, silent-failure-hunter, pr-test-analyzer, type-design-analyzer, comment-analyzer, code-simplifier) — and layers kobe's own review rubric into the prompt.

## Why
The generic reviewer catches diff-level correctness but doesn't know kobe's house rules. The new prompt has the reviewer ALSO enforce, on every PR:
- the five review directions (correctness, issue/user-story conformance, architecture & code health, feature/UX, shipped-vs-intent);
- no AI/Anthropic/Claude attribution in commits or PR body;
- a Changeset is present for user-facing package changes, with a `patch` bump unless stated otherwise;
- flex-first layout (hardcoded `width={N}` needs a documented rationale);
- engine-owned UI data (no hard-coded Claude/Codex strings in neutral layers);
- no placeholder/stub implementations or stray deletions.

Output is one consolidated comment grouped Blocking / Should-fix / Nit. `pull-requests` permission is bumped to `write` so the comment can post.

## Note on timing
`pull_request` workflows run from the **base branch** definition, so this only takes effect for PRs opened/updated **after** it lands on `main` — it can't self-test on this PR.