### PR TITLE
Stabilize quicklook replay capture and rendering

### DIFF
--- a/packages/branding/scripts/capture-tui.ts
+++ b/packages/branding/scripts/capture-tui.ts
@@ -13,7 +13,17 @@
 // Side effect: creates kobe task branches in --repo (one per created task).
 
 import { $ } from "bun"
+import { createHash } from "node:crypto"
 import replaySpecJson from "../src/quicklook/quicklook.replay.json"
+import { DEFAULT_TERMINAL_THEME, terminalLineFromAnsi } from "../src/quicklook/ansi"
+import {
+  STARSHIP_PROMPT_CONFIG,
+  captureEnv,
+  isolatedPromptEnv,
+  promptDefaultCommand,
+  promptEnvEntries,
+  promptEnvTmuxArgs,
+} from "../src/quicklook/capture-env"
 import {
   resolveReplaySpec,
   type CreateTaskFlowSpec,
@@ -27,6 +37,7 @@ const spec = resolveReplaySpec(replaySpecJson, {
   rows: replaySpecJson.viewport.rows,
   frames: [{ t: replaySpecJson.capture.seconds, lines: [] }],
 })
+const CAPTURE_THEME = spec.theme ?? DEFAULT_TERMINAL_THEME
 
 const arg = (name: string, fallback: string) => {
   const i = process.argv.indexOf(`--${name}`)
@@ -43,34 +54,90 @@ const ROWS = spec.viewport.rows
 const SOCKET = spec.capture.socket ?? `${spec.id}-capture`
 const INNER_SOCKET = spec.capture.innerSocket ?? `${SOCKET}-inner`
 const SESSION = spec.capture.session ?? spec.id
+const INNER_ENV_SESSION = `${spec.id}-capture-env`
 const homeArg = arg("home", spec.capture.home)
 const HOME = homeArg.startsWith("/") ? homeArg : `${import.meta.dir}/../${homeArg}`
+const PROMPT_ENV = isolatedPromptEnv(HOME)
+const WIDTH_TABLE_PATH = new URL("../../kobe/src/lib/display-width.ts", import.meta.url)
 
 // The demo must run the LOCAL source (dev:sandbox flavour), not the installed
 // CLI — a shim named `kobe` first in PATH keeps the on-camera command spelled
 // `kobe` while executing this repo's packages/kobe.
 const KOBE_SRC = `${import.meta.dir}/../../kobe`
 const BIN = `${HOME}/bin`
-await $`mkdir -p ${BIN}`.quiet()
+const KOBE_SHIM = `${BIN}/kobe`
+await $`mkdir -p ${BIN} ${PROMPT_ENV.ZDOTDIR} ${PROMPT_ENV.STARSHIP_CACHE}`.quiet()
+await Bun.write(PROMPT_ENV.STARSHIP_CONFIG, STARSHIP_PROMPT_CONFIG)
 await Bun.write(
-  `${BIN}/kobe`,
+  KOBE_SHIM,
   `#!/bin/sh\nexec env KOBE_DEV=1 bun --conditions=browser ${KOBE_SRC}/src/cli/index.ts "$@"\n`,
 )
-await $`chmod +x ${BIN}/kobe`.quiet()
+await $`chmod +x ${KOBE_SHIM}`.quiet()
 const PATH = `${BIN}:${process.env.PATH}`
+const OUT_PATH = OUT.startsWith("/") ? OUT : new URL(`../${OUT}`, import.meta.url)
 
-const ENV = {
-  ...process.env,
-  PATH,
-  KOBE_HOME_DIR: HOME,
-  KOBE_TMUX_SOCKET: INNER_SOCKET,
-}
+const ENV = captureEnv({
+  promptEnv: PROMPT_ENV,
+  path: PATH,
+  home: HOME,
+  innerSocket: INNER_SOCKET,
+  seconds: SECONDS,
+  warmupSeconds: spec.capture.warmupSeconds ?? 50,
+}) as NodeJS.ProcessEnv
 
 const tmux = (...args: string[]) => $`tmux -L ${SOCKET} ${args}`.env(ENV).quiet()
 const innerTmux = (...args: string[]) => $`tmux -L ${INNER_SOCKET} ${args}`.env(ENV).quiet()
 const key = (k: string) => tmux("send-keys", "-t", SESSION, k)
 const sleep = (ms: number) => Bun.sleep(ms)
 const screenText = () => tmux("capture-pane", "-p", "-t", SESSION).text()
+
+async function seedInnerTmuxEnvironment(): Promise<void> {
+  await innerTmux("kill-server").nothrow()
+  await innerTmux(
+    "new-session", "-d", "-s", INNER_ENV_SESSION, "-x", "1", "-y", "1",
+    "-e", `PATH=${PATH}`, ...promptEnvTmuxArgs(PROMPT_ENV),
+    "sleep 3600",
+  )
+  await innerTmux("set-option", "-g", "default-shell", PROMPT_ENV.SHELL)
+  await innerTmux(
+    "set-option", "-g", "default-command",
+    promptDefaultCommand(PROMPT_ENV, { home: HOME, path: PATH }),
+  )
+  for (const [key, value] of [
+    ["PATH", PATH],
+    ["KOBE_HOME_DIR", HOME],
+    ["KOBE_TMUX_SOCKET", INNER_SOCKET],
+    ...promptEnvEntries(PROMPT_ENV),
+  ] as Array<[string, string]>) {
+    await innerTmux("set-environment", "-g", key, value)
+  }
+}
+
+async function sha256File(path: URL): Promise<string> {
+  const bytes = await Bun.file(path).arrayBuffer()
+  return createHash("sha256").update(Buffer.from(bytes)).digest("hex")
+}
+
+async function captureMetadata() {
+  const tmuxVersion = await $`tmux -V`.quiet().nothrow().text()
+  const repoSha = await $`git -C ${REPO} rev-parse HEAD`.quiet().nothrow().text()
+  return {
+    tmuxVersion: tmuxVersion.trim() || "unknown",
+    widthTable: "packages/kobe/src/lib/display-width.ts",
+    widthTableHash: await sha256File(WIDTH_TABLE_PATH),
+    repo: REPO,
+    repoSha: repoSha.trim() || "unknown",
+    lang: ENV.LANG ?? "",
+    lcCtype: ENV.LC_CTYPE ?? "",
+    term: ENV.TERM ?? "",
+    colorterm: ENV.COLORTERM ?? "",
+    noColor: ENV.NO_COLOR ?? "",
+    clicolor: ENV.CLICOLOR ?? "",
+    clicolorForce: ENV.CLICOLOR_FORCE ?? "",
+    forceColor: ENV.FORCE_COLOR ?? "",
+    theme: CAPTURE_THEME,
+  }
+}
 
 /**
  * Kill a socket's pane PROCESSES, then its server. `kill-server` alone only
@@ -107,7 +174,7 @@ async function teardown(): Promise<void> {
   if (torndown) return
   torndown = true
   await killPanesThenServer(SOCKET)
-  await $`kobe daemon stop`.env(ENV).quiet().nothrow()
+  await $`${KOBE_SHIM} daemon stop`.env(ENV).quiet().nothrow()
   await killPanesThenServer(INNER_SOCKET)
 }
 
@@ -290,10 +357,12 @@ async function runBeat(beat: ReplayBeat): Promise<void> {
 
 await $`mkdir -p ${HOME}`.quiet()
 await tmux("kill-server").nothrow()
+await seedInnerTmuxEnvironment()
+await $`${KOBE_SHIM} daemon restart`.env(ENV).quiet()
 
 // Pre-existing tasks so the sidebar isn't empty (no engine, just the row).
 for (const task of spec.setup?.seedTasks ?? []) {
-  await $`kobe api add --repo ${REPO} --title ${task.title} --status ${task.status}`
+  await $`${KOBE_SHIM} api add --repo ${REPO} --title ${task.title} --status ${task.status}`
     .env(ENV)
     .quiet()
     .nothrow()
@@ -305,7 +374,7 @@ for (const task of spec.setup?.seedTasks ?? []) {
 await tmux(
   "new-session", "-d", "-s", "warmup", "-x", String(COLS), "-y", String(ROWS),
   "-e", `KOBE_HOME_DIR=${HOME}`, "-e", `KOBE_TMUX_SOCKET=${INNER_SOCKET}`,
-  "-e", `PATH=${PATH}`,
+  "-e", `PATH=${PATH}`, ...promptEnvTmuxArgs(PROMPT_ENV),
   "-c", REPO,
   "kobe",
 )
@@ -316,7 +385,7 @@ await tmux("kill-session", "-t", "warmup").nothrow()
 await tmux(
   "new-session", "-d", "-s", SESSION, "-x", String(COLS), "-y", String(ROWS),
   "-e", `KOBE_HOME_DIR=${HOME}`, "-e", `KOBE_TMUX_SOCKET=${INNER_SOCKET}`,
-  "-e", `PATH=${PATH}`, "-e", `PS1=${spec.capture.shellPrompt}`,
+  "-e", `PATH=${PATH}`, ...promptEnvTmuxArgs(PROMPT_ENV), "-e", `PS1=${spec.capture.shellPrompt}`,
   "-c", REPO,
   "sh",
 )
@@ -352,7 +421,18 @@ while (elapsed() < SECONDS) {
 await teardown()
 
 await Bun.write(
-  new URL(`../${OUT}`, import.meta.url),
-  JSON.stringify({ cols: COLS, rows: ROWS, fps: FPS, seconds: SECONDS, frames }),
+  OUT_PATH,
+  JSON.stringify({
+    schemaVersion: 2,
+    cols: COLS,
+    rows: ROWS,
+    fps: FPS,
+    seconds: SECONDS,
+    meta: await captureMetadata(),
+    frames: frames.map((frame) => ({
+      t: frame.t,
+      lines: frame.lines.map((line) => terminalLineFromAnsi(line, COLS, CAPTURE_THEME)),
+    })),
+  }),
 )
 console.log(`captured ${frames.length} keyframes -> ${OUT}`)

--- a/packages/branding/scripts/capture-tui.ts
+++ b/packages/branding/scripts/capture-tui.ts
@@ -14,7 +14,13 @@
 
 import { $ } from "bun"
 import replaySpecJson from "../src/quicklook/quicklook.replay.json"
-import { resolveReplaySpec, type ReplayBeat, type ReplayStep } from "../src/quicklook/replay-spec"
+import {
+  resolveReplaySpec,
+  type CreateTaskFlowSpec,
+  type DismissRule,
+  type ReplayBeat,
+  type ReplayStep,
+} from "../src/quicklook/replay-spec"
 
 const spec = resolveReplaySpec(replaySpecJson, {
   cols: replaySpecJson.viewport.cols,
@@ -46,15 +52,9 @@ const HOME = homeArg.startsWith("/") ? homeArg : `${import.meta.dir}/../${homeAr
 const KOBE_SRC = `${import.meta.dir}/../../kobe`
 const BIN = `${HOME}/bin`
 await $`mkdir -p ${BIN}`.quiet()
-// Preload by absolute path — a relative path resolves from the
-// *invocation* cwd (the repo on camera), where it doesn't exist. kobe's
-// own preload (scripts/jsx-plugin.ts) replaces the bare
-// @opentui/solid/preload: Solid transform everywhere EXCEPT
-// src/tui-react/** (React pragma files), matching kobe's dev scripts.
-const PRELOAD = `${KOBE_SRC}/scripts/jsx-preload.ts`
 await Bun.write(
   `${BIN}/kobe`,
-  `#!/bin/sh\nexec env KOBE_DEV=1 bun --preload ${PRELOAD} --conditions=browser ${KOBE_SRC}/src/cli/index.ts "$@"\n`,
+  `#!/bin/sh\nexec env KOBE_DEV=1 bun --conditions=browser ${KOBE_SRC}/src/cli/index.ts "$@"\n`,
 )
 await $`chmod +x ${BIN}/kobe`.quiet()
 const PATH = `${BIN}:${process.env.PATH}`
@@ -67,6 +67,7 @@ const ENV = {
 }
 
 const tmux = (...args: string[]) => $`tmux -L ${SOCKET} ${args}`.env(ENV).quiet()
+const innerTmux = (...args: string[]) => $`tmux -L ${INNER_SOCKET} ${args}`.env(ENV).quiet()
 const key = (k: string) => tmux("send-keys", "-t", SESSION, k)
 const sleep = (ms: number) => Bun.sleep(ms)
 const screenText = () => tmux("capture-pane", "-p", "-t", SESSION).text()
@@ -150,6 +151,71 @@ async function waitForNamed(name: string): Promise<void> {
   await waitFor(new RegExp(wait.pattern), wait.timeoutMs)
 }
 
+type InnerPane = {
+  id: string
+  sessionAttached: number
+  windowActive: number
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+async function activeInnerWindowPanes(): Promise<InnerPane[]> {
+  const out = await innerTmux(
+    "list-panes",
+    "-a",
+    "-F",
+    "#{pane_id}\t#{session_attached}\t#{window_active}\t#{pane_left}\t#{pane_top}\t#{pane_width}\t#{pane_height}",
+  )
+    .nothrow()
+    .text()
+  return out
+    .split("\n")
+    .map((line): InnerPane | null => {
+      const [id, sessionAttached, windowActive, left, top, width, height] = line.trim().split("\t")
+      if (!id) return null
+      return {
+        id,
+        sessionAttached: Number(sessionAttached),
+        windowActive: Number(windowActive),
+        left: Number(left),
+        top: Number(top),
+        width: Number(width),
+        height: Number(height),
+      }
+    })
+    .filter((pane): pane is InnerPane =>
+      Boolean(
+        pane &&
+          Number.isFinite(pane.sessionAttached) &&
+          Number.isFinite(pane.windowActive) &&
+          Number.isFinite(pane.left) &&
+          Number.isFinite(pane.top) &&
+          Number.isFinite(pane.width) &&
+          Number.isFinite(pane.height),
+      ),
+    )
+    .filter((pane) => pane.sessionAttached > 0 && pane.windowActive === 1)
+}
+
+async function focusPaneBeforeOpen(target: CreateTaskFlowSpec["focusPaneBeforeOpen"]): Promise<void> {
+  if (!target) return
+  if (target !== "leftmost") throw new Error(`unknown replay focus pane target "${target}"`)
+  const panes = await activeInnerWindowPanes()
+  if (panes.length === 0) throw new Error("inner tmux active window has no panes to focus")
+  const leftmost = panes.toSorted((a, b) => a.left - b.left || a.top - b.top || b.height - a.height)[0]
+  await innerTmux("select-pane", "-t", leftmost.id)
+  await sleep(200)
+}
+
+async function dismissMatchingRules(rules: readonly DismissRule[] | undefined): Promise<void> {
+  for (const rule of rules ?? []) {
+    const screen = await screenText()
+    if (screen.includes(rule.includes)) for (const step of rule.steps) await runStep(step)
+  }
+}
+
 // Walk the NewTaskDialog. Wait for it to actually open (opening while the
 // UI is busy ate a timed keypress once and the walk derailed into the wrong
 // sub-tab), pick the engine with Ctrl+E (works from ANY field — no bet on
@@ -158,6 +224,7 @@ async function waitForNamed(name: string): Promise<void> {
 async function createTaskViaDialog(engine: string): Promise<void> {
   const flow = spec.flows?.createTask
   if (!flow) throw new Error('missing replay flow "createTask"')
+  await focusPaneBeforeOpen(flow.focusPaneBeforeOpen)
   await key(flow.openKey ?? "n")
   await waitForNamed(flow.dialogWait)
   await sleep(flow.dialogSettleMs ?? 1500) // dialog just opened, let it breathe on camera
@@ -179,6 +246,7 @@ function textForBeat(beat: ReplayBeat): string {
 }
 
 async function typeAndMaybeSubmit(beat: ReplayBeat): Promise<void> {
+  await dismissMatchingRules(beat.dismissIfText)
   await typeText(textForBeat(beat), beat.msPerChar ?? 45)
   if (beat.submit) {
     await sleep(beat.submitDelayMs ?? 500)
@@ -199,11 +267,8 @@ async function runBeat(beat: ReplayBeat): Promise<void> {
       return
     case "typeTextWhenReady":
       if (!beat.waitFor) throw new Error(`replay beat at ${beat.at}s is missing waitFor`)
+      await dismissMatchingRules(beat.dismissIfText)
       await waitForNamed(beat.waitFor)
-      for (const rule of beat.dismissIfText ?? []) {
-        const screen = await screenText()
-        if (screen.includes(rule.includes)) for (const step of rule.steps) await runStep(step)
-      }
       if (beat.settleMs) await sleep(beat.settleMs)
       await typeAndMaybeSubmit(beat)
       return

--- a/packages/branding/scripts/capture-tui.ts
+++ b/packages/branding/scripts/capture-tui.ts
@@ -13,22 +13,32 @@
 // Side effect: creates kobe task branches in --repo (one per created task).
 
 import { $ } from "bun"
+import replaySpecJson from "../src/quicklook/quicklook.replay.json"
+import { resolveReplaySpec, type ReplayBeat, type ReplayStep } from "../src/quicklook/replay-spec"
+
+const spec = resolveReplaySpec(replaySpecJson, {
+  cols: replaySpecJson.viewport.cols,
+  rows: replaySpecJson.viewport.rows,
+  frames: [{ t: replaySpecJson.capture.seconds, lines: [] }],
+})
 
 const arg = (name: string, fallback: string) => {
   const i = process.argv.indexOf(`--${name}`)
   return i >= 0 ? process.argv[i + 1] : fallback
 }
 
-const FPS = Number(arg("fps", "10"))
-const SECONDS = Number(arg("seconds", "120"))
-const OUT = arg("out", "src/quicklook/frames.json")
-const REPO = arg("repo", "/Users/jacksonc/i/kobe")
-const COLS = 160
-const ROWS = 45
+const FPS = Number(arg("fps", String(spec.capture.fps)))
+const SECONDS = Number(arg("seconds", String(spec.capture.seconds)))
+const OUT = arg("out", spec.capture.output)
+const REPO = arg("repo", spec.capture.repoDefault)
+const COLS = spec.viewport.cols
+const ROWS = spec.viewport.rows
 
-const SOCKET = "kobe-capture"
-const SESSION = "quicklook"
-const HOME = `${import.meta.dir}/../${arg("home", ".capture-home-5")}`
+const SOCKET = spec.capture.socket ?? `${spec.id}-capture`
+const INNER_SOCKET = spec.capture.innerSocket ?? `${SOCKET}-inner`
+const SESSION = spec.capture.session ?? spec.id
+const homeArg = arg("home", spec.capture.home)
+const HOME = homeArg.startsWith("/") ? homeArg : `${import.meta.dir}/../${homeArg}`
 
 // The demo must run the LOCAL source (dev:sandbox flavour), not the installed
 // CLI — a shim named `kobe` first in PATH keeps the on-camera command spelled
@@ -53,15 +63,13 @@ const ENV = {
   ...process.env,
   PATH,
   KOBE_HOME_DIR: HOME,
-  KOBE_TMUX_SOCKET: "kobe-capture-inner",
+  KOBE_TMUX_SOCKET: INNER_SOCKET,
 }
-
-const CLAUDE_PROMPT = "Explain what packages/kobe/src/cli/api-cmd.ts does in three short bullets. Read-only."
-const CODEX_PROMPT = "Summarize the purpose of packages/branding in two sentences. Read-only."
 
 const tmux = (...args: string[]) => $`tmux -L ${SOCKET} ${args}`.env(ENV).quiet()
 const key = (k: string) => tmux("send-keys", "-t", SESSION, k)
 const sleep = (ms: number) => Bun.sleep(ms)
+const screenText = () => tmux("capture-pane", "-p", "-t", SESSION).text()
 
 /**
  * Kill a socket's pane PROCESSES, then its server. `kill-server` alone only
@@ -99,7 +107,7 @@ async function teardown(): Promise<void> {
   torndown = true
   await killPanesThenServer(SOCKET)
   await $`kobe daemon stop`.env(ENV).quiet().nothrow()
-  await killPanesThenServer("kobe-capture-inner")
+  await killPanesThenServer(INNER_SOCKET)
 }
 
 for (const sig of ["SIGINT", "SIGTERM"] as const) {
@@ -129,10 +137,17 @@ async function typeText(text: string, msPerChar: number): Promise<void> {
 async function waitFor(re: RegExp, timeoutMs: number): Promise<void> {
   const t0 = Date.now()
   while (Date.now() - t0 < timeoutMs) {
-    const text = await tmux("capture-pane", "-p", "-t", SESSION).text()
+    const text = await screenText()
     if (re.test(text)) return
     await sleep(300)
   }
+  throw new Error(`timed out waiting for ${re}`)
+}
+
+async function waitForNamed(name: string): Promise<void> {
+  const wait = spec.waits[name]
+  if (!wait) throw new Error(`unknown replay wait "${name}"`)
+  await waitFor(new RegExp(wait.pattern), wait.timeoutMs)
 }
 
 // Walk the NewTaskDialog. Wait for it to actually open (opening while the
@@ -140,91 +155,110 @@ async function waitFor(re: RegExp, timeoutMs: number): Promise<void> {
 // sub-tab), pick the engine with Ctrl+E (works from ANY field — no bet on
 // where focus is), then Tab through tabs -> engine -> repo -> branch ->
 // Create and commit with Enter (only fires on the confirm field).
-async function createTaskViaDialog(engine: "claude" | "codex"): Promise<void> {
-  await key("n")
-  await waitFor(/New task/, 8_000)
-  await sleep(1500) // dialog just opened, let it breathe on camera
-  if (engine === "codex") {
-    await key("C-e") // cycle engine vendor
-    await sleep(900)
+async function createTaskViaDialog(engine: string): Promise<void> {
+  const flow = spec.flows?.createTask
+  if (!flow) throw new Error('missing replay flow "createTask"')
+  await key(flow.openKey ?? "n")
+  await waitForNamed(flow.dialogWait)
+  await sleep(flow.dialogSettleMs ?? 1500) // dialog just opened, let it breathe on camera
+  if (engine === "codex" && flow.codexEngineCycleKey) {
+    await key(flow.codexEngineCycleKey) // cycle engine vendor
+    await sleep(flow.codexEngineSettleMs ?? 900)
   }
-  for (let i = 0; i < 4; i++) {
+  for (let i = 0; i < (flow.tabCount ?? 4); i++) {
     await key("Tab")
-    await sleep(700)
+    await sleep(flow.tabDelayMs ?? 700)
   }
-  await key("Enter") // [ Create ]
+  await key(flow.submitKey ?? "Enter") // [ Create ]
+}
+
+function textForBeat(beat: ReplayBeat): string {
+  if (typeof beat.text === "string") return beat.text
+  if (beat.textRef && spec.text[beat.textRef]) return spec.text[beat.textRef]
+  throw new Error(`replay beat at ${beat.at}s is missing text/textRef`)
+}
+
+async function typeAndMaybeSubmit(beat: ReplayBeat): Promise<void> {
+  await typeText(textForBeat(beat), beat.msPerChar ?? 45)
+  if (beat.submit) {
+    await sleep(beat.submitDelayMs ?? 500)
+    await key("Enter")
+  }
+}
+
+async function runStep(step: ReplayStep): Promise<void> {
+  if (step.action === "key") await key(step.key)
+  else if (step.action === "sleep") await sleep(step.ms)
+  else await waitForNamed(step.waitFor)
+}
+
+async function runBeat(beat: ReplayBeat): Promise<void> {
+  switch (beat.action) {
+    case "typeText":
+      await typeAndMaybeSubmit(beat)
+      return
+    case "typeTextWhenReady":
+      if (!beat.waitFor) throw new Error(`replay beat at ${beat.at}s is missing waitFor`)
+      await waitForNamed(beat.waitFor)
+      for (const rule of beat.dismissIfText ?? []) {
+        const screen = await screenText()
+        if (screen.includes(rule.includes)) for (const step of rule.steps) await runStep(step)
+      }
+      if (beat.settleMs) await sleep(beat.settleMs)
+      await typeAndMaybeSubmit(beat)
+      return
+    case "key":
+      if (!beat.key) throw new Error(`replay beat at ${beat.at}s is missing key`)
+      await key(beat.key)
+      return
+    case "flow":
+      if (beat.flow === "createTask") {
+        await createTaskViaDialog(beat.engine ?? "claude")
+        return
+      }
+      throw new Error(`unknown replay flow "${beat.flow}"`)
+    case "sleep":
+      await sleep(beat.ms ?? 0)
+      return
+  }
 }
 
 await $`mkdir -p ${HOME}`.quiet()
 await tmux("kill-server").nothrow()
 
-// Pre-existing task so the sidebar isn't empty (no engine, just the row).
-await $`kobe api add --repo ${REPO} --title ${"fix flaky turn-detector test"} --status in_progress`
-  .env(ENV)
-  .quiet()
-  .nothrow()
+// Pre-existing tasks so the sidebar isn't empty (no engine, just the row).
+for (const task of spec.setup?.seedTasks ?? []) {
+  await $`kobe api add --repo ${REPO} --title ${task.title} --status ${task.status}`
+    .env(ENV)
+    .quiet()
+    .nothrow()
+}
 
 // Warm-up pass (off camera): boot the TUI once so the pre-seeded task's
 // worktree + bun install settle before we roll — the video must open on a
 // calm kobe workspace, not an install screen.
 await tmux(
   "new-session", "-d", "-s", "warmup", "-x", String(COLS), "-y", String(ROWS),
-  "-e", `KOBE_HOME_DIR=${HOME}`, "-e", "KOBE_TMUX_SOCKET=kobe-capture-inner",
+  "-e", `KOBE_HOME_DIR=${HOME}`, "-e", `KOBE_TMUX_SOCKET=${INNER_SOCKET}`,
   "-e", `PATH=${PATH}`,
   "-c", REPO,
   "kobe",
 )
-await sleep(50_000)
+await sleep((spec.capture.warmupSeconds ?? 50) * 1000)
 await tmux("kill-session", "-t", "warmup").nothrow()
 
 // Plain shell first — the demo opens on `$ kobe<Enter>` like the original.
 await tmux(
   "new-session", "-d", "-s", SESSION, "-x", String(COLS), "-y", String(ROWS),
-  "-e", `KOBE_HOME_DIR=${HOME}`, "-e", "KOBE_TMUX_SOCKET=kobe-capture-inner",
-  "-e", `PATH=${PATH}`, "-e", "PS1=jackson@kobe:~/i/kobe$ ",
+  "-e", `KOBE_HOME_DIR=${HOME}`, "-e", `KOBE_TMUX_SOCKET=${INNER_SOCKET}`,
+  "-e", `PATH=${PATH}`, "-e", `PS1=${spec.capture.shellPrompt}`,
   "-c", REPO,
   "sh",
 )
 
 // Scripted beats: [atSecond, action]. Long-running beats sleep internally;
 // the capture loop keeps polling concurrently.
-const BEATS: Array<[number, () => Promise<unknown>]> = [
-  [1.0, () => typeText("kobe", 160)],
-  [2.2, () => key("Enter")],
-  [7.0, () => key("C-h")], // sidebar focus
-  [8.0, () => createTaskViaDialog("claude")], // via the real NewTaskDialog
-  // Engine boots ~14-30s (worktree + bun install + claude). Then type the
-  // first prompt into the composer, visibly.
-  // Type, then submit — chained, not a separate timed beat: per-char send-keys
-  // overhead makes typing finish later than nominal, and a timed Enter can
-  // fire mid-prompt and submit a truncated message (it did).
-  [32.0, () => typeText(CLAUDE_PROMPT, 45).then(() => sleep(500)).then(() => key("Enter"))],
-  // Let the agent stream tool calls + response breathe (~20s on camera),
-  // then create the codex task.
-  [60.0, () => key("C-h")],
-  [61.0, () => createTaskViaDialog("codex")],
-  // NB: codex rotates its placeholder examples — never match their wording.
-  // The composer prompt char "›" (U+203A) is codex-only (claude uses ❯,
-  // the file tree uses ▸) and appears exactly when the composer is ready.
-  [86.0, async () => {
-    await waitFor(/›/, 30_000)
-    // Codex may interpose a hooks-trust prompt whose list cursor is ALSO
-    // "›" — typing into it derails the demo. Dismiss with "Trust all and
-    // continue" (option 2), then wait for the real composer.
-    const screen = await tmux("capture-pane", "-p", "-t", SESSION).text()
-    if (screen.includes("Hooks need review")) {
-      await key("Down")
-      await sleep(600)
-      await key("Enter")
-      await sleep(1500)
-      await waitFor(/›/, 20_000)
-    }
-    await sleep(1200) // composer just appeared — let it sit a beat
-    await typeText(CODEX_PROMPT, 45)
-    await sleep(500)
-    await key("Enter")
-  }],
-]
+const BEATS = spec.beats
 
 const frames: Array<{ t: number; lines: string[] }> = []
 let last = ""
@@ -235,11 +269,11 @@ const elapsed = () => (Date.now() - start) / 1000
 while (elapsed() < SECONDS) {
   const t = elapsed()
   for (let b = 0; b < BEATS.length; b++) {
-    if (t >= BEATS[b][0] && !fired.has(b)) {
+    if (t >= BEATS[b].at && !fired.has(b)) {
       fired.add(b)
       // Bun Shell promises are lazy — .catch() forces execution without
       // stalling the capture loop on slow beats.
-      BEATS[b][1]().catch(() => {})
+      runBeat(BEATS[b]).catch((error) => console.error(`replay beat ${b} failed:`, error))
     }
   }
   const text = await tmux("capture-pane", "-ep", "-t", SESSION).text()

--- a/packages/branding/src/Root.tsx
+++ b/packages/branding/src/Root.tsx
@@ -4,33 +4,32 @@ import { GlyphK } from "./GlyphK"
 import { PaneGrid } from "./PaneGrid"
 import { QuickLookReplay } from "./quicklook/QuickLookReplay"
 import quicklookCapture from "./quicklook/frames.json"
+import quicklookSpec from "./quicklook/quicklook.replay.json"
+import { replayDurationSeconds } from "./quicklook/replay-spec"
 import { TaskStreams } from "./TaskStreams"
 
 export const RemotionRoot: React.FC = () => {
+  const quicklookDuration = replayDurationSeconds(quicklookSpec, quicklookCapture)
+  const quicklookSpeedCuts = quicklookSpec.delivery?.speedCuts ?? [1, 4]
+
   return (
     <>
       <Composition id="bracket-chip" component={BracketChip} durationInFrames={120} fps={30} width={1200} height={630} />
       <Composition id="pane-grid" component={PaneGrid} durationInFrames={150} fps={30} width={1200} height={800} />
       <Composition id="task-streams" component={TaskStreams} durationInFrames={120} fps={30} width={1200} height={630} />
       <Composition id="glyph-k" component={GlyphK} durationInFrames={150} fps={30} width={800} height={800} />
-      <Composition
-        id="quicklook-replay"
-        component={QuickLookReplay}
-        durationInFrames={Math.round((quicklookCapture.frames[quicklookCapture.frames.length - 1].t + 4) * 30)}
-        fps={30}
-        width={1280}
-        height={720}
-      />
-      {/* Landing-page cut: content at 4x, camera easing still in output time. */}
-      <Composition
-        id="quicklook-replay-4x"
-        component={QuickLookReplay}
-        defaultProps={{ speed: 4 }}
-        durationInFrames={Math.round(((quicklookCapture.frames[quicklookCapture.frames.length - 1].t + 4) / 4) * 30)}
-        fps={30}
-        width={1280}
-        height={720}
-      />
+      {quicklookSpeedCuts.map((speed) => (
+        <Composition
+          key={speed}
+          id={speed === 1 ? "quicklook-replay" : `quicklook-replay-${speed}x`}
+          component={QuickLookReplay}
+          defaultProps={speed === 1 ? {} : { speed }}
+          durationInFrames={Math.round((quicklookDuration / speed) * 30)}
+          fps={30}
+          width={quicklookSpec.viewport.width}
+          height={quicklookSpec.viewport.height}
+        />
+      ))}
     </>
   )
 }

