### PR TITLE
fix: truncate file-pane paths by code point, not UTF-16 unit

### DIFF
--- a/.changeset/filetree-path-truncation-codepoints.md
+++ b/.changeset/filetree-path-truncation-codepoints.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+File pane no longer mangles non-ASCII filenames when the path is truncated on a narrow pane. `truncatePathTail` counted UTF-16 code units and sliced mid-character, so a path tail ending in an emoji or other astral character (e.g. `…my-🎉-feature.ts`) could split a surrogate pair and render a `�` replacement glyph. It now slices by code point — matching `orchestrator/title.ts` — so characters stay intact. The helper moved to the pure `filetree/rows.ts` module and gained unit tests.

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -65,7 +65,15 @@ import { useTheme } from "../../context/theme"
 import { type FileStatus, type StatusEntry, type TreeNode, buildTree, listFiles, statusFiles } from "./git"
 import { type FileTreeTab, useFileTreeBindings } from "./keys"
 import { openExternally } from "./open-external"
-import { type Row, flattenTree, reconcileRows, sameFileList, sameStatusEntries, statusRows } from "./rows"
+import {
+  type Row,
+  flattenTree,
+  reconcileRows,
+  sameFileList,
+  sameStatusEntries,
+  statusRows,
+  truncatePathTail,
+} from "./rows"
 
 /**
  * Default width of the pane in terminal cells from the old centre-column
@@ -177,17 +185,6 @@ export function summarizeGitError(raw: string): string {
 const TAB_LABEL: Record<FileTreeTab, string> = {
   all: "All",
   changes: "Changes",
-}
-
-/**
- * Truncate a path keeping its TAIL — the leaf (filename) carries the
- * meaning, so on a narrow pane we drop the leading directories and show
- * `…components/sidebar/Sidebar.tsx` rather than clipping the filename
- * off the right. A leading `…` marks the elided prefix.
- */
-function truncatePathTail(path: string, max: number): string {
-  if (max <= 0 || path.length <= max) return path
-  return `…${path.slice(path.length - Math.max(0, max - 1))}`
 }
 
 export function FileTree(props: FileTreeProps) {

--- a/packages/kobe/src/tui/panes/filetree/rows.ts
+++ b/packages/kobe/src/tui/panes/filetree/rows.ts
@@ -56,6 +56,25 @@ export function flattenTree(node: TreeNode, expanded: ReadonlySet<string>, depth
   }
 }
 
+/**
+ * Truncate a path keeping its TAIL — the leaf (filename) carries the
+ * meaning, so on a narrow pane we drop the leading directories and show
+ * `…components/sidebar/Sidebar.tsx` rather than clipping the filename off
+ * the right. A leading `…` marks the elided prefix.
+ *
+ * Counts by code POINT, not UTF-16 code unit: a plain `.slice` can bisect a
+ * surrogate pair (emoji / astral char in a filename) and render a `�`
+ * replacement glyph. Same fix as `orchestrator/title.ts`. `max` is still an
+ * approximate cell budget — a code point can be a wide (CJK) glyph — but
+ * never splitting a character is the correctness floor.
+ */
+export function truncatePathTail(path: string, max: number): string {
+  if (max <= 0) return path
+  const points = [...path]
+  if (points.length <= max) return path
+  return `…${points.slice(points.length - Math.max(0, max - 1)).join("")}`
+}
+
 /** Map a status entry list to Changes-tab rows. */
 export function statusRows(entries: readonly StatusEntry[]): Row[] {
   return entries.map((e) => ({

--- a/packages/kobe/test/tui/filetree-rows.test.ts
+++ b/packages/kobe/test/tui/filetree-rows.test.ts
@@ -13,7 +13,13 @@
  */
 
 import { describe, expect, test } from "vitest"
-import { type Row, reconcileRows, sameFileList, sameStatusEntries } from "../../src/tui/panes/filetree/rows"
+import {
+  type Row,
+  reconcileRows,
+  sameFileList,
+  sameStatusEntries,
+  truncatePathTail,
+} from "../../src/tui/panes/filetree/rows"
 
 function file(path: string, depth = 0): Row {
   return { kind: "file", path, name: path.split("/").pop() ?? path, depth }
@@ -86,5 +92,27 @@ describe("content-equality signal guards", () => {
     expect(sameStatusEntries(a, [{ path: "a.ts", status: "M", added: 1, deleted: 0 }])).toBe(true)
     expect(sameStatusEntries(a, [{ path: "a.ts", status: "M", added: 2, deleted: 0 }])).toBe(false)
     expect(sameStatusEntries(a, null)).toBe(false)
+  })
+})
+
+describe("truncatePathTail", () => {
+  test("returns the path unchanged when it fits the budget", () => {
+    expect(truncatePathTail("src/a.ts", 20)).toBe("src/a.ts")
+    expect(truncatePathTail("src/a.ts", 8)).toBe("src/a.ts")
+  })
+
+  test("keeps the tail (leaf) and marks the elided prefix with a leading …", () => {
+    expect(truncatePathTail("components/sidebar/Sidebar.tsx", 14)).toBe("…r/Sidebar.tsx")
+  })
+
+  test("never bisects a surrogate pair — emoji stay intact", () => {
+    // Each 🎉 is one code point but two UTF-16 code units. Counting by code
+    // point keeps the tail on a character boundary; the old `.slice` by
+    // .length would start mid-emoji and emit a lone surrogate (→ �).
+    expect(truncatePathTail("src/aaaaa-🎉🎉🎉.ts", 8)).toBe("…-🎉🎉🎉.ts")
+  })
+
+  test("max <= 0 returns the path untouched", () => {
+    expect(truncatePathTail("a/b/c.ts", 0)).toBe("a/b/c.ts")
   })
 })


### PR DESCRIPTION
## Problem
On a narrow Ops pane the Changes/All tab truncates long paths to fit, keeping the tail. `truncatePathTail` sliced by `.length` (UTF-16 code units), so a path tail ending in an emoji or other astral character split the surrogate pair and rendered a `�` replacement glyph (e.g. `src/my-🎉-feature.ts` → `…y-�-feature.ts`).

## Fix
Slice by code point (`[...path]`) instead, mirroring the established pattern in `orchestrator/title.ts`. Characters stay intact on any truncation boundary. `max` remains an approximate cell budget (a code point can still be a wide CJK glyph — a separate concern), but never splitting a character is the correctness floor.

Moved the helper from `FileTree.tsx` into the pure, already-tested `filetree/rows.ts` module and added unit tests covering the surrogate-pair case.

## Test
- `packages/kobe/test/tui/filetree-rows.test.ts` — 4 new cases (fits, tail-with-…, surrogate-pair intact, max<=0).
- typecheck + full unit suite green; root lint clean.