### PR TITLE
fix: scope sidebar status to agent runtime

### DIFF
--- a/.changeset/sidebar-runtime-status.md
+++ b/.changeset/sidebar-runtime-status.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep the Tasks sidebar status glyph scoped to agent runtime activity, with a hollow idle circle and an always-visible running animation.

--- a/bun.lock
+++ b/bun.lock
@@ -712,19 +712,19 @@
 
     "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.8", "", { "dependencies": { "@tanstack/devtools": "0.12.5" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-YJV6YttQf9lhhPbPBLULgy1eScEvJUMsCS26mjg9hfBKgAJQA5sF9zvzorDzW9Ob6o/asoXikO81JnRUVuFX0Q=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.170.17", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.14", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.170.18", "", { "dependencies": { "@tanstack/history": "1.162.0", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.171.15", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-wpbGYZEp/fmz1q4bn7BD8VZ+/VZ7GBqSJv5V969pU+chP8y7dquWDmKTFMohvUegb9lg12m1uPVvD6kB2wORvQ=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.167.0", "", { "dependencies": { "@tanstack/router-devtools-core": "1.168.0" }, "peerDependencies": { "@tanstack/react-router": "^1.170.0", "@tanstack/router-core": "^1.170.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.171.14", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.171.15", "", { "dependencies": { "@tanstack/history": "1.162.0", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-IILCDcLaItMZQ2jEmCABHY1Nhjjn5XUvwpQp3e4Nmu+vfg0BgYFuu/QASz2SwE2ZNbVMrvt8X/wxa+Gg5aErxA=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.168.0", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.170.0", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-wQoQhlBK7nlZgqzaqdYXKWNTpdHdsaREdaPhFZVH0/Ador+F+eM3/NF2i3f2LPeS0GgKraZUQXe1Q/1+KHyEYg=="],
 
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.167.18", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.14", "@tanstack/router-utils": "1.162.2", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-kFvM4caRds9Q3EXg64bZubJ6rbDxyV0YDSBSGvOGzmKspQPdz5Xrh0uj5T1Ov8avUUg+c761u04VQAaEzSBXRw=="],
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.167.19", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.15", "@tanstack/router-utils": "1.162.2", "@tanstack/virtual-file-routes": "1.162.0", "jiti": "^2.7.0", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^4.4.3" } }, "sha512-db3AQGLinf8ZQ8AKMyxLVWwHIFZxtx+zLktvPXv/nFH/B793/Z7lKLl4dUWM3JpAluynDSVVKaTWQVTAgTYmVA=="],
 
-    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.19", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.14", "@tanstack/router-generator": "1.167.18", "@tanstack/router-utils": "1.162.2", "chokidar": "^5.0.0", "unplugin": "^3.0.0", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.17", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-aFglwLc+bbPTgZlkXn3PvOwpjJAfgUyPGSuql4MP3XrqTTh6WkBiy2RYb6oaG5h0s7EKwivEuq85K3Y4V0Mt1g=="],
+    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.168.20", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.171.15", "@tanstack/router-generator": "1.167.19", "@tanstack/router-utils": "1.162.2", "chokidar": "^5.0.0", "unplugin": "^3.0.0", "zod": "^4.4.3" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.170.18", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"] }, "sha512-G5S63xDr2AxADtWP+0tQtJsduijT/Mk85hDh3Od4ct8UV0PHr2f/H1CGl72lYWLgcWRMn6bKJoQhz27QFIgLRQ=="],
 
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
 
@@ -1058,7 +1058,7 @@
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.24.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw=="],
+    "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -1760,8 +1760,6 @@
 
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
 
-    "@tailwindcss/node/enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
@@ -1859,6 +1857,8 @@
     "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "webpack/enhanced-resolve": ["enhanced-resolve@5.24.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
