### PR TITLE
fix: split-leaf ctrl+w/F2 gating and live leaf-1 titles

### DIFF
--- a/.changeset/split-close-and-leaf-titles.md
+++ b/.changeset/split-close-and-leaf-titles.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix ctrl+w/F2 not reaching split leaves, and split leaf-1's corner tag freezing on "zsh".
+
+While a workspace tab was split, ctrl+w and F2 were always captured by the tab-level close/rename bindings (React mounts ancestors on top of the keymap stack, inverting the Solid-era precedence), so a split leaf could never be closed or renamed — on a single tab ctrl+w just toasted "cannot close last tab". The tab-level entries now gate themselves off while the active tab is split. Also, a shell tab's own leaf (leaf-1) now tracks its live foreground-process title, so entering claude/vim from the shell updates the split corner tag instead of freezing on "zsh"; engine tabs keep their conversation title.

--- a/packages/kobe/src/tui-react/lib/keymap.ts
+++ b/packages/kobe/src/tui-react/lib/keymap.ts
@@ -14,9 +14,12 @@
  * Known ordering difference (documented, accepted for the migration): Solid
  * registers during component SETUP (parents before children → children end
  * up on top); React registers in mount EFFECTS (children before parents →
- * ancestors end up on top). The only cross-level competitor today is the
- * dialog provider's escape/ctrl+c pair, which gates itself on the dialog
- * stack being non-empty — modal-on-top is the desired behavior anyway.
+ * ancestors end up on top). Consequence: a parent and child sharing a chord
+ * must resolve by GATING, not stack order — the parent's entry disables
+ * itself when the child should win. Cases today: the dialog provider's
+ * escape/ctrl+c pair (gates on the dialog stack being non-empty) and
+ * TerminalTabs' ctrl+w/F2 (gate off while the active tab is split so
+ * TerminalSplit's leaf-level close/rename fire).
  */
 
 import type { KeyEvent, KeyHandler } from "@opentui/core"

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -216,14 +216,16 @@ export function TerminalSplit(props: {
 
   const leafFocused = (id: string) => props.focused && activeLeaf === id
 
-  // Live foreground-process titles for split-created SHELL leaves (real
-  // terminals track this via the OSC 0/2 window-title escape: "zsh" idle,
-  // "vim"/"htop" once you run one — see `TaskPtyLike.onTitleChange`).
-  // Engine leaves keep their own conversation-title naming (`engineTitle`),
-  // untouched here. Lazy-attach + retry: a leaf's PTY spawns asynchronously
-  // after its Terminal mounts, same contract as `use-turn-polls.ts`'s poll
-  // attach. Ephemeral (not persisted) — a fresh mount re-derives it as soon
-  // as the shell's next title escape lands.
+  // Live foreground-process titles for EVERY leaf (real terminals track
+  // this via the OSC 0/2 window-title escape: "zsh" idle, "vim"/"htop"
+  // once you run one — see `TaskPtyLike.onTitleChange`). leaf-1 is
+  // included: a SHELL tab's own leaf runs zsh and can enter claude/vim,
+  // and its static command basename would freeze on "zsh". Engine leaves
+  // still prefer their conversation title (`engineTitle` wins in
+  // `splitLeafNames`). Lazy-attach + retry: a leaf's PTY spawns
+  // asynchronously after its Terminal mounts, same contract as
+  // `use-turn-polls.ts`'s poll attach. Ephemeral (not persisted) — a fresh
+  // mount re-derives it as soon as the shell's next title escape lands.
   const [liveTitles, setLiveTitles] = useState<ReadonlyMap<string, string>>(new Map())
   const titleSubsRef = useRef(new Map<string, () => void>())
   const [titleTick, setTitleTick] = useState(0)
@@ -235,12 +237,8 @@ export function TerminalSplit(props: {
     void titleTick
     const reg = getDefaultPtyRegistry()
     const titleSubs = titleSubsRef.current
-    const shellLeafIds = new Set(
-      leaves(state.root)
-        .filter((l) => l.content !== null)
-        .map((l) => l.id),
-    )
-    for (const id of shellLeafIds) {
+    const leafIds = new Set(leaves(state.root).map((l) => l.id))
+    for (const id of leafIds) {
       if (titleSubs.has(id)) continue
       const pty = reg.get(splitLeafPtyKey(props.tabKey, id))
       if (!pty) continue
@@ -253,7 +251,7 @@ export function TerminalSplit(props: {
       )
     }
     for (const [id, dispose] of titleSubs) {
-      if (shellLeafIds.has(id)) continue
+      if (leafIds.has(id)) continue
       dispose()
       titleSubs.delete(id)
       setLiveTitles((prev) => {

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -51,6 +51,7 @@ import { type ReactNode, useEffect, useRef, useState } from "react"
 import { defaultShell } from "../../tui/panes/terminal/pty-types"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { waitAndDeliverInitialPrompt } from "../../tui/workspace/quick-fork-delivery"
+import { leaves } from "../../tui/workspace/split-core"
 import {
   type EngineTab,
   type TabsState,
@@ -418,6 +419,23 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
         update(pinSession(addTab(state, preferred), preferred))
       },
       "chat.tab.chooseEngine": requestChooseEngine,
+      "chat.tab.cycle-next": () => update(cycleTab(state, 1)),
+      "chat.tab.cycle-prev": () => update(cycleTab(state, -1)),
+      "chat.fork.new": requestQuickFork,
+    }),
+  }))
+
+  // ctrl+w / F2 share their chords with TerminalSplit's leaf-level close/
+  // rename. In React the keymap stack puts ANCESTORS on top (mount effects
+  // run children-first — see keymap.ts), so these tab-level entries would
+  // always shadow the split ones. Gate them off while the active tab is
+  // actually split (>1 leaf) so the chords fall through the LIFO stack to
+  // the leaf bindings — the Solid-era precedence, restored by gating
+  // instead of ordering.
+  const activeIsSplit = active.splitTree ? leaves(active.splitTree.root).length > 1 : false
+  useBindings(() => ({
+    enabled: props.focused && !activeIsSplit,
+    bindings: bindByIds({
       "chat.tab.close": () => {
         const closing = state.tabs.find((tb) => tb.id === state.activeId)
         const { state: next, closedId } = closeActiveTab(state)
@@ -435,9 +453,6 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
         getDefaultPtyRegistry().release(tabPtyKey(props.taskId, closedId))
       },
       "chat.tab.rename": requestRename,
-      "chat.tab.cycle-next": () => update(cycleTab(state, 1)),
-      "chat.tab.cycle-prev": () => update(cycleTab(state, -1)),
-      "chat.fork.new": requestQuickFork,
     }),
   }))
 

--- a/packages/kobe/src/tui/context/keybindings-chat.ts
+++ b/packages/kobe/src/tui/context/keybindings-chat.ts
@@ -281,9 +281,10 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   {
     // Same chord as chat.tab.close, contextual scope: while the tab is
     // SPLIT, ctrl+w closes the active leaf (the innermost thing — VS
-    // Code/iTerm/Warp convention, tmux `prefix x`); TerminalSplit only
-    // enables this entry when split, so unsplit tabs fall through the
-    // LIFO stack to the close-tab binding.
+    // Code/iTerm/Warp convention, tmux `prefix x`). Resolution is mutual
+    // gating (React stacks ancestors on top — see tui-react/lib/keymap.ts):
+    // TerminalSplit enables this entry only when split, and TerminalTabs
+    // disables its close-tab entry while split, so exactly one is live.
     id: "workspace.split.close",
     scope: "workspace",
     keys: ["ctrl+w"],

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -356,11 +356,15 @@ export function splitLeafNames(
       out.set(leaf.id, leaf.title)
       continue
     }
-    // Engine leaf → first-prompt title (else vendor basename); split shell
-    // leaf → its live foreground-process title, else generic "shell".
-    // Both dedupe by reading order.
+    // Engine leaf → first-prompt title, else its live foreground-process
+    // title (a shell tab's leaf-1 runs zsh and can enter claude/vim — the
+    // static command basename would freeze on "zsh"), else vendor basename;
+    // split shell leaf → live title, else generic "shell". Both dedupe by
+    // reading order.
     const name =
-      leaf.content === null ? engineTitle || basename(leaf.content) : liveTitles?.get(leaf.id) || SHELL_LEAF_NAME
+      leaf.content === null
+        ? engineTitle || liveTitles?.get(leaf.id) || basename(leaf.content)
+        : liveTitles?.get(leaf.id) || SHELL_LEAF_NAME
     const n = (seen.get(name) ?? 0) + 1
     seen.set(name, n)
     out.set(leaf.id, n === 1 ? name : `${name} ${n}`)

--- a/packages/kobe/test/tui/split-core.test.ts
+++ b/packages/kobe/test/tui/split-core.test.ts
@@ -161,4 +161,19 @@ describe("split tree (content-agnostic)", () => {
     const renamed = splitLeafNames(leaves(renameLeaf(s, "leaf-2", "logs").root), ["claude"], null, live)
     expect(renamed.get("leaf-2")).toBe("logs")
   })
+
+  // Why: a SHELL tab's own leaf (leaf-1, null content) runs zsh and can
+  // enter claude/vim — the static command basename froze its corner tag
+  // on "zsh" forever. Live title fills in when there's no engine title;
+  // an engine tab's conversation title still wins.
+  it("splitLeafNames: leaf-1 uses its live title when there is no engine title", () => {
+    const s = splitActive(initialSplit(MAIN), "row", SH) // leaf-1 | shell(leaf-2)
+    const live = new Map([["leaf-1", "claude"]])
+    // Shell tab (no engine title): the live foreground process wins over "zsh".
+    expect(splitLeafNames(leaves(s.root), ["/bin/zsh"], null, live).get("leaf-1")).toBe("claude")
+    // Engine tab: the first-prompt title still outranks the live title.
+    expect(splitLeafNames(leaves(s.root), ["claude"], "fix the resize race", live).get("leaf-1")).toBe(
+      "fix the resize race",
+    )
+  })
 })


### PR DESCRIPTION
## Summary

Two split-view bugs, both in the React migration layer:

**ctrl+w (and F2) never reached a split leaf.** `TerminalTabs` (parent) and `TerminalSplit` (child) share the chords, resolved by the keymap's LIFO stack — but React registers bindings in mount effects (children first), so ancestors land on top, inverting the Solid-era precedence. `chat.tab.close` always won: on a single tab ctrl+w just toasted "cannot close last tab"; on multiple tabs it closed the whole tab instead of the leaf. F2 renamed the tab instead of the leaf. Fix: the tab-level close/rename entries gate themselves off while the active tab is split (>1 leaf), so the chords fall through the stack to the leaf bindings. Documented the gating rule in `keymap.ts` / `keybindings-chat.ts`.

**A shell tab's leaf-1 corner tag froze on "zsh".** The live-title (OSC 0/2) subscription excluded leaf-1, so entering claude/vim from a shell tab never updated its split name. Leaf-1 now subscribes too; naming prefers `engineTitle || liveTitle || basename`, so engine tabs keep their conversation title.

## Test plan
- `splitLeafNames` unit tests extended: leaf-1 live title wins without an engine title, engine title still outranks it
- typecheck, full test suite (226), root lint all green locally


coverage-exemption: packages/kobe/src/tui-react/lib/keymap.ts — comment-only change (header doc of the ancestor-on-top gating rule); no executable lines touched
