### PR TITLE
Add native chat model routing

### DIFF
--- a/.changeset/native-chat-model-router-history.md
+++ b/.changeset/native-chat-model-router-history.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Make native chat keep Kobe-owned conversation history across model changes and add an opt-in same-provider auto-model router.

--- a/.changeset/native-chat-model-router-history.md
+++ b/.changeset/native-chat-model-router-history.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-Make native chat keep Kobe-owned conversation history across model changes and add an opt-in same-provider auto-model router.
+Make native chat preserve provider sessions across model changes, use Kobe-owned history only as a resume fallback, and add an opt-in same-provider auto-model router.

--- a/docs/superpowers/plans/2026-07-06-native-chat-model-router-history.md
+++ b/docs/superpowers/plans/2026-07-06-native-chat-model-router-history.md
@@ -1,0 +1,85 @@
+# Native Chat Model Router History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Kobe native chat own the conversation history while allowing same-provider automatic model selection before each turn.
+
+**Architecture:** Keep provider runtime sessions as disposable execution caches. `tui/chat` owns a Kobe thread transcript, `engine/ai-sdk` converts that transcript into bounded prompt context, and a small same-provider router can override the next turn's model without changing the Kobe thread.
+
+**Tech Stack:** TypeScript, Solid, Vitest, AI SDK harness, existing engine registry/capability contracts.
+
+## Global Constraints
+
+- Start from latest `origin/main`, not the old #223 branch.
+- Do not introduce a third-party router service or a new dependency.
+- Keep routing within the task's current provider.
+- Treat provider session ids as disposable; Kobe thread history is the semantic source of truth.
+- If the selected model changes, rebuild the provider runtime but still pass Kobe history into the next turn.
+- Add a patch changeset.
+
+---
+
+### Task 1: Prompt Context Adapter
+
+**Files:**
+- Modify: `packages/kobe/src/engine/ai-sdk/harness-turn.ts`
+- Test: `packages/kobe/test/engine/ai-sdk-harness-turn.test.ts`
+
+**Interfaces:**
+- Produces: `AiSdkConversationMessage` with `{ role: "user" | "assistant"; text: string }`.
+- Produces: `buildPromptWithHistory(prompt: string, history?: readonly AiSdkConversationMessage[]): string`.
+- Consumes later: `startAiSdkTurn({ history })`.
+
+- [x] Write failing tests that `buildPromptWithHistory` leaves empty history unchanged and includes prior user/assistant turns before the new prompt.
+- [x] Run `bun --filter @sma1lboy/kobe test:fast -- test/engine/ai-sdk-harness-turn.test.ts` and verify the new tests fail because the helper does not exist.
+- [x] Implement `AiSdkConversationMessage`, bounded text serialization, `buildPromptWithHistory`, and have `startAiSdkTurn` pass the built prompt to `runtime.agent.stream`.
+- [x] Re-run the focused test and verify it passes.
+
+### Task 2: Native Chat Thread SOT
+
+**Files:**
+- Create: `packages/kobe/src/tui/chat/thread-history.ts`
+- Modify: `packages/kobe/src/tui/chat/ChatPane.tsx`
+- Test: `packages/kobe/test/tui/chat-thread-history.test.ts`
+
+**Interfaces:**
+- Produces: `chatItemsToAiSdkHistory(items: readonly ChatItem[]): readonly AiSdkConversationMessage[]`.
+- Consumes: `startAiSdkTurn({ history })`.
+
+- [x] Write failing tests that prompt rows and final assistant UI rows become history messages, error rows are ignored, and transient replacement of the assistant tail still yields one assistant message.
+- [x] Run the focused test and verify it fails because the adapter file does not exist.
+- [x] Implement `thread-history.ts` with conservative UIMessage text extraction for text-like parts.
+- [x] Update `ChatPane.runTurn` to capture previous items as `history` before appending the new prompt and pass it to `startAiSdkTurn`.
+- [x] Re-run the focused test and harness-turn test.
+
+### Task 3: Same-Provider Router Hook
+
+**Files:**
+- Create: `packages/kobe/src/engine/ai-sdk/model-router.ts`
+- Modify: `packages/kobe/src/tui/chat/ChatPane.tsx`
+- Test: `packages/kobe/test/engine/model-router.test.ts`
+
+**Interfaces:**
+- Produces: `chooseTurnModel({ vendor, prompt, history, current, capabilities, autoModelEnabled, callSmallModel? }): Promise<ModelPickerResult>`.
+- Consumes: current `ModelPickerResult`, provider capabilities, and history from Task 2.
+
+- [x] Write failing tests for disabled router returning current/default model, router accepting only same-provider catalog choices, invalid choices falling back, and small-model call failure falling back.
+- [x] Run the focused model-router test and verify it fails because the module does not exist.
+- [x] Implement the router as an injected async decision function with a deterministic local fallback; no OpenRouter or new dependency.
+- [x] Wire `ChatPane.runTurn` to resolve the model before `startAiSdkTurn`; manual current model remains the fallback.
+- [x] Re-run focused tests.
+
+### Task 4: Settings, Changeset, Verification
+
+**Files:**
+- Modify: existing TUI/web settings state files if present for native chat defaults.
+- Modify: `packages/kobe/src/engine/codex-local/capabilities.ts` only if real model ids are available locally.
+- Create: `.changeset/native-chat-model-router-history.md`
+
+**Interfaces:**
+- Produces: user-editable setting for auto model routing and router model where existing settings surfaces can already persist them.
+
+- [x] Add a patch changeset describing native chat history SOT and same-provider model routing.
+- [x] Run focused tests, `bun --filter @sma1lboy/kobe test:fast`, `bun run typecheck`, and `bun run lint`.
+- [x] Restart sandbox daemon if daemon/orchestrator/engine changes require it.
+- [ ] Commit only files for this PR, push the branch, and open a PR with the local `gh` CLI.

--- a/packages/kobe/src/engine/ai-sdk/harness-turn.ts
+++ b/packages/kobe/src/engine/ai-sdk/harness-turn.ts
@@ -15,17 +15,22 @@
  * tail message on every update (no delta bookkeeping, no mapping layer —
  * the UIMessage parts ARE the render schema on this path).
  *
- * The provider runtime session is an execution cache, not Kobe's source of
- * truth. When a pane supplies Kobe-owned history, we prepend it to the prompt
- * so a model/effort rebuild can still see the same semantic conversation.
- * Persisting UIMessage history to vendor on-disk session-record formats is
- * still future work at the persistence boundary.
+ * The provider runtime session is the model-friendly context path: Kobe parks
+ * the harness session on runtime rebuild/dispose and later resumes it with the
+ * same `sessionId + resumeFrom` payload. Kobe-owned UI history is only a bridge
+ * when no provider session can be resumed.
  */
 
+import {
+  type NativeChatSessionRecord,
+  clearNativeChatSession,
+  readNativeChatSession,
+  writeNativeChatSession,
+} from "@/state/native-chat-session"
 import type { VendorId } from "@/types/vendor"
 import { createClaudeCode } from "@ai-sdk/harness-claude-code"
 import { type CodexHarnessSettings, createCodex } from "@ai-sdk/harness-codex"
-import { HarnessAgent } from "@ai-sdk/harness/agent"
+import { HarnessAgent, type HarnessAgentResumeSessionState } from "@ai-sdk/harness/agent"
 import { getErrorMessage } from "@ai-sdk/provider-utils"
 import { type UIMessage, readUIMessageStream } from "ai"
 import { createLocalSandbox } from "./local-sandbox"
@@ -33,14 +38,22 @@ import { createLocalSandbox } from "./local-sandbox"
 export type AiSdkHarnessVendor = "claude" | "codex"
 export type AiSdkRuntimePurpose = "chat" | "router"
 type CodexReasoningEffort = NonNullable<CodexHarnessSettings["reasoningEffort"]>
+type HarnessSession = Awaited<ReturnType<HarnessAgent["createSession"]>>
 
 export interface AiSdkConversationMessage {
   readonly role: "user" | "assistant"
   readonly text: string
 }
 
