### PR TITLE
perf: O(1) inbound pty-frame dispatch instead of O(open-tabs)

### DIFF
--- a/.changeset/pty-dispatch-o1.md
+++ b/.changeset/pty-dispatch-o1.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Inbound pty-frame routing is now O(1) per chunk instead of O(open-tabs).
+
+Every open terminal tab used to register its own `pty.data`/`pty.exit` handler on the one shared pty-host client, so the client walked N handlers (N-1 pure key-mismatch rejections) for every chunk an interactive engine streamed — on the busiest inbound path. A single keyed dispatcher now installs once per client and does one `Map` lookup per frame; each hosted handle registers/deregisters through its existing teardown so detach/kill/park never leave a stale route. Behavior is identical: a frame still reaches exactly its own tab and unknown keys drop.

--- a/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
@@ -38,12 +38,48 @@ import { XtermTaskPty } from "./pty-xterm-base"
  */
 let shared: Promise<KobeDaemonClient> | null = null
 
+/**
+ * Key → live handle, for O(1) inbound routing. The client's `emit()` walks
+ * its whole `pty.data`/`pty.exit` handler Set per frame, so one `on()` per
+ * open tab made every interactive `claude` chunk cost N handler calls +
+ * N key-compares (N-1 pure rejections) on the busiest path. Instead we
+ * install ONE dispatcher per shared client (see `installDispatch`) that
+ * does a single map lookup. Each handle `set`s itself here on open and the
+ * `cleanup()` teardown route (`detach`/`kill`/`park`/socket-close all pass
+ * through it) `delete`s it — so a dead tab never receives a stray chunk.
+ */
+const hostedByKey = new Map<string, HostedTaskPty>()
+
+/** Guards the one-time dispatcher install per client instance. */
+const dispatchInstalled = new WeakSet<KobeDaemonClient>()
+
+/**
+ * Install the single per-frame router on a shared client. Both `pty.data`
+ * and `pty.exit` fan out to exactly one map lookup; unknown keys (a dead
+ * handle's late frame, a key from another process) drop silently — the same
+ * behavior the old per-handle `payload.key === this.taskId` guard gave, but
+ * O(1) instead of O(open-tabs).
+ */
+function installDispatch(client: KobeDaemonClient): void {
+  if (dispatchInstalled.has(client)) return
+  dispatchInstalled.add(client)
+  client.on("pty.data", (frame) => {
+    const payload = frame.payload as PtyDataEventPayload
+    hostedByKey.get(payload.key)?.feedFrame(payload.data)
+  })
+  client.on("pty.exit", (frame) => {
+    const payload = frame.payload as PtyExitEventPayload
+    hostedByKey.get(payload.key)?.remoteGone()
+  })
+}
+
 function getSharedPtyClient(): Promise<KobeDaemonClient> {
   if (shared) return shared
   const p = (async () => {
     const socketPath = await ensurePtyHostReachable()
     const client = new KobeDaemonClient(socketPath)
     await client.connect()
+    installDispatch(client)
     client.onLifecycle("close", () => {
       if (shared === p) shared = null
     })
@@ -77,15 +113,11 @@ export class HostedTaskPty extends XtermTaskPty {
       const client = await getSharedPtyClient()
       if (this.killed) return
       this.client = client
+      // Route inbound frames through the shared O(1) dispatcher (installed
+      // on the client in getSharedPtyClient) instead of a per-handle
+      // `on("pty.data")` that the client would walk for every tab per chunk.
+      hostedByKey.set(this.taskId, this)
       this.unsubs.push(
-        client.on("pty.data", (frame) => {
-          const payload = frame.payload as PtyDataEventPayload
-          if (payload.key === this.taskId) this.feed(Buffer.from(payload.data, "base64"))
-        }),
-        client.on("pty.exit", (frame) => {
-          const payload = frame.payload as PtyExitEventPayload
-          if (payload.key === this.taskId) this.remoteGone()
-        }),
         // Host died / socket dropped: the pane shows its dead-shell
         // banner; the user reopens the tab (or reset) to reattach.
         client.onLifecycle("close", () => this.remoteGone()),
@@ -190,13 +222,29 @@ export class HostedTaskPty extends XtermTaskPty {
     void this.client?.request("pty.resize", { key: this.taskId, cols, rows }).catch(() => {})
   }
 
-  /** The remote child (or the host itself) is gone — dead-shell banner. */
-  private remoteGone(): void {
+  /**
+   * Decode + feed one inbound `pty.data` frame. Public so the module-level
+   * dispatcher (getSharedPtyClient) can route by key; not for outside use.
+   */
+  feedFrame(dataB64: string): void {
+    this.feed(Buffer.from(dataB64, "base64"))
+  }
+
+  /**
+   * The remote child (or the host itself) is gone — dead-shell banner.
+   * Public for the shared dispatcher's `pty.exit` route; also the local
+   * lifecycle-close reaction.
+   */
+  remoteGone(): void {
     this.cleanup()
     this.markDead(false)
   }
 
   private cleanup(): void {
+    // Drop our map entry FIRST so no in-flight frame can reach a torn-down
+    // handle — every teardown route (detach/kill/park/socket-close) lands
+    // here, so this is the single place the registration is undone.
+    if (hostedByKey.get(this.taskId) === this) hostedByKey.delete(this.taskId)
     for (const unsub of this.unsubs.splice(0)) {
       try {
         unsub()

--- a/packages/kobe/test/tui/pty-dispatch-budget.test.ts
+++ b/packages/kobe/test/tui/pty-dispatch-budget.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Inbound pty-frame dispatch is O(1), not O(open-tabs).
+ *
+ * Every open terminal tab is a HostedTaskPty on ONE shared pty-host client.
+ * The client's `emit()` walks its whole `pty.data` handler Set per inbound
+ * frame, so a per-tab `client.on("pty.data")` made every chunk interactive
+ * `claude` streams cost N handler-body runs + N `payload.key === taskId`
+ * compares (N-1 pure rejections) — on the busiest inbound path. The fix
+ * installs ONE keyed dispatcher on the client (`installDispatch`) that does a
+ * single `hostedByKey.get(key)?.feedFrame(...)` lookup; a frame reaches
+ * exactly its own handle and adding tabs never grows per-frame work for an
+ * unrelated key.
+ *
+ * This test pins that budget deterministically (op-count, not wall-clock):
+ * spy `HostedTaskPty.feedFrame` (the sole per-frame dispatch body) and count
+ * its invocations when the fake host pushes ONE frame at N=8 open tabs.
+ * Before the fix the analogous count would be 8 (every handle's body ran its
+ * compare); after it is exactly 1.
+ *
+ * A REAL `HostedTaskPty` over a REAL `KobeDaemonClient` (protocol-only fake
+ * host — no child spawn) exercises the actual dispatcher + `hostedByKey` map
+ * + `cleanup()` teardown, so it also guards that detach removes the entry (no
+ * leak, no stray chunk to a dead tab).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { type Server, type Socket, createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { type DaemonFrame, frameToLine } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { HostedTaskPty } from "../../src/tui/panes/terminal/pty-hosted"
+
+/**
+ * Protocol-only pty host: answers `hello`/`pty.open` so a real client can
+ * attach without spawning a child, swallows write/resize/kill/detach, and
+ * exposes `push()` to broadcast one event frame to every attached socket
+ * (the exact wire path the real host uses for `pty.data`/`pty.exit`).
+ */
+class FakePtyHost {
+  private readonly server: Server
+  private readonly sockets = new Set<Socket>()
+
+  private constructor(server: Server) {
+    this.server = server
+    server.on("connection", (socket) => {
+      this.sockets.add(socket)
+      socket.on("error", () => {})
+      socket.on("close", () => this.sockets.delete(socket))
+      let buf = ""
+      socket.on("data", (chunk) => {
+        buf += chunk.toString("utf8")
+        let nl = buf.indexOf("\n")
+        while (nl !== -1) {
+          const line = buf.slice(0, nl)
+          buf = buf.slice(nl + 1)
+          if (line.trim()) this.onRequest(socket, JSON.parse(line) as DaemonFrame)
+          nl = buf.indexOf("\n")
+        }
+      })
+    })
+  }
+
+  static start(socketPath: string): Promise<FakePtyHost> {
+    return new Promise((resolve, reject) => {
+      const server = createServer()
+      server.once("error", reject)
+      server.listen(socketPath, () => resolve(new FakePtyHost(server)))
+    })
+  }
+
+  private onRequest(socket: Socket, frame: DaemonFrame): void {
+    if (frame.type !== "request") return
+    // `pty.open` gets a live, empty-replay attach; everything else (hello,
+    // write, resize, kill, detach) just needs *a* reply so the client's
+    // pending entry resolves.
+    const payload = frame.name === "pty.open" ? { replay: "", alive: true } : {}
+    socket.write(frameToLine({ type: "response", id: frame.id, payload }))
+  }
+
+  /** Broadcast one event frame to every attached client (the host push path). */
+  push(frame: Extract<DaemonFrame, { type: "event" }>): void {
+    const line = frameToLine(frame)
+    for (const socket of this.sockets) socket.write(line)
+  }
+
+  async close(): Promise<void> {
+    for (const socket of this.sockets) socket.destroy()
+    this.sockets.clear()
+    await new Promise<void>((resolve) => this.server.close(() => resolve()))
+  }
+}
+
+function dataFrame(key: string): Extract<DaemonFrame, { type: "event" }> {
+  return { type: "event", name: "pty.data", payload: { key, data: Buffer.from("x").toString("base64") } }
+}
+
+async function until(cond: () => boolean, ms = 3000): Promise<void> {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error("timeout")
+    await new Promise((r) => setTimeout(r, 15))
+  }
+}
+
+const N = 8
+const OPTS = { cwd: "/", command: ["/bin/cat"], cols: 40, rows: 10 }
+
+describe("hosted pty inbound dispatch budget", () => {
+  // One host + one shared client for the file: the module-level `shared`
+  // pty-host connection is a singleton, so tearing the socket down between
+  // tests would strand it. Distinct keys per test keep the `hostedByKey` map
+  // clean without needing a fresh socket.
+  let dir: string
+  let host: FakePtyHost
+
+  beforeAll(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kobe-pty-dispatch-"))
+    process.env.KOBE_PTY_SOCKET_PATH = join(dir, "pty.sock")
+    process.env.KOBE_PTY_PID_PATH = join(dir, "pty.pid")
+    host = await FakePtyHost.start(process.env.KOBE_PTY_SOCKET_PATH)
+  })
+
+  afterAll(async () => {
+    await host.close()
+    Reflect.deleteProperty(process.env, "KOBE_PTY_SOCKET_PATH")
+    Reflect.deleteProperty(process.env, "KOBE_PTY_PID_PATH")
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it("one pushed frame hits exactly one handle's dispatch body, whatever N", async () => {
+    // feedFrame is the SOLE per-frame dispatch body — its invocation count is
+    // the op budget. Spy it before the handles open so every call is caught.
+    const feed = vi.spyOn(HostedTaskPty.prototype, "feedFrame")
+
+    const ptys: HostedTaskPty[] = []
+    for (let i = 0; i < N; i++) ptys.push(new HostedTaskPty({ taskId: `t${i}::tab`, ...OPTS }))
+    // Wait until every handle has attached (opened its remote), so all N are
+    // registered in the shared map and would be walked by an O(N) fan-out.
+    await until(() => ptys.every((p) => (p as unknown as { opened: boolean }).opened))
+    feed.mockClear()
+
+    // ONE frame for a single key → exactly ONE dispatch-body run, not N.
+    host.push(dataFrame("t3::tab"))
+    await until(() => feed.mock.calls.length > 0)
+    expect(feed).toHaveBeenCalledTimes(1)
+    expect(feed.mock.instances[0]).toBe(ptys[3])
+
+    // A frame for an unknown key touches NO handle (dropped by the map miss,
+    // same as the old per-handle key-compare rejecting) — and this holds no
+    // matter how many tabs are open, i.e. per-frame cost doesn't grow with N.
+    feed.mockClear()
+    host.push(dataFrame("nobody::tab"))
+    await new Promise((r) => setTimeout(r, 80))
+    expect(feed).toHaveBeenCalledTimes(0)
+
+    for (const p of ptys) p.detach()
+  })
+
+  it("detach removes the map entry — a later frame reaches no handle (no leak)", async () => {
+    const feed = vi.spyOn(HostedTaskPty.prototype, "feedFrame")
+    const pty = new HostedTaskPty({ taskId: "solo::tab", ...OPTS })
+    await until(() => (pty as unknown as { opened: boolean }).opened)
+
+    feed.mockClear()
+    pty.detach() // app-teardown / park route — must delete the registration
+    host.push(dataFrame("solo::tab"))
+    await new Promise((r) => setTimeout(r, 80))
+    expect(feed).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
Every open terminal tab registered its own pty.data/pty.exit handler on the
one shared pty-host client, so the client walked N handlers (N-1 pure
key-mismatch rejections) per chunk an interactive engine streamed. A single
keyed dispatcher now installs once per client and does one Map lookup per
frame; each hosted handle registers on open and deregisters through its
existing cleanup() so detach/kill/park never leave a stale route.
