### PR TITLE
fix: web diff viewer shows patches for special-char filenames

### DIFF
--- a/.changeset/web-diff-special-paths.md
+++ b/.changeset/web-diff-special-paths.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: the web diff viewer now shows the patch for files whose names have non-ASCII characters, spaces, or control characters. Git C-quotes those paths in `git diff` output (octal byte escapes like `"b/\303\274.txt"`) and appends a disambiguation tab to spaced names (`+++ b/a b.txt\t`), but the per-file patch splitter keyed on the raw marker text and used a weaker local unquoter, so the patch never matched the NUL-delimited porcelain path and the file rendered as changed with an empty diff. Path resolution now flows through the shared rigorous git-path unquoter and strips the disambiguation tab, so unicode, spaced, and special-char filenames join their hunks correctly.

--- a/packages/kobe/src/web/diff.ts
+++ b/packages/kobe/src/web/diff.ts
@@ -34,6 +34,7 @@
 
 import { statSync } from "node:fs"
 import { execHostForWorktreePath, worktreeUsable } from "../exec/resolve.ts"
+import { unquoteGitPath } from "../lib/git-parsers.ts"
 import { runWorktreeGit } from "../worktree/content.ts"
 
 const GIT_TIMEOUT_MS = 15_000
@@ -96,10 +97,40 @@ export function statusLabel(code: string): string {
 }
 
 /**
+ * Resolve the repo-relative path from a unified-diff `--- ` / `+++ ` marker
+ * payload (everything after the 4-char `--- ` / `+++ ` prefix, to end of line).
+ * Handles the three shapes real git emits:
+ *   - `/dev/null`             — the absent side of an add/delete → `null`.
+ *   - `b/<path>` / `a/<path>` — plain; git appends a disambiguation TAB when
+ *     the path contains a space (`+++ b/a b.txt\t`), so strip a trailing tab.
+ *   - `"b/<c-escaped>"`       — C-quoted when the path has control / non-ASCII
+ *     bytes or a quote (`"b/\303\274.txt"`); the quote wraps the whole `b/…`.
+ * Quoted forms are decoded with the shared rigorous unquoter so the key
+ * matches the raw (NUL-delimited, unquoted) path the porcelain `-z` pass emits.
+ */
+function markerPath(payload: string): string | null {
+  if (payload === "/dev/null") return null
+  let token = payload
+  if (token.startsWith('"')) {
+    token = unquoteGitPath(token) // `"b/<esc>"` → `b/<path>`
+  } else {
+    // A literal tab is git's space-disambiguation suffix, never part of the
+    // path (a path that truly contained a tab would be C-quoted instead).
+    const tab = token.indexOf("\t")
+    if (tab >= 0) token = token.slice(0, tab)
+  }
+  if (token.startsWith("a/") || token.startsWith("b/")) token = token.slice(2)
+  return token.length > 0 ? token : null
+}
+
+/**
  * Split a multi-file `git diff` blob into per-file patches keyed by the
  * post-image path. Each file's hunk starts at a `diff --git a/… b/…` line; we
- * read the destination path from the `+++ b/<path>` marker when present (it
- * handles renames and quoted/space paths better than parsing the header).
+ * read the path from the `+++ ` marker (post-image), falling back to `--- `
+ * for deletes (`+++ /dev/null`) and finally to the header for marker-less
+ * chunks (a pure rename / mode change). All three honour git's path quoting so
+ * non-ASCII, spaced, and special-char names key the same path the porcelain
+ * pass reports — otherwise their patch silently comes back empty.
  */
 export function splitDiffByFile(diff: string): Map<string, string> {
   const byFile = new Map<string, string>()
@@ -109,25 +140,22 @@ export function splitDiffByFile(diff: string): Map<string, string> {
   for (const chunk of chunks) {
     if (!chunk.startsWith("diff --git")) continue
     let path: string | null = null
-    const plus = chunk.match(/^\+\+\+ b\/(.*)$/m)
-    if (plus && plus[1] !== "/dev/null") {
-      path = plus[1]
-    } else {
-      // Deleted file (+++ /dev/null) or no body — fall back to the header's b/.
-      const header = chunk.match(/^diff --git a\/.* b\/(.*)$/m)
-      if (header) path = header[1]
+    const plus = chunk.match(/^\+\+\+ (.*)$/m)
+    if (plus) path = markerPath(plus[1])
+    if (path === null) {
+      // Deleted file (`+++ /dev/null`): take the pre-image path from `--- `.
+      const minus = chunk.match(/^--- (.*)$/m)
+      if (minus) path = markerPath(minus[1])
     }
-    if (!path) continue
-    byFile.set(unquoteGitPath(path), chunk.endsWith("\n") ? chunk : `${chunk}\n`)
+    if (path === null) {
+      // Marker-less chunk (pure rename / mode change): best-effort header key.
+      const header = chunk.match(/^diff --git a\/.* b\/(.*)$/m)
+      if (header) path = unquoteGitPath(header[1])
+    }
+    if (path === null) continue
+    byFile.set(path, chunk.endsWith("\n") ? chunk : `${chunk}\n`)
   }
   return byFile
-}
-
-/** Git quotes paths with special chars as C-style strings ("a\tb"); undo that. */
-function unquoteGitPath(p: string): string {
-  if (!(p.startsWith('"') && p.endsWith('"'))) return p
-  const inner = p.slice(1, -1)
-  return inner.replace(/\\([\\"nt])/g, (_m, c: string) => (c === "n" ? "\n" : c === "t" ? "\t" : c))
 }
 
 /**

--- a/packages/kobe/test/web/diff.test.ts
+++ b/packages/kobe/test/web/diff.test.ts
@@ -149,21 +149,58 @@ describe("splitDiffByFile", () => {
   })
 
   it("keys paths containing spaces by their post-image path", () => {
-    // Git leaves spaces unquoted (only control chars / quotes trigger C-quoting),
-    // so the `+++ b/<path>` marker carries the literal space.
+    // Git leaves spaces unquoted but appends a TAB after the name in the
+    // `---`/`+++` markers to disambiguate it — that tab is NOT part of the
+    // path and must be stripped, else the key never matches the porcelain row.
     const diff = [
       "diff --git a/has space.ts b/has space.ts",
       "index 111..222 100644",
-      "--- a/has space.ts",
-      "+++ b/has space.ts",
+      "--- a/has space.ts\t",
+      "+++ b/has space.ts\t",
       "@@ -1 +1 @@",
       "-x",
       "+y",
       "",
     ].join("\n")
     const byFile = splitDiffByFile(diff)
-    expect(byFile.has("has space.ts")).toBe(true)
+    expect([...byFile.keys()]).toEqual(["has space.ts"])
     expect(byFile.get("has space.ts")).toContain("+y")
+  })
+
+  it("decodes a C-quoted non-ASCII post-image path (octal byte escapes)", () => {
+    // Git C-quotes a path with non-ASCII bytes, octal-escaping each UTF-8 byte
+    // and wrapping the whole `b/…` in quotes: `+++ "b/\303\274.txt"` (ü.txt).
+    const diff = [
+      'diff --git "a/\\303\\274.txt" "b/\\303\\274.txt"',
+      "index 111..222 100644",
+      '--- "a/\\303\\274.txt"',
+      '+++ "b/\\303\\274.txt"',
+      "@@ -1 +1 @@",
+      "-a",
+      "+b",
+      "",
+    ].join("\n")
+    const byFile = splitDiffByFile(diff)
+    expect([...byFile.keys()]).toEqual(["ü.txt"])
+    expect(byFile.get("ü.txt")).toContain("+b")
+  })
+
+  it("decodes a C-quoted path with a control char (tab in the name)", () => {
+    // A genuine tab inside a name forces C-quoting (`"b/a\tb.txt"`); the decoded
+    // key carries the literal tab, matching the raw porcelain `-z` path.
+    const diff = [
+      'diff --git "a/a\\tb.txt" "b/a\\tb.txt"',
+      "index 111..222 100644",
+      '--- "a/a\\tb.txt"',
+      '+++ "b/a\\tb.txt"',
+      "@@ -1 +1 @@",
+      "-a",
+      "+b",
+      "",
+    ].join("\n")
+    const byFile = splitDiffByFile(diff)
+    expect([...byFile.keys()]).toEqual(["a\tb.txt"])
+    expect(byFile.get("a\tb.txt")).toContain("+b")
   })
 
   it("ignores leading content that is not a diff chunk", () => {


### PR DESCRIPTION
## Direction

Bug / correctness — surfaced during a code-health review of the git-output parsers (`a` + `c` in the daily-review directions).

## Problem

The kobe-web diff route (`GET /api/diff`, `src/web/diff.ts`) enumerates changed files with `git status --porcelain=v1 -z` (NUL-delimited → paths are emitted **raw**, never quoted) and then slices each file's patch out of a full `git diff` blob, keyed by path. The keying was broken for any filename git treats specially:

- **Non-ASCII names** (`ü.txt`): `git diff` C-quotes the whole side as `+++ "b/\303\274.txt"`. The splitter's regex `^\+\+\+ b\/(.*)$` requires `b/` immediately after `+++ `, so the leading `"` made it miss entirely, the chunk was skipped, and the patch came back empty.
- **Spaced names** (`a b.txt`): git appends a disambiguation **tab** to the marker (`+++ b/a b.txt\t`). The captured key kept the trailing tab, so it never matched the porcelain path `a b.txt`.
- **Control-char names** (tab/newline/quote): C-quoted like non-ASCII; the file's local `unquoteGitPath` only handled `\\ \" \n \t` and could not decode the octal byte escapes git actually emits.

Net effect: such a file shows up in the web diff list as "modified" but with **no diff content**. The existing space test masked this — its fixture omitted the trailing tab real git produces.

## Fix

- Resolve `--- ` / `+++ ` marker paths through a new `markerPath` helper that: returns `null` for `/dev/null`, strips git's trailing disambiguation tab on unquoted names, and decodes C-quoted names via the repository's **shared rigorous** unquoter `unquoteGitPath` from `src/lib/git-parsers.ts` (the module documented as "one rigorous, shared parser … with correct C-string unquoting", which handles octal-byte/UTF-8 escapes).
- Delete the weaker local `unquoteGitPath` duplicate in `web/diff.ts` (DRY/code-health).
- Use `+++` for the post-image path, fall back to `--- ` for deletes (`+++ /dev/null`), then the `diff --git` header for marker-less chunks (pure rename / mode change).

No change to the git invocations or response shape.

## Verification

- `bun run typecheck` ✓, `bun run lint` ✓.
- `bun run test:fast` ✓ (1200 tests).
- Updated the spaced-name test to use **real** git output (trailing tab) and added tests for C-quoted non-ASCII (octal escapes) and control-char names — `test/web/diff.test.ts` ✓.
- End-to-end against real `git diff` + `git status -z` in a scratch repo with `ü.txt`, `a b.txt`, and a tab-in-name file: all three now JOIN their patches (previously empty).

## Follow-ups

- None required. The TUI file-tree pane already uses `git-parsers.ts` directly, so this consolidates the last remaining ad-hoc git-path unquoter onto the shared parser.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TdAT9PwGJBStzeYyGVs8Rz)_