### PR TITLE
fix: scrub the full outer-emulator identity namespace from embedded PTYs

### DIFF
--- a/.changeset/full-identity-scrub.md
+++ b/.changeset/full-identity-scrub.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Embedded terminals now scrub the outer emulator's entire identity namespace (LC_TERMINAL, ITERM_*, TERM_SESSION_ID, KITTY_*, GHOSTTY_*, WEZTERM_*, ALACRITTY_*, KONSOLE_*, VTE_VERSION, WT_*, TMUX, ZELLIJ, screen markers, __CFBundleIdentifier), not just TERM_PROGRAM. Apps with layered terminal detection (claude-code) no longer fall back to the outer emulator's dialect, which kept causing redraw artifacts inside kobe panes.

--- a/.changeset/shell-typed-engine-native-title.md
+++ b/.changeset/shell-typed-engine-native-title.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+A user-typed engine in a shell tab now gets the same native-title treatment as a kobe-launched one: the tab strip resolves "does this process own its status" from the live process identity instead of the tab's launch path, so no duplicate kobe turn glyph is prefixed either way.

--- a/packages/kobe-daemon/src/daemon/pty-env.js
+++ b/packages/kobe-daemon/src/daemon/pty-env.js
@@ -3,11 +3,49 @@
  * The embedded parser is not the outer emulator, so its identity must not
  * leak through and trigger emulator-specific protocol choices in children.
  *
+ * The scrub covers the whole ancestor-identity namespace, not just
+ * TERM_PROGRAM: apps with layered detection (claude-code checks
+ * LC_TERMINAL, ITERM_SESSION_ID, __CFBundleIdentifier, KITTY_*, TMUX, …
+ * as fallbacks) otherwise still resolve the OUTER emulator and keep
+ * emitting its dialect at kobe's xterm parser. Capability variables
+ * (TERM, COLORTERM, TERMINFO*) survive — they describe what the immediate
+ * parser can do, which the spawn sites set explicitly.
+ */
+
+/** Exact variable names that identify an ancestor emulator or multiplexer. */
+const IDENTITY_VARS = new Set([
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TERM_SESSION_ID", // Terminal.app / iTerm2 session
+  "TERM_FEATURES", // iTerm2 capability advertisement
+  "LC_TERMINAL", // iTerm2 identity (survives ssh)
+  "LC_TERMINAL_VERSION",
+  "__CFBundleIdentifier", // macOS ancestor app id (com.googlecode.iterm2)
+  "VTE_VERSION", // GNOME VTE terminals
+  "WT_SESSION", // Windows Terminal
+  "WT_PROFILE_ID",
+  "TMUX", // children talk to xterm-headless, not a tmux pane
+  "TMUX_PANE",
+  "ZELLIJ",
+  "STY", // GNU screen
+  "WINDOW",
+])
+
+/** Emulator-owned variable families, matched by prefix. */
+const IDENTITY_PREFIXES = ["ITERM_", "KITTY_", "GHOSTTY_", "WEZTERM_", "ALACRITTY_", "KONSOLE_", "ZELLIJ_"]
+
+/**
  * @param {Readonly<Record<string, string | undefined>>} base
  * @param {Readonly<Record<string, string | undefined>>} [overrides]
  * @returns {Record<string, string | undefined>}
  */
 export function embeddedTerminalEnv(base, overrides = {}) {
-  const { TERM_PROGRAM: _termProgram, TERM_PROGRAM_VERSION: _termProgramVersion, ...env } = base
+  /** @type {Record<string, string | undefined>} */
+  const env = {}
+  for (const [key, value] of Object.entries(base)) {
+    if (IDENTITY_VARS.has(key)) continue
+    if (IDENTITY_PREFIXES.some((prefix) => key.startsWith(prefix))) continue
+    env[key] = value
+  }
   return { ...env, ...overrides }
 }

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -254,7 +254,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   useTabNaming({ stateRef, propsRef, update })
 
   /* --------- per-tab turn state --------- */
