### PR TITLE
test: pin #205 orphaned-pane-process regression + doctor resource snapshot

### DIFF
--- a/.changeset/pane-leak-regression-net.md
+++ b/.changeset/pane-leak-regression-net.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+test: pin the #205 orphaned-pane-process regression + add a `kobe doctor` resource snapshot
+
+- `test/behavior/pane-cleanup.test.ts` boots a real kobe session, runs `kobe kill-sessions` (the command `kobe reset`/`dev:sandbox:reset` also call), and asserts every pane's full process group is gone after the exit grace — not just the pane leader, since an engine CLI that ignores SIGHUP (real `claude` does) survives as an orphaned child of an already-dead leader. Verified against a temporary revert of the `termAllPaneGroups()` sweep: the test fails and catches the leaked pid, then passes again with the fix restored.
+- The shared behavior-test fake `claude` shim (`test/behavior/harness.ts`) now ignores SIGHUP like the real CLI does, so this and future behavior tests exercise the same "engine survives HUP" path production hits.
+- `kobe doctor` gains a `resources:` section (`src/cli/doctor-resources.ts`): kobe pane-process count + RSS grouped by command, so a future memory report comes with hard numbers instead of "eventually had to kill bun manually".
+
+No behavior change to the shipped CLI beyond the new `kobe doctor` section.

--- a/packages/kobe/src/cli/doctor-resources.ts
+++ b/packages/kobe/src/cli/doctor-resources.ts
@@ -1,0 +1,84 @@
+/**
+ * Resource snapshot for `kobe doctor` — issue-triage context for
+ * memory/CPU complaints (#205). Nothing in this repo measures the thing
+ * that actually regressed twice (orphaned pane processes in 0.7.59, idle
+ * poller CPU in 0.7.60) — both were verified by eyeballing `ps aux`, not by
+ * a tool. This gives a structured `ps` snapshot to attach to a report
+ * instead of "eventually had to kill bun manually" (#205). Read-only, like
+ * the rest of doctor.
+ */
+
+import { KOBE_TMUX_SOCKET, runTmuxCapturing, tmuxAvailable } from "../tmux/client.ts"
+
+interface ProcessRow {
+  pid: number
+  pgid: number
+  rssKb: number
+  comm: string
+}
+
+/** Parse `ps -axo pid,pgid,rss,comm` output — one shape works across BSD
+ *  (macOS) and GNU (Linux CI) `ps`, so no platform branch is needed. */
+export function parsePsRows(psOutput: string): ProcessRow[] {
+  const rows: ProcessRow[] = []
+  for (const line of psOutput.split("\n").slice(1)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const [pid, pgid, rss, ...commParts] = trimmed.split(/\s+/)
+    const pidN = Number.parseInt(pid ?? "", 10)
+    const pgidN = Number.parseInt(pgid ?? "", 10)
+    const rssN = Number.parseInt(rss ?? "", 10)
+    if (!Number.isFinite(pidN) || !Number.isFinite(pgidN) || !Number.isFinite(rssN) || commParts.length === 0) continue
+    rows.push({ pid: pidN, pgid: pgidN, rssKb: rssN, comm: commParts.join(" ") })
+  }
+  return rows
+}
+
+/** Every process whose group leader is one of kobe's pane pids — the exact
+ *  set `killSession`'s SIGTERM sweep targets (tmux/client.ts termPaneGroups),
+ *  i.e. Tasks/Ops helpers, engine CLIs, and anything they spawned. */
+export function paneProcessGroups(rows: readonly ProcessRow[], panePids: readonly number[]): ProcessRow[] {
+  const groups = new Set(panePids)
+  return rows.filter((r) => groups.has(r.pgid))
+}
+
+async function listPanePids(): Promise<number[]> {
+  const { code, stdout } = await runTmuxCapturing(["list-panes", "-a", "-F", "#{pane_pid}"])
+  if (code !== 0) return []
+  return stdout
+    .split("\n")
+    .map((l) => Number.parseInt(l.trim(), 10))
+    .filter((n) => Number.isFinite(n) && n > 1)
+}
+
+async function psSnapshot(): Promise<ProcessRow[]> {
+  const proc = Bun.spawn(["ps", "-axo", "pid,pgid,rss,comm"], { stdin: "ignore", stdout: "pipe", stderr: "ignore" })
+  const [text] = await Promise.all([new Response(proc.stdout).text().catch(() => ""), proc.exited])
+  return parsePsRows(text)
+}
+
+/** The `resources:` doctor section: kobe pane-process count + RSS, grouped
+ *  by command, so a memory report comes with hard numbers. */
+export async function resourceDoctorLines(): Promise<string[]> {
+  if (!(await tmuxAvailable())) return ["resources: tmux not installed — no kobe sessions to measure"]
+  const panePids = await listPanePids()
+  if (panePids.length === 0) return [`resources: 0 process(es) on \`${KOBE_TMUX_SOCKET}\``]
+
+  const rows = paneProcessGroups(await psSnapshot(), panePids)
+  const totalMb = rows.reduce((sum, r) => sum + r.rssKb, 0) / 1024
+  const byComm = new Map<string, { count: number; kb: number }>()
+  for (const r of rows) {
+    const entry = byComm.get(r.comm) ?? { count: 0, kb: 0 }
+    entry.count++
+    entry.kb += r.rssKb
+    byComm.set(r.comm, entry)
+  }
+
+  const lines = [
+    `resources: ${rows.length} process(es) across ${panePids.length} pane(s) on \`${KOBE_TMUX_SOCKET}\`, ${totalMb.toFixed(1)} MB RSS total`,
+  ]
+  for (const [comm, { count, kb }] of [...byComm].sort((a, b) => b[1].kb - a[1].kb)) {
+    lines.push(`           ${comm}: ${count} proc, ${(kb / 1024).toFixed(1)} MB`)
+  }
+  return lines
+}

