### PR TITLE
fix: keep streamed scrollback viewport stable

### DIFF
--- a/.changeset/atomic-macos-frames.md
+++ b/.changeset/atomic-macos-frames.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-Keep macOS fullscreen frames atomic while terminal output streams, preventing scrollback interactions from exposing a partially painted Kobe screen.
+Keep macOS fullscreen frames atomic while terminal output streams, and prevent the scrollback status from resizing the PTY and invalidating its stable viewport anchor.

--- a/.changeset/atomic-macos-frames.md
+++ b/.changeset/atomic-macos-frames.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep macOS fullscreen frames atomic while terminal output streams, preventing scrollback interactions from exposing a partially painted Kobe screen.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -434,9 +434,11 @@ export function Terminal(props: TerminalProps) {
         scrollBy(scroll.direction === "up" ? -step : step)
       }}
     >
-      {/* Scroll affordance — only rendered when scrolled back into
-          history, so the body's screenY equals the pane's content top in
-          the steady state (the cursor math depends on that). */}
+      {/* Scroll affordance overlays the historical viewport instead of
+          joining this flex column. A flow child would shrink `bodyEl` by
+          one row on the first wheel tick, resize xterm, invalidate its
+          absolute-line epoch, and put the stream back on a drifting
+          relative offset. */}
       {exited ? (
         <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1}>
           <text fg={theme.error} wrapMode="none">
@@ -445,7 +447,17 @@ export function Terminal(props: TerminalProps) {
         </box>
       ) : null}
       {scrollOffset > 0 ? (
-        <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1}>
+        <box
+          position="absolute"
+          zIndex={10}
+          left={0}
+          right={0}
+          bottom={0}
+          flexDirection="row"
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={theme.backgroundPanel}
+        >
           <text fg={theme.warning} wrapMode="none">
             {t("terminal.scrolledBack", { lines: scrollOffset })}
           </text>

--- a/packages/kobe/src/tui/lib/ime-anchor-output.ts
+++ b/packages/kobe/src/tui/lib/ime-anchor-output.ts
@@ -3,11 +3,14 @@
  *
  * OpenTUI restores a visible cursor after each diff frame, but a hidden
  * cursor is left at the last painted cell. macOS input methods use that real
- * terminal cursor for preedit/candidate placement. This adapter inserts the
- * focused embedded terminal's hidden cursor position immediately before the
- * synchronized-frame terminator, keeping the entire update atomic.
+ * terminal cursor for preedit/candidate placement. This adapter buffers each
+ * synchronized update as one transaction and inserts the focused embedded
+ * terminal's hidden cursor position immediately before its terminator. A
+ * truncated frame is therefore discarded before any partial paint can reach
+ * the outer terminal.
  */
 
+const SYNC_START = Buffer.from("\x1b[?2026h")
 const SYNC_END = Buffer.from("\x1b[?2026l")
 const HIDE_CURSOR = "\x1b[?25l"
 
@@ -45,47 +48,89 @@ export const imeAnchorController = new ImeAnchorController()
 
 class ImeAnchorFrameTransformer {
   private pending = Buffer.alloc(0)
+  private frame = Buffer.alloc(0)
 
   constructor(private readonly controller: ImeAnchorController) {}
 
   push(chunk: Buffer): Buffer {
     const data = this.pending.length > 0 ? Buffer.concat([this.pending, chunk]) : chunk
     this.pending = Buffer.alloc(0)
-
-    if (!this.controller.current()) return data
-
     const output: Buffer[] = []
     let offset = 0
+
     while (offset < data.length) {
-      const marker = data.indexOf(SYNC_END, offset)
-      if (marker < 0) break
-      output.push(data.subarray(offset, marker))
-      const anchor = this.controller.current()
-      // Renderer coordinates are zero-based; ANSI CUP rows/columns are one-based.
-      if (anchor) output.push(Buffer.from(`\x1b[${anchor.y + 1};${anchor.x + 1}H${HIDE_CURSOR}`))
-      output.push(SYNC_END)
-      offset = marker + SYNC_END.length
+      if (this.frame.length === 0) {
+        const start = data.indexOf(SYNC_START, offset)
+        if (start < 0) {
+          const tail = data.subarray(offset)
+          const pendingLength = longestMarkerPrefixSuffix(tail, [SYNC_START])
+          const safeLength = tail.length - pendingLength
+          if (safeLength > 0) output.push(tail.subarray(0, safeLength))
+          if (pendingLength > 0) this.pending = Buffer.from(tail.subarray(safeLength))
+          break
+        }
+
+        if (start > offset) output.push(data.subarray(offset, start))
+        this.frame = Buffer.from(SYNC_START)
+        offset = start + SYNC_START.length
+        continue
+      }
+
+      const end = data.indexOf(SYNC_END, offset)
+      const restart = data.indexOf(SYNC_START, offset)
+      if (restart >= 0 && (end < 0 || restart < end)) {
+        // A new transaction means the prior one was truncated. Nothing from
+        // it has reached the terminal, so discard it and recover at the new
+        // frame boundary instead of exposing a half-painted screen.
+        this.frame = Buffer.from(SYNC_START)
+        offset = restart + SYNC_START.length
+        continue
+      }
+
+      if (end >= 0) {
+        if (end > offset) this.frame = Buffer.concat([this.frame, data.subarray(offset, end)])
+        output.push(this.frame)
+        const anchor = this.controller.current()
+        // Renderer coordinates are zero-based; ANSI CUP rows/columns are one-based.
+        if (anchor) output.push(Buffer.from(`\x1b[${anchor.y + 1};${anchor.x + 1}H${HIDE_CURSOR}`))
+        output.push(SYNC_END)
+        this.frame = Buffer.alloc(0)
+        offset = end + SYNC_END.length
+        continue
+      }
+
+      const tail = data.subarray(offset)
+      const pendingLength = longestMarkerPrefixSuffix(tail, [SYNC_START, SYNC_END])
+      const safeLength = tail.length - pendingLength
+      if (safeLength > 0) this.frame = Buffer.concat([this.frame, tail.subarray(0, safeLength)])
+      if (pendingLength > 0) this.pending = Buffer.from(tail.subarray(safeLength))
+      break
     }
 
-    const tail = data.subarray(offset)
-    const pendingLength = longestTerminatorPrefixSuffix(tail)
-    const safeLength = tail.length - pendingLength
-    if (safeLength > 0) output.push(tail.subarray(0, safeLength))
-    if (pendingLength > 0) this.pending = Buffer.from(tail.subarray(safeLength))
     return output.length > 0 ? Buffer.concat(output) : Buffer.alloc(0)
   }
 
   flush(): Buffer {
+    // Never expose an incomplete synchronized update during teardown. The
+    // terminal never saw its opener, so dropping it preserves the last fully
+    // committed screen. A partial opener outside a frame is ordinary pending
+    // output and still needs to be restored verbatim.
+    if (this.frame.length > 0) {
+      this.frame = Buffer.alloc(0)
+      this.pending = Buffer.alloc(0)
+      return Buffer.alloc(0)
+    }
     const pending = this.pending
     this.pending = Buffer.alloc(0)
     return pending
   }
 }
 
-function longestTerminatorPrefixSuffix(bytes: Buffer): number {
-  const max = Math.min(bytes.length, SYNC_END.length - 1)
+function longestMarkerPrefixSuffix(bytes: Buffer, markers: readonly Buffer[]): number {
+  const max = Math.min(bytes.length, Math.max(...markers.map((marker) => marker.length - 1)))
   for (let length = max; length > 0; length -= 1) {
-    if (bytes.subarray(bytes.length - length).equals(SYNC_END.subarray(0, length))) return length
+    const suffix = bytes.subarray(bytes.length - length)
+    if (markers.some((marker) => length < marker.length && suffix.equals(marker.subarray(0, length)))) return length
   }
   return 0
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -382,17 +382,18 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     // to cache. The normal buffer's anchor/cache are left untouched so
     // they're still valid when the fullscreen app exits.
     const alt = active.type === "alternate"
-    if (!alt && (this.anchor === undefined || this.anchor.isDisposed)) {
+    const canAnchor = !alt && active.baseY > 0
+    if (canAnchor && (this.anchor === undefined || this.anchor.isDisposed)) {
       // A fresh epoch must populate the new absolute-id cache in this pass.
       this.scrollbackCache.clear()
-      const fresh = this.term.registerMarker(0)
+      const fresh = this.term.registerMarker(-active.cursorY - 1)
       if (fresh) {
         this.snapshotEpoch += 1
         this.anchor = fresh
         this.anchorId = fresh.line
       }
     }
-    const anchorAlive = !alt && this.anchor !== undefined && !this.anchor.isDisposed
+    const anchorAlive = canAnchor && this.anchor !== undefined && !this.anchor.isDisposed
     // Absolute id of buffer line y — only meaningful while the anchor lives.
     const absBase = anchorAlive ? this.anchorId - (this.anchor as IMarker).line : 0
     const cache = this.scrollbackCache
@@ -420,9 +421,9 @@ export abstract class XtermTaskPty implements TaskPtyLike {
       const min = absBase + start
       for (const id of cache.keys()) if (id < min) cache.delete(id)
     }
-    if (!alt) {
-      // Re-anchor at the cursor line before the old marker can trim out.
-      const next = this.term.registerMarker(0)
+    if (canAnchor) {
+      // Re-anchor on frozen scrollback before the old marker can trim out.
+      const next = this.term.registerMarker(-active.cursorY - 1)
       if (next) {
         this.anchorId = anchorAlive ? absBase + next.line : 0
         this.anchor?.dispose()

--- a/packages/kobe/test/render/terminal-scrollback-layout.test.tsx
+++ b/packages/kobe/test/render/terminal-scrollback-layout.test.tsx
@@ -1,0 +1,47 @@
+/** @jsxImportSource @opentui/react */
+
+import { expect, test } from "bun:test"
+import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
+import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
+import { type RenderHandle, act, renderComponent } from "./harness"
+
+async function mountTerminal(): Promise<{
+  handle: RenderHandle
+  harness: ReturnType<typeof createScriptedPtyRegistry>
+}> {
+  const harness = createScriptedPtyRegistry()
+  let handle: RenderHandle | undefined
+  await act(async () => {
+    handle = await renderComponent(
+      <Terminal cwd="/wt" taskId="scrollback-layout" focused registry={harness.registry} />,
+      { width: 60, height: 16, providers: { dialog: true } },
+    )
+  })
+  if (!handle) throw new Error("terminal mount failed")
+  await act(async () => {
+    await handle?.frame()
+  })
+  return { handle, harness }
+}
+
+test("entering scrollback does not resize the child PTY", async () => {
+  const { handle, harness } = await mountTerminal()
+  try {
+    const pty = harness.last()
+    await act(async () => {
+      pty.feed(Array.from({ length: 60 }, (_, index) => `line-${index + 1}`).join("\r\n"))
+      await handle.frame()
+    })
+    const before = pty.geometry
+
+    await act(async () => {
+      await handle.mockMouse.scroll(20, 8, "up")
+      await handle.frame()
+    })
+
+    expect(await handle.frame()).toMatch(/scrolled|已回滚/)
+    expect(pty.geometry).toEqual(before)
+  } finally {
+    handle.destroy()
+  }
+})

--- a/packages/kobe/test/tui/ime-anchor-output.test.ts
+++ b/packages/kobe/test/tui/ime-anchor-output.test.ts
@@ -86,6 +86,60 @@ describe("createImeAnchoredOutput", () => {
     expect(sink.text()).toBe(frame)
   })
 
+  it("withholds a synchronized update until the complete frame can be written atomically", () => {
+    const sink = collectingOutput()
+    const anchored = createImeAnchoredOutput(sink.output, new ImeAnchorController())
+
+    anchored.stdout.write(`${SYNC_START}${HIDE_CURSOR}\x1b[2;3HA`)
+    expect(sink.text()).toBe("")
+
+    anchored.stdout.write(SYNC_END)
+    expect(sink.text()).toBe(`${SYNC_START}${HIDE_CURSOR}\x1b[2;3HA${SYNC_END}`)
+  })
+
+  it("recognizes a synchronized-frame opener split at every byte boundary", () => {
+    for (let split = 1; split < SYNC_START.length; split += 1) {
+      const sink = collectingOutput()
+      const anchored = createImeAnchoredOutput(sink.output, new ImeAnchorController())
+
+      anchored.stdout.write(Buffer.from(`plain${SYNC_START.slice(0, split)}`))
+      anchored.stdout.write(Buffer.from(`${SYNC_START.slice(split)}frame${SYNC_END}`))
+      anchored.flush()
+
+      expect(sink.text(), `split=${split}`).toBe(`plain${SYNC_START}frame${SYNC_END}`)
+    }
+  })
+
+  it("drops a truncated update when a fresh synchronized frame starts", () => {
+    const sink = collectingOutput()
+    const anchored = createImeAnchoredOutput(sink.output, new ImeAnchorController())
+    const complete = `${SYNC_START}\x1b[4;5Hnew${SYNC_END}`
+
+    anchored.stdout.write(`${SYNC_START}\x1b[2;3Hstale`)
+    anchored.stdout.write(complete)
+
+    expect(sink.text()).toBe(complete)
+  })
+
+  it("keeps a high-churn sequence complete across rotating chunk boundaries", () => {
+    const sink = collectingOutput()
+    const anchored = createImeAnchoredOutput(sink.output, new ImeAnchorController())
+    const expected: string[] = []
+
+    for (let frame = 0; frame < 250; frame += 1) {
+      const transaction = `${SYNC_START}\x1b[${(frame % 40) + 1};1Hframe-${frame}${SYNC_END}`
+      expected.push(transaction)
+      for (let offset = 0; offset < transaction.length; ) {
+        const width = (frame + offset) % 11 || 1
+        anchored.stdout.write(transaction.slice(offset, offset + width))
+        offset += width
+      }
+    }
+
+    anchored.flush()
+    expect(sink.text()).toBe(expected.join(""))
+  })
+
   it("ends every animated diff frame at the same hidden IME anchor", () => {
     const sink = collectingOutput()
     const controller = new ImeAnchorController()
@@ -119,16 +173,26 @@ describe("createImeAnchoredOutput", () => {
     }
   })
 
-  it("flushes an incomplete terminator prefix without inventing a frame end", () => {
+  it("drops an incomplete synchronized update on flush", () => {
     const sink = collectingOutput()
     const controller = new ImeAnchorController()
     const anchored = createImeAnchoredOutput(sink.output, controller)
     controller.claim(Symbol("terminal"), { x: 6, y: 4 })
 
-    anchored.stdout.write(`plain${SYNC_END.slice(0, 4)}`)
+    anchored.stdout.write(`${SYNC_START}plain${SYNC_END.slice(0, 4)}`)
     anchored.flush()
 
-    expect(sink.text()).toBe(`plain${SYNC_END.slice(0, 4)}`)
+    expect(sink.text()).toBe("")
+  })
+
+  it("flushes a partial frame opener outside a transaction verbatim", () => {
+    const sink = collectingOutput()
+    const anchored = createImeAnchoredOutput(sink.output, new ImeAnchorController())
+
+    anchored.stdout.write(`plain${SYNC_START.slice(0, 4)}`)
+    anchored.flush()
+
+    expect(sink.text()).toBe(`plain${SYNC_START.slice(0, 4)}`)
   })
 })
 

--- a/packages/kobe/test/tui/terminal-pty-scrollback-cache.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-scrollback-cache.test.ts
@@ -87,6 +87,29 @@ describe("XtermTaskPty scrollback cache", () => {
     pty.kill()
   })
 
+  it("keeps the window origin stable across live-grid insert/delete redraws", async () => {
+    const pty = makePty()
+    for (let i = 1; i <= 30; i++) pty.pump(`redraw L${i}\r\n`)
+    await settle()
+    pty.capture()
+    const before = pty.captureWindow()
+
+    // Codex redraws its live viewport with IL/DL while output streams. Those
+    // edits must not move the absolute marker that names frozen scrollback.
+    pty.pump("\x1b[1;1H\x1b[M")
+    await settle()
+    pty.capture()
+
+    expect(before).not.toBeNull()
+    expect(pty.captureWindow()).toEqual(before)
+
+    pty.pump("\x1b[1;1H\x1b[L")
+    await settle()
+    pty.capture()
+    expect(pty.captureWindow()).toEqual(before)
+    pty.kill()
+  })
+
   it("stays chunk-identical to a full rebuild across heavy trimming (with colors)", async () => {
     const pty = makePty()
     // 600 lines >> rows+margin (210): the buffer trims hard, shifting


### PR DESCRIPTION
## Problem

Two independent effects made ChatPane appear to keep moving while Codex streamed:

1. The first upward wheel event rendered the scrollback status as a normal flex row, shrinking the child PTY by one row and invalidating the absolute-line epoch.
2. Even after PTY geometry stayed fixed, the absolute xterm marker lived on the live cursor row. Codex redraws its streaming viewport with IL/DL control sequences, so those edits moved or discarded the marker and changed the historical window identity.

The branch also retains the earlier macOS synchronized-frame hardening for partial outer frames.

## Fix

- Render the scrollback status as an absolute overlay so entering history does not resize the PTY.
- Anchor absolute line identity on the newest frozen scrollback row, outside the live grid that Codex rewrites.
- Re-anchor only while normal-buffer scrollback exists and preserve the existing cache/epoch behavior across continued streaming.
- Keep each macOS DEC synchronized update atomic before forwarding it to the host terminal.

## Regression evidence

The focused IL/DL regression failed before the new marker placement: a single delete-line changed the captured window start from 0 to 1. It now proves both delete-line and insert-line redraws leave the published window origin unchanged.

A real Codex 0.146.0 streaming run also reproduced the remaining bug before this commit: while 115,342 bytes arrived, the visible response markers drifted from 0001–0009 to 0008–0044 without the user scrolling again.

After the fix, another real Codex run kept response markers 0001–0007 exactly stationary while 6,666 more bytes arrived over 3.5 seconds. Returning to the bottom showed the response had advanced through 0030, confirming that streaming continued behind the anchored historical viewport.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`: 288 fast files / 2723 tests, 55 socket files / 480 tests, plugin SDK 11 tests
- `packages/kobe bun run test:render`: passed
- `packages/kobe bun run build`
- `packages/kobe bun run test:behavior`: 7 files / 13 tests
- Fixed-viewport real OpenTUI path (`/harness -> xterm.js -> PTY sidecar -> OpenTUI`) with a real Codex session and continued streaming

## Local acceptance note

An already-running source `dev:sandbox` process must be restarted to load this latest commit before manual retesting.