### PR TITLE
fix: preserve IME anchor across pane focus

### DIFF
--- a/.changeset/steady-ime-pane-focus.md
+++ b/.changeset/steady-ime-pane-focus.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep the macOS input-method candidate window anchored to the visible chat terminal when keyboard focus moves to Tasks or Files, while transferring ownership safely across chat tabs, content tabs, split leaves, PTY changes, and dialogs.

--- a/docs/superpowers/specs/2026-07-13-ime-anchor-stability-design.md
+++ b/docs/superpowers/specs/2026-07-13-ime-anchor-stability-design.md
@@ -64,7 +64,14 @@ cursor.
 Separately, the terminal retains the last non-null PTY cursor for IME anchoring.
 Transient `CSI ? 25 l` / `CSI ? 25 h` redraw intervals no longer send the
 anchor to `(0, 0)`. The retained cursor is cleared when the PTY identity
-changes, focus leaves the pane, or the pane unmounts.
+changes or the pane unmounts.
+
+Keyboard focus and IME-anchor ownership are independent. Moving keyboard
+focus from Workspace to Sidebar or Files leaves the visible chat terminal's
+anchor active, because its PTY can keep repainting in the background. Within a
+split tab, only the active leaf owns the anchor; inactive leaves may render but
+cannot move it. A modal dialog suppresses the terminal anchor so its own input
+can control native cursor placement.
 
 Each mounted terminal owns a unique token. Anchor updates claim ownership;
 release clears the global anchor only when the releasing token is still the
@@ -75,9 +82,12 @@ claimed by the newly focused leaf.
 
 When no terminal owns the anchor, the output adapter passes bytes through
 unchanged. If the cursor has never been observed or is outside a historical
-scrollback viewport, a focused pane keeps the prior valid screen anchor rather
-than inventing an origin coordinate. On focus loss, KOBE parks the native
-cursor at the origin as before; no IME composition belongs to that pane then.
+scrollback viewport, the active visible terminal keeps the prior valid screen
+anchor rather than inventing an origin coordinate. Switching to a content
+file/preview tab unmounts the terminal and releases its owner; returning to a
+chat tab claims the selected PTY's current coordinate. Switching chat tabs or
+split leaves transfers ownership without allowing stale cleanup or background
+output to clear the new anchor.
 
 ## Verification
 
@@ -89,6 +99,12 @@ cursor at the origin as before; no IME composition belongs to that pane then.
   anchor.
 - Cursor-retention test: a transient null PTY cursor preserves the IME anchor
   while the visual cursor remains null; a PTY identity change clears it.
+- Focus-transition test: Sidebar/Files keyboard focus does not clear the
+  visible chat terminal's anchor.
+- Tab/split tests: chat PTY switches replace retained coordinates, content
+  tabs release and reclaim on return, and inactive split output cannot steal
+  ownership.
+- Modal test: an open dialog suppresses the terminal anchor.
 - Existing terminal IME key-forwarding render tests remain green.
 - Pre-PR gates: lint, typecheck, fast + socket tests, render tests, build, and
   behavior tests.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -69,6 +69,13 @@ export type TerminalProps = {
   taskId: string | null
   focused?: boolean
   /**
+   * Whether this mounted terminal represents the visible chat tab / active
+   * split leaf for macOS IME placement. Unlike `focused`, this stays true when
+   * keyboard ownership moves to Sidebar or Files. Inactive split leaves pass
+   * false so background output cannot steal the shared anchor.
+   */
+  imeAnchorActive?: boolean
+  /**
    * Ask the host to focus this pane (mouse click). Needed because opentui
    * mouse events don't bubble to the workspace wrapper's `onMouseUp`, and
    * this pane's own selection handlers consume the click — so a bare click
@@ -214,6 +221,9 @@ export function Terminal(props: TerminalProps) {
   /* --------- reset (F5, confirm-gated) ---------- */
 
   const dialog = useDialog()
+  // A modal input owns the native cursor while it is open. Side-pane focus
+  // does not: the visible terminal remains the stable IME fallback there.
+  const imeAnchorActive = (props.imeAnchorActive ?? true) && dialog.stack.length === 0
   const resetTaskIdRef = useLatest(props.taskId)
   const resetCwdRef = useLatest(props.cwd)
   const mountedRef = useRef(true)
@@ -275,18 +285,18 @@ export function Terminal(props: TerminalProps) {
     }
   }, [pty, bodyGeometry])
 
