### PR TITLE
feat: chrome animations (engine-owned spinner, pulse, slide-in, reduced motion) + split pane name tags

### DIFF
--- a/.changeset/chrome-animations-batch.md
+++ b/.changeset/chrome-animations-batch.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Chrome animations, first batch (design review follow-up): the sidebar running badge now animates with the task engine's own brand spinner (claude gets Claude Code's `·✢✳✶✻✽` star oscillation; other engines keep braille) via a new engine-registry `spinnerFrames` slot; a background tab's turn-complete ✓ pulses emphasized for ~600ms when it lands; toasts slide in from the right; a materializing worktree row shows an indeterminate partial-block comet sweep ahead of the word. All of it sits behind a new Settings → General → Reduced motion toggle (persisted + daemon-fanned like theme/transparent) that degrades the spinner to Claude Code's slow pulsing-dot form and turns the other effects off. Also: the file tree's `−N` deletion counter now uses the same typographic minus as the sidebar.

--- a/.changeset/split-pane-names.md
+++ b/.changeset/split-pane-names.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Split panes now carry a name: while a tab is split, each pane shows a corner tag (`group 1`, `group 2`, …, numbered in reading order like tmux pane numbers) in its top-right cell, with the focused pane's tag lit in the focus accent — tabs already had titles, panes had no identity at all.

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -239,6 +239,8 @@ export interface ChannelPayloads {
     sortMode: "default" | "recent"
     keysCollapsed: boolean
     projectFilter: string | null
+    /** Accessibility: chrome animations degrade to calm forms. */
+    reducedMotion: boolean
   }
   /**
    * "Re-read your keybindings" ping (KOB — live keybinding propagation).

--- a/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
+++ b/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
@@ -109,7 +109,8 @@ export function readUiPrefsFromStateFile(statePath: string): UiPrefsPayload {
   // file; the TUI validates it against its registered locales (defaulting
   // to English on anything unknown). Empty/missing → "en".
   const locale = typeof parsed.locale === "string" && parsed.locale.length > 0 ? parsed.locale : "en"
-  return { theme, transparentBackground, focusAccent, locale, sortMode, keysCollapsed, projectFilter }
+  const reducedMotion = parsed.reducedMotion === true
+  return { theme, transparentBackground, focusAccent, locale, sortMode, keysCollapsed, projectFilter, reducedMotion }
 }
 
 function samePrefs(a: UiPrefsPayload, b: UiPrefsPayload): boolean {
@@ -120,7 +121,8 @@ function samePrefs(a: UiPrefsPayload, b: UiPrefsPayload): boolean {
     a.locale === b.locale &&
     a.sortMode === b.sortMode &&
     a.keysCollapsed === b.keysCollapsed &&
-    a.projectFilter === b.projectFilter
+    a.projectFilter === b.projectFilter &&
+    a.reducedMotion === b.reducedMotion
   )
 }
 

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -114,6 +114,7 @@ export function decodeUiPrefsPayload(payload: unknown): UiPrefsPayload | null {
     sortMode: p.sortMode === "recent" ? "recent" : "default",
     keysCollapsed: p.keysCollapsed === true,
     projectFilter: typeof p.projectFilter === "string" && p.projectFilter.length > 0 ? p.projectFilter : null,
+    reducedMotion: p.reducedMotion === true,
   }
 }
 

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -46,6 +46,7 @@ import * as codexHistory from "./codex-local/history.ts"
 import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
 import * as copilotHistory from "./copilot-local/history.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
+import { CLAUDE_SPINNER_FRAMES } from "./spinner-frames.ts"
 import { ClaudeTurnDetector, CodexTurnDetector, type EngineTurnDetector, UnknownTurnDetector } from "./turn-detector.ts"
 
 /**
@@ -116,6 +117,12 @@ export interface EngineRegistryEntry {
   readonly capabilities?: EngineCapabilities
   /** Product identity (composer placeholder etc.). Paired with capabilities. */
   readonly identity?: EngineIdentity
+  /**
+   * Brand spinner frame set for this engine's running rows (sidebar badge).
+   * Omit for engines without one — consumers fall back to the neutral
+   * braille set (`spinner-frames.ts` `DEFAULT_SPINNER_FRAMES`).
+   */
+  readonly spinnerFrames?: readonly string[]
 }
 
 /**
@@ -178,6 +185,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot", EngineRegistryEntr
     createTurnDetector: () => new ClaudeTurnDetector(),
     capabilities: claudeCapabilities,
     identity: claudeIdentity,
+    spinnerFrames: CLAUDE_SPINNER_FRAMES,
   },
   codex: {
     vendor: "codex",

--- a/packages/kobe/src/engine/spinner-frames.ts
+++ b/packages/kobe/src/engine/spinner-frames.ts
@@ -1,0 +1,36 @@
+/**
+ * Engine-owned spinner frame sets (CLAUDE.md "Engine-owned UI data").
+ *
+ * The sidebar's running-row badge animates with the task engine's own
+ * brand spinner instead of one hard-coded set: the registry entry carries
+ * `spinnerFrames`, and neutral layers fall back to
+ * {@link DEFAULT_SPINNER_FRAMES} when an engine doesn't declare one.
+ *
+ * Must stay importable from vitest and MUST NOT import from `src/tui/`
+ * (same constraint as the registry that consumes it).
+ */
+
+/** Neutral fallback — the braille dots every engine without a brand set gets. */
+export const DEFAULT_SPINNER_FRAMES: readonly string[] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+/**
+ * Claude Code's brand spinner, lifted from refs/claude-code
+ * `src/components/Spinner.tsx` (`getDefaultCharacters()` + the
+ * forward-then-reverse concat that makes the glyph oscillate ·→✽→· with a
+ * one-frame hold at each end).
+ */
+const CLAUDE_SPINNER_CHARS: readonly string[] = ["·", "✢", "✳", "✶", "✻", "✽"]
+export const CLAUDE_SPINNER_FRAMES: readonly string[] = [
+  ...CLAUDE_SPINNER_CHARS,
+  ...[...CLAUDE_SPINNER_CHARS].reverse(),
+]
+
+/**
+ * Reduced-motion replacement for EVERY engine's frame set: a dot that
+ * pulses big/small on a 2s cycle (Claude Code's `REDUCED_MOTION_DOT` +
+ * `REDUCED_MOTION_CYCLE_MS` counterpart). Encoded as 10 frames per phase
+ * so the shared 10Hz tick drives it without a second timer; identical
+ * consecutive frames re-render nothing (`withSpinnerFrame` returns the
+ * same view when the glyph is unchanged).
+ */
+export const REDUCED_MOTION_SPINNER_FRAMES: readonly string[] = [...Array(10).fill("●"), ...Array(10).fill("·")]

--- a/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
@@ -153,6 +153,13 @@ export function SettingsDialog(props: SettingsDialogProps) {
     props.onVisualPrefsChange?.()
   }
 
+  function toggleReducedMotion(): void {
+    const next = !themeCtx.reducedMotion
+    themeCtx.setReducedMotion(next)
+    props.kv.set("reducedMotion", next)
+    props.onVisualPrefsChange?.()
+  }
+
   function selectFocusAccent(slot: FocusAccentSlot): void {
     if (themeCtx.focusAccent === slot) return
     themeCtx.setFocusAccent(slot)
@@ -233,6 +240,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
     language: (row) => selectLanguage(row.locale),
     transparent: () => toggleTransparent(),
     focusAccent: (row) => selectFocusAccent(row.slot),
+    reducedMotion: () => toggleReducedMotion(),
     toast: () => prefs.toggleToast(),
     sound: () => prefs.toggleSound(),
     zenKeepTasks: () => prefs.toggleZenKeepsTasks(),
@@ -349,6 +357,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
               currentLocale={currentLang()}
               selectLanguage={selectLanguage}
               toggleTransparent={toggleTransparent}
+              toggleReducedMotion={toggleReducedMotion}
               selectFocusAccent={selectFocusAccent}
               toastEnabled={prefs.toastEnabled()}
               soundEnabled={prefs.soundEnabled()}

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-general.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-general.tsx
@@ -69,6 +69,7 @@ export function GeneralSettingsSection(
     currentLocale: LocaleId
     selectLanguage: (locale: LocaleId) => void
     toggleTransparent: () => void
+    toggleReducedMotion: () => void
     selectFocusAccent: (slot: FocusAccentSlot) => void
     toastEnabled: boolean
     soundEnabled: boolean
@@ -109,6 +110,7 @@ export function GeneralSettingsSection(
   const check = (on: boolean) => (on ? "[x]" : "[ ]")
 
   const transparentRow = rowIdx("transparent")
+  const reducedMotionRow = rowIdx("reduced-motion")
   const toastRow = rowIdx("toast")
   const soundRow = rowIdx("sound")
   const zenKeepTasksRow = rowIdx("zen-keep-tasks")
@@ -186,6 +188,16 @@ export function GeneralSettingsSection(
             </Row>
           )
         })}
