### PR TITLE
fix: engine exit degrades the tab to a shell again on the hosted backend

### DIFF
--- a/.changeset/hosted-pty-dead-session-kill.md
+++ b/.changeset/hosted-pty-dead-session-kill.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Quitting claude/codex inside an engine tab now degrades the tab to a shell again instead of closing it. The hosted PTY backend's `kill()` early-returned once the child had already exited, so the pty host kept the dead session record under the tab's key; the degraded shell's `pty.open` then reattached that corpse (spawn spec ignored, `alive: false`) and died instantly, which routed the exit through the command-tab close path. A kill on an already-dead handle now still tells the host to forget the session, which also un-breaks F5 reset of a dead shell and stops dead session records leaking in the host on tab close.

--- a/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
@@ -136,6 +136,24 @@ export class HostedTaskPty extends XtermTaskPty {
   }
 
   /**
+   * kill() must forget the REMOTE session record even when this handle is
+   * already dead: the host keeps an exited session under its key
+   * (post-mortem reattach), and the base kill() early-returns on `_killed`
+   * so `pty.kill` never reached the host. The next `pty.open` under the
+   * same key then reattached the corpse (spawn spec ignored, alive:false)
+   * instead of spawning fresh — which turned "engine exit → degrade to
+   * shell" into the tab closing itself, and made F5 reset of a dead shell
+   * a no-op.
+   */
+  override kill(): void {
+    if (this.killed) {
+      void this.client?.request("pty.kill", { key: this.taskId }).catch(() => {})
+      return
+    }
+    super.kill()
+  }
+
+  /**
    * Drop this handle, leave the child running in the pty host — the whole
    * point of the backend. Called by `registry.detachAll()` on app exit.
    */

--- a/packages/kobe/test/render/pty-hosted.test.ts
+++ b/packages/kobe/test/render/pty-hosted.test.ts
@@ -88,4 +88,31 @@ describe("HostedTaskPty over a real pty-host socket", () => {
     await until(() => text(c).includes("fresh") && !text(c).includes("persist-me"), "fresh session after kill")
     c.kill()
   })
+
+  test("kill() on a self-exited session forgets the host record — reopen spawns fresh", async () => {
+    // The engine-degrade path: the child exits on its own (claude/codex
+    // quit), so the handle is already dead when the registry release()s it.
+    const a = new HostedTaskPty({
+      taskId: "smoke::t2",
+      cwd: dir,
+      command: ["/bin/sh", "-c", "echo engine-died"],
+      cols: 60,
+      rows: 12,
+    })
+    await until(() => a.killed, "self-exited child marks the handle dead")
+    a.kill()
+
+    // The degraded tab reopens the SAME key with a different command (the
+    // user's shell). The host must spawn it — not hand back the corpse.
+    const b = new HostedTaskPty({
+      taskId: "smoke::t2",
+      cwd: dir,
+      command: ["/bin/sh", "-c", "echo fresh-shell; sleep 30"],
+      cols: 60,
+      rows: 12,
+    })
+    await until(() => text(b).includes("fresh-shell"), "reopen after dead-handle kill spawns the new command")
+    expect(b.killed).toBe(false)
+    b.kill()
+  })
 })


### PR DESCRIPTION
## Symptom

Quitting `claude`/`codex` inside an engine tab closed the tab outright instead of degrading it to a plain shell at the worktree (`degradeToShell`, the documented vendor-exit behavior).

## Root cause

Two contracts colliding around the pty host's keep-dead-sessions design:

1. The host keeps an exited session record under its key (post-mortem reattach), removed only by an explicit `pty.kill`.
2. `XtermTaskPty.kill()` early-returns when the handle is already `_killed` — and when the engine exits on its own, the handle is dead *before* the registry `release()`s it. So `pty.kill` never reached the host.

The degrade path then re-opened the SAME key with the shell command; `PtyHost.open` found the dead record, **ignored the spawn spec**, and returned `alive:false`. The "shell" died instantly, and since the tab had already flipped to `kind: "command"`, the second exit routed through `closeExitedTab` — tab gone.

Same root cause also made F5 reset of a dead shell a no-op loop and leaked dead session records in the host on tab close.

## Fix

`HostedTaskPty` overrides `kill()`: on an already-dead handle it still sends `pty.kill` so the host forgets the record. Ordering is safe — the kill and the subsequent `pty.open` ride the same shared client socket in call order. Local backends are untouched (nothing remote to forget).

## Test

New case in `test/render/pty-hosted.test.ts` (real pty-host + real socket): child self-exits → `kill()` on the dead handle → reopen same key with a different command must spawn fresh, not reattach the corpse. Times out without the fix, passes with it.


coverage-exemption: packages/kobe/src/tui/panes/terminal/pty-hosted.ts — this backend only executes under the Bun runtime (`Bun.spawn(..., { terminal })` in the pty host); its coverage lives in the bun-test render track (`test/render/pty-hosted.test.ts`, which this PR extends with a regression test for the changed behavior) and is invisible to the vitest coverage report.