--- a/packages/branding/src/quicklook/QuickLookReplay.tsx
+++ b/packages/branding/src/quicklook/QuickLookReplay.tsx
@@ -7,13 +7,18 @@ import { colors, monoStack } from "../colors"
 loadFont("normal", { weights: ["400", "700"] })
 import { parseAnsiLine, type Span } from "./ansi"
 import capture from "./frames.json"
+import replaySpecJson from "./quicklook.replay.json"
+import { resolveReplaySpec, type Region } from "./replay-spec"
 
 // Replays a captured kobe TUI session (scripts/capture-tui.ts output) as the
 // landing-page quicklook video. UI iterates -> re-run capture -> re-render;
 // no manual screen recording.
 
-const CELL_W = 1280 / capture.cols
-const LINE_H = 720 / capture.rows
+const replaySpec = resolveReplaySpec(replaySpecJson, capture)
+const VIEW_W = replaySpec.viewport.width
+const VIEW_H = replaySpec.viewport.height
+const CELL_W = VIEW_W / capture.cols
+const LINE_H = VIEW_H / capture.rows
 
 function frameAt(t: number) {
   let current = capture.frames[0]
@@ -68,41 +73,11 @@ const stripLine = (l: string) =>
   l.replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)?/g, "").replace(/\x1b\[[0-9;]*m/g, "")
 
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v))
-const END = capture.frames[capture.frames.length - 1].t + 4 // + tail hold (matches Root.tsx)
-
-// Grid rect a stage is allowed to look at — the pane the story is about.
-// Chrome (composer/status/footer) and unrelated panes stay out of frame.
-type Region = { c0: number; c1: number; r0: number; r1: number }
-const FULL: Region = { c0: 0, c1: capture.cols - 1, r0: 0, r1: capture.rows - 1 }
-const CHAT: Region = { c0: 33, c1: 107, r0: 3, r1: 36 } // workspace conversation area
-// Agent-streaming shots start below the engine banner/promo block — its
-// one-off repaints otherwise drag the frame up to the pane's top.
-const AGENT: Region = { c0: 33, c1: 107, r0: 11, r1: 36 }
-const DIALOG: Region = { c0: 30, c1: 130, r0: 6, r1: 38 } // centered NewTaskDialog card
-const INPUT: Region = { c0: 33, c1: 110, r0: 37, r1: 44 } // composer at the chat pane's bottom
-// Codex's composer row drifts with what it printed above — give it the lower
-// half of the pane and let the change mask find the typing.
-const INPUT_CODEX: Region = { c0: 33, c1: 110, r0: 22, r1: 40 }
-
-// Stage boundaries mirror the capture script's beats.
-// No region = wide shot (boot repaints everything; wrap pulls out).
-const STAGES: Array<{ name: string; from: number; to: number; region?: Region }> = [
-  { name: "shell", from: 0, to: 2.7, region: FULL }, // $ kobe typed
-  { name: "boot", from: 2.7, to: 8 }, // TUI paints — full shot, sidebar has a task
-  { name: "dialog", from: 8, to: 15, region: DIALOG }, // NewTaskDialog: claude
-  { name: "engine-boot", from: 15, to: 31 }, // worktree + bun install + claude — wide
-  { name: "type-prompt", from: 31, to: 39, region: INPUT }, // prompt typed into the composer
-  { name: "agent", from: 39, to: 60, region: AGENT }, // tool stream + response
-  { name: "dialog-codex", from: 60, to: 68, region: DIALOG }, // second task: codex
-  { name: "codex-boot", from: 68, to: 85 }, // codex boots — wide
-  { name: "type-codex", from: 85, to: 95, region: INPUT_CODEX }, // codex prompt typed
-  { name: "agent-2", from: 95, to: END - 4, region: AGENT },
-  { name: "wrap", from: END - 4, to: END }, // pull back out
-]
+const STAGES = replaySpec.stages
 
 // A shot is a scale + the content point (px) to center in the viewport.
 type Shot = { scale: number; cx: number; cy: number }
