### PR TITLE
fix: reject a dangling-modifier keybinding chord instead of silently binding Ctrl+Plus

### DIFF
--- a/.changeset/keymap-dangling-modifier.md
+++ b/.changeset/keymap-dangling-modifier.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fixed a keybinding override where a dangling modifier chord (e.g. `ctrl+` or `cmd+alt+` in `keybindings.yaml`, with no key typed after the `+`) was silently bound to Ctrl+Plus instead of being rejected — kobe now reports a clear "no key after the modifiers" error, while the literal plus key (`ctrl++`, `+`) keeps working.

--- a/packages/kobe/src/tui/lib/keymap-overrides.ts
+++ b/packages/kobe/src/tui/lib/keymap-overrides.ts
@@ -229,14 +229,19 @@ export function normalizeChord(raw: string, opts?: NormalizeChordOpts): ChordRes
   const trimmed = raw.trim().toLowerCase()
   if (!trimmed) return { error: "empty chord" }
 
-  // Split on "+" but let a trailing "+" mean the literal plus key
-  // ("ctrl++" = ctrl plus "+").
+  // Split on "+", then read the trailing token. A trailing "+" leaves an
+  // empty final token; whether that means "the literal plus key" or "a
+  // dangling modifier with no key" is decided by the part BEFORE it:
+  //   "ctrl++" → ["ctrl", "", ""] — an empty marker part precedes, so "+"
+  //              is the key; drop the marker.
+  //   "+"      → ["", ""]         — the plus key on its own.
+  //   "ctrl+"  → ["ctrl", ""]     — a real modifier precedes, so there is
+  //              no key; fall through to the error below.
   const parts = trimmed.split("+")
   let key = parts.pop() ?? ""
-  if (key === "" && parts.length > 0) {
+  if (key === "" && parts.length > 0 && parts[parts.length - 1] === "") {
     key = "+"
-    // "ctrl++" splits to ["ctrl", "", ""] — drop the empty marker part.
-    if (parts[parts.length - 1] === "") parts.pop()
+    parts.pop()
   }
   if (!key) return { error: `"${raw}": no key after the modifiers` }
 

--- a/packages/kobe/test/tui/keymap-overrides.test.ts
+++ b/packages/kobe/test/tui/keymap-overrides.test.ts
@@ -48,6 +48,15 @@ describe("normalizeChord", () => {
 
   test("trailing + means the literal plus key", () => {
     expect(chordOf("ctrl++")).toBe("ctrl++")
+    expect(chordOf("+")).toBe("+")
+  })
+
+  test("a dangling modifier (no key after the +) is an error, not silently Ctrl+Plus", () => {
+    for (const raw of ["ctrl+", "cmd+alt+", "ctrl+shift+", "shift+"]) {
+      const r = normalizeChord(raw)
+      if (!("error" in r)) throw new Error(`expected ${raw} to error, got chord ${r.chord}`)
+      expect(r.error).toMatch(/no key after the modifiers/)
+    }
   })
 
   test("rejects shift+<single char> — terminals deliver it as a plain character", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in the pure keybinding-override logic (`packages/kobe/src/tui/lib/keymap-overrides.ts`). This was flagged as an explicit follow-up in the "Follow-ups" section of PR #224 ("`normalizeChord("ctrl+")` silently binds Ctrl+Plus instead of erroring — its 'no key after the modifiers' branch is unreachable"), surfaced during today's daily review.

## Problem

`normalizeChord` turns a user-written chord from `~/.kobe/settings/keybindings.yaml` into the exact candidate string `matchKey()` mints. It supports a literal plus key via a trailing `+` (`ctrl++` → ctrl plus `+`, `+` → the plus key alone).

But it conflated two different trailing-`+` shapes:

```
"ctrl++"    → ["ctrl", "", ""]   literal plus key      �  (intended)
"ctrl+"     → ["ctrl", ""]       dangling modifier     ✗  → silently became "ctrl++"
"cmd+alt+"  → ["cmd","alt",""]   dangling modifier     ✗  → silently became "cmd+alt++"
```

A user who typed `ctrl+` and forgot the key got **Ctrl+Plus** bound to that action with no warning — an unrelated chord — and the `if (!key) return { error: "…no key after the modifiers" }` guard was dead code that could never run.

Confirmed at runtime before the fix:

```
"ctrl+"    => {"chord":"ctrl++"}
"cmd+alt+" => {"chord":"cmd+alt++"}
```

## Fix

Only treat the empty trailing token as the literal `+` key when an **empty marker part** precedes it (the `++` seam), which is what distinguishes `ctrl++`/`+` (real plus key) from `ctrl+`/`cmd+alt+` (a modifier with nothing after it). A dangling modifier now falls through to the existing "no key after the modifiers" error — which becomes reachable. No behavior change for `ctrl++`, `+`, or any normal chord.

After the fix:

```
"ctrl+"    => {"error":"\"ctrl+\": no key after the modifiers"}
"cmd+alt+" => {"error":"\"cmd+alt+\": no key after the modifiers"}
"ctrl++"   => {"chord":"ctrl++"}     (unchanged)
"+"        => {"chord":"+"}          (unchanged)
```

As a bonus, `shift+`/`ctrl+shift+` now report the accurate "no key after the modifiers" instead of the misleading "shift+<character> can never match".

## Verification

- Added regression tests to `test/tui/keymap-overrides.test.ts`: the literal-plus cases (`ctrl++`, `+`) still normalize, and a dangling modifier (`ctrl+`, `cmd+alt+`, `ctrl+shift+`, `shift+`) errors with `/no key after the modifiers/`.
- `bunx vitest run test/tui/keymap-overrides.test.ts` → 23 passed.
- Shared-path regression: `bunx vitest run test/tmux/keybindings.test.ts test/tui/keymap-reload.test.ts` → 21 passed (the tmux resolver routes through the same normalizer; `ctrl++` → `C-+` still holds).
- `bun run lint` (biome) and `bun run typecheck` (kobe + kobe-daemon) both green from repo root.

## Follow-ups

None required — the fix is scoped to the one `normalizeChord` seam.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyCmLy4VsmUunzTW7BLCBN)_