### PR TITLE
feat: workspace terminal tabs — the PTY-world chattab (issue #16)

### DIFF
--- a/.changeset/terminal-chattabs.md
+++ b/.changeset/terminal-chattabs.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Workspace terminal tabs (issue #16): the PTY-world chattab. The KOBE_TUI center column now carries a tab strip over the embedded terminal — ctrl+t opens a parallel engine session in the same worktree, ctrl+w closes (the last tab refuses), F2 renames through the real rename dialog, ctrl+]/[ cycle — reusing the canonical chattab binding ids and reserving those chords from PTY passthrough exactly as the tmux root key-table did. Per-task tab state survives task switches; each tab keys its own registry-backed PTY.

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -7,6 +7,12 @@
 export const en = {
   noTask: "(no task — press n to create)",
   exited: "process exited — F5 restarts it",
+  tab: {
+    defaultTitle: "Terminal {n}",
+    renameTitle: "Rename tab",
+    renameField: "tab title",
+    renameSubmit: "rename",
+  },
   scrolledBack: "↑ scrolled {lines}L (ctrl+pgdn to follow)",
   unavailable: {
     shellMissing: "terminal unavailable — configured shell is not available",
@@ -21,6 +27,12 @@ export const en = {
 export const zh: typeof en = {
   noTask: "（无任务 —— 按 n 创建）",
   exited: "进程已退出 —— 按 F5 重启",
+  tab: {
+    defaultTitle: "终端 {n}",
+    renameTitle: "重命名标签页",
+    renameField: "标签页名称",
+    renameSubmit: "重命名",
+  },
   scrolledBack: "↑ 已回滚 {lines} 行（ctrl+pgdn 回到底部）",
   unavailable: {
     shellMissing: "终端不可用 —— 配置的 shell 不存在",

--- a/packages/kobe/src/tui/panes/terminal/CLAUDE.md
+++ b/packages/kobe/src/tui/panes/terminal/CLAUDE.md
@@ -1,7 +1,8 @@
-# `panes/terminal/` — mixed: live tmux stack + DORMANT embedded-terminal pane
+# `panes/terminal/` — mixed: live tmux stack + LIVE embedded-terminal pane
 
 This directory holds two unrelated things. Read this before assuming anything
-here ships (or doesn't).
+here ships. (Historical note: the embedded pane was dormant until the
+terminal-in-the-middle pivot, issue #16, revived it — 2026-07-06.)
 
 ## Two stacks, one folder
 
@@ -12,27 +13,21 @@ These are imported all over the codebase (`cli/commands-tui.ts`, `tui/lib/task-e
 `tmux/*`, `settings/host.tsx`, …) and drive the default product path — the tmux
 handover. Nothing below applies to them.
 
-**DORMANT — the embedded-terminal pane (this doc's subject):**
+**LIVE — the embedded-terminal pane (this doc's subject), since issue #16:**
 `Terminal.tsx`, `pty.ts`, `pty-pipe.ts`, `pty-types.ts`, `pty-mock.ts`, `registry.ts`,
 `keys.ts`, `keys-pure.ts`, `xterm-chunks.ts`, `sgr.ts`, `sgr-to-text-chunk.ts`,
 `terminal-render.ts` (~1820 lines).
 
-## Status of the dormant cluster
+## Status
 
-**Dormant. Not wired into v1. Zero importers outside this directory — intentional.**
-It was revived from git history as an in-process embedded shell pane (Conductor's
-bottom-right terminal). It is kept in-tree on purpose but nothing renders it: the
-native workspace host (`tui/workspace/host.tsx`) deliberately omits it and says so
-in its header comment.
-
-## Why it was parked
-
-The `@xterm/headless`-backed pane's rendering bled outside its box — the snapshot
-`<text>` painted past the pane's bounds instead of clipping to it. `Terminal.tsx`'s
-own comments record how brittle the geometry is: cursor position is computed from
-`body.screenY + cursor.y` and depends on a single flat multi-line `<text>` (one
-`<text>` per row shifted `screenY` and parked the cursor a row off). That coupling
-is what needs to be made robust before it can ship.
+**Live — the terminal-in-the-middle center column (issue #16).** The KOBE_TUI
+workspace host mounts it through `tui/workspace/TerminalTabs.tsx` (the PTY-world
+chattab: ctrl+t/ctrl+w/F2/ctrl+]/[ on registry keys `${taskId}::${tabId}`),
+running the task's real interactive engine CLI via `interactiveEngineCommand`.
+Bleed is contained by opentui 0.4 `overflow="hidden"` + viewport slicing
+(`viewport.ts`); the snapshot StyledText is assigned through the renderable's
+`content` setter (the solid binding's content prop stringifies at runtime);
+a dead shell surfaces via the backends' `onExit` + the pane's exit banner.
 
 ## What it is (by responsibility cluster)
 
@@ -50,7 +45,7 @@ is what needs to be made robust before it can ship.
   `terminal-render.ts`): turn xterm cells / SGR runs into opentui `StyledText`
   chunks, overlay the cursor cell, and detect the "shell missing" error state.
 
-## Revival checklist
+## Revival checklist (ALL DONE — issue #16, PRs #249/#250 + terminal tabs)
 
 1. **Fix the rendering bleed** — clip the body `<text>` to the pane box; re-verify
    the `screenY + cursor.y` math survives resize and the single-`<text>` constraint.

--- a/packages/kobe/src/tui/panes/terminal/keys-pure.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys-pure.ts
@@ -105,6 +105,15 @@ export const RESERVED_GLOBAL_CHORDS: readonly string[] = [
   // reserving it the pane forwarder sent `\x11` (XON) to claude and the
   // global jump never fired (KOB-208 interactive mode).
   "ctrl+q",
+  // Terminal tab chords (workspace chattab, issue #16) — the strip must
+  // win these against the engine CLI, same interception the tmux root
+  // key-table performed. ctrl+w costs shells their delete-word and F2 is
+  // rebindable per docs/KEYBINDINGS.md; parity with the tmux chattab wins.
+  "ctrl+t",
+  "ctrl+w",
+  "ctrl+]",
+  "ctrl+[",
+  "f2",
   // Help / palette / settings.
   "f1",
   "ctrl+p",

--- a/packages/kobe/src/tui/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalTabs.tsx
@@ -1,0 +1,121 @@
+/**
+ * Workspace terminal tabs (issue #16) — the PTY-world chattab. A strip of
+ * engine-terminal tabs above the embedded Terminal pane; every tab runs
+ * the task's SAME interactive engine command in its own PTY (registry key
+ * `${taskId}::${tabId}`), so ctrl+t gives a parallel session in the same
+ * worktree exactly like the tmux chattab did with windows.
+ *
+ * Chords reuse the canonical chattab binding ids (keybindings-chat.ts):
+ * ctrl+t new · ctrl+w close (last tab refuses) · F2 rename · ctrl+]/[
+ * cycle. They are reserved from PTY passthrough in keys-pure.ts — same
+ * interception the tmux root key-table performed.
+ *
+ * Per-task tab state lives in a module-level map so switching tasks and
+ * back preserves each task's tabs (their PTYs already survive via the
+ * registry's acquire-reuse).
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { For, Show, createSignal } from "solid-js"
+import { RenameTaskDialog } from "../component/rename-task-dialog/index"
+import { bindByIds } from "../context/keybindings"
+import { useTheme } from "../context/theme"
+import { t } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { Terminal } from "../panes/terminal/Terminal"
+import { useDialog } from "../ui/dialog"
+import {
+  type TabsState,
+  type TerminalTab,
+  addTab,
+  closeActiveTab,
+  cycleTab,
+  initialTabs,
+  renameActiveTab,
+  tabPtyKey,
+} from "./terminal-tabs-core"
+
+/** Per-task tab state, preserved across task switches for the process. */
+const tabsByTask = new Map<string, TabsState>()
+
+function tabTitle(tab: TerminalTab): string {
+  return tab.title ?? t("terminal.tab.defaultTitle", { n: tab.ordinal })
+}
+
+export function TerminalTabs(props: {
+  taskId: string
+  worktree: string
+  command: readonly string[]
+  focused: () => boolean
+}): ReturnType<typeof Terminal> {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const [state, setState] = createSignal<TabsState>(tabsByTask.get(props.taskId) ?? initialTabs())
+  const update = (next: TabsState): void => {
+    tabsByTask.set(props.taskId, next)
+    setState(next)
+  }
+
+  const active = () => state().tabs.find((tab) => tab.id === state().activeId) ?? state().tabs[0]
+
+  const requestRename = (): void => {
+    const tab = active()
+    if (!tab) return
+    void RenameTaskDialog.show(dialog, tabTitle(tab), {
+      dialogTitle: t("terminal.tab.renameTitle"),
+      fieldLabel: t("terminal.tab.renameField"),
+      submitLabel: t("terminal.tab.renameSubmit"),
+      allowEmpty: true,
+    }).then((title) => {
+      if (title === undefined) return
+      update(renameActiveTab(state(), title))
+    })
+  }
+
+  useBindings(() => ({
+    enabled: props.focused(),
+    bindings: bindByIds({
+      "chat.tab.new": () => update(addTab(state())),
+      "chat.tab.close": () => {
+        const { state: next } = closeActiveTab(state())
+        update(next)
+      },
+      "chat.tab.rename": requestRename,
+      "chat.tab.cycle-next": () => update(cycleTab(state(), 1)),
+      "chat.tab.cycle-prev": () => update(cycleTab(state(), -1)),
+    }),
+  }))
+
+  return (
+    <box flexDirection="column" flexGrow={1}>
+      {/* Tab strip — flush to the pane edge, dense, hidden for one tab. */}
+      <Show when={state().tabs.length > 1}>
+        <box flexDirection="row" gap={1} flexShrink={0} paddingLeft={1} backgroundColor={theme.backgroundElement}>
+          <For each={state().tabs}>
+            {(tab) => (
+              <text
+                fg={tab.id === state().activeId ? theme.focusAccent : theme.textMuted}
+                attributes={tab.id === state().activeId ? TextAttributes.BOLD : undefined}
+                wrapMode="none"
+              >
+                {tabTitle(tab)}
+              </text>
+            )}
+          </For>
+        </box>
+      </Show>
+      {/* keyed remount per tab — each tab owns a registry-backed PTY that
+          survives switches; only the visible one renders. */}
+      <Show when={active()} keyed>
+        {(tab) => (
+          <Terminal
+            cwd={() => props.worktree}
+            taskId={() => tabPtyKey(props.taskId, tab.id)}
+            command={props.command}
+            focused={props.focused}
+          />
+        )}
+      </Show>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui/workspace/host.tsx
+++ b/packages/kobe/src/tui/workspace/host.tsx
@@ -26,9 +26,9 @@ import { FileTree } from "../panes/filetree/FileTree"
 import { openExternally } from "../panes/filetree/open-external"
 import { Sidebar, type SidebarHover } from "../panes/sidebar/Sidebar"
 import { SidebarHoverTooltip } from "../panes/sidebar/hover-tooltip"
-import { Terminal } from "../panes/terminal/Terminal"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
+import { TerminalTabs } from "./TerminalTabs"
 
 const SIDEBAR_WIDTH = 32
 const WORKTREE_TOOLS_MIN_WIDTH = 22
@@ -233,9 +233,9 @@ function ShowWorkspace(props: { task: Task | undefined; worktree: string | null;
         // real interactive CLI, so kobe never re-renders the engine's own
         // TUI. `keyed` remounts per worktree, giving each task its own
         // registry-backed PTY (acquire reuses a live one on switch-back).
-        <Terminal
-          cwd={() => path}
-          taskId={() => props.task?.id ?? path}
+        <TerminalTabs
+          taskId={props.task?.id ?? path}
+          worktree={path}
           command={interactiveEngineCommand(props.task?.vendor, props.task?.modelEffort)}
           focused={props.focused}
         />

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure tab-list state for the workspace terminal tabs (issue #16) — the
+ * PTY-world successor of the tmux chattab concept. Same user contract:
+ * new tab spawns the SAME engine command in the same worktree, the last
+ * tab can't be closed, titles are user-renameable, bracket chords cycle.
+ *
+ * Framework-free on purpose: the Solid component owns signals/UI, this
+ * module owns the transitions so vitest can pin them. Tab PTYs are keyed
+ * `${taskId}::${tabId}` into the existing PtyRegistry — no registry
+ * changes; each tab is just another registry entry that survives task
+ * switches (acquire-reuse) until closed.
+ */
+
+export interface TerminalTab {
+  /** Stable id — registry key suffix. Never reused within a task. */
+  readonly id: string
+  /** User title; null = untitled (view shows the numbered default). */
+  readonly title: string | null
+  /** 1-based creation ordinal — drives the "Terminal {n}" default. */
+  readonly ordinal: number
+}
+
+export interface TabsState {
+  readonly tabs: readonly TerminalTab[]
+  readonly activeId: string
+  /** Next ordinal to hand out (monotonic — close does not recycle). */
+  readonly nextOrdinal: number
+}
+
+/** A task's initial state: one untitled tab, active. */
+export function initialTabs(): TabsState {
+  return { tabs: [{ id: "tab-1", title: null, ordinal: 1 }], activeId: "tab-1", nextOrdinal: 2 }
+}
+
+/** Open a new tab after the active one and focus it. */
+export function addTab(state: TabsState): TabsState {
+  const ordinal = state.nextOrdinal
+  const tab: TerminalTab = { id: `tab-${ordinal}`, title: null, ordinal }
+  const i = state.tabs.findIndex((t) => t.id === state.activeId)
+  const tabs = [...state.tabs.slice(0, i + 1), tab, ...state.tabs.slice(i + 1)]
+  return { tabs, activeId: tab.id, nextOrdinal: ordinal + 1 }
+}
+
+/**
+ * Close the active tab, focusing its left neighbor (right neighbor when
+ * closing the first). Refuses to close the only tab — same guard the
+ * tmux chattab had; the caller surfaces the refusal, state is unchanged.
+ */
+export function closeActiveTab(state: TabsState): { state: TabsState; closedId: string | null } {
+  if (state.tabs.length <= 1) return { state, closedId: null }
+  const i = state.tabs.findIndex((t) => t.id === state.activeId)
+  const closed = state.tabs[i]
+  if (!closed) return { state, closedId: null }
+  const tabs = state.tabs.filter((t) => t.id !== closed.id)
+  const next = tabs[Math.max(0, i - 1)]
+  return {
+    state: { ...state, tabs, activeId: (next ?? tabs[0]).id },
+    closedId: closed.id,
+  }
+}
+
+/** Rename the active tab; empty/whitespace titles clear back to default. */
+export function renameActiveTab(state: TabsState, title: string): TabsState {
+  const trimmed = title.trim()
+  const tabs = state.tabs.map((t) =>
+    t.id === state.activeId ? { ...t, title: trimmed.length > 0 ? trimmed : null } : t,
+  )
+  return { ...state, tabs }
+}
+
+/** Cycle the active tab by ±1, wrapping at the ends. */
+export function cycleTab(state: TabsState, delta: 1 | -1): TabsState {
+  const n = state.tabs.length
+  if (n <= 1) return state
+  const i = state.tabs.findIndex((t) => t.id === state.activeId)
+  const next = state.tabs[(i + delta + n) % n]
+  return { ...state, activeId: next.id }
+}
+
+/** Registry key for one tab's PTY — namespaced so tabs never collide. */
+export function tabPtyKey(taskId: string, tabId: string): string {
+  return `${taskId}::${tabId}`
+}

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Why this matters: these transitions ARE the chattab contract carried
+ * into the PTY world (issue #16) — new-tab placement, the can't-close-last
+ * guard, left-neighbor focus on close, wrap-around cycling, and the
+ * never-reused registry key. A regression silently kills or orphans live
+ * engine PTYs (each tab id keys one).
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  addTab,
+  closeActiveTab,
+  cycleTab,
+  initialTabs,
+  renameActiveTab,
+  tabPtyKey,
+} from "../../src/tui/workspace/terminal-tabs-core"
+
+describe("terminal tabs state", () => {
+  it("starts with one untitled active tab", () => {
+    const s = initialTabs()
+    expect(s.tabs).toHaveLength(1)
+    expect(s.activeId).toBe("tab-1")
+    expect(s.tabs[0].title).toBeNull()
+  })
+
+  it("addTab inserts after the active tab, focuses it, never reuses ids", () => {
+    let s = addTab(initialTabs()) // [1, 2*]
+    s = cycleTab(s, -1) // [1*, 2]
+    s = addTab(s) // [1, 3*, 2]
+    expect(s.tabs.map((t) => t.ordinal)).toEqual([1, 3, 2])
+    expect(s.activeId).toBe("tab-3")
+    const { state: closed } = closeActiveTab(s)
+    const reAdded = addTab(closed)
+    expect(reAdded.tabs.some((t) => t.id === "tab-3")).toBe(false)
+    expect(reAdded.activeId).toBe("tab-4")
+  })
+
+  it("closeActiveTab focuses the left neighbor and refuses on the last tab", () => {
+    const s = addTab(addTab(initialTabs())) // [1, 2, 3*]
+    const first = closeActiveTab(s)
+    expect(first.closedId).toBe("tab-3")
+    expect(first.state.activeId).toBe("tab-2")
+    const second = closeActiveTab(first.state)
+    expect(second.state.activeId).toBe("tab-1")
+    const last = closeActiveTab(second.state)
+    expect(last.closedId).toBeNull()
+    expect(last.state).toBe(second.state)
+  })
+
+  it("closing the FIRST tab focuses the right neighbor", () => {
+    let s = addTab(initialTabs())
+    s = cycleTab(s, 1) // wraps to tab-1 ([1*, 2])
+    expect(s.activeId).toBe("tab-1")
+    const { state } = closeActiveTab(s)
+    expect(state.activeId).toBe("tab-2")
+  })
+
+  it("cycleTab wraps both directions and is a no-op with one tab", () => {
+    const s = addTab(initialTabs()) // [1, 2*]
+    expect(cycleTab(s, 1).activeId).toBe("tab-1")
+    expect(cycleTab(s, -1).activeId).toBe("tab-1")
+    expect(cycleTab(initialTabs(), 1).activeId).toBe("tab-1")
+  })
+
+  it("rename trims; blank clears back to the numbered default", () => {
+    let s = renameActiveTab(initialTabs(), "  build watch  ")
+    expect(s.tabs[0].title).toBe("build watch")
+    s = renameActiveTab(s, "   ")
+    expect(s.tabs[0].title).toBeNull()
+  })
+
+  it("tabPtyKey namespaces per task so tabs never collide across tasks", () => {
+    expect(tabPtyKey("task-a", "tab-1")).not.toBe(tabPtyKey("task-b", "tab-1"))
+    expect(tabPtyKey("task-a", "tab-1")).toBe("task-a::tab-1")
+  })
+})


### PR DESCRIPTION
## Summary
- The chattab concept lands in the PTY world: the KOBE_TUI center column gets a tab strip over the embedded terminal. ctrl+t opens a **parallel engine session** in the same worktree (each tab keys its own registry PTY as `taskId::tabId` — zero registry changes), ctrl+w closes with the can't-close-last guard, F2 renames through the real RenameTaskDialog, ctrl+]/[ cycle with wrap. All five reuse the canonical `chat.tab.*` binding ids.
- Those chords are added to `RESERVED_GLOBAL_CHORDS` so the strip wins them against the engine CLI — the same interception the tmux root key-table performed (ctrl+w's shell delete-word is deliberately sacrificed for parity, noted inline per KEYBINDINGS convention).
- Per-task tab state persists across task switches (module map), matching how tab PTYs already survive via acquire-reuse; pure tab transitions (insert-after-active, left-neighbor focus on close, id never reused, wrap cycling, blank-rename-resets) are vitest-pinned.
- `panes/terminal/CLAUDE.md` sheds its DORMANT framing — revival checklist recorded as complete (#249/#250 + this).

coverage-exemption: packages/kobe/src/tui/workspace/TerminalTabs.tsx — renderer-bound strip; transitions pinned via terminal-tabs-core tests, seam exercised by dev:mock-terminal.
coverage-exemption: packages/kobe/src/tui/workspace/host.tsx — renderer-bound host swap.
coverage-exemption: packages/kobe/src/tui/panes/terminal/keys-pure.ts — const-list addition; the reserved-chord contract is asserted in terminal-keys-pure.test.ts.

## Test plan
- [x] `bun run typecheck` + repo-root `bun run lint` clean
- [x] `bun run test` — fast 2431/2431 (+7 tab-core) + socket 218/218
- [x] `dev:mock-terminal` live PTY marker still renders