### PR TITLE
feat: top-to-bottom keyboard flow for the new-task dialog

### DIFF
--- a/.changeset/new-task-dialog-keyboard-flow.md
+++ b/.changeset/new-task-dialog-keyboard-flow.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Reworked the new-task dialog into a single top-to-bottom keyboard flow. The mode tabs (For Existing / New Repo / Adopt) and the engine selector are now real focus stops — the dialog opens on the mode row so ←/→ switches the mode immediately, Tab walks down `mode → engine → repo → branch → Create`, and the Create button moved to the bottom-right where "tab through, then commit" expects it. Picking a directory in the repo / clone-parent pickers now **selects** it (Enter or click) and advances to the next field instead of drilling endlessly into its children; keep typing to browse deeper. Enter on the last field creates the task directly (no second press on Create).

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -33,14 +33,14 @@
  * `../../lib/path-helpers.ts`.
  */
 
-import { ALL_VENDORS, type VendorId, nextVendorWithin } from "@/types/vendor"
+import { ALL_VENDORS, type VendorId, nextVendorWithin, prevVendorWithin } from "@/types/vendor"
 import type { AdoptableWorktree } from "@/types/worktree"
 import { TextAttributes } from "@opentui/core"
 import { For, Show, createEffect, createMemo, createResource, createSignal } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { DEFAULT_BASE_REF, getCurrentBranch, listLocalBranches, validateRepoPath } from "../../lib/git-snapshot"
 import { useBindings } from "../../lib/keymap"
-import { expandHome, filterSubdirs, joinDrill, listSubdirs, splitPathForDirSuggest } from "../../lib/path-helpers"
+import { expandHome, filterSubdirs, joinPicked, listSubdirs, splitPathForDirSuggest } from "../../lib/path-helpers"
 import { useDialog } from "../../ui/dialog"
 import {
   cloneRepo,
@@ -64,6 +64,7 @@ import {
   nextDialogTab,
   nextField,
   pickerModeFor,
+  prevDialogTab,
   resolveBaseRef,
   stripNewlines,
   windowAround,
@@ -133,7 +134,10 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
   // prompt lives in the chat composer — orchestrator.runTask back-fills
   // the task title from it on first submit (see PLACEHOLDER_TASK_TITLE
   // in core.ts).
-  const [field, setField] = createSignal<Field>("repo")
+  // Open focused on the mode selector so ←/→ switches existing/clone/adopt
+  // the moment the dialog appears (no text input has the arrows yet); Tab
+  // then walks down engine → repo → branch → Create.
+  const [field, setField] = createSignal<Field>("tabs")
   const [repo, setRepo] = createSignal(props.defaultRepo)
   // Initial baseRef tracks the cwd's current branch (e.g. a worktree
   // forked from a feature branch should default to that branch, not
@@ -185,6 +189,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
   const activeList = createMemo<readonly string[]>(() => (mode() === "browse" ? subdirFiltered() : savedFiltered()))
   const [repoCursor, setRepoCursor] = createSignal(0)
   const activeWindow = createMemo<PickerWindow>(() => windowAround(activeList(), repoCursor()))
+  // True once the user has SELECTED a directory (Enter / click) rather
+  // than drilling into it — collapses the suggestion dropdown so the path
+  // reads as "locked in". Reset on the next keystroke so typing resumes
+  // browsing. Without this, browse mode would keep listing the selected
+  // dir's children and there'd be no way to say "this one, done".
+  const [repoPicked, setRepoPicked] = createSignal(false)
 
   // Branch picker — refreshed whenever the repo path changes. The
   // baseRef field still accepts free text (so tags / commit SHAs / refs
@@ -208,6 +218,9 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
   )
   const [cloneParentCursor, setCloneParentCursor] = createSignal(0)
   const cloneParentWindow = createMemo<PickerWindow>(() => windowAround(cloneParentFiltered(), cloneParentCursor()))
+  // Same "selected, not drilled" latch as repoPicked, for the clone
+  // parent-dir picker.
+  const [cloneParentPicked, setCloneParentPicked] = createSignal(false)
 
   // Adopt-tab state (KOB-256): discover existing worktrees for the
   // chosen repo, filter by a path glob, multi-select, then import.
@@ -393,6 +406,26 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
     setSubmitError(null)
   }
 
