### PR TITLE
chore: ponytail over-engineering cleanup (dead code + structural refactors)

### DIFF
--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -348,9 +348,6 @@ export interface SessionDeliverPayload {
 /** The `ui-prefs` channel payload — the persisted visual prefs snapshot. */
 export type UiPrefsPayload = ChannelPayloads["ui-prefs"]
 
-/** The `task.jobs` channel payload — long-operation lifecycle progress. */
-export type TaskJobsPayload = ChannelPayloads["task.jobs"]
-
 /** The `worktree.changes` channel payload — daemon-collected change counts. */
 export type WorktreeChangesPayload = ChannelPayloads["worktree.changes"]
 

--- a/packages/kobe-web/src/lib/api-client.ts
+++ b/packages/kobe-web/src/lib/api-client.ts
@@ -58,36 +58,13 @@ export function apiUrl(path: string, query?: QueryParams): string {
 async function readPayload(
   res: Response,
 ): Promise<{ json?: unknown; text: string }> {
-  const response = res as Response & {
-    text?: () => Promise<string>
-    json?: () => Promise<unknown>
+  const text = await res.text().catch(() => "")
+  if (!text) return { text }
+  try {
+    return { text, json: JSON.parse(text) }
+  } catch {
+    return { text }
   }
-  if (typeof response.text === "function") {
-    const text = await response.text().catch(() => "")
-    if (!text) {
-      if (typeof response.json === "function") {
-        try {
-          return { text, json: await response.json() }
-        } catch {
-          return { text }
-        }
-      }
-      return { text }
-    }
-    try {
-      return { text, json: JSON.parse(text) }
-    } catch {
-      return { text }
-    }
-  }
-  if (typeof response.json === "function") {
-    try {
-      return { text: "", json: await response.json() }
-    } catch {
-      return { text: "" }
-    }
-  }
-  return { text: "" }
 }
 
 function errorDetail(payload: { json?: unknown; text: string }): {

--- a/packages/kobe-web/src/lib/diff.ts
+++ b/packages/kobe-web/src/lib/diff.ts
@@ -21,8 +21,6 @@ export interface DiffFile {
 
 export interface DiffResult {
   files: DiffFile[]
-  /** Concatenated staged + unstaged raw diff (whole worktree). */
-  raw: string
 }
 
 /** Options that narrow what the diff route has to compute server-side. */
@@ -61,5 +59,5 @@ export async function fetchDiff(
     },
     label: "diff fetch",
   })
-  return { files: json.files ?? [], raw: json.raw ?? "" }
+  return { files: json.files ?? [] }
 }

--- a/packages/kobe-web/src/lib/notify.ts
+++ b/packages/kobe-web/src/lib/notify.ts
@@ -15,23 +15,14 @@ import { useSyncExternalStore } from "react"
 import type { ActivityState } from "./types.ts"
 
 const ENABLED_KEY = "kobe-web.notify"
-
-/** The notification categories a user can toggle independently. They fire only
- *  when the master switch is on; default ON so an upgrade keeps every ping.
- *  (PR-transition notifications were removed in the web redesign, leaving the
- *  engine-attention category — the per-event-toggle machinery stays so adding
- *  another category later is a one-line change.) */
-export type NotifyCategory = "engine"
-const CATEGORY_KEYS: Record<NotifyCategory, string> = {
-  engine: "kobe-web.notify.engine",
-}
+const ENGINE_KEY = "kobe-web.notify.engine"
 
 type Navigate = (taskId: string) => void
 let navigate: Navigate | null = null
 let enabled = readEnabled()
-let categories: Record<NotifyCategory, boolean> = {
-  engine: readCategory("engine"),
-}
+// Engine-attention is the only notification category (PR-transition pings were
+// removed in the web redesign). Read once; defaults ON so an upgrade keeps it.
+const engineEnabled = readEngineEnabled()
 const listeners = new Set<() => void>()
 
 function readEnabled(): boolean {
@@ -42,10 +33,9 @@ function readEnabled(): boolean {
   }
 }
 
-/** A category defaults ON when unset (an upgrade keeps current behavior). */
-function readCategory(category: NotifyCategory): boolean {
+function readEngineEnabled(): boolean {
   try {
-    return localStorage.getItem(CATEGORY_KEYS[category]) !== "0"
+    return localStorage.getItem(ENGINE_KEY) !== "0"
   } catch {
     return true
   }
@@ -117,8 +107,6 @@ export interface NotifyState {
   permission: NotificationPermission
   /** The user has turned the feature on (and granted permission). */
   enabled: boolean
-  /** Per-event-type toggles (only meaningful while `enabled`). */
-  categories: Record<NotifyCategory, boolean>
 }
 
 function permission(): NotificationPermission {
@@ -132,7 +120,6 @@ function snapshot(): NotifyState {
     supported: typeof Notification !== "undefined",
     permission: permission(),
     enabled: enabled && permission() === "granted",
-    categories,
   }
 }
 
@@ -142,8 +129,7 @@ function getSnapshot(): NotifyState {
   if (
     next.supported !== cached.supported ||
     next.permission !== cached.permission ||
-    next.enabled !== cached.enabled ||
-    next.categories !== cached.categories
+    next.enabled !== cached.enabled
   ) {
     cached = next
   }
@@ -166,19 +152,6 @@ export async function setNotificationsEnabled(on: boolean): Promise<void> {
   enabled = on
   try {
     localStorage.setItem(ENABLED_KEY, on ? "1" : "0")
-  } catch {
-    /* ignore */
-  }
-  notify()
-}
-
-/** Toggle one event category (engine attention / PR updates). Persisted; the
- *  master switch still gates everything. */
-export function setNotifyCategory(category: NotifyCategory, on: boolean): void {
-  // New object so getSnapshot's identity check sees the change.
-  categories = { ...categories, [category]: on }
-  try {
-    localStorage.setItem(CATEGORY_KEYS[category], on ? "1" : "0")
   } catch {
     /* ignore */
   }
@@ -216,7 +189,7 @@ export function notifyEngineTransition(
       enabled,
       permission: permission(),
       hidden,
-      engineEnabled: categories.engine,
+      engineEnabled,
     })
   )
     return

--- a/packages/kobe-web/src/lib/tab-kinds.ts
+++ b/packages/kobe-web/src/lib/tab-kinds.ts
@@ -26,10 +26,9 @@ export type WorkspaceTabKind =
 type TitleMode =
   /** `${label} N`, where N = (existing tabs of this kind) + 1. */
   | "count"
-  /** the fixed label. */
+  /** the fixed label — callers that derive their own title (e.g. file, from
+   *  its path) start from this label and override it afterward. */
   | "static"
-  /** the caller supplies the title (file: derived from its path). */
-  | "derived"
 
 interface TabKindSpec {
   /** Owns a server-side PTY — closing/pruning the tab must close that PTY. */
@@ -43,7 +42,7 @@ export const TAB_KINDS: Record<WorkspaceTabKind, TabKindSpec> = {
   vendor: { hasPty: true, titleMode: "count", label: "Vendor" },
   terminal: { hasPty: true, titleMode: "count", label: "Terminal" },
   transcript: { hasPty: false, titleMode: "static", label: "Chat" },
-  file: { hasPty: false, titleMode: "derived", label: "File" },
+  file: { hasPty: false, titleMode: "static", label: "File" },
 }
 
 /**
@@ -57,8 +56,9 @@ export function tabHasPty(kind: WorkspaceTabKind): boolean {
 
 /**
  * The title for a fresh tab of `kind`, given the task's existing tabs (for the
- * per-kind count). `derived`-titled kinds (file) return their bare label — the
- * caller titles those from their own data (e.g. the file basename).
+ * per-kind count). `static`-titled kinds return their bare label — kinds that
+ * derive a title (file) start from that label and override it from their own
+ * data (e.g. the file basename).
  */
 export function nextTabTitle(
   kind: WorkspaceTabKind,

--- a/packages/kobe-web/src/lib/terminal.ts
+++ b/packages/kobe-web/src/lib/terminal.ts
@@ -9,16 +9,11 @@ import { ApiError, api } from "./api-client.ts"
 
 export type PtyMode = "engine" | "shell"
 
-function ptyOrigin(): string {
-  const proto = location.protocol === "https:" ? "wss" : "ws"
-  const host = location.hostname || "localhost"
-  const currentPort = Number.parseInt(location.port || "5173", 10)
-  const ptyPort = Number.isFinite(currentPort) ? currentPort + 2 : 5175
-  return `${proto}://${host}:${ptyPort}`
-}
-
-function ptyHttpOrigin(): string {
-  const proto = location.protocol === "https:" ? "https" : "http"
+/** PTY sidecar origin (port + 2). `ws` picks ws/wss; `http` picks http/https. */
+function ptyBase(kind: "ws" | "http"): string {
+  const secure = location.protocol === "https:"
+  const proto =
+    kind === "ws" ? (secure ? "wss" : "ws") : secure ? "https" : "http"
   const host = location.hostname || "localhost"
   const currentPort = Number.parseInt(location.port || "5173", 10)
   const ptyPort = Number.isFinite(currentPort) ? currentPort + 2 : 5175
@@ -39,14 +34,14 @@ export function ptyUrl(
     cols: String(cols),
     rows: String(rows),
   })
-  return `${ptyOrigin()}/pty?${q.toString()}`
+  return `${ptyBase("ws")}/pty?${q.toString()}`
 }
 
 /** Kill a tab's engine process server-side (when the user closes the tab). */
 export async function closePtyTab(tabId: string): Promise<void> {
   try {
     await api.post<void>(
-      `${ptyHttpOrigin()}/pty/close`,
+      `${ptyBase("http")}/pty/close`,
       { tab: tabId },
       { label: "close PTY tab" },
     )
@@ -70,7 +65,7 @@ export async function sendPtyText(
 ): Promise<{ spawned: boolean }> {
   try {
     const json = await api.post<{ sent?: boolean; spawned?: boolean }>(
-      `${ptyHttpOrigin()}/pty/send`,
+      `${ptyBase("http")}/pty/send`,
       { tab: tabId, taskId, text },
       { label: "send PTY text" },
     )

--- a/packages/kobe-web/test/diff-client.test.ts
+++ b/packages/kobe-web/test/diff-client.test.ts
@@ -9,11 +9,9 @@ import { fetchDiff } from "../src/lib/diff.ts"
 function mockFetch(impl: (url: string) => { ok: boolean; body: unknown }) {
   vi.stubGlobal("fetch", (url: string) => {
     const { ok, body } = impl(url)
-    return Promise.resolve({
-      ok,
-      status: ok ? 200 : 500,
-      json: () => Promise.resolve(body),
-    } as Response)
+    return Promise.resolve(
+      new Response(JSON.stringify(body), { status: ok ? 200 : 500 }),
+    )
   })
 }
 
@@ -24,7 +22,7 @@ describe("fetchDiff", () => {
     let seen = ""
     mockFetch((url) => {
       seen = url
-      return { ok: true, body: { files: [], raw: "" } }
+      return { ok: true, body: { files: [] } }
     })
     await fetchDiff("/abs/wt")
     expect(seen).toContain("worktreePath=%2Fabs%2Fwt")
@@ -36,16 +34,16 @@ describe("fetchDiff", () => {
     let seen = ""
     mockFetch((url) => {
       seen = url
-      return { ok: true, body: { files: [], raw: "" } }
+      return { ok: true, body: { files: [] } }
     })
     await fetchDiff("/wt", { namesOnly: true, path: "src/a.ts" })
     expect(seen).toContain("namesOnly=1")
     expect(seen).toContain("path=src%2Fa.ts")
   })
 
-  it("normalizes a sparse response to files[] + raw", async () => {
+  it("normalizes a sparse response to files[]", async () => {
     mockFetch(() => ({ ok: true, body: {} }))
-    expect(await fetchDiff("/wt")).toEqual({ files: [], raw: "" })
+    expect(await fetchDiff("/wt")).toEqual({ files: [] })
   })
 
   it("throws the server error message on a JSON error", async () => {

--- a/packages/kobe-web/test/fetch-diff.test.ts
+++ b/packages/kobe-web/test/fetch-diff.test.ts
@@ -2,14 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { fetchDiff } from "../src/lib/diff.ts"
 
 /** Capture the URL fetchDiff builds and return a canned diff payload. */
-function stubFetch(payload: unknown = { files: [], raw: "" }, ok = true) {
+function stubFetch(payload: unknown = { files: [] }, ok = true) {
   const calls: string[] = []
   const fetchMock = vi.fn(async (url: string | URL | Request) => {
     calls.push(String(url))
-    return {
-      ok,
-      json: async () => payload,
-    } as unknown as Response
+    return new Response(JSON.stringify(payload), { status: ok ? 200 : 500 })
   })
   vi.stubGlobal("fetch", fetchMock)
   return { calls }
@@ -48,11 +45,10 @@ describe("fetchDiff query construction", () => {
   })
 
   it("normalizes a partial/forward-compat payload to the full result shape", async () => {
-    // A namesOnly response may omit patches/raw; fetchDiff fills defaults so
-    // callers always get { files, raw }.
+    // A namesOnly response may omit patches; fetchDiff fills defaults so
+    // callers always get { files }.
     stubFetch({ files: [{ path: "a", status: "added", staged: false, patch: "" }] })
     const result = await fetchDiff("/abs/wt", { namesOnly: true })
-    expect(result.raw).toBe("")
     expect(result.files).toHaveLength(1)
     expect(result.files[0].path).toBe("a")
   })

--- a/packages/kobe-web/test/notes-history-client.test.ts
+++ b/packages/kobe-web/test/notes-history-client.test.ts
@@ -21,12 +21,8 @@ function mockFetch(resp: Resp | ((url: string) => Resp)) {
   vi.stubGlobal("fetch", (url: string, init?: RequestInit) => {
     lastReq = { url, init }
     const r = typeof resp === "function" ? resp(url) : resp
-    return Promise.resolve({
-      ok: r.ok,
-      status: r.status ?? (r.ok ? 200 : 500),
-      json: () => Promise.resolve(r.json ?? {}),
-      text: () => Promise.resolve(r.text ?? ""),
-    } as Response)
+    const body = r.text ?? (r.json !== undefined ? JSON.stringify(r.json) : "")
+    return Promise.resolve(new Response(body, { status: r.status ?? (r.ok ? 200 : 500) }))
   })
 }
 

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -490,7 +490,6 @@ const VERBS: readonly VerbSpec[] = [
 
 /** Verb names in canonical order (schema/help/tests). */
 export const API_VERBS = VERBS.map((v) => v.name)
-export type ApiVerb = (typeof API_VERBS)[number]
 
 function findVerb(name: string): VerbSpec | undefined {
   const canonical = VERB_ALIASES[name] ?? name

--- a/packages/kobe/src/cli/subcommands.ts
+++ b/packages/kobe/src/cli/subcommands.ts
@@ -32,5 +32,3 @@ export const TOP_LEVEL_SUBCOMMANDS = [
   "reload",
   "kill-sessions",
 ] as const
-
-export type TopLevelSubcommand = (typeof TOP_LEVEL_SUBCOMMANDS)[number]

--- a/packages/kobe/src/cli/theme.ts
+++ b/packages/kobe/src/cli/theme.ts
@@ -23,7 +23,6 @@
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs"
 import { basename, join, resolve } from "node:path"
-import { kobeStateDir } from "../env"
 import { userThemesDir } from "../tui/context/theme/loader"
 import { validateTheme } from "../tui/context/theme/schema"
 
@@ -250,9 +249,6 @@ function printUsage(): void {
  * `kobe theme` on the command line.
  */
 export async function runThemeSubcommand(args: string[]): Promise<void> {
-  // Touch the state dir helper so tree-shakers don't drop it from
-  // bundled output when we add lazily-used callsites later.
-  void kobeStateDir
   const [action, ...rest] = args
   if (!action || action === "--help" || action === "-h" || action === "help") {
     printUsage()

--- a/packages/kobe/src/exec/exec-host.ts
+++ b/packages/kobe/src/exec/exec-host.ts
@@ -50,6 +50,7 @@
 import { spawn, spawnSync } from "node:child_process"
 import { existsSync } from "node:fs"
 import { mkdir, readFile as readFileAsync, readdir as readdirAsync } from "node:fs/promises"
+import { quoteShellArg, quoteShellArgv } from "../lib/shell-command"
 
 /** SSH auth: a key (or the agent) vs a password held in the OS keychain. */
 export type RemoteAuth =
@@ -128,21 +129,17 @@ export interface ExecHost {
 
 // ── pure shell / ssh construction (exported for tests) ───────────────────────
 
-/** Single-quote a string for a POSIX shell (`'` → `'\''`). */
-export function shQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`
-}
+/** Single-quote a string for a POSIX shell — the shared {@link quoteShellArg}. */
+export const shQuote = quoteShellArg
+
+/** Quote each argv element and join — the shared {@link quoteShellArgv}. */
+export const shJoin = quoteShellArgv
 
 /** Single-quote a token only if it contains characters that aren't safe to
  *  leave bare in a POSIX shell word. Keeps flags / `user@host` readable while
  *  still protecting paths with spaces or metachars. */
 export function shToken(s: string): string {
-  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : shQuote(s)
-}
-
-/** Quote each argv element and join — a safe command line for a POSIX shell. */
-export function shJoin(argv: readonly string[]): string {
-  return argv.map(shQuote).join(" ")
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(s) ? s : quoteShellArg(s)
 }
 
 /** The remote command string: `cd <cwd> && <argv>` (or just `<argv>` with no cwd). */

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -1,8 +1,5 @@
 import type { TaskStatus } from "../types/task.ts"
 
-/** Maximum simultaneous `in_progress` tasks. From DESIGN §11.5. */
-export const CONCURRENCY_CAP = 20
-
 /** Thrown when a state-machine transition is illegal. */
 export class IllegalTransitionError extends Error {
   constructor(
@@ -12,14 +9,6 @@ export class IllegalTransitionError extends Error {
   ) {
     super(`illegal transition for task ${taskId}: ${from} -> ${to}`)
     this.name = "IllegalTransitionError"
-  }
-}
-
-/** Thrown when we'd exceed {@link CONCURRENCY_CAP}. */
-export class ConcurrencyCapError extends Error {
-  constructor() {
-    super(`concurrency cap reached: ${CONCURRENCY_CAP} tasks running`)
-    this.name = "ConcurrencyCapError"
   }
 }
 

--- a/packages/kobe/src/tmux/clipboard.ts
+++ b/packages/kobe/src/tmux/clipboard.ts
@@ -67,11 +67,6 @@ export const clipboardBinaryOnPath: ClipboardProbe = (binary) => {
   }
 }
 
-/** Convenience: resolve using the real PATH probe for the current platform. */
-export function resolveSystemClipboardCopyCommand(): string | null {
-  return resolveClipboardCopyCommand(process.platform, clipboardBinaryOnPath)
-}
-
 /** A single tmux command as the argv tuple `runTmuxSequence` consumes. */
 export type TmuxCommand = readonly string[]
 

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -258,11 +258,6 @@ export function engineTabExitCleanup(envPrefix: string, inv: readonly string[], 
   return `${envPrefix}${inv.map(shellQuote).join(" ")} engine-tab-exit --session ${shellQuote(session)}`
 }
 
-/** Single-quote a string for safe interpolation into a `sh -c` program. */
-function shQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`
-}
-
 /**
  * The kobe-home "no task" main pane — the welcome area to the right of the
  * Tasks rail in the home layout. Purely informational: the Tasks rail owns
@@ -272,7 +267,7 @@ function shQuote(s: string): string {
  */
 export function homeWelcomeCommand(): string {
   const msg = "\\n  No task selected\\n\\n  Press N to create a task, or pick one on the left.\\n\\n"
-  return `clear; printf ${shQuote(msg)}; exec "\${SHELL:-/bin/sh}"`
+  return `clear; printf ${shellQuote(msg)}; exec "\${SHELL:-/bin/sh}"`
 }
 
 export interface EngineInitLaunch {
@@ -396,8 +391,8 @@ export function engineLaunchLine(engineCmd: string, init?: EngineInitLaunch, onE
   // only covers from the engine command onward). Redundant with the tail's guard
   // for the no-init path — harmless, `trap` is idempotent.
   if (init?.markerPath) {
-    const marker = shQuote(init.markerPath)
-    const markerDir = shQuote(markerDirOf(init.markerPath))
+    const marker = shellQuote(init.markerPath)
+    const markerDir = shellQuote(markerDirOf(init.markerPath))
     return (
       SIGINT_GUARD +
       [

--- a/packages/kobe/src/tui/component/help-dialog.tsx
+++ b/packages/kobe/src/tui/component/help-dialog.tsx
@@ -44,9 +44,6 @@ import { type DialogContext, useDialog } from "../ui/dialog"
 // Users discover slashes natively inside the interactive `claude`
 // pane now. The dialog stays focused on kobe's own keybindings.
 
-/** Sentinel string the behavior test asserts on. */
-export const HELP_DIALOG_TITLE = "kobe — keybindings"
-
 /**
  * Group the flat keymap into categories in declaration order.
  */

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -64,8 +64,6 @@ export type SettingsRow =
   | { id: "dispatcher"; kind: "devDispatcher" }
   | { id: "archived-history"; kind: "devArchivedHistory" }
 
-export type SettingsRowKind = SettingsRow["kind"]
-
 /** Stable row ids for payload-bearing rows (shared by builders + views). */
 export function themeRowId(name: string): string {
   return `theme:${name}`

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -928,11 +928,6 @@ export function chordsOf(id: string): readonly string[] {
   return findBinding(id)?.keys ?? []
 }
 
-/** All bindings whose `scope` matches. */
-export function bindingsForScope(scope: KobeBindingScope): KobeBinding[] {
-  return KobeKeymap.filter((b) => b.scope === scope)
-}
-
 /**
  * Build a list of `Binding` (chord → handler) entries from a map of
  * `binding-id → handler`. Each id's chords from `KobeKeymap` get

--- a/packages/kobe/src/tui/context/notifications.tsx
+++ b/packages/kobe/src/tui/context/notifications.tsx
@@ -148,7 +148,3 @@ export function useNotifications(): NotificationsContext {
   if (!value) throw new Error("useNotifications must be used within a NotificationsProvider")
   return value
 }
-
-export function notificationKey(taskId: string, tabId: string): string {
-  return unreadKey(taskId, tabId)
-}

--- a/packages/kobe/src/tui/i18n/index.ts
+++ b/packages/kobe/src/tui/i18n/index.ts
@@ -63,11 +63,6 @@ export function t(key: string, params?: Record<string, string | number>): string
   return interpolate(resolved, params)
 }
 
-/** The label to show for a language id in the picker (e.g. `en` → "English"). */
-export function localeLabel(id: LocaleId): string {
-  return LOCALES.find((l) => l.id === id)?.label ?? id
-}
-
 /**
  * Lookup for the keybinding catalog (`keys.category.*` / `keys.desc.*`),
  * where the lookup key is itself a binding id like `chat.tab.new` whose dots

--- a/packages/kobe/src/tui/lib/keymap.tsx
+++ b/packages/kobe/src/tui/lib/keymap.tsx
@@ -76,11 +76,3 @@ export function useBindings(config: () => BindingsConfig): void {
     if (i >= 0) stack.splice(i, 1)
   })
 }
-
-/**
- * Hook for tests / debugging. Returns the number of currently active binding
- * groups in the stack.
- */
-export function _bindingStackSize(): number {
-  return stack.length
-}

--- a/packages/kobe/src/tui/panes/filetree/git.ts
+++ b/packages/kobe/src/tui/panes/filetree/git.ts
@@ -147,16 +147,6 @@ export async function statusFiles(worktreePath: string, signal?: AbortSignal): P
 }
 
 /**
- * Run `git diff HEAD --numstat` and parse into structured stats.
- * Useful as a primitive for callers that want raw numstat without the
- * porcelain status. Throws on non-zero exit (caller can wrap to soften).
- */
-export async function numstatFiles(worktreePath: string): Promise<NumstatEntry[]> {
-  const out = await runGit(["diff", "--no-color", "--numstat", "HEAD"], worktreePath)
-  return parseNumstat(out)
-}
-
-/**
  * Pure parser for `git diff --numstat` output, kept as the pane's typed
  * façade ({@link NumstatEntry}) over the shared {@link parseNumstatRows}.
  * The shared parser owns the hard parts — C-string unquoting and rename

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -308,21 +308,6 @@ function viewTabLabel(view: SidebarView): string {
 export const MAIN_BRANCH_POLL_MS = 2_000
 
 /**
- * Reserved width (cells) for the per-row "uncommitted changes" chip
- * (`+N −M`). Sized to fit the common `+9 −9` (5 cell) case exactly;
- * the chip is right-aligned inside the column so longer chips (e.g.
- * `+12 −3`, 6 char) extend slightly leftward toward the title rather
- * than cluttering the row's right edge with reserved padding. Even
- * longer chips (`+99 −99`, 7 char) clip on the left — rare in practice
- * and the right edge stays aligned, which is what the eye tracks.
- * Keeping the column reserved even when empty is the whole point of
- * this — the eye should land on the same x for every row's chip
- * regardless of how short or long the title above it is. Exported for
- * tests.
- */
-export const CHANGES_COLUMN_WIDTH = 5
-
-/**
  * Max width (cells) for a task row's branch label. The rail is narrow, so
  * a long branch is truncated keeping its PREFIX (`feat/long-branch…`) —
  * the front of a branch name carries the type/scope the eye scans for,
@@ -334,21 +319,6 @@ export const BRANCH_LABEL_MAX = 16
 export function truncateBranchLabel(branch: string, max = BRANCH_LABEL_MAX): string {
   return truncateEnd(branch, max)
 }
-
-/**
- * Responsive column breakpoints (cells of total pane width). A task row packs
- * up to four columns — badge, title, the `+N −M` changes chip, and the branch
- * label. The branch (≤16 cells) + changes (5) are *metadata*; the title is the
- * primary content. On a narrow rail those metadata columns are `flexShrink={0}`
- * and would crush the title to a single character (`(new task)` → `(`), so we
- * drop them progressively as width shrinks: title-only first, then add the
- * changes chip, then the branch. The title always survives. Above the branch
- * breakpoint the full row shows. Tuned so the 32-cell convention width
- * ({@link SIDEBAR_WIDTH}) keeps the changes chip but hides the branch, leaving
- * a comfortable title budget; widen the pane and the branch returns.
- */
-export const SHOW_CHANGES_MIN_WIDTH = 30
-export const SHOW_BRANCH_MIN_WIDTH = 44
 
 /**
  * Rough display width in terminal cells, counting CJK / fullwidth codepoints
@@ -364,20 +334,6 @@ export function approxCellWidth(s: string): number {
 
 /** Truncate a filesystem path keeping the TAIL (the leaf carries the meaning). */
 const truncatePathTail = truncateStart
-
-/**
- * Abbreviate the user's home prefix to `~` for the project (main row)
- * directory label — `/Users/x/i/kobe` → `~/i/kobe`. Keeps the project
- * row's repo path compact and recognisable. Falls back to the raw path
- * when `$HOME` is unset or doesn't prefix the path.
- */
-export function abbrevHome(path: string): string {
-  const home = process.env.HOME
-  if (home && (path === home || path.startsWith(`${home}/`))) {
-    return `~${path.slice(home.length)}`
-  }
-  return path
-}
 
 export function Sidebar(props: SidebarProps) {
   const { theme } = useTheme()

--- a/packages/kobe/src/tui/ui/dialog.tsx
+++ b/packages/kobe/src/tui/ui/dialog.tsx
@@ -160,29 +160,20 @@ function init() {
     }, 1)
   }
 
+  // escape and ctrl+c both dismiss the top dialog identically.
+  const dismissTop = () => {
+    if (renderer?.getSelection()) renderer.clearSelection()
+    const current = store.stack.at(-1)
+    current?.onClose?.()
+    setStore("stack", store.stack.slice(0, -1))
+    refocus()
+  }
+
   useBindings(() => ({
     enabled: store.stack.length > 0 && !renderer?.getSelection()?.getSelectedText(),
     bindings: [
-      {
-        key: "escape",
-        cmd: () => {
-          if (renderer?.getSelection()) renderer.clearSelection()
-          const current = store.stack.at(-1)
-          current?.onClose?.()
-          setStore("stack", store.stack.slice(0, -1))
-          refocus()
-        },
-      },
-      {
-        key: "ctrl+c",
-        cmd: () => {
-          if (renderer?.getSelection()) renderer.clearSelection()
-          const current = store.stack.at(-1)
-          current?.onClose?.()
-          setStore("stack", store.stack.slice(0, -1))
-          refocus()
-        },
-      },
+      { key: "escape", cmd: dismissTop },
+      { key: "ctrl+c", cmd: dismissTop },
     ],
   }))
 


### PR DESCRIPTION
## Summary

Whole-repo over-engineering pass (ponytail-audit): remove dead code and collapse a few duplicated/over-general structures. **No behavior changes** — every commit is gated green (root typecheck + lint, kobe 1249 tests, kobe-web 570 tests).

**Dead code (batches 1–2)**
- 15 fully-orphaned exports with zero references anywhere (knip-flagged, re-verified repo-wide incl. tests): stale consts, a dead test/debug hook, delegate-only wrappers, unused type aliases.
- `ConcurrencyCapError` + `CONCURRENCY_CAP` (never thrown; the cap went away with the engine port), unreferenced `TaskJobsPayload` alias, and a `void kobeStateDir` tree-shake cargo-cult + its import.

**Structural refactors (batch 3)**
- Single-source POSIX shell quoting: exec-host `shQuote`/`shJoin` now reference `lib/shell-command`; session-layout's private `shQuote` deleted for its existing `shellQuote` (the `'`→`'\''` escape was hand-rolled 3×). `shToken` kept — wider bare-token set.
- kobe-web lib clients: drop write-only `DiffResult.raw`; fold `ptyOrigin`/`ptyHttpOrigin` → `ptyBase(kind)`; merge identical `TitleMode` variants; simplify `api-client.readPayload` (drop typeof-guards + a dead post-`text()` `json()` fallback).
- notify.ts: collapse the one-member category apparatus (zero-caller `setNotifyCategory`, `NotifyState.categories`, `CATEGORY_KEYS`…) to a single `engineEnabled` flag — same localStorage key + default-on semantics.
- Dialog: dedupe byte-identical `escape`/`ctrl+c` handlers. The `push`/`pop`/`stack` API is left intact (deliberate 1:1 opencode port).

Net: **-254 / +63** across 25 files.

## Deliberately not touched
Dialog stack (opencode parity), filetree barrel + `attention-nav.ts` / `PrChip.tsx` (whole-file deletions), test-entangled dead code (release-notes cluster, `deleteKeychainPassword`, `joinDrill`), `ExecHost.existsSync`/Spawner redesign (experimental remote code), and the `ws`/`node-pty` unused-dep question (native-addon red line). These need a judgment call.

## Test plan
- [x] `bun run typecheck` (root) — clean
- [x] `bun run lint` (root) — clean
- [x] kobe `test:fast` — 1249 pass
- [x] kobe-web `test` — 570 pass