### PR TITLE
test(kobe): add bun-test render track for .tsx components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@
 # coverage-cap (PR only) is the coverage sibling of file-size-cap: every
 # packages/kobe/src file a PR touches must meet a line-coverage floor
 # (scripts/coverage-gate.mjs; `coverage-exemption: <reason>` in the PR body
-# opts out with a paper trail).
+# opts out with a paper trail). It also runs `test:render` (the bun-test-only
+# .tsx render track, see docs/HARNESS.md "render track") and folds its lcov
+# into the same Codecov upload — not yet per-file gated.
 
 name: CI
 
@@ -154,11 +156,20 @@ jobs:
         working-directory: packages/kobe
         run: bun run coverage
 
+      - name: Render-track coverage (kobe package .tsx)
+        # bun test + @opentui/solid's testRender (docs/HARNESS.md "render
+        # track") — the only runner that can execute opentui Solid
+        # components at all. Separate report; not gated per-file (yet), just
+        # folded into the Codecov upload below so the repo-wide badge
+        # reflects .tsx too.
+        working-directory: packages/kobe
+        run: bun run test:render
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/kobe/coverage/lcov.info
+          files: packages/kobe/coverage/lcov.info,packages/kobe/coverage-render/lcov.info
           fail_ci_if_error: false
 
       - name: Touched files must meet the coverage floor

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ packages/*/.dev-sandbox/
 # json-summary in-place, nothing here is source.
 packages/*/coverage/
 
