### PR TITLE
test: dev:mock + browser UI e2e (Playwright drives the real TUI in the web xterm)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.5",
+        "@playwright/test": "^1.49.0",
         "@tailwindcss/typography": "^0.5.20",
         "@tanstack/devtools-vite": "latest",
         "@tanstack/router-plugin": "latest",
@@ -481,6 +482,8 @@
     "@oxc-resolver/binding-win32-arm64-msvc": ["@oxc-resolver/binding-win32-arm64-msvc@11.20.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA=="],
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.20.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@remotion/bundler": ["@remotion/bundler@4.0.482", "", { "dependencies": { "@remotion/media-parser": "4.0.482", "@remotion/studio": "4.0.482", "@remotion/studio-shared": "4.0.482", "@remotion/timeline-utils": "4.0.482", "@rspack/core": "1.7.11", "@rspack/plugin-react-refresh": "1.6.1", "css-loader": "7.1.4", "esbuild": "0.28.1", "react-refresh": "0.18.0", "remotion": "4.0.482", "style-loader": "4.0.0", "webpack": "5.105.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JlzZ38dLmL8Lb0YmOM2I7+j+VJAjrWi2GLDlxJS2c8vydslrFfaQaooNHEjECQcJyvpqFpskdsoX4FKBWUaQfQ=="],
 
