### PR TITLE
fix: surface a rate-limited background task in the attention Inbox

### DIFF
--- a/.changeset/rate-limit-inbox-toast.md
+++ b/.changeset/rate-limit-inbox-toast.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Announce a background task that hits a rate limit: a non-selected task entering the rate-limited state now raises the same cross-task toast, chime, and desktop notification as an error, matching how the per-tab chip already surfaces it, so a rate-limited task no longer lands silently in the attention Inbox with no heads-up.

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -3,7 +3,8 @@
  *
  *  1. Rising-edge notify — diff the previous vs current daemon `engineState`
  *     map each render and fire `notify()` for any NON-selected task that just
- *     crossed into an attention state (permission_needed / error / turn_complete).
+ *     crossed into an attention state (permission_needed / error / rate_limited
+ *     / turn_complete — the daemon's `ATTENTION_INBOX_STATES`).
  *     The selected task already surfaces its own state in the middle column, so
  *     it's skipped. Gated by the `notifications.crossTask.enabled` preference.
  *  2. Jump-to-next — F7 walks available pending episodes in the daemon-owned

--- a/packages/kobe/src/tui/lib/notify-state.ts
+++ b/packages/kobe/src/tui/lib/notify-state.ts
@@ -78,15 +78,19 @@ export function shouldShowToast(kind: NotificationKind, toastEnabled: boolean): 
 /**
  * Cross-task attention (WorkspaceRoot rising-edge notify). The daemon's
  * `TaskActivityState` is engine-normalized (no vendor strings); we map the
- * three attention-worthy transitions to a {@link NotificationKind} and treat
+ * attention-worthy transitions to a {@link NotificationKind} and treat
  * everything else as "no notification". A `null` return means "don't notify".
- * `permission_needed` → `needs_input` (yellow), `error` → `error` (red), and
- * `turn_complete` → `done` (green). Kept as a string→string map so the caller
- * (which owns the daemon state type) doesn't import the notify enum names.
+ * `permission_needed` → `needs_input` (yellow), `error`/`rate_limited` →
+ * `error` (red), and `turn_complete` → `done` (green). These are exactly the
+ * daemon's `ATTENTION_INBOX_STATES`, so a state that becomes a pending Inbox
+ * episode always announces itself — `rate_limited` maps to `error` here the
+ * same way the per-tab chip notifier does (`activityTurnState`), keeping the
+ * two notifiers symmetric. Kept as a string→string map so the caller (which
+ * owns the daemon state type) doesn't import the notify enum names.
  */
 export function attentionKindFor(state: string): NotificationKind | null {
   if (state === "permission_needed") return "needs_input"
-  if (state === "error") return "error"
+  if (state === "error" || state === "rate_limited") return "error"
   if (state === "turn_complete") return "done"
   return null
 }

--- a/packages/kobe/test/tui-react/notify-state.test.ts
+++ b/packages/kobe/test/tui-react/notify-state.test.ts
@@ -73,10 +73,15 @@ describe("shouldShowToast", () => {
 })
 
 describe("attentionKindFor", () => {
-  it("maps the three attention transitions and ignores the rest", () => {
+  it("maps every Inbox-episode transition and ignores the rest", () => {
     expect(attentionKindFor("permission_needed")).toBe("needs_input")
     expect(attentionKindFor("error")).toBe("error")
     expect(attentionKindFor("turn_complete")).toBe("done")
+    // rate_limited is an ATTENTION_INBOX_STATE — a non-selected task that hits
+    // it becomes a pending Inbox episode, so it MUST announce itself. It maps
+    // to "error" (red) like the per-tab chip notifier (activityTurnState),
+    // keeping the two notifiers symmetric instead of silently dropping it.
+    expect(attentionKindFor("rate_limited")).toBe("error")
     expect(attentionKindFor("running")).toBeNull()
     expect(attentionKindFor("idle")).toBeNull()
   })


### PR DESCRIPTION
## Direction

Bugs / correctness — found during a review of the recently-landed attention Inbox / turn-state notification logic (this direction was chosen because it's the freshest, most-churned subsystem).

## Problem

`rate_limited` is one of the daemon's `ATTENTION_INBOX_STATES` (`packages/kobe-daemon/src/daemon/contracts.ts:130`), so when a **non-selected** task's engine hits a rate limit the daemon retains it as a pending Inbox episode — the Inbox badge increments and a ⌛ card appears in the pane.

But the cross-task notifier silently dropped it. `useAttention` (`src/tui-react/workspace/use-attention.ts`) diffs the per-task `engineState` map and calls `attentionEdges(prev, next, selectedId, attentionKindFor)`, and `attentionKindFor` (`src/tui/lib/notify-state.ts`) only mapped `permission_needed` / `error` / `turn_complete`, returning `null` for `rate_limited`. Result: **no toast, no chime, no OSC-9 desktop notification** for a rate-limited background task — it just quietly showed up in the Inbox.

This also created an asymmetry the "one notification module" design tries to prevent: the per-tab chip notifier already maps `rate_limited` → `error` (`activityTurnState` in `src/tui/workspace/turn-state-merge.ts:40`), so the same event on a background *tab* toasts, while on a non-selected *task* it was silent.

## Fix

Map `rate_limited` → `error` in `attentionKindFor`, matching the per-tab notifier and the color/kind `rate_limited` already carries everywhere else (Inbox card color, sticky state, chip). One-line logic change plus a doc-comment refresh on both `attentionKindFor` and the stale `useAttention` header that listed only three states.

## Verification

- `bun run lint` — clean
- `bun run typecheck` — clean (both packages)
- `vitest run test/tui-react/notify-state.test.ts` — 14 pass (added an assertion pinning `attentionKindFor("rate_limited") === "error"`, closing the test gap that let this drift)
- Ran the surrounding suites (`turn-state-merge`, `attention-inbox-core`, `sidebar-row-view`) — all green

## Follow-ups deferred

- A separate review surfaced two lower-confidence items not touched here: viewport (`ptyTask`) tabs resolving the wrong PTY key in `turn-target.ts` / `use-tab-handoffs.ts`, and selected-task active-tab episodes auto-resolving regardless of pane focus. Both need an owner call on intent and are out of this slice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL56MurLHJ5URbBjG4jiPc)_