### PR TITLE
refactor: declare modal keymap scope explicitly + extract dialog gating predicate

### DIFF
--- a/.changeset/modal-scope-declared.md
+++ b/.changeset/modal-scope-declared.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Modal keybinding precedence is now declared data, not a React effect-order accident.
+
+The dialog barrier and dialog-body bindings used to resolve their precedence by which effect happened to commit first (sibling tree order) — documented only in a comment and pinned by no test. Registrations now carry an explicit modal scope (`modalOwner` on the barrier, membership stamped via `ModalScopeContext`), and a pure `insertRegistration` slots the barrier below its members under either registration order; dispatch itself is unchanged. Workspace-host dialog/page gating is consolidated into named, framework-free predicates (`workspacePagesClosed` / `settingsCloseKeysEnabled`) with unit tests, including the negative case (open dialog disables workspace chords) and the deliberate settings-close exemption. No chords added, moved, or rebound.

--- a/packages/kobe/src/tui-react/lib/keymap.ts
+++ b/packages/kobe/src/tui-react/lib/keymap.ts
@@ -16,19 +16,35 @@
  * up on top); React registers in mount EFFECTS (children before parents →
  * ancestors end up on top). Consequence: a parent and child sharing a chord
  * must resolve by GATING, not stack order — the parent's entry disables
- * itself when the child should win. Cases today: the dialog provider's
- * escape/ctrl+c pair (gates on the dialog stack being non-empty) and
- * TerminalTabs' ctrl+w/F2 (gate off while the active tab is split so
- * TerminalSplit's leaf-level close/rename fire).
+ * itself when the child should win. Case today: TerminalTabs' ctrl+w/F2
+ * (gate off while the active tab is split so TerminalSplit's leaf-level
+ * close/rename fire). Modal barrier vs dialog body is NOT resolved by
+ * order anymore — it's declared via `ModalScopeContext` + `modalOwner`
+ * below and settled by `insertRegistration`.
  */
 
 import type { KeyEvent, KeyHandler } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
-import { useEffect, useRef } from "react"
-import { type BindingsConfig, type RegisteredBinding, dispatchKeyEvent } from "../../tui/lib/keymap-dispatch"
+import { createContext, useContext, useEffect, useRef } from "react"
+import {
+  type BindingsConfig,
+  type RegisteredBinding,
+  dispatchKeyEvent,
+  insertRegistration,
+} from "../../tui/lib/keymap-dispatch"
 
 export type { Binding, BindingsConfig, RegisteredBinding } from "../../tui/lib/keymap-dispatch"
 export { dispatchKeyEvent } from "../../tui/lib/keymap-dispatch"
+
+/**
+ * Modal-scope context: a provider (the dialog overlay) sets a scope token;
+ * every `useBindings` mounted inside is stamped as a MEMBER of that scope,
+ * and the barrier declares OWNERSHIP via `useBindings`'s `modalOwner`
+ * option. `insertRegistration` (keymap-dispatch.ts) then places the barrier
+ * below its members no matter which effect committed first — the explicit
+ * replacement for the old "sibling order is load-bearing" contract.
+ */
+export const ModalScopeContext = createContext<symbol | null>(null)
 
 let nextId = 1
 const stack: RegisteredBinding[] = []
