### PR TITLE
feat: drop redundant hero badge from kobe-landing

### DIFF
--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -54,10 +54,6 @@
 
   <!-- HERO -->
   <header style="position:relative;max-width:1180px;margin:0 auto;padding:72px 40px 40px;">
-    <div style="display:inline-flex;align-items:center;gap:9px;border:1px solid #34302a;background:#1a1917;border-radius:999px;padding:6px 14px;font-size:12.5px;color:#8a847a;margin-bottom:34px;">
-      <span style="width:7px;height:7px;border-radius:50%;background:#9aca86;box-shadow:0 0 8px #9aca86;"></span>
-      TUI orchestrator for Claude Code, Codex &amp; more
-    </div>
     <h1 style="font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:clamp(40px,6.4vw,76px);line-height:0.98;letter-spacing:-0.03em;max-width:14ch;margin-bottom:26px;color:#eae7df;">
       Run parallel coding agents from any <span style="color:#cc785c;">terminal</span>.
     </h1>


### PR DESCRIPTION
Removes the kobe-landing hero badge. It restated the orchestrator tagline already carried by the h1 and subtext below, so the hero now opens directly on the headline. Follow-up to #167, which landed the rest of the hero/platform/star-count polish.