### PR TITLE
fix: restore agent hooks and isolate sidebar runtime status

### DIFF
--- a/.changeset/runtime-only-sidebar-status.md
+++ b/.changeset/runtime-only-sidebar-status.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Restore global engine hook installation at TUI startup and keep the Tasks sidebar's leading status glyph scoped to live agent activity instead of task lifecycle state.

--- a/docs/superpowers/specs/2026-07-14-agent-hooks-sidebar-status-design.md
+++ b/docs/superpowers/specs/2026-07-14-agent-hooks-sidebar-status-design.md
@@ -24,11 +24,11 @@ The installer remains best-effort and idempotent. It merges Kobe-owned activity 
 
 The leading task glyph and its tone will derive only from:
 
-- transient engine activity published by the daemon (`running`, `turn_complete`, `rate_limited`, `permission_needed`, or `error`);
+- transient engine activity published by the daemon (`idle`, `running`, `turn_complete`, `rate_limited`, `permission_needed`, or `error`);
 - an in-flight daemon task job such as worktree materialization; or
 - the explicit no-tracking affordance for a custom engine without telemetry.
 
-Persisted `task.status` values (`backlog`, `in_progress`, `in_review`, `done`, `canceled`, and `error`) will not affect sidebar loading, glyphs, tones, or subtitles. With no runtime signal, a normal task has no leading status glyph and uses its branch as the subtitle, or a neutral dash when no branch is available.
+Persisted `task.status` values (`backlog`, `in_progress`, `in_review`, `done`, `canceled`, and `error`) will not affect sidebar loading, glyphs, tones, or subtitles. With no active runtime signal, a normal task shows the hollow idle circle `○` and uses its branch as the subtitle, or a neutral dash when no branch is available.
 
 Project-row behavior remains unchanged. The right-side PR checks chip also remains unchanged because it represents CI checks, not board lifecycle or agent activity.
 
@@ -42,13 +42,13 @@ Task lifecycle status continues through the existing persisted task snapshot for
 
 Hook installation remains non-fatal: malformed or unwritable engine settings must not prevent Kobe from opening. Existing merge logic continues to preserve user-owned configuration and skip no-op writes.
 
-If no activity event is available, the sidebar shows a neutral idle row instead of guessing activity from lifecycle state.
+If no activity event is available, the sidebar shows a neutral idle row with `○` instead of guessing activity from lifecycle state.
 
 ## Testing
 
 1. Add a TUI-startup regression test that uses temporary engine settings paths and verifies startup installs real Kobe activity and worktree-watch hooks before the Workspace Host starts.
 2. Add a sidebar projection test proving all six task lifecycle values produce the same visible runtime state when every other input is identical.
-3. Keep existing activity-pipeline tests as protection for running, completion, permission, rate-limit, error, custom-engine, materialization, and viewed-terminal behavior.
+3. Keep existing activity-pipeline tests as protection for running, completion, permission, rate-limit, error, custom-engine, and materialization behavior; running animation remains visible for the selected task too.
 4. Run the focused TUI and activity tests, type checking, and the repository's relevant broad verification before publishing the branch.
 
 ## Non-Goals

