### PR TITLE
feat: borderless terminal pane + maximal key passthrough (issue #16)

### DIFF
--- a/.changeset/terminal-passthrough.md
+++ b/.changeset/terminal-passthrough.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Embedded terminal input + chrome fixes (issue #16): the pane no longer draws its own border (the workspace layout wrapper owns the focus border — double borders gone), and key passthrough is now maximal — shift+tab (claude's plan-mode cycle), ctrl+hjkl, F1, ctrl+p and every other modifier combo reach the engine CLI. Kobe reserves only ctrl+q (escape hatch), the tab-management chords, and F5 while the terminal is focused; its other global chords stay reachable from every non-terminal pane.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -340,3 +340,25 @@ re-derive it.
 need protocol upgrades; modifiers other than ctrl get hijacked by user-space launchers. Pick a single-modifier ctrl+letter chord
 and accept that "this conflicts with shell editor commands" is acceptable when the binding's intent is to MOVE focus AWAY from
 the input that would consume it.
+
+## Embedded terminal passthrough (2026-07-06, issue #16)
+
+The terminal-in-the-middle center column forwards **maximal** input to the
+engine CLI. `RESERVED_GLOBAL_CHORDS`
+([`panes/terminal/keys-pure.ts`](../packages/kobe/src/tui/panes/terminal/keys-pure.ts))
+shrank to the minimum kobe cannot give up while the terminal is focused:
+
+| chord | owner |
+|---|---|
+| `ctrl+q` | THE escape hatch back to the tasks list (KOB-208) |
+| `ctrl+t` / `ctrl+w` / `ctrl+]` / `ctrl+[` / `F2` | terminal tab management (PTY chattab) |
+| `F5` | terminal reset (confirm-gated) |
+| `ctrl+pgup` / `ctrl+pgdn` | local scrollback (trapped, not reserved) |
+
+Everything else — `shift+tab` (claude plan-mode cycle), `ctrl+hjkl`, `F1`,
+`ctrl+p`, `ctrl+,`, `ctrl+r`, alt-combos — passes through to the engine.
+The pane registers modifier-variant passthrough bindings (`ctrl+`/`alt+`/
+`shift+` forms) so they WIN the LIFO stack against kobe's global bindings;
+kobe's globals stay reachable from every non-terminal pane. The pane also
+draws no border of its own — the workspace layout wrapper owns the focus
+border.

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -407,13 +407,9 @@ export function Terminal(props: TerminalProps): JSXElement {
   })
 
   return (
-    <box
-      flexDirection="column"
-      flexGrow={1}
-      overflow="hidden"
-      borderColor={focused() ? theme.focusAccent : theme.border}
-      onMouseUp={() => setFocusedLocal(true)}
-    >
+    // Borderless by design: the workspace layout wrapper owns the focus
+    // border (double borders otherwise); this pane is pure content.
+    <box flexDirection="column" flexGrow={1} overflow="hidden" onMouseUp={() => setFocusedLocal(true)}>
       {/* Scroll affordance — only rendered when the user has scrolled
           back into history. Replaces what used to be a permanent
           worktree-id header row; that row was redundant with the

--- a/packages/kobe/src/tui/panes/terminal/keys-pure.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys-pure.ts
@@ -25,6 +25,15 @@ export function keyEventToShellBytes(evt: KeyEvent): string | null {
   const name = evt.name
   if (!name) return null
 
+  // Modifier synthesis for synthetic events (real keystrokes carry
+  // `sequence`): shift+tab is the back-tab CSI claude's plan-mode cycle
+  // expects; alt+<key> is ESC-prefixed per xterm convention.
+  if (evt.shift && name === "tab") return "\x1b[Z"
+  if (evt.option || evt.meta) {
+    const inner = keyEventToShellBytes({ ...evt, option: false, meta: false } as KeyEvent)
+    return inner == null ? null : `\x1b${inner}`
+  }
+
   switch (name) {
     case "return":
     case "enter":
@@ -78,11 +87,12 @@ export const DEFAULT_PAGE_SIZE = 10
 export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown"] as const
 
 /**
- * Chord strings the terminal pane must NEVER passthrough to the shell —
- * these are kobe's global escape hatches and have to win against the
- * pane-local PTY forwarder. Without this list, ctrl+hjkl/shift+tab/F1/
- * palette chords get consumed as shell input and the user is trapped
- * inside the terminal pane with no way back to the tasks list.
+ * Chord strings the terminal pane must NEVER passthrough to the shell.
+ * Deliberately MINIMAL (owner decision 2026-07-06): the engine CLI owns
+ * its own chords (shift+tab plan-mode, ctrl+r history, ctrl+hjkl, F1…),
+ * so kobe keeps only ctrl+q as the escape hatch plus the tab-management
+ * and reset chords. Kobe's other global chords stay reachable from every
+ * non-terminal pane.
  *
  * Notes on what's *not* here:
  *   - bare `escape` and `tab` stay as passthrough so vim and shell tab
@@ -91,43 +101,21 @@ export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown"] as const
  *     same bindings array (scrollback) — first-match-wins handles them.
  */
 export const RESERVED_GLOBAL_CHORDS: readonly string[] = [
-  // Pane focus (focus.numeric) — primary escape hatch out of the terminal.
-  "ctrl+h",
-  "ctrl+j",
-  "ctrl+k",
-  "ctrl+l",
-  // Pane cycle (focus.prev). focus.next is bare `tab` and stays passthrough
-  // so shell completion works; users get out via shift+tab or ctrl+hjkl.
-  "shift+tab",
-  // Workspace → sidebar jump (app-keymap WORKSPACE_SCOPED). When the chat
-  // content pane runs interactive `claude` it is focused as `workspace`,
-  // and `ctrl+q` is the user's way back to the tasks list. Without
-  // reserving it the pane forwarder sent `\x11` (XON) to claude and the
-  // global jump never fired (KOB-208 interactive mode).
+  // THE escape hatch out of the terminal (KOB-208): from anywhere inside
+  // the engine CLI, ctrl+q returns to the tasks list. Everything else the
+  // engine may want (shift+tab plan-mode, ctrl+hjkl, f1, ctrl+p, ctrl+,)
+  // now PASSES THROUGH — owner decision 2026-07-06: kobe must not eat the
+  // engine's own chords; kobe-global chords remain available from every
+  // other pane.
   "ctrl+q",
-  // Terminal tab chords (workspace chattab, issue #16) — the strip must
-  // win these against the engine CLI, same interception the tmux root
-  // key-table performed. ctrl+w costs shells their delete-word and F2 is
-  // rebindable per docs/KEYBINDINGS.md; parity with the tmux chattab wins.
+  // Terminal tab management (the PTY chattab, issue #16) — parity with the
+  // tmux root key-table which also intercepted these.
   "ctrl+t",
   "ctrl+w",
   "ctrl+]",
   "ctrl+[",
   "f2",
-  // Help / palette / settings.
-  "f1",
-  "ctrl+p",
-  "ctrl+,",
-  // Terminal reset — `F5` kills the current shell and respawns at the
-  // worktree. Earlier passes tried `alt+r` (eaten by opentui's native
-  // debug-overlay handler) and `ctrl+shift+r` (Windows Terminal and
-  // most legacy emulators do NOT distinguish `ctrl+shift+letter` from
-  // `ctrl+letter` at the byte level — kobe receives `ctrl+r` and the
-  // shell sees `\x12`, kicking off readline's reverse-i-search).
-  // F-keys are sent as their own escape sequences (`\x1bOP` /
-  // `\x1b[15~` for F5) so they're unambiguous regardless of modifier
-  // distinguishing capability, and the browser-refresh mnemonic
-  // matches the "reset / restart" intent.
+  // Terminal reset (confirm-gated).
   "f5",
 ] as const
 

--- a/packages/kobe/src/tui/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys.ts
@@ -107,25 +107,21 @@ export function useTerminalBindings(opts: TerminalBindingsOpts): void {
   )
 
   const reserved = new Set<string>(RESERVED_GLOBAL_CHORDS)
+  const forward = (evt: KeyEvent): void => {
+    const bytes = keyEventToShellBytes(evt)
+    if (bytes != null) opts.write(bytes)
+  }
   for (const name of PASSTHROUGH_NAMES) {
-    if (!reserved.has(name)) {
-      bindings.push({
-        key: name,
-        cmd: (evt) => {
-          const bytes = keyEventToShellBytes(evt)
-          if (bytes != null) opts.write(bytes)
-        },
-      })
-    }
-    const ctrlChord = `ctrl+${name}`
-    if (!reserved.has(ctrlChord)) {
-      bindings.push({
-        key: ctrlChord,
-        cmd: (evt) => {
-          const bytes = keyEventToShellBytes(evt)
-          if (bytes != null) opts.write(bytes)
-        },
-      })
+    // Register the bare name plus every modifier form the keymap can mint
+    // (ctrl+/alt+/shift+/meta combos) — modifier chords must WIN the LIFO
+    // stack against kobe's global bindings so the engine CLI receives its
+    // own shortcuts (shift+tab plan-mode, alt+enter, ctrl+r history…).
+    // Shift on printable characters never minted a chord (terminals send
+    // the shifted glyph), so shift+ registrations only matter for named keys.
+    for (const prefix of ["", "ctrl+", "alt+", "shift+", "ctrl+shift+", "alt+shift+", "ctrl+alt+"]) {
+      const chord = `${prefix}${name}`
+      if (reserved.has(chord)) continue
+      bindings.push({ key: chord, cmd: forward })
     }
   }
 

--- a/packages/kobe/test/tui/terminal-keys-pure.test.ts
+++ b/packages/kobe/test/tui/terminal-keys-pure.test.ts
@@ -49,18 +49,27 @@ describe("keyEventToShellBytes", () => {
 })
 
 describe("key routing tables", () => {
-  it("keeps every escape hatch reserved (first-match beats passthrough)", () => {
+  it("reserves ONLY the minimal kobe chords; the engine owns the rest", () => {
     expect(TRAPPED_KEYS).toEqual(["ctrl+pageup", "ctrl+pagedown"])
-    // The primary escape hatches stay reserved — losing any of these traps
-    // the user inside the engine CLI. (F-keys deliberately ALSO appear in
-    // PASSTHROUGH_NAMES: reservation wins by binding order, not disjointness.)
-    for (const chord of ["ctrl+h", "ctrl+j", "ctrl+k", "ctrl+l", "ctrl+q", "f1", "f5", "ctrl+p", "shift+tab"]) {
-      expect(RESERVED_GLOBAL_CHORDS).toContain(chord)
+    // Owner decision 2026-07-06: ctrl+q escape hatch + tab management +
+    // reset. Anything beyond this list steals a chord from the engine CLI.
+    expect([...RESERVED_GLOBAL_CHORDS].sort()).toEqual(
+      ["ctrl+[", "ctrl+]", "ctrl+q", "ctrl+t", "ctrl+w", "f2", "f5"].sort(),
+    )
+    // Chords the engine depends on must NOT be reserved (shift+tab is
+    // claude's plan-mode cycle; the rest are its own UI shortcuts).
+    for (const chord of ["shift+tab", "ctrl+h", "ctrl+p", "f1", "ctrl+r"]) {
+      expect(RESERVED_GLOBAL_CHORDS).not.toContain(chord)
     }
     // Plain typing keys must stay forwardable.
     for (const name of ["a", "Z", "0", " ", "return", "escape", "tab"]) {
       expect(PASSTHROUGH_NAMES).toContain(name)
     }
     expect(DEFAULT_PAGE_SIZE).toBeGreaterThan(0)
+  })
+
+  it("synthesizes modifier bytes for synthetic events", () => {
+    expect(keyEventToShellBytes(evt({ name: "tab", shift: true }))).toBe("\x1b[Z")
+    expect(keyEventToShellBytes(evt({ name: "b", option: true } as never))).toBe("\x1bb")
   })
 })


### PR DESCRIPTION
## Summary
- **Borderless pane**: the embedded terminal drew its own focus border INSIDE the workspace wrapper's border (doubled chrome). The pane is pure content now; the layout wrapper owns the border — per owner feedback from hands-on testing.
- **Maximal passthrough** (owner decision): `RESERVED_GLOBAL_CHORDS` shrinks to the minimum kobe cannot give up while the terminal is focused — `ctrl+q` (THE escape hatch), the five tab-management chords, `F5` reset. Everything else now reaches the engine CLI: `shift+tab` (claude's plan-mode cycle), `ctrl+hjkl`, `F1`, `ctrl+p`, `ctrl+,`, `ctrl+r`, alt combos. The pane registers modifier-variant passthrough bindings (ctrl+/alt+/shift+ forms) so they win the LIFO stack against kobe's globals, which stay reachable from every non-terminal pane; byte synthesis added for shift+tab (`ESC[Z`) and ESC-prefixed alt.
- Contract pinned: reserved list asserted EXACTLY in tests (any future addition must consciously edit the pin), decision recorded in docs/KEYBINDINGS.md.

coverage-exemption: packages/kobe/src/tui/panes/terminal/Terminal.tsx — renderer-bound pane; dev:mock-terminal gate.
coverage-exemption: packages/kobe/src/tui/panes/terminal/keys.ts — Solid hook layer; the pure contract is fully pinned in terminal-keys-pure.test.ts.

## Test plan
- [x] `bun run typecheck` + repo-root lint clean
- [x] `bun run test:fast` 2433/2433 (reserved-list pin updated to the new minimal contract + modifier synthesis cases)
- [x] `dev:mock-terminal` live PTY marker renders (borderless)