### PR TITLE
fix: reuse a single File tab

### DIFF
--- a/.changeset/tidy-files-share.md
+++ b/.changeset/tidy-files-share.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+FileTree opens now reuse one File tab, replacing its current file instead of growing a new editor tab for every file you browse.

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -57,8 +57,10 @@ import {
   closeTab,
   cycleTab,
   engineTabArgv,
+  findEditorTab,
   initialTabs,
   isTabSplit,
+  openCommandTab,
   openEditorTab,
   rehydrateTabs,
   renameActiveTab,
@@ -98,7 +100,7 @@ export interface TerminalTabsProps {
   modelEffort?: string
   /** Best-effort: persist the picked vendor as the task's new default. */
   onChooseEngine?: (vendor: VendorId) => void
-  /** Hands the parent an imperative "open this file in a new editor tab"
+  /** Hands the parent an imperative "open this file in the editor tab"
    *  function, once per mount (see file header). */
   onEditorTabReady?: (open: (command: readonly string[], label: string) => void) => void
   /** Hands the parent an imperative "paste this into the active engine tab
@@ -181,6 +183,10 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   const engineTabCommandRef = useRef(engineTabCommand)
   engineTabCommandRef.current = engineTabCommand
 
+  /** Nudge Terminal to re-acquire under the CURRENTLY visible tab's key —
+   *  see the `resetToken` doc on `Terminal.tsx`. */
+  const [resetToken, setResetToken] = useState(0)
+
   /* --------- restart resume verification (issue #22) — mount-only ------- */
   const hydrating = useTabHydration(rehydratedRef.current, { stateRef, propsRef, update })
 
@@ -188,7 +194,17 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   // per mount — remounting on task/worktree switch re-fires it.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once handoff; the callback reads propsRef/stateRef for freshness.
   useEffect(() => {
-    propsRef.current.onEditorTabReady?.((command, label) => update(openEditorTab(stateRef.current, command, label)))
+    propsRef.current.onEditorTabReady?.((command, label) => {
+      const current = stateRef.current
+      const existing = findEditorTab(current)
+      if (existing) {
+        const key = tabPtyKey(propsRef.current.taskId, existing.id)
+        releaseSplitLeaves(key, existing.splitTree ?? null)
+        getDefaultPtyRegistry().release(key)
+      }
+      update(openEditorTab(current, command, label))
+      if (existing?.id === current.activeId) setResetToken((n) => n + 1)
+    })
   }, [])
   useEffect(() => {
     propsRef.current.onEngineSendReady?.((text) => {
@@ -272,10 +288,6 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
     notif.markRead(props.taskId, state.activeId)
   }, [state.activeId])
 
-  /** Nudge Terminal to re-acquire under the CURRENTLY visible tab's key —
-   *  see the `resetToken` doc on `Terminal.tsx`. */
-  const [resetToken, setResetToken] = useState(0)
-
   /** Auto-close (issue #16): a command tab closes itself when that process
    *  exits and releases its PTY. */
   function closeExitedTab(id: string): void {
@@ -348,7 +360,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
       // vendor preference write, closes itself on exit. Null label so the
       // tab is named by its live foreground process ("zsh", "vim"…).
       if (picked === "shell") {
-        update(openEditorTab(state, [defaultShell()], null))
+        update(openCommandTab(state, [defaultShell()], null))
         return
       }
       update(pinSession(addTab(state, picked), picked))

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -193,7 +193,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   /**
    * FileTree's Enter action (issue #16 editor-tab flow): resolve the user's
    * real editor via the tmux-agnostic `resolveEditorLaunch`, then run it in
-   * a new embedded terminal tab. Falls back to the host-OS opener when no
+   * the reusable File tab. Falls back to the host-OS opener when no
    * editor is configured/installed.
    */
   async function openFileInEditor(relPath: string): Promise<void> {

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -92,6 +92,8 @@ export interface EngineTab extends TabBase {
 export interface CommandTab extends TabBase {
   readonly kind: "command"
   readonly command: readonly string[]
+  /** FileTree-owned singleton slot. Other command tabs remain independent. */
+  readonly purpose?: "editor"
 }
 
 /**
@@ -138,9 +140,38 @@ export function addTab(state: TabsState, vendor?: VendorId): TabsState {
  * "shell" pick), and closes itself when the process exits (kind
  * "command", consumed by `TerminalTabs.tsx`'s `onExit` wiring).
  */
-export function openEditorTab(state: TabsState, command: readonly string[], label: string | null): TabsState {
+export function openCommandTab(state: TabsState, command: readonly string[], label: string | null): TabsState {
   const ordinal = state.nextOrdinal
   return insertAfterActive(state, { kind: "command", id: `tab-${ordinal}`, title: label, ordinal, command })
+}
+
+/** The FileTree-owned command tab, if this task already has one. */
+export function findEditorTab(state: TabsState): CommandTab | undefined {
+  return state.tabs.find((tab): tab is CommandTab => tab.kind === "command" && tab.purpose === "editor")
+}
+
+/**
+ * Open or replace the one FileTree-owned editor tab. Its stable identity and
+ * position make it a reusable File slot; callers restart its PTY when this
+ * transition targets an existing tab.
+ */
+export function openEditorTab(state: TabsState, command: readonly string[], label: string): TabsState {
+  const existing = findEditorTab(state)
+  if (!existing) {
+    const ordinal = state.nextOrdinal
+    return insertAfterActive(state, {
+      kind: "command",
+      id: `tab-${ordinal}`,
+      title: label,
+      ordinal,
+      command,
+      purpose: "editor",
+    })
+  }
+  const tabs = state.tabs.map(
+    (tab): TerminalTab => (tab.id === existing.id ? { ...existing, title: label, command, splitTree: null } : tab),
+  )
+  return { ...state, tabs, activeId: existing.id }
 }
 
 /**
@@ -283,7 +314,9 @@ export function tabExitAction(tab: TerminalTab, deadOnAttach: boolean, resumeTri
  * `activeId` if it pointed at a tab that no longer exists.
  */
 export function rehydrateTabs(persisted: TabsState, shell: readonly string[]): TabsState {
-  const tabs = persisted.tabs.map((t): TerminalTab => (t.kind === "command" ? { ...t, command: shell } : t))
+  const tabs = persisted.tabs.map(
+    (t): TerminalTab => (t.kind === "command" ? { ...t, command: shell, purpose: undefined } : t),
+  )
   if (tabs.length === 0) return initialTabs()
   const activeId = tabs.some((t) => t.id === persisted.activeId) ? persisted.activeId : tabs[0].id
   const maxOrdinal = tabs.reduce((max, t) => Math.max(max, t.ordinal), 0)

--- a/packages/kobe/test/behavior/pure-tui-file-tab.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-file-tab.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression (2026-07-10): opening files from the pure-TUI FileTree uses
+ * one reusable File tab. The old transition appended one command tab for
+ * every file, so browsing a few files permanently grew the tab strip.
+ */
+
+import { describe, expect, test } from "vitest"
+import { initialTabs, openEditorTab } from "../../src/tui/workspace/terminal-tabs-core"
+
+describe("pure-TUI File tab behavior", () => {
+  test("opening another file replaces and focuses the existing File tab", () => {
+    let tabs = initialTabs()
+    const openFile = (path: string): void => {
+      tabs = openEditorTab(tabs, ["nvim", path], path)
+    }
+
+    openFile("src/a.ts")
+    const fileTabId = tabs.activeId
+    openFile("src/b.ts")
+
+    expect(tabs.tabs).toHaveLength(2)
+    expect(tabs.activeId).toBe(fileTabId)
+    expect(tabs.tabs.find((tab) => tab.id === fileTabId)).toMatchObject({
+      kind: "command",
+      purpose: "editor",
+      title: "src/b.ts",
+      command: ["nvim", "src/b.ts"],
+    })
+  })
+})

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -11,6 +11,7 @@ import {
   initialTabs,
   isTabSplit,
   markTabSpawned,
+  openCommandTab,
   openEditorTab,
   rehydrateTabs,
   renameActiveTab,
@@ -118,13 +119,45 @@ describe("terminal tabs state", () => {
     expect(tabToShell(s, "tab-99", ["/bin/zsh"]).tabs).toEqual(s.tabs)
   })
 
-  // Why: the ctrl+e "shell" pick opens a plain terminal tab through
-  // openEditorTab with a NULL label — the tab must stay unnamed so the
+  // Why: the ctrl+e "shell" pick opens a plain command tab with a NULL
+  // label — the tab must stay unnamed so the
   // live foreground-process title (tabTitle's liveName path) names it.
-  it("openEditorTab with a null label leaves the tab unnamed (live title names it)", () => {
-    const s = openEditorTab(initialTabs(), ["/bin/zsh"], null)
+  it("openCommandTab with a null label leaves the tab unnamed (live title names it)", () => {
+    const s = openCommandTab(initialTabs(), ["/bin/zsh"], null)
     expect(s.tabs[1]).toMatchObject({ kind: "command", title: null, command: ["/bin/zsh"] })
     expect(s.activeId).toBe("tab-2")
+  })
+
+  // Regression (2026-07-10): FileTree opens share one File tab. Opening a
+  // second file replaces and focuses that slot instead of growing one editor
+  // tab per file forever.
+  it("openEditorTab reuses the single editor slot", () => {
+    let s = openEditorTab(initialTabs(), ["nvim", "a.ts"], "a.ts")
+    const editorId = s.activeId
+    s = openEditorTab(s, ["nvim", "b.ts"], "b.ts")
+
+    expect(s.tabs).toHaveLength(2)
+    expect(s.activeId).toBe(editorId)
+    expect(s.tabs[1]).toMatchObject({
+      kind: "command",
+      id: editorId,
+      title: "b.ts",
+      command: ["nvim", "b.ts"],
+      purpose: "editor",
+    })
+  })
+
+  it("the singleton editor slot does not replace a user-opened shell tab", () => {
+    let s = openCommandTab(initialTabs(), ["/bin/zsh"], null)
+    const shellId = s.activeId
+    s = openEditorTab(s, ["nvim", "a.ts"], "a.ts")
+    s = openEditorTab(s, ["nvim", "b.ts"], "b.ts")
+
+    expect(s.tabs).toHaveLength(3)
+    const shellTab = s.tabs.find((tab) => tab.id === shellId)
+    expect(shellTab).toMatchObject({ kind: "command" })
+    expect(shellTab).not.toHaveProperty("purpose")
+    expect(s.tabs.filter((tab) => tab.kind === "command" && tab.purpose === "editor")).toHaveLength(1)
   })
 
   // Why: sessionId is the naming/resume anchor (tmux @kobe_session_id) —
@@ -155,6 +188,7 @@ describe("terminal tabs state", () => {
     expect(back.tabs[0]).toMatchObject({ kind: "engine", sessionId: "uuid-1" })
     // The editor's process is gone — its terminal comes back as a shell.
     expect(back.tabs[2]).toMatchObject({ kind: "command", command: ["/bin/zsh"] })
+    expect(back.tabs[2]).toHaveProperty("purpose", undefined)
     expect(back.nextOrdinal).toBe(s.nextOrdinal)
     // THE reported bug: a single tab whose engine exited (degraded to a
     // shell) must reopen as that shell, NOT as a fresh engine tab.


### PR DESCRIPTION
## Summary

- reuse one FileTree-owned editor tab and replace its command/title when another file opens
- restart the reused tab PTY while keeping user-opened shell tabs independent
- add patch release notes plus unit and pure-TUI behavior regressions

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run test:render`
- `bun run coverage` + per-file coverage gate (terminal-tabs-core: 100%)
- `KOBE_INCLUDE_BEHAVIOR=1 bunx vitest run test/behavior/pure-tui-file-tab.test.ts --minWorkers=1 --maxWorkers=1`
- `gtimeout 5 bun run dev:mock-react-workspace` (expected timeout after live render)

Local full behavior run also exercised the suite; the new File-tab regression passed. The unrelated macOS tmux `ctrl+[` cycle assertion remained red locally (`tmux-chords.test.ts`), while all other behavior files passed.