### PR TITLE
fix: keep the empty first line when copying a terminal selection

### DIFF
--- a/.changeset/terminal-copy-empty-first-line.md
+++ b/.changeset/terminal-copy-empty-first-line.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix embedded-terminal copy losing a line when a selection starts in the blank space past a short line: dragging from the empty padding to the right of a short row down into the next line highlighted both rows but copied only the lower one, silently dropping the leading blank line (and its newline) so two visibly-selected lines collapsed into one. The copy now keeps every highlighted row — an empty first line contributes an empty line, matching what the on-screen selection shows.

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -97,8 +97,18 @@ function sliceTextByCells(text: string, from: number, to: number): CellSlice {
 
 /**
  * Extract the selected text: per-row slice by span, trailing whitespace
- * trimmed per line (terminal rows are space-padded to the grid width),
- * lines joined with \n.
+ * trimmed per line, lines joined with \n.
+ *
+ * Snapshot rows are TRIMMED, not grid-padded (`xtermLineToChunks` drops
+ * trailing blank cells), so a row's text can be shorter than the grid. The
+ * mouse column, however, is clamped to the grid width — a drag can anchor in
+ * the blank padding past a short line. When that happens on a multi-row
+ * selection's FIRST row, its selected slice is empty. The loop only visits
+ * rows within `[start.row, end.row]`, so a null span here always means "in
+ * selection, empty slice" (rowSpan's out-of-range null can't occur inside
+ * these bounds) — it must still contribute an empty line so the newline
+ * survives, matching what `overlaySelection` highlights. Dropping it collapsed
+ * two visibly-selected lines into one on copy.
  */
 export function extractSelection(rows: readonly (readonly Chunk[])[], range: SelectionRange): string {
   const { start, end } = orderRange(range)
@@ -106,8 +116,7 @@ export function extractSelection(rows: readonly (readonly Chunk[])[], range: Sel
   for (let r = Math.max(0, start.row); r <= Math.min(rows.length - 1, end.row); r++) {
     const text = rowText(rows[r] ?? [])
     const span = rowSpan(range, r, Math.max(textCells(text), 1))
-    if (!span) continue
-    lines.push(sliceTextByCells(text, span[0], span[1]).selected.trimEnd())
+    lines.push(span ? sliceTextByCells(text, span[0], span[1]).selected.trimEnd() : "")
   }
   return lines.join("\n")
 }

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -36,6 +36,29 @@ describe("terminal grid selection", () => {
     expect(extractSelection(ROWS, { anchor: { row: 1, col: 6 }, head: { row: 1, col: 0 } })).toBe("charlie")
   })
 
+  it("keeps the empty first line when a multi-row drag anchors past a short row's text", () => {
+    // Real snapshot rows are TRIMMED, not grid-padded, and the mouse column is
+    // clamped to the grid width — so a drag can anchor in the blank padding
+    // past a short first line (here col 5, past "ab"). That row is still part
+    // of the selection (overlaySelection highlights it), so the copy must keep
+    // it as an empty line, preserving the newline into the next row.
+    const rows = [row("ab"), row("cdef")]
+    const range = { anchor: { row: 0, col: 5 }, head: { row: 1, col: 2 } }
+    expect(extractSelection(rows, range)).toBe("\ncde")
+    // overlaySelection (grid width 8) does highlight that first row — the two
+    // sides must agree on which rows are selected.
+    const painted = overlaySelection(rows, range, 0, 8)[0].filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+    expect(painted.length).toBeGreaterThan(0)
+  })
+
+  it("preserves an interior blank line across a multi-row selection", () => {
+    // A wholly-blank middle row (trimmed to empty) must survive as "" so the
+    // reading-order line structure — and its newlines — is intact.
+    const rows = [row("first"), row(""), row("third")]
+    const range = { anchor: { row: 0, col: 0 }, head: { row: 2, col: 4 } }
+    expect(extractSelection(rows, range)).toBe("first\n\nthird")
+  })
+
   it("overlaySelection inverses exactly the selected cells of visible rows", () => {
     const range = { anchor: { row: 1, col: 8 }, head: { row: 1, col: 12 } }
     // Viewport starting at absolute row 1 → the selected row is index 0.


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found, reachable copy defect in the embedded-terminal grid selection (the same subsystem as the recent v0.8.13 wide-char copy fix). Chosen from a daily review pass over the pure/logic surface; the codebase is unusually clean and heavily tested, and this was the one concrete, user-facing, fully-verifiable correctness bug found.

## Problem

`extractSelection` (`src/tui/panes/terminal/terminal-selection.ts`) and `overlaySelection` disagree on which rows a selection covers:

- **Highlight** (`overlaySelection`) bounds each row's span by the **grid width**, so a short row is highlighted even when the drag anchored in the blank padding to its right (it even paints the padding).
- **Copy** (`extractSelection`) bounds by the **row's trimmed text width**. Snapshot rows are trimmed, not grid-padded (`xtermLineToChunks` drops trailing blanks), and the mouse column is clamped to the grid width (`useTerminalSelection.cellFromEvent`) — so on a multi-row selection whose **first** row is short and whose anchor sits past that row's text, `rowSpan` returns an empty span and the old code did `if (!span) continue`, **dropping the row entirely** rather than emitting an empty line.

Result: a two-line visual selection (first line highlighted) copies as **one** line — the leading blank line and its newline are silently lost. Reachable in normal use: start a drag in the empty area right of a short line and drag down.

Concrete case (unpadded rows, as real snapshots are):

```
rows  = [ "ab", "cdef" ]
range = anchor (0,5) → head (1,2)
before: "cde"      ← first row dropped, newline lost
after:  "\ncde"    ← first (empty) row preserved, matches the highlight
```

## Fix

Within `extractSelection`'s loop, every row visited is already within `[start.row, end.row]`, so a `null` span there can only mean "in selection, empty slice" — never `rowSpan`'s out-of-range null. Push an empty line for that case instead of `continue`, so the copy matches the on-screen highlight. One-line behavior change plus a corrected/expanded doc comment (the old comment wrongly claimed rows are "space-padded to the grid width").

## Verification

- New regression test in `test/tui/terminal-selection.test.ts` using **unpadded** rows (the existing `ROWS` fixture is space-padded to the grid width, which is exactly why the null-span path was never exercised). Confirmed it **fails before** the fix and **passes after**; a second test pins interior blank-line preservation.
- `bunx vitest run test/tui/terminal-selection.test.ts` → 12 passed.
- `test/tui/` full group → 88 files, 786 tests passed.
- `bun run lint` → clean; `bun run typecheck` (kobe) → clean.
- Patch changeset added (touches published copy behavior).

## Follow-ups (deliberately deferred, not in this PR)

- Separately found: `orchestrator/title.ts` `autoBranch` can emit a double hyphen (`kobe/...--<id>`) when the 32-char slug cap lands on a `-`, because the trailing-hyphen trim runs before the `.slice(0, 32)`. Cosmetic (git-valid) and out of this slice; can be a tiny standalone fix if wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaKK7Ew6KoRWoLHDcyBEP3)_