### PR TITLE
feat: React pane host-boot + framework-free live-prefs stores (G3.0, issue #15)

### DIFF
--- a/.changeset/react-host-boot-g3.md
+++ b/.changeset/react-host-boot-g3.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+G3 groundwork (issue #15): React pane hosts get a real bootPaneHost — shared boot steps (crash handlers, keybindings.yaml overlay, user themes), persisted-prefs seeding before first paint, a themed crash boundary, and the shared exit-signal backstop. Live daemon ui-prefs/keybindings pushes now ride framework-free external-store twins in the client layer (solid-js signals are inert outside reactive-solid runtimes), consumed by React via subscribe/get; dev:mock-react boots through the real host path.

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -18,6 +18,7 @@ import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-proce
 import type { ChannelName, SubscribeRole, UiPrefsPayload } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { isDaemonVersionStale } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { type Accessor, createEffect, createRoot, createSignal } from "solid-js"
+import { type ExternalStore, createExternalStore } from "../lib/external-store.ts"
 import type { Orchestrator, Unsubscribe } from "../orchestrator/core.ts"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import type { AdoptableWorktree, WorktreeProject } from "../types/worktree.ts"
@@ -93,6 +94,14 @@ export class RemoteOrchestrator {
   private readonly setUiPrefsSig: (next: UiPrefsPayload | null) => void
   private readonly keybindingsRevAcc: Accessor<number | null>
   private readonly setKeybindingsRevSig: (next: number | null) => void
+  // Framework-free twins of the two signals above (issue #15 G3): React
+  // hosts subscribe via useSyncExternalStore-compatible stores because
+  // solid-js reactivity is DEAD outside browser-conditions/plugin-swapped
+  // runtimes (node/vitest and plain `bun` resolve the SSR server build).
+  // The setter wrappers below dual-write signal + store — single writer,
+  // no drift. Solid consumers keep the accessor facade untouched.
+  private readonly uiPrefsStoreInner = createExternalStore<UiPrefsPayload | null>(null)
+  private readonly keybindingsRevStoreInner = createExternalStore<number | null>(null)
   private readonly connectionStateAcc: Accessor<DaemonConnectionState>
   private readonly setConnectionState: (next: DaemonConnectionState) => void
   private readonly ensureReachable: () => Promise<unknown>
@@ -139,9 +148,15 @@ export class RemoteOrchestrator {
     this.transcriptActivityAcc = transcriptActivity
     this.setTranscriptActivitySig = (next) => setTranscriptActivity(() => next)
     this.uiPrefsAcc = uiPrefs
-    this.setUiPrefsSig = (next) => setUiPrefs(() => next)
+    this.setUiPrefsSig = (next) => {
+      setUiPrefs(() => next)
+      this.uiPrefsStoreInner.set(next)
+    }
     this.keybindingsRevAcc = keybindingsRev
-    this.setKeybindingsRevSig = (next) => setKeybindingsRev(() => next)
+    this.setKeybindingsRevSig = (next) => {
+      setKeybindingsRev(() => next)
+      this.keybindingsRevStoreInner.set(next)
+    }
     this.connectionStateAcc = connectionState
     this.setConnectionState = (next) => setConnectionState(() => next)
     this.ensureReachable = options.ensureReachable ?? ensureDaemonReachable
@@ -362,6 +377,16 @@ export class RemoteOrchestrator {
   }
 
   /**
+   * Framework-free twin of {@link uiPrefsSignal} for React hosts
+   * (`src/tui-react/lib/host-boot.tsx`): a subscribe/get pair that works in
+   * every runtime, including ones where solid-js resolves to the inert SSR
+   * build. Same values, same nullability, one writer (the setter dual-writes).
+   */
+  uiPrefsStore(): ExternalStore<UiPrefsPayload | null> {
+    return this.uiPrefsStoreInner
+  }
+
+  /**
    * The keybindings-file revision, bumped on the daemon's `keybindings`
    * channel whenever `~/.kobe/settings/keybindings.yaml` changes. An opaque
    * token — a consumer re-reads + re-applies the file on each transition.
@@ -370,6 +395,11 @@ export class RemoteOrchestrator {
    */
   keybindingsRevSignal(): Accessor<number | null> {
     return this.keybindingsRevAcc
+  }
+
+  /** Framework-free twin of {@link keybindingsRevSignal} — see uiPrefsStore. */
+  keybindingsRevStore(): ExternalStore<number | null> {
+    return this.keybindingsRevStoreInner
   }
 
   listTasks(): Task[] {

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -94,12 +94,9 @@ export class RemoteOrchestrator {
   private readonly setUiPrefsSig: (next: UiPrefsPayload | null) => void
   private readonly keybindingsRevAcc: Accessor<number | null>
   private readonly setKeybindingsRevSig: (next: number | null) => void
-  // Framework-free twins of the two signals above (issue #15 G3): React
-  // hosts subscribe via useSyncExternalStore-compatible stores because
-  // solid-js reactivity is DEAD outside browser-conditions/plugin-swapped
-  // runtimes (node/vitest and plain `bun` resolve the SSR server build).
-  // The setter wrappers below dual-write signal + store — single writer,
-  // no drift. Solid consumers keep the accessor facade untouched.
+  // Framework-free twins of the two signals above (issue #15 G3) — React
+  // hosts need stores because solid-js reactivity is inert outside
+  // reactive-solid runtimes. Setters dual-write; single writer, no drift.
   private readonly uiPrefsStoreInner = createExternalStore<UiPrefsPayload | null>(null)
   private readonly keybindingsRevStoreInner = createExternalStore<number | null>(null)
   private readonly connectionStateAcc: Accessor<DaemonConnectionState>
@@ -377,10 +374,9 @@ export class RemoteOrchestrator {
   }
 
   /**
-   * Framework-free twin of {@link uiPrefsSignal} for React hosts
-   * (`src/tui-react/lib/host-boot.tsx`): a subscribe/get pair that works in
-   * every runtime, including ones where solid-js resolves to the inert SSR
-   * build. Same values, same nullability, one writer (the setter dual-writes).
+   * Framework-free twin of {@link uiPrefsSignal} for React hosts: a
+   * subscribe/get pair that notifies in every runtime. Same values,
+   * same nullability, one writer (the setter dual-writes).
    */
   uiPrefsStore(): ExternalStore<UiPrefsPayload | null> {
     return this.uiPrefsStoreInner

--- a/packages/kobe/src/lib/external-store.ts
+++ b/packages/kobe/src/lib/external-store.ts
@@ -1,11 +1,15 @@
 /**
- * Minimal framework-free observable store — the React migration's stand-in
- * for the Solid module-level `createStore`/`createSignal` singletons (issue
- * #15, G2). Solid modules get reactivity for free by reading a store inside
- * a tracked scope; React needs an explicit subscribe/getSnapshot pair for
- * `useSyncExternalStore`. This helper is deliberately tiny: synchronous
- * notify, identity-compared snapshots, no selectors — module singletons in
- * this codebase hold small value objects, not collections.
+ * Minimal framework-free observable store (issue #15, G2/G3). The React
+ * migration's reactive primitive: Solid modules get reactivity for free by
+ * reading a store inside a tracked scope; React needs an explicit
+ * subscribe/getSnapshot pair for `useSyncExternalStore`. Lives in the
+ * framework-free `src/lib/` layer because the daemon CLIENT layer also
+ * publishes live state through it (remote-orchestrator's ui-prefs /
+ * keybindings-rev stores) — deliberately independent of solid-js, whose
+ * reactivity is dead under node/vitest and plain-bun resolution (they get
+ * the SSR server build; only --conditions=browser or the build-time plugin
+ * swap yield the reactive build). Tiny on purpose: synchronous notify,
+ * identity-compared snapshots, no selectors.
  */
 
 export interface ExternalStore<T> {

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -19,6 +19,7 @@
 import { RGBA } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
 import { type ReactNode, createContext, useContext, useEffect, useMemo, useSyncExternalStore } from "react"
+import { createExternalStore } from "../../lib/external-store"
 import {
   BUNDLED_THEMES,
   type FocusAccentSlot,
@@ -27,7 +28,6 @@ import {
   applyDisplayOverlay,
   resolveTheme,
 } from "../../tui/context/theme-core"
-import { createExternalStore } from "../lib/external-store"
 
 export { FOCUS_ACCENT_SLOTS, resolveTheme } from "../../tui/context/theme-core"
 export type { FocusAccentSlot, Theme, ThemeJson } from "../../tui/context/theme-core"
@@ -61,6 +61,42 @@ export function addTheme(name: string, theme: ThemeJson): boolean {
   if (!theme || typeof theme !== "object" || !theme.theme) return false
   store.update((s) => ({ ...s, themes: { ...s.themes, [name]: theme } }))
   return true
+}
+
+// Module-level accessors/setters, mirroring the Solid module's
+// store-outside-the-provider semantics. The React host-boot path (issue #15
+// G3) seeds persisted prefs through these BEFORE the first render (no
+// flash) and applies live daemon ui-prefs pushes without a hook scope; the
+// provider's context methods delegate to the same store.
+
+export function selectedTheme(): string {
+  return store.get().active
+}
+
+export function setTheme(name: string): boolean {
+  if (!hasTheme(name)) return false
+  store.update((s) => ({ ...s, active: name }))
+  return true
+}
+
+export function transparentBackground(): boolean {
+  return store.get().transparentBackground
+}
+
+export function setTransparentBackground(v: boolean): void {
+  store.update((s) => ({ ...s, transparentBackground: v }))
+}
+
+export function focusAccent(): FocusAccentSlot {
+  return store.get().focusAccent
+}
+
+export function setFocusAccent(v: FocusAccentSlot): void {
+  store.update((s) => ({ ...s, focusAccent: v }))
+}
+
+export function setThemeMode(mode: "dark" | "light"): void {
+  store.update((s) => ({ ...s, mode }))
 }
 
 export type ThemeContextValue = {

--- a/packages/kobe/src/tui-react/i18n/index.ts
+++ b/packages/kobe/src/tui-react/i18n/index.ts
@@ -15,9 +15,9 @@
  */
 
 import { useCallback, useSyncExternalStore } from "react"
+import { createExternalStore } from "../../lib/external-store"
 import { CATALOGS, DEFAULT_LOCALE, LOCALES, type LocaleId } from "../../tui/i18n/catalog"
 import { interpolate, lookup, lookupKeys } from "../../tui/i18n/lookup"
-import { createExternalStore } from "../lib/external-store"
 
 export { LOCALES, DEFAULT_LOCALE, isLocaleId } from "../../tui/i18n/catalog"
 export type { LocaleId } from "../../tui/i18n/catalog"

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -1,0 +1,265 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Shared boot sequence for kobe's React pane hosts (issue #15, G3) — the
+ * `src/tui/lib/host-boot.tsx` counterpart. Same responsibilities, same
+ * boot order (log context → crash handlers → keybindings.yaml overlay →
+ * user themes → prefs read → per-host setup → provider-wrapped render),
+ * with the framework-free pieces (`applyUserKeybindings`, `loadUserThemes`,
+ * `readPersistedUiPrefs`, `applyUiPrefs`, `hostRenderOptions`,
+ * `installPaneExitBackstop`) imported from the shared modules.
+ *
+ * Deliberate deltas from the Solid host:
+ *   - Visual prefs are seeded into the module-level theme store BEFORE
+ *     `createRoot().render()` (the Solid version applies them inside a
+ *     sync component during first render) — the first painted frame is
+ *     already styled, and no component needs render-time side effects.
+ *   - The live daemon subscription rides the client layer's framework-free
+ *     store twins (`uiPrefsStore()` / `keybindingsRevStore()`) — Solid
+ *     signals don't notify outside a reactive-solid runtime.
+ *   - Error boundary is a small class component (React's only boundary
+ *     primitive); crash logging + themed fallback match the Solid host.
+ *   - Provider flags: only `focus` is portable today. `kv` /
+ *     `notifications` have no React port yet — requesting one throws
+ *     loudly at boot rather than silently skipping a provider a pane
+ *     depends on. They land with the panes that need them (issue #15 G3).
+ */
+
+import { createCliRenderer } from "@opentui/core"
+import { createRoot, useRenderer } from "@opentui/react"
+import {
+  installClientCrashHandlers,
+  logClientError,
+  setClientLogContext,
+} from "@sma1lboy/kobe-daemon/client/client-log"
+import type { UiPrefsPayload } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { Component, type ReactNode, useEffect } from "react"
+import { connectPaneOrchestrator } from "../../client/connect-pane-orchestrator"
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { applyUserKeybindings, reloadUserKeybindings } from "../../tui/context/keybindings-user"
+import { loadUserThemes } from "../../tui/context/theme/loader"
+import { type UiPrefsTarget, applyUiPrefs } from "../../tui/lib/apply-ui-prefs"
+import { sessionAttached } from "../../tui/lib/attach-gate"
+import { hostRenderOptions, installPaneExitBackstop } from "../../tui/lib/host-render-options"
+import { type PersistedUiPrefs, readPersistedUiPrefs } from "../../tui/lib/persisted-ui-prefs"
+import { FocusProvider } from "../context/focus"
+import {
+  ThemeProvider,
+  addTheme,
+  focusAccent,
+  hasTheme,
+  selectedTheme,
+  setFocusAccent,
+  setTheme,
+  setTransparentBackground,
+  transparentBackground,
+} from "../context/theme"
+import { useTheme } from "../context/theme"
+import { isLocaleId, setLocaleLang, t } from "../i18n"
+import { DialogProvider } from "../ui/dialog"
+
+/** Theme used when `state.json` is missing/stale — kobe's brand default. */
+const FALLBACK_THEME = "claude"
+
+/** Same flag surface as the Solid host; see header for the un-ported pair. */
+export interface HostProviderFlags {
+  /** KVProvider — NOT PORTED yet; `true` throws at boot. */
+  readonly kv?: boolean
+  /** FocusProvider, initial pane "sidebar". Default true. */
+  readonly focus?: boolean
+  /** NotificationsProvider — NOT PORTED yet; `true` throws at boot. */
+  readonly notifications?: boolean
+}
+
+/** What a host's `setup` hands back once its own pre-render work is done. */
+export interface HostScreen {
+  /** The host's root view, rendered inside the provider stack. */
+  readonly root: () => ReactNode
+  /** Teardown on ACTUAL exit (renderer destroy), never at mount-resolve. */
+  readonly onDestroy?: () => void
+}
+
+export interface BootPaneHostOpts {
+  readonly logContext?: string
+  readonly providers?: HostProviderFlags
+  readonly setup: (prefs: PersistedUiPrefs) => HostScreen | Promise<HostScreen>
+}
+
+/** The module-level theme store as a ui-prefs target (shared applyUiPrefs). */
+const themeTarget: UiPrefsTarget = {
+  selectedTheme,
+  hasTheme,
+  setTheme,
+  reloadUserThemes: () => {
+    for (const { name, theme } of loadUserThemes()) addTheme(name, theme)
+  },
+  transparentBackground,
+  setTransparentBackground,
+  focusAccent,
+  setFocusAccent,
+}
+
+/** Detached fps while the pane's session has no attached client. */
+const DETACHED_FPS = 2
+/** How often to re-check attachment (the probe itself is TTL-cached). */
+const DETACH_CHECK_MS = 3000
+
+/**
+ * Render-loop throttle for background panes — fps drops to DETACHED_FPS
+ * while the tmux session has no attached client, restores within ~3s of
+ * re-attach. Same contract and rationale as the Solid host's sibling.
+ */
+function DetachFpsThrottle() {
+  const renderer = useRenderer()
+  useEffect(() => {
+    if (!renderer) return
+    const attachedFps = renderer.targetFps
+    const timer = setInterval(() => {
+      void sessionAttached().then((attached) => {
+        const want = attached ? attachedFps : DETACHED_FPS
+        if (renderer.targetFps !== want) renderer.targetFps = want
+      })
+    }, DETACH_CHECK_MS)
+    return () => clearInterval(timer)
+  }, [renderer])
+  return null
+}
+
+/**
+ * Live ui-prefs + keybindings subscription — boot values were already
+ * seeded before render (see `bootPaneHost`), so this component only owns
+ * the daemon channel. Channel-scoped, non-spawning, degrades to boot-time
+ * prefs with no daemon; late connects after unmount are disposed on the
+ * spot. The first keybindings rev observed is the boot replay — skipped.
+ */
+function UiPrefsSync() {
+  useEffect(() => {
+    let disposed = false
+    let orch: RemoteOrchestrator | null = null
+    const disposers: Array<() => void> = []
+    void (async () => {
+      const remote = await connectPaneOrchestrator({
+        logTag: "ui-prefs",
+        channels: ["ui-prefs", "keybindings"],
+      })
+      if (!remote) return
+      if (disposed) {
+        remote.dispose()
+        return
+      }
+      orch = remote
+      // Framework-free store twins of the client layer's Solid signals —
+      // signals don't notify outside a reactive-solid runtime, stores
+      // notify everywhere. Deliver the current value eagerly (the
+      // subscribe-time channel replay may have landed before we attached).
+      const applyPrefs = (payload: UiPrefsPayload | null) => {
+        if (!payload) return
+        applyUiPrefs(themeTarget, payload)
+        if (isLocaleId(payload.locale)) setLocaleLang(payload.locale)
+      }
+      const prefsStore = remote.uiPrefsStore()
+      applyPrefs(prefsStore.get())
+      disposers.push(prefsStore.subscribe(() => applyPrefs(prefsStore.get())))
+
+      const revStore = remote.keybindingsRevStore()
+      // The first observed rev is the boot replay — already applied by
+      // applyUserKeybindings in bootPaneHost; only later bumps are edits.
+      let lastKeybindingsRev: number | null = revStore.get()
+      disposers.push(
+        revStore.subscribe(() => {
+          const rev = revStore.get()
+          if (rev == null || rev === lastKeybindingsRev) return
+          const isFirst = lastKeybindingsRev === null
+          lastKeybindingsRev = rev
+          if (!isFirst) reloadUserKeybindings()
+        }),
+      )
+    })()
+    return () => {
+      disposed = true
+      for (const dispose of disposers) dispose()
+      orch?.dispose()
+    }
+  }, [])
+  return null
+}
+
+/** Themed crash fallback — logs once, paints a minimal placeholder. */
+function PaneCrashFallback(props: { error: unknown }) {
+  const { theme } = useTheme()
+  useEffect(() => {
+    logClientError("pane-crash", props.error)
+  }, [props.error])
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background} paddingLeft={1} paddingTop={1} gap={1}>
+      <text fg={theme.error}>{t("common.paneCrash.title")}</text>
+      <text fg={theme.textMuted}>{t("common.paneCrash.hint")}</text>
+    </box>
+  )
+}
+
+/**
+ * React's boundary primitive is still a class component. Catches render
+ * errors from the host's view tree; fire-and-forget rejections are covered
+ * by `installClientCrashHandlers`, same split as the Solid host.
+ */
+class PaneErrorBoundary extends Component<{ children?: ReactNode }, { error: unknown | null }> {
+  override state: { error: unknown | null } = { error: null }
+  static getDerivedStateFromError(error: unknown) {
+    return { error }
+  }
+  override render() {
+    if (this.state.error !== null) return <PaneCrashFallback error={this.state.error} />
+    return this.props.children
+  }
+}
+
+/**
+ * Boot a standalone React pane host: shared steps → prefs read + seed →
+ * per-host `setup` → provider-wrapped `createRoot().render()`. Resolves
+ * once the root is mounted, mirroring the Solid host's render-resolve.
+ */
+export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
+  if (opts.logContext) setClientLogContext(opts.logContext)
+  installClientCrashHandlers()
+  applyUserKeybindings()
+  for (const { name, theme } of loadUserThemes()) addTheme(name, theme)
+
+  const prefs = readPersistedUiPrefs(FALLBACK_THEME)
+  // Seed ALL visual prefs + language before the first render — the module
+  // store is live before any component mounts, so the first frame is
+  // already themed (no transparent/accent flash).
+  applyUiPrefs(themeTarget, {
+    theme: prefs.theme,
+    transparentBackground: prefs.transparent,
+    focusAccent: prefs.focusAccent,
+  })
+  setLocaleLang(prefs.locale)
+
+  if (opts.providers?.kv) throw new Error("bootPaneHost(react): KVProvider is not ported yet (issue #15 G3)")
+  if (opts.providers?.notifications)
+    throw new Error("bootPaneHost(react): NotificationsProvider is not ported yet (issue #15 G3)")
+  const focus = opts.providers?.focus ?? true
+
+  const screen = await opts.setup(prefs)
+  const renderer = await createCliRenderer(hostRenderOptions(screen.onDestroy))
+
+  const body = (
+    <>
+      <UiPrefsSync />
+      <DetachFpsThrottle />
+      <PaneErrorBoundary>{screen.root()}</PaneErrorBoundary>
+    </>
+  )
+  createRoot(renderer).render(
+    <ThemeProvider mode="dark" theme={prefs.theme}>
+      {focus ? (
+        <FocusProvider initial="sidebar">
+          <DialogProvider>{body}</DialogProvider>
+        </FocusProvider>
+      ) : (
+        <DialogProvider>{body}</DialogProvider>
+      )}
+    </ThemeProvider>,
+  )
+  installPaneExitBackstop()
+}

--- a/packages/kobe/src/tui-react/mock/host.tsx
+++ b/packages/kobe/src/tui-react/mock/host.tsx
@@ -10,13 +10,13 @@
  * Keys: q quits · tab cycles pane focus · d opens a dialog (esc closes).
  */
 
-import { TextAttributes, createCliRenderer } from "@opentui/core"
-import { createRoot } from "@opentui/react"
-import { FocusProvider, PANE_ORDER, useFocus } from "../context/focus"
-import { ThemeProvider, useTheme } from "../context/theme"
+import { TextAttributes } from "@opentui/core"
+import { PANE_ORDER, useFocus } from "../context/focus"
+import { useTheme } from "../context/theme"
 import { t } from "../i18n"
+import { bootPaneHost } from "../lib/host-boot"
 import { useBindings } from "../lib/keymap"
-import { Dialog, DialogProvider, useDialog } from "../ui/dialog"
+import { Dialog, useDialog } from "../ui/dialog"
 
 function DemoDialog() {
   const { theme } = useTheme()
@@ -42,6 +42,7 @@ function Workbench() {
     enabled: true,
     bindings: [
       { key: "q", cmd: () => process.exit(0) },
+      { key: "ctrl+c", cmd: () => process.exit(0) },
       { key: "tab", cmd: () => focus.cycle(1) },
       { key: "d", cmd: () => dialog.replace(() => <DemoDialog />) },
     ],
@@ -81,13 +82,9 @@ function Workbench() {
   )
 }
 
-const renderer = await createCliRenderer({ exitOnCtrlC: true })
-createRoot(renderer).render(
-  <ThemeProvider>
-    <FocusProvider>
-      <DialogProvider>
-        <Workbench />
-      </DialogProvider>
-    </FocusProvider>
-  </ThemeProvider>,
-)
+// Boot through the real React pane host (G3): shared boot steps, persisted
+// prefs seeding, live ui-prefs subscription, crash boundary, exit backstop —
+// this entry IS the live smoke for that path.
+await bootPaneHost({
+  setup: () => ({ root: () => <Workbench /> }),
+})

--- a/packages/kobe/src/tui/lib/host-boot.tsx
+++ b/packages/kobe/src/tui/lib/host-boot.tsx
@@ -46,6 +46,7 @@ import { isLocaleId, setLocaleLang, t } from "../i18n"
 import { DialogProvider } from "../ui/dialog"
 import { type UiPrefsTarget, applyUiPrefs } from "./apply-ui-prefs"
 import { sessionAttached } from "./attach-gate"
+import { hostRenderOptions, installPaneExitBackstop } from "./host-render-options"
 import { type PersistedUiPrefs, readPersistedUiPrefs } from "./persisted-ui-prefs"
 
 /**
@@ -132,24 +133,8 @@ function applyHostBootSteps(logContext?: string): void {
   }
 }
 
-/**
- * The render-option set shared by every host, verbatim from the blocks this
- * module replaced: transparent background (the terminal's own bg shows
- * through), passthrough external output, no exit-on-Ctrl+C (hosts own their
- * quit semantics), alternate screen, kitty keyboard protocol. `onDestroy`
- * is the only delta any host ever had; it's spread in only when present so
- * a host without teardown passes the exact same shape as before.
- */
-function hostRenderOptions(onDestroy?: () => void): Record<string, unknown> {
-  const base = {
-    backgroundColor: "transparent",
-    externalOutputMode: "passthrough",
-    exitOnCtrlC: false,
-    screenMode: "alternate-screen",
-    useKittyKeyboard: {},
-  }
-  return onDestroy ? { ...base, onDestroy } : base
-}
+// Render options + the exit backstop are shared with the React host path —
+// see ./host-render-options.ts.
 
 /**
  * The fixed-order provider nest. Built innermost-out as NAMED closures:
@@ -398,29 +383,5 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
     ),
     hostRenderOptions(screen.onDestroy),
   )
-  // Exit-signal backstop (orphaned-helper leak): opentui's own exit handler
-  // for SIGHUP/SIGTERM only destroys the renderer — it never calls
-  // process.exit — and installing that listener replaced the signals'
-  // default "terminate" action. A host keeps its event loop alive (daemon
-  // socket, file watcher, poll timers), so every tmux `kill-pane` /
-  // `respawn-pane -k` / session teardown left the process running forever
-  // with a revoked tty, reparented to launchd. Registered AFTER `render`
-  // resolves so opentui's handler (terminal restore + onDestroy) runs
-  // first.
-  //
-  // The exit is DELAYED, not immediate: some flows kill the session their
-  // own pane lives in and then keep orchestrating (togglePreview's
-  // kill→rebuild→switch, ensureSession's vendor-switch rebuild) — an
-  // instant exit on the incoming SIGHUP would truncate them. Five seconds
-  // is enough for any in-flight tmux sequence; the pane is already gone
-  // from the screen, so the tail is invisible.
-  let exitScheduled = false
-  const scheduleExit = () => {
-    if (exitScheduled) return
-    exitScheduled = true
-    setTimeout(() => process.exit(0), 5000)
-  }
-  for (const signal of ["SIGHUP", "SIGTERM", "SIGINT"] as const) {
-    process.on(signal, scheduleExit)
-  }
+  installPaneExitBackstop()
 }

--- a/packages/kobe/src/tui/lib/host-render-options.ts
+++ b/packages/kobe/src/tui/lib/host-render-options.ts
@@ -1,0 +1,54 @@
+/**
+ * Framework-free host-boot pieces shared by the Solid pane host
+ * (`./host-boot.tsx`) and the React one (`src/tui-react/lib/host-boot.tsx`,
+ * issue #15 G3). Extracted so the render-option contract and the
+ * exit-signal backstop cannot drift between the two boot paths.
+ */
+
+/**
+ * The render-option set shared by every host: transparent background (the
+ * terminal's own bg shows through), passthrough external output, no
+ * exit-on-Ctrl+C (hosts own their quit semantics), alternate screen, kitty
+ * keyboard protocol. `onDestroy` is the only delta any host ever had; it's
+ * spread in only when present so a host without teardown passes the exact
+ * same shape as before.
+ */
+export function hostRenderOptions(onDestroy?: () => void): Record<string, unknown> {
+  const base = {
+    backgroundColor: "transparent",
+    externalOutputMode: "passthrough",
+    exitOnCtrlC: false,
+    screenMode: "alternate-screen",
+    useKittyKeyboard: {},
+  }
+  return onDestroy ? { ...base, onDestroy } : base
+}
+
+/**
+ * Exit-signal backstop (orphaned-helper leak): opentui's own exit handler
+ * for SIGHUP/SIGTERM only destroys the renderer — it never calls
+ * process.exit — and installing that listener replaced the signals' default
+ * "terminate" action. A host keeps its event loop alive (daemon socket,
+ * file watcher, poll timers), so every tmux `kill-pane` / `respawn-pane -k`
+ * / session teardown would leave the process running forever with a revoked
+ * tty, reparented to launchd. Register AFTER render resolves so opentui's
+ * handler (terminal restore + onDestroy) runs first.
+ *
+ * The exit is DELAYED, not immediate: some flows kill the session their own
+ * pane lives in and then keep orchestrating (togglePreview's
+ * kill→rebuild→switch, ensureSession's vendor-switch rebuild) — an instant
+ * exit on the incoming SIGHUP would truncate them. Five seconds is enough
+ * for any in-flight tmux sequence; the pane is already gone from the
+ * screen, so the tail is invisible.
+ */
+export function installPaneExitBackstop(): void {
+  let exitScheduled = false
+  const scheduleExit = () => {
+    if (exitScheduled) return
+    exitScheduled = true
+    setTimeout(() => process.exit(0), 5000)
+  }
+  for (const signal of ["SIGHUP", "SIGTERM", "SIGINT"] as const) {
+    process.on(signal, scheduleExit)
+  }
+}

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -457,3 +457,38 @@ describe("worktree.changes pure helpers", () => {
     expect(sameWorktreeChangesMap(a, new Map())).toBe(false)
   })
 })
+
+describe("framework-free store twins (React hosts, issue #15 G3)", () => {
+  // Why this matters: React panes receive live daemon pushes ONLY through
+  // these stores — solid-js signals are inert under node/vitest and plain
+  // bun (SSR build). If the dual-write drifts or stops notifying, React
+  // panes silently freeze on boot-time prefs. Note the SUBSCRIBE assertions:
+  // in this very environment the Solid accessor would not notify, which is
+  // the reason the stores exist.
+  it("ui-prefs channel lands in uiPrefsStore and notifies subscribers", () => {
+    const { client, emit } = fakeClient()
+    const orch = new RemoteOrchestrator(client)
+    const store = orch.uiPrefsStore()
+    const seen: Array<string | undefined> = []
+    const unsub = store.subscribe(() => seen.push(store.get()?.theme))
+    emit("ui-prefs", { theme: "nord" })
+    expect(store.get()?.theme).toBe("nord")
+    expect(orch.uiPrefsSignal()()?.theme).toBe("nord")
+    emit("ui-prefs", { theme: "claude" })
+    unsub()
+    emit("ui-prefs", { theme: "dracula" })
+    expect(seen).toEqual(["nord", "claude"])
+    expect(store.get()?.theme).toBe("dracula")
+  })
+
+  it("keybindings channel lands in keybindingsRevStore and notifies", () => {
+    const { client, emit } = fakeClient()
+    const orch = new RemoteOrchestrator(client)
+    const store = orch.keybindingsRevStore()
+    const seen: Array<number | null> = []
+    store.subscribe(() => seen.push(store.get()))
+    emit("keybindings", { rev: 1 })
+    emit("keybindings", { rev: 2 })
+    expect(seen).toEqual([1, 2])
+  })
+})

--- a/packages/kobe/test/tui-react/external-store.test.ts
+++ b/packages/kobe/test/tui-react/external-store.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest"
-import { createExternalStore } from "../../src/tui-react/lib/external-store"
+import { createExternalStore } from "../../src/lib/external-store"
 
 describe("createExternalStore", () => {
   it("get returns the current snapshot; set replaces it", () => {

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Why this matters: hostRenderOptions is the render contract EVERY pane host
+ * (Solid and React) passes to createCliRenderer — a drifted flag here changes
+ * terminal behavior for all panes at once (alt-screen, ctrl+c semantics,
+ * passthrough). installPaneExitBackstop is the orphaned-helper fix (KOB —
+ * SIGHUP-swallow leak): registration must cover exactly the three signals.
+ */
+
+import { afterEach, describe, expect, it } from "vitest"
+import { hostRenderOptions, installPaneExitBackstop } from "../../src/tui/lib/host-render-options"
+
+describe("hostRenderOptions", () => {
+  it("returns the shared option set verbatim", () => {
+    expect(hostRenderOptions()).toEqual({
+      backgroundColor: "transparent",
+      externalOutputMode: "passthrough",
+      exitOnCtrlC: false,
+      screenMode: "alternate-screen",
+      useKittyKeyboard: {},
+    })
+  })
+
+  it("spreads onDestroy in only when present (same shape otherwise)", () => {
+    const onDestroy = () => {}
+    expect(hostRenderOptions(onDestroy)).toMatchObject({ onDestroy })
+    expect("onDestroy" in hostRenderOptions()).toBe(false)
+  })
+})
+
+describe("installPaneExitBackstop", () => {
+  const SIGNALS = ["SIGHUP", "SIGTERM", "SIGINT"] as const
+  const added: Array<{ signal: (typeof SIGNALS)[number]; fn: NodeJS.SignalsListener }> = []
+
+  afterEach(() => {
+    for (const { signal, fn } of added.splice(0)) process.removeListener(signal, fn)
+  })
+
+  it("registers one delayed-exit listener per teardown signal", () => {
+    const before = new Map(SIGNALS.map((s) => [s, process.listeners(s).length]))
+    installPaneExitBackstop()
+    for (const signal of SIGNALS) {
+      const listeners = process.listeners(signal)
+      expect(listeners.length).toBe((before.get(signal) ?? 0) + 1)
+      added.push({ signal, fn: listeners.at(-1) as NodeJS.SignalsListener })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- G3 step 0 of the Solid → React TUI migration (issue #15): React hosts get a real `bootPaneHost` (`src/tui-react/lib/host-boot.tsx`) mirroring the Solid one — shared boot steps (crash handlers, keybindings.yaml overlay, user themes), persisted-prefs **seeded before first paint** (no theme/transparent flash), themed class error boundary, detach-fps throttle, and the exit-signal backstop. `dev:mock-react` now boots through this real path.
- The render-option contract + exit backstop are extracted to framework-free `src/tui/lib/host-render-options.ts`, consumed by BOTH hosts (no drift).
- **Live daemon pushes go framework-free** (owner decision this session: pure React, no solid dependency in the React graph): `RemoteOrchestrator` gains `uiPrefsStore()` / `keybindingsRevStore()` external-store twins (single writer dual-writes store + the existing Solid accessor facade). Rationale: solid-js resolves to its inert SSR build under node/vitest and plain `bun` — a Solid-signal bridge would silently drop live updates in any React runtime missing `--conditions=browser`. Verified by a minimal probe; the new store tests assert the subscribe-notify path that Solid signals fail in that exact environment.
- `createExternalStore` moved to `src/lib/` (client layer + React infra both consume it); provider flags `kv`/`notifications` throw loudly until their React ports land with the panes that need them.

coverage-exemption: packages/kobe/src/tui-react/lib/host-boot.tsx — renderer-bound boot layer (imports @opentui/react, not importable under vitest); mirrors the Solid src/tui/lib/host-boot.tsx which is likewise uncovered; exercised live by the dev:mock-react gate.

## Test plan
- [x] `bun run typecheck` + repo-root `bun run lint` clean
- [x] `bun run test` — fast 2449/2449 + socket 218/218, including new store-twin contract tests (subscribe/notify assertions that the Solid accessors would fail under vitest)
- [x] `timeout 6 bun run dev:mock-react` — React pilot boots through bootPaneHost and renders
- [x] `timeout 6 bun run dev:mock` — Solid path unbroken (exit 124)
- [x] `bun run compile` → `release-bin/kobe --version` OK

file-size-exemption: packages/kobe/src/client/remote-orchestrator.ts — pre-existing 497-line 4-way-split file; +26 lines of store-twin plumbing. The proper shrink (signal-bag factory extraction) is filed on the oversized-files debt (issue #12).
