### PR TITLE
fix: chattab switch-back no longer loses claude's UI (park removal + reliable reattach repaint + replay reply mute)

### DIFF
--- a/.changeset/full-identity-scrub.md
+++ b/.changeset/full-identity-scrub.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Embedded terminals now scrub the outer emulator's entire identity namespace (LC_TERMINAL, ITERM_*, TERM_SESSION_ID, KITTY_*, GHOSTTY_*, WEZTERM_*, ALACRITTY_*, KONSOLE_*, VTE_VERSION, WT_*, TMUX, ZELLIJ, screen markers, __CFBundleIdentifier), not just TERM_PROGRAM. Apps with layered terminal detection (claude-code) no longer fall back to the outer emulator's dialect, which kept causing redraw artifacts inside kobe panes.

--- a/.changeset/no-auto-park-and-reliable-wiggle.md
+++ b/.changeset/no-auto-park-and-reliable-wiggle.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Switching back to a background chattab no longer comes up with claude's UI missing. Two changes: hidden tabs' local terminal screens are no longer auto-parked (the reattach replay can't reconstruct a long session's full screen from the byte-capped ring buffer, so revived tabs could lose the input box — screens now stay resident, owner-accepted memory cost); and the TUI-restart reattach repaint wiggle no longer fires its two resizes back-to-back, where the child's SIGWINCHes coalesce into one same-size signal that apps like claude ignore — the restore now waits for the child's shrink repaint (200ms timeout fallback).

--- a/.changeset/replay-reply-mute.md
+++ b/.changeset/replay-reply-mute.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Reattaching to a hosted terminal session no longer re-answers the child's past terminal queries. The ring-buffer replay contains DSR/DA queries the child asked long ago; the fresh emulator answered them again and the stray CPR bytes landed in the child's stdin as phantom input — one source of interactive claude's scrambled/misplaced UI after a TUI restart, tab park-wake, or second viewer attach. Replay parsing now mutes the emulator's auto-replies; live queries are still answered.

--- a/.changeset/shell-typed-engine-native-title.md
+++ b/.changeset/shell-typed-engine-native-title.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+A user-typed engine in a shell tab now gets the same native-title treatment as a kobe-launched one: the tab strip resolves "does this process own its status" from the live process identity instead of the tab's launch path, so no duplicate kobe turn glyph is prefixed either way.

--- a/packages/kobe-daemon/src/daemon/pty-env.js
+++ b/packages/kobe-daemon/src/daemon/pty-env.js
@@ -3,11 +3,49 @@
  * The embedded parser is not the outer emulator, so its identity must not
  * leak through and trigger emulator-specific protocol choices in children.
  *
+ * The scrub covers the whole ancestor-identity namespace, not just
+ * TERM_PROGRAM: apps with layered detection (claude-code checks
+ * LC_TERMINAL, ITERM_SESSION_ID, __CFBundleIdentifier, KITTY_*, TMUX, …
+ * as fallbacks) otherwise still resolve the OUTER emulator and keep
+ * emitting its dialect at kobe's xterm parser. Capability variables
+ * (TERM, COLORTERM, TERMINFO*) survive — they describe what the immediate
+ * parser can do, which the spawn sites set explicitly.
+ */
+
+/** Exact variable names that identify an ancestor emulator or multiplexer. */
+const IDENTITY_VARS = new Set([
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TERM_SESSION_ID", // Terminal.app / iTerm2 session
+  "TERM_FEATURES", // iTerm2 capability advertisement
+  "LC_TERMINAL", // iTerm2 identity (survives ssh)
+  "LC_TERMINAL_VERSION",
+  "__CFBundleIdentifier", // macOS ancestor app id (com.googlecode.iterm2)
+  "VTE_VERSION", // GNOME VTE terminals
+  "WT_SESSION", // Windows Terminal
+  "WT_PROFILE_ID",
+  "TMUX", // children talk to xterm-headless, not a tmux pane
+  "TMUX_PANE",
+  "ZELLIJ",
+  "STY", // GNU screen
+  "WINDOW",
+])
+
+/** Emulator-owned variable families, matched by prefix. */
+const IDENTITY_PREFIXES = ["ITERM_", "KITTY_", "GHOSTTY_", "WEZTERM_", "ALACRITTY_", "KONSOLE_", "ZELLIJ_"]
+
+/**
  * @param {Readonly<Record<string, string | undefined>>} base
  * @param {Readonly<Record<string, string | undefined>>} [overrides]
  * @returns {Record<string, string | undefined>}
  */
 export function embeddedTerminalEnv(base, overrides = {}) {
-  const { TERM_PROGRAM: _termProgram, TERM_PROGRAM_VERSION: _termProgramVersion, ...env } = base
+  /** @type {Record<string, string | undefined>} */
+  const env = {}
+  for (const [key, value] of Object.entries(base)) {
+    if (IDENTITY_VARS.has(key)) continue
+    if (IDENTITY_PREFIXES.some((prefix) => key.startsWith(prefix))) continue
+    env[key] = value
+  }
   return { ...env, ...overrides }
 }

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -254,7 +254,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   useTabNaming({ stateRef, propsRef, update })
 
   /* --------- per-tab turn state --------- */