--- a/packages/kobe/src/cli/maintenance.ts
+++ b/packages/kobe/src/cli/maintenance.ts
@@ -35,6 +35,7 @@ import { homeDir, kobeStateDir, kvStatePath } from "../env.ts"
 import { SKILL_INSTALL_COMMAND, kobeSkillState } from "../lib/skill-install.ts"
 import { KOBE_TMUX_SOCKET, termAllPaneGroups, tmuxArgs, tmuxAvailable } from "../tmux/client.ts"
 import { CURRENT_VERSION } from "../version.ts"
+import { resourceDoctorLines } from "./doctor-resources.ts"
 import { terminalDoctorLines } from "./doctor-terminal.ts"
 
 /** `kill(pid, 0)` throws ESRCH once a process is gone; EPERM means it's
@@ -218,6 +219,11 @@ export async function runDoctorSubcommand(argv: readonly string[] = []): Promise
     out.push("tmux:    ✗ not found on PATH (task sessions need tmux)")
   }
   out.push("")
+
+  // --- resources --------------------------------------------------------
+  // Memory/CPU complaints (#205) had no hard numbers to triage from —
+  // attach this snapshot to a report instead of "eventually killed bun".
+  out.push(...(await resourceDoctorLines()), "")
 
   // --- agent skill ----------------------------------------------------
   const skill = kobeSkillState()

--- a/packages/kobe/test/behavior/harness.ts
+++ b/packages/kobe/test/behavior/harness.ts
@@ -60,7 +60,10 @@ export async function makeBehaviorEnv(): Promise<BehaviorEnv> {
   await writeFile(join(bin, "kobe"), `#!/bin/sh\nexec bun ${DIST_CLI} "$@"\n`)
   await chmod(join(bin, "kobe"), 0o755)
   // Fake engine so a task/engine pane renders without a real `claude` on CI.
-  await writeFile(join(bin, "claude"), `#!/bin/sh\necho "fake-claude ready"\nexec sleep 600\n`)
+  // Ignores SIGHUP like the real CLI does (`trap` sets SIG_IGN, which `exec`
+  // preserves) — pane-cleanup.test.ts depends on this to reproduce the
+  // "engine CLI swallows HUP" half of the #205/bc69596 leak.
+  await writeFile(join(bin, "claude"), `#!/bin/sh\ntrap '' HUP\necho "fake-claude ready"\nexec sleep 600\n`)
   await chmod(join(bin, "claude"), 0o755)
 
   const env: NodeJS.ProcessEnv = {

--- a/packages/kobe/test/behavior/pane-cleanup.test.ts
+++ b/packages/kobe/test/behavior/pane-cleanup.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression pin for the #205 memory-leak class (orphaned pane-process leak,
+ * `bc69596`/0.7.59): a killed session's pane leader dies to tmux's default
+ * SIGHUP, but an engine CLI that ignores HUP (real `claude` does, so the
+ * fake shim in ./harness.ts does too) survives as a CHILD of that pane,
+ * reparented to launchd once its parent is gone — invisible to
+ * `tmux list-panes` (the session is already gone) but still burning RAM/CPU.
+ * Over a hundred such zombies ate ~14 GB / 100%+ CPU in a busy week before
+ * `killSession`/`kobe kill-sessions`/`kobe reset` started SIGTERM-ing each
+ * pane's whole PROCESS GROUP first. Checking only the pane leader pid (not
+ * its group) would miss exactly this child-survives-parent-dies case, so
+ * this test expands to the full group via `ps`, the same way `kobe doctor`'s
+ * resource snapshot does (doctor-resources.ts).
+ */
+
+import { spawnSync } from "node:child_process"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { paneProcessGroups, parsePsRows } from "../../src/cli/doctor-resources.ts"
+import {
+  type BehaviorEnv,
+  makeBehaviorEnv,
+  makeScratchRepo,
+  runKobe,
+  tmux,
+  tmuxAvailable,
+  tmuxInner,
+  waitForScreen,
+} from "./harness.ts"
+
+const SESSION = "leak-check"
+
+/** `kill(pid, 0)` throws ESRCH once a process is gone; EPERM means it's
+ *  alive but owned by someone else (same check as `kobe doctor`). */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM"
+  }
+}
+
+function psSnapshot(): ReturnType<typeof parsePsRows> {
+  const r = spawnSync("ps", ["-axo", "pid,pgid,rss,comm"], { encoding: "utf8" })
+  return parsePsRows(r.stdout ?? "")
+}
+
+describe.skipIf(!tmuxAvailable())("pane-process cleanup on `kobe kill-sessions` (#205 regression)", () => {
+  let env: BehaviorEnv
+
+  beforeAll(async () => {
+    env = await makeBehaviorEnv()
+    const repo = await makeScratchRepo(env)
+    const boot = tmux(env, "new-session", "-d", "-x", "180", "-y", "45", "-s", SESSION, `cd ${repo} && kobe`)
+    expect(boot.code).toBe(0)
+    await waitForScreen(env, SESSION, (s) => s.includes("fake-claude ready"), 45_000)
+  }, 60_000)
+
+  afterAll(async () => {
+    await env.dispose()
+  })
+
+  it("leaves no surviving process in any pane's group after the exit grace", async () => {
+    const panePids = tmuxInner(env, "list-panes", "-a", "-F", "#{pane_pid}")
+      .stdout.split("\n")
+      .map((l) => Number.parseInt(l.trim(), 10))
+      .filter((n) => Number.isFinite(n) && n > 1)
+    // Tasks + Ops + engine at minimum.
+    expect(panePids.length).toBeGreaterThanOrEqual(3)
+
+    // Expand each pane leader to its FULL process group — the engine's fake
+    // `claude` (ignores HUP) lives as a CHILD of the pane leader, not the
+    // leader itself, so checking only `panePids` would miss it surviving.
+    const groupPids = paneProcessGroups(psSnapshot(), panePids).map((r) => r.pid)
+    expect(groupPids.length).toBeGreaterThanOrEqual(panePids.length)
+
+    // The command a user in #205's position actually runs (also what
+    // `kobe reset` and `dev:sandbox:reset` call under the hood): SIGTERM
+    // every pane's process group, then kill the tmux server.
+    const result = runKobe(["kill-sessions"], env)
+    expect(result.code).toBe(0)
+
+    // host-boot.tsx's exit-signal backstop gives itself a 5s grace before
+    // `process.exit(0)`; poll instead of a flat sleep so a fast pass isn't
+    // slowed down by it.
+    const deadline = Date.now() + 15_000
+    let stragglers = groupPids.filter(isAlive)
+    while (stragglers.length > 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 300))
+      stragglers = groupPids.filter(isAlive)
+    }
+    expect(stragglers).toEqual([])
+  }, 20_000)
+})

