### PR TITLE
test: shared daemon test harness + web-transport and socket-adversarial coverage

### DIFF
--- a/packages/kobe/test/daemon/active-task-replay.test.ts
+++ b/packages/kobe/test/daemon/active-task-replay.test.ts
@@ -10,68 +10,22 @@
  * over the real Unix socket.
  */
 
-import { mkdtempSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
-import { type DaemonServer, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import type { Orchestrator } from "../../src/orchestrator/core.ts"
-
-/** Minimal orchestrator whose restored focus is `taskId`. */
-function fakeOrchestrator(taskId: string | null): Orchestrator {
-  return {
-    subscribeTasks: (listener: (snapshot: unknown[]) => void) => {
-      listener([])
-      return () => {}
-    },
-    listTasks: () => [],
-    activeTaskSignal: () => () => taskId,
-  } as unknown as Orchestrator
-}
-
-async function waitFor(cond: () => boolean): Promise<void> {
-  const deadline = Date.now() + 2000
-  while (!cond() && Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 20))
-  }
-}
+import { afterEach, describe, expect, it } from "vitest"
+import { type DaemonHarness, bootDaemonHarness, fakeOrchestrator, waitFor } from "./harness.ts"
 
 describe("active-task connect-time replay", () => {
-  let dir: string
-  let socketPath: string
-  let pidPath: string
-  let server: DaemonServer | null
-  let savedHome: string | undefined
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kobe-active-replay-"))
-    socketPath = join(dir, "daemon.sock")
-    pidPath = join(dir, "daemon.pid")
-    savedHome = process.env.KOBE_HOME_DIR
-    process.env.KOBE_HOME_DIR = dir
-    server = null
-  })
+  let h: DaemonHarness
 
   afterEach(async () => {
-    if (savedHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
-    else process.env.KOBE_HOME_DIR = savedHome
-    await server?.close().catch(() => {})
-    rmSync(dir, { recursive: true, force: true })
+    await h.close()
   })
 
-  async function replayedActiveTask(orch: Orchestrator): Promise<string | null | undefined> {
-    server = await startDaemonServer(orch, {
-      socketPath,
-      pidPath,
-      homeDir: dir,
-      updatePollMs: 0,
-      autoTitlePollMs: 0,
-      uiPrefsDebounceMs: 0,
-      keybindingsDebounceMs: 25,
-      worktreeChangesTickMs: 0,
+  async function replayedActiveTask(taskId: string | null): Promise<string | null | undefined> {
+    // Minimal orchestrator whose restored focus is `taskId`.
+    h = await bootDaemonHarness({
+      orchestrator: fakeOrchestrator({ activeTaskSignal: () => () => taskId }),
     })
-    const client = new KobeDaemonClient(socketPath)
+    const client = h.client()
     let seen: string | null | undefined
     let arrived = false
     client.on("active-task", (frame) => {
@@ -85,10 +39,10 @@ describe("active-task connect-time replay", () => {
   }
 
   it("a fresh daemon replays the orchestrator's restored focus", async () => {
-    expect(await replayedActiveTask(fakeOrchestrator("task-42"))).toBe("task-42")
+    expect(await replayedActiveTask("task-42")).toBe("task-42")
   })
 
   it("no persisted focus replays an explicit null, not a cold channel", async () => {
-    expect(await replayedActiveTask(fakeOrchestrator(null))).toBeNull()
+    expect(await replayedActiveTask(null)).toBeNull()
   })
 })

--- a/packages/kobe/test/daemon/activity-state.test.ts
+++ b/packages/kobe/test/daemon/activity-state.test.ts
@@ -1,56 +1,26 @@
-import { mkdtempSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
 import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
-import { type DaemonServer, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import type { TaskActivityState } from "../../src/engine/hook-events.ts"
-import type { Orchestrator } from "../../src/orchestrator/core.ts"
+import { type DaemonHarness, bootDaemonHarness } from "./harness.ts"
 
 const TTL_MS = 30
-
-function fakeOrchestrator(): Orchestrator {
-  return {
-    subscribeTasks: (listener: (snapshot: unknown[]) => void) => {
-      listener([])
-      return () => {}
-    },
-    listTasks: () => [],
-  } as unknown as Orchestrator
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 describe("daemon activity state", () => {
-  let dir: string
-  let socketPath: string
-  let pidPath: string
-  let server: DaemonServer | null
-  let prevTtl: string | undefined
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kobe-activity-"))
-    socketPath = join(dir, "daemon.sock")
-    pidPath = join(dir, "daemon.pid")
-    prevTtl = process.env.KOBE_ENGINE_STATE_TTL_MS
-    process.env.KOBE_ENGINE_STATE_TTL_MS = String(TTL_MS)
-    server = null
-  })
+  let h: DaemonHarness | null = null
 
   afterEach(async () => {
-    if (prevTtl === undefined) Reflect.deleteProperty(process.env, "KOBE_ENGINE_STATE_TTL_MS")
-    else process.env.KOBE_ENGINE_STATE_TTL_MS = prevTtl
-    await server?.close().catch(() => {})
-    rmSync(dir, { recursive: true, force: true })
+    await h?.close()
+    h = null
   })
 
   it("keeps turn-complete visible instead of lapsing it back to idle", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), { socketPath, pidPath, homeDir: dir, updatePollMs: 0 })
-    const client = new KobeDaemonClient(socketPath)
+    h = await bootDaemonHarness({ env: { KOBE_ENGINE_STATE_TTL_MS: String(TTL_MS) } })
+    const client = h.client()
     const states: TaskActivityState[] = []
     client.onChannel("engine-state", (payload) => {
       if (payload.taskId === "task-1") states.push(payload.state)

--- a/packages/kobe/test/daemon/channel-filter.test.ts
+++ b/packages/kobe/test/daemon/channel-filter.test.ts
@@ -9,72 +9,30 @@
  * gets everything (back-compat). Exercised over the real Unix socket.
  */
 
-import { mkdtempSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
-import { type DaemonServer, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import type { Orchestrator } from "../../src/orchestrator/core.ts"
-
-/**
- * Minimal orchestrator. `subscribeTasks` fires once eagerly, which warms the
- * bus's `task.snapshot` last-value — the "unwanted" channel a filtered
- * subscriber must NOT receive.
- */
-function fakeOrchestrator(): Orchestrator {
-  return {
-    subscribeTasks: (listener: (snapshot: unknown[]) => void) => {
-      listener([])
-      return () => {}
-    },
-    listTasks: () => [],
-  } as unknown as Orchestrator
-}
-
-async function waitFor(cond: () => boolean): Promise<void> {
-  const deadline = Date.now() + 2000
-  while (!cond() && Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, 20))
-  }
-}
+import { afterEach, describe, expect, it } from "vitest"
+import { type DaemonHarness, bootDaemonHarness, waitFor } from "./harness.ts"
 
 describe("per-channel subscribe filter (daemon → client)", () => {
-  let dir: string
-  let socketPath: string
-  let pidPath: string
-  let server: DaemonServer | null
-  let savedHome: string | undefined
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kobe-chan-filter-"))
-    socketPath = join(dir, "daemon.sock")
-    pidPath = join(dir, "daemon.pid")
-    savedHome = process.env.KOBE_HOME_DIR
-    process.env.KOBE_HOME_DIR = dir
-    server = null
-  })
+  let h: DaemonHarness
 
   afterEach(async () => {
-    if (savedHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
-    else process.env.KOBE_HOME_DIR = savedHome
-    await server?.close().catch(() => {})
-    rmSync(dir, { recursive: true, force: true })
+    await h.close()
   })
 
-  it("a filtered subscriber receives only its channels in the replay", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), {
-      socketPath,
-      pidPath,
-      homeDir: dir,
-      updatePollMs: 0,
-      autoTitlePollMs: 0,
-      uiPrefsDebounceMs: 0,
-      keybindingsDebounceMs: 25,
-      worktreeChangesTickMs: 0,
-    })
+  /**
+   * Boot with a live keybindings watcher (its debounce fires an initial
+   * `keybindings` rev) — that channel is the "wanted" one; `task.snapshot`
+   * (warmed by the fake orchestrator's eager subscribeTasks fire) is the
+   * "unwanted" one a filtered subscriber must NOT receive.
+   */
+  function boot(): Promise<DaemonHarness> {
+    return bootDaemonHarness({ server: { keybindingsDebounceMs: 25 } })
+  }
 
-    const client = new KobeDaemonClient(socketPath)
+  it("a filtered subscriber receives only its channels in the replay", async () => {
+    h = await boot()
+
+    const client = h.client()
     const channels: string[] = []
     client.on("*", (frame) => {
       if (frame.name !== "daemon.stopping") channels.push(frame.name)
@@ -91,18 +49,9 @@ describe("per-channel subscribe filter (daemon → client)", () => {
   })
 
   it("an unfiltered subscriber still receives every channel (back-compat)", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), {
-      socketPath,
-      pidPath,
-      homeDir: dir,
-      updatePollMs: 0,
-      autoTitlePollMs: 0,
-      uiPrefsDebounceMs: 0,
-      keybindingsDebounceMs: 25,
-      worktreeChangesTickMs: 0,
-    })
+    h = await boot()
 
-    const client = new KobeDaemonClient(socketPath)
+    const client = h.client()
     const channels: string[] = []
     client.on("*", (frame) => {
       if (frame.name !== "daemon.stopping") channels.push(frame.name)

--- a/packages/kobe/test/daemon/harness.ts
+++ b/packages/kobe/test/daemon/harness.ts
@@ -1,0 +1,282 @@
+/**
+ * Shared daemon test harness — ONE call boots a real daemon server on a
+ * throwaway temp home + temp Unix socket with an injectable orchestrator
+ * double; one call tears everything down (clients, raw sockets, server,
+ * env, temp dir). Extracted from the boot code previously hand-rolled by
+ * lazy-shutdown / channel-filter / active-task-replay / activity-state
+ * (and mirrored by scripts/perf-golden.ts), so every daemon integration
+ * test isolates the same way: never the real `~/.kobe`, never the default
+ * sockets (the 2026-07-07/08 "test run swept the real pty host" incident),
+ * no leaked clients or sockets between tests.
+ *
+ * Web transport: vitest's fork workers run under NODE (no `Bun.serve`), so
+ * the harness cannot bind the real ephemeral-port web server here. Instead
+ * it instantiates the exported `createDaemonWebRequestHandler` — the pure
+ * `(Request) => Response` function where ALL of the route table, origin
+ * policy, RPC allowlist, and error shaping live — with its RPC link backed
+ * by a REAL socket client into the booted daemon, so `/api/rpc` calls run
+ * the genuine registry dispatch end-to-end. Only the `Bun.serve` bind,
+ * port takeover, and `createDirectWebLink` snapshot assembly stay out of
+ * reach (they need a bun runtime; covered by `bun run perf:golden` and
+ * live use).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { type Socket, connect } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { type DaemonServer, type DaemonServerOptions, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
+import {
+  type DaemonWebSnapshotState,
+  type RequestHandlerDeps,
+  createDaemonWebRequestHandler,
+} from "@sma1lboy/kobe-daemon/daemon/web-server"
+import type { Orchestrator } from "../../src/orchestrator/core.ts"
+
+/**
+ * Minimal orchestrator double — the daemon boot path only touches
+ * `subscribeTasks` (fired once eagerly, warming the bus's `task.snapshot`
+ * last-value) + `listTasks`. Tests that need more (e.g. `activeTaskSignal`
+ * for the focus replay) pass overrides.
+ */
+export function fakeOrchestrator(overrides: Record<string, unknown> = {}): Orchestrator {
+  return {
+    subscribeTasks: (listener: (snapshot: unknown[]) => void) => {
+      listener([])
+      return () => {}
+    },
+    listTasks: () => [],
+    ...overrides,
+  } as unknown as Orchestrator
+}
+
+/** Poll `cond` every 10ms until true or the timeout elapses. Returns the final value. */
+export async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (cond()) return true
+    await new Promise((r) => setTimeout(r, 10))
+  }
+  return cond()
+}
+
+/** A wire frame as decoded off the raw socket — loose on purpose (adversarial tests). */
+export interface RawWireFrame {
+  readonly type?: string
+  readonly id?: string
+  readonly name?: string
+  readonly payload?: unknown
+  readonly error?: { readonly message: string; readonly name?: string }
+}
+
+/**
+ * A raw JSON-lines connection to the daemon socket, below `KobeDaemonClient`
+ * — for sending malformed/adversarial bytes and asserting on the exact
+ * response frames.
+ */
+export interface RawDaemonSocket {
+  readonly socket: Socket
+  /** Every frame the daemon has written to this connection, in order. */
+  readonly frames: readonly RawWireFrame[]
+  sendLine(line: string): void
+  /** Convenience: send a well-formed request frame. */
+  request(name: string, payload?: unknown, id?: string): void
+  /** Resolve the first already-received or future frame matching `match`. */
+  nextFrame(match: (frame: RawWireFrame) => boolean, timeoutMs?: number): Promise<RawWireFrame>
+  destroy(): void
+}
+
+/** The web-transport half of the harness (see module doc for scope). */
+export interface HarnessWebTransport {
+  /** Run a Request through the daemon's web request handler. */
+  fetch(path: string, init?: RequestInit): Promise<Response>
+  /** The live SSE send registry — size = currently-open event streams. */
+  readonly sseSends: RequestHandlerDeps["sseSends"]
+  /** SSE gui-lifetime hook counters (`onSseOpen` open/close). */
+  readonly sse: { opened: number; closed: number }
+  /** taskIds the RPC route asked to tear the web session down for. */
+  readonly tornDownSessions: readonly string[]
+}
+
+export interface DaemonHarnessOptions {
+  orchestrator?: Orchestrator
+  /** Overrides merged over the harness defaults (every poller/watcher off). */
+  server?: Partial<DaemonServerOptions>
+  /** Env vars to set for the daemon's lifetime; restored on `close()`. */
+  env?: Record<string, string>
+  /** Also build the web request handler (see module doc). */
+  web?: boolean | { allowedHost?: string; snapshot?: () => DaemonWebSnapshotState }
+}
+
+export interface DaemonHarness {
+  readonly dir: string
+  readonly socketPath: string
+  readonly pidPath: string
+  readonly server: DaemonServer
+  readonly web: HarnessWebTransport | null
+  /** A tracked socket client — auto-closed by `close()`. */
+  client(): KobeDaemonClient
+  /** A tracked raw JSON-lines connection — auto-destroyed by `close()`. */
+  rawSocket(): Promise<RawDaemonSocket>
+  close(): Promise<void>
+}
+
+/** An empty-but-connected web snapshot (the SSE hydration payload). */
+export function emptyWebSnapshot(): DaemonWebSnapshotState {
+  return {
+    tasks: [],
+    activeTaskId: null,
+    engineStates: {},
+    update: null,
+    jobs: {},
+    worktreeChanges: {},
+    issueSnapshots: {},
+    deliver: null,
+    uiPrefs: null,
+    connected: true,
+  }
+}
+
+export async function bootDaemonHarness(opts: DaemonHarnessOptions = {}): Promise<DaemonHarness> {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-daemon-harness-"))
+  const socketPath = join(dir, "daemon.sock")
+  const pidPath = join(dir, "daemon.pid")
+
+  // Point every ambient home-dir read at the temp home BEFORE boot, plus any
+  // test-specific knobs (grace/TTL envs are read once at server start).
+  const savedEnv = new Map<string, string | undefined>()
+  const setEnv = (key: string, value: string): void => {
+    if (!savedEnv.has(key)) savedEnv.set(key, process.env[key])
+    process.env[key] = value
+  }
+  setEnv("KOBE_HOME_DIR", dir)
+  for (const [key, value] of Object.entries(opts.env ?? {})) setEnv(key, value)
+
+  const server = await startDaemonServer(opts.orchestrator ?? fakeOrchestrator(), {
+    socketPath,
+    pidPath,
+    homeDir: dir,
+    updatePollMs: 0,
+    autoTitlePollMs: 0,
+    prStatusPollMs: 0,
+    uiPrefsDebounceMs: 0,
+    keybindingsDebounceMs: 0,
+    worktreeChangesTickMs: 0,
+    transcriptActivityTickMs: 0,
+    ...opts.server,
+  })
+
+  const clients: KobeDaemonClient[] = []
+  const rawSockets: RawDaemonSocket[] = []
+  const trackClient = (client: KobeDaemonClient): KobeDaemonClient => {
+    clients.push(client)
+    return client
+  }
+
+  let web: HarnessWebTransport | null = null
+  if (opts.web) {
+    const webOpts = opts.web === true ? {} : opts.web
+    const sseSends: RequestHandlerDeps["sseSends"] = new Set()
+    const sse = { opened: 0, closed: 0 }
+    const tornDownSessions: string[] = []
+    const linkClient = trackClient(new KobeDaemonClient(socketPath))
+    const snapshot = webOpts.snapshot ?? emptyWebSnapshot
+    const handle = createDaemonWebRequestHandler({
+      link: {
+        request: <T>(name: Parameters<KobeDaemonClient["request"]>[0], payload?: unknown) =>
+          linkClient.request<T>(name, payload),
+        snapshot,
+      },
+      sseSends,
+      allowedHost: webOpts.allowedHost,
+      // Injected recorder instead of the real tearDownTaskSession: the real
+      // one reaches for PTY-sidecar state this fixture never creates.
+      tearDownSession: (taskId) => tornDownSessions.push(taskId),
+      onSseOpen: () => {
+        sse.opened++
+        return () => {
+          sse.closed++
+        }
+      },
+    })
+    web = {
+      fetch: (path, init) => handle(new Request(new URL(path, "http://127.0.0.1").toString(), init)),
+      sseSends,
+      sse,
+      tornDownSessions,
+    }
+  }
+
+  let closed = false
+  return {
+    dir,
+    socketPath,
+    pidPath,
+    server,
+    web,
+    client() {
+      return trackClient(new KobeDaemonClient(socketPath))
+    },
+    rawSocket() {
+      return new Promise<RawDaemonSocket>((resolve, reject) => {
+        const socket = connect(socketPath)
+        const frames: RawWireFrame[] = []
+        let buffer = ""
+        socket.on("data", (chunk) => {
+          buffer += chunk.toString("utf8")
+          let nl = buffer.indexOf("\n")
+          while (nl !== -1) {
+            const line = buffer.slice(0, nl)
+            buffer = buffer.slice(nl + 1)
+            if (line.trim().length > 0) {
+              try {
+                frames.push(JSON.parse(line) as RawWireFrame)
+              } catch {
+                /* the daemon never writes garbage; ignore partial teardown noise */
+              }
+            }
+            nl = buffer.indexOf("\n")
+          }
+        })
+        socket.on("error", () => {})
+        const raw: RawDaemonSocket = {
+          socket,
+          frames,
+          sendLine(line) {
+            socket.write(`${line}\n`)
+          },
+          request(name, payload, id = "1") {
+            raw.sendLine(JSON.stringify({ type: "request", id, name, payload }))
+          },
+          async nextFrame(match, timeoutMs = 2000) {
+            await waitFor(() => frames.some(match), timeoutMs)
+            const frame = frames.find(match)
+            if (!frame) throw new Error(`no matching frame within ${timeoutMs}ms (saw ${frames.length} frames)`)
+            return frame
+          },
+          destroy() {
+            socket.destroy()
+          },
+        }
+        socket.once("connect", () => {
+          rawSockets.push(raw)
+          resolve(raw)
+        })
+        socket.once("error", reject)
+      })
+    },
+    async close() {
+      if (closed) return
+      closed = true
+      for (const raw of rawSockets) raw.destroy()
+      for (const client of clients) client.close()
+      await server.close().catch(() => {})
+      for (const [key, value] of savedEnv) {
+        if (value === undefined) Reflect.deleteProperty(process.env, key)
+        else process.env[key] = value
+      }
+      rmSync(dir, { recursive: true, force: true })
+    },
+  }
+}

--- a/packages/kobe/test/daemon/lazy-shutdown.test.ts
+++ b/packages/kobe/test/daemon/lazy-shutdown.test.ts
@@ -1,10 +1,6 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
-import { type DaemonServer, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import type { Orchestrator } from "../../src/orchestrator/core.ts"
+import { existsSync } from "node:fs"
+import { afterEach, describe, expect, it } from "vitest"
+import { type DaemonHarness, bootDaemonHarness, waitFor } from "./harness.ts"
 
 /**
  * Refcounted lazy shutdown: the daemon's lifetime is bound to the number of
@@ -18,106 +14,65 @@ import type { Orchestrator } from "../../src/orchestrator/core.ts"
 
 const GRACE_MS = 80
 
-/** Minimal orchestrator: the refcount path only touches subscribeTasks + listTasks. */
-function fakeOrchestrator(): Orchestrator {
-  return {
-    subscribeTasks: (listener: (snapshot: unknown[]) => void) => {
-      listener([])
-      return () => {}
-    },
-    listTasks: () => [],
-  } as unknown as Orchestrator
-}
-
-async function until(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs
-  while (Date.now() < deadline) {
-    if (predicate()) return true
-    await new Promise((r) => setTimeout(r, 10))
-  }
-  return predicate()
-}
-
 describe("daemon refcounted lazy shutdown", () => {
-  let dir: string
-  let socketPath: string
-  let pidPath: string
-  let server: DaemonServer | null
-  let prevGrace: string | undefined
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kobe-lazy-"))
-    socketPath = join(dir, "daemon.sock")
-    pidPath = join(dir, "daemon.pid")
-    prevGrace = process.env.KOBE_DAEMON_IDLE_GRACE_MS
-    process.env.KOBE_DAEMON_IDLE_GRACE_MS = String(GRACE_MS)
-    server = null
-  })
+  let h: DaemonHarness
 
   afterEach(async () => {
-    if (prevGrace === undefined) Reflect.deleteProperty(process.env, "KOBE_DAEMON_IDLE_GRACE_MS")
-    else process.env.KOBE_DAEMON_IDLE_GRACE_MS = prevGrace
-    await server?.close().catch(() => {})
-    rmSync(dir, { recursive: true, force: true })
+    await h.close()
   })
 
+  /** Boot with the short grace window every test here relies on. */
+  function boot(): Promise<DaemonHarness> {
+    return bootDaemonHarness({ env: { KOBE_DAEMON_IDLE_GRACE_MS: String(GRACE_MS) } })
+  }
+
   it("self-stops a grace period after the last subscriber disconnects", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), {
-      socketPath,
-      pidPath,
-      homeDir: dir,
-      updatePollMs: 0,
-    })
-    const client = new KobeDaemonClient(socketPath)
+    h = await boot()
+    const client = h.client()
     await client.request("hello")
     await client.subscribe({ role: "gui" })
     // A subscribed GUI is attached → daemon must NOT be tearing down yet.
-    expect(existsSync(socketPath)).toBe(true)
+    expect(existsSync(h.socketPath)).toBe(true)
 
     client.close()
     // Last GUI gone → grace timer fires → close() unlinks the socket + pidfile.
-    expect(await until(() => !existsSync(socketPath), GRACE_MS + 500)).toBe(true)
-    expect(await until(() => !existsSync(pidPath), 500)).toBe(true)
+    expect(await waitFor(() => !existsSync(h.socketPath), GRACE_MS + 500)).toBe(true)
+    expect(await waitFor(() => !existsSync(h.pidPath), 500)).toBe(true)
   })
 
   it("stays up for a transient, never-subscribed connection", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), {
-      socketPath,
-      pidPath,
-      homeDir: dir,
-      updatePollMs: 0,
-    })
-    const poke = new KobeDaemonClient(socketPath)
+    h = await boot()
+    const poke = h.client()
     await poke.request("hello")
     await poke.request("daemon.status")
     poke.close()
 
     // Wait past the grace window; a non-GUI socket never armed the timer.
     await new Promise((r) => setTimeout(r, GRACE_MS + 150))
-    expect(existsSync(socketPath)).toBe(true)
+    expect(existsSync(h.socketPath)).toBe(true)
   })
 
   it("stays up for a transient, never-subscribed connection (default subscribe is pane)", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), { socketPath, pidPath, homeDir: dir, updatePollMs: 0 })
+    h = await boot()
     // A bare subscribe() (no role) is a "pane": it must NOT keep the daemon
     // alive. This is the bug — N ChatTab Tasks panes subscribed and the count
     // never hit 0 on quit, so the daemon never idle-stopped.
-    const pane = new KobeDaemonClient(socketPath)
+    const pane = h.client()
     await pane.subscribe()
     pane.close()
     // No gui ever attached → nothing armed the timer → daemon holds (a pane
     // closing must not stop it either, but no gui means it just stays up).
     await new Promise((r) => setTimeout(r, GRACE_MS + 150))
-    expect(existsSync(socketPath)).toBe(true)
+    expect(existsSync(h.socketPath)).toBe(true)
     pane.close()
   })
 
   it("panes never hold the daemon alive after the gui quits", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), { socketPath, pidPath, homeDir: dir, updatePollMs: 0 })
+    h = await boot()
     // The real-world shape: one gui front-end + several in-tmux Tasks panes.
-    const gui = new KobeDaemonClient(socketPath)
-    const pane1 = new KobeDaemonClient(socketPath)
-    const pane2 = new KobeDaemonClient(socketPath)
+    const gui = h.client()
+    const pane1 = h.client()
+    const pane2 = h.client()
     await gui.subscribe({ role: "gui" })
     await pane1.subscribe({ role: "pane" })
     await pane2.subscribe({ role: "pane" })
@@ -125,64 +80,54 @@ describe("daemon refcounted lazy shutdown", () => {
     // User quits kobe → only the gui socket drops. Panes stay subscribed
     // (the tmux session persists), but the daemon must still self-stop.
     gui.close()
-    expect(await until(() => !existsSync(socketPath), GRACE_MS + 500)).toBe(true)
+    expect(await waitFor(() => !existsSync(h.socketPath), GRACE_MS + 500)).toBe(true)
     pane1.close()
     pane2.close()
   })
 
   it("a pane subscribing during the grace window does NOT cancel shutdown", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), { socketPath, pidPath, homeDir: dir, updatePollMs: 0 })
-    const gui = new KobeDaemonClient(socketPath)
+    h = await boot()
+    const gui = h.client()
     await gui.subscribe({ role: "gui" })
     gui.close() // arms the grace timer
 
     // A pane connecting mid-grace must not rescue the daemon — only a gui can.
-    const pane = new KobeDaemonClient(socketPath)
+    const pane = h.client()
     await pane.subscribe({ role: "pane" })
 
-    expect(await until(() => !existsSync(socketPath), GRACE_MS + 500)).toBe(true)
+    expect(await waitFor(() => !existsSync(h.socketPath), GRACE_MS + 500)).toBe(true)
     pane.close()
   })
 
   it("only stops once the LAST of several subscribers leaves", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), {
-      socketPath,
-      pidPath,
-      homeDir: dir,
-      updatePollMs: 0,
-    })
-    const a = new KobeDaemonClient(socketPath)
-    const b = new KobeDaemonClient(socketPath)
+    h = await boot()
+    const a = h.client()
+    const b = h.client()
     await a.subscribe({ role: "gui" })
     await b.subscribe({ role: "gui" })
 
     a.close()
     // One GUI remains → daemon holds.
     await new Promise((r) => setTimeout(r, GRACE_MS + 150))
