### PR TITLE
fix: reject a merge-strategy land of an already-merged/empty branch

### DIFF
--- a/.changeset/land-merge-empty-branch.md
+++ b/.changeset/land-merge-empty-branch.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Landing a task with the default merge strategy now refuses a branch that has nothing to land instead of reporting a fake success. A branch with no commits ahead of its base (already merged, or an agent that produced no commits) made `git merge --no-ff` exit cleanly with "Already up to date." and no commit, so `kobe api land` / the worktrees-page `l` key reported it as landed on an unrelated pre-existing commit — and with cleanup enabled would then delete the branch and archive the task. The merge path now detects the unmoved HEAD and throws the same "nothing to land (already merged or empty)" error the squash path already raised.

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -148,11 +148,21 @@ export async function landTask(
       throw new Error(`landTask: '${branch}' has nothing to land onto '${landedOn}' (already merged or empty)`)
     }
   } else {
+    const before = (await git(exec, dir, ["rev-parse", "HEAD"])).stdout.trim()
     const merge = await git(exec, dir, ["merge", "--no-ff", "-m", `Land ${branch}`, branch])
     if (merge.exitCode !== 0) {
       const files = await conflictedFiles(exec, dir)
       await git(exec, dir, ["merge", "--abort"]).catch(() => {})
       throw new LandConflictError(task.id, branch, files)
+    }
+    // `git merge --no-ff` on an already-merged/empty branch exits 0 with
+    // "Already up to date." and creates NO commit — HEAD does not move. Guard
+    // it the same way the squash path guards its empty `git commit`, so both
+    // strategies reject a nothing-to-land branch instead of the merge path
+    // reporting a fake success on the unchanged base commit.
+    const after = (await git(exec, dir, ["rev-parse", "HEAD"])).stdout.trim()
+    if (before === after) {
+      throw new Error(`landTask: '${branch}' has nothing to land onto '${landedOn}' (already merged or empty)`)
     }
   }
 

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -112,6 +112,20 @@ describe("landTask", () => {
     expect(status).toBe("")
   })
 
+  test("merge refuses a branch with nothing to land (already merged / no commits ahead)", async () => {
+    // `feat` branches off main but adds no commits of its own, so it is fully
+    // merged into main from the start. `git merge --no-ff` exits 0 ("Already up
+    // to date.") without creating a commit — landTask must reject this rather
+    // than report a fake success on the unchanged base commit.
+    git(["branch", "feat"], repo)
+    const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
+
+    await expect(landTask(task("feat"))).rejects.toThrow(/nothing to land/)
+    // Base checkout must be untouched — no phantom merge commit.
+    const after = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
+    expect(after).toBe(head)
+  })
+
   test("refuses a dirty base checkout", async () => {
     git(["checkout", "-b", "feat"], repo)
     write("b.txt", "feature\n")


### PR DESCRIPTION
## Direction

Bugs / correctness — found by direct code review of the task-landing executor `src/orchestrator/land.ts` (the `task.land` RPC behind `kobe api land` and the worktrees-page `l` key), a merge-vs-squash asymmetry that its integration test suite did not cover.

## Problem

`landTask` merges a task's branch back into its base repo. The **default** strategy is `merge` (`input.strategy ?? "merge"`), and its failure check treated only a **non-zero** git exit as failure:

```ts
const merge = await git(exec, dir, ["merge", "--no-ff", "-m", `Land ${branch}`, branch])
if (merge.exitCode !== 0) { /* conflict */ }
// …then reports success:
return { branch, strategy, landedOn, commit: shaOut.stdout.trim() }
```

But `git merge --no-ff` on a branch with **no commits ahead of its base** (already fully merged, or an agent that produced no commits) exits **0** with `"Already up to date."` and creates **no commit** — HEAD does not move. `landTask` then returned `{ commit: <unchanged base SHA> }` as a success.

The `squash` path already guards this exact case (its empty `git commit` exits non-zero → it throws `"'<branch>' has nothing to land onto '<landedOn>' (already merged or empty)"`). The default `merge` path was missing the equivalent guard, so the two strategies disagreed on identical input.

Reproduced with real git: `git merge --no-ff -m … feat` on a fully-merged `feat` → `Already up to date.`, exit 0, HEAD unchanged.

## Impact

`landTaskWithCleanup(task, { deleteBranch: true, archive: true }, …)` runs its post-land cleanup on this fake success: it **deletes the task's branch** and **archives the task**, reporting the work "landed" at a commit that is actually the pre-existing base SHA — while nothing was merged. For an empty branch that silently discards the branch.

## Fix

Capture HEAD before the `--no-ff` merge and compare after. If HEAD didn't move, nothing was landed — throw the same nothing-to-land error the squash path already raises. This is locale-independent (no parsing of "Already up to date.") and one function, unchanged elsewhere. A real merge always moves HEAD under `--no-ff`, so genuine lands are unaffected.

## Verification

- Added `test/orchestrator/land.test.ts` case: a `feat` branch with no commits ahead → `landTask` rejects with `/nothing to land/` and the base HEAD is unchanged. Confirmed this case **fails** against the pre-fix code and passes with the fix.
- `bunx vitest run test/orchestrator/land.test.ts` — 5 pass (4 existing + the new one).
- `bunx vitest run test/orchestrator/` — 172 pass across 23 files, no regressions.
- `bun run lint` — green (750 files). `bun run typecheck` — green (`@sma1lboy/kobe-daemon` + `@sma1lboy/kobe`).

Patch changeset included.

## Follow-ups (deliberately deferred, out of this slice)

- Separately, code review surfaced a Codex history-reader bug: `findLatestRolloutForWorktree` in `src/engine/codex-local/history.ts` caps its scan at the 12 newest-**created** rollouts *globally* (`MAX_MTIME_SCAN`), so with 13+ codex sessions an older task's Ops activity badge and turn-completion detection can go dark while its agent is still working — and it returns the first cwd match's mtime rather than the max mtime across a worktree's rollouts (Claude/Copilot readers get this right). Worth its own PR; not bundled here to keep this change to one slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_013tDNPgy8JoEZobs42FPPq8)_