### PR TITLE
fix: drop the fake "press R to relaunch" from the engine-exited banner

### DIFF
--- a/.changeset/drop-fake-press-r-banner.md
+++ b/.changeset/drop-fake-press-r-banner.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: the "Engine exited" banner no longer tells you to "press R to relaunch" — a key that was never wired. When an engine pane exits non-zero it drops to a fallback shell and prints the exit code; the banner promised an `R` relaunch shortcut that does not exist (the terminal pane forwards bare keys straight to the shell, so `R` just typed an `R`). The banner now points only at Settings → Engines to fix the launch command, which is the action that actually exists.

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -189,7 +189,7 @@ export function shellQuoteArgv(argv: readonly string[]): string {
  * for a frame and then lands on a bare prompt — indistinguishable from
  * a healthy idle shell, so the user assumes kobe is broken. The banner
  * names the failing exit code and points at where to fix it (Settings →
- * Engines) and how to retry (`R` = relaunch). Exit 0 is unchanged: the
+ * Engines). Exit 0 is unchanged: the
  * pane drops straight to the shell with no banner, as before. `__rc` is
  * captured immediately so the embedded command (which may contain any
  * characters — it's already composed/quoted by callers) can't perturb
@@ -200,8 +200,7 @@ export function keepAlive(cmd: string): string {
   // interpret `\u`, and the wrapper shell may be plain `sh`. Only `\n`
   // (newline) and `%s` (the exit code) are printf-interpreted. No stray
   // `%` in the prose, so the format string is safe.
-  const banner =
-    "\\n  ⚠ Engine exited (code %s). Check Settings → Engines, fix the launch command, then press R to relaunch.\\n\\n"
+  const banner = "\\n  ⚠ Engine exited (code %s). Check Settings → Engines and fix the launch command.\\n\\n"
   return `${cmd}; __rc=$?; [ "$__rc" -ne 0 ] && printf '${banner}' "$__rc"; exec "\${SHELL:-/bin/sh}"`
 }
 


### PR DESCRIPTION
## Direction

Bug / correctness — a dead UI promise uncovered while scoping the engine-exit behavior for the #179 layout family.

## Problem

When an engine pane exits **non-zero** (a crash, or a misconfigured/custom engine launch command), `keepAlive` drops the pane to a fallback shell and prints:

> ⚠ Engine exited (code N). Check Settings → Engines, fix the launch command, then **press R to relaunch.**

But `R` is **not wired to anything**. Searched the keybinding table, the tmux `bind-key` setup, and the TUI — there is no `R` (or any key) bound to an engine relaunch, and there is no engine-exited TUI component that captures keys. The terminal pane forwards every bare alphanumeric key straight to the PTY (see the passthrough note in `keybindings.ts`), so at that fallback prompt **`R` just types an `R`** (then `R: command not found`).

It has been a dead promise since it was introduced in 0.7.15 (`e5cbfbf`). It survived unnoticed because the banner only appears on the **non-zero exit** path — a clean exit prints nothing — so a healthy user never sees it; only someone with a broken engine config hits it, and they fix the config rather than reporting the dud key.

## Fix

Remove the false `R` clause. The banner now names the exit code and points only at **Settings → Engines** — the recovery that actually exists. No behavior change on the exit-0 path (still no banner). The doc comment above `keepAlive` is updated to match.

This is the honest-banner half of the agreed engine-exit cleanup; the follow-up (closing the chat tab when the user exits the engine's fallback shell) lands separately.

## Verification

- `bun run lint` ✓ · `bun run typecheck` ✓.
- `bun test test/tmux` — 106 pass; the 2 failures are pre-existing environment-only integration tests (spawn / tmuxSessionName), identical on `main`. No test asserted the old banner text.