### PR TITLE
fix: spell every weekday correctly in the schedule preview

### DIFF
--- a/.changeset/cron-preview-weekday-names.md
+++ b/.changeset/cron-preview-weekday-names.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix the automation schedule preview spelling four of the seven weekdays wrong — a `TUE`/`WED`/`THU`/`SAT` cron rendered "Tuedays", "Weddays", "Thudays", "Satdays"; the preview now names every weekday correctly and stays silent on an hourly list/range minute (`15,45 * * * *`) instead of asserting a fire time (`:15,45`) the schedule never has.

--- a/packages/kobe/src/tui/component/cron-segments.ts
+++ b/packages/kobe/src/tui/component/cron-segments.ts
@@ -35,6 +35,17 @@ const MONTH_LADDER = ["*", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG
 // describe a schedule, and neither is reachable by stepping single days.
 const DOW_LADDER = ["*", "MON-FRI", "SAT,SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
 
+/** Plural weekday names, keyed by the cron abbreviation the ladder steps to. */
+const DOW_NAMES: Record<string, string> = {
+  MON: "Mondays",
+  TUE: "Tuesdays",
+  WED: "Wednesdays",
+  THU: "Thursdays",
+  FRI: "Fridays",
+  SAT: "Saturdays",
+  SUN: "Sundays",
+}
+
 function range(from: number, to: number): string[] {
   const out: string[] = []
   for (let n = from; n <= to; n++) out.push(String(n))
@@ -97,7 +108,8 @@ export function describeCron(expression: string): string | null {
   if (dow === "*") return `every day ${at}`
   if (dow === "MON-FRI") return `weekdays ${at}`
   if (dow === "SAT,SUN") return `weekends ${at}`
-  if (/^[A-Z]{3}$/.test(dow)) return `${dow.charAt(0)}${dow.slice(1).toLowerCase()}days ${at}`
+  const named = DOW_NAMES[dow.toUpperCase()]
+  if (named) return `${named} ${at}`
   return null
 }
 
@@ -105,7 +117,12 @@ function describeTimeOfDay(minute: string, hour: string): string | null {
   if (hour === "*") {
     if (minute === "*") return "every minute"
     if (minute.startsWith("*/")) return `every ${minute.slice(2)}m`
-    return `hourly at :${minute.padStart(2, "0")}`
+    // Only a single clock minute names a real fire time. A list/range
+    // (`15,45`, `10-20`) is not one instant, so `:15,45` would assert a
+    // time the schedule never fires — stay silent and let the raw cron
+    // plus the next-run preview carry the truth.
+    if (/^\d+$/.test(minute)) return `hourly at :${minute.padStart(2, "0")}`
+    return null
   }
   if (hour.startsWith("*/") && minute === "0") return `every ${hour.slice(2)}h`
   if (/^\d+$/.test(hour) && /^\d+$/.test(minute)) {

--- a/packages/kobe/test/tui/cron-segments.test.ts
+++ b/packages/kobe/test/tui/cron-segments.test.ts
@@ -93,6 +93,27 @@ describe("describeCron", () => {
     expect(describeCron("0 */6 * * *")).toBe("every day every 6h")
   })
 
+  test("spells every weekday, not just the ones whose slice happens to work", () => {
+    // The old `${d[0]}${d.slice(1).toLowerCase()}days` trick only spelled
+    // MON/FRI/SUN correctly; TUE/WED/THU/SAT came out "Tuedays", "Weddays",
+    // "Thudays", "Satdays". Every rung the ladder can step to must read right.
+    expect(describeCron("0 9 * * TUE")).toBe("Tuesdays at 09:00")
+    expect(describeCron("0 9 * * WED")).toBe("Wednesdays at 09:00")
+    expect(describeCron("0 9 * * THU")).toBe("Thursdays at 09:00")
+    expect(describeCron("0 9 * * FRI")).toBe("Fridays at 09:00")
+    expect(describeCron("0 9 * * SAT")).toBe("Saturdays at 09:00")
+    expect(describeCron("0 9 * * SUN")).toBe("Sundays at 09:00")
+  })
+
+  test("stays silent on an hourly list/range minute instead of naming a false time", () => {
+    // `15,45` and `10-20` are not one clock minute — `:15,45` would assert a
+    // fire time the schedule never has. The next-run preview carries the truth.
+    expect(describeCron("15,45 * * * *")).toBeNull()
+    expect(describeCron("10-20 * * * *")).toBeNull()
+    // A plain hourly minute still names itself.
+    expect(describeCron("15 * * * *")).toBe("every day hourly at :15")
+  })
+
   test("stays silent rather than describing a shape it does not model", () => {
     // A half-truth about when a schedule fires is worse than the raw cron —
     // the next-run preview already carries the ground truth.


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in the automation composer's schedule-preview text.

## Problem

`describeCron` in `src/tui/component/cron-segments.ts` built the single-weekday phrase by string surgery — uppercase the first letter, lowercase the tail, append `"days"`:

```ts
if (/^[A-Z]{3}$/.test(dow)) return `${dow.charAt(0)}${dow.slice(1).toLowerCase()}days ${at}`
```

That only spells the three abbreviations whose first-letter + lowercased-tail + `"days"` happens to equal the real word (`MON`→Mondays, `FRI`→Fridays, `SUN`→Sundays). The other four render garbage, and every one of them is reachable straight from the day-of-week stepper (`DOW_LADDER`):

| cron | rendered before | correct |
|---|---|---|
| `0 9 * * TUE` | `Tuedays at 09:00` | Tuesdays |
| `0 9 * * WED` | `Weddays at 09:00` | Wednesdays |
| `0 9 * * THU` | `Thudays at 09:00` | Thursdays |
| `0 9 * * SAT` | `Satdays at 09:00` | Saturdays |

The whole point of the preview is to let a user confirm a cron they can't read back, so 4/7 weekdays showing a nonsense word defeats it.

A second, narrower defect in the same function's helper (`describeTimeOfDay`): for an hourly schedule (`hour === "*"`) any non-`*/n` minute fell through to `` `hourly at :${minute.padStart(2, "0")}` ``. A list/range minute is not a single clock minute, so `15,45 * * * *` rendered `every day hourly at :15,45` — a confidently-false fire time — instead of returning `null` the way every other unmodelled shape does.

## Fix

- Name weekdays from an explicit `DOW_NAMES` map instead of the slice trick.
- Guard the hourly-minute path so it only names a plain numeric minute (`/^\d+$/`) and otherwise returns `null`, keeping the preview's "silent rather than wrong" contract.

Both changes are confined to `cron-segments.ts` (still ~127 lines, well under the size cap).

## Verification

- Extended `test/tui/cron-segments.test.ts`: the existing `describeCron` block only asserted `MON` (the one accidentally-correct case), so the bug slipped through. Added all six other weekdays plus the hourly list/range-minute cases. `bun run vitest run test/tui/cron-segments.test.ts` → 16 passed.
- `bun run lint` and `bun run typecheck` both green across the workspace.

## Follow-ups

None required. The bug-hunt also flagged a borderline `formatRelative` rounding choice (`Math.round(minutes / 60)` reports 90 min as "in 2h") in `automation-composer.ts` — left out of scope as an approximation-precision judgement call, not a clear defect.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T9GsV5VC2QWc5iq2N7rQgW)_