### PR TITLE
feat(kobe-web): add standalone worktree management page

### DIFF
--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -25,6 +25,7 @@ import { allowedHostForBindHost, originAllowed } from "./web-origin.ts"
 import { WEB_RPC_ALLOWSET } from "./web-rpc-allowlist.ts"
 import { engineSpec, ensureTaskSession, tearDownTaskSession, terminalSpec } from "./web-session.ts"
 import { settingsPatch, settingsSnapshot } from "./web-settings.ts"
+import { handleWorktreesRequest } from "./web-worktrees-route.ts"
 
 export const DAEMON_WEB_HEALTH_MARKER = "kobe-web"
 export const DAEMON_WEB_HEALTH_PATH = "/__kobe_web"
@@ -268,6 +269,8 @@ export function createDaemonWebRequestHandler(deps: RequestHandlerDeps): (req: R
     if (issues) return issues
     const issueAssets = await handleIssueAssetsRequest(req, url)
     if (issueAssets) return issueAssets
+    const worktrees = await handleWorktreesRequest(req, url)
+    if (worktrees) return worktrees
     const themes = handleThemesRequest(req, url)
     if (themes) return themes
     if (staticDir) return staticResponse(url.pathname, staticDir)

--- a/packages/kobe-daemon/src/daemon/web-worktrees-route.ts
+++ b/packages/kobe-daemon/src/daemon/web-worktrees-route.ts
@@ -1,0 +1,113 @@
+/**
+ * `/api/worktrees` — cross-project worktree audit for the standalone
+ * worktree-management page.
+ *
+ * Deliberately NOT a daemon RPC (`handlers.ts`/`protocol.ts`): everything it
+ * needs — `GitWorktreeManager`, `getSavedRepos` — is already a public,
+ * orchestrator-independent primitive, so this route composes them directly
+ * instead of adding to the already-oversized handler registry. Task linkage
+ * ("is this worktree backing an active task?") is left to the caller, which
+ * already holds the task list client-side.
+ *
+ * Local projects only for v1 — a remote (`ssh://…`) project's worktrees would
+ * need `git ls-remote`/`fs.stat` run over its `ExecHost` instead of directly,
+ * a real follow-up rather than bundled here.
+ */
+
+import { statSync } from "node:fs"
+import { execHostForWorktreePath } from "@/exec/resolve"
+import { GitWorktreeManager } from "@/orchestrator/worktree/manager"
+import { getRemoteRepoConfig, getSavedRepos } from "@/state/repos"
+import type { AdoptableWorktree } from "@/types/worktree"
+
+const ROUTE = "/api/worktrees"
+const REMOTE_CHECK_TIMEOUT_MS = 4_000
+
+const manager = new GitWorktreeManager()
+
+export interface WorktreeRow extends AdoptableWorktree {
+  readonly repo: string
+  /** Worktree directory's creation time (epoch ms) — distinct from the
+   *  existing `lastActivityMs` (last-commit time). 0 when unreadable. */
+  readonly createdAtMs: number
+  /** Whether `branch` exists on `origin`. `null` = no origin / unreachable /
+   *  timed out — rendered as "unknown", never a delete-blocker. */
+  readonly branchOnRemote: boolean | null
+}
+
+function createdAtMs(worktreePath: string): number {
+  try {
+    const stat = statSync(worktreePath)
+    return stat.birthtimeMs || stat.mtimeMs
+  } catch {
+    return 0
+  }
+}
+
+async function branchOnRemote(worktreePath: string, branch: string): Promise<boolean | null> {
+  try {
+    const exec = execHostForWorktreePath(worktreePath)
+    const out = await exec.run(["git", "ls-remote", "--exit-code", "--heads", "origin", branch], {
+      cwd: worktreePath,
+      signal: AbortSignal.timeout(REMOTE_CHECK_TIMEOUT_MS),
+    })
+    if (out.exitCode === 0) return true
+    if (out.exitCode === 2) return false
+    return null
+  } catch {
+    return null
+  }
+}
+
+async function listProjects(): Promise<{ repo: string; worktrees: WorktreeRow[] }[]> {
+  const localRepos = getSavedRepos().filter((repo) => !getRemoteRepoConfig(repo))
+  return Promise.all(
+    localRepos.map(async (repo) => {
+      const worktrees = await manager.listAll(repo)
+      const rows = await Promise.all(
+        worktrees.map(
+          async (wt): Promise<WorktreeRow> => ({
+            ...wt,
+            repo,
+            createdAtMs: createdAtMs(wt.path),
+            branchOnRemote: await branchOnRemote(wt.path, wt.branch),
+          }),
+        ),
+      )
+      return { repo, worktrees: rows }
+    }),
+  )
+}
+
+async function handleGet(): Promise<Response> {
+  try {
+    return Response.json({ projects: await listProjects() })
+  } catch (err) {
+    return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+  }
+}
+
+async function handleDelete(req: Request): Promise<Response> {
+  let body: { path?: unknown; force?: unknown }
+  try {
+    body = (await req.json()) as typeof body
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 })
+  }
+  if (typeof body.path !== "string" || !body.path) {
+    return Response.json({ error: "missing path" }, { status: 400 })
+  }
+  try {
+    await manager.remove(body.path, { force: body.force === true })
+    return Response.json({ removed: true })
+  } catch (err) {
+    return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 400 })
+  }
+}
+
+export async function handleWorktreesRequest(req: Request, url: URL): Promise<Response | null> {
+  if (url.pathname !== ROUTE) return null
+  if (req.method === "GET") return handleGet()
+  if (req.method === "DELETE") return handleDelete(req)
+  return Response.json({ error: "method not allowed" }, { status: 405 })
+}

