### PR TITLE
fix: partial-keep prefix keybinding overrides on a mixed chord list

### DIFF
--- a/.changeset/prefix-override-partial-keep.md
+++ b/.changeset/prefix-override-partial-keep.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Prefix keybinding overrides now keep the chords that parsed when one entry in a list is invalid, instead of silently discarding the whole binding and reverting to the default — so a config like `chat.tab.new: [n, ctrl+shift+z]` still binds `n`, and the default is only kept (with a clear "no valid chords" warning) when nothing in the list is usable, matching how direct-chord overrides already behave.

--- a/packages/kobe/src/tui/lib/keymap-prefix-overrides.ts
+++ b/packages/kobe/src/tui/lib/keymap-prefix-overrides.ts
@@ -50,16 +50,26 @@ function collectEntries(source: unknown, warnings: string[]): Map<string, string
       continue
     }
     const keys: string[] = []
+    let anyError = false
     for (const rawKey of rawKeys) {
       const normalized = normalizeChord(rawKey)
       if ("error" in normalized) {
         warnings.push(`prefix.bindings.${id}: ${normalized.error}`)
+        anyError = true
         continue
       }
       keys.push(normalized.chord)
       if (normalized.warning) warnings.push(`prefix.bindings.${id}: ${normalized.warning}`)
     }
-    if (keys.length === rawKeys.length) out.set(id, keys)
+    // Partial-keep, mirroring extractKeybindingOverrides' direct-chord path:
+    // one bad chord in a list must not discard the siblings that parsed. Only
+    // fall back to the default when NONE survived, and say so explicitly
+    // instead of dropping the whole entry on a lone warning-only chord.
+    if (keys.length === 0 && anyError) {
+      warnings.push(`prefix.bindings.${id}: no valid chords — keeping the default`)
+      continue
+    }
+    out.set(id, keys)
   }
   return out
 }

--- a/packages/kobe/test/tui/keymap-prefix-overrides.test.ts
+++ b/packages/kobe/test/tui/keymap-prefix-overrides.test.ts
@@ -48,6 +48,33 @@ describe("PureTUI prefix settings", () => {
     expect(extracted.warnings.join("\n")).toContain("modifier")
   })
 
+  test("keeps the valid second strokes when a sibling chord in the list is invalid", () => {
+    const extracted = extractPrefixKeybindings(
+      {
+        prefix: { bindings: { "chat.tab.new": ["n", "ctrl+shift+z"] } },
+      },
+      "linux",
+    )
+
+    // The valid "n" survives; only the impossible ctrl+shift+z is dropped.
+    expect(extracted.entries).toEqual([{ id: "chat.tab.new", keys: ["n"] }])
+    expect(extracted.warnings.join("\n")).toContain("ctrl+shift+z")
+    expect(extracted.warnings.join("\n")).not.toContain("keeping the default")
+  })
+
+  test("falls back to the default and says so when every chord in the list is invalid", () => {
+    const extracted = extractPrefixKeybindings(
+      {
+        prefix: { bindings: { "chat.tab.new": ["ctrl+shift+z", "cmd+shift+q"] } },
+      },
+      "linux",
+    )
+
+    // No valid chord survived, so the id is not overridden and the default holds.
+    expect(extracted.entries).toEqual([])
+    expect(extracted.warnings.join("\n")).toContain("no valid chords — keeping the default")
+  })
+
   test("adds declared prefix rows without clearing their direct chords", () => {
     const copy = keymap.map((row) => ({
       ...row,


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-contained defect that was explicitly deferred from PR #365's follow-ups ("Prefix keybinding overrides are all-or-nothing where the direct parser is partial-keep"). Confirmed by reading both parsers side by side.

## Problem

`collectEntries` in `src/tui/lib/keymap-prefix-overrides.ts` builds a prefix binding's second-stroke chords, then gated the whole entry on **every** chord parsing:

```ts
if (keys.length === rawKeys.length) out.set(id, keys)
```

If a single chord in a list fails to normalize, the entry is silently dropped — the valid chords are discarded and the default binding is kept, with a warning emitted only about the *invalid* chord (nothing tells the user their whole binding was ignored).

This is reachable from ordinary config. A user who writes a prefix binding such as:

```yaml
prefix:
  bindings:
    chat.tab.new: [n, ctrl+shift+z]
```

loses the perfectly valid `n` entirely — `ctrl+shift+z` can never match on legacy terminals so it errors, and the all-or-nothing gate throws away `n` with it.

The sibling direct-chord parser (`extractKeybindingOverrides` in `keymap-overrides-parse.ts`) already does the right thing: it keeps the chords that parsed and only reverts to the default when **none** survive, with an explicit `"no valid chords — keeping the default"` warning. The two parsers had drifted apart on this policy.

## Fix

Align the prefix parser to the direct-chord partial-keep contract: keep the chords that parsed, and only fall back to the default (with the same explicit warning) when nothing in the list is usable. One function, no call-site changes; the file stays at ~148 lines, well under the size cap.

## Verification

- Extended `test/tui/keymap-prefix-overrides.test.ts` with the two cases the existing suite never exercised: a mixed valid+invalid list (the valid `n` survives, only the bad chord warns, no fallback) and an all-invalid list (entry not overridden, `"no valid chords — keeping the default"` warning). Both fail against the old `keys.length === rawKeys.length` gate and pass after.
- `bunx vitest run test/tui/keymap-prefix-overrides.test.ts test/tui/keymap-prefix.test.ts test/tui/keybindings-user.test.ts` → 27 passed.
- Repo-root `bun run lint` and `bun run typecheck` both green.
- Patch changeset added.

## Follow-ups (deliberately out of scope)

The two parsers still differ in one smaller way: `extractKeybindingOverrides` de-duplicates chords within a list (`if (!chords.includes(...))`) while `collectEntries` does not. That's a separate, lower-stakes alignment and is left for its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVLYgK2cGmtVWgxc4o9SSB)_