--- a/packages/kobe/test/cli/doctor-resources.test.ts
+++ b/packages/kobe/test/cli/doctor-resources.test.ts
@@ -1,0 +1,44 @@
+/**
+ * `kobe doctor` resource section — pure halves only (ps-output parsing +
+ * pane-group filtering). Why this matters: #205's memory reports had no
+ * hard numbers to triage from; this is the parsing kobe uses to build them.
+ */
+
+import { describe, expect, test } from "vitest"
+import { paneProcessGroups, parsePsRows } from "../../src/cli/doctor-resources"
+
+describe("parsePsRows", () => {
+  test("parses pid/pgid/rss/comm, skipping the header row", () => {
+    const output = ["  PID  PGID    RSS COMM", "  501   501   3168 kobe tasks", "  502   501   1536 /bin/sh"].join("\n")
+    expect(parsePsRows(output)).toEqual([
+      { pid: 501, pgid: 501, rssKb: 3168, comm: "kobe tasks" },
+      { pid: 502, pgid: 501, rssKb: 1536, comm: "/bin/sh" },
+    ])
+  })
+
+  test("ignores blank lines and unparseable rows", () => {
+    const output = ["  PID  PGID    RSS COMM", "", "   not a row at all", "  501   501   3168 kobe ops"].join("\n")
+    expect(parsePsRows(output)).toEqual([{ pid: 501, pgid: 501, rssKb: 3168, comm: "kobe ops" }])
+  })
+
+  test("empty input yields no rows", () => {
+    expect(parsePsRows("")).toEqual([])
+    expect(parsePsRows("  PID  PGID    RSS COMM")).toEqual([])
+  })
+})
+
+describe("paneProcessGroups", () => {
+  test("keeps only rows whose pgid is one of the given pane pids", () => {
+    const rows = [
+      { pid: 501, pgid: 501, rssKb: 3168, comm: "kobe tasks" },
+      { pid: 610, pgid: 600, rssKb: 9000, comm: "claude" },
+      { pid: 1, pgid: 1, rssKb: 9999, comm: "launchd" },
+    ]
+    expect(paneProcessGroups(rows, [501, 600])).toEqual([rows[0], rows[1]])
+  })
+
+  test("no matching pane pids yields no rows", () => {
+    const rows = [{ pid: 501, pgid: 501, rssKb: 3168, comm: "kobe tasks" }]
+    expect(paneProcessGroups(rows, [999])).toEqual([])
+  })
+})

