### PR TITLE
fix: detect attached-form session flags in the Claude session guard

### DIFF
--- a/.changeset/fix-claude-session-guard-attached-flag.md
+++ b/.changeset/fix-claude-session-guard-attached-flag.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix a custom Claude launch command that pins its own session with the attached `--flag=value` form (`claude --resume=abc`, `--session-id=abc`, `--from-pr=42`) getting a second, conflicting `--session-id` force-appended by kobe — which Claude then rejects. The guard that detects an already-session-controlled command matched whole tokens, so it saw the separated form (`--resume abc`) but missed the attached form that the same command parser deliberately keeps as one token; it now compares the flag name before any `=`, so both forms launch the session you configured.

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -179,6 +179,19 @@ export function withEngineEffort(
 const CLAUDE_SESSION_CONTROL_FLAGS = new Set(["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"])
 
 /**
+ * Does `arg` carry a session-control flag, in EITHER the separated form
+ * (`--resume`, its own token) or the attached form (`--resume=abc`, one
+ * token)? `parseEngineCommand` preserves `--flag=value` as a single token
+ * (the documented `--append-system-prompt="…"` idiom), and Claude accepts
+ * `--session-id=<uuid>` / `--resume=<id>` / `--from-pr=<n>` too, so the guard
+ * must match on the flag NAME before any `=`, not the whole token.
+ */
+function isSessionControlFlag(arg: string): boolean {
+  const name = arg.startsWith("-") && arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg
+  return CLAUDE_SESSION_CONTROL_FLAGS.has(name)
+}
+
+/**
  * For a Claude launch, append a kobe-generated `--session-id <uuid>` so the
  * hosted session can be mapped to its transcript (recorded as the
  * `@kobe_session_id` window option) and auto-named from its first prompt
@@ -194,7 +207,7 @@ export function withClaudeSessionId(
   vendor: string | undefined,
 ): { argv: readonly string[]; sessionId: string | null } {
   if ((vendor ?? "claude") !== "claude") return { argv, sessionId: null }
-  if (argv.some((a) => CLAUDE_SESSION_CONTROL_FLAGS.has(a))) return { argv, sessionId: null }
+  if (argv.some(isSessionControlFlag)) return { argv, sessionId: null }
   const sessionId = randomUUID()
   return { argv: [...argv, "--session-id", sessionId], sessionId }
 }

--- a/packages/kobe/test/engine/interactive-command-overrides.test.ts
+++ b/packages/kobe/test/engine/interactive-command-overrides.test.ts
@@ -136,4 +136,17 @@ describe("withClaudeSessionId", () => {
       expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
     }
   })
+
+  it("honors the attached --flag=value form of a session control (parseEngineCommand keeps it one token)", () => {
+    for (const arg of ["--session-id=abc123", "--resume=abc123", "--from-pr=42"]) {
+      const argv = ["claude", arg]
+      expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
+    }
+  })
+
+  it("does not mistake an unrelated attached flag for a session control", () => {
+    const { argv, sessionId } = withClaudeSessionId(["claude", "--append-system-prompt=be terse"], "claude")
+    expect(sessionId).not.toBeNull()
+    expect(argv).toEqual(["claude", "--append-system-prompt=be terse", "--session-id", sessionId])
+  })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found latent defect surfaced by a code-review pass over `src/engine`. The codebase is mature and heavily tested; this is a concrete wrong-output bug rather than a speculative change.

## Problem

`withClaudeSessionId` (`packages/kobe/src/engine/interactive-command.ts`) appends a kobe-generated `--session-id <uuid>` to a Claude launch **unless** the command already controls its own session. That guard tested for a session-control flag by **whole-token** membership:

```ts
if (argv.some((a) => CLAUDE_SESSION_CONTROL_FLAGS.has(a))) return { argv, sessionId: null }
```

But the same module's `parseEngineCommand` deliberately preserves the **attached** `--flag=value` form as a single token — the `--append-system-prompt="…"` idiom fixed in 0.8.21 — and Claude accepts `--session-id=<uuid>`, `--resume=<id>`, and `--from-pr=<n>` in that form. Because `"--resume=abc" !== "--resume"`, the guard misses the attached form.

Every launch site composes argv via `withClaudeSessionId(interactiveEngineCommand(vendor), vendor)`, and `interactiveEngineCommand` builds argv from the user's per-vendor override. So a custom command such as `claude --resume=abc123` or `claude --session-id=abc123` reaches the guard as one attached token and slips through:

- **Input:** `withClaudeSessionId(["claude", "--resume=abc123"], "claude")`
- **Expected:** `{ argv: ["claude", "--resume=abc123"], sessionId: null }` — the command already controls its session.
- **Actual:** `{ argv: ["claude", "--resume=abc123", "--session-id", "<uuid>"], … }` — two conflicting session controls, which Claude rejects, so the session fails to launch (the `--session-id=…` attached form is worse: a literal duplicate flag).

The guard's own comment claims it "Covers both long and short forms," and the existing test only exercised the separated form (`["claude", flag, "x"]`), so the attached path was never characterized.

## Fix

Match on the flag **name** (the portion before any `=`) rather than the whole token, via a small pure helper `isSessionControlFlag`. This mirrors how the rest of the module already treats attached flags as first-class. One-line behavior change; no call-site changes.

## Verification

- `bunx vitest run test/engine/interactive-command-overrides.test.ts` → 18 passed (added: attached `--session-id=` / `--resume=` / `--from-pr=` all suppress the forced id; an unrelated attached flag like `--append-system-prompt=be terse` still gets a fresh `--session-id`).
- `bun run lint` → clean.
- `bun run typecheck` → clean (daemon + kobe).

Changeset: `.changeset/fix-claude-session-guard-attached-flag.md` (`patch`).

## Follow-ups (deliberately deferred, not in this PR)

- **Prefix keybinding overrides are all-or-nothing where the direct parser is partial-keep.** In `src/tui/lib/keymap-prefix-overrides.ts` (`collectEntries`), a binding list containing one invalid chord (`chat.tab.new: [n, ctrl+shift+z]`) discards the *whole* entry — the valid `n` is silently dropped and the default kept, with a warning only about the invalid chord. The sibling direct-chord parser (`keymap-overrides-parse.ts`) keeps the valid chords and only reverts to the default (with an explicit warning) when none survive. Aligning prefix overrides to that partial-keep contract is a separate, self-contained slice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVrg7Ky6nPvEKp3d4EmWFH)_