### PR TITLE
fix: share the append-aware transcript cache across codex and copilot readers

### DIFF
--- a/.changeset/reader-cache-port.md
+++ b/.changeset/reader-cache-port.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Codex and Copilot history readers now share the append-aware transcript parse cache (previously Claude-only), so the ~2.5s history polls parse only newly appended lines and chat rows keep stable identity instead of re-rendering every tick.

--- a/packages/kobe/src/engine/claude-code-local/history-parse.ts
+++ b/packages/kobe/src/engine/claude-code-local/history-parse.ts
@@ -1,63 +1,25 @@
 /**
- * JSONL → Message[] parsing for Claude Code transcripts, plus an
- * append-aware per-file cache so repeated `readHistory` polls don't
- * re-parse the whole session every 2.5s tick.
+ * JSONL → Message[] parsing for Claude Code transcripts. The append-aware
+ * per-file cache lives in `../history-cache.ts` (shared with the codex and
+ * copilot readers); this module supplies the Claude-specific line parser.
  *
- * Why the cache exists: the history pane polls transcript mtime and calls
- * `readHistory` on every change. A full re-parse builds a completely fresh
- * `Message[]` with new object identities each call — Solid's `<For>` keys
- * rows by reference, so all-new identities destroy + recreate every rendered
- * row's native subtree per poll, and the re-parse itself is O(n²) allocation
- * over a session's lifetime. Transcripts are append-only in the common case,
- * so we cache the parsed prefix and only parse the appended slice, returning
- * the SAME message object refs for already-seen records.
- *
- * Soundness: `parseJsonl` is line-local (no cross-line state), so
- * `parse(prefix) ++ parse(appendedSlice)` reproduces `parse(whole)` exactly,
- * in file order. The cache boundary always sits on a `\n` so a partially
- * flushed trailing line is never split across prefix/suffix — the
- * un-terminated tail is re-parsed fresh every call and never cached.
- * `sortByTimestamp` then reorders the same objects, so the final array has
- * identical content/order to a full parse, with stable element identities.
- *
- * Rewrite/truncation (compaction, resume-branch rewrites) is detected by
- * validating the cached prefix: previous prefix length + a SHA-256 of that
- * prefix (we never retain the previous file content itself). Any mismatch
- * falls back to a full re-parse and replaces the cache entry.
+ * Soundness of caching here: `parseJsonl` is line-local (no cross-line
+ * state), so `parse(prefix) ++ parse(appendedSlice)` reproduces
+ * `parse(whole)` exactly, in file order. `sortByTimestamp` then reorders
+ * the same objects, so the final array has identical content/order to a
+ * full parse, with stable element identities.
  */
 
-import { createHash } from "node:crypto"
 import type { Message } from "@/types/engine"
 import { isJsonlLineWithinBound } from "../file-bounds"
+import { createAppendParseCache, sortByTimestamp } from "../history-cache"
 import { normalizeClaudeContent } from "./normalize"
 import { isClaudeCommandBreadcrumb, isSyntheticClaudeRecord } from "./synthetic"
 
