### PR TITLE
fix: clean legacy tmux runtimes

### DIFF
--- a/.changeset/clean-legacy-tmux.md
+++ b/.changeset/clean-legacy-tmux.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Detect and report pre-v0.8 tmux process memory in `kobe doctor`, and make `kobe reset` safely terminate those legacy pane process groups before stopping the retired server.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,6 +57,11 @@ The Daemon is refcounted by attached GUI clients and browser streams. A daemon
 idle exit leaves the PTY Host untouched. The PTY Host idle-exits only when it
 owns zero live sessions.
 
+Tmux is not a session backend. The CLI retains one quarantined compatibility
+seam solely for upgrades from pre-v0.8: `kobe doctor` reports processes still
+owned by the retired `tmux -L kobe` server, and `kobe reset` terminates those
+pane process groups before stopping that server.
+
 ## 4. Hosted session addressing
 
 Each Terminal Tab uses `<taskId>::<tabId>`. The initial engine tab is

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -88,7 +88,8 @@ in `packages/kobe-web/test-results/` (actual/diff/trace).
 - render paths do not run synchronous subprocesses outside the explicit
   whitelist;
 - production code cannot import, spawn, or configure the retired session
-  backend;
+  backend; the sole exception is `cli/legacy-tmux.ts`, which only diagnoses
+  and removes pre-v0.8 leftovers for `doctor` / `reset`;
 - published source changes include one patch changeset by default;
 - daemon/orchestrator/engine edits are verified after replacing stale daemon
   processes in the chosen sandbox.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -64,3 +64,24 @@ The wheel follows real terminal-emulator semantics, in order:
 
 If scrolling "does nothing" inside an app, that app received the events and
 chose not to scroll — check its own mouse setting (e.g. `:set mouse=a`).
+
+## Memory stays high after upgrading from a pre-0.8 build
+
+kobe 0.8 replaced the old tmux runtime with the PureTUI + Hosted PTY backend,
+but upgrading the package does not stop sessions that a pre-0.8 build already
+left running. Those old `tmux -L kobe` sessions keep their `bun` / engine
+process groups resident, so memory can look unchanged after the upgrade.
+
+`kobe doctor` now reports them:
+
+```
+legacy tmux: ⚠ tmux 3.5a — 2 pre-v0.8 session(s) on `kobe`
+             20 process(es) across 8 pane(s), 1008.5 MB RSS total
+             → run `kobe reset` to stop this retired runtime safely
+```
+
+**Fix:** `kobe reset`. It stops the daemon and Hosted PTY host, then SIGTERMs
+each legacy pane process group before killing the retired tmux server (a bare
+`tmux kill-server` would leak engines that ignore `SIGHUP`). Worktrees and the
+task index are untouched; add `--hard` only if you also want to wipe task/UI
+state.

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -15,6 +15,7 @@ import { readPidFile } from "@sma1lboy/kobe-daemon/daemon/server"
 import { homeDir, kobeStateDir, kvStatePath } from "../env.ts"
 import { SKILL_INSTALL_COMMAND, kobeSkillState } from "../lib/skill-install.ts"
 import { CURRENT_VERSION } from "../version.ts"
+import { inspectLegacyTmux, legacyTmuxDoctorLines } from "./legacy-tmux.ts"
 
 type PtySessionStatus = { alive?: boolean }
 
