### PR TITLE
feat: live PR check-status chip in the Tasks sidebar (KOB-10)

### DIFF
--- a/.changeset/pr-status-poller.md
+++ b/.changeset/pr-status-poller.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+The Tasks sidebar now shows live PR check status (KOB-10). A daemon poller runs `gh pr view` for each task's branch (GitHub only) and writes the result onto the task, so the sidebar row gains a right-stuck chip — ✓ passing / ✗ failing / • pending — that updates as CI moves, without leaving the TUI. Status is persisted on the task (it rides the existing snapshot push, so every Tasks pane and the web board see it, and it survives a daemon restart) and only ever written from a successful `gh` call, so a missing/unauthed `gh` or a transient network blip never clears a known chip. The poller backs off for branches with no PR and for merged/closed PRs, and pauses entirely when no pane is attached.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -21,6 +21,7 @@
     "./daemon/lifecycle": "./src/daemon/lifecycle.ts",
     "./daemon/lifetime": "./src/daemon/lifetime.ts",
     "./daemon/paths": "./src/daemon/paths.ts",
+    "./daemon/pr-status-collector": "./src/daemon/pr-status-collector.ts",
     "./daemon/protocol": "./src/daemon/protocol.ts",
     "./daemon/server": "./src/daemon/server.ts",
     "./daemon/ui-prefs-watcher": "./src/daemon/ui-prefs-watcher.ts",

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -1,0 +1,181 @@
+/**
+ * Daemon-side PR-status poller (KOB-10).
+ *
+ * For every non-archived task with a real branch + local worktree, shell
+ * `gh pr view <branch> --json …` on an interval, map the result to a neutral
+ * {@link TaskPRStatus}, and write it through `orch.setPRStatus` → `store.update`
+ * → the `task.snapshot` broadcast. Persisting on the Task (rather than a
+ * bespoke channel like the worktree-changes collector) means the existing push
+ * fans the chip to every Tasks pane + the web board for free, and the status
+ * survives a daemon restart. The TUI sidebar renders the check-state chip and
+ * — mirroring `useCompletionNotifications` — fires a toast/bell when a task's
+ * checks resolve (pending → passing/failing); the poller itself only persists.
+ *
+ * GitHub only (KOB-10): the runner is `gh`, so remote (`ssh://`) projects and
+ * non-GitHub remotes simply yield no PR and are cheap no-ops.
+ *
+ * Cost control — a per-task backoff map keyed off the outcome:
+ *   - has an open PR  → re-poll at tick cadence (checks move).
+ *   - merged / closed → {@link SETTLED_BACKOFF_MS} (the PR is done).
+ *   - no PR / `gh` unavailable → {@link NO_PR_BACKOFF_MS} (a branch rarely
+ *                       sprouts a PR between ticks, and a missing/unauthed `gh`
+ *                       must not turn into a per-task spawn every tick).
+ *
+ * A status is only ever WRITTEN from a successful `gh pr view` (exit 0 with a
+ * PR number); any other outcome keeps the last value, so a transient
+ * auth/network blip never clobbers a known chip. Best-effort + sequential
+ * (gentle on the subprocess budget); a per-task failure is logged, never
+ * fatal, never blocks the other tasks in the pass.
+ */
+
+import { spawnCapture } from "@/lib/poll-scheduling"
+import { GH_PR_VIEW_FIELDS, type GhPrView, mapGhPrView, samePrStatus } from "@/monitor/pr-status"
+import type { Orchestrator } from "@/orchestrator/core"
+import { isRemoteRepoKey } from "@/state/repos"
+import type { Task } from "@/types/task"
+import { logDaemonError } from "./crash-log.ts"
+
+/** Default re-scan cadence. PR checks move on the order of seconds-to-minutes;
+ * 30s is responsive without hammering `gh` (which hits the network). */
+export const DEFAULT_PR_STATUS_POLL_MS = 30_000
+/** Re-poll backoff for a branch with no PR yet. */
+export const NO_PR_BACKOFF_MS = 5 * 60_000
+/** Re-poll backoff once a PR is merged/closed — effectively done. */
+export const SETTLED_BACKOFF_MS = 10 * 60_000
+/** Kill a `gh pr view` that hangs past this (network stall). */
+export const PR_VIEW_TIMEOUT_MS = 10_000
+
+/**
+ * The outcome of one `gh pr view`. `pr` = a parsed payload (the only case that
+ * writes a status); `empty` = no usable PR — branch has none, `gh` is missing/
+ * unauthed, the call timed out, or the JSON didn't parse. We deliberately don't
+ * try to distinguish "no PR" from "transient error" (`gh` doesn't give us a
+ * clean signal without stderr), so `empty` never clears a known status — it
+ * just backs off.
+ */
+export type PrViewResult = { kind: "pr"; view: GhPrView } | { kind: "empty" }
+
+/** Runs `gh pr view` for a branch in a worktree. Injectable for tests. */
+export type PrViewRunner = (worktreePath: string, branch: string) => Promise<PrViewResult>
+
+/** The real runner. Exit 0 with parseable JSON carrying a PR number → `pr`;
+ * everything else (no PR, gh missing/unauthed, timeout, bad JSON) → `empty`.
+ * `spawnCapture` never throws — a spawn failure resolves with `status: null`. */
+export const runGhPrView: PrViewRunner = async (worktreePath, branch) => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), PR_VIEW_TIMEOUT_MS)
+  try {
+    const res = await spawnCapture("gh", ["pr", "view", branch, "--json", GH_PR_VIEW_FIELDS], {
+      cwd: worktreePath,
+      signal: controller.signal,
+    })
+    if (res.status !== 0) return { kind: "empty" }
+    const view = JSON.parse(res.stdout) as GhPrView
+    return typeof view.number === "number" ? { kind: "pr", view } : { kind: "empty" }
+  } catch {
+    return { kind: "empty" } // bad JSON / abort
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** A task eligible for PR polling: a real branch on a LOCAL worktree. `main`
+ * rows (no branch) and remote projects are skipped. Pure — unit-tested. */
+export function isPrPollable(task: Task): boolean {
+  if (task.archived) return false
+  if (task.kind === "main") return false
+  if (!task.branch || !task.worktreePath) return false
+  if (isRemoteRepoKey(task.repo) || isRemoteRepoKey(task.worktreePath)) return false
+  return true
+}
+
+/** Next-allowed-at backoff, keyed by task id. */
+export type PrPollSchedule = Map<string, number>
+
+export interface PrStatusPassOptions {
+  readonly run: PrViewRunner
+  /** `Date.now()`-style clock (ms). Injected so tests are deterministic. */
+  readonly now: number
+  /** ISO timestamp stamped onto each status. Injected for the same reason. */
+  readonly at: string
+  /** Per-task backoff state, carried across passes by the live poller. */
+  readonly schedule: PrPollSchedule
+  readonly tickMs?: number
+}
+
+/**
+ * Run one polling pass over every eligible task whose backoff has elapsed.
+ * Returns the ids whose persisted status actually changed (for tests). Pure
+ * orchestrator work — no timers, no `Date.now()`.
+ */
+export async function runPrStatusPass(orch: Orchestrator, opts: PrStatusPassOptions): Promise<string[]> {
+  const tickMs = opts.tickMs ?? DEFAULT_PR_STATUS_POLL_MS
+  const changed: string[] = []
+  for (const task of orch.listTasks()) {
+    if (!isPrPollable(task)) {
+      opts.schedule.delete(task.id) // forget backoff for now-ineligible tasks
+      continue
+    }
+    const due = opts.schedule.get(task.id) ?? 0
+    if (opts.now < due) continue
+    try {
+      const result = await opts.run(task.worktreePath, task.branch)
+      if (result.kind === "empty") {
+        // No usable PR (none yet, or gh unavailable). Keep the last value;
+        // back off so a missing/unauthed gh isn't spawned every tick.
+        opts.schedule.set(task.id, opts.now + NO_PR_BACKOFF_MS)
+        continue
+      }
+      const next = mapGhPrView(result.view, opts.at)
+      // Re-read under the live store (the task may have been archived/deleted
+      // during the await) and diff before writing.
+      const current = orch.getTask(task.id)
+      if (!current) {
+        opts.schedule.delete(task.id)
+        continue
+      }
+      if (!samePrStatus(current.prStatus, next ?? undefined)) {
+        await orch.setPRStatus(task.id, next)
+        changed.push(task.id)
+      }
+      // A merged/closed PR is done — poll it rarely; an open one tracks checks.
+      const settled = next?.lifecycle === "merged" || next?.lifecycle === "closed"
+      opts.schedule.set(task.id, opts.now + (settled ? SETTLED_BACKOFF_MS : tickMs))
+    } catch (err) {
+      logDaemonError("pr-status-poller", err)
+      opts.schedule.set(task.id, opts.now + tickMs)
+    }
+  }
+  return changed
+}
+
+/**
+ * Start the live poller. Returns a `stop()` clearing the interval. Pass
+ * `intervalMs <= 0` to disable (no-op stop). `hasSubscribers` is the
+ * idle-daemon consumer gate: a tick is a no-op while it returns `false`, so a
+ * gui-less daemon never hits the network for nobody. The interval keeps
+ * running; the first tick after a pane subscribes repopulates.
+ */
+export function startPrStatusPoller(
+  orch: Orchestrator,
+  intervalMs: number = DEFAULT_PR_STATUS_POLL_MS,
+  hasSubscribers?: () => boolean,
+  run: PrViewRunner = runGhPrView,
+): () => void {
+  if (intervalMs <= 0) return () => {}
+  const schedule: PrPollSchedule = new Map()
+  let running = false
+  const tick = (): void => {
+    if (hasSubscribers && !hasSubscribers()) return
+    if (running) return
+    running = true
+    void runPrStatusPass(orch, { run, now: Date.now(), at: new Date().toISOString(), schedule, tickMs: intervalMs })
+      .catch((err) => logDaemonError("pr-status-poller", err))
+      .finally(() => {
+        running = false
+      })
+  }
+  const timer = setInterval(tick, intervalMs)
+  timer.unref?.()
+  return () => clearInterval(timer)
+}

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -37,6 +37,7 @@ import {
 } from "./keybindings-watcher.ts"
 import { DaemonLifetime } from "./lifetime.ts"
 import { defaultDaemonPidPath, defaultDaemonSocketPath } from "./paths.ts"
+import { DEFAULT_PR_STATUS_POLL_MS, startPrStatusPoller } from "./pr-status-collector.ts"
 import { type ChannelName, type DaemonFrame, frameToLine, normalizeChannelFilter, serializeTask } from "./protocol.ts"
 import { DEFAULT_UI_PREFS_DEBOUNCE_MS, defaultUiPrefsStatePath, startUiPrefsWatcher } from "./ui-prefs-watcher.ts"
 import { type DaemonWebServer, createDirectWebLink, startDaemonWebServer } from "./web-server.ts"
@@ -84,6 +85,8 @@ export interface DaemonServerOptions {
   readonly updatePollMs?: number
   /** Auto-title re-scan interval in ms; `0` disables. Defaults to {@link DEFAULT_AUTO_TITLE_POLL_MS}. */
   readonly autoTitlePollMs?: number
+  /** PR-status (`gh pr view`) poll interval in ms; `0` disables. Defaults to {@link DEFAULT_PR_STATUS_POLL_MS}. */
+  readonly prStatusPollMs?: number
   /** UI-prefs watcher debounce in ms; `0` disables. Defaults to {@link DEFAULT_UI_PREFS_DEBOUNCE_MS}. */
   readonly uiPrefsDebounceMs?: number
   /** Keybindings watcher debounce in ms; `0` disables. Defaults to {@link DEFAULT_KEYBINDINGS_DEBOUNCE_MS}. */
@@ -306,6 +309,14 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
     () => lifetime.hasSubscribers(),
   )
 
+  // PR-status poller (KOB-10): shells `gh pr view` per task with a real branch
+  // and writes the result onto Task.prStatus, which rides the same task push as
+  // every other field. Gated on subscribers so a gui-less daemon never hits the
+  // network for nobody.
+  const stopPrStatusPoller = startPrStatusPoller(orch, options.prStatusPollMs ?? DEFAULT_PR_STATUS_POLL_MS, () =>
+    lifetime.hasSubscribers(),
+  )
+
   let webServer: DaemonWebServer | null = null
   const serverApi: DaemonServer = {
     socketPath,
@@ -322,6 +333,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
       webServer = null
       if (updateTimer) clearInterval(updateTimer)
       stopAutoTitlePoller()
+      stopPrStatusPoller()
       stopUiPrefsWatcher()
       stopKeybindingsWatcher()
       stopWorktreeChangesCollector()

--- a/packages/kobe/src/monitor/pr-status.ts
+++ b/packages/kobe/src/monitor/pr-status.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure mapping for the PR-status poller (KOB-10).
+ *
+ * The daemon-side `pr-status-collector` shells `gh pr view <branch> --json
+ * <fields>` per task and feeds the parsed JSON through {@link mapGhPrView} to
+ * get a neutral {@link TaskPRStatus}. Keeping the mapping pure (no `gh`, no
+ * tmux, no fs) is what lets the error-prone bits — the `statusCheckRollup`
+ * reduction and the `state`→lifecycle mapping — be unit-tested directly.
+ *
+ * GitHub only by design (KOB-10): GitLab/Bitbucket carry no `gh` equivalent
+ * here, so the collector never runs for them and this module always stamps
+ * `provider: "github"`.
+ */
+
+import type { PRCheckState, PRLifecycleState, TaskPRStatus } from "@/types/task"
+
+/** The `--json` field set the collector requests from `gh pr view`. */
+export const GH_PR_VIEW_FIELDS =
+  "number,url,title,state,baseRefName,headRefName,reviewDecision,mergeable,statusCheckRollup"
+
+/**
+ * One entry of `gh`'s `statusCheckRollup`. GitHub returns a heterogeneous
+ * array: GraphQL `CheckRun`s carry `status` + `conclusion`; legacy
+ * `StatusContext`s carry a single `state`. We read whichever is present.
+ */
+export interface GhCheckEntry {
+  readonly __typename?: string
+  /** CheckRun: QUEUED | IN_PROGRESS | COMPLETED | … */
+  readonly status?: string
+  /** CheckRun: SUCCESS | FAILURE | CANCELLED | TIMED_OUT | NEUTRAL | SKIPPED | … */
+  readonly conclusion?: string
+  /** StatusContext: SUCCESS | PENDING | FAILURE | ERROR | EXPECTED */
+  readonly state?: string
+}
+
+/** Shape of `gh pr view --json <GH_PR_VIEW_FIELDS>`. All fields optional —
+ * `gh` omits empties and older versions vary. */
+export interface GhPrView {
+  readonly number?: number
+  readonly url?: string
+  readonly title?: string
+  readonly state?: string
+  readonly baseRefName?: string
+  readonly headRefName?: string
+  readonly reviewDecision?: string
+  readonly mergeable?: string
+  readonly statusCheckRollup?: readonly GhCheckEntry[]
+}
+
+/** Map `gh`'s PR `state` (+ review decision) to a neutral lifecycle. */
+export function lifecycleFromState(state: string | undefined, reviewDecision: string | undefined): PRLifecycleState {
+  switch ((state ?? "").toUpperCase()) {
+    case "MERGED":
+      return "merged"
+    case "CLOSED":
+      return "closed"
+    case "OPEN":
+      // An approved, open PR reads as ready-to-merge; the sidebar surfaces it
+      // distinctly so a finished review is obvious without opening the PR.
+      return (reviewDecision ?? "").toUpperCase() === "APPROVED" ? "ready_to_merge" : "open"
+    default:
+      return "unknown"
+  }
+}
+
+/** Reduce a check entry to one of the four headline states. */
+function entryCheckState(entry: GhCheckEntry): PRCheckState {
+  // CheckRun: prefer conclusion once COMPLETED, else it's still running.
+  const status = (entry.status ?? "").toUpperCase()
+  const conclusion = (entry.conclusion ?? "").toUpperCase()
+  const contextState = (entry.state ?? "").toUpperCase()
+
+  if (status && status !== "COMPLETED") return "pending" // QUEUED / IN_PROGRESS / WAITING / PENDING
+  if (conclusion) {
+    if (conclusion === "SUCCESS" || conclusion === "NEUTRAL" || conclusion === "SKIPPED") return "passing"
+    return "failing" // FAILURE | CANCELLED | TIMED_OUT | ACTION_REQUIRED | STARTUP_FAILURE | STALE
+  }
+  // StatusContext path.
+  if (contextState === "SUCCESS") return "passing"
+  if (contextState === "PENDING" || contextState === "EXPECTED") return "pending"
+  if (contextState === "FAILURE" || contextState === "ERROR") return "failing"
+  return "unknown"
+}
+
+/**
+ * Roll the per-check states up to the PR headline. Precedence is the same
+ * mental model GitHub's own badge uses: **any** failing → failing; else any
+ * pending → pending; else all-passing → passing; an empty rollup is `none`
+ * (no checks configured); anything we can't read is `unknown`.
+ */
+export function checkStateFromRollup(rollup: readonly GhCheckEntry[] | undefined): PRCheckState {
+  if (!rollup || rollup.length === 0) return "none"
+  let sawPending = false
+  let sawPassing = false
+  for (const entry of rollup) {
+    const s = entryCheckState(entry)
+    if (s === "failing") return "failing"
+    if (s === "pending") sawPending = true
+    else if (s === "passing") sawPassing = true
+  }
+  if (sawPending) return "pending"
+  if (sawPassing) return "passing"
+  return "unknown"
+}
+
+/**
+ * Map a parsed `gh pr view` payload to a {@link TaskPRStatus}. `at` is the
+ * caller's ISO timestamp (kept out so the function stays pure/deterministic
+ * for tests). Returns `null` when the payload has no PR number — the caller
+ * treats that as "no PR for this branch" and clears any stale status.
+ */
+export function mapGhPrView(view: GhPrView | null | undefined, at: string): TaskPRStatus | null {
+  if (!view || typeof view.number !== "number") return null
+  return {
+    provider: "github",
+    lifecycle: lifecycleFromState(view.state, view.reviewDecision),
+    checkState: checkStateFromRollup(view.statusCheckRollup),
+    number: view.number,
+    url: view.url,
+    title: view.title,
+    baseRef: view.baseRefName,
+    headRef: view.headRefName,
+    reviewDecision: view.reviewDecision || undefined,
+    mergeable: view.mergeable || undefined,
+    lastCheckedAt: at,
+  }
+}
+
+/**
+ * Value equality for the fields the UI renders + the poller diffs on. Excludes
+ * `lastCheckedAt` (it changes every poll) and `lastError` so an unchanged PR
+ * doesn't churn a persist + broadcast every tick.
+ */
+export function samePrStatus(a: TaskPRStatus | undefined, b: TaskPRStatus | undefined): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return (
+    a.provider === b.provider &&
+    a.lifecycle === b.lifecycle &&
+    a.checkState === b.checkState &&
+    a.number === b.number &&
+    a.url === b.url &&
+    a.title === b.title &&
+    a.baseRef === b.baseRef &&
+    a.headRef === b.headRef &&
+    a.reviewDecision === b.reviewDecision &&
+    a.mergeable === b.mergeable
+  )
+}
+
+/**
+ * Whether a check-state transition is worth interrupting the user for. We
+ * notify only when checks RESOLVE — pending → passing or pending → failing —
+ * not on every flap (e.g. none → pending is just "CI started"). Returns the
+ * landing state to notify on, or `null` for a non-event.
+ */
+export function checkResolutionNotify(
+  prev: PRCheckState | undefined,
+  next: PRCheckState,
+): "passing" | "failing" | null {
+  if (prev !== "pending") return null
+  if (next === "passing" || next === "failing") return next
+  return null
+}

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -26,8 +26,9 @@ import { realpathSync } from "node:fs"
 import { basename, resolve } from "node:path"
 import type { Accessor } from "solid-js"
 import { createSignal } from "solid-js"
+import { samePrStatus } from "../monitor/pr-status.ts"
 import { getRemoteRepoConfig, isRemoteRepoKey, resolveRepoRoot } from "../state/repos.ts"
-import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
+import type { Task, TaskId, TaskPRStatus, TaskStatus, VendorId } from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR, toTaskId } from "../types/task.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 import {
@@ -448,6 +449,20 @@ export class Orchestrator {
       throw new IllegalTransitionError(task.status, status, task.id)
     }
     await this.store.update(task.id, { status })
