### PR TITLE
Add Codex headless runTurn

### DIFF
--- a/.changeset/codex-runturn-settings.md
+++ b/.changeset/codex-runturn-settings.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Add a Codex-backed headless runTurn path with small-model configuration and expose runTurn model settings in TUI/Web Settings.

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -13,6 +13,13 @@ import {
   kobeApiInvocation,
 } from "@/engine/interactive-command"
 import { engineEntry } from "@/engine/registry"
+import {
+  normalizeRunTurnEffort,
+  runTurnEffortKey,
+  runTurnModelKey,
+  runTurnSettingsFromState,
+  runTurnSmallModelKey,
+} from "@/engine/run-turn-settings"
 import type { Orchestrator } from "@/orchestrator/core"
 import { AUTO_STATUS_KEY } from "@/state/auto-status"
 import { DISPATCHER_KEY } from "@/state/dispatcher"
@@ -227,14 +234,21 @@ function settingsSnapshot(): Response {
     autoStatus: state[AUTO_STATUS_KEY] === true,
     dispatcher: state[DISPATCHER_KEY] === true,
     defaultEngine,
-    engines: engineIds.map((id) => ({
-      id,
-      label: engineLabelText(state, id),
-      command: engineCommandText(state, id),
-      isBuiltin: isBuiltinVendor(id),
-      isCustom: !isBuiltinVendor(id),
-      isDefault: id === defaultEngine,
-    })),
+    engines: engineIds.map((id) => {
+      const runTurn = runTurnSettingsFromState(state, id)
+      return {
+        id,
+        label: engineLabelText(state, id),
+        command: engineCommandText(state, id),
+        runTurnModel: runTurn.model,
+        runTurnSmallModel: runTurn.smallModel,
+        runTurnEffort: runTurn.effort,
+        runTurnEffortLevels: runTurn.effortLevels,
+        isBuiltin: isBuiltinVendor(id),
+        isCustom: !isBuiltinVendor(id),
+        isDefault: id === defaultEngine,
+      }
+    }),
   })
 }
 
