### PR TITLE
Fix long project filter overflow in Sidebar

### DIFF
--- a/.changeset/fit-sidebar-project-filter.md
+++ b/.changeset/fit-sidebar-project-filter.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep long active project names inside the sidebar's Projects header.

--- a/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
@@ -131,11 +131,11 @@ export function Sidebar(props: SidebarProps) {
   }, [projectFilter, projectOptions])
   const projectFilterRepo = projectFilterOption?.repo ?? null
   const effectiveWidth = props.width ?? SIDEBAR_WIDTH
-  const projectFilterLabel = truncateProjectFilterLabel(
-    projectFilterOption?.label ?? "all",
-    t("tasks.header.projects"),
-    effectiveWidth,
-  )
+  const projectFilterLabel = truncateProjectFilterLabel({
+    label: projectFilterOption?.label ?? "all",
+    sectionLabel: t("tasks.header.projects"),
+    width: effectiveWidth,
+  })
 
   // Identity-reconciled row list (docs/DESIGN.md §5.5): keep previous row
   // objects (and the previous ARRAY when nothing changed) so daemon

--- a/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/Sidebar.tsx
@@ -47,6 +47,7 @@ import {
   searchQueryKeystroke,
   subtitleBudgetFor,
   titleBudgetFor,
+  truncateProjectFilterLabel,
 } from "../../../tui/panes/sidebar/view-core"
 import { useT } from "../../i18n"
 import { modalActive } from "../../lib/keymap"
@@ -129,7 +130,12 @@ export function Sidebar(props: SidebarProps) {
     return projectOptions.find((option) => sidebarProjectKey(option.repo) === key) ?? null
   }, [projectFilter, projectOptions])
   const projectFilterRepo = projectFilterOption?.repo ?? null
-  const projectFilterLabel = projectFilterOption?.label ?? "all"
+  const effectiveWidth = props.width ?? SIDEBAR_WIDTH
+  const projectFilterLabel = truncateProjectFilterLabel(
+    projectFilterOption?.label ?? "all",
+    t("tasks.header.projects"),
+    effectiveWidth,
+  )
 
   // Identity-reconciled row list (docs/DESIGN.md §5.5): keep previous row
   // objects (and the previous ARRAY when nothing changed) so daemon
@@ -176,7 +182,6 @@ export function Sidebar(props: SidebarProps) {
   }
 
   // Two-line card budgets from the live width (view-core math).
-  const effectiveWidth = props.width ?? SIDEBAR_WIDTH
   const titleBudget = titleBudgetFor(effectiveWidth)
   const subtitleBudget = subtitleBudgetFor(effectiveWidth)
 

