### PR TITLE
Add durable attention Inbox

### DIFF
--- a/.changeset/calm-attention-inbox.md
+++ b/.changeset/calm-attention-inbox.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Add a durable bottom-right Inbox for chat tabs that need attention, retaining permission requests, failures, rate limits, and completions until that tab starts working again or the user explicitly deletes the episode.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -25,8 +25,8 @@ Default prefix actions:
 |---|---|
 | `ctrl+a`, `f` | Quick-fork a child task |
 | `ctrl+a`, `y` | Resume a prior engine Session |
-| `ctrl+a`, `j` | Cycle focus backward (Files → Workspace → Sidebar) |
-| `ctrl+a`, `k` | Cycle focus forward (Sidebar → Workspace → Files) |
+| `ctrl+a`, `j` | Cycle focus backward (Inbox → Files → Workspace → Sidebar) |
+| `ctrl+a`, `k` | Cycle focus forward (Sidebar → Workspace → Files → Inbox) |
 | `ctrl+a`, `\\` | Split right |
 | `ctrl+a`, `=` | Split down |
 | `ctrl+a`, `w` | Close active split |
@@ -44,7 +44,7 @@ High-frequency tab actions remain direct: `ctrl+t`, `ctrl+e`, `ctrl+w`,
 | `F4` | Cycle focus forward |
 | `F5` | Confirm and reset the active terminal |
 | `F6` | Toggle zen mode |
-| `F7` | Jump to the next waiting task/tab — permission, question dialog, error, or unseen turn-completion, across every project and the current task's other tabs (2026-07-12 owner call; targets: `nextAttentionTarget` in `tui/lib/notify-state.ts`, tab identity via the launch script's exported `KOBE_TASK_ID`/`KOBE_TAB_ID`) |
+| `F7` | Jump to the next retained Inbox episode — permission/input, error/rate-limit, or turn completion — across every project and the current task's other tabs. Jumping does not consume the episode. |
 | `ctrl+t` | New engine tab |
 | `ctrl+e` | New tab with engine/shell picker |
 | `ctrl+w` | Close active split, otherwise close tab |
@@ -72,6 +72,12 @@ branch, `v` change engine, `/` search, and `[`/`]` switch Working/Archives.
 
 Common Files actions include `j/k` navigation, `h/l` collapse/expand, `enter`
 preview, `e` open in the configured editor, and `[`/`]` switch file tabs.
+
+The bottom-right Inbox is a separate focused surface. Its pane-local bindings
+are `j/k` to select, `enter` to jump to the task/chat tab, and `d` to delete
+that attention episode. Owner decision (2026-07-15): `d` is direct and
+Inbox-scoped because deletion is a frequent, explicit cleanup action there;
+it cannot shadow chat input or embedded-terminal shortcuts outside the pane.
 
 ## User customization
 

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -12,6 +12,7 @@
     "./client/pty-process": "./src/client/pty-process.ts",
     "./client/rpc": "./src/client/rpc.ts",
     "./daemon/activity-registry": "./src/daemon/activity-registry.ts",
+    "./daemon/attention-inbox": "./src/daemon/attention-inbox.ts",
     "./daemon/auto-title-poller": "./src/daemon/auto-title-poller.ts",
     "./daemon/client-writer": "./src/daemon/client-writer.ts",
     "./daemon/conflict-collector": "./src/daemon/conflict-collector.ts",

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -1,0 +1,161 @@
+/**
+ * Durable, daemon-owned attention Inbox.
+ *
+ * Live engine activity and Inbox retention are deliberately different state:
+ * activity may idle on session close/archive, while an unresolved episode must
+ * remain until that exact task+tab starts another turn or the user dismisses
+ * it. The store persists a full snapshot so daemon/TUI reconnects cannot
+ * consume work by accident.
+ */
+
+import { randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import type { AttentionInboxItem, AttentionInboxState, EngineActivityDetail, EngineActivityKind } from "./contracts.ts"
+import type { DaemonEventBus } from "./event-bus.ts"
+
+interface AttentionInboxFile {
+  readonly version: 1
+  readonly items: AttentionInboxItem[]
+}
+
+export function defaultAttentionInboxPath(homeDir = process.env.KOBE_HOME_DIR ?? homedir()): string {
+  return join(homeDir, ".kobe", "attention-inbox.json")
+}
+
+function itemKey(taskId: string, tabId: string | null): string {
+  return `${taskId}\0${tabId ?? ""}`
+}
+
+function stateFor(kind: EngineActivityKind, detail?: EngineActivityDetail): AttentionInboxState | null {
+  if (kind === "turn-complete") return "turn_complete"
+  if (kind === "awaiting-input") return "permission_needed"
+  if (kind !== "turn-failed") return null
+  return detail?.failure === "rate_limit" || detail?.failure === "billing" ? "rate_limited" : "error"
+}
+
+function normalizeItem(value: unknown): AttentionInboxItem | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const item = value as Partial<AttentionInboxItem>
+  if (typeof item.taskId !== "string" || item.taskId.length === 0) return null
+  if (item.tabId !== null && typeof item.tabId !== "string") return null
+  if (
+    item.state !== "turn_complete" &&
+    item.state !== "permission_needed" &&
+    item.state !== "error" &&
+    item.state !== "rate_limited"
+  )
+    return null
+  if (typeof item.at !== "number" || !Number.isFinite(item.at)) return null
+  return {
+    taskId: item.taskId,
+    tabId: item.tabId,
+    state: item.state,
+    ...(item.detail ? { detail: item.detail } : {}),
+    at: item.at,
+  }
+}
+
+async function readStore(path: string): Promise<AttentionInboxItem[]> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<AttentionInboxFile>
+    if (!Array.isArray(parsed.items)) return []
+    return parsed.items.map(normalizeItem).filter((item): item is AttentionInboxItem => item !== null)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw err
+  }
+}
+
+async function writeStore(path: string, items: readonly AttentionInboxItem[]): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
+  const body: AttentionInboxFile = { version: 1, items: [...items] }
+  await writeFile(tmp, `${JSON.stringify(body, null, 2)}\n`, "utf8")
+  await rename(tmp, path)
+}
+
+export class AttentionInboxStore {
+  private readonly items = new Map<string, AttentionInboxItem>()
+  private tail: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly path: string,
+    private readonly bus: DaemonEventBus,
+    private readonly now = () => Date.now(),
+  ) {}
+
+  async init(): Promise<void> {
+    await this.enqueue(async () => {
+      this.items.clear()
+      for (const item of await readStore(this.path)) this.items.set(itemKey(item.taskId, item.tabId), item)
+      this.publish()
+    })
+  }
+
+  snapshot(): AttentionInboxItem[] {
+    return [...this.items.values()].sort(
+      (a, b) => a.at - b.at || a.taskId.localeCompare(b.taskId) || (a.tabId ?? "").localeCompare(b.tabId ?? ""),
+    )
+  }
+
+  async record(taskId: string, kind: EngineActivityKind, detail?: EngineActivityDetail, tabId?: string): Promise<void> {
+    await this.enqueue(async () => {
+      const key = itemKey(taskId, tabId ?? null)
+      if (kind === "turn-start") {
+        if (!this.items.delete(key)) return
+      } else {
+        const state = stateFor(kind, detail)
+        if (!state) return
+        this.items.set(key, {
+          taskId,
+          tabId: tabId ?? null,
+          state,
+          ...(detail ? { detail } : {}),
+          at: this.now(),
+        })
+      }
+      await this.persistAndPublish()
+    })
+  }
+
+  async deleteEpisode(taskId: string, tabId: string | null): Promise<boolean> {
+    return await this.enqueue(async () => {
+      if (!this.items.delete(itemKey(taskId, tabId))) return false
+      await this.persistAndPublish()
+      return true
+    })
+  }
+
+  async deleteTask(taskId: string): Promise<void> {
+    await this.enqueue(async () => {
+      let changed = false
+      for (const [key, item] of this.items) {
+        if (item.taskId !== taskId) continue
+        this.items.delete(key)
+        changed = true
+      }
+      if (changed) await this.persistAndPublish()
+    })
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(operation)
+    this.tail = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
+  private async persistAndPublish(): Promise<void> {
+    const items = this.snapshot()
+    await writeStore(this.path, items)
+    this.bus.publish("attention.inbox", { items })
+  }
+
+  private publish(): void {
+    this.bus.publish("attention.inbox", { items: this.snapshot() })
+  }
+}

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -3,9 +3,9 @@
  *
  * Live engine activity and Inbox retention are deliberately different state:
  * activity may idle on session close/archive, while an unresolved episode must
- * remain until that exact task+tab starts another turn or the user dismisses
- * it. The store persists a full snapshot so daemon/TUI reconnects cannot
- * consume work by accident.
+ * remain until that exact task+tab starts another turn, the user dismisses it,
+ * or the containing task is explicitly hard-deleted. The store persists a
+ * full snapshot so daemon/TUI reconnects cannot consume work by accident.
  */
 
 import { randomUUID } from "node:crypto"
@@ -13,6 +13,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import type { AttentionInboxItem, AttentionInboxState, EngineActivityDetail, EngineActivityKind } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 
 interface AttentionInboxFile {
@@ -32,7 +33,7 @@ function stateFor(kind: EngineActivityKind, detail?: EngineActivityDetail): Atte
   if (kind === "turn-complete") return "turn_complete"
   if (kind === "awaiting-input") return "permission_needed"
   if (kind !== "turn-failed") return null
-  return detail?.failure === "rate_limit" || detail?.failure === "billing" ? "rate_limited" : "error"
+  return detail?.failure === "rate_limit" ? "rate_limited" : "error"
 }
 
 function normalizeItem(value: unknown): AttentionInboxItem | null {
@@ -64,7 +65,8 @@ async function readStore(path: string): Promise<AttentionInboxItem[]> {
     return parsed.items.map(normalizeItem).filter((item): item is AttentionInboxItem => item !== null)
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
-    throw err
+    logDaemonError("attention-inbox-load", err)
+    return []
   }
 }
 
