### PR TITLE
feat: unified process-identity model for terminal tabs

### DIFF
--- a/.changeset/terminal-process-identity.md
+++ b/.changeset/terminal-process-identity.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Terminal tabs now follow one model: every tab is a shell, an engine is just a process running in it. Tab default names are "$process $ordinal" ("claude 3", "shell 5") instead of "tab N"; split shell leaves and tab labels track the live foreground process via OSC window titles ("vim", "htop"), with engine titles normalized to one vocabulary ("✳ Claude Code" → "claude"). Typing `claude` inside a plain shell now attaches the same turn-status chip (●/✓) as a kobe-launched engine tab, and it detaches when the process exits. Fixes: a tab degraded to a shell no longer reopens as a fresh claude after restart; closing the engine leaf inside a split no longer leaves a stale turn chip flapping against a dead PTY; the corner name tag hides when a single leaf survives (the tab label already says it).

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -245,6 +245,41 @@ export function engineEntry(vendor: VendorId): EngineRegistryEntry {
 }
 
 /**
+ * Match a live terminal window title (OSC 0/2 — `TaskPtyLike.onTitleChange`)
+ * to the engine whose CLI set it. This is how a shell tab where the USER
+ * typed `claude` joins the same turn-status management as a kobe-launched
+ * engine tab (owner model 2026-07-07: every tab is a shell; an engine is
+ * just a process running in it). Two engine-owned signals, checked per
+ * built-in entry so neutral layers never hard-code vendor strings:
+ *   - the product name anywhere in the title  (claude sets "✳ Claude Code")
+ *   - the launch binary as a whole word       (zsh-preexec-style "claude")
+ * Custom engines aren't matched — kobe knows nothing about their titles.
+ */
+export function vendorFromTerminalTitle(title: string | null | undefined): VendorId | null {
+  if (!title) return null
+  const lower = title.toLowerCase()
+  for (const entry of Object.values(BUILTIN_ENGINES)) {
+    if (entry.identity && lower.includes(entry.identity.productName.toLowerCase())) return entry.vendor
+    const bin = entry.defaultCommand[0]?.toLowerCase()
+    if (bin && new RegExp(`(^|\\s)${bin}(\\s|$)`).test(lower)) return entry.vendor
+  }
+  return null
+}
+
+/**
+ * Display name for a live terminal title: an engine's own title collapses
+ * to its launch binary ("✳ Claude Code" → "claude", codex's likewise) so
+ * every kobe surface (tab labels, split corner tags) speaks ONE vocabulary
+ * for a process no matter how it was started or what decoration the CLI
+ * put in its title. Non-engine titles pass through raw (vim, htop, a
+ * cwd-titling shell) — that's the dynamic real-terminal behavior.
+ */
+export function titleDisplayName(title: string): string {
+  const vendor = vendorFromTerminalTitle(title)
+  return vendor ? (engineEntry(vendor).defaultCommand[0] ?? vendor) : title
+}
+
+/**
  * Capabilities for a vendor, or `undefined` when the engine has none (copilot,
  * custom). Consumed by the native chat composer's model picker +
  * permission-mode cycle; callers must handle the missing case rather than

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -9,12 +9,9 @@ export const en = {
   exited: "process exited — F5 restarts it",
   restoring: "restoring session…",
   tab: {
-    // A NORMAL (single) tab is just "tab N"; only a SPLIT tab is a "group"
-    // (see groupTitle) — the tab that groups several leaves, each carrying
-    // its own name. Content-neutral on purpose: tabs host more than
-    // terminals, so the numbered fallback must not say "Terminal".
-    defaultTitle: "tab {n}",
-    // A split tab's label — the "group" of leaves.
+    // A NORMAL (single) tab's default name is "$process $ordinal" —
+    // built in code from the live process identity ("claude 3",
+    // "shell 5"), not translated. Only the SPLIT label lives here.
     groupTitle: "group {n}",
     renameTitle: "Rename tab",
     renameField: "tab title",
@@ -45,7 +42,6 @@ export const zh: typeof en = {
   exited: "进程已退出 —— 按 F5 重启",
   restoring: "正在恢复会话…",
   tab: {
-    defaultTitle: "tab {n}",
     groupTitle: "group {n}",
     renameTitle: "重命名标签页",
     renameField: "标签页名称",

--- a/packages/kobe/src/tui/panes/terminal/pty-mock.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-mock.ts
@@ -6,6 +6,7 @@ import {
   type TaskPtyLike,
   type TaskPtyOpts,
   type TerminalRow,
+  extractOscTitle,
 } from "./pty-types"
 import { parseAnsiSnapshot } from "./sgr"
 
@@ -16,7 +17,9 @@ export class MockTaskPty implements TaskPtyLike {
   private buffer = ""
   private writes: string[] = []
   private _killed = false
+  private _title: string | null = null
   private readonly exitListeners = new Set<() => void>()
+  private readonly titleListeners = new Set<(title: string) => void>()
   /** Pasted payloads, observable by tests. */
   readonly pastes: string[] = []
   readonly wheels: { direction: "up" | "down"; col: number; row: number }[] = []