--- a/packages/kobe-web/src/components/ViewToggle.tsx
+++ b/packages/kobe-web/src/components/ViewToggle.tsx
@@ -1,64 +1,85 @@
 /**
- * ViewToggle — the top-left peer switch between the Workspace and the Board.
- * They are PEER views (no back link): a segmented two-button control that
- * reads the current pathname from the router and navigates between the two
+ * ViewToggle — the top-left peer switch between Workspace, Board, and
+ * Worktrees. They are PEER views (no back link): a segmented control that
+ * reads the current pathname from the router and navigates between the
  * surfaces.
  *
  * "Workspace" routes to the selected task (/task/$taskId from the persisted
  * tab selection) so the toggle lands you on a real task, falling back to the
- * index when nothing is selected. "Board" routes to /board.
+ * index when nothing is selected. "Board" routes to /board. "Worktrees"
+ * routes to /worktrees.
  */
 
 import { useNavigate, useRouterState } from "@tanstack/react-router"
-import { Columns3, PanelsTopLeft } from "lucide-react"
+import { Columns3, GitBranch, PanelsTopLeft } from "lucide-react"
 import { useTabsState } from "../lib/tabs.ts"
+
+type View = "workspace" | "board" | "worktrees"
 
 export function ViewToggle() {
   const navigate = useNavigate()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const { selectedTaskId } = useTabsState()
-  const onBoard = pathname.startsWith("/board")
+  const view: View = pathname.startsWith("/board")
+    ? "board"
+    : pathname.startsWith("/worktrees")
+      ? "worktrees"
+      : "workspace"
 
-  const goWorkspace = (): void => {
-    if (onBoard === false) return
-    if (selectedTaskId)
-      void navigate({ to: "/task/$taskId", params: { taskId: selectedTaskId } })
-    else void navigate({ to: "/" })
+  const goTo = (target: View): void => {
+    if (view === target) return
+    if (target === "workspace") {
+      if (selectedTaskId) {
+        void navigate({
+          to: "/task/$taskId",
+          params: { taskId: selectedTaskId },
+        })
+      } else {
+        void navigate({ to: "/" })
+      }
+      return
+    }
+    void navigate({ to: target === "board" ? "/board" : "/worktrees" })
   }
-  const goBoard = (): void => {
-    if (onBoard) return
-    void navigate({ to: "/board" })
-  }
+
+  const tabClass = (active: boolean): string =>
+    `flex items-center gap-1.5 border-l border-line px-2 py-1 text-[11px] transition-colors first:border-l-0 ${
+      active
+        ? "border-line-active bg-inset text-fg"
+        : "text-subtle hover:text-fg"
+    }`
 
   return (
     <div className="flex items-center overflow-hidden rounded-sm border border-line">
       <button
         type="button"
-        onClick={goWorkspace}
-        aria-pressed={!onBoard}
+        onClick={() => goTo("workspace")}
+        aria-pressed={view === "workspace"}
         title="Workspace"
-        className={`flex items-center gap-1.5 px-2 py-1 text-[11px] transition-colors ${
-          !onBoard
-            ? "border-line-active bg-inset text-fg"
-            : "text-subtle hover:text-fg"
-        }`}
+        className={tabClass(view === "workspace")}
       >
         <PanelsTopLeft size={13} strokeWidth={1.8} />
         Workspace
       </button>
       <button
         type="button"
-        onClick={goBoard}
-        aria-pressed={onBoard}
+        onClick={() => goTo("board")}
+        aria-pressed={view === "board"}
         title="Board"
-        className={`flex items-center gap-1.5 border-l border-line px-2 py-1 text-[11px] transition-colors ${
-          onBoard
-            ? "border-line-active bg-inset text-fg"
-            : "text-subtle hover:text-fg"
-        }`}
+        className={tabClass(view === "board")}
       >
         <Columns3 size={13} strokeWidth={1.8} />
         Board
+      </button>
+      <button
+        type="button"
+        onClick={() => goTo("worktrees")}
+        aria-pressed={view === "worktrees"}
+        title="Worktrees"
+        className={tabClass(view === "worktrees")}
+      >
+        <GitBranch size={13} strokeWidth={1.8} />
+        Worktrees
       </button>
     </div>
   )

--- a/packages/kobe-web/src/components/WorktreesPage.tsx
+++ b/packages/kobe-web/src/components/WorktreesPage.tsx
@@ -1,0 +1,260 @@
+/**
+ * WorktreesPage — the standalone `/worktrees` lens onto every git worktree
+ * kobe can see across all locally-saved projects (not just kobe-managed
+ * ones — see `web-worktrees-route.ts`'s `GitWorktreeManager.listAll`). Lets
+ * Jackson audit and clean up stray worktrees from one page instead of
+ * `cd`-ing into each project.
+ *
+ * Delete flow mirrors the daemon's own safety gate: a clean worktree deletes
+ * on a single confirm; a dirty one (uncommitted/untracked changes) fails the
+ * first attempt and surfaces a SECOND, danger-styled confirm before retrying
+ * with `force: true` — no client-side dirty check duplicates the backend's.
+ */
+
+import { useNavigate } from "@tanstack/react-router"
+import { ArrowLeft, RefreshCw } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useAppState } from "../lib/store.ts"
+import { relativeTimeAgo } from "../lib/time.ts"
+import { reportError } from "../lib/toast.ts"
+import {
+  DirtyWorktreeError,
+  fetchWorktreeProjects,
+  removeWorktree,
+  type WorktreeProject,
+  type WorktreeRow,
+} from "../lib/worktrees.ts"
+import { ConfirmDialog } from "./ConfirmDialog.tsx"
+import { DesktopWindowControls } from "./DesktopWindowControls.tsx"
+
+function remoteBadge(status: boolean | null) {
+  if (status === true) {
+    return (
+      <span className="shrink-0 text-[10px] text-kobe-green">on remote</span>
+    )
+  }
+  if (status === false) {
+    return (
+      <span className="shrink-0 text-[10px] text-kobe-yellow">not pushed</span>
+    )
+  }
+  return (
+    <span className="shrink-0 text-[10px] text-subtle">remote unknown</span>
+  )
+}
+
+function WorktreeRowView({
+  row,
+  linkedTaskTitle,
+  onDelete,
+}: {
+  row: WorktreeRow
+  linkedTaskTitle: string | null
+  onDelete: () => void
+}) {
+  return (
+    <div className="flex items-center gap-2 border-b border-line-subtle px-3 py-2 last:border-b-0">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-mono text-[12px] text-fg">
+            {row.branch || "(detached)"}
+          </span>
+          {row.kobeManaged && (
+            <span className="shrink-0 text-[10px] text-subtle">kobe</span>
+          )}
+          {row.dirty && (
+            <span className="shrink-0 text-[10px] text-kobe-yellow">dirty</span>
+          )}
+          {remoteBadge(row.branchOnRemote)}
+          {linkedTaskTitle && (
+            <span className="shrink-0 truncate text-[10px] text-subtle">
+              task: {linkedTaskTitle}
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-[10px] text-subtle">
+          <span className="truncate font-mono">{row.path}</span>
+          {row.createdAtMs > 0 && (
+            <span className="ml-auto shrink-0">
+              created {relativeTimeAgo(row.createdAtMs)}
+            </span>
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onDelete}
+        className="shrink-0 border border-line bg-bg px-2 py-1 text-[11px] text-muted transition-colors hover:border-kobe-red hover:text-kobe-red"
+      >
+        Delete
+      </button>
+    </div>
+  )
+}
+
+export function WorktreesPage() {
+  const navigate = useNavigate()
+  const { tasks } = useAppState()
+  const [projects, setProjects] = useState<WorktreeProject[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<WorktreeRow | null>(null)
+  const [pendingForceDelete, setPendingForceDelete] =
+    useState<WorktreeRow | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const linkedTaskTitles = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const task of tasks) {
+      if (task.worktreePath)
+        map.set(task.worktreePath, task.title || task.branch)
+    }
+    return map
+  }, [tasks])
+
+  const load = (): void => {
+    setLoading(true)
+    void fetchWorktreeProjects()
+      .then(setProjects)
+      .catch((err: unknown) => reportError("load worktrees", err))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(load, [])
+
+  const removeRow = (path: string): void => {
+    setProjects(
+      (prev) =>
+        prev?.map((project) => ({
+          ...project,
+          worktrees: project.worktrees.filter((w) => w.path !== path),
+        })) ?? prev,
+    )
+  }
+
+  const onConfirmDelete = (): void => {
+    if (!pendingDelete) return
+    const row = pendingDelete
+    setBusy(true)
+    void removeWorktree(row.path, false)
+      .then(() => {
+        removeRow(row.path)
+        setPendingDelete(null)
+      })
+      .catch((err: unknown) => {
+        setPendingDelete(null)
+        if (err instanceof DirtyWorktreeError) {
+          setPendingForceDelete(row)
+        } else {
+          reportError("delete worktree", err)
+        }
+      })
+      .finally(() => setBusy(false))
+  }
+
+  const onConfirmForceDelete = (): void => {
+    if (!pendingForceDelete) return
+    const row = pendingForceDelete
+    setBusy(true)
+    void removeWorktree(row.path, true)
+      .then(() => {
+        removeRow(row.path)
+        setPendingForceDelete(null)
+      })
+      .catch((err: unknown) => reportError("force delete worktree", err))
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-bg text-fg">
+      <header
+        data-kobe-topbar
+        className="flex h-10 shrink-0 items-center gap-3 border-b border-line bg-surface px-3"
+      >
+        <DesktopWindowControls />
+        <button
+          type="button"
+          onClick={() => navigate({ to: "/" })}
+          className="flex items-center gap-1.5 text-muted transition-colors hover:text-fg"
+          title="Back to workspace"
+        >
+          <ArrowLeft size={15} strokeWidth={1.8} />
+          <span className="text-[12px]">Workspace</span>
+        </button>
+        <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-fg">
+          Worktrees
+        </span>
+        <button
+          type="button"
+          onClick={load}
+          disabled={loading}
+          className="ml-auto flex items-center gap-1.5 text-muted transition-colors hover:text-fg disabled:opacity-40"
+          title="Refresh"
+        >
+          <RefreshCw
+            size={13}
+            strokeWidth={1.8}
+            className={loading ? "animate-spin" : ""}
+          />
+        </button>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {projects === null ? (
+          <p className="px-3 py-6 text-center text-[12px] text-subtle">
+            Loading worktrees…
+          </p>
+        ) : projects.length === 0 ? (
+          <p className="px-3 py-6 text-center text-[12px] text-subtle">
+            No local projects known to kobe yet.
+          </p>
+        ) : (
+          projects.map((project) => (
+            <div key={project.repo} className="border-b border-line">
+              <div className="border-b border-line-subtle bg-surface px-3 py-1.5 font-mono text-[11px] text-subtle">
+                {project.repo}
+              </div>
+              {project.worktrees.length === 0 ? (
+                <p className="px-3 py-3 text-[12px] text-subtle">
+                  No worktrees.
+                </p>
+              ) : (
+                project.worktrees.map((row) => (
+                  <WorktreeRowView
+                    key={row.path}
+                    row={row}
+                    linkedTaskTitle={linkedTaskTitles.get(row.path) ?? null}
+                    onDelete={() => setPendingDelete(row)}
+                  />
+                ))
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      {pendingDelete && (
+        <ConfirmDialog
+          title="Delete worktree"
+          body={`Delete the worktree for "${pendingDelete.branch || pendingDelete.path}"? This removes the working directory; the branch itself is kept.`}
+          confirmLabel="Delete"
+          danger
+          busy={busy}
+          onConfirm={onConfirmDelete}
+          onCancel={() => setPendingDelete(null)}
+        />
+      )}
+
+      {pendingForceDelete && (
+        <ConfirmDialog
+          title="Force delete worktree"
+          body={`"${pendingForceDelete.branch || pendingForceDelete.path}" has uncommitted or untracked changes that will be PERMANENTLY LOST. Force delete anyway?`}
+          confirmLabel="Force delete"
+          danger
+          busy={busy}
+          onConfirm={onConfirmForceDelete}
+          onCancel={() => setPendingForceDelete(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/kobe-web/src/lib/api-client.ts
+++ b/packages/kobe-web/src/lib/api-client.ts
@@ -132,6 +132,13 @@ export const api = {
   patch<T>(path: string, body?: unknown, opts?: ApiRequestOptions): Promise<T> {
     return requestJson<T>(path, jsonInit("PATCH", body), opts)
   },
+  delete<T>(
+    path: string,
+    body?: unknown,
+    opts?: ApiRequestOptions,
+  ): Promise<T> {
+    return requestJson<T>(path, jsonInit("DELETE", body), opts)
+  },
   form<T>(path: string, body: FormData, opts?: ApiRequestOptions): Promise<T> {
     return requestJson<T>(path, { method: "POST", body }, opts)
   },

--- a/packages/kobe-web/src/lib/worktrees.ts
+++ b/packages/kobe-web/src/lib/worktrees.ts
@@ -1,0 +1,57 @@
+/**
+ * Client for `/api/worktrees` — the standalone worktree-management page.
+ * See `packages/kobe-daemon/src/daemon/web-worktrees-route.ts` for the
+ * server side. `DirtyWorktreeError` distinguishes "refused: dirty" from any
+ * other delete failure so the page knows when to offer a force-confirm.
+ */
+
+import { ApiError, api } from "./api-client.ts"
+
+export interface WorktreeRow {
+  path: string
+  branch: string
+  head: string
+  dirty: boolean
+  kobeManaged: boolean
+  lastActivityMs: number
+  repo: string
+  createdAtMs: number
+  branchOnRemote: boolean | null
+}
+
+export interface WorktreeProject {
+  repo: string
+  worktrees: WorktreeRow[]
+}
+
+export class DirtyWorktreeError extends Error {}
+
+export async function fetchWorktreeProjects(): Promise<WorktreeProject[]> {
+  const data = await api.get<{ projects?: unknown }>("/api/worktrees", {
+    label: "load worktrees",
+  })
+  return Array.isArray(data.projects)
+    ? (data.projects as WorktreeProject[])
+    : []
+}
+
+export async function removeWorktree(
+  path: string,
+  force: boolean,
+): Promise<void> {
+  try {
+    await api.delete<{ removed: boolean }>(
+      "/api/worktrees",
+      { path, force },
+      { label: "delete worktree" },
+    )
+  } catch (err) {
+    if (
+      err instanceof ApiError &&
+      /refusing to remove dirty worktree/.test(err.detail)
+    ) {
+      throw new DirtyWorktreeError(err.detail)
+    }
+    throw err
+  }
+}

--- a/packages/kobe-web/src/routeTree.gen.ts
+++ b/packages/kobe-web/src/routeTree.gen.ts
@@ -9,12 +9,18 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as WorktreesRouteImport } from './routes/worktrees'
 import { Route as IssuesRouteImport } from './routes/issues'
 import { Route as HarnessRouteImport } from './routes/harness'
 import { Route as BoardRouteImport } from './routes/board'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TaskTaskIdRouteImport } from './routes/task.$taskId'
 
+const WorktreesRoute = WorktreesRouteImport.update({
+  id: '/worktrees',
+  path: '/worktrees',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IssuesRoute = IssuesRouteImport.update({
   id: '/issues',
   path: '/issues',
@@ -46,6 +52,7 @@ export interface FileRoutesByFullPath {
   '/board': typeof BoardRoute
   '/harness': typeof HarnessRoute
   '/issues': typeof IssuesRoute
+  '/worktrees': typeof WorktreesRoute
   '/task/$taskId': typeof TaskTaskIdRoute
 }
 export interface FileRoutesByTo {
@@ -53,6 +60,7 @@ export interface FileRoutesByTo {
   '/board': typeof BoardRoute
   '/harness': typeof HarnessRoute
   '/issues': typeof IssuesRoute
+  '/worktrees': typeof WorktreesRoute
   '/task/$taskId': typeof TaskTaskIdRoute
 }
 export interface FileRoutesById {
@@ -61,14 +69,28 @@ export interface FileRoutesById {
   '/board': typeof BoardRoute
   '/harness': typeof HarnessRoute
   '/issues': typeof IssuesRoute
+  '/worktrees': typeof WorktreesRoute
   '/task/$taskId': typeof TaskTaskIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/board' | '/harness' | '/issues' | '/task/$taskId'
+  fullPaths:
+    | '/'
+    | '/board'
+    | '/harness'
+    | '/issues'
+    | '/worktrees'
+    | '/task/$taskId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/board' | '/harness' | '/issues' | '/task/$taskId'
-  id: '__root__' | '/' | '/board' | '/harness' | '/issues' | '/task/$taskId'
+  to: '/' | '/board' | '/harness' | '/issues' | '/worktrees' | '/task/$taskId'
+  id:
+    | '__root__'
+    | '/'
+    | '/board'
+    | '/harness'
+    | '/issues'
+    | '/worktrees'
+    | '/task/$taskId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -76,11 +98,19 @@ export interface RootRouteChildren {
   BoardRoute: typeof BoardRoute
   HarnessRoute: typeof HarnessRoute
   IssuesRoute: typeof IssuesRoute
+  WorktreesRoute: typeof WorktreesRoute
   TaskTaskIdRoute: typeof TaskTaskIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/worktrees': {
+      id: '/worktrees'
+      path: '/worktrees'
+      fullPath: '/worktrees'
+      preLoaderRoute: typeof WorktreesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/issues': {
       id: '/issues'
       path: '/issues'
@@ -124,6 +154,7 @@ const rootRouteChildren: RootRouteChildren = {
   BoardRoute: BoardRoute,
   HarnessRoute: HarnessRoute,
   IssuesRoute: IssuesRoute,
+  WorktreesRoute: WorktreesRoute,
   TaskTaskIdRoute: TaskTaskIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/packages/kobe-web/src/routes/worktrees.tsx
+++ b/packages/kobe-web/src/routes/worktrees.tsx
@@ -1,0 +1,4 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { WorktreesPage } from "../components/WorktreesPage.tsx"
+
+export const Route = createFileRoute("/worktrees")({ component: WorktreesPage })


### PR DESCRIPTION
## Summary
- New `/worktrees` page (third `ViewToggle` tab) listing every git worktree across all locally-saved projects — including ones the user created by hand, not just kobe-managed ones.
- Each row surfaces: kobe-managed vs stray, age since creation, dirty (uncommitted/untracked) state, and whether the branch has reached `origin`.
- Delete flow: a clean worktree removes on a single confirm; a dirty one fails safely (existing `GitWorktreeManager.remove()` dirty-guard, untouched) and surfaces a second, danger-styled force-confirm before retrying with `force: true`.
- Backend lives outside the daemon RPC registry — a plain REST route (`web-worktrees-route.ts`) composing the existing `GitWorktreeManager`/`getSavedRepos()` directly — since `handlers.ts`/`protocol.ts`/`core.ts` are already over this repo's 500-line file-size cap and this feature needs no orchestrator state.
- Scope: all locally-saved projects; SSH-backed remote projects are excluded for v1 (follow-up).

## Test plan
- [x] `bun --filter @sma1lboy/kobe-daemon typecheck` clean
- [x] `bun run lint` (root, covers kobe + kobe-daemon) clean
- [x] `bun run check` (kobe-web biome) clean
- [x] `bun --filter @sma1lboy/kobe test` — 213/213 passing
- [x] kobe-web `bun run test` — 575/575 unit tests passing (2 pre-existing, unrelated Playwright-e2e-in-vitest failures)
- [x] `bun run build` (kobe-web) succeeds, route tree regenerated
- [ ] Manual: `bun run dev:sandbox`, open the Worktrees tab, verify badges render and both delete paths (clean single-confirm, dirty double-confirm force-delete) work end-to-end