### PR TITLE
feat: forward paste into the embedded terminal (issue #16)

### DIFF
--- a/.changeset/terminal-paste.md
+++ b/.changeset/terminal-paste.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Paste reaches the embedded engine CLI (issue #16): opentui's parsed paste events forward to the PTY, and the Bun backend re-wraps them in bracketed-paste markers exactly when the embedded app negotiated DECSET 2004 — a multiline prompt pasted into claude lands as one paste instead of executing line by line.

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -259,6 +259,11 @@ export function Terminal(props: TerminalProps): JSXElement {
       if (!handle || handle.killed) return
       handle.write(data)
     },
+    paste: (text) => {
+      const handle = pty()
+      if (!handle || handle.killed) return
+      handle.paste(text)
+    },
     scroll: (lines) => {
       setScrollOffset((cur) => Math.max(0, cur - lines))
       // (negative `lines` moves up = increases the offset toward

--- a/packages/kobe/src/tui/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys.ts
@@ -61,6 +61,8 @@ export type TerminalBindingsOpts = {
   focused: Accessor<boolean>
   /** Forward a byte sequence to the underlying PTY. */
   write: (data: string) => void
+  /** Deliver pasted text (backend applies bracketed-paste wrapping). */
+  paste: (text: string) => void
   /** Scroll the local scrollback view by N lines (negative = up). */
   scroll: (lines: number) => void
   /** How many lines `ctrl+pgup`/`ctrl+pgdown` move per press. */
@@ -160,7 +162,20 @@ export function useTerminalBindings(opts: TerminalBindingsOpts): void {
     evt.preventDefault()
   }
   renderer.keyInput.on("keypress", forwardUnhandled)
+  // Paste forwarding: opentui parses the host terminal's bracketed paste
+  // into a PasteEvent; re-deliver it to the PTY (the backend re-wraps in
+  // 200~/201~ iff the embedded app negotiated DECSET 2004). Without this,
+  // pasting into the embedded engine CLI silently dropped.
+  const forwardPaste = (evt: { bytes: Uint8Array; defaultPrevented: boolean; preventDefault(): void }) => {
+    if (!opts.focused() || evt.defaultPrevented) return
+    const text = new TextDecoder().decode(evt.bytes)
+    if (text.length === 0) return
+    opts.paste(text)
+    evt.preventDefault()
+  }
+  renderer.keyInput.on("paste", forwardPaste)
   onCleanup(() => {
     renderer.keyInput.off("keypress", forwardUnhandled)
+    renderer.keyInput.off("paste", forwardPaste)
   })
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-mock.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-mock.ts
@@ -17,6 +17,8 @@ export class MockTaskPty implements TaskPtyLike {
   private writes: string[] = []
   private _killed = false
   private readonly exitListeners = new Set<() => void>()
+  /** Pasted payloads, observable by tests. */
+  readonly pastes: string[] = []
   private _cols: number
   private _rows: number
   private _cursor: CursorPos | null = null
@@ -100,6 +102,11 @@ export class MockTaskPty implements TaskPtyLike {
     const exitCbs = [...this.exitListeners]
     this.exitListeners.clear()
     for (const cb of exitCbs) cb()
+  }
+
+  paste(text: string): void {
+    if (this._killed) return
+    this.pastes.push(text)
   }
 
   onExit(cb: () => void): () => void {

--- a/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
@@ -154,6 +154,11 @@ export class PipeTaskPty implements TaskPtyLike {
     }
   }
 
+  paste(text: string): void {
+    // Pipes have no bracketed-paste negotiation — deliver raw.
+    this.write(text)
+  }
+
   onExit(cb: () => void): () => void {
     if (this._killed) {
       cb()

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -39,6 +39,13 @@ export interface TaskPtyLike {
   readonly killed: boolean
 
   write(data: string): void
+  /**
+   * Deliver pasted text. Backends that can see the app's DECSET 2004
+   * state wrap it in bracketed-paste markers when (and only when) the
+   * app asked for them — pasting a multiline prompt into an engine CLI
+   * must not execute line-by-line.
+   */
+  paste(text: string): void
   onData(cb: DataListener): () => void
   /**
    * Notify once when the underlying process ends for ANY reason (its own

--- a/packages/kobe/src/tui/panes/terminal/pty.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty.ts
@@ -135,6 +135,17 @@ export class BunTerminalTaskPty implements TaskPtyLike {
     }
   }
 
+  paste(text: string): void {
+    if (this._killed || text.length === 0) return
+    let bracketed = false
+    try {
+      bracketed = this.term.modes.bracketedPasteMode === true
+    } catch {
+      /* mode probe is best-effort */
+    }
+    this.write(bracketed ? `\x1b[200~${text}\x1b[201~` : text)
+  }
+
   onData(cb: DataListener): () => void {
     this.listeners.add(cb)
     if (this.snapshot.length > 0) {

--- a/packages/kobe/test/tui/terminal-registry.test.ts
+++ b/packages/kobe/test/tui/terminal-registry.test.ts
@@ -120,3 +120,14 @@ describe("releaseWhere (task-scoped teardown, issue #16)", () => {
     expect(reg.size).toBe(1)
   })
 })
+
+describe("paste contract (mock backend)", () => {
+  it("records pastes while alive and drops them once dead", () => {
+    const pty = new MockTaskPty({ taskId: "t", cwd: "/" })
+    pty.paste("multi\nline prompt")
+    expect(pty.pastes).toEqual(["multi\nline prompt"])
+    pty.kill()
+    pty.paste("late")
+    expect(pty.pastes).toEqual(["multi\nline prompt"])
+  })
+})


### PR DESCRIPTION
## Summary
- Pasting into the embedded engine CLI previously dropped silently — opentui parses the host terminal's bracketed paste into `PasteEvent`s that never reached the PTY. The pane now forwards them (focused + not default-prevented), and the Bun backend re-wraps the text in `200~/201~` markers **iff** the embedded app negotiated DECSET 2004 (`@xterm/headless` tracks the mode) — so a multiline prompt lands in claude's composer as one paste instead of executing line by line. Pipe backend delivers raw; mock records pastes for tests.

coverage-exemption: packages/kobe/src/tui/panes/terminal/keys.ts — Solid hook layer; paste contract pinned via the mock backend test.
coverage-exemption: packages/kobe/src/tui/panes/terminal/pty.ts — Bun PTY backend, renderer/PTY-bound; mode-gated wrapping exercised live by dev:mock-terminal.

## Test plan
- [x] `bun run typecheck` + repo-root lint clean
- [x] `bun run test:fast` green (+paste contract pin)
- [x] `dev:mock-terminal` live marker renders

coverage-exemption: packages/kobe/src/tui/panes/terminal/pty-pipe.ts — subprocess pipe fallback backend (spawns real children); paste() delegates to the tested write path, contract pinned via the mock backend.
