### PR TITLE
Refine TUI visual hierarchy and interaction focus

### DIFF
--- a/.changeset/calm-rails-focus.md
+++ b/.changeset/calm-rails-focus.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-Refine the TUI visual hierarchy: sidebar rows use neutral selection chrome with brighter branch metadata and anchored git counts, pane backgrounds separate work from navigation, and inactive dividers use the theme's subtle border while the focus accent is reserved for the active pane.
+Refine the TUI visual hierarchy: sidebar rows use neutral selection chrome with brighter branch metadata and anchored git counts, while pane dividers stay subtle on solid backgrounds and become clearer in transparent mode so the focus accent remains reserved for the active pane.

--- a/.changeset/calm-rails-focus.md
+++ b/.changeset/calm-rails-focus.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-Refine the TUI visual hierarchy: sidebar rows use neutral selection chrome with brighter branch metadata and anchored git counts, while pane dividers stay subtle on solid backgrounds and become clearer in transparent mode so the focus accent remains reserved for the active pane.
+Refine the TUI visual hierarchy: navigation panes share neutral row-selection chrome, sidebar metadata and git counts scan more clearly, transparent-mode dividers remain visible, and clicking a New task input moves field focus directly to it.

--- a/.changeset/calm-rails-focus.md
+++ b/.changeset/calm-rails-focus.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Refine the TUI visual hierarchy: sidebar rows use neutral selection chrome with brighter branch metadata and anchored git counts, pane backgrounds separate work from navigation, and inactive dividers use the theme's subtle border while the focus accent is reserved for the active pane.

--- a/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
@@ -77,7 +77,10 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
                   key={v}
                   fg={selected ? theme.primary : theme.textMuted}
                   attributes={selected ? TextAttributes.BOLD : undefined}
-                  onMouseUp={() => vm.setVendor(v)}
+                  onMouseUp={() => {
+                    vm.setVendor(v)
+                    vm.setField("engine")
+                  }}
                 >
                   {selected ? "▸ " : "  "}
                   {v}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