+      </SubSection>
+      <SubSection title={t("settings.general.reducedMotion")} hint={t("settings.general.reducedMotionHint")}>
+        <Row
+          cursor={isBodyCursor(reducedMotionRow)}
+          onMouseUp={activate(reducedMotionRow, props.toggleReducedMotion)}
+          fg={themeCtx.reducedMotion ? theme.accent : theme.textMuted}
+          bold={true}
+        >
+          {onOff(themeCtx.reducedMotion)}
+        </Row>
       </SubSection>
       <SubSection title={t("settings.general.notifications")} hint={t("settings.general.notificationsHint")}>
         <Row

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -38,6 +38,7 @@ type State = {
   readonly mode: "dark" | "light"
   readonly transparentBackground: boolean
   readonly focusAccent: FocusAccentSlot
+  readonly reducedMotion: boolean
 }
 
 const store = createExternalStore<State>({
@@ -46,6 +47,7 @@ const store = createExternalStore<State>({
   mode: "dark",
   transparentBackground: false,
   focusAccent: "primary",
+  reducedMotion: false,
 })
 
 export function listThemes(): string[] {
@@ -95,6 +97,14 @@ export function setFocusAccent(v: FocusAccentSlot): void {
   store.update((s) => ({ ...s, focusAccent: v }))
 }
 
+export function reducedMotion(): boolean {
+  return store.get().reducedMotion
+}
+
+export function setReducedMotion(v: boolean): void {
+  store.update((s) => ({ ...s, reducedMotion: v }))
+}
+
 export function setThemeMode(mode: "dark" | "light"): void {
   store.update((s) => ({ ...s, mode }))
 }
@@ -105,11 +115,13 @@ export type ThemeContextValue = {
   selected: string
   transparentBackground: boolean
   focusAccent: FocusAccentSlot
+  reducedMotion: boolean
   mode(): "dark" | "light"
   set(name: string): boolean
   setMode(mode: "dark" | "light"): void
   setTransparentBackground(v: boolean): void
   setFocusAccent(v: FocusAccentSlot): void
+  setReducedMotion(v: boolean): void
   all(): string[]
   has(name: string): boolean
 }
@@ -161,6 +173,7 @@ export function ThemeProvider(props: { children?: ReactNode; mode?: "dark" | "li
       selected: state.active,
       transparentBackground: state.transparentBackground,
       focusAccent: state.focusAccent,
+      reducedMotion: state.reducedMotion,
       mode: () => state.mode,
       set(name: string): boolean {
         if (!hasTheme(name)) return false
@@ -175,6 +188,9 @@ export function ThemeProvider(props: { children?: ReactNode; mode?: "dark" | "li
       },
       setFocusAccent(v: FocusAccentSlot): void {
         store.update((s) => ({ ...s, focusAccent: v }))
+      },
+      setReducedMotion(v: boolean): void {
+        store.update((s) => ({ ...s, reducedMotion: v }))
       },
       all: listThemes,
       has: hasTheme,

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -49,8 +49,10 @@ import {
   addTheme,
   focusAccent,
   hasTheme,
+  reducedMotion,
   selectedTheme,
   setFocusAccent,
+  setReducedMotion,
   setTheme,
   setTransparentBackground,
   transparentBackground,
@@ -98,6 +100,8 @@ const themeTarget: UiPrefsTarget = {
   setTransparentBackground,
   focusAccent,
   setFocusAccent,
+  reducedMotion,
+  setReducedMotion,
 }
 
 /** Detached fps while the pane's session has no attached client. */
@@ -234,6 +238,7 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
     theme: prefs.theme,
     transparentBackground: prefs.transparent,
     focusAccent: prefs.focusAccent,
+    reducedMotion: prefs.reducedMotion,
   })
   setLocaleLang(prefs.locale)
 

--- a/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
@@ -35,7 +35,7 @@ import {
   sidebarProjectKey,
   splitSidebarRows,
 } from "../../../tui/panes/sidebar/groups"
-import { IN_PROGRESS_SPINNER, SPINNER_FRAME_MS } from "../../../tui/panes/sidebar/row-view"
+import { SPINNER_FRAME_MS, SPINNER_TICK_CYCLE } from "../../../tui/panes/sidebar/row-view"
 import {
   MAIN_BRANCH_POLL_MS,
   SIDEBAR_WIDTH,
@@ -112,7 +112,8 @@ export function Sidebar(props: SidebarProps) {
   }, [])
   const [spinnerFrame, setSpinnerFrame] = useState(0)
   useEffect(() => {
-    const timer = setInterval(() => setSpinnerFrame((n) => (n + 1) % IN_PROGRESS_SPINNER.length), SPINNER_FRAME_MS)
+    // Common-multiple cycle — rows reduce modulo their own engine frame set.
+    const timer = setInterval(() => setSpinnerFrame((n) => (n + 1) % SPINNER_TICK_CYCLE), SPINNER_FRAME_MS)
     return () => clearInterval(timer)
   }, [])
 

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -17,10 +17,16 @@
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
 import { type BoxRenderable, TextAttributes } from "@opentui/core"
 import { type ReactNode, useEffect } from "react"
+import { sweepBar } from "../../../tui/lib/progress-bar"
 import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
 import type { SidebarRow } from "../../../tui/panes/sidebar/groups"
 import { spacedTitle } from "../../../tui/panes/sidebar/labels"
-import { buildSidebarRowView, prCheckChip, withSpinnerFrame } from "../../../tui/panes/sidebar/row-view"
+import {
+  type SidebarRowView,
+  buildSidebarRowView,
+  prCheckChip,
+  withSpinnerFrame,
+} from "../../../tui/panes/sidebar/row-view"
 import { taskIsLive, toneColor, truncateBranchLabel } from "../../../tui/panes/sidebar/view-core"
 import { type WorktreeChanges, pickPushedChanges } from "../../../tui/panes/sidebar/worktree-changes"
 import { pollWorktreeChanges, worktreeChanges } from "../../../tui/panes/sidebar/worktree-changes-poller"
@@ -65,6 +71,33 @@ function useChanges(shared: SidebarRowCardSharedProps, task: SidebarRow["task"])
   return pushed ?? worktreeChanges(task.worktreePath)
 }
 
+/**
+ * Subtitle line of a row card — Solid `SubtitleText`'s React counterpart.
+ * Plain muted text, except a materialising row, which renders the
+ * indeterminate sweep bar ahead of the word.
+ */
+function SubtitleText(props: { readonly view: SidebarRowView; readonly frame: number }) {
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
+  if (!props.view.materializing || themeCtx.reducedMotion) {
+    return (
+      <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
+        {props.view.subtitleText}
+      </text>
+    )
+  }
+  return (
+    <box flexDirection="row" gap={1} flexGrow={1}>
+      <text fg={theme.primary} wrapMode="none">
+        {sweepBar(props.frame)}
+      </text>
+      <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
+        {props.view.subtitleText}
+      </text>
+    </box>
+  )
+}
+
 function RowBody(props: {
   readonly row: SidebarRow
   readonly shared: SidebarRowCardSharedProps
@@ -103,7 +136,8 @@ function RowBody(props: {
 }
 
 export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
-  const { theme } = useTheme()
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
   const shared = props.shared
   const task = props.row.task
   const flatIndex = props.row.flatIndex
@@ -125,6 +159,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
       subtitleBudget: shared.subtitleBudget,
       truncateBranch: truncateBranchLabel,
       mainBranch: currentBranch(task.repo),
+      reducedMotion: themeCtx.reducedMotion,
     }),
     () => shared.spinnerFrame,
   )
@@ -153,9 +188,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
             {barGlyph}
           </text>
           <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
-            <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
-              {rowView.subtitleText}
-            </text>
+            <SubtitleText view={rowView} frame={shared.spinnerFrame} />
             {changes.added > 0 ? (
               <text fg={theme.success} wrapMode="none">
                 +{changes.added}
@@ -174,7 +207,8 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
 }
 
 export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
-  const { theme } = useTheme()
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
   const t = useT()
   const shared = props.shared
   const task = props.row.task
@@ -192,6 +226,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
       subtitleBudget: shared.subtitleBudget,
       truncateBranch: truncateBranchLabel,
       mainBranch: "",
+      reducedMotion: themeCtx.reducedMotion,
     }),
     () => shared.spinnerFrame,
   )
@@ -231,9 +266,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
             {barGlyph}
           </text>
           <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
-            <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
-              {rowView.subtitleText}
-            </text>
+            <SubtitleText view={rowView} frame={shared.spinnerFrame} />
             {task.pinned === true ? (
               <text fg={theme.warning} wrapMode="none">
                 ▴

--- a/packages/kobe/src/tui/component/settings-dialog.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog.tsx
@@ -199,6 +199,13 @@ export function SettingsDialog(props: SettingsDialogProps) {
     setTransparentBackground(!themeCtx.transparentBackground)
   }
 
+  function toggleReducedMotion(): void {
+    const next = !themeCtx.reducedMotion
+    themeCtx.setReducedMotion(next)
+    props.kv.set("reducedMotion", next)
+    props.onVisualPrefsChange?.()
+  }
+
   function selectFocusAccent(slot: FocusAccentSlot): void {
     if (themeCtx.focusAccent === slot) return
     themeCtx.setFocusAccent(slot)
@@ -604,6 +611,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
     language: (row) => selectLanguage(row.locale),
     transparent: () => toggleTransparent(),
     focusAccent: (row) => selectFocusAccent(row.slot),
+    reducedMotion: () => toggleReducedMotion(),
     toast: () => toggleToast(),
     sound: () => toggleSound(),
     zenKeepTasks: () => toggleZenKeepsTasks(),
@@ -735,6 +743,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
               selectLanguage={selectLanguage}
               toggleTransparent={toggleTransparent}
               selectFocusAccent={selectFocusAccent}
+              toggleReducedMotion={toggleReducedMotion}
               toastEnabled={toastEnabled}
               soundEnabled={soundEnabled}
               toggleToast={toggleToast}

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -47,6 +47,7 @@ export type SettingsRow =
   | { id: string; kind: "language"; locale: LocaleId }
   | { id: "transparent"; kind: "transparent" }
   | { id: string; kind: "focusAccent"; slot: FocusAccentSlot }
+  | { id: "reduced-motion"; kind: "reducedMotion" }
   | { id: "toast"; kind: "toast" }
   | { id: "sound"; kind: "sound" }
   | { id: "zen-keep-tasks"; kind: "zenKeepTasks" }
@@ -109,6 +110,7 @@ export function generalRows(input: Pick<SettingsRowsInput, "themeNames" | "focus
     ...LOCALES.map((l): SettingsRow => ({ id: languageRowId(l.id), kind: "language", locale: l.id })),
     { id: "transparent", kind: "transparent" },
     ...input.focusAccentSlots.map((slot): SettingsRow => ({ id: focusAccentRowId(slot), kind: "focusAccent", slot })),
+    { id: "reduced-motion", kind: "reducedMotion" },
     { id: "toast", kind: "toast" },
     { id: "sound", kind: "sound" },
     { id: "zen-keep-tasks", kind: "zenKeepTasks" },

--- a/packages/kobe/src/tui/component/settings-dialog/sections.tsx
+++ b/packages/kobe/src/tui/component/settings-dialog/sections.tsx
@@ -73,6 +73,7 @@ export function GeneralSettingsSection(
     selectLanguage: (locale: LocaleId) => void
     toggleTransparent: () => void
     selectFocusAccent: (slot: (typeof FOCUS_ACCENT_SLOTS)[number]) => void
+    toggleReducedMotion: () => void
     toastEnabled: Accessor<boolean>
     soundEnabled: Accessor<boolean>
     toggleToast: () => void
@@ -99,6 +100,7 @@ export function GeneralSettingsSection(
   const rows = () => generalRows({ themeNames: props.themeNames(), focusAccentSlots: FOCUS_ACCENT_SLOTS })
   const rowIdx = (id: string) => rowIndex(rows(), id)
   const transparentRow = () => rowIdx("transparent")
+  const reducedMotionRow = () => rowIdx("reduced-motion")
   const toastRow = () => rowIdx("toast")
   const soundRow = () => rowIdx("sound")
   const zenKeepTasksRow = () => rowIdx("zen-keep-tasks")
@@ -109,6 +111,7 @@ export function GeneralSettingsSection(
   const worktreeBaseRow = () => rowIdx("worktree-base")
   const worktreeCustomRow = () => rowIdx("worktree-custom")
   const isTransparentRow = () => props.bodyRow() === transparentRow()
+  const isReducedMotionRow = () => props.bodyRow() === reducedMotionRow()
   const isToastRow = () => props.bodyRow() === toastRow()
   const isSoundRow = () => props.bodyRow() === soundRow()
   const isZenKeepTasksRow = () => props.bodyRow() === zenKeepTasksRow()
@@ -265,6 +268,39 @@ export function GeneralSettingsSection(
             )
           }}
         </For>
+      </box>
+      <box flexDirection="column" gap={0} paddingTop={1}>
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          {t("settings.general.reducedMotion")}
+        </text>
+        <text fg={theme.textMuted} wrapMode="word">
+          {t("settings.general.reducedMotionHint")}
+        </text>
+        <box
+          flexDirection="row"
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={isReducedMotionRow() ? theme.primary : undefined}
+          onMouseUp={() => {
+            props.setLevel("body")
+            props.setBodyRow(reducedMotionRow())
+            props.toggleReducedMotion()
+          }}
+        >
+          <text
+            fg={
+              isReducedMotionRow()
+                ? theme.selectedListItemText
+                : themeCtx.reducedMotion
+                  ? theme.accent
+                  : theme.textMuted
+            }
+            attributes={TextAttributes.BOLD}
+            wrapMode="none"
+          >
+            {themeCtx.reducedMotion ? t("settings.general.on") : t("settings.general.off")}
+          </text>
+        </box>
       </box>
       <box flexDirection="column" gap={0} paddingTop={1}>
         <text fg={theme.text} attributes={TextAttributes.BOLD}>

--- a/packages/kobe/src/tui/component/toast-overlay.tsx
+++ b/packages/kobe/src/tui/component/toast-overlay.tsx
@@ -18,7 +18,7 @@
 
 import { TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
-import { For, Show } from "solid-js"
+import { For, Show, createEffect, createSignal, onCleanup } from "solid-js"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 
@@ -26,19 +26,47 @@ const MAX_VISIBLE = 4
 const CHIP_WIDTH = 40
 const RIGHT_MARGIN = 2
 const BOTTOM_MARGIN = 2
+/** Slide-in: cells the stack starts shifted right by, and the step cadence. */
+const SLIDE_CELLS = 6
+const SLIDE_STEP_MS = 40
 
 export function ToastOverlay() {
-  const { theme } = useTheme()
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
   const dims = useTerminalDimensions()
   const notif = useNotifications()
 
   const visibleToasts = () => notif.toasts().slice(-MAX_VISIBLE)
 
+  /* Slide-in on arrival: a NEW newest toast shifts the whole stack
+   * SLIDE_CELLS right of its anchor, then steps back to rest over a few
+   * frames — the overshoot clips at the screen edge, reading as a slide
+   * in from the right. Dismissals don't retrigger (newest id unchanged
+   * or the stack empties). */
+  const [slide, setSlide] = createSignal(0)
+  let lastNewest: string | number | null = null
+  createEffect(() => {
+    const list = notif.toasts()
+    const newest = list.length > 0 ? list[list.length - 1]?.id : null
+    if (newest === lastNewest) return
+    lastNewest = newest
+    if (!newest || themeCtx.reducedMotion) return
+    setSlide(SLIDE_CELLS)
+    const timer = setInterval(() => {
+      setSlide((cur) => {
+        const next = Math.max(0, cur - 2)
+        if (next === 0) clearInterval(timer)
+        return next
+      })
+    }, SLIDE_STEP_MS)
+    onCleanup(() => clearInterval(timer))
+  })
+
   // Anchor the stack to the bottom-right corner. Position is absolute
   // so the overlay sits on top of the Shell layout without taking flow
   // space; `zIndex` keeps it above the panes but below the dialog
   // backdrop (dialogs use 3000).
-  const left = () => Math.max(0, dims().width - CHIP_WIDTH - RIGHT_MARGIN)
+  const left = () => Math.max(0, dims().width - CHIP_WIDTH - RIGHT_MARGIN) + slide()
   const top = () => Math.max(0, dims().height - BOTTOM_MARGIN - MAX_VISIBLE - 1)
 
   return (

--- a/packages/kobe/src/tui/context/theme.tsx
+++ b/packages/kobe/src/tui/context/theme.tsx
@@ -39,6 +39,13 @@ type State = {
    */
   transparentBackground: boolean
   focusAccent: FocusAccentSlot
+  /**
+   * Accessibility toggle: chrome animations (spinner sweep, shimmer,
+   * toast slide, tab pulse) degrade to their calm forms. Persisted via
+   * KV + fanned over the daemon `ui-prefs` channel like the other
+   * display prefs.
+   */
+  reducedMotion: boolean
 }
 
 const [store, setStore] = createStore<State>({
@@ -47,6 +54,7 @@ const [store, setStore] = createStore<State>({
   mode: "dark",
   transparentBackground: false,
   focusAccent: "primary",
+  reducedMotion: false,
 })
 
 export function listThemes(): string[] {
@@ -112,6 +120,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       get focusAccent() {
         return store.focusAccent
       },
+      get reducedMotion() {
+        return store.reducedMotion
+      },
       mode() {
         return store.mode
       },
@@ -128,6 +139,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       },
       setFocusAccent(v: FocusAccentSlot): void {
         setStore("focusAccent", v)
+      },
+      setReducedMotion(v: boolean): void {
+        setStore("reducedMotion", v)
       },
       all(): string[] {
         return listThemes()

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -34,6 +34,9 @@ export const en = {
     accentPrimary: "Primary (brand accent)",
     accentSuccess: "Success (legacy green)",
     accentInfo: "Info (cool blue)",
+    reducedMotion: "Reduced motion",
+    reducedMotionHint:
+      "Calms chrome animations: the running-task spinner becomes a slow pulsing dot, and the toast slide-in, materializing sweep, and tab-complete flash turn off.",
     notifications: "Notifications",
     notificationsHint:
       "Fired when a background chat tab finishes or pauses on an approval. Toast = bottom-right popup; Sound = terminal bell + chime. Tab-chip unread dot is always on.",
@@ -163,6 +166,9 @@ export const zh: typeof en = {
     accentPrimary: "主色（品牌强调色）",
     accentSuccess: "成功色（传统绿）",
     accentInfo: "信息色（冷蓝）",
+    reducedMotion: "减弱动效",
+    reducedMotionHint:
+      "让界面动效安静下来：运行中任务的 spinner 变为缓慢明暗脉冲点，Toast 滑入、worktree 创建扫动条和标签完成闪烁全部关闭。",
     notifications: "通知",
     notificationsHint:
       "后台聊天页完成或在审批处暂停时触发。Toast = 右下角弹窗；Sound = 终端响铃 + 提示音。标签上的未读圆点始终开启。",

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -20,6 +20,11 @@ export const en = {
     chooseEngineHint: "←/→ choose, enter confirm, esc cancel",
     cannotCloseLast: "Cannot close the only tab",
   },
+  split: {
+    // Corner tag on each pane while a tab is split — panes have no other
+    // identity ("group" is the owner's vocabulary for a split pane).
+    name: "group {n}",
+  },
   scrolledBack: "↑ scrolled {lines}L (ctrl+pgdn to follow)",
   unavailable: {
     shellMissing: "terminal unavailable — configured shell is not available",
@@ -43,6 +48,9 @@ export const zh: typeof en = {
     chooseEngineTitle: "新建标签页 —— 选择引擎",
     chooseEngineHint: "←/→ 选择，enter 确认，esc 取消",
     cannotCloseLast: "无法关闭唯一的标签页",
+  },
+  split: {
+    name: "group {n}",
   },
   scrolledBack: "↑ 已回滚 {lines} 行（ctrl+pgdn 回到底部）",
   unavailable: {

--- a/packages/kobe/src/tui/lib/apply-ui-prefs.ts
+++ b/packages/kobe/src/tui/lib/apply-ui-prefs.ts
@@ -38,6 +38,7 @@ export interface UiPrefsSnapshot {
   readonly theme?: unknown
   readonly transparentBackground?: unknown
   readonly focusAccent?: unknown
+  readonly reducedMotion?: unknown
 }
 
 /**
@@ -60,6 +61,8 @@ export interface UiPrefsTarget {
   setTransparentBackground(v: boolean): void
   focusAccent(): string
   setFocusAccent(slot: UiPrefsFocusAccentSlot): void
+  reducedMotion(): boolean
+  setReducedMotion(v: boolean): void
 }
 
 /**
@@ -95,6 +98,10 @@ export function applyUiPrefs(target: UiPrefsTarget, prefs: UiPrefsSnapshot): voi
   if (prefs.focusAccent === null || typeof prefs.focusAccent === "string") {
     const slot = normalizeFocusAccent(prefs.focusAccent)
     if (slot && slot !== target.focusAccent()) target.setFocusAccent(slot)
+  }
+
+  if (typeof prefs.reducedMotion === "boolean" && prefs.reducedMotion !== target.reducedMotion()) {
+    target.setReducedMotion(prefs.reducedMotion)
   }
 }
 

--- a/packages/kobe/src/tui/lib/host-boot.tsx
+++ b/packages/kobe/src/tui/lib/host-boot.tsx
@@ -276,6 +276,8 @@ function UiPrefsSync(props: { boot: PersistedUiPrefs }) {
     setTransparentBackground: (v) => themeCtx.setTransparentBackground(v),
     focusAccent: () => themeCtx.focusAccent,
     setFocusAccent: (slot) => themeCtx.setFocusAccent(slot),
+    reducedMotion: () => themeCtx.reducedMotion,
+    setReducedMotion: (v) => themeCtx.setReducedMotion(v),
   }
 
   // Boot application, during this component's render — the sibling host
@@ -286,6 +288,7 @@ function UiPrefsSync(props: { boot: PersistedUiPrefs }) {
     theme: props.boot.theme,
     transparentBackground: props.boot.transparent,
     focusAccent: props.boot.focusAccent,
+    reducedMotion: props.boot.reducedMotion,
   })
   // Language is a module-global reactive value (not part of the theme
   // target), so it's seeded directly rather than through applyUiPrefs.

--- a/packages/kobe/src/tui/lib/persisted-ui-prefs.ts
+++ b/packages/kobe/src/tui/lib/persisted-ui-prefs.ts
@@ -27,6 +27,8 @@ export interface PersistedUiPrefs {
   readonly focusAccent: FocusAccentSlot | null
   /** Active UI language, validated against the registered locales. */
   readonly locale: LocaleId
+  /** Accessibility: chrome animations degrade to calm forms. */
+  readonly reducedMotion: boolean
 }
 
 /**
@@ -45,8 +47,9 @@ export function readPersistedUiPrefs(fallbackTheme: string): PersistedUiPrefs {
         ? (parsed.focusAccent as FocusAccentSlot)
         : null
     const locale = isLocaleId(parsed[LOCALE_KEY]) ? parsed[LOCALE_KEY] : DEFAULT_LOCALE
-    return { theme, transparent, focusAccent, locale }
+    const reducedMotion = parsed.reducedMotion === true
+    return { theme, transparent, focusAccent, locale, reducedMotion }
   } catch {
-    return { theme: fallbackTheme, transparent: false, focusAccent: null, locale: DEFAULT_LOCALE }
+    return { theme: fallbackTheme, transparent: false, focusAccent: null, locale: DEFAULT_LOCALE, reducedMotion: false }
   }
 }

--- a/packages/kobe/src/tui/lib/progress-bar.ts
+++ b/packages/kobe/src/tui/lib/progress-bar.ts
@@ -1,0 +1,31 @@
+/**
+ * Terminal progress glyphs. The partial-block vocabulary is lifted from
+ * Claude Code's design-system ProgressBar (refs/claude-code
+ * `src/components/design-system/ProgressBar.tsx`); kobe currently ships
+ * only the INDETERMINATE form — a comet sweeping a fixed-width track —
+ * because the one long-job consumer (worktree materializing) has no ratio
+ * to render. Add the determinate ratio→blocks form when a real ratio
+ * consumer appears.
+ */
+
+/** Comet profile, head-first: full block, then two tapering tails. */
+const COMET = ["█", "▋", "▍"] as const
+
+export const SWEEP_WIDTH = 8
+
+/**
+ * One frame of the indeterminate sweep: a 3-cell comet crossing a
+ * `width`-cell track left→right, fully exiting before it wraps (the
+ * `+ COMET.length` overshoot), so the motion reads as repeated passes
+ * rather than a loop snap. Pure — drive it with the shared 10Hz spinner
+ * tick. Always returns exactly `width` chars.
+ */
+export function sweepBar(frame: number, width = SWEEP_WIDTH): string {
+  const head = frame % (width + COMET.length)
+  let out = ""
+  for (let i = 0; i < width; i++) {
+    const d = head - i
+    out += d >= 0 && d < COMET.length ? (COMET[d] ?? " ") : " "
+  }
+  return out
+}

--- a/packages/kobe/src/tui/panes/filetree/pane-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/pane-core.ts
@@ -91,7 +91,10 @@ export function computePathBudget(paneWidth: number, w: StatWidths): number {
 /** Render a `+N` / `-N` stat cell padded to the column width; a missing
  * count renders as blanks so the columns stay aligned. */
 export function statCell(value: number | null | undefined, width: number, sign: "+" | "-"): string {
-  return value == null ? " ".repeat(width) : `${sign}${value}`.padStart(width)
+  // Deletions render the typographic minus (U+2212) — same glyph as the
+  // sidebar's −N counter, same 1-cell width as ASCII "-".
+  const glyph = sign === "-" ? "−" : sign
+  return value == null ? " ".repeat(width) : `${glyph}${value}`.padStart(width)
 }
 
 /** Toggle a directory path in the expansion set (immutably). */

--- a/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/Sidebar.tsx
@@ -19,7 +19,7 @@ import {
 import { useSidebarBindings } from "./keys"
 import { SidebarPanel } from "./panel"
 import type { SidebarRowCardSharedProps } from "./row-cards"
-import { IN_PROGRESS_SPINNER, SPINNER_FRAME_MS } from "./row-view"
+import { SPINNER_FRAME_MS, SPINNER_TICK_CYCLE } from "./row-view"
 import type { SidebarHover, SidebarProps } from "./types"
 import {
   MAIN_BRANCH_POLL_MS,
@@ -129,7 +129,9 @@ export function Sidebar(props: SidebarProps) {
   // the rows whose badge derivation actually reads `spinnerFrame()`.
   const [spinnerFrame, setSpinnerFrame] = createSignal(0)
   const spinnerInterval = setInterval(
-    () => setSpinnerFrame((n) => (n + 1) % IN_PROGRESS_SPINNER.length),
+    // Common-multiple cycle, not one set's length — each row reduces modulo
+    // its own engine frame set (row-view SPINNER_TICK_CYCLE doc).
+    () => setSpinnerFrame((n) => (n + 1) % SPINNER_TICK_CYCLE),
     SPINNER_FRAME_MS,
   )
   onCleanup(() => clearInterval(spinnerInterval))

--- a/packages/kobe/src/tui/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui/panes/sidebar/row-cards.tsx
@@ -4,10 +4,11 @@ import { type BoxRenderable, TextAttributes } from "@opentui/core"
 import type { Accessor, JSX } from "solid-js"
 import { Show, createMemo, onCleanup } from "solid-js"
 import { useTheme } from "../../context/theme"
+import { sweepBar } from "../../lib/progress-bar"
 import { currentBranch, pollCurrentBranch } from "./git-head"
 import type { SidebarRow } from "./groups"
 import { spacedTitle } from "./labels"
-import { buildSidebarRowView, prCheckChip, withSpinnerFrame } from "./row-view"
+import { type SidebarRowView, buildSidebarRowView, prCheckChip, withSpinnerFrame } from "./row-view"
 import type { ChatRunState, SidebarHover } from "./types"
 import { taskIsLive, toneColor, truncateBranchLabel } from "./view-core"
 import { type WorktreeChanges, pickPushedChanges, sameWorktreeChanges } from "./worktree-changes"
@@ -48,6 +49,37 @@ function useChanges(props: SidebarRowCardSharedProps, task: SidebarRow["task"]) 
   )
 }
 
+/**
+ * Subtitle line of a row card. Plain muted text, except a materialising
+ * row (worktree add in flight), which renders the indeterminate sweep bar
+ * ahead of the word. Frame is read only in that branch, so ordinary rows
+ * never subscribe to the 10Hz signal (same conditional-dependency contract
+ * as `withSpinnerFrame`).
+ */
+function SubtitleText(props: { readonly view: () => SidebarRowView; readonly frame: Accessor<number> }) {
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
+  return (
+    <Show
+      when={props.view().materializing && !themeCtx.reducedMotion}
+      fallback={
+        <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
+          {props.view().subtitleText}
+        </text>
+      }
+    >
+      <box flexDirection="row" gap={1} flexGrow={1}>
+        <text fg={theme.primary} wrapMode="none">
+          {sweepBar(props.frame())}
+        </text>
+        <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
+          {props.view().subtitleText}
+        </text>
+      </box>
+    </Show>
+  )
+}
+
 function RowBody(props: {
   readonly row: SidebarRow
   readonly shared: SidebarRowCardSharedProps
@@ -83,7 +115,8 @@ function RowBody(props: {
 }
 
 export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
-  const { theme } = useTheme()
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
   const task = props.row.task
   const flatIndex = props.row.flatIndex
   const isCursor = () => flatIndex === props.shared.cursorIndex()
@@ -104,6 +137,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
       subtitleBudget: props.shared.subtitleBudget(),
       truncateBranch: truncateBranchLabel,
       mainBranch: projectBranch(),
+      reducedMotion: themeCtx.reducedMotion,
     }),
   )
   const rowView = createMemo(() => withSpinnerFrame(baseRowView(), props.shared.spinnerFrame))
@@ -132,9 +166,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
             {barGlyph()}
           </text>
           <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
-            <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
-              {rowView().subtitleText}
-            </text>
+            <SubtitleText view={rowView} frame={props.shared.spinnerFrame} />
             <Show when={changes().added > 0}>
               <text fg={theme.success} wrapMode="none">
                 +{changes().added}
@@ -153,7 +185,8 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
 }
 
 export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
-  const { theme } = useTheme()
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
   const task = props.row.task
   const flatIndex = props.row.flatIndex
   const isCursor = () => flatIndex === props.shared.cursorIndex()
@@ -169,6 +202,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
       subtitleBudget: props.shared.subtitleBudget(),
       truncateBranch: truncateBranchLabel,
       mainBranch: "",
+      reducedMotion: themeCtx.reducedMotion,
     }),
   )
   const rowView = createMemo(() => withSpinnerFrame(baseRowView(), props.shared.spinnerFrame))
@@ -207,9 +241,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
             {barGlyph()}
           </text>
           <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
-            <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
-              {rowView().subtitleText}
-            </text>
+            <SubtitleText view={rowView} frame={props.shared.spinnerFrame} />
             <Show when={task.pinned === true}>
               <text fg={theme.warning} wrapMode="none">
                 ▴

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -1,7 +1,9 @@
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
 import type { TaskActivityState } from "@/engine/hook-events"
+import { engineEntry } from "@/engine/registry"
+import { DEFAULT_SPINNER_FRAMES, REDUCED_MOTION_SPINNER_FRAMES } from "@/engine/spinner-frames"
 import { t } from "@/tui/i18n"
-import type { Task, TaskStatus } from "@/types/task"
+import { DEFAULT_TASK_VENDOR, type Task, type TaskStatus } from "@/types/task"
 import { isBuiltinVendor } from "@/types/vendor"
 import { repoBasename } from "./groups"
 
@@ -15,6 +17,17 @@ export interface SidebarRowView {
   readonly stateGlyph: string
   readonly projectGlyph: string
   readonly tone: SidebarTone
+  /**
+   * The engine-owned frame set this row animates with while loading
+   * (registry `spinnerFrames`, braille fallback). Carried on the view so
+   * `withSpinnerFrame` needs no extra caller wiring.
+   */
+  readonly spinnerFrames: readonly string[]
+  /**
+   * A daemon job (worktree add) is materialising this task — the subtitle
+   * renders the indeterminate sweep bar instead of the shimmer.
+   */
+  readonly materializing: boolean
 }
 
 const STATUS_BADGE: Record<TaskStatus, { glyph: string; tone: SidebarTone }> = {
@@ -71,9 +84,19 @@ function activityLabelFor(state: TaskActivityState | undefined): { text: string;
   }
 }
 
-export const IN_PROGRESS_SPINNER: readonly string[] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+/** Neutral fallback frames — kept under the historical name for existing consumers/tests. */
+export const IN_PROGRESS_SPINNER: readonly string[] = DEFAULT_SPINNER_FRAMES
 
 export const SPINNER_FRAME_MS = 100
+
+/**
+ * Cycle length for the shared 10Hz frame counter. Engine frame sets have
+ * different lengths (braille 10, claude's star oscillation 12); the counter
+ * ticks over a common multiple and each row reduces modulo its own set, so
+ * every set loops seamlessly. 600 covers every divisor we'd plausibly ship
+ * (8/10/12/15/20/24/25).
+ */
+export const SPINNER_TICK_CYCLE = 600
 
 /**
  * The right-stuck PR-check chip for a task's subtitle row. The
@@ -158,6 +181,8 @@ export function buildSidebarRowView(opts: {
    * `main` / `feat/x` on line 2 like a task does.
    */
   readonly mainBranch?: string
+  /** Accessibility: swap the engine spinner for the slow pulsing dot. */
+  readonly reducedMotion?: boolean
 }): SidebarRowView {
   const { task } = opts
   const isMain = task.kind === "main"
@@ -185,7 +210,12 @@ export function buildSidebarRowView(opts: {
     materializing ||
     (!untrackedCustomEngine &&
       (activityState === "running" || opts.live || (!hasActivity && !isMain && task.status === "in_progress")))
-  const spinner = IN_PROGRESS_SPINNER[opts.spinnerFrame] ?? IN_PROGRESS_SPINNER[0]
+  // Engine-owned brand frames (registry `spinnerFrames`), braille fallback;
+  // reduced motion replaces every set with the slow pulsing dot.
+  const spinnerFrames = opts.reducedMotion
+    ? REDUCED_MOTION_SPINNER_FRAMES
+    : (engineEntry(task.vendor ?? DEFAULT_TASK_VENDOR).spinnerFrames ?? DEFAULT_SPINNER_FRAMES)
+  const spinner = spinnerFrames[opts.spinnerFrame % spinnerFrames.length] ?? spinnerFrames[0]
   const tone = materializing
     ? "primary"
     : untrackedCustomEngine
@@ -217,6 +247,8 @@ export function buildSidebarRowView(opts: {
     stateGlyph: loading ? spinner : restGlyph,
     projectGlyph: loading ? spinner : restProjectGlyph,
     tone,
+    spinnerFrames,
+    materializing,
   }
 }
 
@@ -232,7 +264,8 @@ export function buildSidebarRowView(opts: {
  */
 export function withSpinnerFrame(view: SidebarRowView, frame: () => number): SidebarRowView {
   if (!view.loading) return view
-  const spinner = IN_PROGRESS_SPINNER[frame() % IN_PROGRESS_SPINNER.length] ?? "⠋"
+  const frames = view.spinnerFrames
+  const spinner = frames[frame() % frames.length] ?? frames[0] ?? "⠋"
   if (spinner === view.stateGlyph && spinner === view.projectGlyph) return view
   return { ...view, stateGlyph: spinner, projectGlyph: spinner }
 }

--- a/packages/kobe/src/tui/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalSplit.tsx
@@ -25,10 +25,11 @@
  * over once a split exists.
  */
 
-import type { RGBA } from "@opentui/core"
+import { type RGBA, TextAttributes } from "@opentui/core"
 import { type Accessor, For, type JSXElement, Show, createEffect, createSignal, on } from "solid-js"
 import { bindByIds } from "../context/keybindings"
 import { useTheme } from "../context/theme"
+import { t } from "../i18n"
 import { useBindings } from "../lib/keymap"
 import { Terminal } from "../panes/terminal/Terminal"
 import { defaultShell } from "../panes/terminal/pty-types"
@@ -164,6 +165,12 @@ export function TerminalSplit(props: {
   const dividerProps = (divider: "left" | "top" | undefined, color: () => RGBA) =>
     divider ? { border: [divider] as ("left" | "top")[], borderColor: color() } : { border: false as const }
 
+  /** 1-based position of a leaf in reading order — the pane's default name
+   *  (`group {n}`, owner ask 2026-07-06: tabs have names, panes had none).
+   *  Positional on purpose: closing a middle pane renumbers the rest, the
+   *  same zero-state convention as tmux pane numbers. */
+  const leafOrdinal = (id: string) => leaves(state().root).findIndex((leaf) => leaf.id === id) + 1
+
   const renderLeaf = (leaf: SplitLeaf<LeafCommand>, divider?: "left" | "top"): JSXElement => (
     <box
       flexGrow={1}
@@ -180,6 +187,19 @@ export function TerminalSplit(props: {
         resetToken={leaf.id === "leaf-1" ? props.resetToken : undefined}
         focused={() => leafFocused(leaf.id)}
       />
+      {/* Corner name tag — panes have no other identity while split. The
+          focused pane's tag lights in the focus accent; overlays the
+          terminal's top-right cell row (tmux-pane-number style, but
+          always on since it's the pane's only label). */}
+      <box position="absolute" right={0} top={0} zIndex={10} backgroundColor={theme.backgroundElement}>
+        <text
+          fg={leafFocused(leaf.id) ? theme.focusAccent : theme.textMuted}
+          attributes={leafFocused(leaf.id) ? TextAttributes.BOLD : TextAttributes.DIM}
+          wrapMode="none"
+        >
+          {` ${t("terminal.split.name", { n: leafOrdinal(leaf.id) })} `}
+        </text>
+      </box>
     </box>
   )
 

--- a/packages/kobe/src/tui/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalTabs.tsx
@@ -24,13 +24,11 @@ import type { TranscriptActivity } from "@/client/remote-orchestrator"
 import { availableEngineIds } from "@/engine/account-detect"
 import { interactiveEngineCommand, withClaudeSessionId } from "@/engine/interactive-command"
 import { engineEntry } from "@/engine/registry"
-import type { ChatTabTurnState } from "@/engine/turn-detector"
 import { deriveTitleFromSessionId } from "@/monitor/auto-title"
 import { resolveMainRepoRoot } from "@/state/repos"
 import { resolvePreferredVendor, setRepoLastActiveVendor } from "@/state/vendor-prefs"
 import type { VendorId } from "@/types/vendor"
-import { TextAttributes } from "@opentui/core"
-import { For, Show, createEffect, createSignal, on, onCleanup } from "solid-js"
+import { Show, createEffect, createSignal, on, onCleanup } from "solid-js"
 import { EnginePickerDialog } from "../component/engine-picker-dialog/index"
 import { RenameTaskDialog } from "../component/rename-task-dialog/index"
 import { bindByIds } from "../context/keybindings"
@@ -39,16 +37,15 @@ import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { t } from "../i18n"
 import { useBindings } from "../lib/keymap"
-import { startTurnStatusPoll } from "../ops/activity-monitor"
 import type { Terminal } from "../panes/terminal/Terminal"
 import { defaultShell } from "../panes/terminal/pty-types"
 import { getDefaultPtyRegistry } from "../panes/terminal/registry"
 import { useDialog } from "../ui/dialog"
 import { TerminalSplit, releaseSplitLeaves } from "./TerminalSplit"
+import { TabStrip, tabTitle } from "./tab-strip"
 import {
   type EngineTab,
   type TabsState,
-  type TerminalTab,
   addTab,
   closeActiveTab,
   closeTab,
@@ -64,29 +61,13 @@ import {
   tabPtyKey,
   tabToShell,
 } from "./terminal-tabs-core"
+import { createTurnPolls } from "./turn-polls"
 
 /** Per-task tab state, preserved across task switches for the process. */
 const tabsByTask = new Map<string, TabsState>()
 
 /** Cadence of the tab auto-naming pass (tmux ran its pass on the monitor tick). */
 const NAMING_POLL_MS = 5000
-/** Cadence of the lazy turn-poll attach retry (a tab's PTY spawns after mount). */
-const TURN_POLL_ATTACH_MS = 2000
-
-/** Same glyph vocabulary as tmux's `CHAT_TAB_STATUS_FORMAT` (`@kobe_tab_state`). */
-const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
-  running: "●",
-  done: "✓",
-  error: "!",
-  unknown: "?",
-  idle: "○",
-}
-
-function tabTitle(tab: TerminalTab): string {
-  // Manual rename wins; the auto-derived first-prompt title is the
-  // fallback; the numbered default is last — tmux automatic-rename order.
-  return tab.title ?? tab.autoTitle ?? t("terminal.tab.defaultTitle", { n: tab.ordinal })
-}
 
 export function TerminalTabs(props: {
   taskId: string
@@ -266,80 +247,18 @@ export function TerminalTabs(props: {
   onCleanup(() => clearInterval(namingTimer))
 
   /* --------- per-tab turn state (tmux @kobe_tab_state, logic layer) -------
-   * The SAME `startTurnStatusPoll` loop the Ops pane runs, with PTY IO in
-   * place of tmux capture-pane — the in-process snapshot IS the pane
-   * capture. Shared mode when the host passes the daemon's
-   * transcript.activity slice (`sharedActivity`), local fixed-cadence
-   * fallback otherwise. Polls attach lazily (a tab's PTY spawns after
-   * its Terminal mounts and measures), retried on a slow tick. */
-  const [turnStates, setTurnStates] = createSignal<ReadonlyMap<string, ChatTabTurnState>>(new Map())
-  const turnPolls = new Map<string, () => void>()
-  const [pollTick, setPollTick] = createSignal(0)
-  const pollAttachTimer = setInterval(() => setPollTick((n) => n + 1), TURN_POLL_ATTACH_MS)
-  onCleanup(() => clearInterval(pollAttachTimer))
-  createEffect(() => {
-    pollTick()
-    const reg = getDefaultPtyRegistry()
-    const engineIds = new Set<string>()
-    for (const tab of state().tabs) {
-      if (tab.kind !== "engine") continue
-      engineIds.add(tab.id)
-      if (turnPolls.has(tab.id)) continue
-      const key = tabPtyKey(props.taskId, tab.id)
-      // Attach only once the PTY exists so the loop's prime() hashes a
-      // real first capture (the Ops pane's prime-before-poll contract).
-      if (!reg.has(key)) continue
-      const tabId = tab.id
-      const detector = engineEntry(tab.vendor ?? props.vendor).createTurnDetector()
-      const dispose = startTurnStatusPoll(
-        {
-          worktree: props.worktree,
-          detector,
-          // Shared mode (issue #24): the daemon's transcript.activity push
-          // supplies completion reads + drives the adaptive capture
-          // cadence; null (no daemon data) falls back to fixed-cadence
-          // local polling — the Ops pane's exact contract.
-          usingShared: () => (props.sharedActivity?.() ?? null) !== null,
-          sharedEntry: () => props.sharedActivity?.() ?? null,
-        },
-        {
-          sessionAttached: async () => true,
-          capturePane: async () => {
-            const pty = getDefaultPtyRegistry().get(key)
-            if (!pty) throw new Error("pty gone")
-            return pty
-              .capture()
-              .map((row) => row.map((chunk) => chunk.text).join(""))
-              .join("\n")
-          },
-          setTurnState: async (turn) => {
-            setTurnStates((prev) => new Map(prev).set(tabId, turn))
-            // Background completion rides the standard notification path
-            // (unread + toast) — the PTY-world version of noticing a ✓
-            // land on an unfocused tmux window.
-            if (turn === "done" && state().activeId !== tabId) {
-              const current = state().tabs.find((t) => t.id === tabId)
-              if (current) notif.notify({ kind: "done", taskId: props.taskId, tabId, title: tabTitle(current) })
-            }
-          },
-        },
-      )
-      turnPolls.set(tabId, dispose)
-    }
-    // Tabs that closed or degraded to a shell stop polling.
-    for (const [id, dispose] of turnPolls) {
-      if (engineIds.has(id)) continue
-      dispose()
-      turnPolls.delete(id)
-      setTurnStates((prev) => {
-        const next = new Map(prev)
-        next.delete(id)
-        return next
-      })
-    }
-  })
-  onCleanup(() => {
-    for (const dispose of turnPolls.values()) dispose()
+   * Extracted to `turn-polls.ts` — the Ops-pane poll loop with PTY IO,
+   * shared/local cadence per the sharedActivity contract. */
+  const { turnStates } = createTurnPolls({
+    taskId: props.taskId,
+    worktree: props.worktree,
+    vendor: () => props.vendor,
+    state,
+    sharedActivity: props.sharedActivity,
+    onBackgroundDone: (tabId) => {
+      const current = state().tabs.find((t) => t.id === tabId)
+      if (current) notif.notify({ kind: "done", taskId: props.taskId, tabId, title: tabTitle(current) })
+    },
   })
 
   // Visiting a tab clears its unread mark (toast already auto-dismisses).
@@ -494,41 +413,15 @@ export function TerminalTabs(props: {
 
   return (
     <box flexDirection="column" flexGrow={1}>
-      {/* Tab strip — flush to the pane edge, dense, hidden for one tab. */}
+      {/* Tab strip — flush to the pane edge, dense, hidden for one tab.
+          View + turn-complete pulse live in tab-strip.tsx. */}
       <Show when={state().tabs.length > 1}>
-        <box flexDirection="row" gap={1} flexShrink={0} paddingLeft={1} backgroundColor={theme.backgroundElement}>
-          <For each={state().tabs}>
-            {(tab) => {
-              const turn = () => turnStates().get(tab.id) ?? "idle"
-              const turnColor = () =>
-                turn() === "running"
-                  ? theme.focusAccent
-                  : turn() === "done"
-                    ? theme.success
-                    : turn() === "error"
-                      ? theme.error
-                      : theme.textMuted
-              return (
-                <box flexDirection="row" gap={0} onMouseUp={() => update(selectTab(state(), tab.id))}>
-                  {/* Turn chip — tmux CHAT_TAB_STATUS_FORMAT's ●/✓/!/?/○,
-                      engine tabs only (a command tab has no turns). */}
-                  <Show when={tab.kind === "engine"}>
-                    <text fg={turnColor()} wrapMode="none">
-                      {`${TURN_GLYPHS[turn()]} `}
-                    </text>
-                  </Show>
-                  <text
-                    fg={tab.id === state().activeId ? theme.focusAccent : theme.textMuted}
-                    attributes={tab.id === state().activeId ? TextAttributes.BOLD : undefined}
-                    wrapMode="none"
-                  >
-                    {tabTitle(tab)}
-                  </text>
-                </box>
-              )
-            }}
-          </For>
-        </box>
+        <TabStrip
+          tabs={() => state().tabs}
+          activeId={() => state().activeId}
+          turnStates={turnStates}
+          onSelect={(tabId) => update(selectTab(state(), tabId))}
+        />
       </Show>
       {/* One long-lived tab body, never remounted on an ordinary tab
           switch — only its `tabKey`/`command` change. TerminalSplit

--- a/packages/kobe/src/tui/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui/workspace/tab-strip.tsx
@@ -1,0 +1,112 @@
+/**
+ * Workspace tab strip — the row of engine/command tabs above the embedded
+ * terminal (split out of `TerminalTabs.tsx`, which was over the 500-line
+ * cap). Owns the per-tab turn chip and the turn-complete pulse: when a
+ * tab's turn flips running→done, the chip and title flash emphasized for a
+ * few frames before settling — a landing cue for work that finished while
+ * you looked elsewhere.
+ */
+
+import type { ChatTabTurnState } from "@/engine/turn-detector"
+import { TextAttributes } from "@opentui/core"
+import { For, Show, createEffect, createSignal, onCleanup } from "solid-js"
+import { useTheme } from "../context/theme"
+import { t } from "../i18n"
+import type { TerminalTab } from "./terminal-tabs-core"
+
+/** Same glyph vocabulary as tmux's `CHAT_TAB_STATUS_FORMAT` (`@kobe_tab_state`). */
+export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
+  running: "●",
+  done: "✓",
+  error: "!",
+  unknown: "?",
+  idle: "○",
+}
+
+/** How long the running→done pulse stays emphasized. */
+const DONE_PULSE_MS = 600
+
+export function tabTitle(tab: TerminalTab): string {
+  // Manual rename wins; the auto-derived first-prompt title is the
+  // fallback; the numbered default is last — tmux automatic-rename order.
+  return tab.title ?? tab.autoTitle ?? t("terminal.tab.defaultTitle", { n: tab.ordinal })
+}
+
+export function TabStrip(props: {
+  tabs: () => readonly TerminalTab[]
+  activeId: () => string
+  turnStates: () => ReadonlyMap<string, ChatTabTurnState>
+  onSelect: (tabId: string) => void
+}) {
+  const themeCtx = useTheme()
+  const { theme } = themeCtx
+
+  /* --------- turn-complete pulse ---------------------------------------
+   * Track running→done transitions; a transitioned tab id sits in
+   * `pulsing` for DONE_PULSE_MS then drops out, un-emphasizing the chip.
+   * Plain prev-map comparison (not a memo) — the effect re-runs only when
+   * the turnStates map identity changes (setTurnStates always writes a
+   * new Map). */
+  const prevTurns = new Map<string, ChatTabTurnState>()
+  const [pulsing, setPulsing] = createSignal<ReadonlySet<string>>(new Set())
+  const timers = new Set<ReturnType<typeof setTimeout>>()
+  createEffect(() => {
+    const turns = props.turnStates()
+    for (const [tabId, turn] of turns) {
+      const prev = prevTurns.get(tabId)
+      prevTurns.set(tabId, turn)
+      if (turn !== "done" || prev !== "running" || themeCtx.reducedMotion) continue
+      setPulsing((cur) => new Set(cur).add(tabId))
+      const timer = setTimeout(() => {
+        timers.delete(timer)
+        setPulsing((cur) => {
+          const next = new Set(cur)
+          next.delete(tabId)
+          return next
+        })
+      }, DONE_PULSE_MS)
+      timers.add(timer)
+    }
+    for (const id of [...prevTurns.keys()]) if (!turns.has(id)) prevTurns.delete(id)
+  })
+  onCleanup(() => {
+    for (const timer of timers) clearTimeout(timer)
+  })
+
+  return (
+    <box flexDirection="row" gap={1} flexShrink={0} paddingLeft={1} backgroundColor={theme.backgroundElement}>
+      <For each={props.tabs()}>
+        {(tab) => {
+          const turn = () => props.turnStates().get(tab.id) ?? "idle"
+          const pulse = () => pulsing().has(tab.id)
+          const turnColor = () =>
+            turn() === "running"
+              ? theme.focusAccent
+              : turn() === "done"
+                ? theme.success
+                : turn() === "error"
+                  ? theme.error
+                  : theme.textMuted
+          return (
+            <box flexDirection="row" gap={0} onMouseUp={() => props.onSelect(tab.id)}>
+              {/* Turn chip — tmux CHAT_TAB_STATUS_FORMAT's ●/✓/!/?/○,
+                  engine tabs only (a command tab has no turns). */}
+              <Show when={tab.kind === "engine"}>
+                <text fg={turnColor()} attributes={pulse() ? TextAttributes.BOLD : undefined} wrapMode="none">
+                  {`${TURN_GLYPHS[turn()]} `}
+                </text>
+              </Show>
+              <text
+                fg={pulse() ? theme.success : tab.id === props.activeId() ? theme.focusAccent : theme.textMuted}
+                attributes={pulse() || tab.id === props.activeId() ? TextAttributes.BOLD : undefined}
+                wrapMode="none"
+              >
+                {tabTitle(tab)}
+              </text>
+            </box>
+          )
+        }}
+      </For>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui/workspace/turn-polls.ts
+++ b/packages/kobe/src/tui/workspace/turn-polls.ts
@@ -1,0 +1,102 @@
+/**
+ * Per-tab turn-state polling for the workspace terminal tabs (split out of
+ * `TerminalTabs.tsx`, which was over the 500-line cap). The SAME
+ * `startTurnStatusPoll` loop the Ops pane runs, with PTY IO in place of
+ * tmux capture-pane — the in-process snapshot IS the pane capture. Shared
+ * mode when the host passes the daemon's transcript.activity slice,
+ * local fixed-cadence fallback otherwise. Polls attach lazily (a tab's PTY
+ * spawns after its Terminal mounts and measures), retried on a slow tick.
+ *
+ * Must be called from a Solid component body (owns effects + onCleanup).
+ */
+
+import type { TranscriptActivity } from "@/client/remote-orchestrator"
+import { engineEntry } from "@/engine/registry"
+import type { ChatTabTurnState } from "@/engine/turn-detector"
+import type { VendorId } from "@/types/vendor"
+import { createEffect, createSignal, onCleanup } from "solid-js"
+import { startTurnStatusPoll } from "../ops/activity-monitor"
+import { getDefaultPtyRegistry } from "../panes/terminal/registry"
+import { type TabsState, tabPtyKey } from "./terminal-tabs-core"
+
+/** Cadence of the lazy turn-poll attach retry (a tab's PTY spawns after mount). */
+const TURN_POLL_ATTACH_MS = 2000
+
+export function createTurnPolls(deps: {
+  taskId: string
+  worktree: string
+  /** Task-level engine — the fallback for tabs without a pinned vendor. */
+  vendor: () => VendorId
+  state: () => TabsState
+  sharedActivity?: () => TranscriptActivity | null
+  /** A background tab's turn just landed ✓ — notification hook. */
+  onBackgroundDone: (tabId: string) => void
+}): { turnStates: () => ReadonlyMap<string, ChatTabTurnState> } {
+  const [turnStates, setTurnStates] = createSignal<ReadonlyMap<string, ChatTabTurnState>>(new Map())
+  const turnPolls = new Map<string, () => void>()
+  const [pollTick, setPollTick] = createSignal(0)
+  const pollAttachTimer = setInterval(() => setPollTick((n) => n + 1), TURN_POLL_ATTACH_MS)
+  onCleanup(() => clearInterval(pollAttachTimer))
+  createEffect(() => {
+    pollTick()
+    const reg = getDefaultPtyRegistry()
+    const engineIds = new Set<string>()
+    for (const tab of deps.state().tabs) {
+      if (tab.kind !== "engine") continue
+      engineIds.add(tab.id)
+      if (turnPolls.has(tab.id)) continue
+      const key = tabPtyKey(deps.taskId, tab.id)
+      // Attach only once the PTY exists so the loop's prime() hashes a
+      // real first capture (the Ops pane's prime-before-poll contract).
+      if (!reg.has(key)) continue
+      const tabId = tab.id
+      const detector = engineEntry(tab.vendor ?? deps.vendor()).createTurnDetector()
+      const dispose = startTurnStatusPoll(
+        {
+          worktree: deps.worktree,
+          detector,
+          // Shared mode (issue #24): the daemon's transcript.activity push
+          // supplies completion reads + drives the adaptive capture
+          // cadence; null (no daemon data) falls back to fixed-cadence
+          // local polling — the Ops pane's exact contract.
+          usingShared: () => (deps.sharedActivity?.() ?? null) !== null,
+          sharedEntry: () => deps.sharedActivity?.() ?? null,
+        },
+        {
+          sessionAttached: async () => true,
+          capturePane: async () => {
+            const pty = getDefaultPtyRegistry().get(key)
+            if (!pty) throw new Error("pty gone")
+            return pty
+              .capture()
+              .map((row) => row.map((chunk) => chunk.text).join(""))
+              .join("\n")
+          },
+          setTurnState: async (turn) => {
+            setTurnStates((prev) => new Map(prev).set(tabId, turn))
+            // Background completion rides the standard notification path
+            // (unread + toast) — the PTY-world version of noticing a ✓
+            // land on an unfocused tmux window.
+            if (turn === "done" && deps.state().activeId !== tabId) deps.onBackgroundDone(tabId)
+          },
+        },
+      )
+      turnPolls.set(tabId, dispose)
+    }
+    // Tabs that closed or degraded to a shell stop polling.
+    for (const [id, dispose] of turnPolls) {
+      if (engineIds.has(id)) continue
+      dispose()
+      turnPolls.delete(id)
+      setTurnStates((prev) => {
+        const next = new Map(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  })
+  onCleanup(() => {
+    for (const dispose of turnPolls.values()) dispose()
+  })
+  return { turnStates }
+}

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -419,6 +419,7 @@ describe("decodeUiPrefsPayload — backward-compat defaults", () => {
       sortMode: "default",
       keysCollapsed: false,
       projectFilter: null,
+      reducedMotion: false,
     })
   })
 
@@ -433,6 +434,7 @@ describe("decodeUiPrefsPayload — backward-compat defaults", () => {
       sortMode: "recent",
       keysCollapsed: true,
       projectFilter: null,
+      reducedMotion: false,
     })
     // empty projectFilter string → null (all projects); unknown sortMode → default
     const d = decodeUiPrefsPayload({ theme: "x", projectFilter: "", sortMode: "weird", focusAccent: "#abc" })

--- a/packages/kobe/test/daemon/ui-prefs-watcher.test.ts
+++ b/packages/kobe/test/daemon/ui-prefs-watcher.test.ts
@@ -87,6 +87,7 @@ describe("readUiPrefsFromStateFile", () => {
       sortMode: "default",
       keysCollapsed: false,
       projectFilter: null,
+      reducedMotion: false,
     })
   })
 
@@ -101,6 +102,7 @@ describe("readUiPrefsFromStateFile", () => {
       sortMode: "default",
       keysCollapsed: false,
       projectFilter: null,
+      reducedMotion: false,
     })
   })
 
@@ -114,6 +116,7 @@ describe("readUiPrefsFromStateFile", () => {
       sortMode: "default",
       keysCollapsed: false,
       projectFilter: null,
+      reducedMotion: false,
     })
   })
 
@@ -162,6 +165,7 @@ describe("startUiPrefsWatcher", () => {
         sortMode: "default",
         keysCollapsed: false,
         projectFilter: null,
+        reducedMotion: false,
       },
     ])
     // The bus last-value cache is warm — what a `subscribe` replays.
@@ -184,6 +188,7 @@ describe("startUiPrefsWatcher", () => {
       sortMode: "default",
       keysCollapsed: false,
       projectFilter: null,
+      reducedMotion: false,
     })
 
     // A write that doesn't move the visual prefs (an unrelated key, then
@@ -204,6 +209,7 @@ describe("startUiPrefsWatcher", () => {
       sortMode: "default",
       keysCollapsed: false,
       projectFilter: null,
+      reducedMotion: false,
     })
   })
 

--- a/packages/kobe/test/engine/activity-pipeline.test.ts
+++ b/packages/kobe/test/engine/activity-pipeline.test.ts
@@ -23,7 +23,7 @@ import { describe, expect, it } from "vitest"
 import type { TaskEngineState } from "../../src/client/remote-orchestrator.ts"
 import { ClaudeHookAdapter, claudeVerbForHookEvent } from "../../src/engine/claude-code-local/hook-adapter.ts"
 import { isEngineActivityKind } from "../../src/engine/hook-events.ts"
-import { IN_PROGRESS_SPINNER, buildSidebarRowView } from "../../src/tui/panes/sidebar/row-view.ts"
+import { buildSidebarRowView } from "../../src/tui/panes/sidebar/row-view.ts"
 import type { Task } from "../../src/types/task.ts"
 import { toTaskId } from "../../src/types/task.ts"
 
@@ -87,7 +87,7 @@ describe("activity pipeline — vendor hook payload to sidebar badge", () => {
   it("turn running: UserPromptSubmit spins the row", () => {
     const row = rowAfterClaudeHook("UserPromptSubmit", { cwd: "/repo/kobe/worktrees/sidebar" })
     expect(row.loading).toBe(true)
-    expect(row.stateGlyph).toBe(IN_PROGRESS_SPINNER[0])
+    expect(row.stateGlyph).toBe(row.spinnerFrames[0])
     expect(row.tone).toBe("primary")
     expect(row.subtitleText).toBe("feature/sidebar") // running keeps the branch
   })

--- a/packages/kobe/test/tui/apply-ui-prefs.test.ts
+++ b/packages/kobe/test/tui/apply-ui-prefs.test.ts
@@ -32,6 +32,7 @@ interface FakeState {
   diskThemes: string[]
   transparent: boolean
   accent: string
+  reducedMotion: boolean
 }
 
 function makeTarget(initial?: Partial<FakeState>) {
@@ -41,6 +42,7 @@ function makeTarget(initial?: Partial<FakeState>) {
     diskThemes: [],
     transparent: false,
     accent: "primary",
+    reducedMotion: false,
     ...initial,
   }
   const calls: string[] = []
@@ -66,6 +68,11 @@ function makeTarget(initial?: Partial<FakeState>) {
     setFocusAccent: (slot) => {
       calls.push(`setFocusAccent:${slot}`)
       state.accent = slot
+    },
+    reducedMotion: () => state.reducedMotion,
+    setReducedMotion: (v) => {
+      calls.push(`setReducedMotion:${v}`)
+      state.reducedMotion = v
     },
   }
   return { state, calls, target }

--- a/packages/kobe/test/tui/perf-budgets.test.ts
+++ b/packages/kobe/test/tui/perf-budgets.test.ts
@@ -38,7 +38,7 @@ import { describe, expect, test, vi } from "vitest"
 import { computeNextAllowedAt, shouldPoll } from "../../src/lib/poll-scheduling"
 import { TASKS_PANE_WIDTH } from "../../src/tmux/session-layout"
 import { type Binding, type RegisteredBinding, dispatchKeyEvent } from "../../src/tui/lib/keymap-dispatch"
-import { IN_PROGRESS_SPINNER, buildSidebarRowView, withSpinnerFrame } from "../../src/tui/panes/sidebar/row-view"
+import { buildSidebarRowView, withSpinnerFrame } from "../../src/tui/panes/sidebar/row-view"
 import {
   MIN_POLL_INTERVAL_MS,
   POLL_TIMEOUT_MS,
@@ -338,8 +338,9 @@ describe("idle sidebar tick — frame-accessor read budget (7a4aba5)", () => {
     expect(out[0]).toBe(views[0])
     expect(out[2]).toBe(views[2])
     expect(out[4]).toBe(views[4])
-    expect(out[1]?.stateGlyph).toBe(IN_PROGRESS_SPINNER[3])
-    expect(out[3]?.stateGlyph).toBe(IN_PROGRESS_SPINNER[3])
+    // Glyphs come from each view's OWN engine frame set (claude stars here).
+    expect(out[1]?.stateGlyph).toBe(views[1]?.spinnerFrames[3])
+    expect(out[3]?.stateGlyph).toBe(views[3]?.spinnerFrames[3])
   })
 })
 

--- a/packages/kobe/test/tui/persisted-ui-prefs.test.ts
+++ b/packages/kobe/test/tui/persisted-ui-prefs.test.ts
@@ -56,6 +56,7 @@ describe("readPersistedUiPrefs", () => {
       transparent: true,
       focusAccent: "success",
       locale: "en",
+      reducedMotion: false,
     })
   })
 
@@ -87,6 +88,7 @@ describe("readPersistedUiPrefs", () => {
       transparent: false,
       focusAccent: null,
       locale: "en",
+      reducedMotion: false,
     })
     writeState("{corrupt")
     expect(readPersistedUiPrefs("claude").theme).toBe("claude")

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -63,6 +63,7 @@ describe("generalRows", () => {
       "focusAccent",
       "focusAccent",
       "focusAccent",
+      "reducedMotion",
       "toast",
       "sound",
       "zenKeepTasks",
@@ -82,21 +83,22 @@ describe("generalRows", () => {
     expect(rows.filter((r) => r.kind === "surface").map((r) => r.surface)).toEqual(["chattab", "taskpanel"])
   })
 
-  it("matches the offset formula (themeCount + langCount + 1 + accentCount + 9) for representative sizes", () => {
+  it("matches the offset formula (themeCount + langCount + 1 + accentCount + 10) for representative sizes", () => {
     for (const themeCount of [0, 1, 12, 30]) {
       const themes = Array.from({ length: themeCount }, (_, i) => `theme-${i}`)
       const rows = generalRows({ themeNames: themes, focusAccentSlots: SLOTS })
-      expect(rows.length).toBe(themeCount + LANG + 1 + SLOTS.length + 9)
+      expect(rows.length).toBe(themeCount + LANG + 1 + SLOTS.length + 10)
       // transparent sits after the theme list + the language picker.
       expect(rowIndex(rows, "transparent")).toBe(themeCount + LANG)
-      // toastRowIndex / soundRowIndex chain, then the zen toggle, then surfaces + editors.
-      expect(rowIndex(rows, "toast")).toBe(themeCount + LANG + 1 + SLOTS.length)
-      expect(rowIndex(rows, "sound")).toBe(themeCount + LANG + 1 + SLOTS.length + 1)
-      expect(rowIndex(rows, "zen-keep-tasks")).toBe(themeCount + LANG + 1 + SLOTS.length + 2)
-      expect(rowIndex(rows, surfaceRowId("chattab"))).toBe(themeCount + LANG + 1 + SLOTS.length + 3)
-      expect(rowIndex(rows, surfaceRowId("taskpanel"))).toBe(themeCount + LANG + 1 + SLOTS.length + 4)
-      expect(rowIndex(rows, "editor-kind")).toBe(themeCount + LANG + 1 + SLOTS.length + 5)
-      expect(rowIndex(rows, "editor-custom")).toBe(themeCount + LANG + 1 + SLOTS.length + 6)
+      // reduced-motion after the accents, then toast/sound, the zen toggle, surfaces + editors.
+      expect(rowIndex(rows, "reduced-motion")).toBe(themeCount + LANG + 1 + SLOTS.length)
+      expect(rowIndex(rows, "toast")).toBe(themeCount + LANG + 1 + SLOTS.length + 1)
+      expect(rowIndex(rows, "sound")).toBe(themeCount + LANG + 1 + SLOTS.length + 2)
+      expect(rowIndex(rows, "zen-keep-tasks")).toBe(themeCount + LANG + 1 + SLOTS.length + 3)
+      expect(rowIndex(rows, surfaceRowId("chattab"))).toBe(themeCount + LANG + 1 + SLOTS.length + 4)
+      expect(rowIndex(rows, surfaceRowId("taskpanel"))).toBe(themeCount + LANG + 1 + SLOTS.length + 5)
+      expect(rowIndex(rows, "editor-kind")).toBe(themeCount + LANG + 1 + SLOTS.length + 6)
+      expect(rowIndex(rows, "editor-custom")).toBe(themeCount + LANG + 1 + SLOTS.length + 7)
     }
   })
 
@@ -189,7 +191,7 @@ describe("sectionRows / bodyRowCount", () => {
     // 12 themes, 3 accents, 2 custom engines, daemon attached.
     const themes = Array.from({ length: 12 }, (_, i) => `t${i}`)
     const inp = input({ themeNames: themes, engineList: [...ALL_VENDORS, "aider", "goose"], hasDaemon: true })
-    expect(bodyRowCount("general", inp)).toBe(12 + LANG + 1 + 3 + 9) // 12 themes + langs + transparent + 3 accents + 9
+    expect(bodyRowCount("general", inp)).toBe(12 + LANG + 1 + 3 + 10) // 12 themes + langs + transparent + 3 accents + 10 (incl. reduced-motion)
     expect(bodyRowCount("engines", inp)).toBe(ALL_VENDORS.length + 2 + 1) // 6
     expect(bodyRowCount("accounts", inp)).toBe(0)
     expect(bodyRowCount("keys", inp)).toBe(0)

--- a/packages/kobe/test/tui/sidebar-row-view.test.ts
+++ b/packages/kobe/test/tui/sidebar-row-view.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
-import { IN_PROGRESS_SPINNER, buildSidebarRowView, withSpinnerFrame } from "../../src/tui/panes/sidebar/row-view.ts"
+import { CLAUDE_SPINNER_FRAMES, REDUCED_MOTION_SPINNER_FRAMES } from "../../src/engine/spinner-frames.ts"
+import { sweepBar } from "../../src/tui/lib/progress-bar.ts"
+import { buildSidebarRowView, withSpinnerFrame } from "../../src/tui/panes/sidebar/row-view.ts"
 import type { Task } from "../../src/types/task.ts"
 import { toTaskId } from "../../src/types/task.ts"
 
@@ -109,10 +111,12 @@ describe("buildSidebarRowView", () => {
       truncateBranch: (b) => b,
     })
     expect(v).toMatchObject({
+      // Claude-vendor task → the engine-owned star frames (frame 0 = "·").
       loading: true,
-      stateGlyph: "⠋",
+      stateGlyph: CLAUDE_SPINNER_FRAMES[0],
       tone: "primary",
       subtitleText: "materializing",
+      materializing: true,
     })
   })
 
@@ -188,8 +192,9 @@ describe("withSpinnerFrame", () => {
     const base = loadingView()
     expect(base.loading).toBe(true)
     const out = withSpinnerFrame(base, () => 3)
-    expect(out.stateGlyph).toBe(IN_PROGRESS_SPINNER[3])
-    expect(out.projectGlyph).toBe(IN_PROGRESS_SPINNER[3])
+    // The overlay honours the view's OWN engine frame set (claude stars here).
+    expect(out.stateGlyph).toBe(base.spinnerFrames[3])
+    expect(out.projectGlyph).toBe(base.spinnerFrames[3])
     // Everything else is untouched — exactly what buildSidebarRowView
     // would have produced with spinnerFrame: 3.
     const direct = buildSidebarRowView({
@@ -211,7 +216,37 @@ describe("withSpinnerFrame", () => {
 
   it("wraps out-of-range frames into the spinner cycle", () => {
     const base = loadingView()
-    const out = withSpinnerFrame(base, () => IN_PROGRESS_SPINNER.length + 2)
-    expect(out.stateGlyph).toBe(IN_PROGRESS_SPINNER[2])
+    const out = withSpinnerFrame(base, () => base.spinnerFrames.length + 2)
+    expect(out.stateGlyph).toBe(base.spinnerFrames[2])
+  })
+
+  it("reduced motion swaps every engine's frames for the pulsing dot", () => {
+    const v = buildSidebarRowView({
+      task: task({ status: "backlog" }),
+      activity: { state: "running", at: 1 },
+      live: false,
+      spinnerFrame: 0,
+      subtitleBudget: 80,
+      truncateBranch: (b) => b,
+      reducedMotion: true,
+    })
+    expect(v.spinnerFrames).toBe(REDUCED_MOTION_SPINNER_FRAMES)
+    expect(v.stateGlyph).toBe("●")
+    // Second phase of the 2s cycle (frames 10-19) is the small dot.
+    expect(withSpinnerFrame(v, () => 15).stateGlyph).toBe("·")
+  })
+})
+
+// Chrome-animation helper — pure string math, pinned so a refactor can't
+// silently break the sweep geometry.
+describe("sweepBar", () => {
+  it("sweepBar always renders exactly `width` cells and the comet crosses the track", () => {
+    for (let frame = 0; frame < 30; frame++) {
+      expect(sweepBar(frame, 8)).toHaveLength(8)
+    }
+    expect(sweepBar(0, 8)).toBe("█       ")
+    expect(sweepBar(2, 8)).toBe("▍▋█     ")
+    // Head has run off the end: comet fully exited before the wrap.
+    expect(sweepBar(10, 8)).toBe("        ")
   })
 })

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -14,11 +14,51 @@ case "$BIN" in
   *) MANAGER="npm" ;;
 esac
 
-echo "Updating ${PACKAGE} via ${MANAGER}..."
-"$MANAGER" install -g "${PACKAGE}@latest"
+LATEST="$(npm view "${PACKAGE}" version 2>/dev/null || true)"
+
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  GREEN='\033[32m'
+  RED='\033[31m'
+  DIM='\033[2m'
+  RESET='\033[0m'
+else
+  BOLD='' GREEN='' RED='' DIM='' RESET=''
+fi
+
+if [ -n "$LATEST" ]; then
+  printf '%bUpdating %s: %s -> v%s%b (via %s)\n' "$BOLD" "$PACKAGE" "${BEFORE:-not installed}" "$LATEST" "$RESET" "$MANAGER"
+else
+  printf '%bUpdating %s via %s...%b\n' "$BOLD" "$PACKAGE" "$MANAGER" "$RESET"
+fi
+
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"' EXIT
+
+"$MANAGER" install -g "${PACKAGE}@latest" >"$LOG" 2>&1 &
+PID=$!
+
+if [ -t 1 ]; then
+  # ponytail: braille spinner, same glyph set as the TUI's DEFAULT_SPINNER_FRAMES
+  # (packages/kobe/src/engine/spinner-frames.ts) — keep the two in sync by eye.
+  set -- ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏
+  while kill -0 "$PID" 2>/dev/null; do
+    frame=$1
+    shift
+    set -- "$@" "$frame"
+    printf '\r%b%s%b installing...' "$DIM" "$frame" "$RESET"
+    sleep 0.1
+  done
+  printf '\r\033[K'
+fi
+
+if ! wait "$PID"; then
+  printf '%berror: %s install failed:%b\n' "$RED" "$MANAGER" "$RESET" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
 
 AFTER="$(kobe -v 2>/dev/null || true)"
-LATEST="$(npm view "${PACKAGE}" version 2>/dev/null || true)"
 
 if [ -n "$LATEST" ] && [ "${AFTER##* }" != "$LATEST" ]; then
   echo "error: 'kobe' on PATH reports '${AFTER:-nothing}' but latest is ${LATEST}." >&2
@@ -27,4 +67,4 @@ if [ -n "$LATEST" ] && [ "${AFTER##* }" != "$LATEST" ]; then
   exit 1
 fi
 
-echo "${BEFORE:-kobe (not installed)} -> ${AFTER:-unknown}"
+printf '%b✓ %s -> %s%b\n' "$GREEN" "${BEFORE:-kobe (not installed)}" "${AFTER:-unknown}" "$RESET"


### PR DESCRIPTION
## What

Three commits:

1. **Update-script animation** — spinner + explicit target version in `scripts/update.sh`.
2. **Chrome animations, first batch** (design-language review follow-up):
   - Sidebar running badge animates with the task engine's own brand frames — new engine-registry `spinnerFrames` slot; claude gets Claude Code's `·✢✳✶✻✽` star oscillation, other engines keep braille, custom engines stay static.
   - A background tab's landing ✓ pulses emphasized for ~600ms (running→done transition).
   - Toasts slide in from the right (3 frames).
   - A materializing worktree row shows an indeterminate partial-block comet sweep ahead of the word.
   - New **Settings → General → Reduced motion** toggle riding the full ui-prefs chain (kv + state.json + daemon `ui-prefs` channel, both Solid and React ports); degrades the spinner to a slow pulsing dot and disables the other effects.
   - `TerminalTabs.tsx` split into `tab-strip.tsx` + `turn-polls.ts` to get back under the 500-line cap.
   - File tree `−N` deletion counter unified with the sidebar's typographic minus.
3. **Split pane name tags** — while a tab is split, each pane shows a top-right corner tag (`group 1`, `group 2`, … in reading order); the focused pane's tag lights in the focus accent. Tabs had names; panes had no identity.

## Verification

typecheck (kobe + kobe-daemon), root lint, i18n (389 keys × 2 locales), vitest fast + socket, render track (31), behavior track (25, built CLI boots the workspace). New pure helpers (`sweepBar`, reduced-motion frame swap) unit-pinned.

file-size-exemption: packages/kobe/src/tui/component/settings-dialog.tsx — pre-existing oversize pending the issue #12 split; this PR adds one toggle handler + prop
file-size-exemption: packages/kobe/src/tui/component/settings-dialog/sections.tsx — pre-existing oversize pending the issue #12 split; this PR adds one toggle row block
coverage-exemption: packages/kobe/src/tui/workspace/turn-polls.ts — Solid-effect/PTY glue extracted verbatim from TerminalTabs.tsx (a .tsx outside the vitest gate); behavior pinned black-box by test/behavior tui-smoke and the Ops-pane startTurnStatusPoll unit suite