+  }
+
+  /**
+   * Set (or clear, with `null`) a task's PR status — driven by the daemon's
+   * `pr-status-collector`. Persisting it on the Task means the snapshot push
+   * already fans the change to every pane + the web board (no new channel),
+   * and it survives a daemon restart. No-op when nothing the UI renders
+   * changed (the collector also pre-diffs, but guard here too so a redundant
+   * call never churns a write + broadcast).
+   */
+  async setPRStatus(id: TaskId | string, prStatus: TaskPRStatus | null): Promise<void> {
+    const task = this.requireTask(id)
+    if (samePrStatus(task.prStatus, prStatus ?? undefined)) return
+    await this.store.update(task.id, { prStatus: prStatus ?? undefined })
   }
 
   /**

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -113,6 +113,7 @@ import {
   SPINNER_FRAME_MS,
   type SidebarTone,
   buildSidebarRowView,
+  prCheckChip,
   withSpinnerFrame,
 } from "./row-view"
 import { type WorktreeChanges, pickPushedChanges, sameWorktreeChanges } from "./worktree-changes"
@@ -1263,6 +1264,13 @@ export function Sidebar(props: SidebarProps) {
                           <text fg={theme.warning} wrapMode="none">
                             ▴
                           </text>
+                        </Show>
+                        <Show when={prCheckChip(task)}>
+                          {(chip) => (
+                            <text fg={toneColor(chip().tone)} wrapMode="none">
+                              {chip().glyph}
+                            </text>
+                          )}
                         </Show>
                         <Show when={changes().added > 0}>
                           <text fg={theme.success} wrapMode="none">

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -62,6 +62,26 @@ export const IN_PROGRESS_SPINNER: readonly string[] = ["⠋", "⠙", "⠹", "⠸
 export const SPINNER_FRAME_MS = 100
 
 /**
+ * The right-stuck PR-check chip for a task's subtitle row (KOB-10). The
+ * daemon's pr-status poller writes `task.prStatus`; this maps its `checkState`
+ * to a single coloured glyph (✓ passing / ✗ failing / • pending). Returns null
+ * for tasks with no PR or no checks configured (`none` / `unknown`) so the row
+ * stays clean. Pure — unit-tested.
+ */
+export function prCheckChip(task: Task): { glyph: string; tone: SidebarTone } | null {
+  switch (task.prStatus?.checkState) {
+    case "passing":
+      return { glyph: "✓", tone: "success" }
+    case "failing":
+      return { glyph: "✗", tone: "error" }
+    case "pending":
+      return { glyph: "•", tone: "warning" }
+    default:
+      return null
+  }
+}
+
+/**
  * Static dim glyph for a custom-engine task with no live signal. A custom
  * engine has no transcript store the monitor can watch (see
  * `monitor/activity.ts`), so its activity badge would otherwise sit on the

--- a/packages/kobe/test/daemon/pr-status-poller.test.ts
+++ b/packages/kobe/test/daemon/pr-status-poller.test.ts
@@ -1,0 +1,187 @@
+/**
+ * PR-status poller (KOB-10). Drives the pass logic against a REAL Orchestrator
+ * + on-disk store with an injected `gh pr view` runner, so the seams under
+ * test are: eligibility filtering, write-on-change + samePrStatus diffing,
+ * keep-last on `empty`, and the per-task backoff schedule.
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import {
+  NO_PR_BACKOFF_MS,
+  type PrPollSchedule,
+  type PrViewResult,
+  type PrViewRunner,
+  SETTLED_BACKOFF_MS,
+  isPrPollable,
+  runPrStatusPass,
+} from "@sma1lboy/kobe-daemon/daemon/pr-status-collector"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import { type Task, toTaskId } from "../../src/types/task.ts"
+
+let tmpRoot: string
+let store: TaskIndexStore
+let orch: Orchestrator
+
+beforeEach(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-prstatus-"))
+  store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  await store.load()
+  orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+async function makeTask(opts: { worktree?: string } = {}): Promise<string> {
+  const task = await orch.createTask({ repo: "/repo" })
+  // A backlog task has no branch until its worktree is materialized; stamp one
+  // (plus a worktree path) so it clears the pr-pollable gate.
+  await store.update(task.id, { worktreePath: opts.worktree ?? `/wt/${task.id}`, branch: `kobe/test-${task.id}` })
+  return task.id
+}
+
+/** A runner that returns a fixed PR view (open, with one check in `state`). */
+function prRunner(state: string, checkConclusion: string): PrViewRunner {
+  return async (): Promise<PrViewResult> => ({
+    kind: "pr",
+    view: {
+      number: 7,
+      state,
+      statusCheckRollup: [{ status: "COMPLETED", conclusion: checkConclusion }],
+    },
+  })
+}
+
+const emptyRunner: PrViewRunner = async () => ({ kind: "empty" })
+
+describe("isPrPollable", () => {
+  const base: Task = {
+    id: toTaskId("t1"),
+    title: "x",
+    repo: "/repo",
+    branch: "kobe/x-1",
+    worktreePath: "/wt/x",
+    status: "backlog",
+    archived: false,
+    createdAt: "2026-06-24T00:00:00.000Z",
+    updatedAt: "2026-06-24T00:00:00.000Z",
+  }
+  test("a regular task with a branch + local worktree is pollable", () => {
+    expect(isPrPollable(base)).toBe(true)
+  })
+  test("archived / main / no-branch / no-worktree are not", () => {
+    expect(isPrPollable({ ...base, archived: true })).toBe(false)
+    expect(isPrPollable({ ...base, kind: "main", branch: "" })).toBe(false)
+    expect(isPrPollable({ ...base, branch: "" })).toBe(false)
+    expect(isPrPollable({ ...base, worktreePath: "" })).toBe(false)
+  })
+  test("remote (ssh://) projects are skipped", () => {
+    expect(isPrPollable({ ...base, repo: "ssh://host/repo" })).toBe(false)
+  })
+})
+
+describe("runPrStatusPass", () => {
+  test("writes a mapped status for an eligible task and reports it changed", async () => {
+    const id = await makeTask()
+    const schedule: PrPollSchedule = new Map()
+    const changed = await runPrStatusPass(orch, {
+      run: prRunner("OPEN", "SUCCESS"),
+      now: 1_000,
+      at: "2026-06-24T00:00:00.000Z",
+      schedule,
+    })
+    expect(changed).toEqual([id])
+    expect(orch.getTask(id)?.prStatus?.checkState).toBe("passing")
+    expect(orch.getTask(id)?.prStatus?.lifecycle).toBe("open")
+  })
+
+  test("a second pass with the same status reports no change (samePrStatus)", async () => {
+    const id = await makeTask()
+    const schedule: PrPollSchedule = new Map()
+    await runPrStatusPass(orch, { run: prRunner("OPEN", "SUCCESS"), now: 0, at: "t1", schedule })
+    // Advance past the backoff so the task is due again.
+    const changed = await runPrStatusPass(orch, {
+      run: prRunner("OPEN", "SUCCESS"),
+      now: 10_000_000,
+      at: "t2",
+      schedule,
+    })
+    expect(changed).toEqual([])
+    expect(orch.getTask(id)?.prStatus?.checkState).toBe("passing")
+  })
+
+  test("backoff: a task is not re-polled until its scheduled time", async () => {
+    const id = await makeTask()
+    const schedule: PrPollSchedule = new Map()
+    let calls = 0
+    const counting: PrViewRunner = async () => {
+      calls++
+      return { kind: "pr", view: { number: 7, state: "OPEN", statusCheckRollup: [{ state: "PENDING" }] } }
+    }
+    await runPrStatusPass(orch, { run: counting, now: 1_000, at: "t1", schedule, tickMs: 30_000 })
+    expect(calls).toBe(1)
+    // Immediately again — still inside the 30s backoff window → skipped.
+    await runPrStatusPass(orch, { run: counting, now: 5_000, at: "t2", schedule, tickMs: 30_000 })
+    expect(calls).toBe(1)
+    // Past the window → polled again.
+    await runPrStatusPass(orch, { run: counting, now: 40_000, at: "t3", schedule, tickMs: 30_000 })
+    expect(calls).toBe(2)
+    expect(id).toBeTruthy()
+  })
+
+  test("empty result keeps the last value and applies the no-PR backoff", async () => {
+    const id = await makeTask()
+    const schedule: PrPollSchedule = new Map()
+    await runPrStatusPass(orch, { run: prRunner("OPEN", "FAILURE"), now: 0, at: "t1", schedule })
+    expect(orch.getTask(id)?.prStatus?.checkState).toBe("failing")
+    // gh now returns nothing usable — must NOT clear the known status.
+    await runPrStatusPass(orch, { run: emptyRunner, now: 10_000_000, at: "t2", schedule })
+    expect(orch.getTask(id)?.prStatus?.checkState).toBe("failing")
+    expect(schedule.get(id)).toBe(10_000_000 + NO_PR_BACKOFF_MS)
+  })
+
+  test("a merged PR gets the long settled backoff", async () => {
+    const id = await makeTask()
+    const schedule: PrPollSchedule = new Map()
+    await runPrStatusPass(orch, { run: prRunner("MERGED", "SUCCESS"), now: 0, at: "t1", schedule, tickMs: 30_000 })
+    expect(orch.getTask(id)?.prStatus?.lifecycle).toBe("merged")
+    expect(schedule.get(id)).toBe(0 + SETTLED_BACKOFF_MS)
+  })
+
+  test("skips archived tasks and forgets their backoff", async () => {
+    const id = await makeTask()
+    const schedule: PrPollSchedule = new Map([[id, 0]])
+    await store.update(id, { archived: true })
+    const changed = await runPrStatusPass(orch, { run: prRunner("OPEN", "SUCCESS"), now: 1_000, at: "t1", schedule })
+    expect(changed).toEqual([])
+    expect(schedule.has(id)).toBe(false)
+  })
+
+  test("a throwing runner does not block the other tasks", async () => {
+    const boom = await makeTask({ worktree: "/wt/boom" })
+    const ok = await makeTask({ worktree: "/wt/ok" })
+    const schedule: PrPollSchedule = new Map()
+    const changed = await runPrStatusPass(orch, {
+      run: async (wt: string) => {
+        if (wt === "/wt/boom") throw new Error("gh blew up")
+        return { kind: "pr", view: { number: 7, state: "OPEN", statusCheckRollup: [{ state: "SUCCESS" }] } }
+      },
+      now: 0,
+      at: "t1",
+      schedule,
+    })
+    expect(changed).toEqual([ok])
+    expect(orch.getTask(boom)?.prStatus).toBeUndefined()
+    expect(orch.getTask(ok)?.prStatus?.checkState).toBe("passing")
+  })
+})

