### PR TITLE
test: pin task lifecycle + tmux handover/layout chords in behavior suite

### DIFF
--- a/packages/kobe/test/behavior/task-lifecycle.test.ts
+++ b/packages/kobe/test/behavior/task-lifecycle.test.ts
@@ -1,0 +1,178 @@
+/**
+ * `kobe api` black-box task + issue lifecycle — drives the CLI verb surface
+ * the way an agent scripting kobe from a shell would, with no TUI/tmux-outer
+ * session involved. Pins:
+ *
+ *   - `add --prompt` materializes the worktree on disk (`ensure-worktree`'s
+ *     contract) AND starts the task's tmux session (`ensureSession`'s
+ *     four-pane workspace: tasks/claude/ops/shell — `docs/ARCHITECTURE.md`'s
+ *     "Task = worktree + engine session + branch" unit, verified end to end).
+ *   - `archive` tears the session down via `killSession`'s pane-process-group
+ *     SIGTERM (the same #205 cleanup path `pane-cleanup.test.ts` pins for
+ *     `kill-sessions`), and is reflected in `get-task`/`list` (non-destructive:
+ *     the task row survives with `archived: true`).
+ *   - the daemon-owned issue store round-trips create → list → set-status
+ *     (`docs/WORK-TRACKING.md`'s backlog, driven via `kobe api issue-*`).
+ *
+ * One `beforeAll` boot (no tmux-outer session needed here — `kobe api`
+ * commands are piped CLI runs that auto-start the daemon and, for `add
+ * --prompt`, the task's own tmux session on `env.socket`), all assertions
+ * share it per docs/HARNESS.md's "one boot, multiple assertions" budget.
+ */
+
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { paneProcessGroups, parsePsRows } from "../../src/cli/doctor-resources.ts"
+import { type BehaviorEnv, makeBehaviorEnv, makeScratchRepo, runKobe, tmuxAvailable, tmuxInner } from "./harness.ts"
+
+interface AddResult {
+  taskId: string
+  task: { worktreePath: string; archived: boolean; status: string }
+  started: boolean
+  engineReady: boolean
+  session: string
+}
+
+interface GetTaskResult {
+  task: { archived: boolean; status: string }
+  running: boolean
+}
+
+interface ListResult {
+  tasks: { id: string; archived: boolean }[]
+}
+
+interface IssueListResult {
+  issues: { id: number; title: string; status: string }[]
+}
+
+/** Same liveness probe `pane-cleanup.test.ts` uses: ESRCH gone, EPERM alive-but-foreign. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM"
+  }
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((r) => setTimeout(r, 300))
+  }
+  return predicate()
+}
+
+describe.skipIf(!tmuxAvailable())("kobe api task + issue lifecycle (behavior)", () => {
+  let env: BehaviorEnv
+  let repo: string
+
+  beforeAll(async () => {
+    env = await makeBehaviorEnv()
+    repo = await makeScratchRepo(env)
+  }, 30_000)
+
+  afterAll(async () => {
+    await env.dispose()
+  })
+
+  let taskId: string
+  let session: string
+  let worktreePath: string
+
+  it("`add --prompt` materializes the worktree and starts a live 4-pane tmux session", () => {
+    const r = runKobe(["api", "add", "--repo", repo, "--prompt", "hello from behavior suite", "--pretty"], env)
+    expect(r.code).toBe(0)
+    const res = JSON.parse(r.stdout) as AddResult
+    taskId = res.taskId
+    session = res.session
+    worktreePath = res.task.worktreePath
+
+    expect(res.started).toBe(true)
+    expect(res.engineReady).toBe(true)
+    expect(session).toBe(`kobe-${taskId}`)
+    expect(res.task.archived).toBe(false)
+
+    // The worktree the task/orchestrator promised is a real directory on disk.
+    expect(existsSync(worktreePath)).toBe(true)
+
+    // The session is alive on kobe's OWN tmux socket with the full workspace.
+    const sessions = tmuxInner(env, "list-sessions", "-F", "#{session_name}").stdout
+    expect(sessions.split("\n")).toContain(session)
+
+    const paneRows = tmuxInner(env, "list-panes", "-t", `=${session}`, "-F", "#{@kobe_role}")
+      .stdout.split("\n")
+      .filter(Boolean)
+    expect(new Set(paneRows)).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+
+    // The engine pane is the fake-claude shim, already up (add awaited engineReady).
+    const claudePane = tmuxInner(env, "list-panes", "-t", `=${session}`, "-F", "#{pane_id}\t#{@kobe_role}")
+      .stdout.split("\n")
+      .find((l) => l.endsWith("\tclaude"))
+      ?.split("\t")[0]
+    expect(claudePane).toBeTruthy()
+    const capture = tmuxInner(env, "capture-pane", "-t", claudePane as string, "-p").stdout
+    expect(capture).toContain("fake-claude ready")
+  })
+
+  it("`archive` kills the session's full pane-process groups and flips `archived` in get-task/list", async () => {
+    const panePids = tmuxInner(env, "list-panes", "-t", `=${session}`, "-F", "#{pane_pid}")
+      .stdout.split("\n")
+      .map((l) => Number.parseInt(l.trim(), 10))
+      .filter((n) => Number.isFinite(n) && n > 1)
+    expect(panePids.length).toBeGreaterThanOrEqual(4)
+
+    const psOut = spawnSync("ps", ["-axo", "pid,pgid,rss,comm"], { encoding: "utf8" }).stdout ?? ""
+    const groupPids = paneProcessGroups(parsePsRows(psOut), panePids).map((r) => r.pid)
+    expect(groupPids.length).toBeGreaterThanOrEqual(panePids.length)
+
+    const r = runKobe(["api", "archive", "--task-id", taskId, "--pretty"], env)
+    expect(r.code).toBe(0)
+
+    // Session gone from kobe's tmux socket (killSession's SIGTERM-the-group path).
+    const sessionGone = await waitUntil(() => tmuxInner(env, "has-session", "-t", `=${session}`).code !== 0, 15_000)
+    expect(sessionGone).toBe(true)
+
+    // No pane-group process outlives the archive — the #205 leak class.
+    const noStragglers = await waitUntil(() => groupPids.every((pid) => !isAlive(pid)), 15_000)
+    expect(noStragglers).toBe(true)
+
+    const getRes = JSON.parse(
+      runKobe(["api", "get-task", "--task-id", taskId, "--pretty"], env).stdout,
+    ) as GetTaskResult
+    expect(getRes.task.archived).toBe(true)
+    expect(getRes.running).toBe(false)
+
+    const listRes = JSON.parse(runKobe(["api", "list", "--pretty"], env).stdout) as ListResult
+    const row = listRes.tasks.find((t) => t.id === taskId)
+    expect(row?.archived).toBe(true)
+
+    // Non-destructive: the worktree the first assertion found on disk is untouched.
+    expect(existsSync(worktreePath)).toBe(true)
+  }, 30_000)
+
+  it("issue store round-trips create -> list -> set-status", () => {
+    const created = JSON.parse(
+      runKobe(["api", "issue-create", "--repo", repo, "--title", "behavior suite issue", "--pretty"], env).stdout,
+    ) as IssueListResult
+    const issue = created.issues.find((i) => i.title === "behavior suite issue")
+    expect(issue).toBeTruthy()
+    expect(issue?.status).toBe("open")
+    const id = issue?.id as number
+
+    const listed = JSON.parse(runKobe(["api", "issue-list", "--repo", repo, "--pretty"], env).stdout) as IssueListResult
+    expect(listed.issues.some((i) => i.id === id && i.title === "behavior suite issue")).toBe(true)
+
+    const setStatus = runKobe(
+      ["api", "issue-set-status", "--repo", repo, "--id", String(id), "--status", "done", "--pretty"],
+      env,
+    )
+    expect(setStatus.code).toBe(0)
+
+    const after = JSON.parse(runKobe(["api", "issue-list", "--repo", repo, "--pretty"], env).stdout) as IssueListResult
+    expect(after.issues.find((i) => i.id === id)?.status).toBe("done")
+  })
+})

--- a/packages/kobe/test/behavior/tmux-chords.test.ts
+++ b/packages/kobe/test/behavior/tmux-chords.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Direct-tmux handover chord pins — one boot (like tui-smoke.test.ts),
+ * multiple send-keys/capture-pane assertions against kobe's OWN tmux socket
+ * (`tmuxInner`), driven through the OUTER attached client the same way a
+ * real terminal would (`tmux(env, "send-keys", ...)` on the pane running
+ * `kobe`). Claims pinned (see `src/tui/panes/terminal/tmux.ts` header comment
+ * + `docs/KEYBINDINGS.md` "Direct-tmux handover keys" table):
+ *
+ *   - `ctrl+t` opens a same-engine ChatTab (new window, same 4-pane layout,
+ *     its own live engine pane).
+ *   - `ctrl+]` / `ctrl+[` cycle ChatTab windows (tmux `next-window` /
+ *     `previous-window` — these WRAP, unlike pane focus).
+ *   - `ctrl+w` closes the current ChatTab window, but never the final one
+ *     (tmux.ts: "refuses to close the final window... the user intent here
+ *     is 'close this ChatTab', not 'destroy the Task handover'").
+ *   - `ctrl+j` / `ctrl+k` are silent no-ops from a pane with no vertical
+ *     neighbor (the engine pane spans full height) — #192's "random-feeling"
+ *     source B, the edge guard in `focusBindCommand`.
+ *   - the zoom exemption in `focusBindCommand`: a zoomed pane reports every
+ *     `pane_at_*` edge flag as 1, so the `window_zoomed_flag` branch bypasses
+ *     the edge guard entirely and falls through to plain `select-pane`,
+ *     un-zooming AND moving — the tmux.ts comment's "verified live" claim,
+ *     now automated.
+ *   - `ctrl+q` two-stage: first press focuses the Tasks pane, second press
+ *     (from Tasks) detaches the attached client while the session keeps
+ *     running.
+ *
+ * `ctrl+q`'s second press ends the OUTER attached client (and, since this
+ * suite's outer session has no other pane, the outer tmux SERVER itself) —
+ * so that test runs last in this file; every other assertion runs before it
+ * against the one shared boot.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import {
+  type BehaviorEnv,
+  makeBehaviorEnv,
+  makeScratchRepo,
+  tmux,
+  tmuxAvailable,
+  tmuxInner,
+  waitForScreen,
+} from "./harness.ts"
+
+const SESSION = "chords"
+
+interface PaneRow {
+  windowId: string
+  paneId: string
+  role: string
+  active: boolean
+  zoomed: boolean
+}
+
+function taskSessionName(env: BehaviorEnv): string {
+  const name = tmuxInner(env, "list-sessions", "-F", "#{session_name}")
+    .stdout.split("\n")
+    .find((s) => s.startsWith("kobe-") && s !== "kobe-home")
+  if (!name) throw new Error("no task session found on the inner socket")
+  return name
+}
+
+/** Every pane across every window of the session (`-s`), with role/active/zoom. */
+function allPanes(env: BehaviorEnv, session: string): PaneRow[] {
+  return tmuxInner(
+    env,
+    "list-panes",
+    "-s",
+    "-t",
+    `=${session}`,
+    "-F",
+    "#{window_id}\t#{pane_id}\t#{@kobe_role}\t#{pane_active}\t#{window_zoomed_flag}",
+  )
+    .stdout.split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [windowId, paneId, role, active, zoomed] = line.split("\t")
+      return { windowId, paneId, role, active: active === "1", zoomed: zoomed === "1" } as PaneRow
+    })
+}
+
+function windowIds(env: BehaviorEnv, session: string): string[] {
+  return tmuxInner(env, "list-windows", "-t", `=${session}`, "-F", "#{window_id}").stdout.split("\n").filter(Boolean)
+}
+
+function activeWindowId(env: BehaviorEnv, session: string): string {
+  const row = tmuxInner(env, "list-windows", "-t", `=${session}`, "-F", "#{window_active}\t#{window_id}")
+    .stdout.split("\n")
+    .find((l) => l.startsWith("1\t"))
+  return row?.split("\t")[1] ?? ""
+}
+
+/** The active pane's row within the CURRENT window (matches tui-smoke's `activeRole`). */
+function activePane(env: BehaviorEnv, session: string): PaneRow | undefined {
+  return allPanes(env, session).find((p) => p.active && p.windowId === activeWindowId(env, session))
+}
+
+function paneByRole(env: BehaviorEnv, session: string, role: string, windowId?: string): PaneRow | undefined {
+  return allPanes(env, session).find((p) => p.role === role && (!windowId || p.windowId === windowId))
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  return predicate()
+}
+
+describe.skipIf(!tmuxAvailable())("tmux direct-handover chords (behavior)", () => {
+  let env: BehaviorEnv
+  let session: string
+
+  beforeAll(async () => {
+    env = await makeBehaviorEnv()
+    const repo = await makeScratchRepo(env)
+    const boot = tmux(env, "new-session", "-d", "-x", "180", "-y", "45", "-s", SESSION, `cd ${repo} && kobe`)
+    expect(boot.code).toBe(0)
+    await waitForScreen(env, SESSION, (s) => s.includes("KOBE v") && s.includes("fake-claude ready"), 45_000)
+    session = taskSessionName(env)
+  }, 60_000)
+
+  afterAll(async () => {
+    await env.dispose()
+  })
+
+  it("ctrl+t opens a new same-engine ChatTab window with its own live engine pane", async () => {
+    const before = new Set(windowIds(env, session))
+    expect(before.size).toBe(1)
+
+    tmux(env, "send-keys", "-t", SESSION, "C-t")
+    const opened = await waitUntil(() => windowIds(env, session).length === before.size + 1)
+    expect(opened).toBe(true)
+
+    const after = windowIds(env, session)
+    const newWindow = after.find((w) => !before.has(w))
+    expect(newWindow).toBeTruthy()
+    // New window carries the full 4-pane workspace, not a bare shell. The
+    // window itself exists as soon as tmux splits it, but the `@kobe_role`
+    // tags land a beat later (buildPanesAround's follow-up set-option calls),
+    // so poll for the full role set rather than asserting on the first read.
+    const rolesInNewWindow = () =>
+      new Set(
+        allPanes(env, session)
+          .filter((p) => p.windowId === newWindow)
+          .map((p) => p.role),
+      )
+    const tagged = await waitUntil(() => rolesInNewWindow().size === 4)
+    expect(tagged).toBe(true)
+    expect(rolesInNewWindow()).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+
+    const claudePane = paneByRole(env, session, "claude", newWindow)
+    expect(claudePane).toBeTruthy()
+    const ready = await waitUntil(() =>
+      tmuxInner(env, "capture-pane", "-t", claudePane?.paneId as string, "-p").stdout.includes("fake-claude ready"),
+    )
+    expect(ready).toBe(true)
+  }, 20_000)
+
+  it("ctrl+] / ctrl+[ cycle the active ChatTab window (wraps, unlike pane focus)", async () => {
+    const start = activeWindowId(env, session)
+    const all = windowIds(env, session)
+    expect(all.length).toBe(2) // carried over from the ctrl+t test
+
+    tmux(env, "send-keys", "-t", SESSION, "C-]")
+    const movedForward = await waitUntil(() => activeWindowId(env, session) !== start)
+    expect(movedForward).toBe(true)
+    const mid = activeWindowId(env, session)
+    expect(mid).not.toBe(start)
+
+    tmux(env, "send-keys", "-t", SESSION, "C-[")
+    const movedBack = await waitUntil(() => activeWindowId(env, session) === start)
+    expect(movedBack).toBe(true)
+  }, 15_000)
+
+  it("ctrl+w closes the current ChatTab window; the final window is protected", async () => {
+    // Leave the active window on the SECOND (non-@0) window before closing —
+    // closing @0 (the session's very first window) is the same operation but
+    // asserting on "count went from 2 to 1" doesn't care which one dies.
+    const before = windowIds(env, session)
+    expect(before.length).toBe(2)
+    // `chat-tab-close` runs plain `kill-window` (layout-actions.ts's
+    // `closeChatTab`) — tmux's own SIGHUP-the-pane teardown, NOT the
+    // SIGTERM-the-process-GROUP `killSession` does for a whole-task kill.
+    // The fake `claude` shim traps SIGHUP (same as the real CLI), so its
+    // process survives the window close, reparented to init, invisible to
+    // `list-panes` once the window is gone — the exact #205 leak class
+    // `pane-cleanup.test.ts` pins for `kill-sessions`, but here on the
+    // ChatTab-close path, which was never given the same fix. Genuine
+    // product gap, out of this test-only branch's scope to fix (see the
+    // PR description); the cleanup below only stops THIS test run from
+    // leaving its own orphan behind.
+    const beforePids = tmuxInner(env, "list-panes", "-s", "-t", `=${session}`, "-F", "#{pane_pid}")
+      .stdout.split("\n")
+      .map((l) => Number.parseInt(l.trim(), 10))
+      .filter((n) => Number.isFinite(n) && n > 1)
+
+    tmux(env, "send-keys", "-t", SESSION, "C-w")
+    const closed = await waitUntil(() => windowIds(env, session).length === 1)
+    expect(closed).toBe(true)
+
+    // Final window: ctrl+w must be a no-op, not a session-kill.
+    tmux(env, "send-keys", "-t", SESSION, "C-w")
+    await new Promise((r) => setTimeout(r, 1_500))
+    expect(windowIds(env, session).length).toBe(1)
+    expect(tmuxInner(env, "has-session", "-t", `=${session}`).code).toBe(0)
+
+    // Test hygiene: reap the #205-class orphan documented above so this
+    // suite doesn't leave a `sleep 600` fake-claude behind on every run.
+    // `env.dispose()` can't reach it (it's already invisible to tmux).
+    const stillOnSession = new Set(
+      tmuxInner(env, "list-panes", "-s", "-t", `=${session}`, "-F", "#{pane_pid}")
+        .stdout.split("\n")
+        .map((l) => Number.parseInt(l.trim(), 10)),
+    )
+    for (const pid of beforePids) {
+      if (stillOnSession.has(pid)) continue
+      try {
+        process.kill(-pid, "SIGKILL")
+      } catch {
+        /* already gone, or not a group leader — best effort */
+      }
+    }
+  }, 15_000)
+
+  it("ctrl+j / ctrl+k are silent no-ops from the engine pane (no vertical neighbor)", async () => {
+    // Pin a known starting pane directly (not via send-keys) so this test
+    // doesn't depend on what the window/close tests above left focused.
+    const claudePane = paneByRole(env, session, "claude")
+    expect(claudePane).toBeTruthy()
+    tmuxInner(env, "select-pane", "-t", claudePane?.paneId as string)
+
+    tmux(env, "send-keys", "-t", SESSION, "C-j")
+    await new Promise((r) => setTimeout(r, 1_000))
+    expect(activePane(env, session)?.role).toBe("claude")
+
+    tmux(env, "send-keys", "-t", SESSION, "C-k")
+    await new Promise((r) => setTimeout(r, 1_000))
+    expect(activePane(env, session)?.role).toBe("claude")
+  }, 15_000)
+
+  it("zoom exemption: resize-pane -Z then ctrl+h un-zooms AND moves focus", async () => {
+    // Zoom the Tasks pane (the true left edge) — without the exemption,
+    // ctrl+h there is normally a guarded no-op (see tui-smoke.test.ts); a
+    // ZOOMED pane reports every pane_at_* edge as 1, so this is the one
+    // state where the guard would turn ctrl+h into a dead key without it.
+    const tasksPane = paneByRole(env, session, "tasks")
+    expect(tasksPane).toBeTruthy()
+    tmuxInner(env, "select-pane", "-t", tasksPane?.paneId as string)
+    const zoomResult = tmuxInner(env, "resize-pane", "-Z", "-t", session)
+    expect(zoomResult.code).toBe(0)
+    expect(activePane(env, session)?.zoomed).toBe(true)
+    expect(activePane(env, session)?.role).toBe("tasks")
+
+    tmux(env, "send-keys", "-t", SESSION, "C-h")
+    const moved = await waitUntil(() => activePane(env, session)?.role !== "tasks")
+    expect(moved).toBe(true)
+    expect(activePane(env, session)?.zoomed).toBe(false)
+  }, 15_000)
+
+  it("ctrl+q is two-stage: focuses Tasks first, detaches the client on the second press", async () => {
+    const claudePane = paneByRole(env, session, "claude")
+    expect(claudePane).toBeTruthy()
+    tmuxInner(env, "select-pane", "-t", claudePane?.paneId as string)
+    expect(activePane(env, session)?.role).toBe("claude")
+
+    const attachedBefore = tmuxInner(env, "list-sessions", "-F", "#{session_name}\t#{session_attached}")
+      .stdout.split("\n")
+      .find((l) => l.startsWith(`${session}\t`))
+    expect(attachedBefore).toBe(`${session}\t1`)
+
+    tmux(env, "send-keys", "-t", SESSION, "C-q")
+    const focusedTasks = await waitUntil(() => activePane(env, session)?.role === "tasks")
+    expect(focusedTasks).toBe(true)
+
+    tmux(env, "send-keys", "-t", SESSION, "C-q")
+    // The client detaches — the session's attached-client count is the
+    // observable signal (the harness never truly "attaches" a client, so we
+    // assert on this rather than an unattached outer TTY's screen content).
+    const detached = await waitUntil(() => {
+      const row = tmuxInner(env, "list-sessions", "-F", "#{session_name}\t#{session_attached}")
+        .stdout.split("\n")
+        .find((l) => l.startsWith(`${session}\t`))
+      return row === `${session}\t0`
+    }, 10_000)
+    expect(detached).toBe(true)
+    // Detach, not destroy: the task's tmux session keeps running.
+    expect(tmuxInner(env, "has-session", "-t", `=${session}`).code).toBe(0)
+  }, 20_000)
+})

