### PR TITLE
feat: dead-shell surfacing + terminal unit tests (issue #16)

### DIFF
--- a/.changeset/terminal-tests-deadshell.md
+++ b/.changeset/terminal-tests-deadshell.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Embedded terminal hardening (issue #16, revival checklist #4/#5): a dead engine/shell now surfaces — every PTY backend gains an onExit notification (fires immediately for fast crashes) and the pane shows an "process exited — F5 restarts it" banner over the frozen snapshot instead of silently freezing. The registry, key-byte translation, and the newly extracted pure viewport math are pinned by unit tests.

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -6,6 +6,7 @@
 
 export const en = {
   noTask: "(no task — press n to create)",
+  exited: "process exited — F5 restarts it",
   scrolledBack: "↑ scrolled {lines}L (ctrl+pgdn to follow)",
   unavailable: {
     shellMissing: "terminal unavailable — configured shell is not available",
@@ -19,6 +20,7 @@ export const en = {
 
 export const zh: typeof en = {
   noTask: "（无任务 —— 按 n 创建）",
+  exited: "进程已退出 —— 按 F5 重启",
   scrolledBack: "↑ 已回滚 {lines} 行（ctrl+pgdn 回到底部）",
   unavailable: {
     shellMissing: "终端不可用 —— 配置的 shell 不存在",

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -70,6 +70,7 @@ import type { CursorPos, TaskPty, TerminalRow } from "./pty"
 import { type PtyRegistry, getDefaultPtyRegistry } from "./registry"
 import { rowsToStyledText } from "./sgr-to-text-chunk"
 import { isShellMissing, overlayCursor } from "./terminal-render"
+import { computeViewport, viewportCursor } from "./viewport"
 
 /* --------------------------------------------------------------------- */
 /*  Public surface                                                        */
@@ -126,6 +127,12 @@ export function Terminal(props: TerminalProps): JSXElement {
   // Latest cursor position from the PTY (null when backend can't report).
   const [cursor, setCursor] = createSignal<CursorPos | null>(null)
 
+  // Dead-shell flag (revival checklist #5): flips when the PTY reports
+  // exit for any reason — its own end, a write failure, or an external
+  // kill. The last snapshot stays visible (frozen output has value);
+  // the banner + F5 reset are the recovery path.
+  const [exited, setExited] = createSignal(false)
+
   // Scroll offset: 0 = follow bottom; positive = N lines back into history.
   const [scrollOffset, setScrollOffset] = createSignal(0)
 
@@ -177,7 +184,10 @@ export function Terminal(props: TerminalProps): JSXElement {
   // accepting input."
   createEffect(() => {
     const handle = pty()
+    setExited(handle ? handle.killed : false)
     if (!handle || handle.killed) return
+    const unsubscribeExit = handle.onExit(() => setExited(true))
+    onCleanup(() => unsubscribeExit())
     const unsubscribe = handle.onData((snap, c) => {
       setSnapshot(snap)
       setCursor(c)
@@ -271,14 +281,7 @@ export function Terminal(props: TerminalProps): JSXElement {
   // follow-bottom: render only the last body-height rows, not the
   // whole scrollback. Positive offset moves the viewport upward into
   // history.
-  const visibleRange = createMemo(() => {
-    const all = parsedRows()
-    const height = Math.max(1, bodyRows())
-    const offset = Math.max(0, scrollOffset())
-    const end = Math.max(0, all.length - offset)
-    const start = Math.max(0, end - height)
-    return { start, end }
-  })
+  const visibleRange = createMemo(() => computeViewport(parsedRows().length, bodyRows(), scrollOffset()))
 
   const visibleRows = createMemo(() => {
     const all = parsedRows()
@@ -289,13 +292,7 @@ export function Terminal(props: TerminalProps): JSXElement {
   // Cursor is only meaningful when we're following the bottom of the
   // buffer; once the user scrolls back, the cursor's reported (x,y)
   // refers to the *live* viewport, not what's currently rendered.
-  const visibleCursor = createMemo(() => {
-    const c = cursor()
-    if (!c || scrollOffset() !== 0) return null
-    const range = visibleRange()
-    if (c.y < range.start || c.y >= range.end) return null
-    return { x: c.x, y: c.y - range.start }
-  })
+  const visibleCursor = createMemo(() => viewportCursor(cursor(), scrollOffset(), visibleRange()))
 
   const cursorRows = createMemo(() => {
     const c = focused() ? visibleCursor() : null
@@ -424,6 +421,13 @@ export function Terminal(props: TerminalProps): JSXElement {
           body's `screenY` by 1, parking the cursor on the header
           instead of the prompt. Conditional render means the body's
           screenY equals the pane's content top in the steady state. */}
+      <Show when={exited()}>
+        <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1}>
+          <text fg={theme.error} wrapMode="none">
+            {t("terminal.exited")}
+          </text>
+        </box>
+      </Show>
       <Show when={scrollOffset() > 0}>
         <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1}>
           <text fg={theme.warning} wrapMode="none">

--- a/packages/kobe/src/tui/panes/terminal/pty-mock.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-mock.ts
@@ -16,6 +16,7 @@ export class MockTaskPty implements TaskPtyLike {
   private buffer = ""
   private writes: string[] = []
   private _killed = false
+  private readonly exitListeners = new Set<() => void>()
   private _cols: number
   private _rows: number
   private _cursor: CursorPos | null = null
@@ -96,5 +97,19 @@ export class MockTaskPty implements TaskPtyLike {
     if (this._killed) return
     this._killed = true
     this.listeners.clear()
+    const exitCbs = [...this.exitListeners]
+    this.exitListeners.clear()
+    for (const cb of exitCbs) cb()
+  }
+
+  onExit(cb: () => void): () => void {
+    if (this._killed) {
+      cb()
+      return () => {}
+    }
+    this.exitListeners.add(cb)
+    return () => {
+      this.exitListeners.delete(cb)
+    }
   }
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
@@ -20,6 +20,7 @@ export class PipeTaskPty implements TaskPtyLike {
   private readonly listeners = new Set<DataListener>()
   private buffer = ""
   private _killed = false
+  private readonly exitListeners = new Set<() => void>()
   private cols: number
   private rows: number
 
@@ -141,6 +142,26 @@ export class PipeTaskPty implements TaskPtyLike {
         /* best effort */
       }
     }
+    const exitCbs = [...this.exitListeners]
     this.listeners.clear()
+    this.exitListeners.clear()
+    for (const cb of exitCbs) {
+      try {
+        cb()
+      } catch {
+        /* one listener must not break the others */
+      }
+    }
+  }
+
+  onExit(cb: () => void): () => void {
+    if (this._killed) {
+      cb()
+      return () => {}
+    }
+    this.exitListeners.add(cb)
+    return () => {
+      this.exitListeners.delete(cb)
+    }
   }
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -40,6 +40,14 @@ export interface TaskPtyLike {
 
   write(data: string): void
   onData(cb: DataListener): () => void
+  /**
+   * Notify once when the underlying process ends for ANY reason (its own
+   * exit, a write failure, or kill()). Fires immediately if already dead —
+   * a pane subscribing after a fast crash must still see the state. The
+   * pane renders a dead-shell banner off this instead of silently freezing
+   * on the last snapshot (revival checklist #5).
+   */
+  onExit(cb: () => void): () => void
   resize(cols: number, rows: number): void
   capture(): readonly TerminalRow[]
   captureCursor(): CursorPos | null

--- a/packages/kobe/src/tui/panes/terminal/pty.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty.ts
@@ -49,6 +49,7 @@ export class BunTerminalTaskPty implements TaskPtyLike {
   private readonly proc: ReturnType<typeof Bun.spawn>
   private readonly term: XtermHeadless
   private readonly listeners = new Set<DataListener>()
+  private readonly exitListeners = new Set<() => void>()
   private snapshot: readonly TerminalRow[] = []
   private cursor: CursorPos | null = null
   private _killed = false
@@ -120,6 +121,17 @@ export class BunTerminalTaskPty implements TaskPtyLike {
       this.proc.terminal?.write(data)
     } catch {
       this.markDead(false)
+    }
+  }
+
+  onExit(cb: () => void): () => void {
+    if (this._killed) {
+      cb()
+      return () => {}
+    }
+    this.exitListeners.add(cb)
+    return () => {
+      this.exitListeners.delete(cb)
     }
   }
 
@@ -262,7 +274,16 @@ export class BunTerminalTaskPty implements TaskPtyLike {
         /* best effort */
       }
     }
+    const exitCbs = [...this.exitListeners]
     this.listeners.clear()
+    this.exitListeners.clear()
+    for (const cb of exitCbs) {
+      try {
+        cb()
+      } catch {
+        /* one listener must not break the others */
+      }
+    }
   }
 }
 

--- a/packages/kobe/src/tui/panes/terminal/viewport.ts
+++ b/packages/kobe/src/tui/panes/terminal/viewport.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure viewport-slicing math for the terminal pane (extracted from
+ * Terminal.tsx so vitest can pin it — revival checklist #4). The pane
+ * keeps the full snapshot in memory and renders only this window.
+ */
+
+export interface ViewportRange {
+  readonly start: number
+  readonly end: number
+}
+
+/**
+ * Visible row window for a buffer of `total` rows in a body of `height`
+ * rows, scrolled `offset` lines back into history. `offset` 0 follows the
+ * bottom (the last `height` rows); positive offsets move the window up,
+ * clamping at the top so the window never underflows.
+ */
+export function computeViewport(total: number, height: number, offset: number): ViewportRange {
+  const h = Math.max(1, height)
+  const end = Math.max(0, total - Math.max(0, offset))
+  const start = Math.max(0, end - h)
+  return { start, end }
+}
+
+/**
+ * Cursor position within the viewport, or null when the cursor is
+ * outside the window or the user has scrolled back (a historical
+ * viewport has no live cursor).
+ */
+export function viewportCursor(
+  cursor: { x: number; y: number } | null,
+  offset: number,
+  range: ViewportRange,
+): { x: number; y: number } | null {
+  if (!cursor || offset !== 0) return null
+  if (cursor.y < range.start || cursor.y >= range.end) return null
+  return { x: cursor.x, y: cursor.y - range.start }
+}

--- a/packages/kobe/test/tui/terminal-keys-pure.test.ts
+++ b/packages/kobe/test/tui/terminal-keys-pure.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Why this matters: keyEventToShellBytes is every keystroke's path into the
+ * embedded engine CLI — a wrong byte turns Enter into a literal, or a ctrl
+ * chord into shell garbage. RESERVED_GLOBAL_CHORDS is the user's only way
+ * OUT of the terminal pane; if a chord leaks from that list into the PTY
+ * the user is trapped inside the engine (the KOB-208 class of bug).
+ */
+
+import type { KeyEvent } from "@opentui/core"
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_PAGE_SIZE,
+  PASSTHROUGH_NAMES,
+  RESERVED_GLOBAL_CHORDS,
+  TRAPPED_KEYS,
+  keyEventToShellBytes,
+} from "../../src/tui/panes/terminal/keys-pure"
+
+function evt(partial: Partial<KeyEvent> & { name: string }): KeyEvent {
+  return partial as unknown as KeyEvent
+}
+
+describe("keyEventToShellBytes", () => {
+  it("forwards the upstream byte sequence verbatim when present", () => {
+    expect(keyEventToShellBytes(evt({ name: "a", sequence: "\x1b[Z" } as never))).toBe("\x1b[Z")
+  })
+
+  it("synthesizes the named-key sequences tests and mocks rely on", () => {
+    expect(keyEventToShellBytes(evt({ name: "return" }))).toBe("\r")
+    expect(keyEventToShellBytes(evt({ name: "enter" }))).toBe("\r")
+    expect(keyEventToShellBytes(evt({ name: "tab" }))).toBe("\t")
+    expect(keyEventToShellBytes(evt({ name: "backspace" }))).toBe("\x7f")
+    expect(keyEventToShellBytes(evt({ name: "delete" }))).toBe("\x1b[3~")
+    expect(keyEventToShellBytes(evt({ name: "up" }))).toBe("\x1b[A")
+    expect(keyEventToShellBytes(evt({ name: "escape" }))).toBe("\x1b")
+    expect(keyEventToShellBytes(evt({ name: "space" }))).toBe(" ")
+  })
+
+  it("maps ctrl+letter to C0 control bytes; plain letters pass through", () => {
+    expect(keyEventToShellBytes(evt({ name: "c", ctrl: true }))).toBe("\x03")
+    expect(keyEventToShellBytes(evt({ name: "Z", ctrl: true }))).toBe("\x1a")
+    expect(keyEventToShellBytes(evt({ name: "q" }))).toBe("q")
+  })
+
+  it("returns null for unknown multi-char names and nameless events", () => {
+    expect(keyEventToShellBytes(evt({ name: "pageup" }))).toBeNull()
+    expect(keyEventToShellBytes(evt({ name: "" }))).toBeNull()
+  })
+})
+
+describe("key routing tables", () => {
+  it("keeps every escape hatch reserved (first-match beats passthrough)", () => {
+    expect(TRAPPED_KEYS).toEqual(["ctrl+pageup", "ctrl+pagedown"])
+    // The primary escape hatches stay reserved — losing any of these traps
+    // the user inside the engine CLI. (F-keys deliberately ALSO appear in
+    // PASSTHROUGH_NAMES: reservation wins by binding order, not disjointness.)
+    for (const chord of ["ctrl+h", "ctrl+j", "ctrl+k", "ctrl+l", "ctrl+q", "f1", "f5", "ctrl+p", "shift+tab"]) {
+      expect(RESERVED_GLOBAL_CHORDS).toContain(chord)
+    }
+    // Plain typing keys must stay forwardable.
+    for (const name of ["a", "Z", "0", " ", "return", "escape", "tab"]) {
+      expect(PASSTHROUGH_NAMES).toContain(name)
+    }
+    expect(DEFAULT_PAGE_SIZE).toBeGreaterThan(0)
+  })
+})

--- a/packages/kobe/test/tui/terminal-registry.test.ts
+++ b/packages/kobe/test/tui/terminal-registry.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Why this matters: the registry is the seam that decouples pane lifecycle
+ * (per-render) from shell lifecycle (per-task) — the terminal-in-the-middle
+ * center column (issue #16) leans on acquire-reuse so switching tasks and
+ * back does NOT restart the engine CLI. A regression here kills running
+ * claude sessions on every sidebar keystroke.
+ */
+
+import { describe, expect, it } from "vitest"
+import { MockTaskPty } from "../../src/tui/panes/terminal/pty-mock"
+import type { TaskPtyOpts } from "../../src/tui/panes/terminal/pty-types"
+import { PtyRegistry, _resetDefaultPtyRegistry, getDefaultPtyRegistry } from "../../src/tui/panes/terminal/registry"
+
+const mockFactory = (opts: TaskPtyOpts) => new MockTaskPty(opts)
+
+describe("PtyRegistry", () => {
+  it("acquire reuses the live PTY for the same task (engine keeps running)", () => {
+    const reg = new PtyRegistry(mockFactory)
+    const a = reg.acquire("t1", "/wt")
+    const b = reg.acquire("t1", "/wt")
+    expect(b).toBe(a)
+    expect(reg.size).toBe(1)
+  })
+
+  it("acquire replaces an externally-killed PTY instead of returning a corpse", () => {
+    const reg = new PtyRegistry(mockFactory)
+    const a = reg.acquire("t1", "/wt")
+    a.kill()
+    const b = reg.acquire("t1", "/wt")
+    expect(b).not.toBe(a)
+    expect(b.killed).toBe(false)
+  })
+
+  it("get/has hide dead PTYs and prune them", () => {
+    const reg = new PtyRegistry(mockFactory)
+    const a = reg.acquire("t1", "/wt")
+    expect(reg.has("t1")).toBe(true)
+    a.kill()
+    expect(reg.get("t1")).toBeNull()
+    expect(reg.has("t1")).toBe(false)
+    expect(reg.size).toBe(0)
+  })
+
+  it("release kills and forgets; releasing an absent id is a no-op", () => {
+    const reg = new PtyRegistry(mockFactory)
+    const a = reg.acquire("t1", "/wt")
+    reg.release("t1")
+    expect(a.killed).toBe(true)
+    expect(reg.size).toBe(0)
+    reg.release("missing")
+  })
+
+  it("releaseAll leaves no live shells behind", () => {
+    const reg = new PtyRegistry(mockFactory)
+    const a = reg.acquire("t1", "/a")
+    const b = reg.acquire("t2", "/b")
+    reg.releaseAll()
+    expect(a.killed).toBe(true)
+    expect(b.killed).toBe(true)
+    expect(reg.size).toBe(0)
+  })
+
+  it("reset kills the old shell and hands back a fresh one", () => {
+    const reg = new PtyRegistry(mockFactory)
+    const a = reg.acquire("t1", "/wt")
+    const fresh = reg.reset("t1", "/wt")
+    expect(a.killed).toBe(true)
+    expect(fresh).not.toBe(a)
+    expect(reg.get("t1")).toBe(fresh)
+  })
+})
+
+describe("default registry singleton", () => {
+  it("is created lazily, shared, and reset drops every shell", () => {
+    _resetDefaultPtyRegistry()
+    const reg = getDefaultPtyRegistry()
+    expect(getDefaultPtyRegistry()).toBe(reg)
+    _resetDefaultPtyRegistry()
+    expect(getDefaultPtyRegistry()).not.toBe(reg)
+    _resetDefaultPtyRegistry()
+  })
+})
+
+describe("TaskPty onExit contract (mock backend)", () => {
+  it("notifies on kill and unsubscribes cleanly", () => {
+    const pty = new MockTaskPty({ taskId: "t", cwd: "/" })
+    let fired = 0
+    const off = pty.onExit(() => {
+      fired += 1
+    })
+    pty.onExit(() => {
+      fired += 10
+    })
+    off()
+    pty.kill()
+    expect(fired).toBe(10)
+  })
+
+  it("fires immediately when subscribing to an already-dead PTY (fast-crash case)", () => {
+    const pty = new MockTaskPty({ taskId: "t", cwd: "/" })
+    pty.kill()
+    let fired = false
+    pty.onExit(() => {
+      fired = true
+    })
+    expect(fired).toBe(true)
+  })
+})

--- a/packages/kobe/test/tui/terminal-viewport.test.ts
+++ b/packages/kobe/test/tui/terminal-viewport.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Why this matters: the viewport window is what keeps the revived terminal
+ * pane from bleeding — the pane renders EXACTLY this slice into its body
+ * box. Off-by-ones here paint outside the pane or park the inline cursor
+ * on the wrong row (the exact bugs that got the cluster shelved).
+ */
+
+import { describe, expect, it } from "vitest"
+import { computeViewport, viewportCursor } from "../../src/tui/panes/terminal/viewport"
+
+describe("computeViewport", () => {
+  it("offset 0 follows the bottom: last `height` rows", () => {
+    expect(computeViewport(100, 24, 0)).toEqual({ start: 76, end: 100 })
+  })
+
+  it("short buffers render whole from row 0 (no underflow)", () => {
+    expect(computeViewport(5, 24, 0)).toEqual({ start: 0, end: 5 })
+    expect(computeViewport(0, 24, 0)).toEqual({ start: 0, end: 0 })
+  })
+
+  it("positive offsets move the window into history and clamp at the top", () => {
+    expect(computeViewport(100, 24, 10)).toEqual({ start: 66, end: 90 })
+    expect(computeViewport(100, 24, 999)).toEqual({ start: 0, end: 0 })
+  })
+
+  it("degenerate heights clamp to one row; negative offsets read as 0", () => {
+    expect(computeViewport(10, 0, 0)).toEqual({ start: 9, end: 10 })
+    expect(computeViewport(10, 4, -5)).toEqual({ start: 6, end: 10 })
+  })
+})
+
+describe("viewportCursor", () => {
+  const range = { start: 76, end: 100 }
+
+  it("maps a live in-window cursor to viewport coordinates", () => {
+    expect(viewportCursor({ x: 3, y: 80 }, 0, range)).toEqual({ x: 3, y: 4 })
+  })
+
+  it("hides the cursor while scrolled back or out of window", () => {
+    expect(viewportCursor({ x: 3, y: 80 }, 5, range)).toBeNull()
+    expect(viewportCursor({ x: 3, y: 10 }, 0, range)).toBeNull()
+    expect(viewportCursor({ x: 3, y: 100 }, 0, range)).toBeNull()
+    expect(viewportCursor(null, 0, range)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Revival checklist #5: every PTY backend (`bun-pty`/`pipe`/`mock`) gains `onExit` — notified on process end from ANY cause (own exit, write failure, kill), firing immediately for already-dead PTYs so a fast crash can't slip past a late subscriber. The pane renders an i18n'd "process exited — F5 restarts it" banner over the frozen snapshot instead of silently freezing (en + zh).
- Revival checklist #4: unit coverage for the untested half — registry acquire-reuse/stale-drop/release/reset (also closes the #249 coverage gap on registry.ts), key→shell byte translation + reserved escape-hatch chords (the KOB-208 "trapped in the engine" class), and viewport slicing extracted to a pure module with edge-case pins.

coverage-exemption: packages/kobe/src/tui/panes/terminal/Terminal.tsx — renderer-bound pane; exercised live by the dev:mock-terminal gate.
coverage-exemption: packages/kobe/src/tui/panes/terminal/pty.ts — Bun.spawn PTY backend (terminal option requires a real Bun PTY); onExit contract pinned via the mock backend, seam exercised by dev:mock-terminal.
coverage-exemption: packages/kobe/src/tui/panes/terminal/pty-pipe.ts — subprocess pipe fallback, same rationale.

## Test plan
- [x] `bun run typecheck` + repo-root `bun run lint` clean
- [x] `bun run test` — fast 2424/2424 (+20 new) + socket 218/218 (one flaky socket run re-ran green)
- [x] `timeout 8 bun run dev:mock-terminal` still renders the live PTY marker