### PR TITLE
feat: configurable worktree base directory

### DIFF
--- a/.changeset/worktree-base-path-setting.md
+++ b/.changeset/worktree-base-path-setting.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+feat: add a configurable worktree base directory (Settings → General → Worktree directory). New task worktrees are created under `~/.kobe/worktrees` by default; set an absolute path (`~` expansion supported) to keep them elsewhere — e.g. a faster disk or outside a backed-up home. The setting is stored in `state.json` and read by the daemon when it creates a worktree, so a change applies to the next task without a relaunch. Existing worktrees stay where they are, and the built-in default root remains recognized so older tasks stay discoverable after a base-path change. A non-absolute value is reflected in the row label and falls back to the default rather than blocking task creation.

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -27,6 +27,7 @@ import path from "node:path"
 import { kobeStateDir } from "../../env.ts"
 import { execHostForRepo } from "../../exec/resolve.ts"
 import { getRemoteRepoConfig, isRemoteRepoKey } from "../../state/repos.ts"
+import { getConfiguredWorktreeBase } from "../../state/worktree-prefs.ts"
 
 /**
  * Directory under kobe's state dir where kobe stores all of its worktrees.
@@ -49,28 +50,54 @@ export const REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
 ] as const
 
 /**
+ * The directory that holds every per-repo worktree root. Defaults to
+ * `<kobeStateDir>/worktrees`, but the user can point it elsewhere via the
+ * `worktree.basePath` setting (Settings → General → Worktree directory).
+ * The override is read FRESH from state.json on each call so a change made
+ * in the TUI takes effect for the next task the daemon creates without a
+ * restart. Unset/invalid falls back to the default.
+ */
+export function worktreesBaseDir(): string {
+  return getConfiguredWorktreeBase() ?? defaultWorktreesBaseDir()
+}
+
+/** The built-in worktrees root, ignoring any user override. */
+export function defaultWorktreesBaseDir(): string {
+  return path.join(kobeStateDir(), KOBE_WORKTREE_ROOT_DIR)
+}
+
+/**
  * Absolute path of the worktree root for a given repo.
  *
  * Example: `worktreeRootFor("/Users/x/proj")` →
- * `/Users/x/.kobe/worktrees/proj-a1b2c3d4e5f6`.
+ * `/Users/x/.kobe/worktrees/proj-a1b2c3d4e5f6` (or under the configured
+ * base when {@link worktreesBaseDir} is overridden).
  */
 export function worktreeRootFor(repo: string): string {
   if (!path.isAbsolute(repo)) {
     throw new Error(`worktreeRootFor: repo must be an absolute path, got: ${repo}`)
   }
-  return path.join(kobeStateDir(), KOBE_WORKTREE_ROOT_DIR, repoWorktreeDirName(repo))
+  return path.join(worktreesBaseDir(), repoWorktreeDirName(repo))
 }
 
 /**
  * Absolute paths of every worktree root kobe recognizes for `repo`.
  * Primary root is first; legacy roots follow for existing task records.
+ *
+ * When the base path is overridden, the built-in `<kobeStateDir>/worktrees`
+ * root is kept as a recognized (legacy) root so worktrees created before the
+ * override — and any the user points back at — stay discoverable, exactly
+ * like the repo-local compatibility roots below.
  */
 export function managedWorktreeRootsFor(repo: string): readonly string[] {
   if (!path.isAbsolute(repo)) {
     throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
   }
+  const primary = worktreeRootFor(repo)
+  const builtinDefault = path.join(defaultWorktreesBaseDir(), repoWorktreeDirName(repo))
   return [
-    worktreeRootFor(repo),
+    primary,
+    ...(primary === builtinDefault ? [] : [builtinDefault]),
     ...REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath)),
   ]
 }

