### PR TITLE
fix: window history pane rendering to a bounded tail

### DIFF
--- a/.changeset/history-pane-window.md
+++ b/.changeset/history-pane-window.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+History pane now renders only the last 200 messages (with an "… N earlier messages" indicator) instead of mounting the entire transcript, fixing unbounded memory growth on long-running sessions.

--- a/packages/kobe/src/tui/history/host.tsx
+++ b/packages/kobe/src/tui/history/host.tsx
@@ -12,17 +12,15 @@
  * through the neutral `EngineHistoryReader` (engine/registry.ts), so no vendor
  * transcript format leaks into this UI (CLAUDE.md: engine-owned UI data).
  *
- * The visual mirrors the web ChatTranscript (kobe's own sibling surface): user
- * turns are tinted cards with a `❯` glyph + relative-time chip, assistant text is
- * plain, tool calls are a colored `⏺` status glyph + bold name + dim summary, and
- * `enter` expands the tool-output / thinking bodies. Runs in its own OS process
- * inside the tmux pane, same standalone-pane shape as `kobe ops`
- * (`tui/ops/host.tsx`). Pure read surface: no engine spawn, no write path, no
- * daemon dependency.
+ * Row rendering (MessageCard / block views) lives in `message-card.tsx`; only
+ * a bounded tail of the transcript is mounted (`window.ts`) because opentui's
+ * scrollbox culls drawing, not Renderables — see that file for the why.
+ * Runs in its own OS process inside the tmux pane, same standalone-pane shape
+ * as `kobe ops` (`tui/ops/host.tsx`). Pure read surface: no engine spawn, no
+ * write path, no daemon dependency.
  */
 
 import { type EngineHistoryReader, engineEntry } from "@/engine/registry"
-import type { ContentBlock } from "@/types/content"
 import type { Message } from "@/types/engine"
 import type { VendorId } from "@/types/task"
 import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
@@ -33,6 +31,11 @@ import { sessionAttached } from "../lib/attach-gate"
 import { bootPaneHost } from "../lib/host-boot"
 import { useBindings } from "../lib/keymap"
 import { ACTIVITY_POLL_MIN_MS, nextActivityPollDelay } from "../ops/activity-poll"
+import { MessageCard, resultsByCallId } from "./message-card"
+import { windowTail } from "./window"
+
+// Shared with the chat surface (chat/ChatRow.tsx imports from this module).
+export { BodyLines, bodyText, toolInputSummary } from "./message-card"
 
 export interface HistoryHostArgs {
   readonly worktree: string
@@ -55,217 +58,10 @@ export interface HistoryHostArgs {
 
 /** Lines of transcript scrolled per `j`/`k` keypress. */
 const SCROLL_STEP = 3
-/** One-line cap for a tool call's input summary. */
-const SUMMARY_MAX = 120
 
 function basename(p: string): string {
   const i = p.lastIndexOf("/")
   return i >= 0 ? p.slice(i + 1) : p
-}
-
-/** Relative age of an ISO timestamp ("3m", "2h", "4d"), or "" when unparseable. */
-function relativeTime(iso: string): string {
-  const ms = Date.parse(iso)
-  if (Number.isNaN(ms)) return ""
-  const secs = Math.max(0, Math.floor((Date.now() - ms) / 1000))
-  if (secs < 60) return `${secs}s`
-  const mins = Math.floor(secs / 60)
-  if (mins < 60) return `${mins}m`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h`
-  return `${Math.floor(hours / 24)}d`
-}
-
-/**
- * One-line label for a tool call — ported from the web `tool-display.ts` so both
- * surfaces read identically (don't reinvent). Picks the most meaningful string field
- * by priority (command → file_path → pattern → url → description → prompt → query), so
- * a Bash call reads as its command and a Read as its path; else compact JSON, truncated.
- */
-export function toolInputSummary(input: unknown): string {
-  if (input && typeof input === "object" && !Array.isArray(input)) {
-    const obj = input as Record<string, unknown>
-    const pick = (key: string): string | null => (typeof obj[key] === "string" ? (obj[key] as string) : null)
-    const candidate =
-      pick("command") ??
-      pick("file_path") ??
-      pick("pattern") ??
-      pick("url") ??
-      pick("description") ??
-      pick("prompt") ??
-      pick("query")
-    if (candidate) return candidate.length > SUMMARY_MAX ? `${candidate.slice(0, SUMMARY_MAX - 1)}…` : candidate
-  }
-  try {
-    const raw = JSON.stringify(input)
-    if (!raw || raw === "{}" || raw === "null") return ""
-    return raw.length > SUMMARY_MAX ? `${raw.slice(0, SUMMARY_MAX - 1)}…` : raw
-  } catch {
-    return ""
-  }
-}
-
-/** Full multi-line stringification of a tool result, for the expanded body. */
-export function bodyText(value: unknown): string {
-  if (typeof value === "string") return value
-  try {
-    return JSON.stringify(value, null, 2)
-  } catch {
-    return String(value)
-  }
-}
-
-/** Index tool_result blocks by their callId so a tool_call can show its result. */
-function resultsByCallId(messages: readonly Message[]): Map<string, Extract<ContentBlock, { type: "tool_result" }>> {
-  const map = new Map<string, Extract<ContentBlock, { type: "tool_result" }>>()
-  for (const m of messages) {
-    for (const b of m.blocks) {
-      if (b.type === "tool_result") map.set(b.callId, b)
-    }
-  }
-  return map
-}
-
-/** A tool-output / thinking body, one `<text>` per line so +/- diff lines tint. */
-export function BodyLines(props: { text: string; error?: boolean }) {
-  const { theme } = useTheme()
-  const lines = () => props.text.replace(/\s+$/, "").split("\n")
-  const lineColor = (line: string) => {
-    if (props.error) return theme.error
-    if (line.startsWith("+") && !line.startsWith("+++")) return theme.success
-    if (line.startsWith("-") && !line.startsWith("---")) return theme.error
-    return theme.textMuted
-  }
-  return (
-    <box flexDirection="column" paddingLeft={2} marginLeft={2} backgroundColor={theme.backgroundElement}>
-      <For each={lines()}>
-        {(line) => (
-          <text fg={lineColor(line)} wrapMode="word">
-            {line || " "}
-          </text>
-        )}
-      </For>
-    </box>
-  )
-}
-
-function BlockView(props: {
-  block: ContentBlock
-  result?: Extract<ContentBlock, { type: "tool_result" }>
-  expanded: boolean
-}) {
-  const { theme } = useTheme()
-  const block = props.block
-  switch (block.type) {
-    case "text":
-      // user-text is rendered as a card by MessageCard; this path is assistant/system.
-      return (
-        <text fg={theme.text} wrapMode="word">
-          {block.text}
-        </text>
-      )
-    case "thinking":
-      return (
-        <box flexDirection="column">
-          <text fg={theme.textMuted} attributes={TextAttributes.ITALIC} wrapMode="none">
-            {`✱ ${t("history.thinking")}${props.expanded ? "" : "…"}`}
-          </text>
-          <Show when={props.expanded && block.text.trim()}>
-            <BodyLines text={block.text} />
-          </Show>
-        </box>
-      )
-    case "tool_call": {
-      const ok = !props.result?.isError
-      const body = props.result ? bodyText(props.result.output) : ""
-      const summary = toolInputSummary(block.input)
-      return (
-        <box flexDirection="column">
-          <box flexDirection="row" gap={1}>
-            <text fg={ok ? theme.success : theme.error} wrapMode="none">
-              ⏺
-            </text>
-            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
-              {block.name}
-            </text>
-            <Show when={summary}>
-              <text fg={theme.textMuted} wrapMode="none">
-                {summary}
-              </text>
-            </Show>
-          </box>
-          <Show when={props.expanded && body.trim()}>
-            <BodyLines text={body} error={props.result?.isError} />
-          </Show>
-        </box>
-      )
-    }
-    case "tool_result":
-      // Attached to its tool_call above — never rendered standalone.
-      return null
-  }
-}
-
-function roleLabel(role: Message["role"]): string {
-  return role === "assistant"
-    ? t("history.role.assistant")
-    : role === "system"
-      ? t("history.role.system")
-      : t("history.role.user")
-}
-
-function MessageCard(props: {
-  msg: Message
-  results: Map<string, Extract<ContentBlock, { type: "tool_result" }>>
-  expanded: boolean
-}) {
-  const { theme } = useTheme()
-  const isUser = () => props.msg.role === "user"
-  const stamp = () => relativeTime(props.msg.timestamp)
-  // user text blocks → a tinted card with a ❯ glyph + time chip; everything
-  // else (assistant/system text, tools, thinking) renders flush below.
-  const userText = createMemo(() =>
-    isUser()
-      ? props.msg.blocks
-          .filter((b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text" && b.text.trim().length > 0)
-          .map((b) => b.text)
-          .join("\n")
-      : "",
-  )
-  const otherBlocks = () => (isUser() ? props.msg.blocks.filter((b) => b.type !== "text") : props.msg.blocks)
-  return (
-    <box flexDirection="column" paddingLeft={1} paddingRight={1} paddingBottom={1} gap={0}>
-      <Show when={isUser() && userText()}>
-        <box flexDirection="row" gap={1} paddingLeft={1} paddingRight={1} backgroundColor={theme.backgroundElement}>
-          <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
-            ❯
-          </text>
-          <text fg={theme.text} wrapMode="word" flexGrow={1}>
-            {userText()}
-          </text>
-          <Show when={stamp()}>
-            <text fg={theme.textMuted} wrapMode="none">
-              {stamp()}
-            </text>
-          </Show>
-        </box>
-      </Show>
-      <Show when={!isUser()}>
-        <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
-          {roleLabel(props.msg.role)}
-        </text>
-      </Show>
-      <For each={otherBlocks()}>
-        {(block) => (
-          <BlockView
-            block={block}
-            result={block.type === "tool_call" ? props.results.get(block.callId) : undefined}
-            expanded={props.expanded}
-          />
-        )}
-      </For>
-    </box>
-  )
 }
 
 function HistoryScreen(props: HistoryHostArgs) {
@@ -324,8 +120,11 @@ function HistoryScreen(props: HistoryHostArgs) {
     },
   )
   const messageList = (): Message[] => messages.latest ?? []
+  // Session-level stats stay computed over the FULL list; only the mounted
+  // rows are windowed (window.ts explains the native-renderable retention).
   const results = createMemo(() => resultsByCallId(messageList()))
   const tokenTotal = createMemo(() => messageList().reduce((sum, m) => sum + (m.usage?.output_tokens ?? 0), 0))
+  const tail = createMemo(() => windowTail(messageList()))
 
   const [expanded, setExpanded] = createSignal(false)
 
@@ -466,7 +265,14 @@ function HistoryScreen(props: HistoryHostArgs) {
               </box>
             }
           >
-            <For each={messageList()}>
+            <Show when={tail().hiddenCount > 0}>
+              <box paddingLeft={1} paddingRight={1} paddingBottom={1}>
+                <text fg={theme.textMuted} attributes={TextAttributes.ITALIC} wrapMode="none">
+                  {t("history.earlier", { count: tail().hiddenCount })}
+                </text>
+              </box>
+            </Show>
+            <For each={tail().visible}>
               {(msg) => <MessageCard msg={msg} results={results()} expanded={expanded()} />}
             </For>
           </Show>

--- a/packages/kobe/src/tui/history/message-card.tsx
+++ b/packages/kobe/src/tui/history/message-card.tsx
@@ -1,0 +1,226 @@
+/**
+ * Transcript row rendering for the history pane — extracted from `host.tsx`
+ * (500-line cap). One `MessageCard` per message: user turns are tinted cards
+ * with a `❯` glyph + relative-time chip, assistant text is plain, tool calls
+ * are a colored `⏺` status glyph + bold name + dim summary, and the expanded
+ * state reveals tool-output / thinking bodies. `BodyLines`, `bodyText` and
+ * `toolInputSummary` are shared with the chat surface (`chat/ChatRow.tsx`,
+ * via the `host.tsx` re-export) so both transcripts read identically.
+ */
+
+import type { ContentBlock } from "@/types/content"
+import type { Message } from "@/types/engine"
+import { TextAttributes } from "@opentui/core"
+import { For, Show, createMemo } from "solid-js"
+import { useTheme } from "../context/theme"
+import { t } from "../i18n"
+
+/** One-line cap for a tool call's input summary. */
+const SUMMARY_MAX = 120
+
+/** Relative age of an ISO timestamp ("3m", "2h", "4d"), or "" when unparseable. */
+function relativeTime(iso: string): string {
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return ""
+  const secs = Math.max(0, Math.floor((Date.now() - ms) / 1000))
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h`
+  return `${Math.floor(hours / 24)}d`
+}
+
+/**
+ * One-line label for a tool call — ported from the web `tool-display.ts` so both
+ * surfaces read identically (don't reinvent). Picks the most meaningful string field
+ * by priority (command → file_path → pattern → url → description → prompt → query), so
+ * a Bash call reads as its command and a Read as its path; else compact JSON, truncated.
+ */
+export function toolInputSummary(input: unknown): string {
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    const obj = input as Record<string, unknown>
+    const pick = (key: string): string | null => (typeof obj[key] === "string" ? (obj[key] as string) : null)
+    const candidate =
+      pick("command") ??
+      pick("file_path") ??
+      pick("pattern") ??
+      pick("url") ??
+      pick("description") ??
+      pick("prompt") ??
+      pick("query")
+    if (candidate) return candidate.length > SUMMARY_MAX ? `${candidate.slice(0, SUMMARY_MAX - 1)}…` : candidate
+  }
+  try {
+    const raw = JSON.stringify(input)
+    if (!raw || raw === "{}" || raw === "null") return ""
+    return raw.length > SUMMARY_MAX ? `${raw.slice(0, SUMMARY_MAX - 1)}…` : raw
+  } catch {
+    return ""
+  }
+}
+
+/** Full multi-line stringification of a tool result, for the expanded body. */
+export function bodyText(value: unknown): string {
+  if (typeof value === "string") return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+/** Index tool_result blocks by their callId so a tool_call can show its result. */
+export function resultsByCallId(
+  messages: readonly Message[],
+): Map<string, Extract<ContentBlock, { type: "tool_result" }>> {
+  const map = new Map<string, Extract<ContentBlock, { type: "tool_result" }>>()
+  for (const m of messages) {
+    for (const b of m.blocks) {
+      if (b.type === "tool_result") map.set(b.callId, b)
+    }
+  }
+  return map
+}
+
+/** A tool-output / thinking body, one `<text>` per line so +/- diff lines tint. */
+export function BodyLines(props: { text: string; error?: boolean }) {
+  const { theme } = useTheme()
+  const lines = () => props.text.replace(/\s+$/, "").split("\n")
+  const lineColor = (line: string) => {
+    if (props.error) return theme.error
+    if (line.startsWith("+") && !line.startsWith("+++")) return theme.success
+    if (line.startsWith("-") && !line.startsWith("---")) return theme.error
+    return theme.textMuted
+  }
+  return (
+    <box flexDirection="column" paddingLeft={2} marginLeft={2} backgroundColor={theme.backgroundElement}>
+      <For each={lines()}>
+        {(line) => (
+          <text fg={lineColor(line)} wrapMode="word">
+            {line || " "}
+          </text>
+        )}
+      </For>
+    </box>
+  )
+}
+
+function BlockView(props: {
+  block: ContentBlock
+  result?: Extract<ContentBlock, { type: "tool_result" }>
+  expanded: boolean
+}) {
+  const { theme } = useTheme()
+  const block = props.block
+  switch (block.type) {
+    case "text":
+      // user-text is rendered as a card by MessageCard; this path is assistant/system.
+      return (
+        <text fg={theme.text} wrapMode="word">
+          {block.text}
+        </text>
+      )
+    case "thinking":
+      return (
+        <box flexDirection="column">
+          <text fg={theme.textMuted} attributes={TextAttributes.ITALIC} wrapMode="none">
+            {`✱ ${t("history.thinking")}${props.expanded ? "" : "…"}`}
+          </text>
+          <Show when={props.expanded && block.text.trim()}>
+            <BodyLines text={block.text} />
+          </Show>
+        </box>
+      )
+    case "tool_call": {
+      const ok = !props.result?.isError
+      const body = props.result ? bodyText(props.result.output) : ""
+      const summary = toolInputSummary(block.input)
+      return (
+        <box flexDirection="column">
+          <box flexDirection="row" gap={1}>
+            <text fg={ok ? theme.success : theme.error} wrapMode="none">
+              ⏺
+            </text>
+            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
+              {block.name}
+            </text>
+            <Show when={summary}>
+              <text fg={theme.textMuted} wrapMode="none">
+                {summary}
+              </text>
+            </Show>
+          </box>
+          <Show when={props.expanded && body.trim()}>
+            <BodyLines text={body} error={props.result?.isError} />
+          </Show>
+        </box>
+      )
+    }
+    case "tool_result":
+      // Attached to its tool_call above — never rendered standalone.
+      return null
+  }
+}
+
+function roleLabel(role: Message["role"]): string {
+  return role === "assistant"
+    ? t("history.role.assistant")
+    : role === "system"
+      ? t("history.role.system")
+      : t("history.role.user")
+}
+
+export function MessageCard(props: {
+  msg: Message
+  results: Map<string, Extract<ContentBlock, { type: "tool_result" }>>
+  expanded: boolean
+}) {
+  const { theme } = useTheme()
+  const isUser = () => props.msg.role === "user"
+  const stamp = () => relativeTime(props.msg.timestamp)
+  // user text blocks → a tinted card with a ❯ glyph + time chip; everything
+  // else (assistant/system text, tools, thinking) renders flush below.
+  const userText = createMemo(() =>
+    isUser()
+      ? props.msg.blocks
+          .filter((b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text" && b.text.trim().length > 0)
+          .map((b) => b.text)
+          .join("\n")
+      : "",
+  )
+  const otherBlocks = () => (isUser() ? props.msg.blocks.filter((b) => b.type !== "text") : props.msg.blocks)
+  return (
+    <box flexDirection="column" paddingLeft={1} paddingRight={1} paddingBottom={1} gap={0}>
+      <Show when={isUser() && userText()}>
+        <box flexDirection="row" gap={1} paddingLeft={1} paddingRight={1} backgroundColor={theme.backgroundElement}>
+          <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
+            ❯
+          </text>
+          <text fg={theme.text} wrapMode="word" flexGrow={1}>
+            {userText()}
+          </text>
+          <Show when={stamp()}>
+            <text fg={theme.textMuted} wrapMode="none">
+              {stamp()}
+            </text>
+          </Show>
+        </box>
+      </Show>
+      <Show when={!isUser()}>
+        <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
+          {roleLabel(props.msg.role)}
+        </text>
+      </Show>
+      <For each={otherBlocks()}>
+        {(block) => (
+          <BlockView
+            block={block}
+            result={block.type === "tool_call" ? props.results.get(block.callId) : undefined}
+            expanded={props.expanded}
+          />
+        )}
+      </For>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui/history/window.ts
+++ b/packages/kobe/src/tui/history/window.ts
@@ -1,0 +1,27 @@
+/**
+ * Bounded-tail windowing for the history transcript. opentui's scrollbox only
+ * culls DRAWING — every off-screen row stays a live Renderable holding native
+ * Yoga nodes + Zig TextBuffers (off-JS-heap), so rendering a multi-day
+ * transcript in full leaks gigabytes of RSS (observed: ~126k messages →
+ * 13-22 GB). The pane therefore mounts only the last {@link RENDER_WINDOW}
+ * messages and shows a one-row "… N earlier messages" indicator; session-level
+ * stats (token total, tool-result index) still run over the FULL list.
+ *
+ * Vitest-safe: no @opentui import (see test/tui/history-window.test.ts).
+ */
+
+/** Max messages mounted in the scrollbox at once. */
+export const RENDER_WINDOW = 200
+
+export interface TailWindow<T> {
+  /** Messages elided before the window (0 → no indicator row). */
+  readonly hiddenCount: number
+  /** The rendered tail — at most `cap` items, same order as the input. */
+  readonly visible: readonly T[]
+}
+
+/** Slice `list` to its last `cap` items, reporting how many were elided. */
+export function windowTail<T>(list: readonly T[], cap: number = RENDER_WINDOW): TailWindow<T> {
+  if (list.length <= cap) return { hiddenCount: 0, visible: list }
+  return { hiddenCount: list.length - cap, visible: list.slice(list.length - cap) }
+}

--- a/packages/kobe/src/tui/i18n/messages/history.ts
+++ b/packages/kobe/src/tui/i18n/messages/history.ts
@@ -7,6 +7,7 @@
 export const en = {
   empty: "No engine history for this task.",
   loading: "loading…",
+  earlier: "… {count} earlier messages",
   sessionLabel: "Session",
   archivedTag: "ARCHIVED",
   liveTag: "● LIVE",
@@ -23,6 +24,7 @@ export const en = {
 export const zh: typeof en = {
   empty: "此任务没有引擎历史记录。",
   loading: "加载中…",
+  earlier: "… 之前还有 {count} 条消息",
   sessionLabel: "会话",
   archivedTag: "已归档",
   liveTag: "● 实时",

--- a/packages/kobe/src/tui/mock/host.tsx
+++ b/packages/kobe/src/tui/mock/host.tsx
@@ -94,6 +94,8 @@ function mockReader(): EngineHistoryReader {
       timestamp: new Date().toISOString(),
       blocks: [{ type: "text", text: `实时追加的第 ${n} 条消息 —— mtime 前进触发 refetch` }],
     })
+    // Cap the fake transcript so a mock left running for days stays bounded.
+    if (grown.length > 500) grown.splice(0, grown.length - 500)
     mtime += 1
   }, 2500)
   timer.unref?.()

--- a/packages/kobe/test/tui/history-window.test.ts
+++ b/packages/kobe/test/tui/history-window.test.ts
@@ -1,0 +1,49 @@
+/**
+ * windowTail (history pane bounded-tail windowing). Why this test matters:
+ * opentui's scrollbox culls drawing but keeps every mounted row alive as a
+ * native Renderable (Yoga nodes + Zig TextBuffers, off the JS heap), so the
+ * history pane leaks unboundedly if the windowing slice ever regresses to
+ * rendering the full transcript — a 3.5-day dev:mock run reached 13-22 GB RSS.
+ * The slice must keep the NEWEST messages (live tail) and report the exact
+ * elided count for the "… N earlier messages" indicator row.
+ */
+
+import { describe, expect, test } from "vitest"
+import { RENDER_WINDOW, windowTail } from "../../src/tui/history/window.ts"
+
+describe("windowTail", () => {
+  test("short list passes through untouched, no indicator", () => {
+    const list = ["a", "b", "c"]
+    const w = windowTail(list, 5)
+    expect(w.hiddenCount).toBe(0)
+    expect(w.visible).toBe(list)
+  })
+
+  test("exactly at the cap is not windowed", () => {
+    const list = [1, 2, 3]
+    const w = windowTail(list, 3)
+    expect(w.hiddenCount).toBe(0)
+    expect(w.visible).toBe(list)
+  })
+
+  test("over the cap keeps the newest tail and counts the elided head", () => {
+    const list = Array.from({ length: 10 }, (_, i) => i)
+    const w = windowTail(list, 4)
+    expect(w.hiddenCount).toBe(6)
+    expect(w.visible).toEqual([6, 7, 8, 9])
+  })
+
+  test("empty list", () => {
+    const w = windowTail([], 4)
+    expect(w.hiddenCount).toBe(0)
+    expect(w.visible).toEqual([])
+  })
+
+  test("default cap is RENDER_WINDOW", () => {
+    const list = Array.from({ length: RENDER_WINDOW + 7 }, (_, i) => i)
+    const w = windowTail(list)
+    expect(w.hiddenCount).toBe(7)
+    expect(w.visible.length).toBe(RENDER_WINDOW)
+    expect(w.visible[w.visible.length - 1]).toBe(RENDER_WINDOW + 6)
+  })
+})


### PR DESCRIPTION
## Summary

The history pane (`src/tui/history/host.tsx`) rendered the ENTIRE transcript via `<For each={messageList()}>` inside an opentui scrollbox. opentui scrollbox only culls drawing — every off-screen row stays a live Renderable holding native Yoga nodes + Zig TextBuffers (off the JS heap). A dev:mock run left for 3.5 days (~126k messages) reached **13-22 GB RSS**.

- Mount only the last **200** messages (`RENDER_WINDOW` in `src/tui/history/window.ts`, pure + unit-tested); a single "… N earlier messages" indicator row (i18n'd, en+zh) shows when messages are elided. Live tail + scroll behavior unchanged for the visible window.
- `tokenTotal` and the tool-result index stay computed over the FULL list — only mounted rows are windowed.
- Cap the dev:mock fake transcript at 500 messages so `dev:mock` can run for days.
- host.tsx was exactly at the 500-line cap: MessageCard/BlockView/BodyLines + helpers moved to `message-card.tsx` (host.tsx re-exports `BodyLines`/`bodyText`/`toolInputSummary` for `chat/ChatRow.tsx`).

## Files
- `packages/kobe/src/tui/history/host.tsx` — 306 lines
- `packages/kobe/src/tui/history/message-card.tsx` — 226 lines (new)
- `packages/kobe/src/tui/history/window.ts` — 27 lines (new)
- `packages/kobe/src/tui/mock/host.tsx` — 125 lines
- `packages/kobe/src/tui/i18n/messages/history.ts` — +2 keys (en/zh)
- `packages/kobe/test/tui/history-window.test.ts` — 5 tests (new)

## Gates
`bun run typecheck && bun run lint && bun run test && bun run build` all green at repo root; `scripts/check-i18n.ts` OK (396 keys × 2 locales).