### PR TITLE
fix: let the claude-review workflow actually post its PR comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,12 @@ jobs:
           plugins: 'pr-review-toolkit@claude-code-plugins'
           additional_permissions: |
             actions: read
+          track_progress: true
+          # Agent mode grants NO comment/Bash tools by default: without this
+          # allowlist the "post a PR comment" instruction below is silently
+          # permission-denied and the review only ever lands in the job log.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(wc:*)"
           prompt: |
             Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 


### PR DESCRIPTION
## Summary
- Every `claude-review` run so far ended with `permission_denials_count: 11` (see e.g. run 28755788167): the workflow's prompt says "Post ONE consolidated review as a PR comment", but agent mode grants no comment/Bash tools by default, so the posting attempt (and the prompt's `wc -l` / CI-read instructions) were silently denied and the review only ever landed in the job log while the job exited green.
- Fix per the official solutions recipe: `claude_args --allowedTools` grants `mcp__github_inline_comment__create_inline_comment` + `Bash(gh pr comment/diff/view/checks)` + `Bash(wc)`, and `track_progress: true` gives the v0.x-style tracking comment that gets updated with the result.

## Test plan
- [x] YAML parses (`gh workflow view` after push)
- [ ] Next PR (or this one's own review run) shows a Claude tracking comment with the consolidated review