### PR TITLE
feat: React ports of the task dialogs (G3W2, issue #15)

### DIFF
--- a/.changeset/react-g3w2-dialogs-b.md
+++ b/.changeset/react-g3w2-dialogs-b.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+React ports of the task dialogs (issue #15, G3 wave 2): the full NewTaskDialog (Existing / New Repo / Adopt tabs, engine selector, saved/browse repo picker, branch picker, async clone) and RenameTaskDialog under `src/tui-react/component/`, driven by the shared framework-free `state.ts`/`clone.ts` helpers, with a `dev:mock-react-dialogs` live-render host.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -28,6 +28,7 @@
     "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
     "dev:mock-react": "env KOBE_DEV=1 bun ./src/tui-react/mock/host.tsx",
     "dev:mock-react-chat": "env KOBE_DEV=1 bun ./src/tui-react/chat/mock-host.tsx",
+    "dev:mock-react-dialogs": "env KOBE_DEV=1 bun ./src/tui-react/component/mock-dialogs-host.tsx",
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
     "dev:mock-react-filetree": "env KOBE_DEV=1 bun ./src/tui-react/panes/filetree/mock-host.tsx",
     "dev:mock-react-sidebar": "env KOBE_DEV=1 bun ./src/tui-react/panes/sidebar/mock-host.tsx",

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -28,7 +28,7 @@
     "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
     "dev:mock-react": "env KOBE_DEV=1 bun ./src/tui-react/mock/host.tsx",
     "dev:mock-react-chat": "env KOBE_DEV=1 bun ./src/tui-react/chat/mock-host.tsx",
-    "dev:mock-react-dialogs": "env KOBE_DEV=1 bun ./src/tui-react/component/mock-dialogs-host.tsx",
+    "dev:mock-react-task-dialogs": "env KOBE_DEV=1 bun ./src/tui-react/component/mock-dialogs-host.tsx",
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",
     "dev:mock-react-filetree": "env KOBE_DEV=1 bun ./src/tui-react/panes/filetree/mock-host.tsx",
     "dev:mock-react-sidebar": "env KOBE_DEV=1 bun ./src/tui-react/panes/sidebar/mock-host.tsx",

--- a/packages/kobe/src/tui-react/component/mock-dialogs-host.tsx
+++ b/packages/kobe/src/tui-react/component/mock-dialogs-host.tsx
@@ -1,0 +1,120 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React task-dialogs mock host (`bun run dev:mock-react-dialogs`) —
+ * live-render proof for the ported NewTaskDialog + RenameTaskDialog
+ * (issue #15, G3W2). Boots through the real React pane host, opens a
+ * dialog on mount with fixture data (saved repos, adoptable worktrees,
+ * a detected-vendor set), and leaves the full dialog interactive:
+ * tab/←→/ctrl+[]/ctrl+e all run for real; esc closes; the last dialog
+ * result is echoed on the backdrop.
+ *
+ * Env knobs (proof-grep seams):
+ *   KOBE_MOCK_DIALOG=rename  — open the rename dialog instead of new-task.
+ *   KOBE_MOCK_LOCALE=zh      — render the zh catalog (via setLocaleLang).
+ * Keys while no dialog is open: n new-task · r rename · q quit.
+ */
+
+import type { AdoptableWorktree } from "@/types/worktree"
+import { TextAttributes } from "@opentui/core"
+import { useEffect, useRef, useState } from "react"
+import { useTheme } from "../context/theme"
+import { isLocaleId, setLocaleLang, useLang } from "../i18n"
+import { bootPaneHost } from "../lib/host-boot"
+import { useBindings } from "../lib/keymap"
+import { useDialog } from "../ui/dialog"
+import { NewTaskDialog } from "./new-task-dialog"
+import { RenameTaskDialog } from "./rename-task-dialog"
+
+const FIXTURE_SAVED_REPOS = ["~/i/alpha", "~/i/beta-service", "/tmp/kobe-mock-repo"] as const
+
+const FIXTURE_ADOPTABLE: readonly AdoptableWorktree[] = [
+  {
+    path: "/tmp/kobe-mock-repo/.claude/worktrees/feature-a",
+    branch: "feature-a",
+    head: "aaaaaaaa",
+    dirty: false,
+    kobeManaged: true,
+    lastActivityMs: Date.now(),
+  },
+  {
+    path: "/tmp/kobe-mock-repo/.claude/worktrees/fix-b",
+    branch: "fix-b",
+    head: "bbbbbbbb",
+    dirty: true,
+    kobeManaged: false,
+    lastActivityMs: Date.now() - 60_000,
+  },
+]
+
+function MockDialogsScreen() {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const [lastResult, setLastResult] = useState("(none yet)")
+
+  // Pin the proof locale: host-boot's UiPrefsSync applies the daemon's
+  // persisted locale after mount, which would race the KOBE_MOCK_LOCALE
+  // seed from setup — re-assert whenever the language drifts.
+  const lang = useLang()
+  const wantLocale = process.env.KOBE_MOCK_LOCALE
+  useEffect(() => {
+    if (wantLocale && isLocaleId(wantLocale) && lang !== wantLocale) setLocaleLang(wantLocale)
+  }, [lang, wantLocale])
+
+  const openNewTask = () => {
+    void NewTaskDialog.show(dialog, process.cwd(), [...FIXTURE_SAVED_REPOS], {
+      defaultCloneParent: "~/",
+      defaultVendor: "claude",
+      availableVendors: ["claude", "codex"],
+      discoverAdoptable: async () => FIXTURE_ADOPTABLE,
+    }).then((r) => setLastResult(r ? JSON.stringify(r) : "(cancelled)"))
+  }
+  const openRename = () => {
+    void RenameTaskDialog.show(dialog, "My mock task").then((r) => setLastResult(r ?? "(cancelled)"))
+  }
+
+  // Open the requested dialog once on mount (proof seam).
+  const opened = useRef(false)
+  useEffect(() => {
+    if (opened.current) return
+    opened.current = true
+    if (process.env.KOBE_MOCK_DIALOG === "rename") openRename()
+    else openNewTask()
+  })
+
+  // Plain letters must stay typable inside the dialog inputs — gate the
+  // whole set on the dialog stack being empty (the config thunk re-runs
+  // per keypress, so this tracks the live stack).
+  useBindings(() => ({
+    enabled: dialog.stack.length === 0,
+    bindings: [
+      { key: "q", cmd: () => process.exit(0) },
+      { key: "ctrl+c", cmd: () => process.exit(0) },
+      { key: "n", cmd: openNewTask },
+      { key: "r", cmd: openRename },
+    ],
+  }))
+
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background} paddingLeft={1} paddingTop={1} gap={1}>
+      <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
+        REACT task-dialogs mock
+      </text>
+      <text fg={theme.textMuted} wrapMode="none">
+        n new-task · r rename · esc close dialog · q quit
+      </text>
+      <text fg={theme.text} wrapMode="word">
+        last result: {lastResult}
+      </text>
+    </box>
+  )
+}
+
+await bootPaneHost({
+  logContext: "mock-dialogs",
+  setup: () => {
+    // Locale proof seam — override AFTER the persisted-prefs seed.
+    const locale = process.env.KOBE_MOCK_LOCALE
+    if (locale && isLocaleId(locale)) setLocaleLang(locale)
+    return { root: () => <MockDialogsScreen /> }
+  },
+})

--- a/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
@@ -1,0 +1,119 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The React new-task dialog JSX shell (issue #15, G3W2) — the
+ * `src/tui/component/new-task-dialog/dialog.tsx` counterpart. Three
+ * sibling sub-tabs share one frame (Existing / New Repo / Adopt),
+ * switched with Ctrl+[ / Ctrl+] or ←/→ on the mode selector; the engine
+ * selector cycles with ctrl+e. All state, effects, commit paths and key
+ * bindings live in `./view-model.ts` (shared pure helpers from the Solid
+ * side's `state.ts`/`clone.ts`); the tab bodies live in `./tab-*.tsx`.
+ * Every user-visible string resolves through `useT()`.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import type { DialogTab } from "../../../tui/component/new-task-dialog/state"
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+import { labelStyle } from "./picker-list"
+import { AdoptTab } from "./tab-adopt"
+import { CloneTab } from "./tab-clone"
+import { ExistingTab } from "./tab-existing"
+import { type NewTaskDialogProps, useNewTaskViewModel } from "./view-model"
+
+export type { NewTaskDialogProps } from "./view-model"
+
+const TAB_ORDER: readonly DialogTab[] = ["existing", "clone", "adopt"]
+
+export function NewTaskDialogView(props: NewTaskDialogProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  const vm = useNewTaskViewModel(props)
+
+  const tabLabel: Record<DialogTab, string> = {
+    existing: t("newTask.tabs.existing"),
+    clone: t("newTask.tabs.clone"),
+    adopt: t("newTask.tabs.adopt"),
+  }
+  const tabsFocused = vm.field === "tabs"
+  // Active selections keep ▸ + bold + primary; an underline marks them only
+  // while that selector holds keyboard focus.
+  const selectedAttrs = (selected: boolean, focused: boolean) =>
+    selected ? (focused ? TextAttributes.BOLD | TextAttributes.UNDERLINE : TextAttributes.BOLD) : undefined
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={0}>
+      <box flexDirection="row">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {t("newTask.title")}
+        </text>
+      </box>
+      <box gap={1} paddingTop={1} paddingBottom={1}>
+        {/* Mode-tab selector — reachable by Tab; ←/→ switches while focused,
+            ctrl+[/] from anywhere, mouse click selects. */}
+        <box flexDirection="row" gap={2}>
+          {TAB_ORDER.map((tabId) => {
+            const active = vm.tab === tabId
+            return (
+              <text
+                key={tabId}
+                fg={active ? theme.primary : theme.textMuted}
+                attributes={selectedAttrs(active, tabsFocused)}
+                onMouseUp={() => vm.switchToTab(tabId)}
+              >
+                {active ? `▸ ${tabLabel[tabId]}` : `  ${tabLabel[tabId]}`}
+              </text>
+            )
+          })}
+        </box>
+        {/* Engine selector — Tab reaches it; ←/→ cycles while focused,
+            ctrl+e from anywhere, click picks. Detected vendors only. */}
+        <box gap={0}>
+          <text {...labelStyle(theme, vm.field, "engine")}>{t("newTask.field.engine")}</text>
+          <box flexDirection="row" gap={2}>
+            {vm.vendors.map((v) => {
+              const selected = vm.vendor === v
+              return (
+                <text
+                  key={v}
+                  fg={selected ? theme.primary : theme.textMuted}
+                  attributes={selected ? TextAttributes.BOLD : undefined}
+                  onMouseUp={() => vm.setVendor(v)}
+                >
+                  {selected ? "▸ " : "  "}
+                  {v}
+                </text>
+              )
+            })}
+            <box flexGrow={1} />
+            <text fg={theme.textMuted}>{t("newTask.hint.engineCycle")}</text>
+          </box>
+        </box>
+        {vm.tab === "existing" ? <ExistingTab vm={vm} /> : null}
+        {vm.tab === "clone" ? <CloneTab vm={vm} /> : null}
+        {vm.tab === "adopt" ? <AdoptTab vm={vm} /> : null}
+        {vm.submitError ? (
+          <text fg={theme.error} wrapMode="word">
+            ※ {vm.submitError}
+          </text>
+        ) : null}
+      </box>
+      {/* Bottom action row — hint legend left, Create button bottom-right.
+          Create commits on click; also reachable by tabbing to the confirm
+          field (Enter), or Enter on the last input of the active tab. */}
+      <box flexDirection="row" justifyContent="space-between" alignItems="center" paddingTop={1} paddingBottom={1}>
+        <text fg={theme.textMuted}>{t("newTask.hint.legend")}</text>
+        <text
+          fg={vm.field === "confirm" ? theme.primary : theme.text}
+          attributes={vm.field === "confirm" ? TextAttributes.BOLD : undefined}
+          onMouseUp={() => vm.commit()}
+        >
+          {vm.cloneInFlight
+            ? t("newTask.button.cloning")
+            : vm.field === "confirm"
+              ? t("newTask.button.createFocused")
+              : t("newTask.button.create")}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React new-task dialog entry point (issue #15, G3W2) — the
+ * `src/tui/component/new-task-dialog/index.tsx` counterpart, with the
+ * identical `show(dialog, defaultRepo, savedRepos, options)` contract so
+ * call sites port unchanged. NewTaskDialog is THE canonical task-creation
+ * surface — this is the full dialog (Existing / New Repo / Adopt tabs,
+ * engine selector, smart pickers), never a simplified stand-in.
+ *
+ * Pure helpers (`state.ts`) and clone plumbing (`clone.ts`) are consumed
+ * from the shared Solid-side modules — both are framework-free .ts.
+ */
+
+import type { VendorId } from "@/types/vendor"
+import type { AdoptableWorktree } from "@/types/worktree"
+import type { NewTaskInput } from "../../../tui/component/new-task-dialog/state"
+import type { DialogContext } from "../../ui/dialog"
+import { NewTaskDialogView } from "./dialog"
+
+export type { NewTaskInput } from "../../../tui/component/new-task-dialog/state"
+export { isBlankText, stripNewlines } from "../../../tui/component/new-task-dialog/state"
+
+/** Same option surface as the Solid entry — see its docs for field notes. */
+export type NewTaskDialogOptions = {
+  /** Default parent dir for the Clone tab (kv `lastClonedRepoParent`). */
+  defaultCloneParent?: string
+  /** Engine to pre-select (kv `lastSelectedVendor`); falls back to claude. */
+  defaultVendor?: VendorId
+  /** Vendors detected on this machine; omit/empty falls back to all. */
+  availableVendors?: readonly VendorId[]
+  /** Adopt-tab discovery (KOB-256); omit to disable adoption. */
+  discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
+}
+
+/**
+ * Open the new-task dialog and resolve with the user's selection —
+ * `undefined` on cancel (esc / dialog dismissed). A `cloned` field on the
+ * result means the user came in via the "For New Repo" tab: the clone has
+ * already completed and `repo` is the fresh worktree path; persist
+ * `cloned.parentDir` to `lastClonedRepoParent` and add `repo` to the
+ * saved-repos list.
+ */
+function show(
+  dialog: DialogContext,
+  defaultRepo: string,
+  savedRepos: readonly string[],
+  options?: NewTaskDialogOptions,
+): Promise<NewTaskInput | undefined> {
+  return new Promise<NewTaskInput | undefined>((resolve) => {
+    dialog.replace(
+      () => (
+        <NewTaskDialogView
+          defaultRepo={defaultRepo}
+          savedRepos={savedRepos}
+          defaultCloneParent={options?.defaultCloneParent}
+          defaultVendor={options?.defaultVendor}
+          availableVendors={options?.availableVendors}
+          discoverAdoptable={options?.discoverAdoptable}
+          onSubmit={(v) => resolve(v)}
+          onCancel={() => resolve(undefined)}
+        />
+      ),
+      () => resolve(undefined),
+    )
+    // medium (80 cols) — small clipped repo paths mid-row; the card sizes
+    // to content height. Same rationale as the Solid entry.
+    dialog.setSize("medium")
+  })
+}
+
+export const NewTaskDialog = {
+  show,
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
@@ -1,0 +1,76 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Shared windowed picker list + field-label styling for the React
+ * new-task dialog (issue #15, G3W2). The Solid shell repeats the
+ * "↑ N more / rows / ↓ N more" block four times (repo, branch, clone
+ * parent, adopt); the React port renders all four through this one
+ * component — callers supply the pre-windowed row bodies and pick
+ * handler, the list owns the cursor arrow, bold, and overflow lines.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import type { ReactNode } from "react"
+import type { Field, PickerWindow } from "../../../tui/component/new-task-dialog/state"
+import { type Theme, useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+
+/** One visible picker row — body text plus an accent (selected) flag. */
+export type PickerRow = {
+  readonly key: string
+  readonly body: string
+  /** Non-cursor rows render accent (selected) instead of muted. */
+  readonly accent?: boolean
+}
+
+export function PickerList(props: {
+  window: PickerWindow
+  cursor: number
+  /** Pre-windowed rows; same length/order as `window.items`. */
+  rows: readonly PickerRow[]
+  onPick: (absoluteIndex: number) => void
+  /** Extra line under the list (e.g. the adopt "N selected" hint). */
+  footer?: ReactNode
+  paddingBottom?: number
+}) {
+  const { theme } = useTheme()
+  const t = useT()
+  const below = props.window.total - props.window.start - props.window.items.length
+  return (
+    <box gap={0} paddingLeft={2} paddingBottom={props.paddingBottom}>
+      {props.window.start > 0 ? (
+        <text fg={theme.textMuted} wrapMode="none">
+          {t("newTask.picker.moreAbove", { count: props.window.start })}
+        </text>
+      ) : null}
+      {props.rows.map((row, i) => {
+        const absoluteIndex = props.window.start + i
+        const isCursor = absoluteIndex === props.cursor
+        return (
+          <text
+            key={row.key}
+            fg={isCursor ? theme.primary : row.accent ? theme.accent : theme.textMuted}
+            attributes={isCursor ? TextAttributes.BOLD : undefined}
+            wrapMode="none"
+            onMouseUp={() => props.onPick(absoluteIndex)}
+          >
+            {isCursor ? "▸ " : "  "}
+            {row.body}
+          </text>
+        )
+      })}
+      {below > 0 ? (
+        <text fg={theme.textMuted} wrapMode="none">
+          {t("newTask.picker.moreBelow", { count: below })}
+        </text>
+      ) : null}
+      {props.footer}
+    </box>
+  )
+}
+
+/** Focused field labels go primary + bold + underline; others stay muted. */
+export function labelStyle(theme: Theme, focusedField: Field, f: Field): { fg: Theme["primary"]; attributes?: number } {
+  return focusedField === f
+    ? { fg: theme.primary, attributes: TextAttributes.BOLD | TextAttributes.UNDERLINE }
+    : { fg: theme.textMuted }
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/pure.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/pure.ts
@@ -1,0 +1,48 @@
+/**
+ * Framework-free helpers for the React new-task dialog (issue #15, G3W2).
+ *
+ * The bulk of the dialog's pure logic (field cycling, filters, windowing)
+ * already lives in the shared `src/tui/component/new-task-dialog/state.ts`
+ * and is consumed verbatim by both frameworks. This file holds only the
+ * bits the Solid shell computes inline — extracted here so the React port
+ * can unit-test them without mounting the dialog (`test/tui-react/
+ * new-task-pure.test.ts`). No React, no Solid, no fs.
+ */
+
+import { ALL_VENDORS, type VendorId } from "@/types/vendor"
+
+/**
+ * Engine selector source: detected vendors only, falling back to the full
+ * list when the caller passed nothing/empty — the selector is never empty
+ * and task creation is never blocked.
+ */
+export function resolveVendorSet(available: readonly VendorId[] | undefined): readonly VendorId[] {
+  return available && available.length > 0 ? available : ALL_VENDORS
+}
+
+/**
+ * Initial engine selection: the user's last-selected vendor, clamped to a
+ * detected one (first detected wins when the preference isn't available).
+ */
+export function resolveInitialVendor(set: readonly VendorId[], preferred: VendorId | undefined): VendorId {
+  const pref = preferred ?? "claude"
+  return set.includes(pref) ? pref : (set[0] ?? "claude")
+}
+
+/** Immutable toggle of one path in the adopt multi-select. */
+export function toggleInSet(prev: ReadonlySet<string>, path: string): ReadonlySet<string> {
+  const next = new Set(prev)
+  if (next.has(path)) next.delete(path)
+  else next.add(path)
+  return next
+}
+
+/**
+ * Ctrl+A semantics on the Adopt tab: everything selected → clear;
+ * otherwise select every visible path. Empty list returns `prev` unchanged.
+ */
+export function toggleSelectAll(prev: ReadonlySet<string>, paths: readonly string[]): ReadonlySet<string> {
+  if (paths.length === 0) return prev
+  const allSelected = paths.every((p) => prev.has(p))
+  return allSelected ? new Set<string>() : new Set(paths)
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
@@ -1,0 +1,75 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Adopt tab of the React new-task dialog (issue #15, G3W2 / KOB-256) —
+ * discover existing git worktrees not yet linked to a task, filter by a
+ * path glob, multi-select, then import. Discovery + selection state live
+ * in the view-model; this file is JSX only.
+ */
+
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+import { PickerList, labelStyle } from "./picker-list"
+import type { NewTaskVm } from "./view-model"
+
+export function AdoptTab({ vm }: { vm: NewTaskVm }) {
+  const { theme } = useTheme()
+  const t = useT()
+
+  const rows = vm.adoptVisible.map((w) => {
+    const tags = [w.dirty ? "dirty" : "", w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
+    return {
+      key: w.path,
+      body: `${vm.adoptSelected.has(w.path) ? "[x] " : "[ ] "}${w.branch}${tags ? `  (${tags})` : ""}`,
+      accent: vm.adoptSelected.has(w.path),
+    }
+  })
+
+  return (
+    <>
+      <box gap={0}>
+        <text {...labelStyle(theme, vm.field, "adoptFilter")}>{t("newTask.field.adoptFilter")}</text>
+        <input
+          value={vm.adoptFilter}
+          placeholder={t("newTask.placeholder.adoptFilter")}
+          focused={vm.field === "adoptFilter"}
+          onInput={(v: string) => vm.setAdoptFilterText(v)}
+          onSubmit={() => vm.toggleAdoptCursor()}
+        />
+      </box>
+      <box paddingLeft={2}>
+        <text fg={theme.textMuted} wrapMode="none">
+          {t("newTask.adopt.repoLine", { path: vm.expandedRepo || t("newTask.adopt.repoNone") })}
+        </text>
+      </box>
+      {vm.adoptLoading ? (
+        <box paddingLeft={2}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {t("newTask.hint.scanningWorktrees")}
+          </text>
+        </box>
+      ) : null}
+      {!vm.adoptLoading && vm.adoptList.length === 0 ? (
+        <box paddingLeft={2}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {vm.adoptDiscoveredCount === 0 ? t("newTask.adopt.noUnlinked") : t("newTask.adopt.noMatch")}
+          </text>
+        </box>
+      ) : null}
+      {vm.adoptList.length > 0 ? (
+        <PickerList
+          window={vm.adoptWindow}
+          cursor={vm.adoptCursor}
+          rows={rows}
+          onPick={vm.pickAdoptAt}
+          footer={
+            <text fg={theme.textMuted} wrapMode="none">
+              {vm.adoptSelected.size > 0
+                ? t("newTask.adopt.hintSelected", { count: vm.adoptSelected.size })
+                : t("newTask.adopt.hintDefault")}
+            </text>
+          }
+        />
+      ) : null}
+    </>
+  )
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-clone.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-clone.tsx
@@ -1,0 +1,96 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Clone ("For New Repo") tab of the React new-task dialog (issue #15,
+ * G3W2) — git URL, parent dir (with the same drill-down picker the
+ * existing tab uses), auto-derived folder name, base branch. The async
+ * clone runs in the view-model; this file is JSX only.
+ */
+
+import { DEFAULT_BASE_REF } from "../../../tui/lib/git-snapshot"
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+import { PickerList, labelStyle } from "./picker-list"
+import type { NewTaskVm } from "./view-model"
+
+export function CloneTab({ vm }: { vm: NewTaskVm }) {
+  const { theme } = useTheme()
+  const t = useT()
+
+  const parentRows = vm.cloneParentWindow.items.map((name, i) => ({
+    key: `${vm.cloneParentWindow.start + i}:${name}`,
+    body: `${name}/`,
+  }))
+
+  return (
+    <>
+      <box gap={0}>
+        <text {...labelStyle(theme, vm.field, "cloneUrl")}>{t("newTask.field.gitUrl")}</text>
+        <input
+          value={vm.cloneUrl}
+          placeholder="https://github.com/user/repo.git"
+          focused={vm.field === "cloneUrl"}
+          onInput={(v: string) => vm.setCloneUrlText(v)}
+          onSubmit={() => {
+            if (!vm.cloneUrl.trim()) return
+            vm.setField("cloneParent")
+          }}
+        />
+      </box>
+      <box gap={0}>
+        <text {...labelStyle(theme, vm.field, "cloneParent")}>{t("newTask.field.parentDir")}</text>
+        <input
+          value={vm.cloneParent}
+          placeholder="~/"
+          focused={vm.field === "cloneParent"}
+          onInput={(v: string) => vm.setCloneParentText(v)}
+          onSubmit={() => vm.onCloneParentSubmit()}
+        />
+      </box>
+      {/* Persistence hint — this field remembers its last value across
+          dialog opens (kv `lastClonedRepoParent`). */}
+      {vm.field === "cloneParent" ? (
+        <box paddingLeft={2}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {t("newTask.hint.remembered")}
+          </text>
+        </box>
+      ) : null}
+      {vm.field === "cloneParent" && vm.cloneParentFiltered.length > 0 && !vm.cloneParentPicked ? (
+        <PickerList
+          window={vm.cloneParentWindow}
+          cursor={vm.cloneParentCursor}
+          rows={parentRows}
+          onPick={vm.selectCloneParentAt}
+        />
+      ) : null}
+      <box gap={0}>
+        <text {...labelStyle(theme, vm.field, "cloneFolder")}>{t("newTask.field.folderName")}</text>
+        <input
+          value={vm.cloneFolder}
+          placeholder={t("newTask.placeholder.folderName")}
+          focused={vm.field === "cloneFolder"}
+          onInput={(v: string) => vm.setCloneFolderText(v)}
+          onSubmit={() => vm.setField("cloneBaseRef")}
+        />
+      </box>
+      <box gap={0}>
+        <text {...labelStyle(theme, vm.field, "cloneBaseRef")}>{t("newTask.field.baseBranch")}</text>
+        <input
+          value={vm.cloneBaseRef}
+          placeholder={DEFAULT_BASE_REF}
+          focused={vm.field === "cloneBaseRef"}
+          onInput={(v: string) => vm.setCloneBaseRefText(v)}
+          // Last field on the tab — Enter kicks off the clone + create.
+          onSubmit={() => void vm.commitClone()}
+        />
+      </box>
+      {vm.cloneInFlight ? (
+        <box gap={0} paddingLeft={2}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {vm.cloneProgress || t("newTask.clone.progressFallback")}
+          </text>
+        </box>
+      ) : null}
+    </>
+  )
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
@@ -1,0 +1,84 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Existing tab of the React new-task dialog (issue #15, G3W2) — pick an
+ * existing local repo path + base branch. Direct port of the Solid
+ * shell's existing-tab body: unified free-text repo input with the
+ * saved/browse smart dropdown, branch picker that augments the input.
+ * All behavior lives in the view-model; this file is JSX only.
+ */
+
+import { DEFAULT_BASE_REF } from "../../../tui/lib/git-snapshot"
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+import { PickerList, labelStyle } from "./picker-list"
+import type { NewTaskVm } from "./view-model"
+
+export function ExistingTab({ vm }: { vm: NewTaskVm }) {
+  const { theme } = useTheme()
+  const t = useT()
+
+  const repoRows = vm.activeWindow.items.map((name, i) => {
+    const isCurrentDir = vm.mode === "saved" && name === vm.defaultRepo
+    const suffix = vm.mode === "browse" ? "/" : ""
+    const tag = isCurrentDir ? `  ${t("newTask.hint.currentDir")}` : ""
+    return {
+      key: `${vm.activeWindow.start + i}:${name}`,
+      body: `${name}${suffix}${tag}`,
+      accent: vm.mode === "saved" && vm.repo.trim() === name,
+    }
+  })
+
+  const branchRows = vm.branchWindow.items.map((name, i) => ({
+    key: `${vm.branchWindow.start + i}:${name}`,
+    body: name,
+    accent: vm.baseRef.trim() === name,
+  }))
+
+  return (
+    <>
+      <box gap={0}>
+        <text {...labelStyle(theme, vm.field, "repo")}>{t("newTask.field.repo")}</text>
+        <input
+          value={vm.repo}
+          placeholder={vm.defaultRepo}
+          focused={vm.field === "repo"}
+          onInput={(v: string) => vm.setRepoText(v)}
+          // Every Enter routes through onRepoSubmit — it handles the
+          // empty-input pick-first case too.
+          onSubmit={() => vm.onRepoSubmit()}
+        />
+      </box>
+      {vm.field === "repo" && vm.activeList.length > 0 && !vm.repoPicked ? (
+        <PickerList window={vm.activeWindow} cursor={vm.repoCursor} rows={repoRows} onPick={vm.selectRepoAt} />
+      ) : null}
+      <box gap={0}>
+        <text {...labelStyle(theme, vm.field, "baseRef")}>{t("newTask.field.fromBranch")}</text>
+        <input
+          value={vm.baseRef}
+          placeholder={DEFAULT_BASE_REF}
+          focused={vm.field === "baseRef"}
+          onInput={(v: string) => vm.setBaseRefText(v)}
+          // Last field on the tab — Enter resolves the highlighted branch
+          // and creates straight away.
+          onSubmit={() => vm.onBaseRefSubmit()}
+        />
+      </box>
+      {vm.field === "baseRef" && vm.branchFiltered.length === 0 && vm.submitError == null ? (
+        <box gap={0} paddingLeft={2} paddingBottom={1}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {vm.branches.length === 0 ? t("newTask.hint.noBranchesFound") : t("newTask.hint.noMatchBranch")}
+          </text>
+        </box>
+      ) : null}
+      {vm.field === "baseRef" && vm.branchFiltered.length > 0 ? (
+        <PickerList
+          window={vm.branchWindow}
+          cursor={vm.branchCursor}
+          rows={branchRows}
+          onPick={vm.pickBranchAt}
+          paddingBottom={1}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
@@ -1,0 +1,148 @@
+/**
+ * Adopt-tab state hook for the React new-task dialog (issue #15, G3W2 /
+ * KOB-256) — split out of `./view-model.ts`: worktree discovery (async
+ * canon: useState + dependency-keyed effect with a disposed flag), glob
+ * filter, windowed cursor, and the multi-select import commit.
+ */
+
+import type { VendorId } from "@/types/vendor"
+import type { AdoptableWorktree } from "@/types/worktree"
+import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  type NewTaskInput,
+  type PickerWindow,
+  clampCursor,
+  filterAdoptableByGlob,
+  stripNewlines,
+  windowAround,
+} from "../../../tui/component/new-task-dialog/state"
+import { t } from "../../i18n"
+import { toggleInSet, toggleSelectAll } from "./pure"
+
+export function useAdoptState(args: {
+  /** Discovery runs only while the Adopt tab is active. */
+  active: boolean
+  expandedRepo: string
+  vendor: VendorId
+  discoverAdoptable: ((repo: string) => Promise<readonly AdoptableWorktree[]>) | undefined
+  onSubmit: (v: NewTaskInput) => void
+  clearDialog: () => void
+  setSubmitError: (e: string | null) => void
+}) {
+  const [adoptFilter, setAdoptFilter] = useState("")
+  const [adoptCursor, setAdoptCursor] = useState(0)
+  const [adoptSelected, setAdoptSelected] = useState<ReadonlySet<string>>(new Set())
+  const [adoptable, setAdoptable] = useState<readonly AdoptableWorktree[] | undefined>(undefined)
+  const [adoptLoading, setAdoptLoading] = useState(false)
+
+  const adoptList = useMemo(() => filterAdoptableByGlob(adoptable ?? [], adoptFilter), [adoptable, adoptFilter])
+  const adoptWindow: PickerWindow = windowAround(
+    adoptList.map((w) => w.path),
+    adoptCursor,
+  )
+  const adoptVisible = adoptList.slice(adoptWindow.start, adoptWindow.start + adoptWindow.items.length)
+  const adoptDiscoveredCount = (adoptable ?? []).length
+
+  const { active, expandedRepo, discoverAdoptable } = args
+  // Refetch whenever the Adopt tab is active for the current repo.
+  useEffect(() => {
+    if (!active) return
+    let disposed = false
+    setAdoptLoading(true)
+    void (async () => {
+      let list: readonly AdoptableWorktree[] = []
+      try {
+        list = discoverAdoptable ? await discoverAdoptable(expandedRepo) : []
+      } catch {
+        list = []
+      }
+      if (disposed) return
+      setAdoptable(list)
+      setAdoptLoading(false)
+    })()
+    return () => {
+      disposed = true
+    }
+  }, [active, expandedRepo, discoverAdoptable])
+
+  // Keep the cursor in range as the filtered list shrinks/grows.
+  useEffect(() => {
+    setAdoptCursor((c) => clampCursor(c, adoptList.length))
+  }, [adoptList])
+
+  // Reset the multi-select when the resolved repo changes — worktree paths
+  // are unique per repo; a stale set would silently no-op the import.
+  const prevRepo = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    if (prevRepo.current !== undefined && prevRepo.current !== expandedRepo) {
+      setAdoptSelected(new Set<string>())
+      setAdoptCursor(0)
+    }
+    prevRepo.current = expandedRepo
+  }, [expandedRepo])
+
+  function setAdoptFilterText(v: string): void {
+    setAdoptFilter(stripNewlines(v))
+  }
+  function toggleAdopt(path: string): void {
+    setAdoptSelected((prev) => toggleInSet(prev, path))
+  }
+  function toggleAdoptCursor(): void {
+    const w = adoptList[adoptCursor]
+    if (w) toggleAdopt(w.path)
+  }
+  function pickAdoptAt(absoluteIndex: number): void {
+    const w = adoptList[absoluteIndex]
+    if (!w) return
+    setAdoptCursor(absoluteIndex)
+    toggleAdopt(w.path)
+  }
+  function adoptSelectAll(): void {
+    setAdoptSelected((prev) =>
+      toggleSelectAll(
+        prev,
+        adoptList.map((w) => w.path),
+      ),
+    )
+  }
+  function moveAdoptCursor(delta: 1 | -1): void {
+    if (adoptList.length === 0) return
+    setAdoptCursor((c) => clampCursor(c + delta, adoptList.length))
+  }
+
+  function commitAdopt(): void {
+    if (adoptList.length === 0) {
+      args.setSubmitError(t("newTask.error.noAdoptable"))
+      return
+    }
+    const chosen =
+      adoptSelected.size > 0
+        ? adoptList.filter((w) => adoptSelected.has(w.path))
+        : adoptList.slice(adoptCursor, adoptCursor + 1)
+    if (chosen.length === 0) return
+    args.onSubmit({
+      mode: "adopt",
+      repo: expandedRepo,
+      vendor: args.vendor,
+      adopt: chosen.map((w) => ({ worktreePath: w.path, branch: w.branch })),
+    })
+    args.clearDialog()
+  }
+
+  return {
+    adoptFilter,
+    adoptLoading,
+    adoptDiscoveredCount,
+    adoptList,
+    adoptWindow,
+    adoptVisible,
+    adoptCursor,
+    adoptSelected,
+    setAdoptFilterText,
+    toggleAdoptCursor,
+    pickAdoptAt,
+    adoptSelectAll,
+    moveAdoptCursor,
+    commitAdopt,
+  }
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
@@ -1,0 +1,161 @@
+/**
+ * Clone-tab state hook for the React new-task dialog (issue #15, G3W2) —
+ * the "For New Repo" cluster split out of `./view-model.ts`: git URL,
+ * parent-dir drill-down picker, auto-derived folder name, base branch,
+ * and the async `git clone` commit path. All fs/spawn plumbing comes from
+ * the shared `src/tui/component/new-task-dialog/clone.ts`.
+ */
+
+import type { VendorId } from "@/types/vendor"
+import { useEffect, useState } from "react"
+import {
+  cloneRepo,
+  deriveFolderName,
+  findAvailableFolderName,
+  resolveCloneTarget,
+  validateCloneTarget,
+  validateGitUrl,
+} from "../../../tui/component/new-task-dialog/clone"
+import {
+  type Field,
+  type NewTaskInput,
+  type PickerWindow,
+  clampCursor,
+  stripNewlines,
+  windowAround,
+} from "../../../tui/component/new-task-dialog/state"
+import { DEFAULT_BASE_REF } from "../../../tui/lib/git-snapshot"
+import { expandHome, joinPicked } from "../../../tui/lib/path-helpers"
+import { t } from "../../i18n"
+import { useDerivedDir } from "./use-derived-dir"
+
+export function useCloneState(args: {
+  defaultCloneParent: string | undefined
+  vendor: VendorId
+  onSubmit: (v: NewTaskInput) => void
+  clearDialog: () => void
+  setField: (f: Field) => void
+  setSubmitError: (e: string | null) => void
+}) {
+  const [cloneUrl, setCloneUrl] = useState("")
+  const [cloneParent, setCloneParent] = useState(args.defaultCloneParent?.trim() ? args.defaultCloneParent : "~/")
+  const [cloneFolder, setCloneFolder] = useState("")
+  const [cloneFolderTouched, setCloneFolderTouched] = useState(false)
+  const [cloneBaseRef, setCloneBaseRef] = useState(DEFAULT_BASE_REF)
+  // True while `git clone` runs — inputs dim, tab switching is gated.
+  const [cloneInFlight, setCloneInFlight] = useState(false)
+  const [cloneProgress, setCloneProgress] = useState("")
+  const [cloneParentCursor, setCloneParentCursor] = useState(0)
+  // "Selected, not drilled" latch — collapses the dropdown after Enter/click.
+  const [cloneParentPicked, setCloneParentPicked] = useState(false)
+
+  const { split: cloneParentSplit, filtered: cloneParentFiltered } = useDerivedDir(cloneParent)
+  const cloneParentWindow: PickerWindow = windowAround(cloneParentFiltered, cloneParentCursor)
+
+  // Folder name follows the URL until manually edited; auto-suffixes on
+  // collision inside the chosen parent dir.
+  useEffect(() => {
+    if (cloneFolderTouched) return
+    setCloneFolder(findAvailableFolderName(cloneParent, deriveFolderName(cloneUrl)))
+  }, [cloneUrl, cloneParent, cloneFolderTouched])
+
+  function setCloneUrlText(v: string): void {
+    setCloneUrl(stripNewlines(v))
+  }
+  function setCloneParentText(v: string): void {
+    setCloneParentPicked(false)
+    setCloneParent(stripNewlines(v))
+    setCloneParentCursor(0)
+  }
+  function setCloneFolderText(v: string): void {
+    setCloneFolderTouched(true)
+    setCloneFolder(stripNewlines(v))
+  }
+  function setCloneBaseRefText(v: string): void {
+    setCloneBaseRef(stripNewlines(v))
+  }
+
+  function onCloneParentSubmit(): void {
+    const picked = cloneParentFiltered[cloneParentCursor]
+    if (picked) {
+      setCloneParent(joinPicked(cloneParent, cloneParentSplit.base, picked))
+      setCloneParentCursor(0)
+      setCloneParentPicked(true)
+    }
+    args.setField("cloneFolder")
+  }
+
+  function selectCloneParentAt(absoluteIndex: number): void {
+    const picked = cloneParentFiltered[absoluteIndex]
+    if (!picked) return
+    setCloneParent(joinPicked(cloneParent, cloneParentSplit.base, picked))
+    setCloneParentCursor(absoluteIndex)
+    setCloneParentPicked(true)
+    args.setField("cloneFolder")
+  }
+
+  function moveParentCursor(delta: 1 | -1): void {
+    if (cloneParentFiltered.length === 0) return
+    setCloneParentCursor((c) => clampCursor(c + delta, cloneParentFiltered.length))
+  }
+
+  async function commitClone(): Promise<void> {
+    if (cloneInFlight) return
+    const urlReason = validateGitUrl(cloneUrl)
+    if (urlReason) {
+      args.setSubmitError(urlReason)
+      args.setField("cloneUrl")
+      return
+    }
+    const targetReason = validateCloneTarget(cloneParent, cloneFolder)
+    if (targetReason) {
+      args.setSubmitError(targetReason)
+      // Blame the field actually at fault — same probe strategy as the
+      // Solid shell (see its commitClone for the full rationale).
+      const folder = cloneFolder.trim()
+      const folderStructurallyBad = !folder || folder.includes("/") || folder.includes("\\")
+      const parentAtFault = !folderStructurallyBad && validateCloneTarget(cloneParent, "__kobe_probe__") != null
+      args.setField(parentAtFault ? "cloneParent" : "cloneFolder")
+      return
+    }
+    const target = resolveCloneTarget(cloneParent, cloneFolder)
+    setCloneInFlight(true)
+    setCloneProgress(t("newTask.clone.progressInto", { target }))
+    const result = await cloneRepo(cloneUrl.trim(), target, (line) => setCloneProgress(line))
+    setCloneInFlight(false)
+    if (!result.ok) {
+      args.setSubmitError(t("newTask.error.cloneFailed", { error: result.error }))
+      args.setField("cloneUrl")
+      return
+    }
+    const b = cloneBaseRef.trim() || DEFAULT_BASE_REF
+    args.onSubmit({
+      repo: result.path,
+      baseRef: b,
+      vendor: args.vendor,
+      cloned: { parentDir: expandHome(cloneParent.trim()) },
+    })
+    args.clearDialog()
+  }
+
+  return {
+    cloneUrl,
+    cloneParent,
+    cloneFolder,
+    cloneBaseRef,
+    cloneInFlight,
+    cloneProgress,
+    cloneParentFiltered,
+    cloneParentWindow,
+    cloneParentCursor,
+    cloneParentPicked,
+    setCloneUrlText,
+    setCloneParentText,
+    setCloneFolderText,
+    setCloneBaseRefText,
+    onCloneParentSubmit,
+    selectCloneParentAt,
+    moveParentCursor,
+    commitClone,
+  }
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-derived-dir.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-derived-dir.ts
@@ -1,0 +1,15 @@
+/**
+ * Directory drill-down derivation (issue #15, G3W2) — memoized
+ * split + readdir + filter over a typed path, shared by the existing
+ * tab's browse-mode repo picker and the clone tab's parent-dir picker.
+ * Pure plumbing from `src/tui/lib/path-helpers.ts`.
+ */
+
+import { useMemo } from "react"
+import { filterSubdirs, listSubdirs, splitPathForDirSuggest } from "../../../tui/lib/path-helpers"
+
+export function useDerivedDir(value: string) {
+  const split = useMemo(() => splitPathForDirSuggest(value), [value])
+  const filtered = useMemo(() => filterSubdirs(listSubdirs(split.base), split.filter), [split])
+  return { split, filtered }
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -1,0 +1,353 @@
+/**
+ * View-model hook for the React new-task dialog (issue #15, G3W2) — the
+ * state half of `src/tui/component/new-task-dialog/dialog.tsx`, with the
+ * JSX stripped out. Every pure helper (field cycling, filters, windowing)
+ * comes from the SHARED `src/tui/component/new-task-dialog/state.ts` /
+ * `clone.ts` / `src/tui/lib/git-snapshot.ts` / `path-helpers.ts` modules —
+ * this file only translates Solid signals/memos/effects into React hooks.
+ * The clone and adopt clusters live in `./use-clone-state.ts` /
+ * `./use-adopt-state.ts`; this hook owns the shared selectors, the
+ * existing tab, the key bindings, and the commit dispatch.
+ *
+ * Reactivity translation notes (vs the Solid original):
+ *   - Solid's "reset cursor when the filtered list changes" effects become
+ *     resets inside the input handlers (same pattern as the chat history
+ *     palette) — typing is the only thing that changes those lists.
+ *   - Error strings resolved at submit time use the module-level `t` —
+ *     same non-reactive semantics as the Solid event handlers.
+ */
+
+import { type VendorId, nextVendorWithin, prevVendorWithin } from "@/types/vendor"
+import type { AdoptableWorktree } from "@/types/worktree"
+import { useEffect, useMemo, useState } from "react"
+import {
+  type DialogTab,
+  type Field,
+  type NewTaskInput,
+  type PickerWindow,
+  clampCursor,
+  computeRepoOptions,
+  filterBranches,
+  filterRepos,
+  firstFieldFor,
+  nextDialogTab,
+  nextField,
+  pickerModeFor,
+  prevDialogTab,
+  resolveBaseRef,
+  stripNewlines,
+  windowAround,
+} from "../../../tui/component/new-task-dialog/state"
+import { DEFAULT_BASE_REF, getCurrentBranch, listLocalBranches, validateRepoPath } from "../../../tui/lib/git-snapshot"
+import { expandHome, joinPicked } from "../../../tui/lib/path-helpers"
+import { useBindings } from "../../lib/keymap"
+import { useDialog } from "../../ui/dialog"
+import { resolveInitialVendor, resolveVendorSet } from "./pure"
+import { useAdoptState } from "./use-adopt-state"
+import { useCloneState } from "./use-clone-state"
+import { useDerivedDir } from "./use-derived-dir"
+
+/** Same prop surface as the Solid `NewTaskDialogView` — see its docs. */
+export type NewTaskDialogProps = {
+  onSubmit: (v: NewTaskInput) => void
+  onCancel: () => void
+  defaultRepo: string
+  /** User-curated repo list (`/add-repo`), cwd prepended by the picker. */
+  savedRepos: readonly string[]
+  /** Default parent dir for the Clone tab (kv `lastClonedRepoParent`). */
+  defaultCloneParent?: string
+  /** Engine to pre-select (kv `lastSelectedVendor`); `ctrl+e` cycles. */
+  defaultVendor?: VendorId
+  /** Vendors detected on this machine; empty falls back to all. */
+  availableVendors?: readonly VendorId[]
+  /** Adopt-tab discovery (KOB-256). Omit to leave the tab empty. */
+  discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
+}
+
+export function useNewTaskViewModel(props: NewTaskDialogProps) {
+  const dialog = useDialog()
+
+  const [tab, setTab] = useState<DialogTab>("existing")
+  const vendors = resolveVendorSet(props.availableVendors)
+  const [vendor, setVendor] = useState<VendorId>(() =>
+    resolveInitialVendor(resolveVendorSet(props.availableVendors), props.defaultVendor),
+  )
+  // Open focused on the mode selector — ←/→ switches tabs immediately;
+  // Tab then walks engine → repo → branch → Create.
+  const [field, setField] = useState<Field>("tabs")
+  const [repo, setRepo] = useState(props.defaultRepo)
+  // Initial baseRef tracks the cwd's current branch (worktree forked from a
+  // feature branch defaults to it, not hardcoded "main").
+  const [baseRef, setBaseRef] = useState(
+    () => getCurrentBranch(expandHome(props.defaultRepo.trim())) ?? DEFAULT_BASE_REF,
+  )
+  // Once the user typed into baseRef we stop auto-syncing from the repo's
+  // current branch — the manual override wins.
+  const [baseRefTouched, setBaseRefTouched] = useState(false)
+
+  const [repoCursor, setRepoCursor] = useState(0)
+  // "Selected, not drilled" latch — collapses the suggestion dropdown after
+  // Enter/click; typing resumes browsing.
+  const [repoPicked, setRepoPicked] = useState(false)
+  const [branchCursor, setBranchCursor] = useState(0)
+
+  // Validation error shown inline on submit; cleared on any input edit.
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  /* ── Derived lists (shared pure helpers; sync fs/git reads memoized) ── */
+
+  const repoOptions = useMemo(
+    () => computeRepoOptions(props.defaultRepo, props.savedRepos),
+    [props.defaultRepo, props.savedRepos],
+  )
+  const mode = pickerModeFor(repo, repoOptions)
+  const { split: subdirSplit, filtered: subdirFiltered } = useDerivedDir(repo)
+  const savedFiltered = useMemo(() => filterRepos(repoOptions, repo), [repoOptions, repo])
+  const activeList = mode === "browse" ? subdirFiltered : savedFiltered
+  const activeWindow: PickerWindow = windowAround(activeList, repoCursor)
+
+  const expandedRepo = expandHome(repo.trim())
+  const branches = useMemo(() => listLocalBranches(expandedRepo), [expandedRepo])
+  const branchFiltered = useMemo(() => filterBranches(branches, baseRef), [branches, baseRef])
+  const branchWindow: PickerWindow = windowAround(branchFiltered, branchCursor)
+
+  const clone = useCloneState({
+    defaultCloneParent: props.defaultCloneParent,
+    vendor,
+    onSubmit: props.onSubmit,
+    clearDialog: () => dialog.clear(),
+    setField,
+    setSubmitError,
+  })
+  const adopt = useAdoptState({
+    active: tab === "adopt",
+    expandedRepo,
+    vendor,
+    discoverAdoptable: props.discoverAdoptable,
+    onSubmit: props.onSubmit,
+    clearDialog: () => dialog.clear(),
+    setSubmitError,
+  })
+
+  /* ── Effects ── */
+
+  // Auto-sync baseRef to the picked repo's current branch until touched.
+  useEffect(() => {
+    if (!expandedRepo || baseRefTouched) return
+    const current = getCurrentBranch(expandedRepo)
+    if (current) setBaseRef(current)
+  }, [expandedRepo, baseRefTouched])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the inputs are the invalidation keys — any edit clears the inline error.
+  useEffect(() => {
+    setSubmitError(null)
+  }, [repo, clone.cloneUrl, clone.cloneParent, clone.cloneFolder, adopt.adoptFilter])
+
+  /* ── Input handlers (strip newlines + reset the affected cursor) ── */
+
+  function setRepoText(v: string): void {
+    setRepoPicked(false)
+    setRepo(stripNewlines(v))
+    setRepoCursor(0)
+    setBranchCursor(0)
+  }
+  function setBaseRefText(v: string): void {
+    setBaseRefTouched(true)
+    setBaseRef(stripNewlines(v))
+    setBranchCursor(0)
+  }
+
+  /* ── Commit paths ── */
+
+  function commitExisting(): void {
+    const r = expandedRepo
+    if (!r) return
+    const reason = validateRepoPath(r)
+    if (reason) {
+      setSubmitError(reason)
+      setField("repo")
+      return
+    }
+    const b = baseRef.trim() || DEFAULT_BASE_REF
+    props.onSubmit({ repo: r, baseRef: b, vendor })
+    dialog.clear()
+  }
+
+  function commit(): void {
+    if (tab === "clone") {
+      void clone.commitClone()
+      return
+    }
+    if (tab === "adopt") {
+      adopt.commitAdopt()
+      return
+    }
+    commitExisting()
+  }
+
+  /* ── Navigation / selection handlers ── */
+
+  function switchToTab(next: DialogTab): void {
+    if (clone.cloneInFlight || next === tab) return
+    setTab(next)
+    setField(firstFieldFor(next))
+    setSubmitError(null)
+  }
+
+  // ←/→ on the mode selector: switch tab but KEEP focus on the selector.
+  function cycleTab(dir: 1 | -1): void {
+    if (clone.cloneInFlight) return
+    const next = dir === 1 ? nextDialogTab(tab) : prevDialogTab(tab)
+    if (next === tab) return
+    setTab(next)
+    setSubmitError(null)
+    setField("tabs")
+  }
+
+  function cycleEngine(dir: 1 | -1): void {
+    setVendor((v) => (dir === 1 ? nextVendorWithin(vendors, v) : prevVendorWithin(vendors, v)))
+  }
+
+  // Enter on the repo field — pure selection, never commits.
+  function onRepoSubmit(): void {
+    if (!repo.trim() && mode === "saved") {
+      const picked = activeList[0]
+      if (picked) {
+        setRepo(picked)
+        setField("baseRef")
+        return
+      }
+    }
+    if (mode === "browse") {
+      const picked = subdirFiltered[repoCursor]
+      if (picked) {
+        // Enter = SELECT this dir as the repo and advance (no drill).
+        setRepo(joinPicked(repo, subdirSplit.base, picked))
+        setRepoCursor(0)
+        setRepoPicked(true)
+      }
+      setField("baseRef")
+      return
+    }
+    const picked = activeList[repoCursor]
+    if (picked) setRepo(picked)
+    setField("baseRef")
+  }
+
+  function selectRepoAt(absoluteIndex: number): void {
+    const picked = activeList[absoluteIndex]
+    if (!picked) return
+    if (mode === "browse") {
+      setRepo(joinPicked(repo, subdirSplit.base, picked))
+      setRepoPicked(true)
+    } else {
+      setRepo(picked)
+    }
+    setRepoCursor(absoluteIndex)
+    setField("baseRef")
+  }
+
+  function pickBranchAt(absoluteIndex: number): void {
+    const name = branchFiltered[absoluteIndex]
+    if (!name) return
+    setBaseRef(name)
+    setBaseRefTouched(true)
+    setBranchCursor(absoluteIndex)
+    setField("confirm")
+  }
+
+  // Last field on the existing tab — Enter resolves the highlighted branch
+  // and creates straight away.
+  function onBaseRefSubmit(): void {
+    setBaseRef(resolveBaseRef(baseRef, branchFiltered, branchCursor))
+    setBaseRefTouched(true)
+    commitExisting()
+  }
+
+  // up/down over whichever picker the focused field drives.
+  function moveCursor(delta: 1 | -1): void {
+    if (clone.cloneInFlight) return
+    if (tab === "existing" && field === "repo" && activeList.length > 0) {
+      setRepoCursor((c) => clampCursor(c + delta, activeList.length))
+      return
+    }
+    if (tab === "existing" && field === "baseRef" && branchFiltered.length > 0) {
+      setBranchCursor((c) => clampCursor(c + delta, branchFiltered.length))
+      return
+    }
+    if (tab === "clone" && field === "cloneParent") {
+      clone.moveParentCursor(delta)
+      return
+    }
+    if (tab === "adopt") adopt.moveAdoptCursor(delta)
+  }
+
+  /* ── Key bindings (config re-evaluated per keypress — closures fresh) ── */
+
+  useBindings(() => ({
+    bindings: [
+      { key: "tab", cmd: () => setField((f) => nextField(f, tab)) },
+      { key: "ctrl+]", cmd: () => switchToTab(nextDialogTab(tab)) },
+      { key: "ctrl+[", cmd: () => switchToTab(prevDialogTab(tab)) },
+      { key: "ctrl+e", cmd: () => cycleEngine(1) },
+      { key: "up", cmd: () => moveCursor(-1) },
+      { key: "down", cmd: () => moveCursor(1) },
+      // ←/→/Enter ONLY while a selector is focused — an always-on binding
+      // would preventDefault the keys away from focused text inputs (same
+      // registration-gating rationale as the Solid shell).
+      ...(field === "tabs" || field === "engine"
+        ? [
+            { key: "left", cmd: () => (field === "tabs" ? cycleTab(-1) : cycleEngine(-1)) },
+            { key: "right", cmd: () => (field === "tabs" ? cycleTab(1) : cycleEngine(1)) },
+            { key: "return", cmd: () => setField((f) => nextField(f, tab)) },
+          ]
+        : []),
+      // Ctrl+A select-all exists ONLY on the Adopt tab; elsewhere it must
+      // fall through to the focused input as line-home.
+      ...(tab === "adopt" ? [{ key: "ctrl+a", cmd: adopt.adoptSelectAll }] : []),
+    ],
+  }))
+
+  // Enter on Create — separate registration with config-level `enabled` so
+  // it is OUT of the dispatch stack while another field holds focus.
+  useBindings(() => ({
+    enabled: field === "confirm" && !clone.cloneInFlight,
+    bindings: [{ key: "return", cmd: () => commit() }],
+  }))
+
+  return {
+    ...clone,
+    ...adopt,
+    defaultRepo: props.defaultRepo,
+    tab,
+    vendors,
+    vendor,
+    setVendor,
+    field,
+    setField,
+    repo,
+    mode,
+    activeList,
+    activeWindow,
+    repoCursor,
+    repoPicked,
+    expandedRepo,
+    baseRef,
+    branches,
+    branchFiltered,
+    branchWindow,
+    branchCursor,
+    submitError,
+    setRepoText,
+    setBaseRefText,
+    onRepoSubmit,
+    selectRepoAt,
+    pickBranchAt,
+    onBaseRefSubmit,
+    switchToTab,
+    commit,
+    commitExisting,
+  }
+}
+
+export type NewTaskVm = ReturnType<typeof useNewTaskViewModel>

--- a/packages/kobe/src/tui-react/component/rename-task-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/rename-task-dialog.tsx
@@ -1,0 +1,121 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React rename dialog (issue #15, G3W2) — the
+ * `src/tui/component/rename-task-dialog/` counterpart, view + `show`
+ * entry in one file (the Solid split exists only for its folder
+ * convention). Same contract: single pre-filled input, Enter commits,
+ * esc cancels via the dialog stack; `dialogTitle` / `fieldLabel` /
+ * `submitLabel` overrides let it double for chat-tab renames, branch
+ * names, launch commands, etc.
+ *
+ * `stripNewlines` / `isBlankText` come from the shared framework-free
+ * `state.ts` — same sanitiser as the new-task dialog (opentui `<input>`
+ * inserts a literal `\n` on Enter; `isBlankText` rejects full-width
+ * space-only titles that `.trim()` misses).
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useState } from "react"
+import { isBlankText, stripNewlines } from "../../tui/component/new-task-dialog/state"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { type DialogContext, useDialog } from "../ui/dialog"
+
+export function RenameTaskDialogView(props: {
+  currentTitle: string
+  dialogTitle?: string
+  /** Inner field label — override for non-title reuses (e.g. `"command"`). */
+  fieldLabel?: string
+  /** Footer verb shown after `enter`. Defaults to `"rename"`. */
+  submitLabel?: string
+  /** Input placeholder. Defaults to {@link currentTitle}. */
+  placeholder?: string
+  /** Allow submitting an empty value (e.g. "blank = default"). Default false. */
+  allowEmpty?: boolean
+  onSubmit: (value: string) => void
+  onCancel: () => void
+}) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const t = useT()
+  const [value, setValue] = useState(props.currentTitle)
+
+  function commit(): void {
+    const v = value.trim()
+    // `isBlankText` (not `!v`) so a title made only of full-width spaces
+    // `　` counts as empty — `.trim()` does not strip `U+3000`.
+    if (isBlankText(v) && !props.allowEmpty) return
+    props.onSubmit(v)
+    dialog.clear()
+  }
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {props.dialogTitle ?? t("common.rename.defaultTitle")}
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => props.onCancel()}>
+          esc
+        </text>
+      </box>
+      <box gap={0}>
+        <text fg={theme.accent}>{props.fieldLabel ?? t("common.rename.defaultFieldLabel")}</text>
+        <input
+          value={value}
+          placeholder={props.placeholder ?? props.currentTitle}
+          focused={true}
+          onInput={(v: string) => setValue(stripNewlines(v))}
+          onSubmit={() => commit()}
+        />
+      </box>
+      <box paddingBottom={1}>
+        <text fg={theme.textMuted}>
+          {t("common.rename.footerHint", { submitLabel: props.submitLabel ?? t("common.rename.defaultSubmitLabel") })}
+        </text>
+      </box>
+    </box>
+  )
+}
+
+/**
+ * Open the rename dialog and resolve with the new title (trimmed) —
+ * `undefined` on cancel, matching the other dialogs' convention.
+ */
+function show(
+  dialog: DialogContext,
+  currentTitle: string,
+  opts: {
+    dialogTitle?: string
+    /** Inner field label — override for non-title reuses (e.g. `"command"`). */
+    fieldLabel?: string
+    /** Footer verb after `enter` (default `"rename"`). */
+    submitLabel?: string
+    /** Input placeholder (default = `currentTitle`). */
+    placeholder?: string
+    /** Allow submitting an empty value (e.g. "blank = default"). */
+    allowEmpty?: boolean
+  } = {},
+): Promise<string | undefined> {
+  return new Promise<string | undefined>((resolve) => {
+    dialog.replace(
+      () => (
+        <RenameTaskDialogView
+          currentTitle={currentTitle}
+          dialogTitle={opts.dialogTitle}
+          fieldLabel={opts.fieldLabel}
+          submitLabel={opts.submitLabel}
+          placeholder={opts.placeholder}
+          allowEmpty={opts.allowEmpty}
+          onSubmit={(v) => resolve(v)}
+          onCancel={() => resolve(undefined)}
+        />
+      ),
+      () => resolve(undefined),
+    )
+  })
+}
+
+export const RenameTaskDialog = {
+  show,
+}

--- a/packages/kobe/test/tui-react/new-task-pure.test.ts
+++ b/packages/kobe/test/tui-react/new-task-pure.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the React new-task dialog's extracted pure helpers
+ * (`src/tui-react/component/new-task-dialog/pure.ts`). These were inline
+ * in the Solid shell; the React port pulls them out so the vendor-set
+ * fallback, initial-vendor clamping, and adopt multi-select semantics
+ * are pinned without mounting the dialog (no @opentui import here —
+ * vitest never loads the renderer).
+ *
+ * Why these matter: the vendor fallback is what guarantees the engine
+ * selector is never empty (task creation must never be blocked by a
+ * missing detection result), and the ctrl+a toggle semantics decide
+ * whether an Adopt import silently targets the wrong worktree set.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  resolveInitialVendor,
+  resolveVendorSet,
+  toggleInSet,
+  toggleSelectAll,
+} from "../../src/tui-react/component/new-task-dialog/pure"
+import { ALL_VENDORS } from "../../src/types/vendor"
+
+describe("resolveVendorSet", () => {
+  it("falls back to ALL_VENDORS when undefined or empty", () => {
+    expect(resolveVendorSet(undefined)).toEqual(ALL_VENDORS)
+    expect(resolveVendorSet([])).toEqual(ALL_VENDORS)
+  })
+  it("returns the detected set verbatim when non-empty", () => {
+    expect(resolveVendorSet(["codex"])).toEqual(["codex"])
+  })
+})
+
+describe("resolveInitialVendor", () => {
+  it("keeps the preferred vendor when it is detected", () => {
+    expect(resolveInitialVendor(["claude", "codex"], "codex")).toBe("codex")
+  })
+  it("clamps to the first detected vendor when the preference is missing", () => {
+    expect(resolveInitialVendor(["codex"], "claude")).toBe("codex")
+  })
+  it("defaults to claude with no preference", () => {
+    expect(resolveInitialVendor(["claude", "codex"], undefined)).toBe("claude")
+  })
+  it("falls back to claude on an empty set (never crashes)", () => {
+    expect(resolveInitialVendor([], undefined)).toBe("claude")
+  })
+})
+
+describe("toggleInSet", () => {
+  it("adds a missing path and removes a present one, immutably", () => {
+    const start: ReadonlySet<string> = new Set(["/a"])
+    const added = toggleInSet(start, "/b")
+    expect([...added].sort()).toEqual(["/a", "/b"])
+    const removed = toggleInSet(added, "/a")
+    expect([...removed]).toEqual(["/b"])
+    expect([...start]).toEqual(["/a"]) // original untouched
+  })
+})
+
+describe("toggleSelectAll", () => {
+  const paths = ["/a", "/b", "/c"]
+  it("selects everything when the selection is partial", () => {
+    expect([...toggleSelectAll(new Set(["/a"]), paths)].sort()).toEqual(paths)
+  })
+  it("clears when everything is already selected", () => {
+    expect(toggleSelectAll(new Set(paths), paths).size).toBe(0)
+  })
+  it("is a no-op on an empty list", () => {
+    const prev: ReadonlySet<string> = new Set(["/x"])
+    expect(toggleSelectAll(prev, [])).toBe(prev)
+  })
+})


### PR DESCRIPTION
## Summary
- G3 wave 2, task-dialogs slice: ports the REAL `NewTaskDialog` — the canonical task-creation surface with all three sub-tabs (For Existing / For New Repo / Adopt Worktree), the engine selector (ctrl+e + ←/→), the saved/browse smart repo picker with directory drill-down, the branch picker, the async `git clone` flow with live stderr progress, and the adopt multi-select (ctrl+a, glob filter) — plus `RenameTaskDialog`, to `src/tui-react/component/`. Both mount through the React dialog thunk API with `show()` contracts identical to the Solid entries, so call sites port unchanged.
- **Shared, framework-free reuse (no duplication):** all dialog logic keeps living in the Solid side's already-tested `state.ts` (field cycling, filters, windowing, `resolveBaseRef`) and `clone.ts` (URL/target validation, async clone), plus `git-snapshot.ts` / `path-helpers.ts` — the React side consumes them verbatim. The only new pure code is `pure.ts` (vendor-set fallback, initial-vendor clamp, adopt select-all toggle — previously inline in the Solid JSX), unit-tested at 100%.
- React glue follows the established canon: view-model hook + `use-clone-state` / `use-adopt-state` clusters (useState + dependency-keyed effects with disposed-flag cancellation for adopt discovery), render-refreshed `useBindings` configs with the same registration-gating as Solid (←/→/Enter only on selectors, ctrl+a only on the Adopt tab), every visible string through `useT()`.
- The Solid `new-task-dialog/dialog.tsx` monolith (1119 lines) is split on the React side into shell + 3 tab bodies + shared `PickerList` + state hooks — every new file ≤ ~360 lines. No Solid files touched.
- **Render proof:** new `dev:mock-react-dialogs` script boots the real React pane host and opens each dialog with fixture data (saved repos, adoptable worktrees, detected-vendor set); `KOBE_MOCK_DIALOG=rename` / `KOBE_MOCK_LOCALE=zh` are the proof seams. No CLI entry exists for these dialogs yet (the Solid app opens them from `app.tsx`, unported), so there is no `KOBE_REACT=1` seam in this slice — the mock host is the live proof, per the wave brief's fallback.

coverage-exemption: packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts — React-hook glue (useState/useEffect cannot execute outside a React renderer under vitest); all dialog semantics live in the shared, unit-tested `state.ts`/`clone.ts` + new `pure.ts` (100%), and the hook is exercised live by the dev:mock-react-dialogs gate.
coverage-exemption: packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts — React-hook glue over the shared `clone.ts` helpers; exercised live by the dev:mock-react-dialogs gate.
coverage-exemption: packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts — React-hook glue over shared `state.ts` + tested `pure.ts` toggles; exercised live by the dev:mock-react-dialogs gate.
coverage-exemption: packages/kobe/src/tui-react/component/new-task-dialog/use-derived-dir.ts — 3-line useMemo wrapper over the shared `path-helpers.ts` drill-down; exercised live by the dev:mock-react-dialogs gate.

## Test plan
- [x] `bun run typecheck` clean (packages/kobe)
- [x] repo-root `bun run lint` clean
- [x] `bun run test` — 27 files / 228 tests green (includes new `new-task-pure` suite)
- [x] `bun run compile` → `./release-bin/kobe --version` OK (0.7.63)
- [x] `timeout 6 bun run dev:mock` — Solid mock unbroken (exit 124)
- [x] `timeout 6 bun run dev:mock-react-dialogs` under a pty — greps prove "New task", "For Existing", "For New Repo", "Adopt Worktree", "engine", "repo", "from branch", "[ Create ]" reach the screen; `KOBE_MOCK_LOCALE=zh` proves 新建任务/已有仓库/引擎/仓库/创建; `KOBE_MOCK_DIALOG=rename` proves "Rename task"/"title"/prefilled value in en and 重命名任务/名称/重命名 in zh
- [x] existing `dev:mock-react`, `-chat`, `-history`, `-filetree`, `-sidebar` all still boot (exit 124 each)
- [x] `bun run coverage` + `scripts/coverage-gate.mjs` (BASE_REF=main) locally — `pure.ts` 100%; the four hook-glue files above exempted
