### PR TITLE
fix: preserve task engine vendor on index load

### DIFF
--- a/.changeset/preserve-task-vendor-on-load.md
+++ b/.changeset/preserve-task-vendor-on-load.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix tasks silently reverting to Claude on restart. The task index loader validated the persisted engine against a stale `claude | codex` check, so a Copilot task — or any task using a user-registered custom engine — quietly downgraded back to Claude every time the daemon reloaded `tasks.json`. Loading now preserves any recorded engine (built-in or custom) and only falls back to Claude when no engine was ever recorded, matching the documented vendor-coercion contract.

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -22,8 +22,9 @@
 import { mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
-import type { Task, TaskId, TaskIndex, TaskPRStatus, TaskStatus, VendorId } from "../../types/task.ts"
+import type { Task, TaskId, TaskIndex, TaskPRStatus, TaskStatus } from "../../types/task.ts"
 import { DEFAULT_TASK_VENDOR, toTaskId } from "../../types/task.ts"
+import { coerceVendorId } from "../../types/vendor.ts"
 import { ulid } from "./ulid.ts"
 
 export interface TaskIndexStoreOptions {
@@ -423,7 +424,7 @@ function coerceTask(value: unknown): Task | null {
     archived,
     pinned: typeof v.pinned === "boolean" ? v.pinned : false,
     kind,
-    vendor: isVendorId(v.vendor) ? v.vendor : DEFAULT_TASK_VENDOR,
+    vendor: coerceVendorId(typeof v.vendor === "string" ? v.vendor : undefined),
     prStatus: coercePRStatus(v.prStatus),
     // Web-board ordering key — must survive the load coercion or every
     // daemon restart silently forgets the user's column order.
@@ -470,10 +471,6 @@ function isPRLifecycleState(v: unknown): v is TaskPRStatus["lifecycle"] {
 
 function isPRCheckState(v: unknown): v is TaskPRStatus["checkState"] {
   return v === "none" || v === "pending" || v === "passing" || v === "failing" || v === "unknown"
-}
-
-function isVendorId(v: unknown): v is VendorId {
-  return v === "claude" || v === "codex"
 }
 
 function isTaskStatus(s: string): s is TaskStatus {

--- a/packages/kobe/test/orchestrator/store-heal.test.ts
+++ b/packages/kobe/test/orchestrator/store-heal.test.ts
@@ -71,6 +71,74 @@ describe("TaskIndexStore self-heal on load", () => {
   })
 })
 
+/**
+ * Vendor coercion on load. The bug it guards: `coerceTask` used to validate
+ * the persisted `vendor` against a narrow `claude | codex` literal check, so a
+ * `copilot` task — or any user-registered custom engine — silently downgraded
+ * to `claude` on every daemon restart. Engines are an OPEN set, so load must
+ * preserve any non-empty recorded vendor (built-in OR custom) and only fall
+ * back to the default for a truly absent/empty value.
+ */
+describe("TaskIndexStore vendor coercion on load", () => {
+  let home: string
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "kobe-vendor-"))
+    await mkdir(join(home, ".kobe"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true })
+  })
+
+  async function writeTasks(tasks: unknown[]): Promise<void> {
+    await writeFile(join(home, ".kobe", "tasks.json"), JSON.stringify({ version: 3, tasks }), "utf8")
+  }
+
+  function taskRow(over: Record<string, unknown>): Record<string, unknown> {
+    return {
+      id: "01HXTASKAAAAAAAAAAAAAAAAA",
+      title: "task",
+      repo: "/repo",
+      branch: "feature",
+      worktreePath: "/repo/feature",
+      status: "backlog",
+      kind: "task",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      ...over,
+    }
+  }
+
+  async function loadVendor(over: Record<string, unknown>): Promise<string | undefined> {
+    await writeTasks([taskRow(over)])
+    const store = new TaskIndexStore({ homeDir: home })
+    const { tasks } = await store.load()
+    return tasks[0]?.vendor
+  }
+
+  it("preserves a copilot vendor", async () => {
+    expect(await loadVendor({ vendor: "copilot" })).toBe("copilot")
+  })
+
+  it("preserves a built-in codex vendor", async () => {
+    expect(await loadVendor({ vendor: "codex" })).toBe("codex")
+  })
+
+  it("preserves a custom (user-registered) engine vendor", async () => {
+    expect(await loadVendor({ vendor: "my-engine" })).toBe("my-engine")
+  })
+
+  it("falls back to claude when vendor is absent", async () => {
+    expect(await loadVendor({})).toBe("claude")
+  })
+
+  it("falls back to claude for an empty or non-string vendor", async () => {
+    expect(await loadVendor({ vendor: "" })).toBe("claude")
+    expect(await loadVendor({ vendor: 42 })).toBe("claude")
+  })
+})
+
 describe("TaskIndexStore task ordering", () => {
   let home: string
 


### PR DESCRIPTION
## Direction

(a) Correctness bug, found by direct code review of the task-index load path.

## Problem

When `TaskIndexStore` loads `tasks.json`, `coerceTask` normalizes each persisted task's `vendor`. It did so through a local guard:

```ts
function isVendorId(v: unknown): v is VendorId {
  return v === "claude" || v === "codex"
}
// ...
vendor: isVendorId(v.vendor) ? v.vendor : DEFAULT_TASK_VENDOR,
```

This is stale and too narrow on two counts:

1. **`copilot` is a first-party engine** (`BUILTIN_VENDORS = ["claude", "codex", "copilot"]` in `types/vendor.ts`) but is missing from the check.
2. **`VendorId` is an OPEN type** (`string & {}`) — users register their own engines (`engineCommand.<id>`, `customEngineIds`). The narrow literal check rejects every custom engine id too.

So any task backed by Copilot **or** a user-registered custom engine silently downgrades to `claude` on every daemon reload / restart — its engine assignment is lost. This also contradicts the documented contract of `coerceVendorId` in `types/vendor.ts`, which is explicitly "a non-empty value passes through as-is — a built-in OR a custom id."

## Fix

Route the load through the canonical `coerceVendorId` instead of the bespoke narrow guard, and delete the now-dead `isVendorId`:

```ts
vendor: coerceVendorId(typeof v.vendor === "string" ? v.vendor : undefined),
```

Now any non-empty recorded engine (built-in or custom) survives the load, and only an absent/empty/non-string value falls back to `claude` (`DEFAULT_TASK_VENDOR`). One source of truth for vendor coercion across the CLI and the store.

## How verified

- Added 5 cases to `test/orchestrator/store-heal.test.ts` covering: copilot preserved, codex preserved, custom engine id preserved, absent vendor → claude, empty/non-string vendor → claude.
- `bun run lint` ✅ and `bun run typecheck` ✅ (both packages) from repo root.
- `vitest run test/orchestrator` → 12 files / 75 tests pass.

## Follow-ups (deliberately deferred)

- The exploration that surfaced this also flagged that several internal `parseOpsFlags` / `parseRemoteFlags` flag parsers report "X is required" when a flag is present but its value is missing — a confusing-error-message nit, not data loss. Left out to keep this slice tight; worth a separate pass if desired.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MKfS1M2D1LGgyaxKuPUuGy)_