### PR TITLE
fix: glob `**` matches zero intervening directories

### DIFF
--- a/.changeset/fix-glob-zero-segment.md
+++ b/.changeset/fix-glob-zero-segment.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix the `**` globstar in `kobe adopt --glob` and the New Task → Adopt filter so it matches zero intervening directories: a pattern like `src/**/task.ts` now matches `src/task.ts` (worktree directly under the prefix) as well as `src/a/task.ts`, and a leading `**/name` matches `name` at the root. Previously a segment globstar compiled to a form that required at least one directory between the slashes, so it silently hid the zero-directory case and dropped worktrees you expected to see.

--- a/packages/kobe/src/lib/path-glob.ts
+++ b/packages/kobe/src/lib/path-glob.ts
@@ -12,6 +12,15 @@
  *   - `**` — any run of chars including `/`
  *   - `?`  — a single char except `/`
  * Everything else is matched literally (regex metachars are escaped).
+ *
+ * A `**` that stands as its own path segment and is immediately followed by
+ * a separator (a leading globstar segment, or an interior one bounded by
+ * slashes) matches ZERO or more directories, folding in the trailing
+ * separator. So a "src, then a globstar segment, then task.ts" pattern
+ * matches both `src/task.ts` (no intervening directory) and `src/a/task.ts`.
+ * Without this fold the globstar compiled to a bare "any run" flanked by two
+ * literal separators, which forced at least one intervening segment and so
+ * silently hid the zero-directory case.
  */
 
 import { basename } from "node:path"
@@ -23,8 +32,20 @@ export function globToRegExp(glob: string): RegExp {
     const c = glob[i]
     if (c === "*") {
       if (glob[i + 1] === "*") {
-        re += ".*"
-        i++
+        // A path-segment globstar — `**` on its own segment (preceded by
+        // `/` or the start of the pattern) and immediately followed by `/`
+        // — matches zero or more directories, so the trailing separator is
+        // folded into the group. That lets `a/**/b` match `a/b` (no
+        // intervening segment) as well as `a/x/b`. A `**` in any other
+        // position keeps the loose "any run including `/`" meaning.
+        const segmentStart = i === 0 || glob[i - 1] === "/"
+        if (segmentStart && glob[i + 2] === "/") {
+          re += "(?:.*/)?"
+          i += 2 // consume the second `*` and the trailing `/`
+        } else {
+          re += ".*"
+          i++
+        }
       } else {
         re += "[^/]*"
       }

--- a/packages/kobe/test/lib/path-glob.test.ts
+++ b/packages/kobe/test/lib/path-glob.test.ts
@@ -14,6 +14,28 @@ describe("globToRegExp", () => {
     expect(re.test("a/b/c")).toBe(true)
   })
 
+  it("lets an interior `**` match zero intervening directories", () => {
+    const re = globToRegExp("src/**/task.ts")
+    expect(re.test("src/task.ts")).toBe(true) // zero directories between
+    expect(re.test("src/a/task.ts")).toBe(true)
+    expect(re.test("src/a/b/task.ts")).toBe(true)
+    expect(re.test("srctask.ts")).toBe(false) // separator is still required
+    expect(re.test("src/task.tsx")).toBe(false) // still anchored
+  })
+
+  it("lets a leading `**/` match zero or more leading directories", () => {
+    const re = globToRegExp("**/task.ts")
+    expect(re.test("task.ts")).toBe(true)
+    expect(re.test("a/task.ts")).toBe(true)
+    expect(re.test("a/b/task.ts")).toBe(true)
+  })
+
+  it("keeps loose `**` semantics when it is not its own segment", () => {
+    const re = globToRegExp("a**b")
+    expect(re.test("a-x/y-b")).toBe(true) // still crosses slashes
+    expect(re.test("axb")).toBe(true)
+  })
+
   it("treats `?` as a single non-slash char", () => {
     const re = globToRegExp("?.ts")
     expect(re.test("a.ts")).toBe(true)
@@ -50,5 +72,12 @@ describe("matchPathGlob", () => {
 
   it("does not let `*` cross directory separators", () => {
     expect(matchPathGlob("/a/*", "/a/b/c")).toBe(false)
+  })
+
+  it("matches a nested `**` filter against a worktree directly under the prefix", () => {
+    // Regression: `src/**/login` previously failed to match `/work/src/login`
+    // because the globstar required at least one intervening directory.
+    expect(matchPathGlob("/work/**/login", "/work/login")).toBe(true)
+    expect(matchPathGlob("/work/**/login", "/work/feature/login")).toBe(true)
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — surfaced during a code-review sweep of `packages/kobe/src`, cross-checked against the `--glob` consumers.

## Problem

`globToRegExp` in `packages/kobe/src/lib/path-glob.ts` compiled a path-segment `**` to a bare `.*` sitting **between** the two literal slashes of the pattern. So `src/**/task.ts` became `^src/.*/task.ts$`, which requires at least one intervening directory — it matched `src/a/task.ts` but **not** `src/task.ts` (the zero-directory case that globstar is supposed to cover).

This is a wrong-result bug, not just a hardening gap, in two user-facing filters that both call `matchPathGlob`:

- `kobe adopt --glob <pattern>` (`src/cli/index.ts:302`)
- New Task → Adopt tab's live filter (`src/tui/component/new-task-dialog/state.ts:237`)

A user narrowing discovered worktrees with `src/**/login` (or a leading `**/login`) would silently not see a worktree sitting directly under the prefix.

## Fix

When a `**` stands as its own path segment (preceded by `/` or the start of the pattern) **and** is immediately followed by `/`, it now compiles to `(?:.*/)?` — matching zero or more directories and folding in the trailing separator. So:

- `src/**/task.ts` → `^src/(?:.*/)?task.ts$` matches `src/task.ts`, `src/a/task.ts`, `src/a/b/task.ts`
- leading `**/task.ts` matches `task.ts` and any depth of prefix

A `**` that is **not** its own segment (e.g. `a**b`) keeps the existing loose "any run including `/`" meaning, and trailing `a/**` is unchanged — so no existing behavior regresses.

## Verification

- `bun run lint` ✓ · `bun run typecheck` ✓
- `test/lib/path-glob.test.ts` extended with the zero-segment case, leading `**/`, the non-segment `**` case, and a `matchPathGlob` regression; full `test/lib` suite green (**76 passed**).

## Follow-ups

- None required. Trailing `/**` intentionally still requires a separator (matches today's behavior and the existing test); making `a/**` also match the bare `a` directory would be a separate, larger semantics change if ever wanted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TXvsWuNmuoGa1vq4qAf7CD)_