@@ -46,6 +49,17 @@ export class MockTaskPty implements TaskPtyLike {
   feed(data: string): void {
     if (this._killed) return
     this.buffer += data
+    const title = extractOscTitle(data)
+    if (title && title !== this._title) {
+      this._title = title
+      for (const cb of this.titleListeners) {
+        try {
+          cb(title)
+        } catch {
+          /* one listener must not break the others */
+        }
+      }
+    }
     const rows = this.capture()
     for (const cb of this.listeners) {
       try {
@@ -124,6 +138,20 @@ export class MockTaskPty implements TaskPtyLike {
     this.exitListeners.add(cb)
     return () => {
       this.exitListeners.delete(cb)
+    }
+  }
+
+  onTitleChange(cb: (title: string) => void): () => void {
+    this.titleListeners.add(cb)
+    if (this._title) {
+      try {
+        cb(this._title)
+      } catch {
+        /* one listener must not break the others */
+      }
+    }
+    return () => {
+      this.titleListeners.delete(cb)
     }
   }
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
@@ -9,6 +9,7 @@ import {
   type TaskPtyOpts,
   type TerminalRow,
   defaultShell,
+  extractOscTitle,
   resolveArgv,
 } from "./pty-types"
 import { parseAnsiSnapshot } from "./sgr"
@@ -20,7 +21,9 @@ export class PipeTaskPty implements TaskPtyLike {
   private readonly listeners = new Set<DataListener>()
   private buffer = ""
   private _killed = false
+  private _title: string | null = null
   private readonly exitListeners = new Set<() => void>()
+  private readonly titleListeners = new Set<(title: string) => void>()
   private cols: number
   private rows: number
 
@@ -122,6 +125,19 @@ export class PipeTaskPty implements TaskPtyLike {
     if (this.buffer.length > PIPE_SCROLLBACK_LIMIT) {
       this.buffer = this.buffer.slice(this.buffer.length - PIPE_SCROLLBACK_LIMIT)
     }
+    // No emulator on this fallback path — extract OSC 0/2 title escapes
+    // by hand (the Bun/xterm backend gets this from `onTitleChange`).
+    const title = extractOscTitle(chunk)
+    if (title && title !== this._title) {
+      this._title = title
+      for (const cb of this.titleListeners) {
+        try {
+          cb(title)
+        } catch {
+          /* one listener must not break the others */
+        }
+      }
+    }
     const rows = this.capture()
     for (const cb of this.listeners) {
       try {
@@ -172,6 +188,20 @@ export class PipeTaskPty implements TaskPtyLike {
     this.exitListeners.add(cb)
     return () => {
       this.exitListeners.delete(cb)
+    }
+  }
+
+  onTitleChange(cb: (title: string) => void): () => void {
+    this.titleListeners.add(cb)
+    if (this._title) {
+      try {
+        cb(this._title)
+      } catch {
+        /* one listener must not break the others */
+      }
+    }
+    return () => {
+      this.titleListeners.delete(cb)
     }
   }
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -1,3 +1,4 @@
+import { parse } from "@ansi-tools/parser"
 import type { Chunk } from "./sgr"
 
 /** One rendered row: a list of opentui-ready style runs. */
@@ -56,6 +57,15 @@ export interface TaskPtyLike {
    */
   onExit(cb: () => void): () => void
   /**
+   * Notify when the foreground command's window title changes — the
+   * same OSC 0/2 mechanism a real terminal emulator uses to show "vim"
+   * or "htop" in a tab instead of a static "shell" (real terminals track
+   * this per-pane). Fires immediately with the latest known title on
+   * subscribe, same replay contract as `onData`. Never fires if the
+   * shell/program never sets one.
+   */
+  onTitleChange(cb: (title: string) => void): () => void
+  /**
    * Route a mouse-wheel tick the way a real terminal emulator would:
    * the app enabled mouse tracking → encode an SGR wheel event at
    * (col,row) (1-based, pane-local) and forward it — the app scrolls
@@ -78,6 +88,25 @@ export const VISIBLE_SCROLLBACK_MARGIN_ROWS = 200
 
 export function defaultShell(): string {
   return process.env.SHELL ?? "/bin/bash"
+}
+
+/**
+ * Extract the last OSC 0/2 (icon+title / title) escape's payload from a
+ * chunk of raw terminal output — `\x1b]0;name\x07` or `\x1b]2;name\x07`,
+ * the window-title mechanism shells/programs (vim, htop, ssh, npm…) use
+ * to name themselves. Backends without a full emulator (`PipeTaskPty`,
+ * `MockTaskPty`) call this per chunk; `BunTerminalTaskPty` gets it for
+ * free from `@xterm/headless`'s own `onTitleChange`. Returns null if the
+ * chunk carries no title escape.
+ */
+export function extractOscTitle(chunk: string): string | null {
+  let title: string | null = null
+  for (const code of parse(chunk)) {
+    if (code.type === "OSC" && (code.command === "0" || code.command === "2") && code.params[0]) {
+      title = code.params[0]
+    }
+  }
+  return title
 }
 
 /**

--- a/packages/kobe/src/tui/panes/terminal/pty.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty.ts
@@ -50,8 +50,10 @@ export class BunTerminalTaskPty implements TaskPtyLike {
   private readonly term: XtermHeadless
   private readonly listeners = new Set<DataListener>()
   private readonly exitListeners = new Set<() => void>()
+  private readonly titleListeners = new Set<(title: string) => void>()
   private snapshot: readonly TerminalRow[] = []
   private cursor: CursorPos | null = null
+  private _title: string | null = null
   private _killed = false
   private cols: number
   private rows: number
@@ -83,6 +85,22 @@ export class BunTerminalTaskPty implements TaskPtyLike {
         this.proc.terminal?.write(data)
       } catch {
         /* best effort — child may have exited */
+      }
+    })
+
+    // Window-title tracking (OSC 0/2) — xterm-headless already parses
+    // these escapes internally, so the split-leaf corner tag can show
+    // "vim"/"htop"/whatever's actually running instead of a static
+    // "shell" (see `terminal-tabs-core.ts`'s `splitLeafNames`).
+    this.term.onTitleChange((title) => {
+      if (!title || title === this._title) return
+      this._title = title
+      for (const cb of this.titleListeners) {
+        try {
+          cb(title)
+        } catch {
+          /* one listener must not break the others */
+        }
       }
     })
 
@@ -132,6 +150,20 @@ export class BunTerminalTaskPty implements TaskPtyLike {
     this.exitListeners.add(cb)
     return () => {
       this.exitListeners.delete(cb)
+    }
+  }
+
+  onTitleChange(cb: (title: string) => void): () => void {
+    this.titleListeners.add(cb)
+    if (this._title) {
+      try {
+        cb(this._title)
+      } catch {
+        /* one listener must not break the others */
+      }
+    }
+    return () => {
+      this.titleListeners.delete(cb)
     }
   }
 

--- a/packages/kobe/src/tui/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalSplit.tsx
@@ -30,8 +30,9 @@
  * over once a split exists.
  */
 
+import { titleDisplayName } from "@/engine/registry"
 import { type RGBA, TextAttributes } from "@opentui/core"
-import { type Accessor, For, type JSXElement, Show, createEffect, createSignal, on } from "solid-js"
+import { type Accessor, For, type JSXElement, Show, createEffect, createSignal, on, onCleanup } from "solid-js"
 import { RenameTaskDialog } from "../component/rename-task-dialog"
 import { bindByIds } from "../context/keybindings"
 import { useTheme } from "../context/theme"
@@ -234,12 +235,61 @@ export function TerminalSplit(props: {
   const dividerProps = (divider: "left" | "top" | undefined, color: () => RGBA) =>
     divider ? { border: [divider] as ("left" | "top")[], borderColor: color() } : { border: false as const }
 
+  // Live foreground-process titles for split-created SHELL leaves (real
+  // terminals track this via the OSC 0/2 window-title escape: "zsh" idle,
+  // "vim"/"htop" once you run one — see `TaskPtyLike.onTitleChange`).
+  // Engine leaves keep their own conversation-title naming (`engineTitle`),
+  // untouched here. Lazy-attach + retry: a leaf's PTY spawns asynchronously
+  // after its Terminal mounts, same contract as `turn-polls.ts`'s poll
+  // attach. Ephemeral (not persisted) — a fresh mount re-derives it as soon
+  // as the shell's next title escape lands.
+  const TITLE_ATTACH_MS = 2000
+  const [liveTitles, setLiveTitles] = createSignal<ReadonlyMap<string, string>>(new Map())
+  const titleSubs = new Map<string, () => void>()
+  const [titleTick, setTitleTick] = createSignal(0)
+  const titleAttachTimer = setInterval(() => setTitleTick((n) => n + 1), TITLE_ATTACH_MS)
+  onCleanup(() => clearInterval(titleAttachTimer))
+  createEffect(() => {
+    titleTick()
+    const reg = getDefaultPtyRegistry()
+    const shellLeafIds = new Set(
+      leaves(state().root)
+        .filter((l) => l.content !== null)
+        .map((l) => l.id),
+    )
+    for (const id of shellLeafIds) {
+      if (titleSubs.has(id)) continue
+      const pty = reg.get(splitLeafPtyKey(props.tabKey, id))
+      if (!pty) continue
+      // Normalize through the registry so an engine's decorated title
+      // ("✳ Claude Code") reads as its binary ("claude") — one vocabulary
+      // across corner tags and tab labels, however the process started.
+      titleSubs.set(
+        id,
+        pty.onTitleChange((title) => setLiveTitles((prev) => new Map(prev).set(id, titleDisplayName(title)))),
+      )
+    }
+    for (const [id, dispose] of titleSubs) {
+      if (shellLeafIds.has(id)) continue
+      dispose()
+      titleSubs.delete(id)
+      setLiveTitles((prev) => {
+        const next = new Map(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  })
+  onCleanup(() => {
+    for (const dispose of titleSubs.values()) dispose()
+  })
+
   /** id → display name. Owner correction 2026-07-06: the TAB is the
    *  "group" (its default title says so) — each leaf carries its OWN
    *  name: F2 rename wins, default = basename of what it runs
    *  ("claude", "zsh", "zsh 2"…). Derivation is pure (`splitLeafNames`)
    *  so vitest pins it. */
-  const leafNames = () => splitLeafNames(leaves(state().root), props.command, props.engineTitle?.())
+  const leafNames = () => splitLeafNames(leaves(state().root), props.command, props.engineTitle?.(), liveTitles())
 
   const renderLeaf = (leaf: SplitLeaf<LeafCommand>, divider?: "left" | "top"): JSXElement => {
     // Focus is LOCAL: a plain setActiveLeaf, so a click updates only the
@@ -265,18 +315,25 @@ export function TerminalSplit(props: {
             focusThis()
           }}
         />
-        {/* Corner name tag — the leaf's OWN name; the focused leaf's tag
+        {/* Corner name tag — ONLY while there's more than one leaf to tell
+            apart. A single surviving leaf (engine closed, one shell left —
+            or the reverse) has nothing to disambiguate: the tab-strip label
+            above already shows this exact same name (`tabTitle`'s solo-leaf
+            branch reads the identical live/derived name), so a second copy
+            pinned to the corner is pure duplication. The focused leaf's tag
             lights in the focus accent (reactive JSX attrs, so a local focus
             change repaints it without a tree re-render). */}
-        <box position="absolute" right={0} top={0} zIndex={10} backgroundColor={theme.backgroundElement}>
-          <text
-            fg={leafFocused(leaf.id) ? theme.focusAccent : theme.textMuted}
-            attributes={leafFocused(leaf.id) ? TextAttributes.BOLD : TextAttributes.DIM}
-            wrapMode="none"
-          >
-            {` ${leafNames().get(leaf.id) ?? ""} `}
-          </text>
-        </box>
+        <Show when={isSplit()}>
+          <box position="absolute" right={0} top={0} zIndex={10} backgroundColor={theme.backgroundElement}>
+            <text
+              fg={leafFocused(leaf.id) ? theme.focusAccent : theme.textMuted}
+              attributes={leafFocused(leaf.id) ? TextAttributes.BOLD : TextAttributes.DIM}
+              wrapMode="none"
+            >
+              {` ${leafNames().get(leaf.id) ?? ""} `}
+            </text>
+          </box>
+        </Show>
       </>
     )
     // borderColor must be a REACTIVE JSX attribute (not a pre-computed spread

--- a/packages/kobe/src/tui/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui/workspace/TerminalTabs.tsx
@@ -133,11 +133,12 @@ export function TerminalTabs(props: {
   const initState = (): TabsState => {
     const existing = tabsByTask.get(props.taskId)
     if (existing) return existing
-    // Restart survival (issue #22): rehydrate the persisted engine-tab
-    // snapshot (titles/ordinals/sessionIds — command tabs are transient
-    // and dropped) before falling back to a fresh single tab.
+    // Restart survival (issue #22): rehydrate the persisted tab snapshot
+    // (titles/ordinals/sessionIds; engine tabs resume their conversation,
+    // command tabs — degraded shells, dead editors — respawn as shells)
+    // before falling back to a fresh single tab.
     const saved = kv.get(persistKey, null) as TabsState | null
-    const fromDisk = saved && Array.isArray(saved.tabs) ? rehydrateTabs(saved) : null
+    const fromDisk = saved && Array.isArray(saved.tabs) ? rehydrateTabs(saved, [defaultShell()]) : null
     rehydratedFromDisk = fromDisk !== null
     const fresh = fromDisk ?? pinSession(initialTabs(), undefined)
     // Persist immediately so a remount before the first mutation doesn't
@@ -252,7 +253,7 @@ export function TerminalTabs(props: {
   /* --------- per-tab turn state (tmux @kobe_tab_state, logic layer) -------
    * Extracted to `turn-polls.ts` — the Ops-pane poll loop with PTY IO,
    * shared/local cadence per the sharedActivity contract. */
-  const { turnStates } = createTurnPolls({
+  const { turnStates, liveTitles } = createTurnPolls({
     taskId: props.taskId,
     worktree: props.worktree,
     vendor: () => props.vendor,
@@ -260,7 +261,7 @@ export function TerminalTabs(props: {
     sharedActivity: props.sharedActivity,
     onBackgroundDone: (tabId) => {
       const current = state().tabs.find((t) => t.id === tabId)
-      if (current) notif.notify({ kind: "done", taskId: props.taskId, tabId, title: tabTitle(current) })
+      if (current) notif.notify({ kind: "done", taskId: props.taskId, tabId, title: tabTitle(current, props.vendor) })
     },
   })
 
@@ -337,7 +338,7 @@ export function TerminalTabs(props: {
   const requestRename = (): void => {
     const tab = active()
     if (!tab) return
-    void RenameTaskDialog.show(dialog, tabTitle(tab), {
+    void RenameTaskDialog.show(dialog, tabTitle(tab, props.vendor, liveTitles().get(tab.id)), {
       dialogTitle: t("terminal.tab.renameTitle"),
       fieldLabel: t("terminal.tab.renameField"),
       submitLabel: t("terminal.tab.renameSubmit"),
@@ -427,6 +428,8 @@ export function TerminalTabs(props: {
           activeId={() => state().activeId}
           turnStates={turnStates}
           onSelect={(tabId) => update(selectTab(state(), tabId))}
+          vendor={() => props.vendor}
+          liveTitles={liveTitles}
         />
       </Show>
       {/* One long-lived tab body, never remounted on an ordinary tab

--- a/packages/kobe/src/tui/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui/workspace/tab-strip.tsx
@@ -7,13 +7,15 @@
  * you looked elsewhere.
  */
 
+import { engineEntry } from "@/engine/registry"
 import type { ChatTabTurnState } from "@/engine/turn-detector"
+import type { VendorId } from "@/types/vendor"
 import { TextAttributes } from "@opentui/core"
 import { For, Show, createEffect, createSignal, onCleanup } from "solid-js"
 import { useTheme } from "../context/theme"
 import { t } from "../i18n"
 import { leaves } from "./split-core"
-import { SHELL_LEAF_NAME, type TerminalTab } from "./terminal-tabs-core"
+import { SHELL_LEAF_NAME, type TerminalTab, hasEngineLeaf } from "./terminal-tabs-core"
 
 /** Same glyph vocabulary as tmux's `CHAT_TAB_STATUS_FORMAT` (`@kobe_tab_state`). */
 export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
@@ -27,19 +29,32 @@ export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
 /** How long the running→done pulse stays emphasized. */
 const DONE_PULSE_MS = 600
 
-export function tabTitle(tab: TerminalTab): string {
-  // Manual rename always wins. Otherwise a NORMAL (single) tab is named by
-  // its first-prompt title, falling back to "tab N"; a SPLIT tab is a
-  // "group N" (its leaves carry the individual names — see splitLeafNames).
+/**
+ * Default tab names are "$process $ordinal" (owner naming 2026-07-07):
+ * a tab IS a terminal, so its name says what runs in it — "claude 3",
+ * "shell 5", "vim 2" — never an opaque "tab N". `liveName` is the tab's
+ * live foreground-process display name from the turn-poll title stream
+ * (`createTurnPolls().liveTitles`); engine tabs don't need it (their
+ * process is known by construction), callers without it (notifications)
+ * fall back to the static shell default.
+ */
+export function tabTitle(tab: TerminalTab, taskVendor: VendorId, liveName?: string | null): string {
+  // Manual rename always wins; a conversation's first-prompt title beats
+  // the numbered default; a multi-leaf SPLIT tab is a "group N" (its
+  // leaves carry the individual names — see splitLeafNames).
   if (tab.title) return tab.title
   const ls = tab.splitTree ? leaves(tab.splitTree.root) : []
   if (ls.length > 1) return t("terminal.tab.groupTitle", { n: tab.ordinal })
-  // Collapsed to a single NON-engine leaf (you closed the engine leaf and a
-  // shell survives) → show that leaf's own name, not the stale engine
-  // conversation title.
+  // Collapsed to a single NON-engine leaf (you closed the engine leaf and
+  // a shell survives) → that leaf's rename, else its live process name.
   const sole = ls.length === 1 ? ls[0] : undefined
-  if (sole && sole.id !== "leaf-1") return sole.title ?? SHELL_LEAF_NAME
-  return tab.autoTitle ?? t("terminal.tab.defaultTitle", { n: tab.ordinal })
+  if (sole && sole.id !== "leaf-1") return sole.title ?? `${liveName ?? SHELL_LEAF_NAME} ${tab.ordinal}`
+  if (tab.autoTitle) return tab.autoTitle
+  const name =
+    tab.kind === "engine"
+      ? (engineEntry(tab.vendor ?? taskVendor).defaultCommand[0] ?? SHELL_LEAF_NAME)
+      : (liveName ?? SHELL_LEAF_NAME)
+  return `${name} ${tab.ordinal}`
 }
 
 export function TabStrip(props: {
@@ -47,6 +62,10 @@ export function TabStrip(props: {
   activeId: () => string
   turnStates: () => ReadonlyMap<string, ChatTabTurnState>
   onSelect: (tabId: string) => void
+  /** Task-level engine — the default-name fallback for unpinned tabs. */
+  vendor: () => VendorId
+  /** tabId → live process display name (see `createTurnPolls().liveTitles`). */
+  liveTitles: () => ReadonlyMap<string, string>
 }) {
   const themeCtx = useTheme()
   const { theme } = themeCtx
@@ -99,9 +118,13 @@ export function TabStrip(props: {
                   : theme.textMuted
           return (
             <box flexDirection="row" gap={0} onMouseUp={() => props.onSelect(tab.id)}>
-              {/* Turn chip — tmux CHAT_TAB_STATUS_FORMAT's ●/✓/!/?/○,
-                  engine tabs only (a command tab has no turns). */}
-              <Show when={tab.kind === "engine"}>
+              {/* Turn chip — tmux CHAT_TAB_STATUS_FORMAT's ●/✓/!/?/○.
+                  Shown when the tab's process IS an engine: kobe-launched
+                  (an engine tab whose engine leaf is alive — instant, by
+                  construction) or detected (a user-typed `claude` in a
+                  shell, which materializes a turnStates entry via the
+                  title-matched poll and disappears when it exits). */}
+              <Show when={props.turnStates().has(tab.id) || (tab.kind === "engine" && hasEngineLeaf(tab.splitTree))}>
                 <text fg={turnColor()} attributes={pulse() ? TextAttributes.BOLD : undefined} wrapMode="none">
                   {`${TURN_GLYPHS[turn()]} `}
                 </text>
@@ -111,7 +134,7 @@ export function TabStrip(props: {
                 attributes={pulse() || tab.id === props.activeId() ? TextAttributes.BOLD : undefined}
                 wrapMode="none"
               >
-                {tabTitle(tab)}
+                {tabTitle(tab, props.vendor(), props.liveTitles().get(tab.id))}
               </text>
             </box>
           )

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -12,7 +12,7 @@
  */
 
 import type { VendorId } from "@/types/vendor"
-import type { SplitState } from "./split-core"
+import { type SplitState, leaves } from "./split-core"
 
 /**
  * A tab's frozen split layout — the content-agnostic tree (`split-core`)
@@ -238,15 +238,19 @@ export function markTabSpawned(state: TabsState, id: string): TabsState {
 }
 
 /**
- * Rehydrate a persisted tab snapshot (issue #22). Command tabs are
- * transient by nature (an editor that quit, a degraded shell) — they are
- * dropped, engine tabs survive with their identity + sessionId so the
- * host can `--resume` them. Guards against a corrupt/empty snapshot by
- * falling back to `initialTabs()`; re-anchors `activeId` if it pointed
- * at a dropped tab.
+ * Rehydrate a persisted tab snapshot (issue #22). A tab is a TERMINAL
+ * (owner model 2026-07-07): claude/an editor are just processes that ran
+ * in it, so EVERY tab survives restart. Engine tabs keep their identity
+ * + sessionId so the host can `--resume` the conversation; command tabs
+ * (an engine degraded to a shell, a dead editor) come back running
+ * `shell` — their old process is gone, and resurrecting a fresh engine
+ * in its place was the "closed shell reopens as claude" bug. Same
+ * freeze-the-layout rule splitTree restore follows. Guards against a
+ * corrupt/empty snapshot by falling back to `initialTabs()`; re-anchors
+ * `activeId` if it pointed at a tab that no longer exists.
  */
-export function rehydrateTabs(persisted: TabsState): TabsState {
-  const tabs = persisted.tabs.filter((t): t is EngineTab => t.kind === "engine")
+export function rehydrateTabs(persisted: TabsState, shell: readonly string[]): TabsState {
+  const tabs = persisted.tabs.map((t): TerminalTab => (t.kind === "command" ? { ...t, command: shell } : t))
   if (tabs.length === 0) return initialTabs()
   const activeId = tabs.some((t) => t.id === persisted.activeId) ? persisted.activeId : tabs[0].id
   const maxOrdinal = tabs.reduce((max, t) => Math.max(max, t.ordinal), 0)
@@ -285,6 +289,18 @@ export function setTabSplit(state: TabsState, id: string, tree: PersistedSplit |
   return { ...state, tabs }
 }
 
+/**
+ * Whether a tab still runs its own engine leaf (`leaf-1`) — false once
+ * you've closed it inside a split and only split-created shells survive
+ * (57e3a20a). Unsplit (no tree) always counts as having it. Callers that
+ * treat an engine tab as having live turn activity (the turn-poll loop,
+ * the tab-strip's turn chip) must gate on this too, or a closed engine
+ * leaf leaves a stale poll flapping against its released PTY.
+ */
+export function hasEngineLeaf(tree: PersistedSplit | null | undefined): boolean {
+  return !tree || leaves(tree.root).some((l) => l.id === "leaf-1")
+}
+
 /** Registry key for one tab's PTY — namespaced so tabs never collide. */
 export function tabPtyKey(taskId: string, tabId: string): string {
   return `${taskId}::${tabId}`
@@ -309,10 +325,13 @@ export function splitLeafPtyKey(tabKey: string, leafId: string): string {
  * conversation's first-prompt title (`engineTitle` — the tab's own
  * title/autoTitle, the same string the group/tab label shows), falling back
  * to the command basename ("claude"/"codex") before the first prompt lands.
- * Split SHELL leaves read a generic "shell" (owner ask 2026-07-06 — a bare
- * shell has no meaningful program name); same-named defaults get a reading-
- * order occurrence suffix ("shell", "shell 2") so two shells stay tellable
- * apart. Manual titles (F2 rename) always win and are never suffixed.
+ * Split SHELL leaves read their live foreground-process title (`liveTitles`
+ * — the OSC 0/2 window-title escape the shell/program sets, same mechanism
+ * a real terminal tab uses: "zsh" idle, "vim"/"htop" once you run one),
+ * falling back to the generic "shell" before any title has landed yet.
+ * Same-named defaults get a reading-order occurrence suffix ("shell",
+ * "shell 2") so two untitled shells stay tellable apart. Manual titles (F2
+ * rename) always win and are never suffixed.
  */
 /** Generic default name for a split-created shell leaf (a bare shell has no
  *  meaningful program name). Shared so the corner tag and a collapsed tab's
@@ -323,6 +342,7 @@ export function splitLeafNames(
   leafList: readonly { id: string; title?: string | null; content: readonly string[] | null }[],
   tabCommand: readonly string[],
   engineTitle?: string | null,
+  liveTitles?: ReadonlyMap<string, string>,
 ): ReadonlyMap<string, string> {
   const basename = (argv: readonly string[] | null): string => {
     const head = (argv ?? tabCommand)[0] ?? ""
@@ -337,8 +357,10 @@ export function splitLeafNames(
       continue
     }
     // Engine leaf → first-prompt title (else vendor basename); split shell
-    // leaf → generic "shell". Both dedupe by reading order.
-    const name = leaf.content === null ? engineTitle || basename(leaf.content) : SHELL_LEAF_NAME
+    // leaf → its live foreground-process title, else generic "shell".
+    // Both dedupe by reading order.
+    const name =
+      leaf.content === null ? engineTitle || basename(leaf.content) : liveTitles?.get(leaf.id) || SHELL_LEAF_NAME
     const n = (seen.get(name) ?? 0) + 1
     seen.set(name, n)
     out.set(leaf.id, n === 1 ? name : `${name} ${n}`)

--- a/packages/kobe/src/tui/workspace/turn-polls.ts
+++ b/packages/kobe/src/tui/workspace/turn-polls.ts
@@ -7,19 +7,31 @@
  * local fixed-cadence fallback otherwise. Polls attach lazily (a tab's PTY
  * spawns after its Terminal mounts and measures), retried on a slow tick.
  *
+ * Unified process-identity model (owner 2026-07-07): every tab is a shell;
+ * an engine is just a process running in it. A tab therefore gets a turn
+ * detector attached whenever its foreground process IS an engine —
+ * whether kobe launched it (an engine tab with a live engine leaf) or the
+ * user typed `claude` into a plain shell. The latter is detected from the
+ * PTY's OSC window title (`vendorFromTerminalTitle`), and detaches again
+ * the moment the title stops matching (the engine exited back to the
+ * shell prompt). The same title stream feeds `liveTitles` — the tab
+ * strip's dynamic "$process $ordinal" default names.
+ *
  * Must be called from a Solid component body (owns effects + onCleanup).
  */
 
 import type { TranscriptActivity } from "@/client/remote-orchestrator"
-import { engineEntry } from "@/engine/registry"
+import { engineEntry, titleDisplayName, vendorFromTerminalTitle } from "@/engine/registry"
 import type { ChatTabTurnState } from "@/engine/turn-detector"
 import type { VendorId } from "@/types/vendor"
 import { createEffect, createSignal, onCleanup } from "solid-js"
 import { startTurnStatusPoll } from "../ops/activity-monitor"
+import type { TaskPtyLike } from "../panes/terminal/pty-types"
 import { getDefaultPtyRegistry } from "../panes/terminal/registry"
-import { type TabsState, tabPtyKey } from "./terminal-tabs-core"
+import { leaves } from "./split-core"
+import { type TabsState, type TerminalTab, hasEngineLeaf, splitLeafPtyKey, tabPtyKey } from "./terminal-tabs-core"
 
-/** Cadence of the lazy turn-poll attach retry (a tab's PTY spawns after mount). */
+/** Cadence of the lazy attach retry (a tab's PTY spawns after mount). */
 const TURN_POLL_ATTACH_MS = 2000
 
 export function createTurnPolls(deps: {
@@ -31,26 +43,108 @@ export function createTurnPolls(deps: {
   sharedActivity?: () => TranscriptActivity | null
   /** A background tab's turn just landed ✓ — notification hook. */
   onBackgroundDone: (tabId: string) => void
-}): { turnStates: () => ReadonlyMap<string, ChatTabTurnState> } {
+}): {
+  turnStates: () => ReadonlyMap<string, ChatTabTurnState>
+  /** tabId → live foreground-process display name (engine binary when the
+   *  title matches a vendor, else the raw OSC title). Feeds the tab
+   *  strip's dynamic default names. */
+  liveTitles: () => ReadonlyMap<string, string>
+} {
   const [turnStates, setTurnStates] = createSignal<ReadonlyMap<string, ChatTabTurnState>>(new Map())
-  const turnPolls = new Map<string, () => void>()
+  const [liveTitles, setLiveTitles] = createSignal<ReadonlyMap<string, string>>(new Map())
+  const turnPolls = new Map<string, { dispose: () => void; vendor: VendorId; key: string }>()
+  /** ptyKey → raw OSC title. Cleared when the PTY instance at that key
+   *  changes (release + respawn), so a dead claude's title can't keep a
+   *  detector attached to the fresh shell that replaced it. */
+  const titles = new Map<string, string>()
+  const titleSubs = new Map<string, { pty: TaskPtyLike; unsub: () => void }>()
   const [pollTick, setPollTick] = createSignal(0)
   const pollAttachTimer = setInterval(() => setPollTick((n) => n + 1), TURN_POLL_ATTACH_MS)
   onCleanup(() => clearInterval(pollAttachTimer))
+
+  /** The tab's single live PTY surface: unsplit tabs (and tabs collapsed
+   *  to one leaf) have exactly one process to identify; a multi-leaf tab
+   *  has no single "the tab's process", so title identity is undefined. */
+  const soloKey = (tab: TerminalTab): string | null => {
+    const tabKey = tabPtyKey(deps.taskId, tab.id)
+    if (!tab.splitTree) return tabKey
+    const ls = leaves(tab.splitTree.root)
+    return ls.length === 1 ? splitLeafPtyKey(tabKey, ls[0].id) : null
+  }
+
+  /** What (if anything) to run a turn detector against for this tab:
+   *  kobe-launched engine → pinned vendor at the tab key; anything else
+   *  with a solo PTY whose live title matches an engine → that vendor. */
+  const targetFor = (tab: TerminalTab): { vendor: VendorId; key: string } | null => {
+    if (tab.kind === "engine" && hasEngineLeaf(tab.splitTree)) {
+      return { vendor: tab.vendor ?? deps.vendor(), key: tabPtyKey(deps.taskId, tab.id) }
+    }
+    const key = soloKey(tab)
+    if (!key) return null
+    const vendor = vendorFromTerminalTitle(titles.get(key))
+    return vendor ? { vendor, key } : null
+  }
+
   createEffect(() => {
     pollTick()
     const reg = getDefaultPtyRegistry()
-    const engineIds = new Set<string>()
+    const attached = new Set<string>()
+
+    // Pass 1 — reconcile title subscriptions on every tab's solo PTY.
+    // Instance-compared: release + respawn at the same key (shell degrade)
+    // must drop the dead PTY's stale title before targets are computed.
+    const soloKeys = new Map<string, string>() // ptyKey → tabId
     for (const tab of deps.state().tabs) {
-      if (tab.kind !== "engine") continue
-      engineIds.add(tab.id)
-      if (turnPolls.has(tab.id)) continue
-      const key = tabPtyKey(deps.taskId, tab.id)
+      const key = soloKey(tab)
+      if (key) soloKeys.set(key, tab.id)
+    }
+    for (const [key, sub] of titleSubs) {
+      const cur = soloKeys.has(key) ? reg.get(key) : null
+      if (cur === sub.pty) continue
+      sub.unsub()
+      titleSubs.delete(key)
+      titles.delete(key)
+    }
+    for (const [key, tabId] of soloKeys) {
+      if (titleSubs.has(key)) continue
+      const pty = reg.get(key)
+      if (!pty) continue
+      const unsub = pty.onTitleChange((title) => {
+        if (titles.get(key) === title) return
+        titles.set(key, title)
+        setLiveTitles((prev) => new Map(prev).set(tabId, titleDisplayName(title)))
+        // Re-evaluate attach/detach now, not on the next slow tick — the
+        // chip should land the moment a user-typed engine announces itself.
+        setPollTick((n) => n + 1)
+      })
+      titleSubs.set(key, { pty, unsub })
+    }
+    setLiveTitles((prev) => {
+      const alive = new Set(deps.state().tabs.map((t) => t.id))
+      if (![...prev.keys()].some((id) => !alive.has(id))) return prev
+      const next = new Map(prev)
+      for (const id of next.keys()) if (!alive.has(id)) next.delete(id)
+      return next
+    })
+
+    // Pass 2 — attach/detach detectors per the tab's process identity.
+    for (const tab of deps.state().tabs) {
+      const target = targetFor(tab)
+      if (!target) continue
+      const existing = turnPolls.get(tab.id)
+      if (existing && existing.vendor === target.vendor && existing.key === target.key) {
+        attached.add(tab.id)
+        continue
+      }
+      if (existing) {
+        existing.dispose()
+        turnPolls.delete(tab.id)
+      }
       // Attach only once the PTY exists so the loop's prime() hashes a
       // real first capture (the Ops pane's prime-before-poll contract).
-      if (!reg.has(key)) continue
+      if (!reg.has(target.key)) continue
       const tabId = tab.id
-      const detector = engineEntry(tab.vendor ?? deps.vendor()).createTurnDetector()
+      const detector = engineEntry(target.vendor).createTurnDetector()
       const dispose = startTurnStatusPoll(
         {
           worktree: deps.worktree,
@@ -65,7 +159,7 @@ export function createTurnPolls(deps: {
         {
           sessionAttached: async () => true,
           capturePane: async () => {
-            const pty = getDefaultPtyRegistry().get(key)
+            const pty = getDefaultPtyRegistry().get(target.key)
             if (!pty) throw new Error("pty gone")
             return pty
               .capture()
@@ -81,12 +175,15 @@ export function createTurnPolls(deps: {
           },
         },
       )
-      turnPolls.set(tabId, dispose)
+      turnPolls.set(tabId, { dispose, vendor: target.vendor, key: target.key })
+      attached.add(tabId)
     }
-    // Tabs that closed or degraded to a shell stop polling.
-    for (const [id, dispose] of turnPolls) {
-      if (engineIds.has(id)) continue
-      dispose()
+
+    // Tabs whose process is no longer an engine (closed, degraded, or the
+    // user-typed engine exited back to the prompt) stop polling.
+    for (const [id, poll] of turnPolls) {
+      if (attached.has(id)) continue
+      poll.dispose()
       turnPolls.delete(id)
       setTurnStates((prev) => {
         const next = new Map(prev)
@@ -96,7 +193,8 @@ export function createTurnPolls(deps: {
     }
   })
   onCleanup(() => {
-    for (const dispose of turnPolls.values()) dispose()
+    for (const poll of turnPolls.values()) poll.dispose()
+    for (const sub of titleSubs.values()) sub.unsub()
   })
-  return { turnStates }
+  return { turnStates, liveTitles }
 }

--- a/packages/kobe/test/tui/split-core.test.ts
+++ b/packages/kobe/test/tui/split-core.test.ts
@@ -145,4 +145,20 @@ describe("split tree (content-agnostic)", () => {
     // No title yet → falls back to the command basename.
     expect(splitLeafNames(leaves(s.root), ["claude"], null).get("leaf-1")).toBe("claude")
   })
+
+  // Why: a split shell leaf's label was hard-coded "shell" forever, unlike
+  // a real terminal tab that tracks the foreground process (OSC 0/2 title
+  // escape) — "zsh" idle, "vim"/"htop" once you run one. `liveTitles` is
+  // the shell leaf's counterpart to the engine leaf's `engineTitle`.
+  it("splitLeafNames: a shell leaf's live foreground title wins over the generic default", () => {
+    const s = splitActive(initialSplit(MAIN), "row", SH) // engine(leaf-1) | shell(leaf-2)
+    const live = new Map([["leaf-2", "vim"]])
+    const named = splitLeafNames(leaves(s.root), ["claude"], "fix the resize race", live)
+    expect(named.get("leaf-2")).toBe("vim")
+    // No live title yet → the generic default, same as before this existed.
+    expect(splitLeafNames(leaves(s.root), ["claude"], "fix the resize race").get("leaf-2")).toBe("shell")
+    // A manual rename still wins over a live title.
+    const renamed = splitLeafNames(leaves(renameLeaf(s, "leaf-2", "logs").root), ["claude"], null, live)
+    expect(renamed.get("leaf-2")).toBe("logs")
+  })
 })

--- a/packages/kobe/test/tui/tab-strip.test.ts
+++ b/packages/kobe/test/tui/tab-strip.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { initialSplit, removeLeaf, splitActive } from "../../src/tui/workspace/split-core"
+import { tabTitle } from "../../src/tui/workspace/tab-strip"
+import type { EngineTab } from "../../src/tui/workspace/terminal-tabs-core"
+
+const baseTab = (overrides: Partial<EngineTab> = {}): EngineTab => ({
+  kind: "engine",
+  id: "tab-1",
+  title: null,
+  ordinal: 1,
+  ...overrides,
+})
+
+describe("tabTitle", () => {
+  // Why: default names are "$process $ordinal" (owner naming 2026-07-07) —
+  // a tab IS a terminal, its name says what runs in it, never "tab N".
+  it("falls back through title -> autoTitle -> '$process $ordinal' when unsplit", () => {
+    expect(tabTitle(baseTab(), "claude")).toBe("claude 1")
+    expect(tabTitle(baseTab({ vendor: "codex" }), "claude")).toBe("codex 1")
+    expect(tabTitle(baseTab({ autoTitle: "fix the resize race" }), "claude")).toBe("fix the resize race")
+    expect(tabTitle(baseTab({ title: "my rename", autoTitle: "auto" }), "claude")).toBe("my rename")
+  })
+
+  it("labels a multi-leaf split as a group, regardless of live name", () => {
+    const tree = splitActive(initialSplit(null), "row", ["/bin/zsh"])
+    expect(tabTitle(baseTab({ splitTree: tree }), "claude")).toBe("group 1")
+    expect(tabTitle(baseTab({ splitTree: tree }), "claude", "vim")).toBe("group 1")
+  })
+
+  // Why: once the engine leaf is closed the surviving shell IS the tab —
+  // its live foreground-process name (OSC title stream) labels it, so
+  // "claude exited" reads as "shell 1"/"vim 1", not a stale engine title.
+  it("a solo non-engine leaf uses the live process name over the generic default", () => {
+    const split = splitActive(initialSplit(null), "row", ["/bin/zsh"])
+    const solo = removeLeaf(split, "leaf-1")
+    expect(solo).not.toBeNull()
+    if (!solo) throw new Error("unreachable")
+    expect(tabTitle(baseTab({ splitTree: solo }), "claude")).toBe("shell 1")
+    expect(tabTitle(baseTab({ splitTree: solo }), "claude", "vim")).toBe("vim 1")
+    // A manual leaf rename still wins over a live title.
+    const renamedSolo = { ...solo, root: { ...solo.root, title: "logs" } }
+    expect(tabTitle(baseTab({ splitTree: renamedSolo }), "claude", "vim")).toBe("logs")
+  })
+
+  it("the pristine engine tab ignores the live name — its process is known by construction", () => {
+    expect(tabTitle(baseTab({ autoTitle: "fix the resize race" }), "claude", "vim")).toBe("fix the resize race")
+    expect(tabTitle(baseTab(), "claude", "vim")).toBe("claude 1")
+  })
+})

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { initialSplit, splitActive } from "../../src/tui/workspace/split-core"
+import { initialSplit, removeLeaf, splitActive } from "../../src/tui/workspace/split-core"
 import {
   addTab,
   closeActiveTab,
   cycleTab,
+  hasEngineLeaf,
   initialTabs,
   markTabSpawned,
   openEditorTab,
@@ -124,21 +125,30 @@ describe("terminal tabs state", () => {
     expect(after.tabs[1]).not.toHaveProperty("sessionId", "uuid-2")
   })
 
-  // Why: rehydrateTabs is the restart contract (issue #22) — engine tabs
-  // come back resumable, transient command tabs (dead editors, degraded
-  // shells) must NOT respawn, and a stale activeId can't strand the UI.
-  it("rehydrateTabs keeps engine tabs, drops command tabs, re-anchors activeId", () => {
+  // Why: rehydrateTabs is the restart contract (issue #22, revised
+  // 2026-07-07) — a tab is a TERMINAL, so every tab survives: engine tabs
+  // come back resumable, command tabs (a degraded shell, a dead editor)
+  // come back as plain shells. Dropping command tabs was the "closed
+  // shell reopens as claude" bug: a lone degraded tab fell through to
+  // initialTabs(), resurrecting a fresh engine in the terminal's place.
+  it("rehydrateTabs keeps every tab; command tabs respawn as shells", () => {
     let s = addTab(initialTabs(), "codex") // [1, 2*(codex)]
     s = setTabSessionId(s, "tab-1", "uuid-1")
     s = openEditorTab(s, ["sh", "-c", "nvim x"], "x") // [1, 2, 3*(editor)]
-    const back = rehydrateTabs(s) // active was the editor tab → dropped
-    expect(back.tabs.map((t) => t.id)).toEqual(["tab-1", "tab-2"])
-    expect(back.activeId).toBe("tab-1")
+    const back = rehydrateTabs(s, ["/bin/zsh"])
+    expect(back.tabs.map((t) => t.id)).toEqual(["tab-1", "tab-2", "tab-3"])
+    expect(back.activeId).toBe("tab-3")
     expect(back.tabs[0]).toMatchObject({ kind: "engine", sessionId: "uuid-1" })
+    // The editor's process is gone — its terminal comes back as a shell.
+    expect(back.tabs[2]).toMatchObject({ kind: "command", command: ["/bin/zsh"] })
     expect(back.nextOrdinal).toBe(s.nextOrdinal)
-    // All-command snapshot (everything degraded) → fresh initial state.
-    const allCommand = rehydrateTabs(tabToShell(initialTabs(), "tab-1", ["/bin/zsh"]))
-    expect(allCommand).toEqual(initialTabs())
+    // THE reported bug: a single tab whose engine exited (degraded to a
+    // shell) must reopen as that shell, NOT as a fresh engine tab.
+    const degraded = rehydrateTabs(tabToShell(initialTabs(), "tab-1", ["/bin/zsh"]), ["/bin/zsh"])
+    expect(degraded.tabs).toHaveLength(1)
+    expect(degraded.tabs[0]).toMatchObject({ kind: "command", id: "tab-1", command: ["/bin/zsh"] })
+    // Corrupt/empty snapshot still falls back to a fresh initial state.
+    expect(rehydrateTabs({ tabs: [], activeId: "tab-1", nextOrdinal: 1 }, ["/bin/zsh"])).toEqual(initialTabs())
   })
 
   // Why: the frozen split layout (owner ask 2026-07-06) must survive the
@@ -153,7 +163,7 @@ describe("terminal tabs state", () => {
     expect(s.tabs[0].splitTree).toEqual(tree)
     // Round-trip through JSON (state.json) then rehydrate — the layout
     // comes back intact on the resumable engine tab.
-    const back = rehydrateTabs(JSON.parse(JSON.stringify(s)))
+    const back = rehydrateTabs(JSON.parse(JSON.stringify(s)), ["/bin/zsh"])
     expect(back.tabs[0]).toMatchObject({ kind: "engine", sessionId: "uuid-1" })
     expect(back.tabs[0].splitTree).toEqual(tree)
     // Clearing (collapse to a single leaf) drops the tree → unsplit tab.
@@ -192,5 +202,20 @@ describe("terminal tabs state", () => {
     // Degrading to a shell keeps the auto-derived name.
     const degraded = tabToShell(s, "tab-1", ["/bin/zsh"])
     expect(degraded.tabs[0].autoTitle).toBe("fix the resize race")
+  })
+
+  // Why: closing the engine leaf (`leaf-1`) inside a split keeps `kind:
+  // "engine"` (57e3a20a — a surviving shell must not respawn the engine),
+  // but its PTY is gone. Turn polling and the tab-strip chip must stop
+  // treating this tab as a live engine, or the chip flaps against a dead
+  // PTY — this predicate is the shared guard for both call sites.
+  it("hasEngineLeaf tracks whether leaf-1 survives a split", () => {
+    expect(hasEngineLeaf(null)).toBe(true)
+    expect(hasEngineLeaf(undefined)).toBe(true)
+    const split = splitActive(initialSplit(null), "row", ["/bin/zsh"])
+    expect(hasEngineLeaf(split)).toBe(true) // leaf-1 (engine) + leaf-2 (shell)
+    const engineClosed = removeLeaf(split, "leaf-1")
+    expect(engineClosed).not.toBeNull()
+    expect(hasEngineLeaf(engineClosed)).toBe(false) // only the shell survives
   })
 })

--- a/packages/kobe/test/tui/terminal-title.test.ts
+++ b/packages/kobe/test/tui/terminal-title.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { MockTaskPty } from "../../src/tui/panes/terminal/pty-mock"
+import { extractOscTitle } from "../../src/tui/panes/terminal/pty-types"
+
+describe("extractOscTitle", () => {
+  it("reads OSC 0 and OSC 2 title payloads, BEL- or ST-terminated", () => {
+    expect(extractOscTitle("hello \x1b]0;my cool title\x07 world")).toBe("my cool title")
+    expect(extractOscTitle("\x1b]2;vim\x1b\\")).toBe("vim")
+  })
+
+  it("returns the LAST title escape when a chunk carries more than one", () => {
+    expect(extractOscTitle("\x1b]2;first\x07 then \x1b]2;second\x07")).toBe("second")
+  })
+
+  it("returns null when the chunk has no title escape", () => {
+    expect(extractOscTitle("just plain output\n")).toBeNull()
+  })
+})
+
+describe("MockTaskPty.onTitleChange", () => {
+  it("fires on a new title, replays the latest on a late subscribe, and dedupes repeats", () => {
+    const pty = new MockTaskPty({ taskId: "t1", cwd: "/wt" })
+    const seen: string[] = []
+    pty.onTitleChange((t) => seen.push(t))
+    pty.feed("prompt$ \x1b]2;vim\x07")
+    expect(seen).toEqual(["vim"])
+    // A late subscriber immediately gets the current title (same replay
+    // contract as `onData`/`onExit`).
+    const late: string[] = []
+    pty.onTitleChange((t) => late.push(t))
+    expect(late).toEqual(["vim"])
+    // Feeding the SAME title again is a no-op — no duplicate notification.
+    pty.feed("\x1b]2;vim\x07")
+    expect(seen).toEqual(["vim"])
+    // A genuinely new title does fire.
+    pty.feed("\x1b]2;htop\x07")
+    expect(seen).toEqual(["vim", "htop"])
+  })
+})


### PR DESCRIPTION
## What

Every tab is a shell; an engine (claude/codex) is just a process running in it. One state model, not two component kinds.

- **OSC 0/2 title tracking** on all three PTY backends (`onTitleChange`, xterm-headless native for the Bun backend, shared `extractOscTitle` for pipe/mock)
- **`turn-polls` owns process identity end to end**: live title → `vendorFromTerminalTitle` (engine-owned matching in the registry) → turn detector attach/detach. A user-typed `claude` inside a plain shell gets the same ●/✓ turn chip as a kobe-launched engine tab, and loses it when the process exits
- **Tab default names are `$process $ordinal`** ("claude 3", "codex 4", "shell 5", "vim 2"), never "tab N"; engine titles normalize to one vocabulary ("✳ Claude Code" → "claude") via `titleDisplayName`
- **Restart contract**: `rehydrateTabs` keeps every tab — engine tabs resume their conversation, command tabs (degraded shells, dead editors) respawn as shells

## Fixes

- A single tab degraded to a shell no longer reopens as a fresh claude after restart
- Closing the engine leaf inside a split no longer leaves a stale turn chip flapping against the released PTY
- The split corner name tag hides when only one leaf survives (the tab label already carries the same name)
- Corner tags no longer show raw decorated titles ("✳ Claude Code")



## Coverage exemptions

coverage-exemption: packages/kobe/src/tui/panes/terminal/pty.ts — Bun-PTY IO backend (Bun.spawn terminal); not mountable under vitest, ~1% coverage predates this change
coverage-exemption: packages/kobe/src/tui/panes/terminal/pty-pipe.ts — child-process pipe fallback backend, same IO-bound nature, ~1% coverage predates this change
coverage-exemption: packages/kobe/src/tui/workspace/turn-polls.ts — Solid component-body hook (createEffect/onCleanup) requiring an opentui mount, which needs bun not vitest; 0% coverage predates this change
