### PR TITLE
fix: re-trim the autoBranch slug after the 32-char cap

### DIFF
--- a/.changeset/fix-autobranch-double-hyphen.md
+++ b/.changeset/fix-autobranch-double-hyphen.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix auto-derived branch names showing a double hyphen (`kobe/<slug>--<id>`) when a long task title's 32-character slug cap lands on a word boundary: the trailing-hyphen trim ran before the cap, so the slice could re-introduce a trailing `-` that the `-<id>` suffix then doubled. The slug is now re-trimmed after the cap, so branches read `kobe/<slug>-<id>` cleanly regardless of where the title is truncated.

--- a/packages/kobe/src/orchestrator/title.ts
+++ b/packages/kobe/src/orchestrator/title.ts
@@ -50,6 +50,11 @@ export function autoBranch(title: string, taskId: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 32)
+    // Re-trim after the cap: the 32-char slice can land on a `-` and
+    // re-introduce a trailing hyphen that the template below would then
+    // double into `kobe/<slug>--<suffix>`. Only trailing can reappear —
+    // the slice keeps the already-leading-trimmed prefix.
+    .replace(/-+$/, "")
   const suffix = taskId.slice(-6).toLowerCase()
   const base = slug || "task"
   return `kobe/${base}-${suffix}`

--- a/packages/kobe/test/orchestrator/title.test.ts
+++ b/packages/kobe/test/orchestrator/title.test.ts
@@ -27,6 +27,15 @@ describe("autoBranch", () => {
     expect(slug.length).toBeLessThanOrEqual(32)
     expect(slug).toBe("fix-the-very-long-feature-name-t")
   })
+
+  it("never emits a double hyphen when the 32-char cap lands on a word boundary", () => {
+    // The trailing-hyphen trim runs BEFORE the .slice(0, 32) cap, so a slice
+    // that ends on a `-` used to survive into the template as `kobe/<slug>--<id>`.
+    // Reachable whenever char 33 is a word boundary: 31 slug chars + a space + a word.
+    const branch = autoBranch(`${"a".repeat(31)} bar`, "01HXQQQQQQ")
+    expect(branch).toBe(`kobe/${"a".repeat(31)}-qqqqqq`)
+    expect(branch).not.toContain("--")
+  })
 })
 
 describe("deriveTitleFromPrompt", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in `orchestrator/title.ts` `autoBranch`, surfaced during a daily review pass over the pure-logic surface (orchestrator, tui/lib, terminal panes, state, engine normalization). The codebase is well-tested and clean; this was the one uncovered, isolated, fully-verifiable correctness bug not already claimed by an open PR. (A separate highlight-paint defect in `terminal-selection.ts` was found but deliberately skipped — that file is being actively reworked by open PR #358, and touching it would overlap an in-flight PR.)

## Problem

`autoBranch(title, taskId)` builds `kobe/<slug>-<id6>` from a task title. The slug pipeline trims trailing hyphens **before** capping at 32 chars:

```ts
const slug = title
  .toLowerCase()
  .replace(/[^a-z0-9]+/g, "-")
  .replace(/^-+|-+$/g, "")   // trailing trim happens here…
  .slice(0, 32)              // …but the cap runs after, and can re-introduce a trailing "-"
```

When the 32-char cut lands on a word boundary, `.slice(0, 32)` re-introduces a trailing `-` that the final `kobe/${base}-${suffix}` template then doubles.

Concrete, reachable case — a 31-char word + space + another word:

```
autoBranch("a".repeat(31) + " bar", "01HXQQQQQQ")
before: kobe/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa--qqqqqq   ← double hyphen
after:  kobe/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-qqqqqq    ← clean
```

The malformed name is git-valid, so nothing breaks — but users see the `--` branch in git, worktrees, the sidebar, and generated PRs, and it reads as broken.

## Fix

Re-trim trailing hyphens **after** the cap (`.replace(/-+$/, "")`). Only trailing hyphens can reappear — the slice keeps the already-leading-trimmed prefix — so a single trailing re-trim is sufficient and leaves every existing case unchanged.

## Verification

- Added a regression test in `test/orchestrator/title.test.ts`; confirmed it **fails before** the fix (`kobe/…--qqqqqq`) and **passes after**.
- `bunx vitest run test/orchestrator/title.test.ts` → 9 passed.
- Full group `test/orchestrator/` → 25 files, 186 tests passed.
- `bun run lint` → clean; `bun run typecheck` (daemon + kobe) → clean.
- Patch changeset added (touches published branch-name behavior).

## Follow-ups (deliberately deferred, not in this PR)

- `terminal-selection.ts` `overlayRowSpan`: when a row's selection span starts past the row's painted text (`from > col`), the trailing-pad branch emits the inverse-video block starting at `col` instead of `from`, so the highlight is drawn `from - col` cells too short / shifted left. Rendering-only (copy text is unaffected). Left out because that file is under active change in open PR #358 — worth a standalone fix once #358 lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_018KKBQYV2AoXs1gUsqPhJpC)_