### PR TITLE
fix: resolve native tab-title status from live process identity

### DIFF
--- a/.changeset/shell-typed-engine-native-title.md
+++ b/.changeset/shell-typed-engine-native-title.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+A user-typed engine in a shell tab now gets the same native-title treatment as a kobe-launched one: the tab strip resolves "does this process own its status" from the live process identity instead of the tab's launch path, so no duplicate kobe turn glyph is prefixed either way.

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -254,7 +254,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   useTabNaming({ stateRef, propsRef, update })
 
   /* --------- per-tab turn state --------- */
-  const { turnStates, liveTitles } = useTurnPolls({
+  const { turnStates, liveTitles, turnVendors } = useTurnPolls({
     taskId: props.taskId,
     worktree: props.worktree,
     vendor: props.vendor,
@@ -450,6 +450,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
           onSelect={(tabId) => update(selectTab(state, tabId))}
           vendor={props.vendor}
           liveTitles={liveTitles}
+          turnVendors={turnVendors}
         />
       ) : null}
       {/* Spawn gate: while restart verification runs (millisecond-scale

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -69,14 +69,24 @@ export function tabTitle(tab: TerminalTab, taskVendor: VendorId, liveName?: stri
   return `${name} ${tab.ordinal}`
 }
 
-/** True only when `tabTitle` is visibly rendering an engine-owned title. */
-function visibleNativeStatus(tab: TerminalTab, taskVendor: VendorId, liveName?: string | null): boolean {
-  if (!liveName || tab.title || tab.kind !== "engine") return false
-  const ls = tab.splitTree ? leaves(tab.splitTree.root) : []
-  if (ls.length > 1) return false
-  const sole = ls.length === 1 ? ls[0] : undefined
-  if (sole && sole.id !== "leaf-1") return false
-  return engineEntry(tab.vendor ?? taskVendor).terminalTitle?.ownsStatus === true
+/**
+ * True only when `tabTitle` is visibly rendering an engine-owned title.
+ * Launch-path agnostic: `vendor` is the tab's resolved live process identity
+ * (`useTurnPolls().turnVendors` — the same `turn-target.ts` rule that
+ * attaches detectors), so a user-typed `claude` in a shell and a
+ * kobe-launched engine tab get the exact same treatment. The label
+ * comparison replaces structural kind/leaf checks: native status is visible
+ * iff the rendered label IS the live title.
+ */
+function visibleNativeStatus(
+  tab: TerminalTab,
+  taskVendor: VendorId,
+  vendor: VendorId | undefined,
+  liveName?: string | null,
+): boolean {
+  if (!vendor || !liveName) return false
+  if (engineEntry(vendor).terminalTitle?.ownsStatus !== true) return false
+  return tabTitle(tab, taskVendor, liveName) === `${liveName} ${tab.ordinal}`
 }
 
 export function TabStrip(props: {
@@ -88,6 +98,8 @@ export function TabStrip(props: {
   vendor: VendorId
   /** tabId → live process display name (see `useTurnPolls().liveTitles`). */
   liveTitles: ReadonlyMap<string, string>
+  /** tabId → resolved live engine identity (see `useTurnPolls().turnVendors`). */
+  turnVendors: ReadonlyMap<string, VendorId>
 }) {
   const themeCtx = useTheme()
   const { theme } = themeCtx
@@ -131,7 +143,7 @@ export function TabStrip(props: {
       {props.tabs.map((tab) => {
         const turn = props.turnStates.get(tab.id) ?? "idle"
         const liveTitle = props.liveTitles.get(tab.id)
-        const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, liveTitle)
+        const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, props.turnVendors.get(tab.id), liveTitle)
         const pulse = pulsing.has(tab.id)
         const turnColor =
           turn === "running"

--- a/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
+++ b/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
@@ -58,9 +58,14 @@ export function useTurnPolls(deps: {
    *  title matches a vendor, else the raw OSC title). Feeds the tab
    *  strip's dynamic default names. */
   liveTitles: ReadonlyMap<string, string>
+  /** tabId → resolved live engine identity — the `targetFor` vendor the
+   *  attached detector tracks, whether kobe-launched or user-typed. The tab
+   *  strip's launch-path-agnostic "does this process own its status" input. */
+  turnVendors: ReadonlyMap<string, VendorId>
 } {
   const [turnStates, setTurnStates] = useState<ReadonlyMap<string, ChatTabTurnState>>(new Map())
   const [liveTitles, setLiveTitles] = useState<ReadonlyMap<string, string>>(new Map())
+  const [turnVendors, setTurnVendors] = useState<ReadonlyMap<string, VendorId>>(new Map())
   const turnPollsRef = useRef(new Map<string, { dispose: () => void; vendor: VendorId; key: string }>())
   /** ptyKey → raw OSC title. Cleared when the PTY instance at that key
    *  changes (release + respawn), so a dead claude's title can't keep a
@@ -192,6 +197,16 @@ export function useTurnPolls(deps: {
         return next
       })
     }
+
+    // Mirror the attach map's resolved identities for render consumers.
+    // Identity-stable: an unchanged map returns `prev` so the 2s attach
+    // tick doesn't churn re-renders.
+    setTurnVendors((prev) => {
+      const next = new Map<string, VendorId>()
+      for (const [id, poll] of turnPolls) next.set(id, poll.vendor)
+      if (next.size === prev.size && [...next].every(([id, v]) => prev.get(id) === v)) return prev
+      return next
+    })
   }, [deps.taskId, deps.worktree, deps.vendor, deps.state, pollTick])
 
   // Final teardown on unmount only.
@@ -202,5 +217,5 @@ export function useTurnPolls(deps: {
     }
   }, [])
 
-  return { turnStates, liveTitles }
+  return { turnStates, liveTitles, turnVendors }
 }

--- a/packages/kobe/test/render/tab-strip.test.tsx
+++ b/packages/kobe/test/render/tab-strip.test.tsx
@@ -2,13 +2,16 @@
 /**
  * Terminal-tab title/status ownership. Interactive engines that publish
  * their own activity in the live OSC title must not get a second kobe
- * turn glyph prefixed to the same tab.
+ * turn glyph prefixed to the same tab — regardless of whether kobe
+ * launched the engine or the user typed it into a shell (the identity
+ * comes from `turnVendors`, not the tab's kind).
  */
 
 import { describe, expect, it } from "bun:test"
 import type { ChatTabTurnState } from "../../src/engine/turn-detector"
 import { TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
+import type { VendorId } from "../../src/types/vendor"
 import { type RenderHandle, act, renderComponent } from "./harness"
 
 const codexTab: TerminalTab = {
@@ -19,57 +22,100 @@ const codexTab: TerminalTab = {
   vendor: "codex",
 }
 
+/** A plain shell tab where the USER typed an engine (no pinned vendor). */
+const shellTab: TerminalTab = {
+  kind: "command",
+  id: "tab-9",
+  title: null,
+  ordinal: 9,
+  command: ["zsh"],
+}
+
+async function renderStrip(props: {
+  tab: TerminalTab
+  turnStates: ReadonlyMap<string, ChatTabTurnState>
+  liveTitles: ReadonlyMap<string, string>
+  turnVendors: ReadonlyMap<string, VendorId>
+  vendor: VendorId
+}): Promise<{ text: string; destroy: () => Promise<void> }> {
+  let handle: RenderHandle | undefined
+  await act(async () => {
+    handle = await renderComponent(
+      <TabStrip
+        tabs={[props.tab]}
+        activeId={props.tab.id}
+        turnStates={props.turnStates}
+        onSelect={() => {}}
+        vendor={props.vendor}
+        liveTitles={props.liveTitles}
+        turnVendors={props.turnVendors}
+      />,
+      { width: 80, height: 3 },
+    )
+  })
+  if (!handle) throw new Error("mount failed")
+  const mounted = handle
+  let text = ""
+  await act(async () => {
+    text = await mounted.frame()
+  })
+  return {
+    text,
+    destroy: async () => {
+      await act(async () => mounted.destroy())
+    },
+  }
+}
+
 describe("TabStrip native terminal-title status", () => {
   it("renders Codex's native activity/thread title without a duplicate kobe glyph", async () => {
-    let handle: RenderHandle | undefined
-    await act(async () => {
-      handle = await renderComponent(
-        <TabStrip
-          tabs={[codexTab]}
-          activeId={codexTab.id}
-          turnStates={new Map<string, ChatTabTurnState>([[codexTab.id, "running"]])}
-          onSelect={() => {}}
-          vendor="codex"
-          liveTitles={new Map([[codexTab.id, "⠇ fix codex tab naming"]])}
-        />,
-        { width: 80, height: 3 },
-      )
-    })
-    if (!handle) throw new Error("mount failed")
-    const mounted = handle
-
-    let text = ""
-    await act(async () => {
-      text = await mounted.frame()
+    const { text, destroy } = await renderStrip({
+      tab: codexTab,
+      turnStates: new Map([[codexTab.id, "running"]]),
+      liveTitles: new Map([[codexTab.id, "⠇ fix codex tab naming"]]),
+      turnVendors: new Map([[codexTab.id, "codex"]]),
+      vendor: "codex",
     })
     expect(text).toContain("⠇ fix codex tab naming 26")
     expect(text).not.toContain("●")
-    await act(async () => mounted.destroy())
+    await destroy()
   })
 
   it("keeps kobe's status fallback until the engine has emitted a native title", async () => {
-    let handle: RenderHandle | undefined
-    await act(async () => {
-      handle = await renderComponent(
-        <TabStrip
-          tabs={[codexTab]}
-          activeId={codexTab.id}
-          turnStates={new Map<string, ChatTabTurnState>([[codexTab.id, "running"]])}
-          onSelect={() => {}}
-          vendor="codex"
-          liveTitles={new Map()}
-        />,
-        { width: 80, height: 3 },
-      )
-    })
-    if (!handle) throw new Error("mount failed")
-    const mounted = handle
-
-    let text = ""
-    await act(async () => {
-      text = await mounted.frame()
+    const { text, destroy } = await renderStrip({
+      tab: codexTab,
+      turnStates: new Map([[codexTab.id, "running"]]),
+      liveTitles: new Map(),
+      turnVendors: new Map([[codexTab.id, "codex"]]),
+      vendor: "codex",
     })
     expect(text).toContain("● codex 26")
-    await act(async () => mounted.destroy())
+    await destroy()
+  })
+
+  it("treats a user-typed engine in a shell tab exactly like a kobe-launched one", async () => {
+    const { text, destroy } = await renderStrip({
+      tab: shellTab,
+      turnStates: new Map([[shellTab.id, "running"]]),
+      liveTitles: new Map([[shellTab.id, "claude"]]),
+      turnVendors: new Map([[shellTab.id, "claude"]]),
+      vendor: "claude",
+    })
+    expect(text).toContain("claude 9")
+    expect(text).not.toContain("●")
+    await destroy()
+  })
+
+  it("keeps the glyph when a rename hides the native title", async () => {
+    const renamed: TerminalTab = { ...shellTab, title: "my session" }
+    const { text, destroy } = await renderStrip({
+      tab: renamed,
+      turnStates: new Map([[renamed.id, "running"]]),
+      liveTitles: new Map([[renamed.id, "claude"]]),
+      turnVendors: new Map([[renamed.id, "claude"]]),
+      vendor: "claude",
+    })
+    expect(text).toContain("● my session")
+    await destroy()
   })
 })


### PR DESCRIPTION
## Problem

A `claude` typed into a plain shell tab still got kobe's default status management (the `●` turn glyph + managed naming), while a kobe-launched engine tab used the engine's native OSC title (#74411888 follow-up). The discriminator was `tab.kind === "engine"` — a launch-path if/else, when the case is general: the same process should get the same treatment however it was started.

## Fix

- `useTurnPolls` now exposes `turnVendors` — the per-tab engine identity it already resolves via `turn-target.ts`'s single rule (pinned vendor for kobe-launched, OSC-title match for user-typed).
- `visibleNativeStatus` drops the kind/leaf-structure checks: the glyph hides iff the tab's resolved engine `ownsStatus` **and** the rendered label IS the live title. Renames, splits, group tabs all fall out of the label comparison instead of hand-kept structural checks.

## Tests

- Render regressions: codex native title (unchanged), pre-title fallback (unchanged), **new** user-typed engine in a shell tab, **new** rename keeps the glyph.
- Full unit (243) + render (61) suites green; root lint + typecheck clean.
