### PR TITLE
fix: strip trailing CR when parsing Copilot workspace.yaml

### DIFF
--- a/.changeset/copilot-workspace-crlf.md
+++ b/.changeset/copilot-workspace-crlf.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix Copilot session history, auto-title, and activity detection silently going blank when the CLI writes a CRLF `workspace.yaml` (as it does on Windows): the workspace parser now strips a trailing carriage return so the recorded `cwd` still matches the task's worktree instead of carrying a stray `\r` that failed every comparison — bringing it in line with the other porcelain parsers and the sibling events reader.

--- a/packages/kobe/src/engine/copilot-local/history.ts
+++ b/packages/kobe/src/engine/copilot-local/history.ts
@@ -148,7 +148,13 @@ export async function readWorkspace(
 
 export function parseWorkspaceYaml(raw: string): CopilotWorkspaceMeta {
   const out: Record<string, string> = {}
-  for (const line of raw.split("\n")) {
+  for (const rawLine of raw.split("\n")) {
+    // Strip a trailing CR so a CRLF workspace.yaml (what the Copilot CLI
+    // writes on Windows) doesn't leave `\r` on every value — the greedy
+    // `.*$` below would otherwise keep it, breaking the `cwd` worktree match
+    // and the quote-strip. Mirrors the sibling porcelain parsers
+    // (git-parsers.ts, worktree-list.ts) and this file's own foldEvents.
+    const line = rawLine.replace(/\r$/, "")
     const match = line.match(/^([A-Za-z_]+):\s*(.*)$/)
     if (!match) continue
     const key = match[1]

--- a/packages/kobe/test/engine/copilot-history.test.ts
+++ b/packages/kobe/test/engine/copilot-history.test.ts
@@ -14,6 +14,36 @@ describe("parseWorkspaceYaml", () => {
     expect(meta.cwd).toBe("/work/tree")
     expect(meta.updatedAt).toBe("2026-05-01T00:00:00Z")
   })
+
+  it("strips a trailing CR so a CRLF workspace.yaml still matches the worktree", () => {
+    // The Copilot CLI writes CRLF line endings on Windows. Without stripping
+    // the CR, `cwd` keeps a trailing "\r" (breaking the worktree comparison)
+    // and a quoted value fails the endsWith('"') quote-strip.
+    const meta = parseWorkspaceYaml('id: abc123\r\ncwd: "/work/tree"\r\nupdated_at: 2026-05-01T00:00:00Z\r\n')
+    expect(meta.id).toBe("abc123")
+    expect(meta.cwd).toBe("/work/tree")
+    expect(meta.updatedAt).toBe("2026-05-01T00:00:00Z")
+  })
+})
+
+describe("listSessionIdsForWorktree — CRLF workspace.yaml", () => {
+  it("matches a worktree whose workspace.yaml uses CRLF line endings", async () => {
+    const dirs: Record<string, string> = {
+      "crlf/workspace.yaml": "id: crlf\r\ncwd: /wt\r\nupdated_at: 2026-01-01T00:00:00Z\r\n",
+    }
+    const deps: CopilotHistoryDeps = {
+      copilotDir: () => "/home/.copilot",
+      readdir: async (p) => (p.endsWith("session-state") ? ["crlf"] : []),
+      readFile: async (p) => {
+        const key = Object.keys(dirs).find((k) => p.endsWith(k))
+        if (!key) throw new Error("missing")
+        return dirs[key]
+      },
+      stat: async () => ({ mtimeMs: 0 }),
+      rm: async () => {},
+    }
+    expect(await listSessionIdsForWorktree("/wt", deps)).toEqual(["crlf"])
+  })
 })
 
 describe("listSessionIdsForWorktree", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — found by direct code review of the pure-logic engine layer. `parseWorkspaceYaml` in `src/engine/copilot-local/history.ts` is the parser behind every Copilot history read, and its CRLF path was uncovered.

## Problem

`parseWorkspaceYaml` reads `~/.copilot/session-state/<id>/workspace.yaml` (the file recording each Copilot conversation's `cwd`). It splits on `"\n"` only and matches each line with a greedy `.*$`:

```ts
for (const line of raw.split("\n")) {
  const match = line.match(/^([A-Za-z_]+):\s*(.*)$/)
  ...
  let value = match[2] ?? ""
  if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1).replace(/\\"/g, '"')
  out[key] = value
}
```

On a **CRLF** `workspace.yaml` — which the GitHub Copilot CLI (a Node app) writes on Windows, where `os.EOL` is `\r\n` — `.` matches the trailing `\r`, so every parsed value keeps a stray carriage return. Two things break:

- **Worktree match fails.** `listSessionIdsForWorktree` / `latestTranscriptMtimeForWorktree` compare `workspace.cwd !== worktree`. With `cwd = "/wt\r"` vs `"/wt"`, that is always true, so **every** Copilot session for that worktree is dropped — session listing, `latestTranscriptMtimeForWorktree` (the Ops activity badge), and auto-title all silently return empty/0.
- **Quote-strip fails.** A quoted `cwd: "/work/tree"` arrives as `"/work/tree"\r`, so `endsWith('"')` is false and the surrounding quotes are never removed.

This is a lone oversight, not a house style: the sibling porcelain parsers strip `\r` (`src/lib/git-parsers.ts:265`, `src/tui/.../worktree-list.ts:32` both `.replace(/\r$/, "")`), and this very file's `foldEvents` is CRLF-safe via `line.trim()`. Only `parseWorkspaceYaml` read the raw line.

## Fix

Strip a trailing CR per line before matching (`rawLine.replace(/\r$/, "")`). `\n`-only input is byte-identical to before; the fix only affects CRLF files, restoring both the `cwd` comparison and the quote-strip. One function, no other behavior changed.

## Verification

- Added two regression tests to `test/engine/copilot-history.test.ts`: `parseWorkspaceYaml` on a CRLF document yields clean `id`/`cwd`/`updatedAt`, and `listSessionIdsForWorktree` matches a worktree whose `workspace.yaml` uses CRLF. Confirmed **both fail against the pre-fix code** — the list case returns `[]` instead of `["crlf"]` (the exact breakage) — and pass with the fix.
- `bunx vitest run test/engine/` — 339 pass across 30 files, no regressions.
- `bun run lint` — green (726 files). `bun run typecheck` — green (`@sma1lboy/kobe-daemon` + `@sma1lboy/kobe`).
- `history.ts` is 302 lines, well under the file-size cap.

Patch changeset included.

## Follow-ups

None required. The trigger is Windows-only (that is where CRLF `workspace.yaml` originates), but the fix is defensive and costless on `\n` input, and it removes a complete-feature-break for Windows Copilot users.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DEUdCCZXtmkEYBVkEXw7B)_