### PR TITLE
fix: make node-pty a runtime dependency for kobe web

### DIFF
--- a/.changeset/web-pty-runtime-dep.md
+++ b/.changeset/web-pty-runtime-dep.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: move `node-pty` to runtime dependencies so `kobe web` works on global installs
+
+The `kobe web` PTY sidecar (`dist/web-ui/pty-server.mjs`) imports `node-pty` at
+runtime, but it was declared under `devDependencies`, so a published `npm i -g
+@sma1lboy/kobe` never installed it and `kobe web` crashed with
+`ERR_MODULE_NOT_FOUND: Cannot find package 'node-pty'`. Moved it to
+`dependencies`.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -49,7 +49,8 @@
     "@opentui/core": "0.2.4",
     "@opentui/solid": "0.2.4",
     "ws": "^8.18.0",
-    "solid-js": "1.9.13"
+    "solid-js": "1.9.13",
+    "node-pty": "^1.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
@@ -59,7 +60,6 @@
     "@types/node": "25.6.2",
     "knip": "^6.14.2",
     "kobe-web": "workspace:*",
-    "node-pty": "^1.1.0",
     "typescript": "5.8.2",
     "vitest": "2.1.9"
   },


### PR DESCRIPTION
`kobe web` crashed on global installs with `ERR_MODULE_NOT_FOUND: Cannot find package 'node-pty'` because the PTY sidecar (`dist/web-ui/pty-server.mjs`) imports `node-pty` at runtime, yet it was declared under `devDependencies` and so never shipped with `npm i -g @sma1lboy/kobe`. This moves `node-pty` to `dependencies` and adds a patch changeset. Verified locally: with node-pty present the PTY server starts cleanly (`kobe pty-server listening on 127.0.0.1:5176`).