@@ -276,10 +290,25 @@ async function settingsPatch(req: Request): Promise<Response> {
     const updates = Array.isArray(body.engineUpdates) ? body.engineUpdates : []
     for (const raw of updates) {
       if (!raw || typeof raw !== "object") continue
-      const update = raw as { id?: unknown; command?: unknown; label?: unknown }
+      const update = raw as {
+        id?: unknown
+        command?: unknown
+        label?: unknown
+        runTurnModel?: unknown
+        runTurnSmallModel?: unknown
+        runTurnEffort?: unknown
+      }
       if (typeof update.id !== "string" || !known.has(update.id)) continue
       putIfString(patch, engineCommandKey(update.id), update.command)
       putIfString(patch, engineNameKey(update.id), update.label)
+      putIfString(patch, runTurnModelKey(update.id), update.runTurnModel)
+      putIfString(patch, runTurnSmallModelKey(update.id), update.runTurnSmallModel)
+      if (typeof update.runTurnEffort === "string") {
+        const effort = update.runTurnEffort.trim()
+        if (effort.length === 0 || normalizeRunTurnEffort(update.id, effort) === effort) {
+          patch[runTurnEffortKey(update.id)] = effort
+        }
+      }
     }
 
     if (body.addEngine && typeof body.addEngine === "object") {
@@ -300,6 +329,9 @@ async function settingsPatch(req: Request): Promise<Response> {
         patch.customEngineIds = custom.filter((engine) => engine !== id)
         patch[engineCommandKey(id)] = undefined
         patch[engineNameKey(id)] = undefined
+        patch[runTurnModelKey(id)] = undefined
+        patch[runTurnSmallModelKey(id)] = undefined
+        patch[runTurnEffortKey(id)] = undefined
         if (state.lastSelectedVendor === id) patch.lastSelectedVendor = "claude"
       }
     }

--- a/packages/kobe-web/src/components/SettingsPage.tsx
+++ b/packages/kobe-web/src/components/SettingsPage.tsx
@@ -141,12 +141,24 @@ function EngineRow({
   onRemove,
 }: {
   engine: WebSettingsEngine
-  onSave: (id: string, command: string, label: string) => void
+  onSave: (
+    id: string,
+    command: string,
+    label: string,
+    runTurnModel: string,
+    runTurnSmallModel: string,
+    runTurnEffort: string,
+  ) => void
   onDefault: (id: string) => void
   onRemove: (id: string) => void
 }) {
   const [command, setCommand] = useState(engine.command)
   const [label, setLabel] = useState(engine.label)
+  const [runTurnModel, setRunTurnModel] = useState(engine.runTurnModel)
+  const [runTurnSmallModel, setRunTurnSmallModel] = useState(
+    engine.runTurnSmallModel,
+  )
+  const [runTurnEffort, setRunTurnEffort] = useState(engine.runTurnEffort)
   const labelLooksLikeCommand =
     /\s--[A-Za-z0-9][\w-]*/.test(label) &&
     !/\s--[A-Za-z0-9][\w-]*/.test(command)
@@ -154,7 +166,16 @@ function EngineRow({
   useEffect(() => {
     setCommand(engine.command)
     setLabel(engine.label)
-  }, [engine.command, engine.label])
+    setRunTurnModel(engine.runTurnModel)
+    setRunTurnSmallModel(engine.runTurnSmallModel)
+    setRunTurnEffort(engine.runTurnEffort)
+  }, [
+    engine.command,
+    engine.label,
+    engine.runTurnModel,
+    engine.runTurnSmallModel,
+    engine.runTurnEffort,
+  ])
 
   return (
     <div className="border border-line bg-bg p-3">
@@ -201,6 +222,42 @@ function EngineRow({
           className="mt-1 w-full border border-line bg-surface px-2 py-1 font-mono text-fg focus:border-line-active focus:outline-none"
         />
       </label>
+      <div className="mt-3 grid gap-2 md:grid-cols-3">
+        <label className="block">
+          <span className="text-[11px] text-muted">
+            runTurn model (blank = CLI default)
+          </span>
+          <input
+            value={runTurnModel}
+            onChange={(event) => setRunTurnModel(event.target.value)}
+            className="mt-1 w-full border border-line bg-surface px-2 py-1 font-mono text-fg focus:border-line-active focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <span className="text-[11px] text-muted">Small-model call</span>
+          <input
+            value={runTurnSmallModel}
+            onChange={(event) => setRunTurnSmallModel(event.target.value)}
+            className="mt-1 w-full border border-line bg-surface px-2 py-1 font-mono text-fg focus:border-line-active focus:outline-none"
+          />
+        </label>
+        <label className="block">
+          <span className="text-[11px] text-muted">Reasoning effort</span>
+          <select
+            value={runTurnEffort}
+            onChange={(event) => setRunTurnEffort(event.target.value)}
+            disabled={engine.runTurnEffortLevels.length === 0}
+            className="mt-1 w-full border border-line bg-surface px-2 py-1 font-mono text-fg disabled:opacity-40 focus:border-line-active focus:outline-none"
+          >
+            <option value="">default</option>
+            {engine.runTurnEffortLevels.map((level) => (
+              <option key={level} value={level}>
+                {level}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
       {labelLooksLikeCommand ? (
         <div className="mt-2 border border-kobe-yellow/40 bg-kobe-yellow/10 px-2 py-1 text-[11px] leading-relaxed text-kobe-yellow">
           This looks like a flag in the display name. Put permission/model flags
@@ -210,7 +267,16 @@ function EngineRow({
       <div className="mt-3 flex items-center gap-2">
         <button
           type="button"
-          onClick={() => onSave(engine.id, command, label)}
+          onClick={() =>
+            onSave(
+              engine.id,
+              command,
+              label,
+              runTurnModel,
+              runTurnSmallModel,
+              runTurnEffort,
+            )
+          }
           className="border border-primary bg-inset px-2 py-1 text-[11px] text-fg"
         >
           Save
@@ -243,9 +309,21 @@ function EnginesSection({
     engineId: string,
     nextCommand: string,
     nextLabel: string,
+    runTurnModel: string,
+    runTurnSmallModel: string,
+    runTurnEffort: string,
   ) =>
     void patch({
-      engineUpdates: [{ id: engineId, command: nextCommand, label: nextLabel }],
+      engineUpdates: [
+        {
+          id: engineId,
+          command: nextCommand,
+          label: nextLabel,
+          runTurnModel,
+          runTurnSmallModel,
+          runTurnEffort,
+        },
+      ],
     }).then(() => pushToast("success", "engine saved"))
 
   return (
@@ -254,8 +332,9 @@ function EnginesSection({
         <p className="text-[11px] leading-relaxed text-subtle">
           Same shared engine settings as the TUI. Built-ins can be renamed or
           pointed at a different command. Permission/model flags must live in
-          Launch command, not Display name. Custom engines are available in new
-          task and tab pickers.
+          Launch command, not Display name. Headless runTurn model settings are
+          separate so router/probe calls can switch models without changing the
+          interactive task pane.
         </p>
         <div className="space-y-2">
           {settings.engines.map((engine) => (

--- a/packages/kobe-web/src/lib/settings.ts
+++ b/packages/kobe-web/src/lib/settings.ts
@@ -8,6 +8,10 @@ export interface WebSettingsEngine {
   id: string
   label: string
   command: string
+  runTurnModel: string
+  runTurnSmallModel: string
+  runTurnEffort: string
+  runTurnEffortLevels: readonly string[]
   isBuiltin: boolean
   isCustom: boolean
   isDefault: boolean
@@ -41,7 +45,14 @@ export type WebSettingsPatch = Partial<
     | "defaultEngine"
   >
 > & {
-  engineUpdates?: Array<{ id: string; command?: string; label?: string }>
+  engineUpdates?: Array<{
+    id: string
+    command?: string
+    label?: string
+    runTurnModel?: string
+    runTurnSmallModel?: string
+    runTurnEffort?: string
+  }>
   addEngine?: { id: string; command: string; label?: string }
   removeEngine?: string
 }

--- a/packages/kobe-web/test/bridge-routes.test.ts
+++ b/packages/kobe-web/test/bridge-routes.test.ts
@@ -424,7 +424,15 @@ describe("/api/quick-prompts", () => {
       archivedHistoryPreview: boolean
       autoStatus: boolean
       dispatcher: boolean
-      engines: Array<{ id: string; isBuiltin: boolean; isDefault: boolean }>
+      engines: Array<{
+        id: string
+        isBuiltin: boolean
+        isDefault: boolean
+        runTurnModel: string
+        runTurnSmallModel: string
+        runTurnEffort: string
+        runTurnEffortLevels: readonly string[]
+      }>
     }
     expect(empty.activeTheme).toBe("claude")
     expect(empty.transparentBackground).toBe(false)
@@ -433,6 +441,15 @@ describe("/api/quick-prompts", () => {
     expect(empty.editorKind).toBe("auto")
     expect(empty.archivedHistoryPreview).toBe(false)
     expect(empty.engines.some((engine) => engine.id === "claude" && engine.isBuiltin)).toBe(true)
+    expect(empty.engines).toContainEqual(
+      expect.objectContaining({
+        id: "codex",
+        runTurnModel: "",
+        runTurnSmallModel: "",
+        runTurnEffort: "",
+        runTurnEffortLevels: ["none", "low", "medium", "high", "xhigh"],
+      }),
+    )
 
     const patched = (await (
       await handle(
@@ -508,13 +525,27 @@ describe("/api/quick-prompts", () => {
           method: "PATCH",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            engineUpdates: [{ id: "aider", command: "aider --yes", label: "Aider CLI" }],
+            engineUpdates: [
+              {
+                id: "aider",
+                command: "aider --yes",
+                label: "Aider CLI",
+                runTurnModel: "aider-large",
+                runTurnSmallModel: "aider-small",
+              },
+            ],
           }),
         }),
       )
     ).json()) as typeof added
     expect(edited.engines).toContainEqual(
-      expect.objectContaining({ id: "aider", label: "Aider CLI", command: "aider --yes" }),
+      expect.objectContaining({
+        id: "aider",
+        label: "Aider CLI",
+        command: "aider --yes",
+        runTurnModel: "aider-large",
+        runTurnSmallModel: "aider-small",
+      }),
     )
 
     const removed = (await (
@@ -568,6 +599,43 @@ describe("/api/quick-prompts", () => {
         id: "codex",
         label: "Codex",
         command: "codex --dangerously-bypass-approvals-and-sandbox",
+      }),
+    )
+  })
+
+  it("rounds codex runTurn model settings through engine updates", async () => {
+    const { handle } = build()
+    const patched = (await (
+      await handle(
+        new Request("http://localhost/api/settings", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            engineUpdates: [
+              {
+                id: "codex",
+                runTurnModel: "gpt-large",
+                runTurnSmallModel: "gpt-small",
+                runTurnEffort: "low",
+              },
+            ],
+          }),
+        }),
+      )
+    ).json()) as {
+      engines: Array<{
+        id: string
+        runTurnModel: string
+        runTurnSmallModel: string
+        runTurnEffort: string
+      }>
+    }
+    expect(patched.engines).toContainEqual(
+      expect.objectContaining({
+        id: "codex",
+        runTurnModel: "gpt-large",
+        runTurnSmallModel: "gpt-small",
+        runTurnEffort: "low",
       }),
     )
   })

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -9,6 +9,7 @@
  *   - `kobe remove [path]`      Forget a saved project (inverse of `add`; non-destructive).
  *   - `kobe adopt [glob]`       Import existing git worktrees as tasks.
  *   - `kobe export [--csv]`     Print the task list (json/csv/table; daemon-free).
+ *   - `kobe run-turn`           Run one headless engine turn (Codex first).
  *   - `kobe api <verb>`         Scriptable RPC surface for agents (fan-out).
  *   - `kobe daemon <verb>`      Manage the long-lived daemon (start / stop / status / restart).
  *   - `kobe theme <verb>`       Manage user themes.
@@ -455,6 +456,11 @@ async function main(): Promise<void> {
   if (subcommand === "repo") {
     const { runRepoSubcommand } = await import("./repo-cmd.ts")
     await runRepoSubcommand(rest)
+    return
+  }
+  if (subcommand === "run-turn") {
+    const { runRunTurnSubcommand } = await import("./run-turn-cmd.ts")
+    await runRunTurnSubcommand(rest)
     return
   }
   if (subcommand === "api") {

--- a/packages/kobe/src/cli/run-turn-cmd.ts
+++ b/packages/kobe/src/cli/run-turn-cmd.ts
@@ -1,0 +1,195 @@
+import { resolve } from "node:path"
+import {
+  CodexRunTurnError,
+  type RunTurnEvent,
+  type RunTurnPurpose,
+  normalizeCodexExecApproval,
+  normalizeCodexExecSandbox,
+} from "../engine/run-turn/codex.ts"
+import { runTurn } from "../engine/run-turn/index.ts"
+import type { VendorId } from "../types/vendor.ts"
+
+const RUN_TURN_USAGE = [
+  "Usage: kobe run-turn [options] [prompt]",
+  "",
+  "Run one headless engine turn. Codex is wired first via `codex exec --json`.",
+  "",
+  "Options:",
+  "  --vendor <id>      Engine vendor (default: codex; only codex is wired today)",
+  "  --worktree <path>  Worktree/repo cwd for the turn (default: current directory)",
+  "  --prompt <text>    Prompt text; otherwise positional args or stdin are used",
+  "  --small           Use the vendor's small-model runTurn setting",
+  "  --model <name>    Override the configured model for this call",
+  "  --effort <level>  Codex reasoning effort (none|low|medium|high|xhigh)",
+  "  --sandbox <mode>  Codex sandbox (read-only|workspace-write|danger-full-access)",
+  "  --approval <mode> Codex approval policy (untrusted|on-failure|on-request|never)",
+  "  --ephemeral       Do not persist this Codex exec session",
+  "  --json            Print normalized runTurn events as JSONL",
+  "  -h, --help        Print this help",
+  "",
+].join("\n")
+
+interface ParsedRunTurnArgs {
+  readonly help: boolean
+  readonly vendor: VendorId
+  readonly worktree: string
+  readonly prompt?: string
+  readonly purpose: RunTurnPurpose
+  readonly model?: string
+  readonly effort?: string
+  readonly sandbox?: string
+  readonly approval?: string
+  readonly ephemeral: boolean
+  readonly json: boolean
+}
+
+function usageError(message: string): never {
+  process.stderr.write(`kobe run-turn: ${message}\n\n${RUN_TURN_USAGE}`)
+  process.exit(2)
+}
+
+function takeValue(args: readonly string[], index: number, flag: string): string {
+  const value = args[index + 1]
+  if (value === undefined || value.startsWith("--")) usageError(`${flag} requires a value`)
+  return value
+}
+
+export function parseRunTurnArgs(args: readonly string[]): ParsedRunTurnArgs {
+  let vendor: VendorId = "codex"
+  let worktree = process.cwd()
+  let prompt: string | undefined
+  let purpose: RunTurnPurpose = "default"
+  let model: string | undefined
+  let effort: string | undefined
+  let sandbox: string | undefined
+  let approval: string | undefined
+  let ephemeral = false
+  let json = false
+  const positional: string[] = []
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === "--help" || arg === "-h" || arg === "help")
+      return { help: true, vendor, worktree, purpose, ephemeral, json }
+    if (arg === "--vendor") {
+      vendor = takeValue(args, i, arg) as VendorId
+      i++
+      continue
+    }
+    if (arg === "--worktree" || arg === "--cwd") {
+      worktree = resolve(takeValue(args, i, arg))
+      i++
+      continue
+    }
+    if (arg === "--prompt") {
+      prompt = takeValue(args, i, arg)
+      i++
+      continue
+    }
+    if (arg === "--small") {
+      purpose = "small"
+      continue
+    }
+    if (arg === "--model") {
+      model = takeValue(args, i, arg)
+      i++
+      continue
+    }
+    if (arg === "--effort") {
+      effort = takeValue(args, i, arg)
+      i++
+      continue
+    }
+    if (arg === "--sandbox") {
+      sandbox = takeValue(args, i, arg)
+      i++
+      continue
+    }
+    if (arg === "--approval") {
+      approval = takeValue(args, i, arg)
+      i++
+      continue
+    }
+    if (arg === "--ephemeral") {
+      ephemeral = true
+      continue
+    }
+    if (arg === "--json") {
+      json = true
+      continue
+    }
+    if (arg === "--") {
+      positional.push(...args.slice(i + 1))
+      break
+    }
+    if (arg.startsWith("-")) usageError(`unknown flag "${arg}"`)
+    positional.push(arg)
+  }
+
+  return {
+    help: false,
+    vendor,
+    worktree,
+    prompt: prompt ?? (positional.length > 0 ? positional.join(" ") : undefined),
+    purpose,
+    model,
+    effort,
+    sandbox,
+    approval,
+    ephemeral,
+    json,
+  }
+}
+
+async function readStdinIfAvailable(): Promise<string> {
+  if (process.stdin.isTTY) return ""
+  process.stdin.setEncoding("utf8")
+  let text = ""
+  for await (const chunk of process.stdin) text += chunk
+  return text
+}
+
+function writeEvent(event: RunTurnEvent, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(event)}\n`)
+    return
+  }
+  if (event.type === "assistant_text") process.stdout.write(event.text)
+  else if (event.type === "stderr") process.stderr.write(event.text)
+}
+
+export async function runRunTurnSubcommand(args: readonly string[]): Promise<void> {
+  const parsed = parseRunTurnArgs(args)
+  if (parsed.help) {
+    process.stdout.write(RUN_TURN_USAGE)
+    return
+  }
+  const prompt = (parsed.prompt ?? (await readStdinIfAvailable())).trim()
+  if (!prompt) usageError("prompt is required")
+
+  const sandbox = normalizeCodexExecSandbox(parsed.sandbox)
+  if (parsed.sandbox && !sandbox) usageError(`invalid sandbox "${parsed.sandbox}"`)
+  const approval = normalizeCodexExecApproval(parsed.approval)
+  if (parsed.approval && !approval) usageError(`invalid approval "${parsed.approval}"`)
+
+  try {
+    await runTurn({
+      vendor: parsed.vendor,
+      worktree: parsed.worktree,
+      prompt,
+      purpose: parsed.purpose,
+      model: parsed.model,
+      effort: parsed.effort,
+      sandbox,
+      approval,
+      ephemeral: parsed.ephemeral || parsed.purpose === "small",
+      onEvent: (event) => writeEvent(event, parsed.json),
+    })
+  } catch (err) {
+    if (err instanceof CodexRunTurnError) {
+      process.exit(err.result.exitCode ?? 1)
+    }
+    process.stderr.write(`kobe run-turn: ${err instanceof Error ? err.message : String(err)}\n`)
+    process.exit(1)
+  }
+}

--- a/packages/kobe/src/cli/subcommands.ts
+++ b/packages/kobe/src/cli/subcommands.ts
@@ -21,6 +21,7 @@ export const TOP_LEVEL_SUBCOMMANDS = [
   "adopt",
   "export",
   "repo",
+  "run-turn",
   "api",
   "daemon",
   "theme",

--- a/packages/kobe/src/cli/usage.ts
+++ b/packages/kobe/src/cli/usage.ts
@@ -25,6 +25,7 @@ export function topLevelUsage(): string {
     "  adopt [glob]            Import existing git worktrees as tasks",
     "  export [--csv|--json]   Print the task list (json/csv/table; daemon-free)",
     "  repo <verb>             Per-repo init script + first prompt (show|set|unset)",
+    "  run-turn [options]      Run one headless engine turn (Codex first)",
     "  api <verb>              Scriptable RPC surface for agents (see `kobe api --help`)",
     "  daemon <verb>           Manage the daemon (start|stop|status|restart)",
     "  theme <verb>            Manage user themes (list|add|remove)",

--- a/packages/kobe/src/engine/run-turn-settings.ts
+++ b/packages/kobe/src/engine/run-turn-settings.ts
@@ -1,0 +1,58 @@
+import { getPersistedString } from "../state/repos.ts"
+import type { VendorId } from "../types/vendor.ts"
+import { engineEntry } from "./registry.ts"
+
+export interface RunTurnEngineSettings {
+  readonly model: string
+  readonly smallModel: string
+  readonly effort: string
+  readonly effortLevels: readonly string[]
+}
+
+/** state.json key for a vendor's default headless runTurn model. */
+export function runTurnModelKey(vendor: VendorId): string {
+  return `runTurnModel.${vendor}`
+}
+
+/** state.json key for the vendor's small-model probe/router calls. */
+export function runTurnSmallModelKey(vendor: VendorId): string {
+  return `runTurnSmallModel.${vendor}`
+}
+
+/** state.json key for a vendor's runTurn reasoning/effort override. */
+export function runTurnEffortKey(vendor: VendorId): string {
+  return `runTurnEffort.${vendor}`
+}
+
+export function normalizeRunTurnEffort(vendor: VendorId, value: unknown): string {
+  if (typeof value !== "string") return ""
+  const trimmed = value.trim()
+  if (!trimmed) return ""
+  const levels = engineEntry(vendor).effortLevels ?? []
+  return levels.includes(trimmed) ? trimmed : ""
+}
+
+function stateString(state: Record<string, unknown>, key: string): string {
+  const value = state[key]
+  return typeof value === "string" ? value.trim() : ""
+}
+
+export function runTurnSettingsFromState(state: Record<string, unknown>, vendor: VendorId): RunTurnEngineSettings {
+  const effortLevels = engineEntry(vendor).effortLevels ?? []
+  return {
+    model: stateString(state, runTurnModelKey(vendor)),
+    smallModel: stateString(state, runTurnSmallModelKey(vendor)),
+    effort: normalizeRunTurnEffort(vendor, state[runTurnEffortKey(vendor)]),
+    effortLevels,
+  }
+}
+
+export function readRunTurnSettings(vendor: VendorId): RunTurnEngineSettings {
+  const effortLevels = engineEntry(vendor).effortLevels ?? []
+  return {
+    model: getPersistedString(runTurnModelKey(vendor))?.trim() ?? "",
+    smallModel: getPersistedString(runTurnSmallModelKey(vendor))?.trim() ?? "",
+    effort: normalizeRunTurnEffort(vendor, getPersistedString(runTurnEffortKey(vendor))),
+    effortLevels,
+  }
+}

--- a/packages/kobe/src/engine/run-turn/codex.ts
+++ b/packages/kobe/src/engine/run-turn/codex.ts
@@ -1,0 +1,285 @@
+import { spawn as nodeSpawn } from "node:child_process"
+import { normalizeCodexContent } from "../codex-local/normalize.ts"
+import { type RunTurnEngineSettings, readRunTurnSettings } from "../run-turn-settings.ts"
+
+export const CODEX_EXEC_SANDBOXES = ["read-only", "workspace-write", "danger-full-access"] as const
+export type CodexExecSandbox = (typeof CODEX_EXEC_SANDBOXES)[number]
+
+export const CODEX_EXEC_APPROVALS = ["untrusted", "on-failure", "on-request", "never"] as const
+export type CodexExecApproval = (typeof CODEX_EXEC_APPROVALS)[number]
+
+export type RunTurnPurpose = "default" | "small"
+
+export type RunTurnEvent =
+  | { readonly type: "assistant_text"; readonly text: string }
+  | { readonly type: "reasoning"; readonly text: string }
+  | { readonly type: "tool"; readonly name: string; readonly input?: unknown; readonly output?: unknown }
+  | { readonly type: "stderr"; readonly text: string }
+  | { readonly type: "turn_completed"; readonly usage?: unknown }
+  | { readonly type: "exit"; readonly code: number | null }
+
+export interface BuildCodexExecArgsOptions {
+  readonly prompt: string
+  readonly worktree: string
+  readonly model?: string
+  readonly effort?: string
+  readonly sandbox?: CodexExecSandbox
+  readonly approval?: CodexExecApproval
+  readonly ephemeral?: boolean
+}
+
+export interface ResolveRunTurnModelOptions {
+  readonly explicitModel?: string
+  readonly purpose: RunTurnPurpose
+  readonly settings: Pick<RunTurnEngineSettings, "model" | "smallModel">
+}
+
+export interface CodexRunTurnOptions extends BuildCodexExecArgsOptions {
+  readonly purpose?: RunTurnPurpose
+  readonly onEvent?: (event: RunTurnEvent) => void
+  readonly signal?: AbortSignal
+}
+
+export interface CodexRunTurnResult {
+  readonly vendor: "codex"
+  readonly argv: readonly string[]
+  readonly text: string
+  readonly events: readonly RunTurnEvent[]
+  readonly exitCode: number | null
+  readonly stderr: string
+}
+
+export class CodexRunTurnError extends Error {
+  constructor(
+    message: string,
+    readonly result: CodexRunTurnResult,
+  ) {
+    super(message)
+  }
+}
+
+export function normalizeCodexExecSandbox(value: string | undefined): CodexExecSandbox | undefined {
+  return CODEX_EXEC_SANDBOXES.includes(value as CodexExecSandbox) ? (value as CodexExecSandbox) : undefined
+}
+
+export function normalizeCodexExecApproval(value: string | undefined): CodexExecApproval | undefined {
+  return CODEX_EXEC_APPROVALS.includes(value as CodexExecApproval) ? (value as CodexExecApproval) : undefined
+}
+
+export function resolveRunTurnModel(options: ResolveRunTurnModelOptions): string | undefined {
+  const explicit = options.explicitModel?.trim()
+  if (explicit) return explicit
+  const configured = options.purpose === "small" ? options.settings.smallModel : options.settings.model
+  const trimmed = configured.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+export function buildCodexExecArgs(options: BuildCodexExecArgsOptions): string[] {
+  const args = ["exec", "--json", "-C", options.worktree]
+  const model = options.model?.trim()
+  if (model) args.push("-m", model)
+  const effort = normalizeCodexEffort(options.effort)
+  if (effort) args.push("-c", `model_reasoning_effort=${effort}`)
+  args.push("-s", options.sandbox ?? "workspace-write")
+  args.push("-a", options.approval ?? "never")
+  if (options.ephemeral) args.push("--ephemeral")
+  args.push(options.prompt)
+  return args
+}
+
+function normalizeCodexEffort(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) return undefined
+  return ["none", "low", "medium", "high", "xhigh"].includes(trimmed) ? trimmed : undefined
+}
+
+export function parseCodexExecJsonLine(line: string): RunTurnEvent[] {
+  const trimmed = line.trim()
+  if (!trimmed) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed) as unknown
+  } catch {
+    return []
+  }
+  if (!isObject(parsed)) return []
+
+  if (parsed.type === "response_item") {
+    const payload = isObject(parsed.payload) ? (parsed.payload as Record<string, unknown>) : undefined
+    return payload ? eventsFromCodexResponseItem(payload) : []
+  }
+
+  if (parsed.type === "response.output_text.delta" || parsed.type === "output_text_delta") {
+    const text = stringOr(parsed.delta, "")
+    return text ? [{ type: "assistant_text", text }] : []
+  }
+
+  if (parsed.type === "response.reasoning_summary.delta" || parsed.type === "reasoning_delta") {
+    const text = stringOr(parsed.delta, "")
+    return text ? [{ type: "reasoning", text }] : []
+  }
+
+  if (parsed.type === "turn.completed") {
+    return [{ type: "turn_completed", usage: parsed.usage }]
+  }
+
+  if (parsed.type === "error") {
+    const message = stringOr(parsed.message, stringOr(parsed.error, "codex error"))
+    return message ? [{ type: "stderr", text: `${message}\n` }] : []
+  }
+
+  return []
+}
+
+function eventsFromCodexResponseItem(payload: Record<string, unknown>): RunTurnEvent[] {
+  if (payload.type === "message") {
+    if (payload.role !== "assistant") return []
+    return normalizeCodexContent(payload.content)
+      .filter((block): block is Extract<typeof block, { type: "text" }> => block.type === "text")
+      .map((block) => ({ type: "assistant_text", text: block.text }))
+  }
+
+  if (payload.type === "reasoning") {
+    const text = reasoningTextFromItem(payload)
+    return text ? [{ type: "reasoning", text }] : []
+  }
+
+  if (payload.type === "function_call" || payload.type === "custom_tool_call" || payload.type === "tool_search_call") {
+    return [
+      {
+        type: "tool",
+        name: stringOr(payload.name, stringOr(payload.type, "tool")),
+        input: parseMaybeJson(payload.arguments ?? payload.input),
+      },
+    ]
+  }
+
+  if (
+    payload.type === "function_call_output" ||
+    payload.type === "custom_tool_call_output" ||
+    payload.type === "tool_search_output"
+  ) {
+    return [
+      {
+        type: "tool",
+        name: stringOr(payload.type, "tool_output"),
+        output: parseMaybeJson(payload.output),
+      },
+    ]
+  }
+
+  return []
+}
+
+function reasoningTextFromItem(item: Record<string, unknown>): string {
+  const content = textFromReasoningValue(item.content)
+  if (content) return content
+  const text = stringOr(item.text, "")
+  if (text) return text
+  return textFromReasoningValue(item.summary)
+}
+
+function textFromReasoningValue(value: unknown): string {
+  if (typeof value === "string") return value
+  if (!Array.isArray(value)) return ""
+  const parts: string[] = []
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      parts.push(entry)
+      continue
+    }
+    if (!isObject(entry)) continue
+    const text = stringOr(entry.text, "")
+    if (text) parts.push(text)
+  }
+  return parts.join("")
+}
+
+export async function runCodexHeadlessTurn(options: CodexRunTurnOptions): Promise<CodexRunTurnResult> {
+  const settings = readRunTurnSettings("codex")
+  const purpose = options.purpose ?? "default"
+  const model = resolveRunTurnModel({ explicitModel: options.model, purpose, settings })
+  const effort = options.effort?.trim() || settings.effort
+  const argv = buildCodexExecArgs({
+    ...options,
+    model,
+    effort,
+    ephemeral: options.ephemeral ?? purpose === "small",
+  })
+  const events: RunTurnEvent[] = []
+  const textParts: string[] = []
+  const stderrParts: string[] = []
+
+  const emit = (event: RunTurnEvent) => {
+    events.push(event)
+    if (event.type === "assistant_text") textParts.push(event.text)
+    if (event.type === "stderr") stderrParts.push(event.text)
+    options.onEvent?.(event)
+  }
+
+  const child = nodeSpawn("codex", argv, {
+    cwd: options.worktree,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    signal: options.signal,
+  })
+
+  let stdoutBuffer = ""
+  let stderr = ""
+  child.stdout.setEncoding("utf8")
+  child.stdout.on("data", (chunk: string) => {
+    stdoutBuffer += chunk
+    let newline = stdoutBuffer.indexOf("\n")
+    while (newline >= 0) {
+      const line = stdoutBuffer.slice(0, newline)
+      stdoutBuffer = stdoutBuffer.slice(newline + 1)
+      for (const event of parseCodexExecJsonLine(line)) emit(event)
+      newline = stdoutBuffer.indexOf("\n")
+    }
+  })
+  child.stderr.setEncoding("utf8")
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk
+    emit({ type: "stderr", text: chunk })
+  })
+
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.on("error", reject)
+    child.on("close", (code) => resolve(code))
+  })
+
+  if (stdoutBuffer.trim()) {
+    for (const event of parseCodexExecJsonLine(stdoutBuffer)) emit(event)
+  }
+  emit({ type: "exit", code: exitCode })
+
+  const result: CodexRunTurnResult = {
+    vendor: "codex",
+    argv,
+    text: textParts.join(""),
+    events,
+    exitCode,
+    stderr: stderr || stderrParts.join(""),
+  }
+  if (exitCode !== 0) {
+    throw new CodexRunTurnError(`codex exec exited with code ${exitCode ?? "null"}`, result)
+  }
+  return result
+}
+
+function stringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== "string") return value
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return value
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/kobe/src/engine/run-turn/index.ts
+++ b/packages/kobe/src/engine/run-turn/index.ts
@@ -1,0 +1,34 @@
+import type { VendorId } from "../../types/vendor.ts"
+import {
+  type CodexRunTurnOptions,
+  type CodexRunTurnResult,
+  type RunTurnPurpose,
+  runCodexHeadlessTurn,
+} from "./codex.ts"
+
+export interface RunTurnOptions extends Omit<CodexRunTurnOptions, "purpose"> {
+  readonly vendor?: VendorId
+  readonly purpose?: RunTurnPurpose
+}
+
+export type RunTurnResult = CodexRunTurnResult
+
+export class UnsupportedRunTurnVendorError extends Error {
+  constructor(readonly vendor: VendorId) {
+    super(`headless runTurn is not wired for engine "${vendor}" yet`)
+  }
+}
+
+export function supportsHeadlessRunTurn(vendor: VendorId | undefined): boolean {
+  return (vendor ?? "codex") === "codex"
+}
+
+export async function runTurn(options: RunTurnOptions): Promise<RunTurnResult> {
+  const vendor = options.vendor ?? "codex"
+  if (vendor !== "codex") throw new UnsupportedRunTurnVendorError(vendor)
+  return runCodexHeadlessTurn(options)
+}
+
+export async function runSmallModelTurn(options: Omit<RunTurnOptions, "purpose">): Promise<RunTurnResult> {
+  return runTurn({ ...options, purpose: "small" })
+}

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -24,6 +24,12 @@ import {
   detectCopilotAccount,
 } from "../../engine/account-detect"
 import { VENDOR_LABEL, defaultEngineCommand, engineCommandKey, engineNameKey } from "../../engine/interactive-command"
+import {
+  normalizeRunTurnEffort,
+  runTurnEffortKey,
+  runTurnModelKey,
+  runTurnSmallModelKey,
+} from "../../engine/run-turn-settings"
 import { submitFeedback } from "../../lib/feedback"
 import { ARCHIVED_HISTORY_PREVIEW_KEY } from "../../state/archived-history"
 import { AUTO_STATUS_KEY } from "../../state/auto-status"
@@ -312,7 +318,14 @@ export function SettingsDialog(props: SettingsDialogProps) {
   }
   function engineIsDefault(vendor: VendorId): boolean {
     // Custom engines have no built-in default, so they never read as "(default)".
-    return isBuiltinVendor(vendor) && engineOverride(vendor).length === 0 && !engineNameIsCustom(vendor)
+    return (
+      isBuiltinVendor(vendor) &&
+      engineOverride(vendor).length === 0 &&
+      !engineNameIsCustom(vendor) &&
+      runTurnModel(vendor).length === 0 &&
+      runTurnSmallModel(vendor).length === 0 &&
+      runTurnEffort(vendor).length === 0
+    )
   }
   // Custom display name override (engineName.<vendor>), empty = VENDOR_LABEL / id.
   function engineNameOverride(vendor: VendorId): string {
@@ -351,6 +364,60 @@ export function SettingsDialog(props: SettingsDialogProps) {
     if (next === undefined) return
     props.kv.set(engineCommandKey(vendor), next.trim())
   }
+  function runTurnModel(vendor: VendorId): string {
+    const v = props.kv.get(runTurnModelKey(vendor), "")
+    return typeof v === "string" ? v.trim() : ""
+  }
+  function runTurnModelText(vendor: VendorId): string {
+    return runTurnModel(vendor) || "default"
+  }
+  async function editRunTurnModel(vendor: VendorId): Promise<void> {
+    const next = await RenameTaskDialog.show(dialog, runTurnModel(vendor), {
+      dialogTitle: `${engineName(vendor)} runTurn model (blank = CLI default)`,
+      fieldLabel: "model",
+      submitLabel: "save",
+      allowEmpty: true,
+    })
+    if (next === undefined) return
+    props.kv.set(runTurnModelKey(vendor), next.trim())
+  }
+  function runTurnSmallModel(vendor: VendorId): string {
+    const v = props.kv.get(runTurnSmallModelKey(vendor), "")
+    return typeof v === "string" ? v.trim() : ""
+  }
+  function runTurnSmallModelText(vendor: VendorId): string {
+    return runTurnSmallModel(vendor) || "unset"
+  }
+  async function editRunTurnSmallModel(vendor: VendorId): Promise<void> {
+    const next = await RenameTaskDialog.show(dialog, runTurnSmallModel(vendor), {
+      dialogTitle: `${engineName(vendor)} small-model runTurn (blank = unset)`,
+      fieldLabel: "model",
+      submitLabel: "save",
+      allowEmpty: true,
+    })
+    if (next === undefined) return
+    props.kv.set(runTurnSmallModelKey(vendor), next.trim())
+  }
+  function runTurnEffort(vendor: VendorId): string {
+    return normalizeRunTurnEffort(vendor, props.kv.get(runTurnEffortKey(vendor), ""))
+  }
+  function runTurnEffortText(vendor: VendorId): string {
+    if (vendor !== "codex") return "n/a"
+    return runTurnEffort(vendor) || "default"
+  }
+  async function editRunTurnEffort(vendor: VendorId): Promise<void> {
+    const levels = vendor === "codex" ? ["none", "low", "medium", "high", "xhigh"] : []
+    if (levels.length === 0) return
+    const next = await RenameTaskDialog.show(dialog, runTurnEffort(vendor), {
+      dialogTitle: `${engineName(vendor)} runTurn effort (blank = default; ${levels.join(" / ")})`,
+      fieldLabel: "effort",
+      submitLabel: "save",
+      allowEmpty: true,
+    })
+    if (next === undefined) return
+    const normalized = normalizeRunTurnEffort(vendor, next)
+    props.kv.set(runTurnEffortKey(vendor), normalized)
+  }
   async function renameEngine(vendor: VendorId): Promise<void> {
     const next = await RenameTaskDialog.show(dialog, engineName(vendor), {
       dialogTitle: `${engineName(vendor)} display name (blank = default)`,
@@ -368,6 +435,9 @@ export function SettingsDialog(props: SettingsDialogProps) {
   function resetEngine(vendor: VendorId): void {
     props.kv.set(engineCommandKey(vendor), "")
     props.kv.set(engineNameKey(vendor), "")
+    props.kv.set(runTurnModelKey(vendor), "")
+    props.kv.set(runTurnSmallModelKey(vendor), "")
+    props.kv.set(runTurnEffortKey(vendor), "")
     if (!isBuiltinVendor(vendor)) {
       props.kv.set(
         "customEngineIds",
@@ -690,6 +760,27 @@ export function SettingsDialog(props: SettingsDialogProps) {
         },
       },
       {
+        key: "m",
+        cmd: () => {
+          const v = currentEngineRow()
+          if (v) void editRunTurnModel(v)
+        },
+      },
+      {
+        key: "s",
+        cmd: () => {
+          const v = currentEngineRow()
+          if (v) void editRunTurnSmallModel(v)
+        },
+      },
+      {
+        key: "f",
+        cmd: () => {
+          const v = currentEngineRow()
+          if (v) void editRunTurnEffort(v)
+        },
+      },
+      {
         // Engines section: `d` sets the focused engine as the DEFAULT for new
         // tasks (the ● marker) — the same `lastSelectedVendor` Ctrl+Shift+T sets.
         key: "d",
@@ -774,6 +865,9 @@ export function SettingsDialog(props: SettingsDialogProps) {
               isCustom={(v) => !isBuiltinVendor(v)}
               displayName={engineName}
               commandText={engineCommandText}
+              runTurnModelText={runTurnModelText}
+              runTurnSmallModelText={runTurnSmallModelText}
+              runTurnEffortText={runTurnEffortText}
               isDefault={engineIsDefault}
               isDefaultEngine={isDefaultEngine}
               editEngine={(v) => void editEngine(v)}

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -527,6 +527,12 @@ export function EngineSettingsSection(
     displayName: (vendor: VendorId) => string
     /** Current launch command shown for a vendor (override or default). */
     commandText: (vendor: VendorId) => string
+    /** Current headless runTurn model (or "default"). */
+    runTurnModelText: (vendor: VendorId) => string
+    /** Current small-model runTurn model (or "unset"). */
+    runTurnSmallModelText: (vendor: VendorId) => string
+    /** Current runTurn effort (or "default"/"n/a"). */
+    runTurnEffortText: (vendor: VendorId) => string
     /** Whether the engine is fully at its built-in default (dims it). */
     isDefault: (vendor: VendorId) => boolean
     /** Open the editor for a vendor's launch command (`enter`). */
@@ -560,8 +566,8 @@ export function EngineSettingsSection(
             const isCursor = () => props.level() === "body" && props.bodyRow() === i()
             return (
               <box
-                flexDirection="row"
-                gap={1}
+                flexDirection="column"
+                gap={0}
                 paddingLeft={1}
                 paddingRight={1}
                 backgroundColor={isCursor() ? theme.primary : undefined}
@@ -571,35 +577,46 @@ export function EngineSettingsSection(
                   props.editEngine(vendor)
                 }}
               >
-                {/* ● marks the DEFAULT engine for new tasks (radio-style, like
-                    the theme list); a space holds the column on the others. */}
-                <text
-                  fg={isCursor() ? theme.selectedListItemText : theme.accent}
-                  attributes={TextAttributes.BOLD}
-                  wrapMode="none"
-                >
-                  {props.isDefaultEngine(vendor) ? "●" : " "}
-                </text>
-                <text
-                  fg={isCursor() ? theme.selectedListItemText : theme.text}
-                  attributes={TextAttributes.BOLD}
-                  wrapMode="none"
-                >
-                  {props.displayName(vendor)}
-                </text>
-                <text
-                  fg={
-                    isCursor() ? theme.selectedListItemText : props.isDefault(vendor) ? theme.textMuted : theme.accent
-                  }
-                  wrapMode="none"
-                >
-                  {props.commandText(vendor)}
-                  {props.isDefault(vendor)
-                    ? t("settings.engines.defaultTag")
-                    : props.isCustom(vendor)
-                      ? t("settings.engines.customTag")
-                      : ""}
-                </text>
+                <box flexDirection="row" gap={1}>
+                  {/* ● marks the DEFAULT engine for new tasks (radio-style, like
+                      the theme list); a space holds the column on the others. */}
+                  <text
+                    fg={isCursor() ? theme.selectedListItemText : theme.accent}
+                    attributes={TextAttributes.BOLD}
+                    wrapMode="none"
+                  >
+                    {props.isDefaultEngine(vendor) ? "●" : " "}
+                  </text>
+                  <text
+                    fg={isCursor() ? theme.selectedListItemText : theme.text}
+                    attributes={TextAttributes.BOLD}
+                    wrapMode="none"
+                  >
+                    {props.displayName(vendor)}
+                  </text>
+                  <text
+                    fg={
+                      isCursor() ? theme.selectedListItemText : props.isDefault(vendor) ? theme.textMuted : theme.accent
+                    }
+                    wrapMode="none"
+                  >
+                    {props.commandText(vendor)}
+                    {props.isDefault(vendor)
+                      ? t("settings.engines.defaultTag")
+                      : props.isCustom(vendor)
+                        ? t("settings.engines.customTag")
+                        : ""}
+                  </text>
+                </box>
+                <box flexDirection="row" gap={1} paddingLeft={2}>
+                  <text fg={isCursor() ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                    {t("settings.engines.runTurnLine", {
+                      model: props.runTurnModelText(vendor),
+                      small: props.runTurnSmallModelText(vendor),
+                      effort: props.runTurnEffortText(vendor),
+                    })}
+                  </text>
+                </box>
               </box>
             )
           }}

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -68,9 +68,10 @@ export const en = {
   },
   engines: {
     title: "Launch command",
-    hint: "The command each engine's task pane runs. Override a built-in when your binary isn't on PATH as `claude` / `codex` (e.g. it's `cl`) or to pass default flags, or add your own engine. ● = default engine for new tasks (also set by Ctrl+Shift+T). enter edit command · r rename · x reset/remove · d set default.",
+    hint: "The command each engine's task pane runs. Override a built-in when your binary isn't on PATH as `claude` / `codex` (e.g. it's `cl`) or to pass default flags, or add your own engine. ● = default engine for new tasks (also set by Ctrl+Shift+T). enter edit command · r rename · x reset/remove · d set default · m runTurn model · s small model · f effort.",
     defaultTag: "  (default)",
     customTag: "  (custom)",
+    runTurnLine: "runTurn: {model} · small: {small} · effort: {effort}",
     addEngine: "+ Add engine",
   },
   accounts: {
@@ -197,9 +198,10 @@ export const zh: typeof en = {
   },
   engines: {
     title: "启动命令",
-    hint: "每个引擎的任务面板运行的命令。当二进制文件不在 PATH 上的 `claude` / `codex` 名下（比如叫 `cl`）、要传默认参数，或要添加自己的引擎时，可覆盖内置项。● = 新任务的默认引擎（也可用 Ctrl+Shift+T 设置）。enter 编辑命令 · r 重命名 · x 重置/移除 · d 设为默认。",
+    hint: "每个引擎的任务面板运行的命令。当二进制文件不在 PATH 上的 `claude` / `codex` 名下（比如叫 `cl`）、要传默认参数，或要添加自己的引擎时，可覆盖内置项。● = 新任务的默认引擎（也可用 Ctrl+Shift+T 设置）。enter 编辑命令 · r 重命名 · x 重置/移除 · d 设为默认 · m 改 runTurn model · s 改小模型 · f 改 effort。",
     defaultTag: "  (默认)",
     customTag: "  (自定义)",
+    runTurnLine: "runTurn: {model} · 小模型: {small} · effort: {effort}",
     addEngine: "+ 添加引擎",
   },
   accounts: {

--- a/packages/kobe/test/engine/run-turn.test.ts
+++ b/packages/kobe/test/engine/run-turn.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+import {
+  runTurnEffortKey,
+  runTurnModelKey,
+  runTurnSettingsFromState,
+  runTurnSmallModelKey,
+} from "../../src/engine/run-turn-settings.ts"
+import { buildCodexExecArgs, parseCodexExecJsonLine, resolveRunTurnModel } from "../../src/engine/run-turn/codex.ts"
+
+describe("buildCodexExecArgs", () => {
+  it("builds a noninteractive JSONL codex exec command for a worktree", () => {
+    expect(
+      buildCodexExecArgs({
+        prompt: "summarize this repo",
+        worktree: "/repo/kobe",
+        model: "gpt-test",
+        effort: "low",
+      }),
+    ).toEqual([
+      "exec",
+      "--json",
+      "-C",
+      "/repo/kobe",
+      "-m",
+      "gpt-test",
+      "-c",
+      "model_reasoning_effort=low",
+      "-s",
+      "workspace-write",
+      "-a",
+      "never",
+      "summarize this repo",
+    ])
+  })
+
+  it("drops unsupported effort levels instead of passing a bad codex flag", () => {
+    expect(
+      buildCodexExecArgs({
+        prompt: "hi",
+        worktree: "/repo/kobe",
+        effort: "bogus",
+      }),
+    ).toEqual(["exec", "--json", "-C", "/repo/kobe", "-s", "workspace-write", "-a", "never", "hi"])
+  })
+
+  it("can build an ephemeral small-model probe", () => {
+    expect(
+      buildCodexExecArgs({
+        prompt: "pick the right model",
+        worktree: "/repo/kobe",
+        model: "small-test",
+        ephemeral: true,
+        sandbox: "read-only",
+      }),
+    ).toEqual([
+      "exec",
+      "--json",
+      "-C",
+      "/repo/kobe",
+      "-m",
+      "small-test",
+      "-s",
+      "read-only",
+      "-a",
+      "never",
+      "--ephemeral",
+      "pick the right model",
+    ])
+  })
+})
+
+describe("parseCodexExecJsonLine", () => {
+  it("extracts assistant text from codex response_item messages", () => {
+    expect(
+      parseCodexExecJsonLine(
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "done" }],
+          },
+        }),
+      ),
+    ).toEqual([{ type: "assistant_text", text: "done" }])
+  })
+
+  it("extracts reasoning text and response output deltas", () => {
+    expect(
+      parseCodexExecJsonLine(
+        JSON.stringify({
+          type: "response_item",
+          payload: {
+            type: "reasoning",
+            summary: [{ text: "checking files" }],
+          },
+        }),
+      ),
+    ).toEqual([{ type: "reasoning", text: "checking files" }])
+
+    expect(parseCodexExecJsonLine(JSON.stringify({ type: "response.output_text.delta", delta: "hi" }))).toEqual([
+      { type: "assistant_text", text: "hi" },
+    ])
+  })
+
+  it("ignores malformed or irrelevant JSONL", () => {
+    expect(parseCodexExecJsonLine("not json")).toEqual([])
+    expect(parseCodexExecJsonLine(JSON.stringify({ type: "turn.completed" }))).toEqual([
+      { type: "turn_completed", usage: undefined },
+    ])
+  })
+})
+
+describe("runTurn settings", () => {
+  it("namespaces model, small-model, and effort per vendor", () => {
+    expect(runTurnModelKey("codex")).toBe("runTurnModel.codex")
+    expect(runTurnSmallModelKey("codex")).toBe("runTurnSmallModel.codex")
+    expect(runTurnEffortKey("codex")).toBe("runTurnEffort.codex")
+  })
+
+  it("reads valid configured runTurn settings from a state snapshot", () => {
+    const state = {
+      [runTurnModelKey("codex")]: "gpt-large",
+      [runTurnSmallModelKey("codex")]: "gpt-small",
+      [runTurnEffortKey("codex")]: "medium",
+    }
+    expect(runTurnSettingsFromState(state, "codex")).toEqual({
+      model: "gpt-large",
+      smallModel: "gpt-small",
+      effort: "medium",
+      effortLevels: ["none", "low", "medium", "high", "xhigh"],
+    })
+  })
+
+  it("keeps the small-model selection separate from the default runTurn model", () => {
+    const state = {
+      [runTurnModelKey("codex")]: "gpt-large",
+      [runTurnSmallModelKey("codex")]: "gpt-small",
+    }
+    const settings = runTurnSettingsFromState(state, "codex")
+
+    expect(resolveRunTurnModel({ explicitModel: undefined, purpose: "default", settings })).toBe("gpt-large")
+    expect(resolveRunTurnModel({ explicitModel: undefined, purpose: "small", settings })).toBe("gpt-small")
+    expect(resolveRunTurnModel({ explicitModel: "override", purpose: "small", settings })).toBe("override")
+  })
+})


### PR DESCRIPTION
## Summary
- add a provider-neutral runTurn entry point backed by Codex `exec --json`
- add `kobe run-turn` for direct Codex headless/small-model testing
- expose runTurn model, small-model, and effort settings in TUI/Web Settings

## Verification
- bun --filter @sma1lboy/kobe test:fast
- bun run typecheck
- bun run lint
- bun --filter kobe-web test -- test/bridge-routes.test.ts
- cd packages/kobe-web && bunx biome check src/components/SettingsPage.tsx src/lib/settings.ts test/bridge-routes.test.ts
- bun --filter @sma1lboy/kobe test:socket
- bun --filter @sma1lboy/kobe check-i18n
- cd packages/kobe && env KOBE_HOME_DIR=$PWD/.dev-sandbox/home KOBE_TMUX_SOCKET=kobe-sandbox bun ./src/cli/index.ts run-turn --help
- cd packages/kobe && env KOBE_HOME_DIR=$PWD/.dev-sandbox/home KOBE_TMUX_SOCKET=kobe-sandbox bun ./src/cli/index.ts daemon restart