### PR TITLE
feat: React port of the chat pane (G3 wave 1, issue #15)

### DIFF
--- a/.changeset/react-chat-pane-g3.md
+++ b/.changeset/react-chat-pane-g3.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+React port of the chat pane (issue #15, G3 wave 1). The full native-chat surface — transcript rendering AI SDK UIMessage parts verbatim, the multi-line composer (bash mode, `/` slash dropdown, `@` file mentions, per-key prompt history + ctrl+r palette, image paste, mid-turn queue, model picker, shift+tab permission cycle) — now exists under `src/tui-react/chat/`, sharing all framework-free composer logic with the Solid pane. The key router, composer props, queue-item shape, keybinding table, and placeholder resolver were extracted framework-free (Solid keeps consuming them), and `bun run dev:mock-react-chat` renders the React pane against a scripted fake harness turn. Solid remains the default; the workspace co-mount is unchanged.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -27,6 +27,7 @@
     "dev": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/cli/index.ts",
     "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
     "dev:mock-react": "env KOBE_DEV=1 bun ./src/tui-react/mock/host.tsx",
+    "dev:mock-react-chat": "env KOBE_DEV=1 bun ./src/tui-react/chat/mock-host.tsx",
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
     "dev:sandbox": "bun run scripts/dev-sandbox.ts run",
     "dev:sandbox:reset": "bun run scripts/dev-sandbox.ts reset",

--- a/packages/kobe/src/tui-react/chat/chat-pane.tsx
+++ b/packages/kobe/src/tui-react/chat/chat-pane.tsx
@@ -1,0 +1,410 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React `ChatPane` — the `src/tui/chat/ChatPane.tsx` counterpart (issue #15
+ * G3). Each prompt runs ONE turn through the AI SDK harness backend
+ * (engine/ai-sdk/harness-turn.ts) which streams a growing `UIMessage`
+ * snapshot per chunk; the transcript holds those UIMessages VERBATIM and the
+ * view renders their parts directly (chat-row.tsx). No normalization layer
+ * between the harness stream and the screen.
+ *
+ * React-port seam: `startTurn` is injectable (defaults to the real
+ * `startAiSdkTurn`) so `dev:mock-react-chat` can script a fake turn without
+ * an engine; `initialPrompt` auto-submits once on mount for the same proof.
+ *
+ * ponytail: like the Solid pane, no on-disk history yet — a remounted pane
+ * starts a fresh harness session.
+ */
+
+import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  type AiSdkTurn,
+  type AiSdkTurnOpts,
+  disposeAiSdkRuntime,
+  startAiSdkTurn,
+} from "../../engine/ai-sdk/harness-turn"
+import { engineEntry, getCapabilities } from "../../engine/registry"
+import { permissionModeLabel } from "../../tui/chat/composer/permission-mode"
+import type { ComposerQueuedItem } from "../../tui/chat/composer/queue-item"
+import { loadUserSlashes } from "../../tui/chat/composer/user-slashes"
+import type { PermissionMode } from "../../types/engine"
+import { DEFAULT_TASK_VENDOR } from "../../types/task"
+import type { VendorId } from "../../types/vendor"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { useDialog } from "../ui/dialog"
+import { type ChatItem, ChatRow } from "./chat-row"
+import { Composer, type ComposerSlashEntry } from "./composer"
+import { ModelPicker, type ModelPickerResult } from "./model-picker"
+
+/** Injectable turn runner — the real harness in production, a script in dev:mock. */
+export type StartTurnFn = (opts: AiSdkTurnOpts) => AiSdkTurn
+
+export interface ChatPaneProps {
+  readonly worktree: string
+  /** Task title for the header; falls back to the worktree basename. */
+  readonly title?: string
+  /** Engine vendor recorded on the selected task. Native chat supports Claude and Codex. */
+  readonly vendor?: VendorId
+  /**
+   * Initial permission mode for the composer's shift+tab cycle.
+   * ponytail: the harness turn doesn't forward it yet — UI seed only.
+   */
+  readonly permissionMode?: string
+  /** Whether this pane owns the keyboard (workspace focus). */
+  readonly focused?: () => boolean
+  /** dev:mock seam — fake turn runner. Defaults to the real harness. */
+  readonly startTurn?: StartTurnFn
+  /** dev:mock seam — auto-submit this prompt once on mount. */
+  readonly initialPrompt?: string
+}
+
+/** Scroll cells per pgup/pgdn keypress. */
+const SCROLL_STEP = 10
+
+function basename(p: string): string {
+  const i = p.lastIndexOf("/")
+  return i >= 0 ? p.slice(i + 1) : p
+}
+
+export function ChatTurnErrorBanner(props: { readonly error: string | null }) {
+  const { theme } = useTheme()
+  const t = useT()
+  if (!props.error) return null
+  return (
+    <box flexShrink={0} paddingLeft={1} paddingRight={1} paddingTop={1}>
+      <text fg={theme.error} wrapMode="word">
+        {`${t("chat.errorPrefix")}: ${props.error}`}
+      </text>
+    </box>
+  )
+}
+
+export function ChatPane(props: ChatPaneProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  const dialog = useDialog()
+  const [items, setItems] = useState<readonly ChatItem[]>([])
+  const [running, setRunning] = useState(false)
+  const [turnError, setTurnError] = useState<string | null>(null)
+  const [draft, setDraft] = useState("")
+  const [expanded, setExpanded] = useState(false)
+
+  const vendor = props.vendor ?? DEFAULT_TASK_VENDOR
+  const entry = useMemo(() => engineEntry(vendor), [vendor])
+  const capabilities = useMemo(() => getCapabilities(vendor), [vendor])
+  const identity = entry.identity
+  // Engine-owned capability checks, not vendor-id checks (CLAUDE.md
+  // "Engine-owned UI data"): native-chat backend gates the model controls,
+  // declared permission modes gate the badge/cycle.
+  const nativeChat = entry.nativeChat
+  const harnessVendor = nativeChat?.harnessVendor
+  const hasNativeChat = nativeChat != null
+  const hasPermissionModes = (capabilities?.permissionModes.length ?? 0) > 0
+
+  // Composer state: pinned model (undefined = engine default), permission
+  // mode (shift+tab cycles the engine's list), and the mid-turn queue.
+  const [model, setModel] = useState<ModelPickerResult>(undefined)
+  const [permissionMode, setPermissionMode] = useState<PermissionMode>(() =>
+    capabilities?.permissionModes.some((m) => m.id === props.permissionMode)
+      ? (props.permissionMode as PermissionMode)
+      : "acceptEdits",
+  )
+  const [queue, setQueue] = useState<readonly ComposerQueuedItem[]>([])
+  // Ref twins for the turn pipeline — `drainQueue` fires from a microtask
+  // after `done`, where this-render state reads would be stale.
+  const runningRef = useRef(false)
+  const queueRef = useRef<readonly ComposerQueuedItem[]>([])
+  const setRunningBoth = (v: boolean): void => {
+    runningRef.current = v
+    setRunning(v)
+  }
+  const updateQueue = (fn: (q: readonly ComposerQueuedItem[]) => readonly ComposerQueuedItem[]): void => {
+    queueRef.current = fn(queueRef.current)
+    setQueue(queueRef.current)
+  }
+
+  const activeInterrupt = useRef<(() => void) | undefined>(undefined)
+  const startTurn: StartTurnFn = props.startTurn ?? startAiSdkTurn
+
+  // The AI SDK harness streams growing UIMessage snapshots; the pane
+  // replaces the tail "ui" item per update. Held in a render-refreshed ref
+  // (useBindings pattern) so the async pipeline (drain microtask, queue
+  // callbacks) always dispatches through the LATEST render's closure —
+  // matching Solid's read-signals-at-call-time semantics.
+  const runTurnRef = useRef<(prompt: string) => Promise<void>>(async () => {})
+  runTurnRef.current = async (prompt: string): Promise<void> => {
+    setRunningBoth(true)
+    setTurnError(null)
+    setItems((prev) => [...prev, { kind: "prompt", text: prompt }])
+    let hasTail = false
+    const turn = startTurn({
+      worktree: props.worktree,
+      vendor,
+      model: model?.id,
+      modelEffort: model?.effort,
+      prompt,
+      onUpdate: (assistant) => {
+        setItems((prev) => {
+          const next = hasTail ? prev.slice(0, -1) : prev
+          hasTail = true
+          return [...next, { kind: "ui", msg: assistant }]
+        })
+      },
+    })
+    activeInterrupt.current = turn.interrupt
+    const { error } = await turn.done
+    if (error) {
+      // Banner is ephemeral (cleared on next submit); the error row keeps
+      // the failure in the transcript history.
+      const message = "code" in error ? t("chat.runtimeBusy") : error.message
+      setTurnError(message)
+      setItems((prev) => [...prev, { kind: "error", text: message }])
+    }
+    activeInterrupt.current = undefined
+    setRunningBoth(false)
+    drainQueue()
+  }
+
+  /** FIFO auto-drain: fire the queue head once the turn ends. */
+  function drainQueue(): void {
+    queueMicrotask(() => {
+      if (runningRef.current) return
+      const head = queueRef.current[0]
+      // ponytail: this pane only ever enqueues prompts (no bash items).
+      if (head?.kind !== "prompt") return
+      updateQueue((q) => q.slice(1))
+      void runTurnRef.current(head.text)
+    })
+  }
+
+  /**
+   * Submit pipeline shared by the composer, slash entries, and the queue.
+   * `auto` queues while a turn is in flight; `steer` interrupts the live
+   * turn and lets the drain fire this prompt next.
+   */
+  const submitRef = useRef<(text: string, mode?: "auto" | "steer") => void>(() => {})
+  submitRef.current = (text: string, mode: "auto" | "steer" = "auto"): void => {
+    const prompt = text.trim()
+    if (!prompt) return
+    setDraft("")
+    setTurnError(null)
+    if (!runningRef.current) {
+      void runTurnRef.current(prompt)
+      return
+    }
+    if (mode === "steer") {
+      updateQueue((q) => [{ id: `q-${Date.now()}-${q.length}`, kind: "prompt" as const, text: prompt }, ...q])
+      activeInterrupt.current?.()
+      return
+    }
+    updateQueue((q) => [...q, { id: `q-${Date.now()}-${q.length}`, kind: "prompt" as const, text: prompt }])
+  }
+  const submit = (text: string, mode?: "auto" | "steer") => submitRef.current(text, mode)
+
+  // Slash-command list: engine-owned builtins + the user's own
+  // `.claude/{commands,skills}/` entries, gated on the engine-owned
+  // `userSlashes` capability (never a vendor-id string).
+  const [slashList, setSlashList] = useState<readonly ComposerSlashEntry[]>([])
+  useEffect(() => {
+    if (!nativeChat?.userSlashes) return
+    let disposed = false
+    void loadUserSlashes(props.worktree)
+      .then((user) => {
+        if (disposed) return
+        const builtin: ComposerSlashEntry[] = (nativeChat?.builtinSlashes ?? []).map((s) => ({
+          display: `/${s.name}`,
+          description: s.description,
+          aliases: s.aliases ? [...s.aliases] : undefined,
+          source: "builtin",
+          onSelect: () => submitRef.current(`/${s.name}`),
+        }))
+        const userEntries: ComposerSlashEntry[] = user.map((s) => ({
+          display: `/${s.name}`,
+          description: s.description,
+          source: "user",
+          onSelect: () => submitRef.current(`/${s.name}`),
+        }))
+        setSlashList([...builtin, ...userEntries])
+      })
+      .catch((err) => console.error("[kobe chat] failed to load user slash commands:", err))
+    return () => {
+      disposed = true
+    }
+  }, [props.worktree, nativeChat])
+
+  // dev:mock seam — auto-submit the scripted prompt once on mount.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once by design (scripted proof prompt).
+  useEffect(() => {
+    if (props.initialPrompt) submitRef.current(props.initialPrompt)
+  }, [])
+
+  // Unmount: interrupt a live turn, drop the per-worktree harness runtime.
+  useEffect(
+    () => () => {
+      activeInterrupt.current?.()
+      disposeAiSdkRuntime(props.worktree)
+    },
+    [props.worktree],
+  )
+
+  /** Footer label for the pinned (or default) model, from the vendor catalog. */
+  const modelLabel = (): string => {
+    const caps = capabilities
+    const pick = model
+    if (!pick) {
+      const id = caps?.defaultModelId() ?? ""
+      return caps?.models.find((m) => m.id === id && !m.effort)?.label ?? id
+    }
+    return (
+      caps?.models.find((m) => m.id === pick.id && m.effort === pick.effort)?.label ??
+      (pick.effort ? `${pick.id} · ${pick.effort}` : pick.id)
+    )
+  }
+
+  function openModelPicker(): void {
+    const hv = harnessVendor
+    if (!hv) return
+    const pick = model
+    dialog.replace(
+      () => (
+        <ModelPicker
+          current={pick?.id}
+          currentEffort={pick?.effort}
+          currentVendor={hv}
+          lockedVendor={hv}
+          onPick={(choice) => {
+            setModel(choice)
+            dialog.clear()
+          }}
+          onCancel={() => dialog.clear()}
+        />
+      ),
+      () => {},
+    )
+  }
+
+  function cyclePermissionMode(): void {
+    const modes = capabilities?.permissionModes ?? []
+    if (modes.length === 0) return
+    setPermissionMode((current) => {
+      const i = modes.findIndex((m) => m.id === current)
+      return modes[(i + 1) % modes.length]?.id ?? "acceptEdits"
+    })
+  }
+
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const scrollBy = (dy: number): void => {
+    const scroll = scrollRef.current
+    if (!scroll) return
+    scroll.scrollTo({ x: 0, y: Math.max(0, scroll.scrollTop + dy) })
+  }
+
+  const paneFocused = (): boolean => props.focused?.() ?? true
+
+  useBindings(() => ({
+    // Pane-scoped: only when the workspace column owns the keyboard.
+    enabled: paneFocused(),
+    bindings: [
+      // pgup/pgdn + ctrl+o only: the composer input owns letters/arrows/enter.
+      { key: "pageup", cmd: () => scrollBy(-SCROLL_STEP) },
+      { key: "pagedown", cmd: () => scrollBy(SCROLL_STEP) },
+      { key: "ctrl+o", cmd: () => setExpanded((e) => !e) },
+      ...(running ? [{ key: "escape", cmd: () => activeInterrupt.current?.() }] : []),
+    ],
+  }))
+
+  const headerTitle = props.title?.trim() || basename(props.worktree)
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+      {/* Quiet brand header — muted CAPS tag + plain bold title; one accent
+          per surface (the transcript's ❯ prompt marker). */}
+      <box
+        flexDirection="row"
+        gap={1}
+        paddingLeft={1}
+        paddingRight={1}
+        flexShrink={0}
+        backgroundColor={theme.backgroundElement}
+      >
+        <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
+          {t("chat.tag")}
+        </text>
+        <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
+          {headerTitle}
+        </text>
+        <box flexGrow={1} />
+        {running ? (
+          <text fg={theme.textMuted} attributes={TextAttributes.ITALIC} wrapMode="none">
+            {t("chat.working")}
+          </text>
+        ) : null}
+      </box>
+      <scrollbox
+        ref={(r: ScrollBoxRenderable | null) => {
+          scrollRef.current = r
+        }}
+        flexGrow={1}
+        stickyScroll={true}
+        stickyStart="bottom"
+        verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
+      >
+        {items.length > 0 ? (
+          /* No paddingTop — the first row is always a prompt echo, which
+             carries its own marginTop. The streaming UIMessage snapshot
+             grows in place, so it IS the live view. */
+          <box flexDirection="column" paddingLeft={1} paddingRight={1}>
+            {items.map((item, i) => (
+              <ChatRow key={`${item.kind}:${i}`} item={item} expanded={expanded} />
+            ))}
+          </box>
+        ) : (
+          <box paddingTop={1} paddingLeft={1}>
+            <text fg={theme.textMuted}>{t("chat.empty")}</text>
+          </box>
+        )}
+      </scrollbox>
+      <ChatTurnErrorBanner error={turnError} />
+      {/* The full composer: multi-line textarea, per-key prompt history
+          (↑↓ + ctrl+r palette), `/` slash dropdown, `@` file mentions, image
+          paste, model picker, shift+tab permission cycle, mid-turn queue. */}
+      <Composer
+        draft={draft}
+        onDraftChange={setDraft}
+        isStreaming={running}
+        hasTask={true}
+        onSubmit={(text, mode) => submit(text, mode)}
+        historyKey={props.worktree}
+        focused={paneFocused}
+        modelLabel={modelLabel}
+        inputPlaceholder={() => identity?.inputPlaceholder ?? t("chat.placeholder")}
+        slashes={() => slashList}
+        permissionMode={hasPermissionModes ? () => permissionMode : undefined}
+        permissionModeLabel={
+          hasPermissionModes
+            ? () => permissionModeLabel(capabilities ?? { permissionModes: [] }, permissionMode)
+            : undefined
+        }
+        onCyclePermissionMode={hasPermissionModes ? cyclePermissionMode : undefined}
+        onChooseModel={hasNativeChat ? openModelPicker : undefined}
+        worktreePath={() => props.worktree}
+        queue={() => queue}
+        onCancelQueued={(id) => updateQueue((q) => q.filter((e) => e.id !== id))}
+        onSendQueuedNow={(id) => {
+          const entryNow = queueRef.current.find((e) => e.id === id)
+          if (!entryNow) return
+          updateQueue((q) => [entryNow, ...q.filter((e) => e.id !== id)])
+          activeInterrupt.current?.()
+        }}
+        currentProjectRoot={() => props.worktree}
+      />
+      <box paddingLeft={1} paddingRight={1} flexShrink={0} backgroundColor={theme.backgroundElement}>
+        <text fg={theme.textMuted} wrapMode="none">
+          {running ? t("chat.hintRunning") : t("chat.hint")}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/chat/chat-row.tsx
+++ b/packages/kobe/src/tui-react/chat/chat-row.tsx
@@ -1,0 +1,157 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React transcript row rendering for the native chat pane (`chat-pane.tsx`)
+ * — the `src/tui/chat/ChatRow.tsx` counterpart (issue #15 G3).
+ *
+ * Pure view layer: AI SDK `UIMessage` parts verbatim → glyphs, per the pane's
+ * rendering contract (no normalization between the harness stream and the
+ * screen — the UIMessage parts ARE the render schema). The body/summary
+ * helpers are the shared framework-free `history/message-core` pair; the
+ * `BodyLines` block comes from the already-ported React history pane.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import {
+  type DynamicToolUIPart,
+  type ToolUIPart,
+  type UIMessage,
+  getToolName,
+  isReasoningUIPart,
+  isTextUIPart,
+  isToolUIPart,
+} from "ai"
+import { bodyText, toolInputSummary } from "../../tui/history/message-core"
+import { useTheme } from "../context/theme"
+import { BodyLines } from "../history/message-card"
+import { useT } from "../i18n"
+
+/** Transcript entries: the typed prompt echo, AI SDK UIMessages verbatim, spawn-level failures. */
+export type ChatItem =
+  | { readonly kind: "prompt"; readonly text: string }
+  | { readonly kind: "ui"; readonly msg: UIMessage }
+  | { readonly kind: "error"; readonly text: string }
+
+type ToolPart = ToolUIPart | DynamicToolUIPart
+
+/** Tool output body, present only once the call resolves successfully. */
+function toolOutputText(part: ToolPart): string {
+  return part.state === "output-available" ? bodyText(part.output) : ""
+}
+
+/** Tool failure text, present only on the error terminal state. */
+function toolErrorText(part: ToolPart): string {
+  return part.state === "output-error" ? part.errorText : ""
+}
+
+/**
+ * One AI SDK UIMessage part → glyphs: text = prose, reasoning = ✱ thinking,
+ * tool (static or dynamic) = ⏺ rows colored by the part's state machine
+ * (input-streaming/-available → output-available | output-error).
+ */
+function UiPartView(props: { part: UIMessage["parts"][number]; expanded: boolean }) {
+  const { theme } = useTheme()
+  const t = useT()
+  const part = props.part
+  if (isTextUIPart(part)) {
+    return (
+      <text fg={theme.text} wrapMode="word">
+        {part.text}
+      </text>
+    )
+  }
+  if (isReasoningUIPart(part)) {
+    return (
+      <box flexDirection="column">
+        <text fg={theme.textMuted} attributes={TextAttributes.ITALIC} wrapMode="none">
+          {`✱ ${t("chat.thinking")}…`}
+        </text>
+        {props.expanded && part.text.trim() ? <BodyLines text={part.text} /> : null}
+      </box>
+    )
+  }
+  if (isToolUIPart(part)) {
+    const summary = toolInputSummary(part.input)
+    const errText = toolErrorText(part)
+    const outText = toolOutputText(part)
+    return (
+      <box flexDirection="column">
+        <box flexDirection="row" gap={1}>
+          {/* Bullet + name never shrink; the one-line summary clips at the
+              pane edge instead of crushing them (long Bash commands). */}
+          <text
+            fg={
+              part.state === "output-error"
+                ? theme.error
+                : part.state === "output-available"
+                  ? theme.success
+                  : theme.textMuted
+            }
+            wrapMode="none"
+            flexShrink={0}
+          >
+            ⏺
+          </text>
+          <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
+            {getToolName(part)}
+          </text>
+          {summary ? (
+            <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
+              {summary}
+            </text>
+          ) : null}
+        </box>
+        {errText ? <BodyLines text={errText} error /> : null}
+        {props.expanded && outText ? <BodyLines text={outText} /> : null}
+      </box>
+    )
+  }
+  return null
+}
+
+function partKey(part: UIMessage["parts"][number], index: number): string {
+  if (isToolUIPart(part)) return `tool:${part.toolCallId}`
+  return `${part.type}:${index}`
+}
+
+/** One transcript row. */
+export function ChatRow(props: { item: ChatItem; expanded: boolean }) {
+  const { theme } = useTheme()
+  const t = useT()
+  const item = props.item
+  if (item.kind === "prompt") {
+    return (
+      <box
+        flexDirection="row"
+        gap={1}
+        paddingLeft={1}
+        paddingRight={1}
+        marginTop={1}
+        marginBottom={1}
+        backgroundColor={theme.backgroundElement}
+      >
+        <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
+          ❯
+        </text>
+        <text fg={theme.text} wrapMode="word" flexGrow={1}>
+          {item.text}
+        </text>
+      </box>
+    )
+  }
+  if (item.kind === "error") {
+    return (
+      <text fg={theme.error} wrapMode="word">
+        {`${t("chat.errorPrefix")}: ${item.text}`}
+      </text>
+    )
+  }
+  // AI SDK path: the UIMessage snapshot grows in place while streaming, so
+  // rendering its parts verbatim IS the live view — no preview row needed.
+  return (
+    <box flexDirection="column" marginBottom={item.msg.parts.some((p) => p.type === "text") ? 1 : 0}>
+      {item.msg.parts.map((part, i) => (
+        <UiPartView key={partKey(part, i)} part={part} expanded={props.expanded} />
+      ))}
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/chat/composer-path-chips.tsx
+++ b/packages/kobe/src/tui-react/chat/composer-path-chips.tsx
@@ -1,0 +1,48 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React clickable path chips above the composer input — the
+ * `src/tui/chat/ComposerPathChips.tsx` counterpart (issue #15 G3).
+ * Label truncation is the shared framework-free `composer/path-preview`.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { formatPreviewPathLabel } from "../../tui/chat/composer/path-preview"
+import { useTheme } from "../context/theme"
+
+export interface ComposerPathRef {
+  readonly path: string
+}
+
+export interface ComposerPathChipsProps {
+  readonly hasTask: boolean
+  readonly refs: readonly ComposerPathRef[]
+  readonly onOpenFilePath?: (relPath: string) => void
+}
+
+export function ComposerPathChips(props: ComposerPathChipsProps) {
+  const { theme } = useTheme()
+  if (!props.hasTask || props.refs.length === 0) return null
+  return (
+    <box flexDirection="row" gap={1} alignItems="center" paddingBottom={1}>
+      <text fg={theme.textMuted} wrapMode="none">
+        open
+      </text>
+      {props.refs.map((ref) => (
+        <box
+          key={ref.path}
+          flexDirection="row"
+          flexShrink={1}
+          maxWidth={36}
+          backgroundColor={theme.backgroundPanel}
+          paddingLeft={1}
+          paddingRight={1}
+          onMouseUp={() => props.onOpenFilePath?.(ref.path)}
+        >
+          <text fg={theme.primary} attributes={TextAttributes.UNDERLINE} wrapMode="none">
+            {formatPreviewPathLabel(ref.path, 34)}
+          </text>
+        </box>
+      ))}
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/chat/composer-queue.tsx
+++ b/packages/kobe/src/tui-react/chat/composer-queue.tsx
@@ -1,0 +1,119 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React mid-turn prompt queue panel — the `src/tui/chat/ComposerQueue.tsx`
+ * counterpart (issue #15 G3). Same visual grammar; the entry shape is the
+ * shared framework-free `composer/queue-item`.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import type { ComposerQueuedItem } from "../../tui/chat/composer/queue-item"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+
+export type { ComposerQueuedItem } from "../../tui/chat/composer/queue-item"
+
+/**
+ * Hard cap on visible queued rows so a fast typist who stacked many
+ * prompts doesn't push the textarea off-screen. Overflow rolls up
+ * into a single muted `+ N more queued` summary row.
+ */
+const QUEUE_VISIBLE_CAP = 4
+
+export interface ComposerQueueProps {
+  readonly queue: readonly ComposerQueuedItem[]
+  /**
+   * Whether auto-drain is paused. When true the panel swaps the
+   * head-row hint to `(paused)` and offers a resume toggle; the
+   * parent skips draining queued items as turns end.
+   */
+  readonly paused?: boolean
+  /** Toggle the queue-paused flag (pause / resume). */
+  readonly onTogglePause?: () => void
+  readonly editingQueueId?: string | null
+  readonly onEditQueued?: (id: string) => void
+  readonly onSendQueuedNow?: (id: string) => void
+  readonly onCancelQueued?: (id: string) => void
+}
+
+export function ComposerQueue(props: ComposerQueueProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  if (props.queue.length === 0) return null
+  return (
+    <box flexDirection="column" paddingBottom={1}>
+      {props.queue.slice(0, QUEUE_VISIBLE_CAP).map((entry, idx) => {
+        const isPrompt = entry.kind === "prompt"
+        const isEditing = props.editingQueueId === entry.id
+        const onRowEdit = () => props.onEditQueued?.(entry.id)
+        return (
+          <box key={entry.id} flexDirection="row" gap={1} alignItems="flex-start">
+            <box
+              flexDirection="row"
+              gap={1}
+              alignItems="flex-start"
+              flexGrow={1}
+              onMouseUp={isPrompt ? onRowEdit : undefined}
+            >
+              <text fg={isEditing ? theme.primary : theme.textMuted} attributes={TextAttributes.BOLD}>
+                ○
+              </text>
+              <text fg={props.paused ? theme.warning : theme.textMuted} wrapMode="none">
+                {t("chat.composer.queuedLabel")}
+                {idx === 0 ? ` ${props.paused ? t("chat.composer.queuedPaused") : t("chat.composer.queuedNext")}` : ""}:
+              </text>
+              {entry.kind === "bash" ? (
+                <text fg={theme.warning} wrapMode="none">
+                  {t("chat.composer.queuedBash")}
+                </text>
+              ) : null}
+              <box flexGrow={1}>
+                <text fg={theme.text}>{entry.kind === "bash" ? entry.command : entry.text}</text>
+              </box>
+            </box>
+            {isPrompt ? (
+              /* Single-letter chip — consistent with the `[↑]` send-now and
+                 `[x]` cancel chips on the same row. Pure ASCII (the `✎`
+                 dingbat rendered thin/ugly across terminals). */
+              <text fg={theme.primary} attributes={TextAttributes.BOLD} onMouseUp={onRowEdit}>
+                [e]
+              </text>
+            ) : null}
+            <text
+              fg={theme.primary}
+              attributes={TextAttributes.BOLD}
+              onMouseUp={() => props.onSendQueuedNow?.(entry.id)}
+            >
+              [↑]
+            </text>
+            <text fg={theme.error} attributes={TextAttributes.BOLD} onMouseUp={() => props.onCancelQueued?.(entry.id)}>
+              [x]
+            </text>
+          </box>
+        )
+      })}
+      {props.queue.length > QUEUE_VISIBLE_CAP ? (
+        <box flexDirection="row" gap={1} alignItems="flex-start">
+          <text fg={theme.textMuted} attributes={TextAttributes.BOLD}>
+            +
+          </text>
+          <text fg={theme.textMuted}>
+            {t("chat.composer.moreQueued", { count: props.queue.length - QUEUE_VISIBLE_CAP })}
+          </text>
+        </box>
+      ) : null}
+      {/* Queue-level pause toggle — deliberately the lowest-priority
+          affordance in the panel (a single muted row beneath the items). */}
+      {props.onTogglePause ? (
+        <box flexDirection="row" paddingTop={props.queue.length > QUEUE_VISIBLE_CAP ? 0 : 1}>
+          <text
+            fg={props.paused ? theme.warning : theme.textMuted}
+            attributes={props.paused ? TextAttributes.BOLD : undefined}
+            onMouseUp={() => props.onTogglePause?.()}
+          >
+            {props.paused ? t("chat.composer.resumeQueue") : t("chat.composer.pauseQueue")}
+          </text>
+        </box>
+      ) : null}
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/chat/composer-view.tsx
+++ b/packages/kobe/src/tui-react/chat/composer-view.tsx
@@ -1,0 +1,363 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React presentational layer of the chat composer — the
+ * `src/tui/chat/ComposerView.tsx` counterpart (issue #15 G3). Same visual
+ * grammar: rail-bordered input block, mention/slash dropdowns above it,
+ * queue panel + path chips inside it, mode/model badges in the footer.
+ * All formatting helpers are the shared framework-free composer modules.
+ */
+
+import { type KeyEvent, TextAttributes, type TextareaRenderable } from "@opentui/core"
+import type { DropdownWindow } from "../../tui/chat/composer/dropdown-window"
+import { composerKeyBindings } from "../../tui/chat/composer/keybindings"
+import type { MentionMatch } from "../../tui/chat/composer/mention"
+import type { PreviewablePathRef } from "../../tui/chat/composer/path-preview"
+import { resolvePlaceholder } from "../../tui/chat/composer/placeholder"
+import type { ComposerSlashEntry } from "../../tui/chat/composer/props"
+import type { ComposerQueuedItem } from "../../tui/chat/composer/queue-item"
+import { formatSlashDescription } from "../../tui/chat/composer/slash-description"
+import { EmptyBorder, SplitBorder } from "../../tui/component/border"
+import { type Theme, useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { ComposerPathChips } from "./composer-path-chips"
+import { ComposerQueue } from "./composer-queue"
+
+const COMPOSER_MAX_LINES = 8
+const COMPOSER_MIN_LINES = 1
+
+export type ComposerModeTone = "muted" | "accent" | "warning" | "primary"
+
+export type ComposerModeBadge = {
+  readonly label: string
+  readonly tone: ComposerModeTone
+}
+
+export interface ComposerViewProps {
+  readonly hasTask: boolean
+  readonly noTaskMessage?: string
+  readonly isStreaming: boolean
+  readonly inputPlaceholder?: string
+  readonly bashMode: boolean
+  readonly railColor: Theme["primary"]
+  readonly footerHint: string
+  readonly modelLabel: string
+  readonly permissionModeLabel: string
+  readonly modeBadge: ComposerModeBadge | null
+  readonly toneColor: (tone: ComposerModeTone) => Theme["primary"]
+  readonly mentionOpen: boolean
+  readonly mentionWindow: DropdownWindow<MentionMatch>
+  readonly mentionCursor: number
+  readonly slashOpen: boolean
+  readonly slashMatchesLength: number
+  readonly slashWindow: DropdownWindow<ComposerSlashEntry>
+  readonly slashCursor: number
+  readonly queue: readonly ComposerQueuedItem[]
+  readonly queuePaused: boolean
+  readonly onToggleQueuePause?: () => void
+  readonly editingQueueId?: string | null
+  readonly onEditQueued?: (id: string) => void
+  readonly onSendQueuedNow?: (id: string) => void
+  readonly onCancelQueued?: (id: string) => void
+  readonly pathRefs: readonly PreviewablePathRef[]
+  readonly onOpenFilePath?: (relPath: string) => void
+  readonly onCyclePermissionMode?: () => void
+  readonly onChooseModel?: () => void
+  readonly onTextareaMount: (r: TextareaRenderable | null) => void
+  readonly onContentChange: () => void
+  readonly onKeyDown: (key: KeyEvent) => void
+  readonly onSubmit: () => void
+}
+
+export function ComposerView(props: ComposerViewProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  return (
+    <box flexShrink={0} flexDirection="column" paddingTop={1}>
+      <MentionDropdown
+        theme={theme}
+        open={props.mentionOpen}
+        window={props.mentionWindow}
+        cursor={props.mentionCursor}
+        railColor={props.railColor}
+      />
+      <SlashDropdown
+        theme={theme}
+        open={props.slashOpen && props.slashMatchesLength > 0}
+        window={props.slashWindow}
+        cursor={props.slashCursor}
+        railColor={props.railColor}
+      />
+      <box
+        border={["left"]}
+        borderColor={props.railColor}
+        customBorderChars={{
+          ...SplitBorder.customBorderChars,
+          bottomLeft: "╹",
+        }}
+      >
+        <box
+          paddingLeft={2}
+          paddingRight={2}
+          paddingTop={1}
+          paddingBottom={0}
+          flexDirection="column"
+          flexGrow={1}
+          backgroundColor={theme.backgroundElement}
+        >
+          <ComposerQueue
+            queue={props.queue}
+            paused={props.queuePaused}
+            onTogglePause={props.onToggleQueuePause}
+            editingQueueId={props.editingQueueId}
+            onEditQueued={props.onEditQueued}
+            onSendQueuedNow={props.onSendQueuedNow}
+            onCancelQueued={props.onCancelQueued}
+          />
+          <ComposerPathChips hasTask={props.hasTask} refs={props.pathRefs} onOpenFilePath={props.onOpenFilePath} />
+          <box flexDirection="row" gap={1} alignItems="flex-start">
+            <PromptGlyph theme={theme} bashMode={props.bashMode} isStreaming={props.isStreaming} />
+            <box flexGrow={1} flexShrink={1} maxHeight={COMPOSER_MAX_LINES} minHeight={COMPOSER_MIN_LINES}>
+              {props.hasTask ? (
+                <textarea
+                  ref={props.onTextareaMount}
+                  placeholder={resolvePlaceholder(
+                    {
+                      isStreaming: props.isStreaming,
+                      hasTask: props.hasTask,
+                      noTaskMessage: props.noTaskMessage,
+                      inputPlaceholder: props.inputPlaceholder,
+                    },
+                    t,
+                  )}
+                  placeholderColor={theme.textMuted}
+                  textColor={theme.text}
+                  backgroundColor={theme.backgroundElement}
+                  focusedBackgroundColor={theme.backgroundElement}
+                  wrapMode="word"
+                  keyBindings={composerKeyBindings}
+                  onContentChange={props.onContentChange}
+                  onKeyDown={props.onKeyDown}
+                  onSubmit={props.onSubmit}
+                />
+              ) : (
+                <text fg={theme.textMuted}>{props.noTaskMessage ?? t("chat.composer.noTask")}</text>
+              )}
+            </box>
+          </box>
+          <ComposerFooter
+            theme={theme}
+            hasTask={props.hasTask}
+            isStreaming={props.isStreaming}
+            footerHint={props.footerHint}
+            modeBadge={props.modeBadge}
+            toneColor={props.toneColor}
+            permissionModeLabel={props.permissionModeLabel}
+            onCyclePermissionMode={props.onCyclePermissionMode}
+            modelLabel={props.modelLabel}
+            onChooseModel={props.onChooseModel}
+          />
+        </box>
+      </box>
+      <box
+        height={1}
+        border={["left"]}
+        borderColor={props.railColor}
+        customBorderChars={{
+          ...EmptyBorder,
+          vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
+        }}
+      >
+        <box
+          height={1}
+          border={["bottom"]}
+          borderColor={theme.backgroundElement}
+          customBorderChars={{
+            ...EmptyBorder,
+            horizontal: theme.backgroundElement.a !== 0 ? "▀" : " ",
+          }}
+        />
+      </box>
+    </box>
+  )
+}
+
+function MentionDropdown(props: {
+  readonly theme: Theme
+  readonly open: boolean
+  readonly window: DropdownWindow<MentionMatch>
+  readonly cursor: number
+  readonly railColor: Theme["primary"]
+}) {
+  const theme = props.theme
+  if (!props.open) return null
+  return (
+    <box
+      flexDirection="column"
+      flexShrink={0}
+      backgroundColor={theme.backgroundElement}
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+      border={["left"]}
+      borderColor={props.railColor}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      {props.window.start > 0 ? (
+        <text fg={theme.textMuted} wrapMode="none">
+          ↑ {props.window.start} more
+        </text>
+      ) : null}
+      {props.window.items.map((match, i) => {
+        const active = props.window.start + i === props.cursor
+        const idx = match.displayPath.lastIndexOf("/")
+        const filename = idx >= 0 ? match.displayPath.slice(idx + 1) : match.displayPath
+        const directory = idx >= 0 ? match.displayPath.slice(0, idx) : ""
+        return (
+          <box key={match.path} flexDirection="row" gap={2}>
+            <text
+              fg={active ? theme.primary : theme.text}
+              attributes={active ? TextAttributes.BOLD : undefined}
+              wrapMode="none"
+            >
+              {active ? "▸ " : "  "}
+              {filename}
+            </text>
+            {directory.length > 0 ? (
+              <text fg={theme.textMuted} wrapMode="none">
+                {directory}
+              </text>
+            ) : null}
+          </box>
+        )
+      })}
+      {props.window.start + props.window.items.length < props.window.total ? (
+        <text fg={theme.textMuted} wrapMode="none">
+          ↓ {props.window.total - props.window.start - props.window.items.length} more
+        </text>
+      ) : null}
+    </box>
+  )
+}
+
+function SlashDropdown(props: {
+  readonly theme: Theme
+  readonly open: boolean
+  readonly window: DropdownWindow<ComposerSlashEntry>
+  readonly cursor: number
+  readonly railColor: Theme["primary"]
+}) {
+  const theme = props.theme
+  if (!props.open) return null
+  return (
+    <box
+      flexDirection="column"
+      flexShrink={0}
+      backgroundColor={theme.backgroundElement}
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+      border={["left"]}
+      borderColor={props.railColor}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      {props.window.start > 0 ? (
+        <text fg={theme.textMuted} wrapMode="none">
+          ↑ {props.window.start} more
+        </text>
+      ) : null}
+      {props.window.items.map((entry, i) => {
+        const active = props.window.start + i === props.cursor
+        const description = formatSlashDescription(entry.description)
+        return (
+          <box key={entry.display} flexDirection="row" gap={2}>
+            <text
+              fg={active ? theme.primary : theme.text}
+              attributes={active ? TextAttributes.BOLD : undefined}
+              wrapMode="none"
+              flexShrink={0}
+            >
+              {active ? "▸ " : "  "}
+              {entry.display}
+            </text>
+            {entry.source === "user" ? (
+              <text fg={theme.textMuted} wrapMode="none" flexShrink={0}>
+                user
+              </text>
+            ) : null}
+            {description ? (
+              <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
+                {description}
+              </text>
+            ) : null}
+          </box>
+        )
+      })}
+      {props.window.start + props.window.items.length < props.window.total ? (
+        <text fg={theme.textMuted} wrapMode="none">
+          ↓ {props.window.total - props.window.start - props.window.items.length} more
+        </text>
+      ) : null}
+    </box>
+  )
+}
+
+function PromptGlyph(props: { readonly theme: Theme; readonly bashMode: boolean; readonly isStreaming: boolean }) {
+  const theme = props.theme
+  if (props.bashMode && !props.isStreaming) {
+    return (
+      <text fg={theme.warning} attributes={TextAttributes.BOLD}>
+        !
+      </text>
+    )
+  }
+  if (props.bashMode && props.isStreaming) {
+    return (
+      <box flexDirection="row">
+        <text fg={theme.accent}>…</text>
+        <text fg={theme.warning} attributes={TextAttributes.BOLD}>
+          !
+        </text>
+      </box>
+    )
+  }
+  return <text fg={props.isStreaming ? theme.accent : theme.primary}>{props.isStreaming ? "…" : ">"}</text>
+}
+
+function ComposerFooter(props: {
+  readonly theme: Theme
+  readonly hasTask: boolean
+  readonly isStreaming: boolean
+  readonly footerHint: string
+  readonly modeBadge: ComposerModeBadge | null
+  readonly toneColor: (tone: ComposerModeTone) => Theme["primary"]
+  readonly permissionModeLabel: string
+  readonly onCyclePermissionMode?: () => void
+  readonly modelLabel: string
+  readonly onChooseModel?: () => void
+}) {
+  const theme = props.theme
+  if (!props.hasTask) return null
+  return (
+    <box flexDirection="row" justifyContent="space-between" paddingTop={1} flexShrink={0}>
+      <text fg={props.isStreaming ? theme.accent : theme.textMuted} wrapMode="none">
+        {props.footerHint}
+      </text>
+      <box flexDirection="row" gap={2} flexShrink={0}>
+        <box flexDirection="row" flexShrink={0} onMouseUp={() => props.onCyclePermissionMode?.()}>
+          <text fg={props.modeBadge ? props.toneColor("primary") : theme.textMuted} wrapMode="none">
+            {props.permissionModeLabel}
+            {props.onCyclePermissionMode ? " ▾" : ""}
+          </text>
+        </box>
+        <box flexDirection="row" flexShrink={0} onMouseUp={() => props.onChooseModel?.()}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {props.modelLabel}
+            {props.onChooseModel ? " ▾" : ""}
+          </text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/chat/composer.tsx
+++ b/packages/kobe/src/tui-react/chat/composer.tsx
@@ -1,0 +1,320 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React multi-line chat composer — the `src/tui/chat/Composer.tsx`
+ * counterpart (issue #15 G3). Same contract: the textarea is the source of
+ * truth for the buffer, the parent stays informed via `onDraftChange`, and
+ * ALL input semantics (bash-mode toggle, slash dropdown, `@` mentions,
+ * prompt history, image paste, ctrl+enter steer, ctrl+r palette) live in the
+ * shared framework-free `composer/*` modules — this file owns only the React
+ * reactivity that feeds them.
+ *
+ * Input-latency notes (per-keystroke hot path):
+ *   - The textarea renderable owns typing; React re-renders only on the
+ *     `liveBuffer` mirror update (needed to drive the dropdown filters).
+ *   - Derived lists (slash matches, mention matches, dropdown windows) are
+ *     `useMemo`s keyed on that mirror — nothing re-filters unless the buffer
+ *     actually changed.
+ *   - The key router reads state through plain closures over the CURRENT
+ *     render (recreated per render, same as every inline handler in this
+ *     tree); the heavy work behind those closures is all memoized.
+ */
+
+import type { TextareaRenderable } from "@opentui/core"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { makeDropdownWindow } from "../../tui/chat/composer/dropdown-window"
+import { getHistory } from "../../tui/chat/composer/history"
+import { PromptHistoryNavigator } from "../../tui/chat/composer/history-nav"
+import { createImageAttach } from "../../tui/chat/composer/image-attach"
+import { ImagePasteRegistry } from "../../tui/chat/composer/image-paste"
+import { createKeyRouter } from "../../tui/chat/composer/key-router"
+import type { ComposerProps, ComposerSlashEntry } from "../../tui/chat/composer/props"
+import { useFocus } from "../context/focus"
+import { useTheme } from "../context/theme"
+import { useDialog } from "../ui/dialog"
+import { type ComposerModeTone, ComposerView } from "./composer-view"
+import { HistoryPalette } from "./history-palette"
+import { useMentionController } from "./mention-controller"
+
+export type { ComposerProps, ComposerSlashEntry } from "../../tui/chat/composer/props"
+
+const NO_SLASHES: readonly ComposerSlashEntry[] = []
+
+// Claude Code-style dropdown windowing: keep roughly eight rows visible and
+// scroll the window around the cursor.
+const SLASH_MAX_VISIBLE = 8
+
+export function Composer(props: ComposerProps) {
+  const { theme } = useTheme()
+  const focusCtx = useFocus()
+  const dialog = useDialog()
+
+  // Imperative ref to the textarea renderable (set once opentui mounts the
+  // node): draft sync, cursor reads for history nav, setText/focus calls.
+  const textareaRef = useRef<TextareaRenderable | undefined>(undefined)
+
+  // Latest-props ref so once-created helpers (history navigator, palette
+  // seam) never read stale closures.
+  const propsRef = useRef(props)
+  propsRef.current = props
+
+  // Transient "no image on clipboard" / paste-failure hint (ctrl+v path);
+  // cleared by the next keystroke.
+  const [pasteHint, setPasteHint] = useState<string | null>(null)
+  // Live draft mirror driving the slash/mention filters, plus its cursor
+  // companion (mention detection is cursor-positional).
+  const [liveBuffer, setLiveBuffer] = useState(props.draft ?? "")
+  const [liveCursor, setLiveCursor] = useState(props.draft?.length ?? 0)
+  // Bash-mode state — typing `!` on an empty buffer SWITCHES MODES instead
+  // of inserting the character (claude-code parity); the buffer holds the
+  // command verbatim and the glyph carries the mode.
+  const [bashMode, setBashMode] = useState(false)
+  const [slashCursor, setSlashCursor] = useState(0)
+
+  const bashAvailable = (): boolean => propsRef.current.onBashCommand != null
+
+  /**
+   * Update the textarea's text imperatively — `setText` (clean slate,
+   * clears undo) for history recall and clear-after-submit, cursor at the
+   * end so the user keeps typing immediately. The renderable's own
+   * content-change event mirrors the new text back into `liveBuffer`.
+   */
+  function setBuffer(text: string): void {
+    const ref = textareaRef.current
+    if (!ref) return
+    if (ref.plainText === text) return
+    ref.setText(text)
+    ref.cursorOffset = text.length
+  }
+
+  /**
+   * Shared recall dispatch for up-arrow history and the ctrl+r palette:
+   * a `!`-prefixed stored entry re-enters bash mode with the `!` stripped
+   * (KOB-151), anything else lands as a plain prompt.
+   */
+  function applyHistoryRecall(recalled: string): void {
+    if (recalled.startsWith("!") && bashAvailable()) {
+      setBuffer(recalled.slice(1))
+      setBashMode(true)
+      return
+    }
+    setBuffer(recalled)
+    setBashMode(false)
+  }
+  const recallRef = useRef(applyHistoryRecall)
+  recallRef.current = applyHistoryRecall
+
+  // History cursor + per-composer image registry — one instance each for
+  // the component's lifetime, reading live state through refs.
+  const bashModeRef = useRef(bashMode)
+  bashModeRef.current = bashMode
+  const historyNav = useMemo(
+    () =>
+      new PromptHistoryNavigator(
+        () => getHistory(propsRef.current.historyKey ?? "global"),
+        () => {
+          const text = textareaRef.current?.plainText ?? ""
+          return bashModeRef.current ? `!${text}` : text
+        },
+        (recalled) => recallRef.current(recalled),
+      ),
+    [],
+  )
+  const imageRegistry = useMemo(() => new ImagePasteRegistry(), [])
+
+  // Slash dropdown: open while the buffer is a bare `/command` prefix.
+  const slashEntries = props.slashes?.() ?? NO_SLASHES
+  const slashOpen = props.slashes != null && liveBuffer.startsWith("/") && !/\s/.test(liveBuffer)
+  const slashMatches = useMemo<readonly ComposerSlashEntry[]>(() => {
+    if (!slashOpen) return NO_SLASHES
+    const query = liveBuffer.toLowerCase()
+    return slashEntries.filter((entry) => {
+      if (entry.display.toLowerCase().startsWith(query)) return true
+      return entry.aliases?.some((a) => a.toLowerCase().startsWith(query)) ?? false
+    })
+  }, [slashOpen, slashEntries, liveBuffer])
+
+  // Keep cursor in bounds when the match list changes.
+  useEffect(() => {
+    const len = slashMatches.length
+    setSlashCursor((cur) => (len === 0 ? 0 : Math.min(cur, len - 1)))
+  }, [slashMatches.length])
+
+  const slashWindow = useMemo(
+    () => makeDropdownWindow(slashMatches, slashCursor, SLASH_MAX_VISIBLE),
+    [slashMatches, slashCursor],
+  )
+
+  const mention = useMentionController({
+    worktreePath: props.worktreePath?.(),
+    liveBuffer,
+    liveCursor,
+    slashOpen,
+    textarea: () => textareaRef.current,
+  })
+  const previewablePathRefs = props.onOpenFilePath ? mention.pathRefs : []
+
+  // Mirror the workspace pane's focus state onto the textarea, re-asserting
+  // on `refocusTick` so a same-pane refocus (tab-chip click) restores native
+  // focus even when the pane state didn't change.
+  const focusedNow = props.focused?.() ?? false
+  useEffect(() => {
+    // Dependency-only invalidation key (history-host canon): a same-pane
+    // refocus bumps the tick without changing `focusedNow`.
+    void focusCtx.refocusTick
+    const ref = textareaRef.current
+    if (!ref) return
+    if (focusedNow) ref.focus()
+    else ref.blur()
+  }, [focusedNow, focusCtx.refocusTick])
+
+  // Sync parent's `draft` onto the textarea when it diverges (the common
+  // case: clear-after-submit round-trip).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the parent draft only — setBuffer is an imperative helper over a ref.
+  useEffect(() => {
+    const ref = textareaRef.current
+    if (ref && ref.plainText !== props.draft) setBuffer(props.draft)
+    setLiveBuffer(props.draft)
+  }, [props.draft])
+
+  // Reset history nav + image numbering when the active history key changes
+  // (task switch): index 4 of the old key is meaningless for the new one.
+  useEffect(() => {
+    // Dependency-only invalidation key: the reset fires on key CHANGE.
+    void props.historyKey
+    historyNav.reset()
+    imageRegistry.clear()
+    setPasteHint(null)
+  }, [props.historyKey, historyNav, imageRegistry])
+
+  // ------- Event handlers -------
+
+  const { handlePaste, tryAttachClipboardImage } = useMemo(
+    () =>
+      createImageAttach({
+        getTextarea: () => textareaRef.current,
+        imageRegistry,
+        setPasteHint,
+      }),
+    [imageRegistry],
+  )
+
+  // Recreated per render on purpose: its closures read THIS render's state,
+  // matching every other inline handler; all list work behind it is memoized.
+  const { handleKeyDown, handleSubmit, handleContentChange } = createKeyRouter({
+    props,
+    // Framework seam: the router is framework-free; only the show-palette
+    // capability crosses over (the React dialog stack stays here).
+    showHistoryPalette: (opts) => HistoryPalette.show(dialog, opts),
+    getTextarea: () => textareaRef.current,
+    bashMode: () => bashMode,
+    setBashMode,
+    bashAvailable,
+    liveBuffer: () => liveBuffer,
+    setLiveBuffer,
+    setLiveCursor,
+    setBuffer,
+    slashOpen: () => slashOpen,
+    slashMatches: () => slashMatches,
+    slashCursor: () => slashCursor,
+    setSlashCursor,
+    mention,
+    historyNav,
+    imageRegistry,
+    pasteHint: () => pasteHint,
+    setPasteHint,
+    applyHistoryRecall,
+    tryAttachClipboardImage,
+  })
+
+  // Drop the ref on unmount so straggling effects don't poke a destroyed
+  // renderable.
+  useEffect(
+    () => () => {
+      textareaRef.current = undefined
+    },
+    [],
+  )
+
+  // Footer copy: bash mode dominates (the user must SEE the mode mid-turn),
+  // then the streaming queue/steer hint; paste feedback wins over both
+  // because it is transient state the user just triggered.
+  const streamingNotice = (): string => {
+    if (!props.hasTask) return ""
+    if (bashMode) return props.isStreaming ? "bash mode · enter to queue" : "bash mode · enter to run"
+    if (props.isStreaming) return "enter queue · ctrl+enter steer"
+    return ""
+  }
+  const footerHint = pasteHint ?? streamingNotice()
+  const modelLabel = props.modelLabel?.() ?? ""
+  const permissionModeLabel =
+    props.permissionModeLabel?.() ?? (props.permissionMode?.() === "plan" ? "plan mode" : "default")
+
+  // Mode indicator: plain text labels, no emoji glyphs; plan mode must be
+  // unmistakable so the user doesn't submit a destructive prompt mid-plan.
+  const modeBadge: { label: string; tone: ComposerModeTone } | null =
+    props.permissionMode?.() === "plan" ? { label: permissionModeLabel, tone: "primary" } : null
+  const toneColor = (tone: ComposerModeTone) => {
+    switch (tone) {
+      case "accent":
+        return theme.accent
+      case "primary":
+        return theme.primary
+      case "warning":
+        return theme.warning
+      default:
+        return theme.textMuted
+    }
+  }
+  // Rail color priority: non-default mode > focused > idle border — the mode
+  // signal persists even when focus moves to a sibling pane.
+  const railColor = modeBadge ? toneColor(modeBadge.tone) : focusedNow ? theme.primary : theme.border
+
+  function handleTextareaMount(r: TextareaRenderable | null): void {
+    if (!r) {
+      textareaRef.current = undefined
+      return
+    }
+    textareaRef.current = r
+    if (propsRef.current.draft) r.setText(propsRef.current.draft)
+    r.onPaste = handlePaste
+    if (propsRef.current.focused?.()) r.focus()
+  }
+
+  return (
+    <ComposerView
+      hasTask={props.hasTask}
+      noTaskMessage={props.noTaskMessage}
+      isStreaming={props.isStreaming}
+      inputPlaceholder={props.inputPlaceholder?.()}
+      bashMode={bashMode}
+      railColor={railColor}
+      footerHint={footerHint}
+      modelLabel={modelLabel}
+      permissionModeLabel={permissionModeLabel}
+      modeBadge={modeBadge}
+      toneColor={toneColor}
+      mentionOpen={mention.open}
+      mentionWindow={mention.window}
+      mentionCursor={mention.cursor}
+      slashOpen={slashOpen}
+      slashMatchesLength={slashMatches.length}
+      slashWindow={slashWindow}
+      slashCursor={slashCursor}
+      queue={props.queue?.() ?? []}
+      queuePaused={props.queuePaused?.() ?? false}
+      onToggleQueuePause={props.onToggleQueuePause}
+      editingQueueId={props.editingQueueId?.() ?? null}
+      onEditQueued={props.onEditQueued}
+      onSendQueuedNow={props.onSendQueuedNow}
+      onCancelQueued={props.onCancelQueued}
+      pathRefs={previewablePathRefs}
+      onOpenFilePath={props.onOpenFilePath}
+      onCyclePermissionMode={props.onCyclePermissionMode}
+      onChooseModel={props.onChooseModel}
+      onTextareaMount={handleTextareaMount}
+      onContentChange={handleContentChange}
+      onKeyDown={handleKeyDown}
+      onSubmit={() => handleSubmit("auto")}
+    />
+  )
+}

--- a/packages/kobe/src/tui-react/chat/history-palette.tsx
+++ b/packages/kobe/src/tui-react/chat/history-palette.tsx
@@ -1,0 +1,233 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React Ctrl+R cross-task prompt-history palette — the
+ * `src/tui/chat/composer/HistoryPalette.tsx` + `history-palette-controller.tsx`
+ * counterpart (issue #15 G3, KOB-154 feature). Aggregates every entry from
+ * the shared on-disk prompt-history store, filters by a fuzzy substring
+ * query, and resolves with the selected entry's raw stored value
+ * (`!`-prefixed for bash-mode submissions) or `undefined` on cancel.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useMemo, useState } from "react"
+import { makeDropdownWindow } from "../../tui/chat/composer/dropdown-window"
+import { getAllHistoryEntries } from "../../tui/chat/composer/history"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { type DialogContext, useDialog } from "../ui/dialog"
+
+/** Maximum visible rows in the palette body. Bigger than the slash dropdown
+ * because cross-task history is the entire raison d'être here. */
+const PALETTE_MAX_ROWS = 12
+
+/**
+ * One palette row. `value` is the raw stored form (`!cmd` for bash);
+ * `display` is the stripped form rendered in the row body.
+ */
+type PaletteRow = {
+  readonly value: string
+  readonly display: string
+  readonly isBash: boolean
+  readonly taskLabel: string | undefined
+  readonly seq: number
+}
+
+function rowsFromEntries(
+  entries: ReadonlyArray<{
+    readonly key: string
+    readonly value: string
+    readonly seq: number
+    readonly project: string | undefined
+  }>,
+  labelFor: (key: string) => string | undefined,
+  currentProject: string | undefined,
+): PaletteRow[] {
+  // Per-project scope (Claude Code parity, KOB-157). When a current project
+  // is known, hide rows from other repos; no current project falls back to
+  // "show every project + global" so the palette is never silently empty.
+  const filtered =
+    currentProject === undefined
+      ? entries
+      : entries.filter((e) => e.project === currentProject || e.project === undefined)
+  return filtered.map((e) => {
+    const isBash = e.value.startsWith("!")
+    return {
+      value: e.value,
+      display: isBash ? e.value.slice(1) : e.value,
+      isBash,
+      taskLabel: labelFor(e.key),
+      seq: e.seq,
+    }
+  })
+}
+
+function fuzzyFilter(rows: readonly PaletteRow[], query: string): PaletteRow[] {
+  const q = query.trim().toLowerCase()
+  if (q.length === 0) return rows.slice()
+  return rows.filter((r) => {
+    const hay = `${r.taskLabel ?? ""} ${r.display}`.toLowerCase()
+    return hay.includes(q)
+  })
+}
+
+/** Truncate `text` to `max` characters, appending `…` when it had to clip. */
+function truncate(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, " ")
+  if (flat.length <= max) return flat
+  return `${flat.slice(0, Math.max(0, max - 1))}…`
+}
+
+export function HistoryPaletteView(props: {
+  taskLabelFor: (historyKey: string) => string | undefined
+  currentProject: string | undefined
+  onSubmit: (value: string) => void
+  onCancel: () => void
+}) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const t = useT()
+  // Snapshot entries on open — the palette is short-lived, and a stable list
+  // keeps the cursor sane across the user's typing.
+  const [allRows] = useState(() => rowsFromEntries(getAllHistoryEntries(), props.taskLabelFor, props.currentProject))
+  const [query, setQuery] = useState("")
+  const [cursor, setCursor] = useState(0)
+
+  const matches = useMemo(() => fuzzyFilter(allRows, query), [allRows, query])
+  const window = useMemo(() => makeDropdownWindow(matches, cursor, PALETTE_MAX_ROWS), [matches, cursor])
+
+  function commit(atIndex?: number): void {
+    const row = matches[atIndex ?? cursor]
+    if (!row) return
+    props.onSubmit(row.value)
+    dialog.clear()
+  }
+
+  function moveCursor(delta: number): void {
+    const len = matches.length
+    if (len === 0) return
+    setCursor((cur) => Math.min(Math.max(cur + delta, 0), len - 1))
+  }
+
+  // Up/down nav lives in `useBindings` because the focused <input> doesn't
+  // let us intercept arrows; the dispatcher fires BEFORE the input reacts.
+  useBindings(() => ({
+    bindings: [
+      { key: "up", cmd: () => moveCursor(-1) },
+      { key: "down", cmd: () => moveCursor(1) },
+    ],
+  }))
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {t("chat.composer.historyTitle")}
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => props.onCancel()}>
+          {t("chat.composer.esc")}
+        </text>
+      </box>
+      <box gap={0}>
+        <text fg={theme.accent}>{t("chat.composer.historySearch")}</text>
+        <input
+          value={query}
+          placeholder={t("chat.composer.historyFilterPlaceholder")}
+          focused={true}
+          onInput={(v: string) => {
+            setQuery(v.replace(/\n/g, ""))
+            // Reset to the top of the filtered list whenever the query
+            // changes — otherwise the cursor can point past the end.
+            setCursor(0)
+          }}
+          onSubmit={() => commit()}
+        />
+      </box>
+      {matches.length > 0 ? (
+        <box gap={0}>
+          {window.items.map((row, idx) => {
+            const absIdx = window.start + idx
+            const isHighlighted = absIdx === cursor
+            return (
+              <box
+                key={`${row.seq}:${row.value}`}
+                flexDirection="row"
+                gap={1}
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={isHighlighted ? theme.primary : undefined}
+                onMouseUp={() => {
+                  setCursor(absIdx)
+                  commit(absIdx)
+                }}
+              >
+                {row.isBash ? (
+                  <text fg={isHighlighted ? theme.selectedListItemText : theme.warning} wrapMode="none">
+                    [bash]
+                  </text>
+                ) : null}
+                {row.taskLabel !== undefined ? (
+                  <>
+                    <text fg={isHighlighted ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                      {row.taskLabel}
+                    </text>
+                    <text fg={isHighlighted ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                      ·
+                    </text>
+                  </>
+                ) : null}
+                <text fg={isHighlighted ? theme.selectedListItemText : theme.text} wrapMode="none" flexGrow={1}>
+                  {truncate(row.display, 80)}
+                </text>
+              </box>
+            )
+          })}
+          {window.total > window.items.length ? (
+            <text fg={theme.textMuted}>
+              {window.total - window.items.length} more match
+              {window.total - window.items.length === 1 ? "" : "es"} hidden — keep typing or scroll
+            </text>
+          ) : null}
+        </box>
+      ) : (
+        <box paddingBottom={1}>
+          <text fg={theme.textMuted}>
+            {allRows.length === 0 ? t("chat.composer.historyEmpty") : t("chat.composer.historyNoMatches")}
+          </text>
+        </box>
+      )}
+      <box paddingBottom={1}>
+        <text fg={theme.textMuted}>{t("chat.composer.historyHint")}</text>
+      </box>
+    </box>
+  )
+}
+
+/**
+ * Promise-shaped entry point, mirroring the Solid
+ * `history-palette-controller` so the shared key-router's
+ * `showHistoryPalette` seam wires up identically on both sides.
+ */
+export const HistoryPalette = {
+  show(
+    dialog: DialogContext,
+    opts: {
+      readonly taskLabelFor: (historyKey: string) => string | undefined
+      readonly currentProject: string | undefined
+    },
+  ): Promise<string | undefined> {
+    return new Promise<string | undefined>((resolve) => {
+      dialog.replace(
+        () => (
+          <HistoryPaletteView
+            taskLabelFor={opts.taskLabelFor}
+            currentProject={opts.currentProject}
+            onSubmit={(v) => resolve(v)}
+            onCancel={() => resolve(undefined)}
+          />
+        ),
+        () => resolve(undefined),
+      )
+    })
+  },
+}

--- a/packages/kobe/src/tui-react/chat/mention-controller.ts
+++ b/packages/kobe/src/tui-react/chat/mention-controller.ts
@@ -1,0 +1,166 @@
+/**
+ * React `@`-mention controller — the `src/tui/chat/composer/mention-controller.ts`
+ * counterpart (issue #15 G3). All mention SEMANTICS (context detection,
+ * ranking, file-list cache, dropdown windowing, path-chip detection) are the
+ * shared framework-free modules; this hook owns only the React reactivity.
+ *
+ * Latency note: the derived values are `useMemo`s keyed on the live buffer /
+ * cursor the composer already re-renders for on each keystroke, and
+ * `handleKeyDown` reads state through a render-refreshed ref so its identity
+ * stays stable (no per-key closure churn in the textarea props).
+ */
+
+import type { KeyEvent, TextareaRenderable } from "@opentui/core"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { type DropdownWindow, makeDropdownWindow } from "../../tui/chat/composer/dropdown-window"
+import { isPlainAutocompleteTabKey } from "../../tui/chat/composer/keys"
+import {
+  type MentionContext,
+  type MentionMatch,
+  filterMentionMatches,
+  findMentionContext,
+  getWorktreeFiles,
+} from "../../tui/chat/composer/mention"
+import { type PreviewablePathRef, findPreviewablePathRefs } from "../../tui/chat/composer/path-preview"
+
+const MENTION_MAX_VISIBLE = 8
+
+export type MentionController = {
+  readonly open: boolean
+  readonly window: DropdownWindow<MentionMatch>
+  readonly cursor: number
+  readonly pathRefs: readonly PreviewablePathRef[]
+  readonly handleKeyDown: (key: KeyEvent) => boolean
+}
+
+export function useMentionController(args: {
+  readonly worktreePath: string | undefined
+  readonly liveBuffer: string
+  readonly liveCursor: number
+  readonly slashOpen: boolean
+  readonly textarea: () => TextareaRenderable | undefined
+}): MentionController {
+  const [files, setFiles] = useState<readonly string[]>([])
+  const [cursor, setCursor] = useState(0)
+  // Buffer offset of an `@` the user explicitly dismissed via Esc. While the
+  // active mention context still resolves to this anchor, suppress the
+  // dropdown. Cleared once the cursor leaves the mention region.
+  const [dismissedAt, setDismissedAt] = useState<number | null>(null)
+
+  // Refetch the worktree file list when the active task's worktree changes.
+  // Canon async shape (see tui-react/history/host.tsx): dependency-keyed
+  // effect, disposed-flag cancellation, failures collapse to empty.
+  useEffect(() => {
+    if (!args.worktreePath) {
+      setFiles([])
+      return
+    }
+    let disposed = false
+    getWorktreeFiles(args.worktreePath)
+      .then((list) => {
+        if (!disposed) setFiles(list)
+      })
+      .catch(() => {
+        if (!disposed) setFiles([])
+      })
+    return () => {
+      disposed = true
+    }
+  }, [args.worktreePath])
+
+  const context = useMemo<MentionContext | null>(() => {
+    if (!args.worktreePath) return null
+    return findMentionContext(args.liveBuffer, args.liveCursor)
+  }, [args.worktreePath, args.liveBuffer, args.liveCursor])
+
+  // Clear the Esc-dismissed anchor when the cursor leaves its span.
+  useEffect(() => {
+    if (dismissedAt === null) return
+    if (!context || context.atPos !== dismissedAt) setDismissedAt(null)
+  }, [context, dismissedAt])
+
+  const matches = useMemo<readonly MentionMatch[]>(() => {
+    if (!context) return []
+    if (dismissedAt === context.atPos) return []
+    return filterMentionMatches(files, context.query, MENTION_MAX_VISIBLE * 4)
+  }, [context, dismissedAt, files])
+
+  // Slash dropdown wins when both could open — a buffer starting with `/`
+  // shouldn't surface a file picker because the user is plainly running a
+  // command.
+  const open = !args.slashOpen && matches.length > 0
+
+  // Keep cursor in bounds when the match list changes.
+  useEffect(() => {
+    const len = matches.length
+    setCursor((cur) => (len === 0 ? 0 : Math.min(cur, len - 1)))
+  }, [matches.length])
+
+  const window = useMemo(() => makeDropdownWindow(matches, cursor, MENTION_MAX_VISIBLE), [matches, cursor])
+
+  const pathRefs = useMemo(() => findPreviewablePathRefs(args.liveBuffer, files), [args.liveBuffer, files])
+
+  // Stable key handler over a render-refreshed state ref (useBindings pattern).
+  const stateRef = useRef({ open, matches, cursor, context })
+  stateRef.current = { open, matches, cursor, context }
+  const handlersRef = useRef<((key: KeyEvent) => boolean) | null>(null)
+  if (handlersRef.current === null) {
+    /**
+     * Replace the active mention span (`@<query>`) with `@<relPath> `.
+     * Uses `setSelection` + `insertText` so the operation participates in
+     * undo. Cursor lands one past the trailing space, ready for more typing.
+     */
+    const insertSelection = (path: string): void => {
+      const ref = args.textarea()
+      const ctx = stateRef.current.context
+      if (!ref || !ctx) return
+      const currentCursor = ref.cursorOffset
+      ref.setSelection(ctx.atPos, currentCursor)
+      ref.deleteSelection()
+      ref.insertText(`@${path} `)
+      setDismissedAt(null)
+      setCursor(0)
+    }
+
+    /**
+     * Mention-dropdown nav. Priority sits above history (so up/down walk
+     * the file list instead of recalling prompts). Tab and Enter both
+     * insert the highlighted file path; Esc dismisses the dropdown until
+     * the cursor leaves the `@` region.
+     */
+    handlersRef.current = (key: KeyEvent): boolean => {
+      const s = stateRef.current
+      if (!s.open) return false
+
+      if (key.name === "up" && !key.shift && !key.ctrl && !key.meta && !key.super) {
+        const len = s.matches.length
+        setCursor((cur) => (cur - 1 + len) % len)
+        key.preventDefault()
+        return true
+      }
+      if (key.name === "down" && !key.shift && !key.ctrl && !key.meta && !key.super) {
+        const len = s.matches.length
+        setCursor((cur) => (cur + 1) % len)
+        key.preventDefault()
+        return true
+      }
+      if ((key.name === "return" && !key.shift && !key.ctrl) || isPlainAutocompleteTabKey(key)) {
+        const match = s.matches[s.cursor]
+        if (match) {
+          insertSelection(match.path)
+          key.preventDefault()
+          return true
+        }
+      }
+      if (key.name === "escape") {
+        if (s.context) setDismissedAt(s.context.atPos)
+        key.preventDefault()
+        return true
+      }
+
+      return false
+    }
+  }
+
+  return { open, window, cursor, pathRefs, handleKeyDown: handlersRef.current }
+}

--- a/packages/kobe/src/tui-react/chat/mock-host.tsx
+++ b/packages/kobe/src/tui-react/chat/mock-host.tsx
@@ -1,0 +1,27 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React chat-pane mock host (`bun run dev:mock-react-chat`) — renders the
+ * ported pane against the scripted fake harness turn in
+ * `src/tui/chat/mock-turn.ts`: the pane auto-submits the fixture prompt on
+ * mount and the fake `startTurn` streams growing UIMessage snapshots
+ * (reasoning → prose → tool call → final summary). No engine, tmux, daemon,
+ * or worktree involved; the composer stays fully interactive.
+ */
+
+import { MOCK_CHAT_PROMPT, MOCK_CHAT_WORKTREE, createMockStartTurn } from "../../tui/chat/mock-turn"
+import { bootPaneHost } from "../lib/host-boot"
+import { ChatPane } from "./chat-pane"
+
+await bootPaneHost({
+  setup: () => ({
+    root: () => (
+      <ChatPane
+        worktree={MOCK_CHAT_WORKTREE}
+        title="mock chat"
+        vendor="claude"
+        startTurn={createMockStartTurn()}
+        initialPrompt={MOCK_CHAT_PROMPT}
+      />
+    ),
+  }),
+})

--- a/packages/kobe/src/tui-react/chat/model-picker.tsx
+++ b/packages/kobe/src/tui-react/chat/model-picker.tsx
@@ -1,0 +1,246 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React model picker dialog — the `src/tui/chat/composer/ModelPicker.tsx`
+ * counterpart (issue #15 G3). Two-step flow: pick a model, then (for models
+ * that declare effort levels) pick an effort. Row grouping/ordering comes
+ * from the shared framework-free `composer/model-picker-row`.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useMemo, useState } from "react"
+import { allModels, getCapabilities } from "../../engine/registry"
+import {
+  type ModelPickerModelOption,
+  modelPickerEffortOptions,
+  modelPickerModelOptions,
+} from "../../tui/chat/composer/model-picker-row"
+import type { ModelChoice } from "../../types/engine"
+import { DEFAULT_TASK_VENDOR } from "../../types/task"
+import type { VendorId } from "../../types/vendor"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { useDialog } from "../ui/dialog"
+
+export type ModelPickerResult = Pick<ModelChoice, "vendor" | "id" | "effort"> | undefined
+
+export type ModelPickerProps = {
+  current: string | undefined
+  currentEffort?: string | undefined
+  currentVendor?: VendorId | undefined
+  lockedVendor?: VendorId | undefined
+  onPick: (choice: Pick<ModelChoice, "vendor" | "id" | "effort">) => void
+  onCancel: () => void
+}
+
+export function ModelPicker(props: ModelPickerProps) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const t = useT()
+
+  // The list is stable for the dialog's lifetime.
+  const models = useMemo(
+    () => modelPickerModelOptions(allModels(), { lockedVendor: props.lockedVendor }),
+    [props.lockedVendor],
+  )
+  const [selectedModel, setSelectedModel] = useState<ModelPickerModelOption | undefined>(undefined)
+  const effortChoices = useMemo(() => (selectedModel ? modelPickerEffortOptions(selectedModel) : []), [selectedModel])
+
+  // Cursor starts on the currently-pinned model so a single enter re-confirms
+  // the existing choice. When unpinned, seed on the active vendor's resolved
+  // default so the picker reflects what the user is actually running.
+  const [cursor, setCursor] = useState(() => {
+    const seedVendor = props.currentVendor ?? props.lockedVendor ?? DEFAULT_TASK_VENDOR
+    const seed = props.current ?? getCapabilities(seedVendor)?.defaultModelId()
+    const initial = models.findIndex((m) => m.id === seed)
+    return nextEnabledIndex(models, initial >= 0 ? initial : 0, 1)
+  })
+  const [effortCursor, setEffortCursor] = useState(0)
+  const inEffortStep = selectedModel !== undefined
+
+  function setInitialEffortCursor(model: ModelPickerModelOption): void {
+    const efforts = modelPickerEffortOptions(model)
+    const idx = efforts.findIndex((choice) => choice.effort === props.currentEffort)
+    setEffortCursor(idx >= 0 ? idx : 0)
+  }
+
+  function commitEffort(): void {
+    const model = selectedModel
+    if (!model) return
+    const choice = effortChoices[effortCursor]
+    if (!choice) return
+    props.onPick({ vendor: model.vendor, id: model.id, effort: choice.effort })
+    dialog.clear()
+  }
+
+  function commit(): void {
+    if (inEffortStep) {
+      commitEffort()
+      return
+    }
+    const model = models[cursor]
+    if (!model) return
+    if (model.disabled) return
+    const efforts = modelPickerEffortOptions(model)
+    if (efforts.length <= 1 && efforts[0]?.effort === undefined) {
+      props.onPick({ vendor: model.vendor, id: model.id, effort: undefined })
+      dialog.clear()
+      return
+    }
+    setSelectedModel(model)
+    setInitialEffortCursor(model)
+  }
+
+  function backToModels(): void {
+    setSelectedModel(undefined)
+  }
+
+  const move = (delta: -1 | 1): void => {
+    const n = inEffortStep ? effortChoices.length : models.length
+    if (n === 0) return
+    if (inEffortStep) setEffortCursor((c) => (c + delta + n) % n)
+    else setCursor((c) => nextEnabledIndex(models, c + delta, delta))
+  }
+
+  useBindings(() => ({
+    bindings: [
+      { key: "up", cmd: () => move(-1) },
+      { key: "down", cmd: () => move(1) },
+      { key: "k", cmd: () => move(-1) },
+      { key: "j", cmd: () => move(1) },
+      { key: "left", cmd: backToModels },
+      { key: "h", cmd: backToModels },
+      { key: "return", cmd: commit },
+    ],
+  }))
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {inEffortStep ? t("chat.composer.pickEffort") : t("chat.composer.pickModel")}
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => props.onCancel()}>
+          {t("chat.composer.esc")}
+        </text>
+      </box>
+      {inEffortStep ? (
+        <box flexDirection="column" paddingBottom={1}>
+          <box flexDirection="row" gap={2} paddingLeft={1} paddingRight={1}>
+            <text fg={theme.textMuted} wrapMode="none">
+              model
+            </text>
+            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
+              {selectedModel?.label}
+            </text>
+          </box>
+          {effortChoices.map((choice, i) => {
+            const active = i === effortCursor
+            return (
+              <box
+                key={`${choice.id}:${choice.effort ?? ""}`}
+                flexDirection="row"
+                gap={2}
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={active ? theme.primary : undefined}
+                onMouseUp={() => {
+                  const model = selectedModel
+                  if (!model) return
+                  setEffortCursor(i)
+                  props.onPick({ vendor: model.vendor, id: choice.id, effort: choice.effort })
+                  dialog.clear()
+                }}
+              >
+                <text
+                  fg={active ? theme.selectedListItemText : theme.text}
+                  attributes={active ? TextAttributes.BOLD : undefined}
+                  wrapMode="none"
+                >
+                  {active ? "▸ " : "  "}
+                  {choice.label}
+                </text>
+                {choice.hint ? (
+                  <text fg={active ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                    {choice.hint}
+                  </text>
+                ) : null}
+              </box>
+            )
+          })}
+        </box>
+      ) : (
+        <box flexDirection="column" paddingBottom={1}>
+          {models.map((model, i) => {
+            const active = i === cursor
+            const disabled = model.disabled === true
+            const hasEfforts = modelPickerEffortOptions(model).some((choice) => choice.effort !== undefined)
+            return (
+              <box
+                key={`${model.vendor}:${model.id}`}
+                flexDirection="row"
+                gap={2}
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={active && !disabled ? theme.primary : undefined}
+                onMouseUp={() => {
+                  if (disabled) return
+                  const efforts = modelPickerEffortOptions(model)
+                  if (efforts.length <= 1 && efforts[0]?.effort === undefined) {
+                    props.onPick({ vendor: model.vendor, id: model.id, effort: undefined })
+                    dialog.clear()
+                    return
+                  }
+                  setCursor(i)
+                  setSelectedModel(model)
+                  setInitialEffortCursor(model)
+                }}
+              >
+                <text
+                  fg={active && !disabled ? theme.selectedListItemText : disabled ? theme.textMuted : theme.text}
+                  attributes={active && !disabled ? TextAttributes.BOLD : undefined}
+                  wrapMode="none"
+                >
+                  {active ? "▸ " : "  "}
+                  {model.label}
+                </text>
+                <text fg={active && !disabled ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                  {model.vendor}
+                </text>
+                {disabled && model.disabledReason ? (
+                  <text fg={theme.textMuted} wrapMode="none">
+                    {model.disabledReason}
+                  </text>
+                ) : hasEfforts ? (
+                  <text fg={active ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                    effort…
+                  </text>
+                ) : null}
+                {model.hint ? (
+                  <text fg={active && !disabled ? theme.selectedListItemText : theme.textMuted} wrapMode="none">
+                    {model.hint}
+                  </text>
+                ) : null}
+              </box>
+            )
+          })}
+        </box>
+      )}
+      <box paddingBottom={1}>
+        <text fg={theme.textMuted}>
+          {inEffortStep ? t("chat.composer.pickerHintEffort") : t("chat.composer.pickerHint")}
+        </text>
+      </box>
+    </box>
+  )
+}
+
+function nextEnabledIndex(models: readonly ModelPickerModelOption[], start: number, step: 1 | -1): number {
+  if (models.length === 0) return 0
+  const normalized = ((start % models.length) + models.length) % models.length
+  for (let offset = 0; offset < models.length; offset++) {
+    const idx = (((normalized + offset * step) % models.length) + models.length) % models.length
+    if (!models[idx]?.disabled) return idx
+  }
+  return normalized
+}

--- a/packages/kobe/src/tui/chat/Composer.tsx
+++ b/packages/kobe/src/tui/chat/Composer.tsx
@@ -55,6 +55,7 @@ import { type ComposerModeTone, ComposerView } from "./ComposerView"
 import { makeDropdownWindow } from "./composer/dropdown-window"
 import { getHistory } from "./composer/history"
 import { PromptHistoryNavigator } from "./composer/history-nav"
+import { HistoryPalette } from "./composer/history-palette-controller"
 import { createImageAttach } from "./composer/image-attach"
 import { ImagePasteRegistry } from "./composer/image-paste"
 import { createKeyRouter } from "./composer/key-router"
@@ -286,7 +287,9 @@ export function Composer(props: ComposerProps) {
 
   const { handleKeyDown, handleSubmit, handleContentChange } = createKeyRouter({
     props,
-    dialog,
+    // Framework seam: the router is framework-free, so the Solid dialog
+    // context stays here and only the show-palette capability crosses over.
+    showHistoryPalette: (opts) => HistoryPalette.show(dialog, opts),
     getTextarea: () => textareaRef,
     bashMode,
     setBashMode,

--- a/packages/kobe/src/tui/chat/ComposerQueue.tsx
+++ b/packages/kobe/src/tui/chat/ComposerQueue.tsx
@@ -2,10 +2,9 @@ import { useTheme } from "@/tui/context/theme"
 import { t } from "@/tui/i18n"
 import { TextAttributes } from "@opentui/core"
 import { type Accessor, For, Show } from "solid-js"
+import type { ComposerQueuedItem } from "./composer/queue-item"
 
-export type ComposerQueuedItem =
-  | { readonly id: string; readonly kind: "prompt"; readonly text: string }
-  | { readonly id: string; readonly kind: "bash"; readonly command: string }
+export type { ComposerQueuedItem } from "./composer/queue-item"
 
 /**
  * Hard cap on visible queued rows so a fast typist who stacked many

--- a/packages/kobe/src/tui/chat/ComposerView.tsx
+++ b/packages/kobe/src/tui/chat/ComposerView.tsx
@@ -116,12 +116,15 @@ export function ComposerView(props: ComposerViewProps) {
               >
                 <textarea
                   ref={props.onTextareaMount}
-                  placeholder={resolvePlaceholder({
-                    isStreaming: props.isStreaming,
-                    hasTask: props.hasTask,
-                    noTaskMessage: props.noTaskMessage,
-                    inputPlaceholder: props.inputPlaceholder,
-                  })}
+                  placeholder={resolvePlaceholder(
+                    {
+                      isStreaming: props.isStreaming,
+                      hasTask: props.hasTask,
+                      noTaskMessage: props.noTaskMessage,
+                      inputPlaceholder: props.inputPlaceholder,
+                    },
+                    t,
+                  )}
                   placeholderColor={theme.textMuted}
                   textColor={theme.text}
                   backgroundColor={theme.backgroundElement}

--- a/packages/kobe/src/tui/chat/composer/key-router.ts
+++ b/packages/kobe/src/tui/chat/composer/key-router.ts
@@ -1,15 +1,29 @@
-import type { DialogContext } from "@/tui/ui/dialog"
 import type { KeyEvent, TextareaRenderable } from "@opentui/core"
-import type { Accessor, Setter } from "solid-js"
 import { isCursorAtFirstLine, isCursorAtLastLine } from "./cursor"
 import { pushHistory } from "./history"
 import type { PromptHistoryNavigator } from "./history-nav"
-import { HistoryPalette } from "./history-palette-controller"
 import type { ImagePasteRegistry } from "./image-paste"
 import { deleteImageTokenBackward, deleteImageTokenForward } from "./image-token-delete"
 import { isPermissionModeCycleKey, isPlainAutocompleteTabKey } from "./keys"
-import type { MentionController } from "./mention-controller"
-import type { ComposerProps, ComposerSlashEntry } from "./props"
+import type { Accessor, ComposerProps, ComposerSlashEntry } from "./props"
+
+/**
+ * Value-or-updater setter — the shape both Solid's `Setter<T>` and React's
+ * `Dispatch<SetStateAction<T>>` satisfy, so the router stays framework-free
+ * (issue #15 G3) and both composers hand their native setters straight in.
+ */
+export type ValueSetter<T> = (value: T | ((prev: T) => T)) => void
+
+/**
+ * Ctrl+R palette seam — the Solid composer wires this to
+ * `HistoryPalette.show(dialog, opts)` and the React composer to its own
+ * dialog stack, keeping the router free of any framework's dialog context.
+ * Resolves with the picked entry's raw stored value, `undefined` on cancel.
+ */
+export type ShowHistoryPalette = (opts: {
+  readonly taskLabelFor: (historyKey: string) => string | undefined
+  readonly currentProject: string | undefined
+}) => Promise<string | undefined>
 
 /**
  * Input-event glue extracted from Composer: the raw-key router
@@ -20,24 +34,25 @@ import type { ComposerProps, ComposerSlashEntry } from "./props"
  */
 export function createKeyRouter(deps: {
   readonly props: ComposerProps
-  readonly dialog: DialogContext
+  readonly showHistoryPalette: ShowHistoryPalette
   readonly getTextarea: () => TextareaRenderable | undefined
   readonly bashMode: Accessor<boolean>
-  readonly setBashMode: Setter<boolean>
+  readonly setBashMode: ValueSetter<boolean>
   readonly bashAvailable: () => boolean
   readonly liveBuffer: Accessor<string>
-  readonly setLiveBuffer: Setter<string>
-  readonly setLiveCursor: Setter<number>
+  readonly setLiveBuffer: ValueSetter<string>
+  readonly setLiveCursor: ValueSetter<number>
   readonly setBuffer: (text: string) => void
   readonly slashOpen: Accessor<boolean>
   readonly slashMatches: Accessor<readonly ComposerSlashEntry[]>
   readonly slashCursor: Accessor<number>
-  readonly setSlashCursor: Setter<number>
-  readonly mention: MentionController
+  readonly setSlashCursor: ValueSetter<number>
+  /** Structural slice of the mention controller — the router only routes keys. */
+  readonly mention: { readonly handleKeyDown: (key: KeyEvent) => boolean }
   readonly historyNav: PromptHistoryNavigator
   readonly imageRegistry: ImagePasteRegistry
   readonly pasteHint: Accessor<string | null>
-  readonly setPasteHint: Setter<string | null>
+  readonly setPasteHint: ValueSetter<string | null>
   readonly applyHistoryRecall: (recalled: string) => void
   readonly tryAttachClipboardImage: () => Promise<void>
 }): {
@@ -47,7 +62,7 @@ export function createKeyRouter(deps: {
 } {
   const {
     props,
-    dialog,
+    showHistoryPalette,
     getTextarea,
     bashMode,
     setBashMode,
@@ -163,7 +178,7 @@ export function createKeyRouter(deps: {
     // the palette, but each row falls back to "no task label".
     if (key.name === "r" && key.ctrl && !key.shift && !key.meta && !key.super) {
       const resolver = props.taskLabelForHistoryKey ?? (() => undefined)
-      void HistoryPalette.show(dialog, {
+      void showHistoryPalette({
         taskLabelFor: resolver,
         currentProject: props.currentProjectRoot?.(),
       }).then((picked) => {

--- a/packages/kobe/src/tui/chat/composer/keybindings.ts
+++ b/packages/kobe/src/tui/chat/composer/keybindings.ts
@@ -34,14 +34,16 @@
  * keys mid-buffer too, breaking multi-line cursor navigation.
  */
 
-import type { TextareaProps } from "@opentui/solid"
+import type { TextareaOptions } from "@opentui/core"
 
 /**
  * Type alias for the array shape `<textarea keyBindings={...}>` expects.
- * Defined inline so we don't depend on opentui's internal exports — the
- * shape is just `{ name, ctrl?, shift?, meta?, super?, action }`.
+ * Sourced from the framework-neutral core renderable options (both the
+ * Solid and React textarea props extend `TextareaOptions`) so this module
+ * stays framework-free — the shape is just
+ * `{ name, ctrl?, shift?, meta?, super?, action }`.
  */
-type Binding = NonNullable<TextareaProps["keyBindings"]>[number]
+type Binding = NonNullable<TextareaOptions["keyBindings"]>[number]
 
 /**
  * Keybindings the composer pushes into `<textarea keyBindings={...}>`.

--- a/packages/kobe/src/tui/chat/composer/placeholder.ts
+++ b/packages/kobe/src/tui/chat/composer/placeholder.ts
@@ -1,15 +1,22 @@
 /**
- * Resolve chat composer placeholder copy without importing opentui UI
- * modules. Kept pure so tests can cover the visual state contract.
+ * Resolve chat composer placeholder copy without importing opentui UI or
+ * either framework's i18n runtime. Kept pure so tests can cover the visual
+ * state contract.
+ *
+ * `translate` is injected: the Solid composer view passes the module `t`,
+ * the React one passes its `useT()` function — the two runtimes hold
+ * separate locale stores, so the fallback copy must resolve in the caller's.
  */
-import { t } from "@/tui/i18n"
-export function resolvePlaceholder(opts: {
-  isStreaming: boolean
-  hasTask: boolean
-  noTaskMessage?: string
-  inputPlaceholder?: string
-}): string {
-  if (!opts.hasTask) return opts.noTaskMessage ?? t("chat.composer.noTask")
+export function resolvePlaceholder(
+  opts: {
+    isStreaming: boolean
+    hasTask: boolean
+    noTaskMessage?: string
+    inputPlaceholder?: string
+  },
+  translate: (key: string) => string,
+): string {
+  if (!opts.hasTask) return opts.noTaskMessage ?? translate("chat.composer.noTask")
   if (opts.isStreaming) return ""
-  return opts.inputPlaceholder ?? t("chat.composer.askFallback")
+  return opts.inputPlaceholder ?? translate("chat.composer.askFallback")
 }

--- a/packages/kobe/src/tui/chat/composer/props.ts
+++ b/packages/kobe/src/tui/chat/composer/props.ts
@@ -1,6 +1,12 @@
 import type { PermissionMode } from "@/types/engine"
-import type { Accessor } from "solid-js"
-import type { ComposerQueuedItem } from "../ComposerQueue"
+import type { ComposerQueuedItem } from "./queue-item"
+
+/**
+ * Structural twin of Solid's `Accessor<T>` so this props contract stays
+ * framework-free (issue #15 G3): the Solid composer passes signal getters,
+ * the React composer passes plain closures over its latest render.
+ */
+export type Accessor<T> = () => T
 
 /**
  * Slash entry rendered in the composer's `/` dropdown. `SlashEntry`

--- a/packages/kobe/src/tui/chat/composer/queue-item.ts
+++ b/packages/kobe/src/tui/chat/composer/queue-item.ts
@@ -1,0 +1,8 @@
+/**
+ * Composer queue entry — extracted from `ComposerQueue.tsx` so the type is
+ * framework-free (issue #15 G3): the Solid and React queue panels, the shared
+ * `ComposerProps`, and the chat panes all consume this one shape.
+ */
+export type ComposerQueuedItem =
+  | { readonly id: string; readonly kind: "prompt"; readonly text: string }
+  | { readonly id: string; readonly kind: "bash"; readonly command: string }

--- a/packages/kobe/src/tui/chat/mock-turn.ts
+++ b/packages/kobe/src/tui/chat/mock-turn.ts
@@ -1,0 +1,82 @@
+/**
+ * `dev:mock-react-chat` fixture — a scripted fake AI SDK harness turn.
+ *
+ * Framework-free (same seam family as `history/mock-fixtures.ts`): the chat
+ * pane takes its turn runner through the injectable `startTurn` prop, and
+ * this factory returns a drop-in for `startAiSdkTurn` that streams growing
+ * `UIMessage` snapshots on a timer — reasoning, prose, a dynamic tool call
+ * resolving to output, then the final summary line — with no engine, tmux,
+ * daemon, or worktree involved. `interrupt()` stops the script mid-stream,
+ * matching the real turn's abort semantics.
+ */
+
+import type { AiSdkTurn, AiSdkTurnOpts } from "@/engine/ai-sdk/harness-turn"
+import type { UIMessage } from "ai"
+
+export const MOCK_CHAT_WORKTREE = "/mock/kobe-chat-demo"
+export const MOCK_CHAT_PROMPT = "Summarize the mock release notes"
+/** Greppable proof line — the dev:mock-react-chat gate asserts this reaches the screen. */
+export const MOCK_CHAT_DONE_TEXT = "Mock harness turn complete — release notes summarized."
+
+type Parts = UIMessage["parts"]
+
+/** The scripted snapshot sequence; each entry REPLACES the assistant tail. */
+function snapshots(): readonly Parts[] {
+  const reasoning: Parts[number] = { type: "reasoning", text: "Scanning the mock release notes fixture…" }
+  const prose: Parts[number] = { type: "text", text: "Reading the fixture transcript for highlights." }
+  const toolRunning: Parts[number] = {
+    type: "dynamic-tool",
+    toolName: "Bash",
+    toolCallId: "mock-tool-1",
+    state: "input-available",
+    input: { command: "git log --oneline -3" },
+  }
+  const toolDone: Parts[number] = {
+    type: "dynamic-tool",
+    toolName: "Bash",
+    toolCallId: "mock-tool-1",
+    state: "output-available",
+    input: { command: "git log --oneline -3" },
+    output: "a1b2c3 feat: mock release entry\nd4e5f6 fix: mock bugfix entry",
+  }
+  const summary: Parts[number] = { type: "text", text: MOCK_CHAT_DONE_TEXT }
+  return [
+    [reasoning],
+    [reasoning, prose],
+    [reasoning, prose, toolRunning],
+    [reasoning, prose, toolDone],
+    [reasoning, prose, toolDone, summary],
+  ]
+}
+
+/**
+ * Build a fake `startAiSdkTurn`. `stepMs` spaces the snapshots (default
+ * 400ms — visible growth inside the 6s dev:mock gate window; tests pass 1ms).
+ */
+export function createMockStartTurn(stepMs = 400): (opts: AiSdkTurnOpts) => AiSdkTurn {
+  return (opts) => {
+    const frames = snapshots()
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let finish: () => void = () => {}
+    const done = new Promise<{ error?: never }>((resolve) => {
+      finish = () => {
+        if (timer) clearTimeout(timer)
+        timer = undefined
+        resolve({})
+      }
+      let i = 0
+      const step = (): void => {
+        const parts = frames[i]
+        if (!parts) {
+          finish()
+          return
+        }
+        i += 1
+        opts.onUpdate({ id: "mock-assistant-1", role: "assistant", parts: [...parts] })
+        timer = setTimeout(step, stepMs)
+      }
+      timer = setTimeout(step, stepMs)
+    })
+    return { done, interrupt: () => finish() }
+  }
+}

--- a/packages/kobe/src/tui/component/border.ts
+++ b/packages/kobe/src/tui/component/border.ts
@@ -5,6 +5,9 @@
  * `EmptyBorder` is the "no chrome" preset; `SplitBorder` draws a solid vertical
  * `┃` between adjacent panes, used everywhere a pane separator is wanted
  * without the rest of a box border.
+ *
+ * Plain data, no JSX — a `.ts` module so both the Solid and React pane
+ * trees can share it (issue #15 G3).
  */
 
 export const EmptyBorder = {

--- a/packages/kobe/test/tui-react/chat-mock-turn.test.ts
+++ b/packages/kobe/test/tui-react/chat-mock-turn.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for `src/tui/chat/mock-turn.ts` — the scripted fake harness
+ * turn behind `dev:mock-react-chat` (issue #15 G3).
+ *
+ * Why this matters: the mock is the render proof for the React chat pane —
+ * if the script stops emitting growing snapshots, ending with the greppable
+ * summary line, the live gate silently loses its assertion target. The
+ * module is framework-free (type-only imports), so it runs directly under
+ * vitest's node environment.
+ */
+
+import type { UIMessage } from "ai"
+import { describe, expect, test } from "vitest"
+import {
+  MOCK_CHAT_DONE_TEXT,
+  MOCK_CHAT_PROMPT,
+  MOCK_CHAT_WORKTREE,
+  createMockStartTurn,
+} from "../../src/tui/chat/mock-turn"
+
+function collect(stepMs: number) {
+  const updates: UIMessage[] = []
+  const turn = createMockStartTurn(stepMs)({
+    worktree: MOCK_CHAT_WORKTREE,
+    prompt: MOCK_CHAT_PROMPT,
+    onUpdate: (msg) => updates.push(msg),
+  })
+  return { updates, turn }
+}
+
+describe("createMockStartTurn", () => {
+  test("streams growing assistant snapshots and resolves without error", async () => {
+    const { updates, turn } = collect(1)
+    const { error } = await turn.done
+    expect(error).toBeUndefined()
+    expect(updates.length).toBeGreaterThanOrEqual(4)
+    // Snapshots REPLACE the tail (ChatPane contract): same id, growing parts.
+    expect(new Set(updates.map((u) => u.id)).size).toBe(1)
+    for (let i = 1; i < updates.length; i++) {
+      const prev = updates[i - 1]
+      const cur = updates[i]
+      if (!prev || !cur) throw new Error("unreachable: bounded loop")
+      expect(cur.parts.length).toBeGreaterThanOrEqual(prev.parts.length)
+    }
+    // The dev:mock-react-chat live gate greps for the final summary line.
+    const last = updates.at(-1)
+    expect(last?.parts.some((p) => p.type === "text" && p.text === MOCK_CHAT_DONE_TEXT)).toBe(true)
+    // The tool call resolves through the dynamic-tool state machine.
+    expect(last?.parts.some((p) => p.type === "dynamic-tool" && p.state === "output-available")).toBe(true)
+  })
+
+  test("interrupt stops the script mid-stream", async () => {
+    const { updates, turn } = collect(60_000) // steps far beyond the test's lifetime
+    turn.interrupt()
+    const { error } = await turn.done
+    expect(error).toBeUndefined()
+    expect(updates.length).toBe(0)
+  })
+})

--- a/packages/kobe/test/tui/border.test.ts
+++ b/packages/kobe/test/tui/border.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Contract test for `src/tui/component/border.ts` — the framework-free
+ * border presets shared by the Solid and React composer views (issue #15
+ * G3). The values are terminal grammar: `SplitBorder`'s heavy `┃` and
+ * `EmptyBorder`'s all-blank charset are what make the composer rail and the
+ * pane separators read correctly, so a drive-by edit should fail a test,
+ * not surface as a subtly wrong glyph across every pane.
+ */
+
+import { describe, expect, test } from "vitest"
+import { EmptyBorder, HSplitBorder, SplitBorder } from "../../src/tui/component/border"
+
+describe("border presets", () => {
+  test("EmptyBorder draws no chrome (only the horizontal space filler)", () => {
+    expect(EmptyBorder.horizontal).toBe(" ")
+    const { horizontal, ...rest } = EmptyBorder
+    expect(Object.values(rest).every((ch) => ch === "")).toBe(true)
+  })
+
+  test("SplitBorder is a heavy vertical rule on the left/right edges", () => {
+    expect(SplitBorder.border).toEqual(["left", "right"])
+    expect(SplitBorder.customBorderChars.vertical).toBe("┃")
+    // Everything else stays EmptyBorder — the rail is the ONLY chrome.
+    expect(SplitBorder.customBorderChars.topLeft).toBe("")
+  })
+
+  test("HSplitBorder is the heavy horizontal sibling", () => {
+    expect(HSplitBorder.customBorderChars.horizontal).toBe("━")
+    expect(HSplitBorder.customBorderChars.vertical).toBe("")
+  })
+})

--- a/packages/kobe/test/tui/composer-glue.test.ts
+++ b/packages/kobe/test/tui/composer-glue.test.ts
@@ -4,7 +4,7 @@
  * predicates, the static keybinding table, and the model-picker row grouping.
  *
  * All of these are pure functions or plain data (no opentui runtime — the
- * `@opentui/solid` import in keybindings.ts is type-only and erased), so they
+ * `@opentui/core` import in keybindings.ts is type-only and erased), so they
  * run directly under vitest's node environment.
  */
 
@@ -57,20 +57,26 @@ type Fake = ReturnType<typeof fakeTextarea>
 const asRef = (f: Fake) => f as unknown as TextareaRenderable
 
 describe("resolvePlaceholder", () => {
+  // The i18n runtime is injected (framework-free module, issue #15 G3);
+  // a key-echo stub proves WHICH catalog key each fallback resolves.
+  const translate = (key: string) => `<${key}>`
+
   test("no task → the noTask override or the i18n default", () => {
-    expect(resolvePlaceholder({ isStreaming: false, hasTask: false, noTaskMessage: "nada" })).toBe("nada")
-    expect(resolvePlaceholder({ isStreaming: true, hasTask: false, noTaskMessage: "nada" })).toBe("nada")
-    // No override → falls through to t("chat.composer.noTask") (en default).
-    expect(resolvePlaceholder({ isStreaming: false, hasTask: false })).toBe("(no task — press n to create)")
+    expect(resolvePlaceholder({ isStreaming: false, hasTask: false, noTaskMessage: "nada" }, translate)).toBe("nada")
+    expect(resolvePlaceholder({ isStreaming: true, hasTask: false, noTaskMessage: "nada" }, translate)).toBe("nada")
+    // No override → falls through to translate("chat.composer.noTask").
+    expect(resolvePlaceholder({ isStreaming: false, hasTask: false }, translate)).toBe("<chat.composer.noTask>")
   })
 
   test("streaming with a task → empty (placeholder hidden mid-stream)", () => {
-    expect(resolvePlaceholder({ isStreaming: true, hasTask: true, inputPlaceholder: "Ask X" })).toBe("")
+    expect(resolvePlaceholder({ isStreaming: true, hasTask: true, inputPlaceholder: "Ask X" }, translate)).toBe("")
   })
 
   test("idle with a task → the input override or the i18n fallback", () => {
-    expect(resolvePlaceholder({ isStreaming: false, hasTask: true, inputPlaceholder: "Ask X" })).toBe("Ask X")
-    expect(resolvePlaceholder({ isStreaming: false, hasTask: true })).toBe("Type a prompt…")
+    expect(resolvePlaceholder({ isStreaming: false, hasTask: true, inputPlaceholder: "Ask X" }, translate)).toBe(
+      "Ask X",
+    )
+    expect(resolvePlaceholder({ isStreaming: false, hasTask: true }, translate)).toBe("<chat.composer.askFallback>")
   })
 })
 

--- a/packages/kobe/test/tui/composer-key-router.test.ts
+++ b/packages/kobe/test/tui/composer-key-router.test.ts
@@ -4,8 +4,8 @@
  * `handleKeyDown` / `handleSubmit` / `handleContentChange` driven with
  * mock callbacks and a fake textarea (no opentui, no real engine).
  *
- * `./history-palette-controller` is mocked so importing the router does
- * not pull in `@opentui/core` (which fails to load under vitest).
+ * The Ctrl+R palette is an injected seam (`showHistoryPalette`), so the
+ * router is framework-free and imports cleanly under vitest.
  */
 
 import type { KeyEvent } from "@opentui/core"
@@ -13,10 +13,6 @@ import { beforeAll, describe, expect, test, vi } from "vitest"
 
 // Never touch the real ~/.kobe history store from a submit path.
 process.env.KOBE_HISTORY_PERSIST = "false"
-
-vi.mock("../../src/tui/chat/composer/history-palette-controller", () => ({
-  HistoryPalette: { show: vi.fn(async () => undefined) },
-}))
 
 import { createKeyRouter } from "../../src/tui/chat/composer/key-router"
 
@@ -100,7 +96,7 @@ function build(opts: {
 
   const deps = {
     props,
-    dialog: {},
+    showHistoryPalette: vi.fn(async () => undefined),
     getTextarea: () => textarea,
     bashMode,
     setBashMode: vi.fn(setBashMode),
@@ -167,6 +163,22 @@ describe("handleKeyDown", () => {
     const { router, slashCursor } = build({ slashOpen: true, slashMatches: matches, slashCursor: 0 })
     router.handleKeyDown(key({ name: "down" }))
     expect(slashCursor()).toBe(1)
+  })
+
+  test("ctrl+r opens the injected history palette and applies the pick", async () => {
+    // The palette is a framework seam (issue #15 G3): the router only knows
+    // the promise contract, so both the Solid and React composers can wire
+    // their own dialog stacks in.
+    const { router, deps } = build({})
+    ;(deps.showHistoryPalette as ReturnType<typeof vi.fn>).mockResolvedValueOnce("!ls -la")
+    const k = key({ name: "r", ctrl: true })
+    router.handleKeyDown(k)
+    expect(deps.showHistoryPalette).toHaveBeenCalledWith(
+      expect.objectContaining({ currentProject: undefined, taskLabelFor: expect.any(Function) }),
+    )
+    expect(k.preventDefault).toHaveBeenCalled()
+    await new Promise((r) => setTimeout(r, 0)) // let the .then(applyHistoryRecall) hop settle
+    expect(deps.applyHistoryRecall).toHaveBeenCalledWith("!ls -la")
   })
 
   test("up arrow at the first line recalls prior history", () => {


### PR DESCRIPTION
## Summary
- G3 wave 1, the biggest pane port: `src/tui-react/chat/` reaches parity with the Solid chat pane — the transcript renders AI SDK `UIMessage` parts verbatim (ChatRow contract unchanged), and the FULL composer ports over: bash mode, `/` slash dropdown, `@` file mentions, per-key prompt history + ctrl+r cross-task palette, image paste (bracketed + ctrl+v), mid-turn queue with steer/send-now/cancel, model picker dialog, shift+tab permission cycle.
- **Shared, framework-free extractions (Solid keeps consuming every one):** the composer key router (`key-router.ts` — the ctrl+r palette became an injected `showHistoryPalette` seam so the router drops its Solid dialog dependency), `composer/props.ts` (structural `Accessor` alias instead of the solid-js type), `composer/queue-item.ts` (queue entry shape out of the Solid `ComposerQueue.tsx`), `composer/keybindings.ts` (types off framework-neutral `@opentui/core`), `composer/placeholder.ts` (injected `translate` so each runtime resolves its own locale store), and `component/border.ts` (renamed from `.tsx` — pure data, no JSX).
- React-only glue follows the G3.1 canon: `useState` + dependency-keyed effects with disposed-flag cancellation (mention file-list fetch), render-refreshed refs for the per-keystroke hot path (key router, mention key handler, turn pipeline), derived dropdown lists memoized on the live-buffer mirror.
- **Render proof:** new `dev:mock-react-chat` script renders the pane against a scripted fake harness turn (`src/tui/chat/mock-turn.ts`, unit-tested): the pane auto-submits a fixture prompt and streams reasoning → prose → a Bash tool call resolving to output → the final summary line.
- Out of scope per the wave brief: the KOBE_TUI=1 workspace co-mount stays Solid-only (a Solid tree cannot host a React subtree); the React pane ships with the mock proof and the injectable `startTurn`/`initialPrompt` seams instead.

coverage-exemption: packages/kobe/src/tui-react/chat/mention-controller.ts — React-hook glue (useState/useEffect cannot execute outside a React renderer under vitest); all mention semantics live in the shared, unit-tested `composer/mention.ts` + `path-preview.ts`, and the hook is exercised live by the dev:mock-react-chat gate.

## Test plan
- [x] `bun run typecheck` clean (packages/kobe)
- [x] repo-root `bun run lint` clean
- [x] `bun run test` — fast + socket, 26 files / 218+ tests green (includes new `chat-mock-turn`, `border`, ctrl+r palette-seam router tests; updated placeholder/key-router tests for the injected seams)
- [x] `bun run compile` → `./release-bin/kobe --version` OK (0.7.63)
- [x] `timeout 6 bun run dev:mock` — Solid mock unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react-chat` under a pty — greps prove the prompt echo ("Summarize the mock release notes"), the reasoning row, the Bash tool row, and the streamed final line ("Mock harness turn complete") all reach the screen
- [x] `bun run coverage` + `scripts/coverage-gate.mjs` (BASE_REF=main) locally — all touched .ts files ≥ floor except the exemption above