@@ -129,9 +129,8 @@ export function Sidebar(props: SidebarProps) {
       anyRowLoading(props.tasks, {
         activity: (id) => props.engineState?.get(id),
         job: (id) => props.taskJobs?.get(id),
-        isViewed: (id) => id === props.selectedId,
       }),
-    [reducedMotion, props.tasks, props.engineState, props.taskJobs, props.selectedId],
+    [reducedMotion, props.tasks, props.engineState, props.taskJobs],
   )
 
   const [spinnerFrame, setSpinnerFrame] = useState(0)

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -190,10 +190,8 @@ function useRowCardChrome(row: SidebarRow, shared: SidebarRowCardSharedProps, op
       truncateBranch: truncateBranchLabel,
       mainBranch,
       reducedMotion,
-      // Defer to the live terminal when this task's pane is the one on screen.
-      isViewed: isSelected,
     })
-  }, [task, activity, job, subtitleBudget, mainBranch, reducedMotion, isSelected, t])
+  }, [task, activity, job, subtitleBudget, mainBranch, reducedMotion, t])
   // Frame overlay stays OUTSIDE the memo: non-loading rows come back as the
   // same object, so an idle row does zero per-frame derivation.
   const rowView = withSpinnerFrame(baseView, () => shared.spinnerFrame)

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -30,15 +30,6 @@ export const en = {
   },
   /** In-list hint shown at the bottom of the Archives view */
   archiveHint: "a to unarchive",
