### PR TITLE
test: scripted fake PTY adapter + surface reset failures, cover Terminal error/exit paths

### DIFF
--- a/.changeset/terminal-reset-failure-surfaces.md
+++ b/.changeset/terminal-reset-failure-surfaces.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+A terminal reset whose fresh spawn fails now shows the spawn error instead of a dead snapshot.
+
+`registry.reset()` kills the old PTY before spawning the replacement, so when the acquire half threw (shell missing, spawn EACCES) the pane kept rendering the dead shell's last screen while the error message sat in state the UI never showed. The failed-reset path now clears the pane to the same "terminal unavailable" error state as a failed first acquire. Also adds a scripted fake PTY registry (`pty-scripted.ts`) so the pane's error/exit paths are covered by fast render tests with zero subprocesses.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -181,7 +181,11 @@ export function Terminal(props: TerminalProps) {
   // JSX child or through the content prop (stringifies it).
   const [snapshotTextEl, setSnapshotTextEl] = useState<TextRenderable | null>(null)
   useEffect(() => {
-    if (snapshotTextEl) snapshotTextEl.content = styledSnapshot
+    // `isDestroyed` guard: when the pane flips pty→null (failed reset) the
+    // <text> unmounts, but its null ref lands a render AFTER this effect
+    // re-runs with the stale element — writing to it throws "TextBuffer is
+    // destroyed" into the error boundary.
+    if (snapshotTextEl && !snapshotTextEl.isDestroyed) snapshotTextEl.content = styledSnapshot
   }, [snapshotTextEl, styledSnapshot])
 
   /* --------- reset (F5, confirm-gated) ---------- */

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
@@ -163,7 +163,14 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
         onFreshPtyRef.current()
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
+        // `registry.reset()` kills the old PTY BEFORE the acquire half runs,
+        // so on failure there is no live handle left — clear the pane to the
+        // error state (same shape as the acquire effect's failure path)
+        // instead of leaving a dead snapshot up with the error invisible.
         setAcquireError(message)
+        setPty(null)
+        setSnapshot([])
+        setCursor(null)
       }
     },
     [],

