### PR TITLE
fix: refocus the surviving leaf when closing the first pane of a split

### DIFF
--- a/.changeset/fix-split-close-first-leaf-focus.md
+++ b/.changeset/fix-split-close-first-leaf-focus.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix focus dangling when you close the first pane of a terminal split while it's focused. Closing the leftmost/topmost leaf refocused the pane that was just removed, leaving keyboard routing and the focus highlight pointing at a leaf that no longer exists (a following focus-cycle would find no match); focus now moves to the surviving neighbour instead.

--- a/packages/kobe/src/tui/workspace/split-core.ts
+++ b/packages/kobe/src/tui/workspace/split-core.ts
@@ -98,8 +98,10 @@ export function splitActive<T>(state: SplitState<T>, orientation: "row" | "colum
  * Remove a leaf (its content finished, tmux-style auto-close): 1-child
  * groups collapse into their parent so the tree never holds degenerate
  * groups. Returns `null` when `id` is the last leaf — the CALLER owns
- * what happens then (e.g. the terminal tab's own exit behavior). Focus
- * moves to the previous leaf in reading order.
+ * what happens then (e.g. the terminal tab's own exit behavior). When the
+ * removed leaf held focus, focus moves to the previous leaf in reading
+ * order — or the next one when the FIRST leaf was the one removed (there
+ * is no previous), never to the just-pruned id.
  */
 export function removeLeaf<T>(state: SplitState<T>, id: string): SplitState<T> | null {
   const all = leaves(state.root)
@@ -115,7 +117,12 @@ export function removeLeaf<T>(state: SplitState<T>, id: string): SplitState<T> |
   if (root === null) return null // unreachable behind the length guard; keeps prune's type honest
   if (leaves(root).length === all.length) return state // id not present — no-op
   const order = all.map((l) => l.id)
-  const fallback = order[Math.max(0, order.indexOf(id) - 1)]
+  // `order` is the reading order BEFORE removal, so `order[removedIdx]` is the
+  // leaf being pruned. Step to the previous surviving leaf; when the first leaf
+  // (index 0) was removed there is no previous, so take the next one — never the
+  // just-pruned id. `all.length >= 2` (length guard) means index 1 always exists.
+  const removedIdx = order.indexOf(id)
+  const fallback = order[removedIdx > 0 ? removedIdx - 1 : removedIdx + 1]
   const activeLeafId = state.activeLeafId === id ? fallback : state.activeLeafId
   return { ...state, root, activeLeafId }
 }

--- a/packages/kobe/test/tui/split-core.test.ts
+++ b/packages/kobe/test/tui/split-core.test.ts
@@ -91,6 +91,25 @@ describe("split tree (content-agnostic)", () => {
     expect(removed?.activeLeafId).toBe("leaf-2")
   })
 
+  it("removeLeaf refocuses the surviving next leaf when the active FIRST leaf is closed", () => {
+    // Regression: the fallback read the pre-removal reading order, so closing
+    // the active leaf at index 0 refocused `order[0]` — the leaf just pruned.
+    let s = splitActive(initialSplit(MAIN), "row", SH) // [leaf-1 | leaf-2*]
+    s = focusLeaf(s, "leaf-1") // active is now the FIRST leaf
+    const removed = removeLeaf(s, "leaf-1")
+    expect(removed).not.toBeNull()
+    // Only leaf-2 survives; focus must land on it, not the removed leaf-1.
+    expect(leaves(removed?.root ?? s.root).map((l) => l.id)).toEqual(["leaf-2"])
+    expect(removed?.activeLeafId).toBe("leaf-2")
+  })
+
+  it("removeLeaf leaves focus untouched when a non-active leaf is closed", () => {
+    let s = splitActive(initialSplit(MAIN), "row", SH) // [leaf-1 | leaf-2*]
+    s = splitActive(s, "row", SH) // [leaf-1 | leaf-3* | leaf-2], active = leaf-3
+    const removed = removeLeaf(s, "leaf-1") // close a leaf that isn't focused
+    expect(removed?.activeLeafId).toBe("leaf-3")
+  })
+
   it("removeLeaf returns null for the last leaf — the caller owns what happens next", () => {
     expect(removeLeaf(initialSplit(MAIN), "leaf-1")).toBeNull()
   })


### PR DESCRIPTION
## Direction

Bugs / correctness — found by direct code review of the pure, content-agnostic split-tree state `src/tui/workspace/split-core.ts` (the tmux-style pane layout behind terminal splits, issue #16). The `removeLeaf` focus-fallback had a boundary bug the existing tests didn't reach.

## Problem

`removeLeaf` prunes a leaf and, when the removed leaf held focus, moves focus to the previous leaf in reading order. It computed that fallback from the leaf order captured **before** removal:

```ts
const order = all.map((l) => l.id)                      // reading order BEFORE removal
const fallback = order[Math.max(0, order.indexOf(id) - 1)]
const activeLeafId = state.activeLeafId === id ? fallback : state.activeLeafId
```

`order[0]` is the leaf being removed. When you close the **active** leaf sitting at reading-index 0 (the leftmost pane in a `row` split, or the topmost in a `column` split), `order.indexOf(id)` is `0`, `Math.max(0, -1)` clamps to `0`, and `fallback = order[0] = id` — the id that was just pruned. Focus is set to a leaf that no longer exists in the tree.

Concrete trigger:

```ts
let s = splitActive(initialSplit(MAIN), "row", SH) // [leaf-1 | leaf-2], active = leaf-2
s = focusLeaf(s, "leaf-1")                         // active = leaf-1 (the FIRST leaf)
const r = removeLeaf(s, "leaf-1")
// wrong:   r.activeLeafId === "leaf-1"  (a removed id)
// correct: r.activeLeafId === "leaf-2"  (the surviving leaf)
```

Downstream this dangles focus: the focus highlight and keyboard routing have no matching leaf, and `cycleLeaf` does `order.indexOf("leaf-1")` → `-1`, so a subsequent focus-cycle starts from the wrong slot. It's reachable in the real UI — closing the leftmost/topmost pane while it's focused is a normal split flow.

The sibling module `terminal-tabs-core.ts` gets the same pattern right because it indexes the **already-filtered** survivor array (`tabs[Math.max(0, i - 1)]`), which confirms the intended behavior.

## Fix

Step to the previous **surviving** leaf, or — when the first leaf was the one removed (there is no previous) — to the next one, never the just-pruned id:

```ts
const removedIdx = order.indexOf(id)
const fallback = order[removedIdx > 0 ? removedIdx - 1 : removedIdx + 1]
```

`order[removedIdx + 1]` is guaranteed to exist and survive: the `all.length <= 1` guard means ≥2 leaves and only index 0 was removed, so index 1 is a different, surviving leaf. All non-index-0 cases are unchanged (`removedIdx - 1` is always a survivor). One function, no other behavior touched.

## Verification

- Added two cases to `test/tui/split-core.test.ts`: closing the active FIRST leaf refocuses the surviving neighbour; closing a non-active leaf leaves focus untouched. Confirmed the first-leaf case **fails** against the pre-fix code and passes with the fix.
- `bunx vitest run test/tui/split-core.test.ts` — 21 pass (19 existing + 2 new).
- `bun run lint` — green (708 files). `bun run typecheck` — green (`@sma1lboy/kobe-daemon` + `@sma1lboy/kobe`).

Patch changeset included.

## Follow-ups

None required — the fallback is now correct at both boundaries; no other `removeLeaf` behavior changed.