@@ -103,12 +105,13 @@ export class AttentionInboxStore {
   async record(taskId: string, kind: EngineActivityKind, detail?: EngineActivityDetail, tabId?: string): Promise<void> {
     await this.enqueue(async () => {
       const key = itemKey(taskId, tabId ?? null)
+      const next = new Map(this.items)
       if (kind === "turn-start") {
-        if (!this.items.delete(key)) return
+        if (!next.delete(key)) return
       } else {
         const state = stateFor(kind, detail)
         if (!state) return
-        this.items.set(key, {
+        next.set(key, {
           taskId,
           tabId: tabId ?? null,
           state,
@@ -116,28 +119,35 @@ export class AttentionInboxStore {
           at: this.now(),
         })
       }
-      await this.persistAndPublish()
+      await this.commit(next)
     })
   }
 
   async deleteEpisode(taskId: string, tabId: string | null): Promise<boolean> {
     return await this.enqueue(async () => {
-      if (!this.items.delete(itemKey(taskId, tabId))) return false
-      await this.persistAndPublish()
+      const next = new Map(this.items)
+      if (!next.delete(itemKey(taskId, tabId))) return false
+      await this.commit(next)
       return true
     })
   }
 
   async deleteTask(taskId: string): Promise<void> {
     await this.enqueue(async () => {
+      const next = new Map(this.items)
       let changed = false
-      for (const [key, item] of this.items) {
+      for (const [key, item] of next) {
         if (item.taskId !== taskId) continue
-        this.items.delete(key)
+        next.delete(key)
         changed = true
       }
-      if (changed) await this.persistAndPublish()
+      if (changed) await this.commit(next)
     })
+  }
+
+  /** Task deletion must continue even when Inbox persistence is unavailable. */
+  async deleteTaskBestEffort(taskId: string): Promise<void> {
+    await this.deleteTask(taskId).catch((err) => logDaemonError("attention-inbox-task-delete", err))
   }
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -149,9 +159,14 @@ export class AttentionInboxStore {
     return run
   }
 
-  private async persistAndPublish(): Promise<void> {
-    const items = this.snapshot()
+  /** Serialize mutations so concurrent hook/RPC writes cannot clobber the file. */
+  private async commit(next: ReadonlyMap<string, AttentionInboxItem>): Promise<void> {
+    const items = [...next.values()].sort(
+      (a, b) => a.at - b.at || a.taskId.localeCompare(b.taskId) || (a.tabId ?? "").localeCompare(b.tabId ?? ""),
+    )
     await writeStore(this.path, items)
+    this.items.clear()
+    for (const item of items) this.items.set(itemKey(item.taskId, item.tabId), item)
     this.bus.publish("attention.inbox", { items })
   }
 

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -71,8 +71,8 @@ export interface ChannelPayloads {
   }
   /**
    * Full durable attention queue. Viewing never consumes an item: an episode
-   * leaves only after a newer `turn-start` for the same task+tab or an explicit
-   * `attention.dismiss` RPC. Full snapshots make reconnect/replay stateless.
+   * leaves only after a newer same-tab `turn-start`, explicit dismissal, or an
+   * explicit hard-delete of its task. Full snapshots make reconnect stateless.
    */
   "attention.inbox": { items: AttentionInboxItem[] }
   /**

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -6,7 +6,7 @@
  * import path for the wire protocol.
  */
 
-import type { EngineActivityDetail, TaskActivityState, UpdateInfo } from "./contracts.ts"
+import type { AttentionInboxItem, EngineActivityDetail, TaskActivityState, UpdateInfo } from "./contracts.ts"
 import type { RepoIssues } from "./issues-store.ts"
 import type { SerializedTask } from "./protocol.ts"
 
@@ -69,6 +69,12 @@ export interface ChannelPayloads {
     detail?: EngineActivityDetail
     at: number
   }
+  /**
+   * Full durable attention queue. Viewing never consumes an item: an episode
+   * leaves only after a newer `turn-start` for the same task+tab or an explicit
+   * `attention.dismiss` RPC. Full snapshots make reconnect/replay stateless.
+   */
+  "attention.inbox": { items: AttentionInboxItem[] }
   /**
    * The user's persisted VISUAL prefs (`state.json`'s `activeTheme` /
    * `transparentBackground` / `focusAccent` / `activeSortMode`), pushed
@@ -254,6 +260,7 @@ export const CHANNEL_NAMES: readonly ChannelName[] = [
   "active-task",
   "update",
   "engine-state",
+  "attention.inbox",
   "ui-prefs",
   "keybindings",
   "task.jobs",

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -124,6 +124,23 @@ export interface EngineActivityDetail {
 
 export type TaskActivityState = "idle" | "running" | "turn_complete" | "rate_limited" | "permission_needed" | "error"
 
+/** States retained as unresolved Inbox episodes until a newer same-tab turn starts. */
+export type AttentionInboxState = Extract<
+  TaskActivityState,
+  "turn_complete" | "permission_needed" | "error" | "rate_limited"
+>
+
+/** One daemon-owned, durable attention episode for a task's engine tab. */
+export interface AttentionInboxItem {
+  readonly taskId: string
+  /** `null` for hook events that predate or lack a tab identity. */
+  readonly tabId: string | null
+  readonly state: AttentionInboxState
+  readonly detail?: EngineActivityDetail
+  /** Event time, epoch milliseconds. Stable across daemon/TUI restarts. */
+  readonly at: number
+}
+
 export interface UpdateInfo {
   readonly current: string
   readonly latest: string

--- a/packages/kobe-daemon/src/daemon/handlers-attention.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-attention.ts
@@ -1,0 +1,15 @@
+/** Durable attention-Inbox RPC handlers. */
+
+import { optionalString, requireString } from "./handler-validators.ts"
+import type { DaemonRequestHandler } from "./handlers.ts"
+
+export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
+  {
+    name: "attention.dismiss",
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = optionalString(payload, "tabId") ?? null
+      return { deleted: await ctx.inbox.deleteEpisode(taskId, tabId) }
+    },
+  },
+]

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -93,6 +93,9 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
         force: optionalBoolean(payload, "force"),
       })
       ctx.activity.clearTask(taskId)
+      // A hard task delete is an explicit user deletion, so it is the one
+      // lifecycle action allowed to cascade its durable Inbox episodes.
+      await ctx.inbox.deleteTask(taskId)
       if (accepted) ctx.deletions.enqueue(taskId)
       return {}
     },

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -95,7 +95,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
       ctx.activity.clearTask(taskId)
       // A hard task delete is an explicit user deletion, so it is the one
       // lifecycle action allowed to cascade its durable Inbox episodes.
-      await ctx.inbox.deleteTask(taskId)
+      await ctx.inbox.deleteTaskBestEffort(taskId)
       if (accepted) ctx.deletions.enqueue(taskId)
       return {}
     },

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -34,11 +34,13 @@
  */
 
 import type { DaemonActivityRegistry } from "./activity-registry.ts"
+import type { AttentionInboxStore } from "./attention-inbox.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { findAdoptableWorktree, matchTaskByCwd } from "./cwd-task.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import { objectPayload, optionalActivityDetail, optionalString, requireString } from "./handler-validators.ts"
+import { ATTENTION_HANDLERS } from "./handlers-attention.ts"
 import { TASK_HANDLERS } from "./handlers-task.ts"
 import { WORKTREE_HANDLERS } from "./handlers-worktree.ts"
 import type { IssuesStore } from "./issues-store.ts"
@@ -80,6 +82,8 @@ export interface DaemonHandlerContext {
   readonly bus: DaemonEventBus
   /** Transient engine-activity state (`engine.reportEvent`, `task.delete`). */
   readonly activity: DaemonActivityRegistry
+  /** Durable attention episodes; independent from transient activity cleanup. */
+  readonly inbox: AttentionInboxStore
   /** Starts deduplicated durable background deletion after RPC acceptance. */
   readonly deletions: TaskDeletionScheduler
   /** Daemon-owned issue tracker store, keyed by git common-dir. */
@@ -250,6 +254,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
     // wire-load-bearing), so grouping them via spread is safe.
     ...TASK_HANDLERS,
     ...WORKTREE_HANDLERS,
+    ...ATTENTION_HANDLERS,
     {
       name: "issue.list",
       async handle(payload, ctx) {
@@ -372,7 +377,9 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         // Which engine tab the event came from — the inherited KOBE_TAB_ID env
         // the hook process reported. Optional: sessions kobe didn't spawn as a
         // tab stay task-level.
-        ctx.activity.report(taskId, kind, detail, optionalString(payload, "tabId"))
+        const tabId = optionalString(payload, "tabId")
+        ctx.activity.report(taskId, kind, detail, tabId)
+        await ctx.inbox.record(taskId, kind, detail, tabId)
         // Auto status flow (docs/design/web-kanban.md M5): an engine
         // STARTING a turn on a backlog task means work began — a pure rule
         // advances it to in_progress. (in_progress → in_review is the

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -379,7 +379,9 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         // tab stay task-level.
         const tabId = optionalString(payload, "tabId")
         ctx.activity.report(taskId, kind, detail, tabId)
-        await ctx.inbox.record(taskId, kind, detail, tabId)
+        await ctx.inbox
+          .record(taskId, kind, detail, tabId)
+          .catch((err) => logDaemonError("attention-inbox-record", err))
         // Auto status flow (docs/design/web-kanban.md M5): an engine
         // STARTING a turn on a backlog task means work began — a pure rule
         // advances it to in_progress. (in_progress → in_review is the

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -154,6 +154,9 @@ export type DaemonRequestName =
   // normalized engine activity event for a task; the daemon folds it into
   // the task's transient activity state and broadcasts `engine-state`.
   | "engine.reportEvent"
+  // Explicitly dismiss one durable attention episode. Viewing/jumping never
+  // calls this; only the Inbox pane's user action does.
+  | "attention.dismiss"
   // Dispatcher messenger (docs/design/dispatcher.md): publish a
   // `session.deliver` channel event addressed to a task's live session.
   // The daemon only routes; the front-end hosting that session delivers.

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -188,9 +188,9 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   const activity = new DaemonActivityRegistry(bus, undefined, undefined, livenessAt)
   const inbox = new AttentionInboxStore(defaultAttentionInboxPath(options.homeDir), bus)
   await inbox.init()
-  const clearTaskState = (taskId: string) => inbox.deleteTask(taskId).then(() => activity.clearTask(taskId))
+  const clearTaskState = (taskId: string) =>
+    inbox.deleteTaskBestEffort(taskId).finally(() => activity.clearTask(taskId))
   const deletions = new TaskDeletionRunner(orch, runtime, clearTaskState)
-
   // Daemon-owned issue tracker (web Issues panel) — a single store keyed by
   // git common-dir, sharing the server's homeDir so sandbox/test homes
   // isolate. Handlers reach it through DaemonHandlerContext.issues.

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -18,6 +18,7 @@ import { dirname } from "node:path"
 import { StringDecoder } from "node:string_decoder"
 import { sweepPtyHostSessions } from "../client/pty-process.ts"
 import { type ActivityLivenessProbe, DaemonActivityRegistry } from "./activity-registry.ts"
+import { AttentionInboxStore, defaultAttentionInboxPath } from "./attention-inbox.ts"
 import {
   type ClientState,
   type DaemonClientConnection,
@@ -185,7 +186,10 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     return runtime.latestTranscriptMtime(task.vendor ?? runtime.defaultTaskVendor, task.worktreePath)
   }
   const activity = new DaemonActivityRegistry(bus, undefined, undefined, livenessAt)
-  const deletions = new TaskDeletionRunner(orch, runtime, (taskId) => activity.clearTask(taskId))
+  const inbox = new AttentionInboxStore(defaultAttentionInboxPath(options.homeDir), bus)
+  await inbox.init()
+  const clearTaskState = (taskId: string) => inbox.deleteTask(taskId).then(() => activity.clearTask(taskId))
+  const deletions = new TaskDeletionRunner(orch, runtime, clearTaskState)
 
   // Daemon-owned issue tracker (web Issues panel) — a single store keyed by
   // git common-dir, sharing the server's homeDir so sandbox/test homes
@@ -346,6 +350,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       runtime,
       bus,
       activity,
+      inbox,
       deletions,
       issues,
       daemon: {

--- a/packages/kobe-daemon/src/daemon/task-deletion-runner.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-runner.ts
@@ -13,7 +13,7 @@ export class TaskDeletionRunner implements TaskDeletionScheduler {
   constructor(
     private readonly orch: DaemonOrchestrator,
     private readonly runtime: Pick<DaemonRuntimeAdapter, "tearDownTaskSession">,
-    private readonly clearActivity: (taskId: string) => void,
+    private readonly clearTaskState: (taskId: string) => void | Promise<void>,
   ) {}
 
   enqueue(taskId: string): void {
@@ -38,7 +38,7 @@ export class TaskDeletionRunner implements TaskDeletionScheduler {
 
   private async run(taskId: string): Promise<void> {
     if (!(await this.orch.beginTaskDeletion(taskId))) return
-    this.clearActivity(taskId)
+    await this.clearTaskState(taskId)
     await this.runtime.tearDownTaskSession(taskId).catch((err) => logDaemonError("task-deletion-session-teardown", err))
     await this.orch.finishTaskDeletion(taskId)
   }

--- a/packages/kobe/src/client/remote-orchestrator-events.ts
+++ b/packages/kobe/src/client/remote-orchestrator-events.ts
@@ -12,6 +12,7 @@ import type { NoticeEventPayload, SerializedTask } from "@sma1lboy/kobe-daemon/d
 import type { EngineActivityDetail, TaskActivityState } from "../engine/hook-events.ts"
 import type { UpdateInfo } from "../version.ts"
 import {
+  type AttentionInboxItem,
   type OrchestratorSignals,
   type TaskEngineState,
   type TaskJobState,
@@ -142,6 +143,32 @@ export function handleOrchestratorEvent(name: string, payload: unknown, signals:
       else nextTabs.delete(p.taskId)
       signals.setEngineTabStateSig(nextTabs)
     }
+    return
+  }
+  if (name === "attention.inbox") {
+    const items = (payload as { items?: unknown } | undefined)?.items
+    if (!Array.isArray(items)) {
+      logClientError("orch", `dropped attention.inbox event: items is not an array (${describePayload(items)})`)
+      return
+    }
+    const valid = items.every((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return false
+      const p = item as Partial<AttentionInboxItem>
+      return (
+        typeof p.taskId === "string" &&
+        (p.tabId === null || typeof p.tabId === "string") &&
+        (p.state === "turn_complete" ||
+          p.state === "permission_needed" ||
+          p.state === "error" ||
+          p.state === "rate_limited") &&
+        typeof p.at === "number"
+      )
+    })
+    if (!valid) {
+      logClientError("orch", `dropped attention.inbox event: malformed item (${describePayload(items)})`)
+      return
+    }
+    signals.setAttentionInboxSig(items as AttentionInboxItem[])
     return
   }
   if (name === "task.jobs") {

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -16,6 +16,7 @@
 
 import type {
   ChannelName,
+  ChannelPayloads,
   NoticeEventPayload,
   SerializedTask,
   SubscribeRole,
@@ -39,6 +40,9 @@ export interface TaskEngineState {
  *  same channel's `tabId`-carrying events. Sparse — only tabs with a live
  *  non-idle state; sessions without a tab identity stay task-level only. */
 export type EngineTabStateMap = ReadonlyMap<string, ReadonlyMap<string, TaskEngineState>>
+
+/** Durable daemon-owned attention episode, pushed as a full snapshot. */
+export type AttentionInboxItem = ChannelPayloads["attention.inbox"]["items"][number]
 
 /**
  * A long daemon operation currently IN FLIGHT for a task, accumulated from
@@ -250,6 +254,7 @@ export interface OrchestratorSignals {
   readonly setEngineStateSig: (next: ReadonlyMap<string, TaskEngineState>) => void
   readonly engineTabStateAcc: ReadableState<EngineTabStateMap>
   readonly setEngineTabStateSig: (next: EngineTabStateMap) => void
+  readonly setAttentionInboxSig: (next: readonly AttentionInboxItem[]) => void
   readonly taskJobsAcc: ReadableState<ReadonlyMap<string, TaskJobState>>
   readonly setTaskJobsSig: (next: ReadonlyMap<string, TaskJobState>) => void
   readonly worktreeChangesAcc: ReadableState<WorktreeChangesMap | null>

--- a/packages/kobe/src/client/remote-orchestrator-reads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-reads.ts
@@ -15,6 +15,7 @@ import type { Unsubscribe } from "../orchestrator/core.ts"
 import type { Task, TaskId } from "../types/task.ts"
 import type { UpdateInfo } from "../version.ts"
 import type {
+  AttentionInboxItem,
   DaemonConnectionState,
   EngineTabStateMap,
   TaskEngineState,
@@ -32,6 +33,7 @@ export interface ReadSignals {
   readonly daemonStaleAcc: ReadableState<boolean>
   readonly engineStateAcc: ReadableState<ReadonlyMap<string, TaskEngineState>>
   readonly engineTabStateAcc: ReadableState<EngineTabStateMap>
+  readonly attentionInboxAcc: ReadableState<readonly AttentionInboxItem[]>
   readonly taskJobsAcc: ReadableState<ReadonlyMap<string, TaskJobState>>
   readonly worktreeChangesAcc: ReadableState<WorktreeChangesMap | null>
   readonly transcriptActivityAcc: ReadableState<TranscriptActivityMap | null>
@@ -106,6 +108,11 @@ export function engineStateSignalOp(s: ReadSignals): ReadableState<ReadonlyMap<s
  */
 export function engineTabStatesSignalOp(s: ReadSignals): ReadableState<EngineTabStateMap> {
   return s.engineTabStateAcc
+}
+
+/** Durable unresolved attention episodes; reading never consumes them. */
+export function attentionInboxSignalOp(s: ReadSignals): ReadableState<readonly AttentionInboxItem[]> {
+  return s.attentionInboxAcc
 }
 
 /**

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -94,7 +94,7 @@ export async function dismissAttentionOp(
 ): Promise<boolean> {
   const res = await client.request<{ deleted: boolean }>("attention.dismiss", {
     taskId: String(taskId),
-    ...(tabId ? { tabId } : {}),
+    ...(tabId !== null ? { tabId } : {}),
   })
   return res.deleted
 }

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -86,6 +86,19 @@ export async function deleteTaskOp(
   await client.request("task.delete", { taskId: String(id), force: opts?.force })
 }
 
+/** Explicitly delete one durable attention episode. */
+export async function dismissAttentionOp(
+  client: KobeDaemonClient,
+  taskId: TaskId | string,
+  tabId: string | null,
+): Promise<boolean> {
+  const res = await client.request<{ deleted: boolean }>("attention.dismiss", {
+    taskId: String(taskId),
+    ...(tabId ? { tabId } : {}),
+  })
+  return res.deleted
+}
+
 /** Land a task's branch back into its base repo (`task.land`). Merge or
  *  squash; optionally delete the branch / archive the task after. The daemon
  *  throws with a `LAND_CONFLICT`/`MAIN_CHECKOUT_DIRTY` sentinel in the message

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -31,6 +31,7 @@ import { CURRENT_VERSION, type UpdateInfo } from "../version.ts"
 import { performInit } from "./remote-orchestrator-connect.ts"
 import { handleOrchestratorEvent } from "./remote-orchestrator-events.ts"
 import {
+  type AttentionInboxItem,
   type DaemonConnectionState,
   type EngineTabStateMap,
   type OrchestratorSignals,
@@ -44,6 +45,7 @@ import {
 import {
   type ReadSignals,
   activeTaskSignalOp,
+  attentionInboxSignalOp,
   daemonStaleSignalOp,
   daemonVersionSignalOp,
   engineStateSignalOp,
@@ -68,6 +70,7 @@ import {
   createTaskOp,
   deleteTaskOp,
   discoverAdoptableWorktreesOp,
+  dismissAttentionOp,
   ensureMainTaskOp,
   ensureWorktreeOp,
   forgetProjectOp,
@@ -87,6 +90,7 @@ import {
 } from "./remote-orchestrator-writes.ts"
 
 export type {
+  AttentionInboxItem,
   DaemonConnectionState,
   EngineTabStateMap,
   RemoteOrchestratorOptions,
@@ -122,6 +126,8 @@ export class RemoteOrchestrator {
   private readonly setEngineStateSig = (next: ReadonlyMap<string, TaskEngineState>) => this.engineStateAcc.set(next)
   private readonly engineTabStateAcc = createStateCell<EngineTabStateMap>(new Map())
   private readonly setEngineTabStateSig = (next: EngineTabStateMap) => this.engineTabStateAcc.set(next)
+  private readonly attentionInboxAcc = createStateCell<readonly AttentionInboxItem[]>([])
+  private readonly setAttentionInboxSig = (next: readonly AttentionInboxItem[]) => this.attentionInboxAcc.set(next)
   private readonly taskJobsAcc = createStateCell<ReadonlyMap<string, TaskJobState>>(new Map())
   private readonly setTaskJobsSig = (next: ReadonlyMap<string, TaskJobState>) => this.taskJobsAcc.set(next)
   private readonly worktreeChangesAcc = createStateCell<WorktreeChangesMap | null>(null)
@@ -169,6 +175,7 @@ export class RemoteOrchestrator {
       setEngineStateSig: this.setEngineStateSig,
       engineTabStateAcc: this.engineTabStateAcc,
       setEngineTabStateSig: this.setEngineTabStateSig,
+      setAttentionInboxSig: this.setAttentionInboxSig,
       taskJobsAcc: this.taskJobsAcc,
       setTaskJobsSig: this.setTaskJobsSig,
       worktreeChangesAcc: this.worktreeChangesAcc,
@@ -188,6 +195,7 @@ export class RemoteOrchestrator {
       daemonStaleAcc: this.daemonStaleAcc,
       engineStateAcc: this.engineStateAcc,
       engineTabStateAcc: this.engineTabStateAcc,
+      attentionInboxAcc: this.attentionInboxAcc,
       taskJobsAcc: this.taskJobsAcc,
       worktreeChangesAcc: this.worktreeChangesAcc,
       transcriptActivityAcc: this.transcriptActivityAcc,
@@ -323,6 +331,10 @@ export class RemoteOrchestrator {
     return engineTabStatesSignalOp(this.reads)
   }
 
+  attentionInboxSignal(): ReadableState<readonly AttentionInboxItem[]> {
+    return attentionInboxSignalOp(this.reads)
+  }
+
   taskJobsSignal(): ReadableState<ReadonlyMap<string, TaskJobState>> {
     return taskJobsSignalOp(this.reads)
   }
@@ -420,6 +432,10 @@ export class RemoteOrchestrator {
 
   deleteTask(id: TaskId | string, opts?: { force?: boolean }): Promise<void> {
     return deleteTaskOp(this.client, id, opts)
+  }
+
+  dismissAttention(taskId: TaskId | string, tabId: string | null): Promise<boolean> {
+    return dismissAttentionOp(this.client, taskId, tabId)
   }
 
   /** Land a task's branch back into its base repo (`task.land`). Throws with a

--- a/packages/kobe/src/tui-react/component/toast-overlay.tsx
+++ b/packages/kobe/src/tui-react/component/toast-overlay.tsx
@@ -17,7 +17,7 @@ const CHIP_WIDTH = 40
 const RIGHT_MARGIN = 2
 const BOTTOM_MARGIN = 2
 
-export function ToastOverlay() {
+export function ToastOverlay(props: { bottomOffset?: number } = {}) {
   const { theme } = useTheme()
   const dims = useTerminalDimensions()
   const notif = useNotifications()
@@ -29,7 +29,7 @@ export function ToastOverlay() {
   // the overlay sits on top of the layout without taking flow space;
   // `zIndex` keeps it above the panes but below the dialog backdrop (3000).
   const left = Math.max(0, dims.width - CHIP_WIDTH - RIGHT_MARGIN)
-  const top = Math.max(0, dims.height - BOTTOM_MARGIN - MAX_VISIBLE - 1)
+  const top = Math.max(0, dims.height - BOTTOM_MARGIN - (props.bottomOffset ?? 0) - MAX_VISIBLE - 1)
 
   return (
     <box position="absolute" zIndex={2500} left={left} top={top} width={CHIP_WIDTH} flexDirection="column" gap={0}>

--- a/packages/kobe/src/tui-react/context/focus.tsx
+++ b/packages/kobe/src/tui-react/context/focus.tsx
@@ -15,11 +15,11 @@ import { useRenderer } from "@opentui/react"
 import { type ReactNode, createContext, useCallback, useContext, useMemo, useRef, useState } from "react"
 import { useLatest } from "../lib/use-latest"
 
-/** The four primary panes in kobe's layout. */
-export type PaneId = "sidebar" | "workspace" | "files" | "terminal"
+/** The primary panes in kobe's layout. */
+export type PaneId = "sidebar" | "workspace" | "files" | "inbox" | "terminal"
 
 /** Cycle order — used by `tab` / `shift+tab`. */
-export const PANE_ORDER = ["sidebar", "workspace", "files", "terminal"] as const satisfies readonly PaneId[]
+export const PANE_ORDER = ["sidebar", "workspace", "files", "inbox", "terminal"] as const satisfies readonly PaneId[]
 
 export type FocusContextValue = {
   /** The currently focused pane. */

--- a/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
+++ b/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
@@ -11,7 +11,7 @@ import type { KVContext } from "../context/kv"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useBindings } from "../lib/keymap"
-import { attentionInboxKey, sortAttentionInbox } from "./attention-inbox-core"
+import { attentionInboxKey, isAttentionInboxItemAvailable, sortAttentionInbox } from "./attention-inbox-core"
 import { knownTaskTab } from "./terminal-tabs-shared"
 
 export const ATTENTION_INBOX_HEIGHT = 8
@@ -35,11 +35,10 @@ function tabLabel(
   task: Task | undefined,
   kv: KVContext,
 ): { label: string; available: boolean } {
-  if (!item.tabId) return { label: "", available: task !== undefined && !task.archived }
-  const tab = knownTaskTab(kv, item.taskId, item.tabId)
+  const tab = item.tabId ? knownTaskTab(kv, item.taskId, item.tabId) : undefined
   return {
-    label: tab ? tabTitle(tab, task?.vendor ?? DEFAULT_TASK_VENDOR) : item.tabId,
-    available: task !== undefined && !task.archived && tab !== undefined,
+    label: tab ? tabTitle(tab, task?.vendor ?? DEFAULT_TASK_VENDOR) : (item.tabId ?? ""),
+    available: isAttentionInboxItemAvailable(item, task, () => tab !== undefined),
   }
 }
 

--- a/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
+++ b/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
@@ -1,0 +1,147 @@
+/** @jsxImportSource @opentui/react */
+
+import { TextAttributes } from "@opentui/core"
+import { useEffect, useState } from "react"
+import type { AttentionInboxItem } from "../../client/remote-orchestrator"
+import { tabTitle } from "../../tui/workspace/terminal-tabs-core"
+import type { Task } from "../../types/task"
+import { DEFAULT_TASK_VENDOR } from "../../types/task"
+import { bindByIds } from "../context/keybindings"
+import type { KVContext } from "../context/kv"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { attentionInboxKey, sortAttentionInbox } from "./attention-inbox-core"
+import { knownTaskTab } from "./terminal-tabs-shared"
+
+export const ATTENTION_INBOX_HEIGHT = 8
+const MAX_ROWS = 4
+
+function itemColor(state: AttentionInboxItem["state"], theme: ReturnType<typeof useTheme>["theme"]) {
+  if (state === "permission_needed") return theme.warning
+  if (state === "turn_complete") return theme.success
+  return theme.error
+}
+
+function itemGlyph(state: AttentionInboxItem["state"]): string {
+  if (state === "permission_needed") return "?"
+  if (state === "turn_complete") return "✓"
+  if (state === "rate_limited") return "⌛"
+  return "!"
+}
+
+function tabLabel(
+  item: AttentionInboxItem,
+  task: Task | undefined,
+  kv: KVContext,
+): { label: string; available: boolean } {
+  if (!item.tabId) return { label: "", available: task !== undefined && !task.archived }
+  const tab = knownTaskTab(kv, item.taskId, item.tabId)
+  return {
+    label: tab ? tabTitle(tab, task?.vendor ?? DEFAULT_TASK_VENDOR) : item.tabId,
+    available: task !== undefined && !task.archived && tab !== undefined,
+  }
+}
+
+export function AttentionInboxPane(props: {
+  items: readonly AttentionInboxItem[]
+  tasks: readonly Task[]
+  kv: KVContext
+  focused: boolean
+  onOpen: (item: AttentionInboxItem) => void
+  onDelete: (item: AttentionInboxItem) => void
+  onRequestFocus: () => void
+}) {
+  const { theme } = useTheme()
+  const t = useT()
+  const [cursor, setCursor] = useState(0)
+  const taskOrder = props.tasks.map((task) => task.id)
+  const ordered = sortAttentionInbox(props.items, taskOrder)
+  const safeCursor = Math.min(cursor, Math.max(0, ordered.length - 1))
+  const windowStart = Math.max(0, Math.min(safeCursor - MAX_ROWS + 1, ordered.length - MAX_ROWS))
+  const visible = ordered.slice(windowStart, windowStart + MAX_ROWS)
+
+  useEffect(() => {
+    if (cursor !== safeCursor) setCursor(safeCursor)
+  }, [cursor, safeCursor])
+
+  function move(delta: 1 | -1): void {
+    if (ordered.length === 0) return
+    setCursor((current) => (current + delta + ordered.length) % ordered.length)
+  }
+
+  function selected(): AttentionInboxItem | undefined {
+    return ordered[safeCursor]
+  }
+
+  useBindings(() => ({
+    enabled: props.focused,
+    bindings: bindByIds({
+      "inbox.nav": (_event, slot) => move((slot ?? 0) % 2 === 0 ? 1 : -1),
+      "inbox.open": () => {
+        const item = selected()
+        if (item) props.onOpen(item)
+      },
+      "inbox.delete": () => {
+        const item = selected()
+        if (item) props.onDelete(item)
+      },
+    }),
+  }))
+
+  return (
+    <box flexDirection="column" flexGrow={1} onMouseUp={props.onRequestFocus}>
+      <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1}>
+        <text fg={props.focused ? theme.focusAccent : theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
+          {t("workspace.inbox.title")}
+        </text>
+        <text fg={theme.textMuted} wrapMode="none">{` ${ordered.length}`}</text>
+      </box>
+      {ordered.length === 0 ? (
+        <box flexGrow={1} paddingLeft={1}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {t("workspace.inbox.empty")}
+          </text>
+        </box>
+      ) : (
+        <box flexDirection="column" flexGrow={1}>
+          {visible.map((item, index) => {
+            const absoluteIndex = windowStart + index
+            const active = absoluteIndex === safeCursor
+            const task = props.tasks.find((candidate) => candidate.id === item.taskId)
+            const tab = tabLabel(item, task, props.kv)
+            const title = task?.title ?? item.taskId
+            return (
+              <box
+                key={attentionInboxKey(item)}
+                flexDirection="row"
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={active ? theme.backgroundElement : undefined}
+                onMouseUp={(event: { stopPropagation(): void }) => {
+                  event.stopPropagation()
+                  setCursor(absoluteIndex)
+                  props.onRequestFocus()
+                  props.onOpen(item)
+                }}
+              >
+                <text fg={itemColor(item.state, theme)} wrapMode="none">{`${itemGlyph(item.state)} `}</text>
+                <text fg={tab.available ? theme.text : theme.textMuted} wrapMode="none">
+                  {`${title}${tab.label ? ` · ${tab.label}` : ""}${tab.available ? "" : ` · ${t("workspace.inbox.unavailable")}`}`}
+                </text>
+              </box>
+            )
+          })}
+        </box>
+      )}
+      <box flexDirection="row" flexShrink={0} paddingLeft={1} gap={1}>
+        <text fg={theme.textMuted} wrapMode="none">
+          {t("workspace.inbox.openHint")}
+        </text>
+        <text fg={theme.textMuted} wrapMode="none">
+          {t("workspace.inbox.deleteHint")}
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/workspace/attention-inbox-core.ts
+++ b/packages/kobe/src/tui-react/workspace/attention-inbox-core.ts
@@ -1,4 +1,5 @@
 import type { AttentionInboxItem } from "../../client/remote-orchestrator"
+import type { Task } from "../../types/task"
 
 const STATE_PRIORITY: Record<AttentionInboxItem["state"], number> = {
   permission_needed: 0,
@@ -9,6 +10,14 @@ const STATE_PRIORITY: Record<AttentionInboxItem["state"], number> = {
 
 export function attentionInboxKey(item: { taskId: string | null; tabId: string | null }): string {
   return `${item.taskId}\u0000${item.tabId ?? ""}`
+}
+
+export function isAttentionInboxItemAvailable(
+  item: AttentionInboxItem,
+  task: Pick<Task, "archived"> | undefined,
+  hasTab: (tabId: string) => boolean,
+): boolean {
+  return task !== undefined && !task.archived && (item.tabId === null || hasTab(item.tabId))
 }
 
 /** Actionable states first, then oldest episode, with task order as a stable tie-breaker. */

--- a/packages/kobe/src/tui-react/workspace/attention-inbox-core.ts
+++ b/packages/kobe/src/tui-react/workspace/attention-inbox-core.ts
@@ -1,0 +1,50 @@
+import type { AttentionInboxItem } from "../../client/remote-orchestrator"
+
+const STATE_PRIORITY: Record<AttentionInboxItem["state"], number> = {
+  permission_needed: 0,
+  error: 1,
+  rate_limited: 1,
+  turn_complete: 2,
+}
+
+export function attentionInboxKey(item: { taskId: string | null; tabId: string | null }): string {
+  return `${item.taskId}\u0000${item.tabId ?? ""}`
+}
+
+/** Actionable states first, then oldest episode, with task order as a stable tie-breaker. */
+export function sortAttentionInbox(
+  items: readonly AttentionInboxItem[],
+  taskOrder: readonly string[],
+): AttentionInboxItem[] {
+  const taskIndex = new Map(taskOrder.map((id, index) => [id, index]))
+  return [...items].sort((a, b) => {
+    const priority = STATE_PRIORITY[a.state] - STATE_PRIORITY[b.state]
+    if (priority !== 0) return priority
+    const age = a.at - b.at
+    if (age !== 0) return age
+    const task =
+      (taskIndex.get(a.taskId) ?? Number.MAX_SAFE_INTEGER) - (taskIndex.get(b.taskId) ?? Number.MAX_SAFE_INTEGER)
+    if (task !== 0) return task
+    return attentionInboxKey(a).localeCompare(attentionInboxKey(b))
+  })
+}
+
+/**
+ * Pick the next retained episode without consuming it. Items for tasks that
+ * are no longer jumpable stay in the Inbox UI but are excluded from F7.
+ */
+export function nextAttentionInboxTarget(
+  items: readonly AttentionInboxItem[],
+  taskOrder: readonly string[],
+  current: { taskId: string | null; tabId: string | null },
+  isAvailable: (item: AttentionInboxItem) => boolean = () => true,
+): AttentionInboxItem | null {
+  const liveTasks = new Set(taskOrder)
+  const ordered = sortAttentionInbox(items, taskOrder).filter((item) => liveTasks.has(item.taskId) && isAvailable(item))
+  if (ordered.length === 0) return null
+  const currentKey = current.taskId === null ? null : attentionInboxKey(current)
+  const currentIndex = currentKey === null ? -1 : ordered.findIndex((item) => attentionInboxKey(item) === currentKey)
+  if (currentIndex < 0) return ordered[0] ?? null
+  if (ordered.length === 1) return null
+  return ordered[(currentIndex + 1) % ordered.length] ?? null
+}

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -29,7 +29,7 @@ import { type WorkspacePageState, settingsCloseKeysEnabled, workspacePagesClosed
 // Cycle order for focus.next — the host's real panes, NOT the context's
 // PANE_ORDER: that includes "terminal", which this host never mounts, and
 // cycling focus onto an unmounted pane would strand it.
-const PANE_CYCLE = ["sidebar", "workspace", "files"] as const satisfies readonly PaneId[]
+const PANE_CYCLE = ["sidebar", "workspace", "files", "inbox"] as const satisfies readonly PaneId[]
 
 export type WorkspaceKeybindingDeps = {
   focus: FocusContextValue

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -10,7 +10,7 @@ import { join } from "node:path"
 import { useTerminalDimensions } from "@opentui/react"
 import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { useEffect, useRef, useState } from "react"
-import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
+import { type AttentionInboxItem, RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { resolveEditorLaunch } from "../../tui/lib/editor-launch.ts"
 import { pathLeaf } from "../../tui/lib/path-helpers"
 import { buildPRPrompt } from "../../tui/ops/pr-prompt"
@@ -37,12 +37,13 @@ import { Sidebar, type SidebarHover } from "../panes/sidebar/Sidebar"
 import { SidebarHoverTooltip } from "../panes/sidebar/hover-tooltip"
 import { useSidebarHostState } from "../panes/sidebar/use-sidebar-host-state.tsx"
 import { useDialog } from "../ui/dialog"
+import { ATTENTION_INBOX_HEIGHT, AttentionInboxPane } from "./AttentionInboxPane"
 import { useWorkspaceKeybindings } from "./host-keybindings"
 import { useWorkspaceTaskActions } from "./host-task-actions"
 import { useQuickFork } from "./quick-fork"
 import { ShowWorkspace } from "./show-workspace"
 import { sweepOrphanTabsSnapshots } from "./terminal-tabs-persist"
-import { forgetTaskTabs } from "./terminal-tabs-shared"
+import { forgetTaskTabs, knownTaskTab, requestTabActivation } from "./terminal-tabs-shared"
 import { useAttention } from "./use-attention"
 import { useIssueChat } from "./use-issue-chat"
 import { useWorkspaceSelection } from "./use-workspace-selection"
@@ -65,7 +66,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   const tasks = useAccessor(orch.tasksSignal())
   const activeTaskId = useAccessor(orch.activeTaskSignal())
   const engineState = useAccessor(orch.engineStateSignal())
-  const engineTabStates = useAccessor(orch.engineTabStatesSignal())
+  const inboxItems = useAccessor(orch.attentionInboxSignal())
   const taskJobs = useAccessor(orch.taskJobsSignal())
   const worktreeChanges = useAccessor(orch.worktreeChangesSignal())
 
@@ -106,7 +107,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   const { jumpToNextAttention } = useAttention({
     tasks,
     engineState,
-    engineTabStates,
+    inboxItems,
     selectedId,
     kv,
     notif,
@@ -190,7 +191,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     if (next) focus.setFocused("workspace")
   }
   useEffect(() => {
-    if (focus.focused === "files") setZen(false)
+    if (focus.focused === "files" || focus.focused === "inbox") setZen(false)
   }, [focus.focused])
 
   /**
@@ -226,6 +227,18 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   function openDiff(relPath: string, base?: string): void {
     const label = pathLeaf(relPath)
     openDiffTabFn.current?.(relPath, label, base)
+  }
+
+  function openInboxItem(item: AttentionInboxItem): void {
+    const task = tasks.find((candidate) => candidate.id === item.taskId && !candidate.archived)
+    const tabAvailable = item.tabId === null || knownTaskTab(kv, item.taskId, item.tabId) !== undefined
+    if (!task || !tabAvailable) {
+      notifyInfo(t("workspace.inbox.unavailable"))
+      return
+    }
+    selectTask(item.taskId)
+    if (item.tabId) requestTabActivation(item.taskId, item.tabId)
+    focus.setFocused("workspace")
   }
 
   // Full-page swap — like the tmux `chattab` surface opening a dedicated
@@ -397,21 +410,40 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
       </box>
 
       {!zen ? (
-        <box
-          width={worktreeToolsWidth}
-          flexShrink={0}
-          borderColor={focus.focused === "files" ? theme.focusAccent : inactiveBorder}
-          onMouseUp={() => focus.setFocused("files")}
-        >
-          <FileTree
-            worktreePath={worktree}
-            prBaseRef={selectedTask?.prStatus?.baseRef}
-            focused={activePane === "files"}
-            onOpenFile={(relPath) => void openFileInEditor(relPath)}
-            onOpenDiff={openDiff}
-            onZenToggle={toggleZen}
-            onCreatePR={() => void createPR()}
-          />
+        <box width={worktreeToolsWidth} flexShrink={0} flexDirection="column">
+          <box
+            flexGrow={1}
+            flexShrink={1}
+            borderColor={focus.focused === "files" ? theme.focusAccent : inactiveBorder}
+            onMouseUp={() => focus.setFocused("files")}
+          >
+            <FileTree
+              worktreePath={worktree}
+              prBaseRef={selectedTask?.prStatus?.baseRef}
+              focused={activePane === "files"}
+              onOpenFile={(relPath) => void openFileInEditor(relPath)}
+              onOpenDiff={openDiff}
+              onZenToggle={toggleZen}
+              onCreatePR={() => void createPR()}
+            />
+          </box>
+          <box
+            // A compact fixed row budget keeps Files as the flexible owner
+            // of the right column; this is UI grammar, not a pane proportion.
+            flexBasis={ATTENTION_INBOX_HEIGHT}
+            flexShrink={0}
+            borderColor={focus.focused === "inbox" ? theme.focusAccent : inactiveBorder}
+          >
+            <AttentionInboxPane
+              items={inboxItems}
+              tasks={tasks}
+              kv={kv}
+              focused={activePane === "inbox"}
+              onOpen={openInboxItem}
+              onDelete={(item) => void orch.dismissAttention(item.taskId, item.tabId).catch(notifyError)}
+              onRequestFocus={() => focus.setFocused("inbox")}
+            />
+          </box>
         </box>
       ) : null}
 
@@ -422,7 +454,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           `kobe tasks` pane did) — so the bottom-right toast silently never
           appeared. Absolute-positioned like SidebarHoverTooltip, under the
           host's NotificationsProvider. */}
-      <ToastOverlay />
+      <ToastOverlay bottomOffset={zen ? 0 : ATTENTION_INBOX_HEIGHT} />
       {/* Prefix sequence HUD — bottom-left over the Tasks sidebar (the
           terminal column is off-limits: it collided with the engine's own
           status line). Width-capped to the rail so lines never spill into

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -38,6 +38,7 @@ import { SidebarHoverTooltip } from "../panes/sidebar/hover-tooltip"
 import { useSidebarHostState } from "../panes/sidebar/use-sidebar-host-state.tsx"
 import { useDialog } from "../ui/dialog"
 import { ATTENTION_INBOX_HEIGHT, AttentionInboxPane } from "./AttentionInboxPane"
+import { isAttentionInboxItemAvailable } from "./attention-inbox-core"
 import { useWorkspaceKeybindings } from "./host-keybindings"
 import { useWorkspaceTaskActions } from "./host-task-actions"
 import { useQuickFork } from "./quick-fork"
@@ -230,9 +231,13 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   }
 
   function openInboxItem(item: AttentionInboxItem): void {
-    const task = tasks.find((candidate) => candidate.id === item.taskId && !candidate.archived)
-    const tabAvailable = item.tabId === null || knownTaskTab(kv, item.taskId, item.tabId) !== undefined
-    if (!task || !tabAvailable) {
+    const task = tasks.find((candidate) => candidate.id === item.taskId)
+    const available = isAttentionInboxItemAvailable(
+      item,
+      task,
+      (tabId) => knownTaskTab(kv, item.taskId, tabId) !== undefined,
+    )
+    if (!available) {
       notifyInfo(t("workspace.inbox.unavailable"))
       return
     }

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -8,7 +8,13 @@
  */
 
 import { interactiveEngineCommand, withClaudeSessionId } from "../../engine/interactive-command"
-import { type EngineTab, type TabsState, initialTabs, rehydrateTabs } from "../../tui/workspace/terminal-tabs-core"
+import {
+  type EngineTab,
+  type TabsState,
+  type TerminalTab,
+  initialTabs,
+  rehydrateTabs,
+} from "../../tui/workspace/terminal-tabs-core"
 import type { VendorId } from "../../types/vendor"
 import { type TabsSnapshotKv, forgetTaskTabsSnapshot, terminalTabsKey } from "./terminal-tabs-persist"
 
@@ -19,6 +25,13 @@ export const tabsByTask = new Map<string, TabsState>()
  *  jump's "where am I" input. Null when the task never mounted tabs. */
 export function activeTabIdFor(taskId: string): string | null {
   return tabsByTask.get(taskId)?.activeId ?? null
+}
+
+/** Resolve a tab from live process state or its restart snapshot. */
+export function knownTaskTab(kv: TabsSnapshotKv, taskId: string, tabId: string): TerminalTab | undefined {
+  const saved = kv.store[terminalTabsKey(taskId)] as TabsState | null | undefined
+  const state = tabsByTask.get(taskId) ?? (saved && Array.isArray(saved.tabs) ? saved : null)
+  return state?.tabs.find((tab) => tab.id === tabId)
 }
 
 /**

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -7,7 +7,8 @@
  *     The selected task already surfaces its own state in the middle column, so
  *     it's skipped. Gated by the `notifications.crossTask.enabled` preference.
  *  2. Jump-to-next — F7 walks the daemon-owned durable Inbox. Jumping never
- *     consumes an episode; only a same-tab turn-start or explicit delete does.
+ *     consumes an episode; removal comes from same-tab turn-start, explicit
+ *     episode deletion, or explicit hard-delete of the containing task.
  *
  * State is engine-owned and vendor-neutral: `TaskEngineState.state` and the
  * Inbox state are the only inputs, so there are no Claude/Codex strings here.
@@ -19,7 +20,7 @@ import { attentionKindFor } from "../../tui/lib/notify-state"
 import type { Task } from "../../types/task"
 import type { KVContext } from "../context/kv"
 import type { NotificationsContext } from "../context/notifications"
-import { nextAttentionInboxTarget } from "./attention-inbox-core"
+import { isAttentionInboxItemAvailable, nextAttentionInboxTarget } from "./attention-inbox-core"
 import { activeTabIdFor, knownTaskTab, requestTabActivation } from "./terminal-tabs-shared"
 
 const CROSS_TASK_KEY = "notifications.crossTask.enabled"
@@ -70,7 +71,12 @@ export function useAttention(args: {
         taskId: selectedId,
         tabId: selectedId ? activeTabIdFor(selectedId) : null,
       },
-      (item) => item.tabId === null || knownTaskTab(kv, item.taskId, item.tabId) !== undefined,
+      (item) =>
+        isAttentionInboxItemAvailable(
+          item,
+          tasks.find((task) => task.id === item.taskId),
+          (tabId) => knownTaskTab(kv, item.taskId, tabId) !== undefined,
+        ),
     )
     if (!target) {
       notif.notify({ kind: "done", taskId: selectedId ?? "", tabId: "", title: noTasksMessage })

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -6,32 +6,28 @@
  *     crossed into an attention state (permission_needed / error / turn_complete).
  *     The selected task already surfaces its own state in the middle column, so
  *     it's skipped. Gated by the `notifications.crossTask.enabled` preference.
- *  2. Jump-to-next — the return value `jumpToNextAttention()` is the handler
- *     the global chord binds to; it walks (task, tab) candidates in sidebar
- *     order × tab order — waiting/question/error/turn-complete, including the
- *     other tabs of the CURRENT task — selects the task, activates the tab,
- *     and marks it read so the cycle advances (or toasts when none).
+ *  2. Jump-to-next — F7 walks the daemon-owned durable Inbox. Jumping never
+ *     consumes an episode; only a same-tab turn-start or explicit delete does.
  *
  * State is engine-owned and vendor-neutral: `TaskEngineState.state` and the
- * unread map are the only inputs, so there are no Claude/Codex strings here.
- * The two pure helpers (`attentionKindFor`, `nextAttentionTarget`) live in the
- * framework-free `tui/lib/notify-state`.
+ * Inbox state are the only inputs, so there are no Claude/Codex strings here.
  */
 
 import { useEffect, useRef } from "react"
-import type { EngineTabStateMap, TaskEngineState } from "../../client/remote-orchestrator"
-import { attentionKindFor, nextAttentionTarget } from "../../tui/lib/notify-state"
+import type { AttentionInboxItem, TaskEngineState } from "../../client/remote-orchestrator"
+import { attentionKindFor } from "../../tui/lib/notify-state"
 import type { Task } from "../../types/task"
 import type { KVContext } from "../context/kv"
 import type { NotificationsContext } from "../context/notifications"
-import { activeTabIdFor, requestTabActivation } from "./terminal-tabs-shared"
+import { nextAttentionInboxTarget } from "./attention-inbox-core"
+import { activeTabIdFor, knownTaskTab, requestTabActivation } from "./terminal-tabs-shared"
 
 const CROSS_TASK_KEY = "notifications.crossTask.enabled"
 
 export function useAttention(args: {
   tasks: readonly Task[]
   engineState: ReadonlyMap<string, TaskEngineState>
-  engineTabStates: EngineTabStateMap
+  inboxItems: readonly AttentionInboxItem[]
   selectedId: string | null
   kv: KVContext
   notif: NotificationsContext
@@ -40,8 +36,7 @@ export function useAttention(args: {
   /** i18n'd toast shown when the chord finds no waiting task. */
   noTasksMessage: string
 }): { jumpToNextAttention: () => void } {
-  const { tasks, engineState, engineTabStates, selectedId, kv, notif, selectTask, focusWorkspace, noTasksMessage } =
-    args
+  const { tasks, engineState, inboxItems, selectedId, kv, notif, selectTask, focusWorkspace, noTasksMessage } = args
 
   // Previous frame's per-task state, for rising-edge detection. Seeded on the
   // first render so tasks already sitting in an attention state at mount don't
@@ -68,19 +63,19 @@ export function useAttention(args: {
 
   function jumpToNextAttention(): void {
     const order = tasks.filter((t) => !t.archived).map((t) => t.id)
-    const target = nextAttentionTarget(order, engineState, engineTabStates, notif.unread, {
-      taskId: selectedId,
-      tabId: selectedId ? activeTabIdFor(selectedId) : null,
-    })
+    const target = nextAttentionInboxTarget(
+      inboxItems,
+      order,
+      {
+        taskId: selectedId,
+        tabId: selectedId ? activeTabIdFor(selectedId) : null,
+      },
+      (item) => item.tabId === null || knownTaskTab(kv, item.taskId, item.tabId) !== undefined,
+    )
     if (!target) {
       notif.notify({ kind: "done", taskId: selectedId ?? "", tabId: "", title: noTasksMessage })
       return
     }
-    // Arrival = seen: clear the unread marks that made this target a
-    // candidate so the next press ADVANCES instead of revisiting a seen
-    // completion. Blocking raw states (permission/error) persist by design.
-    notif.markRead(target.taskId, "")
-    if (target.tabId) notif.markRead(target.taskId, target.tabId)
     selectTask(target.taskId)
     if (target.tabId) requestTabActivation(target.taskId, target.tabId)
     focusWorkspace()

--- a/packages/kobe/src/tui/context/keybindings-inbox.ts
+++ b/packages/kobe/src/tui/context/keybindings-inbox.ts
@@ -1,0 +1,28 @@
+import type { KobeBinding } from "./keybindings-table.ts"
+
+export const INBOX_BINDINGS: readonly KobeBinding[] = [
+  {
+    id: "inbox.nav",
+    scope: "inbox",
+    keys: ["j", "k", "down", "up"],
+    category: "Inbox",
+    description: "Move cursor up/down",
+    hint: { keys: "j/k" },
+  },
+  {
+    id: "inbox.open",
+    scope: "inbox",
+    keys: ["return"],
+    category: "Inbox",
+    description: "Open the selected task and chat tab",
+    hint: { keys: "enter" },
+  },
+  {
+    id: "inbox.delete",
+    scope: "inbox",
+    keys: ["d"],
+    category: "Inbox",
+    description: "Delete the selected attention episode",
+    hint: { keys: "d" },
+  },
+]

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -66,10 +66,11 @@
 
 import { CHAT_BINDINGS } from "./keybindings-chat.ts"
 import { FILES_BINDINGS } from "./keybindings-files.ts"
+import { INBOX_BINDINGS } from "./keybindings-inbox.ts"
 import { SIDEBAR_BINDINGS } from "./keybindings-sidebar.ts"
 
 /** Pane scopes used to gate where a binding is active. */
-export type KobeBindingScope = "global" | "sidebar" | "workspace" | "files" | "terminal"
+export type KobeBindingScope = "global" | "sidebar" | "workspace" | "files" | "inbox" | "terminal"
 
 /**
  * Friendly-chord display override, read by the help dialog (F1) and the
@@ -242,7 +243,7 @@ export const KobeKeymap: readonly KobeBinding[] = [
     keys: ["f4"],
     prefixKeys: ["k"],
     category: "Navigation",
-    description: "Focus next pane (sidebar → workspace → files)",
+    description: "Focus next pane (sidebar → workspace → files → inbox)",
     hint: { keys: "f4" },
   },
   {
@@ -302,6 +303,9 @@ export const KobeKeymap: readonly KobeBinding[] = [
   // ─── Files ────────────────────────────────────────────────────────────
   // Moved to keybindings-files.ts (file-size cap) — same entries, same order.
   ...FILES_BINDINGS,
+
+  // ─── Attention Inbox ─────────────────────────────────────────────────
+  ...INBOX_BINDINGS,
 
   // ─── Terminal ─────────────────────────────────────────────────────────
   {

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -16,6 +16,13 @@ export const en = {
   attention: {
     none: "No tasks waiting for input",
   },
+  inbox: {
+    title: "INBOX",
+    empty: "No pending attention",
+    unavailable: "unavailable",
+    openHint: "enter open",
+    deleteHint: "d delete",
+  },
   terminalComing: "Embedded terminal is starting...",
 }
 
@@ -30,6 +37,13 @@ export const zh: typeof en = {
   },
   attention: {
     none: "没有等待输入的任务",
+  },
+  inbox: {
+    title: "收件箱",
+    empty: "暂无待处理",
+    unavailable: "目标不可用",
+    openHint: "enter 打开",
+    deleteHint: "d 删除",
   },
   terminalComing: "嵌入终端正在启动……",
 }

--- a/packages/kobe/test/client/remote-orchestrator-attention.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-attention.test.ts
@@ -1,0 +1,39 @@
+import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { describe, expect, it, vi } from "vitest"
+import { RemoteOrchestrator } from "../../src/client/remote-orchestrator.ts"
+
+const { logClientError } = vi.hoisted(() => ({ logClientError: vi.fn() }))
+vi.mock("@sma1lboy/kobe-daemon/client/client-log", async (importActual) => ({
+  ...(await importActual<typeof import("@sma1lboy/kobe-daemon/client/client-log")>()),
+  logClientError,
+}))
+
+function fakeClient(): { client: KobeDaemonClient; emit: (name: string, payload: unknown) => void } {
+  let star: ((frame: { name: string; payload: unknown }) => void) | undefined
+  const client = {
+    on: (name: string, handler: (frame: { name: string; payload: unknown }) => void) => {
+      if (name === "*") star = handler
+      return () => {}
+    },
+    onLifecycle: () => () => {},
+  } as unknown as KobeDaemonClient
+  return { client, emit: (name, payload) => star?.({ name, payload }) }
+}
+
+describe("RemoteOrchestrator attention channel", () => {
+  it("replaces the durable Inbox from full snapshots and rejects malformed payloads", () => {
+    const { client, emit } = fakeClient()
+    const orch = new RemoteOrchestrator(client)
+    const item = { taskId: "t1", tabId: "tab-2", state: "permission_needed" as const, at: 42 }
+
+    emit("attention.inbox", { items: [item] })
+    expect(orch.attentionInboxSignal()()).toEqual([item])
+
+    emit("attention.inbox", { items: "bad" })
+    expect(orch.attentionInboxSignal()()).toEqual([item])
+    expect(logClientError).toHaveBeenCalledWith("orch", expect.stringContaining("dropped attention.inbox"))
+
+    emit("attention.inbox", { items: [] })
+    expect(orch.attentionInboxSignal()()).toEqual([])
+  })
+})

--- a/packages/kobe/test/client/remote-orchestrator-rpc.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-rpc.test.ts
@@ -24,6 +24,7 @@ const serializedTask = {
 
 function fakeClient() {
   const request = vi.fn(async (method: string) => {
+    if (method === "attention.dismiss") return { deleted: true }
     if (method === "task.ensureWorktree") return { worktreePath: "/wt" }
     if (method === "worktree.discoverAdoptable") return { worktrees: [] }
     if (method.startsWith("task.") || method === "worktree.adopt") return { task: serializedTask }
@@ -92,6 +93,14 @@ describe("RemoteOrchestrator RPC wire mapping", () => {
     expect(request).toHaveBeenCalledWith("task.move", { taskId: "t1", direction: "up" })
     await orch.moveTask("t1", 1)
     expect(request).toHaveBeenCalledWith("task.move", { taskId: "t1", direction: "down" })
+  })
+
+  it("dismissAttention targets exactly one task+tab episode", async () => {
+    await expect(orch.dismissAttention("t1", "tab-2")).resolves.toBe(true)
+    expect(request).toHaveBeenCalledWith("attention.dismiss", { taskId: "t1", tabId: "tab-2" })
+
+    await orch.dismissAttention("t1", null)
+    expect(request).toHaveBeenCalledWith("attention.dismiss", { taskId: "t1" })
   })
 
   it("worktree adoption RPCs", async () => {

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -28,22 +28,6 @@ function fakeClient(): { client: KobeDaemonClient; emit: (name: string, payload:
 }
 
 describe("RemoteOrchestrator channel handling", () => {
-  it("replaces the durable attention Inbox from full snapshots and rejects malformed payloads", () => {
-    const { client, emit } = fakeClient()
-    const orch = new RemoteOrchestrator(client)
-    const item = { taskId: "t1", tabId: "tab-2", state: "permission_needed" as const, at: 42 }
-
-    emit("attention.inbox", { items: [item] })
-    expect(orch.attentionInboxSignal()()).toEqual([item])
-
-    emit("attention.inbox", { items: "bad" })
-    expect(orch.attentionInboxSignal()()).toEqual([item])
-    expect(logClientError).toHaveBeenCalledWith("orch", expect.stringContaining("dropped attention.inbox"))
-
-    emit("attention.inbox", { items: [] })
-    expect(orch.attentionInboxSignal()()).toEqual([])
-  })
-
   it("reflects the daemon-owned `update` channel in updateSignal", () => {
     const { client, emit } = fakeClient()
     const orch = new RemoteOrchestrator(client)

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -28,6 +28,22 @@ function fakeClient(): { client: KobeDaemonClient; emit: (name: string, payload:
 }
 
 describe("RemoteOrchestrator channel handling", () => {
+  it("replaces the durable attention Inbox from full snapshots and rejects malformed payloads", () => {
+    const { client, emit } = fakeClient()
+    const orch = new RemoteOrchestrator(client)
+    const item = { taskId: "t1", tabId: "tab-2", state: "permission_needed" as const, at: 42 }
+
+    emit("attention.inbox", { items: [item] })
+    expect(orch.attentionInboxSignal()()).toEqual([item])
+
+    emit("attention.inbox", { items: "bad" })
+    expect(orch.attentionInboxSignal()()).toEqual([item])
+    expect(logClientError).toHaveBeenCalledWith("orch", expect.stringContaining("dropped attention.inbox"))
+
+    emit("attention.inbox", { items: [] })
+    expect(orch.attentionInboxSignal()()).toEqual([])
+  })
+
   it("reflects the daemon-owned `update` channel in updateSignal", () => {
     const { client, emit } = fakeClient()
     const orch = new RemoteOrchestrator(client)

--- a/packages/kobe/test/daemon/attention-inbox.test.ts
+++ b/packages/kobe/test/daemon/attention-inbox.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
@@ -73,5 +73,52 @@ describe("daemon attention inbox", () => {
     await store.deleteTask("task-1")
 
     expect(store.snapshot().map((item) => item.taskId)).toEqual(["task-2"])
+  })
+
+  it("classifies waiting, rate limits, billing failures, and other failures", async () => {
+    const { store } = await create()
+    await store.record("task-1", "awaiting-input", { waiting: "input" }, "tab-1")
+    await store.record("task-1", "turn-failed", { failure: "rate_limit" }, "tab-2")
+    await store.record("task-1", "turn-failed", { failure: "billing" }, "tab-3")
+    await store.record("task-1", "turn-failed", { failure: "other" }, "tab-4")
+
+    expect(Object.fromEntries(store.snapshot().map((item) => [item.tabId, item.state]))).toEqual({
+      "tab-1": "permission_needed",
+      "tab-2": "rate_limited",
+      "tab-3": "error",
+      "tab-4": "error",
+    })
+  })
+
+  it("boots with an empty Inbox when the persisted JSON is corrupt", async () => {
+    dir = await mkdtemp(join(tmpdir(), "kobe-attention-inbox-corrupt-"))
+    const path = join(dir, "attention-inbox.json")
+    await writeFile(path, "{not-json", "utf8")
+    const bus = new DaemonEventBus()
+    const store = new AttentionInboxStore(path, bus)
+
+    await expect(store.init()).resolves.toBeUndefined()
+    expect(store.snapshot()).toEqual([])
+    expect(bus.snapshot()).toContainEqual({ channel: "attention.inbox", payload: { items: [] } })
+  })
+
+  it("keeps memory unchanged when an atomic write fails", async () => {
+    dir = await mkdtemp(join(tmpdir(), "kobe-attention-inbox-blocked-"))
+    const blocker = join(dir, "not-a-directory")
+    await writeFile(blocker, "blocked", "utf8")
+    const store = new AttentionInboxStore(join(blocker, "attention-inbox.json"), new DaemonEventBus())
+    await store.init()
+
+    await expect(store.record("task-1", "turn-complete", undefined, "tab-1")).rejects.toThrow()
+    expect(store.snapshot()).toEqual([])
+  })
+
+  it("keeps task deletion live when Inbox cleanup fails", async () => {
+    const { store } = await create()
+    store.deleteTask = async () => {
+      throw new Error("disk full")
+    }
+
+    await expect(store.deleteTaskBestEffort("task-1")).resolves.toBeUndefined()
   })
 })

--- a/packages/kobe/test/daemon/attention-inbox.test.ts
+++ b/packages/kobe/test/daemon/attention-inbox.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { afterEach, describe, expect, it } from "vitest"
+
+describe("daemon attention inbox", () => {
+  let dir: string | null = null
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+    dir = null
+  })
+
+  async function create(now = 100): Promise<{ store: AttentionInboxStore; path: string; bus: DaemonEventBus }> {
+    dir = await mkdtemp(join(tmpdir(), "kobe-attention-inbox-"))
+    const path = join(dir, "attention-inbox.json")
+    const bus = new DaemonEventBus()
+    const store = new AttentionInboxStore(path, bus, () => now)
+    await store.init()
+    return { store, path, bus }
+  }
+
+  it("persists attention episodes and replays the full snapshot", async () => {
+    const { store, path, bus } = await create(123)
+    const snapshots: unknown[] = []
+    bus.onPublish((event) => {
+      if (event.channel === "attention.inbox") snapshots.push(event.payload)
+    })
+
+    await store.record("task-1", "turn-complete", undefined, "tab-2")
+
+    expect(store.snapshot()).toEqual([{ taskId: "task-1", tabId: "tab-2", state: "turn_complete", at: 123 }])
+    expect(snapshots.at(-1)).toEqual({ items: store.snapshot() })
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ version: 1, items: store.snapshot() })
+
+    const reloaded = new AttentionInboxStore(path, new DaemonEventBus(), () => 999)
+    await reloaded.init()
+    expect(reloaded.snapshot()).toEqual(store.snapshot())
+  })
+
+  it("removes only on a newer turn-start for the same task and tab", async () => {
+    const { store } = await create()
+    await store.record("task-1", "awaiting-input", { waiting: "permission" }, "tab-1")
+
+    await store.record("task-1", "session-end", undefined, "tab-1")
+    await store.record("task-1", "turn-start", undefined, "tab-2")
+    expect(store.snapshot()).toHaveLength(1)
+
+    await store.record("task-1", "turn-start", undefined, "tab-1")
+    expect(store.snapshot()).toEqual([])
+  })
+
+  it("manual deletion dismisses one episode but a later episode returns", async () => {
+    const { store } = await create()
+    await store.record("task-1", "turn-failed", { failure: "other", note: "boom" }, "tab-1")
+
+    expect(await store.deleteEpisode("task-1", "tab-1")).toBe(true)
+    expect(store.snapshot()).toEqual([])
+    expect(await store.deleteEpisode("task-1", "tab-1")).toBe(false)
+
+    await store.record("task-1", "turn-complete", undefined, "tab-1")
+    expect(store.snapshot()).toEqual([{ taskId: "task-1", tabId: "tab-1", state: "turn_complete", at: 100 }])
+  })
+
+  it("keeps closed-tab episodes but cascades an explicit task deletion", async () => {
+    const { store } = await create()
+    await store.record("task-1", "turn-complete", undefined, "tab-1")
+    await store.record("task-1", "session-end", undefined, "tab-1")
+    await store.record("task-2", "turn-complete", undefined, "tab-1")
+
+    await store.deleteTask("task-1")
+
+    expect(store.snapshot().map((item) => item.taskId)).toEqual(["task-2"])
+  })
+})

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -57,6 +57,10 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
         rec.inboxTaskDeleted.push(taskId)
         return Promise.resolve()
       },
+      deleteTaskBestEffort: (taskId: string) => {
+        rec.inboxTaskDeleted.push(taskId)
+        return Promise.resolve()
+      },
     } as unknown as AttentionInboxStore,
     deletions: {
       enqueue: (taskId: string) => rec.deletions.push(taskId),

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -1,4 +1,5 @@
 import type { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
+import type { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
 import type { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import type { IssuesStore } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import type { DaemonHandlerContext } from "@sma1lboy/kobe-daemon/daemon/server"
@@ -10,6 +11,9 @@ export interface RecordedHandlerEffects {
   readonly reported: Array<{ taskId: string; kind: string; detail?: unknown }>
   readonly issueCalls: Array<{ method: string; repo: unknown; op?: unknown }>
   readonly cleared: string[]
+  readonly inboxRecords: Array<{ taskId: string; kind: string; detail?: unknown; tabId?: string }>
+  readonly inboxDeleted: Array<{ taskId: string; tabId: string | null }>
+  readonly inboxTaskDeleted: string[]
   readonly deletions: string[]
   stopped: number
 }
@@ -24,6 +28,9 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
     reported: [],
     issueCalls: [],
     cleared: [],
+    inboxRecords: [],
+    inboxDeleted: [],
+    inboxTaskDeleted: [],
     deletions: [],
     stopped: 0,
   }
@@ -37,6 +44,20 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
       report: (taskId: string, kind: string, detail?: unknown) => rec.reported.push({ taskId, kind, detail }),
       clearTask: (taskId: string) => rec.cleared.push(taskId),
     } as unknown as DaemonActivityRegistry,
+    inbox: {
+      record: (taskId: string, kind: string, detail?: unknown, tabId?: string) => {
+        rec.inboxRecords.push({ taskId, kind, detail, tabId })
+        return Promise.resolve()
+      },
+      deleteEpisode: (taskId: string, tabId: string | null) => {
+        rec.inboxDeleted.push({ taskId, tabId })
+        return Promise.resolve(true)
+      },
+      deleteTask: (taskId: string) => {
+        rec.inboxTaskDeleted.push(taskId)
+        return Promise.resolve()
+      },
+    } as unknown as AttentionInboxStore,
     deletions: {
       enqueue: (taskId: string) => rec.deletions.push(taskId),
     },

--- a/packages/kobe/test/daemon/handlers-attention.test.ts
+++ b/packages/kobe/test/daemon/handlers-attention.test.ts
@@ -1,0 +1,34 @@
+import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import {
+  type DaemonHandlerContext,
+  createDaemonHandlerRegistry,
+  dispatchDaemonRequest,
+} from "@sma1lboy/kobe-daemon/daemon/server"
+import { describe, expect, it } from "vitest"
+import { fakeCtx } from "./handler-test-context.ts"
+
+function dispatch(name: DaemonRequestName, payload: unknown, ctx: DaemonHandlerContext): Promise<unknown> {
+  return dispatchDaemonRequest(createDaemonHandlerRegistry(), name, payload, ctx)
+}
+
+describe("attention.dismiss handler", () => {
+  it("deletes exactly one task+tab episode", async () => {
+    const { ctx, rec } = fakeCtx()
+    await expect(dispatch("attention.dismiss", { taskId: "t1", tabId: "tab-2" }, ctx)).resolves.toEqual({
+      deleted: true,
+    })
+    expect(rec.inboxDeleted).toEqual([{ taskId: "t1", tabId: "tab-2" }])
+  })
+
+  it("supports a legacy task-level episode", async () => {
+    const { ctx, rec } = fakeCtx()
+    await dispatch("attention.dismiss", { taskId: "t1" }, ctx)
+    expect(rec.inboxDeleted).toEqual([{ taskId: "t1", tabId: null }])
+  })
+
+  it("records normalized engine events with their chat-tab identity", async () => {
+    const { ctx, rec } = fakeCtx()
+    await dispatch("engine.reportEvent", { taskId: "t1", tabId: "tab-3", kind: "awaiting-input" }, ctx)
+    expect(rec.inboxRecords).toEqual([{ taskId: "t1", kind: "awaiting-input", detail: undefined, tabId: "tab-3" }])
+  })
+})

--- a/packages/kobe/test/daemon/handlers-attention.test.ts
+++ b/packages/kobe/test/daemon/handlers-attention.test.ts
@@ -31,4 +31,16 @@ describe("attention.dismiss handler", () => {
     await dispatch("engine.reportEvent", { taskId: "t1", tabId: "tab-3", kind: "awaiting-input" }, ctx)
     expect(rec.inboxRecords).toEqual([{ taskId: "t1", kind: "awaiting-input", detail: undefined, tabId: "tab-3" }])
   })
+
+  it("does not drop the engine event when Inbox persistence fails", async () => {
+    const { ctx, rec } = fakeCtx()
+    ctx.inbox.record = async () => {
+      throw new Error("disk full")
+    }
+
+    await expect(
+      dispatch("engine.reportEvent", { taskId: "t1", tabId: "tab-3", kind: "turn-complete" }, ctx),
+    ).resolves.toEqual({})
+    expect(rec.reported).toEqual([{ taskId: "t1", kind: "turn-complete", detail: undefined }])
+  })
 })

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -255,22 +255,6 @@ describe("daemon handler registry", () => {
     })
   })
 
-  describe("attention.dismiss", () => {
-    it("deletes exactly one task+tab episode", async () => {
-      const { ctx, rec } = fakeCtx()
-      await expect(dispatch("attention.dismiss", { taskId: "t1", tabId: "tab-2" }, ctx)).resolves.toEqual({
-        deleted: true,
-      })
-      expect(rec.inboxDeleted).toEqual([{ taskId: "t1", tabId: "tab-2" }])
-    })
-
-    it("supports a legacy task-level episode", async () => {
-      const { ctx, rec } = fakeCtx()
-      await dispatch("attention.dismiss", { taskId: "t1" }, ctx)
-      expect(rec.inboxDeleted).toEqual([{ taskId: "t1", tabId: null }])
-    })
-  })
-
   describe("issues", () => {
     it("issue.list and issue.mutate delegate to the daemon-owned issue store", async () => {
       const { ctx, rec } = fakeCtx()
@@ -413,9 +397,6 @@ describe("daemon handler registry", () => {
       )
       expect(result).toEqual({})
       expect(rec.reported).toEqual([{ taskId: "t1", kind: "awaiting-input", detail: { waiting: "permission" } }])
-      expect(rec.inboxRecords).toEqual([
-        { taskId: "t1", kind: "awaiting-input", detail: { waiting: "permission" }, tabId: undefined },
-      ])
     })
 
     it("an explicit taskId wins over cwd resolution", async () => {

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -97,6 +97,7 @@ describe("daemon handler registry", () => {
       "worktree.list",
       "worktree.remove",
       "engine.reportEvent",
+      "attention.dismiss",
       "session.deliver",
       "notice.send",
       "note.file",
@@ -235,6 +236,7 @@ describe("daemon handler registry", () => {
       await expect(dispatch("task.delete", { taskId: "t1", force: true }, ctx)).resolves.toEqual({})
       expect(prepared).toEqual([["t1", { force: true }]])
       expect(rec.cleared).toEqual(["t1"])
+      expect(rec.inboxTaskDeleted).toEqual(["t1"])
       expect(rec.deletions).toEqual(["t1"])
     })
 
@@ -242,6 +244,7 @@ describe("daemon handler registry", () => {
       const { ctx, rec } = fakeCtx({ prepareTaskDeletion: async () => false })
       await expect(dispatch("task.delete", { taskId: "missing" }, ctx)).resolves.toEqual({})
       expect(rec.deletions).toEqual([])
+      expect(rec.inboxTaskDeleted).toEqual(["missing"])
     })
 
     it("task.move rejects a bogus direction with the legacy wording", async () => {
@@ -249,6 +252,22 @@ describe("daemon handler registry", () => {
       await expect(dispatch("task.move", { taskId: "t1", direction: "sideways" }, ctx)).rejects.toThrow(
         "direction must be up or down",
       )
+    })
+  })
+
+  describe("attention.dismiss", () => {
+    it("deletes exactly one task+tab episode", async () => {
+      const { ctx, rec } = fakeCtx()
+      await expect(dispatch("attention.dismiss", { taskId: "t1", tabId: "tab-2" }, ctx)).resolves.toEqual({
+        deleted: true,
+      })
+      expect(rec.inboxDeleted).toEqual([{ taskId: "t1", tabId: "tab-2" }])
+    })
+
+    it("supports a legacy task-level episode", async () => {
+      const { ctx, rec } = fakeCtx()
+      await dispatch("attention.dismiss", { taskId: "t1" }, ctx)
+      expect(rec.inboxDeleted).toEqual([{ taskId: "t1", tabId: null }])
     })
   })
 
@@ -394,12 +413,20 @@ describe("daemon handler registry", () => {
       )
       expect(result).toEqual({})
       expect(rec.reported).toEqual([{ taskId: "t1", kind: "awaiting-input", detail: { waiting: "permission" } }])
+      expect(rec.inboxRecords).toEqual([
+        { taskId: "t1", kind: "awaiting-input", detail: { waiting: "permission" }, tabId: undefined },
+      ])
     })
 
     it("an explicit taskId wins over cwd resolution", async () => {
       const { ctx, rec } = fakeCtx({ listTasks: () => [TASK] })
-      await dispatch("engine.reportEvent", { kind: "turn-complete", taskId: "direct", cwd: TASK.worktreePath }, ctx)
+      await dispatch(
+        "engine.reportEvent",
+        { kind: "turn-complete", taskId: "direct", tabId: "tab-3", cwd: TASK.worktreePath },
+        ctx,
+      )
       expect(rec.reported).toEqual([{ taskId: "direct", kind: "turn-complete", detail: undefined }])
+      expect(rec.inboxRecords).toEqual([{ taskId: "direct", kind: "turn-complete", detail: undefined, tabId: "tab-3" }])
     })
 
     it("an unmatched cwd is silently dropped (returns {} with no report)", async () => {
@@ -408,6 +435,7 @@ describe("daemon handler registry", () => {
         dispatch("engine.reportEvent", { kind: "turn-start", cwd: "/somewhere/else" }, ctx),
       ).resolves.toEqual({})
       expect(rec.reported).toEqual([])
+      expect(rec.inboxRecords).toEqual([])
     })
 
     it("rejects an unknown kind and a missing kind with the exact wording", async () => {

--- a/packages/kobe/test/render/attention-inbox-pane.test.tsx
+++ b/packages/kobe/test/render/attention-inbox-pane.test.tsx
@@ -60,6 +60,17 @@ function Probe(props: {
 }
 
 describe("AttentionInboxPane", () => {
+  it("renders the empty Inbox state", async () => {
+    const { frame } = await renderComponent(<Probe items={[]} onOpen={() => {}} onDelete={() => {}} />, {
+      providers: { kv: true },
+      width: 46,
+      height: 8,
+    })
+    const text = await frame()
+    expect(text).toContain("INBOX 0")
+    expect(text).toContain("No pending attention")
+  })
+
   it("renders retained episodes and exposes pane-local navigation/open/delete", async () => {
     const opened: string[] = []
     const deleted: string[] = []

--- a/packages/kobe/test/render/attention-inbox-pane.test.tsx
+++ b/packages/kobe/test/render/attention-inbox-pane.test.tsx
@@ -1,0 +1,95 @@
+/** @jsxImportSource @opentui/react */
+
+import { describe, expect, it } from "bun:test"
+import type { AttentionInboxItem } from "../../src/client/remote-orchestrator"
+import { useKV } from "../../src/tui-react/context/kv"
+import { AttentionInboxPane } from "../../src/tui-react/workspace/AttentionInboxPane"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { act, renderComponent } from "./harness"
+
+process.env.KOBE_HOME_DIR = process.env.KOBE_HOME_DIR ?? "/tmp/kobe-attention-inbox-render-test"
+
+const tasks: Task[] = [
+  {
+    id: toTaskId("task-a"),
+    title: "Alpha",
+    repo: "/tmp/a",
+    branch: "a",
+    worktreePath: "/tmp/a",
+    status: "in_progress",
+    archived: false,
+    createdAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+  },
+  {
+    id: toTaskId("task-b"),
+    title: "Beta",
+    repo: "/tmp/b",
+    branch: "b",
+    worktreePath: "/tmp/b",
+    status: "in_progress",
+    archived: false,
+    createdAt: "2026-07-15T00:00:00.000Z",
+    updatedAt: "2026-07-15T00:00:00.000Z",
+  },
+]
+
+const items: AttentionInboxItem[] = [
+  { taskId: "task-b", tabId: null, state: "turn_complete", at: 10 },
+  { taskId: "task-a", tabId: null, state: "permission_needed", at: 20 },
+]
+
+function Probe(props: {
+  onOpen: (item: AttentionInboxItem) => void
+  onDelete: (item: AttentionInboxItem) => void
+  items?: AttentionInboxItem[]
+}) {
+  const kv = useKV()
+  return (
+    <AttentionInboxPane
+      items={props.items ?? items}
+      tasks={tasks}
+      kv={kv}
+      focused={true}
+      onOpen={props.onOpen}
+      onDelete={props.onDelete}
+      onRequestFocus={() => {}}
+    />
+  )
+}
+
+describe("AttentionInboxPane", () => {
+  it("renders retained episodes and exposes pane-local navigation/open/delete", async () => {
+    const opened: string[] = []
+    const deleted: string[] = []
+    const { frame, mockInput } = await renderComponent(
+      <Probe onOpen={(item) => opened.push(item.taskId)} onDelete={(item) => deleted.push(item.taskId)} />,
+      { providers: { kv: true }, width: 46, height: 8 },
+    )
+    const text = await frame()
+    expect(text).toContain("INBOX 2")
+    expect(text).toContain("Alpha")
+    expect(text).toContain("Beta")
+
+    act(() => mockInput.pressKey("j"))
+    act(() => mockInput.pressKey("d"))
+    act(() => mockInput.pressEnter())
+    expect(deleted).toEqual(["task-b"])
+    expect(opened).toEqual(["task-b"])
+  })
+
+  it("keeps a closed chat tab visible as unavailable", async () => {
+    const { frame } = await renderComponent(
+      <Probe
+        items={[{ taskId: "task-a", tabId: "closed-tab", state: "error", at: 10 }]}
+        onOpen={() => {}}
+        onDelete={() => {}}
+      />,
+      { providers: { kv: true }, width: 60, height: 8 },
+    )
+    const text = await frame()
+    expect(text).toContain("closed-tab")
+    expect(text).toContain("unavailable")
+  })
+})

--- a/packages/kobe/test/render/focus-provider.test.tsx
+++ b/packages/kobe/test/render/focus-provider.test.tsx
@@ -62,7 +62,10 @@ describe("FocusProvider", () => {
     act(() => setFocusedFn?.("files"))
     expect(await frame()).toContain("focused:files")
 
-    act(() => cycleFn?.(1)) // files -> terminal (PANE_ORDER: sidebar, workspace, files, terminal)
+    act(() => cycleFn?.(1)) // files -> inbox
+    expect(await frame()).toContain("focused:inbox")
+
+    act(() => cycleFn?.(1)) // inbox -> terminal
     expect(await frame()).toContain("focused:terminal")
 
     act(() => cycleFn?.(1)) // terminal wraps back to sidebar

--- a/packages/kobe/test/render/toast-overlay.test.tsx
+++ b/packages/kobe/test/render/toast-overlay.test.tsx
@@ -19,13 +19,13 @@ import { renderComponent } from "./harness"
 // (or depends on) a real ~/.config/kobe/state.json.
 process.env.KOBE_HOME_DIR = process.env.KOBE_HOME_DIR ?? "/tmp/kobe-render-test-home"
 
-function NotifyProbe(props: { kind: "done" | "needs_input" | "error"; title: string }) {
+function NotifyProbe(props: { kind: "done" | "needs_input" | "error"; title: string; bottomOffset?: number }) {
   const notif = useNotifications()
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once notify.
   useEffect(() => {
     notif.notify({ kind: props.kind, taskId: "t1", tabId: "tab1", title: props.title })
   }, [])
-  return <ToastOverlay />
+  return <ToastOverlay bottomOffset={props.bottomOffset} />
 }
 
 function findSpan(frame: CapturedFrame, needle: string) {
@@ -54,6 +54,19 @@ describe("ToastOverlay", () => {
     const text = await frame()
     expect(text).toContain("clone failed")
     expect(text).toContain("✕")
+  })
+
+  it("moves above a bottom pane offset", async () => {
+    const normal = await renderComponent(<NotifyProbe kind="done" title="normal anchor" />, {
+      providers: { notifications: true },
+    })
+    const normalLine = (await normal.frame()).split("\n").findIndex((line) => line.includes("normal anchor"))
+    normal.destroy()
+    const raised = await renderComponent(<NotifyProbe kind="done" title="raised anchor" bottomOffset={8} />, {
+      providers: { notifications: true },
+    })
+    const raisedLine = (await raised.frame()).split("\n").findIndex((line) => line.includes("raised anchor"))
+    expect(raisedLine).toBe(normalLine - 8)
   })
 
   it.each([

--- a/packages/kobe/test/tui-react/attention-inbox-core.test.ts
+++ b/packages/kobe/test/tui-react/attention-inbox-core.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest"
+import type { AttentionInboxItem } from "../../src/client/remote-orchestrator"
+import {
+  attentionInboxKey,
+  nextAttentionInboxTarget,
+  sortAttentionInbox,
+} from "../../src/tui-react/workspace/attention-inbox-core"
+
+const item = (
+  taskId: string,
+  tabId: string | null,
+  state: AttentionInboxItem["state"],
+  at: number,
+): AttentionInboxItem => ({ taskId, tabId, state, at })
+
+describe("attention inbox ordering", () => {
+  test("prioritizes input and failures over completions, then oldest first", () => {
+    const ordered = sortAttentionInbox(
+      [
+        item("b", "tab-1", "turn_complete", 10),
+        item("a", "tab-2", "error", 9),
+        item("a", "tab-1", "permission_needed", 11),
+        item("b", "tab-2", "rate_limited", 8),
+      ],
+      ["a", "b"],
+    )
+    expect(ordered.map(attentionInboxKey)).toEqual(["a\u0000tab-1", "b\u0000tab-2", "a\u0000tab-2", "b\u0000tab-1"])
+  })
+
+  test("F7 cycles task and chat-tab episodes without removing them", () => {
+    const items = [item("a", "tab-1", "error", 8), item("b", "tab-2", "turn_complete", 9)]
+    const target = nextAttentionInboxTarget(items, ["a", "b"], { taskId: "a", tabId: "tab-1" })
+    expect(target?.taskId).toBe("b")
+    expect(items).toHaveLength(2)
+  })
+
+  test("does not pretend the only current episode is a new target", () => {
+    const items = [item("a", "tab-1", "error", 8)]
+    expect(nextAttentionInboxTarget(items, ["a"], { taskId: "a", tabId: "tab-1" })).toBeNull()
+  })
+
+  test("retains unavailable task episodes in the sorted list but skips them for F7", () => {
+    const missing = item("deleted", null, "error", 8)
+    const live = item("live", null, "turn_complete", 9)
+    expect(sortAttentionInbox([missing, live], ["live"])).toContain(missing)
+    expect(nextAttentionInboxTarget([missing, live], ["live"], { taskId: null, tabId: null })).toBe(live)
+  })
+
+  test("skips a retained episode whose chat tab has closed", () => {
+    const closed = item("live", "closed", "error", 8)
+    const open = item("live", "open", "turn_complete", 9)
+    expect(
+      nextAttentionInboxTarget(
+        [closed, open],
+        ["live"],
+        { taskId: null, tabId: null },
+        (candidate) => candidate.tabId === "open",
+      ),
+    ).toBe(open)
+  })
+})

--- a/packages/kobe/test/tui-react/attention-inbox-core.test.ts
+++ b/packages/kobe/test/tui-react/attention-inbox-core.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest"
 import type { AttentionInboxItem } from "../../src/client/remote-orchestrator"
 import {
   attentionInboxKey,
+  isAttentionInboxItemAvailable,
   nextAttentionInboxTarget,
   sortAttentionInbox,
 } from "../../src/tui-react/workspace/attention-inbox-core"
@@ -57,5 +58,12 @@ describe("attention inbox ordering", () => {
         (candidate) => candidate.tabId === "open",
       ),
     ).toBe(open)
+  })
+
+  test("uses one availability rule for archived tasks and closed tabs", () => {
+    const open = item("live", "open", "error", 8)
+    expect(isAttentionInboxItemAvailable(open, { archived: false }, (id) => id === "open")).toBe(true)
+    expect(isAttentionInboxItemAvailable(open, { archived: true }, () => true)).toBe(false)
+    expect(isAttentionInboxItemAvailable(open, { archived: false }, () => false)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- persist permission/input waits, failures, rate limits, and completions as daemon-owned per-chat-tab Inbox episodes
- remove an episode only when that same chat tab starts a newer turn, the user explicitly deletes it, or the containing task is explicitly hard-deleted
- add a focused Inbox below Files with `j/k`, `enter`, and `d`; make F7 traverse the durable Inbox without consuming entries
- retain closed/archived targets as unavailable for manual cleanup while skipping them during F7 navigation

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` (2260 fast tests and 273 socket tests)
- `cd packages/kobe && bun run test:render` (111 tests)
- `cd packages/kobe && bun run build && bun run test:behavior` (12 tests)
- real 1280x800 browser `/harness`: verified empty and populated Inbox layouts, then cycled focus Sidebar → Workspace → Files → Inbox and deleted the persisted episode with `d`

## Visual baseline note

`bun run visual` reaches the real OpenTUI but the committed Kanban screenshot differs by 2% for an unrelated pre-existing drift: the baseline lacks the current `AFTER START` form section and contains an older checkout path. This PR does not update that unrelated baseline; the Inbox is not mounted on the full-page Kanban screenshot.
