### PR TITLE
fix: capitalize Sonnet/Haiku in the Claude model picker

### DIFF
--- a/.changeset/claude-model-label-casing.md
+++ b/.changeset/claude-model-label-casing.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: the Claude model picker now capitalizes Sonnet and Haiku to match Opus and Anthropic's product names, so the list reads "Opus 4.7 / Sonnet 4.6 / Haiku 4.5" instead of a mix of capitalized and lowercase labels.

--- a/packages/kobe/src/engine/claude-code-local/models.ts
+++ b/packages/kobe/src/engine/claude-code-local/models.ts
@@ -41,9 +41,9 @@ export const CLAUDE_MODELS: readonly ModelChoice[] = [
   ...opus47EffortChoices("claude-opus-4-7[1m]", "Opus 4.7 1M"),
   { vendor: "claude", id: "claude-opus-4-7", label: "Opus 4.7", hint: "most capable, slowest" },
   ...opus47EffortChoices("claude-opus-4-7", "Opus 4.7"),
-  { vendor: "claude", id: "claude-sonnet-4-6[1m]", label: "sonnet 4.6 (1M)", hint: "long context" },
-  { vendor: "claude", id: "claude-sonnet-4-6", label: "sonnet 4.6" },
-  { vendor: "claude", id: "claude-haiku-4-5-20251001", label: "haiku 4.5", hint: "fastest, cheapest" },
+  { vendor: "claude", id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", hint: "long context" },
+  { vendor: "claude", id: "claude-sonnet-4-6", label: "Sonnet 4.6" },
+  { vendor: "claude", id: "claude-haiku-4-5-20251001", label: "Haiku 4.5", hint: "fastest, cheapest" },
 ] as const
 
 const LONG_CTX = 1_000_000

--- a/packages/kobe/test/engine/claude-models.test.ts
+++ b/packages/kobe/test/engine/claude-models.test.ts
@@ -1,0 +1,74 @@
+import { CLAUDE_MODELS, claudeContextWindowFor } from "@/engine/claude-code-local/models"
+import { describe, expect, it } from "vitest"
+
+/**
+ * The Claude model catalog is engine-owned UI data (CLAUDE.md): the composer's
+ * model picker + footer read `label` verbatim and the context meter reads
+ * `claudeContextWindowFor`. Pin the two contracts that matter — the
+ * context-window math, and the picker-label style — without hardcoding the
+ * mutable model list (ids rotate as Anthropic ships new builds).
+ */
+
+const LONG_CTX = 1_000_000
+const STD_CTX = 200_000
+
+describe("claudeContextWindowFor", () => {
+  it("resolves the [1m] long-context build to a 1M window", () => {
+    expect(claudeContextWindowFor("claude-opus-4-7[1m]")).toBe(LONG_CTX)
+    expect(claudeContextWindowFor("claude-sonnet-4-6[1m]")).toBe(LONG_CTX)
+  })
+
+  it("resolves standard builds to the 200k window", () => {
+    expect(claudeContextWindowFor("claude-opus-4-7")).toBe(STD_CTX)
+    expect(claudeContextWindowFor("claude-sonnet-4-6")).toBe(STD_CTX)
+    expect(claudeContextWindowFor("claude-haiku-4-5-20251001")).toBe(STD_CTX)
+  })
+
+  it("matches the 1m marker loosely (case-insensitive, variant spellings)", () => {
+    expect(claudeContextWindowFor("claude-opus-4-7[1M]")).toBe(LONG_CTX)
+    expect(claudeContextWindowFor("some-pinned-model-1m")).toBe(LONG_CTX)
+  })
+
+  it("falls back to the standard window for unknown / ad-hoc pinned ids", () => {
+    expect(claudeContextWindowFor("")).toBe(STD_CTX)
+    expect(claudeContextWindowFor("claude-3-5-haiku-20241022")).toBe(STD_CTX)
+  })
+})
+
+describe("CLAUDE_MODELS catalog", () => {
+  it("is non-empty and every entry is a well-formed claude model choice", () => {
+    expect(CLAUDE_MODELS.length).toBeGreaterThan(0)
+    for (const model of CLAUDE_MODELS) {
+      expect(model.vendor).toBe("claude")
+      expect(model.id.length).toBeGreaterThan(0)
+      expect(model.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("labels use title-case product names, never a lowercase Opus/Sonnet/Haiku", () => {
+    // Picker labels follow the house style (Opus 4.7, Codex, Claude Code): the
+    // Anthropic product name is always capitalized. Guards the regression where
+    // Sonnet/Haiku shipped lowercase while Opus was capitalized.
+    for (const model of CLAUDE_MODELS) {
+      expect(model.label).not.toMatch(/\b(opus|sonnet|haiku)\b/)
+      expect(model.label).toMatch(/\b(Opus|Sonnet|Haiku)\b/)
+    }
+  })
+
+  it("keys the long-context builds by the [1m] marker the context math reads", () => {
+    for (const model of CLAUDE_MODELS) {
+      const expected = /1m/i.test(model.id) ? LONG_CTX : STD_CTX
+      expect(claudeContextWindowFor(model.id)).toBe(expected)
+    }
+  })
+
+  it("offers the full effort ladder for each Opus family entry", () => {
+    const LEVELS = ["low", "medium", "high", "xhigh", "max"]
+    const opusIds = new Set(CLAUDE_MODELS.filter((m) => m.effort).map((m) => m.id))
+    expect(opusIds.size).toBeGreaterThan(0)
+    for (const id of opusIds) {
+      const efforts = CLAUDE_MODELS.filter((m) => m.id === id && m.effort).map((m) => m.effort)
+      expect(efforts).toEqual(LEVELS)
+    }
+  })
+})


### PR DESCRIPTION
## Direction

Feature optimization / UX polish + code health — found by direct code review of the engine-owned Claude model catalog (`src/engine/claude-code-local/models.ts`), which had **zero test coverage**.

## Problem

`CLAUDE_MODELS` is engine-owned UI data (per CLAUDE.md): the composer's model picker and footer render each entry's `label` verbatim. The catalog labeled Opus capitalized but Sonnet/Haiku lowercase:

```
Opus 4.7 1M / Opus 4.7        ← capitalized
sonnet 4.6 (1M) / sonnet 4.6  ← lowercase
haiku 4.5                     ← lowercase
```

The lowercase labels are an oversight, not a style choice — they contradict:
- **The module's own docstring**, which writes "Sonnet 4.6" capitalized.
- **The house style** — the Codex catalog uses `"Codex"` / `"Codex default"` and the adapter identity is `"Claude Code"`, all capitalized.
- **Anthropic's product names** (Opus / Sonnet / Haiku).

So the picker read as an inconsistent mix of capitalized and lowercase product names.

## Fix

Capitalize the Sonnet and Haiku labels to match Opus, the docstring, and Anthropic's naming, and normalize the Sonnet long-context label to `"Sonnet 4.6 1M"` so it mirrors the Opus `"… 1M"` form (instead of the odd `"sonnet 4.6 (1M)"` parenthesized variant). The model **ids** — what's forwarded to `claude --model` — are untouched; this is display copy only, in the engine-owned registry (the correct place to change it).

## Tests

Adds `test/engine/claude-models.test.ts` — the catalog's **first** unit coverage:
- `claudeContextWindowFor`: `[1m]` builds → 1M window, standard builds → 200k, case-insensitive `1m` marker, and ad-hoc/unknown ids fall back to 200k.
- A label-style invariant: every label carries a capitalized `Opus`/`Sonnet`/`Haiku` and never a lowercase one. This assertion **fails against the pre-fix labels**, so it guards the exact regression.
- Structural sanity (every entry is a `claude` choice with non-empty id/label), a check that each `[1m]` id maps to the long window, and that every Opus family entry offers the full `low → max` effort ladder.

## Verification

- `bun run lint` — green (705 files).
- `bun run typecheck` — green (`@sma1lboy/kobe-daemon` + `@sma1lboy/kobe`).
- `bunx vitest run test/engine/` — 325 pass across 29 files (including the 8 new cases). Confirmed the label-casing assertion fails on the pre-fix code and passes with the fix.
- Repo-wide grep confirms no snapshot, picker test, or doc hardcoded the old lowercase labels.

## Follow-ups

- None required. Scope was deliberately kept to the Claude catalog's own internal inconsistency; the Codex/Copilot catalogs already follow the capitalized house style.

Patch changeset included (`.changeset/claude-model-label-casing.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_0163B8gybsirZeqF3jcoqL3U)_