### PR TITLE
fix: align `kobe export --format table` by display width, not code units

### DIFF
--- a/.changeset/export-table-cjk-width.md
+++ b/.changeset/export-table-cjk-width.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+`kobe export --format table` now aligns its columns by terminal display width instead of UTF-16 code-unit length, so a wide-glyph cell no longer shoves every column to its right out of line. A CJK task title (the common case — kobe is Simplified-Chinese-default), a fullwidth or emoji character all count as two cells, combining marks and variation selectors as zero, and astral characters (CJK Extension B, emoji) count once rather than as their two surrogate units; the table stays aligned for any mix of scripts.

--- a/bun.lock
+++ b/bun.lock
@@ -683,21 +683,21 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.1", "", { "dependencies": { "@tailwindcss/node": "4.3.1", "@tailwindcss/oxide": "4.3.1", "tailwindcss": "4.3.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ=="],
 
-    "@tanstack/devtools": ["@tanstack/devtools@0.12.4", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.7", "@tanstack/devtools-event-bus": "0.4.2", "@tanstack/devtools-ui": "0.5.3", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-fYZ0KTEpKq7JyjULDe4kGQBN77aw5jtULs1MaVraWvwtcoIwe4UOKV48UJQ9/mEQMFTytbgKxYk2QaSDgI/Znw=="],
+    "@tanstack/devtools": ["@tanstack/devtools@0.12.5", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "@tanstack/devtools-ui": "0.6.0", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-JdxTSeVdjJheycgz4c7qbldNKDCEDWlWr1l9dZBhd9sOmRBT5Z70ka9Eb8mb+FUnalcOIB62IDSR/iSxAIUD8Q=="],
 
-    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.7", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.4" } }, "sha512-bAqBnXQlg/1PqmIC3XhqzG8jV3YmUQ41fD9VlOVzSilFBD4Kp6WJFJa+7N6TvlYXqMAy8xoeF9gg0d2Lt74OEQ=="],
+    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.5.0" } }, "sha512-cG3iZkGWCwN330bLBKa8+9r4Of2AXNoz2zUqcsy/4XsD3105ghVBx78cGyvJj9fSclNomPxoqAnDGXXhg1WLvA=="],
 
     "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.4.2", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-2LHzhwBFlKHCcklsQrGe8TeyjHd4XAF8nuCO6wHmva5fePUkJUULbu6CsCNAlGlCi0KkEsMXZSvRdR4HgMq4yA=="],
 
-    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.4", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw=="],
+    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.5.0", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-H+OH3zC6Vhu/K0NaVfQKknEKawc/+2PT+D3SB3Ox0V8SiMlTo0abbmH2rH0721R2aNYbjdMXA1oENOd8E2UVoA=="],
 
-    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.5.3", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-iJjwWtdXhUGpeHyyW9+3NhXhmlVFhh3v3UBNKCouykG9UFXEtneVVNXgSRpd70DeYJFmvKOY19LafKRI5/cM7A=="],
+    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.6.0", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-CVaM6rT6Nl5ijo83vJYFa2SjofvpuOl/uOvbYGhBrRgUhhelNHhx8zZX+hnZCHmIr0/lzM65hsocnZ72592Rvg=="],
 
