### PR TITLE
fix: a remote (ssh://) project no longer breaks live engine activity for all tasks

### DIFF
--- a/.changeset/remote-project-adoptable-worktree-guard.md
+++ b/.changeset/remote-project-adoptable-worktree-guard.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fixed a bug where adding a remote (`ssh://`) project silently broke live engine activity for every task — the worktree auto-adoption check fed the remote project's synthetic key into a path helper that only accepts absolute paths, throwing and dropping the entire engine event, so task status, transcript, and telemetry stopped updating until the remote project was removed.

--- a/packages/kobe-daemon/src/daemon/cwd-task.ts
+++ b/packages/kobe-daemon/src/daemon/cwd-task.ts
@@ -157,7 +157,11 @@ export function findAdoptableWorktree(
   const repos = new Set<string>()
   const known = new Set<string>()
   for (const t of tasks) {
-    if (t.repo) repos.add(normalize(t.repo))
+    // A remote-project repo key (`ssh://…`) is not an absolute path and has no
+    // local managed worktree root, so it can never host an adoptable on-disk
+    // worktree — and feeding it to `managedWorktreeRootsFor` below throws.
+    // Skip it: a single remote project must not reject the whole event handler.
+    if (t.repo && path.isAbsolute(t.repo)) repos.add(normalize(t.repo))
     if (t.worktreePath) known.add(normalize(t.worktreePath))
   }
   for (const repo of repos) {

--- a/packages/kobe/test/daemon/cwd-task.test.ts
+++ b/packages/kobe/test/daemon/cwd-task.test.ts
@@ -193,4 +193,16 @@ describe("findAdoptableWorktree", () => {
   it("ignores a sibling-prefix repo (/repo vs /repo-other)", () => {
     expect(findAdoptableWorktree(tasks(), "/repo-other/.kobe/worktrees/x")).toBeUndefined()
   })
+
+  it("skips a remote-project repo key (ssh://…) without throwing", () => {
+    // A remote main task's `repo` is a synthetic `ssh://user@host` key, not an
+    // absolute path — it has no local managed worktree root. It must be skipped,
+    // not fed to `managedWorktreeRootsFor` (which throws on non-absolute paths),
+    // so a single remote project never rejects the whole engine.reportEvent path.
+    const withRemote = [...tasks(), { id: "remote", repo: "ssh://user@host:22", worktreePath: "/remote/base" }]
+    const wt = path.join(worktreeRootFor("/repo"), "external")
+    expect(() => findAdoptableWorktree(withRemote, wt)).not.toThrow()
+    // The local repo's worktree is still adoptable alongside the remote task.
+    expect(findAdoptableWorktree(withRemote, wt)).toEqual({ repo: "/repo", worktreePath: wt })
+  })
 })


### PR DESCRIPTION
## Direction

Bug / correctness — a self-found regression surfaced during review of the remote-project code path (also noted as a deferred follow-up in #348).

## Problem

`findAdoptableWorktree` (`packages/kobe-daemon/src/daemon/cwd-task.ts`) is called on every engine `session-start` event to auto-adopt an unadopted worktree under a tracked repo. It iterates **every** task's `repo` and feeds each into `managedWorktreeRootsFor`, which **throws** for any non-absolute path:

```ts
function managedWorktreeRootsFor(repo: string): readonly string[] {
  if (!path.isAbsolute(repo)) {
    throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
  }
  ...
}
```

A **remote project's** task stores a synthetic `ssh://user@host[:port]` key as its `repo` (see `orchestrator/core.ts` → `normalizeMainRepo` / `repoWorkingDir`), which is not an absolute path. So the moment any remote project exists in the task store, `findAdoptableWorktree` throws.

The call site in `handlers.ts` (`engine.reportEvent`) invokes it **outside** the try/catch — only the subsequent `adoptWorktree` is guarded:

```ts
const cand = findAdoptableWorktree(ctx.orch.listTasks(), cwd) // throws → rejects the whole handler
if (cand) {
  try { await ctx.orch.adoptWorktree(...) } catch (err) { logDaemonError(...) }
}
```

Result: **with a remote project added, every engine activity event is rejected** — task status, transcript, and telemetry stop updating for all tasks until the remote project is removed.

## Fix

Guard the repo set in `findAdoptableWorktree` with `path.isAbsolute`. A remote-project key has no local managed worktree root, so it can never host an adoptable on-disk worktree — skipping it is correct, and a single remote project no longer rejects the whole event handler. Local worktree adoption is unchanged.

## Verification

- `KOBE_INCLUDE_SOCKET=1 bunx vitest run test/daemon/cwd-task.test.ts` — 28 pass (added a case: a task with an `ssh://` repo key alongside a local repo does not throw, and the local worktree stays adoptable).
- `KOBE_INCLUDE_SOCKET=1 bunx vitest run test/daemon/handlers.test.ts` — 32 pass (no regression on the caller).
- `bun run lint` and `bun run typecheck` — both green.

## Follow-ups (deferred, out of this slice)

- `formatBytes` (`src/tui/ops/preview-core.ts`) can render `"1024 KB"` instead of promoting to `"1.0 MB"` at a unit boundary (cosmetic — noted in #348, left for a separate PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_0111qzffewrULTo9kV8D7qD7)_