-interface CacheEntry {
-  /** Char length of the cached prefix — always ends at a `\n` boundary. */
-  prefixLength: number
-  /** SHA-256 hex of `raw.slice(0, prefixLength)` at cache time. */
-  prefixHash: string
-  /** Messages parsed from that prefix, in file order (pre-sort). */
-  messages: Message[]
-}
-
-// ponytail: FIFO cap, not LRU — a pane process only ever polls a handful of
-// session files; switch to LRU if panes start juggling many sessions.
-const MAX_CACHED_FILES = 8
-const cache = new Map<string, CacheEntry>()
-
-function hashPrefix(raw: string, length: number): string {
-  return createHash("sha256").update(raw.slice(0, length)).digest("hex")
-}
-
-function remember(filePath: string, entry: CacheEntry): void {
-  cache.delete(filePath) // re-insert so Map order tracks recency of writes
-  cache.set(filePath, entry)
-  if (cache.size > MAX_CACHED_FILES) {
-    const oldest = cache.keys().next().value
-    if (oldest !== undefined) cache.delete(oldest)
-  }
-}
+const cache = createAppendParseCache<Message[], string>({
+  initial: () => [],
+  parseChunk: (chunk, prev, sessionId) => prev.concat(parseJsonl(chunk, sessionId)),
+})
 
 /**
  * Parse `raw` (the full current contents of `filePath`) into sorted
@@ -66,58 +28,7 @@ function remember(filePath: string, entry: CacheEntry): void {
  * already-seen records keep their identity across calls.
  */
 export function parseSessionRaw(filePath: string, raw: string, sessionId: string): Message[] {
-  // Complete-line boundary: everything past the last `\n` may be a
-  // partially flushed record — parse it fresh each call, never cache it.
-  const stableLength = raw.lastIndexOf("\n") + 1
-  const entry = cache.get(filePath)
-
-  let prefixMessages: Message[]
-  if (entry && entry.prefixLength <= stableLength && hashPrefix(raw, entry.prefixLength) === entry.prefixHash) {
-    // Append-only since last read: parse just the new complete lines.
-    prefixMessages =
-      entry.prefixLength < stableLength
-        ? entry.messages.concat(parseJsonl(raw.slice(entry.prefixLength, stableLength), sessionId))
-        : entry.messages
-  } else {
-    // First read, rewrite, or truncation: full re-parse of the stable prefix.
-    prefixMessages = parseJsonl(raw.slice(0, stableLength), sessionId)
-  }
-
-  if (!entry || entry.prefixLength !== stableLength || entry.messages !== prefixMessages) {
-    remember(filePath, {
-      prefixLength: stableLength,
-      prefixHash: hashPrefix(raw, stableLength),
-      messages: prefixMessages,
-    })
-  }
-
-  const tail = raw.slice(stableLength)
-  const all = tail.trim().length > 0 ? prefixMessages.concat(parseJsonl(tail, sessionId)) : prefixMessages
-  return sortByTimestamp(all)
-}
-
-/**
- * Sort messages by their `timestamp` ASC (oldest first → newest last).
- *
- * Claude Code's JSONL is a DAG (records carry `parentUuid` for branching
- * resumes), so file-order is NOT strictly chronological — a resumed
- * session can interleave records from different branches. The chat pane
- * relies on `past[]` being chronological so newest messages render at
- * the bottom; we sort here at the engine boundary so every consumer
- * gets the same shape.
- *
- * Stable sort: ties (same ISO timestamp) keep file-order, which roughly
- * preserves causal ordering even at sub-millisecond ties.
- */
-function sortByTimestamp(messages: Message[]): Message[] {
-  return messages
-    .map((msg, idx) => ({ msg, idx }))
-    .sort((a, b) => {
-      if (a.msg.timestamp < b.msg.timestamp) return -1
-      if (a.msg.timestamp > b.msg.timestamp) return 1
-      return a.idx - b.idx
-    })
-    .map((entry) => entry.msg)
+  return sortByTimestamp(cache(filePath, raw, sessionId))
 }
 
 /**

--- a/packages/kobe/src/engine/codex-local/history-parse.ts
+++ b/packages/kobe/src/engine/codex-local/history-parse.ts
@@ -1,0 +1,284 @@
+/**
+ * Rollout JSONL → Message[] parsing for Codex transcripts, on top of the
+ * shared append-aware per-file cache (`../history-cache.ts`) so repeated
+ * `readHistory` polls don't re-parse the whole rollout every ~2.5s tick.
+ *
+ * One fold pass extracts BOTH the conversation messages (`response_item`
+ * records) and the latest `turn.completed` usage snapshot — previously two
+ * separate full scans of the raw text per poll. The fold is line-local
+ * apart from the usage carry-over (latest snapshot + its timestamp), which
+ * threads through the cached state, so folding the appended slice onto the
+ * cached prefix reproduces a full parse exactly, with stable message
+ * object identities.
+ */
+
+import type { ContentBlock } from "@/types/content"
+import type { EngineHistory, EngineUsageSnapshot, Message } from "@/types/engine"
+import { isJsonlLineWithinBound } from "../file-bounds"
+import { createAppendParseCache, sortByTimestamp } from "../history-cache"
+import { normalizeCodexContent } from "./normalize"
+import { isSyntheticCodexUserRow } from "./synthetic"
+import { codexUsageToSnapshot } from "./usage"
+
+interface CodexParseState {
+  /** `response_item` messages in file order (pre-sort). */
+  readonly messages: Message[]
+  /** Winning `turn.completed` usage snapshot so far. */
+  readonly latestUsage: EngineUsageSnapshot | undefined
+  /** Timestamp (epoch ms) of that snapshot, when it carried one. */
+  readonly latestUsageTimestampMs: number | null
+}
+
+const emptyState: CodexParseState = { messages: [], latestUsage: undefined, latestUsageTimestampMs: null }
+
+const cache = createAppendParseCache<CodexParseState, string>({
+  initial: () => emptyState,
+  parseChunk: foldRolloutChunk,
+})
+
+/**
+ * Parse `raw` (the full current contents of rollout `filePath`) into
+ * sorted messages + the latest usage snapshot, reusing the cached fold of
+ * the unchanged prefix when the file only appended since the last call.
+ */
+export function parseRolloutRaw(filePath: string, raw: string, sessionId: string): EngineHistory {
+  const state = cache(filePath, raw, sessionId)
+  const messages = sortByTimestamp(state.messages)
+  return { messages, ...(state.latestUsage ? { usageMetrics: state.latestUsage } : {}) }
+}
+
+/** Uncached message-only parse. Exported for unit testing. */
+export function parseJsonl(raw: string, sessionId: string): Message[] {
+  return foldRolloutChunk(raw, emptyState, sessionId).messages
+}
+
+/** Latest `turn.completed` usage in `raw`, uncached. Exported for unit testing. */
+export function deriveCodexUsageMetrics(raw: string): EngineUsageSnapshot | undefined {
+  return foldRolloutChunk(raw, emptyState, "").latestUsage
+}
+
+/** Fold rollout lines onto `prev` without mutating it (cache contract). */
+function foldRolloutChunk(chunk: string, prev: CodexParseState, sessionId: string): CodexParseState {
+  const messages = prev.messages.slice()
+  let latestUsage = prev.latestUsage
+  let latestUsageTimestampMs = prev.latestUsageTimestampMs
+
+  for (const line of chunk.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    if (!isJsonlLineWithinBound(trimmed)) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!isObject(parsed)) continue
+
+    if (parsed.type === "response_item") {
+      const payload = isObject(parsed.payload) ? parsed.payload : undefined
+      if (!payload) continue
+      const ts = typeof parsed.timestamp === "string" ? parsed.timestamp : new Date().toISOString()
+      const msg = normalizeCodexResponseItem(payload, ts, sessionId)
+      if (msg) messages.push(msg)
+      continue
+    }
+
+    if (parsed.type !== "turn.completed") continue
+    const usage = isObject(parsed.usage) ? parsed.usage : undefined
+    if (!usage) continue
+    const snapshot = codexUsageToSnapshot(usage)
+    if (!snapshot) continue
+    const timestampMs = typeof parsed.timestamp === "string" ? parseTimestampMs(parsed.timestamp) : null
+    if (timestampMs !== null && (latestUsageTimestampMs === null || timestampMs > latestUsageTimestampMs)) {
+      latestUsageTimestampMs = timestampMs
+      latestUsage = snapshot
+    } else if (latestUsageTimestampMs === null) {
+      // No timestamped record has won yet — keep advancing to the latest in
+      // FILE order. Gating on `latestUsage === undefined` (the old check) froze
+      // on the FIRST snapshot when turn.completed lines carry no timestamp, so
+      // every later turn's usage was silently discarded and the session
+      // reported stale first-turn tokens.
+      latestUsage = snapshot
+    }
+  }
+
+  return { messages, latestUsage, latestUsageTimestampMs }
+}
+
+function normalizeCodexResponseItem(
+  payload: Record<string, unknown>,
+  timestamp: string,
+  sessionId: string,
+): Message | undefined {
+  if (payload.type === "message") {
+    const role = payload.role
+    if (role !== "user" && role !== "assistant" && role !== "system") return undefined
+    const blocks = normalizeCodexContent(payload.content)
+    // Drop Codex's synthetic user rows. Codex persists both repository
+    // instructions and the environment envelope in rollout JSONL as
+    // role=user messages, but the live `codex exec --json` stream does
+    // not replay them. Reloading history should therefore hide them so
+    // the visible transcript matches what the user actually typed.
+    if (role === "user" && isSyntheticCodexUserRow(blocks)) return undefined
+    return { role, blocks, timestamp, sessionId }
+  }
+
+  if (payload.type === "reasoning") return normalizeCodexReasoning(payload, timestamp, sessionId)
+
+  if (payload.type === "function_call") {
+    return normalizeCodexToolCall(payload, timestamp, sessionId, {
+      name: stringOr(payload.name, "function_call"),
+      input: parseMaybeJson(payload.arguments),
+    })
+  }
+  if (payload.type === "custom_tool_call") {
+    return normalizeCodexToolCall(payload, timestamp, sessionId, {
+      name: stringOr(payload.name, "custom_tool_call"),
+      input: parseMaybeJson(payload.input),
+    })
+  }
+  if (payload.type === "tool_search_call") {
+    return normalizeCodexToolCall(payload, timestamp, sessionId, {
+      name: "tool_search_call",
+      input: stripPayload(payload, ["type", "call_id", "status"]),
+    })
+  }
+
+  if (payload.type === "function_call_output" || payload.type === "custom_tool_call_output") {
+    return normalizeCodexToolResult(payload, timestamp, sessionId, parseMaybeJson(payload.output))
+  }
+  if (payload.type === "tool_search_output") {
+    return normalizeCodexToolResult(payload, timestamp, sessionId, stripPayload(payload, ["type", "call_id"]))
+  }
+
+  if (
+    payload.type === "web_search_call" ||
+    payload.type === "image_generation_call" ||
+    payload.type === "local_shell_call"
+  ) {
+    return normalizeSingleRecordTool(payload, timestamp, sessionId)
+  }
+
+  return undefined
+}
+
+function normalizeCodexReasoning(
+  payload: Record<string, unknown>,
+  timestamp: string,
+  sessionId: string,
+): Message | undefined {
+  const text = reasoningTextFromItem(payload)
+  if (text.length === 0) return undefined
+  return { role: "assistant", blocks: [{ type: "thinking", text }], timestamp, sessionId }
+}
+
+function normalizeCodexToolCall(
+  payload: Record<string, unknown>,
+  timestamp: string,
+  sessionId: string,
+  args: { readonly name: string; readonly input: unknown },
+): Message | undefined {
+  const callId = typeof payload.call_id === "string" ? payload.call_id : undefined
+  if (!callId) return undefined
+  const block: ContentBlock = {
+    type: "tool_call",
+    callId,
+    name: args.name,
+    input: args.input,
+  }
+  return { role: "assistant", blocks: [block], timestamp, sessionId }
+}
+
+function normalizeCodexToolResult(
+  payload: Record<string, unknown>,
+  timestamp: string,
+  sessionId: string,
+  output: unknown,
+): Message | undefined {
+  const callId = typeof payload.call_id === "string" ? payload.call_id : undefined
+  if (!callId) return undefined
+  const block: ContentBlock = {
+    type: "tool_result",
+    callId,
+    output,
+    isError: false,
+  }
+  return { role: "user", blocks: [block], timestamp, sessionId }
+}
+
+function normalizeSingleRecordTool(
+  payload: Record<string, unknown>,
+  timestamp: string,
+  sessionId: string,
+): Message | undefined {
+  const type = typeof payload.type === "string" ? payload.type : "tool"
+  const callId =
+    typeof payload.call_id === "string" && payload.call_id.length > 0 ? payload.call_id : `${type}:${timestamp}`
+  const name = stringOr(payload.name, type)
+  const input = stripPayload(payload, ["type", "call_id", "status"])
+  const output = stripPayload(payload, ["type", "call_id"])
+  return {
+    role: "assistant",
+    timestamp,
+    sessionId,
+    blocks: [
+      { type: "tool_call", callId, name, input },
+      { type: "tool_result", callId, output, isError: false },
+    ],
+  }
+}
+
+function reasoningTextFromItem(item: Record<string, unknown>): string {
+  const content = textFromReasoningValue(item.content)
+  if (content.length > 0) return content
+  const text = typeof item.text === "string" ? item.text : ""
+  if (text.length > 0) return text
+  return textFromReasoningValue(item.summary)
+}
+
+function textFromReasoningValue(value: unknown): string {
+  if (typeof value === "string") return value
+  if (!Array.isArray(value)) return ""
+  const parts: string[] = []
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      parts.push(entry)
+      continue
+    }
+    if (!isObject(entry)) continue
+    const text = typeof entry.text === "string" ? entry.text : ""
+    if (text.length > 0) parts.push(text)
+  }
+  return parts.join("")
+}
+
+function stripPayload(payload: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(payload)) {
+    if (!keys.includes(key)) out[key] = value
+  }
+  return out
+}
+
+function stringOr(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== "string") return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+function parseTimestampMs(value: string): number | null {
+  const ms = new Date(value).getTime()
+  return Number.isFinite(ms) ? ms : null
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+}

