### PR TITLE
feat: React port of the sidebar pane (G3, issue #15)

### DIFF
--- a/.changeset/react-sidebar-pane.md
+++ b/.changeset/react-sidebar-pane.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+React port of the sidebar pane behind the G3 migration track (issue #15): `src/tui-react/panes/sidebar/` mirrors the Solid Sidebar (views, `/`-search, project filter, move mode, cursor policy, hover tooltip, row cards) on the React runtime, with the framework-free view logic extracted to `src/tui/panes/sidebar/view-core.ts` and consumed by both renderers. New `dev:mock-react-sidebar` smoke host renders the port against shared synthetic task fixtures. No behavior change for the shipped Solid TUI.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -28,6 +28,7 @@
     "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
     "dev:mock-react": "env KOBE_DEV=1 bun ./src/tui-react/mock/host.tsx",
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
+    "dev:mock-react-sidebar": "env KOBE_DEV=1 bun ./src/tui-react/panes/sidebar/mock-host.tsx",
     "dev:sandbox": "bun run scripts/dev-sandbox.ts run",
     "dev:sandbox:reset": "bun run scripts/dev-sandbox.ts reset",
     "dev:version": "bash ../../scripts/dev-version.sh",

--- a/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
@@ -1,0 +1,411 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React sidebar (issue #15, G3) — the `src/tui/panes/sidebar/Sidebar.tsx`
+ * counterpart, the highest-Solid-density pane port. All list shaping /
+ * cursor policy / budgets are the shared framework-free modules (`groups`,
+ * `view-core`, `row-view`); this file owns only the React state machine.
+ *
+ * Translation notes vs the Solid original (full rationale lives there):
+ *   - Signals → useState; memos → useMemo (row reconcile keeps its `prev`
+ *     in a ref so daemon snapshot echoes preserve row identity).
+ *   - The cursor is state + a ref written together: key handlers between
+ *     renders must read the just-set index (Solid signals are sync; React
+ *     state commits later), so `keys.ts` reads through `getCursorIndex`.
+ *   - `defer: true` effects (view switch / project-filter reset) become
+ *     mount-skip refs; `untrack` reads become ref reads.
+ *   - The 10Hz spinner tick re-renders the pane unconditionally (Solid made
+ *     it a conditional dependency per row). Accepted: the rail's tree is
+ *     small and the tick doubles as the pull that surfaces poller results.
+ */
+
+import type { KeyEvent } from "@opentui/core"
+import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core"
+import { useRenderer, useTerminalDimensions } from "@opentui/react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type SidebarProjectOption,
+  type SidebarRow,
+  type SidebarView,
+  buildProjectOptions,
+  buildRows,
+  cursorIndexForProjectScope,
+  flattenIds,
+  reconcileSidebarRows,
+  resolveCursorTarget,
+  sidebarProjectKey,
+  splitSidebarRows,
+} from "../../../tui/panes/sidebar/groups"
+import { IN_PROGRESS_SPINNER, SPINNER_FRAME_MS } from "../../../tui/panes/sidebar/row-view"
+import {
+  MAIN_BRANCH_POLL_MS,
+  SIDEBAR_WIDTH,
+  cycleViewTarget,
+  projectScrollMaxHeightFor,
+  projectTaskCountKey,
+  searchQueryKeystroke,
+  subtitleBudgetFor,
+  titleBudgetFor,
+} from "../../../tui/panes/sidebar/view-core"
+import { useT } from "../../i18n"
+import { useSidebarBindings } from "./keys"
+import { SidebarPanel } from "./panel"
+import type { SidebarRowCardSharedProps } from "./row-cards"
+import type { SidebarHover, SidebarProps } from "./types"
+
+export type { ChatRunState, SidebarHover, SidebarProps } from "./types"
+
+export function Sidebar(props: SidebarProps) {
+  const t = useT()
+  const focused = props.focused ?? true
+  const focusedRef = useRef(focused)
+  focusedRef.current = focused
+
+  const [view, setView] = useState<SidebarView>("active")
+  const [searchMode, setSearchMode] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [localProjectFilter, setLocalProjectFilter] = useState<string | null>(null)
+  const projectFilter = props.projectFilter !== undefined ? props.projectFilter : localProjectFilter
+  const onProjectFilterChange = props.onProjectFilterChange
+  const setProjectFilter = useCallback(
+    (repo: string | null): void => {
+      if (onProjectFilterChange) onProjectFilterChange(repo)
+      else setLocalProjectFilter(repo)
+    },
+    [onProjectFilterChange],
+  )
+
+  function enterSearch(): void {
+    setSearchQuery("")
+    setSearchMode(true)
+    props.onSearchActiveChange?.(true)
+  }
+  // Enter and esc both just close the search row; selection semantics are
+  // handled by keys.ts (see the Solid original's exitSearch comment).
+  function exitSearch(_select: boolean): void {
+    setSearchMode(false)
+    setSearchQuery("")
+    props.onSearchActiveChange?.(false)
+  }
+
+  // Search-mode keystroke capture on the renderer's global keypress event —
+  // registered AFTER the keymap dispatcher, so chords that preventDefault'd
+  // are skipped by the shared reducer. Same custom-text-input rationale as
+  // the Solid original (opentui <input> misbehaved).
+  const renderer = useRenderer()
+  useEffect(() => {
+    if (!searchMode || !renderer) return
+    const listener = (evt: KeyEvent): void => {
+      if (!focusedRef.current) return
+      setSearchQuery((q) => searchQueryKeystroke(q, evt) ?? q)
+    }
+    renderer.keyInput.on("keypress", listener)
+    return () => {
+      renderer.keyInput.off("keypress", listener)
+    }
+  }, [searchMode, renderer])
+
+  // Branch/changes poll tick + shared spinner frame (one system pulse).
+  const [branchTick, setBranchTick] = useState(0)
+  useEffect(() => {
+    const timer = setInterval(() => setBranchTick((n) => n + 1), MAIN_BRANCH_POLL_MS)
+    return () => clearInterval(timer)
+  }, [])
+  const [spinnerFrame, setSpinnerFrame] = useState(0)
+  useEffect(() => {
+    const timer = setInterval(() => setSpinnerFrame((n) => (n + 1) % IN_PROGRESS_SPINNER.length), SPINNER_FRAME_MS)
+    return () => clearInterval(timer)
+  }, [])
+
+  const sortMode = props.sortMode ?? "default"
+  const projectOptions = useMemo<readonly SidebarProjectOption[]>(
+    () => buildProjectOptions(props.tasks, view),
+    [props.tasks, view],
+  )
+  const projectFilterOption = useMemo<SidebarProjectOption | null>(() => {
+    if (!projectFilter) return null
+    const key = sidebarProjectKey(projectFilter)
+    return projectOptions.find((option) => sidebarProjectKey(option.repo) === key) ?? null
+  }, [projectFilter, projectOptions])
+  const projectFilterRepo = projectFilterOption?.repo ?? null
+  const projectFilterLabel = projectFilterOption?.label ?? "all"
+  const projectFilterCount = projectFilterOption
+    ? projectFilterOption.count
+    : projectOptions.reduce((sum, entry) => sum + entry.count, 0)
+  const projectFilterCountLabel = `${projectFilterCount} ${t(projectTaskCountKey(projectFilterCount))}`
+
+  // Identity-reconciled row list (docs/DESIGN.md §5.5): keep previous row
+  // objects (and the previous ARRAY when nothing changed) so daemon
+  // snapshot echoes don't churn row renderables.
+  const prevRowsRef = useRef<readonly SidebarRow[]>([])
+  const rows = useMemo<readonly SidebarRow[]>(() => {
+    const next = reconcileSidebarRows(
+      prevRowsRef.current,
+      buildRows(props.tasks, view, searchMode ? searchQuery : "", sortMode, projectFilterRepo),
+    )
+    prevRowsRef.current = next
+    return next
+  }, [props.tasks, view, searchMode, searchQuery, sortMode, projectFilterRepo])
+  const flatIds = useMemo(() => flattenIds(rows), [rows])
+  const flatIdsRef = useRef(flatIds)
+  flatIdsRef.current = flatIds
+  const rowsRef = useRef(rows)
+  rowsRef.current = rows
+  const { projectRows, taskRows } = useMemo(() => splitSidebarRows(rows), [rows])
+  // Total unfiltered count for the active view — the "N/total" in search mode.
+  const totalRows = useMemo(
+    () => flattenIds(buildRows(props.tasks, view, "", sortMode, projectFilterRepo)).length,
+    [props.tasks, view, sortMode, projectFilterRepo],
+  )
+
+  // Drop a stale project filter when its repo disappears / only one repo left.
+  useEffect(() => {
+    if (
+      projectFilter !== null &&
+      projectOptions.length > 0 &&
+      (projectOptions.length <= 1 || projectFilterOption === null)
+    ) {
+      setProjectFilter(null)
+    }
+  }, [projectFilter, projectOptions, projectFilterOption, setProjectFilter])
+
+  function cycleProjectFilter(): void {
+    if (projectOptions.length <= 1) {
+      setProjectFilter(null)
+      return
+    }
+    const activeKey = projectFilterRepo ? sidebarProjectKey(projectFilterRepo) : null
+    const idx =
+      activeKey === null ? -1 : projectOptions.findIndex((option) => sidebarProjectKey(option.repo) === activeKey)
+    setProjectFilter(projectOptions[idx + 1]?.repo ?? null)
+  }
+
+  // Two-line card budgets from the live width (view-core math).
+  const effectiveWidth = props.width ?? SIDEBAR_WIDTH
+  const titleBudget = titleBudgetFor(effectiveWidth)
+  const subtitleBudget = subtitleBudgetFor(effectiveWidth)
+
+  const dims = useTerminalDimensions()
+  const projectScrollMaxHeight = projectScrollMaxHeightFor(dims.height, projectRows.length)
+
+  // Hover tooltip state; mirrored to the host and cleared on unmount.
+  const [hover, setLocalHover] = useState<SidebarHover | null>(null)
+  const hoverRef = useRef(hover)
+  hoverRef.current = hover
+  const onHoverChangeRef = useRef(props.onHoverChange)
+  onHoverChangeRef.current = props.onHoverChange
+  const setHover = useCallback((next: SidebarHover | null): void => {
+    setLocalHover(next)
+    onHoverChangeRef.current?.(next)
+  }, [])
+  const clearHoverForTask = useCallback(
+    (taskId: string): void => {
+      if (hoverRef.current?.task.id !== taskId) return
+      setHover(null)
+    },
+    [setHover],
+  )
+  useEffect(
+    () => () => {
+      onHoverChangeRef.current?.(null)
+    },
+    [],
+  )
+
+  // Cursor: state + ref written together so key handlers between renders
+  // read the just-set index (see header).
+  const [cursorIndex, setCursorIndexState] = useState(-1)
+  const cursorRef = useRef(cursorIndex)
+  const setCursorIndex = useCallback((next: number): void => {
+    cursorRef.current = next
+    setCursorIndexState(next)
+  }, [])
+
+  // Renderable refs for the split scroll machinery.
+  const projectScrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const taskScrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const outerBoxRef = useRef<BoxRenderable | null>(null)
+  const rowElsRef = useRef<Map<number, BoxRenderable> | null>(null)
+  if (rowElsRef.current === null) rowElsRef.current = new Map()
+  const rowEls = rowElsRef.current
+
+  // Apply the rail width imperatively, restoring flexShrink/minHeight in the
+  // same effect (opentui's width setter force-zeroes flexShrink — see the
+  // Solid original for the full story).
+  useEffect(() => {
+    const el = outerBoxRef.current
+    if (!el) return
+    el.width = effectiveWidth
+    el.flexShrink = 1
+    el.minHeight = 0
+  }, [effectiveWidth])
+
+  // Viewport follow: scroll whichever section owns the cursor row.
+  useEffect(() => {
+    const row = rows.find((r) => r.flatIndex === cursorIndex)
+    if (!row) return
+    const scrollRef = row.task.kind === "main" ? projectScrollRef.current : taskScrollRef.current
+    if (!scrollRef) return
+    if (scrollRef.viewport.height <= 0) return
+    const el = rowEls.get(cursorIndex)
+    if (!el) return
+    scrollRef.scrollChildIntoView(el.id)
+  }, [cursorIndex, rows, rowEls])
+
+  // Sync cursor from external selectedId — deps are ONLY the selected id and
+  // the flat id list; the current cursor is read via ref (Solid's untrack).
+  useEffect(() => {
+    const cur = cursorRef.current
+    const next = resolveCursorTarget(props.selectedId, flatIds, cur)
+    if (next !== cur) setCursorIndex(next)
+  }, [props.selectedId, flatIds, setCursorIndex])
+
+  // Reset cursor on a LATER view switch only (Solid's `defer: true`): the
+  // mount-time position is owned by the selectedId sync above.
+  const viewMountedRef = useRef(false)
+  useEffect(() => {
+    // Dependency-only invalidation key: reset on view switches, not data churn.
+    void view
+    if (!viewMountedRef.current) {
+      viewMountedRef.current = true
+      return
+    }
+    setCursorIndex(flatIdsRef.current.length > 0 ? 0 : -1)
+  }, [view, setCursorIndex])
+
+  // Project filter changes replace the visible task universe (defer'd too).
+  const filterMountedRef = useRef(false)
+  useEffect(() => {
+    if (!filterMountedRef.current) {
+      filterMountedRef.current = true
+      return
+    }
+    setCursorIndex(cursorIndexForProjectScope(rowsRef.current, projectFilterRepo))
+  }, [projectFilterRepo, setCursorIndex])
+
+  // Land the highlight on the top match on every search keystroke.
+  useEffect(() => {
+    // Dependency-only invalidation key: every keystroke re-lands the cursor.
+    void searchQuery
+    if (!searchMode) return
+    setCursorIndex(flatIdsRef.current.length > 0 ? 0 : -1)
+  }, [searchMode, searchQuery, setCursorIndex])
+
+  function cycleView(delta: -1 | 1): void {
+    const target = cycleViewTarget(view, delta)
+    if (target) setView(target)
+  }
+
+  // Single activation funnel (keyboard enter + row onMouseUp). In a
+  // pinned-selection pane a jump to ANOTHER task snaps the cursor back to
+  // the pinned row (see the Solid original).
+  const activateRow = (id: string): void => {
+    props.onActivate?.(id)
+    if (!props.pinnedSelection) return
+    const pinned = props.selectedId
+    if (!pinned || id === pinned) return
+    const idx = flatIdsRef.current.indexOf(pinned)
+    if (idx >= 0) setCursorIndex(idx)
+  }
+  const activateRowRef = useRef(activateRow)
+  activateRowRef.current = activateRow
+
+  // Surface the cursor row's task id to the host (o/b/v target the cursor).
+  const onCursorChangeRef = useRef(props.onCursorChange)
+  onCursorChangeRef.current = props.onCursorChange
+  useEffect(() => {
+    onCursorChangeRef.current?.(
+      cursorIndex >= 0 && cursorIndex < flatIds.length ? (flatIds[cursorIndex] ?? null) : null,
+    )
+  }, [cursorIndex, flatIds])
+
+  useSidebarBindings({
+    focused,
+    getCursorIndex: () => cursorRef.current,
+    setCursorIndex,
+    flatTaskIds: flatIds,
+    onSelect: (id) => {
+      // Keyboard `enter`: sync the highlight AND activate (single Enter
+      // opens the task). Mouse clicks route through the row's onMouseUp.
+      props.onSelect(id)
+      activateRowRef.current(id)
+    },
+    onDeleteRequest: (id) => props.onDeleteRequest?.(id),
+    onArchiveRequest: (id) => props.onArchiveRequest?.(id),
+    onLocalMergeRequest: (id) => props.onLocalMergeRequest?.(id),
+    moveMode: props.moveMode,
+    onMoveRequest: (id, delta) => props.onMoveRequest?.(id, delta),
+    onMoveModeExit: () => props.onMoveModeExit?.(),
+    onRenameRequest: (id) => props.onRenameRequest?.(id),
+    onPinRequest: (id) => props.onPinRequest?.(id),
+    onPreviewToggleRequest: (id) => props.onPreviewToggleRequest?.(id),
+    onViewSwitch: (delta) => cycleView(delta),
+    onSortModeToggle: () => props.onSortModeToggle?.(),
+    onProjectFilterToggle: () => cycleProjectFilter(),
+    searchMode,
+    onSearchEnter: () => enterSearch(),
+    onSearchExit: (select) => exitSearch(select),
+  })
+
+  const rowCardShared: SidebarRowCardSharedProps = {
+    selectedId: props.selectedId,
+    cursorIndex,
+    setCursorIndex,
+    rowEls,
+    onSelect: props.onSelect,
+    activateRow,
+    activateOnClick: props.activateOnClick,
+    setHover,
+    clearHoverForTask,
+    branchTick,
+    spinnerFrame,
+    titleBudget,
+    subtitleBudget,
+    chatRunState: props.chatRunState,
+    engineState: props.engineState,
+    taskJobs: props.taskJobs,
+    worktreeChanges: props.worktreeChanges,
+    moveMode: props.moveMode,
+  }
+
+  return (
+    <SidebarPanel
+      rootRef={(r) => {
+        outerBoxRef.current = r
+      }}
+      focused={focused}
+      view={view}
+      setView={setView}
+      sortMode={sortMode}
+      hasSortToggle={props.sortMode !== undefined}
+      onSortModeToggle={props.onSortModeToggle}
+      searchMode={searchMode}
+      searchQuery={searchQuery}
+      flatIds={flatIds}
+      totalRows={totalRows}
+      projectRows={projectRows}
+      taskRows={taskRows}
+      hasTaskRows={taskRows.length > 0}
+      projectOptions={projectOptions}
+      projectFilterRepo={projectFilterRepo}
+      projectFilterLabel={projectFilterLabel}
+      projectFilterCountLabel={projectFilterCountLabel}
+      cycleProjectFilter={cycleProjectFilter}
+      projectScrollMaxHeight={projectScrollMaxHeight}
+      setProjectScrollRef={(r) => {
+        projectScrollRef.current = r
+      }}
+      setTaskScrollRef={(r) => {
+        taskScrollRef.current = r
+      }}
+      rowCardShared={rowCardShared}
+      headerStatus={props.headerStatus}
+      onHeaderStatusClick={props.onHeaderStatusClick}
+      onAddTask={props.onAddTask}
+      zenActive={props.zenActive}
+      onZenClick={props.onZenClick}
+      hover={hover}
+      dims={dims}
+      renderHoverFallback={!props.onHoverChange}
+    />
+  )
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/hover-tooltip.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/hover-tooltip.tsx
@@ -1,0 +1,62 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React sidebar hover tooltip (issue #15, G3) — the
+ * `src/tui/panes/sidebar/hover-tooltip.tsx` counterpart. Line building and
+ * screen-clamped layout are the shared framework-free `hover-layout.ts`.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { truncateStart } from "../../../tui/lib/truncate"
+import {
+  SIDEBAR_HOVER_TOOLTIP_Z_INDEX,
+  resolveSidebarHoverTooltipLayout,
+  sidebarHoverTooltipLines,
+} from "../../../tui/panes/sidebar/hover-layout"
+import { truncateTitle } from "../../../tui/panes/sidebar/labels"
+import { useTheme } from "../../context/theme"
+import type { SidebarHover } from "./types"
+
+export { approxCellWidth } from "../../../tui/panes/sidebar/hover-layout"
+
+export function SidebarHoverTooltip(props: {
+  hover: SidebarHover | null
+  dims: { width: number; height: number }
+}) {
+  const { theme } = useTheme()
+  const hover = props.hover
+  if (!hover) return null
+  const lines = sidebarHoverTooltipLines(hover)
+  const layout = resolveSidebarHoverTooltipLayout({
+    hoverX: hover.x,
+    hoverY: hover.y,
+    screenWidth: props.dims.width,
+    screenHeight: props.dims.height,
+    lines,
+  })
+  return (
+    <box
+      position="absolute"
+      zIndex={SIDEBAR_HOVER_TOOLTIP_Z_INDEX}
+      left={layout.left}
+      top={layout.top}
+      width={layout.boxWidth}
+      flexDirection="column"
+      border
+      borderColor={theme.focusAccent}
+      backgroundColor={theme.backgroundElement}
+      paddingLeft={1}
+      paddingRight={1}
+    >
+      {lines.map((line) => (
+        <text
+          key={line.text}
+          fg={line.dim ? theme.textMuted : theme.text}
+          attributes={line.bold ? TextAttributes.BOLD : line.dim ? TextAttributes.DIM : undefined}
+          wrapMode="none"
+        >
+          {line.dim ? truncateStart(line.text, layout.innerWidth) : truncateTitle(line.text, layout.innerWidth)}
+        </text>
+      ))}
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/keys.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/keys.ts
@@ -1,0 +1,200 @@
+/**
+ * Sidebar key bindings — React hook layer (issue #15, G3), the
+ * `src/tui/panes/sidebar/keys.ts` counterpart. The navigation/chord state
+ * machine is the shared framework-free `tui/panes/sidebar/controller.ts`;
+ * this file owns only the React hook + key→method wiring through the
+ * render-refreshed-ref `useBindings` (tui-react/lib/keymap).
+ *
+ * Contract parity notes:
+ *   - Opts are plain per-render values (the Solid accessors' React shape);
+ *     the hook reads them through a ref refreshed every render, so the
+ *     per-keypress config always sees the latest render's state.
+ *   - The cursor is the one exception: reads go through `getCursorIndex`
+ *     because two keypresses can land between renders (React state commits
+ *     asynchronously) — the Sidebar backs it with a ref so a fast j·j
+ *     doesn't move from a stale index.
+ *   - Same three binding blocks (letters+`/`, view switch, search-mode) and
+ *     the same slot/evt.shift discrimination as the Solid hook.
+ */
+
+import { useRef } from "react"
+import { createSidebarController } from "../../../tui/panes/sidebar/controller"
+import { bindByIds } from "../../context/keybindings"
+import { useBindings } from "../../lib/keymap"
+
+export type SidebarBindingsOpts = {
+  /** Whether the sidebar should respond to keys at all. */
+  focused: boolean
+  /** Live cursor read — ref-backed by the Sidebar (see header). */
+  getCursorIndex: () => number
+  /** Setter for the cursor index. The controller clamps to valid range. */
+  setCursorIndex: (next: number) => void
+  /** Flat list of navigable task ids, in display order (latest render). */
+  flatTaskIds: readonly string[]
+  /** Selection callback. Fires on `enter` with the task id under the cursor. */
+  onSelect: (id: string) => void
+  onDeleteRequest?: (taskId: string) => void
+  onArchiveRequest?: (taskId: string) => void
+  /** Shift+M — lowercase `m` is captured but ignored (shift dropped on letters). */
+  onLocalMergeRequest?: (taskId: string) => void
+  /** Task reorder mode: j/k move the cursor task instead of the cursor. */
+  moveMode?: boolean
+  onMoveRequest?: (taskId: string, delta: -1 | 1) => void
+  onMoveModeExit?: () => void
+  onRenameRequest?: (taskId: string) => void
+  /** Shift+P only — bare `p` is consumed but does nothing (same as Solid). */
+  onPinRequest?: (taskId: string) => void
+  onPreviewToggleRequest?: (taskId: string) => void
+  /** `[` (-1) / `]` (+1). Always live, even during search. */
+  onViewSwitch?: (delta: -1 | 1) => void
+  onSortModeToggle?: () => void
+  onProjectFilterToggle?: () => void
+  /** While true, single-letter chords are de-registered so typing reaches the search input. */
+  searchMode?: boolean
+  onSearchEnter?: () => void
+  onSearchExit?: (select: boolean) => void
+}
+
+/**
+ * Register the sidebar's pane-local key bindings for the lifetime of the
+ * calling component. Same behavior contract as the Solid hook — see
+ * `src/tui/panes/sidebar/keys.ts` for the full per-binding rationale.
+ */
+export function useSidebarBindings(opts: SidebarBindingsOpts): void {
+  const optsRef = useRef(opts)
+  optsRef.current = opts
+
+  // One controller per mount: it owns the g·g chord timer state. Its
+  // callbacks read through optsRef so they never go stale across renders.
+  const ctrlRef = useRef<ReturnType<typeof createSidebarController> | null>(null)
+  if (ctrlRef.current === null) {
+    ctrlRef.current = createSidebarController({
+      getCursor: () => optsRef.current.getCursorIndex(),
+      setCursor: (n) => optsRef.current.setCursorIndex(n),
+      getFlatIds: () => optsRef.current.flatTaskIds,
+      onSelect: (id) => optsRef.current.onSelect(id),
+    })
+  }
+  const ctrl = ctrlRef.current
+
+  // Resolve the task id under the cursor for d/a/r — same source of truth
+  // as `enter` so the visible-highlight row is always the target.
+  const cursorTaskId = (): string | undefined => {
+    const ids = optsRef.current.flatTaskIds
+    const idx = optsRef.current.getCursorIndex()
+    if (idx < 0 || idx >= ids.length) return undefined
+    return ids[idx]
+  }
+
+  const searchModeOn = (): boolean => optsRef.current.searchMode ?? false
+  const moveModeOn = (): boolean => optsRef.current.moveMode ?? false
+
+  // Block A — letter chords + `/` to enter search. Disabled while the user
+  // is typing in the search input.
+  useBindings(() => ({
+    enabled: optsRef.current.focused && !searchModeOn(),
+    bindings: bindByIds({
+      // Direction-multiplexed: slot layout is alternating [down, up] pairs.
+      "sidebar.nav": (_evt, slot) => {
+        const down = (slot ?? 0) % 2 === 0
+        if (moveModeOn()) {
+          const id = cursorTaskId()
+          if (id === undefined) return
+          optsRef.current.onMoveRequest?.(id, down ? 1 : -1)
+          return
+        }
+        if (down) ctrl.moveDown()
+        else ctrl.moveUp()
+      },
+      "sidebar.select": () => {
+        if (moveModeOn()) {
+          optsRef.current.onMoveModeExit?.()
+          return
+        }
+        ctrl.selectCurrent()
+      },
+      // gg chord (top) / Shift+G (bottom); shift is discriminated via evt.
+      "sidebar.goto": (evt) => {
+        if (moveModeOn()) return
+        if (evt.shift) ctrl.pressShiftG()
+        else ctrl.pressG()
+      },
+      "sidebar.delete": () => {
+        if (moveModeOn()) return
+        const id = cursorTaskId()
+        if (id !== undefined) optsRef.current.onDeleteRequest?.(id)
+      },
+      "sidebar.archive": () => {
+        if (moveModeOn()) return
+        const id = cursorTaskId()
+        if (id !== undefined) optsRef.current.onArchiveRequest?.(id)
+      },
+      "sidebar.localMerge": (evt) => {
+        if (!evt.shift) return
+        const id = cursorTaskId()
+        if (id !== undefined) optsRef.current.onLocalMergeRequest?.(id)
+      },
+      "sidebar.rename": () => {
+        if (moveModeOn()) return
+        const id = cursorTaskId()
+        if (id !== undefined) optsRef.current.onRenameRequest?.(id)
+      },
+      "sidebar.pin": (evt) => {
+        if (moveModeOn()) return
+        if (!evt.shift) return
+        const id = cursorTaskId()
+        if (id !== undefined) optsRef.current.onPinRequest?.(id)
+      },
+      "sidebar.previewToggle": () => {
+        if (moveModeOn()) return
+        const id = cursorTaskId()
+        if (id !== undefined) optsRef.current.onPreviewToggleRequest?.(id)
+      },
+      "sidebar.search.enter": () => {
+        if (moveModeOn()) return
+        optsRef.current.onSearchEnter?.()
+      },
+      "sidebar.sort": () => {
+        if (moveModeOn()) return
+        optsRef.current.onSortModeToggle?.()
+      },
+      "sidebar.projectFilter": () => {
+        if (moveModeOn()) return
+        optsRef.current.onProjectFilterToggle?.()
+      },
+    }),
+  }))
+
+  useBindings(() => ({
+    enabled: optsRef.current.focused && moveModeOn(),
+    bindings: [{ key: "escape", cmd: () => optsRef.current.onMoveModeExit?.() }],
+  }))
+
+  // Block B — view switcher. Always on (even during search).
+  useBindings(() => ({
+    enabled: optsRef.current.focused,
+    bindings: bindByIds({
+      // Slot layout: [previous view, next view] pairs (default ["[", "]"]).
+      "sidebar.view": (_evt, slot) => {
+        optsRef.current.onViewSwitch?.((slot ?? 0) % 2 === 0 ? -1 : 1)
+      },
+    }),
+  }))
+
+  // Block C — search-mode chords, registered only while the input shows.
+  useBindings(() => ({
+    enabled: optsRef.current.focused && searchModeOn(),
+    bindings: bindByIds({
+      // j/k intentionally excluded — they must reach the input as text.
+      "sidebar.search.nav": (_evt, slot) => {
+        if ((slot ?? 0) % 2 === 0) ctrl.moveDown()
+        else ctrl.moveUp()
+      },
+      "sidebar.search.submit": () => {
+        ctrl.selectCurrent()
+        optsRef.current.onSearchExit?.(true)
+      },
+      "sidebar.search.cancel": () => optsRef.current.onSearchExit?.(false),
+    }),
+  }))
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/mock-host.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/mock-host.tsx
@@ -1,0 +1,44 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React sidebar mock host (`bun run dev:mock-react-sidebar`) — renders the
+ * ported Sidebar against the shared synthetic task fixtures, standing in
+ * for the not-yet-ported tasks-pane host (its kv/notifications providers
+ * land with a later G3 slice). j/k/enter/g/G//, `[` `]`, and the ticks all
+ * run for real; q / ctrl+c quits.
+ */
+
+import { useTerminalDimensions } from "@opentui/react"
+import { useState } from "react"
+import { seedSidebarTasks } from "../../../tui/panes/sidebar/mock-fixtures"
+import { bootPaneHost } from "../../lib/host-boot"
+import { useBindings } from "../../lib/keymap"
+import { Sidebar } from "./Sidebar"
+
+function MockSidebarScreen() {
+  const [tasks] = useState(seedSidebarTasks)
+  const [selectedId, setSelectedId] = useState<string | null>(tasks[0]?.id ?? null)
+  const dims = useTerminalDimensions()
+
+  useBindings(() => ({
+    bindings: [
+      { key: "q", cmd: () => process.exit(0) },
+      { key: "ctrl+c", cmd: () => process.exit(0) },
+    ],
+  }))
+
+  return (
+    <Sidebar
+      tasks={tasks}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      width={dims.width}
+      sortMode="default"
+      headerStatus={{ label: "v0.0.0-mock", emphasize: false }}
+    />
+  )
+}
+
+await bootPaneHost({
+  logContext: "mock-sidebar",
+  setup: () => ({ root: () => <MockSidebarScreen /> }),
+})

--- a/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
@@ -1,29 +1,29 @@
-import { t } from "@/tui/i18n"
+/** @jsxImportSource @opentui/react */
+/**
+ * React sidebar panel (issue #15, G3) — the presentational half of the
+ * sidebar, mirroring `src/tui/panes/sidebar/panel.tsx`. All copy comes
+ * through `useT()` (language-reactive); tab metadata and empty-state key
+ * selection are the shared framework-free `view-core.ts`.
+ */
+
 import { type BoxRenderable, type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
-import type { Accessor } from "solid-js"
-import { For, Show } from "solid-js"
+import type { SidebarProjectOption, SidebarRow, SidebarView, TaskSortMode } from "../../../tui/panes/sidebar/groups"
+import { VIEW_TABS, sidebarEmptyStateKey, viewTabLabelKey } from "../../../tui/panes/sidebar/view-core"
 import { useTheme } from "../../context/theme"
-import type { SidebarProjectOption, SidebarRow, SidebarView as SidebarViewId, TaskSortMode } from "./groups"
+import { useT } from "../../i18n"
 import { SidebarHoverTooltip } from "./hover-tooltip"
 import { ProjectRowCard, type SidebarRowCardSharedProps, TaskRowCard } from "./row-cards"
 import type { SidebarHover, SidebarProps } from "./types"
-import { VIEW_TABS, sidebarEmptyStateKey, viewTabLabelKey } from "./view-core"
-
-export { VIEW_TABS } from "./view-core"
-
-export function viewTabLabel(view: SidebarViewId): string {
-  return t(viewTabLabelKey(view))
-}
 
 function SectionHeader(props: { label: string; suffix?: string; topPad?: boolean }) {
   const { theme } = useTheme()
   return (
     <box flexDirection="column" flexShrink={0}>
-      <Show when={props.topPad}>
+      {props.topPad ? (
         <box flexShrink={0}>
           <text wrapMode="none"> </text>
         </box>
-      </Show>
+      ) : null}
       <box flexDirection="row" flexShrink={0} gap={1} paddingLeft={1} paddingRight={1}>
         <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
           {props.label}
@@ -31,50 +31,52 @@ function SectionHeader(props: { label: string; suffix?: string; topPad?: boolean
         <text fg={theme.border} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
           {"─".repeat(240)}
         </text>
-        <Show when={props.suffix}>
+        {props.suffix ? (
           <text fg={theme.info} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
             {props.suffix}
           </text>
-        </Show>
+        ) : null}
       </box>
     </box>
   )
 }
 
 export function SidebarPanel(props: {
-  rootRef: (renderable: BoxRenderable) => void
-  focused: Accessor<boolean>
-  view: Accessor<SidebarViewId>
-  setView: (view: SidebarViewId) => void
-  sortMode: Accessor<TaskSortMode>
+  rootRef: (renderable: BoxRenderable | null) => void
+  focused: boolean
+  view: SidebarView
+  setView: (view: SidebarView) => void
+  sortMode: TaskSortMode
   hasSortToggle: boolean
   onSortModeToggle?: () => void
-  searchMode: Accessor<boolean>
-  searchQuery: Accessor<string>
-  flatIds: Accessor<readonly string[]>
-  totalRows: Accessor<number>
-  projectRows: Accessor<readonly SidebarRow[]>
-  taskRows: Accessor<readonly SidebarRow[]>
-  hasTaskRows: Accessor<boolean>
-  projectOptions: Accessor<readonly SidebarProjectOption[]>
-  projectFilterRepo: Accessor<string | null>
-  projectFilterLabel: Accessor<string>
-  projectFilterCountLabel: Accessor<string>
+  searchMode: boolean
+  searchQuery: string
+  flatIds: readonly string[]
+  totalRows: number
+  projectRows: readonly SidebarRow[]
+  taskRows: readonly SidebarRow[]
+  hasTaskRows: boolean
+  projectOptions: readonly SidebarProjectOption[]
+  projectFilterRepo: string | null
+  projectFilterLabel: string
+  projectFilterCountLabel: string
   cycleProjectFilter: () => void
-  projectScrollMaxHeight: Accessor<number>
-  setProjectScrollRef: (renderable: ScrollBoxRenderable) => void
-  setTaskScrollRef: (renderable: ScrollBoxRenderable) => void
+  projectScrollMaxHeight: number
+  setProjectScrollRef: (renderable: ScrollBoxRenderable | null) => void
+  setTaskScrollRef: (renderable: ScrollBoxRenderable | null) => void
   rowCardShared: SidebarRowCardSharedProps
   headerStatus?: SidebarProps["headerStatus"]
   onHeaderStatusClick?: () => void
   onAddTask?: () => void
-  zenActive?: SidebarProps["zenActive"]
+  zenActive?: boolean
   onZenClick?: () => void
-  hover: Accessor<SidebarHover | null>
-  dims: Accessor<{ width: number; height: number }>
+  hover: SidebarHover | null
+  dims: { width: number; height: number }
   renderHoverFallback: boolean
 }) {
   const { theme } = useTheme()
+  const t = useT()
+  const status = props.headerStatus ?? null
   return (
     <box
       ref={props.rootRef}
@@ -96,26 +98,24 @@ export function SidebarPanel(props: {
       >
         <box flexDirection="row" gap={1}>
           <text
-            fg={props.focused() ? theme.focusAccent : theme.textMuted}
+            fg={props.focused ? theme.focusAccent : theme.textMuted}
             attributes={TextAttributes.BOLD}
             wrapMode="none"
           >
             KOBE
           </text>
-          <Show when={props.headerStatus?.()}>
-            {(status) => (
-              <text
-                fg={status().emphasize ? theme.warning : theme.textMuted}
-                attributes={status().emphasize ? TextAttributes.BOLD : TextAttributes.DIM}
-                wrapMode="none"
-                onMouseUp={() => props.onHeaderStatusClick?.()}
-              >
-                {status().label}
-              </text>
-            )}
-          </Show>
+          {status ? (
+            <text
+              fg={status.emphasize ? theme.warning : theme.textMuted}
+              attributes={status.emphasize ? TextAttributes.BOLD : TextAttributes.DIM}
+              wrapMode="none"
+              onMouseUp={() => props.onHeaderStatusClick?.()}
+            >
+              {status.label}
+            </text>
+          ) : null}
         </box>
-        <Show when={props.onAddTask}>
+        {props.onAddTask ? (
           <text
             fg={theme.primary}
             attributes={TextAttributes.BOLD}
@@ -124,34 +124,33 @@ export function SidebarPanel(props: {
           >
             [+]
           </text>
-        </Show>
+        ) : null}
       </box>
 
-      <Show when={props.searchMode()}>
+      {props.searchMode ? (
         <box flexDirection="row" gap={0} paddingBottom={1} paddingLeft={1}>
           <text fg={theme.info} wrapMode="none">
             /
           </text>
           <text fg={theme.text} wrapMode="none">
-            {props.searchQuery()}
+            {props.searchQuery}
           </text>
           <text fg={theme.info} attributes={TextAttributes.BLINK} wrapMode="none">
             █
           </text>
-          <Show when={props.searchQuery().length === 0}>
+          {props.searchQuery.length === 0 ? (
             <text fg={theme.textMuted} wrapMode="none">
               {" "}
               {t("tasks.search.placeholder")}
             </text>
-          </Show>
-          <Show when={props.searchQuery().length > 0}>
+          ) : (
             <text fg={theme.textMuted} wrapMode="none">
               {" "}
-              {props.flatIds().length}/{props.totalRows()}
+              {props.flatIds.length}/{props.totalRows}
             </text>
-          </Show>
+          )}
         </box>
-      </Show>
+      ) : null}
 
       <box
         flexDirection="row"
@@ -162,26 +161,25 @@ export function SidebarPanel(props: {
         paddingRight={1}
       >
         <box flexDirection="row" gap={2}>
-          <For each={VIEW_TABS}>
-            {(tab) => {
-              const active = () => props.view() === tab.view
-              return (
-                <text
-                  fg={active() ? theme.primary : theme.textMuted}
-                  attributes={active() ? TextAttributes.BOLD : undefined}
-                  wrapMode="none"
-                  onMouseUp={() => props.setView(tab.view)}
-                >
-                  {viewTabLabel(tab.view)}
-                </text>
-              )
-            }}
-          </For>
+          {VIEW_TABS.map((tab) => {
+            const active = props.view === tab.view
+            return (
+              <text
+                key={tab.view}
+                fg={active ? theme.primary : theme.textMuted}
+                attributes={active ? TextAttributes.BOLD : undefined}
+                wrapMode="none"
+                onMouseUp={() => props.setView(tab.view)}
+              >
+                {t(viewTabLabelKey(tab.view))}
+              </text>
+            )
+          })}
           <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
             [/]
           </text>
         </box>
-        <Show when={props.hasSortToggle}>
+        {props.hasSortToggle ? (
           <text
             fg={theme.textMuted}
             attributes={TextAttributes.DIM}
@@ -190,10 +188,10 @@ export function SidebarPanel(props: {
           >
             {t("tasks.sort")}
           </text>
-        </Show>
+        ) : null}
       </box>
 
-      <Show when={props.projectRows().length > 0}>
+      {props.projectRows.length > 0 ? (
         <box flexDirection="column" flexShrink={0}>
           <box
             flexDirection="row"
@@ -206,45 +204,47 @@ export function SidebarPanel(props: {
             <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
               {t("tasks.header.projects")}
             </text>
-            <Show when={props.projectOptions().length > 1}>
+            {props.projectOptions.length > 1 ? (
               <text
-                fg={props.projectFilterRepo() ? theme.primary : theme.textMuted}
-                attributes={props.projectFilterRepo() ? TextAttributes.BOLD : undefined}
+                fg={props.projectFilterRepo ? theme.primary : theme.textMuted}
+                attributes={props.projectFilterRepo ? TextAttributes.BOLD : undefined}
                 wrapMode="none"
                 flexShrink={0}
               >
-                {props.projectFilterLabel()}
+                {props.projectFilterLabel}
               </text>
-            </Show>
+            ) : null}
             <text fg={theme.border} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
               {"─".repeat(240)}
             </text>
-            <Show when={props.projectOptions().length > 1}>
+            {props.projectOptions.length > 1 ? (
               <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexShrink={0}>
-                {props.projectFilterCountLabel()}
+                {props.projectFilterCountLabel}
               </text>
-            </Show>
+            ) : null}
           </box>
           <scrollbox
             ref={props.setProjectScrollRef}
             flexShrink={0}
             flexGrow={0}
             minHeight={0}
-            maxHeight={props.projectScrollMaxHeight()}
+            maxHeight={props.projectScrollMaxHeight}
             stickyScroll={false}
             verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
           >
             <box flexShrink={0} gap={0}>
-              <For each={props.projectRows()}>{(row) => <ProjectRowCard row={row} shared={props.rowCardShared} />}</For>
+              {props.projectRows.map((row) => (
+                <ProjectRowCard key={row.task.id} row={row} shared={props.rowCardShared} />
+              ))}
             </box>
           </scrollbox>
         </box>
-      </Show>
+      ) : null}
 
       <SectionHeader
         label={t("tasks.header.tasks")}
-        suffix={props.sortMode() === "default" ? undefined : props.sortMode()}
-        topPad={props.projectRows().length > 0}
+        suffix={props.sortMode === "default" ? undefined : props.sortMode}
+        topPad={props.projectRows.length > 0}
       />
       <scrollbox
         ref={props.setTaskScrollRef}
@@ -254,45 +254,43 @@ export function SidebarPanel(props: {
         verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
       >
         <box flexShrink={0} gap={0}>
-          <For each={props.taskRows()}>{(row) => <TaskRowCard row={row} shared={props.rowCardShared} />}</For>
-          <Show when={props.flatIds().length === 0}>
+          {props.taskRows.map((row) => (
+            <TaskRowCard key={row.task.id} row={row} shared={props.rowCardShared} />
+          ))}
+          {props.flatIds.length === 0 ? (
             <box paddingTop={1} paddingLeft={1}>
               <text fg={theme.textMuted}>
                 {t(
                   sidebarEmptyStateKey({
-                    searching: props.searchMode() && props.searchQuery().trim().length > 0,
-                    projectFilter: props.projectFilterRepo() !== null,
-                    view: props.view(),
+                    searching: props.searchMode && props.searchQuery.trim().length > 0,
+                    projectFilter: props.projectFilterRepo !== null,
+                    view: props.view,
                   }),
                 )}
               </text>
             </box>
-          </Show>
-          <Show
-            when={
-              props.projectFilterRepo() &&
-              props.flatIds().length > 0 &&
-              !props.hasTaskRows() &&
-              !(props.searchMode() && props.searchQuery().trim().length > 0)
-            }
-          >
+          ) : null}
+          {props.projectFilterRepo &&
+          props.flatIds.length > 0 &&
+          !props.hasTaskRows &&
+          !(props.searchMode && props.searchQuery.trim().length > 0) ? (
             <box paddingTop={1} paddingLeft={1}>
               <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
-                {t(sidebarEmptyStateKey({ searching: false, projectFilter: true, view: props.view() }))}
+                {t(sidebarEmptyStateKey({ searching: false, projectFilter: true, view: props.view }))}
               </text>
             </box>
-          </Show>
-          <Show when={props.view() === "archived" && props.flatIds().length > 0}>
+          ) : null}
+          {props.view === "archived" && props.flatIds.length > 0 ? (
             <box paddingTop={1} paddingLeft={1}>
               <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
                 {t("tasks.archiveHint")}
               </text>
             </box>
-          </Show>
+          ) : null}
         </box>
       </scrollbox>
 
-      <Show when={props.zenActive?.()}>
+      {props.zenActive ? (
         <box flexShrink={0} paddingLeft={1} paddingRight={1} paddingTop={1}>
           <text
             fg={theme.accent}
@@ -303,11 +301,9 @@ export function SidebarPanel(props: {
             ☯ ZEN
           </text>
         </box>
-      </Show>
+      ) : null}
 
-      <Show when={props.renderHoverFallback}>
-        <SidebarHoverTooltip hover={props.hover} dims={props.dims} />
-      </Show>
+      {props.renderHoverFallback ? <SidebarHoverTooltip hover={props.hover} dims={props.dims} /> : null}
     </box>
   )
 }

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -1,0 +1,262 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React sidebar row cards (issue #15, G3) — the
+ * `src/tui/panes/sidebar/row-cards.tsx` counterpart. Row derivation
+ * (`buildSidebarRowView`), the `+N −M` pollers, and the tone/label helpers
+ * are the shared framework-free modules; this file owns only React
+ * rendering.
+ *
+ * Poller contract (async canon): the fire-and-forget `poll*` calls live in
+ * effects keyed on the Sidebar's `branchTick` (never in render), while the
+ * cached `read` side (`worktreeChanges` / `currentBranch`) is a plain
+ * synchronous getter read at render time. A finishing poll surfaces on the
+ * next tick re-render (≤100ms via the spinner tick) instead of notifying —
+ * the Solid signal's push is replaced by the tick's pull.
+ */
+
+import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
+import { type BoxRenderable, TextAttributes } from "@opentui/core"
+import { type ReactNode, useEffect } from "react"
+import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
+import type { SidebarRow } from "../../../tui/panes/sidebar/groups"
+import { spacedTitle } from "../../../tui/panes/sidebar/labels"
+import { buildSidebarRowView, prCheckChip, withSpinnerFrame } from "../../../tui/panes/sidebar/row-view"
+import { taskIsLive, toneColor, truncateBranchLabel } from "../../../tui/panes/sidebar/view-core"
+import { type WorktreeChanges, pickPushedChanges } from "../../../tui/panes/sidebar/worktree-changes"
+import { pollWorktreeChanges, worktreeChanges } from "../../../tui/panes/sidebar/worktree-changes-poller"
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+import type { ChatRunState, SidebarHover } from "./types"
+
+export type SidebarRowCardSharedProps = {
+  readonly selectedId: string | null
+  readonly cursorIndex: number
+  readonly setCursorIndex: (index: number) => void
+  readonly rowEls: Map<number, BoxRenderable>
+  readonly onSelect: (id: string) => void
+  readonly activateRow: (id: string) => void
+  readonly activateOnClick?: boolean
+  readonly setHover: (hover: SidebarHover | null) => void
+  readonly clearHoverForTask: (taskId: string) => void
+  readonly branchTick: number
+  readonly spinnerFrame: number
+  readonly titleBudget: number
+  readonly subtitleBudget: number
+  readonly chatRunState?: ReadonlyMap<string, ChatRunState>
+  readonly engineState?: ReadonlyMap<string, TaskEngineState>
+  readonly taskJobs?: ReadonlyMap<string, TaskJobState>
+  readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
+  readonly moveMode?: boolean
+}
+
+/**
+ * Per-row `+N −M` counts: daemon-pushed when available, else the local
+ * poller cache (poll scheduled in an effect; archived rows never poll).
+ */
+function useChanges(shared: SidebarRowCardSharedProps, task: SidebarRow["task"]): WorktreeChanges {
+  const pushed = pickPushedChanges(shared.worktreeChanges, task.worktreePath)
+  const hasPushed = pushed !== null
+  useEffect(() => {
+    // Dependency-only invalidation key: re-poll on the sidebar's ~2s tick.
+    void shared.branchTick
+    if (hasPushed || task.archived) return
+    pollWorktreeChanges(task.worktreePath)
+  }, [hasPushed, task.archived, task.worktreePath, shared.branchTick])
+  return pushed ?? worktreeChanges(task.worktreePath)
+}
+
+function RowBody(props: {
+  readonly row: SidebarRow
+  readonly shared: SidebarRowCardSharedProps
+  readonly children: ReactNode
+}) {
+  const { theme } = useTheme()
+  const task = props.row.task
+  const flatIndex = props.row.flatIndex
+  const shared = props.shared
+  return (
+    // biome-ignore lint/a11y/useKeyWithMouseEvents: opentui terminal UI has no DOM focus model; hover is pointer-only while keyboard nav exposes the same row detail by selection.
+    <box
+      ref={(renderable: BoxRenderable | null) => {
+        if (!renderable) return
+        shared.rowEls.set(flatIndex, renderable)
+        // React 19 ref cleanup — same "only if still ours" guard as Solid.
+        return () => {
+          if (shared.rowEls.get(flatIndex) === renderable) shared.rowEls.delete(flatIndex)
+        }
+      }}
+      width="100%"
+      flexDirection="column"
+      gap={0}
+      backgroundColor={flatIndex === shared.cursorIndex ? theme.backgroundElement : undefined}
+      onMouseUp={() => {
+        shared.setCursorIndex(flatIndex)
+        shared.onSelect(task.id)
+        if (shared.activateOnClick) shared.activateRow(task.id)
+      }}
+      onMouseOver={(event) => shared.setHover({ task, x: event.x, y: event.y })}
+      onMouseOut={() => shared.clearHoverForTask(task.id)}
+    >
+      {props.children}
+    </box>
+  )
+}
+
+export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
+  const { theme } = useTheme()
+  const shared = props.shared
+  const task = props.row.task
+  const flatIndex = props.row.flatIndex
+  const isCursor = flatIndex === shared.cursorIndex
+  const isSelected = task.id === shared.selectedId
+  const changes = useChanges(shared, task)
+  useEffect(() => {
+    // Dependency-only invalidation key: re-poll on the sidebar's ~2s tick.
+    void shared.branchTick
+    pollCurrentBranch(task.repo)
+  }, [task.repo, shared.branchTick])
+  const rowView = withSpinnerFrame(
+    buildSidebarRowView({
+      task,
+      activity: shared.engineState?.get(task.id),
+      job: shared.taskJobs?.get(task.id),
+      live: taskIsLive(task.id, shared.chatRunState),
+      spinnerFrame: 0,
+      subtitleBudget: shared.subtitleBudget,
+      truncateBranch: truncateBranchLabel,
+      mainBranch: currentBranch(task.repo),
+    }),
+    () => shared.spinnerFrame,
+  )
+  const stateColor = !rowView.loading ? theme.primary : toneColor(theme, rowView.tone)
+  const barColor = isCursor ? theme.focusAccent : isSelected ? theme.primary : undefined
+  const barGlyph = isCursor || isSelected ? "▌" : " "
+
+  return (
+    <box flexDirection="column" gap={0} paddingBottom={0}>
+      <RowBody row={props.row} shared={shared}>
+        <box flexDirection="row" gap={0}>
+          <text fg={barColor} wrapMode="none">
+            {barGlyph}
+          </text>
+          <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
+            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none">
+              {rowView.projectGlyph}
+            </text>
+            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none" flexGrow={1}>
+              {spacedTitle(rowView.titleText, shared.titleBudget)}
+            </text>
+          </box>
+        </box>
+        <box flexDirection="row" gap={0}>
+          <text fg={barColor} wrapMode="none">
+            {barGlyph}
+          </text>
+          <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
+            <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
+              {rowView.subtitleText}
+            </text>
+            {changes.added > 0 ? (
+              <text fg={theme.success} wrapMode="none">
+                +{changes.added}
+              </text>
+            ) : null}
+            {changes.deleted > 0 ? (
+              <text fg={theme.error} wrapMode="none">
+                −{changes.deleted}
+              </text>
+            ) : null}
+          </box>
+        </box>
+      </RowBody>
+    </box>
+  )
+}
+
+export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
+  const { theme } = useTheme()
+  const t = useT()
+  const shared = props.shared
+  const task = props.row.task
+  const flatIndex = props.row.flatIndex
+  const isCursor = flatIndex === shared.cursorIndex
+  const isSelected = task.id === shared.selectedId
+  const changes = useChanges(shared, task)
+  const rowView = withSpinnerFrame(
+    buildSidebarRowView({
+      task,
+      activity: shared.engineState?.get(task.id),
+      job: shared.taskJobs?.get(task.id),
+      live: taskIsLive(task.id, shared.chatRunState),
+      spinnerFrame: 0,
+      subtitleBudget: shared.subtitleBudget,
+      truncateBranch: truncateBranchLabel,
+      mainBranch: "",
+    }),
+    () => shared.spinnerFrame,
+  )
+  const stateColor = toneColor(theme, rowView.tone)
+  const barColor = isCursor ? theme.focusAccent : isSelected ? theme.primary : undefined
+  const barGlyph = isCursor || isSelected ? "▌" : " "
+  const chip = prCheckChip(task)
+
+  return (
+    <box flexDirection="column" gap={0} paddingBottom={1}>
+      <RowBody row={props.row} shared={shared}>
+        <box flexDirection="row" gap={0}>
+          <text fg={barColor} wrapMode="none">
+            {barGlyph}
+          </text>
+          <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
+            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none">
+              {rowView.stateGlyph}
+            </text>
+            <text
+              fg={theme.text}
+              attributes={isSelected || isCursor ? TextAttributes.BOLD : undefined}
+              wrapMode="none"
+              flexGrow={1}
+            >
+              {spacedTitle(rowView.titleText, shared.titleBudget)}
+            </text>
+            {shared.moveMode && isCursor ? (
+              <text fg={theme.warning} wrapMode="none">
+                {t("tasks.moveChip")}
+              </text>
+            ) : null}
+          </box>
+        </box>
+        <box flexDirection="row" gap={0}>
+          <text fg={barColor} wrapMode="none">
+            {barGlyph}
+          </text>
+          <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
+            <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
+              {rowView.subtitleText}
+            </text>
+            {task.pinned === true ? (
+              <text fg={theme.warning} wrapMode="none">
+                ▴
+              </text>
+            ) : null}
+            {chip ? (
+              <text fg={toneColor(theme, chip.tone)} wrapMode="none">
+                {chip.glyph}
+              </text>
+            ) : null}
+            {changes.added > 0 ? (
+              <text fg={theme.success} wrapMode="none">
+                +{changes.added}
+              </text>
+            ) : null}
+            {changes.deleted > 0 ? (
+              <text fg={theme.error} wrapMode="none">
+                −{changes.deleted}
+              </text>
+            ) : null}
+          </box>
+        </box>
+      </RowBody>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -1,0 +1,62 @@
+/**
+ * React sidebar prop types (issue #15, G3). Same surface as the Solid
+ * `src/tui/panes/sidebar/types.ts`, with the idiomatic React translation:
+ * every `Accessor<T>` prop becomes a plain `T` — the host re-renders the
+ * Sidebar when the value changes, so per-read reactivity has no equivalent.
+ * Callback props are unchanged. Shared data shapes (`SidebarHover`,
+ * `ChatRunState`, `WorktreeChanges`) are the framework-free originals.
+ */
+
+import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
+import type { Task } from "@/types/task"
+import type { TaskSortMode } from "../../../tui/panes/sidebar/groups"
+import type { ChatRunState, SidebarHover } from "../../../tui/panes/sidebar/types"
+import type { WorktreeChanges } from "../../../tui/panes/sidebar/worktree-changes"
+
+export type { ChatRunState, SidebarHover } from "../../../tui/panes/sidebar/types"
+
+export type SidebarProps = {
+  tasks: readonly Task[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+  /** Fires on keyboard enter, and optionally mouse click in the Tasks pane. */
+  onActivate?: (taskId: string) => void
+  /** Task pane opts in because click-to-switch is cheap there. */
+  activateOnClick?: boolean
+  /** Keep a task-bound pane visually pinned to its own task after jump-away. */
+  pinnedSelection?: boolean
+  focused?: boolean
+  onDeleteRequest?: (taskId: string) => void
+  onArchiveRequest?: (taskId: string) => void
+  onLocalMergeRequest?: (taskId: string) => void
+  moveMode?: boolean
+  onMoveRequest?: (taskId: string, delta: -1 | 1) => void
+  onMoveModeExit?: () => void
+  onRenameRequest?: (taskId: string) => void
+  onPinRequest?: (taskId: string) => void
+  onPreviewToggleRequest?: (taskId: string) => void
+  /** Presence (non-undefined) turns on the sort toggle, like the Solid accessor. */
+  sortMode?: TaskSortMode
+  onSortModeToggle?: () => void
+  /** Presence (non-undefined, null = "all") makes the filter host-controlled. */
+  projectFilter?: string | null
+  onProjectFilterChange?: (repo: string | null) => void
+  onSearchActiveChange?: (active: boolean) => void
+  onCursorChange?: (taskId: string | null) => void
+  /** Optional width override; defaults to the sidebar rail width. */
+  width?: number
+  headerStatus?: { label: string; emphasize: boolean } | null
+  onHeaderStatusClick?: () => void
+  onAddTask?: () => void
+  zenActive?: boolean
+  onZenClick?: () => void
+  chatRunState?: ReadonlyMap<string, ChatRunState>
+  engineState?: ReadonlyMap<string, TaskEngineState>
+  taskJobs?: ReadonlyMap<string, TaskJobState>
+  worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
+  /**
+   * Parent-level overlay hook for native workspace. When omitted, Sidebar
+   * renders its own local fallback tooltip for standalone/tmux pane hosts.
+   */
+  onHoverChange?: (hover: SidebarHover | null) => void
+}

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -17,19 +17,24 @@ import {
   splitSidebarRows,
 } from "./groups"
 import { useSidebarBindings } from "./keys"
-import { SidebarPanel, VIEW_TABS } from "./panel"
+import { SidebarPanel } from "./panel"
 import type { SidebarRowCardSharedProps } from "./row-cards"
 import { IN_PROGRESS_SPINNER, SPINNER_FRAME_MS } from "./row-view"
 import type { SidebarHover, SidebarProps } from "./types"
+import {
+  MAIN_BRANCH_POLL_MS,
+  SIDEBAR_WIDTH,
+  cycleViewTarget,
+  projectScrollMaxHeightFor,
+  projectTaskCountKey,
+  searchQueryKeystroke,
+  subtitleBudgetFor,
+  titleBudgetFor,
+} from "./view-core"
 
 export type { ChatRunState, SidebarHover, SidebarProps } from "./types"
 export { approxCellWidth } from "./hover-tooltip"
-
-/** Default sidebar width — task-list rail matching the tmux Tasks pane. */
-const SIDEBAR_WIDTH = 32
-
-/** Polling interval for the per-main-row git branch refresh. */
-export const MAIN_BRANCH_POLL_MS = 2_000
+export { MAIN_BRANCH_POLL_MS } from "./view-core"
 
 export function Sidebar(props: SidebarProps) {
   const focusedAccessor = () => (props.focused ? props.focused() : true)
@@ -98,23 +103,10 @@ export function Sidebar(props: SidebarProps) {
     const r = useRenderer()
     if (!r) return
     const listener = (evt: KeyEvent): void => {
-      if (evt.defaultPrevented) return
       if (!focusedAccessor()) return
-      if (evt.ctrl || evt.meta || evt.option) return
-      if (evt.name === "backspace") {
-        setSearchQuery((q) => q.slice(0, -1))
-        return
-      }
-      // Printable single chars only — opentui's KeyEvent.sequence
-      // holds the raw byte that arrived; non-printables (esc, arrows,
-      // function keys) have multi-byte sequences or names like
-      // "escape" / "return" / "up" that we already handle through
-      // Block C bindings.
-      const seq = evt.sequence
-      if (!seq || seq.length !== 1) return
-      const code = seq.charCodeAt(0)
-      if (code < 32 || code === 127) return
-      setSearchQuery((q) => q + seq)
+      // The printable/backspace/modifier policy is the shared reducer
+      // (view-core.ts, shared with the React port); null = not ours.
+      setSearchQuery((q) => searchQueryKeystroke(q, evt) ?? q)
     }
     r.keyInput.on("keypress", listener)
     onCleanup(() => r.keyInput.off("keypress", listener))
@@ -172,7 +164,7 @@ export function Sidebar(props: SidebarProps) {
   })
   const projectFilterCountLabel = createMemo(() => {
     const count = projectFilterCount()
-    return `${count} ${count === 1 ? t("tasks.project.taskSingular") : t("tasks.project.taskPlural")}`
+    return `${count} ${t(projectTaskCountKey(count))}`
   })
   const rows = createMemo<readonly SidebarRow[]>(
     (prev) =>
@@ -226,12 +218,9 @@ export function Sidebar(props: SidebarProps) {
   // title gets the WHOLE first line and the branch the whole second line —
   // each just truncated to its own line budget.
   const effectiveWidth = (): number => (props.width ? props.width() : SIDEBAR_WIDTH)
-  // Line 1: container pad (4) + accent edge (1) + badge + its gap (2) +
-  // scrollbar (1) + right pad (1) = 9 reserved.
-  const titleBudget = createMemo(() => Math.max(6, effectiveWidth() - 9))
-  // Line 2: the above plus the badge-column indent (2) and a reserve for the
-  // right-aligned `+N −M` chip (~6) ≈ 16 reserved.
-  const subtitleBudget = createMemo(() => Math.max(6, effectiveWidth() - 16))
+  // Reserved-cell math lives in view-core.ts (shared with the React port).
+  const titleBudget = createMemo(() => titleBudgetFor(effectiveWidth()))
+  const subtitleBudget = createMemo(() => subtitleBudgetFor(effectiveWidth()))
 
   // Hover tooltip (KOB): on a narrow rail the responsive columns hide the
   // branch and the title is ellipsised, so hovering a row pops a detail
@@ -246,11 +235,7 @@ export function Sidebar(props: SidebarProps) {
   // cap from terminal cells and clamp it to a small, predictable rail band.
   // Then shrink to the actual project rows (each card is 2 lines, no inter-card
   // gap) so a one-project workspace doesn't reserve the full cap as dead space.
-  const projectScrollMaxHeight = createMemo(() => {
-    const cellCap = Math.max(2, Math.min(10, Math.floor(dims().height * 0.25)))
-    const contentHeight = Math.max(2, projectRows().length * 2)
-    return Math.min(cellCap, contentHeight)
-  })
+  const projectScrollMaxHeight = createMemo(() => projectScrollMaxHeightFor(dims().height, projectRows().length))
   const [hover, setLocalHover] = createSignal<SidebarHover | null>(null)
   const setHover = (next: SidebarHover | null): void => {
     setLocalHover(next)
@@ -367,12 +352,8 @@ export function Sidebar(props: SidebarProps) {
    * "[ goes right" bug was a pinyin-IME swallow.)
    */
   function cycleView(delta: -1 | 1): void {
-    const cur = view()
-    const idx = VIEW_TABS.findIndex((t) => t.view === cur)
-    if (idx < 0) return
-    const next = (idx + delta + VIEW_TABS.length) % VIEW_TABS.length
-    const target = VIEW_TABS[next]
-    if (target) setView(target.view)
+    const target = cycleViewTarget(view(), delta)
+    if (target) setView(target)
   }
 
   // Activate (jump to) a row — the single funnel for both the keyboard `enter`

--- a/packages/kobe/src/tui/panes/sidebar/mock-fixtures.ts
+++ b/packages/kobe/src/tui/panes/sidebar/mock-fixtures.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared mock task fixtures for the sidebar smoke hosts (issue #15, G3).
+ * Framework-free, so the Solid and React mock entries can render the same
+ * synthetic task list without a daemon, tasks.json, or real worktrees.
+ * Paths point under /mock so the git pollers fail closed (chips hidden).
+ */
+
+import type { Task } from "@/types/task"
+import { toTaskId } from "@/types/task"
+
+export const MOCK_SIDEBAR_REPO = "/mock/repos/kobe"
+
+/** A representative task list: project row, running/pinned/backlog/archived. */
+export function seedSidebarTasks(): readonly Task[] {
+  const ts = "2026-07-01T00:00:00.000Z"
+  const base = {
+    repo: MOCK_SIDEBAR_REPO,
+    createdAt: ts,
+    updatedAt: ts,
+  }
+  return [
+    {
+      ...base,
+      id: toTaskId("mock-main"),
+      title: "kobe",
+      branch: "",
+      worktreePath: MOCK_SIDEBAR_REPO,
+      kind: "main",
+      status: "backlog",
+      archived: false,
+    },
+    {
+      ...base,
+      id: toTaskId("mock-alpha"),
+      title: "Port sidebar to React",
+      branch: "feat/react-sidebar-pane",
+      worktreePath: "/mock/worktrees/react-sidebar",
+      kind: "task",
+      status: "in_progress",
+      archived: false,
+      pinned: true,
+      vendor: "claude",
+    },
+    {
+      ...base,
+      id: toTaskId("mock-beta"),
+      title: "Fix transcript cache identity",
+      branch: "fix/transcript-cache",
+      worktreePath: "/mock/worktrees/transcript-cache",
+      kind: "task",
+      status: "in_review",
+      archived: false,
+      vendor: "claude",
+      prStatus: {
+        provider: "github",
+        lifecycle: "open",
+        checkState: "passing",
+      },
+    },
+    {
+      ...base,
+      id: toTaskId("mock-gamma"),
+      title: "调研 tmux 布局持久化",
+      branch: "spike/tmux-layout",
+      worktreePath: "/mock/worktrees/tmux-layout",
+      kind: "task",
+      status: "backlog",
+      archived: false,
+      vendor: "codex",
+    },
+    {
+      ...base,
+      id: toTaskId("mock-archived"),
+      title: "Old shipped experiment",
+      branch: "feat/old-experiment",
+      worktreePath: "/mock/worktrees/old-experiment",
+      kind: "task",
+      status: "done",
+      archived: true,
+      vendor: "claude",
+    },
+  ]
+}

--- a/packages/kobe/src/tui/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/row-cards.tsx
@@ -4,45 +4,14 @@ import { type BoxRenderable, TextAttributes } from "@opentui/core"
 import type { Accessor, JSX } from "solid-js"
 import { Show, createMemo, onCleanup } from "solid-js"
 import { useTheme } from "../../context/theme"
-import { truncateEnd } from "../../lib/truncate"
 import { currentBranch, pollCurrentBranch } from "./git-head"
 import type { SidebarRow } from "./groups"
 import { spacedTitle } from "./labels"
-import type { SidebarTone } from "./row-view"
 import { buildSidebarRowView, prCheckChip, withSpinnerFrame } from "./row-view"
 import type { ChatRunState, SidebarHover } from "./types"
+import { taskIsLive, toneColor, truncateBranchLabel } from "./view-core"
 import { type WorktreeChanges, pickPushedChanges, sameWorktreeChanges } from "./worktree-changes"
 import { pollWorktreeChanges, worktreeChanges } from "./worktree-changes-poller"
-
-const BRANCH_LABEL_MAX = 16
-
-function truncateBranchLabel(branch: string, max = BRANCH_LABEL_MAX): string {
-  return truncateEnd(branch, max)
-}
-
-function taskIsLive(taskId: string, map: ReadonlyMap<string, ChatRunState> | undefined): boolean {
-  if (!map) return false
-  const prefix = `${taskId}:`
-  for (const [key, state] of map) {
-    if (state === "running" && key.startsWith(prefix)) return true
-  }
-  return false
-}
-
-function toneColor(theme: ReturnType<typeof useTheme>["theme"], tone: SidebarTone) {
-  switch (tone) {
-    case "success":
-      return theme.success
-    case "warning":
-      return theme.warning
-    case "primary":
-      return theme.primary
-    case "error":
-      return theme.error
-    default:
-      return theme.textMuted
-  }
-}
 
 export type SidebarRowCardSharedProps = {
   readonly selectedId: Accessor<string | null>

--- a/packages/kobe/src/tui/panes/sidebar/view-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/view-core.ts
@@ -1,0 +1,154 @@
+/**
+ * Framework-free view logic shared by the Solid sidebar and its React port
+ * (issue #15, G3). Pure derivations only — no Solid, no React, no opentui:
+ * view-tab cycling, line budgets, the search-input keystroke reducer,
+ * empty-state / label i18n-key selection, and small row helpers. Both
+ * renderers consume this module so the pair cannot drift (theme-core /
+ * lookup / message-core precedent).
+ */
+
+import { truncateEnd } from "../../lib/truncate"
+import type { SidebarView } from "./groups"
+import type { SidebarTone } from "./row-view"
+import type { ChatRunState } from "./types"
+
+/** Default sidebar width — task-list rail matching the tmux Tasks pane. */
+export const SIDEBAR_WIDTH = 32
+
+/** Polling interval for the per-main-row git branch refresh. */
+export const MAIN_BRANCH_POLL_MS = 2_000
+
+/** The view tab strip, in `[` / `]` cycle order. */
+export const VIEW_TABS: ReadonlyArray<{ view: SidebarView }> = [{ view: "active" }, { view: "archived" }]
+
+/** i18n key for a view tab's label — callers translate with their own `t`. */
+export function viewTabLabelKey(view: SidebarView): string {
+  switch (view) {
+    case "active":
+      return "tasks.view.workspace"
+    case "archived":
+      return "tasks.view.archives"
+  }
+}
+
+/**
+ * Cycle the view by `delta` (-1 = `[` / left, +1 = `]` / right). Wraps:
+ * `[` from the leftmost lands on the rightmost and vice versa (loop is the
+ * confirmed intended behavior — see the Solid Sidebar's history note).
+ * Returns null when `cur` isn't a known tab.
+ */
+export function cycleViewTarget(cur: SidebarView, delta: -1 | 1): SidebarView | null {
+  const idx = VIEW_TABS.findIndex((t) => t.view === cur)
+  if (idx < 0) return null
+  return VIEW_TABS[(idx + delta + VIEW_TABS.length) % VIEW_TABS.length]?.view ?? null
+}
+
+/**
+ * Two-line card budgets. Line 1: container pad (4) + accent edge (1) +
+ * badge + its gap (2) + scrollbar (1) + right pad (1) = 9 reserved.
+ */
+export function titleBudgetFor(width: number): number {
+  return Math.max(6, width - 9)
+}
+
+/**
+ * Line 2: the title reserve plus the badge-column indent (2) and a reserve
+ * for the right-aligned `+N −M` chip (~6) ≈ 16 reserved.
+ */
+export function subtitleBudgetFor(width: number): number {
+  return Math.max(6, width - 16)
+}
+
+/**
+ * PROJECTS scroll-region height: cap derived from terminal cells, clamped
+ * to a small rail band, then shrunk to the actual content (each project
+ * card is 2 lines) so a one-project workspace doesn't reserve dead space.
+ */
+export function projectScrollMaxHeightFor(terminalHeight: number, projectRowCount: number): number {
+  const cellCap = Math.max(2, Math.min(10, Math.floor(terminalHeight * 0.25)))
+  const contentHeight = Math.max(2, projectRowCount * 2)
+  return Math.min(cellCap, contentHeight)
+}
+
+/** i18n key for the project-filter `N task(s)` count label. */
+export function projectTaskCountKey(count: number): string {
+  return count === 1 ? "tasks.project.taskSingular" : "tasks.project.taskPlural"
+}
+
+/**
+ * i18n key for the task list's empty-state / scoped-empty placeholder.
+ * `searching` wins (no fuzzy match), then a project-scoped empty, then the
+ * plain per-view empty copy.
+ */
+export function sidebarEmptyStateKey(opts: {
+  readonly searching: boolean
+  readonly projectFilter: boolean
+  readonly view: SidebarView
+}): string {
+  if (opts.searching) return "tasks.empty.noMatchSearch"
+  if (opts.projectFilter) {
+    return opts.view === "active" ? "tasks.empty.noActiveProject" : "tasks.empty.noArchivedProject"
+  }
+  return opts.view === "active" ? "tasks.empty.noActive" : "tasks.empty.noArchived"
+}
+
+/** Widest branch label a two-line card renders before tail-truncation. */
+export const BRANCH_LABEL_MAX = 16
+
+export function truncateBranchLabel(branch: string, max = BRANCH_LABEL_MAX): string {
+  return truncateEnd(branch, max)
+}
+
+/** True when any chat tab of `taskId` is in the `running` state. */
+export function taskIsLive(taskId: string, map: ReadonlyMap<string, ChatRunState> | undefined): boolean {
+  if (!map) return false
+  const prefix = `${taskId}:`
+  for (const [key, state] of map) {
+    if (state === "running" && key.startsWith(prefix)) return true
+  }
+  return false
+}
+
+/** Map a row tone to its theme slot. Works on the Solid Proxy and the plain React theme alike. */
+export function toneColor<V>(theme: Record<SidebarTone, V>, tone: SidebarTone): V {
+  switch (tone) {
+    case "success":
+      return theme.success
+    case "warning":
+      return theme.warning
+    case "primary":
+      return theme.primary
+    case "error":
+      return theme.error
+    default:
+      return theme.textMuted
+  }
+}
+
+/** The subset of a keypress the search-input reducer reads. */
+export type SearchKeystroke = {
+  readonly defaultPrevented: boolean
+  readonly ctrl?: boolean
+  readonly meta?: boolean
+  readonly option?: boolean
+  readonly name?: string
+  readonly sequence?: string
+}
+
+/**
+ * `/`-search inline-input reducer: the next query for a keypress, or null
+ * when the key doesn't belong to the input (already consumed by a chord,
+ * modifier-prefixed, or non-printable — esc/arrows/function keys have
+ * multi-byte sequences or names the search-mode bindings already handle).
+ * Backspace pops the last char.
+ */
+export function searchQueryKeystroke(query: string, evt: SearchKeystroke): string | null {
+  if (evt.defaultPrevented) return null
+  if (evt.ctrl || evt.meta || evt.option) return null
+  if (evt.name === "backspace") return query.slice(0, -1)
+  const seq = evt.sequence
+  if (!seq || seq.length !== 1) return null
+  const code = seq.charCodeAt(0)
+  if (code < 32 || code === 127) return null
+  return query + seq
+}

--- a/packages/kobe/test/tui-react/sidebar-mock-fixtures.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-mock-fixtures.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Invariants for the shared sidebar mock fixtures (issue #15, G3): the
+ * smoke hosts (Solid + React) and the render-proof grep both key off this
+ * data, so pin the shape — a project row that stops satisfying the `main`
+ * contract or a renamed fixture title would silently hollow out the
+ * dev:mock-react-sidebar gate.
+ */
+
+import { describe, expect, it } from "vitest"
+import { buildRows, splitSidebarRows } from "../../src/tui/panes/sidebar/groups"
+import { MOCK_SIDEBAR_REPO, seedSidebarTasks } from "../../src/tui/panes/sidebar/mock-fixtures"
+
+describe("seedSidebarTasks", () => {
+  it("provides unique ids and one main project row satisfying the main contract", () => {
+    const tasks = seedSidebarTasks()
+    expect(new Set(tasks.map((t) => t.id)).size).toBe(tasks.length)
+    const mains = tasks.filter((t) => t.kind === "main")
+    expect(mains).toHaveLength(1)
+    // main rows pin the repo root: worktreePath === repo, branch === ""
+    expect(mains[0]?.repo).toBe(MOCK_SIDEBAR_REPO)
+    expect(mains[0]?.worktreePath).toBe(MOCK_SIDEBAR_REPO)
+    expect(mains[0]?.branch).toBe("")
+  })
+
+  it("covers both views and feeds buildRows a project + task split", () => {
+    const tasks = seedSidebarTasks()
+    expect(tasks.some((t) => t.archived)).toBe(true)
+    const { projectRows, taskRows } = splitSidebarRows(buildRows(tasks, "active"))
+    expect(projectRows.length).toBe(1)
+    expect(taskRows.length).toBeGreaterThanOrEqual(2)
+    // Pinned task floats to the top of the TASKS section.
+    expect(taskRows[0]?.task.pinned).toBe(true)
+    // The render-proof grep string stays stable.
+    expect(taskRows.map((r) => r.task.title)).toContain("Port sidebar to React")
+  })
+})

--- a/packages/kobe/test/tui-react/sidebar-view-core.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-view-core.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for `src/tui/panes/sidebar/view-core.ts` — the framework-free
+ * view logic extracted for the React sidebar port (issue #15, G3) and
+ * consumed by BOTH renderers. These pin the shared derivations (tab cycle,
+ * budgets, empty-state key selection, the `/`-search keystroke reducer, and
+ * the small row helpers) so the Solid original and the React port cannot
+ * drift: a behavior change here is a behavior change in two shipped panes.
+ */
+
+import { describe, expect, it } from "vitest"
+import type { ChatRunState } from "../../src/tui/panes/sidebar/types"
+import {
+  BRANCH_LABEL_MAX,
+  type SearchKeystroke,
+  VIEW_TABS,
+  cycleViewTarget,
+  projectScrollMaxHeightFor,
+  projectTaskCountKey,
+  searchQueryKeystroke,
+  sidebarEmptyStateKey,
+  subtitleBudgetFor,
+  taskIsLive,
+  titleBudgetFor,
+  toneColor,
+  truncateBranchLabel,
+  viewTabLabelKey,
+} from "../../src/tui/panes/sidebar/view-core"
+
+describe("view tabs", () => {
+  it("cycles with wrap-around in both directions", () => {
+    expect(VIEW_TABS.map((t) => t.view)).toEqual(["active", "archived"])
+    expect(cycleViewTarget("active", 1)).toBe("archived")
+    expect(cycleViewTarget("archived", 1)).toBe("active")
+    expect(cycleViewTarget("active", -1)).toBe("archived")
+    expect(cycleViewTarget("archived", -1)).toBe("active")
+  })
+
+  it("maps every view to an i18n label key", () => {
+    expect(viewTabLabelKey("active")).toBe("tasks.view.workspace")
+    expect(viewTabLabelKey("archived")).toBe("tasks.view.archives")
+  })
+})
+
+describe("line budgets", () => {
+  it("reserves 9 cells for the title line and 16 for the subtitle, floored at 6", () => {
+    expect(titleBudgetFor(32)).toBe(23)
+    expect(subtitleBudgetFor(32)).toBe(16)
+    // A collapsed pane never produces a <=0 budget.
+    expect(titleBudgetFor(4)).toBe(6)
+    expect(subtitleBudgetFor(10)).toBe(6)
+  })
+
+  it("caps the PROJECTS scroll region and shrinks it to real content", () => {
+    // Tall terminal, many projects: hits the 10-cell rail cap.
+    expect(projectScrollMaxHeightFor(60, 12)).toBe(10)
+    // One project (2-line card): reserves only its own height.
+    expect(projectScrollMaxHeightFor(60, 1)).toBe(2)
+    // Short terminal: the 25%-of-cells cap wins over content.
+    expect(projectScrollMaxHeightFor(16, 5)).toBe(4)
+    // Degenerate terminal still yields the 2-cell floor.
+    expect(projectScrollMaxHeightFor(3, 5)).toBe(2)
+  })
+})
+
+describe("i18n key selection", () => {
+  it("picks the empty-state key by search > project filter > view", () => {
+    expect(sidebarEmptyStateKey({ searching: true, projectFilter: true, view: "active" })).toBe(
+      "tasks.empty.noMatchSearch",
+    )
+    expect(sidebarEmptyStateKey({ searching: false, projectFilter: true, view: "active" })).toBe(
+      "tasks.empty.noActiveProject",
+    )
+    expect(sidebarEmptyStateKey({ searching: false, projectFilter: true, view: "archived" })).toBe(
+      "tasks.empty.noArchivedProject",
+    )
+    expect(sidebarEmptyStateKey({ searching: false, projectFilter: false, view: "active" })).toBe(
+      "tasks.empty.noActive",
+    )
+    expect(sidebarEmptyStateKey({ searching: false, projectFilter: false, view: "archived" })).toBe(
+      "tasks.empty.noArchived",
+    )
+  })
+
+  it("pluralizes the project task-count label key", () => {
+    expect(projectTaskCountKey(1)).toBe("tasks.project.taskSingular")
+    expect(projectTaskCountKey(0)).toBe("tasks.project.taskPlural")
+    expect(projectTaskCountKey(2)).toBe("tasks.project.taskPlural")
+  })
+})
+
+describe("searchQueryKeystroke", () => {
+  const key = (over: Partial<SearchKeystroke>): SearchKeystroke => ({ defaultPrevented: false, ...over })
+
+  it("appends printable single chars and pops on backspace", () => {
+    expect(searchQueryKeystroke("ko", key({ sequence: "b" }))).toBe("kob")
+    expect(searchQueryKeystroke("kob", key({ name: "backspace" }))).toBe("ko")
+    expect(searchQueryKeystroke("", key({ name: "backspace" }))).toBe("")
+  })
+
+  it("ignores consumed, modifier-prefixed, and non-printable keys", () => {
+    expect(searchQueryKeystroke("k", key({ sequence: "j", defaultPrevented: true }))).toBeNull()
+    expect(searchQueryKeystroke("k", key({ sequence: "p", ctrl: true }))).toBeNull()
+    expect(searchQueryKeystroke("k", key({ sequence: "p", meta: true }))).toBeNull()
+    expect(searchQueryKeystroke("k", key({ sequence: "p", option: true }))).toBeNull()
+    // esc / arrows: multi-byte sequences or empty
+    expect(searchQueryKeystroke("k", key({ name: "escape", sequence: "" }))).toBeNull()
+    expect(searchQueryKeystroke("k", key({ name: "up", sequence: "[A" }))).toBeNull()
+    // control chars and DEL are not printable
+    expect(searchQueryKeystroke("k", key({ sequence: "" }))).toBeNull()
+    expect(searchQueryKeystroke("k", key({ sequence: "" }))).toBeNull()
+    expect(searchQueryKeystroke("k", key({ sequence: undefined }))).toBeNull()
+  })
+})
+
+describe("row helpers", () => {
+  it("truncateBranchLabel caps at BRANCH_LABEL_MAX by default", () => {
+    const long = "feature/very-long-branch-name"
+    expect(truncateBranchLabel(long).length).toBeLessThanOrEqual(BRANCH_LABEL_MAX)
+    expect(truncateBranchLabel("main")).toBe("main")
+  })
+
+  it("taskIsLive matches only running states under the task's key prefix", () => {
+    const map = new Map<string, ChatRunState>([
+      ["a:tab1", "idle"],
+      ["a:tab2", "running"],
+      ["b:tab1", "running"],
+    ])
+    expect(taskIsLive("a", map)).toBe(true)
+    expect(taskIsLive("c", map)).toBe(false)
+    expect(taskIsLive("a", undefined)).toBe(false)
+    // Prefix discipline: "a" must not match a task id "ab".
+    const tricky = new Map<string, ChatRunState>([["ab:tab1", "running"]])
+    expect(taskIsLive("a", tricky)).toBe(false)
+  })
+
+  it("toneColor maps every tone to its theme slot with textMuted as default", () => {
+    const theme = {
+      success: "S",
+      warning: "W",
+      primary: "P",
+      error: "E",
+      textMuted: "M",
+    } as const
+    expect(toneColor(theme, "success")).toBe("S")
+    expect(toneColor(theme, "warning")).toBe("W")
+    expect(toneColor(theme, "primary")).toBe("P")
+    expect(toneColor(theme, "error")).toBe("E")
+    expect(toneColor(theme, "textMuted")).toBe("M")
+  })
+})


### PR DESCRIPTION
## Summary
- G3 wave 1: the sidebar — the highest-Solid-density pane (33 memo / 23 signal / 15 effect) — reaches parity on the React runtime under `src/tui-react/panes/sidebar/` (views + `[`/`]` cycle, `/`-search with the inline text input, project filter, move mode, cursor policy incl. pinned-selection snap-back, hover tooltip, two-line row cards with the branch/changes pollers and the shared spinner pulse).
- Shared pure logic extracted for both frameworks (theme-core/message-core precedent): `src/tui/panes/sidebar/view-core.ts` (tab cycle, line budgets, PROJECTS scroll cap, `/`-search keystroke reducer, empty-state/label i18n-key selection, `taskIsLive`/`toneColor`/branch truncation) + `src/tui/panes/sidebar/mock-fixtures.ts` — the Solid Sidebar/panel/row-cards now consume the extraction, so the pair cannot drift.
- The ~9 already-framework-free sidebar modules (groups, row-view, controller, git-head, worktree-changes(+poller), hover-layout, labels, fuzzy) are imported as-is; the React `keys.ts` wires the same controller through the render-refreshed-ref `useBindings`.
- **Entry seam deviation (anticipated in the brief):** the sidebar has no CLI subcommand — it mounts inside the tasks-pane host, whose kv/notifications providers are not ported yet (a later G3 slice), so there is no `KOBE_REACT=1` gate to flip for it alone. Parity is proven by the new `dev:mock-react-sidebar` smoke host over the shared fixtures instead; the tasks-pane port will mount this Sidebar behind its own gate.
- Solid side: zero behavior change; the pinned render test (`test/render/sidebar.test.tsx`) stays green untouched.

coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/keys.ts — renderer-bound (imports @opentui/react via tui-react/lib/keymap, not importable under vitest); the chord state machine it wires is the unit-tested shared controller, and the wiring is exercised live by the dev:mock-react-sidebar gate.
coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx — renderer-bound React pane, same rationale as the history-port exemptions (#240); extracted pure logic is unit-tested instead.
coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/panel.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/hover-tooltip.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/mock-host.tsx — dev-only mock entry, same rationale.

## Test plan
- [x] `bun run typecheck` clean
- [x] repo-root `bun run lint` clean
- [x] `bun run test` — fast 2473/2473 + socket 218/218 (new: `sidebar-view-core.test.ts` 11 tests, `sidebar-mock-fixtures.test.ts` 2 tests)
- [x] `bun test test/render/sidebar.test.tsx` — the pinned Solid render test stays green
- [x] `bun run compile` → `release-bin/kobe --version` OK (0.7.63)
- [x] `timeout 6 bun run dev:mock` — Solid mock unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react-sidebar` under a pty (exit 124) — captured ANSI output contains the fixture strings `KOBE`, `kobe` (project row), `Port sidebar to React`, `Fix transcript cache`, and the truncated branch `feat/react-sideb` (proves the row-view truncation path)
- [x] `bun run check-i18n` — 396 keys × 2 locales in sync
- [x] local dry-run of `scripts/coverage-gate.mjs` against this diff: view-core.ts 100%, mock-fixtures.ts 100%, types.ts 100%, keys.ts exempted above
