### PR TITLE
feat: polish kobe-landing hero, platform copy, and live GitHub stars

### DIFF
--- a/packages/kobe-landing/TODOS.md
+++ b/packages/kobe-landing/TODOS.md
@@ -1,0 +1,55 @@
+# kobe-landing — TODOs
+
+Landing page 迭代清单。目标：去掉与项目实际不符的细节，让首屏更吸引人、更可信。
+
+源文件：`packages/kobe-landing/index.html`（单文件静态页）。
+
+---
+
+## 1. Hero badge 去重
+- 位置：`index.html` 顶部 hero badge（L52）"TUI orchestrator for Claude Code · bun i -g @sma1lboy/kobe"
+- 问题：`bun i -g @sma1lboy/kobe` 与下方的安装命令按钮（L64 `bun install -g @sma1lboy/kobe`）重复。
+- 改法：badge 只保留 slogan（如 "TUI orchestrator for Claude Code"），删掉安装命令片段。
+
+## 2. 安装要求补充平台支持
+- 位置：L69 "Requires Bun ≥ 1.3.11, tmux, and one engine CLI on your PATH."
+- 改法：加上 macOS / Linux 支持说明（如 "Runs on macOS & Linux."）。
+- 待确认：Windows 是否支持（WSL?）——确认后再定文案。
+
+## 3. 顶部 GitHub 链接升级
+- 位置：nav GitHub 链接（L44）
+- 改法：
+  - 显示 GitHub 官方 logo（inline SVG）。
+  - 显示 repo 当前**实时 star 数**。
+- 实现注意：纯静态页，star 数需前端 fetch GitHub API（`https://api.github.com/repos/Sma1lboy/kobe`，读 `stargazers_count`）；注意未鉴权速率限制（60/h per IP），加 fallback/缓存。
+
+## 4. Hero CTA 文案
+- 位置：L67 "Read the docs ↗"
+- 改法：改成 "Get started"（更有行动号召力）。
+- 倾向：采纳。需确认链接目标（docs / 安装段锚点 / README quickstart）。
+
+## 5. TUI mockup 重做
+- 位置：workspace section 的窗口 chrome（L80）"ssh devbox — kobe — 178×44" + 整个静态 mockup
+- 问题：
+  - 标题不符合 kobe 调性。
+  - 是个**静态**截图式 mockup，不会动，不够生动。
+- 改法：
+  - 换更贴合 kobe 的窗口标题。
+  - 让 mockup "动起来"（如打字机效果、任务状态流转、live 输出滚动）或换成真实录屏/动图驱动。
+
+## 6. "Why" section 改为图片驱动
+- 位置：why section（L162）"// why try it" + "The terminal is the product." + 5 张卡片
+- 问题：纯文字卡片，一点都不吸引人。
+- 改法：改成**以图片/视觉为驱动**的叙事，引导用户一屏一屏往下滑（scroll-driven 视觉故事），而非一排干巴巴的特性卡。
+
+## 7. "Engines" section 重构 fan-out 呈现
+- 位置：engines section（L197）"// choose your engine" + "Bring whatever CLI you already trust." + `kobe api fan-out` 代码块（L211-220）
+- 问题：右侧 `kobe api fan-out` 命令显得很怪、让人觉得"不方便"，反而是减分项。
+- 改法：换一种更直观、更"轻松好用"的方式展示多引擎/并行能力（弱化裸 CLI 命令，强调一键 fan-out 的体验）。
+
+---
+
+## 已确认的决定
+- **#4** "Get started" → 跳 GitHub README（repo quickstart）。
+- **#2** 平台文案：macOS & Linux，Windows via WSL。
+- **#5 / #6** 暂无现成素材，需新做——先用纯 CSS/HTML 实现动效与图片叙事（不依赖外部录屏）。

--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -41,7 +41,14 @@
       <a href="#why" style="color:#8a847a;text-decoration:none;">why</a>
       <a href="#engines" style="color:#8a847a;text-decoration:none;">engines</a>
       <a href="#install" style="color:#8a847a;text-decoration:none;">install</a>
