### PR TITLE
fix: promote formatBytes at the unit boundary instead of "1024 KB"

### DIFF
--- a/.changeset/format-bytes-unit-boundary.md
+++ b/.changeset/format-bytes-unit-boundary.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix the binary/image preview size line rounding up to a bogus "1024 KB" (or "1024 MB") at a unit boundary instead of promoting to "1.0 MB" (or "1.0 GB") — file sizes within half a kilobyte of the next unit now roll over to the larger unit as expected.

--- a/packages/kobe/src/tui/ops/preview-core.ts
+++ b/packages/kobe/src/tui/ops/preview-core.ts
@@ -53,7 +53,9 @@ export function formatBytes(n: number): string {
   const units = ["KB", "MB", "GB", "TB"]
   let v = n / 1024
   let i = 0
-  while (v >= 1024 && i < units.length - 1) {
+  // Promote at 1023.5, not 1024: once v rounds up to 1024 it would render as
+  // "1024 KB" instead of "1.0 MB" at the unit boundary (Math.round rounds .5 up).
+  while (v >= 1023.5 && i < units.length - 1) {
     v /= 1024
     i++
   }

--- a/packages/kobe/test/tui-react/ops-preview-core.test.ts
+++ b/packages/kobe/test/tui-react/ops-preview-core.test.ts
@@ -98,4 +98,12 @@ describe("binary detection helpers", () => {
     expect(formatBytes(1536)).toBe("1.5 KB")
     expect(formatBytes(2 * 1024 * 1024)).toBe("2.0 MB")
   })
+
+  test("formatBytes promotes at the unit boundary instead of rendering 1024", () => {
+    // v rounds up to 1024 KB → must roll over to 1.0 MB, not "1024 KB".
+    expect(formatBytes(1024 * 1024 - 512)).toBe("1.0 MB")
+    expect(formatBytes(1024 * 1024 * 1024 - 1)).toBe("1.0 GB")
+    // Just below the round-up threshold stays in the smaller unit.
+    expect(formatBytes(1024 * 1024 - 513)).toBe("1023 KB")
+  })
 })


### PR DESCRIPTION
## Direction

Bug / correctness — a self-found rounding bug in `formatBytes` (`packages/kobe/src/tui/ops/preview-core.ts`), previously noted as a deferred follow-up in #348 and #349 and not covered by any open PR.

## Problem

`formatBytes` renders the size line on the binary/image preview card. It promotes to the next unit while `v >= 1024`, but the display then applies `Math.round(v)` for `v >= 100`. Since `Math.round` rounds `.5` up, any size where `v` lands in `[1023.5, 1024)` renders the impossible unit value `"1024 KB"` (or `"1024 MB"`) instead of rolling over to `"1.0 MB"` (or `"1.0 GB"`).

Reproduced before the fix:

```
1048064 (1 MB − 512 B)      -> "1024 KB"   (want "1.0 MB")
1073741823 (1 GB − 1 B)     -> "1024 MB"   (want "1.0 GB")
```

## Fix

Promote at `1023.5` rather than `1024`, so a size within half a kilobyte of the next unit rolls over before the round-up can produce a `1024`-valued unit. Values below the round-up threshold stay in the smaller unit (`1048063 B` still shows `"1023 KB"`). The top unit (`TB`) has no higher unit to promote into, unchanged.

## Verification

- `bunx vitest run test/tui-react/ops-preview-core.test.ts` — 10 pass (added a boundary-promotion case: `1 MB − 512 B → "1.0 MB"`, `1 GB − 1 B → "1.0 GB"`, and `1 MB − 513 B → "1023 KB"` for the just-below-threshold side).
- `bun run lint` and `bun run typecheck` — both green.

## Follow-ups (deferred)

None for this slice. The other follow-up noted alongside this one (`findAdoptableWorktree` throwing on `ssh://` remote-project keys) is already handled by the open PR #349.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mr7zvXSfbu6wqkH4sxyjGi)_