### PR TITLE
feat: delete task worktrees in the background

### DIFF
--- a/.changeset/quiet-tasks-delete.md
+++ b/.changeset/quiet-tasks-delete.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Move task worktree cleanup into a durable daemon background job so deleting a large task returns control immediately, survives daemon restarts, and keeps failures visible and retryable in the sidebar.

--- a/docs/superpowers/specs/2026-07-15-background-task-delete-design.md
+++ b/docs/superpowers/specs/2026-07-15-background-task-delete-design.md
@@ -1,0 +1,142 @@
+# Background Task Deletion Design
+
+## Goal
+
+Make task deletion return control to the TUI immediately after safety checks,
+while the daemon removes large worktrees in the background. A 10+ GB ignored
+build tree must not leave the sidebar looking frozen, and a failed cleanup must
+never create an invisible orphan worktree.
+
+## Current behavior and root cause
+
+`task.delete` currently waits for `KobeOrchestrator.deleteTask()`. That method
+runs the dirty-worktree guard, `git worktree remove`, metadata prune, optional
+branch deletion, and task-index removal before the RPC replies. The TUI cannot
+move selection until that reply arrives. Ignored directories such as
+`node_modules/`, Rust `target/`, replay capture homes, and video artifacts are
+not reported by `git status --porcelain`, but `git worktree remove` still has to
+delete every byte and directory entry.
+
+## Considered approaches
+
+### 1. Persist deletion state on the Task and run cleanup in the daemon
+
+Recommended. Add an optional `Task.deletion` record and split deletion into a
+short prepare step plus a background execute step. The task remains visible and
+recoverable until physical cleanup succeeds. A new daemon process resumes
+queued or interrupted deletions from `tasks.json`.
+
+Trade-off: this crosses the task codec, daemon protocol, orchestrator, and row
+view, but each boundary receives a small additive field and the failure model is
+explicit.
+
+### 2. Reuse only the in-memory `task.jobs` channel
+
+The handler could fire-and-forget the existing synchronous delete and publish a
+spinner event. This is smaller, but the event bus dies with the daemon. A
+restart can leave an in-progress or partially completed deletion with no owner
+and no visible state.
+
+Rejected because deletion is destructive and must be recoverable.
+
+### 3. Rename the worktree into a trash directory, then delete it
+
+This can make the original path disappear quickly on one filesystem. It changes
+Git worktree metadata semantics, can fail across volumes, and still needs a
+durable cleanup queue.
+
+Rejected as unnecessary scope and a weaker fit for `git worktree remove`.
+
+## Data model
+
+Add this optional additive field to `Task`, `DaemonTask`, and `SerializedTask`:
+
+```ts
+interface TaskDeletionState {
+  phase: "queued" | "running" | "error"
+  force: boolean
+  requestedAt: string
+  error?: string
+}
+```
+
+The task-index version remains v3 because the field is optional and older v3
+files remain valid. The v3 codec must preserve valid deletion records and drop
+malformed ones.
+
+- `queued`: safety checks passed and the request was durably accepted.
+- `running`: the daemon runner started session teardown and filesystem cleanup.
+- `error`: cleanup failed. The task and error remain visible; pressing delete
+  again performs the normal confirmation and retries from `queued`.
+
+## Deletion flow
+
+1. The existing TUI confirmation calls `task.delete` as today.
+2. The daemon calls `prepareTaskDeletion(taskId, { force })`.
+3. Prepare rejects main tasks and performs the current dirty-worktree check.
+   A dirty non-force request still returns `DIRTY_WORKTREE`, so the existing
+   explicit force-delete confirmation remains unchanged.
+4. Prepare persists `deletion.phase = "queued"` before replying.
+5. The daemon starts one deduplicated background runner for the task and returns
+   the RPC response immediately. Repeated requests while queued/running do not
+   start a second runner.
+6. The TUI moves selection and releases its local tab snapshot using its
+   existing post-delete flow. Other clients see the task row change to
+   `deleting` through the authoritative `task.snapshot`.
+7. The runner persists `running`, stops the task's Hosted PTY sessions through
+   the existing neutral runtime adapter, then removes the worktree, prunes Git
+   metadata, and performs the existing best-effort branch cleanup.
+8. On success, the task is removed from the index. On failure, the runner
+   persists `error` and the message instead of removing the task.
+
+The runner scans `listTasks()` when a daemon starts and resumes both `queued`
+and `running` records. It does not auto-retry `error` records.
+
+## Interaction guards
+
+A task with any `deletion` state is not activatable. Worktree materialization
+and Hosted PTY session/spec creation must reject it with a stable
+`TASK_DELETING` message. This prevents another client from recreating a session
+inside a directory that the background runner is deleting.
+
+The task stays in snapshots until success. It is not archived and is not hidden
+from the index, so cleanup errors remain discoverable and retryable.
+
+## UI behavior
+
+- `queued` and `running` rows use the existing spinner infrastructure with the
+  subtitle `deleting` / `正在删除`.
+- `error` is non-animated, uses the error tone, and shows
+  `delete failed` / `删除失败`.
+- No percentage is shown because `git worktree remove` exposes no reliable
+  progress metric.
+- The existing dirty and force-confirm dialogs are unchanged.
+
+## Compatibility
+
+`task.delete` keeps its request name and payload. Its success meaning changes
+from "physical cleanup completed" to "background deletion durably accepted".
+The CLI, TUI, and web clients therefore remain wire-compatible. Existing
+post-RPC Hosted PTY teardown calls remain safe because teardown is idempotent;
+the daemon runner becomes the authoritative cleanup owner.
+
+## Tests
+
+- Codec tests preserve valid deletion state and drop malformed state.
+- Orchestrator tests pin prepare safety, durable queued/running/error
+  transitions, successful removal, failed cleanup retention, and activation
+  guards.
+- Daemon handler tests prove `task.delete` returns before a blocked physical
+  cleanup finishes and deduplicates repeated requests.
+- Daemon runner tests prove startup resume, Hosted PTY teardown ordering, error
+  persistence, and no auto-retry of terminal errors.
+- Sidebar row tests pin deleting spinner and delete-failed rendering.
+- Existing dirty-worktree, force-delete, task snapshot, CLI, web, and behavior
+  tests remain green.
+
+## Scope boundaries
+
+This change does not make filesystem deletion faster, calculate byte progress,
+move worktrees to a trash directory, add cancellation, or change archive
+semantics. It only makes task deletion responsive, durable, observable, and
+retryable.

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -3,6 +3,13 @@
 export type VendorId = "claude" | "codex" | "copilot" | (string & {})
 export type TaskStatus = "backlog" | "in_progress" | "in_review" | "done" | "canceled" | "error"
 
