### PR TITLE
fix: stabilize macOS IME anchor in embedded terminals

### DIFF
--- a/.changeset/stable-ime-anchor.md
+++ b/.changeset/stable-ime-anchor.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep macOS input-method preedit and candidate windows anchored to the embedded terminal prompt while Claude or another engine animates output.

--- a/docs/superpowers/plans/2026-07-13-ime-anchor-stability.md
+++ b/docs/superpowers/plans/2026-07-13-ime-anchor-stability.md
@@ -53,7 +53,8 @@ Expected: FAIL because `tui/lib/ime-anchor-output` does not exist.
 
 Implement owner-aware anchor state and a byte transformer that retains only a
 suffix which could be the start of the synchronized-frame terminator. Insert a
-1-based CUP plus `CSI ? 25 l` before each complete terminator. Wrap the real
+1-based CUP converted from the renderer's zero-based screen coordinate, plus
+`CSI ? 25 l`, before each complete terminator. Wrap the real
 stdout in a delegating proxy so OpenTUI selects its native custom-output feed.
 
 Expose a resize forwarder with this contract:

--- a/docs/superpowers/plans/2026-07-13-ime-anchor-stability.md
+++ b/docs/superpowers/plans/2026-07-13-ime-anchor-stability.md
@@ -1,0 +1,234 @@
+# Stable macOS IME Anchor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep macOS IME preedit and candidate UI anchored to the embedded PTY cursor during OpenTUI animation frames.
+
+**Architecture:** A framework-free anchor controller owns the focused terminal's screen coordinate. On macOS fullscreen hosts, an OpenTUI custom-stdout adapter inserts a hidden cursor move immediately before each synchronized-frame terminator; the React terminal separately retains the last valid PTY cursor for this anchor while continuing to hide its visual inverse-cell cursor when the PTY hides its cursor.
+
+**Tech Stack:** TypeScript, React 19, Bun, OpenTUI 0.4.3, Vitest, Bun render tests.
+
+## Global Constraints
+
+- Preserve the inverse-cell visual cursor and OpenTUI 0.4.3 dependency.
+- Never patch `node_modules` or write ANSI directly from a React component.
+- Apply the output adapter only to macOS fullscreen hosts.
+- Keep every touched source file at or below 500 lines.
+- Ship one patch changeset.
+
+---
+
+### Task 1: Frame-final IME anchor output
+
+**Files:**
+- Create: `packages/kobe/src/tui/lib/ime-anchor-output.ts`
+- Create: `packages/kobe/test/tui/ime-anchor-output.test.ts`
+
+**Interfaces:**
+- Produces: `ImeAnchorController`, `imeAnchorController`, `createImeAnchoredOutput`, and `installRendererResizeForwarder`.
+- Consumes: a terminal-like output stream and an OpenTUI renderer with `resize(width, height)`.
+
+- [ ] **Step 1: Write the failing wire tests**
+
+Cover owner-safe claim/release, an unchanged inactive stream, injection before
+`\x1b[?2026l`, every delimiter split point, and resize-listener cleanup. The
+wire assertion must require this ordering:
+
+```ts
+expect(output).toContain("\x1b[5;7H\x1b[?25l\x1b[?2026l")
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+cd packages/kobe
+bunx vitest run test/tui/ime-anchor-output.test.ts
+```
+
+Expected: FAIL because `tui/lib/ime-anchor-output` does not exist.
+
+- [ ] **Step 3: Implement the minimal streaming adapter**
+
+Implement owner-aware anchor state and a byte transformer that retains only a
+suffix which could be the start of the synchronized-frame terminator. Insert a
+1-based CUP plus `CSI ? 25 l` before each complete terminator. Wrap the real
+stdout in a delegating proxy so OpenTUI selects its native custom-output feed.
+
+Expose a resize forwarder with this contract:
+
+```ts
+installRendererResizeForwarder(
+  renderer: { resize(width: number, height: number): void },
+  terminal: Pick<NodeJS.WriteStream, "columns" | "rows">,
+  signals?: Pick<NodeJS.Process, "on" | "removeListener">,
+): () => void
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+cd packages/kobe
+bunx vitest run test/tui/ime-anchor-output.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the renderer-output seam**
+
+```bash
+git add packages/kobe/src/tui/lib/ime-anchor-output.ts packages/kobe/test/tui/ime-anchor-output.test.ts
+git commit -m "fix: anchor hidden cursor at frame end" -m "Route macOS OpenTUI frames through an owner-aware output adapter. It restores the hidden hardware cursor before synchronized-frame commit so IME preedit cannot follow diff rendering."
+```
+
+### Task 2: Retain the PTY cursor independently from the visual cursor
+
+**Files:**
+- Create: `packages/kobe/src/tui/panes/terminal/ime-cursor.ts`
+- Create: `packages/kobe/test/tui/terminal-ime-cursor.test.ts`
+- Modify: `packages/kobe/src/tui-react/panes/terminal/Terminal.tsx`
+
+**Interfaces:**
+- Produces: `ImeCursorRetention.update(pty, cursor)` returning the retained `CursorPos | null`.
+- Consumes: the shared `imeAnchorController` from Task 1.
+
+- [ ] **Step 1: Write the failing retention tests**
+
+Pin these transitions:
+
+```ts
+tracker.update(ptyA, { x: 12, y: 4 }) // => { x: 12, y: 4 }
+tracker.update(ptyA, null)             // => { x: 12, y: 4 }
+tracker.update(ptyB, null)             // => null
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+cd packages/kobe
+bunx vitest run test/tui/terminal-ime-cursor.test.ts
+```
+
+Expected: FAIL because `terminal/ime-cursor` does not exist.
+
+- [ ] **Step 3: Implement minimal cursor retention**
+
+Add a small framework-free tracker that remembers the last non-null cursor for
+one PTY identity and clears on identity change.
+
+- [ ] **Step 4: Integrate anchor ownership in `Terminal.tsx`**
+
+Keep `visibleCursor` unchanged for `overlayCursor`. Derive a second viewport
+cursor from the retention tracker. When focused and laid out, claim the shared
+controller with a stable per-component owner token, then call OpenTUI's existing
+hidden `setCursorPosition`. Release only the matching owner on blur/unmount and
+park at origin only when that release actually cleared the active anchor.
+
+- [ ] **Step 5: Run focused terminal tests and verify GREEN**
+
+Run:
+
+```bash
+cd packages/kobe
+bunx vitest run test/tui/terminal-ime-cursor.test.ts test/tui/terminal-viewport.test.ts test/tui/terminal-render.test.ts
+bun test test/render/terminal-ime-keys.test.tsx
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit cursor-state separation**
+
+```bash
+git add packages/kobe/src/tui/panes/terminal/ime-cursor.ts packages/kobe/src/tui-react/panes/terminal/Terminal.tsx packages/kobe/test/tui/terminal-ime-cursor.test.ts
+git commit -m "fix: retain terminal IME anchor through redraws" -m "Separate the visual PTY cursor from the macOS IME anchor. Transient cursor-hide frames retain the last valid location, and owner tokens prevent stale split cleanup from clearing the focused pane."
+```
+
+### Task 3: Wire the macOS host and publish the fix
+
+**Files:**
+- Modify: `packages/kobe/src/tui-react/lib/host-boot.tsx`
+- Modify: `packages/kobe/test/tui/host-render-options.test.ts`
+- Create: `.changeset/stable-ime-anchor.md`
+
+**Interfaces:**
+- Consumes: `createImeAnchoredOutput` and `installRendererResizeForwarder` from Task 1.
+- Produces: macOS fullscreen hosts using the transformed custom stdout with `remote: false`; all other hosts retain current options.
+
+- [ ] **Step 1: Add failing host-option tests**
+
+Extract a pure composition helper that receives `platform`, `stdout`, and
+`onDestroy`. Assert macOS fullscreen options contain the proxy stdout and
+`remote: false`, while Linux and inline options remain byte-for-byte equivalent
+to the prior direct path.
+
+- [ ] **Step 2: Run the host tests and verify RED**
+
+Run:
+
+```bash
+cd packages/kobe
+bunx vitest run test/tui/host-render-options.test.ts
+```
+
+Expected: FAIL because the macOS renderer-output composition is absent.
+
+- [ ] **Step 3: Wire renderer construction and cleanup**
+
+Create the adapter only for `platform === "darwin"` and fullscreen hosts. Pass
+its proxy as `stdout`, set `remote: false`, forward `SIGWINCH`, and release the
+listener plus any pending transformer prefix in the wrapped destroy callback.
+
+- [ ] **Step 4: Add the patch changeset**
+
+Create `.changeset/stable-ime-anchor.md`:
+
+```md
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep macOS input-method preedit and candidate windows anchored to the embedded terminal prompt while Claude or another engine animates output.
+```
+
+- [ ] **Step 5: Run scoped and repository verification**
+
+Run:
+
+```bash
+cd packages/kobe
+bunx vitest run test/tui/ime-anchor-output.test.ts test/tui/terminal-ime-cursor.test.ts test/tui/host-render-options.test.ts
+bun test test/render/terminal-ime-keys.test.tsx
+cd ../..
+bun run lint
+bun run typecheck
+bun run test
+cd packages/kobe
+bun run test:render
+bun run build
+bun run test:behavior
+```
+
+Expected: all commands pass. Inspect touched source-file line counts and confirm
+all are at or below 500 lines.
+
+- [ ] **Step 6: Commit publication metadata**
+
+```bash
+git add packages/kobe/src/tui-react/lib/host-boot.tsx packages/kobe/test/tui/host-render-options.test.ts .changeset/stable-ime-anchor.md
+git commit -m "fix: enable stable macOS IME anchoring" -m "Use the frame-final cursor adapter only for fullscreen macOS hosts and preserve local terminal detection and resize handling. Ship the behavior as a patch changeset."
+```
+
+- [ ] **Step 7: Push and open the KOBE pull request**
+
+```bash
+git push -u origin fix/ime-anchor-stability
+gh pr create --base main --head fix/ime-anchor-stability --title "fix: stabilize macOS IME anchor in embedded terminals" --body-file /tmp/kobe-ime-pr.md
+```
+
+The PR body must include the reproduced root cause, the frame-final output
+contract, test evidence, and the remaining manual iTerm acceptance item.

