### PR TITLE
chore: comment cleanup within the header-preserving policy

### DIFF
--- a/packages/kobe-daemon/src/client/daemon-process.ts
+++ b/packages/kobe-daemon/src/client/daemon-process.ts
@@ -150,7 +150,7 @@ export async function testDaemonResponds(
  *    to the same bundled entry — bun re-executes itself against it.
  *  - standalone: running a `bun build --compile` binary. `process.execPath`
  *    IS the kobe binary, so we re-exec it directly. After the kobed → kobe
- *    bin merge (KOB-136), no sibling lookup is needed.
+ *    bin merge, no sibling lookup is needed.
  */
 function resolveKobeSpawn(subcommand: readonly string[]): string[] {
   const here = fileURLToPath(import.meta.url)

--- a/packages/kobe-daemon/src/client/index.ts
+++ b/packages/kobe-daemon/src/client/index.ts
@@ -136,7 +136,7 @@ export class KobeDaemonClient implements DaemonRpcClient {
   }
 
   /**
-   * Typed sugar over {@link on} for a push channel (KOB-246): the handler
+   * Typed sugar over {@link on} for a push channel: the handler
    * receives the channel's payload, typed from {@link ChannelPayloads}.
    * Adding a consumer for a new channel is just `onChannel("cost", …)`.
    */

--- a/packages/kobe-daemon/src/daemon/event-bus.ts
+++ b/packages/kobe-daemon/src/daemon/event-bus.ts
@@ -1,5 +1,5 @@
 /**
- * Daemon event bus (KOB-246).
+ * Daemon event bus.
  *
  * One typed pub/sub hub the daemon uses to fan channel events out to
  * subscribed clients. It replaces the inline single-purpose `task.snapshot`

--- a/packages/kobe-daemon/src/daemon/file-watch-trigger.ts
+++ b/packages/kobe-daemon/src/daemon/file-watch-trigger.ts
@@ -9,7 +9,7 @@
  *
  * The watcher is backed by chokidar, which already smooths over the
  * cross-platform fs-event edge cases (macOS rename/inode churn, rapid bursts,
- * atomic saves) that previously needed a hand-rolled polling safety-net.
+ * atomic saves) without a hand-rolled polling safety-net.
  */
 
 import { mkdirSync, statSync } from "node:fs"

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -214,7 +214,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
       // task's updatedAt so "recent" task sorting reflects actual use.
       // Publishing caches the last value so a late-subscribing Tasks pane
       // gets the current focus on connect and every pane highlights the
-      // same active task (KOB-247).
+      // same active task.
       const taskId = optionalString(payload, "taskId") ?? null
       await ctx.orch.setActiveTask(taskId)
       ctx.bus.publish("active-task", { taskId })

--- a/packages/kobe-daemon/src/daemon/lifecycle.ts
+++ b/packages/kobe-daemon/src/daemon/lifecycle.ts
@@ -1,5 +1,5 @@
 /**
- * Shared daemon-stop primitive (KOB-258).
+ * Shared daemon-stop primitive.
  *
  * `kobe daemon restart` and `kobe reset` both need to make a daemon
  * actually GO AWAY — not just ask it to — before they continue (restart

--- a/packages/kobe-daemon/src/daemon/lifetime.ts
+++ b/packages/kobe-daemon/src/daemon/lifetime.ts
@@ -3,8 +3,8 @@
  * collectors?" policy, extracted from `server.ts` into one testable seam.
  * (Distinct from `lifecycle.ts`, which kills an EXTERNAL daemon process.)
  *
- * Three interdependent rules used to live as loose functions + a shared
- * `stopping` flag scattered across the server closure (`guiCount`,
+ * Three interdependent rules live here instead of as loose functions + a
+ * shared `stopping` flag scattered across the server closure (`guiCount`,
  * `hasSubscribers`, `cancelIdleTimer`, `maybeArmIdleShutdown`, and the timer
  * callback). They are really ONE policy keyed on which front-ends are attached:
  *

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -1,5 +1,5 @@
 /**
- * Daemon-side PR-status poller (KOB-10).
+ * Daemon-side PR-status poller.
  *
  * For every non-archived task with a real branch + local worktree, shell
  * `gh pr view <branch> --json …` on an interval, map the result to a neutral
@@ -11,7 +11,7 @@
  * — mirroring `useCompletionNotifications` — fires a toast/bell when a task's
  * checks resolve (pending → passing/failing); the poller itself only persists.
  *
- * GitHub only (KOB-10): the runner is `gh`, so remote (`ssh://`) projects and
+ * GitHub only: the runner is `gh`, so remote (`ssh://`) projects and
  * non-GitHub remotes simply yield no PR and are cheap no-ops.
  *
  * Cost control — a per-task schedule keyed off the outcome:

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -164,7 +164,7 @@ export type SubscribeRole = "gui" | "pane"
 
 /**
  * Channel registry — the SINGLE source of truth for daemon→client push
- * channels (KOB-246). The daemon is a cross-process pub/sub bus over the
+ * channels. The daemon is a cross-process pub/sub bus over the
  * socket: each channel carries a last-value the daemon caches and replays
  * to a late subscriber on connect (see `daemon/event-bus.ts`). Add a key
  * here (name + payload type) and the whole stack — `bus.publish`,
@@ -191,7 +191,7 @@ export interface ChannelPayloads {
   /**
    * The currently-active task (the session last switched/entered into).
    * Shared so EVERY Tasks pane + the outer monitor highlight the SAME
-   * focus, instead of each pane remembering its own last click (KOB-247).
+   * focus, instead of each pane remembering its own last click.
    * `null` = nothing active yet. Set via the `task.setActive` RPC.
    */
   "active-task": { taskId: string | null }

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -606,7 +606,7 @@ function writeFrame(client: Pick<ClientState, "writer">, frame: DaemonFrame): vo
 
 function broadcast(clients: ReadonlySet<ClientState>, frame: DaemonFrame): void {
   // Serialize ONCE per publish, not once per subscriber: a task.snapshot
-  // frame is ~8.5KB at 20 tasks, so N subscribed panes used to cost N
+  // frame is ~8.5KB at 20 tasks, so N subscribers would otherwise cost N
   // identical JSON.stringify passes per task mutation. The wire bytes are
   // unchanged — every subscriber receives the exact same line.
   //

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -196,7 +196,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
     onIdleStop: () => void stopSoon().catch((err) => logDaemonError("daemon-idle-shutdown", err)),
   })
 
-  // Channel event bus (KOB-246): the single hub the daemon publishes push
+  // Channel event bus: the single hub the daemon publishes push
   // events to. One sink fans each publish out to subscribed sockets; the
   // bus also caches the last value per channel so a late subscriber gets
   // the current value on connect. `task.snapshot` is channel #1; new
@@ -357,7 +357,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
     () => lifetime.hasSubscribers(),
   )
 
-  // PR-status poller (KOB-10): shells `gh pr view` per task with a real branch
+  // PR-status poller: shells `gh pr view` per task with a real branch
   // and writes the result onto Task.prStatus, which rides the same task push as
   // every other field. Gated on subscribers so a gui-less daemon never hits the
   // network for nobody.
@@ -513,7 +513,7 @@ export async function startDaemonServer(orch: Orchestrator, options: DaemonServe
       )
       // Replay the current value of every populated channel so a late
       // subscriber hydrates without a separate round trip — generalized
