### PR TITLE
fix: engine chip shows selection by weight+colour, not underline

### DIFF
--- a/.changeset/new-task-dialog-focus-underline.md
+++ b/.changeset/new-task-dialog-focus-underline.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-New-task dialog focus is now shown with an underline in the element's own colour instead of switching to the accent hue, which read as jumpy. Field labels stay muted and gain an underline when their field is focused; the active mode tab and selected engine keep their ▸ + bold + primary look and just add an underline while that selector holds focus.
+New-task dialog focus is now shown with an underline in the element's own colour instead of switching to the accent hue, which read as jumpy. Field labels (incl. `engine`) stay muted and gain an underline when their field/selector is focused. The active mode tab and the selected engine are marked by weight + colour (▸ + bold + primary) rather than an underline — the engine row's focus is carried by its label, so the `claude`/`codex` chips never underline.

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -704,12 +704,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
             </box>
           )
         })()}
-        {/* Engine selector — same label-on-top / options-below shape as the
-            mode strip and the repo/branch fields. Reachable by Tab (field
-            === "engine"); ←/→ cycles while focused, ctrl+e from anywhere,
-            click picks. Only detected vendors are listed. The selected
-            vendor carries a ▸ marker (parallel to the mode strip) and shows
-            accent-when-focused / primary otherwise; the ctrl+e hint is
+        {/* Engine selector — label-on-top / options-below. Reachable by Tab
+            (field === "engine"); ←/→ cycles while focused, ctrl+e from
+            anywhere, click picks. Only detected vendors are listed. The
+            selected vendor is ▸ + bold + primary (no underline — selection
+            is shown by weight+colour); focus of the whole selector is shown
+            by the underlined `engine` label instead. The ctrl+e hint is
             right-stuck + muted so it reads as a hint, not an engine. */}
         <box gap={0}>
           <text fg={theme.textMuted} attributes={labelAttrs("engine")}>
@@ -722,7 +722,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
                 return (
                   <text
                     fg={selected() ? theme.primary : theme.textMuted}
-                    attributes={selectedAttrs(selected(), field() === "engine")}
+                    attributes={selected() ? TextAttributes.BOLD : undefined}
                     onMouseUp={() => setVendor(v)}
                   >
                     {selected() ? "▸ " : "  "}


### PR DESCRIPTION
## Summary
- Follow-up to #152. The selected engine chip was bold + primary **and** underlined, which read as redundant/ugly.
- The selected vendor now shows selection by `▸ + bold + primary` only (no underline). The engine row's focus is already carried by its underlined `engine` label, so the `claude`/`codex` chips never underline.
- Mode tabs are unchanged (they have no label, so the active tab still underlines while the mode selector holds focus).
- Folds the wording into the existing pending `new-task-dialog-focus-underline` changeset rather than adding a new one.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` exit 0
- [ ] Spot-check in `bun dev:sandbox`: focus engine row → `engine` label underlines, selected chip is bold+blue with no underline