### PR TITLE
fix: fold conjoining Hangul jamo and combining half marks to zero display width

### DIFF
--- a/.changeset/display-width-combining-marks.md
+++ b/.changeset/display-width-combining-marks.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix `kobe export --format=table` column alignment for decomposed Korean text and combining half marks: the shared cell-width measurer counted conjoining Hangul Jamo (the medial vowel + final consonant of a decomposed syllable, as macOS produces in NFD filenames) and the U+FE20–U+FE2F combining half marks as one cell each instead of zero, so a Korean filename measured up to twice its true width and shoved every later table column out of line. Both now fold to zero width, matching xterm's own wcwidth table (the embedded-terminal cursor path was already unaffected — it floors zero-width glyphs to one cell); the previously untested `display-width` module also gains its first test file.

--- a/packages/kobe/src/lib/display-width.ts
+++ b/packages/kobe/src/lib/display-width.ts
@@ -16,6 +16,7 @@ export function charWidth(cp: number): number {
   // Zero-width: combining marks + bidi/format controls + variation selectors.
   if (
     (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks
+    (cp >= 0x1160 && cp <= 0x11ff) || // conjoining Hangul Jamo (medial/final) — fold onto the leading jamo's cell
     (cp >= 0x1ab0 && cp <= 0x1aff) || // combining diacritical marks extended
     (cp >= 0x1dc0 && cp <= 0x1dff) || // combining diacritical marks supplement
     (cp >= 0x200b && cp <= 0x200f) || // zero-width space … LTR/RTL marks
@@ -23,13 +24,14 @@ export function charWidth(cp: number): number {
     (cp >= 0x2060 && cp <= 0x2064) || // word joiner … invisible operators
     (cp >= 0x20d0 && cp <= 0x20ff) || // combining marks for symbols
     (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
+    (cp >= 0xfe20 && cp <= 0xfe2f) || // combining half marks
     cp === 0xfeff // zero-width no-break space (BOM)
   ) {
     return 0
   }
   // Wide: East Asian Wide + Fullwidth + the common emoji / pictograph blocks.
   if (
-    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo (leading/choseong) — medial/final fold to zero above
     cp === 0x2329 ||
     cp === 0x232a || // angle brackets
     (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals … Kangxi … CJK symbols

--- a/packages/kobe/test/lib/display-width.test.ts
+++ b/packages/kobe/test/lib/display-width.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import { charWidth, displayWidth } from "../../src/lib/display-width.ts"
+
+describe("charWidth", () => {
+  it("counts plain ASCII / Latin as one cell", () => {
+    expect(charWidth("a".codePointAt(0) as number)).toBe(1)
+    expect(charWidth("Z".codePointAt(0) as number)).toBe(1)
+    expect(charWidth(" ".codePointAt(0) as number)).toBe(1)
+    expect(charWidth("ü".codePointAt(0) as number)).toBe(1)
+  })
+
+  it("counts CJK ideographs, kana, and fullwidth forms as two cells", () => {
+    expect(charWidth("中".codePointAt(0) as number)).toBe(2) // CJK Unified
+    expect(charWidth("あ".codePointAt(0) as number)).toBe(2) // Hiragana
+    expect(charWidth("Ａ".codePointAt(0) as number)).toBe(2) // Fullwidth A (U+FF21)
+    expect(charWidth("한".codePointAt(0) as number)).toBe(2) // precomposed Hangul syllable
+  })
+
+  it("counts astral CJK / emoji as two cells (single code point)", () => {
+    expect(charWidth(0x20000)).toBe(2) // CJK Unified Ext B
+    expect(charWidth("😀".codePointAt(0) as number)).toBe(2) // U+1F600
+  })
+
+  it("counts combining diacritical / bidi / variation-selector marks as zero", () => {
+    expect(charWidth(0x0301)).toBe(0) // combining acute accent
+    expect(charWidth(0x200b)).toBe(0) // zero-width space
+    expect(charWidth(0xfe0f)).toBe(0) // variation selector-16
+    expect(charWidth(0xfeff)).toBe(0) // BOM / zero-width no-break space
+  })
+
+  it("splits conjoining Hangul Jamo: leading is wide, medial/final are zero-width", () => {
+    // Decomposed 한 = choseong U+1112 + jungseong U+1161 + jongseong U+11AB.
+    // Only the leading jamo advances the cursor; the vowel/final fold onto it.
+    expect(charWidth(0x1112)).toBe(2) // choseong (leading)
+    expect(charWidth(0x1161)).toBe(0) // jungseong (medial)
+    expect(charWidth(0x11ab)).toBe(0) // jongseong (final)
+    expect(charWidth(0x1160)).toBe(0) // jungseong filler (range floor)
+    expect(charWidth(0x11ff)).toBe(0) // range ceiling
+  })
+
+  it("counts combining half marks (U+FE20–U+FE2F) as zero", () => {
+    expect(charWidth(0xfe20)).toBe(0)
+    expect(charWidth(0xfe26)).toBe(0) // combining conjoining macron
+    expect(charWidth(0xfe2f)).toBe(0)
+  })
+
+  it("keeps the wide CJK-compatibility neighbours of the half-mark block intact", () => {
+    expect(charWidth(0xfe19)).toBe(2) // presentation form for vertical horizontal ellipsis (0xfe10–0xfe19)
+    expect(charWidth(0xfe30)).toBe(2) // CJK compatibility form (0xfe30–0xfe6f)
+  })
+})
+
+describe("displayWidth", () => {
+  it("is zero for the empty string", () => {
+    expect(displayWidth("")).toBe(0)
+  })
+
+  it("sums cells across a mixed CJK / ASCII string", () => {
+    expect(displayWidth("ab中c")).toBe(5) // 1 + 1 + 2 + 1
+    expect(displayWidth("你好, world")).toBe(11) // 2 + 2 + rest ASCII (7)
+  })
+
+  it("measures decomposed (NFD) Hangul the same as precomposed", () => {
+    // macOS filenames arrive NFD-decomposed; a Korean name in the file tree
+    // or `kobe export` table must occupy the same width either way.
+    const precomposed = "한글" // U+D55C U+AE00
+    const decomposed = precomposed.normalize("NFD")
+    expect(decomposed.length).toBeGreaterThan(precomposed.length) // genuinely decomposed
+    expect(displayWidth(precomposed)).toBe(4)
+    expect(displayWidth(decomposed)).toBe(4)
+  })
+
+  it("does not count a combining half mark as an extra cell", () => {
+    expect(displayWidth("a︦")).toBe(1) // base glyph + zero-width mark
+  })
+
+  it("counts an astral character once, not as two UTF-16 units", () => {
+    const ext = "𠀀" // U+20000, one wide code point stored as a surrogate pair
+    expect(ext.length).toBe(2) // two UTF-16 units
+    expect(displayWidth(ext)).toBe(2) // still two cells, not four
+  })
+})


### PR DESCRIPTION
## Direction

Bugs / correctness — found by direct code review of the pure-logic layer. `src/lib/display-width.ts` is a load-bearing cell-width measurer with **no test file at all**, and its zero-width table had two concrete gaps.

## Problem

`charWidth` classifies a code point as 0 (zero-width), 2 (wide), or 1. Two ranges of nonspacing marks were missing from the zero-width branch and fell through to the default `return 1`:

- **Conjoining Hangul Jamo, medial/final (U+1160–U+11FF).** A decomposed (NFD) Korean syllable is a *leading* jamo (choseong, correctly wide) plus a medial vowel and final consonant that visually fold onto that same cell. Counting each of those as 1 made a decomposed syllable measure up to **4 cells instead of 2**. macOS stores filenames NFD-decomposed, so a Korean filename measured up to double its real width.
- **Combining half marks (U+FE20–U+FE2F).** These nonspacing marks sat in the gap between two *wide* CJK-compatibility ranges (`0xfe10–0xfe19` and `0xfe30–0xfe6f`) and were counted as 1 instead of 0.

The visible symptom is column misalignment in `kobe export --format=table`: `padCell` pads each cell to `width − displayWidth(cell)`, so any over-measured cell shoves every later column out of line.

Concrete triggers (verified against the shipped code):
- `displayWidth("한글")` = 4, but `displayWidth("한글".normalize("NFD"))` = **8** before this change (should be 4).
- `displayWidth("a" + "︦")` = **2** before this change (should be 1).

## Fix

Add both ranges to the zero-width branch of `charWidth`. The values match Markus Kuhn's / xterm's canonical `wcwidth` combining table, so kobe agrees with the terminal about these widths.

**Why this is safe for the other consumer.** `charWidth` has two callers. `src/tui/panes/terminal/terminal-render.ts` (cursor-column → chunk mapping) already coerces zero-width glyphs to one cell (`charWidth(...) || 1`), so flipping these code points from 1 to 0 is a no-op there — the cursor path is untouched. Only `src/cli/export-cmd.ts`'s `displayWidth` is affected, which is exactly the alignment bug being fixed.

Deliberately **out of scope**: BMP emoji that render 2-wide in some terminals but are EAW-Neutral (⭐, ✅, ❤️). "Correct" there is consumer-dependent (default `@xterm/headless` wcwidth treats them as 1, so widening them would *introduce* cursor drift on the terminal path) and disputed — left as a possible follow-up, not bundled into a correctness fix.

## Verification

- Added `test/lib/display-width.test.ts` — the module's first tests: pins ASCII/CJK/fullwidth/astral widths, the existing combining/bidi/variation-selector zero-widths, the new jamo split (leading wide, medial/final zero) and half-mark zero-width, the wide neighbours of the half-mark block, and NFD-vs-precomposed Hangul parity. Confirmed the jamo and half-mark cases **fail** against the pre-fix code and pass with it.
- `bun run lint` — green (674 files).
- `bun run typecheck` — green (`@sma1lboy/kobe-daemon` + `@sma1lboy/kobe`).
- `bun run test` — 230 pass (27 files), including the 12 new cases.

## Follow-ups

- Emoji-presentation width for EAW-Neutral BMP symbols (see the out-of-scope note) would need a per-consumer width table (terminal cursor vs. export table want different answers) — a larger, separate change.


---
_Generated by [Claude Code](https://claude.ai/code/session_012qEis2JEvNV7agpcYh6L1K)_