### PR TITLE
feat: split vendor prefs into per-repo last-active + global default

### DIFF
--- a/.changeset/vendor-prefs-layers.md
+++ b/.changeset/vendor-prefs-layers.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Engine preference now layers per-project last-active over a Settings-owned global default: picking an engine via Ctrl+Shift+T or in the new-task/quick-task dialogs remembers it for that project only, and no longer clobbers the default engine set in Settings → Engines. Existing `lastSelectedVendor` values carry over as the global default.

--- a/packages/kobe-daemon/src/daemon/web-settings.ts
+++ b/packages/kobe-daemon/src/daemon/web-settings.ts
@@ -58,7 +58,8 @@ export function settingsSnapshot(): Response {
   const state = loadStateFile()
   const custom = customEngineIdsFrom(state)
   const engineIds = [...BUILTIN_VENDORS, ...custom] as VendorId[]
-  const defaultEngine = stringValue(state.lastSelectedVendor, "claude")
+  // `lastSelectedVendor` is the pre-split legacy key (see kobe's state/vendor-prefs.ts).
+  const defaultEngine = stringValue(state.defaultVendor, stringValue(state.lastSelectedVendor, "claude"))
   const focusAccent = stringValue(state.focusAccent, "primary")
   return Response.json({
     activeTheme: stringValue(state.activeTheme, "claude"),
@@ -114,7 +115,7 @@ export async function settingsPatch(req: Request): Promise<Response> {
     putIfBool(patch, "experimental.archivedHistoryPreview", body.archivedHistoryPreview)
     putIfBool(patch, AUTO_STATUS_KEY, body.autoStatus)
     putIfBool(patch, DISPATCHER_KEY, body.dispatcher)
-    putIfString(patch, "lastSelectedVendor", body.defaultEngine)
+    putIfString(patch, "defaultVendor", body.defaultEngine)
 
     const state = loadStateFile()
     const custom = customEngineIdsFrom(state)
@@ -147,6 +148,7 @@ export async function settingsPatch(req: Request): Promise<Response> {
         patch.customEngineIds = custom.filter((engine) => engine !== id)
         patch[engineCommandKey(id)] = undefined
         patch[engineNameKey(id)] = undefined
+        if (state.defaultVendor === id) patch.defaultVendor = "claude"
         if (state.lastSelectedVendor === id) patch.lastSelectedVendor = "claude"
       }
     }

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -942,8 +942,8 @@ interface ApiRuntime {
   deliverPrompt(client: DaemonRpc, target: PromptTarget, prompt: string): Promise<DeliveredPrompt>
   /** Canonical source repo for task creation and grouping. */
   resolveRepoRoot(absPath: string): Promise<string>
-  /** Settings default engine for new tasks; undefined delegates to daemon defaults. */
-  defaultVendor(): Promise<VendorId | undefined>
+  /** Preferred engine for new tasks in `repo`; undefined delegates to daemon defaults. */
+  defaultVendor(repo?: string): Promise<VendorId | undefined>
   /** Uncommitted +/− counts for a worktree. */
   readWorktreeChanges(worktreePath: string): Promise<{ added: number; deleted: number }>
   /**
@@ -962,10 +962,9 @@ const defaultApiRuntime: ApiRuntime = {
   isTaskRunning: (taskId) => sessionExists(tmuxSessionName(taskId)),
   deliverPrompt: (client, target, prompt) => deliverPrompt(client, target, prompt),
   resolveRepoRoot: async (absPath) => (await import("../state/repos.ts")).resolveMainRepoRoot(absPath),
-  defaultVendor: async () => {
-    const { getPersistedString } = await import("../state/repos.ts")
-    const value = getPersistedString("lastSelectedVendor")?.trim()
-    return value ? (value as VendorId) : undefined
+  defaultVendor: async (repo) => {
+    const { getGlobalDefaultVendor, getRepoLastActiveVendor } = await import("../state/vendor-prefs.ts")
+    return (repo ? getRepoLastActiveVendor(repo) : undefined) ?? getGlobalDefaultVendor()
   },
   readWorktreeChanges: async (worktreePath) =>
     (await import("../tui/panes/sidebar/worktree-changes.ts")).readWorktreeChanges(worktreePath),
@@ -1016,7 +1015,7 @@ async function add(ctx: VerbContext): Promise<unknown> {
   if (branch) payload.branch = branch
   const baseRef = args.str("base-branch")
   if (baseRef) payload.baseRef = baseRef
-  const vendor = args.vendor() ?? (await runtime.defaultVendor())
+  const vendor = args.vendor() ?? (await runtime.defaultVendor(repo))
   if (vendor) payload.vendor = vendor
 
   const res = await daemon.request<{ taskId: string; task: SerializedTask }>("task.create", payload)
@@ -1170,7 +1169,7 @@ async function fanOut(ctx: VerbContext): Promise<unknown> {
   const baseRef = args.str("base-branch")
 
   const agentsSpec = args.str("agents")
-  const defaultVendor = await runtime.defaultVendor()
+  const defaultVendor = await runtime.defaultVendor(repo)
   const plan: VendorId[] = agentsSpec
     ? parseAgentsSpec(agentsSpec)
     : new Array<VendorId>(args.int("count") ?? 1).fill(args.vendor() ?? defaultVendor ?? "claude")

--- a/packages/kobe/src/cli/commands-tui.ts
+++ b/packages/kobe/src/cli/commands-tui.ts
@@ -139,13 +139,7 @@ export async function dispatchTuiCommand(subcommand: string | undefined, rest: r
         process.exit(2)
       }
       vendor = typed as VendorId
-      // An explicit engine pick (Ctrl+Shift+T / prefix T → engine prompt) sets
-      // the DEFAULT engine for new tasks too — `lastSelectedVendor` is the one
-      // reference the new-task dialog, quick-task, and Settings → Engines all
-      // read/show. Without this, picking an engine for a chat tab silently left
-      // the default untouched.
-      const { setPersistedString } = await import("../state/repos.ts")
-      setPersistedString("lastSelectedVendor", vendor)
+      // newChatTab records the pick as the project's last-active engine.
     }
     const { newChatTab } = await import("../tui/panes/terminal/tmux.ts")
     await newChatTab(session, vendor)

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -28,17 +28,15 @@ import type { Accessor } from "solid-js"
 import { createSignal } from "solid-js"
 import { samePrStatus } from "../monitor/pr-status.ts"
 import {
-  getCustomEngineIds,
-  getPersistedString,
   getRemoteRepoConfig,
   getSavedRepos,
   isRemoteRepoKey,
   removeSavedRepo,
   resolveRepoRoot,
 } from "../state/repos.ts"
+import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
 import type { Task, TaskId, TaskPRStatus, TaskStatus, VendorId } from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR, toTaskId } from "../types/task.ts"
-import { resolvePersistedVendor } from "../types/vendor.ts"
 import type { AdoptableWorktree, WorktreeInfo } from "../types/worktree.ts"
 import {
   CannotDeleteMainTaskError,
@@ -252,11 +250,9 @@ export class Orchestrator {
     const inflight = this.mainTaskLocks.get(key)
     if (inflight) return inflight
     const promise = (async () => {
-      // Follow the user's configured default engine (`lastSelectedVendor`, the
-      // same key new-task / quick-task read) instead of hardcoding "claude", so
-      // a project's main chat opens with the default engine. Falls back to
-      // DEFAULT_TASK_VENDOR when unset/invalid.
-      const vendor = resolvePersistedVendor(getPersistedString("lastSelectedVendor"), getCustomEngineIds())
+      // A project's main chat opens with the repo's preferred engine
+      // (per-repo last-active → global default → claude).
+      const vendor = resolvePreferredVendor(normalizedRepo)
       const created = await this.store.create({
         repo: normalizedRepo,
         title: titleFromRepo(normalizedRepo),

--- a/packages/kobe/src/state/vendor-prefs.ts
+++ b/packages/kobe/src/state/vendor-prefs.ts
@@ -1,0 +1,54 @@
+/**
+ * Vendor preference layers, as flat keys in the shared `state.json`:
+ * `lastActiveVendor.<repo>` (per-project, written by Ctrl+Shift+T and
+ * dialog picks) → `defaultVendor` (global, Settings-only) →
+ * `lastSelectedVendor` (legacy pre-split key, read-only) → `claude`.
+ * Per-TASK vendor lives on the task record, not here.
+ */
+
+import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
+import { type VendorId, isBuiltinVendor } from "../types/vendor.ts"
+import { getCustomEngineIds, getPersistedString, setPersistedString } from "./repos.ts"
+
+const REPO_KEY_PREFIX = "lastActiveVendor."
+
+/** Validate one persisted value; undefined lets the chain fall through. */
+function validVendor(value: string | undefined, customIds: readonly string[]): VendorId | undefined {
+  const v = value?.trim()
+  if (!v) return undefined
+  if (isBuiltinVendor(v) || customIds.includes(v)) return v
+  return undefined
+}
+
+/** The project's last actively-used engine (undefined = never recorded). */
+export function getRepoLastActiveVendor(repo: string): VendorId | undefined {
+  return validVendor(getPersistedString(REPO_KEY_PREFIX + repo), getCustomEngineIds())
+}
+
+export function setRepoLastActiveVendor(repo: string, vendor: VendorId): void {
+  setPersistedString(REPO_KEY_PREFIX + repo, vendor)
+}
+
+/** The Settings-owned global default (legacy key honored; undefined = unset). */
+export function getGlobalDefaultVendor(): VendorId | undefined {
+  const customIds = getCustomEngineIds()
+  return (
+    validVendor(getPersistedString("defaultVendor"), customIds) ??
+    validVendor(getPersistedString("lastSelectedVendor"), customIds)
+  )
+}
+
+export function setGlobalDefaultVendor(vendor: VendorId): void {
+  setPersistedString("defaultVendor", vendor)
+}
+
+/**
+ * The vendor a new task / relaunch should default to: the repo's last-active
+ * engine, else the Settings global default, else `claude`. Each level is
+ * validated independently, so a corrupt repo entry falls through to the
+ * global default rather than straight to the built-in fallback.
+ */
+export function resolvePreferredVendor(repo?: string): VendorId {
+  const repoPick = repo ? getRepoLastActiveVendor(repo) : undefined
+  return repoPick ?? getGlobalDefaultVendor() ?? DEFAULT_TASK_VENDOR
+}

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -90,9 +90,9 @@ export type NewTaskDialogProps = {
    */
   defaultCloneParent?: string
   /**
-   * Engine to pre-select, defaulting to the user's last-selected vendor
-   * (kv `lastSelectedVendor`). `ctrl+e` cycles it; the choice rides out
-   * on {@link NewTaskInput.vendor} and the caller persists it.
+   * Engine to pre-select — the repo's preferred vendor. `ctrl+e` cycles it;
+   * the choice rides out on {@link NewTaskInput.vendor} and the caller
+   * persists it.
    */
   defaultVendor?: VendorId
   /**

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -90,9 +90,9 @@ export type NewTaskDialogProps = {
    */
   defaultCloneParent?: string
   /**
-   * Engine to pre-select — the repo's preferred vendor. `ctrl+e` cycles it;
-   * the choice rides out on {@link NewTaskInput.vendor} and the caller
-   * persists it.
+   * Engine to pre-select, defaulting to the user's last-selected vendor
+   * (kv `lastSelectedVendor`). `ctrl+e` cycles it; the choice rides out
+   * on {@link NewTaskInput.vendor} and the caller persists it.
    */
   defaultVendor?: VendorId
   /**

--- a/packages/kobe/src/tui/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/index.tsx
@@ -36,8 +36,8 @@ export type NewTaskDialogOptions = {
    */
   defaultCloneParent?: string
   /**
-   * Engine to pre-select — the repo's preferred vendor
-   * (state/vendor-prefs.ts). Falls back to `claude` in the dialog.
+   * Engine to pre-select — the user's last-selected vendor (kv
+   * `lastSelectedVendor`). Falls back to `claude` in the dialog.
    */
   defaultVendor?: VendorId
   /**

--- a/packages/kobe/src/tui/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/index.tsx
@@ -36,8 +36,8 @@ export type NewTaskDialogOptions = {
    */
   defaultCloneParent?: string
   /**
-   * Engine to pre-select — the user's last-selected vendor (kv
-   * `lastSelectedVendor`). Falls back to `claude` in the dialog.
+   * Engine to pre-select — the repo's preferred vendor
+   * (state/vendor-prefs.ts). Falls back to `claude` in the dialog.
    */
   defaultVendor?: VendorId
   /**

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -28,7 +28,7 @@ import { submitFeedback } from "../../lib/feedback"
 import { ARCHIVED_HISTORY_PREVIEW_KEY } from "../../state/archived-history"
 import { AUTO_STATUS_KEY } from "../../state/auto-status"
 import { DISPATCHER_KEY } from "../../state/dispatcher"
-import { getPersistedString, setPersistedString } from "../../state/repos"
+import { getGlobalDefaultVendor, setGlobalDefaultVendor } from "../../state/vendor-prefs"
 import {
   PROJECT_DIR_TOKEN,
   PROJECT_SIBLING_BASE,
@@ -40,8 +40,8 @@ import {
   worktreeBaseKindOf,
 } from "../../state/worktree-base"
 import { ZEN_KEEP_TASKS_KEY } from "../../state/zen"
-import type { VendorId } from "../../types/task"
-import { ALL_VENDORS, isBuiltinVendor, resolvePersistedVendor } from "../../types/vendor"
+import { DEFAULT_TASK_VENDOR, type VendorId } from "../../types/task"
+import { ALL_VENDORS, isBuiltinVendor } from "../../types/vendor"
 import type { KVContext } from "../context/kv"
 import { FOCUS_ACCENT_SLOTS, type FocusAccentSlot, useTheme } from "../context/theme"
 import { type LocaleId, currentLang, setLocaleLang, t } from "../i18n"
@@ -326,19 +326,15 @@ export function SettingsDialog(props: SettingsDialogProps) {
     // Built-ins fall back to VENDOR_LABEL; a custom engine falls back to its id.
     return engineNameOverride(vendor) || VENDOR_LABEL[vendor] || vendor
   }
-  // The DEFAULT engine for new tasks — the single `lastSelectedVendor` reference
-  // the new-task dialog / quick-task read and Ctrl+Shift+T writes. Read fresh on
-  // open (getPersistedString) so a default set via Ctrl+Shift+T in another
-  // process is reflected here; `d` on an engine row sets it (the ● marker).
-  const [defaultEngine, setDefaultEngineSig] = createSignal<VendorId>(
-    resolvePersistedVendor(getPersistedString("lastSelectedVendor"), customEngines()),
-  )
+  // The GLOBAL default engine (the ● marker) — only this dialog writes it;
+  // per-project picks live in their own layer (state/vendor-prefs.ts).
+  const [defaultEngine, setDefaultEngineSig] = createSignal<VendorId>(getGlobalDefaultVendor() ?? DEFAULT_TASK_VENDOR)
   function isDefaultEngine(vendor: VendorId): boolean {
     return defaultEngine() === vendor
   }
   function setEngineDefault(vendor: VendorId): void {
-    setPersistedString("lastSelectedVendor", vendor)
-    props.kv.set("lastSelectedVendor", vendor) // keep the in-process kv consistent
+    setGlobalDefaultVendor(vendor)
+    props.kv.set("defaultVendor", vendor) // keep the in-process kv consistent
     setDefaultEngineSig(vendor)
   }
   async function editEngine(vendor: VendorId): Promise<void> {
@@ -690,8 +686,8 @@ export function SettingsDialog(props: SettingsDialogProps) {
         },
       },
       {
-        // Engines section: `d` sets the focused engine as the DEFAULT for new
-        // tasks (the ● marker) — the same `lastSelectedVendor` Ctrl+Shift+T sets.
+        // Engines section: `d` sets the focused engine as the global default
+        // (the ● marker).
         key: "d",
         cmd: () => {
           const v = currentEngineRow()

--- a/packages/kobe/src/tui/direct.ts
+++ b/packages/kobe/src/tui/direct.ts
@@ -16,15 +16,14 @@ import { PLACEHOLDER_TASK_TITLE } from "../orchestrator/core.ts"
 import { resolveEngineLaunchInit } from "../state/repo-init.ts"
 import {
   addSavedRepo,
-  getCustomEngineIds,
   getPersistedString,
   getSavedRepos,
   normalizeSavedRepos,
   setPersistedString,
 } from "../state/repos.ts"
+import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
 import { ensureFallbackSession } from "../tmux/client.ts"
 import type { Task } from "../types/task.ts"
-import { resolvePersistedVendor } from "../types/vendor.ts"
 import { applyTmuxChromeTheme } from "./lib/tmux-border-theme.ts"
 import { syncSessionZen } from "./panes/terminal/layout-actions.ts"
 import {
@@ -152,12 +151,12 @@ export async function startDirectTmux(): Promise<void> {
     // frozen at creation time. Reconcile before launch: adopt the live session's
     // ACTUAL vendor when one is running (so a daemon restart never respawns a
     // healthy codex session back to the persisted "claude"), otherwise fall back
-    // to the global default (so cold-opening an existing project honors it).
+    // to the repo's preferred vendor (so cold-opening an existing project honors it).
     // Regular tasks keep their explicitly chosen vendor untouched.
     let vendor = task.vendor
     if (task.kind === "main") {
       const live = await observeSessionVendor(name)
-      const desired = live ?? resolvePersistedVendor(getPersistedString("lastSelectedVendor"), getCustomEngineIds())
+      const desired = live ?? resolvePreferredVendor(task.repo)
       if (desired !== task.vendor) {
         await orchestrator.setVendor(task.id, desired).catch(() => {})
         vendor = desired

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -68,7 +68,7 @@ export const en = {
   },
   engines: {
     title: "Launch command",
-    hint: "The command each engine's task pane runs. Override a built-in when your binary isn't on PATH as `claude` / `codex` (e.g. it's `cl`) or to pass default flags, or add your own engine. ● = default engine for new tasks (also set by Ctrl+Shift+T). enter edit command · r rename · x reset/remove · d set default.",
+    hint: "The command each engine's task pane runs. Override a built-in when your binary isn't on PATH as `claude` / `codex` (e.g. it's `cl`) or to pass default flags, or add your own engine. ● = global default engine (per-project picks, e.g. Ctrl+Shift+T, override it). enter edit command · r rename · x reset/remove · d set default.",
     defaultTag: "  (default)",
     customTag: "  (custom)",
     addEngine: "+ Add engine",
@@ -197,7 +197,7 @@ export const zh: typeof en = {
   },
   engines: {
     title: "启动命令",
-    hint: "每个引擎的任务面板运行的命令。当二进制文件不在 PATH 上的 `claude` / `codex` 名下（比如叫 `cl`）、要传默认参数，或要添加自己的引擎时，可覆盖内置项。● = 新任务的默认引擎（也可用 Ctrl+Shift+T 设置）。enter 编辑命令 · r 重命名 · x 重置/移除 · d 设为默认。",
+    hint: "每个引擎的任务面板运行的命令。当二进制文件不在 PATH 上的 `claude` / `codex` 名下（比如叫 `cl`）、要传默认参数，或要添加自己的引擎时，可覆盖内置项。● = 全局默认引擎（各项目自己的选择会覆盖它，如 Ctrl+Shift+T）。enter 编辑命令 · r 重命名 · x 重置/移除 · d 设为默认。",
     defaultTag: "  (默认)",
     customTag: "  (自定义)",
     addEngine: "+ 添加引擎",

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -124,14 +124,10 @@ export interface CreateTaskContext extends TaskActionContext {
    * `savedRepos[0]` then `process.cwd()` for both.
    */
   readonly cursorRepo: () => string | undefined
-  /**
-   * DIVERGENCE — last-selected-vendor persistence: the outer monitor
-   * goes through its in-process kv store, the Tasks pane through the
-   * disk-only `getPersistedString`/`setPersistedString` pair. Same
-   * state.json underneath, different write paths.
-   */
-  readonly lastVendor: () => VendorId | undefined
-  readonly rememberVendor: (vendor: VendorId) => void
+  /** Vendor preference for `repo` (layered resolution: state/vendor-prefs.ts). */
+  readonly lastVendor: (repo: string) => VendorId | undefined
+  /** Record `vendor` as `repo`'s last-active engine. */
+  readonly rememberVendor: (repo: string, vendor: VendorId) => void
   /**
    * DIVERGENCE — after `addSavedRepo`, the outer monitor mirrors the fresh
    * list into its kv store so the debounced whole-store flush doesn't
@@ -459,7 +455,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
   // "spawn a sibling" default.
   const defaultRepo = ctx.cursorRepo() ?? repos[0] ?? process.cwd()
   if (ctx.openCreateSurface && (await ctx.openCreateSurface(defaultRepo))) return
-  const defaultVendor = ctx.lastVendor() ?? DEFAULT_TASK_VENDOR
+  const defaultVendor = ctx.lastVendor(defaultRepo) ?? DEFAULT_TASK_VENDOR
   const availableVendors = await availableEngineIds()
   // First-run guard (#24): no built-in engine detected AND no custom engine
   // configured. The dialog would still let the user pick a vendor, then the
@@ -475,9 +471,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     discoverAdoptable: orch ? (repo) => orch.discoverAdoptableWorktrees(repo) : undefined,
   })
   if (!result) return
-  // Remember the choice so the next new-task dialog — either host —
-  // defaults to it (shared state.json; write path is host-provided).
-  ctx.rememberVendor(result.vendor)
+  ctx.rememberVendor(result.repo, result.vendor)
   // Auto-save the chosen repo so the saved list self-populates and
   // `kobe add` stays optional.
   addSavedRepo(result.repo)

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -124,9 +124,8 @@ export interface CreateTaskContext extends TaskActionContext {
    * `savedRepos[0]` then `process.cwd()` for both.
    */
   readonly cursorRepo: () => string | undefined
-  /** Vendor preference for `repo` (layered resolution: state/vendor-prefs.ts). */
+  /** Repo-scoped vendor preference — see state/vendor-prefs.ts. */
   readonly lastVendor: (repo: string) => VendorId | undefined
-  /** Record `vendor` as `repo`'s last-active engine. */
   readonly rememberVendor: (repo: string, vendor: VendorId) => void
   /**
    * DIVERGENCE — after `addSavedRepo`, the outer monitor mirrors the fresh

--- a/packages/kobe/src/tui/new-task/host.tsx
+++ b/packages/kobe/src/tui/new-task/host.tsx
@@ -24,15 +24,9 @@ import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-proces
 import { onMount } from "solid-js"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { availableEngineIds } from "../../engine/account-detect.ts"
-import {
-  addSavedRepo,
-  getCustomEngineIds,
-  getPersistedString,
-  getSavedRepos,
-  setPersistedString,
-} from "../../state/repos.ts"
+import { addSavedRepo, getSavedRepos } from "../../state/repos.ts"
+import { resolvePreferredVendor, setRepoLastActiveVendor } from "../../state/vendor-prefs.ts"
 import type { Task } from "../../types/task.ts"
-import { resolvePersistedVendor } from "../../types/vendor.ts"
 import { NewTaskDialog } from "../component/new-task-dialog"
 import { useTheme } from "../context/theme"
 import { bootPaneHost } from "../lib/host-boot"
@@ -57,7 +51,7 @@ export function NewTaskPage(props: NewTaskHostArgs & { orchestrator: RemoteOrche
   async function run(): Promise<void> {
     const repos = getSavedRepos()
     const defaultRepo = props.defaultRepo || repos[0] || process.cwd()
-    const defaultVendor = resolvePersistedVendor(getPersistedString("lastSelectedVendor"), getCustomEngineIds())
+    const defaultVendor = resolvePreferredVendor(defaultRepo)
     const availableVendors = await availableEngineIds()
     const orch = props.orchestrator
 
@@ -70,9 +64,7 @@ export function NewTaskPage(props: NewTaskHostArgs & { orchestrator: RemoteOrche
       process.exit(0)
     }
 
-    // Remember the choices (shared kv state.json) so the next new-task
-    // dialog — here or in any Tasks pane — defaults to them.
-    setPersistedString("lastSelectedVendor", result.vendor)
+    setRepoLastActiveVendor(result.repo, result.vendor)
     addSavedRepo(result.repo)
 
     if (!orch) {

--- a/packages/kobe/src/tui/panes/terminal/chattab.ts
+++ b/packages/kobe/src/tui/panes/terminal/chattab.ts
@@ -279,7 +279,17 @@ export async function newChatTab(session: string, vendorOverride?: VendorId): Pr
   const taskId = sessionOptions["@kobe_task"] || undefined
   const remoteKey = sessionOptions[REMOTE_KEY_OPTION] || undefined
   const vendor = vendorOverride ?? (sessionOptions["@kobe_vendor"] as VendorId | undefined)
-  if (vendorOverride) await rememberSessionVendor(session, taskId, vendorOverride)
+  if (vendorOverride) {
+    await rememberSessionVendor(session, taskId, vendorOverride)
+    // Also the project's last-active engine (never the global default).
+    try {
+      const { resolveMainRepoRoot } = await import("../../../state/repos.ts")
+      const { setRepoLastActiveVendor } = await import("../../../state/vendor-prefs.ts")
+      setRepoLastActiveVendor(resolveMainRepoRoot(cwd), vendorOverride)
+    } catch {
+      // Best-effort: a stale worktree path must not block the new tab.
+    }
+  }
   const command = interactiveEngineCommand(vendor)
   // Same forced-session-id mapping as the first window, so a Ctrl+T tab is
   // auto-named from its OWN first prompt (KOB).

--- a/packages/kobe/src/tui/quick-task/host.tsx
+++ b/packages/kobe/src/tui/quick-task/host.tsx
@@ -30,17 +30,11 @@ import { onMount } from "solid-js"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { availableEngineIds } from "../../engine/account-detect.ts"
 import { engineDisplayName } from "../../engine/interactive-command.ts"
-import {
-  addSavedRepo,
-  getCustomEngineIds,
-  getPersistedString,
-  getSavedRepos,
-  setPersistedString,
-} from "../../state/repos.ts"
+import { addSavedRepo, getSavedRepos } from "../../state/repos.ts"
+import { resolvePreferredVendor, setRepoLastActiveVendor } from "../../state/vendor-prefs.ts"
 import { getSessionOptions, tmuxSessionName } from "../../tmux/client.ts"
 import { pasteAndSubmit, waitForEnginePane } from "../../tmux/prompt-delivery.ts"
 import type { Task, VendorId } from "../../types/task.ts"
-import { resolvePersistedVendor } from "../../types/vendor.ts"
 import { QuickTaskComposer } from "../component/quick-task-composer"
 import { useTheme } from "../context/theme"
 import { appendAttachmentRefs } from "../lib/attachments.ts"
@@ -87,10 +81,10 @@ async function resolveQuickTaskContext(
   const fallbackRepo = repo ?? worktree ?? process.cwd()
   if (!repo) return { ctx: null, fallbackRepo }
 
-  // Engine: last-selected vendor, clamped to a detected one. With nothing
-  // detected we keep the preference (the dialog-less path can't ask).
+  // Engine: the repo's preferred vendor, clamped to a detected one. With
+  // nothing detected we keep the preference (the dialog-less path can't ask).
   const detected = await availableEngineIds()
-  const pref = resolvePersistedVendor(getPersistedString("lastSelectedVendor"), getCustomEngineIds())
+  const pref = resolvePreferredVendor(repo)
   const vendor: VendorId = detected.length === 0 || detected.includes(pref) ? pref : (detected[0] ?? pref)
   const baseRef = getCurrentBranch(expandHome(repo)) ?? DEFAULT_BASE_REF
   // The composer needs at least the chosen vendor to render its chip even when
@@ -137,8 +131,7 @@ function QuickTaskPage(props: { ctx: QuickTaskContext; orchestrator: RemoteOrche
     })
     if (result === undefined) process.exit(0) // esc
 
-    // Remember the chosen engine so the next dialog (here or any pane) matches.
-    setPersistedString("lastSelectedVendor", result.vendor)
+    setRepoLastActiveVendor(ctx.repo, result.vendor)
     addSavedRepo(ctx.repo)
 
     const orch = props.orchestrator

--- a/packages/kobe/src/tui/tasks-pane/actions.ts
+++ b/packages/kobe/src/tui/tasks-pane/actions.ts
@@ -12,9 +12,8 @@ import { existsSync } from "node:fs"
 import { claudePaneIdStrict, currentSessionName, killSession, runTmux, tmuxSessionName } from "@/tmux/client"
 import { t } from "@/tui/i18n"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
-import { getCustomEngineIds, getPersistedString, setPersistedString } from "../../state/repos.ts"
+import { resolvePreferredVendor, setRepoLastActiveVendor } from "../../state/vendor-prefs.ts"
 import type { Task } from "../../types/task.ts"
-import { resolvePersistedVendor } from "../../types/vendor.ts"
 import { CURRENT_VERSION, type UpdateInfo } from "../../version.ts"
 import { HelpDialog } from "../component/help-dialog"
 import { NewTaskDialog } from "../component/new-task-dialog"
@@ -340,8 +339,8 @@ export function buildTaskActionsContext(deps: TaskActionsContextDeps): CreateTas
     },
     // This pane uses disk-only persistence (no in-process kv store), so the
     // atomic disk write is sufficient — no onRepoSaved kv mirror needed.
-    lastVendor: () => resolvePersistedVendor(getPersistedString("lastSelectedVendor"), getCustomEngineIds()),
-    rememberVendor: (vendor) => setPersistedString("lastSelectedVendor", vendor),
+    lastVendor: (repo) => resolvePreferredVendor(repo),
+    rememberVendor: (repo, vendor) => setRepoLastActiveVendor(repo, vendor),
     // Same surface preference as Settings (default chattab): open the
     // new-task flow as a dedicated full-window page in a new tmux tab.
     // The page performs the create/adopt itself and the subscribe pushes

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -100,10 +100,15 @@ describe("defaultApiRuntime", () => {
     expect(mocks.resolveMainRepoRoot).toHaveBeenCalledWith("/repo/main/.kobe/worktrees/x")
   })
 
-  it("defaultVendor reads lastSelectedVendor, treating blank/unset as undefined", async () => {
+  it("defaultVendor resolves repo last-active → global default, blank/unset → undefined", async () => {
     mocks.getPersistedString.mockReturnValue("codex")
     await expect(defaultApiRuntime.defaultVendor()).resolves.toBe("codex")
-    expect(mocks.getPersistedString).toHaveBeenCalledWith("lastSelectedVendor")
+    expect(mocks.getPersistedString).toHaveBeenCalledWith("defaultVendor")
+
+    mocks.getPersistedString.mockClear()
+    mocks.getPersistedString.mockReturnValue("codex")
+    await expect(defaultApiRuntime.defaultVendor("/repo")).resolves.toBe("codex")
+    expect(mocks.getPersistedString).toHaveBeenCalledWith("lastActiveVendor./repo")
 
     mocks.getPersistedString.mockReturnValue("   ")
     await expect(defaultApiRuntime.defaultVendor()).resolves.toBeUndefined()

--- a/packages/kobe/test/cli/index-dispatch.test.ts
+++ b/packages/kobe/test/cli/index-dispatch.test.ts
@@ -217,10 +217,10 @@ describe("in-session handlers (new-chattab / focus-tasks / layout / kill-session
     expect(spies.newChatTab).not.toHaveBeenCalled()
   })
 
-  test("new-chattab opens a tab in the session, honoring a valid --vendor and persisting it as default", async () => {
+  test("new-chattab opens a tab in the session, honoring a valid --vendor", async () => {
     await runCli("new-chattab", "--session", "kobe-t1", "--vendor", "codex")
+    // Per-repo last-active persistence happens inside newChatTab (mocked here).
     expect(spies.newChatTab).toHaveBeenCalledWith("kobe-t1", "codex")
-    expect(spies.setPersistedString).toHaveBeenCalledWith("lastSelectedVendor", "codex")
   })
 
   test("new-chattab rejects an unknown engine VISIBLY via tmux display-message", async () => {

--- a/packages/kobe/test/state/vendor-prefs.test.ts
+++ b/packages/kobe/test/state/vendor-prefs.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Vendor-preference layering: per-repo last-active → global default →
+ * legacy `lastSelectedVendor` → claude, with each layer validated
+ * independently (a corrupt repo entry must fall through to the global
+ * default, not straight to the built-in fallback). Isolated state.json
+ * via `KOBE_HOME_DIR`.
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { setPersistedString } from "../../src/state/repos.ts"
+import {
+  getGlobalDefaultVendor,
+  getRepoLastActiveVendor,
+  resolvePreferredVendor,
+  setGlobalDefaultVendor,
+  setRepoLastActiveVendor,
+} from "../../src/state/vendor-prefs.ts"
+
+let tmpHome: string
+let originalHome: string | undefined
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-vendor-prefs-"))
+  originalHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = tmpHome
+})
+
+afterEach(() => {
+  if (originalHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = originalHome
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+})
+
+describe("vendor preference layers", () => {
+  test("unset everywhere → claude", () => {
+    expect(resolvePreferredVendor("/repo")).toBe("claude")
+    expect(resolvePreferredVendor()).toBe("claude")
+    expect(getGlobalDefaultVendor()).toBeUndefined()
+  })
+
+  test("repo last-active wins over the global default", () => {
+    setGlobalDefaultVendor("claude")
+    setRepoLastActiveVendor("/repo", "codex")
+    expect(resolvePreferredVendor("/repo")).toBe("codex")
+    expect(resolvePreferredVendor("/other")).toBe("claude")
+    expect(resolvePreferredVendor()).toBe("claude")
+  })
+
+  test("legacy lastSelectedVendor backs the global default until defaultVendor is set", () => {
+    setPersistedString("lastSelectedVendor", "codex")
+    expect(getGlobalDefaultVendor()).toBe("codex")
+    expect(resolvePreferredVendor("/repo")).toBe("codex")
+    setGlobalDefaultVendor("copilot")
+    expect(getGlobalDefaultVendor()).toBe("copilot")
+  })
+
+  test("a corrupt repo entry falls through to the global default", () => {
+    setPersistedString("lastActiveVendor./repo", "gpt9-typo")
+    setGlobalDefaultVendor("codex")
+    expect(getRepoLastActiveVendor("/repo")).toBeUndefined()
+    expect(resolvePreferredVendor("/repo")).toBe("codex")
+  })
+})

--- a/packages/kobe/test/tui/chattab.test.ts
+++ b/packages/kobe/test/tui/chattab.test.ts
@@ -36,6 +36,13 @@ vi.mock("../../src/tui/panes/terminal/pane-heal", () => ({
   PANE_VERSION_OPTION: "@kobe_pane_version",
   globalRightColumnResizeArgs: vi.fn(async () => [] as readonly string[]),
 }))
+vi.mock("../../src/state/repos", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/state/repos")>()
+  return { ...actual, resolveMainRepoRoot: vi.fn((p: string) => `${p}-root`) }
+})
+vi.mock("../../src/state/vendor-prefs", () => ({
+  setRepoLastActiveVendor: vi.fn(),
+}))
 
 vi.mock("../../src/tmux/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/tmux/client")>()
@@ -85,6 +92,8 @@ vi.mock("@sma1lboy/kobe-daemon/client/daemon-process", () => ({
 
 const chattab = await import("../../src/tui/panes/terminal/chattab")
 const daemonProcess = await import("@sma1lboy/kobe-daemon/client/daemon-process")
+const stateRepos = await import("../../src/state/repos")
+const vendorPrefs = await import("../../src/state/vendor-prefs")
 
 function resetState(): void {
   state.existingSessions = new Set(["kobe-t1"])
@@ -188,6 +197,19 @@ describe("newChatTab", () => {
     await chattab.newChatTab("kobe-t1", "codex")
     expect(state.sessionOptions["@kobe_vendor"]).toBe("codex")
     expect(daemonProcess.connectOrStartDaemon).toHaveBeenCalled()
+    // ... and as the PROJECT's last-active engine, keyed on the repo root.
+    expect(vendorPrefs.setRepoLastActiveVendor).toHaveBeenCalledWith("/wt-root", "codex")
+  })
+
+  test("a stale worktree path never blocks the new tab (repo-root resolution throws)", async () => {
+    state.sessionOptions = { "@kobe_worktree": "/gone", "@kobe_task": "t1" }
+    vi.mocked(stateRepos.resolveMainRepoRoot).mockImplementationOnce(() => {
+      throw new Error("not a git repository")
+    })
+    await chattab.newChatTab("kobe-t1", "codex")
+    expect(vendorPrefs.setRepoLastActiveVendor).not.toHaveBeenCalled()
+    const newWindowCall = state.capturingCalls.find((c) => c[0] === "new-window")
+    expect(newWindowCall).toBeDefined()
   })
 
   test("degrades gracefully when new-window returns no pane id", async () => {

--- a/packages/kobe/test/tui/create-task-flow.test.ts
+++ b/packages/kobe/test/tui/create-task-flow.test.ts
@@ -187,7 +187,7 @@ describe("createTaskFlow — create mode + guards", () => {
     await createTaskFlow(ctx)
 
     expect(createTask).toHaveBeenCalledWith({ repo: "/repo", baseRef: "main", vendor: "claude" })
-    expect(rememberVendor).toHaveBeenCalledWith("claude")
+    expect(rememberVendor).toHaveBeenCalledWith("/repo", "claude")
     expect(reload).toHaveBeenCalledTimes(1)
     expect(selectTask).toHaveBeenCalledWith("new-id")
     expect(enterTask).toHaveBeenCalledWith("new-id")
@@ -267,7 +267,7 @@ describe("createTaskFlow — create mode + guards", () => {
 
     await createTaskFlow(ctx)
 
-    expect(rememberVendor).toHaveBeenCalledWith("claude")
+    expect(rememberVendor).toHaveBeenCalledWith("/repo", "claude")
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("no daemon"))
     // Never reaches the "Creating task…" toast — that's gated on `orch`.
     expect(notifyInfo).not.toHaveBeenCalledWith(expect.stringContaining("Creating task"))

--- a/packages/kobe/test/tui/tasks-pane-actions.test.ts
+++ b/packages/kobe/test/tui/tasks-pane-actions.test.ts
@@ -417,8 +417,8 @@ describe("buildTaskActionsContext", () => {
 
     expect(taskActions.cursorRepo()).toBe("/repo")
 
-    expect(taskActions.lastVendor()).toBeDefined()
-    taskActions.rememberVendor("claude" as never)
+    expect(taskActions.lastVendor("/repo")).toBeDefined()
+    taskActions.rememberVendor("/repo", "claude" as never)
 
     taskActions.selectTask!("t2")
     expect(setSelectedId).toHaveBeenCalledWith("t2")


### PR DESCRIPTION
## Summary
- `lastSelectedVendor` did double duty as both "default engine" and "last pick": choosing an engine via Ctrl+Shift+T or in the new-task/quick-task dialogs silently clobbered the default set in Settings → Engines.
- New `state/vendor-prefs.ts` layers the resolution: `lastActiveVendor.<repo>` (per-project, written by engine picks) → `defaultVendor` (Settings-only) → legacy `lastSelectedVendor` (read-only fallback so existing defaults carry over) → `claude`. Each layer validates independently so a corrupt entry falls through instead of jumping to the built-in fallback.
- All resolution sites (new-task, quick-task, Tasks pane, `kobe api` create/fan-out, main-task cold-open reconcile, web settings `defaultEngine`) go through `resolvePreferredVendor(repo)`. Per-task vendor stays on the task record, unchanged.

file-size-exemption: the five flagged files (api-cmd, new-task-dialog/dialog, settings-dialog, orchestrator/core, task-actions) were already over the cap on main; this PR only swaps 1-3 resolution lines in each — shrinking them is pre-existing debt out of scope for this fix.

## Test plan
- [x] `bun run lint` (repo root), `bun run typecheck`, `bun run test:fast` (2255 pass), `bun run check-i18n` — all green on this branch
- [x] New `test/state/vendor-prefs.test.ts` covers the layered fallback chain incl. corrupt-entry fall-through and legacy-key migration
- [ ] Manual: set default in Settings → Engines, Ctrl+Shift+T a different engine in one project, confirm the Settings default is untouched and new tasks in that project default to the picked engine