### PR TITLE
revert: pure TUI on-disk session adoption (#265)

### DIFF
--- a/.changeset/cross-mode-session-adopt.md
+++ b/.changeset/cross-mode-session-adopt.md
@@ -1,5 +1,0 @@
----
-"@sma1lboy/kobe": patch
----
-
-Cross-mode session sync: opening a task in the pure-TUI workspace (`KOBE_TUI=1`) for the first time now adopts the task's newest existing conversation from the engine's own on-disk store — so sessions created under the tmux flavour (or a previous install) continue where they left off instead of starting blank. Works for both claude (`--resume <id>`) and codex (`codex resume <id>`) through a new engine-owned `resumeCommand` registry hook; engines without resume support (copilot, custom) keep starting fresh. The adopted tab auto-names itself from the conversation's first prompt like any other tab.

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -123,18 +123,6 @@ export interface EngineRegistryEntry {
    * braille set (`spinner-frames.ts` `DEFAULT_SPINNER_FRAMES`).
    */
   readonly spinnerFrames?: readonly string[]
-  /**
-   * Build the argv that RESUMES an existing session id on top of the
-   * already-built launch command `base` (engine defaults + user override +
-   * effort flags — see `interactive-command.ts`). Engine-owned so neutral
-   * layers never hard-code vendor flags:
-   *   - claude: `claude … --resume <id>`
-   *   - codex:  `codex … resume <id>` (the `-c` config flags are global
-   *     and parse before the subcommand — verified against codex CLI)
-   * Omit for engines that can't resume by id (copilot, custom); callers
-   * fall back to `base` (a fresh session).
-   */
-  readonly resumeCommand?: (base: readonly string[], sessionId: string) => readonly string[]
 }
 
 /**
@@ -198,7 +186,6 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot", EngineRegistryEntr
     capabilities: claudeCapabilities,
     identity: claudeIdentity,
     spinnerFrames: CLAUDE_SPINNER_FRAMES,
-    resumeCommand: (base, sessionId) => [...base, "--resume", sessionId],
   },
   codex: {
     vendor: "codex",
@@ -215,7 +202,6 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot", EngineRegistryEntr
     createTurnDetector: () => new CodexTurnDetector(),
     capabilities: codexCapabilities,
     identity: codexIdentity,
-    resumeCommand: (base, sessionId) => [...base, "resume", sessionId],
   },
   copilot: {
     vendor: "copilot",

--- a/packages/kobe/src/tui/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalTabs.tsx
@@ -54,7 +54,6 @@ import {
   openEditorTab,
   rehydrateTabs,
   renameActiveTab,
-  seedTabsFromSessions,
   selectTab,
   setTabAutoTitle,
   setTabSessionId,
@@ -128,11 +127,6 @@ export function TerminalTabs(props: {
   // flags are up to 5s stale (the naming tick's cadence) and must be
   // re-verified against the real transcripts before anything spawns.
   let rehydratedFromDisk = false
-  // Flips true when the task has NO persisted snapshot at all — its first
-  // open in this host. The engine's own transcript store may still hold
-  // conversations for the worktree (created by the tmux flavour, or a
-  // prior install): the seed pass below adopts the newest one.
-  let needsDiskSeed = false
   const initState = (): TabsState => {
     const existing = tabsByTask.get(props.taskId)
     if (existing) return existing
@@ -142,7 +136,6 @@ export function TerminalTabs(props: {
     const saved = kv.get(persistKey, null) as TabsState | null
     const fromDisk = saved && Array.isArray(saved.tabs) ? rehydrateTabs(saved) : null
     rehydratedFromDisk = fromDisk !== null
-    needsDiskSeed = fromDisk === null
     const fresh = fromDisk ?? pinSession(initialTabs(), undefined)
     // Persist immediately so a remount before the first mutation doesn't
     // re-pin a different session id against the already-spawned PTY.
@@ -169,18 +162,7 @@ export function TerminalTabs(props: {
     const base = tab.vendor ? interactiveEngineCommand(tab.vendor, props.modelEffort) : props.command
     if (!tab.sessionId) return base
     const live = getDefaultPtyRegistry().has(tabPtyKey(props.taskId, tab.id))
-    if (tab.spawned && !live) {
-      // Engine-owned resume argv (registry `resumeCommand`): claude appends
-      // `--resume <id>`, codex the `resume <id>` subcommand. Engines
-      // without the hook start fresh.
-      const resume = engineEntry(tab.vendor ?? props.vendor).resumeCommand
-      return resume ? resume(base, tab.sessionId) : base
-    }
-    // Fresh session under a pre-pinned id is claude's `--session-id`
-    // contract only (`withClaudeSessionId` never pins other vendors). A
-    // non-claude tab can land here when its ADOPTED session's transcript
-    // vanished (restart-verify flipped spawned off) — start it fresh.
-    if ((tab.vendor ?? props.vendor) !== "claude") return base
+    if (tab.spawned && !live) return [...base, "--resume", tab.sessionId]
     return [...base, "--session-id", tab.sessionId]
   }
 
@@ -192,7 +174,7 @@ export function TerminalTabs(props: {
    * spawn (the Show gate below) and set each tab's `spawned` from a real
    * history read before the first PTY starts. Millisecond-scale reads;
    * failures degrade to fresh-session (never the not-found path). */
-  const [hydrating, setHydrating] = createSignal(rehydratedFromDisk || needsDiskSeed)
+  const [hydrating, setHydrating] = createSignal(rehydratedFromDisk)
   if (rehydratedFromDisk) {
     void (async () => {
       try {
@@ -208,30 +190,6 @@ export function TerminalTabs(props: {
             update(setTabSpawned(state(), tab.id, exists))
           }),
         )
-      } finally {
-        setHydrating(false)
-      }
-    })()
-  }
-
-  /* --------- cross-mode session adoption ---------------------------------
-   * First-ever open of this task in the pure-TUI host: the engine's own
-   * transcript store is the ONE place both kobe flavours record
-   * conversations (DESIGN.md §2.5 — state lives where it already lives),
-   * so a task driven under the tmux flavour has its sessions on disk even
-   * though this host has no snapshot. Hold the spawn behind the same
-   * hydrating gate, list the store (claude ~ms, codex ≤ a few hundred ms,
-   * capped), and adopt the newest conversation as the initial tab — it
-   * resumes via the engine-owned `resumeCommand` instead of opening blank.
-   * Empty/unreadable store → the fresh session already pinned in initState. */
-  if (needsDiskSeed) {
-    void (async () => {
-      try {
-        const ids = await engineEntry(props.vendor).history.listSessionIdsForWorktree(props.worktree)
-        const seeded = seedTabsFromSessions(ids)
-        if (seeded) update(seeded)
-      } catch {
-        /* unreadable store → keep the fresh session */
       } finally {
         setHydrating(false)
       }

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -45,12 +45,12 @@ export interface EngineTab extends TabBase {
    */
   readonly vendor?: VendorId
   /**
-   * Engine session id: pinned at spawn (`withClaudeSessionId` — the same
+   * Engine session id pinned at spawn (`withClaudeSessionId` — the same
    * `--session-id` mapping the tmux chattab stashed as
-   * `@kobe_session_id`), or ADOPTED from the engine's on-disk store
-   * (`seedTabsFromSessions` — how a codex tab, whose id can't be
-   * caller-set, still gets one). Null for a fresh non-claude tab (named
-   * from the worktree instead, matching the tmux fallback).
+   * `@kobe_session_id`), so the tab is auto-named from ITS OWN first
+   * prompt and can later be resumed. Null for vendors that can't take a
+   * caller-set id (codex/custom — their origin tab is named from the
+   * worktree instead, matching the tmux fallback).
    */
   readonly sessionId?: string | null
   /**
@@ -215,26 +215,6 @@ export function setTabSpawned(state: TabsState, id: string, spawned: boolean): T
 /** Mark an engine tab's PTY as having spawned (see `EngineTab.spawned`). */
 export function markTabSpawned(state: TabsState, id: string): TabsState {
   return setTabSpawned(state, id, true)
-}
-
-/**
- * Seed a task's FIRST-EVER tab state (no persisted snapshot) from the
- * engine's on-disk session store — the cross-mode sync: conversations
- * created by the tmux flavour (or any prior kobe run) live in the
- * engine's OWN transcript store, so the pure-TUI host adopts the newest
- * one as its initial tab and resumes it instead of opening a blank
- * session. `sessionIds` follows the registry reader contract
- * (OLDEST-first → the last entry is the newest conversation). Returns
- * null when there is nothing to adopt. `spawned: true` by construction:
- * the id came from a transcript that exists on disk, which is exactly
- * what the restart-verify pass would conclude.
- */
-export function seedTabsFromSessions(sessionIds: readonly string[]): TabsState | null {
-  const newest = sessionIds.at(-1)
-  if (!newest) return null
-  const base = initialTabs()
-  const tabs = base.tabs.map((t): TerminalTab => (t.kind === "engine" ? { ...t, sessionId: newest, spawned: true } : t))
-  return { ...base, tabs }
 }
 
 /**

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -77,20 +77,6 @@ describe("engineEntry — built-in vendors", () => {
     expect(entry.capabilities?.permissionModes).toEqual([])
   })
 
-  // Why: the resume argv is engine-owned (CLAUDE.md "Engine-owned UI
-  // data") — the pure-TUI tab host resumes cross-mode sessions through
-  // this hook, so the vendor flag shapes must never drift: claude is a
-  // FLAG on the base argv, codex a SUBCOMMAND (its global `-c` config
-  // flags parse before subcommands), copilot/custom have none.
-  it("builds each vendor's resume argv shape (claude flag, codex subcommand, none elsewhere)", () => {
-    const base = ["claude", "--permission-mode", "plan"]
-    expect(engineEntry("claude").resumeCommand?.(base, "sid-1")).toEqual([...base, "--resume", "sid-1"])
-    const codexBase = ["codex", "-c", "model_reasoning_effort=high"]
-    expect(engineEntry("codex").resumeCommand?.(codexBase, "sid-2")).toEqual([...codexBase, "resume", "sid-2"])
-    expect(engineEntry("copilot").resumeCommand).toBeUndefined()
-    expect(engineEntry("my-custom").resumeCommand).toBeUndefined()
-  })
-
   it("routes detectAccount to the vendor's own detector (claude oauth)", async () => {
     const status = await engineEntry("claude").detectAccount(
       deps({

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -8,7 +8,6 @@ import {
   openEditorTab,
   rehydrateTabs,
   renameActiveTab,
-  seedTabsFromSessions,
   selectTab,
   setTabAutoTitle,
   setTabSessionId,
@@ -155,28 +154,6 @@ describe("terminal tabs state", () => {
     expect(down.tabs[0]).toMatchObject({ spawned: false })
     // No-op keeps tab identity (persistence write-churn guard).
     expect(setTabSpawned(down, "tab-1", false).tabs[0]).toBe(down.tabs[0])
-  })
-
-  // Why: cross-mode session adoption — the engine's transcript store is
-  // the one place BOTH kobe flavours record conversations, so a task
-  // driven under tmux must open in the pure TUI on its newest existing
-  // conversation, not a blank session. The reader contract is
-  // oldest-first, so the LAST id is the one to resume; spawned=true by
-  // construction (the listing itself proves the transcript exists).
-  it("seedTabsFromSessions adopts the newest on-disk session as the initial tab", () => {
-    const seeded = seedTabsFromSessions(["old-1", "old-2", "newest-3"])
-    expect(seeded).not.toBeNull()
-    expect(seeded?.tabs).toHaveLength(1)
-    expect(seeded?.tabs[0]).toMatchObject({
-      kind: "engine",
-      sessionId: "newest-3",
-      spawned: true,
-    })
-    expect(seeded?.activeId).toBe(seeded?.tabs[0]?.id)
-  })
-
-  it("seedTabsFromSessions returns null when the store has nothing to adopt", () => {
-    expect(seedTabsFromSessions([])).toBeNull()
   })
 
   it("autoTitle fills the display gap under a manual title and survives degradation", () => {


### PR DESCRIPTION
Owner decision: the cross-mode session sync didn't behave as expected — dropping the feature. Clean revert of the #265 squash (adoption seed in TerminalTabs, `seedTabsFromSessions`, the engine `resumeCommand` registry hook, its tests, and the pending changeset so it never reaches release notes). Never released — #265 landed after v0.7.69.