-  const { turnStates, liveTitles } = useTurnPolls({
+  const { turnStates, liveTitles, turnVendors } = useTurnPolls({
     taskId: props.taskId,
     worktree: props.worktree,
     vendor: props.vendor,
@@ -450,6 +450,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
           onSelect={(tabId) => update(selectTab(state, tabId))}
           vendor={props.vendor}
           liveTitles={liveTitles}
+          turnVendors={turnVendors}
         />
       ) : null}
       {/* Spawn gate: while restart verification runs (millisecond-scale

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -69,14 +69,24 @@ export function tabTitle(tab: TerminalTab, taskVendor: VendorId, liveName?: stri
   return `${name} ${tab.ordinal}`
 }
 
-/** True only when `tabTitle` is visibly rendering an engine-owned title. */
-function visibleNativeStatus(tab: TerminalTab, taskVendor: VendorId, liveName?: string | null): boolean {
-  if (!liveName || tab.title || tab.kind !== "engine") return false
-  const ls = tab.splitTree ? leaves(tab.splitTree.root) : []
-  if (ls.length > 1) return false
-  const sole = ls.length === 1 ? ls[0] : undefined
-  if (sole && sole.id !== "leaf-1") return false
-  return engineEntry(tab.vendor ?? taskVendor).terminalTitle?.ownsStatus === true
+/**
+ * True only when `tabTitle` is visibly rendering an engine-owned title.
+ * Launch-path agnostic: `vendor` is the tab's resolved live process identity
+ * (`useTurnPolls().turnVendors` — the same `turn-target.ts` rule that
+ * attaches detectors), so a user-typed `claude` in a shell and a
+ * kobe-launched engine tab get the exact same treatment. The label
+ * comparison replaces structural kind/leaf checks: native status is visible
+ * iff the rendered label IS the live title.
+ */
+function visibleNativeStatus(
+  tab: TerminalTab,
+  taskVendor: VendorId,
+  vendor: VendorId | undefined,
+  liveName?: string | null,
+): boolean {
+  if (!vendor || !liveName) return false
+  if (engineEntry(vendor).terminalTitle?.ownsStatus !== true) return false
+  return tabTitle(tab, taskVendor, liveName) === `${liveName} ${tab.ordinal}`
 }
 
 export function TabStrip(props: {
@@ -88,6 +98,8 @@ export function TabStrip(props: {
   vendor: VendorId
   /** tabId → live process display name (see `useTurnPolls().liveTitles`). */
   liveTitles: ReadonlyMap<string, string>
+  /** tabId → resolved live engine identity (see `useTurnPolls().turnVendors`). */
+  turnVendors: ReadonlyMap<string, VendorId>
 }) {
   const themeCtx = useTheme()
   const { theme } = themeCtx
@@ -131,7 +143,7 @@ export function TabStrip(props: {
       {props.tabs.map((tab) => {
         const turn = props.turnStates.get(tab.id) ?? "idle"
         const liveTitle = props.liveTitles.get(tab.id)
-        const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, liveTitle)
+        const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, props.turnVendors.get(tab.id), liveTitle)
         const pulse = pulsing.has(tab.id)
         const turnColor =
           turn === "running"

--- a/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
+++ b/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
@@ -58,9 +58,14 @@ export function useTurnPolls(deps: {
    *  title matches a vendor, else the raw OSC title). Feeds the tab
    *  strip's dynamic default names. */
   liveTitles: ReadonlyMap<string, string>
+  /** tabId → resolved live engine identity — the `targetFor` vendor the
+   *  attached detector tracks, whether kobe-launched or user-typed. The tab
+   *  strip's launch-path-agnostic "does this process own its status" input. */
+  turnVendors: ReadonlyMap<string, VendorId>
 } {
   const [turnStates, setTurnStates] = useState<ReadonlyMap<string, ChatTabTurnState>>(new Map())
   const [liveTitles, setLiveTitles] = useState<ReadonlyMap<string, string>>(new Map())
+  const [turnVendors, setTurnVendors] = useState<ReadonlyMap<string, VendorId>>(new Map())
   const turnPollsRef = useRef(new Map<string, { dispose: () => void; vendor: VendorId; key: string }>())
   /** ptyKey → raw OSC title. Cleared when the PTY instance at that key
    *  changes (release + respawn), so a dead claude's title can't keep a
@@ -192,6 +197,16 @@ export function useTurnPolls(deps: {
         return next
       })
     }
+
+    // Mirror the attach map's resolved identities for render consumers.
+    // Identity-stable: an unchanged map returns `prev` so the 2s attach
+    // tick doesn't churn re-renders.
+    setTurnVendors((prev) => {
+      const next = new Map<string, VendorId>()
+      for (const [id, poll] of turnPolls) next.set(id, poll.vendor)
+      if (next.size === prev.size && [...next].every(([id, v]) => prev.get(id) === v)) return prev
+      return next
+    })
   }, [deps.taskId, deps.worktree, deps.vendor, deps.state, pollTick])
 
   // Final teardown on unmount only.
@@ -202,5 +217,5 @@ export function useTurnPolls(deps: {
     }
   }, [])
 
-  return { turnStates, liveTitles }
+  return { turnStates, liveTitles, turnVendors }
 }

--- a/packages/kobe/test/lib/embedded-terminal-env.test.ts
+++ b/packages/kobe/test/lib/embedded-terminal-env.test.ts
@@ -21,4 +21,42 @@ describe("embeddedTerminalEnv", () => {
     })
     expect(base.TERM_PROGRAM).toBe("iTerm.app")
   })
+
+  it("removes fallback identity channels apps use once TERM_PROGRAM is gone", () => {
+    // claude-code's layered detection: with TERM_PROGRAM stripped it still
+    // resolved iTerm2 from these and kept redrawing in iTerm's dialect.
+    const result = embeddedTerminalEnv({
+      LC_TERMINAL: "iTerm2",
+      LC_TERMINAL_VERSION: "3.5.11",
+      ITERM_SESSION_ID: "w0t0p0:UUID",
+      ITERM_PROFILE: "Default",
+      TERM_SESSION_ID: "w0t0p0:UUID",
+      TERM_FEATURES: "T3LrMSc7UUw9Ts3BFGsSyHNoSxF",
+      __CFBundleIdentifier: "com.googlecode.iterm2",
+      HOME: "/home/test",
+    })
+
+    expect(result).toEqual({ HOME: "/home/test" })
+  })
+
+  it("removes every emulator family's identity variables and multiplexer markers", () => {
+    const result = embeddedTerminalEnv({
+      KITTY_WINDOW_ID: "1",
+      KITTY_PID: "42",
+      GHOSTTY_RESOURCES_DIR: "/opt/ghostty",
+      WEZTERM_PANE: "0",
+      ALACRITTY_WINDOW_ID: "7",
+      KONSOLE_VERSION: "230800",
+      VTE_VERSION: "7600",
+      WT_SESSION: "uuid",
+      TMUX: "/tmp/tmux-501/default,123,0",
+      TMUX_PANE: "%1",
+      ZELLIJ: "0",
+      ZELLIJ_SESSION_NAME: "main",
+      STY: "1234.pts-0.host",
+      PATH: "/usr/bin",
+    })
+
+    expect(result).toEqual({ PATH: "/usr/bin" })
+  })
 })

--- a/packages/kobe/test/render/tab-strip.test.tsx
+++ b/packages/kobe/test/render/tab-strip.test.tsx
@@ -2,13 +2,16 @@
 /**
  * Terminal-tab title/status ownership. Interactive engines that publish
  * their own activity in the live OSC title must not get a second kobe
- * turn glyph prefixed to the same tab.
+ * turn glyph prefixed to the same tab — regardless of whether kobe
+ * launched the engine or the user typed it into a shell (the identity
+ * comes from `turnVendors`, not the tab's kind).
  */
 
 import { describe, expect, it } from "bun:test"
 import type { ChatTabTurnState } from "../../src/engine/turn-detector"
 import { TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
+import type { VendorId } from "../../src/types/vendor"
 import { type RenderHandle, act, renderComponent } from "./harness"
 
 const codexTab: TerminalTab = {
@@ -19,57 +22,100 @@ const codexTab: TerminalTab = {
   vendor: "codex",
 }
 
+/** A plain shell tab where the USER typed an engine (no pinned vendor). */
+const shellTab: TerminalTab = {
+  kind: "command",
+  id: "tab-9",
+  title: null,
+  ordinal: 9,
+  command: ["zsh"],
+}
+
+async function renderStrip(props: {
+  tab: TerminalTab
+  turnStates: ReadonlyMap<string, ChatTabTurnState>
+  liveTitles: ReadonlyMap<string, string>
+  turnVendors: ReadonlyMap<string, VendorId>
+  vendor: VendorId
+}): Promise<{ text: string; destroy: () => Promise<void> }> {
+  let handle: RenderHandle | undefined
+  await act(async () => {
+    handle = await renderComponent(
+      <TabStrip
+        tabs={[props.tab]}
+        activeId={props.tab.id}
+        turnStates={props.turnStates}
+        onSelect={() => {}}
+        vendor={props.vendor}
+        liveTitles={props.liveTitles}
+        turnVendors={props.turnVendors}
+      />,
+      { width: 80, height: 3 },
+    )
+  })
+  if (!handle) throw new Error("mount failed")
+  const mounted = handle
+  let text = ""
+  await act(async () => {
+    text = await mounted.frame()
+  })
+  return {
+    text,
+    destroy: async () => {
+      await act(async () => mounted.destroy())
+    },
+  }
+}
+
 describe("TabStrip native terminal-title status", () => {
   it("renders Codex's native activity/thread title without a duplicate kobe glyph", async () => {
-    let handle: RenderHandle | undefined
-    await act(async () => {
-      handle = await renderComponent(
-        <TabStrip
-          tabs={[codexTab]}
-          activeId={codexTab.id}
-          turnStates={new Map<string, ChatTabTurnState>([[codexTab.id, "running"]])}
-          onSelect={() => {}}
-          vendor="codex"
-          liveTitles={new Map([[codexTab.id, "⠇ fix codex tab naming"]])}
-        />,
-        { width: 80, height: 3 },
-      )
-    })
-    if (!handle) throw new Error("mount failed")
-    const mounted = handle
-
-    let text = ""
-    await act(async () => {
-      text = await mounted.frame()
+    const { text, destroy } = await renderStrip({
+      tab: codexTab,
+      turnStates: new Map([[codexTab.id, "running"]]),
+      liveTitles: new Map([[codexTab.id, "⠇ fix codex tab naming"]]),
+      turnVendors: new Map([[codexTab.id, "codex"]]),
+      vendor: "codex",
     })
     expect(text).toContain("⠇ fix codex tab naming 26")
     expect(text).not.toContain("●")
-    await act(async () => mounted.destroy())
+    await destroy()
   })
 
   it("keeps kobe's status fallback until the engine has emitted a native title", async () => {
-    let handle: RenderHandle | undefined
-    await act(async () => {
-      handle = await renderComponent(
-        <TabStrip
-          tabs={[codexTab]}
-          activeId={codexTab.id}
-          turnStates={new Map<string, ChatTabTurnState>([[codexTab.id, "running"]])}
-          onSelect={() => {}}
-          vendor="codex"
-          liveTitles={new Map()}
-        />,
-        { width: 80, height: 3 },
-      )
-    })
-    if (!handle) throw new Error("mount failed")
-    const mounted = handle
-
-    let text = ""
-    await act(async () => {
-      text = await mounted.frame()
+    const { text, destroy } = await renderStrip({
+      tab: codexTab,
+      turnStates: new Map([[codexTab.id, "running"]]),
+      liveTitles: new Map(),
+      turnVendors: new Map([[codexTab.id, "codex"]]),
+      vendor: "codex",
     })
     expect(text).toContain("● codex 26")
-    await act(async () => mounted.destroy())
+    await destroy()
+  })
+
+  it("treats a user-typed engine in a shell tab exactly like a kobe-launched one", async () => {
+    const { text, destroy } = await renderStrip({
+      tab: shellTab,
+      turnStates: new Map([[shellTab.id, "running"]]),
+      liveTitles: new Map([[shellTab.id, "claude"]]),
+      turnVendors: new Map([[shellTab.id, "claude"]]),
+      vendor: "claude",
+    })
+    expect(text).toContain("claude 9")
+    expect(text).not.toContain("●")
+    await destroy()
+  })
+
+  it("keeps the glyph when a rename hides the native title", async () => {
+    const renamed: TerminalTab = { ...shellTab, title: "my session" }
+    const { text, destroy } = await renderStrip({
+      tab: renamed,
+      turnStates: new Map([[renamed.id, "running"]]),
+      liveTitles: new Map([[renamed.id, "claude"]]),
+      turnVendors: new Map([[renamed.id, "claude"]]),
+      vendor: "claude",
+    })
+    expect(text).toContain("● my session")
+    await destroy()
   })
 })


### PR DESCRIPTION
## Problem

The claude redraw artifacts inside kobe panes persisted after #296 + the 0.7.89 pty-host reset fix. Empirical check from a claude session running inside a post-fix embedded PTY (`KOBE_TERMINAL_PTY=1`): `TERM_PROGRAM` is gone, but the outer iTerm2 still leaks through `LC_TERMINAL`, `ITERM_SESSION_ID`, `ITERM_PROFILE`, `TERM_SESSION_ID`, `TERM_FEATURES`, and `__CFBundleIdentifier`.

claude-code's terminal detection is layered — grepping the installed bundle shows it also keys on `LC_TERMINAL` (26 hits), `ITERM_SESSION_ID` (14), `__CFBundleIdentifier` (22), `KITTY_WINDOW_ID` (18), `GHOSTTY*` (8), `ALACRITTY*` (16), `KONSOLE*` (16), `VTE_VERSION` (24), `WT_SESSION` (42), `TMUX` (118), `ZELLIJ` (22). With `TERM_PROGRAM` stripped it falls back to those, still resolves iTerm2, and keeps emitting iTerm's dialect at kobe's xterm parser.

## Fix

`embeddedTerminalEnv` (the one shared policy behind all four spawn paths — hosted, Bun, pipe, web) now scrubs the whole ancestor-identity namespace: exact names (`TERM_SESSION_ID`, `TERM_FEATURES`, `LC_TERMINAL{,_VERSION}`, `__CFBundleIdentifier`, `VTE_VERSION`, `WT_*`, `TMUX{,_PANE}`, `ZELLIJ`, `STY`, `WINDOW`) plus emulator prefix families (`ITERM_`, `KITTY_`, `GHOSTTY_`, `WEZTERM_`, `ALACRITTY_`, `KONSOLE_`, `ZELLIJ_`). Capability vars (`TERM`, `COLORTERM`, terminfo) survive per the CONTEXT.md Terminal Identity Boundary rule: describe the immediate parser, never an ancestor.

## Tests

- Two new pure cases: iTerm's fallback identity channels, and the cross-emulator + multiplexer families.
- Full kobe unit (245) + render (61) suites, kobe-web pty-env, root lint + both typechecks green.

## Verification note

The env applies at spawn: after this ships, the standalone PTY host must restart (`kobe reset`, per fde7164) and existing claude sessions must be relaunched to pick it up.