--- a/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/panel.tsx
@@ -190,7 +190,7 @@ export function SidebarPanel(props: {
                 fg={props.projectFilterRepo ? theme.text : theme.textMuted}
                 attributes={props.projectFilterRepo ? TextAttributes.BOLD : undefined}
                 wrapMode="none"
-                flexShrink={0}
+                flexShrink={1}
               >
                 {props.projectFilterLabel}
               </text>

--- a/packages/kobe/src/tui/panes/sidebar/view-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/view-core.ts
@@ -59,11 +59,17 @@ export function subtitleBudgetFor(width: number): number {
 
 /**
  * Fit the active project filter into the PROJECTS header. Besides the
- * translated section label, the row reserves two padding cells, two gaps,
- * and one divider cell. The label itself is measured in terminal cells so a
- * wide CJK glyph cannot paint past the sidebar edge.
+ * translated section label, the row reserves two padding cells and two gaps,
+ * plus one safety cell for the divider (which Yoga may shrink to zero). The
+ * label itself is measured in terminal cells so a wide CJK glyph cannot paint
+ * past the sidebar edge.
  */
-export function truncateProjectFilterLabel(label: string, sectionLabel: string, width: number): string {
+export function truncateProjectFilterLabel(opts: {
+  readonly label: string
+  readonly sectionLabel: string
+  readonly width: number
+}): string {
+  const { label, sectionLabel, width } = opts
   const reservedCells = displayWidth(sectionLabel) + 5
   return truncateEndCells(label, Math.max(0, width - reservedCells), charWidth)
 }

--- a/packages/kobe/src/tui/panes/sidebar/view-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/view-core.ts
@@ -6,7 +6,8 @@
  * (theme-core / lookup / message-core precedent).
  */
 
-import { truncateEnd } from "../../lib/truncate"
+import { charWidth, displayWidth } from "../../../lib/display-width"
+import { truncateEnd, truncateEndCells } from "../../lib/truncate"
 import type { SidebarView } from "./groups"
 import type { SidebarTone } from "./row-view"
 
@@ -54,6 +55,17 @@ export function titleBudgetFor(width: number): number {
  */
 export function subtitleBudgetFor(width: number): number {
   return Math.max(6, width - 16)
+}
+
+/**
+ * Fit the active project filter into the PROJECTS header. Besides the
+ * translated section label, the row reserves two padding cells, two gaps,
+ * and one divider cell. The label itself is measured in terminal cells so a
+ * wide CJK glyph cannot paint past the sidebar edge.
+ */
+export function truncateProjectFilterLabel(label: string, sectionLabel: string, width: number): string {
+  const reservedCells = displayWidth(sectionLabel) + 5
+  return truncateEndCells(label, Math.max(0, width - reservedCells), charWidth)
 }
 
 /**

--- a/packages/kobe/test/render/sidebar.test.tsx
+++ b/packages/kobe/test/render/sidebar.test.tsx
@@ -183,4 +183,44 @@ describe("Sidebar", () => {
       destroy()
     }
   })
+
+  it("keeps a long active project filter inside the sidebar header", async () => {
+    const longRepo = "/repo/shushu-internship-resume"
+    const otherRepo = "/repo/kobe"
+    const longProject = task({
+      id: "main-long",
+      title: "shushu-internship-resume",
+      repo: longRepo,
+      kind: "main",
+      worktreePath: longRepo,
+    })
+    const otherProject = task({
+      id: "main-other",
+      title: "kobe",
+      repo: otherRepo,
+      kind: "main",
+      worktreePath: otherRepo,
+    })
+    const scopedTask = task({ repo: longRepo, worktreePath: `${longRepo}/.kobe/worktrees/alpha` })
+    const { destroy, spans } = await renderComponent(
+      <Sidebar
+        width={30}
+        tasks={[longProject, otherProject, scopedTask]}
+        selectedId={scopedTask.id}
+        onSelect={() => {}}
+        projectFilter={longRepo}
+        worktreeChanges={new Map()}
+      />,
+      { width: 40, height: 18 },
+    )
+
+    try {
+      const projectHeader = findLine(await spans(), "PROJECTS")
+      const headerText = projectHeader?.spans.map((span) => span.text).join("") ?? ""
+      expect(headerText).toContain("shushu-internshi…")
+      expect(headerText).not.toContain("shushu-internship-resume")
+    } finally {
+      destroy()
+    }
+  })
 })

--- a/packages/kobe/test/tui-react/sidebar-view-core.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-view-core.test.ts
@@ -19,6 +19,7 @@ import {
   titleBudgetFor,
   toneColor,
   truncateBranchLabel,
+  truncateProjectFilterLabel,
   viewTabLabelKey,
 } from "../../src/tui/panes/sidebar/view-core"
 
@@ -55,6 +56,12 @@ describe("line budgets", () => {
     expect(projectScrollMaxHeightFor(16, 5)).toBe(4)
     // Degenerate terminal still yields the 2-cell floor.
     expect(projectScrollMaxHeightFor(3, 5)).toBe(2)
+  })
+
+  it("fits the active project filter beside the PROJECTS header", () => {
+    expect(truncateProjectFilterLabel("shushu-internship-resume", "PROJECTS", 30)).toBe("shushu-internshi…")
+    expect(truncateProjectFilterLabel("长项目名称", "PROJECTS", 17)).toBe("长…")
+    expect(truncateProjectFilterLabel("anything", "PROJECTS", 12)).toBe("")
   })
 })
 

--- a/packages/kobe/test/tui-react/sidebar-view-core.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-view-core.test.ts
@@ -59,9 +59,19 @@ describe("line budgets", () => {
   })
 
   it("fits the active project filter beside the PROJECTS header", () => {
-    expect(truncateProjectFilterLabel("shushu-internship-resume", "PROJECTS", 30)).toBe("shushu-internshi…")
-    expect(truncateProjectFilterLabel("长项目名称", "PROJECTS", 17)).toBe("长…")
-    expect(truncateProjectFilterLabel("anything", "PROJECTS", 12)).toBe("")
+    expect(truncateProjectFilterLabel({ label: "kobe", sectionLabel: "PROJECTS", width: 30 })).toBe("kobe")
+    expect(truncateProjectFilterLabel({ label: "shushu-internship-resume", sectionLabel: "PROJECTS", width: 30 })).toBe(
+      "shushu-internshi…",
+    )
+    expect(truncateProjectFilterLabel({ label: "长项目名称", sectionLabel: "PROJECTS", width: 17 })).toBe("长…")
+    // Exact boundary: four label cells fit at width 17; one fewer cell
+    // reserves the ellipsis instead of painting a fifth cell.
+    expect(truncateProjectFilterLabel({ label: "kobe", sectionLabel: "PROJECTS", width: 17 })).toBe("kobe")
+    expect(truncateProjectFilterLabel({ label: "kobe", sectionLabel: "PROJECTS", width: 16 })).toBe("ko…")
+    expect(truncateProjectFilterLabel({ label: "all", sectionLabel: "PROJECTS", width: 16 })).toBe("all")
+    // At this degenerate width even one suffix cell would overflow; containment
+    // takes precedence. Production's sidebar inner width is 30 cells.
+    expect(truncateProjectFilterLabel({ label: "anything", sectionLabel: "PROJECTS", width: 12 })).toBe("")
   })
 })
 


### PR DESCRIPTION
## Summary
- truncate the active project filter against the live Sidebar cell budget
- keep the filter suffix flex-shrinkable at narrow widths
- cover ASCII, CJK, and rendered long-project regressions

## Verification
- bun test packages/kobe/test/tui-react/sidebar-view-core.test.ts packages/kobe/test/render/sidebar.test.tsx
- bun run lint
- bun run typecheck
- real /harness screenshot with two repos and Ctrl+P filtering: long label stays inside the pane border

## Local visual gate note
KOBE_VISUAL_FRESH=1 bun run visual reached the unrelated Kanban journeys. On this Darwin checkout, one run hit the existing Esc-close flake and the snapshot still embeds another machine's absolute fixture path; the Sidebar acceptance itself passed in the required /harness path.