### PR TITLE
feat: React ports of the small shared dialogs + notifications (G3, issue #15)

### DIFF
--- a/.changeset/react-g3w2-dialogs-a.md
+++ b/.changeset/react-g3w2-dialogs-a.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+React ports of the small shared dialogs + notifications (issue #15, G3 wave 2): NotificationsProvider (wired into the React pane host's provider nest), HelpDialog, ToastOverlay, and VersionSkewBanner under `src/tui-react/`, with `kobe help-page` selecting the React host behind `KOBE_REACT=1`. The pure notification state transforms and help-dialog category grouping moved to framework-free `src/tui/lib/{notify-state,help-groups}.ts` shared by both runtimes, and a `dev:mock-react-dialogs` workbench proves banner/toast/help render live.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -31,6 +31,7 @@
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
     "dev:mock-react-filetree": "env KOBE_DEV=1 bun ./src/tui-react/panes/filetree/mock-host.tsx",
     "dev:mock-react-sidebar": "env KOBE_DEV=1 bun ./src/tui-react/panes/sidebar/mock-host.tsx",
+    "dev:mock-react-dialogs": "env KOBE_DEV=1 bun ./src/tui-react/mock/dialogs-host.tsx",
     "dev:sandbox": "bun run scripts/dev-sandbox.ts run",
     "dev:sandbox:reset": "bun run scripts/dev-sandbox.ts reset",
     "dev:version": "bash ../../scripts/dev-version.sh",

--- a/packages/kobe/src/cli/commands-tui.ts
+++ b/packages/kobe/src/cli/commands-tui.ts
@@ -375,7 +375,8 @@ export async function dispatchTuiCommand(subcommand: string | undefined, rest: r
     // (distinct from `kobe help`, which prints CLI usage). Opened by
     // `openHelpTab` as a new tmux window; reuses the same HelpDialog
     // the in-pane overlay uses.
-    const { startHelpHost } = await import("../tui/help/host.tsx")
+    const { startHelpHost } =
+      process.env.KOBE_REACT === "1" ? await import("../tui-react/help/host.tsx") : await import("../tui/help/host.tsx")
     await startHelpHost()
     return true
   }

--- a/packages/kobe/src/tui-react/component/help-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/help-dialog.tsx
@@ -1,0 +1,126 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Help dialog (React port of `src/tui/component/help-dialog.tsx`, issue
+ * #15 G3) — kobe's global keybindings, grouped by category via the shared
+ * framework-free `src/tui/lib/help-groups.ts`. Each row prints the
+ * canonical chord (macOS glyphs via `formatChord`) plus the description;
+ * alternate chords in a lighter color. Pane-local bindings are
+ * intentionally not listed — this is the global-bindings registry only.
+ * Full rationale (what was dropped in v0.6, why esc isn't re-bound here)
+ * lives in the Solid header.
+ *
+ * React deltas: the keymap table is mutated in place on keybindings.yaml
+ * reloads, invisible to React — `useKeymapVersion()` subscribes this
+ * component and invalidates the grouped rows; `useT()` subscribes it to
+ * language changes so the non-reactive `tKeys` lookups re-run.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useEffect, useMemo, useState } from "react"
+import { runTmuxCapturing } from "../../tmux/client"
+import { formatChord, tmuxPrefixGlyph } from "../../tui/lib/chord-glyphs"
+import { groupBindings } from "../../tui/lib/help-groups"
+import { KobeKeymap, useKeymapVersion } from "../context/keybindings"
+import { useTheme } from "../context/theme"
+import { tKeys, useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { type DialogContext, useDialog } from "../ui/dialog"
+
+export function HelpDialog(props: { onClose?: () => void }) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const t = useT()
+  const keymapVersion = useKeymapVersion()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keymapVersion is the invalidation key — the table is mutated in place.
+  const grouped = useMemo(() => groupBindings(KobeKeymap), [keymapVersion])
+  // Standalone full-window page (`kobe help-page`) passes its own exit;
+  // the in-pane overlay closes by clearing the dialog stack.
+  const close = () => (props.onClose ? props.onClose() : dialog.clear())
+
+  // Resolve the user's real tmux prefix so `prefix f` shows as e.g. `⌃B F`
+  // (their actual prefix, not a guess). Falls back to the `⌃B` default when
+  // there's no kobe tmux server (e.g. the dev outer monitor).
+  const [prefixGlyph, setPrefixGlyph] = useState("⌃B")
+  useEffect(() => {
+    let disposed = false
+    void runTmuxCapturing(["show-options", "-g", "prefix"]).then(({ code, stdout }) => {
+      if (disposed || code !== 0) return
+      const glyph = tmuxPrefixGlyph(stdout)
+      if (glyph) setPrefixGlyph(glyph)
+    })
+    return () => {
+      disposed = true
+    }
+  }, [])
+
+  // Press `?` again to dismiss (ergonomic mirror of vim/tmux help). esc
+  // is handled by the DialogProvider's own binding stack — don't re-bind.
+  useBindings(() => ({
+    bindings: [{ key: "?", cmd: close }],
+  }))
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1} flexShrink={1}>
+      <box flexDirection="row" justifyContent="space-between" flexShrink={0}>
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {t("help.title")}
+        </text>
+        <text fg={theme.textMuted} onMouseUp={close}>
+          {t("help.esc")}
+        </text>
+      </box>
+      {/* Long-content dialogs handle their own overflow: flexShrink={1}
+          fits the dialog's maxHeight, the scrollbox owns the scrolling. */}
+      <scrollbox
+        flexShrink={1}
+        flexGrow={1}
+        stickyScroll={false}
+        verticalScrollbarOptions={{
+          trackOptions: { backgroundColor: theme.backgroundDialog, foregroundColor: theme.borderActive },
+        }}
+      >
+        <box paddingBottom={1} gap={1} paddingRight={1}>
+          {grouped.map((group) => (
+            <box key={group.category} gap={0}>
+              <text fg={theme.accent} attributes={TextAttributes.BOLD}>
+                {tKeys("category", group.category)}
+              </text>
+              {group.rows.map((row) => {
+                // Prefer hint.keys (the user-facing chord label, e.g. "j/k")
+                // when present; fall back to the first registered chord.
+                // Rendered as macOS key glyphs (⌃Q, ⇧⇥, ⌃B F) via formatChord
+                // so the help matches the footer.
+                const rawPrimary = row.hint?.keys ?? row.keys[0] ?? "—"
+                const primary = rawPrimary === "—" ? "—" : formatChord(rawPrimary, prefixGlyph)
+                const aliases = (row.hint ? row.keys : row.keys.slice(1)).map((k) => formatChord(k, prefixGlyph))
+                return (
+                  <box key={row.id} flexDirection="row" gap={2} paddingLeft={1}>
+                    <box width={14}>
+                      <text fg={theme.primary}>{primary}</text>
+                    </box>
+                    <box flexGrow={1}>
+                      <text fg={theme.text}>{tKeys("desc", row.id)}</text>
+                    </box>
+                    {aliases.length > 0 ? (
+                      <box>
+                        <text fg={theme.textMuted}>{`(${aliases.join(", ")})`}</text>
+                      </box>
+                    ) : null}
+                  </box>
+                )
+              })}
+            </box>
+          ))}
+        </box>
+      </scrollbox>
+    </box>
+  )
+}
+
+/**
+ * Convenience opener — pushes the help dialog onto the dialog stack.
+ * Used by the global `?` binding. Static for parity with the Solid original.
+ */
+HelpDialog.show = (dialog: DialogContext): void => {
+  dialog.replace(() => <HelpDialog />)
+}

--- a/packages/kobe/src/tui-react/component/toast-overlay.tsx
+++ b/packages/kobe/src/tui-react/component/toast-overlay.tsx
@@ -1,0 +1,63 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Toast overlay (React port of `src/tui/component/toast-overlay.tsx`,
+ * issue #15 G3) — bottom-right transient chips, colored by kind
+ * (done→success, needs_input→warning, error→red), newest at the bottom,
+ * up to four visible, click to dismiss early. Auto-dismiss timers stay
+ * owned by the notifications context; full rationale in the Solid header.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/react"
+import { useNotifications } from "../context/notifications"
+import { useTheme } from "../context/theme"
+
+const MAX_VISIBLE = 4
+const CHIP_WIDTH = 40
+const RIGHT_MARGIN = 2
+const BOTTOM_MARGIN = 2
+
+export function ToastOverlay() {
+  const { theme } = useTheme()
+  const dims = useTerminalDimensions()
+  const notif = useNotifications()
+
+  if (notif.toasts.length === 0) return null
+  const visibleToasts = notif.toasts.slice(-MAX_VISIBLE)
+
+  // Anchor the stack to the bottom-right corner. Position is absolute so
+  // the overlay sits on top of the layout without taking flow space;
+  // `zIndex` keeps it above the panes but below the dialog backdrop (3000).
+  const left = Math.max(0, dims.width - CHIP_WIDTH - RIGHT_MARGIN)
+  const top = Math.max(0, dims.height - BOTTOM_MARGIN - MAX_VISIBLE - 1)
+
+  return (
+    <box position="absolute" zIndex={2500} left={left} top={top} width={CHIP_WIDTH} flexDirection="column" gap={0}>
+      {visibleToasts.map((toast) => {
+        const bg = toast.kind === "needs_input" ? theme.warning : toast.kind === "error" ? theme.error : theme.success
+        // selectedListItemText is the readable foreground over a saturated
+        // chip background — same slot the active tab chip uses.
+        const fg = theme.selectedListItemText
+        const prefix = toast.kind === "needs_input" ? "?" : toast.kind === "error" ? "✕" : "✓"
+        return (
+          <box
+            key={toast.id}
+            flexDirection="row"
+            gap={1}
+            paddingLeft={1}
+            paddingRight={1}
+            backgroundColor={bg}
+            onMouseUp={() => notif.dismiss(toast.id)}
+          >
+            <text fg={fg} attributes={TextAttributes.BOLD} wrapMode="none">
+              {prefix}
+            </text>
+            <text fg={fg} wrapMode="none">
+              {toast.title}
+            </text>
+          </box>
+        )
+      })}
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/component/version-skew-banner.tsx
+++ b/packages/kobe/src/tui-react/component/version-skew-banner.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Daemon build-version skew banner (React port of
+ * `src/tui/component/version-skew-banner.tsx`, issue #15 G3). The visible,
+ * NON-fatal signal that the running daemon is an older build than this
+ * process: a thin full-width top strip (amber accent rule + BOLD CAPS
+ * label + action hint) that auto-hides once the daemon matches again.
+ * Theme tokens only, engine-neutral copy — full rationale in the Solid
+ * header. React canon: props are plain values, not Accessors.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+
+export type VersionSkewBannerProps = {
+  /** True when the daemon is running a different build than this process. */
+  stale: boolean
+  /** The daemon's reported build version (e.g. "0.7.3"), or null if unknown. */
+  daemonVersion: string | null
+  /** This process's own build version (e.g. "0.7.4"). */
+  clientVersion: string
+  /** Available width (cells) so the accent rule fills the strip. */
+  width: number
+}
+
+export function VersionSkewBanner(props: VersionSkewBannerProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  if (!props.stale) return null
+  // One-line action hint: terse + actionable, naming both versions and the
+  // two commands that fix it (same copy as the Solid `versionSkewHint`).
+  const daemon = props.daemonVersion ? `v${props.daemonVersion}` : t("update.skew.olderBuild")
+  const hint = t("update.skew.hint", { daemon, clientVersion: props.clientVersion })
+  // Accent rule spans the strip, clamped to the pane width minus the 1-cell
+  // selection gutter; a small floor keeps it visible on a very narrow pane.
+  const ruleWidth = Math.max(4, props.width - 2)
+  return (
+    // flexShrink={0} so the strip never gets squeezed away; it owns its own
+    // rows at the very top of the pane.
+    <box flexDirection="column" flexShrink={0} paddingLeft={1} paddingRight={1} paddingBottom={1}>
+      {/* The amber accent rule — a warning-toned bar of `▔` (upper block)
+          so it reads as a thin rule above the message, not a heavy fill. */}
+      <text fg={theme.warning} wrapMode="none">
+        {"▔".repeat(ruleWidth)}
+      </text>
+      <box flexDirection="row" gap={1}>
+        <text fg={theme.warning} attributes={TextAttributes.BOLD} wrapMode="none">
+          {t("update.skew.title")}
+        </text>
+      </box>
+      <box flexDirection="row" gap={1}>
+        <text fg={theme.text} wrapMode="word">
+          {hint}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/context/notifications.tsx
+++ b/packages/kobe/src/tui-react/context/notifications.tsx
@@ -1,0 +1,117 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Per-ChatTab completion notifications (React port of
+ * `src/tui/context/notifications.tsx`, issue #15 G3). Same three signals
+ * (audible cue, transient toast, unread tab mark) and the same gating —
+ * the pure state transforms + the "error toasts always show" invariant
+ * live in the shared `src/tui/lib/notify-state.ts` consumed by both
+ * runtimes; see the Solid header for the full rationale.
+ *
+ * Deliberate delta: the Solid provider reads the sound/toast toggles from
+ * the live KVProvider. The React KV context isn't ported yet (issue #15
+ * G3, settings slice), so this provider reads a one-shot `state.json`
+ * snapshot at mount — the same snapshot-only semantics KV documents
+ * (another process's writes need a restart to be seen), and no React pane
+ * host has an in-process settings surface that could flip the toggles
+ * live yet.
+ */
+
+import { type ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
+import { loadStateFile } from "../../state/store"
+import {
+  type NotificationKind,
+  type NotifyInput,
+  TOAST_DURATION_MS,
+  type Toast,
+  addUnread,
+  removeUnread,
+  shouldShowToast,
+} from "../../tui/lib/notify-state"
+import { pulse as pulseSound } from "../../tui/lib/sound"
+
+export type { NotificationKind, Toast, NotifyInput } from "../../tui/lib/notify-state"
+
+export interface NotificationsContext {
+  readonly toasts: readonly Toast[]
+  readonly unread: ReadonlyMap<string, NotificationKind>
+  notify(input: NotifyInput): void
+  dismiss(id: number): void
+  markRead(taskId: string, tabId: string): void
+}
+
+const ctx = createContext<NotificationsContext | null>(null)
+
+export function NotificationsProvider(props: { children?: ReactNode }) {
+  const [toasts, setToasts] = useState<readonly Toast[]>([])
+  const [unread, setUnread] = useState<ReadonlyMap<string, NotificationKind>>(new Map())
+  // ponytail: one-shot toggle snapshot; swap to the React KV context when it lands.
+  const prefs = useMemo(() => loadStateFile(), [])
+  const counter = useRef(0)
+
+  // Toast auto-dismiss timers are provider-scoped: any still-pending timer
+  // is cleared on unmount so `dismiss()` never fires against a torn-down
+  // tree (the Solid version's createManagedTimeouts, inlined).
+  const timers = useRef(new Set<ReturnType<typeof setTimeout>>())
+  useEffect(
+    () => () => {
+      for (const id of timers.current) clearTimeout(id)
+      timers.current.clear()
+    },
+    [],
+  )
+
+  const dismiss = useCallback((id: number): void => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const notify = useCallback(
+    (input: NotifyInput): void => {
+      // Always update the unread map — the dot is a passive marker, not an
+      // interruption, so neither toggle gates it. Escalation rule
+      // (needs_input/error outrank done) lives in the shared notify-state.
+      setUnread((prev) => addUnread(prev, input))
+
+      // Sound gate (BEL + chime). BEL alone leaks past `pulse.wav`
+      // failure — they're the same intent (audible cue), one toggle.
+      if ((prefs["notifications.sound.enabled"] as boolean | undefined) !== false) {
+        try {
+          process.stdout.write("\x07")
+        } catch {
+          /* swallow — bell is best-effort */
+        }
+        pulseSound()
+      }
+
+      // Toast gate — independent of sound; `error` always shows (shared
+      // notify-state invariant).
+      const toastEnabled = (prefs["notifications.toast.enabled"] as boolean | undefined) !== false
+      if (shouldShowToast(input.kind, toastEnabled)) {
+        const id = ++counter.current
+        setToasts((prev) => [...prev, { id, ...input }])
+        const timer = setTimeout(() => {
+          timers.current.delete(timer)
+          dismiss(id)
+        }, TOAST_DURATION_MS)
+        timers.current.add(timer)
+      }
+    },
+    [prefs, dismiss],
+  )
+
+  const markRead = useCallback((taskId: string, tabId: string): void => {
+    setUnread((prev) => removeUnread(prev, taskId, tabId))
+  }, [])
+
+  const value = useMemo<NotificationsContext>(
+    () => ({ toasts, unread, notify, dismiss, markRead }),
+    [toasts, unread, notify, dismiss, markRead],
+  )
+
+  return <ctx.Provider value={value}>{props.children}</ctx.Provider>
+}
+
+export function useNotifications(): NotificationsContext {
+  const value = useContext(ctx)
+  if (!value) throw new Error("useNotifications must be used within a NotificationsProvider")
+  return value
+}

--- a/packages/kobe/src/tui-react/help/host.tsx
+++ b/packages/kobe/src/tui-react/help/host.tsx
@@ -1,0 +1,54 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * `kobe help-page` — React host (issue #15, G3), the `src/tui/help/host.tsx`
+ * counterpart selected by `KOBE_REACT=1`. Same contract: the F1 keybindings
+ * help as a standalone full-window surface, rendering the SAME `HelpDialog`
+ * component the in-pane overlay pushes onto the dialog stack; closing
+ * (q / esc / F1 / ? / Ctrl+C) exits the process so tmux closes the window.
+ * Purely read-only — no daemon connection, no KV/Focus providers.
+ */
+
+import { HelpDialog } from "../component/help-dialog"
+import { useTheme } from "../context/theme"
+import { bootPaneHost } from "../lib/host-boot"
+import { useBindings } from "../lib/keymap"
+import { useDialog } from "../ui/dialog"
+
+function HelpPage() {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+
+  function exit(): void {
+    process.exit(0)
+  }
+
+  // Page-level close keys. In the overlay surface the dialog stack owns
+  // esc/Ctrl+C; here there's no enclosing stack, so the page binds them
+  // itself — plus `q` (the page is not a text input) and `f1` so the
+  // opening chord also toggles the page closed. `?` is bound inside
+  // HelpDialog via its onClose prop.
+  useBindings(() => ({
+    enabled: dialog.stack.length === 0,
+    bindings: [
+      { key: "escape", cmd: exit },
+      { key: "q", cmd: exit },
+      { key: "f1", cmd: exit },
+      { key: "ctrl+c", cmd: exit },
+    ],
+  }))
+
+  return (
+    // The component sizes itself with an internal scrollbox; give it the
+    // full window height so tall keymaps scroll instead of clipping.
+    <box flexGrow={1} backgroundColor={theme.background} paddingTop={1}>
+      <HelpDialog onClose={exit} />
+    </box>
+  )
+}
+
+export async function startHelpHost(): Promise<void> {
+  await bootPaneHost({
+    providers: { kv: false, focus: false },
+    setup: () => ({ root: () => <HelpPage /> }),
+  })
+}

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -18,10 +18,10 @@
  *     signals don't notify outside a reactive-solid runtime.
  *   - Error boundary is a small class component (React's only boundary
  *     primitive); crash logging + themed fallback match the Solid host.
- *   - Provider flags: only `focus` is portable today. `kv` /
- *     `notifications` have no React port yet — requesting one throws
- *     loudly at boot rather than silently skipping a provider a pane
- *     depends on. They land with the panes that need them (issue #15 G3).
+ *   - Provider flags: `focus` and `notifications` are portable today.
+ *     `kv` has no React port yet — requesting it throws loudly at boot
+ *     rather than silently skipping a provider a pane depends on. It
+ *     lands with the settings slice (issue #15 G3).
  */
 
 import { createCliRenderer } from "@opentui/core"
@@ -42,6 +42,7 @@ import { sessionAttached } from "../../tui/lib/attach-gate"
 import { hostRenderOptions, installPaneExitBackstop } from "../../tui/lib/host-render-options"
 import { type PersistedUiPrefs, readPersistedUiPrefs } from "../../tui/lib/persisted-ui-prefs"
 import { FocusProvider } from "../context/focus"
+import { NotificationsProvider } from "../context/notifications"
 import {
   ThemeProvider,
   addTheme,
@@ -60,13 +61,13 @@ import { DialogProvider } from "../ui/dialog"
 /** Theme used when `state.json` is missing/stale — kobe's brand default. */
 const FALLBACK_THEME = "claude"
 
-/** Same flag surface as the Solid host; see header for the un-ported pair. */
+/** Same flag surface as the Solid host; see header for the un-ported one. */
 export interface HostProviderFlags {
   /** KVProvider — NOT PORTED yet; `true` throws at boot. */
   readonly kv?: boolean
   /** FocusProvider, initial pane "sidebar". Default true. */
   readonly focus?: boolean
-  /** NotificationsProvider — NOT PORTED yet; `true` throws at boot. */
+  /** NotificationsProvider (toast queue). Default false. */
   readonly notifications?: boolean
 }
 
@@ -236,9 +237,8 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
   setLocaleLang(prefs.locale)
 
   if (opts.providers?.kv) throw new Error("bootPaneHost(react): KVProvider is not ported yet (issue #15 G3)")
-  if (opts.providers?.notifications)
-    throw new Error("bootPaneHost(react): NotificationsProvider is not ported yet (issue #15 G3)")
   const focus = opts.providers?.focus ?? true
+  const notifications = opts.providers?.notifications ?? false
 
   const screen = await opts.setup(prefs)
   const renderer = await createCliRenderer(hostRenderOptions(screen.onDestroy))
@@ -250,15 +250,14 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
       <PaneErrorBoundary>{screen.root()}</PaneErrorBoundary>
     </>
   )
+  // Same nesting ORDER as the Solid host (Theme > Focus > Dialog >
+  // Notifications) — only membership varies.
+  const dialogTree = (
+    <DialogProvider>{notifications ? <NotificationsProvider>{body}</NotificationsProvider> : body}</DialogProvider>
+  )
   createRoot(renderer).render(
     <ThemeProvider mode="dark" theme={prefs.theme}>
-      {focus ? (
-        <FocusProvider initial="sidebar">
-          <DialogProvider>{body}</DialogProvider>
-        </FocusProvider>
-      ) : (
-        <DialogProvider>{body}</DialogProvider>
-      )}
+      {focus ? <FocusProvider initial="sidebar">{dialogTree}</FocusProvider> : dialogTree}
     </ThemeProvider>,
   )
   installPaneExitBackstop()

--- a/packages/kobe/src/tui-react/mock/dialogs-host.tsx
+++ b/packages/kobe/src/tui-react/mock/dialogs-host.tsx
@@ -1,0 +1,85 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React dialogs/notifications mock host (`bun run dev:mock-react-dialogs`,
+ * issue #15 G3) — the live render proof for the small-shared-dialogs slice:
+ * NotificationsProvider wired through `bootPaneHost` (providers:
+ * notifications), VersionSkewBanner, ToastOverlay, and HelpDialog all on
+ * one screen.
+ *
+ * At boot the banner is visible (stale=true) and a fixture toast fires;
+ * ~2.5s in, the help dialog opens on its own so a piped `timeout 6` run
+ * captures every fixture string without keystroke injection. Interactive
+ * keys: `?` help dialog · n toast · e error toast · v toggle banner ·
+ * q / ctrl+c quit.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/react"
+import { useEffect, useState } from "react"
+import { HelpDialog } from "../component/help-dialog"
+import { ToastOverlay } from "../component/toast-overlay"
+import { VersionSkewBanner } from "../component/version-skew-banner"
+import { useNotifications } from "../context/notifications"
+import { useTheme } from "../context/theme"
+import { bootPaneHost } from "../lib/host-boot"
+import { useBindings } from "../lib/keymap"
+import { useDialog } from "../ui/dialog"
+
+/** Render-proof grep string for the dev:mock-react-dialogs gate. */
+const MOCK_TOAST_TITLE = "React toast fixture"
+
+function MockDialogsScreen() {
+  const { theme } = useTheme()
+  const dims = useTerminalDimensions()
+  const notif = useNotifications()
+  const dialog = useDialog()
+  const [stale, setStale] = useState(true)
+
+  // Boot sequence for the piped proof: fixture toast immediately, help
+  // dialog after the first frames so the banner/toast strings are captured
+  // before the dialog backdrop covers them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: boot-once sequence.
+  useEffect(() => {
+    notif.notify({ kind: "done", taskId: "mock-task", tabId: "tab-1", title: MOCK_TOAST_TITLE })
+    const timer = setTimeout(() => HelpDialog.show(dialog), 2500)
+    return () => clearTimeout(timer)
+  }, [])
+
+  useBindings(() => ({
+    bindings: [
+      { key: "q", cmd: () => process.exit(0) },
+      { key: "ctrl+c", cmd: () => process.exit(0) },
+      { key: "?", cmd: () => HelpDialog.show(dialog) },
+      {
+        key: "n",
+        cmd: () => notif.notify({ kind: "done", taskId: "mock-task", tabId: "tab-1", title: MOCK_TOAST_TITLE }),
+      },
+      {
+        key: "e",
+        cmd: () => notif.notify({ kind: "error", taskId: "mock-task", tabId: "tab-2", title: "mock error toast" }),
+      },
+      { key: "v", cmd: () => setStale((s) => !s) },
+    ],
+  }))
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+      <VersionSkewBanner stale={stale} daemonVersion="0.0.1" clientVersion="0.0.2" width={dims.width} />
+      <box paddingLeft={1} paddingRight={1} flexDirection="column" flexGrow={1}>
+        <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
+          REACT dialogs workbench
+        </text>
+        <text fg={theme.textMuted} wrapMode="word">
+          ? help · n toast · e error toast · v banner · q quit — unread: {notif.unread.size}
+        </text>
+      </box>
+      <ToastOverlay />
+    </box>
+  )
+}
+
+await bootPaneHost({
+  logContext: "mock-dialogs",
+  providers: { notifications: true },
+  setup: () => ({ root: () => <MockDialogsScreen /> }),
+})

--- a/packages/kobe/src/tui/component/help-dialog.tsx
+++ b/packages/kobe/src/tui/component/help-dialog.tsx
@@ -32,10 +32,11 @@
 import { TextAttributes } from "@opentui/core"
 import { For, createSignal, onMount } from "solid-js"
 import { runTmuxCapturing } from "../../tmux/client"
-import { type KobeBinding, KobeKeymap } from "../context/keybindings"
+import { KobeKeymap } from "../context/keybindings"
 import { useTheme } from "../context/theme"
 import { t, tKeys } from "../i18n"
 import { formatChord, tmuxPrefixGlyph } from "../lib/chord-glyphs"
+import { groupBindings } from "../lib/help-groups"
 import { useBindings } from "../lib/keymap"
 import { type DialogContext, useDialog } from "../ui/dialog"
 
@@ -43,22 +44,7 @@ import { type DialogContext, useDialog } from "../ui/dialog"
 // (which read `BUILTIN_CLAUDE_SLASHES` from the composer) is gone.
 // Users discover slashes natively inside the interactive `claude`
 // pane now. The dialog stays focused on kobe's own keybindings.
-
-/**
- * Group the flat keymap into categories in declaration order.
- */
-function groupBindings(keymap: readonly KobeBinding[]): { category: string; rows: readonly KobeBinding[] }[] {
-  const groups = new Map<string, KobeBinding[]>()
-  const order: string[] = []
-  for (const b of keymap) {
-    if (!groups.has(b.category)) {
-      groups.set(b.category, [])
-      order.push(b.category)
-    }
-    groups.get(b.category)!.push(b)
-  }
-  return order.map((cat) => ({ category: cat, rows: groups.get(cat)! }))
-}
+// Category grouping is the shared framework-free `lib/help-groups`.
 
 export function HelpDialog(props: { onClose?: () => void } = {}) {
   const dialog = useDialog()

--- a/packages/kobe/src/tui/context/notifications.tsx
+++ b/packages/kobe/src/tui/context/notifications.tsx
@@ -28,27 +28,19 @@
 
 import { type Accessor, type ParentProps, createContext, createSignal, useContext } from "solid-js"
 import { createManagedTimeouts } from "../lib/managed-timeout"
+import {
+  type NotificationKind,
+  type NotifyInput,
+  TOAST_DURATION_MS,
+  type Toast,
+  addUnread,
+  removeUnread,
+  shouldShowToast,
+} from "../lib/notify-state"
 import { pulse as pulseSound } from "../lib/sound"
 import { useKV } from "./kv"
 
-export type NotificationKind = "done" | "needs_input" | "error"
-
-export interface Toast {
-  readonly id: number
-  readonly kind: NotificationKind
-  readonly taskId: string
-  readonly tabId: string
-  readonly title: string
-}
-
-export interface NotifyInput {
-  readonly kind: NotificationKind
-  readonly taskId: string
-  readonly tabId: string
-  readonly title: string
-}
-
-const TOAST_DURATION_MS = 4500
+export type { NotificationKind, Toast, NotifyInput } from "../lib/notify-state"
 
 export interface NotificationsContext {
   toasts: Accessor<readonly Toast[]>
@@ -59,10 +51,6 @@ export interface NotificationsContext {
 }
 
 const ctx = createContext<NotificationsContext>()
-
-function unreadKey(taskId: string, tabId: string): string {
-  return `${taskId}:${tabId}`
-}
 
 export function NotificationsProvider(props: ParentProps) {
   const kv = useKV()
@@ -76,18 +64,9 @@ export function NotificationsProvider(props: ParentProps) {
 
   function notify(input: NotifyInput): void {
     // Always update the unread map — the dot is a passive marker, not
-    // an interruption, so neither toggle gates it.
-    setUnread((prev) => {
-      const next = new Map(prev)
-      const key = unreadKey(input.taskId, input.tabId)
-      // Attention-demanding kinds outrank `done` if both fire for the
-      // same key before the user clears it — yellow (`needs_input`) /
-      // red (`error`) trump green.
-      const existing = prev.get(key)
-      if (existing === "needs_input" || existing === "error") return prev
-      next.set(key, input.kind)
-      return next
-    })
+    // an interruption, so neither toggle gates it. Escalation rule
+    // (needs_input/error outrank done) lives in the shared notify-state.
+    setUnread((prev) => addUnread(prev, input))
 
     // Sound gate (BEL + chime). BEL alone leaks past `pulse.wav`
     // failure — they're the same intent (audible cue), so they share
@@ -103,12 +82,13 @@ export function NotificationsProvider(props: ParentProps) {
 
     // Toast gate. Independent of sound so a quiet-office user can keep
     // the visual cue without audio, and an eyes-elsewhere user can keep
-    // audio without the popup. `error` always shows: error toasts are
-    // failure feedback (the tasks pane routes failures through here), and
-    // must not vanish into the daemon log when someone disables the
-    // completion "Toast" preference — that's a silent-failure regression.
+    // audio without the popup. `error` always shows (shared notify-state
+    // invariant): error toasts are failure feedback (the tasks pane routes
+    // failures through here), and must not vanish into the daemon log when
+    // someone disables the completion "Toast" preference — that's a
+    // silent-failure regression.
     const toastEnabled = (kv.get("notifications.toast.enabled", true) as boolean) !== false
-    if (input.kind === "error" || toastEnabled) {
+    if (shouldShowToast(input.kind, toastEnabled)) {
       const id = ++counter
       const toast: Toast = {
         id,
@@ -127,13 +107,7 @@ export function NotificationsProvider(props: ParentProps) {
   }
 
   function markRead(taskId: string, tabId: string): void {
-    setUnread((prev) => {
-      const key = unreadKey(taskId, tabId)
-      if (!prev.has(key)) return prev
-      const next = new Map(prev)
-      next.delete(key)
-      return next
-    })
+    setUnread((prev) => removeUnread(prev, taskId, tabId))
   }
 
   const value: NotificationsContext = {

--- a/packages/kobe/src/tui/lib/help-groups.ts
+++ b/packages/kobe/src/tui/lib/help-groups.ts
@@ -1,0 +1,24 @@
+/**
+ * Framework-free keymap grouping for the help dialog (issue #15, G3) —
+ * shared by the Solid `src/tui/component/help-dialog.tsx` and the React
+ * port. Generic over the `category` field so it never drags the keybinding
+ * table (and its Solid signal) into unit tests.
+ */
+
+/** Group a flat keymap into categories in declaration order. */
+export function groupBindings<T extends { readonly category: string }>(
+  keymap: readonly T[],
+): { category: string; rows: readonly T[] }[] {
+  const grouped: { category: string; rows: T[] }[] = []
+  const index = new Map<string, T[]>()
+  for (const b of keymap) {
+    let rows = index.get(b.category)
+    if (!rows) {
+      rows = []
+      index.set(b.category, rows)
+      grouped.push({ category: b.category, rows })
+    }
+    rows.push(b)
+  }
+  return grouped
+}

--- a/packages/kobe/src/tui/lib/notify-state.ts
+++ b/packages/kobe/src/tui/lib/notify-state.ts
@@ -1,0 +1,72 @@
+/**
+ * Framework-free notification state (issue #15, G3) — the pure map
+ * transforms + gating rules behind the per-ChatTab completion
+ * notifications, shared by the Solid provider
+ * (`src/tui/context/notifications.tsx`) and the React port
+ * (`src/tui-react/context/notifications.tsx`). Keeping the escalation
+ * rule ("needs_input / error outrank done") and the "error toasts always
+ * show" invariant in one place means both runtimes can't drift.
+ */
+
+export type NotificationKind = "done" | "needs_input" | "error"
+
+export interface Toast {
+  readonly id: number
+  readonly kind: NotificationKind
+  readonly taskId: string
+  readonly tabId: string
+  readonly title: string
+}
+
+export interface NotifyInput {
+  readonly kind: NotificationKind
+  readonly taskId: string
+  readonly tabId: string
+  readonly title: string
+}
+
+export const TOAST_DURATION_MS = 4500
+
+export function unreadKey(taskId: string, tabId: string): string {
+  return `${taskId}:${tabId}`
+}
+
+/**
+ * Merge a notification into the unread map. Attention-demanding kinds
+ * outrank `done` if both fire for the same key before the user clears it —
+ * yellow (`needs_input`) / red (`error`) trump green. Returns `prev`
+ * unchanged when the existing mark already outranks the new one.
+ */
+export function addUnread(
+  prev: ReadonlyMap<string, NotificationKind>,
+  input: NotifyInput,
+): ReadonlyMap<string, NotificationKind> {
+  const key = unreadKey(input.taskId, input.tabId)
+  const existing = prev.get(key)
+  if (existing === "needs_input" || existing === "error") return prev
+  const next = new Map(prev)
+  next.set(key, input.kind)
+  return next
+}
+
+/** Clear the unread mark for a (task, tab). Returns `prev` when absent. */
+export function removeUnread(
+  prev: ReadonlyMap<string, NotificationKind>,
+  taskId: string,
+  tabId: string,
+): ReadonlyMap<string, NotificationKind> {
+  const key = unreadKey(taskId, tabId)
+  if (!prev.has(key)) return prev
+  const next = new Map(prev)
+  next.delete(key)
+  return next
+}
+
+/**
+ * Toast gate. `error` always shows: error toasts are failure feedback and
+ * must not vanish into the daemon log when the user disables the
+ * completion "Toast" preference — that's a silent-failure regression.
+ */
+export function shouldShowToast(kind: NotificationKind, toastEnabled: boolean): boolean {
+  return kind === "error" || toastEnabled
+}

--- a/packages/kobe/test/tui-react/help-groups.test.ts
+++ b/packages/kobe/test/tui-react/help-groups.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Invariants for the shared help-dialog grouping (issue #15, G3) — consumed
+ * by BOTH the Solid and React HelpDialogs. Declaration order is the visible
+ * contract: the F1 help lists categories in the order the keymap declares
+ * them, and every binding must land in exactly one group (a dropped row is
+ * an invisible keybinding).
+ */
+
+import { describe, expect, it } from "vitest"
+import { groupBindings } from "../../src/tui/lib/help-groups"
+
+describe("groupBindings", () => {
+  it("groups by category in declaration order, preserving row order", () => {
+    const rows = [
+      { id: "a", category: "Global" },
+      { id: "b", category: "Tasks" },
+      { id: "c", category: "Global" },
+      { id: "d", category: "Tasks" },
+    ]
+    const grouped = groupBindings(rows)
+    expect(grouped.map((g) => g.category)).toEqual(["Global", "Tasks"])
+    expect(grouped[0]?.rows.map((r) => r.id)).toEqual(["a", "c"])
+    expect(grouped[1]?.rows.map((r) => r.id)).toEqual(["b", "d"])
+    // No binding lost or duplicated across groups.
+    expect(grouped.flatMap((g) => g.rows)).toHaveLength(rows.length)
+  })
+
+  it("returns an empty list for an empty keymap", () => {
+    expect(groupBindings([])).toEqual([])
+  })
+})

--- a/packages/kobe/test/tui-react/notify-state.test.ts
+++ b/packages/kobe/test/tui-react/notify-state.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Invariants for the shared notification state (issue #15, G3) — the pure
+ * transforms behind BOTH the Solid and React NotificationsProviders. The
+ * escalation rule (needs_input/error outrank done) and the "error toasts
+ * always show" gate are behavior users notice the moment they regress
+ * (a red unread dot silently downgraded to green, or a failure toast
+ * suppressed by the completion-toast preference), so they're pinned here
+ * framework-free.
+ */
+
+import { describe, expect, it } from "vitest"
+import { addUnread, removeUnread, shouldShowToast, unreadKey } from "../../src/tui/lib/notify-state"
+
+const input = (kind: "done" | "needs_input" | "error", tabId = "tab-1") =>
+  ({ kind, taskId: "task-1", tabId, title: "t" }) as const
+
+describe("addUnread", () => {
+  it("marks a fresh (task, tab) and keys it as task:tab", () => {
+    const next = addUnread(new Map(), input("done"))
+    expect(next.get(unreadKey("task-1", "tab-1"))).toBe("done")
+  })
+
+  it("lets needs_input/error overwrite done, never the reverse", () => {
+    let map = addUnread(new Map(), input("done"))
+    map = addUnread(map, input("needs_input"))
+    expect(map.get("task-1:tab-1")).toBe("needs_input")
+    // done must NOT downgrade an attention-demanding mark…
+    const after = addUnread(map, input("done"))
+    expect(after).toBe(map) // same reference — untouched
+    // …and error is equally sticky.
+    let errMap = addUnread(new Map(), input("error"))
+    errMap = addUnread(errMap, input("needs_input"))
+    expect(errMap.get("task-1:tab-1")).toBe("error")
+  })
+
+  it("tracks tabs independently", () => {
+    let map = addUnread(new Map(), input("done", "tab-1"))
+    map = addUnread(map, input("error", "tab-2"))
+    expect(map.size).toBe(2)
+    expect(map.get("task-1:tab-2")).toBe("error")
+  })
+})
+
+describe("removeUnread", () => {
+  it("clears only the given (task, tab) and no-ops (same ref) when absent", () => {
+    let map = addUnread(new Map(), input("done", "tab-1"))
+    map = addUnread(map, input("done", "tab-2"))
+    const cleared = removeUnread(map, "task-1", "tab-1")
+    expect(cleared.has("task-1:tab-1")).toBe(false)
+    expect(cleared.has("task-1:tab-2")).toBe(true)
+    expect(removeUnread(cleared, "task-1", "tab-1")).toBe(cleared)
+  })
+})
+
+describe("shouldShowToast", () => {
+  it("respects the toggle for done/needs_input but always shows errors", () => {
+    expect(shouldShowToast("done", true)).toBe(true)
+    expect(shouldShowToast("done", false)).toBe(false)
+    expect(shouldShowToast("needs_input", false)).toBe(false)
+    // Error toasts are failure feedback — disabling the completion-toast
+    // preference must never silence them (silent-failure regression).
+    expect(shouldShowToast("error", false)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- G3 wave 2, small shared dialogs + notifications slice: React ports of `NotificationsProvider`, `HelpDialog`, `ToastOverlay`, and `VersionSkewBanner` under `src/tui-react/`, mirroring the Solid originals' behavior and copy (theme tokens, engine-neutral strings, same escalation/gating semantics).
- **Shared, framework-free extractions (Solid keeps consuming both):** `src/tui/lib/notify-state.ts` (unread-map escalation rule — needs_input/error outrank done — plus the "error toasts always show" gate and toast constants/types) and `src/tui/lib/help-groups.ts` (help-dialog category grouping, made generic so tests never drag the keymap table in). Both unit-tested in `test/tui-react/`.
- `NotificationsProvider` replaces the `notifications: true` throw in the React `bootPaneHost` provider nest (same Theme > Focus > Dialog > Notifications order as the Solid host). Deliberate delta, noted in the header: the React KV context isn't ported yet (settings slice owns it, `kv: true` still throws), so the provider reads the sound/toast toggles from a one-shot `state.json` snapshot at mount — the same snapshot-only semantics KV documents, and no React pane host has an in-process settings surface yet.
- React deltas follow the established canon: `useKeymapVersion()` invalidates the help dialog's grouped rows on keybindings.yaml reloads, `useT()` subscribes it to language changes, VersionSkewBanner takes plain-value props instead of Accessors, and toast auto-dismiss timers are provider-scoped (cleared on unmount).
- **Real CLI seam:** `kobe help-page` selects the React host (`src/tui-react/help/host.tsx`) behind `KOBE_REACT=1`, same pattern as the history seam in `commands-tui.ts`.
- **Render proof:** new `dev:mock-react-dialogs` workbench boots with `providers: { notifications: true }`, shows the skew banner, fires a fixture toast, and auto-opens the help dialog ~2.5s in so a piped `timeout 6` run captures every fixture string; interactive keys (`?`/n/e/v) drive each surface live.

coverage-exemption: packages/kobe/src/tui-react/context/notifications.tsx — renderer-bound provider (imports @opentui/react JSX runtime, not importable under vitest); the state transforms + gating it wires are the unit-tested shared notify-state.ts, and the provider is exercised live by the dev:mock-react-dialogs gate.
coverage-exemption: packages/kobe/src/tui-react/component/help-dialog.tsx — renderer-bound view layer, same rationale as the wave-1 pane exemptions (#240–#243); grouping logic is the unit-tested shared help-groups.ts.
coverage-exemption: packages/kobe/src/tui-react/component/toast-overlay.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/component/version-skew-banner.tsx — renderer-bound view layer, same rationale.
coverage-exemption: packages/kobe/src/tui-react/help/host.tsx — renderer-bound page host behind the KOBE_REACT=1 seam, same rationale.
coverage-exemption: packages/kobe/src/tui-react/mock/dialogs-host.tsx — dev-only mock entry, same rationale.

## Test plan
- [x] `bun run typecheck` clean (packages/kobe)
- [x] repo-root `bun run lint` clean
- [x] `bun run test` — fast + socket green (includes new `notify-state` + `help-groups` suites, 7 tests)
- [x] `bun run compile` → `./release-bin/kobe --version` OK (0.7.63)
- [x] `timeout 6 bun run dev:mock` — Solid mock unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react-dialogs` under `script -q` — greps prove the toast chip ("React toast fixture"), the skew banner ("DAEMON OUT OF DATE" + rule + hint), and the help dialog (title, "Global" category, "Show keybindings" row) all reach the screen
- [x] existing `dev:mock-react{,-chat,-history,-filetree,-sidebar}` all still boot (exit 124)
- [x] `bun run coverage` + `BASE_REF=main bun scripts/coverage-gate.mjs` locally — all touched .ts files green (commands-tui 98%, notify-state 100%, help-groups 100%)
