### PR TITLE
refactor: unify daemon RPC dispatch — registry-driven web exposure + shared error shape

### DIFF
--- a/.changeset/web-rpc-registry-exposure.md
+++ b/.changeset/web-rpc-registry-exposure.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Web RPC exposure now derives from the daemon handler registry (`web: true` per entry) instead of a hand-maintained allowlist, and the web transport's error envelopes share the socket's `shapeDaemonError` policy.

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -16,12 +16,14 @@ import { serializeTask } from "./protocol.ts"
 export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   {
     name: "task.list",
+    web: true,
     handle(_payload, ctx: DaemonHandlerContext) {
       return { tasks: ctx.orch.listTasks().map(serializeTask) }
     },
   },
   {
     name: "task.get",
+    web: true,
     handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       const task = ctx.orch.getTask(taskId)
@@ -31,6 +33,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.create",
+    web: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
       const task = await ctx.orch.createTask({
@@ -46,6 +49,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.archive",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       await ctx.orch.setArchived(taskId, optionalBoolean(payload, "archived"))
@@ -54,6 +58,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.rename",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       await ctx.orch.setTitle(taskId, requireString(payload, "title"))
@@ -62,6 +67,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.setBranch",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       await ctx.orch.setBranch(taskId, requireString(payload, "branch"))
@@ -70,6 +76,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.setVendor",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       const vendor = optionalVendor(payload, "vendor")
@@ -80,6 +87,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.delete",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       await ctx.orch.deleteTask(taskId, { force: optionalBoolean(payload, "force") })
@@ -89,6 +97,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.pin",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       await ctx.orch.setPinned(taskId, optionalBoolean(payload, "pinned"))
@@ -97,6 +106,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.move",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       const direction = requireString(payload, "direction")
@@ -107,6 +117,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.status",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       const status = requireString(payload, "status")
@@ -140,6 +151,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.reorder",
+    web: true,
     async handle(payload, ctx) {
       const moves = payload.moves
       if (!Array.isArray(moves) || moves.length === 0) throw new Error("moves must be a non-empty array")
@@ -160,6 +172,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.ensureMain",
+    web: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
       const task = await ctx.orch.ensureMainTask(repo)
@@ -176,6 +189,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.ensureWorktree",
+    web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       // Long-operation feedback (issue #5): `git worktree add` is
@@ -209,6 +223,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.setActive",
+    web: true,
     async handle(payload, ctx) {
       // UI/session focus lives on the bus, but setting it also touches the
       // task's updatedAt so "recent" task sorting reflects actual use.

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -180,6 +180,7 @@ async function listLocalProjects(network: boolean): Promise<WorktreeProject[]> {
 export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
   {
     name: "worktree.discoverAdoptable",
+    web: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
       const worktrees = await ctx.orch.discoverAdoptableWorktrees(repo)
@@ -188,6 +189,7 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "worktree.adopt",
+    web: true,
     async handle(payload, ctx) {
       const task = await ctx.orch.adoptWorktree({
         repo: requireString(payload, "repo"),

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -107,7 +107,25 @@ export interface DaemonHandlerContext {
  */
 export interface DaemonRequestHandler {
   readonly name: DaemonRequestName
+  /**
+   * Browser-reachable through POST /api/rpc? Absent/false means socket-only.
+   * This is the ONE place an RPC declares its web exposure — the web
+   * transport derives its allowset from the registry (see
+   * {@link webExposedRpcNames}), so a new verb is not browser-reachable
+   * until its entry says so. Connection-scoped verbs (`hello`), the daemon
+   * kill switch (`daemon.stop`), and hook-ingest paths must stay unexposed.
+   */
+  readonly web?: boolean
   handle(payload: Record<string, unknown>, ctx: DaemonHandlerContext): Promise<unknown> | unknown
+}
+
+/** The registry-derived web-RPC allowset: every entry marked `web: true`. */
+export function webExposedRpcNames(
+  registry: ReadonlyMap<DaemonRequestName, DaemonRequestHandler>,
+): ReadonlySet<DaemonRequestName> {
+  const names = new Set<DaemonRequestName>()
+  for (const entry of registry.values()) if (entry.web === true) names.add(entry.name)
+  return names
 }
 
 /**
@@ -190,6 +208,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
     },
     {
       name: "daemon.status",
+      web: true,
       handle(_payload, ctx) {
         return {
           daemonPid: ctx.daemon.pid,

--- a/packages/kobe-daemon/src/daemon/web-rpc-allowlist.ts
+++ b/packages/kobe-daemon/src/daemon/web-rpc-allowlist.ts
@@ -1,30 +1,15 @@
+import { createDaemonHandlerRegistry, webExposedRpcNames } from "./handlers.ts"
 import type { DaemonRequestName } from "./protocol.ts"
 
 /**
  * The daemon RPCs the browser UI may invoke through POST /api/rpc.
  *
- * Explicit allowlist: a new daemon verb is not browser-reachable until added
- * deliberately alongside the SPA surface that uses it.
+ * Thin shim over the handler registry: web exposure is declared per-entry
+ * (`web: true` in handlers*.ts) so an RPC's browser reachability lives where
+ * the handler is defined — this file no longer hand-maintains a list that
+ * can drift from the registry. Kept as a re-export for existing importers
+ * (kobe-web's allowlist contract test).
  */
-export const WEB_RPC_ALLOWLIST: readonly DaemonRequestName[] = [
-  "daemon.status",
-  "task.list",
-  "task.get",
-  "task.create",
-  "task.archive",
-  "task.rename",
-  "task.setBranch",
-  "task.setVendor",
-  "task.delete",
-  "task.pin",
-  "task.move",
-  "task.status",
-  "task.reorder",
-  "task.ensureMain",
-  "task.ensureWorktree",
-  "task.setActive",
-  "worktree.discoverAdoptable",
-  "worktree.adopt",
-]
+export const WEB_RPC_ALLOWSET: ReadonlySet<string> = webExposedRpcNames(createDaemonHandlerRegistry())
 
-export const WEB_RPC_ALLOWSET: ReadonlySet<string> = new Set<string>(WEB_RPC_ALLOWLIST)
+export const WEB_RPC_ALLOWLIST: readonly DaemonRequestName[] = [...WEB_RPC_ALLOWSET] as DaemonRequestName[]

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -16,13 +16,18 @@ import { handleThemesRequest } from "@/web/themes"
 import type { DaemonRpcClient } from "../client/rpc.ts"
 import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import type { ChannelEvent, DaemonEventBus } from "./event-bus.ts"
-import { type DaemonHandlerContext, createDaemonHandlerRegistry, dispatchDaemonRequest } from "./handlers.ts"
+import {
+  type DaemonHandlerContext,
+  createDaemonHandlerRegistry,
+  dispatchDaemonRequest,
+  shapeDaemonError,
+  webExposedRpcNames,
+} from "./handlers.ts"
 import type { ChannelName, ChannelPayloads, DaemonRequestName, SerializedTask } from "./protocol.ts"
 import { serializeTask } from "./protocol.ts"
 import { handleIssueAssetsRequest } from "./web-issue-assets-route.ts"
 import { handleIssuesRequest } from "./web-issues-route.ts"
 import { allowedHostForBindHost, originAllowed } from "./web-origin.ts"
-import { WEB_RPC_ALLOWSET } from "./web-rpc-allowlist.ts"
 import { engineSpec, ensureTaskSession, tearDownTaskSession, terminalSpec } from "./web-session.ts"
 import { settingsPatch, settingsSnapshot } from "./web-settings.ts"
 import { handleWorktreesRequest } from "./web-worktrees-route.ts"
@@ -123,11 +128,38 @@ function sseResponse(register: (send: SseSend) => () => void, signal?: AbortSign
   })
 }
 
+// Exposure policy comes FROM the handler registry (`web: true` per entry) —
+// no separately maintained allowlist to drift. Registry construction is
+// stateless/cheap, so deriving the set once at module load is fine.
+// Re-exported: this module is the web-exposure seam, and `server.ts` (the
+// usual re-export spot) is over the file-size cap.
+export { webExposedRpcNames } from "./handlers.ts"
+const WEB_EXPOSED_RPCS = webExposedRpcNames(createDaemonHandlerRegistry())
+
+/**
+ * Map a thrown error to the HTTP error envelope. The error POLICY (message
+ * wording, name propagation) is {@link shapeDaemonError} — the same shaping
+ * the socket transport puts in its response frames — so the two transports
+ * carry identical fields. Two deliberate HTTP-side differences, both pinned
+ * by tests: the message travels under `error` (the SPA's api-client parses
+ * `error`, not `message` — packages/kobe-web/src/lib/api-client.ts), and a
+ * plain anonymous Error's `name: "Error"` stays off the wire (historical
+ * shape, pinned by kobe-web's bridge-routes test).
+ */
+export function webRpcErrorBody(err: unknown): { error: string; name?: string } {
+  const { message, name } = shapeDaemonError(err)
+  return { error: message, ...(name !== undefined && name !== "Error" ? { name } : {}) }
+}
+
+function webRpcErrorResponse(err: unknown, status: number): Response {
+  return Response.json(webRpcErrorBody(err), { status })
+}
+
 async function rpcResponse(req: Request, link: DaemonWebLink, tearDown: (taskId: string) => void): Promise<Response> {
   try {
     const { name, payload } = (await req.json()) as { name?: DaemonRequestName; payload?: unknown }
     if (!name) return Response.json({ error: "missing rpc name" }, { status: 400 })
-    if (!WEB_RPC_ALLOWSET.has(name)) {
+    if (!WEB_EXPOSED_RPCS.has(name)) {
       return Response.json({ error: `rpc ${name} is not exposed to the web UI` }, { status: 403 })
     }
     const result = await link.request(name, payload)
@@ -138,11 +170,7 @@ async function rpcResponse(req: Request, link: DaemonWebLink, tearDown: (taskId:
     }
     return Response.json({ result })
   } catch (err) {
-    const name = err instanceof Error && err.name !== "Error" ? err.name : undefined
-    return Response.json(
-      { error: err instanceof Error ? err.message : String(err), ...(name ? { name } : {}) },
-      { status: 500 },
-    )
+    return webRpcErrorResponse(err, 500)
   }
 }
 
@@ -156,7 +184,7 @@ async function enginesResponse(): Promise<Response> {
     }))
     return Response.json({ engines: engines.length > 0 ? engines : [{ id: "claude", label: "Claude" }] })
   } catch (err) {
-    return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+    return webRpcErrorResponse(err, 500)
   }
 }
 
@@ -174,7 +202,7 @@ async function sessionResponse(req: Request, link: DaemonWebLink): Promise<Respo
     if (!taskId) return Response.json({ error: "missing taskId" }, { status: 400 })
     return Response.json(await ensureTaskSession(link, taskId))
   } catch (err) {
-    return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+    return webRpcErrorResponse(err, 500)
   }
 }
 
@@ -188,7 +216,7 @@ async function specResponse(
     if (!taskId) return Response.json({ error: "missing taskId" }, { status: 400 })
     return Response.json(await spec(link, taskId))
   } catch (err) {
-    return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+    return webRpcErrorResponse(err, 500)
   }
 }
 
@@ -211,7 +239,7 @@ async function quickPromptsPut(req: Request): Promise<Response> {
     if (typeof body.pr === "string") setPersistedString(QUICK_PROMPT_KEYS.pr, body.pr)
     return quickPromptsGet()
   } catch (err) {
-    return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 400 })
+    return webRpcErrorResponse(err, 400)
   }
 }
 

--- a/packages/kobe/test/daemon/web-exposure.test.ts
+++ b/packages/kobe/test/daemon/web-exposure.test.ts
@@ -1,0 +1,100 @@
+import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { createDaemonHandlerRegistry, shapeDaemonError } from "@sma1lboy/kobe-daemon/daemon/server"
+import { WEB_RPC_ALLOWLIST, WEB_RPC_ALLOWSET } from "@sma1lboy/kobe-daemon/daemon/web-rpc-allowlist"
+import { webExposedRpcNames, webRpcErrorBody } from "@sma1lboy/kobe-daemon/daemon/web-server"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Web-exposure policy + error-shape parity for the unified dispatch seam.
+ *
+ * WHY these matter: the web transport's RPC allowlist used to be a
+ * hand-maintained constant that could silently drift from the handler
+ * registry, and its error envelope was hand-rolled separately from the
+ * socket's shapeDaemonError. Both now derive from the registry
+ * (`web: true` per entry / webExposedRpcNames) and from shapeDaemonError
+ * (webRpcErrorBody). These tests pin the SECURITY contract — the exact set
+ * of browser-reachable verbs, so exposing a new one is a deliberate,
+ * test-visible act — and the wire parity between the two transports.
+ */
+
+/** The full browser-reachable surface, pinned EXACTLY (order-insensitive). */
+const EXPOSED: readonly DaemonRequestName[] = [
+  "daemon.status",
+  "task.list",
+  "task.get",
+  "task.create",
+  "task.archive",
+  "task.rename",
+  "task.setBranch",
+  "task.setVendor",
+  "task.delete",
+  "task.pin",
+  "task.move",
+  "task.status",
+  "task.reorder",
+  "task.ensureMain",
+  "task.ensureWorktree",
+  "task.setActive",
+  "worktree.discoverAdoptable",
+  "worktree.adopt",
+]
+
+// Verbs that must never cross the web boundary, whatever the daemon grows:
+// connection lifecycle, the kill switch, hook ingest, and bulk mutation.
+const FORBIDDEN = ["hello", "subscribe", "daemon.stop", "engine.reportEvent", "worktree.reconcile"] as const
+
+describe("registry web-exposure policy", () => {
+  const exposed = webExposedRpcNames(createDaemonHandlerRegistry())
+
+  it("exposes exactly the pinned browser-reachable surface", () => {
+    expect([...exposed].sort()).toEqual([...EXPOSED].sort())
+  })
+
+  it("never exposes connection/lifecycle/hook verbs", () => {
+    for (const name of FORBIDDEN) {
+      expect(exposed.has(name as DaemonRequestName)).toBe(false)
+    }
+  })
+
+  it("the web-rpc-allowlist shim mirrors the registry metadata exactly", () => {
+    expect(new Set(WEB_RPC_ALLOWLIST)).toEqual(new Set(exposed))
+    expect(WEB_RPC_ALLOWSET.size).toBe(WEB_RPC_ALLOWLIST.length)
+    for (const name of exposed) expect(WEB_RPC_ALLOWSET.has(name)).toBe(true)
+  })
+})
+
+describe("socket/web error-shape parity", () => {
+  it("a named error carries the same message + name on both transports", () => {
+    const err = new Error("illegal transition for task t1")
+    err.name = "IllegalTransitionError"
+    const socket = shapeDaemonError(err)
+    const web = webRpcErrorBody(err)
+    expect(socket).toEqual({ message: "illegal transition for task t1", name: "IllegalTransitionError" })
+    // Same fields, message keyed as `error` (the SPA's api-client parses that key).
+    expect(web).toEqual({ error: socket.message, name: socket.name })
+  })
+
+  it("a plain anonymous Error: same message; web drops the noise name (historical HTTP shape)", () => {
+    const err = new Error("boom")
+    expect(shapeDaemonError(err)).toEqual({ message: "boom", name: "Error" })
+    const web = webRpcErrorBody(err)
+    expect(web).toEqual({ error: "boom" })
+    expect(web).not.toHaveProperty("name")
+  })
+
+  it("a non-Error throw is String()-coerced identically, with no name on either wire", () => {
+    const socket = shapeDaemonError("plain string")
+    const web = webRpcErrorBody("plain string")
+    expect(socket.message).toBe("plain string")
+    // shapeDaemonError leaves name: undefined (dropped by JSON.stringify);
+    // the web body omits the key structurally.
+    expect(socket.name).toBeUndefined()
+    expect(web).toEqual({ error: "plain string" })
+  })
+
+  it("a subclassed error (TypeError) keeps its name on both transports", () => {
+    const err = new TypeError("bad type")
+    expect(shapeDaemonError(err)).toEqual({ message: "bad type", name: "TypeError" })
+    expect(webRpcErrorBody(err)).toEqual({ error: "bad type", name: "TypeError" })
+  })
+})


### PR DESCRIPTION
The web transport hand-maintained its own RPC allowlist constant and hand-rolled a byte-incompatible error envelope, both able to drift from socket dispatch. Web exposure is now registry metadata and errors flow through shapeDaemonError, so socket and web are two adapters over one dispatch policy.