--- a/docs/superpowers/specs/2026-07-13-ime-anchor-stability-design.md
+++ b/docs/superpowers/specs/2026-07-13-ime-anchor-stability-design.md
@@ -40,7 +40,7 @@ anchor is active, the transform inserts the following bytes immediately before
 the terminator:
 
 ```text
-CUP(anchorRow, anchorColumn) + DECTCEM hide
+CUP(screenY + 1, screenX + 1) + DECTCEM hide
 ```
 
 The cursor move is therefore committed in the same synchronized frame as the

--- a/docs/superpowers/specs/2026-07-13-ime-anchor-stability-design.md
+++ b/docs/superpowers/specs/2026-07-13-ime-anchor-stability-design.md
@@ -1,0 +1,97 @@
+# Stable macOS IME anchor design
+
+## Problem
+
+The embedded Claude/Codex terminal draws its visible cursor as an inverse
+cell, while the outer terminal's hardware cursor stays hidden and supplies the
+anchor used by macOS input methods. KOBE already calls
+`renderer.setCursorPosition(x, y, false)`, but OpenTUI 0.4.3 restores cursor
+position at the end of a rendered frame only when the cursor is visible.
+
+During an engine animation, OpenTUI's row-major diff leaves the hidden
+hardware cursor at the last changed cell. macOS then moves the uncommitted
+pinyin preedit and candidate popup to that cell even though the embedded PTY
+cursor has not moved.
+
+## Constraints
+
+- Keep KOBE's inverse-cell visual cursor; the visible native-cursor experiment
+  was previously reverted.
+- Do not pause PTY output or disable engine animation. Both only mask the
+  renderer defect.
+- Do not write ANSI directly from `Terminal.tsx`; the renderer owns terminal
+  output ordering.
+- Preserve the OpenTUI 0.4.3 dependency and do not patch generated
+  `node_modules` or ship a platform-specific native binary.
+- Limit the output interposition to macOS fullscreen hosts, where the reported
+  system IME behavior exists. Other platforms and inline command pages retain
+  the direct `process.stdout` path.
+
+## Design
+
+### 1. Frame-final cursor anchoring
+
+Create a framework-free macOS renderer-output adapter. OpenTUI supports a
+custom stdout stream through its native span feed; KOBE supplies a proxy stream
+that delegates to `process.stdout` after applying one streaming transform.
+
+For every synchronized frame terminator (`CSI ? 2026 l`) while a terminal IME
+anchor is active, the transform inserts the following bytes immediately before
+the terminator:
+
+```text
+CUP(anchorRow, anchorColumn) + DECTCEM hide
+```
+
+The cursor move is therefore committed in the same synchronized frame as the
+screen diff. The hardware cursor remains invisible, but the outer terminal's
+real cursor position ends every frame at the embedded PTY cursor.
+
+The transformer carries a partial terminator prefix across output chunks, so
+the invariant holds when OpenTUI's native feed splits an ANSI sequence.
+
+Using a custom stream makes OpenTUI stop installing its own `SIGWINCH` handler.
+The adapter therefore installs an equivalent resize forwarder and removes it
+when the renderer is destroyed. The host passes `remote: false` so terminal
+capability detection continues to describe the local terminal.
+
+### 2. Separate visual cursor from IME anchor
+
+`Terminal.tsx` continues to derive `visibleCursor` directly from the current
+PTY cursor. A hidden PTY cursor therefore still hides the inverse-cell visual
+cursor.
+
+Separately, the terminal retains the last non-null PTY cursor for IME anchoring.
+Transient `CSI ? 25 l` / `CSI ? 25 h` redraw intervals no longer send the
+anchor to `(0, 0)`. The retained cursor is cleared when the PTY identity
+changes, focus leaves the pane, or the pane unmounts.
+
+Each mounted terminal owns a unique token. Anchor updates claim ownership;
+release clears the global anchor only when the releasing token is still the
+owner. This prevents an old split leaf's cleanup from clearing the anchor just
+claimed by the newly focused leaf.
+
+### 3. Failure and fallback behavior
+
+When no terminal owns the anchor, the output adapter passes bytes through
+unchanged. If the cursor has never been observed or is outside a historical
+scrollback viewport, a focused pane keeps the prior valid screen anchor rather
+than inventing an origin coordinate. On focus loss, KOBE parks the native
+cursor at the origin as before; no IME composition belongs to that pane then.
+
+## Verification
+
+- Streaming-unit test: alternating left/right diff frames both end with the
+  same hidden `CUP` before synchronized-update reset.
+- Chunk-boundary test: every split point inside `CSI ? 2026 l` produces the
+  same output as an unsplit frame.
+- Ownership test: a stale terminal release cannot clear a newer terminal's
+  anchor.
+- Cursor-retention test: a transient null PTY cursor preserves the IME anchor
+  while the visual cursor remains null; a PTY identity change clears it.
+- Existing terminal IME key-forwarding render tests remain green.
+- Pre-PR gates: lint, typecheck, fast + socket tests, render tests, build, and
+  behavior tests.
+- Manual acceptance: in iTerm with macOS pinyin, type while Claude animates;
+  preedit and candidate popup stay at the prompt, with no visible second
+  cursor and no CJK width drift.

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -47,6 +47,7 @@ import {
   installOrphanExitWatchdog,
   installPaneExitBackstop,
 } from "../../tui/lib/host-render-options"