--- a/packages/kobe/test/cli/doctor-resources.test.ts
+++ b/packages/kobe/test/cli/doctor-resources.test.ts
@@ -1,11 +1,29 @@
 /**
- * `kobe doctor` resource section — pure halves only (ps-output parsing +
- * pane-group filtering). Why this matters: #205's memory reports had no
- * hard numbers to triage from; this is the parsing kobe uses to build them.
+ * `kobe doctor` resource section — pure halves (ps-output parsing +
+ * pane-group filtering) plus the async wiring (`resourceDoctorLines`)
+ * against a mocked tmux + `ps`. Why this matters: #205's memory reports had
+ * no hard numbers to triage from; this is what kobe uses to build them.
  */
 
-import { describe, expect, test } from "vitest"
-import { paneProcessGroups, parsePsRows } from "../../src/cli/doctor-resources"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  tmuxAvailable: vi.fn(),
+  runTmuxCapturing: vi.fn(),
+  bunSpawn: vi.fn(),
+}))
+
+vi.mock("../../src/tmux/client.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/tmux/client.ts")>()
+  return {
+    ...actual,
+    KOBE_TMUX_SOCKET: "kobe-test",
+    tmuxAvailable: mocks.tmuxAvailable,
+    runTmuxCapturing: mocks.runTmuxCapturing,
+  }
+})
+
+import { paneProcessGroups, parsePsRows, resourceDoctorLines } from "../../src/cli/doctor-resources"
 
 describe("parsePsRows", () => {
   test("parses pid/pgid/rss/comm, skipping the header row", () => {
@@ -40,5 +58,52 @@ describe("paneProcessGroups", () => {
   test("no matching pane pids yields no rows", () => {
     const rows = [{ pid: 501, pgid: 501, rssKb: 3168, comm: "kobe tasks" }]
     expect(paneProcessGroups(rows, [999])).toEqual([])
+  })
+})
+
+describe("resourceDoctorLines", () => {
+  beforeEach(() => {
+    mocks.tmuxAvailable.mockReset()
+    mocks.runTmuxCapturing.mockReset()
+    mocks.bunSpawn.mockReset()
+    vi.stubGlobal("Bun", { spawn: mocks.bunSpawn })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test("tmux not installed", async () => {
+    mocks.tmuxAvailable.mockResolvedValue(false)
+    expect(await resourceDoctorLines()).toEqual(["resources: tmux not installed — no kobe sessions to measure"])
+  })
+
+  test("tmux installed, no kobe panes", async () => {
+    mocks.tmuxAvailable.mockResolvedValue(true)
+    mocks.runTmuxCapturing.mockResolvedValue({ code: 0, stdout: "" })
+    expect(await resourceDoctorLines()).toEqual(["resources: 0 process(es) on `kobe-test`"])
+  })
+
+  test("groups pane-group processes by command with RSS totals", async () => {
+    mocks.tmuxAvailable.mockResolvedValue(true)
+    mocks.runTmuxCapturing.mockResolvedValue({ code: 0, stdout: "501\n502\n" })
+    mocks.bunSpawn.mockImplementation(() => ({
+      stdout: new Response(
+        ["  PID  PGID    RSS COMM", "  501   501   3168 zsh", "  510   501   9000 bun", "  502   502   1536 zsh"].join(
+          "\n",
+        ),
+      ).body,
+      exited: Promise.resolve(0),
+    }))
+    const lines = await resourceDoctorLines()
+    expect(lines[0]).toBe("resources: 3 process(es) across 2 pane(s) on `kobe-test`, 13.4 MB RSS total")
+    expect(lines).toContain("           bun: 1 proc, 8.8 MB")
+    expect(lines).toContain("           zsh: 2 proc, 4.6 MB")
+  })
+
+  test("list-panes failure yields zero pane pids, not a crash", async () => {
+    mocks.tmuxAvailable.mockResolvedValue(true)
+    mocks.runTmuxCapturing.mockResolvedValue({ code: 1, stdout: "" })
+    expect(await resourceDoctorLines()).toEqual(["resources: 0 process(es) on `kobe-test`"])
   })
 })


### PR DESCRIPTION
## Summary
- Adds `test/behavior/pane-cleanup.test.ts`: boots a real kobe session, runs `kobe kill-sessions` (same command `kobe reset`/`dev:sandbox:reset` call), and asserts every pane's *full process group* — not just the pane leader — is gone after the exit grace. An engine CLI that ignores SIGHUP (real `claude` does) survives as an orphaned child once its pane leader dies to tmux's default HUP, which is exactly the #205/`bc69596` class of leak (over a hundred zombies, ~14GB/100%+ CPU in a busy week) that no test caught before.
- The shared behavior-test fake `claude` shim now ignores SIGHUP like the real CLI, so this (and future) behavior tests exercise the same path production hits.
- Adds a `resources:` section to `kobe doctor` (`src/cli/doctor-resources.ts`, same shape as the existing `doctor-terminal.ts`): pane-process count + RSS grouped by command, so a future memory report comes with hard numbers instead of "eventually had to kill bun manually."
- No behavior change to the shipped CLI beyond the new `kobe doctor` section.

## Why
#205 asked for continued investigation of memory reports after the 0.7.59 (orphaned-pane-process) and 0.7.60 (idle-poller CPU) fixes. Neither of those had an automated regression check — both were verified by eyeballing `ps aux`. This closes that gap with a process-*count* assertion (consistent with `docs/HARNESS.md`'s "counting tests gate CI, wall-clock/byte assertions never do" philosophy — not a new profiler or telemetry service).

Verification: I temporarily reverted the `termAllPaneGroups()` SIGTERM sweep and confirmed the new test fails and reports the exact leaked pid, then restored the fix and confirmed it passes — so this isn't a vacuous assertion.

## Test plan
- [x] `bun run typecheck` / `bun run lint` (repo root) — clean
- [x] `bun run test:fast` — 2207/2207 passing
- [x] `KOBE_INCLUDE_BEHAVIOR=1 vitest run test/behavior/` — 12/12 passing, including the new test
- [x] Confirmed the new test fails (catches a leaked pid) when the `termAllPaneGroups()` fix is reverted, and passes again once restored
- [ ] CI green