+  // ←/→ while the mode-tab selector (field === "tabs") is focused: switch
+  // the active sub-tab but KEEP focus on the selector so the user can keep
+  // arrowing. (switchToTab, used by mouse + ctrl+[/], dives into the form
+  // instead.) `tabs` is a shared field, valid on every sub-tab.
+  function cycleTab(dir: 1 | -1) {
+    if (cloneInFlight()) return
+    const next = dir === 1 ? nextDialogTab(tab()) : prevDialogTab(tab())
+    if (next === tab()) return
+    setTab(next)
+    setSubmitError(null)
+    setField("tabs")
+  }
+
+  // ←/→ while the engine selector (field === "engine") is focused: cycle
+  // the vendor within the detected set. Mirrors ctrl+e, which works from
+  // any field.
+  function cycleEngine(dir: 1 | -1) {
+    setVendor((v) => (dir === 1 ? nextVendorWithin(availableVendors(), v) : prevVendorWithin(availableVendors(), v)))
+  }
+
   // Enter on the repo field (existing tab). Pure selection — never
   // commits. Commit lives on the Create button at the bottom.
   function onRepoSubmit() {
@@ -409,15 +442,16 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
       const picked = list[repoCursor()]
       const split = subdirSplit()
       if (picked) {
-        if (split.filter) {
-          setRepo(joinDrill(repo(), split.base, picked))
-          return
-        }
-        const resolved = expandHome(repo().trim())
-        if (!resolved || validateRepoPath(resolved) !== null) {
-          setRepo(joinDrill(repo(), split.base, picked))
-          return
-        }
+        // Enter = SELECT this directory as the repo (no trailing slash, no
+        // deeper drill) and advance to the branch field. Collapse the
+        // dropdown; typing in repo again resumes browsing. Previously Enter
+        // drilled into the dir and re-listed its children, so there was no
+        // way to say "this one — done".
+        setRepo(joinPicked(repo(), split.base, picked))
+        setRepoCursor(0)
+        setRepoPicked(true)
+        setField("baseRef")
+        return
       }
       setField("baseRef")
       return
@@ -436,9 +470,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
     const picked = list[absoluteIndex]
     if (!picked) return
     if (mode() === "browse") {
+      // Click = select (not drill) and advance, mirroring Enter.
       const split = subdirSplit()
-      setRepo(joinDrill(repo(), split.base, picked))
+      setRepo(joinPicked(repo(), split.base, picked))
       setRepoCursor(absoluteIndex)
+      setRepoPicked(true)
+      setField("baseRef")
       return
     }
     setRepo(picked)
@@ -455,7 +492,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
     const picked = list[cloneParentCursor()]
     const split = cloneParentSplit()
     if (picked) {
-      setCloneParent(joinDrill(cloneParent(), split.base, picked))
+      // Enter = select this parent dir (not drill) and advance to the
+      // folder-name field. Collapse the dropdown; typing resumes browsing.
+      setCloneParent(joinPicked(cloneParent(), split.base, picked))
+      setCloneParentCursor(0)
+      setCloneParentPicked(true)
+      setField("cloneFolder")
       return
     }
     setField("cloneFolder")
@@ -465,8 +507,10 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
     const picked = list[absoluteIndex]
     if (!picked) return
     const split = cloneParentSplit()
-    setCloneParent(joinDrill(cloneParent(), split.base, picked))
+    setCloneParent(joinPicked(cloneParent(), split.base, picked))
     setCloneParentCursor(absoluteIndex)
+    setCloneParentPicked(true)
+    setField("cloneFolder")
   }
 
   // Ctrl+A toggles select-all on the Adopt tab. It MUST be gated at
@@ -564,6 +608,23 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
           }
         },
       },