@@ -1396,6 +1399,10 @@
 
     "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postcss-modules-extract-imports": ["postcss-modules-extract-imports@3.1.0", "", { "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q=="],
@@ -1849,6 +1856,8 @@
     "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "pkg-up/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss-modules-local-by-default/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 

--- a/packages/kobe-web/.gitignore
+++ b/packages/kobe-web/.gitignore
@@ -11,3 +11,9 @@ dist-ssr
 .vinxi
 __unconfig*
 todos.json
+
+# Playwright (UI e2e)
+/test-results/
+/playwright-report/
+/blob-report/
+/.playwright/

--- a/packages/kobe-web/e2e/global-teardown.ts
+++ b/packages/kobe-web/e2e/global-teardown.ts
@@ -1,0 +1,18 @@
+import { execSync } from "node:child_process"
+import { resolve } from "node:path"
+
+/**
+ * Kill any tmux sessions the dev:sandbox TUI left on the sandbox socket so they
+ * don't bleed into the next run (the tmux server persists across processes).
+ * No-op for dev:mock (no tmux) — the reset just finds nothing to kill.
+ */
+export default function globalTeardown(): void {
+  try {
+    execSync("bun run dev:sandbox:reset", {
+      cwd: resolve(import.meta.dirname, "../../kobe"),
+      stdio: "ignore",
+    })
+  } catch {
+    // Best-effort cleanup — never fail the run on teardown.
+  }
+}

--- a/packages/kobe-web/e2e/sandbox.spec.ts
+++ b/packages/kobe-web/e2e/sandbox.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test"
+
+/**
+ * Goal B — the FULL kobe TUI (dev:sandbox: real kobe + tmux + engine) driven
+ * through the web xterm. Run with KOBE_PTY_DEV_COMMAND="bun run dev:sandbox".
+ *
+ * Proves the whole product renders + responds over the browser terminal: brand
+ * header, the Tasks rail (PROJECTS / TASKS), the keys legend, and a live engine
+ * pane — all inside tmux inside the PTY inside xterm. tmux sessions are cleaned
+ * by the global teardown (dev:sandbox:reset) so runs don't bleed.
+ */
+test("full kobe TUI (dev:sandbox) renders + responds in the web xterm", async ({ page }) => {
+  test.skip(!process.env.KOBE_PTY_DEV_COMMAND?.includes("sandbox"), "dev:sandbox only")
+
+  await page.goto("/harness")
+  const rows = page.locator(".xterm-rows")
+  await expect(rows).toBeVisible({ timeout: 40_000 })
+
+  // Full kobe + tmux + engine cold start — the retrying matcher waits it out.
+  await expect(rows).toContainText("KOBE", { timeout: 45_000 })
+  await expect(rows).toContainText("PROJECTS")
+  await expect(rows).toContainText("TASKS")
+  // The Tasks-pane keys legend rendered (proves the rail, not just a bare shell).
+  await expect(rows).toContainText("new task")
+
+  // Drive it: focus the terminal and switch the sidebar view with `[`.
+  await page.locator(".xterm-helper-textarea").focus()
+  await page.keyboard.press("BracketLeft")
+  // Still the full TUI after input (didn't die on a key).
+  await expect(rows).toContainText("KOBE")
+})

--- a/packages/kobe-web/e2e/tui.spec.ts
+++ b/packages/kobe-web/e2e/tui.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test"
+
+/**
+ * Drives the real kobe TUI (dev:mock's live history preview) through the web
+ * xterm and asserts on the rendered terminal DOM. Proves the UI-layer e2e chain
+ * — browser → xterm → PTY → opentui TUI → keystrokes → visible output — works.
+ *
+ * Assertions target short, stable substrings (the LIVE header tag, a role
+ * label, the CJK seed line). DOM rows are viewport-only + cell-split, so we
+ * never assert exact layout. Timing is handled by Playwright's retrying
+ * matchers, never fixed sleeps (the TUI cold-starts in ~1-2s).
+ *
+ * No daemon runs, so `/api/themes` + `/events` 502 in the console — expected and
+ * harmless (the harness bypasses the daemon via the pty-server DEV override).
+ */
+test("mock live-history pane renders + responds to keys in the web terminal", async ({ page }) => {
+  await page.goto("/harness")
+
+  const rows = page.locator(".xterm-rows")
+  await expect(rows).toBeVisible()
+
+  // Header tag from the live preview (history/host.tsx liveTag = "● LIVE").
+  await expect(rows).toContainText("LIVE")
+  // A role label from the seeded transcript.
+  await expect(rows).toContainText("ASSISTANT")
+  // The CJK seed line — proves wide-glyph rendering round-trips through xterm.
+  await expect(rows).toContainText("预览")
+
+  // Drive it: focus the terminal, switch session with `[`, scroll with `j`.
+  await page.locator(".xterm-helper-textarea").focus()
+  await page.keyboard.press("BracketLeft")
+  await page.keyboard.press("j")
+  // Still a live pane after input (sanity — the process didn't die on a key).
+  await expect(rows).toContainText("LIVE")
+})

--- a/packages/kobe-web/e2e/tui.spec.ts
+++ b/packages/kobe-web/e2e/tui.spec.ts
@@ -14,6 +14,8 @@ import { expect, test } from "@playwright/test"
  * harmless (the harness bypasses the daemon via the pty-server DEV override).
  */
 test("mock live-history pane renders + responds to keys in the web terminal", async ({ page }) => {
+  test.skip(!!process.env.KOBE_PTY_DEV_COMMAND?.includes("sandbox"), "dev:mock only")
+
   await page.goto("/harness")
 
   const rows = page.locator(".xterm-rows")

--- a/packages/kobe-web/package.json
+++ b/packages/kobe-web/package.json
@@ -13,6 +13,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "format": "biome format",
     "lint": "biome lint",
     "check": "biome check"
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.5",
+    "@playwright/test": "^1.49.0",
     "@tailwindcss/typography": "^0.5.20",
     "@tanstack/devtools-vite": "latest",
     "@tanstack/router-plugin": "latest",

--- a/packages/kobe-web/playwright.config.ts
+++ b/packages/kobe-web/playwright.config.ts
@@ -1,0 +1,52 @@
+import { resolve } from "node:path"
+import { defineConfig } from "@playwright/test"
+
+/**
+ * UI-layer e2e: Playwright opens the SPA, an xterm on `/pty-harness` runs a real
+ * kobe TUI (dev:mock by default; dev:sandbox for the full tmux flow), and the
+ * test drives it with keystrokes + asserts on the rendered `.xterm-rows` DOM.
+ *
+ * webServer boots ONLY Vite (5173) + the PTY sidecar (5175) — no daemon needed,
+ * because the sidecar's KOBE_PTY_DEV_COMMAND override skips task/daemon spec
+ * resolution. The browser dials the sidecar on port+2 (5175) directly, so both
+ * ports are fixed. Override the TUI with KOBE_PTY_DEV_COMMAND=... to target
+ * dev:sandbox.
+ */
+
+// packages/kobe (holds the dev:mock / dev:sandbox scripts) is a sibling of kobe-web.
+const KOBE_DIR = resolve(import.meta.dirname, "../kobe")
+const DEV_COMMAND = process.env.KOBE_PTY_DEV_COMMAND ?? "bun run dev:mock"
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    baseURL: "http://localhost:5173",
+    viewport: { width: 1280, height: 800 },
+    trace: "retain-on-failure",
+  },
+  webServer: [
+    {
+      command: "bun run dev:vite",
+      port: 5173,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      // node-pty doesn't run under bun — the sidecar is a node process.
+      command: "node pty-server.mjs",
+      port: 5175,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        KOBE_PTY_DEV_CWD: KOBE_DIR,
+        KOBE_PTY_DEV_COMMAND: DEV_COMMAND,
+      },
+    },
+  ],
+})