-const MAX_HISTORY_MESSAGES = 16
-const MAX_HISTORY_CHARS = 24_000
+export interface BuildPromptWithHistoryOpts {
+  readonly historyTokenBudget?: number
+}
+
+const APPROX_CHARS_PER_TOKEN = 4
+const DEFAULT_HISTORY_TOKEN_BUDGET = 128_000
+const MAX_HISTORY_TOKEN_BUDGET = 800_000
+const RESERVED_TURN_TOKENS = 16_000
+const HISTORY_CONTEXT_FRACTION = 0.75
 
 /**
  * Turn failure surfaced to the pane. `runtimeBusy` is a kobe-authored
@@ -58,7 +71,7 @@ interface WorktreeRuntime {
   // model/effort rebuilds the runtime rather than silently serving the old one.
   readonly model?: string
   readonly modelEffort?: string
-  session?: Awaited<ReturnType<HarnessAgent["createSession"]>>
+  session?: HarnessSession
   busy: boolean
 }
 
@@ -87,16 +100,31 @@ function normalizeHistoryText(text: string): string {
   return text.replace(/\r\n?/g, "\n").trim()
 }
 
-function boundedHistory(history: readonly AiSdkConversationMessage[] | undefined): readonly AiSdkConversationMessage[] {
+export function historyTokenBudgetForContextWindow(contextWindowTokens: number | undefined): number {
+  if (!contextWindowTokens || contextWindowTokens <= RESERVED_TURN_TOKENS) return DEFAULT_HISTORY_TOKEN_BUDGET
+  const budget = Math.floor((contextWindowTokens - RESERVED_TURN_TOKENS) * HISTORY_CONTEXT_FRACTION)
+  return Math.min(MAX_HISTORY_TOKEN_BUDGET, Math.max(0, budget))
+}
+
+function historyCharBudget(opts: BuildPromptWithHistoryOpts | undefined): number {
+  const tokens = Math.max(0, opts?.historyTokenBudget ?? DEFAULT_HISTORY_TOKEN_BUDGET)
+  return Math.floor(tokens * APPROX_CHARS_PER_TOKEN)
+}
+
+function boundedHistory(
+  history: readonly AiSdkConversationMessage[] | undefined,
+  opts?: BuildPromptWithHistoryOpts,
+): readonly AiSdkConversationMessage[] {
   if (!history?.length) return []
   const out: AiSdkConversationMessage[] = []
   let chars = 0
-  for (const msg of [...history].slice(-MAX_HISTORY_MESSAGES).reverse()) {
+  const charBudget = historyCharBudget(opts)
+  for (const msg of [...history].reverse()) {
     const text = normalizeHistoryText(msg.text)
     if (!text) continue
     const next = { role: msg.role, text }
     chars += text.length
-    if (chars > MAX_HISTORY_CHARS && out.length > 0) break
+    if (chars > charBudget && out.length > 0) break
     out.push(next)
   }
   return out.reverse()
@@ -105,8 +133,9 @@ function boundedHistory(history: readonly AiSdkConversationMessage[] | undefined
 export function buildPromptWithHistory(
   prompt: string,
   history?: readonly AiSdkConversationMessage[] | undefined,
+  opts?: BuildPromptWithHistoryOpts,
 ): string {
-  const prior = boundedHistory(history)
+  const prior = boundedHistory(history, opts)
   if (prior.length === 0) return prompt
   const lines = ["Previous Kobe conversation:"]
   for (const msg of prior) {
@@ -134,18 +163,21 @@ function createHarness(opts: {
   })
 }
 
-function ensureRuntime(opts: {
+async function ensureRuntime(opts: {
   readonly vendor: AiSdkHarnessVendor
   readonly purpose?: AiSdkRuntimePurpose
   readonly worktree: string
   readonly model?: string
   readonly modelEffort?: string
-}): WorktreeRuntime {
+}): Promise<WorktreeRuntime> {
   const purpose = opts.purpose ?? "chat"
   const key = aiSdkRuntimeKey(opts.vendor, opts.worktree, purpose)
   const existing = runtimes.get(key)
   if (existing && existing.model === opts.model && existing.modelEffort === opts.modelEffort) return existing
-  if (existing) destroyRuntimeSession(existing)
+  if (existing) {
+    if (existing.busy) return existing
+    await parkRuntimeSession(existing)
+  }
   const runtime: WorktreeRuntime = {
     vendor: opts.vendor,
     purpose,
@@ -162,18 +194,77 @@ function ensureRuntime(opts: {
   return runtime
 }
 
-function destroyRuntimeSession(runtime: WorktreeRuntime): void {
-  void runtime.session?.destroy().catch((err) => {
-    console.error(`[kobe ai-sdk] failed to dispose runtime session for ${runtime.worktree}:`, err)
-  })
+function sessionRef(runtime: WorktreeRuntime) {
+  return { vendor: runtime.vendor, purpose: runtime.purpose, worktree: runtime.worktree }
 }
 
-export function disposeAiSdkRuntime(worktree: string): void {
+function sessionRecord(
+  runtime: WorktreeRuntime,
+  sessionId: string,
+  resumeState: HarnessAgentResumeSessionState,
+): NativeChatSessionRecord {
+  return {
+    version: 1,
+    vendor: runtime.vendor,
+    purpose: runtime.purpose,
+    worktree: runtime.worktree,
+    sessionId,
+    resumeState,
+    ...(runtime.model ? { model: runtime.model } : {}),
+    ...(runtime.modelEffort ? { modelEffort: runtime.modelEffort } : {}),
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+async function parkRuntimeSession(runtime: WorktreeRuntime): Promise<NativeChatSessionRecord | undefined> {
+  const session = runtime.session
+  runtime.session = undefined
+  if (!session) return undefined
+  try {
+    const resumeState = await session.stop()
+    const record = sessionRecord(runtime, session.sessionId, resumeState)
+    writeNativeChatSession(record)
+    return record
+  } catch (err) {
+    clearNativeChatSession(sessionRef(runtime))
+    console.error(`[kobe ai-sdk] failed to park runtime session for ${runtime.worktree}:`, err)
+    await session.destroy().catch((destroyErr) => {
+      console.error(`[kobe ai-sdk] failed to destroy unparked runtime session for ${runtime.worktree}:`, destroyErr)
+    })
+    return undefined
+  }
+}
+
+async function ensureRuntimeSession(runtime: WorktreeRuntime): Promise<{
+  readonly session: HarnessSession
+  readonly shouldBridgeHistory: boolean
+}> {
+  if (runtime.session) return { session: runtime.session, shouldBridgeHistory: false }
+  const stored = readNativeChatSession(sessionRef(runtime))
+  if (stored) {
+    try {
+      runtime.session = await runtime.agent.createSession({
+        sessionId: stored.sessionId,
+        resumeFrom: stored.resumeState,
+      })
+      return { session: runtime.session, shouldBridgeHistory: false }
+    } catch (err) {
+      clearNativeChatSession(sessionRef(runtime))
+      console.error(`[kobe ai-sdk] failed to resume parked session for ${runtime.worktree}:`, err)
+    }
+  }
+  runtime.session = await runtime.agent.createSession()
+  return { session: runtime.session, shouldBridgeHistory: true }
+}
+
+export async function disposeAiSdkRuntime(worktree: string): Promise<void> {
+  const pending: Promise<unknown>[] = []
   for (const [key, runtime] of runtimes) {
     if (runtime.worktree !== worktree) continue
     runtimes.delete(key)
-    destroyRuntimeSession(runtime)
+    pending.push(parkRuntimeSession(runtime))
   }
+  await Promise.all(pending)
 }
 
 export interface AiSdkTurnOpts {
@@ -183,6 +274,7 @@ export interface AiSdkTurnOpts {
   readonly model?: string
   readonly modelEffort?: string
   readonly history?: readonly AiSdkConversationMessage[]
+  readonly historyTokenBudget?: number
   readonly prompt: string
   /** Growing assistant snapshot per stream chunk — replace the tail message. */
   readonly onUpdate: (assistant: UIMessage) => void
