### PR TITLE
feat: CJK-aware word boundaries in TUI text inputs

### DIFF
--- a/.changeset/cjk-word-boundaries.md
+++ b/.changeset/cjk-word-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+TUI 输入框中文分词:alt+←/→ 跳词、alt+backspace 删词现在按中文词语(Intl.Segmenter)移动,`]`、`=`、全角标点都是词边界;之前 native 词边界对中文是固定步长乱跳。覆盖所有 `<input>`/`<textarea>`(quick-task、new-task、rename、settings)。

--- a/packages/kobe/src/cli/export-cmd.ts
+++ b/packages/kobe/src/cli/export-cmd.ts
@@ -98,62 +98,11 @@ function renderCsv(rows: readonly Record<Column, string>[]): string {
   return lines.join("\n")
 }
 
-/**
- * Terminal display width of `s` in cells. Iterates by code point (so astral
- * characters — CJK Extension B, emoji — count once, not as two UTF-16 units),
- * mirroring the code-point awareness of `filetree/rows.ts`'s `truncatePathTail`.
- * East-Asian-wide / fullwidth glyphs and most emoji occupy two cells; combining
- * marks and zero-width formatting characters occupy none; everything else one.
- *
- * kobe is Simplified-Chinese-default, so a CJK task title is the common case —
- * measuring by `String.length` (UTF-16 units) under-counts it and shoves every
- * column to its right out of alignment. Exported for unit tests.
- */
-export function displayWidth(s: string): number {
-  let width = 0
-  for (const ch of s) width += charWidth(ch.codePointAt(0) as number)
-  return width
-}
-
-/** Cell width of a single Unicode code point: 0 (zero-width), 2 (wide), or 1. */
-function charWidth(cp: number): number {
-  // Zero-width: combining marks + bidi/format controls + variation selectors.
-  if (
-    (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks
-    (cp >= 0x1ab0 && cp <= 0x1aff) || // combining diacritical marks extended
-    (cp >= 0x1dc0 && cp <= 0x1dff) || // combining diacritical marks supplement
-    (cp >= 0x200b && cp <= 0x200f) || // zero-width space … LTR/RTL marks
-    (cp >= 0x202a && cp <= 0x202e) || // bidi embedding / override
-    (cp >= 0x2060 && cp <= 0x2064) || // word joiner … invisible operators
-    (cp >= 0x20d0 && cp <= 0x20ff) || // combining marks for symbols
-    (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
-    cp === 0xfeff // zero-width no-break space (BOM)
-  ) {
-    return 0
-  }
-  // Wide: East Asian Wide + Fullwidth + the common emoji / pictograph blocks.
-  if (
-    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
-    cp === 0x2329 ||
-    cp === 0x232a || // angle brackets
-    (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals … Kangxi … CJK symbols
-    (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana … Katakana … CJK compat
-    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Unified Ext A
-    (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
-    (cp >= 0xa000 && cp <= 0xa4cf) || // Yi Syllables
-    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
-    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
-    (cp >= 0xfe10 && cp <= 0xfe19) || // vertical forms
-    (cp >= 0xfe30 && cp <= 0xfe6f) || // CJK compatibility forms
-    (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth forms
-    (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
-    (cp >= 0x1f300 && cp <= 0x1faff) || // emoji, symbols & pictographs
-    (cp >= 0x20000 && cp <= 0x3fffd) // CJK Unified Ext B and beyond
-  ) {
-    return 2
-  }
-  return 1
-}
+// displayWidth moved to ../lib/display-width.ts (the TUI's CJK word-boundary
+// math needs the same cell metric); re-exported so existing imports/tests keep
+// working.
+export { displayWidth } from "../lib/display-width.ts"
+import { displayWidth } from "../lib/display-width.ts"
 
 /** Pad `cell` with trailing spaces to reach `width` terminal cells. */
 function padCell(cell: string, width: number): string {

--- a/packages/kobe/src/lib/display-width.ts
+++ b/packages/kobe/src/lib/display-width.ts
@@ -1,0 +1,66 @@
+/**
+ * Terminal cell-width measurement, shared by every layer that has to agree
+ * with the terminal grid: CLI table export (`cli/export-cmd.ts`) and the
+ * TUI's CJK word-boundary math (`tui/lib/cjk-word.ts`, whose cursor offsets
+ * are display-column offsets in opentui's native edit buffer).
+ *
+ * Moved out of `cli/export-cmd.ts` verbatim so the TUI doesn't import from
+ * the CLI layer. Behavior notes live on each function.
+ */
+
+/**
+ * Terminal display width of `s` in cells. Iterates by code point (so astral
+ * characters — CJK Extension B, emoji — count once, not as two UTF-16 units),
+ * mirroring the code-point awareness of `filetree/rows.ts`'s `truncatePathTail`.
+ * East-Asian-wide / fullwidth glyphs and most emoji occupy two cells; combining
+ * marks and zero-width formatting characters occupy none; everything else one.
+ *
+ * kobe is Simplified-Chinese-default, so a CJK task title is the common case —
+ * measuring by `String.length` (UTF-16 units) under-counts it and shoves every
+ * column to its right out of alignment. Exported for unit tests.
+ */
+export function displayWidth(s: string): number {
+  let width = 0
+  for (const ch of s) width += charWidth(ch.codePointAt(0) as number)
+  return width
+}
+
+/** Cell width of a single Unicode code point: 0 (zero-width), 2 (wide), or 1. */
+export function charWidth(cp: number): number {
+  // Zero-width: combining marks + bidi/format controls + variation selectors.
+  if (
+    (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks
+    (cp >= 0x1ab0 && cp <= 0x1aff) || // combining diacritical marks extended
+    (cp >= 0x1dc0 && cp <= 0x1dff) || // combining diacritical marks supplement
+    (cp >= 0x200b && cp <= 0x200f) || // zero-width space … LTR/RTL marks
+    (cp >= 0x202a && cp <= 0x202e) || // bidi embedding / override
+    (cp >= 0x2060 && cp <= 0x2064) || // word joiner … invisible operators
+    (cp >= 0x20d0 && cp <= 0x20ff) || // combining marks for symbols
+    (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
+    cp === 0xfeff // zero-width no-break space (BOM)
+  ) {
+    return 0
+  }
+  // Wide: East Asian Wide + Fullwidth + the common emoji / pictograph blocks.
+  if (
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    cp === 0x2329 ||
+    cp === 0x232a || // angle brackets
+    (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals … Kangxi … CJK symbols
+    (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana … Katakana … CJK compat
+    (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Unified Ext A
+    (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
+    (cp >= 0xa000 && cp <= 0xa4cf) || // Yi Syllables
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+    (cp >= 0xfe10 && cp <= 0xfe19) || // vertical forms
+    (cp >= 0xfe30 && cp <= 0xfe6f) || // CJK compatibility forms
+    (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth forms
+    (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+    (cp >= 0x1f300 && cp <= 0x1faff) || // emoji, symbols & pictographs
+    (cp >= 0x20000 && cp <= 0x3fffd) // CJK Unified Ext B and beyond
+  ) {
+    return 2
+  }
+  return 1
+}

--- a/packages/kobe/src/tui/lib/cjk-word-patch.ts
+++ b/packages/kobe/src/tui/lib/cjk-word-patch.ts
@@ -1,0 +1,112 @@
+/**
+ * Installs CJK-aware word boundaries (see `cjk-word.ts`) on EVERY opentui
+ * text input by patching `TextareaRenderable.prototype` once at host boot.
+ *
+ * Why a prototype patch and not per-`<input>` refs: the word-jump methods
+ * live on the shared base class of `<input>` AND `<textarea>`, and the
+ * native (Zig) boundary functions they call are not configurable. One patch
+ * point covers the quick-task composer, new-task dialog, rename dialog and
+ * settings fields without touching each call site; a new input added
+ * tomorrow gets correct Chinese word jumps for free.
+ *
+ * Scope: same-line jumps/deletes are reimplemented via `Intl.Segmenter`;
+ * at a line edge (multi-line `<textarea>` only) the ORIGINAL native method
+ * runs so cross-line movement keeps its old behavior. Selection bookkeeping
+ * mirrors the originals: `updateSelectionForMovement` around moves,
+ * `deleteSelection`/`clearSelection` around deletes — those members are
+ * `protected`/absent in the d.ts, hence the single structural cast below.
+ *
+ * NOTE: imports @opentui — not importable under vitest. The pure boundary
+ * math is in `cjk-word.ts`; only wiring lives here.
+ */
+
+import { TextareaRenderable } from "@opentui/core"
+import { nextWordCol, prevWordCol } from "./cjk-word.ts"
+
+/** Runtime shape of the renderable members the patch drives. */
+interface WordEditTarget {
+  plainText: string
+  logicalCursor: { row: number; col: number }
+  setCursor(row: number, col: number): void
+  deleteRange(startLine: number, startCol: number, endLine: number, endCol: number): void
+  hasSelection(): boolean
+  deleteSelection(): boolean
+  clearSelection(): boolean
+  requestRender(): void
+  updateSelectionForMovement(shiftPressed: boolean, isBeforeMovement: boolean): void
+}
+
+function lineAt(text: string, row: number): string {
+  return text.split("\n")[row] ?? ""
+}
+
+let installed = false
+
+/** Idempotent; called from the shared TUI host boot. */
+export function installCjkWordBoundaries(): void {
+  if (installed) return
+  installed = true
+
+  const proto = TextareaRenderable.prototype as unknown as WordEditTarget & {
+    moveWordForward(options?: { select?: boolean }): boolean
+    moveWordBackward(options?: { select?: boolean }): boolean
+    deleteWordForward(): boolean
+    deleteWordBackward(): boolean
+  }
+  const nativeMoveForward = proto.moveWordForward
+  const nativeMoveBackward = proto.moveWordBackward
+  const nativeDeleteForward = proto.deleteWordForward
+  const nativeDeleteBackward = proto.deleteWordBackward
+
+  proto.moveWordForward = function (this: WordEditTarget, options?: { select?: boolean }): boolean {
+    const { row, col } = this.logicalCursor
+    const line = lineAt(this.plainText, row)
+    const target = nextWordCol(line, col)
+    if (target <= col) return nativeMoveForward.call(this, options) // at line end → cross-line natively
+    const select = options?.select ?? false
+    this.updateSelectionForMovement(select, true)
+    this.setCursor(row, target)
+    this.updateSelectionForMovement(select, false)
+    this.requestRender()
+    return true
+  }
+
+  proto.moveWordBackward = function (this: WordEditTarget, options?: { select?: boolean }): boolean {
+    const { row, col } = this.logicalCursor
+    if (col === 0) return nativeMoveBackward.call(this, options)
+    const select = options?.select ?? false
+    this.updateSelectionForMovement(select, true)
+    this.setCursor(row, prevWordCol(lineAt(this.plainText, row), col))
+    this.updateSelectionForMovement(select, false)
+    this.requestRender()
+    return true
+  }
+
+  proto.deleteWordForward = function (this: WordEditTarget): boolean {
+    if (this.hasSelection()) {
+      this.deleteSelection()
+      return true
+    }
+    const { row, col } = this.logicalCursor
+    const target = nextWordCol(lineAt(this.plainText, row), col)
+    if (target <= col) return nativeDeleteForward.call(this)
+    this.deleteRange(row, col, row, target)
+    this.clearSelection()
+    this.requestRender()
+    return true
+  }
+
+  proto.deleteWordBackward = function (this: WordEditTarget): boolean {
+    if (this.hasSelection()) {
+      this.deleteSelection()
+      return true
+    }
+    const { row, col } = this.logicalCursor
+    if (col === 0) return nativeDeleteBackward.call(this)
+    const target = prevWordCol(lineAt(this.plainText, row), col)
+    if (target < col) this.deleteRange(row, target, row, col)
+    this.clearSelection()
+    this.requestRender()
+    return true
+  }
+}

--- a/packages/kobe/src/tui/lib/cjk-word.ts
+++ b/packages/kobe/src/tui/lib/cjk-word.ts
@@ -1,0 +1,104 @@
+/**
+ * CJK-aware word boundaries for the TUI's text inputs, in DISPLAY-COLUMN
+ * space.
+ *
+ * opentui's native (Zig) edit buffer computes word jumps itself, and for
+ * Chinese text they are useless: a run of 汉字 is walked in arbitrary
+ * fixed-width hops, and ASCII/fullwidth punctuation (`]`, `=`, `】`…) never
+ * splits. kobe is Simplified-Chinese-default, so alt+←/→ and alt+backspace
+ * inside a Chinese prompt are a core editing path, not an edge case.
+ *
+ * `Intl.Segmenter("zh", { granularity: "word" })` (ICU, built into Bun)
+ * does real Chinese word segmentation — 「中文输入法优化」→ 中文|输入|法|优|化 —
+ * and emits every punctuation mark as its own non-word segment, which makes
+ * `]`/`=`/fullwidth punctuation natural split points for free.
+ *
+ * Coordinate contract (probed against @opentui/core 0.4.3): the edit
+ * buffer's cursor `col`/`offset` are TERMINAL CELLS, not UTF-16 units — a
+ * CJK glyph occupies 2, mid-glyph positions snap down. All public functions
+ * here therefore take and return column offsets within ONE logical line;
+ * `cjk-word-patch.ts` owns the per-line/renderable wiring.
+ */
+
+import { charWidth } from "../../lib/display-width.ts"
+
+const segmenter = new Intl.Segmenter("zh", { granularity: "word" })
+
+/** JS string index → display column (cells before `index`). */
+export function indexToCol(line: string, index: number): number {
+  let col = 0
+  let i = 0
+  for (const ch of line) {
+    if (i >= index) break
+    col += charWidth(ch.codePointAt(0) as number)
+    i += ch.length
+  }
+  return col
+}
+
+/** Display column → JS string index, snapping down mid-glyph (native rule). */
+export function colToIndex(line: string, col: number): number {
+  let acc = 0
+  let i = 0
+  for (const ch of line) {
+    const w = charWidth(ch.codePointAt(0) as number)
+    if (acc + w > col) return i
+    acc += w
+    i += ch.length
+  }
+  return line.length
+}
+
+const isSpace = (s: string) => s.trim().length === 0
+
+interface Seg {
+  readonly start: number
+  readonly end: number
+  readonly kind: "word" | "punct" | "space"
+}
+
+function segmentsOf(line: string): Seg[] {
+  const out: Seg[] = []
+  for (const s of segmenter.segment(line)) {
+    out.push({
+      start: s.index,
+      end: s.index + s.segment.length,
+      kind: s.isWordLike ? "word" : isSpace(s.segment) ? "space" : "punct",
+    })
+  }
+  return out
+}
+
+/**
+ * Column of the previous word boundary before `col` (0 if none). Skips
+ * whitespace, then lands on the start of the word — or of the whole
+ * punctuation run (vim-style: `]]==` is one hop, a lone `=` still splits).
+ */
+export function prevWordCol(line: string, col: number): number {
+  const segs = segmentsOf(line)
+  let i = segs.length - 1
+  const idx = colToIndex(line, col)
+  while (i >= 0 && (segs[i] as Seg).start >= idx) i--
+  while (i >= 0 && (segs[i] as Seg).kind === "space") i--
+  if (i < 0) return 0
+  const kind = (segs[i] as Seg).kind
+  while (i > 0 && (segs[i - 1] as Seg).kind === kind && kind === "punct") i--
+  return indexToCol(line, (segs[i] as Seg).start)
+}
+
+/**
+ * Column of the next word boundary after `col` (end of line if none).
+ * Mirror of {@link prevWordCol}: skip whitespace, consume one word or one
+ * punctuation run, land after it.
+ */
+export function nextWordCol(line: string, col: number): number {
+  const segs = segmentsOf(line)
+  const idx = colToIndex(line, col)
+  let i = 0
+  while (i < segs.length && (segs[i] as Seg).end <= idx) i++
+  while (i < segs.length && (segs[i] as Seg).kind === "space") i++
+  if (i >= segs.length) return indexToCol(line, line.length)
+  const kind = (segs[i] as Seg).kind
+  while (i < segs.length - 1 && (segs[i + 1] as Seg).kind === kind && kind === "punct") i++
+  return indexToCol(line, (segs[i] as Seg).end)
+}

--- a/packages/kobe/src/tui/lib/host-boot.tsx
+++ b/packages/kobe/src/tui/lib/host-boot.tsx
@@ -46,6 +46,7 @@ import { isLocaleId, setLocaleLang, t } from "../i18n"
 import { DialogProvider } from "../ui/dialog"
 import { type UiPrefsTarget, applyUiPrefs } from "./apply-ui-prefs"
 import { sessionAttached } from "./attach-gate"
+import { installCjkWordBoundaries } from "./cjk-word-patch.ts"
 import { hostRenderOptions, installPaneExitBackstop } from "./host-render-options"
 import { type PersistedUiPrefs, readPersistedUiPrefs } from "./persisted-ui-prefs"
 
@@ -127,6 +128,7 @@ function applyHostBootSteps(logContext?: string): void {
   // (mirrors the daemon's `installDaemonCrashHandlers`). The render tree's
   // own throws are caught separately by the <ErrorBoundary> in bootPaneHost.
   installClientCrashHandlers()
+  installCjkWordBoundaries()
   applyUserKeybindings()
   for (const { name, theme } of loadUserThemes()) {
     addTheme(name, theme)

--- a/packages/kobe/test/tui/cjk-word.test.ts
+++ b/packages/kobe/test/tui/cjk-word.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure CJK word-boundary math (`src/tui/lib/cjk-word.ts`).
+ *
+ * Why these tests matter: the functions operate in DISPLAY-COLUMN space —
+ * the coordinate system of opentui's native edit buffer, probed against
+ * @opentui/core 0.4.3 (CJK glyph = 2 cells, mid-glyph snaps down). A
+ * regression here silently lands word jumps/deletes inside the wrong
+ * character for every Chinese prompt, which is kobe's default language.
+ * The prototype wiring (`cjk-word-patch.ts`) imports @opentui and can't run
+ * under vitest; this pure layer is the tested contract.
+ */
+
+import { describe, expect, it } from "vitest"
+import { colToIndex, indexToCol, nextWordCol, prevWordCol } from "../../src/tui/lib/cjk-word.ts"
+
+describe("col/index conversion", () => {
+  it("counts CJK as two cells, ASCII as one", () => {
+    // "中文ab" → cols: 中=0..2, 文=2..4, a=4, b=5
+    expect(indexToCol("中文ab", 0)).toBe(0)
+    expect(indexToCol("中文ab", 1)).toBe(2)
+    expect(indexToCol("中文ab", 2)).toBe(4)
+    expect(indexToCol("中文ab", 4)).toBe(6)
+    expect(colToIndex("中文ab", 4)).toBe(2)
+    expect(colToIndex("中文ab", 6)).toBe(4)
+  })
+
+  it("snaps down inside a wide glyph (native edit-buffer rule)", () => {
+    expect(colToIndex("中文", 1)).toBe(0)
+    expect(colToIndex("中文", 3)).toBe(1)
+  })
+
+  it("clamps past end of line", () => {
+    expect(colToIndex("ab", 99)).toBe(2)
+  })
+})
+
+describe("nextWordCol", () => {
+  it("jumps by Chinese word, not by whole CJK run", () => {
+    // 中文|输入|法 — from 0 the first hop is after 中文 (col 4), not line end
+    const line = "中文输入法"
+    expect(nextWordCol(line, 0)).toBe(4)
+    expect(nextWordCol(line, 4)).toBe(8)
+  })
+
+  it("treats ] and = as split points", () => {
+    // "a]b=c" cols: a=0 ]=1 b=2 ==3 c=4
+    const line = "a]b=c"
+    expect(nextWordCol(line, 0)).toBe(1) // end of "a"
+    expect(nextWordCol(line, 1)).toBe(2) // past "]"
+    expect(nextWordCol(line, 2)).toBe(3) // end of "b"
+    expect(nextWordCol(line, 3)).toBe(4) // past "="
+  })
+
+  it("treats fullwidth punctuation as split points", () => {
+    // "任务】名" cols: 任=0..2 务=2..4 】=4..6 名=6..8
+    const line = "任务】名"
+    expect(nextWordCol(line, 0)).toBe(4) // end of 任务
+    expect(nextWordCol(line, 4)).toBe(6) // past 】
+    expect(nextWordCol(line, 6)).toBe(8)
+  })
+
+  it("consumes a punctuation run as one hop", () => {
+    expect(nextWordCol("a]]==b", 1)).toBe(5) // whole "]]==" run
+  })
+
+  it("skips whitespace before the next word", () => {
+    // "中文  输入" cols: 中文=0..4, spaces=4..6, 输入=6..10
+    expect(nextWordCol("中文  输入", 4)).toBe(10)
+  })
+
+  it("returns line-end col when nothing follows (patch falls back to native)", () => {
+    expect(nextWordCol("中文", 4)).toBe(4)
+    expect(nextWordCol("中文  ", 4)).toBe(6) // trailing spaces → end of line
+  })
+})
+
+describe("prevWordCol", () => {
+  it("jumps back by Chinese word", () => {
+    const line = "中文输入法"
+    // 中文|输入|法 → from end (col 10) back to start of 法 (col 8)
+    expect(prevWordCol(line, 10)).toBe(8)
+    expect(prevWordCol(line, 8)).toBe(4)
+    expect(prevWordCol(line, 4)).toBe(0)
+  })
+
+  it("stops at ] and = boundaries", () => {
+    const line = "路径=值" // 路径=0..4, ==4..5, 值=5..7
+    expect(prevWordCol(line, 7)).toBe(5) // start of 值
+    expect(prevWordCol(line, 5)).toBe(4) // start of =
+    expect(prevWordCol(line, 4)).toBe(0) // start of 路径
+  })
+
+  it("skips trailing whitespace, then deletes/moves one word", () => {
+    // "中文 " cols: 中文=0..4, space=4..5
+    expect(prevWordCol("中文 ", 5)).toBe(0)
+  })
+
+  it("consumes a punctuation run as one hop", () => {
+    expect(prevWordCol("a]]==b", 5)).toBe(1)
+  })
+
+  it("returns 0 at or before the first word", () => {
+    expect(prevWordCol("中文", 0)).toBe(0)
+    expect(prevWordCol("  中文", 2)).toBe(0)
+  })
+
+  it("lands on word start when cursor is mid-word", () => {
+    expect(prevWordCol("中文输入", 6)).toBe(4) // mid-输入 → start of 输入
+  })
+})
+
+describe("mixed real-world prompt", () => {
+  it("walks 'feat: 中文输入法优化(quick-task)' by word", () => {
+    const line = "feat: 中文输入法优化(quick-task)"
+    // forward from 0: feat | : | 中文 | 输入 | 法 | 优 | 化 | ( | quick | - | task | )
+    const hops: number[] = []
+    let col = 0
+    for (let guard = 0; guard < 20; guard++) {
+      const next = nextWordCol(line, col)
+      if (next <= col) break
+      hops.push(next)
+      col = next
+    }
+    expect(hops[0]).toBe(4) // after "feat"
+    expect(hops[hops.length - 1]).toBe(indexToCol(line, line.length))
+    // every hop lands on a boundary that prevWordCol agrees with
+    for (const h of hops.slice(0, -1)) {
+      expect(nextWordCol(line, prevWordCol(line, h))).toBe(h)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- opentui's native (Zig) word boundaries are useless for Chinese: a CJK run is walked in arbitrary fixed-width hops, and punctuation (`]`, `=`, `】`…) never splits. kobe is Simplified-Chinese-default, so alt+←/→ and alt+backspace inside a Chinese prompt are a core editing path.
- Patch `TextareaRenderable.prototype` once at host boot (`installCjkWordBoundaries`, wired in `host-boot.tsx`): same-line word move/delete are reimplemented via `Intl.Segmenter("zh", { granularity: "word" })` — 「中文输入法优化」 hops 中文|输入|法|优|化, and ASCII/fullwidth punctuation are natural split points (a punctuation run is one hop, vim-style). One patch point covers every `<input>`/`<textarea>` (quick-task composer, new-task dialog, rename dialog, settings) without touching the >500-line dialog files.
- Coordinate contract probed against @opentui/core 0.4.3: edit-buffer cursor col/offset are terminal CELLS (CJK glyph = 2, mid-glyph snaps down). The pure column math lives in `src/tui/lib/cjk-word.ts`; `displayWidth`/`charWidth` moved from `cli/export-cmd.ts` to `src/lib/display-width.ts` so the TUI doesn't import from the CLI layer (re-exported, existing imports keep working).
- At a line edge (multi-line `<textarea>` cross-line moves) the original native method still runs; selection bookkeeping mirrors the originals.

## Test plan
- [x] `test/tui/cjk-word.test.ts` — 16 unit tests on the pure boundary math (CJK cell widths, mid-glyph snap, `]`/`=`/fullwidth splits, punctuation runs, whitespace skip, mixed CJK+ASCII prompt round-trip)
- [x] Integration smoke on a real `TextareaRenderable` via `@opentui/core/testing`: backward hops land per Chinese word (`end → ] → 值 → = → 化 → 优 → 法 → 输入 → 中文`); repeated alt+backspace deletes one unit at a time
- [x] Full kobe suite (218 tests), root `bun run lint`, package typecheck — all green

coverage-exemption: packages/kobe/src/tui/lib/cjk-word-patch.ts — imports @opentui (not loadable under vitest); pure boundary math is tested in test/tui/cjk-word.test.ts