### PR TITLE
refactor: extract tab exit/resume/split-collapse decisions into terminal-tabs-core

### DIFF
--- a/.changeset/tab-exit-policy-pure.md
+++ b/.changeset/tab-exit-policy-pure.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Extract the remaining terminal tab/split decision logic out of the React components into the framework-free `terminal-tabs-core` module — the engine-tab resume-vs-pin argv choice (`engineTabArgv`), the tab exit policy (`tabExitAction`: close / one-shot resume / degrade to shell), the split collapse-to-unsplit rule (`collapseSplit`), and the is-split keybinding gate (`isTabSplit`) — with unit coverage for each. Behavior-invariant; `TerminalTabs`/`TerminalSplit` now only dispatch.

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -50,7 +50,13 @@ import {
   renameLeaf,
   splitActive,
 } from "../../tui/workspace/split-core"
-import { type PersistedSplit, splitLeafNames, splitLeafPtyKey } from "../../tui/workspace/terminal-tabs-core"
+import {
+  type PersistedSplit,
+  collapseSplit,
+  isTabSplit,
+  splitLeafNames,
+  splitLeafPtyKey,
+} from "../../tui/workspace/terminal-tabs-core"
 import { RenameTaskDialog } from "../component/rename-task-dialog"
 import { bindByIds } from "../context/keybindings"
 import { useKV } from "../context/kv"
