### PR TITLE
fix: ship React's production build in the bundled CLI

### DIFF
--- a/.changeset/react-production-build.md
+++ b/.changeset/react-production-build.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix unbounded memory growth in the TUI client. The published bundle shipped React's *development* build: `Bun.build` defaults `process.env.NODE_ENV` to `"development"`, so the bundler resolved react and react-reconciler to their development entries and inlined them. Those builds keep per-update debug bookkeeping alive, which grows without bound in a long-lived TUI — a session climbed several GB over a few hours, and the pressure could make tasks disappear from the sidebar.
+
+Both `build.ts` and `compile.ts` now pin `NODE_ENV=production`, and an architecture test guards the pin. The npm bundle also drops ~100 KB.

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -78,6 +78,11 @@ const result = await Bun.build({
   // resolve the optional platform package under isolated installs.
   external: ["node-pty", "@opentui/core"],
   minify: true,
+  // Without this Bun inlines NODE_ENV as "development", so react/react-reconciler
+  // pick their *development* builds and ship them to users. Those builds retain
+  // per-update debug bookkeeping (fiber _debugTask/_debugInfo, update-timer
+  // state), which grows unboundedly in a long-lived TUI — the #307 memory leak.
+  define: { "process.env.NODE_ENV": JSON.stringify("production") },
 })
 
 if (!result.success) {

--- a/packages/kobe/scripts/compile.ts
+++ b/packages/kobe/scripts/compile.ts
@@ -39,6 +39,9 @@ const result = await Bun.build({
   conditions: ["browser"],
   external: ["node-pty"],
   minify: true,
+  // Same reason as build.ts: default NODE_ENV is "development", which ships
+  // React's development reconciler and its per-update debug bookkeeping (#307).
+  define: { "process.env.NODE_ENV": JSON.stringify("production") },
   compile: { outfile },
 })
 if (!result.success) {

--- a/packages/kobe/test/architecture/production-react-build.test.ts
+++ b/packages/kobe/test/architecture/production-react-build.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression guard for #307: the shipped bundles must NOT contain React's
+ * development build.
+ *
+ * Bun defaults `process.env.NODE_ENV` to "development" during `Bun.build`, so
+ * without an explicit `define` the bundler resolves react/react-reconciler to
+ * their development entries and inlines them. Those builds keep per-update
+ * debug bookkeeping alive (fiber `_debugTask`/`_debugInfo`, update-timer
+ * state), which in a long-lived TUI grows without bound — the process climbed
+ * multiple GB over a session.
+ *
+ * Asserting on the build SCRIPTS rather than on `dist/` on purpose: `dist/` is
+ * gitignored and absent on a fresh clone, so a bundle assertion would be a
+ * silently-skipped test. The `define` is the invariant that produces the
+ * bundle; guard that.
+ */
+
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+
+const SCRIPTS = ["build.ts", "compile.ts"]
+
+describe("production React build", () => {
+  for (const script of SCRIPTS) {
+    test(`scripts/${script} pins NODE_ENV=production`, () => {
+      const source = readFileSync(fileURLToPath(new URL(`../../scripts/${script}`, import.meta.url)), "utf8")
+      expect(source).toContain('"process.env.NODE_ENV": JSON.stringify("production")')
+    })
+  }
+})


### PR DESCRIPTION
Closes #307.

## Root cause

The published CLI bundle shipped **React's development build**.

`react-reconciler/index.js` (and `react/index.js`) dispatch at require time:

```js
if (process.env.NODE_ENV === 'production') {
  module.exports = require('./cjs/react-reconciler.production.js');
} else {
  module.exports = require('./cjs/react-reconciler.development.js');
}
```

`Bun.build` inlines `process.env.NODE_ENV` as `"development"` unless you pass a `define`. Neither `scripts/build.ts` nor `scripts/compile.ts` did, so the bundler resolved both packages to their *development* entries, inlined the branch, and tree-shook the production builds away.

The dev reconciler keeps per-update debug bookkeeping alive (fiber `_debugTask`/`_debugInfo`, `startUpdateTimerByLane` → `blockingUpdateTask = createTask(method)`, update-timer state). In a long-lived TUI that grows without bound.

Confirmed on `dist/cli/index.js` as built from `main`: `"This likely indicates a bug in React"`, `"Each child in a list"`, `"act(...)"` ×5, `"Warning:"` ×4 — all dev-only strings — and zero remaining `process.env.NODE_ENV` occurrences.

## Evidence

Measured with `vmmap -summary` **Physical footprint** (RSS understates it — pages swap out). The growing region is WebKit Malloc, not the JS object heap.

Decisive A/B — no-op React host (no opentui at all), 250 Hz `setState`, ~5 min:

| build | start | end | rate |
|---|---|---|---|
| `NODE_ENV=production` | 35.3 M | 72.1 M | ~2 M / 20 s |
| default (development) | 34.7 M | 155.0 M | ~7 M / 20 s |

Bisection behind that:

- React + **no-op host**, no opentui, 250 Hz: 25.5 → 178.8 M — opentui is not required to reproduce.
- Same at 2 Hz: 17.5 → 21.9 M — nearly flat, which is why earlier low-cadence probes missed it.
- React + opentui 0.4.3 @ 250 Hz: 76.8 → 100.9 M. @ 2 Hz: flat.
- React 19.2.0 vs 19.2.8: identical — not a point-release regression.
- **Node v26 / V8**, same probe @ 250 Hz: 37.6 → 136.3 M — not Bun/JSC-specific.
- `BUN_JSC_useJIT=0`: 12.7 → 38.4 M — still grows; not a JIT code-cache artifact.
- Plain Bun object/closure/string churn at 250 Hz, no React: 8.8 → 12.4 M — flat.
- Forced `gcAndSweep()` + `heapStats()` at 250 Hz: `objectCount` flat ~8300, `heapSize` pinned at 2.7 M, external 2.0 M, while RSS climbed 72 → 124 M — the growth is outside the JS object heap and not GC-reclaimable.

## The fix

`define: { "process.env.NODE_ENV": JSON.stringify("production") }` in both build entries, plus an architecture test that guards the pin.

The test asserts on the build *scripts* rather than on `dist/`, deliberately: `dist/` is gitignored and absent on a fresh clone, so a bundle assertion would be a silently-skipped test.

After: `dist/cli/index.js` has **0** dev markers, and drops 1,652,913 → 1,548,386 bytes.

## Known remainder

**This fix reduces the leak rate; it does not eliminate it.** An 11-minute run of the production probe grew 35.3 → 101.0 M at a steady ~2 M / 20 s, with no sign of plateauing — so the residual is a second, smaller leak, not a bounded allocator arena. Side by side over the same window, the dev build went 34.7 → 154.4 M (~6 M / 20 s). So production is ~3× slower, and both are linear.

`vmmap` on the production probe shows Physical footprint 76.6 M with WebKit Malloc at 19.0 M resident / 46.0 M swapped — same region as the dev-build growth, which is consistent with a shared underlying mechanism rather than a distinct one.

Caveat on scale: the probe drives 250 `setState`/sec, far above any real TUI cadence, so neither number is a user-facing rate. Measured on the real kobe mock host over 12 minutes, the residual does not appear at all:

| build | start | end | trend |
|---|---|---|---|
| production | 99.4 M | 93.0 M | flat; oscillates 86–108 M with no upward slope |
| development | 102.2 M | 121.2 M | climbing, peaks 137 M |

So the residual is only observable at cadences far above what a real TUI generates. Worth its own issue, but not a user-facing regression and not a reason to hold this change.

Filing the remainder separately is the right call — this change is a strict improvement and shouldn't wait on it.

## Gates

- `bun run typecheck` clean
- `bunx biome check` clean on the four changed files
- `bunx vitest run test/architecture/` → 14 pass, including the 2 new ones