-  /** Row-view status labels (shown in subtitle when no branch) */
-  status: {
-    done: "done",
-    inReview: "in review",
-    working: "working",
-    backlog: "—",
-    canceled: "canceled",
-    error: "error",
-  },
   /** Row-view engine activity labels (shown in subtitle, override branch) */
   activity: {
     rateLimited: "rate limited",
@@ -114,14 +105,6 @@ export const zh: typeof en = {
     noArchived: "暂无归档任务。",
   },
   archiveHint: "a 取消归档",
-  status: {
-    done: "已完成",
-    inReview: "审核中",
-    working: "进行中",
-    backlog: "—",
-    canceled: "已取消",
-    error: "错误",
-  },
   activity: {
     rateLimited: "请求受限",
     permissionNeeded: "等待授权",

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -3,7 +3,7 @@ import type { TaskActivityState } from "@/engine/hook-events"
 import { engineEntry } from "@/engine/registry"
 import { DEFAULT_SPINNER_FRAMES, REDUCED_MOTION_SPINNER_FRAMES } from "@/engine/spinner-frames"
 import { t } from "@/tui/i18n"
-import { DEFAULT_TASK_VENDOR, type Task, type TaskStatus } from "@/types/task"
+import { DEFAULT_TASK_VENDOR, type Task } from "@/types/task"
 import { isBuiltinVendor } from "@/types/vendor"
 import { repoBasename } from "./groups"
 
@@ -28,40 +28,6 @@ export interface SidebarRowView {
    * renders the indeterminate sweep bar instead of the shimmer.
    */
   readonly materializing: boolean
-}
-
-const STATUS_BADGE: Record<TaskStatus, { glyph: string; tone: SidebarTone }> = {
-  done: { glyph: "✓", tone: "success" },
-  in_review: { glyph: "◐", tone: "warning" },
-  in_progress: { glyph: "", tone: "primary" },
-  backlog: { glyph: "○", tone: "textMuted" },
-  canceled: { glyph: "⊘", tone: "textMuted" },
-  error: { glyph: "✕", tone: "error" },
-}
-
-/**
- * Returns a localised subtitle label for the given task status. Called at
- * render time (inside buildSidebarRowView) so `t()` is always scoped to a
- * reactive context — never frozen at module load.
- */
-function statusLabel(status: TaskStatus): string {
-  switch (status) {
-    case "done":
-      return t("tasks.status.done")
-    case "in_review":
-      return t("tasks.status.inReview")
-    case "in_progress":
-      return t("tasks.status.working")
-    case "backlog":
-      // No "backlog" word: every regular task is born `backlog` and nothing
-      // in the live engine path ever flips it, so surfacing the literal word
-      // lies (KOB). Fall back to the branch / a neutral dash instead.
-      return t("tasks.status.backlog")
-    case "canceled":
-      return t("tasks.status.canceled")
-    case "error":
-      return t("tasks.status.error")
-  }
 }
 
 /**
@@ -164,7 +130,6 @@ export interface RowLoadingInputs {
   readonly task: Task
   readonly activity?: TaskEngineState
   readonly job?: TaskJobState
-  readonly isViewed?: boolean
 }
 
 /**
@@ -176,17 +141,11 @@ export interface RowLoadingInputs {
  */
 export function rowIsLoading(opts: RowLoadingInputs): boolean {
   const { task } = opts
-  const isMain = task.kind === "main"
   const activityState = opts.activity?.state
   const hasActivity = activityState !== undefined
   const untrackedCustomEngine = isCustomEngineTask(task) && !hasActivity
   const materializing = opts.job !== undefined
-  return (
-    materializing ||
-    (!opts.isViewed &&
-      !untrackedCustomEngine &&
-      (activityState === "running" || (!hasActivity && !isMain && task.status === "in_progress")))
-  )
+  return materializing || (!untrackedCustomEngine && activityState === "running")
 }
 
 /**
@@ -200,7 +159,6 @@ export function anyRowLoading(
   reads: {
     activity(taskId: string): TaskEngineState | undefined
     job(taskId: string): TaskJobState | undefined
-    isViewed(taskId: string): boolean
   },
 ): boolean {
   return tasks.some((task) =>
@@ -208,7 +166,6 @@ export function anyRowLoading(
       task,
       activity: reads.activity(task.id),
       job: reads.job(task.id),
-      isViewed: reads.isViewed(task.id),
     }),
   )
 }
@@ -237,24 +194,12 @@ export function buildSidebarRowView(opts: {
   readonly mainBranch?: string
   /** Accessibility: swap the engine spinner for the slow pulsing dot. */
   readonly reducedMotion?: boolean
-  /**
-   * This task's terminal is the one currently on screen in the workspace
-   * (task.id === the host's selectedId). When true, the row suppresses its
-   * own engine-activity spinner and defers to the live terminal, where
-   * claude/codex draws its OWN zero-latency spinner — kobe's derived signal
-   * is necessarily a beat behind, so a spinner here is just a laggy duplicate
-   * of one you can already see. `materializing` is exempt (no terminal exists
-   * yet). Other rows are unaffected: their terminal isn't visible, so kobe's
-   * spinner is the only liveness cue they have.
-   */
-  readonly isViewed?: boolean
 }): SidebarRowView {
   const { task } = opts
   const isMain = task.kind === "main"
   // Regular tasks store their branch; a `main` row's branch lives in the repo
   // root checkout, resolved by the caller and passed as `mainBranch`.
   const branch = isMain ? (opts.mainBranch ?? "") : task.branch
-  const badge = STATUS_BADGE[task.status]
   const activityState = opts.activity?.state
   const hasActivity = activityState !== undefined
   const activityBadge = activityBadgeFor(activityState)
@@ -275,7 +220,6 @@ export function buildSidebarRowView(opts: {
     task,
     activity: opts.activity,
     job: opts.job,
-    isViewed: opts.isViewed,
   })
   // Engine-owned brand frames (registry `spinnerFrames`), braille fallback;
   // reduced motion replaces every set with the slow pulsing dot.
@@ -287,14 +231,15 @@ export function buildSidebarRowView(opts: {
     ? "primary"
     : untrackedCustomEngine
       ? "textMuted"
-      : (activityLabel?.tone ?? (loading ? "primary" : (activityBadge?.tone ?? badge.tone)))
+      : (activityLabel?.tone ?? (loading ? "primary" : (activityBadge?.tone ?? "textMuted")))
   // Subtitle priority: the materializing word while a worktree job runs
   // (there is no branch on disk yet), then a non-normal activity word (rate
   // limited / needs permission / error), then the branch, then — for an
   // untracked custom engine with no branch — an explicit "no activity
-  // tracking" note so the row reads as un-tracked rather than stuck, then
-  // the lifecycle label (a neutral dash for `backlog`, never the word).
-  const fallbackSubtitle = untrackedCustomEngine ? noTrackingSubtitle() : statusLabel(task.status)
+  // tracking" note so the row reads as un-tracked rather than stuck, then a
+  // neutral dash. Persisted task lifecycle belongs to the board, not this
+  // runtime-activity projection.
+  const fallbackSubtitle = untrackedCustomEngine ? noTrackingSubtitle() : "—"
   const subtitleText = materializing
     ? opts.truncateBranch(materializingSubtitle(), opts.subtitleBudget)
     : activityLabel
@@ -302,9 +247,10 @@ export function buildSidebarRowView(opts: {
       : branch.length > 0
         ? opts.truncateBranch(branch, opts.subtitleBudget)
         : opts.truncateBranch(fallbackSubtitle, opts.subtitleBudget)
-  // Untracked custom engine: a static dim dot instead of the spinner / empty
-  // backlog badge, so liveness reads as "not tracked" rather than frozen.
-  const restGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? badge.glyph)
+  // Untracked custom engine gets a distinct dim dot. Normal tasks fall back
+  // to the hollow idle circle because the client deliberately removes an
+  // explicit `idle` activity entry; absence is therefore the idle projection.
+  const restGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "○")
   const restProjectGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "★")
   return {
     isMain,

--- a/packages/kobe/test/engine/activity-pipeline.test.ts
+++ b/packages/kobe/test/engine/activity-pipeline.test.ts
@@ -130,10 +130,11 @@ describe("activity pipeline — vendor hook payload to sidebar badge", () => {
     expect(row.subtitleText).toBe("needs permission")
   })
 
-  it("session end: the row falls back to its lifecycle badge", () => {
+  it("session end: the row returns to neutral runtime chrome", () => {
     const row = rowAfterClaudeHook("SessionEnd", { cwd: "/repo/kobe/worktrees/sidebar" })
     expect(row.loading).toBe(false)
-    expect(row.stateGlyph).toBe("○") // backlog lifecycle badge — no activity left
+    expect(row.stateGlyph).toBe("○")
     expect(row.tone).toBe("textMuted")
+    expect(row.subtitleText).toBe("feature/sidebar")
   })
 })

--- a/packages/kobe/test/tui/sidebar-row-view.test.ts
+++ b/packages/kobe/test/tui/sidebar-row-view.test.ts
@@ -7,7 +7,7 @@ import {
   rowIsLoading,
   withSpinnerFrame,
 } from "../../src/tui/panes/sidebar/row-view.ts"
-import type { Task } from "../../src/types/task.ts"
+import type { Task, TaskStatus } from "../../src/types/task.ts"
 import { toTaskId } from "../../src/types/task.ts"
 
 function task(overrides: Omit<Partial<Task>, "id"> & { id?: string } = {}): Task {
@@ -39,6 +39,43 @@ function view(overrides: Parameters<typeof task>[0], activity?: Parameters<typeo
 }
 
 describe("buildSidebarRowView", () => {
+  const lifecycleStatuses: readonly TaskStatus[] = ["backlog", "in_progress", "in_review", "done", "canceled", "error"]
+
+  it("does not project task lifecycle status into a branched task's runtime chrome", () => {
+    const projections = lifecycleStatuses.map((status) => {
+      const row = view({ status })
+      return {
+        loading: row.loading,
+        stateGlyph: row.stateGlyph,
+        tone: row.tone,
+        subtitleText: row.subtitleText,
+      }
+    })
+
+    expect(new Set(projections.map((projection) => JSON.stringify(projection))).size).toBe(1)
+    expect(projections[0]).toEqual({
+      loading: false,
+      stateGlyph: "○",
+      tone: "textMuted",
+      subtitleText: "feature/sidebar",
+    })
+  })
+
+  it("uses the same neutral fallback for every lifecycle status when a task has no branch", () => {
+    const projections = lifecycleStatuses.map((status) => {
+      const row = view({ status, branch: "" })
+      return {
+        loading: row.loading,
+        stateGlyph: row.stateGlyph,
+        tone: row.tone,
+        subtitleText: row.subtitleText,
+      }
+    })
+
+    expect(new Set(projections.map((projection) => JSON.stringify(projection))).size).toBe(1)
+    expect(projections[0]).toEqual({ loading: false, stateGlyph: "○", tone: "textMuted", subtitleText: "—" })
+  })
+
   it("keeps turn-complete as the visible row badge", () => {
     expect(view({ status: "in_progress" }, { state: "turn_complete", at: 1 })).toMatchObject({
       loading: false,
@@ -247,28 +284,29 @@ describe("sweepBar", () => {
   })
 })
 
-describe("buildSidebarRowView — defer to the live terminal (isViewed)", () => {
+describe("buildSidebarRowView — runtime spinner visibility", () => {
   const base = { spinnerFrame: 0, subtitleBudget: 80, truncateBranch: (b: string) => b } as const
 
-  it("spins for an in-progress task whose terminal is NOT the one on screen", () => {
-    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base, isViewed: false })
-    expect(v.loading).toBe(true)
-  })
-
-  it("suppresses its own spinner when the task's terminal is the one being viewed", () => {
-    // claude/codex draws its OWN zero-latency spinner in the visible pane, so
-    // kobe's derived (laggier) spinner would be a duplicate — the viewed row
-    // defers to the live terminal instead of animating.
-    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base, isViewed: true })
+  it("does not infer a running engine from in-progress lifecycle status", () => {
+    const v = buildSidebarRowView({ task: task({ status: "in_progress" }), ...base })
     expect(v.loading).toBe(false)
-    expect(v.stateGlyph).toBe("")
+    expect(v.stateGlyph).toBe("○")
   })
 
-  it("still spins a viewed row while its worktree materializes (no terminal yet)", () => {
+  it("shows the spinner whenever runtime activity is running", () => {
+    const v = buildSidebarRowView({
+      task: task({ status: "in_progress" }),
+      activity: { state: "running", at: 1 },
+      ...base,
+    })
+    expect(v.loading).toBe(true)
+    expect(v.stateGlyph).not.toBe("○")
+  })
+
+  it("spins while its worktree materializes", () => {
     const v = buildSidebarRowView({
       task: task({ status: "in_progress" }),
       ...base,
-      isViewed: true,
       job: { kind: "ensureWorktree" },
     })
     expect(v.loading).toBe(true)
@@ -283,7 +321,6 @@ describe("rowIsLoading / anyRowLoading (spinner gate)", () => {
   it("rowIsLoading matches buildSidebarRowView.loading across cases", () => {
     const cases = [
       { task: task({ status: "in_progress" }) },
-      { task: task({ status: "in_progress" }), isViewed: true },
       { task: task({ status: "backlog" }) },
       { task: task({ kind: "main", branch: "", status: "in_progress" }) },
       { task: task({ status: "done" }), job: { kind: "ensureWorktree" as const } },
@@ -295,28 +332,24 @@ describe("rowIsLoading / anyRowLoading (spinner gate)", () => {
     }
   })
 
-  it("anyRowLoading is true iff at least one row spins", () => {
+  it("anyRowLoading is true iff at least one row has live runtime activity", () => {
     const idle = task({ id: "idle", status: "backlog" })
     const busy = task({ id: "busy", status: "in_progress" })
     const reads = {
-      activity: () => undefined,
+      activity: (id: string) => (id === "busy" ? ({ state: "running" as const, at: 1 } as const) : undefined),
       job: () => undefined,
-      isViewed: () => false,
     }
     expect(anyRowLoading([idle], reads)).toBe(false)
     expect(anyRowLoading([idle, busy], reads)).toBe(true)
     expect(anyRowLoading([], reads)).toBe(false)
   })
 
-  it("a viewed busy row does not by itself keep the pane spinning", () => {
+  it("a running row keeps the pane spinner active", () => {
     const busy = task({ id: "busy", status: "in_progress" })
     const reads = {
-      activity: () => undefined,
+      activity: () => ({ state: "running" as const, at: 1 }),
       job: () => undefined,
-      isViewed: (id: string) => id === "busy",
     }
-    // The only busy row is the one on screen (its terminal draws its own
-    // spinner), so the pane has nothing to animate.
-    expect(anyRowLoading([busy], reads)).toBe(false)
+    expect(anyRowLoading([busy], reads)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- remove persisted task lifecycle state from the Tasks sidebar glyph, tone, spinner, and fallback subtitle
- show neutral idle task rows with a hollow circle
- keep the running animation visible for selected and background tasks
- preserve materialization, custom-engine no-tracking, and right-side PR check indicators

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `cd packages/kobe && bun run build`
- `cd packages/kobe && bun run test:behavior`
- fixed-viewport browser `/harness`: idle task renders `○` with no layout shift

One unrelated file-watch socket test timed out once during the first full run; its isolated rerun and the subsequent complete test run passed.