### PR TITLE
fix: expand a leading `~` in CLI path arguments

### DIFF
--- a/.changeset/cli-tilde-path-expansion.md
+++ b/.changeset/cli-tilde-path-expansion.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix: CLI path arguments now expand a leading `~` to your home directory. A quoted or tool-forwarded `~` reaches kobe verbatim (the shell only expands unquoted words), and it was being treated as an ordinary path segment — so `kobe add "~/repo"`, `kobe remove ~/repo`, `kobe adopt ~/repo`, `kobe repo set --init-script-file ~/s.sh ~/repo`, `kobe theme import ~/theme.json`, and `kobe api --repo ~/repo` all resolved to a bogus `<cwd>/~/repo` path that failed the downstream git/file checks with a confusing "not a git repository / file not found" error. These entry points now expand `~` / `~/…` (honouring `KOBE_HOME_DIR`) before resolving relative paths against the current directory, so `~`-relative paths work the same as absolute ones.

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -43,6 +43,7 @@ import { resolve } from "node:path"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { interactiveEngineCommand } from "../engine/interactive-command.ts"
 import { DEFAULT_FEEDBACK_CATEGORY_SLUG, submitFeedback } from "../lib/feedback.ts"
+import { expandTilde } from "../lib/path-home.ts"
 import type { EngineLaunchInit, PromptDeliveryIntent } from "../state/repo-init.ts"
 import { killSession, sessionExists, switchClientBeforeKill, tmuxSessionName } from "../tmux/client.ts"
 import { pasteAndSubmit, waitForEnginePane } from "../tmux/prompt-delivery.ts"
@@ -652,15 +653,15 @@ class VerbArgs {
     return n
   }
 
-  /** Optional PATH flag resolved against $PWD. */
+  /** Optional PATH flag resolved against $PWD (with a leading `~` expanded first). */
   path(name: string): string | undefined {
     const v = this.str(name)
-    return v === undefined ? undefined : resolve(process.cwd(), v)
+    return v === undefined ? undefined : resolve(process.cwd(), expandTilde(v))
   }
 
-  /** Required PATH flag resolved against $PWD. */
+  /** Required PATH flag resolved against $PWD (with a leading `~` expanded first). */
   requirePath(name: string): string {
-    return resolve(process.cwd(), this.require(name))
+    return resolve(process.cwd(), expandTilde(this.require(name)))
   }
 }
 

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -40,6 +40,7 @@
  */
 import { resolve } from "node:path"
 import { matchPathGlob } from "../lib/path-glob.ts"
+import { expandTilde } from "../lib/path-home.ts"
 import { ALL_VENDORS, type VendorId, coerceVendorId } from "../types/vendor.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 import { topLevelUsage } from "./usage.ts"
@@ -65,7 +66,7 @@ async function runAddSubcommand(rest: readonly string[]): Promise<void> {
     process.stderr.write(`kobe add: unknown flag "${arg}"\n\n${ADD_USAGE}`)
     process.exit(2)
   }
-  const target = resolve(process.cwd(), arg && arg.length > 0 ? arg : ".")
+  const target = resolve(process.cwd(), expandTilde(arg && arg.length > 0 ? arg : "."))
   const { addSavedRepo, isGitRepo } = await import("../state/repos.ts")
   // A saved project must be a real local git repository — reject garbage
   // paths (e.g. `kobe add ,`, which resolves to a non-existent dir) before