@@ -106,9 +107,12 @@ async function appendUnavailableProcess(
 export async function runDoctorSubcommand(argv: readonly string[] = []): Promise<void> {
   if (argv.some((arg) => arg === "--help" || arg === "-h" || arg === "help")) {
     process.stdout.write(
-      ["Usage: kobe doctor", "", "Read-only diagnosis of the daemon / Hosted PTY / state. Takes no options.", ""].join(
-        "\n",
-      ),
+      [
+        "Usage: kobe doctor",
+        "",
+        "Read-only diagnosis of the daemon / Hosted PTY / legacy tmux / state. Takes no options.",
+        "",
+      ].join("\n"),
     )
     return
   }
@@ -167,6 +171,8 @@ export async function runDoctorSubcommand(argv: readonly string[] = []): Promise
     await appendUnavailableProcess(out, "pty host", defaultPtyHostPidPath(), ptySocket)
   }
   out.push("")
+
+  out.push(...legacyTmuxDoctorLines(await inspectLegacyTmux()), "")
 
   const skill = kobeSkillState()
   if (!skill.installed) {

--- a/packages/kobe/src/cli/legacy-tmux.ts
+++ b/packages/kobe/src/cli/legacy-tmux.ts
@@ -1,0 +1,219 @@
+/** Read-only diagnosis and reset-time cleanup for pre-v0.8 tmux sessions. */
+
+export const LEGACY_TMUX_SOCKET = "kobe"
+
+interface CommandResult {
+  code: number
+  stdout: string
+  stderr: string
+  missing: boolean
+}
+
+export interface LegacyProcessRow {
+  pid: number
+  pgid: number
+  rssKb: number
+  command: string
+}
+
+export interface LegacyTmuxReport {
+  available: boolean
+  version: string | null
+  sessions: string[]
+  panePids: number[]
+  processes: LegacyProcessRow[]
+  error: string | null
+}
+
+export interface LegacyTmuxStopResult {
+  status: "absent" | "stopped" | "failed"
+  sessions: number
+  signalledGroups: number
+  error?: string
+}
+
+async function run(argv: readonly string[]): Promise<CommandResult> {
+  try {
+    const proc = Bun.spawn([...argv], { stdin: "ignore", stdout: "pipe", stderr: "pipe" })
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text().catch(() => ""),
+      new Response(proc.stderr).text().catch(() => ""),
+      proc.exited,
+    ])
+    return { code, stdout, stderr, missing: false }
+  } catch (error) {
+    const systemError = error as NodeJS.ErrnoException
+    return {
+      code: 127,
+      stdout: "",
+      stderr: error instanceof Error ? error.message : String(error),
+      missing: systemError.code === "ENOENT",
+    }
+  }
+}
+
+async function runTmux(socket: string, args: readonly string[]): Promise<CommandResult> {
+  return run(["tmux", "-L", socket, ...args])
+}
+
+function commandFailure(label: string, result: CommandResult): string {
+  return `${label} failed: ${result.stderr.trim() || `exit ${result.code}`}`
+}
+
+function isMissingServer(result: CommandResult): boolean {
+  return /no server running|failed to connect to server|no sessions/i.test(`${result.stdout}\n${result.stderr}`)
+}
+
+function parsePositiveInts(output: string): number[] {
+  return output
+    .split("\n")
+    .map((line) => Number.parseInt(line.trim(), 10))
+    .filter((value) => Number.isFinite(value) && value > 1)
+}
+
+export function parseLegacyPsRows(output: string): LegacyProcessRow[] {
+  const rows: LegacyProcessRow[] = []
+  for (const line of output.split("\n").slice(1)) {
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 4) continue
+    const pid = Number.parseInt(parts[0] ?? "", 10)
+    const pgid = Number.parseInt(parts[1] ?? "", 10)
+    const rssKb = Number.parseInt(parts[2] ?? "", 10)
+    if (!Number.isFinite(pid) || !Number.isFinite(pgid) || !Number.isFinite(rssKb)) continue
+    rows.push({ pid, pgid, rssKb, command: parts.slice(3).join(" ") })
+  }
+  return rows
+}
+
+export function legacyPaneProcesses(
+  rows: readonly LegacyProcessRow[],
+  panePids: readonly number[],
+): LegacyProcessRow[] {
+  const groups = new Set(panePids)
+  return rows.filter((row) => groups.has(row.pgid))
+}
+
+function emptyReport(available: boolean, version: string | null, error: string | null = null): LegacyTmuxReport {
+  return { available, version, sessions: [], panePids: [], processes: [], error }
+}
+
+export async function inspectLegacyTmux(socket: string = LEGACY_TMUX_SOCKET): Promise<LegacyTmuxReport> {
+  const versionResult = await run(["tmux", "-V"])
+  if (versionResult.missing) return emptyReport(false, null)
+  if (versionResult.code !== 0) return emptyReport(true, null, commandFailure("tmux -V", versionResult))
+
+  const version = versionResult.stdout.trim() || null
+  const sessionsResult = await runTmux(socket, ["list-sessions", "-F", "#{session_name}"])
+  if (sessionsResult.code !== 0) {
+    if (isMissingServer(sessionsResult)) return emptyReport(true, version)
+    return emptyReport(true, version, commandFailure("tmux list-sessions", sessionsResult))
+  }
+
+  const sessions = sessionsResult.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+  if (sessions.length === 0) return emptyReport(true, version)
+
+  const panesResult = await runTmux(socket, ["list-panes", "-a", "-F", "#{pane_pid}"])
+  if (panesResult.code !== 0) {
+    return { ...emptyReport(true, version, commandFailure("tmux list-panes", panesResult)), sessions }
+  }
+  const panePids = parsePositiveInts(panesResult.stdout)
+  if (panePids.length === 0) {
+    return { ...emptyReport(true, version, "tmux reported live sessions but no pane process groups"), sessions }
+  }
+
+  const psResult = await run(["ps", "-axo", "pid,pgid,rss,comm"])
+  if (psResult.code !== 0) {
+    return { available: true, version, sessions, panePids, processes: [], error: commandFailure("ps", psResult) }
+  }
+  return {
+    available: true,
+    version,
+    sessions,
+    panePids,
+    processes: legacyPaneProcesses(parseLegacyPsRows(psResult.stdout), panePids),
+    error: null,
+  }
+}
+
+export function legacyTmuxDoctorLines(report: LegacyTmuxReport, socket: string = LEGACY_TMUX_SOCKET): string[] {
+  if (report.error) return [`legacy tmux: ✗ inspection failed — ${report.error}`]
+  if (!report.available) return ["legacy tmux: not installed — no pre-v0.8 sessions to inspect"]
+
+  const version = report.version ?? "tmux (version unknown)"
+  if (report.sessions.length === 0) return [`legacy tmux: ${version} — no sessions on \`${socket}\``]
+
+  const totalMb = report.processes.reduce((sum, row) => sum + row.rssKb, 0) / 1024
+  const grouped = new Map<string, { count: number; rssKb: number }>()
+  for (const row of report.processes) {
+    const item = grouped.get(row.command) ?? { count: 0, rssKb: 0 }
+    item.count++
+    item.rssKb += row.rssKb
+    grouped.set(row.command, item)
+  }
+
+  const lines = [
+    `legacy tmux: ⚠ ${version} — ${report.sessions.length} pre-v0.8 session(s) on \`${socket}\``,
+    `             ${report.processes.length} process(es) across ${report.panePids.length} pane(s), ${totalMb.toFixed(1)} MB RSS total`,
+  ]
+  for (const [command, item] of [...grouped].sort((a, b) => b[1].rssKb - a[1].rssKb)) {
+    lines.push(`             ${command}: ${item.count} proc, ${(item.rssKb / 1024).toFixed(1)} MB`)
+  }
+  lines.push("             → run `kobe reset` to stop this retired runtime safely")
+  return lines
+}
+
+async function ownProcessGroup(): Promise<{ pgid: number | null; error: string | null }> {
+  const result = await run(["ps", "-o", "pgid=", "-p", String(process.pid)])
+  if (result.code !== 0) return { pgid: null, error: commandFailure("ps current process group", result) }
+  const pgid = Number.parseInt(result.stdout.trim(), 10)
+  if (!Number.isFinite(pgid) || pgid <= 1) return { pgid: null, error: "unable to determine current process group" }
+  return { pgid, error: null }
+}
+
+export async function stopLegacyTmux(socket: string = LEGACY_TMUX_SOCKET): Promise<LegacyTmuxStopResult> {
+  const report = await inspectLegacyTmux(socket)
+  if (report.error)
+    return { status: "failed", sessions: report.sessions.length, signalledGroups: 0, error: report.error }
+  if (!report.available || report.sessions.length === 0) {
+    return { status: "absent", sessions: 0, signalledGroups: 0 }
+  }
+
+  const ownGroup = await ownProcessGroup()
+  if (ownGroup.error) {
+    return { status: "failed", sessions: report.sessions.length, signalledGroups: 0, error: ownGroup.error }
+  }
+
+  let signalledGroups = 0
+  for (const pgid of new Set(report.panePids)) {
+    if (pgid === ownGroup.pgid) continue
+    try {
+      process.kill(-pgid, "SIGTERM")
+      signalledGroups++
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") continue
+      return {
+        status: "failed",
+        sessions: report.sessions.length,
+        signalledGroups,
+        error: `failed to SIGTERM pane group ${pgid}: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
+  }
+
+  const result = await runTmux(socket, ["kill-server"])
+  if (result.code === 0) return { status: "stopped", sessions: report.sessions.length, signalledGroups }
+
+  const remaining = await inspectLegacyTmux(socket)
+  if (!remaining.error && remaining.sessions.length === 0) {
+    return { status: "stopped", sessions: report.sessions.length, signalledGroups }
+  }
+  return {
+    status: "failed",
+    sessions: report.sessions.length,
+    signalledGroups,
+    error: remaining.error ?? (result.stderr.trim() || `tmux exited ${result.code}`),
+  }
+}

--- a/packages/kobe/src/cli/legacy-tmux.ts
+++ b/packages/kobe/src/cli/legacy-tmux.ts
@@ -165,12 +165,34 @@ export function legacyTmuxDoctorLines(report: LegacyTmuxReport, socket: string =
   return lines
 }
 
+const PROCESS_GROUP_EXIT_GRACE_MS = 6_000
+const PROCESS_GROUP_POLL_MS = 100
+
 async function ownProcessGroup(): Promise<{ pgid: number | null; error: string | null }> {
   const result = await run(["ps", "-o", "pgid=", "-p", String(process.pid)])
   if (result.code !== 0) return { pgid: null, error: commandFailure("ps current process group", result) }
   const pgid = Number.parseInt(result.stdout.trim(), 10)
   if (!Number.isFinite(pgid) || pgid <= 1) return { pgid: null, error: "unable to determine current process group" }
   return { pgid, error: null }
+}
+
+function processGroupAlive(pgid: number): boolean {
+  try {
+    process.kill(-pgid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH"
+  }
+}
+
+async function waitForProcessGroupsExit(pgids: readonly number[]): Promise<number[]> {
+  const deadline = Date.now() + PROCESS_GROUP_EXIT_GRACE_MS
+  let survivors = pgids.filter(processGroupAlive)
+  while (survivors.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, PROCESS_GROUP_POLL_MS))
+    survivors = survivors.filter(processGroupAlive)
+  }
+  return survivors
 }
 
 export async function stopLegacyTmux(socket: string = LEGACY_TMUX_SOCKET): Promise<LegacyTmuxStopResult> {
@@ -186,34 +208,44 @@ export async function stopLegacyTmux(socket: string = LEGACY_TMUX_SOCKET): Promi
     return { status: "failed", sessions: report.sessions.length, signalledGroups: 0, error: ownGroup.error }
   }
 
-  let signalledGroups = 0
+  const signalledPaneGroups: number[] = []
   for (const pgid of new Set(report.panePids)) {
     if (pgid === ownGroup.pgid) continue
     try {
       process.kill(-pgid, "SIGTERM")
-      signalledGroups++
+      signalledPaneGroups.push(pgid)
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ESRCH") continue
       return {
         status: "failed",
         sessions: report.sessions.length,
-        signalledGroups,
+        signalledGroups: signalledPaneGroups.length,
         error: `failed to SIGTERM pane group ${pgid}: ${error instanceof Error ? error.message : String(error)}`,
       }
     }
   }
 
   const result = await runTmux(socket, ["kill-server"])
-  if (result.code === 0) return { status: "stopped", sessions: report.sessions.length, signalledGroups }
+  if (result.code !== 0) {
+    const remaining = await inspectLegacyTmux(socket)
+    if (remaining.error || remaining.sessions.length > 0) {
+      return {
+        status: "failed",
+        sessions: report.sessions.length,
+        signalledGroups: signalledPaneGroups.length,
+        error: remaining.error ?? (result.stderr.trim() || `tmux exited ${result.code}`),
+      }
+    }
+  }
 
-  const remaining = await inspectLegacyTmux(socket)
-  if (!remaining.error && remaining.sessions.length === 0) {
-    return { status: "stopped", sessions: report.sessions.length, signalledGroups }
+  const survivors = await waitForProcessGroupsExit(signalledPaneGroups)
+  if (survivors.length > 0) {
+    return {
+      status: "failed",
+      sessions: report.sessions.length,
+      signalledGroups: signalledPaneGroups.length,
+      error: `pane process groups still alive after ${PROCESS_GROUP_EXIT_GRACE_MS}ms: ${survivors.join(", ")}`,
+    }
   }
-  return {
-    status: "failed",
-    sessions: report.sessions.length,
-    signalledGroups,
-    error: remaining.error ?? (result.stderr.trim() || `tmux exited ${result.code}`),
-  }
+  return { status: "stopped", sessions: report.sessions.length, signalledGroups: signalledPaneGroups.length }
 }

--- a/packages/kobe/src/cli/reset-cmd.ts
+++ b/packages/kobe/src/cli/reset-cmd.ts
@@ -13,6 +13,7 @@ import {
   defaultPtyHostSocketPath,
 } from "@sma1lboy/kobe-daemon/daemon/paths"
 import { kobeStateDir, kvStatePath } from "../env.ts"
+import { stopLegacyTmux } from "./legacy-tmux.ts"
 import { stampResetGate } from "./reset-gate.ts"
 
 function printUsage(out: Pick<typeof process.stderr, "write">): void {
@@ -20,7 +21,7 @@ function printUsage(out: Pick<typeof process.stderr, "write">): void {
     [
       "Usage: kobe reset [--hard] [--yes]",
       "",
-      "Recover a wedged install: stop the daemon, then stop the standalone Hosted PTY host.",
+      "Recover a wedged install: stop the daemon, Hosted PTY host, and any pre-v0.8 tmux sessions.",
       "This ends background terminal and engine sessions; the next launch starts fresh.",
       "Never touches your git worktrees.",
       "",
@@ -58,7 +59,7 @@ async function removeStateFile(path: string, label: string): Promise<void> {
     console.log(`  removed ${label} (${path})`)
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") console.log(`  ${label}: already absent`)
-    else console.error(`  failed to remove ${label} (${path}): ${errorMessage(err)}`)
+    else throw new Error(`failed to remove ${label} (${path}): ${errorMessage(err)}`)
   }
 }
 
@@ -85,6 +86,7 @@ export async function runResetSubcommand(argv: readonly string[]): Promise<void>
   console.log("  • stop the kobe daemon (graceful → SIGTERM → SIGKILL)")
   console.log(`  • remove its socket + pidfile (${daemonSocket})`)
   console.log("  • stop the standalone Hosted PTY host and all background terminal/engine sessions")
+  console.log("  • stop any pre-v0.8 tmux sessions after SIGTERM-ing their pane process groups")
   if (hard) {
     const count = taskCount(tasksPath)
     console.log(`  • DELETE the task index${count === null ? "" : ` (${count} task(s))`} — ${tasksPath}`)
@@ -120,6 +122,18 @@ export async function runResetSubcommand(argv: readonly string[]): Promise<void>
     ptyHost.method === "absent"
       ? "  pty host: was not running (cleared any stale socket/pidfile)"
       : `  pty host: stopped via ${ptyHost.method}${ptyHost.pid ? ` (pid ${ptyHost.pid})` : ""}`,
+  )
+
+  const legacyTmux = await stopLegacyTmux()
+  if (legacyTmux.status === "failed") {
+    console.error(`  legacy tmux: cleanup failed — ${legacyTmux.error ?? "unknown error"}`)
+    process.exitCode = 1
+    return
+  }
+  console.log(
+    legacyTmux.status === "absent"
+      ? "  legacy tmux: no pre-v0.8 sessions found"
+      : `  legacy tmux: stopped ${legacyTmux.sessions} session(s) after signalling ${legacyTmux.signalledGroups} pane group(s)`,
   )
 
   if (hard) {

--- a/packages/kobe/test/architecture/no-tmux-runtime.test.ts
+++ b/packages/kobe/test/architecture/no-tmux-runtime.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, test } from "vitest"
 
 const SRC_ROOT = fileURLToPath(new URL("../../src", import.meta.url))
 const RETIRED_ROOT = join(SRC_ROOT, "tmux")
+const LEGACY_COMPAT = join(SRC_ROOT, "cli", "legacy-tmux.ts")
+const LEGACY_IMPORTERS = new Set([join(SRC_ROOT, "cli", "doctor-cmd.ts"), join(SRC_ROOT, "cli", "reset-cmd.ts")])
 
 function sourceFiles(dir: string, files: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -22,22 +24,27 @@ describe("Hosted PTY-only runtime boundary", () => {
     expect(existsSync(RETIRED_ROOT)).toBe(false)
   })
 
-  test("production sources cannot import, spawn, or configure the retired backend", () => {
+  test("only the reset/doctor compatibility seam can reference tmux", () => {
     const offenders = sourceFiles(SRC_ROOT)
       .filter((file) => {
         const source = readFileSync(file, "utf8")
         if (source.includes("KOBE_TMUX")) return true
         return source.split("\n").some((line) => {
           if (line.trimStart().startsWith("//")) return false
-          return (
-            /^\s*(?:import|export)\b.*\bfrom\s*["'][^"']*tmux/i.test(line) ||
-            /\bimport\(\s*["'][^"']*tmux/i.test(line) ||
-            /^\s*(?:await\s+)?(?:Bun\.)?(?:spawn|spawnSync|execFile|execFileSync)\s*\([^\n]*["']tmux["']/i.test(line)
-          )
+          const importsLegacyCompat = /["'][^"']*legacy-tmux(?:\.ts)?["']/.test(line)
+          const importsTmux =
+            /^\s*(?:import|export)\b.*\bfrom\s*["'][^"']*tmux/i.test(line) || /\bimport\(\s*["'][^"']*tmux/i.test(line)
+          const namesTmuxBinary = /["']tmux["']/.test(line)
+          if (importsLegacyCompat) return !LEGACY_IMPORTERS.has(file)
+          return importsTmux || (namesTmuxBinary && file !== LEGACY_COMPAT)
         })
       })
       .map((file) => relative(SRC_ROOT, file))
 
     expect(offenders, `retired runtime references: ${offenders.join(", ")}`).toEqual([])
+    expect(existsSync(LEGACY_COMPAT)).toBe(true)
+    const compatibilitySource = readFileSync(LEGACY_COMPAT, "utf8")
+    expect(compatibilitySource).toContain('LEGACY_TMUX_SOCKET = "kobe"')
+    expect(compatibilitySource).not.toContain("KOBE_TMUX")
   })
 })

--- a/packages/kobe/test/behavior/legacy-tmux-cleanup.test.ts
+++ b/packages/kobe/test/behavior/legacy-tmux-cleanup.test.ts
@@ -1,0 +1,86 @@
+import { spawn, spawnSync } from "node:child_process"
+import { Readable } from "node:stream"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { legacyPaneProcesses, parseLegacyPsRows, stopLegacyTmux } from "../../src/cli/legacy-tmux.ts"
+
+const TMUX_AVAILABLE = spawnSync("tmux", ["-V"], { stdio: "ignore" }).status === 0
+const SOCKET = `kobe-legacy-cleanup-${process.pid}`
+const SESSION = "legacy-cleanup"
+let panePgid: number | null = null
+
+function tmux(...args: string[]) {
+  return spawnSync("tmux", ["-L", SOCKET, ...args], { encoding: "utf8" })
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM"
+  }
+}
+
+function groupProcesses(pgid: number) {
+  const result = spawnSync("ps", ["-axo", "pid,pgid,rss,comm"], { encoding: "utf8" })
+  return legacyPaneProcesses(parseLegacyPsRows(result.stdout ?? ""), [pgid])
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!predicate() && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 100))
+}
+
+beforeAll(() => {
+  vi.stubGlobal("Bun", {
+    spawn(argv: readonly string[]) {
+      const child = spawn(argv[0] ?? "", argv.slice(1), { stdio: ["ignore", "pipe", "pipe"] })
+      return {
+        stdout: Readable.toWeb(child.stdout),
+        stderr: Readable.toWeb(child.stderr),
+        exited: new Promise<number>((resolve) => {
+          child.once("error", () => resolve(127))
+          child.once("close", (code) => resolve(code ?? 1))
+        }),
+      }
+    },
+  })
+})
+
+afterAll(() => {
+  if (panePgid && panePgid > 1) {
+    try {
+      process.kill(-panePgid, "SIGTERM")
+    } catch {
+      // The regression path already cleaned it.
+    }
+  }
+  tmux("kill-server")
+  vi.unstubAllGlobals()
+})
+
+describe.skipIf(!TMUX_AVAILABLE)("legacy tmux process-group cleanup", () => {
+  it("terminates a HUP-ignoring pane group before killing the server", async () => {
+    const command = "/bin/sh -c 'trap \"\" HUP; while :; do sleep 1; done'"
+    const created = tmux("new-session", "-d", "-s", SESSION, command)
+    expect(created.status, created.stderr).toBe(0)
+
+    const pane = tmux("list-panes", "-t", SESSION, "-F", "#{pane_pid}")
+    panePgid = Number.parseInt(pane.stdout.trim(), 10)
+    expect(panePgid).toBeGreaterThan(1)
+
+    await waitUntil(() => groupProcesses(panePgid ?? 0).length >= 2, 5_000)
+    const groupPids = groupProcesses(panePgid ?? 0).map((row) => row.pid)
+    expect(groupPids.length).toBeGreaterThanOrEqual(2)
+
+    await expect(stopLegacyTmux(SOCKET)).resolves.toMatchObject({
+      status: "stopped",
+      sessions: 1,
+      signalledGroups: 1,
+    })
+
+    await waitUntil(() => groupPids.every((pid) => !isAlive(pid)), 10_000)
+    expect(groupPids.filter(isAlive)).toEqual([])
+    expect(tmux("list-sessions").status).not.toBe(0)
+  }, 20_000)
+})

--- a/packages/kobe/test/behavior/legacy-tmux-cleanup.test.ts
+++ b/packages/kobe/test/behavior/legacy-tmux-cleanup.test.ts
@@ -50,7 +50,7 @@ beforeAll(() => {
 afterAll(() => {
   if (panePgid && panePgid > 1) {
     try {
-      process.kill(-panePgid, "SIGTERM")
+      process.kill(-panePgid, "SIGKILL")
     } catch {
       // The regression path already cleaned it.
     }
@@ -82,5 +82,30 @@ describe.skipIf(!TMUX_AVAILABLE)("legacy tmux process-group cleanup", () => {
     await waitUntil(() => groupPids.every((pid) => !isAlive(pid)), 10_000)
     expect(groupPids.filter(isAlive)).toEqual([])
     expect(tmux("list-sessions").status).not.toBe(0)
+  }, 20_000)
+
+  it("reports failure when a pane process group survives TERM and HUP", async () => {
+    const command = "/bin/sh -c 'trap \"\" HUP TERM; while :; do sleep 1; done'"
+    const created = tmux("new-session", "-d", "-s", "term-ignore", command)
+    expect(created.status, created.stderr).toBe(0)
+
+    const pane = tmux("list-panes", "-t", "term-ignore", "-F", "#{pane_pid}")
+    panePgid = Number.parseInt(pane.stdout.trim(), 10)
+    expect(panePgid).toBeGreaterThan(1)
+    await waitUntil(() => groupProcesses(panePgid ?? 0).length >= 2, 5_000)
+
+    await expect(stopLegacyTmux(SOCKET)).resolves.toMatchObject({
+      status: "failed",
+      sessions: 1,
+      signalledGroups: 1,
+      error: expect.stringContaining("pane process groups still alive"),
+    })
+    expect(groupProcesses(panePgid ?? 0).length).toBeGreaterThan(0)
+    expect(tmux("list-sessions").status).not.toBe(0)
+
+    process.kill(-(panePgid ?? 0), "SIGKILL")
+    await waitUntil(() => groupProcesses(panePgid ?? 0).length === 0, 5_000)
+    expect(groupProcesses(panePgid ?? 0)).toEqual([])
+    panePgid = null
   }, 20_000)
 })

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   request: vi.fn(),
   close: vi.fn(),
+  inspectLegacyTmux: vi.fn(),
   kobeSkillState: vi.fn(),
 }))
 
@@ -21,6 +22,11 @@ vi.mock("../../src/lib/skill-install.ts", () => ({
   kobeSkillState: mocks.kobeSkillState,
 }))
 
+vi.mock("../../src/cli/legacy-tmux.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/cli/legacy-tmux.ts")>()
+  return { ...actual, inspectLegacyTmux: mocks.inspectLegacyTmux }
+})
+
 import { runDoctorSubcommand } from "../../src/cli/doctor-cmd.ts"
 
 let home: string
@@ -34,6 +40,14 @@ beforeEach(() => {
   mkdirSync(join(home, ".kobe"), { recursive: true })
   mocks.request.mockReset()
   mocks.close.mockReset()
+  mocks.inspectLegacyTmux.mockReset().mockResolvedValue({
+    available: true,
+    version: "tmux 3.6b",
+    sessions: [],
+    panePids: [],
+    processes: [],
+    error: null,
+  })
   mocks.kobeSkillState.mockReset().mockReturnValue({
     installed: true,
     installedVersion: 3,
@@ -57,7 +71,7 @@ function output(): string {
 }
 
 describe("runDoctorSubcommand", () => {
-  it("reports daemon and Hosted PTY health without a tmux section", async () => {
+  it("reports daemon, Hosted PTY, and installed tmux health", async () => {
     mocks.request.mockImplementation(async (name: string) => {
       if (name === "daemon.status") {
         return { daemonPid: 42, uptimeMs: 65_000, taskCount: 2, attachedClients: 1 }
@@ -77,13 +91,36 @@ describe("runDoctorSubcommand", () => {
 
     expect(output()).toContain("daemon:  ✓ running (pid 42, up 1m 5s, 2 task(s), 1 client(s))")
     expect(output()).toContain("pty host: ✓ running (2 session(s), 1 live)")
-    expect(output()).not.toContain("tmux")
+    expect(output()).toContain("legacy tmux: tmux 3.6b — no sessions on `kobe`")
   })
 
-  it("help describes a read-only daemon and Hosted PTY diagnosis", async () => {
+  it("reports legacy process counts and RSS without mutating them", async () => {
+    mocks.request.mockRejectedValue(new Error("not running"))
+    mocks.inspectLegacyTmux.mockResolvedValue({
+      available: true,
+      version: "tmux 3.6b",
+      sessions: ["kobe-a"],
+      panePids: [501],
+      processes: [
+        { pid: 501, pgid: 501, rssKb: 4096, command: "bun" },
+        { pid: 510, pgid: 501, rssKb: 2048, command: "claude" },
+      ],
+      error: null,
+    })
+
+    await runDoctorSubcommand([])
+
+    expect(output()).toContain("legacy tmux: ⚠ tmux 3.6b — 1 pre-v0.8 session(s)")
+    expect(output()).toContain("2 process(es) across 1 pane(s), 6.0 MB RSS total")
+    expect(output()).toContain("bun: 1 proc, 4.0 MB")
+    expect(output()).toContain("claude: 1 proc, 2.0 MB")
+    expect(mocks.inspectLegacyTmux).toHaveBeenCalledTimes(1)
+  })
+
+  it("help describes a read-only daemon, Hosted PTY, and legacy tmux diagnosis", async () => {
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
     await runDoctorSubcommand(["--help"])
-    expect(writeSpy.mock.calls.join("")).toContain("daemon / Hosted PTY / state")
+    expect(writeSpy.mock.calls.join("")).toContain("daemon / Hosted PTY / legacy tmux / state")
     expect(mocks.request).not.toHaveBeenCalled()
     writeSpy.mockRestore()
   })

--- a/packages/kobe/test/cli/legacy-tmux.test.ts
+++ b/packages/kobe/test/cli/legacy-tmux.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  inspectLegacyTmux,
+  legacyPaneProcesses,
+  legacyTmuxDoctorLines,
+  parseLegacyPsRows,
+  stopLegacyTmux,
+} from "../../src/cli/legacy-tmux.ts"
+
+function result(stdout = "", code = 0, stderr = "") {
+  return {
+    stdout: new Response(stdout).body,
+    stderr: new Response(stderr).body,
+    exited: Promise.resolve(code),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("legacy tmux process inspection", () => {
+  it("parses ps rows and selects complete pane process groups", () => {
+    const rows = parseLegacyPsRows(
+      ["PID PGID RSS COMM", "501 501 3168 bun", "510 501 9000 claude", "1 1 999 launchd"].join("\n"),
+    )
+
+    expect(rows).toEqual([
+      { pid: 501, pgid: 501, rssKb: 3168, command: "bun" },
+      { pid: 510, pgid: 501, rssKb: 9000, command: "claude" },
+      { pid: 1, pgid: 1, rssKb: 999, command: "launchd" },
+    ])
+    expect(legacyPaneProcesses(rows, [501])).toEqual(rows.slice(0, 2))
+  })
+
+  it("reports an unavailable tmux binary without failing", async () => {
+    vi.stubGlobal("Bun", {
+      spawn: vi.fn(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" })
+      }),
+    })
+
+    await expect(inspectLegacyTmux()).resolves.toEqual({
+      available: false,
+      version: null,
+      sessions: [],
+      panePids: [],
+      processes: [],
+      error: null,
+    })
+  })
+
+  it("keeps the installed version when no legacy server is running", async () => {
+    vi.stubGlobal("Bun", {
+      spawn: vi.fn((argv: readonly string[]) =>
+        argv.join(" ") === "tmux -V" ? result("tmux 3.6b\n") : result("", 1, "no server running on /tmp/tmux/test"),
+      ),
+    })
+
+    await expect(inspectLegacyTmux()).resolves.toEqual({
+      available: true,
+      version: "tmux 3.6b",
+      sessions: [],
+      panePids: [],
+      processes: [],
+      error: null,
+    })
+  })
+
+  it("surfaces list-sessions failures instead of reporting zero sessions", async () => {
+    vi.stubGlobal("Bun", {
+      spawn: vi.fn((argv: readonly string[]) =>
+        argv.join(" ") === "tmux -V" ? result("tmux 3.6b\n") : result("", 1, "permission denied"),
+      ),
+    })
+
+    const report = await inspectLegacyTmux()
+    expect(report.sessions).toEqual([])
+    expect(report.error).toContain("tmux list-sessions failed: permission denied")
+    expect(legacyTmuxDoctorLines(report)[0]).toContain("inspection failed")
+  })
+
+  it("formats version, session count, and RSS grouped by command", () => {
+    const lines = legacyTmuxDoctorLines({
+      available: true,
+      version: "tmux 3.6b",
+      sessions: ["kobe-a", "kobe-b"],
+      panePids: [501, 502],
+      processes: [
+        { pid: 501, pgid: 501, rssKb: 4096, command: "bun" },
+        { pid: 510, pgid: 501, rssKb: 2048, command: "bun" },
+        { pid: 502, pgid: 502, rssKb: 3072, command: "claude" },
+      ],
+      error: null,
+    })
+
+    expect(lines[0]).toContain("tmux 3.6b — 2 pre-v0.8 session(s)")
+    expect(lines[1]).toContain("3 process(es) across 2 pane(s), 9.0 MB RSS total")
+    expect(lines).toContain("             bun: 2 proc, 6.0 MB")
+    expect(lines).toContain("             claude: 1 proc, 3.0 MB")
+    expect(lines.at(-1)).toContain("kobe reset")
+  })
+})
+
+describe("stopLegacyTmux", () => {
+  it("SIGTERMs pane process groups before killing the legacy server", async () => {
+    const events: string[] = []
+    const spawn = vi.fn((argv: readonly string[]) => {
+      events.push(argv.join(" "))
+      const command = argv.join(" ")
+      if (command === "tmux -V") return result("tmux 3.6b\n")
+      if (command.includes("list-sessions")) return result("kobe-a\nkobe-b\n")
+      if (command.includes("list-panes")) return result("501\n502\n")
+      if (command === "ps -axo pid,pgid,rss,comm") {
+        return result("PID PGID RSS COMM\n501 501 1024 bun\n502 502 1024 bun\n")
+      }
+      if (command.startsWith("ps -o pgid=")) return result("502\n")
+      if (command.endsWith("kill-server")) return result()
+      throw new Error(`unexpected command: ${command}`)
+    })
+    vi.stubGlobal("Bun", { spawn })
+    const kill = vi.spyOn(process, "kill").mockImplementation((pid) => {
+      events.push(`SIGTERM ${pid}`)
+      return true
+    })
+
+    await expect(stopLegacyTmux("test-socket")).resolves.toEqual({
+      status: "stopped",
+      sessions: 2,
+      signalledGroups: 1,
+    })
+    expect(kill).toHaveBeenCalledWith(-501, "SIGTERM")
+    expect(kill).not.toHaveBeenCalledWith(-502, "SIGTERM")
+    expect(events.indexOf("SIGTERM -501")).toBeLessThan(events.indexOf("tmux -L test-socket kill-server"))
+  })
+
+  it("refuses HUP-only cleanup when pane enumeration fails", async () => {
+    const spawn = vi.fn((argv: readonly string[]) => {
+      const command = argv.join(" ")
+      if (command === "tmux -V") return result("tmux 3.6b\n")
+      if (command.includes("list-sessions")) return result("kobe-a\n")
+      if (command.includes("list-panes")) return result("", 1, "permission denied")
+      throw new Error(`unexpected command: ${command}`)
+    })
+    vi.stubGlobal("Bun", { spawn })
+    const kill = vi.spyOn(process, "kill")
+
+    await expect(stopLegacyTmux("test-socket")).resolves.toMatchObject({
+      status: "failed",
+      error: "tmux list-panes failed: permission denied",
+    })
+    expect(kill).not.toHaveBeenCalled()
+    expect(spawn.mock.calls.some(([argv]) => (argv as readonly string[]).includes("kill-server"))).toBe(false)
+  })
+
+  it("fails instead of swallowing a process-group permission error", async () => {
+    const spawn = vi.fn((argv: readonly string[]) => {
+      const command = argv.join(" ")
+      if (command === "tmux -V") return result("tmux 3.6b\n")
+      if (command.includes("list-sessions")) return result("kobe-a\n")
+      if (command.includes("list-panes")) return result("501\n")
+      if (command === "ps -axo pid,pgid,rss,comm") return result("PID PGID RSS COMM\n501 501 1024 bun\n")
+      if (command.startsWith("ps -o pgid=")) return result("999\n")
+      throw new Error(`unexpected command: ${command}`)
+    })
+    vi.stubGlobal("Bun", { spawn })
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("not permitted"), { code: "EPERM" })
+    })
+
+    await expect(stopLegacyTmux("test-socket")).resolves.toMatchObject({
+      status: "failed",
+      error: "failed to SIGTERM pane group 501: not permitted",
+    })
+    expect(spawn.mock.calls.some(([argv]) => (argv as readonly string[]).includes("kill-server"))).toBe(false)
+  })
+
+  it("reports kill-server failure while the legacy server remains live", async () => {
+    let listCalls = 0
+    const spawn = vi.fn((argv: readonly string[]) => {
+      const command = argv.join(" ")
+      if (command === "tmux -V") return result("tmux 3.6b\n")
+      if (command.includes("list-sessions")) {
+        listCalls++
+        return result("kobe-a\n")
+      }
+      if (command.includes("list-panes")) return result("501\n")
+      if (command === "ps -axo pid,pgid,rss,comm") return result("PID PGID RSS COMM\n501 501 1024 bun\n")
+      if (command.startsWith("ps -o pgid=")) return result("999\n")
+      if (command.endsWith("kill-server")) return result("", 1, "permission denied")
+      throw new Error(`unexpected command: ${command}`)
+    })
+    vi.stubGlobal("Bun", { spawn })
+    vi.spyOn(process, "kill").mockReturnValue(true)
+
+    await expect(stopLegacyTmux("test-socket")).resolves.toMatchObject({
+      status: "failed",
+      error: "permission denied",
+    })
+    expect(listCalls).toBe(2)
+  })
+})

--- a/packages/kobe/test/cli/legacy-tmux.test.ts
+++ b/packages/kobe/test/cli/legacy-tmux.test.ts
@@ -120,7 +120,8 @@ describe("stopLegacyTmux", () => {
       throw new Error(`unexpected command: ${command}`)
     })
     vi.stubGlobal("Bun", { spawn })
-    const kill = vi.spyOn(process, "kill").mockImplementation((pid) => {
+    const kill = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      if (signal === 0) throw Object.assign(new Error("gone"), { code: "ESRCH" })
       events.push(`SIGTERM ${pid}`)
       return true
     })

--- a/packages/kobe/test/cli/reset-cmd.test.ts
+++ b/packages/kobe/test/cli/reset-cmd.test.ts
@@ -5,11 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   stopDaemonProcess: vi.fn(),
+  stopLegacyTmux: vi.fn(),
   stampResetGate: vi.fn(),
 }))
 
 vi.mock("@sma1lboy/kobe-daemon/daemon/lifecycle", () => ({
   stopDaemonProcess: mocks.stopDaemonProcess,
+}))
+
+vi.mock("../../src/cli/legacy-tmux.ts", () => ({
+  stopLegacyTmux: mocks.stopLegacyTmux,
 }))
 
 vi.mock("../../src/cli/reset-gate.ts", () => ({
@@ -20,23 +25,31 @@ import { runResetSubcommand } from "../../src/cli/reset-cmd.ts"
 
 let home: string
 let originalHome: string | undefined
+let originalExitCode: number | string | null | undefined
 let logSpy: ReturnType<typeof vi.spyOn>
+let errorSpy: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
   originalHome = process.env.KOBE_HOME_DIR
+  originalExitCode = process.exitCode
+  process.exitCode = 0
   home = mkdtempSync(join(tmpdir(), "kobe-reset-"))
   process.env.KOBE_HOME_DIR = home
   mkdirSync(join(home, ".kobe"), { recursive: true })
   mocks.stopDaemonProcess.mockReset().mockResolvedValue({ pid: null, method: "absent" })
+  mocks.stopLegacyTmux.mockReset().mockResolvedValue({ status: "absent", sessions: 0, signalledGroups: 0 })
   mocks.stampResetGate.mockReset()
   logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
 })
 
 afterEach(() => {
   if (originalHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
   else process.env.KOBE_HOME_DIR = originalHome
+  process.exitCode = originalExitCode
   rmSync(home, { recursive: true, force: true })
   logSpy.mockRestore()
+  errorSpy.mockRestore()
 })
 
 function output(): string {
@@ -44,16 +57,21 @@ function output(): string {
 }
 
 describe("runResetSubcommand", () => {
-  it("stops the daemon and Hosted PTY host without invoking tmux", async () => {
+  it("stops current runtimes before safely cleaning legacy tmux", async () => {
     mocks.stopDaemonProcess
       .mockResolvedValueOnce({ pid: 11, method: "sigterm" })
       .mockResolvedValueOnce({ pid: 12, method: "graceful" })
+    mocks.stopLegacyTmux.mockResolvedValue({ status: "stopped", sessions: 2, signalledGroups: 8 })
 
     await runResetSubcommand(["--yes"])
 
     expect(mocks.stopDaemonProcess).toHaveBeenCalledTimes(2)
+    expect(mocks.stopLegacyTmux).toHaveBeenCalledTimes(1)
+    expect(mocks.stopLegacyTmux.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.stopDaemonProcess.mock.invocationCallOrder[1] ?? 0,
+    )
     expect(output()).toContain("pty host: stopped via graceful (pid 12)")
-    expect(output()).not.toContain("tmux")
+    expect(output()).toContain("legacy tmux: stopped 2 session(s) after signalling 8 pane group(s)")
     expect(mocks.stampResetGate).toHaveBeenCalledTimes(1)
   })
 
@@ -72,12 +90,42 @@ describe("runResetSubcommand", () => {
     expect(mocks.stampResetGate).not.toHaveBeenCalled()
   })
 
-  it("help names Hosted PTY and contains no tmux contract", async () => {
+  it("does not wipe state or stamp reset complete when legacy cleanup fails", async () => {
+    const tasksPath = join(home, ".kobe", "tasks.json")
+    const statePath = join(home, ".config", "kobe", "state.json")
+    mkdirSync(join(home, ".config", "kobe"), { recursive: true })
+    writeFileSync(tasksPath, JSON.stringify({ tasks: [{ id: "a" }] }))
+    writeFileSync(statePath, "{}")
+    mocks.stopLegacyTmux.mockResolvedValue({
+      status: "failed",
+      sessions: 1,
+      signalledGroups: 1,
+      error: "server still running",
+    })
+
+    await runResetSubcommand(["--hard", "--yes"])
+    expect(process.exitCode).toBe(1)
+    expect(errorSpy).toHaveBeenCalledWith("  legacy tmux: cleanup failed — server still running")
+    expect(existsSync(tasksPath)).toBe(true)
+    expect(existsSync(statePath)).toBe(true)
+    expect(mocks.stampResetGate).not.toHaveBeenCalled()
+    expect(output()).not.toContain("reset complete")
+  })
+
+  it("does not report success when a hard-reset state path cannot be removed", async () => {
+    const tasksPath = join(home, ".kobe", "tasks.json")
+    mkdirSync(tasksPath)
+
+    await expect(runResetSubcommand(["--hard", "--yes"])).rejects.toThrow("failed to remove task index")
+    expect(output()).not.toContain("reset complete")
+  })
+
+  it("help names Hosted PTY and legacy tmux cleanup", async () => {
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
     await runResetSubcommand(["--help"])
     const help = writeSpy.mock.calls.join("")
-    expect(help).toContain("stop the standalone Hosted PTY host")
-    expect(help).not.toContain("tmux")
+    expect(help).toContain("Hosted PTY host")
+    expect(help).toContain("pre-v0.8 tmux sessions")
     writeSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

- restore a quarantined pre-v0.8 tmux compatibility seam for maintenance only
- show legacy tmux version, sessions, pane-process count, and grouped RSS in `kobe doctor`
- make `kobe reset` SIGTERM complete pane process groups before stopping the retired tmux server
- fail reset without deleting state or stamping the reset gate when inspection, signalling, server shutdown, or survivor verification fails
- keep the PureTUI-only architecture boundary, allowing tmux access only from the doctor/reset compatibility module

Refs #307

## Test Coverage

All new code paths are covered, including missing tmux, no server, inspection failures, process-group permission errors, kill-server failure, HUP-ignoring children, and TERM+HUP survivors.

## Pre-Landing Review

Final code review: clean, no remaining actionable findings.

## Design Review

No frontend files changed.

## Verification

- `bun run lint`
- `bun --filter @sma1lboy/kobe typecheck`
- `bun --filter @sma1lboy/kobe test` — 2243 fast tests + 263 socket tests passed
- `bun --filter @sma1lboy/kobe build`
- `bun --filter @sma1lboy/kobe test:behavior` — 12 tests passed, including real tmux HUP/TERM lifecycle regressions
- live read-only smoke: `kobe doctor` detected 2 hidden pre-v0.8 sessions, 20 processes, and about 1 GB RSS on the legacy `kobe` tmux socket

## Release

Includes a patch changeset for `@sma1lboy/kobe`.


## Documentation

- docs/ARCHITECTURE.md: note that tmux stays retired; doctor/reset keep one bounded migration seam.
- docs/HARNESS.md: the no-tmux architecture gate now names `cli/legacy-tmux.ts` as the sole exception.
- docs/TROUBLESHOOTING.md: new "Memory stays high after upgrading from a pre-0.8 build" entry pointing at `kobe doctor` / `kobe reset`.
