### PR TITLE
feat: React port of the Ops pane behind KOBE_REACT=1 (G3, issue #15)

### DIFF
--- a/.changeset/react-g3w2-ops.md
+++ b/.changeset/react-g3w2-ops.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+React port of the Ops pane + preview window behind `KOBE_REACT=1` (issue #15, G3): `kobe ops` and `kobe ops --preview` now route to `src/tui-react/ops/` when the flag is set, mounting the already-ported React FileTree. The Solid host was split under the file-size cap, extracting the framework-free poll loops (`tui/ops/activity-monitor.ts`), shell actions + concrete tmux IO (`tui/ops/host-io.ts`), and the preview data/syntax mapping (`preview-core.ts`/`preview-syntax.ts`) shared verbatim by both hosts. `RemoteOrchestrator` gains a `transcriptActivityStore()` external-store twin of the `transcript.activity` signal for React consumers, plus a `dev:mock-react-ops` render-proof script.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -31,6 +31,7 @@
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
     "dev:mock-react-filetree": "env KOBE_DEV=1 bun ./src/tui-react/panes/filetree/mock-host.tsx",
     "dev:mock-react-sidebar": "env KOBE_DEV=1 bun ./src/tui-react/panes/sidebar/mock-host.tsx",
+    "dev:mock-react-ops": "env KOBE_DEV=1 bun ./src/tui-react/ops/mock-host.tsx",
     "dev:sandbox": "bun run scripts/dev-sandbox.ts run",
     "dev:sandbox:reset": "bun run scripts/dev-sandbox.ts reset",
     "dev:version": "bash ../../scripts/dev-version.sh",

--- a/packages/kobe/src/cli/commands-tui.ts
+++ b/packages/kobe/src/cli/commands-tui.ts
@@ -436,11 +436,15 @@ export async function dispatchTuiCommand(subcommand: string | undefined, rest: r
     // `--preview <rel>` → full-width syntax-highlighted file/diff view
     // (opentui `<diff>` / `<code>`). Otherwise the FileTree browser.
     if (flags.preview) {
-      const { startOpsPreview } = await import("../tui/ops/host.tsx")
+      const { startOpsPreview } =
+        process.env.KOBE_REACT === "1"
+          ? await import("../tui-react/ops/preview.tsx")
+          : await import("../tui/ops/preview.tsx")
       await startOpsPreview({ worktree: flags.worktree, relPath: flags.preview })
       return true
     }
-    const { startOpsHost } = await import("../tui/ops/host.tsx")
+    const { startOpsHost } =
+      process.env.KOBE_REACT === "1" ? await import("../tui-react/ops/host.tsx") : await import("../tui/ops/host.tsx")
     await startOpsHost({
       taskId: flags.taskId ?? "",
       worktree: flags.worktree,

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -94,11 +94,12 @@ export class RemoteOrchestrator {
   private readonly setUiPrefsSig: (next: UiPrefsPayload | null) => void
   private readonly keybindingsRevAcc: Accessor<number | null>
   private readonly setKeybindingsRevSig: (next: number | null) => void
-  // Framework-free twins of the two signals above (issue #15 G3) — React
-  // hosts need stores because solid-js reactivity is inert outside
+  // Framework-free twins of Solid signals (issue #15 G3) — React hosts
+  // need stores because solid-js reactivity is inert outside
   // reactive-solid runtimes. Setters dual-write; single writer, no drift.
   private readonly uiPrefsStoreInner = createExternalStore<UiPrefsPayload | null>(null)
   private readonly keybindingsRevStoreInner = createExternalStore<number | null>(null)
+  private readonly transcriptActivityStoreInner = createExternalStore<TranscriptActivityMap | null>(null)
   private readonly connectionStateAcc: Accessor<DaemonConnectionState>
   private readonly setConnectionState: (next: DaemonConnectionState) => void
   private readonly ensureReachable: () => Promise<unknown>
@@ -143,7 +144,10 @@ export class RemoteOrchestrator {
     this.worktreeChangesAcc = worktreeChanges
     this.setWorktreeChangesSig = (next) => setWorktreeChanges(() => next)
     this.transcriptActivityAcc = transcriptActivity
-    this.setTranscriptActivitySig = (next) => setTranscriptActivity(() => next)
+    this.setTranscriptActivitySig = (next) => {
+      setTranscriptActivity(() => next)
+      this.transcriptActivityStoreInner.set(next)
+    }
     this.uiPrefsAcc = uiPrefs
     this.setUiPrefsSig = (next) => {
       setUiPrefs(() => next)
@@ -359,6 +363,11 @@ export class RemoteOrchestrator {
    */
   transcriptActivitySignal(): Accessor<TranscriptActivityMap | null> {
     return this.transcriptActivityAcc
+  }
+
+  /** Framework-free twin of {@link transcriptActivitySignal} — see uiPrefsStore. */
+  transcriptActivityStore(): ExternalStore<TranscriptActivityMap | null> {
+    return this.transcriptActivityStoreInner
   }
 
   /**

--- a/packages/kobe/src/tui-react/ops/host.tsx
+++ b/packages/kobe/src/tui-react/ops/host.tsx
@@ -1,0 +1,168 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React `kobe ops` host — the `src/tui/ops/host.tsx` counterpart (issue
+ * #15, G3), behind `KOBE_REACT=1` in `cli/commands-tui.ts`. Same pane, same
+ * shared framework-free pieces: the poll-loop bodies
+ * (`tui/ops/activity-monitor.ts`), the shell actions + concrete IO
+ * (`tui/ops/host-io.ts`), and the already-ported React FileTree. This file
+ * owns only the React reactivity.
+ *
+ * CLIENT-LAYER LIVE STATE: React never consumes Solid signals — the
+ * daemon's `transcript.activity` push is read through
+ * `RemoteOrchestrator.transcriptActivityStore()`, the external-store twin
+ * of `transcriptActivitySignal()` (same dual-write precedent as
+ * `uiPrefsStore`), via `useSyncExternalStore`. The poll loops read the
+ * LATEST map through a render-refreshed ref — they are timer-driven, not
+ * reactive, exactly like the Solid host's untracked reads.
+ */
+
+import { createEngineTurnDetector } from "@/engine/turn-detector"
+import type { VendorId } from "@/types/task"
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react"
+import { connectPaneOrchestrator } from "../../client/connect-pane-orchestrator"
+import type { RemoteOrchestrator, TranscriptActivityMap } from "../../client/remote-orchestrator"
+import { startLocalBadgePoll, startTurnStatusPoll } from "../../tui/ops/activity-monitor"
+import { badgePollIo, makeOpsActions, turnStatusIo } from "../../tui/ops/host-io"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { bootPaneHost } from "../lib/host-boot"
+import { FileTree } from "../panes/filetree/FileTree"
+
+export interface OpsHostArgs {
+  readonly taskId: string
+  readonly worktree: string
+  /** tmux pane id / selector for the claude pane — send-keys target. */
+  readonly targetPane: string | null
+  /** Task engine vendor — selects which transcript store the activity badge polls. */
+  readonly vendor: VendorId
+}
+
+const noopSubscribe = () => () => {}
+
+export function OpsShell(props: OpsHostArgs) {
+  const { theme } = useTheme()
+  const t = useT()
+  // Props are process-lifetime launcher args — safe to bind once.
+  const actionsRef = useRef(makeOpsActions(props))
+  const actions = actionsRef.current
+
+  // ONE scoped pane orchestrator for the daemon's `transcript.activity`
+  // channel — non-spawning + leak-guarded (a late connect after unmount is
+  // disposed on the spot), same contract as the Solid host and host-boot's
+  // UiPrefsSync. No daemon / an old daemon without the channel leaves the
+  // map `null`, which is the fallback trigger throughout this component.
+  const [activityOrch, setActivityOrch] = useState<RemoteOrchestrator | null>(null)
+  useEffect(() => {
+    let disposed = false
+    let orch: RemoteOrchestrator | null = null
+    void (async () => {
+      const remote = await connectPaneOrchestrator({ logTag: "ops-activity", channels: ["transcript.activity"] })
+      if (!remote) return
+      if (disposed) {
+        remote.dispose()
+        return
+      }
+      orch = remote
+      setActivityOrch(remote)
+    })()
+    return () => {
+      disposed = true
+      orch?.dispose()
+    }
+  }, [])
+
+  // The daemon-collected facts, live via the external-store twin (see file
+  // header). `null` until a daemon with the channel pushes data.
+  const activityStore = activityOrch?.transcriptActivityStore()
+  const sharedActivityMap = useSyncExternalStore(
+    useCallback((cb: () => void) => (activityStore ? activityStore.subscribe(cb) : noopSubscribe()), [activityStore]),
+    () => activityStore?.get() ?? null,
+  )
+  // Latest-render mirror for the timer-driven loops (they must always see
+  // the current map without being torn down per push).
+  const sharedMapRef = useRef<TranscriptActivityMap | null>(sharedActivityMap)
+  sharedMapRef.current = sharedActivityMap
+
+  // New-activity badge (KOB-254) — same two-source design as the Solid
+  // host: the daemon push when available, the local mtime probe otherwise.
+  // `baseline` seeds at the first observed mtime so a pane mounting onto an
+  // already-busy task doesn't flash stale activity; `r` refresh acks it.
+  const [baseline, setBaseline] = useState(0)
+  const [latest, setLatest] = useState(0)
+  const primedRef = useRef(false)
+
+  // Shared-source badge: seed the baseline on the first NON-ZERO mtime (an
+  // empty/just-connected map reads 0 — not real activity), then track
+  // advances. Inert while there's no daemon-collected data.
+  useEffect(() => {
+    const map = sharedActivityMap
+    if (!map) return
+    const mtime = map.get(props.worktree)?.mtimeMs ?? 0
+    if (!primedRef.current && mtime > 0) {
+      primedRef.current = true
+      setBaseline(mtime)
+    }
+    setLatest(mtime)
+  }, [sharedActivityMap, props.worktree])
+
+  // Local fallback badge poll — runs ONLY while there's no daemon-collected
+  // data; torn down the instant the channel becomes available and restarted
+  // if a reconnect downgrades. Loop body shared with the Solid host.
+  const sharedAvailable = sharedActivityMap !== null
+  useEffect(() => {
+    if (sharedAvailable) return
+    return startLocalBadgePoll(badgePollIo(props.vendor, props.worktree), {
+      isPrimed: () => primedRef.current,
+      prime: (mtime) => {
+        primedRef.current = true
+        setBaseline(mtime)
+      },
+      setLatest,
+    })
+  }, [sharedAvailable, props.vendor, props.worktree])
+
+  const hasNewActivity = primedRef.current && latest > baseline
+  const cornerBadge = hasNewActivity ? { text: t("ops.badge.newActivity"), active: true } : null
+  const ackActivity = useCallback(() => setBaseline(latest), [latest])
+
+  // Per-window turn detector — mounted once for the pane's lifetime (like
+  // the Solid host's onMount); the getters read the live map off the ref.
+  useEffect(() => {
+    const targetPane = props.targetPane
+    if (!targetPane) return
+    return startTurnStatusPoll(
+      {
+        worktree: props.worktree,
+        detector: createEngineTurnDetector(props.vendor),
+        usingShared: () => sharedMapRef.current !== null,
+        sharedEntry: () => sharedMapRef.current?.get(props.worktree) ?? null,
+      },
+      turnStatusIo(targetPane),
+    )
+  }, [props.targetPane, props.vendor, props.worktree])
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+      <FileTree
+        worktreePath={props.worktree}
+        focused={true}
+        onOpenFile={actions.openFile}
+        onMention={actions.injectMention}
+        onCreatePR={() => void actions.createPR()}
+        onZenToggle={props.taskId ? actions.toggleZen : undefined}
+        cornerBadge={cornerBadge}
+        onRefresh={ackActivity}
+      />
+    </box>
+  )
+}
+
+export async function startOpsHost(args: OpsHostArgs): Promise<void> {
+  // No KV / Focus providers — the FileTree never touches persisted UI
+  // state or pane focus; this pane has always been Theme > Dialog only.
+  await bootPaneHost({
+    logContext: "ops",
+    providers: { kv: false, focus: false },
+    setup: () => ({ root: () => <OpsShell {...args} /> }),
+  })
+}

--- a/packages/kobe/src/tui-react/ops/mock-host.tsx
+++ b/packages/kobe/src/tui-react/ops/mock-host.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React ops mock host (`bun run dev:mock-react-ops`) — the live render
+ * proof for the ported Ops pane. Same fixture recipe as the filetree mock
+ * (a throwaway `git init` repo with deterministic `kobe-fixture-*` names
+ * the smoke greps out of the captured ANSI output), but mounted through
+ * the real `OpsShell`: standalone shape (no task id, no target pane), so
+ * the tmux-bound turn poll stays off and the badge runs the local
+ * fallback probe against the fixture worktree.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { bootPaneHost } from "../lib/host-boot"
+import { OpsShell } from "./host"
+
+function makeFixtureWorktree(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-ops-mock-"))
+  execFileSync("git", ["init", "-q"], { cwd: dir })
+  writeFileSync(join(dir, "kobe-fixture-alpha.ts"), "export const alpha = 1\n")
+  writeFileSync(join(dir, "kobe-fixture-readme.md"), "# ops mock fixture\n")
+  mkdirSync(join(dir, "src"))
+  writeFileSync(join(dir, "src", "kobe-fixture-beta.ts"), "export const beta = 2\n")
+  return dir
+}
+
+await bootPaneHost({
+  logContext: "ops-mock",
+  providers: { kv: false, focus: false },
+  setup: () => {
+    const worktree = makeFixtureWorktree()
+    return {
+      root: () => <OpsShell taskId="" worktree={worktree} targetPane={null} vendor="claude" />,
+    }
+  },
+})

--- a/packages/kobe/src/tui-react/ops/preview.tsx
+++ b/packages/kobe/src/tui-react/ops/preview.tsx
@@ -1,0 +1,83 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React `kobe ops --preview <rel>` — the `src/tui/ops/preview.tsx`
+ * counterpart (issue #15, G3), behind `KOBE_REACT=1`. Data + syntax-style
+ * mapping are the shared `tui/ops/preview-core.ts` / `preview-syntax.ts`.
+ * The Solid host's single `createResource` follows THE ASYNC CANON
+ * (`src/tui-react/history/host.tsx`): `useState` + a dependency-keyed
+ * `useEffect` whose stale completions are dropped by an effect-local
+ * `disposed` flag. The read is one-shot (the preview window is immutable
+ * for its lifetime), so there's no refresh tick.
+ */
+
+import { useEffect, useMemo, useState } from "react"
+import { type PreviewData, filetypeOf, loadPreviewData } from "../../tui/ops/preview-core"
+import { buildSyntaxStyle } from "../../tui/ops/preview-syntax"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { bootPaneHost } from "../lib/host-boot"
+import { useBindings } from "../lib/keymap"
+
+export interface OpsPreviewArgs {
+  readonly worktree: string
+  readonly relPath: string
+}
+
+function PreviewScreen(props: OpsPreviewArgs) {
+  const { theme } = useTheme()
+  const t = useT()
+  const style = useMemo(() => buildSyntaxStyle(theme), [theme])
+  const filetype = filetypeOf(props.relPath)
+
+  const [data, setData] = useState<PreviewData | null>(null)
+  useEffect(() => {
+    let disposed = false
+    void loadPreviewData(props.worktree, props.relPath)
+      .then((d) => {
+        if (!disposed) setData(d)
+      })
+      .catch(() => {
+        // Same boundary as the Solid resource: a failed read (worktree torn
+        // down mid-open) leaves the loading placeholder rather than crashing.
+      })
+    return () => {
+      disposed = true
+    }
+  }, [props.worktree, props.relPath])
+
+  useBindings(() => ({
+    bindings: [
+      { key: "q", cmd: () => process.exit(0) },
+      { key: "escape", cmd: () => process.exit(0) },
+      { key: "ctrl+c", cmd: () => process.exit(0) },
+    ],
+  }))
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+      <box flexDirection="row" gap={1} paddingLeft={1} paddingRight={1}>
+        <text fg={theme.accent}>{props.relPath}</text>
+        <text fg={theme.textMuted}>{data?.kind === "diff" ? t("ops.preview.diffVsHead") : t("ops.preview.file")}</text>
+        <text fg={theme.textMuted}>{t("ops.preview.closeHint")}</text>
+      </box>
+      <box flexGrow={1}>
+        {data == null ? (
+          <text fg={theme.textMuted}>{t("ops.preview.loading")}</text>
+        ) : data.kind === "diff" ? (
+          <diff diff={data.text} view="unified" filetype={filetype} syntaxStyle={style} showLineNumbers={true} />
+        ) : (
+          <code content={data.text} filetype={filetype} syntaxStyle={style} />
+        )}
+      </box>
+    </box>
+  )
+}
+
+export async function startOpsPreview(args: OpsPreviewArgs): Promise<void> {
+  // Same minimal provider set as the Ops pane host (and same
+  // no-log-context delta as the Solid preview entrypoint — preserved).
+  await bootPaneHost({
+    providers: { kv: false, focus: false },
+    setup: () => ({ root: () => <PreviewScreen {...args} /> }),
+  })
+}

--- a/packages/kobe/src/tui/ops/activity-monitor.ts
+++ b/packages/kobe/src/tui/ops/activity-monitor.ts
@@ -1,0 +1,239 @@
+/**
+ * Framework-free poll loops for the Ops pane — the badge fallback poll and
+ * the per-window turn-status (capture-pane quiescence) poll, extracted from
+ * `tui/ops/host.tsx` so the Solid AND React hosts (issue #15, G3) run the
+ * SAME loop bodies verbatim. Only types are imported (erased at runtime);
+ * all IO — tmux capture-pane / window-option writes, the transcript mtime
+ * probe, the attach gate — is injected (`tui/ops/host-io.ts` builds the
+ * real set), which is also what makes these loops unit-testable under
+ * vitest with fakes. Cadence math stays in `./activity-poll`.
+ */
+
+import { createHash } from "node:crypto"
+import type { ChatTabTurnState } from "@/engine/turn-detector"
+import type { TranscriptActivity } from "../../client/remote-orchestrator"
+import {
+  ACTIVITY_POLL_MIN_MS,
+  TURN_STATUS_POLL_MS,
+  nextActivityPollDelay,
+  nextTurnStatusPollDelay,
+} from "./activity-poll"
+
+/** Consecutive unchanged capture-pane reads before a completion marker counts as "done". */
+export const STABLE_POLLS_FOR_DONE = 2
+/** tmux window option the ChatTab turn chip reads. */
+export const CHAT_TAB_STATE_OPTION = "@kobe_tab_state"
+
+export function fingerprint(text: string): string {
+  return createHash("sha1").update(text).digest("hex")
+}
+
+/* ─── local fallback badge poll ──────────────────────────────────────── */
+
+export interface BadgePollIo {
+  /** Attach gate — a detached (background) session skips the fs sweep. */
+  readonly sessionAttached: () => Promise<boolean>
+  /** Newest transcript mtime for this task's worktree (`latestTranscriptMtime`). */
+  readonly latestMtime: () => Promise<number>
+}
+
+/** Host-side badge state, shared with the daemon-push effect (see host.tsx). */
+export interface BadgePollHooks {
+  readonly isPrimed: () => boolean
+  /** First read seeds the baseline so only post-mount activity flags. */
+  readonly prime: (mtime: number) => void
+  readonly setLatest: (mtime: number) => void
+}
+
+/**
+ * The `● new` badge's LOCAL fallback poll — runs only while there's no
+ * daemon-collected `transcript.activity` data. Adaptive backoff: fast while
+ * the transcript advances, ramping toward the max while idle (the probe
+ * readdir+stats an unboundedly growing dir). Transient read failures are
+ * swallowed: the worktree can vanish mid-poll during task deletion, and the
+ * pane process has no crash net. Returns the dispose function.
+ */
+export function startLocalBadgePoll(io: BadgePollIo, hooks: BadgePollHooks): () => void {
+  let disposed = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let delayMs = ACTIVITY_POLL_MIN_MS
+  let idleStreak = 0
+  let lastSeenMtime = 0
+  async function poll(): Promise<void> {
+    // Detached (background) session: skip the readdir+stat sweep entirely —
+    // the badge is invisible. Next tick after re-attach resumes.
+    if (!(await io.sessionAttached())) {
+      if (!disposed) timer = setTimeout(() => void poll(), delayMs)
+      return
+    }
+    try {
+      const mtime = await io.latestMtime()
+      if (disposed) return
+      if (!hooks.isPrimed()) {
+        hooks.prime(mtime)
+        lastSeenMtime = mtime
+      }
+      // Snap back to the fast interval the instant the transcript advances;
+      // otherwise ramp the delay so an idle pane stops stat-churning.
+      if (mtime > lastSeenMtime) {
+        lastSeenMtime = mtime
+        idleStreak = 0
+      } else {
+        idleStreak++
+      }
+      hooks.setLatest(mtime)
+    } catch {
+      // A failed read isn't "activity" — let the idle ramp keep climbing and
+      // the next tick retry (or `disposed` stop us).
+      idleStreak++
+    } finally {
+      if (!disposed) {
+        delayMs = nextActivityPollDelay(delayMs, idleStreak)
+        timer = setTimeout(() => void poll(), delayMs)
+      }
+    }
+  }
+  void poll()
+  return () => {
+    disposed = true
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/* ─── per-window turn-status poll ────────────────────────────────────── */
+
+/** The slice of `EngineTurnDetector` this loop consumes (structural, fakeable). */
+export interface TurnDetectorLike {
+  supportsCompletionMarkers(): boolean
+  latestCompletion(worktree: string): Promise<{ readonly id: string } | null>
+}
+
+export interface TurnStatusIo {
+  readonly sessionAttached: () => Promise<boolean>
+  /** `tmux capture-pane` of the paired engine pane (quiescence source). */
+  readonly capturePane: () => Promise<string>
+  /** Write the ChatTab turn chip ({@link CHAT_TAB_STATE_OPTION}). */
+  readonly setTurnState: (state: ChatTabTurnState) => Promise<void>
+}
+
+export interface TurnStatusOpts {
+  readonly worktree: string
+  readonly detector: TurnDetectorLike
+  /** Whether the daemon is publishing transcript activity for this worktree. */
+  readonly usingShared: () => boolean
+  /** This worktree's slice of the daemon push (`null` when absent). */
+  readonly sharedEntry: () => TranscriptActivity | null
+}
+
+/**
+ * Per-window turn detector loop. The engine adapter owns completion markers;
+ * this loop owns only the tmux-local quiescence check for its paired engine
+ * pane, so sibling ChatTabs on the same worktree don't report done unless
+ * THIS window actually changed. The capture-pane hash + turn-state write
+ * stay strictly in-process (the daemon never touches tmux); in shared mode
+ * the COMPLETION read comes from the daemon push and the capture cadence
+ * ramps while quiescent, in fallback mode it's a local `latestCompletion`
+ * read on a fixed cadence — verbatim the pre-daemon behavior. Returns the
+ * dispose function.
+ */
+export function startTurnStatusPoll(opts: TurnStatusOpts, io: TurnStatusIo): () => void {
+  const { detector } = opts
+  let disposed = false
+  let baselineCompletionId: string | null = null
+  let baselinePrimed = false
+  let paneHash = ""
+  let observedPaneActivity = false
+  let stablePolls = 0
+  let published: ChatTabTurnState | null = null
+  // Adaptive capture-pane cadence (shared mode only): ramps up while the
+  // shared transcript is quiescent, snaps back when its mtime advances.
+  let delayMs = TURN_STATUS_POLL_MS
+  let lastSharedMtime = 0
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  async function publish(state: ChatTabTurnState): Promise<void> {
+    if (state === published) return
+    published = state
+    await io.setTurnState(state)
+  }
+
+  /** Latest completion id — from the shared push when available, else a local read. */
+  async function latestCompletionId(): Promise<string | null> {
+    if (opts.usingShared()) return opts.sharedEntry()?.completionId ?? null
+    return (await detector.latestCompletion(opts.worktree))?.id ?? null
+  }
+
+  async function prime(): Promise<void> {
+    try {
+      paneHash = fingerprint(await io.capturePane())
+      baselineCompletionId = await latestCompletionId()
+      baselinePrimed = true
+      await publish(detector.supportsCompletionMarkers() ? "idle" : "unknown")
+    } catch {
+      // Transient failures during the delete→kill teardown window must not
+      // crash this crash-net-less pane process; the next poll() re-primes.
+    }
+  }
+
+  async function poll(): Promise<void> {
+    // Detached session: no capture-pane spawn for an invisible status chip.
+    if (!(await io.sessionAttached())) {
+      if (!disposed) timer = setTimeout(() => void poll(), delayMs)
+      return
+    }
+    const shared = opts.usingShared()
+    try {
+      const nextPaneHash = fingerprint(await io.capturePane())
+      if (disposed) return
+      // Lazily seed the baseline if shared activity arrived only after prime
+      // ran with no entry — so the first daemon-pushed completion isn't
+      // mistaken for a fresh "done".
+      if (shared && !baselinePrimed) {
+        baselineCompletionId = opts.sharedEntry()?.completionId ?? null
+        baselinePrimed = true
+      }
+      // Track shared-transcript mtime advance for the adaptive cadence.
+      const sharedMtime = shared ? (opts.sharedEntry()?.mtimeMs ?? 0) : 0
+      const mtimeAdvanced = sharedMtime > lastSharedMtime
+      if (sharedMtime > lastSharedMtime) lastSharedMtime = sharedMtime
+
+      if (nextPaneHash !== paneHash) {
+        paneHash = nextPaneHash
+        observedPaneActivity = true
+        stablePolls = 0
+        await publish(detector.supportsCompletionMarkers() ? "running" : "unknown")
+      } else if (observedPaneActivity) {
+        stablePolls++
+      }
+
+      if (detector.supportsCompletionMarkers() && observedPaneActivity && stablePolls >= STABLE_POLLS_FOR_DONE) {
+        const completionId = await latestCompletionId()
+        // Done rule unchanged: a NEW completion id past the baseline, with
+        // the pane having gone quiescent, means the turn finished.
+        if (!disposed && completionId !== null && completionId !== baselineCompletionId) {
+          baselineCompletionId = completionId
+          observedPaneActivity = false
+          stablePolls = 0
+          await publish("done")
+        }
+      }
+      // Cadence: shared mode ramps the capture-pane interval while idle;
+      // fallback keeps the fixed 1.5s tick.
+      delayMs = shared ? nextTurnStatusPollDelay(delayMs, mtimeAdvanced, published) : TURN_STATUS_POLL_MS
+    } catch {
+      // capture-pane / the turn-state write fire tmux against a pane that a
+      // task deletion tears down mid-flight — swallow so the race degrades
+      // to a quiet no-op instead of crashing the Ops pane to a shell.
+      delayMs = TURN_STATUS_POLL_MS
+    } finally {
+      if (!disposed) timer = setTimeout(() => void poll(), delayMs)
+    }
+  }
+
+  void prime()
+  timer = setTimeout(() => void poll(), TURN_STATUS_POLL_MS)
+  return () => {
+    disposed = true
+    if (timer) clearTimeout(timer)
+  }
+}

--- a/packages/kobe/src/tui/ops/host-io.ts
+++ b/packages/kobe/src/tui/ops/host-io.ts
@@ -1,0 +1,126 @@
+/**
+ * Real-world side of the Ops pane, extracted from `tui/ops/host.tsx` so the
+ * Solid AND React hosts (issue #15, G3) share it verbatim: the user-facing
+ * shell actions (open file / preview / @mention / create PR / zen toggle)
+ * plus the concrete IO sets the framework-free poll loops in
+ * `./activity-monitor` consume. No Solid, no React — plain functions over
+ * tmux + git.
+ */
+
+import { kobeCliInvocation } from "@/cli/invocation"
+import { latestTranscriptMtime } from "@/monitor/activity"
+import {
+  capturePaneById,
+  newWindow,
+  runTmux,
+  sendKeyName,
+  sendKeys,
+  setWindowOption,
+  tmuxSessionName,
+} from "@/tmux/client"
+import { openInEditor } from "@/tmux/editor-launch"
+import { previewWindowCommand, shellQuote, shellQuoteArgv } from "@/tmux/session-layout"
+import { sessionAttached } from "@/tui/lib/attach-gate"
+import type { VendorId } from "@/types/task"
+import { inheritedEnvPrefix } from "../panes/terminal/launch"
+import { type BadgePollIo, CHAT_TAB_STATE_OPTION, type TurnStatusIo } from "./activity-monitor"
+import { buildPRPrompt } from "./pr-prompt"
+
+export function basename(p: string): string {
+  const i = p.lastIndexOf("/")
+  return i >= 0 ? p.slice(i + 1) : p
+}
+
+/** The launcher-provided identity of one Ops pane (see `OpsHostArgs`). */
+export interface OpsShellContext {
+  readonly taskId: string
+  readonly worktree: string
+  readonly targetPane: string | null
+}
+
+export interface OpsActions {
+  /** enter on a file → editor window, falling back to the opentui preview. */
+  readonly openFile: (rel: string) => void
+  /** `a` — inject `@<path> ` into the engine pane (no Enter; KOB-232). */
+  readonly injectMention: (rel: string) => void
+  /** `p` — send the PR prompt to the engine pane and submit it. */
+  readonly createPR: () => Promise<void>
+  /** Zen chip — toggle zen layout via tmux `run-shell -b` (survives this pane's death). */
+  readonly toggleZen: () => void
+}
+
+/** Build the Ops pane's shell actions. Same guards as the original host:
+ * a standalone `kobe ops` (no task id / target pane) degrades gracefully. */
+export function makeOpsActions(ctx: OpsShellContext): OpsActions {
+  // Open the file's diff/content in a full-width preview window of the
+  // task's tmux session (`kobe-<taskId>`). Without a task id there is no
+  // session to target — bail rather than fire at a phantom (KOB-244).
+  function openPreview(rel: string): void {
+    if (!ctx.taskId) return
+    void newWindow(tmuxSessionName(ctx.taskId), {
+      cwd: ctx.worktree,
+      command: previewWindowCommand({ worktree: ctx.worktree, relPath: rel, cliInvocation: kobeCliInvocation() }),
+      name: basename(rel),
+    })
+  }
+
+  return {
+    // One-key "just open it": the user's nvim/vim in a fresh tmux window
+    // (side-by-side `nvim -d` diff vs HEAD when changed, plain open
+    // otherwise); only when no editor can launch do we fall back to the
+    // read-only opentui preview — enter is never a dead key. A standalone
+    // `kobe ops` (no task id) has no session for an editor window, so it
+    // just previews.
+    openFile(rel: string): void {
+      if (!ctx.taskId) {
+        openPreview(rel)
+        return
+      }
+      const abs = `${ctx.worktree}/${rel}`
+      void openInEditor(tmuxSessionName(ctx.taskId), ctx.worktree, abs).then((launched) => {
+        if (!launched) openPreview(rel)
+      })
+    },
+    // Literal send (`sendKeys` uses `-l`), trailing space, NO Enter — the
+    // user decides when to submit and can queue several mentions. No-op
+    // without a target pane (standalone invocation).
+    injectMention(rel: string): void {
+      if (!ctx.targetPane) return
+      void sendKeys(ctx.targetPane, `@${rel} `)
+    },
+    async createPR(): Promise<void> {
+      if (!ctx.targetPane) return
+      const prompt = await buildPRPrompt(ctx.worktree)
+      await sendKeys(ctx.targetPane, prompt)
+      await sendKeyName(ctx.targetPane, "Enter")
+    },
+    // Entering zen kills THIS pane, so the action must not run in-process —
+    // SIGHUP would abort it half-done. tmux `run-shell -b` runs it detached
+    // from any pane (same path as the prefix-space chord), surviving this
+    // pane's death. A standalone `kobe ops` has no session to act on.
+    toggleZen(): void {
+      if (!ctx.taskId) return
+      const session = tmuxSessionName(ctx.taskId)
+      const inv = kobeCliInvocation()
+      const cmd = `${inheritedEnvPrefix()}${shellQuoteArgv(inv)} layout --session ${shellQuote(session)} --action zen-toggle`
+      void runTmux(["run-shell", "-b", cmd])
+    },
+  }
+}
+
+/** The real IO set for `startLocalBadgePoll` — attach gate + engine-owned mtime probe. */
+export function badgePollIo(vendor: VendorId, worktree: string): BadgePollIo {
+  return {
+    sessionAttached,
+    latestMtime: () => latestTranscriptMtime(vendor, worktree),
+  }
+}
+
+/** The real IO set for `startTurnStatusPoll` against the paired engine pane. */
+export function turnStatusIo(targetPane: string): TurnStatusIo {
+  return {
+    sessionAttached,
+    capturePane: () => capturePaneById(targetPane, 80),
+    setTurnState: (state) => setWindowOption(targetPane, CHAT_TAB_STATE_OPTION, state),
+  }
+}

--- a/packages/kobe/src/tui/ops/host.tsx
+++ b/packages/kobe/src/tui/ops/host.tsx
@@ -8,10 +8,10 @@
  * HEAD when the file has changes, a plain editable open when it doesn't.
  * Only when no nvim/vim is installed does it fall back to our own built-in
  * **full-width preview window** — a fresh tmux window running
- * `kobe ops --preview <file>`, which renders opentui's `<diff>` / `<code>`
- * (tree-sitter syntax highlighting + line numbers, zero external deps),
- * closed with `q` back to the three-pane layout. So nvim is the primary
- * surface and the opentui preview is the last-resort fallback.
+ * `kobe ops --preview <file>` (`./preview.tsx`), which renders opentui's
+ * `<diff>` / `<code>`, closed with `q` back to the three-pane layout. So
+ * nvim is the primary surface and the opentui preview is the last-resort
+ * fallback.
  *
  * Runs in its own OS process inside the tmux pane (separate opentui
  * render loop from the outer kobe TUI). It can't share the outer TUI's
@@ -19,43 +19,25 @@
  * the persisted prefs at boot (read-only — the outer app owns
  * `state.json`) and re-applies them live from the daemon's `ui-prefs`
  * channel (UiPrefsSync).
+ *
+ * File-size-cap split (issue #15 G3): the preview window lives in
+ * `./preview.tsx`; the poll loops (badge fallback + turn status) in the
+ * framework-free `./activity-monitor.ts`; shell actions + concrete IO in
+ * `./host-io.ts` — all shared verbatim with the React port
+ * (`src/tui-react/ops/`). This file owns only the Solid reactivity.
  */
 
-import { createHash } from "node:crypto"
-import { kobeCliInvocation } from "@/cli/invocation"
-import { type ChatTabTurnState, createEngineTurnDetector } from "@/engine/turn-detector"
-import { latestTranscriptMtime } from "@/monitor/activity"
-import {
-  capturePaneById,
-  newWindow,
-  runTmux,
-  sendKeyName,
-  sendKeys,
-  setWindowOption,
-  tmuxSessionName,
-} from "@/tmux/client"
-import { openInEditor } from "@/tmux/editor-launch"
-import { previewWindowCommand, shellQuote, shellQuoteArgv } from "@/tmux/session-layout"
-import { sessionAttached } from "@/tui/lib/attach-gate"
+import { createEngineTurnDetector } from "@/engine/turn-detector"
 import type { VendorId } from "@/types/task"
-import { readWorktreeFile, runWorktreeGit } from "@/worktree/content"
-import { SyntaxStyle } from "@opentui/core"
-import { Show, createEffect, createResource, createSignal, onCleanup, onMount } from "solid-js"
+import { createEffect, createSignal, onCleanup, onMount } from "solid-js"
 import { connectPaneOrchestrator } from "../../client/connect-pane-orchestrator"
 import type { RemoteOrchestrator, TranscriptActivity } from "../../client/remote-orchestrator"
 import { useTheme } from "../context/theme"
 import { t } from "../i18n"
 import { bootPaneHost } from "../lib/host-boot"
-import { useBindings } from "../lib/keymap"
 import { FileTree } from "../panes/filetree/FileTree"
-import { inheritedEnvPrefix } from "../panes/terminal/launch"
-import {
-  ACTIVITY_POLL_MIN_MS,
-  TURN_STATUS_POLL_MS,
-  nextActivityPollDelay,
-  nextTurnStatusPollDelay,
-} from "./activity-poll"
-import { buildPRPrompt } from "./pr-prompt"
+import { startLocalBadgePoll, startTurnStatusPoll } from "./activity-monitor"
+import { badgePollIo, makeOpsActions, turnStatusIo } from "./host-io"
 
 export interface OpsHostArgs {
   readonly taskId: string
@@ -66,17 +48,16 @@ export interface OpsHostArgs {
   readonly vendor: VendorId
 }
 
-// Poll-cadence constants + the pure backoff curves live in `./activity-poll`
-// (host.tsx can't be imported under vitest — it pulls @opentui render assets —
-// so the testable math is factored out). The daemon's `transcript.activity`
-// channel now does the shareable filesystem half; these cadences govern only
-// the local fallback (badge mtime probe) and the always-in-process tmux
-// capture-pane quiescence poll.
-const STABLE_POLLS_FOR_DONE = 2
-const CHAT_TAB_STATE_OPTION = "@kobe_tab_state"
+// Poll-cadence constants + the pure backoff curves live in `./activity-poll`,
+// the loop bodies in `./activity-monitor` (host.tsx can't be imported under
+// vitest — it pulls @opentui render assets — so the testable logic is
+// factored out). The daemon's `transcript.activity` channel does the
+// shareable filesystem half; the loops govern only the local fallback (badge
+// mtime probe) and the always-in-process tmux capture-pane quiescence poll.
 
 function OpsShell(props: OpsHostArgs) {
   const { theme } = useTheme()
+  const actions = makeOpsActions(props)
 
   // Visual prefs (theme / transparent / focus accent) are applied
   // centrally — boot + live `ui-prefs` pushes — by host-boot's
@@ -149,68 +130,23 @@ function OpsShell(props: OpsHostArgs) {
 
   // Local fallback badge poll — runs ONLY while there's no daemon-collected
   // data (`sharedActivityMap()` null: no daemon, or an old daemon without the
-  // channel). Verbatim the pre-daemon adaptive-backoff loop. The effect tears
-  // it down the instant the daemon channel becomes available (Solid runs the
-  // prior run's onCleanup before re-running) and restarts it if a reconnect
-  // downgrades to a daemon without the channel.
+  // channel). Verbatim the pre-daemon adaptive-backoff loop (the body lives
+  // in `activity-monitor.ts`). The effect tears it down the instant the
+  // daemon channel becomes available (Solid runs the prior run's onCleanup
+  // before re-running) and restarts it if a reconnect downgrades to a daemon
+  // without the channel.
   createEffect(() => {
     if (sharedActivityMap() !== null) return
-    let disposed = false
-    let timer: ReturnType<typeof setTimeout> | undefined
-    // Adaptive backoff state: the current poll delay + how many consecutive
-    // reads have seen no mtime advance (see nextActivityPollDelay).
-    let delayMs = ACTIVITY_POLL_MIN_MS
-    let idleStreak = 0
-    let lastSeenMtime = 0
-    async function poll(): Promise<void> {
-      // Detached (background) session: skip the readdir+stat sweep entirely —
-      // the badge is invisible. Next tick after re-attach resumes.
-      if (!(await sessionAttached())) {
-        if (!disposed) timer = setTimeout(() => void poll(), delayMs)
-        return
-      }
-      try {
-        const mtime = await latestTranscriptMtime(props.vendor, props.worktree)
-        if (disposed) return
-        if (!primed) {
-          // First read seeds the baseline so we only ever flag activity
-          // that happened after the pane came up.
+    onCleanup(
+      startLocalBadgePoll(badgePollIo(props.vendor, props.worktree), {
+        isPrimed: () => primed,
+        prime: (mtime) => {
           primed = true
           setBaseline(mtime)
-          lastSeenMtime = mtime
-        }
-        // Snap back to the fast interval the instant the transcript advances;
-        // otherwise ramp the delay so an idle pane stops stat-churning the
-        // (unboundedly growing) transcript dir every 2.5s.
-        if (mtime > lastSeenMtime) {
-          lastSeenMtime = mtime
-          idleStreak = 0
-        } else {
-          idleStreak++
-        }
-        setLatest(mtime)
-      } catch {
-        // The worktree can vanish out from under a live pane (the task is
-        // being deleted: kobe removes the worktree, then kills this
-        // session — a multi-second window for a node_modules-heavy tree).
-        // A transient read failure must NOT crash the pane: this process
-        // has no unhandledRejection net (that's daemon-only), so a bare
-        // `void poll()` rejection would drop the whole Ops pane to a raw
-        // shell. Swallow and let the next tick retry / `disposed` stop us. A
-        // failed read isn't "activity", so let the idle ramp keep climbing.
-        idleStreak++
-      } finally {
-        if (!disposed) {
-          delayMs = nextActivityPollDelay(delayMs, idleStreak)
-          timer = setTimeout(() => void poll(), delayMs)
-        }
-      }
-    }
-    void poll()
-    onCleanup(() => {
-      disposed = true
-      if (timer) clearTimeout(timer)
-    })
+        },
+        setLatest,
+      }),
+    )
   })
   const hasNewActivity = () => primed && latest() > baseline()
   const cornerBadge = () => (hasNewActivity() ? { text: t("ops.badge.newActivity"), active: true } : null)
@@ -218,225 +154,42 @@ function OpsShell(props: OpsHostArgs) {
     setBaseline(latest())
   }
 
-  // Per-window turn detector. The engine adapter owns transcript-specific
-  // completion markers (Codex `turn.completed`, Claude assistant records).
-  // This pane owns only the tmux-local quiescence check for its paired
-  // engine pane, so sibling ChatTabs on the same worktree don't report done
-  // unless THIS window actually changed.
-  //
-  // The `tmux capture-pane` hash + the `@kobe_tab_state` `setWindowOption`
-  // write STAY strictly in-process — the daemon never touches tmux. What
-  // moved daemon-side is the COMPLETION read: when the `transcript.activity`
-  // channel is live we take the engine-owned `completionId` from the shared
-  // push instead of re-parsing the JSONL here, and back the capture-pane
-  // interval off while the shared transcript is quiescent. With no daemon-
-  // collected data we keep the pre-daemon behavior verbatim: a fixed 1.5s
-  // capture-pane interval + a local `detector.latestCompletion` read.
+  // Per-window turn detector (loop body in `activity-monitor.ts`). The
+  // engine adapter owns transcript-specific completion markers; this pane
+  // owns only the tmux-local quiescence check for its paired engine pane, so
+  // sibling ChatTabs on the same worktree don't report done unless THIS
+  // window actually changed. The `usingShared` / `sharedEntry` getters read
+  // the live signal from inside the loop's async ticks (untracked — the loop
+  // is not reactive, it just always sees the latest value).
   onMount(() => {
     if (!props.targetPane) return
-    // Construct the detector unconditionally: `supportsCompletionMarkers()` is
-    // a pure synchronous flag (no IO) needed in both modes, and the fallback
-    // path still calls `latestCompletion`. In shared mode `latestCompletion`
-    // is never called — the daemon owns that read.
-    const detector = createEngineTurnDetector(props.vendor)
-    let disposed = false
-    let baselineCompletionId: string | null = null
-    let baselinePrimed = false
-    let paneHash = ""
-    let observedPaneActivity = false
-    let stablePolls = 0
-    let published: ChatTabTurnState | null = null
-    // Adaptive capture-pane cadence (shared mode only): ramps up while the
-    // shared transcript is quiescent, snaps back when its mtime advances.
-    let delayMs = TURN_STATUS_POLL_MS
-    let lastSharedMtime = 0
-    let timer: ReturnType<typeof setTimeout> | undefined
-
-    /** Whether the daemon is publishing transcript activity for this worktree. */
-    const usingShared = (): boolean => sharedActivityMap() !== null
-
-    async function publish(state: ChatTabTurnState): Promise<void> {
-      if (state === published) return
-      published = state
-      await setWindowOption(props.targetPane!, CHAT_TAB_STATE_OPTION, state)
-    }
-
-    /** Latest completion id — from the shared push when available, else a local read. */
-    async function latestCompletionId(): Promise<string | null> {
-      if (usingShared()) return sharedEntry()?.completionId ?? null
-      return (await detector.latestCompletion(props.worktree))?.id ?? null
-    }
-
-    async function prime(): Promise<void> {
-      try {
-        paneHash = fingerprint(await capturePaneById(props.targetPane!, 80))
-        baselineCompletionId = await latestCompletionId()
-        baselinePrimed = true
-        await publish(detector.supportsCompletionMarkers() ? "idle" : "unknown")
-      } catch {
-        // See the activity poll above: transient failures during the
-        // delete→kill teardown window must not crash this crash-net-less
-        // pane process. The next `poll()` tick re-primes naturally.
-      }
-    }
-
-    async function poll(): Promise<void> {
-      // Detached session: no capture-pane spawn for an invisible status chip.
-      if (!(await sessionAttached())) {
-        if (!disposed) timer = setTimeout(() => void poll(), delayMs)
-        return
-      }
-      const shared = usingShared()
-      try {
-        const nextPaneHash = fingerprint(await capturePaneById(props.targetPane!, 80))
-        if (disposed) return
-        // Lazily seed the baseline if shared activity arrived only after
-        // prime ran with no entry — so the first daemon-pushed completion
-        // isn't mistaken for a fresh "done".
-        if (shared && !baselinePrimed) {
-          baselineCompletionId = sharedEntry()?.completionId ?? null
-          baselinePrimed = true
-        }
-        // Track shared-transcript mtime advance for the adaptive cadence.
-        const sharedMtime = shared ? (sharedEntry()?.mtimeMs ?? 0) : 0
-        const mtimeAdvanced = sharedMtime > lastSharedMtime
-        if (sharedMtime > lastSharedMtime) lastSharedMtime = sharedMtime
-
-        if (nextPaneHash !== paneHash) {
-          paneHash = nextPaneHash
-          observedPaneActivity = true
-          stablePolls = 0
-          await publish(detector.supportsCompletionMarkers() ? "running" : "unknown")
-        } else if (observedPaneActivity) {
-          stablePolls++
-        }
-
-        if (detector.supportsCompletionMarkers() && observedPaneActivity && stablePolls >= STABLE_POLLS_FOR_DONE) {
-          const completionId = await latestCompletionId()
-          // Done rule unchanged: a NEW completion id past the baseline, with
-          // the pane having gone quiescent, means the turn finished.
-          if (!disposed && completionId !== null && completionId !== baselineCompletionId) {
-            baselineCompletionId = completionId
-            observedPaneActivity = false
-            stablePolls = 0
-            await publish("done")
-          }
-        }
-        // Cadence: shared mode ramps the capture-pane interval while idle;
-        // fallback keeps the fixed 1.5s tick.
-        delayMs = shared ? nextTurnStatusPollDelay(delayMs, mtimeAdvanced, published) : TURN_STATUS_POLL_MS
-      } catch {
-        // capturePaneById / publish (setWindowOption) fire tmux against
-        // `props.targetPane` — once the task is deleted that pane and its
-        // session are torn down, so these reject mid-flight. Swallow so a
-        // teardown race degrades to a quiet no-op instead of crashing the
-        // Ops pane to a shell with a stack dump (the reported bug).
-        delayMs = TURN_STATUS_POLL_MS
-      } finally {
-        if (!disposed) timer = setTimeout(() => void poll(), delayMs)
-      }
-    }
-
-    void prime()
-    timer = setTimeout(() => void poll(), TURN_STATUS_POLL_MS)
-    onCleanup(() => {
-      disposed = true
-      if (timer) clearTimeout(timer)
-    })
+    onCleanup(
+      startTurnStatusPoll(
+        {
+          worktree: props.worktree,
+          detector: createEngineTurnDetector(props.vendor),
+          usingShared: () => sharedActivityMap() !== null,
+          sharedEntry,
+        },
+        turnStatusIo(props.targetPane),
+      ),
+    )
   })
-
-  // Open the file's diff/content in a full-width preview window of the
-  // task's tmux session. The Ops pane lives in that session, named
-  // `kobe-<taskId>`, so we can target it by name.
-  function openPreview(rel: string): void {
-    // Without a task id, `tmuxSessionName("")` is `kobe-`, which targets a
-    // session that doesn't exist — new-window would just error and Enter
-    // would silently do nothing. Only the standalone `kobe ops --worktree X`
-    // invocation (no --task-id) hits this; the in-session Ops pane always
-    // has one. Bail rather than fire at a phantom session (KOB-244).
-    if (!props.taskId) return
-    void newWindow(tmuxSessionName(props.taskId), {
-      cwd: props.worktree,
-      command: previewWindowCommand({ worktree: props.worktree, relPath: rel, cliInvocation: kobeCliInvocation() }),
-      name: basename(rel),
-    })
-  }
-
-  // enter on a file → one-key "just open it". Open it in the user's
-  // nvim/vim in a fresh tmux window (side-by-side `nvim -d` diff vs HEAD
-  // when changed, plain editable open otherwise). Only when no editor can
-  // launch (no nvim/vim installed / nothing configured) do we fall back to
-  // our own read-only opentui preview — so enter is never a dead key.
-  // Phantom-session guard: a standalone `kobe ops` (no task id) has no
-  // session to open an editor window in, so it just previews.
-  function openFile(rel: string): void {
-    if (!props.taskId) {
-      openPreview(rel)
-      return
-    }
-    const abs = `${props.worktree}/${rel}`
-    void openInEditor(tmuxSessionName(props.taskId), props.worktree, abs).then((launched) => {
-      if (!launched) openPreview(rel)
-    })
-  }
-
-  // `a` on a file → inject `@<path> ` into the engine pane via tmux
-  // send-keys (KOB-232). `targetPane` is the claude/codex pane id passed
-  // by the launcher (`opsPaneCommand --target-pane`). Literal send (the
-  // shared `sendKeys` uses `-l`), trailing space, NO Enter — the user
-  // decides when to submit, and focus stays in the Ops pane so they can
-  // queue several mentions. No-op when there's no target pane (a
-  // standalone `kobe ops` invocation without --target-pane).
-  function injectMention(rel: string): void {
-    if (!props.targetPane) return
-    void sendKeys(props.targetPane, `@${rel} `)
-  }
-
-  async function createPR(): Promise<void> {
-    if (!props.targetPane) return
-    const prompt = await buildPRPrompt(props.worktree)
-    await sendKeys(props.targetPane, prompt)
-    await sendKeyName(props.targetPane, "Enter")
-  }
-
-  // Toggle zen mode for this ChatTab's tmux session. Entering zen kills THIS
-  // pane (the file/Ops pane the chip lives in), so we must NOT run the action
-  // in-process — SIGHUP would abort it after only the Ops pane was hidden,
-  // leaving the terminal up. Hand it to tmux `run-shell -b` instead (same path
-  // the `prefix`-space chord uses): the tmux server runs it detached from any
-  // pane, so it survives this pane's death and completes every hide/restore.
-  // A standalone `kobe ops` (no task id) has no session to act on.
-  function toggleZen(): void {
-    if (!props.taskId) return
-    const session = tmuxSessionName(props.taskId)
-    const inv = kobeCliInvocation()
-    const cmd = `${inheritedEnvPrefix()}${shellQuoteArgv(inv)} layout --session ${shellQuote(session)} --action zen-toggle`
-    void runTmux(["run-shell", "-b", cmd])
-  }
 
   return (
     <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
       <FileTree
         worktreePath={() => props.worktree}
         focused={() => true}
-        onOpenFile={openFile}
-        onMention={injectMention}
-        onCreatePR={() => void createPR()}
-        onZenToggle={props.taskId ? toggleZen : undefined}
+        onOpenFile={actions.openFile}
+        onMention={actions.injectMention}
+        onCreatePR={() => void actions.createPR()}
+        onZenToggle={props.taskId ? actions.toggleZen : undefined}
         cornerBadge={cornerBadge}
         onRefresh={ackActivity}
       />
     </box>
   )
-}
-
-function basename(p: string): string {
-  const i = p.lastIndexOf("/")
-  return i >= 0 ? p.slice(i + 1) : p
-}
-
-function fingerprint(text: string): string {
-  return createHash("sha1").update(text).digest("hex")
 }
 
 export async function startOpsHost(args: OpsHostArgs): Promise<void> {
@@ -446,161 +199,5 @@ export async function startOpsHost(args: OpsHostArgs): Promise<void> {
     logContext: "ops",
     providers: { kv: false, focus: false },
     setup: () => ({ root: () => <OpsShell {...args} /> }),
-  })
-}
-
-/* ─── full-width preview window (`kobe ops --preview <rel>`) ─────────── */
-
-export interface OpsPreviewArgs {
-  readonly worktree: string
-  readonly relPath: string
-}
-
-/** Map a file extension to an opentui tree-sitter grammar name. */
-function filetypeOf(relPath: string): string | undefined {
-  const ext = relPath.slice(relPath.lastIndexOf(".") + 1).toLowerCase()
-  switch (ext) {
-    case "ts":
-    case "tsx":
-    case "mts":
-    case "cts":
-      return "typescript"
-    case "js":
-    case "jsx":
-    case "mjs":
-    case "cjs":
-      return "javascript"
-    case "md":
-    case "markdown":
-      return "markdown"
-    default:
-      return undefined
-  }
-}
-
-async function gitDiff(worktree: string, relPath: string): Promise<string> {
-  const res = await runWorktreeGit(worktree, ["diff", "HEAD", "--", relPath])
-  return res.status === 0 ? res.stdout : ""
-}
-
-async function readFileText(worktree: string, relPath: string): Promise<string> {
-  return (await readWorktreeFile(worktree, relPath)) ?? ""
-}
-
-/**
- * Build a tree-sitter SyntaxStyle from the active kobe theme.
- * `SyntaxStyle.create()` is an EMPTY style — opentui parses the code
- * into capture groups but renders them plain unless each scope has a
- * registered colour. We map the nvim-treesitter capture names the
- * bundled ts/js/markdown grammars emit (probed: keyword, string,
- * comment, type, function, number, …) onto kobe's palette so the
- * preview's highlighting matches the rest of the TUI.
- */
-function buildSyntaxStyle(theme: ReturnType<typeof useTheme>["theme"]): SyntaxStyle {
-  const kw = { fg: theme.primary }
-  const str = { fg: theme.success }
-  const fn = { fg: theme.info }
-  const typ = { fg: theme.warning }
-  const num = { fg: theme.accent }
-  const com = { fg: theme.textMuted, italic: true }
-  const punct = { fg: theme.textMuted }
-  const txt = { fg: theme.text }
-  return SyntaxStyle.fromStyles({
-    keyword: kw,
-    "keyword.function": kw,
-    "keyword.return": kw,
-    "keyword.import": kw,
-    "keyword.exception": kw,
-    "keyword.conditional": kw,
-    "keyword.repeat": kw,
-    "keyword.operator": kw,
-    "keyword.modifier": kw,
-    "keyword.type": kw,
-    string: str,
-    "string.escape": str,
-    "string.regexp": str,
-    "string.special": str,
-    "character.special": str,
-    comment: com,
-    "comment.documentation": com,
-    function: fn,
-    "function.call": fn,
-    "function.method": fn,
-    "function.builtin": fn,
-    constructor: fn,
-    type: typ,
-    "type.builtin": typ,
-    constant: num,
-    "constant.builtin": num,
-    boolean: num,
-    number: num,
-    operator: punct,
-    "punctuation.bracket": punct,
-    "punctuation.delimiter": punct,
-    "punctuation.special": punct,
-    variable: txt,
-    "variable.member": txt,
-    "variable.parameter": txt,
-    "variable.builtin": num,
-    property: txt,
-    attribute: typ,
-    label: txt,
-    module: txt,
-  })
-}
-
-function PreviewScreen(props: OpsPreviewArgs) {
-  const { theme } = useTheme()
-  const style = buildSyntaxStyle(theme)
-  const filetype = filetypeOf(props.relPath)
-
-  const [data] = createResource(
-    () => props.relPath,
-    async (rel) => {
-      const diff = await gitDiff(props.worktree, rel)
-      if (diff.trim().length > 0) return { kind: "diff" as const, text: diff }
-      return { kind: "code" as const, text: await readFileText(props.worktree, rel) }
-    },
-  )
-
-  useBindings(() => ({
-    bindings: [
-      { key: "q", cmd: () => process.exit(0) },
-      { key: "escape", cmd: () => process.exit(0) },
-      { key: "ctrl+c", cmd: () => process.exit(0) },
-    ],
-  }))
-
-  return (
-    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
-      <box flexDirection="row" gap={1} paddingLeft={1} paddingRight={1}>
-        <text fg={theme.accent}>{props.relPath}</text>
-        <text fg={theme.textMuted}>
-          {data()?.kind === "diff" ? t("ops.preview.diffVsHead") : t("ops.preview.file")}
-        </text>
-        <text fg={theme.textMuted}>{t("ops.preview.closeHint")}</text>
-      </box>
-      <box flexGrow={1}>
-        <Show when={data()} fallback={<text fg={theme.textMuted}>{t("ops.preview.loading")}</text>}>
-          {(d) => (
-            <Show
-              when={d().kind === "diff"}
-              fallback={<code content={d().text} filetype={filetype} syntaxStyle={style} />}
-            >
-              <diff diff={d().text} view="unified" filetype={filetype} syntaxStyle={style} showLineNumbers={true} />
-            </Show>
-          )}
-        </Show>
-      </box>
-    </box>
-  )
-}
-
-export async function startOpsPreview(args: OpsPreviewArgs): Promise<void> {
-  // Same minimal provider set as the Ops pane. Note: unlike startOpsHost
-  // this entrypoint never set a client-log context — preserved as-is.
-  await bootPaneHost({
-    providers: { kv: false, focus: false },
-    setup: () => ({ root: () => <PreviewScreen {...args} /> }),
   })
 }

--- a/packages/kobe/src/tui/ops/preview-core.ts
+++ b/packages/kobe/src/tui/ops/preview-core.ts
@@ -1,0 +1,44 @@
+/**
+ * Framework-free data half of the `kobe ops --preview <rel>` window,
+ * extracted from `tui/ops/host.tsx` so the Solid and React previews (issue
+ * #15, G3) share it. Vitest-safe: no @opentui imports (the theme-bound
+ * SyntaxStyle builder lives in `./preview-syntax`), no framework.
+ */
+
+import { readWorktreeFile, runWorktreeGit } from "@/worktree/content"
+
+/** Map a file extension to an opentui tree-sitter grammar name. */
+export function filetypeOf(relPath: string): string | undefined {
+  const ext = relPath.slice(relPath.lastIndexOf(".") + 1).toLowerCase()
+  switch (ext) {
+    case "ts":
+    case "tsx":
+    case "mts":
+    case "cts":
+      return "typescript"
+    case "js":
+    case "jsx":
+    case "mjs":
+    case "cjs":
+      return "javascript"
+    case "md":
+    case "markdown":
+      return "markdown"
+    default:
+      return undefined
+  }
+}
+
+export interface PreviewData {
+  /** `diff` renders opentui `<diff>` (unified vs HEAD); `code` a plain `<code>` view. */
+  readonly kind: "diff" | "code"
+  readonly text: string
+}
+
+/** Diff vs HEAD when the file has changes, otherwise its full content. */
+export async function loadPreviewData(worktree: string, relPath: string): Promise<PreviewData> {
+  const res = await runWorktreeGit(worktree, ["diff", "HEAD", "--", relPath])
+  const diff = res.status === 0 ? res.stdout : ""
+  if (diff.trim().length > 0) return { kind: "diff", text: diff }
+  return { kind: "code", text: (await readWorktreeFile(worktree, relPath)) ?? "" }
+}

--- a/packages/kobe/src/tui/ops/preview-syntax.ts
+++ b/packages/kobe/src/tui/ops/preview-syntax.ts
@@ -1,0 +1,71 @@
+/**
+ * Theme → tree-sitter SyntaxStyle mapping for the ops preview window,
+ * extracted from `tui/ops/host.tsx` and shared by the Solid and React
+ * previews (issue #15, G3). Kept apart from `./preview-core` because it
+ * imports `@opentui/core`, which vitest can't load.
+ */
+
+import { SyntaxStyle } from "@opentui/core"
+import type { Theme } from "../context/theme-core"
+
+/**
+ * Build a tree-sitter SyntaxStyle from the active kobe theme.
+ * `SyntaxStyle.create()` is an EMPTY style — opentui parses the code
+ * into capture groups but renders them plain unless each scope has a
+ * registered colour. We map the nvim-treesitter capture names the
+ * bundled ts/js/markdown grammars emit (probed: keyword, string,
+ * comment, type, function, number, …) onto kobe's palette so the
+ * preview's highlighting matches the rest of the TUI.
+ */
+export function buildSyntaxStyle(theme: Theme): SyntaxStyle {
+  const kw = { fg: theme.primary }
+  const str = { fg: theme.success }
+  const fn = { fg: theme.info }
+  const typ = { fg: theme.warning }
+  const num = { fg: theme.accent }
+  const com = { fg: theme.textMuted, italic: true }
+  const punct = { fg: theme.textMuted }
+  const txt = { fg: theme.text }
+  return SyntaxStyle.fromStyles({
+    keyword: kw,
+    "keyword.function": kw,
+    "keyword.return": kw,
+    "keyword.import": kw,
+    "keyword.exception": kw,
+    "keyword.conditional": kw,
+    "keyword.repeat": kw,
+    "keyword.operator": kw,
+    "keyword.modifier": kw,
+    "keyword.type": kw,
+    string: str,
+    "string.escape": str,
+    "string.regexp": str,
+    "string.special": str,
+    "character.special": str,
+    comment: com,
+    "comment.documentation": com,
+    function: fn,
+    "function.call": fn,
+    "function.method": fn,
+    "function.builtin": fn,
+    constructor: fn,
+    type: typ,
+    "type.builtin": typ,
+    constant: num,
+    "constant.builtin": num,
+    boolean: num,
+    number: num,
+    operator: punct,
+    "punctuation.bracket": punct,
+    "punctuation.delimiter": punct,
+    "punctuation.special": punct,
+    variable: txt,
+    "variable.member": txt,
+    "variable.parameter": txt,
+    "variable.builtin": num,
+    property: txt,
+    attribute: typ,
+    label: txt,
+    module: txt,
+  })
+}

--- a/packages/kobe/src/tui/ops/preview.tsx
+++ b/packages/kobe/src/tui/ops/preview.tsx
@@ -1,0 +1,74 @@
+/**
+ * `kobe ops --preview <rel>` — the full-width fallback preview window,
+ * extracted from `tui/ops/host.tsx` (file-size-cap split, issue #15 G3).
+ * Renders opentui's `<diff>` / `<code>` (tree-sitter syntax highlighting +
+ * line numbers, zero external deps) in a fresh tmux window when no
+ * nvim/vim is available; closed with `q` back to the three-pane layout.
+ * Data + syntax-style mapping live in `./preview-core` / `./preview-syntax`,
+ * shared with the React port.
+ */
+
+import { Show, createResource } from "solid-js"
+import { useTheme } from "../context/theme"
+import { t } from "../i18n"
+import { bootPaneHost } from "../lib/host-boot"
+import { useBindings } from "../lib/keymap"
+import { filetypeOf, loadPreviewData } from "./preview-core"
+import { buildSyntaxStyle } from "./preview-syntax"
+
+export interface OpsPreviewArgs {
+  readonly worktree: string
+  readonly relPath: string
+}
+
+function PreviewScreen(props: OpsPreviewArgs) {
+  const { theme } = useTheme()
+  const style = buildSyntaxStyle(theme)
+  const filetype = filetypeOf(props.relPath)
+
+  const [data] = createResource(
+    () => props.relPath,
+    (rel) => loadPreviewData(props.worktree, rel),
+  )
+
+  useBindings(() => ({
+    bindings: [
+      { key: "q", cmd: () => process.exit(0) },
+      { key: "escape", cmd: () => process.exit(0) },
+      { key: "ctrl+c", cmd: () => process.exit(0) },
+    ],
+  }))
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+      <box flexDirection="row" gap={1} paddingLeft={1} paddingRight={1}>
+        <text fg={theme.accent}>{props.relPath}</text>
+        <text fg={theme.textMuted}>
+          {data()?.kind === "diff" ? t("ops.preview.diffVsHead") : t("ops.preview.file")}
+        </text>
+        <text fg={theme.textMuted}>{t("ops.preview.closeHint")}</text>
+      </box>
+      <box flexGrow={1}>
+        <Show when={data()} fallback={<text fg={theme.textMuted}>{t("ops.preview.loading")}</text>}>
+          {(d) => (
+            <Show
+              when={d().kind === "diff"}
+              fallback={<code content={d().text} filetype={filetype} syntaxStyle={style} />}
+            >
+              <diff diff={d().text} view="unified" filetype={filetype} syntaxStyle={style} showLineNumbers={true} />
+            </Show>
+          )}
+        </Show>
+      </box>
+    </box>
+  )
+}
+
+export async function startOpsPreview(args: OpsPreviewArgs): Promise<void> {
+  // Same minimal provider set as the Ops pane. Note: unlike startOpsHost
+  // this entrypoint never set a client-log context — preserved as-is.
+  await bootPaneHost({
+    providers: { kv: false, focus: false },
+    setup: () => ({ root: () => <PreviewScreen {...args} /> }),
+  })
+}

--- a/packages/kobe/test/cli/index-pane-hosts.test.ts
+++ b/packages/kobe/test/cli/index-pane-hosts.test.ts
@@ -46,10 +46,8 @@ vi.mock("../../src/tui/help/host.tsx", () => ({ startHelpHost: spies.startHelpHo
 vi.mock("../../src/tui/new-task/host.tsx", () => ({ startNewTaskHost: spies.startNewTaskHost }))
 vi.mock("../../src/tui/update/host.tsx", () => ({ startUpdateHost: spies.startUpdateHost }))
 vi.mock("../../src/tui/history/host.tsx", () => ({ startHistoryHost: spies.startHistoryHost }))
-vi.mock("../../src/tui/ops/host.tsx", () => ({
-  startOpsHost: spies.startOpsHost,
-  startOpsPreview: spies.startOpsPreview,
-}))
+vi.mock("../../src/tui/ops/host.tsx", () => ({ startOpsHost: spies.startOpsHost }))
+vi.mock("../../src/tui/ops/preview.tsx", () => ({ startOpsPreview: spies.startOpsPreview }))
 
 let originalArgv: string[]
 let exitSpy: ReturnType<typeof vi.fn>

--- a/packages/kobe/test/tui-react/ops-activity-monitor.test.ts
+++ b/packages/kobe/test/tui-react/ops-activity-monitor.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The Ops pane's framework-free poll loops (`tui/ops/activity-monitor.ts`),
+ * extracted from the Solid host so the React port (issue #15, G3) runs the
+ * SAME loop bodies. Why these tests matter: the loops were previously
+ * component-internal and untestable (host.tsx pulls @opentui render
+ * assets); the extraction makes the badge-prime rule ("only post-mount
+ * activity flags"), the teardown-race swallow, and the ChatTab done rule
+ * ("new completion id + quiescent pane") directly checkable with fake IO
+ * and fake timers — regressions here silently break the `● new` badge or
+ * report "done" for a sibling window's turn.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { startLocalBadgePoll, startTurnStatusPoll } from "../../src/tui/ops/activity-monitor.ts"
+import { ACTIVITY_POLL_MIN_MS, TURN_STATUS_POLL_MS } from "../../src/tui/ops/activity-poll.ts"
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** Badge-state harness standing in for the host's primed/baseline/latest. */
+function badgeHooks() {
+  const state = { primed: false, baseline: [] as number[], latest: [] as number[] }
+  return {
+    state,
+    hooks: {
+      isPrimed: () => state.primed,
+      prime: (mtime: number) => {
+        state.primed = true
+        state.baseline.push(mtime)
+      },
+      setLatest: (mtime: number) => {
+        state.latest.push(mtime)
+      },
+    },
+  }
+}
+
+describe("startLocalBadgePoll", () => {
+  it("primes on the first read, then reports each subsequent mtime", async () => {
+    const mtimes = [100, 100, 250]
+    let reads = 0
+    const { state, hooks } = badgeHooks()
+    const stop = startLocalBadgePoll(
+      {
+        sessionAttached: async () => true,
+        latestMtime: async () => mtimes[Math.min(reads++, mtimes.length - 1)] as number,
+      },
+      hooks,
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    // First read seeds the baseline — it must NOT count as new activity.
+    expect(state.baseline).toEqual([100])
+    expect(state.latest).toEqual([100])
+    await vi.advanceTimersByTimeAsync(ACTIVITY_POLL_MIN_MS)
+    await vi.advanceTimersByTimeAsync(ACTIVITY_POLL_MIN_MS)
+    expect(state.baseline).toEqual([100])
+    expect(state.latest).toEqual([100, 100, 250])
+    stop()
+  })
+
+  it("skips the probe entirely while the session is detached", async () => {
+    const latestMtime = vi.fn(async () => 1)
+    const { state, hooks } = badgeHooks()
+    const stop = startLocalBadgePoll({ sessionAttached: async () => false, latestMtime }, hooks)
+    await vi.advanceTimersByTimeAsync(ACTIVITY_POLL_MIN_MS * 3)
+    expect(latestMtime).not.toHaveBeenCalled()
+    expect(state.latest).toEqual([])
+    stop()
+  })
+
+  it("swallows probe failures (worktree deleted mid-poll) and keeps ticking", async () => {
+    let reads = 0
+    const { state, hooks } = badgeHooks()
+    const stop = startLocalBadgePoll(
+      {
+        sessionAttached: async () => true,
+        latestMtime: async () => {
+          reads++
+          if (reads === 1) throw new Error("ENOENT")
+          return 42
+        },
+      },
+      hooks,
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    expect(state.latest).toEqual([])
+    await vi.advanceTimersByTimeAsync(ACTIVITY_POLL_MIN_MS)
+    expect(state.baseline).toEqual([42])
+    expect(state.latest).toEqual([42])
+    stop()
+    // Disposed: no further reads regardless of elapsed time.
+    const after = reads
+    await vi.advanceTimersByTimeAsync(ACTIVITY_POLL_MIN_MS * 10)
+    expect(reads).toBe(after)
+  })
+})
+
+describe("startTurnStatusPoll", () => {
+  function makeIo(pane: () => string) {
+    const published: string[] = []
+    return {
+      published,
+      io: {
+        sessionAttached: async () => true,
+        capturePane: async () => pane(),
+        setTurnState: async (state: string) => {
+          published.push(state)
+        },
+      },
+    }
+  }
+
+  it("fallback mode: idle on prime, running on pane change, done after quiescence + NEW completion", async () => {
+    let pane = "A"
+    let completion: string | null = "c0"
+    const latestCompletion = vi.fn(async () => (completion ? { id: completion } : null))
+    const { published, io } = makeIo(() => pane)
+    const stop = startTurnStatusPoll(
+      {
+        worktree: "/wt",
+        detector: { supportsCompletionMarkers: () => true, latestCompletion },
+        usingShared: () => false,
+        sharedEntry: () => null,
+      },
+      io,
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    expect(published).toEqual(["idle"])
+    // The pane content changed → a turn is running.
+    pane = "B"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    expect(published).toEqual(["idle", "running"])
+    // A new completion id lands, pane goes quiescent: done only after the
+    // stable-poll threshold, not on the first unchanged read.
+    completion = "c1"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    expect(published).toEqual(["idle", "running"])
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    expect(published).toEqual(["idle", "running", "done"])
+    stop()
+  })
+
+  it("stays quiet when the pane never changed, even with a new completion id (sibling-window turn)", async () => {
+    let completion = "c0"
+    const { published, io } = makeIo(() => "A")
+    const stop = startTurnStatusPoll(
+      {
+        worktree: "/wt",
+        detector: { supportsCompletionMarkers: () => true, latestCompletion: async () => ({ id: completion }) },
+        usingShared: () => false,
+        sharedEntry: () => null,
+      },
+      io,
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    completion = "c1"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS * 5)
+    expect(published).toEqual(["idle"])
+    stop()
+  })
+
+  it("shared mode: completion comes from the daemon push, never a local transcript read", async () => {
+    let pane = "A"
+    let entry = { mtimeMs: 1, completionId: "c0", completionAt: 0 }
+    const latestCompletion = vi.fn(async () => ({ id: "local-never-used" }))
+    const { published, io } = makeIo(() => pane)
+    const stop = startTurnStatusPoll(
+      {
+        worktree: "/wt",
+        detector: { supportsCompletionMarkers: () => true, latestCompletion },
+        usingShared: () => true,
+        sharedEntry: () => entry,
+      },
+      io,
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    expect(published).toEqual(["idle"])
+    pane = "B"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    expect(published).toEqual(["idle", "running"])
+    entry = { mtimeMs: 2, completionId: "c1", completionAt: 1 }
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    expect(published).toEqual(["idle", "running", "done"])
+    expect(latestCompletion).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it("unknown-marker engines publish unknown and never done", async () => {
+    let pane = "A"
+    const { published, io } = makeIo(() => pane)
+    const stop = startTurnStatusPoll(
+      {
+        worktree: "/wt",
+        detector: { supportsCompletionMarkers: () => false, latestCompletion: async () => ({ id: "x" }) },
+        usingShared: () => false,
+        sharedEntry: () => null,
+      },
+      io,
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    pane = "B"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS * 4)
+    expect(published).toEqual(["unknown"])
+    stop()
+  })
+})

--- a/packages/kobe/test/tui-react/ops-preview-core.test.ts
+++ b/packages/kobe/test/tui-react/ops-preview-core.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Data half of the ops preview window (`tui/ops/preview-core.ts`), shared
+ * by the Solid and React previews (issue #15, G3). Why these tests matter:
+ * `loadPreviewData` decides which renderable the preview mounts — a dirty
+ * file MUST render as a `<diff>` vs HEAD and a clean/untracked one as its
+ * `<code>` content — and `filetypeOf` picks the tree-sitter grammar; both
+ * were previously locked inside the untestable host.tsx.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "vitest"
+import { filetypeOf, loadPreviewData } from "../../src/tui/ops/preview-core.ts"
+
+describe("filetypeOf", () => {
+  test("maps known extensions to their tree-sitter grammar and unknown ones to undefined", () => {
+    expect(filetypeOf("src/a.ts")).toBe("typescript")
+    expect(filetypeOf("src/a.tsx")).toBe("typescript")
+    expect(filetypeOf("a.mjs")).toBe("javascript")
+    expect(filetypeOf("README.markdown")).toBe("markdown")
+    expect(filetypeOf("Makefile")).toBeUndefined()
+    expect(filetypeOf("img.png")).toBeUndefined()
+  })
+})
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-preview-core-"))
+  execFileSync("git", ["init", "-q"], { cwd: dir })
+  writeFileSync(join(dir, "a.ts"), "export const a = 1\n")
+  execFileSync("git", ["add", "a.ts"], { cwd: dir })
+  execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "init"], { cwd: dir })
+  return dir
+}
+
+describe("loadPreviewData", () => {
+  test("a changed file previews as the unified diff vs HEAD", async () => {
+    const repo = makeRepo()
+    writeFileSync(join(repo, "a.ts"), "export const a = 2\n")
+    const data = await loadPreviewData(repo, "a.ts")
+    expect(data.kind).toBe("diff")
+    expect(data.text).toContain("-export const a = 1")
+    expect(data.text).toContain("+export const a = 2")
+  })
+
+  test("a clean file previews as its content", async () => {
+    const repo = makeRepo()
+    const data = await loadPreviewData(repo, "a.ts")
+    expect(data).toEqual({ kind: "code", text: "export const a = 1\n" })
+  })
+
+  test("a missing file degrades to empty content, not a throw", async () => {
+    const repo = makeRepo()
+    const data = await loadPreviewData(repo, "nope.ts")
+    expect(data).toEqual({ kind: "code", text: "" })
+  })
+})


### PR DESCRIPTION
## Summary
- G3 wave 2, ops slice: `kobe ops` and `kobe ops --preview` route to the new React port (`src/tui-react/ops/host.tsx` / `preview.tsx`) behind `KOBE_REACT=1` in `cli/commands-tui.ts` — the exact seam `kobe history` uses. The React host mounts the already-ported React FileTree; the preview's single Solid `createResource` follows the G3.1 async canon (`useState` + dependency-keyed effect with disposed-flag cancellation).
- **File-size-cap split first (behavior-preserving, Solid keeps consuming every piece):** the 606-line Solid `tui/ops/host.tsx` shrinks to 203 by extracting the preview window (`preview.tsx`), the framework-free poll-loop bodies (`activity-monitor.ts` — badge fallback poll + turn-status capture-pane poll, IO injected, type-only imports so they run under vitest), the shell actions + concrete tmux IO (`host-io.ts`), and the preview data/grammar mapping (`preview-core.ts`) + theme→SyntaxStyle table (`preview-syntax.ts`).
- **Client-layer live state:** ops consumes the daemon's `transcript.activity` channel, so `RemoteOrchestrator` gains a `transcriptActivityStore()` external-store twin of `transcriptActivitySignal()` — same dual-write single-writer pattern as `uiPrefsStore`/`keybindingsRevStore`. The React host reads it via `useSyncExternalStore`; the timer-driven poll loops read the latest map through a render-refreshed ref (the React analog of the Solid host's untracked signal reads).
- **Render proof:** new `dev:mock-react-ops` script mounts the real `OpsShell` (standalone shape: no task id / target pane, local badge fallback live) against a throwaway `git init` fixture with deterministic `kobe-fixture-*` names.
- New vitest coverage for the extracted loops: badge priming ("first read is baseline, not activity"), detached-session probe skip, teardown-race swallow + dispose, and the ChatTab done rule (idle → running → done only after quiescence + a NEW completion id; sibling-window turns stay quiet; shared mode never reads the transcript locally), plus `loadPreviewData` diff/code/missing-file behavior against a real repo.

file-size-exemption: packages/kobe/src/client/remote-orchestrator.ts — pre-existing exemption debt (523 lines on main, mechanical accessor/delegate surface); this PR adds only the 9-line transcriptActivityStore twin alongside its documented siblings.
coverage-exemption: packages/kobe/src/tui/ops/host-io.ts — tmux/editor IO glue moved verbatim out of the untestable host.tsx (spawns tmux windows, send-keys, run-shell); the decision logic it wraps is covered by pr-prompt + activity-monitor tests and the actions are exercised live by the dev:mock-react-ops / dev:mock gates.
coverage-exemption: packages/kobe/src/tui/ops/preview-syntax.ts — imports @opentui/core (SyntaxStyle), which vitest cannot load; a static capture-name→palette table with no branches, exercised live by both preview hosts.

## Test plan
- [x] `bun run typecheck` clean (packages/kobe)
- [x] repo-root `bun run lint` clean
- [x] `bun run test` — fast + socket green (2512 fast tests incl. new `ops-activity-monitor` + `ops-preview-core`; `index-pane-hosts` routing mocks updated for the host/preview split)
- [x] `bun run compile` → `./release-bin/kobe --version` OK (0.7.63)
- [x] `timeout 6 bun run dev:mock` — Solid mock unbroken (exit 124)
- [x] `timeout 8 bun run dev:mock-react-ops` under a pty — captured frames grep `kobe-fixture-alpha.ts` / `kobe-fixture-readme.md`
- [x] all prior `dev:mock-react-*` scripts (base/chat/history/filetree/sidebar) still boot (exit 124)
- [x] real CLI seam: `KOBE_REACT=1 kobe ops --worktree <fixture>` and `--preview` render under a pty; same invocations without the flag boot the split Solid hosts
- [x] `bun run coverage` + `scripts/coverage-gate.mjs` (BASE_REF=main) locally — all touched .ts ≥ floor except the two exemptions above
