### PR TITLE
feat: task-scoped PTY teardown for the embedded terminal (issue #16)

### DIFF
--- a/.changeset/terminal-pty-lifecycle.md
+++ b/.changeset/terminal-pty-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Embedded-PTY lifecycle closes its loop (issue #16): archiving or deleting a task now releases every engine PTY its terminal tabs own (registry gains releaseWhere for task-scoped teardown), and quitting the KOBE_TUI workspace releases all of them — no orphan engine processes either way.

--- a/packages/kobe/src/tui/panes/terminal/registry.ts
+++ b/packages/kobe/src/tui/panes/terminal/registry.ts
@@ -109,6 +109,16 @@ export class PtyRegistry {
   }
 
   /**
+   * Kill and forget every PTY whose id matches `predicate` — the
+   * task-scoped teardown for tab-keyed PTYs (`taskId::tabId`, issue
+   * #16): archiving a task must end every engine session it owns.
+   */
+  releaseWhere(predicate: (id: string) => boolean): void {
+    const ids = Array.from(this.map.keys()).filter(predicate)
+    for (const id of ids) this.release(id)
+  }
+
+  /**
    * Kill every PTY and forget them all. Called on TUI teardown to
    * leave no orphan shell processes.
    */

--- a/packages/kobe/src/tui/workspace/host.tsx
+++ b/packages/kobe/src/tui/workspace/host.tsx
@@ -26,6 +26,7 @@ import { FileTree } from "../panes/filetree/FileTree"
 import { openExternally } from "../panes/filetree/open-external"
 import { Sidebar, type SidebarHover } from "../panes/sidebar/Sidebar"
 import { SidebarHoverTooltip } from "../panes/sidebar/hover-tooltip"
+import { getDefaultPtyRegistry } from "../panes/terminal/registry"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
 import { TerminalTabs } from "./TerminalTabs"
@@ -77,6 +78,22 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
       { defer: false },
     ),
   )
+
+  // PTY lifecycle (issue #16): archiving/deleting a task must end every
+  // engine session it owns — its tab PTYs are keyed `taskId::tabId` in the
+  // default registry, invisible to the pane once unmounted. Watch the task
+  // snapshot and release the corpses; the pane never kills (registry docs),
+  // so this is the one place tab shells die with their task.
+  let liveTaskIds = new Set<string>()
+  createEffect(() => {
+    const list = tasks()
+    const next = new Set<string>(list.filter((task) => !task.archived).map((task) => task.id))
+    const registry = getDefaultPtyRegistry()
+    for (const id of liveTaskIds) {
+      if (!next.has(id)) registry.releaseWhere((key) => key === id || key.startsWith(`${id}::`))
+    }
+    liveTaskIds = next
+  })
 
   function selectTask(id: string): void {
     setSelectedId(id)
@@ -255,7 +272,13 @@ export async function startWorkspaceHost(): Promise<void> {
       process.env.KOBE_DAEMON_SOCKET_PATH = client.socketPath
       return {
         root: () => <WorkspaceRoot orchestrator={orchestrator} />,
-        onDestroy: () => orchestrator.dispose(),
+        onDestroy: () => {
+          orchestrator.dispose()
+          // End every embedded engine/shell PTY with the app — the exit
+          // backstop only covers the host process; the PTY children are
+          // process-group members that must be killed explicitly.
+          getDefaultPtyRegistry().releaseAll()
+        },
       }
     },
   })

--- a/packages/kobe/test/tui/terminal-registry.test.ts
+++ b/packages/kobe/test/tui/terminal-registry.test.ts
@@ -106,3 +106,17 @@ describe("TaskPty onExit contract (mock backend)", () => {
     expect(fired).toBe(true)
   })
 })
+
+describe("releaseWhere (task-scoped teardown, issue #16)", () => {
+  it("kills exactly the matching task's tab PTYs and leaves the rest alive", () => {
+    const reg = new PtyRegistry(mockFactory)
+    const a1 = reg.acquire("task-a::tab-1", "/a")
+    const a2 = reg.acquire("task-a::tab-2", "/a")
+    const b1 = reg.acquire("task-b::tab-1", "/b")
+    reg.releaseWhere((id) => id.startsWith("task-a::"))
+    expect(a1.killed).toBe(true)
+    expect(a2.killed).toBe(true)
+    expect(b1.killed).toBe(false)
+    expect(reg.size).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Closes the embedded-PTY lifecycle loop: archiving or deleting a task now ends every engine session its terminal tabs own. The workspace host watches the task snapshot and releases `taskId::*` registry keys via the registry's new `releaseWhere`; quitting the workspace calls `releaseAll` on teardown — no orphan engine processes either way. The pane itself still never kills (single lifecycle owner: the host).

coverage-exemption: packages/kobe/src/tui/workspace/host.tsx — renderer-bound host; the release predicate + registry semantics are pinned in terminal-registry.test.ts.

## Test plan
- [x] `bun run typecheck` + repo-root lint clean
- [x] `bun run test:fast` 2432/2432 (+releaseWhere pin); socket suite unchanged
- [x] `dev:mock-terminal` live marker renders