--- a/packages/kobe/src/engine/codex-local/history.ts
+++ b/packages/kobe/src/engine/codex-local/history.ts
@@ -16,7 +16,8 @@
  *
  * We extract `response_item` records of type `message` with a known role,
  * plus persisted Codex tool call/result items, and surface them via
- * {@link Message}; other record types are dropped.
+ * {@link Message}; other record types are dropped. Record parsing (and the
+ * shared append-aware parse cache) lives in `./history-parse.ts`.
  *
  * Session-lookup-by-UUID requires scanning the date-organized tree
  * because the UUID alone doesn't carry the rollout date — newest-first
@@ -28,12 +29,11 @@
 import { readdir, stat, unlink } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
-import type { ContentBlock } from "@/types/content"
-import type { EngineHistory, EngineUsageSnapshot, Message } from "@/types/engine"
+import type { EngineHistory, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
-import { normalizeCodexContent } from "./normalize"
-import { isSyntheticCodexUserRow } from "./synthetic"
-import { codexUsageToSnapshot } from "./usage"
+import { parseRolloutRaw } from "./history-parse"
+
+export { deriveCodexUsageMetrics, parseJsonl } from "./history-parse"
 
 export interface HistoryDeps {
   /** Absolute path to `~/.codex/sessions`. */
@@ -288,9 +288,7 @@ export async function readHistoryWithMetrics(
   } catch {
     return { messages: [] }
   }
-  const messages = sortByTimestamp(parseJsonl(raw, sessionId))
-  const usageMetrics = deriveCodexUsageMetrics(raw)
-  return { messages, ...(usageMetrics ? { usageMetrics } : {}) }
+  return parseRolloutRaw(file, raw, sessionId)
 }
 
 export async function deleteHistory(sessionId: string, deps: HistoryDeps = defaultDeps): Promise<void> {
@@ -302,256 +300,4 @@ export async function deleteHistory(sessionId: string, deps: HistoryDeps = defau
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return
     throw err
   }
-}
-
-function sortByTimestamp(messages: Message[]): Message[] {
-  return messages
-    .map((msg, idx) => ({ msg, idx }))
-    .sort((a, b) => {
-      if (a.msg.timestamp < b.msg.timestamp) return -1
-      if (a.msg.timestamp > b.msg.timestamp) return 1
-      return a.idx - b.idx
-    })
-    .map((entry) => entry.msg)
-}
-
-export function parseJsonl(raw: string, sessionId: string): Message[] {
-  const out: Message[] = []
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    if (!isJsonlLineWithinBound(trimmed)) continue
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(trimmed)
-    } catch {
-      continue
-    }
-    if (!isObject(parsed)) continue
-    if (parsed.type !== "response_item") continue
-    const payload = isObject(parsed.payload) ? (parsed.payload as Record<string, unknown>) : undefined
-    if (!payload) continue
-    const ts = typeof parsed.timestamp === "string" ? (parsed.timestamp as string) : new Date().toISOString()
-    const msg = normalizeCodexResponseItem(payload, ts, sessionId)
-    if (msg) out.push(msg)
-  }
-  return out
-}
-
-function normalizeCodexResponseItem(
-  payload: Record<string, unknown>,
-  timestamp: string,
-  sessionId: string,
-): Message | undefined {
-  if (payload.type === "message") {
-    const role = payload.role
-    if (role !== "user" && role !== "assistant" && role !== "system") return undefined
-    const blocks = normalizeCodexContent(payload.content)
-    // Drop Codex's synthetic user rows. Codex persists both repository
-    // instructions and the environment envelope in rollout JSONL as
-    // role=user messages, but the live `codex exec --json` stream does
-    // not replay them. Reloading history should therefore hide them so
-    // the visible transcript matches what the user actually typed.
-    if (role === "user" && isSyntheticCodexUserRow(blocks)) return undefined
-    return { role, blocks, timestamp, sessionId }
-  }
-
-  if (payload.type === "reasoning") return normalizeCodexReasoning(payload, timestamp, sessionId)
-
-  if (payload.type === "function_call") {
-    return normalizeCodexToolCall(payload, timestamp, sessionId, {
-      name: stringOr(payload.name, "function_call"),
-      input: parseMaybeJson(payload.arguments),
-    })
-  }
-  if (payload.type === "custom_tool_call") {
-    return normalizeCodexToolCall(payload, timestamp, sessionId, {
-      name: stringOr(payload.name, "custom_tool_call"),
-      input: parseMaybeJson(payload.input),
-    })
-  }
-  if (payload.type === "tool_search_call") {
-    return normalizeCodexToolCall(payload, timestamp, sessionId, {
-      name: "tool_search_call",
-      input: stripPayload(payload, ["type", "call_id", "status"]),
-    })
-  }
-
-  if (payload.type === "function_call_output" || payload.type === "custom_tool_call_output") {
-    return normalizeCodexToolResult(payload, timestamp, sessionId, parseMaybeJson(payload.output))
-  }
-  if (payload.type === "tool_search_output") {
-    return normalizeCodexToolResult(payload, timestamp, sessionId, stripPayload(payload, ["type", "call_id"]))
-  }
-
-  if (
-    payload.type === "web_search_call" ||
-    payload.type === "image_generation_call" ||
-    payload.type === "local_shell_call"
-  ) {
-    return normalizeSingleRecordTool(payload, timestamp, sessionId)
-  }
-
-  return undefined
-}
-
-function normalizeCodexReasoning(
-  payload: Record<string, unknown>,
-  timestamp: string,
-  sessionId: string,
-): Message | undefined {
-  const text = reasoningTextFromItem(payload)
-  if (text.length === 0) return undefined
-  return { role: "assistant", blocks: [{ type: "thinking", text }], timestamp, sessionId }
-}
-
-function normalizeCodexToolCall(
-  payload: Record<string, unknown>,
-  timestamp: string,
-  sessionId: string,
-  args: { readonly name: string; readonly input: unknown },
-): Message | undefined {
-  const callId = typeof payload.call_id === "string" ? payload.call_id : undefined
-  if (!callId) return undefined
-  const block: ContentBlock = {
-    type: "tool_call",
-    callId,
-    name: args.name,
-    input: args.input,
-  }
-  return { role: "assistant", blocks: [block], timestamp, sessionId }
-}
-
-function normalizeCodexToolResult(
-  payload: Record<string, unknown>,
-  timestamp: string,
-  sessionId: string,
-  output: unknown,
-): Message | undefined {
-  const callId = typeof payload.call_id === "string" ? payload.call_id : undefined
-  if (!callId) return undefined
-  const block: ContentBlock = {
-    type: "tool_result",
-    callId,
-    output,
-    isError: false,
-  }
-  return { role: "user", blocks: [block], timestamp, sessionId }
-}
-
-function normalizeSingleRecordTool(
-  payload: Record<string, unknown>,
-  timestamp: string,
-  sessionId: string,
-): Message | undefined {
-  const type = typeof payload.type === "string" ? payload.type : "tool"
-  const callId =
-    typeof payload.call_id === "string" && payload.call_id.length > 0 ? payload.call_id : `${type}:${timestamp}`
-  const name = stringOr(payload.name, type)
-  const input = stripPayload(payload, ["type", "call_id", "status"])
-  const output = stripPayload(payload, ["type", "call_id"])
-  return {
-    role: "assistant",
-    timestamp,
-    sessionId,
-    blocks: [
-      { type: "tool_call", callId, name, input },
-      { type: "tool_result", callId, output, isError: false },
-    ],
-  }
-}
-
-function reasoningTextFromItem(item: Record<string, unknown>): string {
-  const content = textFromReasoningValue(item.content)
-  if (content.length > 0) return content
-  const text = typeof item.text === "string" ? item.text : ""
-  if (text.length > 0) return text
-  return textFromReasoningValue(item.summary)
-}
-
-function textFromReasoningValue(value: unknown): string {
-  if (typeof value === "string") return value
-  if (!Array.isArray(value)) return ""
-  const parts: string[] = []
-  for (const entry of value) {
-    if (typeof entry === "string") {
-      parts.push(entry)
-      continue
-    }
-    if (!isObject(entry)) continue
-    const text = typeof entry.text === "string" ? entry.text : ""
-    if (text.length > 0) parts.push(text)
-  }
-  return parts.join("")
-}
-
-function stripPayload(payload: Record<string, unknown>, keys: readonly string[]): Record<string, unknown> {
-  const out: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(payload)) {
-    if (!keys.includes(key)) out[key] = value
-  }
-  return out
-}
-
-function stringOr(value: unknown, fallback: string): string {
-  return typeof value === "string" && value.length > 0 ? value : fallback
-}
-
-function parseMaybeJson(value: unknown): unknown {
-  if (typeof value !== "string") return value
-  try {
-    return JSON.parse(value)
-  } catch {
-    return value
-  }
-}
-
-export function deriveCodexUsageMetrics(raw: string): EngineUsageSnapshot | undefined {
-  let latestUsage: EngineUsageSnapshot | undefined
-  let latestUsageTimestampMs: number | null = null
-
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    if (!isJsonlLineWithinBound(trimmed)) continue
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(trimmed)
-    } catch {
-      continue
-    }
-    if (!isObject(parsed)) continue
-
-    const timestampMs = typeof parsed.timestamp === "string" ? parseTimestampMs(parsed.timestamp) : null
-    if (parsed.type === "response_item") continue
-
-    if (parsed.type !== "turn.completed") continue
-    const usage = isObject(parsed.usage) ? (parsed.usage as Record<string, unknown>) : undefined
-    if (!usage) continue
-    const snapshot = codexUsageToSnapshot(usage)
-    if (!snapshot) continue
-
-    if (timestampMs !== null && (latestUsageTimestampMs === null || timestampMs > latestUsageTimestampMs)) {
-      latestUsageTimestampMs = timestampMs
-      latestUsage = snapshot
-    } else if (latestUsageTimestampMs === null) {
-      // No timestamped record has won yet — keep advancing to the latest in
-      // FILE order. Gating on `latestUsage === undefined` (the old check) froze
-      // on the FIRST snapshot when turn.completed lines carry no timestamp, so
-      // every later turn's usage was silently discarded and the session
-      // reported stale first-turn tokens.
-      latestUsage = snapshot
-    }
-  }
-
-  return latestUsage
-}
-
-function parseTimestampMs(value: string): number | null {
-  const ms = new Date(value).getTime()
-  return Number.isFinite(ms) ? ms : null
-}
-
-function isObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v)
 }