+# `bun test test/render --coverage` output (the render-track sibling of the
+# vitest coverage/ above) — see docs/HARNESS.md "render track".
+packages/*/coverage-render/
+
 # Session handoff — local working state / scratchpad for the next agent in
 # THIS environment. Not shared history (the durable record lives in git
 # commits, CHANGELOG.md, docs/, and the daemon issue store). Keep it local.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -95,7 +95,39 @@ A bug fix is not done until the same commit carries a test that **fails before t
 
 ### Coverage gate (per-touched-file, PR CI)
 
-`cd packages/kobe && bun run coverage` writes text + `coverage/coverage-summary.json` (v8). CI's `coverage-cap` job gates PRs: every `packages/kobe/src` file the PR touches must meet the line-coverage floor (default 50%, `scripts/coverage-gate.mjs`); a file absent from the report counts as 0%. Escape hatch: a `coverage-exemption: <reason>` line in the PR body. Deliberately NO repo-wide % threshold — global bars breed filler tests; the per-touched-file floor ratchets coverage exactly where work happens. **Scope**: the metric covers `src/**/*.ts` only — opentui Solid components (`*.tsx`) cannot execute under vitest's node env (their behavior is pinned black-box in `test/behavior/`), so they are excluded from both the report and the gate rather than sitting in the denominator as unreachable 0% lines.
+`cd packages/kobe && bun run coverage` writes text + `coverage/coverage-summary.json` (v8). CI's `coverage-cap` job gates PRs: every `packages/kobe/src` file the PR touches must meet the line-coverage floor (default 50%, `scripts/coverage-gate.mjs`); a file absent from the report counts as 0%. Escape hatch: a `coverage-exemption: <reason>` line in the PR body. Deliberately NO repo-wide % threshold — global bars breed filler tests; the per-touched-file floor ratchets coverage exactly where work happens. **Scope**: the metric covers `src/**/*.ts` only — opentui Solid components (`*.tsx`) cannot execute under vitest's node env (their behavior is pinned black-box in `test/behavior/`), so they are excluded from both the report and the gate rather than sitting in the denominator as unreachable 0% lines. `.tsx` gets its own report from the render track below, uploaded to Codecov alongside the `.ts` report but **not yet gated per-file**.
+
+### Render track (`bun test` + `@opentui/solid`'s `testRender`)
+
+A second, narrower test track for `src/**/*.tsx` — opentui Solid components. Lives entirely under `packages/kobe/test/render/`, invisible to vitest (`vitest.config.ts` excludes `test/render/**` — the two runners would otherwise fight over `bun:test` globals and vitest's node environment can't execute opentui anyway).
+
+**Why `bun test`, not vitest**: `@opentui/core` ships raw `.scm`/`.wasm` tree-sitter assets via `with { type: "file" }` imports that vitest's node environment can't resolve, and the JSX needs `@opentui/solid`'s Babel-driven transform rather than vitest's default. `bun test --preload @opentui/solid/preload` is the one runner where both resolve natively — confirmed by a throwaway spike before this track was built. The preload must be under `bunfig.toml`'s `[test]` table specifically: the top-level `preload` key (used by `bun run dev`/`dev:mock`) is **not** read by `bun test`.
+
+**Running it**: `cd packages/kobe && bun run test:render` (plain `bun test test/render` works too; always scope the path argument to `test/render` — an unscoped `bun test` would also try to execute the vitest suites' `*.test.ts` files, which use `vi.mock` and blow up under bun's runner). Coverage: `--coverage --coverage-reporter=lcov --coverage-dir=coverage-render` (gitignored, matching `coverage/`).
+
+**Writing a new component test**: import `renderComponent` from `test/render/harness.tsx`.
+
+```tsx
+import { describe, expect, it } from "bun:test"
+import { MyDialog } from "../../src/tui/component/my-dialog"
+import { renderComponent } from "./harness"
+
+it("shows the title and confirms on enter", async () => {
+  const { frame, mockInput } = await renderComponent(() => <MyDialog title="Delete task?" />, {
+    providers: { dialog: true }, // opt into Theme(default)/KV/Focus/Dialog/Notifications as needed
+  })
+  expect(await frame()).toContain("Delete task?")
+  mockInput.pressEnter() // NOT pressKey("return") — string literals are typed verbatim; use the named helpers
+  expect(await frame()).toContain("...")
+})
+```
+
+Three gotchas the harness's own tests hit first, so later ones don't have to:
+1. **`mockInput.pressKey("return")`/`"escape"`/`"left"` do nothing** — those lowercase names aren't in opentui's `KeyCodes` table, so the string is typed as literal text instead. Use the named convenience methods (`pressEnter()`, `pressEscape()`, `pressArrow("left"|"right"|"up"|"down")`, `pressTab()`, `pressBackspace()`, `pressCtrlC()`) or a single literal character (`pressKey("?")`) instead.
+2. **`pressEscape()` needs a settle tick** — a lone ESC byte is ambiguous with a multi-byte escape sequence, so the parser holds it briefly before deciding it's a standalone key. `await settle()` (exported from `harness.tsx`) before asserting.
+3. **A `let result: T | undefined = undefined` mutated inside an async callback narrows to `undefined` under `tsc`** (a classic closure-narrowing gotcha, not opentui-specific) — drop the `= undefined` initializer (`let result: T | undefined`) so TS doesn't narrow the declared type down to the literal.
+
+Skipped for now: the four large pane hosts (`tasks-pane/host.tsx`, `panes/filetree/FileTree.tsx`, `component/settings-dialog.tsx`, `component/settings-dialog/sections.tsx`) pending the issue #12 split, and every `*/host.tsx` CLI entry point (`new-task/host.tsx`, `quick-task/host.tsx`, `settings/host.tsx`, `update/host.tsx`, `help/host.tsx`, `history/host.tsx`, `ops/host.tsx`) — those call `render()` and connect to the daemon; they're process bootstrappers, not embeddable components, and are already covered black-box by `test/behavior/`.
 
 ### When unit tests are still useful
 

--- a/packages/kobe/bunfig.toml
+++ b/packages/kobe/bunfig.toml
@@ -2,3 +2,13 @@
 exact = true
 
 preload = ["@opentui/solid/preload"]
+
+# `bun test` does NOT read the top-level `preload` above (that only applies
+# to `bun run`/`bun <script>`) — it needs its own [test] table. Without this,
+# opentui/solid's Babel-driven JSX transform never registers and every .tsx
+# render test fails to parse JSX. See test/render/harness.tsx.
+[test]
+preload = ["@opentui/solid/preload"]
+# Keep the coverage report scoped to the components under test — harness.tsx
+# and fixtures.ts are test infra, not the thing being measured.
+coveragePathIgnorePatterns = ["test/render/harness.tsx", "test/render/fixtures.ts"]

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -38,6 +38,7 @@
     "test:fast": "vitest run --passWithNoTests",
     "test:socket": "KOBE_INCLUDE_SOCKET=1 vitest run test/daemon --pool forks --minWorkers=1 --maxWorkers=1 --passWithNoTests",
     "test:behavior": "KOBE_INCLUDE_BEHAVIOR=1 vitest run test/behavior --passWithNoTests",
+    "test:render": "bun test test/render --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage-render",
     "coverage": "vitest run --coverage --passWithNoTests",
     "bench": "vitest bench --run",
     "lint": "biome check .",

--- a/packages/kobe/src/tui/lib/keymap.tsx
+++ b/packages/kobe/src/tui/lib/keymap.tsx
@@ -38,15 +38,26 @@ export { dispatchKeyEvent } from "./keymap-dispatch"
 
 let nextId = 1
 const stack: RegisteredBinding[] = []
+// `installedRenderer` guards against re-attaching the listener on every
+// keystroke; it does NOT assume there's only ever one renderer per process.
+// Production only ever runs one renderer per process, so `renderer ===
+// installedRenderer` is true from the second call onward and this is a
+// no-op — but the render test track (test/render/harness.tsx) creates a
+// fresh `testRender()` renderer per test in the SAME process, and without
+// rebinding here every test after the first would silently attach zero
+// listeners to its own (destroyed) predecessor's keyInput emitter.
+let installedRenderer: unknown = null
 let installed: KeyHandler | null = null
 let listener: ((evt: KeyEvent) => void) | null = null
 
 function ensureInstalled() {
-  if (installed) return
   const renderer = useRenderer()
   if (!renderer) {
     throw new Error("useBindings: no renderer in scope; call inside a component rendered by @opentui/solid.")
   }
+  if (installedRenderer === renderer) return
+  if (installed && listener) installed.off("keypress", listener)
+  installedRenderer = renderer
   installed = renderer.keyInput
   listener = (evt: KeyEvent) => {
     dispatchKeyEvent(stack, evt)

--- a/packages/kobe/test/render/dialog-confirm.test.tsx
+++ b/packages/kobe/test/render/dialog-confirm.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * DialogConfirm — yes/no prompt (src/tui/ui/dialog-confirm.tsx). Drives the
+ * real DialogProvider stack (DialogConfirm.show pushes onto it) and asserts
+ * on the actual keyboard flow: left/right swaps the focused button, enter
+ * commits, esc cancels via the dialog's own escape binding.
+ */
+import { describe, expect, it } from "bun:test"
+import { useDialog } from "../../src/tui/ui/dialog"
+import { DialogConfirm } from "../../src/tui/ui/dialog-confirm"
+import { renderComponent, settle } from "./harness"
+
+function Harness(props: { onResult: (v: boolean | undefined) => void }) {
+  const dialog = useDialog()
+  void DialogConfirm.show(dialog, "Delete task?", "This cannot be undone.").then(props.onResult)
+  return <box />
+}
+
+describe("DialogConfirm", () => {
+  it("shows the title and message, confirm focused by default", async () => {
+    const { frame } = await renderComponent(() => <Harness onResult={() => {}} />, {
+      providers: { dialog: true },
+    })
+    const text = await frame()
+    expect(text).toContain("Delete task?")
+    expect(text).toContain("This cannot be undone.")
+    expect(text).toContain("Confirm")
+    expect(text).toContain("Cancel")
+  })
+
+  it("enter on the default-focused Confirm button resolves true", async () => {
+    let result: boolean | undefined
+    const { frame, mockInput } = await renderComponent(
+      () => (
+        <Harness
+          onResult={(v) => {
+            result = v
+          }}
+        />
+      ),
+      {
+        providers: { dialog: true },
+      },
+    )
+    await frame()
+    mockInput.pressEnter()
+    await frame()
+    expect(result).toBe(true)
+  })
+
+  it("left then enter switches focus to Cancel and resolves false", async () => {
+    let result: boolean | undefined
+    const { frame, mockInput } = await renderComponent(
+      () => (
+        <Harness
+          onResult={(v) => {
+            result = v
+          }}
+        />
+      ),
+      {
+        providers: { dialog: true },
+      },
+    )
+    await frame()
+    mockInput.pressArrow("left")
+    mockInput.pressEnter()
+    await frame()
+    expect(result).toBe(false)
+  })
+
+  it("esc dismisses without resolving true or false", async () => {
+    let result: boolean | undefined = "unset" as unknown as boolean | undefined
+    const { frame, mockInput } = await renderComponent(
+      () => (
+        <Harness
+          onResult={(v) => {
+            result = v
+          }}
+        />
+      ),
+      {
+        providers: { dialog: true },
+      },
+    )
+    await frame()
+    mockInput.pressEscape()
+    await settle()
+    await frame()
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/kobe/test/render/dialog-stack.test.tsx
+++ b/packages/kobe/test/render/dialog-stack.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * DialogProvider / useDialog — the dialog stack itself (src/tui/ui/dialog.tsx),
+ * independent of any concrete dialog. push/replace/clear + the esc/ctrl+c
+ * dismiss-top binding every *Dialog component relies on.
+ */
+import { describe, expect, it } from "bun:test"
+import { DialogProvider, useDialog } from "../../src/tui/ui/dialog"
+import { renderComponent, settle } from "./harness"
+
+function Driver(props: { onReady: (dialog: ReturnType<typeof useDialog>) => void }) {
+  const dialog = useDialog()
+  props.onReady(dialog)
+  return <text>base content</text>
+}
+
+describe("DialogProvider", () => {
+  it("renders no overlay when the stack is empty", async () => {
+    const { frame } = await renderComponent(() => <DialogProvider>{<Driver onReady={() => {}} />}</DialogProvider>)
+    const text = await frame()
+    expect(text).toContain("base content")
+  })
+
+  it("push shows the dialog body on top of the base content", async () => {
+    const { frame } = await renderComponent(() => (
+      <DialogProvider>
+        <Driver onReady={(dialog) => dialog.push(() => <text>dialog A</text>)} />
+      </DialogProvider>
+    ))
+    const text = await frame()
+    expect(text).toContain("base content")
+    expect(text).toContain("dialog A")
+  })
+
+  it("replace swaps the top dialog instead of stacking", async () => {
+    const { frame } = await renderComponent(() => (
+      <DialogProvider>
+        <Driver
+          onReady={(dialog) => {
+            dialog.push(() => <text>dialog A</text>)
+            dialog.replace(() => <text>dialog B</text>)
+          }}
+        />
+      </DialogProvider>
+    ))
+    const text = await frame()
+    expect(text).not.toContain("dialog A")
+    expect(text).toContain("dialog B")
+  })
+
+  it("esc pops the top dialog and fires its onClose", async () => {
+    let closed = false
+    const dialogRef: { current?: ReturnType<typeof useDialog> } = {}
+    const { frame, mockInput } = await renderComponent(() => (
+      <DialogProvider>
+        <Driver
+          onReady={(dialog) => {
+            dialogRef.current = dialog
+            dialog.push(
+              () => <text>dialog A</text>,
+              () => {
+                closed = true
+              },
+            )
+          }}
+        />
+      </DialogProvider>
+    ))
+    expect(await frame()).toContain("dialog A")
+    mockInput.pressEscape()
+    await settle()
+    await frame()
+    expect(closed).toBe(true)
+    expect(dialogRef.current?.stack.length).toBe(0)
+  })
+
+  it("clear empties the whole stack at once", async () => {
+    const dialogRef: { current?: ReturnType<typeof useDialog> } = {}
+    const { frame } = await renderComponent(() => (
+      <DialogProvider>
+        <Driver
+          onReady={(dialog) => {
+            dialogRef.current = dialog
+            dialog.push(() => <text>dialog A</text>)
+            dialog.push(() => <text>dialog B</text>)
+          }}
+        />
+      </DialogProvider>
+    ))
+    expect(await frame()).toContain("dialog B")
+    dialogRef.current?.clear()
+    const text = await frame()
+    expect(text).not.toContain("dialog B")
+    expect(dialogRef.current?.stack.length).toBe(0)
+  })
+})

--- a/packages/kobe/test/render/focus-provider.test.tsx
+++ b/packages/kobe/test/render/focus-provider.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * FocusProvider — pane focus context (src/tui/context/focus.tsx). Imports
+ * @opentui/solid (useRenderer) so it can't run under vitest at all; this is
+ * its only coverage. Drives the real reactive `focused`/`cycle`/`setFocused`
+ * surface every pane wrapper reads.
+ */
+import { describe, expect, it } from "bun:test"
+import { FocusProvider, useFocus } from "../../src/tui/context/focus"
+import { renderComponent } from "./harness"
+
+function Probe() {
+  const focus = useFocus()
+  return (
+    <box flexDirection="column">
+      <text>{`focused:${focus.focused()}`}</text>
+      <text>{`sidebar:${focus.is("sidebar")()}`}</text>
+      <text>{`workspace:${focus.is("workspace")()}`}</text>
+    </box>
+  )
+}
+
+describe("FocusProvider", () => {
+  it("defaults to the sidebar pane", async () => {
+    const { frame } = await renderComponent(() => (
+      <FocusProvider>
+        <Probe />
+      </FocusProvider>
+    ))
+    const text = await frame()
+    expect(text).toContain("focused:sidebar")
+    expect(text).toContain("sidebar:true")
+    expect(text).toContain("workspace:false")
+  })
+
+  it("honors an explicit `initial` pane", async () => {
+    const { frame } = await renderComponent(() => (
+      <FocusProvider initial="terminal">
+        <Probe />
+      </FocusProvider>
+    ))
+    expect(await frame()).toContain("focused:terminal")
+  })
+
+  it("setFocused moves focus and cycle wraps through PANE_ORDER", async () => {
+    let cycleFn: ((delta: 1 | -1) => void) | undefined
+    let setFocusedFn: ((pane: "sidebar" | "workspace" | "files" | "terminal") => void) | undefined
+    function Driver() {
+      const focus = useFocus()
+      cycleFn = focus.cycle
+      setFocusedFn = focus.setFocused
+      return <text>{`focused:${focus.focused()}`}</text>
+    }
+    const { frame } = await renderComponent(() => (
+      <FocusProvider>
+        <Driver />
+      </FocusProvider>
+    ))
+    expect(await frame()).toContain("focused:sidebar")
+
+    setFocusedFn?.("files")
+    expect(await frame()).toContain("focused:files")
+
+    cycleFn?.(1) // files -> terminal (PANE_ORDER: sidebar, workspace, files, terminal)
+    expect(await frame()).toContain("focused:terminal")
+
+    cycleFn?.(1) // terminal wraps back to sidebar
+    expect(await frame()).toContain("focused:sidebar")
+  })
+})

--- a/packages/kobe/test/render/harness.tsx
+++ b/packages/kobe/test/render/harness.tsx
@@ -1,0 +1,180 @@
+/**
+ * Render-track test harness — mount a REAL opentui Solid component and
+ * assert on its actual rendered frame / keyboard interaction.
+ *
+ * Why `bun test`, not vitest: opentui Solid components (`src/**\/*.tsx`)
+ * cannot execute under vitest's node environment at all — `@opentui/core`
+ * ships raw `.scm`/`.wasm` assets via `with { type: "file" }` imports that
+ * node's loader can't resolve, and the JSX needs `@opentui/solid`'s
+ * Babel-driven transform, not vitest's default. `bun test --preload
+ * @opentui/solid/preload` is the one runner where both resolve natively
+ * (verified: spike-artifacts/tsx-render.spike.bun.test.tsx). Their `.test.ts`
+ * sibling required a hand-rolled JSX bridge + asset stubs and is not worth
+ * carrying forward. See docs/HARNESS.md "render track" and vitest.config.ts's
+ * `test/render/**` exclusion (this whole directory is invisible to vitest).
+ *
+ * Usage:
+ *
+ *   import { renderComponent } from "./harness"
+ *
+ *   test("shows the confirm title", async () => {
+ *     const { frame, mockInput, destroy } = await renderComponent(
+ *       () => <MyDialog title="Delete task?" />,
+ *       { providers: { dialog: true } },
+ *     )
+ *     expect(await frame()).toContain("Delete task?")
+ *     mockInput.pressKey("return")
+ *     expect(await frame()).toContain("...")
+ *     destroy() // optional — afterEach also cleans up any renderer left open
+ *   })
+ */
+
+import { afterEach } from "bun:test"
+import { EventEmitter } from "node:events"
+import type { CapturedFrame } from "@opentui/core"
+import type { MockInput, MockMouse, TestRenderer } from "@opentui/core/testing"
+import { testRender } from "@opentui/solid"
+import type { JSX } from "solid-js"
+import { FocusProvider } from "../../src/tui/context/focus"
+import { KVProvider } from "../../src/tui/context/kv"
+import { NotificationsProvider } from "../../src/tui/context/notifications"
+import { ThemeProvider } from "../../src/tui/context/theme"
+import { DialogProvider } from "../../src/tui/ui/dialog"
+
+/** Which ambient providers to mount around the component under test. All default off except `theme`. */
+export interface ProviderFlags {
+  /** `<ThemeProvider theme="claude">`. Default true — nearly every component reads `useTheme()`. */
+  theme?: boolean
+  /** `<KVProvider>` — persisted UI state. Reads/writes `~/.config/kobe/state.json` (or `$KOBE_HOME_DIR`); set that env var in a test that enables this. Default false. */
+  kv?: boolean
+  /** `<FocusProvider>` — pane focus context. Default false. */
+  focus?: boolean
+  /** `<DialogProvider>` — the dialog stack (`useDialog()`). Required by every `*Dialog`/`*Composer` component. Default false. */
+  dialog?: boolean
+  /** `<NotificationsProvider>` — toast queue (`useNotifications()`). Implies `kv` (NotificationsProvider reads `useKV()`). Default false. */
+  notifications?: boolean
+}
+
+export interface RenderOptions {
+  width?: number
+  height?: number
+  providers?: ProviderFlags
+}
+
+export interface RenderHandle {
+  renderer: TestRenderer
+  mockInput: MockInput
+  mockMouse: MockMouse
+  /** Flush a render pass and return the captured char-grid frame as a string. */
+  frame: () => Promise<string>
+  /** Flush a render pass without capturing — use between multiple `mockInput` actions when only the final frame matters. */
+  rerender: () => Promise<void>
+  /** Flush a render pass and return the captured frame with per-span colors/attributes — for assertions that need actual fg/bg (a text frame is colorless). */
+  spans: () => Promise<CapturedFrame>
+  resize: (width: number, height: number) => void
+  destroy: () => void
+}
+
+// Tracks the most recently created renderer so `afterEach` can destroy it
+// even if a test forgets to (or fails before reaching its own destroy()) —
+// opentui renderers hold real timers/listeners and leak across tests
+// otherwise. Single-slot is enough: render tests never overlap two
+// renderers within one test.
+let liveRenderer: TestRenderer | null = null
+
+// opentui/core's process-wide `TerminalConsoleCache` singleton picks up one
+// listener per `testRender()` call; a render-track file with more than 10
+// tests trips Node's default max-listener warning even though every
+// renderer is destroyed in `afterEach`. Cosmetic only — bump the ceiling
+// rather than chase a leak that isn't one.
+EventEmitter.defaultMaxListeners = 200
+
+afterEach(() => {
+  if (!liveRenderer) return
+  try {
+    liveRenderer.destroy()
+  } catch {
+    // already destroyed by the test itself — fine
+  }
+  liveRenderer = null
+})
+
+/** Wrap `ui` in the requested providers, innermost-to-outermost: Theme > KV > Focus > Dialog > Notifications — the same nesting order `lib/host-boot.tsx` mounts for every real pane host. */
+function withProviders(ui: () => JSX.Element, flags: ProviderFlags | undefined): () => JSX.Element {
+  const { theme = true, kv = false, focus = false, dialog = false, notifications = false } = flags ?? {}
+  let node = ui
+  if (notifications) {
+    const inner = node
+    node = () => <NotificationsProvider>{inner()}</NotificationsProvider>
+  }
+  if (dialog) {
+    const inner = node
+    node = () => <DialogProvider>{inner()}</DialogProvider>
+  }
+  if (focus) {
+    const inner = node
+    node = () => <FocusProvider>{inner()}</FocusProvider>
+  }
+  if (kv || notifications) {
+    const inner = node
+    node = () => <KVProvider>{inner()}</KVProvider>
+  }
+  if (theme) {
+    const inner = node
+    node = () => <ThemeProvider theme="claude">{inner()}</ThemeProvider>
+  }
+  return node
+}
+
+/**
+ * Wait out opentui's raw-mode escape-sequence disambiguation window. A lone
+ * ESC byte is ambiguous with the start of a multi-byte escape sequence
+ * (arrow keys, `alt+`, kitty-protocol chords all start with `\x1B`), so the
+ * parser holds it briefly before deciding it was a standalone Escape key.
+ * `mockInput.pressEscape()` writes the byte synchronously but the resulting
+ * `keypress` event (and therefore any `useBindings` escape handler) doesn't
+ * fire until that window closes — call `await settle()` before the next
+ * `frame()`/assertion or the escape will appear to have done nothing.
+ */
+export function settle(ms = 60): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Mount `ui` against a real opentui test renderer and return a handle to
+ * drive/inspect it. Always renders one initial frame before resolving, so
+ * `frame()` immediately after `renderComponent()` reflects the mounted
+ * state without a redundant extra call.
+ */
+export async function renderComponent(ui: () => JSX.Element, options: RenderOptions = {}): Promise<RenderHandle> {
+  const { width = 80, height = 24, providers } = options
+  const wrapped = withProviders(ui, providers)
+  const { renderer, mockInput, mockMouse, renderOnce, captureCharFrame, captureSpans, resize } = await testRender(
+    wrapped,
+    { width, height },
+  )
+  liveRenderer = renderer
+  await renderOnce()
+
+  return {
+    renderer,
+    mockInput,
+    mockMouse,
+    frame: async () => {
+      await renderOnce()
+      return captureCharFrame()
+    },
+    rerender: async () => {
+      await renderOnce()
+    },
+    spans: async () => {
+      await renderOnce()
+      return captureSpans()
+    },
+    resize,
+    destroy: () => {
+      renderer.destroy()
+      if (liveRenderer === renderer) liveRenderer = null
+    },
+  }
+}

--- a/packages/kobe/test/render/help-dialog.test.tsx
+++ b/packages/kobe/test/render/help-dialog.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * HelpDialog — global keybindings reference (src/tui/component/help-dialog.tsx).
+ * `HelpDialog.show` pushes it onto the real dialog stack; the `?` chord
+ * re-dismisses it (the mount-time `runTmuxCapturing` call degrades to a
+ * harmless no-op without a real tmux server — see src/tmux/client.ts).
+ */
+import { describe, expect, it } from "bun:test"
+import { HelpDialog } from "../../src/tui/component/help-dialog"
+import { useDialog } from "../../src/tui/ui/dialog"
+import { renderComponent } from "./harness"
+
+function Harness() {
+  const dialog = useDialog()
+  HelpDialog.show(dialog)
+  return <box />
+}
+
+describe("HelpDialog", () => {
+  it("renders the title and at least one keybinding row", async () => {
+    const { frame } = await renderComponent(() => <Harness />, {
+      providers: { dialog: true },
+      width: 100,
+      height: 40,
+    })
+    const text = await frame()
+    expect(text).toContain("kobe — keybindings")
+    // Every keymap category renders a row with the "esc" close hint visible.
+    expect(text).toContain("esc")
+  })
+
+  it("? dismisses the dialog (dialog stack empties)", async () => {
+    const dialog = { current: undefined as ReturnType<typeof useDialog> | undefined }
+    function Capture() {
+      dialog.current = useDialog()
+      HelpDialog.show(dialog.current)
+      return <box />
+    }
+    const { frame, mockInput } = await renderComponent(() => <Capture />, {
+      providers: { dialog: true },
+      width: 100,
+      height: 40,
+    })
+    expect(await frame()).toContain("kobe — keybindings")
+    mockInput.pressKey("?")
+    await frame()
+    expect(dialog.current?.stack.length).toBe(0)
+  })
+})

--- a/packages/kobe/test/render/kv-provider.test.tsx
+++ b/packages/kobe/test/render/kv-provider.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * KVProvider — disk-backed UI state (src/tui/context/kv.tsx). Imports
+ * @opentui/solid indirectly via createSimpleContext's sibling modules? No —
+ * kv.tsx itself has no @opentui import, but every real host mounts it
+ * alongside Theme/Focus (lib/host-boot.tsx) and it's exercised here as the
+ * other providers' shared dependency (NotificationsProvider reads
+ * `useKV()`). Covers get/set/signal/dirty-key persistence against a
+ * throwaway state.json, independent of any real ~/.config/kobe.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { KVProvider, useKV } from "../../src/tui/context/kv"
+import { renderComponent } from "./harness"
+
+let homeDir: string
+const previousHomeDir = process.env.KOBE_HOME_DIR
+
+beforeEach(() => {
+  homeDir = mkdtempSync(join(tmpdir(), "kobe-kv-render-test-"))
+  process.env.KOBE_HOME_DIR = homeDir
+})
+
+afterEach(() => {
+  rmSync(homeDir, { recursive: true, force: true })
+  process.env.KOBE_HOME_DIR = previousHomeDir
+})
+
+function statePath(): string {
+  return join(homeDir, ".config", "kobe", "state.json")
+}
+
+describe("KVProvider", () => {
+  it("get() falls back to the provided default when unset", async () => {
+    let seen: unknown
+    function Probe() {
+      const kv = useKV()
+      seen = kv.get("nonexistent.key", "fallback")
+      return <text>ready</text>
+    }
+    await renderComponent(() => (
+      <KVProvider>
+        <Probe />
+      </KVProvider>
+    ))
+    expect(seen).toBe("fallback")
+  })
+
+  it("set() + flush() persists the key to state.json", async () => {
+    let kvRef: ReturnType<typeof useKV> | undefined
+    function Probe() {
+      kvRef = useKV()
+      return <text>{`v:${kvRef.get("theme.name", "default")}`}</text>
+    }
+    const { frame } = await renderComponent(() => (
+      <KVProvider>
+        <Probe />
+      </KVProvider>
+    ))
+    kvRef?.set("theme.name", "dracula")
+    kvRef?.flush()
+    expect(await frame()).toContain("v:dracula")
+
+    const onDisk = JSON.parse(readFileSync(statePath(), "utf8"))
+    expect(onDisk["theme.name"]).toBe("dracula")
+  })
+
+  it("signal() hydrates a reactive accessor pair from a stored value", async () => {
+    let read: (() => unknown) | undefined
+    function Probe() {
+      const kv = useKV()
+      const [get] = kv.signal("focusAccent", "primary")
+      read = get
+      return <text>{`accent:${get()}`}</text>
+    }
+    const { frame } = await renderComponent(() => (
+      <KVProvider>
+        <Probe />
+      </KVProvider>
+    ))
+    expect(await frame()).toContain("accent:primary")
+    expect(read?.()).toBe("primary")
+  })
+})

--- a/packages/kobe/test/render/quick-task-composer.test.tsx
+++ b/packages/kobe/test/render/quick-task-composer.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * QuickTaskComposer — prompt-first quick-task dialog (`<prefix> f`), src/tui/component/quick-task-composer.tsx.
+ * Covers the "type a prompt, hit enter" happy path and tab-cycling to the
+ * engine field with ctrl+e stepping the vendor.
+ */
+import { describe, expect, it } from "bun:test"
+import { QuickTaskComposer, type QuickTaskResult } from "../../src/tui/component/quick-task-composer"
+import { useDialog } from "../../src/tui/ui/dialog"
+import { renderComponent } from "./harness"
+
+const OPTS = {
+  repoLabel: "kobe",
+  engines: ["claude", "codex"] as const,
+  defaultVendor: "claude" as const,
+  defaultBaseRef: "main",
+  engineLabel: (v: string) => v,
+}
+
+function Harness(props: { onResult: (v: QuickTaskResult | undefined) => void }) {
+  const dialog = useDialog()
+  void QuickTaskComposer.show(dialog, OPTS).then(props.onResult)
+  return <box />
+}
+
+describe("QuickTaskComposer", () => {
+  it("shows the repo label and both engines, claude pre-selected", async () => {
+    const { frame } = await renderComponent(() => <Harness onResult={() => {}} />, {
+      providers: { dialog: true },
+    })
+    const text = await frame()
+    expect(text).toContain("Quick task · kobe")
+    expect(text).toContain("claude")
+    expect(text).toContain("codex")
+  })
+
+  it("typing a prompt and hitting enter creates the task with the default engine/branch", async () => {
+    let result: QuickTaskResult | undefined
+    const { frame, mockInput } = await renderComponent(
+      () => (
+        <Harness
+          onResult={(v) => {
+            result = v
+          }}
+        />
+      ),
+      {
+        providers: { dialog: true },
+      },
+    )
+    await frame()
+    await mockInput.typeText("fix the flaky test")
+    mockInput.pressEnter()
+    await frame()
+    expect(result).toEqual({
+      prompt: "fix the flaky test",
+      vendor: "claude",
+      baseRef: "main",
+      attachments: [],
+    })
+  })
+
+  it("tab then ctrl+e cycles the engine field to codex", async () => {
+    let result: QuickTaskResult | undefined
+    const { frame, mockInput } = await renderComponent(
+      () => (
+        <Harness
+          onResult={(v) => {
+            result = v
+          }}
+        />
+      ),
+      {
+        providers: { dialog: true },
+      },
+    )
+    await frame()
+    await mockInput.typeText("switch engine")
+    mockInput.pressTab() // prompt -> engine field
+    mockInput.pressKey("e", { ctrl: true }) // step vendor within the engine field
+    mockInput.pressEnter()
+    await frame()
+    expect(result?.vendor).toBe("codex")
+  })
+})

--- a/packages/kobe/test/render/rename-task-dialog.test.tsx
+++ b/packages/kobe/test/render/rename-task-dialog.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * RenameTaskDialog — single-field rename prompt (src/tui/component/rename-task-dialog/{index,dialog}.tsx).
+ * Drives it through the public `RenameTaskDialog.show` entry point (same
+ * call the sidebar's `r` chord makes) rather than the inner view directly.
+ */
+import { describe, expect, it } from "bun:test"
+import { RenameTaskDialog } from "../../src/tui/component/rename-task-dialog"
+import { useDialog } from "../../src/tui/ui/dialog"
+import { renderComponent, settle } from "./harness"
+
+function Harness(props: { onResult: (v: string | undefined) => void }) {
+  const dialog = useDialog()
+  void RenameTaskDialog.show(dialog, "old title").then(props.onResult)
+  return <box />
+}
+
+describe("RenameTaskDialog", () => {
+  it("pre-fills the input with the current title", async () => {
+    const { frame } = await renderComponent(() => <Harness onResult={() => {}} />, {
+      providers: { dialog: true },
+    })
+    const text = await frame()
+    expect(text).toContain("Rename task")
+    expect(text).toContain("old title")
+  })
+
+  it("typing replaces the field and enter resolves the new title", async () => {
+    let result: string | undefined
+    const { frame, mockInput } = await renderComponent(
+      () => (
+        <Harness
+          onResult={(v) => {
+            result = v
+          }}
+        />
+      ),
+      {
+        providers: { dialog: true },
+      },
+    )
+    await frame()
+    // Clear the pre-filled text (one backspace per character of "old title"),
+    // then type the replacement.
+    for (let i = 0; i < "old title".length; i++) mockInput.pressBackspace()
+    await mockInput.typeText("new title")
+    mockInput.pressEnter()
+    await frame()
+    expect(result).toBe("new title")
+  })
+
+  it("esc cancels without resolving a value", async () => {
+    let result: string | undefined = "unset"
+    const { frame, mockInput } = await renderComponent(
+      () => (
+        <Harness
+          onResult={(v) => {
+            result = v
+          }}
+        />
+      ),
+      {
+        providers: { dialog: true },
+      },
+    )
+    await frame()
+    mockInput.pressEscape()
+    await settle()
+    await frame()
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/kobe/test/render/theme-provider.test.tsx
+++ b/packages/kobe/test/render/theme-provider.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ThemeProvider — reactive theme context (src/tui/context/theme.tsx). Pure
+ * hex-resolution logic already has vitest coverage (test/tui/theme-hex.test.ts,
+ * context/theme/hex.ts has no @opentui import); this covers the piece that
+ * DOES import @opentui/solid and so can't run under vitest at all: the
+ * live `useTheme()` wiring — default theme, color resolution actually
+ * reaching a rendered cell, and the transparentBackground toggle.
+ */
+import { describe, expect, it } from "bun:test"
+import { type CapturedFrame, RGBA } from "@opentui/core"
+import { ThemeProvider, useTheme } from "../../src/tui/context/theme"
+import { BUNDLED_THEME_JSONS } from "../../src/tui/context/theme/bundled"
+import { resolveThemeSlotHex } from "../../src/tui/context/theme/hex"
+import { renderComponent } from "./harness"
+
+function Probe() {
+  const { theme } = useTheme()
+  return <text fg={theme.warning}>WARN</text>
+}
+
+function findSpan(frame: CapturedFrame, needle: string) {
+  for (const line of frame.lines) {
+    for (const span of line.spans) {
+      if (span.text.includes(needle)) return span
+    }
+  }
+  return undefined
+}
+
+describe("ThemeProvider", () => {
+  it("defaults to the claude theme and resolves theme.warning to claude's actual warning hex", async () => {
+    const { spans } = await renderComponent(() => (
+      <ThemeProvider theme="claude">
+        <Probe />
+      </ThemeProvider>
+    ))
+    const captured = await spans()
+    const span = findSpan(captured, "WARN")
+    expect(span).toBeDefined()
+
+    const expectedHex = resolveThemeSlotHex(BUNDLED_THEME_JSONS.claude!, "warning")
+    expect(expectedHex).not.toBeNull()
+    expect(span?.fg.equals(RGBA.fromHex(expectedHex!))).toBe(true)
+  })
+
+  it("selects a non-default bundled theme via the `theme` prop", async () => {
+    function SelectedProbe() {
+      const { selected } = useTheme()
+      return <text>{selected}</text>
+    }
+    const { frame } = await renderComponent(() => (
+      <ThemeProvider theme="dracula">
+        <SelectedProbe />
+      </ThemeProvider>
+    ))
+    expect(await frame()).toContain("dracula")
+  })
+})

--- a/packages/kobe/test/render/toast-overlay.test.tsx
+++ b/packages/kobe/test/render/toast-overlay.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * ToastOverlay — bottom-right transient toast stack (src/tui/component/toast-overlay.tsx).
+ * Exercises the real NotificationsProvider (notify/dismiss), not a mock —
+ * this is the actual (kind -> chip) wiring the pane hosts rely on.
+ */
+import { describe, expect, it } from "bun:test"
+import { ToastOverlay } from "../../src/tui/component/toast-overlay"
+import { useNotifications } from "../../src/tui/context/notifications"
+import { renderComponent } from "./harness"
+
+// KV writes debounce to disk; point them at a throwaway dir so the test
+// never touches (or depends on) a real ~/.config/kobe/state.json.
+process.env.KOBE_HOME_DIR = process.env.KOBE_HOME_DIR ?? "/tmp/kobe-render-test-home"
+
+function NotifyProbe(props: { kind: "done" | "needs_input" | "error"; title: string }) {
+  const notif = useNotifications()
+  notif.notify({ kind: props.kind, taskId: "t1", tabId: "tab1", title: props.title })
+  return <ToastOverlay />
+}
+
+describe("ToastOverlay", () => {
+  it("renders nothing with no toasts queued", async () => {
+    const { frame } = await renderComponent(() => <ToastOverlay />, { providers: { notifications: true } })
+    expect((await frame()).trim().length).toBe(0)
+  })
+
+  it("shows a done toast with its title and a check prefix", async () => {
+    const { frame } = await renderComponent(() => <NotifyProbe kind="done" title="build finished" />, {
+      providers: { notifications: true },
+    })
+    const text = await frame()
+    expect(text).toContain("build finished")
+    expect(text).toContain("✓")
+  })
+
+  it("shows an error toast with an X prefix", async () => {
+    const { frame } = await renderComponent(() => <NotifyProbe kind="error" title="clone failed" />, {
+      providers: { notifications: true },
+    })
+    const text = await frame()
+    expect(text).toContain("clone failed")
+    expect(text).toContain("✕")
+  })
+})

--- a/packages/kobe/test/render/version-skew-banner.test.tsx
+++ b/packages/kobe/test/render/version-skew-banner.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * VersionSkewBanner — daemon build-version skew strip (src/tui/component/version-skew-banner.tsx).
+ * Ported from the render-track spike (spike-artifacts/tsx-render.spike.bun.test.tsx).
+ */
+import { describe, expect, it } from "bun:test"
+import { createSignal } from "solid-js"
+import { VersionSkewBanner } from "../../src/tui/component/version-skew-banner"
+import { renderComponent } from "./harness"
+
+describe("VersionSkewBanner", () => {
+  it("renders both versions when stale", async () => {
+    const [stale] = createSignal(true)
+    const [daemonVersion] = createSignal<string | null>("0.7.3")
+    const [width] = createSignal(80)
+
+    const { frame } = await renderComponent(() => (
+      <VersionSkewBanner stale={stale} daemonVersion={daemonVersion} clientVersion="0.7.4" width={width} />
+    ))
+
+    const text = await frame()
+    expect(text).toContain("0.7.3")
+    expect(text).toContain("0.7.4")
+  })
+
+  it("renders nothing when not stale", async () => {
+    const [stale] = createSignal(false)
+    const [daemonVersion] = createSignal<string | null>(null)
+    const [width] = createSignal(80)
+
+    const { frame } = await renderComponent(() => (
+      <VersionSkewBanner stale={stale} daemonVersion={daemonVersion} clientVersion="0.7.4" width={width} />
+    ))
+
+    const text = await frame()
+    expect(text).not.toContain("0.7.4")
+  })
+})

--- a/packages/kobe/vitest.config.ts
+++ b/packages/kobe/vitest.config.ts
@@ -3,7 +3,12 @@ import { defineConfig } from "vitest/config"
 
 const includeBehavior = process.env.KOBE_INCLUDE_BEHAVIOR === "1"
 const includeSocket = process.env.KOBE_INCLUDE_SOCKET === "1"
-const exclude: string[] = []
+// test/render/** is the bun-test-only render track (see test/render/harness.tsx
+// + docs/HARNESS.md "render track") — it uses bun:test APIs vitest can't
+// resolve, and mounts real opentui Solid components vitest's node
+// environment can't execute at all. Always excluded here regardless of the
+// behavior/socket flags.
+const exclude: string[] = ["test/render/**"]
 if (!includeBehavior) exclude.push("test/behavior/**")
 if (!includeSocket) {
   exclude.push("test/daemon/**", "test/orchestrator/bridge.test.ts")

--- a/scripts/coverage-gate.mjs
+++ b/scripts/coverage-gate.mjs
@@ -40,6 +40,9 @@ const touched = diff
   .split("\n")
   .map((l) => l.trim())
   // .ts only — .tsx (opentui components) is outside the coverage scope; see vitest.config.ts.
+  // .tsx render coverage is reported separately by `bun run test:render` (bun test +
+  // @opentui/solid's testRender, see docs/HARNESS.md "render track") and uploaded to
+  // Codecov alongside this report; it is NOT gated per-file here yet.
   .filter((f) => /^packages\/kobe\/src\/.*\.ts$/.test(f))
   .filter((f) => !f.endsWith(".d.ts"))
 


### PR DESCRIPTION
## Summary

Adds a second, bun-test-only test track for `packages/kobe/src/**/*.tsx` (opentui Solid components) that vitest's node environment cannot execute at all (`@opentui/core` ships raw `.scm`/`.wasm` assets via `with { type: "file" }` imports vitest can't resolve, and the JSX needs `@opentui/solid`'s Babel transform). `bun test --preload @opentui/solid/preload` + `@opentui/core/testing`'s `createTestRenderer`/`testRender` is the one runner where both resolve — confirmed with a throwaway spike before building this out.

### Render track
- New `packages/kobe/test/render/` — invisible to vitest (`vitest.config.ts` now excludes `test/render/**`).
- `packages/kobe/bunfig.toml` gets a `[test]` table with the preload (the top-level `preload` key only applies to `bun run`, not `bun test`).
- `bun run test:render` → `bun test test/render --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage-render` (gitignored, sibling to `coverage/`).
- CI: `coverage-cap` job now also runs `test:render` and uploads `coverage-render/lcov.info` to Codecov alongside `coverage/lcov.info` (comma-separated `files:`). `scripts/coverage-gate.mjs` is untouched — still `.ts`-only, per-touched-file gate; a comment notes `.tsx` is reported but not yet gated.
- `docs/HARNESS.md` gets a "Render track" section: why `bun test` not vitest, how to run it, a copy-paste pattern for a new component test, and the three gotchas this PR's own tests hit first (lowercase key names like `"return"`/`"escape"` type as literal text instead of firing the named key — use `pressEnter()`/`pressEscape()`/`pressArrow()`; `pressEscape()` needs `await settle()` before the next assertion — opentui's parser holds a lone ESC briefly to disambiguate multi-byte sequences; a `let x: T | undefined = undefined` mutated inside an async callback narrows to `undefined` under `tsc` — drop the initializer).

### Harness (`test/render/harness.tsx`, 180 lines)
`renderComponent(ui, { width, height, providers })` → `{ frame(), spans(), rerender(), mockInput, mockMouse, renderer, resize, destroy() }`. `providers` composes `Theme > KV > Focus > Dialog > Notifications` (same nesting order every real pane host uses, `lib/host-boot.tsx`), each opt-in and off by default except Theme. `afterEach` auto-destroys the last renderer so a forgotten `destroy()` can't leak into the next test.

**One real (pre-existing) bug fixed along the way**: `useBindings` (`src/tui/lib/keymap.tsx`) cached the *first* renderer's `keyInput` emitter in a module-level singleton and never rebound it. Harmless in production (one renderer per process — the check was already a permanent no-op after the first call), but it silently zeroed out every keyboard-interaction test after the first one in the same bun process, since the render track creates a fresh `testRender()` renderer per test. Fixed to detach/reattach when the active renderer changes; zero behavior change for the single-renderer production case (verified via the full existing test suite + a fresh `bun run build`).

### Component coverage (30 tests / 10 files)

Tested — real rendered frames + real keyboard interaction, no snapshots:
- `component/version-skew-banner.tsx` — stale/fresh states
- `component/toast-overlay.tsx` — empty state, done/error toast chips via the real `NotificationsProvider`
- `ui/dialog-confirm.tsx` — title/message, left/right focus swap, enter confirms, esc cancels
- `component/help-dialog.tsx` — keybinding rows render, `?` dismisses
- `component/rename-task-dialog/{index,dialog}.tsx` — pre-filled input, edit + enter resolves, esc cancels
- `component/quick-task-composer.tsx` — engine list renders, prompt+enter happy path, tab+ctrl+e engine cycling
- `ui/dialog.tsx` (`DialogProvider`/`useDialog`) — push/replace/clear, esc pops + fires `onClose`
- `context/theme.tsx` (`ThemeProvider`) — default theme resolves to the actual claude-theme hex (via `captureSpans`, not just text), `theme` prop selects a different bundled theme
- `context/focus.tsx` (`FocusProvider`) — default/initial pane, `setFocused`/`cycle` wrap through `PANE_ORDER`
- `context/kv.tsx` (`KVProvider`) — default fallback, `set`+`flush` persists to a throwaway `state.json`, `signal()` hydration

Skipped, on purpose:
- The four large pane hosts named in the brief, pending the issue #12 split: `tasks-pane/host.tsx`, `panes/filetree/FileTree.tsx`, `component/settings-dialog.tsx`, `component/settings-dialog/sections.tsx`.
- Every other `*/host.tsx` (`new-task/host.tsx`, `quick-task/host.tsx`, `settings/host.tsx`, `update/host.tsx`, `help/host.tsx`, `history/host.tsx`, `ops/host.tsx`) — these call `render()` and connect to the daemon; they're CLI process bootstrappers, not embeddable components, and are already covered black-box by `test/behavior/`.
- `component/new-task-dialog/dialog.tsx` (1119 lines) — the one judgment call not in the brief's named list. It's transitively loaded (and partially exercised) via `rename-task-dialog`/`quick-task-composer`'s shared `isBlankText`/`stripNewlines` import, but its own tabs (repo picker, clone, adopt) are complex enough to deserve a dedicated follow-up pass rather than a rushed test here.
- `panes/sidebar/Sidebar.tsx` (1441 lines) and `ops/host.tsx`/`history/host.tsx` — large, not in the brief's explicit skip list, deferred for the same reason.

### Coverage numbers (packages/kobe, measured locally)

- `.ts` (vitest, unchanged by this PR): **96.97%** lines (17011/17541).
- `.tsx` (new render track, first-ever execution of these files): **54.49%** lines (3326/6104) across every `.tsx` file the render suite loads (10 directly tested + a few transitively-imported siblings like `new-task-dialog/dialog.tsx`/`state.ts`). Before this PR every one of those lines reported 0% (excluded from the denominator entirely per `vitest.config.ts`'s existing scope note).
- Whole-monorepo Codecov % (across kobe + kobe-daemon + kobe-web + branding) isn't reproducible locally with certainty — this PR's CI run is the first to upload `coverage-render/lcov.info`, so the actual before→after delta will show on the Codecov PR check once CI runs.

### Writing a new component test (3 lines)

1. `import { renderComponent } from "./harness"`, call it with your component + `{ providers: {...} }` for whatever context it needs.
2. `await frame()` / `await spans()` after mount and after every `mockInput` action; use the named key helpers (`pressEnter`, `pressEscape`, `pressArrow`, `pressTab`), not lowercase string literals.
3. Assert on the real returned text/color, not a snapshot.

## Test plan
- [x] `bun run lint` (repo root) — clean
- [x] `bun run typecheck` (packages/kobe) — clean
- [x] `bun run test` (packages/kobe, vitest — unaffected by this PR) — 2202 + 213 passing
- [x] `bun run test:render` (packages/kobe, new) — 30 passing
- [x] `bun run build` (packages/kobe) — succeeds