+      // ←/→ and Enter on the shared selectors (mode tabs + engine). These
+      // MUST be registration-gated to field === "tabs"|"engine": while a
+      // text input is focused, left/right belong to the input's cursor and
+      // Enter to its onSubmit — the dispatcher calls preventDefault() on
+      // every matched binding, so an always-on left/right would swallow
+      // those keys from the focused input (same regression class as the
+      // ctrl+a gating above). The config thunk re-runs per keypress, so
+      // this spread tracks field() live.
+      ...(field() === "tabs" || field() === "engine"
+        ? [
+            { key: "left", cmd: () => (field() === "tabs" ? cycleTab(-1) : cycleEngine(-1)) },
+            { key: "right", cmd: () => (field() === "tabs" ? cycleTab(1) : cycleEngine(1)) },
+            // Enter on a selector commits the highlight and advances, same
+            // as Tab — so a keyboard user can run the whole form on Enter.
+            { key: "return", cmd: () => setField((f) => nextField(f, tab())) },
+          ]
+        : []),
       // Ctrl+A select-all exists ONLY on the Adopt tab (registration-gated;
       // see `adoptSelectAll` above). On the Existing/Clone tabs it's absent,
       // so ctrl+a falls through to the focused input as line-home.
@@ -588,22 +649,9 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
 
   return (
     <box paddingLeft={2} paddingRight={2} gap={0}>
-      <box flexDirection="row" justifyContent="space-between">
+      <box flexDirection="row">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
           New task
-        </text>
-        {/* Header-right Create button. Commits the active tab's form
-            on click; the form is also reachable by tabbing to the
-            confirm field and pressing Enter (handler shared via
-            commit()). Lives in the header — not the bottom container —
-            so its position stays anchored regardless of how tall the
-            interactive surface below grows. */}
-        <text
-          fg={field() === "confirm" ? theme.primary : theme.text}
-          attributes={field() === "confirm" ? TextAttributes.BOLD : undefined}
-          onMouseUp={() => commit()}
-        >
-          {cloneInFlight() ? "[ Cloning… ]" : field() === "confirm" ? "▸ [ Create ]" : "[ Create ]"}
         </text>
       </box>
       {/* Top section — interactive surface: the sub-tab selector, the
@@ -612,46 +660,69 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
           clone has 4). ctrl+[ / ctrl+] toggles tabs; mouse click
           selects. */}
       <box gap={1} paddingTop={1} paddingBottom={1}>
-        <box flexDirection="row" gap={2}>
-          <text
-            fg={tab() === "existing" ? theme.primary : theme.textMuted}
-            attributes={tab() === "existing" ? TextAttributes.BOLD : undefined}
-            onMouseUp={() => switchToTab("existing")}
-          >
-            {tab() === "existing" ? "▸ For Existing" : "  For Existing"}
-          </text>
-          <text
-            fg={tab() === "clone" ? theme.primary : theme.textMuted}
-            attributes={tab() === "clone" ? TextAttributes.BOLD : undefined}
-            onMouseUp={() => switchToTab("clone")}
-          >
-            {tab() === "clone" ? "▸ For New Repo" : "  For New Repo"}
-          </text>
-          <text
-            fg={tab() === "adopt" ? theme.primary : theme.textMuted}
-            attributes={tab() === "adopt" ? TextAttributes.BOLD : undefined}
-            onMouseUp={() => switchToTab("adopt")}
-          >
-            {tab() === "adopt" ? "▸ Adopt Worktree" : "  Adopt Worktree"}
-          </text>
-        </box>
-        {/* Engine selector — common to both tabs. Defaults to the user's
-            last-selected vendor (clamped to a detected one); ctrl+e cycles,
-            click picks. Only vendors whose CLI was detected are listed. */}
-        <box flexDirection="row" gap={2}>
-          <text fg={theme.textMuted}>engine</text>
-          <For each={availableVendors()}>
-            {(v) => (
+        {/* Mode-tab selector. Self-describing phrases, so no label line
+            (unlike the engine chips). Reachable by Tab (field === "tabs");
+            ←/→ switches the active tab while focused, ctrl+[/] from anywhere,
+            mouse click selects. The active tab shows accent while the
+            selector is focused (so keyboard focus is visible without a text
+            cursor) and primary otherwise. */}
+        {(() => {
+          const tabFocused = () => field() === "tabs"
+          const tabFg = (active: boolean) => (active ? (tabFocused() ? theme.accent : theme.primary) : theme.textMuted)
+          return (
+            <box flexDirection="row" gap={2}>
               <text
-                fg={vendor() === v ? theme.primary : theme.textMuted}
-                attributes={vendor() === v ? TextAttributes.BOLD : undefined}
-                onMouseUp={() => setVendor(v)}
+                fg={tabFg(tab() === "existing")}
+                attributes={tab() === "existing" ? TextAttributes.BOLD : undefined}
+                onMouseUp={() => switchToTab("existing")}
               >
-                {v}
+                {tab() === "existing" ? "▸ For Existing" : "  For Existing"}
               </text>
-            )}
-          </For>
-          <text fg={theme.textMuted}>ctrl+e</text>
+              <text
+                fg={tabFg(tab() === "clone")}
+                attributes={tab() === "clone" ? TextAttributes.BOLD : undefined}
+                onMouseUp={() => switchToTab("clone")}
+              >
+                {tab() === "clone" ? "▸ For New Repo" : "  For New Repo"}
+              </text>
+              <text
+                fg={tabFg(tab() === "adopt")}
+                attributes={tab() === "adopt" ? TextAttributes.BOLD : undefined}
+                onMouseUp={() => switchToTab("adopt")}
+              >
+                {tab() === "adopt" ? "▸ Adopt Worktree" : "  Adopt Worktree"}
+              </text>
+            </box>
+          )
+        })()}
+        {/* Engine selector — same label-on-top / options-below shape as the
+            mode strip and the repo/branch fields. Reachable by Tab (field
+            === "engine"); ←/→ cycles while focused, ctrl+e from anywhere,
+            click picks. Only detected vendors are listed. The selected
+            vendor carries a ▸ marker (parallel to the mode strip) and shows
+            accent-when-focused / primary otherwise; the ctrl+e hint is
+            right-stuck + muted so it reads as a hint, not an engine. */}
+        <box gap={0}>
+          <text fg={field() === "engine" ? theme.accent : theme.textMuted}>engine</text>
+          <box flexDirection="row" gap={2}>
+            <For each={availableVendors()}>
+              {(v) => {
+                const selected = () => vendor() === v
+                return (
+                  <text
+                    fg={selected() ? (field() === "engine" ? theme.accent : theme.primary) : theme.textMuted}
+                    attributes={selected() ? TextAttributes.BOLD : undefined}
+                    onMouseUp={() => setVendor(v)}
+                  >
+                    {selected() ? "▸ " : "  "}
+                    {v}
+                  </text>
+                )
+              }}
+            </For>
+            <box flexGrow={1} />
+            <text fg={theme.textMuted}>ctrl+e</text>
+          </box>
         </box>
         <Show when={tab() === "existing"}>
           {/* ── Existing tab body ───────────────────────────────────── */}
@@ -661,14 +732,17 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={repo()}
               placeholder={props.defaultRepo}
               focused={field() === "repo"}
-              onInput={(v: string) => setRepo(stripNewlines(v))}
+              onInput={(v: string) => {
+                setRepoPicked(false)
+                setRepo(stripNewlines(v))
+              }}
               onSubmit={() => {
                 if (!repo().trim()) return
                 onRepoSubmit()
               }}
             />
           </box>
-          <Show when={field() === "repo" && activeList().length > 0}>
+          <Show when={field() === "repo" && activeList().length > 0 && !repoPicked()}>
             <box gap={0} paddingLeft={2}>
               <Show when={activeWindow().start > 0}>
                 <text fg={theme.textMuted} wrapMode="none">
@@ -716,9 +790,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
                 setBaseRef(stripNewlines(v))
               }}
               onSubmit={() => {
+                // Last field on the existing tab — Enter resolves the
+                // highlighted branch and creates straight away (no second
+                // Enter on Create). Mouse users still get the Create button.
                 setBaseRef(resolveBaseRef(baseRef(), branchFiltered(), branchCursor()))
                 setBaseRefTouched(true)
-                setField("confirm")
+                commitExisting()
               }}
             />
           </box>
