### PR TITLE
feat: configurable global worktree base path

### DIFF
--- a/.changeset/configurable-worktree-base-path.md
+++ b/.changeset/configurable-worktree-base-path.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Add a global "Worktree location" setting (Settings → General) to configure where new task worktrees are created. By default kobe stores local worktrees under `~/.kobe/worktrees/<repo>-<hash>/<slug>`; the new free-text field re-roots that base directory to any path you choose (with `~` and relative-path expansion), while keeping the per-repo `<repo>-<hash>` subfolder so worktrees from different repos never collide. The override is read fresh by the daemon on every task create — no restart needed — and applies to new tasks only: existing worktrees keep their recorded path and the old default root stays recognized for listing and slug allocation. Remote (SSH) projects are unaffected; their worktrees still live under the project's remote `basePath`.

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -86,6 +86,16 @@ export function worktreeRootFor(repo: string): string {
  * follows when an override moved it (so worktrees created before the
  * override stay discoverable for listing + slug allocation), then the
  * repo-local legacy roots for existing task records.
+ *
+ * KNOWN LIMITATION: only the CURRENT override and the built-in default
+ * are recognized — we don't persist a history of past override paths.
+ * If a user points the base at A, creates tasks, then re-points it at B,
+ * the worktrees under A fall out of managed listing + slug allocation.
+ * Those tasks are NOT lost — each task record pins its own absolute
+ * `worktreePath`, so opening/removing them keeps working; they just stop
+ * appearing in "list kobe-managed worktrees" and their slugs no longer
+ * block reuse. Recording every base ever used would close the gap but is
+ * deliberately out of scope here.
  */
 export function managedWorktreeRootsFor(repo: string): readonly string[] {
   if (!path.isAbsolute(repo)) {

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -27,6 +27,7 @@ import path from "node:path"
 import { kobeStateDir } from "../../env.ts"
 import { execHostForRepo } from "../../exec/resolve.ts"
 import { getRemoteRepoConfig, isRemoteRepoKey } from "../../state/repos.ts"
+import { getWorktreeBaseOverride } from "../../state/worktree-base.ts"
 
 /**
  * Directory under kobe's state dir where kobe stores all of its worktrees.
@@ -49,30 +50,51 @@ export const REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
 ] as const
 
 /**
+ * The `worktrees` root that new LOCAL tasks are created under. Defaults
+ * to `<home>/.kobe/worktrees`; a user-configured global override
+ * (Settings → General → Worktree location) relocates it wholesale. The
+ * override IS the worktrees root — the per-repo `<repo-key>` subdir is
+ * still appended below it by {@link worktreeRootFor}. Read fresh so a
+ * settings change needs no daemon restart.
+ */
+function localWorktreesRoot(): string {
+  return getWorktreeBaseOverride() ?? path.join(kobeStateDir(), KOBE_WORKTREE_ROOT_DIR)
+}
+
+/** The built-in default worktrees root, ignoring any override. */
+function defaultLocalWorktreesRoot(): string {
+  return path.join(kobeStateDir(), KOBE_WORKTREE_ROOT_DIR)
+}
+
+/**
  * Absolute path of the worktree root for a given repo.
  *
  * Example: `worktreeRootFor("/Users/x/proj")` →
- * `/Users/x/.kobe/worktrees/proj-a1b2c3d4e5f6`.
+ * `/Users/x/.kobe/worktrees/proj-a1b2c3d4e5f6` (or, when a base override
+ * is set, `<override>/proj-a1b2c3d4e5f6`).
  */
 export function worktreeRootFor(repo: string): string {
   if (!path.isAbsolute(repo)) {
     throw new Error(`worktreeRootFor: repo must be an absolute path, got: ${repo}`)
   }
-  return path.join(kobeStateDir(), KOBE_WORKTREE_ROOT_DIR, repoWorktreeDirName(repo))
+  return path.join(localWorktreesRoot(), repoWorktreeDirName(repo))
 }
 
 /**
  * Absolute paths of every worktree root kobe recognizes for `repo`.
- * Primary root is first; legacy roots follow for existing task records.
+ * The active root (override-aware) is first; the built-in default root
+ * follows when an override moved it (so worktrees created before the
+ * override stay discoverable for listing + slug allocation), then the
+ * repo-local legacy roots for existing task records.
  */
 export function managedWorktreeRootsFor(repo: string): readonly string[] {
   if (!path.isAbsolute(repo)) {
     throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
   }
-  return [
-    worktreeRootFor(repo),
-    ...REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath)),
-  ]
+  const active = worktreeRootFor(repo)
+  const fallback = path.join(defaultLocalWorktreesRoot(), repoWorktreeDirName(repo))
+  const primaryRoots = active === fallback ? [active] : [active, fallback]
+  return [...primaryRoots, ...REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath))]
 }
 
 /**

--- a/packages/kobe/src/state/worktree-base.ts
+++ b/packages/kobe/src/state/worktree-base.ts
@@ -1,0 +1,56 @@
+/**
+ * Global worktree base-path override.
+ *
+ * By default kobe stores every LOCAL task worktree under
+ * `<home>/.kobe/worktrees/<repo-key>/<slug>` (see
+ * `orchestrator/worktree/paths.ts`). This module owns the one optional
+ * knob that relocates that `<home>/.kobe/worktrees` root to a
+ * user-chosen directory — e.g. a faster disk, or a folder the user
+ * already keeps their scratch checkouts in. The per-repo `<repo-key>`
+ * namespacing below it is preserved, so worktrees from different repos
+ * never collide under a shared base.
+ *
+ * Stored in the shared state.json (the Settings dialog's KV writes the
+ * same file) and read FRESH on every worktree-path computation, so
+ * changing it takes effect for the next task with no daemon restart.
+ * Only NEW tasks move: existing tasks keep their persisted worktreePath,
+ * and the old default root stays recognized for listing/slug allocation
+ * (see `managedWorktreeRootsFor`).
+ *
+ * Remote (SSH) projects are unaffected — their worktrees live on the
+ * remote host under the project's own `basePath` (`remoteWorktreeRootFor`).
+ */
+
+import { homedir } from "node:os"
+import { isAbsolute, join, resolve } from "node:path"
+import { homeDir } from "../env.ts"
+import { loadStateFile } from "./store.ts"
+
+export const WORKTREE_BASE_KEY = "worktree.basePath"
+
+/**
+ * Normalize a raw user-entered base path to an absolute directory, or
+ * `null` when it's unset/blank (meaning "use kobe's default root").
+ *
+ * A leading `~` / `~/` expands to the OS home; relative paths resolve
+ * against it too, so a user who types `code/worktrees` gets a stable
+ * absolute location instead of one that depends on kobe's cwd.
+ */
+export function normalizeWorktreeBase(raw: string | undefined | null): string | null {
+  if (typeof raw !== "string") return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  const home = homeDir() || homedir()
+  if (trimmed === "~") return home
+  const expanded = trimmed.startsWith("~/") ? join(home, trimmed.slice(2)) : trimmed
+  return isAbsolute(expanded) ? expanded : resolve(home, expanded)
+}
+
+/**
+ * The configured worktree base override as an absolute path, or `null`
+ * when unset. Read fresh from state.json on every call.
+ */
+export function getWorktreeBaseOverride(): string | null {
+  const value = loadStateFile()[WORKTREE_BASE_KEY]
+  return normalizeWorktreeBase(typeof value === "string" ? value : null)
+}