--- a/docs/superpowers/specs/2026-07-14-agent-hooks-sidebar-status-design.md
+++ b/docs/superpowers/specs/2026-07-14-agent-hooks-sidebar-status-design.md
@@ -1,0 +1,59 @@
+# Agent Hooks and Sidebar Runtime Status Design
+
+**Date:** 2026-07-14
+
+## Goal
+
+Restore the global engine-hook installation lost during the PureTUI-only migration, and make the Tasks sidebar's leading status glyph describe runtime activity only. Persisted task lifecycle status remains available to the board and automation but must not affect the sidebar row's glyph, tone, spinner, or fallback subtitle.
+
+## Root Cause
+
+The PureTUI-only migration removed `tui/direct.ts`, including the only call to `ensureGlobalKobeHooks()`. The installer, engine adapters, hook command, daemon event reducer, and client subscription all remain intact, but no current startup path invokes the installer.
+
+The sidebar view currently combines two independent state owners. Transient engine activity from hooks has priority, while persisted `task.status` supplies fallback glyphs, colors, loading state, and labels. This makes the agent-status position also display board lifecycle state.
+
+## Design
+
+### Hook Installation
+
+`startTui()` will invoke and await `ensureGlobalKobeHooks()` before starting the Workspace Host.
+
+The installer remains best-effort and idempotent. It merges Kobe-owned activity and worktree-watch hook groups into each supported engine's global settings file, preserves unrelated user hooks and settings, and removes Kobe's obsolete Claude `WorktreeCreate` provider hook. Awaiting the local file merge ensures the first engine session cannot start before its hooks are present; installer failures still do not block launch.
+
+### Sidebar Status Ownership
+
+The leading task glyph and its tone will derive only from:
+
+- transient engine activity published by the daemon (`running`, `turn_complete`, `rate_limited`, `permission_needed`, or `error`);
+- an in-flight daemon task job such as worktree materialization; or
+- the explicit no-tracking affordance for a custom engine without telemetry.
+
+Persisted `task.status` values (`backlog`, `in_progress`, `in_review`, `done`, `canceled`, and `error`) will not affect sidebar loading, glyphs, tones, or subtitles. With no runtime signal, a normal task has no leading status glyph and uses its branch as the subtitle, or a neutral dash when no branch is available.
+
+Project-row behavior remains unchanged. The right-side PR checks chip also remains unchanged because it represents CI checks, not board lifecycle or agent activity.
+
+## Data Flow
+
+Engine hooks run `kobe hook <verb>`. The hook command reports a normalized event to the running daemon using task/tab identity inherited from the Hosted PTY, with cwd matching as fallback. The daemon reduces the event into transient task activity and broadcasts it. `RemoteOrchestrator` stores that activity in memory, and the sidebar projects it into the runtime-only glyph.
+
+Task lifecycle status continues through the existing persisted task snapshot for board, API, grouping, archive, and automation consumers. The sidebar view simply stops projecting it into runtime chrome.
+
+## Error Handling
+
+Hook installation remains non-fatal: malformed or unwritable engine settings must not prevent Kobe from opening. Existing merge logic continues to preserve user-owned configuration and skip no-op writes.
+
+If no activity event is available, the sidebar shows a neutral idle row instead of guessing activity from lifecycle state.
+
+## Testing
+
+1. Add a TUI-startup regression test that uses temporary engine settings paths and verifies startup installs real Kobe activity and worktree-watch hooks before the Workspace Host starts.
+2. Add a sidebar projection test proving all six task lifecycle values produce the same visible runtime state when every other input is identical.
+3. Keep existing activity-pipeline tests as protection for running, completion, permission, rate-limit, error, custom-engine, materialization, and viewed-terminal behavior.
+4. Run the focused TUI and activity tests, type checking, and the repository's relevant broad verification before publishing the branch.
+
+## Non-Goals
+
+- Removing or redesigning `TaskStatus`.
+- Changing board, issue, archive, API, or automation semantics.
+- Removing or changing the PR checks chip.
+- Redesigning hook event mappings or daemon activity transport.

--- a/packages/kobe/src/engine/json-hook-adapter.ts
+++ b/packages/kobe/src/engine/json-hook-adapter.ts
@@ -19,13 +19,16 @@ import type { EngineHookAdapter } from "./hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
 import { type HookEventSpec, isObject, mergeActivityHooks, mergeWorktreeWatchHook } from "./json-hooks.ts"
 
-/** Read a JSON object from `path`, or {} if absent/unparseable/not-an-object. */
-async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+/** Read a JSON object from `path`. A missing file starts empty; any other read
+ * or parse failure returns undefined so a best-effort install cannot clobber
+ * an existing engine configuration it could not understand. */
+async function readJsonObject(path: string): Promise<Record<string, unknown> | undefined> {
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as unknown
-    return isObject(parsed) ? parsed : {}
-  } catch {
-    return {}
+    return isObject(parsed) ? parsed : undefined
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return {}
+    return undefined
   }
 }
 