--- a/packages/kobe/src/engine/copilot-local/history.ts
+++ b/packages/kobe/src/engine/copilot-local/history.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import type { ContentBlock } from "@/types/content"
 import type { EngineHistory, EngineUsageSnapshot, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
+import { createAppendParseCache } from "../history-cache"
 import { copilotUsageToSnapshot } from "./usage"
 
 export interface CopilotHistoryDeps {
@@ -101,9 +102,10 @@ export async function readHistoryWithMetrics(
 ): Promise<EngineHistory> {
   const dir = await findSessionDir(sessionId, deps)
   if (!dir) return { messages: [] }
-  const raw = await deps.readFile(path.join(dir, "events.jsonl")).catch(() => "")
-  const parsed = parseEvents(raw, sessionId)
-  return { messages: parsed.messages, ...(parsed.usageMetrics ? { usageMetrics: parsed.usageMetrics } : {}) }
+  const file = path.join(dir, "events.jsonl")
+  const raw = await deps.readFile(file).catch(() => "")
+  const state = eventsCache(file, raw, sessionId)
+  return { messages: state.messages, ...(state.usageMetrics ? { usageMetrics: state.usageMetrics } : {}) }
 }
 
 export async function readHistory(sessionId: string, deps: CopilotHistoryDeps = defaultDeps): Promise<Message[]> {
@@ -167,11 +169,49 @@ export function parseEvents(
   raw: string,
   fallbackSessionId: string,
 ): { messages: Message[]; usageMetrics?: EngineUsageSnapshot; firstUserMessage?: string | null } {
-  const messages: Message[] = []
-  const toolNameById = new Map<string, string>()
-  let sessionId = fallbackSessionId
-  let usageMetrics: EngineUsageSnapshot | undefined
-  let firstUserMessage: string | null = null
+  const state = foldEvents(raw, initialParseState(fallbackSessionId))
+  return { messages: state.messages, usageMetrics: state.usageMetrics, firstUserMessage: state.firstUserMessage }
+}
+
+/**
+ * Fold state for `events.jsonl` parsing. Unlike claude/codex, the copilot
+ * event stream is NOT line-local: `session.start` sets the sessionId for
+ * everything after it, tool names are resolved from an earlier
+ * `tool.execution_start`, and firstUserMessage/usage are first/last-wins.
+ * The append-aware cache therefore snapshots this whole fold state at the
+ * cached prefix boundary, so folding an appended slice onto it reproduces
+ * a full parse exactly.
+ */
+interface CopilotParseState {
+  readonly messages: Message[]
+  readonly toolNameById: ReadonlyMap<string, string>
+  readonly sessionId: string
+  readonly usageMetrics: EngineUsageSnapshot | undefined
+  readonly firstUserMessage: string | null
+}
+
+function initialParseState(fallbackSessionId: string): CopilotParseState {
+  return {
+    messages: [],
+    toolNameById: new Map(),
+    sessionId: fallbackSessionId,
+    usageMetrics: undefined,
+    firstUserMessage: null,
+  }
+}
+
+const eventsCache = createAppendParseCache<CopilotParseState, string>({
+  initial: initialParseState,
+  parseChunk: (chunk, prev) => foldEvents(chunk, prev),
+})
+
+/** Fold event lines onto `prev` without mutating it (cache contract). */
+function foldEvents(raw: string, prev: CopilotParseState): CopilotParseState {
+  const messages = prev.messages.slice()
+  const toolNameById = new Map(prev.toolNameById)
+  let sessionId = prev.sessionId
+  let usageMetrics = prev.usageMetrics
+  let firstUserMessage = prev.firstUserMessage
 
   for (const line of raw.split("\n")) {
     const trimmed = line.trim()
@@ -246,7 +286,7 @@ export function parseEvents(
     }
   }
 
-  return { messages, usageMetrics, firstUserMessage }
+  return { messages, toolNameById, sessionId, usageMetrics, firstUserMessage }
 }
 
 const PREVIEW_CHAR_CAP = 200

--- a/packages/kobe/src/engine/history-cache.ts
+++ b/packages/kobe/src/engine/history-cache.ts
@@ -1,0 +1,135 @@
+/**
+ * Append-aware per-file transcript parse cache, shared by the engine
+ * history readers (claude-code-local, codex-local, copilot-local).
+ *
+ * Why it exists: the history pane polls transcript mtime and re-reads the
+ * file every ~2.5s. A full re-parse builds a completely fresh `Message[]`
+ * with new object identities each call — Solid's `<For>` keys rows by
+ * reference, so all-new identities destroy + recreate every rendered row's
+ * native subtree per poll, and the re-parse itself is O(n²) allocation over
+ * a session's lifetime. Transcripts are append-only in the common case, so
+ * we cache the parsed prefix and only parse the appended slice, returning
+ * the SAME object refs for already-seen records.
+ *
+ * Soundness: the cache boundary always sits on a `\n` so a partially
+ * flushed trailing line is never split across prefix/suffix — the
+ * un-terminated tail is re-parsed fresh every call and never cached.
+ * Rewrite/truncation (compaction, resume-branch rewrites) is detected by
+ * validating the cached prefix: previous prefix length + a SHA-256 of that
+ * prefix (we never retain the previous file content itself). Any mismatch
+ * falls back to a full re-parse and replaces the cache entry.
+ *
+ * Vendors with cross-line parse state (copilot's session.start id /
+ * tool-name map) cache that state alongside the messages: `S` is whatever
+ * fold state the vendor's `parseChunk` threads through.
+ */
+
+import { createHash } from "node:crypto"
+import type { Message } from "@/types/engine"
+
+export interface AppendParseCacheOptions<S, C> {
+  /** Fold state for an empty transcript (before any complete line). */
+  initial: (ctx: C) => S
+  /**
+   * Fold a chunk of transcript lines onto `prev`, returning NEW state
+   * WITHOUT mutating `prev` — the cached prefix state is shared across
+   * calls (clone arrays/maps before appending). Must fold associatively
+   * over line boundaries: `parseChunk(b, parseChunk(a, s))` must equal
+   * `parseChunk(a + b, s)` when `a` ends at a `\n`, so a cached prefix
+   * can be extended one appended slice at a time.
+   */
+  parseChunk: (chunk: string, prev: S, ctx: C) => S
+  /** FIFO cap on cached files (default 8). */
+  maxFiles?: number
+}
+
+interface CacheEntry<S> {
+  /** Char length of the cached prefix — always ends at a `\n` boundary. */
+  prefixLength: number
+  /** SHA-256 hex of `raw.slice(0, prefixLength)` at cache time. */
+  prefixHash: string
+  /** Fold state over that prefix (messages + any vendor carry-over). */
+  state: S
+}
+
+/**
+ * Create a per-file append-aware parse cache. Call the returned function
+ * with the full current contents of `filePath`; it reuses the cached fold
+ * of the unchanged prefix when the file only appended since the last call,
+ * so objects for already-seen records keep their identity across calls.
+ */
+export function createAppendParseCache<S, C = void>(
+  opts: AppendParseCacheOptions<S, C>,
+): (filePath: string, raw: string, ctx: C) => S {
+  // ponytail: FIFO cap, not LRU — a pane process only ever polls a handful
+  // of session files; switch to LRU if panes start juggling many sessions.
+  const maxFiles = opts.maxFiles ?? 8
+  const cache = new Map<string, CacheEntry<S>>()
+
+  function hashPrefix(raw: string, length: number): string {
+    return createHash("sha256").update(raw.slice(0, length)).digest("hex")
+  }
+
+  function remember(filePath: string, entry: CacheEntry<S>): void {
+    cache.delete(filePath) // re-insert so Map order tracks recency of writes
+    cache.set(filePath, entry)
+    if (cache.size > maxFiles) {
+      const oldest = cache.keys().next().value
+      if (oldest !== undefined) cache.delete(oldest)
+    }
+  }
+
+  return function parseCached(filePath: string, raw: string, ctx: C): S {
+    // Complete-line boundary: everything past the last `\n` may be a
+    // partially flushed record — parse it fresh each call, never cache it.
+    const stableLength = raw.lastIndexOf("\n") + 1
+    const entry = cache.get(filePath)
+
+    let prefixState: S
+    if (entry && entry.prefixLength <= stableLength && hashPrefix(raw, entry.prefixLength) === entry.prefixHash) {
+      // Append-only since last read: fold just the new complete lines.
+      prefixState =
+        entry.prefixLength < stableLength
+          ? opts.parseChunk(raw.slice(entry.prefixLength, stableLength), entry.state, ctx)
+          : entry.state
+    } else {
+      // First read, rewrite, or truncation: full re-fold of the stable prefix.
+      prefixState = opts.parseChunk(raw.slice(0, stableLength), opts.initial(ctx), ctx)
+    }
+
+    if (!entry || entry.prefixLength !== stableLength || entry.state !== prefixState) {
+      remember(filePath, {
+        prefixLength: stableLength,
+        prefixHash: hashPrefix(raw, stableLength),
+        state: prefixState,
+      })
+    }
+
+    const tail = raw.slice(stableLength)
+    return tail.trim().length > 0 ? opts.parseChunk(tail, prefixState, ctx) : prefixState
+  }
+}
+
+/**
+ * Sort messages by their `timestamp` ASC (oldest first → newest last).
+ *
+ * Vendor transcripts aren't strictly chronological in file order (e.g.
+ * Claude's JSONL is a DAG — records carry `parentUuid` for branching
+ * resumes, so a resumed session can interleave records from different
+ * branches). The chat pane relies on `past[]` being chronological so
+ * newest messages render at the bottom; readers sort at the engine
+ * boundary so every consumer gets the same shape.
+ *
+ * Stable sort: ties (same ISO timestamp) keep file-order, which roughly
+ * preserves causal ordering even at sub-millisecond ties.
+ */
+export function sortByTimestamp(messages: readonly Message[]): Message[] {
+  return messages
+    .map((msg, idx) => ({ msg, idx }))
+    .sort((a, b) => {
+      if (a.msg.timestamp < b.msg.timestamp) return -1
+      if (a.msg.timestamp > b.msg.timestamp) return 1
+      return a.idx - b.idx
+    })
+    .map((entry) => entry.msg)
+}

--- a/packages/kobe/test/engine/codex-copilot-history-incremental.test.ts
+++ b/packages/kobe/test/engine/codex-copilot-history-incremental.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest"
+import type { HistoryDeps } from "../../src/engine/codex-local/history.ts"
+import {
+  readHistory as readCodexHistory,
+  readHistoryWithMetrics as readCodexHistoryWithMetrics,
+} from "../../src/engine/codex-local/history.ts"
+import type { CopilotHistoryDeps } from "../../src/engine/copilot-local/history.ts"
+import {
+  readHistory as readCopilotHistory,
+  readHistoryWithMetrics as readCopilotHistoryWithMetrics,
+} from "../../src/engine/copilot-local/history.ts"
+
+/**
+ * Why these tests matter: the history pane polls `readHistory` every ~2.5s
+ * and Solid's `<For>` keys rows by object reference — all-new identities per
+ * poll destroy + recreate every rendered row. PR #233 gave the claude reader
+ * an append-aware parse cache; these tests pin the same contract for the
+ * codex and copilot readers: (a) already-seen messages keep object identity
+ * when the file only appended, (b) output stays identical to a full re-parse,
+ * falling back on rewrite/truncation, and (c) copilot's cross-line fold state
+ * (session.start id, tool-name map, usage) survives the cache boundary.
+ */
+
+// ---------------------------------------------------------------- codex ----
+
+const CODEX_UUID = "aaaaaaaa-1111-2222-3333-444444444444"
+const CODEX_ROLLOUT = `rollout-2026-06-10T01-00-00-${CODEX_UUID}.jsonl`
+
+function codexMsg(role: "user" | "assistant", text: string, ts: string): string {
+  const type = role === "user" ? "input_text" : "output_text"
+  return JSON.stringify({
+    timestamp: ts,
+    type: "response_item",
+    payload: { type: "message", role, content: [{ type, text }] },
+  })
+}
+
+function codexTurn(output: number): string {
+  return JSON.stringify({ type: "turn.completed", usage: { output_tokens: output } })
+}
+
+/**
+ * Fake FS where the rollout contents are mutable between reads. Each test
+ * uses a unique sessions root so the module-level cache (keyed by file path)
+ * never bleeds state across tests.
+ */
+function codexDeps(name: string): { deps: HistoryDeps; set: (raw: string) => void } {
+  let raw = ""
+  const root = `/codex-${name}`
+  const deps: HistoryDeps = {
+    sessionsDir: () => root,
+    readdir: async (p) => {
+      if (p === root) return ["2026"]
+      if (p === `${root}/2026`) return ["06"]
+      if (p === `${root}/2026/06`) return ["10"]
+      if (p === `${root}/2026/06/10`) return [CODEX_ROLLOUT]
+      return []
+    },
+    readFile: async (p) => {
+      if (p !== `${root}/2026/06/10/${CODEX_ROLLOUT}`) throw new Error("ENOENT")
+      return raw
+    },
+    stat: async () => ({ mtimeMs: 1 }),
+  }
+  return {
+    deps,
+    set: (next) => {
+      raw = next
+    },
+  }
+}
+
+describe("codex readHistory append-aware cache", () => {
+  it("append: already-seen messages keep object identity; new ones are appended", async () => {
+    const { deps, set } = codexDeps("append")
+    const l1 = codexMsg("user", "first", "2026-06-10T01:00:01Z")
+    const l2 = codexMsg("assistant", "second", "2026-06-10T01:00:02Z")
+    set(`${l1}\n${l2}\n`)
+
+    const first = await readCodexHistory(CODEX_UUID, deps)
+    expect(first.map((m) => m.blocks)).toEqual([[{ type: "text", text: "first" }], [{ type: "text", text: "second" }]])
+
+    const l3 = codexMsg("user", "third", "2026-06-10T01:00:03Z")
+    set(`${l1}\n${l2}\n${l3}\n`)
+    const second = await readCodexHistory(CODEX_UUID, deps)
+
+    expect(second).toHaveLength(3)
+    // Identity-stable prefix: same refs, not just deep-equal copies.
+    expect(second[0]).toBe(first[0])
+    expect(second[1]).toBe(first[1])
+    expect(second[2]?.blocks).toEqual([{ type: "text", text: "third" }])
+  })
+
+  it("rewrite: a changed prefix falls back to a full re-parse", async () => {
+    const { deps, set } = codexDeps("rewrite")
+    set(`${codexMsg("user", "original", "2026-06-10T01:00:01Z")}\n`)
+    await readCodexHistory(CODEX_UUID, deps)
+
+    set(
+      `${codexMsg("user", "rewritten", "2026-06-10T01:00:01Z")}\n${codexMsg("assistant", "after", "2026-06-10T01:00:02Z")}\n`,
+    )
+    const out = await readCodexHistory(CODEX_UUID, deps)
+    expect(out.map((m) => m.blocks[0])).toEqual([
+      { type: "text", text: "rewritten" },
+      { type: "text", text: "after" },
+    ])
+  })
+
+  it("truncation: a shorter file falls back to a full re-parse", async () => {
+    const { deps, set } = codexDeps("truncate")
+    const l1 = codexMsg("user", "keep", "2026-06-10T01:00:01Z")
+    set(`${l1}\n${codexMsg("assistant", "dropped", "2026-06-10T01:00:02Z")}\n`)
+    expect(await readCodexHistory(CODEX_UUID, deps)).toHaveLength(2)
+
+    set(`${l1}\n`)
+    const out = await readCodexHistory(CODEX_UUID, deps)
+    expect(out).toHaveLength(1)
+    expect(out[0]?.blocks).toEqual([{ type: "text", text: "keep" }])
+  })
+
+  it("usage metrics keep advancing across appends (fold state, not first-turn freeze)", async () => {
+    const { deps, set } = codexDeps("usage")
+    const l1 = codexMsg("user", "hi", "2026-06-10T01:00:01Z")
+    set(`${l1}\n${codexTurn(10)}\n`)
+    const first = await readCodexHistoryWithMetrics(CODEX_UUID, deps)
+    expect(first.usageMetrics).toEqual({ input_tokens: 0, output_tokens: 10 })
+
+    set(`${l1}\n${codexTurn(10)}\n${codexTurn(30)}\n`)
+    const second = await readCodexHistoryWithMetrics(CODEX_UUID, deps)
+    expect(second.usageMetrics).toEqual({ input_tokens: 0, output_tokens: 30 })
+    expect(second.messages[0]).toBe(first.messages[0])
+  })
+})
+
+// -------------------------------------------------------------- copilot ----
+
+function copilotEvent(type: string, data: Record<string, unknown>, ts: string): string {
+  return JSON.stringify({ type, data, timestamp: ts })
+}
+
+function copilotDeps(name: string): { deps: CopilotHistoryDeps; set: (raw: string) => void } {
+  let events = ""
+  const root = `/copilot-${name}`
+  const dir = `${root}/session-state/sess1`
+  const deps: CopilotHistoryDeps = {
+    copilotDir: () => root,
+    readdir: async (p) => (p === `${root}/session-state` ? ["sess1"] : []),
+    readFile: async (p) => {
+      if (p === `${dir}/workspace.yaml`) return 'id: sess1\ncwd: "/wt"\n'
+      if (p === `${dir}/events.jsonl`) return events
+      throw new Error("ENOENT")
+    },
+    stat: async () => ({ mtimeMs: 1 }),
+    rm: async () => {},
+  }
+  return {
+    deps,
+    set: (next) => {
+      events = next
+    },
+  }
+}
+
+describe("copilot readHistory append-aware cache", () => {
+  it("append: already-seen messages keep object identity; new ones are appended", async () => {
+    const { deps, set } = copilotDeps("append")
+    const l1 = copilotEvent("user.message", { content: "first" }, "2026-06-10T01:00:01Z")
+    const l2 = copilotEvent("assistant.message", { content: "second" }, "2026-06-10T01:00:02Z")
+    set(`${l1}\n${l2}\n`)
+
+    const first = await readCopilotHistory("sess1", deps)
+    expect(first.map((m) => m.blocks)).toEqual([[{ type: "text", text: "first" }], [{ type: "text", text: "second" }]])
+
+    const l3 = copilotEvent("user.message", { content: "third" }, "2026-06-10T01:00:03Z")
+    set(`${l1}\n${l2}\n${l3}\n`)
+    const second = await readCopilotHistory("sess1", deps)
+
+    expect(second).toHaveLength(3)
+    expect(second[0]).toBe(first[0])
+    expect(second[1]).toBe(first[1])
+    expect(second[2]?.blocks).toEqual([{ type: "text", text: "third" }])
+  })
+
+  it("rewrite: a changed prefix falls back to a full re-parse", async () => {
+    const { deps, set } = copilotDeps("rewrite")
+    set(`${copilotEvent("user.message", { content: "original" }, "2026-06-10T01:00:01Z")}\n`)
+    await readCopilotHistory("sess1", deps)
+
+    set(`${copilotEvent("user.message", { content: "rewritten" }, "2026-06-10T01:00:01Z")}\n`)
+    const out = await readCopilotHistory("sess1", deps)
+    expect(out).toHaveLength(1)
+    expect(out[0]?.blocks).toEqual([{ type: "text", text: "rewritten" }])
+  })
+
+  it("cross-line fold state survives the cache boundary (session.start id applies to appended lines)", async () => {
+    const { deps, set } = copilotDeps("state")
+    const start = copilotEvent("session.start", { sessionId: "real-sid" }, "2026-06-10T01:00:00Z")
+    const l1 = copilotEvent("user.message", { content: "hi" }, "2026-06-10T01:00:01Z")
+    set(`${start}\n${l1}\n`)
+    const first = await readCopilotHistory("sess1", deps)
+    expect(first[0]?.sessionId).toBe("real-sid")
+
+    // The appended message must pick up the sessionId recorded in the CACHED
+    // prefix — a naive line-local cache would fall back to "sess1".
+    const l2 = copilotEvent("assistant.message", { content: "yo" }, "2026-06-10T01:00:02Z")
+    set(`${start}\n${l1}\n${l2}\n`)
+    const second = await readCopilotHistory("sess1", deps)
+    expect(second).toHaveLength(2)
+    expect(second[0]).toBe(first[0])
+    expect(second[1]?.sessionId).toBe("real-sid")
+  })
+
+  it("usage metrics from an appended session.shutdown are picked up", async () => {
+    const { deps, set } = copilotDeps("usage")
+    const l1 = copilotEvent("user.message", { content: "hi" }, "2026-06-10T01:00:01Z")
+    set(`${l1}\n`)
+    const first = await readCopilotHistoryWithMetrics("sess1", deps)
+    expect(first.usageMetrics).toBeUndefined()
+
+    const shutdown = copilotEvent(
+      "session.shutdown",
+      { modelMetrics: { m: { usage: { inputTokens: 5, outputTokens: 7 } } } },
+      "2026-06-10T01:00:02Z",
+    )
+    set(`${l1}\n${shutdown}\n`)
+    const second = await readCopilotHistoryWithMetrics("sess1", deps)
+    expect(second.usageMetrics).toEqual({ input_tokens: 5, output_tokens: 7 })
+    expect(second.messages[0]).toBe(first.messages[0])
+  })
+})


### PR DESCRIPTION
Ports the #233 append-aware transcript parse cache (prefix-hash + complete-line boundary + rewrite fallback) from the claude reader to codex-local and copilot-local, consolidated as a generic fold cache in `src/engine/history-cache.ts` instead of three copies.

- **claude**: `history-parse.ts` now supplies only the line parser; cache mechanics + `sortByTimestamp` moved to the shared module. Existing incremental tests unchanged and green.
- **codex**: parse layer split into `codex-local/history-parse.ts` (also brings the previously 557-line `history.ts` under the 500 cap). One cached fold now extracts both messages and the latest `turn.completed` usage — previously two full scans of the raw text per 2.5s poll.
- **copilot**: `parseEvents` is NOT line-local (`session.start` sessionId, tool-name map, first-user-message, usage are cross-line), so prefix reuse caches the whole fold state at the boundary rather than falling back — appends reproduce a full parse exactly, covered by a dedicated cross-boundary test.

New tests pin append reuse (identity-stable refs), rewrite/truncation fallback, and usage-advance-across-append for both vendors.