### PR TITLE
fix: flush the pending Notes autosave on task switch and unmount

### DIFF
--- a/.changeset/flush-notes-autosave.md
+++ b/.changeset/flush-notes-autosave.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Stop the web Notes panel from losing the last edits when you switch tasks or close the panel: an autosave still pending inside the 600ms debounce window is now flushed to the task it belongs to instead of being cancelled, so edits typed just before navigating away are no longer silently dropped.

--- a/packages/kobe-web/src/components/NotesPanel.tsx
+++ b/packages/kobe-web/src/components/NotesPanel.tsx
@@ -50,11 +50,42 @@ export function NotesPanel({
   // Track the task the current buffer belongs to, so an in-flight load or
   // a queued autosave for a previous task never writes to the new one.
   const loadedTaskRef = useRef<string | null>(null)
+  // The newest un-persisted edit, kept so a task switch or an unmount that
+  // lands inside the autosave debounce window can FLUSH it instead of dropping
+  // it. Carries its own taskId so a flush always writes to the task the text
+  // actually belongs to, never the task we're navigating to.
+  const pendingSaveRef = useRef<{ taskId: string; value: string } | null>(null)
+
+  // Persist the pending edit right now, cancelling the debounce. A no-op when
+  // nothing is pending. The success/error reflection stays target-guarded so a
+  // flush for a task we've since left saves the data without stamping a stale
+  // status onto the task now on screen.
+  const flushPendingSave = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    const pending = pendingSaveRef.current
+    if (!pending) return
+    pendingSaveRef.current = null
+    const { taskId: target, value } = pending
+    void saveNotes(target, value)
+      .then(() => {
+        if (loadedTaskRef.current === target) setSaveState("saved")
+      })
+      .catch(() => {
+        if (loadedTaskRef.current === target) setSaveState("error")
+      })
+  }, [])
 
   // Load on task change.
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current)
+    // Repoint the ref BEFORE flushing so the outgoing task's queued save can't
+    // reflect a stale "saved" onto the incoming task (the flush is target-
+    // guarded on this ref). The flush persists an edit made in the last
+    // <debounce ms — the old clearTimeout here silently dropped it.
     loadedTaskRef.current = taskId
+    flushPendingSave()
     setSaveState("idle")
     // Clear the buffer + drop to Edit mode immediately so the previous task's
     // content (or a stale preview render) can't show during the async reload.
@@ -78,14 +109,15 @@ export function NotesPanel({
     return () => {
       cancelled = true
     }
-  }, [taskId])
+  }, [taskId, flushPendingSave])
 
