### PR TITLE
fix: incremental append-aware transcript parsing with stable message identity

### DIFF
--- a/.changeset/history-incremental-parse.md
+++ b/.changeset/history-incremental-parse.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Chat history polling no longer re-parses the whole Claude transcript every tick: appends parse incrementally and already-seen messages keep stable identity, eliminating per-poll row churn in the history pane.

--- a/packages/kobe/src/engine/claude-code-local/history-parse.ts
+++ b/packages/kobe/src/engine/claude-code-local/history-parse.ts
@@ -1,0 +1,201 @@
+/**
+ * JSONL → Message[] parsing for Claude Code transcripts, plus an
+ * append-aware per-file cache so repeated `readHistory` polls don't
+ * re-parse the whole session every 2.5s tick.
+ *
+ * Why the cache exists: the history pane polls transcript mtime and calls
+ * `readHistory` on every change. A full re-parse builds a completely fresh
+ * `Message[]` with new object identities each call — Solid's `<For>` keys
+ * rows by reference, so all-new identities destroy + recreate every rendered
+ * row's native subtree per poll, and the re-parse itself is O(n²) allocation
+ * over a session's lifetime. Transcripts are append-only in the common case,
+ * so we cache the parsed prefix and only parse the appended slice, returning
+ * the SAME message object refs for already-seen records.
+ *
+ * Soundness: `parseJsonl` is line-local (no cross-line state), so
+ * `parse(prefix) ++ parse(appendedSlice)` reproduces `parse(whole)` exactly,
+ * in file order. The cache boundary always sits on a `\n` so a partially
+ * flushed trailing line is never split across prefix/suffix — the
+ * un-terminated tail is re-parsed fresh every call and never cached.
+ * `sortByTimestamp` then reorders the same objects, so the final array has
+ * identical content/order to a full parse, with stable element identities.
+ *
+ * Rewrite/truncation (compaction, resume-branch rewrites) is detected by
+ * validating the cached prefix: previous prefix length + a SHA-256 of that
+ * prefix (we never retain the previous file content itself). Any mismatch
+ * falls back to a full re-parse and replaces the cache entry.
+ */
+
+import { createHash } from "node:crypto"
+import type { Message } from "@/types/engine"
+import { isJsonlLineWithinBound } from "../file-bounds"
+import { normalizeClaudeContent } from "./normalize"
+import { isClaudeCommandBreadcrumb, isSyntheticClaudeRecord } from "./synthetic"
+
+interface CacheEntry {
+  /** Char length of the cached prefix — always ends at a `\n` boundary. */
+  prefixLength: number
+  /** SHA-256 hex of `raw.slice(0, prefixLength)` at cache time. */
+  prefixHash: string
+  /** Messages parsed from that prefix, in file order (pre-sort). */
+  messages: Message[]
+}
+
+// ponytail: FIFO cap, not LRU — a pane process only ever polls a handful of
+// session files; switch to LRU if panes start juggling many sessions.
+const MAX_CACHED_FILES = 8
+const cache = new Map<string, CacheEntry>()
+
+function hashPrefix(raw: string, length: number): string {
+  return createHash("sha256").update(raw.slice(0, length)).digest("hex")
+}
+
+function remember(filePath: string, entry: CacheEntry): void {
+  cache.delete(filePath) // re-insert so Map order tracks recency of writes
+  cache.set(filePath, entry)
+  if (cache.size > MAX_CACHED_FILES) {
+    const oldest = cache.keys().next().value
+    if (oldest !== undefined) cache.delete(oldest)
+  }
+}
+
+/**
+ * Parse `raw` (the full current contents of `filePath`) into sorted
+ * conversation messages, reusing the cached parse of the unchanged prefix
+ * when the file only appended since the last call. Message objects for
+ * already-seen records keep their identity across calls.
+ */
+export function parseSessionRaw(filePath: string, raw: string, sessionId: string): Message[] {
+  // Complete-line boundary: everything past the last `\n` may be a
+  // partially flushed record — parse it fresh each call, never cache it.
+  const stableLength = raw.lastIndexOf("\n") + 1
+  const entry = cache.get(filePath)
+
+  let prefixMessages: Message[]
+  if (entry && entry.prefixLength <= stableLength && hashPrefix(raw, entry.prefixLength) === entry.prefixHash) {
+    // Append-only since last read: parse just the new complete lines.
+    prefixMessages =
+      entry.prefixLength < stableLength
+        ? entry.messages.concat(parseJsonl(raw.slice(entry.prefixLength, stableLength), sessionId))
+        : entry.messages
+  } else {
+    // First read, rewrite, or truncation: full re-parse of the stable prefix.
+    prefixMessages = parseJsonl(raw.slice(0, stableLength), sessionId)
+  }
+
+  if (!entry || entry.prefixLength !== stableLength || entry.messages !== prefixMessages) {
+    remember(filePath, {
+      prefixLength: stableLength,
+      prefixHash: hashPrefix(raw, stableLength),
+      messages: prefixMessages,
+    })
+  }
+
+  const tail = raw.slice(stableLength)
+  const all = tail.trim().length > 0 ? prefixMessages.concat(parseJsonl(tail, sessionId)) : prefixMessages
+  return sortByTimestamp(all)
+}
+
+/**
+ * Sort messages by their `timestamp` ASC (oldest first → newest last).
+ *
+ * Claude Code's JSONL is a DAG (records carry `parentUuid` for branching
+ * resumes), so file-order is NOT strictly chronological — a resumed
+ * session can interleave records from different branches. The chat pane
+ * relies on `past[]` being chronological so newest messages render at
+ * the bottom; we sort here at the engine boundary so every consumer
+ * gets the same shape.
+ *
+ * Stable sort: ties (same ISO timestamp) keep file-order, which roughly
+ * preserves causal ordering even at sub-millisecond ties.
+ */
+function sortByTimestamp(messages: Message[]): Message[] {
+  return messages
+    .map((msg, idx) => ({ msg, idx }))
+    .sort((a, b) => {
+      if (a.msg.timestamp < b.msg.timestamp) return -1
+      if (a.msg.timestamp > b.msg.timestamp) return 1
+      return a.idx - b.idx
+    })
+    .map((entry) => entry.msg)
+}
+
+/**
+ * Parse a JSONL blob into the subset of records that look like
+ * conversation messages (role + content). Exported for unit testing.
+ * Line-local: each line parses independently, so a blob may be parsed
+ * in slices and concatenated (the append-cache above relies on this).
+ */
+export function parseJsonl(raw: string, sessionId: string): Message[] {
+  const out: Message[] = []
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    // Skip a pathological mega-line before parsing — same outcome as a
+    // malformed line, but without risking a hang in JSON.parse.
+    if (!isJsonlLineWithinBound(trimmed)) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!isObject(parsed)) continue
+    const msg = extractMessage(parsed, sessionId)
+    if (msg) out.push(msg)
+  }
+  return out
+}
+
+function extractMessage(record: Record<string, unknown>, fallbackSessionId: string): Message | null {
+  // The on-disk shape commonly looks like:
+  //   { type: "user"|"assistant", message: { role, content }, timestamp, sessionId }
+  // but older records sometimes have role+content at the top level.
+  // Drop Claude-injected synthetic rows (local-command caveat, compaction
+  // summary) — the flags live on the OUTER record, and Claude's own
+  // human-turn/title paths skip exactly these. Without this, a session that
+  // opens with a slash/bash command auto-titles from the injected boilerplate.
+  if (isSyntheticClaudeRecord(record)) return null
+
+  const inner = isObject(record.message) ? (record.message as Record<string, unknown>) : record
+
+  const role = inner.role
+  if (role !== "user" && role !== "assistant" && role !== "system") return null
+
+  if (!("content" in inner)) return null
+  // Normalize Claude's vendor shape (string OR content-block array) into
+  // the neutral ContentBlock[] surfaced via Message.blocks. Empty arrays
+  // are kept so callers can distinguish "message with no renderable
+  // content" from "no message" (extractMessage returns null for the latter).
+  const blocks = normalizeClaudeContent(inner.content)
+  // A `<command-name>…` breadcrumb is a plain (un-flagged) user record Claude
+  // writes before the real prompt; drop it so it can't become the title.
+  if (role === "user" && isClaudeCommandBreadcrumb(blocks)) return null
+
+  const ts = typeof record.timestamp === "string" ? (record.timestamp as string) : new Date().toISOString()
+  const sid = typeof record.sessionId === "string" ? (record.sessionId as string) : fallbackSessionId
+
+  const usage = extractUsage(inner.usage)
+  return usage
+    ? { role, blocks, timestamp: ts, sessionId: sid, usage }
+    : { role, blocks, timestamp: ts, sessionId: sid }
+}
+
+function extractUsage(v: unknown): Message["usage"] {
+  if (!isObject(v)) return undefined
+  const inTok = typeof v.input_tokens === "number" ? v.input_tokens : undefined
+  const outTok = typeof v.output_tokens === "number" ? v.output_tokens : undefined
+  if (inTok === undefined || outTok === undefined) return undefined
+  const cacheRead = typeof v.cache_read_input_tokens === "number" ? v.cache_read_input_tokens : undefined
+  const cacheCreate = typeof v.cache_creation_input_tokens === "number" ? v.cache_creation_input_tokens : undefined
+  return {
+    input_tokens: inTok,
+    output_tokens: outTok,
+    ...(cacheRead !== undefined ? { cache_read_input_tokens: cacheRead } : {}),
+    ...(cacheCreate !== undefined ? { cache_creation_input_tokens: cacheCreate } : {}),
+  }
+}
+
+export function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+}

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -41,8 +41,11 @@ import { homedir } from "node:os"
 import path from "node:path"
 import type { Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
-import { normalizeClaudeContent } from "./normalize"
-import { isClaudeCommandBreadcrumb, isSyntheticClaudeRecord } from "./synthetic"
+import { isObject, parseSessionRaw } from "./history-parse"
+
+// Parsing (JSONL → Message[], sorting, and the append-aware per-file cache)
+// lives in ./history-parse; re-exported here for existing consumers/tests.
+export { parseJsonl } from "./history-parse"
 
 /** Optional FS injection for tests. */
 export interface HistoryDeps {
@@ -161,6 +164,11 @@ export async function latestTranscriptMtimeForWorktree(worktree: string): Promis
  * Returns `[]` if the session file isn't found or contains no messages.
  * Never throws on parse failure — bad lines are skipped (Claude Code's
  * JSONL evolves over time and old sessions may have unfamiliar shapes).
+ *
+ * Consecutive calls for the same file are append-aware: the unchanged
+ * prefix is served from a per-file parse cache with stable Message object
+ * identities (see ./history-parse), so the polling chat pane doesn't churn
+ * row identity — a rewrite/truncation falls back to a full re-parse.
  */
 export async function readHistory(sessionId: string, deps: HistoryDeps = defaultDeps): Promise<Message[]> {
   const root = deps.projectsDir()
@@ -174,7 +182,7 @@ export async function readHistory(sessionId: string, deps: HistoryDeps = default
     } catch {
       continue
     }
-    return sortByTimestamp(parseJsonl(raw, sessionId))
+    return parseSessionRaw(candidate, raw, sessionId)
   }
   return []
 }
@@ -203,108 +211,6 @@ export async function deleteHistory(sessionId: string, deps: HistoryDeps = defau
       throw err
     }
   }
