### PR TITLE
fix: tint focused input value primary in the new-task dialog

### DIFF
--- a/.changeset/new-task-dialog-focus-underline.md
+++ b/.changeset/new-task-dialog-focus-underline.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-New-task dialog focus is now shown with an underline in the element's own colour instead of switching to the accent hue, which read as jumpy. Field labels (incl. `engine`) stay muted and gain an underline when their field/selector is focused. The active mode tab and the selected engine are marked by weight + colour (▸ + bold + primary) rather than an underline — the engine row's focus is carried by its label, so the `claude`/`codex` chips never underline.
+New-task dialog focus is now shown with an underline in the element's own colour instead of switching to the accent hue, which read as jumpy. Field labels (incl. `engine`) stay muted and gain an underline when their field/selector is focused. The active mode tab and the selected engine are marked by weight + colour (▸ + bold + primary) rather than an underline — the engine row's focus is carried by its label, so the `claude`/`codex` chips never underline. The focused field's input value (repo, branch, clone fields) is tinted primary so the value you're editing matches the selected mode tab / engine.

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -745,6 +745,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={repo()}
               placeholder={props.defaultRepo}
               focused={field() === "repo"}
+              focusedTextColor={theme.primary}
               onInput={(v: string) => {
                 setRepoPicked(false)
                 setRepo(stripNewlines(v))
@@ -800,6 +801,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={baseRef()}
               placeholder={DEFAULT_BASE_REF}
               focused={field() === "baseRef"}
+              focusedTextColor={theme.primary}
               onInput={(v: string) => {
                 setBaseRefTouched(true)
                 setBaseRef(stripNewlines(v))
@@ -871,6 +873,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={cloneUrl()}
               placeholder="https://github.com/user/repo.git"
               focused={field() === "cloneUrl"}
+              focusedTextColor={theme.primary}
               onInput={(v: string) => setCloneUrl(stripNewlines(v))}
               onSubmit={() => {
                 if (!cloneUrl().trim()) return
@@ -886,6 +889,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={cloneParent()}
               placeholder="~/"
               focused={field() === "cloneParent"}
+              focusedTextColor={theme.primary}
               onInput={(v: string) => {
                 setCloneParentPicked(false)
                 setCloneParent(stripNewlines(v))
@@ -945,6 +949,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={cloneFolder()}
               placeholder="auto from url"
               focused={field() === "cloneFolder"}
+              focusedTextColor={theme.primary}
               onInput={(v: string) => {
                 setCloneFolderTouched(true)
                 setCloneFolder(stripNewlines(v))
@@ -960,6 +965,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={cloneBaseRef()}
               placeholder={DEFAULT_BASE_REF}
               focused={field() === "cloneBaseRef"}
+              focusedTextColor={theme.primary}
               onInput={(v: string) => setCloneBaseRef(stripNewlines(v))}
               // Last field on the clone tab — Enter kicks off the clone +
               // create directly, no second Enter on the Create button.
@@ -984,6 +990,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
               value={adoptFilter()}
               placeholder="* — type e.g. feature-* to narrow"
               focused={field() === "adoptFilter"}
+              focusedTextColor={theme.primary}
               onInput={(v: string) => setAdoptFilter(stripNewlines(v))}
               onSubmit={() => toggleAdoptCursor()}
             />


### PR DESCRIPTION
## Summary
- Follow-up to #152/#153. The repo / branch / clone input **values** rendered plain white, while the selected mode tab and engine are primary+bold — so the field you're editing didn't read as "the active value".
- Sets `focusedTextColor={theme.primary}` on every input in the dialog: the value of the focused field is now tinted primary, matching the selector language. Unfocused fields stay default.
- Note: opentui `<input>` has no bold attribute, so input values get colour only (not bold); the `<text>`-based mode/engine selections keep bold.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` exit 0
- [ ] Spot-check in `bun dev:sandbox`: focus repo → value turns primary; Tab to branch → its value turns primary, repo returns to default