--- a/packages/kobe-web/playwright.config.ts
+++ b/packages/kobe-web/playwright.config.ts
@@ -19,7 +19,8 @@ const DEV_COMMAND = process.env.KOBE_PTY_DEV_COMMAND ?? "bun run dev:mock"
 
 export default defineConfig({
   testDir: "./e2e",
-  timeout: 60_000,
+  globalTeardown: "./e2e/global-teardown.ts",
+  timeout: 90_000,
   expect: { timeout: 30_000 },
   fullyParallel: false,
   workers: 1,

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -39,6 +39,15 @@ function ptyEnv() {
 }
 
 async function fetchSpec(taskId, mode) {
+  // e2e/dev harness override: run an arbitrary TUI (dev:mock / dev:sandbox) in
+  // the PTY instead of resolving a task's engine via the daemon — so a Playwright
+  // test can drive the real TUI through the web terminal with no daemon or task.
+  if (process.env.KOBE_PTY_DEV_COMMAND) {
+    return {
+      cwd: process.env.KOBE_PTY_DEV_CWD ?? process.cwd(),
+      command: ["/bin/sh", "-lc", process.env.KOBE_PTY_DEV_COMMAND],
+    }
+  }
   const path = mode === "shell" ? "/api/terminal-spec" : "/api/engine-spec"
   const res = await fetch(`http://localhost:${DAEMON_WEB_PORT}${path}?taskId=${encodeURIComponent(taskId)}`)
   const json = await res.json()

--- a/packages/kobe-web/src/routeTree.gen.ts
+++ b/packages/kobe-web/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IssuesRouteImport } from './routes/issues'
+import { Route as HarnessRouteImport } from './routes/harness'
 import { Route as BoardRouteImport } from './routes/board'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TaskTaskIdRouteImport } from './routes/task.$taskId'
@@ -17,6 +18,11 @@ import { Route as TaskTaskIdRouteImport } from './routes/task.$taskId'
 const IssuesRoute = IssuesRouteImport.update({
   id: '/issues',
   path: '/issues',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HarnessRoute = HarnessRouteImport.update({
+  id: '/harness',
+  path: '/harness',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BoardRoute = BoardRouteImport.update({
@@ -38,12 +44,14 @@ const TaskTaskIdRoute = TaskTaskIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/board': typeof BoardRoute
+  '/harness': typeof HarnessRoute
   '/issues': typeof IssuesRoute
   '/task/$taskId': typeof TaskTaskIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/board': typeof BoardRoute
+  '/harness': typeof HarnessRoute
   '/issues': typeof IssuesRoute
   '/task/$taskId': typeof TaskTaskIdRoute
 }
@@ -51,20 +59,22 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/board': typeof BoardRoute
+  '/harness': typeof HarnessRoute
   '/issues': typeof IssuesRoute
   '/task/$taskId': typeof TaskTaskIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/board' | '/issues' | '/task/$taskId'
+  fullPaths: '/' | '/board' | '/harness' | '/issues' | '/task/$taskId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/board' | '/issues' | '/task/$taskId'
-  id: '__root__' | '/' | '/board' | '/issues' | '/task/$taskId'
+  to: '/' | '/board' | '/harness' | '/issues' | '/task/$taskId'
+  id: '__root__' | '/' | '/board' | '/harness' | '/issues' | '/task/$taskId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BoardRoute: typeof BoardRoute
+  HarnessRoute: typeof HarnessRoute
   IssuesRoute: typeof IssuesRoute
   TaskTaskIdRoute: typeof TaskTaskIdRoute
 }
@@ -76,6 +86,13 @@ declare module '@tanstack/react-router' {
       path: '/issues'
       fullPath: '/issues'
       preLoaderRoute: typeof IssuesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/harness': {
+      id: '/harness'
+      path: '/harness'
+      fullPath: '/harness'
+      preLoaderRoute: typeof HarnessRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/board': {
@@ -105,6 +122,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BoardRoute: BoardRoute,
+  HarnessRoute: HarnessRoute,
   IssuesRoute: IssuesRoute,
   TaskTaskIdRoute: TaskTaskIdRoute,
 }

--- a/packages/kobe-web/src/routes/harness.tsx
+++ b/packages/kobe-web/src/routes/harness.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { ChatTerminal } from "../components/ChatTerminal.tsx"
+
+/**
+ * `/harness` — a bare full-screen xterm for UI e2e / manual dev.
+ * (Named `/harness`, not `/pty-*`: the Vite dev `/pty` proxy would capture the
+ * route and forward it to the PTY sidecar → 404.)
+ *
+ * It mounts a single {@link ChatTerminal} whose PTY runs whatever
+ * `KOBE_PTY_DEV_COMMAND` the sidecar was launched with (`bun run dev:mock` /
+ * `dev:sandbox`), bypassing the daemon + task machinery (see pty-server.mjs
+ * `fetchSpec` override). Playwright drives the real TUI through this terminal.
+ * Not linked from the app; `taskId` is ignored by the overridden spec.
+ */
+function PtyHarness() {
+  return (
+    <div style={{ position: "fixed", inset: 0, background: "#141413" }}>
+      <ChatTerminal tabId="e2e" taskId="e2e" mode="shell" />
+    </div>
+  )
+}
+
+export const Route = createFileRoute("/harness")({ component: PtyHarness })

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "dev": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/cli/index.ts",
+    "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
     "dev:sandbox": "mkdir -p .dev-sandbox/home && env KOBE_DEV=1 KOBE_HOME_DIR=$PWD/.dev-sandbox/home KOBE_TMUX_SOCKET=kobe-sandbox bun --preload @opentui/solid/preload --conditions=browser ./src/cli/index.ts",
     "dev:sandbox:reset": "env KOBE_TMUX_SOCKET=kobe-sandbox bun ./src/cli/index.ts kill-sessions",
     "dev:version": "bash ../../scripts/dev-version.sh",

--- a/packages/kobe/src/tui/history/host.tsx
+++ b/packages/kobe/src/tui/history/host.tsx
@@ -21,8 +21,7 @@
  * spawn, no write path, no daemon dependency.
  */
 
-import { engineEntry } from "@/engine/registry"
-import { latestTranscriptMtime } from "@/monitor/activity"
+import { type EngineHistoryReader, engineEntry } from "@/engine/registry"
 import type { ContentBlock } from "@/types/content"
 import type { Message } from "@/types/engine"
 import type { VendorId } from "@/types/task"
@@ -45,6 +44,12 @@ export interface HistoryHostArgs {
    * this only picks the badge.
    */
   readonly live?: boolean
+  /**
+   * Override the transcript source. Production leaves it undefined (reads the
+   * real engine store via {@link engineEntry}); the dev:mock host injects a
+   * fake reader so the whole pane renders without a real worktree/transcript.
+   */
+  readonly reader?: EngineHistoryReader
 }
 
 /** Lines of transcript scrolled per `j`/`k` keypress. */
@@ -265,6 +270,9 @@ function MessageCard(props: {
 
 function HistoryScreen(props: HistoryHostArgs) {
   const { theme } = useTheme()
+  // Data source: the injected reader (dev:mock) or the real engine transcript
+  // store. All three reads below go through it so a mock drives the whole pane.
+  const reader = props.reader ?? engineEntry(props.vendor).history
 
   // Live refresh: poll the vendor transcript mtime (adaptive backoff, shared
   // with the Ops pane) and bump this tick when it advances so the resources
@@ -277,7 +285,7 @@ function HistoryScreen(props: HistoryHostArgs) {
     () => [props.worktree, refreshTick()] as const,
     async ([wt]): Promise<readonly string[]> => {
       try {
-        return await engineEntry(props.vendor).history.listSessionIdsForWorktree(wt)
+        return await reader.listSessionIdsForWorktree(wt)
       } catch {
         return []
       }
@@ -309,7 +317,7 @@ function HistoryScreen(props: HistoryHostArgs) {
     },
     async ([id]): Promise<Message[]> => {
       try {
-        return await engineEntry(props.vendor).history.readHistory(id)
+        return await reader.readHistory(id)
       } catch {
         return []
       }
@@ -334,7 +342,7 @@ function HistoryScreen(props: HistoryHostArgs) {
     let primed = false
     async function poll(): Promise<void> {
       try {
-        const mtime = await latestTranscriptMtime(props.vendor, props.worktree)
+        const mtime = await reader.latestTranscriptMtimeForWorktree(props.worktree)
         if (disposed) return
         if (!primed) {
           primed = true

--- a/packages/kobe/src/tui/mock/host.tsx
+++ b/packages/kobe/src/tui/mock/host.tsx
@@ -1,0 +1,123 @@
+/**
+ * `dev:mock` host — render a REAL kobe pane against FAKE data.
+ *
+ * `bun run dev:mock` boots a real pane component (the live history preview) with
+ * a synthetic, growing transcript — no engine, tmux, daemon, worktree, or
+ * `~/.kobe` involved. It's for eyeballing UI + interaction fast (theme, layout,
+ * CJK, long lines, the live tail) without the dev:sandbox round-trip.
+ *
+ * How it works: the pane hosts take their transcript through an injectable
+ * `EngineHistoryReader` (see history/host.tsx). Here we pass a fake reader whose
+ * message list grows on a timer + advances its mtime, so the pane's own mtime
+ * poll refetches and you watch the transcript tail live.
+ *
+ * To mock another pane, add a branch to `startMockHost` (each pane host already
+ * takes its data via a narrow seam — inject a fake the same way).
+ */
+
+import type { EngineHistoryReader } from "@/engine/registry"
+import type { Message } from "@/types/engine"
+import { coerceVendorId } from "@/types/vendor"
+import { startHistoryHost } from "../history/host"
+
+const SID = "mock-session"
+
+/** A representative starter transcript exercising every block renderer. */
+function seedMessages(): Message[] {
+  const ts = new Date().toISOString()
+  return [
+    {
+      role: "user",
+      sessionId: SID,
+      timestamp: ts,
+      blocks: [{ type: "text", text: "帮我给 history pane 加一个实时刷新的预览" }],
+    },
+    {
+      role: "assistant",
+      sessionId: SID,
+      timestamp: ts,
+      usage: { input_tokens: 1240, output_tokens: 356 },
+      blocks: [
+        {
+          type: "thinking",
+          text: "The read-only history pane should tail the transcript. Reuse the Ops pane's adaptive mtime poll instead of a new file watcher.",
+        },
+        { type: "text", text: "好的，我复用 Ops pane 的 mtime 轮询，把 HistoryScreen 做成 live。先看现有 effect……" },
+        { type: "tool_call", callId: "c1", name: "Read", input: { file_path: "src/tui/history/host.tsx" } },
+      ],
+    },
+    {
+      role: "user",
+      sessionId: SID,
+      timestamp: ts,
+      blocks: [{ type: "tool_result", callId: "c1", output: "…file contents…", isError: false }],
+    },
+    {
+      role: "assistant",
+      sessionId: SID,
+      timestamp: ts,
+      usage: { input_tokens: 2010, output_tokens: 128 },
+      blocks: [
+        {
+          type: "tool_call",
+          callId: "c2",
+          name: "Edit",
+          input: { file_path: "host.tsx", old_string: "…", new_string: "…" },
+        },
+        {
+          type: "text",
+          text: `A deliberately long line to check wrapping and tail-truncation in the transcript view — ${"lorem ipsum dolor sit amet ".repeat(16)}`,
+        },
+      ],
+    },
+    {
+      role: "user",
+      sessionId: SID,
+      timestamp: ts,
+      blocks: [{ type: "tool_result", callId: "c2", output: "File updated", isError: false }],
+    },
+  ]
+}
+
+/** A fake reader whose transcript grows on a timer to demo the live tail. */
+function mockReader(): EngineHistoryReader {
+  const grown = seedMessages()
+  let mtime = 1000
+  let n = 0
+  // Append an assistant turn + advance mtime every few seconds; the pane's mtime
+  // poll then refetches and the new message appears — the live-tail demo.
+  const timer = setInterval(() => {
+    n += 1
+    grown.push({
+      role: "assistant",
+      sessionId: SID,
+      timestamp: new Date().toISOString(),
+      blocks: [{ type: "text", text: `实时追加的第 ${n} 条消息 —— mtime 前进触发 refetch` }],
+    })
+    mtime += 1
+  }, 2500)
+  timer.unref?.()
+  return {
+    // Two sessions so `[` / `]` session switching is exercisable.
+    async listSessionIdsForWorktree() {
+      return ["mock-session-old", SID]
+    },
+    async readHistory(id) {
+      return id === SID ? grown.slice() : seedMessages().slice(0, 2)
+    },
+    async latestTranscriptMtimeForWorktree() {
+      return mtime
+    },
+  }
+}
+
+export async function startMockHost(): Promise<void> {
+  await startHistoryHost({
+    worktree: "/mock/worktree",
+    vendor: coerceVendorId("claude"),
+    live: true,
+    reader: mockReader(),
+  })
+}
+
+void startMockHost()


### PR DESCRIPTION
## Summary
Two dev/test capabilities for iterating on the TUI without the full dev:sandbox loop:

- **`bun run dev:mock`** — boots a REAL pane (the live history preview) against a synthetic, growing transcript via an injectable `EngineHistoryReader`. No engine/tmux/daemon/worktree; for fast UI eyeballing (theme, CJK, long lines, live tail).
- **Browser UI e2e** (Playwright) — opens the SPA, runs a real kobe TUI in the web xterm, sends keystrokes, asserts on the rendered `.xterm-rows` DOM. The UI-layer e2e chain HARNESS.md specced but never landed:
  - `pty-server.mjs`: `KOBE_PTY_DEV_COMMAND` override (4 lines, env-gated) so the PTY runs an arbitrary TUI with no daemon/task.
  - `/harness` route: bare full-screen `ChatTerminal` (named off the `/pty` Vite proxy).
  - `e2e/tui.spec.ts` (dev:mock, default) + `e2e/sandbox.spec.ts` (full kobe + tmux + live engine via `KOBE_PTY_DEV_COMMAND="bun run dev:sandbox"`), gated so each mode runs only its spec; global teardown runs `dev:sandbox:reset` so tmux sessions don't bleed.

**Both modes green locally**: `test:e2e` 1 passed / 1 skipped each way.

## Test plan
- [x] `bun run test:e2e` (dev:mock) — passed
- [x] `KOBE_PTY_DEV_COMMAND="bun run dev:sandbox" bun run test:e2e` — passed
- [x] kobe typecheck + test:fast green (dev:mock commit)