-  // Cleanup any pending debounce on unmount.
+  // Flush (not drop) any pending autosave on unmount, so edits made in the last
+  // <debounce ms before the panel closes still reach the server.
   useEffect(() => {
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
+      flushPendingSave()
     }
-  }, [])
+  }, [flushPendingSave])
 
   const onChange = useCallback(
     (value: string) => {
@@ -93,19 +125,13 @@ export function NotesPanel({
       if (!taskId) return
       const target = taskId
       setSaveState("saving")
+      // Stash the newest edit so a flush (task switch / unmount) can persist it
+      // even if the debounce hasn't fired yet.
+      pendingSaveRef.current = { taskId: target, value }
       if (debounceRef.current) clearTimeout(debounceRef.current)
-      debounceRef.current = setTimeout(() => {
-        saveNotes(target, value)
-          .then(() => {
-            // Only reflect success if we're still on the same task.
-            if (loadedTaskRef.current === target) setSaveState("saved")
-          })
-          .catch(() => {
-            if (loadedTaskRef.current === target) setSaveState("error")
-          })
-      }, AUTOSAVE_DEBOUNCE_MS)
+      debounceRef.current = setTimeout(flushPendingSave, AUTOSAVE_DEBOUNCE_MS)
     },
-    [taskId],
+    [taskId, flushPendingSave],
   )
 
   return (

--- a/packages/kobe-web/test/notes-panel-flush.test.tsx
+++ b/packages/kobe-web/test/notes-panel-flush.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Hoisted so the vi.mock factory (hoisted above imports) can reference them.
+const { saveNotes, fetchNotes } = vi.hoisted(() => ({
+  saveNotes: vi.fn<(taskId: string, markdown: string) => Promise<void>>(() => Promise.resolve()),
+  fetchNotes: vi.fn<(taskId: string) => Promise<string>>(() => Promise.resolve("")),
+}))
+vi.mock("../src/lib/notes.ts", () => ({ saveNotes, fetchNotes }))
+
+import { NotesPanel } from "../src/components/NotesPanel.tsx"
+
+/** Render and let the initial fetchNotes() settle so the textarea un-disables. */
+async function renderLoaded(taskId: string) {
+  let utils!: ReturnType<typeof render>
+  await act(async () => {
+    utils = render(<NotesPanel taskId={taskId} />)
+  })
+  return utils
+}
+
+function editNotes(value: string) {
+  const textarea = screen.getByPlaceholderText(/Notes for this task/i)
+  fireEvent.change(textarea, { target: { value } })
+}
+
+describe("NotesPanel autosave flush", () => {
+  beforeEach(() => {
+    saveNotes.mockClear()
+    fetchNotes.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+  })
+
+  it("flushes the pending autosave to the OLD task when the task changes mid-debounce", async () => {
+    const { rerender } = await renderLoaded("task-a")
+    editNotes("unsaved thought")
+    // Still inside the debounce window — no save has fired yet.
+    expect(saveNotes).not.toHaveBeenCalled()
+
+    await act(async () => {
+      rerender(<NotesPanel taskId="task-b" />)
+    })
+
+    // The edit must land on task-a (where it was typed), not be dropped.
+    expect(saveNotes).toHaveBeenCalledWith("task-a", "unsaved thought")
+  })
+
+  it("flushes the pending autosave on unmount", async () => {
+    const { unmount } = await renderLoaded("task-a")
+    editNotes("closing note")
+    expect(saveNotes).not.toHaveBeenCalled()
+
+    await act(async () => {
+      unmount()
+    })
+
+    expect(saveNotes).toHaveBeenCalledWith("task-a", "closing note")
+  })
+
+  it("still autosaves once after the debounce elapses when left alone", async () => {
+    vi.useFakeTimers()
+    let utils!: ReturnType<typeof render>
+    await act(async () => {
+      utils = render(<NotesPanel taskId="task-a" />)
+      // Flush the fetchNotes() microtasks queued by the load effect.
+      await Promise.resolve()
+    })
+    editNotes("steady edit")
+    expect(saveNotes).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+
+    expect(saveNotes).toHaveBeenCalledTimes(1)
+    expect(saveNotes).toHaveBeenCalledWith("task-a", "steady edit")
+    utils.unmount()
+  })
+})


### PR DESCRIPTION
## Direction

Bugs / correctness — found reviewing the web dashboard (`packages/kobe-web`), an area not covered by any open PR.

## Problem

The web-only Notes panel (`NotesPanel.tsx`) autosaves on a **600ms debounce**. But both the task-change effect and the unmount cleanup **cancelled** the pending timer with `clearTimeout(debounceRef.current)` instead of letting it fire. So any keystrokes typed in the last <600ms before you switch tasks (or close the panel) were never sent to the server — silent data loss, despite the panel advertising "autosaved."

Concrete repro: open Task A's Notes, type "important note", and within 600ms click Task B in the rail. `saveNotes(A, …)` is cancelled and never sent. Reopen Task A → the note is gone.

The debounced save callback already captured its own `target = taskId` and guards its `.then/.catch` on `loadedTaskRef.current === target`, so firing the pending save is fully task-isolated and correct — it was only the cancellation that lost the data.

## Fix

Track the newest un-persisted edit in a ref (`{ taskId, value }`) and add a `flushPendingSave()` helper that persists it immediately instead of dropping it:

- **Task change**: repoint `loadedTaskRef` to the new task first, then `flushPendingSave()` — the outgoing task's edit is written to the task it belongs to, and the target-guard prevents a stale "saved" status flashing onto the incoming task.
- **Unmount**: flush instead of clear.
- **Debounce fire**: the timer now calls `flushPendingSave` (same save path, so a normal idle autosave still fires exactly once and clears the pending ref).

## Verification

- New `test/notes-panel-flush.test.tsx` (jsdom + Testing Library): asserts the edit is flushed to the **old** task on a mid-debounce task switch, flushed on unmount, and that a left-alone edit still autosaves exactly once after the debounce. Confirmed the two flush tests **fail** without the fix and pass with it.
- `bun run lint` (monorepo) and `biome lint` (kobe-web) — clean.
- `bun run typecheck` (kobe + daemon) — clean. Full kobe-web vitest suite: 570 pass; the only 3 failures (`server-session`, `web-state-routes`) are pre-existing and environment-dependent (tmux/PTY/state.json), unrelated to this change — verified they fail identically on a clean tree.
- Added a patch changeset (`@sma1lboy/kobe`) — the notes panel ships in the published package (`kobe-web` is a `workspace:*` dep) and this is user-facing.

## Follow-ups (deliberately deferred, out of this slice)

While reviewing I noted two other candidates left for separate PRs to keep this scoped: (1) `orchestrator/land.ts` — `--delete-branch` cleanup can't delete a branch still checked out in the task's worktree, so it silently no-ops; this file overlaps open PR #309's merge-strategy work, so it should be handled there or in a dedicated PR. (2) `daemon/issues-store.ts` `link` op doesn't clear a prior issue→task link, allowing two issues to point at one task — needs a product decision on whether task↔issue is meant to be 1:1.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jKJGfRg38rmcw6cco3hCD)_