@@ -790,7 +867,10 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={cloneParent()}
               placeholder="~/"
               focused={field() === "cloneParent"}
-              onInput={(v: string) => setCloneParent(stripNewlines(v))}
+              onInput={(v: string) => {
+                setCloneParentPicked(false)
+                setCloneParent(stripNewlines(v))
+              }}
               onSubmit={() => onCloneParentSubmit()}
             />
           </box>
@@ -807,7 +887,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               </text>
             </box>
           </Show>
-          <Show when={field() === "cloneParent" && cloneParentFiltered().length > 0}>
+          <Show when={field() === "cloneParent" && cloneParentFiltered().length > 0 && !cloneParentPicked()}>
             <box gap={0} paddingLeft={2}>
               <Show when={cloneParentWindow().start > 0}>
                 <text fg={theme.textMuted} wrapMode="none">
@@ -858,7 +938,9 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               placeholder={DEFAULT_BASE_REF}
               focused={field() === "cloneBaseRef"}
               onInput={(v: string) => setCloneBaseRef(stripNewlines(v))}
-              onSubmit={() => setField("confirm")}
+              // Last field on the clone tab — Enter kicks off the clone +
+              // create directly, no second Enter on the Create button.
+              onSubmit={() => void commitClone()}
             />
           </box>
           <Show when={cloneInFlight()}>
