### PR TITLE
fix: codex latest-rollout reader returns the max-mtime match, not first-by-filename

### DIFF
--- a/.changeset/codex-latest-rollout-max-mtime.md
+++ b/.changeset/codex-latest-rollout-max-mtime.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Codex activity detection now tracks the rollout the agent is actually writing to. A worktree's "new activity" badge and turn-completion detection pick the Codex rollout with the newest modified time (matching how the Claude and Copilot readers already work) instead of whichever rollout was created most recently — so a resumed older session that a newer, idle rollout was created after no longer reports stale activity, and the turn detector reads the right transcript for its completion marker.

--- a/packages/kobe/src/engine/codex-local/history.ts
+++ b/packages/kobe/src/engine/codex-local/history.ts
@@ -225,17 +225,23 @@ export async function listSessionIdsForWorktree(worktree: string, deps: HistoryD
   return matches.reverse()
 }
 
-/** Reads probed before giving up the cwd-match scan in {@link findLatestRolloutForWorktree}. */
+/** Newest-first files probed for the max-mtime scan in {@link findLatestRolloutForWorktree}. */
 const MAX_MTIME_SCAN = 12
 
 /**
- * The newest rollout recorded for `worktree` (path + current mtime), or
- * `null` when none match. Walks `listRolloutFiles` (newest-first by
- * filename ≈ chronological) and returns the first cwd match — the file
- * the agent just appended to is the newest, so the common case is a
- * single probe, and with the {@link rolloutCwdForFile} memo a REPEAT
- * poll issues no file reads at all (directory listings + one stat).
- * Capped at {@link MAX_MTIME_SCAN} probes so a busy machine with many
+ * The rollout with the newest mtime recorded for `worktree` (path +
+ * that mtime), or `null` when none match. Walks `listRolloutFiles`
+ * (newest-first by filename ≈ chronological) and returns the cwd match
+ * with the greatest mtime — the "newest activity" signal the Ops badge
+ * and turn detector consume. This is the max mtime across the
+ * worktree's rollouts, matching the Claude and Copilot readers'
+ * `latestTranscriptMtimeForWorktree` semantics: filename order is
+ * creation order, so a resumed older session (a rollout appended to
+ * after a newer, idle one was created) can carry the higher mtime, and
+ * the older-by-filename file is then the one the agent is truly active
+ * in. With the {@link rolloutCwdForFile} memo a REPEAT poll issues no
+ * file reads at all (directory listings + one stat per match). Capped
+ * at {@link MAX_MTIME_SCAN} probes so a busy machine with many
  * unrelated sessions can't make the poll expensive. A match whose stat
  * fails (deleted mid-scan) is skipped and the scan continues.
  */
