### PR TITLE
fix: spell every weekday correctly in the Routines schedule preview

### DIFF
--- a/.changeset/weekday-plural-restatement.md
+++ b/.changeset/weekday-plural-restatement.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix the Routines schedule preview spelling four weekdays wrong — a Tuesday, Wednesday, Thursday, or Saturday schedule now reads "Tuesdays"/"Wednesdays"/"Thursdays"/"Saturdays" instead of "Tuedays"/"Weddays"/"Thudays"/"Satdays".

--- a/packages/kobe/src/tui/component/cron-segments.ts
+++ b/packages/kobe/src/tui/component/cron-segments.ts
@@ -35,6 +35,19 @@ const MONTH_LADDER = ["*", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG
 // describe a schedule, and neither is reachable by stepping single days.
 const DOW_LADDER = ["*", "MON-FRI", "SAT,SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
 
+/** Cron weekday code → its plural English name, for the restatement. Spelled out
+ *  because mechanically appending "days" to the code mangles four of the seven
+ *  (TUE→"Tuedays", WED→"Weddays", THU→"Thudays", SAT→"Satdays"). */
+const DOW_PLURAL: Readonly<Record<string, string>> = {
+  MON: "Mondays",
+  TUE: "Tuesdays",
+  WED: "Wednesdays",
+  THU: "Thursdays",
+  FRI: "Fridays",
+  SAT: "Saturdays",
+  SUN: "Sundays",
+}
+
 function range(from: number, to: number): string[] {
   const out: string[] = []
   for (let n = from; n <= to; n++) out.push(String(n))
@@ -97,7 +110,8 @@ export function describeCron(expression: string): string | null {
   if (dow === "*") return `every day ${at}`
   if (dow === "MON-FRI") return `weekdays ${at}`
   if (dow === "SAT,SUN") return `weekends ${at}`
-  if (/^[A-Z]{3}$/.test(dow)) return `${dow.charAt(0)}${dow.slice(1).toLowerCase()}days ${at}`
+  const plural = DOW_PLURAL[dow.toUpperCase()]
+  if (plural) return `${plural} ${at}`
   return null
 }
 

--- a/packages/kobe/test/tui/cron-segments.test.ts
+++ b/packages/kobe/test/tui/cron-segments.test.ts
@@ -93,6 +93,18 @@ describe("describeCron", () => {
     expect(describeCron("0 */6 * * *")).toBe("every day every 6h")
   })
 
+  test("spells out every weekday, not just the ones ending -on/-ri", () => {
+    // Every value the weekday ladder can reach must restate correctly; a
+    // mechanical "code + days" mangles four of the seven (Tuedays, Weddays,
+    // Thudays, Satdays), and each is one ↑/↓ step away in the composer.
+    expect(describeCron("0 9 * * TUE")).toBe("Tuesdays at 09:00")
+    expect(describeCron("0 9 * * WED")).toBe("Wednesdays at 09:00")
+    expect(describeCron("0 9 * * THU")).toBe("Thursdays at 09:00")
+    expect(describeCron("0 9 * * FRI")).toBe("Fridays at 09:00")
+    expect(describeCron("0 9 * * SAT")).toBe("Saturdays at 09:00")
+    expect(describeCron("0 9 * * SUN")).toBe("Sundays at 09:00")
+  })
+
   test("stays silent rather than describing a shape it does not model", () => {
     // A half-truth about when a schedule fires is worse than the raw cron —
     // the next-run preview already carries the ground truth.


### PR DESCRIPTION
## Direction

Bugs / correctness — self-found during a review of the recently-shipped Routines / cron-composer slice.

## Problem

The Routines composer restates a schedule in plain English in its live preview (`describeCron`, rendered at `automation-composer-dialog.tsx`). For a single-day schedule it built the plural by taking the three-letter cron code, lowercasing the tail, and appending `days`:

```ts
`${dow.charAt(0)}${dow.slice(1).toLowerCase()}days ${at}`
```

That only produces correct English for `MON`/`FRI`/`SUN`. The other four are mangled:

| cron | preview showed | should be |
|------|----------------|-----------|
| `TUE` | Tuedays | Tuesdays |
| `WED` | Weddays | Wednesdays |
| `THU` | Thudays | Thursdays |
| `SAT` | Satdays | Saturdays |

Every one of these is reachable in the UI — the weekday cell's `DOW_LADDER` contains all seven days, so a single ↑/↓ step lands the draft on a mangled value, and the composer renders the preview verbatim. So a majority of weekday schedules showed a misspelled restatement in the one field whose entire job is to restate the schedule correctly.

## Fix

Replace the mechanical `code + "days"` with a full-name lookup table (`DOW_PLURAL`) in `packages/kobe/src/tui/component/cron-segments.ts`. Pure, single-function change; no behavior change for the shapes that were already correct.

## Verification

- Added `describeCron` cases for TUE/WED/THU/FRI/SAT/SUN to `packages/kobe/test/tui/cron-segments.test.ts`.
- `bun test packages/kobe/test/tui/cron-segments.test.ts` — 15 pass / 0 fail.
- `bun run lint` — clean. `bun run typecheck` — clean (all three packages).
- Changeset added (`patch`).

## Follow-ups (deliberately out of scope)

Two unrelated bugs surfaced in the adjacent work-items slice during the same review and are left for separate PRs, since that slice is a different scope (and is CLI-only / not yet on the rail):
- `work-items-page.tsx`: `reloadTick > 0` makes `refresh: true` sticky after the first `r`, so every later repo-switch / filter-toggle bypasses the daemon's 60s cache instead of feeling instant.
- `work-items.ts` `classifyGhFailure`: a repo with only a non-GitHub remote is misreported as "not authenticated" instead of "no GitHub remote" (checks auth before no-remote and omits gh's `none of the git remotes` wording — the tested sibling `pr-status.ts` gets the order and patterns right).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArPkoAAwVTZ7mr4nQkpv5r)_