### PR TITLE
perf: daemon transcript-activity probe walks each dir once, not twice

### DIFF
--- a/.changeset/transcript-activity-single-walk.md
+++ b/.changeset/transcript-activity-single-walk.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+perf: the daemon's transcript-activity probe walks each worktree's transcript dir once per tick, not twice.
+
+Each ~1.5s tick used to make two independent directory listings of the same on-disk transcript store per local worktree — `latestTranscriptMtime` (a readdir + stats, or a full `~/.codex/sessions` date-tree walk) then the turn detector's `latestCompletion` (another walk). The detector already finds the newest file's mtime while locating the latest completion, so it now surfaces both from a single scan (`latestActivity`), and the probe drops the redundant mtime call for claude/codex — one listing per probe, half the stats — while copilot/custom engines keep their single existing walk. The published activity facts (mtime/completionId/completionAt) are byte-identical.

--- a/packages/kobe-daemon/src/daemon/transcript-activity-collector.ts
+++ b/packages/kobe-daemon/src/daemon/transcript-activity-collector.ts
@@ -103,10 +103,19 @@ export type TranscriptActivityRunner = (
 ) => Promise<TranscriptActivityEntry>
 
 /**
- * The real probe: newest transcript mtime (the engine's fs-only history
- * reader) + the engine-owned latest completion marker. Both are best-effort
- * and FILESYSTEM-only — no tmux, no subprocess. The detector's internal
- * memo skips the JSONL re-parse when the file's mtime hasn't moved.
+ * The real probe: the engine-owned latest completion marker AND the newest
+ * transcript mtime — from ONE directory scan via `detector.latestActivity`.
+ * Before this the probe made TWO independent walks of the same transcript
+ * dir per tick (`latestTranscriptMtime` then `latestCompletion`), each doing
+ * its own readdir (+ stats / a codex date-tree walk). The detector already
+ * stats the newest file while finding the completion, so it surfaces that
+ * mtime for free — one listing per probe.
+ *
+ * Vendors whose detector can't read a transcript store (copilot/custom →
+ * `UnknownTurnDetector`) yield no mtime, so we fall back to the vendor's own
+ * `latestTranscriptMtime` for them (copilot has a real store the detector
+ * doesn't read) — a SINGLE walk, exactly as before for those vendors.
+ * Best-effort and FILESYSTEM-only — no tmux, no subprocess.
  */
 export async function runTranscriptActivity(
   worktreePath: string,
@@ -114,9 +123,11 @@ export async function runTranscriptActivity(
   detector: EngineTurnDetector,
   _signal: AbortSignal,
 ): Promise<TranscriptActivityEntry> {
-  const mtimeMs = await latestTranscriptMtime(vendor, worktreePath)
-  const marker = await detector.latestCompletion(worktreePath)
-  return { mtimeMs, completionId: marker?.id ?? null, completionAt: marker?.timestampMs ?? 0 }
+  const { marker, mtimeMs } = await detector.latestActivity(worktreePath)
+  const resolvedMtime = detector.supportsCompletionMarkers()
+    ? mtimeMs
+    : await latestTranscriptMtime(vendor, worktreePath)
+  return { mtimeMs: resolvedMtime, completionId: marker?.id ?? null, completionAt: marker?.timestampMs ?? 0 }
 }
 
 /**

--- a/packages/kobe/src/engine/turn-detector.ts
+++ b/packages/kobe/src/engine/turn-detector.ts
@@ -36,6 +36,19 @@ export interface TurnCompletionMarker {
   readonly source: VendorId
 }
 
+/**
+ * The two fs-derived facts a single transcript-dir scan yields: the newest
+ * completion marker AND the newest transcript mtime. The daemon collector
+ * wants both per probe, and finding the completion already walks the dir
+ * and stats its files — so one scan surfaces both instead of two callers
+ * each doing their own readdir (the perf win). `mtimeMs` is `0` when the
+ * worktree has no transcript yet (or the detector has no store to read).
+ */
+export interface TranscriptScan {
+  readonly marker: TurnCompletionMarker | null
+  readonly mtimeMs: number
+}
+
 export abstract class EngineTurnDetector {
   abstract readonly vendor: VendorId
 
@@ -44,8 +57,17 @@ export abstract class EngineTurnDetector {
     return true
   }
 
+  /**
+   * Newest completion marker AND newest transcript mtime for `worktree`
+   * from ONE directory scan. Callers that want both (the daemon's activity
+   * collector) use this so the transcript dir is listed once, not twice.
+   */
+  abstract latestActivity(worktree: string): Promise<TranscriptScan>
+
   /** Newest persisted completion marker for `worktree`, or null when absent. */
-  abstract latestCompletion(worktree: string): Promise<TurnCompletionMarker | null>
+  async latestCompletion(worktree: string): Promise<TurnCompletionMarker | null> {
+    return (await this.latestActivity(worktree)).marker
+  }
 }
 
 /**
@@ -93,8 +115,13 @@ export class ClaudeTurnDetector extends EngineTurnDetector {
     super()
   }
 
-  async latestCompletion(worktree: string): Promise<TurnCompletionMarker | null> {
+  async latestActivity(worktree: string): Promise<TranscriptScan> {
     const files = await this.deps.listSessionFiles(worktree)
+    // `listSessionFiles` sorts newest-first, so `files[0]` is the newest
+    // transcript overall — the same value `latestTranscriptMtimeForWorktree`
+    // returns. Surfacing it here lets the daemon collector skip its own
+    // second directory scan for the mtime.
+    const mtimeMs = files[0]?.mtimeMs ?? 0
     let latest: TurnCompletionMarker | null = null
     const next = new Map<string, { mtimeMs: number; marker: TurnCompletionMarker | null }>()
     for (const file of files.slice(0, 4)) {
@@ -111,7 +138,7 @@ export class ClaudeTurnDetector extends EngineTurnDetector {
       if (marker && (!latest || marker.timestampMs > latest.timestampMs)) latest = marker
     }
     this.cache = next
-    return latest
+    return { marker: latest, mtimeMs }
   }
 }
 
@@ -143,18 +170,21 @@ export class CodexTurnDetector extends EngineTurnDetector {
     super()
   }
 
-  async latestCompletion(worktree: string): Promise<TurnCompletionMarker | null> {
-    if (!worktree) return null
+  async latestActivity(worktree: string): Promise<TranscriptScan> {
+    if (!worktree) return { marker: null, mtimeMs: 0 }
     const found = await this.deps.findLatestRollout(worktree)
-    if (!found) return null
+    if (!found) return { marker: null, mtimeMs: 0 }
+    // `found.mtimeMs` is the newest matching rollout's mtime — identical to
+    // what `latestTranscriptMtimeForWorktree` returns — so surface it even
+    // when the marker parse below yields null (no `turn.completed` yet).
     if (this.cache && this.cache.path === found.path && found.mtimeMs > 0 && this.cache.mtimeMs === found.mtimeMs) {
-      return this.cache.marker
+      return { marker: this.cache.marker, mtimeMs: found.mtimeMs }
     }
     const raw = await this.deps.readFile(found.path).catch(() => "")
-    if (!raw) return null
+    if (!raw) return { marker: null, mtimeMs: found.mtimeMs }
     const marker = latestCodexCompletionMarkerFromJsonl(raw, found.path)
     this.cache = { path: found.path, mtimeMs: found.mtimeMs, marker }
-    return marker
+    return { marker, mtimeMs: found.mtimeMs }
   }
 }
 
@@ -168,8 +198,11 @@ export class UnknownTurnDetector extends EngineTurnDetector {
     return false
   }
 
-  async latestCompletion(): Promise<TurnCompletionMarker | null> {
-    return null
+  // No transcript store this detector can read — no marker, no mtime. The
+  // daemon collector falls back to the vendor's own `latestTranscriptMtime`
+  // (e.g. copilot's) when `supportsCompletionMarkers()` is false.
+  async latestActivity(): Promise<TranscriptScan> {
+    return { marker: null, mtimeMs: 0 }
   }
 }
 

--- a/packages/kobe/test/daemon/transcript-activity-collector.test.ts
+++ b/packages/kobe/test/daemon/transcript-activity-collector.test.ts
@@ -29,10 +29,17 @@ import type { TranscriptActivityPayload } from "@sma1lboy/kobe-daemon/daemon/pro
 import {
   TranscriptActivityCollector,
   type TranscriptActivityEntry,
+  runTranscriptActivity,
   sameTranscriptActivityEntry,
   trackedWorktrees,
 } from "@sma1lboy/kobe-daemon/daemon/transcript-activity-collector"
 import { describe, expect, test } from "vitest"
+import {
+  type HistoryDeps as CodexHistoryDeps,
+  findLatestRolloutForWorktree,
+  latestTranscriptMtimeForWorktree,
+} from "../../src/engine/codex-local/history.ts"
+import { CodexTurnDetector } from "../../src/engine/turn-detector.ts"
 import { type Task, type VendorId, toTaskId } from "../../src/types/task.ts"
 
 /** Minimal Task — only the fields the collector reads. */
@@ -274,5 +281,83 @@ describe("TranscriptActivityCollector", () => {
     collector.tick()
     await settle()
     expect(published).toEqual([])
+  })
+})
+
+/**
+ * The perf fix this suite guards: `runTranscriptActivity` used to make TWO
+ * independent walks of the same codex `sessions` date-tree per probe —
+ * `latestTranscriptMtime` (a full tree readdir) then `detector.latestCompletion`
+ * (another full tree readdir + a stat). The detector already computes the
+ * newest mtime while finding the completion, so one `detector.latestActivity`
+ * call now yields both — ONE tree walk, HALF the stats. This is a deterministic
+ * call-count assertion (readdir/stat spies), not a wall-clock benchmark; a
+ * regression that re-introduces the second walk fails the readdir count.
+ */
+describe("runTranscriptActivity — single codex tree walk", () => {
+  const WT = "/wt"
+  // One rollout under a single day dir, matching the worktree cwd, with a
+  // turn.completed marker so the returned entry carries a completionId.
+  const ROLLOUT = "rollout-2026-05-29T02-00-00-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl"
+  const RAW = JSON.stringify({ type: "turn.completed", timestamp: "2026-05-29T02:00:03.000Z", usage: {} })
+
+  /** Codex `HistoryDeps` that counts every readdir/readFile/stat. */
+  function countingDeps() {
+    const counts = { readdir: 0, readFile: 0, stat: 0, treeReaddir: 0 }
+    const deps: CodexHistoryDeps = {
+      sessionsDir: () => "/sessions",
+      readdir: async (p) => {
+        counts.readdir++
+        // A full tree walk touches exactly these four dirs, in order.
+        if (p === "/sessions") return ["2026"]
+        if (p === "/sessions/2026") return ["05"]
+        if (p === "/sessions/2026/05") return ["29"]
+        if (p === "/sessions/2026/05/29") {
+          counts.treeReaddir++
+          return [ROLLOUT]
+        }
+        return []
+      },
+      readFile: async () => {
+        counts.readFile++
+        return `${JSON.stringify({ type: "session_meta", payload: { cwd: WT } })}\n${RAW}`
+      },
+      stat: async () => {
+        counts.stat++
+        return { mtimeMs: 2000 }
+      },
+    }
+    // The detector's deps (findLatestRollout / readFile) delegate into the
+    // SAME counting HistoryDeps, so a detector probe drives (and counts) a
+    // real codex date-tree walk exactly as production does.
+    const detector = new CodexTurnDetector({
+      findLatestRollout: (wt) => findLatestRolloutForWorktree(wt, deps),
+      readFile: (p) => deps.readFile(p),
+    })
+    return { deps, counts, detector }
+  }
+
+  test("probes the date-tree once and returns byte-identical facts to the old two-walk path", async () => {
+    // Correctness pin: recompute the OLD path's result (mtime from the
+    // standalone reader + marker from the detector) over an INDEPENDENT deps
+    // instance, then assert the fused single-walk probe matches it exactly.
+    const oldSide = countingDeps()
+    const oldMtime = await latestTranscriptMtimeForWorktree(WT, oldSide.deps)
+    const oldMarker = await oldSide.detector.latestCompletion(WT)
+    const expected: TranscriptActivityEntry = {
+      mtimeMs: oldMtime,
+      completionId: oldMarker?.id ?? null,
+      completionAt: oldMarker?.timestampMs ?? 0,
+    }
+    // The old path walked the day dir TWICE (once per reader).
+    expect(oldSide.counts.treeReaddir).toBe(2)
+
+    const newSide = countingDeps()
+    const got = await runTranscriptActivity(WT, "codex", newSide.detector, new AbortController().signal)
+
+    expect(got).toEqual(expected)
+    // AFTER the fix: exactly ONE day-dir readdir, and half the stats.
+    expect(newSide.counts.treeReaddir).toBe(1)
+    expect(newSide.counts.stat).toBe(oldSide.counts.stat / 2)
   })
 })


### PR DESCRIPTION
The ~1.5s tick made two independent directory listings of the same
transcript store per worktree — latestTranscriptMtime then the turn
detector's latestCompletion, each doing its own readdir (+ a full
~/.codex/sessions date-tree walk for codex). The detector already
computes the newest mtime while locating the completion, so it now
surfaces both from one scan (latestActivity); the probe drops the
redundant mtime call for claude/codex and keeps copilot's single
existing walk. Published facts stay byte-identical; a counting-spy
test pins the day-dir readdir at 1 (was 2) and the returned entry
unchanged.
