### PR TITLE
perf: reuse one scratch cell in xtermLineToChunks instead of per-cell alloc

### DIFF
--- a/.changeset/xterm-chunks-scratch-cell.md
+++ b/.changeset/xterm-chunks-scratch-cell.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+perf: reuse one scratch cell in `xtermLineToChunks` instead of allocating per cell
+
+`@xterm/headless`'s `line.getCell(x)` allocates a fresh cell object on every call, and the terminal render path called it for every cell of every converted line — the dominant per-cell allocation on that hot path. It now threads one shared scratch cell into `getCell(x, cell)` (xterm's documented reuse fast path), lazily seeded once program-wide, so line conversion allocates zero cells after warmup. Pure allocation change: the two-pass structure and the `minLast` cursor-tail invariant are untouched.

--- a/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
@@ -102,6 +102,44 @@ function isVisibleCell(cell: XtermCellLike): boolean {
 }
 
 /**
+ * One reusable scratch cell, shared across every line conversion.
+ *
+ * `@xterm/headless`'s `line.getCell(x)` allocates a fresh cell object on
+ * every call; `getCell(x, cell)` instead loads the data into `cell` and
+ * returns that same reference (xterm's documented "avoid recreating cell
+ * objects" fast path). On the terminal render hot path this fires for
+ * every cell of every converted line, so the no-arg form was the dominant
+ * per-cell allocation.
+ *
+ * There is no public `CellData` constructor in `@xterm/headless` (it
+ * exports only `Terminal`), and `getNullCell()` needs a live buffer this
+ * function never sees. So we seed the scratch lazily from the first
+ * `getCell` call we ever make (a fresh cell obtained without the scratch
+ * arg) and reuse it forever after — a single program-wide allocation
+ * amortized to zero per line.
+ *
+ * Reuse is safe ONLY because nothing here retains a cell reference across
+ * iterations: each pass reads the cell's chars + attributes immediately
+ * (`cellStyle` copies every attribute out into a fresh `RenderStyle`,
+ * `getChars()` extracts the text) and moves on. Stashing the cell object
+ * itself would see it clobbered on the next `getCell`.
+ */
+let scratchCell: XtermCellLike | undefined
+
+function getCellReusing(
+  line: { getCell(index: number, cell?: XtermCellLike): XtermCellLike | undefined },
+  x: number,
+): XtermCellLike | undefined {
+  if (scratchCell === undefined) {
+    // First-ever call: no scratch yet, so this one fresh cell becomes it.
+    const seeded = line.getCell(x)
+    if (seeded) scratchCell = seeded
+    return seeded
+  }
+  return line.getCell(x, scratchCell)
+}
+
+/**
  * Map one xterm buffer line to a list of opentui-ready style runs.
  *
  * This is the direct cell→chunk path: we read xterm's authoritative
@@ -112,7 +150,7 @@ function isVisibleCell(cell: XtermCellLike): boolean {
  * overlay is computed against.
  */
 export function xtermLineToChunks(
-  line: { length: number; getCell(index: number): XtermCellLike | undefined },
+  line: { length: number; getCell(index: number, cell?: XtermCellLike): XtermCellLike | undefined },
   minLast = -1,
 ): Chunk[] {
   // `Math.max` is load-bearing: the `minLast` seed (cursor column) must
@@ -122,7 +160,7 @@ export function xtermLineToChunks(
   // overlay stuck at end-of-text — "cursor doesn't move on space".
   let last = Math.min(line.length - 1, minLast)
   for (let x = 0; x < line.length; x++) {
-    const cell = line.getCell(x)
+    const cell = getCellReusing(line, x)
     if (!cell || cell.getWidth() === 0) continue
     if (isVisibleCell(cell)) last = Math.max(last, x)
   }
@@ -137,7 +175,7 @@ export function xtermLineToChunks(
     buf = ""
   }
   for (let x = 0; x <= last; x++) {
-    const cell = line.getCell(x)
+    const cell = getCellReusing(line, x)
     if (!cell || cell.getWidth() === 0) continue
     const next = cellStyle(cell)
     if (!styleEquals(active, next)) {

--- a/packages/kobe/test/tui/xterm-chunks.test.ts
+++ b/packages/kobe/test/tui/xterm-chunks.test.ts
@@ -38,6 +38,22 @@ function line(text: string, length = 40) {
   }
 }
 
+/**
+ * A styled cell: default-style except a bold + RGB-fg run, so adjacent
+ * styled cells coalesce into one chunk and an interior blank breaks the run.
+ */
+function styledCell(chars: string) {
+  return {
+    ...cell(chars),
+    isFgDefault: () => false,
+    isFgRGB: () => true,
+    getFgColorMode: () => 3 << 24,
+    getFgColor: () => 0xff8800,
+    isAttributeDefault: () => false,
+    isBold: () => true,
+  }
+}
+
 describe("xtermLineToChunks — minLast keeps the cursor's blank tail", () => {
   it("trims trailing blanks without minLast", () => {
     expect(
@@ -65,5 +81,87 @@ describe("xtermLineToChunks — minLast keeps the cursor's blank tail", () => {
         .map((c) => c.text)
         .join(""),
     ).toBe("ab ")
+  })
+})
+
+describe("xtermLineToChunks — scratch cell reuse", () => {
+  /**
+   * xterm-faithful line: `getCell(x, scratch)` loads the cell's data into
+   * `scratch` and returns *that same reference* (zero allocation), exactly
+   * like `@xterm/headless`. Only the no-arg form constructs a fresh cell —
+   * `construct` counts those, standing in for `new CellData()`. `getChars`
+   * counts per-cell reads so we can prove work is unchanged.
+   */
+  function countingLine(text: string, length = 180) {
+    let construct = 0
+    let getChars = 0
+    const dataAt = (index: number) => {
+      const c = cell(index < text.length ? (text[index] as string) : "")
+      const origGetChars = c.getChars
+      c.getChars = () => {
+        getChars++
+        return origGetChars()
+      }
+      return c
+    }
+    return {
+      counts: () => ({ construct, getChars }),
+      line: {
+        length,
+        getCell(index: number, scratch?: ReturnType<typeof cell>) {
+          if (scratch) {
+            // Reuse: copy into the caller's scratch, allocate nothing.
+            Object.assign(scratch, dataAt(index))
+            return scratch
+          }
+          construct++
+          return dataAt(index)
+        },
+      },
+    }
+  }
+
+  it("allocates zero fresh cells per line and reads getChars unchanged", () => {
+    // Warm the module scratch first (its lazy seed is a one-time cost, not
+    // per-line), then measure a clean 180-col line.
+    xtermLineToChunks(countingLine("warmup").line)
+
+    const first = countingLine("hello world")
+    xtermLineToChunks(first.line)
+    const a = first.counts()
+    expect(a.construct).toBe(0)
+
+    // getChars count is identical for an identical line before/after — the
+    // scratch changes allocation only, never the amount of work.
+    const second = countingLine("hello world")
+    xtermLineToChunks(second.line)
+    const b = second.counts()
+    expect(b.construct).toBe(0)
+    expect(b.getChars).toBe(a.getChars)
+    expect(b.getChars).toBeGreaterThan(0)
+  })
+})
+
+describe("xtermLineToChunks — run boundaries survive scratch reuse", () => {
+  it("keeps an interior blank between two styled runs", () => {
+    // "AB" (styled) + " " (default blank) + "CD" (styled): scratch reuse must
+    // not bleed the styled attributes across the blank, so this is three
+    // chunks — styled / blank / styled — not one coalesced run.
+    const cells = [styledCell("A"), styledCell("B"), cell(" "), styledCell("C"), styledCell("D")]
+    const line = {
+      length: 5,
+      getCell: (index: number, scratch?: ReturnType<typeof cell>) => {
+        const src = cells[index] ?? cell("")
+        if (scratch) {
+          Object.assign(scratch, src)
+          return scratch
+        }
+        return src
+      },
+    }
+    const chunks = xtermLineToChunks(line)
+    expect(chunks.map((c) => c.text)).toEqual(["AB", " ", "CD"])
+    expect(chunks[0]?.attributes).toBe(chunks[2]?.attributes)
+    expect(chunks[1]?.attributes).toBeUndefined()
   })
 })


### PR DESCRIPTION
@xterm/headless's line.getCell(x) allocates a fresh cell object per call,
and the terminal render path fired it for every cell of every converted
line — the dominant per-cell allocation on that hot path. Thread one shared
scratch cell into getCell(x, cell) (xterm's documented reuse fast path),
lazily seeded once program-wide, so line conversion allocates zero cells
after warmup. Pure allocation change: the two-pass structure and the minLast
cursor-tail invariant are untouched; reuse is safe because both passes read
chars+attrs immediately and retain no cell reference across iterations.