+import { createHostImeOutput } from "../../tui/lib/ime-anchor-output"
 import { type PersistedUiPrefs, readPersistedUiPrefs } from "../../tui/lib/persisted-ui-prefs"
 import { FocusProvider } from "../context/focus"
 import { KVProvider } from "../context/kv"
@@ -234,11 +235,22 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
   const notifications = opts.providers?.notifications ?? false
 
   const screen = await opts.setup(prefs)
-  const renderer = await createCliRenderer(
-    opts.inlineRows !== undefined
-      ? inlineRenderOptions(opts.inlineRows, screen.onDestroy)
-      : hostRenderOptions(screen.onDestroy),
-  )
+  const imeOutput = createHostImeOutput({
+    platform: process.platform,
+    fullscreen: opts.inlineRows === undefined,
+    stdout: process.stdout,
+  })
+  let detachImeOutput = (): void => {}
+  const onDestroy = (): void => {
+    detachImeOutput()
+    imeOutput.flush()
+    screen.onDestroy?.()
+  }
+  const renderer = await createCliRenderer({
+    ...(opts.inlineRows !== undefined ? inlineRenderOptions(opts.inlineRows, onDestroy) : hostRenderOptions(onDestroy)),
+    ...imeOutput.rendererOptions,
+  })
+  detachImeOutput = imeOutput.attach(renderer)
 
   const body = (
     <>

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -37,6 +37,8 @@ import type { BoxRenderable, TextRenderable } from "@opentui/core"
 import { StyledText } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
+import { imeAnchorController } from "../../../tui/lib/ime-anchor-output"
+import { ImeCursorRetention } from "../../../tui/panes/terminal/ime-cursor"
 import { type PtyRegistry, getDefaultPtyRegistry } from "../../../tui/panes/terminal/registry"
 import { rowsToStyledText } from "../../../tui/panes/terminal/sgr-to-text-chunk"
 import { isShellMissing, overlayCursor } from "../../../tui/panes/terminal/terminal-render"
@@ -153,6 +155,15 @@ export function Terminal(props: TerminalProps) {
     () => viewportCursor(cursor, scrollOffset, visibleRange),
     [cursor, scrollOffset, visibleRange],
   )
+  // The inverse-cell cursor above follows the PTY's current visibility.
+  // macOS IME anchoring instead retains the last valid coordinate while an
+  // app briefly hides its cursor during a redraw.
+  const [imeCursorRetention] = useState(() => new ImeCursorRetention())
+  const imeCursor = imeCursorRetention.update(pty, cursor)
+  const visibleImeCursor = useMemo(
+    () => viewportCursor(imeCursor, scrollOffset, visibleRange),
+    [imeCursor, scrollOffset, visibleRange],
+  )
 
   /* --------- selection ---------- */
 
@@ -230,6 +241,8 @@ export function Terminal(props: TerminalProps) {
   /* --------- resize-push + host-cursor anchor ---------- */
 
   const renderer = useRenderer()
+  const imeAnchorOwner = useRef(Symbol("terminal-ime-anchor")).current
+  const lastImeScreenAnchorRef = useRef<{ x: number; y: number } | null>(null)
 
   // Push geometry changes to the backend, deduped against the last push —
   // real PTY backends may emit SIGWINCH even when geometry is unchanged.
@@ -250,33 +263,49 @@ export function Terminal(props: TerminalProps) {
   // Keep the native host cursor INVISIBLE (the visible cursor is the
   // inline inverse cell in `cursorRows`) but ANCHORED to the embedded
   // cursor's screen cell — the OS IME candidate window follows the real
-  // terminal cursor. Falls back to origin when scrolled out of view or
-  // not yet laid out.
+  // terminal cursor. A transient PTY cursor-hide retains the last position;
+  // the renderer-output adapter restores it at the end of every diff frame.
   useEffect(() => {
     // Dependency-only invalidation keys — see use-terminal-geometry.ts;
     // screenX/screenY are read imperatively, non-reactive geometry.
     void dims
     void geomTick
     if (!renderer) return
-    if (!focused) return
-    if (bodyEl && visibleCursor && bodyEl.width > 0) {
-      renderer.setCursorPosition(bodyEl.screenX + visibleCursor.x, bodyEl.screenY + visibleCursor.y, false)
-    } else {
-      renderer.setCursorPosition(0, 0, false)
+    if (!focused) {
+      lastImeScreenAnchorRef.current = null
+      if (imeAnchorController.release(imeAnchorOwner)) renderer.setCursorPosition(0, 0, false)
+      return
     }
-  }, [renderer, focused, bodyEl, visibleCursor, dims, geomTick])
+    if (bodyEl && visibleImeCursor && bodyEl.width > 0) {
+      const anchor = {
+        x: bodyEl.screenX + visibleImeCursor.x,
+        y: bodyEl.screenY + visibleImeCursor.y,
+      }
+      lastImeScreenAnchorRef.current = anchor
+      imeAnchorController.claim(imeAnchorOwner, anchor)
+      renderer.setCursorPosition(anchor.x, anchor.y, false)
+      return
+    }
+    // Historical scrollback has no live viewport cursor. Keep the prior
+    // screen-cell anchor instead of sending the IME to the outer origin.
+    const retainedAnchor = lastImeScreenAnchorRef.current
+    if (retainedAnchor) {
+      imeAnchorController.claim(imeAnchorOwner, retainedAnchor)
+      renderer.setCursorPosition(retainedAnchor.x, retainedAnchor.y, false)
+    }
+  }, [renderer, focused, bodyEl, visibleImeCursor, dims, geomTick, imeAnchorOwner])
 
   // On unmount, hide the cursor so it doesn't leak into whichever pane
   // gains focus next.
   useEffect(() => {
     return () => {
       try {
-        renderer?.setCursorPosition(0, 0, false)
+        if (imeAnchorController.release(imeAnchorOwner)) renderer?.setCursorPosition(0, 0, false)
       } catch {
         /* renderer may already be torn down */
       }
     }
-  }, [renderer])
+  }, [renderer, imeAnchorOwner])
 
   /* --------- view ---------- */
 

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -38,7 +38,11 @@ import { StyledText } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { imeAnchorController } from "../../../tui/lib/ime-anchor-output"
-import { ImeCursorRetention } from "../../../tui/panes/terminal/ime-cursor"
+import {
+  ImeCursorRetention,
+  type ImeScreenAnchor,
+  ImeScreenAnchorRetention,
+} from "../../../tui/panes/terminal/ime-cursor"
 import { type PtyRegistry, getDefaultPtyRegistry } from "../../../tui/panes/terminal/registry"
 import { rowsToStyledText } from "../../../tui/panes/terminal/sgr-to-text-chunk"
 import { isShellMissing, overlayCursor } from "../../../tui/panes/terminal/terminal-render"
