### PR TITLE
feat: revive the embedded terminal as the engine tab (issue #16)

### DIFF
--- a/.changeset/embedded-terminal-tab.md
+++ b/.changeset/embedded-terminal-tab.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Terminal-in-the-middle lands (issue #16): the dormant embedded-terminal pane is revived — overflow clipping via opentui 0.4, the StyledText snapshot pushed through the renderable's content setter (the solid binding's content prop stringifies at runtime), user-visible strings moved to a new terminal.* i18n namespace — and the KOBE_TUI workspace's center column now runs the task's real interactive engine CLI in an in-process Bun PTY. A dev:mock-terminal entry proves the PTY→xterm→render seam live.

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "dev": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/cli/index.ts",
     "dev:mock": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/host.tsx",
+    "dev:mock-terminal": "env KOBE_DEV=1 bun --preload @opentui/solid/preload --conditions=browser ./src/tui/mock/terminal-host.tsx",
     "dev:mock-react": "env KOBE_DEV=1 bun ./src/tui-react/mock/host.tsx",
     "dev:mock-react-task-dialogs": "env KOBE_DEV=1 bun ./src/tui-react/component/mock-dialogs-host.tsx",
     "dev:mock-react-history": "env KOBE_DEV=1 bun ./src/tui-react/history/mock-host.tsx",

--- a/packages/kobe/src/tui/i18n/catalog.ts
+++ b/packages/kobe/src/tui/i18n/catalog.ts
@@ -27,6 +27,7 @@ import { en as ops, zh as opsZh } from "./messages/ops"
 import { en as quickTask, zh as quickTaskZh } from "./messages/quickTask"
 import { en as settings, zh as settingsZh } from "./messages/settings"
 import { en as tasks, zh as tasksZh } from "./messages/tasks"
+import { en as terminal, zh as terminalZh } from "./messages/terminal"
 import { en as update, zh as updateZh } from "./messages/update"
 import { en as workspace, zh as workspaceZh } from "./messages/workspace"
 import { en as worktrees, zh as worktreesZh } from "./messages/worktrees"
@@ -34,6 +35,7 @@ import { en as worktrees, zh as worktreesZh } from "./messages/worktrees"
 export const en = {
   settings,
   tasks,
+  terminal,
   files,
   newTask,
   ops,
@@ -57,6 +59,7 @@ export type Messages = typeof en
 export const zh: Messages = {
   settings: settingsZh,
   tasks: tasksZh,
+  terminal: terminalZh,
   files: filesZh,
   newTask: newTaskZh,
   ops: opsZh,

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -1,0 +1,31 @@
+/**
+ * `terminal.*` messages — the embedded terminal pane (issue #16): the
+ * in-process PTY running the task's engine CLI (or a plain worktree
+ * shell). English is the source of truth; `zh: typeof en` locks shapes.
+ */
+
+export const en = {
+  noTask: "(no task — press n to create)",
+  scrolledBack: "↑ scrolled {lines}L (ctrl+pgdn to follow)",
+  unavailable: {
+    shellMissing: "terminal unavailable — configured shell is not available",
+    spawnFailed: "terminal unavailable — shell could not start",
+  },
+  reset: {
+    title: "Reset terminal?",
+    body: "The running shell will be killed and a fresh one will spawn at the worktree. Any in-flight processes (vim, htop, paused jobs) end immediately.",
+  },
+}
+
+export const zh: typeof en = {
+  noTask: "（无任务 —— 按 n 创建）",
+  scrolledBack: "↑ 已回滚 {lines} 行（ctrl+pgdn 回到底部）",
+  unavailable: {
+    shellMissing: "终端不可用 —— 配置的 shell 不存在",
+    spawnFailed: "终端不可用 —— shell 启动失败",
+  },
+  reset: {
+    title: "重置终端？",
+    body: "正在运行的 shell 会被杀掉并在 worktree 重新启动，进行中的进程（vim、htop、暂停的任务）会立即结束。",
+  },
+}

--- a/packages/kobe/src/tui/mock/terminal-host.tsx
+++ b/packages/kobe/src/tui/mock/terminal-host.tsx
@@ -1,0 +1,32 @@
+/**
+ * `dev:mock-terminal` host — the embedded terminal pane against a REAL
+ * in-process PTY, no engine/daemon/task involved (issue #16).
+ *
+ * Boots the revived Terminal pane with a throwaway command that prints a
+ * greppable marker and then keeps an interactive `sh` alive, proving the
+ * whole seam live: Bun.spawn PTY → @xterm/headless snapshot → StyledText
+ * render → keyboard write-through. The smoke gate greps the marker from
+ * the ANSI output; run it interactively to type into the shell.
+ */
+
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { bootPaneHost } from "../lib/host-boot"
+import { Terminal } from "../panes/terminal/Terminal"
+
+const cwd = mkdtempSync(join(tmpdir(), "kobe-mock-terminal-"))
+
+void bootPaneHost({
+  providers: { kv: false, focus: false },
+  setup: () => ({
+    root: () => (
+      <Terminal
+        cwd={() => cwd}
+        taskId={() => "mock-terminal"}
+        command={["sh", "-c", 'echo TERMINAL-PANE-OK "(cwd: $PWD)"; exec sh -i']}
+        focused={() => true}
+      />
+    ),
+  }),
+})

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -67,7 +67,7 @@ import { useDialog } from "../../ui/dialog"
 import { DialogConfirm } from "../../ui/dialog-confirm"
 import { useTerminalBindings } from "./keys"
 import type { CursorPos, TaskPty, TerminalRow } from "./pty"
-import { PtyRegistry } from "./registry"
+import { type PtyRegistry, getDefaultPtyRegistry } from "./registry"
 import { rowsToStyledText } from "./sgr-to-text-chunk"
 import { isShellMissing, overlayCursor } from "./terminal-render"
 
@@ -95,33 +95,6 @@ export type TerminalProps = {
    * the orchestrator reaches into it via the exported helper.
    */
   registry?: PtyRegistry
-}
-
-/* --------------------------------------------------------------------- */
-/*  Module-level registry                                                 */
-/* --------------------------------------------------------------------- */
-
-/**
- * Default registry shared by every `<Terminal />` instance in the app.
- * Stream E will reach into it to call `release(taskId)` when a task is
- * archived; until then the registry just keeps PTYs alive.
- *
- * Tests pass their own registry via `props.registry`.
- */
-let defaultRegistry: PtyRegistry | null = null
-
-export function getDefaultPtyRegistry(): PtyRegistry {
-  if (!defaultRegistry) defaultRegistry = new PtyRegistry()
-  return defaultRegistry
-}
-
-/**
- * Reset the module-level registry. Tests use this between cases so a
- * leftover registry doesn't leak shell processes across tests.
- */
-export function _resetDefaultPtyRegistry(): void {
-  if (defaultRegistry) defaultRegistry.releaseAll()
-  defaultRegistry = null
 }
 
 /* --------------------------------------------------------------------- */

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -1,10 +1,12 @@
 /**
- * DORMANT — not wired into v1. This is the embedded-xterm terminal pane; it
- * has zero importers and does not ship (the rendering bled outside its box).
- * See ./CLAUDE.md for status, why it was parked, and the revival checklist
- * (fix bleed → wire into workspace host → i18n these hardcoded strings → tests).
+ * Embedded terminal pane — the terminal-in-the-middle seam (issue #16).
+ * Revived from dormancy: the KOBE_TUI workspace host mounts it as the
+ * center column running the task's real interactive engine CLI (its
+ * `command` prop), and it remains usable as a plain worktree shell.
+ * Bleed containment: the body box clips via opentui 0.4's `overflow`
+ * and the viewport slices to the measured row count before render.
  *
- * Terminal pane (Stream J) — bottom-right of the Conductor layout.
+ * Terminal pane (Stream J) — originally bottom-right of the Conductor layout.
  *
  * Renders an embedded shell scoped to the active task's worktree.
  * Body: a headless xterm screen snapshot fed by the task PTY. The
@@ -56,10 +58,11 @@
  * xterm buffer; this component maps them onto opentui's native cursor.
  */
 
-import { type BoxRenderable, StyledText } from "@opentui/core"
+import { type BoxRenderable, StyledText, type TextRenderable } from "@opentui/core"
 import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { type Accessor, type JSXElement, Show, createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import { useTheme } from "../../context/theme"
+import { t } from "../../i18n"
 import { useDialog } from "../../ui/dialog"
 import { DialogConfirm } from "../../ui/dialog-confirm"
 import { useTerminalBindings } from "./keys"
@@ -247,12 +250,7 @@ export function Terminal(props: TerminalProps): JSXElement {
     const cwdAtClick = cwd
     const taskIdAtClick = taskId
     const geometryAtClick = geometry
-    void DialogConfirm.show(
-      dialog,
-      "Reset terminal?",
-      "The running shell will be killed and a fresh one will spawn at the worktree. Any in-flight processes (vim, htop, paused jobs) end immediately.",
-      "cancel",
-    ).then((ok) => {
+    void DialogConfirm.show(dialog, t("terminal.reset.title"), t("terminal.reset.body"), "cancel").then((ok) => {
       if (ok !== true) return
       const reg = registry()
       // Only reset if the user is still on the same task — a
@@ -340,6 +338,12 @@ export function Terminal(props: TerminalProps): JSXElement {
   // with pane row indexing, and the cursor landed one row above
   // the visible prompt.
   const styledSnapshot = createMemo(() => new StyledText(rowsToStyledText(cursorRows())))
+  // Imperative content push — see the render-site comment (solid 0.4 content-prop gap).
+  const [snapshotTextRef, setSnapshotTextRef] = createSignal<TextRenderable | null>(null)
+  createEffect(() => {
+    const ref = snapshotTextRef()
+    if (ref) ref.content = styledSnapshot()
+  })
 
   /* --------- cursor handling ----------
    *
@@ -436,6 +440,7 @@ export function Terminal(props: TerminalProps): JSXElement {
     <box
       flexDirection="column"
       flexGrow={1}
+      overflow="hidden"
       borderColor={focused() ? theme.focusAccent : theme.border}
       onMouseUp={() => setFocusedLocal(true)}
     >
@@ -449,7 +454,7 @@ export function Terminal(props: TerminalProps): JSXElement {
       <Show when={scrollOffset() > 0}>
         <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1}>
           <text fg={theme.warning} wrapMode="none">
-            ↑ scrolled {scrollOffset()}L (ctrl+pgdn to follow)
+            {t("terminal.scrolledBack", { lines: scrollOffset() })}
           </text>
         </box>
       </Show>
@@ -459,6 +464,7 @@ export function Terminal(props: TerminalProps): JSXElement {
           setBodyRef(r)
         }}
         flexGrow={1}
+        overflow="hidden"
         paddingLeft={1}
         paddingRight={1}
       >
@@ -467,10 +473,11 @@ export function Terminal(props: TerminalProps): JSXElement {
           when={pty()}
           fallback={
             <box paddingLeft={1} paddingTop={1} flexDirection="column" gap={0}>
-              <Show when={acquireError()} fallback={<text fg={theme.textMuted}>(no task — press n to create)</text>}>
+              <Show when={acquireError()} fallback={<text fg={theme.textMuted}>{t("terminal.noTask")}</text>}>
                 <text fg={theme.error} wrapMode="word">
-                  terminal unavailable —{" "}
-                  {isShellMissing(acquireError() ?? "") ? "configured shell is not available" : "shell could not start"}
+                  {isShellMissing(acquireError() ?? "")
+                    ? t("terminal.unavailable.shellMissing")
+                    : t("terminal.unavailable.spawnFailed")}
                 </text>
                 <text fg={theme.textMuted} wrapMode="word">
                   {acquireError()}
@@ -488,9 +495,17 @@ export function Terminal(props: TerminalProps): JSXElement {
               Keeping a single multi-line `<text>` preserves the
               original layout assumption that drives the cursor math
               in the createEffect below. */}
-          {/* opentui 0.4: StyledText is no longer a valid JSX child — it goes
-              through the `content` prop (TextRenderable.content). */}
-          <text fg={theme.text} wrapMode="none" content={styledSnapshot()} />
+          {/* opentui 0.4: StyledText is neither a valid JSX child nor honored
+              through the solid binding's `content` prop at runtime (the
+              reconciler stringifies it — "[object Object]"). Assign the
+              TextRenderable's `content` setter directly via ref + effect. */}
+          <text
+            fg={theme.text}
+            wrapMode="none"
+            ref={(r: TextRenderable) => {
+              setSnapshotTextRef(r)
+            }}
+          />
         </Show>
       </box>
     </box>

--- a/packages/kobe/src/tui/panes/terminal/registry.ts
+++ b/packages/kobe/src/tui/panes/terminal/registry.ts
@@ -141,3 +141,26 @@ export class PtyRegistry {
     return this.map.size
   }
 }
+
+/**
+ * Default registry shared by every `<Terminal />` instance in the app.
+ * Stream E will reach into it to call `release(taskId)` when a task is
+ * archived; until then the registry just keeps PTYs alive.
+ *
+ * Tests pass their own registry via `props.registry`.
+ */
+let defaultRegistry: PtyRegistry | null = null
+
+export function getDefaultPtyRegistry(): PtyRegistry {
+  if (!defaultRegistry) defaultRegistry = new PtyRegistry()
+  return defaultRegistry
+}
+
+/**
+ * Reset the module-level registry. Tests use this between cases so a
+ * leftover registry doesn't leak shell processes across tests.
+ */
+export function _resetDefaultPtyRegistry(): void {
+  if (defaultRegistry) defaultRegistry.releaseAll()
+  defaultRegistry = null
+}

--- a/packages/kobe/src/tui/workspace/host.tsx
+++ b/packages/kobe/src/tui/workspace/host.tsx
@@ -1,11 +1,11 @@
 /**
  * Experimental native opentui workspace (`KOBE_TUI=1`).
  *
- * This is the v0.5-shaped single-process app: Sidebar | Chat | Files.
- * The default product path stays the tmux handover; this host is intentionally
- * gated behind `KOBE_TUI=1` while the headless chat backend proves out.
- * No embedded Terminal pane in v1 — the @xterm/headless-backed pane's
- * rendering bled outside its box; it returns once that's fixed.
+ * Single-process app: Sidebar | engine Terminal | Files. The center column
+ * is the terminal-in-the-middle seam (issue #16) — an in-process PTY
+ * running the task's real interactive engine CLI (claude/codex), so kobe
+ * wraps the engine's own TUI instead of re-rendering its stream. The
+ * default product path stays the tmux handover while this proves out.
  */
 
 import { join } from "node:path"
@@ -13,6 +13,7 @@ import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { Show, createEffect, createMemo, createSignal, on } from "solid-js"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
+import { interactiveEngineCommand } from "../../engine/interactive-command.ts"
 import type { Task } from "../../types/task.ts"
 import { HelpDialog } from "../component/help-dialog"
 import { type PaneId, useFocus } from "../context/focus"
@@ -25,6 +26,7 @@ import { FileTree } from "../panes/filetree/FileTree"
 import { openExternally } from "../panes/filetree/open-external"
 import { Sidebar, type SidebarHover } from "../panes/sidebar/Sidebar"
 import { SidebarHoverTooltip } from "../panes/sidebar/hover-tooltip"
+import { Terminal } from "../panes/terminal/Terminal"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
 
@@ -226,13 +228,17 @@ function ShowWorkspace(props: { task: Task | undefined; worktree: string | null;
       keyed
     >
       {(path) => (
-        // Center seam for the embedded-terminal tab (issue #16): the native
-        // chat pane was removed with the AI SDK layer; the in-process PTY
-        // terminal running the real engine CLI mounts here next.
-        <box flexGrow={1} alignItems="center" justifyContent="center" flexDirection="column" gap={1}>
-          <text fg={theme.text}>{props.task?.title ?? path}</text>
-          <text fg={theme.textMuted}>{t("workspace.terminalComing")}</text>
-        </box>
+        // The terminal-in-the-middle seam (issue #16): the center column IS
+        // the engine — an in-process PTY (Bun.spawn terminal) running the
+        // real interactive CLI, so kobe never re-renders the engine's own
+        // TUI. `keyed` remounts per worktree, giving each task its own
+        // registry-backed PTY (acquire reuses a live one on switch-back).
+        <Terminal
+          cwd={() => path}
+          taskId={() => props.task?.id ?? path}
+          command={interactiveEngineCommand(props.task?.vendor, props.task?.modelEffort)}
+          focused={props.focused}
+        />
       )}
     </Show>
   )


### PR DESCRIPTION
## Summary
- Second cut of the terminal-in-the-middle pivot (issue #16): the dormant `panes/terminal/` cluster (Bun.spawn PTY + @xterm/headless, no native addons) is revived and the `KOBE_TUI=1` workspace center column now runs the task's **real interactive engine CLI** (`interactiveEngineCommand(vendor, modelEffort)`) in an in-process PTY — kobe wraps the engine's own TUI instead of re-rendering its stream. The pane's pre-existing `command` prop anticipated exactly this use.
- Revival checklist items done here: (1) bleed containment — `overflow="hidden"` on the pane boxes (new in opentui 0.4) plus the existing viewport row-slicing; (3) all hardcoded strings → new `terminal.*` i18n namespace (en + zh, catalog-registered).
- Upstream gap found + worked around with a minimal repro: `@opentui/solid` 0.4's `content` prop **stringifies StyledText at runtime** (renders `[object Object]`) even though the types accept it — the snapshot is now assigned through the `TextRenderable.content` setter via ref + effect, documented inline.
- New `dev:mock-terminal` entry proves the seam live (spawns a real `sh` in a temp dir, greps the marker from rendered output).
- Checklist items 4 (keys-pure/viewport tests) + 5 (dead-shell surfacing) and the chattab-style tab shell (naming/switching/lifecycle) follow in the next slices; tmux path untouched.

coverage-exemption: packages/kobe/src/tui/panes/terminal/Terminal.tsx — renderer-bound pane (imports @opentui); exercised live by the dev:mock-terminal gate.
coverage-exemption: packages/kobe/src/tui/workspace/host.tsx — renderer-bound host, center-column swap; exercised by the KOBE_TUI boot smoke.
coverage-exemption: packages/kobe/src/tui/mock/terminal-host.tsx — dev-only mock entry.

## Test plan
- [x] `bun run typecheck` + repo-root `bun run lint` clean
- [x] `bun run test` — fast 2404/2404 + socket 218/218
- [x] `timeout 8 bun run dev:mock-terminal` → renders `TERMINAL-PANE-OK` from a live PTY (marker grep)
- [x] `KOBE_TUI=1` workspace boots (isolated home, exit 124)
- [x] `bun run compile` → binary OK; `dev:mock` / `dev:mock-react` unbroken