### PR TITLE
perf: gate pane pollers on session attachment

### DIFF
--- a/.changeset/pane-attach-gate.md
+++ b/.changeset/pane-attach-gate.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Background (detached) task sessions no longer burn CPU: the Tasks/Ops pane
+pollers — sidebar git-HEAD spawns, the Ops transcript-mtime sweep and
+capture-pane turn-status probe, the tasks.json backstop stat, and the live
+history tail — now check a shared, cached "is this session attached?" gate and
+skip their expensive work while nobody is looking. With ~10 sessions open this
+was ~25 pane processes at ~30% combined idle CPU; detached panes now cost one
+cached tmux probe per 3s. The first tick after re-attach resumes full cadence,
+and any probe failure fails open so a visible pane can never quiesce itself.

--- a/packages/kobe/src/tui/history/host.tsx
+++ b/packages/kobe/src/tui/history/host.tsx
@@ -29,6 +29,7 @@ import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { For, Show, createEffect, createMemo, createResource, createSignal, on, onCleanup, onMount } from "solid-js"
 import { useTheme } from "../context/theme"
 import { t } from "../i18n"
+import { sessionAttached } from "../lib/attach-gate"
 import { bootPaneHost } from "../lib/host-boot"
 import { useBindings } from "../lib/keymap"
 import { ACTIVITY_POLL_MIN_MS, nextActivityPollDelay } from "../ops/activity-poll"