@@ -242,7 +246,7 @@ export function Terminal(props: TerminalProps) {
 
   const renderer = useRenderer()
   const imeAnchorOwner = useRef(Symbol("terminal-ime-anchor")).current
-  const lastImeScreenAnchorRef = useRef<{ x: number; y: number } | null>(null)
+  const [imeScreenAnchorRetention] = useState(() => new ImeScreenAnchorRetention())
 
   // Push geometry changes to the backend, deduped against the last push —
   // real PTY backends may emit SIGWINCH even when geometry is unchanged.
@@ -272,28 +276,29 @@ export function Terminal(props: TerminalProps) {
     void geomTick
     if (!renderer) return
     if (!focused) {
-      lastImeScreenAnchorRef.current = null
+      imeScreenAnchorRetention.update(null, null)
       if (imeAnchorController.release(imeAnchorOwner)) renderer.setCursorPosition(0, 0, false)
       return
     }
+    let currentScreenAnchor: ImeScreenAnchor | null = null
     if (bodyEl && visibleImeCursor && bodyEl.width > 0) {
-      const anchor = {
+      currentScreenAnchor = {
         x: bodyEl.screenX + visibleImeCursor.x,
         y: bodyEl.screenY + visibleImeCursor.y,
       }
-      lastImeScreenAnchorRef.current = anchor
-      imeAnchorController.claim(imeAnchorOwner, anchor)
-      renderer.setCursorPosition(anchor.x, anchor.y, false)
-      return
     }
     // Historical scrollback has no live viewport cursor. Keep the prior
-    // screen-cell anchor instead of sending the IME to the outer origin.
-    const retainedAnchor = lastImeScreenAnchorRef.current
+    // screen-cell anchor for this PTY instead of sending the IME to the outer
+    // origin. A replacement PTY starts at origin until it reports a cursor.
+    const retainedAnchor = imeScreenAnchorRetention.update(pty, currentScreenAnchor)
     if (retainedAnchor) {
       imeAnchorController.claim(imeAnchorOwner, retainedAnchor)
       renderer.setCursorPosition(retainedAnchor.x, retainedAnchor.y, false)
+      return
     }
-  }, [renderer, focused, bodyEl, visibleImeCursor, dims, geomTick, imeAnchorOwner])
+    imeAnchorController.claim(imeAnchorOwner, { x: 0, y: 0 })
+    renderer.setCursorPosition(0, 0, false)
+  }, [renderer, focused, bodyEl, visibleImeCursor, dims, geomTick, imeAnchorOwner, imeScreenAnchorRetention, pty])
 
   // On unmount, hide the cursor so it doesn't leak into whichever pane
   // gains focus next.

--- a/packages/kobe/src/tui/lib/ime-anchor-output.ts
+++ b/packages/kobe/src/tui/lib/ime-anchor-output.ts
@@ -110,6 +110,13 @@ export interface ImeAnchoredOutput {
   flush(): void
 }
 
+export interface HostImeOutput {
+  readonly active: boolean
+  readonly rendererOptions: Readonly<{ stdout?: NodeJS.WriteStream; remote?: false }>
+  attach(renderer: { resize(width: number, height: number): void }): () => void
+  flush(): void
+}
+
 /**
  * Return a TTY-compatible proxy whose distinct identity selects OpenTUI's
  * ordered NativeSpanFeed, while every property except `write` delegates to
@@ -151,6 +158,31 @@ export function createImeAnchoredOutput(
       const pending = transformer.flush()
       if (pending.length > 0) target.write(pending)
     },
+  }
+}
+
+/** Select the custom output path only for the affected fullscreen macOS TUI. */
+export function createHostImeOutput(opts: {
+  readonly platform: NodeJS.Platform
+  readonly fullscreen: boolean
+  readonly stdout: NodeJS.WriteStream
+  readonly controller?: ImeAnchorController
+}): HostImeOutput {
+  if (opts.platform !== "darwin" || !opts.fullscreen) {
+    return {
+      active: false,
+      rendererOptions: {},
+      attach: () => () => {},
+      flush: () => {},
+    }
+  }
+
+  const output = createImeAnchoredOutput(opts.stdout, opts.controller)
+  return {
+    active: true,
+    rendererOptions: { stdout: output.stdout, remote: false },
+    attach: (renderer) => installRendererResizeForwarder(renderer, opts.stdout),
+    flush: () => output.flush(),
   }
 }
 