+export interface TaskDeletionState {
+  readonly phase: "queued" | "running" | "error"
+  readonly force: boolean
+  readonly requestedAt: string
+  readonly error?: string
+}
+
 export interface TaskPRStatus {
   readonly provider: "github" | "gitlab" | "bitbucket" | "unknown"
   readonly lifecycle: "creating" | "open" | "ready_to_merge" | "merged" | "closed" | "unknown"
@@ -32,6 +39,7 @@ export interface DaemonTask {
   readonly prStatus?: TaskPRStatus
   readonly position?: number
   readonly modelEffort?: string
+  readonly deletion?: TaskDeletionState
   readonly createdAt: string
   readonly updatedAt: string
 }
@@ -79,6 +87,9 @@ export interface DaemonOrchestrator {
   setPRStatus(id: string, status: TaskPRStatus | null): Promise<void>
   reorderTasks(moves: ReadonlyArray<{ taskId: string; position: number }>): Promise<void>
   deleteTask(id: string, options?: { force?: boolean }): Promise<void>
+  prepareTaskDeletion(id: string, options?: { force?: boolean }): Promise<boolean>
+  beginTaskDeletion(id: string): Promise<boolean>
+  finishTaskDeletion(id: string): Promise<void>
   landTask(
     id: string,
     options?: { strategy?: "merge" | "squash"; deleteBranch?: boolean; archive?: boolean },

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -89,8 +89,11 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
-      await ctx.orch.deleteTask(taskId, { force: optionalBoolean(payload, "force") })
+      const accepted = await ctx.orch.prepareTaskDeletion(taskId, {
+        force: optionalBoolean(payload, "force"),
+      })
       ctx.activity.clearTask(taskId)
+      if (accepted) ctx.deletions.enqueue(taskId)
       return {}
     },
   },

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -52,6 +52,7 @@ import {
   serializeTask,
 } from "./protocol.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import type { TaskDeletionScheduler } from "./task-deletion-runner.ts"
 
 // Re-exported for backward compatibility — `server.ts` and (transitively)
 // `packages/kobe/test/daemon/handlers.test.ts` import these from here.
@@ -79,6 +80,8 @@ export interface DaemonHandlerContext {
   readonly bus: DaemonEventBus
   /** Transient engine-activity state (`engine.reportEvent`, `task.delete`). */
   readonly activity: DaemonActivityRegistry
+  /** Starts deduplicated durable background deletion after RPC acceptance. */
+  readonly deletions: TaskDeletionScheduler
   /** Daemon-owned issue tracker store, keyed by git common-dir. */
   readonly issues: IssuesStore
   /** Daemon-process facts + lifecycle controls handlers surface or drive. */

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -282,6 +282,8 @@ export interface SerializedTask {
   readonly position?: number
   /** Engine reasoning/effort level, when the vendor supports one. */
   readonly modelEffort?: string
+  /** Durable daemon-owned background deletion state. */
+  readonly deletion?: DaemonTask["deletion"]
   readonly createdAt: string
   readonly updatedAt: string
 }
@@ -301,6 +303,7 @@ export function serializeTask(task: DaemonTask): SerializedTask {
     prStatus: task.prStatus,
     position: task.position,
     modelEffort: task.modelEffort,
+    deletion: task.deletion,
     createdAt: task.createdAt,
     updatedAt: task.updatedAt,
   }

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -42,6 +42,7 @@ import { DaemonLifetime } from "./lifetime.ts"
 import { defaultDaemonPidPath, defaultDaemonSocketPath } from "./paths.ts"
 import { type DaemonFrame, normalizeChannelFilter, serializeTask } from "./protocol.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { TaskDeletionRunner } from "./task-deletion-runner.ts"
 import { type DaemonWebServer, createDirectWebLink, startDaemonWebServer } from "./web-server.ts"
 
 // RPC handler registry + per-request dispatch seam — re-exported so consumers
@@ -184,6 +185,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     return runtime.latestTranscriptMtime(task.vendor ?? runtime.defaultTaskVendor, task.worktreePath)
   }
   const activity = new DaemonActivityRegistry(bus, undefined, undefined, livenessAt)
+  const deletions = new TaskDeletionRunner(orch, runtime, (taskId) => activity.clearTask(taskId))
 
   // Daemon-owned issue tracker (web Issues panel) — a single store keyed by
   // git common-dir, sharing the server's homeDir so sandbox/test homes
@@ -255,6 +257,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       options.homeDir,
     )
   })
+  deletions.resume(orch.listTasks())
 
   // Warm the active-task channel with the orchestrator's restored focus
   // (seeded from the persisted `lastActive` record — state/last-active.ts).
@@ -343,6 +346,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       runtime,
       bus,
       activity,
+      deletions,
       issues,
       daemon: {
         startedAt,

--- a/packages/kobe-daemon/src/daemon/task-deletion-runner.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-runner.ts
@@ -1,0 +1,45 @@
+import type { DaemonOrchestrator, DaemonTask } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
+import type { DaemonRuntimeAdapter } from "./runtime.ts"
+
+export interface TaskDeletionScheduler {
+  enqueue(taskId: string): void
+}
+
+/** Deduplicated daemon owner for durable background task deletion. */
+export class TaskDeletionRunner implements TaskDeletionScheduler {
+  private readonly inFlight = new Map<string, Promise<void>>()
+
+  constructor(
+    private readonly orch: DaemonOrchestrator,
+    private readonly runtime: Pick<DaemonRuntimeAdapter, "tearDownTaskSession">,
+    private readonly clearActivity: (taskId: string) => void,
+  ) {}
+
+  enqueue(taskId: string): void {
+    if (this.inFlight.has(taskId)) return
+    const pending = Promise.resolve()
+      .then(() => this.run(taskId))
+      .catch((err) => logDaemonError("task-deletion", err))
+      .finally(() => this.inFlight.delete(taskId))
+    this.inFlight.set(taskId, pending)
+  }
+
+  resume(tasks: readonly DaemonTask[]): void {
+    for (const task of tasks) {
+      if (task.deletion?.phase === "queued" || task.deletion?.phase === "running") this.enqueue(task.id)
+    }
+  }
+
+  /** Test seam: resolves when all jobs known at call time have settled. */
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.inFlight.values()])
+  }
+
+  private async run(taskId: string): Promise<void> {
+    if (!(await this.orch.beginTaskDeletion(taskId))) return
+    this.clearActivity(taskId)
+    await this.runtime.tearDownTaskSession(taskId).catch((err) => logDaemonError("task-deletion-session-teardown", err))
+    await this.orch.finishTaskDeletion(taskId)
+  }
+}

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -44,6 +44,12 @@ export interface Task {
    *  drawer's engine+effort picker. The task does not reverse-reference its
    *  issue; the issue→task link lives on {@link Issue.taskId}. */
   modelEffort?: string
+  deletion?: {
+    phase: "queued" | "running" | "error"
+    force: boolean
+    requestedAt: string
+    error?: string
+  }
   createdAt: string
   updatedAt: string
 }

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -296,6 +296,7 @@ export function deserializeTask(s: SerializedTask): Task {
     vendor: s.vendor,
     prStatus: s.prStatus,
     modelEffort: s.modelEffort,
+    deletion: s.deletion,
     createdAt: s.createdAt,
     updatedAt: s.updatedAt,
   }

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -10,6 +10,7 @@ import {
 } from "../engine/hosted-session.ts"
 import { interactiveEngineCommand } from "../engine/interactive-command.ts"
 import { buildEngineSessionLaunch } from "../engine/session-launch.ts"
