### PR TITLE
ci: serialize the behavior suite (one worker), same as test:socket

### DIFF
--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -37,7 +37,7 @@
     "test": "bun run test:fast && bun run test:socket",
     "test:fast": "vitest run --passWithNoTests",
     "test:socket": "KOBE_INCLUDE_SOCKET=1 vitest run test/daemon --pool forks --minWorkers=1 --maxWorkers=1 --passWithNoTests",
-    "test:behavior": "KOBE_INCLUDE_BEHAVIOR=1 vitest run test/behavior --passWithNoTests",
+    "test:behavior": "KOBE_INCLUDE_BEHAVIOR=1 vitest run test/behavior --pool forks --minWorkers=1 --maxWorkers=1 --passWithNoTests",
     "test:render": "bun test test/render --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage-render",
     "coverage": "vitest run --coverage --passWithNoTests",
     "bench": "vitest bench --run",


### PR DESCRIPTION
Each behavior file boots a full kobe stack (daemon + tmux server + panes);
four in parallel on a 2-core runner starved pane-cleanup into an empty-frame
waitForScreen timeout (first red: the #215/#216 merge interaction on main —
each PR's own CI was green because #216's base predated pane-cleanup).
Serial locally: 23s, deterministic.