@@ -952,13 +1034,21 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
           </text>
         </Show>
       </box>
-      {/* Bottom hint legend — sits right below the form with no chrome
-          around it; the Create button lives in the dialog header
-          (top-right) so the action stays anchored as the form resizes.
-          paddingTop separates it from the form above, paddingBottom
-          gives the dialog's bottom edge breathing room. */}
-      <box paddingTop={1} paddingBottom={1}>
-        <text fg={theme.textMuted}>↑↓ pick · enter select · tab next field · ctrl+[/] switch · esc cancel</text>
+      {/* Bottom action row — hint legend on the left, Create button stuck
+          to the bottom-right (the conventional "tab through, then commit"
+          anchor). Create commits the active tab's form on click; it's also
+          reachable by tabbing to the confirm field (Enter), or by pressing
+          Enter on the last input of the tab. Shows accent/bold while the
+          confirm field is focused so the keyboard anchor is visible. */}
+      <box flexDirection="row" justifyContent="space-between" alignItems="center" paddingTop={1} paddingBottom={1}>
+        <text fg={theme.textMuted}>↑↓ pick · tab next field · ←→ switch · enter done · esc cancel</text>
+        <text
+          fg={field() === "confirm" ? theme.primary : theme.text}
+          attributes={field() === "confirm" ? TextAttributes.BOLD : undefined}
+          onMouseUp={() => commit()}
+        >
+          {cloneInFlight() ? "[ Cloning… ]" : field() === "confirm" ? "▸ [ Create ]" : "[ Create ]"}
+        </text>
       </box>
     </box>
   )

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -76,14 +76,30 @@ export function nextDialogTab(tab: DialogTab): DialogTab {
   return "existing"
 }
 
+/** Reverse cycle for the tab strip: existing → adopt → clone → existing.
+ *  Powers ←/→ navigation when the mode-tab selector is focused. */
+export function prevDialogTab(tab: DialogTab): DialogTab {
+  if (tab === "existing") return "adopt"
+  if (tab === "clone") return "existing"
+  return "clone"
+}
+
 /**
- * Field states for the dialog. The "existing" tab uses `repo` / `baseRef`
- * / `confirm`. The "clone" tab uses `cloneUrl` / `cloneParent` /
- * `cloneFolder` / `cloneBaseRef` / `confirm` — same `confirm` value is
- * shared so the bottom-row Create button works identically on both
- * surfaces. Tab cycling stays inside a single sub-tab's field list.
+ * Field states for the dialog. Two are shared across every sub-tab and
+ * sit at the top of the visual order:
+ *   - `tabs`   — the mode-tab selector (For Existing / New Repo / Adopt).
+ *                ←/→ switches the active sub-tab while it's focused.
+ *   - `engine` — the vendor selector. ←/→ (and ctrl+e from anywhere)
+ *                cycles the engine while it's focused.
+ * Below them each sub-tab has its own inputs: "existing" uses `repo` /
+ * `baseRef`; "clone" uses `cloneUrl` / `cloneParent` / `cloneFolder` /
+ * `cloneBaseRef`; "adopt" uses `adoptFilter`. `confirm` is the bottom-
+ * right Create button, shared by all tabs. Tab walks the whole chain so
+ * the selectors AND the Create button are reachable by keyboard.
  */
 export type Field =