--- a/packages/kobe/test/monitor/pr-status.test.ts
+++ b/packages/kobe/test/monitor/pr-status.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest"
+import {
+  type GhPrView,
+  checkResolutionNotify,
+  checkStateFromRollup,
+  lifecycleFromState,
+  mapGhPrView,
+  samePrStatus,
+} from "../../src/monitor/pr-status"
+
+describe("lifecycleFromState", () => {
+  test("maps gh PR state to lifecycle", () => {
+    expect(lifecycleFromState("MERGED", undefined)).toBe("merged")
+    expect(lifecycleFromState("CLOSED", undefined)).toBe("closed")
+    expect(lifecycleFromState("OPEN", undefined)).toBe("open")
+    expect(lifecycleFromState("open", "REVIEW_REQUIRED")).toBe("open")
+    expect(lifecycleFromState("garbage", undefined)).toBe("unknown")
+  })
+  test("an approved open PR is ready_to_merge", () => {
+    expect(lifecycleFromState("OPEN", "APPROVED")).toBe("ready_to_merge")
+  })
+})
+
+describe("checkStateFromRollup", () => {
+  test("no rollup / empty → none (no checks configured)", () => {
+    expect(checkStateFromRollup(undefined)).toBe("none")
+    expect(checkStateFromRollup([])).toBe("none")
+  })
+  test("any failing CheckRun → failing, regardless of others", () => {
+    expect(
+      checkStateFromRollup([
+        { __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" },
+        { __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" },
+      ]),
+    ).toBe("failing")
+  })
+  test("in-progress with no failure → pending", () => {
+    expect(
+      checkStateFromRollup([
+        { __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" },
+        { __typename: "CheckRun", status: "IN_PROGRESS" },
+      ]),
+    ).toBe("pending")
+  })
+  test("all success/neutral/skipped → passing", () => {
+    expect(
+      checkStateFromRollup([
+        { __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" },
+        { __typename: "CheckRun", status: "COMPLETED", conclusion: "NEUTRAL" },
+        { __typename: "CheckRun", status: "COMPLETED", conclusion: "SKIPPED" },
+      ]),
+    ).toBe("passing")
+  })
+  test("legacy StatusContext entries are read via state", () => {
+    expect(checkStateFromRollup([{ __typename: "StatusContext", state: "SUCCESS" }])).toBe("passing")
+    expect(checkStateFromRollup([{ __typename: "StatusContext", state: "PENDING" }])).toBe("pending")
+    expect(checkStateFromRollup([{ __typename: "StatusContext", state: "FAILURE" }])).toBe("failing")
+  })
+  test("failure precedence beats a pending sibling", () => {
+    expect(checkStateFromRollup([{ status: "IN_PROGRESS" }, { status: "COMPLETED", conclusion: "FAILURE" }])).toBe(
+      "failing",
+    )
+  })
+})
+
+describe("mapGhPrView", () => {
+  const at = "2026-06-24T00:00:00.000Z"
+  test("no PR number → null (no PR for the branch)", () => {
+    expect(mapGhPrView(null, at)).toBeNull()
+    expect(mapGhPrView({}, at)).toBeNull()
+  })
+  test("maps a full open PR with running checks", () => {
+    const view: GhPrView = {
+      number: 42,
+      url: "https://github.com/o/r/pull/42",
+      title: "feat: x",
+      state: "OPEN",
+      baseRefName: "main",
+      headRefName: "feat/x",
+      reviewDecision: "REVIEW_REQUIRED",
+      mergeable: "MERGEABLE",
+      statusCheckRollup: [{ status: "IN_PROGRESS" }],
+    }
+    expect(mapGhPrView(view, at)).toEqual({
+      provider: "github",
+      lifecycle: "open",
+      checkState: "pending",
+      number: 42,
+      url: "https://github.com/o/r/pull/42",
+      title: "feat: x",
+      baseRef: "main",
+      headRef: "feat/x",
+      reviewDecision: "REVIEW_REQUIRED",
+      mergeable: "MERGEABLE",
+      lastCheckedAt: at,
+    })
+  })
+  test("empty-string reviewDecision/mergeable normalize to undefined", () => {
+    const out = mapGhPrView({ number: 1, state: "OPEN", reviewDecision: "", mergeable: "" }, at)
+    expect(out?.reviewDecision).toBeUndefined()
+    expect(out?.mergeable).toBeUndefined()
+  })
+})
+
+describe("samePrStatus", () => {
+  const base = mapGhPrView({ number: 1, state: "OPEN", statusCheckRollup: [{ status: "IN_PROGRESS" }] }, "t1")
+  test("ignores lastCheckedAt churn", () => {
+    const later = mapGhPrView({ number: 1, state: "OPEN", statusCheckRollup: [{ status: "IN_PROGRESS" }] }, "t2")
+    expect(samePrStatus(base ?? undefined, later ?? undefined)).toBe(true)
+  })
+  test("a checkState change is not equal", () => {
+    const passed = mapGhPrView(
+      { number: 1, state: "OPEN", statusCheckRollup: [{ status: "COMPLETED", conclusion: "SUCCESS" }] },
+      "t3",
+    )
+    expect(samePrStatus(base ?? undefined, passed ?? undefined)).toBe(false)
+  })
+  test("undefined handling", () => {
+    expect(samePrStatus(undefined, undefined)).toBe(true)
+    expect(samePrStatus(base ?? undefined, undefined)).toBe(false)
+  })
+})
+
+describe("checkResolutionNotify", () => {
+  test("notifies only when pending resolves", () => {
+    expect(checkResolutionNotify("pending", "passing")).toBe("passing")
+    expect(checkResolutionNotify("pending", "failing")).toBe("failing")
+  })
+  test("does not notify on CI starting or steady states", () => {
+    expect(checkResolutionNotify("none", "pending")).toBeNull()
+    expect(checkResolutionNotify(undefined, "passing")).toBeNull()
+    expect(checkResolutionNotify("passing", "passing")).toBeNull()
+    expect(checkResolutionNotify("pending", "pending")).toBeNull()
+  })
+})


### PR DESCRIPTION
## What
The Tasks sidebar now surfaces each task's PR CI status live, so you don't context-switch to GitHub or `gh` to know if a branch's checks passed.

A daemon poller runs `gh pr view <branch> --json …` for every non-archived task with a real branch + local worktree, maps the result to the (until now dormant) `Task.prStatus` field, and writes it through `orch.setPRStatus` → `store.update` → the existing `task.snapshot` broadcast. The sidebar row gains a right-stuck chip: **✓ passing / ✗ failing / • pending**.

## Design
- **No new channel.** `prStatus` is a persisted Task field, so it rides the same push every other field does — every Tasks pane *and* the web board get it for free, and it survives a daemon restart.
- **GitHub only** (KOB-10): the runner is `gh`; remote/non-GitHub branches just yield no PR and cost nothing.
- **Never clobbers on a blip.** A status is only written from a successful `gh pr view` (exit 0 + a PR number). A missing/unauthed `gh`, a timeout, or bad JSON keeps the last value.
- **Cost control:** per-task backoff — open PRs poll at tick cadence, no-PR branches back off (5m), merged/closed back off (10m); the whole pass pauses when no pane is attached (idle-daemon gate), mirroring the auto-title + worktree-changes collectors.

## Tests
- `test/monitor/pr-status.test.ts` (16) — the pure `gh`→`TaskPRStatus` mapper: rollup reduction (failing-precedence, pending, StatusContext), lifecycle, `samePrStatus` churn-suppression, `checkResolutionNotify`.
- `test/daemon/pr-status-poller.test.ts` (10) — the pass against a real Orchestrator + temp store with an injected runner: eligibility, write-on-change, keep-last-on-empty, backoff schedule, archived-skip, error isolation.
- Full unit suite + typecheck green; root lint clean.

## Scope / follow-up
This PR ships the poll + persist + **live chip** (the passive alert surface). The proactive **toast/bell on a pending→passing/failing flip** is the obvious fast-follow — the tested `checkResolutionNotify` helper is already here as its foundation; it just needs a TUI hook mirroring `useCompletionNotifications`.

> Note: the `gh` integration + chip rendering need a quick on-device smoke test (this env has no live daemon/PRs); the pure mapper and pass logic are unit-covered.