--- a/packages/kobe/src/tui/lib/ime-anchor-output.ts
+++ b/packages/kobe/src/tui/lib/ime-anchor-output.ts
@@ -24,8 +24,8 @@ export class ImeAnchorController {
   claim(owner: symbol, anchor: ImeAnchor): void {
     this.owner = owner
     this.anchor = {
-      x: Math.max(1, Math.trunc(anchor.x)),
-      y: Math.max(1, Math.trunc(anchor.y)),
+      x: Math.max(0, Math.trunc(anchor.x)),
+      y: Math.max(0, Math.trunc(anchor.y)),
     }
   }
 
@@ -61,7 +61,8 @@ class ImeAnchorFrameTransformer {
       if (marker < 0) break
       output.push(data.subarray(offset, marker))
       const anchor = this.controller.current()
-      if (anchor) output.push(Buffer.from(`\x1b[${anchor.y};${anchor.x}H${HIDE_CURSOR}`))
+      // Renderer coordinates are zero-based; ANSI CUP rows/columns are one-based.
+      if (anchor) output.push(Buffer.from(`\x1b[${anchor.y + 1};${anchor.x + 1}H${HIDE_CURSOR}`))
       output.push(SYNC_END)
       offset = marker + SYNC_END.length
     }

--- a/packages/kobe/src/tui/lib/ime-anchor-output.ts
+++ b/packages/kobe/src/tui/lib/ime-anchor-output.ts
@@ -1,0 +1,171 @@
+/**
+ * macOS IME cursor anchoring at the OpenTUI output boundary.
+ *
+ * OpenTUI restores a visible cursor after each diff frame, but a hidden
+ * cursor is left at the last painted cell. macOS input methods use that real
+ * terminal cursor for preedit/candidate placement. This adapter inserts the
+ * focused embedded terminal's hidden cursor position immediately before the
+ * synchronized-frame terminator, keeping the entire update atomic.
+ */
+
+const SYNC_END = Buffer.from("\x1b[?2026l")
+const HIDE_CURSOR = "\x1b[?25l"
+
+export interface ImeAnchor {
+  readonly x: number
+  readonly y: number
+}
+
+/** Single-owner state: stale split-pane cleanup cannot clear a newer claim. */
+export class ImeAnchorController {
+  private owner: symbol | null = null
+  private anchor: ImeAnchor | null = null
+
+  claim(owner: symbol, anchor: ImeAnchor): void {
+    this.owner = owner
+    this.anchor = {
+      x: Math.max(1, Math.trunc(anchor.x)),
+      y: Math.max(1, Math.trunc(anchor.y)),
+    }
+  }
+
+  release(owner: symbol): boolean {
+    if (this.owner !== owner) return false
+    this.owner = null
+    this.anchor = null
+    return true
+  }
+
+  current(): ImeAnchor | null {
+    return this.anchor
+  }
+}
+
+export const imeAnchorController = new ImeAnchorController()
+
+class ImeAnchorFrameTransformer {
+  private pending = Buffer.alloc(0)
+
+  constructor(private readonly controller: ImeAnchorController) {}
+
+  push(chunk: Buffer): Buffer {
+    const data = this.pending.length > 0 ? Buffer.concat([this.pending, chunk]) : chunk
+    this.pending = Buffer.alloc(0)
+
+    if (!this.controller.current()) return data
+
+    const output: Buffer[] = []
+    let offset = 0
+    while (offset < data.length) {
+      const marker = data.indexOf(SYNC_END, offset)
+      if (marker < 0) break
+      output.push(data.subarray(offset, marker))
+      const anchor = this.controller.current()
+      if (anchor) output.push(Buffer.from(`\x1b[${anchor.y};${anchor.x}H${HIDE_CURSOR}`))
+      output.push(SYNC_END)
+      offset = marker + SYNC_END.length
+    }
+
+    const tail = data.subarray(offset)
+    const pendingLength = longestTerminatorPrefixSuffix(tail)
+    const safeLength = tail.length - pendingLength
+    if (safeLength > 0) output.push(tail.subarray(0, safeLength))
+    if (pendingLength > 0) this.pending = Buffer.from(tail.subarray(safeLength))
+    return output.length > 0 ? Buffer.concat(output) : Buffer.alloc(0)
+  }
+
+  flush(): Buffer {
+    const pending = this.pending
+    this.pending = Buffer.alloc(0)
+    return pending
+  }
+}
+
+function longestTerminatorPrefixSuffix(bytes: Buffer): number {
+  const max = Math.min(bytes.length, SYNC_END.length - 1)
+  for (let length = max; length > 0; length -= 1) {
+    if (bytes.subarray(bytes.length - length).equals(SYNC_END.subarray(0, length))) return length
+  }
+  return 0
+}
+
+function asBuffer(
+  chunk: string | Uint8Array,
+  encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+): Buffer {
+  if (typeof chunk !== "string") return Buffer.from(chunk)
+  const encoding = typeof encodingOrCallback === "string" ? encodingOrCallback : undefined
+  return Buffer.from(chunk, encoding)
+}
+
+function writeCallback(
+  encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+  maybeCallback?: (error?: Error | null) => void,
+): ((error?: Error | null) => void) | undefined {
+  return typeof encodingOrCallback === "function" ? encodingOrCallback : maybeCallback
+}
+
+export interface ImeAnchoredOutput {
+  readonly stdout: NodeJS.WriteStream
+  flush(): void
+}
+
+/**
+ * Return a TTY-compatible proxy whose distinct identity selects OpenTUI's
+ * ordered NativeSpanFeed, while every property except `write` delegates to
+ * the real terminal stream.
+ */
+export function createImeAnchoredOutput(
+  target: NodeJS.WriteStream,
+  controller: ImeAnchorController = imeAnchorController,
+): ImeAnchoredOutput {
+  const transformer = new ImeAnchorFrameTransformer(controller)
+  const write = (
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    maybeCallback?: (error?: Error | null) => void,
+  ): boolean => {
+    const transformed = transformer.push(asBuffer(chunk, encodingOrCallback))
+    const callback = writeCallback(encodingOrCallback, maybeCallback)
+    if (transformed.length === 0) {
+      if (callback) queueMicrotask(() => callback(null))
+      return true
+    }
+    return callback ? target.write(transformed, callback) : target.write(transformed)
+  }
+
+  const stdout = new Proxy(target, {
+    get(stream, property) {
+      if (property === "write") return write
+      const value = Reflect.get(stream, property, stream)
+      return typeof value === "function" ? value.bind(stream) : value
+    },
+    set(stream, property, value) {
+      return Reflect.set(stream, property, value, stream)
+    },
+  }) as NodeJS.WriteStream
+
+  return {
+    stdout,
+    flush() {
+      const pending = transformer.flush()
+      if (pending.length > 0) target.write(pending)
+    },
+  }
+}
+
+/** Restore the resize handling OpenTUI omits when stdout is a custom stream. */
+export function installRendererResizeForwarder(
+  renderer: { resize(width: number, height: number): void },
+  terminal: Pick<NodeJS.WriteStream, "columns" | "rows">,
+  signals: Pick<NodeJS.Process, "on" | "removeListener"> = process,
+): () => void {
+  const onResize = (): void => {
+    const width = terminal.columns
+    const height = terminal.rows
+    if (!width || !height) return
+    renderer.resize(width, height)
+  }
+  signals.on("SIGWINCH", onResize)
+  return () => signals.removeListener("SIGWINCH", onResize)
+}

--- a/packages/kobe/src/tui/lib/ime-anchor-output.ts
+++ b/packages/kobe/src/tui/lib/ime-anchor-output.ts
@@ -141,14 +141,19 @@ export function createImeAnchoredOutput(
     }
     return callback ? target.write(transformed, callback) : target.write(transformed)
   }