-  const { turnStates, liveTitles } = useTurnPolls({
+  const { turnStates, liveTitles, turnVendors } = useTurnPolls({
     taskId: props.taskId,
     worktree: props.worktree,
     vendor: props.vendor,
@@ -450,6 +450,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
           onSelect={(tabId) => update(selectTab(state, tabId))}
           vendor={props.vendor}
           liveTitles={liveTitles}
+          turnVendors={turnVendors}
         />
       ) : null}
       {/* Spawn gate: while restart verification runs (millisecond-scale

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -69,14 +69,24 @@ export function tabTitle(tab: TerminalTab, taskVendor: VendorId, liveName?: stri
   return `${name} ${tab.ordinal}`
 }
 
-/** True only when `tabTitle` is visibly rendering an engine-owned title. */
-function visibleNativeStatus(tab: TerminalTab, taskVendor: VendorId, liveName?: string | null): boolean {
-  if (!liveName || tab.title || tab.kind !== "engine") return false
-  const ls = tab.splitTree ? leaves(tab.splitTree.root) : []
-  if (ls.length > 1) return false
-  const sole = ls.length === 1 ? ls[0] : undefined
-  if (sole && sole.id !== "leaf-1") return false
-  return engineEntry(tab.vendor ?? taskVendor).terminalTitle?.ownsStatus === true
+/**
+ * True only when `tabTitle` is visibly rendering an engine-owned title.
+ * Launch-path agnostic: `vendor` is the tab's resolved live process identity
+ * (`useTurnPolls().turnVendors` — the same `turn-target.ts` rule that
+ * attaches detectors), so a user-typed `claude` in a shell and a
+ * kobe-launched engine tab get the exact same treatment. The label
+ * comparison replaces structural kind/leaf checks: native status is visible
+ * iff the rendered label IS the live title.
+ */
+function visibleNativeStatus(
+  tab: TerminalTab,
+  taskVendor: VendorId,
+  vendor: VendorId | undefined,
+  liveName?: string | null,
+): boolean {
+  if (!vendor || !liveName) return false
+  if (engineEntry(vendor).terminalTitle?.ownsStatus !== true) return false
+  return tabTitle(tab, taskVendor, liveName) === `${liveName} ${tab.ordinal}`
 }
 
 export function TabStrip(props: {
@@ -88,6 +98,8 @@ export function TabStrip(props: {
   vendor: VendorId
   /** tabId → live process display name (see `useTurnPolls().liveTitles`). */
   liveTitles: ReadonlyMap<string, string>
+  /** tabId → resolved live engine identity (see `useTurnPolls().turnVendors`). */
+  turnVendors: ReadonlyMap<string, VendorId>
 }) {
   const themeCtx = useTheme()
   const { theme } = themeCtx
@@ -131,7 +143,7 @@ export function TabStrip(props: {
       {props.tabs.map((tab) => {
         const turn = props.turnStates.get(tab.id) ?? "idle"
         const liveTitle = props.liveTitles.get(tab.id)
-        const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, liveTitle)
+        const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, props.turnVendors.get(tab.id), liveTitle)
         const pulse = pulsing.has(tab.id)
         const turnColor =
           turn === "running"

--- a/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
+++ b/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
@@ -58,9 +58,14 @@ export function useTurnPolls(deps: {
    *  title matches a vendor, else the raw OSC title). Feeds the tab
    *  strip's dynamic default names. */
   liveTitles: ReadonlyMap<string, string>
+  /** tabId → resolved live engine identity — the `targetFor` vendor the
+   *  attached detector tracks, whether kobe-launched or user-typed. The tab
+   *  strip's launch-path-agnostic "does this process own its status" input. */
+  turnVendors: ReadonlyMap<string, VendorId>
 } {
   const [turnStates, setTurnStates] = useState<ReadonlyMap<string, ChatTabTurnState>>(new Map())
   const [liveTitles, setLiveTitles] = useState<ReadonlyMap<string, string>>(new Map())
+  const [turnVendors, setTurnVendors] = useState<ReadonlyMap<string, VendorId>>(new Map())
   const turnPollsRef = useRef(new Map<string, { dispose: () => void; vendor: VendorId; key: string }>())
   /** ptyKey → raw OSC title. Cleared when the PTY instance at that key
    *  changes (release + respawn), so a dead claude's title can't keep a
@@ -192,6 +197,16 @@ export function useTurnPolls(deps: {
         return next
       })
     }
+
+    // Mirror the attach map's resolved identities for render consumers.
+    // Identity-stable: an unchanged map returns `prev` so the 2s attach
+    // tick doesn't churn re-renders.
+    setTurnVendors((prev) => {
+      const next = new Map<string, VendorId>()
+      for (const [id, poll] of turnPolls) next.set(id, poll.vendor)
+      if (next.size === prev.size && [...next].every(([id, v]) => prev.get(id) === v)) return prev
+      return next
+    })
   }, [deps.taskId, deps.worktree, deps.vendor, deps.state, pollTick])
 
   // Final teardown on unmount only.
@@ -202,5 +217,5 @@ export function useTurnPolls(deps: {
     }
   }, [])
 
-  return { turnStates, liveTitles }
+  return { turnStates, liveTitles, turnVendors }
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
@@ -161,8 +161,11 @@ export class HostedTaskPty extends XtermTaskPty {
       })
       if (this.killed) return
       // Replay BEFORE flushing queued input — the ring buffer is the
-      // session's past; queued keystrokes are its future.
-      if (res.replay.length > 0) this.feed(Buffer.from(res.replay, "base64"))
+      // session's past; queued keystrokes are its future. feedReplay, not
+      // feed: the replayed stream contains the child's PAST terminal
+      // queries, and answering them again from this fresh emulator would
+      // inject stray CPR/DA into the child's stdin.
+      if (res.replay.length > 0) this.feedReplay(Buffer.from(res.replay, "base64"))
       this.opened = true
       if (this.pendingResize) {
         const { cols, rows } = this.pendingResize

--- a/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
@@ -177,16 +177,23 @@ export class HostedTaskPty extends XtermTaskPty {
         this.deadOnAttach = res.replay.length > 0
         this.remoteGone()
       } else if (res.replay.length > 0) {
-        // Reattach to a LIVE session (TUI restart, park-sweep wake): when
-        // our geometry matches the host's, no SIGWINCH ever fires and
-        // nothing tells the app to repaint what the replay painted — a
-        // long session's ring-buffer tail starts mid-stream, so the
-        // replayed screen is garbage until the next full redraw. Wiggle
-        // one row and back to force it (tmux repaints on attach the same
-        // way); a same-size TIOCSWINSZ raises no signal, it must move.
+        // Reattach to a LIVE session (TUI restart): when our geometry
+        // matches the host's, no SIGWINCH ever fires and nothing tells
+        // the app to repaint what the replay painted — a long session's
+        // ring-buffer tail starts mid-stream, so the replayed screen is
+        // garbage until the next full redraw. Wiggle one row and back to
+        // force it (tmux repaints on attach the same way); a same-size
+        // TIOCSWINSZ raises no signal, it must move.
         // ponytail: a 1-row-tall pane can't wiggle — never real.
         this.sendResize(this.cols, Math.max(1, this.rows - 1))
-        this.sendResize(this.cols, this.rows)
+        // Back-to-back resizes COALESCE: the child gets ONE SIGWINCH,
+        // reads the already-restored size, sees "unchanged", and skips
+        // the repaint (measured: 2 zero-gap resizes → 1 signal at the
+        // final size). Wait for the child's shrink repaint to actually
+        // arrive before restoring; the timeout covers children that
+        // don't repaint on WINCH at all (a plain shell).
+        await this.nextDataOrTimeout(200)
+        if (!this.killed) this.sendResize(this.cols, this.rows)
       }
     } catch (err) {
       logClientError("pty-hosted", err)
@@ -259,11 +266,30 @@ export class HostedTaskPty extends XtermTaskPty {
     void this.client?.request("pty.resize", { key: this.taskId, cols, rows }).catch(() => {})
   }
 
+  /** One-shot resolver armed by {@link nextDataOrTimeout}. */
+  private dataWaiter: (() => void) | null = null
+
+  /** Resolve on the next inbound `pty.data` frame, or after `ms`. */
+  private nextDataOrTimeout(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.dataWaiter = null
+        resolve()
+      }, ms)
+      this.dataWaiter = () => {
+        this.dataWaiter = null
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+  }
+
   /**
    * Decode + feed one inbound `pty.data` frame. Public so the module-level
    * dispatcher (getSharedPtyClient) can route by key; not for outside use.
    */
   feedFrame(dataB64: string): void {
+    this.dataWaiter?.()
     this.feed(Buffer.from(dataB64, "base64"))
   }
 

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -60,6 +60,11 @@ export abstract class XtermTaskPty implements TaskPtyLike {
    * it. See `TaskPtyLike.unwatchedSinceMs`. */
   private _unwatchedSince: number | null = Date.now()
   private _killed = false
+  /** True while a ring-buffer replay is being parsed — see the reply
+   * channel in the constructor. Flips back in the replay write's
+   * completion callback, which xterm fires strictly after that chunk's
+   * parse and before any later `feed` chunk's. */
+  private muteReplies = false
   protected cols: number
   protected rows: number
   private refreshQueued = false
@@ -89,7 +94,13 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     // path whose relative cursor-move + erase-to-EOL redraw landed on
     // the wrong rows, half-erasing its input-box rule.
     this.term.onData((data) => {
-      if (this._killed) return
+      // `muteReplies`: replies triggered while parsing a ring-buffer REPLAY
+      // are answers to queries the child asked in the PAST (it already got
+      // them, from whatever emulator was attached then). Sending fresh
+      // answers now injects unsolicited CPR/DA bytes into the child's
+      // stdin — an interactive claude read them as input and scrambled its
+      // renderer. Live queries still flow.
+      if (this._killed || this.muteReplies) return
       try {
         this.transportWrite(data)
       } catch {
@@ -280,6 +291,19 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   protected feed(data: string | Uint8Array): void {
     if (this._killed) return
     this.term.write(data, () => this.queueRefresh())
+  }
+
+  /** Feed a ring-buffer REPLAY: parsed like live output, but the emulator's
+   * auto-replies are muted for exactly this chunk's parse (see the reply
+   * channel). Live chunks fed after this parse in FIFO order, so the
+   * un-mute callback lands between the replay's parse and theirs. */
+  protected feedReplay(data: string | Uint8Array): void {
+    if (this._killed) return
+    this.muteReplies = true
+    this.term.write(data, () => {
+      this.muteReplies = false
+      this.queueRefresh()
+    })
   }
 
   private queueRefresh(): void {

--- a/packages/kobe/src/tui/panes/terminal/registry.ts
+++ b/packages/kobe/src/tui/panes/terminal/registry.ts
@@ -27,21 +27,17 @@
  *     dumb container.
  *   - It does not cap concurrency. PLAN.md §4 caps simultaneous
  *     *running* tasks at 4, but a paused-but-in-progress task may
- *     still hold a live PTY. Memory pressure from idle instances is
- *     handled by the park sweep below (issue #28), not by a cap.
+ *     still hold a live PTY.
  *
- * PTY parking (issue #28): every open tab used to keep a full
- * @xterm/headless instance (live grid + scrollback) resident forever —
- * ~250-300MB with many tabs, the biggest process when memory got tight.
- * A periodic sweep now DETACHES persistent-backend handles that have had
- * no data subscriber for PARK_AFTER_MS (only the mounted pane subscribes,
- * so unwatched == hidden): the child keeps running in the pty host, whose
- * byte ring buffer is the authoritative history; the local xterm instance
- * is dropped and GC'd. Switching back re-`acquire()`s under the same key
- * — the exact TUI-restart reattach path (`pty.open` replay), so revived
- * content is identical to what a restart would show. Backends without
- * `detach()` (local child — dropping the handle would kill the shell)
- * are never parked, and neither is anything with a live subscriber.
+ * PTY parking (issue #28) — MANUAL ONLY since 2026-07-10 (owner call):
+ * the automatic idle sweep parked hidden tabs' xterm instances and
+ * revived them through the reattach replay, but the replay reconstructs
+ * a long session from a byte-capped ring buffer (UI painted before the
+ * window is simply gone), so switching back to a parked tab could come
+ * up without claude's input box. Background tabs now keep their local
+ * xterm resident for the app's lifetime — the memory cost is accepted.
+ * `parkIdle` remains for the perf harness and any future explicit
+ * memory-pressure hook; nothing in the app calls it on a timer.
  *
  * Concurrency: every method is synchronous and JS is single-threaded,
  * so there's no race within a single registry. Two registries pointing
@@ -55,11 +51,6 @@ import { type TaskPty, type TaskPtyOpts, createTaskPty } from "./pty"
 
 export type AcquireOpts = Omit<TaskPtyOpts, "taskId" | "cwd">
 
-/** Hidden (no data subscriber) for this long → park the local handle. */
-export const PARK_AFTER_MS = 120_000
-/** Cadence of the park sweep. */
-const PARK_SWEEP_MS = 30_000
-
 /**
  * Factory for the underlying `TaskPty`. Defaults to `createTaskPty`
  * but is injectable so tests can swap in a `MockTaskPty` without
@@ -70,20 +61,9 @@ export type PtyFactory = (opts: TaskPtyOpts) => TaskPty
 export class PtyRegistry {
   private readonly map = new Map<string, TaskPty>()
   private readonly factory: PtyFactory
-  private sweepTimer: ReturnType<typeof setInterval> | null = null
 
   constructor(factory: PtyFactory = createTaskPty) {
     this.factory = factory
-  }
-
-  /** Lazily start the park sweep on first acquire — a registry that never
-   *  holds a PTY (tests, mock hosts) never runs a timer. `unref` so the
-   *  sweep can't keep a wound-down process alive. */
-  private ensureSweeper(): void {
-    if (this.sweepTimer) return
-    const timer = setInterval(() => this.parkIdle(PARK_AFTER_MS), PARK_SWEEP_MS)
-    ;(timer as { unref?: () => void }).unref?.()
-    this.sweepTimer = timer
   }
 
   /**
@@ -92,6 +72,10 @@ export class PtyRegistry {
    * mounted pane subscribes, so unwatched == hidden tab). The child keeps
    * running in the pty host; re-`acquire()` under the same key reattaches
    * and replays the host ring buffer. Returns the parked keys.
+   *
+   * NOT called automatically (see the header): the reattach replay can't
+   * reconstruct a long session's full screen, so parking is reserved for
+   * explicit callers (perf harness) rather than a background sweep.
    */
   parkIdle(idleMs: number, now: number = Date.now()): string[] {
     const parked: string[] = []
@@ -133,7 +117,6 @@ export class PtyRegistry {
 
     const pty = this.factory({ taskId, cwd, ...opts })
     this.map.set(taskId, pty)
-    this.ensureSweeper()
     return pty
   }
 
@@ -185,12 +168,6 @@ export class PtyRegistry {
   releaseAll(): void {
     const ids = Array.from(this.map.keys())
     for (const id of ids) this.release(id)
-    this.stopSweeper()
-  }
-
-  private stopSweeper(): void {
-    if (this.sweepTimer) clearInterval(this.sweepTimer)
-    this.sweepTimer = null
   }
 
   /**
@@ -211,7 +188,6 @@ export class PtyRegistry {
         /* already dead */
       }
     }
-    this.stopSweeper()
   }
 
   /**

--- a/packages/kobe/test/lib/embedded-terminal-env.test.ts
+++ b/packages/kobe/test/lib/embedded-terminal-env.test.ts
@@ -21,4 +21,42 @@ describe("embeddedTerminalEnv", () => {
     })
     expect(base.TERM_PROGRAM).toBe("iTerm.app")
   })
+
+  it("removes fallback identity channels apps use once TERM_PROGRAM is gone", () => {
+    // claude-code's layered detection: with TERM_PROGRAM stripped it still
+    // resolved iTerm2 from these and kept redrawing in iTerm's dialect.
+    const result = embeddedTerminalEnv({
+      LC_TERMINAL: "iTerm2",
+      LC_TERMINAL_VERSION: "3.5.11",
+      ITERM_SESSION_ID: "w0t0p0:UUID",
+      ITERM_PROFILE: "Default",
+      TERM_SESSION_ID: "w0t0p0:UUID",
+      TERM_FEATURES: "T3LrMSc7UUw9Ts3BFGsSyHNoSxF",
+      __CFBundleIdentifier: "com.googlecode.iterm2",
+      HOME: "/home/test",
+    })
+
+    expect(result).toEqual({ HOME: "/home/test" })
+  })
+
+  it("removes every emulator family's identity variables and multiplexer markers", () => {
+    const result = embeddedTerminalEnv({
+      KITTY_WINDOW_ID: "1",
+      KITTY_PID: "42",
+      GHOSTTY_RESOURCES_DIR: "/opt/ghostty",
+      WEZTERM_PANE: "0",
+      ALACRITTY_WINDOW_ID: "7",
+      KONSOLE_VERSION: "230800",
+      VTE_VERSION: "7600",
+      WT_SESSION: "uuid",
+      TMUX: "/tmp/tmux-501/default,123,0",
+      TMUX_PANE: "%1",
+      ZELLIJ: "0",
+      ZELLIJ_SESSION_NAME: "main",
+      STY: "1234.pts-0.host",
+      PATH: "/usr/bin",
+    })
+
+    expect(result).toEqual({ PATH: "/usr/bin" })
+  })
 })

--- a/packages/kobe/test/render/pty-hosted.test.ts
+++ b/packages/kobe/test/render/pty-hosted.test.ts
@@ -90,11 +90,18 @@ describe("HostedTaskPty over a real pty-host socket", () => {
   })
 
   test("same-size reattach to a live session forces a repaint wiggle (SIGWINCH)", async () => {
-    // A full-screen app repaints only on SIGWINCH; a same-size reattach
-    // used to raise none, leaving the replayed screen stale forever (the
-    // restart / park-wake "UI is gone" bug). The trap stands in for the
-    // app's repaint handler.
-    const cmd = ["/bin/sh", "-c", 'trap "echo REPAINT" WINCH; echo ready; while :; do sleep 0.1; done']
+    // A full-screen app repaints only when a SIGWINCH delivers a size that
+    // actually CHANGED (claude's behavior) — the trap mimics that. Two
+    // regressions guarded here: a same-size reattach that raises no
+    // SIGWINCH at all (the restart "UI is gone" bug), and a zero-gap
+    // shrink+restore wiggle whose signals COALESCE into one delivery at
+    // the unchanged final size, which such an app ignores (measured: two
+    // back-to-back resizes → one SIGWINCH at the original size).
+    const cmd = [
+      "/bin/sh",
+      "-c",
+      'cur=$(stty size); trap \'new=$(stty size); if [ "$new" != "$cur" ]; then cur=$new; echo REPAINT; fi\' WINCH; echo ready; while :; do sleep 0.1; done',
+    ]
     const a = new HostedTaskPty({ taskId: "smoke::t3", cwd: dir, command: cmd, cols: 60, rows: 12 })
     await until(() => text(a).includes("ready"), "first attach sees output")
     // Fresh spawn (empty replay) must NOT wiggle — nothing to repaint.

--- a/packages/kobe/test/render/pty-replay-replies.test.ts
+++ b/packages/kobe/test/render/pty-replay-replies.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Ring-buffer replay must not re-answer the child's PAST terminal queries.
+ *
+ * A reattach feeds the host's replay into a fresh xterm; the replayed
+ * stream contains queries (DSR `ESC[6n`, DA `ESC[c`) the child asked long
+ * ago. Answering them again injects unsolicited CPR/DA bytes into the
+ * child's stdin — an interactive claude read them as input and scrambled
+ * its renderer. Live queries after the replay must still be answered:
+ * dropping those is the OTHER historical bug (half-erased input-box rule).
+ */
+
+import { describe, expect, it } from "bun:test"
+import type { TaskPtyOpts } from "../../src/tui/panes/terminal/pty-types"
+import { XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
+
+class ProbeTaskPty extends XtermTaskPty {
+  readonly writes: string[] = []
+  protected transportWrite(data: string): void {
+    this.writes.push(data)
+  }
+  protected transportResize(): void {}
+  protected transportKill(): void {}
+  feedLive(data: string): void {
+    this.feed(data)
+  }
+  replay(data: string): void {
+    this.feedReplay(data)
+  }
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching the raw ESC-prefixed CPR reply is the whole point
+const CPR = /\x1b\[\d+;\d+R/
+
+function screenText(pty: ProbeTaskPty): string {
+  return pty
+    .capture()
+    .map((row) => row.map((c) => c.text).join(""))
+    .join("\n")
+}
+
+async function until(cond: () => boolean): Promise<void> {
+  for (let i = 0; i < 200 && !cond(); i++) await new Promise((r) => setTimeout(r, 5))
+  expect(cond()).toBe(true)
+}
+
+function probe(): ProbeTaskPty {
+  const opts: TaskPtyOpts = { taskId: "t1", cwd: "/tmp", cols: 40, rows: 6 }
+  return new ProbeTaskPty(opts)
+}
+
+describe("XtermTaskPty replay reply muting", () => {
+  it("mutes replies while parsing a replay, then answers live queries again", async () => {
+    const pty = probe()
+    pty.replay("past \x1b[6n output")
+    pty.feedLive("live \x1b[6n tail")
+    await until(() => screenText(pty).includes("tail"))
+    const replies = pty.writes.filter((w) => CPR.test(w))
+    expect(replies).toHaveLength(1)
+  })
+
+  it("keeps answering a purely live stream (no replay involved)", async () => {
+    const pty = probe()
+    pty.feedLive("hello \x1b[6n world")
+    await until(() => screenText(pty).includes("world"))
+    expect(pty.writes.filter((w) => CPR.test(w))).toHaveLength(1)
+  })
+})

--- a/packages/kobe/test/render/tab-strip.test.tsx
+++ b/packages/kobe/test/render/tab-strip.test.tsx
@@ -2,13 +2,16 @@
 /**
  * Terminal-tab title/status ownership. Interactive engines that publish
  * their own activity in the live OSC title must not get a second kobe
- * turn glyph prefixed to the same tab.
+ * turn glyph prefixed to the same tab — regardless of whether kobe
+ * launched the engine or the user typed it into a shell (the identity
+ * comes from `turnVendors`, not the tab's kind).
  */
 
 import { describe, expect, it } from "bun:test"
 import type { ChatTabTurnState } from "../../src/engine/turn-detector"
 import { TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
+import type { VendorId } from "../../src/types/vendor"
 import { type RenderHandle, act, renderComponent } from "./harness"
 
 const codexTab: TerminalTab = {
@@ -19,57 +22,100 @@ const codexTab: TerminalTab = {
   vendor: "codex",
 }
 
+/** A plain shell tab where the USER typed an engine (no pinned vendor). */
+const shellTab: TerminalTab = {
+  kind: "command",
+  id: "tab-9",
+  title: null,
+  ordinal: 9,
+  command: ["zsh"],
+}
+
+async function renderStrip(props: {
+  tab: TerminalTab
+  turnStates: ReadonlyMap<string, ChatTabTurnState>
+  liveTitles: ReadonlyMap<string, string>
+  turnVendors: ReadonlyMap<string, VendorId>
+  vendor: VendorId
+}): Promise<{ text: string; destroy: () => Promise<void> }> {
+  let handle: RenderHandle | undefined
+  await act(async () => {
+    handle = await renderComponent(
+      <TabStrip
+        tabs={[props.tab]}
+        activeId={props.tab.id}
+        turnStates={props.turnStates}
+        onSelect={() => {}}
+        vendor={props.vendor}
+        liveTitles={props.liveTitles}
+        turnVendors={props.turnVendors}
+      />,
+      { width: 80, height: 3 },
+    )
+  })
+  if (!handle) throw new Error("mount failed")
+  const mounted = handle
+  let text = ""
+  await act(async () => {
+    text = await mounted.frame()
+  })
+  return {
+    text,
+    destroy: async () => {
+      await act(async () => mounted.destroy())
+    },
+  }
+}
+
 describe("TabStrip native terminal-title status", () => {
   it("renders Codex's native activity/thread title without a duplicate kobe glyph", async () => {
-    let handle: RenderHandle | undefined
-    await act(async () => {
-      handle = await renderComponent(
-        <TabStrip
-          tabs={[codexTab]}
-          activeId={codexTab.id}
-          turnStates={new Map<string, ChatTabTurnState>([[codexTab.id, "running"]])}
-          onSelect={() => {}}
-          vendor="codex"
-          liveTitles={new Map([[codexTab.id, "⠇ fix codex tab naming"]])}
-        />,
-        { width: 80, height: 3 },
-      )
-    })
-    if (!handle) throw new Error("mount failed")
-    const mounted = handle
-
-    let text = ""
-    await act(async () => {
-      text = await mounted.frame()
+    const { text, destroy } = await renderStrip({
+      tab: codexTab,
+      turnStates: new Map([[codexTab.id, "running"]]),
+      liveTitles: new Map([[codexTab.id, "⠇ fix codex tab naming"]]),
+      turnVendors: new Map([[codexTab.id, "codex"]]),
+      vendor: "codex",
     })
     expect(text).toContain("⠇ fix codex tab naming 26")
     expect(text).not.toContain("●")
-    await act(async () => mounted.destroy())
+    await destroy()
   })
 
   it("keeps kobe's status fallback until the engine has emitted a native title", async () => {
-    let handle: RenderHandle | undefined
-    await act(async () => {
-      handle = await renderComponent(
-        <TabStrip
-          tabs={[codexTab]}
-          activeId={codexTab.id}
-          turnStates={new Map<string, ChatTabTurnState>([[codexTab.id, "running"]])}
-          onSelect={() => {}}
-          vendor="codex"
-          liveTitles={new Map()}
-        />,
-        { width: 80, height: 3 },
-      )
-    })
-    if (!handle) throw new Error("mount failed")
-    const mounted = handle
-
-    let text = ""
-    await act(async () => {
-      text = await mounted.frame()
+    const { text, destroy } = await renderStrip({
+      tab: codexTab,
+      turnStates: new Map([[codexTab.id, "running"]]),
+      liveTitles: new Map(),
+      turnVendors: new Map([[codexTab.id, "codex"]]),
+      vendor: "codex",
     })
     expect(text).toContain("● codex 26")
-    await act(async () => mounted.destroy())
+    await destroy()
+  })
+
+  it("treats a user-typed engine in a shell tab exactly like a kobe-launched one", async () => {
+    const { text, destroy } = await renderStrip({
+      tab: shellTab,
+      turnStates: new Map([[shellTab.id, "running"]]),
+      liveTitles: new Map([[shellTab.id, "claude"]]),
+      turnVendors: new Map([[shellTab.id, "claude"]]),
+      vendor: "claude",
+    })
+    expect(text).toContain("claude 9")
+    expect(text).not.toContain("●")
+    await destroy()
+  })
+
+  it("keeps the glyph when a rename hides the native title", async () => {
+    const renamed: TerminalTab = { ...shellTab, title: "my session" }
+    const { text, destroy } = await renderStrip({
+      tab: renamed,
+      turnStates: new Map([[renamed.id, "running"]]),
+      liveTitles: new Map([[renamed.id, "claude"]]),
+      turnVendors: new Map([[renamed.id, "claude"]]),
+      vendor: "claude",
+    })
+    expect(text).toContain("● my session")
+    await destroy()
   })
 })


### PR DESCRIPTION
## The bug (as reported)

Switch away from a chattab → come back a while later → claude's input box / transcript not painted; the process is fine; typing a long enough message (forcing the input box to grow → full redraw) brings the content back. Intermittent.

## Root-cause chain (each link verified)

1. The park sweep releases a hidden tab's local xterm after 120s; switching back goes through the pty-host reattach path.
2. The reattach replay reconstructs the screen from the host's byte-capped ring buffer (512KB). In a long session, the frames that painted the static UI (claude's input box) predate the window — the replayed screen structurally lacks them.
3. The repaint wiggle that is supposed to fix exactly that (shrink one row, restore) fires its two resizes back-to-back. **Measured: two zero-gap resizes deliver ONE coalesced SIGWINCH and the child reads the already-restored (unchanged) size** — a size-comparing app like claude skips the repaint. Race → intermittent.
4. Bonus defect found on the same path: the fresh emulator answers the child's PAST terminal queries found in the replay (DSR/DA), injecting stray CPR bytes into claude's stdin (first commit).

## Fixes

- **No more auto-parking** (owner call): background tabs keep their local xterm resident; `parkIdle` stays for the perf harness. The everyday tab-switch never touches the replay path anymore.
- **Reliable wiggle** for the remaining replay path (TUI restart): after the shrink, wait for the child's repaint output (200ms timeout for children that don't repaint on WINCH) before restoring the size — two real SIGWINCHes with a real size change each.
- **Replay reply mute**: emulator auto-replies are suppressed for exactly the replay chunk's parse; live queries still answered.

## Tests

- Wiggle regression upgraded: the child now repaints only on an actual size change (claude's behavior) — it FAILS against the old zero-gap wiggle (verified red) and passes with the wait.
- Replay-reply regression: a replayed `ESC[6n` produces no reply; a live one after it produces exactly one.
- Full unit (243) + render (63) suites, typecheck, root lint green.