### PR TITLE
Align Inbox wording with pending queue behavior

### DIFF
--- a/.changeset/quiet-inbox-wording.md
+++ b/.changeset/quiet-inbox-wording.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Align Inbox help, fallback copy, and internal documentation with the pending queue model: opening or visiting an episode resolves it instead of retaining a read item.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -24,7 +24,7 @@ Default prefix actions:
 | Sequence | Action |
 |---|---|
 | `ctrl+a`, `f` | Quick-fork a child task |
-| `ctrl+a`, `i` | Open the attention Inbox dialog (PROPOSED; awaiting owner confirmation) |
+| `ctrl+a`, `i` | Open the attention Inbox dialog |
 | `ctrl+a`, `y` | Resume a prior engine Session |
 | `ctrl+a`, `j` | Cycle focus backward (Files → Workspace → Sidebar) |
 | `ctrl+a`, `k` | Cycle focus forward (Sidebar → Workspace → Files) |
@@ -46,7 +46,7 @@ High-frequency tab actions remain direct: `ctrl+t`, `ctrl+e`, `ctrl+w`,
 | `F4` | Cycle focus forward |
 | `F5` | Confirm and reset the active terminal |
 | `F6` | Toggle zen mode |
-| `F7` | Open the next unread Inbox episode across every project and the current task's other tabs. Opening marks it read but does not remove it; read episodes remain available in the Inbox dialog. |
+| `F7` | Open the next available pending Inbox episode across every project and the current task's other tabs. Opening or visiting its target removes the episode from the queue. |
 | `ctrl+t` | New engine tab |
 | `ctrl+e` | New tab with engine/shell picker |
 | `ctrl+w` | Close active split, otherwise close tab |
@@ -75,13 +75,15 @@ branch, `v` change engine, `/` search, and `[`/`]` switch Working/Archives.
 Common Files actions include `j/k` navigation, `h/l` collapse/expand, `enter`
 preview, `e` open in the configured editor, and `[`/`]` switch file tabs.
 
-The Inbox is a modal dialog opened with the proposed `prefix+i` sequence. Unread
-episodes sort ahead of retained read episodes. Inside
-the dialog, `j/k` selects, `enter` jumps to the task/chat tab, and `d` deletes
-that attention episode. Opening marks its unread dot read; only a newer turn in
-the same tab or `d` removes it. Owner decision (2026-07-15): `d` is direct and
-dialog-scoped because deletion is a frequent, explicit cleanup action there;
-it cannot shadow chat input or embedded-terminal shortcuts outside the dialog.
+The Inbox is a modal dialog opened with `prefix+i`. Every row is a pending
+episode, ordered oldest first. Inside the dialog, `j/k` selects, `enter` jumps
+to the task/chat tab and removes that episode from the queue, and `d` deletes
+it without navigating. Landing on a task/chat tab also resolves matching
+episodes because visiting means handled. A newer episode for the same task and
+tab replaces the older one and moves to the end of the queue. Owner decision
+(2026-07-15): `d` is direct and dialog-scoped because deletion is a frequent,
+explicit cleanup action there; it cannot shadow chat input or
+embedded-terminal shortcuts outside the dialog.
 
 ## User customization
 

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -2,10 +2,11 @@
  * Durable, daemon-owned attention Inbox.
  *
  * Live engine activity and Inbox retention are deliberately different state:
- * activity may idle on session close/archive, while an unresolved episode must
- * remain until that exact task+tab starts another turn, the user dismisses it,
- * or the containing task is explicitly hard-deleted. The store persists a
- * full snapshot so daemon/TUI reconnects cannot consume work by accident.
+ * activity may idle on session close/archive, while a pending episode remains
+ * until its target is visited/opened, the user dismisses it, that task+tab
+ * starts another turn, or the containing task is explicitly hard-deleted. The
+ * store persists a full snapshot so daemon/TUI reconnects cannot consume work
+ * by accident.
  */
 
 import { randomUUID } from "node:crypto"
