### PR TITLE
docs: refresh harness guidance and journeys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,18 @@ bun install
 
 This is a Bun-workspaces monorepo:
 
-- [`packages/kobe/`](./packages/kobe) — the TUI itself, published as `@sma1lboy/kobe`. Almost all work happens here.
-- [`packages/branding/`](./packages/branding) — Remotion render pipeline for brand assets. Private, never published.
+- [`packages/kobe/`](./packages/kobe) — the published CLI and PureTUI.
+- [`packages/kobe-daemon/`](./packages/kobe-daemon) — daemon protocol/server and Hosted PTY runtime.
+- [`packages/kobe-web/`](./packages/kobe-web) — browser dashboard and PTY sidecar.
+- [`packages/branding/`](./packages/branding) — Remotion render pipeline for brand assets.
+
+The current ownership map is in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 Run package scripts from the root via `bun --filter @sma1lboy/kobe <script>`, or `cd packages/kobe` first. Most common scripts are also aliased at the root (`bun run dev`, `bun run test`, etc.).
 
 ### Reference repos (optional but recommended)
 
-kobe deliberately borrows ideas from a set of reference projects cloned into `refs/` (gitignored). If you're touching engine adapters, stream rendering, or status/usage derivation, clone the relevant refs first — see the "Reference repos" section in [`CLAUDE.md`](./CLAUDE.md) for the list and what each one is for. **Never edit anything inside `refs/`** — it's read-only study material.
+kobe deliberately borrows ideas from a set of reference projects cloned into `refs/` (gitignored). If you're touching engine adapters, stream rendering, or status/usage derivation, clone the relevant refs first — see the "Reference repos" section in [`AGENTS.md`](./AGENTS.md) for the list and what each one is for. **Never edit anything inside `refs/`** — it's read-only study material.
 
 ## Development
 
@@ -56,15 +60,17 @@ Debugging the daemon? Read `<KOBE_HOME>/.kobe/daemon.log` first — the daemon's
 ## Checks — run before every PR
 
 ```bash
+bun run lint          # formatting and static checks
 bun run typecheck     # tsc --noEmit
-bun run lint          # biome check . (bun run lint:fix to auto-fix)
 bun run test          # fast Vitest suite + Unix-socket daemon suite
-bun run build         # the publish gate runs this too
+bun run build
+bun run test:behavior # built CLI against an isolated daemon and Hosted PTY
 ```
 
-CI (`.github/workflows/ci.yml`) runs typecheck + tests + build on every PR. Note that lint is in `ci.yml` but **not** in the release gate, so run it locally.
-
-There is also a behavioral suite — `bun run test:behavior` — which drives the built CLI against an isolated daemon and hosted PTY engine. It runs in CI; use it locally for packaged-path and session-lifecycle changes. See [`docs/HARNESS.md`](./docs/HARNESS.md) for the philosophy: unit tests prove functions work, behavioral tests prove the *product* works.
+For a native OpenTUI visual change, also run `bun run visual`; it is the only
+visual acceptance path and drives `/harness → xterm.js → PTY → real OpenTUI`.
+CI runs the full required matrix. The exact track selection and current gates
+live in [`docs/HARNESS.md`](./docs/HARNESS.md).
 
 ## Making changes
 
@@ -96,13 +102,15 @@ Default the bump to `patch` — kobe is pre-1.0 and ships features as patches; a
 
 ## Work tracking
 
-There is no external issue tracker. Everything is repo-local:
+The product backlog is local. Everything used for normal development is
+repo-local:
 
-- **Backlog**: [`docs/issues.json`](./docs/issues.json) — see [`docs/WORK-TRACKING.md`](./docs/WORK-TRACKING.md) for the shape.
+- **Backlog**: the daemon-owned issue store — see [`docs/WORK-TRACKING.md`](./docs/WORK-TRACKING.md).
 - **Shipped behavior**: [`packages/kobe/CHANGELOG.md`](./packages/kobe/CHANGELOG.md), via changesets.
 - **Durable design decisions**: Markdown in `docs/`.
 