+  | "tabs"
+  | "engine"
   | "repo"
   | "baseRef"
   | "cloneUrl"
@@ -151,15 +167,23 @@ export function stripNewlines(v: string): string {
 }
 
 /**
- * Advance the field-cycle state. Tab walks within the current sub-tab's
- * field list:
- *   existing:   repo → baseRef → confirm → repo
- *   clone:      cloneUrl → cloneParent → cloneFolder → cloneBaseRef → confirm → cloneUrl
+ * Advance the field-cycle state. Tab walks the full chain in visual
+ * order, threading the two shared selectors (`tabs`, `engine`) and the
+ * shared `confirm` button into every sub-tab:
+ *   existing:   tabs → engine → repo → baseRef → confirm → tabs
+ *   clone:      tabs → engine → cloneUrl → cloneParent → cloneFolder → cloneBaseRef → confirm → tabs
+ *   adopt:      tabs → engine → adoptFilter → confirm → tabs
  *
- * `confirm` is shared between both sub-tabs — the caller is responsible
- * for resetting to the right "first field" when the user switches tabs.
+ * The `confirm → tabs → engine → <first input>` trailer is shared, so
+ * tabbing past Create lands back on the selectors rather than stranding
+ * the user. A stale cross-tab input field restarts the active tab's
+ * cycle at its first input.
  */
 export function nextField(field: Field, tab: DialogTab = "existing"): Field {
+  // Shared trailer — the selectors + Create button common to every tab.
+  if (field === "confirm") return "tabs"
+  if (field === "tabs") return "engine"
+  if (field === "engine") return firstFieldFor(tab)
   if (tab === "clone") {
     if (field === "cloneUrl") return "cloneParent"
     if (field === "cloneParent") return "cloneFolder"
@@ -168,7 +192,7 @@ export function nextField(field: Field, tab: DialogTab = "existing"): Field {
     return "cloneUrl"
   }
   if (tab === "adopt") {
-    // Two stops: the glob-filter input and the Create (= Adopt) button.
+    // One input stop (the glob filter) then the Create (= Adopt) button.
     // List navigation is up/down on the rows, not Tab.
     return field === "adoptFilter" ? "confirm" : "adoptFilter"
   }

--- a/packages/kobe/src/tui/lib/path-helpers.ts
+++ b/packages/kobe/src/tui/lib/path-helpers.ts
@@ -119,3 +119,21 @@ export function joinDrill(typedValue: string, baseExpanded: string, name: string
   }
   return out
 }
+
+/**
+ * Compose the input value when the user SELECTS a highlighted
+ * subdirectory (Enter / click) rather than drilling into it: the
+ * concrete path with NO trailing slash, so the suggestion dropdown
+ * collapses instead of listing the dir's children. Preserves a typed
+ * `~/` prefix the same way {@link joinDrill} does. Drilling deeper is
+ * still possible by typing (append `/`).
+ */
+export function joinPicked(typedValue: string, baseExpanded: string, name: string): string {
+  const out = baseExpanded + name
+  if (typedValue.startsWith("~")) {
+    const home = os.homedir()
+    if (out === home) return "~"
+    if (out.startsWith(`${home}/`)) return `~${out.slice(home.length)}`
+  }
+  return out
+}

--- a/packages/kobe/src/types/vendor.ts
+++ b/packages/kobe/src/types/vendor.ts
@@ -59,6 +59,19 @@ export function nextVendorWithin(list: readonly VendorId[], current: VendorId): 
 }
 
 /**
+ * Previous vendor within an arbitrary subset, wrapping around — the
+ * reverse of {@link nextVendorWithin}, powering ←/→ on the new-task
+ * engine selector. A `current` not in the list starts from the last
+ * entry; an empty list returns `current` unchanged.
+ */
+export function prevVendorWithin(list: readonly VendorId[], current: VendorId): VendorId {
+  if (list.length === 0) return current
+  const i = list.indexOf(current)
+  if (i < 0) return list[list.length - 1] ?? current
+  return list[(i - 1 + list.length) % list.length] ?? current
+}
+
+/**
  * Coerce an untrusted string (a CLI flag, a persisted record) to a
  * {@link VendorId}. Engines are now OPEN (users register their own), so a
  * non-empty value passes through as-is — a built-in OR a custom id; the

--- a/packages/kobe/test/tui/lib/path-helpers.test.ts
+++ b/packages/kobe/test/tui/lib/path-helpers.test.ts
@@ -14,7 +14,7 @@
  */
 
 import * as os from "node:os"