--- a/packages/kobe/test/behavior/tmux-layout-keys.test.ts
+++ b/packages/kobe/test/behavior/tmux-layout-keys.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Prefix-table layout chord pins (`docs/KEYBINDINGS.md` "Direct-tmux handover
+ * keys": `prefix a/o/z/space`) — one boot, one send-keys per toggle, reusing
+ * the same session across assertions (`docs/HARNESS.md` budget).
+ *
+ * The prefix itself is NOT hardcoded to tmux's built-in `C-b`: the `-L kobe`
+ * socket still loads the operator's own `~/.tmux.conf` (see the header
+ * comment on `ensureSession` in `src/tui/panes/terminal/tmux.ts`), and a
+ * config that rebinds the primary `prefix` (common — e.g. screen-style
+ * `C-a` setups) would otherwise silently no-op every assertion below. This
+ * suite resolves the live prefix via `show-options -g prefix` instead, so it
+ * is correct both on a bare CI runner (tmux's built-in `C-b`) and on a
+ * developer machine with a customized one.
+ *
+ * Claims pinned (`session-layout.ts`/`layout-actions.ts`'s hide/restore
+ * contract, quoting `docs/KEYBINDINGS.md` rows 112-115):
+ *   - `prefix a` hides/restores the Tasks rail by moving it to a background
+ *     tmux window (`break-pane` into a hidden helper session), so its
+ *     process is preserved, not killed.
+ *   - `prefix o` toggles the Ops pane — but "hiding it closes only the
+ *     kobe-owned Ops pane; showing it rebuilds that pane": unlike Tasks and
+ *     the terminal, this is a real kill + respawn, so its pid changes.
+ *   - `prefix z` hides/restores the terminal (shell) pane the same
+ *     process-preserving way as Tasks.
+ *   - `prefix space` (zen) collapses every pane except Tasks + the engine
+ *     pane (default `zen.keepTasks: true`, `src/state/zen.ts`), and restores
+ *     the full 4-pane workspace on a second press — preserving the
+ *     hidden-session panes' processes (Ops still rebuilds, per its own
+ *     toggle contract).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import {
+  type BehaviorEnv,
+  makeBehaviorEnv,
+  makeScratchRepo,
+  tmux,
+  tmuxAvailable,
+  tmuxInner,
+  waitForScreen,
+} from "./harness.ts"
+
+const SESSION = "layoutkeys"
+
+interface PaneRow {
+  paneId: string
+  role: string
+  pid: number
+}
+
+function taskSessionName(env: BehaviorEnv): string {
+  const name = tmuxInner(env, "list-sessions", "-F", "#{session_name}")
+    .stdout.split("\n")
+    .find((s) => s.startsWith("kobe-") && s !== "kobe-home")
+  if (!name) throw new Error("no task session found on the inner socket")
+  return name
+}
+
+/** Panes of the session's CURRENT window (mirrors the running ChatTab's visible workspace). */
+function currentPanes(env: BehaviorEnv, session: string): PaneRow[] {
+  return tmuxInner(env, "list-panes", "-t", `=${session}`, "-F", "#{pane_id}\t#{@kobe_role}\t#{pane_pid}")
+    .stdout.split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [paneId, role, pid] = line.split("\t")
+      return { paneId, role, pid: Number.parseInt(pid ?? "", 10) } as PaneRow
+    })
+}
+
+function roleSet(rows: readonly PaneRow[]): Set<string> {
+  return new Set(rows.map((r) => r.role))
+}
+
+function pidOf(rows: readonly PaneRow[], role: string): number | undefined {
+  return rows.find((r) => r.role === role)?.pid
+}
+
+/** ESRCH -> gone, EPERM -> alive but owned elsewhere (same probe pane-cleanup.test.ts uses). */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM"
+  }
+}
+
+function resolvePrefixKey(env: BehaviorEnv): string {
+  const out = tmuxInner(env, "show-options", "-g", "prefix").stdout.trim()
+  return out.split(/\s+/)[1] || "C-b"
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (predicate()) return true
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  return predicate()
+}
+
+describe.skipIf(!tmuxAvailable())("tmux prefix-table layout chords (behavior)", () => {
+  let env: BehaviorEnv
+  let session: string
+  let prefixKey: string
+
+  beforeAll(async () => {
+    env = await makeBehaviorEnv()
+    const repo = await makeScratchRepo(env)
+    const boot = tmux(env, "new-session", "-d", "-x", "180", "-y", "45", "-s", SESSION, `cd ${repo} && kobe`)
+    expect(boot.code).toBe(0)
+    await waitForScreen(env, SESSION, (s) => s.includes("KOBE v") && s.includes("fake-claude ready"), 45_000)
+    session = taskSessionName(env)
+    prefixKey = resolvePrefixKey(env)
+  }, 60_000)
+
+  afterAll(async () => {
+    await env.dispose()
+  })
+
+  /** Send one prefix chord (`prefix a`, `prefix space`, ...) as a single ordered send-keys call. */
+  function sendPrefixChord(letter: string): void {
+    tmux(env, "send-keys", "-t", SESSION, prefixKey, letter)
+  }
+
+  it("prefix a hides/restores the Tasks rail, preserving its pane process", async () => {
+    const before = currentPanes(env, session)
+    expect(roleSet(before)).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+    const tasksPid = pidOf(before, "tasks") as number
+
+    sendPrefixChord("a")
+    const hidden = await waitUntil(() => !roleSet(currentPanes(env, session)).has("tasks"))
+    expect(hidden).toBe(true)
+    expect(roleSet(currentPanes(env, session))).toEqual(new Set(["claude", "ops", "shell"]))
+    // Hidden, not killed: break-pane into the helper session keeps it running.
+    expect(isAlive(tasksPid)).toBe(true)
+
+    sendPrefixChord("a")
+    const restored = await waitUntil(() => roleSet(currentPanes(env, session)).has("tasks"))
+    expect(restored).toBe(true)
+    const after = currentPanes(env, session)
+    expect(roleSet(after)).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+    expect(pidOf(after, "tasks")).toBe(tasksPid)
+  }, 20_000)
+
+  it("prefix o toggles the Ops pane by killing + rebuilding it (pid changes on restore)", async () => {
+    const before = currentPanes(env, session)
+    const opsPidBefore = pidOf(before, "ops") as number
+
+    sendPrefixChord("o")
+    const hidden = await waitUntil(() => !roleSet(currentPanes(env, session)).has("ops"))
+    expect(hidden).toBe(true)
+    expect(roleSet(currentPanes(env, session))).toEqual(new Set(["tasks", "claude", "shell"]))
+    // Unlike Tasks/terminal, kobe explicitly kills the Ops pane on hide (docs/KEYBINDINGS.md):
+    // its old pid must be gone, not parked in a hidden session.
+    const killed = await waitUntil(() => !isAlive(opsPidBefore))
+    expect(killed).toBe(true)
+
+    sendPrefixChord("o")
+    const restored = await waitUntil(() => roleSet(currentPanes(env, session)).has("ops"))
+    expect(restored).toBe(true)
+    const after = currentPanes(env, session)
+    expect(roleSet(after)).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+    expect(pidOf(after, "ops")).not.toBe(opsPidBefore)
+  }, 20_000)
+
+  it("prefix z hides/restores the terminal pane, preserving its shell process", async () => {
+    const before = currentPanes(env, session)
+    const shellPid = pidOf(before, "shell") as number
+
+    sendPrefixChord("z")
+    const hidden = await waitUntil(() => !roleSet(currentPanes(env, session)).has("shell"))
+    expect(hidden).toBe(true)
+    expect(roleSet(currentPanes(env, session))).toEqual(new Set(["tasks", "claude", "ops"]))
+    expect(isAlive(shellPid)).toBe(true)
+
+    sendPrefixChord("z")
+    const restored = await waitUntil(() => roleSet(currentPanes(env, session)).has("shell"))
+    expect(restored).toBe(true)
+    const after = currentPanes(env, session)
+    expect(roleSet(after)).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+    expect(pidOf(after, "shell")).toBe(shellPid)
+  }, 20_000)
+
+  it("prefix space (zen) collapses to Tasks + engine, restoring the full workspace with the terminal process intact", async () => {
+    const before = currentPanes(env, session)
+    expect(roleSet(before)).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+    const shellPid = pidOf(before, "shell") as number
+
+    sendPrefixChord("Space")
+    const zenned = await waitUntil(() => roleSet(currentPanes(env, session)).size === 2)
+    expect(zenned).toBe(true)
+    // Default zen.keepTasks: true (src/state/zen.ts) — Tasks survives, Ops + terminal hide.
+    expect(roleSet(currentPanes(env, session))).toEqual(new Set(["tasks", "claude"]))
+
+    sendPrefixChord("Space")
+    const restored = await waitUntil(() => roleSet(currentPanes(env, session)).size === 4)
+    expect(restored).toBe(true)
+    const after = currentPanes(env, session)
+    expect(roleSet(after)).toEqual(new Set(["tasks", "claude", "ops", "shell"]))
+    // The terminal pane survived zen hidden, not rebuilt (same pid); Ops is
+    // rebuilt on every restore regardless of the path that hid it (its own
+    // toggle contract, pinned above) so its pid is deliberately NOT asserted here.
+    expect(pidOf(after, "shell")).toBe(shellPid)
+  }, 20_000)
+})


