### PR TITLE
feat: sidebar defers its engine spinner to the live terminal for the viewed task

### DIFF
--- a/.changeset/sidebar-defer-live-terminal.md
+++ b/.changeset/sidebar-defer-live-terminal.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Sidebar: the task whose terminal you're currently viewing no longer draws kobe's own engine spinner. The live terminal already shows claude/codex's own zero-latency spinner, so the sidebar row defers to it instead of animating a duplicate that's necessarily a beat behind. Unfocused rows still spin (their terminal isn't on screen, so kobe's signal is the only liveness cue), and a materializing worktree job still spins even on the viewed row since no terminal exists yet.

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -160,6 +160,8 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
       truncateBranch: truncateBranchLabel,
       mainBranch: currentBranch(task.repo),
       reducedMotion: themeCtx.reducedMotion,
+      // Defer to the live terminal when this task's pane is the one on screen.
+      isViewed: isSelected,
     }),
     () => shared.spinnerFrame,
   )
@@ -227,6 +229,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
       truncateBranch: truncateBranchLabel,
       mainBranch: "",
       reducedMotion: themeCtx.reducedMotion,
+      isViewed: isSelected,
     }),
     () => shared.spinnerFrame,
   )

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -183,6 +183,17 @@ export function buildSidebarRowView(opts: {
   readonly mainBranch?: string
   /** Accessibility: swap the engine spinner for the slow pulsing dot. */
   readonly reducedMotion?: boolean
+  /**
+   * This task's terminal is the one currently on screen in the workspace
+   * (task.id === the host's selectedId). When true, the row suppresses its
+   * own engine-activity spinner and defers to the live terminal, where
+   * claude/codex draws its OWN zero-latency spinner — kobe's derived signal
+   * is necessarily a beat behind, so a spinner here is just a laggy duplicate
+   * of one you can already see. `materializing` is exempt (no terminal exists
+   * yet). Other rows are unaffected: their terminal isn't visible, so kobe's
+   * spinner is the only liveness cue they have.
+   */
+  readonly isViewed?: boolean
 }): SidebarRowView {
   const { task } = opts
   const isMain = task.kind === "main"
@@ -208,7 +219,8 @@ export function buildSidebarRowView(opts: {
   const materializing = opts.job !== undefined
   const loading =
     materializing ||
-    (!untrackedCustomEngine &&
+    (!opts.isViewed &&
+      !untrackedCustomEngine &&
       (activityState === "running" || opts.live || (!hasActivity && !isMain && task.status === "in_progress")))
   // Engine-owned brand frames (registry `spinnerFrames`), braille fallback;
   // reduced motion replaces every set with the slow pulsing dot.

--- a/packages/kobe/test/tui/sidebar-row-view.test.ts
+++ b/packages/kobe/test/tui/sidebar-row-view.test.ts
@@ -250,3 +250,31 @@ describe("sweepBar", () => {
     expect(sweepBar(10, 8)).toBe("        ")
   })
 })
+
+describe("buildSidebarRowView — defer to the live terminal (isViewed)", () => {
+  const base = { live: true, spinnerFrame: 0, subtitleBudget: 80, truncateBranch: (b: string) => b } as const
+
+  it("spins for a live task whose terminal is NOT the one on screen", () => {
+    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base, isViewed: false })
+    expect(v.loading).toBe(true)
+  })
+
+  it("suppresses its own spinner when the task's terminal is the one being viewed", () => {
+    // claude/codex draws its OWN zero-latency spinner in the visible pane, so
+    // kobe's derived (laggier) spinner would be a duplicate — the viewed row
+    // defers to the live terminal instead of animating.
+    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base, isViewed: true })
+    expect(v.loading).toBe(false)
+    expect(v.stateGlyph).toBe("")
+  })
+
+  it("still spins a viewed row while its worktree materializes (no terminal yet)", () => {
+    const v = buildSidebarRowView({
+      task: task({ status: "in_progress" }),
+      ...base,
+      isViewed: true,
+      job: { kind: "ensureWorktree" },
+    })
+    expect(v.loading).toBe(true)
+  })
+})


### PR DESCRIPTION
The sidebar row for the task you're **currently viewing** drew kobe's own engine-activity spinner — but claude/codex already draws its OWN zero-latency spinner in that on-screen terminal, so kobe's was a laggy duplicate a beat behind (kobe's signal is hook/transcript-derived; the terminal's is first-hand).

`buildSidebarRowView` now takes `isViewed` (`task.id === the host's selectedId`, i.e. the pane on screen) and suppresses the engine-activity spinner for that one row, deferring to the live terminal. Unfocused rows are unchanged — their terminal isn't visible, so kobe's spinner is the only liveness cue they have. A materializing worktree job still spins even on the viewed row (no terminal exists yet). Pure-function change in `row-view.ts` with 3 new unit cases; wired at both `row-cards.tsx` call sites.