@@ -73,17 +89,31 @@ function ensureInstalled(renderer: ReturnType<typeof useRenderer>): void {
  * Register a set of bindings for the lifetime of the calling component.
  * The `config` function is re-evaluated on every keypress via a ref, so
  * `enabled` flags computed from the latest render stay correct.
+ *
+ * Modal semantics are declared, not positional: a component inside a
+ * `ModalScopeContext` provider registers as a member of that scope; the
+ * barrier passes `modalOwner` and is slotted below its members by
+ * `insertRegistration`. Both tokens are read at mount (the scope symbol is
+ * stable for the provider's lifetime), matching the mount-once effect.
  */
-export function useBindings(config: () => BindingsConfig): void {
+export function useBindings(config: () => BindingsConfig, opts?: { modalOwner?: symbol }): void {
   const renderer = useRenderer()
   ensureInstalled(renderer)
 
   const configRef = useRef(config)
   configRef.current = config
+  const scope = useContext(ModalScopeContext)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once registration; scope/owner tokens are stable for the component's lifetime.
   useEffect(() => {
-    const reg: RegisteredBinding = { config: () => configRef.current(), id: nextId++ }
-    stack.push(reg)
+    const reg: RegisteredBinding = {
+      config: () => configRef.current(),
+      id: nextId++,
+      modalOwner: opts?.modalOwner,
+      // The owner of a scope is not a member of it — it must sit below.
+      modalMember: opts?.modalOwner === undefined ? (scope ?? undefined) : undefined,
+    }
+    insertRegistration(stack, reg)
     return () => {
       const i = stack.findIndex((r) => r.id === reg.id)
       if (i >= 0) stack.splice(i, 1)

--- a/packages/kobe/src/tui-react/ui/dialog.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog.tsx
@@ -19,7 +19,7 @@ import { RGBA, type Renderable } from "@opentui/core"
 import { useRenderer, useTerminalDimensions } from "@opentui/react"
 import { type ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import { useTheme } from "../context/theme"
-import { useBindings } from "../lib/keymap"
+import { ModalScopeContext, useBindings } from "../lib/keymap"
 
 export type DialogSize = "small" | "medium" | "large" | "xlarge"
 
@@ -217,22 +217,26 @@ export function DialogProvider(props: { children?: ReactNode }) {
       {props.children}
       <box position="absolute" zIndex={3000}>
         {top ? (
-          <>
-            {/* Sibling ORDER is load-bearing: React commits effects
-                depth-first in tree order, so the barrier registers BEFORE
-                the dialog body's own useBindings — body keys sit above the
-                barrier (reachable), every pane registered earlier sits
-                below it (cut off). */}
+          // Modal precedence is DECLARED, not positional: everything inside
+          // this ModalScopeContext (the dialog body's useBindings) registers
+          // as a member of MODAL_SCOPE; the barrier declares ownership of it
+          // and insertRegistration (keymap-dispatch.ts) slots the barrier
+          // below its members — body keys win, panes registered earlier are
+          // cut off — regardless of effect-commit order.
+          <ModalScopeContext value={MODAL_SCOPE}>
             <ModalBarrier dismissTop={dismissTop} />
             <Dialog onClose={() => value.clear()} size={size}>
               {top.element()}
             </Dialog>
-          </>
+          </ModalScopeContext>
         ) : null}
       </box>
     </ctx.Provider>
   )
 }
+
+/** One process, one dialog overlay → one scope token (module-stable). */
+const MODAL_SCOPE = Symbol("kobe.dialog.modal")
 
 /**
  * Mounted exactly while a dialog is up. Owns the esc/ctrl+c dismiss keys
@@ -241,15 +245,22 @@ export function DialogProvider(props: { children?: ReactNode }) {
  * reaching the panes behind the dialog. Structural fix for the "dialog is
  * open but keys still operate the background" bug class — background
  * bindings no longer rely on their own `dialog.stack.length === 0` gates.
+ *
+ * `modalOwner` (stack position: below the body's member registrations) and
+ * `modal: true` (dispatch cut-off) together are the explicit contract —
+ * see RegisteredBinding in keymap-dispatch.ts.
  */
 function ModalBarrier(props: { dismissTop: () => void }) {
-  useBindings(() => ({
-    modal: true,
-    bindings: [
-      { key: "escape", cmd: props.dismissTop },
-      { key: "ctrl+c", cmd: props.dismissTop },
-    ],
-  }))
+  useBindings(
+    () => ({
+      modal: true,
+      bindings: [
+        { key: "escape", cmd: props.dismissTop },
+        { key: "ctrl+c", cmd: props.dismissTop },
+      ],
+    }),
+    { modalOwner: MODAL_SCOPE },
+  )
   return null
 }
 

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -24,6 +24,7 @@ import { useT } from "../i18n"
 import { useBindings } from "../lib/keymap"
 import type { DialogContext } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
+import { type WorkspacePageState, settingsCloseKeysEnabled, workspacePagesClosed } from "./keybinding-gates"
 
 // Slot 3 (ctrl+l — "terminal" in the 4-pane model) maps back to workspace:
 // this host is 3-pane and its middle column IS the terminal, so ctrl+l
@@ -89,7 +90,16 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
     focus.setFocused(PANE_CYCLE[next] as PaneId)
   }
 
-  const pagesClosed = deps.dialog.stack.length === 0 && !deps.settingsOpen && !deps.worktreesOpen && !deps.updateOpen
+  // One named predicate instead of inline `dialog.stack.length === 0 && …`
+  // expressions — the open-page gating contract is unit-tested in
+  // test/tui-react/keybinding-gates.test.ts.
+  const pages: WorkspacePageState = {
+    dialogOpen: deps.dialog.stack.length > 0,
+    settingsOpen: deps.settingsOpen,
+    worktreesOpen: deps.worktreesOpen,
+    updateOpen: deps.updateOpen,
+  }
+  const pagesClosed = workspacePagesClosed(pages)
 
   useBindings(() => ({
     enabled: pagesClosed,
@@ -162,7 +172,7 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
   // page binds them itself; gated on an empty dialog stack so a sub-dialog,
   // e.g. the engine-command editor, keeps esc/typing for itself).
   useBindings(() => ({
-    enabled: deps.settingsOpen && deps.dialog.stack.length === 0,
+    enabled: settingsCloseKeysEnabled(pages),
     bindings: [
       { key: "escape", cmd: deps.closeSettings },
       { key: "q", cmd: deps.closeSettings },

--- a/packages/kobe/src/tui-react/workspace/keybinding-gates.ts
+++ b/packages/kobe/src/tui-react/workspace/keybinding-gates.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure gating predicates for the workspace host's keybindings
+ * (host-keybindings.ts). Framework-free on purpose: vitest can import this
+ * without pulling in `@opentui/react`, so the "an open dialog/page disables
+ * workspace chords" contract is pinned by a unit test instead of living as
+ * scattered inline boolean expressions.
+ *
+ * Note the ModalBarrier (ui/dialog.tsx) already cuts dialog-open keys off
+ * structurally; `dialogOpen` here is defense in depth for dialogs and the
+ * ONLY gate for the full-page swaps (settings/worktrees/update), which are
+ * not dialogs and mount no barrier.
+ */
+
+export type WorkspacePageState = {
+  /** `dialog.stack.length > 0` — any dialog up on the shared stack. */
+  dialogOpen: boolean
+  settingsOpen: boolean
+  worktreesOpen: boolean
+  updateOpen: boolean
+}
+
+/**
+ * Every workspace-level chord group (help/focus/quit/task-lifecycle…) is
+ * gated on this: no dialog AND no full-page swap open. The one deliberate
+ * exemption in host-keybindings.ts is {@link settingsCloseKeysEnabled}.
+ */
+export function workspacePagesClosed(s: WorkspacePageState): boolean {
+  return !s.dialogOpen && !s.settingsOpen && !s.worktreesOpen && !s.updateOpen
+}
+
+/**
+ * The settings page's own close keys (esc/q/ctrl+c) — deliberately exempt
+ * from {@link workspacePagesClosed}: they are live exactly BECAUSE the
+ * settings page is open, but yield to any sub-dialog above it (e.g. the
+ * engine-command editor needs esc + typed keys for itself).
+ */
+export function settingsCloseKeysEnabled(s: WorkspacePageState): boolean {
+  return s.settingsOpen && !s.dialogOpen
+}

--- a/packages/kobe/src/tui/lib/keymap-dispatch.ts
+++ b/packages/kobe/src/tui/lib/keymap-dispatch.ts
@@ -53,6 +53,40 @@ export type BindingsConfig = {
 export type RegisteredBinding = {
   config: () => BindingsConfig
   id: number
+  /**
+   * Modal-scope declaration (static, set at registration — unlike `config`,
+   * never re-read per keypress). Together with {@link insertRegistration}
+   * this makes barrier-vs-body precedence a function of DECLARED DATA
+   * instead of registration (React effect-commit) order:
+   *   - `modalOwner`: this entry IS the modal barrier for that scope token.
+   *     Its `config()` should also return `modal: true` — the owner field
+   *     governs stack POSITION, `config.modal` governs the dispatch cut-off.
+   *   - `modalMember`: this entry belongs INSIDE that scope (a dialog
+   *     body's bindings) and must stay reachable above the barrier.
+   */
+  modalOwner?: symbol
+  modalMember?: symbol
+}
+
+/**
+ * Insert a registration into the live binding stack. Plain entries push
+ * (LIFO, unchanged). A modal OWNER (barrier) is inserted BELOW the lowest
+ * already-registered MEMBER of its scope, so members win over the barrier
+ * and the barrier still cuts off everything older — regardless of whether
+ * React committed the body's effects before or after the barrier's. This
+ * is the explicit contract that used to be an effect-commit-order accident
+ * (see tui-react/ui/dialog.tsx). O(n) only at mount/unmount, never on the
+ * per-keypress dispatch path.
+ */
+export function insertRegistration(stack: RegisteredBinding[], reg: RegisteredBinding): void {
+  if (reg.modalOwner !== undefined) {
+    const firstMember = stack.findIndex((r) => r.modalMember === reg.modalOwner)
+    if (firstMember >= 0) {
+      stack.splice(firstMember, 0, reg)
+      return
+    }
+  }
+  stack.push(reg)
 }
 
 /**

--- a/packages/kobe/test/render/dialog-stack.test.tsx
+++ b/packages/kobe/test/render/dialog-stack.test.tsx
@@ -170,6 +170,42 @@ describe("DialogProvider", () => {
     expect(background).toBe(2)
   })
 
+  // The other half of the modal contract: bindings registered BY the dialog
+  // body must stay reachable above the barrier. Precedence is declared
+  // (ModalScopeContext membership + the barrier's modalOwner slot in
+  // insertRegistration), not an effect-commit-order accident — this pins the
+  // context stamping end-to-end through the real provider.
+  it("dialog body bindings fire while the barrier blocks the background", async () => {
+    let body = 0
+    let background = 0
+    function Background() {
+      useBindings(() => ({ bindings: [{ key: "j", cmd: () => background++ }] }))
+      return <text>bg</text>
+    }
+    function Body() {
+      useBindings(() => ({ bindings: [{ key: "j", cmd: () => body++ }] }))
+      return <text>dialog A</text>
+    }
+    const dialogRef: { current?: ReturnType<typeof useDialog> } = {}
+    const { frame, mockInput } = await renderComponent(
+      <DialogProvider>
+        <Background />
+        <Driver
+          onMount={(dialog) => {
+            dialogRef.current = dialog
+          }}
+        />
+      </DialogProvider>,
+    )
+    await frame()
+    act(() => dialogRef.current?.push(() => <Body />))
+    expect(await frame()).toContain("dialog A")
+    act(() => mockInput.pressKey("j"))
+    await settle()
+    expect(body).toBe(1)
+    expect(background).toBe(0)
+  })
+
   it("clear empties the whole stack at once", async () => {
     const dialogRef: { current?: ReturnType<typeof useDialog> } = {}
     const { frame } = await renderComponent(

--- a/packages/kobe/test/tui-react/keybinding-gates.test.ts
+++ b/packages/kobe/test/tui-react/keybinding-gates.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Pins the workspace-host gating contract (workspace/keybinding-gates.ts):
+ * an open dialog or full-page swap disables every workspace chord group,
+ * and the ONE deliberate exemption — the settings page's own close keys —
+ * is live exactly while settings is open with no sub-dialog above it.
+ * Previously these were inline `dialog.stack.length === 0 && …` expressions
+ * in host-keybindings.ts with no test.
+ */
+
+import { describe, expect, test } from "vitest"
+import {
+  type WorkspacePageState,
+  settingsCloseKeysEnabled,
+  workspacePagesClosed,
+} from "../../src/tui-react/workspace/keybinding-gates"
+
+const closed: WorkspacePageState = {
+  dialogOpen: false,
+  settingsOpen: false,
+  worktreesOpen: false,
+  updateOpen: false,
+}
+
+describe("workspacePagesClosed", () => {
+  test("true only when nothing is open", () => {
+    expect(workspacePagesClosed(closed)).toBe(true)
+  })
+
+  test("an open dialog disables workspace bindings", () => {
+    expect(workspacePagesClosed({ ...closed, dialogOpen: true })).toBe(false)
+  })
+
+  test.each(["settingsOpen", "worktreesOpen", "updateOpen"] as const)("an open %s page disables them too", (page) => {
+    expect(workspacePagesClosed({ ...closed, [page]: true })).toBe(false)
+  })
+})
+
+describe("settingsCloseKeysEnabled — the deliberate exemption", () => {
+  test("live while the settings page is open (workspace chords are NOT)", () => {
+    const state = { ...closed, settingsOpen: true }
+    expect(settingsCloseKeysEnabled(state)).toBe(true)
+    expect(workspacePagesClosed(state)).toBe(false)
+  })
+
+  test("yields to a sub-dialog above the settings page (esc/typing stay with the dialog)", () => {
+    expect(settingsCloseKeysEnabled({ ...closed, settingsOpen: true, dialogOpen: true })).toBe(false)
+  })
+
+  test("dead while settings is closed", () => {
+    expect(settingsCloseKeysEnabled(closed)).toBe(false)
+    expect(settingsCloseKeysEnabled({ ...closed, worktreesOpen: true })).toBe(false)
+  })
+})

--- a/packages/kobe/test/tui/keymap-dispatch.test.ts
+++ b/packages/kobe/test/tui/keymap-dispatch.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { beforeEach, describe, expect, test, vi } from "vitest"
-import { type RegisteredBinding, dispatchKeyEvent } from "../../src/tui/lib/keymap-dispatch"
+import { type RegisteredBinding, dispatchKeyEvent, insertRegistration } from "../../src/tui/lib/keymap-dispatch"
 
 // Silence + capture the shadowed-match warning (several LIFO tests below
 // stack two enabled same-chord bindings on purpose). NOTE: the warning
@@ -490,6 +490,103 @@ describe("dispatchKeyEvent", () => {
       expect(dispatchKeyEvent(stack, evt)).toBe(true)
       expect(dismissed).toBe(1)
       expect(evt.defaultPrevented).toBe(true)
+    })
+
+    // Declared modal scope (insertRegistration): barrier-vs-body precedence
+    // used to be an accident of React committing the barrier's effect before
+    // the body's (sibling tree order). It is now declared data — the barrier
+    // carries `modalOwner`, body entries carry `modalMember`, and
+    // insertRegistration slots the barrier BELOW its members. These tests pin
+    // the invariant under BOTH registration orders.
+    describe("declared scope — order independence", () => {
+      const SCOPE = Symbol("test.modal")
+
+      function barrier(id: number, onEsc: () => void): RegisteredBinding {
+        return {
+          id,
+          modalOwner: SCOPE,
+          config: () => ({ modal: true, bindings: [{ key: "escape", cmd: onEsc }] }),
+        }
+      }
+      function body(id: number, key: string, cmd: () => void): RegisteredBinding {
+        return { id, modalMember: SCOPE, config: () => ({ bindings: [{ key, cmd }] }) }
+      }
+
+      /** Run the barrier/body/background assertions against a built stack. */
+      function assertModalContract(stack: RegisteredBinding[], counts: { body: number; bg: number; esc: number }) {
+        // Body key wins (reachable above the barrier) …
+        expect(dispatchKeyEvent(stack, makeEvt("j"))).toBe(true)
+        expect(counts.body).toBe(1)
+        // … background is cut off wholesale …
+        expect(dispatchKeyEvent(stack, makeEvt("x"))).toBe(false)
+        expect(counts.bg).toBe(0)
+        // … and the barrier's own esc still fires (body doesn't bind it).
+        expect(dispatchKeyEvent(stack, makeEvt("escape"))).toBe(true)
+        expect(counts.esc).toBe(1)
+      }
+
+      test("barrier registered BEFORE the body (today's React commit order)", () => {
+        const counts = { body: 0, bg: 0, esc: 0 }
+        const stack: RegisteredBinding[] = []
+        insertRegistration(
+          stack,
+          makeReg(1, "x", () => counts.bg++),
+        ) // background pane
+        insertRegistration(
+          stack,
+          barrier(2, () => counts.esc++),
+        )
+        insertRegistration(
+          stack,
+          body(3, "j", () => counts.body++),
+        )
+        assertModalContract(stack, counts)
+      })
+
+      test("body registered BEFORE the barrier (the order that used to break)", () => {
+        const counts = { body: 0, bg: 0, esc: 0 }
+        const stack: RegisteredBinding[] = []
+        insertRegistration(
+          stack,
+          makeReg(1, "x", () => counts.bg++),
+        ) // background pane
+        insertRegistration(
+          stack,
+          body(3, "j", () => counts.body++),
+        )
+        insertRegistration(
+          stack,
+          barrier(2, () => counts.esc++),
+        ) // slots BELOW its member
+        assertModalContract(stack, counts)
+      })
+
+      test("body's own esc beats the barrier's esc under both orders", () => {
+        for (const bodyFirst of [true, false]) {
+          let bodyEsc = 0
+          const stack: RegisteredBinding[] = []
+          const regs = [barrier(1, () => {}), body(2, "escape", () => bodyEsc++)]
+          if (bodyFirst) regs.reverse()
+          for (const r of regs) insertRegistration(stack, r)
+          expect(dispatchKeyEvent(stack, makeEvt("escape"))).toBe(true)
+          expect(bodyEsc).toBe(1)
+        }
+      })
+
+      test("plain registrations (no scope) keep pure LIFO push semantics", () => {
+        const fired: number[] = []
+        const stack: RegisteredBinding[] = []
+        insertRegistration(
+          stack,
+          makeReg(1, "enter", () => fired.push(1)),
+        )
+        insertRegistration(
+          stack,
+          makeReg(2, "enter", () => fired.push(2)),
+        )
+        dispatchKeyEvent(stack, makeEvt("return"))
+        expect(fired).toEqual([2])
+      })
     })
 
     test("a disabled modal entry does not block (dialog closed)", () => {


### PR DESCRIPTION
Makes modal keybinding precedence an explicit declared property instead of a React effect-commit-order accident, and pulls dialog-open gating into one unit-tested predicate (`keybinding-gates.ts`).

The ModalBarrier's precedence over the dialog body used to depend on React committing effects depth-first in tree order — load-bearing but pinned by no test. Registrations now declare their modal scope, so precedence is data-driven and pinned under both registration orders.

file-size-exemption: packages/kobe/test/tui/keymap-dispatch.test.ts — pre-existing over the ~500 cap (563 lines on main); this change adds modal-precedence coverage (+~97 lines) and splitting the shared keymap-dispatch suite is out of scope for this plumbing refactor (tracked as a follow-up).
coverage-exemption: packages/kobe/src/tui-react/lib/keymap.ts — React-integration registration hook (opentui/React); not executable under vitest node coverage, same reason .tsx is excluded from the gate. Behavior is pinned via the render track + the extracted keybinding-gates predicate's unit tests.
coverage-exemption: packages/kobe/src/tui-react/workspace/host-keybindings.ts — React-integration host wiring; not executable under vitest node coverage. The extracted gating predicate (keybinding-gates.ts) is unit-tested at 100%; this file is the React glue that calls it.
