### PR TITLE
refactor: cut the unreachable remote existsSync from ExecHost (ponytail C)

### DIFF
--- a/packages/kobe/src/exec/exec-host.ts
+++ b/packages/kobe/src/exec/exec-host.ts
@@ -24,12 +24,13 @@
  *
  *   The cheap/metadata members stay sync:
  *
- *     - `isRemote`, `wrapCommand` (pure string building), `ensureReady`
- *       (ControlMaster bring-up; sync ssh, see caveat below), and
- *     - `existsSync` — kept for sync TUI fast-paths (`worktreeUsable`) that
- *       already guard with `isRemote`. Locally it's `fs.existsSync` (cheap);
- *       REMOTELY it is a BLOCKING ssh round-trip — callers must short-circuit
- *       on `isRemote` first and only use it for local paths.
+ *     - `isRemote`, `wrapCommand` (pure string building), and `ensureReady`
+ *       (ControlMaster bring-up; sync ssh, see caveat below).
+ *
+ *   (A sync existence probe used to live here, but its only caller —
+ *   `worktreeUsable` — short-circuits on `isRemote` and so only ever needs a
+ *   LOCAL check; it now calls `fs.existsSync` directly, and no remote sync
+ *   existence round-trip exists.)
  *
  *   `ensureReady()` remains sync: it's called from TUI processes
  *   (tmux engine launch) and from `RemoteExecHost.run`'s first call per host