--- a/packages/kobe/src/state/worktree-prefs.ts
+++ b/packages/kobe/src/state/worktree-prefs.ts
@@ -1,0 +1,78 @@
+/**
+ * Worktree base-path preference — the user-configurable directory that
+ * replaces the default `<kobeStateDir>/worktrees` root for newly created
+ * kobe worktrees.
+ *
+ * Two-process split (mirrors the editor-command setting):
+ *   - the TUI WRITES it via the reactive `kv` store (a debounced patch
+ *     into `~/.config/kobe/state.json`), and
+ *   - the daemon/orchestrator READS it cross-process via {@link loadStateFile}
+ *     when computing a new worktree's path in `orchestrator/worktree/paths.ts`.
+ *
+ * Both sides agree only on the key string {@link WORKTREE_BASE_PATH_KEY} and
+ * the normalization in {@link normalizeWorktreeBasePath}, so the value is
+ * stored exactly as the user typed it (`~`-relative paths display nicely)
+ * and resolved to an absolute path only at read time. An empty/blank/
+ * invalid value means "use the built-in default" — never a hard error, so
+ * a fat-fingered relative path can't wedge task creation.
+ */
+
+import path from "node:path"
+import { homeDir } from "../env.ts"
+import { loadStateFile } from "./store.ts"
+
+/** state.json key the TUI writes and the daemon reads. */
+export const WORKTREE_BASE_PATH_KEY = "worktree.basePath"
+
+/**
+ * Expand a leading `~` / `~/...` to the user's home directory. We honor
+ * kobe's {@link homeDir} (which respects `KOBE_HOME_DIR`) so an isolated
+ * dev/test home expands consistently with every other kobe path. A bare
+ * `~user` form is left untouched — we only special-case the current user.
+ */
+function expandHome(input: string): string {
+  if (input === "~") return homeDir()
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return path.join(homeDir(), input.slice(2))
+  }
+  return input
+}
+
+/**
+ * Resolve a raw stored value to an absolute base directory, or `undefined`
+ * when it should fall back to the default. A value is usable only when it
+ * is non-blank and resolves to an absolute path (after `~` expansion);
+ * anything else (blank, relative, garbage) returns `undefined` so callers
+ * keep the built-in default rather than rooting worktrees somewhere wrong.
+ */
+export function normalizeWorktreeBasePath(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined
+  const trimmed = raw.trim()
+  if (trimmed === "") return undefined
+  const expanded = expandHome(trimmed)
+  if (!path.isAbsolute(expanded)) return undefined
+  const normalized = path.normalize(expanded)
+  // Drop a trailing separator so the stored root joins cleanly and displays
+  // consistently — but never strip a bare root ("/" or "C:\").
+  if (normalized.length > 1 && (normalized.endsWith("/") || normalized.endsWith("\\"))) {
+    const stripped = normalized.replace(/[/\\]+$/, "")
+    return stripped === "" ? normalized : stripped
+  }
+  return normalized
+}
+
+/** True iff `raw` is a usable worktree base path (blank counts as "valid": means default). */
+export function isValidWorktreeBasePath(raw: string): boolean {
+  return raw.trim() === "" || normalizeWorktreeBasePath(raw) !== undefined
+}
+
+/**
+ * The configured worktree base directory, resolved to an absolute path, or
+ * `undefined` when unset/invalid. Reads `~/.config/kobe/state.json` FRESH on
+ * every call (no cache) so a change the TUI just wrote is picked up by the
+ * daemon on the next worktree creation — matching the snapshot-only,
+ * no-file-watching contract the rest of kobe's state layer uses.
+ */
+export function getConfiguredWorktreeBase(): string | undefined {
+  return normalizeWorktreeBasePath(loadStateFile()[WORKTREE_BASE_PATH_KEY])
+}

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -27,6 +27,7 @@ import { submitFeedback } from "../../lib/feedback"
 import { AUTO_STATUS_KEY } from "../../state/auto-status"
 import { DISPATCHER_KEY } from "../../state/dispatcher"
 import { getPersistedString, setPersistedString } from "../../state/repos"
+import { WORKTREE_BASE_PATH_KEY, isValidWorktreeBasePath } from "../../state/worktree-prefs"
 import { ZEN_KEEP_TASKS_KEY } from "../../state/zen"
 import type { VendorId } from "../../types/task"
 import { ALL_VENDORS, isBuiltinVendor, resolvePersistedVendor } from "../../types/vendor"
@@ -425,6 +426,32 @@ export function SettingsDialog(props: SettingsDialogProps) {
     if (cmd) props.kv.set(EDITOR_KIND_KEY, "custom")
   }
 
