### PR TITLE
fix: tmux drag-copy survives oh-my-tmux stripping the copy-pipe command

### DIFF
--- a/.changeset/tmux-copy-command-fallback.md
+++ b/.changeset/tmux-copy-command-fallback.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Drag-copy to the system clipboard survives an oh-my-tmux config rewrite. The workspace's copy-mode bindings (`copy-pipe-and-cancel pbcopy` on drag-release / `y` / Enter) could be silently rewritten by a user tmux.conf: oh-my-tmux's apply step, with its default `tmux_conf_copy_to_os_clipboard=false`, strips the clipboard command off every `copy-pipe*` binding, leaving a bare `copy-pipe-and-cancel` that never reached the OS clipboard — so drag-copy broke in panes without their own mouse handling (codex, plain shells) while Claude Code's built-in selection masked it. kobe now also sets tmux's `copy-command` option to the resolved clipboard tool; on tmux ≥ 3.2 a bare `copy-pipe` falls back to `copy-command`, so the copy lands in the system clipboard even after the rewrite.

--- a/packages/kobe/src/tmux/clipboard.ts
+++ b/packages/kobe/src/tmux/clipboard.ts
@@ -89,10 +89,19 @@ const COPY_FINISH_TRIGGERS = ["MouseDragEnd1Pane", "y", "Enter"] as const
  * clipboard command is available it ALSO binds the copy-mode finish actions to
  * `copy-pipe-and-cancel <cmd>` in both copy-mode tables. With no command the
  * copy-pipe bindings are omitted but `set-clipboard on` stays.
+ *
+ * `copy-command` is set alongside the bindings because a user tmux.conf can
+ * rewrite them: oh-my-tmux (gpakosz) dumps `list-keys` and, with its default
+ * `tmux_conf_copy_to_os_clipboard=false`, strips the `<cmd>` argument off
+ * every `copy-pipe*` binding — including ours — leaving a bare
+ * `copy-pipe-and-cancel`. On tmux ≥ 3.2 a bare copy-pipe falls back to the
+ * `copy-command` option, so setting it keeps the copy reaching the OS
+ * clipboard even after that rewrite.
  */
 export function clipboardTmuxConfig(clipboardCopyCommand: string | null): TmuxCommand[] {
   const config: TmuxCommand[] = [["set-option", "-g", "set-clipboard", "on"]]
   if (clipboardCopyCommand) {
+    config.push(["set-option", "-g", "copy-command", clipboardCopyCommand])
     for (const table of COPY_MODE_TABLES) {
       for (const trigger of COPY_FINISH_TRIGGERS) {
         config.push(["bind-key", "-T", table, trigger, "send-keys", "-X", "copy-pipe-and-cancel", clipboardCopyCommand])

--- a/packages/kobe/test/tmux/clipboard.test.ts
+++ b/packages/kobe/test/tmux/clipboard.test.ts
@@ -71,8 +71,12 @@ describe("clipboardTmuxConfig", () => {
         ])
       }
     }
-    // 1 set-option + 2 tables * 3 triggers = 7 commands.
-    expect(config).toHaveLength(7)
+    // 2 set-options + 2 tables * 3 triggers = 8 commands.
+    expect(config).toHaveLength(8)
+  })
+
+  test("with a clip command: sets copy-command so a binding stripped to a bare copy-pipe (oh-my-tmux rewrite) still reaches the clipboard", () => {
+    expect(clipboardTmuxConfig("pbcopy")).toContainEqual(["set-option", "-g", "copy-command", "pbcopy"])
   })
 
   test("MouseDragEnd1Pane (the drag-release flow) pipes to the resolved command", () => {


### PR DESCRIPTION
## 问题

优化过的 pane-aware drag-copy(73b0788)在 codex pane 里失效,claude pane 看起来还能用。

## 根因

- `~/.tmux.conf`(oh-my-tmux)的 `_apply_configuration` 会把 `list-keys` 全量 dump 出来重写再灌回去;在默认 `tmux_conf_copy_to_os_clipboard=false` 下,它把所有 `copy-pipe*` 绑定的剪贴板命令参数**剥掉**——kobe 装的 `copy-pipe-and-cancel pbcopy` 变成裸的 `copy-pipe-and-cancel`,选区只进 tmux buffer,到不了系统剪贴板。
- claude pane「还能用」是假象:Claude Code 自己开了鼠标上报(mouse_all=1)并实现了拖选+复制,根本不走 tmux copy-mode;codex 没有鼠标上报,走的正是被改坏的 tmux 路径。

## 修复

在 clipboard 配置里同时 `set -g copy-command <resolved cmd>`:tmux ≥ 3.2 的裸 `copy-pipe` 会回退读 `copy-command`,所以即使绑定被 oh-my-tmux 改写,复制仍然落到系统剪贴板。已在 live server 上验证(设置 copy-command 后裸 copy-pipe-and-cancel 成功写入 pbcopy)。

## 测试

- `clipboard.test.ts` 新增 copy-command 断言,序列长度 7→8
- 全量 kobe test 230 绿,root lint + typecheck 绿