### PR TITLE
ci: make the informational .tsx render-coverage step non-fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,11 +211,16 @@ jobs:
         run: bun run coverage
 
       - name: Render-track coverage (kobe package .tsx)
-        # bun test + @opentui/solid's testRender (docs/HARNESS.md "render
-        # track") — the only runner that can execute opentui Solid
-        # components at all. Separate report; not gated per-file (yet), just
-        # folded into the Codecov upload below so the repo-wide badge
-        # reflects .tsx too.
+        # bun test + @opentui/react's testRender (docs/HARNESS.md "render
+        # track") — the only runner that can execute opentui components at
+        # all. Separate report; not gated per-file (yet), just folded into
+        # the Codecov upload below so the repo-wide badge reflects .tsx too.
+        # Non-fatal: Bun 1.3.13's coverage instrumentation SIGILLs on the
+        # opentui native path on the current ubuntu runner (test:render is
+        # green locally). Since this track is informational — the .ts
+        # per-file gate below is the real one — a crash here must not block
+        # the gate. Drop continue-on-error once a Bun bump stops the crash.
+        continue-on-error: true
         working-directory: packages/kobe
         run: bun run test:render
 


### PR DESCRIPTION
Bun 1.3.13's coverage instrumentation SIGILLs (exit 132) on the opentui native path on the current ubuntu runner, failing the whole `coverage-cap` job at the `test:render` step — before the real per-file `.ts` gate (`coverage-gate.mjs`) even runs. `test:render` is green locally (40/40), so this is an environment crash, not a test regression.

The render track is informational ("not gated per-file" per docs/HARNESS.md), so this marks that step `continue-on-error: true`. The `.ts` per-file coverage floor still hard-fails. Also corrects the stale "@opentui/solid" comment (the render track is @opentui/react since the Solid TUI was removed).

Unblocks #281–#291, whose only red check is this crash. Revert once a Bun bump stops the SIGILL.