-      <a href="https://github.com/Sma1lboy/kobe" style="color:#eae7df;text-decoration:none;border:1px solid #34302a;padding:7px 14px;border-radius:8px;display:flex;align-items:center;gap:7px;">GitHub <span style="color:#cc785c;">↗</span></a>
+      <a href="https://github.com/Sma1lboy/kobe" target="_blank" rel="noopener" style="color:#eae7df;text-decoration:none;border:1px solid #34302a;padding:7px 12px;border-radius:8px;display:flex;align-items:center;gap:8px;">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        <span>GitHub</span>
+        <span style="display:flex;align-items:center;gap:4px;border-left:1px solid #34302a;padding-left:8px;color:#a39d92;">
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="#d6a85c" aria-hidden="true" style="flex:none;"><path d="M8 .25l2.06 4.18 4.61.67-3.34 3.25.79 4.6L8 10.97l-4.12 2.17.79-4.6L1.33 5.1l4.61-.67L8 .25z"/></svg>
+          <span id="starCount">–</span>
+        </span>
+      </a>
     </div>
   </nav>
 
@@ -49,7 +56,7 @@
   <header style="position:relative;max-width:1180px;margin:0 auto;padding:72px 40px 40px;">
     <div style="display:inline-flex;align-items:center;gap:9px;border:1px solid #34302a;background:#1a1917;border-radius:999px;padding:6px 14px;font-size:12.5px;color:#8a847a;margin-bottom:34px;">
       <span style="width:7px;height:7px;border-radius:50%;background:#9aca86;box-shadow:0 0 8px #9aca86;"></span>
-      TUI orchestrator for Claude Code · bun i -g @sma1lboy/kobe
+      TUI orchestrator for Claude Code, Codex &amp; more
     </div>
     <h1 style="font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:clamp(40px,6.4vw,76px);line-height:0.98;letter-spacing:-0.03em;max-width:14ch;margin-bottom:26px;color:#eae7df;">
       Run parallel coding agents from any <span style="color:#cc785c;">terminal</span>.
@@ -64,9 +71,9 @@
         <span>bun install -g @sma1lboy/kobe</span>
         <span id="copyLabel" style="color:#6b655c;border-left:1px solid #34302a;padding-left:14px;font-size:12px;">click to copy</span>
       </button>
-      <a href="https://github.com/Sma1lboy/kobe" style="background:#cc785c;color:#1a0f0a;text-decoration:none;font-weight:600;border-radius:11px;padding:14px 22px;font-size:14.5px;">Read the docs ↗</a>
+      <a href="https://github.com/Sma1lboy/kobe#readme" style="background:#cc785c;color:#1a0f0a;text-decoration:none;font-weight:600;border-radius:11px;padding:14px 22px;font-size:14.5px;">Get started ↗</a>
     </div>
-    <div style="font-size:12.5px;color:#6b655c;">Requires Bun ≥ 1.3.11, tmux, and one engine CLI on your PATH.</div>
+    <div style="font-size:12.5px;color:#6b655c;">Runs on macOS &amp; Linux (Windows via WSL). Requires Bun ≥ 1.3.11, tmux, and one engine CLI on your PATH.</div>
   </header>
 
   <!-- TUI WORKSPACE MOCKUP -->
@@ -267,6 +274,28 @@
       clearTimeout(timer);
       timer = setTimeout(function () { label.textContent = 'click to copy'; }, 1800);
     });
+  })();
+
+  // live GitHub star count (cache for instant first paint, refresh each load, graceful fallback)
+  (function () {
+    var el = document.getElementById('starCount');
+    if (!el) return;
+    function render(n) {
+      el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n);
+    }
+    var CACHE_KEY = 'kobe_stars';
+    try {
+      var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+      if (cached && typeof cached.n === 'number') render(cached.n);
+    } catch (e) {}
+    fetch('https://api.github.com/repos/Sma1lboy/kobe')
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) {
+        if (!d || typeof d.stargazers_count !== 'number') return;
+        render(d.stargazers_count);
+        try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count })); } catch (e) {}
+      })
+      .catch(function () { if (el.textContent === '–') el.textContent = '☆'; });
   })();
 
   // engine selector → updates the fan-out command + parallel task count


### PR DESCRIPTION
Polishes the kobe-landing marketing page. Dedupes the hero badge (drops the duplicated install command), adds macOS/Linux/WSL to the requirements line, and renames the hero CTA from "Read the docs" to "Get started" pointing at the README. The nav GitHub link now shows the official octocat mark plus a live star count fetched from the GitHub API (localStorage-cached for instant first paint, with a graceful fallback). Adds a TODOS.md tracking the remaining visual rework (animated TUI mockup, image-driven "why" section, and a friendlier engines section).