### PR TITLE
perf: kill capture leftovers at the root + throttle detached panes

### DIFF
--- a/.changeset/detached-fps-throttle.md
+++ b/.changeset/detached-fps-throttle.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Background panes now throttle their render loop: while a pane's tmux session
+has no attached client, the opentui targetFps drops to 2 (restored within ~3s
+of re-attach), cutting the remaining idle burn of invisible panes on top of
+the attach-gated pollers. Applied once in the shared pane-host boot, so every
+current and future pane host gets it.

--- a/packages/branding/scripts/capture-tui.ts
+++ b/packages/branding/scripts/capture-tui.ts
@@ -59,6 +59,59 @@ const tmux = (...args: string[]) => $`tmux -L ${SOCKET} ${args}`.env(ENV).quiet(
 const key = (k: string) => tmux("send-keys", "-t", SESSION, k)
 const sleep = (ms: number) => Bun.sleep(ms)
 
+/**
+ * Kill a socket's pane PROCESSES, then its server. `kill-server` alone only
+ * SIGHUPs the panes, and the opentui pane hosts survive SIGHUP — they reparent
+ * to init and keep polling forever (the observed leak: 16 orphaned `kobe
+ * tasks/ops` processes from dead capture sockets). SIGKILL each pane's process
+ * group first so nothing outlives the capture.
+ */
+async function killPanesThenServer(socket: string): Promise<void> {
+  const out = await $`tmux -L ${socket} list-panes -a -F '#{pane_pid}'`.env(ENV).quiet().nothrow().text()
+  for (const line of out.split("\n")) {
+    const pid = Number.parseInt(line.trim(), 10)
+    if (!Number.isFinite(pid) || pid <= 1) continue
+    try {
+      process.kill(-pid, "SIGKILL") // pane's process group
+    } catch {
+      try {
+        process.kill(pid, "SIGKILL")
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+  await $`tmux -L ${socket} kill-server`.env(ENV).quiet().nothrow()
+}
+
+/**
+ * Idempotent full teardown — outer capture server, sandbox daemon, inner kobe
+ * server. Wired to normal exit AND crash/interrupt paths below: a capture that
+ * dies mid-run must never leave engine/pane processes behind (leaks are bugs).
+ */
+let torndown = false
+async function teardown(): Promise<void> {
+  if (torndown) return
+  torndown = true
+  await killPanesThenServer(SOCKET)
+  await $`kobe daemon stop`.env(ENV).quiet().nothrow()
+  await killPanesThenServer("kobe-capture-inner")
+}
+
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    void teardown().finally(() => process.exit(130))
+  })
+}
+process.on("uncaughtException", (err) => {
+  console.error("capture crashed:", err)
+  void teardown().finally(() => process.exit(1))
+})
+process.on("unhandledRejection", (err) => {
+  console.error("capture crashed (rejection):", err)
+  void teardown().finally(() => process.exit(1))
+})
+
 async function typeText(text: string, msPerChar: number): Promise<void> {
   for (const ch of text) {
     await $`tmux -L ${SOCKET} send-keys -t ${SESSION} -l ${ch}`.env(ENV).quiet()
@@ -193,10 +246,7 @@ while (elapsed() < SECONDS) {
   await sleep(Math.max(0, 1000 / FPS - (elapsed() - t) * 1000))
 }
 
-await tmux("kill-server").nothrow()
-// Stop the sandbox daemon + engine sessions on the inner socket.
-await $`kobe daemon stop`.env(ENV).quiet().nothrow()
-await $`tmux -L kobe-capture-inner kill-server`.env(ENV).quiet().nothrow()
+await teardown()
 
 await Bun.write(
   new URL(`../${OUT}`, import.meta.url),

--- a/packages/kobe/src/tui/lib/host-boot.tsx
+++ b/packages/kobe/src/tui/lib/host-boot.tsx
@@ -27,7 +27,7 @@
  * must live elsewhere.
  */
 
-import { render } from "@opentui/solid"
+import { render, useRenderer } from "@opentui/solid"
 import {
   installClientCrashHandlers,
   logClientError,
@@ -45,6 +45,7 @@ import { loadUserThemes } from "../context/theme/loader"
 import { isLocaleId, setLocaleLang, t } from "../i18n"
 import { DialogProvider } from "../ui/dialog"
 import { type UiPrefsTarget, applyUiPrefs } from "./apply-ui-prefs"
+import { sessionAttached } from "./attach-gate"
 import { type PersistedUiPrefs, readPersistedUiPrefs } from "./persisted-ui-prefs"
 
 /**
@@ -245,6 +246,38 @@ function PaneCrashFallback(props: { error: unknown }) {
  * `refreshKobeWorkspacePanes` → `applyTmuxChromeTheme` call already covers
  * every session; doing it from N panes would just race the same `set-option`s.
  */
+/** Detached fps while the pane's session has no attached client. */
+const DETACHED_FPS = 2
+/** How often to re-check attachment (the probe itself is TTL-cached). */
+const DETACH_CHECK_MS = 3000
+
+/**
+ * Render-loop throttle for background panes, ONCE for every host (sibling of
+ * {@link UiPrefsSync}). The attach gate already stops the pollers; this stops
+ * the other half of a detached pane's idle burn — the opentui render loop
+ * ticking at full fps for a screen nobody can see. Detached → targetFps drops
+ * to {@link DETACHED_FPS}; re-attach restores the boot fps within ~3s (the
+ * loop keeps running, so the first restored frame repaints any staleness).
+ * Deliberately fps-throttle rather than pause(): the renderer state machine
+ * (input, dialogs, suspend semantics) stays untouched, and a gate failure
+ * fails open to full fps.
+ */
+function DetachFpsThrottle() {
+  const renderer = useRenderer()
+  onMount(() => {
+    if (!renderer) return
+    const attachedFps = renderer.targetFps
+    const timer = setInterval(() => {
+      void sessionAttached().then((attached) => {
+        const want = attached ? attachedFps : DETACHED_FPS
+        if (renderer.targetFps !== want) renderer.targetFps = want
+      })
+    }, DETACH_CHECK_MS)
+    onCleanup(() => clearInterval(timer))
+  })
+  return null
+}
+
 function UiPrefsSync(props: { boot: PersistedUiPrefs }) {
   const themeCtx = useTheme()
   const target: UiPrefsTarget = {
@@ -359,6 +392,7 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
     () => (
       <HostProviders theme={prefs.theme} kv={kv} focus={focus} notifications={notifications}>
         <UiPrefsSync boot={prefs} />
+        <DetachFpsThrottle />
         <ErrorBoundary fallback={(err) => <PaneCrashFallback error={err} />}>{screen.root()}</ErrorBoundary>
       </HostProviders>
     ),


### PR DESCRIPTION
## Summary
Two fixes from the "computer overheating" investigation — leftovers are bugs, and background panes should cost ~nothing.

**1. capture-tui teardown kills pane processes on every exit path** (`packages/branding/scripts/capture-tui.ts`)
- `tmux kill-server` only SIGHUPs panes and opentui hosts survive SIGHUP → they reparent to init and poll forever. Observed fallout: 16 orphaned `kobe tasks/ops` processes from dead `kobe-capture*` sockets (~12% CPU + 1.2GB, killed manually).
- Teardown now SIGKILLs each pane's process group before `kill-server`, is idempotent, and runs on SIGINT/SIGTERM + uncaught exception/rejection — a crash mid-capture cleans up too.

**2. detached panes throttle their render loop** (`packages/kobe/src/tui/lib/host-boot.tsx`)
- The attach gate (#203) stopped the pollers; the opentui render loop was the other half of the idle burn (~1%/pane × 25 panes). A `DetachFpsThrottle` boot component — mounted once in `bootPaneHost`, all hosts inherit — drops `targetFps` to 2 while the session is detached, restores within ~3s of re-attach.
- fps-throttle instead of `pause()`: renderer state machine + input handling untouched; gate failure fails open to full fps.

## Test plan
- [x] typecheck 0 / lint 0 / test:fast 1272 pass
- [x] capture-tui parse check passes; manual sweep confirms zero capture-home orphans
- [ ] Post-release: re-measure idle CPU on the live multi-session setup