### PR TITLE
feat: React port of the file tree pane (G3, issue #15)

### DIFF
--- a/.changeset/react-filetree-pane.md
+++ b/.changeset/react-filetree-pane.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+React port of the file tree pane (issue #15, G3): `src/tui-react/panes/filetree/` mirrors the Solid pane on the shared framework-free logic (`git.ts`, `rows.ts`, and the newly extracted `pane-core.ts` / `keys-core.ts`), with a `dev:mock-react-filetree` render proof against a throwaway git fixture. The Solid `FileTree.tsx` was also split back under the 500-line cap (pane-core / keys-core / row-view / header-view), behavior-preserving.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -28,6 +28,7 @@
     "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
     "dev:mock-react": "env KOBE_DEV=1 bun ./src/tui-react/mock/host.tsx",
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
+    "dev:mock-react-filetree": "env KOBE_DEV=1 bun ./src/tui-react/panes/filetree/mock-host.tsx",
     "dev:sandbox": "bun run scripts/dev-sandbox.ts run",
     "dev:sandbox:reset": "bun run scripts/dev-sandbox.ts reset",
     "dev:version": "bash ../../scripts/dev-version.sh",

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -1,0 +1,365 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React file tree pane — the `src/tui/panes/filetree/FileTree.tsx`
+ * counterpart (issue #15, G3). Same behavior, same shared framework-free
+ * logic (`git.ts`, `rows.ts`, `pane-core.ts`, `keys-core.ts`,
+ * `open-external.ts`); this file owns only the React reactivity, following
+ * THE ASYNC CANON from `src/tui-react/history/host.tsx`:
+ *
+ *   - each async git read is `useState` + a dependency-keyed `useEffect`;
+ *   - the last resolved value stays visible while a refresh is in flight;
+ *   - stale completions are dropped (AbortController + fetch sequence);
+ *   - the opt-in fs watch bumps a `refreshTick` scalar the data effect
+ *     refetches from, instead of owning its own fetch.
+ *
+ * Solid→React prop delta: `worktreePath` / `focused` / `cornerBadge` are
+ * plain values here (React re-renders on prop change), not Accessors.
+ *
+ * Fetch-effect shape mirrors the Solid original 1:1 — three effects on
+ * worktree change (wipe + reload), tab change (cache-first + cursor
+ * reset), and refresh tick (cursor-preserving reload). Content-equality
+ * setters (`sameFileList` / `sameStatusEntries`) keep no-change refreshes
+ * from re-rendering, the same renderable-churn guard the Solid pane
+ * carries (rows.ts has the memory-leak story).
+ */
+
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { type StatusEntry, type TreeNode, buildTree, listFiles, statusFiles } from "../../../tui/panes/filetree/git"
+import { type FileTreeTab, fileTreeBindings } from "../../../tui/panes/filetree/keys-core"
+import { openExternally } from "../../../tui/panes/filetree/open-external"
+import {
+  type NavAction,
+  collapseOrParentAction,
+  computePathBudget,
+  computeStatWidths,
+  expandOrDescendAction,
+  followScrollTop,
+  summarizeGitError,
+  toggleDir,
+  watchWorktree,
+} from "../../../tui/panes/filetree/pane-core"
+import {
+  type Row,
+  flattenTree,
+  reconcileRows,
+  sameFileList,
+  sameStatusEntries,
+  statusRows,
+} from "../../../tui/panes/filetree/rows"
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+import { useBindings } from "../../lib/keymap"
+import { FileTreeHeaderView } from "./header-view"
+import { FileTreeRowView } from "./row-view"
+
+/** Public props — the Solid `FileTreeProps` with plain values for the
+ * reactive fields (see file header). Same field docs as the Solid pane. */
+export type FileTreeProps = {
+  /** Active task's worktree path; `null` renders the "No worktree" placeholder. */
+  worktreePath: string | null
+  /** Fires when the user activates a row (enter / click); worktree-relative path. */
+  onOpenFile: (relPath: string) => void
+  /** `a` — inject the current file as an `@<path>` mention (Ops host only). */
+  onMention?: (relPath: string) => void
+  /** `p` — request PR creation (Ops host only); also rendered as a chip. */
+  onCreatePR?: () => void
+  /** Zen-mode chip left of Create PR (enter-only, see the Solid pane doc). */
+  onZenToggle?: () => void
+  /** Whether the pane has keyboard focus. Defaults to `true`. */
+  focused?: boolean
+  /** Right-aligned activity badge (KOB-254); `null`/omit hides it. */
+  cornerBadge?: { text: string; active: boolean } | null
+  /** Fires on explicit `r` refresh — the Ops host's "I've looked" ack. */
+  onRefresh?: () => void
+}
+
+export function FileTree(props: FileTreeProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  // Pane width — in the Ops pane each FileTree runs in its own tmux pane
+  // process, so `useTerminalDimensions` tracks THIS pane's size and reflows
+  // the Changes-tab path truncation on resize.
+  const dims = useTerminalDimensions()
+
+  // ---------- pane state ----------
+  const [tab, setTab] = useState<FileTreeTab>("all")
+  const [cursorIndex, setCursorIndex] = useState(0)
+  // Bumped by `r` (and the opt-in fs watch) to force a re-fetch.
+  const [refreshTick, setRefreshTick] = useState(0)
+  const [allFiles, setAllFiles] = useState<string[] | null>(null)
+  const [changes, setChanges] = useState<StatusEntry[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  // Expanded directory paths (worktree-relative). Reset on worktree change.
+  const [expandedDirs, setExpandedDirs] = useState<ReadonlySet<string>>(() => new Set())
+
+  // Latest-render mirrors for effect bodies that must read a value without
+  // depending on it (the Solid originals read these untracked inside `on(...)`).
+  const pathRef = useRef(props.worktreePath)
+  pathRef.current = props.worktreePath
+  const tabRef = useRef(tab)
+  tabRef.current = tab
+  const allFilesRef = useRef(allFiles)
+  allFilesRef.current = allFiles
+  const changesRef = useRef(changes)
+  changesRef.current = changes
+  const fetchSeq = useRef(0)
+
+  /**
+   * Fetch the data for a tab. Errors land in `error` and the row list goes
+   * empty. The non-active tab's cache is wiped only on worktree change, not
+   * on tab switch (cache-first tab pings). Content-equality functional
+   * setters keep a no-change refresh from notifying downstream.
+   */
+  const refetch = useCallback(
+    async (currentTab: FileTreeTab, path: string | null, signal?: AbortSignal): Promise<void> => {
+      const seq = ++fetchSeq.current
+      if (path == null) {
+        setAllFiles(null)
+        setChanges(null)
+        setError(null)
+        return
+      }
+      setError(null)
+      try {
+        if (currentTab === "all") {
+          const files = await listFiles(path, signal)
+          if (signal?.aborted || seq !== fetchSeq.current || pathRef.current !== path) return
+          setAllFiles((prev) => (sameFileList(prev, files) ? prev : files))
+        } else if (currentTab === "changes") {
+          const entries = await statusFiles(path, signal)
+          if (signal?.aborted || seq !== fetchSeq.current || pathRef.current !== path) return
+          setChanges((prev) => (sameStatusEntries(prev, entries) ? prev : entries))
+        }
+      } catch (err) {
+        // An aborted fetch (tab/worktree changed out from under us) throws
+        // via the killed subprocess — swallow it, the next run owns state.
+        if (signal?.aborted) return
+        const message = err instanceof Error ? err.message : String(err)
+        if (seq === fetchSeq.current && pathRef.current === path) setError(message)
+      }
+    },
+    [],
+  )
+
+  // Re-fetch when the worktree changes — wipe all caches first because the
+  // old cache no longer applies. Cleanup aborts the in-flight git read so
+  // rapid task-switches don't stack subprocesses.
+  useEffect(() => {
+    setAllFiles(null)
+    setChanges(null)
+    setError(null)
+    setCursorIndex(0)
+    setExpandedDirs(new Set<string>())
+    const controller = new AbortController()
+    void refetch(tabRef.current, props.worktreePath, controller.signal)
+    return () => controller.abort()
+  }, [props.worktreePath, refetch])
+
+  // Realtime watch is opt-in (see watchWorktree) — the default path is
+  // explicit refresh (`r`) plus tab/worktree changes.
+  useEffect(() => {
+    const path = props.worktreePath
+    if (path == null) return
+    if (process.env.KOBE_FILETREE_WATCH !== "1") return
+    return watchWorktree(path, () => setRefreshTick((n) => n + 1))
+  }, [props.worktreePath])
+
+  // Re-fetch when the active TAB changes — cache-first, so pinging between
+  // already-loaded tabs never respawns git. Resetting the cursor belongs
+  // here (a different tab is a different list); a refresh of the SAME tab
+  // must NOT yank the cursor to the top (that effect is below).
+  useEffect(() => {
+    setCursorIndex(0)
+    const path = pathRef.current
+    if (path == null) return
+    const controller = new AbortController()
+    if (tab === "all") {
+      if (allFilesRef.current == null) void refetch("all", path, controller.signal)
+    } else if (tab === "changes") {
+      if (changesRef.current == null) void refetch("changes", path, controller.signal)
+    }
+    return () => controller.abort()
+  }, [tab, refetch])
+
+  // Re-fetch on a real refresh tick (`r` or a debounced fs-watch event).
+  // Tick 0 is the mount value — the worktree effect already did the first
+  // fetch. Unlike a tab switch, a refresh PRESERVES the cursor (the clamp
+  // effect below pulls it back only if the row count shrank past it).
+  useEffect(() => {
+    if (refreshTick === 0) return
+    const path = pathRef.current
+    if (path == null) return
+    const controller = new AbortController()
+    void refetch(tabRef.current, path, controller.signal)
+    return () => controller.abort()
+  }, [refreshTick, refetch])
+
+  // Tree built once per `allFiles` change and reused while expansion
+  // state mutates — flattening below is O(visible-rows).
+  const tree = useMemo<TreeNode | null>(() => (allFiles == null ? null : buildTree(allFiles)), [allFiles])
+
+  // Derived rows, reconciled against the previous list so unchanged rows
+  // keep object identity (stable React keys + reference-equal memo output
+  // when nothing changed — same renderable-reuse story as the Solid pane).
+  const prevRows = useRef<readonly Row[]>([])
+  const rows = useMemo<readonly Row[]>(() => {
+    const next: Row[] = []
+    if (tab === "all") {
+      if (tree != null) flattenTree(tree, expandedDirs, 0, next)
+    } else if (tab === "changes") {
+      if (changes != null) next.push(...statusRows(changes))
+    }
+    const reconciled = reconcileRows(prevRows.current, next)
+    prevRows.current = reconciled
+    return reconciled
+  }, [tab, tree, expandedDirs, changes])
+
+  // Keep the cursor in range when a refresh shrinks the list. Tab switches
+  // already reset the cursor to 0; this only clamps a preserved cursor that
+  // now points past the end.
+  useEffect(() => {
+    if (rows.length === 0) return
+    setCursorIndex((i) => (i > rows.length - 1 ? rows.length - 1 : i))
+  }, [rows])
+
+  const statWidths = useMemo(() => computeStatWidths(rows), [rows])
+  const pathBudget = useMemo(() => computePathBudget(dims.width, statWidths), [dims.width, statWidths])
+
+  // ---------- key bindings ----------
+  function applyNav(action: NavAction | null): void {
+    if (!action) return
+    if (action.type === "cursor") setCursorIndex(action.index)
+    else if (action.type === "expand") setExpandedDirs((prev) => new Set(prev).add(action.path))
+    else setExpandedDirs((prev) => toggleDir(prev, action.path))
+  }
+
+  /** Shared enter/click activation: dirs toggle, files open. */
+  function activateRow(row: Row): void {
+    if (row.kind === "dir") setExpandedDirs((prev) => toggleDir(prev, row.path))
+    else props.onOpenFile(row.path)
+  }
+
+  // `useBindings` re-reads the config per keypress through a render-refreshed
+  // ref, so these closures always see the latest rows/cursor/tab.
+  useBindings(() => ({
+    enabled: props.focused ?? true,
+    bindings: fileTreeBindings({
+      moveDown: () => {
+        if (rows.length === 0) return
+        setCursorIndex((i) => Math.min(i + 1, rows.length - 1))
+      },
+      moveUp: () => {
+        if (rows.length === 0) return
+        setCursorIndex((i) => Math.max(i - 1, 0))
+      },
+      setTab,
+      currentTab: () => tab,
+      openCurrent: () => {
+        const row = rows[cursorIndex]
+        if (row) activateRow(row)
+      },
+      mentionCurrent: () => {
+        const row = rows[cursorIndex]
+        // Only files make sense as an @mention; dirs are ignored.
+        if (!row || row.kind === "dir") return
+        props.onMention?.(row.path)
+      },
+      createPR: props.onCreatePR,
+      openExternal: () => {
+        const row = rows[cursorIndex]
+        if (!row || row.kind === "dir") return
+        if (!props.worktreePath) return
+        openExternally(`${props.worktreePath}/${row.path}`)
+      },
+      refresh: () => {
+        setRefreshTick((n) => n + 1)
+        props.onRefresh?.()
+      },
+      expandOrDescend: () => applyNav(expandOrDescendAction(rows, cursorIndex)),
+      collapseOrParent: () => {
+        if (tab !== "all") return
+        applyNav(collapseOrParentAction(rows, cursorIndex))
+      },
+    }),
+  }))
+
+  // ---------- viewport follow ----------
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  useEffect(() => {
+    const scroll = scrollRef.current
+    if (!scroll || rows.length === 0) return
+    const y = followScrollTop(scroll.scrollTop, scroll.viewport.height, cursorIndex)
+    if (y != null) scroll.scrollTo({ x: 0, y })
+  }, [cursorIndex, rows])
+
+  // ---------- render ----------
+  const loaded = (tab === "all" && allFiles != null) || (tab === "changes" && changes != null)
+  return (
+    <box flexDirection="column" flexGrow={1} paddingTop={1} paddingBottom={1} paddingLeft={0} paddingRight={0}>
+      <FileTreeHeaderView
+        tab={tab}
+        onSelectTab={setTab}
+        cornerBadge={props.cornerBadge ?? null}
+        onZenToggle={props.onZenToggle}
+        onCreatePR={props.onCreatePR}
+      />
+
+      {/* Body: scrollable list. Track + thumb both transparent → invisible
+         by default but still scrollable. */}
+      <scrollbox
+        ref={(r: ScrollBoxRenderable | null) => {
+          scrollRef.current = r
+        }}
+        flexGrow={1}
+        verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
+      >
+        {props.worktreePath == null ? (
+          <box paddingTop={1} paddingLeft={1}>
+            <text fg={theme.textMuted}>{t("files.empty.noTask")}</text>
+          </box>
+        ) : error != null ? (
+          <box paddingTop={1} paddingLeft={1} flexDirection="column" gap={0}>
+            <text fg={theme.error} wrapMode="word">
+              {summarizeGitError(error, t)}
+            </text>
+            <text fg={theme.textMuted} wrapMode="word">
+              {t("files.error.retryHint")}
+            </text>
+          </box>
+        ) : rows.length === 0 && loaded ? (
+          <box paddingTop={1} paddingLeft={1}>
+            <text fg={theme.textMuted}>{tab === "all" ? t("files.empty.noFiles") : t("files.empty.noChanges")}</text>
+          </box>
+        ) : rows.length > 0 ? (
+          <box flexShrink={0} gap={0} paddingRight={1}>
+            {rows.map((row, index) => (
+              <FileTreeRowView
+                key={`${row.kind}:${row.path}`}
+                row={row}
+                cursor={index === cursorIndex}
+                statWidths={statWidths}
+                pathBudget={pathBudget}
+                onActivate={() => {
+                  setCursorIndex(index)
+                  activateRow(row)
+                }}
+              />
+            ))}
+          </box>
+        ) : null}
+      </scrollbox>
+
+      {/* Footer hint — shown only when a worktree is loaded so the
+         "no task" placeholder stays clean. */}
+      {props.worktreePath != null ? (
+        <box flexDirection="row" paddingTop={1} flexShrink={0}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {t("files.footer.openHint")}
+          </text>
+        </box>
+      ) : null}
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -1,0 +1,103 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React view for the file tree pane's header chrome — the `src/tui/panes/
+ * filetree/header-view.tsx` counterpart (issue #15, G3): the optional
+ * Zen / Create-PR action row, the All / Changes tab chips, the corner
+ * activity badge (KOB-254), and the Changes-tab status legend. Pure
+ * render — tab state and actions stay in the pane component.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { type FileTreeTab, TAB_ORDER, tabLabelKey } from "../../../tui/panes/filetree/keys-core"
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+
+export type FileTreeHeaderProps = {
+  /** The active tab. */
+  tab: FileTreeTab
+  /** Mouse tab switch. */
+  onSelectTab: (tab: FileTreeTab) => void
+  /** Right-aligned activity badge; `null` hides it. */
+  cornerBadge: { text: string; active: boolean } | null
+  /** Optional Ops-pane chips (see FileTreeProps). */
+  onZenToggle?: () => void
+  onCreatePR?: () => void
+}
+
+export function FileTreeHeaderView(props: FileTreeHeaderProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  const badge = props.cornerBadge
+  return (
+    <>
+      {/* Action row — sits above the All / Changes tabs so it's reachable
+         from both tabs. Zen toggle sits left of Create PR (bound to `p`). */}
+      {props.onZenToggle || props.onCreatePR ? (
+        <box flexDirection="row" justifyContent="flex-end" gap={2} paddingBottom={1} flexShrink={0}>
+          {props.onZenToggle ? (
+            <box flexDirection="row" gap={1} onMouseUp={() => props.onZenToggle?.()}>
+              <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+                [~]
+              </text>
+              <text fg={theme.text} wrapMode="none">
+                {t("files.actions.zen")}
+              </text>
+            </box>
+          ) : null}
+          {props.onCreatePR ? (
+            <box flexDirection="row" gap={1} onMouseUp={() => props.onCreatePR?.()}>
+              <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+                [P]
+              </text>
+              <text fg={theme.text} wrapMode="none">
+                {t("files.actions.createPR")}
+              </text>
+            </box>
+          ) : null}
+        </box>
+      ) : null}
+      {/* Header: tabs row. Each tab is clickable (sets active), and
+         `[` / `]` cycle from the keyboard. */}
+      <box flexDirection="row" justifyContent="space-between" paddingBottom={0} flexShrink={0}>
+        <box flexDirection="row" gap={2}>
+          {TAB_ORDER.map((tabId) => {
+            const isActive = props.tab === tabId
+            return (
+              <text
+                key={tabId}
+                fg={isActive ? theme.primary : theme.textMuted}
+                attributes={isActive ? TextAttributes.BOLD : undefined}
+                wrapMode="none"
+                onMouseUp={() => props.onSelectTab(tabId)}
+              >
+                {t(tabLabelKey(tabId))}
+              </text>
+            )
+          })}
+        </box>
+        {/* Right-aligned activity badge (KOB-254). No background fill so
+           it stays clean in transparent mode. */}
+        {badge ? (
+          <text
+            fg={badge.active ? theme.accent : theme.textMuted}
+            attributes={badge.active ? TextAttributes.BOLD : undefined}
+            wrapMode="none"
+          >
+            {badge.text}
+          </text>
+        ) : null}
+      </box>
+      {/* Status legend — only shown on the Changes tab so users can
+         decode single-char git status codes without leaving the TUI. */}
+      {props.tab === "changes" ? (
+        <box flexDirection="column" paddingBottom={1} flexShrink={0} gap={0}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {t("files.legend.changes")}
+          </text>
+        </box>
+      ) : (
+        <box flexDirection="row" paddingBottom={1} flexShrink={0} />
+      )}
+    </>
+  )
+}

--- a/packages/kobe/src/tui-react/panes/filetree/mock-host.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/mock-host.tsx
@@ -1,0 +1,46 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React file-tree mock host (`bun run dev:mock-react-filetree`) — the live
+ * render proof for the ported pane. The pane reads real git, so the fixture
+ * is a throwaway `git init` repo in the OS tempdir with deterministic
+ * `kobe-fixture-*` file names: the All tab lists them via
+ * `git ls-files --others`, no commit required, and the smoke greps one of
+ * them out of the captured ANSI output.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { bootPaneHost } from "../../lib/host-boot"
+import { FileTree } from "./FileTree"
+
+function makeFixtureWorktree(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-filetree-mock-"))
+  execFileSync("git", ["init", "-q"], { cwd: dir })
+  writeFileSync(join(dir, "kobe-fixture-alpha.ts"), "export const alpha = 1\n")
+  writeFileSync(join(dir, "kobe-fixture-readme.md"), "# filetree mock fixture\n")
+  mkdirSync(join(dir, "src"))
+  writeFileSync(join(dir, "src", "kobe-fixture-beta.ts"), "export const beta = 2\n")
+  return dir
+}
+
+// Same minimal provider set as the Ops pane host that mounts the Solid
+// FileTree: Theme > Dialog only, no KV / Focus.
+await bootPaneHost({
+  logContext: "filetree-mock",
+  providers: { kv: false, focus: false },
+  setup: () => {
+    const worktree = makeFixtureWorktree()
+    return {
+      root: () => (
+        <FileTree
+          worktreePath={worktree}
+          onOpenFile={() => {}}
+          cornerBadge={{ text: "mock", active: true }}
+          onCreatePR={() => {}}
+        />
+      ),
+    }
+  },
+})

--- a/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
@@ -1,0 +1,104 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React view for a single file tree row — the `src/tui/panes/filetree/
+ * row-view.tsx` counterpart (issue #15, G3). Pure render: all row math
+ * (stat widths, path budget, status→token mapping) comes from the shared
+ * framework-free `pane-core.ts`, so the two runtimes render identically.
+ *
+ * Cursor row treatment — matches the Sidebar: a left accent ▌
+ * (focusAccent) + a subtle `backgroundElement` tint, NOT a solid
+ * terracotta fill, so the semantic colours survive instead of being
+ * flattened to inverted text. A bare space holds the 1-cell gutter on
+ * non-cursor rows so content stays aligned.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { type StatWidths, statCell, statusToken } from "../../../tui/panes/filetree/pane-core"
+import { type Row, truncatePathTail } from "../../../tui/panes/filetree/rows"
+import { useTheme } from "../../context/theme"
+
+export type FileTreeRowProps = {
+  row: Row
+  /** Whether the cursor sits on this row. */
+  cursor: boolean
+  /** Shared stat column widths (Changes tab). */
+  statWidths: StatWidths
+  /** Path cell budget (Changes tab). */
+  pathBudget: number
+  /** Mouse activation: sets the cursor here and opens/toggles the row. */
+  onActivate: () => void
+}
+
+export function FileTreeRowView(props: FileTreeRowProps) {
+  const { theme } = useTheme()
+  const bar = (
+    <text fg={props.cursor ? theme.focusAccent : undefined} wrapMode="none">
+      {props.cursor ? "▌" : " "}
+    </text>
+  )
+  const rowBg = props.cursor ? theme.backgroundElement : undefined
+  const row = props.row
+  if (row.kind === "dir") {
+    // Indent: 2 cells per depth level. Marker: ▾ open, ▸ closed.
+    const indent = "  ".repeat(row.depth)
+    return (
+      <box flexDirection="row" gap={0} backgroundColor={rowBg} onMouseUp={() => props.onActivate()}>
+        {bar}
+        <box flexGrow={1} paddingRight={1}>
+          <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
+            {`${indent}${row.expanded ? "▾" : "▸"} ${row.name}/`}
+          </text>
+        </box>
+      </box>
+    )
+  }
+  if (row.kind === "file") {
+    const indent = "  ".repeat(row.depth)
+    // Two-cell gutter where the dir marker would sit.
+    return (
+      <box flexDirection="row" gap={0} backgroundColor={rowBg} onMouseUp={() => props.onActivate()}>
+        {bar}
+        <box flexGrow={1} paddingRight={1}>
+          <text fg={theme.text} wrapMode="none">
+            {`${indent}  ${row.name}`}
+          </text>
+        </box>
+      </box>
+    )
+  }
+  // Changes row: status char + path + +N -N stats.
+  const tone = statusToken(row.status)
+  const statusColor =
+    tone === "success"
+      ? theme.success
+      : tone === "warning"
+        ? theme.warning
+        : tone === "error"
+          ? theme.error
+          : tone === "info"
+            ? theme.info
+            : theme.textMuted
+  return (
+    <box flexDirection="row" gap={0} backgroundColor={rowBg} onMouseUp={() => props.onActivate()}>
+      {bar}
+      <box flexDirection="row" flexGrow={1} gap={1} paddingRight={1}>
+        <text fg={statusColor} wrapMode="none">
+          {row.status}
+        </text>
+        <text fg={theme.text} wrapMode="none" flexGrow={1}>
+          {truncatePathTail(row.path, props.pathBudget)}
+        </text>
+        {props.statWidths.added > 0 ? (
+          <text fg={theme.success} wrapMode="none">
+            {statCell(row.added, props.statWidths.added, "+")}
+          </text>
+        ) : null}
+        {props.statWidths.deleted > 0 ? (
+          <text fg={theme.error} wrapMode="none">
+            {statCell(row.deleted, props.statWidths.deleted, "-")}
+          </text>
+        ) : null}
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -15,27 +15,16 @@
  *   │  ...                                    │
  *   └────────────────────────────────────────┘
  *
- * Layout: ~38 cells wide in the old five-pane shell. The width is
- * a layout target, not a hard cap — the parent can adjust by overriding
- * via the surrounding box; we just render as `width={FILETREE_WIDTH}`.
- *
  * Tabs:
  *   - `All`: `git ls-files --cached --others --exclude-standard`
- *     (gitignore respected). Flat list of paths, alphabetically sorted.
+ *     (gitignore respected). Collapsible directory tree.
  *   - `Changes`: `git status --porcelain`, with a single-char status
  *     prefix coloured per the theme tokens.
- *   - `Checks`: placeholder — CI/test integration not yet implemented.
  *
  * State lives where it lives (DESIGN.md §2.5): files come from disk via
- * git, not from a separate cache. We re-fetch on:
- *   - tab switch
- *   - worktree path change
- *   - explicit `r` keypress
- *   - first mount
- *   - optional filesystem activity inside the worktree when
- *     `KOBE_FILETREE_WATCH=1` is set. Recursive watch is intentionally
- *     opt-in because large monorepos can make the watcher itself more
- *     expensive than a manual refresh.
+ * git, not from a separate cache. We re-fetch on tab switch, worktree
+ * path change, explicit `r`, first mount, and (opt-in via
+ * `KOBE_FILETREE_WATCH=1`) filesystem activity inside the worktree.
  *
  * Reactivity: `worktreePath` is an `Accessor` so the pane reacts to
  * task switches without a manual prop-equality check. Data is refetched
@@ -45,38 +34,39 @@
  * bumped by `r` and by the debounced fs-watch handler.
  *
  * Empty / error states:
- *   - `worktreePath() == null` → "No worktree" (we treat this as the
- *     "no task selected" placeholder; matches what the chat pane does
- *     at G3).
- *   - non-null path but listFiles/statusFiles errors → render the
- *     error message in red. Most likely cause: the path isn't a git
- *     worktree yet (orchestrator races during task creation).
+ *   - `worktreePath() == null` → "No worktree" placeholder.
+ *   - non-null path but listFiles/statusFiles errors → the error message
+ *     in red (most likely: the path isn't a git worktree yet).
  *   - empty results → "No files" (All) or "No changes" (Changes).
  *
- * This file is intentionally cross-stream-import-safe: it imports only
- * from sibling files in the same directory and from `../../context/theme`,
- * `../../lib/keymap`. It never touches the orchestrator (the parent
- * threads `worktreePath` and consumes `onOpenFile`).
+ * Split for the 500-line cap (issue #15, G3): pure pane logic lives in
+ * `pane-core.ts`, the bindings map in `keys-core.ts`, the per-row view in
+ * `row-view.tsx` — all shared with the React port. This file owns only
+ * the Solid reactivity + pane chrome.
  */
 
-import { type FSWatcher, watch } from "node:fs"
 import { t } from "@/tui/i18n"
-import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import type { ScrollBoxRenderable } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
 import { type Accessor, For, Show, createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import { useTheme } from "../../context/theme"
-import { type FileStatus, type StatusEntry, type TreeNode, buildTree, listFiles, statusFiles } from "./git"
+import { type StatusEntry, type TreeNode, buildTree, listFiles, statusFiles } from "./git"
+import { FileTreeHeaderView } from "./header-view"
 import { type FileTreeTab, useFileTreeBindings } from "./keys"
 import { openExternally } from "./open-external"
 import {
-  type Row,
-  flattenTree,
-  reconcileRows,
-  sameFileList,
-  sameStatusEntries,
-  statusRows,
-  truncatePathTail,
-} from "./rows"
+  type NavAction,
+  collapseOrParentAction,
+  computePathBudget,
+  computeStatWidths,
+  expandOrDescendAction,
+  followScrollTop,
+  summarizeGitError,
+  toggleDir,
+  watchWorktree,
+} from "./pane-core"
+import { FileTreeRowView } from "./row-view"
+import { type Row, flattenTree, reconcileRows, sameFileList, sameStatusEntries, statusRows } from "./rows"
 
 /**
  * Default width of the pane in terminal cells from the old centre-column
@@ -87,9 +77,8 @@ import {
 export const FILETREE_WIDTH = 38
 
 /**
- * Public props for `FileTree`. Stable contract — `app.tsx` (the
- * orchestrator's integration point) imports this shape from the
- * barrel. Adding fields is fine; renaming or removing is breaking.
+ * Public props for `FileTree`. Stable contract — adding fields is fine;
+ * renaming or removing is breaking.
  */
 export type FileTreeProps = {
   /**
@@ -123,9 +112,7 @@ export type FileTreeProps = {
    */
   onZenToggle?: () => void
   /**
-   * Whether the pane has keyboard focus. Defaults to `() => true` —
-   * Wave 3 has no focus manager yet, the integration agent will
-   * thread real signals when the 5-pane layout lands.
+   * Whether the pane has keyboard focus. Defaults to `() => true`.
    */
   focused?: Accessor<boolean>
   /**
@@ -143,65 +130,6 @@ export type FileTreeProps = {
   onRefresh?: () => void
 }
 
-/**
- * Map a status code to its theme token. Resolved at render time so a
- * theme switch reactively recolours pre-existing rows.
- */
-function statusToken(s: FileStatus): "warning" | "success" | "error" | "textMuted" | "info" {
-  switch (s) {
-    case "M":
-      return "warning"
-    case "A":
-      return "success"
-    case "D":
-      return "error"
-    case "?":
-      return "textMuted"
-    case "R":
-    case "C":
-    case "U":
-    case "T":
-      // Renames/copies/conflicts/typechanges are uncommon in the loop;
-      // render them in info-blue to distinguish from the M/A/D/? majority.
-      return "info"
-  }
-}
-
-/**
- * The tabs in render order. `as const` so TypeScript keeps the
- * literal-tuple narrowing for downstream `.map()` callers.
- */
-const TABS = ["all", "changes"] as const satisfies readonly FileTreeTab[]
-
-/**
- * Boil a raw `git ls-files` / `git status` error down to a single
- * human-friendly sentence. The thrown messages from `git.ts` look
- * like `git ls-files ... (cwd=/foo) exited with code 128: fatal: not
- * a git repository`. Most users don't need the full args / exit
- * code; we surface the common cases and keep the rest generic.
- */
-export function summarizeGitError(raw: string): string {
-  const m = raw.toLowerCase()
-  if (m.includes("not a git repository")) return t("files.error.notGitRepo")
-  if (m.includes("does not exist") || m.includes("enoent")) return t("files.error.pathMissing")
-  if (m.includes("permission denied") || m.includes("eacces")) return t("files.error.permissionDenied")
-  if (m.includes("git: not found") || m.includes("command not found")) return t("files.error.gitNotInstalled")
-  // Fallback: strip the leading `git <args> (cwd=...)` boilerplate.
-  const colon = raw.indexOf(": ")
-  if (colon >= 0 && raw.startsWith("git ")) return raw.slice(colon + 2).trim() || t("files.error.gitFailed")
-  return raw.trim() || t("files.error.gitFailed")
-}
-
-/** Display label for each tab — resolved at render time via t() so language switches are reactive. */
-function tabLabel(tab: FileTreeTab): string {
-  switch (tab) {
-    case "all":
-      return t("files.tabs.all")
-    case "changes":
-      return t("files.tabs.changes")
-  }
-}
-
 export function FileTree(props: FileTreeProps) {
   const { theme } = useTheme()
 
@@ -210,7 +138,7 @@ export function FileTree(props: FileTreeProps) {
   // the Changes-tab path truncation on resize.
   const dims = useTerminalDimensions()
 
-  // Default `focused` accessor — see file header.
+  // Default `focused` accessor — see props doc.
   const focusedAccessor = () => (props.focused ? props.focused() : true)
 
   // ---------- pane state ----------
@@ -291,37 +219,13 @@ export function FileTree(props: FileTreeProps) {
     }),
   )
 
-  // Realtime watch is opt-in. On large repos a recursive watcher can
-  // overwhelm the TUI process before the user does anything, so the
-  // default path is explicit refresh (`r`) plus tab/worktree changes.
+  // Realtime watch is opt-in (see watchWorktree) — the default path is
+  // explicit refresh (`r`) plus tab/worktree changes.
   createEffect(
     on(props.worktreePath, (path) => {
       if (path == null) return
       if (process.env.KOBE_FILETREE_WATCH !== "1") return
-      let debounceTimer: ReturnType<typeof setTimeout> | null = null
-      let watcher: EventedWatcher | null = null
-      try {
-        watcher = watch(path, { recursive: true }, (_event, filename) => {
-          if (filename == null) return
-          const f = filename.toString()
-          if (f === ".git" || f.startsWith(".git/") || f.startsWith(".git\\")) return
-          if (f.startsWith("node_modules/") || f.startsWith("node_modules\\")) return
-          if (debounceTimer != null) clearTimeout(debounceTimer)
-          debounceTimer = setTimeout(() => {
-            debounceTimer = null
-            setRefreshTick((n) => n + 1)
-          }, 500)
-        }) as unknown as EventedWatcher
-        watcher.on("error", () => {
-          // Swallow — the `r` keystroke remains as the escape hatch.
-        })
-      } catch {
-        // Path missing or not watchable — fall back to manual refresh.
-      }
-      onCleanup(() => {
-        if (debounceTimer != null) clearTimeout(debounceTimer)
-        if (watcher != null) watcher.close()
-      })
+      onCleanup(watchWorktree(path, () => setRefreshTick((n) => n + 1)))
     }),
   )
 
@@ -408,255 +312,91 @@ export function FileTree(props: FileTreeProps) {
     }),
   )
 
-  /**
-   * Column widths for the `+N` / `-N` stats on the Changes tab. Computed
-   * across the visible rows so every cell pads to the widest sibling —
-   * without this, `+0 -202` and `+1 -1` end at the same right edge but
-   * the `-` columns drift, which reads as misaligned. Width includes
-   * the leading sign (`+`/`-`).
-   */
-  const statWidths = createMemo<{ added: number; deleted: number }>(() => {
-    let added = 0
-    let deleted = 0
-    for (const row of rows()) {
-      if (row.kind !== "status") continue
-      if (row.added != null) added = Math.max(added, String(row.added).length + 1)
-      if (row.deleted != null) deleted = Math.max(deleted, String(row.deleted).length + 1)
-    }
-    return { added, deleted }
-  })
-
-  /**
-   * Cell budget for a Changes-tab path. Tail-truncated to whatever the pane
-   * leaves after the status char, the `+N`/`-N` stat columns, the inter-column
-   * gaps, row padding, and the scrollbar — so the filename always survives and
-   * only the leading directories elide. Recomputes on resize / stat-width change.
-   */
-  const pathBudget = createMemo<number>(() => {
-    const w = statWidths()
-    const stats = (w.added > 0 ? w.added + 1 : 0) + (w.deleted > 0 ? w.deleted + 1 : 0)
-    // row padding (2) + status glyph (1) + gap (1) + stats + scrollbar (1) + slack (1).
-    return Math.max(8, dims().width - 6 - stats)
-  })
+  const statWidths = createMemo(() => computeStatWidths(rows()))
+  const pathBudget = createMemo(() => computePathBudget(dims().width, statWidths()))
 
   // ---------- key bindings ----------
-  function moveDown(): void {
-    const r = rows()
-    if (r.length === 0) return
-    setCursorIndex(Math.min(cursorIndex() + 1, r.length - 1))
-  }
-  function moveUp(): void {
-    if (rows().length === 0) return
-    setCursorIndex(Math.max(cursorIndex() - 1, 0))
+  function applyNav(action: NavAction | null): void {
+    if (!action) return
+    if (action.type === "cursor") setCursorIndex(action.index)
+    else if (action.type === "expand") setExpandedDirs((prev) => new Set(prev).add(action.path))
+    else setExpandedDirs((prev) => toggleDir(prev, action.path))
   }
 
-  /** `l` — hierarchy navigation only. On a closed dir, expand it; on
-   * an open dir, step into its first child; on a file, no-op (use
-   * `enter` to open). Keeping `l` purely structural lets the user roam
-   * through the tree without accidentally pulling the file into the
-   * preview pane. */
-  function expandOrDescend(): void {
-    const r = rows()
-    const i = cursorIndex()
-    const row = r[i]
-    if (!row) return
-    if (row.kind !== "dir") return
-    if (!row.expanded && row.hasChildren) {
-      setExpandedDirs((prev) => {
-        const next = new Set(prev)
-        next.add(row.path)
-        return next
-      })
-    } else if (row.expanded) {
-      if (i + 1 < r.length) setCursorIndex(i + 1)
-    }
+  /** Shared enter/click activation: dirs toggle, files open. */
+  function activateRow(row: Row): void {
+    if (row.kind === "dir") setExpandedDirs((prev) => toggleDir(prev, row.path))
+    else props.onOpenFile(row.path)
   }
 
-  /** `h` — collapse current directory, or jump to parent. Behavior on
-   * the All tab; no-op elsewhere. */
-  function collapseOrParent(): void {
-    if (tab() !== "all") return
-    const r = rows()
-    const i = cursorIndex()
-    const row = r[i]
-    if (!row) return
-    // Open dir → collapse.
-    if (row.kind === "dir" && row.expanded) {
-      setExpandedDirs((prev) => {
-        const next = new Set(prev)
-        next.delete(row.path)
-        return next
-      })
-      return
-    }
-    // Otherwise jump to parent dir (depth - 1) walking upward in rows.
-    if (row.kind !== "dir" && row.kind !== "file") return
-    const targetDepth = row.depth - 1
-    if (targetDepth < 0) return
-    for (let j = i - 1; j >= 0; j--) {
-      const candidate = r[j]
-      if (!candidate) continue
-      if (candidate.kind === "dir" && candidate.depth === targetDepth) {
-        setCursorIndex(j)
-        return
-      }
-    }
-  }
-
-  function openCurrent(): void {
-    const r = rows()
-    const i = cursorIndex()
-    if (i < 0 || i >= r.length) return
-    const row = r[i]
-    if (!row) return
-    if (row.kind === "dir") {
-      // Toggle expansion on enter for directory rows.
-      setExpandedDirs((prev) => {
-        const next = new Set(prev)
-        if (next.has(row.path)) next.delete(row.path)
-        else next.add(row.path)
-        return next
-      })
-      return
-    }
-    props.onOpenFile(row.path)
-  }
-  function mentionCurrent(): void {
-    const r = rows()
-    const i = cursorIndex()
-    if (i < 0 || i >= r.length) return
-    const row = r[i]
-    // Only files make sense as an @mention; dirs are ignored.
-    if (!row || row.kind === "dir") return
-    props.onMention?.(row.path)
-  }
-  function refresh(): void {
-    setRefreshTick((n) => n + 1)
-    props.onRefresh?.()
-  }
-  function openExternal(): void {
-    const r = rows()
-    const i = cursorIndex()
-    if (i < 0 || i >= r.length) return
-    const row = r[i]
-    if (!row || row.kind === "dir") return
-    const wt = props.worktreePath()
-    if (!wt) return
-    const absPath = `${wt}/${row.path}`
-    openExternally(absPath)
+  function currentRow(): Row | undefined {
+    return rows()[cursorIndex()]
   }
 
   useFileTreeBindings({
     focused: focusedAccessor,
-    moveDown,
-    moveUp,
+    moveDown: () => {
+      const r = rows()
+      if (r.length === 0) return
+      setCursorIndex(Math.min(cursorIndex() + 1, r.length - 1))
+    },
+    moveUp: () => {
+      if (rows().length === 0) return
+      setCursorIndex(Math.max(cursorIndex() - 1, 0))
+    },
     setTab: (t) => setTab(t),
     currentTab: tab,
-    openCurrent,
-    mentionCurrent,
+    openCurrent: () => {
+      const row = currentRow()
+      if (row) activateRow(row)
+    },
+    mentionCurrent: () => {
+      const row = currentRow()
+      // Only files make sense as an @mention; dirs are ignored.
+      if (!row || row.kind === "dir") return
+      props.onMention?.(row.path)
+    },
     createPR: props.onCreatePR,
-    openExternal,
-    refresh,
-    expandOrDescend,
-    collapseOrParent,
+    openExternal: () => {
+      const row = currentRow()
+      if (!row || row.kind === "dir") return
+      const wt = props.worktreePath()
+      if (!wt) return
+      openExternally(`${wt}/${row.path}`)
+    },
+    refresh: () => {
+      setRefreshTick((n) => n + 1)
+      props.onRefresh?.()
+    },
+    expandOrDescend: () => applyNav(expandOrDescendAction(rows(), cursorIndex())),
+    collapseOrParent: () => {
+      if (tab() !== "all") return
+      applyNav(collapseOrParentAction(rows(), cursorIndex()))
+    },
   })
 
   // ---------- viewport follow ----------
-  // Each row renders as a height-1 box, so its y-offset inside the
-  // scrollbox content equals its index in `rows()`. When the cursor
-  // moves past the visible window (either edge), nudge the scrollbox
-  // so the cursor row is just inside the viewport.
   let scrollRef: ScrollBoxRenderable | undefined
   createEffect(
     on([cursorIndex, rows], ([i, r]) => {
       if (!scrollRef) return
       if (r.length === 0) return
-      const top = scrollRef.scrollTop
-      const height = scrollRef.viewport.height
-      if (height <= 0) return
-      if (i < top) {
-        scrollRef.scrollTo({ x: 0, y: i })
-      } else if (i >= top + height) {
-        scrollRef.scrollTo({ x: 0, y: i - height + 1 })
-      }
+      const y = followScrollTop(scrollRef.scrollTop, scrollRef.viewport.height, i)
+      if (y != null) scrollRef.scrollTo({ x: 0, y })
     }),
   )
 
   // ---------- render ----------
   return (
     <box flexDirection="column" flexGrow={1} paddingTop={1} paddingBottom={1} paddingLeft={0} paddingRight={0}>
-      {/* Action row — sits above the All / Changes tabs so it's reachable
-         from both tabs. Zen toggle sits left of Create PR (bound to `p`). */}
-      <Show when={props.onZenToggle || props.onCreatePR}>
-        <box flexDirection="row" justifyContent="flex-end" gap={2} paddingBottom={1} flexShrink={0}>
-          <Show when={props.onZenToggle}>
-            <box flexDirection="row" gap={1} onMouseUp={() => props.onZenToggle?.()}>
-              <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
-                [~]
-              </text>
-              <text fg={theme.text} wrapMode="none">
-                {t("files.actions.zen")}
-              </text>
-            </box>
-          </Show>
-          <Show when={props.onCreatePR}>
-            <box flexDirection="row" gap={1} onMouseUp={() => props.onCreatePR?.()}>
-              <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
-                [P]
-              </text>
-              <text fg={theme.text} wrapMode="none">
-                {t("files.actions.createPR")}
-              </text>
-            </box>
-          </Show>
-        </box>
-      </Show>
-      {/* Header: tabs row. Each tab is clickable (sets active), and
-         `1` / `2` / `3` switch from the keyboard. */}
-      <box flexDirection="row" justifyContent="space-between" paddingBottom={0} flexShrink={0}>
-        <box flexDirection="row" gap={2}>
-          <For each={TABS}>
-            {(t) => {
-              const isActive = () => tab() === t
-              return (
-                <text
-                  fg={isActive() ? theme.primary : theme.textMuted}
-                  attributes={isActive() ? TextAttributes.BOLD : undefined}
-                  wrapMode="none"
-                  onMouseUp={() => setTab(t)}
-                >
-                  {tabLabel(t)}
-                </text>
-              )
-            }}
-          </For>
-        </box>
-        {/* Right-aligned activity badge (KOB-254). No background fill so
-           it stays clean in transparent mode. */}
-        <Show when={props.cornerBadge?.()}>
-          {(badge) => (
-            <text
-              fg={badge().active ? theme.accent : theme.textMuted}
-              attributes={badge().active ? TextAttributes.BOLD : undefined}
-              wrapMode="none"
-            >
-              {badge().text}
-            </text>
-          )}
-        </Show>
-      </box>
-      {/* Status legend — only shown on the Changes tab so users can
-         decode single-char git status codes without leaving the TUI. */}
-      <Show when={tab() === "changes"}>
-        <box flexDirection="column" paddingBottom={1} flexShrink={0} gap={0}>
-          <text fg={theme.textMuted} wrapMode="none">
-            {t("files.legend.changes")}
-          </text>
-        </box>
-      </Show>
-      <Show when={tab() !== "changes"}>
-        <box flexDirection="row" paddingBottom={1} flexShrink={0} />
-      </Show>
+      {/* Header chrome — action chips, tab row, badge, legend. */}
+      <FileTreeHeaderView
+        tab={tab()}
+        onSelectTab={setTab}
+        cornerBadge={props.cornerBadge?.() ?? null}
+        onZenToggle={props.onZenToggle}
+        onCreatePR={props.onCreatePR}
+      />
 
       {/* Body: scrollable list. Scrollbar styled subtle — track blends
          into the panel bg, thumb is muted text color. */}
@@ -682,7 +422,7 @@ export function FileTree(props: FileTreeProps) {
         <Show when={props.worktreePath() != null && error() != null}>
           <box paddingTop={1} paddingLeft={1} flexDirection="column" gap={0}>
             <text fg={theme.error} wrapMode="word">
-              {summarizeGitError(error() ?? "")}
+              {summarizeGitError(error() ?? "", t)}
             </text>
             <text fg={theme.textMuted} wrapMode="word">
               {t("files.error.retryHint")}
@@ -706,120 +446,18 @@ export function FileTree(props: FileTreeProps) {
         <Show when={props.worktreePath() != null && error() == null && rows().length > 0}>
           <box flexShrink={0} gap={0} paddingRight={1}>
             <For each={rows()}>
-              {(row, index) => {
-                const isCursor = () => index() === cursorIndex()
-                // Cursor row treatment — matches the Sidebar: a left accent ▌
-                // (focusAccent) + a subtle `backgroundElement` tint, NOT a solid
-                // terracotta fill, so the semantic colours survive instead of
-                // being flattened to inverted text. A bare space holds the
-                // 1-cell gutter on non-cursor rows so content stays aligned.
-                const bar = (
-                  <text fg={isCursor() ? theme.focusAccent : undefined} wrapMode="none">
-                    {isCursor() ? "▌" : " "}
-                  </text>
-                )
-                const rowBg = () => (isCursor() ? theme.backgroundElement : undefined)
-                if (row.kind === "dir") {
-                  // Indent: 2 cells per depth level. Marker: ▾ open, ▸ closed.
-                  const indent = "  ".repeat(row.depth)
-                  const marker = row.expanded ? "▾" : "▸"
-                  return (
-                    <box
-                      flexDirection="row"
-                      gap={0}
-                      backgroundColor={rowBg()}
-                      onMouseUp={() => {
-                        setCursorIndex(index())
-                        setExpandedDirs((prev) => {
-                          const next = new Set(prev)
-                          if (next.has(row.path)) next.delete(row.path)
-                          else next.add(row.path)
-                          return next
-                        })
-                      }}
-                    >
-                      {bar}
-                      <box flexGrow={1} paddingRight={1}>
-                        <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
-                          {`${indent}${marker} ${row.name}/`}
-                        </text>
-                      </box>
-                    </box>
-                  )
-                }
-                if (row.kind === "file") {
-                  const indent = "  ".repeat(row.depth)
-                  // Two-cell gutter where the dir marker would sit.
-                  return (
-                    <box
-                      flexDirection="row"
-                      gap={0}
-                      backgroundColor={rowBg()}
-                      onMouseUp={() => {
-                        setCursorIndex(index())
-                        props.onOpenFile(row.path)
-                      }}
-                    >
-                      {bar}
-                      <box flexGrow={1} paddingRight={1}>
-                        <text fg={theme.text} wrapMode="none">
-                          {`${indent}  ${row.name}`}
-                        </text>
-                      </box>
-                    </box>
-                  )
-                }
-                // Changes row: status char + path + +N -N stats.
-                const tone = statusToken(row.status)
-                const statusColor = () => {
-                  switch (tone) {
-                    case "success":
-                      return theme.success
-                    case "warning":
-                      return theme.warning
-                    case "error":
-                      return theme.error
-                    case "info":
-                      return theme.info
-                    default:
-                      return theme.textMuted
-                  }
-                }
-                const w = statWidths()
-                const addedText = row.added == null ? " ".repeat(w.added) : `+${row.added}`.padStart(w.added)
-                const deletedText = row.deleted == null ? " ".repeat(w.deleted) : `-${row.deleted}`.padStart(w.deleted)
-                return (
-                  <box
-                    flexDirection="row"
-                    gap={0}
-                    backgroundColor={rowBg()}
-                    onMouseUp={() => {
-                      setCursorIndex(index())
-                      props.onOpenFile(row.path)
-                    }}
-                  >
-                    {bar}
-                    <box flexDirection="row" flexGrow={1} gap={1} paddingRight={1}>
-                      <text fg={statusColor()} wrapMode="none">
-                        {row.status}
-                      </text>
-                      <text fg={theme.text} wrapMode="none" flexGrow={1}>
-                        {truncatePathTail(row.path, pathBudget())}
-                      </text>
-                      <Show when={w.added > 0}>
-                        <text fg={theme.success} wrapMode="none">
-                          {addedText}
-                        </text>
-                      </Show>
-                      <Show when={w.deleted > 0}>
-                        <text fg={theme.error} wrapMode="none">
-                          {deletedText}
-                        </text>
-                      </Show>
-                    </box>
-                  </box>
-                )
-              }}
+              {(row, index) => (
+                <FileTreeRowView
+                  row={row}
+                  cursor={index() === cursorIndex()}
+                  statWidths={statWidths()}
+                  pathBudget={pathBudget()}
+                  onActivate={() => {
+                    setCursorIndex(index())
+                    activateRow(row)
+                  }}
+                />
+              )}
             </For>
           </box>
         </Show>
@@ -839,4 +477,3 @@ export function FileTree(props: FileTreeProps) {
     </box>
   )
 }
-type EventedWatcher = FSWatcher & { on(event: "error", listener: (err: Error) => void): void }

--- a/packages/kobe/src/tui/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui/panes/filetree/header-view.tsx
@@ -1,0 +1,105 @@
+/**
+ * Solid view for the file tree pane's header chrome — the optional
+ * Zen / Create-PR action row, the All / Changes tab chips, the corner
+ * activity badge (KOB-254), and the Changes-tab status legend. Split out
+ * of `FileTree.tsx` (issue #15, G3; the component was over the 500-line
+ * cap). Pure render — tab state and actions stay in the pane component.
+ */
+
+import { t } from "@/tui/i18n"
+import { TextAttributes } from "@opentui/core"
+import { For, Show } from "solid-js"
+import { useTheme } from "../../context/theme"
+import { type FileTreeTab, TAB_ORDER, tabLabelKey } from "./keys-core"
+
+export type FileTreeHeaderProps = {
+  /** The active tab. */
+  tab: FileTreeTab
+  /** Mouse tab switch. */
+  onSelectTab: (tab: FileTreeTab) => void
+  /** Right-aligned activity badge; `null` hides it. */
+  cornerBadge: { text: string; active: boolean } | null
+  /** Optional Ops-pane chips (see FileTreeProps). */
+  onZenToggle?: () => void
+  onCreatePR?: () => void
+}
+
+export function FileTreeHeaderView(props: FileTreeHeaderProps) {
+  const { theme } = useTheme()
+  return (
+    <>
+      {/* Action row — sits above the All / Changes tabs so it's reachable
+         from both tabs. Zen toggle sits left of Create PR (bound to `p`). */}
+      <Show when={props.onZenToggle || props.onCreatePR}>
+        <box flexDirection="row" justifyContent="flex-end" gap={2} paddingBottom={1} flexShrink={0}>
+          <Show when={props.onZenToggle}>
+            <box flexDirection="row" gap={1} onMouseUp={() => props.onZenToggle?.()}>
+              <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+                [~]
+              </text>
+              <text fg={theme.text} wrapMode="none">
+                {t("files.actions.zen")}
+              </text>
+            </box>
+          </Show>
+          <Show when={props.onCreatePR}>
+            <box flexDirection="row" gap={1} onMouseUp={() => props.onCreatePR?.()}>
+              <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+                [P]
+              </text>
+              <text fg={theme.text} wrapMode="none">
+                {t("files.actions.createPR")}
+              </text>
+            </box>
+          </Show>
+        </box>
+      </Show>
+      {/* Header: tabs row. Each tab is clickable (sets active), and
+         `[` / `]` cycle from the keyboard. */}
+      <box flexDirection="row" justifyContent="space-between" paddingBottom={0} flexShrink={0}>
+        <box flexDirection="row" gap={2}>
+          <For each={TAB_ORDER}>
+            {(tabId) => {
+              const isActive = () => props.tab === tabId
+              return (
+                <text
+                  fg={isActive() ? theme.primary : theme.textMuted}
+                  attributes={isActive() ? TextAttributes.BOLD : undefined}
+                  wrapMode="none"
+                  onMouseUp={() => props.onSelectTab(tabId)}
+                >
+                  {t(tabLabelKey(tabId))}
+                </text>
+              )
+            }}
+          </For>
+        </box>
+        {/* Right-aligned activity badge (KOB-254). No background fill so
+           it stays clean in transparent mode. */}
+        <Show when={props.cornerBadge}>
+          {(badge) => (
+            <text
+              fg={badge().active ? theme.accent : theme.textMuted}
+              attributes={badge().active ? TextAttributes.BOLD : undefined}
+              wrapMode="none"
+            >
+              {badge().text}
+            </text>
+          )}
+        </Show>
+      </box>
+      {/* Status legend — only shown on the Changes tab so users can
+         decode single-char git status codes without leaving the TUI. */}
+      <Show when={props.tab === "changes"}>
+        <box flexDirection="column" paddingBottom={1} flexShrink={0} gap={0}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {t("files.legend.changes")}
+          </text>
+        </box>
+      </Show>
+      <Show when={props.tab !== "changes"}>
+        <box flexDirection="row" paddingBottom={1} flexShrink={0} />
+      </Show>
+    </>
+  )
+}

--- a/packages/kobe/src/tui/panes/filetree/keys-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/keys-core.ts
@@ -1,0 +1,100 @@
+/**
+ * Framework-free core of the file tree pane's key bindings — the tab
+ * vocabulary plus the id → controller-action map that both the Solid hook
+ * (`keys.ts`) and the React pane (`src/tui-react/panes/filetree/`) register
+ * through their respective `useBindings` layers. Extracted from `keys.ts`
+ * (issue #15, G3) so the slot-multiplexed dispatch — the property that makes
+ * these chords user-rebindable — is single-sourced across both runtimes.
+ *
+ * `bindByIds` itself is framework-free (the React keybindings context
+ * re-exports it from the same module), so the full `Binding[]` construction
+ * can live here; only the per-keypress registration is framework-specific.
+ */
+
+import { bindByIds } from "../../context/keybindings"
+import type { Binding } from "../../lib/keymap-dispatch"
+
+/** Tab identifiers — kept out of the component files so neither runtime's
+ * view creates a circular import with its bindings hook. */
+export type FileTreeTab = "all" | "changes"
+
+/** Tab order for `[`/`]` cycling. Same source-order as the visible chips. */
+export const TAB_ORDER: readonly FileTreeTab[] = ["all", "changes"]
+
+/** i18n key for a tab's display label — each runtime resolves it through
+ * its own reactive `t` so language switches repaint the chips. */
+export function tabLabelKey(tab: FileTreeTab): string {
+  switch (tab) {
+    case "all":
+      return "files.tabs.all"
+    case "changes":
+      return "files.tabs.changes"
+  }
+}
+
+/**
+ * The controller surface the bindings drive. Plain thunks — a Solid
+ * `Accessor` satisfies `currentTab` structurally, React passes closures
+ * over the latest render (its `useBindings` re-reads config per keypress).
+ */
+export type FileTreeController = {
+  /** Move the cursor to the next visible row. */
+  moveDown: () => void
+  /** Move the cursor to the previous visible row. */
+  moveUp: () => void
+  /** Switch to a tab (used both by mouse-clicks and the cycle handler below). */
+  setTab: (tab: FileTreeTab) => void
+  /** Returns the currently active tab — the cycle handler reads it to
+   *  know where `[`/`]` should land relative to the current selection. */
+  currentTab: () => FileTreeTab
+  /** Activate the row under the cursor (calls `onOpenFile` upstream). */
+  openCurrent: () => void
+  /** `a` — inject the current file as an `@<path>` mention (Ops host only). */
+  mentionCurrent?: () => void
+  /** `p` — inject the Create PR prompt into the engine pane (Ops host only). */
+  createPR?: () => void
+  /** Hand the current row off to the OS default app (audio, video, PDF). */
+  openExternal: () => void
+  /** Force a reload of the current tab's data. */
+  refresh: () => void
+  /** `l` — expand current dir / descend into it / open file. */
+  expandOrDescend: () => void
+  /** `h` — collapse current dir or jump to parent. */
+  collapseOrParent: () => void
+}
+
+/**
+ * Build the pane's binding table. Direction-multiplexed ids dispatch on the
+ * matched chord's SLOT (its index in the id's keys array, threaded through
+ * by bindByIds → dispatchKeyEvent), never on evt.name — that's what makes
+ * them user-rebindable. Layouts live in SLOT_CONTRACTS
+ * (lib/keymap-overrides.ts):
+ *   files.nav        [down, up] pairs         (default j, k, down, up)
+ *   files.hierarchy  [collapse, expand] pairs (default h, l, left, right)
+ *   files.tab        [previous, next] pairs   (default [, ])
+ */
+export function fileTreeBindings(opts: FileTreeController): Binding[] {
+  return bindByIds({
+    "files.nav": (_evt, slot) => {
+      if ((slot ?? 0) % 2 === 0) opts.moveDown()
+      else opts.moveUp()
+    },
+    "files.hierarchy": (_evt, slot) => {
+      if ((slot ?? 0) % 2 === 0) opts.collapseOrParent()
+      else opts.expandOrDescend()
+    },
+    "files.tab": (_evt, slot) => {
+      const cur = opts.currentTab()
+      const idx = TAB_ORDER.indexOf(cur)
+      if (idx < 0) return
+      const delta = (slot ?? 0) % 2 === 0 ? -1 : 1
+      const next = TAB_ORDER[(idx + delta + TAB_ORDER.length) % TAB_ORDER.length]
+      if (next) opts.setTab(next)
+    },
+    "files.open": () => opts.openCurrent(),
+    "files.mention": () => opts.mentionCurrent?.(),
+    "files.createPR": () => opts.createPR?.(),
+    "files.openExternal": () => opts.openExternal(),
+    "files.refresh": () => opts.refresh(),
+  })
+}

--- a/packages/kobe/src/tui/panes/filetree/keys.ts
+++ b/packages/kobe/src/tui/panes/filetree/keys.ts
@@ -4,7 +4,8 @@
  * Bindings (only when `focused()` is true):
  *   - `j` / `down`         next row
  *   - `k` / `up`           previous row
- *   - `1` / `2` / `3`      switch to All / Changes / Checks tab
+ *   - `[` / `]`            cycle All / Changes tab
+ *   - `h` / `l`            collapse / expand hierarchy
  *   - `enter` / `return`   open current file in nvim/vim — `-d` diff vs HEAD
  *                          when changed, plain edit otherwise; falls back to
  *                          our opentui read-only preview (calls `onOpenFile`)
@@ -12,102 +13,34 @@
  *   - `p`                  create PR prompt (Ops host only)
  *   - `r`                  refresh (re-run git commands)
  *
- * The bindings reach into a tiny controller object the parent
- * (`FileTree.tsx`) exposes — same shape as the sidebar's
- * `useSidebarBindings` so anyone reading the codebase recognises the
- * pattern. The controller indirection lets the FileTree component
- * avoid passing 5 separate setters into this hook.
+ * The id → action map itself is the framework-free `keys-core.ts`
+ * (shared with the React port); this file owns only the Solid
+ * registration via `useBindings` — which transitively imports
+ * `@opentui/solid`, hence the split. Tear-down happens automatically via
+ * `useBindings`'s `onCleanup` hook when the host component unmounts.
  *
  * No multi-key chords. The brief explicitly waives vim niceties for v1
  * — adding `g g` etc. would mean lifting `controller.ts`-style chord
  * machinery from the sidebar, and it's not worth the LoC for this
  * pane until we have at least two chords that need it.
- *
- * Why a separate file: keeps `useBindings` (which transitively imports
- * `@opentui/solid` and therefore `@opentui/core`) out of the file tree
- * pane's pure-logic modules (`git.ts`). Tests that exercise parsing
- * import `git.ts` directly; tests that exercise navigation logic
- * exercise the controller from `FileTree.tsx` indirectly via the host.
  */
 
 import type { Accessor } from "solid-js"
-import { bindByIds } from "../../context/keybindings"
 import { useBindings } from "../../lib/keymap"
+import { type FileTreeController, fileTreeBindings } from "./keys-core"
 
-/** Tab identifiers — kept here so `keys.ts` doesn't import from the
- * component file (which would create a circular import once `FileTree.tsx`
- * imports the hook from here). */
-export type FileTreeTab = "all" | "changes"
+export { TAB_ORDER } from "./keys-core"
+export type { FileTreeTab } from "./keys-core"
 
-/** Tab order for `[`/`]` cycling. Same source-order as the visible chips. */
-export const TAB_ORDER: readonly FileTreeTab[] = ["all", "changes"]
-
-export type FileTreeBindingsOpts = {
+export type FileTreeBindingsOpts = FileTreeController & {
   /** Whether the pane should respond to keys. Default `() => true`. */
   focused: Accessor<boolean>
-  /** Move the cursor to the next visible row. */
-  moveDown: () => void
-  /** Move the cursor to the previous visible row. */
-  moveUp: () => void
-  /** Switch to a tab (used both by mouse-clicks and the cycle handler below). */
-  setTab: (tab: FileTreeTab) => void
-  /** Returns the currently active tab — the cycle handler reads it to
-   *  know where `[`/`]` should land relative to the current selection. */
-  currentTab: Accessor<FileTreeTab>
-  /** Activate the row under the cursor (calls `onOpenFile` upstream). */
-  openCurrent: () => void
-  /** `a` — inject the current file as an `@<path>` mention (Ops host only). */
-  mentionCurrent?: () => void
-  /** `p` — inject the Create PR prompt into the engine pane (Ops host only). */
-  createPR?: () => void
-  /** Hand the current row off to the OS default app (audio, video, PDF). */
-  openExternal: () => void
-  /** Force a reload of the current tab's data. */
-  refresh: () => void
-  /** `l` — expand current dir / descend into it / open file. */
-  expandOrDescend: () => void
-  /** `h` — collapse current dir or jump to parent. */
-  collapseOrParent: () => void
 }
 
-/**
- * Register the pane's local key bindings. Tear-down happens
- * automatically via `useBindings`'s `onCleanup` hook when the host
- * component unmounts.
- */
+/** Register the pane's local key bindings. */
 export function useFileTreeBindings(opts: FileTreeBindingsOpts): void {
   useBindings(() => ({
     enabled: opts.focused(),
-    bindings: bindByIds({
-      // Direction-multiplexed ids dispatch on the matched chord's SLOT
-      // (its index in the id's keys array, threaded through by
-      // bindByIds → dispatchKeyEvent), never on evt.name — that's what
-      // makes them user-rebindable. Layouts live in SLOT_CONTRACTS
-      // (lib/keymap-overrides.ts):
-      //   files.nav        [down, up] pairs       (default j, k, down, up)
-      //   files.hierarchy  [collapse, expand] pairs (default h, l, left, right)
-      //   files.tab        [previous, next] pairs  (default [, ])
-      "files.nav": (_evt, slot) => {
-        if ((slot ?? 0) % 2 === 0) opts.moveDown()
-        else opts.moveUp()
-      },
-      "files.hierarchy": (_evt, slot) => {
-        if ((slot ?? 0) % 2 === 0) opts.collapseOrParent()
-        else opts.expandOrDescend()
-      },
-      "files.tab": (_evt, slot) => {
-        const cur = opts.currentTab()
-        const idx = TAB_ORDER.indexOf(cur)
-        if (idx < 0) return
-        const delta = (slot ?? 0) % 2 === 0 ? -1 : 1
-        const next = TAB_ORDER[(idx + delta + TAB_ORDER.length) % TAB_ORDER.length]
-        if (next) opts.setTab(next)
-      },
-      "files.open": () => opts.openCurrent(),
-      "files.mention": () => opts.mentionCurrent?.(),
-      "files.createPR": () => opts.createPR?.(),
-      "files.openExternal": () => opts.openExternal(),
-      "files.refresh": () => opts.refresh(),
-    }),
+    bindings: fileTreeBindings(opts),
   }))
 }

--- a/packages/kobe/src/tui/panes/filetree/pane-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/pane-core.ts
@@ -1,0 +1,195 @@
+/**
+ * Framework-free pane logic for the file tree — extracted from the Solid
+ * `FileTree.tsx` (issue #15, G3) so the React port shares the exact same
+ * behavior instead of duplicating it. Everything here is pure functions
+ * over the `Row` model (plus one node-only fs.watch helper), unit-tested
+ * in `test/tui-react/filetree-pane-core.test.ts`; the Solid component
+ * keeps consuming these so the two runtimes cannot drift.
+ */
+
+import { watch } from "node:fs"
+import type { FileStatus } from "./git"
+import type { Row } from "./rows"
+
+/**
+ * Map a status code to its theme token. Resolved at render time so a
+ * theme switch reactively recolours pre-existing rows.
+ */
+export function statusToken(s: FileStatus): "warning" | "success" | "error" | "textMuted" | "info" {
+  switch (s) {
+    case "M":
+      return "warning"
+    case "A":
+      return "success"
+    case "D":
+      return "error"
+    case "?":
+      return "textMuted"
+    case "R":
+    case "C":
+    case "U":
+    case "T":
+      // Renames/copies/conflicts/typechanges are uncommon in the loop;
+      // render them in info-blue to distinguish from the M/A/D/? majority.
+      return "info"
+  }
+}
+
+/**
+ * Boil a raw `git ls-files` / `git status` error down to a single
+ * human-friendly sentence. The thrown messages from `git.ts` look
+ * like `git ls-files ... (cwd=/foo) exited with code 128: fatal: not
+ * a git repository`. Most users don't need the full args / exit
+ * code; we surface the common cases and keep the rest generic.
+ * `t` is the caller's translate fn — Solid and React each pass their
+ * own reactive one.
+ */
+export function summarizeGitError(raw: string, t: (key: string) => string): string {
+  const m = raw.toLowerCase()
+  if (m.includes("not a git repository")) return t("files.error.notGitRepo")
+  if (m.includes("does not exist") || m.includes("enoent")) return t("files.error.pathMissing")
+  if (m.includes("permission denied") || m.includes("eacces")) return t("files.error.permissionDenied")
+  if (m.includes("git: not found") || m.includes("command not found")) return t("files.error.gitNotInstalled")
+  // Fallback: strip the leading `git <args> (cwd=...)` boilerplate.
+  const colon = raw.indexOf(": ")
+  if (colon >= 0 && raw.startsWith("git ")) return raw.slice(colon + 2).trim() || t("files.error.gitFailed")
+  return raw.trim() || t("files.error.gitFailed")
+}
+
+/**
+ * Column widths for the `+N` / `-N` stats on the Changes tab. Computed
+ * across the visible rows so every cell pads to the widest sibling —
+ * without this, `+0 -202` and `+1 -1` end at the same right edge but
+ * the `-` columns drift, which reads as misaligned. Width includes
+ * the leading sign (`+`/`-`).
+ */
+export type StatWidths = { added: number; deleted: number }
+
+export function computeStatWidths(rows: readonly Row[]): StatWidths {
+  let added = 0
+  let deleted = 0
+  for (const row of rows) {
+    if (row.kind !== "status") continue
+    if (row.added != null) added = Math.max(added, String(row.added).length + 1)
+    if (row.deleted != null) deleted = Math.max(deleted, String(row.deleted).length + 1)
+  }
+  return { added, deleted }
+}
+
+/**
+ * Cell budget for a Changes-tab path. Tail-truncated to whatever the pane
+ * leaves after the status char, the `+N`/`-N` stat columns, the inter-column
+ * gaps, row padding, and the scrollbar — so the filename always survives and
+ * only the leading directories elide.
+ */
+export function computePathBudget(paneWidth: number, w: StatWidths): number {
+  const stats = (w.added > 0 ? w.added + 1 : 0) + (w.deleted > 0 ? w.deleted + 1 : 0)
+  // row padding (2) + status glyph (1) + gap (1) + stats + scrollbar (1) + slack (1).
+  return Math.max(8, paneWidth - 6 - stats)
+}
+
+/** Render a `+N` / `-N` stat cell padded to the column width; a missing
+ * count renders as blanks so the columns stay aligned. */
+export function statCell(value: number | null | undefined, width: number, sign: "+" | "-"): string {
+  return value == null ? " ".repeat(width) : `${sign}${value}`.padStart(width)
+}
+
+/** Toggle a directory path in the expansion set (immutably). */
+export function toggleDir(expanded: ReadonlySet<string>, path: string): ReadonlySet<string> {
+  const next = new Set(expanded)
+  if (next.has(path)) next.delete(path)
+  else next.add(path)
+  return next
+}
+
+/** What a hierarchy keypress should do — mutate the expansion set or move
+ * the cursor. `null` means no-op. */
+export type NavAction = { type: "expand" | "collapse"; path: string } | { type: "cursor"; index: number }
+
+/** `l` — hierarchy navigation only. On a closed dir, expand it; on
+ * an open dir, step into its first child; on a file, no-op (use
+ * `enter` to open). Keeping `l` purely structural lets the user roam
+ * through the tree without accidentally pulling the file into the
+ * preview pane. */
+export function expandOrDescendAction(rows: readonly Row[], cursorIndex: number): NavAction | null {
+  const row = rows[cursorIndex]
+  if (!row || row.kind !== "dir") return null
+  if (!row.expanded && row.hasChildren) return { type: "expand", path: row.path }
+  if (row.expanded && cursorIndex + 1 < rows.length) return { type: "cursor", index: cursorIndex + 1 }
+  return null
+}
+
+/** `h` — collapse the current directory, or jump to the parent dir
+ * (depth - 1) walking upward in rows. All-tab behavior; the caller
+ * gates on the active tab. */
+export function collapseOrParentAction(rows: readonly Row[], cursorIndex: number): NavAction | null {
+  const row = rows[cursorIndex]
+  if (!row) return null
+  // Open dir → collapse.
+  if (row.kind === "dir" && row.expanded) return { type: "collapse", path: row.path }
+  if (row.kind !== "dir" && row.kind !== "file") return null
+  const targetDepth = row.depth - 1
+  if (targetDepth < 0) return null
+  for (let j = cursorIndex - 1; j >= 0; j--) {
+    const candidate = rows[j]
+    if (!candidate) continue
+    if (candidate.kind === "dir" && candidate.depth === targetDepth) return { type: "cursor", index: j }
+  }
+  return null
+}
+
+/**
+ * Viewport follow: each row renders as a height-1 box, so its y-offset
+ * inside the scrollbox content equals its index. When the cursor moves
+ * past the visible window (either edge), return the scrollTop that puts
+ * the cursor row just inside the viewport; `null` means don't scroll.
+ */
+export function followScrollTop(scrollTop: number, viewportHeight: number, cursorIndex: number): number | null {
+  if (viewportHeight <= 0) return null
+  if (cursorIndex < scrollTop) return cursorIndex
+  if (cursorIndex >= scrollTop + viewportHeight) return cursorIndex - viewportHeight + 1
+  return null
+}
+
+/** Whether an fs-watch event under the worktree should trigger a refresh —
+ * `.git` internals and node_modules churn are noise. */
+export function watchEventRelevant(filename: string): boolean {
+  if (filename === ".git" || filename.startsWith(".git/") || filename.startsWith(".git\\")) return false
+  if (filename.startsWith("node_modules/") || filename.startsWith("node_modules\\")) return false
+  return true
+}
+
+type EventedWatcher = ReturnType<typeof watch> & { on(event: "error", listener: (err: Error) => void): void }
+
+/**
+ * Recursive fs watch over a worktree with a 500ms trailing debounce.
+ * Returns a disposer. Errors are swallowed (the `r` keystroke remains as
+ * the escape hatch); an unwatchable path degrades to manual refresh.
+ * Opt-in at the call site via `KOBE_FILETREE_WATCH=1` — on large repos a
+ * recursive watcher can overwhelm the TUI process before the user does
+ * anything.
+ */
+export function watchWorktree(path: string, onChange: () => void, debounceMs = 500): () => void {
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let watcher: EventedWatcher | null = null
+  try {
+    watcher = watch(path, { recursive: true }, (_event, filename) => {
+      if (filename == null) return
+      if (!watchEventRelevant(filename.toString())) return
+      if (debounceTimer != null) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null
+        onChange()
+      }, debounceMs)
+    }) as EventedWatcher
+    watcher.on("error", () => {
+      // Swallow — the `r` keystroke remains as the escape hatch.
+    })
+  } catch {
+    // Path missing or not watchable — fall back to manual refresh.
+  }
+  return () => {
+    if (debounceTimer != null) clearTimeout(debounceTimer)
+    if (watcher != null) watcher.close()
+  }
+}

--- a/packages/kobe/src/tui/panes/filetree/row-view.tsx
+++ b/packages/kobe/src/tui/panes/filetree/row-view.tsx
@@ -1,0 +1,109 @@
+/**
+ * Solid view for a single file tree row — split out of `FileTree.tsx`
+ * (issue #15, G3; the component was over the 500-line cap). Pure render:
+ * all row math (stat widths, path budget, status→token mapping) comes from
+ * the shared framework-free `pane-core.ts`.
+ *
+ * Cursor row treatment — matches the Sidebar: a left accent ▌
+ * (focusAccent) + a subtle `backgroundElement` tint, NOT a solid
+ * terracotta fill, so the semantic colours survive instead of being
+ * flattened to inverted text. A bare space holds the 1-cell gutter on
+ * non-cursor rows so content stays aligned.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { Show } from "solid-js"
+import { useTheme } from "../../context/theme"
+import { type StatWidths, statCell, statusToken } from "./pane-core"
+import type { Row } from "./rows"
+import { truncatePathTail } from "./rows"
+
+export type FileTreeRowProps = {
+  row: Row
+  /** Whether the cursor sits on this row. */
+  cursor: boolean
+  /** Shared stat column widths (Changes tab). */
+  statWidths: StatWidths
+  /** Path cell budget (Changes tab). */
+  pathBudget: number
+  /** Mouse activation: sets the cursor here and opens/toggles the row. */
+  onActivate: () => void
+}
+
+export function FileTreeRowView(props: FileTreeRowProps) {
+  const { theme } = useTheme()
+  const bar = (
+    <text fg={props.cursor ? theme.focusAccent : undefined} wrapMode="none">
+      {props.cursor ? "▌" : " "}
+    </text>
+  )
+  const rowBg = () => (props.cursor ? theme.backgroundElement : undefined)
+  const row = props.row
+  if (row.kind === "dir") {
+    // Indent: 2 cells per depth level. Marker: ▾ open, ▸ closed.
+    const indent = "  ".repeat(row.depth)
+    return (
+      <box flexDirection="row" gap={0} backgroundColor={rowBg()} onMouseUp={() => props.onActivate()}>
+        {bar}
+        <box flexGrow={1} paddingRight={1}>
+          <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
+            {`${indent}${row.expanded ? "▾" : "▸"} ${row.name}/`}
+          </text>
+        </box>
+      </box>
+    )
+  }
+  if (row.kind === "file") {
+    const indent = "  ".repeat(row.depth)
+    // Two-cell gutter where the dir marker would sit.
+    return (
+      <box flexDirection="row" gap={0} backgroundColor={rowBg()} onMouseUp={() => props.onActivate()}>
+        {bar}
+        <box flexGrow={1} paddingRight={1}>
+          <text fg={theme.text} wrapMode="none">
+            {`${indent}  ${row.name}`}
+          </text>
+        </box>
+      </box>
+    )
+  }
+  // Changes row: status char + path + +N -N stats.
+  const tone = statusToken(row.status)
+  const statusColor = () => {
+    switch (tone) {
+      case "success":
+        return theme.success
+      case "warning":
+        return theme.warning
+      case "error":
+        return theme.error
+      case "info":
+        return theme.info
+      default:
+        return theme.textMuted
+    }
+  }
+  return (
+    <box flexDirection="row" gap={0} backgroundColor={rowBg()} onMouseUp={() => props.onActivate()}>
+      {bar}
+      <box flexDirection="row" flexGrow={1} gap={1} paddingRight={1}>
+        <text fg={statusColor()} wrapMode="none">
+          {row.status}
+        </text>
+        <text fg={theme.text} wrapMode="none" flexGrow={1}>
+          {truncatePathTail(row.path, props.pathBudget)}
+        </text>
+        <Show when={props.statWidths.added > 0}>
+          <text fg={theme.success} wrapMode="none">
+            {statCell(row.added, props.statWidths.added, "+")}
+          </text>
+        </Show>
+        <Show when={props.statWidths.deleted > 0}>
+          <text fg={theme.error} wrapMode="none">
+            {statCell(row.deleted, props.statWidths.deleted, "-")}
+          </text>
+        </Show>
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/test/tui-react/filetree-pane-core.test.ts
+++ b/packages/kobe/test/tui-react/filetree-pane-core.test.ts
@@ -1,0 +1,173 @@
+/**
+ * pane-core — the framework-free file-tree logic extracted for the React
+ * port (issue #15, G3). Both runtimes drive their cursor / expansion /
+ * stat-column behavior through these functions, so this suite is the single
+ * behavioral pin for hierarchy navigation (`h`/`l` semantics), the
+ * Changes-tab stat alignment math, git-error summarization, and the
+ * fs-watch event filter. A regression here misbehaves identically in the
+ * Solid pane and the React pane — which is exactly the point of the
+ * extraction.
+ */
+
+import { describe, expect, test } from "vitest"
+import { TAB_ORDER, tabLabelKey } from "../../src/tui/panes/filetree/keys-core"
+import {
+  collapseOrParentAction,
+  computePathBudget,
+  computeStatWidths,
+  expandOrDescendAction,
+  followScrollTop,
+  statCell,
+  statusToken,
+  summarizeGitError,
+  toggleDir,
+  watchEventRelevant,
+  watchWorktree,
+} from "../../src/tui/panes/filetree/pane-core"
+import type { Row } from "../../src/tui/panes/filetree/rows"
+
+// A small All-tab row list:
+//   0  dir  src/        (expanded, has children)
+//   1  file src/a.ts    (depth 1)
+//   2  dir  src/lib/    (closed, has children, depth 1)
+//   3  file top.ts      (depth 0)
+const treeRows: Row[] = [
+  { kind: "dir", path: "src", name: "src", depth: 0, expanded: true, hasChildren: true },
+  { kind: "file", path: "src/a.ts", name: "a.ts", depth: 1 },
+  { kind: "dir", path: "src/lib", name: "lib", depth: 1, expanded: false, hasChildren: true },
+  { kind: "file", path: "top.ts", name: "top.ts", depth: 0 },
+]
+
+const statusRowsFixture: Row[] = [
+  { kind: "status", path: "src/index.ts", status: "M", added: 12, deleted: 202 },
+  { kind: "status", path: "new.txt", status: "?", added: 3, deleted: 0 },
+  { kind: "status", path: "bin.dat", status: "A", added: null, deleted: null },
+]
+
+describe("statusToken", () => {
+  test("maps every status to its theme token", () => {
+    expect(statusToken("M")).toBe("warning")
+    expect(statusToken("A")).toBe("success")
+    expect(statusToken("D")).toBe("error")
+    expect(statusToken("?")).toBe("textMuted")
+    for (const s of ["R", "C", "U", "T"] as const) expect(statusToken(s)).toBe("info")
+  })
+})
+
+describe("summarizeGitError", () => {
+  const t = (key: string) => `<${key}>`
+  test("maps the common failure classes to i18n keys", () => {
+    expect(summarizeGitError("fatal: not a git repository", t)).toBe("<files.error.notGitRepo>")
+    expect(summarizeGitError("ENOENT: no such file", t)).toBe("<files.error.pathMissing>")
+    expect(summarizeGitError("EACCES permission denied", t)).toBe("<files.error.permissionDenied>")
+    expect(summarizeGitError("bash: git: not found", t)).toBe("<files.error.gitNotInstalled>")
+  })
+  test("strips the git-args boilerplate from unknown git errors", () => {
+    expect(summarizeGitError("git ls-files --cached (cwd=/x) exited with code 128: something odd", t)).toBe(
+      "something odd",
+    )
+  })
+  test("falls back to the raw text, then the generic key", () => {
+    expect(summarizeGitError("  weird failure  ", t)).toBe("weird failure")
+    expect(summarizeGitError("   ", t)).toBe("<files.error.gitFailed>")
+  })
+})
+
+describe("stat columns", () => {
+  test("widths pad to the widest sibling, sign included", () => {
+    // widest added `+12` → 3; widest deleted `-202` → 4.
+    expect(computeStatWidths(statusRowsFixture)).toEqual({ added: 3, deleted: 4 })
+  })
+  test("non-status rows and null counts contribute nothing", () => {
+    expect(computeStatWidths(treeRows)).toEqual({ added: 0, deleted: 0 })
+    expect(computeStatWidths([statusRowsFixture[2] as Row])).toEqual({ added: 0, deleted: 0 })
+  })
+  test("path budget subtracts chrome + stat columns with a floor of 8", () => {
+    expect(computePathBudget(38, { added: 3, deleted: 4 })).toBe(38 - 6 - 9)
+    expect(computePathBudget(38, { added: 0, deleted: 0 })).toBe(32)
+    expect(computePathBudget(10, { added: 3, deleted: 4 })).toBe(8)
+  })
+  test("statCell right-aligns counts and blanks missing ones", () => {
+    expect(statCell(12, 3, "+")).toBe("+12")
+    expect(statCell(1, 3, "+")).toBe(" +1")
+    expect(statCell(null, 4, "-")).toBe("    ")
+    expect(statCell(undefined, 2, "-")).toBe("  ")
+  })
+})
+
+describe("toggleDir", () => {
+  test("adds and removes immutably", () => {
+    const start: ReadonlySet<string> = new Set(["a"])
+    const opened = toggleDir(start, "b")
+    expect([...opened].sort()).toEqual(["a", "b"])
+    const closed = toggleDir(opened, "a")
+    expect([...closed]).toEqual(["b"])
+    expect([...start]).toEqual(["a"]) // untouched
+  })
+})
+
+describe("expandOrDescendAction (`l`)", () => {
+  test("closed dir with children → expand", () => {
+    expect(expandOrDescendAction(treeRows, 2)).toEqual({ type: "expand", path: "src/lib" })
+  })
+  test("open dir → step to the next row", () => {
+    expect(expandOrDescendAction(treeRows, 0)).toEqual({ type: "cursor", index: 1 })
+  })
+  test("open dir at the end of the list → no-op", () => {
+    const rows: Row[] = [{ kind: "dir", path: "src", name: "src", depth: 0, expanded: true, hasChildren: true }]
+    expect(expandOrDescendAction(rows, 0)).toBeNull()
+  })
+  test("files and out-of-range cursors → no-op", () => {
+    expect(expandOrDescendAction(treeRows, 1)).toBeNull()
+    expect(expandOrDescendAction(treeRows, 99)).toBeNull()
+  })
+})
+
+describe("collapseOrParentAction (`h`)", () => {
+  test("open dir → collapse it", () => {
+    expect(collapseOrParentAction(treeRows, 0)).toEqual({ type: "collapse", path: "src" })
+  })
+  test("nested row → jump to its parent dir", () => {
+    expect(collapseOrParentAction(treeRows, 1)).toEqual({ type: "cursor", index: 0 })
+    expect(collapseOrParentAction(treeRows, 2)).toEqual({ type: "cursor", index: 0 })
+  })
+  test("top-level file / status rows / empty → no-op", () => {
+    expect(collapseOrParentAction(treeRows, 3)).toBeNull()
+    expect(collapseOrParentAction(statusRowsFixture, 0)).toBeNull()
+    expect(collapseOrParentAction([], 0)).toBeNull()
+  })
+})
+
+describe("followScrollTop", () => {
+  test("cursor above the window scrolls it to the cursor", () => {
+    expect(followScrollTop(10, 5, 3)).toBe(3)
+  })
+  test("cursor below the window scrolls it just inside", () => {
+    expect(followScrollTop(0, 5, 9)).toBe(5)
+  })
+  test("cursor inside the window / degenerate viewport → no scroll", () => {
+    expect(followScrollTop(2, 5, 4)).toBeNull()
+    expect(followScrollTop(0, 0, 3)).toBeNull()
+  })
+})
+
+describe("fs watch", () => {
+  test("filters .git and node_modules churn", () => {
+    expect(watchEventRelevant(".git")).toBe(false)
+    expect(watchEventRelevant(".git/HEAD")).toBe(false)
+    expect(watchEventRelevant("node_modules/react/index.js")).toBe(false)
+    expect(watchEventRelevant("src/index.ts")).toBe(true)
+    expect(watchEventRelevant(".gitignore")).toBe(true)
+  })
+  test("watchWorktree on an unwatchable path degrades to a no-op disposer", () => {
+    const dispose = watchWorktree("/nonexistent/kobe-filetree-test", () => {})
+    expect(() => dispose()).not.toThrow()
+  })
+})
+
+describe("keys-core tab vocabulary", () => {
+  test("tab order and label keys stay in sync", () => {
+    expect(TAB_ORDER).toEqual(["all", "changes"])
+    expect(TAB_ORDER.map(tabLabelKey)).toEqual(["files.tabs.all", "files.tabs.changes"])
+  })
+})


### PR DESCRIPTION
## Summary
- **G3 wave 1 (issue #15): React port of the file tree pane.** `src/tui-react/panes/filetree/` reaches behavior parity with the Solid pane — All/Changes tabs, collapsible tree, cursor + viewport follow, stat columns, corner activity badge, Zen / Create-PR chips, error/empty states, opt-in `KOBE_FILETREE_WATCH` fs refresh — following the history pane's async canon (dependency-keyed effects, AbortController + fetch-sequence stale-write guards, `refreshTick` refresh seam).
- **Step 1 (own commit): the Solid `FileTree.tsx` (842 lines, over the 500-line cap) split behavior-preserving** into framework-free `pane-core.ts` (status tokens, git-error summaries, stat-column math, hierarchy navigation, fs-watch glue) + `keys-core.ts` (the slot-multiplexed bindings map), and Solid views `row-view.tsx` / `header-view.tsx`. FileTree.tsx is now 479 lines; the existing filetree unit tests pass untouched.
- Both runtimes consume the same extractions (plus the already framework-free `git.ts` / `rows.ts` / `open-external.ts`), so the two panes cannot drift.
- New `dev:mock-react-filetree` script renders the React pane against a throwaway `git init` fixture — the live render proof.
- **Deviation — no `KOBE_REACT=1` CLI seam:** the file tree pane has no standalone CLI entry; `kobe ops` mounts the wider Ops host (activity polling, turn detector, tmux injection — its own G3 slice, and its daemon signal layer has no framework-free store twin yet). Per the wave brief, the entry gating ships with the Ops-host port; this PR ships the mock render proof instead.

coverage-exemption: packages/kobe/src/tui-react/panes/filetree/FileTree.tsx — renderer-bound pane (imports @opentui/react, not importable under vitest); exercised live by the dev:mock-react-filetree gate; extracted pure logic is unit-tested instead.
coverage-exemption: packages/kobe/src/tui-react/panes/filetree/row-view.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/panes/filetree/header-view.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/panes/filetree/mock-host.tsx — dev-only mock entry, same rationale.
coverage-exemption: packages/kobe/src/tui/panes/filetree/FileTree.tsx — renderer-bound Solid pane (mechanical split only), covered by the Solid dev:mock gate.
coverage-exemption: packages/kobe/src/tui/panes/filetree/row-view.tsx — renderer-bound Solid view split out of FileTree.tsx, same rationale.
coverage-exemption: packages/kobe/src/tui/panes/filetree/header-view.tsx — renderer-bound Solid view split out of FileTree.tsx, same rationale.

## Test plan
- [x] `bun run typecheck` clean
- [x] repo-root `bun run lint` clean
- [x] `bun run test` — fast 2482/2482 + socket 218/218 (includes the new `test/tui-react/filetree-pane-core.test.ts`, 22 tests; existing filetree suites untouched and green)
- [x] local coverage check on touched .ts files: keys.ts 100%, keys-core.ts 100%, pane-core.ts 91.4%
- [x] `bun run compile` → `./release-bin/kobe --version` OK (0.7.63)
- [x] `timeout 6 bun run dev:mock` — Solid mock unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react` + `dev:mock-react-history` — existing React mocks unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react-filetree` — React pane renders the git fixture; `kobe-fixture-alpha.ts` grepped from the captured ANSI output