-}
-
-/**
- * Sort messages by their `timestamp` ASC (oldest first → newest last).
- *
- * Claude Code's JSONL is a DAG (records carry `parentUuid` for branching
- * resumes), so file-order is NOT strictly chronological — a resumed
- * session can interleave records from different branches. The chat pane
- * relies on `past[]` being chronological so newest messages render at
- * the bottom; we sort here at the engine boundary so every consumer
- * gets the same shape.
- *
- * Stable sort: ties (same ISO timestamp) keep file-order, which roughly
- * preserves causal ordering even at sub-millisecond ties.
- */
-function sortByTimestamp(messages: Message[]): Message[] {
-  return messages
-    .map((msg, idx) => ({ msg, idx }))
-    .sort((a, b) => {
-      if (a.msg.timestamp < b.msg.timestamp) return -1
-      if (a.msg.timestamp > b.msg.timestamp) return 1
-      return a.idx - b.idx
-    })
-    .map((entry) => entry.msg)
-}
-
-/**
- * Parse a JSONL blob into the subset of records that look like
- * conversation messages (role + content). Exported for unit testing.
- */
-export function parseJsonl(raw: string, sessionId: string): Message[] {
-  const out: Message[] = []
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    // Skip a pathological mega-line before parsing — same outcome as a
-    // malformed line, but without risking a hang in JSON.parse.
-    if (!isJsonlLineWithinBound(trimmed)) continue
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(trimmed)
-    } catch {
-      continue
-    }
-    if (!isObject(parsed)) continue
-    const msg = extractMessage(parsed, sessionId)
-    if (msg) out.push(msg)
-  }
-  return out
-}
-
-function extractMessage(record: Record<string, unknown>, fallbackSessionId: string): Message | null {
-  // The on-disk shape commonly looks like:
-  //   { type: "user"|"assistant", message: { role, content }, timestamp, sessionId }
-  // but older records sometimes have role+content at the top level.
-  // Drop Claude-injected synthetic rows (local-command caveat, compaction
-  // summary) — the flags live on the OUTER record, and Claude's own
-  // human-turn/title paths skip exactly these. Without this, a session that
-  // opens with a slash/bash command auto-titles from the injected boilerplate.
-  if (isSyntheticClaudeRecord(record)) return null
-
-  const inner = isObject(record.message) ? (record.message as Record<string, unknown>) : record
-
-  const role = inner.role
-  if (role !== "user" && role !== "assistant" && role !== "system") return null
-
-  if (!("content" in inner)) return null
-  // Normalize Claude's vendor shape (string OR content-block array) into
-  // the neutral ContentBlock[] surfaced via Message.blocks. Empty arrays
-  // are kept so callers can distinguish "message with no renderable
-  // content" from "no message" (extractMessage returns null for the latter).
-  const blocks = normalizeClaudeContent(inner.content)
-  // A `<command-name>…` breadcrumb is a plain (un-flagged) user record Claude
-  // writes before the real prompt; drop it so it can't become the title.
-  if (role === "user" && isClaudeCommandBreadcrumb(blocks)) return null
-
-  const ts = typeof record.timestamp === "string" ? (record.timestamp as string) : new Date().toISOString()
-  const sid = typeof record.sessionId === "string" ? (record.sessionId as string) : fallbackSessionId
-
-  const usage = extractUsage(inner.usage)
-  return usage
-    ? { role, blocks, timestamp: ts, sessionId: sid, usage }
-    : { role, blocks, timestamp: ts, sessionId: sid }
-}
-
-function extractUsage(v: unknown): Message["usage"] {
-  if (!isObject(v)) return undefined
-  const inTok = typeof v.input_tokens === "number" ? v.input_tokens : undefined
-  const outTok = typeof v.output_tokens === "number" ? v.output_tokens : undefined
-  if (inTok === undefined || outTok === undefined) return undefined
-  const cacheRead = typeof v.cache_read_input_tokens === "number" ? v.cache_read_input_tokens : undefined
-  const cacheCreate = typeof v.cache_creation_input_tokens === "number" ? v.cache_creation_input_tokens : undefined
-  return {
-    input_tokens: inTok,
-    output_tokens: outTok,
-    ...(cacheRead !== undefined ? { cache_read_input_tokens: cacheRead } : {}),
-    ...(cacheCreate !== undefined ? { cache_creation_input_tokens: cacheCreate } : {}),
-  }
-}
-
-function isObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v)
 }
 
 /**

--- a/packages/kobe/test/engine/claude-history-incremental.test.ts
+++ b/packages/kobe/test/engine/claude-history-incremental.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest"
+import type { HistoryDeps } from "../../src/engine/claude-code-local/history.ts"
+import { readHistory } from "../../src/engine/claude-code-local/history.ts"
+
+/**
+ * Why these tests matter: the chat pane polls `readHistory` every ~2.5s and
+ * Solid's `<For>` keys rows by object reference. If each poll returns fresh
+ * Message objects for unchanged records, every rendered row's native subtree
+ * is destroyed and recreated per tick. The append-aware cache must therefore
+ * (a) return the SAME object refs for already-seen messages when the file only
+ * appended, and (b) still produce output identical to a full re-parse —
+ * including on rewrite/truncation (compaction, branch rewrites), where it must
+ * fall back rather than serve stale prefix state.
+ */
+
+function record(role: "user" | "assistant", text: string, ts: string): string {
+  return JSON.stringify({ type: role, message: { role, content: text }, timestamp: ts, sessionId: "sid" })
+}
+
+/**
+ * Fake FS where the "file" contents are mutable between reads. Each test uses
+ * a unique projectsDir so the module-level cache (keyed by file path) never
+ * bleeds state across tests.
+ */
+function fakeDeps(name: string, sessionId: string): { deps: HistoryDeps; set: (raw: string) => void } {
+  let raw = ""
+  const root = `/fake-${name}`
+  const deps: HistoryDeps = {
+    projectsDir: () => root,
+    readdir: async () => ["proj"],
+    readFile: async (p) => {
+      if (p !== `${root}/proj/${sessionId}.jsonl`) throw new Error("ENOENT")
+      return raw
+    },
+    pathExists: async () => true,
+  }
+  return {
+    deps,
+    set: (next) => {
+      raw = next
+    },
+  }
+}
+
+describe("readHistory append-aware cache", () => {
+  it("append: already-seen messages keep object identity; new ones are appended", async () => {
+    const { deps, set } = fakeDeps("append", "s1")
+    const l1 = record("user", "first", "2026-01-01T00:00:01.000Z")
+    const l2 = record("assistant", "second", "2026-01-01T00:00:02.000Z")
+    set(`${l1}\n${l2}\n`)
+
+    const first = await readHistory("s1", deps)
+    expect(first.map((m) => m.blocks)).toEqual([[{ type: "text", text: "first" }], [{ type: "text", text: "second" }]])
+
+    const l3 = record("user", "third", "2026-01-01T00:00:03.000Z")
+    set(`${l1}\n${l2}\n${l3}\n`)
+    const second = await readHistory("s1", deps)
+
+    expect(second).toHaveLength(3)
+    // Identity-stable prefix: same refs, not just deep-equal copies.
+    expect(second[0]).toBe(first[0])
+    expect(second[1]).toBe(first[1])
+    expect(second[2]?.blocks).toEqual([{ type: "text", text: "third" }])
+  })
+
+  it("append with an out-of-order timestamp still sorts like a full parse", async () => {
+    const { deps, set } = fakeDeps("resort", "s2")
+    const late = record("assistant", "late", "2026-01-01T00:00:09.000Z")
+    set(`${late}\n`)
+    const first = await readHistory("s2", deps)
+
+    // A resumed-branch record can land in the file AFTER records that carry
+    // an earlier timestamp; output must stay timestamp-sorted.
+    const early = record("user", "early", "2026-01-01T00:00:01.000Z")
+    set(`${late}\n${early}\n`)
+    const second = await readHistory("s2", deps)
+
+    expect(second.map((m) => m.blocks[0])).toEqual([
+      { type: "text", text: "early" },
+      { type: "text", text: "late" },
+    ])
+    expect(second[1]).toBe(first[0])
+  })
+
+  it("rewrite: a changed prefix falls back to a full re-parse", async () => {
+    const { deps, set } = fakeDeps("rewrite", "s3")
+    const l1 = record("user", "original", "2026-01-01T00:00:01.000Z")
+    set(`${l1}\n`)
+    await readHistory("s3", deps)
+
+    // Same length or longer doesn't matter — the prefix hash must mismatch.
+    const rewritten = record("user", "compacted summary instead", "2026-01-01T00:00:01.000Z")
+    const extra = record("assistant", "after rewrite", "2026-01-01T00:00:02.000Z")
+    set(`${rewritten}\n${extra}\n`)
+
+    const out = await readHistory("s3", deps)
+    expect(out.map((m) => m.blocks[0])).toEqual([
+      { type: "text", text: "compacted summary instead" },
+      { type: "text", text: "after rewrite" },
+    ])
+  })
+
+  it("truncation: a shorter file falls back to a full re-parse", async () => {
+    const { deps, set } = fakeDeps("truncate", "s4")
+    const l1 = record("user", "keep", "2026-01-01T00:00:01.000Z")
+    const l2 = record("assistant", "dropped by truncation", "2026-01-01T00:00:02.000Z")
+    set(`${l1}\n${l2}\n`)
+    const first = await readHistory("s4", deps)
+    expect(first).toHaveLength(2)
+
+    set(`${l1}\n`)
+    const second = await readHistory("s4", deps)
+    expect(second).toHaveLength(1)
+    expect(second[0]?.blocks).toEqual([{ type: "text", text: "keep" }])
+
+    // And the cache is REPLACED by the truncated state: appending after the
+    // truncation parses from the new baseline, not the stale long prefix.
+    const l3 = record("assistant", "fresh reply", "2026-01-01T00:00:03.000Z")
+    set(`${l1}\n${l3}\n`)
+    const third = await readHistory("s4", deps)
+    expect(third.map((m) => m.blocks[0])).toEqual([
+      { type: "text", text: "keep" },
+      { type: "text", text: "fresh reply" },
+    ])
+    expect(third[0]).toBe(second[0])
+  })
+
+  it("a partially flushed trailing line is never split by the cache boundary", async () => {
+    const { deps, set } = fakeDeps("partial", "s5")
+    const l1 = record("user", "done line", "2026-01-01T00:00:01.000Z")
+    const l2 = record("assistant", "mid-flush", "2026-01-01T00:00:02.000Z")
+    // Snapshot taken mid-write: l2 has no trailing newline and is only half
+    // on disk. A naive byte-offset cache would anchor here and later parse
+    // only the REST of l2 — losing the message vs a full parse.
+    set(`${l1}\n${l2.slice(0, 20)}`)
+    const first = await readHistory("s5", deps)
+    expect(first).toHaveLength(1)
+
+    set(`${l1}\n${l2}\n`)
+    const second = await readHistory("s5", deps)
+    expect(second.map((m) => m.blocks[0])).toEqual([
+      { type: "text", text: "done line" },
+      { type: "text", text: "mid-flush" },
+    ])
+    expect(second[0]).toBe(first[0])
+  })
+
+  it("repeat read with no change returns the same message refs", async () => {
+    const { deps, set } = fakeDeps("stable", "s6")
+    set(`${record("user", "hello", "2026-01-01T00:00:01.000Z")}\n`)
+    const a = await readHistory("s6", deps)
+    const b = await readHistory("s6", deps)
+    expect(b[0]).toBe(a[0])
+  })
+})


### PR DESCRIPTION
The history pane polls `readHistory` every ~2.5s; each poll re-parsed the whole session JSONL into all-new `Message` objects, so Solid's `<For>` (keyed by reference) destroyed and recreated every rendered row per tick, plus O(n²) allocation over a session.

`readHistory` (claude-code-local) now keeps a small per-file cache of the parsed prefix (prefix length + SHA-256, anchored at the last newline so a partially flushed line is never split) and parses only appended lines, returning the same object refs for already-seen messages. A rewrite or truncation (compaction, branch rewrite) fails prefix validation and falls back to a full re-parse. Output content/order is identical to a full parse — `parseJsonl` is line-local and `sortByTimestamp` runs over the concatenated file-order array. Parsing moved to `history-parse.ts` to stay under the 500-line cap; `parseJsonl` is re-exported from `history.ts` for existing consumers.

Follow-up: the codex-local and copilot-local readers still full-re-parse per poll and could adopt the same cache — deliberately untouched in this slice.

Gates: typecheck, lint, test (incl. 6 new unit tests: append identity reuse, out-of-order append re-sort, rewrite fallback, truncation fallback + cache replacement, partial-line boundary, no-change identity), build — all green locally.