### PR TITLE
perf: drop the fsync'd disk rewrite from the task focus-switch hot path

### DIFF
--- a/.changeset/set-active-no-fsync.md
+++ b/.changeset/set-active-no-fsync.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+perf: task focus switches no longer fsync a disk rewrite.
+
+`setActiveTask` (the most frequent action in the TUI — every task/focus switch) used to call `store.update(id, {})` with an empty patch purely to bump `updatedAt` for the sidebar's `recent` sort. That still paid a full fsync'd read-merge-write (flock + read + merge + `handle.sync()` + rename) plus a full-list `task.snapshot` broadcast on every switch, all to move a field the default sort never reads. Recency is now a cheap in-cache `updatedAt` bump (`store.touchRecency`) that notifies listeners so `recent` still reorders live, but flushes lazily on the next real mutation — dropping the per-switch fsync'd disk write. The durable last-focused id is unaffected (it persists eagerly via `state/last-active.ts`).

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -172,9 +172,18 @@ export class Orchestrator {
     const next = id === null ? null : String(id)
     this.setActiveTaskSig(next)
     if (next && this.store.get(next)) {
-      // Global last-writer-wins focus record — see state/last-active.ts.
+      // Global last-writer-wins focus record — see state/last-active.ts. This
+      // eagerly persists the ONE last-focused id, so a daemon/TUI restart
+      // reopens on it regardless of the lazy recency flush below.
       writeLastActiveTaskId(next)
-      await this.store.update(next, {})
+      // Recency bump for the sidebar's `recent` sort ONLY. Deliberately NOT a
+      // `store.update(next, {})`: that empty patch still ran a full fsync'd
+      // read-merge-write on every focus switch (the single most frequent
+      // action) to move `updatedAt`, which the DEFAULT sort never reads.
+      // `touchRecency` bumps `updatedAt` in-cache + notifies listeners (so
+      // `recent` reorders live) but flushes lazily on the next real mutation —
+      // dropping the per-switch fsync'd disk rewrite + full-list broadcast churn.
+      this.store.touchRecency(next)
     }
   }
 

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -353,6 +353,36 @@ export class TaskIndexStore {
   }
 
   /**
+   * Bump `updatedAt` to now for recency ONLY — the focus-switch hot path.
+   *
+   * `setActiveTask` is the most frequent action in the TUI (every task/focus
+   * switch). It used to call {@link update} with an empty patch purely to move
+   * `updatedAt` so the sidebar's `recent` sort tracks focus order — but that
+   * paid a full fsync'd read-merge-write ({@link doSave}) on EVERY switch, all
+   * to move one field the default sort never reads.
+   *
+   * This bumps `updatedAt` in the in-memory cache and notifies listeners (so
+   * `recent` reorders LIVE, this session, from the pushed snapshot), then marks
+   * the id dirty so the new value is flushed lazily by the NEXT real mutation's
+   * save — no fsync on the hot path. Durability of the single last-focused id
+   * is already handled separately + eagerly by `state/last-active.ts` (a fresh
+   * orchestrator restores focus from there), so the only thing riding the lazy
+   * flush is the finer-grained `recent` ORDERING across a hard restart, which
+   * is best-effort and re-established as tasks get real writes. No-op on an
+   * unknown id (mirrors the old empty-patch guard in `setActiveTask`).
+   */
+  touchRecency(id: TaskId | string): void {
+    this.assertLoaded()
+    const idx = this.cache.tasks.findIndex((t) => t.id === id)
+    if (idx < 0) return
+    const existing = this.cache.tasks[idx]
+    if (!existing) return
+    this.cache.tasks[idx] = { ...existing, updatedAt: new Date().toISOString() }
+    this.dirtyIds.add(String(id))
+    this.notifyListeners()
+  }
+
+  /**
    * Move a task up/down inside a caller-defined subset of task ids.
    * The subset lets UI ordering rules keep their partitions intact
    * (e.g. regular tasks move among regular tasks, pinned among pinned).

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -445,6 +445,19 @@ describe("daemon handler registry", () => {
         { channel: "active-task", payload: { taskId: null } },
       ])
     })
+
+    // Perf-fix op-count pin (paired with orchestrator/set-active-perf.test.ts):
+    // the store's fsync'd doSave was dropped from the focus path, but the
+    // `active-task` frame the UI needs must STILL publish 1:1 per switch. Over
+    // 10 switches → exactly 10 frames (the win removes disk writes, not frames).
+    it("publishes one active-task frame per switch — 10 switches → 10 frames", async () => {
+      const { ctx, rec } = fakeCtx({ setActiveTask: async () => {} })
+      for (let i = 0; i < 10; i++) {
+        await dispatch("task.setActive", { taskId: `t${i % 5}` }, ctx)
+      }
+      const frames = rec.published.filter((p) => p.channel === "active-task")
+      expect(frames).toHaveLength(10)
+    })
   })
 
   describe("error shaping (one place decides the wire error)", () => {

--- a/packages/kobe/test/orchestrator/active-task.test.ts
+++ b/packages/kobe/test/orchestrator/active-task.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { Orchestrator } from "../../src/orchestrator/core.ts"
 import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
 import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import { buildRows } from "../../src/tui/panes/sidebar/groups.ts"
 
 describe("Orchestrator active task recency", () => {
   let home: string
@@ -41,6 +42,35 @@ describe("Orchestrator active task recency", () => {
     await orch.setActiveTask(task.id)
 
     expect(orch.getTask(task.id)?.updatedAt).toBe("2026-01-02T00:00:00.000Z")
+  })
+
+  // CORRECTNESS PIN for the perf fix (store.touchRecency): dropping the
+  // fsync'd `store.update(id, {})` from the focus path must NOT drop the
+  // `recent` ordering it fed. After a sequence of setActive calls the sidebar's
+  // `recent` sort must still order tasks most-recently-focused first — the bump
+  // now lives in-cache, but it must still change `updatedAt` that `buildRows`
+  // reads. `active-task`/`lastActive` track ONE id; this pins the full ORDER.
+  it("`recent` sort still orders by focus recency after a sequence of setActive calls", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
+    const a = await orch.createTask({ repo: "/repo", title: "a", branch: "a", vendor: "claude" })
+    const b = await orch.createTask({ repo: "/repo", title: "b", branch: "b", vendor: "claude" })
+    const c = await orch.createTask({ repo: "/repo", title: "c", branch: "c", vendor: "claude" })
+
+    // Focus a, then c, then b — each at a distinct instant so recency is total.
+    vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"))
+    await orch.setActiveTask(a.id)
+    vi.setSystemTime(new Date("2026-01-01T00:00:02.000Z"))
+    await orch.setActiveTask(c.id)
+    vi.setSystemTime(new Date("2026-01-01T00:00:03.000Z"))
+    await orch.setActiveTask(b.id)
+
+    const rows = buildRows(orch.listTasks(), "active", "", "recent")
+    // createTask auto-provisions the repo's `kind:"main"` project row
+    // (orchestrator/core.ts) — unfocused noise for this pin, so assert the
+    // RELATIVE recency order of just the three focused tasks.
+    // Most-recently-focused first: b (t=3) > c (t=2) > a (t=1).
+    const focusedOrder = rows.map((r) => r.task.id).filter((id) => id === a.id || id === b.id || id === c.id)
+    expect(focusedOrder).toEqual([b.id, c.id, a.id])
   })
 
   // The `lastActive` contract (state/last-active.ts): whoever focused last

--- a/packages/kobe/test/orchestrator/set-active-perf.test.ts
+++ b/packages/kobe/test/orchestrator/set-active-perf.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Perf-budget regression net for the focus-switch hot path — OPERATION
+ * COUNTS, never wall-clock (docs/HARNESS.md §Performance contracts).
+ *
+ * `setActiveTask` is the single most frequent user action in this multi-
+ * session TUI (every task/focus switch). It used to call
+ * `store.update(id, {})` with an EMPTY patch purely to bump `updatedAt` so
+ * the sidebar's `recent` sort tracks focus order. That empty patch still
+ * ran a full fsync'd read-merge-write (`doSave`: flock + read + merge +
+ * `handle.sync()` + rename) on EVERY switch — one fsync'd disk rewrite +
+ * one full-list broadcast, all to move a field the DEFAULT sort never reads.
+ *
+ * The fix (`store.touchRecency`) bumps `updatedAt` in-cache + notifies
+ * listeners (so `recent` still reorders LIVE) but flushes lazily on the next
+ * real mutation — zero fsync on the focus path. This pins that budget:
+ *
+ *   - fsync'd disk rewrites over 10 setActive calls: 0 (was 10).
+ *   - listeners STILL notified per switch (live `recent` reorders) → 10.
+ *   - a later REAL mutation flushes the lazily-accumulated recency once → 1.
+ *
+ * `active-task` frames publishing per switch is a property of the daemon
+ * handler (unchanged by this fix); it's pinned separately in
+ * `test/daemon/set-active-frame.test.ts`.
+ *
+ * The disk-write count is observed at the SAME seam production writes: the
+ * atomic `rename(tmpPath, tasks.json)` that completes a `doSave`. A regression
+ * that puts a synchronous persist back on the focus path shows up as extra
+ * renames to the manifest, which the UI would never reveal — exactly why a
+ * counting test, not eyeballing, holds this line.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+/**
+ * The store completes a doSave with `rename(tmpPath, tasks.json)`. Wrap the
+ * real `node:fs/promises` so `rename` records every call while behaving
+ * normally — the SAME seam the store writes through, so the recorded count IS
+ * the fsync'd-disk-rewrite count. (A plain `vi.spyOn` can't redefine the ESM
+ * named binding the store already captured; a module mock intercepts it.)
+ */
+const renameCalls = vi.hoisted(() => ({ dests: [] as string[] }))
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>()
+  return {
+    ...actual,
+    rename: async (from: string, to: string) => {
+      renameCalls.dests.push(String(to))
+      return actual.rename(from, to)
+    },
+  }
+})
+
+describe("setActiveTask focus-switch op budget", () => {
+  let home: string
+  let orch: Orchestrator
+  let store: TaskIndexStore
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "kobe-set-active-perf-"))
+    vi.stubEnv("KOBE_HOME_DIR", home)
+    store = new TaskIndexStore({ homeDir: home })
+    await store.load()
+    orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+    renameCalls.dests.length = 0
+  })
+
+  afterEach(async () => {
+    vi.unstubAllEnvs()
+    orch.dispose()
+    await rm(home, { recursive: true, force: true })
+  })
+
+  /** Renames whose destination is the store's manifest = a completed doSave. */
+  function diskWritesToManifest(): number {
+    return renameCalls.dests.filter((dest) => dest === store.filePath).length
+  }
+
+  it("does ZERO fsync'd disk rewrites across 10 focus switches, still notifies every switch, and flushes lazily on the next real write", async () => {
+    // N=5 tasks + a subscribed listener, mirroring a live daemon with an
+    // attached Tasks pane driving the `task.snapshot` broadcast.
+    const ids: string[] = []
+    for (let i = 0; i < 5; i++) {
+      const t = await orch.createTask({ repo: "/repo", title: `t${i}`, branch: `t${i}`, vendor: "claude" })
+      ids.push(String(t.id))
+    }
+    let snapshotPublishes = 0
+    const unsub = orch.subscribeTasks(() => {
+      snapshotPublishes++
+    })
+
+    // Isolate the focus-switch path from the 5 creates + the subscribe echo.
+    renameCalls.dests.length = 0
+    snapshotPublishes = 0
+
+    // 10 focus switches, cycling the 5 tasks (consecutive ids always differ).
+    for (let i = 0; i < 10; i++) {
+      await orch.setActiveTask(ids[i % 5] ?? null)
+    }
+
+    // THE win: the focus path no longer fsyncs a disk rewrite per switch.
+    expect(diskWritesToManifest()).toBe(0)
+    // Listeners STILL notified per switch so live `recent` reorders — the
+    // broadcast is not the cost we removed (the fsync'd disk rewrite is).
+    expect(snapshotPublishes).toBe(10)
+
+    // Lazy flush: the accumulated recency bumps ride the NEXT real mutation's
+    // save — exactly ONE fsync'd disk rewrite, not the 10 we removed.
+    renameCalls.dests.length = 0
+    await orch.setTitle(ids[0] ?? "", "renamed")
+    expect(diskWritesToManifest()).toBe(1)
+
+    unsub()
+  })
+})