-const WIDE: Shot = { scale: 1, cx: 640, cy: 360 }
+const WIDE: Shot = { scale: 1, cx: VIEW_W / 2, cy: VIEW_H / 2 }
 
 // Frame a stage: mark every cell inside the stage's region that changed at
 // least once (binary — a spinner redrawing 50 times counts once), cluster
@@ -126,14 +101,15 @@ function frameStage(from: number, to: number, region: Region): Shot {
       }
     }
   }
-  if (total < 10) return WIDE
+  if (total < replaySpec.camera.minChangedCells) return WIDE
   const rowW = heat.map((row) => row.reduce((a, b) => a + b, 0))
   // Biggest row band.
-  let best: { w: number; r0: number; r1: number } | null = null
-  let band: typeof best = null
+  type Band = { w: number; r0: number; r1: number }
+  let best: Band | null = null
+  let band: Band | null = null
   for (let r = region.r0; r <= region.r1; r++) {
     if (!rowW[r]) continue
-    if (band && r - band.r1 <= 3) {
+    if (band && r - band.r1 <= replaySpec.camera.rowGap) {
       band.w += rowW[r]
       band.r1 = r
     } else {
@@ -142,30 +118,35 @@ function frameStage(from: number, to: number, region: Region): Shot {
     if (!best || band.w > best.w) best = band
   }
   if (!best) return WIDE
-  // Column span: 5–95% weight quantiles within the winning band.
+  // Column span: configured weight quantiles within the winning band.
   const colW = new Array(capture.cols).fill(0)
   for (let r = best.r0; r <= best.r1; r++) for (let c = region.c0; c <= region.c1; c++) colW[c] += heat[r][c]
   const sum = colW.reduce((a: number, b: number) => a + b, 0)
   let acc = 0
   let c0 = region.c0
   let c1 = region.c1
+  const [q0, q1] = replaySpec.camera.colQuantiles
   for (let c = region.c0; c <= region.c1; c++) {
     acc += colW[c]
-    if (acc < sum * 0.05) c0 = c + 1
-    if (acc <= sum * 0.95) c1 = c
+    if (acc < sum * q0) c0 = c + 1
+    if (acc <= sum * q1) c1 = c
   }
   c1 = Math.max(c0, c1)
   const w = (c1 - c0 + 1) * CELL_W
   const h = (best.r1 - best.r0 + 1) * LINE_H
-  // Fit the band into ~80% of the viewport, capped so text stays crisp.
-  const scale = clamp(Math.min((1280 * 0.8) / w, (720 * 0.8) / h), 1, 1.6)
+  // Fit the band into the configured portion of the viewport, capped so text stays crisp.
+  const scale = clamp(
+    Math.min((VIEW_W * replaySpec.camera.fit) / w, (VIEW_H * replaySpec.camera.fit) / h),
+    replaySpec.camera.minScale,
+    replaySpec.camera.maxScale,
+  )
   return { scale, cx: ((c0 + c1 + 1) / 2) * CELL_W, cy: ((best.r0 + best.r1 + 1) / 2) * LINE_H }
 }
 
 const SHOTS: Shot[] = STAGES.map((s) => (s.region ? frameStage(s.from, s.to, s.region) : WIDE))
 
 const easeInOut = (p: number) => p * p * (3 - 2 * p)
-const TRANSITION = 1.2 // seconds of OUTPUT time to move between stage shots
+const TRANSITION = replaySpec.camera.transitionSeconds // seconds of OUTPUT time to move between stage shots
 
 // `t` is capture time; `speed` is the content playback rate. Camera easing
 // runs in OUTPUT time — a sped-up render must not speed up the zooms too —
@@ -208,15 +189,15 @@ export const QuickLookReplay: React.FC<{ speed?: number }> = ({ speed = 1 }) => 
   const cam = cameraAt(t, speed)
   // Center the shot's target point, clamped so the viewport never leaves the
   // content — a target near an edge sticks to that edge instead of cropping.
-  const tx = clamp(640 - cam.cx * cam.scale, 1280 * (1 - cam.scale), 0)
-  const ty = clamp(360 - cam.cy * cam.scale, 720 * (1 - cam.scale), 0)
+  const tx = clamp(VIEW_W / 2 - cam.cx * cam.scale, VIEW_W * (1 - cam.scale), 0)
+  const ty = clamp(VIEW_H / 2 - cam.cy * cam.scale, VIEW_H * (1 - cam.scale), 0)
 
   return (
     <AbsoluteFill style={{ backgroundColor: colors.bg, fontFamily: monoStack }}>
       <div
         style={{
-          width: 1280,
-          height: 720,
+          width: VIEW_W,
+          height: VIEW_H,
           fontSize: CELL_W / 0.6,
           lineHeight: `${LINE_H}px`,
           transform: `translate(${tx}px, ${ty}px) scale(${cam.scale})`,

--- a/packages/branding/src/quicklook/QuickLookReplay.tsx
+++ b/packages/branding/src/quicklook/QuickLookReplay.tsx
@@ -1,11 +1,11 @@
 import { loadFont } from "@remotion/google-fonts/JetBrainsMono"
 import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion"
-import { colors, monoStack } from "../colors"
+import { monoStack } from "../colors"
 
 // Bundle the real font: the fallback mono has a different advance width, so
 // the 160-col grid wouldn't fill 1280px and the frame shows bg "black bars".
 loadFont("normal", { weights: ["400", "700"] })
-import { parseAnsiLine, type Span } from "./ansi"
+import { DEFAULT_TERMINAL_THEME, normalizeTerminalLine, renderTextPresentation, terminalThemeFrom, type TerminalLine } from "./ansi"
 import capture from "./frames.json"
 import replaySpecJson from "./quicklook.replay.json"
 import { resolveReplaySpec, type Region } from "./replay-spec"
@@ -19,6 +19,10 @@ const VIEW_W = replaySpec.viewport.width
 const VIEW_H = replaySpec.viewport.height
 const CELL_W = VIEW_W / capture.cols
 const LINE_H = VIEW_H / capture.rows
+const captureTheme = terminalThemeFrom(
+  (capture as { meta?: { theme?: unknown } }).meta?.theme,
+  replaySpec.theme ?? DEFAULT_TERMINAL_THEME,
+)
 
 function frameAt(t: number) {
   let current = capture.frames[0]
@@ -29,37 +33,57 @@ function frameAt(t: number) {
   return current
 }
 
-// Spans are pinned to their grid column, not flowed: glyphs missing from
-// JetBrains Mono (nerd-font icons, braille spinners) fall back to a font
-// with a different advance width, and flowed layout lets that drift shift
-// everything after them — pane borders stopped lining up.
-const Line: React.FC<{ spans: Span[] }> = ({ spans }) => {
-  let col = 0
+const terminalStack =
+  '"JetBrains Mono", "JetBrainsMono Nerd Font", "Symbols Nerd Font", "Apple Color Emoji", ' + monoStack
+
+type CaptureLine = string | TerminalLine
+
+function positionedLine(line: CaptureLine | undefined): TerminalLine {
+  return normalizeTerminalLine(line, capture.cols, captureTheme)
+}
+
+const rawLine = (line: CaptureLine | undefined): string => (typeof line === "string" ? line : line?.rawAnsi ?? "")
+
+// Render positioned runs resolved from raw ANSI and the editable capture theme.
+// V2 JSON keeps cached runs for inspection, but rawAnsi is the source of truth
+// so changing meta.theme/defaultFg does not require recapturing frames.
+const Line: React.FC<{ line: TerminalLine }> = ({ line }) => {
   return (
     <div style={{ height: LINE_H, position: "relative" }}>
-      {spans.map((s, i) => {
-        const at = col
-        col += [...s.text].length
-        return (
-          <span
-            key={i}
-            style={{
-              position: "absolute",
-              left: at * CELL_W,
-              top: 0,
-              whiteSpace: "pre",
-              color: s.fg ?? colors.fg,
-              backgroundColor: s.bg,
-              fontWeight: s.bold ? 700 : 400,
-              opacity: s.dim ? 0.6 : 1,
-              fontStyle: s.italic ? "italic" : undefined,
-              textDecoration: s.underline ? "underline" : undefined,
-            }}
-          >
-            {s.text}
-          </span>
-        )
-      })}
+      {line.backgrounds.map((run, i) => (
+        <span
+          key={`bg-${i}`}
+          style={{
+            position: "absolute",
+            left: run.c * CELL_W,
+            top: 0,
+            width: run.w * CELL_W,
+            height: LINE_H,
+            backgroundColor: run.bg,
+          }}
+        />
+      ))}
+      {line.runs.map((run, i) => (
+        <span
+          key={`fg-${i}-${run.c}`}
+          style={{
+            position: "absolute",
+            left: run.c * CELL_W,
+            top: 0,
+            width: run.w * CELL_W,
+            height: LINE_H,
+            whiteSpace: "pre",
+            overflow: "visible",
+            color: run.fg ?? captureTheme.defaultFg,
+            fontWeight: run.bold ? 700 : 400,
+            opacity: run.dim ? 0.6 : 1,
+            fontStyle: run.italic ? "italic" : undefined,
+            textDecoration: run.underline ? "underline" : undefined,
+          }}
+        >
+          {renderTextPresentation(run.text)}
+        </span>
+      ))}
     </div>
   )
 }
@@ -87,8 +111,8 @@ function frameStage(from: number, to: number, region: Region): Shot {
   let total = 0
   for (let i = 1; i < capture.frames.length; i++) {
     if (capture.frames[i].t < from || capture.frames[i].t >= to) continue
-    const prev = capture.frames[i - 1].lines.map(stripLine)
-    const cur = capture.frames[i].lines.map(stripLine)
+    const prev = capture.frames[i - 1].lines.map((line: CaptureLine) => stripLine(rawLine(line)))
+    const cur = capture.frames[i].lines.map((line: CaptureLine) => stripLine(rawLine(line)))
     for (let r = region.r0; r <= Math.min(region.r1, cur.length - 1); r++) {
       const a = prev[r] ?? ""
       const b = cur[r]
@@ -182,9 +206,9 @@ export const QuickLookReplay: React.FC<{ speed?: number }> = ({ speed = 1 }) => 
 
   const snapshot = frameAt(t)
   // Each capture-pane line is self-contained (leading unstyled cells mean
-  // DEFAULT bg) — carrying SGR state across lines painted a stray trailing
-  // bg color onto the next line's leading spaces (black band left of dialogs).
-  const lines = snapshot.lines.map((line) => parseAnsiLine(line).spans)
+  // DEFAULT bg). V2 captures already carry positioned runs; legacy string
+  // captures are normalized once through the same run builder.
+  const lines = Array.from({ length: capture.rows }, (_, i) => positionedLine(snapshot.lines[i] as CaptureLine | undefined))
 
   const cam = cameraAt(t, speed)
   // Center the shot's target point, clamped so the viewport never leaves the
@@ -193,19 +217,21 @@ export const QuickLookReplay: React.FC<{ speed?: number }> = ({ speed = 1 }) => 
   const ty = clamp(VIEW_H / 2 - cam.cy * cam.scale, VIEW_H * (1 - cam.scale), 0)
 
   return (
-    <AbsoluteFill style={{ backgroundColor: colors.bg, fontFamily: monoStack }}>
+    <AbsoluteFill style={{ backgroundColor: captureTheme.defaultBg, fontFamily: terminalStack }}>
       <div
         style={{
           width: VIEW_W,
           height: VIEW_H,
           fontSize: CELL_W / 0.6,
           lineHeight: `${LINE_H}px`,
+          fontVariantLigatures: "none",
+          fontKerning: "none",
           transform: `translate(${tx}px, ${ty}px) scale(${cam.scale})`,
           transformOrigin: "0 0",
         }}
       >
-        {lines.map((spans, i) => (
-          <Line key={i} spans={spans} />
+        {lines.map((line, i) => (
+          <Line key={i} line={line} />
         ))}
       </div>
     </AbsoluteFill>

--- a/packages/branding/src/quicklook/ansi.ts
+++ b/packages/branding/src/quicklook/ansi.ts
@@ -4,6 +4,9 @@
 // ponytail: covers reset/bold/dim/italic/underline/reverse + 16/256/truecolor;
 // add charset or OSC handling only if a capture ever shows artifacts.
 
+import { charWidth } from "../../../kobe/src/lib/display-width"
+import { colors } from "../colors"
+
 export type Span = {
   text: string
   fg?: string
@@ -14,13 +17,73 @@ export type Span = {
   underline?: boolean
 }
 
-const BASE16 = [
+export type Cell = Omit<Span, "text"> & {
+  text: string
+  skip?: boolean
+}
+
+export type TerminalRun = Omit<Span, "bg"> & {
+  c: number
+  w: number
+}
+
+export type TerminalBackgroundRun = {
+  c: number
+  w: number
+  bg: string
+}
+
+export type TerminalLine = {
+  rawAnsi: string
+  runs: TerminalRun[]
+  backgrounds: TerminalBackgroundRun[]
+}
+
+export type TerminalTheme = {
+  defaultFg: string
+  defaultBg: string
+  ansi16: readonly string[]
+}
+
+const DEFAULT_ANSI16 = [
   "#141413", "#D47563", "#9ACA86", "#E8C96B", "#CC785C", "#9B87F5", "#D4967E", "#EAE7DF",
   "#3A3835", "#E08A76", "#B0DCA0", "#F2DA8C", "#D4967E", "#B3A3F8", "#E2B39F", "#FFFFFF",
-]
+] as const
 
-function xterm256(n: number): string {
-  if (n < 16) return BASE16[n]
+export const DEFAULT_TERMINAL_THEME: TerminalTheme = {
+  defaultFg: "#FFFFFF",
+  defaultBg: colors.bg,
+  ansi16: DEFAULT_ANSI16,
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+export function isTerminalTheme(value: unknown): value is TerminalTheme {
+  return (
+    isObject(value) &&
+    typeof value.defaultFg === "string" &&
+    typeof value.defaultBg === "string" &&
+    Array.isArray(value.ansi16) &&
+    value.ansi16.length === 16 &&
+    value.ansi16.every((entry) => typeof entry === "string")
+  )
+}
+
+export function terminalThemeFrom(
+  value: unknown,
+  fallback: TerminalTheme = DEFAULT_TERMINAL_THEME,
+): TerminalTheme {
+  if (!isTerminalTheme(value)) return fallback
+  return {
+    defaultFg: value.defaultFg,
+    defaultBg: value.defaultBg,
+    ansi16: value.ansi16,
+  }
+}
+
+function xterm256(n: number, theme: TerminalTheme): string {
+  if (n < 16) return theme.ansi16[n] ?? DEFAULT_ANSI16[n]
   if (n < 232) {
     const c = n - 16
     const steps = [0, 95, 135, 175, 215, 255]
@@ -35,18 +98,248 @@ function xterm256(n: number): string {
 
 type State = Omit<Span, "text"> & { reverse?: boolean }
 
-export function parseAnsiLine(line: string, prev: State = {}): { spans: Span[]; state: State } {
+const stripOsc = (line: string): string => line.replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)?/g, "")
+
+const applySgr = (state: State, params: number[], theme: TerminalTheme): State => {
+  let next = { ...state }
+  for (let p = 0; p < params.length; p++) {
+    const n = params[p]
+    if (n === 0) next = {}
+    else if (n === 1) next.bold = true
+    else if (n === 2) next.dim = true
+    else if (n === 3) next.italic = true
+    else if (n === 4) next.underline = true
+    else if (n === 7) next.reverse = true
+    else if (n === 22) { next.bold = false; next.dim = false }
+    else if (n === 23) next.italic = false
+    else if (n === 24) next.underline = false
+    else if (n === 27) next.reverse = false
+    else if (n >= 30 && n <= 37) next.fg = theme.ansi16[n - 30]
+    else if (n === 38 || n === 48) {
+      const key = n === 38 ? "fg" : "bg"
+      if (params[p + 1] === 5) { next[key] = xterm256(params[p + 2], theme); p += 2 }
+      else if (params[p + 1] === 2) { next[key] = `rgb(${params[p + 2]},${params[p + 3]},${params[p + 4]})`; p += 4 }
+    } else if (n === 39) next.fg = undefined
+    else if (n >= 40 && n <= 47) next.bg = theme.ansi16[n - 40]
+    else if (n === 49) next.bg = undefined
+    else if (n >= 90 && n <= 97) next.fg = theme.ansi16[n - 90 + 8]
+    else if (n >= 100 && n <= 107) next.bg = theme.ansi16[n - 100 + 8]
+  }
+  return next
+}
+
+const paramsFromSgr = (sequence: string): number[] => sequence.split(";").map((p) => (p === "" ? 0 : Number(p)))
+
+const styleFromState = (state: State, theme: TerminalTheme): Omit<Cell, "text" | "skip"> => {
+  const { reverse, ...rest } = state
+  return reverse
+    ? { ...rest, fg: state.bg ?? theme.defaultBg, bg: state.fg ?? theme.defaultFg }
+    : { ...rest, fg: state.fg ?? theme.defaultFg }
+}
+
+const segmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null
+
+const graphemes = (text: string): string[] =>
+  segmenter ? Array.from(segmenter.segment(text), (segment) => segment.segment) : Array.from(text)
+
+const TEXT_PRESENTATION = "\uFE0E"
+const EMOJI_PRESENTATION = "\uFE0F"
+const extendedPictographic = /\p{Extended_Pictographic}/u
+
+export function renderTextPresentation(text: string): string {
+  let out = ""
+  for (let i = 0; i < text.length;) {
+    const cp = text.codePointAt(i) as number
+    const glyph = String.fromCodePoint(cp)
+    const next = i + glyph.length
+    const variation = text[next]
+    if (extendedPictographic.test(glyph)) {
+      out += glyph
+      if (variation === TEXT_PRESENTATION) {
+        out += variation
+        i = next + variation.length
+      } else {
+        out += TEXT_PRESENTATION
+        i = next + (variation === EMOJI_PRESENTATION ? variation.length : 0)
+      }
+      continue
+    }
+    out += glyph
+    i = next
+  }
+  return out
+}
+
+export const cellWidth = (text: string): number => {
+  let width = 0
+  for (const ch of text) {
+    const w = charWidth(ch.codePointAt(0) as number)
+    if (w === 2) return 2
+    if (w === 1) width = 1
+  }
+  return width
+}
+
+export function parseAnsiCells(line: string, cols: number, theme: TerminalTheme = DEFAULT_TERMINAL_THEME): Cell[] {
+  const cells: Cell[] = Array.from({ length: cols }, () => ({ text: " ", skip: false }))
+  let state: State = {}
+  let col = 0
+  line = stripOsc(line)
+
+  const write = (text: string) => {
+    for (const glyph of graphemes(text)) {
+      const width = cellWidth(glyph)
+      if (width === 0) {
+        const prev = cells[Math.max(0, col - 1)]
+        if (prev && !prev.skip) prev.text += glyph
+        continue
+      }
+      if (col >= cols) return
+      const style = styleFromState(state, theme)
+      cells[col] = { ...style, text: glyph, skip: false }
+      for (let i = 1; i < width && col + i < cols; i++) cells[col + i] = { ...style, text: "", skip: true }
+      col += width
+    }
+  }
+
+  let i = 0
+  while (i < line.length) {
+    const esc = line.indexOf("\x1b[", i)
+    if (esc === -1) {
+      write(line.slice(i))
+      break
+    }
+    write(line.slice(i, esc))
+    const end = line.indexOf("m", esc)
+    if (end === -1) break
+    state = applySgr(state, paramsFromSgr(line.slice(esc + 2, end)), theme)
+    i = end + 1
+  }
+
+  return cells
+}
+
+const styleKey = (cell: Cell): string =>
+  [cell.fg ?? "", cell.bold ? "1" : "0", cell.dim ? "1" : "0", cell.italic ? "1" : "0", cell.underline ? "1" : "0"]
+    .join("|")
+
+const codePointOf = (cell: Cell): number => cell.text.codePointAt(0) ?? 0
+
+const glyphKind = (cell: Cell): string => {
+  const cp = codePointOf(cell)
+  if (cp >= 0x2580 && cp <= 0x259f) return "block"
+  if (cp >= 0x2500 && cp <= 0x257f) return "box"
+  if (cellWidth(cell.text) !== 1 || cp > 0x7f) return `symbol:${cell.text}`
+  return "text"
+}
+
+const cellRunWidth = (cells: Cell[], col: number): number => {
+  let width = 1
+  while (col + width < cells.length && cells[col + width].skip) width++
+  return width
+}
+
+function foregroundRuns(cells: Cell[]): TerminalRun[] {
+  const runs: TerminalRun[] = []
+  let col = 0
+  while (col < cells.length) {
+    const cell = cells[col]
+    if (cell.skip || cell.text === " ") {
+      col++
+      continue
+    }
+
+    const kind = glyphKind(cell)
+    const key = styleKey(cell)
+    const start = col
+    let width = 0
+    let text = ""
+    let end = col
+
+    while (end < cells.length) {
+      const next = cells[end]
+      if (next.skip || next.text === " " || glyphKind(next) !== kind || styleKey(next) !== key) break
+      const w = cellRunWidth(cells, end)
+      text += next.text
+      width += w
+      end += w
+    }
+
+    runs.push({
+      c: start,
+      w: width,
+      text,
+      fg: cell.fg,
+      bold: cell.bold,
+      dim: cell.dim,
+      italic: cell.italic,
+      underline: cell.underline,
+    })
+    col = end
+  }
+  return runs
+}
+
+function backgroundRuns(cells: Cell[]): TerminalBackgroundRun[] {
+  const runs: TerminalBackgroundRun[] = []
+  let run: TerminalBackgroundRun | null = null
+  for (let c = 0; c < cells.length; c++) {
+    const bg = cells[c].bg
+    if (!bg) {
+      if (run) runs.push(run)
+      run = null
+      continue
+    }
+    if (run && run.bg === bg && run.c + run.w === c) run.w++
+    else {
+      if (run) runs.push(run)
+      run = { c, w: 1, bg }
+    }
+  }
+  if (run) runs.push(run)
+  return runs
+}
+
+export function terminalLineFromAnsi(
+  rawAnsi: string,
+  cols: number,
+  theme: TerminalTheme = DEFAULT_TERMINAL_THEME,
+): TerminalLine {
+  const cells = parseAnsiCells(rawAnsi, cols, theme)
+  return {
+    rawAnsi,
+    runs: foregroundRuns(cells),
+    backgrounds: backgroundRuns(cells),
+  }
+}
+
+export function normalizeTerminalLine(
+  line: string | TerminalLine | undefined,
+  cols: number,
+  theme: TerminalTheme = DEFAULT_TERMINAL_THEME,
+): TerminalLine {
+  if (!line) return { rawAnsi: "", runs: [], backgrounds: [] }
+  return terminalLineFromAnsi(typeof line === "string" ? line : line.rawAnsi, cols, theme)
+}
+
+export function parseAnsiLine(
+  line: string,
+  prev: State = {},
+  theme: TerminalTheme = DEFAULT_TERMINAL_THEME,
+): { spans: Span[]; state: State } {
   const spans: Span[] = []
   let state: State = { ...prev }
   let buf = ""
 
   // Strip OSC sequences (tmux emits OSC 8 hyperlinks) — we only render SGR.
-  line = line.replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)?/g, "")
+  line = stripOsc(line)
 
   const flush = () => {
     if (!buf) return
-    const { reverse, ...rest } = state
-    spans.push(reverse ? { ...rest, text: buf, fg: state.bg ?? "#141413", bg: state.fg ?? "#EAE7DF" } : { ...rest, text: buf })
+    spans.push({ ...styleFromState(state, theme), text: buf })
     buf = ""
   }
 
@@ -61,30 +354,7 @@ export function parseAnsiLine(line: string, prev: State = {}): { spans: Span[]; 
     const end = line.indexOf("m", esc)
     if (end === -1) break
     flush()
-    const params = line.slice(esc + 2, end).split(";").map((p) => (p === "" ? 0 : Number(p)))
-    for (let p = 0; p < params.length; p++) {
-      const n = params[p]
-      if (n === 0) state = {}
-      else if (n === 1) state.bold = true
-      else if (n === 2) state.dim = true
-      else if (n === 3) state.italic = true
-      else if (n === 4) state.underline = true
-      else if (n === 7) state.reverse = true
-      else if (n === 22) { state.bold = false; state.dim = false }
-      else if (n === 23) state.italic = false
-      else if (n === 24) state.underline = false
-      else if (n === 27) state.reverse = false
-      else if (n >= 30 && n <= 37) state.fg = BASE16[n - 30]
-      else if (n === 38 || n === 48) {
-        const key = n === 38 ? "fg" : "bg"
-        if (params[p + 1] === 5) { state[key] = xterm256(params[p + 2]); p += 2 }
-        else if (params[p + 1] === 2) { state[key] = `rgb(${params[p + 2]},${params[p + 3]},${params[p + 4]})`; p += 4 }
-      } else if (n === 39) state.fg = undefined
-      else if (n >= 40 && n <= 47) state.bg = BASE16[n - 40]
-      else if (n === 49) state.bg = undefined
-      else if (n >= 90 && n <= 97) state.fg = BASE16[n - 90 + 8]
-      else if (n >= 100 && n <= 107) state.bg = BASE16[n - 100 + 8]
-    }
+    state = applySgr(state, paramsFromSgr(line.slice(esc + 2, end)), theme)
     i = end + 1
   }
   flush()

--- a/packages/branding/src/quicklook/capture-env.ts
+++ b/packages/branding/src/quicklook/capture-env.ts
@@ -1,0 +1,150 @@
+export type PromptIsolationEnv = {
+  SHELL: string
+  PS1: string
+  TERM: string
+  COLORTERM: string
+  KOBE_TERMINAL_BACKEND: string
+  ENV: string
+  BASH_ENV: string
+  ZDOTDIR: string
+  STARSHIP_CONFIG: string
+  STARSHIP_CACHE: string
+}
+
+type EnvRecord = Record<string, string | undefined>
+
+export type CaptureEnvOptions = {
+  baseEnv?: EnvRecord
+  promptEnv: PromptIsolationEnv
+  path: string
+  home: string
+  innerSocket: string
+  seconds: number
+  warmupSeconds: number
+}
+
+export const STARSHIP_PROMPT_CONFIG = [
+  'format = "$directory$git_branch$git_status$character"',
+  "add_newline = false",
+  "",
+  "[git_branch]",
+  'symbol = "git "',
+  "",
+  "[character]",
+  'success_symbol = "> "',
+  'error_symbol = "> "',
+  "",
+  "[package]",
+  "disabled = true",
+  "",
+  "[bun]",
+  "disabled = true",
+  "",
+].join("\n")
+
+const PROMPT_ENV_KEYS = [
+  "SHELL",
+  "PS1",
+  "TERM",
+  "COLORTERM",
+  "KOBE_TERMINAL_BACKEND",
+  "ENV",
+  "BASH_ENV",
+  "ZDOTDIR",
+  "STARSHIP_CONFIG",
+  "STARSHIP_CACHE",
+] as const
+
+export const CAPTURE_TERMINAL_ENV = {
+  TERM: "xterm-256color",
+  COLORTERM: "truecolor",
+} as const
+
+const COLOR_CONTROL_ENV_KEYS = [
+  "NO_COLOR",
+  "CLICOLOR",
+  "CLICOLOR_FORCE",
+  "FORCE_COLOR",
+] as const
+
+const KOBE_PROCESS_ENV_KEYS = [
+  "KOBE_DAEMON_SOCKET_PATH",
+  "KOBE_DAEMON_PID_PATH",
+  "KOBE_PTY_SOCKET_PATH",
+  "KOBE_PTY_PID_PATH",
+] as const
+
+export function sanitizeCaptureEnv<T extends EnvRecord>(base: T): EnvRecord {
+  const env: EnvRecord = { ...base }
+  for (const key of COLOR_CONTROL_ENV_KEYS) delete env[key]
+  return {
+    ...env,
+    ...CAPTURE_TERMINAL_ENV,
+  }
+}
+
+export function captureEnv({
+  baseEnv = process.env,
+  promptEnv,
+  path,
+  home,
+  innerSocket,
+  seconds,
+  warmupSeconds,
+}: CaptureEnvOptions): EnvRecord {
+  const env = sanitizeCaptureEnv(baseEnv)
+  for (const key of KOBE_PROCESS_ENV_KEYS) delete env[key]
+  return {
+    ...env,
+    ...promptEnv,
+    PATH: path,
+    KOBE_HOME_DIR: home,
+    KOBE_TMUX_SOCKET: innerSocket,
+    KOBE_DAEMON_WEB_PORT: "off",
+    KOBE_DAEMON_IDLE_GRACE_MS: String(Math.ceil((seconds + warmupSeconds + 30) * 1000)),
+  }
+}
+
+export function isolatedPromptEnv(home: string): PromptIsolationEnv {
+  return {
+    SHELL: "/bin/sh",
+    PS1: "$ ",
+    ...CAPTURE_TERMINAL_ENV,
+    KOBE_TERMINAL_BACKEND: "bun-pty",
+    ENV: "/dev/null",
+    BASH_ENV: "/dev/null",
+    ZDOTDIR: `${home}/zdotdir`,
+    STARSHIP_CONFIG: `${home}/starship.toml`,
+    STARSHIP_CACHE: `${home}/starship-cache`,
+  }
+}
+
+export function promptEnvEntries(env: PromptIsolationEnv): Array<[keyof PromptIsolationEnv, string]> {
+  return PROMPT_ENV_KEYS.map((key) => [key, env[key]])
+}
+
+export function promptEnvTmuxArgs(env: PromptIsolationEnv): string[] {
+  return promptEnvEntries(env).flatMap(([key, value]) => ["-e", `${key}=${value}`])
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,+-]+$/.test(value)) return value
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+export function promptDefaultCommand(
+  env: PromptIsolationEnv,
+  opts: { home: string; path: string },
+): string {
+  const entries: Array<[string, string]> = [
+    ["PATH", opts.path],
+    ["HOME", opts.home],
+    ...promptEnvEntries(env),
+  ]
+  return [
+    "env",
+    "-i",
+    ...entries.map(([key, value]) => `${key}=${shellQuote(value)}`),
+    shellQuote(env.SHELL),
+  ].join(" ")
+}

--- a/packages/branding/src/quicklook/quicklook.replay.json
+++ b/packages/branding/src/quicklook/quicklook.replay.json
@@ -48,6 +48,7 @@
   "flows": {
     "createTask": {
       "openKey": "n",
+      "focusPaneBeforeOpen": "leftmost",
       "dialogWait": "newTaskDialog",
       "dialogSettleMs": 1500,
       "codexEngineCycleKey": "C-e",
@@ -86,7 +87,22 @@
       "textRef": "claudePrompt",
       "msPerChar": 45,
       "submit": true,
-      "submitDelayMs": 500
+      "submitDelayMs": 500,
+      "dismissIfText": [
+        {
+          "includes": "Claude in Chrome extension detected",
+          "steps": [
+            {
+              "action": "key",
+              "key": "Escape"
+            },
+            {
+              "action": "sleep",
+              "ms": 800
+            }
+          ]
+        }
+      ]
     },
     {
       "at": 60,
@@ -109,6 +125,27 @@
       "submit": true,
       "submitDelayMs": 500,
       "dismissIfText": [
+        {
+          "includes": "Update available!",
+          "steps": [
+            {
+              "action": "key",
+              "key": "Down"
+            },
+            {
+              "action": "sleep",
+              "ms": 400
+            },
+            {
+              "action": "key",
+              "key": "Enter"
+            },
+            {
+              "action": "sleep",
+              "ms": 1500
+            }
+          ]
+        },
         {
           "includes": "Hooks need review",
           "steps": [
@@ -204,14 +241,24 @@
       "region": "input"
     },
     {
-      "name": "agent",
+      "name": "prompt-wide",
       "from": 39,
+      "to": 40
+    },
+    {
+      "name": "agent",
+      "from": 40,
       "to": 60,
       "region": "agent"
     },
     {
-      "name": "dialog-codex",
+      "name": "agent-wide",
       "from": 60,
+      "to": 61
+    },
+    {
+      "name": "dialog-codex",
+      "from": 61,
       "to": 68,
       "region": "dialog"
     },
@@ -227,8 +274,13 @@
       "region": "inputCodex"
     },
     {
-      "name": "agent-2",
+      "name": "codex-wide",
       "from": 95,
+      "to": 96
+    },
+    {
+      "name": "agent-2",
+      "from": 96,
       "to": "capture-end",
       "region": "agent"
     },

--- a/packages/branding/src/quicklook/quicklook.replay.json
+++ b/packages/branding/src/quicklook/quicklook.replay.json
@@ -300,6 +300,28 @@
     "rowGap": 3,
     "colQuantiles": [0.05, 0.95]
   },
+  "theme": {
+    "defaultFg": "#FFFFFF",
+    "defaultBg": "#141413",
+    "ansi16": [
+      "#141413",
+      "#D47563",
+      "#9ACA86",
+      "#E8C96B",
+      "#CC785C",
+      "#9B87F5",
+      "#D4967E",
+      "#EAE7DF",
+      "#3A3835",
+      "#E08A76",
+      "#B0DCA0",
+      "#F2DA8C",
+      "#D4967E",
+      "#B3A3F8",
+      "#E2B39F",
+      "#FFFFFF"
+    ]
+  },
   "delivery": {
     "speedCuts": [1, 4],
     "posterAt": 3.2

--- a/packages/branding/src/quicklook/quicklook.replay.json
+++ b/packages/branding/src/quicklook/quicklook.replay.json
@@ -1,0 +1,255 @@
+{
+  "id": "quicklook-replay",
+  "viewport": {
+    "cols": 160,
+    "rows": 45,
+    "width": 1280,
+    "height": 720
+  },
+  "capture": {
+    "fps": 10,
+    "seconds": 120,
+    "output": "src/quicklook/frames.json",
+    "home": ".capture-home-5",
+    "repoDefault": "/Users/jacksonc/i/kobe",
+    "shellPrompt": "jackson@kobe:~/i/kobe$ ",
+    "socket": "kobe-capture",
+    "innerSocket": "kobe-capture-inner",
+    "session": "quicklook",
+    "warmupSeconds": 50
+  },
+  "setup": {
+    "seedTasks": [
+      {
+        "title": "fix flaky turn-detector test",
+        "status": "in_progress"
+      }
+    ]
+  },
+  "waits": {
+    "newTaskDialog": {
+      "pattern": "New task",
+      "timeoutMs": 8000
+    },
+    "codexComposerReady": {
+      "pattern": "›",
+      "timeoutMs": 30000
+    },
+    "codexComposerAfterTrust": {
+      "pattern": "›",
+      "timeoutMs": 20000
+    }
+  },
+  "text": {
+    "shellCommand": "kobe",
+    "claudePrompt": "Explain what packages/kobe/src/cli/api-cmd.ts does in three short bullets. Read-only.",
+    "codexPrompt": "Summarize the purpose of packages/branding in two sentences. Read-only."
+  },
+  "flows": {
+    "createTask": {
+      "openKey": "n",
+      "dialogWait": "newTaskDialog",
+      "dialogSettleMs": 1500,
+      "codexEngineCycleKey": "C-e",
+      "codexEngineSettleMs": 900,
+      "tabCount": 4,
+      "tabDelayMs": 700,
+      "submitKey": "Enter"
+    }
+  },
+  "beats": [
+    {
+      "at": 1,
+      "action": "typeText",
+      "textRef": "shellCommand",
+      "msPerChar": 160
+    },
+    {
+      "at": 2.2,
+      "action": "key",
+      "key": "Enter"
+    },
+    {
+      "at": 7,
+      "action": "key",
+      "key": "C-h"
+    },
+    {
+      "at": 8,
+      "action": "flow",
+      "flow": "createTask",
+      "engine": "claude"
+    },
+    {
+      "at": 32,
+      "action": "typeText",
+      "textRef": "claudePrompt",
+      "msPerChar": 45,
+      "submit": true,
+      "submitDelayMs": 500
+    },
+    {
+      "at": 60,
+      "action": "key",
+      "key": "C-h"
+    },
+    {
+      "at": 61,
+      "action": "flow",
+      "flow": "createTask",
+      "engine": "codex"
+    },
+    {
+      "at": 86,
+      "action": "typeTextWhenReady",
+      "waitFor": "codexComposerReady",
+      "textRef": "codexPrompt",
+      "msPerChar": 45,
+      "settleMs": 1200,
+      "submit": true,
+      "submitDelayMs": 500,
+      "dismissIfText": [
+        {
+          "includes": "Hooks need review",
+          "steps": [
+            {
+              "action": "key",
+              "key": "Down"
+            },
+            {
+              "action": "sleep",
+              "ms": 600
+            },
+            {
+              "action": "key",
+              "key": "Enter"
+            },
+            {
+              "action": "sleep",
+              "ms": 1500
+            },
+            {
+              "action": "waitFor",
+              "waitFor": "codexComposerAfterTrust"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "regions": {
+    "chat": {
+      "c0": 33,
+      "c1": 107,
+      "r0": 3,
+      "r1": 36,
+      "hash": "rg_0clck2w"
+    },
+    "agent": {
+      "c0": 33,
+      "c1": 107,
+      "r0": 11,
+      "r1": 36,
+      "hash": "rg_1swli1i"
+    },
+    "dialog": {
+      "c0": 30,
+      "c1": 130,
+      "r0": 6,
+      "r1": 38,
+      "hash": "rg_01xmnv4"
+    },
+    "input": {
+      "c0": 33,
+      "c1": 110,
+      "r0": 37,
+      "r1": 44,
+      "hash": "rg_01d9era"
+    },
+    "inputCodex": {
+      "c0": 33,
+      "c1": 110,
+      "r0": 22,
+      "r1": 40,
+      "hash": "rg_1kdxvrj"
+    }
+  },
+  "stages": [
+    {
+      "name": "shell",
+      "from": 0,
+      "to": 2.7,
+      "region": "full"
+    },
+    {
+      "name": "boot",
+      "from": 2.7,
+      "to": 8
+    },
+    {
+      "name": "dialog",
+      "from": 8,
+      "to": 15,
+      "region": "dialog"
+    },
+    {
+      "name": "engine-boot",
+      "from": 15,
+      "to": 31
+    },
+    {
+      "name": "type-prompt",
+      "from": 31,
+      "to": 39,
+      "region": "input"
+    },
+    {
+      "name": "agent",
+      "from": 39,
+      "to": 60,
+      "region": "agent"
+    },
+    {
+      "name": "dialog-codex",
+      "from": 60,
+      "to": 68,
+      "region": "dialog"
+    },
+    {
+      "name": "codex-boot",
+      "from": 68,
+      "to": 85
+    },
+    {
+      "name": "type-codex",
+      "from": 85,
+      "to": 95,
+      "region": "inputCodex"
+    },
+    {
+      "name": "agent-2",
+      "from": 95,
+      "to": "capture-end",
+      "region": "agent"
+    },
+    {
+      "name": "wrap",
+      "from": "capture-end",
+      "to": "end"
+    }
+  ],
+  "camera": {
+    "transitionSeconds": 1.2,
+    "fit": 0.8,
+    "minScale": 1,
+    "maxScale": 1.6,
+    "tailHoldSeconds": 4,
+    "minChangedCells": 10,
+    "rowGap": 3,
+    "colQuantiles": [0.05, 0.95]
+  },
+  "delivery": {
+    "speedCuts": [1, 4],
+    "posterAt": 3.2
+  }
+}

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -1,0 +1,299 @@
+export type RegionBounds = { c0: number; c1: number; r0: number; r1: number }
+export type Region = RegionBounds & { hash: string }
+export type RawRegion = RegionBounds & { hash?: string }
+
+export type CaptureFrame = { t: number; lines: string[] }
+export type CaptureMeta = { cols: number; rows: number; frames: CaptureFrame[] }
+
+export type ViewportSpec = {
+  cols: number
+  rows: number
+  width: number
+  height: number
+}
+
+export type CaptureSpec = {
+  fps: number
+  seconds: number
+  output: string
+  home: string
+  repoDefault: string
+  shellPrompt: string
+  socket?: string
+  innerSocket?: string
+  session?: string
+  warmupSeconds?: number
+}
+
+export type WaitSpec = {
+  pattern: string
+  timeoutMs: number
+}
+
+export type ReplayStep =
+  | { action: "key"; key: string }
+  | { action: "sleep"; ms: number }
+  | { action: "waitFor"; waitFor: string }
+
+export type DismissRule = {
+  includes: string
+  steps: ReplayStep[]
+}
+
+export type ReplayBeat = {
+  at: number
+  action: "typeText" | "typeTextWhenReady" | "key" | "flow" | "sleep"
+  text?: string
+  textRef?: string
+  msPerChar?: number
+  submit?: boolean
+  submitDelayMs?: number
+  waitFor?: string
+  settleMs?: number
+  dismissIfText?: DismissRule[]
+  key?: string
+  flow?: string
+  engine?: string
+  ms?: number
+}
+
+export type StagePoint = number | "capture-end" | "end"
+
+export type RawStage = {
+  name: string
+  from: StagePoint
+  to: StagePoint
+  region?: string
+}
+
+export type ResolvedStage = {
+  name: string
+  from: number
+  to: number
+  region?: Region
+}
+
+export type CameraSpec = {
+  transitionSeconds: number
+  fit: number
+  minScale: number
+  maxScale: number
+  tailHoldSeconds: number
+  minChangedCells?: number
+  rowGap?: number
+  colQuantiles?: [number, number]
+}
+
+export type ResolvedCameraSpec = Required<CameraSpec>
+
+export type CreateTaskFlowSpec = {
+  openKey?: string
+  dialogWait: string
+  dialogSettleMs?: number
+  codexEngineCycleKey?: string
+  codexEngineSettleMs?: number
+  tabCount?: number
+  tabDelayMs?: number
+  submitKey?: string
+}
+
+export type ReplayFlows = {
+  createTask?: CreateTaskFlowSpec
+}
+
+export type SeedTask = {
+  title: string
+  status: string
+}
+
+export type ReplaySetup = {
+  seedTasks?: SeedTask[]
+}
+
+export type DeliverySpec = {
+  speedCuts?: number[]
+  posterAt?: number
+}
+
+export type RawReplaySpec = {
+  id: string
+  viewport: ViewportSpec
+  capture: CaptureSpec
+  setup?: ReplaySetup
+  waits: Record<string, WaitSpec>
+  text: Record<string, string>
+  flows?: ReplayFlows
+  beats: ReplayBeat[]
+  regions: Record<string, RawRegion>
+  stages: RawStage[]
+  camera: CameraSpec
+  delivery?: DeliverySpec
+}
+
+export type ResolvedReplaySpec = Omit<RawReplaySpec, "camera" | "regions" | "stages"> & {
+  camera: ResolvedCameraSpec
+  regions: Record<string, Region>
+  stages: ResolvedStage[]
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const assertObject = (value: unknown, name: string): Record<string, unknown> => {
+  if (!isObject(value)) throw new Error(`replay spec ${name} must be an object`)
+  return value
+}
+
+const assertArray = (value: unknown, name: string): unknown[] => {
+  if (!Array.isArray(value)) throw new Error(`replay spec ${name} must be an array`)
+  return value
+}
+
+const assertNumber = (value: unknown, name: string): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`replay spec ${name} must be a finite number`)
+  }
+  return value
+}
+
+const assertString = (value: unknown, name: string): string => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`replay spec ${name} must be a non-empty string`)
+  }
+  return value
+}
+
+const lastCaptureTime = (capture: CaptureMeta): number => capture.frames.at(-1)?.t ?? 0
+
+export function regionCoordinateHash(
+  name: string,
+  region: RegionBounds,
+  capture: Pick<CaptureMeta, "cols" | "rows">,
+): string {
+  const input = `v1|${name}|${capture.cols}x${capture.rows}|${region.c0},${region.c1},${region.r0},${region.r1}`
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return `rg_${hash.toString(36).padStart(7, "0")}`
+}
+
+const assertRegion = (region: RawRegion, name: string, capture: CaptureMeta): Region => {
+  for (const key of ["c0", "c1", "r0", "r1"] as const) assertNumber(region[key], `${name}.${key}`)
+  if (region.hash !== undefined) assertString(region.hash, `${name}.hash`)
+  if (region.c0 < 0 || region.c1 >= capture.cols || region.r0 < 0 || region.r1 >= capture.rows) {
+    throw new Error(`replay spec ${name} is outside the ${capture.cols}x${capture.rows} capture grid`)
+  }
+  if (region.c0 > region.c1 || region.r0 > region.r1) throw new Error(`replay spec ${name} has inverted bounds`)
+  return { ...region, hash: region.hash ?? regionCoordinateHash(name.replace(/^regions\./, ""), region, capture) }
+}
+
+const assertWaitRef = (waits: Record<string, WaitSpec>, waitFor: string | undefined, owner: string) => {
+  if (waitFor && !waits[waitFor]) throw new Error(`${owner} references unknown wait "${waitFor}"`)
+}
+
+const assertTextRef = (text: Record<string, string>, textRef: string | undefined, owner: string) => {
+  if (textRef && !text[textRef]) throw new Error(`${owner} references unknown text "${textRef}"`)
+}
+
+const resolvePoint = (point: StagePoint, captureEnd: number, tailHoldSeconds: number, name: string): number => {
+  if (typeof point === "number" && Number.isFinite(point)) return point
+  if (point === "capture-end") return captureEnd
+  if (point === "end") return captureEnd + tailHoldSeconds
+  throw new Error(`replay spec stage "${name}" has invalid time point "${String(point)}"`)
+}
+
+const resolveCamera = (camera: CameraSpec): ResolvedCameraSpec => {
+  const rawColQuantiles = camera.colQuantiles ?? [0.05, 0.95]
+  if (
+    rawColQuantiles.length !== 2 ||
+    rawColQuantiles[0] < 0 ||
+    rawColQuantiles[1] > 1 ||
+    rawColQuantiles[0] >= rawColQuantiles[1]
+  ) {
+    throw new Error("replay spec camera.colQuantiles must be an increasing pair inside [0, 1]")
+  }
+  const colQuantiles: [number, number] = [rawColQuantiles[0], rawColQuantiles[1]]
+  return {
+    transitionSeconds: camera.transitionSeconds,
+    fit: camera.fit,
+    minScale: camera.minScale,
+    maxScale: camera.maxScale,
+    tailHoldSeconds: camera.tailHoldSeconds,
+    minChangedCells: camera.minChangedCells ?? 10,
+    rowGap: camera.rowGap ?? 3,
+    colQuantiles,
+  }
+}
+
+export function replayDurationSeconds(spec: { camera: { tailHoldSeconds: number } }, capture: CaptureMeta): number {
+  return lastCaptureTime(capture) + spec.camera.tailHoldSeconds
+}
+
+export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedReplaySpec {
+  const root = assertObject(raw, "root")
+  const spec = raw as RawReplaySpec
+  assertString(root.id, "id")
+  assertObject(root.viewport, "viewport")
+  assertObject(root.capture, "capture")
+  assertObject(root.waits, "waits")
+  assertObject(root.text, "text")
+  assertObject(root.regions, "regions")
+  assertObject(root.camera, "camera")
+  assertArray(root.beats, "beats")
+  assertArray(root.stages, "stages")
+
+  const viewport = spec.viewport
+  for (const key of ["cols", "rows", "width", "height"] as const) assertNumber(viewport[key], `viewport.${key}`)
+  if (capture.cols !== viewport.cols || capture.rows !== viewport.rows) {
+    throw new Error(
+      `replay spec viewport ${viewport.cols}x${viewport.rows} does not match capture ${capture.cols}x${capture.rows}`,
+    )
+  }
+
+  const camera = resolveCamera(spec.camera)
+  const rawRegions: Record<string, RawRegion> = {
+    ...spec.regions,
+    full: { c0: 0, c1: capture.cols - 1, r0: 0, r1: capture.rows - 1 },
+  }
+  const regions: Record<string, Region> = {}
+  for (const [name, region] of Object.entries(rawRegions)) {
+    regions[name] = assertRegion(region, `regions.${name}`, capture)
+  }
+
+  for (const [name, wait] of Object.entries(spec.waits)) {
+    assertString(wait.pattern, `waits.${name}.pattern`)
+    assertNumber(wait.timeoutMs, `waits.${name}.timeoutMs`)
+  }
+  for (const [name, value] of Object.entries(spec.text)) assertString(value, `text.${name}`)
+
+  for (const [i, beat] of spec.beats.entries()) {
+    assertNumber(beat.at, `beats[${i}].at`)
+    assertString(beat.action, `beats[${i}].action`)
+    assertWaitRef(spec.waits, beat.waitFor, `beat ${i}`)
+    assertTextRef(spec.text, beat.textRef, `beat ${i}`)
+    for (const [ruleIndex, rule] of (beat.dismissIfText ?? []).entries()) {
+      assertString(rule.includes, `beats[${i}].dismissIfText[${ruleIndex}].includes`)
+      for (const [stepIndex, step] of rule.steps.entries()) {
+        if (step.action === "waitFor") assertWaitRef(spec.waits, step.waitFor, `beat ${i} dismiss step ${stepIndex}`)
+      }
+    }
+  }
+
+  if (spec.flows?.createTask) assertWaitRef(spec.waits, spec.flows.createTask.dialogWait, "flow createTask")
+
+  const captureEnd = lastCaptureTime(capture)
+  const stages = spec.stages.map((stage, i) => {
+    assertString(stage.name, `stages[${i}].name`)
+    const from = resolvePoint(stage.from, captureEnd, camera.tailHoldSeconds, stage.name)
+    const to = resolvePoint(stage.to, captureEnd, camera.tailHoldSeconds, stage.name)
+    if (to <= from) throw new Error(`replay spec stage "${stage.name}" must end after it starts`)
+    if (!stage.region) return { name: stage.name, from, to }
+    const region = regions[stage.region]
+    if (!region) throw new Error(`replay spec stage "${stage.name}" references unknown region "${stage.region}"`)
+    return { name: stage.name, from, to, region }
+  })
+
+  return { ...spec, camera, regions, stages }
+}

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -88,6 +88,7 @@ export type ResolvedCameraSpec = Required<CameraSpec>
 
 export type CreateTaskFlowSpec = {
   openKey?: string
+  focusPaneBeforeOpen?: "leftmost"
   dialogWait: string
   dialogSettleMs?: number
   codexEngineCycleKey?: string
@@ -281,7 +282,13 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
     }
   }
 
-  if (spec.flows?.createTask) assertWaitRef(spec.waits, spec.flows.createTask.dialogWait, "flow createTask")
+  if (spec.flows?.createTask) {
+    assertWaitRef(spec.waits, spec.flows.createTask.dialogWait, "flow createTask")
+    const focusPane = spec.flows.createTask.focusPaneBeforeOpen
+    if (focusPane !== undefined && focusPane !== "leftmost") {
+      throw new Error('flow createTask.focusPaneBeforeOpen must be "leftmost" when set')
+    }
+  }
 
   const captureEnd = lastCaptureTime(capture)
   const stages = spec.stages.map((stage, i) => {

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -1,9 +1,23 @@
+import type { TerminalTheme } from "./ansi"
+
 export type RegionBounds = { c0: number; c1: number; r0: number; r1: number }
 export type Region = RegionBounds & { hash: string }
 export type RawRegion = RegionBounds & { hash?: string }
 
-export type CaptureFrame = { t: number; lines: string[] }
-export type CaptureMeta = { cols: number; rows: number; frames: CaptureFrame[] }
+export type PositionedLine = {
+  rawAnsi: string
+  runs?: unknown[]
+  backgrounds?: unknown[]
+}
+export type CaptureLine = string | PositionedLine
+export type CaptureFrame = { t: number; lines: CaptureLine[] }
+export type CaptureMeta = {
+  cols: number
+  rows: number
+  frames: CaptureFrame[]
+  schemaVersion?: number
+  meta?: { theme?: unknown }
+}
 
 export type ViewportSpec = {
   cols: number
@@ -128,6 +142,7 @@ export type RawReplaySpec = {
   regions: Record<string, RawRegion>
   stages: RawStage[]
   camera: CameraSpec
+  theme?: TerminalTheme
   delivery?: DeliverySpec
 }
 
@@ -162,6 +177,24 @@ const assertString = (value: unknown, name: string): string => {
     throw new Error(`replay spec ${name} must be a non-empty string`)
   }
   return value
+}
+
+const assertTheme = (value: unknown, name: string): TerminalTheme => {
+  const theme = assertObject(value, name)
+  for (const key of Object.keys(theme)) {
+    if (!["defaultFg", "defaultBg", "ansi16"].includes(key)) {
+      throw new Error(`replay spec ${name}.${key} is not supported`)
+    }
+  }
+  const defaultFg = assertString(theme.defaultFg, `${name}.defaultFg`)
+  const defaultBg = assertString(theme.defaultBg, `${name}.defaultBg`)
+  const ansi16 = assertArray(theme.ansi16, `${name}.ansi16`)
+  if (ansi16.length !== 16) throw new Error(`replay spec ${name}.ansi16 must contain exactly 16 colors`)
+  return {
+    defaultFg,
+    defaultBg,
+    ansi16: ansi16.map((entry, i) => assertString(entry, `${name}.ansi16[${i}]`)),
+  }
 }
 
 const lastCaptureTime = (capture: CaptureMeta): number => capture.frames.at(-1)?.t ?? 0
@@ -254,6 +287,7 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
   }
 
   const camera = resolveCamera(spec.camera)
+  const theme = spec.theme === undefined ? undefined : assertTheme(spec.theme, "theme")
   const rawRegions: Record<string, RawRegion> = {
     ...spec.regions,
     full: { c0: 0, c1: capture.cols - 1, r0: 0, r1: capture.rows - 1 },
@@ -302,5 +336,5 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
     return { name: stage.name, from, to, region }
   })
 
-  return { ...spec, camera, regions, stages }
+  return { ...spec, camera, theme, regions, stages }
 }

--- a/packages/branding/tests/ansi.test.ts
+++ b/packages/branding/tests/ansi.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import {
+  renderTextPresentation,
+  normalizeTerminalLine,
+  parseAnsiCells,
+  terminalLineFromAnsi,
+  terminalThemeFrom,
+  type TerminalTheme,
+} from "../src/quicklook/ansi"
+import quicklookSpec from "../src/quicklook/quicklook.replay.json"
+
+describe("ANSI cell parser", () => {
+  test("keeps terminal-narrow symbols in one cell without shifting following text", () => {
+    const cells = parseAnsiCells("A⚠B", 5)
+
+    expect(cells.map((cell) => cell.text)).toEqual(["A", "⚠", "B", " ", " "])
+    expect(cells.map((cell) => cell.skip)).toEqual([false, false, false, false, false])
+  })
+
+  test("records positioned runs at terminal columns", () => {
+    const line = terminalLineFromAnsi(" ⚠ DAEMON OUT OF DATE           │", 40)
+
+    expect(line.runs.find((run) => run.text === "⚠")).toMatchObject({ c: 1, w: 1 })
+    expect(line.runs.find((run) => run.text === "│")).toMatchObject({ c: 32, w: 1 })
+  })
+
+  test("coalesces contiguous block glyphs into one positioned run", () => {
+    const line = terminalLineFromAnsi("  ▐▛███▜▌   Claude", 24)
+
+    expect(line.runs.find((run) => run.text === "▐▛███▜▌")).toMatchObject({ c: 2, w: 7 })
+  })
+
+  test("resolves default and ANSI 16 colors from the capture theme", () => {
+    const theme: TerminalTheme = {
+      defaultFg: "#ffffff",
+      defaultBg: "#101010",
+      ansi16: [
+        "#000000", "#aa0000", "#00aa00", "#aaaa00", "#0000aa", "#aa00aa", "#00aaaa", "#aaaaaa",
+        "#555555", "#ff5555", "#55ff55", "#ffff55", "#5555ff", "#ff55ff", "#55ffff", "#ffffff",
+      ],
+    }
+
+    const line = terminalLineFromAnsi("\x1b[31mR\x1b[39mD", 4, theme)
+
+    expect(line.runs.find((run) => run.text === "R")?.fg).toBe("#aa0000")
+    expect(line.runs.find((run) => run.text === "D")?.fg).toBe("#ffffff")
+  })
+
+  test("re-resolves v2 raw ANSI against the editable capture theme", () => {
+    const theme: TerminalTheme = {
+      defaultFg: "#d78787",
+      defaultBg: "#101010",
+      ansi16: [
+        "#000000", "#aa0000", "#00aa00", "#aaaa00", "#0000aa", "#aa00aa", "#00aaaa", "#aaaaaa",
+        "#555555", "#ff5555", "#55ff55", "#ffff55", "#5555ff", "#ff55ff", "#55ffff", "#ffffff",
+      ],
+    }
+
+    const line = normalizeTerminalLine({
+      rawAnsi: "\x1b[39mClaude",
+      runs: [{ c: 0, w: 6, text: "Claude", fg: "#ffffff" }],
+      backgrounds: [],
+    }, 12, theme)
+
+    expect(line.runs.find((run) => run.text === "Claude")?.fg).toBe("#d78787")
+  })
+
+  test("preserves captured glyphs instead of rewriting them in the parser", () => {
+    const line = terminalLineFromAnsi("⚠ ✳", 4)
+
+    expect(line.runs.map((run) => run.text)).toEqual(["⚠", "✳"])
+  })
+
+  test("marks emoji-capable symbols for text presentation at render time", () => {
+    const line = terminalLineFromAnsi("⏺ Please run /login", 20)
+
+    expect(line.runs[0].text).toBe("⏺")
+    expect(renderTextPresentation(line.runs[0].text)).toBe("⏺\uFE0E")
+    expect(renderTextPresentation("⏺\uFE0F 🔍 📦 ★")).toBe("⏺\uFE0E 🔍\uFE0E 📦\uFE0E ★")
+  })
+
+  test("renders default-color block glyphs with the terminal default foreground", () => {
+    const theme: TerminalTheme = {
+      defaultFg: "#ffffff",
+      defaultBg: "#101010",
+      ansi16: [
+        "#000000", "#aa0000", "#00aa00", "#aaaa00", "#0000aa", "#aa00aa", "#00aaaa", "#aaaaaa",
+        "#555555", "#ff5555", "#55ff55", "#ffff55", "#5555ff", "#ff55ff", "#55ffff", "#ffffff",
+      ],
+    }
+
+    const line = terminalLineFromAnsi("\x1b[39m▌ ▐▛███▜▌   Product", 24, theme)
+
+    expect(line.runs.find((run) => run.text === "▌")?.fg).toBe("#ffffff")
+    expect(line.runs.find((run) => run.text === "▐▛███▜▌")?.fg).toBe("#ffffff")
+    expect(line.runs.find((run) => run.text === "Product")?.fg).toBe("#ffffff")
+  })
+
+  test("uses a valid capture theme directly without parser rule merging", () => {
+    const ansi16 = [
+      "#000000", "#aa0000", "#00aa00", "#aaaa00", "#0000aa", "#aa00aa", "#00aaaa", "#aaaaaa",
+      "#555555", "#ff5555", "#55ff55", "#ffff55", "#5555ff", "#ff55ff", "#55ffff", "#ffffff",
+    ]
+    const fallback: TerminalTheme = {
+      defaultFg: "#ffffff",
+      defaultBg: "#101010",
+      ansi16,
+    }
+
+    const theme = terminalThemeFrom({ defaultFg: "#eeeeee", defaultBg: "#000000", ansi16 }, fallback)
+    const line = terminalLineFromAnsi("⚠ ▐▛███▜▌ Product", 24, theme)
+
+    expect(theme.defaultFg).toBe("#eeeeee")
+    expect(line.runs.find((run) => run.text === "⚠")).toBeDefined()
+    expect(line.runs.find((run) => run.text === "▐▛███▜▌")?.fg).toBe("#eeeeee")
+  })
+
+  test("drops unsupported parser patch fields from capture themes", () => {
+    const ansi16 = [
+      "#000000", "#aa0000", "#00aa00", "#aaaa00", "#0000aa", "#aa00aa", "#00aaaa", "#aaaaaa",
+      "#555555", "#ff5555", "#55ff55", "#ffff55", "#5555ff", "#ff55ff", "#55ffff", "#ffffff",
+    ]
+    const theme = terminalThemeFrom({
+      defaultFg: "#eeeeee",
+      defaultBg: "#000000",
+      ansi16,
+      glyphMap: { "⚠": "!" },
+      runOverrides: [],
+    })
+
+    expect(Object.keys(theme).sort()).toEqual(["ansi16", "defaultBg", "defaultFg"])
+  })
+
+  test("quicklook theme does not patch parser output", () => {
+    expect("glyphMap" in quicklookSpec.theme).toBe(false)
+    expect("runOverrides" in quicklookSpec.theme).toBe(false)
+  })
+
+  test("preserves background style on trailing spaces until reset", () => {
+    const cells = parseAnsiCells("\x1b[48;2;1;2;3mX  \x1b[0mY", 5)
+
+    expect(cells.map((cell) => cell.text)).toEqual(["X", " ", " ", "Y", " "])
+    expect(cells.slice(0, 3).map((cell) => cell.bg)).toEqual(["rgb(1,2,3)", "rgb(1,2,3)", "rgb(1,2,3)"])
+    expect(cells[3].bg).toBeUndefined()
+  })
+
+  test("applies reverse video at cell level", () => {
+    const cells = parseAnsiCells("\x1b[31;44;7mR", 1)
+
+    expect(cells[0]).toMatchObject({
+      text: "R",
+      fg: "#CC785C",
+      bg: "#D47563",
+    })
+  })
+})

--- a/packages/branding/tests/capture-env.test.ts
+++ b/packages/branding/tests/capture-env.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test"
+import {
+  CAPTURE_TERMINAL_ENV,
+  STARSHIP_PROMPT_CONFIG,
+  captureEnv,
+  isolatedPromptEnv,
+  promptDefaultCommand,
+  promptEnvEntries,
+  promptEnvTmuxArgs,
+  sanitizeCaptureEnv,
+} from "../src/quicklook/capture-env"
+
+describe("capture prompt isolation", () => {
+  test("forces task shells through a deterministic shell with user init files disabled", () => {
+    const env = isolatedPromptEnv("/tmp/capture-home")
+
+    expect(env).toMatchObject({
+      SHELL: "/bin/sh",
+      PS1: "$ ",
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      KOBE_TERMINAL_BACKEND: "bun-pty",
+      ENV: "/dev/null",
+      BASH_ENV: "/dev/null",
+      ZDOTDIR: "/tmp/capture-home/zdotdir",
+      STARSHIP_CONFIG: "/tmp/capture-home/starship.toml",
+      STARSHIP_CACHE: "/tmp/capture-home/starship-cache",
+    })
+  })
+
+  test("keeps the fallback starship prompt ASCII-only and disables runtime modules", () => {
+    expect(STARSHIP_PROMPT_CONFIG).not.toMatch(/[^\x00-\x7F]/)
+    expect(STARSHIP_PROMPT_CONFIG).toContain("[package]\ndisabled = true")
+    expect(STARSHIP_PROMPT_CONFIG).toContain("[bun]\ndisabled = true")
+    expect(STARSHIP_PROMPT_CONFIG).toContain('symbol = "git "')
+  })
+
+  test("passes prompt isolation through tmux environment arguments", () => {
+    const args = promptEnvTmuxArgs(isolatedPromptEnv("/tmp/capture-home"))
+
+    expect(args).toContain("SHELL=/bin/sh")
+    expect(args).toContain("PS1=$ ")
+    expect(args).toContain("TERM=xterm-256color")
+    expect(args).toContain("COLORTERM=truecolor")
+    expect(args).toContain("KOBE_TERMINAL_BACKEND=bun-pty")
+    expect(args).toContain("ENV=/dev/null")
+    expect(args).toContain("BASH_ENV=/dev/null")
+    expect(args).toContain("ZDOTDIR=/tmp/capture-home/zdotdir")
+    expect(args).toContain("STARSHIP_CONFIG=/tmp/capture-home/starship.toml")
+    expect(args).toContain("STARSHIP_CACHE=/tmp/capture-home/starship-cache")
+  })
+
+  test("exposes prompt isolation as tmux server environment entries", () => {
+    const entries = promptEnvEntries(isolatedPromptEnv("/tmp/capture-home"))
+
+    expect(entries).toContainEqual(["SHELL", "/bin/sh"])
+    expect(entries).toContainEqual(["PS1", "$ "])
+    expect(entries).toContainEqual(["TERM", "xterm-256color"])
+    expect(entries).toContainEqual(["COLORTERM", "truecolor"])
+    expect(entries).toContainEqual(["ENV", "/dev/null"])
+  })
+
+  test("sanitizes color-affecting environment before capture", () => {
+    const env = sanitizeCaptureEnv({
+      PATH: "/usr/bin:/bin",
+      TERM: "dumb",
+      COLORTERM: "",
+      NO_COLOR: "1",
+      CLICOLOR: "0",
+      CLICOLOR_FORCE: "1",
+      FORCE_COLOR: "0",
+    })
+
+    expect(env.PATH).toBe("/usr/bin:/bin")
+    expect(env.NO_COLOR).toBeUndefined()
+    expect(env.CLICOLOR).toBeUndefined()
+    expect(env.CLICOLOR_FORCE).toBeUndefined()
+    expect(env.FORCE_COLOR).toBeUndefined()
+    expect(env).toMatchObject(CAPTURE_TERMINAL_ENV)
+  })
+
+  test("builds full capture env from an injected base env and cleans it by default", () => {
+    const env = captureEnv({
+      baseEnv: {
+        PATH: "/usr/bin:/bin",
+        NO_COLOR: "1",
+        CLICOLOR_FORCE: "1",
+        KOBE_DAEMON_SOCKET_PATH: "/tmp/socket",
+        KOBE_PTY_PID_PATH: "/tmp/pid",
+        KEEP_ME: "yes",
+      },
+      promptEnv: isolatedPromptEnv("/tmp/capture-home"),
+      path: "/tmp/capture-home/bin:/usr/bin:/bin",
+      home: "/tmp/capture-home",
+      innerSocket: "quicklook-inner",
+      seconds: 8,
+      warmupSeconds: 2,
+    })
+
+    expect(env.KEEP_ME).toBe("yes")
+    expect(env.NO_COLOR).toBeUndefined()
+    expect(env.CLICOLOR_FORCE).toBeUndefined()
+    expect(env.KOBE_DAEMON_SOCKET_PATH).toBeUndefined()
+    expect(env.KOBE_PTY_PID_PATH).toBeUndefined()
+    expect(env).toMatchObject({
+      ...CAPTURE_TERMINAL_ENV,
+      PATH: "/tmp/capture-home/bin:/usr/bin:/bin",
+      KOBE_HOME_DIR: "/tmp/capture-home",
+      KOBE_TMUX_SOCKET: "quicklook-inner",
+      KOBE_DAEMON_WEB_PORT: "off",
+      KOBE_DAEMON_IDLE_GRACE_MS: "40000",
+      SHELL: "/bin/sh",
+      PS1: "$ ",
+    })
+  })
+
+  test("cleans process.env by default when no base env is injected", () => {
+    const previousNoColor = process.env.NO_COLOR
+    const previousTerm = process.env.TERM
+    try {
+      process.env.NO_COLOR = "1"
+      process.env.TERM = "dumb"
+
+      const env = captureEnv({
+        promptEnv: isolatedPromptEnv("/tmp/capture-home"),
+        path: "/tmp/capture-home/bin:/usr/bin:/bin",
+        home: "/tmp/capture-home",
+        innerSocket: "quicklook-inner",
+        seconds: 1,
+        warmupSeconds: 1,
+      })
+
+      expect(env.NO_COLOR).toBeUndefined()
+      expect(env.TERM).toBe("xterm-256color")
+      expect(env.COLORTERM).toBe("truecolor")
+    } finally {
+      if (previousNoColor === undefined) delete process.env.NO_COLOR
+      else process.env.NO_COLOR = previousNoColor
+      if (previousTerm === undefined) delete process.env.TERM
+      else process.env.TERM = previousTerm
+    }
+  })
+
+  test("builds a non-login default command for tmux shell panes", () => {
+    const command = promptDefaultCommand(isolatedPromptEnv("/tmp/capture-home"), {
+      home: "/tmp/capture-home",
+      path: "/usr/bin:/bin",
+    })
+
+    expect(command).toContain("env -i")
+    expect(command).toContain("HOME=/tmp/capture-home")
+    expect(command).toContain("TERM=xterm-256color")
+    expect(command).toContain("COLORTERM=truecolor")
+    expect(command).toContain("ENV=/dev/null")
+    expect(command).toContain("BASH_ENV=/dev/null")
+    expect(command).toContain("PS1='$ '")
+    expect(command.endsWith(" /bin/sh")).toBe(true)
+  })
+})

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import quicklookSpec from "../src/quicklook/quicklook.replay.json"
 import { regionCoordinateHash, resolveReplaySpec, replayDurationSeconds } from "../src/quicklook/replay-spec"
 
 const capture = {
@@ -96,5 +97,37 @@ describe("replay spec", () => {
         capture,
       ),
     ).toThrow(/focusPaneBeforeOpen/)
+
+    expect(() =>
+      resolveReplaySpec(
+        {
+          ...baseSpec,
+          theme: { defaultFg: "#fff", defaultBg: "#000", ansi16: ["#000"] },
+        },
+        capture,
+      ),
+    ).toThrow(/theme.ansi16/)
+
+    expect(() =>
+      resolveReplaySpec(
+        {
+          ...baseSpec,
+          theme: {
+            defaultFg: "#fff",
+            defaultBg: "#000",
+            ansi16: [
+              "#000", "#000", "#000", "#000", "#000", "#000", "#000", "#000",
+              "#000", "#000", "#000", "#000", "#000", "#000", "#000", "#000",
+            ],
+            runOverrides: [],
+          },
+        },
+        capture,
+      ),
+    ).toThrow(/theme.runOverrides/)
+  })
+
+  test("keeps quicklook theme limited to terminal state", () => {
+    expect(Object.keys(quicklookSpec.theme).sort()).toEqual(["ansi16", "defaultBg", "defaultFg"])
   })
 })

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { regionCoordinateHash, resolveReplaySpec, replayDurationSeconds } from "../src/quicklook/replay-spec"
+
+const capture = {
+  cols: 160,
+  rows: 45,
+  frames: [{ t: 0, lines: [] }, { t: 12.5, lines: [] }],
+}
+
+const baseSpec = {
+  id: "quicklook",
+  viewport: { cols: 160, rows: 45, width: 1280, height: 720 },
+  capture: {
+    fps: 10,
+    seconds: 120,
+    output: "src/quicklook/frames.json",
+    home: ".capture-home",
+    repoDefault: "/tmp/kobe",
+    shellPrompt: "kobe$ ",
+  },
+  waits: {
+    newTaskDialog: { pattern: "New task", timeoutMs: 8000 },
+    composerReady: { pattern: "›", timeoutMs: 30000 },
+  },
+  text: {
+    prompt: "Summarize packages/branding.",
+  },
+  regions: {
+    dialog: { c0: 30, c1: 130, r0: 6, r1: 38, hash: "ai-reviewed-dialog-region" },
+  },
+  stages: [
+    { name: "shell", from: 0, to: 3, region: "full" },
+    { name: "dialog", from: 3, to: 8, region: "dialog" },
+    { name: "wrap", from: 8, to: "end" },
+  ],
+  beats: [
+    { at: 1, action: "typeText", text: "kobe", msPerChar: 160 },
+    { at: 4, action: "typeTextWhenReady", waitFor: "composerReady", textRef: "prompt", msPerChar: 45, submit: true },
+  ],
+  camera: { transitionSeconds: 1.2, fit: 0.8, minScale: 1, maxScale: 1.6, tailHoldSeconds: 4 },
+}
+
+describe("replay spec", () => {
+  test("resolves dynamic full region and duration from capture tail", () => {
+    const spec = resolveReplaySpec(baseSpec, capture)
+
+    expect(spec.regions.full).toEqual({
+      c0: 0,
+      c1: 159,
+      r0: 0,
+      r1: 44,
+      hash: regionCoordinateHash("full", { c0: 0, c1: 159, r0: 0, r1: 44 }, capture),
+    })
+    expect(spec.regions.dialog.hash).toBe("ai-reviewed-dialog-region")
+    expect(spec.stages[2]).toEqual({ name: "wrap", from: 8, to: 16.5 })
+    expect(replayDurationSeconds(spec, capture)).toBe(16.5)
+  })
+
+  test("rejects unknown stage regions and wait references", () => {
+    expect(() =>
+      resolveReplaySpec(
+        {
+          ...baseSpec,
+          stages: [{ name: "bad", from: 0, to: 1, region: "missing" }],
+        },
+        capture,
+      ),
+    ).toThrow(/unknown region "missing"/)
+
+    expect(() =>
+      resolveReplaySpec(
+        {
+          ...baseSpec,
+          beats: [{ at: 1, action: "typeTextWhenReady", waitFor: "missing", textRef: "prompt", msPerChar: 45 }],
+        },
+        capture,
+      ),
+    ).toThrow(/unknown wait "missing"/)
+
+    expect(() =>
+      resolveReplaySpec(
+        {
+          ...baseSpec,
+          regions: { dialog: { c0: 30, c1: 130, r0: 6, r1: 38, hash: 42 } },
+        },
+        capture,
+      ),
+    ).toThrow(/regions.dialog.hash/)
+  })
+})

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -86,5 +86,15 @@ describe("replay spec", () => {
         capture,
       ),
     ).toThrow(/regions.dialog.hash/)
+
+    expect(() =>
+      resolveReplaySpec(
+        {
+          ...baseSpec,
+          flows: { createTask: { dialogWait: "newTaskDialog", focusPaneBeforeOpen: "rightmost" } },
+        },
+        capture,
+      ),
+    ).toThrow(/focusPaneBeforeOpen/)
   })
 })


### PR DESCRIPTION
## Summary
- add a validated quicklook replay spec for capture settings, beats, regions, stages, camera knobs, delivery cuts, and editable region hashes
- make `capture-tui` emit v2 positioned ANSI frames with capture metadata/theme, stable absolute `--out` handling, and host-side daemon/API calls pinned to the repo shim
- isolate capture env by clearing color-control variables, forcing `TERM=xterm-256color` / `COLORTERM=truecolor`, and using deterministic prompt shell/starship settings
- render replay frames from raw ANSI into positioned terminal cells with explicit theme resolution, background runs, grapheme/cell width handling, and text-presentation glyph rendering so emoji-capable symbols do not become colored emoji
- keep parser behavior generic: captured glyphs are preserved, unsupported parser patch fields are rejected, and capture theme remains terminal-state only

## Testing
- `bun test packages/branding/tests/ansi.test.ts packages/branding/tests/replay-spec.test.ts packages/branding/tests/capture-env.test.ts` — 24 pass / 0 fail
- `bun build packages/branding/scripts/capture-tui.ts --target=bun --outdir=/tmp/quicklook-capture-build`
- `git diff --check`
- e2e capture: `bun packages/branding/scripts/capture-tui.ts --home /tmp/quicklook-rerecord-text-v2-home.ZklCMK --repo /Users/narwhal/proj/kobe-replay-spec --out /tmp/quicklook-rerecord-text-v2.json` — captured 902 keyframes
- e2e render: `bun x remotion render src/index.ts quicklook-replay-4x /tmp/quicklook-rerecord-text-v2-4x.mp4 --codec=h264 --crf=23`
- visual still review: sampled frames `f025`, `f115`, `f300`, `f520`, `f820` from the latest capture/render

## Follow-up
- the latest capture fixes the daemon/version banner, logo color, and emoji-style rendering, but the camera strategy can still frame empty pane area during install/resolve stages; that should be handled in a separate camera pass.