+  // `worktree.basePath` is the directory new task worktrees are created
+  // under (default `~/.kobe/worktrees`). Stored raw (so a `~`-relative path
+  // displays as typed); the daemon expands + validates it at creation time
+  // and falls back to the default when blank/invalid. Read cross-process by
+  // orchestrator/worktree/paths.ts.
+  function worktreeBasePath(): string {
+    const v = props.kv.get(WORKTREE_BASE_PATH_KEY, "")
+    return typeof v === "string" ? v : ""
+  }
+  function worktreeBaseIsValid(): boolean {
+    return isValidWorktreeBasePath(worktreeBasePath())
+  }
+  async function editWorktreeBase(): Promise<void> {
+    const next = await RenameTaskDialog.show(dialog, worktreeBasePath(), {
+      dialogTitle: "Worktree directory (absolute path, ~ allowed; blank = default ~/.kobe/worktrees)",
+      fieldLabel: "path",
+      submitLabel: "save",
+      allowEmpty: true,
+    })
+    if (next === undefined) return
+    // Store exactly what was typed (trimmed). Validation/expansion happens on
+    // read; an unusable value is reflected in the row label rather than
+    // silently swallowed, and never blocks task creation.
+    props.kv.set(WORKTREE_BASE_PATH_KEY, next.trim())
+  }
+
   async function sendFeedback(): Promise<void> {
     setFeedbackStatus("submitting...")
     try {
@@ -505,6 +532,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
     surface: (row) => selectSurface(row.surface),
     editorKind: () => cycleEditorKind(),
     editorCustom: () => void editEditorCustom(),
+    worktreeBase: () => void editWorktreeBase(),
     engine: (row) => void editEngine(row.vendor),
     engineAdd: () => void addEngineFlow(), // the trailing "+ Add engine" row
     feedbackTitle: () => setBodyRow(0),
@@ -639,6 +667,9 @@ export function SettingsDialog(props: SettingsDialogProps) {
               cycleEditorKind={cycleEditorKind}
               editorCustomCommand={editorCustomCommand}
               editEditorCustom={() => void editEditorCustom()}
+              worktreeBasePath={worktreeBasePath}
+              worktreeBaseIsValid={worktreeBaseIsValid}
+              editWorktreeBase={() => void editWorktreeBase()}
             />
           </Show>
           <Show when={section() === "engines"}>

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -51,6 +51,7 @@ export type SettingsRow =
   | { id: string; kind: "surface"; surface: "chattab" | "taskpanel" }
   | { id: "editor-kind"; kind: "editorKind" }
   | { id: "editor-custom"; kind: "editorCustom" }
+  | { id: "worktree-base"; kind: "worktreeBase" }
   | { id: string; kind: "engine"; vendor: VendorId }
   | { id: "add-engine"; kind: "engineAdd" }
   | { id: "feedback-title"; kind: "feedbackTitle" }
@@ -113,6 +114,7 @@ export function generalRows(input: Pick<SettingsRowsInput, "themeNames" | "focus
     { id: surfaceRowId("taskpanel"), kind: "surface", surface: "taskpanel" },
     { id: "editor-kind", kind: "editorKind" },
     { id: "editor-custom", kind: "editorCustom" },
+    { id: "worktree-base", kind: "worktreeBase" },
   ]
 }
 

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -84,6 +84,9 @@ export function GeneralSettingsSection(
     cycleEditorKind: () => void
     editorCustomCommand: Accessor<string>
     editEditorCustom: () => void
+    worktreeBasePath: Accessor<string>
+    worktreeBaseIsValid: Accessor<boolean>
+    editWorktreeBase: () => void
   },
 ) {
   const themeCtx = useTheme()
@@ -100,6 +103,7 @@ export function GeneralSettingsSection(
   const surfaceTaskpanelRow = () => rowIdx(surfaceRowId("taskpanel"))
   const editorKindRow = () => rowIdx("editor-kind")
   const editorCustomRow = () => rowIdx("editor-custom")
+  const worktreeBaseRow = () => rowIdx("worktree-base")
   const isTransparentRow = () => props.bodyRow() === transparentRow()
   const isToastRow = () => props.bodyRow() === toastRow()
   const isSoundRow = () => props.bodyRow() === soundRow()
@@ -108,6 +112,7 @@ export function GeneralSettingsSection(
   const isSurfaceTaskpanelRow = () => props.bodyRow() === surfaceTaskpanelRow()
   const isEditorKindRow = () => props.bodyRow() === editorKindRow()
   const isEditorCustomRow = () => props.bodyRow() === editorCustomRow()
+  const isWorktreeBaseRow = () => props.bodyRow() === worktreeBaseRow()
 
   return (
     <box flexDirection="column" gap={1}>
@@ -445,6 +450,42 @@ export function GeneralSettingsSection(
           >
             {t("settings.general.editorCustom", {
               cmd: props.editorCustomCommand().trim() || t("settings.general.editorCustomUnset"),
+            })}
+          </text>
+        </box>
+      </box>
+      <box flexDirection="column" gap={0} paddingTop={1}>
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          {t("settings.general.worktree")}
+        </text>
+        <text fg={theme.textMuted} wrapMode="word">
+          {t("settings.general.worktreeHint")}
+        </text>
+        <box
+          flexDirection="row"
+          gap={1}
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={isWorktreeBaseRow() ? theme.primary : undefined}
+          onMouseUp={() => {
+            props.setLevel("body")
+            props.setBodyRow(worktreeBaseRow())
+            props.editWorktreeBase()
+          }}
+        >
+          <text
+            fg={
+              isWorktreeBaseRow() ? theme.selectedListItemText : props.worktreeBaseIsValid() ? theme.text : theme.error
+            }
+            wrapMode="none"
+          >
+            {t("settings.general.worktreeBase", {
+              path:
+                props.worktreeBasePath().trim() === ""
+                  ? t("settings.general.worktreeBaseDefault")
+                  : props.worktreeBaseIsValid()
+                    ? props.worktreeBasePath().trim()
+                    : t("settings.general.worktreeBaseInvalid", { path: props.worktreeBasePath().trim() }),
             })}
           </text>
         </box>

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -54,6 +54,12 @@ export const en = {
     editorRow: "editor: < {kind} >  (enter to change)",
     editorCustom: "custom: {cmd}",
     editorCustomUnset: "(unset — enter to edit)",
+    worktree: "Worktree directory",
+    worktreeHint:
+      "Where new task worktrees are created. Default is `~/.kobe/worktrees`. Set an absolute path (`~` allowed) to keep worktrees elsewhere — e.g. a faster disk or outside a backed-up home. Applies to tasks created after the change; existing worktrees stay where they are.",
+    worktreeBase: "dir: {path}  (enter to change)",
+    worktreeBaseDefault: "(default — ~/.kobe/worktrees)",
+    worktreeBaseInvalid: "{path}  (not absolute — using default)",
   },
   engines: {
     title: "Launch command",
@@ -168,6 +174,12 @@ export const zh: typeof en = {
     editorRow: "编辑器: < {kind} >  (enter 切换)",
     editorCustom: "自定义: {cmd}",
     editorCustomUnset: "(未设置 — enter 编辑)",
+    worktree: "Worktree 目录",
+    worktreeHint:
+      "新任务的 worktree 创建在哪里。默认是 `~/.kobe/worktrees`。可设为绝对路径（支持 `~`）把 worktree 放到别处——例如更快的磁盘或主目录备份之外。仅对修改之后创建的任务生效；已有 worktree 保持原位。",
+    worktreeBase: "目录: {path}  (enter 修改)",
+    worktreeBaseDefault: "(默认 — ~/.kobe/worktrees)",
+    worktreeBaseInvalid: "{path}  (非绝对路径 — 使用默认)",
   },
   engines: {
     title: "启动命令",

--- a/packages/kobe/test/state/worktree-prefs.test.ts
+++ b/packages/kobe/test/state/worktree-prefs.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the configurable worktree base path
+ * (`src/state/worktree-prefs.ts`) and its effect on the canonical worktree
+ * layout (`src/orchestrator/worktree/paths.ts`).
+ *
+ * Like the other state tests, HOME is redirected via `KOBE_HOME_DIR` to a
+ * per-test tmpdir so every state.json read/write is scoped there and the
+ * real `~/.config/kobe/` is untouched. The setting is the TUI-written
+ * `worktree.basePath` key; the daemon reads it here through the same blob.
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import {
+  defaultWorktreesBaseDir,
+  managedWorktreeRootsFor,
+  worktreeRootFor,
+  worktreesBaseDir,
+} from "../../src/orchestrator/worktree/paths.ts"
+import { patchStateFile } from "../../src/state/store.ts"
+import {
+  WORKTREE_BASE_PATH_KEY,
+  getConfiguredWorktreeBase,
+  isValidWorktreeBasePath,
+  normalizeWorktreeBasePath,
+} from "../../src/state/worktree-prefs.ts"
+
+let tmpHome: string
+let originalHome: string | undefined
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-wtprefs-"))
+  originalHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = tmpHome
+})
+
+afterEach(() => {
+  // biome-ignore lint/performance/noDelete: env cleanup must fully unset when the var was unset before the test.
+  if (originalHome === undefined) delete process.env.KOBE_HOME_DIR
+  else process.env.KOBE_HOME_DIR = originalHome
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+})
+
+function setBasePath(value: string): void {
+  patchStateFile({ [WORKTREE_BASE_PATH_KEY]: value })
+}
+
+describe("normalizeWorktreeBasePath", () => {
+  test("blank / whitespace / non-string → undefined (means default)", () => {
+    expect(normalizeWorktreeBasePath("")).toBeUndefined()
+    expect(normalizeWorktreeBasePath("   ")).toBeUndefined()
+    expect(normalizeWorktreeBasePath(undefined)).toBeUndefined()
+    expect(normalizeWorktreeBasePath(42)).toBeUndefined()
+  })
+
+  test("relative path → undefined (never roots worktrees somewhere ambiguous)", () => {
+    expect(normalizeWorktreeBasePath("worktrees")).toBeUndefined()
+    expect(normalizeWorktreeBasePath("./wt")).toBeUndefined()
+    expect(normalizeWorktreeBasePath("../wt")).toBeUndefined()
+  })
+
+  test("absolute path → trimmed + normalized", () => {
+    expect(normalizeWorktreeBasePath("  /srv/wt  ")).toBe("/srv/wt")
+    expect(normalizeWorktreeBasePath("/srv/wt/")).toBe("/srv/wt")
+    expect(normalizeWorktreeBasePath("/srv/./a/../wt")).toBe("/srv/wt")
+  })
+
+  test("leading ~ expands to KOBE_HOME_DIR", () => {
+    expect(normalizeWorktreeBasePath("~")).toBe(tmpHome)
+    expect(normalizeWorktreeBasePath("~/code/wt")).toBe(path.join(tmpHome, "code/wt"))
+  })
+})
+
+describe("isValidWorktreeBasePath", () => {
+  test("blank is valid (means default); absolute is valid; relative is not", () => {
+    expect(isValidWorktreeBasePath("")).toBe(true)
+    expect(isValidWorktreeBasePath("   ")).toBe(true)
+    expect(isValidWorktreeBasePath("~/wt")).toBe(true)
+    expect(isValidWorktreeBasePath("/abs/wt")).toBe(true)
+    expect(isValidWorktreeBasePath("relative/wt")).toBe(false)
+  })
+})
+
+describe("getConfiguredWorktreeBase", () => {
+  test("undefined when the key is unset", () => {
+    expect(getConfiguredWorktreeBase()).toBeUndefined()
+  })
+
+  test("reads + normalizes the stored value", () => {
+    setBasePath("~/elsewhere")
+    expect(getConfiguredWorktreeBase()).toBe(path.join(tmpHome, "elsewhere"))
+  })
+
+  test("a relative (invalid) stored value falls back to undefined", () => {
+    setBasePath("not/absolute")
+    expect(getConfiguredWorktreeBase()).toBeUndefined()
+  })
+})
+
+describe("worktreesBaseDir / worktreeRootFor", () => {
+  const repo = "/Users/x/proj"
+
+  test("defaults under <kobeStateDir>/worktrees when unset", () => {
+    expect(worktreesBaseDir()).toBe(defaultWorktreesBaseDir())
+    expect(defaultWorktreesBaseDir()).toBe(path.join(tmpHome, ".kobe", "worktrees"))
+    expect(worktreeRootFor(repo).startsWith(path.join(tmpHome, ".kobe", "worktrees"))).toBe(true)
+  })
+
+  test("an override relocates the base while keeping the per-repo subdir name", () => {
+    // The per-repo dir name depends only on the repo, so it is stable across bases.
+    const repoDirName = path.basename(worktreeRootFor(repo))
+    setBasePath("/srv/worktrees")
+    expect(worktreesBaseDir()).toBe("/srv/worktrees")
+    const root = worktreeRootFor(repo)
+    expect(path.dirname(root)).toBe("/srv/worktrees")
+    expect(path.basename(root)).toBe(repoDirName)
+  })
+})
+
+describe("managedWorktreeRootsFor", () => {
+  const repo = "/Users/x/proj"
+
+  test("no duplicate built-in root when the base is unset", () => {
+    const roots = managedWorktreeRootsFor(repo)
+    // primary == built-in default, so it appears exactly once (then repo-local legacy roots)
+    const primary = worktreeRootFor(repo)
+    expect(roots[0]).toBe(primary)
+    expect(roots.filter((r) => r === primary)).toHaveLength(1)
+  })
+
+  test("keeps the built-in default as a recognized legacy root when overridden", () => {
+    const repoDirName = path.basename(worktreeRootFor(repo)) // computed while unset
+    setBasePath("/srv/worktrees")
+    const roots = managedWorktreeRootsFor(repo)
+    const builtin = path.join(defaultWorktreesBaseDir(), repoDirName)
+    expect(roots[0]).toBe(worktreeRootFor(repo)) // primary = new base
+    expect(roots).toContain(builtin) // old worktrees stay discoverable
+    // repo-local compat roots still present
+    expect(roots.some((r) => r === path.join(repo, ".kobe/worktrees"))).toBe(true)
+  })
+})

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -69,6 +69,7 @@ describe("generalRows", () => {
       "surface",
       "editorKind",
       "editorCustom",
+      "worktreeBase",
     ])
     // Payload order matches input order, and the two surfaces are ChatTab then Task panel.
     expect(rows.slice(0, 3).map((r) => (r.kind === "theme" ? r.name : "?"))).toEqual(themes)
@@ -79,11 +80,11 @@ describe("generalRows", () => {
     expect(rows.filter((r) => r.kind === "surface").map((r) => r.surface)).toEqual(["chattab", "taskpanel"])
   })
 
-  it("matches the offset formula (themeCount + langCount + 1 + accentCount + 7) for representative sizes", () => {
+  it("matches the offset formula (themeCount + langCount + 1 + accentCount + 8) for representative sizes", () => {
     for (const themeCount of [0, 1, 12, 30]) {
       const themes = Array.from({ length: themeCount }, (_, i) => `theme-${i}`)
       const rows = generalRows({ themeNames: themes, focusAccentSlots: SLOTS })
-      expect(rows.length).toBe(themeCount + LANG + 1 + SLOTS.length + 7)
+      expect(rows.length).toBe(themeCount + LANG + 1 + SLOTS.length + 8)
       // transparent sits after the theme list + the language picker.
       expect(rowIndex(rows, "transparent")).toBe(themeCount + LANG)
       // toastRowIndex / soundRowIndex chain, then the zen toggle, then surfaces + editors.
@@ -94,6 +95,7 @@ describe("generalRows", () => {
       expect(rowIndex(rows, surfaceRowId("taskpanel"))).toBe(themeCount + LANG + 1 + SLOTS.length + 4)
       expect(rowIndex(rows, "editor-kind")).toBe(themeCount + LANG + 1 + SLOTS.length + 5)
       expect(rowIndex(rows, "editor-custom")).toBe(themeCount + LANG + 1 + SLOTS.length + 6)
+      expect(rowIndex(rows, "worktree-base")).toBe(themeCount + LANG + 1 + SLOTS.length + 7)
     }
   })
 
@@ -177,7 +179,7 @@ describe("sectionRows / bodyRowCount", () => {
     // 12 themes, 3 accents, 2 custom engines, daemon attached.
     const themes = Array.from({ length: 12 }, (_, i) => `t${i}`)
     const inp = input({ themeNames: themes, engineList: [...ALL_VENDORS, "aider", "goose"], hasDaemon: true })
-    expect(bodyRowCount("general", inp)).toBe(12 + LANG + 1 + 3 + 7) // 12 themes + langs + transparent + 3 accents + 7
+    expect(bodyRowCount("general", inp)).toBe(12 + LANG + 1 + 3 + 8) // 12 themes + langs + transparent + 3 accents + 8
     expect(bodyRowCount("engines", inp)).toBe(ALL_VENDORS.length + 2 + 1) // 6
     expect(bodyRowCount("accounts", inp)).toBe(0)
     expect(bodyRowCount("keys", inp)).toBe(0)


### PR DESCRIPTION
Adds a **Settings → General → Worktree directory** setting so users can create new task worktrees somewhere other than the default `~/.kobe/worktrees` (e.g. a faster disk or outside a backed-up home). The value is stored raw in `state.json` under `worktree.basePath` and read cross-process by the daemon in `orchestrator/worktree/paths.ts` at creation time, so a change applies to the next task without a relaunch. `~` is expanded and non-absolute values fall back to the default (surfaced in the row label) rather than blocking task creation, and the built-in default root stays recognized when overridden so existing tasks remain discoverable. Existing worktrees are never moved. Scope is TUI-only; the `kobe-web` dashboard is unchanged.