+  let exposedWrite: unknown = write
 
   const stdout = new Proxy(target, {
     get(stream, property) {
-      if (property === "write") return write
+      if (property === "write") return exposedWrite
       const value = Reflect.get(stream, property, stream)
       return typeof value === "function" ? value.bind(stream) : value
     },
     set(stream, property, value) {
+      if (property === "write") {
+        exposedWrite = value
+        return true
+      }
       return Reflect.set(stream, property, value, stream)
     },
   }) as NodeJS.WriteStream

--- a/packages/kobe/src/tui/panes/terminal/ime-cursor.ts
+++ b/packages/kobe/src/tui/panes/terminal/ime-cursor.ts
@@ -1,0 +1,29 @@
+import type { CursorPos } from "./pty-types"
+
+/**
+ * IME anchoring and cursor painting have different visibility semantics.
+ * The painted cursor follows the PTY's current DECTCEM state; the IME anchor
+ * retains the last visible position while an app briefly hides its cursor to
+ * redraw. A new PTY identity starts with no inherited coordinate.
+ */
+export class ImeCursorRetention {
+  private ptyIdentity: unknown = null
+  private cursor: CursorPos | null = null
+
+  update(ptyIdentity: unknown, cursor: CursorPos | null): CursorPos | null {
+    if (ptyIdentity !== this.ptyIdentity) {
+      this.ptyIdentity = ptyIdentity
+      this.cursor = null
+    }
+    if (ptyIdentity === null) {
+      this.cursor = null
+      return null
+    }
+    if (cursor) this.cursor = { x: cursor.x, y: cursor.y }
+    return this.cursor
+  }
+
+  current(): CursorPos | null {
+    return this.cursor
+  }
+}

--- a/packages/kobe/src/tui/panes/terminal/ime-cursor.ts
+++ b/packages/kobe/src/tui/panes/terminal/ime-cursor.ts
@@ -1,29 +1,36 @@
 import type { CursorPos } from "./pty-types"
 
+class PtyCoordinateRetention {
+  private ptyIdentity: unknown = null
+  private coordinate: CursorPos | null = null
+
+  update(ptyIdentity: unknown, coordinate: CursorPos | null): CursorPos | null {
+    if (ptyIdentity !== this.ptyIdentity) {
+      this.ptyIdentity = ptyIdentity
+      this.coordinate = null
+    }
+    if (ptyIdentity === null) {
+      this.coordinate = null
+      return null
+    }
+    if (coordinate) this.coordinate = { x: coordinate.x, y: coordinate.y }
+    return this.coordinate
+  }
+
+  current(): CursorPos | null {
+    return this.coordinate
+  }
+}
+
 /**
  * IME anchoring and cursor painting have different visibility semantics.
  * The painted cursor follows the PTY's current DECTCEM state; the IME anchor
  * retains the last visible position while an app briefly hides its cursor to
  * redraw. A new PTY identity starts with no inherited coordinate.
  */
