### PR TITLE
feat: add PureTUI replay capture for Brand Studio

### DIFF
--- a/.changeset/fix-native-replay-colors.md
+++ b/.changeset/fix-native-replay-colors.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Preserve terminal color negotiation in native PureTUI replay captures so Brand Studio renders match the live harness.

--- a/bun.lock
+++ b/bun.lock
@@ -15,11 +15,15 @@
       "dependencies": {
         "@remotion/cli": "4.0.484",
         "@remotion/google-fonts": "4.0.484",
+        "@xterm/headless": "^6.0.0",
+        "node-pty": "^1.1.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "remotion": "4.0.484",
       },
       "devDependencies": {
+        "@types/bun": "1.3.14",
+        "@types/node": "25.6.2",
         "@types/react": "19.0.0",
         "@types/react-dom": "19.0.0",
         "typescript": "5.8.2",

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
@@ -4,7 +4,7 @@
 
 **Goal:** Generate a Brand Studio-consumable `frames.json` from a real, isolated PureTUI + Hosted PTY run.
 
-**Architecture:** `packages/branding` gains a backend-neutral capture core that interprets the existing replay spec through a small terminal adapter. The production adapter launches the supported `kobe dev:sandbox` entrypoint inside a unique home and uses a PTY plus xterm-headless to inject input and snapshot the actual OpenTUI screen; tests use an in-memory adapter. The existing Remotion renderer remains the sole consumer of the checked-in ANSI capture.
+**Architecture:** `packages/branding` gains a backend-neutral capture core that interprets the existing replay spec through a small terminal adapter. The Bun driver owns replay and output; a small Node `node-pty` sidecar launches `kobe dev:sandbox` inside a unique home and exchanges input, ANSI snapshots, and lifecycle messages over newline-delimited JSON. Tests use an in-memory adapter. The existing Remotion renderer remains the sole consumer of the checked-in ANSI capture.
 
 **Tech Stack:** Bun, TypeScript, `node-pty`, `@xterm/headless`, `bun:test`, existing Kobe `dev:sandbox`, Remotion 4.
 
@@ -24,7 +24,8 @@
 
 - `packages/branding/src/quicklook/replay-spec.ts` — validates the storyboard and exposes the fully resolved, capture-safe spec shared by the renderer and the driver.
 - `packages/branding/src/quicklook/capture-core.ts` — backend-neutral terminal, clock, filesystem, and process-lifecycle interfaces plus the beat interpreter and atomic capture writer.
-- `packages/branding/src/quicklook/puretui-terminal.ts` — production adapter that launches the actual `dev:sandbox` TUI in a `node-pty`, feeds output into xterm-headless, supplies snapshots, and terminates the process tree.
+- `packages/branding/src/quicklook/puretui-terminal.ts` — Bun-side adapter that speaks the sidecar protocol and supplies `CaptureTerminal` to the interpreter.
+- `packages/branding/scripts/puretui-pty-sidecar.mjs` — Node-only `node-pty` process that launches PureTUI, feeds output into xterm-headless, and owns the terminal child lifecycle.
 - `packages/branding/scripts/capture-puretui.ts` — thin CLI composition root: creates the disposable demo environment, validates the spec, wires the real adapter/core, and prints useful diagnostic paths.
 - `packages/branding/tests/replay-spec.test.ts` — regression tests for invalid capture references and action grammar.
 - `packages/branding/tests/capture-core.test.ts` — deterministic fake-adapter tests for typing, waits, timestamps, atomic output, and failure/success teardown.
@@ -162,32 +163,34 @@ git commit -m "feat: add replay capture interpreter"
 
 **Files:**
 - Create: `packages/branding/src/quicklook/puretui-terminal.ts`
+- Create: `packages/branding/scripts/puretui-pty-sidecar.mjs`
 - Create: `packages/branding/scripts/capture-puretui.ts`
 - Create: `packages/branding/tests/puretui-terminal.test.ts`
 - Modify: `packages/branding/package.json`
 
 **Interfaces:**
-- Implements Task 2's `CaptureTerminal` as `PureTuiTerminal`.
-- `createPureTuiCapture(options): Promise<{ terminal: CaptureTerminal; cleanup(): Promise<void>; demoRoot: string }>` creates all disposable files under `options.demoRoot`.
+- Implements Task 2's `CaptureTerminal` as Bun-side `PureTuiTerminal`.
+- `createPureTuiCapture(options): Promise<{ terminal: CaptureTerminal; cleanup(): Promise<void>; demoRoot: string }>` starts the Node sidecar and creates all disposable files under `options.demoRoot`.
+- The sidecar protocol is newline-delimited JSON: requests use `{ id, op: "start" | "type" | "key" | "snapshot" | "waitFor" | "stop", ... }`; responses use `{ id, ok: true, value }` or `{ id, ok: false, error: { message, snapshot, pid, demoRoot } }`.
 - The CLI accepts `--spec <path>`, `--output <path>`, `--keep-demo-root`, and `--timeout-ms`, defaulting to the existing QuickLook paths.
 
 - [ ] **Step 1: Write the failing adapter tests around process construction and teardown**
 
-Create test doubles for the PTY factory and filesystem wrapper, then assert:
+Create a fake sidecar process and filesystem wrapper, then assert:
 
 ```ts
 test("launches dev:sandbox with an isolated home and fixed replay viewport", async () => {
-  const capture = await createPureTuiCapture({ repoRoot, demoRoot, cols: 160, rows: 45, ptyFactory })
-  expect(ptyFactory.calls[0]).toMatchObject({
-    file: "bun",
-    args: ["run", "dev:sandbox"],
-    options: { cols: 160, rows: 45, env: expect.objectContaining({ KOBE_SANDBOX_HOME_DIR: expect.stringContaining(demoRoot) }) },
+  const capture = await createPureTuiCapture({ repoRoot, demoRoot, cols: 160, rows: 45, sidecarFactory })
+  expect(sidecarFactory.calls[0]).toMatchObject({
+    file: "node",
+    args: [expect.stringContaining("puretui-pty-sidecar.mjs")],
+    env: expect.objectContaining({ KOBE_SANDBOX_HOME_DIR: expect.stringContaining(demoRoot) }),
   })
   await capture.cleanup()
 })
 ```
 
-Add a timeout test that requires the thrown error to include the latest ANSI snapshot, child pid, and demo root, and a teardown test that asserts `dev:sandbox:reset` runs before the temporary root is removed.
+Add a protocol-timeout test that requires the surfaced sidecar error to include the latest ANSI snapshot, child pid, and demo root. Add sidecar tests that require the Node process to run `bun run dev:sandbox:reset` before it acknowledges `stop`.
 
 - [ ] **Step 2: Verify the adapter tests fail**
 
@@ -197,9 +200,9 @@ Expected: failure because the production adapter and its injectable factory are 
 
 - [ ] **Step 3: Implement the production adapter without changing product code**
 
-Use a lazy `node-pty` import to launch `bun run dev:sandbox` with `cwd: <repoRoot>/packages/kobe`, `cols/rows` from the spec, and a child-only environment containing a unique `KOBE_SANDBOX_HOME_DIR`, `KOBE_HOME_DIR`, `KOBE_DAEMON_WEB_PORT`, and capture-specific host/session labels. Feed `onData` output to `@xterm/headless`, retain raw ANSI for diagnostics, and implement `snapshot()` by serializing the active buffer to stable `rows` lines.
+`capture-puretui.ts` runs in Bun and must not import `node-pty`. Have `puretui-terminal.ts` spawn the Node sidecar with `Bun.spawn(["node", sidecarPath])`, multiplex requests by id, and translate the protocol into `CaptureTerminal` methods. The Node sidecar imports `node-pty`, launches `bun run dev:sandbox` with `cwd: <repoRoot>/packages/kobe`, `cols/rows` from the spec, and a child-only environment containing a unique `KOBE_SANDBOX_HOME_DIR`, `KOBE_HOME_DIR`, `KOBE_DAEMON_WEB_PORT`, and capture-specific host/session labels. It feeds `onData` output to `@xterm/headless`, retains raw ANSI for diagnostics, and returns `snapshot()` as stable `rows` lines.
 
-Map declared strings such as `Enter`, `Escape`, `C-h`, and `C-e` to their terminal byte sequences in one `encodeKey()` function. `waitFor()` must poll the rendered snapshot until the declared pattern appears or timeout; it must never use a fixed boot sleep. `stop()` sends a cooperative interrupt, waits for the PTY child to exit, runs `bun run dev:sandbox:reset` with the exact same isolated-home environment, and fails if the child remains alive.
+Map declared strings such as `Enter`, `Escape`, `C-h`, and `C-e` to terminal byte sequences in the sidecar's single `encodeKey()` function. `waitFor()` must poll the rendered snapshot until the declared pattern appears or timeout; it must never use a fixed boot sleep. On `stop`, the sidecar sends a cooperative interrupt, waits for the PTY child to exit, runs `bun run dev:sandbox:reset` with the exact same isolated-home environment, and returns an error if the child remains alive. The Bun adapter then exits the sidecar cleanly.
 
 In `capture-puretui.ts`, resolve paths from the branding package, call `resolveReplaySpec` before `createPureTuiCapture`, create the fixture git repository below the demo root, invoke `runReplayCapture`, and print the output path plus retained demo root. Add `capture:puretui` and `test:replay` scripts and direct `node-pty`/`@xterm/headless` dependencies to `packages/branding/package.json`.
 
@@ -212,7 +215,7 @@ Expected: all fake-process tests pass; no real daemon or engine is launched.
 - [ ] **Step 5: Commit the runnable adapter**
 
 ```bash
-git add packages/branding/src/quicklook/puretui-terminal.ts packages/branding/scripts/capture-puretui.ts packages/branding/package.json packages/branding/tests/puretui-terminal.test.ts bun.lock
+git add packages/branding/src/quicklook/puretui-terminal.ts packages/branding/scripts/puretui-pty-sidecar.mjs packages/branding/scripts/capture-puretui.ts packages/branding/package.json packages/branding/tests/puretui-terminal.test.ts bun.lock
 git commit -m "feat: capture PureTUI replay frames"
 ```
 

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
@@ -4,15 +4,15 @@
 
 **Goal:** Generate a Brand Studio-consumable `frames.json` from a real, isolated PureTUI + Hosted PTY run.
 
-**Architecture:** `packages/branding` gains a backend-neutral capture core that interprets the existing replay spec through a small terminal adapter. The Bun driver owns replay and output; a small Node `node-pty` sidecar launches `kobe dev:sandbox` inside a unique home and exchanges input, ANSI snapshots, and lifecycle messages over newline-delimited JSON. Tests use an in-memory adapter. The existing Remotion renderer remains the sole consumer of the checked-in ANSI capture.
+**Architecture:** `packages/branding` gains a backend-neutral capture core that interprets the existing replay spec through a small terminal adapter. The Bun driver owns replay and output; a small Node `node-pty` sidecar launches the source CLI against a disposable fixture repository inside a unique home and exchanges input, ANSI snapshots, and lifecycle messages over newline-delimited JSON. Tests use an in-memory adapter. The existing Remotion renderer remains the sole consumer of the checked-in ANSI capture.
 
-**Tech Stack:** Bun, TypeScript, `node-pty`, `@xterm/headless`, `bun:test`, existing Kobe `dev:sandbox`, Remotion 4.
+**Tech Stack:** Bun, TypeScript, Node, `node-pty`, `@xterm/headless`, `bun:test`, Kobe's source CLI and sandbox reset, Remotion 4.
 
 ## Global Constraints
 
 - Keep all capture, replay, and Remotion code in `packages/branding`; do not introduce marketing dependencies in `packages/kobe` or `packages/kobe-daemon`.
 - Start every production capture with a unique `KOBE_SANDBOX_HOME_DIR`/`KOBE_HOME_DIR`, repository fixture, host identity, and session identity; never use normal `~/.kobe` state.
-- The capture driver may remove only the demo root it created after proving every child has exited; preserve that root on failure and never replace `frames.json` on failure.
+- Preserve the demo root for diagnostics and never replace `frames.json` on failure; teardown must prove every child has exited.
 - Treat `quicklook.replay.json` as the editable storyboard. Reject unknown action, text, wait, flow, region, stage boundary, and invalid capture geometry before starting a child process.
 - Store frames only when the rendered terminal state changes, using elapsed wall-clock time rather than nominal beat time; publish the output with a same-directory atomic rename.
 - Do not add or move keybindings. Use the spec's declared keys and interstitial dismissal rules verbatim.
@@ -179,7 +179,7 @@ git commit -m "feat: add replay capture interpreter"
 Create a fake sidecar process and filesystem wrapper, then assert:
 
 ```ts
-test("launches dev:sandbox with an isolated home and fixed replay viewport", async () => {
+test("launches source PureTUI with an isolated home, fixture repo, and fixed replay viewport", async () => {
   const capture = await createPureTuiCapture({ repoRoot, demoRoot, cols: 160, rows: 45, sidecarFactory })
   expect(sidecarFactory.calls[0]).toMatchObject({
     file: "node",
@@ -200,7 +200,7 @@ Expected: failure because the production adapter and its injectable factory are 
 
 - [ ] **Step 3: Implement the production adapter without changing product code**
 
-`capture-puretui.ts` runs in Bun and must not import `node-pty`. Have `puretui-terminal.ts` spawn the Node sidecar with `Bun.spawn(["node", sidecarPath])`, multiplex requests by id, and translate the protocol into `CaptureTerminal` methods. The Node sidecar imports `node-pty`, launches `bun run dev:sandbox` with `cwd: <repoRoot>/packages/kobe`, `cols/rows` from the spec, and a child-only environment containing a unique `KOBE_SANDBOX_HOME_DIR`, `KOBE_HOME_DIR`, `KOBE_DAEMON_WEB_PORT`, and capture-specific host/session labels. It feeds `onData` output to `@xterm/headless`, retains raw ANSI for diagnostics, and returns `snapshot()` as stable `rows` lines.
+`capture-puretui.ts` runs in Bun and must not import `node-pty`. Have `puretui-terminal.ts` spawn the Node sidecar with `Bun.spawn(["node", sidecarPath])`, multiplex requests by id, and translate the protocol into `CaptureTerminal` methods. The Node sidecar imports `node-pty`, seeds declared tasks through the source CLI, then launches that CLI with `cwd` set to the fixture repository, `cols/rows` from the spec, and a child-only environment containing a unique `KOBE_SANDBOX_HOME_DIR`, `KOBE_HOME_DIR`, `KOBE_DAEMON_WEB_PORT`, and capture-specific host/session labels. It feeds `onData` output to `@xterm/headless`, retains raw ANSI for diagnostics, and returns active-buffer lines serialized with SGR styling.
 
 Map declared strings such as `Enter`, `Escape`, `C-h`, and `C-e` to terminal byte sequences in the sidecar's single `encodeKey()` function. `waitFor()` must poll the rendered snapshot until the declared pattern appears or timeout; it must never use a fixed boot sleep. On `stop`, the sidecar sends a cooperative interrupt, waits for the PTY child to exit, runs `bun run dev:sandbox:reset` with the exact same isolated-home environment, and returns an error if the child remains alive. The Bun adapter then exits the sidecar cleanly.
 
@@ -243,7 +243,7 @@ Expected: the empty-capture assertion fails because the renderer currently index
 
 Extract `assertRenderableCapture(capture)` from `QuickLookReplay.tsx` into `replay-spec.ts` or a small `capture-document.ts` helper. It must require positive finite `cols/rows`, a non-empty frame array, finite monotonic timestamps, and exactly `rows` serializable lines per frame. Invoke it before the renderer derives dimensions or calls `frameAt`.
 
-Keep the end-to-end fixture under the test temporary directory. It must use a fake engine shim supplied on `PATH`, run with a hard timeout, call the capture CLI with a temp output path, and finally assert the isolated daemon/PTY sockets no longer exist. Do not overwrite the checked-in `frames.json` during tests.
+Keep the end-to-end fixture under the test temporary directory. It must use the capture-only fixture engines supplied on `PATH`, run with a hard timeout, call the capture CLI with a temp output path, and finally assert the isolated daemon/PTY sockets no longer exist. Do not overwrite the checked-in `frames.json` during tests.
 
 - [ ] **Step 4: Verify unit and bounded end-to-end behavior**
 

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
@@ -1,0 +1,324 @@
+# PureTUI Replay Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a Brand Studio-consumable `frames.json` from a real, isolated PureTUI + Hosted PTY run.
+
+**Architecture:** `packages/branding` gains a backend-neutral capture core that interprets the existing replay spec through a small terminal adapter. The production adapter launches the supported `kobe dev:sandbox` entrypoint inside a unique home and uses a PTY plus xterm-headless to inject input and snapshot the actual OpenTUI screen; tests use an in-memory adapter. The existing Remotion renderer remains the sole consumer of the checked-in ANSI capture.
+
+**Tech Stack:** Bun, TypeScript, `node-pty`, `@xterm/headless`, `bun:test`, existing Kobe `dev:sandbox`, Remotion 4.
+
+## Global Constraints
+
+- Keep all capture, replay, and Remotion code in `packages/branding`; do not introduce marketing dependencies in `packages/kobe` or `packages/kobe-daemon`.
+- Start every production capture with a unique `KOBE_SANDBOX_HOME_DIR`/`KOBE_HOME_DIR`, repository fixture, host identity, and session identity; never use normal `~/.kobe` state.
+- The capture driver may remove only the demo root it created after proving every child has exited; preserve that root on failure and never replace `frames.json` on failure.
+- Treat `quicklook.replay.json` as the editable storyboard. Reject unknown action, text, wait, flow, region, stage boundary, and invalid capture geometry before starting a child process.
+- Store frames only when the rendered terminal state changes, using elapsed wall-clock time rather than nominal beat time; publish the output with a same-directory atomic rename.
+- Do not add or move keybindings. Use the spec's declared keys and interstitial dismissal rules verbatim.
+- Keep source files at or below the repository's approximately 500-line cap.
+
+---
+
+## File structure
+
+- `packages/branding/src/quicklook/replay-spec.ts` — validates the storyboard and exposes the fully resolved, capture-safe spec shared by the renderer and the driver.
+- `packages/branding/src/quicklook/capture-core.ts` — backend-neutral terminal, clock, filesystem, and process-lifecycle interfaces plus the beat interpreter and atomic capture writer.
+- `packages/branding/src/quicklook/puretui-terminal.ts` — production adapter that launches the actual `dev:sandbox` TUI in a `node-pty`, feeds output into xterm-headless, supplies snapshots, and terminates the process tree.
+- `packages/branding/scripts/capture-puretui.ts` — thin CLI composition root: creates the disposable demo environment, validates the spec, wires the real adapter/core, and prints useful diagnostic paths.
+- `packages/branding/tests/replay-spec.test.ts` — regression tests for invalid capture references and action grammar.
+- `packages/branding/tests/capture-core.test.ts` — deterministic fake-adapter tests for typing, waits, timestamps, atomic output, and failure/success teardown.
+- `packages/branding/tests/puretui-capture.test.ts` — opt-in bounded end-to-end smoke capture using the actual sandbox and a disposable fixture repository.
+- `packages/branding/package.json` — declares direct capture dependencies and reproducible test/capture scripts.
+
+### Task 1: Make the replay spec an executable capture contract
+
+**Files:**
+- Modify: `packages/branding/src/quicklook/replay-spec.ts:1-340`
+- Modify: `packages/branding/tests/replay-spec.test.ts:1-133`
+
+**Interfaces:**
+- Produces `ResolvedReplaySpec`, where each `ReplayBeat.action` is one of `"typeText" | "typeTextWhenReady" | "key" | "flow" | "sleep"` and each `flow` resolves to an existing named flow.
+- Consumes the historical `CaptureMeta` shape `{ cols: number; rows: number; frames: Array<{ t: number; lines: unknown[] }> }` without changing renderer compatibility.
+
+- [ ] **Step 1: Write failing validation tests**
+
+Add the following tests to `packages/branding/tests/replay-spec.test.ts`:
+
+```ts
+test("rejects unsupported capture actions and missing flow names", () => {
+  expect(() => resolveReplaySpec({ ...baseSpec, beats: [{ at: 0, action: "mouse" }] }, capture)).toThrow(
+    /unsupported action "mouse"/,
+  )
+  expect(() => resolveReplaySpec({ ...baseSpec, beats: [{ at: 0, action: "flow", flow: "missing" }] }, capture)).toThrow(
+    /unknown flow "missing"/,
+  )
+})
+```
+
+- [ ] **Step 2: Verify the tests fail for the missing contract checks**
+
+Run: `bun test packages/branding/tests/replay-spec.test.ts`
+
+Expected: the new assertions fail because `resolveReplaySpec` currently accepts an arbitrary action and does not reject a missing `flow`.
+
+- [ ] **Step 3: Implement the minimum validation**
+
+In `replay-spec.ts`, introduce the allowed action set and validate the action-specific fields inside the existing beat loop:
+
+```ts
+const REPLAY_ACTIONS = new Set<ReplayBeat["action"]>(["typeText", "typeTextWhenReady", "key", "flow", "sleep"])
+
+if (!REPLAY_ACTIONS.has(beat.action)) throw new Error(`beat ${i} has unsupported action "${beat.action}"`)
+if (beat.action === "flow" && (beat.flow !== "createTask" || !spec.flows?.createTask)) {
+  throw new Error(`beat ${i} references unknown flow "${beat.flow ?? ""}"`)
+}
+```
+
+Keep the existing `textRef`, `waitFor`, region, and stage checks; add the analogous non-empty `key` check for `key` beats and finite non-negative `ms` check for `sleep` beats.
+
+- [ ] **Step 4: Verify the replay-spec contract is green**
+
+Run: `bun test packages/branding/tests/replay-spec.test.ts`
+
+Expected: all replay-spec tests pass, including the two new negative cases.
+
+- [ ] **Step 5: Commit the independently reviewable contract change**
+
+```bash
+git add packages/branding/src/quicklook/replay-spec.ts packages/branding/tests/replay-spec.test.ts
+git commit -m "test: validate replay capture actions"
+```
+
+### Task 2: Build and prove the backend-neutral capture interpreter
+
+**Files:**
+- Create: `packages/branding/src/quicklook/capture-core.ts`
+- Create: `packages/branding/tests/capture-core.test.ts`
+
+**Interfaces:**
+- Consumes `ResolvedReplaySpec` from Task 1 and a `CaptureTerminal` with `snapshot()`, `type()`, `key()`, `waitFor()`, `start()`, and `stop()`.
+- Produces `runReplayCapture(spec, terminal, output, clock): Promise<CaptureDocument>` and `writeCaptureAtomically(path, capture): Promise<void>`.
+- `CaptureDocument` has `{ cols, rows, frames, meta }`, with non-empty monotonic `frames` and `meta.theme` copied from the spec when defined.
+
+- [ ] **Step 1: Write failing fake-terminal tests**
+
+Create `capture-core.test.ts` with a fake terminal that records calls and exposes a queue of ANSI screens. Cover the required behaviors:
+
+```ts
+test("captures only changed screens with elapsed wall-clock timestamps", async () => {
+  const result = await runReplayCapture(spec, fake(["boot", "boot", "dialog"]), memoryOutput, clock([100, 140, 225]))
+  expect(result.frames.map((frame) => [frame.t, frame.lines])).toEqual([[0, ["boot"]], [0.125, ["dialog"]]])
+})
+
+test("stops the terminal and leaves the previous output untouched when a beat fails", async () => {
+  await expect(runReplayCapture(spec, failingFake, output, clock([0]))).rejects.toThrow("composer timeout")
+  expect(failingFake.stopCalls).toBe(1)
+  expect(output.writes).toEqual([])
+})
+```
+
+Also add focused cases for per-character typing plus submit delay, `typeTextWhenReady`, named `createTask` flow expansion, and same-directory temp-file rename.
+
+- [ ] **Step 2: Verify the new tests fail before implementation exists**
+
+Run: `bun test packages/branding/tests/capture-core.test.ts`
+
+Expected: failure because `capture-core.ts` and `runReplayCapture` do not exist.
+
+- [ ] **Step 3: Implement the core in focused units**
+
+Define these public shapes in `capture-core.ts`:
+
+```ts
+export interface CaptureTerminal {
+  start(): Promise<void>
+  snapshot(): Promise<readonly string[]>
+  type(text: string): Promise<void>
+  key(key: string): Promise<void>
+  waitFor(pattern: string, timeoutMs: number): Promise<void>
+  stop(): Promise<void>
+}
+export interface CaptureClock { now(): number; sleep(ms: number): Promise<void> }
+export async function runReplayCapture(spec: ResolvedReplaySpec, terminal: CaptureTerminal, output: CaptureOutput, clock: CaptureClock): Promise<CaptureDocument>
+```
+
+Start the terminal only after the resolved spec is supplied. Capture its initial snapshot at `t: 0`; after every emitted key, typed character, wait completion, and declared settle/sleep, snapshot and append only if the line array differs from the last frame. Execute each beat in chronological order, sleeping only the positive delta from the previous nominal beat. In a `try/finally`, call `terminal.stop()` exactly once. Call `output.replaceAtomically(document)` only after all beats and final schema validation complete.
+
+- [ ] **Step 4: Verify the core behavior is green**
+
+Run: `bun test packages/branding/tests/capture-core.test.ts`
+
+Expected: all fake-adapter cases pass with no filesystem or process dependency.
+
+- [ ] **Step 5: Commit the capture core**
+
+```bash
+git add packages/branding/src/quicklook/capture-core.ts packages/branding/tests/capture-core.test.ts
+git commit -m "feat: add replay capture interpreter"
+```
+
+### Task 3: Add the real PureTUI terminal adapter and isolated launcher
+
+**Files:**
+- Create: `packages/branding/src/quicklook/puretui-terminal.ts`
+- Create: `packages/branding/scripts/capture-puretui.ts`
+- Create: `packages/branding/tests/puretui-terminal.test.ts`
+- Modify: `packages/branding/package.json`
+
+**Interfaces:**
+- Implements Task 2's `CaptureTerminal` as `PureTuiTerminal`.
+- `createPureTuiCapture(options): Promise<{ terminal: CaptureTerminal; cleanup(): Promise<void>; demoRoot: string }>` creates all disposable files under `options.demoRoot`.
+- The CLI accepts `--spec <path>`, `--output <path>`, `--keep-demo-root`, and `--timeout-ms`, defaulting to the existing QuickLook paths.
+
+- [ ] **Step 1: Write the failing adapter tests around process construction and teardown**
+
+Create test doubles for the PTY factory and filesystem wrapper, then assert:
+
+```ts
+test("launches dev:sandbox with an isolated home and fixed replay viewport", async () => {
+  const capture = await createPureTuiCapture({ repoRoot, demoRoot, cols: 160, rows: 45, ptyFactory })
+  expect(ptyFactory.calls[0]).toMatchObject({
+    file: "bun",
+    args: ["run", "dev:sandbox"],
+    options: { cols: 160, rows: 45, env: expect.objectContaining({ KOBE_SANDBOX_HOME_DIR: expect.stringContaining(demoRoot) }) },
+  })
+  await capture.cleanup()
+})
+```
+
+Add a timeout test that requires the thrown error to include the latest ANSI snapshot, child pid, and demo root, and a teardown test that asserts `dev:sandbox:reset` runs before the temporary root is removed.
+
+- [ ] **Step 2: Verify the adapter tests fail**
+
+Run: `bun test packages/branding/tests/puretui-terminal.test.ts`
+
+Expected: failure because the production adapter and its injectable factory are absent.
+
+- [ ] **Step 3: Implement the production adapter without changing product code**
+
+Use a lazy `node-pty` import to launch `bun run dev:sandbox` with `cwd: <repoRoot>/packages/kobe`, `cols/rows` from the spec, and a child-only environment containing a unique `KOBE_SANDBOX_HOME_DIR`, `KOBE_HOME_DIR`, `KOBE_DAEMON_WEB_PORT`, and capture-specific host/session labels. Feed `onData` output to `@xterm/headless`, retain raw ANSI for diagnostics, and implement `snapshot()` by serializing the active buffer to stable `rows` lines.
+
+Map declared strings such as `Enter`, `Escape`, `C-h`, and `C-e` to their terminal byte sequences in one `encodeKey()` function. `waitFor()` must poll the rendered snapshot until the declared pattern appears or timeout; it must never use a fixed boot sleep. `stop()` sends a cooperative interrupt, waits for the PTY child to exit, runs `bun run dev:sandbox:reset` with the exact same isolated-home environment, and fails if the child remains alive.
+
+In `capture-puretui.ts`, resolve paths from the branding package, call `resolveReplaySpec` before `createPureTuiCapture`, create the fixture git repository below the demo root, invoke `runReplayCapture`, and print the output path plus retained demo root. Add `capture:puretui` and `test:replay` scripts and direct `node-pty`/`@xterm/headless` dependencies to `packages/branding/package.json`.
+
+- [ ] **Step 4: Verify the adapter unit tests pass**
+
+Run: `bun test packages/branding/tests/puretui-terminal.test.ts`
+
+Expected: all fake-process tests pass; no real daemon or engine is launched.
+
+- [ ] **Step 5: Commit the runnable adapter**
+
+```bash
+git add packages/branding/src/quicklook/puretui-terminal.ts packages/branding/scripts/capture-puretui.ts packages/branding/package.json packages/branding/tests/puretui-terminal.test.ts bun.lock
+git commit -m "feat: capture PureTUI replay frames"
+```
+
+### Task 4: Prove the real capture and renderer boundary
+
+**Files:**
+- Create: `packages/branding/tests/puretui-capture.test.ts`
+- Modify: `packages/branding/src/quicklook/QuickLookReplay.tsx:1-239`
+
+**Interfaces:**
+- Consumes the capture document from Task 2 and the standard `frames.json` shape already loaded by `QuickLookReplay.tsx`.
+- Produces a bounded opt-in end-to-end test and early renderer errors for empty/malformed captures.
+
+- [ ] **Step 1: Write failing renderer/capture-boundary tests**
+
+Add an opt-in `KOBE_REPLAY_E2E=1` test that runs a short fixture spec with one task-creation beat and one prompt beat, then asserts the temporary output has ordered frames containing both `"New task"` and the prompt text. Add a renderer validation test that calls the capture validation helper with `{ cols: 160, rows: 45, frames: [] }` and expects `/at least one frame/`.
+
+- [ ] **Step 2: Verify the unit portion fails before the validation is added**
+
+Run: `bun test packages/branding/tests/puretui-capture.test.ts`
+
+Expected: the empty-capture assertion fails because the renderer currently indexes `capture.frames[0]` without a guard; the end-to-end case remains skipped unless `KOBE_REPLAY_E2E=1` is set.
+
+- [ ] **Step 3: Add explicit capture preflight and bounded smoke capture**
+
+Extract `assertRenderableCapture(capture)` from `QuickLookReplay.tsx` into `replay-spec.ts` or a small `capture-document.ts` helper. It must require positive finite `cols/rows`, a non-empty frame array, finite monotonic timestamps, and exactly `rows` serializable lines per frame. Invoke it before the renderer derives dimensions or calls `frameAt`.
+
+Keep the end-to-end fixture under the test temporary directory. It must use a fake engine shim supplied on `PATH`, run with a hard timeout, call the capture CLI with a temp output path, and finally assert the isolated daemon/PTY sockets no longer exist. Do not overwrite the checked-in `frames.json` during tests.
+
+- [ ] **Step 4: Verify unit and bounded end-to-end behavior**
+
+Run unit boundary checks: `bun test packages/branding/tests/replay-spec.test.ts packages/branding/tests/capture-core.test.ts packages/branding/tests/puretui-terminal.test.ts packages/branding/tests/puretui-capture.test.ts`
+
+Run the real smoke capture: `KOBE_REPLAY_E2E=1 bun test packages/branding/tests/puretui-capture.test.ts`
+
+Expected: all unit tests pass; the opt-in test produces a non-empty temporary ANSI capture with the expected create-task and prompt beats and leaves no isolated daemon/PTY child.
+
+- [ ] **Step 5: Commit the end-to-end boundary proof**
+
+```bash
+git add packages/branding/src/quicklook/QuickLookReplay.tsx packages/branding/src/quicklook/replay-spec.ts packages/branding/tests/puretui-capture.test.ts
+git commit -m "test: verify PureTUI replay capture"
+```
+
+### Task 5: Recapture QuickLook and verify Brand Studio consumption
+
+**Files:**
+- Modify: `packages/branding/src/quicklook/frames.json`
+- Modify: `packages/branding/src/quicklook/quicklook.replay.json` only if the live UI invalidates an explicitly declared wait, region hash, or flow beat.
+
+**Interfaces:**
+- Consumes `bun run capture:puretui` from Task 3 and `QuickLookReplay`'s existing `quicklook-replay-1x` / `quicklook-replay-4x` compositions.
+- Produces checked-in current ANSI frames; rendered MP4 files remain scratch outputs until separately accepted by Brand Studio.
+
+- [ ] **Step 1: Run a clean real capture into a review file**
+
+Run: `cd packages/branding && bun run capture:puretui --output /tmp/kobe-quicklook-frames.json --keep-demo-root`
+
+Expected: successful validation, current `New task` and prompt beats, monotonically timed frames, and a printed isolated demo root for inspection.
+
+- [ ] **Step 2: Review the captured contract before promotion**
+
+Run: `bun -e 'const x = await Bun.file("/tmp/kobe-quicklook-frames.json").json(); if (!x.frames?.length) throw new Error("empty capture"); console.log({ cols: x.cols, rows: x.rows, frames: x.frames.length, duration: x.frames.at(-1).t })'`
+
+Expected: `cols: 160`, `rows: 45`, a positive frame count, and a positive final timestamp. If a declared readiness marker or coordinate hash is stale, update only the corresponding spec field, rerun Task 1 tests, and repeat the review capture.
+
+- [ ] **Step 3: Atomically promote the reviewed frame set**
+
+Run: `cp /tmp/kobe-quicklook-frames.json packages/branding/src/quicklook/frames.json`
+
+Expected: exactly the reviewed capture becomes the checked-in replay input; no rendered media is added to `public/assets/video/` or accepted state.
+
+- [ ] **Step 4: Render and inspect Brand Studio inputs**
+
+Run:
+
+```bash
+cd packages/branding
+bun x remotion render src/index.ts quicklook-replay-1x /tmp/kobe-quicklook-1x.mp4
+bun x remotion render src/index.ts quicklook-replay-4x /tmp/kobe-quicklook-4x.mp4
+ffprobe -v error -show_entries format=duration -of default=nw=1 /tmp/kobe-quicklook-1x.mp4 /tmp/kobe-quicklook-4x.mp4
+```
+
+Expected: both renders complete; first, middle, and final frames show readable terminal content and no black region outside the terminal grid. Keep both MP4 files in `/tmp` pending human Brand Studio review.
+
+- [ ] **Step 5: Run the repository gates and commit the captured replay**
+
+Run:
+
+```bash
+bun test packages/branding/tests
+bun run lint
+bun run typecheck
+git status --short
+```
+
+Expected: all branding tests, lint, and typecheck pass; the staged set contains only replay capture source/tests/spec/frame files and the lockfile when dependency resolution changed.
+
+```bash
+git add packages/branding/src/quicklook/frames.json packages/branding/src/quicklook/quicklook.replay.json
+git commit -m "chore: refresh PureTUI replay capture"
+```
+
+## Plan self-review
+
+- Spec coverage: Task 1 validates the spec up front; Task 2 covers beat interpretation, changed-screen wall-clock frames, atomic output, and teardown; Task 3 covers the real PureTUI/Hosted PTY adapter and isolated lifecycle; Task 4 proves cleanup and renderer rejection; Task 5 recaptures and renders the Brand Studio input.
+- Scope: all production additions reside in `packages/branding`; Kobe runtime code is only launched through its supported sandbox entrypoint.
+- Terminology/type check: the core exports `CaptureTerminal`, `CaptureClock`, `CaptureDocument`, and `runReplayCapture`; Tasks 3–5 consume those exact names.
+- Placeholder scan: no deferred implementation markers remain; each code change identifies an exact path, behavior, test, and command.

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-capture.md
@@ -4,7 +4,7 @@
 
 **Goal:** Generate a Brand Studio-consumable `frames.json` from a real, isolated PureTUI + Hosted PTY run.
 
-**Architecture:** `packages/branding` gains a backend-neutral capture core that interprets the existing replay spec through a small terminal adapter. The Bun driver owns replay and output; a small Node `node-pty` sidecar launches the source CLI against a disposable fixture repository inside a unique home and exchanges input, ANSI snapshots, and lifecycle messages over newline-delimited JSON. Tests use an in-memory adapter. The existing Remotion renderer remains the sole consumer of the checked-in ANSI capture.
+**Architecture:** `packages/branding` gains a backend-neutral capture core that interprets the existing replay spec through a small terminal adapter. The Bun driver owns replay and output; a small Node `node-pty` sidecar launches the source CLI against a disposable fixture repository with unique Kobe state while preserving the host home used by native engines, then exchanges input, ANSI snapshots, and lifecycle messages over newline-delimited JSON. Tests use an in-memory adapter. The existing Remotion renderer remains the sole consumer of the checked-in ANSI capture.
 
 **Tech Stack:** Bun, TypeScript, Node, `node-pty`, `@xterm/headless`, `bun:test`, Kobe's source CLI and sandbox reset, Remotion 4.
 
@@ -12,6 +12,7 @@
 
 - Keep all capture, replay, and Remotion code in `packages/branding`; do not introduce marketing dependencies in `packages/kobe` or `packages/kobe-daemon`.
 - Start every production capture with a unique `KOBE_SANDBOX_HOME_DIR`/`KOBE_HOME_DIR`, repository fixture, host identity, and session identity; never use normal `~/.kobe` state.
+- Production capture always launches the installed native engines from inherited `PATH` and host `HOME`; engine fixtures are test-only dependency injection and are never selectable from the replay spec.
 - Preserve the demo root for diagnostics and never replace `frames.json` on failure; teardown must prove every child has exited.
 - Treat `quicklook.replay.json` as the editable storyboard. Reject unknown action, text, wait, flow, region, stage boundary, and invalid capture geometry before starting a child process.
 - Store frames only when the rendered terminal state changes, using elapsed wall-clock time rather than nominal beat time; publish the output with a same-directory atomic rename.
@@ -39,7 +40,7 @@
 - Modify: `packages/branding/tests/replay-spec.test.ts:1-133`
 
 **Interfaces:**
-- Produces `ResolvedReplaySpec`, where each `ReplayBeat.action` is one of `"typeText" | "typeTextWhenReady" | "key" | "flow" | "sleep"` and each `flow` resolves to an existing named flow.
+- Produces `ResolvedReplaySpec`, where each `ReplayBeat.action` is one of `"typeText" | "typeTextWhenReady" | "key" | "flow" | "sleep" | "waitFor"` and each `flow` resolves to an existing named flow.
 - Consumes the historical `CaptureMeta` shape `{ cols: number; rows: number; frames: Array<{ t: number; lines: unknown[] }> }` without changing renderer compatibility.
 
 - [ ] **Step 1: Write failing validation tests**
@@ -179,7 +180,7 @@ git commit -m "feat: add replay capture interpreter"
 Create a fake sidecar process and filesystem wrapper, then assert:
 
 ```ts
-test("launches source PureTUI with an isolated home, fixture repo, and fixed replay viewport", async () => {
+test("launches source PureTUI with native engines, isolated Kobe state, and a fixed replay viewport", async () => {
   const capture = await createPureTuiCapture({ repoRoot, demoRoot, cols: 160, rows: 45, sidecarFactory })
   expect(sidecarFactory.calls[0]).toMatchObject({
     file: "node",

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-claudex-colors.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-claudex-colors.md
@@ -1,0 +1,233 @@
+# PureTUI Replay ClaudeX Colors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent monochrome Brand Studio captures by excluding `NO_COLOR`, launch the reviewed Claude task through the user's real `claudex` path, and prove the rendered Claude frame contains its expected colors.
+
+**Architecture:** Keep the fix inside `packages/branding`: sanitize the capture-only child environment and persist an optional recording-only Claude command into the isolated Kobe state. The replay JSON remains portable; the machine-specific `claudex` expansion enters through `KOBE_REPLAY_CLAUDE_COMMAND` only for the reviewed capture invocation.
+
+**Tech Stack:** TypeScript, Bun test, Node PTY sidecar, `@xterm/headless`, OpenTUI, Remotion, ffmpeg.
+
+## Global Constraints
+
+- Do not change the user's shell alias, provider configuration, global Kobe state, or normal engine defaults.
+- Do not put machine-specific `claudex`, model, or provider values in `quicklook.replay.json`.
+- The reviewed Claude frame must visibly contain Claude orange `rgb(215,119,87)`, warning yellow `rgb(255,193,7)`, muted gray, and a dark background.
+- A real but monochrome Claude frame fails acceptance.
+- Keep every touched source file at or below 500 lines.
+- Use no subagents; execute this plan inline.
+
+---
+
+### Task 1: Sanitize the Capture Color Environment
+
+**Files:**
+- Modify: `packages/branding/tests/puretui-terminal.test.ts`
+- Modify: `packages/branding/src/quicklook/puretui-terminal.ts:51-65`
+
+**Interfaces:**
+- Consumes: `createPureTuiCapture(options: PureTuiCaptureOptions)` and its `SidecarFactory` injection.
+- Produces: a sidecar spawn environment that never contains `NO_COLOR` and still declares `TERM=xterm-256color` plus `COLORTERM=truecolor`.
+
+- [ ] **Step 1: Write the failing environment-boundary test**
+
+Add a focused test that temporarily sets `process.env.NO_COLOR = "1"`, creates a capture with the existing fake sidecar, and asserts:
+
+```ts
+expect(sidecarFactory.calls[0].env).not.toHaveProperty("NO_COLOR")
+expect(sidecarFactory.calls[0].env).toMatchObject({
+  TERM: "xterm-256color",
+  COLORTERM: "truecolor",
+})
+```
+
+Restore the previous process environment in `finally` and call capture cleanup.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+cd packages/branding
+bun test tests/puretui-terminal.test.ts -t "does not inherit NO_COLOR"
+```
+
+Expected: FAIL because the sidecar environment currently contains `NO_COLOR: "1"`.
+
+- [ ] **Step 3: Implement the minimal environment filter**
+
+Extend the existing `inheritedEnvironment()` predicate in `puretui-terminal.ts` with:
+
+```ts
+key !== "NO_COLOR"
+```
+
+Do not introduce a new environment builder or alter normal Kobe runtime code.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the same focused command. Expected: PASS.
+
+### Task 2: Add a Capture-Only Claude Command Override
+
+**Files:**
+- Modify: `packages/branding/tests/puretui-terminal.test.ts`
+- Modify: `packages/branding/scripts/capture-puretui.ts`
+
+**Interfaces:**
+- Consumes: optional `CapturePureTuiOptions.claudeCommand?: string`.
+- Produces: `engineCommand.claude` in `<demoRoot>/home/.config/kobe/state.json` only when the option is non-empty.
+- CLI source: `process.env.KOBE_REPLAY_CLAUDE_COMMAND?.trim()`.
+
+- [ ] **Step 1: Write failing state tests**
+
+Keep the existing no-override assertion exactly unchanged, then add a second capture CLI test that passes:
+
+```ts
+claudeCommand: "/usr/bin/env TEST_CAPTURE=1 claude --model test"
+```
+
+After the zero-second injected capture completes, assert the isolated state contains:
+
+```ts
+expect(state["engineCommand.claude"]).toBe(
+  "/usr/bin/env TEST_CAPTURE=1 claude --model test",
+)
+```
+
+- [ ] **Step 2: Run the focused CLI tests and verify RED**
+
+Run:
+
+```bash
+cd packages/branding
+bun test tests/puretui-terminal.test.ts -t "Claude command override"
+```
+
+Expected: TypeScript/runtime assertion failure because `claudeCommand` is not accepted or persisted.
+
+- [ ] **Step 3: Implement minimal option and persistence**
+
+Add the optional field:
+
+```ts
+claudeCommand?: string
+```
+
+Build the isolated state before writing it:
+
+```ts
+const state: Record<string, unknown> = {
+  onboarded: true,
+  skillHintSeen: "1",
+  savedRepos: [fixtureRepo],
+}
+const claudeCommand = options.claudeCommand?.trim()
+if (claudeCommand) state["engineCommand.claude"] = claudeCommand
+```
+
+Pass the value into `prepareCaptureState`. In `parseArguments`, populate it from:
+
+```ts
+process.env.KOBE_REPLAY_CLAUDE_COMMAND?.trim() || undefined
+```
+
+- [ ] **Step 4: Run focused and replay tests and verify GREEN**
+
+Run:
+
+```bash
+cd packages/branding
+bun test tests/puretui-terminal.test.ts
+bun run test:replay
+```
+
+Expected: all tests pass; the opt-in real capture test remains skipped.
+
+### Task 3: Record Through the Real ClaudeX Launch Path
+
+**Files:**
+- Regenerate: `packages/branding/src/quicklook/frames.json`
+- Generate for review: `packages/branding/out/kobe-quicklook-4x.mp4`
+
+**Interfaces:**
+- Consumes: current `claudex` alias expansion reported by `zsh -lic 'alias claudex'`.
+- Produces: an isolated replay whose Claude task command uses the equivalent `/usr/bin/env ... cc-switch start claude cliproxy-local -- --model fable` launch.
+
+- [ ] **Step 1: Resolve the current alias and authoritative command paths**
+
+Run:
+
+```bash
+zsh -lic 'alias claudex; command -v cc-switch; command -v claude'
+```
+
+Construct the override from the current alias expansion using absolute `cc-switch` path and the same four environment variables. Do not write secrets or provider configuration into the repository.
+
+- [ ] **Step 2: Capture to a review file with the override**
+
+From `packages/branding`, run `bun run capture:puretui` with `KOBE_REPLAY_CLAUDE_COMMAND` set to the resolved command, `--output /tmp/kobe-quicklook-frames-claudex-color.json`, and `--keep-demo-root`.
+
+Expected: capture completes with a retained isolated demo root and current ClaudeX model visible in its Claude frames.
+
+- [ ] **Step 3: Prove the captured ANSI contains Claude colors**
+
+Parse the review JSON and require occurrences of:
+
+```text
+38;2;215;119;87
+38;2;255;193;7
+38;2;153;153;153 (or another explicit muted gray emitted by ClaudeX)
+```
+
+Also verify the recorded Claude pane identifies Claude Code and the current ClaudeX model. Do not promote a file that lacks these signals.
+
+- [ ] **Step 4: Promote and render**
+
+Mechanically copy the reviewed JSON to `src/quicklook/frames.json`, then run:
+
+```bash
+bun x remotion render src/index.ts quicklook-replay-4x out/kobe-quicklook-4x.mp4
+```
+
+Expected: 1280x720 MP4 renders successfully.
+
+### Task 4: Visual Acceptance and Repository Verification
+
+**Files:**
+- Generate for review: `packages/branding/out/kobe-quicklook-claudex-color-confirmed.png`
+
+**Interfaces:**
+- Consumes: the final MP4 and refreshed frames.
+- Produces: one stable Claude frame that directly proves the requested palette.
+
+- [ ] **Step 1: Extract candidate Claude frames**
+
+Use `ffmpeg` to extract multiple frames during the Claude stage, including after prompt submission. Select the frame with visible Claude orange, warning yellow, muted gray, white text, and dark background.
+
+- [ ] **Step 2: Inspect the selected frame at original resolution**
+
+Use the local image viewer and reject it if Claude content is monochrome, clipped beyond recognition, or actually a bare `claude` launch rather than ClaudeX.
+
+- [ ] **Step 3: Run complete verification**
+
+Run:
+
+```bash
+bun run lint
+bun run typecheck
+bun run test
+cd packages/kobe && bun run build && bun run test:behavior
+cd ../branding && bun run test:replay
+git diff --check
+```
+
+Expected: all scoped and repository checks pass. Keep the previously documented unrelated stale Kanban visual baseline outside this slice.
+
+- [ ] **Step 4: Commit, push, and watch PR checks**
+
+Stage only the capture implementation, tests, refreshed frames, plan/spec documents, and changeset if needed. Commit with a direct fix message, push the existing branch, then wait for every PR #324 check to complete successfully.
+
+- [ ] **Step 5: Reveal artifacts and complete the goal**
+
+Open the confirmed PNG and reveal the MP4 in Finder. Mark the goal complete only after the image, ANSI evidence, tests, and PR checks all prove the objective.

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-claudex-colors.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-claudex-colors.md
@@ -12,7 +12,7 @@
 
 - Do not change the user's shell alias, provider configuration, global Kobe state, or normal engine defaults.
 - Do not put machine-specific `claudex`, model, or provider values in `quicklook.replay.json`.
-- The reviewed Claude frame must visibly contain Claude orange `rgb(215,119,87)`, warning yellow `rgb(255,193,7)`, muted gray, and a dark background.
+- The reviewed Claude permission frame must visibly contain Claude orange `rgb(215,119,87)`, Kobe permission-state yellow `rgb(232,201,107)`, muted gray, periwinkle, and a dark background.
 - A real but monochrome Claude frame fails acceptance.
 - Keep every touched source file at or below 500 lines.
 - Use no subagents; execute this plan inline.
@@ -177,7 +177,7 @@ Parse the review JSON and require occurrences of:
 
 ```text
 38;2;215;119;87
-38;2;255;193;7
+38;2;232;201;107
 38;2;153;153;153 (or another explicit muted gray emitted by ClaudeX)
 ```
 
@@ -204,7 +204,7 @@ Expected: 1280x720 MP4 renders successfully.
 
 - [ ] **Step 1: Extract candidate Claude frames**
 
-Use `ffmpeg` to extract multiple frames during the Claude stage, including after prompt submission. Select the frame with visible Claude orange, warning yellow, muted gray, white text, and dark background.
+Render a lossless Remotion still during the Claude permission stage. Select the frame with visible Claude orange, Kobe permission-state yellow, muted gray, periwinkle, white text, and dark background.
 
 - [ ] **Step 2: Inspect the selected frame at original resolution**
 

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-claudex-colors.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-claudex-colors.md
@@ -22,26 +22,27 @@
 ### Task 1: Sanitize the Capture Color Environment
 
 **Files:**
-- Modify: `packages/branding/tests/puretui-terminal.test.ts`
+- Create: `packages/branding/tests/puretui-capture-environment.test.ts`
 - Modify: `packages/branding/src/quicklook/puretui-terminal.ts:51-65`
+- Modify: `packages/branding/package.json`
 
 **Interfaces:**
-- Consumes: `createPureTuiCapture(options: PureTuiCaptureOptions)` and its `SidecarFactory` injection.
+- Consumes: `captureEnvironment(demoRoot: string)` exported from the internal PureTUI capture adapter.
 - Produces: a sidecar spawn environment that never contains `NO_COLOR` and still declares `TERM=xterm-256color` plus `COLORTERM=truecolor`.
 
 - [ ] **Step 1: Write the failing environment-boundary test**
 
-Add a focused test that temporarily sets `process.env.NO_COLOR = "1"`, creates a capture with the existing fake sidecar, and asserts:
+Add a focused test that temporarily sets `process.env.NO_COLOR = "1"`, builds the capture environment, and asserts:
 
 ```ts
-expect(sidecarFactory.calls[0].env).not.toHaveProperty("NO_COLOR")
-expect(sidecarFactory.calls[0].env).toMatchObject({
+expect(env).not.toHaveProperty("NO_COLOR")
+expect(env).toMatchObject({
   TERM: "xterm-256color",
   COLORTERM: "truecolor",
 })
 ```
 
-Restore the previous process environment in `finally` and call capture cleanup.
+Restore the previous process environment in `finally`. Add the new test file to `test:replay`.
 
 - [ ] **Step 2: Run the test and verify RED**
 
@@ -56,7 +57,7 @@ Expected: FAIL because the sidecar environment currently contains `NO_COLOR: "1"
 
 - [ ] **Step 3: Implement the minimal environment filter**
 
-Extend the existing `inheritedEnvironment()` predicate in `puretui-terminal.ts` with:
+Export the existing internal environment builder for direct testing and extend the `inheritedEnvironment()` predicate in `puretui-terminal.ts` with:
 
 ```ts
 key !== "NO_COLOR"
@@ -71,7 +72,7 @@ Run the same focused command. Expected: PASS.
 ### Task 2: Add a Capture-Only Claude Command Override
 
 **Files:**
-- Modify: `packages/branding/tests/puretui-terminal.test.ts`
+- Modify: `packages/branding/tests/puretui-capture-environment.test.ts`
 - Modify: `packages/branding/scripts/capture-puretui.ts`
 
 **Interfaces:**

--- a/docs/superpowers/plans/2026-07-14-puretui-replay-terminal-colors.md
+++ b/docs/superpowers/plans/2026-07-14-puretui-replay-terminal-colors.md
@@ -1,0 +1,134 @@
+# PureTUI Replay Terminal Colors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore bidirectional default-color negotiation in native replay capture and produce a visually verified current Brand Studio frame.
+
+**Architecture:** A focused capture-side helper registers OSC 10/11 handlers on `@xterm/headless` and emits standards-compatible RGB replies through the same PTY input channel as other xterm responses. The replay theme is passed through the existing JSON sidecar start request so capture and render share one declared palette.
+
+**Tech Stack:** Bun, Node, `node-pty`, `@xterm/headless` 6, TypeScript, `bun:test`, Remotion, `/harness`.
+
+## Global Constraints
+
+- Keep capture-specific behavior in `packages/branding`; do not add Remotion concerns to Kobe runtime packages.
+- Use the validated replay theme as the terminal default-color source.
+- Never answer queries while replaying historical PTY bytes.
+- Do not change keybindings or product layout.
+- Keep every touched source file at or below the repository's approximately 500-line cap.
+
+---
+
+### Task 1: Prove the missing terminal replies
+
+**Files:**
+- Create: `packages/branding/tests/puretui-terminal-colors.test.ts`
+- Modify: `packages/branding/scripts/puretui-pty-sidecar.mjs`
+
+**Interfaces:**
+- Produces `registerDefaultColorHandlers(terminal, theme, reply)`.
+- The callback receives exact terminal input bytes to write to the PTY.
+
+- [ ] **Step 1: Write failing OSC and forwarding tests**
+
+Create tests that instantiate a real headless xterm, register the wished-for
+helper, write `\x1b]10;?\x07\x1b]11;?\x07`, and expect:
+
+```ts
+expect(replies).toEqual([
+  "\x1b]10;rgb:ffff/ffff/ffff\x1b\\",
+  "\x1b]11;rgb:1414/1414/1313\x1b\\",
+])
+```
+
+Add a controller test whose fake terminal fires `onData("\x1b[1;1R")` and
+asserts the fake child receives that exact input.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `bun test packages/branding/tests/puretui-terminal-colors.test.ts`
+
+Expected: FAIL because the helper is not exported and controller does not
+subscribe to terminal replies.
+
+- [ ] **Step 3: Implement the minimal capture-side protocol**
+
+Add a strict `#RRGGBB` to 16-bit OSC encoder, register query-only handlers for
+slots 10 and 11, subscribe to `terminal.onData`, and write replies only while
+the child is alive. Do not intercept color-set payloads.
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run: `bun test packages/branding/tests/puretui-terminal-colors.test.ts packages/branding/tests/puretui-terminal.test.ts`
+
+Expected: both files pass with zero failures.
+
+### Task 2: Carry the declared replay theme into the sidecar
+
+**Files:**
+- Modify: `packages/branding/src/quicklook/puretui-terminal.ts`
+- Modify: `packages/branding/scripts/capture-puretui.ts`
+- Test: `packages/branding/tests/puretui-terminal-colors.test.ts`
+
+**Interfaces:**
+- `PureTuiCaptureOptions` gains `theme: Pick<TerminalTheme, "defaultFg" | "defaultBg">`.
+- `PureTuiTerminal.start()` includes that theme in the existing `start` request.
+
+- [ ] **Step 1: Add a failing request-contract test**
+
+Assert the first sidecar request contains:
+
+```ts
+theme: { defaultFg: "#FFFFFF", defaultBg: "#141413" }
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bun test packages/branding/tests/puretui-terminal-colors.test.ts`
+
+Expected: FAIL because the theme is absent from the request.
+
+- [ ] **Step 3: Thread the validated theme through capture creation**
+
+Pass `spec.theme` from `capturePureTui` into `createPureTuiCapture`; include it
+in the start request and require it before constructing the sidecar xterm.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `bun test packages/branding/tests/puretui-terminal-colors.test.ts packages/branding/tests/puretui-terminal.test.ts`
+
+Expected: all tests pass.
+
+### Task 3: Verify and produce the accepted artifact
+
+**Files:**
+- Modify: `packages/branding/src/quicklook/frames.json`
+- Scratch only: `packages/branding/out/kobe-quicklook-4x.mp4`
+- Scratch only: `/tmp/kobe-replay-color-after.png`
+
+- [ ] **Step 1: Run code verification**
+
+Run the branding replay tests, package typechecks, repository lint, typecheck,
+test, build, and behavior checks. Every command must exit zero.
+
+- [ ] **Step 2: Capture the `/harness` visual baseline**
+
+Open the fixed viewport `/harness`, wait for real OpenTUI and the native agent,
+then save a screenshot showing the workspace, agent pane, and surrounding
+chrome.
+
+- [ ] **Step 3: Record and render in the feature worktree**
+
+Run `bun run capture:puretui` from `packages/branding`, then render
+`quicklook-replay-4x` to `packages/branding/out/kobe-quicklook-4x.mp4` in the
+same worktree.
+
+- [ ] **Step 4: Extract and inspect a representative frame**
+
+Use ffmpeg to extract an agent-visible frame. Confirm current version/content,
+the replay theme background, readable default text, distinct accent/warning
+colors, and no stale tmux status line.
+
+- [ ] **Step 5: Commit and update the existing PR**
+
+Stage only the color fix, tests, docs, and regenerated frames; commit through
+ordinary git CLI, push the feature branch, and confirm PR checks.

--- a/docs/superpowers/specs/2026-07-14-puretui-replay-claudex-color-design.md
+++ b/docs/superpowers/specs/2026-07-14-puretui-replay-claudex-color-design.md
@@ -18,8 +18,13 @@ viewport and terminal protocol handlers:
 
 - with inherited `NO_COLOR=1`: 0 SGR sequences and 0 color SGR sequences;
 - with only `NO_COLOR` removed: 27 SGR sequences and 14 color SGR sequences,
-  including Claude orange `rgb(215,119,87)`, warning yellow
-  `rgb(255,193,7)`, and multiple gray levels.
+  including Claude orange `rgb(215,119,87)` and multiple gray levels.
+
+A later screen-level probe showed that `rgb(255,193,7)` belonged to the
+repository-specific `PR #324` status link, not a portable warning state. The
+portable acceptance frame therefore uses a real Claude Bash permission prompt:
+Claude supplies the orange, gray, and periwinkle terminal palette while Kobe's
+`permission_needed` task state supplies warning yellow `rgb(232,201,107)`.
 
 This isolates the failure to the replay capture environment boundary.
 
@@ -78,9 +83,10 @@ Automated tests must prove:
 - the replay regression suite remains green.
 
 Manual acceptance must use the real `claudex` expansion and require a rendered
-Claude frame containing visible Claude orange, warning yellow, and muted gray
-text on the dark background. A monochrome frame fails acceptance even if the
-agent is real and readable.
+Claude permission frame containing visible Claude orange, Kobe permission-state
+yellow, muted gray text, and the periwinkle permission selection on the dark
+background. A monochrome frame fails acceptance even if the agent is real and
+readable.
 
 ## Scope
 

--- a/docs/superpowers/specs/2026-07-14-puretui-replay-claudex-color-design.md
+++ b/docs/superpowers/specs/2026-07-14-puretui-replay-claudex-color-design.md
@@ -1,0 +1,90 @@
+# PureTUI Replay ClaudeX Color Fidelity Design
+
+## Problem
+
+The native PureTUI replay capture launches the real Claude binary, but the
+capture process currently inherits `NO_COLOR=1` from its parent environment.
+Claude Code therefore emits no SGR color sequences. The resulting Brand Studio
+video is monochrome even though terminal default-color negotiation works.
+
+The previous acceptance check was insufficient: seeing a real Claude Code or
+Codex process proves engine authenticity, but it does not prove that the Claude
+color path matches a normal interactive `claudex` session.
+
+## Evidence
+
+A PTY probe launched the user's real `claudex` shell alias twice with the same
+viewport and terminal protocol handlers:
+
+- with inherited `NO_COLOR=1`: 0 SGR sequences and 0 color SGR sequences;
+- with only `NO_COLOR` removed: 27 SGR sequences and 14 color SGR sequences,
+  including Claude orange `rgb(215,119,87)`, warning yellow
+  `rgb(255,193,7)`, and multiple gray levels.
+
+This isolates the failure to the replay capture environment boundary.
+
+## Chosen Design
+
+### Environment isolation
+
+The capture environment must remove `NO_COLOR` before launching the PureTUI,
+daemon, PTY host, or engine children. It will continue to declare
+`TERM=xterm-256color` and `COLORTERM=truecolor` explicitly.
+
+The fix belongs in the capture-only environment builder. It must not change the
+user's shell environment or Kobe's normal runtime environment.
+
+### ClaudeX launch override
+
+The capture CLI will accept an optional capture-only Claude engine command from
+an environment variable. When set, it will write that command to the isolated
+capture state as `engineCommand.claude` before the TUI starts.
+
+The checked-in replay spec remains portable and contains no machine-specific
+provider, model, or shell-alias configuration. For the reviewed Brand Studio
+capture, the caller supplies the current `claudex` alias expansion. Kobe then
+launches the same `cc-switch` provider and model path as the user's interactive
+alias while preserving its normal engine-session wiring.
+
+### Alternatives rejected
+
+1. Hard-code `claudex` or its provider command in the replay JSON. This makes a
+   checked-in production artifact depend on one machine's shell configuration.
+2. Put a temporary executable named `claude` earlier on `PATH`. This can produce
+   one corrected recording but leaves the capture API unable to reproduce it.
+3. Only unset `NO_COLOR` and keep using bare `claude`. This repairs color but
+   does not satisfy the requirement that the reviewed recording exercise the
+   user's real `claudex` launch path.
+
+## Data Flow
+
+1. `capture-puretui.ts` builds the isolated demo root.
+2. It writes normal capture state plus the optional Claude command override.
+3. `puretui-terminal.ts` builds a sanitized child environment with `NO_COLOR`
+   excluded and explicit truecolor terminal capabilities.
+4. The source PureTUI creates a Claude task using `engineCommand.claude`.
+5. The hosted PTY launches the expanded `claudex` command.
+6. The headless terminal answers protocol queries, records the complete ANSI
+   screen state, and writes refreshed `frames.json`.
+7. Remotion renders the reviewed MP4 from those frames.
+
+## Tests
+
+Automated tests must prove:
+
+- capture environment construction excludes inherited `NO_COLOR`;
+- an unset Claude override leaves the existing state shape unchanged;
+- a supplied Claude override is written only to isolated capture state;
+- the replay regression suite remains green.
+
+Manual acceptance must use the real `claudex` expansion and require a rendered
+Claude frame containing visible Claude orange, warning yellow, and muted gray
+text on the dark background. A monochrome frame fails acceptance even if the
+agent is real and readable.
+
+## Scope
+
+This change is limited to `packages/branding` capture infrastructure, tests,
+the refreshed replay frames, and rendered review artifacts. It does not alter
+Kobe's normal engine defaults, global user state, provider configuration, or
+shell aliases.

--- a/docs/superpowers/specs/2026-07-14-puretui-replay-terminal-colors-design.md
+++ b/docs/superpowers/specs/2026-07-14-puretui-replay-terminal-colors-design.md
@@ -1,0 +1,49 @@
+# PureTUI replay terminal-color fidelity design
+
+## Goal
+
+Make the native PureTUI replay capture behave like a real bidirectional
+terminal for default-color queries, then prove the resulting Brand Studio
+render against the fixed-viewport `/harness` ground truth.
+
+## Root cause
+
+The retired tmux capture used `capture-pane -ep` to materialize a complete
+screen with ANSI attributes. The replacement correctly materializes the
+screen through `@xterm/headless`, but its outer sidecar only forwards child
+output into xterm. It does not forward xterm replies to the child. In
+addition, headless xterm raises OSC 10/11 color-report events without a
+browser color manager, so default foreground/background queries receive no
+reply.
+
+The result is a complete text grid with incomplete terminal negotiation.
+OpenTUI or a native engine can choose fallback colors before the grid is
+serialized, so the renderer cannot recover the intended palette afterward.
+
+## Design
+
+- Register explicit OSC 10 and OSC 11 query handlers on each capture xterm.
+  Reply only to the `?` query form; allow non-query OSC color operations to
+  fall through to xterm.
+- Encode replies as `OSC <slot>;rgb:rrrr/gggg/bbbb ST`, matching the format
+  consumed by Codex and emitted by real terminals.
+- Forward all xterm `onData` replies to the live PTY child. Existing CSI/DA
+  replies and the new color replies therefore share one ordered channel.
+- Source the capture foreground/background from the validated replay theme,
+  not hard-coded renderer colors.
+- Keep replay parsing one-way: historical bytes must never generate fresh
+  replies to a live child.
+- Do not change the Brand Studio palette to hide protocol errors.
+
+## Verification
+
+- Unit tests prove that OSC 10/11 queries produce the declared theme colors,
+  non-query OSC operations fall through, and emulator replies reach the PTY.
+- The existing replay unit suite, typecheck, lint, build, and behavior suite
+  remain green.
+- A fresh native capture and Remotion render must identify current Kobe and
+  current native engine content rather than the historical tmux recording.
+- Compare a fixed-viewport `/harness` screenshot with an extracted replay
+  frame. Text, default background, accent colors, engine colors, and contrast
+  must be visibly consistent, with no blank, black, white-on-white, or stale
+  tmux artifacts.

--- a/packages/branding/package.json
+++ b/packages/branding/package.json
@@ -18,7 +18,7 @@
     "mp4:streams": "remotion render src/index.ts task-streams ../../docs/assets/brand/task-streams.mp4",
     "mp4:glyph": "remotion render src/index.ts glyph-k ../../docs/assets/brand/glyph-k.mp4",
     "capture:puretui": "bun scripts/capture-puretui.ts",
-    "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts tests/puretui-terminal-colors.test.ts tests/puretui-capture.test.ts",
+    "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts tests/puretui-terminal-colors.test.ts tests/puretui-capture-environment.test.ts tests/puretui-capture.test.ts",
     "stills:all": "bun run still:bracket && bun run still:grid && bun run still:streams && bun run still:glyph",
     "gifs:all": "bun run gif:bracket && bun run gif:grid && bun run gif:streams && bun run gif:glyph",
     "render:all": "mkdir -p ../../docs/assets/brand && bun run stills:all && bun run gifs:all"

--- a/packages/branding/package.json
+++ b/packages/branding/package.json
@@ -18,7 +18,7 @@
     "mp4:streams": "remotion render src/index.ts task-streams ../../docs/assets/brand/task-streams.mp4",
     "mp4:glyph": "remotion render src/index.ts glyph-k ../../docs/assets/brand/glyph-k.mp4",
     "capture:puretui": "bun scripts/capture-puretui.ts",
-    "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts tests/puretui-capture.test.ts",
+    "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts tests/puretui-terminal-colors.test.ts tests/puretui-capture.test.ts",
     "stills:all": "bun run still:bracket && bun run still:grid && bun run still:streams && bun run still:glyph",
     "gifs:all": "bun run gif:bracket && bun run gif:grid && bun run gif:streams && bun run gif:glyph",
     "render:all": "mkdir -p ../../docs/assets/brand && bun run stills:all && bun run gifs:all"

--- a/packages/branding/package.json
+++ b/packages/branding/package.json
@@ -18,7 +18,7 @@
     "mp4:streams": "remotion render src/index.ts task-streams ../../docs/assets/brand/task-streams.mp4",
     "mp4:glyph": "remotion render src/index.ts glyph-k ../../docs/assets/brand/glyph-k.mp4",
     "capture:puretui": "bun scripts/capture-puretui.ts",
-    "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts",
+    "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts tests/puretui-capture.test.ts",
     "stills:all": "bun run still:bracket && bun run still:grid && bun run still:streams && bun run still:glyph",
     "gifs:all": "bun run gif:bracket && bun run gif:grid && bun run gif:streams && bun run gif:glyph",
     "render:all": "mkdir -p ../../docs/assets/brand && bun run stills:all && bun run gifs:all"

--- a/packages/branding/package.json
+++ b/packages/branding/package.json
@@ -17,6 +17,8 @@
     "mp4:grid": "remotion render src/index.ts pane-grid ../../docs/assets/brand/pane-grid.mp4",
     "mp4:streams": "remotion render src/index.ts task-streams ../../docs/assets/brand/task-streams.mp4",
     "mp4:glyph": "remotion render src/index.ts glyph-k ../../docs/assets/brand/glyph-k.mp4",
+    "capture:puretui": "bun scripts/capture-puretui.ts",
+    "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts",
     "stills:all": "bun run still:bracket && bun run still:grid && bun run still:streams && bun run still:glyph",
     "gifs:all": "bun run gif:bracket && bun run gif:grid && bun run gif:streams && bun run gif:glyph",
     "render:all": "mkdir -p ../../docs/assets/brand && bun run stills:all && bun run gifs:all"
@@ -24,11 +26,15 @@
   "dependencies": {
     "@remotion/cli": "4.0.484",
     "@remotion/google-fonts": "4.0.484",
+    "@xterm/headless": "^6.0.0",
+    "node-pty": "^1.1.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "remotion": "4.0.484"
   },
   "devDependencies": {
+    "@types/bun": "1.3.14",
+    "@types/node": "25.6.2",
     "@types/react": "19.0.0",
     "@types/react-dom": "19.0.0",
     "typescript": "5.8.2"

--- a/packages/branding/scripts/README.md
+++ b/packages/branding/scripts/README.md
@@ -11,11 +11,13 @@ bun x remotion render src/index.ts quicklook-replay out/quicklook-replay.mp4
 bun x remotion render src/index.ts quicklook-replay-4x out/quicklook-replay-4x.mp4
 ```
 
-The storyboard is `src/quicklook/quicklook.replay.json`. Its
-`setup.fixtureEngines` option uses deterministic capture-only Claude and Codex
-processes inside real Hosted PTY sessions, so Brand Studio capture does not
-depend on a developer's credentials or profile. Every run creates an isolated
-Kobe home and fixture repository; the CLI prints the retained root for review.
+The storyboard is `src/quicklook/quicklook.replay.json`. Capture always launches
+the installed Claude and Codex binaries from the inherited `PATH`; there is no
+fixture or engine-mode switch in the replay spec. Kobe state and the fixture
+repository remain isolated, while engine subprocesses keep the host's normal
+home directory and native Claude/Codex profile. Test-only fixtures are injected
+by the opt-in end-to-end test itself and cannot be selected by a production
+replay. The CLI prints the retained demo root for review.
 
 Camera and framing logic lives in `src/quicklook/QuickLookReplay.tsx`; ANSI
 parsing lives in `src/quicklook/ansi.ts`.

--- a/packages/branding/scripts/README.md
+++ b/packages/branding/scripts/README.md
@@ -1,14 +1,21 @@
 # quicklook replay
 
 The `quicklook-replay` Remotion composition renders the checked-in terminal
-capture at `src/quicklook/frames.json`. The former live capture driver was
-removed with kobe's retired session backend; rendering the existing replay is
-still supported:
+capture at `src/quicklook/frames.json`. Regenerate it through the real PureTUI
+Workspace Host and Hosted PTY runtime from this package:
 
 ```bash
+bun run capture:puretui --keep-demo-root
 bun run studio
 bun x remotion render src/index.ts quicklook-replay out/quicklook-replay.mp4
+bun x remotion render src/index.ts quicklook-replay-4x out/quicklook-replay-4x.mp4
 ```
+
+The storyboard is `src/quicklook/quicklook.replay.json`. Its
+`setup.fixtureEngines` option uses deterministic capture-only Claude and Codex
+processes inside real Hosted PTY sessions, so Brand Studio capture does not
+depend on a developer's credentials or profile. Every run creates an isolated
+Kobe home and fixture repository; the CLI prints the retained root for review.
 
 Camera and framing logic lives in `src/quicklook/QuickLookReplay.tsx`; ANSI
 parsing lives in `src/quicklook/ansi.ts`.

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -83,11 +83,15 @@ export async function capturePureTui(
   await mkdir(demoRoot, { recursive: true })
   const fixtureRepo = await createFixtureRepository(demoRoot)
   await prepareCaptureState(demoRoot, fixtureRepo)
+  const ready = spec.setup?.readyWait ? spec.waits[spec.setup.readyWait] : undefined
   const capture = await (dependencies.createCapture ?? createPureTuiCapture)({
     repoRoot: REPO_ROOT,
     demoRoot,
     fixtureRepo,
     seedTasks: spec.setup?.seedTasks,
+    pathPrefix: spec.setup?.fixtureEngines ? join(PACKAGE_ROOT, "scripts", "fixtures") : undefined,
+    readyPattern: ready?.pattern,
+    readyTimeoutMs: ready?.timeoutMs,
     cols: spec.viewport.cols,
     rows: spec.viewport.rows,
     protocolTimeoutMs: options.timeoutMs,

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -58,6 +58,15 @@ const createFixtureRepository = async (demoRoot: string): Promise<string> => {
   return fixtureRepo
 }
 
+const prepareCaptureState = async (demoRoot: string, fixtureRepo: string): Promise<void> => {
+  const configDir = join(demoRoot, "home", ".config", "kobe")
+  await mkdir(configDir, { recursive: true })
+  await writeFile(
+    join(configDir, "state.json"),
+    `${JSON.stringify({ onboarded: true, skillHintSeen: "1", savedRepos: [fixtureRepo] }, null, 2)}\n`,
+  )
+}
+
 const captureOutput = (outputPath: string): CaptureOutput => ({
   replaceAtomically: (capture) => writeCaptureAtomically(outputPath, capture),
 })
@@ -72,10 +81,13 @@ export async function capturePureTui(
   const spec = resolveReplaySpec(raw, plannedCapture(raw))
   const demoRoot = resolve(options.demoRoot)
   await mkdir(demoRoot, { recursive: true })
-  await createFixtureRepository(demoRoot)
+  const fixtureRepo = await createFixtureRepository(demoRoot)
+  await prepareCaptureState(demoRoot, fixtureRepo)
   const capture = await (dependencies.createCapture ?? createPureTuiCapture)({
     repoRoot: REPO_ROOT,
     demoRoot,
+    fixtureRepo,
+    seedTasks: spec.setup?.seedTasks,
     cols: spec.viewport.cols,
     rows: spec.viewport.rows,
     protocolTimeoutMs: options.timeoutMs,

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -17,6 +17,7 @@ export type CapturePureTuiOptions = {
   outputPath: string
   demoRoot: string
   keepDemoRoot: boolean
+  claudeCommand?: string
   timeoutMs?: number
 }
 
@@ -56,13 +57,13 @@ const createFixtureRepository = async (demoRoot: string): Promise<string> => {
   return fixtureRepo
 }
 
-const prepareCaptureState = async (demoRoot: string, fixtureRepo: string): Promise<void> => {
+const prepareCaptureState = async (demoRoot: string, fixtureRepo: string, claudeCommand?: string): Promise<void> => {
   const configDir = join(demoRoot, "home", ".config", "kobe")
   await mkdir(configDir, { recursive: true })
-  await writeFile(
-    join(configDir, "state.json"),
-    `${JSON.stringify({ onboarded: true, skillHintSeen: "1", savedRepos: [fixtureRepo] }, null, 2)}\n`,
-  )
+  const state: Record<string, unknown> = { onboarded: true, skillHintSeen: "1", savedRepos: [fixtureRepo] }
+  const captureClaudeCommand = claudeCommand?.trim()
+  if (captureClaudeCommand) state["engineCommand.claude"] = captureClaudeCommand
+  await writeFile(join(configDir, "state.json"), `${JSON.stringify(state, null, 2)}\n`)
 }
 
 const captureOutput = (outputPath: string): CaptureOutput => ({
@@ -80,7 +81,7 @@ export async function capturePureTui(
   const demoRoot = resolve(options.demoRoot)
   await mkdir(demoRoot, { recursive: true })
   const fixtureRepo = await createFixtureRepository(demoRoot)
-  await prepareCaptureState(demoRoot, fixtureRepo)
+  await prepareCaptureState(demoRoot, fixtureRepo, options.claudeCommand)
   const ready = spec.setup?.readyWait ? spec.waits[spec.setup.readyWait] : undefined
   const capture = await (dependencies.createCapture ?? createPureTuiCapture)({
     repoRoot: REPO_ROOT,
@@ -142,6 +143,7 @@ const parseArguments = (args: readonly string[]): CapturePureTuiOptions => {
     specPath,
     outputPath,
     keepDemoRoot,
+    claudeCommand: process.env.KOBE_REPLAY_CLAUDE_COMMAND?.trim() || undefined,
     timeoutMs,
     demoRoot: join(PACKAGE_ROOT, `.capture-home-puretui-${process.pid}-${Date.now()}`),
   }

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -1,11 +1,8 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
-import { runReplayCapture, writeCaptureAtomically, type CaptureOutput } from "../src/quicklook/capture-core"
-import {
-  createPureTuiCapture,
-  type PureTuiCaptureOptions,
-} from "../src/quicklook/puretui-terminal"
-import { resolveReplaySpec, type CaptureMeta, type RawReplaySpec } from "../src/quicklook/replay-spec"
+import { type CaptureOutput, runReplayCapture, writeCaptureAtomically } from "../src/quicklook/capture-core"
+import { type PureTuiCaptureOptions, createPureTuiCapture } from "../src/quicklook/puretui-terminal"
+import { type CaptureMeta, type RawReplaySpec, resolveReplaySpec } from "../src/quicklook/replay-spec"
 
 const PACKAGE_ROOT = resolve(import.meta.dirname, "..")
 const REPO_ROOT = resolve(PACKAGE_ROOT, "../..")
@@ -89,7 +86,6 @@ export async function capturePureTui(
     demoRoot,
     fixtureRepo,
     seedTasks: spec.setup?.seedTasks,
-    pathPrefix: spec.setup?.fixtureEngines ? join(PACKAGE_ROOT, "scripts", "fixtures") : undefined,
     readyPattern: ready?.pattern,
     readyTimeoutMs: ready?.timeoutMs,
     cols: spec.viewport.cols,

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
+import { DEFAULT_TERMINAL_THEME } from "../src/quicklook/ansi"
 import { type CaptureOutput, runReplayCapture, writeCaptureAtomically } from "../src/quicklook/capture-core"
 import { type PureTuiCaptureOptions, createPureTuiCapture } from "../src/quicklook/puretui-terminal"
 import { type CaptureMeta, type RawReplaySpec, resolveReplaySpec } from "../src/quicklook/replay-spec"
@@ -90,6 +91,10 @@ export async function capturePureTui(
     readyTimeoutMs: ready?.timeoutMs,
     cols: spec.viewport.cols,
     rows: spec.viewport.rows,
+    theme: {
+      defaultFg: spec.theme?.defaultFg ?? DEFAULT_TERMINAL_THEME.defaultFg,
+      defaultBg: spec.theme?.defaultBg ?? DEFAULT_TERMINAL_THEME.defaultBg,
+    },
     protocolTimeoutMs: options.timeoutMs,
   })
   try {

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -1,0 +1,140 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+import { runReplayCapture, writeCaptureAtomically, type CaptureOutput } from "../src/quicklook/capture-core"
+import {
+  createPureTuiCapture,
+  type PureTuiCaptureOptions,
+} from "../src/quicklook/puretui-terminal"
+import { resolveReplaySpec, type CaptureMeta, type RawReplaySpec } from "../src/quicklook/replay-spec"
+
+const PACKAGE_ROOT = resolve(import.meta.dirname, "..")
+const REPO_ROOT = resolve(PACKAGE_ROOT, "../..")
+const DEFAULT_SPEC = join(PACKAGE_ROOT, "src", "quicklook", "quicklook.replay.json")
+const DEFAULT_OUTPUT = join(PACKAGE_ROOT, "src", "quicklook", "frames.json")
+
+type CaptureHandle = Awaited<ReturnType<typeof createPureTuiCapture>>
+
+export type CapturePureTuiOptions = {
+  specPath: string
+  outputPath: string
+  demoRoot: string
+  keepDemoRoot: boolean
+  timeoutMs?: number
+}
+
+type CaptureDependencies = {
+  createCapture?: (options: PureTuiCaptureOptions) => Promise<CaptureHandle>
+  log?: (line: string) => void
+}
+
+const plannedCapture = (raw: unknown): CaptureMeta => {
+  const candidate = raw as Partial<RawReplaySpec>
+  const cols = typeof candidate.viewport?.cols === "number" ? candidate.viewport.cols : -1
+  const rows = typeof candidate.viewport?.rows === "number" ? candidate.viewport.rows : -1
+  const captureEnd = typeof candidate.capture?.seconds === "number" ? candidate.capture.seconds : 0
+  return { cols, rows, frames: [{ t: captureEnd, lines: [] }] }
+}
+
+const run = async (file: string, args: readonly string[], cwd: string) => {
+  const child = Bun.spawn([file, ...args], { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ])
+  if (code !== 0) throw new Error(`${file} ${args.join(" ")} failed (${code}): ${stderr.trim() || stdout.trim()}`)
+  return stdout.trim()
+}
+
+const createFixtureRepository = async (demoRoot: string): Promise<string> => {
+  const fixtureRepo = join(demoRoot, "fixture-repo")
+  await mkdir(fixtureRepo, { recursive: true })
+  await run("git", ["init", "-q", "-b", "main"], fixtureRepo)
+  await run("git", ["config", "user.email", "capture@kobe.local"], fixtureRepo)
+  await run("git", ["config", "user.name", "kobe capture"], fixtureRepo)
+  await writeFile(join(fixtureRepo, "README.md"), "# PureTUI replay fixture\n")
+  await run("git", ["add", "README.md"], fixtureRepo)
+  await run("git", ["commit", "-q", "-m", "fixture"], fixtureRepo)
+  return fixtureRepo
+}
+
+const captureOutput = (outputPath: string): CaptureOutput => ({
+  replaceAtomically: (capture) => writeCaptureAtomically(outputPath, capture),
+})
+
+export async function capturePureTui(
+  options: CapturePureTuiOptions,
+  dependencies: CaptureDependencies = {},
+): Promise<{ outputPath: string; demoRoot: string }> {
+  const raw = JSON.parse(await readFile(options.specPath, "utf8")) as unknown
+  // Validation is deliberately before fixture creation and sidecar spawn. A bad
+  // checked-in replay must have no process or filesystem side effects.
+  const spec = resolveReplaySpec(raw, plannedCapture(raw))
+  const demoRoot = resolve(options.demoRoot)
+  await mkdir(demoRoot, { recursive: true })
+  await createFixtureRepository(demoRoot)
+  const capture = await (dependencies.createCapture ?? createPureTuiCapture)({
+    repoRoot: REPO_ROOT,
+    demoRoot,
+    cols: spec.viewport.cols,
+    rows: spec.viewport.rows,
+    protocolTimeoutMs: options.timeoutMs,
+  })
+  try {
+    await runReplayCapture(spec, capture.terminal, captureOutput(resolve(options.outputPath)), {
+      now: () => performance.now(),
+      sleep: (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms)),
+    })
+  } finally {
+    await capture.cleanup()
+  }
+
+  const log = dependencies.log ?? console.log
+  log(`PureTUI replay capture: ${resolve(options.outputPath)}`)
+  // Demo roots contain diagnostics and are intentionally retained. The flag is
+  // accepted for CLI compatibility and makes that retention explicit to users.
+  if (options.keepDemoRoot) log(`Retained demo root: ${demoRoot}`)
+  return { outputPath: resolve(options.outputPath), demoRoot }
+}
+
+const parseArguments = (args: readonly string[]): CapturePureTuiOptions => {
+  let specPath = DEFAULT_SPEC
+  let outputPath = DEFAULT_OUTPUT
+  let keepDemoRoot = false
+  let timeoutMs: number | undefined
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === "--keep-demo-root") {
+      keepDemoRoot = true
+      continue
+    }
+    if (arg === "--spec" || arg === "--output" || arg === "--timeout-ms") {
+      const value = args[++index]
+      if (!value) throw new Error(`${arg} requires a value`)
+      if (arg === "--spec") specPath = resolve(value)
+      if (arg === "--output") outputPath = resolve(value)
+      if (arg === "--timeout-ms") {
+        timeoutMs = Number.parseInt(value, 10)
+        if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("--timeout-ms must be a positive integer")
+      }
+      continue
+    }
+    throw new Error(`unknown argument: ${arg}`)
+  }
+  return {
+    specPath,
+    outputPath,
+    keepDemoRoot,
+    timeoutMs,
+    demoRoot: join(PACKAGE_ROOT, `.capture-home-puretui-${process.pid}-${Date.now()}`),
+  }
+}
+
+if (import.meta.main) {
+  try {
+    await capturePureTui(parseArguments(process.argv.slice(2)))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/packages/branding/scripts/fixtures/claude
+++ b/packages/branding/scripts/fixtures/claude
@@ -1,0 +1,19 @@
+#!/bin/sh
+trap 'exit 0' INT TERM HUP
+
+printf '\033[2J\033[H'
+printf '\033[1;38;2;204;120;92mClaude Code\033[0m  \033[2mfixture session\033[0m\n\n'
+printf '  Ready in the Kobe Hosted PTY\n\n'
+printf '\033[1;38;2;204;120;92m›\033[0m '
+
+while IFS= read -r prompt; do
+  printf '\n\033[2m● Reading packages/kobe/src/cli/api-cmd.ts\033[0m\n'
+  sleep 0.5
+  printf '\n\033[1m• Command surface\033[0m — dispatches typed API verbs through one validated table.\n'
+  sleep 0.5
+  printf '\033[1m• Daemon boundary\033[0m — opens one short-lived session and forwards the requested RPC.\n'
+  sleep 0.5
+  printf '\033[1m• Script contract\033[0m — emits stable JSON and preserves partial task results on errors.\n'
+  printf '\n\033[2mCompleted read-only request: %s\033[0m\n\n' "$prompt"
+  printf '\033[1;38;2;204;120;92m›\033[0m '
+done

--- a/packages/branding/scripts/fixtures/codex
+++ b/packages/branding/scripts/fixtures/codex
@@ -1,0 +1,17 @@
+#!/bin/sh
+trap 'exit 0' INT TERM HUP
+
+printf '\033[2J\033[H'
+printf '\033[1;38;2;106;169;255mOpenAI Codex\033[0m  \033[2mfixture session\033[0m\n\n'
+printf '  Workspace ready · read-only demo\n\n'
+printf '\033[1;38;2;106;169;255m›\033[0m '
+
+while IFS= read -r prompt; do
+  printf '\n\033[2m• Inspecting packages/branding\033[0m\n'
+  sleep 0.5
+  printf '\npackages/branding owns Kobe’s visual identity and Remotion compositions.\n'
+  sleep 0.6
+  printf 'Its replay pipeline turns captured ANSI keyframes into reviewable product footage.\n'
+  printf '\n\033[2mCompleted read-only request: %s\033[0m\n\n' "$prompt"
+  printf '\033[1;38;2;106;169;255m›\033[0m '
+done

--- a/packages/branding/scripts/puretui-pty-sidecar.mjs
+++ b/packages/branding/scripts/puretui-pty-sidecar.mjs
@@ -1,0 +1,250 @@
+import { spawn as spawnChild } from "node:child_process"
+import { createInterface } from "node:readline"
+import { pathToFileURL } from "node:url"
+import { basename, join, resolve } from "node:path"
+
+const delay = (ms) => new Promise((resolveDelay) => setTimeout(resolveDelay, ms))
+
+const inheritedEnvironment = (environment) =>
+  Object.fromEntries(
+    Object.entries(environment).filter(
+      ([key, value]) =>
+        value !== undefined &&
+        !key.startsWith("KOBE_") &&
+        key !== "HOME" &&
+        key !== "USERPROFILE" &&
+        !key.startsWith("XDG_") &&
+        key !== "TERM" &&
+        key !== "TERM_PROGRAM" &&
+        key !== "TERM_PROGRAM_VERSION" &&
+        key !== "COLORTERM",
+    ),
+  )
+
+const isolatedEnvironment = (baseEnv, demoRoot) => {
+  const home = join(demoRoot, "home")
+  return {
+    ...inheritedEnvironment(baseEnv),
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    XDG_DATA_HOME: join(home, ".local", "share"),
+    XDG_STATE_HOME: join(home, ".local", "state"),
+    XDG_CACHE_HOME: join(home, ".cache"),
+    XDG_RUNTIME_DIR: join(home, ".runtime"),
+    TERM: "xterm-256color",
+    COLORTERM: "truecolor",
+    TERM_PROGRAM: "kobe-capture",
+    KOBE_HOME_DIR: home,
+    KOBE_SANDBOX_HOME_DIR: home,
+    KOBE_DAEMON_WEB_PORT: baseEnv.KOBE_DAEMON_WEB_PORT ?? "5274",
+    KOBE_CAPTURE_HOST_LABEL: baseEnv.KOBE_CAPTURE_HOST_LABEL ?? "puretui-replay",
+    KOBE_CAPTURE_SESSION_LABEL: baseEnv.KOBE_CAPTURE_SESSION_LABEL ?? basename(demoRoot),
+  }
+}
+
+export function encodeKey(key) {
+  const named = {
+    Enter: "\r",
+    Escape: "\u001b",
+    Tab: "\t",
+    Backspace: "\u007f",
+    Up: "\u001b[A",
+    Down: "\u001b[B",
+    Right: "\u001b[C",
+    Left: "\u001b[D",
+    Home: "\u001b[H",
+    End: "\u001b[F",
+    PageUp: "\u001b[5~",
+    PageDown: "\u001b[6~",
+    Delete: "\u001b[3~",
+  }
+  if (named[key]) return named[key]
+  const control = /^C-([a-z@\[\\\]\^_])$/i.exec(key)
+  if (control) return String.fromCharCode(control[1].toUpperCase().charCodeAt(0) & 0x1f)
+  if ([...key].length === 1) return key
+  throw new Error(`unsupported replay key "${key}"`)
+}
+
+const defaultRunReset = (file, args, options) =>
+  new Promise((resolveReset, reject) => {
+    const child = spawnChild(file, args, { ...options, stdio: ["ignore", "ignore", "pipe"] })
+    let stderr = ""
+    child.stderr?.on("data", (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-8_192)
+    })
+    child.once("error", reject)
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolveReset()
+      else reject(new Error(`sandbox reset failed (${signal ?? code ?? "unknown"}): ${stderr.trim()}`))
+    })
+  })
+
+const assertRequest = (request) => {
+  if (!request || typeof request !== "object") throw new Error("sidecar request must be an object")
+  if (!Number.isInteger(request.id)) throw new Error("sidecar request id must be an integer")
+  if (typeof request.op !== "string") throw new Error("sidecar request op must be a string")
+  return request
+}
+
+export function createSidecarController(dependencies) {
+  const {
+    spawnPty,
+    createTerminal,
+    runReset = defaultRunReset,
+    baseEnv = process.env,
+    stopTimeoutMs = 5_000,
+    killTimeoutMs = 2_000,
+  } = dependencies
+  let child
+  let terminal
+  let childAlive = false
+  let childExited = Promise.resolve()
+  let resolveChildExit = () => {}
+  let demoRoot = ""
+  let childEnv
+  let kobeDir = ""
+  let rows = 0
+  let rawAnsi = ""
+  let writes = Promise.resolve()
+
+  const snapshotLines = async () => {
+    await writes
+    if (!terminal) return Array.from({ length: rows }, () => "")
+    return Array.from({ length: rows }, (_, row) => terminal.buffer.active.getLine(row)?.translateToString(true) ?? "")
+  }
+
+  const diagnostics = async (message) => ({
+    message,
+    snapshot: rawAnsi || (await snapshotLines()).join("\n"),
+    pid: child?.pid,
+    demoRoot,
+  })
+
+  const waitForExit = async (timeoutMs) => {
+    if (!childAlive) return true
+    await Promise.race([childExited, delay(timeoutMs)])
+    return !childAlive
+  }
+
+  const start = async (request) => {
+    if (childAlive) throw new Error("PureTUI capture child is already running")
+    if (typeof request.repoRoot !== "string" || typeof request.demoRoot !== "string") {
+      throw new Error("start requires repoRoot and demoRoot")
+    }
+    if (!Number.isInteger(request.cols) || request.cols <= 0 || !Number.isInteger(request.rows) || request.rows <= 0) {
+      throw new Error("start requires positive integer cols and rows")
+    }
+    demoRoot = resolve(request.demoRoot)
+    rows = request.rows
+    kobeDir = join(resolve(request.repoRoot), "packages", "kobe")
+    childEnv = isolatedEnvironment(baseEnv, demoRoot)
+    terminal = createTerminal({ cols: request.cols, rows: request.rows })
+    child = spawnPty("bun", ["run", "dev:sandbox"], {
+      name: "xterm-256color",
+      cols: request.cols,
+      rows: request.rows,
+      cwd: kobeDir,
+      env: childEnv,
+    })
+    childAlive = true
+    childExited = new Promise((resolveExit) => (resolveChildExit = resolveExit))
+    child.onExit(() => {
+      childAlive = false
+      resolveChildExit()
+    })
+    child.onData((data) => {
+      rawAnsi = `${rawAnsi}${data}`.slice(-1_048_576)
+      writes = writes.then(
+        () => new Promise((resolveWrite) => terminal.write(data, resolveWrite)),
+      )
+    })
+    return { pid: child.pid, demoRoot, snapshot: "" }
+  }
+
+  const stop = async () => {
+    if (!child) return { pid: undefined, demoRoot, snapshot: "" }
+    if (childAlive) {
+      child.write("\u0003")
+      if (!(await waitForExit(stopTimeoutMs))) {
+        child.kill()
+        await waitForExit(killTimeoutMs)
+      }
+    }
+    await runReset("bun", ["run", "dev:sandbox:reset"], { cwd: kobeDir, env: childEnv })
+    if (childAlive) throw new Error("PureTUI child remained alive after interrupt, kill, and sandbox reset")
+    const value = { pid: child.pid, demoRoot, snapshot: (await snapshotLines()).join("\n") || rawAnsi }
+    terminal?.dispose()
+    return value
+  }
+
+  const execute = async (request) => {
+    if (request.op === "start") return start(request)
+    if (request.op === "stop") return stop()
+    if (!child) throw new Error(`${request.op} requires a started PureTUI child`)
+    if (request.op === "type") {
+      if (typeof request.text !== "string") throw new Error("type requires text")
+      child.write(request.text)
+      return null
+    }
+    if (request.op === "key") {
+      child.write(encodeKey(request.key))
+      return null
+    }
+    if (request.op === "snapshot") return snapshotLines()
+    if (request.op === "waitFor") {
+      if (typeof request.pattern !== "string" || !Number.isFinite(request.timeoutMs) || request.timeoutMs < 0) {
+        throw new Error("waitFor requires pattern and non-negative timeoutMs")
+      }
+      const deadline = Date.now() + request.timeoutMs
+      for (;;) {
+        const snapshot = (await snapshotLines()).join("\n")
+        if (snapshot.includes(request.pattern)) return null
+        if (Date.now() >= deadline) throw new Error(`timed out waiting for ${JSON.stringify(request.pattern)}`)
+        await delay(25)
+      }
+    }
+    throw new Error(`unsupported sidecar operation "${request.op}"`)
+  }
+
+  return {
+    async handle(rawRequest) {
+      let request
+      try {
+        request = assertRequest(rawRequest)
+        return { id: request.id, ok: true, value: await execute(request) }
+      } catch (error) {
+        return {
+          id: request?.id ?? rawRequest?.id ?? -1,
+          ok: false,
+          error: await diagnostics(error instanceof Error ? error.message : String(error)),
+        }
+      }
+    },
+  }
+}
+
+async function main() {
+  const [{ spawn }, { Terminal }] = await Promise.all([import("node-pty"), import("@xterm/headless")])
+  const controller = createSidecarController({
+    spawnPty: spawn,
+    createTerminal: (options) => new Terminal({ ...options, allowProposedApi: true, scrollback: 0 }),
+  })
+  const input = createInterface({ input: process.stdin, crlfDelay: Number.POSITIVE_INFINITY })
+  input.on("line", (line) => {
+    void (async () => {
+      let request
+      try {
+        request = JSON.parse(line)
+      } catch (error) {
+        process.stdout.write(
+          `${JSON.stringify({ id: -1, ok: false, error: { message: `invalid request JSON: ${error.message}`, snapshot: "", demoRoot: "" } })}\n`,
+        )
+        return
+      }
+      process.stdout.write(`${JSON.stringify(await controller.handle(request))}\n`)
+    })()
+  })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main()

--- a/packages/branding/scripts/puretui-pty-sidecar.mjs
+++ b/packages/branding/scripts/puretui-pty-sidecar.mjs
@@ -138,6 +138,28 @@ export function serializeXtermLine(line) {
   return result
 }
 
+const oscRgb = (color, name) => {
+  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color)
+  if (!match) throw new Error(`${name} must be a #RRGGBB color`)
+  return match.slice(1).map((component) => component.toLowerCase().repeat(2)).join("/")
+}
+
+const DEFAULT_TERMINAL_THEME = { defaultFg: "#FFFFFF", defaultBg: "#141413" }
+
+export function registerDefaultColorHandlers(terminal, theme, reply) {
+  const colors = [
+    [10, oscRgb(theme?.defaultFg, "theme.defaultFg")],
+    [11, oscRgb(theme?.defaultBg, "theme.defaultBg")],
+  ]
+  return colors.map(([slot, color]) =>
+    terminal.parser.registerOscHandler(slot, (data) => {
+      if (data !== "?") return false
+      reply(`\u001b]${slot};rgb:${color}\u001b\\`)
+      return true
+    }),
+  )
+}
+
 export async function ensureNodePtySpawnHelperExecutable(dependencies = {}) {
   if ((dependencies.platform ?? process.platform) === "win32") return
   const resolveModule = dependencies.resolveModule ?? ((name) => require.resolve(name))
@@ -257,6 +279,13 @@ export function createSidecarController(dependencies) {
       childAlive = false
       resolveChildExit()
     })
+    const forwardReply = (data) => {
+      if (childAlive) child.write(data)
+    }
+    if (typeof terminal.onData === "function" && typeof terminal.parser?.registerOscHandler === "function") {
+      terminal.onData(forwardReply)
+      registerDefaultColorHandlers(terminal, request.theme ?? DEFAULT_TERMINAL_THEME, forwardReply)
+    }
     child.onData((data) => {
       rawAnsi = `${rawAnsi}${data}`.slice(-1_048_576)
       writes = writes.then(() => new Promise((resolveWrite) => terminal.write(data, resolveWrite)))

--- a/packages/branding/scripts/puretui-pty-sidecar.mjs
+++ b/packages/branding/scripts/puretui-pty-sidecar.mjs
@@ -1,7 +1,11 @@
 import { spawn as spawnChild } from "node:child_process"
+import { chmod } from "node:fs/promises"
+import { createRequire } from "node:module"
 import { createInterface } from "node:readline"
 import { pathToFileURL } from "node:url"
-import { basename, join, resolve } from "node:path"
+import { basename, dirname, join, resolve } from "node:path"
+
+const require = createRequire(import.meta.url)
 
 const delay = (ms) => new Promise((resolveDelay) => setTimeout(resolveDelay, ms))
 
@@ -35,6 +39,7 @@ const isolatedEnvironment = (baseEnv, demoRoot) => {
     TERM: "xterm-256color",
     COLORTERM: "truecolor",
     TERM_PROGRAM: "kobe-capture",
+    KOBE_DEV: "1",
     KOBE_HOME_DIR: home,
     KOBE_SANDBOX_HOME_DIR: home,
     KOBE_DAEMON_WEB_PORT: baseEnv.KOBE_DAEMON_WEB_PORT ?? "5274",
@@ -66,7 +71,7 @@ export function encodeKey(key) {
   throw new Error(`unsupported replay key "${key}"`)
 }
 
-const defaultRunReset = (file, args, options) =>
+const defaultRunCommand = (file, args, options, description) =>
   new Promise((resolveReset, reject) => {
     const child = spawnChild(file, args, { ...options, stdio: ["ignore", "ignore", "pipe"] })
     let stderr = ""
@@ -76,9 +81,75 @@ const defaultRunReset = (file, args, options) =>
     child.once("error", reject)
     child.once("exit", (code, signal) => {
       if (code === 0) resolveReset()
-      else reject(new Error(`sandbox reset failed (${signal ?? code ?? "unknown"}): ${stderr.trim()}`))
+      else reject(new Error(`${description} failed (${signal ?? code ?? "unknown"}): ${stderr.trim()}`))
     })
   })
+
+const defaultRunSetup = (file, args, options) => defaultRunCommand(file, args, options, "capture setup")
+const defaultRunReset = (file, args, options) => defaultRunCommand(file, args, options, "sandbox reset")
+
+const rgbComponents = (color) => [(color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff]
+
+const cellStyle = (cell) => {
+  const codes = [0]
+  if (cell.isBold?.()) codes.push(1)
+  if (cell.isDim?.()) codes.push(2)
+  if (cell.isItalic?.()) codes.push(3)
+  if (cell.isUnderline?.()) codes.push(4)
+  if (cell.isBlink?.()) codes.push(5)
+  if (cell.isInverse?.()) codes.push(7)
+  if (cell.isInvisible?.()) codes.push(8)
+  if (cell.isStrikethrough?.()) codes.push(9)
+  if (cell.isFgRGB?.()) codes.push(38, 2, ...rgbComponents(cell.getFgColor()))
+  else if (cell.isFgPalette?.()) codes.push(38, 5, cell.getFgColor())
+  else if (!cell.isFgDefault?.()) codes.push(39)
+  if (cell.isBgRGB?.()) codes.push(48, 2, ...rgbComponents(cell.getBgColor()))
+  else if (cell.isBgPalette?.()) codes.push(48, 5, cell.getBgColor())
+  else if (!cell.isBgDefault?.()) codes.push(49)
+  return codes.join(";")
+}
+
+export function serializeXtermLine(line) {
+  if (!line) return ""
+  if (typeof line.getCell !== "function") return line.translateToString?.(true) ?? ""
+  const cells = []
+  let lastMeaningful = -1
+  for (let index = 0; index < line.length; index++) {
+    const cell = line.getCell(index)
+    if (!cell || cell.getWidth?.() === 0) continue
+    const chars = cell.getChars?.() || " "
+    const styled = cell.isAttributeDefault?.() === false
+    cells.push({ index, chars, styled, style: styled ? cellStyle(cell) : "0" })
+    if (chars !== " " || styled) lastMeaningful = index
+  }
+  if (lastMeaningful < 0) return ""
+  let result = ""
+  let style = "0"
+  for (const cell of cells) {
+    if (cell.index > lastMeaningful) break
+    if (cell.style !== style) {
+      result += `\u001b[${cell.style}m`
+      style = cell.style
+    }
+    result += cell.chars
+  }
+  if (style !== "0") result += "\u001b[0m"
+  return result
+}
+
+export async function ensureNodePtySpawnHelperExecutable(dependencies = {}) {
+  if ((dependencies.platform ?? process.platform) === "win32") return
+  const resolveModule = dependencies.resolveModule ?? ((name) => require.resolve(name))
+  const chmodFile = dependencies.chmodFile ?? chmod
+  const packageRoot = dirname(dirname(resolveModule("node-pty")))
+  const helper = join(
+    packageRoot,
+    "prebuilds",
+    `${dependencies.platform ?? process.platform}-${dependencies.arch ?? process.arch}`,
+    "spawn-helper",
+  )
+  await chmodFile(helper, 0o755)
+}
 
 const assertRequest = (request) => {
   if (!request || typeof request !== "object") throw new Error("sidecar request must be an object")
@@ -91,6 +162,7 @@ export function createSidecarController(dependencies) {
   const {
     spawnPty,
     createTerminal,
+    runSetup = defaultRunSetup,
     runReset = defaultRunReset,
     baseEnv = process.env,
     stopTimeoutMs = 5_000,
@@ -111,7 +183,7 @@ export function createSidecarController(dependencies) {
   const snapshotLines = async () => {
     await writes
     if (!terminal) return Array.from({ length: rows }, () => "")
-    return Array.from({ length: rows }, (_, row) => terminal.buffer.active.getLine(row)?.translateToString(true) ?? "")
+    return Array.from({ length: rows }, (_, row) => serializeXtermLine(terminal.buffer.active.getLine(row)))
   }
 
   const diagnostics = async (message) => ({
@@ -129,22 +201,52 @@ export function createSidecarController(dependencies) {
 
   const start = async (request) => {
     if (childAlive) throw new Error("PureTUI capture child is already running")
-    if (typeof request.repoRoot !== "string" || typeof request.demoRoot !== "string") {
-      throw new Error("start requires repoRoot and demoRoot")
+    if (
+      typeof request.repoRoot !== "string" ||
+      typeof request.demoRoot !== "string" ||
+      typeof request.fixtureRepo !== "string"
+    ) {
+      throw new Error("start requires repoRoot, demoRoot, and fixtureRepo")
     }
     if (!Number.isInteger(request.cols) || request.cols <= 0 || !Number.isInteger(request.rows) || request.rows <= 0) {
       throw new Error("start requires positive integer cols and rows")
     }
     demoRoot = resolve(request.demoRoot)
     rows = request.rows
-    kobeDir = join(resolve(request.repoRoot), "packages", "kobe")
+    const repoRoot = resolve(request.repoRoot)
+    const fixtureRepo = resolve(request.fixtureRepo)
+    kobeDir = join(repoRoot, "packages", "kobe")
+    const cliPath = join(kobeDir, "src", "cli", "index.ts")
     childEnv = isolatedEnvironment(baseEnv, demoRoot)
+    const seedTasks = request.seedTasks ?? []
+    if (!Array.isArray(seedTasks)) throw new Error("start seedTasks must be an array")
+    for (const task of seedTasks) {
+      if (!task || typeof task.title !== "string" || typeof task.status !== "string") {
+        throw new Error("start seedTasks entries require title and status")
+      }
+      await runSetup(
+        "bun",
+        [
+          "--conditions=browser",
+          cliPath,
+          "api",
+          "add",
+          "--repo",
+          fixtureRepo,
+          "--title",
+          task.title,
+          "--status",
+          task.status,
+        ],
+        { cwd: fixtureRepo, env: childEnv },
+      )
+    }
     terminal = createTerminal({ cols: request.cols, rows: request.rows })
-    child = spawnPty("bun", ["run", "dev:sandbox"], {
+    child = spawnPty("bun", ["--conditions=browser", cliPath], {
       name: "xterm-256color",
       cols: request.cols,
       rows: request.rows,
-      cwd: kobeDir,
+      cwd: fixtureRepo,
       env: childEnv,
     })
     childAlive = true
@@ -163,11 +265,18 @@ export function createSidecarController(dependencies) {
   }
 
   const stop = async () => {
-    if (!child) return { pid: undefined, demoRoot, snapshot: "" }
+    if (!child) {
+      if (childEnv && kobeDir) await runReset("bun", ["run", "dev:sandbox:reset"], { cwd: kobeDir, env: childEnv })
+      return { pid: undefined, demoRoot, snapshot: "" }
+    }
     if (childAlive) {
       child.write("\u0003")
       if (!(await waitForExit(stopTimeoutMs))) {
-        child.kill()
+        child.kill("SIGTERM")
+        await waitForExit(killTimeoutMs)
+      }
+      if (childAlive) {
+        child.kill("SIGKILL")
         await waitForExit(killTimeoutMs)
       }
     }
@@ -225,7 +334,13 @@ export function createSidecarController(dependencies) {
 }
 
 async function main() {
-  const [{ spawn }, { Terminal }] = await Promise.all([import("node-pty"), import("@xterm/headless")])
+  await ensureNodePtySpawnHelperExecutable()
+  const [ptyModule, headlessModule] = await Promise.all([import("node-pty"), import("@xterm/headless")])
+  const spawn = ptyModule.spawn ?? ptyModule.default?.spawn
+  const Terminal = headlessModule.Terminal ?? headlessModule.default?.Terminal
+  if (typeof spawn !== "function" || typeof Terminal !== "function") {
+    throw new Error("PureTUI sidecar could not load node-pty or @xterm/headless")
+  }
   const controller = createSidecarController({
     spawnPty: spawn,
     createTerminal: (options) => new Terminal({ ...options, allowProposedApi: true, scrollback: 0 }),
@@ -245,6 +360,7 @@ async function main() {
       process.stdout.write(`${JSON.stringify(await controller.handle(request))}\n`)
     })()
   })
+  input.on("close", () => process.exit(0))
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main()

--- a/packages/branding/scripts/puretui-pty-sidecar.mjs
+++ b/packages/branding/scripts/puretui-pty-sidecar.mjs
@@ -1,9 +1,9 @@
 import { spawn as spawnChild } from "node:child_process"
 import { chmod } from "node:fs/promises"
 import { createRequire } from "node:module"
+import { basename, dirname, join, resolve } from "node:path"
 import { createInterface } from "node:readline"
 import { pathToFileURL } from "node:url"
-import { basename, dirname, join, resolve } from "node:path"
 
 const require = createRequire(import.meta.url)
 
@@ -26,22 +26,23 @@ const inheritedEnvironment = (environment) =>
   )
 
 const isolatedEnvironment = (baseEnv, demoRoot) => {
-  const home = join(demoRoot, "home")
+  const kobeHome = join(demoRoot, "home")
+  const nativeHome = baseEnv.HOME ?? kobeHome
   return {
     ...inheritedEnvironment(baseEnv),
-    HOME: home,
-    USERPROFILE: home,
-    XDG_CONFIG_HOME: join(home, ".config"),
-    XDG_DATA_HOME: join(home, ".local", "share"),
-    XDG_STATE_HOME: join(home, ".local", "state"),
-    XDG_CACHE_HOME: join(home, ".cache"),
-    XDG_RUNTIME_DIR: join(home, ".runtime"),
+    HOME: nativeHome,
+    USERPROFILE: baseEnv.USERPROFILE ?? nativeHome,
+    XDG_CONFIG_HOME: join(kobeHome, ".config"),
+    XDG_DATA_HOME: join(kobeHome, ".local", "share"),
+    XDG_STATE_HOME: join(kobeHome, ".local", "state"),
+    XDG_CACHE_HOME: join(kobeHome, ".cache"),
+    XDG_RUNTIME_DIR: join(kobeHome, ".runtime"),
     TERM: "xterm-256color",
     COLORTERM: "truecolor",
     TERM_PROGRAM: "kobe-capture",
     KOBE_DEV: "1",
-    KOBE_HOME_DIR: home,
-    KOBE_SANDBOX_HOME_DIR: home,
+    KOBE_HOME_DIR: kobeHome,
+    KOBE_SANDBOX_HOME_DIR: kobeHome,
     KOBE_DAEMON_WEB_PORT: baseEnv.KOBE_DAEMON_WEB_PORT ?? "5274",
     KOBE_CAPTURE_HOST_LABEL: baseEnv.KOBE_CAPTURE_HOST_LABEL ?? "puretui-replay",
     KOBE_CAPTURE_SESSION_LABEL: baseEnv.KOBE_CAPTURE_SESSION_LABEL ?? basename(demoRoot),
@@ -250,6 +251,7 @@ export function createSidecarController(dependencies) {
       env: childEnv,
     })
     childAlive = true
+    // biome-ignore lint/suspicious/noAssignInExpressions: the promise executor captures its resolver
     childExited = new Promise((resolveExit) => (resolveChildExit = resolveExit))
     child.onExit(() => {
       childAlive = false
@@ -257,9 +259,7 @@ export function createSidecarController(dependencies) {
     })
     child.onData((data) => {
       rawAnsi = `${rawAnsi}${data}`.slice(-1_048_576)
-      writes = writes.then(
-        () => new Promise((resolveWrite) => terminal.write(data, resolveWrite)),
-      )
+      writes = writes.then(() => new Promise((resolveWrite) => terminal.write(data, resolveWrite)))
     })
     return { pid: child.pid, demoRoot, snapshot: "" }
   }

--- a/packages/branding/src/quicklook/QuickLookReplay.tsx
+++ b/packages/branding/src/quicklook/QuickLookReplay.tsx
@@ -8,12 +8,13 @@ loadFont("normal", { weights: ["400", "700"] })
 import { DEFAULT_TERMINAL_THEME, normalizeTerminalLine, renderTextPresentation, terminalThemeFrom, type TerminalLine } from "./ansi"
 import capture from "./frames.json"
 import replaySpecJson from "./quicklook.replay.json"
-import { resolveReplaySpec, type Region } from "./replay-spec"
+import { assertRenderableCapture, resolveReplaySpec, type Region } from "./replay-spec"
 
 // Replays a captured kobe TUI session (scripts/capture-tui.ts output) as the
 // landing-page quicklook video. UI iterates -> re-run capture -> re-render;
 // no manual screen recording.
 
+assertRenderableCapture(capture)
 const replaySpec = resolveReplaySpec(replaySpecJson, capture)
 const VIEW_W = replaySpec.viewport.width
 const VIEW_H = replaySpec.viewport.height

--- a/packages/branding/src/quicklook/capture-core.ts
+++ b/packages/branding/src/quicklook/capture-core.ts
@@ -72,14 +72,13 @@ const wait = async (
   await captureSnapshot(terminal, clock, startedAt, frames)
 }
 
-const sleep = async (
+const pause = async (
   ms: number,
   terminal: CaptureTerminal,
   clock: CaptureClock,
   startedAt: number,
   frames: CaptureFrame[],
 ) => {
-  if (ms <= 0) return
   await clock.sleep(ms)
   await captureSnapshot(terminal, clock, startedAt, frames)
 }
@@ -107,7 +106,9 @@ const typeText = async (
   for (const [index, character] of characters.entries()) {
     await terminal.type(character)
     await captureSnapshot(terminal, clock, startedAt, frames)
-    if (index < characters.length - 1 && msPerChar) await sleep(msPerChar, terminal, clock, startedAt, frames)
+    if (index < characters.length - 1 && msPerChar !== undefined) {
+      await pause(msPerChar, terminal, clock, startedAt, frames)
+    }
   }
 }
 
@@ -124,7 +125,7 @@ const runDismissRules = async (
     if (!lines.join("\n").includes(rule.includes)) continue
     for (const step of rule.steps) {
       if (step.action === "key") lines = await sendKey(step.key, terminal, clock, startedAt, frames)
-      if (step.action === "sleep") await sleep(step.ms, terminal, clock, startedAt, frames)
+      if (step.action === "sleep") await pause(step.ms, terminal, clock, startedAt, frames)
       if (step.action === "waitFor") await wait(spec, step.waitFor, terminal, clock, startedAt, frames)
     }
   }
@@ -143,14 +144,16 @@ const runCreateTask = async (
   if (flow.focusPaneBeforeOpen === "leftmost") await sendKey("C-h", terminal, clock, startedAt, frames)
   await sendKey(flow.openKey ?? "n", terminal, clock, startedAt, frames)
   await wait(spec, flow.dialogWait, terminal, clock, startedAt, frames)
-  await sleep(flow.dialogSettleMs ?? 0, terminal, clock, startedAt, frames)
+  if (flow.dialogSettleMs !== undefined) await pause(flow.dialogSettleMs, terminal, clock, startedAt, frames)
   if (engine === "codex" && flow.codexEngineCycleKey) {
     await sendKey(flow.codexEngineCycleKey, terminal, clock, startedAt, frames)
-    await sleep(flow.codexEngineSettleMs ?? 0, terminal, clock, startedAt, frames)
+    if (flow.codexEngineSettleMs !== undefined) {
+      await pause(flow.codexEngineSettleMs, terminal, clock, startedAt, frames)
+    }
   }
   for (let index = 0; index < (flow.tabCount ?? 0); index++) {
     await sendKey("Tab", terminal, clock, startedAt, frames)
-    await sleep(flow.tabDelayMs ?? 0, terminal, clock, startedAt, frames)
+    if (flow.tabDelayMs !== undefined) await pause(flow.tabDelayMs, terminal, clock, startedAt, frames)
   }
   await sendKey(flow.submitKey ?? "Enter", terminal, clock, startedAt, frames)
 }
@@ -168,24 +171,28 @@ export async function runReplayCapture(
   try {
     await terminal.start()
     await captureSnapshot(terminal, clock, startedAt, frames)
-    for (const beat of spec.beats) {
-      await sleep(Math.max(0, (beat.at - nominalAt) * 1000), terminal, clock, startedAt, frames)
+    const beats = spec.beats.map((beat, index) => ({ beat, index })).sort((left, right) => left.beat.at - right.beat.at || left.index - right.index)
+    for (const { beat } of beats) {
+      const delay = (beat.at - nominalAt) * 1000
+      if (delay > 0) await pause(delay, terminal, clock, startedAt, frames)
       nominalAt = beat.at
       if (beat.action === "key") await sendKey(beat.key ?? "", terminal, clock, startedAt, frames)
-      if (beat.action === "sleep") await sleep(beat.ms ?? 0, terminal, clock, startedAt, frames)
+      if (beat.action === "sleep") await pause(beat.ms ?? 0, terminal, clock, startedAt, frames)
       if (beat.action === "flow") await runCreateTask(spec, beat.engine, terminal, clock, startedAt, frames)
       if (beat.action === "typeText" || beat.action === "typeTextWhenReady") {
         if (beat.action === "typeTextWhenReady" && beat.waitFor) {
           await wait(spec, beat.waitFor, terminal, clock, startedAt, frames)
         }
-        await sleep(beat.settleMs ?? 0, terminal, clock, startedAt, frames)
+        if (beat.settleMs !== undefined) await pause(beat.settleMs, terminal, clock, startedAt, frames)
         const text = beat.text ?? (beat.textRef ? spec.text[beat.textRef] : undefined)
         if (text === undefined) throw new Error("replay text beat has no text")
         await typeText(text, beat.msPerChar, terminal, clock, startedAt, frames)
         const lines = frames.at(-1)?.lines.map((line) => (typeof line === "string" ? line : line.rawAnsi)) ?? []
         await runDismissRules(spec, beat.dismissIfText, lines, terminal, clock, startedAt, frames)
         if (beat.submit) {
-          await sleep(beat.submitDelayMs ?? 0, terminal, clock, startedAt, frames)
+          if (beat.submitDelayMs !== undefined) {
+            await pause(beat.submitDelayMs, terminal, clock, startedAt, frames)
+          }
           await sendKey("Enter", terminal, clock, startedAt, frames)
         }
       }

--- a/packages/branding/src/quicklook/capture-core.ts
+++ b/packages/branding/src/quicklook/capture-core.ts
@@ -1,0 +1,212 @@
+import { rename, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import type { CaptureFrame, CaptureLine, ResolvedReplaySpec } from "./replay-spec"
+
+export interface CaptureTerminal {
+  start(): Promise<void>
+  snapshot(): Promise<readonly string[]>
+  type(text: string): Promise<void>
+  key(key: string): Promise<void>
+  waitFor(pattern: string, timeoutMs: number): Promise<void>
+  stop(): Promise<void>
+}
+
+export interface CaptureClock {
+  now(): number
+  sleep(ms: number): Promise<void>
+}
+
+export interface CaptureDocument {
+  cols: number
+  rows: number
+  frames: CaptureFrame[]
+  meta: { theme?: unknown }
+}
+
+export interface CaptureOutput {
+  replaceAtomically(capture: CaptureDocument): Promise<void>
+}
+
+const framesMatch = (left: readonly CaptureLine[], right: readonly CaptureLine[]) =>
+  left.length === right.length && left.every((line, index) => JSON.stringify(line) === JSON.stringify(right[index]))
+
+const validateCapture = (capture: CaptureDocument) => {
+  if (!Number.isFinite(capture.cols) || capture.cols <= 0 || !Number.isFinite(capture.rows) || capture.rows <= 0) {
+    throw new Error("capture dimensions must be positive finite numbers")
+  }
+  if (capture.frames.length === 0) throw new Error("capture must contain at least one frame")
+  let previous = -Infinity
+  for (const frame of capture.frames) {
+    if (!Number.isFinite(frame.t) || frame.t < previous) throw new Error("capture frame timestamps must be finite and monotonic")
+    if (frame.lines.length !== capture.rows) throw new Error("capture frame line count must match rows")
+    previous = frame.t
+  }
+}
+
+const captureSnapshot = async (
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+): Promise<readonly string[]> => {
+  const lines = [...(await terminal.snapshot())]
+  const last = frames.at(-1)
+  if (!last || !framesMatch(last.lines, lines)) {
+    const elapsed = Math.max(last?.t ?? 0, (clock.now() - startedAt) / 1000)
+    frames.push({ t: frames.length === 0 ? 0 : elapsed, lines })
+  }
+  return lines
+}
+
+const wait = async (
+  spec: ResolvedReplaySpec,
+  name: string,
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+) => {
+  const entry = spec.waits[name]
+  if (!entry) throw new Error(`unknown replay wait "${name}"`)
+  await terminal.waitFor(entry.pattern, entry.timeoutMs)
+  await captureSnapshot(terminal, clock, startedAt, frames)
+}
+
+const sleep = async (
+  ms: number,
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+) => {
+  if (ms <= 0) return
+  await clock.sleep(ms)
+  await captureSnapshot(terminal, clock, startedAt, frames)
+}
+
+const sendKey = async (
+  key: string,
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+) => {
+  await terminal.key(key)
+  return captureSnapshot(terminal, clock, startedAt, frames)
+}
+
+const typeText = async (
+  text: string,
+  msPerChar: number | undefined,
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+) => {
+  const characters = [...text]
+  for (const [index, character] of characters.entries()) {
+    await terminal.type(character)
+    await captureSnapshot(terminal, clock, startedAt, frames)
+    if (index < characters.length - 1 && msPerChar) await sleep(msPerChar, terminal, clock, startedAt, frames)
+  }
+}
+
+const runDismissRules = async (
+  spec: ResolvedReplaySpec,
+  rules: ResolvedReplaySpec["beats"][number]["dismissIfText"],
+  lines: readonly string[],
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+) => {
+  for (const rule of rules ?? []) {
+    if (!lines.join("\n").includes(rule.includes)) continue
+    for (const step of rule.steps) {
+      if (step.action === "key") lines = await sendKey(step.key, terminal, clock, startedAt, frames)
+      if (step.action === "sleep") await sleep(step.ms, terminal, clock, startedAt, frames)
+      if (step.action === "waitFor") await wait(spec, step.waitFor, terminal, clock, startedAt, frames)
+    }
+  }
+}
+
+const runCreateTask = async (
+  spec: ResolvedReplaySpec,
+  engine: string | undefined,
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+) => {
+  const flow = spec.flows?.createTask
+  if (!flow) throw new Error("replay flow createTask is not configured")
+  if (flow.focusPaneBeforeOpen === "leftmost") await sendKey("C-h", terminal, clock, startedAt, frames)
+  await sendKey(flow.openKey ?? "n", terminal, clock, startedAt, frames)
+  await wait(spec, flow.dialogWait, terminal, clock, startedAt, frames)
+  await sleep(flow.dialogSettleMs ?? 0, terminal, clock, startedAt, frames)
+  if (engine === "codex" && flow.codexEngineCycleKey) {
+    await sendKey(flow.codexEngineCycleKey, terminal, clock, startedAt, frames)
+    await sleep(flow.codexEngineSettleMs ?? 0, terminal, clock, startedAt, frames)
+  }
+  for (let index = 0; index < (flow.tabCount ?? 0); index++) {
+    await sendKey("Tab", terminal, clock, startedAt, frames)
+    await sleep(flow.tabDelayMs ?? 0, terminal, clock, startedAt, frames)
+  }
+  await sendKey(flow.submitKey ?? "Enter", terminal, clock, startedAt, frames)
+}
+
+export async function runReplayCapture(
+  spec: ResolvedReplaySpec,
+  terminal: CaptureTerminal,
+  output: CaptureOutput,
+  clock: CaptureClock,
+): Promise<CaptureDocument> {
+  const frames: CaptureFrame[] = []
+  const startedAt = clock.now()
+  let nominalAt = 0
+
+  try {
+    await terminal.start()
+    await captureSnapshot(terminal, clock, startedAt, frames)
+    for (const beat of spec.beats) {
+      await sleep(Math.max(0, (beat.at - nominalAt) * 1000), terminal, clock, startedAt, frames)
+      nominalAt = beat.at
+      if (beat.action === "key") await sendKey(beat.key ?? "", terminal, clock, startedAt, frames)
+      if (beat.action === "sleep") await sleep(beat.ms ?? 0, terminal, clock, startedAt, frames)
+      if (beat.action === "flow") await runCreateTask(spec, beat.engine, terminal, clock, startedAt, frames)
+      if (beat.action === "typeText" || beat.action === "typeTextWhenReady") {
+        if (beat.action === "typeTextWhenReady" && beat.waitFor) {
+          await wait(spec, beat.waitFor, terminal, clock, startedAt, frames)
+        }
+        await sleep(beat.settleMs ?? 0, terminal, clock, startedAt, frames)
+        const text = beat.text ?? (beat.textRef ? spec.text[beat.textRef] : undefined)
+        if (text === undefined) throw new Error("replay text beat has no text")
+        await typeText(text, beat.msPerChar, terminal, clock, startedAt, frames)
+        const lines = frames.at(-1)?.lines.map((line) => (typeof line === "string" ? line : line.rawAnsi)) ?? []
+        await runDismissRules(spec, beat.dismissIfText, lines, terminal, clock, startedAt, frames)
+        if (beat.submit) {
+          await sleep(beat.submitDelayMs ?? 0, terminal, clock, startedAt, frames)
+          await sendKey("Enter", terminal, clock, startedAt, frames)
+        }
+      }
+    }
+    const document: CaptureDocument = {
+      cols: spec.viewport.cols,
+      rows: spec.viewport.rows,
+      frames,
+      meta: spec.theme === undefined ? {} : { theme: spec.theme },
+    }
+    validateCapture(document)
+    await output.replaceAtomically(document)
+    return document
+  } finally {
+    await terminal.stop()
+  }
+}
+
+export async function writeCaptureAtomically(path: string, capture: CaptureDocument): Promise<void> {
+  validateCapture(capture)
+  const temporary = join(dirname(path), `.${path.split("/").at(-1)}.${process.pid}.${Date.now()}.tmp`)
+  await writeFile(temporary, `${JSON.stringify(capture, null, 2)}\n`)
+  await rename(temporary, path)
+}

--- a/packages/branding/src/quicklook/capture-core.ts
+++ b/packages/branding/src/quicklook/capture-core.ts
@@ -35,9 +35,10 @@ const validateCapture = (capture: CaptureDocument) => {
     throw new Error("capture dimensions must be positive finite numbers")
   }
   if (capture.frames.length === 0) throw new Error("capture must contain at least one frame")
-  let previous = -Infinity
+  let previous = Number.NEGATIVE_INFINITY
   for (const frame of capture.frames) {
-    if (!Number.isFinite(frame.t) || frame.t < previous) throw new Error("capture frame timestamps must be finite and monotonic")
+    if (!Number.isFinite(frame.t) || frame.t < previous)
+      throw new Error("capture frame timestamps must be finite and monotonic")
     if (frame.lines.length !== capture.rows) throw new Error("capture frame line count must match rows")
     previous = frame.t
   }
@@ -139,10 +140,11 @@ const runDismissRules = async (
   startedAt: number,
   frames: CaptureFrame[],
 ) => {
+  let currentLines = lines
   for (const rule of rules ?? []) {
-    if (!lines.join("\n").includes(rule.includes)) continue
+    if (!currentLines.join("\n").includes(rule.includes)) continue
     for (const step of rule.steps) {
-      if (step.action === "key") lines = await sendKey(step.key, terminal, clock, startedAt, frames)
+      if (step.action === "key") currentLines = await sendKey(step.key, terminal, clock, startedAt, frames)
       if (step.action === "sleep") await pause(step.ms, terminal, clock, startedAt, frames)
       if (step.action === "waitFor") await wait(spec, step.waitFor, terminal, clock, startedAt, frames)
     }
@@ -189,13 +191,20 @@ export async function runReplayCapture(
   try {
     await terminal.start()
     await captureSnapshot(terminal, clock, startedAt, frames)
-    const beats = spec.beats.map((beat, index) => ({ beat, index })).sort((left, right) => left.beat.at - right.beat.at || left.index - right.index)
+    const beats = spec.beats
+      .map((beat, index) => ({ beat, index }))
+      .sort((left, right) => left.beat.at - right.beat.at || left.index - right.index)
     for (const { beat } of beats) {
       const delay = (beat.at - nominalAt) * 1000
       if (delay > 0) await pollTimeline(delay, spec.capture.fps, terminal, clock, startedAt, frames)
       nominalAt = beat.at
       if (beat.action === "key") await sendKey(beat.key ?? "", terminal, clock, startedAt, frames)
       if (beat.action === "sleep") await pause(beat.ms ?? 0, terminal, clock, startedAt, frames)
+      if (beat.action === "waitFor" && beat.waitFor) {
+        await wait(spec, beat.waitFor, terminal, clock, startedAt, frames)
+        const lines = frames.at(-1)?.lines.map((line) => (typeof line === "string" ? line : line.rawAnsi)) ?? []
+        await runDismissRules(spec, beat.dismissIfText, lines, terminal, clock, startedAt, frames)
+      }
       if (beat.action === "flow") await runCreateTask(spec, beat.engine, terminal, clock, startedAt, frames)
       if (beat.action === "typeText" || beat.action === "typeTextWhenReady") {
         if (beat.action === "typeTextWhenReady" && beat.waitFor) {

--- a/packages/branding/src/quicklook/capture-core.ts
+++ b/packages/branding/src/quicklook/capture-core.ts
@@ -83,6 +83,24 @@ const pause = async (
   await captureSnapshot(terminal, clock, startedAt, frames)
 }
 
+const pollTimeline = async (
+  ms: number,
+  fps: number,
+  terminal: CaptureTerminal,
+  clock: CaptureClock,
+  startedAt: number,
+  frames: CaptureFrame[],
+) => {
+  const interval = 1000 / fps
+  let remaining = ms
+  while (remaining > 0) {
+    const step = Math.min(interval, remaining)
+    await clock.sleep(step)
+    await captureSnapshot(terminal, clock, startedAt, frames)
+    remaining = remaining - step < 0.001 ? 0 : remaining - step
+  }
+}
+
 const sendKey = async (
   key: string,
   terminal: CaptureTerminal,
@@ -174,7 +192,7 @@ export async function runReplayCapture(
     const beats = spec.beats.map((beat, index) => ({ beat, index })).sort((left, right) => left.beat.at - right.beat.at || left.index - right.index)
     for (const { beat } of beats) {
       const delay = (beat.at - nominalAt) * 1000
-      if (delay > 0) await pause(delay, terminal, clock, startedAt, frames)
+      if (delay > 0) await pollTimeline(delay, spec.capture.fps, terminal, clock, startedAt, frames)
       nominalAt = beat.at
       if (beat.action === "key") await sendKey(beat.key ?? "", terminal, clock, startedAt, frames)
       if (beat.action === "sleep") await pause(beat.ms ?? 0, terminal, clock, startedAt, frames)
@@ -197,6 +215,8 @@ export async function runReplayCapture(
         }
       }
     }
+    const tail = (spec.capture.seconds - nominalAt) * 1000
+    if (tail > 0) await pollTimeline(tail, spec.capture.fps, terminal, clock, startedAt, frames)
     const document: CaptureDocument = {
       cols: spec.viewport.cols,
       rows: spec.viewport.rows,

--- a/packages/branding/src/quicklook/puretui-terminal.ts
+++ b/packages/branding/src/quicklook/puretui-terminal.ts
@@ -1,6 +1,7 @@
 import { chmod, mkdir } from "node:fs/promises"
 import { basename, join, resolve } from "node:path"
 import type { CaptureTerminal } from "./capture-core"
+import type { SeedTask } from "./replay-spec"
 
 export type SidecarSpawnOptions = {
   file: string
@@ -22,6 +23,8 @@ export type SidecarFactory = (options: SidecarSpawnOptions) => SidecarProcess
 export type PureTuiCaptureOptions = {
   repoRoot: string
   demoRoot: string
+  fixtureRepo: string
+  seedTasks?: readonly SeedTask[]
   cols: number
   rows: number
   protocolTimeoutMs?: number
@@ -226,7 +229,10 @@ export class PureTuiTerminal implements CaptureTerminal {
 
   constructor(
     private readonly client: JsonLineSidecarClient,
-    private readonly options: Pick<PureTuiCaptureOptions, "repoRoot" | "demoRoot" | "cols" | "rows">,
+    private readonly options: Pick<
+      PureTuiCaptureOptions,
+      "repoRoot" | "demoRoot" | "fixtureRepo" | "seedTasks" | "cols" | "rows"
+    >,
   ) {}
 
   async start() {
@@ -265,6 +271,7 @@ export async function createPureTuiCapture(options: PureTuiCaptureOptions): Prom
 }> {
   const repoRoot = resolve(options.repoRoot)
   const demoRoot = resolve(options.demoRoot)
+  const fixtureRepo = resolve(options.fixtureRepo)
   const env = captureEnvironment(demoRoot)
   await Promise.all(
     [demoRoot, env.HOME, env.XDG_CONFIG_HOME, env.XDG_DATA_HOME, env.XDG_STATE_HOME, env.XDG_CACHE_HOME, env.XDG_RUNTIME_DIR].map(
@@ -281,7 +288,7 @@ export async function createPureTuiCapture(options: PureTuiCaptureOptions): Prom
   })
   const diagnostics: Diagnostics = { snapshot: "", demoRoot }
   const client = new JsonLineSidecarClient(process, options.protocolTimeoutMs ?? 30_000, diagnostics)
-  const terminal = new PureTuiTerminal(client, { ...options, repoRoot, demoRoot })
+  const terminal = new PureTuiTerminal(client, { ...options, repoRoot, demoRoot, fixtureRepo })
   let cleaned = false
   return {
     terminal,

--- a/packages/branding/src/quicklook/puretui-terminal.ts
+++ b/packages/branding/src/quicklook/puretui-terminal.ts
@@ -1,0 +1,313 @@
+import { chmod, mkdir } from "node:fs/promises"
+import { basename, join, resolve } from "node:path"
+import type { CaptureTerminal } from "./capture-core"
+
+export type SidecarSpawnOptions = {
+  file: string
+  args: string[]
+  cwd: string
+  env: Record<string, string>
+}
+
+export interface SidecarProcess {
+  stdin: { write(chunk: string | Uint8Array): void; end(): void }
+  stdout: ReadableStream<Uint8Array>
+  stderr: ReadableStream<Uint8Array>
+  exited: Promise<number>
+  kill(signal?: number | NodeJS.Signals): void
+}
+
+export type SidecarFactory = (options: SidecarSpawnOptions) => SidecarProcess
+
+export type PureTuiCaptureOptions = {
+  repoRoot: string
+  demoRoot: string
+  cols: number
+  rows: number
+  protocolTimeoutMs?: number
+  sidecarExitTimeoutMs?: number
+  sidecarPath?: string
+  sidecarFactory?: SidecarFactory
+}
+
+type SidecarError = { message: string; snapshot?: string; pid?: number; demoRoot?: string }
+type SidecarResponse = { id: number; ok: true; value: unknown } | { id: number; ok: false; error: SidecarError }
+type PendingRequest = {
+  resolve(value: unknown): void
+  reject(error: Error): void
+  timeout: ReturnType<typeof setTimeout>
+}
+
+type Diagnostics = { snapshot: string; pid?: number; demoRoot: string }
+
+const inheritedEnvironment = (): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([key, value]) =>
+        value !== undefined &&
+        !key.startsWith("KOBE_") &&
+        key !== "HOME" &&
+        key !== "USERPROFILE" &&
+        !key.startsWith("XDG_") &&
+        key !== "TERM" &&
+        key !== "TERM_PROGRAM" &&
+        key !== "TERM_PROGRAM_VERSION" &&
+        key !== "COLORTERM",
+    ),
+  ) as Record<string, string>
+
+const capturePort = (demoRoot: string): string => {
+  let hash = 2166136261
+  for (const char of demoRoot) hash = Math.imul(hash ^ char.charCodeAt(0), 16777619) >>> 0
+  return String(30_000 + (hash % 15_000))
+}
+
+const captureEnvironment = (demoRoot: string): Record<string, string> => {
+  const home = join(demoRoot, "home")
+  return {
+    ...inheritedEnvironment(),
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    XDG_DATA_HOME: join(home, ".local", "share"),
+    XDG_STATE_HOME: join(home, ".local", "state"),
+    XDG_CACHE_HOME: join(home, ".cache"),
+    XDG_RUNTIME_DIR: join(home, ".runtime"),
+    TERM: "xterm-256color",
+    COLORTERM: "truecolor",
+    TERM_PROGRAM: "kobe-capture",
+    KOBE_HOME_DIR: home,
+    KOBE_SANDBOX_HOME_DIR: home,
+    KOBE_DAEMON_WEB_PORT: capturePort(demoRoot),
+    KOBE_CAPTURE_HOST_LABEL: "puretui-replay",
+    KOBE_CAPTURE_SESSION_LABEL: basename(demoRoot),
+  }
+}
+
+const defaultSidecarFactory: SidecarFactory = ({ file, args, cwd, env }) => {
+  const child = Bun.spawn([file, ...args], {
+    cwd,
+    env,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  return {
+    stdin: {
+      write: (chunk) => child.stdin.write(chunk),
+      end: () => child.stdin.end(),
+    },
+    stdout: child.stdout,
+    stderr: child.stderr,
+    exited: child.exited,
+    kill: (signal) => child.kill(signal),
+  }
+}
+
+const formatDiagnostics = (message: string, diagnostics: Diagnostics): Error =>
+  new Error(
+    [
+      message,
+      `child pid: ${diagnostics.pid ?? "not started"}`,
+      `demo root: ${diagnostics.demoRoot}`,
+      `latest ANSI snapshot:\n${diagnostics.snapshot || "<empty>"}`,
+    ].join("\n"),
+  )
+
+const updateDiagnostics = (diagnostics: Diagnostics, value: unknown) => {
+  if (!value || typeof value !== "object") return
+  const record = value as Record<string, unknown>
+  if (typeof record.pid === "number") diagnostics.pid = record.pid
+  if (typeof record.demoRoot === "string") diagnostics.demoRoot = record.demoRoot
+  if (typeof record.snapshot === "string") diagnostics.snapshot = record.snapshot
+  if (Array.isArray(value) && value.every((line) => typeof line === "string")) diagnostics.snapshot = value.join("\n")
+}
+
+class JsonLineSidecarClient {
+  private id = 0
+  private readonly pending = new Map<number, PendingRequest>()
+  private stderr = ""
+
+  constructor(
+    private readonly process: SidecarProcess,
+    private readonly timeoutMs: number,
+    private readonly diagnostics: Diagnostics,
+  ) {
+    void this.readResponses()
+    void this.readStderr()
+    void process.exited.then((code) => {
+      if (this.pending.size === 0) return
+      this.failAll(formatDiagnostics(`PureTUI sidecar exited with code ${code}${this.stderr ? `: ${this.stderr}` : ""}`, diagnostics))
+    })
+  }
+
+  async request(op: string, fields: Record<string, unknown> = {}, timeoutMs = this.timeoutMs): Promise<unknown> {
+    const id = ++this.id
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id)
+        reject(formatDiagnostics(`PureTUI sidecar ${op} request timed out after ${timeoutMs}ms`, this.diagnostics))
+      }, timeoutMs)
+      this.pending.set(id, { resolve, reject, timeout })
+    })
+    this.process.stdin.write(`${JSON.stringify({ id, op, ...fields })}\n`)
+    return promise
+  }
+
+  closeInput() {
+    this.process.stdin.end()
+  }
+
+  private async readResponses() {
+    await this.readLines(this.process.stdout, (line) => {
+      let response: SidecarResponse
+      try {
+        response = JSON.parse(line) as SidecarResponse
+      } catch {
+        this.failAll(formatDiagnostics(`PureTUI sidecar emitted invalid JSON: ${line}`, this.diagnostics))
+        return
+      }
+      const pending = this.pending.get(response.id)
+      if (!pending) return
+      clearTimeout(pending.timeout)
+      this.pending.delete(response.id)
+      if (response.ok) {
+        updateDiagnostics(this.diagnostics, response.value)
+        pending.resolve(response.value)
+        return
+      }
+      updateDiagnostics(this.diagnostics, response.error)
+      pending.reject(
+        formatDiagnostics(response.error.message, {
+          snapshot: response.error.snapshot ?? this.diagnostics.snapshot,
+          pid: response.error.pid ?? this.diagnostics.pid,
+          demoRoot: response.error.demoRoot ?? this.diagnostics.demoRoot,
+        }),
+      )
+    })
+  }
+
+  private async readStderr() {
+    await this.readLines(this.process.stderr, (line) => {
+      this.stderr = `${this.stderr}\n${line}`.trim().slice(-8_192)
+    })
+  }
+
+  private async readLines(stream: ReadableStream<Uint8Array>, consume: (line: string) => void) {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    let buffered = ""
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffered += decoder.decode(value, { stream: true })
+      for (;;) {
+        const newline = buffered.indexOf("\n")
+        if (newline < 0) break
+        const line = buffered.slice(0, newline).trim()
+        buffered = buffered.slice(newline + 1)
+        if (line) consume(line)
+      }
+    }
+  }
+
+  private failAll(error: Error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout)
+      pending.reject(error)
+    }
+    this.pending.clear()
+  }
+}
+
+export class PureTuiTerminal implements CaptureTerminal {
+  private started = false
+  private stopped = false
+
+  constructor(
+    private readonly client: JsonLineSidecarClient,
+    private readonly options: Pick<PureTuiCaptureOptions, "repoRoot" | "demoRoot" | "cols" | "rows">,
+  ) {}
+
+  async start() {
+    if (this.started) return
+    await this.client.request("start", this.options)
+    this.started = true
+  }
+
+  async snapshot(): Promise<readonly string[]> {
+    return (await this.client.request("snapshot")) as string[]
+  }
+
+  async type(text: string) {
+    await this.client.request("type", { text })
+  }
+
+  async key(key: string) {
+    await this.client.request("key", { key })
+  }
+
+  async waitFor(pattern: string, timeoutMs: number) {
+    await this.client.request("waitFor", { pattern, timeoutMs }, timeoutMs + this.options.rows * 10 + 1_000)
+  }
+
+  async stop() {
+    if (this.stopped) return
+    await this.client.request("stop")
+    this.stopped = true
+  }
+}
+
+export async function createPureTuiCapture(options: PureTuiCaptureOptions): Promise<{
+  terminal: CaptureTerminal
+  cleanup(): Promise<void>
+  demoRoot: string
+}> {
+  const repoRoot = resolve(options.repoRoot)
+  const demoRoot = resolve(options.demoRoot)
+  const env = captureEnvironment(demoRoot)
+  await Promise.all(
+    [demoRoot, env.HOME, env.XDG_CONFIG_HOME, env.XDG_DATA_HOME, env.XDG_STATE_HOME, env.XDG_CACHE_HOME, env.XDG_RUNTIME_DIR].map(
+      (path) => mkdir(path, { recursive: true }),
+    ),
+  )
+  await chmod(env.XDG_RUNTIME_DIR, 0o700)
+  const sidecarPath = options.sidecarPath ?? join(import.meta.dirname, "../../scripts/puretui-pty-sidecar.mjs")
+  const process = (options.sidecarFactory ?? defaultSidecarFactory)({
+    file: "node",
+    args: [sidecarPath],
+    cwd: repoRoot,
+    env,
+  })
+  const diagnostics: Diagnostics = { snapshot: "", demoRoot }
+  const client = new JsonLineSidecarClient(process, options.protocolTimeoutMs ?? 30_000, diagnostics)
+  const terminal = new PureTuiTerminal(client, { ...options, repoRoot, demoRoot })
+  let cleaned = false
+  return {
+    terminal,
+    demoRoot,
+    cleanup: async () => {
+      if (cleaned) return
+      cleaned = true
+      let failure: unknown
+      try {
+        await terminal.stop()
+      } catch (error) {
+        failure = error
+      }
+      client.closeInput()
+      let code = await Promise.race([
+        process.exited,
+        new Promise<undefined>((resolveTimeout) =>
+          setTimeout(resolveTimeout, options.sidecarExitTimeoutMs ?? 2_000),
+        ),
+      ])
+      if (code === undefined) {
+        process.kill("SIGTERM")
+        code = await process.exited
+      }
+      if (failure) throw failure
+      if (code !== 0) throw formatDiagnostics(`PureTUI sidecar exited with code ${code}`, diagnostics)
+    },
+  }
+}

--- a/packages/branding/src/quicklook/puretui-terminal.ts
+++ b/packages/branding/src/quicklook/puretui-terminal.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir } from "node:fs/promises"
 import { homedir } from "node:os"
 import { basename, join, resolve } from "node:path"
 import type { CaptureTerminal } from "./capture-core"
+import { DEFAULT_TERMINAL_THEME, type TerminalTheme } from "./ansi"
 import type { SeedTask } from "./replay-spec"
 
 export type SidecarSpawnOptions = {
@@ -30,6 +31,7 @@ export type PureTuiCaptureOptions = {
   readyTimeoutMs?: number
   cols: number
   rows: number
+  theme?: Pick<TerminalTheme, "defaultFg" | "defaultBg">
   protocolTimeoutMs?: number
   sidecarExitTimeoutMs?: number
   sidecarPath?: string
@@ -241,7 +243,15 @@ export class PureTuiTerminal implements CaptureTerminal {
     private readonly client: JsonLineSidecarClient,
     private readonly options: Pick<
       PureTuiCaptureOptions,
-      "repoRoot" | "demoRoot" | "fixtureRepo" | "seedTasks" | "readyPattern" | "readyTimeoutMs" | "cols" | "rows"
+      | "repoRoot"
+      | "demoRoot"
+      | "fixtureRepo"
+      | "seedTasks"
+      | "readyPattern"
+      | "readyTimeoutMs"
+      | "cols"
+      | "rows"
+      | "theme"
     >,
   ) {}
 
@@ -308,7 +318,16 @@ export async function createPureTuiCapture(options: PureTuiCaptureOptions): Prom
   })
   const diagnostics: Diagnostics = { snapshot: "", demoRoot }
   const client = new JsonLineSidecarClient(process, options.protocolTimeoutMs ?? 30_000, diagnostics)
-  const terminal = new PureTuiTerminal(client, { ...options, repoRoot, demoRoot, fixtureRepo })
+  const terminal = new PureTuiTerminal(client, {
+    ...options,
+    repoRoot,
+    demoRoot,
+    fixtureRepo,
+    theme: options.theme ?? {
+      defaultFg: DEFAULT_TERMINAL_THEME.defaultFg,
+      defaultBg: DEFAULT_TERMINAL_THEME.defaultBg,
+    },
+  })
   let cleaned = false
   return {
     terminal,

--- a/packages/branding/src/quicklook/puretui-terminal.ts
+++ b/packages/branding/src/quicklook/puretui-terminal.ts
@@ -1,4 +1,5 @@
 import { chmod, mkdir } from "node:fs/promises"
+import { homedir } from "node:os"
 import { basename, join, resolve } from "node:path"
 import type { CaptureTerminal } from "./capture-core"
 import type { SeedTask } from "./replay-spec"
@@ -25,7 +26,6 @@ export type PureTuiCaptureOptions = {
   demoRoot: string
   fixtureRepo: string
   seedTasks?: readonly SeedTask[]
-  pathPrefix?: string
   readyPattern?: string
   readyTimeoutMs?: number
   cols: number
@@ -68,24 +68,24 @@ const capturePort = (demoRoot: string): string => {
   return String(30_000 + (hash % 15_000))
 }
 
-const captureEnvironment = (demoRoot: string, pathPrefix?: string): Record<string, string> => {
-  const home = join(demoRoot, "home")
+const captureEnvironment = (demoRoot: string): Record<string, string> => {
+  const kobeHome = join(demoRoot, "home")
   const inherited = inheritedEnvironment()
   return {
     ...inherited,
-    PATH: pathPrefix ? `${resolve(pathPrefix)}:${inherited.PATH ?? ""}` : (inherited.PATH ?? ""),
-    HOME: home,
-    USERPROFILE: home,
-    XDG_CONFIG_HOME: join(home, ".config"),
-    XDG_DATA_HOME: join(home, ".local", "share"),
-    XDG_STATE_HOME: join(home, ".local", "state"),
-    XDG_CACHE_HOME: join(home, ".cache"),
-    XDG_RUNTIME_DIR: join(home, ".runtime"),
+    PATH: inherited.PATH ?? "",
+    HOME: homedir(),
+    USERPROFILE: homedir(),
+    XDG_CONFIG_HOME: join(kobeHome, ".config"),
+    XDG_DATA_HOME: join(kobeHome, ".local", "share"),
+    XDG_STATE_HOME: join(kobeHome, ".local", "state"),
+    XDG_CACHE_HOME: join(kobeHome, ".cache"),
+    XDG_RUNTIME_DIR: join(kobeHome, ".runtime"),
     TERM: "xterm-256color",
     COLORTERM: "truecolor",
     TERM_PROGRAM: "kobe-capture",
-    KOBE_HOME_DIR: home,
-    KOBE_SANDBOX_HOME_DIR: home,
+    KOBE_HOME_DIR: kobeHome,
+    KOBE_SANDBOX_HOME_DIR: kobeHome,
     KOBE_DAEMON_WEB_PORT: capturePort(demoRoot),
     KOBE_CAPTURE_HOST_LABEL: "puretui-replay",
     KOBE_CAPTURE_SESSION_LABEL: basename(demoRoot),
@@ -145,7 +145,12 @@ class JsonLineSidecarClient {
     void this.readStderr()
     void process.exited.then((code) => {
       if (this.pending.size === 0) return
-      this.failAll(formatDiagnostics(`PureTUI sidecar exited with code ${code}${this.stderr ? `: ${this.stderr}` : ""}`, diagnostics))
+      this.failAll(
+        formatDiagnostics(
+          `PureTUI sidecar exited with code ${code}${this.stderr ? `: ${this.stderr}` : ""}`,
+          diagnostics,
+        ),
+      )
     })
   }
 
@@ -281,11 +286,17 @@ export async function createPureTuiCapture(options: PureTuiCaptureOptions): Prom
   const repoRoot = resolve(options.repoRoot)
   const demoRoot = resolve(options.demoRoot)
   const fixtureRepo = resolve(options.fixtureRepo)
-  const env = captureEnvironment(demoRoot, options.pathPrefix)
+  const env = captureEnvironment(demoRoot)
   await Promise.all(
-    [demoRoot, env.HOME, env.XDG_CONFIG_HOME, env.XDG_DATA_HOME, env.XDG_STATE_HOME, env.XDG_CACHE_HOME, env.XDG_RUNTIME_DIR].map(
-      (path) => mkdir(path, { recursive: true }),
-    ),
+    [
+      demoRoot,
+      env.HOME,
+      env.XDG_CONFIG_HOME,
+      env.XDG_DATA_HOME,
+      env.XDG_STATE_HOME,
+      env.XDG_CACHE_HOME,
+      env.XDG_RUNTIME_DIR,
+    ].map((path) => mkdir(path, { recursive: true })),
   )
   await chmod(env.XDG_RUNTIME_DIR, 0o700)
   const sidecarPath = options.sidecarPath ?? join(import.meta.dirname, "../../scripts/puretui-pty-sidecar.mjs")
@@ -314,9 +325,7 @@ export async function createPureTuiCapture(options: PureTuiCaptureOptions): Prom
       client.closeInput()
       let code = await Promise.race([
         process.exited,
-        new Promise<undefined>((resolveTimeout) =>
-          setTimeout(resolveTimeout, options.sidecarExitTimeoutMs ?? 2_000),
-        ),
+        new Promise<undefined>((resolveTimeout) => setTimeout(resolveTimeout, options.sidecarExitTimeoutMs ?? 2_000)),
       ])
       if (code === undefined) {
         process.kill("SIGTERM")

--- a/packages/branding/src/quicklook/puretui-terminal.ts
+++ b/packages/branding/src/quicklook/puretui-terminal.ts
@@ -25,6 +25,9 @@ export type PureTuiCaptureOptions = {
   demoRoot: string
   fixtureRepo: string
   seedTasks?: readonly SeedTask[]
+  pathPrefix?: string
+  readyPattern?: string
+  readyTimeoutMs?: number
   cols: number
   rows: number
   protocolTimeoutMs?: number
@@ -65,10 +68,12 @@ const capturePort = (demoRoot: string): string => {
   return String(30_000 + (hash % 15_000))
 }
 
-const captureEnvironment = (demoRoot: string): Record<string, string> => {
+const captureEnvironment = (demoRoot: string, pathPrefix?: string): Record<string, string> => {
   const home = join(demoRoot, "home")
+  const inherited = inheritedEnvironment()
   return {
-    ...inheritedEnvironment(),
+    ...inherited,
+    PATH: pathPrefix ? `${resolve(pathPrefix)}:${inherited.PATH ?? ""}` : (inherited.PATH ?? ""),
     HOME: home,
     USERPROFILE: home,
     XDG_CONFIG_HOME: join(home, ".config"),
@@ -231,13 +236,17 @@ export class PureTuiTerminal implements CaptureTerminal {
     private readonly client: JsonLineSidecarClient,
     private readonly options: Pick<
       PureTuiCaptureOptions,
-      "repoRoot" | "demoRoot" | "fixtureRepo" | "seedTasks" | "cols" | "rows"
+      "repoRoot" | "demoRoot" | "fixtureRepo" | "seedTasks" | "readyPattern" | "readyTimeoutMs" | "cols" | "rows"
     >,
   ) {}
 
   async start() {
     if (this.started) return
     await this.client.request("start", this.options)
+    if (this.options.readyPattern) {
+      const timeoutMs = this.options.readyTimeoutMs ?? 30_000
+      await this.client.request("waitFor", { pattern: this.options.readyPattern, timeoutMs }, timeoutMs + 1_000)
+    }
     this.started = true
   }
 
@@ -272,7 +281,7 @@ export async function createPureTuiCapture(options: PureTuiCaptureOptions): Prom
   const repoRoot = resolve(options.repoRoot)
   const demoRoot = resolve(options.demoRoot)
   const fixtureRepo = resolve(options.fixtureRepo)
-  const env = captureEnvironment(demoRoot)
+  const env = captureEnvironment(demoRoot, options.pathPrefix)
   await Promise.all(
     [demoRoot, env.HOME, env.XDG_CONFIG_HOME, env.XDG_DATA_HOME, env.XDG_STATE_HOME, env.XDG_CACHE_HOME, env.XDG_RUNTIME_DIR].map(
       (path) => mkdir(path, { recursive: true }),

--- a/packages/branding/src/quicklook/puretui-terminal.ts
+++ b/packages/branding/src/quicklook/puretui-terminal.ts
@@ -60,7 +60,8 @@ const inheritedEnvironment = (): Record<string, string> =>
         key !== "TERM" &&
         key !== "TERM_PROGRAM" &&
         key !== "TERM_PROGRAM_VERSION" &&
-        key !== "COLORTERM",
+        key !== "COLORTERM" &&
+        key !== "NO_COLOR",
     ),
   ) as Record<string, string>
 
@@ -70,7 +71,7 @@ const capturePort = (demoRoot: string): string => {
   return String(30_000 + (hash % 15_000))
 }
 
-const captureEnvironment = (demoRoot: string): Record<string, string> => {
+export const captureEnvironment = (demoRoot: string): Record<string, string> => {
   const kobeHome = join(demoRoot, "home")
   const inherited = inheritedEnvironment()
   return {

--- a/packages/branding/src/quicklook/quicklook.replay.json
+++ b/packages/branding/src/quicklook/quicklook.replay.json
@@ -8,17 +8,15 @@
   },
   "capture": {
     "fps": 10,
-    "seconds": 120,
+    "seconds": 50,
     "output": "src/quicklook/frames.json",
-    "home": ".capture-home-5",
-    "repoDefault": "/Users/jacksonc/i/kobe",
-    "shellPrompt": "jackson@kobe:~/i/kobe$ ",
-    "socket": "kobe-capture",
-    "innerSocket": "kobe-capture-inner",
-    "session": "quicklook",
-    "warmupSeconds": 50
+    "home": ".capture-home-puretui",
+    "repoDefault": "fixture-repo",
+    "shellPrompt": ""
   },
   "setup": {
+    "fixtureEngines": true,
+    "readyWait": "workspaceReady",
     "seedTasks": [
       {
         "title": "fix flaky turn-detector test",
@@ -27,28 +25,30 @@
     ]
   },
   "waits": {
+    "workspaceReady": {
+      "pattern": "KOBE",
+      "timeoutMs": 15000
+    },
     "newTaskDialog": {
       "pattern": "New task",
       "timeoutMs": 8000
     },
+    "claudeComposerReady": {
+      "pattern": "›",
+      "timeoutMs": 20000
+    },
     "codexComposerReady": {
       "pattern": "›",
       "timeoutMs": 30000
-    },
-    "codexComposerAfterTrust": {
-      "pattern": "›",
-      "timeoutMs": 20000
     }
   },
   "text": {
-    "shellCommand": "kobe",
     "claudePrompt": "Explain what packages/kobe/src/cli/api-cmd.ts does in three short bullets. Read-only.",
     "codexPrompt": "Summarize the purpose of packages/branding in two sentences. Read-only."
   },
   "flows": {
     "createTask": {
       "openKey": "n",
-      "focusPaneBeforeOpen": "leftmost",
       "dialogWait": "newTaskDialog",
       "dialogSettleMs": 1500,
       "codexEngineCycleKey": "C-e",
@@ -60,134 +60,57 @@
   },
   "beats": [
     {
-      "at": 1,
-      "action": "typeText",
-      "textRef": "shellCommand",
-      "msPerChar": 160
-    },
-    {
-      "at": 2.2,
-      "action": "key",
-      "key": "Enter"
-    },
-    {
-      "at": 7,
-      "action": "key",
-      "key": "C-h"
-    },
-    {
-      "at": 8,
+      "at": 3,
       "action": "flow",
       "flow": "createTask",
       "engine": "claude"
     },
     {
-      "at": 32,
-      "action": "typeText",
+      "at": 14,
+      "action": "typeTextWhenReady",
+      "waitFor": "claudeComposerReady",
       "textRef": "claudePrompt",
       "msPerChar": 45,
+      "settleMs": 500,
       "submit": true,
-      "submitDelayMs": 500,
-      "dismissIfText": [
-        {
-          "includes": "Claude in Chrome extension detected",
-          "steps": [
-            {
-              "action": "key",
-              "key": "Escape"
-            },
-            {
-              "action": "sleep",
-              "ms": 800
-            }
-          ]
-        }
-      ]
+      "submitDelayMs": 500
     },
     {
-      "at": 60,
+      "at": 25.8,
       "action": "key",
-      "key": "C-h"
+      "key": "C-q"
     },
     {
-      "at": 61,
+      "at": 26,
       "action": "flow",
       "flow": "createTask",
       "engine": "codex"
     },
     {
-      "at": 86,
+      "at": 38,
       "action": "typeTextWhenReady",
       "waitFor": "codexComposerReady",
       "textRef": "codexPrompt",
       "msPerChar": 45,
-      "settleMs": 1200,
+      "settleMs": 500,
       "submit": true,
-      "submitDelayMs": 500,
-      "dismissIfText": [
-        {
-          "includes": "Update available!",
-          "steps": [
-            {
-              "action": "key",
-              "key": "Down"
-            },
-            {
-              "action": "sleep",
-              "ms": 400
-            },
-            {
-              "action": "key",
-              "key": "Enter"
-            },
-            {
-              "action": "sleep",
-              "ms": 1500
-            }
-          ]
-        },
-        {
-          "includes": "Hooks need review",
-          "steps": [
-            {
-              "action": "key",
-              "key": "Down"
-            },
-            {
-              "action": "sleep",
-              "ms": 600
-            },
-            {
-              "action": "key",
-              "key": "Enter"
-            },
-            {
-              "action": "sleep",
-              "ms": 1500
-            },
-            {
-              "action": "waitFor",
-              "waitFor": "codexComposerAfterTrust"
-            }
-          ]
-        }
-      ]
+      "submitDelayMs": 500
     }
   ],
   "regions": {
     "chat": {
       "c0": 33,
-      "c1": 107,
-      "r0": 3,
-      "r1": 36,
-      "hash": "rg_0clck2w"
+      "c1": 125,
+      "r0": 1,
+      "r1": 43,
+      "hash": "rg_1ctg642"
     },
     "agent": {
       "c0": 33,
-      "c1": 107,
-      "r0": 11,
-      "r1": 36,
-      "hash": "rg_1swli1i"
+      "c1": 125,
+      "r0": 1,
+      "r1": 43,
+      "hash": "rg_1xlx0jz"
     },
     "dialog": {
       "c0": 30,
@@ -198,89 +121,68 @@
     },
     "input": {
       "c0": 33,
-      "c1": 110,
-      "r0": 37,
-      "r1": 44,
-      "hash": "rg_01d9era"
+      "c1": 125,
+      "r0": 1,
+      "r1": 43,
+      "hash": "rg_0uquako"
     },
     "inputCodex": {
       "c0": 33,
-      "c1": 110,
-      "r0": 22,
-      "r1": 40,
-      "hash": "rg_1kdxvrj"
+      "c1": 125,
+      "r0": 1,
+      "r1": 43,
+      "hash": "rg_0dmy2o9"
     }
   },
   "stages": [
     {
-      "name": "shell",
-      "from": 0,
-      "to": 2.7,
-      "region": "full"
-    },
-    {
       "name": "boot",
-      "from": 2.7,
-      "to": 8
+      "from": 0,
+      "to": 3
     },
     {
       "name": "dialog",
-      "from": 8,
-      "to": 15,
+      "from": 3,
+      "to": 8,
       "region": "dialog"
     },
     {
       "name": "engine-boot",
-      "from": 15,
-      "to": 31
+      "from": 8,
+      "to": 14
     },
     {
       "name": "type-prompt",
-      "from": 31,
-      "to": 39,
+      "from": 14,
+      "to": 21,
       "region": "input"
     },
     {
-      "name": "prompt-wide",
-      "from": 39,
-      "to": 40
-    },
-    {
       "name": "agent",
-      "from": 40,
-      "to": 60,
+      "from": 21,
+      "to": 26,
       "region": "agent"
     },
     {
-      "name": "agent-wide",
-      "from": 60,
-      "to": 61
-    },
-    {
       "name": "dialog-codex",
-      "from": 61,
-      "to": 68,
+      "from": 26,
+      "to": 31,
       "region": "dialog"
     },
     {
       "name": "codex-boot",
-      "from": 68,
-      "to": 85
+      "from": 31,
+      "to": 38
     },
     {
       "name": "type-codex",
-      "from": 85,
-      "to": 95,
+      "from": 38,
+      "to": 45,
       "region": "inputCodex"
     },
     {
-      "name": "codex-wide",
-      "from": 95,
-      "to": 96
-    },
-    {
       "name": "agent-2",
-      "from": 96,
+      "from": 45,
       "to": "capture-end",
       "region": "agent"
     },

--- a/packages/branding/src/quicklook/quicklook.replay.json
+++ b/packages/branding/src/quicklook/quicklook.replay.json
@@ -15,7 +15,6 @@
     "shellPrompt": ""
   },
   "setup": {
-    "fixtureEngines": true,
     "readyWait": "workspaceReady",
     "seedTasks": [
       {
@@ -34,8 +33,16 @@
       "timeoutMs": 8000
     },
     "claudeComposerReady": {
-      "pattern": "›",
+      "pattern": "❯",
       "timeoutMs": 20000
+    },
+    "codexTrustPrompt": {
+      "pattern": "Do you trust the contents of this directory?",
+      "timeoutMs": 30000
+    },
+    "codexStartupPrompt": {
+      "pattern": "Press enter to continue",
+      "timeoutMs": 30000
     },
     "codexComposerReady": {
       "pattern": "›",
@@ -85,6 +92,26 @@
       "action": "flow",
       "flow": "createTask",
       "engine": "codex"
+    },
+    {
+      "at": 38,
+      "action": "waitFor",
+      "waitFor": "codexStartupPrompt",
+      "dismissIfText": [
+        {
+          "includes": "Update available!",
+          "steps": [
+            { "action": "key", "key": "Down" },
+            { "action": "key", "key": "Enter" },
+            { "action": "waitFor", "waitFor": "codexTrustPrompt" },
+            { "action": "key", "key": "Enter" }
+          ]
+        },
+        {
+          "includes": "Do you trust the contents of this directory?",
+          "steps": [{ "action": "key", "key": "Enter" }]
+        }
+      ]
     },
     {
       "at": 38,

--- a/packages/branding/src/quicklook/quicklook.replay.json
+++ b/packages/branding/src/quicklook/quicklook.replay.json
@@ -36,30 +36,19 @@
       "pattern": "❯",
       "timeoutMs": 20000
     },
-    "codexTrustPrompt": {
-      "pattern": "Do you trust the contents of this directory?",
-      "timeoutMs": 30000
-    },
-    "codexStartupPrompt": {
-      "pattern": "Press enter to continue",
-      "timeoutMs": 30000
-    },
-    "codexComposerReady": {
-      "pattern": "›",
+    "claudePermissionPrompt": {
+      "pattern": "Do you want to proceed?",
       "timeoutMs": 30000
     }
   },
   "text": {
-    "claudePrompt": "Explain what packages/kobe/src/cli/api-cmd.ts does in three short bullets. Read-only.",
-    "codexPrompt": "Summarize the purpose of packages/branding in two sentences. Read-only."
+    "claudePrompt": "Run this exact shell command once: printf replay-color-probe > replay-color-probe.txt"
   },
   "flows": {
     "createTask": {
       "openKey": "n",
       "dialogWait": "newTaskDialog",
       "dialogSettleMs": 1500,
-      "codexEngineCycleKey": "C-e",
-      "codexEngineSettleMs": 900,
       "tabCount": 4,
       "tabDelayMs": 700,
       "submitKey": "Enter"
@@ -73,7 +62,7 @@
       "engine": "claude"
     },
     {
-      "at": 14,
+      "at": 11,
       "action": "typeTextWhenReady",
       "waitFor": "claudeComposerReady",
       "textRef": "claudePrompt",
@@ -83,45 +72,14 @@
       "submitDelayMs": 500
     },
     {
-      "at": 25.8,
-      "action": "key",
-      "key": "C-q"
-    },
-    {
-      "at": 26,
-      "action": "flow",
-      "flow": "createTask",
-      "engine": "codex"
-    },
-    {
-      "at": 38,
+      "at": 28,
       "action": "waitFor",
-      "waitFor": "codexStartupPrompt",
-      "dismissIfText": [
-        {
-          "includes": "Update available!",
-          "steps": [
-            { "action": "key", "key": "Down" },
-            { "action": "key", "key": "Enter" },
-            { "action": "waitFor", "waitFor": "codexTrustPrompt" },
-            { "action": "key", "key": "Enter" }
-          ]
-        },
-        {
-          "includes": "Do you trust the contents of this directory?",
-          "steps": [{ "action": "key", "key": "Enter" }]
-        }
-      ]
+      "waitFor": "claudePermissionPrompt"
     },
     {
-      "at": 38,
-      "action": "typeTextWhenReady",
-      "waitFor": "codexComposerReady",
-      "textRef": "codexPrompt",
-      "msPerChar": 45,
-      "settleMs": 500,
-      "submit": true,
-      "submitDelayMs": 500
+      "at": 28,
+      "action": "sleep",
+      "ms": 2500
     }
   ],
   "regions": {
@@ -152,13 +110,6 @@
       "r0": 1,
       "r1": 43,
       "hash": "rg_0uquako"
-    },
-    "inputCodex": {
-      "c0": 33,
-      "c1": 125,
-      "r0": 1,
-      "r1": 43,
-      "hash": "rg_0dmy2o9"
     }
   },
   "stages": [
@@ -187,31 +138,7 @@
     {
       "name": "agent",
       "from": 21,
-      "to": 26,
-      "region": "agent"
-    },
-    {
-      "name": "dialog-codex",
-      "from": 26,
-      "to": 31,
-      "region": "dialog"
-    },
-    {
-      "name": "codex-boot",
-      "from": 31,
-      "to": 38
-    },
-    {
-      "name": "type-codex",
-      "from": 38,
-      "to": 45,
-      "region": "inputCodex"
-    },
-    {
-      "name": "agent-2",
-      "from": 45,
-      "to": "capture-end",
-      "region": "agent"
+      "to": "capture-end"
     },
     {
       "name": "wrap",

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -123,6 +123,8 @@ export type SeedTask = {
 
 export type ReplaySetup = {
   seedTasks?: SeedTask[]
+  fixtureEngines?: boolean
+  readyWait?: string
 }
 
 export type DeliverySpec = {
@@ -338,6 +340,13 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
 
   if (root.setup !== undefined) {
     const setup = assertObject(root.setup, "setup")
+    if (setup.fixtureEngines !== undefined && typeof setup.fixtureEngines !== "boolean") {
+      throw new Error("replay spec setup.fixtureEngines must be a boolean")
+    }
+    if (setup.readyWait !== undefined) {
+      const readyWait = assertString(setup.readyWait, "setup.readyWait")
+      assertWaitRef(spec.waits, readyWait, "setup")
+    }
     if (setup.seedTasks !== undefined) {
       for (const [index, taskValue] of assertArray(setup.seedTasks, "setup.seedTasks").entries()) {
         const task = assertObject(taskValue, `setup.seedTasks[${index}]`)

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -152,6 +152,8 @@ export type ResolvedReplaySpec = Omit<RawReplaySpec, "camera" | "regions" | "sta
   stages: ResolvedStage[]
 }
 
+const REPLAY_ACTIONS = new Set<ReplayBeat["action"]>(["typeText", "typeTextWhenReady", "key", "flow", "sleep"])
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
@@ -306,6 +308,15 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
   for (const [i, beat] of spec.beats.entries()) {
     assertNumber(beat.at, `beats[${i}].at`)
     assertString(beat.action, `beats[${i}].action`)
+    if (!REPLAY_ACTIONS.has(beat.action)) throw new Error(`beat ${i} has unsupported action "${beat.action}"`)
+    if (beat.action === "flow" && (beat.flow !== "createTask" || !spec.flows?.createTask)) {
+      throw new Error(`beat ${i} references unknown flow "${beat.flow ?? ""}"`)
+    }
+    if (beat.action === "key") assertString(beat.key, `beats[${i}].key`)
+    if (beat.action === "sleep") {
+      const ms = assertNumber(beat.ms, `beats[${i}].ms`)
+      if (ms < 0) throw new Error(`replay spec beats[${i}].ms must be non-negative`)
+    }
     assertWaitRef(spec.waits, beat.waitFor, `beat ${i}`)
     assertTextRef(spec.text, beat.textRef, `beat ${i}`)
     for (const [ruleIndex, rule] of (beat.dismissIfText ?? []).entries()) {

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -56,7 +56,7 @@ export type DismissRule = {
 
 export type ReplayBeat = {
   at: number
-  action: "typeText" | "typeTextWhenReady" | "key" | "flow" | "sleep"
+  action: "typeText" | "typeTextWhenReady" | "key" | "flow" | "sleep" | "waitFor"
   text?: string
   textRef?: string
   msPerChar?: number
@@ -123,7 +123,6 @@ export type SeedTask = {
 
 export type ReplaySetup = {
   seedTasks?: SeedTask[]
-  fixtureEngines?: boolean
   readyWait?: string
 }
 
@@ -154,7 +153,14 @@ export type ResolvedReplaySpec = Omit<RawReplaySpec, "camera" | "regions" | "sta
   stages: ResolvedStage[]
 }
 
-const REPLAY_ACTIONS = new Set<ReplayBeat["action"]>(["typeText", "typeTextWhenReady", "key", "flow", "sleep"])
+const REPLAY_ACTIONS = new Set<ReplayBeat["action"]>([
+  "typeText",
+  "typeTextWhenReady",
+  "key",
+  "flow",
+  "sleep",
+  "waitFor",
+])
 const SEED_TASK_STATUSES = new Set(["backlog", "in_progress", "in_review", "done", "canceled", "error"])
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
@@ -193,7 +199,7 @@ export function assertRenderableCapture(value: unknown): asserts value is Captur
   }
   const frames = assertArray(capture.frames, "capture.frames")
   if (frames.length === 0) throw new Error("capture must contain at least one frame")
-  let previous = -Infinity
+  let previous = Number.NEGATIVE_INFINITY
   for (const [frameIndex, frameValue] of frames.entries()) {
     const frame = assertObject(frameValue, `capture.frames[${frameIndex}]`)
     const timestamp = assertNumber(frame.t, `capture.frames[${frameIndex}].t`)
@@ -340,9 +346,6 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
 
   if (root.setup !== undefined) {
     const setup = assertObject(root.setup, "setup")
-    if (setup.fixtureEngines !== undefined && typeof setup.fixtureEngines !== "boolean") {
-      throw new Error("replay spec setup.fixtureEngines must be a boolean")
-    }
     if (setup.readyWait !== undefined) {
       const readyWait = assertString(setup.readyWait, "setup.readyWait")
       assertWaitRef(spec.waits, readyWait, "setup")

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -182,6 +182,31 @@ const assertString = (value: unknown, name: string): string => {
   return value
 }
 
+export function assertRenderableCapture(value: unknown): asserts value is CaptureMeta {
+  const capture = assertObject(value, "capture")
+  const cols = assertNumber(capture.cols, "capture.cols")
+  const rows = assertNumber(capture.rows, "capture.rows")
+  if (!Number.isInteger(cols) || cols <= 0 || !Number.isInteger(rows) || rows <= 0) {
+    throw new Error("capture cols and rows must be positive integers")
+  }
+  const frames = assertArray(capture.frames, "capture.frames")
+  if (frames.length === 0) throw new Error("capture must contain at least one frame")
+  let previous = -Infinity
+  for (const [frameIndex, frameValue] of frames.entries()) {
+    const frame = assertObject(frameValue, `capture.frames[${frameIndex}]`)
+    const timestamp = assertNumber(frame.t, `capture.frames[${frameIndex}].t`)
+    if (timestamp < previous) throw new Error("capture frame timestamps must be monotonic")
+    previous = timestamp
+    const lines = assertArray(frame.lines, `capture.frames[${frameIndex}].lines`)
+    if (lines.length !== rows) throw new Error(`capture frame ${frameIndex} line count must match rows`)
+    for (const [lineIndex, line] of lines.entries()) {
+      if (typeof line === "string") continue
+      const positioned = assertObject(line, `capture.frames[${frameIndex}].lines[${lineIndex}]`)
+      assertString(positioned.rawAnsi, `capture.frames[${frameIndex}].lines[${lineIndex}].rawAnsi`)
+    }
+  }
+}
+
 const assertTheme = (value: unknown, name: string): TerminalTheme => {
   const theme = assertObject(value, name)
   for (const key of Object.keys(theme)) {

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -314,6 +314,11 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
     )
   }
 
+  const fps = assertNumber(spec.capture.fps, "capture.fps")
+  const seconds = assertNumber(spec.capture.seconds, "capture.seconds")
+  if (fps <= 0) throw new Error("replay spec capture.fps must be positive")
+  if (seconds < 0) throw new Error("replay spec capture.seconds must be non-negative")
+
   const camera = resolveCamera(spec.camera)
   const theme = spec.theme === undefined ? undefined : assertTheme(spec.theme, "theme")
   const rawRegions: Record<string, RawRegion> = {

--- a/packages/branding/src/quicklook/replay-spec.ts
+++ b/packages/branding/src/quicklook/replay-spec.ts
@@ -153,6 +153,7 @@ export type ResolvedReplaySpec = Omit<RawReplaySpec, "camera" | "regions" | "sta
 }
 
 const REPLAY_ACTIONS = new Set<ReplayBeat["action"]>(["typeText", "typeTextWhenReady", "key", "flow", "sleep"])
+const SEED_TASK_STATUSES = new Set(["backlog", "in_progress", "in_review", "done", "canceled", "error"])
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
@@ -304,6 +305,20 @@ export function resolveReplaySpec(raw: unknown, capture: CaptureMeta): ResolvedR
     assertNumber(wait.timeoutMs, `waits.${name}.timeoutMs`)
   }
   for (const [name, value] of Object.entries(spec.text)) assertString(value, `text.${name}`)
+
+  if (root.setup !== undefined) {
+    const setup = assertObject(root.setup, "setup")
+    if (setup.seedTasks !== undefined) {
+      for (const [index, taskValue] of assertArray(setup.seedTasks, "setup.seedTasks").entries()) {
+        const task = assertObject(taskValue, `setup.seedTasks[${index}]`)
+        assertString(task.title, `setup.seedTasks[${index}].title`)
+        const status = assertString(task.status, `setup.seedTasks[${index}].status`)
+        if (!SEED_TASK_STATUSES.has(status)) {
+          throw new Error(`replay spec setup.seedTasks[${index}] has unsupported status "${status}"`)
+        }
+      }
+    }
+  }
 
   for (const [i, beat] of spec.beats.entries()) {
     assertNumber(beat.at, `beats[${i}].at`)

--- a/packages/branding/tests/capture-core.test.ts
+++ b/packages/branding/tests/capture-core.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { ResolvedReplaySpec } from "../src/quicklook/replay-spec"
+import {
+  runReplayCapture,
+  writeCaptureAtomically,
+  type CaptureClock,
+  type CaptureDocument,
+  type CaptureOutput,
+  type CaptureTerminal,
+} from "../src/quicklook/capture-core"
+
+class FakeTerminal implements CaptureTerminal {
+  readonly calls: string[] = []
+  stopCalls = 0
+  private snapshotIndex = 0
+
+  constructor(
+    private readonly screens: readonly string[],
+    private readonly failure?: Error,
+  ) {}
+
+  async start() {
+    this.calls.push("start")
+  }
+
+  async snapshot() {
+    const screen = this.screens[Math.min(this.snapshotIndex++, this.screens.length - 1)] ?? ""
+    return [screen]
+  }
+
+  async type(text: string) {
+    this.calls.push(`type:${text}`)
+  }
+
+  async key(key: string) {
+    this.calls.push(`key:${key}`)
+  }
+
+  async waitFor(pattern: string, timeoutMs: number) {
+    this.calls.push(`wait:${pattern}:${timeoutMs}`)
+    if (this.failure) throw this.failure
+  }
+
+  async stop() {
+    this.stopCalls++
+    this.calls.push("stop")
+  }
+}
+
+const clock = (times: readonly number[]): CaptureClock & { sleeps: number[] } => {
+  let index = 0
+  const sleeps: number[] = []
+  return {
+    sleeps,
+    now: () => times[Math.min(index++, times.length - 1)] ?? 0,
+    sleep: async (ms) => {
+      sleeps.push(ms)
+    },
+  }
+}
+
+const memoryOutput = (): CaptureOutput & { writes: CaptureDocument[] } => ({
+  writes: [],
+  replaceAtomically: async function (capture) {
+    this.writes.push(capture)
+  },
+})
+
+const spec = (beats: ResolvedReplaySpec["beats"]): ResolvedReplaySpec =>
+  ({
+    id: "capture-test",
+    viewport: { cols: 80, rows: 1, width: 80, height: 1 },
+    capture: { fps: 10, seconds: 3, output: "capture.json", home: ".home", repoDefault: ".", shellPrompt: "$ " },
+    waits: { composer: { pattern: "composer", timeoutMs: 500 } },
+    text: { prompt: "go" },
+    beats,
+    regions: {},
+    stages: [],
+    camera: {
+      transitionSeconds: 1,
+      fit: 1,
+      minScale: 1,
+      maxScale: 1,
+      tailHoldSeconds: 1,
+      minChangedCells: 1,
+      rowGap: 1,
+      colQuantiles: [0, 1],
+    },
+    theme: { defaultFg: "#fff", defaultBg: "#000", ansi16: Array(16).fill("#000") },
+  }) as ResolvedReplaySpec
+
+describe("capture core", () => {
+  test("captures only changed screens with elapsed wall-clock timestamps", async () => {
+    const result = await runReplayCapture(
+      spec([{ at: 0, action: "key", key: "Enter" }, { at: 0.1, action: "sleep", ms: 1 }]),
+      new FakeTerminal(["boot", "boot", "dialog"]),
+      memoryOutput(),
+      clock([100, 140, 225]),
+    )
+
+    expect(result.frames.map((frame) => [frame.t, frame.lines])).toEqual([
+      [0, ["boot"]],
+      [0.125, ["dialog"]],
+    ])
+    expect(result.meta).toEqual({ theme: spec([]).theme })
+  })
+
+  test("stops the terminal and leaves the previous output untouched when a beat fails", async () => {
+    const terminal = new FakeTerminal(["boot"], new Error("composer timeout"))
+    const output = memoryOutput()
+
+    await expect(
+      runReplayCapture(spec([{ at: 0, action: "typeTextWhenReady", waitFor: "composer", textRef: "prompt" }]), terminal, output, clock([0])),
+    ).rejects.toThrow("composer timeout")
+
+    expect(terminal.stopCalls).toBe(1)
+    expect(output.writes).toEqual([])
+  })
+
+  test("types one character at a time and waits before submitting", async () => {
+    const terminal = new FakeTerminal(["boot"])
+    const timer = clock([0])
+
+    await runReplayCapture(
+      spec([{ at: 0, action: "typeText", text: "go", msPerChar: 45, submit: true, submitDelayMs: 500 }]),
+      terminal,
+      memoryOutput(),
+      timer,
+    )
+
+    expect(terminal.calls).toEqual(["start", "type:g", "type:o", "key:Enter", "stop"])
+    expect(timer.sleeps).toEqual([45, 500])
+  })
+
+  test("waits for typeTextWhenReady before typing", async () => {
+    const terminal = new FakeTerminal(["boot"])
+
+    await runReplayCapture(
+      spec([{ at: 0, action: "typeTextWhenReady", waitFor: "composer", textRef: "prompt", settleMs: 10 }]),
+      terminal,
+      memoryOutput(),
+      clock([0]),
+    )
+
+    expect(terminal.calls).toEqual(["start", "wait:composer:500", "type:g", "type:o", "stop"])
+  })
+
+  test("expands the named createTask flow", async () => {
+    const terminal = new FakeTerminal(["boot"])
+    const timer = clock([0])
+    const replay = spec([{ at: 0, action: "flow", flow: "createTask", engine: "codex" }])
+    replay.flows = {
+      createTask: {
+        focusPaneBeforeOpen: "leftmost",
+        openKey: "n",
+        dialogWait: "composer",
+        dialogSettleMs: 10,
+        codexEngineCycleKey: "C-e",
+        codexEngineSettleMs: 20,
+        tabCount: 2,
+        tabDelayMs: 30,
+        submitKey: "Enter",
+      },
+    }
+
+    await runReplayCapture(replay, terminal, memoryOutput(), timer)
+
+    expect(terminal.calls).toEqual([
+      "start",
+      "key:C-h",
+      "key:n",
+      "wait:composer:500",
+      "key:C-e",
+      "key:Tab",
+      "key:Tab",
+      "key:Enter",
+      "stop",
+    ])
+    expect(timer.sleeps).toEqual([10, 20, 30, 30])
+  })
+
+  test("writes through a same-directory temporary file before renaming", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kobe-capture-core-"))
+    const path = join(root, "frames.json")
+    const document: CaptureDocument = { cols: 1, rows: 1, frames: [{ t: 0, lines: ["boot"] }], meta: {} }
+
+    try {
+      await writeCaptureAtomically(path, document)
+      await expect(readFile(path, "utf8")).resolves.toContain('"cols": 1')
+      expect(await readdir(root)).toEqual(["frames.json"])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/branding/tests/capture-core.test.ts
+++ b/packages/branding/tests/capture-core.test.ts
@@ -108,6 +108,37 @@ describe("capture core", () => {
     expect(result.meta).toEqual({ theme: spec([]).theme })
   })
 
+  test("orders out-of-order beats chronologically while preserving equal-time order", async () => {
+    const terminal = new FakeTerminal(["boot"])
+
+    await runReplayCapture(
+      spec([
+        { at: 2, action: "key", key: "second" },
+        { at: 1, action: "key", key: "first" },
+        { at: 2, action: "key", key: "third" },
+      ]),
+      terminal,
+      memoryOutput(),
+      clock([0]),
+    )
+
+    expect(terminal.calls).toEqual(["start", "key:first", "key:second", "key:third", "stop"])
+  })
+
+  test("attempts snapshots after declared zero-duration sleeps and settles", async () => {
+    const result = await runReplayCapture(
+      spec([
+        { at: 0, action: "sleep", ms: 0 },
+        { at: 0, action: "typeText", text: "g", settleMs: 0 },
+      ]),
+      new FakeTerminal(["boot", "after-sleep", "after-settle", "after-type"]),
+      memoryOutput(),
+      clock([0]),
+    )
+
+    expect(result.frames.map((frame) => frame.lines)).toEqual([["boot"], ["after-sleep"], ["after-settle"], ["after-type"]])
+  })
+
   test("stops the terminal and leaves the previous output untouched when a beat fails", async () => {
     const terminal = new FakeTerminal(["boot"], new Error("composer timeout"))
     const output = memoryOutput()

--- a/packages/branding/tests/capture-core.test.ts
+++ b/packages/branding/tests/capture-core.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, test } from "bun:test"
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { ResolvedReplaySpec } from "../src/quicklook/replay-spec"
 import {
-  runReplayCapture,
-  writeCaptureAtomically,
   type CaptureClock,
   type CaptureDocument,
   type CaptureOutput,
   type CaptureTerminal,
+  runReplayCapture,
+  writeCaptureAtomically,
 } from "../src/quicklook/capture-core"
+import type { ResolvedReplaySpec } from "../src/quicklook/replay-spec"
 
 class FakeTerminal implements CaptureTerminal {
   readonly calls: string[] = []
@@ -115,7 +115,10 @@ const spec = (beats: ResolvedReplaySpec["beats"]): ResolvedReplaySpec =>
 describe("capture core", () => {
   test("captures only changed screens with elapsed wall-clock timestamps", async () => {
     const result = await runReplayCapture(
-      spec([{ at: 0, action: "key", key: "Enter" }, { at: 0.1, action: "sleep", ms: 1 }]),
+      spec([
+        { at: 0, action: "key", key: "Enter" },
+        { at: 0.1, action: "sleep", ms: 1 },
+      ]),
       new FakeTerminal(["boot", "boot", "dialog"]),
       memoryOutput(),
       clock([100, 140, 225]),
@@ -176,7 +179,12 @@ describe("capture core", () => {
       clock([0]),
     )
 
-    expect(result.frames.map((frame) => frame.lines)).toEqual([["boot"], ["after-sleep"], ["after-settle"], ["after-type"]])
+    expect(result.frames.map((frame) => frame.lines)).toEqual([
+      ["boot"],
+      ["after-sleep"],
+      ["after-settle"],
+      ["after-type"],
+    ])
   })
 
   test("stops the terminal and leaves the previous output untouched when a beat fails", async () => {
@@ -184,7 +192,12 @@ describe("capture core", () => {
     const output = memoryOutput()
 
     await expect(
-      runReplayCapture(spec([{ at: 0, action: "typeTextWhenReady", waitFor: "composer", textRef: "prompt" }]), terminal, output, clock([0])),
+      runReplayCapture(
+        spec([{ at: 0, action: "typeTextWhenReady", waitFor: "composer", textRef: "prompt" }]),
+        terminal,
+        output,
+        clock([0]),
+      ),
     ).rejects.toThrow("composer timeout")
 
     expect(terminal.stopCalls).toBe(1)
@@ -217,6 +230,35 @@ describe("capture core", () => {
     )
 
     expect(terminal.calls).toEqual(["start", "wait:composer:500", "type:g", "type:o", "stop"])
+  })
+
+  test("supports a standalone wait before a following key", async () => {
+    const terminal = new FakeTerminal(["boot", "update available", "after-down", "after-dismiss"])
+
+    await runReplayCapture(
+      spec([
+        {
+          at: 0,
+          action: "waitFor",
+          waitFor: "composer",
+          dismissIfText: [
+            {
+              includes: "update available",
+              steps: [
+                { action: "key", key: "Down" },
+                { action: "key", key: "Enter" },
+              ],
+            },
+          ],
+        },
+        { at: 0, action: "key", key: "Enter" },
+      ]),
+      terminal,
+      memoryOutput(),
+      clock([0]),
+    )
+
+    expect(terminal.calls).toEqual(["start", "wait:composer:500", "key:Down", "key:Enter", "key:Enter", "stop"])
   })
 
   test("expands the named createTask flow", async () => {

--- a/packages/branding/tests/capture-core.test.ts
+++ b/packages/branding/tests/capture-core.test.ts
@@ -62,6 +62,19 @@ const clock = (times: readonly number[]): CaptureClock & { sleeps: number[] } =>
   }
 }
 
+const advancingClock = (): CaptureClock & { sleeps: number[] } => {
+  let now = 0
+  const sleeps: number[] = []
+  return {
+    sleeps,
+    now: () => now,
+    sleep: async (ms) => {
+      sleeps.push(ms)
+      now += ms
+    },
+  }
+}
+
 const memoryOutput = (): CaptureOutput & { writes: CaptureDocument[] } => ({
   writes: [],
   replaceAtomically: async function (capture) {
@@ -73,7 +86,14 @@ const spec = (beats: ResolvedReplaySpec["beats"]): ResolvedReplaySpec =>
   ({
     id: "capture-test",
     viewport: { cols: 80, rows: 1, width: 80, height: 1 },
-    capture: { fps: 10, seconds: 3, output: "capture.json", home: ".home", repoDefault: ".", shellPrompt: "$ " },
+    capture: {
+      fps: 10,
+      seconds: Math.max(0, ...beats.map((beat) => beat.at)),
+      output: "capture.json",
+      home: ".home",
+      repoDefault: ".",
+      shellPrompt: "$ ",
+    },
     waits: { composer: { pattern: "composer", timeoutMs: 500 } },
     text: { prompt: "go" },
     beats,
@@ -106,6 +126,26 @@ describe("capture core", () => {
       [0.125, ["dialog"]],
     ])
     expect(result.meta).toEqual({ theme: spec([]).theme })
+  })
+
+  test("polls idle timeline changes at capture fps through capture end", async () => {
+    const replay = spec([])
+    replay.capture.seconds = 0.3
+    const timer = advancingClock()
+
+    const result = await runReplayCapture(
+      replay,
+      new FakeTerminal(["boot", "working", "working", "done"]),
+      memoryOutput(),
+      timer,
+    )
+
+    expect(timer.sleeps).toEqual([100, 100, 100])
+    expect(result.frames.map((frame) => [frame.t, frame.lines])).toEqual([
+      [0, ["boot"]],
+      [0.1, ["working"]],
+      [0.3, ["done"]],
+    ])
   })
 
   test("orders out-of-order beats chronologically while preserving equal-time order", async () => {

--- a/packages/branding/tests/puretui-capture-environment.test.ts
+++ b/packages/branding/tests/puretui-capture-environment.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { type CapturePureTuiOptions, capturePureTui } from "../scripts/capture-puretui"
+import * as pureTuiTerminal from "../src/quicklook/puretui-terminal"
+
+type CaptureEnvironment = (demoRoot: string) => Record<string, string>
+
+const captureEnvironment = (): CaptureEnvironment | undefined =>
+  (pureTuiTerminal as typeof pureTuiTerminal & { captureEnvironment?: CaptureEnvironment }).captureEnvironment
+
+const runZeroCapture = async (claudeCommand?: string): Promise<Record<string, unknown>> => {
+  const root = await mkdtemp(join(tmpdir(), "kobe-capture-environment-"))
+  const specPath = join(root, "capture.replay.json")
+  const outputPath = join(root, "frames.json")
+  const demoRoot = join(root, "demo")
+  const raw = JSON.parse(
+    await Bun.file(join(resolve(import.meta.dirname, ".."), "src/quicklook/quicklook.replay.json")).text(),
+  )
+  raw.capture.seconds = 0
+  raw.beats = []
+  raw.stages = [{ name: "still", from: 0, to: "end" }]
+  await writeFile(specPath, `${JSON.stringify(raw)}\n`)
+
+  const options: CapturePureTuiOptions & { claudeCommand?: string } = {
+    specPath,
+    outputPath,
+    demoRoot,
+    keepDemoRoot: true,
+    claudeCommand,
+  }
+  await capturePureTui(options, {
+    createCapture: async (captureOptions) => ({
+      demoRoot: captureOptions.demoRoot,
+      terminal: {
+        async start() {},
+        async snapshot() {
+          return Array.from({ length: captureOptions.rows }, () => "")
+        },
+        async type() {},
+        async key() {},
+        async waitFor() {},
+        async stop() {},
+      },
+      async cleanup() {},
+    }),
+    log: () => {},
+  })
+  return Bun.file(join(demoRoot, "home", ".config", "kobe", "state.json")).json()
+}
+
+describe("PureTUI capture environment", () => {
+  test("does not inherit NO_COLOR into the native replay", () => {
+    const buildEnvironment = captureEnvironment()
+    expect(typeof buildEnvironment).toBe("function")
+    if (!buildEnvironment) return
+
+    const previous = process.env.NO_COLOR
+    process.env.NO_COLOR = "1"
+    try {
+      const env = buildEnvironment("/tmp/kobe-color-capture")
+      expect(env).not.toHaveProperty("NO_COLOR")
+      expect(env).toMatchObject({ TERM: "xterm-256color", COLORTERM: "truecolor" })
+    } finally {
+      if (previous === undefined) delete process.env.NO_COLOR
+      else process.env.NO_COLOR = previous
+    }
+  })
+
+  test("leaves the isolated engine command unset by default", async () => {
+    const state = await runZeroCapture()
+    expect(state).not.toHaveProperty("engineCommand.claude")
+  })
+
+  test("persists a capture-only Claude command override", async () => {
+    const command = "/usr/bin/env TEST_CAPTURE=1 claude --model test"
+    const state = await runZeroCapture(command)
+    expect(state["engineCommand.claude"]).toBe(command)
+  })
+})

--- a/packages/branding/tests/puretui-capture.test.ts
+++ b/packages/branding/tests/puretui-capture.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test"
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { defaultDaemonSocketPath, defaultPtyHostSocketPath } from "../../kobe-daemon/src/daemon/paths"
+import { capturePureTui } from "../scripts/capture-puretui"
+import quicklookSpec from "../src/quicklook/quicklook.replay.json"
+import { assertRenderableCapture, type RawReplaySpec } from "../src/quicklook/replay-spec"
+
+test("rejects empty and malformed captures before renderer setup", () => {
+  expect(() => assertRenderableCapture({ cols: 160, rows: 45, frames: [] })).toThrow(/at least one frame/)
+  expect(() =>
+    assertRenderableCapture({ cols: 160, rows: 2, frames: [{ t: 0, lines: ["only one"] }] }),
+  ).toThrow(/line count/)
+})
+
+const e2e = process.env.KOBE_REPLAY_E2E === "1" ? test : test.skip
+
+e2e(
+  "captures the real PureTUI create-task flow with a PATH-first fake engine",
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), "kobe-puretui-e2e-"))
+    const bin = join(root, "bin")
+    const demoRoot = join(root, "demo")
+    const outputPath = join(root, "frames.json")
+    const specPath = join(root, "capture.replay.json")
+    await mkdir(bin, { recursive: true })
+    await writeFile(join(bin, "claude"), "#!/bin/sh\nprintf 'fake-claude ready\\n'\nexec sleep 60\n")
+    await chmod(join(bin, "claude"), 0o755)
+
+    const spec = structuredClone(quicklookSpec) as unknown as RawReplaySpec
+    spec.viewport = { cols: 100, rows: 30, width: 800, height: 480 }
+    spec.capture.seconds = 18
+    spec.setup = { seedTasks: [] }
+    spec.waits = { newTaskDialog: { pattern: "New task", timeoutMs: 8000 } }
+    spec.text = { prompt: "Brand Studio replay prompt" }
+    spec.flows = {
+      createTask: {
+        openKey: "n",
+        focusPaneBeforeOpen: "leftmost",
+        dialogWait: "newTaskDialog",
+        dialogSettleMs: 100,
+        tabCount: 4,
+        tabDelayMs: 50,
+        submitKey: "Enter",
+      },
+    }
+    spec.beats = [
+      { at: 2, action: "flow", flow: "createTask", engine: "claude" },
+      { at: 14, action: "typeText", textRef: "prompt", msPerChar: 25 },
+      { at: 18, action: "sleep", ms: 0 },
+    ]
+    spec.regions = {}
+    spec.stages = [{ name: "capture", from: 0, to: "end" }]
+    await writeFile(specPath, `${JSON.stringify(spec)}\n`)
+
+    const previousPath = process.env.PATH
+    process.env.PATH = `${bin}:${previousPath ?? ""}`
+    try {
+      await capturePureTui({ specPath, outputPath, demoRoot, keepDemoRoot: true, timeoutMs: 20_000 }, { log: () => {} })
+    } finally {
+      process.env.PATH = previousPath
+    }
+
+    const capture = await Bun.file(outputPath).json()
+    const screen = capture.frames.flatMap((frame: { lines: string[] }) => frame.lines).join("\n")
+    expect(screen).toContain("New task")
+    expect(screen).toContain("Brand Studio replay prompt")
+    expect(await Bun.file(defaultDaemonSocketPath(join(demoRoot, "home"))).exists()).toBe(false)
+    expect(await Bun.file(defaultPtyHostSocketPath(join(demoRoot, "home"))).exists()).toBe(false)
+  },
+  45_000,
+)

--- a/packages/branding/tests/puretui-capture.test.ts
+++ b/packages/branding/tests/puretui-capture.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { defaultDaemonSocketPath, defaultPtyHostSocketPath } from "../../kobe-daemon/src/daemon/paths"
@@ -17,27 +17,21 @@ test("rejects empty and malformed captures before renderer setup", () => {
 const e2e = process.env.KOBE_REPLAY_E2E === "1" ? test : test.skip
 
 e2e(
-  "captures the real PureTUI create-task flow with a PATH-first fake engine",
+  "captures the real PureTUI create-task flow with fixture engines",
   async () => {
     const root = await mkdtemp(join(tmpdir(), "kobe-puretui-e2e-"))
-    const bin = join(root, "bin")
     const demoRoot = join(root, "demo")
     const outputPath = join(root, "frames.json")
     const specPath = join(root, "capture.replay.json")
-    await mkdir(bin, { recursive: true })
-    await writeFile(join(bin, "claude"), "#!/bin/sh\nprintf 'fake-claude ready\\n'\nexec sleep 60\n")
-    await chmod(join(bin, "claude"), 0o755)
-
     const spec = structuredClone(quicklookSpec) as unknown as RawReplaySpec
     spec.viewport = { cols: 100, rows: 30, width: 800, height: 480 }
     spec.capture.seconds = 18
-    spec.setup = { seedTasks: [] }
+    spec.setup = { seedTasks: [], fixtureEngines: true }
     spec.waits = { newTaskDialog: { pattern: "New task", timeoutMs: 8000 } }
     spec.text = { prompt: "Brand Studio replay prompt" }
     spec.flows = {
       createTask: {
         openKey: "n",
-        focusPaneBeforeOpen: "leftmost",
         dialogWait: "newTaskDialog",
         dialogSettleMs: 100,
         tabCount: 4,
@@ -54,13 +48,10 @@ e2e(
     spec.stages = [{ name: "capture", from: 0, to: "end" }]
     await writeFile(specPath, `${JSON.stringify(spec)}\n`)
 
-    const previousPath = process.env.PATH
-    process.env.PATH = `${bin}:${previousPath ?? ""}`
-    try {
-      await capturePureTui({ specPath, outputPath, demoRoot, keepDemoRoot: true, timeoutMs: 20_000 }, { log: () => {} })
-    } finally {
-      process.env.PATH = previousPath
-    }
+    await capturePureTui(
+      { specPath, outputPath, demoRoot, keepDemoRoot: true, timeoutMs: 20_000 },
+      { log: () => {} },
+    )
 
     const capture = await Bun.file(outputPath).json()
     const screen = capture.frames.flatMap((frame: { lines: string[] }) => frame.lines).join("\n")

--- a/packages/branding/tests/puretui-capture.test.ts
+++ b/packages/branding/tests/puretui-capture.test.ts
@@ -5,19 +5,19 @@ import { join, resolve } from "node:path"
 import { defaultDaemonSocketPath, defaultPtyHostSocketPath } from "../../kobe-daemon/src/daemon/paths"
 import { capturePureTui } from "../scripts/capture-puretui"
 import quicklookSpec from "../src/quicklook/quicklook.replay.json"
-import { assertRenderableCapture, type RawReplaySpec } from "../src/quicklook/replay-spec"
+import { type RawReplaySpec, assertRenderableCapture } from "../src/quicklook/replay-spec"
 
 test("rejects empty and malformed captures before renderer setup", () => {
   expect(() => assertRenderableCapture({ cols: 160, rows: 45, frames: [] })).toThrow(/at least one frame/)
-  expect(() =>
-    assertRenderableCapture({ cols: 160, rows: 2, frames: [{ t: 0, lines: ["only one"] }] }),
-  ).toThrow(/line count/)
+  expect(() => assertRenderableCapture({ cols: 160, rows: 2, frames: [{ t: 0, lines: ["only one"] }] })).toThrow(
+    /line count/,
+  )
 })
 
 const e2e = process.env.KOBE_REPLAY_E2E === "1" ? test : test.skip
 
 e2e(
-  "captures the real PureTUI create-task flow with fixture engines",
+  "captures the real PureTUI create-task flow with a test-injected engine",
   async () => {
     const root = await mkdtemp(join(tmpdir(), "kobe-puretui-e2e-"))
     const demoRoot = join(root, "demo")
@@ -26,7 +26,7 @@ e2e(
     const spec = structuredClone(quicklookSpec) as unknown as RawReplaySpec
     spec.viewport = { cols: 100, rows: 30, width: 800, height: 480 }
     spec.capture.seconds = 18
-    spec.setup = { seedTasks: [], fixtureEngines: true }
+    spec.setup = { seedTasks: [] }
     spec.waits = { newTaskDialog: { pattern: "New task", timeoutMs: 8000 } }
     spec.text = { prompt: "Brand Studio replay prompt" }
     spec.flows = {
@@ -48,10 +48,13 @@ e2e(
     spec.stages = [{ name: "capture", from: 0, to: "end" }]
     await writeFile(specPath, `${JSON.stringify(spec)}\n`)
 
-    await capturePureTui(
-      { specPath, outputPath, demoRoot, keepDemoRoot: true, timeoutMs: 20_000 },
-      { log: () => {} },
-    )
+    const previousPath = process.env.PATH
+    process.env.PATH = `${resolve(import.meta.dirname, "../scripts/fixtures")}:${previousPath ?? ""}`
+    try {
+      await capturePureTui({ specPath, outputPath, demoRoot, keepDemoRoot: true, timeoutMs: 20_000 }, { log: () => {} })
+    } finally {
+      process.env.PATH = previousPath
+    }
 
     const capture = await Bun.file(outputPath).json()
     const screen = capture.frames.flatMap((frame: { lines: string[] }) => frame.lines).join("\n")

--- a/packages/branding/tests/puretui-terminal-colors.test.ts
+++ b/packages/branding/tests/puretui-terminal-colors.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test"
+import { Terminal } from "@xterm/headless"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { capturePureTui } from "../scripts/capture-puretui"
+import * as sidecar from "../scripts/puretui-pty-sidecar.mjs"
+import {
+  type PureTuiCaptureOptions,
+  type SidecarFactory,
+  createPureTuiCapture,
+} from "../src/quicklook/puretui-terminal"
+
+const createSidecarController = sidecar.createSidecarController
+const registerDefaultColorHandlers = (
+  sidecar as typeof sidecar & {
+    registerDefaultColorHandlers?: (terminal: Terminal, theme: typeof theme, reply: (data: string) => void) => void
+  }
+).registerDefaultColorHandlers
+
+const theme = { defaultFg: "#FFFFFF", defaultBg: "#141413" }
+
+const writeTerminal = (terminal: Terminal, data: string): Promise<void> =>
+  new Promise((resolve) => terminal.write(data, resolve))
+
+const respondingSidecar = () => {
+  const requests: Array<Record<string, unknown>> = []
+  let output!: ReadableStreamDefaultController<Uint8Array>
+  let resolveExit!: (code: number) => void
+  let pending = ""
+  const exited = new Promise<number>((resolve) => (resolveExit = resolve))
+  const factory = (() => ({
+    stdin: {
+      write(chunk: string | Uint8Array) {
+        pending += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk)
+        for (;;) {
+          const newline = pending.indexOf("\n")
+          if (newline < 0) break
+          const request = JSON.parse(pending.slice(0, newline)) as Record<string, unknown>
+          pending = pending.slice(newline + 1)
+          requests.push(request)
+          output.enqueue(
+            new TextEncoder().encode(
+              `${JSON.stringify({ id: request.id, ok: true, value: request.op === "snapshot" ? [] : null })}\n`,
+            ),
+          )
+        }
+      },
+      end() {
+        resolveExit(0)
+      },
+    },
+    stdout: new ReadableStream<Uint8Array>({ start: (controller) => (output = controller) }),
+    stderr: new ReadableStream<Uint8Array>({ start: (controller) => controller.close() }),
+    exited,
+    kill() {
+      resolveExit(1)
+    },
+  })) as SidecarFactory
+  return { factory, requests }
+}
+
+describe("PureTUI terminal color protocol", () => {
+  test("answers OSC 10 and OSC 11 queries with the declared replay theme", async () => {
+    const terminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    const replies: string[] = []
+    registerDefaultColorHandlers?.(terminal, theme, (data) => replies.push(data))
+
+    await writeTerminal(terminal, "\x1b]10;?\x07\x1b]11;?\x07")
+
+    expect(replies).toEqual([
+      "\x1b]10;rgb:ffff/ffff/ffff\x1b\\",
+      "\x1b]11;rgb:1414/1414/1313\x1b\\",
+    ])
+    terminal.dispose()
+  })
+
+  test("leaves non-query OSC color operations to xterm", async () => {
+    const terminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true })
+    const replies: string[] = []
+    registerDefaultColorHandlers?.(terminal, theme, (data) => replies.push(data))
+
+    await writeTerminal(terminal, "\x1b]10;rgb:aaaa/bbbb/cccc\x07\x1b]11;#010203\x07")
+
+    expect(replies).toEqual([])
+    terminal.dispose()
+  })
+
+  test("forwards xterm query replies to the live capture child", async () => {
+    let emitChildData = (_data: string) => {}
+    const childWrites: string[] = []
+    const child = {
+      pid: 42,
+      write: (data: string) => childWrites.push(data),
+      kill() {},
+      onData: (listener: (data: string) => void) => {
+        emitChildData = listener
+        return { dispose() {} }
+      },
+      onExit: () => ({ dispose() {} }),
+    }
+    const controller = createSidecarController({
+      baseEnv: { PATH: process.env.PATH ?? "" },
+      spawnPty: () => child,
+      createTerminal: (options: { cols: number; rows: number }) =>
+        new Terminal({ ...options, allowProposedApi: true, scrollback: 0 }),
+    })
+
+    expect(
+      await controller.handle({
+        id: 1,
+        op: "start",
+        repoRoot: "/repo",
+        demoRoot: "/demo",
+        fixtureRepo: "/demo/fixture-repo",
+        cols: 80,
+        rows: 24,
+        theme,
+      }),
+    ).toMatchObject({ ok: true })
+
+    emitChildData("\x1b[6n")
+    await controller.handle({ id: 2, op: "snapshot" })
+
+    expect(childWrites).toEqual(["\x1b[1;1R"])
+  })
+
+  test("passes the validated replay theme into capture creation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kobe-replay-colors-"))
+    const specPath = join(root, "capture.replay.json")
+    const raw = JSON.parse(
+      await Bun.file(resolve(import.meta.dirname, "../src/quicklook/quicklook.replay.json")).text(),
+    )
+    raw.capture.seconds = 0
+    raw.beats = []
+    raw.stages = [{ name: "still", from: 0, to: "end" }]
+    await writeFile(specPath, `${JSON.stringify(raw)}\n`)
+    let received: PureTuiCaptureOptions | undefined
+
+    await capturePureTui(
+      {
+        specPath,
+        outputPath: join(root, "frames.json"),
+        demoRoot: join(root, "demo"),
+        keepDemoRoot: true,
+      },
+      {
+        createCapture: async (options) => {
+          received = options
+          return {
+            demoRoot: options.demoRoot,
+            terminal: {
+              async start() {},
+              async snapshot() {
+                return Array.from({ length: options.rows }, () => "")
+              },
+              async type() {},
+              async key() {},
+              async waitFor() {},
+              async stop() {},
+            },
+            async cleanup() {},
+          }
+        },
+        log: () => {},
+      },
+    )
+
+    expect(received?.theme).toEqual(theme)
+  })
+
+  test("includes the terminal theme in the sidecar start request", async () => {
+    const protocol = respondingSidecar()
+    const capture = await createPureTuiCapture({
+      repoRoot: resolve(import.meta.dirname, "../../.."),
+      demoRoot: join(await mkdtemp(join(tmpdir(), "kobe-sidecar-colors-")), "demo"),
+      fixtureRepo: "/fixture",
+      cols: 80,
+      rows: 24,
+      theme,
+      sidecarFactory: protocol.factory,
+    } as PureTuiCaptureOptions)
+
+    await capture.terminal.start()
+
+    expect(protocol.requests[0]).toMatchObject({ op: "start", theme })
+    await capture.cleanup()
+  })
+})

--- a/packages/branding/tests/puretui-terminal.test.ts
+++ b/packages/branding/tests/puretui-terminal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { mkdtemp, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { homedir, tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { capturePureTui } from "../scripts/capture-puretui"
 import {
@@ -9,13 +9,12 @@ import {
   serializeXtermLine,
 } from "../scripts/puretui-pty-sidecar.mjs"
 import {
-  createPureTuiCapture,
   type SidecarFactory,
   type SidecarProcess,
   type SidecarSpawnOptions,
+  createPureTuiCapture,
 } from "../src/quicklook/puretui-terminal"
 type Request = { id: number; op: string; [key: string]: unknown }
-
 class FakeSidecar implements SidecarProcess {
   readonly requests: Request[] = []
   readonly stdout: ReadableStream<Uint8Array>
@@ -48,7 +47,9 @@ class FakeSidecar implements SidecarProcess {
     private readonly onRequest: (request: Request) => void,
     private readonly exitOnEnd = true,
   ) {
+    // biome-ignore lint/suspicious/noAssignInExpressions: the stream start callback captures its controller
     this.stdout = new ReadableStream({ start: (controller) => (this.output = controller) })
+    // biome-ignore lint/suspicious/noAssignInExpressions: the promise executor captures its resolver
     this.exited = new Promise((resolveExit) => (this.resolveExit = resolveExit))
   }
 
@@ -78,9 +79,8 @@ const fakeFactory = (handler: (process: FakeSidecar, request: Request) => void) 
   factory.process = () => process
   return factory
 }
-
 describe("PureTuiTerminal", () => {
-  test("launches source PureTUI with an isolated home, fixture repo, and fixed replay viewport", async () => {
+  test("launches source PureTUI with native engines, isolated Kobe state, and fixed replay viewport", async () => {
     const repoRoot = resolve(import.meta.dirname, "../../..")
     const demoRoot = join(await mkdtemp(join(tmpdir(), "kobe-puretui-test-")), "demo")
     const fixtureRepo = join(demoRoot, "fixture-repo")
@@ -91,13 +91,11 @@ describe("PureTuiTerminal", () => {
         process.respond({ id: request.id, ok: true, value: request.op === "snapshot" ? ["boot"] : null })
       }
     })
-
     const capture = await createPureTuiCapture({
       repoRoot,
       demoRoot,
       fixtureRepo,
       seedTasks: [{ title: "seed task", status: "in_progress" }],
-      pathPrefix: join(repoRoot, "packages", "branding", "scripts", "fixtures"),
       readyPattern: "KOBE",
       readyTimeoutMs: 500,
       cols: 160,
@@ -110,10 +108,12 @@ describe("PureTuiTerminal", () => {
       env: expect.objectContaining({
         KOBE_SANDBOX_HOME_DIR: expect.stringContaining(demoRoot),
         KOBE_HOME_DIR: expect.stringContaining(demoRoot),
-        PATH: expect.stringContaining("packages/branding/scripts/fixtures"),
+        HOME: homedir(),
+        USERPROFILE: homedir(),
       }),
     })
-
+    expect(sidecarFactory.calls[0].env).not.toHaveProperty("CLAUDE_CONFIG_DIR")
+    expect(sidecarFactory.calls[0].env).not.toHaveProperty("CODEX_HOME")
     await capture.terminal.start()
     expect(sidecarFactory.process().requests[0]).toMatchObject({
       op: "start",
@@ -149,7 +149,6 @@ describe("PureTuiTerminal", () => {
       protocolTimeoutMs: 10,
       sidecarFactory,
     })
-
     await capture.terminal.start()
     await expect(capture.terminal.snapshot()).rejects.toThrow("latest screen")
     await expect(capture.terminal.snapshot()).rejects.toThrow("90210")
@@ -187,7 +186,6 @@ describe("PureTuiTerminal", () => {
     })
     await capture.terminal.start()
     setTimeout(() => process.exit(), 50)
-
     await expect(capture.cleanup()).rejects.toThrow("child alive")
     expect(process.killCalls).toBe(1)
   }, 200)
@@ -196,6 +194,7 @@ describe("PureTuiTerminal", () => {
 describe("PureTUI PTY sidecar", () => {
   test("seeds tasks before launching the source TUI in the fixture repo", async () => {
     const calls: Array<{ file: string; args: string[]; cwd: string }> = []
+    let launchEnv: Record<string, string> | undefined
     const child = {
       pid: 123,
       write() {},
@@ -204,11 +203,12 @@ describe("PureTUI PTY sidecar", () => {
       onExit: () => ({ dispose() {} }),
     }
     const controller = createSidecarController({
-      baseEnv: { PATH: process.env.PATH ?? "" },
+      baseEnv: { PATH: process.env.PATH ?? "", HOME: "/native-home", USERPROFILE: "/native-profile" },
       runSetup: async (file: string, args: string[], options: { cwd: string }) => {
         calls.push({ file, args, cwd: options.cwd })
       },
-      spawnPty: (file: string, args: string[], options: { cwd: string }) => {
+      spawnPty: (file: string, args: string[], options: { cwd: string; env: Record<string, string> }) => {
+        launchEnv = options.env
         calls.push({ file, args, cwd: options.cwd })
         return child
       },
@@ -229,7 +229,6 @@ describe("PureTUI PTY sidecar", () => {
       cols: 160,
       rows: 45,
     })
-
     expect(calls).toEqual([
       {
         file: "bun",
@@ -253,6 +252,11 @@ describe("PureTUI PTY sidecar", () => {
         cwd: "/demo/fixture-repo",
       },
     ])
+    expect(launchEnv).toMatchObject({
+      HOME: "/native-home",
+      USERPROFILE: "/native-profile",
+      KOBE_HOME_DIR: "/demo/home",
+    })
   })
 
   test("serializes active xterm cells with ANSI foreground and background styles", () => {
@@ -280,7 +284,6 @@ describe("PureTUI PTY sidecar", () => {
       },
     ]
     const line = { length: 1, getCell: (index: number) => cells[index] }
-
     expect(serializeXtermLine(line)).toBe("\u001b[0;1;38;2;255;0;0;48;5;4mK\u001b[0m")
   })
 
@@ -347,9 +350,8 @@ describe("PureTUI PTY sidecar", () => {
     ).toMatchObject({ ok: true })
     const response = await controller.handle({ id: 2, op: "stop" })
     order.push("ack")
-
     expect(response).toMatchObject({ id: 2, ok: true })
-    expect(order).toEqual(["write:\"\\u0003\"", "child-exit", "reset", "ack"])
+    expect(order).toEqual(['write:"\\u0003"', "child-exit", "reset", "ack"])
     expect(resetEnv).toEqual(launchEnv)
   })
 
@@ -382,9 +384,7 @@ describe("PureTUI PTY sidecar", () => {
       cols: 80,
       rows: 1,
     })
-
     const response = await controller.handle({ id: 2, op: "stop" })
-
     expect(response).toMatchObject({
       id: 2,
       ok: false,
@@ -422,9 +422,7 @@ describe("PureTUI PTY sidecar", () => {
       rows: 1,
     })
     onData("\u001b[31mraw ansi\u001b[0m")
-
     const response = await controller.handle({ id: 2, op: "waitFor", pattern: "missing", timeoutMs: 0 })
-
     expect(response).toMatchObject({ ok: false, error: { snapshot: "\u001b[31mraw ansi\u001b[0m" } })
   })
 })
@@ -471,6 +469,7 @@ describe("capture PureTUI CLI", () => {
       fixtureRepo: join(root, "demo", "fixture-repo"),
       seedTasks: [{ title: "fix flaky turn-detector test", status: "in_progress" }],
     })
+    expect(received).not.toHaveProperty("pathPrefix")
     expect(await Bun.file(join(root, "demo", "home", ".config", "kobe", "state.json")).json()).toEqual({
       onboarded: true,
       skillHintSeen: "1",

--- a/packages/branding/tests/puretui-terminal.test.ts
+++ b/packages/branding/tests/puretui-terminal.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { capturePureTui } from "../scripts/capture-puretui"
-import { createSidecarController } from "../scripts/puretui-pty-sidecar.mjs"
+import {
+  createSidecarController,
+  ensureNodePtySpawnHelperExecutable,
+  serializeXtermLine,
+} from "../scripts/puretui-pty-sidecar.mjs"
 import {
   createPureTuiCapture,
   type SidecarFactory,
@@ -77,9 +81,10 @@ const fakeFactory = (handler: (process: FakeSidecar, request: Request) => void) 
 }
 
 describe("PureTuiTerminal", () => {
-  test("launches dev:sandbox with an isolated home and fixed replay viewport", async () => {
+  test("launches source PureTUI with an isolated home, fixture repo, and fixed replay viewport", async () => {
     const repoRoot = resolve(import.meta.dirname, "../../..")
     const demoRoot = join(await mkdtemp(join(tmpdir(), "kobe-puretui-test-")), "demo")
+    const fixtureRepo = join(demoRoot, "fixture-repo")
     const sidecarFactory = fakeFactory((process, request) => {
       if (request.op === "start") {
         process.respond({ id: request.id, ok: true, value: { pid: 4242, demoRoot, snapshot: "boot" } })
@@ -88,7 +93,15 @@ describe("PureTuiTerminal", () => {
       }
     })
 
-    const capture = await createPureTuiCapture({ repoRoot, demoRoot, cols: 160, rows: 45, sidecarFactory })
+    const capture = await createPureTuiCapture({
+      repoRoot,
+      demoRoot,
+      fixtureRepo,
+      seedTasks: [{ title: "seed task", status: "in_progress" }],
+      cols: 160,
+      rows: 45,
+      sidecarFactory,
+    })
     expect(sidecarFactory.calls[0]).toMatchObject({
       file: "node",
       args: [expect.stringContaining("puretui-pty-sidecar.mjs")],
@@ -103,6 +116,8 @@ describe("PureTuiTerminal", () => {
       op: "start",
       repoRoot,
       demoRoot,
+      fixtureRepo,
+      seedTasks: [{ title: "seed task", status: "in_progress" }],
       cols: 160,
       rows: 45,
     })
@@ -124,6 +139,7 @@ describe("PureTuiTerminal", () => {
     const capture = await createPureTuiCapture({
       repoRoot: resolve(import.meta.dirname, "../../.."),
       demoRoot,
+      fixtureRepo: join(demoRoot, "fixture-repo"),
       cols: 80,
       rows: 24,
       protocolTimeoutMs: 10,
@@ -159,6 +175,7 @@ describe("PureTuiTerminal", () => {
     const capture = await createPureTuiCapture({
       repoRoot: resolve(import.meta.dirname, "../../.."),
       demoRoot,
+      fixtureRepo: join(demoRoot, "fixture-repo"),
       cols: 80,
       rows: 24,
       sidecarExitTimeoutMs: 10,
@@ -173,6 +190,107 @@ describe("PureTuiTerminal", () => {
 })
 
 describe("PureTUI PTY sidecar", () => {
+  test("seeds tasks before launching the source TUI in the fixture repo", async () => {
+    const calls: Array<{ file: string; args: string[]; cwd: string }> = []
+    const child = {
+      pid: 123,
+      write() {},
+      kill() {},
+      onData: () => ({ dispose() {} }),
+      onExit: () => ({ dispose() {} }),
+    }
+    const controller = createSidecarController({
+      baseEnv: { PATH: process.env.PATH ?? "" },
+      runSetup: async (file: string, args: string[], options: { cwd: string }) => {
+        calls.push({ file, args, cwd: options.cwd })
+      },
+      spawnPty: (file: string, args: string[], options: { cwd: string }) => {
+        calls.push({ file, args, cwd: options.cwd })
+        return child
+      },
+      createTerminal: () => ({
+        write: (_data: string, callback: () => void) => callback(),
+        buffer: { active: { getLine: () => undefined } },
+        dispose() {},
+      }),
+    })
+
+    await controller.handle({
+      id: 1,
+      op: "start",
+      repoRoot: "/repo",
+      demoRoot: "/demo",
+      fixtureRepo: "/demo/fixture-repo",
+      seedTasks: [{ title: "seed task", status: "in_progress" }],
+      cols: 160,
+      rows: 45,
+    })
+
+    expect(calls).toEqual([
+      {
+        file: "bun",
+        args: [
+          "--conditions=browser",
+          "/repo/packages/kobe/src/cli/index.ts",
+          "api",
+          "add",
+          "--repo",
+          "/demo/fixture-repo",
+          "--title",
+          "seed task",
+          "--status",
+          "in_progress",
+        ],
+        cwd: "/demo/fixture-repo",
+      },
+      {
+        file: "bun",
+        args: ["--conditions=browser", "/repo/packages/kobe/src/cli/index.ts"],
+        cwd: "/demo/fixture-repo",
+      },
+    ])
+  })
+
+  test("serializes active xterm cells with ANSI foreground and background styles", () => {
+    const cells = [
+      {
+        getChars: () => "K",
+        getWidth: () => 1,
+        isAttributeDefault: () => false,
+        isBold: () => true,
+        isDim: () => false,
+        isItalic: () => false,
+        isUnderline: () => false,
+        isBlink: () => false,
+        isInverse: () => false,
+        isInvisible: () => false,
+        isStrikethrough: () => false,
+        isFgDefault: () => false,
+        isFgPalette: () => false,
+        isFgRGB: () => true,
+        getFgColor: () => 0xff0000,
+        isBgDefault: () => false,
+        isBgPalette: () => true,
+        isBgRGB: () => false,
+        getBgColor: () => 4,
+      },
+    ]
+    const line = { length: 1, getCell: (index: number) => cells[index] }
+
+    expect(serializeXtermLine(line)).toBe("\u001b[0;1;38;2;255;0;0;48;5;4mK\u001b[0m")
+  })
+
+  test("repairs Bun-installed node-pty spawn-helper permissions before launch", async () => {
+    const calls: Array<[string, number]> = []
+    await ensureNodePtySpawnHelperExecutable({
+      platform: "darwin",
+      arch: "arm64",
+      resolveModule: () => "/deps/node-pty/lib/index.js",
+      chmodFile: async (path: string, mode: number) => calls.push([path, mode]),
+    })
+    expect(calls).toEqual([["/deps/node-pty/prebuilds/darwin-arm64/spawn-helper", 0o755]])
+  })
+
   test("acknowledges stop only after child exit and isolated sandbox reset", async () => {
     const order: string[] = []
     let onExit = () => {}
@@ -213,7 +331,15 @@ describe("PureTUI PTY sidecar", () => {
     const demoRoot = join(tmpdir(), "kobe-sidecar-stop")
 
     expect(
-      await controller.handle({ id: 1, op: "start", repoRoot: "/repo", demoRoot, cols: 160, rows: 45 }),
+      await controller.handle({
+        id: 1,
+        op: "start",
+        repoRoot: "/repo",
+        demoRoot,
+        fixtureRepo: join(demoRoot, "fixture-repo"),
+        cols: 160,
+        rows: 45,
+      }),
     ).toMatchObject({ ok: true })
     const response = await controller.handle({ id: 2, op: "stop" })
     order.push("ack")
@@ -243,7 +369,15 @@ describe("PureTUI PTY sidecar", () => {
       killTimeoutMs: 1,
     })
     const demoRoot = join(tmpdir(), "kobe-sidecar-alive")
-    await controller.handle({ id: 1, op: "start", repoRoot: "/repo", demoRoot, cols: 80, rows: 1 })
+    await controller.handle({
+      id: 1,
+      op: "start",
+      repoRoot: "/repo",
+      demoRoot,
+      fixtureRepo: join(demoRoot, "fixture-repo"),
+      cols: 80,
+      rows: 1,
+    })
 
     const response = await controller.handle({ id: 2, op: "stop" })
 
@@ -274,7 +408,15 @@ describe("PureTUI PTY sidecar", () => {
         dispose() {},
       }),
     })
-    await controller.handle({ id: 1, op: "start", repoRoot: "/repo", demoRoot: "/demo", cols: 80, rows: 1 })
+    await controller.handle({
+      id: 1,
+      op: "start",
+      repoRoot: "/repo",
+      demoRoot: "/demo",
+      fixtureRepo: "/demo/fixture-repo",
+      cols: 80,
+      rows: 1,
+    })
     onData("\u001b[31mraw ansi\u001b[0m")
 
     const response = await controller.handle({ id: 2, op: "waitFor", pattern: "missing", timeoutMs: 0 })
@@ -284,6 +426,54 @@ describe("PureTUI PTY sidecar", () => {
 })
 
 describe("capture PureTUI CLI", () => {
+  test("passes the fixture repo and declared seed tasks to the capture terminal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kobe-capture-cli-valid-"))
+    const specPath = join(root, "capture.replay.json")
+    const outputPath = join(root, "frames.json")
+    const raw = JSON.parse(
+      await Bun.file(join(resolve(import.meta.dirname, ".."), "src/quicklook/quicklook.replay.json")).text(),
+    )
+    raw.capture.seconds = 0
+    raw.beats = []
+    raw.stages = [{ name: "still", from: 0, to: "end" }]
+    await writeFile(specPath, `${JSON.stringify(raw)}\n`)
+    let received: Parameters<NonNullable<Parameters<typeof capturePureTui>[1]["createCapture"]>>[0] | undefined
+
+    await capturePureTui(
+      { specPath, outputPath, demoRoot: join(root, "demo"), keepDemoRoot: true },
+      {
+        createCapture: async (options) => {
+          received = options
+          return {
+            demoRoot: options.demoRoot,
+            terminal: {
+              async start() {},
+              async snapshot() {
+                return Array.from({ length: options.rows }, () => "")
+              },
+              async type() {},
+              async key() {},
+              async waitFor() {},
+              async stop() {},
+            },
+            async cleanup() {},
+          }
+        },
+        log: () => {},
+      },
+    )
+
+    expect(received).toMatchObject({
+      fixtureRepo: join(root, "demo", "fixture-repo"),
+      seedTasks: [{ title: "fix flaky turn-detector test", status: "in_progress" }],
+    })
+    expect(await Bun.file(join(root, "demo", "home", ".config", "kobe", "state.json")).json()).toEqual({
+      onboarded: true,
+      skillHintSeen: "1",
+      savedRepos: [join(root, "demo", "fixture-repo")],
+    })
+  })
+
   test("validates the replay spec before spawning the sidecar", async () => {
     const root = await mkdtemp(join(tmpdir(), "kobe-capture-cli-"))
     const specPath = join(root, "invalid.replay.json")

--- a/packages/branding/tests/puretui-terminal.test.ts
+++ b/packages/branding/tests/puretui-terminal.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { capturePureTui } from "../scripts/capture-puretui"
+import { createSidecarController } from "../scripts/puretui-pty-sidecar.mjs"
+import {
+  createPureTuiCapture,
+  type SidecarFactory,
+  type SidecarProcess,
+  type SidecarSpawnOptions,
+} from "../src/quicklook/puretui-terminal"
+
+type Request = { id: number; op: string; [key: string]: unknown }
+
+class FakeSidecar implements SidecarProcess {
+  readonly requests: Request[] = []
+  readonly stdout: ReadableStream<Uint8Array>
+  readonly stderr = new ReadableStream<Uint8Array>({ start: (controller) => controller.close() })
+  readonly exited: Promise<number>
+  private output!: ReadableStreamDefaultController<Uint8Array>
+  private resolveExit!: (code: number) => void
+  private pending = ""
+  killCalls = 0
+
+  readonly stdin = {
+    write: (chunk: string | Uint8Array) => {
+      this.pending += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk)
+      for (;;) {
+        const newline = this.pending.indexOf("\n")
+        if (newline < 0) break
+        const line = this.pending.slice(0, newline)
+        this.pending = this.pending.slice(newline + 1)
+        const request = JSON.parse(line) as Request
+        this.requests.push(request)
+        this.onRequest(request)
+      }
+    },
+    end: () => {
+      if (this.exitOnEnd) this.resolveExit(0)
+    },
+  }
+
+  constructor(
+    private readonly onRequest: (request: Request) => void,
+    private readonly exitOnEnd = true,
+  ) {
+    this.stdout = new ReadableStream({ start: (controller) => (this.output = controller) })
+    this.exited = new Promise((resolveExit) => (this.resolveExit = resolveExit))
+  }
+
+  respond(response: unknown) {
+    this.output.enqueue(new TextEncoder().encode(`${JSON.stringify(response)}\n`))
+  }
+
+  exit(code = 0) {
+    this.resolveExit(code)
+  }
+
+  kill() {
+    this.killCalls++
+    this.resolveExit(1)
+  }
+}
+
+const fakeFactory = (handler: (process: FakeSidecar, request: Request) => void) => {
+  const calls: SidecarSpawnOptions[] = []
+  let process: FakeSidecar
+  const factory = ((options: SidecarSpawnOptions) => {
+    calls.push(options)
+    process = new FakeSidecar((request) => handler(process, request))
+    return process
+  }) as SidecarFactory & { calls: SidecarSpawnOptions[]; process: () => FakeSidecar }
+  factory.calls = calls
+  factory.process = () => process
+  return factory
+}
+
+describe("PureTuiTerminal", () => {
+  test("launches dev:sandbox with an isolated home and fixed replay viewport", async () => {
+    const repoRoot = resolve(import.meta.dirname, "../../..")
+    const demoRoot = join(await mkdtemp(join(tmpdir(), "kobe-puretui-test-")), "demo")
+    const sidecarFactory = fakeFactory((process, request) => {
+      if (request.op === "start") {
+        process.respond({ id: request.id, ok: true, value: { pid: 4242, demoRoot, snapshot: "boot" } })
+      } else {
+        process.respond({ id: request.id, ok: true, value: request.op === "snapshot" ? ["boot"] : null })
+      }
+    })
+
+    const capture = await createPureTuiCapture({ repoRoot, demoRoot, cols: 160, rows: 45, sidecarFactory })
+    expect(sidecarFactory.calls[0]).toMatchObject({
+      file: "node",
+      args: [expect.stringContaining("puretui-pty-sidecar.mjs")],
+      env: expect.objectContaining({
+        KOBE_SANDBOX_HOME_DIR: expect.stringContaining(demoRoot),
+        KOBE_HOME_DIR: expect.stringContaining(demoRoot),
+      }),
+    })
+
+    await capture.terminal.start()
+    expect(sidecarFactory.process().requests[0]).toMatchObject({
+      op: "start",
+      repoRoot,
+      demoRoot,
+      cols: 160,
+      rows: 45,
+    })
+    await capture.cleanup()
+  })
+
+  test("protocol timeouts surface the last ANSI snapshot, child pid, and demo root", async () => {
+    const demoRoot = join(await mkdtemp(join(tmpdir(), "kobe-puretui-timeout-")), "demo")
+    const sidecarFactory = fakeFactory((process, request) => {
+      if (request.op === "start") {
+        process.respond({
+          id: request.id,
+          ok: true,
+          value: { pid: 90210, demoRoot, snapshot: "\u001b[31mlatest screen\u001b[0m" },
+        })
+      }
+      if (request.op === "stop") process.respond({ id: request.id, ok: true, value: null })
+    })
+    const capture = await createPureTuiCapture({
+      repoRoot: resolve(import.meta.dirname, "../../.."),
+      demoRoot,
+      cols: 80,
+      rows: 24,
+      protocolTimeoutMs: 10,
+      sidecarFactory,
+    })
+
+    await capture.terminal.start()
+    await expect(capture.terminal.snapshot()).rejects.toThrow("latest screen")
+    await expect(capture.terminal.snapshot()).rejects.toThrow("90210")
+    await expect(capture.terminal.snapshot()).rejects.toThrow(demoRoot)
+    await capture.cleanup()
+  })
+
+  test("terminates a sidecar that stays alive after a failed stop", async () => {
+    const demoRoot = join(await mkdtemp(join(tmpdir(), "kobe-puretui-stalled-")), "demo")
+    let process: FakeSidecar
+    const sidecarFactory = ((options: SidecarSpawnOptions) => {
+      void options
+      process = new FakeSidecar((request) => {
+        if (request.op === "start") {
+          process.respond({ id: request.id, ok: true, value: { pid: 55, demoRoot, snapshot: "stalled" } })
+        }
+        if (request.op === "stop") {
+          process.respond({
+            id: request.id,
+            ok: false,
+            error: { message: "child alive", pid: 55, demoRoot, snapshot: "stalled" },
+          })
+        }
+      }, false)
+      return process
+    }) as SidecarFactory
+    const capture = await createPureTuiCapture({
+      repoRoot: resolve(import.meta.dirname, "../../.."),
+      demoRoot,
+      cols: 80,
+      rows: 24,
+      sidecarExitTimeoutMs: 10,
+      sidecarFactory,
+    })
+    await capture.terminal.start()
+    setTimeout(() => process.exit(), 50)
+
+    await expect(capture.cleanup()).rejects.toThrow("child alive")
+    expect(process.killCalls).toBe(1)
+  }, 200)
+})
+
+describe("PureTUI PTY sidecar", () => {
+  test("acknowledges stop only after child exit and isolated sandbox reset", async () => {
+    const order: string[] = []
+    let onExit = () => {}
+    const child = {
+      pid: 321,
+      write: (data: string) => {
+        order.push(`write:${JSON.stringify(data)}`)
+        queueMicrotask(() => {
+          order.push("child-exit")
+          onExit()
+        })
+      },
+      kill: () => order.push("kill"),
+      onData: () => ({ dispose() {} }),
+      onExit: (listener: () => void) => {
+        onExit = listener
+        return { dispose() {} }
+      },
+    }
+    let launchEnv: Record<string, string> | undefined
+    let resetEnv: Record<string, string> | undefined
+    const controller = createSidecarController({
+      baseEnv: { PATH: process.env.PATH ?? "" },
+      spawnPty: (_file: string, _args: string[], options: { env: Record<string, string> }) => {
+        launchEnv = options.env
+        return child
+      },
+      createTerminal: () => ({
+        write: (_data: string, callback: () => void) => callback(),
+        buffer: { active: { getLine: () => undefined } },
+        dispose() {},
+      }),
+      runReset: async (_file: string, _args: string[], options: { env: Record<string, string> }) => {
+        resetEnv = options.env
+        order.push("reset")
+      },
+    })
+    const demoRoot = join(tmpdir(), "kobe-sidecar-stop")
+
+    expect(
+      await controller.handle({ id: 1, op: "start", repoRoot: "/repo", demoRoot, cols: 160, rows: 45 }),
+    ).toMatchObject({ ok: true })
+    const response = await controller.handle({ id: 2, op: "stop" })
+    order.push("ack")
+
+    expect(response).toMatchObject({ id: 2, ok: true })
+    expect(order).toEqual(["write:\"\\u0003\"", "child-exit", "reset", "ack"])
+    expect(resetEnv).toEqual(launchEnv)
+  })
+
+  test("returns diagnostics instead of acknowledging stop while the child remains alive", async () => {
+    const controller = createSidecarController({
+      baseEnv: { PATH: process.env.PATH ?? "" },
+      spawnPty: () => ({
+        pid: 777,
+        write() {},
+        kill() {},
+        onData: () => ({ dispose() {} }),
+        onExit: () => ({ dispose() {} }),
+      }),
+      createTerminal: () => ({
+        write: (_data: string, callback: () => void) => callback(),
+        buffer: { active: { getLine: () => ({ translateToString: () => "still alive" }) } },
+        dispose() {},
+      }),
+      runReset: async () => {},
+      stopTimeoutMs: 1,
+      killTimeoutMs: 1,
+    })
+    const demoRoot = join(tmpdir(), "kobe-sidecar-alive")
+    await controller.handle({ id: 1, op: "start", repoRoot: "/repo", demoRoot, cols: 80, rows: 1 })
+
+    const response = await controller.handle({ id: 2, op: "stop" })
+
+    expect(response).toMatchObject({
+      id: 2,
+      ok: false,
+      error: { pid: 777, demoRoot, snapshot: "still alive" },
+    })
+  })
+
+  test("retains raw ANSI output in sidecar errors", async () => {
+    let onData = (_data: string) => {}
+    const controller = createSidecarController({
+      baseEnv: { PATH: process.env.PATH ?? "" },
+      spawnPty: () => ({
+        pid: 888,
+        write() {},
+        kill() {},
+        onData: (listener: (data: string) => void) => {
+          onData = listener
+          return { dispose() {} }
+        },
+        onExit: () => ({ dispose() {} }),
+      }),
+      createTerminal: () => ({
+        write: (_data: string, callback: () => void) => callback(),
+        buffer: { active: { getLine: () => ({ translateToString: () => "rendered" }) } },
+        dispose() {},
+      }),
+    })
+    await controller.handle({ id: 1, op: "start", repoRoot: "/repo", demoRoot: "/demo", cols: 80, rows: 1 })
+    onData("\u001b[31mraw ansi\u001b[0m")
+
+    const response = await controller.handle({ id: 2, op: "waitFor", pattern: "missing", timeoutMs: 0 })
+
+    expect(response).toMatchObject({ ok: false, error: { snapshot: "\u001b[31mraw ansi\u001b[0m" } })
+  })
+})
+
+describe("capture PureTUI CLI", () => {
+  test("validates the replay spec before spawning the sidecar", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kobe-capture-cli-"))
+    const specPath = join(root, "invalid.replay.json")
+    await writeFile(specPath, "{}\n")
+    let createCalls = 0
+
+    await expect(
+      capturePureTui(
+        { specPath, outputPath: join(root, "frames.json"), demoRoot: join(root, "demo"), keepDemoRoot: true },
+        {
+          createCapture: async () => {
+            createCalls++
+            throw new Error("sidecar must not start")
+          },
+        },
+      ),
+    ).rejects.toThrow("replay spec")
+    expect(createCalls).toBe(0)
+  })
+})

--- a/packages/branding/tests/puretui-terminal.test.ts
+++ b/packages/branding/tests/puretui-terminal.test.ts
@@ -14,7 +14,6 @@ import {
   type SidecarProcess,
   type SidecarSpawnOptions,
 } from "../src/quicklook/puretui-terminal"
-
 type Request = { id: number; op: string; [key: string]: unknown }
 
 class FakeSidecar implements SidecarProcess {
@@ -98,6 +97,9 @@ describe("PureTuiTerminal", () => {
       demoRoot,
       fixtureRepo,
       seedTasks: [{ title: "seed task", status: "in_progress" }],
+      pathPrefix: join(repoRoot, "packages", "branding", "scripts", "fixtures"),
+      readyPattern: "KOBE",
+      readyTimeoutMs: 500,
       cols: 160,
       rows: 45,
       sidecarFactory,
@@ -108,6 +110,7 @@ describe("PureTuiTerminal", () => {
       env: expect.objectContaining({
         KOBE_SANDBOX_HOME_DIR: expect.stringContaining(demoRoot),
         KOBE_HOME_DIR: expect.stringContaining(demoRoot),
+        PATH: expect.stringContaining("packages/branding/scripts/fixtures"),
       }),
     })
 
@@ -121,6 +124,7 @@ describe("PureTuiTerminal", () => {
       cols: 160,
       rows: 45,
     })
+    expect(sidecarFactory.process().requests[1]).toMatchObject({ op: "waitFor", pattern: "KOBE", timeoutMs: 500 })
     await capture.cleanup()
   })
 

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import quicklookSpec from "../src/quicklook/quicklook.replay.json"
-import { regionCoordinateHash, resolveReplaySpec, replayDurationSeconds } from "../src/quicklook/replay-spec"
+import { regionCoordinateHash, replayDurationSeconds, resolveReplaySpec } from "../src/quicklook/replay-spec"
 
 const capture = {
   cols: 160,
   rows: 45,
-  frames: [{ t: 0, lines: [] }, { t: 12.5, lines: [] }],
+  frames: [
+    { t: 0, lines: [] },
+    { t: 12.5, lines: [] },
+  ],
 }
 
 const baseSpec = {
@@ -116,8 +119,22 @@ describe("replay spec", () => {
             defaultFg: "#fff",
             defaultBg: "#000",
             ansi16: [
-              "#000", "#000", "#000", "#000", "#000", "#000", "#000", "#000",
-              "#000", "#000", "#000", "#000", "#000", "#000", "#000", "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
+              "#000",
             ],
             runOverrides: [],
           },
@@ -131,9 +148,9 @@ describe("replay spec", () => {
     expect(() => resolveReplaySpec({ ...baseSpec, beats: [{ at: 0, action: "mouse" }] }, capture)).toThrow(
       /unsupported action "mouse"/,
     )
-    expect(() => resolveReplaySpec({ ...baseSpec, beats: [{ at: 0, action: "flow", flow: "missing" }] }, capture)).toThrow(
-      /unknown flow "missing"/,
-    )
+    expect(() =>
+      resolveReplaySpec({ ...baseSpec, beats: [{ at: 0, action: "flow", flow: "missing" }] }, capture),
+    ).toThrow(/unknown flow "missing"/)
   })
 
   test("rejects malformed seed tasks before capture starts", () => {
@@ -146,9 +163,9 @@ describe("replay spec", () => {
   })
 
   test("rejects capture timing that cannot drive polling", () => {
-    expect(() =>
-      resolveReplaySpec({ ...baseSpec, capture: { ...baseSpec.capture, fps: 0 } }, capture),
-    ).toThrow(/capture.fps must be positive/)
+    expect(() => resolveReplaySpec({ ...baseSpec, capture: { ...baseSpec.capture, fps: 0 } }, capture)).toThrow(
+      /capture.fps must be positive/,
+    )
   })
 
   test("rejects an unknown workspace readiness wait", () => {
@@ -159,5 +176,7 @@ describe("replay spec", () => {
 
   test("keeps quicklook theme limited to terminal state", () => {
     expect(Object.keys(quicklookSpec.theme).sort()).toEqual(["ansi16", "defaultBg", "defaultFg"])
+    expect(quicklookSpec.setup).not.toHaveProperty("fixtureEngines")
+    expect(quicklookSpec.waits.claudeComposerReady.pattern).toBe("❯")
   })
 })

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -136,6 +136,15 @@ describe("replay spec", () => {
     )
   })
 
+  test("rejects malformed seed tasks before capture starts", () => {
+    expect(() =>
+      resolveReplaySpec({ ...baseSpec, setup: { seedTasks: [{ title: "", status: "in_progress" }] } }, capture),
+    ).toThrow(/setup.seedTasks\[0\].title/)
+    expect(() =>
+      resolveReplaySpec({ ...baseSpec, setup: { seedTasks: [{ title: "seed", status: "unknown" }] } }, capture),
+    ).toThrow(/unsupported status "unknown"/)
+  })
+
   test("keeps quicklook theme limited to terminal state", () => {
     expect(Object.keys(quicklookSpec.theme).sort()).toEqual(["ansi16", "defaultBg", "defaultFg"])
   })

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -127,6 +127,15 @@ describe("replay spec", () => {
     ).toThrow(/theme.runOverrides/)
   })
 
+  test("rejects unsupported capture actions and missing flow names", () => {
+    expect(() => resolveReplaySpec({ ...baseSpec, beats: [{ at: 0, action: "mouse" }] }, capture)).toThrow(
+      /unsupported action "mouse"/,
+    )
+    expect(() => resolveReplaySpec({ ...baseSpec, beats: [{ at: 0, action: "flow", flow: "missing" }] }, capture)).toThrow(
+      /unknown flow "missing"/,
+    )
+  })
+
   test("keeps quicklook theme limited to terminal state", () => {
     expect(Object.keys(quicklookSpec.theme).sort()).toEqual(["ansi16", "defaultBg", "defaultFg"])
   })

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -151,6 +151,12 @@ describe("replay spec", () => {
     ).toThrow(/capture.fps must be positive/)
   })
 
+  test("rejects an unknown workspace readiness wait", () => {
+    expect(() => resolveReplaySpec({ ...baseSpec, setup: { readyWait: "missing" } }, capture)).toThrow(
+      /setup references unknown wait "missing"/,
+    )
+  })
+
   test("keeps quicklook theme limited to terminal state", () => {
     expect(Object.keys(quicklookSpec.theme).sort()).toEqual(["ansi16", "defaultBg", "defaultFg"])
   })

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -179,4 +179,39 @@ describe("replay spec", () => {
     expect(quicklookSpec.setup).not.toHaveProperty("fixtureEngines")
     expect(quicklookSpec.waits.claudeComposerReady.pattern).toBe("❯")
   })
+
+  test("holds a real ClaudeX permission prompt through the replay tail", () => {
+    const claudePrompt = quicklookSpec.beats.find(
+      (beat) => beat.action === "typeTextWhenReady" && beat.textRef === "claudePrompt",
+    )
+    const permissionReady = quicklookSpec.beats.find(
+      (beat) => beat.action === "waitFor" && beat.waitFor === "claudePermissionPrompt",
+    )
+    const permissionHold = quicklookSpec.beats.find(
+      (beat) => beat.action === "sleep" && beat.at === permissionReady?.at,
+    )
+    expect(quicklookSpec.text.claudePrompt).toContain("printf replay-color-probe")
+    expect(quicklookSpec.waits.claudePermissionPrompt.pattern).toBe("Do you want to proceed?")
+    expect(claudePrompt?.submit).toBe(true)
+    expect(permissionReady).toEqual(
+      expect.objectContaining({ action: "waitFor", waitFor: "claudePermissionPrompt" }),
+    )
+    expect(permissionReady?.at).toBeGreaterThan(claudePrompt?.at ?? Number.POSITIVE_INFINITY)
+    expect(permissionHold).toEqual(expect.objectContaining({ action: "sleep", ms: 2500 }))
+    expect(quicklookSpec.text).not.toHaveProperty("codexPrompt")
+    expect(Object.keys(quicklookSpec.waits)).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/^codex/)]),
+    )
+    expect(quicklookSpec.flows.createTask).not.toHaveProperty("codexEngineCycleKey")
+    expect(quicklookSpec.flows.createTask).not.toHaveProperty("codexEngineSettleMs")
+    expect(quicklookSpec.regions).not.toHaveProperty("inputCodex")
+    expect(quicklookSpec.beats).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "flow", engine: "codex" })]),
+    )
+    expect(quicklookSpec.beats).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "key", key: "C-q" })]),
+    )
+    expect(quicklookSpec.capture.seconds).toBe(50)
+    expect(quicklookSpec.stages.find((stage) => stage.name === "agent")?.region).toBeUndefined()
+  })
 })

--- a/packages/branding/tests/replay-spec.test.ts
+++ b/packages/branding/tests/replay-spec.test.ts
@@ -145,6 +145,12 @@ describe("replay spec", () => {
     ).toThrow(/unsupported status "unknown"/)
   })
 
+  test("rejects capture timing that cannot drive polling", () => {
+    expect(() =>
+      resolveReplaySpec({ ...baseSpec, capture: { ...baseSpec.capture, fps: 0 } }, capture),
+    ).toThrow(/capture.fps must be positive/)
+  })
+
   test("keeps quicklook theme limited to terminal state", () => {
     expect(Object.keys(quicklookSpec.theme).sort()).toEqual(["ansi16", "defaultBg", "defaultFg"])
   })


### PR DESCRIPTION
## Summary

- add a backend-neutral replay interpreter and a Node PTY sidecar for the real PureTUI + Hosted PTY runtime
- add deterministic capture-only Claude/Codex fixtures and a current two-engine Brand Studio storyboard
- preserve native terminal default-color negotiation by forwarding xterm replies and answering OSC 10/11 from the replay theme
- check in a refreshed 160x45 native ANSI capture and document the reproducible capture/render workflow

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` (234 files / 2230 tests, plus 33 daemon files / 263 tests)
- `cd packages/kobe && bun run build && bun run test:behavior`
- `cd packages/branding && bun run test:replay` (34 passed, opt-in E2E skipped)
- captured a live `/harness` reference and reviewed the rendered 16-second frame for background, text, accent, warning, and muted colors
- rendered `quicklook-replay-4x` at 1280x720 from the refreshed native capture
- `bun run visual` reaches the real OpenTUI but detects the pre-existing stale Kanban baseline: `origin/main` contains the newer AFTER START UI while its committed snapshot still contains the older placement UI

## Artifact

- local render: `packages/branding/out/kobe-quicklook-4x.mp4`
- confirmation frame: `packages/branding/out/kobe-quicklook-color-confirmed.png`