### PR TITLE
fix: isolate embedded terminal identity

### DIFF
--- a/.changeset/embedded-terminal-identity.md
+++ b/.changeset/embedded-terminal-identity.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Embedded terminals no longer leak the outer emulator's identity to child applications, preventing terminal-specific escape sequences from being selected for the wrong parser.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,6 +90,14 @@ _Avoid_: pty daemon, sidecar (that's kobe-web's Node PTY process).
 A terminal-backend handle whose child lives in the **PTY Host** (`HostedTaskPty`, `src/tui/panes/terminal/pty-hosted.ts`) — the DEFAULT backend. VT emulation stays in the TUI process (`pty-xterm-base.ts`); only raw bytes cross the socket. `kill()` ends the remote child; `detach()` drops just this handle and leaves the child running. The local-child backend (`pty.ts`) and pipe fallback (`pty-pipe.ts`) still exist for non-persistent uses; they cannot detach and are never parked.
 _Avoid_: remote pty (that's the SSH/remote-projects sense).
 
+**Terminal Identity Boundary**:
+The environment boundary between a terminal child and the VT parser it immediately talks to. A child inside the **Workspace Host** talks to kobe's xterm parser, not to an outer iTerm2 or Terminal.app, so every spawn path uses `embeddedTerminalEnv`: advertise embedded-terminal capabilities (`TERM=xterm-256color`, `COLORTERM=truecolor`) but strip outer-emulator identity (`TERM_PROGRAM`, `TERM_PROGRAM_VERSION`). This policy covers **Hosted PTY**, local Bun PTY, pipe fallback, and the web PTY sidecar.
+
+SSH appeared correct because it normally forwards `TERM` but not `TERM_PROGRAM` or `TERM_PROGRAM_VERSION`. Remote Neovim therefore stayed on its xterm-compatible color path. Locally, the contradictory pair `TERM=xterm-256color` plus inherited `TERM_PROGRAM=iTerm.app` made Neovim emit iTerm's short colon RGB form (`38:2:R:G:B`); xterm.js follows the fixed T.416 field positions and interpreted the channels differently, producing the yellow/olive cast. Explicitly forwarding the outer identity over SSH can reproduce the same failure.
+
+The identity at each nested-terminal or multiplexer boundary must describe the immediate parser, never an ancestor emulator. Fix the spawn boundary rather than application-specific configuration or user Neovim state.
+_Avoid_: outer terminal passthrough, Neovim color workaround, terminal config mismatch.
+
 **Focus**:
 The single source of truth for which pane has the keyboard (`src/tui-react/context/focus.tsx`): `PaneId = "sidebar" | "workspace" | "files" | "terminal"`, default `sidebar`. Pane wrappers set it on click; `ctrl+h/j/k/l` jump directly (global `focus.numeric`), F4 cycles forward (`focus.next`), `ctrl+q` returns to the sidebar. Pane-scoped plain-letter bindings gate on it — the boundary rule in [`docs/KEYBINDINGS.md`](./docs/KEYBINDINGS.md).
 _Avoid_: active pane, selection (that's the sidebar's selected task).

--- a/docs/superpowers/plans/2026-07-10-embedded-terminal-identity.md
+++ b/docs/superpowers/plans/2026-07-10-embedded-terminal-identity.md
@@ -1,0 +1,218 @@
+# Embedded Terminal Identity Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent Kobe's embedded terminals from advertising the outer terminal emulator's identity to child applications.
+
+**Architecture:** Add one package-level pure environment builder in `@sma1lboy/kobe-daemon` that removes `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` while preserving all capability variables and explicit PTY overrides. Reuse it from the daemon-hosted PTY, Bun PTY, pipe fallback, and web PTY sidecar; keep the web sidecar's existing `NO_COLOR`/`CLICOLOR` policy in a small wrapper.
+
+**Tech Stack:** TypeScript, ESM JavaScript, Bun PTY, node-pty, Vitest, bun:test.
+
+## Global Constraints
+
+- Do not modify user Neovim, shell, or global terminal configuration.
+- Remove only `TERM_PROGRAM` and `TERM_PROGRAM_VERSION`; retain `TERM`, `COLORTERM`, and Kobe's PTY marker variables.
+- Apply the policy at every embedded PTY spawn boundary: hosted, Bun fallback, pipe fallback, and web.
+- Preserve the in-progress terminal-palette work already present in the working tree.
+- Add no dependency and keep every touched source file below 500 lines.
+- Add one patch changeset; do not promote the release bump.
+- Restart the daemon after daemon code changes.
+
+---
+
+### Task 1: Shared environment policy
+
+**Files:**
+- Create: `packages/kobe-daemon/src/daemon/pty-env.js`
+- Create: `packages/kobe-daemon/src/daemon/pty-env.d.ts`
+- Modify: `packages/kobe-daemon/package.json`
+- Create: `packages/kobe/test/lib/embedded-terminal-env.test.ts`
+
+**Interfaces:**
+- Produces: `embeddedTerminalEnv(base, overrides?) -> NodeJS.ProcessEnv` from `@sma1lboy/kobe-daemon/daemon/pty-env`.
+- Guarantees: the returned object omits `TERM_PROGRAM` and `TERM_PROGRAM_VERSION`, does not mutate `base`, and applies explicit overrides last.
+
+- [x] **Step 1: Add a compiling stub and the failing pure test**
+
+Create the package export and a stub that clones the environment without removing terminal identity. Add this test:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { embeddedTerminalEnv } from "@sma1lboy/kobe-daemon/daemon/pty-env"
+
+describe("embeddedTerminalEnv", () => {
+  it("removes the outer terminal identity while retaining capabilities and overrides", () => {
+    const base = {
+      TERM_PROGRAM: "iTerm.app",
+      TERM_PROGRAM_VERSION: "3.6.11",
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      HOME: "/home/test",
+    }
+    const result = embeddedTerminalEnv(base, { KOBE_TERMINAL_PTY: "1" })
+    expect(result).toEqual({
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      HOME: "/home/test",
+      KOBE_TERMINAL_PTY: "1",
+    })
+    expect(base.TERM_PROGRAM).toBe("iTerm.app")
+  })
+})
+```
+
+- [x] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+cd packages/kobe
+bunx vitest run test/lib/embedded-terminal-env.test.ts
+```
+
+Expected: FAIL because the stub still returns `TERM_PROGRAM` and `TERM_PROGRAM_VERSION`.
+
+- [x] **Step 3: Implement the minimal environment builder**
+
+Replace the stub with:
+
+```js
+export function embeddedTerminalEnv(base, overrides = {}) {
+  const { TERM_PROGRAM: _termProgram, TERM_PROGRAM_VERSION: _termProgramVersion, ...env } = base
+  return { ...env, ...overrides }
+}
+```
+
+- [x] **Step 4: Run the pure test and verify GREEN**
+
+Run the same focused Vitest command. Expected: PASS.
+
+---
+
+### Task 2: Hosted, Bun, and pipe PTY spawn boundaries
+
+**Files:**
+- Modify: `packages/kobe-daemon/src/daemon/pty-host.ts`
+- Modify: `packages/kobe/src/tui/panes/terminal/pty.ts`
+- Modify: `packages/kobe/src/tui/panes/terminal/pty-pipe.ts`
+- Modify: `packages/kobe/test/render/pty-host.test.ts`
+- Create: `packages/kobe/test/render/pty-local-env.test.ts`
+
+**Interfaces:**
+- Consumes: `embeddedTerminalEnv` from Task 1.
+- Preserves: each backend's existing `TERM`, geometry, shell-warning, and Kobe marker overrides.
+
+- [x] **Step 1: Add failing real-child environment tests**
+
+For `PtyHost`, spawn `/bin/sh -c` to print `${TERM_PROGRAM-unset}` and `${TERM_PROGRAM_VERSION-unset}` while the parent environment contains iTerm values. For `BunTerminalTaskPty` and `PipeTaskPty`, do the same and poll their existing `capture()` surfaces. Each assertion expects `program=unset version=unset`.
+
+- [x] **Step 2: Run render tests and verify RED**
+
+Run:
+
+```bash
+cd packages/kobe
+bun test test/render/pty-host.test.ts test/render/pty-local-env.test.ts
+```
+
+Expected: the three new assertions fail with inherited `iTerm.app` / `3.6.11` values.
+
+- [x] **Step 3: Route all three spawn environments through the shared helper**
+
+Replace each inline `{ ...process.env, ...overrides }` with:
+
+```ts
+embeddedTerminalEnv(process.env, {
+  TERM: "xterm-256color",
+  COLUMNS: String(this.cols),
+  LINES: String(this.rows),
+  BASH_SILENCE_DEPRECATION_WARNING: "1",
+  KOBE_TERMINAL_PTY: "1",
+})
+```
+
+The daemon-hosted and Bun blocks use the four overrides above. The pipe block
+uses `TERM: process.env.TERM ?? "xterm-256color"`, its current `COLUMNS` and
+`LINES`, and `KOBE_TERMINAL_PIPE: "1"`.
+
+- [x] **Step 4: Run render tests and verify GREEN**
+
+Run the same focused Bun test command. Expected: all selected tests pass.
+
+---
+
+### Task 3: Web PTY sidecar
+
+**Files:**
+- Create: `packages/kobe-web/pty-env.mjs`
+- Modify: `packages/kobe-web/pty-server.mjs`
+- Create: `packages/kobe-web/test/pty-env.test.ts`
+
+**Interfaces:**
+- Produces: `ptyEnv(base?)`, which composes the shared identity cleanup with the web sidecar's existing `NO_COLOR`, `CLICOLOR`, and `COLORTERM` policy.
+
+- [x] **Step 1: Extract the existing web policy and add a failing identity test**
+
+Create `pty-env.mjs` with the current `NO_COLOR` behavior but without identity cleanup. Add a test whose explicit base contains iTerm identity and `NO_COLOR=1`; expect identity and `NO_COLOR` absent, with `CLICOLOR=1` and `COLORTERM=truecolor` retained.
+
+- [x] **Step 2: Run the web test and verify RED**
+
+Run:
+
+```bash
+cd packages/kobe-web
+bunx vitest run test/pty-env.test.ts
+```
+
+Expected: FAIL because the extracted current behavior still retains the two iTerm variables.
+
+- [x] **Step 3: Compose the shared helper and wire the server**
+
+Import `embeddedTerminalEnv`, call it after removing `NO_COLOR`, export `ptyEnv`, and replace the server-local function with an import from `./pty-env.mjs`.
+
+- [x] **Step 4: Run the web test and verify GREEN**
+
+Run the same focused Vitest command. Expected: PASS.
+
+---
+
+### Task 4: Release note and verification
+
+**Files:**
+- Create: `.changeset/embedded-terminal-identity.md`
+- Modify: only files listed in Tasks 1-3 and this plan.
+
+- [x] **Step 1: Add a patch changeset**
+
+```md
+---
+"@sma1lboy/kobe": patch
+---
+
+Embedded terminals no longer leak the outer emulator's identity to child applications, preventing terminal-specific escape sequences from being selected for the wrong parser.
+```
+
+- [x] **Step 2: Run focused and package verification**
+
+```bash
+cd packages/kobe && bun test test/render/pty-host.test.ts test/render/pty-local-env.test.ts
+cd packages/kobe && bunx vitest run test/lib/embedded-terminal-env.test.ts
+bun --filter @sma1lboy/kobe typecheck
+bun --filter @sma1lboy/kobe-daemon typecheck
+cd packages/kobe-web && bunx vitest run test/pty-env.test.ts
+bun --filter kobe-web build
+```
+
+Expected: every command exits 0 without new warnings.
+
+- [x] **Step 3: Run hygiene checks and restart the daemon**
+
+```bash
+git diff --check
+bunx biome check packages/kobe-daemon/src/daemon/pty-env.js packages/kobe-daemon/src/daemon/pty-env.d.ts packages/kobe-daemon/src/daemon/pty-host.ts packages/kobe/src/tui/panes/terminal/pty.ts packages/kobe/src/tui/panes/terminal/pty-pipe.ts packages/kobe-web/pty-env.mjs packages/kobe-web/pty-server.mjs packages/kobe/test/lib/embedded-terminal-env.test.ts packages/kobe/test/render/pty-host.test.ts packages/kobe/test/render/pty-local-env.test.ts packages/kobe-web/test/pty-env.test.ts
+kobe daemon restart
+```
+
+- [x] **Step 4: Commit only this stream's hunks**
+
+Inspect `git status`, `git diff`, and `git diff --cached`. Stage only the files and partial `pty-pipe.ts` hunks belonging to terminal identity isolation, then commit with a conventional message and 2-3 sentence body. Do not stage the pre-existing palette implementation or unrelated workspace files.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -27,6 +27,7 @@
     "./daemon/paths": "./src/daemon/paths.ts",
     "./daemon/pr-status-collector": "./src/daemon/pr-status-collector.ts",
     "./daemon/protocol": "./src/daemon/protocol.ts",
+    "./daemon/pty-env": "./src/daemon/pty-env.js",
     "./daemon/pty-host": "./src/daemon/pty-host.ts",
     "./daemon/pty-server": "./src/daemon/pty-server.ts",
     "./daemon/server": "./src/daemon/server.ts",

--- a/packages/kobe-daemon/src/daemon/pty-env.d.ts
+++ b/packages/kobe-daemon/src/daemon/pty-env.d.ts
@@ -1,0 +1,6 @@
+export type TerminalEnvironment = Readonly<Record<string, string | undefined>>
+
+export declare function embeddedTerminalEnv(
+  base: TerminalEnvironment,
+  overrides?: TerminalEnvironment,
+): Record<string, string | undefined>

--- a/packages/kobe-daemon/src/daemon/pty-env.js
+++ b/packages/kobe-daemon/src/daemon/pty-env.js
@@ -1,0 +1,13 @@
+/**
+ * Build the environment seen by a child of an embedded terminal.
+ * The embedded parser is not the outer emulator, so its identity must not
+ * leak through and trigger emulator-specific protocol choices in children.
+ *
+ * @param {Readonly<Record<string, string | undefined>>} base
+ * @param {Readonly<Record<string, string | undefined>>} [overrides]
+ * @returns {Record<string, string | undefined>}
+ */
+export function embeddedTerminalEnv(base, overrides = {}) {
+  const { TERM_PROGRAM: _termProgram, TERM_PROGRAM_VERSION: _termProgramVersion, ...env } = base
+  return { ...env, ...overrides }
+}

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -26,6 +26,7 @@
 
 import { StringDecoder } from "node:string_decoder"
 import type { DaemonFrame } from "./protocol.ts"
+import { embeddedTerminalEnv } from "./pty-env.js"
 
 /** Everything `pty.open` needs to spawn a session's child on first open. */
 export interface PtySpawnSpec {
@@ -223,14 +224,13 @@ export class PtyHost {
     try {
       session.proc = Bun.spawn(argv, {
         cwd: spec.cwd,
-        env: {
-          ...process.env,
+        env: embeddedTerminalEnv(process.env, {
           TERM: "xterm-256color",
           COLUMNS: String(spec.cols),
           LINES: String(spec.rows),
           BASH_SILENCE_DEPRECATION_WARNING: "1",
           KOBE_TERMINAL_PTY: "1",
-        },
+        }),
         terminal: {
           cols: spec.cols,
           rows: spec.rows,

--- a/packages/kobe-web/pty-env.mjs
+++ b/packages/kobe-web/pty-env.mjs
@@ -1,0 +1,15 @@
+import { embeddedTerminalEnv } from "@sma1lboy/kobe-daemon/daemon/pty-env"
+
+/**
+ * Environment policy for browser-backed PTY children.
+ *
+ * @param {Readonly<Record<string, string | undefined>>} [base]
+ * @returns {Record<string, string | undefined>}
+ */
+export function ptyEnv(base = process.env) {
+  const { NO_COLOR: _noColor, ...env } = embeddedTerminalEnv(base)
+  // CI/launcher shells may suppress color, but this child owns a real PTY.
+  env.CLICOLOR = env.CLICOLOR ?? "1"
+  env.COLORTERM = env.COLORTERM || "truecolor"
+  return env
+}

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -17,6 +17,7 @@ import { createServer } from "node:http"
 import { spawn } from "node-pty"
 import { WebSocketServer } from "ws"
 import { allowedHostForBindHost, originAllowed } from "./origin-policy.mjs"
+import { ptyEnv } from "./pty-env.mjs"
 import { createScrollback } from "./pty-scrollback.mjs"
 import { createPtySessionManager } from "./pty-session-lifecycle.mjs"
 
@@ -27,16 +28,6 @@ const HEALTH_PATH = "/__kobe_web"
 const HEALTH_MARKER = "kobe-web"
 const HOST = process.env.KOBE_WEB_HOST?.trim() || "127.0.0.1"
 const ALLOWED_HOST = allowedHostForBindHost(HOST)
-
-function ptyEnv() {
-  const { NO_COLOR: _noColor, ...env } = process.env
-  // Codex/CI shells often set NO_COLOR=1. The browser PTY is a real terminal
-  // surface, so don't let the launcher process accidentally turn off colors in
-  // Claude, Codex, shells, or common CLI tools.
-  env.CLICOLOR = env.CLICOLOR ?? "1"
-  env.COLORTERM = env.COLORTERM || "truecolor"
-  return env
-}
 
 async function fetchSpec(taskId, mode) {
   // e2e/dev harness override: run an arbitrary TUI (dev:mock / dev:sandbox) in

--- a/packages/kobe-web/test/pty-env.test.ts
+++ b/packages/kobe-web/test/pty-env.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { ptyEnv } from "../pty-env.mjs"
+
+describe("ptyEnv", () => {
+  it("removes launcher color suppression and outer terminal identity", () => {
+    const base = {
+      NO_COLOR: "1",
+      TERM_PROGRAM: "iTerm.app",
+      TERM_PROGRAM_VERSION: "3.6.11",
+      TERM: "xterm-256color",
+    }
+
+    expect(ptyEnv(base)).toEqual({
+      TERM: "xterm-256color",
+      CLICOLOR: "1",
+      COLORTERM: "truecolor",
+    })
+    expect(base.NO_COLOR).toBe("1")
+  })
+})

--- a/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-pipe.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { embeddedTerminalEnv } from "@sma1lboy/kobe-daemon/daemon/pty-env"
 import {
   type CursorPos,
   DEFAULT_COLS,
@@ -41,13 +42,12 @@ export class PipeTaskPty implements TaskPtyLike {
     const args = argv.slice(1)
     this.proc = spawn(exe, args, {
       cwd: opts.cwd,
-      env: {
-        ...process.env,
+      env: embeddedTerminalEnv(process.env, {
         TERM: process.env.TERM ?? "xterm-256color",
         COLUMNS: String(this.cols),
         LINES: String(this.rows),
         KOBE_TERMINAL_PIPE: "1",
-      },
+      }),
       stdio: ["pipe", "pipe", "pipe"],
     })
 

--- a/packages/kobe/src/tui/panes/terminal/pty.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty.ts
@@ -21,6 +21,7 @@
  * same `Chunk[]` rows.
  */
 
+import { embeddedTerminalEnv } from "@sma1lboy/kobe-daemon/daemon/pty-env"
 import { HostedTaskPty } from "./pty-hosted"
 import { MockTaskPty } from "./pty-mock"
 import { PipeTaskPty } from "./pty-pipe"
@@ -43,14 +44,13 @@ export class BunTerminalTaskPty extends XtermTaskPty {
     super(opts)
     this.proc = Bun.spawn(resolveArgv(opts), {
       cwd: opts.cwd,
-      env: {
-        ...process.env,
+      env: embeddedTerminalEnv(process.env, {
         TERM: "xterm-256color",
         COLUMNS: String(this.cols),
         LINES: String(this.rows),
         BASH_SILENCE_DEPRECATION_WARNING: "1",
         KOBE_TERMINAL_PTY: "1",
-      },
+      }),
       terminal: {
         cols: this.cols,
         rows: this.rows,

--- a/packages/kobe/test/lib/embedded-terminal-env.test.ts
+++ b/packages/kobe/test/lib/embedded-terminal-env.test.ts
@@ -1,0 +1,24 @@
+import { embeddedTerminalEnv } from "@sma1lboy/kobe-daemon/daemon/pty-env"
+import { describe, expect, it } from "vitest"
+
+describe("embeddedTerminalEnv", () => {
+  it("removes the outer terminal identity while retaining capabilities and overrides", () => {
+    const base = {
+      TERM_PROGRAM: "iTerm.app",
+      TERM_PROGRAM_VERSION: "3.6.11",
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      HOME: "/home/test",
+    }
+
+    const result = embeddedTerminalEnv(base, { KOBE_TERMINAL_PTY: "1" })
+
+    expect(result).toEqual({
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      HOME: "/home/test",
+      KOBE_TERMINAL_PTY: "1",
+    })
+    expect(base.TERM_PROGRAM).toBe("iTerm.app")
+  })
+})

--- a/packages/kobe/test/render/pty-host.test.ts
+++ b/packages/kobe/test/render/pty-host.test.ts
@@ -45,6 +45,21 @@ function dataText(frames: DaemonFrame[]): string {
   return out
 }
 
+function withOuterTerminalIdentity<T>(run: () => T): T {
+  const program = process.env.TERM_PROGRAM
+  const version = process.env.TERM_PROGRAM_VERSION
+  process.env.TERM_PROGRAM = "iTerm.app"
+  process.env.TERM_PROGRAM_VERSION = "3.6.11"
+  try {
+    return run()
+  } finally {
+    if (program === undefined) Reflect.deleteProperty(process.env, "TERM_PROGRAM")
+    else process.env.TERM_PROGRAM = program
+    if (version === undefined) Reflect.deleteProperty(process.env, "TERM_PROGRAM_VERSION")
+    else process.env.TERM_PROGRAM_VERSION = version
+  }
+}
+
 async function until(cond: () => boolean, ms = 3000): Promise<void> {
   const start = Date.now()
   while (!cond()) {
@@ -136,5 +151,28 @@ describe("PtyHost", () => {
     expect(row).toMatchObject({ key: "t1::tab1", alive: true, title: "实时进程" })
     expect(typeof row?.pid).toBe("number")
     expect(row?.command[0]).toBe("/bin/sh")
+  })
+
+  test("does not leak the outer terminal emulator identity to hosted children", async () => {
+    const host = makeHost()
+    const { frames, sink } = collector()
+    withOuterTerminalIdentity(() => {
+      host.open(
+        "t1::env",
+        {
+          ...SPEC,
+          command: [
+            "/bin/sh",
+            "-c",
+            'printf "program=%s version=%s\\n" "${TERM_PROGRAM-unset}" "${TERM_PROGRAM_VERSION-unset}"; sleep 1',
+          ],
+        },
+        {},
+        sink,
+      )
+    })
+
+    await until(() => dataText(frames).includes("program="))
+    expect(dataText(frames)).toContain("program=unset version=unset")
   })
 })

--- a/packages/kobe/test/render/pty-local-env.test.ts
+++ b/packages/kobe/test/render/pty-local-env.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { TaskPtyLike } from "../../src/tui/panes/terminal/pty-types.ts"
+import { BunTerminalTaskPty, PipeTaskPty } from "../../src/tui/panes/terminal/pty.ts"
+
+const children: TaskPtyLike[] = []
+
+afterEach(() => {
+  for (const child of children.splice(0)) child.kill()
+})
+
+function withOuterTerminalIdentity<T>(run: () => T): T {
+  const program = process.env.TERM_PROGRAM
+  const version = process.env.TERM_PROGRAM_VERSION
+  process.env.TERM_PROGRAM = "iTerm.app"
+  process.env.TERM_PROGRAM_VERSION = "3.6.11"
+  try {
+    return run()
+  } finally {
+    if (program === undefined) Reflect.deleteProperty(process.env, "TERM_PROGRAM")
+    else process.env.TERM_PROGRAM = program
+    if (version === undefined) Reflect.deleteProperty(process.env, "TERM_PROGRAM_VERSION")
+    else process.env.TERM_PROGRAM_VERSION = version
+  }
+}
+
+function text(pty: TaskPtyLike): string {
+  return pty
+    .capture()
+    .map((row) => row.map((chunk) => chunk.text).join(""))
+    .join("\n")
+}
+
+async function until(cond: () => boolean, ms = 3000): Promise<void> {
+  const started = Date.now()
+  while (!cond()) {
+    if (Date.now() - started > ms) throw new Error("timeout waiting for child environment")
+    await Bun.sleep(20)
+  }
+}
+
+const command = [
+  "/bin/sh",
+  "-c",
+  'printf "program=%s version=%s\\n" "${TERM_PROGRAM-unset}" "${TERM_PROGRAM_VERSION-unset}"; sleep 1',
+]
+
+describe("local terminal child environment", () => {
+  test("Bun PTY does not leak the outer terminal emulator identity", async () => {
+    const pty = withOuterTerminalIdentity(
+      () => new BunTerminalTaskPty({ taskId: "bun-env", cwd: process.cwd(), command, cols: 60, rows: 8 }),
+    )
+    children.push(pty)
+
+    await until(() => text(pty).includes("program="))
+    expect(text(pty)).toContain("program=unset version=unset")
+  })
+
+  test("pipe fallback does not leak the outer terminal emulator identity", async () => {
+    const pty = withOuterTerminalIdentity(
+      () => new PipeTaskPty({ taskId: "pipe-env", cwd: process.cwd(), command, cols: 60, rows: 8 }),
+    )
+    children.push(pty)
+
+    await until(() => text(pty).includes("program="))
+    expect(text(pty)).toContain("program=unset version=unset")
+  })
+})

--- a/packages/kobe/test/render/pty-local-env.test.ts
+++ b/packages/kobe/test/render/pty-local-env.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import type { TaskPtyLike } from "../../src/tui/panes/terminal/pty-types.ts"
-import { BunTerminalTaskPty, PipeTaskPty } from "../../src/tui/panes/terminal/pty.ts"
+import { BunTerminalTaskPty } from "../../src/tui/panes/terminal/pty.ts"
 
 const children: TaskPtyLike[] = []
 
@@ -44,20 +44,10 @@ const command = [
   'printf "program=%s version=%s\\n" "${TERM_PROGRAM-unset}" "${TERM_PROGRAM_VERSION-unset}"; sleep 1',
 ]
 
-describe("local terminal child environment", () => {
+describe("local Bun PTY child environment", () => {
   test("Bun PTY does not leak the outer terminal emulator identity", async () => {
     const pty = withOuterTerminalIdentity(
       () => new BunTerminalTaskPty({ taskId: "bun-env", cwd: process.cwd(), command, cols: 60, rows: 8 }),
-    )
-    children.push(pty)
-
-    await until(() => text(pty).includes("program="))
-    expect(text(pty)).toContain("program=unset version=unset")
-  })
-
-  test("pipe fallback does not leak the outer terminal emulator identity", async () => {
-    const pty = withOuterTerminalIdentity(
-      () => new PipeTaskPty({ taskId: "pipe-env", cwd: process.cwd(), command, cols: 60, rows: 8 }),
     )
     children.push(pty)
 

--- a/packages/kobe/test/tui/terminal-bun-env.test.ts
+++ b/packages/kobe/test/tui/terminal-bun-env.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { BunTerminalTaskPty } from "../../src/tui/panes/terminal/pty"
+
+const originalTermProgram = process.env.TERM_PROGRAM
+const originalTermProgramVersion = process.env.TERM_PROGRAM_VERSION
+const originalColorTerm = process.env.COLORTERM
+
+interface SpawnOptions {
+  env?: Record<string, string | undefined>
+}
+
+function restore(name: "COLORTERM" | "TERM_PROGRAM" | "TERM_PROGRAM_VERSION", value: string | undefined): void {
+  if (value === undefined) Reflect.deleteProperty(process.env, name)
+  else process.env[name] = value
+}
+
+describe("BunTerminalTaskPty child environment", () => {
+  const close = vi.fn()
+  const kill = vi.fn()
+  const spawn = vi.fn((_argv: readonly string[], _options: SpawnOptions) => ({
+    exited: new Promise<void>(() => {}),
+    kill,
+    terminal: { close, resize: vi.fn(), write: vi.fn() },
+    unref: vi.fn(),
+  }))
+
+  beforeEach(() => {
+    process.env.COLORTERM = "truecolor"
+    process.env.TERM_PROGRAM = "iTerm.app"
+    process.env.TERM_PROGRAM_VERSION = "3.6.11"
+    vi.stubGlobal("Bun", { spawn })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    restore("COLORTERM", originalColorTerm)
+    restore("TERM_PROGRAM", originalTermProgram)
+    restore("TERM_PROGRAM_VERSION", originalTermProgramVersion)
+  })
+
+  it("advertises xterm capabilities without leaking the outer emulator identity", () => {
+    const pty = new BunTerminalTaskPty({
+      taskId: "bun-env",
+      cwd: process.cwd(),
+      command: ["/bin/sh"],
+      cols: 60,
+      rows: 8,
+    })
+
+    expect(spawn).toHaveBeenCalledOnce()
+    const options = spawn.mock.calls[0]?.[1]
+    expect(options?.env).toMatchObject({
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+      COLUMNS: "60",
+      LINES: "8",
+      KOBE_TERMINAL_PTY: "1",
+    })
+    expect(options?.env).not.toHaveProperty("TERM_PROGRAM")
+    expect(options?.env).not.toHaveProperty("TERM_PROGRAM_VERSION")
+
+    pty.kill()
+    expect(close).toHaveBeenCalledOnce()
+    expect(kill).toHaveBeenCalledWith("SIGTERM")
+  })
+})

--- a/packages/kobe/test/tui/terminal-pipe-env.test.ts
+++ b/packages/kobe/test/tui/terminal-pipe-env.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { PipeTaskPty } from "../../src/tui/panes/terminal/pty-pipe"
+import type { TaskPtyLike, TerminalRow } from "../../src/tui/panes/terminal/pty-types"
+
+const children: TaskPtyLike[] = []
+
+afterEach(() => {
+  for (const child of children.splice(0)) child.kill()
+})
+
+function withOuterTerminalIdentity<T>(run: () => T): T {
+  const program = process.env.TERM_PROGRAM
+  const version = process.env.TERM_PROGRAM_VERSION
+  process.env.TERM_PROGRAM = "iTerm.app"
+  process.env.TERM_PROGRAM_VERSION = "3.6.11"
+  try {
+    return run()
+  } finally {
+    if (program === undefined) Reflect.deleteProperty(process.env, "TERM_PROGRAM")
+    else process.env.TERM_PROGRAM = program
+    if (version === undefined) Reflect.deleteProperty(process.env, "TERM_PROGRAM_VERSION")
+    else process.env.TERM_PROGRAM_VERSION = version
+  }
+}
+
+function rowsText(rows: readonly TerminalRow[]): string {
+  return rows.map((row) => row.map((chunk) => chunk.text).join("")).join("\n")
+}
+
+async function until(cond: () => boolean, ms = 3000): Promise<void> {
+  const started = Date.now()
+  while (!cond()) {
+    if (Date.now() - started > ms) throw new Error("timeout waiting for pipe child")
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+describe("PipeTaskPty child environment", () => {
+  it("does not leak the outer terminal identity through the pipe fallback", async () => {
+    const pty = withOuterTerminalIdentity(
+      () =>
+        new PipeTaskPty({
+          taskId: "pipe-env",
+          cwd: process.cwd(),
+          command: [
+            "/bin/sh",
+            "-c",
+            `printf '\\033]2;env-probe\\007program=%s version=%s\\n' "\${TERM_PROGRAM-unset}" "\${TERM_PROGRAM_VERSION-unset}"; exec cat`,
+          ],
+          cols: 60,
+          rows: 8,
+        }),
+    )
+    children.push(pty)
+
+    let latest: readonly TerminalRow[] = []
+    const titles: string[] = []
+    let exits = 0
+    pty.onData((rows) => {
+      latest = rows
+    })
+    pty.onTitleChange((title) => titles.push(title))
+    pty.onExit(() => exits++)
+
+    await until(() => rowsText(latest).includes("program="))
+    expect(rowsText(latest)).toContain("program=unset version=unset")
+    await until(() => titles.includes("env-probe"))
+
+    pty.write("echo-through-pipe\r")
+    await until(() => rowsText(latest).includes("echo-through-pipe"))
+    pty.resize(72, 9)
+    expect(pty.captureCursor()).toBeNull()
+    expect(pty.wheel()).toBe(false)
+
+    pty.kill()
+    expect(pty.killed).toBe(true)
+    expect(exits).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- centralize the environment policy for embedded terminal children across daemon-hosted, local Bun PTY, pipe fallback, and web PTY paths
- strip inherited `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` while preserving capability variables such as `TERM` and `COLORTERM`
- add real-child regressions for hosted, Bun-native, pipe, and web terminal paths, plus a patch changeset

## Root cause

Kobe advertised an `xterm-256color` parser to child applications but inherited the outer iTerm2 identity. Neovim therefore selected an iTerm-specific short colon truecolor form, while xterm.js interpreted the fixed parameter positions and shifted RGB values, producing the yellow/olive tint.

The embedded parser is the terminal applications actually face, so outer-emulator identity must stop at the embedding boundary.

## Verification

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 230 fast files / 2504 tests and 31 socket files / 243 tests
- [x] `cd packages/kobe && bun run test:render` — 51 tests
- [x] `cd packages/kobe-web && bunx vitest run test` — 72 files / 576 tests
- [x] `bun run build`
- [x] `cd packages/kobe-web && bun run build`
- [x] `bun run test:behavior` — 7 files / 25 tests
- [x] touched-file coverage gate — `pty-pipe.ts` 80.12%
- [x] live hosted child probe — `TERM=xterm-256color`, `COLORTERM=truecolor`, no `TERM_PROGRAM*`

## Release

Patch changeset for `@sma1lboy/kobe`.

coverage-exemption: packages/kobe/src/tui/panes/terminal/pty.ts — Bun native PTY uses Bun.spawn terminal, which is unavailable under Vitest's Node runtime; the changed environment path is covered by test/render/pty-local-env.test.ts with a real child.
