### PR TITLE
chore: point brand-studio submodule at CodeFox-Repo producers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule ".agents/skills/marketing-harness"]
 	path = .agents/skills/brand-studio
-	url = https://github.com/sma1lboy/brand-studio
+	url = https://github.com/CodeFox-Repo/brand-studio-codefox.git
 	ignore = dirty


### PR DESCRIPTION
## Summary
- Repoint `.agents/skills/brand-studio` from `sma1lboy/brand-studio` to **`CodeFox-Repo/brand-studio-internal`** and bump to `10b9ebc`.
- That repo bundles the org producer payloads under `producers/` — **logo, social, video, banner** — so the brand-studio skill ships with ready producers.
- The repo is public, so the recursive submodule checkout in `claude.yml` / `claude-code-review.yml` needs no token.

## Test plan
- [x] Submodule clones over HTTPS without auth (`git ls-remote` OK)
- [x] Producers present in submodule (`producers/{logo,social,video,banner}`)
- [ ] Reviewer: confirm typecheck-and-test + bot workflows are green