### PR TITLE
Fix unreadable task labels in the sidebar

### DIFF
--- a/.changeset/readable-sidebar-task-titles.md
+++ b/.changeset/readable-sidebar-task-titles.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Restore human task titles as the primary label for task worktrees in the tree sidebar. Generated branch names remain git metadata, while the main checkout still shows its live branch to avoid repeating the project name.

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -107,8 +107,9 @@ function RowShell(props: {
 /**
  * A worktree row carries NO state glyph (owner call 2026-08-01, round 6):
  * the session state belongs to the chattab that runs it, so the glyph lives
- * on the tab row below. What stays here is worktree-level fact — branch,
- * pin, PR chip, ±change stats.
+ * on the tab row below. What stays here is worktree-level identity — the
+ * human task title (or the live branch for main), pin, PR chip, ±change
+ * stats.
  */
 export function WorktreeTreeRow(props: {
   readonly rowId: string
@@ -122,18 +123,17 @@ export function WorktreeTreeRow(props: {
   const isCursor = shared.cursorIndex === props.flatIndex
   const changes = useChanges(shared, task)
   const chip = prCheckChip(task)
-  // A worktree row is named by its BRANCH. A `main` row stores no branch
-  // (its checkout moves freely), so it polls the repo HEAD — falling back
-  // to the title repeated the project header's name right under it (owner
-  // 2026-08-02), which read as a duplicate row instead of "the main
-  // checkout, currently on <branch>".
+  // Task worktrees use their human title: generated branch slugs are useful
+  // git metadata but too abstract to scan as the task's only visible name.
+  // A `main` row is the exception. Its title repeats the project header, so
+  // it polls repo HEAD and shows the live branch instead (owner 2026-08-04).
   const isMain = task.kind === "main"
   useEffect(() => {
     // Dependency-only invalidation key: re-poll on the sidebar's ~2s tick.
     void shared.branchTick
     if (isMain) pollCurrentBranch(task.repo)
   }, [isMain, task.repo, shared.branchTick])
-  const label = (isMain ? currentBranch(task.repo) : task.branch) || task.branch || task.title
+  const label = isMain ? currentBranch(task.repo) || task.branch || task.title : task.title || task.branch
   return (
     <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={1} shared={shared}>
       <box flexDirection="row" flexGrow={1} paddingRight={1} gap={1}>

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -39,7 +39,7 @@ const RIGHT = 2
 function tree(over: Partial<Parameters<typeof SidebarTree>[0]> = {}) {
   return (
     <SidebarTree
-      tasks={[MAIN, task("a"), task("b")]}
+      tasks={[MAIN, task("a", { title: "alpha task" }), task("b", { title: "bravo task" })]}
       selectedId="a"
       selectedTabId={null}
       onSelect={() => {}}
@@ -64,7 +64,7 @@ test("right-click on a worktree row opens that row's menu", async () => {
   const before = await frame()
   expect(before).not.toContain("Rename")
 
-  await mockMouse.click(2, lineOf(before, "feat/a"), RIGHT)
+  await mockMouse.click(2, lineOf(before, "alpha task"), RIGHT)
   await settle()
 
   const after = await frame()
@@ -82,7 +82,7 @@ test("a menu entry fires the row's real callback", async () => {
     height: 24,
   })
   await settle()
-  await mockMouse.click(2, lineOf(await frame(), "feat/a"), RIGHT)
+  await mockMouse.click(2, lineOf(await frame(), "alpha task"), RIGHT)
   await settle()
 
   // Highlight starts on "Open"; j steps to "Rename".
@@ -106,7 +106,7 @@ test("escape closes the menu and hands j/k back to the tree", async () => {
     height: 24,
   })
   await settle()
-  await mockMouse.click(2, lineOf(await frame(), "feat/a"), RIGHT)
+  await mockMouse.click(2, lineOf(await frame(), "alpha task"), RIGHT)
   await settle()
   expect(await frame()).toContain("Rename")
 
@@ -145,7 +145,7 @@ test("left-click still activates the row it lands on", async () => {
     height: 24,
   })
   await settle()
-  await mockMouse.click(2, lineOf(await frame(), "feat/b"), 0)
+  await mockMouse.click(2, lineOf(await frame(), "bravo task"), 0)
   await settle()
 
   expect(chosen).toEqual(["b"])

--- a/packages/kobe/test/render/sidebar-tree.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree.test.tsx
@@ -61,7 +61,8 @@ function tree(over: Partial<Parameters<typeof SidebarTree>[0]> = {}) {
 
 test("renders project header, worktree cards, and tab rows", async () => {
   seedTabs("a", ["tab-1", "tab-2"])
-  const { frame } = await renderComponent(tree(), { width: 28, height: 24 })
+  const tasks = [MAIN, task("a", { title: "alpha task" }), task("b", { title: "bravo task" })]
+  const { frame } = await renderComponent(tree({ tasks }), { width: 28, height: 24 })
   await new Promise((r) => setTimeout(r, SETTLE))
   const text = await frame()
 
@@ -71,9 +72,12 @@ test("renders project header, worktree cards, and tab rows", async () => {
   expect(text).toContain("kobe ─")
   expect(text).not.toContain("▾")
   expect(text).not.toContain("▸")
-  // Worktrees are the same two-line cards; their branch is the subtitle.
-  expect(text).toContain("feat/a")
-  expect(text).toContain("feat/b")
+  // Worktree rows keep the task's human name. The generated branch remains
+  // git metadata rather than replacing the only scannable task label.
+  expect(text).toContain("alpha task")
+  expect(text).toContain("bravo task")
+  expect(text).not.toContain("feat/a")
+  expect(text).not.toContain("feat/b")
   // The selected worktree starts expanded, so its tabs are visible without a
   // keystroke — that is the whole point of replacing the strip.
   expect(text).toContain("tab 1")
@@ -84,10 +88,19 @@ test("renders project header, worktree cards, and tab rows", async () => {
     const line = lines.find((l) => l.includes(needle)) ?? ""
     return line.indexOf(needle)
   }
-  // A tab row reads as a CHILD of its card: one level right of the card's
-  // subtitle column. (Cards and section headers share the left edge — that
-  // is the flat sidebar's own grammar, unchanged.)
-  expect(indentOf("tab 1")).toBeGreaterThan(indentOf("feat/a"))
+  // A tab row reads as a CHILD of its worktree: one level farther right.
+  expect(indentOf("tab 1")).toBeGreaterThan(indentOf("alpha task"))
+})
+
+test("worktree rows show the human task title instead of the generated branch", async () => {
+  tabsByTask.clear()
+  const tasks = [MAIN, task("a", { title: "fix readable rail", branch: "kobe/fix-readable-rail-a1b2c3" })]
+  const { frame } = await renderComponent(tree({ tasks }), { width: 28, height: 20 })
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  const text = await frame()
+  expect(text).toContain("fix readable rail")
+  expect(text).not.toContain("kobe/fix-readable")
 })
 
 test("enter on a tab row activates that tab, not just its task", async () => {
@@ -192,7 +205,7 @@ test("/ opens the query row and prunes the tree to matches plus ancestors", asyn
   const tasks = [MAIN, task("a", { title: "alpha" }), task("b", { title: "bravo" })]
   const { frame, mockInput } = await renderComponent(tree({ tasks }), { width: 28, height: 20 })
   await new Promise((r) => setTimeout(r, SETTLE))
-  expect(await frame()).toContain("feat/a")
+  expect(await frame()).toContain("alpha")
 
   mockInput.typeText("/")
   await new Promise((r) => setTimeout(r, SETTLE))
@@ -204,8 +217,8 @@ test("/ opens the query row and prunes the tree to matches plus ancestors", asyn
   expect(text).toContain("/bravo")
   // …the match survives, its sibling does not, and the project header stays
   // so the hit is not left floating.
-  expect(text).toContain("feat/b")
-  expect(text).not.toContain("feat/a")
+  expect(text).toContain("bravo")
+  expect(text).not.toContain("alpha")
   expect(text).toContain("kobe")
 })
 
@@ -213,7 +226,8 @@ test("the query matches a live TAB title, which no task-title search could", asy
   // The tree's own increment over the flat sidebar: "which tab is running
   // that thing" is answerable, and the answer drags its worktree along.
   seedTabsNamed("a", [["tab-1", "zebra-tab"]])
-  const { frame, mockInput } = await renderComponent(tree(), { width: 28, height: 20 })
+  const tasks = [MAIN, task("a", { title: "alpha parent" }), task("b", { title: "bravo sibling" })]
+  const { frame, mockInput } = await renderComponent(tree({ tasks }), { width: 28, height: 20 })
   await new Promise((r) => setTimeout(r, SETTLE))
 
   mockInput.typeText("/")
@@ -223,8 +237,8 @@ test("the query matches a live TAB title, which no task-title search could", asy
 
   const text = await frame()
   expect(text).toContain("zebra-tab")
-  expect(text).toContain("feat/a")
-  expect(text).not.toContain("feat/b")
+  expect(text).toContain("alpha parent")
+  expect(text).not.toContain("bravo sibling")
 })
 
 test("escape leaves search and restores the full tree", async () => {
@@ -237,12 +251,12 @@ test("escape leaves search and restores the full tree", async () => {
   await new Promise((r) => setTimeout(r, SETTLE))
   mockInput.typeText("bravo")
   await new Promise((r) => setTimeout(r, SETTLE))
-  expect(await frame()).not.toContain("feat/a")
+  expect(await frame()).not.toContain("alpha")
 
   mockInput.pressEscape()
   await new Promise((r) => setTimeout(r, SETTLE))
   const text = await frame()
-  expect(text).toContain("feat/a")
+  expect(text).toContain("alpha")
   expect(text).not.toContain("/bravo")
 })
 


### PR DESCRIPTION
Restores human-readable task titles as the primary labels for task worktrees in the tree sidebar, while main checkouts continue to show their live branch. Updates sidebar render and mouse interaction coverage so generated kobe/... branch names cannot replace task labels again, and adds a patch Changeset. Validation: bun run lint, bun run typecheck, bun run build, and 18 targeted render tests pass.