@@ -130,7 +131,7 @@ async function runRemoveSubcommand(rest: readonly string[]): Promise<void> {
   const target = saved.includes(raw)
     ? raw
     : (() => {
-        const abs = resolve(process.cwd(), raw)
+        const abs = resolve(process.cwd(), expandTilde(raw))
         const top = resolveRepoRoot(abs)
         if (saved.includes(top)) return top
         if (saved.includes(abs)) return abs
@@ -285,7 +286,7 @@ async function runAdoptSubcommand(args: readonly string[]): Promise<void> {
   }
 
   const { resolveRepoRoot } = await import("../state/repos.ts")
-  const repo = resolveRepoRoot(resolve(process.cwd(), repoArg && repoArg.length > 0 ? repoArg : "."))
+  const repo = resolveRepoRoot(resolve(process.cwd(), expandTilde(repoArg && repoArg.length > 0 ? repoArg : ".")))
   const vendor = coerceVendorId(vendorArg)
 
   // Discovery is a local read (git + tasks.json) — no daemon needed, so

--- a/packages/kobe/src/cli/repo-cmd.ts
+++ b/packages/kobe/src/cli/repo-cmd.ts
@@ -11,6 +11,7 @@
 
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
+import { expandTilde } from "../lib/path-home.ts"
 
 const REPO_USAGE = [
   "Usage: kobe repo <show|set|unset> [path] [options]",
@@ -40,7 +41,7 @@ function usageError(message: string): never {
 
 function readArgFile(path: string): string {
   try {
-    return readFileSync(resolve(process.cwd(), path), "utf8")
+    return readFileSync(resolve(process.cwd(), expandTilde(path)), "utf8")
   } catch (err) {
     usageError(`cannot read ${path}: ${err instanceof Error ? err.message : String(err)}`)
   }
@@ -106,7 +107,7 @@ export async function runRepoSubcommand(args: readonly string[]): Promise<void> 
 
   if (verb === "show") {
     const [pathArg] = rest.filter((a) => !a.startsWith("-"))
-    const repo = resolveRepoRoot(resolve(process.cwd(), pathArg ?? "."))
+    const repo = resolveRepoRoot(resolve(process.cwd(), expandTilde(pathArg ?? ".")))
     const override = getRepoInitOverride(repo)
     const hasFileScript = existsSync(join(repo, ".kobe", "init.sh"))
     const hasFilePrompt = existsSync(join(repo, ".kobe", "init-prompt.md"))
@@ -123,7 +124,7 @@ export async function runRepoSubcommand(args: readonly string[]): Promise<void> 
     if (flags.initScript === undefined && flags.initPrompt === undefined) {
       usageError("set needs at least one of --init-script(-file) / --init-prompt(-file)")
     }
-    const repo = resolveRepoRoot(resolve(process.cwd(), flags.path ?? "."))
+    const repo = resolveRepoRoot(resolve(process.cwd(), expandTilde(flags.path ?? ".")))
     const next = setRepoInitOverride(repo, {
       ...(flags.initScript !== undefined ? { initScript: flags.initScript } : {}),
       ...(flags.initPrompt !== undefined ? { initPrompt: flags.initPrompt } : {}),
@@ -136,7 +137,7 @@ export async function runRepoSubcommand(args: readonly string[]): Promise<void> 
 
   if (verb === "unset") {
     const { path, clearScript, clearPrompt } = parseUnsetArgs(rest)
-    const repo = resolveRepoRoot(resolve(process.cwd(), path ?? "."))
+    const repo = resolveRepoRoot(resolve(process.cwd(), expandTilde(path ?? ".")))
     const next = setRepoInitOverride(repo, {
       ...(clearScript ? { initScript: "" } : {}),
       ...(clearPrompt ? { initPrompt: "" } : {}),

--- a/packages/kobe/src/cli/theme.ts
+++ b/packages/kobe/src/cli/theme.ts
@@ -23,6 +23,7 @@
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs"
 import { basename, join, resolve } from "node:path"
+import { expandTilde } from "../lib/path-home.ts"
 import { userThemesDir } from "../tui/context/theme/loader"
 import { validateTheme } from "../tui/context/theme/schema"
 
@@ -128,7 +129,7 @@ async function readSource(source: string): Promise<{ text: string; defaultName: 
     const defaultName = file.endsWith(".json") ? file.slice(0, -".json".length) : file
     return { text, defaultName }
   }
-  const abs = resolve(process.cwd(), source)
+  const abs = resolve(process.cwd(), expandTilde(source))
   let text: string
   try {
     text = readFileSync(abs, "utf8")

--- a/packages/kobe/src/lib/path-home.ts
+++ b/packages/kobe/src/lib/path-home.ts
@@ -1,0 +1,24 @@
+/**
+ * Neutral `~` (home directory) expansion for CLI path arguments.
+ *
+ * Shells expand a leading `~` before a program ever sees it, but only for
+ * *unquoted* words — `kobe add "~/repo"`, a `~` typed into a prompt, or a
+ * path forwarded from another tool all reach us verbatim. `resolve()`
+ * treats that `~` as an ordinary path segment, so `resolve(cwd, "~/repo")`
+ * yields `<cwd>/~/repo` — a bogus directory that fails every downstream
+ * git / fs check. Expand it first, then let the caller resolve relative
+ * paths against `$PWD` as usual.
+ *
+ * `homeDir()` (not `os.homedir()`) so this honours `KOBE_HOME_DIR`, matching
+ * `normalizeWorktreeBase` and keeping tests isolated to a tmp home. Only a
+ * bare `~` and `~/…` are expanded — `~user/` lookups are rare and left
+ * untouched, same as the TUI's `expandHome`.
+ */
+import { join } from "node:path"
+import { homeDir } from "../env.ts"
+
+export function expandTilde(path: string): string {
+  if (path === "~") return homeDir()
+  if (path.startsWith("~/")) return join(homeDir(), path.slice(2))
+  return path
+}

--- a/packages/kobe/test/lib/path-home.test.ts
+++ b/packages/kobe/test/lib/path-home.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for CLI `~` expansion.
+ *
+ * The CLI's path arguments (`kobe add ~/repo`, `kobe api --repo ~/repo`,
+ * `kobe repo set --init-script-file ~/s.sh`, …) reach us verbatim when the
+ * `~` is quoted or forwarded from another tool. `expandTilde` turns a
+ * leading `~` / `~/` into the (KOBE_HOME_DIR-aware) home directory so the
+ * later `resolve(cwd, …)` can't produce a bogus `<cwd>/~/repo` path.
+ */
+
+import path from "node:path"
+import { resolve } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { expandTilde } from "../../src/lib/path-home.ts"
+
+let prevHome: string | undefined
+const HOME = path.join(path.sep, "tmp", "kobe-home-fixture")
+
+beforeEach(() => {
+  prevHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = HOME
+})
+
+afterEach(() => {
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = prevHome
+})
+
+describe("expandTilde", () => {
+  test("expands a bare `~` to the home directory", () => {
+    expect(expandTilde("~")).toBe(HOME)
+  })
+
+  test("expands a `~/…` prefix, joining the remainder onto home", () => {
+    expect(expandTilde("~/myrepo")).toBe(path.join(HOME, "myrepo"))
+    expect(expandTilde("~/a/b/c")).toBe(path.join(HOME, "a", "b", "c"))
+  })
+
+  test("leaves absolute and relative paths untouched", () => {
+    expect(expandTilde("/abs/path")).toBe("/abs/path")
+    expect(expandTilde("relative/path")).toBe("relative/path")
+    expect(expandTilde(".")).toBe(".")
+    expect(expandTilde("")).toBe("")
+  })
+
+  test("does not expand `~user` (no username lookup)", () => {
+    expect(expandTilde("~user/repo")).toBe("~user/repo")
+    expect(expandTilde("~-foo")).toBe("~-foo")
+  })
+
+  test("only a *leading* `~` is special — an interior `~` is literal", () => {
+    expect(expandTilde("a/~/b")).toBe("a/~/b")
+    expect(expandTilde("foo~bar")).toBe("foo~bar")
+  })
+
+  test("the regression: resolving a quoted `~/repo` no longer yields `<cwd>/~/repo`", () => {
+    const cwd = "/some/cwd"
+    // Before the fix, `resolve(cwd, "~/repo")` produced `/some/cwd/~/repo`.
+    expect(resolve(cwd, expandTilde("~/repo"))).toBe(path.join(HOME, "repo"))
+    expect(resolve(cwd, expandTilde("~/repo"))).not.toContain("~")
+  })
+})


### PR DESCRIPTION
## Direction

Bugs / correctness — found during a code-health review of CLI path handling (cross-checked against an exploration pass over `src/cli` + `src/state`).

## Problem

The shell only expands `~` for **unquoted** words. When the `~` is quoted (`kobe add "~/repo"`), typed into a prompt, or forwarded from another tool, it reaches kobe verbatim. Every local-path CLI entry point resolved it with `resolve(process.cwd(), arg)`, which treats `~` as an ordinary path segment — so the input became a bogus `<cwd>/~/repo` directory that then failed the downstream git/fs checks with a confusing *"not a git repository"* / *"file not found"* error.

Affected commands (all resolved `~` incorrectly):

- `kobe add ~/repo`, `kobe remove ~/repo`, `kobe adopt ~/repo`
- `kobe repo show/set/unset ~/repo` and the `--init-script-file ~/s.sh` / `--init-prompt-file ~/p.md` flags
- `kobe theme import ~/theme.json` (local-file branch)
- `kobe api --repo ~/repo` (and every other PATH flag via `VerbArgs.path()` / `requirePath()`)

The codebase already expanded `~` correctly for the TUI (`src/tui/lib/path-helpers.ts` `expandHome`) and for the worktree base override (`src/state/worktree-base.ts` `normalizeWorktreeBase`) — the CLI arg-parsing layer was the one place it was missing.

## Fix

- New neutral helper `src/lib/path-home.ts` → `expandTilde(path)`: expands a bare `~` and a `~/…` prefix to the home directory, leaves absolute/relative/`~user` paths untouched. It uses `homeDir()` (so it honours `KOBE_HOME_DIR`), matching `normalizeWorktreeBase` and keeping tests isolated to a tmp home. Placed in `src/lib/` (not `src/tui/`) so the CLI doesn't reach up into the TUI layer.
- Routed all ten local-path CLI resolution sites through `expandTilde(...)` before `resolve(process.cwd(), ...)`. Remote (SSH) paths in `kobe add --remote` are intentionally left untouched — that `~` is resolved on the remote host, not locally.

## Verification

- `bun run lint` ✓ · `bun run typecheck` ✓
- New unit test `test/lib/path-home.test.ts` (bare `~`, `~/…`, absolute/relative pass-through, `~user` left alone, interior `~` literal, and the `<cwd>/~/repo` regression).
- Full fast suite green: **1255 tests passed** (`vitest run`).

## Follow-ups

- None required. If desired, a future pass could add a shared note so the TUI's `expandHome` and this CLI `expandTilde` converge on one home policy, but they intentionally differ today (`os.homedir()` vs `KOBE_HOME_DIR`-aware) and unifying them would change TUI behavior — out of scope for this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASXXmPS5qp8HVpkiCEaFfd)_


---
file-size-exemption: api-cmd.ts (1349) / cli/index.ts (883) are pre-existing oversize CLI entry files; this PR adds ~1 line to each call site.
coverage-exemption: cli/index.ts / repo-cmd.ts / theme.ts read 0% because their coverage lives in the subprocess behavior suite which v8 cannot attribute — gate blind spot tracked in the daemon issue store; the new logic itself is unit-tested (test/lib/path-home.test.ts).
