### PR TITLE
fix: archived-history preview no longer spawns a live engine on close

### DIFF
--- a/.changeset/archived-history-no-engine-relaunch.md
+++ b/.changeset/archived-history-no-engine-relaunch.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix (TUI beta): closing the archived-history preview no longer spawns a live engine on the archived task. With `experimental.archivedHistoryPreview` on, opening an archived task shows a read-only `kobe history` pane in the engine slot — but pressing its "q close" key dropped to a bare shell and, on exit, routed through the engine pane's `engine-tab-exit` cleanup, which relaunches a live engine when it's the task's only tab. That re-ran a real `claude`/`codex` on an archived task (in a fallback dir when the worktree was already removed) — exactly what the preview is built to avoid. The preview is now a persistent read-only pane (like the Ops pane): it ignores SIGINT and re-launches itself instead of falling through to a shell or an engine, and the misleading self-close key is removed — leave the preview via the Tasks rail or Ctrl+Q like any other pane.

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -225,6 +225,27 @@ export function keepAlive(cmd: string, onExit?: string): string {
 }
 
 /**
+ * Keep-alive wrapper for the read-only archived-history preview pane (`kobe
+ * history`, shown in the engine pane slot when an archived task is opened with
+ * `experimental.archivedHistoryPreview` on).
+ *
+ * This pane must NEVER follow the engine pane's {@link keepAlive} `onExit` path:
+ * that drops to a fallback shell and then runs `kobe engine-tab-exit`, which on
+ * a task's ONLY tab opens a fresh chat tab via `newChatTab` — spawning a LIVE
+ * ENGINE. Relaunching a real engine on an ARCHIVED task is precisely what the
+ * preview exists to avoid (no engine spawn, no worktree re-materialize). So the
+ * preview is a PERSISTENT pane like the Ops fallback: SIGINT is ignored and
+ * `kobe history` is re-launched in a guarded loop, so closing/quitting the
+ * preview can never collapse the pane into a shell or an engine. The user leaves
+ * the preview the same way they leave any pane — the Tasks rail or Ctrl+Q — not
+ * by exiting this pane. The `sleep 1` bounds a re-launch spin if the history
+ * host can't boot.
+ */
+export function historyPaneKeepAlive(cmd: string): string {
+  return `trap '' INT; while :; do ${cmd}; sleep 1; done`
+}
+
+/**
  * Build the engine pane's {@link keepAlive} `onExit` cleanup command: after the
  * user exits the post-engine fallback shell (fully tearing this tab's engine
  * down), run `kobe engine-tab-exit --session <name>`, which closes this chat

--- a/packages/kobe/src/tui/history/host.tsx
+++ b/packages/kobe/src/tui/history/host.tsx
@@ -309,11 +309,13 @@ function HistoryScreen(props: HistoryHostArgs) {
     setSelected((i) => Math.min(Math.max(i + delta, 0), n - 1))
   }
 
+  // No self-close binding: this read-only preview replaces the engine pane of an
+  // ARCHIVED task. Its pane re-launches it on exit (historyPaneKeepAlive), so a
+  // quit would just reload the preview — and the original behavior was worse: it
+  // dropped to a shell that, on exit, spawned a live engine via engine-tab-exit.
+  // The preview is left like any other pane — the Tasks rail or Ctrl+Q.
   useBindings(() => ({
     bindings: [
-      { key: "q", cmd: () => process.exit(0) },
-      { key: "escape", cmd: () => process.exit(0) },
-      { key: "ctrl+c", cmd: () => process.exit(0) },
       { key: "j", cmd: () => scrollBy(SCROLL_STEP) },
       { key: "k", cmd: () => scrollBy(-SCROLL_STEP) },
       { key: "down", cmd: () => scrollBy(SCROLL_STEP) },

--- a/packages/kobe/src/tui/i18n/messages/history.ts
+++ b/packages/kobe/src/tui/i18n/messages/history.ts
@@ -9,8 +9,8 @@ export const en = {
   loading: "loading…",
   sessionLabel: "Session",
   archivedTag: "ARCHIVED",
-  hint: "[ ] session · j/k scroll · ⏎ expand · q close",
-  hintExpanded: "[ ] session · j/k scroll · ⏎ collapse · q close",
+  hint: "[ ] session · j/k scroll · ⏎ expand",
+  hintExpanded: "[ ] session · j/k scroll · ⏎ collapse",
   role: {
     user: "USER",
     assistant: "ASSISTANT",
@@ -24,8 +24,8 @@ export const zh: typeof en = {
   loading: "加载中…",
   sessionLabel: "会话",
   archivedTag: "已归档",
-  hint: "[ ] 会话 · j/k 滚动 · ⏎ 展开 · q 关闭",
-  hintExpanded: "[ ] 会话 · j/k 滚动 · ⏎ 收起 · q 关闭",
+  hint: "[ ] 会话 · j/k 滚动 · ⏎ 展开",
+  hintExpanded: "[ ] 会话 · j/k 滚动 · ⏎ 收起",
   role: {
     user: "用户",
     assistant: "助手",

--- a/packages/kobe/src/tui/panes/terminal/tmux.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux.ts
@@ -83,6 +83,7 @@ import {
   HIDDEN_TASKS_PANE_OPTION,
   engineLaunchLine,
   engineTabExitCleanup,
+  historyPaneKeepAlive,
   openUrlCommand,
   resolveRepoInitTimeoutSeconds,
   shellQuote,
@@ -716,6 +717,26 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     ...(opts.title ? ["--title", opts.title] : []),
   ]
   const engineCmd = wrapEngineLaunch(shellQuoteArgv(historyPreview ? historyArgv : launchArgv), remoteKey, opts.cwd)
+  // The history preview is a PERSISTENT read-only pane: it re-launches itself on
+  // exit (and ignores SIGINT) instead of following the engine pane's exit path,
+  // which would drop to a shell and then spawn a LIVE engine via engine-tab-exit
+  // — the one thing an archived-task preview must never do. The live engine path
+  // keeps the per-repo init weave + engine-tab-exit cleanup verbatim.
+  const paneCommand = historyPreview
+    ? historyPaneKeepAlive(engineCmd)
+    : engineLaunchLine(
+        engineCmd,
+        {
+          initScript: remoteKey ? undefined : launchInit?.initScript,
+          markerPath: !remoteKey && launchInit?.initScript ? worktreeInitMarkerPath(opts.cwd) : undefined,
+          // Operator escape hatch for an unusually slow (or fast-fail) init —
+          // clamped + defaulted by the resolver; unset keeps the 120s default.
+          timeoutSeconds: resolveRepoInitTimeoutSeconds(process.env.KOBE_REPO_INIT_TIMEOUT_SECONDS),
+        },
+        // Exiting the post-engine fallback shell tears this tab down → close it
+        // (or replace it with a fresh engine tab when it's the task's only tab).
+        engineTabExitCleanup(inheritedEnvPrefix(), inv, opts.name),
+      )
   const r0 = await runTmuxCapturing([
     "new-session",
     "-d",
@@ -727,23 +748,7 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
     "-P",
     "-F",
     "#{pane_id}",
-    // Weave the per-repo init script before the engine (once-per-worktree
-    // via a marker under <home>/.kobe/). Plain keepAlive when there's none.
-    engineLaunchLine(
-      engineCmd,
-      {
-        // No per-repo init script for the read-only history preview.
-        initScript: remoteKey || historyPreview ? undefined : launchInit?.initScript,
-        markerPath:
-          !remoteKey && !historyPreview && launchInit?.initScript ? worktreeInitMarkerPath(opts.cwd) : undefined,
-        // Operator escape hatch for an unusually slow (or fast-fail) init —
-        // clamped + defaulted by the resolver; unset keeps the 120s default.
-        timeoutSeconds: resolveRepoInitTimeoutSeconds(process.env.KOBE_REPO_INIT_TIMEOUT_SECONDS),
-      },
-      // Exiting the post-engine fallback shell tears this tab down → close it
-      // (or replace it with a fresh engine tab when it's the task's only tab).
-      engineTabExitCleanup(inheritedEnvPrefix(), inv, opts.name),
-    ),
+    paneCommand,
   ])
   const pane0 = r0.stdout.trim()
   if (!pane0) {

--- a/packages/kobe/test/tmux/session-layout.test.ts
+++ b/packages/kobe/test/tmux/session-layout.test.ts
@@ -25,6 +25,7 @@ import {
   engineLaunchLine,
   engineTabExitCleanup,
   fallbackOpsScript,
+  historyPaneKeepAlive,
   keepAlive,
   openUrlCommand,
   opsPaneCommand,
@@ -127,6 +128,22 @@ describe("keepAlive", () => {
     expect(keepAlive("claude", "kobe engine-tab-exit --session 'kobe-x'").startsWith("trap ':' INT; ")).toBe(true)
     // Non-engine panes keep their exact prior shape — no guard.
     expect(keepAlive("claude")).not.toContain("trap ':' INT")
+  })
+})
+
+describe("historyPaneKeepAlive", () => {
+  test("re-launches the command in a loop and never drops to a shell or engine", () => {
+    const out = historyPaneKeepAlive("kobe history --worktree /wt --vendor claude")
+    // Persistent like the Ops pane: re-run forever, bounded by a sleep.
+    expect(out).toBe("trap '' INT; while :; do kobe history --worktree /wt --vendor claude; sleep 1; done")
+    // The bug being fixed: the archived preview must NOT reach the engine pane's
+    // exit path, which drops to a shell and then spawns a live engine.
+    expect(out).not.toContain("${SHELL")
+    expect(out).not.toContain("engine-tab-exit")
+  })
+
+  test("ignores SIGINT so a Ctrl+C can't collapse the read-only pane", () => {
+    expect(historyPaneKeepAlive("kobe history").startsWith("trap '' INT; ")).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Direction

Bugs / correctness — found by reviewing the freshly-landed `experimental.archivedHistoryPreview` feature (TUI, v0.7.55) against its own stated invariant: *no engine spawn, no worktree re-materialize on an archived task*.

## The problem

When an archived task is opened with the preview gate on, the session build (`ensureSessionImpl` in `panes/terminal/tmux.ts`) launches a read-only `kobe history` pane **into the engine pane slot**, via the same launch path a live engine uses — i.e. `engineLaunchLine(engineCmd, …, engineTabExitCleanup(…))`.

That wrapper is built for a live engine, and it misfires here:

1. The history host binds `q` / `Esc` / `Ctrl+C` to `process.exit(0)` ("q close").
2. On exit, `keepAlive` drops the pane to a **bare fallback shell** (confusing for a read-only preview).
3. When the user exits that shell, it runs `kobe engine-tab-exit`, which on a task's **only tab** opens a fresh chat tab via `newChatTab` — **spawning a live `claude`/`codex` engine**.
4. Because an archived task's worktree is usually gone, that engine launches in a **fallback dir** (repo root or `$HOME`).

So "closing" the read-only archived preview re-runs a real engine on an archived task — exactly what the feature exists to avoid.

## The fix

Give the preview its own keep-alive wrapper instead of the engine one:

- **`historyPaneKeepAlive(cmd)`** (`tmux/session-layout.ts`) — a persistent, SIGINT-ignoring re-launch loop (`trap '' INT; while :; do <cmd>; sleep 1; done`), the same "never collapse into a shell" shape the Ops fallback pane already uses. It can never drop to a shell or fall through to `engine-tab-exit`.
- `ensureSessionImpl` routes the history-preview pane through `historyPaneKeepAlive`; the live-engine path keeps its per-repo init weave + `engineTabExitCleanup` verbatim (the now-unreachable `historyPreview` guards in that branch are dropped).
- The history host drops its self-close bindings, and the hint loses the false "q close". The preview is left like any other pane — the **Tasks rail** or **Ctrl+Q** — never by quitting it.

## How I verified

- `bun run typecheck` ✓ · `bun run lint` ✓
- `bun test test/tmux/session-layout.test.ts` — 43 pass, including two new cases asserting `historyPaneKeepAlive` re-launches in a loop and never emits `${SHELL}` or `engine-tab-exit`.
- i18n parity + key-resolution tests pass (both `en`/`zh` hints updated).
- The 13 failing tmux/tui tests on this branch also fail on a clean `main` — they need a live tmux server, which the cloud checkout lacks; none are in the touched files.

## Follow-ups (deliberately out of scope)

- Opening a **new chat tab** (`Ctrl+T`) on an archived task still calls `newChatTab` → a live engine. That's an explicit user action rather than an implicit "close", so it's left for a separate decision.
- A richer "close → jump back to the Tasks rail" affordance for `q` could replace the removed binding if desired.


---
_Generated by [Claude Code](https://claude.ai/code/session_017kruuVMcm3hFfTSGbBHjrV)_