### PR TITLE
Accept attachment drops outside ChatTab focus

### DIFF
--- a/.changeset/unfocused-chat-attachment-paste.md
+++ b/.changeset/unfocused-chat-attachment-paste.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Let the visible ChatTab accept dragged image and PDF paths while Sidebar or Files retains keyboard focus, without submitting the prompt or stealing focus.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -251,6 +251,10 @@ export function Terminal(props: TerminalProps) {
 
   useTerminalBindings({
     focused,
+    // IME anchor ownership already identifies the visible ChatTab's active
+    // leaf while Sidebar or Files owns keyboard focus. Reuse that single
+    // target for attachment drops so split siblings never receive duplicates.
+    unfocusedAttachmentTarget: imeAnchorActive,
     write: (data) => {
       if (!pty || pty.killed) return
       pty.write(data)

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -72,7 +72,9 @@ export type TerminalProps = {
    * Whether this mounted terminal represents the visible chat tab / active
    * split leaf for macOS IME placement. Unlike `focused`, this stays true when
    * keyboard ownership moves to Sidebar or Files. Inactive split leaves pass
-   * false so background output cannot steal the shared anchor.
+   * false so background output cannot steal the shared anchor. An explicit
+   * true also designates the sole unfocused attachment-paste target; omission
+   * remains IME-compatible but fails closed for attachment routing.
    */
   imeAnchorActive?: boolean
   /**
@@ -224,6 +226,7 @@ export function Terminal(props: TerminalProps) {
   // A modal input owns the native cursor while it is open. Side-pane focus
   // does not: the visible terminal remains the stable IME fallback there.
   const imeAnchorActive = (props.imeAnchorActive ?? true) && dialog.stack.length === 0
+  const unfocusedAttachmentTarget = props.imeAnchorActive === true && dialog.stack.length === 0
   const resetTaskIdRef = useLatest(props.taskId)
   const resetCwdRef = useLatest(props.cwd)
   const mountedRef = useRef(true)
@@ -251,10 +254,9 @@ export function Terminal(props: TerminalProps) {
 
   useTerminalBindings({
     focused,
-    // IME anchor ownership already identifies the visible ChatTab's active
-    // leaf while Sidebar or Files owns keyboard focus. Reuse that single
-    // target for attachment drops so split siblings never receive duplicates.
-    unfocusedAttachmentTarget: imeAnchorActive,
+    // TerminalSplit explicitly assigns IME ownership to its active leaf.
+    // Require that explicit signal here so standalone/future mounts fail closed.
+    unfocusedAttachmentTarget,
     write: (data) => {
       if (!pty || pty.killed) return
       pty.write(data)

--- a/packages/kobe/src/tui-react/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/keys.ts
@@ -35,8 +35,8 @@ export { DEFAULT_PAGE_SIZE, TRAPPED_KEYS, keyEventToShellBytes }
 export type TerminalBindingsOpts = {
   /** Whether the terminal pane currently has focus. */
   focused: boolean
-  /** Capture image/PDF path pastes while unfocused (the visible engine leaf only). */
-  unfocusedAttachmentTarget?: boolean
+  /** Whether this caller explicitly owns image/PDF path pastes while unfocused. */
+  unfocusedAttachmentTarget: boolean
   /** Forward a byte sequence to the underlying PTY. */
   write: (data: string) => void
   /** Deliver pasted text (backend applies bracketed-paste wrapping). */
@@ -111,9 +111,7 @@ export function useTerminalBindings(opts: TerminalBindingsOpts): void {
       if (evt.defaultPrevented || modalActive()) return
       const text = decodePasteBytes(evt.bytes)
       if (text.length === 0) return
-      if (!optsRef.current.focused) {
-        if (!optsRef.current.unfocusedAttachmentTarget || !asAttachmentPaths(text)) return
-      }
+      if (!optsRef.current.focused && (!optsRef.current.unfocusedAttachmentTarget || !asAttachmentPaths(text))) return
       optsRef.current.paste(text)
       evt.preventDefault()
     }

--- a/packages/kobe/src/tui-react/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/keys.ts
@@ -14,9 +14,10 @@
  * the raw keypress/paste listeners on the renderer).
  */
 
-import type { KeyEvent } from "@opentui/core"
+import { type KeyEvent, decodePasteBytes } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
 import { useEffect, useMemo, useRef } from "react"
+import { asAttachmentPaths } from "../../../tui/lib/attachments"
 import {
   DEFAULT_PAGE_SIZE,
   PASSTHROUGH_CHORDS,
@@ -34,6 +35,8 @@ export { DEFAULT_PAGE_SIZE, TRAPPED_KEYS, keyEventToShellBytes }
 export type TerminalBindingsOpts = {
   /** Whether the terminal pane currently has focus. */
   focused: boolean
+  /** Capture image/PDF path pastes while unfocused (the visible engine leaf only). */
+  unfocusedAttachmentTarget?: boolean
   /** Forward a byte sequence to the underlying PTY. */
   write: (data: string) => void
   /** Deliver pasted text (backend applies bracketed-paste wrapping). */
@@ -105,9 +108,12 @@ export function useTerminalBindings(opts: TerminalBindingsOpts): void {
       evt.preventDefault()
     }
     const forwardPaste = (evt: { bytes: Uint8Array; defaultPrevented: boolean; preventDefault(): void }) => {
-      if (!optsRef.current.focused || evt.defaultPrevented || modalActive()) return
-      const text = new TextDecoder().decode(evt.bytes)
+      if (evt.defaultPrevented || modalActive()) return
+      const text = decodePasteBytes(evt.bytes)
       if (text.length === 0) return
+      if (!optsRef.current.focused) {
+        if (!optsRef.current.unfocusedAttachmentTarget || !asAttachmentPaths(text)) return
+      }
       optsRef.current.paste(text)
       evt.preventDefault()
     }

--- a/packages/kobe/test/render/terminal-ime-keys.test.tsx
+++ b/packages/kobe/test/render/terminal-ime-keys.test.tsx
@@ -27,6 +27,7 @@ function Probe(opts: { writes: string[]; globalHits: string[]; focused: boolean 
   }))
   useTerminalBindings({
     focused: opts.focused,
+    unfocusedAttachmentTarget: false,
     write: (d: string) => opts.writes.push(d),
     paste: () => {},
     scroll: () => {},

--- a/packages/kobe/test/render/terminal-modal-keys.test.tsx
+++ b/packages/kobe/test/render/terminal-modal-keys.test.tsx
@@ -21,6 +21,7 @@ function TerminalProbe(props: { writes: string[] }) {
   // up (border stays lit); that unchanged focus is what made the leak.
   useTerminalBindings({
     focused: true,
+    unfocusedAttachmentTarget: false,
     write: (d: string) => props.writes.push(d),
     paste: () => {},
     scroll: () => {},

--- a/packages/kobe/test/render/terminal-prefix.test.tsx
+++ b/packages/kobe/test/render/terminal-prefix.test.tsx
@@ -37,6 +37,7 @@ function Probe(opts: { writes: string[]; actionHits: string[] }) {
   }))
   useTerminalBindings({
     focused: true,
+    unfocusedAttachmentTarget: false,
     write: (d: string) => opts.writes.push(d),
     paste: () => {},
     scroll: () => {},

--- a/packages/kobe/test/render/terminal-unfocused-attachment-paste.test.tsx
+++ b/packages/kobe/test/render/terminal-unfocused-attachment-paste.test.tsx
@@ -11,11 +11,11 @@
  */
 import { describe, expect, it } from "bun:test"
 import { resolve } from "node:path"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
 import { useTerminalBindings } from "../../src/tui-react/panes/terminal/keys"
 import { DialogProvider, useDialog } from "../../src/tui-react/ui/dialog"
-import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
+import { type ScriptedPtyRegistry, createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
 import { act, renderComponent, settle } from "./harness"
 
 const IMAGE_PATH = resolve(import.meta.dir, "../../../../public/assets/logos/cursor-block.png")
@@ -27,13 +27,39 @@ function PasteProbe(props: {
 }) {
   useTerminalBindings({
     focused: props.focused === true,
-    unfocusedAttachmentTarget: props.target,
+    unfocusedAttachmentTarget: props.target === true,
     write: () => {},
     paste: (text) => props.pastes.push(text),
     scroll: () => {},
     reset: () => {},
   })
   return <box />
+}
+
+function ActiveLeafTerminals(props: {
+  harness: ScriptedPtyRegistry
+  api: { setActive?: (leaf: "left" | "right") => void }
+}) {
+  const [active, setActive] = useState<"left" | "right">("left")
+  props.api.setActive = setActive
+  return (
+    <box flexDirection="row" flexGrow={1}>
+      <Terminal
+        cwd="/wt"
+        taskId="left"
+        focused={false}
+        imeAnchorActive={active === "left"}
+        registry={props.harness.registry}
+      />
+      <Terminal
+        cwd="/wt"
+        taskId="right"
+        focused={false}
+        imeAnchorActive={active === "right"}
+        registry={props.harness.registry}
+      />
+    </box>
+  )
 }
 
 function DialogDriver(props: { onMount: (dialog: ReturnType<typeof useDialog>) => void }) {
@@ -58,34 +84,48 @@ describe("terminal pane — unfocused attachment paste", () => {
     expect(harness.last().pastes).toEqual([IMAGE_PATH])
   })
 
-  it("leaves ordinary text and non-target terminals untouched", async () => {
+  it("leaves ordinary text untouched even on the designated target", async () => {
     const pastes: string[] = []
-    const { renderer } = await renderComponent(<PasteProbe pastes={pastes} />)
+    const { renderer } = await renderComponent(<PasteProbe target pastes={pastes} />)
 
-    act(() => {
-      renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH))
-      renderer.keyInput.processPaste(new TextEncoder().encode("explain this failure"))
-    })
+    act(() => renderer.keyInput.processPaste(new TextEncoder().encode("explain this failure")))
     await settle()
 
     expect(pastes).toHaveLength(0)
   })
 
-  it("delivers to only the designated terminal when multiple leaves are mounted", async () => {
-    const targetPastes: string[] = []
-    const siblingPastes: string[] = []
-    const { renderer } = await renderComponent(
-      <>
-        <PasteProbe pastes={siblingPastes} />
-        <PasteProbe target pastes={targetPastes} />
-      </>,
-    )
+  it("leaves attachment paths untouched on a non-target terminal", async () => {
+    const pastes: string[] = []
+    const { renderer } = await renderComponent(<PasteProbe pastes={pastes} />)
 
     act(() => renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH)))
     await settle()
 
-    expect(targetPastes).toEqual([IMAGE_PATH])
-    expect(siblingPastes).toHaveLength(0)
+    expect(pastes).toHaveLength(0)
+  })
+
+  it("follows active-leaf ownership across multiple mounted Terminals", async () => {
+    const harness = createScriptedPtyRegistry()
+    const api: { setActive?: (leaf: "left" | "right") => void } = {}
+    const { renderer, frame } = await renderComponent(<ActiveLeafTerminals harness={harness} api={api} />, {
+      providers: { dialog: true },
+    })
+    await frame()
+    expect(harness.ptys).toHaveLength(2)
+
+    act(() => renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH)))
+    await settle()
+
+    expect(harness.ptys[0]?.pastes).toEqual([IMAGE_PATH])
+    expect(harness.ptys[1]?.pastes).toHaveLength(0)
+
+    act(() => api.setActive?.("right"))
+    await frame()
+    act(() => renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH)))
+    await settle()
+
+    expect(harness.ptys[0]?.pastes).toEqual([IMAGE_PATH])
+    expect(harness.ptys[1]?.pastes).toEqual([IMAGE_PATH])
   })
 
   it("keeps the focused terminal's normal paste behavior", async () => {

--- a/packages/kobe/test/render/terminal-unfocused-attachment-paste.test.tsx
+++ b/packages/kobe/test/render/terminal-unfocused-attachment-paste.test.tsx
@@ -1,0 +1,122 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Finder screenshot drag-drop routing while the workspace is unfocused.
+ *
+ * iTerm turns a file drop into a terminal paste event without preserving the
+ * drop coordinates. Kobe therefore reuses IME-anchor ownership to designate
+ * exactly one mounted Terminal: the visible ChatTab's active leaf. That target
+ * may consume an existing image/PDF path while Sidebar or Files owns keyboard
+ * focus; ordinary text, non-target terminals, and modal-covered terminals
+ * must remain untouched.
+ */
+import { describe, expect, it } from "bun:test"
+import { resolve } from "node:path"
+import { useEffect } from "react"
+import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
+import { useTerminalBindings } from "../../src/tui-react/panes/terminal/keys"
+import { DialogProvider, useDialog } from "../../src/tui-react/ui/dialog"
+import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
+import { act, renderComponent, settle } from "./harness"
+
+const IMAGE_PATH = resolve(import.meta.dir, "../../../../public/assets/logos/cursor-block.png")
+
+function PasteProbe(props: {
+  focused?: boolean
+  target?: boolean
+  pastes: string[]
+}) {
+  useTerminalBindings({
+    focused: props.focused === true,
+    unfocusedAttachmentTarget: props.target,
+    write: () => {},
+    paste: (text) => props.pastes.push(text),
+    scroll: () => {},
+    reset: () => {},
+  })
+  return <box />
+}
+
+function DialogDriver(props: { onMount: (dialog: ReturnType<typeof useDialog>) => void }) {
+  const dialog = useDialog()
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only test handoff.
+  useEffect(() => props.onMount(dialog), [])
+  return null
+}
+
+describe("terminal pane — unfocused attachment paste", () => {
+  it("routes through the visible Terminal's IME-anchor ownership without focus", async () => {
+    const harness = createScriptedPtyRegistry()
+    const { renderer, frame } = await renderComponent(
+      <Terminal cwd="/wt" taskId="chat" focused={false} imeAnchorActive registry={harness.registry} />,
+      { providers: { dialog: true } },
+    )
+    await frame()
+
+    act(() => renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH)))
+    await settle()
+
+    expect(harness.last().pastes).toEqual([IMAGE_PATH])
+  })
+
+  it("leaves ordinary text and non-target terminals untouched", async () => {
+    const pastes: string[] = []
+    const { renderer } = await renderComponent(<PasteProbe pastes={pastes} />)
+
+    act(() => {
+      renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH))
+      renderer.keyInput.processPaste(new TextEncoder().encode("explain this failure"))
+    })
+    await settle()
+
+    expect(pastes).toHaveLength(0)
+  })
+
+  it("delivers to only the designated terminal when multiple leaves are mounted", async () => {
+    const targetPastes: string[] = []
+    const siblingPastes: string[] = []
+    const { renderer } = await renderComponent(
+      <>
+        <PasteProbe pastes={siblingPastes} />
+        <PasteProbe target pastes={targetPastes} />
+      </>,
+    )
+
+    act(() => renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH)))
+    await settle()
+
+    expect(targetPastes).toEqual([IMAGE_PATH])
+    expect(siblingPastes).toHaveLength(0)
+  })
+
+  it("keeps the focused terminal's normal paste behavior", async () => {
+    const pastes: string[] = []
+    const { renderer } = await renderComponent(<PasteProbe focused pastes={pastes} />)
+
+    act(() => renderer.keyInput.processPaste(new TextEncoder().encode("ordinary prompt text")))
+    await settle()
+
+    expect(pastes).toEqual(["ordinary prompt text"])
+  })
+
+  it("does not route behind an open modal", async () => {
+    const pastes: string[] = []
+    const dialogRef: { current?: ReturnType<typeof useDialog> } = {}
+    const { renderer, frame } = await renderComponent(
+      <DialogProvider>
+        <PasteProbe target pastes={pastes} />
+        <DialogDriver
+          onMount={(dialog) => {
+            dialogRef.current = dialog
+          }}
+        />
+      </DialogProvider>,
+    )
+
+    act(() => dialogRef.current?.replace(() => <text>rename dialog</text>))
+    expect(await frame()).toContain("rename dialog")
+    act(() => renderer.keyInput.processPaste(new TextEncoder().encode(IMAGE_PATH)))
+    await settle()
+
+    expect(pastes).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

- route dragged image and PDF paths to the visible ChatTab's active terminal while Sidebar or Files retains keyboard focus
- preserve ordinary paste routing, modal ownership, split-leaf uniqueness, and paste-only behavior without auto-submit
- add OpenTUI renderer regressions plus a patch changeset

## Verification

- bun run lint
- bun --filter @sma1lboy/kobe typecheck
- bun --filter @sma1lboy/kobe test:fast (253 files, 2382 tests)
- bun --filter @sma1lboy/kobe test:render (148 tests)
- BASE_REF=main KOBE_RENDER_COVERAGE=1 bun scripts/coverage-gate.mjs