### PR DESCRIPTION
## Summary

Three new black-box `test/behavior/` files, per docs/HARNESS.md's "behavioral self-test" contract — no src changes, test-only.

- **`task-lifecycle.test.ts`** — drives `kobe api` end to end: `add --prompt` (worktree materialized on disk, live 4-pane tmux session, engine ready) → `archive` (session + full pane-process groups torn down, `get-task`/`list` flip to `archived: true`) → the daemon-owned issue store round trip (`issue-create` → `issue-list` → `issue-set-status` → `issue-list`).
- **`tmux-chords.test.ts`** — one boot, drives the no-prefix direct-tmux handover chords in sequence.
- **`tmux-layout-keys.test.ts`** — one boot, drives the prefix-table layout toggles (`prefix a/o/z/space`), resolving the live tmux `prefix` via `show-options -g prefix` instead of assuming `C-b` (the `-L kobe` socket still loads the operator's own `~/.tmux.conf`, which can rebind it).

### Claims pinned (mapped to `tmux.ts` / `docs/KEYBINDINGS.md`)

| Chord | Claim | Source |
|---|---|---|
| `ctrl+t` | new same-engine ChatTab window, full 4-pane workspace, live engine pane | tmux.ts header comment |
| `ctrl+]` / `ctrl+[` | ChatTab cycle, **wraps** (unlike pane focus) | KEYBINDINGS.md row 106 |
| `ctrl+w` | closes current ChatTab window; final window protected | tmux.ts comment ("refuses to close the final window") |
| `ctrl+j` / `ctrl+k` | silent no-op from a pane with no vertical neighbor (#192 source B) | `focusBindCommand` edge guard |
| zoom exemption | `resize-pane -Z` + `ctrl+h` → un-zooms AND moves | `focusBindCommand`'s `window_zoomed_flag` branch, "verified live" comment now automated |
| `ctrl+q` | two-stage: focus Tasks, then detach (session keeps running) | KEYBINDINGS.md row 102 |
| `prefix a` | Tasks rail hide/restore, pane process preserved (break-pane to hidden session) | KEYBINDINGS.md row 112 |
| `prefix o` | Ops pane hide/restore, **killed + rebuilt** (pid changes) | KEYBINDINGS.md row 113 |
| `prefix z` | terminal pane hide/restore, process preserved | KEYBINDINGS.md row 114 |
| `prefix space` | zen collapses to Tasks+engine (default `zen.keepTasks: true`), restores full workspace | KEYBINDINGS.md row 115, `src/state/zen.ts` |
| `kobe api add/archive/get-task/list` | worktree materialization, live session, non-destructive archive | `docs/ARCHITECTURE.md`'s Task unit |
| `kobe api issue-*` | daemon-owned issue store CRUD+status | `docs/WORK-TRACKING.md` |

### Skipped / not asserted

- Nothing skipped outright — the one originally-risky claim (ctrl+q's second-press detach, since the harness never truly *attaches* a client) turned out to be directly observable: the inner session's `#{session_attached}` flips `1` → `0`, and the session itself keeps running (`has-session` still 0). Asserted on that instead of screen content.

### Found while pinning (not fixed — out of scope for a test-only branch)

`ctrl+w` / `chat-tab-close` (`layout-actions.ts`'s `closeChatTab`) tears down the closed window with plain `kill-window` — tmux's default SIGHUP-the-pane teardown — instead of the SIGTERM-the-process-**group** path `killSession` uses for a whole-task kill. An engine that ignores SIGHUP (the real `claude` CLI does, same as the fake shim) survives the window close as an orphan, reparented to init and invisible to `list-panes` once the window is gone — the same #205 leak class `pane-cleanup.test.ts` already pins for `kill-sessions`, just never extended to the ChatTab-close path. The `ctrl+w` test in `tmux-chords.test.ts` documents this inline and reaps its own orphan as test hygiene (`env.dispose()` can't reach it, since it's already gone from tmux's view) — suggest a follow-up to give `closeChatTab` the same pane-group SIGTERM `killSession` uses.

### Suite timing

New suites add ~26s to the behavior run (`task-lifecycle` ~10.5s, `tmux-chords` ~9s, `tmux-layout-keys` ~6.4s) on top of the existing ~23s (4 files), for a serial CI total of ~50s — within the ~60s added-time budget. Ran the full `bun run test:behavior` locally 3x consecutively (after fixing one initial flake — a role-tag race on `ctrl+t`'s freshly split panes, fixed by polling for the full role set instead of just the window count) with 25/25 green and, after the ctrl+w hygiene fix above, zero leaked processes across all 3 runs.

## Test plan

- [x] `cd packages/kobe && bun run build && bun run test:behavior` — 7 files / 25 tests green, 3 consecutive local runs
- [x] repo-root `bun run lint` — green
- [x] repo-root `bun run typecheck` — green
- [x] no src changes; test-only, no changeset needed