-import { expandHome, filterSubdirs, joinDrill, splitPathForDirSuggest } from "@/tui/lib/path-helpers"
+import { expandHome, filterSubdirs, joinDrill, joinPicked, splitPathForDirSuggest } from "@/tui/lib/path-helpers"
 import { describe, expect, it } from "vitest"
 
 describe("expandHome", () => {
@@ -87,5 +87,29 @@ describe("joinDrill", () => {
   it("keeps absolute display when the user typed an absolute path", () => {
     const home = os.homedir()
     expect(joinDrill(`${home}/`, `${home}/`, "code")).toBe(`${home}/code/`)
+  })
+})
+
+describe("joinPicked (select, don't drill — no trailing slash)", () => {
+  it("appends the picked dir WITHOUT a trailing slash so the dropdown collapses", () => {
+    expect(joinPicked("/tmp/", "/tmp/", "repo")).toBe("/tmp/repo")
+  })
+
+  it("rewraps home-relative results in ~/ when the user typed ~", () => {
+    const home = os.homedir()
+    expect(joinPicked("~/", `${home}/`, "code")).toBe("~/code")
+  })
+
+  it("collapses a pick AT the home root back to bare ~", () => {
+    const home = os.homedir()
+    // base is the parent of home, name is home's leaf → out === home.
+    const parent = `${home.slice(0, home.lastIndexOf("/") + 1)}`
+    const leaf = home.slice(home.lastIndexOf("/") + 1)
+    expect(joinPicked("~", parent, leaf)).toBe("~")
+  })
+
+  it("keeps absolute display when the user typed an absolute path", () => {
+    const home = os.homedir()
+    expect(joinPicked(`${home}/`, `${home}/`, "code")).toBe(`${home}/code`)
   })
 })

--- a/packages/kobe/test/tui/new-task-dialog/state.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/state.test.ts
@@ -30,6 +30,7 @@ import {
   nextDialogTab,
   nextField,
   pickerModeFor,
+  prevDialogTab,
   resolveBaseRef,
   stripNewlines,
   windowAround,
@@ -70,6 +71,14 @@ describe("nextDialogTab (KOB-256: 3-tab cycle)", () => {
   })
 })
 
+describe("prevDialogTab (←/→ reverse cycle on the mode-tab selector)", () => {
+  it("cycles existing → adopt → clone → existing", () => {
+    expect(prevDialogTab("existing")).toBe("adopt")
+    expect(prevDialogTab("adopt")).toBe("clone")
+    expect(prevDialogTab("clone")).toBe("existing")
+  })
+})
+
 describe("pickerModeFor", () => {
   it("stays in saved mode when the input exactly matches a saved repo", () => {
     const cwd = "/home/me/proj"
@@ -99,23 +108,34 @@ describe("computeRepoOptions", () => {
 })
 
 describe("nextField / firstFieldFor (per-tab field cycling)", () => {
-  it("cycles the existing tab: repo → baseRef → confirm → repo", () => {
+  it("cycles the existing tab: tabs → engine → repo → baseRef → confirm → tabs", () => {
     expect(nextField("repo", "existing")).toBe("baseRef")
     expect(nextField("baseRef", "existing")).toBe("confirm")
-    expect(nextField("confirm", "existing")).toBe("repo")
+    expect(nextField("confirm", "existing")).toBe("tabs")
+    expect(nextField("tabs", "existing")).toBe("engine")
+    expect(nextField("engine", "existing")).toBe("repo")
   })
 
-  it("cycles the clone tab through all four inputs to confirm and back", () => {
+  it("cycles the clone tab through the selectors + all four inputs to confirm and back", () => {
+    expect(nextField("engine", "clone")).toBe("cloneUrl")
     expect(nextField("cloneUrl", "clone")).toBe("cloneParent")
     expect(nextField("cloneParent", "clone")).toBe("cloneFolder")
     expect(nextField("cloneFolder", "clone")).toBe("cloneBaseRef")
     expect(nextField("cloneBaseRef", "clone")).toBe("confirm")
-    expect(nextField("confirm", "clone")).toBe("cloneUrl")
+    expect(nextField("confirm", "clone")).toBe("tabs")
   })
 
-  it("toggles the adopt tab between filter and confirm (list nav is up/down)", () => {
+  it("walks the adopt tab tabs → engine → filter → confirm → tabs", () => {
+    expect(nextField("engine", "adopt")).toBe("adoptFilter")
     expect(nextField("adoptFilter", "adopt")).toBe("confirm")
-    expect(nextField("confirm", "adopt")).toBe("adoptFilter")
+    expect(nextField("confirm", "adopt")).toBe("tabs")
+  })
+
+  it("threads the shared selectors + Create through every tab in the same order", () => {
+    // confirm → tabs → engine → <first input> is shared trailer logic.
+    expect(nextField("confirm", "existing")).toBe("tabs")
+    expect(nextField("tabs", "clone")).toBe("engine")
+    expect(nextField("engine", "adopt")).toBe("adoptFilter")
   })
 
   it("recovers a stale cross-tab field by restarting the cycle", () => {


### PR DESCRIPTION
## Summary
- Reworks the new-task dialog into one top-to-bottom keyboard flow. The mode tabs (For Existing / New Repo / Adopt) and the engine selector become real focus stops: the dialog **opens on the mode row** so `←/→` switches the mode the instant it appears, and Tab walks `mode → engine → repo → branch → Create`. `ctrl+[ /]` and `ctrl+e` still work from anywhere.
- **Create button moved to the bottom-right** (from the header) — the conventional "tab through, then commit" anchor. Enter on the last field of a tab now creates the task directly (no second press on Create).
- **Directory pickers select-and-advance** instead of drilling endlessly. Enter / click on a highlighted dir in the repo (and clone parent-dir) picker now selects it as the path and moves to the next field; the suggestion dropdown collapses. Keep typing (append `/`) to browse deeper.
- Engine row restructured: `ctrl+e` hint is right-stuck + muted so it no longer reads like a third engine.

## Implementation notes
- New shared selectors threaded into the field cycle (`state.ts` `nextField`: `confirm → tabs → engine → <first input>`), plus `prevDialogTab` and `prevVendorWithin` for `←` reverse cycling.
- `←/→`/Enter selector bindings are **registration-gated** to `field === "tabs"|"engine"` so they never steal cursor/`onSubmit` keys from a focused text input (same dispatcher `preventDefault` class as the existing ctrl+a gating).
- `joinPicked` (no trailing slash) added alongside `joinDrill`; a `repoPicked`/`cloneParentPicked` latch collapses the dropdown until the next keystroke.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test` green (added `joinPicked`, `prevDialogTab`, and rewired `nextField` cycle tests)
- [x] `bun run lint` exit 0
- [ ] Spot-check in `bun dev:sandbox`: open dialog → `←/→` switches mode → Tab to engine → `←/→` switches engine → Tab to repo → `↑/↓` + Enter selects a dir and jumps to branch → Enter creates