@@ -41,6 +44,7 @@ export async function editJsonSettings(
 ): Promise<void> {
   try {
     const current = await readJsonObject(settingsFilePath)
+    if (!current) return
     const next = transform(current)
     if (JSON.stringify(next) === JSON.stringify(current)) return
     await mkdir(dirname(settingsFilePath), { recursive: true })

--- a/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
@@ -129,9 +129,8 @@ export function Sidebar(props: SidebarProps) {
       anyRowLoading(props.tasks, {
         activity: (id) => props.engineState?.get(id),
         job: (id) => props.taskJobs?.get(id),
-        isViewed: (id) => id === props.selectedId,
       }),
-    [reducedMotion, props.tasks, props.engineState, props.taskJobs, props.selectedId],
+    [reducedMotion, props.tasks, props.engineState, props.taskJobs],
   )
 
   const [spinnerFrame, setSpinnerFrame] = useState(0)

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -190,10 +190,8 @@ function useRowCardChrome(row: SidebarRow, shared: SidebarRowCardSharedProps, op
       truncateBranch: truncateBranchLabel,
       mainBranch,
       reducedMotion,
-      // Defer to the live terminal when this task's pane is the one on screen.
-      isViewed: isSelected,
     })
-  }, [task, activity, job, subtitleBudget, mainBranch, reducedMotion, isSelected, t])
+  }, [task, activity, job, subtitleBudget, mainBranch, reducedMotion, t])
   // Frame overlay stays OUTSIDE the memo: non-loading rows come back as the
   // same object, so an idle row does zero per-frame derivation.
   const rowView = withSpinnerFrame(baseView, () => shared.spinnerFrame)