@@ -51,7 +52,8 @@ function normalizeItem(value: unknown): AttentionInboxItem | null {
     tabId: item.tabId,
     state: item.state,
     ...(item.detail ? { detail: item.detail } : {}),
-    // Snapshots written before unread tracking are unresolved by definition.
+    // All retained episodes are pending. Preserve the compatibility field
+    // when loading snapshots, but the queue model no longer reads it.
     unread: item.unread !== false,
     at: item.at,
   }

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -126,7 +126,7 @@ export interface EngineActivityDetail {
 
 export type TaskActivityState = "idle" | "running" | "turn_complete" | "rate_limited" | "permission_needed" | "error"
 
-/** States retained as unresolved Inbox episodes until a newer same-tab turn starts. */
+/** States retained as pending Inbox episodes until handled or replaced by a newer same-tab event. */
 export const ATTENTION_INBOX_STATES = [
   "turn_complete",
   "permission_needed",
@@ -151,7 +151,7 @@ export interface AttentionInboxItem {
   readonly tabId: string | null
   readonly state: AttentionInboxState
   readonly detail?: EngineActivityDetail
-  /** Cleared only when this exact episode is opened; survives reconnects. */
+  /** Compatibility field ignored by the queue model; new episodes set it to `true`. */
   readonly unread: boolean
   /** Event time, epoch milliseconds. Stable across daemon/TUI restarts. */
   readonly at: number

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -102,7 +102,7 @@ export async function dismissAttentionOp(
   return res.deleted
 }
 
-/** Persist that the user opened this exact attention episode. */
+/** Legacy compatibility alias: resolving this exact episode removes it. */
 export async function markAttentionReadOp(
   client: KobeDaemonClient,
   taskId: TaskId | string,

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -6,9 +6,9 @@
  *     crossed into an attention state (permission_needed / error / turn_complete).
  *     The selected task already surfaces its own state in the middle column, so
  *     it's skipped. Gated by the `notifications.crossTask.enabled` preference.
- *  2. Jump-to-next — F7 walks only unread episodes in the daemon-owned durable
- *     Inbox. Opening marks the episode read without removing it; removal comes
- *     from same-tab turn-start, explicit deletion, or task hard-delete.
+ *  2. Jump-to-next — F7 walks available pending episodes in the daemon-owned
+ *     durable Inbox. Opening or visiting the target resolves the episode and
+ *     removes it from the queue.
  *
  * State is engine-owned and vendor-neutral: `TaskEngineState.state` and the
  * Inbox state are the only inputs, so there are no Claude/Codex strings here.
@@ -34,7 +34,7 @@ export function useAttention(args: {
   kv: KVContext
   notif: NotificationsContext
   openAttention: (item: AttentionInboxItem) => void
-  /** i18n'd toast shown when the chord finds no unread Inbox episode. */
+  /** i18n'd toast shown when the chord finds no available pending Inbox episode. */
   noTasksMessage: string
 }): { jumpToNextAttention: () => void } {
   const { tasks, engineState, inboxItems, selectedId, kv, notif, openAttention, noTasksMessage } = args

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -247,9 +247,8 @@ export const KobeKeymap: readonly KobeBinding[] = [
     hint: { keys: "f4" },
   },
   {
-    // Jump to the next unread durable Inbox episode. Read episodes remain in
-    // the Inbox dialog until work restarts or the user deletes them, but F7
-    // does not revisit them. `f7`
+    // Jump to the next available pending durable Inbox episode. Opening or
+    // visiting the target resolves it and removes it from the queue. `f7`
     // continues kobe's F-row (F2 rename / F3 split / F4 pane-cycle / F5 reset
     // / F6 zen) — the only chord tier that fires from inside the embedded
     // terminal without stealing an engine chord. NOT `ctrl+g`: that's the
@@ -261,7 +260,7 @@ export const KobeKeymap: readonly KobeBinding[] = [
     scope: "global",
     keys: ["f7"],
     category: "Navigation",
-    description: "Open the next unread Inbox item",
+    description: "Open the next pending Inbox item",
     hint: { keys: "f7" },
   },
   {

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -14,12 +14,10 @@ export const en = {
     selectTask: "Select a task with a worktree",
   },
   attention: {
-    none: "No unread Inbox items",
+    none: "No pending Inbox items",
   },
   inbox: {
     title: "INBOX",
-    unread: "Unread",
-    all: "All",
     empty: "No pending attention",
     unavailable: "unavailable",
     openHint: "enter open",
@@ -44,12 +42,10 @@ export const zh: typeof en = {
     selectTask: "请选择一个带 worktree 的任务",
   },
   attention: {
-    none: "收件箱没有未读内容",
+    none: "收件箱没有待处理内容",
   },
   inbox: {
     title: "收件箱",
-    unread: "未读",
-    all: "全部",
     empty: "暂无待处理",
     unavailable: "目标不可用",
     openHint: "enter 打开",

--- a/packages/kobe/test/render/use-attention.test.tsx
+++ b/packages/kobe/test/render/use-attention.test.tsx
@@ -39,7 +39,7 @@ function notifications(notify: NotificationsContext["notify"]): NotificationsCon
 afterEach(() => tabsByTask.clear())
 
 describe("useAttention", () => {
-  it("jumps from the current chat tab to the next unread live task", async () => {
+  it("jumps from the current chat tab to the next pending live task", async () => {
     const tasks = [task("task-a", "Alpha"), task("task-b", "Beta"), task("task-c", "Archived", true)]
     const opened: AttentionInboxItem[] = []
     let jump: (() => void) | undefined
@@ -58,7 +58,7 @@ describe("useAttention", () => {
         kv: kv(),
         notif: notifications(() => {}),
         openAttention: (item) => opened.push(item),
-        noTasksMessage: "No unread attention",
+        noTasksMessage: "No pending attention",
       }).jumpToNextAttention
       return <text>ready</text>
     }
@@ -84,7 +84,7 @@ describe("useAttention", () => {
         kv: kv(),
         notif: notifications((notice) => notices.push(notice)),
         openAttention: () => {},
-        noTasksMessage: "No unread attention",
+        noTasksMessage: "No pending attention",
       }).jumpToNextAttention
       return <text>ready</text>
     }
@@ -92,7 +92,7 @@ describe("useAttention", () => {
     await renderComponent(<Probe />)
     act(() => jump?.())
 
-    expect(notices).toEqual([{ kind: "done", taskId: "task-a", tabId: "", title: "No unread attention" }])
+    expect(notices).toEqual([{ kind: "done", taskId: "task-a", tabId: "", title: "No pending attention" }])
   })
 
   it("notifies only on a non-selected task's rising attention edge", async () => {
@@ -113,7 +113,7 @@ describe("useAttention", () => {
         kv: kv(),
         notif: notifications((notice) => notices.push(notice)),
         openAttention: () => {},
-        noTasksMessage: "No unread attention",
+        noTasksMessage: "No pending attention",
       })
       return <text>ready</text>
     }
@@ -144,7 +144,7 @@ describe("useAttention", () => {
         kv: kv(false),
         notif: notifications((notice) => notices.push(notice)),
         openAttention: () => {},
-        noTasksMessage: "No unread attention",
+        noTasksMessage: "No pending attention",
       })
       return <text>ready</text>
     }


### PR DESCRIPTION
## Summary
- update keybinding docs and F1 help to describe pending Inbox episodes
- align English/Chinese fallback copy and remove unused Unread/All labels
- refresh daemon/client comments and render-test wording for open/visit resolution

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test` (2305 fast tests, 301 socket tests)
- `cd packages/kobe && bun run build && bun run test:behavior` (13 tests)
- `cd packages/kobe && bun test test/render/use-attention.test.tsx` (4 tests)