### PR TITLE
fix: fold NFD kana sound marks and CJK tone marks to zero cell width

### DIFF
--- a/.changeset/nfd-kana-cell-width.md
+++ b/.changeset/nfd-kana-cell-width.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix cell-width measurement for NFD-decomposed Japanese kana and the CJK tone marks so a voiced-kana filename no longer drifts every later column out of alignment: the combining katakana-hiragana (semi-)voiced sound marks (U+3099/U+309A, which macOS splits off precomposed が/ぱ in NFD filenames) and the ideographic/Hangul tone marks (U+302A–U+302F) sat inside the wide Hiragana/CJK-symbols ranges and were each counted as one extra cell, so a decomposed kana measured up to twice its true width in the `kobe export` table and the embedded-terminal cursor overlay. They now fold to zero width like the already-handled Hangul jamo and combining half marks, matching xterm's own wcwidth table.

--- a/packages/kobe/src/lib/display-width.ts
+++ b/packages/kobe/src/lib/display-width.ts
@@ -23,6 +23,8 @@ export function charWidth(cp: number): number {
     (cp >= 0x202a && cp <= 0x202e) || // bidi embedding / override
     (cp >= 0x2060 && cp <= 0x2064) || // word joiner … invisible operators
     (cp >= 0x20d0 && cp <= 0x20ff) || // combining marks for symbols
+    (cp >= 0x302a && cp <= 0x302f) || // ideographic + Hangul tone marks (xterm wcwidth: combining, zero-width)
+    (cp >= 0x3099 && cp <= 0x309a) || // combining katakana-hiragana (semi-)voiced sound marks (NFD-decomposed が/ぱ)
     (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
     (cp >= 0xfe20 && cp <= 0xfe2f) || // combining half marks
     cp === 0xfeff // zero-width no-break space (BOM)
@@ -34,8 +36,8 @@ export function charWidth(cp: number): number {
     (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo (leading/choseong) — medial/final fold to zero above
     cp === 0x2329 ||
     cp === 0x232a || // angle brackets
-    (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals … Kangxi … CJK symbols
-    (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana … Katakana … CJK compat
+    (cp >= 0x2e80 && cp <= 0x303e) || // CJK radicals … Kangxi … CJK symbols — tone marks 302A–302F fold to zero above
+    (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana … Katakana … CJK compat — sound marks 3099/309A fold to zero above
     (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Unified Ext A
     (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
     (cp >= 0xa000 && cp <= 0xa4cf) || // Yi Syllables

--- a/packages/kobe/test/lib/display-width.test.ts
+++ b/packages/kobe/test/lib/display-width.test.ts
@@ -44,6 +44,18 @@ describe("charWidth", () => {
     expect(charWidth(0x11ff)).toBe(0) // range ceiling
   })
 
+  it("counts the CJK-region combining sound / tone marks as zero", () => {
+    // U+3099/U+309A are the nonspacing (semi-)voiced sound marks that NFD
+    // decomposition splits off precomposed voiced kana (が = か + U+3099);
+    // U+302A–U+302F are ideographic / Hangul tone marks. All fold onto the
+    // preceding glyph's cell, matching xterm's wcwidth combining table.
+    expect(charWidth(0x3099)).toBe(0) // combining voiced sound mark
+    expect(charWidth(0x309a)).toBe(0) // combining semi-voiced sound mark
+    expect(charWidth(0x302a)).toBe(0) // ideographic tone mark (range floor)
+    expect(charWidth(0x302f)).toBe(0) // range ceiling
+    expect(charWidth(0x3041)).toBe(2) // ぁ — wide kana just past the sound marks
+  })
+
   it("counts combining half marks (U+FE20–U+FE2F) as zero", () => {
     expect(charWidth(0xfe20)).toBe(0)
     expect(charWidth(0xfe26)).toBe(0) // combining conjoining macron
@@ -85,6 +97,16 @@ describe("displayWidth", () => {
     // or `kobe export` table must occupy the same width either way.
     const precomposed = "한글" // U+D55C U+AE00
     const decomposed = precomposed.normalize("NFD")
+    expect(decomposed.length).toBeGreaterThan(precomposed.length) // genuinely decomposed
+    expect(displayWidth(precomposed)).toBe(4)
+    expect(displayWidth(decomposed)).toBe(4)
+  })
+
+  it("measures decomposed (NFD) voiced kana the same as precomposed", () => {
+    // Same macOS-NFD case as Hangul: a Japanese filename with voiced kana
+    // (が ぱ) must occupy its precomposed width, not gain a cell per mark.
+    const precomposed = "がぱ" // U+304C U+3071
+    const decomposed = precomposed.normalize("NFD") // か+U+3099, は+U+309A
     expect(decomposed.length).toBeGreaterThan(precomposed.length) // genuinely decomposed
     expect(displayWidth(precomposed)).toBe(4)
     expect(displayWidth(decomposed)).toBe(4)


### PR DESCRIPTION
## Direction

Bug / correctness — a self-found gap in the shared cell-width table (`src/lib/display-width.ts`), the same class of fix already shipped for NFD Hangul, Enclosed Ideographic glyphs, and the mahjong/joker tiles (CHANGELOG 0.8.8).

## Problem

`charWidth` folds combining marks to zero so they don't advance the terminal cursor, but two nonspacing-mark groups that live *inside* the wide CJK ranges were never excluded, so each was counted as **2** cells instead of **0**:

- **U+3099 / U+309A** — the combining katakana-hiragana (semi-)voiced sound marks. NFD decomposition splits these off precomposed voiced kana (`が` = `か` + U+3099), and **macOS stores filenames in NFD**, so a Japanese filename with voiced kana (`が`, `ぱ`, …) in the file tree or `kobe export` table measured up to twice its true width.
- **U+302A–U+302F** — ideographic / Hangul tone marks (xterm's wcwidth table treats these as combining/zero-width).

Because these feed the `kobe export` table renderer and the embedded-terminal cursor overlay, one over-counted mark drifts **every column to its right** out of alignment — the exact misalignment the module exists to prevent. Verified before the fix: `displayWidth("が".normalize("NFD"))` returned `4`, not `2`.

## Fix

Add both ranges to the zero-width block in `charWidth` (it runs before the wide check, so the fold wins), and annotate the two wide ranges to document the exclusion — mirroring the existing Hangul-jamo comment. Now `charWidth(0x3099) === 0` and NFD-decomposed kana measures identically to its precomposed form, matching xterm's wcwidth table.

## Verification

- `bunx vitest run test/lib/display-width.test.ts` — 17 pass (added a `charWidth` case for the combining sound/tone marks and an NFD-kana equality case parallel to the existing NFD-Hangul test).
- Ran the width consumers' tests: `test/cli/export-cmd.test.ts`, `test/cli/export-cmd-run.test.ts`, `test/tui/terminal-render.test.ts`, `test/tui-react/sidebar-view-core.test.ts` — all green (no regression).
- `bun run lint` and `bun run typecheck` — both green.

## Follow-ups (deferred, out of this slice)

Two unrelated bugs surfaced during review, left for separate PRs:
- `findAdoptableWorktree` (`packages/kobe-daemon/src/daemon/cwd-task.ts`) throws on any `ssh://` remote-project repo because it feeds every task's repo into the absolute-path-only `managedWorktreeRootsFor`; that rejects the whole `engine.reportEvent` handler while a remote project exists. Filter remote keys before the path helper.
- `formatBytes` (`src/tui/ops/preview-core.ts`) can render `"1024 KB"` instead of promoting to `"1.0 MB"` at a unit boundary (cosmetic).

---
_Generated by [Claude Code](https://claude.ai/code/session_017zH7aT3Psq6R2HYdA4ptTb)_