-For bugs and feature requests from outside the repo, use [GitHub issues](https://github.com/Sma1lboy/kobe/issues).
+GitHub Issues are reserved for inbound user reports; do not create them for
+normal project planning.
 
 ## Pull request checklist
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,9 @@
 </p>
 <img width="2559" height="1510" alt="image" src="https://github.com/user-attachments/assets/f8dab7ca-43a1-4f76-adad-f19239f5f503" />
 
-
 ## A quick look
 
-
-
-
-
 https://github.com/user-attachments/assets/17947cf2-bd90-41d8-9e56-2b30050f6d08
-
-
-
-
 
 kobe opens into a PureTUI workspace with:
 
@@ -156,17 +147,18 @@ Start with [`AGENTS.md`](./AGENTS.md), [`docs/ARCHITECTURE.md`](./docs/ARCHITECT
 
 ### Testing & coverage
 
-Three test layers (contract: [`docs/HARNESS.md`](./docs/HARNESS.md)):
+Verification layers (contract: [`docs/HARNESS.md`](./docs/HARNESS.md)):
 
 ```bash
 bun run test                                   # unit + socket suites (fast, CI-gated)
 bun run build && bun run test:behavior         # black-box: the BUILT CLI in a temp home
                                                # + isolated daemon and Hosted PTY runtime
                                                # (CI-gated, `behavior` job)
+bun run visual                                 # real OpenTUI through /harness + PTY (Linux CI gate)
 cd packages/kobe && bun run coverage           # v8 coverage report (text + json-summary)
 ```
 
 Two hard rules keep regressions from coming back:
 
 - **Every bug fix ships a regression test** that fails before the fix and passes after, commented with the issue it pins. Environment-shaped bugs (terminal bytes, PATH state, packaged-vs-dev) get pinned in `test/behavior/`, not in a mocked unit test.
-- **Per-touched-file coverage floor on PRs** — every `packages/kobe/src` **`.ts`** file a PR touches must meet the line-coverage floor (default 50%, `scripts/coverage-gate.mjs`); `coverage-exemption: <reason>` in the PR body opts out with a paper trail. Coverage scope is unit-testable `.ts` logic — opentui `.tsx` components can't run under vitest and are pinned by the behavior suite instead. There is deliberately no repo-wide % gate.
+- **Per-touched-file coverage floor on PRs** — touched source must meet the current floor or carry a documented `coverage-exemption`. OpenTUI render paths are also covered by the native render and browser visual gates; there is deliberately no repo-wide percentage target. See [`docs/HARNESS.md`](./docs/HARNESS.md) for the current CI matrix.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -67,16 +67,24 @@ running server — stop `visual:serve` first. `KOBE_VISUAL_FRESH=1` forces a
 fixture rebuild.
 
 Both commands rebuild a disposable fixture under `.scratch/opentui-visual-*`
-(real git repo, real task, three issues via `kobe api`), drive the real TUI
-through the harness (workspace → F1 help → Settings, then Kanban → New Story),
-lock the completed intake with `kanban-new-issue.png`, and tear everything
-down. CI and release run this exact command on Linux. Ports derive from
-`KOBE_VISUAL_PORT_BASE` (default 5273); a busy port fails fast — never reuse a
-stray server, and never point the fixture at a real HOME or the shared
-`.dev-sandbox/home`. Local Terminal screenshots, native `kobe-web` pages such
-as `/board`, render-test frames, and `dev:mock` cannot approve visual changes;
-`test:e2e` (dev:mock) stays a PTY-transport smoke only. Failure artifacts land
-in `packages/kobe-web/test-results/` (actual/diff/trace).
+(real git repo, real task, three issues via `kobe api`). Each journey gets a
+fresh `/harness` browser PTY and starts from the Workspace; the journeys are
+independent, not one long stateful session. CI and release run this exact
+command on Linux.
+
+| Journey | Real OpenTUI route | Contract pinned |
+| --- | --- | --- |
+| Help and settings | Workspace → `F1` Help → close → Settings → close | Global modal and sidebar page transitions return to the live Workspace. |
+| Worktree audit | Workspace sidebar → Worktrees → close | The daemon-backed Worktrees page loads from the real fixture and returns safely. |
+| Story detail | Workspace sidebar → Kanban → select fixture card → detail drawer → close | Board selection reaches the persisted story detail without mutating it. |
+| Story intake | Workspace sidebar → Kanban → New Story → title and description | The creation drawer accepts real terminal input; its completed state is screenshot-pinned as `kanban-new-issue.png`. |
+
+Ports derive from `KOBE_VISUAL_PORT_BASE` (default 5273); a busy port fails
+fast — never reuse a stray server, and never point the fixture at a real HOME
+or the shared `.dev-sandbox/home`. Local Terminal screenshots, native
+`kobe-web` pages such as `/board`, render-test frames, and `dev:mock` cannot
+approve visual changes; `test:e2e` (dev:mock) stays a PTY-transport smoke only.
+Failure artifacts land in `packages/kobe-web/test-results/` (actual/diff/trace).
 
 ## Terminal endurance probe
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,8 +1,17 @@
-# kobe — Phase 0 → Phase 1 Plan
+# kobe — archived Phase 0 → Phase 1 delivery record
 
-> Read [`DESIGN.md`](./DESIGN.md) first. This document operationalizes it: what to build, in what order, by whom, with what dependencies.
+> **Status: closed.** Phase 1 shipped as v0.1.0 on 2026-05-09. This file is a
+> preserved delivery record for its dependency graph, gates, and prompt seeds;
+> it is not an active implementation plan.
 >
-> **Stack** (locked): TypeScript + `@opentui/core` + `@opentui/react` + React 19 + Bun. (Solid TUI removed 2026-07-07; `solid-js` kept only as reactive-signals primitives in the orchestrator/client core.)
+> For current implementation decisions, read [`DESIGN.md`](./DESIGN.md),
+> [`ARCHITECTURE.md`](./ARCHITECTURE.md), and
+> [`HARNESS.md`](./HARNESS.md). Shipped behavior lives in the
+> [`CHANGELOG`](../packages/kobe/CHANGELOG.md).
+>
+> Names, stack details, estimates, and instructions below are historical
+> snapshots. In particular, references to Solid, tmux fallback paths, or
+> direct-main work are not current policy.
 >
 > Plan model: **streams** that run in parallel, converging at named **integration points** where everything must land for a demoable milestone. Each stream is sized for one Claude Code agent in one focused session (~600–1500 LoC).
 

--- a/docs/WORK-TRACKING.md
+++ b/docs/WORK-TRACKING.md
@@ -47,7 +47,8 @@ Code changes still land their user-facing line as a **Changeset** (see [`RELEASI
 2. Check `git status --short` so user changes are not mistaken for agent changes.
 3. Make a focused change.
 4. Run the applicable checks from `docs/HARNESS.md`.
-5. Update `CHANGELOG.md` for user-visible changes.
+5. Add a Changeset for user-visible package behavior; the release workflow
+   updates `CHANGELOG.md`. Do not edit the generated changelog by hand.
 6. Commit when green, using the repository commit rules from `AGENTS.md`.
 
 ## Recording follow-ups

--- a/packages/kobe-web/e2e/sandbox.spec.ts
+++ b/packages/kobe-web/e2e/sandbox.spec.ts
@@ -90,8 +90,9 @@ test("Kanban fixture detail opens and returns through the real OpenTUI", async (
     await pressTerminal(terminal, "c")
     await expect(buffer).toContainText("Backlog fixture")
 
-    // The first cursor key anchors the board's selection on the first card.
-    await pressTerminal(terminal, "ArrowDown")
+    // Kanban opens focused on the fixture task's linked card; move to the
+    // independent Backlog card before opening its editable detail drawer.
+    await pressTerminal(terminal, "ArrowLeft")
     await pressTerminal(terminal, "Enter")
     await expect(buffer).toContainText("#1")
     await expect(buffer).toContainText("Waiting to start.")

--- a/packages/kobe-web/e2e/sandbox.spec.ts
+++ b/packages/kobe-web/e2e/sandbox.spec.ts
@@ -67,6 +67,44 @@ test("workspace help and settings render in the real OpenTUI", async ({ page }) 
   })
 })
 
+test("worktree audit opens and returns through the real OpenTUI", async ({ page }) => {
+  test.skip(process.env.KOBE_VISUAL !== "1", "visual ground-truth only")
+
+  await withVisualTui(page, async (terminal, buffer) => {
+    await terminal.click({ position: { x: 24, y: 24 } })
+    await pressTerminal(terminal, "x")
+
+    await expect(buffer).toContainText("Worktrees")
+    await expect(buffer).toContainText("fixture-repo", { timeout: 45_000 })
+
+    await pressTerminal(terminal, "Escape")
+    await expect(buffer).toContainText("Visual Fixture")
+  })
+})
+
+test("Kanban fixture detail opens and returns through the real OpenTUI", async ({ page }) => {
+  test.skip(process.env.KOBE_VISUAL !== "1", "visual ground-truth only")
+
+  await withVisualTui(page, async (terminal, buffer) => {
+    await terminal.click({ position: { x: 24, y: 24 } })
+    await pressTerminal(terminal, "c")
+    await expect(buffer).toContainText("Backlog fixture")
+
+    // The first cursor key anchors the board's selection on the first card.
+    await pressTerminal(terminal, "ArrowDown")
+    await pressTerminal(terminal, "Enter")
+    await expect(buffer).toContainText("#1")
+    await expect(buffer).toContainText("Waiting to start.")
+    await expect(buffer).toContainText("WORKSPACE")
+
+    await pressTerminal(terminal, "Escape")
+    await expect(buffer).toContainText("Kanban")
+    await expect(buffer).toContainText("Backlog fixture")
+    await pressTerminal(terminal, "Escape")
+    await expect(buffer).toContainText("Visual Fixture")
+  })
+})
+
 test("Kanban new issue intake renders in the real OpenTUI", async ({ page }) => {
   test.skip(process.env.KOBE_VISUAL !== "1", "visual ground-truth only")
 

--- a/packages/kobe-web/e2e/visual-fixture.ts
+++ b/packages/kobe-web/e2e/visual-fixture.ts
@@ -14,7 +14,7 @@ export const VISUAL_HOME = join(VISUAL_ROOT, "home")
 export const VISUAL_REPO = join(VISUAL_ROOT, "fixture-repo")
 
 /** Bump when the fixture shape changes so warm reuse rebuilds. */
-const FIXTURE_VERSION = "1"
+const FIXTURE_VERSION = "2"
 const FIXTURE_MARKER = join(VISUAL_ROOT, "fixture-ok")
 
 // Inlined into the PTY command: the child runs under `/bin/sh -lc`, and a
@@ -99,10 +99,14 @@ async function seedStartupState(): Promise<void> {
     skillVersion = undefined
   }
 
-  const state: Record<string, string | boolean> = {
+  const state: Record<string, string | boolean | string[]> = {
     "app.lastRunVersion": packageJson.version,
     onboarded: true,
     skillHintSeen: "1",
+    // The Worktrees page audits saved projects rather than task rows. Keep
+    // the fixture repo in this independent registry so that visual journey
+    // exercises the real daemon-backed audit instead of its empty state.
+    savedRepos: [VISUAL_REPO],
   }
   if (skillVersion) state[`skillHintSeen:v${skillVersion}`] = "1"
   const stateDir = join(XDG_CONFIG_HOME, "kobe")

--- a/plans/README.md
+++ b/plans/README.md
@@ -17,7 +17,8 @@ Audit base: `81969596` (`0.8.2` release commit). Source changes are intentionall
 
 ## Execution policy
 
-- Work directly on `main` only because the owner explicitly requested it in the `/loop` invocation.
+- Land follow-up changes through the repository's PR-only mainline; this
+  historical audit does not authorize direct commits to `main`.
 - Complete and verify one coherent batch before the next: security, terminal correctness, async workspace correctness, accessibility/performance, architecture.
 - Add patch changesets for user-visible fixes. Combine notes only when one commit intentionally ships a single behavior group.
 - Stage only named files; preserve unrelated `.codex/` and landing-page assets.


### PR DESCRIPTION
## Summary
- mark stale delivery plans as historical and align contributor/work-tracking guidance with current policy
- document the independent browser-to-PTY OpenTUI journey matrix
- cover Worktrees and Kanban story-detail routes in the real visual harness

## Verification
- `bun run lint`
- `bun --filter kobe-web check`
- `bun run typecheck`
- `cd packages/kobe-web && bunx playwright test e2e/sandbox.spec.ts --list`

`bun --filter kobe-web test` still has three baseline failures in `server-session.test.ts` and `web-state-routes.test.ts`; this branch has no implementation diff under `packages/kobe-web/src`, `packages/kobe-web/test`, `packages/kobe/src`, or `packages/kobe-daemon/src`. That package test is not in the current PR CI matrix; the added real visual routes run in `visual-ground-truth`.