@@ -90,8 +91,7 @@ export interface ExecOpts {
  * ASYNC members (`run`, `exists`, `mkdirp`, `readFile`, `readdir`) are the
  * ones that do real subprocess / ssh / disk work — awaiting them keeps the
  * daemon's event loop free. SYNC members are metadata (`isRemote`), pure
- * string building (`wrapCommand`), the documented `existsSync` local
- * fast-path, and `ensureReady` (see file header).
+ * string building (`wrapCommand`), and `ensureReady` (see file header).
  */
 export interface ExecHost {
   readonly isRemote: boolean
@@ -99,12 +99,6 @@ export interface ExecHost {
   run(argv: readonly string[], opts?: ExecOpts): Promise<ExecResult>
   /** Whether `path` exists on the host. ASYNC (remote = ssh round-trip). */
   exists(path: string): Promise<boolean>
-  /**
-   * SYNC existence probe for local-path fast-paths (e.g. `worktreeUsable`).
-   * Local: `fs.existsSync` (cheap). Remote: a BLOCKING ssh round-trip —
-   * callers MUST short-circuit on `isRemote` before reaching this.
-   */
-  existsSync(path: string): boolean
   /** `mkdir -p`. ASYNC (remote = ssh round-trip). */
   mkdirp(path: string): Promise<void>
   /** Read a file as utf8, or null when unreadable. ASYNC. */
@@ -239,9 +233,6 @@ export class LocalExecHost implements ExecHost {
   async exists(path: string): Promise<boolean> {
     return existsSync(path)
   }
-  existsSync(path: string): boolean {
-    return existsSync(path)
-  }
   async mkdirp(path: string): Promise<void> {
     await mkdir(path, { recursive: true })
   }
@@ -269,7 +260,7 @@ export class LocalExecHost implements ExecHost {
 
 /**
  * Spawn seam so tests can assert the ssh argv without a real connection.
- * SYNC — used by `ensureReady` (ControlMaster bring-up) and `existsSync`.
+ * SYNC — used by `ensureReady` (ControlMaster bring-up).
  */
 export type Spawner = (argv: readonly string[], env?: Record<string, string>) => ExecResult
 
@@ -358,12 +349,6 @@ export class RemoteExecHost implements ExecHost {
 
   async exists(path: string): Promise<boolean> {
     return (await this.run(["test", "-e", path])).exitCode === 0
-  }
-  /** BLOCKING ssh round-trip — see the interface doc; guard with `isRemote`. */
-  existsSync(path: string): boolean {
-    this.ensureReady()
-    const r = this.spawn([...sshConnectArgs(this.spec, { batch: true }), remoteShellCommand(["test", "-e", path])])
-    return r.exitCode === 0
   }
   async mkdirp(path: string): Promise<void> {
     await this.run(["mkdir", "-p", path])

--- a/packages/kobe/src/exec/resolve.ts
+++ b/packages/kobe/src/exec/resolve.ts
@@ -10,6 +10,7 @@
  * the `repoConfigs` init-override discipline.
  */
 
+import { existsSync } from "node:fs"
 import { homeDir, remoteControlSocketPath } from "../env.ts"
 import { type RemoteRepoConfig, getRemoteRepoConfig, getRemoteRepos, isRemoteRepoKey } from "../state/repos.ts"
 import { type ExecHost, LocalExecHost, type RemoteAuth, RemoteExecHost, type RemoteSpec } from "./exec-host.ts"
@@ -85,11 +86,10 @@ export function remoteKeyForRepo(repo: string | undefined): string | undefined {
  * round-trip per render). Local paths keep the real on-disk check.
  */
 export function worktreeUsable(worktreePath: string): boolean {
-  const host = execHostForWorktreePath(worktreePath)
-  // `isRemote` short-circuits BEFORE `existsSync` — the sync probe is only
-  // ever evaluated for a LOCAL host (cheap fs.existsSync); a remote host's
-  // existsSync would be a blocking ssh round-trip and must not run here.
-  return host.isRemote || host.existsSync(worktreePath)
+  // `isRemote` short-circuits BEFORE the on-disk probe — a remote worktree is
+  // trusted (see above), and the cheap sync `fs.existsSync` only ever runs for
+  // a LOCAL path.
+  return execHostForWorktreePath(worktreePath).isRemote || existsSync(worktreePath)
 }
 
 /**

--- a/packages/kobe/test/exec/exec-host.test.ts
+++ b/packages/kobe/test/exec/exec-host.test.ts
@@ -215,8 +215,6 @@ describe("RemoteExecHost fs helpers", () => {
     await expect(host.exists("/srv/wt/.git")).resolves.toBe(true)
     await expect(host.readFile("/srv/wt/README.md")).resolves.toBe("file body")
     await expect(host.readdir("/srv/wt")).resolves.toEqual(["a", "b", ".git"])
-    // The documented-blocking sync probe goes through the same ssh wrapping.
-    expect(host.existsSync("/srv/wt/.git")).toBe(true)
   })
 })
 

--- a/packages/kobe/test/orchestrator/worktree-remote.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remote.test.ts
@@ -15,7 +15,6 @@ function fakeRemote(script: (argv: readonly string[]) => ExecResult) {
       return script(argv)
     },
     exists: async () => false,
-    existsSync: () => false,
     mkdirp: async () => {},
     readFile: async () => null,
     readdir: async () => [],

--- a/packages/kobe/test/worktree/content.test.ts
+++ b/packages/kobe/test/worktree/content.test.ts
@@ -16,7 +16,6 @@ function fakeExecHost(result: ExecResult = { stdout: "", stderr: "", exitCode: 0
       return result
     },
     exists: async () => false,
-    existsSync: () => false,
     mkdirp: async () => {},
     readFile: async (path) => {
       reads.push(path)
@@ -74,7 +73,6 @@ describe("runWorktreeGit", () => {
         return { stdout: "", stderr: "", exitCode: -1 }
       },
       exists: async () => false,
-      existsSync: () => false,
       mkdirp: async () => {},
       readFile: async () => null,
       readdir: async () => [],
@@ -101,7 +99,6 @@ describe("runWorktreeGit", () => {
         throw new Error("ssh failed")
       },
       exists: async () => false,
-      existsSync: () => false,
       mkdirp: async () => {},
       readFile: async () => null,
       readdir: async () => [],
@@ -143,7 +140,6 @@ describe("readWorktreeFile", () => {
       isRemote: true,
       run: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
       exists: async () => false,
-      existsSync: () => false,
       mkdirp: async () => {},
       readFile: async () => {
         throw new Error("read failed")


### PR DESCRIPTION
## Summary
- `ExecHost.existsSync` was a **sync** interface member documented as "callers MUST short-circuit on `isRemote` before reaching this." Its only caller, `worktreeUsable`, does exactly that (`host.isRemote || host.existsSync(...)`), so `RemoteExecHost.existsSync` (a blocking ssh round-trip) **never ran** — only `LocalExecHost`'s did.
- Remove `existsSync` from the interface and both implementations. `worktreeUsable` now calls node `fs.existsSync` directly for the local branch (the remote branch was already trusted without probing). Fake `ExecHost`s in the tests drop the member too.
- The sync `Spawner` seam is **kept** — `ensureReady` (ControlMaster bring-up) still needs it. This PR is scoped to the unreachable `existsSync` only, not the broader spawner redesign.

Last parked group-C item (follow-up to #194 / #195). Experimental remote-projects code; no behavior change on the local path.

## Test plan
- [x] `bun run typecheck` (root) — clean
- [x] `bun run lint` (root) — clean
- [x] kobe `test:fast` — 1249 pass (incl. exec-host + remote worktree suites)