### PR TITLE
chore: scope the coverage metric to unit-testable .ts logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,4 +161,4 @@ cd packages/kobe && bun run coverage           # v8 coverage report (text + json
 Two hard rules keep regressions from coming back:
 
 - **Every bug fix ships a regression test** that fails before the fix and passes after, commented with the issue it pins. Environment-shaped bugs (terminal bytes, PATH state, packaged-vs-dev) get pinned in `test/behavior/`, not in a mocked unit test.
-- **Per-touched-file coverage floor on PRs** — every `packages/kobe/src` file a PR touches must meet the line-coverage floor (default 50%, `scripts/coverage-gate.mjs`); `coverage-exemption: <reason>` in the PR body opts out with a paper trail. There is deliberately no repo-wide % gate.
+- **Per-touched-file coverage floor on PRs** — every `packages/kobe/src` **`.ts`** file a PR touches must meet the line-coverage floor (default 50%, `scripts/coverage-gate.mjs`); `coverage-exemption: <reason>` in the PR body opts out with a paper trail. Coverage scope is unit-testable `.ts` logic — opentui `.tsx` components can't run under vitest and are pinned by the behavior suite instead. There is deliberately no repo-wide % gate.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -95,7 +95,7 @@ A bug fix is not done until the same commit carries a test that **fails before t
 
 ### Coverage gate (per-touched-file, PR CI)
 
-`cd packages/kobe && bun run coverage` writes text + `coverage/coverage-summary.json` (v8). CI's `coverage-cap` job gates PRs: every `packages/kobe/src` file the PR touches must meet the line-coverage floor (default 50%, `scripts/coverage-gate.mjs`); a file absent from the report counts as 0%. Escape hatch: a `coverage-exemption: <reason>` line in the PR body. Deliberately NO repo-wide % threshold — global bars breed filler tests; the per-touched-file floor ratchets coverage exactly where work happens.
+`cd packages/kobe && bun run coverage` writes text + `coverage/coverage-summary.json` (v8). CI's `coverage-cap` job gates PRs: every `packages/kobe/src` file the PR touches must meet the line-coverage floor (default 50%, `scripts/coverage-gate.mjs`); a file absent from the report counts as 0%. Escape hatch: a `coverage-exemption: <reason>` line in the PR body. Deliberately NO repo-wide % threshold — global bars breed filler tests; the per-touched-file floor ratchets coverage exactly where work happens. **Scope**: the metric covers `src/**/*.ts` only — opentui Solid components (`*.tsx`) cannot execute under vitest's node env (their behavior is pinned black-box in `test/behavior/`), so they are excluded from both the report and the gate rather than sitting in the denominator as unreachable 0% lines.
 
 ### When unit tests are still useful
 

--- a/packages/kobe/vitest.config.ts
+++ b/packages/kobe/vitest.config.ts
@@ -31,9 +31,14 @@ export default defineConfig({
     // `bun run coverage` / --coverage. v8 provider; json-summary feeds the
     // per-touched-file CI gate (scripts/coverage-gate.mjs), text is for humans.
     // No global % thresholds — the gate is per-file on files a PR touches.
+    // SCOPE: .ts only. opentui Solid components (src/**/*.tsx) cannot execute
+    // under vitest's node environment at all (0/6591 lines — the renderer
+    // needs a real terminal); their behavior is covered black-box by
+    // test/behavior/ (spawned dist subprocesses v8 can't attribute). Keeping
+    // them in the denominator made the % measure the runtime, not the tests.
     coverage: {
       provider: "v8",
-      include: ["src/**/*.ts", "src/**/*.tsx"],
+      include: ["src/**/*.ts"],
       reporter: ["text-summary", "json-summary", "lcov"],
       reportsDirectory: "./coverage",
     },

--- a/scripts/coverage-gate.mjs
+++ b/scripts/coverage-gate.mjs
@@ -39,7 +39,8 @@ const diff = execSync(`git diff --name-only --diff-filter=ACMR origin/${baseRef}
 const touched = diff
   .split("\n")
   .map((l) => l.trim())
-  .filter((f) => /^packages\/kobe\/src\/.*\.(ts|tsx)$/.test(f))
+  // .ts only — .tsx (opentui components) is outside the coverage scope; see vitest.config.ts.
+  .filter((f) => /^packages\/kobe\/src\/.*\.ts$/.test(f))
   .filter((f) => !f.endsWith(".d.ts"))
 
 if (touched.length === 0) {


### PR DESCRIPTION
opentui Solid components (src/**/*.tsx) cannot execute under vitest's node
environment at all — 0 of 6591 lines, the renderer needs a real terminal —
and their behavior is pinned black-box by test/behavior/ instead. Keeping
them in the denominator made the metric measure the runtime, not the tests
(all-.ts-covered capped the repo % at 72.7%). The report, the Codecov badge,
and the touched-file gate now all speak the same scope: src/**/*.ts, which
sits at 90.96% after #211.