@@ -341,6 +342,12 @@ function HistoryScreen(props: HistoryHostArgs) {
     let lastMtime = 0
     let primed = false
     async function poll(): Promise<void> {
+      // Detached (background) session: skip the transcript stat — the preview
+      // is invisible. Next tick after re-attach resumes the live tail.
+      if (!(await sessionAttached())) {
+        if (!disposed) timer = setTimeout(() => void poll(), delayMs)
+        return
+      }
       try {
         const mtime = await reader.latestTranscriptMtimeForWorktree(props.worktree)
         if (disposed) return

--- a/packages/kobe/src/tui/lib/attach-gate.ts
+++ b/packages/kobe/src/tui/lib/attach-gate.ts
@@ -1,0 +1,49 @@
+/**
+ * Attach gate — "is anyone looking at this pane's session?"
+ *
+ * Every task session carries its own Tasks/Ops pane processes, and a detached
+ * (background) session's panes used to keep polling at full cadence — spawning
+ * git / tmux capture-pane / stat loops for a screen nobody can see. With ~10
+ * sessions that was ~25 processes burning ~30% CPU at idle. The pollers now ask
+ * this gate first and skip their expensive body while the session is detached;
+ * the next tick after re-attach resumes normal cadence.
+ *
+ * One cached tmux probe (`#{session_attached}`, resolved via the pane's own
+ * $TMUX context) shared by all pollers in the process, refreshed at most every
+ * {@link ATTACH_TTL_MS} — so a fully detached pane process costs one tmux spawn
+ * per 3s total, instead of git+capture-pane+stat every 1.5-2s each.
+ *
+ * Fail-open: any probe failure (no tmux server, not inside tmux — e.g. dev
+ * direct runs) reports "attached", so a visible pane can never quiesce itself.
+ */
+
+import { runTmuxCapturing } from "@/tmux/client"
+
+export const ATTACH_TTL_MS = 3000
+
+type Probe = () => Promise<{ code: number; stdout: string }>
+
+/** Factory (injectable for tests). Returns the cached async "attached?" check. */
+export function createAttachGate(probe: Probe, now: () => number = Date.now): () => Promise<boolean> {
+  let refreshedAt = Number.NEGATIVE_INFINITY
+  let attached = true
+  return async (): Promise<boolean> => {
+    if (now() - refreshedAt < ATTACH_TTL_MS) return attached
+    // Stamp before awaiting so concurrent ticks share one in-flight probe
+    // window instead of stampeding spawns.
+    refreshedAt = now()
+    try {
+      const r = await probe()
+      const n = Number.parseInt(r.stdout.trim(), 10)
+      attached = r.code !== 0 || Number.isNaN(n) ? true : n > 0
+    } catch {
+      attached = true
+    }
+    return attached
+  }
+}
+
+/** The process-wide gate every poller shares. */
+export const sessionAttached = createAttachGate(() =>
+  runTmuxCapturing(["display-message", "-p", "#{session_attached}"]),
+)

--- a/packages/kobe/src/tui/ops/host.tsx
+++ b/packages/kobe/src/tui/ops/host.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/tmux/client"
 import { openInEditor } from "@/tmux/editor-launch"
 import { previewWindowCommand, shellQuote, shellQuoteArgv } from "@/tmux/session-layout"
+import { sessionAttached } from "@/tui/lib/attach-gate"
 import type { VendorId } from "@/types/task"
 import { readWorktreeFile, runWorktreeGit } from "@/worktree/content"
 import { SyntaxStyle } from "@opentui/core"
@@ -162,6 +163,12 @@ function OpsShell(props: OpsHostArgs) {
     let idleStreak = 0
     let lastSeenMtime = 0
     async function poll(): Promise<void> {
+      // Detached (background) session: skip the readdir+stat sweep entirely —
+      // the badge is invisible. Next tick after re-attach resumes.
+      if (!(await sessionAttached())) {
+        if (!disposed) timer = setTimeout(() => void poll(), delayMs)
+        return
+      }
       try {
         const mtime = await latestTranscriptMtime(props.vendor, props.worktree)
         if (disposed) return
@@ -274,6 +281,11 @@ function OpsShell(props: OpsHostArgs) {
     }
 
     async function poll(): Promise<void> {
+      // Detached session: no capture-pane spawn for an invisible status chip.
+      if (!(await sessionAttached())) {
+        if (!disposed) timer = setTimeout(() => void poll(), delayMs)
+        return
+      }
       const shared = usingShared()
       try {
         const nextPaneHash = fingerprint(await capturePaneById(props.targetPane!, 80))

--- a/packages/kobe/src/tui/panes/sidebar/git-head.ts
+++ b/packages/kobe/src/tui/panes/sidebar/git-head.ts
@@ -30,6 +30,7 @@
 import { stat } from "node:fs/promises"
 import { join } from "node:path"
 import { readOnlyGitProcessEnv } from "@/lib/git-env"
+import { sessionAttached } from "@/tui/lib/attach-gate"
 import { createBackgroundPoller, spawnCapture } from "../../lib/background-poll"
 
 /** Kill a ref read that runs longer than this — O(1) commands, tight leash. */
@@ -143,7 +144,12 @@ export function currentBranch(repo: string): string {
  * interval floor make the extra calls free.
  */
 export function pollCurrentBranch(repo: string): void {
-  poller.poll(repo)
+  // Detached (background) session: skip the git spawn — the branch hint is
+  // invisible. The gate is cached process-wide, so this stays free to call
+  // from a reactive memo every tick.
+  void sessionAttached().then((attached) => {
+    if (attached) poller.poll(repo)
+  })
 }
 
 /** Test hook: drop all cached entries/backoff state. */

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -79,6 +79,7 @@ import { bindByIds, findBinding, keymapVersion } from "../context/keybindings"
 import { useKV } from "../context/kv"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
+import { sessionAttached } from "../lib/attach-gate"
 import { formatChord, tmuxPrefixGlyph } from "../lib/chord-glyphs"
 import { type HostScreen, bootPaneHost } from "../lib/host-boot"
 import { useBindings } from "../lib/keymap"
@@ -1110,6 +1111,8 @@ async function setupTasksPane(opts: { initialTaskId?: string }): Promise<HostScr
   const timer = setInterval(() => {
     if (orch && orch.connectionStateSignal()() === "online") return
     void (async () => {
+      // Detached (background) session: skip even the stat — nobody's looking.
+      if (!(await sessionAttached())) return
       let fingerprint = "missing"
       try {
         const st = await stat(store.filePath)

--- a/packages/kobe/test/tui/attach-gate.test.ts
+++ b/packages/kobe/test/tui/attach-gate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { ATTACH_TTL_MS, createAttachGate } from "../../src/tui/lib/attach-gate"
+
+/**
+ * The attach gate decides whether background pollers may spawn subprocesses.
+ * Pin its three load-bearing behaviors: the TTL cache (one probe per window,
+ * however many pollers ask), the attached/detached parse, and fail-open (a
+ * probe failure must never quiesce a possibly-visible pane).
+ */
+
+function fakeProbe(results: Array<{ code: number; stdout: string } | Error>) {
+  let calls = 0
+  const probe = async () => {
+    const r = results[Math.min(calls, results.length - 1)]
+    calls++
+    if (r instanceof Error) throw r
+    return r as { code: number; stdout: string }
+  }
+  return { probe, callCount: () => calls }
+}
+
+describe("createAttachGate", () => {
+  it("parses attached (>0) and detached (0) probe output", async () => {
+    let t = 0
+    const attached = createAttachGate(
+      async () => ({ code: 0, stdout: "1\n" }),
+      () => t,
+    )
+    await expect(attached()).resolves.toBe(true)
+
+    t += ATTACH_TTL_MS + 1
+    const detached = createAttachGate(
+      async () => ({ code: 0, stdout: "0\n" }),
+      () => 0,
+    )
+    await expect(detached()).resolves.toBe(false)
+  })
+
+  it("caches within the TTL — many callers share one probe", async () => {
+    let t = 0
+    const { probe, callCount } = fakeProbe([{ code: 0, stdout: "0" }])
+    const gate = createAttachGate(probe, () => t)
+    await gate()
+    await gate()
+    await gate()
+    expect(callCount()).toBe(1)
+
+    t = ATTACH_TTL_MS + 1
+    await gate()
+    expect(callCount()).toBe(2)
+  })
+
+  it("flips detached → attached after the TTL expires", async () => {
+    let t = 0
+    const { probe } = fakeProbe([
+      { code: 0, stdout: "0" },
+      { code: 0, stdout: "1" },
+    ])
+    const gate = createAttachGate(probe, () => t)
+    await expect(gate()).resolves.toBe(false)
+    t = ATTACH_TTL_MS + 1
+    await expect(gate()).resolves.toBe(true)
+  })
+
+  it("fails open on a non-zero exit, garbage output, or a thrown probe", async () => {
+    const nonZero = createAttachGate(
+      async () => ({ code: 1, stdout: "" }),
+      () => 0,
+    )
+    await expect(nonZero()).resolves.toBe(true)
+
+    const garbage = createAttachGate(
+      async () => ({ code: 0, stdout: "not-a-number" }),
+      () => 0,
+    )
+    await expect(garbage()).resolves.toBe(true)
+
+    const throws = createAttachGate(
+      async () => {
+        throw new Error("no tmux")
+      },
+      () => 0,
+    )
+    await expect(throws()).resolves.toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
The "computer about to catch fire" fix. With ~10 task sessions open (1 attached, 9 background), the per-session Tasks/Ops pane processes — 25 of them — kept polling at full cadence for screens nobody could see: **~30% combined idle CPU + 2.5GB RAM**. The daemon itself was innocent (0.9MB RSS, 0% CPU).

- New `src/tui/lib/attach-gate.ts`: one process-wide cached probe (`tmux display-message -p '#{session_attached}'`, 3s TTL, **fail-open** — any probe failure reports "attached" so a visible pane can never quiesce itself).
- Gated pollers (skip the expensive body while detached; first tick after re-attach resumes full cadence):
  - sidebar git-HEAD branch poll (git spawn every ~2s per project row)
  - Ops transcript-mtime activity sweep (readdir + stat)
  - Ops turn-status capture-pane probe (tmux spawn every 1.5–6s)
  - tasks.json backstop stat (offline fallback path)
  - live history preview mtime tail
- Detached pane steady-state cost drops to one cached tmux probe per 3s per process.

## Test plan
- [x] `test/tui/attach-gate.test.ts` — TTL cache (N callers → 1 probe), detached→attached flip after TTL, fail-open on non-zero exit / garbage / throw
- [x] typecheck 0 / lint 0 / test:fast 1272 pass
- [ ] Live before/after CPU measurement on the real 10-session setup (after release + `kobe reload`); sandbox spot-check in PR comments