### PR TITLE
fix: defer submit Enter on tmux prompt delivery

### DIFF
--- a/.changeset/tmux-prompt-delivery-defer-enter.md
+++ b/.changeset/tmux-prompt-delivery-defer-enter.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Prompts delivered into a tmux engine pane (the repo `init-prompt.md` first message, `kobe api send`, and quick-task delivery) no longer occasionally sit unsent in the composer. `pasteAndSubmit` wrote the bracketed paste and the submit Enter back-to-back, so they could coalesce into one tty read and the engine treated the carriage return as paste content instead of a submit — the same failure the web composer and PTY sidecar already fixed by deferring the Enter ~150ms (CHANGELOG 8f6dd64). The tmux delivery path now applies the same split.

--- a/packages/kobe/src/tmux/prompt-delivery.ts
+++ b/packages/kobe/src/tmux/prompt-delivery.ts
@@ -14,6 +14,13 @@ import { capturePaneById, claudePaneId, claudePaneIdStrict, runTmux, sendKeyName
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
+ * Delay between the bracketed paste and the submit Enter so they land as
+ * separate tty reads. Matches the web composer + sidecar `/pty/send` fix
+ * (CHANGELOG 8f6dd64); see {@link pasteAndSubmit}.
+ */
+const SUBMIT_DELAY_MS = 150
+
+/**
  * Wait until a session's engine pane exists and (for a freshly-built
  * session) has painted a stable prompt, so a paste lands in the composer
  * rather than mid-boot.
@@ -54,6 +61,13 @@ export async function pasteAndSubmit(pane: string, text: string): Promise<void> 
   const buffer = `kobe-api-${pane.replace(/[^A-Za-z0-9]/g, "")}`
   await runTmux(["set-buffer", "-b", buffer, "--", text])
   await runTmux(["paste-buffer", "-p", "-d", "-b", buffer, "-t", pane])
+  // Defer the submit Enter so it lands as a SEPARATE tty read from the
+  // bracketed paste. Written back-to-back, the paste's `\e[201~` end-marker
+  // and the `\r` can coalesce into one read and the engine treats the
+  // carriage return as paste content — the prompt then sits unsent in the
+  // composer. The web composer + sidecar `/pty/send` path already split these
+  // (CHANGELOG 8f6dd64); this is the tmux delivery twin.
+  await sleep(SUBMIT_DELAY_MS)
   await sendKeyName(pane, "Enter")
 }
 


### PR DESCRIPTION
## Problem
`pasteAndSubmit` (the shared tmux delivery used by the repo `init-prompt.md` first message, `kobe api send`, and quick-task delivery) wrote the bracketed paste and the submit Enter back-to-back:

```
paste-buffer -p …   # bracketed paste, ends with \e[201~
send-keys Enter      # \r, immediately
```

Written back-to-back they can coalesce into one tty read, and the engine treats the `\r` as paste content instead of a submit — the prompt then **sits unsent in the composer**.

This is the exact failure the **web composer** and the **PTY sidecar `/pty/send`** path already fixed by deferring the Enter ~150ms (CHANGELOG `8f6dd64`: *"The Enter is now deferred ~150ms to land as a separate read — the same split the sidecar's /pty/send path already used."*). The tmux delivery twin never got the same treatment.

## Fix
Sleep ~150ms between the paste and the Enter so it lands as a separate read, matching the proven web/sidecar value. One change point covers all three tmux delivery callers.

## Test
- `pasteAndSubmit` is dependency-injected as a mock in `api-handlers.test.ts`, so the change doesn't perturb existing tests; full unit suite + typecheck green, root lint clean.
- The 150ms is the canonical value already shipped on the web/sidecar paths (not a new guess).