@@ -203,7 +295,7 @@ export function startAiSdkTurn(opts: AiSdkTurnOpts): AiSdkTurn {
     // failures resolve as a turn error, never an unhandled rejection.
     let runtime: WorktreeRuntime
     try {
-      runtime = ensureRuntime({
+      runtime = await ensureRuntime({
         vendor: resolveAiSdkHarnessVendor(opts.vendor),
         purpose: opts.purpose,
         worktree: opts.worktree,
@@ -217,10 +309,12 @@ export function startAiSdkTurn(opts: AiSdkTurnOpts): AiSdkTurn {
     runtime.busy = true
     let error: AiSdkTurnError | undefined
     try {
-      runtime.session ??= await runtime.agent.createSession()
+      const { session, shouldBridgeHistory } = await ensureRuntimeSession(runtime)
       const result = await runtime.agent.stream({
-        session: runtime.session,
-        prompt: buildPromptWithHistory(opts.prompt, opts.history),
+        session,
+        prompt: shouldBridgeHistory
+          ? buildPromptWithHistory(opts.prompt, opts.history, { historyTokenBudget: opts.historyTokenBudget })
+          : opts.prompt,
         abortSignal: controller.signal,
       })
       const uiStream = result.toUIMessageStream({ sendReasoning: true })

--- a/packages/kobe/src/engine/ai-sdk/harness-turn.ts
+++ b/packages/kobe/src/engine/ai-sdk/harness-turn.ts
@@ -15,11 +15,11 @@
  * tail message on every update (no delta bookkeeping, no mapping layer —
  * the UIMessage parts ARE the render schema on this path).
  *
- * ponytail: turn results are ephemeral — nothing here persists the UIMessage
- * history to claude's on-disk session-record format. That conversion is
- * future work handled by a one-way adapter at the persistence boundary (the
- * UIMessage schema is Vercel-owned; the session record is claude-owned), NOT
- * in this stream path. Don't build it here.
+ * The provider runtime session is an execution cache, not Kobe's source of
+ * truth. When a pane supplies Kobe-owned history, we prepend it to the prompt
+ * so a model/effort rebuild can still see the same semantic conversation.
+ * Persisting UIMessage history to vendor on-disk session-record formats is
+ * still future work at the persistence boundary.
  */
 
 import type { VendorId } from "@/types/vendor"
@@ -31,7 +31,16 @@ import { type UIMessage, readUIMessageStream } from "ai"
 import { createLocalSandbox } from "./local-sandbox"
 
 export type AiSdkHarnessVendor = "claude" | "codex"
+export type AiSdkRuntimePurpose = "chat" | "router"
 type CodexReasoningEffort = NonNullable<CodexHarnessSettings["reasoningEffort"]>
+
+export interface AiSdkConversationMessage {
+  readonly role: "user" | "assistant"
+  readonly text: string
+}
+
+const MAX_HISTORY_MESSAGES = 16
+const MAX_HISTORY_CHARS = 24_000
 
 /**
  * Turn failure surfaced to the pane. `runtimeBusy` is a kobe-authored
@@ -43,6 +52,7 @@ export type AiSdkTurnError = { readonly code: "runtimeBusy" } | { readonly messa
 interface WorktreeRuntime {
   readonly agent: HarnessAgent
   readonly vendor: AiSdkHarnessVendor
+  readonly purpose: AiSdkRuntimePurpose
   readonly worktree: string
   // Settings the agent was built with; a later turn requesting a different
   // model/effort rebuilds the runtime rather than silently serving the old one.
@@ -60,12 +70,51 @@ export function resolveAiSdkHarnessVendor(vendor: VendorId | undefined): AiSdkHa
   return vendor === "codex" ? "codex" : "claude"
 }
 
-export function aiSdkRuntimeKey(vendor: AiSdkHarnessVendor, worktree: string): string {
+export function aiSdkRuntimeKey(
+  vendor: AiSdkHarnessVendor,
+  worktree: string,
+  purpose: AiSdkRuntimePurpose = "chat",
+): string {
+  if (purpose !== "chat") return `${purpose}:${vendor}:${worktree}`
   return `${vendor}:${worktree}`
 }
 
 export function codexReasoningEffort(effort: string | undefined): CodexReasoningEffort | undefined {
   return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined
+}
+
+function normalizeHistoryText(text: string): string {
+  return text.replace(/\r\n?/g, "\n").trim()
+}
+
+function boundedHistory(history: readonly AiSdkConversationMessage[] | undefined): readonly AiSdkConversationMessage[] {
+  if (!history?.length) return []
+  const out: AiSdkConversationMessage[] = []
+  let chars = 0
+  for (const msg of [...history].slice(-MAX_HISTORY_MESSAGES).reverse()) {
+    const text = normalizeHistoryText(msg.text)
+    if (!text) continue
+    const next = { role: msg.role, text }
+    chars += text.length
+    if (chars > MAX_HISTORY_CHARS && out.length > 0) break
+    out.push(next)
+  }
+  return out.reverse()
+}
+
+export function buildPromptWithHistory(
+  prompt: string,
+  history?: readonly AiSdkConversationMessage[] | undefined,
+): string {
+  const prior = boundedHistory(history)
+  if (prior.length === 0) return prompt
+  const lines = ["Previous Kobe conversation:"]
+  for (const msg of prior) {
+    const label = msg.role === "assistant" ? "Assistant" : "User"
+    lines.push(`${label}: ${msg.text}`)
+  }
+  lines.push("", "Current user prompt:", prompt)
+  return lines.join("\n")
 }
 
 function createHarness(opts: {
@@ -87,16 +136,19 @@ function createHarness(opts: {
 
 function ensureRuntime(opts: {
   readonly vendor: AiSdkHarnessVendor
+  readonly purpose?: AiSdkRuntimePurpose
   readonly worktree: string
   readonly model?: string
   readonly modelEffort?: string
 }): WorktreeRuntime {
-  const key = aiSdkRuntimeKey(opts.vendor, opts.worktree)
+  const purpose = opts.purpose ?? "chat"
+  const key = aiSdkRuntimeKey(opts.vendor, opts.worktree, purpose)
   const existing = runtimes.get(key)
   if (existing && existing.model === opts.model && existing.modelEffort === opts.modelEffort) return existing
   if (existing) destroyRuntimeSession(existing)
   const runtime: WorktreeRuntime = {
     vendor: opts.vendor,
+    purpose,
     worktree: opts.worktree,
     model: opts.model,
     modelEffort: opts.modelEffort,
@@ -127,8 +179,10 @@ export function disposeAiSdkRuntime(worktree: string): void {
 export interface AiSdkTurnOpts {
   readonly worktree: string
   readonly vendor?: VendorId
+  readonly purpose?: AiSdkRuntimePurpose
   readonly model?: string
   readonly modelEffort?: string
+  readonly history?: readonly AiSdkConversationMessage[]
   readonly prompt: string
   /** Growing assistant snapshot per stream chunk — replace the tail message. */
   readonly onUpdate: (assistant: UIMessage) => void
@@ -151,6 +205,7 @@ export function startAiSdkTurn(opts: AiSdkTurnOpts): AiSdkTurn {
     try {
       runtime = ensureRuntime({
         vendor: resolveAiSdkHarnessVendor(opts.vendor),
+        purpose: opts.purpose,
         worktree: opts.worktree,
         model: opts.model,
         modelEffort: opts.modelEffort,
@@ -165,7 +220,7 @@ export function startAiSdkTurn(opts: AiSdkTurnOpts): AiSdkTurn {
       runtime.session ??= await runtime.agent.createSession()
       const result = await runtime.agent.stream({
         session: runtime.session,
-        prompt: opts.prompt,
+        prompt: buildPromptWithHistory(opts.prompt, opts.history),
         abortSignal: controller.signal,
       })
       const uiStream = result.toUIMessageStream({ sendReasoning: true })

--- a/packages/kobe/src/engine/ai-sdk/local-sandbox.ts
+++ b/packages/kobe/src/engine/ai-sdk/local-sandbox.ts
@@ -93,100 +93,110 @@ async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
 }
 
 export function createLocalSandbox({ workRoot }: { workRoot: string }): HarnessV1SandboxProvider {
+  async function openSession(
+    options: {
+      sessionId?: string
+      abortSignal?: AbortSignal
+      onFirstCreate?: (session: SandboxSession, opts: { abortSignal?: AbortSignal }) => Promise<void>
+    } = {},
+    runFirstCreate = true,
+  ): Promise<HarnessV1NetworkSandboxSession> {
+    const id = options.sessionId ?? randomUUID()
+    const root = workRoot
+    await mkdir(root, { recursive: true })
+    let ports: number[] = [await freePort()]
+    const procs = new Set<SandboxProcess>()
+
+    const spawnProc: SandboxSession["spawn"] = async ({ command, workingDirectory, env, abortSignal }) => {
+      const child = nodeSpawn("/bin/sh", ["-c", command], {
+        cwd: workingDirectory ?? root,
+        env: { ...process.env, ...env },
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+      const proc = toSandboxProcess(child, abortSignal)
+      procs.add(proc)
+      void proc.wait().then(() => procs.delete(proc))
+      return proc
+    }
+
+    const session: HarnessV1NetworkSandboxSession = {
+      id,
+      description: `Local host machine (${os.platform()} ${os.arch()}), working directory ${root}. Commands run as the current user with no isolation.`,
+      defaultWorkingDirectory: root,
+      get ports() {
+        return ports
+      },
+      getPortUrl: async ({ port, protocol = "http" }) => `${protocol}://127.0.0.1:${port}`,
+      setPorts: async (next) => {
+        ports = [...next]
+      },
+
+      readFile: async ({ path: p }) => {
+        const bytes = await readOrNull(p)
+        if (bytes == null) return null
+        return new ReadableStream<Uint8Array>({
+          start(c) {
+            c.enqueue(new Uint8Array(bytes))
+            c.close()
+          },
+        })
+      },
+      readBinaryFile: async ({ path: p }) => {
+        const bytes = await readOrNull(p)
+        return bytes == null ? null : new Uint8Array(bytes)
+      },
+      readTextFile: async ({ path: p, encoding = "utf-8", startLine, endLine }) => {
+        const bytes = await readOrNull(p)
+        if (bytes == null) return null
+        const text = new TextDecoder(encoding).decode(bytes)
+        if (startLine == null && endLine == null) return text
+        const lines = text.split("\n")
+        return lines.slice((startLine ?? 1) - 1, endLine ?? lines.length).join("\n")
+      },
+      writeFile: async ({ path: p, content }) => {
+        await mkdir(path.dirname(p), { recursive: true })
+        const chunks: Uint8Array[] = []
+        for await (const chunk of content as unknown as AsyncIterable<Uint8Array>) chunks.push(chunk)
+        await writeFile(p, Buffer.concat(chunks))
+      },
+      writeBinaryFile: async ({ path: p, content }) => {
+        await mkdir(path.dirname(p), { recursive: true })
+        await writeFile(p, content)
+      },
+      writeTextFile: async ({ path: p, content }) => {
+        await mkdir(path.dirname(p), { recursive: true })
+        await writeFile(p, content, "utf-8")
+      },
+
+      spawn: spawnProc,
+      run: async (opts) => {
+        const proc = await spawnProc(opts)
+        const [stdout, stderr, { exitCode }] = await Promise.all([
+          collect(proc.stdout),
+          collect(proc.stderr),
+          proc.wait(),
+        ])
+        return { exitCode, stdout, stderr }
+      },
+
+      stop: async () => {
+        await Promise.all([...procs].map((p) => p.kill()))
+      },
+      destroy: async () => {
+        await session.stop()
+      },
+      restricted: () => session,
+    }
+
+    if (runFirstCreate && options.onFirstCreate) await options.onFirstCreate(session, {})
+    return session
+  }
+
   return {
     specificationVersion: "harness-sandbox-v1",
     providerId: "kobe-local-host-sandbox",
 
-    createSession: async (options = {}) => {
-      const id = options.sessionId ?? randomUUID()
-      const root = workRoot
-      await mkdir(root, { recursive: true })
-      let ports: number[] = [await freePort()]
-      const procs = new Set<SandboxProcess>()
-
-      const spawnProc: SandboxSession["spawn"] = async ({ command, workingDirectory, env, abortSignal }) => {
-        const child = nodeSpawn("/bin/sh", ["-c", command], {
-          cwd: workingDirectory ?? root,
-          env: { ...process.env, ...env },
-          stdio: ["ignore", "pipe", "pipe"],
-        })
-        const proc = toSandboxProcess(child, abortSignal)
-        procs.add(proc)
-        void proc.wait().then(() => procs.delete(proc))
-        return proc
-      }
-
-      const session: HarnessV1NetworkSandboxSession = {
-        id,
-        description: `Local host machine (${os.platform()} ${os.arch()}), working directory ${root}. Commands run as the current user with no isolation.`,
-        defaultWorkingDirectory: root,
-        get ports() {
-          return ports
-        },
-        getPortUrl: async ({ port, protocol = "http" }) => `${protocol}://127.0.0.1:${port}`,
-        setPorts: async (next) => {
-          ports = [...next]
-        },
-
-        readFile: async ({ path: p }) => {
-          const bytes = await readOrNull(p)
-          if (bytes == null) return null
-          return new ReadableStream<Uint8Array>({
-            start(c) {
-              c.enqueue(new Uint8Array(bytes))
-              c.close()
-            },
-          })
-        },
-        readBinaryFile: async ({ path: p }) => {
-          const bytes = await readOrNull(p)
-          return bytes == null ? null : new Uint8Array(bytes)
-        },
-        readTextFile: async ({ path: p, encoding = "utf-8", startLine, endLine }) => {
-          const bytes = await readOrNull(p)
-          if (bytes == null) return null
-          const text = new TextDecoder(encoding).decode(bytes)
-          if (startLine == null && endLine == null) return text
-          const lines = text.split("\n")
-          return lines.slice((startLine ?? 1) - 1, endLine ?? lines.length).join("\n")
-        },
-        writeFile: async ({ path: p, content }) => {
-          await mkdir(path.dirname(p), { recursive: true })
-          const chunks: Uint8Array[] = []
-          for await (const chunk of content as unknown as AsyncIterable<Uint8Array>) chunks.push(chunk)
-          await writeFile(p, Buffer.concat(chunks))
-        },
-        writeBinaryFile: async ({ path: p, content }) => {
-          await mkdir(path.dirname(p), { recursive: true })
-          await writeFile(p, content)
-        },
-        writeTextFile: async ({ path: p, content }) => {
-          await mkdir(path.dirname(p), { recursive: true })
-          await writeFile(p, content, "utf-8")
-        },
-
-        spawn: spawnProc,
-        run: async (opts) => {
-          const proc = await spawnProc(opts)
-          const [stdout, stderr, { exitCode }] = await Promise.all([
-            collect(proc.stdout),
-            collect(proc.stderr),
-            proc.wait(),
-          ])
-          return { exitCode, stdout, stderr }
-        },
-
-        stop: async () => {
-          await Promise.all([...procs].map((p) => p.kill()))
-        },
-        destroy: async () => {
-          await session.stop()
-        },
-        restricted: () => session,
-      }
-
-      if (options.onFirstCreate) await options.onFirstCreate(session, {})
-      return session
-    },
+    createSession: (options = {}) => openSession(options, true),
+    resumeSession: (options) => openSession({ sessionId: options.sessionId, abortSignal: options.abortSignal }, false),
   }
 }

--- a/packages/kobe/src/engine/ai-sdk/model-router.ts
+++ b/packages/kobe/src/engine/ai-sdk/model-router.ts
@@ -1,0 +1,162 @@
+import type { ModelChoice } from "@/types/engine"
+import type { VendorId } from "@/types/vendor"
+import type { UIMessage } from "ai"
+import { type AiSdkConversationMessage, startAiSdkTurn } from "./harness-turn"
+
+export type TurnModelChoice = Pick<ModelChoice, "vendor" | "id" | "effort"> | undefined
+
+export interface ModelRouterChoice {
+  readonly id: string
+  readonly effort?: string
+}
+
+export interface SmallModelRouteRequest {
+  readonly vendor: VendorId
+  readonly routerModel?: string | undefined
+  readonly prompt: string
+  readonly history: readonly AiSdkConversationMessage[]
+  readonly candidates: readonly ModelChoice[]
+  readonly current: TurnModelChoice
+}
+
+export type CallSmallModelForRoute = (
+  request: SmallModelRouteRequest,
+) => Promise<string | ModelRouterChoice | undefined>
+
+export interface ChooseTurnModelOpts {
+  readonly vendor: VendorId
+  readonly prompt: string
+  readonly history: readonly AiSdkConversationMessage[]
+  readonly current: TurnModelChoice
+  readonly capabilities:
+    | {
+        readonly models: readonly ModelChoice[]
+        defaultModelId(): string
+        smallFastModelId?(): string | undefined
+      }
+    | undefined
+  readonly autoModelEnabled: boolean
+  readonly callSmallModel?: CallSmallModelForRoute
+}
+
+export interface AiSdkModelRouterCallOpts extends SmallModelRouteRequest {
+  readonly worktree: string
+}
+
+function sameProviderCandidates(vendor: VendorId, models: readonly ModelChoice[]): readonly ModelChoice[] {
+  return models.filter((model) => model.vendor === vendor)
+}
+
+function fallbackChoice(opts: ChooseTurnModelOpts, candidates: readonly ModelChoice[]): TurnModelChoice {
+  if (opts.current?.vendor === opts.vendor) return opts.current
+  const defaultId = opts.capabilities?.defaultModelId()
+  const defaultChoice =
+    candidates.find((model) => model.id === defaultId && model.effort === undefined) ?? candidates[0]
+  return defaultChoice
+    ? { vendor: defaultChoice.vendor, id: defaultChoice.id, effort: defaultChoice.effort }
+    : undefined
+}
+
+function matchingCandidate(
+  vendor: VendorId,
+  candidates: readonly ModelChoice[],
+  choice: ModelRouterChoice | undefined,
+): ModelChoice | undefined {
+  if (!choice?.id) return undefined
+  const sameId = candidates.filter((model) => model.vendor === vendor && model.id === choice.id)
+  if (sameId.length === 0) return undefined
+  if (choice.effort === undefined)
+    return sameId.length === 1 ? sameId[0] : sameId.find((model) => model.effort === undefined)
+  return sameId.find((model) => model.effort === choice.effort)
+}
+
+function asTurnChoice(model: ModelChoice | undefined): TurnModelChoice {
+  return model ? { vendor: model.vendor, id: model.id, effort: model.effort } : undefined
+}
+
+export function parseModelRouterChoice(raw: string | ModelRouterChoice | undefined): ModelRouterChoice | undefined {
+  if (!raw) return undefined
+  if (typeof raw !== "string") return raw.id.trim() ? raw : undefined
+  const text = raw.trim()
+  if (!text) return undefined
+  try {
+    const parsed = JSON.parse(text) as unknown
+    if (parsed && typeof parsed === "object") {
+      const obj = parsed as { id?: unknown; model?: unknown; effort?: unknown }
+      const id = typeof obj.model === "string" ? obj.model : typeof obj.id === "string" ? obj.id : undefined
+      const effort = typeof obj.effort === "string" ? obj.effort : undefined
+      return id?.trim() ? { id: id.trim(), ...(effort?.trim() ? { effort: effort.trim() } : {}) } : undefined
+    }
+  } catch {
+    // Plain model ids are accepted below.
+  }
+  const match = text.match(/(?:model|id)\s*[:=]\s*([A-Za-z0-9_.:/@-]+)/i)
+  return { id: (match?.[1] ?? text.split(/\s+/)[0] ?? "").trim() }
+}
+
+export function buildModelRouterPrompt(request: SmallModelRouteRequest): string {
+  const candidates = request.candidates
+    .map((model) => `- ${model.id}${model.effort ? ` effort=${model.effort}` : ""}: ${model.label}`)
+    .join("\n")
+  const history = request.history
+    .slice(-8)
+    .map((msg) => `${msg.role === "assistant" ? "Assistant" : "User"}: ${msg.text}`)
+    .join("\n")
+  return [
+    "Choose the best model for the next turn.",
+    'Return only compact JSON: {"model":"<id>","effort":"<effort>"}. Omit effort when not needed.',
+    `Provider: ${request.vendor}`,
+    `Current model: ${request.current?.id ?? "(default)"}`,
+    "Allowed candidates:",
+    candidates,
+    history ? `Recent conversation:\n${history}` : "Recent conversation: (none)",
+    `Next user prompt:\n${request.prompt}`,
+  ].join("\n\n")
+}
+
+function uiMessageText(msg: UIMessage | undefined): string | undefined {
+  const text = msg?.parts
+    .map((part) => (part.type === "text" && typeof part.text === "string" ? part.text.trim() : ""))
+    .filter(Boolean)
+    .join("\n")
+  return text || undefined
+}
+
+export async function callAiSdkModelRouter(opts: AiSdkModelRouterCallOpts): Promise<string | undefined> {
+  let latest: UIMessage | undefined
+  const turn = startAiSdkTurn({
+    worktree: opts.worktree,
+    vendor: opts.vendor,
+    purpose: "router",
+    model: opts.routerModel,
+    prompt: buildModelRouterPrompt(opts),
+    onUpdate: (msg) => {
+      latest = msg
+    },
+  })
+  const { error } = await turn.done
+  if (error) return undefined
+  return uiMessageText(latest)
+}
+
+export async function chooseTurnModel(opts: ChooseTurnModelOpts): Promise<TurnModelChoice> {
+  const candidates = sameProviderCandidates(opts.vendor, opts.capabilities?.models ?? [])
+  const fallback = fallbackChoice(opts, candidates)
+  if (!opts.autoModelEnabled || candidates.length <= 1 || !opts.callSmallModel) return fallback
+  const routerModel = opts.capabilities?.smallFastModelId?.() ?? opts.capabilities?.defaultModelId()
+  let raw: string | ModelRouterChoice | undefined
+  try {
+    raw = await opts.callSmallModel({
+      vendor: opts.vendor,
+      routerModel,
+      prompt: opts.prompt,
+      history: opts.history,
+      candidates,
+      current: opts.current,
+    })
+  } catch {
+    return fallback
+  }
+  const match = matchingCandidate(opts.vendor, candidates, parseModelRouterChoice(raw))
+  return asTurnChoice(match) ?? fallback
+}

--- a/packages/kobe/src/state/native-chat-router.ts
+++ b/packages/kobe/src/state/native-chat-router.ts
@@ -1,0 +1,12 @@
+/**
+ * Native chat model-router toggle. The router is opt-in because it spends an
+ * extra same-provider small-model turn before each prompt.
+ */
+
+import { getPersistedBool } from "./store.ts"
+
+export const NATIVE_CHAT_AUTO_MODEL_KEY = "experimental.nativeChatAutoModel"
+
+export function nativeChatAutoModelEnabled(): boolean {
+  return getPersistedBool(NATIVE_CHAT_AUTO_MODEL_KEY, false)
+}

--- a/packages/kobe/src/state/native-chat-session.ts
+++ b/packages/kobe/src/state/native-chat-session.ts
@@ -1,0 +1,120 @@
+/**
+ * Native-chat provider session parking.
+ *
+ * This is runtime state, not a user setting: it stores the opaque harness
+ * resume payload returned by `HarnessAgentSession.stop()` so a later Kobe
+ * process can call `agent.createSession({ sessionId, resumeFrom })`.
+ */
+
+import { createHash } from "node:crypto"
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import type { HarnessAgentResumeSessionState } from "@ai-sdk/harness/agent"
+import { kobeStateDir } from "../env"
+
+export type NativeChatSessionVendor = "claude" | "codex"
+export type NativeChatSessionPurpose = "chat" | "router"
+
+export interface NativeChatSessionRef {
+  readonly vendor: NativeChatSessionVendor
+  readonly purpose: NativeChatSessionPurpose
+  readonly worktree: string
+}
+
+export interface NativeChatSessionRecord extends NativeChatSessionRef {
+  readonly version: 1
+  readonly sessionId: string
+  readonly resumeState: HarnessAgentResumeSessionState
+  readonly model?: string
+  readonly modelEffort?: string
+  readonly updatedAt: string
+}
+
+interface NativeChatSessionFile {
+  readonly version: 1
+  readonly sessions: Record<string, NativeChatSessionRecord>
+}
+
+export function nativeChatSessionStorePath(): string {
+  return join(kobeStateDir(), "native-chat-sessions.json")
+}
+
+export function nativeChatSessionKey(ref: NativeChatSessionRef): string {
+  const hash = createHash("sha1").update(ref.worktree).digest("hex").slice(0, 16)
+  return `${ref.purpose}:${ref.vendor}:${hash}`
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function isResumeState(value: unknown): value is HarnessAgentResumeSessionState {
+  if (!isObject(value)) return false
+  return (
+    value.type === "resume-session" &&
+    typeof value.harnessId === "string" &&
+    value.specificationVersion === "harness-v1" &&
+    "data" in value
+  )
+}
+
+function parseRecord(value: unknown): NativeChatSessionRecord | undefined {
+  if (!isObject(value)) return undefined
+  if (value.version !== 1) return undefined
+  if (value.vendor !== "claude" && value.vendor !== "codex") return undefined
+  if (value.purpose !== "chat" && value.purpose !== "router") return undefined
+  if (typeof value.worktree !== "string" || typeof value.sessionId !== "string") return undefined
+  if (typeof value.updatedAt !== "string" || !isResumeState(value.resumeState)) return undefined
+  const model = typeof value.model === "string" ? value.model : undefined
+  const modelEffort = typeof value.modelEffort === "string" ? value.modelEffort : undefined
+  return {
+    version: 1,
+    vendor: value.vendor,
+    purpose: value.purpose,
+    worktree: value.worktree,
+    sessionId: value.sessionId,
+    resumeState: value.resumeState,
+    ...(model ? { model } : {}),
+    ...(modelEffort ? { modelEffort } : {}),
+    updatedAt: value.updatedAt,
+  }
+}
+
+function loadSessionFile(): NativeChatSessionFile {
+  try {
+    const parsed = JSON.parse(readFileSync(nativeChatSessionStorePath(), "utf8")) as unknown
+    if (!isObject(parsed) || !isObject(parsed.sessions)) return { version: 1, sessions: {} }
+    const sessions: Record<string, NativeChatSessionRecord> = {}
+    for (const [key, value] of Object.entries(parsed.sessions)) {
+      const record = parseRecord(value)
+      if (record) sessions[key] = record
+    }
+    return { version: 1, sessions }
+  } catch {
+    return { version: 1, sessions: {} }
+  }
+}
+
+function writeSessionFile(file: NativeChatSessionFile): void {
+  const path = nativeChatSessionStorePath()
+  mkdirSync(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp`
+  writeFileSync(tmp, JSON.stringify(file, null, 2), "utf8")
+  renameSync(tmp, path)
+}
+
+export function readNativeChatSession(ref: NativeChatSessionRef): NativeChatSessionRecord | undefined {
+  return loadSessionFile().sessions[nativeChatSessionKey(ref)]
+}
+
+export function writeNativeChatSession(record: NativeChatSessionRecord): void {
+  const file = loadSessionFile()
+  file.sessions[nativeChatSessionKey(record)] = record
+  writeSessionFile(file)
+}
+
+export function clearNativeChatSession(ref: NativeChatSessionRef): void {
+  const file = loadSessionFile()
+  delete file.sessions[nativeChatSessionKey(ref)]
+  writeSessionFile(file)
+}

--- a/packages/kobe/src/tui/chat/ChatPane.tsx
+++ b/packages/kobe/src/tui/chat/ChatPane.tsx
@@ -20,7 +20,7 @@
  * at the persistence boundary (see harness-turn.ts), not wired here.
  */
 
-import { disposeAiSdkRuntime, startAiSdkTurn } from "@/engine/ai-sdk/harness-turn"
+import { disposeAiSdkRuntime, historyTokenBudgetForContextWindow, startAiSdkTurn } from "@/engine/ai-sdk/harness-turn"
 import { callAiSdkModelRouter, chooseTurnModel } from "@/engine/ai-sdk/model-router"
 import { engineEntry, getCapabilities } from "@/engine/registry"
 import { nativeChatAutoModelEnabled } from "@/state/native-chat-router"
@@ -155,7 +155,9 @@ export function ChatPane(props: ChatPaneProps) {
 
   let activeInterrupt: (() => void) | undefined
   onCleanup(() => activeInterrupt?.())
-  onCleanup(() => disposeAiSdkRuntime(props.worktree))
+  onCleanup(() => {
+    void disposeAiSdkRuntime(props.worktree)
+  })
 
   // The AI SDK harness drives the local Claude Code runtime (subscription
   // login) and streams growing UIMessage snapshots; the pane replaces the tail
@@ -164,6 +166,7 @@ export function ChatPane(props: ChatPaneProps) {
     setRunning(true)
     setTurnError(null)
     const history = chatItemsToAiSdkHistory(items())
+    const caps = capabilities()
     const autoModel = nativeChatAutoModelEnabled()
     const turnModel = autoModel
       ? await chooseTurnModel({
@@ -171,12 +174,14 @@ export function ChatPane(props: ChatPaneProps) {
           prompt,
           history,
           current: model(),
-          capabilities: capabilities(),
+          capabilities: caps,
           autoModelEnabled: true,
           callSmallModel: (request) => callAiSdkModelRouter({ ...request, worktree: props.worktree }),
         })
       : model()
     if (autoModel) setModel(turnModel)
+    const turnModelId = turnModel?.id ?? caps?.defaultModelId()
+    const contextWindow = turnModelId ? (caps?.contextWindowFor(turnModelId) ?? 0) : 0
     setItems((prev) => [...prev, { kind: "prompt", text: prompt }])
     let hasTail = false
     const turn = startAiSdkTurn({
@@ -185,6 +190,7 @@ export function ChatPane(props: ChatPaneProps) {
       model: turnModel?.id,
       modelEffort: turnModel?.effort,
       history,
+      historyTokenBudget: historyTokenBudgetForContextWindow(contextWindow),
       prompt,
       onUpdate: (assistant) => {
         setItems((prev) => {

--- a/packages/kobe/src/tui/chat/ChatPane.tsx
+++ b/packages/kobe/src/tui/chat/ChatPane.tsx
@@ -21,7 +21,9 @@
  */
 
 import { disposeAiSdkRuntime, startAiSdkTurn } from "@/engine/ai-sdk/harness-turn"
+import { callAiSdkModelRouter, chooseTurnModel } from "@/engine/ai-sdk/model-router"
 import { engineEntry, getCapabilities } from "@/engine/registry"
+import { nativeChatAutoModelEnabled } from "@/state/native-chat-router"
 import type { PermissionMode } from "@/types/engine"
 import { DEFAULT_TASK_VENDOR } from "@/types/task"
 import type { VendorId } from "@/types/vendor"
@@ -37,6 +39,7 @@ import type { ComposerQueuedItem } from "./ComposerQueue"
 import { ModelPicker, type ModelPickerResult } from "./composer/ModelPicker"
 import { permissionModeLabel } from "./composer/permission-mode"
 import { loadUserSlashes } from "./composer/user-slashes"
+import { chatItemsToAiSdkHistory } from "./thread-history"
 
 export interface ChatPaneProps {
   readonly worktree: string
@@ -160,13 +163,28 @@ export function ChatPane(props: ChatPaneProps) {
   async function runTurn(prompt: string): Promise<void> {
     setRunning(true)
     setTurnError(null)
+    const history = chatItemsToAiSdkHistory(items())
+    const autoModel = nativeChatAutoModelEnabled()
+    const turnModel = autoModel
+      ? await chooseTurnModel({
+          vendor: vendor(),
+          prompt,
+          history,
+          current: model(),
+          capabilities: capabilities(),
+          autoModelEnabled: true,
+          callSmallModel: (request) => callAiSdkModelRouter({ ...request, worktree: props.worktree }),
+        })
+      : model()
+    if (autoModel) setModel(turnModel)
     setItems((prev) => [...prev, { kind: "prompt", text: prompt }])
     let hasTail = false
     const turn = startAiSdkTurn({
       worktree: props.worktree,
       vendor: vendor(),
-      model: model()?.id,
-      modelEffort: model()?.effort,
+      model: turnModel?.id,
+      modelEffort: turnModel?.effort,
+      history,
       prompt,
       onUpdate: (assistant) => {
         setItems((prev) => {

--- a/packages/kobe/src/tui/chat/thread-history.ts
+++ b/packages/kobe/src/tui/chat/thread-history.ts
@@ -1,0 +1,27 @@
+import type { AiSdkConversationMessage } from "@/engine/ai-sdk/harness-turn"
+import type { UIMessage } from "ai"
+import type { ChatItem } from "./ChatRow"
+
+function textPartText(part: UIMessage["parts"][number]): string {
+  if (part.type !== "text") return ""
+  return typeof part.text === "string" ? part.text.trim() : ""
+}
+
+function assistantText(msg: UIMessage): string {
+  return msg.parts.map(textPartText).filter(Boolean).join("\n\n")
+}
+
+export function chatItemsToAiSdkHistory(items: readonly ChatItem[]): readonly AiSdkConversationMessage[] {
+  const out: AiSdkConversationMessage[] = []
+  for (const item of items) {
+    if (item.kind === "prompt") {
+      const text = item.text.trim()
+      if (text) out.push({ role: "user", text })
+      continue
+    }
+    if (item.kind !== "ui") continue
+    const text = assistantText(item.msg)
+    if (text) out.push({ role: "assistant", text })
+  }
+  return out
+}

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -28,6 +28,7 @@ import { submitFeedback } from "../../lib/feedback"
 import { ARCHIVED_HISTORY_PREVIEW_KEY } from "../../state/archived-history"
 import { AUTO_STATUS_KEY } from "../../state/auto-status"
 import { DISPATCHER_KEY } from "../../state/dispatcher"
+import { NATIVE_CHAT_AUTO_MODEL_KEY } from "../../state/native-chat-router"
 import { getGlobalDefaultVendor, setGlobalDefaultVendor } from "../../state/vendor-prefs"
 import {
   PROJECT_DIR_TOKEN,
@@ -273,6 +274,17 @@ export function SettingsDialog(props: SettingsDialogProps) {
 
   function toggleDispatcher(): void {
     props.kv.set(DISPATCHER_KEY, !dispatcherOn())
+  }
+
+  // Experimental: same-provider native chat model router (off by default).
+  // When enabled, the composer asks the provider's small/fast model to choose
+  // among that provider's catalog entries before each native-chat turn.
+  function nativeChatAutoModelOn(): boolean {
+    return props.kv.get(NATIVE_CHAT_AUTO_MODEL_KEY, false) === true
+  }
+
+  function toggleNativeChatAutoModel(): void {
+    props.kv.set(NATIVE_CHAT_AUTO_MODEL_KEY, !nativeChatAutoModelOn())
   }
 
   // Experimental (beta): archived-task history preview (off by default) —
@@ -628,6 +640,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
     devRemoteProjects: () => toggleRemoteProjects(),
     devAutoStatus: () => toggleAutoStatus(),
     devDispatcher: () => toggleDispatcher(),
+    devNativeChatAutoModel: () => toggleNativeChatAutoModel(),
     devArchivedHistory: () => toggleArchivedHistory(),
   }
 
@@ -824,6 +837,8 @@ export function SettingsDialog(props: SettingsDialogProps) {
               toggleAutoStatus={toggleAutoStatus}
               dispatcherEnabled={dispatcherOn}
               toggleDispatcher={toggleDispatcher}
+              nativeChatAutoModelEnabled={nativeChatAutoModelOn}
+              toggleNativeChatAutoModel={toggleNativeChatAutoModel}
               archivedHistoryEnabled={archivedHistoryOn}
               toggleArchivedHistory={toggleArchivedHistory}
             />

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -63,6 +63,7 @@ export type SettingsRow =
   | { id: "remote-projects"; kind: "devRemoteProjects" }
   | { id: "auto-status"; kind: "devAutoStatus" }
   | { id: "dispatcher"; kind: "devDispatcher" }
+  | { id: "native-chat-auto-model"; kind: "devNativeChatAutoModel" }
   | { id: "archived-history"; kind: "devArchivedHistory" }
 
 /** Stable row ids for payload-bearing rows (shared by builders + views). */
@@ -151,6 +152,7 @@ export function devRows(hasDaemon: boolean): SettingsRow[] {
     { id: "remote-projects", kind: "devRemoteProjects" },
     { id: "auto-status", kind: "devAutoStatus" },
     { id: "dispatcher", kind: "devDispatcher" },
+    { id: "native-chat-auto-model", kind: "devNativeChatAutoModel" },
     { id: "archived-history", kind: "devArchivedHistory" },
   ]
 }

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -894,6 +894,8 @@ export function DevSettingsSection(
     toggleAutoStatus: () => void
     dispatcherEnabled: Accessor<boolean>
     toggleDispatcher: () => void
+    nativeChatAutoModelEnabled: Accessor<boolean>
+    toggleNativeChatAutoModel: () => void
     archivedHistoryEnabled: Accessor<boolean>
     toggleArchivedHistory: () => void
   },
@@ -907,6 +909,8 @@ export function DevSettingsSection(
   const autoStatusIsCursor = () => props.level() === "body" && props.bodyRow() === autoStatusRow()
   const dispatcherRow = () => rowIndex(devRows(props.hasDaemon), "dispatcher")
   const dispatcherIsCursor = () => props.level() === "body" && props.bodyRow() === dispatcherRow()
+  const nativeChatAutoModelRow = () => rowIndex(devRows(props.hasDaemon), "native-chat-auto-model")
+  const nativeChatAutoModelIsCursor = () => props.level() === "body" && props.bodyRow() === nativeChatAutoModelRow()
   const archivedHistoryRow = () => rowIndex(devRows(props.hasDaemon), "archived-history")
   const archivedHistoryIsCursor = () => props.level() === "body" && props.bodyRow() === archivedHistoryRow()
   return (
@@ -1026,6 +1030,29 @@ export function DevSettingsSection(
             attributes={props.dispatcherEnabled() ? TextAttributes.BOLD : undefined}
           >
             {props.dispatcherEnabled() ? t("settings.dev.dispatcherOn") : t("settings.dev.dispatcherOff")}
+          </text>
+        </box>
+        <text fg={theme.textMuted} wrapMode="word">
+          {t("settings.dev.nativeChatAutoModelHint")}
+        </text>
+        <box
+          flexDirection="row"
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={nativeChatAutoModelIsCursor() ? theme.primary : theme.backgroundElement}
+          onMouseUp={() => {
+            props.setLevel("body")
+            props.setBodyRow(nativeChatAutoModelRow())
+            props.toggleNativeChatAutoModel()
+          }}
+        >
+          <text
+            fg={nativeChatAutoModelIsCursor() ? theme.selectedListItemText : theme.text}
+            attributes={props.nativeChatAutoModelEnabled() ? TextAttributes.BOLD : undefined}
+          >
+            {props.nativeChatAutoModelEnabled()
+              ? t("settings.dev.nativeChatAutoModelOn")
+              : t("settings.dev.nativeChatAutoModelOff")}
           </text>
         </box>
         <text fg={theme.textMuted} wrapMode="word">

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -127,6 +127,10 @@ export const en = {
       "Field-notes dispatcher: task sessions file one-line gotchas (`kobe api note`), the daemon forwards each to the repo's main session, and that session relays them to the in-flight tasks that benefit (`kobe api dispatch`). Web-hosted sessions receive the relays today.",
     dispatcherOn: "[x] Field-notes dispatcher (on)",
     dispatcherOff: "[ ] Field-notes dispatcher (off)",
+    nativeChatAutoModelHint:
+      "Native chat auto model: before each native-chat turn, ask the current provider's small/fast model to choose among that provider's model catalog. The Kobe conversation history stays the source of truth when the chosen model changes.",
+    nativeChatAutoModelOn: "[x] Native chat auto model (on)",
+    nativeChatAutoModelOff: "[ ] Native chat auto model (off)",
     archivedHistoryHint:
       "Archived history preview (beta): opening an archived task shows a read-only `kobe history` pane (session selector + transcript) in the engine slot instead of relaunching the engine. Its transcript survives worktree removal because the engine store is keyed by the worktree path. Shared with the web dashboard.",
     archivedHistoryOn: "[x] Archived history preview (on)",
@@ -256,6 +260,10 @@ export const zh: typeof en = {
       "现场笔记调度器：任务会话提交一行经验（`kobe api note`），daemon 将每条转发给仓库的主会话，主会话再把它们转达给能受益的进行中任务（`kobe api dispatch`）。目前由 Web 托管的会话会收到转达。",
     dispatcherOn: "[x] 现场笔记调度器 (开)",
     dispatcherOff: "[ ] 现场笔记调度器 (关)",
+    nativeChatAutoModelHint:
+      "原生聊天自动模型：每轮原生聊天前，让当前 provider 的小/快模型在该 provider 的模型目录里选择。所选模型变化时，Kobe 对话历史仍是上下文来源。",
+    nativeChatAutoModelOn: "[x] 原生聊天自动模型 (开)",
+    nativeChatAutoModelOff: "[ ] 原生聊天自动模型 (关)",
     archivedHistoryHint:
       "归档历史预览（beta）：打开已归档的任务时，引擎位置改为只读的 `kobe history` 面板（会话选择器 + 对话记录），而不是重新启动引擎。引擎记录按 worktree 路径存储，所以 worktree 被删除后历史仍然可读。与 Web 仪表盘共用同一开关。",
     archivedHistoryOn: "[x] 归档历史预览 (开)",

--- a/packages/kobe/test/engine/ai-sdk-harness-turn.test.ts
+++ b/packages/kobe/test/engine/ai-sdk-harness-turn.test.ts
@@ -6,12 +6,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const state: {
   ctorCalls: Array<{ harness: unknown }>
   claudeCalls: Array<{ model?: string }>
+  streamCalls: unknown[]
   createSession: () => Promise<{ destroy: ReturnType<typeof vi.fn> }>
   stream: (args: unknown) => Promise<{ toUIMessageStream: () => unknown }>
   readStream: () => AsyncIterable<unknown>
 } = {
   ctorCalls: [],
   claudeCalls: [],
+  streamCalls: [],
   createSession: async () => ({ destroy: vi.fn().mockResolvedValue(undefined) }),
   stream: async () => ({ toUIMessageStream: () => ({}) }),
   readStream: async function* () {
@@ -28,6 +30,7 @@ vi.mock("@ai-sdk/harness/agent", () => ({
       return state.createSession()
     }
     stream(args: unknown) {
+      state.streamCalls.push(args)
       return state.stream(args)
     }
   },
@@ -44,6 +47,7 @@ vi.mock("ai", () => ({ readUIMessageStream: () => state.readStream() }))
 
 import {
   aiSdkRuntimeKey,
+  buildPromptWithHistory,
   codexReasoningEffort,
   disposeAiSdkRuntime,
   resolveAiSdkHarnessVendor,
@@ -61,6 +65,7 @@ describe("AI SDK harness turn helpers", () => {
   it("keys runtimes by vendor and worktree", () => {
     expect(aiSdkRuntimeKey("claude", "/repo/wt")).toBe("claude:/repo/wt")
     expect(aiSdkRuntimeKey("codex", "/repo/wt")).toBe("codex:/repo/wt")
+    expect(aiSdkRuntimeKey("codex", "/repo/wt", "router")).toBe("router:codex:/repo/wt")
   })
 
   it("passes only Codex harness-supported reasoning efforts", () => {
@@ -70,6 +75,22 @@ describe("AI SDK harness turn helpers", () => {
     expect(codexReasoningEffort("xhigh")).toBeUndefined()
     expect(codexReasoningEffort("none")).toBeUndefined()
     expect(codexReasoningEffort(undefined)).toBeUndefined()
+  })
+
+  it("leaves prompts unchanged when no Kobe history is supplied", () => {
+    expect(buildPromptWithHistory("what changed?", [])).toBe("what changed?")
+    expect(buildPromptWithHistory("what changed?")).toBe("what changed?")
+  })
+
+  it("serializes prior Kobe history before the new prompt", () => {
+    const prompt = buildPromptWithHistory("continue", [
+      { role: "user", text: "first request" },
+      { role: "assistant", text: "first answer" },
+    ])
+    expect(prompt).toContain("Previous Kobe conversation:")
+    expect(prompt).toContain("User: first request")
+    expect(prompt).toContain("Assistant: first answer")
+    expect(prompt).toContain("Current user prompt:\ncontinue")
   })
 })
 
@@ -85,6 +106,7 @@ describe("startAiSdkTurn", () => {
   beforeEach(() => {
     state.ctorCalls = []
     state.claudeCalls = []
+    state.streamCalls = []
     state.createSession = async () => ({ destroy: vi.fn().mockResolvedValue(undefined) })
     state.stream = async () => ({ toUIMessageStream: () => ({}) })
     state.readStream = async function* () {
@@ -152,5 +174,34 @@ describe("startAiSdkTurn", () => {
     await run(worktree, { model: "model-a" }).done
     await run(worktree, { model: "model-a" }).done
     expect(state.ctorCalls).toHaveLength(1)
+  })
+
+  it("passes Kobe history as prompt context even after a model rebuild", async () => {
+    const worktree = nextWorktree()
+    await run(worktree, {
+      model: "model-a",
+      prompt: "second request",
+      history: [
+        { role: "user", text: "first request" },
+        { role: "assistant", text: "first answer" },
+      ],
+    }).done
+
+    await run(worktree, {
+      model: "model-b",
+      prompt: "third request",
+      history: [
+        { role: "user", text: "first request" },
+        { role: "assistant", text: "first answer" },
+        { role: "user", text: "second request" },
+        { role: "assistant", text: "second answer" },
+      ],
+    }).done
+
+    expect(state.ctorCalls).toHaveLength(2)
+    const secondStream = state.streamCalls.at(-1) as { prompt?: string } | undefined
+    expect(secondStream?.prompt).toContain("User: first request")
+    expect(secondStream?.prompt).toContain("Assistant: second answer")
+    expect(secondStream?.prompt).toContain("Current user prompt:\nthird request")
   })
 })

--- a/packages/kobe/test/engine/ai-sdk-harness-turn.test.ts
+++ b/packages/kobe/test/engine/ai-sdk-harness-turn.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // --- harness module mocks (hoisted) --------------------------------------
@@ -6,15 +9,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const state: {
   ctorCalls: Array<{ harness: unknown }>
   claudeCalls: Array<{ model?: string }>
+  createSessionCalls: unknown[]
   streamCalls: unknown[]
-  createSession: () => Promise<{ destroy: ReturnType<typeof vi.fn> }>
+  createSession: (opts?: unknown) => Promise<{
+    sessionId?: string
+    isResume?: boolean
+    stop?: ReturnType<typeof vi.fn>
+    destroy: ReturnType<typeof vi.fn>
+  }>
   stream: (args: unknown) => Promise<{ toUIMessageStream: () => unknown }>
   readStream: () => AsyncIterable<unknown>
 } = {
   ctorCalls: [],
   claudeCalls: [],
+  createSessionCalls: [],
   streamCalls: [],
-  createSession: async () => ({ destroy: vi.fn().mockResolvedValue(undefined) }),
+  createSession: async () => ({
+    sessionId: "session-default",
+    stop: vi.fn().mockResolvedValue({
+      type: "resume-session",
+      harnessId: "test-harness",
+      specificationVersion: "harness-v1",
+      data: {},
+    }),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  }),
   stream: async () => ({ toUIMessageStream: () => ({}) }),
   readStream: async function* () {
     yield { role: "assistant", parts: [] }
@@ -26,8 +45,9 @@ vi.mock("@ai-sdk/harness/agent", () => ({
     constructor(opts: { harness: unknown }) {
       state.ctorCalls.push(opts)
     }
-    createSession() {
-      return state.createSession()
+    createSession(opts?: unknown) {
+      state.createSessionCalls.push(opts)
+      return state.createSession(opts)
     }
     stream(args: unknown) {
       state.streamCalls.push(args)
@@ -50,6 +70,7 @@ import {
   buildPromptWithHistory,
   codexReasoningEffort,
   disposeAiSdkRuntime,
+  historyTokenBudgetForContextWindow,
   resolveAiSdkHarnessVendor,
   startAiSdkTurn,
 } from "../../src/engine/ai-sdk/harness-turn"
@@ -92,10 +113,33 @@ describe("AI SDK harness turn helpers", () => {
     expect(prompt).toContain("Assistant: first answer")
     expect(prompt).toContain("Current user prompt:\ncontinue")
   })
+
+  it("uses caller-supplied token budget instead of a tiny fixed history cap", () => {
+    const older = "older ".repeat(3000)
+    const newer = "newer ".repeat(3000)
+    const prompt = buildPromptWithHistory(
+      "continue",
+      [
+        { role: "user", text: older },
+        { role: "assistant", text: newer },
+      ],
+      { historyTokenBudget: 10_000 },
+    )
+    expect(prompt).toContain("User: older older older")
+    expect(prompt).toContain("Assistant: newer newer newer")
+  })
+
+  it("derives a large history budget from the model context window", () => {
+    expect(historyTokenBudgetForContextWindow(200_000)).toBeGreaterThan(100_000)
+    expect(historyTokenBudgetForContextWindow(1_000_000)).toBeGreaterThan(700_000)
+    expect(historyTokenBudgetForContextWindow(0)).toBeGreaterThan(100_000)
+  })
 })
 
 describe("startAiSdkTurn", () => {
   let wt = 0
+  let home: string | undefined
+  let previousHomeEnv: string | undefined
   const nextWorktree = () => `/repo/wt-${++wt}`
   const opened: string[] = []
   const run = (worktree: string, extra: Record<string, unknown> = {}) => {
@@ -104,17 +148,35 @@ describe("startAiSdkTurn", () => {
   }
 
   beforeEach(() => {
+    previousHomeEnv = process.env.KOBE_HOME_DIR
+    home = mkdtempSync(join(tmpdir(), "kobe-ai-sdk-home-"))
+    process.env.KOBE_HOME_DIR = home
     state.ctorCalls = []
     state.claudeCalls = []
+    state.createSessionCalls = []
     state.streamCalls = []
-    state.createSession = async () => ({ destroy: vi.fn().mockResolvedValue(undefined) })
+    state.createSession = async () => ({
+      sessionId: "session-default",
+      stop: vi.fn().mockResolvedValue({
+        type: "resume-session",
+        harnessId: "test-harness",
+        specificationVersion: "harness-v1",
+        data: {},
+      }),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
     state.stream = async () => ({ toUIMessageStream: () => ({}) })
     state.readStream = async function* () {
       yield { role: "assistant", parts: [] }
     }
   })
-  afterEach(() => {
-    for (const w of opened.splice(0)) disposeAiSdkRuntime(w)
+  afterEach(async () => {
+    await Promise.all(opened.splice(0).map((w) => disposeAiSdkRuntime(w)))
+    if (previousHomeEnv === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+    else process.env.KOBE_HOME_DIR = previousHomeEnv
+    if (home) rmSync(home, { recursive: true, force: true })
+    home = undefined
+    previousHomeEnv = undefined
   })
 
   it("completes a normal turn, forwarding stream snapshots to onUpdate", async () => {
@@ -146,7 +208,17 @@ describe("startAiSdkTurn", () => {
     let release!: () => void
     state.createSession = () =>
       new Promise((resolve) => {
-        release = () => resolve({ destroy: vi.fn().mockResolvedValue(undefined) })
+        release = () =>
+          resolve({
+            sessionId: "busy-session",
+            stop: vi.fn().mockResolvedValue({
+              type: "resume-session",
+              harnessId: "test-harness",
+              specificationVersion: "harness-v1",
+              data: {},
+            }),
+            destroy: vi.fn().mockResolvedValue(undefined),
+          })
       })
     const first = run(worktree) // suspends on createSession -> busy = true
     const second = await run(worktree).done
@@ -155,10 +227,21 @@ describe("startAiSdkTurn", () => {
     await first.done
   })
 
-  it("rebuilds the runtime (new agent, old session disposed) when the model changes", async () => {
+  it("rebuilds the runtime and resumes the same provider session when the model changes", async () => {
     const worktree = nextWorktree()
-    const destroy = vi.fn().mockResolvedValue(undefined)
-    state.createSession = async () => ({ destroy })
+    const resumeState = {
+      type: "resume-session",
+      harnessId: "test-harness",
+      specificationVersion: "harness-v1",
+      data: { bridge: "kept" },
+    }
+    const stop = vi.fn().mockResolvedValue(resumeState)
+    state.createSession = async (opts?: unknown) => ({
+      sessionId: (opts as { sessionId?: string } | undefined)?.sessionId ?? "same-session",
+      isResume: Boolean((opts as { resumeFrom?: unknown } | undefined)?.resumeFrom),
+      stop,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
     await run(worktree, { model: "model-a" }).done
     expect(state.ctorCalls).toHaveLength(1)
     expect(state.claudeCalls.at(-1)).toEqual({ model: "model-a" })
@@ -166,7 +249,11 @@ describe("startAiSdkTurn", () => {
     await run(worktree, { model: "model-b" }).done
     expect(state.ctorCalls).toHaveLength(2)
     expect(state.claudeCalls.at(-1)).toEqual({ model: "model-b" })
-    expect(destroy).toHaveBeenCalled()
+    expect(stop).toHaveBeenCalled()
+    expect(state.createSessionCalls.at(-1)).toEqual({
+      sessionId: "same-session",
+      resumeFrom: resumeState,
+    })
   })
 
   it("reuses the runtime (no rebuild) when the model is unchanged", async () => {
@@ -176,8 +263,19 @@ describe("startAiSdkTurn", () => {
     expect(state.ctorCalls).toHaveLength(1)
   })
 
-  it("passes Kobe history as prompt context even after a model rebuild", async () => {
+  it("does not replay Kobe history when a model rebuild resumes the provider session", async () => {
     const worktree = nextWorktree()
+    const resumeState = {
+      type: "resume-session",
+      harnessId: "test-harness",
+      specificationVersion: "harness-v1",
+      data: { thread: "still-here" },
+    }
+    state.createSession = async (opts?: unknown) => ({
+      sessionId: (opts as { sessionId?: string } | undefined)?.sessionId ?? "resume-session-id",
+      stop: vi.fn().mockResolvedValue(resumeState),
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
     await run(worktree, {
       model: "model-a",
       prompt: "second request",
@@ -200,8 +298,80 @@ describe("startAiSdkTurn", () => {
 
     expect(state.ctorCalls).toHaveLength(2)
     const secondStream = state.streamCalls.at(-1) as { prompt?: string } | undefined
-    expect(secondStream?.prompt).toContain("User: first request")
-    expect(secondStream?.prompt).toContain("Assistant: second answer")
-    expect(secondStream?.prompt).toContain("Current user prompt:\nthird request")
+    expect(secondStream?.prompt).toBe("third request")
+  })
+
+  it("replays bounded Kobe history only when provider session resume fails", async () => {
+    const worktree = nextWorktree()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    const resumeState = {
+      type: "resume-session",
+      harnessId: "test-harness",
+      specificationVersion: "harness-v1",
+      data: { thread: "stale" },
+    }
+    const firstStop = vi.fn().mockResolvedValue(resumeState)
+    let resumedOnce = false
+    state.createSession = async (opts?: unknown) => {
+      const resumeFrom = (opts as { resumeFrom?: unknown } | undefined)?.resumeFrom
+      if (resumeFrom) {
+        resumedOnce = true
+        throw new Error("stale resume state")
+      }
+      return {
+        sessionId: "fallback-session",
+        stop: firstStop,
+        destroy: vi.fn().mockResolvedValue(undefined),
+      }
+    }
+
+    try {
+      await run(worktree, { model: "model-a", prompt: "first request" }).done
+      await disposeAiSdkRuntime(worktree)
+      const res = await run(worktree, {
+        model: "model-a",
+        prompt: "second request",
+        history: [
+          { role: "user", text: "first request" },
+          { role: "assistant", text: "first answer" },
+        ],
+      }).done
+
+      expect(res).toEqual({})
+      expect(resumedOnce).toBe(true)
+      const secondStream = state.streamCalls.at(-1) as { prompt?: string } | undefined
+      expect(secondStream?.prompt).toContain("Previous Kobe conversation:")
+      expect(secondStream?.prompt).toContain("Assistant: first answer")
+      expect(secondStream?.prompt).toContain("Current user prompt:\nsecond request")
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("persists a stopped provider session on dispose and resumes it next time", async () => {
+    const worktree = nextWorktree()
+    const resumeState = {
+      type: "resume-session",
+      harnessId: "test-harness",
+      specificationVersion: "harness-v1",
+      data: { thread: "parked" },
+    }
+    const stop = vi.fn().mockResolvedValue(resumeState)
+    state.createSession = async (opts?: unknown) => ({
+      sessionId: (opts as { sessionId?: string } | undefined)?.sessionId ?? "parked-session",
+      isResume: Boolean((opts as { resumeFrom?: unknown } | undefined)?.resumeFrom),
+      stop,
+      destroy: vi.fn().mockResolvedValue(undefined),
+    })
+
+    await run(worktree, { model: "model-a" }).done
+    await disposeAiSdkRuntime(worktree)
+    await run(worktree, { model: "model-a" }).done
+
+    expect(stop).toHaveBeenCalled()
+    expect(state.createSessionCalls.at(-1)).toEqual({
+      sessionId: "parked-session",
+      resumeFrom: resumeState,
+    })
   })
 })

--- a/packages/kobe/test/engine/ai-sdk-local-sandbox.test.ts
+++ b/packages/kobe/test/engine/ai-sdk-local-sandbox.test.ts
@@ -87,4 +87,19 @@ describe("createLocalSandbox (real temp dir)", () => {
   it("restricted() returns a filesystem/exec view", () => {
     expect(typeof session.restricted().run).toBe("function")
   })
+
+  it("reattaches to the same local workRoot by session id", async () => {
+    const provider = createLocalSandbox({ workRoot: root })
+    const first = await provider.createSession({ sessionId: "stable-session" })
+    const p = join(root, "persisted.txt")
+    await first.writeTextFile({ path: p, content: "kept" })
+    await first.stop()
+
+    expect(provider.resumeSession).toBeDefined()
+    const resumed = await provider.resumeSession?.({ sessionId: "stable-session" })
+
+    expect(resumed?.id).toBe("stable-session")
+    expect(await resumed?.readTextFile({ path: p })).toBe("kept")
+    await resumed?.destroy?.()
+  })
 })

--- a/packages/kobe/test/engine/model-router.test.ts
+++ b/packages/kobe/test/engine/model-router.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest"
+import { chooseTurnModel, parseModelRouterChoice } from "../../src/engine/ai-sdk/model-router"
+import type { EngineCapabilities } from "../../src/types/engine"
+
+const caps: EngineCapabilities = {
+  vendorId: "codex",
+  label: "Codex",
+  models: [
+    { vendor: "codex", id: "codex-small", label: "small" },
+    { vendor: "codex", id: "codex-large", label: "large", effort: "high" },
+    { vendor: "claude", id: "claude-cross", label: "cross" },
+  ],
+  permissionModes: [],
+  defaultModelId: () => "codex-small",
+  contextWindowFor: () => 0,
+  smallFastModelId: () => "codex-small",
+}
+
+describe("parseModelRouterChoice", () => {
+  it("accepts plain text and json model choices", () => {
+    expect(parseModelRouterChoice("codex-large")).toEqual({ id: "codex-large" })
+    expect(parseModelRouterChoice('{"model":"codex-large","effort":"high"}')).toEqual({
+      id: "codex-large",
+      effort: "high",
+    })
+  })
+})
+
+describe("chooseTurnModel", () => {
+  it("does not call the small model when auto routing is disabled", async () => {
+    const callSmallModel = vi.fn()
+    const current = { vendor: "codex" as const, id: "codex-large", effort: "high" as const }
+    await expect(
+      chooseTurnModel({
+        vendor: "codex",
+        prompt: "fix it",
+        history: [],
+        current,
+        capabilities: caps,
+        autoModelEnabled: false,
+        callSmallModel,
+      }),
+    ).resolves.toEqual(current)
+    expect(callSmallModel).not.toHaveBeenCalled()
+  })
+
+  it("accepts a same-provider catalog choice returned by the small model", async () => {
+    await expect(
+      chooseTurnModel({
+        vendor: "codex",
+        prompt: "fix it",
+        history: [],
+        current: undefined,
+        capabilities: caps,
+        autoModelEnabled: true,
+        callSmallModel: async () => '{"model":"codex-large","effort":"high"}',
+      }),
+    ).resolves.toEqual({ vendor: "codex", id: "codex-large", effort: "high" })
+  })
+
+  it("does not call the small model when there is only one same-provider candidate", async () => {
+    const callSmallModel = vi.fn()
+    await expect(
+      chooseTurnModel({
+        vendor: "codex",
+        prompt: "fix it",
+        history: [],
+        current: undefined,
+        capabilities: { ...caps, models: [{ vendor: "codex", id: "codex-small", label: "small" }] },
+        autoModelEnabled: true,
+        callSmallModel,
+      }),
+    ).resolves.toEqual({ vendor: "codex", id: "codex-small", effort: undefined })
+    expect(callSmallModel).not.toHaveBeenCalled()
+  })
+
+  it("falls back when the small model returns a cross-provider or unknown model", async () => {
+    const current = { vendor: "codex" as const, id: "codex-small" }
+    await expect(
+      chooseTurnModel({
+        vendor: "codex",
+        prompt: "fix it",
+        history: [],
+        current,
+        capabilities: caps,
+        autoModelEnabled: true,
+        callSmallModel: async () => "claude-cross",
+      }),
+    ).resolves.toEqual(current)
+
+    await expect(
+      chooseTurnModel({
+        vendor: "codex",
+        prompt: "fix it",
+        history: [],
+        current,
+        capabilities: caps,
+        autoModelEnabled: true,
+        callSmallModel: async () => "not-in-catalog",
+      }),
+    ).resolves.toEqual(current)
+  })
+
+  it("falls back when the small model call fails", async () => {
+    const current = { vendor: "codex" as const, id: "codex-small" }
+    await expect(
+      chooseTurnModel({
+        vendor: "codex",
+        prompt: "fix it",
+        history: [],
+        current,
+        capabilities: caps,
+        autoModelEnabled: true,
+        callSmallModel: async () => {
+          throw new Error("router down")
+        },
+      }),
+    ).resolves.toEqual(current)
+  })
+})

--- a/packages/kobe/test/tui/chat-thread-history.test.ts
+++ b/packages/kobe/test/tui/chat-thread-history.test.ts
@@ -1,0 +1,66 @@
+import type { UIMessage } from "ai"
+import { describe, expect, it } from "vitest"
+import type { ChatItem } from "../../src/tui/chat/ChatRow"
+import { chatItemsToAiSdkHistory } from "../../src/tui/chat/thread-history"
+
+function assistant(parts: UIMessage["parts"]): ChatItem {
+  return {
+    kind: "ui",
+    msg: {
+      id: `msg-${parts.length}`,
+      role: "assistant",
+      parts,
+    } as UIMessage,
+  }
+}
+
+describe("chatItemsToAiSdkHistory", () => {
+  it("converts prompt rows and assistant text parts into Kobe conversation history", () => {
+    const history = chatItemsToAiSdkHistory([
+      { kind: "prompt", text: "first request" },
+      assistant([{ type: "text", text: "first answer" }]),
+      { kind: "prompt", text: "second request" },
+    ])
+
+    expect(history).toEqual([
+      { role: "user", text: "first request" },
+      { role: "assistant", text: "first answer" },
+      { role: "user", text: "second request" },
+    ])
+  })
+
+  it("ignores errors and assistant messages without text content", () => {
+    const history = chatItemsToAiSdkHistory([
+      { kind: "prompt", text: "fix it" },
+      { kind: "error", text: "runtime failed" },
+      assistant([
+        {
+          type: "reasoning",
+          text: "private chain",
+          providerMetadata: undefined,
+          state: "done",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "Bash",
+          toolCallId: "call-1",
+          state: "input-available",
+          input: { command: "pwd" },
+        },
+      ] as UIMessage["parts"]),
+    ])
+
+    expect(history).toEqual([{ role: "user", text: "fix it" }])
+  })
+
+  it("joins multiple assistant text parts into one assistant history message", () => {
+    const history = chatItemsToAiSdkHistory([
+      assistant([
+        { type: "text", text: "line one" },
+        { type: "text", text: "line two" },
+      ]),
+    ])
+
+    expect(history).toEqual([{ role: "assistant", text: "line one\n\nline two" }])
+  })
+})

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -133,7 +133,7 @@ describe("engineRows", () => {
 })
 
 describe("devRows", () => {
-  it("with a daemon: reset, restart, remote-projects, auto-status, dispatcher, archived-history", () => {
+  it("with a daemon: reset, restart, remote-projects, auto-status, dispatcher, native-chat-auto-model, archived-history", () => {
     const rows = devRows(true)
     expect(rows.map((r) => r.kind)).toEqual([
       "devReset",
@@ -141,27 +141,31 @@ describe("devRows", () => {
       "devRemoteProjects",
       "devAutoStatus",
       "devDispatcher",
+      "devNativeChatAutoModel",
       "devArchivedHistory",
     ])
     expect(rowIndex(rows, "remote-projects")).toBe(2)
     expect(rowIndex(rows, "auto-status")).toBe(3)
     expect(rowIndex(rows, "dispatcher")).toBe(4)
-    expect(rowIndex(rows, "archived-history")).toBe(5)
+    expect(rowIndex(rows, "native-chat-auto-model")).toBe(5)
+    expect(rowIndex(rows, "archived-history")).toBe(6)
   })
 
-  it("without a daemon: reset, remote-projects, auto-status, dispatcher, archived-history", () => {
+  it("without a daemon: reset, remote-projects, auto-status, dispatcher, native-chat-auto-model, archived-history", () => {
     const rows = devRows(false)
     expect(rows.map((r) => r.kind)).toEqual([
       "devReset",
       "devRemoteProjects",
       "devAutoStatus",
       "devDispatcher",
+      "devNativeChatAutoModel",
       "devArchivedHistory",
     ])
     expect(rowIndex(rows, "remote-projects")).toBe(1)
     expect(rowIndex(rows, "auto-status")).toBe(2)
     expect(rowIndex(rows, "dispatcher")).toBe(3)
-    expect(rowIndex(rows, "archived-history")).toBe(4)
+    expect(rowIndex(rows, "native-chat-auto-model")).toBe(4)
+    expect(rowIndex(rows, "archived-history")).toBe(5)
   })
 })
 
@@ -193,8 +197,8 @@ describe("sectionRows / bodyRowCount", () => {
     expect(bodyRowCount("accounts", inp)).toBe(0)
     expect(bodyRowCount("keys", inp)).toBe(0)
     expect(bodyRowCount("feedback", inp)).toBe(3)
-    expect(bodyRowCount("dev", inp)).toBe(6)
-    expect(bodyRowCount("dev", { ...inp, hasDaemon: false })).toBe(5)
+    expect(bodyRowCount("dev", inp)).toBe(7)
+    expect(bodyRowCount("dev", { ...inp, hasDaemon: false })).toBe(6)
   })
 
   it("row ids are unique within every section", () => {


### PR DESCRIPTION
## Summary
- Make native chat pass Kobe-owned conversation history into AI SDK turns so model/effort rebuilds keep the semantic thread.
- Add an opt-in same-provider auto-model router backed by the provider's small/fast model and a separate router runtime cache.
- Add a Dev settings toggle plus tests for history serialization, router fallback/catalog validation, and settings row ordering.

## Verification
- bun --filter @sma1lboy/kobe test:fast
- bun run typecheck
- bun run lint
- bun --filter @sma1lboy/kobe check-i18n
- KOBE_HOME_DIR=/Users/narwhal/.kobe/worktrees/kobe-d0b1d48497f6/lionfish/packages/kobe/.dev-sandbox/home KOBE_TMUX_SOCKET=kobe-sandbox kobe daemon restart