@@ -128,22 +134,16 @@ export function TerminalSplit(props: {
    *  leaf (split / remove / cycle operate relative to it). */
   const fullState = (): PersistedSplit => ({ ...state, activeLeafId: activeLeaf })
 
-  // Persist a STRUCTURAL change through the parent; clearing to a single
-  // leaf drops the tree so an unsplit tab returns to the fast path. Focus
+  // Persist a STRUCTURAL change through the parent; the collapse-to-null
+  // rule (sole survivor is leaf-1 → back to the unsplit fast path, a sole
+  // surviving SHELL leaf keeps the tree) is pure — `collapseSplit`. Focus
   // changes do NOT come here — they use `setActiveLeaf` (local).
   const update = (next: SplitState<LeafCommand>): void => {
     if (next === state) return
-    const ls = leaves(next.root)
-    // Collapse to the unsplit fast path (null) ONLY when the sole survivor
-    // is leaf-1 — the tab's own engine at `tabKey`. A sole surviving SHELL
-    // leaf (you closed the engine leaf) must KEEP the tree so the tree
-    // renderer shows the shell at `tabKey::leaf-N`; the fast path would
-    // respawn the engine (`props.command` at `tabKey`) instead.
-    const collapsesToEngine = ls.length === 1 && ls[0]?.id === "leaf-1"
-    props.onSplitChange(collapsesToEngine ? null : next)
+    props.onSplitChange(collapseSplit(next))
   }
 
-  const isSplit = leaves(state.root).length > 1
+  const isSplit = isTabSplit(state)
   // Split appearance (Settings → General → Appearance): `box` frames every
   // leaf, `line` draws only shared-edge dividers. Frames apply only while
   // ACTUALLY split — a lone surviving leaf inside the already-bordered
@@ -151,9 +151,9 @@ export function TerminalSplit(props: {
   const useBoxFrames = normalizeSplitStyle(kv.get(SPLIT_STYLE_KEY)) === "box" && isSplit
   // Render via the split tree (not the single-engine fast path) whenever
   // there are multiple leaves OR a single NON-leaf-1 leaf survives (engine
-  // closed, shell kept). Only the pristine leaf-1 engine uses the fast path.
-  const stateLeaves = leaves(state.root)
-  const renderViaTree = stateLeaves.length > 1 || stateLeaves[0]?.id !== "leaf-1"
+  // closed, shell kept). Only the pristine leaf-1 engine uses the fast
+  // path — exactly the trees `collapseSplit` would fold to null.
+  const renderViaTree = collapseSplit(state) !== null
 
   /** Remove `id` from the tree and kill its PTY. False when `id` is the
    *  last leaf (nothing removed). State first (the re-render detaches the

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -49,7 +49,6 @@ import { type ReactNode, useEffect, useRef, useState } from "react"
 import { defaultShell } from "../../tui/panes/terminal/pty-types"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { waitAndDeliverInitialPrompt } from "../../tui/workspace/quick-fork-delivery"
-import { leaves } from "../../tui/workspace/split-core"
 import {
   type EngineTab,
   type TabsState,
@@ -57,13 +56,16 @@ import {
   closeActiveTab,
   closeTab,
   cycleTab,
+  engineTabArgv,
   initialTabs,
+  isTabSplit,
   openEditorTab,
   rehydrateTabs,
   renameActiveTab,
   selectTab,
   setTabSessionId,
   setTabSplit,
+  tabExitAction,
   tabPtyKey,
   tabToShell,
 } from "../../tui/workspace/terminal-tabs-core"
@@ -168,13 +170,11 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
     kv.set(persistKey, next)
   }
 
-  /** Engine-tab argv: the tab's pinned session id rides the base command. */
+  /** Engine-tab argv: the tab's pinned session id rides the base command
+   *  (resume-vs-pin decision is pure — `engineTabArgv`). */
   const engineTabCommand = (tab: EngineTab): readonly string[] => {
     const base = tab.vendor ? interactiveEngineCommand(tab.vendor, props.modelEffort) : props.command
-    if (!tab.sessionId) return base
-    const live = getDefaultPtyRegistry().has(tabPtyKey(props.taskId, tab.id))
-    if (tab.spawned && !live) return [...base, "--resume", tab.sessionId]
-    return [...base, "--session-id", tab.sessionId]
+    return engineTabArgv(tab, base, getDefaultPtyRegistry().has(tabPtyKey(props.taskId, tab.id)))
   }
   // Latest-render mirror for the mount-once engine-send closure below —
   // same freshness convention as propsRef/stateRef (file header).
@@ -307,16 +307,17 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   const resumeTriedRef = useRef(new Set<string>())
 
   function handleActiveExit(info?: { deadOnAttach?: boolean }): void {
-    if (active.kind === "command") {
+    // Policy is pure (`tabExitAction`): command tabs close; a corpse found
+    // on reattach (host restart, park-sweep window, machine reboot) gets
+    // ONE resume — releasing the dead handle makes `engineTabCommand`
+    // build `--resume <sessionId>` on the re-acquire (`spawned && !live`),
+    // the restart-survival path; everything else degrades to a shell.
+    const action = tabExitAction(active, info?.deadOnAttach === true, resumeTriedRef.current.has(active.id))
+    if (action === "close") {
       closeExitedTab(active.id)
       return
     }
-    // Reattach found a corpse (the engine died while no TUI was attached
-    // — host restart, park-sweep window, machine reboot): resume the
-    // conversation instead of silently degrading. Releasing the dead
-    // handle makes `engineTabCommand` build `--resume <sessionId>` on the
-    // re-acquire (`spawned && !live`) — the restart-survival path.
-    if (info?.deadOnAttach && active.sessionId && active.spawned && !resumeTriedRef.current.has(active.id)) {
+    if (action === "resume") {
       resumeTriedRef.current.add(active.id)
       getDefaultPtyRegistry().release(tabPtyKey(props.taskId, active.id))
       setResetToken((n) => n + 1)
@@ -414,7 +415,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   // actually split (>1 leaf) so the chords fall through the LIFO stack to
   // the leaf bindings — the Solid-era precedence, restored by gating
   // instead of ordering.
-  const activeIsSplit = active.splitTree ? leaves(active.splitTree.root).length > 1 : false
+  const activeIsSplit = isTabSplit(active.splitTree)
   useBindings(() => ({
     enabled: props.focused && !activeIsSplit,
     bindings: bindByIds({

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -239,6 +239,38 @@ export function markTabSpawned(state: TabsState, id: string): TabsState {
 }
 
 /**
+ * Argv for an engine tab's PTY spawn. `base` is the tab's engine command
+ * (vendor-pinned or the task's); `live` is whether the tab's PTY currently
+ * exists in the registry. No pinned session id → the bare command (codex/
+ * custom vendors). A tab that already spawned but has NO live PTY (host
+ * restart, degrade re-acquire) resumes its conversation; otherwise the id
+ * is pinned fresh — the flag shapes ride `withClaudeSessionId`'s existing
+ * per-vendor contract, verbatim from the component it was extracted from.
+ */
+export function engineTabArgv(tab: EngineTab, base: readonly string[], live: boolean): readonly string[] {
+  if (!tab.sessionId) return base
+  if (tab.spawned && !live) return [...base, "--resume", tab.sessionId]
+  return [...base, "--session-id", tab.sessionId]
+}
+
+export type TabExitAction = "close" | "resume" | "degrade"
+
+/**
+ * Policy for the ACTIVE tab's process exiting. Command tabs close
+ * themselves (editor quit, degraded shell exit). An engine tab found dead
+ * ON ATTACH (host restart / park-sweep corpse) with a resumable session
+ * gets ONE resume attempt — `resumeTried` is the per-tab one-shot guard,
+ * so a `--resume` that itself dies degrades normally instead of
+ * respawning forever. Every other engine exit degrades the tab to a
+ * plain shell in place (exiting the vendor CLI is allowed, not an error).
+ */
+export function tabExitAction(tab: TerminalTab, deadOnAttach: boolean, resumeTried: boolean): TabExitAction {
+  if (tab.kind === "command") return "close"
+  if (deadOnAttach && !!tab.sessionId && tab.spawned && !resumeTried) return "resume"
+  return "degrade"
+}
+
+/**
  * Rehydrate a persisted tab snapshot (issue #22). A tab is a TERMINAL
  * (owner model 2026-07-07): claude/an editor are just processes that ran
  * in it, so EVERY tab survives restart. Engine tabs keep their identity
@@ -300,6 +332,30 @@ export function setTabSplit(state: TabsState, id: string, tree: PersistedSplit |
  */
 export function hasEngineLeaf(tree: PersistedSplit | null | undefined): boolean {
   return !tree || leaves(tree.root).some((l) => l.id === "leaf-1")
+}
+
+/**
+ * Whether a tab's frozen layout is ACTUALLY split (>1 leaf). Gates the
+ * ctrl+w / F2 chord fall-through between `TerminalTabs` and
+ * `TerminalSplit`: while split, the tab-level close/rename bindings
+ * disable so the chords reach the leaf-level ones, and vice versa. A
+ * single surviving non-leaf-1 shell is NOT split — tab-level chords apply.
+ */
+export function isTabSplit(tree: PersistedSplit | null | undefined): boolean {
+  return tree ? leaves(tree.root).length > 1 : false
+}
+
+/**
+ * Collapse rule for a structural split edit: a tree whose SOLE survivor
+ * is `leaf-1` (the tab's own engine at the tab key) folds back to `null`
+ * — the unsplit fast path. A sole surviving SHELL leaf must KEEP the
+ * tree: the fast path would respawn the engine (`props.command` at the
+ * tab key) over it. Doubles as the render predicate — a non-null result
+ * means the tab renders via the tree, not the single-engine fast path.
+ */
+export function collapseSplit(next: PersistedSplit): PersistedSplit | null {
+  const ls = leaves(next.root)
+  return ls.length === 1 && ls[0]?.id === "leaf-1" ? null : next
 }
 
 /** Registry key for one tab's PTY — namespaced so tabs never collide. */

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest"
 import { initialSplit, removeLeaf, splitActive } from "../../src/tui/workspace/split-core"
 import {
+  type EngineTab,
   addTab,
   closeActiveTab,
+  collapseSplit,
   cycleTab,
+  engineTabArgv,
   hasEngineLeaf,
   initialTabs,
+  isTabSplit,
   markTabSpawned,
   openEditorTab,
   rehydrateTabs,
@@ -15,6 +19,7 @@ import {
   setTabSessionId,
   setTabSpawned,
   setTabSplit,
+  tabExitAction,
   tabPtyKey,
   tabToShell,
 } from "../../src/tui/workspace/terminal-tabs-core"
@@ -226,5 +231,69 @@ describe("terminal tabs state", () => {
     const engineClosed = removeLeaf(split, "leaf-1")
     expect(engineClosed).not.toBeNull()
     expect(hasEngineLeaf(engineClosed)).toBe(false) // only the shell survives
+  })
+
+  // Why: this argv decision IS the restart-survival contract (issue #22) —
+  // `--resume` must fire ONLY for a tab that already conversed and has no
+  // live PTY; a live PTY (re-render churn) or a never-spawned tab must
+  // keep pinning the fresh id, or claude errors "no conversation found".
+  it("engineTabArgv: pin fresh, resume dead spawned sessions, bare when unpinnable", () => {
+    const tab = (over: Partial<EngineTab>): EngineTab => ({
+      kind: "engine",
+      id: "tab-1",
+      title: null,
+      ordinal: 1,
+      ...over,
+    })
+    const base = ["claude"] as const
+    // No session id (codex/custom vendors) → the bare command, always.
+    expect(engineTabArgv(tab({ sessionId: null }), base, false)).toEqual(["claude"])
+    // Fresh tab (never spawned) → pin the id.
+    expect(engineTabArgv(tab({ sessionId: "u1" }), base, false)).toEqual(["claude", "--session-id", "u1"])
+    // Spawned + PTY still live (ordinary re-render) → keep pinning.
+    expect(engineTabArgv(tab({ sessionId: "u1", spawned: true }), base, true)).toEqual(["claude", "--session-id", "u1"])
+    // Spawned + PTY gone (host restart / degrade re-acquire) → resume.
+    expect(engineTabArgv(tab({ sessionId: "u1", spawned: true }), base, false)).toEqual(["claude", "--resume", "u1"])
+  })
+
+  // Why: the exit policy decides between three irreversible side-effect
+  // paths (close tab / one-shot resume / degrade to shell). The one-shot
+  // guard is load-bearing: without it a `--resume` that itself dies
+  // respawns forever.
+  it("tabExitAction: command closes; dead-on-attach resumes once; everything else degrades", () => {
+    const engine: EngineTab = { kind: "engine", id: "tab-1", title: null, ordinal: 1, sessionId: "u1", spawned: true }
+    expect(
+      tabExitAction({ kind: "command", id: "tab-2", title: null, ordinal: 2, command: ["zsh"] }, true, false),
+    ).toBe("close")
+    expect(tabExitAction(engine, true, false)).toBe("resume")
+    expect(tabExitAction(engine, true, true)).toBe("degrade") // resume already tried once
+    expect(tabExitAction(engine, false, false)).toBe("degrade") // live exit (user quit the CLI)
+    expect(tabExitAction({ ...engine, sessionId: null }, true, false)).toBe("degrade") // nothing to resume
+    expect(tabExitAction({ ...engine, spawned: undefined }, true, false)).toBe("degrade") // never conversed
+  })
+
+  // Why: collapse decides persistence (null = unsplit fast path) AND the
+  // render path. Folding a sole surviving SHELL leaf would respawn the
+  // engine over it — the tree must survive; only a pristine leaf-1 folds.
+  it("collapseSplit folds only a sole-survivor leaf-1; isTabSplit gates the chord fall-through", () => {
+    const unsplit = initialSplit<readonly string[] | null>(null)
+    expect(collapseSplit(unsplit)).toBeNull()
+    expect(isTabSplit(null)).toBe(false)
+    expect(isTabSplit(unsplit)).toBe(false)
+    const split = splitActive(unsplit, "row", ["/bin/zsh"]) // leaf-1 | leaf-2
+    expect(collapseSplit(split)).toBe(split) // still split → keep the tree
+    expect(isTabSplit(split)).toBe(true)
+    // Close the shell leaf → back to the pristine engine → fold to null.
+    const shellClosed = removeLeaf(split, "leaf-2")
+    expect(shellClosed).not.toBeNull()
+    if (shellClosed) expect(collapseSplit(shellClosed)).toBeNull()
+    // Close the ENGINE leaf → the sole shell survivor keeps the tree, and
+    // tab-level ctrl+w / F2 apply again (not split anymore).
+    const engineClosed = removeLeaf(split, "leaf-1")
+    expect(engineClosed).not.toBeNull()
+    if (engineClosed) {
+      expect(collapseSplit(engineClosed)).toBe(engineClosed)
+      expect(isTabSplit(engineClosed)).toBe(false)
+    }
   })
 })


### PR DESCRIPTION
The tab-list and split-tree state machines already lived framework-free in
terminal-tabs-core.ts/split-core.ts; this moves the four decision rules that
were still inline in the React components — engineTabArgv (resume-vs-pin),
tabExitAction (close/one-shot-resume/degrade), collapseSplit (fold-to-unsplit,
doubling as the render-path predicate), and isTabSplit (the ctrl+w/F2 chord
fall-through gate). Behavior-invariant; each rule gains unit coverage.
