### PR TITLE
fix: keep external engine sessions out of Inbox

### DIFF
--- a/.changeset/calm-inbox-tabs.md
+++ b/.changeset/calm-inbox-tabs.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep globally hooked Codex and Claude sessions outside Kobe out of the attention Inbox while preserving their cwd-matched project activity status.

--- a/.changeset/calm-inbox-tabs.md
+++ b/.changeset/calm-inbox-tabs.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-Keep globally hooked Codex and Claude sessions outside Kobe out of the attention Inbox while preserving their cwd-matched project activity status.
+Keep engine events without exact Kobe task-and-tab identity out of the attention Inbox while preserving their cwd-matched project activity status.

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -105,6 +105,7 @@ export class AttentionInboxStore {
     detail: EngineActivityDetail | undefined,
     tabId: string,
   ): Promise<void> {
+    if (!tabId) throw new Error("AttentionInboxStore.record: tabId is required")
     await this.enqueue(async () => {
       const key = attentionInboxItemKey({ taskId, tabId })
       const next = new Map(this.items)
@@ -141,7 +142,7 @@ export class AttentionInboxStore {
     return await this.deleteEpisode(taskId, tabId, at)
   }
 
-  /** Delete only the episode the caller saw; omitted `at` keeps old clients compatible. */
+  /** Nullable tabId addresses legacy task-level data only; new writes require a tab. */
   async deleteEpisode(taskId: string, tabId: string | null, at?: number): Promise<boolean> {
     return await this.enqueue(async () => {
       const key = attentionInboxItemKey({ taskId, tabId })

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -99,10 +99,14 @@ export class AttentionInboxStore {
     return [...this.items.values()].sort(compareItems)
   }
 
-  async record(taskId: string, kind: EngineActivityKind, detail?: EngineActivityDetail, tabId?: string): Promise<void> {
+  async record(
+    taskId: string,
+    kind: EngineActivityKind,
+    detail: EngineActivityDetail | undefined,
+    tabId: string,
+  ): Promise<void> {
     await this.enqueue(async () => {
-      const normalizedTabId = tabId || null
-      const key = attentionInboxItemKey({ taskId, tabId: normalizedTabId })
+      const key = attentionInboxItemKey({ taskId, tabId })
       const next = new Map(this.items)
       if (kind === "turn-start") {
         if (!next.delete(key)) return
@@ -115,7 +119,7 @@ export class AttentionInboxStore {
         next.delete(key)
         next.set(key, {
           taskId,
-          tabId: normalizedTabId,
+          tabId,
           state,
           ...(detail ? { detail } : {}),
           // Every stored episode is pending by definition (opening removes

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -374,9 +374,8 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         const taskId = explicitId ?? (cwd ? matchTaskByCwd(ctx.orch.listTasks(), cwd) : undefined)
         if (!taskId) return {} // unmatched cwd → drop
         const detail = optionalActivityDetail(payload)
-        // Which engine tab the event came from — the inherited KOBE_TAB_ID env
-        // the hook process reported. Optional: sessions kobe didn't spawn as a
-        // tab stay task-level.
+        // Which engine tab the event came from — the inherited KOBE_TAB_ID env.
+        // Sessions outside a Kobe tab remain activity-only via the report below.
         const tabId = optionalString(payload, "tabId")
         // The engine's own session identity, from its hook payload (Claude
         // pipes session_id/transcript_path). Optional + additive: an old
@@ -385,7 +384,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         const transcriptPath = optionalString(payload, "transcriptPath")
         const session = sessionId ? { id: sessionId, transcriptPath } : undefined
         ctx.activity.report(taskId, kind, detail, tabId, session)
-        // Kobe tabs provide task+tab IDs; keep cwd-inferred activity visible without making it Inbox-navigable.
+        // Kobe tabs provide both IDs; cwd-only and legacy task-only hooks are not Inbox-navigable.
         if (explicitId && tabId) {
           await ctx.inbox
             .record(taskId, kind, detail, tabId)

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -385,7 +385,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         const transcriptPath = optionalString(payload, "transcriptPath")
         const session = sessionId ? { id: sessionId, transcriptPath } : undefined
         ctx.activity.report(taskId, kind, detail, tabId, session)
-        // Keep cwd-inferred activity, but only exact kobe tab identity belongs in the navigable Inbox.
+        // Kobe tabs provide task+tab IDs; keep cwd-inferred activity visible without making it Inbox-navigable.
         if (explicitId && tabId) {
           await ctx.inbox
             .record(taskId, kind, detail, tabId)

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -385,10 +385,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         const transcriptPath = optionalString(payload, "transcriptPath")
         const session = sessionId ? { id: sessionId, transcriptPath } : undefined
         ctx.activity.report(taskId, kind, detail, tabId, session)
-        // Activity remains cwd-aware so externally-started engines can light up
-        // the tracked project row. The Inbox is tab navigation, though: only a
-        // kobe-spawned tab carries BOTH exact identity fields. A cwd-inferred
-        // external session has neither and must not create a task-level episode.
+        // Keep cwd-inferred activity, but only exact kobe tab identity belongs in the navigable Inbox.
         if (explicitId && tabId) {
           await ctx.inbox
             .record(taskId, kind, detail, tabId)

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -385,9 +385,15 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         const transcriptPath = optionalString(payload, "transcriptPath")
         const session = sessionId ? { id: sessionId, transcriptPath } : undefined
         ctx.activity.report(taskId, kind, detail, tabId, session)
-        await ctx.inbox
-          .record(taskId, kind, detail, tabId)
-          .catch((err) => logDaemonError("attention-inbox-record", err))
+        // Activity remains cwd-aware so externally-started engines can light up
+        // the tracked project row. The Inbox is tab navigation, though: only a
+        // kobe-spawned tab carries BOTH exact identity fields. A cwd-inferred
+        // external session has neither and must not create a task-level episode.
+        if (explicitId && tabId) {
+          await ctx.inbox
+            .record(taskId, kind, detail, tabId)
+            .catch((err) => logDaemonError("attention-inbox-record", err))
+        }
         // Auto status flow (docs/design/web-kanban.md M5): an engine
         // STARTING a turn on a backlog task means work began — a pure rule
         // advances it to in_progress. (in_progress → in_review is the

--- a/packages/kobe/bunfig.toml
+++ b/packages/kobe/bunfig.toml
@@ -1,2 +1,7 @@
 [install]
 exact = true
+
+[test]
+# Render coverage owns the Kobe package UI surface. Daemon sources have their
+# own Vitest coverage report and must not be re-reported as uncovered here.
+coveragePathIgnorePatterns = ["../kobe-daemon/**"]

--- a/packages/kobe/test/daemon/attention-inbox-invariants.test.ts
+++ b/packages/kobe/test/daemon/attention-inbox-invariants.test.ts
@@ -13,17 +13,17 @@ describe("attention inbox store invariants", () => {
     dir = null
   })
 
-  it("normalizes an empty tab id before storing and indexing an episode", async () => {
+  it("stores and indexes a new episode under its required tab identity", async () => {
     dir = await mkdtemp(join(tmpdir(), "kobe-attention-inbox-invariants-"))
     const store = new AttentionInboxStore(join(dir, "attention-inbox.json"), new DaemonEventBus(), () => 100)
     await store.init()
 
-    await store.record("task-1", "turn-complete", undefined, "")
+    await store.record("task-1", "turn-complete", undefined, "tab-1")
 
     expect(store.snapshot()).toEqual([
-      expect.objectContaining({ taskId: "task-1", tabId: null, state: "turn_complete", at: 100 }),
+      expect.objectContaining({ taskId: "task-1", tabId: "tab-1", state: "turn_complete", at: 100 }),
     ])
-    expect(await store.markRead("task-1", null, 100)).toBe(true)
+    expect(await store.markRead("task-1", "tab-1", 100)).toBe(true)
   })
 
   it("does not delete a replacement episode through a stale dismiss action", async () => {

--- a/packages/kobe/test/daemon/attention-inbox-invariants.test.ts
+++ b/packages/kobe/test/daemon/attention-inbox-invariants.test.ts
@@ -26,6 +26,15 @@ describe("attention inbox store invariants", () => {
     expect(await store.markRead("task-1", "tab-1", 100)).toBe(true)
   })
 
+  it("rejects an empty tab identity before writing an episode", async () => {
+    dir = await mkdtemp(join(tmpdir(), "kobe-attention-inbox-invariants-"))
+    const store = new AttentionInboxStore(join(dir, "attention-inbox.json"), new DaemonEventBus())
+    await store.init()
+
+    await expect(store.record("task-1", "turn-complete", undefined, "")).rejects.toThrow("tabId is required")
+    expect(store.snapshot()).toEqual([])
+  })
+
   it("does not delete a replacement episode through a stale dismiss action", async () => {
     let now = 100
     dir = await mkdtemp(join(tmpdir(), "kobe-attention-inbox-invariants-"))

--- a/packages/kobe/test/daemon/handlers-attention.test.ts
+++ b/packages/kobe/test/daemon/handlers-attention.test.ts
@@ -62,6 +62,14 @@ describe("attention.dismiss handler", () => {
     expect(rec.inboxRecords).toEqual([])
   })
 
+  it("rejects an orphaned tabId without exact task identity", async () => {
+    const { ctx, rec } = fakeCtx({ listTasks: () => [{ id: "t1", worktreePath: "/repo" }] })
+    await dispatch("engine.reportEvent", { cwd: "/repo/src", tabId: "tab-9", kind: "turn-complete" }, ctx)
+
+    expect(rec.reported).toEqual([{ taskId: "t1", kind: "turn-complete", detail: undefined }])
+    expect(rec.inboxRecords).toEqual([])
+  })
+
   it("requires a tabId before recording an explicitly attributed event", async () => {
     const { ctx, rec } = fakeCtx()
     await dispatch("engine.reportEvent", { taskId: "t1", kind: "turn-complete" }, ctx)

--- a/packages/kobe/test/daemon/handlers-attention.test.ts
+++ b/packages/kobe/test/daemon/handlers-attention.test.ts
@@ -64,6 +64,7 @@ describe("attention.dismiss handler", () => {
 
   it("rejects an orphaned tabId without exact task identity", async () => {
     const { ctx, rec } = fakeCtx({ listTasks: () => [{ id: "t1", worktreePath: "/repo" }] })
+    // This value makes the test distinguish the intended AND gate from an accidental OR.
     await dispatch("engine.reportEvent", { cwd: "/repo/src", tabId: "tab-9", kind: "turn-complete" }, ctx)
 
     expect(rec.reported).toEqual([{ taskId: "t1", kind: "turn-complete", detail: undefined }])

--- a/packages/kobe/test/daemon/handlers-attention.test.ts
+++ b/packages/kobe/test/daemon/handlers-attention.test.ts
@@ -54,6 +54,22 @@ describe("attention.dismiss handler", () => {
     expect(rec.inboxRecords).toEqual([{ taskId: "t1", kind: "awaiting-input", detail: undefined, tabId: "tab-3" }])
   })
 
+  it("keeps cwd-matched external engine events out of the Inbox", async () => {
+    const { ctx, rec } = fakeCtx({ listTasks: () => [{ id: "t1", worktreePath: "/repo" }] })
+    await dispatch("engine.reportEvent", { cwd: "/repo/src", kind: "turn-complete" }, ctx)
+
+    expect(rec.reported).toEqual([{ taskId: "t1", kind: "turn-complete", detail: undefined }])
+    expect(rec.inboxRecords).toEqual([])
+  })
+
+  it("requires a tabId before recording an explicitly attributed event", async () => {
+    const { ctx, rec } = fakeCtx()
+    await dispatch("engine.reportEvent", { taskId: "t1", kind: "turn-complete" }, ctx)
+
+    expect(rec.reported).toEqual([{ taskId: "t1", kind: "turn-complete", detail: undefined }])
+    expect(rec.inboxRecords).toEqual([])
+  })
+
   it("does not drop the engine event when Inbox persistence fails", async () => {
     const { ctx, rec } = fakeCtx()
     ctx.inbox.record = async () => {


### PR DESCRIPTION
## Summary

- keep cwd-matched external engine activity available to project status
- persist Inbox episodes only when an event has exact Kobe task and tab identity
- require tab identity at the AttentionInboxStore write boundary while retaining legacy task-level episode reads
- cover all four taskId/tabId truth-table cells with daemon handler regressions

## Verification

- bun run lint
- bun run typecheck
- bun run test: 2305 fast tests and 300 daemon tests passed
- bun run build
- 55 targeted Inbox/handler tests passed
- touched files remain below the 500-line cap

## Compatibility note

Legacy or manual hook events that provide taskId without KOBE_TAB_ID continue to update task activity but no longer create a task-level Inbox episode. Existing persisted tabId:null episodes remain readable and dismissible.

## Local environment note

The unrelated pure-tui-open-worktree behavior test intermittently misses its initial key because it waits for the PROJECTS paint rather than handler readiness. It passed in isolation and in PR CI; the final commit CI result is authoritative.