### PR TITLE
fix: make Ctrl+[ step to the previous New Task sub-tab

### DIFF
--- a/.changeset/newtask-ctrl-bracket-prev-tab.md
+++ b/.changeset/newtask-ctrl-bracket-prev-tab.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix Ctrl+[ in the New Task dialog so it steps to the previous sub-tab instead of repeating Ctrl+]'s forward jump — with the three Existing / New Repo / Adopt tabs both chords were cycling the same direction, leaving no keyboard chord to move back.

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -542,9 +542,9 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
         cmd: () => switchToTab(nextDialogTab(tab())),
       },
       {
-        // Ctrl+[ → previous sub-tab. With two tabs this toggles too.
+        // Ctrl+[ → previous sub-tab (reverse of Ctrl+]).
         key: "ctrl+[",
-        cmd: () => switchToTab(nextDialogTab(tab())),
+        cmd: () => switchToTab(prevDialogTab(tab())),
       },
       {
         // Ctrl+E cycles the engine vendor within the detected set.

--- a/packages/kobe/test/tui/new-task-dialog/tab-cycle-bindings.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/tab-cycle-bindings.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression test for the new-task dialog's Ctrl+[ / Ctrl+] tab-cycle chords.
+ *
+ * The production bug this pins: Ctrl+[ ("previous sub-tab", per its own
+ * comment) was wired to `nextDialogTab`, identical to Ctrl+] — so with the
+ * three sub-tabs (Existing / Clone / Adopt, KOB-256) both chords cycled
+ * FORWARD and there was no way to step back with the keyboard chords. The
+ * ←/→ selector path (`cycleTab`) used prev/next correctly, masking the defect.
+ *
+ * dialog.tsx builds its bindings inline (the component drags in opentui), so —
+ * like ctrl-a-gating.test.ts — this reproduces the exact binding shape and the
+ * real `nextDialogTab`/`prevDialogTab` cycle helpers, then asserts the dispatch
+ * outcome: Ctrl+] advances, Ctrl+[ reverses, and the two are inverses on every
+ * tab. If a future edit re-points either chord at the wrong helper, the
+ * round-trip assertions below fail.
+ */
+
+import { type DialogTab, nextDialogTab, prevDialogTab } from "@/tui/component/new-task-dialog/state"
+import { type RegisteredBinding, dispatchKeyEvent } from "@/tui/lib/keymap-dispatch"
+import { describe, expect, test } from "vitest"
+
+const ALL_TABS: readonly DialogTab[] = ["existing", "clone", "adopt"]
+
+/** The tab-cycle slice of the dialog's binding list, built exactly as
+ *  dialog.tsx does: Ctrl+] → next sub-tab, Ctrl+[ → previous sub-tab. */
+function tabCycleSlice(tab: DialogTab, switchToTab: (next: DialogTab) => void) {
+  return [
+    { key: "ctrl+]", cmd: () => switchToTab(nextDialogTab(tab)) },
+    { key: "ctrl+[", cmd: () => switchToTab(prevDialogTab(tab)) },
+  ]
+}
+
+function evt(name: string, ctrl = false) {
+  let prevented = false
+  return {
+    name,
+    ctrl,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true
+    },
+    get prevented() {
+      return prevented
+    },
+  }
+}
+
+function stackFor(bindings: ReturnType<typeof tabCycleSlice>): RegisteredBinding[] {
+  return [{ id: 1, config: () => ({ bindings }) }]
+}
+
+/** Dispatch one chord against the slice built for `from`, returning the tab the
+ *  handler switched to (or `from` if nothing fired). */
+function press(from: DialogTab, keyName: string): DialogTab {
+  let landed: DialogTab = from
+  const switchToTab = (next: DialogTab): void => {
+    landed = next
+  }
+  const hit = dispatchKeyEvent(stackFor(tabCycleSlice(from, switchToTab)), evt(keyName, true))
+  expect(hit).toBe(true)
+  return landed
+}
+
+describe("new-task dialog tab-cycle chords", () => {
+  test("Ctrl+] advances forward through every tab", () => {
+    for (const tab of ALL_TABS) {
+      expect(press(tab, "]")).toBe(nextDialogTab(tab))
+    }
+  })
+
+  test("Ctrl+[ steps backward through every tab (the bug: it used to go forward)", () => {
+    for (const tab of ALL_TABS) {
+      expect(press(tab, "[")).toBe(prevDialogTab(tab))
+    }
+    // Concretely: from "existing", back lands on "adopt", not "clone".
+    expect(press("existing", "[")).toBe("adopt")
+  })
+
+  test("Ctrl+] and Ctrl+[ are inverses on every tab", () => {
+    for (const tab of ALL_TABS) {
+      expect(press(press(tab, "]"), "[")).toBe(tab)
+      expect(press(press(tab, "["), "]")).toBe(tab)
+    }
+  })
+})


### PR DESCRIPTION
## Direction

Daily review, direction (a) bugs/correctness. A correctness sweep of the recently-changed TUI modules turned up one observable wiring defect in the New Task dialog's tab-cycle chords. (I deliberately stayed clear of areas already covered by open PRs — file-pane numstat parsing in #172 and `kobe export` display-width alignment in #165.)

## Problem

In `packages/kobe/src/tui/component/new-task-dialog/dialog.tsx`, the `Ctrl+[` keybinding was wired to `nextDialogTab(tab())` — **identical** to the `Ctrl+]` binding directly above it — even though its own comment reads "Ctrl+[ → previous sub-tab".

The dialog now has **three** sub-tabs (`existing` / `clone` / `adopt`, per KOB-256), so this is observable, not latent:

- `Ctrl+]` cycles `existing → clone → adopt → existing` (forward) ✓
- `Ctrl+[` should cycle `existing → adopt → clone → existing` (backward), but instead cycled **forward**, exactly like `Ctrl+]`.

The result: there was no keyboard chord to move *back* through the sub-tabs. (The `←/→` selector path — `cycleTab` — used `prev`/`next` correctly, which masked the defect.) The stale "with two tabs this toggles" comment is a leftover from when next/prev were indistinguishable, before the third tab landed.

## Fix

Point `Ctrl+[` at `prevDialogTab(tab())` (already imported and used correctly by `cycleTab`) and refresh the comment. One line of behavior change; the `nextDialogTab`/`prevDialogTab` cycle helpers themselves are unchanged and already fully covered by `state.test.ts`.

## Verification

- New `test/tui/new-task-dialog/tab-cycle-bindings.test.ts` reproduces the dialog's binding shape and dispatches the chords via the real `dispatchKeyEvent`, pinning the contract: `Ctrl+]` advances, `Ctrl+[` reverses, and the two are inverses on every tab (so re-pointing either chord at the wrong helper fails the round-trip). Follows the existing `ctrl-a-gating.test.ts` pattern — dialog.tsx pulls in opentui, so the binding slice is reproduced rather than imported. 3/3 pass.
- `bun test test/tui/new-task-dialog/` — 41/41 green.
- `bun run lint` — green.
- `bun run typecheck` — green.

## Follow-ups (out of scope)

- Separately, the PR-status feature (KOB-10) ships a `checkResolutionNotify` helper (`src/monitor/pr-status.ts`) plus doc comments promising the sidebar "fires a toast/bell when a task's checks resolve", but that helper currently has zero production callers and no TUI effect wires it up. Wiring it touches task-vs-tab notification scoping decisions that deserve a human call, so I left it for a maintainer rather than guessing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DALXGH8HNjHQrBEWKK7wUA)_