--- a/packages/kobe/src/tui/index.tsx
+++ b/packages/kobe/src/tui/index.tsx
@@ -7,6 +7,7 @@
  * restart`, not a daemon-less in-process Orchestrator.
  */
 
+import { ensureGlobalKobeHooks } from "../cli/hook-cmd.ts"
 import { enforceResetGate } from "../cli/reset-gate.ts"
 import { maybeHintSkillInstall } from "../lib/skill-install.ts"
 import { publishKobeTerminalTitle } from "./lib/outer-terminal-title.ts"
@@ -25,6 +26,11 @@ export async function startTui(): Promise<void> {
   // (one-time hint), or prompt yes/no/don't-notify-this-version if it's
   // out of date. Best-effort — the reliable check is `kobe skill status`.
   await maybeHintSkillInstall()
+
+  // Hook installation used to live in the retired direct-tmux bootstrap.
+  // Finish the idempotent local settings merge before the Workspace Host can
+  // launch an engine, so its first activity events are observable too.
+  await ensureGlobalKobeHooks()
 
   const { startWorkspaceHost } = await import("../tui-react/workspace/host.tsx")
   await startWorkspaceHost()

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -3,7 +3,7 @@ import type { TaskActivityState } from "@/engine/hook-events"
 import { engineEntry } from "@/engine/registry"
 import { DEFAULT_SPINNER_FRAMES, REDUCED_MOTION_SPINNER_FRAMES } from "@/engine/spinner-frames"
 import { t } from "@/tui/i18n"
-import { DEFAULT_TASK_VENDOR, type Task, type TaskStatus } from "@/types/task"
+import { DEFAULT_TASK_VENDOR, type Task } from "@/types/task"
 import { isBuiltinVendor } from "@/types/vendor"
 import { repoBasename } from "./groups"
 
@@ -28,40 +28,6 @@ export interface SidebarRowView {
    * renders the indeterminate sweep bar instead of the shimmer.
    */
   readonly materializing: boolean
-}
-
-const STATUS_BADGE: Record<TaskStatus, { glyph: string; tone: SidebarTone }> = {
-  done: { glyph: "✓", tone: "success" },
-  in_review: { glyph: "◐", tone: "warning" },
-  in_progress: { glyph: "", tone: "primary" },
-  backlog: { glyph: "○", tone: "textMuted" },
-  canceled: { glyph: "⊘", tone: "textMuted" },
-  error: { glyph: "✕", tone: "error" },
-}
-
-/**
- * Returns a localised subtitle label for the given task status. Called at
- * render time (inside buildSidebarRowView) so `t()` is always scoped to a
- * reactive context — never frozen at module load.
- */
-function statusLabel(status: TaskStatus): string {
-  switch (status) {
-    case "done":
-      return t("tasks.status.done")
-    case "in_review":
-      return t("tasks.status.inReview")
-    case "in_progress":
-      return t("tasks.status.working")
-    case "backlog":
-      // No "backlog" word: every regular task is born `backlog` and nothing
-      // in the live engine path ever flips it, so surfacing the literal word
-      // lies (KOB). Fall back to the branch / a neutral dash instead.
-      return t("tasks.status.backlog")
-    case "canceled":
-      return t("tasks.status.canceled")
-    case "error":
-      return t("tasks.status.error")
-  }
 }
 
 /**
@@ -176,17 +142,11 @@ export interface RowLoadingInputs {
  */
 export function rowIsLoading(opts: RowLoadingInputs): boolean {
   const { task } = opts
-  const isMain = task.kind === "main"
   const activityState = opts.activity?.state
   const hasActivity = activityState !== undefined
   const untrackedCustomEngine = isCustomEngineTask(task) && !hasActivity
   const materializing = opts.job !== undefined
-  return (
-    materializing ||
-    (!opts.isViewed &&
-      !untrackedCustomEngine &&
-      (activityState === "running" || (!hasActivity && !isMain && task.status === "in_progress")))
-  )
+  return materializing || (!opts.isViewed && !untrackedCustomEngine && activityState === "running")
 }
 
 /**
@@ -254,7 +214,6 @@ export function buildSidebarRowView(opts: {
   // Regular tasks store their branch; a `main` row's branch lives in the repo
   // root checkout, resolved by the caller and passed as `mainBranch`.
   const branch = isMain ? (opts.mainBranch ?? "") : task.branch
-  const badge = STATUS_BADGE[task.status]
   const activityState = opts.activity?.state
   const hasActivity = activityState !== undefined
   const activityBadge = activityBadgeFor(activityState)
@@ -287,14 +246,15 @@ export function buildSidebarRowView(opts: {
     ? "primary"
     : untrackedCustomEngine
       ? "textMuted"
-      : (activityLabel?.tone ?? (loading ? "primary" : (activityBadge?.tone ?? badge.tone)))
+      : (activityLabel?.tone ?? (loading ? "primary" : (activityBadge?.tone ?? "textMuted")))
   // Subtitle priority: the materializing word while a worktree job runs
   // (there is no branch on disk yet), then a non-normal activity word (rate
   // limited / needs permission / error), then the branch, then — for an
   // untracked custom engine with no branch — an explicit "no activity
-  // tracking" note so the row reads as un-tracked rather than stuck, then
-  // the lifecycle label (a neutral dash for `backlog`, never the word).
-  const fallbackSubtitle = untrackedCustomEngine ? noTrackingSubtitle() : statusLabel(task.status)
+  // tracking" note so the row reads as un-tracked rather than stuck, then a
+  // neutral dash. Persisted task lifecycle belongs to the board, not this
+  // runtime-activity projection.
+  const fallbackSubtitle = untrackedCustomEngine ? noTrackingSubtitle() : "—"
   const subtitleText = materializing
     ? opts.truncateBranch(materializingSubtitle(), opts.subtitleBudget)
     : activityLabel
@@ -302,9 +262,9 @@ export function buildSidebarRowView(opts: {
       : branch.length > 0
         ? opts.truncateBranch(branch, opts.subtitleBudget)
         : opts.truncateBranch(fallbackSubtitle, opts.subtitleBudget)
-  // Untracked custom engine: a static dim dot instead of the spinner / empty
-  // backlog badge, so liveness reads as "not tracked" rather than frozen.
-  const restGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? badge.glyph)
+  // Untracked custom engine: a static dim dot instead of an empty runtime
+  // badge, so liveness reads as "not tracked" rather than frozen.
+  const restGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "")
   const restProjectGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "★")
   return {
     isMain,

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -130,7 +130,6 @@ export interface RowLoadingInputs {
   readonly task: Task
   readonly activity?: TaskEngineState
   readonly job?: TaskJobState
-  readonly isViewed?: boolean
 }
 
 /**
@@ -146,7 +145,7 @@ export function rowIsLoading(opts: RowLoadingInputs): boolean {
   const hasActivity = activityState !== undefined
   const untrackedCustomEngine = isCustomEngineTask(task) && !hasActivity
   const materializing = opts.job !== undefined
-  return materializing || (!opts.isViewed && !untrackedCustomEngine && activityState === "running")
+  return materializing || (!untrackedCustomEngine && activityState === "running")
 }
 
 /**
@@ -160,7 +159,6 @@ export function anyRowLoading(
   reads: {
     activity(taskId: string): TaskEngineState | undefined
     job(taskId: string): TaskJobState | undefined
-    isViewed(taskId: string): boolean
   },
 ): boolean {
   return tasks.some((task) =>
@@ -168,7 +166,6 @@ export function anyRowLoading(
       task,
       activity: reads.activity(task.id),
       job: reads.job(task.id),
-      isViewed: reads.isViewed(task.id),
     }),
   )
 }
@@ -197,17 +194,6 @@ export function buildSidebarRowView(opts: {
   readonly mainBranch?: string
   /** Accessibility: swap the engine spinner for the slow pulsing dot. */
   readonly reducedMotion?: boolean
-  /**
-   * This task's terminal is the one currently on screen in the workspace
-   * (task.id === the host's selectedId). When true, the row suppresses its
-   * own engine-activity spinner and defers to the live terminal, where
-   * claude/codex draws its OWN zero-latency spinner — kobe's derived signal
-   * is necessarily a beat behind, so a spinner here is just a laggy duplicate
-   * of one you can already see. `materializing` is exempt (no terminal exists
-   * yet). Other rows are unaffected: their terminal isn't visible, so kobe's
-   * spinner is the only liveness cue they have.
-   */
-  readonly isViewed?: boolean
 }): SidebarRowView {
   const { task } = opts
   const isMain = task.kind === "main"
@@ -234,7 +220,6 @@ export function buildSidebarRowView(opts: {
     task,
     activity: opts.activity,
     job: opts.job,
-    isViewed: opts.isViewed,
   })
   // Engine-owned brand frames (registry `spinnerFrames`), braille fallback;
   // reduced motion replaces every set with the slow pulsing dot.
@@ -262,9 +247,10 @@ export function buildSidebarRowView(opts: {
       : branch.length > 0
         ? opts.truncateBranch(branch, opts.subtitleBudget)
         : opts.truncateBranch(fallbackSubtitle, opts.subtitleBudget)
-  // Untracked custom engine: a static dim dot instead of an empty runtime
-  // badge, so liveness reads as "not tracked" rather than frozen.
-  const restGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "")
+  // Untracked custom engine gets a distinct dim dot. Normal tasks fall back
+  // to the hollow idle circle because the client deliberately removes an
+  // explicit `idle` activity entry; absence is therefore the idle projection.
+  const restGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "○")
   const restProjectGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "★")
   return {
     isMain,

--- a/packages/kobe/test/engine/activity-pipeline.test.ts
+++ b/packages/kobe/test/engine/activity-pipeline.test.ts
@@ -133,7 +133,7 @@ describe("activity pipeline — vendor hook payload to sidebar badge", () => {
   it("session end: the row returns to neutral runtime chrome", () => {
     const row = rowAfterClaudeHook("SessionEnd", { cwd: "/repo/kobe/worktrees/sidebar" })
     expect(row.loading).toBe(false)
-    expect(row.stateGlyph).toBe("")
+    expect(row.stateGlyph).toBe("○")
     expect(row.tone).toBe("textMuted")
     expect(row.subtitleText).toBe("feature/sidebar")
   })

--- a/packages/kobe/test/engine/activity-pipeline.test.ts
+++ b/packages/kobe/test/engine/activity-pipeline.test.ts
@@ -130,10 +130,11 @@ describe("activity pipeline — vendor hook payload to sidebar badge", () => {
     expect(row.subtitleText).toBe("needs permission")
   })
 
-  it("session end: the row falls back to its lifecycle badge", () => {
+  it("session end: the row returns to neutral runtime chrome", () => {
     const row = rowAfterClaudeHook("SessionEnd", { cwd: "/repo/kobe/worktrees/sidebar" })
     expect(row.loading).toBe(false)
-    expect(row.stateGlyph).toBe("○") // backlog lifecycle badge — no activity left
+    expect(row.stateGlyph).toBe("")
     expect(row.tone).toBe("textMuted")
+    expect(row.subtitleText).toBe("feature/sidebar")
   })
 })

--- a/packages/kobe/test/engine/codex-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/codex-hook-adapter.test.ts
@@ -61,6 +61,25 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
     return JSON.parse(await readFile(file, "utf8")).hooks
   }
 
+  it("creates a missing settings file", async () => {
+    await adapter.installActivityHooks(file)
+
+    const hooks = await readHooks()
+    expect(hooks.SessionStart).toBeDefined()
+    expect(hooks.UserPromptSubmit).toBeDefined()
+    expect(hooks.Stop).toBeDefined()
+  })
+
+  it("leaves a malformed settings file untouched", async () => {
+    const malformed = '{"model":"gpt-5",'
+    await writeFile(file, malformed)
+
+    await adapter.installActivityHooks(file)
+    await adapter.installWorktreeWatchHook(file)
+
+    expect(await readFile(file, "utf8")).toBe(malformed)
+  })
+
   it("installs SessionStart/UserPromptSubmit/Stop + the Bash worktree-watch, preserving the user's hooks", async () => {
     // Seed a user-authored hook that must survive kobe's merge.
     await writeFile(file, JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }] } }))

--- a/packages/kobe/test/tui/sidebar-row-view.test.ts
+++ b/packages/kobe/test/tui/sidebar-row-view.test.ts
@@ -7,7 +7,7 @@ import {
   rowIsLoading,
   withSpinnerFrame,
 } from "../../src/tui/panes/sidebar/row-view.ts"
-import type { Task } from "../../src/types/task.ts"
+import type { Task, TaskStatus } from "../../src/types/task.ts"
 import { toTaskId } from "../../src/types/task.ts"
 
 function task(overrides: Omit<Partial<Task>, "id"> & { id?: string } = {}): Task {
@@ -39,6 +39,43 @@ function view(overrides: Parameters<typeof task>[0], activity?: Parameters<typeo
 }
 
 describe("buildSidebarRowView", () => {
+  const lifecycleStatuses: readonly TaskStatus[] = ["backlog", "in_progress", "in_review", "done", "canceled", "error"]
+
+  it("does not project task lifecycle status into a branched task's runtime chrome", () => {
+    const projections = lifecycleStatuses.map((status) => {
+      const row = view({ status })
+      return {
+        loading: row.loading,
+        stateGlyph: row.stateGlyph,
+        tone: row.tone,
+        subtitleText: row.subtitleText,
+      }
+    })
+
+    expect(new Set(projections.map((projection) => JSON.stringify(projection))).size).toBe(1)
+    expect(projections[0]).toEqual({
+      loading: false,
+      stateGlyph: "",
+      tone: "textMuted",
+      subtitleText: "feature/sidebar",
+    })
+  })
+
+  it("uses the same neutral fallback for every lifecycle status when a task has no branch", () => {
+    const projections = lifecycleStatuses.map((status) => {
+      const row = view({ status, branch: "" })
+      return {
+        loading: row.loading,
+        stateGlyph: row.stateGlyph,
+        tone: row.tone,
+        subtitleText: row.subtitleText,
+      }
+    })
+
+    expect(new Set(projections.map((projection) => JSON.stringify(projection))).size).toBe(1)
+    expect(projections[0]).toEqual({ loading: false, stateGlyph: "", tone: "textMuted", subtitleText: "—" })
+  })
+
   it("keeps turn-complete as the visible row badge", () => {
     expect(view({ status: "in_progress" }, { state: "turn_complete", at: 1 })).toMatchObject({
       loading: false,
@@ -250,9 +287,10 @@ describe("sweepBar", () => {
 describe("buildSidebarRowView — defer to the live terminal (isViewed)", () => {
   const base = { spinnerFrame: 0, subtitleBudget: 80, truncateBranch: (b: string) => b } as const
 
-  it("spins for an in-progress task whose terminal is NOT the one on screen", () => {
+  it("does not infer a running engine from in-progress lifecycle status", () => {
     const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base, isViewed: false })
-    expect(v.loading).toBe(true)
+    expect(v.loading).toBe(false)
+    expect(v.stateGlyph).toBe("")
   })
 
   it("suppresses its own spinner when the task's terminal is the one being viewed", () => {
@@ -295,11 +333,11 @@ describe("rowIsLoading / anyRowLoading (spinner gate)", () => {
     }
   })
 
-  it("anyRowLoading is true iff at least one row spins", () => {
+  it("anyRowLoading is true iff at least one row has live runtime activity", () => {
     const idle = task({ id: "idle", status: "backlog" })
     const busy = task({ id: "busy", status: "in_progress" })
     const reads = {
-      activity: () => undefined,
+      activity: (id: string) => (id === "busy" ? ({ state: "running" as const, at: 1 } as const) : undefined),
       job: () => undefined,
       isViewed: () => false,
     }
@@ -311,7 +349,7 @@ describe("rowIsLoading / anyRowLoading (spinner gate)", () => {
   it("a viewed busy row does not by itself keep the pane spinning", () => {
     const busy = task({ id: "busy", status: "in_progress" })
     const reads = {
-      activity: () => undefined,
+      activity: () => ({ state: "running" as const, at: 1 }),
       job: () => undefined,
       isViewed: (id: string) => id === "busy",
     }

--- a/packages/kobe/test/tui/sidebar-row-view.test.ts
+++ b/packages/kobe/test/tui/sidebar-row-view.test.ts
@@ -55,7 +55,7 @@ describe("buildSidebarRowView", () => {
     expect(new Set(projections.map((projection) => JSON.stringify(projection))).size).toBe(1)
     expect(projections[0]).toEqual({
       loading: false,
-      stateGlyph: "",
+      stateGlyph: "○",
       tone: "textMuted",
       subtitleText: "feature/sidebar",
     })
@@ -73,7 +73,7 @@ describe("buildSidebarRowView", () => {
     })
 
     expect(new Set(projections.map((projection) => JSON.stringify(projection))).size).toBe(1)
-    expect(projections[0]).toEqual({ loading: false, stateGlyph: "", tone: "textMuted", subtitleText: "—" })
+    expect(projections[0]).toEqual({ loading: false, stateGlyph: "○", tone: "textMuted", subtitleText: "—" })
   })
 
   it("keeps turn-complete as the visible row badge", () => {
@@ -284,29 +284,29 @@ describe("sweepBar", () => {
   })
 })
 
-describe("buildSidebarRowView — defer to the live terminal (isViewed)", () => {
+describe("buildSidebarRowView — runtime spinner visibility", () => {
   const base = { spinnerFrame: 0, subtitleBudget: 80, truncateBranch: (b: string) => b } as const
 
   it("does not infer a running engine from in-progress lifecycle status", () => {
-    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base, isViewed: false })
+    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base })
     expect(v.loading).toBe(false)
-    expect(v.stateGlyph).toBe("")
+    expect(v.stateGlyph).toBe("○")
   })
 
-  it("suppresses its own spinner when the task's terminal is the one being viewed", () => {
-    // claude/codex draws its OWN zero-latency spinner in the visible pane, so
-    // kobe's derived (laggier) spinner would be a duplicate — the viewed row
-    // defers to the live terminal instead of animating.
-    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base, isViewed: true })
-    expect(v.loading).toBe(false)
-    expect(v.stateGlyph).toBe("")
+  it("shows the spinner whenever runtime activity is running", () => {
+    const v = buildSidebarRowView({
+      task: task({ status: "in_progress" }),
+      activity: { state: "running", at: 1 },
+      ...base,
+    })
+    expect(v.loading).toBe(true)
+    expect(v.stateGlyph).not.toBe("○")
   })
 
-  it("still spins a viewed row while its worktree materializes (no terminal yet)", () => {
+  it("spins while its worktree materializes", () => {
     const v = buildSidebarRowView({
       task: task({ status: "in_progress" }),
       ...base,
-      isViewed: true,
       job: { kind: "ensureWorktree" },
     })
     expect(v.loading).toBe(true)
@@ -321,7 +321,6 @@ describe("rowIsLoading / anyRowLoading (spinner gate)", () => {
   it("rowIsLoading matches buildSidebarRowView.loading across cases", () => {
     const cases = [
       { task: task({ status: "in_progress" }) },
-      { task: task({ status: "in_progress" }), isViewed: true },
       { task: task({ status: "backlog" }) },
       { task: task({ kind: "main", branch: "", status: "in_progress" }) },
       { task: task({ status: "done" }), job: { kind: "ensureWorktree" as const } },
@@ -339,22 +338,18 @@ describe("rowIsLoading / anyRowLoading (spinner gate)", () => {
     const reads = {
       activity: (id: string) => (id === "busy" ? ({ state: "running" as const, at: 1 } as const) : undefined),
       job: () => undefined,
-      isViewed: () => false,
     }
     expect(anyRowLoading([idle], reads)).toBe(false)
     expect(anyRowLoading([idle, busy], reads)).toBe(true)
     expect(anyRowLoading([], reads)).toBe(false)
   })
 
-  it("a viewed busy row does not by itself keep the pane spinning", () => {
+  it("a running row keeps the pane spinner active", () => {
     const busy = task({ id: "busy", status: "in_progress" })
     const reads = {
       activity: () => ({ state: "running" as const, at: 1 }),
       job: () => undefined,
-      isViewed: (id: string) => id === "busy",
     }
-    // The only busy row is the one on screen (its terminal draws its own
-    // spinner), so the pane has nothing to animate.
-    expect(anyRowLoading([busy], reads)).toBe(false)
+    expect(anyRowLoading([busy], reads)).toBe(true)
   })
 })

--- a/packages/kobe/test/tui/start-tui.test.ts
+++ b/packages/kobe/test/tui/start-tui.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const spies = vi.hoisted(() => ({
+  enforceResetGate: vi.fn(),
   hintSkillInstall: vi.fn(),
+  installHooks: vi.fn(async () => {}),
   publishTitle: vi.fn(),
   startWorkspaceHost: vi.fn(async () => {}),
 }))
 
+vi.mock("../../src/cli/hook-cmd.ts", () => ({ ensureGlobalKobeHooks: spies.installHooks }))
+vi.mock("../../src/cli/reset-gate.ts", () => ({ enforceResetGate: spies.enforceResetGate }))
 vi.mock("../../src/lib/skill-install.ts", () => ({ maybeHintSkillInstall: spies.hintSkillInstall }))
 vi.mock("../../src/tui/lib/outer-terminal-title.ts", () => ({ publishKobeTerminalTitle: spies.publishTitle }))
 vi.mock("../../src/tui-react/workspace/host", () => ({ startWorkspaceHost: spies.startWorkspaceHost }))
@@ -21,5 +25,20 @@ describe("startTui", () => {
     await startTui()
 
     expect(spies.startWorkspaceHost).toHaveBeenCalledOnce()
+  })
+
+  it("installs engine hooks before starting the Workspace Host", async () => {
+    const order: string[] = []
+    spies.installHooks.mockImplementationOnce(async () => {
+      order.push("hooks")
+    })
+    spies.startWorkspaceHost.mockImplementationOnce(async () => {
+      order.push("host")
+    })
+
+    await startTui()
+
+    expect(spies.installHooks).toHaveBeenCalledOnce()
+    expect(order).toEqual(["hooks", "host"])
   })
 })


### PR DESCRIPTION
## Summary

- restore idempotent Claude/Codex hook installation before the PureTUI Workspace Host starts
- preserve malformed engine settings files instead of overwriting unreadable configuration
- remove persisted task lifecycle state from the Tasks sidebar runtime projection
- render neutral idle task rows with a hollow circle and keep the running spinner visible even for the selected task
- keep materialization, custom-engine tracking state, and right-side PR check indicators unchanged

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` (2215 fast tests, 259 socket tests)
- `cd packages/kobe && bun run build`
- `cd packages/kobe && bun run test:behavior` (10 tests)
- fixed-viewport browser `/harness` screenshot: idle task renders `○` with no layout shift

## Visual baseline note

`bun run visual` still reports the existing non-hermetic Kanban snapshot drift: the committed baseline embeds an older absolute checkout path and date, while the current fixture renders the present path and date. The changed Tasks sidebar was inspected separately through the required real OpenTUI harness path.