### PR TITLE
fix: count wide Enclosed Ideographic Supplement glyphs as two cells

### DIFF
--- a/.changeset/wide-enclosed-ideographic-width.md
+++ b/.changeset/wide-enclosed-ideographic-width.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix cell-width measurement for Enclosed Ideographic Supplement glyphs (e.g. 🈚 🈯 🉐) and the 🀄/🃏 tile emoji so they count as two cells like other wide CJK/emoji characters — previously they under-counted as one cell, drifting every column to their right out of alignment in the `kobe export` table and the embedded-terminal cursor overlay.

--- a/packages/kobe/src/lib/display-width.ts
+++ b/packages/kobe/src/lib/display-width.ts
@@ -45,6 +45,9 @@ export function charWidth(cp: number): number {
     (cp >= 0xfe30 && cp <= 0xfe6f) || // CJK compatibility forms
     (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth forms
     (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+    cp === 0x1f004 || // Mahjong Tile Red Dragon (RGI emoji, EAW=W)
+    cp === 0x1f0cf || // Playing Card Black Joker (RGI emoji, EAW=W)
+    (cp >= 0x1f200 && cp <= 0x1f2ff) || // Enclosed Ideographic Supplement (EAW=W)
     (cp >= 0x1f300 && cp <= 0x1faff) || // emoji, symbols & pictographs
     (cp >= 0x20000 && cp <= 0x3fffd) // CJK Unified Ext B and beyond
   ) {

--- a/packages/kobe/test/lib/display-width.test.ts
+++ b/packages/kobe/test/lib/display-width.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 import { charWidth, displayWidth } from "../../src/lib/display-width.ts"
 
+/**
+ * Cell-width contract for `charWidth`/`displayWidth`. These feed the
+ * `kobe export` table renderer and the embedded-terminal cursor overlay, so an
+ * under-counted wide glyph drifts every cell to its right by one column — the
+ * exact misalignment the module exists to prevent.
+ */
 describe("charWidth", () => {
   it("counts plain ASCII / Latin as one cell", () => {
     expect(charWidth("a".codePointAt(0) as number)).toBe(1)
@@ -48,6 +54,20 @@ describe("charWidth", () => {
     expect(charWidth(0xfe19)).toBe(2) // presentation form for vertical horizontal ellipsis (0xfe10–0xfe19)
     expect(charWidth(0xfe30)).toBe(2) // CJK compatibility form (0xfe30–0xfe6f)
   })
+
+  it("counts the Enclosed Ideographic Supplement block as two cells", () => {
+    // Whole block (U+1F200–U+1F2FF) is East-Asian-Width = Wide; it sits just
+    // below the emoji range and was previously counted as one cell.
+    expect(charWidth(0x1f200)).toBe(2) // 🈀 square hiragana hoka
+    expect(charWidth(0x1f21a)).toBe(2) // 🈚 squared CJK "no charge"
+    expect(charWidth(0x1f22f)).toBe(2) // 🈯 squared CJK "reserved"
+    expect(charWidth(0x1f250)).toBe(2) // 🉐 circled ideograph "advantage"
+  })
+
+  it("counts the isolated Mahjong / playing-card emoji as two cells", () => {
+    expect(charWidth(0x1f004)).toBe(2) // 🀄 mahjong tile red dragon
+    expect(charWidth(0x1f0cf)).toBe(2) // 🃏 playing card black joker
+  })
 })
 
 describe("displayWidth", () => {
@@ -78,5 +98,10 @@ describe("displayWidth", () => {
     const ext = "𠀀" // U+20000, one wide code point stored as a surrogate pair
     expect(ext.length).toBe(2) // two UTF-16 units
     expect(displayWidth(ext)).toBe(2) // still two cells, not four
+  })
+
+  it("sums wide enclosed-ideograph glyphs over code points, not UTF-16 units", () => {
+    expect(displayWidth("🈚x")).toBe(3) // wide (2) + ascii (1)
+    expect(displayWidth("🀄🃏")).toBe(4)
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found cell-width bug in the shared `display-width` table, found while reviewing pure/testable logic under `packages/kobe/src`.

## Problem

`charWidth` (`packages/kobe/src/lib/display-width.ts`) starts its astral emoji/pictograph wide range at `0x1f300`. Two wide code-point groups sit **below** that boundary and fell through as **one** cell:

- **Enclosed Ideographic Supplement** — `U+1F200–U+1F2FF`. Every assigned code point in this block is East-Asian-Width = **Wide** (e.g. 🈚 `U+1F21A`, 🈯 `U+1F22F`, 🉐 `U+1F250`).
- The two isolated RGI tile/card emoji 🀄 `U+1F004` (Mahjong Tile Red Dragon) and 🃏 `U+1F0CF` (Playing Card Black Joker), both EAW = Wide.

Concretely, `displayWidth("🈚")` returned `1` instead of `2`. This table feeds the `kobe export` table renderer and the embedded-terminal cursor overlay, so an under-counted wide glyph drifts every cell to its right by one column — the exact misalignment class the module exists to prevent (same failure mode as the CJK/emoji width bugs it already documents).

## Fix

Add the missing wide ranges to `charWidth`, immediately before the existing `0x1f300–0x1faff` emoji range:

- `cp === 0x1f004` and `cp === 0x1f0cf` (the two isolated tile/card emoji; their surrounding Mahjong/Playing-card blocks are EAW = Neutral, so only these two are added)
- `0x1f200 <= cp <= 0x1f2ff` (the whole Enclosed Ideographic Supplement block — all assigned points are Wide, consistent with how the module already treats broad blocks as ranges)

No overlap with the in-flight Hangul-jamo/combining-half-marks width PR (#272) — entirely different code-point ranges.

## Verification

- Added `packages/kobe/test/lib/display-width.test.ts` pinning the width contract, including the newly-fixed ranges plus ASCII / core-CJK / emoji / combining-mark anchors (7 tests, green).
- Existing adjacent suites still green: `terminal-pty-unicode.test.ts`, `export-cmd.test.ts`, `truncate.test.ts`.
- `bun run lint` and `bun run typecheck` both green.

## Follow-ups (deferred, not in this slice)

- A lower-confidence review note flagged that `/`-search in the sidebar (`view-core.ts`) rejects astral characters (length-2 UTF-16), making emoji/rare-CJK filenames unsearchable. Out of scope here; noting for a future pass.