### PR TITLE
fix: parse an attached quoted flag in a custom engine command

### DIFF
--- a/.changeset/engine-command-attached-quote.md
+++ b/.changeset/engine-command-attached-quote.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix a custom engine launch command in Settings → Engines mis-splitting an attached quoted flag: `claude --append-system-prompt="be terse"` (the common `--flag="value with spaces"` idiom) was parsed as two broken argv elements (`--append-system-prompt="be` and `terse"`) instead of one (`--append-system-prompt=be terse`), because the tokenizer only honored a quote that started a word. The command splitter now treats a quote opening anywhere in a token as a quoted span that concatenates with the surrounding text — matching a shell — so both the attached (`--flag="…"`) and separated (`--flag "…"`) forms launch the engine with the argv you configured; an unterminated quote runs to the end of the command rather than being kept literally.

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -85,15 +85,43 @@ export function defaultEngineCommand(vendor: VendorId | undefined): readonly str
 
 /**
  * Split a command string into argv, honouring single/double quotes so a
- * flag value with a space survives (`claude --append-system-prompt "be
- * terse"`). Whitespace-separated otherwise. Returns `[]` for blank input.
+ * flag value with a space survives — in BOTH the separated form
+ * (`claude --append-system-prompt "be terse"`) and the attached form
+ * (`claude --append-system-prompt="be terse"`, the common CLI idiom).
+ * Whitespace-separated otherwise. A quote may open anywhere in a token and
+ * its content concatenates with the surrounding unquoted text, matching a
+ * shell's word-splitting; the other quote kind is literal inside a quoted
+ * span (`--x='a "b" c'` → `--x=a "b" c`). An unterminated quote runs to the
+ * end of the string. Pure, total, never throws. Returns `[]` for blank input.
  */
 export function parseEngineCommand(command: string): string[] {
   const out: string[] = []
-  const re = /"([^"]*)"|'([^']*)'|(\S+)/g
-  for (let m = re.exec(command); m !== null; m = re.exec(command)) {
-    out.push(m[1] ?? m[2] ?? m[3] ?? "")
+  let token = ""
+  let hasToken = false // distinguishes an empty quoted arg ("") from no arg
+  let quote: '"' | "'" | null = null
+  for (const ch of command) {
+    if (quote) {
+      if (ch === quote) quote = null
+      else token += ch
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      hasToken = true
+      continue
+    }
+    if (/\s/.test(ch)) {
+      if (hasToken) {
+        out.push(token)
+        token = ""
+        hasToken = false
+      }
+      continue
+    }
+    token += ch
+    hasToken = true
   }
+  if (hasToken) out.push(token)
   return out
 }
 

--- a/packages/kobe/test/engine/interactive-command.test.ts
+++ b/packages/kobe/test/engine/interactive-command.test.ts
@@ -24,6 +24,28 @@ describe("parseEngineCommand", () => {
     expect(parseEngineCommand("codex --x 'a b c'")).toEqual(["codex", "--x", "a b c"])
   })
 
+  it('keeps a quote attached to a flag (--flag="value with spaces") as one element', () => {
+    // The common CLI idiom: a quote opens mid-token and concatenates with the
+    // `--flag=` prefix rather than starting a fresh, mis-split argv element.
+    expect(parseEngineCommand('claude --append-system-prompt="be terse"')).toEqual([
+      "claude",
+      "--append-system-prompt=be terse",
+    ])
+    expect(parseEngineCommand("codex --x='a b c'")).toEqual(["codex", "--x=a b c"])
+  })
+
+  it("treats the other quote kind as literal inside a quoted span", () => {
+    expect(parseEngineCommand("claude --x='a \"b\" c'")).toEqual(["claude", '--x=a "b" c'])
+  })
+
+  it("concatenates adjacent quoted and unquoted spans within one token", () => {
+    expect(parseEngineCommand('a"b c"d')).toEqual(["ab cd"])
+  })
+
+  it("runs an unterminated quote to the end of the string", () => {
+    expect(parseEngineCommand('claude "be terse')).toEqual(["claude", "be terse"])
+  })
+
   it("collapses extra whitespace and ignores leading/trailing spaces", () => {
     expect(parseEngineCommand("  spaced   out ")).toEqual(["spaced", "out"])
   })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found, reachable defect in `parseEngineCommand` (`src/engine/interactive-command.ts`), surfaced during a daily review pass over the pure-logic surface (lib, state, engine, orchestrator, monitor, core). The codebase is unusually clean and heavily tested; this was the one concrete, user-facing, fully-verifiable bug not already claimed by an open PR (the terminal-selection and `autoBranch` defects are already in flight as #358 / #359).

## Problem

`parseEngineCommand` splits a user's custom engine launch command (set in **Settings → Engines**) into argv. It honors quotes only when a quote **starts** a word, via the regex `/"([^"]*)"|'([^']*)'|(\S+)/g` — so the common attached idiom `--flag="value with spaces"` is swallowed by the `\S+` branch and mis-split:

```
parseEngineCommand('claude --append-system-prompt="be terse"')
before: ["claude", '--append-system-prompt="be', 'terse"']   ← two broken elements, literal quote
after:  ["claude", "--append-system-prompt=be terse"]         ← one element, as configured
```

The **separated** form (`--append-system-prompt "be terse"`) already worked, so the two idioms disagreed. A user who writes the attached form — the more common shell habit — gets a malformed argv that mislaunches the engine (a stray `terse"` argument, a truncated system prompt), with no error to explain it. This flows through every launch site (`interactiveEngineCommand` → the outer monitor's Handover, the Tasks-pane switch, `new-chattab`).

## Fix

Replace the regex with a small shell-like character scanner: a quote opening **anywhere** in a token forms a quoted span whose content concatenates with the surrounding unquoted text (matching a shell's word-splitting). The other quote kind stays literal inside a quoted span (`--x='a "b" c'` → `--x=a "b" c`), and an unterminated quote runs to the end of the command rather than being kept with its literal opening quote. Pure, total, never throws. `src/engine/interactive-command.ts` stays at ~330 lines (well under the file-size cap).

## Verification

- Added 4 regression tests in `test/engine/interactive-command.test.ts` (attached `--flag="…"`, cross-quote literal, adjacent quoted/unquoted concatenation, unterminated quote). Confirmed all 4 **fail before** the fix and **pass after**; the 10 pre-existing `parseEngineCommand` cases (bare binary, whitespace split, separated `--flag "…"`, blank input) are unchanged.
- `bunx vitest run test/engine/ test/tui/issue-chat-spawn.test.ts test/cli/api-cmd-runtime.test.ts` → 33 files, 367 tests passed (the engine group plus the consumers of `interactiveEngineCommand`).
- `bun run lint` → clean; `bun run typecheck` (daemon + kobe) → clean.
- Patch changeset added (touches published engine-launch behavior).

## Follow-ups (deliberately deferred, not in this PR)

- Backslash escaping (`--flag=\"x\"`) is still not interpreted — the documented contract is quote-honoring only, and no launch idiom in the wild needs escapes today; adding a full escape layer would widen scope beyond this one bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxjPB1xYqc2GTydMYdneCn)_