-    expect(existsSync(socketPath)).toBe(true)
+    expect(existsSync(h.socketPath)).toBe(true)
 
     b.close()
     // Now zero → self-stop.
-    expect(await until(() => !existsSync(socketPath), GRACE_MS + 500)).toBe(true)
+    expect(await waitFor(() => !existsSync(h.socketPath), GRACE_MS + 500)).toBe(true)
   })
 
   it("a re-subscribe within the grace window cancels the pending shutdown", async () => {
-    server = await startDaemonServer(fakeOrchestrator(), {
-      socketPath,
-      pidPath,
-      homeDir: dir,
-      updatePollMs: 0,
-    })
-    const first = new KobeDaemonClient(socketPath)
+    h = await boot()
+    const first = h.client()
     await first.subscribe({ role: "gui" })
     first.close() // arms the grace timer
 
     // Reconnect before grace elapses (mirrors manualReconnect's force-drop).
-    const second = new KobeDaemonClient(socketPath)
+    const second = h.client()
     await second.subscribe({ role: "gui" })
 
     await new Promise((r) => setTimeout(r, GRACE_MS + 150))
-    expect(existsSync(socketPath)).toBe(true)
+    expect(existsSync(h.socketPath)).toBe(true)
     second.close()
   })
 })

--- a/packages/kobe/test/daemon/socket-adversarial.test.ts
+++ b/packages/kobe/test/daemon/socket-adversarial.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Adversarial socket paths, over the REAL Unix socket — the failure modes
+ * the happy-path integration tests never send: malformed bytes, unknown
+ * request names, protocol-range mismatches, and clients that vanish or
+ * stall mid-conversation. Each test pins today's wire contract exactly
+ * (parse-error id, error wording, bare-`{message}` vs shaped errors) so a
+ * dispatch refactor that changes bytes fails loudly here.
+ */
+
+import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { DAEMON_PROTOCOL_VERSION, MIN_COMPATIBLE_PROTOCOL_VERSION } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { type DaemonHarness, bootDaemonHarness, waitFor } from "./harness.ts"
+
+describe("daemon socket adversarial paths", () => {
+  let h: DaemonHarness
+
+  beforeEach(async () => {
+    h = await bootDaemonHarness()
+  })
+
+  afterEach(async () => {
+    await h.close()
+  })
+
+  it("a malformed JSON line gets a parse-error response and the connection survives", async () => {
+    const raw = await h.rawSocket()
+    raw.sendLine("this is not json {{{")
+    const parseError = await raw.nextFrame((f) => f.type === "response" && f.id === "parse-error")
+    expect(parseError.error?.message).toBeTruthy()
+    // The parse-error path deliberately sends a bare `{ message }` — no
+    // `name` key ever hits the wire on this branch (server.ts).
+    expect(parseError.error && "name" in parseError.error).toBe(false)
+
+    // The connection is still usable: a well-formed request round-trips.
+    raw.request("daemon.status", {}, "after-garbage")
+    const ok = await raw.nextFrame((f) => f.type === "response" && f.id === "after-garbage")
+    expect(ok.error).toBeUndefined()
+    expect((ok.payload as { daemonPid: number }).daemonPid).toBe(process.pid)
+  })
+
+  it("a non-request frame from a client is refused with the request-only wire error", async () => {
+    const raw = await h.rawSocket()
+    raw.sendLine(JSON.stringify({ type: "event", name: "task.snapshot", payload: {} }))
+    const refusal = await raw.nextFrame((f) => f.type === "response" && f.id === "parse-error")
+    expect(refusal.error?.message).toBe("daemon only accepts request frames from clients")
+  })
+
+  it("an unknown request name rejects with the registry error and keeps the client usable", async () => {
+    const client = h.client()
+    await expect(client.request("definitely.not.a.thing" as DaemonRequestName)).rejects.toThrow(
+      "unknown daemon request: definitely.not.a.thing",
+    )
+    // The error is per-request, not per-connection: the same client still works.
+    const status = (await client.request("daemon.status")) as { daemonPid: number }
+    expect(status.daemonPid).toBe(process.pid)
+  })
+
+  it("hello refuses an out-of-range protocol peer and accepts a compatible one", async () => {
+    const client = h.client()
+    // An ancient client below the daemon's minimum → clear upgrade error.
+    const ancient = MIN_COMPATIBLE_PROTOCOL_VERSION - 1
+    await expect(client.request("hello", { protocolVersion: ancient, minProtocolVersion: ancient })).rejects.toThrow(
+      /Upgrade your kobe/,
+    )
+    // A future client whose MINIMUM is above the daemon's version → also refused.
+    const future = DAEMON_PROTOCOL_VERSION + 50
+    await expect(client.request("hello", { protocolVersion: future, minProtocolVersion: future })).rejects.toThrow(
+      /Upgrade your kobe/,
+    )
+    // The mismatch is per-request: the same connection completes a compatible
+    // handshake afterwards, and the daemon advertises its own range.
+    const hello = (await client.request("hello", {
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      minProtocolVersion: MIN_COMPATIBLE_PROTOCOL_VERSION,
+    })) as { protocolVersion: number; minProtocolVersion: number }
+    expect(hello.protocolVersion).toBe(DAEMON_PROTOCOL_VERSION)
+    expect(hello.minProtocolVersion).toBe(MIN_COMPATIBLE_PROTOCOL_VERSION)
+  })
+
+  it("a client that disconnects mid-request never takes the daemon down", async () => {
+    // Fire a request and hard-destroy the socket before the response can be
+    // written — the daemon's reply hits a dead socket (EPIPE path).
+    const raw = await h.rawSocket()
+    raw.request("hello", {})
+    raw.destroy()
+
+    // Do it again with a subscriber, so the teardown also races channel replay.
+    const raw2 = await h.rawSocket()
+    raw2.request("subscribe", {})
+    raw2.destroy()
+
+    // The daemon must still be fully alive for a fresh client.
+    const client = h.client()
+    const status = (await client.request("daemon.status")) as { daemonPid: number }
+    expect(status.daemonPid).toBe(process.pid)
+  })
+
+  it("a stalled subscriber never blocks delivery to a healthy one (backpressure end-to-end)", async () => {
+    // A subscriber that stops reading: its kernel buffer fills, pushing the
+    // daemon's writes for this socket into the bounded ClientWriter queue
+    // (droppable event frames shed past the high-water mark) instead of
+    // stalling the broadcast loop or growing the daemon heap unbounded.
+    const stalled = await h.rawSocket()
+    stalled.request("subscribe", {})
+    await stalled.nextFrame((f) => f.type === "response")
+    stalled.socket.pause() // stop reading — never resumes
+
+    const seen: string[] = []
+    const healthy = h.client()
+    healthy.onChannel("engine-state", (payload) => seen.push(payload.taskId))
+    await healthy.subscribe()
+
+    // Publish a meaty event stream: 100 distinct tasks × an ~8KB note each
+    // (~800KB of fan-out — far past a Unix socket's buffer for the stalled
+    // reader). Every publish must still reach the healthy subscriber.
+    const note = "x".repeat(8192)
+    const reporter = h.client()
+    for (let i = 0; i < 100; i++) {
+      await reporter.request("engine.reportEvent", { taskId: `task-${i}`, kind: "turn-start", detail: { note } })
+    }
+
+    expect(await waitFor(() => seen.includes("task-99"), 5000)).toBe(true)
+    expect(seen.length).toBe(100)
+    // And the daemon still answers RPC promptly with the stalled socket open.
+    const status = (await healthy.request("daemon.status")) as { daemonPid: number }
+    expect(status.daemonPid).toBe(process.pid)
+  })
+})


### PR DESCRIPTION
The knowledge of booting a daemon for tests was scattered across perf-golden and each integration test. Extract a single temp-socket boot/teardown harness, migrate the existing daemon integration tests onto it, and add previously-absent web-transport and socket-adversarial coverage.