@@ -32,6 +32,7 @@ export function AdoptTab({ vm }: { vm: NewTaskVm }) {
           value={vm.adoptFilter}
           placeholder={t("newTask.placeholder.adoptFilter")}
           focused={vm.field === "adoptFilter"}
+          onMouseUp={() => vm.setField("adoptFilter")}
           onInput={(v: string) => vm.setAdoptFilterText(v)}
           onSubmit={() => vm.toggleAdoptCursor()}
         />

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-clone.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-clone.tsx
@@ -29,6 +29,7 @@ export function CloneTab({ vm }: { vm: NewTaskVm }) {
           value={vm.cloneUrl}
           placeholder="https://github.com/user/repo.git"
           focused={vm.field === "cloneUrl"}
+          onMouseUp={() => vm.setField("cloneUrl")}
           onInput={(v: string) => vm.setCloneUrlText(v)}
           onSubmit={() => {
             if (!vm.cloneUrl.trim()) return
@@ -42,6 +43,7 @@ export function CloneTab({ vm }: { vm: NewTaskVm }) {
           value={vm.cloneParent}
           placeholder="~/"
           focused={vm.field === "cloneParent"}
+          onMouseUp={() => vm.setField("cloneParent")}
           onInput={(v: string) => vm.setCloneParentText(v)}
           onSubmit={() => vm.onCloneParentSubmit()}
         />
@@ -69,6 +71,7 @@ export function CloneTab({ vm }: { vm: NewTaskVm }) {
           value={vm.cloneFolder}
           placeholder={t("newTask.placeholder.folderName")}
           focused={vm.field === "cloneFolder"}
+          onMouseUp={() => vm.setField("cloneFolder")}
           onInput={(v: string) => vm.setCloneFolderText(v)}
           onSubmit={() => vm.setField("cloneBaseRef")}
         />
@@ -79,6 +82,7 @@ export function CloneTab({ vm }: { vm: NewTaskVm }) {
           value={vm.cloneBaseRef}
           placeholder={DEFAULT_BASE_REF}
           focused={vm.field === "cloneBaseRef"}
+          onMouseUp={() => vm.setField("cloneBaseRef")}
           onInput={(v: string) => vm.setCloneBaseRefText(v)}
           // Last field on the tab — Enter kicks off the clone + create.
           onSubmit={() => void vm.commitClone()}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
@@ -42,6 +42,7 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
           value={vm.repo}
           placeholder={vm.defaultRepo}
           focused={vm.field === "repo"}
+          onMouseUp={() => vm.setField("repo")}
           onInput={(v: string) => vm.setRepoText(v)}
           // Every Enter routes through onRepoSubmit — it handles the
           // empty-input pick-first case too.
@@ -57,6 +58,7 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
           value={vm.baseRef}
           placeholder={DEFAULT_BASE_REF}
           focused={vm.field === "baseRef"}
+          onMouseUp={() => vm.setField("baseRef")}
           onInput={(v: string) => vm.setBaseRefText(v)}
           // Last field on the tab — Enter resolves the highlighted branch
           // and creates straight away.

--- a/packages/kobe/src/tui-react/mock/host.tsx
+++ b/packages/kobe/src/tui-react/mock/host.tsx
@@ -29,7 +29,8 @@ import { TerminalTabs } from "../workspace/TerminalTabs"
 const cwd = mkdtempSync(join(tmpdir(), "kobe-mock-react-"))
 
 function MockScene() {
-  const { theme } = useTheme()
+  const { theme, transparentBackground } = useTheme()
+  const inactiveBorder = transparentBackground ? theme.border : theme.borderSubtle
   const focus = useFocus()
   const [tasks] = useState(seedSidebarTasks)
   const [selectedId, setSelectedId] = useState<string | null>(tasks.find((t) => t.kind === "task")?.id ?? null)
@@ -49,7 +50,7 @@ function MockScene() {
         width={SIDEBAR_WIDTH}
         flexShrink={0}
         backgroundColor={theme.backgroundPanel}
-        borderColor={focus.focused === "sidebar" ? theme.focusAccent : theme.borderSubtle}
+        borderColor={focus.focused === "sidebar" ? theme.focusAccent : inactiveBorder}
         onMouseUp={() => focus.setFocused("sidebar")}
       >
         <Sidebar
@@ -64,7 +65,7 @@ function MockScene() {
       </box>
       <box
         flexGrow={1}
-        borderColor={focus.focused !== "sidebar" ? theme.focusAccent : theme.borderSubtle}
+        borderColor={focus.focused !== "sidebar" ? theme.focusAccent : inactiveBorder}
         onMouseUp={() => focus.setFocused("workspace")}
       >
         <TerminalTabs

--- a/packages/kobe/src/tui-react/mock/host.tsx
+++ b/packages/kobe/src/tui-react/mock/host.tsx
@@ -48,7 +48,8 @@ function MockScene() {
       <box
         width={SIDEBAR_WIDTH}
         flexShrink={0}
-        borderColor={focus.focused === "sidebar" ? theme.focusAccent : theme.border}
+        backgroundColor={theme.backgroundPanel}
+        borderColor={focus.focused === "sidebar" ? theme.focusAccent : theme.borderSubtle}
         onMouseUp={() => focus.setFocused("sidebar")}
       >
         <Sidebar
@@ -63,7 +64,7 @@ function MockScene() {
       </box>
       <box
         flexGrow={1}
-        borderColor={focus.focused !== "sidebar" ? theme.focusAccent : theme.border}
+        borderColor={focus.focused !== "sidebar" ? theme.focusAccent : theme.borderSubtle}
         onMouseUp={() => focus.setFocused("workspace")}
       >
         <TerminalTabs

--- a/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
@@ -5,8 +5,8 @@
  * (stat widths, path budget, status→token mapping) comes from the shared
  * framework-free `pane-core.ts`, so the two runtimes render identically.
  *
- * Cursor row treatment — matches the Sidebar: a left accent ▌
- * (focusAccent) + a subtle `backgroundElement` tint, NOT a solid
+ * Cursor row treatment — shares the Sidebar's neutral left marker +
+ * `backgroundElement` tint, NOT the pane-level focus accent or a solid
  * terracotta fill, so the semantic colours survive instead of being
  * flattened to inverted text. A bare space holds the 1-cell gutter on
  * non-cursor rows so content stays aligned.
@@ -16,6 +16,7 @@ import { TextAttributes } from "@opentui/core"
 import { type StatWidths, statCell, statusToken } from "../../../tui/panes/filetree/pane-core"
 import { type Row, truncatePathTail } from "../../../tui/panes/filetree/rows"
 import { useTheme } from "../../context/theme"
+import { resolveRowSelectionChrome } from "../../ui/row-selection-chrome"
 
 export type FileTreeRowProps = {
   row: Row
@@ -31,12 +32,13 @@ export type FileTreeRowProps = {
 
 export function FileTreeRowView(props: FileTreeRowProps) {
   const { theme } = useTheme()
+  const selection = resolveRowSelectionChrome(theme, { cursor: props.cursor })
   const bar = (
-    <text fg={props.cursor ? theme.focusAccent : undefined} wrapMode="none">
-      {props.cursor ? "▌" : " "}
+    <text fg={selection.markerColor} wrapMode="none">
+      {selection.marker}
     </text>
   )
-  const rowBg = props.cursor ? theme.backgroundElement : undefined
+  const rowBg = selection.backgroundColor
   const row = props.row
   if (row.kind === "dir") {
     // Indent: 2 cells per depth level. Marker: ▾ open, ▸ closed.

--- a/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
@@ -28,7 +28,7 @@ function SectionHeader(props: { label: string; suffix?: string; topPad?: boolean
         <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
           {props.label}
         </text>
-        <text fg={theme.border} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
+        <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
           {"─".repeat(240)}
         </text>
         {props.suffix ? (
@@ -80,6 +80,7 @@ export function SidebarPanel(props: {
       flexGrow={1}
       minHeight={0}
       flexDirection="column"
+      backgroundColor={theme.backgroundPanel}
       paddingTop={1}
       paddingBottom={1}
       paddingLeft={0}
@@ -94,11 +95,9 @@ export function SidebarPanel(props: {
         paddingRight={1}
       >
         <box flexDirection="row" gap={1}>
-          <text
-            fg={props.focused ? theme.focusAccent : theme.textMuted}
-            attributes={TextAttributes.BOLD}
-            wrapMode="none"
-          >
+          {/* The outer pane border owns keyboard focus. Keep the brand neutral
+              so it cannot compete with that one global focus signal. */}
+          <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
             KOBE
           </text>
           {status ? (
@@ -155,7 +154,7 @@ export function SidebarPanel(props: {
           return (
             <text
               key={tab.view}
-              fg={active ? theme.primary : theme.textMuted}
+              fg={active ? theme.text : theme.textMuted}
               attributes={active ? TextAttributes.BOLD : undefined}
               wrapMode="none"
               onMouseUp={() => props.setView(tab.view)}
@@ -179,14 +178,14 @@ export function SidebarPanel(props: {
             <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
               {t("tasks.header.projects")}
             </text>
-            <text fg={theme.border} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
+            <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
               {"─".repeat(240)}
             </text>
             {/* Project-filter label sits at flex end (owner taste 2026-07-10);
                 the task-count label is gone — not worth the cells. */}
             {props.projectOptions.length > 1 ? (
               <text
-                fg={props.projectFilterRepo ? theme.primary : theme.textMuted}
+                fg={props.projectFilterRepo ? theme.text : theme.textMuted}
                 attributes={props.projectFilterRepo ? TextAttributes.BOLD : undefined}
                 wrapMode="none"
                 flexShrink={0}

--- a/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
@@ -16,7 +16,8 @@ import { ProjectRowCard, type SidebarRowCardSharedProps, TaskRowCard } from "./r
 import type { SidebarHover, SidebarProps } from "./types"
 
 function SectionHeader(props: { label: string; suffix?: string; topPad?: boolean }) {
-  const { theme } = useTheme()
+  const { theme, transparentBackground } = useTheme()
+  const dividerColor = transparentBackground ? theme.border : theme.borderSubtle
   return (
     <box flexDirection="column" flexShrink={0}>
       {props.topPad ? (
@@ -28,7 +29,7 @@ function SectionHeader(props: { label: string; suffix?: string; topPad?: boolean
         <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
           {props.label}
         </text>
-        <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
+        <text fg={dividerColor} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
           {"─".repeat(240)}
         </text>
         {props.suffix ? (
@@ -71,7 +72,8 @@ export function SidebarPanel(props: {
   dims: { width: number; height: number }
   renderHoverFallback: boolean
 }) {
-  const { theme } = useTheme()
+  const { theme, transparentBackground } = useTheme()
+  const dividerColor = transparentBackground ? theme.border : theme.borderSubtle
   const t = useT()
   const status = props.headerStatus ?? null
   return (
@@ -178,7 +180,7 @@ export function SidebarPanel(props: {
             <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
               {t("tasks.header.projects")}
             </text>
-            <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
+            <text fg={dividerColor} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
               {"─".repeat(240)}
             </text>
             {/* Project-filter label sits at flex end (owner taste 2026-07-10);

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -81,19 +81,41 @@ function SubtitleText(props: { readonly view: SidebarRowView; readonly frame: nu
   const { theme } = themeCtx
   if (!props.view.materializing || themeCtx.reducedMotion) {
     return (
-      <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none" flexGrow={1}>
+      <text fg={theme.textMuted} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
         {props.view.subtitleText}
       </text>
     )
   }
   return (
-    <box flexDirection="row" gap={1} flexGrow={1}>
+    <box flexDirection="row" gap={1} flexBasis={0} flexGrow={1} flexShrink={1}>
       <text fg={theme.primary} wrapMode="none">
         {sweepBar(props.frame)}
       </text>
       <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
         {props.view.subtitleText}
       </text>
+    </box>
+  )
+}
+
+/** Right-edge git metrics stay one non-shrinking cluster while metadata takes
+ * the flexible middle column. This keeps every row scannable at the same
+ * visual anchor even when a branch/title is long. */
+function ChangeStats(props: { readonly changes: WorktreeChanges }) {
+  const { theme } = useTheme()
+  if (props.changes.added <= 0 && props.changes.deleted <= 0) return null
+  return (
+    <box flexDirection="row" gap={1} flexShrink={0}>
+      {props.changes.added > 0 ? (
+        <text fg={theme.success} wrapMode="none" flexShrink={0}>
+          +{props.changes.added}
+        </text>
+      ) : null}
+      {props.changes.deleted > 0 ? (
+        <text fg={theme.error} wrapMode="none" flexShrink={0}>
+          −{props.changes.deleted}
+        </text>
+      ) : null}
     </box>
   )
 }
@@ -107,6 +129,8 @@ function RowBody(props: {
   const task = props.row.task
   const flatIndex = props.row.flatIndex
   const shared = props.shared
+  const isCursor = flatIndex === shared.cursorIndex
+  const isSelected = task.id === shared.selectedId
   return (
     // biome-ignore lint/a11y/useKeyWithMouseEvents: opentui terminal UI has no DOM focus model; hover is pointer-only while keyboard nav exposes the same row detail by selection.
     <box
@@ -121,7 +145,7 @@ function RowBody(props: {
       width="100%"
       flexDirection="column"
       gap={0}
-      backgroundColor={flatIndex === shared.cursorIndex ? theme.backgroundElement : undefined}
+      backgroundColor={isCursor ? theme.backgroundElement : isSelected ? theme.background : undefined}
       onMouseUp={() => {
         shared.setCursorIndex(flatIndex)
         shared.onSelect(task.id)
@@ -166,7 +190,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
     () => shared.spinnerFrame,
   )
   const stateColor = !rowView.loading ? theme.primary : toneColor(theme, rowView.tone)
-  const barColor = isCursor ? theme.focusAccent : isSelected ? theme.primary : undefined
+  const barColor = isCursor ? theme.text : isSelected ? theme.borderActive : undefined
   const barGlyph = isCursor || isSelected ? "▌" : " "
 
   return (
@@ -177,7 +201,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
             {barGlyph}
           </text>
           <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
-            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none">
+            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none" width={1} flexShrink={0}>
               {rowView.projectGlyph}
             </text>
             <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none" flexGrow={1}>
@@ -191,16 +215,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
           </text>
           <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
             <SubtitleText view={rowView} frame={shared.spinnerFrame} />
-            {changes.added > 0 ? (
-              <text fg={theme.success} wrapMode="none">
-                +{changes.added}
-              </text>
-            ) : null}
-            {changes.deleted > 0 ? (
-              <text fg={theme.error} wrapMode="none">
-                −{changes.deleted}
-              </text>
-            ) : null}
+            <ChangeStats changes={changes} />
           </box>
         </box>
       </RowBody>
@@ -234,7 +249,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
     () => shared.spinnerFrame,
   )
   const stateColor = toneColor(theme, rowView.tone)
-  const barColor = isCursor ? theme.focusAccent : isSelected ? theme.primary : undefined
+  const barColor = isCursor ? theme.text : isSelected ? theme.borderActive : undefined
   const barGlyph = isCursor || isSelected ? "▌" : " "
   const chip = prCheckChip(task)
 
@@ -246,7 +261,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
             {barGlyph}
           </text>
           <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
-            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none">
+            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none" width={1} flexShrink={0}>
               {rowView.stateGlyph}
             </text>
             <text
@@ -280,16 +295,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
                 {chip.glyph}
               </text>
             ) : null}
-            {changes.added > 0 ? (
-              <text fg={theme.success} wrapMode="none">
-                +{changes.added}
-              </text>
-            ) : null}
-            {changes.deleted > 0 ? (
-              <text fg={theme.error} wrapMode="none">
-                −{changes.deleted}
-              </text>
-            ) : null}
+            <ChangeStats changes={changes} />
           </box>
         </box>
       </RowBody>

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -32,6 +32,7 @@ import { type WorktreeChanges, pickPushedChanges } from "../../../tui/panes/side
 import { pollWorktreeChanges, worktreeChanges } from "../../../tui/panes/sidebar/worktree-changes-poller"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
+import { resolveRowSelectionChrome } from "../../ui/row-selection-chrome"
 import type { ChatRunState, SidebarHover } from "./types"
 
 export type SidebarRowCardSharedProps = {
@@ -131,6 +132,7 @@ function RowBody(props: {
   const shared = props.shared
   const isCursor = flatIndex === shared.cursorIndex
   const isSelected = task.id === shared.selectedId
+  const selection = resolveRowSelectionChrome(theme, { cursor: isCursor, selected: isSelected })
   return (
     // biome-ignore lint/a11y/useKeyWithMouseEvents: opentui terminal UI has no DOM focus model; hover is pointer-only while keyboard nav exposes the same row detail by selection.
     <box
@@ -145,7 +147,7 @@ function RowBody(props: {
       width="100%"
       flexDirection="column"
       gap={0}
-      backgroundColor={isCursor ? theme.backgroundElement : isSelected ? theme.background : undefined}
+      backgroundColor={selection.backgroundColor}
       onMouseUp={() => {
         shared.setCursorIndex(flatIndex)
         shared.onSelect(task.id)
@@ -167,6 +169,7 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
   const flatIndex = props.row.flatIndex
   const isCursor = flatIndex === shared.cursorIndex
   const isSelected = task.id === shared.selectedId
+  const selection = resolveRowSelectionChrome(theme, { cursor: isCursor, selected: isSelected })
   const changes = useChanges(shared, task)
   useEffect(() => {
     // Dependency-only invalidation key: re-poll on the sidebar's ~2s tick.
@@ -190,15 +193,13 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
     () => shared.spinnerFrame,
   )
   const stateColor = !rowView.loading ? theme.primary : toneColor(theme, rowView.tone)
-  const barColor = isCursor ? theme.text : isSelected ? theme.borderActive : undefined
-  const barGlyph = isCursor || isSelected ? "▌" : " "
 
   return (
     <box flexDirection="column" gap={0} paddingBottom={0}>
       <RowBody row={props.row} shared={shared}>
         <box flexDirection="row" gap={0}>
-          <text fg={barColor} wrapMode="none">
-            {barGlyph}
+          <text fg={selection.markerColor} wrapMode="none">
+            {selection.marker}
           </text>
           <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
             <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none" width={1} flexShrink={0}>
@@ -210,8 +211,8 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
           </box>
         </box>
         <box flexDirection="row" gap={0}>
-          <text fg={barColor} wrapMode="none">
-            {barGlyph}
+          <text fg={selection.markerColor} wrapMode="none">
+            {selection.marker}
           </text>
           <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
             <SubtitleText view={rowView} frame={shared.spinnerFrame} />
@@ -232,6 +233,7 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
   const flatIndex = props.row.flatIndex
   const isCursor = flatIndex === shared.cursorIndex
   const isSelected = task.id === shared.selectedId
+  const selection = resolveRowSelectionChrome(theme, { cursor: isCursor, selected: isSelected })
   const changes = useChanges(shared, task)
   const rowView = withSpinnerFrame(
     buildSidebarRowView({
@@ -249,16 +251,14 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
     () => shared.spinnerFrame,
   )
   const stateColor = toneColor(theme, rowView.tone)
-  const barColor = isCursor ? theme.text : isSelected ? theme.borderActive : undefined
-  const barGlyph = isCursor || isSelected ? "▌" : " "
   const chip = prCheckChip(task)
 
   return (
     <box flexDirection="column" gap={0} paddingBottom={1}>
       <RowBody row={props.row} shared={shared}>
         <box flexDirection="row" gap={0}>
-          <text fg={barColor} wrapMode="none">
-            {barGlyph}
+          <text fg={selection.markerColor} wrapMode="none">
+            {selection.marker}
           </text>
           <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
             <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none" width={1} flexShrink={0}>
@@ -280,8 +280,8 @@ export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardShar
           </box>
         </box>
         <box flexDirection="row" gap={0}>
-          <text fg={barColor} wrapMode="none">
-            {barGlyph}
+          <text fg={selection.markerColor} wrapMode="none">
+            {selection.marker}
           </text>
           <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
             <SubtitleText view={rowView} frame={shared.spinnerFrame} />

--- a/packages/kobe/src/tui-react/tasks-pane/host.tsx
+++ b/packages/kobe/src/tui-react/tasks-pane/host.tsx
@@ -350,7 +350,7 @@ export function TasksShell(props: TasksShellProps) {
   const selectedIsMain = props.tasks.find((t) => t.id === selectedId)?.kind === "main"
 
   return (
-    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+    <box flexDirection="column" flexGrow={1} backgroundColor={theme.backgroundPanel}>
       <VersionSkewBanner
         stale={props.daemonStale}
         daemonVersion={props.daemonVersion}

--- a/packages/kobe/src/tui-react/ui/row-selection-chrome.ts
+++ b/packages/kobe/src/tui-react/ui/row-selection-chrome.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared row-selection semantics for navigation panes.
+ *
+ * Pane focus belongs to the pane frame (`focusAccent`). Rows deliberately
+ * stay neutral: the movable keyboard cursor gets the strongest local marker
+ * and tint, while a persistent selection remains visible after the cursor
+ * moves without pretending the pane owns global focus.
+ */
+
+import type { Theme } from "../context/theme"
+
+export type RowSelectionState = {
+  readonly cursor: boolean
+  readonly selected?: boolean
+}
+
+export function resolveRowSelectionChrome(theme: Theme, state: RowSelectionState) {
+  if (state.cursor) {
+    return {
+      marker: "▌" as const,
+      markerColor: theme.text,
+      backgroundColor: theme.backgroundElement,
+    }
+  }
+  if (state.selected) {
+    return {
+      marker: "▌" as const,
+      markerColor: theme.borderActive,
+      backgroundColor: theme.background,
+    }
+  }
+  return {
+    marker: " " as const,
+    markerColor: undefined,
+    backgroundColor: undefined,
+  }
+}

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -334,7 +334,7 @@ export function TerminalSplit(props: {
           flexShrink={1}
           flexBasis={0}
           border={true}
-          borderColor={focused ? theme.focusAccent : theme.border}
+          borderColor={focused ? theme.focusAccent : theme.borderSubtle}
           onMouseUp={focusThis}
         >
           {body}
@@ -348,7 +348,7 @@ export function TerminalSplit(props: {
         flexShrink={1}
         flexBasis={0}
         border={[divider]}
-        borderColor={focused ? theme.focusAccent : theme.border}
+        borderColor={focused ? theme.focusAccent : theme.borderSubtle}
         onMouseUp={focusThis}
       >
         {body}
@@ -376,7 +376,7 @@ export function TerminalSplit(props: {
         flexGrow={1}
         flexShrink={1}
         flexBasis={0}
-        {...dividerProps(useBoxFrames ? undefined : divider, theme.border)}
+        {...dividerProps(useBoxFrames ? undefined : divider, theme.borderSubtle)}
       >
         {node.children.map((child, i) =>
           renderNode(

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -113,7 +113,8 @@ export function TerminalSplit(props: {
    *  name, matching the group/tab label. Null before the first prompt. */
   engineTitle?: string | null
 }): ReactNode {
-  const { theme } = useTheme()
+  const { theme, transparentBackground } = useTheme()
+  const inactiveBorder = transparentBackground ? theme.border : theme.borderSubtle
   const t = useT()
   const kv = useKV()
   const state = props.splitTree ?? UNSPLIT
@@ -334,7 +335,7 @@ export function TerminalSplit(props: {
           flexShrink={1}
           flexBasis={0}
           border={true}
-          borderColor={focused ? theme.focusAccent : theme.borderSubtle}
+          borderColor={focused ? theme.focusAccent : inactiveBorder}
           onMouseUp={focusThis}
         >
           {body}
@@ -348,7 +349,7 @@ export function TerminalSplit(props: {
         flexShrink={1}
         flexBasis={0}
         border={[divider]}
-        borderColor={focused ? theme.focusAccent : theme.borderSubtle}
+        borderColor={focused ? theme.focusAccent : inactiveBorder}
         onMouseUp={focusThis}
       >
         {body}
@@ -376,7 +377,7 @@ export function TerminalSplit(props: {
         flexGrow={1}
         flexShrink={1}
         flexBasis={0}
-        {...dividerProps(useBoxFrames ? undefined : divider, theme.borderSubtle)}
+        {...dividerProps(useBoxFrames ? undefined : divider, inactiveBorder)}
       >
         {node.children.map((child, i) =>
           renderNode(

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -283,7 +283,8 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
       <box
         width={SIDEBAR_WIDTH}
         flexShrink={0}
-        borderColor={focus.focused === "sidebar" ? theme.focusAccent : theme.border}
+        backgroundColor={theme.backgroundPanel}
+        borderColor={focus.focused === "sidebar" ? theme.focusAccent : theme.borderSubtle}
         onMouseUp={() => focus.setFocused("sidebar")}
       >
         <Sidebar
@@ -329,7 +330,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
       <box
         flexGrow={1}
         flexShrink={1}
-        borderColor={focus.focused === "workspace" ? theme.focusAccent : theme.border}
+        borderColor={focus.focused === "workspace" ? theme.focusAccent : theme.borderSubtle}
         onMouseUp={() => focus.setFocused("workspace")}
       >
         <ShowWorkspace
@@ -353,7 +354,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
         <box
           width={worktreeToolsWidth}
           flexShrink={0}
-          borderColor={focus.focused === "files" ? theme.focusAccent : theme.border}
+          borderColor={focus.focused === "files" ? theme.focusAccent : theme.borderSubtle}
           onMouseUp={() => focus.setFocused("files")}
         >
           <FileTree

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -43,7 +43,8 @@ const WORKTREE_TOOLS_MIN_WIDTH = 22
 const WORKTREE_TOOLS_MAX_WIDTH = 34
 
 function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
-  const { theme } = useTheme()
+  const { theme, transparentBackground } = useTheme()
+  const inactiveBorder = transparentBackground ? theme.border : theme.borderSubtle
   const dialog = useDialog()
   const kv = useKV()
   const focus = useFocus()
@@ -284,7 +285,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
         width={SIDEBAR_WIDTH}
         flexShrink={0}
         backgroundColor={theme.backgroundPanel}
-        borderColor={focus.focused === "sidebar" ? theme.focusAccent : theme.borderSubtle}
+        borderColor={focus.focused === "sidebar" ? theme.focusAccent : inactiveBorder}
         onMouseUp={() => focus.setFocused("sidebar")}
       >
         <Sidebar
@@ -330,7 +331,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
       <box
         flexGrow={1}
         flexShrink={1}
-        borderColor={focus.focused === "workspace" ? theme.focusAccent : theme.borderSubtle}
+        borderColor={focus.focused === "workspace" ? theme.focusAccent : inactiveBorder}
         onMouseUp={() => focus.setFocused("workspace")}
       >
         <ShowWorkspace
@@ -354,7 +355,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
         <box
           width={worktreeToolsWidth}
           flexShrink={0}
-          borderColor={focus.focused === "files" ? theme.focusAccent : theme.borderSubtle}
+          borderColor={focus.focused === "files" ? theme.focusAccent : inactiveBorder}
           onMouseUp={() => focus.setFocused("files")}
         >
           <FileTree

--- a/packages/kobe/src/tui/lib/tmux-border-theme.ts
+++ b/packages/kobe/src/tui/lib/tmux-border-theme.ts
@@ -10,7 +10,7 @@
  * derives the tmux-owned chrome from the active kobe theme and injects
  * it as global options on the `-L kobe` socket:
  *
- *   pane-border-style        fg=<theme.border>
+ *   pane-border-style        fg=<theme.borderSubtle>
  *   pane-active-border-style fg=<theme.focusAccent slot>   (focus signal,
  *                            same slot the in-pane focus indicators use)
  *   status-style             bg=<theme.backgroundPanel> fg=<theme.textMuted>
@@ -102,8 +102,8 @@ function lookupThemeJson(name: string): ThemeJson | null {
 }
 
 /**
- * The two border colors for a theme. Fallback chains mirror
- * `resolveTheme()`: `border` falls back to `text`; the active border
+ * The two border colors for a theme. Inactive pane edges deliberately use
+ * the subtle divider slot (then `border` / `text` fallbacks); the active border
  * uses the user's focus-accent slot with the same `primary` fallback
  * the in-pane focus indicators apply.
  */
@@ -159,7 +159,7 @@ export function resolveTmuxChromeHexes(theme: ThemeJson, focusAccentSlot: string
   const primary = firstHex(theme, focusAccentSlot, "primary", "borderActive", "border", "text")
 
   return {
-    border: firstHex(theme, "border", "text"),
+    border: firstHex(theme, "borderSubtle", "border", "text"),
     activeBorder: primary,
     statusBg: backgroundPanel,
     statusFg: textMuted,

--- a/packages/kobe/src/tui/lib/tmux-border-theme.ts
+++ b/packages/kobe/src/tui/lib/tmux-border-theme.ts
@@ -10,7 +10,8 @@
  * derives the tmux-owned chrome from the active kobe theme and injects
  * it as global options on the `-L kobe` socket:
  *
- *   pane-border-style        fg=<theme.borderSubtle>
+ *   pane-border-style        fg=<theme.borderSubtle>, or <theme.border>
+ *                            when transparent mode needs more separation
  *   pane-active-border-style fg=<theme.focusAccent slot>   (focus signal,
  *                            same slot the in-pane focus indicators use)
  *   status-style             bg=<theme.backgroundPanel> fg=<theme.textMuted>
@@ -66,6 +67,7 @@ const FOCUS_ACCENT_SLOT_NAMES = ["primary", "success", "info"] as const
 interface TmuxChromePrefs {
   readonly themeName: string
   readonly focusAccentSlot: string
+  readonly transparentBackground: boolean
   /** `"tmuxChromeTheme": "off"` in state.json disables the injection. */
   readonly enabled: boolean
 }
@@ -88,10 +90,11 @@ function readTmuxChromePrefs(): TmuxChromePrefs {
     return {
       themeName,
       focusAccentSlot,
+      transparentBackground: parsed.transparentBackground === true,
       enabled: parsed.tmuxChromeTheme !== "off" && parsed.tmuxBorderTheme !== "off",
     }
   } catch {
-    return { themeName: "claude", focusAccentSlot: "primary", enabled: true }
+    return { themeName: "claude", focusAccentSlot: "primary", transparentBackground: false, enabled: true }
   }
 }
 
@@ -102,16 +105,17 @@ function lookupThemeJson(name: string): ThemeJson | null {
 }
 
 /**
- * The two border colors for a theme. Inactive pane edges deliberately use
- * the subtle divider slot (then `border` / `text` fallbacks); the active border
- * uses the user's focus-accent slot with the same `primary` fallback
- * the in-pane focus indicators apply.
+ * The two border colors for a theme. Inactive pane edges use the subtle
+ * divider on solid backgrounds, but the regular border in transparent mode
+ * where there is no panel fill to separate adjacent regions. The active edge
+ * keeps the user's focus-accent slot.
  */
 export function resolveBorderHexes(
   theme: ThemeJson,
   focusAccentSlot: string,
+  transparentBackground = false,
 ): { border: string | null; active: string | null } {
-  const hexes = resolveTmuxChromeHexes(theme, focusAccentSlot)
+  const hexes = resolveTmuxChromeHexes(theme, focusAccentSlot, transparentBackground)
   const border = hexes.border
   const active = hexes.activeBorder
   return { border, active }
@@ -148,7 +152,11 @@ function firstHex(theme: ThemeJson, ...slots: string[]): string | null {
  * `resolveTheme()` where possible, but return null when a whole category
  * cannot be derived so the planner releases instead of painting black.
  */
-export function resolveTmuxChromeHexes(theme: ThemeJson, focusAccentSlot: string): TmuxChromeHexes {
+export function resolveTmuxChromeHexes(
+  theme: ThemeJson,
+  focusAccentSlot: string,
+  transparentBackground = false,
+): TmuxChromeHexes {
   const text = firstHex(theme, "text")
   const background = firstHex(theme, "background")
   const textMuted = firstHex(theme, "textMuted", "text")
@@ -159,7 +167,9 @@ export function resolveTmuxChromeHexes(theme: ThemeJson, focusAccentSlot: string
   const primary = firstHex(theme, focusAccentSlot, "primary", "borderActive", "border", "text")
 
   return {
-    border: firstHex(theme, "borderSubtle", "border", "text"),
+    border: transparentBackground
+      ? firstHex(theme, "border", "borderSubtle", "text")
+      : firstHex(theme, "borderSubtle", "border", "text"),
     activeBorder: primary,
     statusBg: backgroundPanel,
     statusFg: textMuted,
@@ -462,7 +472,7 @@ export async function applyTmuxChromeTheme(): Promise<void> {
     // Disabled or unknown theme → null hexes, which release (never set)
     // the options below; a marker-less server then plans zero commands.
     const hexes = themeJson
-      ? resolveTmuxChromeHexes(themeJson, prefs.focusAccentSlot)
+      ? resolveTmuxChromeHexes(themeJson, prefs.focusAccentSlot, prefs.transparentBackground)
       : resolveTmuxChromeHexes({ theme: {} }, prefs.focusAccentSlot)
     // `-q` keeps an unset option (notably the marker on a fresh server)
     // from logging an "invalid option" error line through runTmuxCapturing.

--- a/packages/kobe/test/behavior/tui-smoke.test.ts
+++ b/packages/kobe/test/behavior/tui-smoke.test.ts
@@ -67,6 +67,13 @@ describe.skipIf(!tmuxAvailable())("kobe TUI boot + focus chords (behavior)", () 
     expect(screen).not.toMatch(/Module not found|panic|Unhandled/i)
   }, 50_000)
 
+  it("uses a subtle inactive divider and keeps the accent for the active pane", () => {
+    const border = tmuxInner(env, "show-options", "-gwv", "pane-border-style").stdout.trim()
+    const active = tmuxInner(env, "show-options", "-gwv", "pane-active-border-style").stdout.trim()
+    expect(border.toLowerCase()).toBe("fg=#2b2a27")
+    expect(active.toLowerCase()).toBe("fg=#cc785c")
+  })
+
   it("ctrl+h focuses the Tasks rail; a second (left-edge) ctrl+h does NOT wrap", async () => {
     tmux(env, "send-keys", "-t", SESSION, "C-h")
     expect(await waitForRole(env, "tasks")).toBe("tasks")

--- a/packages/kobe/test/render/filetree-row.test.tsx
+++ b/packages/kobe/test/render/filetree-row.test.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource @opentui/react */
+
+import { describe, expect, it } from "bun:test"
+import { type CapturedFrame, RGBA } from "@opentui/core"
+import { FileTreeRowView } from "../../src/tui-react/panes/filetree/row-view"
+import { BUNDLED_THEME_JSONS } from "../../src/tui/context/theme/bundled"
+import { resolveThemeSlotHex } from "../../src/tui/context/theme/hex"
+import { renderComponent } from "./harness"
+
+function findSpan(frame: CapturedFrame, needle: string) {
+  return frame.lines.flatMap((line) => line.spans).find((span) => span.text.includes(needle))
+}
+
+describe("FileTreeRowView", () => {
+  it("uses the shared neutral cursor marker instead of the pane focus accent", async () => {
+    const text = RGBA.fromHex(resolveThemeSlotHex(BUNDLED_THEME_JSONS.claude!, "text")!)
+    const focusAccent = RGBA.fromHex(resolveThemeSlotHex(BUNDLED_THEME_JSONS.claude!, "primary")!)
+    const { destroy, spans } = await renderComponent(
+      <FileTreeRowView
+        row={{ kind: "dir", path: ".agents", name: ".agents", depth: 0, expanded: false, hasChildren: true }}
+        cursor
+        statWidths={{ added: 0, deleted: 0 }}
+        pathBudget={30}
+        onActivate={() => {}}
+      />,
+      { width: 36, height: 4 },
+    )
+
+    try {
+      const marker = findSpan(await spans(), "▌")
+      expect(marker?.fg.equals(text)).toBe(true)
+      expect(marker?.fg.equals(focusAccent)).toBe(false)
+    } finally {
+      destroy()
+    }
+  })
+})

--- a/packages/kobe/test/render/new-task-dialog.test.tsx
+++ b/packages/kobe/test/render/new-task-dialog.test.tsx
@@ -1,0 +1,44 @@
+/** @jsxImportSource @opentui/react */
+
+import { describe, expect, it } from "bun:test"
+import { type CapturedFrame, TextAttributes } from "@opentui/core"
+import { NewTaskDialogView } from "../../src/tui-react/component/new-task-dialog/dialog"
+import { act, renderComponent } from "./harness"
+
+function findSpan(frame: CapturedFrame, needle: string) {
+  return frame.lines.flatMap((line) => line.spans).find((span) => span.text.includes(needle))
+}
+
+describe("NewTaskDialogView", () => {
+  it("moves section focus directly to a clicked input", async () => {
+    const { destroy, frame, mockInput, mockMouse, spans } = await renderComponent(
+      <NewTaskDialogView
+        defaultRepo=""
+        savedRepos={[]}
+        availableVendors={["claude", "codex"]}
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />,
+      { width: 90, height: 24, providers: { dialog: true } },
+    )
+
+    try {
+      const initial = await frame()
+      const lines = initial.split("\n")
+      const labelY = lines.findIndex((line) => line.includes("from branch"))
+      const inputY = labelY + 1
+      const inputX = lines[inputY]?.indexOf("main") ?? -1
+      expect(labelY).toBeGreaterThanOrEqual(0)
+      expect(inputX).toBeGreaterThanOrEqual(0)
+
+      await act(async () => mockMouse.click(inputX, inputY))
+      const branchLabel = findSpan(await spans(), "from branch")
+      expect((branchLabel?.attributes ?? 0) & TextAttributes.UNDERLINE).toBe(TextAttributes.UNDERLINE)
+
+      await act(async () => mockInput.pressTab())
+      expect(await frame()).toContain("▸ [ Create ]")
+    } finally {
+      destroy()
+    }
+  })
+})

--- a/packages/kobe/test/render/sidebar.test.tsx
+++ b/packages/kobe/test/render/sidebar.test.tsx
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it } from "bun:test"
 import { type CapturedFrame, RGBA, TextAttributes } from "@opentui/core"
+import { setTransparentBackground } from "../../src/tui-react/context/theme"
 import { Sidebar } from "../../src/tui-react/panes/sidebar/Sidebar"
 import { BUNDLED_THEME_JSONS } from "../../src/tui/context/theme/bundled"
 import { resolveThemeSlotHex } from "../../src/tui/context/theme/hex"
@@ -151,6 +152,33 @@ describe("Sidebar", () => {
       expect(backgroundWidth(frame, "beta task", cursorBg)).toBe(30)
     } finally {
       destroy()
+    }
+  })
+
+  it("strengthens section dividers when transparent mode removes panel fills", async () => {
+    const selected = task()
+    const theme = BUNDLED_THEME_JSONS.claude!
+    const border = RGBA.fromHex(resolveThemeSlotHex(theme, "border")!)
+    setTransparentBackground(true)
+    const { destroy, spans } = await renderComponent(
+      <Sidebar
+        width={30}
+        tasks={[selected]}
+        selectedId={selected.id}
+        onSelect={() => {}}
+        focused
+        worktreeChanges={new Map([[selected.worktreePath, { added: 0, deleted: 0 }]])}
+      />,
+      { width: 34, height: 14 },
+    )
+
+    try {
+      const sectionLine = findLine(await spans(), "TASKS")
+      const divider = sectionLine?.spans.find((span) => span.text.includes("─"))
+      expect(divider?.fg.equals(border)).toBe(true)
+    } finally {
+      destroy()
+      setTransparentBackground(false)
     }
   })
 })

--- a/packages/kobe/test/render/sidebar.test.tsx
+++ b/packages/kobe/test/render/sidebar.test.tsx
@@ -6,13 +6,13 @@
  * not accessors.
  */
 import { describe, expect, it } from "bun:test"
-import { type CapturedFrame, RGBA } from "@opentui/core"
+import { type CapturedFrame, RGBA, TextAttributes } from "@opentui/core"
 import { Sidebar } from "../../src/tui-react/panes/sidebar/Sidebar"
 import { BUNDLED_THEME_JSONS } from "../../src/tui/context/theme/bundled"
 import { resolveThemeSlotHex } from "../../src/tui/context/theme/hex"
 import type { Task } from "../../src/types/task"
 import { toTaskId } from "../../src/types/task"
-import { renderComponent } from "./harness"
+import { act, renderComponent } from "./harness"
 
 function task(overrides: Omit<Partial<Task>, "id"> & { id?: string } = {}): Task {
   return {
@@ -34,6 +34,10 @@ function task(overrides: Omit<Partial<Task>, "id"> & { id?: string } = {}): Task
 
 function findLine(frame: CapturedFrame, needle: string) {
   return frame.lines.find((line) => line.spans.some((span) => span.text.includes(needle)))
+}
+
+function findSpan(frame: CapturedFrame, needle: string) {
+  return frame.lines.flatMap((line) => line.spans).find((span) => span.text.includes(needle))
 }
 
 function backgroundWidth(frame: CapturedFrame, needle: string, bg: RGBA): number {
@@ -65,6 +69,86 @@ describe("Sidebar", () => {
       // stop short — the regression this guards against left a bare gutter
       // column at the row's trailing edge.
       expect(backgroundWidth(frame, "alpha task", selectedBg)).toBe(30)
+    } finally {
+      destroy()
+    }
+  })
+
+  it("reserves the focus accent for the pane border and keeps row metadata readable", async () => {
+    const selected = task()
+    const theme = BUNDLED_THEME_JSONS.claude!
+    const text = RGBA.fromHex(resolveThemeSlotHex(theme, "text")!)
+    const textMuted = RGBA.fromHex(resolveThemeSlotHex(theme, "textMuted")!)
+    const primary = RGBA.fromHex(resolveThemeSlotHex(theme, "primary")!)
+    const borderSubtle = RGBA.fromHex(resolveThemeSlotHex(theme, "borderSubtle")!)
+    const { destroy, spans } = await renderComponent(
+      <Sidebar
+        width={30}
+        tasks={[selected]}
+        selectedId={selected.id}
+        onSelect={() => {}}
+        focused
+        worktreeChanges={new Map([[selected.worktreePath, { added: 7, deleted: 2 }]])}
+      />,
+      { width: 34, height: 14 },
+    )
+
+    try {
+      const frame = await spans()
+      const brand = findSpan(frame, "KOBE")
+      const activeView = findSpan(frame, "Workspace")
+      const branch = findSpan(frame, "main")
+      const selectedLine = findLine(frame, "alpha task")
+      const marker = selectedLine?.spans.find((span) => span.text.includes("▌"))
+      const sectionLine = findLine(frame, "TASKS")
+      const divider = sectionLine?.spans.find((span) => span.text.includes("─"))
+
+      expect(brand?.fg.equals(textMuted)).toBe(true)
+      expect(activeView?.fg.equals(text)).toBe(true)
+      expect(activeView?.fg.equals(primary)).toBe(false)
+      expect(marker?.fg.equals(text)).toBe(true)
+      expect(marker?.fg.equals(primary)).toBe(false)
+      expect(branch?.fg.equals(textMuted)).toBe(true)
+      expect((branch?.attributes ?? 0) & TextAttributes.DIM).toBe(0)
+      expect(divider?.fg.equals(borderSubtle)).toBe(true)
+    } finally {
+      destroy()
+    }
+  })
+
+  it("separates the active task from the movable sidebar cursor", async () => {
+    const selected = task()
+    const cursorTarget = task({
+      id: "task-2",
+      title: "beta task",
+      branch: "feat/beta",
+      worktreePath: "/repo/kobe/.kobe/worktrees/beta",
+    })
+    const theme = BUNDLED_THEME_JSONS.claude!
+    const selectedBg = RGBA.fromHex(resolveThemeSlotHex(theme, "background")!)
+    const cursorBg = RGBA.fromHex(resolveThemeSlotHex(theme, "backgroundElement")!)
+    const { destroy, mockInput, spans } = await renderComponent(
+      <Sidebar
+        width={30}
+        tasks={[selected, cursorTarget]}
+        selectedId={selected.id}
+        onSelect={() => {}}
+        focused
+        worktreeChanges={
+          new Map([
+            [selected.worktreePath, { added: 0, deleted: 0 }],
+            [cursorTarget.worktreePath, { added: 0, deleted: 0 }],
+          ])
+        }
+      />,
+      { width: 34, height: 16 },
+    )
+
+    try {
+      await act(async () => mockInput.pressArrow("down"))
+      const frame = await spans()
+      expect(findSpan(frame, "alpha task")?.bg.equals(selectedBg)).toBe(true)
+      expect(backgroundWidth(frame, "beta task", cursorBg)).toBe(30)
     } finally {
       destroy()
     }

--- a/packages/kobe/test/tui-react/row-selection-chrome.test.ts
+++ b/packages/kobe/test/tui-react/row-selection-chrome.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { resolveRowSelectionChrome } from "../../src/tui-react/ui/row-selection-chrome"
+import { BUNDLED_THEMES, resolveTheme } from "../../src/tui/context/theme-core"
+
+const theme = resolveTheme(BUNDLED_THEMES.claude as never, "dark")
+
+describe("resolveRowSelectionChrome", () => {
+  it("uses a neutral marker and element tint for the movable cursor", () => {
+    expect(resolveRowSelectionChrome(theme, { cursor: true })).toEqual({
+      marker: "▌",
+      markerColor: theme.text,
+      backgroundColor: theme.backgroundElement,
+    })
+  })
+
+  it("keeps a persistent selection visible without borrowing pane focus", () => {
+    expect(resolveRowSelectionChrome(theme, { cursor: false, selected: true })).toEqual({
+      marker: "▌",
+      markerColor: theme.borderActive,
+      backgroundColor: theme.background,
+    })
+  })
+
+  it("lets the cursor win when it also sits on the selected row", () => {
+    expect(resolveRowSelectionChrome(theme, { cursor: true, selected: true }).markerColor).toBe(theme.text)
+  })
+})

--- a/packages/kobe/test/tui/tmux-border-theme.test.ts
+++ b/packages/kobe/test/tui/tmux-border-theme.test.ts
@@ -10,12 +10,18 @@ import {
 } from "../../src/tui/lib/tmux-border-theme"
 
 describe("resolveBorderHexes", () => {
-  test("uses border + the focus-accent slot", () => {
+  test("uses the subtle divider + the focus-accent slot", () => {
     const theme: ThemeJson = {
-      theme: { border: "#333333", primary: "#cc5544", info: "#3377cc", text: "#eeeeee" },
+      theme: {
+        borderSubtle: "#222222",
+        border: "#333333",
+        primary: "#cc5544",
+        info: "#3377cc",
+        text: "#eeeeee",
+      },
     }
-    expect(resolveBorderHexes(theme, "primary")).toEqual({ border: "#333333", active: "#cc5544" })
-    expect(resolveBorderHexes(theme, "info")).toEqual({ border: "#333333", active: "#3377cc" })
+    expect(resolveBorderHexes(theme, "primary")).toEqual({ border: "#222222", active: "#cc5544" })
+    expect(resolveBorderHexes(theme, "info")).toEqual({ border: "#222222", active: "#3377cc" })
   })
 
   test("border falls back to text, active falls back to primary", () => {
@@ -32,6 +38,7 @@ describe("resolveTmuxChromeHexes", () => {
   test("derives border, statusbar, prompt, mode, and overlay colors from the active theme", () => {
     const theme: ThemeJson = {
       theme: {
+        borderSubtle: "#222222",
         border: "#333333",
         primary: "#cc5544",
         info: "#3377cc",
@@ -47,7 +54,7 @@ describe("resolveTmuxChromeHexes", () => {
     }
 
     expect(resolveTmuxChromeHexes(theme, "primary")).toEqual({
-      border: "#333333",
+      border: "#222222",
       activeBorder: "#cc5544",
       statusBg: "#181818",
       statusFg: "#999999",

--- a/packages/kobe/test/tui/tmux-border-theme.test.ts
+++ b/packages/kobe/test/tui/tmux-border-theme.test.ts
@@ -22,6 +22,7 @@ describe("resolveBorderHexes", () => {
     }
     expect(resolveBorderHexes(theme, "primary")).toEqual({ border: "#222222", active: "#cc5544" })
     expect(resolveBorderHexes(theme, "info")).toEqual({ border: "#222222", active: "#3377cc" })
+    expect(resolveBorderHexes(theme, "primary", true)).toEqual({ border: "#333333", active: "#cc5544" })
   })
 
   test("border falls back to text, active falls back to primary", () => {
@@ -70,6 +71,7 @@ describe("resolveTmuxChromeHexes", () => {
       modeBg: "#cc5544",
       modeFg: "#101010",
     })
+    expect(resolveTmuxChromeHexes(theme, "primary", true).border).toBe("#333333")
   })
 
   test("an empty theme yields nulls so the caller releases owned tmux options", () => {


### PR DESCRIPTION
## Summary

- clarify sidebar information hierarchy and align git-change counters
- keep transparent pane boundaries visible without competing with the active focus frame
- centralize neutral row selection chrome across Sidebar and FileTree
- move New task field focus directly to clicked inputs and engine choices

## Why

Sidebar, file-tree, and pane focus cues had drifted into competing accent colors, especially in transparent mode. Mouse clicks in the New task form also updated text input state without updating the form field focus, forcing extra Tab presses.

## Validation

- bun run typecheck
- bun run lint
- bun run test (2518 unit tests and 243 socket tests)
- bun run test:render (69 tests)
- bun run build
- scoped TUI and New task behavior tests (5 tests)