### PR TITLE
Fix terminal copy selection for wide characters

### DIFF
--- a/.changeset/fix-terminal-selection-cell-coordinates.md
+++ b/.changeset/fix-terminal-selection-cell-coordinates.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix embedded-terminal copy selection around Chinese, emoji, and other wide glyphs: highlighting and clipboard extraction now map mouse columns by terminal-cell width, so selections no longer overpaint blank space or omit text at their boundaries.

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -16,6 +16,7 @@
  * refresh untouched.
  */
 
+import { charWidth } from "../../../lib/display-width"
 import { ATTR, type Chunk } from "./sgr"
 
 export type CellPoint = { readonly row: number; readonly col: number }
@@ -47,6 +48,53 @@ function rowText(row: readonly Chunk[]): string {
   return s
 }
 
+/** Terminal-cell width of text, preserving zero-width combining marks. */
+function textCells(text: string): number {
+  let cells = 0
+  for (const ch of text) cells += charWidth(ch.codePointAt(0) as number)
+  return cells
+}
+
+type CellSlice = { readonly before: string; readonly selected: string; readonly after: string }
+
+/**
+ * Split text around a terminal-cell span. A wide glyph is kept whole when
+ * either of its two cells intersects the span; zero-width marks stay attached
+ * to the preceding glyph instead of becoming independently selectable.
+ */
+function sliceTextByCells(text: string, from: number, to: number): CellSlice {
+  let before = ""
+  let selected = ""
+  let after = ""
+  let col = 0
+  let lastPart: keyof CellSlice = "before"
+
+  for (const ch of text) {
+    const width = charWidth(ch.codePointAt(0) as number)
+    if (width === 0) {
+      if (lastPart === "selected") selected += ch
+      else if (lastPart === "after") after += ch
+      else before += ch
+      continue
+    }
+
+    const end = col + width
+    if (end <= from) {
+      before += ch
+      lastPart = "before"
+    } else if (col >= to) {
+      after += ch
+      lastPart = "after"
+    } else {
+      selected += ch
+      lastPart = "selected"
+    }
+    col = end
+  }
+
+  return { before, selected, after }
+}
+
 /**
  * Extract the selected text: per-row slice by span, trailing whitespace
  * trimmed per line (terminal rows are space-padded to the grid width),
@@ -57,9 +105,9 @@ export function extractSelection(rows: readonly (readonly Chunk[])[], range: Sel
   const lines: string[] = []
   for (let r = Math.max(0, start.row); r <= Math.min(rows.length - 1, end.row); r++) {
     const text = rowText(rows[r] ?? [])
-    const span = rowSpan(range, r, Math.max(text.length, 1))
+    const span = rowSpan(range, r, Math.max(textCells(text), 1))
     if (!span) continue
-    lines.push(Array.from(text).slice(span[0], span[1]).join("").trimEnd())
+    lines.push(sliceTextByCells(text, span[0], span[1]).selected.trimEnd())
   }
   return lines.join("\n")
 }
@@ -69,19 +117,14 @@ function overlayRowSpan(row: readonly Chunk[], from: number, to: number): Chunk[
   const out: Chunk[] = []
   let col = 0
   for (const chunk of row) {
-    const chars = Array.from(chunk.text)
     const start = col
-    const end = start + chars.length
+    const end = start + textCells(chunk.text)
     col = end
     if (end <= from || start >= to) {
       out.push(chunk)
       continue
     }
-    const cutA = Math.max(from - start, 0)
-    const cutB = Math.min(to - start, chars.length)
-    const before = chars.slice(0, cutA).join("")
-    const selected = chars.slice(cutA, cutB).join("")
-    const after = chars.slice(cutB).join("")
+    const { before, selected, after } = sliceTextByCells(chunk.text, from - start, to - start)
     if (before) out.push({ ...chunk, text: before })
     out.push({ ...chunk, text: selected, attributes: (chunk.attributes ?? 0) | ATTR.INVERSE })
     if (after) out.push({ ...chunk, text: after })

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { displayWidth } from "../../src/lib/display-width"
 import { ATTR, type Chunk } from "../../src/tui/panes/terminal/sgr"
 import {
   extractSelection,
@@ -52,5 +53,45 @@ describe("terminal grid selection", () => {
     const range = { anchor: { row: 0, col: 0 }, head: { row: 0, col: 5 } }
     const out = overlaySelection(short, range, 0, 10)
     expect(out[0].map((c) => c.text).join("")).toBe("ab    ")
+  })
+
+  it("extracts a CJK range by terminal cells in either drag direction", () => {
+    const cjk = [row("唯一需要区分的是：")]
+    const forward = { anchor: { row: 0, col: 4 }, head: { row: 0, col: 9 } }
+    const backward = { anchor: forward.head, head: forward.anchor }
+
+    expect(extractSelection(cjk, forward)).toBe("需要区")
+    expect(extractSelection(cjk, backward)).toBe("需要区")
+  })
+
+  it("highlights whole wide glyphs without over-padding the row", () => {
+    const cjk = [row("你a")]
+    const range = { anchor: { row: 0, col: 0 }, head: { row: 0, col: 4 } }
+    const out = overlaySelection(cjk, range, 0, 5)[0]
+    const painted = out.filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+
+    expect(painted.map((c) => c.text).join("")).toBe("你a  ")
+    expect(displayWidth(out.map((c) => c.text).join(""))).toBe(5)
+  })
+
+  it("selects a whole wide glyph when the range hits its trailing cell", () => {
+    const cjk = [row("你a")]
+    const range = { anchor: { row: 0, col: 1 }, head: { row: 0, col: 1 } }
+
+    // A zero-width drag is normally filtered by the hook; the pure overlay
+    // still defines how a one-cell range inside a wide glyph is painted.
+    const out = overlaySelection(cjk, range, 0, 3)[0]
+    const painted = out.filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+    expect(painted.map((c) => c.text).join("")).toBe("你")
+  })
+
+  it("keeps emoji cell coordinates aligned across styled chunks", () => {
+    const styled: readonly (readonly Chunk[])[] = [[{ text: "🚀", fg: [1, 2, 3] }, { text: "go" }]]
+    const range = { anchor: { row: 0, col: 2 }, head: { row: 0, col: 2 } }
+
+    expect(extractSelection(styled, range)).toBe("g")
+    const out = overlaySelection(styled, range, 0, 4)[0]
+    const painted = out.filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+    expect(painted.map((c) => c.text).join("")).toBe("g")
   })
 })

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -94,4 +94,17 @@ describe("terminal grid selection", () => {
     const painted = out.filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
     expect(painted.map((c) => c.text).join("")).toBe("g")
   })
+
+  it("keeps zero-width marks attached before, inside, and after a selection", () => {
+    const decomposed = "a\u0301b\u0301c\u0301"
+    const rows = [row(decomposed)]
+    const range = { anchor: { row: 0, col: 1 }, head: { row: 0, col: 1 } }
+
+    expect(displayWidth(decomposed)).toBe(3)
+    expect(extractSelection(rows, range)).toBe("b\u0301")
+    const out = overlaySelection(rows, range, 0, 3)[0]
+    expect(out.map((c) => c.text).join("")).toBe(decomposed)
+    const painted = out.filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+    expect(painted.map((c) => c.text).join("")).toBe("b\u0301")
+  })
 })


### PR DESCRIPTION
## Summary
- map embedded-terminal selection spans by terminal-cell width instead of Unicode character index
- keep wide glyphs whole when either cell is selected and preserve zero-width marks with their preceding glyph
- add regression coverage for Chinese, emoji, reverse drags, styled chunks, and row padding

## Verification
- `bun run lint`
- `bun run typecheck`
- focused terminal selection/render/unicode tests: 16 passed
- fast suite: 2,373 passed

## Unrelated local gate failures
- socket suite: `file-watch-trigger.test.ts` times out waiting for a second chokidar change event; this PR does not touch daemon/watch code
- visual harness: Kanban navigation/screenshot timing is unstable without any terminal selection active; this PR changes output only when a selection range exists

Patch changeset included.