### PR TITLE
chore: PR-only mainline rule, CI + coverage badges, Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,11 @@ jobs:
         run: bun run --filter @sma1lboy/kobe test:behavior
 
   coverage-cap:
-    # Per-touched-file coverage floor (the coverage sibling of file-size-cap).
-    # No repo-wide % gate — only files this PR touches must clear the bar, so
+    # Per-touched-file coverage floor (the coverage sibling of file-size-cap)
+    # + the Codecov upload that feeds the README badge. Runs on push too so
+    # main's coverage stays current; the touched-file GATE step is PR-only.
+    # No repo-wide % gate — only files a PR touches must clear the bar, so
     # coverage ratchets up where work actually happens.
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -153,7 +154,18 @@ jobs:
         working-directory: packages/kobe
         run: bun run coverage
 
+      - name: Upload coverage to Codecov
+        # Tokenless works for public repos; if uploads start 429ing, add a
+        # CODECOV_TOKEN repo secret and it gets picked up automatically.
+        uses: codecov/codecov-action@v5
+        with:
+          files: packages/kobe/coverage/lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Touched files must meet the coverage floor
+        if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ No Linear. Backlog/open issues live in the daemon-owned issue store (web Issues 
 
 ## Hard rules (non-negotiable)
 
+### PR-only mainline (2026-07-03)
+- ALL development lands via pull request: feature branch → commits → `gh pr create` → CI green (typecheck/test, behavior, file-size-cap, coverage-cap, Review CI) → `gh pr merge --squash --delete-branch`. **NEVER push commits directly to `main`.**
+- Sole exception: the `chore: release — X.Y.Z` commit + tag pushed by `scripts/release.sh` (see [`docs/RELEASING.md`](./docs/RELEASING.md)).
+- Rationale: the PR gates are the enforcement point for the hard rules below — direct pushes bypass them.
+
 ### Commits
 - Commit at the end of each stream when green (per-stream commits are pre-authorized). Message: `<type>: <summary>` + a 2-3 sentence body.
 - **NEVER** add `Co-Authored-By: Claude` / any AI/Anthropic attribution or "Generated with Claude Code" footers.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@sma1lboy/kobe"><img src="https://img.shields.io/npm/v/%40sma1lboy%2Fkobe.svg" alt="npm version" /></a>
+  <a href="https://github.com/Sma1lboy/kobe/actions/workflows/ci.yml"><img src="https://github.com/Sma1lboy/kobe/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://codecov.io/gh/Sma1lboy/kobe"><img src="https://codecov.io/gh/Sma1lboy/kobe/graph/badge.svg" alt="coverage" /></a>
   <a href="./packages/kobe/CHANGELOG.md"><img src="https://img.shields.io/badge/changelog-latest-blue" alt="changelog" /></a>
 </p>
 <img width="2559" height="1510" alt="image" src="https://github.com/user-attachments/assets/f8dab7ca-43a1-4f76-adad-f19239f5f503" />

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -24,6 +24,11 @@ This prompts for the bump type (**patch** / **minor** / **major**) and a summary
 scripts/release.sh
 ```
 
+> **PR-only exception.** Development lands on `main` exclusively via pull
+> requests (AGENTS.md "PR-only mainline"); the `chore: release — X.Y.Z`
+> commit + tag that `release.sh` pushes is the ONE sanctioned direct push —
+> it only consumes changesets that already passed PR CI.
+
 This consumes every pending `.changeset/*.md`:
 
 1. `changeset version` — computes the next version from the pending bump types, rewrites `packages/kobe/package.json`, and prepends the collected notes to `CHANGELOG.md` (then deletes the consumed changesets).

--- a/packages/kobe/vitest.config.ts
+++ b/packages/kobe/vitest.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts", "src/**/*.tsx"],
-      reporter: ["text-summary", "json-summary"],
+      reporter: ["text-summary", "json-summary", "lcov"],
       reportsDirectory: "./coverage",
     },
   },


### PR DESCRIPTION
## What

- **AGENTS.md hard rule — PR-only mainline (2026-07-03):** all development lands via pull request (feature branch → `gh pr create` → CI green → squash merge). Never push directly to `main`. Sole exception: the release commit + tag from `scripts/release.sh` (noted in `docs/RELEASING.md`).
- **README badges:** CI status + coverage badges join the npm badge row.
- **Codecov:** the `coverage-cap` job now also runs on pushes to main and uploads `lcov.info` via `codecov/codecov-action@v5` (tokenless for the public repo; add a `CODECOV_TOKEN` secret if uploads get rate-limited). The per-touched-file gate step stays PR-only.

## Why

The PR gates (file-size-cap, coverage-cap, behavior, Review CI) are the enforcement point for the repo's hard rules — direct pushes bypass them, which is how a red commit landed on main unnoticed this week.