### PR TITLE
perf: defer snapshot rebuilds on unwatched PTYs

### DIFF
--- a/.changeset/lazy-pty-snapshot.md
+++ b/.changeset/lazy-pty-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+perf: background engine PTYs no longer rebuild their full screen snapshot at output cadence — with no pane subscribed, the grid+scrollback conversion is deferred until the turn poll's next `capture()` (or a resubscribe), cutting per-session CPU roughly to the 1.5s poll rate while output streams unwatched.

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -35,6 +35,12 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   private readonly titleListeners = new Set<(title: string) => void>()
   private snapshot: readonly TerminalRow[] = []
   private cursor: CursorPos | null = null
+  /** Output arrived while nobody was subscribed — snapshot is stale and
+   * will be rebuilt lazily on the next capture()/subscribe. Keeps the N
+   * background sessions of a multi-task workspace from re-converting
+   * their full grid+scrollback at output cadence for a consumer (the
+   * 1.5s turn poll) that only reads via capture(). */
+  private snapshotDirty = false
   private _title: string | null = null
   private _killed = false
   protected cols: number
@@ -176,6 +182,10 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   }
 
   onData(cb: DataListener): () => void {
+    // Refresh BEFORE registering so a lazily-deferred snapshot doesn't
+    // double-notify the new subscriber (once from the rebuild's listener
+    // loop, once from the prime below).
+    this.ensureFreshSnapshot()
     this.listeners.add(cb)
     if (this.snapshot.length > 0) {
       try {
@@ -203,11 +213,22 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   }
 
   capture(): readonly TerminalRow[] {
+    this.ensureFreshSnapshot()
     return this.snapshot
   }
 
   captureCursor(): CursorPos | null {
+    this.ensureFreshSnapshot()
     return this.cursor
+  }
+
+  /** Rebuild a lazily-deferred snapshot before handing it out. Mid-
+   * synchronized-output the rebuild is skipped (same torn-frame rule as
+   * the live path) — the snapshot stays dirty and the caller gets the
+   * last whole frame. */
+  private ensureFreshSnapshot(): void {
+    if (!this.snapshotDirty || this._killed) return
+    this.refreshSnapshot()
   }
 
   kill(): void {
@@ -226,6 +247,12 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   }
 
   private queueRefresh(): void {
+    // No subscriber → don't pay the full grid+scrollback conversion at
+    // output cadence; mark stale and rebuild on capture()/subscribe.
+    if (this.listeners.size === 0) {
+      this.snapshotDirty = true
+      return
+    }
     if (this.refreshQueued) return
     this.refreshQueued = true
     setTimeout(() => {
@@ -289,6 +316,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
       rows.push(line ? xtermLineToChunks(line, minLast) : [])
     }
     this.snapshot = rows
+    this.snapshotDirty = false
     // A hidden cursor (`?25l`) reports as null so the pane draws no
     // inverse cursor cell — same contract as a backend that can't
     // report a cursor at all.

--- a/packages/kobe/test/tui/terminal-pty-lazy-snapshot.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-lazy-snapshot.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest"
+import type { TerminalRow } from "../../src/tui/panes/terminal/pty-types"
+import { XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
+
+/**
+ * Lazy snapshot rebuild for unwatched PTYs.
+ *
+ * Why this matters: the workspace keeps every task's engine PTYs alive in
+ * the registry, but only the visible tab subscribes via `onData`. Before
+ * the lazy path, EVERY live PTY re-converted its full grid + 200-row
+ * scrollback margin at output cadence (~60Hz) even though its only reader
+ * was the 1.5s turn-status poll's `capture()` — N background streaming
+ * sessions burned N× a full-screen conversion for nothing. These tests pin
+ * the contract: no subscriber → no eager rebuild; `capture()` and a late
+ * `onData` subscribe still always see fresh content.
+ */
+
+class FakeTransportPty extends XtermTaskPty {
+  protected transportWrite(_data: string): void {}
+  protected transportResize(_cols: number, _rows: number): void {}
+  protected transportKill(): void {}
+  pump(data: string): void {
+    this.feed(data)
+  }
+}
+
+function rowsText(rows: readonly TerminalRow[]): string {
+  return rows.map((row) => row.map((chunk) => chunk.text).join("")).join("\n")
+}
+
+/** Let xterm's async write callback + the 16ms refresh debounce drain. */
+function settle(ms = 60): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe("XtermTaskPty lazy snapshot (no subscribers)", () => {
+  it("defers the rebuild until capture(), then serves it without re-converting", async () => {
+    const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt" })
+    // biome-ignore lint/suspicious/noExplicitAny: reaching a private method to observe laziness
+    const refresh = vi.spyOn(pty as any, "refreshSnapshot")
+
+    pty.pump("hello from background\r\n")
+    await settle()
+    // Output landed but nobody is watching — no conversion ran.
+    expect(refresh).not.toHaveBeenCalled()
+
+    // The turn poll's read path: capture() rebuilds once, lazily.
+    expect(rowsText(pty.capture())).toContain("hello from background")
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    // Clean now — a second read doesn't rebuild again.
+    pty.capture()
+    pty.captureCursor()
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    pty.kill()
+  })
+
+  it("primes a late onData subscriber with fresh content, not the stale snapshot", async () => {
+    const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt" })
+    pty.pump("first output\r\n")
+    await settle()
+
+    const primed: string[] = []
+    pty.onData((snap) => primed.push(rowsText(snap)))
+    expect(primed).toHaveLength(1)
+    expect(primed[0]).toContain("first output")
+
+    pty.kill()
+  })
+
+  it("keeps the eager push path for live subscribers", async () => {
+    const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt" })
+    const seen: string[] = []
+    pty.onData((snap) => seen.push(rowsText(snap)))
+
+    pty.pump("streamed line\r\n")
+    await settle()
+    // No capture() needed — the subscriber was pushed the fresh snapshot.
+    expect(seen.some((s) => s.includes("streamed line"))).toBe(true)
+
+    pty.kill()
+  })
+})


### PR DESCRIPTION
## Summary
- Every live PTY re-converted its full grid + 200-row scrollback margin at output cadence (~60Hz, `refreshSnapshot` in `pty-xterm-base.ts`) even with no pane subscribed. The workspace keeps every task's engine PTYs alive in the registry, so N background streaming sessions burned N full-screen conversions for a consumer — the 1.5s turn-status poll — that only reads via `capture()`.
- With no `onData` subscriber, output now just marks the snapshot dirty; the rebuild happens lazily on the next `capture()`/`captureCursor()` or when a pane resubscribes (task switch back). The visible tab's eager push path is unchanged.
- `onData` refreshes before registering the new listener so a lazily-deferred snapshot doesn't double-notify the subscriber.

## Test plan
- [x] New `test/tui/terminal-pty-lazy-snapshot.test.ts` pins the contract: no eager rebuild without subscribers, fresh content on `capture()`, fresh (single) prime on late subscribe, eager push preserved for live subscribers.
- [x] Full vitest suite 2414 green, `tsc --noEmit` clean, root `bun run lint` clean.