### PR TITLE
fix: restore global PureTUI navigation chords

### DIFF
--- a/.changeset/restore-global-puretui-navigation.md
+++ b/.changeset/restore-global-puretui-navigation.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Restore the PureTUI global `Ctrl+Q` return-to-Tasks shortcut and `Ctrl+H/J/K/L` pane navigation, while retaining configurable prefix aliases.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -22,13 +22,12 @@ There are four panes:
 | k       | Files       | `"files"`     | `ctrl+k`    |
 | l       | Terminal    | `"terminal"`  | `ctrl+l`    |
 
-`prefix + h/j/k/l` is the cross-pane navigator (`scope: "global"`, id `focus.numeric`), with h/j/k/l mapped to sidebar/workspace/
-files/terminal. It remains prefix-only because direct control bytes collide with ChatPane and terminal input. An open dialog
-suppresses it — binding registrations include `enabled: dialog.stack.length === 0` so dialog-internal keys (esc to dismiss, enter to
-confirm) win on the dialog stack.
+`ctrl+h/j/k/l` is the global cross-pane navigator (`scope: "global"`, id `focus.numeric`), with prefix + h/j/k/l as equivalent
+aliases; h/j/k/l map to sidebar/workspace/files/terminal. An open dialog suppresses both forms — binding registrations include
+`enabled: dialog.stack.length === 0` so dialog-internal keys (esc to dismiss, enter to confirm) win on the dialog stack.
 
-`prefix + q` from any non-sidebar pane jumps back to the sidebar (`focus.sidebar`). In Tasks, `ctrl+q` exits the attached native UI,
-while plain `q` opens the quit confirmation.
+`ctrl+q` from any non-sidebar pane jumps back to the sidebar (`focus.sidebar`), with `prefix + q` as an alias. In Tasks, a second
+`ctrl+q` exits the attached native UI, while plain `q` opens the quit confirmation.
 `esc` is
 **not** a global "back to sidebar" — it would yank focus out of the chat composer mid-edit. ESC is reserved for: closing
 the top dialog (DialogProvider) and interrupting a streaming turn (Chat). Sidebar focus owns plain `q` (quit confirm)
@@ -57,8 +56,8 @@ site — they should agree.
 
 | Chord            | Overlap                                 | Resolution                                                                                                                                                                          |
 | ---------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `prefix + h/j/k/l` | `focus.numeric` (global) vs ChatPane / terminal input | Pane focus uses the configurable prefix followed by vim-style h/j/k/l, mapped to sidebar/workspace/files/terminal. The prefix keeps raw control bytes available to ChatPane and the terminal child process. **Why not ctrl+digit?** ctrl+digit needs CSI-u / kitty keyboard support; iTerm2 has a quirk where ctrl+1 / ctrl+9 / ctrl+0 fall through to a bare digit byte while ctrl+2..8 emit CSI-u correctly. |
