### PR TITLE
fix: show line counts for renamed files in the Changes tab

### DIFF
--- a/.changeset/numstat-rename-stats.md
+++ b/.changeset/numstat-rename-stats.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+File pane Changes tab now shows +/- line counts for renamed files. The pane merges `git diff --numstat` counts onto each `git status` row by path, but the numstat parser looked for porcelain's ` -> ` rename separator — whereas `git diff --numstat` actually renders renames with ` => ` and brace-compacts the unchanged path segments (e.g. `src/{old.txt => new.txt}` or `{dir => other}/x.txt`). So a renamed file's stats keyed off the raw brace text, never matched its post-rename path, and the row rendered with blank counts. The parser now resolves the numstat field to the same canonical new path the porcelain `R` row reports, so renamed files carry their line counts like every other change.

--- a/packages/kobe/src/tui/panes/filetree/git.ts
+++ b/packages/kobe/src/tui/panes/filetree/git.ts
@@ -143,12 +143,44 @@ export async function numstatFiles(worktreePath: string): Promise<NumstatEntry[]
 }
 
 /**
+ * Reconstruct the post-rename path from a `git diff --numstat` path field.
+ *
+ * numstat renders a rename/copy with ` => ` (NOT porcelain's ` -> `), and
+ * compacts the unchanged segments around the change into `{old => new}`
+ * braces:
+ *   - `src/{old.txt => new.txt}` → `src/new.txt`   (common prefix + suffix)
+ *   - `{dir => other}/x.txt`     → `other/x.txt`
+ *   - `root1.txt => root2.txt`   → `root2.txt`      (no common segment, no braces)
+ *
+ * Returning the canonical NEW path is what lets {@link statusFiles} key the
+ * numstat counts by the same path the porcelain `R` row reports — without
+ * this the brace/`=>` text was kept verbatim, never matched the status
+ * entry, and renamed files showed no +/- line counts in the Changes tab.
+ * A plain (non-rename) path has no ` => ` and is returned unchanged.
+ */
+function numstatRenamePath(field: string): string {
+  const open = field.indexOf("{")
+  if (open >= 0) {
+    const close = field.indexOf("}", open)
+    const sep = field.indexOf(" => ", open)
+    if (close > open && sep >= 0 && sep < close) {
+      const newSeg = field.slice(sep + " => ".length, close)
+      return field.slice(0, open) + newSeg + field.slice(close + 1)
+    }
+  }
+  const arrow = field.indexOf(" => ")
+  if (arrow >= 0) return field.slice(arrow + " => ".length)
+  return field
+}
+
+/**
  * Pure parser for `git diff --numstat` output. Each line is:
  *   `<added>\t<deleted>\t<path>`
  * Binary files use `-\t-\tpath` — we surface those as `null` counts.
- * Renames look like `<a>\t<d>\told -> new` (or with `{}` braces depending
- * on git config); we keep the raw path text because the porcelain status
- * row carries the canonical post-rename path already.
+ * Renames look like `<a>\t<d>\tsrc/{old => new}` (numstat uses ` => `, not
+ * porcelain's ` -> `, and brace-compacts the unchanged segments); we resolve
+ * them to the canonical post-rename path so the counts key by the same path
+ * the porcelain status row reports.
  */
 export function parseNumstat(raw: string): NumstatEntry[] {
   const lines = raw.split("\n").map((l) => l.replace(/\r$/, ""))
@@ -161,10 +193,7 @@ export function parseNumstat(raw: string): NumstatEntry[] {
     if (tab2 < 0) continue
     const a = line.slice(0, tab1)
     const d = line.slice(tab1 + 1, tab2)
-    let path = line.slice(tab2 + 1)
-    // Rename forms: "old -> new" or "{old => new}".
-    const arrow = path.indexOf(" -> ")
-    if (arrow >= 0) path = path.slice(arrow + " -> ".length)
+    const path = numstatRenamePath(line.slice(tab2 + 1))
     const added = a === "-" ? null : Number.parseInt(a, 10)
     const deleted = d === "-" ? null : Number.parseInt(d, 10)
     if (path.length === 0) continue

--- a/packages/kobe/test/tui/filetree-git.test.ts
+++ b/packages/kobe/test/tui/filetree-git.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the file tree's pure git parsers (`filetree/git.ts`).
+ *
+ * Focus: `parseNumstat` rename handling. `git diff --numstat` renders a
+ * rename with ` => ` (NOT porcelain's ` -> `) and brace-compacts the
+ * unchanged path segments. The Changes tab merges these counts onto the
+ * porcelain `R` row by PATH, so the parser must resolve the numstat field
+ * to the same canonical post-rename path porcelain reports — otherwise a
+ * renamed file silently shows no +/- line counts.
+ */
+
+import { describe, expect, test } from "vitest"
+import { parseNumstat } from "../../src/tui/panes/filetree/git"
+
+describe("parseNumstat", () => {
+  test("parses a plain modified file", () => {
+    expect(parseNumstat("3\t2\tsrc/app.ts")).toEqual([{ path: "src/app.ts", added: 3, deleted: 2 }])
+  })
+
+  test("surfaces binary `-` counts as null", () => {
+    expect(parseNumstat("-\t-\tassets/logo.png")).toEqual([{ path: "assets/logo.png", added: null, deleted: null }])
+  })
+
+  test("ignores blank and malformed lines", () => {
+    expect(parseNumstat("\n3\t1\ta.ts\nnotatabline\n")).toEqual([{ path: "a.ts", added: 3, deleted: 1 }])
+  })
+
+  // ── Rename forms (the bug this file pins) ────────────────────────────────
+  // git outputs ` => ` with brace-compaction; the canonical NEW path must
+  // match what `git status --porcelain` reports as the `R` row's path.
+
+  test("resolves a same-directory rename to the new path", () => {
+    // git: `0\t0\tsrc/{old.txt => new.txt}`  (porcelain row: `src/new.txt`)
+    expect(parseNumstat("0\t0\tsrc/{old.txt => new.txt}")).toEqual([{ path: "src/new.txt", added: 0, deleted: 0 }])
+  })
+
+  test("resolves a cross-directory rename (brace on the leading segment)", () => {
+    // git: `0\t0\t{dir => other}/x.txt`  (porcelain row: `other/x.txt`)
+    expect(parseNumstat("0\t0\t{dir => other}/x.txt")).toEqual([{ path: "other/x.txt", added: 0, deleted: 0 }])
+  })
+
+  test("resolves a root-level rename with no common segment (no braces)", () => {
+    // git: `0\t0\troot1.txt => root2.txt`  (porcelain row: `root2.txt`)
+    expect(parseNumstat("0\t0\troot1.txt => root2.txt")).toEqual([{ path: "root2.txt", added: 0, deleted: 0 }])
+  })
+
+  test("keeps content-change counts on a renamed-and-edited file", () => {
+    expect(parseNumstat("8\t1\tsrc/{a.ts => b.ts}")).toEqual([{ path: "src/b.ts", added: 8, deleted: 1 }])
+  })
+
+  test("does not mangle a normal path that merely contains a brace", () => {
+    // No ` => ` inside the braces → not a rename → returned verbatim.
+    expect(parseNumstat("1\t0\tsrc/{shared}/util.ts")).toEqual([{ path: "src/{shared}/util.ts", added: 1, deleted: 0 }])
+  })
+})


### PR DESCRIPTION
## Direction

Daily review, direction (a) bugs/correctness. A correctness sweep of recently-touched modules (the project add/remove/forget flows, `kobe export`, the i18n runtime, the PR-status poller, and the file-pane git parsers) turned up one real defect in the file pane's numstat parser. Everything else reviewed clean. I deliberately stayed clear of the in-flight PR #165 (export display-width alignment).

## Problem

The file pane's **Changes** tab merges `git diff --numstat` line counts onto each `git status --porcelain` row by path (`statusFiles` in `packages/kobe/src/tui/panes/filetree/git.ts`). For a **renamed** file, that merge silently fails, so the row renders with **no +/- counts**.

Root cause: `parseNumstat` looked for porcelain's ` -> ` rename separator, but `git diff --numstat` doesn't use that form. It renders renames with ` => ` **and** brace-compacts the unchanged path segments. Verified against real git:

```
$ git status --porcelain
R  src/old.txt -> src/new.txt
R  dir/x.txt -> other/x.txt

$ git diff --numstat HEAD
0	0	src/{old.txt => new.txt}
0	0	{dir => other}/x.txt
0	0	root1.txt => root2.txt     # no common segment → no braces
```

Because ` -> ` never appears, the parser kept the raw `src/{old.txt => new.txt}` text as the path. That never matches the porcelain `R` row's canonical path (`src/new.txt`), so `stats.get(e.path)` misses and the renamed file shows blank counts. (A naive swap to ` => ` + `slice` is **not** enough — it leaves stray braces like `new.txt}` / `other}/x.txt`, which still don't match.)

## Fix

Add a small pure helper, `numstatRenamePath`, that reconstructs the canonical post-rename path from numstat's compacted field:

- `src/{old.txt => new.txt}` → `src/new.txt` (common prefix + suffix)
- `{dir => other}/x.txt` → `other/x.txt`
- `root1.txt => root2.txt` → `root2.txt` (no braces)
- a plain path with no ` => ` (incl. one that merely contains a `{`) is returned unchanged

Now the numstat counts key by the same path the porcelain row reports, and renamed files carry their line counts like every other change. One file, one pure function; no behavior change for non-rename paths.

## Verification

- New `packages/kobe/test/tui/filetree-git.test.ts` pins all three numstat rename forms (same-dir, cross-dir, root-level), the renamed-and-edited case, binary `-` counts, malformed-line dropping, and the "brace but not a rename" guard. The inputs are the exact strings real git emits (confirmed empirically in a throwaway repo). 8/8 pass.
- `bun run typecheck` — green.
- `bun run lint` — green.
- `bun test test/tui/filetree-git.test.ts test/tui/filetree-rows.test.ts test/tui/worktree-changes.test.ts` — 30/30 green.
- Note: the full `test/tui/` directory shows some pre-existing, nondeterministic `terminal-tmux.test.ts` failures from parallel test-isolation (shared env/cwd) that also occur on `main` and are unrelated to this change — `terminal-tmux.test.ts` passes when run alone.

## Follow-ups (out of scope)

- The `terminal-tmux.test.ts` cross-file test-isolation flakiness in the `test/tui/` suite is worth a separate look but isn't touched here.
- Copy detection (`C` rows) uses the same ` => ` numstat form and is handled by this helper for free, but porcelain copy rows aren't currently surfaced specially — no change needed today.


---
_Generated by [Claude Code](https://claude.ai/code/session_01R43DfRSaPCUzDYW8DKj49h)_