### PR TITLE
fix: don't poison global Ops height when a task's terminal pane exits

### DIFF
--- a/.changeset/no-poison-ops-height-on-shell-exit.md
+++ b/.changeset/no-poison-ops-height-on-shell-exit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: closing a task's bottom-right terminal with `exit` no longer squashes the terminal pane across every task. The shell pane has no keepAlive, so typing `exit` really kills it and the Ops pane grows to fill the right column. The layout-capture path (both the live `window-layout-changed` drag gate and the switch-away capture) then read that transient ~100% Ops height and wrote it to the GLOBAL Ops-height option, so every later layout heal re-applied the squashed height to all tasks until a manual re-drag. Capture now bails when the `shell` role is absent (without the hidden-by-toggle flag), so a closed terminal can't poison the saved geometry.

--- a/packages/kobe/src/tui/panes/terminal/pane-heal.ts
+++ b/packages/kobe/src/tui/panes/terminal/pane-heal.ts
@@ -535,6 +535,12 @@ export async function captureGlobalLayout(session: string): Promise<void> {
   if (rows.some((cols) => cols[5]?.trim() === "1")) return // zoomed → geometry is unreliable
   if (rows.some((cols) => (cols[6]?.trim() ?? "") !== "")) return // hidden shell → Ops is temporarily full-height
   if (rows.some((cols) => (cols[7]?.trim() ?? "") !== "")) return // hidden Tasks → remaining panes are temporarily full-width
+  // Shell pane CLOSED (user typed `exit` in the bottom-right terminal — it has no
+  // keepAlive, so it really dies) rather than hidden-by-toggle (caught above via
+  // HIDDEN_TERMINAL_PANE_OPTION). With the shell gone, Ops has grown to fill the
+  // right column, so its height reads back as ~100% — capturing that would poison
+  // the global Ops height for EVERY task until the next manual drag. Bail.
+  if (!rows.some((cols) => cols[0]?.trim() === "shell")) return
   const winW = Number.parseInt(rows[0][3]?.trim() ?? "", 10)
   const winH = Number.parseInt(rows[0][4]?.trim() ?? "", 10)
   const sets: (readonly string[])[] = []
@@ -568,9 +574,13 @@ export async function captureGlobalLayout(session: string): Promise<void> {
  *   - NOT zoomed — a zoomed pane reports the full-window grid, so the rail /
  *     right-column widths read back as garbage; capturing them would poison
  *     the global until the next real drag.
- *   - the full kobe role set is present (`tasks` + `ops`) — excludes the
- *     transient half-built layouts that pane splits emit during a session
- *     build / respawn, where the geometry isn't the user's to keep.
+ *   - the full kobe role set is present (`tasks` + `ops` + `shell`) — excludes
+ *     the transient half-built layouts that pane splits emit during a session
+ *     build / respawn, where the geometry isn't the user's to keep, AND the case
+ *     where the user closed the bottom-right shell pane via `exit` (it has no
+ *     keepAlive, so it dies): Ops then fills the right column and its height
+ *     would read back as ~100%, poisoning the global Ops height. The hidden-by-
+ *     toggle case is caught separately by the hidden-state columns below.
  *   - terminal is not hidden in a background tmux window — when hidden, the
  *     Ops pane temporarily fills the right column and would poison the saved
  *     Ops height.
@@ -593,7 +603,7 @@ export function shouldCaptureDrag(stdout: string): boolean {
   if (rows.some((cols) => (cols[2]?.trim() ?? "") !== "")) return false
   if (rows.some((cols) => (cols[3]?.trim() ?? "") !== "")) return false
   const roles = new Set(rows.map((cols) => cols[0]?.trim()))
-  return roles.has("tasks") && roles.has("ops")
+  return roles.has("tasks") && roles.has("ops") && roles.has("shell")
 }
 
 /**

--- a/packages/kobe/test/tui/layout-coord.test.ts
+++ b/packages/kobe/test/tui/layout-coord.test.ts
@@ -118,6 +118,14 @@ describe("shouldCaptureDrag", () => {
     expect(shouldCaptureDrag("tasks\t0\nclaude\t0\n")).toBe(false)
   })
 
+  test("skips when the shell pane has closed via `exit` (Ops now fills the right column)", () => {
+    // tasks + ops + engine present, but the bottom-right shell pane is gone and
+    // NO hidden-state flag is set (a real `exit`, not a toggle). Capturing here
+    // would persist Ops at ~100% height into the global, squashing the terminal
+    // for every task — the regression this guard prevents.
+    expect(shouldCaptureDrag("tasks\t0\nclaude\t0\nops\t0\n")).toBe(false)
+  })
+
   test("skips while the terminal is hidden in a background window", () => {
     expect(shouldCaptureDrag("tasks\t0\t%9\nclaude\t0\t%9\nops\t0\t%9\n")).toBe(false)
   })


### PR DESCRIPTION
## Direction

Bug / correctness — a sibling of #179 ("Exit the terminal layout error"), found by diving into the same layout-reflow family while reviewing #182. This one is **strictly worse than #179**: instead of leaving the focused task locally disordered, it corrupts the **global** layout for *every* task.

## Problem

The bottom-right shell pane of a task is created with no keepAlive wrapper (`chattab.ts` `split-window … shell=#{pane_id}`), so typing `exit` **really kills it** (unlike the engine/tasks/ops panes, which `exec $SHELL` and degrade to a shell). When it dies, the Ops pane grows to fill the right column and tmux fires `window-layout-changed`.

Both layout-capture paths then mistake that transient geometry for the user's intended layout and persist it:

- the live drag gate `captureGlobalLayoutOnDrag` → `shouldCaptureDrag` returned `true` (it only required `tasks` + `ops` to be present, plus no zoom / no hidden-by-toggle flags — none of which catch a *closed* shell);
- the switch-away `captureGlobalLayout` (`task-enter.ts`) had the same blind spot — its hidden-shell guard checks only `HIDDEN_TERMINAL_PANE_OPTION`, which a real `exit` never sets.

With the shell gone, `opsH / winH ≈ 100%`, so capture wrote ~100% to the **global** `@kobe_ops_height`. From then on, every `healWorkspaceLayout` (every task switch / attach) re-applied the squashed Ops height to **all** tasks — the terminal pane stayed squashed everywhere until a manual re-drag.

This is the deeper, spreading version of what #179 reports ("the last-edited task stays wrong"), and it also makes #182's `pane-exited` heal racy: if capture poisons the global before the heal reads it, the heal faithfully re-pins the poison.

## Fix

Capture now bails when the `shell` role is **absent** and the terminal isn't legitimately hidden-by-toggle (that case is still caught earlier by the hidden-state flags). One guard added to `captureGlobalLayout`, one role added to `shouldCaptureDrag`'s required set. A closed terminal can no longer poison the saved geometry, so:

- the global Ops height is never corrupted by an `exit`;
- every later heal re-pins to clean geometry;
- it removes the latent race in #182's approach — capture can't poison regardless of hook ordering.

This is complementary to #182 (which adds the local heal-on-pane-exit). Together they fully resolve #179; this PR alone already stops the cross-task corruption.

## Verification

- `bun run lint` ✓ (repo-root biome) · `bun run typecheck` ✓.
- `bun test test/tui/layout-coord.test.ts` — 14 pass / 0 fail, including a new regression test for the closed-shell listing (`tasks\t0\nclaude\t0\nops\t0\n` → not captured). The pre-existing 56 suite failures are environment-only (real tmux/git integration: archive/delete flows, spawn, tmuxSessionName, forgetProject) and are identical on `main`; none touch the capture path.
- Existing `shouldCaptureDrag` cases (zoom, half-built, hidden terminal, hidden Tasks, empty) still pass — the hidden-by-toggle cases return earlier via the hidden-state columns, so requiring `shell` doesn't regress them.

## Other siblings investigated (deferred, not in this PR)

Diving the same family surfaced two lower-confidence gaps I did **not** fix here (no confirmed user-visible repro, and `aggressive-resize` masks the common case):

- intra-session chat-tab switch (`Ctrl+[` / `Ctrl+]`) uses raw `previous/next-window` with no pre-switch fit+heal;
- no `client-detached` hook to re-pin after the size-driving client of a multi-client session leaves.

Worth tracking separately if either ever reproduces.