@@ -246,17 +252,19 @@ export async function findLatestRolloutForWorktree(
   if (!worktree) return null
   const files = await listRolloutFiles(deps)
   let scanned = 0
+  let best: { path: string; mtimeMs: number } | null = null
   for (const file of files) {
     if (scanned >= MAX_MTIME_SCAN) break
     scanned++
     if ((await rolloutCwdForFile(file, deps)) !== worktree) continue
     try {
-      return { path: file, mtimeMs: (await deps.stat(file)).mtimeMs }
+      const mtimeMs = (await deps.stat(file)).mtimeMs
+      if (!best || mtimeMs > best.mtimeMs) best = { path: file, mtimeMs }
     } catch {
       // vanished between listing and stat — keep scanning older rollouts
     }
   }
-  return null
+  return best
 }
 
 /**

--- a/packages/kobe/test/engine/transcript-mtime.test.ts
+++ b/packages/kobe/test/engine/transcript-mtime.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest"
 import { latestTranscriptMtimeForWorktree as claudeMtime } from "../../src/engine/claude-code-local/history.ts"
 import {
   type HistoryDeps as CodexDeps,
+  findLatestRolloutForWorktree as codexFindLatest,
   latestTranscriptMtimeForWorktree as codexMtime,
 } from "../../src/engine/codex-local/history.ts"
 import {
@@ -46,14 +47,36 @@ describe("codex latestTranscriptMtimeForWorktree", () => {
     }
   }
 
-  it("returns the newest-by-filename rollout matching the worktree cwd", async () => {
+  it("returns the newest-mtime rollout matching the worktree cwd, skipping other worktrees", async () => {
     const files = {
       "rollout-2026-05-29T01-00-00-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl": { cwd: "/wt", mtimeMs: 1000 },
       "rollout-2026-05-29T02-00-00-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl": { cwd: "/wt", mtimeMs: 2000 },
       "rollout-2026-05-29T03-00-00-cccccccc-cccc-cccc-cccc-cccccccccccc.jsonl": { cwd: "/other", mtimeMs: 3000 },
     }
-    // Newest filename (03:00, /other) is skipped; first /wt match is 02:00.
+    // Newest filename (03:00, /other) belongs to another worktree and is
+    // skipped; the max mtime among /wt's rollouts is 02:00's 2000.
     expect(await codexMtime("/wt", deps(files))).toBe(2000)
+  })
+
+  it("returns the max mtime even when an older-by-filename rollout is the active one", async () => {
+    // Filename order is CREATION order. A resumed older session appended to
+    // after a newer, idle rollout was created carries the higher mtime — the
+    // Ops badge and turn detector want that newest ACTIVITY, i.e. the max
+    // mtime, not whichever rollout was created most recently. This mirrors
+    // the Claude/Copilot readers. The pre-fix "first cwd match by filename"
+    // returned the newer-but-idle 3000-mtime file's 3000 here.
+    const files = {
+      // Older filename, but the session the agent is actively appending to.
+      "rollout-2026-05-29T01-00-00-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl": { cwd: "/wt", mtimeMs: 9000 },
+      // Newer filename, idle since creation.
+      "rollout-2026-05-29T02-00-00-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl": { cwd: "/wt", mtimeMs: 3000 },
+    }
+    expect(await codexMtime("/wt", deps(files))).toBe(9000)
+    // findLatestRolloutForWorktree surfaces the PATH of that active rollout —
+    // the file the turn detector then reads for the completion marker.
+    const found = await codexFindLatest("/wt", deps(files))
+    expect(found?.mtimeMs).toBe(9000)
+    expect(found?.path).toContain("rollout-2026-05-29T01-00-00-aaaaaaaa")
   })
 
   it("returns 0 when no rollout matches the worktree", async () => {


### PR DESCRIPTION
## Direction

Bugs / correctness + engine-owned-data consistency — found by following up the deferred note in PR #309 and confirming it against both sibling history readers.

## Problem

`findLatestRolloutForWorktree` in `src/engine/codex-local/history.ts` is the "newest activity" reader for Codex: the Ops pane's activity badge polls it (via `latestTranscriptMtimeForWorktree`) and the turn detector reads the returned `path` for its `turn.completed` marker. It walked `listRolloutFiles` (newest-first **by filename**) and returned the **first cwd match**:

```ts
for (const file of files) {
  if (scanned >= MAX_MTIME_SCAN) break
  scanned++
  if ((await rolloutCwdForFile(file, deps)) !== worktree) continue
  return { path: file, mtimeMs: (await deps.stat(file)).mtimeMs } // first match
}
```

Filename order is **creation** order, not activity order. When a worktree has more than one rollout and the one the agent is actively appending to was **created earlier** than a newer, idle rollout (e.g. a resumed session, or a second session started and abandoned in the same worktree), the first-by-filename match is the newer **idle** rollout. Its stale mtime is reported to the activity badge, and its path — not the active transcript — is handed to the turn detector for completion-marker parsing.

This is out of step with the rest of the engine layer:

- **The documented contract** (header of `test/engine/transcript-mtime.test.ts`): "*the newest transcript mtime for a worktree*" — i.e. the max.
- **Claude** (`claude-code-local/history.ts`): sorts matching files by mtime and returns `files[0].mtimeMs` — the max.
- **Copilot** (`copilot-local/history.ts`): iterates and takes `if (mtimeMs > newest) newest = mtimeMs` — the max.
- **The turn detector itself** (`turn-detector.ts`) already documents its assumption — "only the newest matching rollout is ever consulted", "`found.mtimeMs` is the newest matching rollout's mtime" — which first-by-filename can violate.

Codex was the only reader taking first-by-creation-order rather than max-mtime.

## Fix

Scan the worktree's cwd matches (within the existing `MAX_MTIME_SCAN` probe cap) and return the one with the **greatest mtime**, matching the Claude/Copilot semantics and the stated contract. Ties keep the newest-by-filename file (strict `>`), so the common single-active-session case is byte-identical to before. One function; the cap and the memo-backed cheap-repeat-poll behavior are unchanged (the memo already makes repeat polls issue zero file reads).

## Verification

- Updated the misleading pinned test in `test/engine/transcript-mtime.test.ts` (its name claimed "newest-by-filename"; the data happened to also be the max, so it never distinguished the two) and added a regression case where an **older-by-filename** rollout carries the **higher** mtime — asserting both the returned mtime (`9000`) and that `findLatestRolloutForWorktree` surfaces that active rollout's **path**. Confirmed this case returns the wrong (idle `3000`) value against the pre-fix code and passes with the fix.
- `bun run test:fast` on the touched suites — `transcript-mtime` (7), `codex-local` (28), `codex-history-edge-cases` (35), `history-default-deps` (16) all pass; the read-count/memo assertions are unchanged.
- `test:socket` `test/daemon/transcript-activity-collector.test.ts` — 13 pass (its single-rollout fixtures keep the same stat counts).
- `bun run lint` — green (718 files). `bun run typecheck` — green (`@sma1lboy/kobe-daemon` + `@sma1lboy/kobe`).
- `history.ts` stays well under the 500-line file-size cap.

Patch changeset included.

## Follow-ups (deliberately deferred, out of this slice)

- The `MAX_MTIME_SCAN = 12` cap counts **all** newest-first files scanned, including unrelated worktrees'. On a machine running many parallel Codex sessions (kobe's core use case), a worktree whose rollouts sit past the global-position-12 window can still return `null` (activity badge dark) even though `listSessionIdsForWorktree` (cap 200) would find it. Aligning that cap is a perf/tuning call for the owner — left separate so this change stays a pure semantics fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QKDq6CwiQG5KQx2xejmBBm)_