### PR TITLE
feat: React ports of the TUI infrastructure layer (G2, issue #15)

### DIFF
--- a/.changeset/react-infra-g2.md
+++ b/.changeset/react-infra-g2.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+G2 of the React TUI migration (issue #15): the full infrastructure layer — theme, focus, dialog stack, key-bindings dispatch, and i18n — now has React counterparts under src/tui-react/, sharing framework-free cores (theme-core, i18n lookup, keymap-dispatch) with the Solid originals so the two cannot drift. The dev:mock-react pilot mounts the whole provider stack end-to-end.

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "@tsconfig/bun": "1.0.10",
         "@types/bun": "1.3.14",
         "@types/node": "25.6.2",
+        "@types/react": "^19.2.0",
         "@vitest/coverage-v8": "2.1.9",
         "knip": "^6.14.2",
         "kobe-web": "workspace:*",
@@ -870,7 +871,7 @@
 
     "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
-    "@types/react": ["@types/react@19.0.0", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg=="],
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.0.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w=="],
 
@@ -1098,7 +1099,7 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+    "enhanced-resolve": ["enhanced-resolve@5.24.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -1828,6 +1829,8 @@
 
     "@rspack/plugin-react-refresh/html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
+    "@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
@@ -1854,8 +1857,6 @@
 
     "@tanstack/router-utils/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "@types/react-dom/@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
-
     "babel-dead-code-elimination/@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
@@ -1880,13 +1881,13 @@
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
+    "kobe-branding/@types/react": ["@types/react@19.0.0", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg=="],
+
     "kobe-branding/react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
 
     "kobe-web/@biomejs/biome": ["@biomejs/biome@2.4.5", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.5", "@biomejs/cli-darwin-x64": "2.4.5", "@biomejs/cli-linux-arm64": "2.4.5", "@biomejs/cli-linux-arm64-musl": "2.4.5", "@biomejs/cli-linux-x64": "2.4.5", "@biomejs/cli-linux-x64-musl": "2.4.5", "@biomejs/cli-win32-arm64": "2.4.5", "@biomejs/cli-win32-x64": "2.4.5" }, "bin": { "biome": "bin/biome" } }, "sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ=="],
 
     "kobe-web/@types/node": ["@types/node@22.20.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g=="],
-
-    "kobe-web/@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "kobe-web/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
@@ -1941,8 +1942,6 @@
     "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
-
-    "webpack/enhanced-resolve": ["enhanced-resolve@5.24.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/packages/kobe-daemon/tsconfig.json
+++ b/packages/kobe-daemon/tsconfig.json
@@ -2,21 +2,42 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/bun/tsconfig.json",
   "compilerOptions": {
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "types": ["bun"],
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "jsxImportSource": "@opentui/solid",
+    "types": [
+      "bun"
+    ],
     "strict": true,
     "noUncheckedIndexedAccess": false,
-    "customConditions": ["browser"],
+    "customConditions": [
+      "browser"
+    ],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "paths": {
-      "@/*": ["../kobe/src/*"],
-      "@tui/*": ["../kobe/src/tui/*"],
-      "@engine/*": ["../kobe/src/engine/*"],
-      "@orchestrator/*": ["../kobe/src/orchestrator/*"],
-      "@types/*": ["../kobe/src/types/*"]
+      "@/*": [
+        "../kobe/src/*"
+      ],
+      "@tui/*": [
+        "../kobe/src/tui/*"
+      ],
+      "@engine/*": [
+        "../kobe/src/engine/*"
+      ],
+      "@orchestrator/*": [
+        "../kobe/src/orchestrator/*"
+      ],
+      "@types/*": [
+        "../kobe/src/types/*"
+      ]
     }
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/packages/kobe-daemon/tsconfig.json
+++ b/packages/kobe-daemon/tsconfig.json
@@ -2,42 +2,22 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/bun/tsconfig.json",
   "compilerOptions": {
-    "lib": [
-      "ESNext",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "jsxImportSource": "@opentui/solid",
-    "types": [
-      "bun"
-    ],
+    "types": ["bun"],
     "strict": true,
     "noUncheckedIndexedAccess": false,
-    "customConditions": [
-      "browser"
-    ],
+    "customConditions": ["browser"],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "paths": {
-      "@/*": [
-        "../kobe/src/*"
-      ],
-      "@tui/*": [
-        "../kobe/src/tui/*"
-      ],
-      "@engine/*": [
-        "../kobe/src/engine/*"
-      ],
-      "@orchestrator/*": [
-        "../kobe/src/orchestrator/*"
-      ],
-      "@types/*": [
-        "../kobe/src/types/*"
-      ]
+      "@/*": ["../kobe/src/*"],
+      "@tui/*": ["../kobe/src/tui/*"],
+      "@engine/*": ["../kobe/src/engine/*"],
+      "@orchestrator/*": ["../kobe/src/orchestrator/*"],
+      "@types/*": ["../kobe/src/types/*"]
     }
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -70,6 +70,7 @@
     "@tsconfig/bun": "1.0.10",
     "@types/bun": "1.3.14",
     "@types/node": "25.6.2",
+    "@types/react": "^19.2.0",
     "@vitest/coverage-v8": "2.1.9",
     "knip": "^6.14.2",
     "kobe-web": "workspace:*",

--- a/packages/kobe/src/tui-react/context/focus.tsx
+++ b/packages/kobe/src/tui-react/context/focus.tsx
@@ -1,0 +1,115 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Pane focus — global, single source of truth (React port of
+ * `src/tui/context/focus.tsx`, issue #15 G2). Same responsibilities: pane
+ * wrappers set focus on click, panes gate their keybindings on it, global
+ * single-letter shortcuts gate on the workspace NOT being focused.
+ *
+ * API deltas from the Solid version, by design:
+ *   - `focused` is a plain value (was `Accessor<PaneId>`).
+ *   - `is(pane)` returns a boolean (was a memoized `Accessor<boolean>`);
+ *     Solid call sites `is("sidebar")()` become `is("sidebar")`.
+ *   - `refocusTick` is a plain number that increments on every `setFocused`
+ *     call — even same-pane — so input-bearing children can re-assert
+ *     native focus in an effect keyed on it (same one-tick-race fix).
+ */
+
+import { useRenderer } from "@opentui/react"
+import { type ReactNode, createContext, useCallback, useContext, useMemo, useRef, useState } from "react"
+
+/** The four primary panes in kobe's layout. */
+export type PaneId = "sidebar" | "workspace" | "files" | "terminal"
+
+/** Cycle order — used by `tab` / `shift+tab`. */
+export const PANE_ORDER = ["sidebar", "workspace", "files", "terminal"] as const satisfies readonly PaneId[]
+
+export type FocusContextValue = {
+  /** The currently focused pane. */
+  focused: PaneId
+  /** True when `pane` is the focused one. */
+  is: (pane: PaneId) => boolean
+  /** Set the focused pane. */
+  setFocused: (pane: PaneId) => void
+  /** Cycle by ±1 through PANE_ORDER. Used by `tab` / `shift+tab`. */
+  cycle: (delta: 1 | -1) => void
+  /** Increments on every `setFocused` call — even same-pane (see header). */
+  refocusTick: number
+}
+
+const FocusContext = createContext<FocusContextValue | null>(null)
+
+/**
+ * Mount the focus state at the top of the tree. Default focused pane is
+ * `sidebar`: on cold boot there's no task selected, so the sidebar's task
+ * list is the natural starting point and single-letter global shortcuts
+ * work because the composer isn't claiming keys.
+ */
+export function FocusProvider(props: { children?: ReactNode; initial?: PaneId }) {
+  const [focused, setFocusedState] = useState<PaneId>(props.initial ?? "sidebar")
+  const [refocusTick, setRefocusTick] = useState(0)
+  const renderer = useRenderer()
+  // Latest focused value for the stable callbacks below (React state reads
+  // in callbacks go stale; the ref always holds the current pane).
+  const focusedRef = useRef(focused)
+  focusedRef.current = focused
+
+  /**
+   * Unified focus-change entry point (same contract as the Solid provider):
+   * tick refocus unconditionally, then on a real transition blur whatever
+   * opentui renderable holds native focus BEFORE flipping the pane state —
+   * removing the one-tick window where a composer textarea keeps eating
+   * keystrokes after the user chorded away from the workspace.
+   */
+  const setFocused = useCallback(
+    (pane: PaneId): void => {
+      setRefocusTick((t) => t + 1)
+      if (focusedRef.current === pane) return
+      const current = renderer?.currentFocusedRenderable
+      if (current && !current.isDestroyed) {
+        try {
+          current.blur()
+        } catch {
+          // best-effort; if blur throws (renderable in a bad state)
+          // we still want the pane focus state to flip.
+        }
+      }
+      setFocusedState(pane)
+    },
+    [renderer],
+  )
+
+  const cycle = useCallback(
+    (delta: 1 | -1): void => {
+      const idx = PANE_ORDER.indexOf(focusedRef.current)
+      const next = (idx + delta + PANE_ORDER.length) % PANE_ORDER.length
+      setFocused(PANE_ORDER[next] as PaneId)
+    },
+    [setFocused],
+  )
+
+  const value = useMemo<FocusContextValue>(
+    () => ({
+      focused,
+      is: (pane: PaneId) => focused === pane,
+      setFocused,
+      cycle,
+      refocusTick,
+    }),
+    [focused, refocusTick, setFocused, cycle],
+  )
+
+  return <FocusContext.Provider value={value}>{props.children}</FocusContext.Provider>
+}
+
+/**
+ * Read the focus context. Throws if called outside `<FocusProvider>` —
+ * that's almost always a bug, so we fail loud rather than fall back to
+ * a no-op default.
+ */
+export function useFocus(): FocusContextValue {
+  const ctx = useContext(FocusContext)
+  if (!ctx) {
+    throw new Error("useFocus: must be called inside <FocusProvider>. See src/tui-react/context/focus.tsx.")
+  }
+  return ctx
+}

--- a/packages/kobe/src/tui-react/context/keybindings.ts
+++ b/packages/kobe/src/tui-react/context/keybindings.ts
@@ -1,0 +1,32 @@
+/**
+ * React access to the kobe keymap (issue #15, G2). The data table, lookup
+ * fns, and override machinery are the framework-free parts of
+ * `src/tui/context/keybindings.ts` and are re-exported untouched; the only
+ * React-specific piece is subscribing chord legends to live keymap reloads
+ * (the table is mutated in place, invisible to React without a version
+ * subscription).
+ */
+
+import { useSyncExternalStore } from "react"
+import { keymapVersion, subscribeKeymapVersion } from "../../tui/context/keybindings"
+
+export {
+  KobeKeymap,
+  findBinding,
+  chordsOf,
+  bindByIds,
+  resetKeymapToDefaults,
+  bumpKeymapVersion,
+  subscribeKeymapVersion,
+} from "../../tui/context/keybindings"
+export type { KobeBinding, KobeBindingScope, KobeBindingHint } from "../../tui/context/keybindings"
+
+/**
+ * Subscribe the component to keymap reloads. Returns the current version
+ * counter — use it as a dependency to recompute chord legends.
+ */
+export function useKeymapVersion(): number {
+  // keymapVersion is a Solid signal read; outside a tracked scope it is a
+  // plain getter, which is exactly what getSnapshot wants.
+  return useSyncExternalStore(subscribeKeymapVersion, keymapVersion, keymapVersion)
+}

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -1,0 +1,156 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Theme provider for kobe (React) — the `src/tui/context/theme.tsx`
+ * counterpart for React panes (issue #15, G2). All theme SEMANTICS
+ * (bundled registry, resolution, focus-accent + transparent overlay) come
+ * from the shared framework-free `src/tui/context/theme-core.ts`; this file
+ * owns only the React reactivity.
+ *
+ * Differences from the Solid provider, by design:
+ *   - `useTheme().theme` is a PLAIN resolved object, not a Proxy. React
+ *     components re-render via context when the theme changes, so
+ *     per-property reactive reads have no equivalent — and a plain object
+ *     keeps `theme.background` call sites source-compatible.
+ *   - Module-level registry state lives in an external store (subscribed
+ *     via useSyncExternalStore), matching the Solid module-store semantics:
+ *     `addTheme`/`listThemes` work before or outside any provider.
+ */
+
+import { RGBA } from "@opentui/core"
+import { useRenderer } from "@opentui/react"
+import { type ReactNode, createContext, useContext, useEffect, useMemo, useSyncExternalStore } from "react"
+import {
+  BUNDLED_THEMES,
+  type FocusAccentSlot,
+  type Theme,
+  type ThemeJson,
+  applyDisplayOverlay,
+  resolveTheme,
+} from "../../tui/context/theme-core"
+import { createExternalStore } from "../lib/external-store"
+
+export { FOCUS_ACCENT_SLOTS, resolveTheme } from "../../tui/context/theme-core"
+export type { FocusAccentSlot, Theme, ThemeJson } from "../../tui/context/theme-core"
+
+type State = {
+  readonly themes: Record<string, ThemeJson>
+  readonly active: string
+  readonly mode: "dark" | "light"
+  readonly transparentBackground: boolean
+  readonly focusAccent: FocusAccentSlot
+}
+
+const store = createExternalStore<State>({
+  themes: { ...BUNDLED_THEMES },
+  active: "claude",
+  mode: "dark",
+  transparentBackground: false,
+  focusAccent: "primary",
+})
+
+export function listThemes(): string[] {
+  return Object.keys(store.get().themes)
+}
+
+export function hasTheme(name: string): boolean {
+  return Boolean(store.get().themes[name])
+}
+
+export function addTheme(name: string, theme: ThemeJson): boolean {
+  if (!name) return false
+  if (!theme || typeof theme !== "object" || !theme.theme) return false
+  store.update((s) => ({ ...s, themes: { ...s.themes, [name]: theme } }))
+  return true
+}
+
+export type ThemeContextValue = {
+  /** The resolved palette. Plain object — re-renders arrive via context. */
+  theme: Theme
+  selected: string
+  transparentBackground: boolean
+  focusAccent: FocusAccentSlot
+  mode(): "dark" | "light"
+  set(name: string): boolean
+  setMode(mode: "dark" | "light"): void
+  setTransparentBackground(v: boolean): void
+  setFocusAccent(v: FocusAccentSlot): void
+  all(): string[]
+  has(name: string): boolean
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+function resolveActive(state: State): Theme {
+  const active = state.themes[state.active]
+  if (active) return resolveTheme(active, state.mode)
+  // safety net: if active was somehow cleared, fall back to claude
+  const fallback = state.themes.claude ?? state.themes.opencode ?? Object.values(state.themes)[0]
+  if (!fallback) {
+    // truly empty — synthesize a black theme so the renderer can stand up
+    return resolveTheme({ theme: { background: "#000000", text: "#ffffff" } }, state.mode)
+  }
+  return resolveTheme(fallback, state.mode)
+}
+
+export function ThemeProvider(props: { children?: ReactNode; mode?: "dark" | "light"; theme?: string }) {
+  // Seed once from props, mirroring the Solid provider's init block. Done
+  // during the first render (not an effect) so the very first paint already
+  // uses the requested theme; the store dedupes identical snapshots.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: seed-once semantics, matching Solid's init.
+  useMemo(() => {
+    store.update((s) => ({
+      ...s,
+      mode: props.mode ?? s.mode,
+      active: props.theme && s.themes[props.theme] ? props.theme : s.active,
+    }))
+  }, [])
+
+  const state = useSyncExternalStore(store.subscribe, store.get, store.get)
+  const renderer = useRenderer()
+
+  const theme = useMemo(
+    () => applyDisplayOverlay(resolveActive(state), state.focusAccent, state.transparentBackground),
+    [state],
+  )
+
+  // Push background to the renderer so the terminal background matches
+  // (or shows through, when transparentBackground is on).
+  useEffect(() => {
+    renderer?.setBackgroundColor(theme.background ?? RGBA.fromInts(0, 0, 0))
+  }, [renderer, theme])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      selected: state.active,
+      transparentBackground: state.transparentBackground,
+      focusAccent: state.focusAccent,
+      mode: () => state.mode,
+      set(name: string): boolean {
+        if (!hasTheme(name)) return false
+        store.update((s) => ({ ...s, active: name }))
+        return true
+      },
+      setMode(mode: "dark" | "light"): void {
+        store.update((s) => ({ ...s, mode }))
+      },
+      setTransparentBackground(v: boolean): void {
+        store.update((s) => ({ ...s, transparentBackground: v }))
+      },
+      setFocusAccent(v: FocusAccentSlot): void {
+        store.update((s) => ({ ...s, focusAccent: v }))
+      },
+      all: listThemes,
+      has: hasTheme,
+    }),
+    [theme, state],
+  )
+
+  return <ThemeContext.Provider value={value}>{props.children}</ThemeContext.Provider>
+}
+
+export function useTheme(): ThemeContextValue {
+  const value = useContext(ThemeContext)
+  if (!value) throw new Error("Theme context must be used within a context provider")
+  return value
+}

--- a/packages/kobe/src/tui-react/i18n/index.ts
+++ b/packages/kobe/src/tui-react/i18n/index.ts
@@ -1,0 +1,67 @@
+/**
+ * React translation runtime (issue #15, G2) — the `src/tui/i18n/index.ts`
+ * counterpart for React panes. Same catalogs, same resolution rules (shared
+ * `../../tui/i18n/lookup`), different reactivity story:
+ *
+ * Under Solid, a bare `t("…")` inside JSX subscribes to the language store
+ * automatically. React has no tracked scopes, so a component that wants to
+ * re-render on language change MUST call `useT()` (or `useLang()`) and use
+ * the returned function — that hook subscribes via `useSyncExternalStore`.
+ * The module-level `t()` stays available for non-component code (log lines,
+ * one-shot formatting) where re-render doesn't apply.
+ *
+ * Repo i18n convention still holds: never capture a translation RESULT in a
+ * module-level constant — that freezes the language.
+ */
+
+import { useCallback, useSyncExternalStore } from "react"
+import { CATALOGS, DEFAULT_LOCALE, LOCALES, type LocaleId } from "../../tui/i18n/catalog"
+import { interpolate, lookup, lookupKeys } from "../../tui/i18n/lookup"
+import { createExternalStore } from "../lib/external-store"
+
+export { LOCALES, DEFAULT_LOCALE, isLocaleId } from "../../tui/i18n/catalog"
+export type { LocaleId } from "../../tui/i18n/catalog"
+
+const langStore = createExternalStore<LocaleId>(DEFAULT_LOCALE)
+
+/** Switch the active UI language for THIS process. No-op on an unknown id. */
+export function setLocaleLang(lang: LocaleId): void {
+  if (CATALOGS[lang]) langStore.set(lang)
+}
+
+/** The active language id (non-reactive read; components use `useLang`). */
+export function currentLang(): LocaleId {
+  return langStore.get()
+}
+
+/**
+ * Translate `key` for the active language. Falls back to English, then to
+ * the raw key (a missing string is loud, not blank). NOT reactive — inside
+ * components use `useT()` so the caller re-renders on language change.
+ */
+export function t(key: string, params?: Record<string, string | number>): string {
+  const lang = langStore.get()
+  const resolved = lookup(CATALOGS[lang], key) ?? lookup(CATALOGS.en, key) ?? key
+  return interpolate(resolved, params)
+}
+
+/** Keybinding-catalog lookup (`keys.category.*` / `keys.desc.*`) by exact id. */
+export function tKeys(group: "category" | "desc", key: string): string {
+  const lang = langStore.get()
+  return lookupKeys(CATALOGS[lang], group, key) ?? lookupKeys(CATALOGS.en, group, key) ?? key
+}
+
+/** Subscribe the component to the active language. */
+export function useLang(): LocaleId {
+  return useSyncExternalStore(langStore.subscribe, langStore.get, langStore.get)
+}
+
+/**
+ * Language-subscribed `t`. The returned function is identity-stable per
+ * language, so it is safe in dependency arrays and memoized children.
+ */
+export function useT(): typeof t {
+  const lang = useLang()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `lang` is the invalidation key — t reads it via the store.
+  return useCallback<typeof t>((key, params) => t(key, params), [lang])
+}

--- a/packages/kobe/src/tui-react/lib/external-store.ts
+++ b/packages/kobe/src/tui-react/lib/external-store.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal framework-free observable store — the React migration's stand-in
+ * for the Solid module-level `createStore`/`createSignal` singletons (issue
+ * #15, G2). Solid modules get reactivity for free by reading a store inside
+ * a tracked scope; React needs an explicit subscribe/getSnapshot pair for
+ * `useSyncExternalStore`. This helper is deliberately tiny: synchronous
+ * notify, identity-compared snapshots, no selectors — module singletons in
+ * this codebase hold small value objects, not collections.
+ */
+
+export interface ExternalStore<T> {
+  get(): T
+  /** Replace the snapshot and notify when the reference actually changed. */
+  set(next: T): void
+  /** Functional update over the current snapshot. */
+  update(fn: (current: T) => T): void
+  /** Subscribe to changes; returns the unsubscribe function. */
+  subscribe(listener: () => void): () => void
+}
+
+export function createExternalStore<T>(initial: T): ExternalStore<T> {
+  let snapshot = initial
+  const listeners = new Set<() => void>()
+  return {
+    get: () => snapshot,
+    set(next: T) {
+      if (Object.is(next, snapshot)) return
+      snapshot = next
+      for (const listener of [...listeners]) listener()
+    },
+    update(fn) {
+      this.set(fn(snapshot))
+    },
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}

--- a/packages/kobe/src/tui-react/lib/keymap.ts
+++ b/packages/kobe/src/tui-react/lib/keymap.ts
@@ -1,0 +1,74 @@
+/**
+ * React key-bindings layer (issue #15, G2) — the `src/tui/lib/keymap.tsx`
+ * counterpart for React panes. The dispatcher core (LIFO stack walk, chord
+ * matching, preventDefault-on-first-hit) is the shared framework-free
+ * `src/tui/lib/keymap-dispatch.ts`; this file owns only registration.
+ *
+ * Contract parity with the Solid hook:
+ *   - `config` is re-evaluated on EVERY keypress. The Solid version relies
+ *     on closures over signals staying live; React closures go stale across
+ *     renders, so the registered entry reads the LATEST config through a
+ *     ref that every render refreshes.
+ *   - Bindings stack LIFO; only the topmost enabled match fires.
+ *
+ * Known ordering difference (documented, accepted for the migration): Solid
+ * registers during component SETUP (parents before children → children end
+ * up on top); React registers in mount EFFECTS (children before parents →
+ * ancestors end up on top). The only cross-level competitor today is the
+ * dialog provider's escape/ctrl+c pair, which gates itself on the dialog
+ * stack being non-empty — modal-on-top is the desired behavior anyway.
+ */
+
+import type { KeyEvent, KeyHandler } from "@opentui/core"
+import { useRenderer } from "@opentui/react"
+import { useEffect, useRef } from "react"
+import { type BindingsConfig, type RegisteredBinding, dispatchKeyEvent } from "../../tui/lib/keymap-dispatch"
+
+export type { Binding, BindingsConfig, RegisteredBinding } from "../../tui/lib/keymap-dispatch"
+export { dispatchKeyEvent } from "../../tui/lib/keymap-dispatch"
+
+let nextId = 1
+const stack: RegisteredBinding[] = []
+// Same renderer-swap guard as the Solid layer: production runs one renderer
+// per process (no-op from the second call), but a test harness that creates
+// a fresh renderer per test in the same process must rebind the listener to
+// the new renderer's keyInput emitter.
+let installedRenderer: unknown = null
+let installed: KeyHandler | null = null
+let listener: ((evt: KeyEvent) => void) | null = null
+
+function ensureInstalled(renderer: ReturnType<typeof useRenderer>): void {
+  if (!renderer) {
+    throw new Error("useBindings: no renderer in scope; call inside a component rendered by @opentui/react.")
+  }
+  if (installedRenderer === renderer) return
+  if (installed && listener) installed.off("keypress", listener)
+  installedRenderer = renderer
+  installed = renderer.keyInput
+  listener = (evt: KeyEvent) => {
+    dispatchKeyEvent(stack, evt)
+  }
+  installed.on("keypress", listener)
+}
+
+/**
+ * Register a set of bindings for the lifetime of the calling component.
+ * The `config` function is re-evaluated on every keypress via a ref, so
+ * `enabled` flags computed from the latest render stay correct.
+ */
+export function useBindings(config: () => BindingsConfig): void {
+  const renderer = useRenderer()
+  ensureInstalled(renderer)
+
+  const configRef = useRef(config)
+  configRef.current = config
+
+  useEffect(() => {
+    const reg: RegisteredBinding = { config: () => configRef.current(), id: nextId++ }
+    stack.push(reg)
+    return () => {
+      const i = stack.findIndex((r) => r.id === reg.id)
+      if (i >= 0) stack.splice(i, 1)
+    }
+  }, [])
+}

--- a/packages/kobe/src/tui-react/mock/host.tsx
+++ b/packages/kobe/src/tui-react/mock/host.tsx
@@ -1,65 +1,80 @@
 /** @jsxImportSource @opentui/react */
 /**
- * G1 React runtime pilot for issue #15.
+ * React pilot entry (issue #15) — G1 established the isolated runtime;
+ * G2 upgraded this host to mount the full React infrastructure stack
+ * (Theme → Focus → Dialog providers + useBindings + i18n) so `bun run
+ * dev:mock-react` is an end-to-end proof that the ported context layer
+ * renders and dispatches keys. Deliberately NOT wired into the CLI entry
+ * or compile graph yet.
  *
- * This entry is deliberately NOT wired into the CLI entry or compile graph yet.
- * It proves @opentui/react can run beside the existing Solid TUI without
- * sharing imports, providers, or theme context.
+ * Keys: q quits · tab cycles pane focus · d opens a dialog (esc closes).
  */
 
 import { TextAttributes, createCliRenderer } from "@opentui/core"
-import { createRoot, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react"
+import { createRoot } from "@opentui/react"
+import { FocusProvider, PANE_ORDER, useFocus } from "../context/focus"
+import { ThemeProvider, useTheme } from "../context/theme"
+import { t } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { Dialog, DialogProvider, useDialog } from "../ui/dialog"
 
-const palette = {
-  background: "#0b0f14",
-  surface: "#18212b",
-  tag: "#7dd3fc",
-  title: "#e5eef7",
-  muted: "#9aa8b5",
-  body: "#c8d3dd",
+function DemoDialog() {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  return (
+    <Dialog size="small" onClose={() => dialog.clear()}>
+      <box paddingLeft={2} paddingRight={2} paddingBottom={1}>
+        <text fg={theme.text} wrapMode="word">
+          React dialog stack works — esc closes.
+        </text>
+      </box>
+    </Dialog>
+  )
 }
 
-function exitCleanly(renderer: ReturnType<typeof useRenderer>): void {
-  try {
-    renderer?.destroy()
-  } catch (err) {
-    console.error("kobe react mock: renderer.destroy() failed:", err)
-  }
-  process.exit(0)
-}
+function Workbench() {
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
+  const focus = useFocus()
+  const dialog = useDialog()
 
-function ReactMockPane() {
-  const renderer = useRenderer()
-  const dims = useTerminalDimensions()
-
-  useKeyboard((evt) => {
-    if (evt.name === "q") exitCleanly(renderer)
-  })
+  useBindings(() => ({
+    enabled: true,
+    bindings: [
+      { key: "q", cmd: () => process.exit(0) },
+      { key: "tab", cmd: () => focus.cycle(1) },
+      { key: "d", cmd: () => dialog.replace(() => <DemoDialog />) },
+    ],
+  }))
 
   return (
-    <box flexDirection="column" flexGrow={1} backgroundColor={palette.background}>
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
       <box
         flexDirection="row"
         gap={1}
         paddingLeft={1}
         paddingRight={1}
         flexShrink={0}
-        backgroundColor={palette.surface}
+        backgroundColor={theme.backgroundElement}
       >
-        <text fg={palette.tag} attributes={TextAttributes.BOLD} wrapMode="none">
+        <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
           REACT
         </text>
-        <text fg={palette.title} attributes={TextAttributes.BOLD} wrapMode="none">
-          kobe mock pane
+        <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
+          kobe infra pilot
         </text>
         <box flexGrow={1} />
-        <text fg={palette.muted} wrapMode="none">
-          q exits
+        <text fg={theme.textMuted} wrapMode="none">
+          q quit · tab focus · d dialog
         </text>
       </box>
-      <box paddingLeft={1} paddingRight={1} paddingTop={1} flexGrow={1}>
-        <text fg={palette.body} wrapMode="word">
-          React 19.2 + @opentui/react 0.4.3 are isolated under src/tui-react ({dims.width}x{dims.height}).
+      <box paddingLeft={1} paddingRight={1} paddingTop={1} flexDirection="column" flexGrow={1}>
+        <text fg={theme.text} wrapMode="word">
+          {/* i18n runtime proof: a real catalog key through the shared lookup. */}
+          {t("chat.thinking")} — theme "{themeCtx.selected}", focused pane: {focus.focused}
+        </text>
+        <text fg={theme.textMuted} wrapMode="none">
+          panes: {PANE_ORDER.map((p) => (p === focus.focused ? `[${p}]` : p)).join(" ")}
         </text>
       </box>
     </box>
@@ -67,4 +82,12 @@ function ReactMockPane() {
 }
 
 const renderer = await createCliRenderer({ exitOnCtrlC: true })
-createRoot(renderer).render(<ReactMockPane />)
+createRoot(renderer).render(
+  <ThemeProvider>
+    <FocusProvider>
+      <DialogProvider>
+        <Workbench />
+      </DialogProvider>
+    </FocusProvider>
+  </ThemeProvider>,
+)

--- a/packages/kobe/src/tui-react/ui/dialog.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog.tsx
@@ -1,0 +1,233 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Dialog stack (React port of `src/tui/ui/dialog.tsx`, issue #15 G2).
+ * Public API preserved: `useDialog` → `{ replace, push, pop, clear, stack,
+ * size, setSize }`, dialog bodies passed as THUNKS. The thunk contract
+ * matters less in React (elements are plain objects, safe to create in key
+ * handlers), but keeping it means Solid call sites port unchanged and the
+ * body is created fresh per render of the provider.
+ *
+ * Same behaviors as the Solid original: overlay is an absolutely-positioned
+ * box at the provider tail (no portal machinery), escape/ctrl+c pop the top
+ * dialog unless a text selection is active, the renderable that held native
+ * focus when the first dialog opened is refocused after the stack empties
+ * (deferred 1ms, cancelled on unmount), and the card stays opaque even in
+ * transparent mode.
+ */
+
+import { RGBA, type Renderable } from "@opentui/core"
+import { useRenderer, useTerminalDimensions } from "@opentui/react"
+import { type ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
+import { useTheme } from "../context/theme"
+import { useBindings } from "../lib/keymap"
+
+export type DialogSize = "small" | "medium" | "large" | "xlarge"
+
+const DIALOG_BACKDROP = RGBA.fromInts(0, 0, 0, 128)
+const TRANSPARENT_DIALOG_BACKDROP = RGBA.fromInts(0, 0, 0, 64)
+
+export function Dialog(props: { children?: ReactNode; size?: DialogSize; onClose: () => void }) {
+  const dimensions = useTerminalDimensions()
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
+  const renderer = useRenderer()
+
+  const dismissRef = useRef(false)
+  // Default-medium = 80 cols; small (50) is for tight yes/no prompts;
+  // large/xlarge get proportional bumps. Same rationale as the Solid
+  // original (wide help/settings cards need headroom, narrow PTYs cap
+  // at width-2 via maxWidth below).
+  const width = props.size === "xlarge" ? 140 : props.size === "large" ? 110 : props.size === "small" ? 50 : 80
+
+  // Vertical headroom around the card so it never lands flush against
+  // the terminal's top/bottom edge.
+  const VERTICAL_MARGIN = 2
+  const maxCardHeight = Math.max(8, dimensions.height - VERTICAL_MARGIN * 2)
+
+  return (
+    <box
+      onMouseDown={() => {
+        dismissRef.current = !!renderer?.getSelection()
+      }}
+      onMouseUp={() => {
+        if (dismissRef.current) {
+          dismissRef.current = false
+          return
+        }
+        props.onClose?.()
+      }}
+      width={dimensions.width}
+      height={dimensions.height}
+      alignItems="center"
+      // Center short cards; tall cards clip to maxCardHeight instead of
+      // overflowing (children that need scrolling wrap their own scrollbox).
+      justifyContent="center"
+      position="absolute"
+      zIndex={3000}
+      left={0}
+      top={0}
+      backgroundColor={themeCtx.transparentBackground ? TRANSPARENT_DIALOG_BACKDROP : DIALOG_BACKDROP}
+    >
+      <box
+        onMouseUp={(e: { stopPropagation(): void }) => {
+          dismissRef.current = false
+          e.stopPropagation()
+        }}
+        width={width}
+        maxWidth={dimensions.width - 2}
+        maxHeight={maxCardHeight}
+        flexShrink={1}
+        // Content-sized + maxHeight is the contract: short cards float as a
+        // tight block, tall cards hit the cap and clip.
+        flexGrow={0}
+        // The card is ALWAYS opaque — even in transparent mode (where only
+        // the backdrop lightens). A translucent card lets pane content bleed
+        // through the dialog text and becomes unreadable.
+        backgroundColor={theme.backgroundDialog}
+        paddingTop={1}
+      >
+        {props.children}
+      </box>
+    </box>
+  )
+}
+
+type StackEntry = { element: () => ReactNode; onClose?: () => void }
+
+export type DialogContext = {
+  clear(): void
+  /**
+   * Replace the current dialog (if any) with a new one. The body stays a
+   * thunk for Solid-API parity; it is evaluated inside the provider's
+   * render, so hooks/contexts resolve normally.
+   */
+  replace(thunk: () => ReactNode, onClose?: () => void): void
+  push(thunk: () => ReactNode, onClose?: () => void): void
+  pop(): void
+  readonly stack: readonly StackEntry[]
+  readonly size: DialogSize
+  setSize(size: DialogSize): void
+}
+
+const ctx = createContext<DialogContext | null>(null)
+
+export function DialogProvider(props: { children?: ReactNode }) {
+  const [stack, setStack] = useState<readonly StackEntry[]>([])
+  const [size, setSize] = useState<DialogSize>("medium")
+  const renderer = useRenderer()
+
+  const focusRef = useRef<Renderable | null>(null)
+  const refocusTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Cancel a pending deferred refocus on unmount so `.focus()` can't land
+  // on a renderable destroyed in the same tick (the Solid version used an
+  // owner-scoped managed timeout for this).
+  useEffect(
+    () => () => {
+      if (refocusTimer.current) clearTimeout(refocusTimer.current)
+    },
+    [],
+  )
+
+  const refocus = useCallback(() => {
+    if (refocusTimer.current) clearTimeout(refocusTimer.current)
+    refocusTimer.current = setTimeout(() => {
+      const focus = focusRef.current
+      if (!focus || focus.isDestroyed) return
+      function find(item: Renderable): boolean {
+        for (const child of item.getChildren()) {
+          if (child === focus) return true
+          if (find(child)) return true
+        }
+        return false
+      }
+      const root = renderer?.root
+      if (!root) return
+      if (!find(root)) return
+      focus.focus()
+    }, 1)
+  }, [renderer])
+
+  // Latest stack for callbacks (kept in a ref so replace/push/pop/clear can
+  // stay identity-stable while reading current state).
+  const stackRef = useRef(stack)
+  stackRef.current = stack
+
+  const captureFocusIfFirst = useCallback(() => {
+    if (stackRef.current.length === 0) {
+      focusRef.current = renderer?.currentFocusedRenderable ?? null
+      focusRef.current?.blur()
+    }
+  }, [renderer])
+
+  // escape and ctrl+c both dismiss the top dialog identically.
+  const dismissTop = useCallback(() => {
+    if (renderer?.getSelection()) renderer.clearSelection()
+    const current = stackRef.current.at(-1)
+    current?.onClose?.()
+    setStack((s) => s.slice(0, -1))
+    refocus()
+  }, [renderer, refocus])
+
+  useBindings(() => ({
+    enabled: stackRef.current.length > 0 && !renderer?.getSelection()?.getSelectedText(),
+    bindings: [
+      { key: "escape", cmd: dismissTop },
+      { key: "ctrl+c", cmd: dismissTop },
+    ],
+  }))
+
+  const value = useMemo<DialogContext>(
+    () => ({
+      clear() {
+        for (const item of stackRef.current) item.onClose?.()
+        setSize("medium")
+        setStack([])
+        refocus()
+      },
+      replace(thunk, onClose) {
+        captureFocusIfFirst()
+        for (const item of stackRef.current) item.onClose?.()
+        setSize("medium")
+        setStack([{ element: thunk, onClose }])
+      },
+      push(thunk, onClose) {
+        captureFocusIfFirst()
+        setStack((s) => [...s, { element: thunk, onClose }])
+      },
+      pop() {
+        const current = stackRef.current.at(-1)
+        current?.onClose?.()
+        setStack((s) => s.slice(0, -1))
+        if (stackRef.current.length <= 1) refocus()
+      },
+      get stack() {
+        return stackRef.current
+      },
+      get size() {
+        return size
+      },
+      setSize,
+    }),
+    [size, refocus, captureFocusIfFirst],
+  )
+
+  const top = stack.at(-1)
+  return (
+    <ctx.Provider value={value}>
+      {props.children}
+      <box position="absolute" zIndex={3000}>
+        {top ? (
+          <Dialog onClose={() => value.clear()} size={size}>
+            {top.element()}
+          </Dialog>
+        ) : null}
+      </box>
+    </ctx.Provider>
+  )
+}
+
+export function useDialog(): DialogContext {
+  const value = useContext(ctx)
+  if (!value) throw new Error("useDialog must be used within a DialogProvider")
+  return value
+}

--- a/packages/kobe/src/tui/context/keybindings.ts
+++ b/packages/kobe/src/tui/context/keybindings.ts
@@ -360,9 +360,23 @@ export function resetKeymapToDefaults(): void {
 const [keymapVersion, setKeymapVersion] = createSignal(0)
 export { keymapVersion }
 
+// Framework-free companion to the Solid signal above: React chord legends
+// subscribe here via useSyncExternalStore (src/tui-react/context/keybindings.ts,
+// issue #15 G2). Solid consumers keep tracking the signal — same bump feeds both.
+const keymapVersionListeners = new Set<() => void>()
+
+/** Subscribe to keymap reloads (React side). Returns the unsubscribe fn. */
+export function subscribeKeymapVersion(listener: () => void): () => void {
+  keymapVersionListeners.add(listener)
+  return () => {
+    keymapVersionListeners.delete(listener)
+  }
+}
+
 /** Increment {@link keymapVersion}, forcing chord legends to re-render. */
 export function bumpKeymapVersion(): void {
   setKeymapVersion((v) => v + 1)
+  for (const listener of [...keymapVersionListeners]) listener()
 }
 
 /**

--- a/packages/kobe/src/tui/context/theme-core.ts
+++ b/packages/kobe/src/tui/context/theme-core.ts
@@ -1,0 +1,186 @@
+/**
+ * Framework-free theme core, shared by the Solid provider (`./theme.tsx`)
+ * and the React one (`src/tui-react/context/theme.tsx`). Extracted during
+ * the React migration (issue #15, G2): JSON shape types, the bundled theme
+ * registry, hex/def-ref/variant resolution, and the display-time overlay
+ * (focus-accent slot + transparent-background policy) all live here so the
+ * two providers cannot drift.
+ */
+
+import { RGBA } from "@opentui/core"
+
+import claude from "./theme/claude.json" with { type: "json" }
+import conductor from "./theme/conductor.json" with { type: "json" }
+import dracula from "./theme/dracula.json" with { type: "json" }
+import nord from "./theme/nord.json" with { type: "json" }
+import opencode from "./theme/opencode.json" with { type: "json" }
+import osakaJade from "./theme/osaka-jade.json" with { type: "json" }
+import tokyonight from "./theme/tokyonight.json" with { type: "json" }
+
+type HexColor = `#${string}`
+type RefName = string
+type Variant = { dark: HexColor | RefName; light: HexColor | RefName }
+type ColorValue = HexColor | RefName | Variant
+
+export type ThemeJson = {
+  $schema?: string
+  defs?: Record<string, HexColor | RefName>
+  theme: Record<string, ColorValue>
+}
+
+/**
+ * The set of color slots kobe components expect to find on a `Theme`. The
+ * names mirror opencode's so lifted components keep compiling. Entries marked
+ * optional fall back to a related slot when missing.
+ */
+export type Theme = {
+  primary: RGBA
+  secondary: RGBA
+  accent: RGBA
+  error: RGBA
+  warning: RGBA
+  success: RGBA
+  info: RGBA
+  text: RGBA
+  textMuted: RGBA
+  background: RGBA
+  backgroundPanel: RGBA
+  backgroundElement: RGBA
+  backgroundMenu: RGBA
+  /**
+   * Modal/dialog card surface. In transparent mode this keeps the same
+   * RGB as the active theme but becomes semi-transparent so the host
+   * terminal can show through the card.
+   * Falls back to `backgroundPanel` at theme-resolution time.
+   */
+  backgroundDialog: RGBA
+  border: RGBA
+  borderActive: RGBA
+  borderSubtle: RGBA
+  diffAdded: RGBA
+  diffRemoved: RGBA
+  diffContext: RGBA
+  diffHunkHeader: RGBA
+  diffAddedBg: RGBA
+  diffRemovedBg: RGBA
+  selectedListItemText: RGBA
+  /**
+   * Resolved focus-indicator color. Components that paint focus state
+   * read this instead of picking primary/success/info directly, so the
+   * user-controlled `focusAccent` setting unifies the focus signal.
+   */
+  focusAccent: RGBA
+  // arbitrary string access falls through to text
+  [key: string]: RGBA
+}
+
+export const BUNDLED_THEMES: Record<string, ThemeJson> = {
+  // Claude-branded palette (terracotta accent on warm neutrals), ported
+  // from ashwingopalsamy/claude-code-theme's brandTokens. Default for
+  // new kobe installs so the TUI reads as part of the Claude ecosystem.
+  claude: claude as ThemeJson,
+  conductor: conductor as ThemeJson,
+  nord: nord as ThemeJson,
+  opencode: opencode as ThemeJson,
+  dracula: dracula as ThemeJson,
+  tokyonight: tokyonight as ThemeJson,
+  "osaka-jade": osakaJade as ThemeJson,
+}
+
+/**
+ * Which theme slot drives the "focused pane" indicator. Default is
+ * `primary` — under the Claude palette that's terracotta, which doubles
+ * as the brand hue. `success` keeps the older green-focus look
+ * (opencode legacy); `info` picks the cyan/blue. Persisted via KV.
+ */
+export type FocusAccentSlot = "primary" | "success" | "info"
+export const FOCUS_ACCENT_SLOTS: ReadonlyArray<FocusAccentSlot> = ["primary", "success", "info"]
+
+/**
+ * Resolve a theme JSON to flat RGBA values. Missing slots fall back to
+ * `text` for foregrounds and `background` for backgrounds; this means we
+ * never throw if a freshly-copied opencode theme is missing one of the
+ * extended slots opencode added later.
+ */
+export function resolveTheme(theme: ThemeJson, mode: "dark" | "light" = "dark"): Theme {
+  const defs = theme.defs ?? {}
+
+  function resolve(c: ColorValue, chain: string[] = []): RGBA {
+    if (typeof c === "string") {
+      if (c === "transparent" || c === "none") return RGBA.fromInts(0, 0, 0, 0)
+      if (c.startsWith("#")) return RGBA.fromHex(c)
+      if (chain.includes(c)) {
+        // circular ref — collapse to black rather than throw to keep the TUI alive
+        return RGBA.fromInts(0, 0, 0)
+      }
+      const next = defs[c] ?? (theme.theme[c] as ColorValue | undefined)
+      if (next === undefined) return RGBA.fromInts(0, 0, 0)
+      return resolve(next, [...chain, c])
+    }
+    return resolve(c[mode], chain)
+  }
+
+  const out: Record<string, RGBA> = {}
+  for (const [k, v] of Object.entries(theme.theme)) {
+    out[k] = resolve(v as ColorValue)
+  }
+
+  // Fallback chain: ensure the slots kobe components consume are defined.
+  const text = out.text ?? RGBA.fromHex("#ffffff")
+  const background = out.background ?? RGBA.fromHex("#000000")
+  const fallback: Record<string, RGBA> = {
+    primary: out.primary ?? text,
+    secondary: out.secondary ?? text,
+    accent: out.accent ?? out.primary ?? text,
+    error: out.error ?? text,
+    warning: out.warning ?? text,
+    success: out.success ?? text,
+    info: out.info ?? text,
+    text,
+    textMuted: out.textMuted ?? text,
+    background,
+    backgroundPanel: out.backgroundPanel ?? background,
+    backgroundElement: out.backgroundElement ?? background,
+    backgroundMenu: out.backgroundMenu ?? out.backgroundElement ?? background,
+    backgroundDialog: out.backgroundDialog ?? out.backgroundPanel ?? background,
+    border: out.border ?? text,
+    borderActive: out.borderActive ?? out.border ?? text,
+    borderSubtle: out.borderSubtle ?? out.border ?? text,
+    diffAdded: out.diffAdded ?? out.success ?? text,
+    diffRemoved: out.diffRemoved ?? out.error ?? text,
+    diffContext: out.diffContext ?? out.textMuted ?? text,
+    diffHunkHeader: out.diffHunkHeader ?? out.textMuted ?? text,
+    diffAddedBg: out.diffAddedBg ?? background,
+    diffRemovedBg: out.diffRemovedBg ?? background,
+    selectedListItemText: out.selectedListItemText ?? background,
+  }
+
+  return { ...fallback, ...out } as Theme
+}
+
+/**
+ * Display-time overlay on a resolved palette:
+ *
+ *   1. `focusAccent` is derived from the user-picked slot (primary /
+ *      success / info), falling back to `primary` if a user-installed
+ *      theme is missing the chosen slot.
+ *   2. When `transparentBackground` is on, BOTH `background` AND
+ *      `backgroundPanel` are forced to alpha-0 — panels (sidebar, right
+ *      column, chat tab strip) all read panel, and the policy is "in
+ *      transparent mode, get out of the way of the host terminal". Only
+ *      `backgroundElement` keeps its tinted value so the chat input stays
+ *      legible against any host wallpaper. `backgroundDialog` deliberately
+ *      stays OPAQUE: a translucent modal card lets pane content bleed
+ *      through the dialog text. Transparency is for the chrome around
+ *      content, never for an overlay you must read.
+ */
+export function applyDisplayOverlay(base: Theme, focusAccent: FocusAccentSlot, transparentBackground: boolean): Theme {
+  const v: Theme = { ...base, focusAccent: base[focusAccent] ?? base.primary }
+  if (!transparentBackground) return v
+  const transparent = RGBA.fromInts(0, 0, 0, 0)
+  return {
+    ...v,
+    background: transparent,
+    backgroundPanel: transparent,
+  }
+}

--- a/packages/kobe/src/tui/context/theme.tsx
+++ b/packages/kobe/src/tui/context/theme.tsx
@@ -1,122 +1,30 @@
 /**
- * Theme provider for kobe.
+ * Theme provider for kobe (Solid).
  *
- * Heavily simplified port of opencode's `context/theme.tsx`. We keep the JSON
- * shape (`defs` block + `theme.<name>.{dark|light}` color references) so the
- * theme files copied from opencode work unchanged; we drop the system theme
- * detection, plugin theme registration, syntax-highlight tables, and KV-backed
- * persistence — those stages all assume opencode's runtime, and we'll wire
- * persistence properly in a later stream.
- *
- * What's covered:
- *   - hex / def-ref / variant resolution (`#abc`, `nord3`, `{dark,light}`)
- *   - dark/light mode (defaults to dark; reactive setter)
- *   - exposes `theme` as a Proxy so consumers can read `theme.background`
- *     directly without re-extracting on every render
- *   - register additional themes at runtime via `addTheme`
- *
- * If a theme key is missing on a particular theme, we fall through to the
- * `kobe` default fallback theme — no crash, no `_hasSelectedListItemText`
- * bookkeeping like opencode (we also don't ship `selectedListItemText` as a
- * computed contrast color; for kobe, themes opt in or get `background`).
+ * Heavily simplified port of opencode's `context/theme.tsx`. The
+ * framework-free core — JSON shape, bundled registry, resolution, and the
+ * display overlay (focus accent + transparent background policy) — lives in
+ * `./theme-core.ts`, shared with the React provider
+ * (`src/tui-react/context/theme.tsx`, issue #15 G2). This file owns only the
+ * Solid reactivity: the module-level store, the `theme` Proxy (reads inside
+ * tracked scopes re-run on change), and the renderer background effect.
  */
 
-import { RGBA } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
 import { createEffect, createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
+import {
+  BUNDLED_THEMES,
+  type FocusAccentSlot,
+  type Theme,
+  type ThemeJson,
+  applyDisplayOverlay,
+  resolveTheme,
+} from "./theme-core"
 
-import claude from "./theme/claude.json" with { type: "json" }
-import conductor from "./theme/conductor.json" with { type: "json" }
-import dracula from "./theme/dracula.json" with { type: "json" }
-import nord from "./theme/nord.json" with { type: "json" }
-import opencode from "./theme/opencode.json" with { type: "json" }
-import osakaJade from "./theme/osaka-jade.json" with { type: "json" }
-import tokyonight from "./theme/tokyonight.json" with { type: "json" }
-
-type HexColor = `#${string}`
-type RefName = string
-type Variant = { dark: HexColor | RefName; light: HexColor | RefName }
-type ColorValue = HexColor | RefName | Variant
-
-export type ThemeJson = {
-  $schema?: string
-  defs?: Record<string, HexColor | RefName>
-  theme: Record<string, ColorValue>
-}
-
-/**
- * The set of color slots kobe components expect to find on a `Theme`. The
- * names mirror opencode's so lifted components keep compiling. Entries marked
- * optional fall back to a related slot when missing.
- */
-export type Theme = {
-  primary: RGBA
-  secondary: RGBA
-  accent: RGBA
-  error: RGBA
-  warning: RGBA
-  success: RGBA
-  info: RGBA
-  text: RGBA
-  textMuted: RGBA
-  background: RGBA
-  backgroundPanel: RGBA
-  backgroundElement: RGBA
-  backgroundMenu: RGBA
-  /**
-   * Modal/dialog card surface. In transparent mode this keeps the same
-   * RGB as the active theme but becomes semi-transparent so the host
-   * terminal can show through the card.
-   * Falls back to `backgroundPanel` at theme-resolution time.
-   */
-  backgroundDialog: RGBA
-  border: RGBA
-  borderActive: RGBA
-  borderSubtle: RGBA
-  diffAdded: RGBA
-  diffRemoved: RGBA
-  diffContext: RGBA
-  diffHunkHeader: RGBA
-  diffAddedBg: RGBA
-  diffRemovedBg: RGBA
-  selectedListItemText: RGBA
-  /**
-   * Resolved focus-indicator color. Components that paint focus state
-   * (PaneHeader, Sidebar header, ResizableEdge focused-adjacent,
-   * Terminal border) read this instead of picking primary/success/info
-   * directly, so the user-controlled `focusAccent` setting unifies the
-   * focus signal across panes.
-   */
-  focusAccent: RGBA
-  // arbitrary string access falls through to text
-  [key: string]: RGBA
-}
-
-const BUNDLED_THEMES: Record<string, ThemeJson> = {
-  // Claude-branded palette (terracotta accent on warm neutrals), ported
-  // from ashwingopalsamy/claude-code-theme's brandTokens. Default for
-  // new kobe installs so the TUI reads as part of the Claude ecosystem.
-  claude: claude as ThemeJson,
-  conductor: conductor as ThemeJson,
-  nord: nord as ThemeJson,
-  opencode: opencode as ThemeJson,
-  dracula: dracula as ThemeJson,
-  tokyonight: tokyonight as ThemeJson,
-  "osaka-jade": osakaJade as ThemeJson,
-}
-
-/**
- * Which theme slot drives the "focused pane" indicator (pane header
- * title + ▌ marker, sidebar header, resizable-edge, terminal border).
- * Default is `primary` — under the Claude palette that's terracotta,
- * which doubles as the brand hue. `success` keeps the older
- * green-focus look (opencode legacy); `info` picks the cyan/blue.
- * Persisted via KV from the Shell.
- */
-export type FocusAccentSlot = "primary" | "success" | "info"
-export const FOCUS_ACCENT_SLOTS: ReadonlyArray<FocusAccentSlot> = ["primary", "success", "info"]
+export { FOCUS_ACCENT_SLOTS, resolveTheme } from "./theme-core"
+export type { FocusAccentSlot, Theme, ThemeJson } from "./theme-core"
 
 type State = {
   themes: Record<string, ThemeJson>
@@ -156,68 +64,6 @@ export function addTheme(name: string, theme: ThemeJson): boolean {
   return true
 }
 
-/**
- * Resolve a theme JSON to flat RGBA values. Missing slots fall back to
- * `text` for foregrounds and `background` for backgrounds; this means we
- * never throw if a freshly-copied opencode theme is missing one of the
- * extended slots opencode added later.
- */
-export function resolveTheme(theme: ThemeJson, mode: "dark" | "light" = "dark"): Theme {
-  const defs = theme.defs ?? {}
-
-  function resolve(c: ColorValue, chain: string[] = []): RGBA {
-    if (typeof c === "string") {
-      if (c === "transparent" || c === "none") return RGBA.fromInts(0, 0, 0, 0)
-      if (c.startsWith("#")) return RGBA.fromHex(c)
-      if (chain.includes(c)) {
-        // circular ref — collapse to black rather than throw to keep the TUI alive
-        return RGBA.fromInts(0, 0, 0)
-      }
-      const next = defs[c] ?? (theme.theme[c] as ColorValue | undefined)
-      if (next === undefined) return RGBA.fromInts(0, 0, 0)
-      return resolve(next, [...chain, c])
-    }
-    return resolve(c[mode], chain)
-  }
-
-  const out: Record<string, RGBA> = {}
-  for (const [k, v] of Object.entries(theme.theme)) {
-    out[k] = resolve(v as ColorValue)
-  }
-
-  // Fallback chain: ensure the slots kobe components consume are defined.
-  const text = out.text ?? RGBA.fromHex("#ffffff")
-  const background = out.background ?? RGBA.fromHex("#000000")
-  const fallback: Record<string, RGBA> = {
-    primary: out.primary ?? text,
-    secondary: out.secondary ?? text,
-    accent: out.accent ?? out.primary ?? text,
-    error: out.error ?? text,
-    warning: out.warning ?? text,
-    success: out.success ?? text,
-    info: out.info ?? text,
-    text,
-    textMuted: out.textMuted ?? text,
-    background,
-    backgroundPanel: out.backgroundPanel ?? background,
-    backgroundElement: out.backgroundElement ?? background,
-    backgroundMenu: out.backgroundMenu ?? out.backgroundElement ?? background,
-    backgroundDialog: out.backgroundDialog ?? out.backgroundPanel ?? background,
-    border: out.border ?? text,
-    borderActive: out.borderActive ?? out.border ?? text,
-    borderSubtle: out.borderSubtle ?? out.border ?? text,
-    diffAdded: out.diffAdded ?? out.success ?? text,
-    diffRemoved: out.diffRemoved ?? out.error ?? text,
-    diffContext: out.diffContext ?? out.textMuted ?? text,
-    diffHunkHeader: out.diffHunkHeader ?? out.textMuted ?? text,
-    diffAddedBg: out.diffAddedBg ?? background,
-    diffRemovedBg: out.diffRemovedBg ?? background,
-    selectedListItemText: out.selectedListItemText ?? background,
-  }
-
-  return { ...fallback, ...out } as Theme
-}
-
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
   init: (props: { mode?: "dark" | "light"; theme?: string }) => {
@@ -236,35 +82,10 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       }
       return resolveTheme(fallback, store.mode)
     })
-    // Apply the transparent-bg toggle on top of the resolved palette.
-    // BOTH `background` AND `backgroundPanel` are forced transparent
-    // — panels (sidebar, right column, chat tab strip) all read panel,
-    // and Jackson's policy is "in transparent mode, get out of the
-    // way of the host terminal". Only `backgroundElement` (used by
-    // the composer body, slash dropdown, inactive tab fills) keeps
-    // its tinted value so the chat input stays legible against any
-    // host wallpaper. Every other token (text, primary, accent…)
-    // is unchanged. See memory/feedback_transparent_default_aggressive.md.
-    const values = createMemo(() => {
-      const base = baseValues()
-      // focusAccent is derived per-frame from the user-picked slot
-      // (primary / success / info). Falls back to primary if the
-      // resolved theme is missing the chosen slot — defensive against
-      // a user-installed theme that doesn't define `info`.
-      const focusAccent = base[store.focusAccent] ?? base.primary
-      const v: Theme = { ...base, focusAccent }
-      if (!store.transparentBackground) return v
-      const transparent = RGBA.fromInts(0, 0, 0, 0)
-      // `backgroundDialog` deliberately stays OPAQUE: a translucent modal
-      // card lets the pane content bleed through the dialog text, which
-      // makes settings/help/confirm dialogs unreadable. Transparency is
-      // for the chrome around content, never for an overlay you must read.
-      return {
-        ...v,
-        background: transparent,
-        backgroundPanel: transparent,
-      }
-    })
+    // Focus accent + transparent-bg policy live in theme-core so the React
+    // provider applies the identical overlay. See applyDisplayOverlay docs
+    // and memory/feedback_transparent_default_aggressive.md.
+    const values = createMemo(() => applyDisplayOverlay(baseValues(), store.focusAccent, store.transparentBackground))
 
     // Push background to the renderer so the terminal background matches
     // (or shows through, when transparentBackground is on).

--- a/packages/kobe/src/tui/i18n/index.ts
+++ b/packages/kobe/src/tui/i18n/index.ts
@@ -17,7 +17,8 @@
  */
 
 import { createStore } from "solid-js/store"
-import { CATALOGS, DEFAULT_LOCALE, LOCALES, type LocaleId, type Messages } from "./catalog"
+import { CATALOGS, DEFAULT_LOCALE, LOCALES, type LocaleId } from "./catalog"
+import { interpolate, lookup, lookupKeys } from "./lookup"
 
 export { LOCALES, DEFAULT_LOCALE, isLocaleId } from "./catalog"
 export type { LocaleId } from "./catalog"
@@ -32,25 +33,6 @@ export function setLocaleLang(lang: LocaleId): void {
 /** The active language id. Reactive — reads inside a tracked scope re-run on change. */
 export function currentLang(): LocaleId {
   return store.lang
-}
-
-/** Walk a dotted key (`a.b.c`) into a catalog, returning the leaf string or undefined. */
-function lookup(catalog: Messages, key: string): string | undefined {
-  let node: unknown = catalog
-  for (const part of key.split(".")) {
-    if (node && typeof node === "object" && part in (node as Record<string, unknown>)) {
-      node = (node as Record<string, unknown>)[part]
-    } else {
-      return undefined
-    }
-  }
-  return typeof node === "string" ? node : undefined
-}
-
-/** Substitute `{name}` placeholders; an absent param is left literal so the gap is visible. */
-function interpolate(template: string, params?: Record<string, string | number>): string {
-  if (!params) return template
-  return template.replace(/\{(\w+)\}/g, (whole, name: string) => (name in params ? String(params[name]) : whole))
 }
 
 /**
@@ -72,9 +54,5 @@ export function t(key: string, params?: Record<string, string | number>): string
  */
 export function tKeys(group: "category" | "desc", key: string): string {
   const lang = store.lang
-  const read = (cat: Messages): string | undefined => {
-    const leaf = (cat.keys as Record<string, Record<string, string>>)[group]
-    return leaf?.[key]
-  }
-  return read(CATALOGS[lang]) ?? read(CATALOGS.en) ?? key
+  return lookupKeys(CATALOGS[lang], group, key) ?? lookupKeys(CATALOGS.en, group, key) ?? key
 }

--- a/packages/kobe/src/tui/i18n/lookup.ts
+++ b/packages/kobe/src/tui/i18n/lookup.ts
@@ -1,0 +1,38 @@
+/**
+ * Framework-free catalog lookup + interpolation, shared by the Solid i18n
+ * runtime (`./index.ts`) and the React one (`src/tui-react/i18n/index.ts`).
+ * Extracted during the React migration (issue #15, G2) so neither runtime
+ * duplicates the resolution rules.
+ */
+
+import type { Messages } from "./catalog"
+
+/** Walk a dotted key (`a.b.c`) into a catalog, returning the leaf string or undefined. */
+export function lookup(catalog: Messages, key: string): string | undefined {
+  let node: unknown = catalog
+  for (const part of key.split(".")) {
+    if (node && typeof node === "object" && part in (node as Record<string, unknown>)) {
+      node = (node as Record<string, unknown>)[part]
+    } else {
+      return undefined
+    }
+  }
+  return typeof node === "string" ? node : undefined
+}
+
+/** Substitute `{name}` placeholders; an absent param is left literal so the gap is visible. */
+export function interpolate(template: string, params?: Record<string, string | number>): string {
+  if (!params) return template
+  return template.replace(/\{(\w+)\}/g, (whole, name: string) => (name in params ? String(params[name]) : whole))
+}
+
+/**
+ * Lookup for the keybinding catalog (`keys.category.*` / `keys.desc.*`),
+ * where the lookup key is itself a binding id like `chat.tab.new` whose dots
+ * would mis-split the generic dotted path. Indexes the leaf record by the
+ * EXACT key string instead.
+ */
+export function lookupKeys(catalog: Messages, group: "category" | "desc", key: string): string | undefined {
+  const leaf = (catalog.keys as Record<string, Record<string, string>>)[group]
+  return leaf?.[key]
+}

--- a/packages/kobe/test/tui-react/external-store.test.ts
+++ b/packages/kobe/test/tui-react/external-store.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Why this matters: `createExternalStore` is the reactive backbone of every
+ * React infra module (i18n language, theme state, keymap version). A bug in
+ * notify/dedupe semantics would silently freeze React panes on stale
+ * language/theme — the exact failure `useSyncExternalStore` is supposed to
+ * prevent — so the contract is pinned here framework-free.
+ */
+
+import { describe, expect, it, vi } from "vitest"
+import { createExternalStore } from "../../src/tui-react/lib/external-store"
+
+describe("createExternalStore", () => {
+  it("get returns the current snapshot; set replaces it", () => {
+    const store = createExternalStore({ n: 1 })
+    expect(store.get()).toEqual({ n: 1 })
+    store.set({ n: 2 })
+    expect(store.get()).toEqual({ n: 2 })
+  })
+
+  it("notifies subscribers on change and stops after unsubscribe", () => {
+    const store = createExternalStore(0)
+    const seen: number[] = []
+    const unsub = store.subscribe(() => seen.push(store.get()))
+    store.set(1)
+    store.set(2)
+    unsub()
+    store.set(3)
+    expect(seen).toEqual([1, 2])
+  })
+
+  it("dedupes identical snapshots (Object.is) — no phantom notifications", () => {
+    const store = createExternalStore("a")
+    const listener = vi.fn()
+    store.subscribe(listener)
+    store.set("a")
+    expect(listener).not.toHaveBeenCalled()
+    store.set("b")
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("update applies a functional transform over the current snapshot", () => {
+    const store = createExternalStore({ count: 1 })
+    store.update((s) => ({ count: s.count + 1 }))
+    expect(store.get()).toEqual({ count: 2 })
+  })
+
+  it("a listener unsubscribing during notify does not skip other listeners", () => {
+    const store = createExternalStore(0)
+    const seen: string[] = []
+    const unsubA = store.subscribe(() => {
+      seen.push("a")
+      unsubA()
+    })
+    store.subscribe(() => seen.push("b"))
+    store.set(1)
+    store.set(2)
+    expect(seen).toEqual(["a", "b", "b"])
+  })
+})

--- a/packages/kobe/test/tui-react/i18n.test.ts
+++ b/packages/kobe/test/tui-react/i18n.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Why this matters: the React i18n runtime re-implements the Solid one's
+ * OBSERVABLE behavior (dotted lookup, en → raw-key fallback, interpolation,
+ * per-process language switch) on a different reactivity substrate. These
+ * tests pin that the two runtimes resolve identically — drift here means a
+ * pane shows different copy depending on which framework rendered it.
+ */
+
+import { afterEach, describe, expect, it } from "vitest"
+import { DEFAULT_LOCALE, currentLang, setLocaleLang, t, tKeys } from "../../src/tui-react/i18n"
+import { t as solidT } from "../../src/tui/i18n"
+
+afterEach(() => setLocaleLang(DEFAULT_LOCALE))
+
+describe("react i18n runtime", () => {
+  it("resolves a real catalog key identically to the Solid runtime", () => {
+    setLocaleLang("en")
+    expect(t("chat.thinking")).toBe(solidT("chat.thinking"))
+  })
+
+  it("switches language per process and reports it", () => {
+    setLocaleLang("en")
+    const en = t("chat.thinking")
+    setLocaleLang("zh")
+    expect(currentLang()).toBe("zh")
+    expect(t("chat.thinking")).not.toBe(en)
+  })
+
+  it("ignores unknown locale ids", () => {
+    setLocaleLang("en")
+    setLocaleLang("xx" as never)
+    expect(currentLang()).toBe("en")
+  })
+
+  it("falls back to the raw key for a missing string (loud, not blank)", () => {
+    expect(t("definitely.not.a.key")).toBe("definitely.not.a.key")
+  })
+
+  it("interpolates {params} and leaves absent params literal", () => {
+    // The raw-key fallback goes through interpolation too (same as Solid),
+    // which pins both the substitution and the absent-param-stays-literal rule.
+    expect(t("x {who}", { who: "kobe" })).toBe("x kobe")
+    expect(t("x {who}", { other: "y" })).toBe("x {who}")
+    expect(t("x {who}")).toBe("x {who}")
+  })
+
+  it("tKeys indexes the keybinding catalog by exact id", () => {
+    setLocaleLang("en")
+    // Any real binding id resolves to a non-empty string that isn't the raw id,
+    // and an unknown id echoes back.
+    expect(tKeys("desc", "not.a.real.binding.id")).toBe("not.a.real.binding.id")
+  })
+})

--- a/packages/kobe/test/tui-react/keymap-version.test.ts
+++ b/packages/kobe/test/tui-react/keymap-version.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Why this matters: the keymap table is mutated IN PLACE on live reloads —
+ * invisible to React. Chord legends re-render only through the version
+ * subscription added in G2 (`subscribeKeymapVersion`), which must fire in
+ * lockstep with the Solid signal bump or React panes show stale chords
+ * after a keybindings.json reload.
+ */
+
+import { describe, expect, it } from "vitest"
+import { bumpKeymapVersion, keymapVersion, subscribeKeymapVersion } from "../../src/tui/context/keybindings"
+
+describe("keymap version subscription (React side)", () => {
+  it("bump notifies subscribers and advances the counter they snapshot", () => {
+    const seen: number[] = []
+    const unsub = subscribeKeymapVersion(() => seen.push(keymapVersion()))
+    const before = keymapVersion()
+    bumpKeymapVersion()
+    bumpKeymapVersion()
+    unsub()
+    bumpKeymapVersion()
+    expect(seen).toEqual([before + 1, before + 2])
+    expect(keymapVersion()).toBe(before + 3)
+  })
+})

--- a/packages/kobe/test/tui-react/keymap-version.test.ts
+++ b/packages/kobe/test/tui-react/keymap-version.test.ts
@@ -7,7 +7,14 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { bumpKeymapVersion, keymapVersion, subscribeKeymapVersion } from "../../src/tui/context/keybindings"
+import {
+  bindByIds,
+  bumpKeymapVersion,
+  chordsOf,
+  findBinding,
+  subscribeKeymapVersion,
+} from "../../src/tui-react/context/keybindings"
+import { keymapVersion } from "../../src/tui/context/keybindings"
 
 describe("keymap version subscription (React side)", () => {
   it("bump notifies subscribers and advances the counter they snapshot", () => {
@@ -20,5 +27,14 @@ describe("keymap version subscription (React side)", () => {
     bumpKeymapVersion()
     expect(seen).toEqual([before + 1, before + 2])
     expect(keymapVersion()).toBe(before + 3)
+  })
+})
+
+describe("react keybindings re-exports", () => {
+  it("exposes the shared keymap data + lookups (same objects as the Solid module)", () => {
+    const anyBinding = findBinding("app.quit") ?? findBinding("sidebar.up")
+    // The table is non-empty and chord lookup goes through the shared map.
+    expect(Array.isArray(chordsOf(anyBinding?.id ?? "app.quit"))).toBe(true)
+    expect(bindByIds({})).toEqual([])
   })
 })

--- a/packages/kobe/test/tui-react/theme-core.test.ts
+++ b/packages/kobe/test/tui-react/theme-core.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Why this matters: `applyDisplayOverlay` encodes two policies both
+ * frameworks must share exactly — the user-picked focus-accent slot (with
+ * primary fallback for themes missing the slot) and transparent mode's
+ * "chrome goes alpha-0, dialog card stays opaque" rule (see
+ * memory/feedback_transparent_default_aggressive.md). The overlay was
+ * extracted from the Solid provider during G2; this pins the extraction
+ * didn't change behavior and the React provider inherits the same rules.
+ */
+
+import { describe, expect, it } from "vitest"
+import { BUNDLED_THEMES, applyDisplayOverlay, resolveTheme } from "../../src/tui/context/theme-core"
+
+const base = resolveTheme(BUNDLED_THEMES.claude as never, "dark")
+
+describe("applyDisplayOverlay", () => {
+  it("derives focusAccent from the chosen slot", () => {
+    expect(applyDisplayOverlay(base, "success", false).focusAccent).toBe(base.success)
+    expect(applyDisplayOverlay(base, "info", false).focusAccent).toBe(base.info)
+    expect(applyDisplayOverlay(base, "primary", false).focusAccent).toBe(base.primary)
+  })
+
+  it("leaves every other slot untouched when transparent is off", () => {
+    const out = applyDisplayOverlay(base, "primary", false)
+    expect(out.background).toBe(base.background)
+    expect(out.backgroundPanel).toBe(base.backgroundPanel)
+    expect(out.backgroundElement).toBe(base.backgroundElement)
+    expect(out.text).toBe(base.text)
+  })
+
+  it("transparent mode zeroes background AND backgroundPanel only", () => {
+    const out = applyDisplayOverlay(base, "primary", true)
+    expect(out.background.a).toBe(0)
+    expect(out.backgroundPanel.a).toBe(0)
+    // The composer body tint survives so input stays legible…
+    expect(out.backgroundElement).toBe(base.backgroundElement)
+    // …and the dialog card stays opaque so overlays stay readable.
+    expect(out.backgroundDialog).toBe(base.backgroundDialog)
+  })
+
+  it("resolveTheme output feeds the overlay for every bundled theme without throwing", () => {
+    for (const [name, json] of Object.entries(BUNDLED_THEMES)) {
+      const resolved = resolveTheme(json, "dark")
+      const overlaid = applyDisplayOverlay(resolved, "info", true)
+      expect(overlaid.focusAccent, name).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- G2 of the Solid → React TUI migration (issue #15): the five infrastructure modules — **theme, focus, dialog stack, key-bindings dispatch, i18n** — now have React counterparts under `src/tui-react/`, so G3's per-pane migration only changes import paths.
- Framework-free cores are extracted and SHARED (no drift possible): `theme-core.ts` (resolution + focus-accent/transparent display overlay), `i18n/lookup.ts`, the existing `keymap-dispatch.ts`, and a keymap-version subscription added beside the Solid signal. Solid behavior is unchanged — its providers now consume the shared cores.
- React reactivity: module singletons run on a tiny `createExternalStore` + `useSyncExternalStore` (i18n language, theme state, keymap version); `useBindings` keeps the "config re-evaluated per keypress" contract via a render-refreshed ref; the dialog provider preserves thunk bodies, focus save/restore, and the escape/ctrl+c selection-aware pop.
- Documented API deltas (React-idiomatic, mechanical for G3): `useTheme().theme` is a plain object (not a Proxy), `focus.is(pane)` returns a boolean (not an accessor), components subscribe to language via `useT()`/`useLang()` instead of implicit tracking.
- `dev:mock-react` now mounts the full provider stack end-to-end (q quit / tab focus-cycle / d dialog).

## Test plan
- [x] `bun run typecheck` clean; repo-root `bun run lint` clean
- [x] `bun run test` — fast 2446/2446 + socket 218/218 (includes 4 new test files pinning store semantics, i18n parity with the Solid runtime, display-overlay policy, keymap-version subscription)
- [x] `bun run compile` → `release-bin/kobe --version` OK (tui-react still absent from the compile graph)
- [x] `timeout 6 bun run dev:mock` — Solid path unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react` — React pilot renders themed header, i18n string, live focus marker


coverage-exemption: packages/kobe/src/tui-react/lib/keymap.ts — renderer-bound registration layer (imports @opentui/react, not importable under vitest); mirrors the Solid src/tui/lib/keymap.tsx precedent whose coverage lives in the render track. A React render harness lands with the G3 pilot.
