### PR TITLE
feat: React port of the history pane behind KOBE_REACT=1 (G3.1, issue #15)

### DIFF
--- a/.changeset/react-history-pane.md
+++ b/.changeset/react-history-pane.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+G3.1 React migration pilot: `kobe history` can now render through the React pane host behind `KOBE_REACT=1`, sharing pure transcript formatting/windowing logic with the Solid pane and adding a React history mock smoke path.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -27,6 +27,7 @@
     "dev": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/cli/index.ts",
     "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
     "dev:mock-react": "env KOBE_DEV=1 bun ./src/tui-react/mock/host.tsx",
+    "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
     "dev:sandbox": "bun run scripts/dev-sandbox.ts run",
     "dev:sandbox:reset": "bun run scripts/dev-sandbox.ts reset",
     "dev:version": "bash ../../scripts/dev-version.sh",

--- a/packages/kobe/src/cli/commands-tui.ts
+++ b/packages/kobe/src/cli/commands-tui.ts
@@ -409,7 +409,10 @@ export async function dispatchTuiCommand(subcommand: string | undefined, rest: r
       console.error("kobe history: --worktree <path> is required")
       process.exit(2)
     }
-    const { startHistoryHost } = await import("../tui/history/host.tsx")
+    const { startHistoryHost } =
+      process.env.KOBE_REACT === "1"
+        ? await import("../tui-react/history/host.tsx")
+        : await import("../tui/history/host.tsx")
     await startHistoryHost({
       worktree: flags.worktree,
       vendor: coerceVendorId(flags.vendor),

--- a/packages/kobe/src/tui-react/history/host.tsx
+++ b/packages/kobe/src/tui-react/history/host.tsx
@@ -1,0 +1,277 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React `kobe history` host — G3.1's first real pane port.
+ *
+ * Async pattern canon for later React panes: each async read is modeled with
+ * `useState` plus a dependency-keyed `useEffect`. The effect keeps the last
+ * resolved value visible while a refresh is in flight, catches read failures to
+ * an empty value at the reader boundary, and cancels stale promise completions
+ * with an effect-local `disposed` flag. Live transcript mtime polling is a
+ * separate effect that bumps `refreshTick`; the data effects refetch from that
+ * scalar instead of owning their own timers.
+ */
+
+import { type EngineHistoryReader, engineEntry } from "@/engine/registry"
+import type { Message } from "@/types/engine"
+import type { VendorId } from "@/types/task"
+import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { resultsByCallId } from "../../tui/history/message-core"
+import { windowTail } from "../../tui/history/window"
+import { sessionAttached } from "../../tui/lib/attach-gate"
+import { ACTIVITY_POLL_MIN_MS, nextActivityPollDelay } from "../../tui/ops/activity-poll"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { bootPaneHost } from "../lib/host-boot"
+import { useBindings } from "../lib/keymap"
+import { MessageCard } from "./message-card"
+
+export interface HistoryHostArgs {
+  readonly worktree: string
+  readonly vendor: VendorId
+  /** Optional task title for the header; falls back to the worktree basename. */
+  readonly title?: string
+  /** Live preview of a non-archived task (vs the frozen archived transcript). */
+  readonly live?: boolean
+  /** Override the transcript source; dev:mock injects a fake reader. */
+  readonly reader?: EngineHistoryReader
+}
+
+/** Lines of transcript scrolled per `j`/`k` keypress. */
+const SCROLL_STEP = 3
+
+function basename(p: string): string {
+  const i = p.lastIndexOf("/")
+  return i >= 0 ? p.slice(i + 1) : p
+}
+
+function HistoryScreen(props: HistoryHostArgs) {
+  const { theme } = useTheme()
+  const t = useT()
+  const reader = useMemo(() => props.reader ?? engineEntry(props.vendor).history, [props.reader, props.vendor])
+  const [refreshTick, setRefreshTick] = useState(0)
+  const [sessions, setSessions] = useState<readonly string[] | undefined>(undefined)
+  const [selected, setSelected] = useState(0)
+  const [messages, setMessages] = useState<Message[] | undefined>(undefined)
+  const [expanded, setExpanded] = useState(false)
+  const prevSessionCount = useRef(0)
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+
+  useEffect(() => {
+    // Dependency-only invalidation key: the reader API takes worktree, while
+    // refreshTick tells this effect when the mtime poll saw new transcript data.
+    void refreshTick
+    let disposed = false
+    void reader
+      .listSessionIdsForWorktree(props.worktree)
+      .then((list) => {
+        if (!disposed) setSessions(list)
+      })
+      .catch(() => {
+        if (!disposed) setSessions([])
+      })
+    return () => {
+      disposed = true
+    }
+  }, [reader, props.worktree, refreshTick])
+
+  const sessionList = sessions ?? []
+  useEffect(() => {
+    if (sessions === undefined) return
+    const n = sessions.length
+    setSelected((i) => (n > prevSessionCount.current ? (n > 0 ? n - 1 : 0) : Math.min(i, Math.max(0, n - 1))))
+    prevSessionCount.current = n
+  }, [sessions])
+
+  const selectedId = sessionList[selected]
+  useEffect(() => {
+    // Dependency-only invalidation key; readHistory itself is session-id based.
+    void refreshTick
+    if (!selectedId) {
+      setMessages([])
+      return
+    }
+    let disposed = false
+    void reader
+      .readHistory(selectedId)
+      .then((list) => {
+        if (!disposed) setMessages(list)
+      })
+      .catch(() => {
+        if (!disposed) setMessages([])
+      })
+    return () => {
+      disposed = true
+    }
+  }, [reader, selectedId, refreshTick])
+
+  const messageList = messages ?? []
+  const results = useMemo(() => resultsByCallId(messageList), [messageList])
+  const tokenTotal = useMemo(
+    () => messageList.reduce((sum, m) => sum + (m.usage?.output_tokens ?? 0), 0),
+    [messageList],
+  )
+  const tail = useMemo(() => windowTail(messageList), [messageList])
+
+  useEffect(() => {
+    let disposed = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let delayMs = ACTIVITY_POLL_MIN_MS
+    let idleStreak = 0
+    let lastMtime = 0
+    let primed = false
+    async function poll(): Promise<void> {
+      if (!(await sessionAttached())) {
+        if (!disposed) timer = setTimeout(() => void poll(), delayMs)
+        return
+      }
+      try {
+        const mtime = await reader.latestTranscriptMtimeForWorktree(props.worktree)
+        if (disposed) return
+        if (!primed) {
+          primed = true
+          lastMtime = mtime
+          idleStreak++
+        } else if (mtime > lastMtime) {
+          lastMtime = mtime
+          idleStreak = 0
+          setRefreshTick((n) => n + 1)
+        } else {
+          idleStreak++
+        }
+      } catch {
+        idleStreak++
+      } finally {
+        if (!disposed) {
+          delayMs = nextActivityPollDelay(delayMs, idleStreak)
+          timer = setTimeout(() => void poll(), delayMs)
+        }
+      }
+    }
+    void poll()
+    return () => {
+      disposed = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [reader, props.worktree])
+
+  const scrollBy = useCallback((dy: number): void => {
+    const scroll = scrollRef.current
+    if (!scroll) return
+    scroll.scrollTo({ x: 0, y: Math.max(0, scroll.scrollTop + dy) })
+  }, [])
+  useEffect(() => {
+    // Dependency-only reset key: scroll to top whenever the selected session changes.
+    void selectedId
+    scrollRef.current?.scrollTo({ x: 0, y: 0 })
+  }, [selectedId])
+
+  const switchSession = useCallback(
+    (delta: number): void => {
+      const n = sessionList.length
+      if (n === 0) return
+      setSelected((i) => Math.min(Math.max(i + delta, 0), n - 1))
+    },
+    [sessionList.length],
+  )
+
+  useBindings(() => ({
+    bindings: [
+      { key: "j", cmd: () => scrollBy(SCROLL_STEP) },
+      { key: "k", cmd: () => scrollBy(-SCROLL_STEP) },
+      { key: "down", cmd: () => scrollBy(SCROLL_STEP) },
+      { key: "up", cmd: () => scrollBy(-SCROLL_STEP) },
+      { key: "[", cmd: () => switchSession(-1) },
+      { key: "]", cmd: () => switchSession(1) },
+      { key: "return", cmd: () => setExpanded((e) => !e) },
+    ],
+  }))
+
+  const headerTitle = props.title?.trim() || basename(props.worktree)
+  const counter = sessionList.length > 0 ? `${t("history.sessionLabel")} ${selected + 1}/${sessionList.length}` : ""
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+      <box
+        flexDirection="row"
+        gap={1}
+        paddingLeft={1}
+        paddingRight={1}
+        flexShrink={0}
+        backgroundColor={theme.backgroundElement}
+      >
+        <text fg={props.live ? theme.success : theme.warning} attributes={TextAttributes.BOLD} wrapMode="none">
+          {props.live ? t("history.liveTag") : t("history.archivedTag")}
+        </text>
+        <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+          {headerTitle}
+        </text>
+        {counter ? (
+          <text fg={theme.textMuted} wrapMode="none">
+            {`· ${counter}`}
+          </text>
+        ) : null}
+        <box flexGrow={1} />
+        {tokenTotal > 0 ? (
+          <text fg={theme.textMuted} wrapMode="none">
+            {`${tokenTotal} tok`}
+          </text>
+        ) : null}
+      </box>
+      <scrollbox
+        ref={(r: ScrollBoxRenderable | null) => {
+          scrollRef.current = r
+        }}
+        flexGrow={1}
+        verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
+      >
+        {sessions === undefined ? (
+          <box paddingTop={1} paddingLeft={1}>
+            <text fg={theme.textMuted}>{t("history.loading")}</text>
+          </box>
+        ) : messageList.length > 0 ? (
+          <>
+            {tail.hiddenCount > 0 ? (
+              <box paddingLeft={1} paddingRight={1} paddingBottom={1}>
+                <text fg={theme.textMuted} attributes={TextAttributes.ITALIC} wrapMode="none">
+                  {t("history.earlier", { count: tail.hiddenCount })}
+                </text>
+              </box>
+            ) : null}
+            {tail.visible.map((msg, i) => (
+              <MessageCard
+                key={`${msg.sessionId}:${msg.timestamp}:${i}`}
+                msg={msg}
+                results={results}
+                expanded={expanded}
+              />
+            ))}
+          </>
+        ) : (
+          <box paddingTop={1} paddingLeft={1}>
+            <text fg={theme.textMuted}>{t("history.empty")}</text>
+          </box>
+        )}
+      </scrollbox>
+      <box
+        flexDirection="row"
+        paddingLeft={1}
+        paddingRight={1}
+        flexShrink={0}
+        backgroundColor={theme.backgroundElement}
+      >
+        <text fg={theme.textMuted} wrapMode="none">
+          {expanded ? t("history.hintExpanded") : t("history.hint")}
+        </text>
+      </box>
+    </box>
+  )
+}
+
+export async function startHistoryHost(args: HistoryHostArgs): Promise<void> {
+  await bootPaneHost({
+    logContext: "history",
+    providers: { kv: false, focus: false },
+    setup: () => ({ root: () => <HistoryScreen {...args} /> }),
+  })
+}

--- a/packages/kobe/src/tui-react/history/message-card.tsx
+++ b/packages/kobe/src/tui-react/history/message-card.tsx
@@ -1,27 +1,40 @@
+/** @jsxImportSource @opentui/react */
 /**
- * Transcript row rendering for the history pane — extracted from `host.tsx`
- * (500-line cap). One `MessageCard` per message: user turns are tinted cards
- * with a `❯` glyph + relative-time chip, assistant text is plain, tool calls
- * are a colored `⏺` status glyph + bold name + dim summary, and the expanded
- * state reveals tool-output / thinking bodies. `BodyLines`, `bodyText` and
- * `toolInputSummary` are shared with the chat surface (`chat/ChatRow.tsx`,
- * via the `host.tsx` re-export) so both transcripts read identically.
+ * React transcript row rendering for the history pane. The visual grammar
+ * mirrors `src/tui/history/message-card.tsx`; pure formatting helpers live in
+ * `src/tui/history/message-core.ts` so Solid and React cannot drift.
  */
 
 import type { ContentBlock } from "@/types/content"
 import type { Message } from "@/types/engine"
 import { TextAttributes } from "@opentui/core"
-import { For, Show, createMemo } from "solid-js"
+import { useMemo } from "react"
+import { type ToolResultBlock, bodyText, relativeTime, toolInputSummary } from "../../tui/history/message-core"
 import { useTheme } from "../context/theme"
-import { t } from "../i18n"
-import { type ToolResultBlock, bodyText, relativeTime, resultsByCallId, toolInputSummary } from "./message-core"
+import { useT } from "../i18n"
 
-export { bodyText, resultsByCallId, toolInputSummary } from "./message-core"
+export { bodyText, toolInputSummary } from "../../tui/history/message-core"
+
+function lineKey(line: string, index: number): string {
+  return `${index}:${line}`
+}
+
+function blockKey(block: ContentBlock, index: number): string {
+  switch (block.type) {
+    case "tool_call":
+    case "tool_result":
+      return `${block.type}:${block.callId}`
+    case "text":
+      return `text:${block.text}:${index}`
+    case "thinking":
+      return `thinking:${block.text}:${index}`
+  }
+}
 
 /** A tool-output / thinking body, one `<text>` per line so +/- diff lines tint. */
 export function BodyLines(props: { text: string; error?: boolean }) {
   const { theme } = useTheme()
-  const lines = () => props.text.replace(/\s+$/, "").split("\n")
+  const lines = useMemo(() => props.text.replace(/\s+$/, "").split("\n"), [props.text])
   const lineColor = (line: string) => {
     if (props.error) return theme.error
     if (line.startsWith("+") && !line.startsWith("+++")) return theme.success
@@ -30,13 +43,11 @@ export function BodyLines(props: { text: string; error?: boolean }) {
   }
   return (
     <box flexDirection="column" paddingLeft={2} marginLeft={2} backgroundColor={theme.backgroundElement}>
-      <For each={lines()}>
-        {(line) => (
-          <text fg={lineColor(line)} wrapMode="word">
-            {line || " "}
-          </text>
-        )}
-      </For>
+      {lines.map((line, i) => (
+        <text key={lineKey(line, i)} fg={lineColor(line)} wrapMode="word">
+          {line || " "}
+        </text>
+      ))}
     </box>
   )
 }
@@ -47,10 +58,10 @@ function BlockView(props: {
   expanded: boolean
 }) {
   const { theme } = useTheme()
+  const t = useT()
   const block = props.block
   switch (block.type) {
     case "text":
-      // user-text is rendered as a card by MessageCard; this path is assistant/system.
       return (
         <text fg={theme.text} wrapMode="word">
           {block.text}
@@ -62,9 +73,7 @@ function BlockView(props: {
           <text fg={theme.textMuted} attributes={TextAttributes.ITALIC} wrapMode="none">
             {`✱ ${t("history.thinking")}${props.expanded ? "" : "…"}`}
           </text>
-          <Show when={props.expanded && block.text.trim()}>
-            <BodyLines text={block.text} />
-          </Show>
+          {props.expanded && block.text.trim() ? <BodyLines text={block.text} /> : null}
         </box>
       )
     case "tool_call": {
@@ -80,25 +89,22 @@ function BlockView(props: {
             <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
               {block.name}
             </text>
-            <Show when={summary}>
+            {summary ? (
               <text fg={theme.textMuted} wrapMode="none">
                 {summary}
               </text>
-            </Show>
+            ) : null}
           </box>
-          <Show when={props.expanded && body.trim()}>
-            <BodyLines text={body} error={props.result?.isError} />
-          </Show>
+          {props.expanded && body.trim() ? <BodyLines text={body} error={props.result?.isError} /> : null}
         </box>
       )
     }
     case "tool_result":
-      // Attached to its tool_call above — never rendered standalone.
       return null
   }
 }
 
-function roleLabel(role: Message["role"]): string {
+function roleLabel(role: Message["role"], t: ReturnType<typeof useT>): string {
   return role === "assistant"
     ? t("history.role.assistant")
     : role === "system"
@@ -112,50 +118,54 @@ export function MessageCard(props: {
   expanded: boolean
 }) {
   const { theme } = useTheme()
-  const isUser = () => props.msg.role === "user"
-  const stamp = () => relativeTime(props.msg.timestamp)
-  // user text blocks → a tinted card with a ❯ glyph + time chip; everything
-  // else (assistant/system text, tools, thinking) renders flush below.
-  const userText = createMemo(() =>
-    isUser()
-      ? props.msg.blocks
-          .filter((b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text" && b.text.trim().length > 0)
-          .map((b) => b.text)
-          .join("\n")
-      : "",
+  const t = useT()
+  const isUser = props.msg.role === "user"
+  const stamp = relativeTime(props.msg.timestamp)
+  const userText = useMemo(
+    () =>
+      isUser
+        ? props.msg.blocks
+            .filter((b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text" && b.text.trim().length > 0)
+            .map((b) => b.text)
+            .join("\n")
+        : "",
+    [isUser, props.msg.blocks],
   )
-  const otherBlocks = () => (isUser() ? props.msg.blocks.filter((b) => b.type !== "text") : props.msg.blocks)
+  const otherBlocks = useMemo(
+    () => (isUser ? props.msg.blocks.filter((b) => b.type !== "text") : props.msg.blocks),
+    [isUser, props.msg.blocks],
+  )
+
   return (
     <box flexDirection="column" paddingLeft={1} paddingRight={1} paddingBottom={1} gap={0}>
-      <Show when={isUser() && userText()}>
+      {isUser && userText ? (
         <box flexDirection="row" gap={1} paddingLeft={1} paddingRight={1} backgroundColor={theme.backgroundElement}>
           <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
             ❯
           </text>
           <text fg={theme.text} wrapMode="word" flexGrow={1}>
-            {userText()}
+            {userText}
           </text>
-          <Show when={stamp()}>
+          {stamp ? (
             <text fg={theme.textMuted} wrapMode="none">
-              {stamp()}
+              {stamp}
             </text>
-          </Show>
+          ) : null}
         </box>
-      </Show>
-      <Show when={!isUser()}>
+      ) : null}
+      {!isUser ? (
         <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
-          {roleLabel(props.msg.role)}
+          {roleLabel(props.msg.role, t)}
         </text>
-      </Show>
-      <For each={otherBlocks()}>
-        {(block) => (
-          <BlockView
-            block={block}
-            result={block.type === "tool_call" ? props.results.get(block.callId) : undefined}
-            expanded={props.expanded}
-          />
-        )}
-      </For>
+      ) : null}
+      {otherBlocks.map((block, i) => (
+        <BlockView
+          key={blockKey(block, i)}
+          block={block}
+          result={block.type === "tool_call" ? props.results.get(block.callId) : undefined}
+          expanded={props.expanded}
+        />
+      ))}
     </box>
   )
 }

--- a/packages/kobe/src/tui-react/history/mock-host.tsx
+++ b/packages/kobe/src/tui-react/history/mock-host.tsx
@@ -1,0 +1,16 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React history-pane mock host. It renders the ported pane against the exact
+ * fake EngineHistoryReader fixtures used by the Solid `dev:mock` smoke.
+ */
+
+import { MOCK_HISTORY_WORKTREE, createMockHistoryReader } from "../../tui/history/mock-fixtures"
+import { coerceVendorId } from "../../types/vendor"
+import { startHistoryHost } from "./host"
+
+await startHistoryHost({
+  worktree: MOCK_HISTORY_WORKTREE,
+  vendor: coerceVendorId("claude"),
+  live: true,
+  reader: createMockHistoryReader(),
+})

--- a/packages/kobe/src/tui/history/message-core.ts
+++ b/packages/kobe/src/tui/history/message-core.ts
@@ -1,0 +1,75 @@
+/**
+ * Framework-free transcript helpers shared by the Solid and React history
+ * renderers. Keep renderer imports out of this file so vitest can pin the
+ * formatting contracts without loading @opentui.
+ */
+
+import type { ContentBlock } from "@/types/content"
+import type { Message } from "@/types/engine"
+
+/** One-line cap for a tool call's input summary. */
+const SUMMARY_MAX = 120
+
+export type ToolResultBlock = Extract<ContentBlock, { type: "tool_result" }>
+
+/** Relative age of an ISO timestamp ("3m", "2h", "4d"), or "" when unparseable. */
+export function relativeTime(iso: string, nowMs: number = Date.now()): string {
+  const ms = Date.parse(iso)
+  if (Number.isNaN(ms)) return ""
+  const secs = Math.max(0, Math.floor((nowMs - ms) / 1000))
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h`
+  return `${Math.floor(hours / 24)}d`
+}
+
+/**
+ * One-line label for a tool call. Picks the most meaningful string field by
+ * priority; else compact JSON, truncated.
+ */
+export function toolInputSummary(input: unknown): string {
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    const obj = input as Record<string, unknown>
+    const pick = (key: string): string | null => (typeof obj[key] === "string" ? (obj[key] as string) : null)
+    const candidate =
+      pick("command") ??
+      pick("file_path") ??
+      pick("pattern") ??
+      pick("url") ??
+      pick("description") ??
+      pick("prompt") ??
+      pick("query")
+    if (candidate) return candidate.length > SUMMARY_MAX ? `${candidate.slice(0, SUMMARY_MAX - 1)}…` : candidate
+  }
+  try {
+    const raw = JSON.stringify(input)
+    if (!raw || raw === "{}" || raw === "null") return ""
+    return raw.length > SUMMARY_MAX ? `${raw.slice(0, SUMMARY_MAX - 1)}…` : raw
+  } catch {
+    return ""
+  }
+}
+
+/** Full multi-line stringification of a tool result, for the expanded body. */
+export function bodyText(value: unknown): string {
+  if (typeof value === "string") return value
+  try {
+    const raw = JSON.stringify(value, null, 2)
+    return raw === undefined ? String(value) : raw
+  } catch {
+    return String(value)
+  }
+}
+
+/** Index tool_result blocks by their callId so a tool_call can show its result. */
+export function resultsByCallId(messages: readonly Message[]): Map<string, ToolResultBlock> {
+  const map = new Map<string, ToolResultBlock>()
+  for (const m of messages) {
+    for (const b of m.blocks) {
+      if (b.type === "tool_result") map.set(b.callId, b)
+    }
+  }
+  return map
+}

--- a/packages/kobe/src/tui/history/mock-fixtures.ts
+++ b/packages/kobe/src/tui/history/mock-fixtures.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared mock transcript fixtures for Solid and React history-pane smoke hosts.
+ * The host injects the returned EngineHistoryReader, so both renderers exercise
+ * the same data path without a real engine transcript store.
+ */
+
+import type { EngineHistoryReader } from "@/engine/registry"
+import type { Message } from "@/types/engine"
+
+export const MOCK_HISTORY_SESSION_ID = "mock-session"
+export const MOCK_HISTORY_WORKTREE = "/mock/worktree"
+
+/** A representative starter transcript exercising every block renderer. */
+export function seedHistoryMessages(): Message[] {
+  const ts = new Date().toISOString()
+  return [
+    {
+      role: "user",
+      sessionId: MOCK_HISTORY_SESSION_ID,
+      timestamp: ts,
+      blocks: [{ type: "text", text: "帮我给 history pane 加一个实时刷新的预览" }],
+    },
+    {
+      role: "assistant",
+      sessionId: MOCK_HISTORY_SESSION_ID,
+      timestamp: ts,
+      usage: { input_tokens: 1240, output_tokens: 356 },
+      blocks: [
+        {
+          type: "thinking",
+          text: "The read-only history pane should tail the transcript. Reuse the Ops pane's adaptive mtime poll instead of a new file watcher.",
+        },
+        { type: "text", text: "好的，我复用 Ops pane 的 mtime 轮询，把 HistoryScreen 做成 live。先看现有 effect……" },
+        { type: "tool_call", callId: "c1", name: "Read", input: { file_path: "src/tui/history/host.tsx" } },
+      ],
+    },
+    {
+      role: "user",
+      sessionId: MOCK_HISTORY_SESSION_ID,
+      timestamp: ts,
+      blocks: [{ type: "tool_result", callId: "c1", output: "…file contents…", isError: false }],
+    },
+    {
+      role: "assistant",
+      sessionId: MOCK_HISTORY_SESSION_ID,
+      timestamp: ts,
+      usage: { input_tokens: 2010, output_tokens: 128 },
+      blocks: [
+        {
+          type: "tool_call",
+          callId: "c2",
+          name: "Edit",
+          input: { file_path: "host.tsx", old_string: "…", new_string: "…" },
+        },
+        {
+          type: "text",
+          text: `A deliberately long line to check wrapping and tail-truncation in the transcript view — ${"lorem ipsum dolor sit amet ".repeat(16)}`,
+        },
+      ],
+    },
+    {
+      role: "user",
+      sessionId: MOCK_HISTORY_SESSION_ID,
+      timestamp: ts,
+      blocks: [{ type: "tool_result", callId: "c2", output: "File updated", isError: false }],
+    },
+  ]
+}
+
+/** A fake reader whose transcript grows on a timer to demo the live tail. */
+export function createMockHistoryReader(): EngineHistoryReader {
+  const grown = seedHistoryMessages()
+  let mtime = 1000
+  let n = 0
+  const timer = setInterval(() => {
+    n += 1
+    grown.push({
+      role: "assistant",
+      sessionId: MOCK_HISTORY_SESSION_ID,
+      timestamp: new Date().toISOString(),
+      blocks: [{ type: "text", text: `实时追加的第 ${n} 条消息 —— mtime 前进触发 refetch` }],
+    })
+    if (grown.length > 500) grown.splice(0, grown.length - 500)
+    mtime += 1
+  }, 2500)
+  timer.unref?.()
+  return {
+    async listSessionIdsForWorktree() {
+      return ["mock-session-old", MOCK_HISTORY_SESSION_ID]
+    },
+    async readHistory(id) {
+      return id === MOCK_HISTORY_SESSION_ID ? grown.slice() : seedHistoryMessages().slice(0, 2)
+    },
+    async latestTranscriptMtimeForWorktree() {
+      return mtime
+    },
+  }
+}

--- a/packages/kobe/src/tui/mock/host.tsx
+++ b/packages/kobe/src/tui/mock/host.tsx
@@ -15,110 +15,16 @@
  * takes its data via a narrow seam — inject a fake the same way).
  */
 
-import type { EngineHistoryReader } from "@/engine/registry"
-import type { Message } from "@/types/engine"
 import { coerceVendorId } from "@/types/vendor"
 import { startHistoryHost } from "../history/host"
-
-const SID = "mock-session"
-
-/** A representative starter transcript exercising every block renderer. */
-function seedMessages(): Message[] {
-  const ts = new Date().toISOString()
-  return [
-    {
-      role: "user",
-      sessionId: SID,
-      timestamp: ts,
-      blocks: [{ type: "text", text: "帮我给 history pane 加一个实时刷新的预览" }],
-    },
-    {
-      role: "assistant",
-      sessionId: SID,
-      timestamp: ts,
-      usage: { input_tokens: 1240, output_tokens: 356 },
-      blocks: [
-        {
-          type: "thinking",
-          text: "The read-only history pane should tail the transcript. Reuse the Ops pane's adaptive mtime poll instead of a new file watcher.",
-        },
-        { type: "text", text: "好的，我复用 Ops pane 的 mtime 轮询，把 HistoryScreen 做成 live。先看现有 effect……" },
-        { type: "tool_call", callId: "c1", name: "Read", input: { file_path: "src/tui/history/host.tsx" } },
-      ],
-    },
-    {
-      role: "user",
-      sessionId: SID,
-      timestamp: ts,
-      blocks: [{ type: "tool_result", callId: "c1", output: "…file contents…", isError: false }],
-    },
-    {
-      role: "assistant",
-      sessionId: SID,
-      timestamp: ts,
-      usage: { input_tokens: 2010, output_tokens: 128 },
-      blocks: [
-        {
-          type: "tool_call",
-          callId: "c2",
-          name: "Edit",
-          input: { file_path: "host.tsx", old_string: "…", new_string: "…" },
-        },
-        {
-          type: "text",
-          text: `A deliberately long line to check wrapping and tail-truncation in the transcript view — ${"lorem ipsum dolor sit amet ".repeat(16)}`,
-        },
-      ],
-    },
-    {
-      role: "user",
-      sessionId: SID,
-      timestamp: ts,
-      blocks: [{ type: "tool_result", callId: "c2", output: "File updated", isError: false }],
-    },
-  ]
-}
-
-/** A fake reader whose transcript grows on a timer to demo the live tail. */
-function mockReader(): EngineHistoryReader {
-  const grown = seedMessages()
-  let mtime = 1000
-  let n = 0
-  // Append an assistant turn + advance mtime every few seconds; the pane's mtime
-  // poll then refetches and the new message appears — the live-tail demo.
-  const timer = setInterval(() => {
-    n += 1
-    grown.push({
-      role: "assistant",
-      sessionId: SID,
-      timestamp: new Date().toISOString(),
-      blocks: [{ type: "text", text: `实时追加的第 ${n} 条消息 —— mtime 前进触发 refetch` }],
-    })
-    // Cap the fake transcript so a mock left running for days stays bounded.
-    if (grown.length > 500) grown.splice(0, grown.length - 500)
-    mtime += 1
-  }, 2500)
-  timer.unref?.()
-  return {
-    // Two sessions so `[` / `]` session switching is exercisable.
-    async listSessionIdsForWorktree() {
-      return ["mock-session-old", SID]
-    },
-    async readHistory(id) {
-      return id === SID ? grown.slice() : seedMessages().slice(0, 2)
-    },
-    async latestTranscriptMtimeForWorktree() {
-      return mtime
-    },
-  }
-}
+import { MOCK_HISTORY_WORKTREE, createMockHistoryReader } from "../history/mock-fixtures"
 
 export async function startMockHost(): Promise<void> {
   await startHistoryHost({
-    worktree: "/mock/worktree",
+    worktree: MOCK_HISTORY_WORKTREE,
     vendor: coerceVendorId("claude"),
     live: true,
-    reader: mockReader(),
+    reader: createMockHistoryReader(),
   })
 }
 

--- a/packages/kobe/test/tui-react/history-message-core.test.ts
+++ b/packages/kobe/test/tui-react/history-message-core.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pins the framework-free history transcript formatting shared by the Solid and
+ * React panes. Renderer-bound TSX stays out of vitest; this file covers the
+ * extracted pure logic only.
+ */
+
+import { describe, expect, it } from "vitest"
+import { bodyText, relativeTime, resultsByCallId, toolInputSummary } from "../../src/tui/history/message-core"
+import type { Message } from "../../src/types/engine"
+
+describe("history message core", () => {
+  it("summarizes tool input by the same field priority as the pane renderer", () => {
+    expect(toolInputSummary({ query: "fallback", file_path: "src/tui/history/host.tsx" })).toBe(
+      "src/tui/history/host.tsx",
+    )
+    expect(toolInputSummary({ command: "bun run test" })).toBe("bun run test")
+    expect(toolInputSummary({})).toBe("")
+  })
+
+  it("truncates long summaries but preserves the cap", () => {
+    const out = toolInputSummary({ command: "x".repeat(200) })
+    expect(out).toHaveLength(120)
+    expect(out.endsWith("…")).toBe(true)
+  })
+
+  it("stringifies expanded tool bodies without throwing", () => {
+    expect(bodyText("plain")).toBe("plain")
+    expect(bodyText({ ok: true })).toBe(JSON.stringify({ ok: true }, null, 2))
+    expect(bodyText(Symbol("s"))).toBe("Symbol(s)")
+  })
+
+  it("indexes the latest tool result by call id", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        sessionId: "s",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        blocks: [{ type: "tool_result", callId: "c1", output: "old", isError: false }],
+      },
+      {
+        role: "user",
+        sessionId: "s",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        blocks: [{ type: "tool_result", callId: "c1", output: "new", isError: true }],
+      },
+    ]
+    expect(resultsByCallId(messages).get("c1")).toMatchObject({ output: "new", isError: true })
+  })
+
+  it("formats relative timestamps and suppresses invalid values", () => {
+    expect(relativeTime("2026-01-01T00:00:00.000Z", Date.parse("2026-01-01T00:00:30.000Z"))).toBe("30s")
+    expect(relativeTime("2026-01-01T00:00:00.000Z", Date.parse("2026-01-01T00:02:00.000Z"))).toBe("2m")
+    expect(relativeTime("2026-01-01T00:00:00.000Z", Date.parse("2026-01-01T03:00:00.000Z"))).toBe("3h")
+    expect(relativeTime("2026-01-01T00:00:00.000Z", Date.parse("2026-01-04T00:00:00.000Z"))).toBe("3d")
+    expect(relativeTime("not-a-date")).toBe("")
+  })
+})

--- a/packages/kobe/test/tui-react/history-mock-fixtures.test.ts
+++ b/packages/kobe/test/tui-react/history-mock-fixtures.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Why this matters: these fixtures back BOTH frameworks' mock hosts
+ * (dev:mock and dev:mock-react-history) — the live render smokes in the
+ * migration gates grep for this data. If the fake reader drifts from the
+ * EngineHistoryReader contract, the smokes go blind while looking green.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  MOCK_HISTORY_SESSION_ID,
+  MOCK_HISTORY_WORKTREE,
+  createMockHistoryReader,
+  seedHistoryMessages,
+} from "../../src/tui/history/mock-fixtures"
+
+describe("history mock fixtures", () => {
+  it("seed messages are non-empty and renderable (roles + text present)", () => {
+    const messages = seedHistoryMessages()
+    expect(messages.length).toBeGreaterThan(0)
+    expect(messages.some((m) => m.role === "assistant")).toBe(true)
+  })
+
+  it("fake reader honors the EngineHistoryReader contract for the mock worktree", async () => {
+    const reader = createMockHistoryReader()
+    await expect(reader.listSessionIdsForWorktree(MOCK_HISTORY_WORKTREE)).resolves.toContain(MOCK_HISTORY_SESSION_ID)
+    const history = await reader.readHistory(MOCK_HISTORY_SESSION_ID)
+    expect(history.length).toBe(seedHistoryMessages().length)
+  })
+
+  it("fake reader serves fixture sessions for ANY worktree and a short stub for other ids", async () => {
+    // Deliberate mock semantics: it's demo data, not a lookup — every
+    // worktree sees the fixture sessions, and non-primary ids get a 2-message
+    // stub so the session switcher has something to show.
+    const reader = createMockHistoryReader()
+    await expect(reader.listSessionIdsForWorktree("/not/mocked")).resolves.toContain(MOCK_HISTORY_SESSION_ID)
+    await expect(reader.readHistory("mock-session-old")).resolves.toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary
- G3.1, the first real pane on the React runtime (implementation by Codex, plan/review/landing by Claude): `src/tui-react/history/` reaches visual + behavior parity with the Solid history pane — session list, live transcript mtime-poll refresh, j/k scroll + expand bindings.
- **Opt-in, not a default switch**: `kobe history` picks the React host only when `KOBE_REACT=1`; the Solid host stays the default for A/B during the migration.
- Shared pure logic extracted for both frameworks (G2 precedent): `history/message-core.ts` (tool-result indexing) + `history/mock-fixtures.ts` (the injectable fake-reader fixtures the Solid dev:mock already used — its host shrank ~100 lines by consuming them).
- Sets the **canonical React async pattern** for later panes (documented in the host header): `useState` + dependency-keyed `useEffect`, last resolved value stays visible during refresh, reader failures caught to empty values, stale completions cancelled via an effect-local disposed flag, mtime polling isolated behind a `refreshTick` scalar.
- New `dev:mock-react-history` script renders the React pane against the shared fixtures.

coverage-exemption: packages/kobe/src/tui-react/history/host.tsx — renderer-bound pane (imports @opentui/react, not importable under vitest); exercised live by the dev:mock-react-history gate; extracted pure logic is unit-tested instead.
coverage-exemption: packages/kobe/src/tui-react/history/message-card.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/history/mock-host.tsx — dev-only mock entry, same rationale.

## Test plan
- [x] `bun run typecheck` + repo-root `bun run lint` clean
- [x] `bun run test` — fast 2457/2457 + socket 218/218 (includes new message-core tests; Codex's sandbox EPERM failures did not reproduce)
- [x] `timeout 6 bun run dev:mock-react-history` — React history pane renders the fixture transcript
- [x] `timeout 6 bun run dev:mock` — Solid mock unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react` — infra workbench unbroken
- [x] `bun run compile` → `release-bin/kobe --version` OK