### PR TITLE
fix: heal a task's workspace layout when a pane exits (#179)

### DIFF
--- a/.changeset/heal-layout-on-pane-exit.md
+++ b/.changeset/heal-layout-on-pane-exit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: a task's workspace layout now re-pins itself after you exit a terminal pane. Closing a workspace-split terminal (typing `exit`) hands its cells to a neighbouring pane, which knocks the fixed-width Tasks rail and the right column off their pinned geometry — the same disorder a terminal resize causes, except `window-resized` never fires because the window size is unchanged. Until now the only recovery was switching to another task and back (which heals on switch-in), so the currently-focused task stayed visually broken until you dragged the panes back yourself. kobe now heals the layout on tmux's `pane-exited` hook, re-pinning the rail and right column to the shared globals the moment a pane closes.

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -612,11 +612,14 @@ async function main(): Promise<void> {
     return
   }
   if (subcommand === "heal-layout") {
-    // `window-resized` tmux hook handler: re-pin the resized session's Tasks-rail
-    // width + right-column geometry to the shared globals. Fixes the first-attach
-    // reflow (the first session is built before any client is attached, so tmux
-    // reflows its panes when `attach` lands the real terminal size) and any live
-    // terminal resize. No-op for the home/role-less session. Reads `--session`.
+    // `window-resized` + `pane-exited` tmux hook handler: re-pin the session's
+    // Tasks-rail width + right-column geometry to the shared globals. Fixes the
+    // first-attach reflow (the first session is built before any client is
+    // attached, so tmux reflows its panes when `attach` lands the real terminal
+    // size), any live terminal resize, and the pane-close reflow (exiting a
+    // workspace-split terminal hands its cells to a neighbour, knocking the rail /
+    // right column off their pinned geometry). No-op for the home/role-less
+    // session. Reads `--session`.
     //
     // A live resize fires this hook many times in a burst; `coalesceLayoutWork`
     // trailing-debounces so the burst collapses to ONE heal (no concurrent

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -832,6 +832,8 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
   // which reflows the rail the same way. `-b` runs it in the background so tmux
   // isn't blocked; `resize-pane` never changes the window size, so the heal
   // can't re-trigger the hook. `heal-layout` is a no-op for role-less sessions.
+  // Reused below for the `pane-exited` hook — a pane close reflows the rail the
+  // same way a resize does, and the same re-pin recovers it.
   const healLayoutCommand = `${envStr}${invStr} heal-layout --session '#{session_name}'`
   const healLayoutTmuxCommand = `run-shell -b ${shellQuote(healLayoutCommand)}`
   // `client-resized` companion to the `window-resized` heal. The pre-attach /
@@ -979,6 +981,17 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     ...clipboardBindings,
     ["set-hook", "-g", "window-resized", healLayoutTmuxCommand],
     ["set-hook", "-g", "client-resized", resyncWindowTmuxCommand],
+    // Re-pin the layout when a pane CLOSES too. Exiting a kobe-owned shell pane
+    // (the user types `exit` in a workspace-split terminal) destroys it and tmux
+    // gives its cells to a neighbour, reflowing the absolute-width Tasks rail and
+    // the right column off their pinned geometry — the same disorder a resize
+    // causes, but `window-resized` never fires (the window size is unchanged), so
+    // the only existing recovery was switching tasks (which heals on switch-in).
+    // The currently-focused task therefore stayed broken until a manual re-drag.
+    // `pane-exited` (tmux ≥ 2.2) fires on that close; `heal-layout` re-pins to the
+    // shared globals — the SAME idempotent, coalesced heal a switch runs. No-op
+    // for role-less sessions and for panes already at the target geometry.
+    ["set-hook", "-g", "pane-exited", healLayoutTmuxCommand],
     ["set-hook", "-g", "window-layout-changed", captureLayoutTmuxCommand],
     ...unbinds,
     // Two-stage: on the Tasks pane → detach (the old exit); anywhere else →


### PR DESCRIPTION
## Direction

Bug / correctness — fixes open issue #179 ("Exit the terminal layout error"). This was the only open issue not reserved as `good first issue`.

## Problem

Reported in #179: after exiting **both** terminal interfaces of a task (typing `exit` in the middle + right workspace-split terminals), the layout becomes disordered, and the **currently-focused** task stays broken until you drag the panes back by hand. The reporter noted that *switching to another task resets the layout* — but the last-edited task never gets that switch, so it stays wrong.

Root cause: closing a pane destroys it and tmux hands its cells to a neighbouring pane, reflowing the absolute-width Tasks rail and the right column off their pinned geometry — the **same** disorder a terminal resize causes. But `window-resized` never fires on a pane close (the window size is unchanged), and the only hook that does fire (`window-layout-changed`) is wired to *capture* a drag, not to *heal*. So nothing re-pins the focused task's layout. Switching tasks worked only because switch-in runs `healWorkspaceLayout` directly.

## Fix

Wire tmux's `pane-exited` hook to the existing `heal-layout` handler (`set-hook -g pane-exited`), reusing the exact idempotent, coalesced re-pin that a task switch already runs — the operation the reporter confirms fixes the disorder. It re-pins the Tasks rail width + right-column geometry to the shared globals the moment a pane closes, and is a no-op for role-less sessions and for panes already at the target geometry. One added hook registration line plus comment/doc updates on the reused `heal-layout` handler; no behavior change to the existing resize/capture hooks.

## Verification

- `bun run lint` ✓ · `bun run typecheck` ✓ (both packages).
- `bun test` for the touched area — `terminal-tmux`, `layout-coord`, `terminal-pane-heal` — 64 pass / 0 fail.
- Empirically validated against a live tmux 3.4 server that the `pane-exited` hook fires on a pane `exit`. Confirmed via the upstream tmux CHANGES that `pane-exited` has existed since tmux **2.2**, well below kobe's documented ≥3.2 minimum, so adding it to the session-setup batch (which halts on the first failed command) is safe on every supported tmux.

## Follow-ups / deferred

- I could not reproduce the exact *visual* disorder end-to-end in the cloud checkout (no live TUI), so this relies on the reporter's own observation that the existing `healWorkspaceLayout` — the operation now triggered on pane exit — resets the layout when invoked via a task switch. Worth a manual confirm on the reporter's macOS setup from #179.
- `pane-exited` also fires on chat-tab close / task delete; the heal is idempotent and coalesced so those are harmless no-ops, but if pane-churn-heavy flows ever show overhead, the coalesce window in `layout-coord.ts` is the knob.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UPsPUNg9y4aL7TdjxBm9Lk)_