### PR TITLE
Polish Inbox copy and lifecycle terminology

### DIFF
--- a/.changeset/clear-inbox-copy.md
+++ b/.changeset/clear-inbox-copy.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Clarify Inbox help and fallback messages by distinguishing opening the queue from jumping to an available item and by using the canonical Task and Terminal Tab terminology.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -24,7 +24,7 @@ Default prefix actions:
 | Sequence | Action |
 |---|---|
 | `ctrl+a`, `f` | Quick-fork a child task |
-| `ctrl+a`, `i` | Open the attention Inbox dialog |
+| `ctrl+a`, `i` | Open the Inbox dialog |
 | `ctrl+a`, `y` | Resume a prior engine Session |
 | `ctrl+a`, `j` | Cycle focus backward (Files → Workspace → Sidebar) |
 | `ctrl+a`, `k` | Cycle focus forward (Sidebar → Workspace → Files) |
@@ -46,7 +46,7 @@ High-frequency tab actions remain direct: `ctrl+t`, `ctrl+e`, `ctrl+w`,
 | `F4` | Cycle focus forward |
 | `F5` | Confirm and reset the active terminal |
 | `F6` | Toggle zen mode |
-| `F7` | Open the next available pending Inbox episode across every project and the current task's other tabs. Opening or visiting its target removes the episode from the queue. |
+| `F7` | Jump to the next available Inbox item across all projects, Tasks, and Terminal Tabs. Visiting its target removes the item from the queue. |
 | `ctrl+t` | New engine tab |
 | `ctrl+e` | New tab with engine/shell picker |
 | `ctrl+w` | Close active split, otherwise close tab |
@@ -76,14 +76,14 @@ Common Files actions include `j/k` navigation, `h/l` collapse/expand, `enter`
 preview, `e` open in the configured editor, and `[`/`]` switch file tabs.
 
 The Inbox is a modal dialog opened with `prefix+i`. Every row is a pending
-episode, ordered oldest first. Inside the dialog, `j/k` selects, `enter` jumps
-to the task/chat tab and removes that episode from the queue, and `d` deletes
-it without navigating. Landing on a task/chat tab also resolves matching
-episodes because visiting means handled. A newer episode for the same task and
-tab replaces the older one and moves to the end of the queue. Owner decision
-(2026-07-15): `d` is direct and dialog-scoped because deletion is a frequent,
-explicit cleanup action there; it cannot shadow chat input or
-embedded-terminal shortcuts outside the dialog.
+item, ordered oldest first. Inside the dialog, `j/k` selects. `enter` opens the
+target Task and Terminal Tab when available; either way, it removes the item
+from the queue. `d` removes it without navigating. Landing on a target also
+removes matching items because visiting means handled. A newer item for the
+same Task and Terminal Tab replaces the older one and moves to the end of the
+queue. Owner decision (2026-07-15): `d` is direct and dialog-scoped because
+removal is a frequent, explicit cleanup action there; it cannot shadow input
+or embedded-terminal shortcuts outside the dialog.
 
 ## User customization
 

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -2,11 +2,11 @@
  * Durable, daemon-owned attention Inbox.
  *
  * Live engine activity and Inbox retention are deliberately different state:
