### PR TITLE
fix: react sidebar/filetree parity — stop chip clicks bubbling to pane focus-grab

### DIFF
--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -35,7 +35,19 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
       {props.onZenToggle || props.onCreatePR ? (
         <box flexDirection="row" justifyContent="flex-end" gap={2} paddingBottom={1} flexShrink={0}>
           {props.onZenToggle ? (
-            <box flexDirection="row" gap={1} onMouseUp={() => props.onZenToggle?.()}>
+            // stopPropagation: the chip click must NOT bubble to the host
+            // pane box's own onMouseUp (workspace host focuses the files
+            // pane there) — zen would toggle on and instantly exit via
+            // the focus-leaves-workspace guard. A chip click is an
+            // action, never a background pane click.
+            <box
+              flexDirection="row"
+              gap={1}
+              onMouseUp={(e: { stopPropagation(): void }) => {
+                e.stopPropagation()
+                props.onZenToggle?.()
+              }}
+            >
               <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
                 [~]
               </text>
@@ -45,7 +57,14 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
             </box>
           ) : null}
           {props.onCreatePR ? (
-            <box flexDirection="row" gap={1} onMouseUp={() => props.onCreatePR?.()}>
+            <box
+              flexDirection="row"
+              gap={1}
+              onMouseUp={(e: { stopPropagation(): void }) => {
+                e.stopPropagation()
+                props.onCreatePR?.()
+              }}
+            >
               <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
                 [P]
               </text>

--- a/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
@@ -296,7 +296,13 @@ export function SidebarPanel(props: {
             fg={theme.accent}
             attributes={TextAttributes.BOLD}
             wrapMode="none"
-            onMouseUp={() => props.onZenClick?.()}
+            onMouseUp={(e: { stopPropagation(): void }) => {
+              // Don't bubble to the pane box's focus-grab (workspace host):
+              // zen entry moves focus to the terminal; a bubbled sidebar
+              // focus would instantly exit zen via the focus guard.
+              e.stopPropagation()
+              props.onZenClick?.()
+            }}
           >
             ☯ ZEN
           </text>


### PR DESCRIPTION
Parity audit of the React sidebar + filetree ports against their Solid originals (drift window: since c29e9d82 / the initial port).

Audit findings: the ports already share all framework-free logic via `../../tui/**` imports, so most Solid-side fixes landed automatically. Exactly one behavioral gap existed on each pane, the same class of bug: chip `onMouseUp` handlers (file tree header's Zen / Create-PR chips, sidebar panel's ZEN click) were missing `stopPropagation()`, so the click bubbled into the host pane's focus-grab `onMouseUp` and could instantly cancel the action — the same fix the Solid side already carries.

Everything else (Sidebar.tsx, row-cards, hover-tooltip, keys, FileTree rows/pane-core) verified line-by-line at parity; no changes needed.