### PR TITLE
fix: order nvm node versions numerically in Claude binary discovery

### DIFF
--- a/.changeset/nvm-claude-binary-order.md
+++ b/.changeset/nvm-claude-binary-order.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix Claude Code binary discovery picking the oldest nvm-installed Node instead of the newest: when `claude` was installed under several nvm node versions, the fallback scan sorted the version directories as plain strings, so a single-digit major like `v8.17.0` outranked `v18.20.0` and kobe could launch the engine from an outdated Node. The scan now orders versions numerically, newest first.

--- a/packages/kobe/src/engine/claude-code-local/binary.ts
+++ b/packages/kobe/src/engine/claude-code-local/binary.ts
@@ -146,9 +146,11 @@ export async function findClaudeBinary(deps: BinaryDiscoveryDeps = defaultDeps):
     if (candidate) return candidate
   }
 
-  // 4. All NVM-installed node versions (newest by string sort).
+  // 4. All NVM-installed node versions, newest first. A plain string sort
+  //    mis-orders unpadded semver dir names ("v8.17.0" sorts after "v18.20.0"),
+  //    so a single-digit major would shadow newer nodes; compare numerically.
   const nvmRoot = path.join(home, ".nvm", "versions", "node")
-  const nvmVersions = deps.readdir(nvmRoot).sort().reverse()
+  const nvmVersions = deps.readdir(nvmRoot).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
   for (const v of nvmVersions) {
     const candidate = tryPath(path.join(nvmRoot, v, "bin", "claude"))
     if (candidate) return candidate

--- a/packages/kobe/test/engine/binary-discovery.test.ts
+++ b/packages/kobe/test/engine/binary-discovery.test.ts
@@ -72,10 +72,14 @@ describe("findClaudeBinary", () => {
     expect(await findClaudeBinary(d)).toBe("/nvm/active/bin/claude")
   })
 
-  it("scans nvm versions newest-first (string sort, reversed)", async () => {
+  it("scans nvm versions newest-first, numerically (a single-digit major must not shadow newer nodes)", async () => {
     const d = claudeDeps({
-      readdir: (p) => (p === "/home/u/.nvm/versions/node" ? ["v18.0.0", "v20.0.0", "v16.0.0"] : []),
-      fileExists: (p) => p === "/home/u/.nvm/versions/node/v20.0.0/bin/claude",
+      readdir: (p) => (p === "/home/u/.nvm/versions/node" ? ["v8.17.0", "v18.0.0", "v20.0.0", "v16.0.0"] : []),
+      // Both the newest node and an old single-digit-major node carry a claude
+      // shim; the newest must win. A plain string sort reverses to "v8.17.0"
+      // first and would launch claude from Node 8.
+      fileExists: (p) =>
+        p === "/home/u/.nvm/versions/node/v20.0.0/bin/claude" || p === "/home/u/.nvm/versions/node/v8.17.0/bin/claude",
     })
     expect(await findClaudeBinary(d)).toBe("/home/u/.nvm/versions/node/v20.0.0/bin/claude")
   })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in engine binary discovery, surfaced by reviewing pure-logic modules for classic sort/comparison mistakes.

## Problem

`findClaudeBinary()` has a fallback (step 4) that scans `~/.nvm/versions/node/*` for a `claude` shim, commented "newest by string sort":

```ts
const nvmVersions = deps.readdir(nvmRoot).sort().reverse()
```

A plain string sort mis-orders unpadded semver directory names. For `["v18.20.0", "v20.9.0", "v8.17.0"]`, `.sort()` yields `["v18.20.0", "v20.9.0", "v8.17.0"]` (because `'1' < '2' < '8'`), and `.reverse()` puts **`v8.17.0` first** — the *oldest* node, not the newest.

For nvm users who have `claude` installed under several node versions (common, since npm globals are per-node-version) and whose `NVM_BIN` doesn't already point at a version carrying `claude`, kobe would launch the engine from an outdated Node — which can fail modern Claude Code's Node engine requirement or run a stale copy.

Scope is tight: Codex's discovery (`codex-local/binary.ts`) only checks `NVM_BIN`, not the full version scan, so it's unaffected. The `codex-local/history.ts` string sorts operate on zero-padded date components (`YYYY`/`MM`/`DD`), where lexical order is already correct — deliberately left alone.

## Fix

Sort the version directories numerically, newest first:

```ts
const nvmVersions = deps.readdir(nvmRoot).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
```

`localeCompare` with `{ numeric: true }` compares digit runs by value, so `v8.17.0` correctly sorts below `v18.x`/`v20.x`.

## Verification

- The existing test at `binary-discovery.test.ts` only used same-width majors (`v16/v18/v20`), so string sort happened to work and the bug slipped through. Updated it to include `v8.17.0` with a `claude` shim present under both the newest node and Node 8 — the newest must win.
- Confirmed the updated test **fails** against the old `.sort().reverse()` and **passes** with the fix.
- `bun run lint` ✅ · `bun run typecheck` ✅ · full fast suite `288 files / 2717 tests` ✅.
- Added a patch changeset.

## Follow-ups

None required. A broader observation for later (not in this PR): the same numeric-vs-lexical care would matter if the nvm scan ever accepts non-`vX.Y.Z` entries, but nvm stores only canonical version dirs under `versions/node`, so the current comparator is sufficient.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfPW1bicuSVkVB3N6xrxsh)_