### PR TITLE
fix: guard kobe api fan-out --count against the cap before allocating

### DIFF
--- a/.changeset/fanout-count-cap.md
+++ b/.changeset/fanout-count-cap.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix: `kobe api fan-out --count N` now rejects an over-cap `N` before allocating instead of after. The `--count` branch built a `new Array(N)` of vendors and only then checked it against the fan-out cap, so a large `--count` (e.g. `--count 1000000000`) allocated a huge array — hanging or crashing the process with an out-of-memory error — before the "exceeds the cap" message it should have produced immediately. It now guards `N` against the cap up front, symmetric to the `--agents` spec path which already did so, so an over-cap request fails fast with the same clear error.

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -696,6 +696,20 @@ export function parseAgentsSpec(spec: string): VendorId[] {
   return out
 }
 
+/**
+ * Build the fan-out plan for the `--count` form (`--count N`, all one vendor):
+ * N copies of `vendor`. Rejects against the fanout cap BEFORE allocating —
+ * symmetric to {@link parseAgentsSpec}, so `--count 1000000000` fails fast
+ * instead of materializing a billion-element array (OOM) only to be caught by
+ * the post-build `plan.length > FANOUT_CAP` check.
+ */
+export function buildCountPlan(count: number, vendor: VendorId): VendorId[] {
+  if (count > FANOUT_CAP) {
+    throw new ApiError(`fan-out of ${count} exceeds the cap of ${FANOUT_CAP} — spawn in batches`, "BAD_FLAG")
+  }
+  return new Array<VendorId>(count).fill(vendor)
+}
+
 // ── Schema (LEVELED) + help (all derived from VERBS) ─────────────────────────
 
 const GLOBAL_FLAGS = [
@@ -1172,7 +1186,7 @@ async function fanOut(ctx: VerbContext): Promise<unknown> {
   const defaultVendor = await runtime.defaultVendor(repo)
   const plan: VendorId[] = agentsSpec
     ? parseAgentsSpec(agentsSpec)
-    : new Array<VendorId>(args.int("count") ?? 1).fill(args.vendor() ?? defaultVendor ?? "claude")
+    : buildCountPlan(args.int("count") ?? 1, args.vendor() ?? defaultVendor ?? "claude")
 
   if (plan.length > FANOUT_CAP) {
     throw new ApiError(`fan-out of ${plan.length} exceeds the cap of ${FANOUT_CAP} — spawn in batches`, "BAD_FLAG")

--- a/packages/kobe/test/cli/api-cmd.test.ts
+++ b/packages/kobe/test/cli/api-cmd.test.ts
@@ -4,6 +4,7 @@ import {
   ApiError,
   VERBS,
   apiUsage,
+  buildCountPlan,
   findVerb,
   fullSchema,
   parseAgentsSpec,
@@ -94,6 +95,21 @@ describe("parseAgentsSpec", () => {
 
   it("rejects a spec that expands to nothing", () => {
     expect(() => parseAgentsSpec(" , ")).toThrow(/no agents/)
+  })
+})
+
+describe("buildCountPlan", () => {
+  it("expands --count N into N copies of the vendor", () => {
+    expect(buildCountPlan(3, "codex")).toEqual(["codex", "codex", "codex"])
+    expect(buildCountPlan(1, "claude")).toEqual(["claude"])
+  })
+
+  it("rejects an over-cap count BEFORE allocating (no OOM on a huge --count)", () => {
+    // Mirrors the parseAgentsSpec guard: `--count 1000000000` must fail fast
+    // instead of building a billion-element array only to hit the post-build
+    // cap check.
+    expect(() => buildCountPlan(1_000_000_000, "claude")).toThrow(/exceeds the cap/)
+    expect(() => buildCountPlan(11, "claude")).toThrow(/exceeds the cap/)
   })
 })
 


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found OOM in the `kobe api` CLI surface, surfaced during today's daily review of `packages/kobe/src/cli/` and `packages/kobe/src/lib/`.

## Problem

`kobe api fan-out` accepts two mutually-exclusive forms: `--agents claude:2,codex:1` or `--count N`. The `--count` branch built the plan as:

```ts
new Array<VendorId>(args.int("count") ?? 1).fill(...)
```

`--count` is validated only as a *positive integer* (no upper bound), so the array is materialized in full **before** the `plan.length > FANOUT_CAP` guard runs. A large value — e.g. `kobe api fan-out --repo . --prompt "x" --count 1000000000` — allocates a billion-element array and hangs / crashes the process with an out-of-memory error, instead of failing fast with the "exceeds the cap of 10" message it should produce immediately.

This is the exact case the sibling `--agents` path already guards. `parseAgentsSpec` checks the cap *before* pushing entries, with a comment noting that otherwise `--agents claude:1000000000` "allocates a billion-element array (OOM) only to be rejected by the post-build check." The `--count` branch reintroduced that OOM.

## Fix

Extract `buildCountPlan(count, vendor)`, symmetric to `parseAgentsSpec`: it rejects an over-cap `count` with the same `BAD_FLAG` cap error **before** allocating, then fills the array. `fanOut` now calls it; the post-build `plan.length > FANOUT_CAP` check stays as a defensive backstop. No behavior change for valid counts (`--count 1`…`--count 10`).

## Verification

- Added `buildCountPlan` unit tests mirroring the existing `parseAgentsSpec` cap tests (`test/cli/api-cmd.test.ts`): expands `N` into `N` vendor entries, and throws `/exceeds the cap/` for `--count 1000000000` and `--count 11` without allocating.
- `bunx vitest run test/cli/api-cmd.test.ts` → 28 passed.
- `bun run lint` (biome) and `bun run typecheck` (tsc) both green from repo root.

## Follow-ups

None required. `api-cmd.ts` remains a large (1363-line) central CLI dispatch file; splitting it is out of scope for this targeted one-guard fix.

file-size-exemption: packages/kobe/src/cli/api-cmd.ts — targeted OOM guard in the pre-existing 1363-line api-cmd.ts; the fix must live where `fanOut` is defined, and splitting the file is out of scope for this bug fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_011brGsvxhmUjG6iQPfgfnQ7)_
