### PR TITLE
fix: join gh stdout bytes before decoding PR titles

### DIFF
--- a/.changeset/pr-status-utf8-decode.md
+++ b/.changeset/pr-status-utf8-decode.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix garbled non-ASCII PR titles in the sidebar check-state chip: the daemon's PR-status poller decoded each `gh pr list --json` stdout chunk on its own, so a multi-byte UTF-8 character in a PR title (Chinese, emoji, accented text) that straddled a ~64 KB pipe-chunk boundary turned into replacement glyphs (`�`) before the JSON was parsed and the title persisted to the task — the same defect already fixed for the background git helpers now closed on the `gh` capture path by joining the raw bytes before decoding.

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -140,18 +140,32 @@ interface GhSpawnResult {
   readonly spawnError: boolean
 }
 
+/**
+ * Decode captured spawn chunks to one UTF-8 string. Chunks MUST be joined as
+ * bytes before decoding: a stdout pipe splits on an arbitrary byte boundary
+ * (~64 KB), so a multi-byte UTF-8 sequence — a non-ASCII PR title inside the
+ * `gh … --json` payload — can straddle two chunks. Decoding each chunk on its
+ * own (`String(chunk)`) turns the split character into replacement bytes
+ * (`�`); concatenating the raw bytes first decodes it intact. Mirrors
+ * `@sma1lboy/kobe`'s `decodeCapturedChunks` — the daemon can't import across
+ * the package boundary (see the file header). Pure — exported for unit tests.
+ */
+export function decodeSpawnChunks(chunks: readonly (Buffer | string)[]): string {
+  return Buffer.concat(chunks.map((c) => (typeof c === "string" ? Buffer.from(c) : c))).toString("utf8")
+}
+
 /** Spawn `gh` capturing stdout AND stderr (needed to classify the failure).
  * Never rejects: a spawn error or abort resolves with `status: null` so the
  * caller branches on the captured signals rather than a thrown error. */
 function spawnGh(args: readonly string[], cwd: string, signal: AbortSignal): Promise<GhSpawnResult> {
   return new Promise((resolve) => {
-    let out = ""
-    let err = ""
+    const outChunks: (Buffer | string)[] = []
+    const errChunks: (Buffer | string)[] = []
     let settled = false
     const finish = (status: number | null, spawnError: boolean): void => {
       if (settled) return
       settled = true
-      resolve({ status, stdout: out, stderr: err, spawnError })
+      resolve({ status, stdout: decodeSpawnChunks(outChunks), stderr: decodeSpawnChunks(errChunks), spawnError })
     }
     const child = spawn("gh", args.slice(), {
       cwd,
@@ -160,10 +174,10 @@ function spawnGh(args: readonly string[], cwd: string, signal: AbortSignal): Pro
       killSignal: "SIGKILL",
     })
     child.stdout?.on("data", (chunk: Buffer | string) => {
-      out += String(chunk)
+      outChunks.push(chunk)
     })
     child.stderr?.on("data", (chunk: Buffer | string) => {
-      err += String(chunk)
+      errChunks.push(chunk)
     })
     // An abort (our timeout) also surfaces as an `error` event — don't count
     // that as a spawn failure; the caller reads `timedOut` separately.

--- a/packages/kobe/test/daemon/pr-status-poller.test.ts
+++ b/packages/kobe/test/daemon/pr-status-poller.test.ts
@@ -18,6 +18,7 @@ import {
   type PrViewResult,
   type PrViewRunner,
   SETTLED_BACKOFF_MS,
+  decodeSpawnChunks,
   isPrPollable,
   pickPr,
   runPrStatusPass as runPrStatusPassRaw,
@@ -270,5 +271,27 @@ describe("runPrStatusPass", () => {
     expect(schedule.get(id)?.failures).toBe(0)
     expect(schedule.get(id)?.nextAllowedAt).toBe(1_000 + NO_REMOTE_BACKOFF_MS)
     expect(orch.getTask(id)?.prStatus).toBeUndefined()
+  })
+})
+
+describe("decodeSpawnChunks — join bytes before decoding the gh payload", () => {
+  test("a multi-byte char split across two chunks decodes intact", () => {
+    // "更" = U+66F4 = E6 9B B4 — a pipe chunk boundary can land mid-sequence.
+    const bytes = Buffer.from("更新", "utf8")
+    const first = bytes.subarray(0, 1)
+    const rest = bytes.subarray(1)
+    expect(decodeSpawnChunks([first, rest])).toBe("更新")
+    // The old per-chunk path (`String(chunk)` on each) would corrupt the split.
+    expect(String(first) + String(rest)).not.toBe("更新")
+  })
+
+  test("an emoji straddling a boundary survives", () => {
+    const bytes = Buffer.from("🚀", "utf8") // F0 9F 9A 80
+    expect(decodeSpawnChunks([bytes.subarray(0, 2), bytes.subarray(2)])).toBe("🚀")
+  })
+
+  test("ASCII, mixed string/Buffer chunks, and empty input are unchanged", () => {
+    expect(decodeSpawnChunks([Buffer.from("ab"), "cd"])).toBe("abcd")
+    expect(decodeSpawnChunks([])).toBe("")
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect surfaced during a daily review pass over the pure-logic surface (lib, state, monitor, engine, orchestrator, daemon protocol/collectors). The codebase is unusually clean and heavily tested; this was the one concrete, user-facing bug not already claimed by an open PR, and it matches the repo's own established fix pattern.

## Problem

The daemon's PR-status poller (`packages/kobe-daemon/src/daemon/pr-status-collector.ts`) shells `gh pr list --head <branch> --json …`, parses the JSON, and persists the PR title onto the task (rendered in the sidebar check-state chip + the web board). Its `spawnGh` helper accumulated stdout per chunk:

```ts
child.stdout?.on("data", (chunk) => { out += String(chunk) })
```

A Node stdout pipe splits on an arbitrary byte boundary (~64 KB), so a multi-byte UTF-8 character in a PR title (Chinese, emoji, accented text) that straddles a chunk boundary is decoded as two half-sequences, producing replacement glyphs (`�`). The JSON stays structurally valid, so nothing throws — the garbled title is silently persisted to `task.prStatus.title` and shown to the user.

This is the **exact** defect already fixed for the background git helpers in v0.8.15 (`b2df533`), for which the repo introduced the byte-join `decodeCapturedChunks` helper (`packages/kobe/src/lib/poll-scheduling.ts`, with its own regression test). This sibling `gh` capture path in the daemon was never converted.

## Fix

Buffer the raw stdout/stderr chunks and decode once with `Buffer.concat(...).toString("utf8")`, via a small exported `decodeSpawnChunks` helper local to the collector.

The daemon deliberately has **no dependency on the `@sma1lboy/kobe` package** (stated in the file header — the package graph must not invert), so `decodeCapturedChunks` cannot be imported; the helper is a self-contained mirror of it. `pr-status-collector.ts` stays at ~390 lines, under the file-size cap.

Not touched: `worktree-changes-collector.ts` uses the same `String(chunk)` pattern but only counts by ASCII status chars (`line[0]`/`line[1]`) and splits on `\n` (0x0A never appears inside a UTF-8 multibyte sequence), so a mid-path byte split is unobservable there — it is correct and out of this slice.

## Verification

- Added 3 regression tests in `test/daemon/pr-status-poller.test.ts` exercising `decodeSpawnChunks` directly: a Chinese char and an emoji split across a chunk boundary decode intact (the test also asserts the old `String(chunk)` path corrupts the same input), plus ASCII / mixed-type / empty inputs unchanged.
- `KOBE_INCLUDE_SOCKET=1 vitest run test/daemon/pr-status-poller.test.ts --pool forks` → 19 passed (16 pre-existing + 3 new).
- `bun run lint` → clean (759 files); `bun run typecheck` (daemon + kobe) → clean.
- Patch changeset added (touches published PR-status behavior).

## Follow-ups (deliberately deferred, not in this PR)

- The remaining `String(chunk)` at `worktree-changes-collector.ts:126` is left as-is (correct, as explained above) — converting it would be churn with no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnN4kXYjeJtY2LrGbjoQKR)_