-    "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.8.0", "", { "dependencies": { "@tanstack/devtools-client": "0.0.7", "@tanstack/devtools-event-bus": "0.4.2", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "magic-string": "^0.30.0", "oxc-parser": "^0.120.0", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-Pj4KB6dTK3NGjVxKRym8X0Df8rL/ofojYMVR8sw4jAT7doMCTNSW7VqXrYD5P2cKgyLJiwg3TNOozRm2o+7m3Q=="],
+    "@tanstack/devtools-vite": ["@tanstack/devtools-vite@0.8.1", "", { "dependencies": { "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "chalk": "^5.6.2", "launch-editor": "^2.11.1", "magic-string": "^0.30.0", "oxc-parser": "^0.120.0", "picomatch": "^4.0.3" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-oQxOo0fI0bwhHtw/psFlIR0OS/bsKrirBxwnw2vuhCM4bjt3k4EZZsW/lvZ1+Vpouhts7LSyvngnxvGXbQ1sUQ=="],
 
     "@tanstack/history": ["@tanstack/history@1.162.0", "", {}, "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA=="],
 
-    "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.7", "", { "dependencies": { "@tanstack/devtools": "0.12.4" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-AYHQH06uuK07Asqq8eASgJjpILlaFBpjnTesxx1JVHGoBl4ijwbyIlKnj3Z8+M8sEOPn5mvtV5o6mielPXKHWg=="],
+    "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.8", "", { "dependencies": { "@tanstack/devtools": "0.12.5" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-YJV6YttQf9lhhPbPBLULgy1eScEvJUMsCS26mjg9hfBKgAJQA5sF9zvzorDzW9Ob6o/asoXikO81JnRUVuFX0Q=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.170.16", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.13", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g=="],
 
@@ -1772,10 +1772,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@tanstack/devtools/solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
-
-    "@tanstack/devtools-ui/solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
 
     "@tanstack/devtools-vite/oxc-parser": ["oxc-parser@0.120.0", "", { "dependencies": { "@oxc-project/types": "^0.120.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.120.0", "@oxc-parser/binding-android-arm64": "0.120.0", "@oxc-parser/binding-darwin-arm64": "0.120.0", "@oxc-parser/binding-darwin-x64": "0.120.0", "@oxc-parser/binding-freebsd-x64": "0.120.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.120.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.120.0", "@oxc-parser/binding-linux-arm64-gnu": "0.120.0", "@oxc-parser/binding-linux-arm64-musl": "0.120.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.120.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.120.0", "@oxc-parser/binding-linux-riscv64-musl": "0.120.0", "@oxc-parser/binding-linux-s390x-gnu": "0.120.0", "@oxc-parser/binding-linux-x64-gnu": "0.120.0", "@oxc-parser/binding-linux-x64-musl": "0.120.0", "@oxc-parser/binding-openharmony-arm64": "0.120.0", "@oxc-parser/binding-wasm32-wasi": "0.120.0", "@oxc-parser/binding-win32-arm64-msvc": "0.120.0", "@oxc-parser/binding-win32-ia32-msvc": "0.120.0", "@oxc-parser/binding-win32-x64-msvc": "0.120.0" } }, "sha512-WyPWZlcIm+Fkte63FGfgFB8mAAk33aH9h5N9lphXVOHSXEBFFsmYdOBedVKly363aWABjZdaj/m9lBfEY4wt+w=="],
 

--- a/packages/kobe/src/cli/export-cmd.ts
+++ b/packages/kobe/src/cli/export-cmd.ts
@@ -98,12 +98,75 @@ function renderCsv(rows: readonly Record<Column, string>[]): string {
   return lines.join("\n")
 }
 
-/** Render aligned columns; widths fit the header and every cell. */
+/**
+ * Terminal display width of `s` in cells. Iterates by code point (so astral
+ * characters — CJK Extension B, emoji — count once, not as two UTF-16 units),
+ * mirroring the code-point awareness of `filetree/rows.ts`'s `truncatePathTail`.
+ * East-Asian-wide / fullwidth glyphs and most emoji occupy two cells; combining
+ * marks and zero-width formatting characters occupy none; everything else one.
+ *
+ * kobe is Simplified-Chinese-default, so a CJK task title is the common case —
+ * measuring by `String.length` (UTF-16 units) under-counts it and shoves every
+ * column to its right out of alignment. Exported for unit tests.
+ */
+export function displayWidth(s: string): number {
+  let width = 0
+  for (const ch of s) width += charWidth(ch.codePointAt(0) as number)
+  return width
+}
+
+/** Cell width of a single Unicode code point: 0 (zero-width), 2 (wide), or 1. */
+function charWidth(cp: number): number {
+  // Zero-width: combining marks + bidi/format controls + variation selectors.
+  if (
+    (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks
+    (cp >= 0x1ab0 && cp <= 0x1aff) || // combining diacritical marks extended
+    (cp >= 0x1dc0 && cp <= 0x1dff) || // combining diacritical marks supplement
+    (cp >= 0x200b && cp <= 0x200f) || // zero-width space … LTR/RTL marks
+    (cp >= 0x202a && cp <= 0x202e) || // bidi embedding / override
+    (cp >= 0x2060 && cp <= 0x2064) || // word joiner … invisible operators
+    (cp >= 0x20d0 && cp <= 0x20ff) || // combining marks for symbols
+    (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
+    cp === 0xfeff // zero-width no-break space (BOM)
+  ) {
+    return 0
+  }
+  // Wide: East Asian Wide + Fullwidth + the common emoji / pictograph blocks.
+  if (
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    cp === 0x2329 ||
+    cp === 0x232a || // angle brackets
+    (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals … Kangxi … CJK symbols
+    (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana … Katakana … CJK compat
+    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Unified Ext A
+    (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
+    (cp >= 0xa000 && cp <= 0xa4cf) || // Yi Syllables
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+    (cp >= 0xfe10 && cp <= 0xfe19) || // vertical forms
+    (cp >= 0xfe30 && cp <= 0xfe6f) || // CJK compatibility forms
+    (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth forms
+    (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+    (cp >= 0x1f300 && cp <= 0x1faff) || // emoji, symbols & pictographs
+    (cp >= 0x20000 && cp <= 0x3fffd) // CJK Unified Ext B and beyond
+  ) {
+    return 2
+  }
+  return 1
+}
+
+/** Pad `cell` with trailing spaces to reach `width` terminal cells. */
+function padCell(cell: string, width: number): string {
+  return cell + " ".repeat(Math.max(0, width - displayWidth(cell)))
+}
+
+/** Render aligned columns; widths fit the header and every cell by terminal
+ *  display width, so a CJK / wide cell doesn't shove later columns out of line. */
 function renderTable(rows: readonly Record<Column, string>[]): string {
   const widths = {} as Record<Column, number>
-  for (const c of COLUMNS) widths[c] = Math.max(c.length, ...rows.map((r) => r[c].length))
+  for (const c of COLUMNS) widths[c] = Math.max(displayWidth(c), ...rows.map((r) => displayWidth(r[c])))
   const line = (cells: Record<Column, string>) =>
-    COLUMNS.map((c) => cells[c].padEnd(widths[c]))
+    COLUMNS.map((c) => padCell(cells[c], widths[c]))
       .join("  ")
       .trimEnd()
   const header = {} as Record<Column, string>

--- a/packages/kobe/test/cli/export-cmd.test.ts
+++ b/packages/kobe/test/cli/export-cmd.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { renderExport } from "../../src/cli/export-cmd.ts"
+import { displayWidth, renderExport } from "../../src/cli/export-cmd.ts"
 import { type Task, toTaskId } from "../../src/types/task.ts"
 
 function task(overrides: Partial<Task> = {}): Task {
@@ -61,5 +61,38 @@ describe("renderExport", () => {
   it("handles an empty task list per format", () => {
     expect(renderExport([], "json")).toBe("[]")
     expect(renderExport([], "csv")).toBe("id,title,status,archived,vendor,branch,repo,worktreePath")
+  })
+
+  it("aligns table columns by terminal display width, not code-unit length (CJK titles)", () => {
+    // Two tasks identical except the title: one ASCII (2 cells), one CJK whose
+    // display width (4 cells) exceeds its code-unit length (2). With true
+    // display-width padding both rows pad the title column to the same cell
+    // width, so every later column lines up and the two rows share one total
+    // display width. Measuring by String.length (the old bug) would under-pad
+    // the CJK row by 2 cells and shove its trailing columns left.
+    const asciiTitle = "ab"
+    const cjkTitle = String.fromCodePoint(0x4e2d, 0x6587) // 中文
+    const ascii = renderExport([task({ id: toTaskId("01HZ0000000000000000000001"), title: asciiTitle })], "table")
+    const cjk = renderExport([task({ id: toTaskId("01HZ0000000000000000000002"), title: cjkTitle })], "table")
+    expect(displayWidth(ascii.split("\n")[1])).toBe(displayWidth(cjk.split("\n")[1]))
+  })
+})
+
+describe("displayWidth", () => {
+  it("counts CJK and fullwidth glyphs as two cells", () => {
+    expect(displayWidth("ascii")).toBe(5)
+    expect(displayWidth(String.fromCodePoint(0x4e2d, 0x6587))).toBe(4) // 中文
+    expect(displayWidth(String.fromCodePoint(0xff21, 0xff22))).toBe(4) // ＡＢ fullwidth latin
+  })
+
+  it("counts an astral emoji once (two cells), not as two UTF-16 units", () => {
+    const party = String.fromCodePoint(0x1f389) // 🎉
+    expect(party.length).toBe(2)
+    expect(displayWidth(party)).toBe(2)
+  })
+
+  it("ignores zero-width combining marks and variation selectors", () => {
+    expect(displayWidth(`e${String.fromCodePoint(0x0301)}`)).toBe(1) // e + combining acute
+    expect(displayWidth(`a${String.fromCodePoint(0xfe0f)}`)).toBe(1) // base + variation selector
   })
 })


### PR DESCRIPTION
## Direction

Daily review, direction (a) bugs/correctness + (d) UX polish. A broad correctness sweep of the recently-changed modules (i18n runtime, PR-status poller, `kobe export`, file-pane git parsing, path truncation) turned up no high-confidence runtime bugs — the code is healthy — except this one alignment defect in the new `kobe export` table renderer.

## Problem

`renderTable` in `packages/kobe/src/cli/export-cmd.ts` promises "aligned columns", but it measured column widths with `String.length` and padded cells with `padEnd` — both of which count **UTF-16 code units**, not terminal display cells. So any wide cell breaks the layout:

- A CJK task title — the common case, since kobe is **Simplified-Chinese-default** — measures 2 units but renders 4 cells, so every column to its right shifts left by 2.
- Fullwidth glyphs and most emoji have the same 1-unit-vs-2-cell gap.
- An astral character (CJK Extension B, emoji) is two UTF-16 surrogate units but one glyph, so `padEnd` *over*-counts it instead.

Concretely, `"中文".length === 2` but it occupies 4 cells, so `"中文".padEnd(5)` yields a 5-unit / 7-cell string and the next column no longer lines up.

This only affects `--format table` (the human-readable view). The `json` and `csv` outputs are unaffected, and `api-cmd.ts`'s only `padEnd` pads ASCII verb names, so it's out of scope.

## Fix

Add a small, pure, code-point-aware `displayWidth` helper local to `export-cmd.ts` (no new dependency — the repo already hand-rolls code-point logic like `filetree/rows.ts`'s `truncatePathTail`):

- East-Asian-wide / fullwidth / common emoji blocks → 2 cells
- combining marks, bidi/format controls, variation selectors → 0 cells
- iterates by code point, so astral characters count once, not as two surrogate units

`renderTable` now sizes columns and pads cells by `displayWidth`, keeping the table aligned for any mix of scripts.

## Verification

- `bun run test test/cli/export-cmd.test.ts` — added unit tests for `displayWidth` (CJK, fullwidth, astral emoji, zero-width combining marks/variation selectors) and a CJK-vs-ASCII row-alignment invariant that fails on the old `String.length` code; full suite green (183 tests).
- `bun run lint` — clean.
- `bun run typecheck` — clean.

## Follow-ups (deliberately out of scope)

- The TUI file pane's `truncatePathTail` truncates by code point but not display width; opentui clips the box so it doesn't misrender, but a future pass could unify on a shared display-width helper if more non-TUI alignment surfaces appear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNWuHq5Pp2h2fUoE3fQ1oU)_