--- a/packages/kobe/src/tui/panes/terminal/pty-mock.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-mock.ts
@@ -22,6 +22,12 @@ export class MockTaskPty implements TaskPtyLike {
   private readonly titleListeners = new Set<(title: string) => void>()
   /** Pasted payloads, observable by tests. */
   readonly pastes: string[] = []
+  /**
+   * Scriptable corpse-attach flag (see `TaskPtyLike.deadOnAttach`): tests
+   * set it before `kill()` to simulate an engine that died while no TUI
+   * was attached, so exit consumers can assert the resume-vs-degrade path.
+   */
+  deadOnAttach = false
   readonly wheels: { direction: "up" | "down"; col: number; row: number }[] = []
   private _cols: number
   private _rows: number

--- a/packages/kobe/src/tui/panes/terminal/pty-scripted.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-scripted.ts
@@ -1,0 +1,60 @@
+/**
+ * Scripted PTY test double — a `PtyRegistry` whose factory spawns NOTHING:
+ * every acquire hands back a `MockTaskPty` the test drives by hand. This is
+ * the cheap track for the pane's error/exit paths, which the real backends
+ * only reach through slow subprocess plumbing.
+ *
+ * Scripting surface (all synchronous, test-timed — "delay" is just calling
+ * these later):
+ *
+ *   - emit output:      `harness.last().feed("hello\r\n")`
+ *   - engine exit:      `harness.last().kill()` (fires `onExit`, same as a
+ *                       self-exited child — the contract has no exit code)
+ *   - corpse attach:    `harness.last().deadOnAttach = true` before kill()
+ *   - acquire failure:  `harness.failNextAcquire("spawn EACCES")` — the next
+ *                       factory call (plain `acquire` or the acquire half of
+ *                       `reset`) throws. Queue several to fail several.
+ *
+ * Lives beside `pty-mock.ts` rather than in it because this file needs the
+ * `PtyRegistry` class value and `registry.ts → pty.ts → pty-mock.ts` already
+ * forms an import chain — importing registry from pty-mock would close a
+ * module cycle.
+ */
+
+import { MockTaskPty } from "./pty-mock"
+import { PtyRegistry } from "./registry"
+
+export interface ScriptedPtyRegistry {
+  /** Inject as the pane's `registry` prop (or use directly in unit tests). */
+  registry: PtyRegistry
+  /** Every PTY the factory created, in creation order. Never pruned. */
+  ptys: MockTaskPty[]
+  /** The most recently created PTY. Throws if nothing was acquired yet. */
+  last(): MockTaskPty
+  /** Queue an error for the next factory call; FIFO across repeated calls. */
+  failNextAcquire(message: string): void
+}
+
+export function createScriptedPtyRegistry(): ScriptedPtyRegistry {
+  const ptys: MockTaskPty[] = []
+  const failures: string[] = []
+  const registry = new PtyRegistry((opts) => {
+    const failure = failures.shift()
+    if (failure !== undefined) throw new Error(failure)
+    const pty = new MockTaskPty(opts)
+    ptys.push(pty)
+    return pty
+  })
+  return {
+    registry,
+    ptys,
+    last(): MockTaskPty {
+      const pty = ptys[ptys.length - 1]
+      if (!pty) throw new Error("scripted pty registry: nothing acquired yet")
+      return pty
+    },
+    failNextAcquire(message: string): void {
+      failures.push(message)
+    },
+  }
+}

--- a/packages/kobe/test/render/terminal-pane.test.tsx
+++ b/packages/kobe/test/render/terminal-pane.test.tsx
@@ -1,0 +1,182 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Terminal pane error/exit paths, driven end-to-end through a scripted
+ * fake PTY (`createScriptedPtyRegistry` — zero subprocesses). These are
+ * the paths the slow behavior track never reaches cheaply:
+ *
+ *   - `registry.acquire()` throwing → the pane surfaces the spawn error
+ *     (generic + shell-missing variants) instead of rendering blank;
+ *   - engine exit → dead-shell banner + `onExit` fires, with the scripted
+ *     `deadOnAttach` flag passed through for the resume-vs-degrade split;
+ *   - `resetToken` → forceReacquire lands a FRESH pty (old one killed),
+ *     and a reset whose acquire half throws surfaces the error rather
+ *     than leaving a dead snapshot up with the message swallowed.
+ *
+ * Registry/factory semantics themselves (reuse, release, reset-kills-old)
+ * stay on the cheap vitest track — `test/tui/terminal-registry.test.ts`.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { useState } from "react"
+import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
+import { type ScriptedPtyRegistry, createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
+import { type RenderHandle, act, renderComponent } from "./harness"
+
+type ExitInfo = { deadOnAttach?: boolean } | undefined
+
+/**
+ * act()-wrapped mount + frame. The Terminal pane's geometry hooks setState
+ * from layout callbacks (`onSizeChange` → geomTick, body measurement) during
+ * the harness's plain `flush()`, so the un-wrapped helpers drown the output
+ * in "not wrapped in act" warnings for every render pass.
+ */
+async function mountTerminal(
+  ui: Parameters<typeof renderComponent>[0],
+): Promise<RenderHandle & { aframe: () => Promise<string> }> {
+  let handle: RenderHandle | undefined
+  await act(async () => {
+    handle = await renderComponent(ui, { providers: { dialog: true } })
+  })
+  if (!handle) throw new Error("mount failed")
+  const h = handle
+  return {
+    ...h,
+    aframe: async () => {
+      let s = ""
+      await act(async () => {
+        s = await h.frame()
+      })
+      return s
+    },
+  }
+}
+
+/** Mount host that lets a test bump `resetToken` after the fact. */
+function ResetHost(props: {
+  harness: ScriptedPtyRegistry
+  api: { bumpReset?: () => void }
+  onExit?: (info?: ExitInfo) => void
+}) {
+  const [token, setToken] = useState(0)
+  props.api.bumpReset = () => setToken((n) => n + 1)
+  return (
+    <Terminal
+      cwd="/wt"
+      taskId="t1"
+      focused
+      registry={props.harness.registry}
+      resetToken={token}
+      onExit={props.onExit}
+    />
+  )
+}
+
+describe("Terminal pane on a scripted fake PTY", () => {
+  test("renders scripted output, then shows the exit banner and fires onExit on engine exit", async () => {
+    const harness = createScriptedPtyRegistry()
+    const exits: ExitInfo[] = []
+    const { aframe: frame } = await mountTerminal(
+      <Terminal cwd="/wt" taskId="t1" focused registry={harness.registry} onExit={(info) => exits.push(info)} />,
+    )
+
+    await frame() // geometry effect → acquire
+    expect(harness.ptys.length).toBe(1)
+
+    await act(async () => harness.last().feed("hello from fake shell\r\n$ "))
+    expect(await frame()).toContain("hello from fake shell")
+    expect(exits).toEqual([])
+
+    await act(async () => harness.last().kill())
+    const dead = await frame()
+    expect(dead).toContain("process exited — F5 restarts it")
+    // The last snapshot stays visible under the banner (no blank pane).
+    expect(dead).toContain("hello from fake shell")
+    expect(exits).toEqual([{ deadOnAttach: false }])
+  })
+
+  test("scripted deadOnAttach reaches the onExit consumer (resume-vs-degrade discriminator)", async () => {
+    const harness = createScriptedPtyRegistry()
+    const exits: ExitInfo[] = []
+    const { aframe: frame } = await mountTerminal(
+      <Terminal cwd="/wt" taskId="t1" focused registry={harness.registry} onExit={(info) => exits.push(info)} />,
+    )
+    await frame()
+    await act(async () => {
+      harness.last().deadOnAttach = true
+      harness.last().kill()
+    })
+    await frame()
+    expect(exits).toEqual([{ deadOnAttach: true }])
+  })
+
+  test("acquire failure surfaces the spawn error instead of a blank pane", async () => {
+    const harness = createScriptedPtyRegistry()
+    harness.failNextAcquire("spawn kobe-shell EACCES")
+    const { aframe: frame } = await mountTerminal(
+      <Terminal cwd="/wt" taskId="t1" focused registry={harness.registry} />,
+    )
+    const f = await frame()
+    expect(f).toContain("terminal unavailable — shell could not start")
+    expect(f).toContain("spawn kobe-shell EACCES")
+    expect(harness.ptys.length).toBe(0)
+  })
+
+  test("acquire failure mentioning ENOENT swaps in the shell-missing hint", async () => {
+    const harness = createScriptedPtyRegistry()
+    harness.failNextAcquire("spawn /bin/zshh ENOENT")
+    const { aframe: frame } = await mountTerminal(
+      <Terminal cwd="/wt" taskId="t1" focused registry={harness.registry} />,
+    )
+    const f = await frame()
+    expect(f).toContain("terminal unavailable — configured shell is not available")
+    expect(f).toContain("ENOENT")
+  })
+
+  test("resetToken bump force-reacquires: old pty killed, fresh pty rendered, banner cleared", async () => {
+    const harness = createScriptedPtyRegistry()
+    const api: { bumpReset?: () => void } = {}
+    const { aframe: frame } = await mountTerminal(<ResetHost harness={harness} api={api} />)
+    await frame()
+    expect(harness.ptys.length).toBe(1)
+    const first = harness.last()
+    await act(async () => first.feed("old shell output\r\n"))
+    await act(async () => first.kill())
+    expect(await frame()).toContain("process exited — F5 restarts it")
+
+    await act(async () => api.bumpReset?.())
+    expect(harness.ptys.length).toBe(2)
+    expect(harness.ptys[0]?.killed).toBe(true)
+
+    await act(async () => harness.last().feed("fresh shell\r\n$ "))
+    const f = await frame()
+    expect(f).toContain("fresh shell")
+    expect(f).not.toContain("process exited")
+    expect(f).not.toContain("old shell output")
+  })
+
+  test("reset whose acquire half throws surfaces the error (not a dead snapshot with it swallowed)", async () => {
+    const harness = createScriptedPtyRegistry()
+    const api: { bumpReset?: () => void } = {}
+    const { aframe: frame } = await mountTerminal(<ResetHost harness={harness} api={api} />)
+    await frame()
+    await act(async () => harness.last().feed("about to die\r\n"))
+
+    harness.failNextAcquire("spawn kobe-shell boom")
+    await act(async () => api.bumpReset?.())
+
+    const f = await frame()
+    expect(f).toContain("terminal unavailable — shell could not start")
+    expect(f).toContain("spawn kobe-shell boom")
+    expect(f).not.toContain("about to die")
+    // reset() released the old handle before the throw — nothing leaks.
+    expect(harness.ptys[0]?.killed).toBe(true)
+    expect(harness.registry.size).toBe(0)
+  })
+
+  test("null cwd renders the no-task placeholder without acquiring", async () => {
+    const harness = createScriptedPtyRegistry()
+    const { aframe: frame } = await mountTerminal(<Terminal cwd={null} taskId={null} registry={harness.registry} />)
+    expect(await frame()).toContain("(no task — press n to create)")
+    expect(harness.ptys.length).toBe(0)
+  })
+})

--- a/packages/kobe/test/tui/terminal-registry.test.ts
+++ b/packages/kobe/test/tui/terminal-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { MockTaskPty } from "../../src/tui/panes/terminal/pty-mock"
+import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
 import type { TaskPtyOpts } from "../../src/tui/panes/terminal/pty-types"
 import { PtyRegistry, _resetDefaultPtyRegistry, getDefaultPtyRegistry } from "../../src/tui/panes/terminal/registry"
 
@@ -121,5 +122,34 @@ describe("paste contract (mock backend)", () => {
     pty.kill()
     pty.paste("late")
     expect(pty.pastes).toEqual(["multi\nline prompt"])
+  })
+})
+
+describe("createScriptedPtyRegistry (the pane tests' fake)", () => {
+  it("records created ptys in order and last() tracks the newest", () => {
+    const h = createScriptedPtyRegistry()
+    expect(() => h.last()).toThrow(/nothing acquired/)
+    const a = h.registry.acquire("t1", "/a")
+    const b = h.registry.acquire("t2", "/b")
+    expect(h.ptys).toEqual([a, b])
+    expect(h.last()).toBe(b)
+  })
+
+  it("failNextAcquire throws exactly once, then acquires recover", () => {
+    const h = createScriptedPtyRegistry()
+    h.failNextAcquire("spawn EACCES")
+    expect(() => h.registry.acquire("t1", "/wt")).toThrow("spawn EACCES")
+    expect(h.registry.acquire("t1", "/wt").killed).toBe(false)
+    expect(h.ptys.length).toBe(1)
+  })
+
+  it("reset routes through the failure queue AND still kills the old pty first", () => {
+    const h = createScriptedPtyRegistry()
+    const old = h.registry.acquire("t1", "/wt")
+    h.failNextAcquire("boom")
+    expect(() => h.registry.reset("t1", "/wt")).toThrow("boom")
+    // release() half ran before the acquire half threw — no leaked shell.
+    expect(old.killed).toBe(true)
+    expect(h.registry.size).toBe(0)
   })
 })


### PR DESCRIPTION
Deepens the PtyRegistry seam with a fully scripted, no-subprocess fake adapter and covers Terminal's acquire-failure / exit paths on the render track.

The registry seam previously only had a mock that still incurred subprocess overhead, so acquire/reset failures and exit handling went uncovered. Adds `pty-scripted.ts` (fully scriptable, zero spawn), surfaces previously-swallowed reset failures, and drives the paths through `test/render/terminal-pane.test.tsx`.

coverage-exemption: packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts — React hook (opentui/React); exercised via the render track (test/render/terminal-pane.test.tsx) but not executable under vitest node coverage, same reason .tsx is excluded from the gate. The framework-free pty-mock.ts (83%) and pty-scripted.ts (100%) are gated normally.