-| `prefix + k` focus | `ctrl+k` remains available to ChatPane / terminal input | The retired palette no longer owns `ctrl+k`; pane focus is the prefix row's `k` second stroke. |
+| `ctrl+h/j/k/l` / `prefix + h/j/k/l` | `focus.numeric` (global) vs ChatPane / terminal input | Pane focus accepts both the global Ctrl chords and configurable prefix aliases, mapped to sidebar/workspace/files/terminal. **Why not ctrl+digit?** ctrl+digit needs CSI-u / kitty keyboard support; iTerm2 has a quirk where ctrl+1 / ctrl+9 / ctrl+0 fall through to a bare digit byte while ctrl+2..8 emit CSI-u correctly. |
+| `ctrl+k` focus | retired palette | The retired palette no longer owns `ctrl+k`; it returns focus to Files, while `prefix + k` is its alias. |
 | `esc`            | dialog dismiss vs chat interrupt        | `DialogProvider` registers a higher-priority `escape` binding while a dialog is open; dialog pop wins. With no dialog and chat focused while streaming, `chat.interrupt` cancels the turn. Idle ESC is a no-op so the composer doesn't lose focus mid-edit. |
 | `ctrl+c`         | copy selection vs double-tap quit       | RETIRED with the outer monitor (`app.copy_or_quit` + `useKobeKeybindings` are gone). In pane hosts `ctrl+c` is host-local (Ops/settings hosts exit); inside a Handover the terminal/tmux own it. |
 | `ctrl+o`         | shell flow-control history (`^O`) / editor-open convention | Global "open active task in editor." We use a modifier chord because it must work from every pane without stealing composer text. The handler is a no-op when no active task or editor opener is available. |

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -189,12 +189,11 @@ export const KobeKeymap: readonly KobeBinding[] = [
   },
   {
     // "Back to tasks" chord. Plain `q` (sidebar scope) actually quits;
-    // this workspace-owned action is prefix-only so it cannot steal a
-    // ChatPane control byte. Scope stays "workspace" for override
-    // validation.
+    // ctrl+q remains the global two-stage escape hatch, with prefix+q as
+    // its alias. Scope stays "workspace" for override validation.
     id: "focus.sidebar",
     scope: "workspace",
-    keys: [],
+    keys: ["ctrl+q"],
     prefixKeys: ["q"],
     category: "Workspace",
     description: "Back to sidebar (tasks)",
@@ -203,9 +202,8 @@ export const KobeKeymap: readonly KobeBinding[] = [
 
   // ─── Navigation ───────────────────────────────────────────────────────
   {
-    // Prefix h/j/k/l — vim-style pane focus. This global navigation action
-    // keeps one static form so it cannot steal ChatPane control bytes. The
-    // four second strokes map to panes by ordinal:
+    // Ctrl+hjkl — vim-style pane focus, with prefix h/j/k/l aliases. The
+    // four chords map to panes by ordinal:
     //   ctrl+h → 1 = sidebar (TASKS)
     //   ctrl+j → 2 = workspace
     //   ctrl+k → 3 = files
@@ -215,7 +213,7 @@ export const KobeKeymap: readonly KobeBinding[] = [
     // byte) and alt+digit gets eaten by macOS launchers like Raycast.
     id: "focus.numeric",
     scope: "global",
-    keys: [],
+    keys: ["ctrl+h", "ctrl+j", "ctrl+k", "ctrl+l"],
     prefixKeys: ["h", "j", "k", "l"],
     category: "Navigation",
     description: "Jump to pane (h=sidebar, j=workspace, k=files, l=terminal)",

--- a/packages/kobe/test/tui/keymap-reload.test.ts
+++ b/packages/kobe/test/tui/keymap-reload.test.ts
@@ -20,10 +20,10 @@ describe("resetKeymapToDefaults", () => {
     expect(findBinding("app.quit")?.prefixKeys).toBeUndefined()
   })
 
-  test("ChatPane navigation keeps only its prefix second strokes", () => {
-    expect(findBinding("focus.sidebar")?.keys).toEqual([])
+  test("global navigation keeps direct Ctrl chords alongside prefix aliases", () => {
+    expect(findBinding("focus.sidebar")?.keys).toEqual(["ctrl+q"])
     expect(findBinding("focus.sidebar")?.prefixKeys).toEqual(["q"])
-    expect(findBinding("focus.numeric")?.keys).toEqual([])
+    expect(findBinding("focus.numeric")?.keys).toEqual(["ctrl+h", "ctrl+j", "ctrl+k", "ctrl+l"])
     expect(findBinding("focus.numeric")?.prefixKeys).toEqual(["h", "j", "k", "l"])
   })
 

--- a/packages/kobe/test/tui/keymap-slot-parity.test.ts
+++ b/packages/kobe/test/tui/keymap-slot-parity.test.ts
@@ -64,7 +64,7 @@ afterEach(() => {
 })
 
 describe("slot dispatch parity with default keys", () => {
-  test("focus.numeric wraps prefix slots back onto the four pane ordinals", () => {
+  test("focus.numeric keeps global Ctrl and prefix pane aliases on the same slots", () => {
     const panes = ["sidebar", "workspace", "files", "workspace"] as const
     const calls: string[] = []
     const reg: RegisteredBinding = {
@@ -76,11 +76,12 @@ describe("slot dispatch parity with default keys", () => {
       }),
     }
 
+    expect(dispatchKeyEvent([reg], makeEvt("h", true))).toBe(true)
     expect(dispatchKeyEvent([reg], makeEvt("a", true))).toBe(true)
     expect(dispatchKeyEvent([reg], makeEvt("h"))).toBe(true)
     expect(dispatchKeyEvent([reg], makeEvt("a", true))).toBe(true)
     expect(dispatchKeyEvent([reg], makeEvt("l"))).toBe(true)
-    expect(calls).toEqual(["sidebar", "workspace"])
+    expect(calls).toEqual(["sidebar", "sidebar", "workspace"])
   })
 
   test("focus.numeric keeps prefix pane slots when direct aliases are added", () => {


### PR DESCRIPTION
## Summary

- restore direct `Ctrl+Q` return-to-Tasks behavior outside the sidebar
- restore direct `Ctrl+H/J/K/L` pane navigation while retaining prefix aliases
- add regression coverage for direct and prefix dispatch paths

## Verification

- `bun run lint`
- `bun run typecheck`
- focused keymap suite (47 tests)
- `bun run test:render` (81 tests)