--- a/packages/kobe/src/state/worktree-base.ts
+++ b/packages/kobe/src/state/worktree-base.ts
@@ -21,7 +21,6 @@
  * remote host under the project's own `basePath` (`remoteWorktreeRootFor`).
  */
 
-import { homedir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
 import { homeDir } from "../env.ts"
 import { loadStateFile } from "./store.ts"
@@ -40,7 +39,8 @@ export function normalizeWorktreeBase(raw: string | undefined | null): string | 
   if (typeof raw !== "string") return null
   const trimmed = raw.trim()
   if (!trimmed) return null
-  const home = homeDir() || homedir()
+  // homeDir() already falls back to os.homedir() when KOBE_HOME_DIR is unset.
+  const home = homeDir()
   if (trimmed === "~") return home
   const expanded = trimmed.startsWith("~/") ? join(home, trimmed.slice(2)) : trimmed
   return isAbsolute(expanded) ? expanded : resolve(home, expanded)

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -28,6 +28,7 @@ import { ARCHIVED_HISTORY_PREVIEW_KEY } from "../../state/archived-history"
 import { AUTO_STATUS_KEY } from "../../state/auto-status"
 import { DISPATCHER_KEY } from "../../state/dispatcher"
 import { getPersistedString, setPersistedString } from "../../state/repos"
+import { WORKTREE_BASE_KEY } from "../../state/worktree-base"
 import { ZEN_KEEP_TASKS_KEY } from "../../state/zen"
 import type { VendorId } from "../../types/task"
 import { ALL_VENDORS, isBuiltinVendor, resolvePersistedVendor } from "../../types/vendor"
@@ -438,6 +439,28 @@ export function SettingsDialog(props: SettingsDialogProps) {
     if (cmd) props.kv.set(EDITOR_KIND_KEY, "custom")
   }
 
+  // Worktree location: a global override for where new LOCAL task
+  // worktrees are created (default `~/.kobe/worktrees`). Free-text path
+  // field (reused RenameTaskDialog); blank = default. Read cross-process
+  // by the daemon's worktree path resolver (state/worktree-base.ts).
+  function worktreeBasePath(): string {
+    const v = props.kv.get(WORKTREE_BASE_KEY, "")
+    return typeof v === "string" ? v : ""
+  }
+  async function editWorktreeBase(): Promise<void> {
+    const next = await RenameTaskDialog.show(dialog, worktreeBasePath(), {
+      dialogTitle: t("settings.general.worktreeBaseTitle"),
+      fieldLabel: t("settings.general.worktreeBaseField"),
+      submitLabel: "save",
+      placeholder: "~/.kobe/worktrees",
+      allowEmpty: true,
+    })
+    if (next === undefined) return
+    // Persist the trimmed raw entry (empty clears the override); the
+    // daemon expands ~ / relative paths when it reads it.
+    props.kv.set(WORKTREE_BASE_KEY, next.trim())
+  }
+
   async function sendFeedback(): Promise<void> {
     setFeedbackStatus("submitting...")
     try {
@@ -518,6 +541,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
     surface: (row) => selectSurface(row.surface),
     editorKind: () => cycleEditorKind(),
     editorCustom: () => void editEditorCustom(),
+    worktreeBase: () => void editWorktreeBase(),
     engine: (row) => void editEngine(row.vendor),
     engineAdd: () => void addEngineFlow(), // the trailing "+ Add engine" row
     feedbackTitle: () => setBodyRow(0),
@@ -653,6 +677,8 @@ export function SettingsDialog(props: SettingsDialogProps) {
               cycleEditorKind={cycleEditorKind}
               editorCustomCommand={editorCustomCommand}
               editEditorCustom={() => void editEditorCustom()}
+              worktreeBasePath={worktreeBasePath}
+              editWorktreeBase={() => void editWorktreeBase()}
             />
           </Show>
           <Show when={section() === "engines"}>

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -9,6 +9,7 @@
  *   - `esc`                  — close (handled by the dialog stack).
  */
 
+import { accessSync, constants as fsConstants, mkdirSync } from "node:fs"
 import { TextAttributes } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
 import { Show, createEffect, createMemo, createSignal } from "solid-js"
@@ -28,7 +29,7 @@ import { ARCHIVED_HISTORY_PREVIEW_KEY } from "../../state/archived-history"
 import { AUTO_STATUS_KEY } from "../../state/auto-status"
 import { DISPATCHER_KEY } from "../../state/dispatcher"
 import { getPersistedString, setPersistedString } from "../../state/repos"
-import { WORKTREE_BASE_KEY } from "../../state/worktree-base"
+import { WORKTREE_BASE_KEY, normalizeWorktreeBase } from "../../state/worktree-base"
 import { ZEN_KEEP_TASKS_KEY } from "../../state/zen"
 import type { VendorId } from "../../types/task"
 import { ALL_VENDORS, isBuiltinVendor, resolvePersistedVendor } from "../../types/vendor"
@@ -52,6 +53,7 @@ import {
   normalizeSettingsSurface,
 } from "../lib/settings-surface"
 import { type DialogContext, useDialog } from "../ui/dialog"
+import { DialogConfirm } from "../ui/dialog-confirm"
 import { RenameTaskDialog } from "./rename-task-dialog"
 import { confirmResetState, confirmRestartDaemon, hasRestartableDaemon } from "./settings-dialog/actions"
 import { type NavLevel, SECTIONS, type SectionId, type SettingsRow, rowAt, sectionRows } from "./settings-dialog/model"
@@ -456,9 +458,30 @@ export function SettingsDialog(props: SettingsDialogProps) {
       allowEmpty: true,
     })
     if (next === undefined) return
-    // Persist the trimmed raw entry (empty clears the override); the
-    // daemon expands ~ / relative paths when it reads it.
-    props.kv.set(WORKTREE_BASE_KEY, next.trim())
+    const raw = next.trim()
+    // A non-empty override must point at a directory kobe can actually
+    // create worktrees under — otherwise every future `git worktree add`
+    // fails with a raw git error and new-task creation breaks silently.
+    // Validate here (create + writability check) and refuse to save a bad
+    // path, rather than persisting a footgun. Blank clears the override.
+    if (raw) {
+      const resolved = normalizeWorktreeBase(raw) ?? raw
+      try {
+        mkdirSync(resolved, { recursive: true })
+        accessSync(resolved, fsConstants.W_OK)
+      } catch (err) {
+        await DialogConfirm.show(
+          dialog,
+          "Can't use that worktree location",
+          `${resolved} isn't usable (${err instanceof Error ? err.message : String(err)}). Keeping the previous setting — pick a writable directory.`,
+          "cancel",
+        )
+        return
+      }
+    }
+    // Persist the trimmed raw entry; the daemon expands ~ / relative
+    // paths the same way when it reads it.
+    props.kv.set(WORKTREE_BASE_KEY, raw)
   }
 
   async function sendFeedback(): Promise<void> {

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -51,6 +51,7 @@ export type SettingsRow =
   | { id: string; kind: "surface"; surface: "chattab" | "taskpanel" }
   | { id: "editor-kind"; kind: "editorKind" }
   | { id: "editor-custom"; kind: "editorCustom" }
+  | { id: "worktree-base"; kind: "worktreeBase" }
   | { id: string; kind: "engine"; vendor: VendorId }
   | { id: "add-engine"; kind: "engineAdd" }
   | { id: "feedback-title"; kind: "feedbackTitle" }
@@ -114,6 +115,7 @@ export function generalRows(input: Pick<SettingsRowsInput, "themeNames" | "focus
     { id: surfaceRowId("taskpanel"), kind: "surface", surface: "taskpanel" },
     { id: "editor-kind", kind: "editorKind" },
     { id: "editor-custom", kind: "editorCustom" },
+    { id: "worktree-base", kind: "worktreeBase" },
   ]
 }
 

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -473,13 +473,8 @@ export function GeneralSettingsSection(
           }}
         >
           <text
-            fg={
-              isWorktreeBaseRow()
-                ? theme.selectedListItemText
-                : props.worktreeBasePath().trim()
-                  ? theme.text
-                  : theme.textMuted
-            }
+            fg={isWorktreeBaseRow() ? theme.selectedListItemText : theme.accent}
+            attributes={TextAttributes.BOLD}
             wrapMode="none"
           >
             {t("settings.general.worktreeBase", {

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -84,6 +84,8 @@ export function GeneralSettingsSection(
     cycleEditorKind: () => void
     editorCustomCommand: Accessor<string>
     editEditorCustom: () => void
+    worktreeBasePath: Accessor<string>
+    editWorktreeBase: () => void
   },
 ) {
   const themeCtx = useTheme()
@@ -100,6 +102,7 @@ export function GeneralSettingsSection(
   const surfaceTaskpanelRow = () => rowIdx(surfaceRowId("taskpanel"))
   const editorKindRow = () => rowIdx("editor-kind")
   const editorCustomRow = () => rowIdx("editor-custom")
+  const worktreeBaseRow = () => rowIdx("worktree-base")
   const isTransparentRow = () => props.bodyRow() === transparentRow()
   const isToastRow = () => props.bodyRow() === toastRow()
   const isSoundRow = () => props.bodyRow() === soundRow()
@@ -108,6 +111,7 @@ export function GeneralSettingsSection(
   const isSurfaceTaskpanelRow = () => props.bodyRow() === surfaceTaskpanelRow()
   const isEditorKindRow = () => props.bodyRow() === editorKindRow()
   const isEditorCustomRow = () => props.bodyRow() === editorCustomRow()
+  const isWorktreeBaseRow = () => props.bodyRow() === worktreeBaseRow()
 
   return (
     <box flexDirection="column" gap={1}>
@@ -445,6 +449,41 @@ export function GeneralSettingsSection(
           >
             {t("settings.general.editorCustom", {
               cmd: props.editorCustomCommand().trim() || t("settings.general.editorCustomUnset"),
+            })}
+          </text>
+        </box>
+      </box>
+      <box flexDirection="column" gap={0} paddingTop={1}>
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          {t("settings.general.worktree")}
+        </text>
+        <text fg={theme.textMuted} wrapMode="word">
+          {t("settings.general.worktreeHint")}
+        </text>
+        <box
+          flexDirection="row"
+          gap={1}
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={isWorktreeBaseRow() ? theme.primary : undefined}
+          onMouseUp={() => {
+            props.setLevel("body")
+            props.setBodyRow(worktreeBaseRow())
+            props.editWorktreeBase()
+          }}
+        >
+          <text
+            fg={
+              isWorktreeBaseRow()
+                ? theme.selectedListItemText
+                : props.worktreeBasePath().trim()
+                  ? theme.text
+                  : theme.textMuted
+            }
+            wrapMode="none"
+          >
+            {t("settings.general.worktreeBase", {
+              path: props.worktreeBasePath().trim() || t("settings.general.worktreeBaseDefault"),
             })}
           </text>
         </box>

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -54,6 +54,13 @@ export const en = {
     editorRow: "editor: < {kind} >  (enter to change)",
     editorCustom: "custom: {cmd}",
     editorCustomUnset: "(unset — enter to edit)",
+    worktree: "Worktree location",
+    worktreeHint:
+      "Where new task worktrees are created (default `~/.kobe/worktrees`). Each repo keeps its own `<repo>-<hash>` subfolder underneath. Applies to new tasks only — existing worktrees stay where they are. Remote projects are unaffected. enter to edit; leave blank for the default.",
+    worktreeBase: "worktree base: {path}",
+    worktreeBaseDefault: "(default — enter to change)",
+    worktreeBaseTitle: "Worktree location (blank = default ~/.kobe/worktrees)",
+    worktreeBaseField: "path",
   },
   engines: {
     title: "Launch command",
@@ -172,6 +179,13 @@ export const zh: typeof en = {
     editorRow: "编辑器: < {kind} >  (enter 切换)",
     editorCustom: "自定义: {cmd}",
     editorCustomUnset: "(未设置 — enter 编辑)",
+    worktree: "工作树位置",
+    worktreeHint:
+      "新任务工作树的创建位置（默认 `~/.kobe/worktrees`）。每个仓库在其下保留自己的 `<仓库名>-<哈希>` 子目录。仅对新任务生效——已有工作树保持原位。远程项目不受影响。enter 编辑；留空则用默认值。",
+    worktreeBase: "工作树根目录: {path}",
+    worktreeBaseDefault: "(默认 — enter 修改)",
+    worktreeBaseTitle: "工作树位置（留空 = 默认 ~/.kobe/worktrees）",
+    worktreeBaseField: "路径",
   },
   engines: {
     title: "启动命令",

--- a/packages/kobe/test/orchestrator/worktree-base.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-base.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the global worktree base-path override.
+ *
+ * The override relocates the `<home>/.kobe/worktrees` root wholesale
+ * while keeping the per-repo `<repo>-<hash>` subfolder. We assert both
+ * the pure normalizer and its effect on the path helpers, plus that the
+ * default root stays recognized (so worktrees created before the
+ * override are still discoverable).
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { managedWorktreeRootsFor, worktreeRootFor } from "../../src/orchestrator/worktree/paths.ts"
+import { getWorktreeBaseOverride, normalizeWorktreeBase } from "../../src/state/worktree-base.ts"
+
+let tmpRoot: string
+let home: string
+let repo: string
+let prevHome: string | undefined
+
+function writeState(obj: Record<string, unknown>): void {
+  const p = path.join(home, ".config", "kobe", "state.json")
+  fs.mkdirSync(path.dirname(p), { recursive: true })
+  fs.writeFileSync(p, JSON.stringify(obj), "utf8")
+}
+
+beforeEach(() => {
+  prevHome = process.env.KOBE_HOME_DIR
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-wt-base-"))
+  home = path.join(tmpRoot, "home")
+  process.env.KOBE_HOME_DIR = home
+  repo = path.join(tmpRoot, "repo")
+  fs.mkdirSync(repo, { recursive: true })
+})
+
+afterEach(() => {
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = prevHome
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+describe("normalizeWorktreeBase", () => {
+  test("blank / non-string values fall back to null (use default)", () => {
+    expect(normalizeWorktreeBase(undefined)).toBeNull()
+    expect(normalizeWorktreeBase(null)).toBeNull()
+    expect(normalizeWorktreeBase("")).toBeNull()
+    expect(normalizeWorktreeBase("   ")).toBeNull()
+  })
+
+  test("expands a leading ~ against the kobe home", () => {
+    expect(normalizeWorktreeBase("~")).toBe(home)
+    expect(normalizeWorktreeBase("~/code/wt")).toBe(path.join(home, "code/wt"))
+  })
+
+  test("resolves a relative path against home; passes an absolute through", () => {
+    expect(normalizeWorktreeBase("code/wt")).toBe(path.resolve(home, "code/wt"))
+    const abs = path.join(tmpRoot, "elsewhere/worktrees")
+    expect(normalizeWorktreeBase(abs)).toBe(abs)
+    expect(normalizeWorktreeBase(`  ${abs}  `)).toBe(abs)
+  })
+})
+
+describe("worktree paths honor the override", () => {
+  test("unset override → default ~/.kobe/worktrees root", () => {
+    expect(getWorktreeBaseOverride()).toBeNull()
+    const root = worktreeRootFor(repo)
+    expect(root.startsWith(path.join(home, ".kobe", "worktrees"))).toBe(true)
+    // No override → only the default root (+ repo-local legacy roots).
+    const roots = managedWorktreeRootsFor(repo)
+    expect(roots[0]).toBe(root)
+    // The default root is not duplicated as a separate fallback.
+    expect(roots.filter((r) => r === root)).toHaveLength(1)
+  })
+
+  test("set override → worktrees re-rooted under it, per-repo subdir kept", () => {
+    const base = path.join(tmpRoot, "custom-worktrees")
+    writeState({ "worktree.basePath": base })
+
+    expect(getWorktreeBaseOverride()).toBe(base)
+    const root = worktreeRootFor(repo)
+    expect(path.dirname(root)).toBe(base) // <base>/<repo>-<hash>
+    expect(path.basename(root)).toMatch(/^repo-[0-9a-f]{12}$/)
+  })
+
+  test("with an override, the default root stays recognized for listing", () => {
+    const base = path.join(tmpRoot, "custom-worktrees")
+    writeState({ "worktree.basePath": base })
+
+    const roots = managedWorktreeRootsFor(repo)
+    const activeRoot = worktreeRootFor(repo)
+    const defaultRoot = path.join(home, ".kobe", "worktrees", path.basename(activeRoot))
+    expect(roots[0]).toBe(activeRoot)
+    expect(roots).toContain(defaultRoot)
+  })
+})

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -69,6 +69,7 @@ describe("generalRows", () => {
       "surface",
       "editorKind",
       "editorCustom",
+      "worktreeBase",
     ])
     // Payload order matches input order, and the two surfaces are ChatTab then Task panel.
     expect(rows.slice(0, 3).map((r) => (r.kind === "theme" ? r.name : "?"))).toEqual(themes)
@@ -79,11 +80,11 @@ describe("generalRows", () => {
     expect(rows.filter((r) => r.kind === "surface").map((r) => r.surface)).toEqual(["chattab", "taskpanel"])
   })
 
-  it("matches the offset formula (themeCount + langCount + 1 + accentCount + 7) for representative sizes", () => {
+  it("matches the offset formula (themeCount + langCount + 1 + accentCount + 8) for representative sizes", () => {
     for (const themeCount of [0, 1, 12, 30]) {
       const themes = Array.from({ length: themeCount }, (_, i) => `theme-${i}`)
       const rows = generalRows({ themeNames: themes, focusAccentSlots: SLOTS })
-      expect(rows.length).toBe(themeCount + LANG + 1 + SLOTS.length + 7)
+      expect(rows.length).toBe(themeCount + LANG + 1 + SLOTS.length + 8)
       // transparent sits after the theme list + the language picker.
       expect(rowIndex(rows, "transparent")).toBe(themeCount + LANG)
       // toastRowIndex / soundRowIndex chain, then the zen toggle, then surfaces + editors.
@@ -186,7 +187,7 @@ describe("sectionRows / bodyRowCount", () => {
     // 12 themes, 3 accents, 2 custom engines, daemon attached.
     const themes = Array.from({ length: 12 }, (_, i) => `t${i}`)
     const inp = input({ themeNames: themes, engineList: [...ALL_VENDORS, "aider", "goose"], hasDaemon: true })
-    expect(bodyRowCount("general", inp)).toBe(12 + LANG + 1 + 3 + 7) // 12 themes + langs + transparent + 3 accents + 7
+    expect(bodyRowCount("general", inp)).toBe(12 + LANG + 1 + 3 + 8) // 12 themes + langs + transparent + 3 accents + 8
     expect(bodyRowCount("engines", inp)).toBe(ALL_VENDORS.length + 2 + 1) // 6
     expect(bodyRowCount("accounts", inp)).toBe(0)
     expect(bodyRowCount("keys", inp)).toBe(0)


### PR DESCRIPTION
Adds a global **Worktree location** setting (Settings → General) that re-roots where new local task worktrees are created — a free-text path field with `~`/relative expansion, defaulting to `~/.kobe/worktrees`, while keeping the per-repo `<repo>-<hash>` subfolder so repos never collide under a shared base. The daemon reads the override fresh from `state.json` on every task create (no restart), and it applies to new tasks only: existing worktrees keep their recorded path and the old default root stays recognized for listing + slug allocation. Remote (SSH) projects are unaffected. Wiring spans the settings row registry/render/i18n (EN + ZH) plus a new `state/worktree-base.ts` resolver and override-aware `worktreeRootFor`/`managedWorktreeRootsFor`. Covered by a new `worktree-base.test.ts` and updated `settings-rows.test.ts`; lint, typecheck, and i18n checks pass.