### PR TITLE
ci: pass CODECOV_TOKEN via the action's token input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,15 +154,12 @@ jobs:
         working-directory: packages/kobe
         run: bun run coverage
 
-      - name: Upload coverage to Codecov
-        # Tokenless works for public repos; if uploads start 429ing, add a
-        # CODECOV_TOKEN repo secret and it gets picked up automatically.
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/kobe/coverage/lcov.info
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Touched files must meet the coverage floor
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Align the Codecov upload step with the documented codecov-action@v5 form
(with.token) instead of the env fallback; tokenless upload was rejected for
main ("Token required because branch is protected"), the repo secret is now
set.
