### PR TITLE
fix: terminal-exit layout errors (#179) — heal, no global poison, honest banner, tidy engine-exit

### DIFF
--- a/.changeset/close-or-replace-tab-on-engine-exit.md
+++ b/.changeset/close-or-replace-tab-on-engine-exit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+feat: exiting a task's engine now tidies up its chat tab instead of leaving a dead shell. When the engine process exits and you then `exit` the fallback shell, kobe closes that chat tab — and if it was the task's only tab, it opens a fresh engine tab in its place so the task session never goes empty. The other workspace terminals (Ops / the bottom shell) are unchanged: exiting one of those just heals the layout. Together with the layout-heal and capture-poison fixes this resolves the "Exit the terminal layout error" report (#179).

--- a/.changeset/drop-fake-press-r-banner.md
+++ b/.changeset/drop-fake-press-r-banner.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: the "Engine exited" banner no longer tells you to "press R to relaunch" — a key that was never wired. When an engine pane exits non-zero it drops to a fallback shell and prints the exit code; the banner promised an `R` relaunch shortcut that does not exist (the terminal pane forwards bare keys straight to the shell, so `R` just typed an `R`). The banner now points only at Settings → Engines to fix the launch command, which is the action that actually exists.

--- a/.changeset/guard-engine-pane-startup-sigint.md
+++ b/.changeset/guard-engine-pane-startup-sigint.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: a fast Ctrl+C right after a task's engine pane appears no longer closes the pane mid-init. The engine ran inside a `sh -c` wrapper, so a SIGINT during the per-repo init script or the engine's startup window hit the whole process group and killed the wrapper before it reached the keep-alive fallback shell — tmux then closed the pane (the center pane "vanished"). The engine wrapper now traps SIGINT (`trap ':' INT`) so only the engine child receives Ctrl+C (it resets to the default handler and stays interruptible) while the wrapper survives and always lands on the fallback terminal. A pane now closes only on a deliberate `exit`.

--- a/.changeset/heal-layout-on-pane-exit.md
+++ b/.changeset/heal-layout-on-pane-exit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: a task's workspace layout now re-pins itself after you exit a terminal pane. Closing a workspace-split terminal (typing `exit`) hands its cells to a neighbouring pane, which knocks the fixed-width Tasks rail and the right column off their pinned geometry — the same disorder a terminal resize causes, except `window-resized` never fires because the window size is unchanged. Until now the only recovery was switching to another task and back (which heals on switch-in), so the currently-focused task stayed visually broken until you dragged the panes back yourself. kobe now heals the layout on tmux's `pane-exited` hook, re-pinning the rail and right column to the shared globals the moment a pane closes.

--- a/.changeset/no-poison-ops-height-on-shell-exit.md
+++ b/.changeset/no-poison-ops-height-on-shell-exit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: closing a task's bottom-right terminal with `exit` no longer squashes the terminal pane across every task. The shell pane has no keepAlive, so typing `exit` really kills it and the Ops pane grows to fill the right column. The layout-capture path (both the live `window-layout-changed` drag gate and the switch-away capture) then read that transient ~100% Ops height and wrote it to the GLOBAL Ops-height option, so every later layout heal re-applied the squashed height to all tasks until a manual re-drag. Capture now bails when the `shell` role is absent (without the hidden-by-toggle flag), so a closed terminal can't poison the saved geometry.

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -563,6 +563,21 @@ async function main(): Promise<void> {
     await newChatTab(session, vendor)
     return
   }
+  if (subcommand === "engine-tab-exit") {
+    // Fired from an engine pane's keepAlive `onExit` (see engineTabExitCleanup)
+    // after the user exits the post-engine fallback shell. Closes this chat tab,
+    // or — when it's the task's only tab — replaces it with a fresh engine tab so
+    // the task session never goes empty. Reads the baked-in `--session`.
+    const flags = parseOpsFlags(rest)
+    const session = flags.session
+    if (!session) {
+      console.error("kobe engine-tab-exit: --session <name> is required")
+      process.exit(2)
+    }
+    const { engineTabExit } = await import("../tui/panes/terminal/layout-actions.ts")
+    await engineTabExit(session)
+    return
+  }
   if (subcommand === "kill-sessions") {
     // Dev/reset helper: tear down kobe's entire tmux server (all task
     // sessions on the `-L kobe` socket). Use after changing Tasks-pane /

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -612,11 +612,14 @@ async function main(): Promise<void> {
     return
   }
   if (subcommand === "heal-layout") {
-    // `window-resized` tmux hook handler: re-pin the resized session's Tasks-rail
-    // width + right-column geometry to the shared globals. Fixes the first-attach
-    // reflow (the first session is built before any client is attached, so tmux
-    // reflows its panes when `attach` lands the real terminal size) and any live
-    // terminal resize. No-op for the home/role-less session. Reads `--session`.
+    // `window-resized` + `pane-exited` tmux hook handler: re-pin the session's
+    // Tasks-rail width + right-column geometry to the shared globals. Fixes the
+    // first-attach reflow (the first session is built before any client is
+    // attached, so tmux reflows its panes when `attach` lands the real terminal
+    // size), any live terminal resize, and the pane-close reflow (exiting a
+    // workspace-split terminal hands its cells to a neighbour, knocking the rail /
+    // right column off their pinned geometry). No-op for the home/role-less
+    // session. Reads `--session`.
     //
     // A live resize fires this hook many times in a burst; `coalesceLayoutWork`
     // trailing-debounces so the burst collapses to ONE heal (no concurrent

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -189,7 +189,7 @@ export function shellQuoteArgv(argv: readonly string[]): string {
  * for a frame and then lands on a bare prompt — indistinguishable from
  * a healthy idle shell, so the user assumes kobe is broken. The banner
  * names the failing exit code and points at where to fix it (Settings →
- * Engines) and how to retry (`R` = relaunch). Exit 0 is unchanged: the
+ * Engines). Exit 0 is unchanged: the
  * pane drops straight to the shell with no banner, as before. `__rc` is
  * captured immediately so the embedded command (which may contain any
  * characters — it's already composed/quoted by callers) can't perturb
@@ -200,8 +200,7 @@ export function keepAlive(cmd: string): string {
   // interpret `\u`, and the wrapper shell may be plain `sh`. Only `\n`
   // (newline) and `%s` (the exit code) are printf-interpreted. No stray
   // `%` in the prose, so the format string is safe.
-  const banner =
-    "\\n  ⚠ Engine exited (code %s). Check Settings → Engines, fix the launch command, then press R to relaunch.\\n\\n"
+  const banner = "\\n  ⚠ Engine exited (code %s). Check Settings → Engines and fix the launch command.\\n\\n"
   return `${cmd}; __rc=$?; [ "$__rc" -ne 0 ] && printf '${banner}' "$__rc"; exec "\${SHELL:-/bin/sh}"`
 }
 

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -201,14 +201,24 @@ export function shellQuoteArgv(argv: readonly string[]): string {
  * with `"$SHELL"; <onExit>` so the wrapper survives the shell and can act on
  * its exit (e.g. close/replace this chat tab). Without `onExit` the behavior
  * is identical to before (`exec`), so Ops/Tasks/home panes are unaffected.
+ *
+ * Engine panes also get {@link SIGINT_GUARD}: a fast Ctrl+C while the engine is
+ * still starting (or while the per-repo init script runs) would otherwise SIGINT
+ * the whole `sh -c` process group and kill the wrapper BEFORE it reaches the
+ * fallback shell — closing the pane mid-init. The guard makes the wrapper ignore
+ * SIGINT (the engine child resets to the default, so Ctrl+C still interrupts it).
  */
+export const SIGINT_GUARD = "trap ':' INT; "
+
 export function keepAlive(cmd: string, onExit?: string): string {
   // Literal UTF-8 glyphs (⚠ →), not `\uXXXX`: POSIX `printf` doesn't
   // interpret `\u`, and the wrapper shell may be plain `sh`. Only `\n`
   // (newline) and `%s` (the exit code) are printf-interpreted. No stray
   // `%` in the prose, so the format string is safe.
   const banner = "\\n  ⚠ Engine exited (code %s). Check Settings → Engines and fix the launch command.\\n\\n"
-  const head = `${cmd}; __rc=$?; [ "$__rc" -ne 0 ] && printf '${banner}' "$__rc"; `
+  // Engine panes (onExit set) guard the wrapper against a startup Ctrl+C.
+  const guard = onExit ? SIGINT_GUARD : ""
+  const head = `${guard}${cmd}; __rc=$?; [ "$__rc" -ne 0 ] && printf '${banner}' "$__rc"; `
   // No `onExit`: exec the shell so it BECOMES the pane (original behavior).
   // With `onExit`: run the shell as a child, then run the cleanup when it exits.
   return onExit ? `${head}"\${SHELL:-/bin/sh}"; ${onExit}` : `${head}exec "\${SHELL:-/bin/sh}"`
@@ -360,18 +370,25 @@ export function engineLaunchLine(engineCmd: string, init?: EngineInitLaunch, onE
   if (!script) return tail
   const timeoutSeconds = resolveRepoInitTimeoutSeconds(init?.timeoutSeconds)
   const group = boundedInitGroup(script, timeoutSeconds)
+  // SIGINT_GUARD up front so a Ctrl+C DURING the init script can't kill the
+  // wrapper before it reaches the engine + fallback shell (keepAlive's own guard
+  // only covers from the engine command onward). Redundant with the tail's guard
+  // for the no-init path — harmless, `trap` is idempotent.
   if (init?.markerPath) {
     const marker = shQuote(init.markerPath)
     const markerDir = shQuote(markerDirOf(init.markerPath))
-    return [
-      `if [ ! -f ${marker} ]; then`,
-      group,
-      `if [ "$__kobe_init_rc" -eq 0 ]; then mkdir -p ${markerDir} && : > ${marker}; fi`,
-      "fi",
-      tail,
-    ].join("\n")
+    return (
+      SIGINT_GUARD +
+      [
+        `if [ ! -f ${marker} ]; then`,
+        group,
+        `if [ "$__kobe_init_rc" -eq 0 ]; then mkdir -p ${markerDir} && : > ${marker}; fi`,
+        "fi",
+        tail,
+      ].join("\n")
+    )
   }
-  return [group, tail].join("\n")
+  return SIGINT_GUARD + [group, tail].join("\n")
 }
 
 /** Parent dir of a marker path, without importing node:path into this pure module's hot path. */

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -194,14 +194,37 @@ export function shellQuoteArgv(argv: readonly string[]): string {
  * captured immediately so the embedded command (which may contain any
  * characters — it's already composed/quoted by callers) can't perturb
  * it.
+ *
+ * `onExit` (engine panes only): a command to run AFTER the fallback shell
+ * itself exits — i.e. the user typed `exit` in the post-engine shell, fully
+ * tearing this tab's engine down. We replace the terminal `exec "$SHELL"`
+ * with `"$SHELL"; <onExit>` so the wrapper survives the shell and can act on
+ * its exit (e.g. close/replace this chat tab). Without `onExit` the behavior
+ * is identical to before (`exec`), so Ops/Tasks/home panes are unaffected.
  */
-export function keepAlive(cmd: string): string {
+export function keepAlive(cmd: string, onExit?: string): string {
   // Literal UTF-8 glyphs (⚠ →), not `\uXXXX`: POSIX `printf` doesn't
   // interpret `\u`, and the wrapper shell may be plain `sh`. Only `\n`
   // (newline) and `%s` (the exit code) are printf-interpreted. No stray
   // `%` in the prose, so the format string is safe.
   const banner = "\\n  ⚠ Engine exited (code %s). Check Settings → Engines and fix the launch command.\\n\\n"
-  return `${cmd}; __rc=$?; [ "$__rc" -ne 0 ] && printf '${banner}' "$__rc"; exec "\${SHELL:-/bin/sh}"`
+  const head = `${cmd}; __rc=$?; [ "$__rc" -ne 0 ] && printf '${banner}' "$__rc"; `
+  // No `onExit`: exec the shell so it BECOMES the pane (original behavior).
+  // With `onExit`: run the shell as a child, then run the cleanup when it exits.
+  return onExit ? `${head}"\${SHELL:-/bin/sh}"; ${onExit}` : `${head}exec "\${SHELL:-/bin/sh}"`
+}
+
+/**
+ * Build the engine pane's {@link keepAlive} `onExit` cleanup command: after the
+ * user exits the post-engine fallback shell (fully tearing this tab's engine
+ * down), run `kobe engine-tab-exit --session <name>`, which closes this chat
+ * tab — or, when it is the task's only tab, replaces it with a fresh engine tab
+ * so the task session never goes empty. `envPrefix` carries the inherited
+ * KOBE_* env (same reason the pane commands do); `inv` is the resolved kobe CLI
+ * argv. The session name is baked in (quoted) since it is known at build time.
+ */
+export function engineTabExitCleanup(envPrefix: string, inv: readonly string[], session: string): string {
+  return `${envPrefix}${inv.map(shellQuote).join(" ")} engine-tab-exit --session ${shellQuote(session)}`
 }
 
 /** Single-quote a string for safe interpolation into a `sh -c` program. */
@@ -331,8 +354,8 @@ function boundedInitGroup(script: string, timeoutSeconds: number): string {
  * launch instead of being marked done. A failed/timed-out init never blocks
  * the engine — the task always becomes enterable.
  */
-export function engineLaunchLine(engineCmd: string, init?: EngineInitLaunch): string {
-  const tail = keepAlive(engineCmd)
+export function engineLaunchLine(engineCmd: string, init?: EngineInitLaunch, onExit?: string): string {
+  const tail = keepAlive(engineCmd, onExit)
   const script = init?.initScript?.trim()
   if (!script) return tail
   const timeoutSeconds = resolveRepoInitTimeoutSeconds(init?.timeoutSeconds)

--- a/packages/kobe/src/tui/panes/terminal/chattab.ts
+++ b/packages/kobe/src/tui/panes/terminal/chattab.ts
@@ -46,6 +46,7 @@ import {
   OPS_PANE_ROLE,
   SHELL_PANE_ROLE,
   TASKS_PANE_ROLE,
+  engineTabExitCleanup,
   keepAlive,
   opsPaneCommand,
   shellQuote,
@@ -295,7 +296,12 @@ export async function newChatTab(session: string, vendorOverride?: VendorId): Pr
     "#{pane_id}",
     // Re-wrap the engine over SSH for a remote task's chat tab (same engine the
     // task launched with), reusing the project's ControlMaster connection.
-    keepAlive(wrapEngineLaunch(shellQuoteArgv(launch.argv), remoteKey, cwd)),
+    // Exiting the post-engine fallback shell closes this tab (or replaces it
+    // with a fresh engine tab when it's the task's only one).
+    keepAlive(
+      wrapEngineLaunch(shellQuoteArgv(launch.argv), remoteKey, cwd),
+      engineTabExitCleanup(inheritedEnvPrefix(), inv, session),
+    ),
   ])
   const claudePane = r.stdout.trim()
   if (!claudePane) return

--- a/packages/kobe/src/tui/panes/terminal/layout-actions.ts
+++ b/packages/kobe/src/tui/panes/terminal/layout-actions.ts
@@ -848,6 +848,39 @@ async function closeChatTab(session: string, windowId: string): Promise<void> {
   await runTmux(["kill-window", "-t", windowId])
 }
 
+/**
+ * Tear down a chat tab whose engine the user fully exited (engine process
+ * exited → fallback shell → user typed `exit`). Invoked by `kobe engine-tab-exit`
+ * from that pane's own keepAlive `onExit` (see {@link engineTabExitCleanup}).
+ *
+ * Multi-tab: close this window; tmux moves the client to a sibling tab.
+ * Only tab: do NOT kill the task's last window (that would end the whole task
+ * session and orphan the client) — instead open a FRESH engine tab and then
+ * close the gutted one, so the task always has a live engine. The old window id
+ * is captured BEFORE `newChatTab` runs, because creating the new window makes it
+ * the active one; we only kill the old window once a new active window exists.
+ */
+export async function engineTabExit(session: string): Promise<void> {
+  if (!(await sessionExists(session))) return
+  const oldWindowId = await activeWindowId(session)
+  if (!oldWindowId) return
+  if ((await activeSessionWindowCount(session)) > 1) {
+    await cleanupHiddenPanesForWindow(session, oldWindowId)
+    await runTmux(["kill-window", "-t", oldWindowId])
+    return
+  }
+  // Only tab → replace it. Dynamic import: chattab statically imports this
+  // module ({@link applyZenToNewWindow}), so a static import here would cycle.
+  const { newChatTab } = await import("./chattab")
+  await newChatTab(session)
+  // Kill the gutted window only if a fresh active window actually took over —
+  // otherwise newChatTab failed and we must not kill the task's last window.
+  if ((await activeWindowId(session)) !== oldWindowId) {
+    await cleanupHiddenPanesForWindow(session, oldWindowId)
+    await runTmux(["kill-window", "-t", oldWindowId])
+  }
+}
+
 export async function runLayoutAction(
   session: string,
   action: LayoutAction,

--- a/packages/kobe/src/tui/panes/terminal/pane-heal.ts
+++ b/packages/kobe/src/tui/panes/terminal/pane-heal.ts
@@ -48,6 +48,7 @@ import {
   TASKS_WIDTH_OPTION,
   clampPanePercent,
   clampTasksPaneWidth,
+  engineTabExitCleanup,
   keepAlive,
   opsPaneCommand,
   shellQuoteArgv,
@@ -347,12 +348,13 @@ export async function relaunchEngineInAllWindows(
   const enginePanes = rows.filter((r) => r.role === "claude")
   if (enginePanes.length === 0) return "no-engine-pane"
   const localCwd = localSpawnCwd(cwd)
+  const cleanup = engineTabExitCleanup(inheritedEnvPrefix(), kobeCliInvocation(), session)
   const commands: (readonly string[])[] = []
   for (const pane of enginePanes) {
     // Fresh identity per window — a distinct `--session-id` UUID for claude so
     // each tab maps to its own transcript; `null` for codex/copilot.
     const launch = withClaudeSessionId(command, vendor)
-    const cmd = keepAlive(wrapEngineLaunch(shellQuoteArgv(launch.argv), remoteKey, cwd))
+    const cmd = keepAlive(wrapEngineLaunch(shellQuoteArgv(launch.argv), remoteKey, cwd), cleanup)
     // `-k` kills the old engine process; `-c` is the LOCAL spawn dir (the
     // worktree is remote for a remote task — the wrapped ssh carries `cd <wt>`).
     commands.push(["respawn-pane", "-k", "-c", localCwd, "-t", pane.paneId, cmd])

--- a/packages/kobe/src/tui/panes/terminal/pane-heal.ts
+++ b/packages/kobe/src/tui/panes/terminal/pane-heal.ts
@@ -535,6 +535,12 @@ export async function captureGlobalLayout(session: string): Promise<void> {
   if (rows.some((cols) => cols[5]?.trim() === "1")) return // zoomed → geometry is unreliable
   if (rows.some((cols) => (cols[6]?.trim() ?? "") !== "")) return // hidden shell → Ops is temporarily full-height
   if (rows.some((cols) => (cols[7]?.trim() ?? "") !== "")) return // hidden Tasks → remaining panes are temporarily full-width
+  // Shell pane CLOSED (user typed `exit` in the bottom-right terminal — it has no
+  // keepAlive, so it really dies) rather than hidden-by-toggle (caught above via
+  // HIDDEN_TERMINAL_PANE_OPTION). With the shell gone, Ops has grown to fill the
+  // right column, so its height reads back as ~100% — capturing that would poison
+  // the global Ops height for EVERY task until the next manual drag. Bail.
+  if (!rows.some((cols) => cols[0]?.trim() === "shell")) return
   const winW = Number.parseInt(rows[0][3]?.trim() ?? "", 10)
   const winH = Number.parseInt(rows[0][4]?.trim() ?? "", 10)
   const sets: (readonly string[])[] = []
@@ -568,9 +574,13 @@ export async function captureGlobalLayout(session: string): Promise<void> {
  *   - NOT zoomed — a zoomed pane reports the full-window grid, so the rail /
  *     right-column widths read back as garbage; capturing them would poison
  *     the global until the next real drag.
- *   - the full kobe role set is present (`tasks` + `ops`) — excludes the
- *     transient half-built layouts that pane splits emit during a session
- *     build / respawn, where the geometry isn't the user's to keep.
+ *   - the full kobe role set is present (`tasks` + `ops` + `shell`) — excludes
+ *     the transient half-built layouts that pane splits emit during a session
+ *     build / respawn, where the geometry isn't the user's to keep, AND the case
+ *     where the user closed the bottom-right shell pane via `exit` (it has no
+ *     keepAlive, so it dies): Ops then fills the right column and its height
+ *     would read back as ~100%, poisoning the global Ops height. The hidden-by-
+ *     toggle case is caught separately by the hidden-state columns below.
  *   - terminal is not hidden in a background tmux window — when hidden, the
  *     Ops pane temporarily fills the right column and would poison the saved
  *     Ops height.
@@ -593,7 +603,7 @@ export function shouldCaptureDrag(stdout: string): boolean {
   if (rows.some((cols) => (cols[2]?.trim() ?? "") !== "")) return false
   if (rows.some((cols) => (cols[3]?.trim() ?? "") !== "")) return false
   const roles = new Set(rows.map((cols) => cols[0]?.trim()))
-  return roles.has("tasks") && roles.has("ops")
+  return roles.has("tasks") && roles.has("ops") && roles.has("shell")
 }
 
 /**

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -81,6 +81,7 @@ import { type ObservedSession, decideSessionAction } from "@/tmux/session-decisi
 import {
   HIDDEN_TASKS_PANE_OPTION,
   engineLaunchLine,
+  engineTabExitCleanup,
   openUrlCommand,
   resolveRepoInitTimeoutSeconds,
   shellQuote,
@@ -690,13 +691,19 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     "#{pane_id}",
     // Weave the per-repo init script before the engine (once-per-worktree
     // via a marker under <home>/.kobe/). Plain keepAlive when there's none.
-    engineLaunchLine(engineCmd, {
-      initScript: remoteKey ? undefined : launchInit?.initScript,
-      markerPath: !remoteKey && launchInit?.initScript ? worktreeInitMarkerPath(opts.cwd) : undefined,
-      // Operator escape hatch for an unusually slow (or fast-fail) init —
-      // clamped + defaulted by the resolver; unset keeps the 120s default.
-      timeoutSeconds: resolveRepoInitTimeoutSeconds(process.env.KOBE_REPO_INIT_TIMEOUT_SECONDS),
-    }),
+    engineLaunchLine(
+      engineCmd,
+      {
+        initScript: remoteKey ? undefined : launchInit?.initScript,
+        markerPath: !remoteKey && launchInit?.initScript ? worktreeInitMarkerPath(opts.cwd) : undefined,
+        // Operator escape hatch for an unusually slow (or fast-fail) init —
+        // clamped + defaulted by the resolver; unset keeps the 120s default.
+        timeoutSeconds: resolveRepoInitTimeoutSeconds(process.env.KOBE_REPO_INIT_TIMEOUT_SECONDS),
+      },
+      // Exiting the post-engine fallback shell tears this tab down → close it
+      // (or replace it with a fresh engine tab when it's the task's only tab).
+      engineTabExitCleanup(inheritedEnvPrefix(), inv, opts.name),
+    ),
   ])
   const pane0 = r0.stdout.trim()
   if (!pane0) {

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -832,6 +832,8 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
   // which reflows the rail the same way. `-b` runs it in the background so tmux
   // isn't blocked; `resize-pane` never changes the window size, so the heal
   // can't re-trigger the hook. `heal-layout` is a no-op for role-less sessions.
+  // Reused below for the `pane-exited` hook — a pane close reflows the rail the
+  // same way a resize does, and the same re-pin recovers it.
   const healLayoutCommand = `${envStr}${invStr} heal-layout --session '#{session_name}'`
   const healLayoutTmuxCommand = `run-shell -b ${shellQuote(healLayoutCommand)}`
   // `client-resized` companion to the `window-resized` heal. The pre-attach /
@@ -979,6 +981,17 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     ...clipboardBindings,
     ["set-hook", "-g", "window-resized", healLayoutTmuxCommand],
     ["set-hook", "-g", "client-resized", resyncWindowTmuxCommand],
+    // Re-pin the layout when a pane CLOSES too. Exiting a kobe-owned shell pane
+    // (the user types `exit` in a workspace-split terminal) destroys it and tmux
+    // gives its cells to a neighbour, reflowing the absolute-width Tasks rail and
+    // the right column off their pinned geometry — the same disorder a resize
+    // causes, but `window-resized` never fires (the window size is unchanged), so
+    // the only existing recovery was switching tasks (which heals on switch-in).
+    // The currently-focused task therefore stayed broken until a manual re-drag.
+    // `pane-exited` (tmux ≥ 2.2) fires on that close; `heal-layout` re-pins to the
+    // shared globals — the SAME idempotent, coalesced heal a switch runs. No-op
+    // for role-less sessions and for panes already at the target geometry.
+    ["set-hook", "-g", "pane-exited", healLayoutTmuxCommand],
     ["set-hook", "-g", "window-layout-changed", captureLayoutTmuxCommand],
     ...unbinds,
     // Two-stage: on the Tasks pane → detach (the old exit); anywhere else →

--- a/packages/kobe/test/tmux/session-layout.test.ts
+++ b/packages/kobe/test/tmux/session-layout.test.ts
@@ -23,6 +23,7 @@ import {
   clampPanePercent,
   clampTasksPaneWidth,
   engineLaunchLine,
+  engineTabExitCleanup,
   fallbackOpsScript,
   keepAlive,
   openUrlCommand,
@@ -107,6 +108,29 @@ describe("keepAlive", () => {
     const out = keepAlive("claude")
     expect(out).toContain('__rc=$?; [ "$__rc" -ne 0 ]')
     expect(out).toContain("Engine exited (code %s)")
+  })
+
+  test("the banner no longer promises a key that isn't wired", () => {
+    expect(keepAlive("claude")).not.toContain("press R")
+  })
+
+  test("with onExit: runs the shell as a child (no exec) then the cleanup", () => {
+    const out = keepAlive("claude", "kobe engine-tab-exit --session 'kobe-x'")
+    // No `exec` — the wrapper must survive the shell to run the cleanup after it.
+    expect(out).not.toContain("exec ")
+    expect(out).toContain("\"${SHELL:-/bin/sh}\"; kobe engine-tab-exit --session 'kobe-x'")
+  })
+})
+
+describe("engineTabExitCleanup", () => {
+  test("quotes the kobe invocation and session (a session name with a space is safe)", () => {
+    expect(engineTabExitCleanup("", ["kobe"], "kobe-my task")).toBe("'kobe' engine-tab-exit --session 'kobe-my task'")
+  })
+
+  test("carries the env prefix so cleanup hits the same home/daemon", () => {
+    expect(engineTabExitCleanup("KOBE_HOME_DIR='/h' ", ["kobe"], "kobe-x")).toBe(
+      "KOBE_HOME_DIR='/h' 'kobe' engine-tab-exit --session 'kobe-x'",
+    )
   })
 })
 

--- a/packages/kobe/test/tmux/session-layout.test.ts
+++ b/packages/kobe/test/tmux/session-layout.test.ts
@@ -120,6 +120,14 @@ describe("keepAlive", () => {
     expect(out).not.toContain("exec ")
     expect(out).toContain("\"${SHELL:-/bin/sh}\"; kobe engine-tab-exit --session 'kobe-x'")
   })
+
+  test("engine panes (onExit) guard the wrapper against a startup Ctrl+C", () => {
+    // SIGINT must reach the engine child but NOT kill the wrapper, so a fast
+    // Ctrl+C during startup/init can't close the pane before the fallback shell.
+    expect(keepAlive("claude", "kobe engine-tab-exit --session 'kobe-x'").startsWith("trap ':' INT; ")).toBe(true)
+    // Non-engine panes keep their exact prior shape — no guard.
+    expect(keepAlive("claude")).not.toContain("trap ':' INT")
+  })
 })
 
 describe("engineTabExitCleanup", () => {
@@ -265,6 +273,12 @@ describe("engineLaunchLine", () => {
   test("no init script → plain keepAlive", () => {
     expect(engineLaunchLine(engine)).toBe(keepAlive(engine))
     expect(engineLaunchLine(engine, { initScript: "   " })).toBe(keepAlive(engine))
+  })
+
+  test("with an init script, the wrapper guards SIGINT from the very front", () => {
+    // A Ctrl+C during the per-repo init must not kill the wrapper before it
+    // reaches the engine + fallback shell — so the guard precedes the init block.
+    expect(engineLaunchLine(engine, { initScript: "export FOO=1" }).startsWith("trap ':' INT; ")).toBe(true)
   })
 
   test("init without a marker is watchdog-bounded and runs every launch", () => {

--- a/packages/kobe/test/tui/layout-coord.test.ts
+++ b/packages/kobe/test/tui/layout-coord.test.ts
@@ -118,6 +118,14 @@ describe("shouldCaptureDrag", () => {
     expect(shouldCaptureDrag("tasks\t0\nclaude\t0\n")).toBe(false)
   })
 
+  test("skips when the shell pane has closed via `exit` (Ops now fills the right column)", () => {
+    // tasks + ops + engine present, but the bottom-right shell pane is gone and
+    // NO hidden-state flag is set (a real `exit`, not a toggle). Capturing here
+    // would persist Ops at ~100% height into the global, squashing the terminal
+    // for every task — the regression this guard prevents.
+    expect(shouldCaptureDrag("tasks\t0\nclaude\t0\nops\t0\n")).toBe(false)
+  })
+
   test("skips while the terminal is hidden in a background window", () => {
     expect(shouldCaptureDrag("tasks\t0\t%9\nclaude\t0\t%9\nops\t0\t%9\n")).toBe(false)
   })


### PR DESCRIPTION
Closes #179. One branch with the complete fix family so it can be checked out and tested locally end-to-end. **Supersedes #182, #184, #185** (their commits are included here).

## The report (#179)

Exiting both right-column terminals of a task left the layout disordered; switching to another task reset it, but the last-edited task stayed broken until dragged back by hand. Diving into the family turned up four distinct issues, fixed here as four commits.

## 1 — Heal the layout when a pane exits (was #182)

Closing a pane hands its cells to a neighbour, knocking the fixed-width Tasks rail and right column off their pinned geometry — the same disorder a resize causes, except `window-resized` never fires (the window size is unchanged). Wire tmux's `pane-exited` hook to the existing idempotent `heal-layout` re-pin (the same one a task switch runs).

## 2 — Don't poison the GLOBAL Ops height on a shell exit (was #184)

The bottom-right shell pane has no keepAlive, so `exit` really kills it and Ops grows to fill the right column. Both capture paths (the live `window-layout-changed` drag gate and the switch-away capture) read that transient ~100% Ops height and wrote it to the **global** Ops-height option, so every later heal re-applied the squashed height to **all** tasks. Capture now bails when the `shell` role is absent (without the hidden-by-toggle flag), so a closed terminal can't poison saved geometry. This is strictly worse than the reported bug (global, not just the focused task) and also removes a latent race in fix #1.

## 3 — Drop the fake "press R to relaunch" banner (was #185)

The engine-exited banner promised an `R` relaunch key that was never wired anywhere — the terminal pane forwards bare keys straight to the PTY, so `R` just typed an `R`. Dead since 0.7.15; only ever shown on the cold non-zero-exit path, which is why it went unreported. The banner now points only at Settings → Engines.

## 4 — Tidy a task's chat tab when its engine is fully exited (new)

Per-pane teardown semantics:
- **Auxiliary terminal** (Ops / bottom shell) exits → just heal (fixes 1–2).
- **Engine** exits (engine process exits → user `exit`s the fallback shell) → tidy the tab instead of leaving a dead shell:
  - **multi-tab**: close this tab; tmux moves the client to a sibling.
  - **only tab**: open a **fresh** engine tab, then close the gutted one — the task session is never killed out from under the client and never goes empty.

Engine panes get a `keepAlive` `onExit` cleanup (`kobe engine-tab-exit --session <name>`) that runs after the fallback shell exits; Ops/Tasks/home panes keep the original `exec $SHELL`. The handler captures the old window id **before** creating the replacement (so it can't kill the new tab) and only kills the old window once a fresh active window exists (so a failed `newChatTab` can't end the task's last window).

## Verification

- `bun run lint` ✓ · `bun run typecheck` ✓.
- New/updated unit tests: `engineTabExitCleanup` quoting + env prefix; `keepAlive` `onExit` (no `exec`, runs cleanup) and the dropped `press R`; the `shouldCaptureDrag` closed-shell guard. `bun test test/tmux/session-layout.test.ts test/tui/layout-coord.test.ts` — all green.
- Full suite: the 56 failures are pre-existing environment-only integration tests (real tmux/git/daemon: archive/delete flows, spawn, tmuxSessionName, daemon client, repo ops), identical on `main`; none touch the changed code.
- **Local testing wanted**: the runtime tmux behavior (pane-exited heal; engine-exit close/replace; the dying-pane self-kill ordering) can't be exercised in CI — please dogfood in a real TUI: new task → exit the bottom shell (layout should re-pin), exit Ops, then quit the engine and `exit` the fallback shell (multi-tab closes to a sibling; single-tab replaces with a fresh engine tab).

— note: drop the now-superseded #182/#184/#185 once this lands.