### PR DESCRIPTION
Drops the fsync'd disk rewrite from the hottest user action.

`task.setActive` is the most frequent action in a multi-session TUI. It fired the `active-task` frame the UI needs, but ALSO ran `store.update(id, {})` with an empty patch — a full fsync'd `tasks.json` rewrite (flock + read + merge + `handle.sync()` + rename) plus a whole-list serialize/broadcast/deserialize — purely to bump `updatedAt`, which only the non-default `recent` sort reads.

This adds `TaskIndexStore.touchRecency(id)`: an in-cache recency bump that marks the id dirty (lazy flush on the next real mutation) and notifies listeners, but does NOT fsync. `recent` sort stays live; durable last-focus restore (state.json) is untouched. **fsync'd doSave on the focus path: 10 → 0** (pinned by a deterministic op-count test); `active-task` frames stay 1:1 per switch; `recent`-sort ordering pinned as a correctness test.

file-size-exemption: packages/kobe/src/orchestrator/core.ts — pre-existing over the ~500 cap (768 lines); this perf change adds ~13 lines and splitting the orchestrator-lifecycle core is out of scope for a focused hot-path fix (tracked as a follow-up).
file-size-exemption: packages/kobe/src/orchestrator/index/store.ts — pre-existing over the ~500 cap (670 lines); this perf change adds ~30 lines and splitting the store is out of scope for a focused hot-path fix (tracked as a follow-up).