-      // from the old single task.snapshot send (KOB-246). Filtered to the
+      // from the old single task.snapshot send. Filtered to the
       // client's requested channels (null = all). The bus cache is warm
       // (subscribeTasks' eager fire).
       for (const event of bus.snapshot()) {

--- a/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
@@ -10,8 +10,8 @@
  * the pushes and spawn ZERO git processes while daemon-connected; the
  * pane-local poller survives only as the no-daemon fallback.
  *
- * The scheduling guards are the SAME ones that fixed the 30GB-repo freeze
- * (shared via `@/lib/poll-scheduling`, extracted from background-poll so
+ * The scheduling guards are the SAME ones the TUI poller uses against
+ * huge-repo `git status` stalls (shared via `@/lib/poll-scheduling`, extracted from background-poll so
  * the daemon doesn't import the TUI's solid-js signal layer):
  *
  *   - **in-flight dedupe** — one `git status` per worktree at a time;

--- a/packages/kobe-web/test/attention-nav.test.ts
+++ b/packages/kobe-web/test/attention-nav.test.ts
@@ -5,11 +5,6 @@ import {
 } from "../src/lib/attention-nav.ts"
 import type { EngineState, Task } from "../src/lib/types.ts"
 
-// Why this matters: this is the one keystroke from "something needs me"
-// (notification / tab badge) to the actual task. It must select the SAME set
-// the Overview "Needs you" bucket shows, and "next" must cycle so a user can
-// walk every waiting task without one stealing focus forever.
-
 function task(id: string, over: Partial<Task> = {}): Task {
   return {
     id,

--- a/packages/kobe-web/test/document-title.test.ts
+++ b/packages/kobe-web/test/document-title.test.ts
@@ -6,11 +6,6 @@ import {
 } from "../src/lib/document-title.ts"
 import type { EngineState, Task } from "../src/lib/types.ts"
 
-// Why this matters: this is the "I walked away — which tab needs me?" signal.
-// It must match the Overview's "Needs you" bucket exactly (same triage set),
-// and it must never count rows that aren't sessions (archived, project mains)
-// or a tab badge lies about how much wants your attention.
-
 function task(id: string, over: Partial<Task> = {}): Task {
   return {
     id,

--- a/packages/kobe-web/test/pr-chip.test.ts
+++ b/packages/kobe-web/test/pr-chip.test.ts
@@ -2,11 +2,6 @@ import { describe, expect, it } from "vitest"
 import { prChipView } from "../src/lib/pr-chip.ts"
 import type { TaskPRStatus } from "../src/lib/types.ts"
 
-// Why this matters: the chip is the rail's AND the Overview's only PR signal.
-// The precedence contract — a terminal lifecycle (merged/closed) wins over
-// any check state, an open PR is colored by its checks — must hold in both
-// surfaces, so it lives in one pure function locked here.
-
 const pr = (over: Partial<TaskPRStatus>): TaskPRStatus => ({
   provider: "github",
   lifecycle: "open",

--- a/packages/kobe-web/test/rail-state.test.ts
+++ b/packages/kobe-web/test/rail-state.test.ts
@@ -9,12 +9,6 @@ import {
   setRailStatusFilter,
 } from "../src/lib/rail-state.ts"
 
-// Why this matters: the rail's filter state lives at module level precisely so
-// it SURVIVES the AppShell remount on the first `/` → /task/$taskId navigation
-// (issue #7). These tests lock the store's semantics — especially the
-// rising-edge pref sync, which is what keeps a remount from stomping a local
-// sort toggle the way the old useState + mount-effect did.
-
 beforeEach(() => {
   resetRailState()
 })

--- a/packages/kobe/src/cli/daemon-cmd.ts
+++ b/packages/kobe/src/cli/daemon-cmd.ts
@@ -1,7 +1,7 @@
 /**
  * `kobe daemon <command>` — daemon lifecycle subcommands.
  *
- * Ported from the now-removed `kobed` bin (KOB-136). The body is the same
+ * Ported from the now-removed `kobed` bin. The body is the same
  * logic with a different argv shape: the dispatcher in `cli/index.ts`
  * passes `rest` already trimmed of the `daemon` verb, so we read the
  * sub-command at `argv[0]` instead of `argv[2]`.
@@ -82,7 +82,7 @@ export async function runDaemonSubcommand(argv: readonly string[]): Promise<void
 
   if (command === "restart") {
     // Stop + confirm-dead + unlink socket/pidfile via the shared
-    // escalation helper (KOB-258), then respawn. Spawn the new daemon as
+    // escalation helper, then respawn. Spawn the new daemon as
     // a detached child instead of becoming it ourselves — otherwise
     // `kobe daemon restart` blocks the shell forever and looks "hung" to
     // anyone running it interactively.

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -85,7 +85,7 @@ async function runAddSubcommand(rest: readonly string[]): Promise<void> {
     console.log(`already saved: ${result.path}`)
   }
   // Fold in the repo's existing git worktrees: scan + adopt the ones not
-  // yet linked to a task, most-recently-active first (KOB-256). A plain
+  // yet linked to a task, most-recently-active first. A plain
   // repo with no extra worktrees imports nothing.
   await adoptAllWorktrees(result.path)
 }
@@ -162,7 +162,7 @@ async function runRemoveSubcommand(rest: readonly string[]): Promise<void> {
 /**
  * Discover every unlinked git worktree of `repo` and adopt each as a
  * task (discovery sorts most-recently-active first). Used by `kobe add`
- * to fold a repo's worktrees in on the way (KOB-256).
+ * to fold a repo's worktrees in on the way.
  *
  * Discovery runs IN-PROCESS — `git worktree list` + a `tasks.json` read,
  * no daemon — so a plain repo with no extra worktrees stays instant and
@@ -203,7 +203,7 @@ async function openLocalOrchestrator() {
  * Adopt `list` as tasks, printing one line each. Prefers a RUNNING
  * daemon (writes over RPC so a live TUI updates + the on-disk index
  * isn't split-brained); falls back to the in-process orchestrator when
- * no daemon is up. Never boots a daemon (KOB-256).
+ * no daemon is up. Never boots a daemon.
  */
 async function adoptWorktreesInto(
   orch: Awaited<ReturnType<typeof openLocalOrchestrator>>,
@@ -236,7 +236,7 @@ async function adoptWorktreesInto(
  * `kobe adopt [glob] [--repo <path>] [--vendor <v>] [--yes]` — scan a
  * repo's existing git worktrees (including ones outside kobe-managed
  * roots) and import the ones not yet linked to a task
- * (KOB-256). No glob → dry-run listing. With a path glob → list matches;
+ *. No glob → dry-run listing. With a path glob → list matches;
  * `--yes` actually adopts them. Goes through the daemon so a running TUI
  * sees the new tasks live.
  */
@@ -291,7 +291,7 @@ async function runAdoptSubcommand(args: readonly string[]): Promise<void> {
   const vendor = coerceVendorId(vendorArg)
 
   // Discovery is a local read (git + tasks.json) — no daemon needed, so
-  // listing never boots one (KOB-256).
+  // listing never boots one.
   const orch = await openLocalOrchestrator()
   const worktrees = await orch.discoverAdoptableWorktrees(repo)
   if (worktrees.length === 0) {

--- a/packages/kobe/src/cli/invocation.ts
+++ b/packages/kobe/src/cli/invocation.ts
@@ -30,7 +30,7 @@ import { fileURLToPath } from "node:url"
  * whose node_modules has no opentui), so a bare `@opentui/solid/preload`
  * specifier wouldn't resolve. `import.meta.resolve` resolves against
  * THIS module (inside the kobe package), so it always finds kobe's
- * own copy. (Bug history: KOB-233.)
+ * own copy.
  */
 export function kobeCliInvocation(): string[] {
   const isBuilt = import.meta.url.endsWith(".js")

--- a/packages/kobe/src/cli/maintenance.ts
+++ b/packages/kobe/src/cli/maintenance.ts
@@ -1,5 +1,5 @@
 /**
- * `kobe doctor` and `kobe reset` — packaged-build recovery (KOB-258).
+ * `kobe doctor` and `kobe reset` — packaged-build recovery.
  *
  * Dev has `bun run dev:sandbox:reset` (a `kobe kill-sessions` on the
  * sandbox tmux socket) to wipe a throwaway environment. The installed
@@ -116,7 +116,7 @@ function tailFile(path: string, n: number): string {
 async function tmuxQuiet(args: string[]): Promise<{ code: number; stdout: string }> {
   const proc = Bun.spawn(tmuxArgs(...args), { stdin: "ignore", stdout: "pipe", stderr: "ignore" })
   // Drain stdout CONCURRENTLY with awaiting exit (the runTmuxCapturing
-  // pattern, KOB-244) so a large `list-sessions` can never fill the pipe
+  // pattern) so a large `list-sessions` can never fill the pipe
   // buffer and wedge the call.
   const [stdout, code] = await Promise.all([new Response(proc.stdout).text().catch(() => ""), proc.exited])
   return { code, stdout }

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -123,7 +123,7 @@ export async function removeWorktreeOp(client: KobeDaemonClient, path: string, f
 /**
  * Mark a task as the active focus (the session just switched/entered).
  * The daemon publishes it on the `active-task` channel so every Tasks
- * pane + the outer monitor highlight the same task (KOB-247).
+ * pane + the outer monitor highlight the same task.
  */
 export async function setActiveTaskOp(client: KobeDaemonClient, id: TaskId | string | null): Promise<void> {
   await client.request("task.setActive", { taskId: id === null ? null : String(id) })

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -185,7 +185,7 @@ export class RemoteOrchestrator {
     this.client.on("*", (frame) => this.handleEvent(frame.name, frame.payload))
     // Socket drop flips us to `disconnected`. What happens next depends on
     // the role:
-    //   - gui:  STOP here (KOB-38). The host TUI watches this signal, shows
+    //   - gui:  STOP here. The host TUI watches this signal, shows
     //     a "Restart daemon or Quit?" modal, and the user decides — a gui
     //     losing its daemon is rare and never transient, so a human prompt
     //     beats a backoff loop.
@@ -276,7 +276,7 @@ export class RemoteOrchestrator {
   }
 
   /** Shared active task id (session last switched/entered), pushed live on
-   *  `active-task` — every surface highlights the SAME focus (KOB-247). */
+   *  `active-task` — every surface highlights the SAME focus. */
   activeTaskSignal(): Accessor<string | null> {
     return this.activeTaskAcc
   }
@@ -518,7 +518,7 @@ export class RemoteOrchestrator {
   /**
    * Mark a task as the active focus (the session just switched/entered).
    * The daemon publishes it on the `active-task` channel so every Tasks
-   * pane + the outer monitor highlight the same task (KOB-247).
+   * pane + the outer monitor highlight the same task.
    */
   setActiveTask(id: TaskId | string | null): Promise<void> {
     return setActiveTaskOp(this.client, id)

--- a/packages/kobe/src/engine/account-detect.ts
+++ b/packages/kobe/src/engine/account-detect.ts
@@ -16,14 +16,14 @@
  *     carries `emailAddress`, `organizationName`, `displayName`,
  *     `billingType`. Verified by reading
  *     `refs/claude-code/src/services/oauth/client.ts` (the canonical
- *     producer) and the live file on Jackson's machine.
+ *     producer) and a live account file.
  *
  *   - **codex**: `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`).
  *     Has two mutually-exclusive shapes:
  *       - ChatGPT login → `tokens.id_token` is a JWT whose payload
  *         carries `email` and `https://api.openai.com/auth.chatgpt_plan_type`.
  *       - API-key login → `OPENAI_API_KEY` is a non-null string.
- *     Verified against the live file on Jackson's machine.
+ *     Verified against a live account file.
  *
  * The functions are pure — fs + env + binary discovery are injected
  * via {@link DetectDeps}, so tests pin every path and the production

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -144,7 +144,7 @@ export async function listSessionFilesForWorktree(worktree: string): Promise<Wor
  * Newest transcript mtime (epoch ms) for `worktree`, or 0 when the task
  * was never entered / has no session files. The Ops pane polls this to
  * detect "the agent produced new conversation output" without parsing
- * the tmux pane (KOB-254). `listSessionFilesForWorktree` already sorts
+ * the tmux pane. `listSessionFilesForWorktree` already sorts
  * newest-first, so `[0]` is the most recent activity.
  */
 export async function latestTranscriptMtimeForWorktree(worktree: string): Promise<number> {

--- a/packages/kobe/src/engine/codex-local/history.ts
+++ b/packages/kobe/src/engine/codex-local/history.ts
@@ -262,7 +262,7 @@ export async function findLatestRolloutForWorktree(
 /**
  * Newest rollout mtime (epoch ms) for `worktree`, or 0 when none match.
  * The Ops pane polls this to detect new Codex conversation output
- * without parsing the tmux pane (KOB-254). Thin wrapper over
+ * without parsing the tmux pane. Thin wrapper over
  * {@link findLatestRolloutForWorktree}.
  */
 export async function latestTranscriptMtimeForWorktree(

--- a/packages/kobe/src/engine/copilot-local/history.ts
+++ b/packages/kobe/src/engine/copilot-local/history.ts
@@ -74,7 +74,7 @@ export async function listSessionIdsForWorktree(
  * Newest `events.jsonl` mtime (epoch ms) across the Copilot sessions
  * rooted at `worktree`, or 0 when none match. The Ops pane polls this to
  * detect new Copilot conversation output without parsing the tmux pane
- * (KOB-254). Each session is a dir with a `workspace.yaml` (for the cwd
+ *. Each session is a dir with a `workspace.yaml` (for the cwd
  * match) and a growing `events.jsonl` (the transcript we stat).
  */
 export async function latestTranscriptMtimeForWorktree(

--- a/packages/kobe/src/engine/copilot-local/usage.ts
+++ b/packages/kobe/src/engine/copilot-local/usage.ts
@@ -1,5 +1,5 @@
 /**
- * Copilot usage-snapshot derivation (KOB-249).
+ * Copilot usage-snapshot derivation.
  *
  * The Copilot CLI's `session.shutdown` event carries a `modelMetrics`
  * map (per-model token tallies) plus a `currentTokens` context figure.

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -1,5 +1,5 @@
 /**
- * Which interactive engine CLI to launch in a task's tmux pane (KOB-233).
+ * Which interactive engine CLI to launch in a task's tmux pane.
  *
  * The "middle" pane of a task session runs a vendor's *interactive* CLI
  * (the same binary a human would run in a terminal) — not the headless
@@ -13,7 +13,7 @@
  * same way bare `claude` does — `codex exec` is the headless path we
  * deliberately don't use here.
  *
- * Per-vendor OVERRIDE (KOB-244): the launch command is configurable in
+ * Per-vendor OVERRIDE: the launch command is configurable in
  * Settings → Engines, so a user whose binary isn't on PATH as `claude`
  * (e.g. it's `cl`) or who wants default flags (`claude --model …`) can
  * set their own. The override is a shell-ish command STRING persisted in
@@ -49,7 +49,7 @@ export function engineCommandKey(vendor: VendorId): string {
 }
 
 /**
- * state.json key holding a vendor's custom DISPLAY-NAME override (KOB-244).
+ * state.json key holding a vendor's custom DISPLAY-NAME override.
  * Parallel to {@link engineCommandKey}; an empty/unset value means "use the
  * built-in {@link VENDOR_LABEL}", so resetting an engine to default is just
  * clearing both keys — no sentinel value.

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -66,7 +66,7 @@ export interface EngineHistoryReader {
   /**
    * Newest transcript mtime (epoch ms) for `worktree`, or 0 when the task
    * has no transcript yet. The Ops pane's activity poll watches this to
-   * light its "new activity" badge (KOB-254). Never throws — readers are
+   * light its "new activity" badge. Never throws — readers are
    * best-effort and the poller treats 0 as "no activity seen".
    */
   latestTranscriptMtimeForWorktree(worktree: string): Promise<number>

--- a/packages/kobe/src/exec/exec-host.ts
+++ b/packages/kobe/src/exec/exec-host.ts
@@ -27,10 +27,6 @@
  *     - `isRemote`, `wrapCommand` (pure string building), and `ensureReady`
  *       (ControlMaster bring-up; sync ssh, see caveat below).
  *
- *   (A sync existence probe used to live here, but its only caller —
- *   `worktreeUsable` — short-circuits on `isRemote` and so only ever needs a
- *   LOCAL check; it now calls `fs.existsSync` directly, and no remote sync
- *   existence round-trip exists.)
  *
  *   `ensureReady()` remains sync: it's called from TUI processes
  *   (tmux engine launch) and from `RemoteExecHost.run`'s first call per host

--- a/packages/kobe/src/exec/resolve.ts
+++ b/packages/kobe/src/exec/resolve.ts
@@ -62,10 +62,7 @@ export function execHostForWorktreePath(worktreePath: string): ExecHost {
 
 // ── Intent-named queries (the remoteness conditionals live HERE, once) ──────
 //
-// Callers around session/spawn code used to derive remoteness themselves
-// (`isRemoteRepoKey(task.repo) ? task.repo : undefined`, `.isRemote ||
-// existsSync(...)`, `.isRemote ? homeDir() : cwd`). These helpers own those
-// derivations so TUI/pane/CLI code asks intent-shaped questions and a third
+// These helpers own the remoteness derivations so TUI/pane/CLI code asks intent-shaped questions and a third
 // adapter only needs changes inside `exec/`.
 
 /**

--- a/packages/kobe/src/lib/path-glob.ts
+++ b/packages/kobe/src/lib/path-glob.ts
@@ -1,5 +1,5 @@
 /**
- * Tiny zero-dependency path glob matcher (KOB-256).
+ * Tiny zero-dependency path glob matcher.
  *
  * Used by `kobe adopt`'s `--glob` and the New Task → Adopt tab's filter
  * to narrow discovered worktree paths. We roll our own instead of

--- a/packages/kobe/src/lib/poll-scheduling.ts
+++ b/packages/kobe/src/lib/poll-scheduling.ts
@@ -2,8 +2,8 @@
  * Pure scheduling core for subprocess-backed background polling —
  * extracted from `src/tui/lib/background-poll.ts` (issue #6) so the
  * daemon's worktree-changes collector can reuse the EXACT guards that
- * fixed the 30GB-repo freeze without importing solid-js (the TUI poller's
- * signal layer) into daemon code.
+ * keep huge-repo `git status` off the event loop, without importing
+ * solid-js (the TUI poller's signal layer) into daemon code.
  *
  * The three guards live here; the two bindings differ only in where a
  * finished value goes:

--- a/packages/kobe/src/monitor/activity.ts
+++ b/packages/kobe/src/monitor/activity.ts
@@ -1,5 +1,5 @@
 /**
- * Engine-conversation activity probe for the Ops pane (KOB-254).
+ * Engine-conversation activity probe for the Ops pane.
  *
  * v0.6 hands the interactive surface to tmux, so the monitor has no chat
  * stream to learn "the agent finished a turn" from — and parsing the

--- a/packages/kobe/src/monitor/auto-title.ts
+++ b/packages/kobe/src/monitor/auto-title.ts
@@ -1,5 +1,5 @@
 /**
- * Derive a task title from its session transcript (KOB-233).
+ * Derive a task title from its session transcript.
  *
  * In the v0.6 tmux model kobe never sees the user's prompt directly —
  * the engine runs interactively in a tmux pane — so a task created via

--- a/packages/kobe/src/monitor/pr-status.ts
+++ b/packages/kobe/src/monitor/pr-status.ts
@@ -1,5 +1,5 @@
 /**
- * Pure mapping for the PR-status poller (KOB-10).
+ * Pure mapping for the PR-status poller.
  *
  * The daemon-side `pr-status-collector` shells `gh pr view <branch> --json
  * <fields>` per task and feeds the parsed JSON through {@link mapGhPrView} to
@@ -7,7 +7,7 @@
  * tmux, no fs) is what lets the error-prone bits — the `statusCheckRollup`
  * reduction and the `state`→lifecycle mapping — be unit-tested directly.
  *
- * GitHub only by design (KOB-10): GitLab/Bitbucket carry no `gh` equivalent
+ * GitHub only by design: GitLab/Bitbucket carry no `gh` equivalent
  * here, so the collector never runs for them and this module always stamps
  * `provider: "github"`.
  */

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -12,7 +12,7 @@
  *     broker. No live event stream from inside an engine to surface.
  *   - Orchestrator-owned ChatTab CRUD. ChatTabs are tmux windows inside a
  *     task's tmux Session now, so tmux owns their lifecycle/persistence.
- *   - Create-PR / merge / refresh-PR-status. KOB-232 will re-introduce
+ *   - Create-PR / merge / refresh-PR-status. A follow-up will re-introduce
  *     create-PR as a `tmux send-keys` injection from the Ops pane.
  *
  * What it gained: `ensureWorktree(id)` — the path task-entry surfaces
@@ -153,7 +153,7 @@ export class Orchestrator {
    * The active-task focus, in-process. Mirrors {@link RemoteOrchestrator}'s
    * daemon-backed `active-task` channel so the `KobeOrchestrator` union has
    * one API; in this local (no-daemon) mode there are no sibling panes to
-   * sync, so it's just an in-process signal (KOB-247).
+   * sync, so it's just an in-process signal.
    */
   activeTaskSignal(): Accessor<string | null> {
     return this.activeTaskAcc
@@ -219,7 +219,7 @@ export class Orchestrator {
     // materialises. We must NOT pre-derive a branch here — at create time
     // there is no task id yet, so every placeholder-titled task would get
     // the SAME name (`kobe/new-task-…`) and the second `git worktree add
-    // -b` would fail on a duplicate branch (KOB-244). Deferring also lets
+    // -b` would fail on a duplicate branch. Deferring also lets
     // the branch follow a rename made before first enter.
     const task = await this.store.create({
       repo: input.repo,
@@ -518,7 +518,7 @@ export class Orchestrator {
    * Permanently remove a task. Refuses to delete `kind: "main"`
    * tasks (the user removes the repo from saved repos instead).
    *
-   * Worktree safety (KOB-244): without `opts.force` a worktree with
+   * Worktree safety: without `opts.force` a worktree with
    * uncommitted / untracked changes is NOT destroyed — we throw
    * {@link DirtyWorktreeError} so the UI can re-prompt for explicit
    * force confirmation. And if `git worktree remove` itself fails
@@ -601,7 +601,7 @@ export class Orchestrator {
 
   /**
    * Discover git worktrees on `repo` that exist on disk but aren't yet
-   * linked to any task — candidates for adoption (KOB-256). Includes
+   * linked to any task — candidates for adoption. Includes
    * worktrees outside the kobe convention root (the user's own
    * `git worktree add`). De-dupes against the task store by canonical
    * path so an already-adopted worktree never reappears.
@@ -619,7 +619,7 @@ export class Orchestrator {
   }
 
   /**
-   * Adopt an existing git worktree as a new task (KOB-256). The worktree
+   * Adopt an existing git worktree as a new task. The worktree
    * already exists on disk, so we record the task with its real path +
    * branch directly — `ensureWorktree` then short-circuits (non-empty
    * `worktreePath`) and never touches the filesystem. Validates the path
@@ -725,7 +725,7 @@ function normalizeMainRepo(repo: string): { repo: string; key: string } {
  * Resolve symlinks so two strings naming the same node compare equal
  * (macOS `/var` → `/private/var`). Falls back to `resolve` when the path
  * doesn't exist. Used to de-dupe discovered worktrees against task paths,
- * which may be stored in different (caller vs git) forms (KOB-256).
+ * which may be stored in different (caller vs git) forms.
  */
 function canonPath(p: string): string {
   try {

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -45,7 +45,7 @@ export const DIRTY_WORKTREE_CODE = "DIRTY_WORKTREE"
  * Thrown when deleting a task whose worktree has uncommitted / untracked
  * changes and `force` was not requested. The UI catches it (via
  * {@link DIRTY_WORKTREE_CODE}) and re-prompts for explicit force-delete
- * confirmation rather than silently destroying the work (KOB-244).
+ * confirmation rather than silently destroying the work.
  */
 export class DirtyWorktreeError extends Error {
   constructor(public readonly taskId: string) {
@@ -58,7 +58,7 @@ export class DirtyWorktreeError extends Error {
  * Thrown when `git worktree remove` itself failed (locked, permission,
  * corrupt git-dir). The orchestrator keeps the task index entry in this
  * case so the orphaned worktree stays visible + re-deletable instead of
- * becoming invisible on-disk debris (KOB-244).
+ * becoming invisible on-disk debris.
  */
 export class WorktreeRemoveFailedError extends Error {
   constructor(

--- a/packages/kobe/src/orchestrator/title.ts
+++ b/packages/kobe/src/orchestrator/title.ts
@@ -30,7 +30,7 @@ export function deriveTitleFromPrompt(prompt: string): string {
  * Build `kobe/<slug>-<ulid-suffix-6>` from a user-supplied title and a
  * freshly-minted ulid. The 6-char suffix comes from the ulid's random
  * tail, so two tasks created from the same placeholder title still get
- * distinct branches (KOB-244 — branch collisions failed `git worktree
+ * distinct branches (branch collisions failed `git worktree
  * add -b`). MUST be passed the real task id, never a fixed placeholder.
  */
 export function autoBranch(title: string, taskId: string): string {

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -183,8 +183,8 @@ export class GitWorktreeManager implements WorktreeManager {
    * the layout).
    *
    * `slug` is the directory basename — allocated by the orchestrator's
-   * {@link SlugAllocator}. Post-KOB-65 this is an animal name (e.g.
-   * `panda`) or version-suffixed (`panda-v2`); pre-KOB-65 it was the
+   * {@link SlugAllocator}. Under the slug scheme this is an animal name (e.g.
+   * `panda`) or version-suffixed (`panda-v2`); before it, this was the
    * task's ULID. The manager doesn't care which — it just joins.
    *
    * `baseRef` (optional): forwarded to {@link create} so the new branch
@@ -304,7 +304,7 @@ export class GitWorktreeManager implements WorktreeManager {
 
   /**
    * List ALL git worktrees registered on `repo` — including ones the
-   * user created outside kobe-managed roots (KOB-256). Unlike
+   * user created outside kobe-managed roots. Unlike
    * {@link list}, this does NOT filter to the kobe convention root; it's
    * the discovery source for "adopt an existing worktree as a task".
    *
@@ -341,7 +341,7 @@ export class GitWorktreeManager implements WorktreeManager {
         lastActivityMs: await this.lastActivityMs(ctx.exec, entry.path),
       })
     }
-    // Most recently active first (KOB-256).
+    // Most recently active first.
     infos.sort((a, b) => b.lastActivityMs - a.lastActivityMs)
     return infos
   }

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -3,7 +3,7 @@
  *
  * The worktree root is per-repo and lives in kobe's state dir at
  * `~/.kobe/worktrees/<repo-key>/<slug>/` (or under `$KOBE_HOME_DIR`
- * when overridden). `<slug>` is an animal-name slug (KOB-65) for tasks
+ * when overridden). `<slug>` is an animal-name slug for tasks
  * created after the switch, or the task's ULID for older records whose
  * path is already persisted.
  *
@@ -113,7 +113,7 @@ export function managedWorktreeRootsFor(repo: string): readonly string[] {
  * Absolute path of the worktree directory keyed by `slug` in `repo`.
  *
  * `slug` is the workspace's directory basename — an animal-name slug
- * allocated by {@link SlugAllocator} for tasks created after KOB-65,
+ * allocated by {@link SlugAllocator} for tasks created since the slug scheme landed,
  * or the task's ULID for older tasks whose worktree was created back
  * when "dir name == task id" was the invariant.
  *

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -7,9 +7,9 @@
  * created after the switch, or the task's ULID for older records whose
  * path is already persisted.
  *
- * Backwards compatibility: kobe briefly used repo-local
- * `<repo>/.kobe/worktrees/<slug>/`, and before multi-engine support it
- * used `<repo>/.claude/worktrees/<slug>/`. Existing tasks in both roots
+ * Backwards compatibility: older checkouts hold worktrees under
+ * repo-local `<repo>/.kobe/worktrees/<slug>/` or
+ * `<repo>/.claude/worktrees/<slug>/`. Existing tasks in both roots
  * remain managed and discoverable, but new kobe-created tasks use the
  * global kobe state dir so no repo-level `.gitignore` entry is needed.
  *

--- a/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
+++ b/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
@@ -7,7 +7,7 @@
  *   ~/.kobe/worktrees/<repo-key>/panda/
  *   ~/.kobe/worktrees/<repo-key>/panda-v2/   # if `panda` was recycled
  *
- * Mechanism (mirrors Conductor's city-name scheme, KOB-65):
+ * Mechanism (mirrors Conductor's city-name scheme):
  *   1. Build the "occupied" set: every slug currently held by a
  *      non-archived task in the store, PLUS every directory name
  *      already present on disk under kobe-managed worktree roots,

--- a/packages/kobe/src/state/repos.ts
+++ b/packages/kobe/src/state/repos.ts
@@ -284,7 +284,7 @@ export function setRepoInitOverride(repoRoot: string, patch: RepoInitOverride): 
 export type RemoveResult = { removed: boolean; path: string; total: number }
 
 /**
- * Remove `absPath` from `savedRepos`. KOB-15 wires this from the
+ * Remove `absPath` from `savedRepos`. Wired from the
  * sidebar's `d` keypress on a main-task row: the confirm copy is
  * "this will remove '<repo>' from your saved repos. The directory and
  * its files stay on disk." The directory itself is never touched —

--- a/packages/kobe/src/state/store.ts
+++ b/packages/kobe/src/state/store.ts
@@ -1,18 +1,11 @@
 /**
  * Single owner of `~/.config/kobe/state.json` I/O.
  *
- * History: this file exists to kill a dual-writer hazard. Two modules used
- * to write the SAME blob independently — the TUI's `KVProvider`
- * (src/tui/context/kv.tsx) debounce-wrote its ENTIRE in-memory snapshot,
- * while `src/state/repos.ts` did sync load→mutate→save for CLI commands
- * and the standalone panes (Tasks pane, quick-task, settings window). With
- * several kobe processes alive at once, the whole-snapshot write-back
- * clobbered any key another process had written since the snapshot was
- * taken (lost update: Tasks pane persists `lastSelectedVendor`, the outer
- * TUI flushes 250ms later from a stale snapshot, the vendor choice is
- * gone). env.ts even carried a "keep them in sync if either moves" comment
- * pointing at the duplicated path expression — the smell that triggered
- * this module.
+ * This file exists to kill a dual-writer hazard: with several kobe
+ * processes alive at once, any writer that flushes a whole in-memory
+ * snapshot clobbers keys another process wrote since that snapshot was
+ * taken (the classic lost update). Every write therefore goes through
+ * the read-merge-write transaction here.
  *
  * The fix is read-merge-write: every write re-reads the file fresh and
  * applies ONLY the keys the caller actually changed, then writes the
@@ -114,8 +107,8 @@ export function patchStateFile(patch: StateSnapshot): StateSnapshot {
  * owner of the "stored bool with a default" rule. Only a real stored boolean
  * overrides `defaultValue`; a missing key OR any non-boolean value falls back.
  * This subsumes the `x === true` (default false) / `x !== false` (default true)
- * idioms each flag module used to inline, where the idiom silently encoded the
- * default and was easy to get backwards.
+ * idioms flag modules would otherwise inline, where the idiom silently
+ * encodes the default and is easy to get backwards.
  */
 export function getPersistedBool(key: string, defaultValue: boolean): boolean {
   const value = loadStateFile()[key]

--- a/packages/kobe/src/tmux/chat-tab-naming.ts
+++ b/packages/kobe/src/tmux/chat-tab-naming.ts
@@ -128,7 +128,7 @@ export async function runChatTabNamingPass(orch: Orchestrator, deps: ChatTabNami
   // and the flag can't tell local-off from inherited-off). The global state
   // is probed lazily, at most ONCE per pass — so the steady state (all
   // windows named, global on) costs one list-windows per task and zero
-  // per-window probes, where it used to spawn one probe per window per tick.
+  // per-window probes.
   let globalOff: boolean | null = null
   const manuallyNamed = async (session: string, w: ChatTabWindow): Promise<boolean> => {
     if (w.autoRename === "1") return false

--- a/packages/kobe/src/tmux/client.ts
+++ b/packages/kobe/src/tmux/client.ts
@@ -87,8 +87,8 @@ async function drainText(stream: ReadableStream<Uint8Array> | null | undefined):
  * Deleting a task unlinks that worktree, after which `Bun.spawn` fails
  * with `posix_spawn` ENOENT BEFORE the command runs — even though tmux is
  * on PATH — because the kernel can't resolve the inherited (now-gone)
- * cwd. That ENOENT used to throw straight into a pane's opentui loop and
- * crash the whole pane to a bare shell when its task was deleted.
+ * cwd. Unanchored, that ENOENT throws straight into a pane's opentui loop
+ * and crashes the whole pane to a bare shell when its task is deleted.
  * Anchoring to `$HOME` (→ `/` if unset) keeps the helpers spawnable from
  * a pane whose worktree just vanished. Read once — `$HOME` is fixed for
  * the process lifetime.
@@ -224,7 +224,7 @@ export async function windowCount(sessionName: string): Promise<number> {
  * NOTE: `set-option` / `show-options` do NOT accept the `=name`
  * exact-match prefix that most other tmux targets take — tmux 3.5a
  * treats `=name` as a literal session name and reports "no such
- * session", silently dropping the option (this burned a debug cycle
+ * session", silently dropping the option (easy to lose a debug cycle
  * on exactly this). So these two helpers target the bare name. Our
  * session names are `kobe-<taskId>` slugs; a prefix collision between
  * two live tasks is the only theoretical risk and we accept it.

--- a/packages/kobe/src/tmux/client.ts
+++ b/packages/kobe/src/tmux/client.ts
@@ -1,5 +1,5 @@
 /**
- * Shared low-level tmux client (v0.6 / KOB-233).
+ * Shared low-level tmux client (v0.6).
  *
  * kobe drives a dedicated tmux server on the `-L kobe` socket
  * (isolated from the user's own tmux). The session-lifecycle code
@@ -10,7 +10,7 @@
  *
  * That workaround is load-bearing: most tmux configs set
  * `base-index 1`, so the first window/pane is `:1.1`, and any code
- * that targeted `:0.0` silently hit nothing (KOB-233 burned hours on
+ * that targeted `:0.0` silently hit nothing (this burned hours on
  * exactly this, twice). Centralising the pane-id resolution here means
  * the fix lives in one place.
  */
@@ -21,7 +21,7 @@ import { kobeCliInvocation } from "@/cli/invocation"
 // module's only deps are `@/exec/resolve` + `@/tmux/session-layout`, neither of
 // which imports this file, so the reference is acyclic at runtime even though it
 // reaches "up" into the tui layer — the import is for the kobe-home Tasks pane's
-// env pinning below (KOB-244). Keeping the prefix in one place avoids re-deriving
+// env pinning below. Keeping the prefix in one place avoids re-deriving
 // the same KOBE_*-pinning logic the workspace panes already use.
 import { inheritedEnvPrefix } from "@/tui/panes/terminal/launch"
 import {
@@ -97,7 +97,7 @@ const SAFE_SPAWN_CWD = homedir() || "/"
 
 /**
  * Run a tmux command, logging stderr when it fails. Silent tmux
- * errors are a foot-gun (KOB-233): a `split-window -t :0.0` that
+ * errors are a foot-gun: a `split-window -t :0.0` that
  * failed because of `base-index 1` left the layout broken with no
  * trace. We only emit on a non-zero exit.
  *
@@ -105,7 +105,7 @@ const SAFE_SPAWN_CWD = homedir() || "/"
  * tmux invocation ever filled the stderr pipe buffer before exiting,
  * reading it only post-exit would dead-lock (the child blocks on the
  * write, we block on `exited`). tmux diagnostics are tiny in practice,
- * but the concurrent read removes the latent hang regardless (KOB-244).
+ * but the concurrent read removes the latent hang regardless.
  */
 export async function runTmux(args: string[]): Promise<number> {
   try {
@@ -165,7 +165,7 @@ export async function runTmuxSequence(commands: readonly (readonly string[])[]):
  * Run a tmux command and capture stdout (stderr logged on failure).
  * Both streams are drained concurrently with the exit so neither a full
  * stdout (large capture-pane) nor a full stderr can dead-lock the call
- * (KOB-244).
+ *.
  */
 export async function runTmuxCapturing(args: string[]): Promise<{ code: number; stdout: string }> {
   try {
@@ -210,7 +210,7 @@ export async function sessionExists(name: string): Promise<boolean> {
 /**
  * Number of windows (chat tabs) in the session. `0` when the session
  * doesn't exist. Used to avoid a whole-session rebuild that would drop
- * sibling Ctrl+T chat-tab windows (KOB-244).
+ * sibling Ctrl+T chat-tab windows.
  */
 export async function windowCount(sessionName: string): Promise<number> {
   const { code, stdout } = await runTmuxCapturing(["list-windows", "-t", `=${sessionName}`, "-F", "#{window_id}"])
@@ -224,7 +224,7 @@ export async function windowCount(sessionName: string): Promise<number> {
  * NOTE: `set-option` / `show-options` do NOT accept the `=name`
  * exact-match prefix that most other tmux targets take — tmux 3.5a
  * treats `=name` as a literal session name and reports "no such
- * session", silently dropping the option (KOB-233 burned a debug cycle
+ * session", silently dropping the option (this burned a debug cycle
  * on exactly this). So these two helpers target the bare name. Our
  * session names are `kobe-<taskId>` slugs; a prefix collision between
  * two live tasks is the only theoretical risk and we accept it.
@@ -391,7 +391,7 @@ export async function claudePaneId(sessionName: string): Promise<string> {
  * its reuse decision on: a legacy/pre-tag (v0.5) session has no tagged
  * claude pane, so this returns `""` and the session is rebuilt, while a
  * healthy session whose disposable shell/ops pane was closed still has
- * its tagged claude pane and is reused (KOB-244).
+ * its tagged claude pane and is reused.
  */
 export async function claudePaneIdStrict(sessionName: string): Promise<string> {
   return paneIdByRole(sessionName, CLAUDE_ROLE_VALUE, false)
@@ -421,7 +421,7 @@ export async function capturePaneById(paneId: string, lines?: number): Promise<s
  * equal to `Enter` / `Space` / `Tab` / `C-x` (or an injected file path
  * shaped like one) fires that key instead of being typed. With `-l` the
  * text is always typed verbatim; `--` ends flag parsing so text starting
- * with `-` isn't mistaken for a flag (KOB-244). To send an actual named
+ * with `-` isn't mistaken for a flag. To send an actual named
  * key (e.g. Enter to submit) use {@link sendKeyName}, not this.
  */
 export async function sendKeys(target: string, text: string): Promise<void> {
@@ -626,7 +626,7 @@ export async function ensureFallbackSession(): Promise<string> {
       // SERVER was born with — which goes stale when the server persists across
       // kobe relaunches (KOBE_* aren't in tmux's update-environment list), so a
       // non-default-home run that lands on home could read/mutate the PRODUCTION
-      // tasks.json / a dead daemon — the KOB-244 desync class.
+      // tasks.json / a dead daemon — the stale-list desync class.
       keepAlive(inheritedEnvPrefix() + tasksPaneCommand(kobeCliInvocation())),
     ])
     const tasksPane = r1.stdout.trim()

--- a/packages/kobe/src/tmux/keybindings.ts
+++ b/packages/kobe/src/tmux/keybindings.ts
@@ -75,9 +75,9 @@ export const TMUX_PREFIX_BINDING_DEFAULTS = {
 } as const
 
 /**
- * 0.7.30 briefly shipped layout controls as no-prefix F6-F11 root bindings.
- * Always unbind these during session setup so a long-lived tmux server does not
- * keep stale root keys after the defaults move to prefix-table bindings.
+ * Unbind the legacy no-prefix F6-F11 root bindings during session setup so a
+ * long-lived tmux server never keeps stale root keys after the defaults moved
+ * to prefix-table bindings.
  */
 export const TMUX_LEGACY_LAYOUT_ROOT_KEYS = ["F6", "F7", "F8", "F9", "F10", "F11"] as const
 

--- a/packages/kobe/src/tmux/session-decision.ts
+++ b/packages/kobe/src/tmux/session-decision.ts
@@ -39,7 +39,7 @@ export interface ObservedSession {
    * Does the ACTIVE window have a live `@kobe_role=claude` pane? This is
    * the load-bearing health signal — keyed off the role tag, NOT a raw
    * pane count, so closing a disposable shell/ops pane never reads as
-   * "session broken" (KOB-244).
+   * "session broken".
    */
   readonly claudePaneAlive: boolean
   /** Number of windows (chat tabs) in the session. */
@@ -71,7 +71,7 @@ export interface TargetSession {
  *   - `reuse`           — leave the session running (then heal widths +
  *                         kobe-owned pane versions in the applier).
  *   - `respawn-engine`  — relaunch the engine pane in place in every
- *                         window (vendor switch, KOB-232). Applier falls
+ *                         window (vendor switch). Applier falls
  *                         back to `rebuild` if no engine pane is found.
  *   - `rebuild`         — kill the session, then build fresh.
  */
@@ -91,19 +91,19 @@ export type SessionAction =
  *   2. Healthy + right place + right engine → reuse. We key health off
  *      the LOAD-BEARING claude pane's role tag in the active window,
  *      not a pane count — typing `exit` in the shell pane used to drop
- *      the count and nuke the live engine conversation (KOB-244).
+ *      the count and nuke the live engine conversation.
  *   3. Vendor-only drift (right worktree, task switched engines via
  *      `setVendor`) with a launch command → respawn the engine pane IN
  *      PLACE in every window instead of kill-session, so the switch
- *      lands WITHOUT destroying sibling Ctrl+T chat tabs (KOB-232).
+ *      lands WITHOUT destroying sibling Ctrl+T chat tabs.
  *      Checked before the degraded-reuse branch and regardless of the
  *      active window's pane health — the respawn is session-wide.
  *   4. Right place + right engine but the active window's engine pane
  *      is gone, with sibling windows present → reuse anyway. A rebuild
  *      would drop those sibling chat tabs; per-window pane recreate is
  *      a future follow-up. (The common shell-exit case never gets here
- *      because the engine pane survives — KOB-244.)
- *   5. Otherwise rebuild: a legacy/pre-tag (v0.5/KOB-225) session, a
+ *      because the engine pane survives.)
+ *   5. Otherwise rebuild: a legacy/pre-tag (v0.5) session, a
  *      wrong-PLACE session (different/empty `@kobe_worktree` — stale
  *      from before env+socket isolation, panes in the wrong dir/wrong
  *      KOBE_HOME), a vendor-drifted session with no command to respawn

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -8,7 +8,7 @@
  * runs, the keep-alive wrapper, the Ops-pane fallback — is pure data
  * + string building. Pulling it out here makes that policy unit
  * testable without a real tmux server, which is exactly the surface
- * that bit us in KOB-233 (quoting + targeting bugs that only showed
+ * that bit us before (quoting + targeting bugs that only showed
  * up at runtime).
  *
  * Everything in this file is pure: same inputs → same strings, no IO.
@@ -18,7 +18,7 @@ import { quoteShellArg, quoteShellArgv } from "@/lib/shell-command"
 
 /**
  * Far-left Tasks pane width in CELLS — FIXED, not a % of the window
- * (KOB-248). A %-split drifted: the pane's absolute width changed with the
+ *. A %-split drifted: the pane's absolute width changed with the
  * terminal size, between chat-tab windows, and across engine (claude/codex)
  * rebuilds (tmux re-lays-out %-panes on those events). Direct-tmux mode
  * makes this pane the primary navigator, not a tiny preview rail, so 32 cells
@@ -441,7 +441,7 @@ done`
 
 /**
  * Shell command for the full-width preview window opened when the user
- * activates a file in the Ops pane (KOB-233). Runs in a fresh tmux
+ * activates a file in the Ops pane. Runs in a fresh tmux
  * window so review gets the whole terminal width.
  *
  * Primary path: `kobe ops --preview <rel>` — opentui's `<diff>` /

--- a/packages/kobe/src/tmux/session-layout.ts
+++ b/packages/kobe/src/tmux/session-layout.ts
@@ -7,9 +7,8 @@
  * *policy* it encodes — pane sizes, which shell command each pane
  * runs, the keep-alive wrapper, the Ops-pane fallback — is pure data
  * + string building. Pulling it out here makes that policy unit
- * testable without a real tmux server, which is exactly the surface
- * that bit us before (quoting + targeting bugs that only showed
- * up at runtime).
+ * testable without a real tmux server — exactly the surface where
+ * quoting + targeting bugs only show up at runtime.
  *
  * Everything in this file is pure: same inputs → same strings, no IO.
  */

--- a/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
@@ -28,7 +28,7 @@ export type NewTaskDialogOptions = {
   defaultVendor?: VendorId
   /** Vendors detected on this machine; omit/empty falls back to all. */
   availableVendors?: readonly VendorId[]
-  /** Adopt-tab discovery (KOB-256); omit to disable adoption. */
+  /** Adopt-tab discovery; omit to disable adoption. */
   discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
 }
 

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Adopt tab of the React new-task dialog (issue #15, G3W2 / KOB-256) —
+ * Adopt tab of the React new-task dialog (issue #15, G3W2) —
  * discover existing git worktrees not yet linked to a task, filter by a
  * path glob, multi-select, then import. Discovery + selection state live
  * in the view-model; this file is JSX only.

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
@@ -1,6 +1,6 @@
 /**
- * Adopt-tab state hook for the React new-task dialog (issue #15, G3W2 /
- * KOB-256) — split out of `./view-model.ts`: worktree discovery (async
+ * Adopt-tab state hook for the React new-task dialog (issue #15,
+ * G3W2) — split out of `./view-model.ts`: worktree discovery (async
  * canon: useState + dependency-keyed effect with a disposed flag), glob
  * filter, windowed cursor, and the multi-select import commit.
  */

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -60,7 +60,7 @@ export type NewTaskDialogProps = {
   defaultVendor?: VendorId
   /** Vendors detected on this machine; empty falls back to all. */
   availableVendors?: readonly VendorId[]
-  /** Adopt-tab discovery (KOB-256). Omit to leave the tab empty. */
+  /** Adopt-tab discovery. Omit to leave the tab empty. */
   discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
 }
 

--- a/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
@@ -96,7 +96,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
   const prefs = useSettingsPrefs(props.kv, dialog)
   const engines = useEngineSettings(props.kv, dialog, (max) => setBodyRow((r) => Math.max(0, Math.min(r, max))))
 
-  // Account detection (KOB-249): read-only fs/env probes, lazily run the
+  // Account detection: read-only fs/env probes, lazily run the
   // first time the Accounts section is opened so a settings open that
   // never visits it pays nothing.
   const [claudeStatus, setClaudeStatus] = useState<EngineAccountStatus<ClaudeAccount> | null>(null)

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-engines.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-engines.tsx
@@ -151,7 +151,7 @@ function AccountBlock(props: {
   )
 }
 
-/** Read-only "is this engine installed + logged in" view (KOB-249). */
+/** Read-only "is this engine installed + logged in" view. */
 export function AccountsSettingsSection(props: {
   claudeStatus: EngineAccountStatus<ClaudeAccount> | null
   codexStatus: EngineAccountStatus<CodexAccount> | null

--- a/packages/kobe/src/tui-react/ops/host.tsx
+++ b/packages/kobe/src/tui-react/ops/host.tsx
@@ -83,7 +83,7 @@ export function OpsShell(props: OpsHostArgs) {
   const sharedMapRef = useRef<TranscriptActivityMap | null>(sharedActivityMap)
   sharedMapRef.current = sharedActivityMap
 
-  // New-activity badge (KOB-254) — same two-source design as the Solid
+  // New-activity badge — same two-source design as the Solid
   // host: the daemon push when available, the local mtime probe otherwise.
   // `baseline` seeds at the first observed mtime so a pane mounting onto an
   // already-busy task doesn't flash stale activity; `r` refresh acks it.

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -69,7 +69,7 @@ export type FileTreeProps = {
   onZenToggle?: () => void
   /** Whether the pane has keyboard focus. Defaults to `true`. */
   focused?: boolean
-  /** Right-aligned activity badge (KOB-254); `null`/omit hides it. */
+  /** Right-aligned activity badge; `null`/omit hides it. */
   cornerBadge?: { text: string; active: boolean } | null
   /** Fires on explicit `r` refresh — the Ops host's "I've looked" ack. */
   onRefresh?: () => void

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -3,7 +3,7 @@
  * React view for the file tree pane's header chrome — the `src/tui/panes/
  * filetree/header-view.tsx` counterpart (issue #15, G3): the optional
  * Zen / Create-PR action row, the All / Changes tab chips, the corner
- * activity badge (KOB-254), and the Changes-tab status legend. Pure
+ * activity badge, and the Changes-tab status legend. Pure
  * render — tab state and actions stay in the pane component.
  */
 
@@ -75,7 +75,7 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
             )
           })}
         </box>
-        {/* Right-aligned activity badge (KOB-254). No background fill so
+        {/* Right-aligned activity badge. No background fill so
            it stays clean in transparent mode. */}
         {badge ? (
           <text

--- a/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/dialog.tsx
@@ -104,7 +104,7 @@ export type NewTaskDialogProps = {
   availableVendors?: readonly VendorId[]
   /**
    * Discover existing git worktrees on a repo not yet linked to a task
-   * (KOB-256) — powers the Adopt tab's list. Omit to leave the tab empty.
+   * — powers the Adopt tab's list. Omit to leave the tab empty.
    */
   discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
 }
@@ -223,7 +223,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
   // parent-dir picker.
   const [cloneParentPicked, setCloneParentPicked] = createSignal(false)
 
-  // Adopt-tab state (KOB-256): discover existing worktrees for the
+  // Adopt-tab state: discover existing worktrees for the
   // chosen repo, filter by a path glob, multi-select, then import.
   const [adoptFilter, setAdoptFilter] = createSignal("")
   const [adoptCursor, setAdoptCursor] = createSignal(0)
@@ -1010,7 +1010,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
           </Show>
         </Show>
         <Show when={tab() === "adopt"}>
-          {/* ── Adopt tab body (KOB-256) ────────────────────────────── */}
+          {/* ── Adopt tab body ────────────────────────────── */}
           <box gap={0}>
             <text fg={labelFg("adoptFilter")} attributes={labelAttrs("adoptFilter")}>
               {t("newTask.field.adoptFilter")}

--- a/packages/kobe/src/tui/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui/component/new-task-dialog/index.tsx
@@ -48,7 +48,7 @@ export type NewTaskDialogOptions = {
   availableVendors?: readonly VendorId[]
   /**
    * Discover existing git worktrees on `repo` not yet linked to a task
-   * (KOB-256) — powers the Adopt tab. Omit to disable adoption (the tab
+   * — powers the Adopt tab. Omit to disable adoption (the tab
    * still renders but shows nothing to import).
    */
   discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -40,7 +40,7 @@ import { DEFAULT_BASE_REF } from "../../lib/git-snapshot"
  * Dialog result. Two shapes, discriminated by `mode`:
  *   - create (default) — make a fresh task on `repo` at `baseRef`.
  *   - adopt — import one or more EXISTING git worktrees as tasks
- *     (KOB-256). `adopt` carries the chosen worktrees; the caller loops
+ *. `adopt` carries the chosen worktrees; the caller loops
  *     `orchestrator.adoptWorktree` over them.
  */
 export type NewTaskInput =
@@ -225,7 +225,7 @@ export function firstFieldFor(tab: DialogTab): Field {
 }
 
 /**
- * Filter adoptable worktrees by a path glob (KOB-256). Empty glob → the
+ * Filter adoptable worktrees by a path glob. Empty glob → the
  * full list. Matches against the absolute path AND the basename, so a
  * bare `feature-*` works without typing the full directory. Uses Bun's
  * built-in `Glob` (zero-dep). An invalid pattern matches nothing rather

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -129,7 +129,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
   )
   const hasDaemon = hasRestartableDaemon(props.orchestrator)
 
-  // Account detection (KOB-249): read-only fs/env probes, lazily run the
+  // Account detection: read-only fs/env probes, lazily run the
   // first time the Accounts section is opened so a settings open that
   // never visits it pays nothing.
   const [claudeStatus, setClaudeStatus] = createSignal<EngineAccountStatus<ClaudeAccount> | null>(null)

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -2,8 +2,8 @@
  * Pure data + helpers for settings-dialog (v0.6).
  *
  * v0.5 had a Codex (app-server / exec backend) section that depended on
- * engine modules v0.6 deleted, so it's gone. Accounts came back in
- * KOB-249 (read-only claude/codex/copilot login detection) alongside
+ * engine modules v0.6 deleted, so it's gone. Accounts came back
+ * (read-only claude/codex/copilot login detection) alongside
  * the Engines launch-command section.
  *
  * Row registry: each section declares an ORDERED list of row descriptors

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -630,7 +630,7 @@ export function EngineSettingsSection(
   )
 }
 
-/** Read-only "is this engine installed + logged in" view (KOB-249). */
+/** Read-only "is this engine installed + logged in" view. */
 export function AccountsSettingsSection(props: {
   claudeStatus: Accessor<EngineAccountStatus<ClaudeAccount> | null>
   codexStatus: Accessor<EngineAccountStatus<CodexAccount> | null>

--- a/packages/kobe/src/tui/context/keybindings-chat.ts
+++ b/packages/kobe/src/tui/context/keybindings-chat.ts
@@ -150,9 +150,9 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   },
   {
     // tmux's chattab has a "prompt for engine, then open a tab" chord on
-    // `ctrl+shift+t`. Can't reuse that chord here: same KOB-74 collision
+    // `ctrl+shift+t`. Can't reuse that chord here: same shift+letter collision
     // (the keymap layer drops shift+ on letter keys, so ctrl+shift+t and
-    // ctrl+t are indistinguishable) — see docs/KEYBINDINGS.md decision log.
+    // ctrl+t are indistinguishable).
     // `ctrl+e` mirrors the "engine" mnemonic the new-task dialog already
     // uses for its own vendor cycle chord.
     id: "chat.tab.chooseEngine",
@@ -163,7 +163,7 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     hint: { keys: "ctrl+e", label: "choose engine", status: false },
   },
   {
-    // KOB-74. Quick-fork: from a focused chat tab, spin up a child
+    // Quick-fork: from a focused chat tab, spin up a child
     // task that inherits repo + branch + model from the source. The
     // dialog asks only for a prompt; the fork's first turn fires
     // immediately. `ctrl+t` is taken by `chat.tab.new` (same task,
@@ -174,7 +174,7 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // Picked `ctrl+f` ("fork") because it's free across the keymap,
     // ctrl+letter has stable C0 byte mappings that work in every
     // terminal, and the workspace scope keeps it from intruding on
-    // other panes. See docs/KEYBINDINGS.md decision log.
+    // other panes.
     id: "chat.fork.new",
     scope: "workspace",
     keys: ["ctrl+f"],
@@ -189,7 +189,7 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // Selecting an already-open session focuses its tab; otherwise a
     // new tab is opened seeded with that sessionId. Chord chosen for
     // mnemonic "yank from history" — `ctrl+r` belongs to the prompt
-    // history palette (claude-code parity, KOB-154) and `ctrl+h`
+    // history palette (claude-code parity) and `ctrl+h`
     // collides with terminals' backspace byte.
     id: "chat.session.resume",
     scope: "workspace",
@@ -210,8 +210,7 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // Rename the active chat tab. F2 is the cross-OS / cross-IDE
     // rename convention (file managers on Windows + Linux, IntelliJ,
     // VS Code etc.) — chosen here because `ctrl+r` is owned by the
-    // composer's prompt-history palette (claude-code parity, KOB-154
-    // → KOB-156). F2 has no other binding in kobe and doesn't
+    // composer's prompt-history palette (claude-code parity). F2 has no other binding in kobe and doesn't
     // collide with terminal bytes the way some control chords do.
     id: "chat.tab.rename",
     scope: "workspace",
@@ -269,8 +268,8 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   },
   {
     // Split-focus cycle in reading order (tmux `prefix o`). F3 because
-    // every useful ctrl+letter is either engine passthrough (owner
-    // decision 2026-07-06) or taken; F-keys already carry the tab
+    // every useful ctrl+letter is either engine passthrough or
+    // taken; F-keys already carry the tab
     // vocabulary here (F2 rename).
     id: "workspace.split.focus-next",
     scope: "workspace",

--- a/packages/kobe/src/tui/context/keybindings-files.ts
+++ b/packages/kobe/src/tui/context/keybindings-files.ts
@@ -75,7 +75,7 @@ export const FILES_BINDINGS: readonly KobeBinding[] = [
   },
   {
     // `a` → inject `@<path>` into the engine (claude/codex) pane via
-    // tmux send-keys (KOB-232). Enter stays the full-width preview; this
+    // tmux send-keys. Enter stays the full-width preview; this
     // is the "add as a mention" action. Plain letter, files-scoped per
     // the keybinding-boundaries rule, so it can't collide elsewhere.
     id: "files.mention",

--- a/packages/kobe/src/tui/context/kv.tsx
+++ b/packages/kobe/src/tui/context/kv.tsx
@@ -12,12 +12,10 @@
  *
  * Writes are debounced (250ms) and routed through `src/state/store.ts`,
  * which owns all state.json I/O (atomic tmp+rename — a crash mid-write
- * can't leave a half-written file). History: this provider used to write
- * its ENTIRE in-memory snapshot back on every flush. With several kobe
- * processes alive at once (outer monitor + Tasks pane + Ops pane +
- * settings window, each with its own KVProvider or `setPersisted*`
- * caller), a whole-snapshot flush silently reverted any key another
- * process had written since this one loaded — the classic lost update.
+ * can't leave a half-written file). Writes are per-key, never a whole
+ * in-memory snapshot: with several kobe processes alive at once, a
+ * whole-snapshot flush silently reverts any key another process wrote
+ * since this one loaded — the classic lost update.
  * The fix is dirty-key tracking: we remember which keys THIS process
  * changed since its last successful flush and merge only those into a
  * fresh read of the file (`patchStateFile`). Keys we never touched pass

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -9,7 +9,7 @@ export const en = {
   exited: "process exited — F5 restarts it",
   restoring: "restoring session…",
   tab: {
-    // Content-neutral on purpose (owner, 2026-07-06): tabs will host
+    // Content-neutral on purpose: tabs will host
     // more than terminals, so the numbered fallback must not say
     // "Terminal".
     defaultTitle: "Tab {n}",

--- a/packages/kobe/src/tui/lib/host-boot.tsx
+++ b/packages/kobe/src/tui/lib/host-boot.tsx
@@ -85,7 +85,7 @@ export interface HostScreen {
    * Teardown on ACTUAL exit. opentui's `render` resolves at mount, so
    * disposing after `await render(...)` would kill daemon clients / poll
    * timers the moment the pane comes up — `onDestroy` is the only correct
-   * place (the KOB-247 "daemon client disposed" lesson from the Tasks pane).
+   * place (the "daemon client disposed" lesson from the Tasks pane).
    */
   readonly onDestroy?: () => void
 }

--- a/packages/kobe/src/tui/lib/keymap-overrides.ts
+++ b/packages/kobe/src/tui/lib/keymap-overrides.ts
@@ -36,7 +36,7 @@
  *     option/opt→alt, esc→escape, pgup/pgdn→pageup/pagedown.
  *   - `shift+<single char>` is rejected: terminals deliver shift+letter as
  *     a plain (uppercase) character, never as a shift-modified event, so
- *     such a chord can never match (see docs/KEYBINDINGS.md decision log).
+ *     such a chord can never match.
  *   - left/right ARROW keys are just `left` / `right`; left vs right
  *     MODIFIER keys cannot be told apart by terminal protocols, so there
  *     is no `lctrl`/`rcmd` syntax.

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -94,7 +94,7 @@ export interface TaskActionContext {
   readonly switchBeforeKill?: boolean
   /**
    * DIVERGENCE — publish the shared active-task focus after archive/delete
-   * (KOB-247). The Tasks pane sets this; the outer monitor historically
+   *. The Tasks pane sets this; the outer monitor historically
    * didn't and keeps that behavior.
    */
   readonly updateActiveTask?: boolean
@@ -285,7 +285,7 @@ export async function archiveTaskFlow(ctx: TaskActionContext, taskId: string): P
  * selection hook. The first attempt is deliberately non-force: the
  * orchestrator refuses to destroy a worktree with uncommitted/untracked
  * work and throws a DIRTY_WORKTREE error instead, so the user can't lose
- * unsaved work silently (KOB-244). A failed/declined delete leaves
+ * unsaved work silently. A failed/declined delete leaves
  * everything in place — no session kill, no selection move.
  */
 export async function deleteTaskFlow(ctx: TaskActionContext, taskId: string): Promise<void> {
@@ -487,7 +487,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
   let createdId: string | undefined
   if (result.mode === "adopt") {
     // Adopt: import one or more existing worktrees as tasks, focusing the last
-    // success (KOB-256). Each adopt is independent — collect per-item results
+    // success. Each adopt is independent — collect per-item results
     // so a later failure can't bury the ones that DID persist behind a generic
     // "couldn't create" toast (they'd be silently invisible). Surface a real
     // N/M summary instead.

--- a/packages/kobe/src/tui/lib/task-enter.ts
+++ b/packages/kobe/src/tui/lib/task-enter.ts
@@ -145,8 +145,8 @@ export interface EnterTaskOpts {
    *  heal, re-weave it). Off for adopt / when the caller delivers its own prompt. */
   includeInitPrompt?: boolean
   /** Re-run `ensureSession` on an ALREADY-running session to heal vendor/worktree
-   *  drift (cwd read from the session's `@kobe_worktree` tag — tasks.json can lag,
-   *  KOB-244). A heal failure never blocks the switch. Opt-in: the Tasks pane uses
+   *  drift (cwd read from the session's `@kobe_worktree` tag — tasks.json can lag).
+   *  A heal failure never blocks the switch. Opt-in: the Tasks pane uses
    *  it; the transitional new-task/quick-task pages don't. */
   heal?: boolean
   /** Save the CURRENT (from) session's layout into the global options before

--- a/packages/kobe/src/tui/new-task/host.tsx
+++ b/packages/kobe/src/tui/new-task/host.tsx
@@ -76,7 +76,7 @@ export function NewTaskPage(props: NewTaskHostArgs & { orchestrator: RemoteOrche
     try {
       if (result.mode === "adopt") {
         // Adopt one or more existing worktrees; enter the LAST one (mirrors the
-        // Tasks pane's "focus the last adopted" — KOB-256).
+        // Tasks pane's "focus the last adopted").
         for (const w of result.adopt) {
           entered = await orch.adoptWorktree({
             repo: result.repo,

--- a/packages/kobe/src/tui/ops/host-io.ts
+++ b/packages/kobe/src/tui/ops/host-io.ts
@@ -41,7 +41,7 @@ export interface OpsShellContext {
 export interface OpsActions {
   /** enter on a file → editor window, falling back to the opentui preview. */
   readonly openFile: (rel: string) => void
-  /** `a` — inject `@<path> ` into the engine pane (no Enter; KOB-232). */
+  /** `a` — inject `@<path> ` into the engine pane (no Enter). */
   readonly injectMention: (rel: string) => void
   /** `p` — send the PR prompt to the engine pane and submit it. */
   readonly createPR: () => Promise<void>
@@ -54,7 +54,7 @@ export interface OpsActions {
 export function makeOpsActions(ctx: OpsShellContext): OpsActions {
   // Open the file's diff/content in a full-width preview window of the
   // task's tmux session (`kobe-<taskId>`). Without a task id there is no
-  // session to target — bail rather than fire at a phantom (KOB-244).
+  // session to target — bail rather than fire at a phantom.
   function openPreview(rel: string): void {
     if (!ctx.taskId) return
     void newWindow(tmuxSessionName(ctx.taskId), {

--- a/packages/kobe/src/tui/ops/host.tsx
+++ b/packages/kobe/src/tui/ops/host.tsx
@@ -1,6 +1,6 @@
 /**
  * `kobe ops` host — the Ops pane on the right side of a task's tmux
- * session (v0.6 / KOB-233).
+ * session (v0.6).
  *
  * Reuses the v0.5 `FileTree` to browse the worktree. Activating a file
  * (enter / click) is a one-key "just open it": it opens the file in the
@@ -98,7 +98,7 @@ function OpsShell(props: OpsHostArgs) {
   const sharedActivityMap = () => activityOrch()?.transcriptActivitySignal()() ?? null
   const sharedEntry = (): TranscriptActivity | null => sharedActivityMap()?.get(props.worktree) ?? null
 
-  // New-activity badge (KOB-254). v0.6 has no chat-stream "done" signal and
+  // New-activity badge. v0.6 has no chat-stream "done" signal and
   // we explicitly don't parse the tmux pane, so the engine's own transcript
   // store (the JSONL the cost dashboard reads) is the source: light a corner
   // badge when its newest mtime advances past what we last acknowledged.

--- a/packages/kobe/src/tui/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui/panes/filetree/FileTree.tsx
@@ -116,7 +116,7 @@ export type FileTreeProps = {
    */
   focused?: Accessor<boolean>
   /**
-   * Optional right-aligned badge in the header (KOB-254). The Ops host
+   * Optional right-aligned badge in the header. The Ops host
    * uses it to surface "new engine activity since you last looked" —
    * `active: true` paints it in the accent colour. Omit (or return
    * `null`) to hide it.
@@ -125,7 +125,7 @@ export type FileTreeProps = {
   /**
    * Fires when the user explicitly refreshes the pane (`r`). The Ops
    * host treats a refresh as "I've looked" and clears the activity
-   * badge (KOB-254).
+   * badge.
    */
   onRefresh?: () => void
 }

--- a/packages/kobe/src/tui/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui/panes/filetree/header-view.tsx
@@ -1,7 +1,7 @@
 /**
  * Solid view for the file tree pane's header chrome — the optional
  * Zen / Create-PR action row, the All / Changes tab chips, the corner
- * activity badge (KOB-254), and the Changes-tab status legend. Split out
+ * activity badge, and the Changes-tab status legend. Split out
  * of `FileTree.tsx` (issue #15, G3; the component was over the 500-line
  * cap). Pure render — tab state and actions stay in the pane component.
  */
@@ -93,7 +93,7 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
             }}
           </For>
         </box>
-        {/* Right-aligned activity badge (KOB-254). No background fill so
+        {/* Right-aligned activity badge. No background fill so
            it stays clean in transparent mode. */}
         <Show when={props.cornerBadge}>
           {(badge) => (

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -347,8 +347,7 @@ export function Sidebar(props: SidebarProps) {
    * `[` from the leftmost lands on the rightmost and vice versa. Today
    * there are 2 views so both directions toggle, but the cycle shape is
    * preserved so a future third view drops in without a binding rewrite.
-   * (An earlier session briefly switched to clamp on a misread of the
-   * spec — Jackson confirmed loop is the intended behavior; the apparent
+   * (Loop, not clamp, is the intended behavior; the apparent
    * "[ goes right" bug was a pinyin-IME swallow.)
    */
   function cycleView(delta: -1 | 1): void {

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -347,8 +347,6 @@ export function Sidebar(props: SidebarProps) {
    * `[` from the leftmost lands on the rightmost and vice versa. Today
    * there are 2 views so both directions toggle, but the cycle shape is
    * preserved so a future third view drops in without a binding rewrite.
-   * (Loop, not clamp, is the intended behavior; the apparent
-   * "[ goes right" bug was a pinyin-IME swallow.)
    */
   function cycleView(delta: -1 | 1): void {
     const target = cycleViewTarget(view(), delta)

--- a/packages/kobe/src/tui/panes/sidebar/git-head.ts
+++ b/packages/kobe/src/tui/panes/sidebar/git-head.ts
@@ -1,7 +1,7 @@
 /**
  * Tiny git-HEAD poller for the sidebar's pinned "main" task rows.
  *
- * Each main task is bound to a saved repo (KOB-15) and shows the repo's
+ * Each main task is bound to a saved repo and shows the repo's
  * live current branch as a right-aligned hint — the row reads e.g.
  * `★ kobe   main`. The branch isn't stored on the task; it's computed
  * at display time so checking out a different branch in another shell
@@ -91,7 +91,7 @@ export async function resolveBranchHead(
   // detached HEAD) vs. both spawns failing/timing out. On a timeout both
   // spawns resolve with status:null and `value` stays "" — caching that
   // empty value against a still-valid HEAD fingerprint would permanently
-  // blank the branch label (KOB-8), so only the resolved case is cached.
+  // blank the branch label, so only the resolved case is cached.
   let resolved = false
   const ref = await spawn("git", ["symbolic-ref", "--short", "HEAD"], {
     cwd: repo,

--- a/packages/kobe/src/tui/panes/sidebar/groups.ts
+++ b/packages/kobe/src/tui/panes/sidebar/groups.ts
@@ -1,7 +1,7 @@
 /**
  * Pure list-shaping helpers for the sidebar pane.
  *
- * Wave 4.5 dropped repo grouping (Jackson decided "撤销 repo分组也太蠢了").
+ * Wave 4.5 dropped repo grouping.
  * The sidebar is now a flat list of task rows split into two views:
  *
  *   - "Working session" (active) — `task.archived === false`
@@ -69,7 +69,7 @@ export function filterByView(tasks: readonly Task[], view: SidebarView): Task[] 
  * the renderer can compare against the cursor without recounting.
  *
  * Row order in the active ("Working session") view:
- *   1. Pinned "main" tasks first, ordered by repo basename (KOB-15).
+ *   1. Pinned "main" tasks first, ordered by repo basename.
  *   2. User-pinned regular tasks (`pinned === true`), in input order.
  *   3. Other regular tasks (`kind === "task"`), in input order.
  *

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -76,7 +76,7 @@ export const IN_PROGRESS_SPINNER: readonly string[] = ["⠋", "⠙", "⠹", "⠸
 export const SPINNER_FRAME_MS = 100
 
 /**
- * The right-stuck PR-check chip for a task's subtitle row (KOB-10). The
+ * The right-stuck PR-check chip for a task's subtitle row. The
  * daemon's pr-status poller writes `task.prStatus`; this maps its `checkState`
  * to a single coloured glyph (✓ passing / ✗ failing / • pending). Returns null
  * for tasks with no PR or no checks configured (`none` / `unknown`) so the row

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -225,9 +225,8 @@ export function buildSidebarRowView(opts: {
  * `spinnerFrame: 0`. The frame is passed as an ACCESSOR and read only
  * when the row is actually loading — inside a Solid memo that makes the
  * 10Hz frame signal a conditional dependency, so an idle row never
- * re-derives on the spinner tick (waste audit: with N tasks and nothing
- * running, every row used to rebuild its whole view 10×/s; now the tick
- * has zero subscribers when no row spins). For a loading row this
+ * re-derives on the spinner tick (with N tasks and nothing running, the
+ * tick has zero subscribers — no row rebuilds its view 10×/s). For a loading row this
  * reproduces exactly what `buildSidebarRowView` would have produced with
  * the live frame: both glyph fields carry the spinner.
  */

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
@@ -2,14 +2,11 @@
  * Async, self-throttling poller behind the sidebar's per-row `+N −M`
  * worktree-changes chip.
  *
- * Why this exists (the 30GB-repo freeze): the chip used to call the
- * synchronous `readWorktreeChanges` (`spawnSync git status`) for EVERY
- * row on every ~2s `branchTick`. `git status` walks the working tree —
- * O(repo size) — so a row pointing at a huge repo blocked the whole
- * event loop for seconds per tick, permanently freezing the Tasks pane
- * the moment that row rendered (the Archives view was the reported
- * trigger). The sync helper survives ONLY for one-shot CLI use
- * (`kobe api`); render paths must go through this poller.
+ * Why this exists: `git status` walks the working tree — O(repo size) —
+ * so calling the synchronous `readWorktreeChanges` (`spawnSync git
+ * status`) from a render path blocks the whole event loop for seconds
+ * per tick on a huge repo. The sync helper survives ONLY for one-shot
+ * CLI use (`kobe api`); render paths must go through this poller.
  *
  * The scheduling core (per-key Solid signal, in-flight dedupe, adaptive
  * cadence, timeout + hard backoff) is the generic

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -128,8 +128,7 @@ export function Terminal(props: TerminalProps): JSXElement {
   // follow-bottom), negative moves up into history — tests assert this.
   // Clamped to the real history depth: an unbounded offset kept growing
   // past the top, so scrolling back down first had to "spin" through the
-  // phantom distance before anything moved (the overshoot half of the
-  // owner's wheel report).
+  // phantom distance before anything moved.
   const scrollBy = (lines: number): void => {
     const max = Math.max(0, snapshot().length - bodyRows())
     setScrollOffset((cur) => Math.min(max, Math.max(0, cur - lines)))
@@ -142,8 +141,8 @@ export function Terminal(props: TerminalProps): JSXElement {
   // copies the cells the highlight showed — dual delivery via
   // clipboard-copy.ts (pbcopy pipe + OSC52). DECLARED BEFORE the render
   // memos: cursorRows reads selection() during its EAGER first
-  // evaluation, and a later declaration is a TDZ crash (pane-crash,
-  // 2026-07-06). cellFromEvent/copySelection only run from event
+  // evaluation, and a later declaration is a TDZ crash.
+  // cellFromEvent/copySelection only run from event
   // handlers, so their later-declared reads (renderer) are safe.
   const [selAnchor, setSelAnchor] = createSignal<CellPoint | null>(null)
   const [selHead, setSelHead] = createSignal<CellPoint | null>(null)
@@ -302,8 +301,8 @@ export function Terminal(props: TerminalProps): JSXElement {
     // wrecked frame until the next real measurement. Skip until the box
     // has actually been laid out; onSizeChange re-fires this effect then.
     if (ref.width <= 0 || ref.height <= 0) return
-    // Flush grid — the body carries no padding (owner feedback 2026-07-06:
-    // the engine CLI owns its own gutters), so the full box width is usable.
+    // Flush grid — the body carries no padding (the engine CLI owns its
+    // own gutters), so the full box width is usable.
     const cols = Math.max(20, ref.width)
     const rows = Math.max(4, ref.height)
     setBodyRows(rows)
@@ -397,7 +396,7 @@ export function Terminal(props: TerminalProps): JSXElement {
         // One line per event: opentui's parser emits delta:1 per wheel
         // tick and the host terminal already granulates trackpad flicks
         // into a stream of ticks — multiplying here compounded to 3x
-        // speed and overshot the target ("滑过", owner report).
+        // speed and overshot the target.
         const step = Math.max(1, scroll.delta || 1)
         scrollBy(scroll.direction === "up" ? -step : step)
       }}

--- a/packages/kobe/src/tui/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui/panes/terminal/Terminal.tsx
@@ -247,10 +247,9 @@ export function Terminal(props: TerminalProps): JSXElement {
   // `\n`s. We render this as a single `<text>` element inside the
   // body so opentui's layout treats the body as a 1:1 cell grid —
   // crucial for the cursor positioning math (`body.screenY + c.y`).
-  // An earlier attempt rendered one `<text>` per row inside a flex
-  // column; opentui's per-row layout didn't keep `screenY` aligned
-  // with pane row indexing, and the cursor landed one row above
-  // the visible prompt.
+  // Per-row `<text>` elements in a flex column don't keep `screenY`
+  // aligned with pane row indexing (the cursor lands one row above
+  // the visible prompt), hence the single element.
   const styledSnapshot = createMemo(() => new StyledText(rowsToStyledText(cursorRows())))
   // Imperative content push — see the render-site comment (solid 0.4 content-prop gap).
   const [snapshotTextRef, setSnapshotTextRef] = createSignal<TextRenderable | null>(null)
@@ -273,8 +272,8 @@ export function Terminal(props: TerminalProps): JSXElement {
   // Yoga computes a new size) so effects reading non-reactive geometry
   // (`ref.width/height`) catch up with layout changes that have no Solid
   // signal of their own (a splitter drag resizes the pane downstream of
-  // the signal it mutates). A prior 1s-poll version left a remount's
-  // first pre-layout `ref.width` read stuck for up to a second.
+  // the signal it mutates). Event-driven, not polled — a poll leaves a remount's
+  // first pre-layout `ref.width` read stuck for the poll interval.
   const [geomTick, setGeomTick] = createSignal(0)
   const bumpGeomTick = (): void => {
     setGeomTick((n) => (n + 1) & 0xff)

--- a/packages/kobe/src/tui/panes/terminal/chattab.ts
+++ b/packages/kobe/src/tui/panes/terminal/chattab.ts
@@ -161,7 +161,7 @@ export async function buildPanesAround(
 ): Promise<void> {
   // Tag claude by a pane user-option — tmux renumbers panes by
   // position when the Tasks pane is inserted on the left, so the
-  // monitor can't rely on "first pane" to find claude (KOB-233).
+  // monitor can't rely on "first pane" to find claude.
   const envPrefix = inheritedEnvPrefix()
   // Build the rail at the user's global width so a brand-new task/chat tab
   // matches the size every existing task already shows (consistency across
@@ -197,7 +197,7 @@ export async function buildPanesAround(
       claudePane,
       "-l",
       // Fixed cell width (no `%`) so the Tasks rail is the same size in every
-      // window + across engine rebuilds (KOB-248). The width is the user's
+      // window + across engine rebuilds. The width is the user's
       // global preference, applied uniformly so every task shows one size.
       `${tasksWidth}`,
       "-c",

--- a/packages/kobe/src/tui/panes/terminal/keys-pure.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys-pure.ts
@@ -36,7 +36,7 @@ const CTRL_PUNCT_C0: Record<string, string> = {
  * Where the keystroke arrived as legacy bytes we forward `evt.sequence`
  * verbatim. Kitty CSI-u keystrokes must be re-encoded: the embedded PTY
  * never negotiated kitty, and opentui's parser makes `sequence`
- * unusable for them — measured on the real wire (probe 2026-07-06):
+ * unusable for them — measured on the real wire:
  * ctrl+c ⇒ `{ raw: "\x1b[99;5u", sequence: "c" }` (forwarding sequence
  * types a literal "c"!) while esc ⇒ `{ raw: "\x1b[27u", sequence:
  * "\x1b[27u" }` (forwarding sends garbage). So if EITHER field is
@@ -123,7 +123,7 @@ export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown"] as const
 
 /**
  * Chord strings the terminal pane must NEVER passthrough to the shell.
- * Deliberately MINIMAL (owner decision 2026-07-06): the engine CLI owns
+ * Deliberately MINIMAL: the engine CLI owns
  * its own chords (shift+tab plan-mode, ctrl+r history, ctrl+hjkl, F1…),
  * so kobe keeps only ctrl+q as the escape hatch plus the tab-management
  * and reset chords. Kobe's other global chords stay reachable from every
@@ -136,10 +136,10 @@ export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown"] as const
  *     same bindings array (scrollback) — first-match-wins handles them.
  */
 export const RESERVED_GLOBAL_CHORDS: readonly string[] = [
-  // THE escape hatch out of the terminal (KOB-208): from anywhere inside
+  // THE escape hatch out of the terminal: from anywhere inside
   // the engine CLI, ctrl+q returns to the tasks list. Everything else the
   // engine may want (shift+tab plan-mode, ctrl+hjkl, f1, ctrl+p, ctrl+,)
-  // now PASSES THROUGH — owner decision 2026-07-06: kobe must not eat the
+  // now PASSES THROUGH — kobe must not eat the
   // engine's own chords; kobe-global chords remain available from every
   // other pane.
   "ctrl+q",
@@ -152,7 +152,7 @@ export const RESERVED_GLOBAL_CHORDS: readonly string[] = [
   "f2",
   // Engine picker for a new chat tab (tmux's `ctrl+shift+t` equivalent —
   // ctrl+e instead, since the keymap layer can't distinguish shift+letter
-  // from the bare letter; see docs/KEYBINDINGS.md's KOB-74 decision log).
+  // from the bare letter).
   "ctrl+e",
   // Split panes inside the tab (tmux % / "): ctrl+\ splits right (the
   // glyph is a vertical divider), ctrl+= splits down (horizontal strokes),

--- a/packages/kobe/src/tui/panes/terminal/launch.ts
+++ b/packages/kobe/src/tui/panes/terminal/launch.ts
@@ -48,7 +48,7 @@ export function wrapEngineLaunch(engineCmd: string, remoteKey: string | undefine
  * restarts. Without this the Tasks pane could read the PRODUCTION
  * `~/.kobe/tasks.json` (KOBE_HOME_DIR missing) or connect to a dead
  * daemon (KOBE_DAEMON_SOCKET_PATH stale) → its task list / clicks
- * desynced from the outer monitor (KOB-244).
+ * desynced from the outer monitor.
  */
 export function inheritedEnvPrefix(): string {
   const parts: string[] = []

--- a/packages/kobe/src/tui/panes/terminal/pane-heal.ts
+++ b/packages/kobe/src/tui/panes/terminal/pane-heal.ts
@@ -20,7 +20,7 @@
  *   - {@link refreshKobeWorkspacePanes} — unconditional Tasks/Ops respawns
  *     after a settings change (`kobe reload`, Settings page exit).
  *   - {@link relaunchEngineInAllWindows} — the vendor-switch engine
- *     respawn (KOB-232), here because it is the same "respawn in place,
+ *     respawn, here because it is the same "respawn in place,
  *     keep pane ids" move aimed at the engine pane instead.
  *
  * The WHICH-panes policy is pure ({@link parseKobePaneRows},
@@ -170,7 +170,7 @@ export type PaneHealTarget =
  *     window with NO claude pane (`claudePaneId: null`) — `opsPaneCommand`
  *     already degrades to its git-status fallback, and skipping it
  *     silently left the pane on stale code after a `kobe reload`.
- *   - `vendorChanged: true` (the vendor-switch heal, KOB-232): respawn
+ *   - `vendorChanged: true` (the vendor-switch heal): respawn
  *     every OPS pane that still has a live claude pane regardless of
  *     version — the Ops pane bakes its `--vendor` flag at spawn time
  *     (`opsPaneCommand`), so on an in-place engine switch a same-version
@@ -319,7 +319,7 @@ export function classifyRelaunchOutcome(enginePaneCount: number, sequenceExitCod
  * `"respawn-failed"` when the batched respawn reported a tmux error (caller
  * leaves the prior `@kobe_vendor` tag rather than falsely claiming the switch).
  * Used to apply a vendor switch to a multi-window session without
- * `kill-session` dropping sibling chat tabs (KOB-232).
+ * `kill-session` dropping sibling chat tabs.
  *
  * Engine identity is re-woven PER WINDOW, exactly like the two fresh launch
  * paths (`ensureSession`'s create branch + `newChatTab`). The pre-fix code
@@ -471,7 +471,7 @@ export async function healWorkspaceLayout(
           force: false,
           // After an in-place vendor switch, force the Ops panes to respawn so
           // their baked `--vendor` flag (and the transcript store the activity
-          // badge / turn detector poll) match the new engine (KOB-232).
+          // badge / turn detector poll) match the new engine.
           vendorChanged: versions.vendorChanged,
         }),
         versions,

--- a/packages/kobe/src/tui/panes/terminal/pty.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty.ts
@@ -11,7 +11,7 @@
  * cells back to ANSI and re-parse them. xterm-headless owns the VT
  * emulation end to end; this file only maps its cells to chunks. (The
  * old cell→ANSI→reparse round-trip was where every render bug lived:
- * true-color SGR mis-parsing, multi-byte glyph corruption. KOB-224.)
+ * true-color SGR mis-parsing, multi-byte glyph corruption.)
  *
  * A pipe backend remains available through `KOBE_TERMINAL_BACKEND=pipe`
  * as a fallback for old Bun builds or unsupported platforms. It has no
@@ -76,7 +76,7 @@ export class BunTerminalTaskPty implements TaskPtyLike {
     // terminal on startup to detect its type/capabilities and to sync
     // its cursor model. Dropping the replies left claude on a fallback
     // path whose relative cursor-move + erase-to-EOL redraw landed on
-    // the wrong rows, half-erasing its input-box rule (KOB-208).
+    // the wrong rows, half-erasing its input-box rule.
     this.term.onData((data) => {
       if (this._killed) return
       try {
@@ -226,7 +226,7 @@ export class BunTerminalTaskPty implements TaskPtyLike {
     // boundary is reassembled correctly. Decoding each chunk to a UTF-8
     // string here instead corrupted any glyph straddling a boundary:
     // claude's full-width input-box rule rendered with gaps and its
-    // relative-cursor redraw landed on the wrong row (KOB-208).
+    // relative-cursor redraw landed on the wrong row.
     this.term.write(data, () => this.queueRefresh())
   }
 

--- a/packages/kobe/src/tui/panes/terminal/sgr.ts
+++ b/packages/kobe/src/tui/panes/terminal/sgr.ts
@@ -106,10 +106,9 @@ export function ansi256ToRgb(index: number): RGB {
  * magenta `#CD00CD`, …). Every ANSI slot kept its "expected" hue in
  * isolation, but real terminal themes commonly cluster several slots
  * (blue/cyan/bright-magenta) into one accent family — e.g. `ls`'s `di`
- * (directory, blue) and `ln` (symlink, cyan) read as the same violet in a
- * themed iTerm2 profile, but as two distinct colors against the stock
- * palette (reported as "kobe renders these wrong" — not a decode bug:
- * `ansi256ToRgb`/truecolor decode is bit-exact, verified).
+ * (directory, blue) and `ln` (symlink, cyan) can read as one accent
+ * family in a themed profile but as two distinct colors against the
+ * stock palette; `ansi256ToRgb`/truecolor decode is bit-exact either way.
  *
  * Replaced with Tokyo Night's published terminal ANSI colors (a popular
  * modern scheme, also one of kobe's own bundled UI themes) so the

--- a/packages/kobe/src/tui/panes/terminal/sgr.ts
+++ b/packages/kobe/src/tui/panes/terminal/sgr.ts
@@ -108,8 +108,8 @@ export function ansi256ToRgb(index: number): RGB {
  * (blue/cyan/bright-magenta) into one accent family — e.g. `ls`'s `di`
  * (directory, blue) and `ln` (symlink, cyan) read as the same violet in a
  * themed iTerm2 profile, but as two distinct colors against the stock
- * palette (KOB, 2026-07-06: reported as "kobe renders these wrong," not a
- * decode bug — `ansi256ToRgb`/truecolor decode is bit-exact, verified).
+ * palette (reported as "kobe renders these wrong" — not a decode bug:
+ * `ansi256ToRgb`/truecolor decode is bit-exact, verified).
  *
  * Replaced with Tokyo Night's published terminal ANSI colors (a popular
  * modern scheme, also one of kobe's own bundled UI themes) so the

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -3,7 +3,7 @@
  * terminal emulators select, replacing opentui's text-flow selection
  * which broke over this pane (the snapshot <text> is replaced wholesale
  * on every PTY frame, so flow anchors were invalidated mid-drag:
- * glitchy highlight, empty extraction, owner report 2026-07-06).
+ * glitchy highlight, empty extraction).
  *
  * Everything here is pure and cell-addressed: a selection is an anchor
  * and a head in ABSOLUTE snapshot coordinates (row = index into the

--- a/packages/kobe/src/tui/panes/terminal/tmux-session-bindings.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux-session-bindings.ts
@@ -113,7 +113,7 @@ export function tasksRestoreEdgeCommand(restoreTasksCommand: string): string {
  * server is definitely up. All `-g` options are idempotent so
  * calling them on every ensureSession is harmless.
  *
- * Status bar: ON (KOB-233). v0.5/KOB-225 hid it because there was
+ * Status bar: ON. v0.5 hid it because there was
  * only one pane and it was pure noise. With three panes it's useful
  * — it tells the user they're inside a kobe-managed tmux session,
  * which pane/window is active, and how to get out. We explicitly
@@ -150,7 +150,7 @@ export function tasksRestoreEdgeCommand(restoreTasksCommand: string): string {
  * vim-tmux-navigator convention — and are edge-guarded so they never
  * wrap (see focusBindCommand). (Ctrl+1/2/3 was tried first but
  * terminals can't encode Ctrl+<digit> without the kitty protocol, so
- * the bindings registered yet never fired — KOB-233.) Directional
+ * the bindings registered yet never fired.) Directional
  * keys DO produce distinct codes and are the tmux-idiomatic choice.
  * Server-scoped on the `-L kobe` socket so the user's own tmux is
  * untouched. Trade-off: this shadows readline Ctrl+k (kill-line) /
@@ -256,7 +256,7 @@ export async function installSessionBindings(inv: readonly string[]): Promise<vo
   const clipboardCopyCommand = resolveClipboardCopyCommand(process.platform, clipboardBinaryOnPath)
   const clipboardBindings = clipboardTmuxConfig(clipboardCopyCommand)
   // `<prefix> f` = quick-create: open the prompt-only quick-task page (the
-  // v0.5 quick-fork chord, KOB-74, reborn in the tmux world). `kobe
+  // v0.5 quick-fork chord, reborn in the tmux world). `kobe
   // quick-create` opens `kobe quick-task` in its own window, which asks for
   // ONLY a prompt and fills repo / engine / base branch from this task's
   // defaults, then creates + delivers and exits. PREFIX-scoped (not no-prefix
@@ -270,7 +270,7 @@ export async function installSessionBindings(inv: readonly string[]): Promise<vo
   // small one). tmux's default sizes a window to the SMALLEST client of the
   // session regardless of which window that client is actually viewing — so a
   // small client on chat-tab B drags chat-tab A down for the big client too,
-  // which then squeezes the fixed-width Tasks pane (KOB-248) against a too-narrow
+  // which then squeezes the fixed-width Tasks pane against a too-narrow
   // window. `aggressive-resize on` scopes the size to the client(s) for which the
   // window is CURRENT, so each chat-tab window tracks only its own viewer.
   // Same-session clients still share one tmux grid; prepareWindowForAttach /

--- a/packages/kobe/src/tui/panes/terminal/tmux-session-create.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux-session-create.ts
@@ -33,7 +33,7 @@ import { attachedWindowInfo, tmuxInitialSizeArgs } from "./tmux.ts"
  * surrounding panes. Each pane command is passed as the trailing arg to
  * new-session / split-window — tmux runs it via its own `sh -c`, so we
  * hand it a single shell command STRING and skip send-keys (which
- * re-parses text and mangled the Ops `sh -c` quoting in KOB-233). Pane
+ * re-parses text and mangled the Ops `sh -c` quoting). Pane
  * ids (`%N`) are server-global and immune to `base-index`, so we always
  * target by id.
  */

--- a/packages/kobe/src/tui/panes/terminal/tmux-session.ts
+++ b/packages/kobe/src/tui/panes/terminal/tmux-session.ts
@@ -94,7 +94,7 @@ const ensureSessionLocks = new Map<string, Promise<boolean>>()
  * Ensure a detached session named `name` exists with the four-pane
  * layout. Returns `true` once the session is ready (reused or freshly
  * built), `false` if creation failed (so callers can avoid attaching to
- * a nonexistent session — KOB-244).
+ * a nonexistent session).
  *
  * Idempotent in the happy path: a healthy session that matches this
  * task is left running (that's the persistence — it survives detach /
@@ -191,8 +191,8 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
   // to a task. No per-worktree write, so reuse/rebuild/fresh all behave the
   // same and a project's real repo root is never touched.)
   //
-  // Observe → decide → apply. The WHY of each branch (KOB-244 pane-count
-  // trap, KOB-232 sibling-tab preservation, legacy/pre-tag rebuilds) is
+  // Observe → decide → apply. The WHY of each branch (pane-count
+  // trap, sibling-tab preservation, legacy/pre-tag rebuilds) is
   // documented on `decideSessionAction`; this function only applies the
   // chosen action against the real tmux server.
   const observed = await observeSession(opts.name)
@@ -215,7 +215,7 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
 
   // Vendor switch: relaunch the engine pane IN PLACE in every window via
   // respawn-pane (keeps pane ids + @kobe_role tags, so the Ops pane's
-  // --target-pane stays valid — KOB-232). Falls through to a full rebuild
+  // --target-pane stays valid). Falls through to a full rebuild
   // when no engine pane is found to respawn — that fact is only knowable
   // here at apply time, so it's the applier's fallback, not the decision's.
   if (action.kind === "respawn-engine") {
@@ -229,7 +229,7 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
       // `vendorChanged` forces every window's Ops pane to respawn so its baked
       // `--vendor` flag (and the transcript store its activity badge + turn
       // detector poll) tracks the NEW engine — a same-version Ops pane would
-      // otherwise keep polling the OLD vendor's store (KOB-232).
+      // otherwise keep polling the OLD vendor's store.
       await healWorkspaceLayout(opts.name, {
         cwd: opts.cwd,
         taskId: opts.taskId,
@@ -242,7 +242,7 @@ async function ensureSessionImpl(opts: EnsureSessionOpts): Promise<boolean> {
       // A respawn in some window failed (tmux already logged the error and
       // halted the sequence). The session still exists and is usable, so we
       // do NOT kill+rebuild — that would drop the sibling chat tabs the
-      // in-place respawn exists to preserve (KOB-232). We also leave the prior
+      // in-place respawn exists to preserve. We also leave the prior
       // `@kobe_vendor` tag untouched rather than falsely claim the switch; the
       // tag still mismatching the task's vendor means the next `ensureSession`
       // re-enters this respawn branch and retries. Heal layout WITHOUT

--- a/packages/kobe/src/tui/panes/terminal/use-terminal-pty.ts
+++ b/packages/kobe/src/tui/panes/terminal/use-terminal-pty.ts
@@ -51,7 +51,7 @@ export function useTerminalPty(opts: {
 
   // Latest structured snapshot from the PTY: one style-run list per row,
   // already opentui-ready. The Bun backend builds these straight from
-  // xterm's cells; there is no ANSI string to re-parse (KOB-224).
+  // xterm's cells; there is no ANSI string to re-parse.
   const [snapshot, setSnapshot] = createSignal<readonly TerminalRow[]>([])
 
   // Latest cursor position from the PTY (null when backend can't report).

--- a/packages/kobe/src/tui/tasks-pane/actions.ts
+++ b/packages/kobe/src/tui/tasks-pane/actions.ts
@@ -309,7 +309,7 @@ export function buildTaskActionsContext(deps: TaskActionsContextDeps): CreateTas
     confirm: async (p) =>
       (await DialogConfirm.show(deps.dialog, p.title, p.body, p.cancelLabel, p.confirmLabel)) === true,
     // Dialogs show IN the Tasks pane without zooming it full-window
-    // (KOB-244): the old `resize-pane -Z` hid the claude / ops / shell
+    //: the old `resize-pane -Z` hid the claude / ops / shell
     // panes for the dialog's lifetime, which felt like the whole layout
     // "popped out". The dialog overlay already caps to the pane width
     // (`maxWidth = dimensions().width - 2`), so it renders fine in the
@@ -323,7 +323,7 @@ export function buildTaskActionsContext(deps: TaskActionsContextDeps): CreateTas
     // This pane runs INSIDE the tmux client whose session a delete kills —
     // switch away first so the kill doesn't yank the user's terminal.
     switchBeforeKill: true,
-    // Publish the shared active-task focus so every surface follows (KOB-247).
+    // Publish the shared active-task focus so every surface follows.
     updateActiveTask: true,
     onTaskDeleted: (taskId, nextTask) => {
       if (deps.selectedId() !== taskId) return

--- a/packages/kobe/src/tui/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui/tasks-pane/host.tsx
@@ -1,6 +1,6 @@
 /**
  * `kobe tasks` — the experimental Tasks pane on the far left of a task's
- * tmux session (KOB-233). agent-deck-style: keep the task list visible
+ * tmux session. agent-deck-style: keep the task list visible
  * inside a tmux Session so you can jump between tasks without detaching to
  * the outer monitor. Reuses the real `Sidebar`; Enter `switch-client`s to
  * a task's session.
@@ -69,7 +69,7 @@ export function TasksShell(props: {
    * The shared task-state framework: one daemon-backed RemoteOrchestrator
    * used for BOTH the live subscribe (reads) and every mutation (writes),
    * so the Tasks pane goes through the same single source of truth as the
-   * outer monitor — no ad-hoc per-op clients (KOB-244). `null` only in the
+   * outer monitor — no ad-hoc per-op clients. `null` only in the
    * degraded no-daemon fallback, where mutations are unavailable.
    */
   orch: RemoteOrchestrator | null
@@ -159,7 +159,7 @@ export function TasksShell(props: {
   // pane on every resize.
   const dimensions = useTerminalDimensions()
 
-  // Shared active-task focus (`active-task` channel, KOB-247) is followed
+  // Shared active-task focus (`active-task` channel) is followed
   // ONLY by a HOME pane (no initialTaskId) — the navigational surface where
   // selecting a row IS the focus. A pane SPAWNED for a task session pins its
   // highlight to that one task instead: following shared focus made it LIE
@@ -245,7 +245,7 @@ export function TasksShell(props: {
   }
 
   // Rename a task's title via the daemon's `task.rename` RPC (same flow
-  // the outer app's `r` uses). No pane zoom (KOB-244) — the dialog shows
+  // the outer app's `r` uses). No pane zoom — the dialog shows
   // in place; the other panes stay visible.
   async function renameTask(id: string): Promise<void> {
     await renameTaskFlow(taskActions, id)
@@ -463,7 +463,7 @@ export function TasksShell(props: {
           // (new-task / rename) leaks past the input to switchTo and yanks
           // you into a task (the Sidebar's Enter isn't registered through
           // the input's onSubmit, so the keymap falls through to it). Mirrors
-          // the n/b/v gate above (KOB-244).
+          // the n/b/v gate above.
           focused={() => dialog.stack.length === 0}
           onSearchActiveChange={setSearchActive}
           // Track the cursor row so the host-scoped o/b/v chords act on the

--- a/packages/kobe/src/tui/tasks-pane/setup.tsx
+++ b/packages/kobe/src/tui/tasks-pane/setup.tsx
@@ -25,14 +25,14 @@ export async function setupTasksPane(opts: { initialTaskId?: string }): Promise<
   // Task source. PRIMARY = a live daemon SUBSCRIBE (via RemoteOrchestrator):
   // a task created / renamed / deleted in ANY session's Tasks pane or in
   // the outer monitor is pushed to THIS pane in real time, so every
-  // session's list stays in sync (KOB-244 — a new task wasn't showing up
+  // session's list stays in sync (a new task wasn't showing up
   // in an already-open session's Tasks pane). The shared env baked onto
   // this pane's command (inheritedEnvPrefix) guarantees we connect to the
   // SAME daemon as everyone else.
   //
   // FALLBACK = a direct tasks.json read + slow poll, used only when the
   // daemon is unreachable. MUST pass `homeDir()` (KOBE_HOME_DIR-aware) or
-  // it would read the PRODUCTION `~/.kobe/tasks.json` (KOB-233).
+  // it would read the PRODUCTION `~/.kobe/tasks.json`.
   const store = new TaskIndexStore({ homeDir: homeDir() })
   await store.load()
   const [fileTasks, setFileTasks] = createSignal<readonly Task[]>(store.list())
@@ -121,7 +121,7 @@ export async function setupTasksPane(opts: { initialTaskId?: string }): Promise<
     // onDestroy), so disposing here is the only correct place. Disposing
     // after `await render(...)` killed the daemon client + poll the moment
     // the pane mounted → "daemon client disposed" on the next switch and
-    // a dead subscribe (KOB-247).
+    // a dead subscribe.
     onDestroy: () => {
       if (timer) clearInterval(timer)
       orch?.dispose()

--- a/packages/kobe/src/tui/tasks-pane/shortcut-hints.tsx
+++ b/packages/kobe/src/tui/tasks-pane/shortcut-hints.tsx
@@ -46,7 +46,7 @@ export function legendRowCap(ids: readonly string[]): string | null {
 }
 
 /**
- * A small shortcut legend pinned to the bottom of the Tasks pane (KOB-244):
+ * A small shortcut legend pinned to the bottom of the Tasks pane:
  * shows the in-pane task actions plus the session-level tmux chords so the
  * keys are discoverable without leaving the pane. The `ctrl+h/j/k/l` and
  * `ctrl+[/]` lines are tmux session bindings — shown here, not rebound.

--- a/packages/kobe/src/tui/ui/dialog-confirm.tsx
+++ b/packages/kobe/src/tui/ui/dialog-confirm.tsx
@@ -68,10 +68,9 @@ export function DialogConfirm(props: DialogConfirmProps) {
     ],
   }))
 
-  // Tight vertical layout — confirms used to have a paragraph-of-air
-  // around the title/message/buttons (gap=1 + bottom paddings), which
-  // made a six-word prompt take 7 vertical lines. Now: title row,
-  // message right under it, buttons row right under that. The dialog
+  // Tight vertical layout: title row, message right under it, buttons
+  // row right under that — no gaps or bottom paddings, so a six-word
+  // prompt stays compact. The dialog
   // wrapper still adds a 1-row paddingTop above the card body.
   return (
     <box paddingLeft={2} paddingRight={2} paddingBottom={1} gap={0}>

--- a/packages/kobe/src/tui/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalSplit.tsx
@@ -148,7 +148,7 @@ export function TerminalSplit(props: {
 
   const leafFocused = (id: string) => props.focused() && state().activeLeafId === id
 
-  /* Dividers, not frames (owner feedback 2026-07-06): a node draws ONLY
+  /* Dividers, not frames: a node draws ONLY
    * the single edge it shares with its previous sibling (`left` in a row,
    * `top` in a column) — tmux's separator-line look, zero padding, no
    * outer wrapping. The divider a focused LEAF owns lights up in the
@@ -160,8 +160,7 @@ export function TerminalSplit(props: {
   // and in the `borderColor` setter (`initializeBorder`), and the setter
   // fires even for undefined because parseColor mints a fresh RGBA every
   // call. Hence the conditional spread. This coercion is what drew the
-  // phantom frames around the first leaf and the group (owner
-  // screenshot, 2026-07-06).
+  // phantom frames around the first leaf and the group.
   const dividerProps = (divider: "left" | "top" | undefined, color: () => RGBA) =>
     divider ? { border: [divider] as ("left" | "top")[], borderColor: color() } : { border: false as const }
 

--- a/packages/kobe/src/tui/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalTabs.tsx
@@ -377,7 +377,7 @@ export function TerminalTabs(props: {
     update(next)
   }
 
-  /** Vendor exit is an allowed case (owner decision 2026-07-06): an engine
+  /** Vendor exit is an allowed case: an engine
    *  tab whose CLI exits degrades into a plain shell at the same worktree
    *  instead of freezing behind the dead-shell banner. */
   function degradeToShell(id: string): void {
@@ -441,7 +441,7 @@ export function TerminalTabs(props: {
     })()
   }
 
-  /** What a plain ctrl+t tab should run (owner decision 2026-07-06): the
+  /** What a plain ctrl+t tab should run: the
    *  full preference chain — repo lastActiveVendor (ctrl+e / dialog picks
    *  write it) → Settings global default → claude. Returning undefined
    *  when the resolution equals the task's engine keeps the tab in

--- a/packages/kobe/src/tui/workspace/host.tsx
+++ b/packages/kobe/src/tui/workspace/host.tsx
@@ -310,7 +310,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   }
 
   /* --------- zen mode (issue #18, pure-tui shape) -----------------------
-   * Matches the tmux zen contract (owner 2026-07-06): hide the FILES
+   * Matches the tmux zen contract: hide the FILES
    * column, keep the Tasks sidebar visible (tmux keeps it per the
    * zenKeepTasks setting — hardcoded keep here for now), terminal takes
    * the freed width. Entering pulls focus to the terminal; the way out is
@@ -339,8 +339,8 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
    * `kobe ops --preview` full CLI subcommand is out of scope for this pass).
    *
    * Focus: opening an INTERACTIVE editor tab pulls focus to the workspace
-   * (owner ask 2026-07-06 — an editor you can't type into is broken), in
-   * deliberate contrast to KOB-25's no-focus-pull rule, which applies to
+   * (an editor you can't type into is broken), in
+   * deliberate contrast to the no-focus-pull rule, which applies to
    * read-only content swaps (previews), not to spawned editors.
    */
   async function openFileInEditor(relPath: string): Promise<void> {
@@ -414,7 +414,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // d/a/r/pin/move fire from the Sidebar's OWN keys via the Request props
   // below; these three are host-scoped in both hosts. Gated on sidebar
   // focus + no dialog + search inactive (typing `n` into the search box
-  // must not open the new-task dialog — same leak class as KOB-244).
+  // must not open the new-task dialog — same chord-leak class).
   useBindings(() => ({
     enabled:
       dialog.stack.length === 0 && !settingsOpen() && !worktreesOpen() && focus.is("sidebar")() && !searchActive(),
@@ -462,8 +462,8 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
         }
       >
         <box flexDirection="row" flexGrow={1} backgroundColor={theme.background}>
-          {/* Tasks sidebar stays visible in zen (tmux-parity, owner
-              2026-07-06) — its ☯ ZEN chip is also the exit affordance. */}
+          {/* Tasks sidebar stays visible in zen (tmux parity) — its
+              ☯ ZEN chip is also the exit affordance. */}
           <box
             width={SIDEBAR_WIDTH}
             flexShrink={0}
@@ -545,7 +545,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
                 // + its refresh-as-ack, same contract as ops/host.tsx.
                 cornerBadge={filesCornerBadge}
                 onRefresh={() => setBadgeBaseline(badgeLatest())}
-                // Ops-pane corner actions (owner ask 2026-07-06): zen + PR.
+                // Ops-pane corner actions: zen + PR.
                 onZenToggle={toggleZen}
                 onCreatePR={() => void createPR()}
               />

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -124,8 +124,8 @@ export function openEditorTab(state: TabsState, command: readonly string[], labe
 
 /**
  * Degrade an engine tab whose CLI exited into a plain shell tab. Exiting
- * the vendor CLI is an allowed action, not an error (owner decision
- * 2026-07-06): the tab keeps its identity (id/title/ordinal) and respawns
+ * the vendor CLI is an allowed action, not an error: the tab keeps
+ * its identity (id/title/ordinal) and respawns
  * as `shell` in the same worktree instead of freezing behind the
  * dead-shell exit banner. No-op if the tab is gone or already a command
  * tab (those close themselves on exit instead — see `TerminalTabs.tsx`).

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -73,7 +73,7 @@ export type PRLifecycleState = "creating" | "open" | "ready_to_merge" | "merged"
 /**
  * PR status persisted on Task. v0.6 keeps the shape (the monitor can
  * still display it) but the orchestrator no longer drives PR creation
- * itself — KOB-232 will re-introduce the create-PR flow via the Ops
+ * itself — a follow-up will re-introduce the create-PR flow via the Ops
  * pane (`tmux send-keys` into the claude pane).
  */
 export interface TaskPRStatus {

--- a/packages/kobe/src/types/vendor.ts
+++ b/packages/kobe/src/types/vendor.ts
@@ -7,7 +7,7 @@
  * whose interactive CLI runs inside the tmux pane and whose on-disk
  * history JSONL the outer monitor reads for the live preview rail and
  * cost dashboard: `"claude"`, `"codex"`, and `"copilot"` (GitHub
- * Copilot CLI, ported into the v0.6 shape in KOB-249).
+ * Copilot CLI, ported into the v0.6 shape).
  *
  * Per-task vendor is still recorded on Task so the monitor knows
  * which history-reader to call.

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -28,7 +28,7 @@ export interface WorktreeInfo {
 
 /**
  * A git worktree discovered on disk that COULD be adopted as a kobe
- * task (KOB-256). Unlike {@link WorktreeInfo} (kobe-managed only), this
+ * task. Unlike {@link WorktreeInfo} (kobe-managed only), this
  * includes worktrees the user created outside kobe-managed worktree roots
  * via plain `git worktree add`. `kobeManaged` marks whether the path
  * lives under the kobe convention root, so the UI can label its origin.
@@ -43,7 +43,7 @@ export interface AdoptableWorktree {
    * Last-activity time (epoch ms) — the worktree HEAD's commit time,
    * falling back to the directory mtime. Discovery sorts by this
    * descending so the most recently-touched worktree leads the list
-   * (KOB-256).
+   *.
    */
   readonly lastActivityMs: number
 }

--- a/packages/kobe/src/version.ts
+++ b/packages/kobe/src/version.ts
@@ -13,8 +13,8 @@
  *     is much smaller than the full package metadata. Anonymous, no
  *     auth, generous rate limit.
  *
- *   - The TUI checks the registry on every launch. We used to cache this
- *     for 6h, but that made the topbar miss freshly published versions.
+ *   - The TUI checks the registry on every launch, uncached (a cache
+ *     makes the topbar miss freshly published versions).
  *     The request is still async and capped at 3s, so startup does not
  *     wait for npm.
  *

--- a/packages/kobe/test/cli/doctor-resources.test.ts
+++ b/packages/kobe/test/cli/doctor-resources.test.ts
@@ -1,10 +1,3 @@
-/**
- * `kobe doctor` resource section — pure halves (ps-output parsing +
- * pane-group filtering) plus the async wiring (`resourceDoctorLines`)
- * against a mocked tmux + `ps`. Why this matters: #205's memory reports had
- * no hard numbers to triage from; this is what kobe uses to build them.
- */
-
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({

--- a/packages/kobe/test/cli/doctor-terminal.test.ts
+++ b/packages/kobe/test/cli/doctor-terminal.test.ts
@@ -1,11 +1,3 @@
-/**
- * `kobe doctor` terminal section — pure halves only (env formatting + kitty
- * probe reply parsing). Why this matters: keyboard bugs are terminal-
- * dependent (issue #192 — Terminal.app's legacy key path broke ctrl+h/j),
- * and doctor's terminal line is how a reporter tells us which key path
- * they're on. The live TTY probe is I/O-thin and untested by design.
- */
-
 import { EventEmitter } from "node:events"
 import { describe, expect, test, vi } from "vitest"
 import {

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -459,12 +459,6 @@ describe("worktree.changes pure helpers", () => {
 })
 
 describe("framework-free store twins (React hosts, issue #15 G3)", () => {
-  // Why this matters: React panes receive live daemon pushes ONLY through
-  // these stores — solid-js signals are inert under node/vitest and plain
-  // bun (SSR build). If the dual-write drifts or stops notifying, React
-  // panes silently freeze on boot-time prefs. Note the SUBSCRIBE assertions:
-  // in this very environment the Solid accessor would not notify, which is
-  // the reason the stores exist.
   it("ui-prefs channel lands in uiPrefsStore and notifies subscribers", () => {
     const { client, emit } = fakeClient()
     const orch = new RemoteOrchestrator(client)

--- a/packages/kobe/test/daemon/client-pending.test.ts
+++ b/packages/kobe/test/daemon/client-pending.test.ts
@@ -6,24 +6,6 @@ import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 /**
- * Memory-leak contract for the daemon client's in-flight request map.
- *
- * Why this matters: `request()` parks a `{ resolve, reject }` pair in the
- * `pending` map until a response frame arrives. Both `close()` and
- * `forceDisconnect()` null `this.socket` BEFORE the socket's own close
- * event fires, so `onSocketClose`'s stale-close guard skips the pending
- * sweep for those paths. Without an explicit sweep in close/forceDisconnect,
- * every teardown that raced an in-flight RPC leaked the entry (promise,
- * resolver closures, request payload) for the life of the client — and the
- * TUI's `manualReconnect()` calls `forceDisconnect()` on every user-driven
- * reconnect, so the leak multiplied across a day-long session.
- *
- * The observable contract: tearing the connection down rejects every
- * in-flight request with the same "daemon connection closed" error the
- * passive-drop path uses, and leaves nothing pending.
- */
-
-/**
  * `request()` awaits `connect()` before parking the entry in `pending`, so
  * after firing a request we must yield the event loop once — otherwise a
  * synchronous teardown lands BEFORE the entry exists and the rejection comes

--- a/packages/kobe/test/state/store.test.ts
+++ b/packages/kobe/test/state/store.test.ts
@@ -85,12 +85,6 @@ describe("loadStateFile", () => {
 })
 
 describe("patchStateFile — the lost-update fix", () => {
-  // Why this matters: THE bug this module exists for. Process A (the TUI's
-  // KVProvider) loads its snapshot at boot; process B (a Tasks pane via
-  // setPersistedString) writes a new key afterwards; process A then
-  // flushes a DIFFERENT dirty key. Under the old whole-snapshot write-back
-  // A's flush rewrote the file from its stale snapshot and B's key
-  // vanished. With read-merge-write, B's key must survive.
   test("interleaved writers do not lose each other's keys", () => {
     writeDisk({ activeTheme: "claude" })
 

--- a/packages/kobe/test/tui-react/external-store.test.ts
+++ b/packages/kobe/test/tui-react/external-store.test.ts
@@ -1,11 +1,3 @@
-/**
- * Why this matters: `createExternalStore` is the reactive backbone of every
- * React infra module (i18n language, theme state, keymap version). A bug in
- * notify/dedupe semantics would silently freeze React panes on stale
- * language/theme — the exact failure `useSyncExternalStore` is supposed to
- * prevent — so the contract is pinned here framework-free.
- */
-
 import { describe, expect, it, vi } from "vitest"
 import { createExternalStore } from "../../src/lib/external-store"
 

--- a/packages/kobe/test/tui-react/history-mock-fixtures.test.ts
+++ b/packages/kobe/test/tui-react/history-mock-fixtures.test.ts
@@ -1,10 +1,3 @@
-/**
- * Why this matters: these fixtures back BOTH frameworks' mock hosts
- * (dev:mock and dev:mock-react-history) — the live render smokes in the
- * migration gates grep for this data. If the fake reader drifts from the
- * EngineHistoryReader contract, the smokes go blind while looking green.
- */
-
 import { describe, expect, it } from "vitest"
 import {
   MOCK_HISTORY_SESSION_ID,

--- a/packages/kobe/test/tui-react/i18n.test.ts
+++ b/packages/kobe/test/tui-react/i18n.test.ts
@@ -1,11 +1,3 @@
-/**
- * Why this matters: the React i18n runtime re-implements the Solid one's
- * OBSERVABLE behavior (dotted lookup, en → raw-key fallback, interpolation,
- * per-process language switch) on a different reactivity substrate. These
- * tests pin that the two runtimes resolve identically — drift here means a
- * pane shows different copy depending on which framework rendered it.
- */
-
 import { afterEach, describe, expect, it } from "vitest"
 import { DEFAULT_LOCALE, currentLang, setLocaleLang, t, tKeys } from "../../src/tui-react/i18n"
 import { t as solidT } from "../../src/tui/i18n"

--- a/packages/kobe/test/tui-react/keymap-version.test.ts
+++ b/packages/kobe/test/tui-react/keymap-version.test.ts
@@ -1,11 +1,3 @@
-/**
- * Why this matters: the keymap table is mutated IN PLACE on live reloads —
- * invisible to React. Chord legends re-render only through the version
- * subscription added in G2 (`subscribeKeymapVersion`), which must fire in
- * lockstep with the Solid signal bump or React panes show stale chords
- * after a keybindings.json reload.
- */
-
 import { describe, expect, it } from "vitest"
 import {
   bindByIds,

--- a/packages/kobe/test/tui-react/theme-core.test.ts
+++ b/packages/kobe/test/tui-react/theme-core.test.ts
@@ -1,13 +1,3 @@
-/**
- * Why this matters: `applyDisplayOverlay` encodes two policies both
- * frameworks must share exactly — the user-picked focus-accent slot (with
- * primary fallback for themes missing the slot) and transparent mode's
- * "chrome goes alpha-0, dialog card stays opaque" rule (see
- * memory/feedback_transparent_default_aggressive.md). The overlay was
- * extracted from the Solid provider during G2; this pins the extraction
- * didn't change behavior and the React provider inherits the same rules.
- */
-
 import { describe, expect, it } from "vitest"
 import { BUNDLED_THEMES, applyDisplayOverlay, resolveTheme } from "../../src/tui/context/theme-core"
 

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -1,11 +1,3 @@
-/**
- * Why this matters: hostRenderOptions is the render contract EVERY pane host
- * (Solid and React) passes to createCliRenderer — a drifted flag here changes
- * terminal behavior for all panes at once (alt-screen, ctrl+c semantics,
- * passthrough). installPaneExitBackstop is the orphaned-helper fix (KOB —
- * SIGHUP-swallow leak): registration must cover exactly the three signals.
- */
-
 import { afterEach, describe, expect, it } from "vitest"
 import { hostRenderOptions, installPaneExitBackstop } from "../../src/tui/lib/host-render-options"
 

--- a/packages/kobe/test/tui/render-path-sync-guard.test.ts
+++ b/packages/kobe/test/tui/render-path-sync-guard.test.ts
@@ -1,22 +1,3 @@
-/**
- * CI guard: render processes must not run synchronous subprocesses.
- *
- * Why this matters (the 30GB-repo freeze): a `spawnSync git status` on
- * the sidebar's ~2s tick blocked the whole event loop for the duration
- * of an O(repo size) status walk — the Tasks pane hard-froze the moment
- * a huge repo's row rendered. Every `src/tui/**` file runs inside a
- * render process (the TUI itself or a tmux pane host), so a sync
- * subprocess anywhere in the tree is a freeze waiting for a big enough
- * repo. Live data belongs in `src/tui/lib/background-poll.ts`
- * (reactive read + fire-and-forget async poll); one-shot actions use
- * async spawn (`spawnCapture`) with await at the call site.
- *
- * This test scans `src/tui/**` source for `spawnSync` / `execSync` /
- * `execFileSync` imports-or-calls and fails unless the file is in the
- * whitelist below. Add to the whitelist only with a reason — and prefer
- * not adding at all.
- */
-
 import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"

--- a/packages/kobe/test/tui/split-core.test.ts
+++ b/packages/kobe/test/tui/split-core.test.ts
@@ -1,14 +1,3 @@
-/**
- * Why this matters: the split tree IS the tmux-pane contract inside one
- * workspace surface (issue #16) — same-orientation splits become
- * siblings, cross-orientation splits nest, finished leaves collapse
- * their group, and the tree stays content-agnostic (leaves carry an
- * opaque payload). The terminal adapter's key rule — `leaf-1` keeps the
- * tab-level PTY key so the engine session survives the first split —
- * is pinned here too via `splitLeafPtyKey`. A regression scrambles
- * leaf→resource mapping and kills or orphans live engine processes.
- */
-
 import { describe, expect, it } from "vitest"
 import {
   type SplitGroup,

--- a/packages/kobe/test/tui/terminal-keys-pure.test.ts
+++ b/packages/kobe/test/tui/terminal-keys-pure.test.ts
@@ -1,11 +1,3 @@
-/**
- * Why this matters: keyEventToShellBytes is every keystroke's path into the
- * embedded engine CLI — a wrong byte turns Enter into a literal, or a ctrl
- * chord into shell garbage. RESERVED_GLOBAL_CHORDS is the user's only way
- * OUT of the terminal pane; if a chord leaks from that list into the PTY
- * the user is trapped inside the engine (the KOB-208 class of bug).
- */
-
 import type { KeyEvent } from "@opentui/core"
 import { describe, expect, it } from "vitest"
 import {

--- a/packages/kobe/test/tui/terminal-registry.test.ts
+++ b/packages/kobe/test/tui/terminal-registry.test.ts
@@ -1,11 +1,3 @@
-/**
- * Why this matters: the registry is the seam that decouples pane lifecycle
- * (per-render) from shell lifecycle (per-task) — the terminal-in-the-middle
- * center column (issue #16) leans on acquire-reuse so switching tasks and
- * back does NOT restart the engine CLI. A regression here kills running
- * claude sessions on every sidebar keystroke.
- */
-
 import { describe, expect, it } from "vitest"
 import { MockTaskPty } from "../../src/tui/panes/terminal/pty-mock"
 import type { TaskPtyOpts } from "../../src/tui/panes/terminal/pty-types"

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -1,12 +1,3 @@
-/**
- * Why this matters: grid selection is the embedded terminal's ONLY copy
- * path (opentui's flow selection breaks over a wholesale-replaced
- * snapshot). These pin the xterm/tmux linear-selection semantics —
- * reading-order normalization, first/middle/last row spans, per-line
- * trailing-space trim — so a drag in any direction copies exactly the
- * cells the highlight showed.
- */
-
 import { describe, expect, it } from "vitest"
 import { ATTR, type Chunk } from "../../src/tui/panes/terminal/sgr"
 import {

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -1,11 +1,3 @@
-/**
- * Why this matters: these transitions ARE the chattab contract carried
- * into the PTY world (issue #16) — new-tab placement, the can't-close-last
- * guard, left-neighbor focus on close, wrap-around cycling, and the
- * never-reused registry key. A regression silently kills or orphans live
- * engine PTYs (each tab id keys one).
- */
-
 import { describe, expect, it } from "vitest"
 import {
   addTab,

--- a/packages/kobe/test/tui/terminal-viewport.test.ts
+++ b/packages/kobe/test/tui/terminal-viewport.test.ts
@@ -1,10 +1,3 @@
-/**
- * Why this matters: the viewport window is what keeps the revived terminal
- * pane from bleeding — the pane renders EXACTLY this slice into its body
- * box. Off-by-ones here paint outside the pane or park the inline cursor
- * on the wrong row (the exact bugs that got the cluster shelved).
- */
-
 import { describe, expect, it } from "vitest"
 import { computeViewport, viewportCursor } from "../../src/tui/panes/terminal/viewport"
 


### PR DESCRIPTION
Redoes the intent of #260 within the policy settled there — thanks @NarwhalChen for the original attempt that prompted writing it down.

**Policy applied:**
- **Kept, untouched:** every file-header design/architecture doc comment (they are load-bearing for this repo's docs + tooling).
- **Removed:** inline decision-record clauses — owner-decision/date citations, `KOB-xxx` ticket references (162 occurrences), decision-log pointers, commit-sha/PR citations. Where a comment mixed a decision record with a technical constraint, only the record clause was removed and the sentence minimally reworded; when in doubt the comment was kept.
- **Removed:** the "Why this matters" preamble blocks in test files (22 files).

**Deliberately kept:** the one `KOB-232` inside a runtime `reason` string (`session-decision.ts` — behavior, not a comment), "decision logic" as a technical term, and `issue #N` feature-arc anchors (they orient which pivot a module belongs to, not who decided what).

111 files, +196/−385. Gates: typecheck, 2459 tests, root lint — all green. No changeset: comment-only, no published-package behavior change.

file-size-exemption: packages/kobe/src/tmux/client.ts — comment-only cleanup shrank it (−9 lines); split is out of scope for a policy sweep
file-size-exemption: packages/kobe/src/tmux/session-layout.ts — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/tui/component/new-task-dialog/dialog.tsx — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/tui/component/settings-dialog.tsx — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/tui/component/settings-dialog/sections.tsx — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/tui/lib/task-actions.ts — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/tui/panes/terminal/pane-heal.ts — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/tui/workspace/TerminalTabs.tsx — comment-only cleanup shrank it; split owed by the in-flight tab-UX work
file-size-exemption: packages/kobe/src/tui/workspace/host.tsx — comment-only cleanup shrank it; split owed by the in-flight workspace work

file-size-exemption: packages/kobe-daemon/src/daemon/server.ts — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/client/remote-orchestrator.ts — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/orchestrator/core.ts — comment-only cleanup shrank it; split out of scope
file-size-exemption: packages/kobe/src/orchestrator/worktree/manager.ts — comment-only cleanup shrank it; split out of scope
coverage-exemption: packages/kobe/src/monitor/activity.ts — comment-only edits, no behavior change to cover
coverage-exemption: packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts — comment-only edits, no behavior change to cover
coverage-exemption: packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts — comment-only edits, no behavior change to cover
coverage-exemption: packages/kobe/src/tui/ops/host-io.ts — comment-only edits, no behavior change to cover
coverage-exemption: packages/kobe/src/tui/panes/terminal/pty.ts — comment-only edits, no behavior change to cover
coverage-exemption: packages/kobe/src/tui/panes/terminal/use-terminal-pty.ts — comment-only edits, no behavior change to cover