+import { TaskDeletingError } from "../orchestrator/errors.ts"
 import type { PromptDeliveryIntent } from "../state/repo-init.ts"
 
 async function getTask(link: DaemonRpcClient, taskId: string): Promise<SerializedTask> {
@@ -19,6 +20,7 @@ async function getTask(link: DaemonRpcClient, taskId: string): Promise<Serialize
 
 async function ensureTaskWorktree(link: DaemonRpcClient, taskId: string) {
   const task = await getTask(link, taskId)
+  if (task.deletion) throw new TaskDeletingError(taskId)
   if (task.worktreePath) return { task, worktreePath: task.worktreePath }
   const { worktreePath } = await link.request<{ worktreePath: string | null }>("task.ensureWorktree", { taskId })
   if (!worktreePath) throw new Error(`task ${taskId} has no worktree`)

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -12,14 +12,10 @@ import type { Task, TaskId, TaskPRStatus, TaskStatus, VendorId } from "../types/
 import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 import { canonPath, normalizeMainRepo, titleFromRepo } from "./core-helpers.ts"
-import {
-  CannotDeleteMainTaskError,
-  DirtyWorktreeError,
-  TaskNotFoundError,
-  WorktreeRemoveFailedError,
-} from "./errors.ts"
+import { DirtyWorktreeError, TaskDeletingError, TaskNotFoundError, WorktreeRemoveFailedError } from "./errors.ts"
 import type { TaskIndexStore, TaskIndexUnsubscribe } from "./index/store.ts"
 import { type LandResult, type LandTaskOpts, landTaskWithCleanup } from "./land.ts"
+import { TaskDeletionCoordinator } from "./task-deletion.ts"
 import { TaskEditor } from "./task-editor.ts"
 import { PLACEHOLDER_TASK_TITLE } from "./title.ts"
 import { WorktreeCoordinator } from "./worktree-coordinator.ts"
@@ -75,6 +71,7 @@ export class Orchestrator {
   private readonly worktreeCoordinator: WorktreeCoordinator
   /** Owns in-place task-field edits (title / branch / vendor / status / …). */
   private readonly editor: TaskEditor
+  private readonly deletions: TaskDeletionCoordinator
   private readonly tasksAcc: StateCell<Task[]>
   private readonly activeTaskAcc: StateCell<string | null>
   private readonly unsubscribeStore: TaskIndexUnsubscribe
@@ -88,6 +85,9 @@ export class Orchestrator {
       this.ensureMainTask(repo),
     )
     this.editor = new TaskEditor(this.store, this.worktrees)
+    this.deletions = new TaskDeletionCoordinator(this.store, this.worktrees, (id) =>
+      this.worktreeCoordinator.forget(id),
+    )
     this.tasksAcc = createStateCell<Task[]>(this.store.list())
     // Seed focus from the persisted `lastActive` record (state/last-active
     // .ts) so a daemon restart or fresh TUI opens on the last-focused task
@@ -125,6 +125,7 @@ export class Orchestrator {
   /** Set the active-task focus and touch recency for task-list sorting. */
   async setActiveTask(id: TaskId | string | null): Promise<void> {
     const next = id === null ? null : String(id)
+    if (next && this.store.get(next)?.deletion) throw new TaskDeletingError(next)
     this.activeTaskAcc.set(next)
     if (next && this.store.get(next)) {
       // Global last-writer-wins focus record — see state/last-active.ts. This
@@ -262,6 +263,7 @@ export class Orchestrator {
    */
   async ensureWorktree(id: TaskId | string): Promise<string> {
     const task = this.requireTask(id)
+    if (task.deletion) throw new TaskDeletingError(String(task.id))
     if (task.kind === "main") return repoWorkingDir(task.repo)
     if (task.worktreePath) {
       if (await this.worktrees.pathExists(task.worktreePath)) return task.worktreePath
@@ -352,36 +354,22 @@ export class Orchestrator {
    * worktree is genuinely gone.
    */
   async deleteTask(id: TaskId | string, opts?: { readonly force?: boolean }): Promise<void> {
-    const task = this.store.get(id)
-    if (!task) return
-    if (task.kind === "main") {
-      throw new CannotDeleteMainTaskError()
-    }
-    const force = opts?.force === true
-    if (task.worktreePath) {
-      if (!force) {
-        let dirty = false
-        try {
-          dirty = await this.worktrees.isDirty(task.worktreePath)
-        } catch {
-          // Can't determine dirtiness (e.g. the path is already gone) —
-          // treat as clean and let remove() handle the missing-dir case.
-        }
-        if (dirty) throw new DirtyWorktreeError(task.id)
-      }
-      try {
-        // deleteBranch: a deleted task shouldn't leave its loser branch piling
-        // up (branch cleanup is best-effort inside remove(), never blocks it).
-        await this.worktrees.remove(task.worktreePath, { force, deleteBranch: true })
-      } catch (err) {
-        // Keep the index entry — see method doc. Surfacing instead of
-        // the old console.warn-and-continue means a failed cleanup no
-        // longer silently orphans the worktree.
-        throw new WorktreeRemoveFailedError(task.id, err)
-      }
-    }
-    await this.store.remove(task.id)
-    this.worktreeCoordinator.forget(task.id)
+    await this.deletions.deleteNow(id, opts)
+  }
+
+  /** Persist a deletion request after the normal safety checks. */
+  async prepareTaskDeletion(id: TaskId | string, opts?: { readonly force?: boolean }): Promise<boolean> {
+    return this.deletions.prepare(id, opts)
+  }
+
+  /** Transition a queued/resumed deletion to running. */
+  async beginTaskDeletion(id: TaskId | string): Promise<boolean> {
+    return this.deletions.begin(id)
+  }
+
+  /** Execute physical cleanup and retain a visible error on failure. */
+  async finishTaskDeletion(id: TaskId | string): Promise<void> {
+    return this.deletions.finish(id)
   }
 
   /** Land a task's branch back into its base repo — executor + cleanup in `land.ts`. */

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -71,6 +71,16 @@ export class WorktreeRemoveFailedError extends Error {
   }
 }
 
+/** Stable wire-visible marker for attempts to reactivate a deleting task. */
+export const TASK_DELETING_CODE = "TASK_DELETING"
+
+export class TaskDeletingError extends Error {
+  constructor(public readonly taskId: string) {
+    super(`${TASK_DELETING_CODE}: task ${taskId} is being deleted`)
+    this.name = "TaskDeletingError"
+  }
+}
+
 /**
  * Stable sentinel embedded in {@link MainCheckoutDirtyError}'s message — the
  * `name` field doesn't survive the daemon wire, so a caller across the boundary

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -16,7 +16,7 @@
  * store class stays under the file-size cap.
  */
 
-import type { Task, TaskPRStatus, TaskStatus } from "../../types/task.ts"
+import type { Task, TaskDeletionState, TaskPRStatus, TaskStatus } from "../../types/task.ts"
 import { toTaskId } from "../../types/task.ts"
 import { coerceVendorId } from "../../types/vendor.ts"
 import { LockfileError, acquire } from "./lockfile.ts"
@@ -130,6 +130,7 @@ function coerceTask(value: unknown): Task | null {
       : v.status === "done" && !archived
         ? "in_progress"
         : v.status
+  const deletion = coerceDeletion(v.deletion)
 
   return {
     id: toTaskId(v.id),
@@ -149,8 +150,29 @@ function coerceTask(value: unknown): Task | null {
     // Engine reasoning/effort level — must survive the load coercion or the
     // task forgets its effort on every daemon restart.
     ...(typeof v.modelEffort === "string" && v.modelEffort.length > 0 ? { modelEffort: v.modelEffort } : {}),
+    ...(deletion ? { deletion } : {}),
     createdAt: v.createdAt,
     updatedAt: v.updatedAt,
+  }
+}
+
+function coerceDeletion(value: unknown): TaskDeletionState | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const v = value as Record<string, unknown>
+  if (
+    (v.phase !== "queued" && v.phase !== "running" && v.phase !== "error") ||
+    typeof v.force !== "boolean" ||
+    typeof v.requestedAt !== "string" ||
+    v.requestedAt.length === 0 ||
+    (v.error !== undefined && typeof v.error !== "string")
+  ) {
+    return undefined
+  }
+  return {
+    phase: v.phase,
+    force: v.force,
+    requestedAt: v.requestedAt,
+    ...(typeof v.error === "string" ? { error: v.error } : {}),
   }
 }
 

--- a/packages/kobe/src/orchestrator/task-deletion.ts
+++ b/packages/kobe/src/orchestrator/task-deletion.ts
@@ -1,0 +1,88 @@
+import { errorMessage } from "../lib/error-message.ts"
+import type { TaskId } from "../types/task.ts"
+import { CannotDeleteMainTaskError, DirtyWorktreeError, WorktreeRemoveFailedError } from "./errors.ts"
+import type { TaskIndexStore } from "./index/store.ts"
+import type { GitWorktreeManager } from "./worktree/manager.ts"
+
+/**
+ * Persistent task-deletion state machine. The daemon owns scheduling; this
+ * collaborator owns safety checks and the atomic task-index transitions.
+ */
+export class TaskDeletionCoordinator {
+  constructor(
+    private readonly store: TaskIndexStore,
+    private readonly worktrees: GitWorktreeManager,
+    private readonly forgetTask: (id: TaskId) => void,
+  ) {}
+
+  /** Persist acceptance after the destructive dirty-worktree safety check. */
+  async prepare(id: TaskId | string, opts?: { readonly force?: boolean }): Promise<boolean> {
+    const task = this.store.get(id)
+    if (!task) return false
+    if (task.kind === "main") throw new CannotDeleteMainTaskError()
+    if (task.deletion?.phase === "queued" || task.deletion?.phase === "running") return true
+
+    const force = opts?.force === true
+    if (task.worktreePath && !force) {
+      let dirty = false
+      try {
+        dirty = await this.worktrees.isDirty(task.worktreePath)
+      } catch {
+        // A missing/unreadable path is resolved by remove(), as before.
+      }
+      if (dirty) throw new DirtyWorktreeError(task.id)
+    }
+
+    await this.store.update(task.id, {
+      deletion: {
+        phase: "queued",
+        force,
+        requestedAt: new Date().toISOString(),
+      },
+    })
+    return true
+  }
+
+  /** Mark a queued/resumed deletion as actively owned by a daemon runner. */
+  async begin(id: TaskId | string): Promise<boolean> {
+    const task = this.store.get(id)
+    if (!task || !task.deletion || task.deletion.phase === "error") return false
+    if (task.deletion.phase !== "running") {
+      await this.store.update(task.id, { deletion: { ...task.deletion, phase: "running" } })
+    }
+    return true
+  }
+
+  /** Remove the worktree and task entry; retain a durable error on failure. */
+  async finish(id: TaskId | string): Promise<void> {
+    const task = this.store.get(id)
+    if (!task?.deletion || task.deletion.phase !== "running") return
+    try {
+      if (task.worktreePath) {
+        await this.worktrees.remove(task.worktreePath, {
+          force: task.deletion.force,
+          deleteBranch: true,
+        })
+      }
+    } catch (cause) {
+      const failure = new WorktreeRemoveFailedError(task.id, cause)
+      await this.store.update(task.id, {
+        deletion: {
+          ...task.deletion,
+          phase: "error",
+          error: errorMessage(failure),
+        },
+      })
+      throw failure
+    }
+    await this.store.remove(task.id)
+    this.forgetTask(task.id)
+  }
+
+  /** Compatibility path for local callers that still require completion. */
+  async deleteNow(id: TaskId | string, opts?: { readonly force?: boolean }): Promise<void> {
+    if (!(await this.prepare(id, opts))) return
+    if (!(await this.begin(id))) return
+    await this.finish(id)
+  }
+}

--- a/packages/kobe/src/tui-react/workspace/use-task-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-task-selection.ts
@@ -3,6 +3,7 @@
  * create-before-snapshot path is testable without mounting the full PTY host.
  */
 
+import { TaskDeletingError } from "../../orchestrator/errors.ts"
 import type { Task } from "../../types/task.ts"
 
 type ActivateWorkspaceTaskOptions = {
@@ -18,6 +19,10 @@ type ActivateWorkspaceTaskOptions = {
 
 export async function activateWorkspaceTask(opts: ActivateWorkspaceTaskOptions, id: string): Promise<boolean> {
   const task = opts.getTask(id)
+  if (task?.deletion) {
+    opts.reportError(new TaskDeletingError(id))
+    return false
+  }
   // A create RPC can resolve before the daemon's task snapshot causes the
   // workspace host to render. An unknown task is therefore not proof that the
   // id is invalid — materialize by the authoritative RPC id and let the daemon
@@ -52,11 +57,11 @@ export function firstSelectableTask(
   lastActiveId?: string | null,
 ): Task | undefined {
   const alive = (id: string | null | undefined): Task | undefined =>
-    id ? tasks.find((task) => task.id === id && !task.archived) : undefined
+    id ? tasks.find((task) => task.id === id && !task.archived && !task.deletion) : undefined
   const active = alive(activeId) ?? alive(lastActiveId)
   if (active) return active
-  const unarchived = tasks.filter((task) => !task.archived)
+  const unarchived = tasks.filter((task) => !task.archived && !task.deletion)
   if (unarchived.length > 0)
     return unarchived.reduce((newest, task) => (task.updatedAt > newest.updatedAt ? task : newest))
-  return tasks[0]
+  return tasks.find((task) => !task.deletion)
 }

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -40,6 +40,8 @@ export const en = {
   subtitle: {
     noTracking: "no activity tracking",
     materializing: "materializing",
+    deleting: "deleting",
+    deleteFailed: "delete failed",
   },
   /** ShortcutHints legend */
   hints: {
@@ -113,6 +115,8 @@ export const zh: typeof en = {
   subtitle: {
     noTracking: "不跟踪活动",
     materializing: "正在创建 worktree",
+    deleting: "正在删除",
+    deleteFailed: "删除失败",
   },
   hints: {
     headerFolded: "── 快捷键 ?▸ ──",

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -112,6 +112,10 @@ function materializingSubtitle(): string {
   return t("tasks.subtitle.materializing")
 }
 
+function deletionSubtitle(failed: boolean): string {
+  return failed ? t("tasks.subtitle.deleteFailed") : t("tasks.subtitle.deleting")
+}
+
 /**
  * True when this task runs on a user-added (custom) engine, which has no
  * transcript store for the activity monitor to read — so liveness simply
@@ -145,7 +149,8 @@ export function rowIsLoading(opts: RowLoadingInputs): boolean {
   const hasActivity = activityState !== undefined
   const untrackedCustomEngine = isCustomEngineTask(task) && !hasActivity
   const materializing = opts.job !== undefined
-  return materializing || (!untrackedCustomEngine && activityState === "running")
+  const deleting = task.deletion?.phase === "queued" || task.deletion?.phase === "running"
+  return deleting || materializing || (!untrackedCustomEngine && activityState === "running")
 }
 
 /**
@@ -216,6 +221,8 @@ export function buildSidebarRowView(opts: {
   // genuine daemon-side liveness fact, not engine telemetry, so the spinner
   // never lies here even for a custom engine.
   const materializing = opts.job !== undefined
+  const deleting = task.deletion?.phase === "queued" || task.deletion?.phase === "running"
+  const deleteFailed = task.deletion?.phase === "error"
   const loading = rowIsLoading({
     task,
     activity: opts.activity,
@@ -227,11 +234,13 @@ export function buildSidebarRowView(opts: {
     ? REDUCED_MOTION_SPINNER_FRAMES
     : (engineEntry(task.vendor ?? DEFAULT_TASK_VENDOR).spinnerFrames ?? DEFAULT_SPINNER_FRAMES)
   const spinner = spinnerFrames[opts.spinnerFrame % spinnerFrames.length] ?? spinnerFrames[0]
-  const tone = materializing
-    ? "primary"
-    : untrackedCustomEngine
-      ? "textMuted"
-      : (activityLabel?.tone ?? (loading ? "primary" : (activityBadge?.tone ?? "textMuted")))
+  const tone = deleteFailed
+    ? "error"
+    : deleting || materializing
+      ? "primary"
+      : untrackedCustomEngine
+        ? "textMuted"
+        : (activityLabel?.tone ?? (loading ? "primary" : (activityBadge?.tone ?? "textMuted")))
   // Subtitle priority: the materializing word while a worktree job runs
   // (there is no branch on disk yet), then a non-normal activity word (rate
   // limited / needs permission / error), then the branch, then — for an
@@ -240,17 +249,20 @@ export function buildSidebarRowView(opts: {
   // neutral dash. Persisted task lifecycle belongs to the board, not this
   // runtime-activity projection.
   const fallbackSubtitle = untrackedCustomEngine ? noTrackingSubtitle() : "—"
-  const subtitleText = materializing
-    ? opts.truncateBranch(materializingSubtitle(), opts.subtitleBudget)
-    : activityLabel
-      ? opts.truncateBranch(activityLabel.text, opts.subtitleBudget)
-      : branch.length > 0
-        ? opts.truncateBranch(branch, opts.subtitleBudget)
-        : opts.truncateBranch(fallbackSubtitle, opts.subtitleBudget)
+  const subtitleText =
+    deleting || deleteFailed
+      ? opts.truncateBranch(deletionSubtitle(deleteFailed), opts.subtitleBudget)
+      : materializing
+        ? opts.truncateBranch(materializingSubtitle(), opts.subtitleBudget)
+        : activityLabel
+          ? opts.truncateBranch(activityLabel.text, opts.subtitleBudget)
+          : branch.length > 0
+            ? opts.truncateBranch(branch, opts.subtitleBudget)
+            : opts.truncateBranch(fallbackSubtitle, opts.subtitleBudget)
   // Untracked custom engine gets a distinct dim dot. Normal tasks fall back
   // to the hollow idle circle because the client deliberately removes an
   // explicit `idle` activity entry; absence is therefore the idle projection.
-  const restGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "○")
+  const restGlyph = deleteFailed ? "✕" : untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "○")
   const restProjectGlyph = untrackedCustomEngine ? NO_TRACKING_GLYPH : (activityBadge?.glyph ?? "★")
   return {
     isMain,

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -81,6 +81,16 @@ export interface TaskPRStatus {
   readonly lastError?: string
 }
 
+export type TaskDeletionPhase = "queued" | "running" | "error"
+
+/** Durable state for daemon-owned background worktree cleanup. */
+export interface TaskDeletionState {
+  readonly phase: TaskDeletionPhase
+  readonly force: boolean
+  readonly requestedAt: string
+  readonly error?: string
+}
+
 /**
  * One task. Stored in `~/.kobe/tasks.json` as part of {@link TaskIndex}.
  *
@@ -142,6 +152,8 @@ export interface Task {
    * vendor-correct flag (see `interactive-command.ts`).
    */
   readonly modelEffort?: string
+  /** Present while background deletion is queued/running or after it failed. */
+  readonly deletion?: TaskDeletionState
   readonly createdAt: string
   readonly updatedAt: string
 }

--- a/packages/kobe/test/client/task-deletion-protocol.test.ts
+++ b/packages/kobe/test/client/task-deletion-protocol.test.ts
@@ -1,0 +1,32 @@
+import { serializeTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { describe, expect, it } from "vitest"
+import { deserializeTask } from "../../src/client/remote-orchestrator-payloads.ts"
+import type { Task } from "../../src/types/task.ts"
+import { toTaskId } from "../../src/types/task.ts"
+
+describe("task deletion wire state", () => {
+  it("round-trips durable deletion state through daemon serialization", () => {
+    const task: Task = {
+      id: toTaskId("t1"),
+      title: "task",
+      repo: "/repo",
+      branch: "branch",
+      worktreePath: "/wt/task",
+      kind: "task",
+      status: "backlog",
+      archived: false,
+      deletion: {
+        phase: "error",
+        force: true,
+        requestedAt: "2026-07-15T00:00:00.000Z",
+        error: "locked",
+      },
+      createdAt: "2026-07-15T00:00:00.000Z",
+      updatedAt: "2026-07-15T00:00:00.000Z",
+    }
+
+    const wire = serializeTask(task)
+    expect(wire.deletion).toEqual(task.deletion)
+    expect(deserializeTask(wire).deletion).toEqual(task.deletion)
+  })
+})

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -117,4 +117,25 @@ describe("daemon session adapter", () => {
     } as unknown as DaemonRpcClient
     await expect(terminalSpecAdapter(missing, "task-5")).rejects.toThrow("has no worktree")
   })
+
+  it("refuses engine and terminal specs for a task being deleted", async () => {
+    const deleting = {
+      request: vi.fn(
+        async <T>() =>
+          ({
+            task: {
+              id: "task-6",
+              repo: "/repo/kobe",
+              vendor: "claude",
+              worktreePath: "/worktrees/task-6",
+              deletion: { phase: "running", force: false, requestedAt: "2026-07-15T00:00:00.000Z" },
+            },
+          }) as T,
+      ),
+    } as unknown as DaemonRpcClient
+
+    await expect(engineSpecAdapter(deleting, "task-6")).rejects.toThrow("TASK_DELETING")
+    await expect(terminalSpecAdapter(deleting, "task-6")).rejects.toThrow("TASK_DELETING")
+    expect(mocks.ensureEngine).not.toHaveBeenCalled()
+  })
 })

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -1,0 +1,65 @@
+import type { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
+import type { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import type { IssuesStore } from "@sma1lboy/kobe-daemon/daemon/issues-store"
+import type { DaemonHandlerContext } from "@sma1lboy/kobe-daemon/daemon/server"
+import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
+import type { Orchestrator } from "../../src/orchestrator/core.ts"
+
+export interface RecordedHandlerEffects {
+  readonly published: Array<{ channel: string; payload: unknown }>
+  readonly reported: Array<{ taskId: string; kind: string; detail?: unknown }>
+  readonly issueCalls: Array<{ method: string; repo: unknown; op?: unknown }>
+  readonly cleared: string[]
+  readonly deletions: string[]
+  stopped: number
+}
+
+/** Build a handler context around a partial fake Orchestrator — no socket. */
+export function fakeCtx(orch: Record<string, unknown> = {}): {
+  ctx: DaemonHandlerContext
+  rec: RecordedHandlerEffects
+} {
+  const rec: RecordedHandlerEffects = {
+    published: [],
+    reported: [],
+    issueCalls: [],
+    cleared: [],
+    deletions: [],
+    stopped: 0,
+  }
+  const ctx: DaemonHandlerContext = {
+    runtime: daemonRuntime,
+    orch: { listTasks: () => [], ...orch } as unknown as Orchestrator,
+    bus: {
+      publish: (channel: string, payload: unknown) => rec.published.push({ channel, payload }),
+    } as unknown as DaemonEventBus,
+    activity: {
+      report: (taskId: string, kind: string, detail?: unknown) => rec.reported.push({ taskId, kind, detail }),
+      clearTask: (taskId: string) => rec.cleared.push(taskId),
+    } as unknown as DaemonActivityRegistry,
+    deletions: {
+      enqueue: (taskId: string) => rec.deletions.push(taskId),
+    },
+    issues: {
+      list: async (repo: unknown) => {
+        rec.issueCalls.push({ method: "list", repo })
+        return { repoRoot: String(repo), exists: false, nextId: 1, issues: [] }
+      },
+      mutate: async (repo: unknown, op: unknown) => {
+        rec.issueCalls.push({ method: "mutate", repo, op })
+        return { repoRoot: String(repo), exists: true, nextId: 2, issues: [] }
+      },
+    } as unknown as IssuesStore,
+    daemon: {
+      startedAt: new Date("2026-06-01T00:00:00.000Z"),
+      socketPath: "/tmp/fake/daemon.sock",
+      pid: 4242,
+      guiCount: () => 1,
+      stopSoon: async () => {
+        rec.stopped++
+      },
+    },
+    clientId: 7,
+  }
+  return { ctx, rec }
+}

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -1,6 +1,3 @@
-import type { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
-import type { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
-import type { IssuesStore } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import {
   type DaemonHandlerContext,
@@ -9,9 +6,8 @@ import {
   shapeDaemonError,
 } from "@sma1lboy/kobe-daemon/daemon/server"
 import { describe, expect, it } from "vitest"
-import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
-import type { Orchestrator } from "../../src/orchestrator/core.ts"
 import type { Task } from "../../src/types/task.ts"
+import { fakeCtx } from "./handler-test-context.ts"
 
 /**
  * RPC dispatch seam tests (registry in `kobe-daemon/src/daemon/handlers.ts`).
@@ -61,51 +57,6 @@ const SERIALIZED_TASK = {
   prStatus: undefined,
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-02T00:00:00.000Z",
-}
-
-interface Recorded {
-  readonly published: Array<{ channel: string; payload: unknown }>
-  readonly reported: Array<{ taskId: string; kind: string; detail?: unknown }>
-  readonly issueCalls: Array<{ method: string; repo: unknown; op?: unknown }>
-  readonly cleared: string[]
-  stopped: number
-}
-
-/** Build a handler context around a partial fake Orchestrator — no socket. */
-function fakeCtx(orch: Record<string, unknown> = {}): { ctx: DaemonHandlerContext; rec: Recorded } {
-  const rec: Recorded = { published: [], reported: [], issueCalls: [], cleared: [], stopped: 0 }
-  const ctx: DaemonHandlerContext = {
-    runtime: daemonRuntime,
-    orch: { listTasks: () => [], ...orch } as unknown as Orchestrator,
-    bus: {
-      publish: (channel: string, payload: unknown) => rec.published.push({ channel, payload }),
-    } as unknown as DaemonEventBus,
-    activity: {
-      report: (taskId: string, kind: string, detail?: unknown) => rec.reported.push({ taskId, kind, detail }),
-      clearTask: (taskId: string) => rec.cleared.push(taskId),
-    } as unknown as DaemonActivityRegistry,
-    issues: {
-      list: async (repo: unknown) => {
-        rec.issueCalls.push({ method: "list", repo })
-        return { repoRoot: String(repo), exists: false, nextId: 1, issues: [] }
-      },
-      mutate: async (repo: unknown, op: unknown) => {
-        rec.issueCalls.push({ method: "mutate", repo, op })
-        return { repoRoot: String(repo), exists: true, nextId: 2, issues: [] }
-      },
-    } as unknown as IssuesStore,
-    daemon: {
-      startedAt: new Date("2026-06-01T00:00:00.000Z"),
-      socketPath: "/tmp/fake/daemon.sock",
-      pid: 4242,
-      guiCount: () => 1,
-      stopSoon: async () => {
-        rec.stopped++
-      },
-    },
-    clientId: 7,
-  }
-  return { ctx, rec }
 }
 
 function dispatch(name: string, payload: unknown, ctx: DaemonHandlerContext): Promise<unknown> {
@@ -273,16 +224,24 @@ describe("daemon handler registry", () => {
       await expect(dispatch("task.reorder", { moves: [{ position: 1 }] }, ctx)).rejects.toThrow("taskId is required")
     })
 
-    it("task.delete clears the task's transient activity after the orchestrator delete", async () => {
-      const deleted: unknown[] = []
+    it("task.delete durably prepares, clears activity, and enqueues background cleanup", async () => {
+      const prepared: unknown[] = []
       const { ctx, rec } = fakeCtx({
-        deleteTask: async (id: string, opts: unknown) => {
-          deleted.push([id, opts])
+        prepareTaskDeletion: async (id: string, opts: unknown) => {
+          prepared.push([id, opts])
+          return true
         },
       })
       await expect(dispatch("task.delete", { taskId: "t1", force: true }, ctx)).resolves.toEqual({})
-      expect(deleted).toEqual([["t1", { force: true }]])
+      expect(prepared).toEqual([["t1", { force: true }]])
       expect(rec.cleared).toEqual(["t1"])
+      expect(rec.deletions).toEqual(["t1"])
+    })
+
+    it("task.delete does not enqueue an unknown task", async () => {
+      const { ctx, rec } = fakeCtx({ prepareTaskDeletion: async () => false })
+      await expect(dispatch("task.delete", { taskId: "missing" }, ctx)).resolves.toEqual({})
+      expect(rec.deletions).toEqual([])
     })
 
     it("task.move rejects a bogus direction with the legacy wording", async () => {

--- a/packages/kobe/test/daemon/task-deletion-background.test.ts
+++ b/packages/kobe/test/daemon/task-deletion-background.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import type { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import { bootDaemonHarness, waitFor } from "./harness.ts"
+
+const cleanups: Array<() => Promise<void>> = []
+
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()?.()
+})
+
+describe("background deletion over the daemon socket", () => {
+  it("returns task.delete while physical worktree removal is still blocked", async () => {
+    const home = await mkdtemp(join(tmpdir(), "kobe-delete-background-"))
+    const store = new TaskIndexStore({ homeDir: home })
+    await store.load()
+    const task = await store.create({
+      repo: "/repo",
+      title: "large task",
+      branch: "kobe/large-task",
+      worktreePath: "/wt/large-task",
+      status: "backlog",
+      kind: "task",
+      vendor: "claude",
+    })
+
+    let releaseRemoval: (() => void) | undefined
+    const remove = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRemoval = resolve
+        }),
+    )
+    const worktrees = {
+      isDirty: vi.fn(async () => false),
+      remove,
+    } as unknown as GitWorktreeManager
+    const orch = new Orchestrator({ store, worktrees })
+    const harness = await bootDaemonHarness({ orchestrator: orch })
+    cleanups.push(async () => {
+      releaseRemoval?.()
+      await harness.close()
+      orch.dispose()
+      await rm(home, { recursive: true, force: true })
+    })
+    const client = harness.client()
+    await client.connect()
+
+    const response = client.request("task.delete", { taskId: task.id })
+    await expect(
+      Promise.race([
+        response.then(() => "returned"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("blocked"), 500)),
+      ]),
+    ).resolves.toBe("returned")
+    await vi.waitFor(() => expect(remove).toHaveBeenCalledOnce())
+    expect(orch.getTask(task.id)?.deletion?.phase).toBe("running")
+
+    releaseRemoval?.()
+    expect(await waitFor(() => orch.getTask(task.id) === undefined)).toBe(true)
+  })
+})

--- a/packages/kobe/test/daemon/task-deletion-runner.test.ts
+++ b/packages/kobe/test/daemon/task-deletion-runner.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest"
+import type { DaemonOrchestrator, DaemonTask } from "../../../kobe-daemon/src/daemon/contracts.ts"
+import { TaskDeletionRunner } from "../../../kobe-daemon/src/daemon/task-deletion-runner.ts"
+
+function task(id: string, phase: "queued" | "running" | "error"): DaemonTask {
+  return {
+    id,
+    title: id,
+    repo: "/repo",
+    branch: "branch",
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "backlog",
+    archived: false,
+    deletion: { phase, force: false, requestedAt: "2026-07-15T00:00:00.000Z" },
+    createdAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+  }
+}
+
+describe("TaskDeletionRunner", () => {
+  it("deduplicates requests and preserves begin -> session teardown -> cleanup ordering", async () => {
+    const order: string[] = []
+    let releaseFinish: (() => void) | undefined
+    const orch = {
+      beginTaskDeletion: vi.fn(async () => {
+        order.push("begin")
+        return true
+      }),
+      finishTaskDeletion: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            order.push("finish")
+            releaseFinish = resolve
+          }),
+      ),
+    } as unknown as DaemonOrchestrator
+    const tearDownTaskSession = vi.fn(async () => {
+      order.push("teardown")
+    })
+    const clearActivity = vi.fn()
+    const runner = new TaskDeletionRunner(orch, { tearDownTaskSession }, clearActivity)
+
+    runner.enqueue("t1")
+    runner.enqueue("t1")
+    await vi.waitFor(() => expect(releaseFinish).toBeTypeOf("function"))
+    expect(order).toEqual(["begin", "teardown", "finish"])
+    expect(orch.beginTaskDeletion).toHaveBeenCalledTimes(1)
+    expect(orch.finishTaskDeletion).toHaveBeenCalledTimes(1)
+    expect(clearActivity).toHaveBeenCalledWith("t1")
+
+    releaseFinish?.()
+    await runner.drain()
+  })
+
+  it("resumes queued/running records on startup but leaves terminal errors for manual retry", async () => {
+    const begun: string[] = []
+    const orch = {
+      beginTaskDeletion: vi.fn(async (id: string) => {
+        begun.push(id)
+        return true
+      }),
+      finishTaskDeletion: vi.fn(async () => {}),
+    } as unknown as DaemonOrchestrator
+    const runner = new TaskDeletionRunner(orch, { tearDownTaskSession: async () => {} }, () => {})
+
+    runner.resume([task("queued", "queued"), task("running", "running"), task("failed", "error")])
+    await runner.drain()
+
+    expect(begun.sort()).toEqual(["queued", "running"])
+    expect(orch.finishTaskDeletion).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/kobe/test/orchestrator/store-load-edge.test.ts
+++ b/packages/kobe/test/orchestrator/store-load-edge.test.ts
@@ -133,6 +133,39 @@ describe("load() recovery", () => {
     expect(withPr?.prStatus).toMatchObject({ provider: "github", number: 12 })
     expect(withoutPr?.prStatus).toBeUndefined()
   })
+
+  it("preserves valid deletion state and drops malformed deletion state", async () => {
+    await primeDir()
+    const base = {
+      id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+      title: "ok",
+      repo: "/r",
+      branch: "b",
+      worktreePath: "/wt/b",
+      status: "backlog",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    }
+    await writeManifest(
+      JSON.stringify({
+        version: 3,
+        tasks: [
+          {
+            ...base,
+            deletion: { phase: "running", force: true, requestedAt: "2026-07-15T00:00:00.000Z" },
+          },
+          { ...base, id: "01ARZ3NDEKTSV4RRFFQ69G5FB0", deletion: { phase: "wat", force: "yes" } },
+        ],
+      }),
+    )
+    const [valid, malformed] = (await store.load()).tasks
+    expect(valid?.deletion).toEqual({
+      phase: "running",
+      force: true,
+      requestedAt: "2026-07-15T00:00:00.000Z",
+    })
+    expect(malformed?.deletion).toBeUndefined()
+  })
 })
 
 describe("loaded guard", () => {

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { DirtyWorktreeError, TaskDeletingError, WorktreeRemoveFailedError } from "../../src/orchestrator/errors.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import type { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+let home: string
+let store: TaskIndexStore
+let orch: Orchestrator
+let worktrees: {
+  isDirty: ReturnType<typeof vi.fn>
+  remove: ReturnType<typeof vi.fn>
+}
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "kobe-task-deletion-"))
+  store = new TaskIndexStore({ homeDir: home })
+  await store.load()
+  worktrees = {
+    isDirty: vi.fn(async () => false),
+    remove: vi.fn(async () => {}),
+  }
+  orch = new Orchestrator({ store, worktrees: worktrees as unknown as GitWorktreeManager })
+})
+
+afterEach(async () => {
+  orch.dispose()
+  await rm(home, { recursive: true, force: true })
+})
+
+async function makeTask(worktreePath = "/wt/task") {
+  const task = await orch.createTask({ repo: "/repo", title: "task", vendor: "claude" })
+  await store.update(task.id, { worktreePath })
+  return orch.getTask(task.id)!
+}
+
+describe("durable background task deletion", () => {
+  it("persists queued/running before physical cleanup and removes the task only on success", async () => {
+    const task = await makeTask()
+
+    await expect(orch.prepareTaskDeletion(task.id)).resolves.toBe(true)
+    expect(orch.getTask(task.id)?.deletion).toMatchObject({ phase: "queued", force: false })
+    expect(worktrees.remove).not.toHaveBeenCalled()
+
+    await expect(orch.beginTaskDeletion(task.id)).resolves.toBe(true)
+    expect(orch.getTask(task.id)?.deletion?.phase).toBe("running")
+
+    await orch.finishTaskDeletion(task.id)
+    expect(worktrees.remove).toHaveBeenCalledWith("/wt/task", { force: false, deleteBranch: true })
+    expect(orch.getTask(task.id)).toBeUndefined()
+  })
+
+  it("keeps a visible error after cleanup failure and supports an explicit retry", async () => {
+    const task = await makeTask()
+    worktrees.remove.mockRejectedValueOnce(new Error("locked"))
+
+    await orch.prepareTaskDeletion(task.id, { force: true })
+    await orch.beginTaskDeletion(task.id)
+    await expect(orch.finishTaskDeletion(task.id)).rejects.toThrow(WorktreeRemoveFailedError)
+    expect(orch.getTask(task.id)?.deletion).toMatchObject({
+      phase: "error",
+      force: true,
+      error: expect.stringContaining("locked"),
+    })
+
+    await orch.prepareTaskDeletion(task.id, { force: true })
+    expect(orch.getTask(task.id)?.deletion).toMatchObject({ phase: "queued", force: true })
+    await orch.beginTaskDeletion(task.id)
+    await orch.finishTaskDeletion(task.id)
+    expect(orch.getTask(task.id)).toBeUndefined()
+  })
+
+  it("runs the dirty-worktree guard before accepting and force bypasses it", async () => {
+    const task = await makeTask("/wt/dirty")
+    worktrees.isDirty.mockResolvedValue(true)
+
+    await expect(orch.prepareTaskDeletion(task.id)).rejects.toThrow(DirtyWorktreeError)
+    expect(orch.getTask(task.id)?.deletion).toBeUndefined()
+    await expect(orch.prepareTaskDeletion(task.id, { force: true })).resolves.toBe(true)
+    expect(worktrees.isDirty).toHaveBeenCalledTimes(1)
+    expect(orch.getTask(task.id)?.deletion?.force).toBe(true)
+  })
+
+  it("rejects focus and worktree materialization once deletion is accepted", async () => {
+    const task = await makeTask("")
+    await orch.prepareTaskDeletion(task.id)
+
+    await expect(orch.setActiveTask(task.id)).rejects.toThrow(TaskDeletingError)
+    await expect(orch.ensureWorktree(task.id)).rejects.toThrow(TaskDeletingError)
+  })
+})

--- a/packages/kobe/test/tui/sidebar-row-view.test.ts
+++ b/packages/kobe/test/tui/sidebar-row-view.test.ts
@@ -182,6 +182,35 @@ describe("buildSidebarRowView", () => {
     expect(v).toMatchObject({ loading: true, tone: "primary", subtitleText: "materializing" })
   })
 
+  it("spins with a deleting subtitle while durable cleanup is queued or running", () => {
+    const v = buildSidebarRowView({
+      task: task({
+        deletion: { phase: "running", force: true, requestedAt: "2026-07-15T00:00:00.000Z" },
+      }),
+      spinnerFrame: 0,
+      subtitleBudget: 80,
+      truncateBranch: (b) => b,
+    })
+    expect(v).toMatchObject({ loading: true, tone: "primary", subtitleText: "deleting", materializing: false })
+  })
+
+  it("renders a durable deletion failure without animation", () => {
+    const v = buildSidebarRowView({
+      task: task({
+        deletion: {
+          phase: "error",
+          force: false,
+          requestedAt: "2026-07-15T00:00:00.000Z",
+          error: "locked",
+        },
+      }),
+      spinnerFrame: 0,
+      subtitleBudget: 80,
+      truncateBranch: (b) => b,
+    })
+    expect(v).toMatchObject({ loading: false, stateGlyph: "✕", tone: "error", subtitleText: "delete failed" })
+  })
+
   it("falls back to a neutral dash for a project with no resolvable branch", () => {
     const v = buildSidebarRowView({
       task: task({ kind: "main", branch: "", status: "backlog" }),

--- a/packages/kobe/test/tui/workspace-task-selection.test.ts
+++ b/packages/kobe/test/tui/workspace-task-selection.test.ts
@@ -97,6 +97,34 @@ describe("pure-TUI workspace task activation", () => {
     expect(focusWorkspace).toHaveBeenCalledOnce()
   })
 
+  test("refuses to activate a task whose background deletion was accepted", async () => {
+    const deleting = {
+      ...task("deleting", "/worktrees/deleting"),
+      deletion: { phase: "queued" as const, force: false, requestedAt: "2026-07-15T00:00:00.000Z" },
+    }
+    const reportError = vi.fn()
+    const ensureWorktree = vi.fn(async () => "/worktrees/deleting")
+    const selectTask = vi.fn()
+
+    await expect(
+      activateWorkspaceTask(
+        {
+          getTask: () => deleting,
+          ensureWorktree,
+          selectTask,
+          focusWorkspace: vi.fn(),
+          reportError,
+        },
+        deleting.id,
+      ),
+    ).resolves.toBe(false)
+    expect(reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("TASK_DELETING") }),
+    )
+    expect(ensureWorktree).not.toHaveBeenCalled()
+    expect(selectTask).not.toHaveBeenCalled()
+  })
+
   test("a superseded activation resolves without stealing selection or focus", async () => {
     const selectTask = vi.fn()
     const focusWorkspace = vi.fn()


### PR DESCRIPTION
## Summary

- persist task deletion as a queued/running/error lifecycle before returning from `task.delete`
- move worktree teardown into a daemon-owned deduplicated background runner and resume interrupted deletions on startup
- expose deletion state through daemon, client, web, and TUI contracts so pending tasks cannot be reactivated and failures remain retryable
- add a patch changeset and focused protocol, orchestrator, daemon, persistence, and TUI tests

## Why

Worktree removal currently blocks the delete RPC and makes the UI appear frozen, especially for large worktrees. This change makes the RPC return after validation and durable queuing while the daemon completes physical cleanup in the background.

## Verification

- `bun --filter @sma1lboy/kobe lint`
- `bun --filter @sma1lboy/kobe typecheck`
- fast test suite: 2253 passed
- daemon test suite: 266 passed
- direct socket test confirmed the delete RPC returns while physical removal is blocked
- behavior suite: 11/12 passed; the remaining case failed independently at `node-pty` with `posix_spawnp failed`