-  // Keep the native host cursor INVISIBLE (the visible cursor is the
-  // inline inverse cell in `cursorRows`) but ANCHORED to the embedded
-  // cursor's screen cell — the OS IME candidate window follows the real
-  // terminal cursor. A transient PTY cursor-hide retains the last position;
-  // the renderer-output adapter restores it at the end of every diff frame.
+  // Keep the native host cursor INVISIBLE (the visible cursor is the inline
+  // inverse cell in `cursorRows`) but ANCHORED to the visible chat terminal's
+  // screen cell — even while Sidebar or Files owns keyboard focus. A transient
+  // PTY cursor-hide retains the last position; the renderer-output adapter
+  // restores it at the end of every diff frame.
   useEffect(() => {
     // Dependency-only invalidation keys — see use-terminal-geometry.ts;
     // screenX/screenY are read imperatively, non-reactive geometry.
     void dims
     void geomTick
     if (!renderer) return
-    if (!focused) {
+    if (!imeAnchorActive) {
       imeScreenAnchorRetention.update(null, null)
       if (imeAnchorController.release(imeAnchorOwner)) renderer.setCursorPosition(0, 0, false)
       return
@@ -309,7 +319,17 @@ export function Terminal(props: TerminalProps) {
     }
     imeAnchorController.claim(imeAnchorOwner, { x: 0, y: 0 })
     renderer.setCursorPosition(0, 0, false)
-  }, [renderer, focused, bodyEl, visibleImeCursor, dims, geomTick, imeAnchorOwner, imeScreenAnchorRetention, pty])
+  }, [
+    renderer,
+    imeAnchorActive,
+    bodyEl,
+    visibleImeCursor,
+    dims,
+    geomTick,
+    imeAnchorOwner,
+    imeScreenAnchorRetention,
+    pty,
+  ])
 
   // On unmount, hide the cursor so it doesn't leak into whichever pane
   // gains focus next.

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -261,6 +261,7 @@ export function TerminalSplit(props: {
 
   const renderLeaf = (leaf: SplitLeaf<LeafCommand>, divider?: "left" | "top"): ReactNode => {
     const focusThis = (): void => setActiveLeaf(leaf.id)
+    const imeAnchorActive = activeLeaf === leaf.id
     const focused = leafFocused(leaf.id)
     const body = (
       <>
@@ -272,6 +273,7 @@ export function TerminalSplit(props: {
           onExit={() => onLeafExit(leaf.id)}
           resetToken={leaf.id === "leaf-1" ? props.resetToken : undefined}
           focused={focused}
+          imeAnchorActive={imeAnchorActive}
           onRequestFocus={() => {
             props.onRequestFocus?.()
             focusThis()
@@ -376,6 +378,7 @@ export function TerminalSplit(props: {
       onExit={props.onExit}
       resetToken={props.resetToken}
       focused={props.focused}
+      imeAnchorActive={true}
       onRequestFocus={props.onRequestFocus}
     />
   )

--- a/packages/kobe/test/render/terminal-pane.test.tsx
+++ b/packages/kobe/test/render/terminal-pane.test.tsx
@@ -20,6 +20,7 @@ import { describe, expect, test } from "bun:test"
 import { useState } from "react"
 import { modalActive } from "../../src/tui-react/lib/keymap"
 import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
+import { imeAnchorController } from "../../src/tui/lib/ime-anchor-output"
 import { type ScriptedPtyRegistry, createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
 import { type RenderHandle, act, renderComponent } from "./harness"
 
@@ -81,10 +82,46 @@ function SwitchHost(props: {
   return <Terminal cwd={target.cwd} taskId={target.taskId} focused registry={props.harness.registry} />
 }
 
-function UnmountHost(props: { harness: ScriptedPtyRegistry; api: { hide?: () => void } }) {
+function UnmountHost(props: {
+  harness: ScriptedPtyRegistry
+  api: { hide?: () => void; setShown?: (shown: boolean) => void }
+}) {
   const [shown, setShown] = useState(true)
   props.api.hide = () => setShown(false)
+  props.api.setShown = setShown
   return shown ? <Terminal cwd="/wt" taskId="t1" focused registry={props.harness.registry} /> : <box />
+}
+
+function FocusHost(props: { harness: ScriptedPtyRegistry; api: { setFocused?: (focused: boolean) => void } }) {
+  const [focused, setFocused] = useState(true)
+  props.api.setFocused = setFocused
+  return <Terminal cwd="/wt" taskId="t1" focused={focused} registry={props.harness.registry} />
+}
+
+function SplitAnchorHost(props: {
+  harness: ScriptedPtyRegistry
+  api: { setActive?: (leaf: "left" | "right") => void }
+}) {
+  const [active, setActive] = useState<"left" | "right">("left")
+  props.api.setActive = setActive
+  return (
+    <box flexDirection="row" flexGrow={1}>
+      <Terminal
+        cwd="/wt"
+        taskId="left"
+        focused={false}
+        imeAnchorActive={active === "left"}
+        registry={props.harness.registry}
+      />
+      <Terminal
+        cwd="/wt"
+        taskId="right"
+        focused={false}
+        imeAnchorActive={active === "right"}
+        registry={props.harness.registry}
+      />
+    </box>
+  )
 }
 
 describe("Terminal pane on a scripted fake PTY", () => {
@@ -280,6 +317,100 @@ describe("Terminal pane on a scripted fake PTY", () => {
 
     expect(harness.ptys.length).toBe(1)
     expect(harness.last().killed).toBe(false)
+  })
+
+  test("keeps the visible terminal's IME anchor when keyboard focus moves to another pane", async () => {
+    const harness = createScriptedPtyRegistry()
+    const api: { setFocused?: (focused: boolean) => void } = {}
+    const { aframe: frame } = await mountTerminal(<FocusHost harness={harness} api={api} />)
+    await frame()
+    const anchoredWhileFocused = imeAnchorController.current()
+    expect(anchoredWhileFocused).not.toBeNull()
+
+    await act(async () => api.setFocused?.(false))
+    await frame()
+
+    expect(imeAnchorController.current()).toEqual(anchoredWhileFocused)
+  })
+
+  test("transfers IME ownership between split leaves without background output stealing it", async () => {
+    const harness = createScriptedPtyRegistry()
+    const api: { setActive?: (leaf: "left" | "right") => void } = {}
+    const { aframe: frame } = await mountTerminal(<SplitAnchorHost harness={harness} api={api} />)
+    await frame()
+    expect(harness.ptys).toHaveLength(2)
+
+    await act(async () => {
+      harness.ptys[0]?.setCursor({ x: 2, y: 0 })
+      harness.ptys[1]?.setCursor({ x: 7, y: 0 })
+      harness.ptys[0]?.feed("left prompt$ ")
+      harness.ptys[1]?.feed("right prompt$ ")
+    })
+    await frame()
+    const leftAnchor = imeAnchorController.current()
+    expect(leftAnchor).not.toBeNull()
+
+    await act(async () => harness.ptys[1]?.feed("background output"))
+    await frame()
+    expect(imeAnchorController.current()).toEqual(leftAnchor)
+
+    await act(async () => api.setActive?.("right"))
+    await frame()
+    expect(imeAnchorController.current()).not.toEqual(leftAnchor)
+  })
+
+  test("releases a chat terminal anchor while a content tab replaces it, then reclaims it on return", async () => {
+    const harness = createScriptedPtyRegistry()
+    const api: { setShown?: (shown: boolean) => void } = {}
+    const { aframe: frame } = await mountTerminal(<UnmountHost harness={harness} api={api} />)
+    await frame()
+    expect(imeAnchorController.current()).not.toBeNull()
+
+    await act(async () => api.setShown?.(false))
+    await frame()
+    expect(imeAnchorController.current()).toBeNull()
+
+    await act(async () => api.setShown?.(true))
+    await frame()
+    expect(imeAnchorController.current()).not.toBeNull()
+  })
+
+  test("replaces the retained IME coordinate when switching chat-tab PTYs", async () => {
+    const harness = createScriptedPtyRegistry()
+    const api: { switchTo?: (taskId: string, cwd: string) => void } = {}
+    const { aframe: frame } = await mountTerminal(<SwitchHost harness={harness} api={api} />)
+    await frame()
+    await act(async () => {
+      harness.last().setCursor({ x: 24, y: 0 })
+      harness.last().feed("a very long first chat prompt$ ")
+    })
+    await frame()
+    const firstAnchor = imeAnchorController.current()
+    expect(firstAnchor).not.toBeNull()
+
+    await act(async () => api.switchTo?.("t2", "/wt-2"))
+    await frame()
+    await act(async () => {
+      harness.last().setCursor({ x: 1, y: 0 })
+      harness.last().feed("$ ")
+    })
+    await frame()
+
+    expect(harness.ptys).toHaveLength(2)
+    expect(imeAnchorController.current()).not.toEqual(firstAnchor)
+  })
+
+  test("yields the terminal IME anchor while a modal dialog owns input", async () => {
+    const harness = createScriptedPtyRegistry()
+    const { aframe: frame, mockInput } = await mountTerminal(
+      <Terminal cwd="/wt" taskId="t1" focused registry={harness.registry} />,
+    )
+    await frame()
+    expect(imeAnchorController.current()).not.toBeNull()
+
+    act(() => mockInput.pressKey("F5"))
+    expect(await frame()).toMatch(/Reset terminal|重置终端/)
+    expect(imeAnchorController.current()).toBeNull()
   })
 
   test("a reset after resize applies the current geometry to the fresh PTY", async () => {


### PR DESCRIPTION
## Summary

- separate macOS IME-anchor ownership from keyboard pane focus, so the visible chat terminal keeps restoring its hidden hardware-cursor position while Tasks or Files is focused
- let only the active split leaf own the anchor; chat-tab PTY changes replace retained coordinates, content/file tabs release and reclaim on return, and modal dialogs yield native cursor placement
- update the IME lifecycle design, add a patch changeset, and cover every ownership transition with OpenTUI render regressions

## Root cause

The earlier IME fix restored the hidden outer-terminal cursor at the end of each OpenTUI frame, but `Terminal` released that frame-final anchor whenever its `focused` prop became false. Moving focus to Tasks or Files leaves the terminal mounted and animated, so subsequent frames again left the real cursor at their last painted cell and macOS moved the candidate window there.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` — 2,253 fast tests + 267 socket/daemon tests
- `cd packages/kobe && bun run test:render` — 108 tests
- `cd packages/kobe && bun run build`
- `cd packages/kobe && bun run test:behavior` — 12 tests
- touched source files remain below 500 lines

## Manual acceptance

The browser harness cannot observe the macOS system IME candidate window. Final acceptance should type with macOS Pinyin in iTerm while the engine animates, then move focus among Workspace, Tasks, and Files and switch chat/content tabs.