- * activity may idle on session close/archive, while a pending episode remains
- * until its target is visited/opened, the user dismisses it, that task+tab
- * starts another turn, or the containing task is explicitly hard-deleted. The
- * store persists a full snapshot so daemon/TUI reconnects cannot consume work
- * by accident.
+ * activity may idle on session close/archive, while the durable queue survives
+ * daemon restarts. An item leaves when its target is visited/opened, the user
+ * removes it, that Task and Terminal Tab start another turn, or the containing
+ * Task is hard-deleted. A newer attention event for the same target replaces
+ * the older item at the end of the queue.
  */
 
 import { randomUUID } from "node:crypto"

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -126,7 +126,8 @@ export interface EngineActivityDetail {
 
 export type TaskActivityState = "idle" | "running" | "turn_complete" | "rate_limited" | "permission_needed" | "error"
 
-/** States retained as pending Inbox episodes until handled or replaced by a newer same-tab event. */
+/** States represented by pending Inbox items until handled or the same
+ * Terminal Tab starts another turn. */
 export const ATTENTION_INBOX_STATES = [
   "turn_complete",
   "permission_needed",

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -156,10 +156,10 @@ export type DaemonRequestName =
   // normalized engine activity event for a task; the daemon folds it into
   // the task's transient activity state and broadcasts `engine-state`.
   | "engine.reportEvent"
-  // Explicitly dismiss the durable attention episode at the supplied event
-  // timestamp. Viewing/jumping never calls this; only the Inbox action does.
+  // Remove the durable Inbox item at the supplied event timestamp. Explicit
+  // removal, opening, and visiting the target all use this guarded operation.
   | "attention.dismiss"
-  // Mark the exact opened episode read; `at` guards against stale opens.
+  // Legacy alias for resolving the exact item; `at` guards stale clients.
   | "attention.read"
   // Dispatcher messenger (docs/design/dispatcher.md): publish a
   // `session.deliver` channel event addressed to a task's live session.

--- a/packages/kobe/src/tui-react/workspace/inbox-open-action.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-open-action.ts
@@ -4,9 +4,9 @@ import { notifyInboxRpcFailure } from "./inbox-rpc-errors"
 type InboxOpenRpc = Pick<RemoteOrchestrator, "dismissAttention">
 
 /**
- * Opening an episode RESOLVES it: the item is removed from the Inbox
+ * Opening an item RESOLVES it: the item is removed from the Inbox
  * (no read/unread lifecycle — owner call 2026-07-16). A fresh event on the
- * same task+tab re-records it as a new episode at the latest position.
+ * same Task and Terminal Tab records a new item at the latest position.
  * Unavailable items are stale UI state and resolve the same way.
  */
 export function requestInboxItemOpen(

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -6,8 +6,8 @@
  *     crossed into an attention state (permission_needed / error / turn_complete).
  *     The selected task already surfaces its own state in the middle column, so
  *     it's skipped. Gated by the `notifications.crossTask.enabled` preference.
- *  2. Jump-to-next — F7 walks available pending episodes in the daemon-owned
- *     durable Inbox. Opening or visiting the target resolves the episode and
+ *  2. Jump-to-next — F7 walks available pending items in the daemon-owned
+ *     durable Inbox. Opening or visiting the target resolves the item and
  *     removes it from the queue.
  *
  * State is engine-owned and vendor-neutral: `TaskEngineState.state` and the
@@ -34,7 +34,7 @@ export function useAttention(args: {
   kv: KVContext
   notif: NotificationsContext
   openAttention: (item: AttentionInboxItem) => void
-  /** i18n'd toast shown when the chord finds no available pending Inbox episode. */
+  /** i18n'd toast shown when the chord finds no available Inbox item. */
   noTasksMessage: string
 }): { jumpToNextAttention: () => void } {
   const { tasks, engineState, inboxItems, selectedId, kv, notif, openAttention, noTasksMessage } = args

--- a/packages/kobe/src/tui/context/keybindings-inbox.ts
+++ b/packages/kobe/src/tui/context/keybindings-inbox.ts
@@ -7,7 +7,7 @@ export const INBOX_BINDINGS: readonly KobeBinding[] = [
     keys: [],
     prefixKeys: ["i"],
     category: "Global",
-    description: "Open attention Inbox",
+    description: "Open Inbox",
   },
   {
     id: "inbox.nav",
@@ -22,7 +22,7 @@ export const INBOX_BINDINGS: readonly KobeBinding[] = [
     scope: "inbox",
     keys: ["return"],
     category: "Inbox",
-    description: "Open the selected task and chat tab",
+    description: "Open the selected Task and Terminal Tab",
     hint: { keys: "enter" },
   },
   {
@@ -30,7 +30,7 @@ export const INBOX_BINDINGS: readonly KobeBinding[] = [
     scope: "inbox",
     keys: ["d"],
     category: "Inbox",
-    description: "Delete the selected attention episode",
+    description: "Remove the selected Inbox item",
     hint: { keys: "d" },
   },
 ]

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -247,8 +247,8 @@ export const KobeKeymap: readonly KobeBinding[] = [
     hint: { keys: "f4" },
   },
   {
-    // Jump to the next available pending durable Inbox episode. Opening or
-    // visiting the target resolves it and removes it from the queue. `f7`
+    // Jump to the next available durable Inbox item. Opening or visiting the
+    // target resolves it and removes it from the queue. `f7`
     // continues kobe's F-row (F2 rename / F3 split / F4 pane-cycle / F5 reset
     // / F6 zen) — the only chord tier that fires from inside the embedded
     // terminal without stealing an engine chord. NOT `ctrl+g`: that's the
@@ -260,7 +260,7 @@ export const KobeKeymap: readonly KobeBinding[] = [
     scope: "global",
     keys: ["f7"],
     category: "Navigation",
-    description: "Open the next pending Inbox item",
+    description: "Jump to the next available Inbox item",
     hint: { keys: "f7" },
   },
   {

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -14,7 +14,7 @@ export const en = {
     selectTask: "Select a task with a worktree",
   },
   attention: {
-    none: "No pending Inbox items",
+    none: "No available Inbox items",
   },
   inbox: {
     title: "INBOX",
@@ -42,7 +42,7 @@ export const zh: typeof en = {
     selectTask: "请选择一个带 worktree 的任务",
   },
   attention: {
-    none: "收件箱没有待处理内容",
+    none: "收件箱中没有可打开的项目",
   },
   inbox: {
     title: "收件箱",

--- a/packages/kobe/test/daemon/handlers-attention.test.ts
+++ b/packages/kobe/test/daemon/handlers-attention.test.ts
@@ -11,8 +11,8 @@ function dispatch(name: DaemonRequestName, payload: unknown, ctx: DaemonHandlerC
   return dispatchDaemonRequest(createDaemonHandlerRegistry(), name, payload, ctx)
 }
 
-describe("attention.dismiss handler", () => {
-  it("marks the exact opened episode read", async () => {
+describe("attention Inbox handlers", () => {
+  it("resolves the exact item through the legacy attention.read alias", async () => {
     const { ctx, rec } = fakeCtx()
     await expect(dispatch("attention.read", { taskId: "t1", tabId: "tab-2", at: 42 }, ctx)).resolves.toEqual({
       updated: true,
@@ -48,7 +48,7 @@ describe("attention.dismiss handler", () => {
     )
   })
 
-  it("records normalized engine events with their chat-tab identity", async () => {
+  it("records normalized engine events with their Terminal Tab identity", async () => {
     const { ctx, rec } = fakeCtx()
     await dispatch("engine.reportEvent", { taskId: "t1", tabId: "tab-3", kind: "awaiting-input" }, ctx)
     expect(rec.inboxRecords).toEqual([{ taskId: "t1", kind: "awaiting-input", detail: undefined, tabId: "tab-3" }])

--- a/packages/kobe/test/render/use-attention.test.tsx
+++ b/packages/kobe/test/render/use-attention.test.tsx
@@ -39,7 +39,7 @@ function notifications(notify: NotificationsContext["notify"]): NotificationsCon
 afterEach(() => tabsByTask.clear())
 
 describe("useAttention", () => {
-  it("jumps from the current chat tab to the next pending live task", async () => {
+  it("jumps from the current Terminal Tab to the next available Inbox item", async () => {
     const tasks = [task("task-a", "Alpha"), task("task-b", "Beta"), task("task-c", "Archived", true)]
     const opened: AttentionInboxItem[] = []
     let jump: (() => void) | undefined
@@ -58,7 +58,7 @@ describe("useAttention", () => {
         kv: kv(),
         notif: notifications(() => {}),
         openAttention: (item) => opened.push(item),
-        noTasksMessage: "No pending attention",
+        noTasksMessage: "No available Inbox items",
       }).jumpToNextAttention
       return <text>ready</text>
     }
@@ -84,7 +84,7 @@ describe("useAttention", () => {
         kv: kv(),
         notif: notifications((notice) => notices.push(notice)),
         openAttention: () => {},
-        noTasksMessage: "No pending attention",
+        noTasksMessage: "No available Inbox items",
       }).jumpToNextAttention
       return <text>ready</text>
     }
@@ -92,7 +92,7 @@ describe("useAttention", () => {
     await renderComponent(<Probe />)
     act(() => jump?.())
 
-    expect(notices).toEqual([{ kind: "done", taskId: "task-a", tabId: "", title: "No pending attention" }])
+    expect(notices).toEqual([{ kind: "done", taskId: "task-a", tabId: "", title: "No available Inbox items" }])
   })
 
   it("notifies only on a non-selected task's rising attention edge", async () => {
@@ -113,7 +113,7 @@ describe("useAttention", () => {
         kv: kv(),
         notif: notifications((notice) => notices.push(notice)),
         openAttention: () => {},
-        noTasksMessage: "No pending attention",
+        noTasksMessage: "No available Inbox items",
       })
       return <text>ready</text>
     }
@@ -144,7 +144,7 @@ describe("useAttention", () => {
         kv: kv(false),
         notif: notifications((notice) => notices.push(notice)),
         openAttention: () => {},
-        noTasksMessage: "No pending attention",
+        noTasksMessage: "No available Inbox items",
       })
       return <text>ready</text>
     }

--- a/packages/kobe/test/render/use-attention.test.tsx
+++ b/packages/kobe/test/render/use-attention.test.tsx
@@ -69,7 +69,7 @@ describe("useAttention", () => {
     expect(opened.map((item) => item.taskId)).toEqual(["task-b"])
   })
 
-  it("shows the fallback toast when no pending episode is available", async () => {
+  it("shows the fallback toast when no Inbox item is available", async () => {
     const notices: Parameters<NotificationsContext["notify"]>[0][] = []
     let jump: (() => void) | undefined
 


### PR DESCRIPTION
## Summary
- distinguish opening the Inbox from jumping to the next available item
- use canonical Task and Terminal Tab terminology in docs and F1 help
- make unavailable-item fallback and lifecycle/restart comments match current behavior

## Commit structure
- `d656cef4` user-facing copy and terminology
- `5cf96826` internal lifecycle comments and patch changeset

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test:fast` (2305 tests)
- targeted Inbox/daemon/render tests (41 + 30 tests across two passes)
- `bun run build`
- `bun run test:behavior` (13 tests)
- socket failures under the four-worker local aggregate were isolated to existing watcher timing tests; both affected files passed together under one worker (16 tests). PR CI will re-run the standard aggregate on a clean runner.