### PR TITLE
fix: restore global agent hook installation

### DIFF
--- a/.changeset/restore-agent-hook-installation.md
+++ b/.changeset/restore-agent-hook-installation.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Restore global engine hook installation at TUI startup while preserving malformed user settings files.

--- a/packages/kobe/src/engine/json-hook-adapter.ts
+++ b/packages/kobe/src/engine/json-hook-adapter.ts
@@ -19,13 +19,16 @@ import type { EngineHookAdapter } from "./hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
 import { type HookEventSpec, isObject, mergeActivityHooks, mergeWorktreeWatchHook } from "./json-hooks.ts"
 
-/** Read a JSON object from `path`, or {} if absent/unparseable/not-an-object. */
-async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+/** Read a JSON object from `path`. A missing file starts empty; any other read
+ * or parse failure returns undefined so a best-effort install cannot clobber
+ * an existing engine configuration it could not understand. */
+async function readJsonObject(path: string): Promise<Record<string, unknown> | undefined> {
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as unknown
-    return isObject(parsed) ? parsed : {}
-  } catch {
-    return {}
+    return isObject(parsed) ? parsed : undefined
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return {}
+    return undefined
   }
 }
 
@@ -41,6 +44,7 @@ export async function editJsonSettings(
 ): Promise<void> {
   try {
     const current = await readJsonObject(settingsFilePath)
+    if (!current) return
     const next = transform(current)
     if (JSON.stringify(next) === JSON.stringify(current)) return
     await mkdir(dirname(settingsFilePath), { recursive: true })

--- a/packages/kobe/src/tui/index.tsx
+++ b/packages/kobe/src/tui/index.tsx
@@ -7,6 +7,7 @@
  * restart`, not a daemon-less in-process Orchestrator.
  */
 
+import { ensureGlobalKobeHooks } from "../cli/hook-cmd.ts"
 import { enforceResetGate } from "../cli/reset-gate.ts"
 import { maybeHintSkillInstall } from "../lib/skill-install.ts"
 import { publishKobeTerminalTitle } from "./lib/outer-terminal-title.ts"
@@ -25,6 +26,11 @@ export async function startTui(): Promise<void> {
   // (one-time hint), or prompt yes/no/don't-notify-this-version if it's
   // out of date. Best-effort — the reliable check is `kobe skill status`.
   await maybeHintSkillInstall()
+
+  // Hook installation used to live in the retired direct-tmux bootstrap.
+  // Finish the idempotent local settings merge before the Workspace Host can
+  // launch an engine, so its first activity events are observable too.
+  await ensureGlobalKobeHooks()
 
   const { startWorkspaceHost } = await import("../tui-react/workspace/host.tsx")
   await startWorkspaceHost()

--- a/packages/kobe/test/engine/codex-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/codex-hook-adapter.test.ts
@@ -61,6 +61,25 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
     return JSON.parse(await readFile(file, "utf8")).hooks
   }
 
+  it("creates a missing settings file", async () => {
+    await adapter.installActivityHooks(file)
+
+    const hooks = await readHooks()
+    expect(hooks.SessionStart).toBeDefined()
+    expect(hooks.UserPromptSubmit).toBeDefined()
+    expect(hooks.Stop).toBeDefined()
+  })
+
+  it("leaves a malformed settings file untouched", async () => {
+    const malformed = '{"model":"gpt-5",'
+    await writeFile(file, malformed)
+
+    await adapter.installActivityHooks(file)
+    await adapter.installWorktreeWatchHook(file)
+
+    expect(await readFile(file, "utf8")).toBe(malformed)
+  })
+
   it("installs SessionStart/UserPromptSubmit/Stop + the Bash worktree-watch, preserving the user's hooks", async () => {
     // Seed a user-authored hook that must survive kobe's merge.
     await writeFile(file, JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }] } }))

--- a/packages/kobe/test/tui/start-tui.test.ts
+++ b/packages/kobe/test/tui/start-tui.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const spies = vi.hoisted(() => ({
+  enforceResetGate: vi.fn(),
   hintSkillInstall: vi.fn(),
+  installHooks: vi.fn(async () => {}),
   publishTitle: vi.fn(),
   startWorkspaceHost: vi.fn(async () => {}),
 }))
 
+vi.mock("../../src/cli/hook-cmd.ts", () => ({ ensureGlobalKobeHooks: spies.installHooks }))
+vi.mock("../../src/cli/reset-gate.ts", () => ({ enforceResetGate: spies.enforceResetGate }))
 vi.mock("../../src/lib/skill-install.ts", () => ({ maybeHintSkillInstall: spies.hintSkillInstall }))
 vi.mock("../../src/tui/lib/outer-terminal-title.ts", () => ({ publishKobeTerminalTitle: spies.publishTitle }))
 vi.mock("../../src/tui-react/workspace/host", () => ({ startWorkspaceHost: spies.startWorkspaceHost }))
@@ -21,5 +25,20 @@ describe("startTui", () => {
     await startTui()
 
     expect(spies.startWorkspaceHost).toHaveBeenCalledOnce()
+  })
+
+  it("installs engine hooks before starting the Workspace Host", async () => {
+    const order: string[] = []
+    spies.installHooks.mockImplementationOnce(async () => {
+      order.push("hooks")
+    })
+    spies.startWorkspaceHost.mockImplementationOnce(async () => {
+      order.push("host")
+    })
+
+    await startTui()
+
+    expect(spies.installHooks).toHaveBeenCalledOnce()
+    expect(order).toEqual(["hooks", "host"])
   })
 })


### PR DESCRIPTION
## Summary

- restore supported engine hook installation before the PureTUI Workspace Host starts
- ensure the first launched engine session can report runtime activity
- leave malformed or unreadable engine settings untouched instead of overwriting user configuration
- add startup-order and real-file hook installation regressions

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `cd packages/kobe && bun run build`
- `cd packages/kobe && bun run test:behavior`