-export class ImeCursorRetention {
-  private ptyIdentity: unknown = null
-  private cursor: CursorPos | null = null
+export class ImeCursorRetention extends PtyCoordinateRetention {}
 
-  update(ptyIdentity: unknown, cursor: CursorPos | null): CursorPos | null {
-    if (ptyIdentity !== this.ptyIdentity) {
-      this.ptyIdentity = ptyIdentity
-      this.cursor = null
-    }
-    if (ptyIdentity === null) {
-      this.cursor = null
-      return null
-    }
-    if (cursor) this.cursor = { x: cursor.x, y: cursor.y }
-    return this.cursor
-  }
+export type ImeScreenAnchor = CursorPos
 
-  current(): CursorPos | null {
-    return this.cursor
-  }
-}
+/** Retain layout gaps for one PTY without leaking coordinates to the next. */
+export class ImeScreenAnchorRetention extends PtyCoordinateRetention {}

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { hostRenderOptions, installPaneExitBackstop } from "../../src/tui/lib/host-render-options"
+import { createHostImeOutput } from "../../src/tui/lib/ime-anchor-output"
+
+function fakeTty(): NodeJS.WriteStream {
+  return {
+    columns: 120,
+    rows: 40,
+    write: () => true,
+  } as unknown as NodeJS.WriteStream
+}
 
 describe("hostRenderOptions", () => {
   it("returns the shared option set verbatim", () => {
@@ -16,6 +25,24 @@ describe("hostRenderOptions", () => {
     const onDestroy = () => {}
     expect(hostRenderOptions(onDestroy)).toMatchObject({ onDestroy })
     expect("onDestroy" in hostRenderOptions()).toBe(false)
+  })
+})
+
+describe("createHostImeOutput", () => {
+  it("uses a local custom-output feed only for fullscreen macOS hosts", () => {
+    const stdout = fakeTty()
+    const mac = createHostImeOutput({ platform: "darwin", fullscreen: true, stdout })
+
+    expect(mac.rendererOptions.remote).toBe(false)
+    expect(mac.rendererOptions.stdout).not.toBe(stdout)
+    expect(mac.active).toBe(true)
+  })
+
+  it("leaves Linux and inline command hosts on the direct stdout path", () => {
+    const stdout = fakeTty()
+
+    expect(createHostImeOutput({ platform: "linux", fullscreen: true, stdout }).rendererOptions).toEqual({})
+    expect(createHostImeOutput({ platform: "darwin", fullscreen: false, stdout }).rendererOptions).toEqual({})
   })
 })
 

--- a/packages/kobe/test/tui/ime-anchor-output.test.ts
+++ b/packages/kobe/test/tui/ime-anchor-output.test.ts
@@ -1,0 +1,130 @@
+import { EventEmitter } from "node:events"
+import { describe, expect, it, vi } from "vitest"
+import {
+  ImeAnchorController,
+  createImeAnchoredOutput,
+  installRendererResizeForwarder,
+} from "../../src/tui/lib/ime-anchor-output"
+
+const SYNC_START = "\x1b[?2026h"
+const SYNC_END = "\x1b[?2026l"
+const HIDE_CURSOR = "\x1b[?25l"
+
+function collectingOutput() {
+  const chunks: Buffer[] = []
+  const output = {
+    columns: 80,
+    rows: 24,
+    isTTY: true,
+    write(
+      chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+      maybeCallback?: (error?: Error | null) => void,
+    ): boolean {
+      const encoding = typeof encodingOrCallback === "string" ? encodingOrCallback : undefined
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk, encoding) : Buffer.from(chunk))
+      const callback = typeof encodingOrCallback === "function" ? encodingOrCallback : maybeCallback
+      callback?.(null)
+      return true
+    },
+  } as unknown as NodeJS.WriteStream
+  return {
+    output,
+    text: () => Buffer.concat(chunks).toString("utf8"),
+  }
+}
+
+describe("ImeAnchorController", () => {
+  it("lets only the current owner clear the shared anchor", () => {
+    const controller = new ImeAnchorController()
+    const oldPane = Symbol("old-pane")
+    const focusedPane = Symbol("focused-pane")
+
+    controller.claim(oldPane, { x: 3, y: 2 })
+    controller.claim(focusedPane, { x: 7, y: 5 })
+
+    expect(controller.release(oldPane)).toBe(false)
+    expect(controller.current()).toEqual({ x: 7, y: 5 })
+    expect(controller.release(focusedPane)).toBe(true)
+    expect(controller.current()).toBeNull()
+  })
+})
+
+describe("createImeAnchoredOutput", () => {
+  it("passes renderer bytes through unchanged while no terminal owns the anchor", () => {
+    const sink = collectingOutput()
+    const controller = new ImeAnchorController()
+    const anchored = createImeAnchoredOutput(sink.output, controller)
+    const frame = `${SYNC_START}${HIDE_CURSOR}\x1b[2;3HA${SYNC_END}`
+
+    anchored.stdout.write(frame)
+    anchored.flush()
+
+    expect(sink.text()).toBe(frame)
+  })
+
+  it("ends every animated diff frame at the same hidden IME anchor", () => {
+    const sink = collectingOutput()
+    const controller = new ImeAnchorController()
+    const anchored = createImeAnchoredOutput(sink.output, controller)
+    controller.claim(Symbol("terminal"), { x: 7, y: 5 })
+
+    const leftFrame = `${SYNC_START}${HIDE_CURSOR}\x1b[2;3HL${SYNC_END}`
+    const rightFrame = `${SYNC_START}${HIDE_CURSOR}\x1b[9;16HR${SYNC_END}`
+    anchored.stdout.write(leftFrame)
+    anchored.stdout.write(rightFrame)
+    anchored.flush()
+
+    const expectedAnchor = `\x1b[5;7H${HIDE_CURSOR}${SYNC_END}`
+    expect(sink.text()).toBe(leftFrame.replace(SYNC_END, expectedAnchor) + rightFrame.replace(SYNC_END, expectedAnchor))
+  })
+
+  it("recognizes a synchronized-frame terminator split at every byte boundary", () => {
+    const framePrefix = `${SYNC_START}${HIDE_CURSOR}\x1b[9;16HR`
+
+    for (let split = 1; split < SYNC_END.length; split += 1) {
+      const sink = collectingOutput()
+      const controller = new ImeAnchorController()
+      const anchored = createImeAnchoredOutput(sink.output, controller)
+      controller.claim(Symbol(`terminal-${split}`), { x: 7, y: 5 })
+
+      anchored.stdout.write(Buffer.from(framePrefix + SYNC_END.slice(0, split)))
+      anchored.stdout.write(Buffer.from(SYNC_END.slice(split)))
+      anchored.flush()
+
+      expect(sink.text(), `split=${split}`).toBe(`${framePrefix}\x1b[5;7H${HIDE_CURSOR}${SYNC_END}`)
+    }
+  })
+
+  it("flushes an incomplete terminator prefix without inventing a frame end", () => {
+    const sink = collectingOutput()
+    const controller = new ImeAnchorController()
+    const anchored = createImeAnchoredOutput(sink.output, controller)
+    controller.claim(Symbol("terminal"), { x: 7, y: 5 })
+
+    anchored.stdout.write(`plain${SYNC_END.slice(0, 4)}`)
+    anchored.flush()
+
+    expect(sink.text()).toBe(`plain${SYNC_END.slice(0, 4)}`)
+  })
+})
+
+describe("installRendererResizeForwarder", () => {
+  it("forwards SIGWINCH using the real terminal size and removes its listener", () => {
+    const signals = new EventEmitter()
+    const resize = vi.fn()
+    const terminal = { columns: 132, rows: 43 }
+    const remove = installRendererResizeForwarder(
+      { resize },
+      terminal,
+      signals as unknown as Pick<NodeJS.Process, "on" | "removeListener">,
+    )
+
+    signals.emit("SIGWINCH")
+    expect(resize).toHaveBeenCalledWith(132, 43)
+
+    remove()
+    signals.emit("SIGWINCH")
+    expect(resize).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/kobe/test/tui/ime-anchor-output.test.ts
+++ b/packages/kobe/test/tui/ime-anchor-output.test.ts
@@ -48,6 +48,14 @@ describe("ImeAnchorController", () => {
     expect(controller.release(focusedPane)).toBe(true)
     expect(controller.current()).toBeNull()
   })
+
+  it("stores renderer screen coordinates as zero-based values", () => {
+    const controller = new ImeAnchorController()
+
+    controller.claim(Symbol("terminal"), { x: 0, y: 0 })
+
+    expect(controller.current()).toEqual({ x: 0, y: 0 })
+  })
 })
 
 describe("createImeAnchoredOutput", () => {
@@ -67,7 +75,7 @@ describe("createImeAnchoredOutput", () => {
     const sink = collectingOutput()
     const controller = new ImeAnchorController()
     const anchored = createImeAnchoredOutput(sink.output, controller)
-    controller.claim(Symbol("terminal"), { x: 7, y: 5 })
+    controller.claim(Symbol("terminal"), { x: 6, y: 4 })
 
     const leftFrame = `${SYNC_START}${HIDE_CURSOR}\x1b[2;3HL${SYNC_END}`
     const rightFrame = `${SYNC_START}${HIDE_CURSOR}\x1b[9;16HR${SYNC_END}`
@@ -86,7 +94,7 @@ describe("createImeAnchoredOutput", () => {
       const sink = collectingOutput()
       const controller = new ImeAnchorController()
       const anchored = createImeAnchoredOutput(sink.output, controller)
-      controller.claim(Symbol(`terminal-${split}`), { x: 7, y: 5 })
+      controller.claim(Symbol(`terminal-${split}`), { x: 6, y: 4 })
 
       anchored.stdout.write(Buffer.from(framePrefix + SYNC_END.slice(0, split)))
       anchored.stdout.write(Buffer.from(SYNC_END.slice(split)))
@@ -100,7 +108,7 @@ describe("createImeAnchoredOutput", () => {
     const sink = collectingOutput()
     const controller = new ImeAnchorController()
     const anchored = createImeAnchoredOutput(sink.output, controller)
-    controller.claim(Symbol("terminal"), { x: 7, y: 5 })
+    controller.claim(Symbol("terminal"), { x: 6, y: 4 })
 
     anchored.stdout.write(`plain${SYNC_END.slice(0, 4)}`)
     anchored.flush()

--- a/packages/kobe/test/tui/ime-anchor-output.test.ts
+++ b/packages/kobe/test/tui/ime-anchor-output.test.ts
@@ -59,6 +59,21 @@ describe("ImeAnchorController", () => {
 })
 
 describe("createImeAnchoredOutput", () => {
+  it("isolates renderer write reassignment from the real terminal stream", () => {
+    const sink = collectingOutput()
+    const originalWrite = sink.output.write
+    const anchored = createImeAnchoredOutput(sink.output, new ImeAnchorController())
+    const adapterWrite = anchored.stdout.write.bind(anchored.stdout)
+    const rendererWrite = vi.fn(() => true) as unknown as NodeJS.WriteStream["write"]
+
+    anchored.stdout.write = rendererWrite
+
+    expect(anchored.stdout.write).toBe(rendererWrite)
+    expect(sink.output.write).toBe(originalWrite)
+    adapterWrite("frame")
+    expect(sink.text()).toBe("frame")
+  })
+
   it("passes renderer bytes through unchanged while no terminal owns the anchor", () => {
     const sink = collectingOutput()
     const controller = new ImeAnchorController()

--- a/packages/kobe/test/tui/terminal-ime-cursor.test.ts
+++ b/packages/kobe/test/tui/terminal-ime-cursor.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { ImeCursorRetention } from "../../src/tui/panes/terminal/ime-cursor"
+
+describe("ImeCursorRetention", () => {
+  it("retains the last visible PTY cursor through a transient hidden-cursor frame", () => {
+    const tracker = new ImeCursorRetention()
+    const pty = {}
+
+    expect(tracker.update(pty, { x: 12, y: 4 })).toEqual({ x: 12, y: 4 })
+    expect(tracker.update(pty, null)).toEqual({ x: 12, y: 4 })
+  })
+
+  it("clears a retained cursor when the PTY identity changes", () => {
+    const tracker = new ImeCursorRetention()
+    const firstPty = {}
+    const nextPty = {}
+
+    tracker.update(firstPty, { x: 12, y: 4 })
+
+    expect(tracker.update(nextPty, null)).toBeNull()
+    expect(tracker.update(nextPty, { x: 3, y: 1 })).toEqual({ x: 3, y: 1 })
+  })
+
+  it("clears the retained cursor when no PTY is active", () => {
+    const tracker = new ImeCursorRetention()
+    const pty = {}
+
+    tracker.update(pty, { x: 12, y: 4 })
+
+    expect(tracker.update(null, null)).toBeNull()
+    expect(tracker.current()).toBeNull()
+  })
+})

--- a/packages/kobe/test/tui/terminal-ime-cursor.test.ts
+++ b/packages/kobe/test/tui/terminal-ime-cursor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { ImeCursorRetention } from "../../src/tui/panes/terminal/ime-cursor"
+import { ImeCursorRetention, ImeScreenAnchorRetention } from "../../src/tui/panes/terminal/ime-cursor"
 
 describe("ImeCursorRetention", () => {
   it("retains the last visible PTY cursor through a transient hidden-cursor frame", () => {
@@ -29,5 +29,17 @@ describe("ImeCursorRetention", () => {
 
     expect(tracker.update(null, null)).toBeNull()
     expect(tracker.current()).toBeNull()
+  })
+})
+
+describe("ImeScreenAnchorRetention", () => {
+  it("retains layout gaps for the same PTY but never inherits across PTYs", () => {
+    const tracker = new ImeScreenAnchorRetention()
+    const firstPty = {}
+    const nextPty = {}
+
+    expect(tracker.update(firstPty, { x: 30, y: 12 })).toEqual({ x: 30, y: 12 })
+    expect(tracker.update(firstPty, null)).toEqual({ x: 30, y: 12 })
+    expect(tracker.update(nextPty, null)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- keep the hidden outer-terminal cursor anchored to the focused embedded PTY at the end of every synchronized OpenTUI frame on macOS
- separate the painted inverse-cell cursor from IME anchor retention, with owner-safe cleanup across splits, focus changes, and PTY replacement
- preserve local terminal capability detection and SIGWINCH handling while limiting the custom stdout path to fullscreen macOS hosts

## Root cause

KOBE paints its own inverse-cell cursor and asks OpenTUI to keep the native cursor hidden. OpenTUI 0.4.3 only restores the native cursor position at frame end when that cursor is visible, so animated diffs left the real terminal cursor at the last changed cell. macOS input methods follow that real cursor, which made preedit text and the candidate window move with Claude's animation.

The output adapter now converts OpenTUI's zero-based screen coordinate to ANSI CUP and injects the hidden cursor anchor immediately before each synchronized-frame terminator, keeping the move atomic with the rendered frame.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `cd packages/kobe && bun run test:render` (93 passed)
- `cd packages/kobe && bun run build`
- `cd packages/kobe && bun run test:behavior` (10 passed)
- `bun run changeset:status` (patch)

Regression coverage includes frame terminators split at every byte boundary, fixed anchoring across alternating animated diffs, zero-based to one-based coordinate conversion, stale-owner release, PTY replacement, focus retention, resize forwarding, and real CLI PTY startup.

## Manual acceptance

- [ ] In iTerm2 with macOS Pinyin, hold an uncommitted preedit while Claude animates output and confirm both preedit text and the candidate window stay at the prompt.
