### PR TITLE
Persist and follow engine runs in Agent Trace

### DIFF
--- a/.changeset/dev-daemon-routing.md
+++ b/.changeset/dev-daemon-routing.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Bind the desktop dev proxy to the exact daemon selected through its socket, and allocate a free daemon HTTP port when another production or sandbox instance already owns the default.

--- a/.changeset/durable-engine-session-bindings.md
+++ b/.changeset/durable-engine-session-bindings.md
@@ -8,5 +8,6 @@ so structured history and Agent Trace remain attached across daemon restarts,
 conversation changes, and repeated resumes. Claude Code and Codex
 SessionStart hooks now preserve their native start cause; startup/resume/clear
 create a Kobe run while compaction stays in the current run. The browser
-consumes the current run, filters earlier turns from the same resumed session,
-and never infers identity from terminal pixels or the newest transcript.
+uses the current run to select the native session and gate live events, while
+rendering that session's complete persisted timeline across repeated resumes.
+It never infers identity from terminal pixels or the newest transcript.

--- a/.changeset/durable-engine-session-bindings.md
+++ b/.changeset/durable-engine-session-bindings.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/kobe": patch
+"@sma1lboy/kobe-plugin-sdk": patch
+---
+
+Persist engine-native session identities per task tab so structured history
+and Agent Trace consumers remain attached across daemon restarts. The browser
+now consumes the durable binding contract instead of inferring a session from
+terminal pixels or the newest transcript.

--- a/.changeset/durable-engine-session-bindings.md
+++ b/.changeset/durable-engine-session-bindings.md
@@ -10,4 +10,8 @@ SessionStart hooks now preserve their native start cause; startup/resume/clear
 create a Kobe run while compaction stays in the current run. The browser
 uses the current run to select the native session and gate live events, while
 rendering that session's complete persisted timeline across repeated resumes.
-It never infers identity from terminal pixels or the newest transcript.
+For Codex in the browser/Electron PTY path, a PID-scoped adapter observer now
+binds native `/resume` selections from Codex's structured rollout record or
+`thread/resume` span before the deferred SessionStart hook, which later
+confirms the same run and remains the compatibility fallback. The UI never
+infers identity from terminal pixels or the newest transcript.

--- a/.changeset/durable-engine-session-bindings.md
+++ b/.changeset/durable-engine-session-bindings.md
@@ -3,7 +3,10 @@
 "@sma1lboy/kobe-plugin-sdk": patch
 ---
 
-Persist engine-native session identities per task tab so structured history
-and Agent Trace consumers remain attached across daemon restarts. The browser
-now consumes the durable binding contract instead of inferring a session from
-terminal pixels or the newest transcript.
+Persist engine-native session identities as temporal EngineRuns per task tab
+so structured history and Agent Trace remain attached across daemon restarts,
+conversation changes, and repeated resumes. Claude Code and Codex
+SessionStart hooks now preserve their native start cause; startup/resume/clear
+create a Kobe run while compaction stays in the current run. The browser
+consumes the current run, filters earlier turns from the same resumed session,
+and never infers identity from terminal pixels or the newest transcript.

--- a/.changeset/resume-existing-session-current-run.md
+++ b/.changeset/resume-existing-session-current-run.md
@@ -1,0 +1,8 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep the desktop Agent Trace attached to the active conversation when Codex
+resumes a session that previously appeared in the same chat tab. A confirmed
+resume now creates a fresh current EngineRun instead of being retained as a
+late event on the historical run.

--- a/.changeset/resume-trace-loading.md
+++ b/.changeset/resume-trace-loading.md
@@ -1,0 +1,6 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Show a stable Agent Trace loading transition when an engine tab resumes into a
+new temporal run, without briefly retaining the previous session timeline.

--- a/.changeset/resume-trace-loading.md
+++ b/.changeset/resume-trace-loading.md
@@ -2,6 +2,6 @@
 "@sma1lboy/kobe": patch
 ---
 
-Show a stable, animated Agent Trace loading transition when an engine tab
-resumes into a new temporal run, without briefly retaining the previous
-session timeline.
+Show a stable, animated Agent Trace loading transition as soon as the engine
+adapter detects a native resume, before the selected session id is available,
+without briefly retaining the previous session timeline.

--- a/.changeset/resume-trace-loading.md
+++ b/.changeset/resume-trace-loading.md
@@ -2,5 +2,6 @@
 "@sma1lboy/kobe": patch
 ---
 
-Show a stable Agent Trace loading transition when an engine tab resumes into a
-new temporal run, without briefly retaining the previous session timeline.
+Show a stable, animated Agent Trace loading transition when an engine tab
+resumes into a new temporal run, without briefly retaining the previous
+session timeline.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -48,11 +48,12 @@ worktree.
 
 ## Chat tabs and engine sessions
 
-A Task owns N chat tabs. Each tab is one engine session with its own
-conversation transcript and its own `sessionId`, which is what the engine's
-resume mechanism keys off. Tabs exist so you can peel a side question off a
-long-running conversation without polluting its transcript. Close the tab
-when exhausted, keep the worktree.
+A Task owns N chat tabs. A tab is a stable terminal slot, not a permanent
+conversation identity: over time it can start a new conversation, resume an
+older one, or clear into another. Each temporal attachment is an `EngineRun`;
+the run points at the engine-native `sessionId` and transcript used by the
+engine's resume mechanism. Resuming the same conversation later creates a new
+run with the same `sessionId`. Context compaction stays inside the current run.
 
 Per-task settings (engine, model, permission mode) apply to all tabs
 equally. If you want a different model, you want a different task.
@@ -181,8 +182,10 @@ for the Issues board, or check in on long-running tasks without a terminal.
   triple, anchored to one repo.
 - **Worktree**: a git worktree on disk, checked out to the task's branch.
   1 per task, never auto-deleted.
-- **Chat tab**: one engine session inside a task, with its own
-  `sessionId` and transcript. N per task.
+- **Chat tab**: one stable terminal slot inside a task. N per task; each can
+  host several engine runs over time.
+- **Engine run**: one temporal attachment of a native engine session to a chat
+  tab. Kobe owns `runId`; the engine owns `sessionId` and transcript history.
 - **Engine**: an interactive coding-agent CLI (`claude`, `codex`,
   `copilot`, `kimi`, or a command you registered) that kobe runs as the
   task's execution backend.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -164,10 +164,12 @@ native `/resume` picker has already switched threads. The browser/Electron PTY
 sidecar therefore reports only the tab/root-pid commit boundary to the daemon;
 the Codex registry adapter resolves the actual Codex descendant and reads its
 PID-scoped structured resume record from `CODEX_HOME/logs_2.sqlite`. That
-observer yields the exact session id and rollout path immediately. The later
-SessionStart confirms the binding, and remains the fallback when Codex changes
-or disables the internal log schema. No neutral daemon or UI code parses the
-vendor record.
+observer first yields an ephemeral pending transition when the resume span
+appears, then the exact session id and rollout path when Codex finishes
+selecting the thread. The transition starts Agent Trace loading early but never
+enters the durable EngineRun ledger. The later SessionStart confirms the
+binding, and remains the fallback when Codex changes or disables the internal
+log schema. No neutral daemon or UI code parses the vendor record.
 
 ### Copilot, Kimi, custom engines
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -159,6 +159,16 @@ those fields to bind the engine-owned conversation to a Kobe-owned temporal
 current run. Neutral UI layers consume that run binding and never infer the
 active conversation from terminal pixels or the newest transcript file.
 
+Codex defers `SessionStart(source=resume)` until the next turn, after its
+native `/resume` picker has already switched threads. The browser/Electron PTY
+sidecar therefore reports only the tab/root-pid commit boundary to the daemon;
+the Codex registry adapter resolves the actual Codex descendant and reads its
+PID-scoped structured resume record from `CODEX_HOME/logs_2.sqlite`. That
+observer yields the exact session id and rollout path immediately. The later
+SessionStart confirms the binding, and remains the fallback when Codex changes
+or disables the internal log schema. No neutral daemon or UI code parses the
+vendor record.
+
 ### Copilot, Kimi, custom engines
 
 No hook mechanism is wired (`NoopHookAdapter`); install is a no-op and nothing

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -152,6 +152,13 @@ Codex also won't run a non-managed hook until you trust it once via `/hooks`
 but never auto-bypasses trust, so Codex activity badges light up only after you
 approve, by design.
 
+For both Claude Code and Codex, the adapter also normalizes the native
+`session_id`, `transcript_path`, and `SessionStart.source`. The daemon uses
+those fields to bind the engine-owned conversation to a Kobe-owned temporal
+`runId`: startup/resume/clear establish a run, while compact stays inside the
+current run. Neutral UI layers consume that run binding and never infer the
+active conversation from terminal pixels or the newest transcript file.
+
 ### Copilot, Kimi, custom engines
 
 No hook mechanism is wired (`NoopHookAdapter`); install is a no-op and nothing

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -12,7 +12,7 @@ flowchart TB
   subgraph daemon["kobe daemon (state, refcounted)"]
     orch[Orchestrator]
     idx["tasks.json"]
-    bindings["session-bindings.json"]
+    bindings["session-bindings.json<br/>current run pointers + run history"]
   end
   subgraph host["kobe pty-host (engine lifetime)"]
     p1["engine PTY — task A"]
@@ -123,14 +123,20 @@ not kobe.
 - Engine tabs pin their conversation up front: a Claude launch gets a
   kobe-generated `--session-id <uuid>` so the session maps to its transcript
   (vendors that can't take a caller-set id, like Codex, are left untouched).
-- The daemon persists the neutral identity link
-  `Task -> Terminal Tab -> Engine Session` in
-  `<KOBE_HOME>/.kobe/session-bindings.json`. A binding starts as `pending`,
-  becomes `bound` when the engine supplies its native id (spawn-time for
-  Claude, hook-time for Codex), and may later become `ended` without losing
-  the transcript identity. This file stores pointers only; conversation
-  content remains exclusively in the engine's own transcript store.
-- Session bindings survive a daemon restart. New clients consume the binding
+- The daemon persists the neutral identity chain
+  `Task -> Terminal Tab -> current EngineRun -> native Engine Session` in
+  `<KOBE_HOME>/.kobe/session-bindings.json`. A run starts as `pending`, becomes
+  `bound` when the engine supplies its native id (spawn-time for Claude,
+  hook-time for Codex), and may later become `ended` or `superseded` without
+  losing the transcript identity. The file retains prior run pointers so a
+  tab changing conversations does not rewrite history; conversation content
+  remains exclusively in the engine's own transcript store.
+- Claude Code and Codex `SessionStart` hooks provide `startup`, `resume`,
+  `clear`, or `compact`. Kobe creates a fresh `runId` for the first three
+  causes (after filling any pending launch) and keeps the current run for
+  `compact`. Consequently, exiting and later resuming a conversation produces
+  a new run with the same native `sessionId`.
+- Current-run pointers and run history survive a daemon restart. New clients consume the binding
   snapshot directly; they do not choose a transcript from visible terminal
   pixels or from whichever history file happens to be newest.
 - After a host restart (reboot, `kobe reset`), a persisted engine tab that

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -136,6 +136,15 @@ not kobe.
   causes (after filling any pending launch) and keeps the current run for
   `compact`. Consequently, exiting and later resuming a conversation produces
   a new run with the same native `sessionId`.
+- Codex's native `/resume` picker changes conversation before it emits the
+  deferred `SessionStart`. In the browser/Electron PTY path, Enter triggers a
+  bounded adapter observation window keyed by that tab's process id. The Codex
+  adapter reads exact structured resume evidence from Codex's local log
+  database: a rollout path when present, otherwise the selected `thread.id`
+  from its `thread/resume` span. It binds the new run immediately and lets the
+  later hook confirm the same run. It never parses picker rows or terminal
+  pixels. If the internal log format is absent or changes, the observer returns
+  nothing and the ordinary hook remains the compatibility fallback.
 - Current-run pointers and run history survive a daemon restart. New clients consume the binding
   snapshot directly; they do not choose a transcript from visible terminal
   pixels or from whichever history file happens to be newest.

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -12,6 +12,7 @@ flowchart TB
   subgraph daemon["kobe daemon (state, refcounted)"]
     orch[Orchestrator]
     idx["tasks.json"]
+    bindings["session-bindings.json"]
   end
   subgraph host["kobe pty-host (engine lifetime)"]
     p1["engine PTY — task A"]
@@ -22,6 +23,7 @@ flowchart TB
   web <-->|HTTP/SSE| daemon
   tui <-->|unix socket| host
   orch --- idx
+  orch --- bindings
   p1 --- ring
   p2 --- ring
 ```
@@ -121,6 +123,16 @@ not kobe.
 - Engine tabs pin their conversation up front: a Claude launch gets a
   kobe-generated `--session-id <uuid>` so the session maps to its transcript
   (vendors that can't take a caller-set id, like Codex, are left untouched).
+- The daemon persists the neutral identity link
+  `Task -> Terminal Tab -> Engine Session` in
+  `<KOBE_HOME>/.kobe/session-bindings.json`. A binding starts as `pending`,
+  becomes `bound` when the engine supplies its native id (spawn-time for
+  Claude, hook-time for Codex), and may later become `ended` without losing
+  the transcript identity. This file stores pointers only; conversation
+  content remains exclusively in the engine's own transcript store.
+- Session bindings survive a daemon restart. New clients consume the binding
+  snapshot directly; they do not choose a transcript from visible terminal
+  pixels or from whichever history file happens to be newest.
 - After a host restart (reboot, `kobe reset`), a persisted engine tab that
   already ran relaunches with `--resume <sessionId>` instead of opening a
   blank session. A tab found dead on attach gets **one** automatic resume

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -140,11 +140,14 @@ not kobe.
   deferred `SessionStart`. In the browser/Electron PTY path, Enter triggers a
   bounded adapter observation window keyed by that tab's process id. The Codex
   adapter reads exact structured resume evidence from Codex's local log
-  database: a rollout path when present, otherwise the selected `thread.id`
-  from its `thread/resume` span. It binds the new run immediately and lets the
-  later hook confirm the same run. It never parses picker rows or terminal
-  pixels. If the internal log format is absent or changes, the observer returns
-  nothing and the ordinary hook remains the compatibility fallback.
+  database. A `thread/resume` span first publishes an in-memory transition so
+  Agent Trace enters loading before Codex finishes restoring the selected
+  thread; the transition never replaces or persists the current run. A rollout
+  path, or the selected `thread.id` when no path exists, then binds the new run
+  and clears the transition. The later hook confirms that same run. Kobe never
+  parses picker rows or terminal pixels. If the internal log format is absent
+  or changes, the observer returns nothing and the ordinary hook remains the
+  compatibility fallback.
 - Current-run pointers and run history survive a daemon restart. New clients consume the binding
   snapshot directly; they do not choose a transcript from visible terminal
   pixels or from whichever history file happens to be newest.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -46,6 +46,7 @@
     "./daemon/pty-termination": "./src/daemon/pty-termination.ts",
     "./daemon/quota-usage-cache": "./src/daemon/quota-usage-cache.ts",
     "./daemon/runtime": "./src/daemon/runtime.ts",
+    "./daemon/session-bindings": "./src/daemon/session-bindings.ts",
     "./daemon/server": "./src/daemon/server.ts",
     "./daemon/transcript-activity-collector": "./src/daemon/transcript-activity-collector.ts",
     "./daemon/ui-prefs-watcher": "./src/daemon/ui-prefs-watcher.ts",

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -84,10 +84,10 @@ export interface ChannelPayloads {
     at: number
   }
   /**
-   * Full durable task -> tab -> engine-session identity map. Unlike
-   * `engine-state`, this survives daemon restarts and is not activity state.
-   * Consumers use it to select history/trace; they never infer identity from
-   * terminal pixels or from whichever transcript happened to be newest.
+   * Full durable task -> tab -> current EngineRun map. Unlike `engine-state`,
+   * this survives daemon restarts and is not activity state. Consumers use it
+   * to select history/trace; they never infer identity from terminal pixels or
+   * from whichever transcript happened to be newest.
    */
   "session.bindings": { bindings: EngineSessionBindingsByTask }
   /**

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -11,6 +11,7 @@ import type {
   AttentionInboxItem,
   EngineActivityDetail,
   EngineQuotaUsage,
+  EngineSessionBindingsByTask,
   TaskActivityState,
   UpdateInfo,
 } from "./contracts.ts"
@@ -82,6 +83,13 @@ export interface ChannelPayloads {
     transcriptPath?: string
     at: number
   }
+  /**
+   * Full durable task -> tab -> engine-session identity map. Unlike
+   * `engine-state`, this survives daemon restarts and is not activity state.
+   * Consumers use it to select history/trace; they never infer identity from
+   * terminal pixels or from whichever transcript happened to be newest.
+   */
+  "session.bindings": { bindings: EngineSessionBindingsByTask }
   /**
    * Full durable attention queue. Viewing never consumes an item: an episode
    * leaves only after a newer same-tab `turn-start`, explicit dismissal, or an

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -12,6 +12,7 @@ import type {
   EngineActivityDetail,
   EngineQuotaUsage,
   EngineSessionBindingsByTask,
+  EngineSessionTransitionsByTask,
   TaskActivityState,
   UpdateInfo,
 } from "./contracts.ts"
@@ -89,7 +90,10 @@ export interface ChannelPayloads {
    * to select history/trace; they never infer identity from terminal pixels or
    * from whichever transcript happened to be newest.
    */
-  "session.bindings": { bindings: EngineSessionBindingsByTask }
+  "session.bindings": {
+    bindings: EngineSessionBindingsByTask
+    transitions: EngineSessionTransitionsByTask
+  }
   /**
    * Full durable attention queue. Viewing never consumes an item: an episode
    * leaves only after a newer same-tab `turn-start`, explicit dismissal, or an

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -3,23 +3,34 @@
 export type VendorId = "claude" | "codex" | "copilot" | (string & {})
 export type TaskStatus = "backlog" | "in_progress" | "in_review" | "done" | "canceled" | "error"
 
-/** Durable identity link from one hosted Terminal Tab to its engine session. */
-export interface EngineSessionBinding {
+export type EngineSessionStartSource = "startup" | "resume" | "clear" | "compact"
+
+/** One temporal attachment of an engine-native conversation to a hosted tab.
+ * A native session can appear in several runs when it is resumed; a tab can
+ * point at several runs over its lifetime as users clear, fork, or resume. */
+export interface EngineRun {
+  readonly runId: string
   readonly taskId: string
   readonly tabId: string
   readonly vendor: VendorId
   /** Null while the engine has started but has not reported its native id. */
   readonly sessionId: string | null
-  readonly state: "pending" | "bound" | "ended" | "missing"
+  readonly state: "pending" | "bound" | "ended" | "superseded" | "missing"
   /** Which authoritative boundary supplied the current identity. */
   readonly source: "spawn" | "hook" | "history-recovery"
+  /** Native SessionStart cause. `compact` stays in the current run; the other
+   * causes establish a new temporal run after any pending spawn is filled. */
+  readonly startSource?: EngineSessionStartSource
   readonly transcriptPath?: string
   /** Epoch milliseconds for the engine spawn this binding belongs to. */
   readonly startedAt: number
   readonly boundAt?: number
+  readonly endedAt?: number
   readonly updatedAt: number
 }
 
+/** Backward-compatible name for the current run published per task/tab. */
+export type EngineSessionBinding = EngineRun
 export type EngineSessionBindingsByTask = Record<string, Record<string, EngineSessionBinding>>
 
 export interface TaskDeletionState {

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -17,7 +17,7 @@ export interface EngineRun {
   readonly sessionId: string | null
   readonly state: "pending" | "bound" | "ended" | "superseded" | "missing"
   /** Which authoritative boundary supplied the current identity. */
-  readonly source: "spawn" | "hook" | "history-recovery"
+  readonly source: "spawn" | "observer" | "hook" | "history-recovery"
   /** Native SessionStart cause. `compact` stays in the current run; the other
    * causes establish a new temporal run after any pending spawn is filled. */
   readonly startSource?: EngineSessionStartSource

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -33,6 +33,18 @@ export interface EngineRun {
 export type EngineSessionBinding = EngineRun
 export type EngineSessionBindingsByTask = Record<string, Record<string, EngineSessionBinding>>
 
+/** Ephemeral native-session transition. It deliberately stays outside the
+ * durable EngineRun ledger until the engine identifies the selected session. */
+export interface EngineSessionTransition {
+  readonly taskId: string
+  readonly tabId: string
+  readonly vendor: VendorId
+  readonly startSource: "resume"
+  readonly observedAt: number
+}
+
+export type EngineSessionTransitionsByTask = Record<string, Record<string, EngineSessionTransition>>
+
 export interface TaskDeletionState {
   readonly phase: "queued" | "running" | "error"
   readonly force: boolean

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -3,6 +3,25 @@
 export type VendorId = "claude" | "codex" | "copilot" | (string & {})
 export type TaskStatus = "backlog" | "in_progress" | "in_review" | "done" | "canceled" | "error"
 
+/** Durable identity link from one hosted Terminal Tab to its engine session. */
+export interface EngineSessionBinding {
+  readonly taskId: string
+  readonly tabId: string
+  readonly vendor: VendorId
+  /** Null while the engine has started but has not reported its native id. */
+  readonly sessionId: string | null
+  readonly state: "pending" | "bound" | "ended" | "missing"
+  /** Which authoritative boundary supplied the current identity. */
+  readonly source: "spawn" | "hook" | "history-recovery"
+  readonly transcriptPath?: string
+  /** Epoch milliseconds for the engine spawn this binding belongs to. */
+  readonly startedAt: number
+  readonly boundAt?: number
+  readonly updatedAt: number
+}
+
+export type EngineSessionBindingsByTask = Record<string, Record<string, EngineSessionBinding>>
+
 export interface TaskDeletionState {
   readonly phase: "queued" | "running" | "error"
   readonly force: boolean

--- a/packages/kobe-daemon/src/daemon/handler-validators.ts
+++ b/packages/kobe-daemon/src/daemon/handler-validators.ts
@@ -10,7 +10,7 @@
  * circular import back into `handlers.ts`, which imports THEM.
  */
 
-import type { EngineActivityDetail, VendorId } from "./contracts.ts"
+import type { EngineActivityDetail, EngineSessionStartSource, VendorId } from "./contracts.ts"
 
 /** Coerce an unknown request payload into a plain object (`{}` for anything else). */
 export function objectPayload(payload: unknown): Record<string, unknown> {
@@ -52,6 +52,14 @@ export function optionalVendor(payload: Record<string, unknown>, key: string): V
   // (missing) binary in the pane. Empty/absent stays undefined (→ claude).
   const value = optionalString(payload, key)
   return value && value.trim().length > 0 ? (value as VendorId) : undefined
+}
+
+export function optionalSessionStartSource(
+  payload: Record<string, unknown>,
+  key: string,
+): EngineSessionStartSource | undefined {
+  const value = optionalString(payload, key)
+  return value === "startup" || value === "resume" || value === "clear" || value === "compact" ? value : undefined
 }
 
 /** Coerce the optional `detail` of an `engine.reportEvent` payload, dropping

--- a/packages/kobe-daemon/src/daemon/handlers-engine.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-engine.ts
@@ -1,0 +1,172 @@
+/** Engine lifecycle, session-binding, and resume-observation RPC handlers. */
+
+import { logDaemonError } from "./crash-log.ts"
+import { findAdoptableWorktree, matchTaskByCwd } from "./cwd-task.ts"
+import {
+  optionalActivityDetail,
+  optionalSessionStartSource,
+  optionalString,
+  requireNumber,
+  requireString,
+} from "./handler-validators.ts"
+import type { DaemonRequestHandler } from "./handlers.ts"
+import { scheduleQuotaResume } from "./quota-resume.ts"
+import { recoverSessionIdentity } from "./session-binding-recovery.ts"
+
+export const ENGINE_HANDLERS: readonly DaemonRequestHandler[] = [
+  {
+    name: "engine.beginSession",
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      const task = ctx.orch.getTask(taskId)
+      if (!task) throw new Error(`task not found: ${taskId}`)
+      const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
+      await ctx.bindings.begin(taskId, tabId, vendor)
+      return {}
+    },
+  },
+  {
+    name: "engine.pinSession",
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      const sessionId = requireString(payload, "sessionId")
+      const task = ctx.orch.getTask(taskId)
+      if (!task) throw new Error(`task not found: ${taskId}`)
+      const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
+      await ctx.bindings.bind({ taskId, tabId, vendor, sessionId, source: "spawn" })
+      ctx.activity.pinTabSession(taskId, tabId, sessionId)
+      return {}
+    },
+  },
+  {
+    name: "engine.observeSession",
+    // The localhost PTY sidecar calls this after a terminal commit. It carries
+    // no transcript bytes and can only ask the adapter to inspect the supplied
+    // process; the daemon still validates task/tab ownership before binding.
+    web: true,
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      const rootPid = requireNumber(payload, "rootPid")
+      if (!Number.isInteger(rootPid) || rootPid <= 0) throw new Error("rootPid must be a positive integer")
+      const task = ctx.orch.getTask(taskId)
+      if (!task) throw new Error(`task not found: ${taskId}`)
+      const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
+      const current = ctx.bindings.snapshotByTask()[taskId]?.[tabId]
+      const activation = await ctx.runtime.observeEngineSessionActivation(vendor, rootPid, current?.updatedAt ?? 0)
+      if (!activation) return { observed: false }
+      await ctx.bindings.bind({
+        taskId,
+        tabId,
+        vendor,
+        sessionId: activation.sessionId,
+        source: "observer",
+        startSource: activation.source,
+        ...(activation.transcriptPath ? { transcriptPath: activation.transcriptPath } : {}),
+      })
+      ctx.activity.pinTabSession(taskId, tabId, activation.sessionId)
+      return { observed: true, sessionId: activation.sessionId }
+    },
+  },
+  {
+    name: "engine.reportEvent",
+    async handle(payload, ctx) {
+      // Vendor hooks arrive normalized here; unmatched cwd events are dropped.
+      const kind = requireString(payload, "kind")
+      if (!ctx.runtime.isEngineActivityKind(kind)) throw new Error(`unknown engine event kind: ${kind}`)
+      const explicitId = optionalString(payload, "taskId")
+      const cwd = optionalString(payload, "cwd")
+      if (!explicitId && cwd && kind === "session-start") {
+        const cand = findAdoptableWorktree(ctx.orch.listTasks(), cwd)
+        if (cand) {
+          try {
+            await ctx.orch.adoptWorktree({ repo: cand.repo, worktreePath: cand.worktreePath, ifExists: "return" })
+          } catch (err) {
+            logDaemonError("worktree-autosync", err)
+          }
+        }
+      }
+      const taskId = explicitId ?? (cwd ? matchTaskByCwd(ctx.orch.listTasks(), cwd) : undefined)
+      if (!taskId) return {}
+      const detail = optionalActivityDetail(payload)
+      const tabId = optionalString(payload, "tabId")
+      const task = ctx.orch.getTask(taskId)
+      const reportedVendor = optionalString(payload, "engine")
+      const vendor = reportedVendor ?? task?.vendor ?? ctx.runtime.defaultTaskVendor
+      const recovered = await recoverSessionIdentity({
+        runtime: ctx.runtime,
+        kind,
+        tabId,
+        vendor,
+        worktreePath: task?.worktreePath,
+        sessionId: optionalString(payload, "sessionId"),
+        transcriptPath: optionalString(payload, "transcriptPath"),
+      })
+      const { sessionId, transcriptPath } = recovered
+      const startSource = optionalSessionStartSource(payload, "sessionStartSource")
+      const session = sessionId ? { id: sessionId, transcriptPath } : undefined
+      if (tabId && sessionId) {
+        await ctx.bindings
+          .bind({
+            taskId,
+            tabId,
+            vendor,
+            sessionId,
+            source: recovered.source,
+            eventKind: kind,
+            ...(startSource ? { startSource } : {}),
+            ...(transcriptPath ? { transcriptPath } : {}),
+            ...(kind === "session-end" ? { state: "ended" } : {}),
+          })
+          .catch((err) => logDaemonError("session-bindings-hook", err))
+      }
+      const isStateKind = ctx.runtime.affectsActivityState(kind)
+      if (isStateKind) {
+        ctx.activity.report(taskId, kind, detail, tabId, session)
+        if (explicitId && tabId) {
+          await ctx.inbox
+            .record(taskId, kind, detail, tabId)
+            .catch((err) => logDaemonError("attention-inbox-record", err))
+        }
+      }
+      ctx.engineEvents?.append(taskId, {
+        kind,
+        ...(tabId ? { tabId } : {}),
+        ...(reportedVendor ? { vendor: reportedVendor } : {}),
+        ...(sessionId ? { sessionId } : {}),
+        ...(detail ? { detail } : {}),
+        at: Date.now(),
+      })
+      if (kind === "pre-compact" || kind === "post-compact" || kind === "subagent-start" || kind === "subagent-stop") {
+        ctx.bus.publish("engine.lifecycle", { taskId, kind, ...(tabId ? { tabId } : {}), at: Date.now() })
+      }
+      ctx.plugins?.handleEngineReport({
+        kind,
+        taskId,
+        ...(detail ? { detail: detail as unknown as Record<string, unknown> } : {}),
+        ...(reportedVendor ? { vendor: reportedVendor } : {}),
+        ...(tabId ? { tabId } : {}),
+        ...(sessionId ? { sessionId } : {}),
+      })
+      if (kind === "turn-start") {
+        ctx.runtime
+          .maybeAutoStart(ctx.orch, taskId)
+          .then((result) => {
+            if (result === "moved") console.log(`[status-rules] task ${taskId} auto-moved backlog → in_progress`)
+          })
+          .catch((err) => logDaemonError("status-rules", err))
+        if (ctx.orch.getTask(taskId)?.quotaResume) {
+          void ctx.orch.setQuotaResume(taskId, null).catch((err) => logDaemonError("quota-resume", err))
+        }
+      }
+      if (kind === "turn-failed" && detail?.failure === "rate_limit") {
+        void scheduleQuotaResume(ctx.orch, ctx.runtime, ctx.quotaUsage, taskId).catch((err) =>
+          logDaemonError("quota-resume", err),
+        )
+      }
+      return {}
+    },
+  },
+]

--- a/packages/kobe-daemon/src/daemon/handlers-engine.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-engine.ts
@@ -57,6 +57,16 @@ export const ENGINE_HANDLERS: readonly DaemonRequestHandler[] = [
       const current = ctx.bindings.snapshotByTask()[taskId]?.[tabId]
       const activation = await ctx.runtime.observeEngineSessionActivation(vendor, rootPid, current?.updatedAt ?? 0)
       if (!activation) return { observed: false }
+      if (activation.phase === "pending") {
+        ctx.bindings.markTransition({
+          taskId,
+          tabId,
+          vendor,
+          startSource: activation.source,
+          observedAt: activation.observedAt,
+        })
+        return { observed: true, pending: true }
+      }
       await ctx.bindings.bind({
         taskId,
         tabId,
@@ -67,7 +77,7 @@ export const ENGINE_HANDLERS: readonly DaemonRequestHandler[] = [
         ...(activation.transcriptPath ? { transcriptPath: activation.transcriptPath } : {}),
       })
       ctx.activity.pinTabSession(taskId, tabId, activation.sessionId)
-      return { observed: true, sessionId: activation.sessionId }
+      return { observed: true, pending: false, sessionId: activation.sessionId }
     },
   },
   {

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -34,18 +34,11 @@ import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import type { AttentionInboxStore } from "./attention-inbox.ts"
 import type { AutomationsStore } from "./automations-store.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
-import { logDaemonError } from "./crash-log.ts"
-import { findAdoptableWorktree, matchTaskByCwd } from "./cwd-task.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
-import {
-  objectPayload,
-  optionalActivityDetail,
-  optionalSessionStartSource,
-  optionalString,
-  requireString,
-} from "./handler-validators.ts"
+import { objectPayload, requireString } from "./handler-validators.ts"
 import { ATTENTION_HANDLERS } from "./handlers-attention.ts"
 import { AUTOMATION_HANDLERS } from "./handlers-automations.ts"
+import { ENGINE_HANDLERS } from "./handlers-engine.ts"
 import { TASK_HANDLERS } from "./handlers-task.ts"
 import { UI_HANDLERS } from "./handlers-ui.ts"
 import { WORK_ITEM_HANDLERS } from "./handlers-work-items.ts"
@@ -60,10 +53,8 @@ import {
   isProtocolCompatible,
   serializeTask,
 } from "./protocol.ts"
-import { scheduleQuotaResume } from "./quota-resume.ts"
 import type { QuotaUsageCache } from "./quota-usage-cache.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
-import { recoverSessionIdentity } from "./session-binding-recovery.ts"
 import type { SessionBindingStore } from "./session-bindings.ts"
 import type { TaskDeletionScheduler } from "./task-deletion-runner.ts"
 import type { WorkItemCache } from "./work-items.ts"
@@ -293,6 +284,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
     ...AUTOMATION_HANDLERS,
     ...WORK_ITEM_HANDLERS,
     ...UI_HANDLERS,
+    ...ENGINE_HANDLERS,
     {
       name: "issue.list",
       async handle(payload, ctx) {
@@ -321,178 +313,6 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         const taskId = requireString(payload, "taskId")
         if (!ctx.orch.getTask(taskId)) throw new Error(`task not found: ${taskId}`)
         return { events: ctx.engineEvents?.recent(taskId) ?? [] }
-      },
-    },
-    {
-      name: "engine.beginSession",
-      async handle(payload, ctx) {
-        const taskId = requireString(payload, "taskId")
-        const tabId = requireString(payload, "tabId")
-        const task = ctx.orch.getTask(taskId)
-        if (!task) throw new Error(`task not found: ${taskId}`)
-        const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
-        await ctx.bindings.begin(taskId, tabId, vendor)
-        return {}
-      },
-    },
-    {
-      name: "engine.pinSession",
-      async handle(payload, ctx) {
-        const taskId = requireString(payload, "taskId")
-        const tabId = requireString(payload, "tabId")
-        const sessionId = requireString(payload, "sessionId")
-        const task = ctx.orch.getTask(taskId)
-        if (!task) throw new Error(`task not found: ${taskId}`)
-        const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
-        await ctx.bindings.bind({ taskId, tabId, vendor, sessionId, source: "spawn" })
-        ctx.activity.pinTabSession(taskId, tabId, sessionId)
-        return {}
-      },
-    },
-    {
-      name: "engine.reportEvent",
-      async handle(payload, ctx) {
-        // A `kobe hook <verb>` process reporting a NORMALIZED engine activity
-        // event (the vendor-specific hook was already translated by the
-        // engine's hook adapter). The global hooks carry no task id — they
-        // report their `cwd`, which we map to a task by worktree path. Fold it
-        // into the task's transient activity state + broadcast on
-        // `engine-state`. Unknown kinds are ignored (forward-compat: a newer
-        // adapter, older daemon); an unmatched cwd (an unrelated repo, a
-        // project with no kobe task) is silently dropped.
-        const kind = requireString(payload, "kind")
-        if (!ctx.runtime.isEngineActivityKind(kind)) throw new Error(`unknown engine event kind: ${kind}`)
-        // `taskId` (legacy/direct) wins; otherwise resolve from `cwd`.
-        const explicitId = optionalString(payload, "taskId")
-        const cwd = optionalString(payload, "cwd")
-        // External-worktree sync (replaces the removed WorktreeCreate hook): a
-        // session starting in an unadopted worktree under a tracked repo's
-        // a managed worktree root is auto-adopted as a task, so the cwd then maps
-        // to it below. Gated to `session-start` to bound the work; the path
-        // check is git-free and `adoptWorktree` is idempotent + git-validated
-        // (a bogus dir just throws → caught → dropped).
-        if (!explicitId && cwd && kind === "session-start") {
-          const cand = findAdoptableWorktree(ctx.orch.listTasks(), cwd)
-          if (cand) {
-            try {
-              await ctx.orch.adoptWorktree({ repo: cand.repo, worktreePath: cand.worktreePath, ifExists: "return" })
-            } catch (err) {
-              logDaemonError("worktree-autosync", err)
-            }
-          }
-        }
-        const taskId = explicitId ?? (cwd ? matchTaskByCwd(ctx.orch.listTasks(), cwd) : undefined)
-        if (!taskId) return {} // unmatched cwd → drop
-        const detail = optionalActivityDetail(payload)
-        // Which engine tab the event came from — the inherited KOBE_TAB_ID env.
-        // Sessions outside a Kobe tab remain activity-only via the report below.
-        const tabId = optionalString(payload, "tabId")
-        // The engine's own session identity, from its hook payload (Claude
-        // pipes session_id/transcript_path). Optional + additive: an old
-        // `kobe hook` simply omits it.
-        const task = ctx.orch.getTask(taskId)
-        const reportedVendor = optionalString(payload, "engine")
-        const vendor = reportedVendor ?? task?.vendor ?? ctx.runtime.defaultTaskVendor
-        const recovered = await recoverSessionIdentity({
-          runtime: ctx.runtime,
-          kind,
-          tabId,
-          vendor,
-          worktreePath: task?.worktreePath,
-          sessionId: optionalString(payload, "sessionId"),
-          transcriptPath: optionalString(payload, "transcriptPath"),
-        })
-        const { sessionId, transcriptPath } = recovered
-        const startSource = optionalSessionStartSource(payload, "sessionStartSource")
-        const session = sessionId ? { id: sessionId, transcriptPath } : undefined
-        if (tabId && sessionId) {
-          await ctx.bindings
-            .bind({
-              taskId,
-              tabId,
-              vendor,
-              sessionId,
-              source: recovered.source,
-              eventKind: kind,
-              ...(startSource ? { startSource } : {}),
-              ...(transcriptPath ? { transcriptPath } : {}),
-              ...(kind === "session-end" ? { state: "ended" } : {}),
-            })
-            .catch((err) => logDaemonError("session-bindings-hook", err))
-        }
-        // Lifecycle-only kinds (tool/compact/subagent) skip the badge + inbox
-        // entirely — folding them into engine-state would broadcast every
-        // tool call to every client. They still reach plugins below.
-        const isStateKind = ctx.runtime.affectsActivityState(kind)
-        if (isStateKind) {
-          ctx.activity.report(taskId, kind, detail, tabId, session)
-          // Kobe tabs provide both IDs; cwd-only and legacy task-only hooks are not Inbox-navigable.
-          if (explicitId && tabId) {
-            await ctx.inbox
-              .record(taskId, kind, detail, tabId)
-              .catch((err) => logDaemonError("attention-inbox-record", err))
-          }
-        }
-        // Per-task recent-events buffer (TUI event feed) + the low-frequency
-        // `engine.lifecycle` channel (sidebar compaction glyph / subagent mark).
-        ctx.engineEvents?.append(taskId, {
-          kind,
-          ...(tabId ? { tabId } : {}),
-          ...(reportedVendor ? { vendor: reportedVendor } : {}),
-          ...(sessionId ? { sessionId } : {}),
-          ...(detail ? { detail } : {}),
-          at: Date.now(),
-        })
-        if (
-          kind === "pre-compact" ||
-          kind === "post-compact" ||
-          kind === "subagent-start" ||
-          kind === "subagent-stop"
-        ) {
-          ctx.bus.publish("engine.lifecycle", { taskId, kind, ...(tabId ? { tabId } : {}), at: Date.now() })
-        }
-        // Plugin event hooks: every report becomes one agent-lifecycle event
-        // (docs/design/plugin-events.md); dispatch fans out only to plugins
-        // that declared the event.
-        ctx.plugins?.handleEngineReport({
-          kind,
-          taskId,
-          ...(detail ? { detail: detail as unknown as Record<string, unknown> } : {}),
-          ...(reportedVendor ? { vendor: reportedVendor } : {}),
-          ...(tabId ? { tabId } : {}),
-          ...(sessionId ? { sessionId } : {}),
-        })
-        // Auto status flow (docs/design/web-kanban.md M5): an engine
-        // STARTING a turn on a backlog task means work began — a pure rule
-        // advances it to in_progress. (in_progress → in_review is the
-        // agent's own self-report via the injected status protocol, not a
-        // daemon rule.) Fire-and-forget; gated inside maybeAutoStart
-        // (opt-in state.json flag).
-        if (kind === "turn-start") {
-          ctx.runtime
-            .maybeAutoStart(ctx.orch, taskId)
-            .then((result) => {
-              if (result === "moved") {
-                console.log(`[status-rules] task ${taskId} auto-moved backlog → in_progress`)
-              }
-            })
-            .catch((err) => logDaemonError("status-rules", err))
-          // A turn actually started (the user resumed manually, or our own
-          // continue prompt landed) — any pending auto-resume is now stale.
-          if (ctx.orch.getTask(taskId)?.quotaResume) {
-            void ctx.orch.setQuotaResume(taskId, null).catch((err) => logDaemonError("quota-resume", err))
-          }
-        }
-        // Real subscription-quota limit → ask the engine's quota probe when
-        // the window resets and arm the durable auto-resume schedule.
-        // Fire-and-forget: the probe does network I/O and must not delay the
-        // hook RPC. `billing` is excluded — it needs a human, not a timer.
-        if (kind === "turn-failed" && detail?.failure === "rate_limit") {
-          void scheduleQuotaResume(ctx.orch, ctx.runtime, ctx.quotaUsage, taskId).catch((err) =>
-            logDaemonError("quota-resume", err),
-          )
-        }
-        return {}
       },
     },
   ]

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -61,6 +61,8 @@ import {
 import { scheduleQuotaResume } from "./quota-resume.ts"
 import type { QuotaUsageCache } from "./quota-usage-cache.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { recoverSessionIdentity } from "./session-binding-recovery.ts"
+import type { SessionBindingStore } from "./session-bindings.ts"
 import type { TaskDeletionScheduler } from "./task-deletion-runner.ts"
 import type { WorkItemCache } from "./work-items.ts"
 
@@ -92,6 +94,8 @@ export interface DaemonHandlerContext {
   readonly activity: DaemonActivityRegistry
   /** Durable attention episodes; independent from transient activity cleanup. */
   readonly inbox: AttentionInboxStore
+  /** Durable Terminal Tab -> native engine-session identities. */
+  readonly bindings: SessionBindingStore
   /** Starts deduplicated durable background deletion after RPC acceptance. */
   readonly deletions: TaskDeletionScheduler
   /** Daemon-owned issue tracker store, keyed by git common-dir. */
@@ -318,11 +322,27 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
       },
     },
     {
+      name: "engine.beginSession",
+      async handle(payload, ctx) {
+        const taskId = requireString(payload, "taskId")
+        const tabId = requireString(payload, "tabId")
+        const task = ctx.orch.getTask(taskId)
+        if (!task) throw new Error(`task not found: ${taskId}`)
+        const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
+        await ctx.bindings.begin(taskId, tabId, vendor)
+        return {}
+      },
+    },
+    {
       name: "engine.pinSession",
       async handle(payload, ctx) {
         const taskId = requireString(payload, "taskId")
         const tabId = requireString(payload, "tabId")
         const sessionId = requireString(payload, "sessionId")
+        const task = ctx.orch.getTask(taskId)
+        if (!task) throw new Error(`task not found: ${taskId}`)
+        const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
+        await ctx.bindings.bind({ taskId, tabId, vendor, sessionId, source: "spawn" })
         ctx.activity.pinTabSession(taskId, tabId, sessionId)
         return {}
       },
@@ -368,9 +388,33 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         // The engine's own session identity, from its hook payload (Claude
         // pipes session_id/transcript_path). Optional + additive: an old
         // `kobe hook` simply omits it.
-        const sessionId = optionalString(payload, "sessionId")
-        const transcriptPath = optionalString(payload, "transcriptPath")
+        const task = ctx.orch.getTask(taskId)
+        const reportedVendor = optionalString(payload, "engine")
+        const vendor = reportedVendor ?? task?.vendor ?? ctx.runtime.defaultTaskVendor
+        const recovered = await recoverSessionIdentity({
+          runtime: ctx.runtime,
+          kind,
+          tabId,
+          vendor,
+          worktreePath: task?.worktreePath,
+          sessionId: optionalString(payload, "sessionId"),
+          transcriptPath: optionalString(payload, "transcriptPath"),
+        })
+        const { sessionId, transcriptPath } = recovered
         const session = sessionId ? { id: sessionId, transcriptPath } : undefined
+        if (tabId && sessionId) {
+          await ctx.bindings
+            .bind({
+              taskId,
+              tabId,
+              vendor,
+              sessionId,
+              source: recovered.source,
+              ...(transcriptPath ? { transcriptPath } : {}),
+              ...(kind === "session-end" ? { state: "ended" } : {}),
+            })
+            .catch((err) => logDaemonError("session-bindings-hook", err))
+        }
         // Lifecycle-only kinds (tool/compact/subagent) skip the badge + inbox
         // entirely — folding them into engine-state would broadcast every
         // tool call to every client. They still reach plugins below.
@@ -386,11 +430,10 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         }
         // Per-task recent-events buffer (TUI event feed) + the low-frequency
         // `engine.lifecycle` channel (sidebar compaction glyph / subagent mark).
-        const vendor = optionalString(payload, "engine")
         ctx.engineEvents?.append(taskId, {
           kind,
           ...(tabId ? { tabId } : {}),
-          ...(vendor ? { vendor } : {}),
+          ...(reportedVendor ? { vendor: reportedVendor } : {}),
           ...(sessionId ? { sessionId } : {}),
           ...(detail ? { detail } : {}),
           at: Date.now(),
@@ -410,7 +453,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
           kind,
           taskId,
           ...(detail ? { detail: detail as unknown as Record<string, unknown> } : {}),
-          ...(vendor ? { vendor } : {}),
+          ...(reportedVendor ? { vendor: reportedVendor } : {}),
           ...(tabId ? { tabId } : {}),
           ...(sessionId ? { sessionId } : {}),
         })

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -4,12 +4,8 @@
  * `server.ts`'s `dispatch` used to be one ~275-line switch over
  * {@link DaemonRequestName}: every case inlined payload extraction, error
  * wording, and the Orchestrator call, and the dispatch layer had zero tests.
- * This module breaks the switch into self-contained entries —
- * `{ name, handle(payload, ctx) }` — keyed in a registry map, so the dispatch
- * seam is: look up entry → validate (the same `requireString`-family helpers,
- * now shared here) → handle → uniform error shaping
- * ({@link shapeDaemonError}, the ONE place a thrown error becomes a
- * {@link DaemonError}).
+ * Registry entries replace that switch: look up → validate → handle →
+ * {@link shapeDaemonError}.
  *
  * Hard constraint: WIRE COMPATIBILITY. Every entry must produce
  * byte-equivalent success and error payloads to the pre-registry switch for
@@ -41,7 +37,13 @@ import type { DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { findAdoptableWorktree, matchTaskByCwd } from "./cwd-task.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
-import { objectPayload, optionalActivityDetail, optionalString, requireString } from "./handler-validators.ts"
+import {
+  objectPayload,
+  optionalActivityDetail,
+  optionalSessionStartSource,
+  optionalString,
+  requireString,
+} from "./handler-validators.ts"
 import { ATTENTION_HANDLERS } from "./handlers-attention.ts"
 import { AUTOMATION_HANDLERS } from "./handlers-automations.ts"
 import { TASK_HANDLERS } from "./handlers-task.ts"
@@ -401,6 +403,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
           transcriptPath: optionalString(payload, "transcriptPath"),
         })
         const { sessionId, transcriptPath } = recovered
+        const startSource = optionalSessionStartSource(payload, "sessionStartSource")
         const session = sessionId ? { id: sessionId, transcriptPath } : undefined
         if (tabId && sessionId) {
           await ctx.bindings
@@ -410,6 +413,8 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
               vendor,
               sessionId,
               source: recovered.source,
+              eventKind: kind,
+              ...(startSource ? { startSource } : {}),
               ...(transcriptPath ? { transcriptPath } : {}),
               ...(kind === "session-end" ? { state: "ended" } : {}),
             })

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -171,6 +171,9 @@ export type DaemonRequestName =
   // (claude `--session-id`), record + broadcast it for tab-precise traces.
   | "engine.beginSession"
   | "engine.pinSession"
+  // Sidecar commit observation: ask the engine adapter whether the PTY's
+  // native conversation changed before its ordinary hook fires.
+  | "engine.observeSession"
   // Remove the durable Inbox item at the supplied event timestamp. Explicit
   // removal, opening, and visiting the target all use this guarded operation.
   | "attention.dismiss"

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -169,6 +169,7 @@ export type DaemonRequestName =
   | "engine.reportEvent"
   // Spawn-time session pin: the engine spec injected a caller-set session id
   // (claude `--session-id`), record + broadcast it for tab-precise traces.
+  | "engine.beginSession"
   | "engine.pinSession"
   // Remove the durable Inbox item at the supplied event timestamp. Explicit
   // removal, opening, and visiting the target all use this guarded operation.

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -56,12 +56,21 @@ export interface DaemonRuntimeAdapter {
     vendor: VendorId,
     rootPid: number,
     afterMs: number,
-  ): Promise<{
-    sessionId: string
-    transcriptPath?: string
-    source: "resume"
-    observedAt: number
-  } | null>
+  ): Promise<
+    | {
+        phase: "pending"
+        source: "resume"
+        observedAt: number
+      }
+    | {
+        phase: "selected"
+        sessionId: string
+        transcriptPath?: string
+        source: "resume"
+        observedAt: number
+      }
+    | null
+  >
   deriveTitleFromSession(worktreePath: string, vendor: VendorId): Promise<string>
   createEngineTurnDetector(vendor: VendorId): EngineTurnDetectorAdapter
   runWorktreeStatus(worktreePath: string, signal: AbortSignal): Promise<WorktreeChanges>

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -39,6 +39,15 @@ export interface DaemonRuntimeAdapter {
   affectsActivityState(value: string): boolean
   checkLatestVersion(): Promise<UpdateInfo | null>
   latestTranscriptMtime(vendor: VendorId, worktreePath: string): Promise<number>
+  /**
+   * Recover the native session created for an explicit engine session-start.
+   * This is an engine-owned compatibility path for older hook reporters that
+   * forward the lifecycle event but omit the provider's session fields.
+   */
+  recoverEngineSession(
+    vendor: VendorId,
+    worktreePath: string,
+  ): Promise<{ sessionId: string; transcriptPath?: string } | null>
   deriveTitleFromSession(worktreePath: string, vendor: VendorId): Promise<string>
   createEngineTurnDetector(vendor: VendorId): EngineTurnDetectorAdapter
   runWorktreeStatus(worktreePath: string, signal: AbortSignal): Promise<WorktreeChanges>

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -48,6 +48,20 @@ export interface DaemonRuntimeAdapter {
     vendor: VendorId,
     worktreePath: string,
   ): Promise<{ sessionId: string; transcriptPath?: string } | null>
+  /**
+   * Observe an engine-native context switch that precedes ordinary lifecycle
+   * hooks. Vendor log/process details remain behind the composition adapter.
+   */
+  observeEngineSessionActivation(
+    vendor: VendorId,
+    rootPid: number,
+    afterMs: number,
+  ): Promise<{
+    sessionId: string
+    transcriptPath?: string
+    source: "resume"
+    observedAt: number
+  } | null>
   deriveTitleFromSession(worktreePath: string, vendor: VendorId): Promise<string>
   createEngineTurnDetector(vendor: VendorId): EngineTurnDetectorAdapter
   runWorktreeStatus(worktreePath: string, signal: AbortSignal): Promise<WorktreeChanges>

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -49,6 +49,7 @@ import { PromptBroker } from "./prompt-broker.ts"
 import { type DaemonFrame, normalizeChannelFilter, serializeTask } from "./protocol.ts"
 import { QuotaUsageCache } from "./quota-usage-cache.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { SessionBindingStore, defaultSessionBindingsPath } from "./session-bindings.ts"
 import { handleSubscribe } from "./subscribe.ts"
 import { TaskDeletionRunner } from "./task-deletion-runner.ts"
 import { type DaemonWebServer, createDirectWebLink, startDaemonWebServer } from "./web-server.ts"
@@ -172,8 +173,12 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   const activity = new DaemonActivityRegistry(bus, undefined, undefined, livenessAt)
   const inbox = new AttentionInboxStore(defaultAttentionInboxPath(options.homeDir), bus)
   await inbox.init().catch((err) => logDaemonError("attention-inbox-init", err))
-  const clearTaskState = (taskId: string) =>
-    inbox.deleteTaskBestEffort(taskId).finally(() => activity.clearTask(taskId))
+  const bindings = new SessionBindingStore(defaultSessionBindingsPath(options.homeDir), bus)
+  await bindings.init().catch((err) => logDaemonError("session-bindings-init", err))
+  const clearTaskState = async (taskId: string) => {
+    await Promise.all([inbox.deleteTaskBestEffort(taskId), bindings.deleteTaskBestEffort(taskId)])
+    activity.clearTask(taskId)
+  }
   const deletions = new TaskDeletionRunner(orch, runtime, clearTaskState)
   // Daemon-owned issue tracker (web Issues panel) — a single store keyed by
   // git common-dir, sharing the server's homeDir so sandbox/test homes
@@ -368,6 +373,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       bus,
       activity,
       inbox,
+      bindings,
       deletions,
       issues,
       automations,
@@ -395,7 +401,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   // no web transport. Built unconditionally: the automation runner needs it to
   // launch engine sessions whether or not `--web-port` was passed. The web
   // server reuses the same object when it is enabled.
-  const selfLink = createDirectWebLink({ orch, bus, activity, ctx: handlerContext })
+  const selfLink = createDirectWebLink({ orch, bus, activity, bindings, ctx: handlerContext })
 
   if (options.webPort !== undefined) {
     // The web transport is a SECONDARY surface — a bind failure (port taken by

--- a/packages/kobe-daemon/src/daemon/session-binding-recovery.ts
+++ b/packages/kobe-daemon/src/daemon/session-binding-recovery.ts
@@ -1,0 +1,36 @@
+import type { EngineActivityKind, VendorId } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
+import type { DaemonRuntimeAdapter } from "./runtime.ts"
+
+export interface SessionIdentityRecoveryInput {
+  readonly runtime: DaemonRuntimeAdapter
+  readonly kind: EngineActivityKind
+  readonly tabId?: string
+  readonly vendor: VendorId
+  readonly worktreePath?: string
+  readonly sessionId?: string
+  readonly transcriptPath?: string
+}
+
+/**
+ * Compatibility for an older globally-installed `kobe hook`: it can report
+ * the exact task/tab session-start while omitting newer session fields. Only
+ * that explicit lifecycle edge may ask the engine adapter to recover identity;
+ * generic activity and UI messages never select a transcript.
+ */
+export async function recoverSessionIdentity(
+  input: SessionIdentityRecoveryInput,
+): Promise<{ sessionId?: string; transcriptPath?: string; source: "hook" | "history-recovery" }> {
+  if (input.sessionId || !input.tabId || input.kind !== "session-start" || !input.worktreePath) {
+    return {
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      ...(input.transcriptPath ? { transcriptPath: input.transcriptPath } : {}),
+      source: "hook",
+    }
+  }
+  const recovered = await input.runtime.recoverEngineSession(input.vendor, input.worktreePath).catch((err) => {
+    logDaemonError("session-bindings-recovery", err)
+    return null
+  })
+  return recovered ? { ...recovered, source: "history-recovery" } : { source: "hook" }
+}

--- a/packages/kobe-daemon/src/daemon/session-bindings.ts
+++ b/packages/kobe-daemon/src/daemon/session-bindings.ts
@@ -229,6 +229,7 @@ export class SessionBindingStore {
         input.source === "hook" &&
         input.startSource === "resume"
       const startsRun = input.eventKind === "session-start" && input.startSource !== "compact"
+      const observesResume = input.source === "observer" && input.startSource === "resume"
 
       if (startsRun && !fillsPending && !confirmsPinnedSpawn && !confirmsObservedResume) {
         const next = this.boundRun(input, at)
@@ -242,7 +243,11 @@ export class SessionBindingStore {
         // never seen on this tab is still accepted for legacy reporters that
         // can miss SessionStart.
         const historical = this.latestMatchingRun(input)
-        if (historical && historical.runId !== current?.runId) {
+        // A PID-scoped resume observation is evidence of the engine's CURRENT
+        // selection, even when that native session appeared in an older run.
+        // Re-entering it is a new temporal run; reviving the historical row
+        // would leave currentRunIds pointing at the session being left.
+        if (historical && historical.runId !== current?.runId && !observesResume) {
           const updated = this.updatedRun(historical, input, at)
           const retained = {
             ...updated,

--- a/packages/kobe-daemon/src/daemon/session-bindings.ts
+++ b/packages/kobe-daemon/src/daemon/session-bindings.ts
@@ -69,7 +69,7 @@ function normalizeRun(value: unknown): EngineRun | null {
   }
   if (item.sessionId !== null && !nonEmpty(item.sessionId)) return null
   if (!["pending", "bound", "ended", "superseded", "missing"].includes(item.state ?? "")) return null
-  if (!["spawn", "hook", "history-recovery"].includes(item.source ?? "")) return null
+  if (!["spawn", "observer", "hook", "history-recovery"].includes(item.source ?? "")) return null
   if (item.startSource !== undefined && !validStartSource(item.startSource)) return null
   if (!Number.isFinite(item.startedAt) || !Number.isFinite(item.updatedAt)) return null
   if (item.boundAt !== undefined && !Number.isFinite(item.boundAt)) return null
@@ -221,9 +221,16 @@ export class SessionBindingStore {
         current.sessionId === input.sessionId &&
         current.source === "spawn" &&
         current.startSource === undefined
+      const confirmsObservedResume =
+        current?.vendor === input.vendor &&
+        current.sessionId === input.sessionId &&
+        current.source === "observer" &&
+        current.startSource === "resume" &&
+        input.source === "hook" &&
+        input.startSource === "resume"
       const startsRun = input.eventKind === "session-start" && input.startSource !== "compact"
 
-      if (startsRun && !fillsPending && !confirmsPinnedSpawn) {
+      if (startsRun && !fillsPending && !confirmsPinnedSpawn && !confirmsObservedResume) {
         const next = this.boundRun(input, at)
         await this.replaceCurrent(next, current, at)
         return next
@@ -329,7 +336,7 @@ export class SessionBindingStore {
       ...current,
       sessionId: input.sessionId,
       state: input.state ?? "bound",
-      source: input.source,
+      source: preferredSource(current.source, input.source),
       ...(startSource ? { startSource } : {}),
       ...((input.transcriptPath ?? current.transcriptPath)
         ? { transcriptPath: input.transcriptPath ?? current.transcriptPath }
@@ -393,6 +400,16 @@ export class SessionBindingStore {
   private publish(): void {
     this.bus.publish("session.bindings", { bindings: this.snapshotByTask() })
   }
+}
+
+function preferredSource(current: EngineRun["source"], incoming: EngineRun["source"]): EngineRun["source"] {
+  const rank: Record<EngineRun["source"], number> = {
+    spawn: 0,
+    "history-recovery": 1,
+    observer: 2,
+    hook: 3,
+  }
+  return rank[incoming] >= rank[current] ? incoming : current
 }
 
 function compareRuns(a: EngineRun, b: EngineRun): number {

--- a/packages/kobe-daemon/src/daemon/session-bindings.ts
+++ b/packages/kobe-daemon/src/daemon/session-bindings.ts
@@ -10,6 +10,8 @@ import type {
   EngineSessionBinding,
   EngineSessionBindingsByTask,
   EngineSessionStartSource,
+  EngineSessionTransition,
+  EngineSessionTransitionsByTask,
   VendorId,
 } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
@@ -150,12 +152,15 @@ async function writeStore(
 export class SessionBindingStore {
   private readonly runs = new Map<string, EngineRun>()
   private readonly currentRunIds = new Map<string, string>()
+  private readonly transitions = new Map<string, EngineSessionTransition>()
+  private readonly transitionTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private tail: Promise<void> = Promise.resolve()
 
   constructor(
     private readonly path: string,
     private readonly bus: DaemonEventBus,
     private readonly now = () => Date.now(),
+    private readonly transitionTtlMs = 4_000,
   ) {}
 
   async init(): Promise<void> {
@@ -163,6 +168,9 @@ export class SessionBindingStore {
       const loaded = await readStore(this.path)
       this.runs.clear()
       this.currentRunIds.clear()
+      for (const timer of this.transitionTimers.values()) clearTimeout(timer)
+      this.transitionTimers.clear()
+      this.transitions.clear()
       for (const run of loaded.runs) this.runs.set(run.runId, run)
       for (const ref of loaded.currentRuns) this.currentRunIds.set(bindingKey(ref), ref.runId)
       if (loaded.migrated) await this.persist()
@@ -178,6 +186,41 @@ export class SessionBindingStore {
       out[run.taskId] = tabs
     }
     return out
+  }
+
+  transitionSnapshotByTask(): EngineSessionTransitionsByTask {
+    const out: EngineSessionTransitionsByTask = {}
+    for (const transition of this.transitions.values()) {
+      const tabs = out[transition.taskId] ?? {}
+      tabs[transition.tabId] = transition
+      out[transition.taskId] = tabs
+    }
+    return out
+  }
+
+  markTransition(transition: EngineSessionTransition): void {
+    const key = bindingKey(transition)
+    const previous = this.transitions.get(key)
+    this.transitions.set(key, transition)
+    const oldTimer = this.transitionTimers.get(key)
+    if (oldTimer) clearTimeout(oldTimer)
+    const timer = setTimeout(() => {
+      if (this.transitions.get(key)?.observedAt !== transition.observedAt) return
+      this.transitions.delete(key)
+      this.transitionTimers.delete(key)
+      this.publish()
+    }, this.transitionTtlMs)
+    timer.unref?.()
+    this.transitionTimers.set(key, timer)
+    if (previous?.observedAt !== transition.observedAt) this.publish()
+  }
+
+  clearTransition(value: Pick<EngineSessionTransition, "taskId" | "tabId">, publish = true): void {
+    const key = bindingKey(value)
+    const timer = this.transitionTimers.get(key)
+    if (timer) clearTimeout(timer)
+    this.transitionTimers.delete(key)
+    if (this.transitions.delete(key) && publish) this.publish()
   }
 
   runsSnapshot(): EngineRun[] {
@@ -234,6 +277,7 @@ export class SessionBindingStore {
       if (startsRun && !fillsPending && !confirmsPinnedSpawn && !confirmsObservedResume) {
         const next = this.boundRun(input, at)
         await this.replaceCurrent(next, current, at)
+        if (input.startSource === "resume") this.clearTransition(input)
         return next
       }
 
@@ -254,15 +298,18 @@ export class SessionBindingStore {
             state: input.state === "ended" ? "ended" : historical.state,
           } satisfies EngineRun
           await this.commitRun(retained)
+          if (input.startSource === "resume") this.clearTransition(input)
           return retained
         }
         const next = this.boundRun(input, at)
         await this.replaceCurrent(next, current, at)
+        if (input.startSource === "resume") this.clearTransition(input)
         return next
       }
 
       const next = this.updatedRun(current, input, at)
       await this.commitRun(next)
+      if (input.startSource === "resume") this.clearTransition(input)
       return next
     })
   }
@@ -270,6 +317,12 @@ export class SessionBindingStore {
   async deleteTask(taskId: string): Promise<void> {
     await this.enqueue(async () => {
       let changed = false
+      for (const [key, transition] of this.transitions) {
+        if (transition.taskId !== taskId) continue
+        this.clearTransition(transition, false)
+        this.transitions.delete(key)
+        changed = true
+      }
       for (const [runId, run] of this.runs) {
         if (run.taskId !== taskId) continue
         this.runs.delete(runId)
@@ -403,7 +456,10 @@ export class SessionBindingStore {
   }
 
   private publish(): void {
-    this.bus.publish("session.bindings", { bindings: this.snapshotByTask() })
+    this.bus.publish("session.bindings", {
+      bindings: this.snapshotByTask(),
+      transitions: this.transitionSnapshotByTask(),
+    })
   }
 }
 

--- a/packages/kobe-daemon/src/daemon/session-bindings.ts
+++ b/packages/kobe-daemon/src/daemon/session-bindings.ts
@@ -1,0 +1,230 @@
+/**
+ * Durable tab -> engine-session identities.
+ *
+ * The activity registry is intentionally transient; session identity is not.
+ * A daemon restart must not make a still-running PTY forget which engine
+ * transcript it owns, so this small versioned store lives beside tasks.json.
+ */
+
+import { randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import type { EngineSessionBinding, EngineSessionBindingsByTask, VendorId } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
+import type { DaemonEventBus } from "./event-bus.ts"
+
+interface SessionBindingsFile {
+  readonly version: 1
+  readonly bindings: EngineSessionBinding[]
+}
+
+export interface BindSessionInput {
+  readonly taskId: string
+  readonly tabId: string
+  readonly vendor: VendorId
+  readonly sessionId: string
+  readonly source: EngineSessionBinding["source"]
+  readonly transcriptPath?: string
+  readonly state?: "bound" | "ended"
+}
+
+export function defaultSessionBindingsPath(homeDir = process.env.KOBE_HOME_DIR ?? homedir()): string {
+  return join(homeDir, ".kobe", "session-bindings.json")
+}
+
+function bindingKey(value: Pick<EngineSessionBinding, "taskId" | "tabId">): string {
+  return `${value.taskId}\0${value.tabId}`
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0
+}
+
+function normalizeBinding(value: unknown): EngineSessionBinding | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const item = value as Partial<EngineSessionBinding>
+  if (!nonEmpty(item.taskId) || !nonEmpty(item.tabId) || !nonEmpty(item.vendor)) return null
+  if (item.sessionId !== null && !nonEmpty(item.sessionId)) return null
+  if (!["pending", "bound", "ended", "missing"].includes(item.state ?? "")) return null
+  if (!["spawn", "hook", "history-recovery"].includes(item.source ?? "")) return null
+  if (!Number.isFinite(item.startedAt) || !Number.isFinite(item.updatedAt)) return null
+  if (item.boundAt !== undefined && !Number.isFinite(item.boundAt)) return null
+  if (item.transcriptPath !== undefined && typeof item.transcriptPath !== "string") return null
+  return {
+    taskId: item.taskId,
+    tabId: item.tabId,
+    vendor: item.vendor,
+    sessionId: item.sessionId,
+    state: item.state as EngineSessionBinding["state"],
+    source: item.source as EngineSessionBinding["source"],
+    ...(item.transcriptPath ? { transcriptPath: item.transcriptPath } : {}),
+    startedAt: item.startedAt as number,
+    ...(item.boundAt !== undefined ? { boundAt: item.boundAt } : {}),
+    updatedAt: item.updatedAt as number,
+  }
+}
+
+async function readStore(path: string): Promise<EngineSessionBinding[]> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<SessionBindingsFile>
+    if (parsed.version !== 1 || !Array.isArray(parsed.bindings)) return []
+    return parsed.bindings.map(normalizeBinding).filter((binding): binding is EngineSessionBinding => binding !== null)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
+    logDaemonError("session-bindings-load", err)
+    return []
+  }
+}
+
+async function writeStore(path: string, bindings: readonly EngineSessionBinding[]): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
+  const body: SessionBindingsFile = { version: 1, bindings: [...bindings] }
+  await writeFile(tmp, `${JSON.stringify(body, null, 2)}\n`, "utf8")
+  await rename(tmp, path)
+}
+
+export class SessionBindingStore {
+  private readonly bindings = new Map<string, EngineSessionBinding>()
+  private tail: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly path: string,
+    private readonly bus: DaemonEventBus,
+    private readonly now = () => Date.now(),
+  ) {}
+
+  async init(): Promise<void> {
+    await this.enqueue(async () => {
+      this.bindings.clear()
+      for (const binding of await readStore(this.path)) {
+        this.bindings.set(bindingKey(binding), binding)
+      }
+      this.publish()
+    })
+  }
+
+  snapshotByTask(): EngineSessionBindingsByTask {
+    const out: EngineSessionBindingsByTask = {}
+    for (const binding of this.sorted()) {
+      const tabs = out[binding.taskId] ?? {}
+      tabs[binding.tabId] = binding
+      out[binding.taskId] = tabs
+    }
+    return out
+  }
+
+  /** Backward-compatible projection consumed by pre-binding web clients. */
+  sessionIdsByTask(): Record<string, Record<string, string>> {
+    const out: Record<string, Record<string, string>> = {}
+    for (const binding of this.bindings.values()) {
+      if (!binding.sessionId) continue
+      const tabs = out[binding.taskId] ?? {}
+      tabs[binding.tabId] = binding.sessionId
+      out[binding.taskId] = tabs
+    }
+    return out
+  }
+
+  async begin(taskId: string, tabId: string, vendor: VendorId): Promise<EngineSessionBinding> {
+    return await this.enqueue(async () => {
+      const previous = this.bindings.get(bindingKey({ taskId, tabId }))
+      // `/api/engine-spec` is consulted for both a first spawn and a PTY
+      // reattach. Re-reading the spec for a live same-vendor tab must not
+      // erase its durable identity: the already-running engine will not emit
+      // another session-start merely because a GUI reloaded. A real later
+      // session-start still replaces the id in bind(); changing vendor starts
+      // a genuinely new pending identity immediately.
+      if (previous?.vendor === vendor) return previous
+      const at = this.now()
+      const next: EngineSessionBinding = {
+        taskId,
+        tabId,
+        vendor,
+        sessionId: null,
+        state: "pending",
+        source: "spawn",
+        startedAt: at,
+        updatedAt: at,
+      }
+      await this.commitWith(next)
+      return next
+    })
+  }
+
+  async bind(input: BindSessionInput): Promise<EngineSessionBinding> {
+    return await this.enqueue(async () => {
+      const at = this.now()
+      const previous = this.bindings.get(bindingKey(input))
+      const sameSpawn = previous?.sessionId === input.sessionId || previous?.sessionId === null
+      const transcriptPath = input.transcriptPath ?? previous?.transcriptPath
+      const next: EngineSessionBinding = {
+        taskId: input.taskId,
+        tabId: input.tabId,
+        vendor: input.vendor,
+        sessionId: input.sessionId,
+        state: input.state ?? "bound",
+        source: input.source,
+        ...(transcriptPath ? { transcriptPath } : {}),
+        startedAt: sameSpawn && previous ? previous.startedAt : at,
+        boundAt: sameSpawn && previous?.boundAt ? previous.boundAt : at,
+        updatedAt: at,
+      }
+      await this.commitWith(next)
+      return next
+    })
+  }
+
+  async deleteTask(taskId: string): Promise<void> {
+    await this.enqueue(async () => {
+      const next = new Map(this.bindings)
+      let changed = false
+      for (const [key, binding] of next) {
+        if (binding.taskId !== taskId) continue
+        next.delete(key)
+        changed = true
+      }
+      if (changed) await this.commit(next)
+    })
+  }
+
+  async deleteTaskBestEffort(taskId: string): Promise<void> {
+    await this.deleteTask(taskId).catch((err) => logDaemonError("session-bindings-task-delete", err))
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(operation)
+    this.tail = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
+  private async commitWith(binding: EngineSessionBinding): Promise<void> {
+    const next = new Map(this.bindings)
+    next.set(bindingKey(binding), binding)
+    await this.commit(next)
+  }
+
+  private async commit(next: ReadonlyMap<string, EngineSessionBinding>): Promise<void> {
+    const bindings = [...next.values()].sort(compareBindings)
+    await writeStore(this.path, bindings)
+    this.bindings.clear()
+    for (const binding of bindings) this.bindings.set(bindingKey(binding), binding)
+    this.publish()
+  }
+
+  private sorted(): EngineSessionBinding[] {
+    return [...this.bindings.values()].sort(compareBindings)
+  }
+
+  private publish(): void {
+    this.bus.publish("session.bindings", { bindings: this.snapshotByTask() })
+  }
+}
+
+function compareBindings(a: EngineSessionBinding, b: EngineSessionBinding): number {
+  return a.taskId.localeCompare(b.taskId) || a.tabId.localeCompare(b.tabId)
+}

--- a/packages/kobe-daemon/src/daemon/session-bindings.ts
+++ b/packages/kobe-daemon/src/daemon/session-bindings.ts
@@ -1,22 +1,36 @@
-/**
- * Durable tab -> engine-session identities.
- *
- * The activity registry is intentionally transient; session identity is not.
- * A daemon restart must not make a still-running PTY forget which engine
- * transcript it owns, so this small versioned store lives beside tasks.json.
- */
+/** Durable ChatTab -> current EngineRun pointers plus temporal run history. */
 
 import { randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
-import type { EngineSessionBinding, EngineSessionBindingsByTask, VendorId } from "./contracts.ts"
+import type {
+  EngineActivityKind,
+  EngineRun,
+  EngineSessionBinding,
+  EngineSessionBindingsByTask,
+  EngineSessionStartSource,
+  VendorId,
+} from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 
-interface SessionBindingsFile {
-  readonly version: 1
-  readonly bindings: EngineSessionBinding[]
+interface CurrentRunRef {
+  readonly taskId: string
+  readonly tabId: string
+  readonly runId: string
+}
+
+interface SessionBindingsFileV2 {
+  readonly version: 2
+  readonly runs: EngineRun[]
+  readonly currentRuns: CurrentRunRef[]
+}
+
+interface LoadedStore {
+  readonly runs: EngineRun[]
+  readonly currentRuns: CurrentRunRef[]
+  readonly migrated: boolean
 }
 
 export interface BindSessionInput {
@@ -25,6 +39,8 @@ export interface BindSessionInput {
   readonly vendor: VendorId
   readonly sessionId: string
   readonly source: EngineSessionBinding["source"]
+  readonly eventKind?: EngineActivityKind
+  readonly startSource?: EngineSessionStartSource
   readonly transcriptPath?: string
   readonly state?: "bound" | "ended"
 }
@@ -33,7 +49,7 @@ export function defaultSessionBindingsPath(homeDir = process.env.KOBE_HOME_DIR ?
   return join(homeDir, ".kobe", "session-bindings.json")
 }
 
-function bindingKey(value: Pick<EngineSessionBinding, "taskId" | "tabId">): string {
+function bindingKey(value: Pick<EngineRun, "taskId" | "tabId">): string {
   return `${value.taskId}\0${value.tabId}`
 }
 
@@ -41,52 +57,99 @@ function nonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.length > 0
 }
 
-function normalizeBinding(value: unknown): EngineSessionBinding | null {
+function validStartSource(value: unknown): value is EngineSessionStartSource {
+  return value === "startup" || value === "resume" || value === "clear" || value === "compact"
+}
+
+function normalizeRun(value: unknown): EngineRun | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null
-  const item = value as Partial<EngineSessionBinding>
-  if (!nonEmpty(item.taskId) || !nonEmpty(item.tabId) || !nonEmpty(item.vendor)) return null
+  const item = value as Partial<EngineRun>
+  if (!nonEmpty(item.runId) || !nonEmpty(item.taskId) || !nonEmpty(item.tabId) || !nonEmpty(item.vendor)) {
+    return null
+  }
   if (item.sessionId !== null && !nonEmpty(item.sessionId)) return null
-  if (!["pending", "bound", "ended", "missing"].includes(item.state ?? "")) return null
+  if (!["pending", "bound", "ended", "superseded", "missing"].includes(item.state ?? "")) return null
   if (!["spawn", "hook", "history-recovery"].includes(item.source ?? "")) return null
+  if (item.startSource !== undefined && !validStartSource(item.startSource)) return null
   if (!Number.isFinite(item.startedAt) || !Number.isFinite(item.updatedAt)) return null
   if (item.boundAt !== undefined && !Number.isFinite(item.boundAt)) return null
+  if (item.endedAt !== undefined && !Number.isFinite(item.endedAt)) return null
   if (item.transcriptPath !== undefined && typeof item.transcriptPath !== "string") return null
   return {
+    runId: item.runId,
     taskId: item.taskId,
     tabId: item.tabId,
     vendor: item.vendor,
     sessionId: item.sessionId,
-    state: item.state as EngineSessionBinding["state"],
-    source: item.source as EngineSessionBinding["source"],
+    state: item.state as EngineRun["state"],
+    source: item.source as EngineRun["source"],
+    ...(item.startSource ? { startSource: item.startSource } : {}),
     ...(item.transcriptPath ? { transcriptPath: item.transcriptPath } : {}),
     startedAt: item.startedAt as number,
     ...(item.boundAt !== undefined ? { boundAt: item.boundAt } : {}),
+    ...(item.endedAt !== undefined ? { endedAt: item.endedAt } : {}),
     updatedAt: item.updatedAt as number,
   }
 }
 
-async function readStore(path: string): Promise<EngineSessionBinding[]> {
+function migrateV1Binding(value: unknown): EngineRun | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const item = value as Record<string, unknown>
+  return normalizeRun({ ...item, runId: randomUUID() })
+}
+
+function normalizeCurrent(value: unknown, runs: ReadonlyMap<string, EngineRun>): CurrentRunRef | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const item = value as Partial<CurrentRunRef>
+  if (!nonEmpty(item.taskId) || !nonEmpty(item.tabId) || !nonEmpty(item.runId)) return null
+  const run = runs.get(item.runId)
+  return run && run.taskId === item.taskId && run.tabId === item.tabId
+    ? { taskId: item.taskId, tabId: item.tabId, runId: item.runId }
+    : null
+}
+
+async function readStore(path: string): Promise<LoadedStore> {
   try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<SessionBindingsFile>
-    if (parsed.version !== 1 || !Array.isArray(parsed.bindings)) return []
-    return parsed.bindings.map(normalizeBinding).filter((binding): binding is EngineSessionBinding => binding !== null)
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>
+    if (parsed.version === 2 && Array.isArray(parsed.runs) && Array.isArray(parsed.currentRuns)) {
+      const runs = parsed.runs.map(normalizeRun).filter((run): run is EngineRun => run !== null)
+      const byId = new Map(runs.map((run) => [run.runId, run]))
+      const currentRuns = parsed.currentRuns
+        .map((item) => normalizeCurrent(item, byId))
+        .filter((item): item is CurrentRunRef => item !== null)
+      return { runs, currentRuns, migrated: false }
+    }
+    if (parsed.version === 1 && Array.isArray(parsed.bindings)) {
+      const runs = parsed.bindings.map(migrateV1Binding).filter((run): run is EngineRun => run !== null)
+      return {
+        runs,
+        currentRuns: runs.map(({ taskId, tabId, runId }) => ({ taskId, tabId, runId })),
+        migrated: true,
+      }
+    }
+    return { runs: [], currentRuns: [], migrated: false }
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { runs: [], currentRuns: [], migrated: false }
     logDaemonError("session-bindings-load", err)
-    return []
+    return { runs: [], currentRuns: [], migrated: false }
   }
 }
 
-async function writeStore(path: string, bindings: readonly EngineSessionBinding[]): Promise<void> {
+async function writeStore(
+  path: string,
+  runs: readonly EngineRun[],
+  currentRuns: readonly CurrentRunRef[],
+): Promise<void> {
   await mkdir(dirname(path), { recursive: true })
   const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
-  const body: SessionBindingsFile = { version: 1, bindings: [...bindings] }
+  const body: SessionBindingsFileV2 = { version: 2, runs: [...runs], currentRuns: [...currentRuns] }
   await writeFile(tmp, `${JSON.stringify(body, null, 2)}\n`, "utf8")
   await rename(tmp, path)
 }
 
 export class SessionBindingStore {
-  private readonly bindings = new Map<string, EngineSessionBinding>()
+  private readonly runs = new Map<string, EngineRun>()
+  private readonly currentRunIds = new Map<string, string>()
   private tail: Promise<void> = Promise.resolve()
 
   constructor(
@@ -97,58 +160,53 @@ export class SessionBindingStore {
 
   async init(): Promise<void> {
     await this.enqueue(async () => {
-      this.bindings.clear()
-      for (const binding of await readStore(this.path)) {
-        this.bindings.set(bindingKey(binding), binding)
-      }
+      const loaded = await readStore(this.path)
+      this.runs.clear()
+      this.currentRunIds.clear()
+      for (const run of loaded.runs) this.runs.set(run.runId, run)
+      for (const ref of loaded.currentRuns) this.currentRunIds.set(bindingKey(ref), ref.runId)
+      if (loaded.migrated) await this.persist()
       this.publish()
     })
   }
 
   snapshotByTask(): EngineSessionBindingsByTask {
     const out: EngineSessionBindingsByTask = {}
-    for (const binding of this.sorted()) {
-      const tabs = out[binding.taskId] ?? {}
-      tabs[binding.tabId] = binding
-      out[binding.taskId] = tabs
+    for (const run of this.currentRuns()) {
+      const tabs = out[run.taskId] ?? {}
+      tabs[run.tabId] = run
+      out[run.taskId] = tabs
     }
     return out
   }
 
-  /** Backward-compatible projection consumed by pre-binding web clients. */
+  runsSnapshot(): EngineRun[] {
+    return [...this.runs.values()].sort(compareRuns)
+  }
+
+  /** Backward-compatible projection consumed by pre-run web clients. */
   sessionIdsByTask(): Record<string, Record<string, string>> {
     const out: Record<string, Record<string, string>> = {}
-    for (const binding of this.bindings.values()) {
-      if (!binding.sessionId) continue
-      const tabs = out[binding.taskId] ?? {}
-      tabs[binding.tabId] = binding.sessionId
-      out[binding.taskId] = tabs
+    for (const run of this.currentRuns()) {
+      if (!run.sessionId) continue
+      const tabs = out[run.taskId] ?? {}
+      tabs[run.tabId] = run.sessionId
+      out[run.taskId] = tabs
     }
     return out
   }
 
   async begin(taskId: string, tabId: string, vendor: VendorId): Promise<EngineSessionBinding> {
     return await this.enqueue(async () => {
-      const previous = this.bindings.get(bindingKey({ taskId, tabId }))
-      // `/api/engine-spec` is consulted for both a first spawn and a PTY
-      // reattach. Re-reading the spec for a live same-vendor tab must not
-      // erase its durable identity: the already-running engine will not emit
-      // another session-start merely because a GUI reloaded. A real later
-      // session-start still replaces the id in bind(); changing vendor starts
-      // a genuinely new pending identity immediately.
-      if (previous?.vendor === vendor) return previous
-      const at = this.now()
-      const next: EngineSessionBinding = {
-        taskId,
-        tabId,
-        vendor,
-        sessionId: null,
-        state: "pending",
-        source: "spawn",
-        startedAt: at,
-        updatedAt: at,
-      }
-      await this.commitWith(next)
+      const previous = this.currentRun({ taskId, tabId })
+      // The PTY sidecar asks for engine-spec only when it is about to spawn a
+      // process; socket reattach reuses the existing sidecar session. Mark the
+      // run before spawn so a prompt supplied on argv cannot begin before the
+      // run's time window. Duplicate begin calls while that spawn is pending
+      // remain idempotent.
+      if (previous?.vendor === vendor && previous.state === "pending") return previous
+      const next = this.newRun({ taskId, tabId, vendor, source: "spawn" })
+      await this.replaceCurrent(next, previous)
       return next
     })
   }
@@ -156,41 +214,161 @@ export class SessionBindingStore {
   async bind(input: BindSessionInput): Promise<EngineSessionBinding> {
     return await this.enqueue(async () => {
       const at = this.now()
-      const previous = this.bindings.get(bindingKey(input))
-      const sameSpawn = previous?.sessionId === input.sessionId || previous?.sessionId === null
-      const transcriptPath = input.transcriptPath ?? previous?.transcriptPath
-      const next: EngineSessionBinding = {
-        taskId: input.taskId,
-        tabId: input.tabId,
-        vendor: input.vendor,
-        sessionId: input.sessionId,
-        state: input.state ?? "bound",
-        source: input.source,
-        ...(transcriptPath ? { transcriptPath } : {}),
-        startedAt: sameSpawn && previous ? previous.startedAt : at,
-        boundAt: sameSpawn && previous?.boundAt ? previous.boundAt : at,
-        updatedAt: at,
+      const current = this.currentRun(input)
+      const fillsPending = current?.vendor === input.vendor && current.sessionId === null && current.state === "pending"
+      const confirmsPinnedSpawn =
+        current?.vendor === input.vendor &&
+        current.sessionId === input.sessionId &&
+        current.source === "spawn" &&
+        current.startSource === undefined
+      const startsRun = input.eventKind === "session-start" && input.startSource !== "compact"
+
+      if (startsRun && !fillsPending && !confirmsPinnedSpawn) {
+        const next = this.boundRun(input, at)
+        await this.replaceCurrent(next, current, at)
+        return next
       }
-      await this.commitWith(next)
+
+      if (!current || current.vendor !== input.vendor || (current.sessionId && current.sessionId !== input.sessionId)) {
+        // Any late event for a superseded run belongs to that historical run;
+        // it must never steal the tab's current pointer back. A session id
+        // never seen on this tab is still accepted for legacy reporters that
+        // can miss SessionStart.
+        const historical = this.latestMatchingRun(input)
+        if (historical && historical.runId !== current?.runId) {
+          const updated = this.updatedRun(historical, input, at)
+          const retained = {
+            ...updated,
+            state: input.state === "ended" ? "ended" : historical.state,
+          } satisfies EngineRun
+          await this.commitRun(retained)
+          return retained
+        }
+        const next = this.boundRun(input, at)
+        await this.replaceCurrent(next, current, at)
+        return next
+      }
+
+      const next = this.updatedRun(current, input, at)
+      await this.commitRun(next)
       return next
     })
   }
 
   async deleteTask(taskId: string): Promise<void> {
     await this.enqueue(async () => {
-      const next = new Map(this.bindings)
       let changed = false
-      for (const [key, binding] of next) {
-        if (binding.taskId !== taskId) continue
-        next.delete(key)
+      for (const [runId, run] of this.runs) {
+        if (run.taskId !== taskId) continue
+        this.runs.delete(runId)
         changed = true
       }
-      if (changed) await this.commit(next)
+      for (const [key, runId] of this.currentRunIds) {
+        if (this.runs.has(runId)) continue
+        this.currentRunIds.delete(key)
+      }
+      if (changed) await this.commit()
     })
   }
 
   async deleteTaskBestEffort(taskId: string): Promise<void> {
     await this.deleteTask(taskId).catch((err) => logDaemonError("session-bindings-task-delete", err))
+  }
+
+  private currentRun(value: Pick<EngineRun, "taskId" | "tabId">): EngineRun | undefined {
+    const runId = this.currentRunIds.get(bindingKey(value))
+    return runId ? this.runs.get(runId) : undefined
+  }
+
+  private currentRuns(): EngineRun[] {
+    return [...this.currentRunIds.values()]
+      .map((runId) => this.runs.get(runId))
+      .filter((run): run is EngineRun => run !== undefined)
+      .sort(compareRuns)
+  }
+
+  private newRun(input: {
+    taskId: string
+    tabId: string
+    vendor: VendorId
+    source: EngineRun["source"]
+  }): EngineRun {
+    const at = this.now()
+    return {
+      runId: randomUUID(),
+      ...input,
+      sessionId: null,
+      state: "pending",
+      startedAt: at,
+      updatedAt: at,
+    }
+  }
+
+  private boundRun(input: BindSessionInput, at: number): EngineRun {
+    return {
+      runId: randomUUID(),
+      taskId: input.taskId,
+      tabId: input.tabId,
+      vendor: input.vendor,
+      sessionId: input.sessionId,
+      state: input.state ?? "bound",
+      source: input.source,
+      ...(input.startSource ? { startSource: input.startSource } : {}),
+      ...(input.transcriptPath ? { transcriptPath: input.transcriptPath } : {}),
+      startedAt: at,
+      boundAt: at,
+      ...(input.state === "ended" ? { endedAt: at } : {}),
+      updatedAt: at,
+    }
+  }
+
+  private updatedRun(current: EngineRun, input: BindSessionInput, at: number): EngineRun {
+    const startSource =
+      input.startSource === "compact" ? current.startSource : (input.startSource ?? current.startSource)
+    return {
+      ...current,
+      sessionId: input.sessionId,
+      state: input.state ?? "bound",
+      source: input.source,
+      ...(startSource ? { startSource } : {}),
+      ...((input.transcriptPath ?? current.transcriptPath)
+        ? { transcriptPath: input.transcriptPath ?? current.transcriptPath }
+        : {}),
+      boundAt: current.boundAt ?? at,
+      ...(input.state === "ended" ? { endedAt: current.endedAt ?? at } : {}),
+      updatedAt: at,
+    }
+  }
+
+  private latestMatchingRun(input: BindSessionInput): EngineRun | undefined {
+    return this.runsSnapshot()
+      .reverse()
+      .find(
+        (run) =>
+          run.taskId === input.taskId &&
+          run.tabId === input.tabId &&
+          run.vendor === input.vendor &&
+          run.sessionId === input.sessionId,
+      )
+  }
+
+  private async replaceCurrent(next: EngineRun, previous?: EngineRun, at = next.startedAt): Promise<void> {
+    if (previous && previous.runId !== next.runId) {
+      this.runs.set(previous.runId, {
+        ...previous,
+        state: previous.state === "ended" ? "ended" : "superseded",
+        endedAt: previous.endedAt ?? at,
+        updatedAt: at,
+      })
+    }
+    this.runs.set(next.runId, next)
+    this.currentRunIds.set(bindingKey(next), next.runId)
+    await this.commit()
+  }
+
+  private async commitRun(run: EngineRun): Promise<void> {
+    this.runs.set(run.runId, run)
+    await this.commit()
   }
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -202,22 +380,14 @@ export class SessionBindingStore {
     return run
   }
 
-  private async commitWith(binding: EngineSessionBinding): Promise<void> {
-    const next = new Map(this.bindings)
-    next.set(bindingKey(binding), binding)
-    await this.commit(next)
-  }
-
-  private async commit(next: ReadonlyMap<string, EngineSessionBinding>): Promise<void> {
-    const bindings = [...next.values()].sort(compareBindings)
-    await writeStore(this.path, bindings)
-    this.bindings.clear()
-    for (const binding of bindings) this.bindings.set(bindingKey(binding), binding)
+  private async commit(): Promise<void> {
+    await this.persist()
     this.publish()
   }
 
-  private sorted(): EngineSessionBinding[] {
-    return [...this.bindings.values()].sort(compareBindings)
+  private async persist(): Promise<void> {
+    const currentRuns = this.currentRuns().map(({ taskId, tabId, runId }) => ({ taskId, tabId, runId }))
+    await writeStore(this.path, this.runsSnapshot(), currentRuns)
   }
 
   private publish(): void {
@@ -225,6 +395,6 @@ export class SessionBindingStore {
   }
 }
 
-function compareBindings(a: EngineSessionBinding, b: EngineSessionBinding): number {
-  return a.taskId.localeCompare(b.taskId) || a.tabId.localeCompare(b.tabId)
+function compareRuns(a: EngineRun, b: EngineRun): number {
+  return a.taskId.localeCompare(b.taskId) || a.tabId.localeCompare(b.tabId) || a.startedAt - b.startedAt
 }

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -40,6 +40,8 @@ export interface DaemonWebSnapshotState {
   engineTabSessions: Record<string, Record<string, string>>
   /** Durable, versioned session identity contract for new consumers. */
   sessionBindings: import("./contracts.ts").EngineSessionBindingsByTask
+  /** Ephemeral native-session transitions; never written to disk. */
+  sessionTransitions: import("./contracts.ts").EngineSessionTransitionsByTask
   update: ChannelPayloads["update"]["info"]
   jobs: Record<string, ChannelPayloads["task.jobs"]>
   worktreeChanges: ChannelPayloads["worktree.changes"]["changes"]
@@ -424,6 +426,7 @@ export function createDirectWebLink(args: {
         engineStates: args.activity.snapshotByTask(),
         engineTabSessions: args.bindings.sessionIdsByTask(),
         sessionBindings: args.bindings.snapshotByTask(),
+        sessionTransitions: args.bindings.transitionSnapshotByTask(),
         update: latest(args.bus, "update")?.info ?? null,
         jobs,
         worktreeChanges: latest(args.bus, "worktree.changes")?.changes ?? {},

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -19,6 +19,7 @@ import {
 import type { ChannelName, ChannelPayloads, DaemonRequestName, SerializedTask } from "./protocol.ts"
 import { serializeTask } from "./protocol.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import type { SessionBindingStore } from "./session-bindings.ts"
 import { handleIssueAssetsRequest } from "./web-issue-assets-route.ts"
 import { handleIssuesRequest } from "./web-issues-route.ts"
 import { allowedHostForBindHost, originAllowed } from "./web-origin.ts"
@@ -37,6 +38,8 @@ export interface DaemonWebSnapshotState {
   engineStates: Record<string, ChannelPayloads["engine-state"]>
   /** taskId → tabId → last known engine session id (tab-precise traces). */
   engineTabSessions: Record<string, Record<string, string>>
+  /** Durable, versioned session identity contract for new consumers. */
+  sessionBindings: import("./contracts.ts").EngineSessionBindingsByTask
   update: ChannelPayloads["update"]["info"]
   jobs: Record<string, ChannelPayloads["task.jobs"]>
   worktreeChanges: ChannelPayloads["worktree.changes"]["changes"]
@@ -322,11 +325,19 @@ export function createDaemonWebRequestHandler(deps: RequestHandlerDeps): (req: R
       const tab = url.searchParams.get("tab") ?? undefined
       return specResponse(url, link, async (l, id) => {
         const spec = await engineSpec(runtime, l, id, vendor, tab)
+        if (tab) {
+          await l.request("engine.beginSession", { taskId: id, tabId: tab, ...(vendor ? { vendor } : {}) })
+        }
         // Spawn-time pin: broadcast the injected session id so the Agent
         // Trace keys to this tab's session before the engine boots.
         if (spec.sessionId && tab) {
           await l
-            .request("engine.pinSession", { taskId: id, tabId: tab, sessionId: spec.sessionId })
+            .request("engine.pinSession", {
+              taskId: id,
+              tabId: tab,
+              sessionId: spec.sessionId,
+              ...(vendor ? { vendor } : {}),
+            })
             .catch(() => {})
         }
         return spec
@@ -389,6 +400,7 @@ export function createDirectWebLink(args: {
   orch: DaemonOrchestrator
   bus: DaemonEventBus
   activity: DaemonActivityRegistry
+  bindings: SessionBindingStore
   ctx: (clientId: number) => DaemonHandlerContext
 }): DaemonWebLink {
   const handlers = createDaemonHandlerRegistry()
@@ -410,7 +422,8 @@ export function createDirectWebLink(args: {
         tasks,
         activeTaskId: latest(args.bus, "active-task")?.taskId ?? null,
         engineStates: args.activity.snapshotByTask(),
-        engineTabSessions: args.activity.tabSessionsByTask(),
+        engineTabSessions: args.bindings.sessionIdsByTask(),
+        sessionBindings: args.bindings.snapshotByTask(),
         update: latest(args.bus, "update")?.info ?? null,
         jobs,
         worktreeChanges: latest(args.bus, "worktree.changes")?.changes ?? {},

--- a/packages/kobe-desktop/package.json
+++ b/packages/kobe-desktop/package.json
@@ -8,7 +8,8 @@
     "dev": "electron .",
     "dev:sandbox": "KOBE_HOME_DIR=../kobe/.dev-sandbox/home electron .",
     "dev:mock": "KOBE_HOME_DIR=../kobe/.dev-sandbox/home KOBE_PTY_DEV_CWD=../kobe KOBE_PTY_DEV_COMMAND='bun run dev:mock' electron .",
-    "check": "node --check src/main.mjs && node --check src/preload.cjs"
+    "check": "node --check src/main.mjs && node --check src/preload.cjs && node --check src/ports.mjs",
+    "test": "node --test test/*.test.mjs"
   },
   "devDependencies": {
     "electron": "^39.2.7"

--- a/packages/kobe-desktop/src/main.mjs
+++ b/packages/kobe-desktop/src/main.mjs
@@ -1,8 +1,8 @@
 import { spawn } from "node:child_process"
-import { createServer } from "node:net"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { app, BrowserWindow, ipcMain, shell } from "electron"
+import { findPorts } from "./ports.mjs"
 
 const here = dirname(fileURLToPath(import.meta.url))
 const packageDir = resolve(here, "..")
@@ -14,40 +14,6 @@ const iconPath = resolve(packageDir, "assets/icon.png")
 let webProcess = null
 let mainWindow = null
 let stopping = false
-
-function canListen(port) {
-  return new Promise((resolveListen) => {
-    const server = createServer()
-    server.once("error", () => resolveListen(false))
-    server.once("listening", () => {
-      server.close(() => resolveListen(true))
-    })
-    server.listen(port, "127.0.0.1")
-  })
-}
-
-async function findPorts(start = 5173, daemonWebPort = 5174) {
-  let webPort = null
-  for (let port = start; port < start + 200; port += 1) {
-    if (port !== daemonWebPort && (await canListen(port))) {
-      webPort = port
-      break
-    }
-  }
-  if (webPort === null) throw new Error(`no free web port found starting at ${start}`)
-
-  const preferredPty = webPort + 2
-  for (let port = preferredPty; port < preferredPty + 200; port += 1) {
-    if (port !== daemonWebPort && port !== webPort && (await canListen(port))) {
-      return {
-        web: webPort,
-        daemonWeb: daemonWebPort,
-        pty: port,
-      }
-    }
-  }
-  throw new Error(`no free PTY port found starting at ${preferredPty}`)
-}
 
 function stopWebProcess() {
   if (stopping) return

--- a/packages/kobe-desktop/src/ports.mjs
+++ b/packages/kobe-desktop/src/ports.mjs
@@ -1,0 +1,43 @@
+import { createServer } from "node:net"
+
+export function canListen(port) {
+  return new Promise((resolveListen) => {
+    const server = createServer()
+    server.once("error", () => resolveListen(false))
+    server.once("listening", () => {
+      server.close(() => resolveListen(true))
+    })
+    server.listen(port, "127.0.0.1")
+  })
+}
+
+async function firstAvailable(start, excluded, available) {
+  for (let port = start; port < start + 200; port += 1) {
+    if (!excluded.has(port) && (await available(port))) return port
+  }
+  return null
+}
+
+async function firstAvailableWebPtyPair(start, available) {
+  for (let web = start; web < start + 200; web += 1) {
+    const pty = web + 2
+    if ((await available(web)) && (await available(pty))) return { web, pty }
+  }
+  return null
+}
+
+/**
+ * Preserve the browser protocol's `PTY = web + 2` invariant, then reserve a
+ * daemon candidate outside that pair. If the desired daemon already exists,
+ * kobe-web replaces this candidate with daemon.status.webPort.
+ */
+export async function findPorts(start = 5173, daemonStart = 5174, available = canListen) {
+  const pair = await firstAvailableWebPtyPair(start, available)
+  if (pair === null) throw new Error(`no free web/PTY pair found starting at ${start}`)
+  const { web, pty } = pair
+
+  const daemonWeb = await firstAvailable(daemonStart, new Set([web, pty]), available)
+  if (daemonWeb === null) throw new Error(`no free daemon web port found starting at ${daemonStart}`)
+
+  return { web, daemonWeb, pty }
+}

--- a/packages/kobe-desktop/test/ports.test.mjs
+++ b/packages/kobe-desktop/test/ports.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { findPorts } from "../src/ports.mjs"
+
+describe("desktop port selection", () => {
+  it("does not hand a new dev daemon an occupied production port", async () => {
+    const occupied = new Set([5174])
+    const ports = await findPorts(5173, 5174, async (port) => !occupied.has(port))
+
+    assert.deepEqual(ports, { web: 5173, daemonWeb: 5176, pty: 5175 })
+  })
+
+  it("allocates three distinct ports when defaults are free", async () => {
+    const ports = await findPorts(5173, 5174, async () => true)
+
+    assert.deepEqual(ports, { web: 5173, daemonWeb: 5174, pty: 5175 })
+  })
+
+  it("keeps the PTY exactly two ports above the selected web port", async () => {
+    const occupied = new Set([5175])
+    const ports = await findPorts(5173, 5174, async (port) => !occupied.has(port))
+
+    assert.equal(ports.pty, ports.web + 2)
+    assert.deepEqual(ports, { web: 5174, daemonWeb: 5177, pty: 5176 })
+  })
+})

--- a/packages/kobe-plugin-sdk/src/contract.ts
+++ b/packages/kobe-plugin-sdk/src/contract.ts
@@ -100,6 +100,7 @@ export const DAEMON_CHANNELS = [
   "active-task",
   "update",
   "engine-state",
+  "session.bindings",
   "attention.inbox",
   "ui-prefs",
   "keybindings",

--- a/packages/kobe-web/dev-daemon.ts
+++ b/packages/kobe-web/dev-daemon.ts
@@ -1,0 +1,28 @@
+export interface DaemonWebStatus {
+  socketPath?: unknown
+  webPort?: unknown
+  webError?: unknown
+}
+
+/**
+ * Bind the dev proxy to the HTTP transport owned by the daemon reached over
+ * the selected socket. A fixed/default port is not an identity: a different
+ * production or sandbox daemon can legitimately be listening there.
+ */
+export function daemonWebPortFromStatus(status: DaemonWebStatus, expectedSocketPath: string): string {
+  if (status.socketPath !== expectedSocketPath) {
+    throw new Error(
+      `daemon identity mismatch: connected to ${expectedSocketPath}, status reported ${String(status.socketPath)}`,
+    )
+  }
+  if (
+    typeof status.webPort !== "number" ||
+    !Number.isInteger(status.webPort) ||
+    status.webPort < 1 ||
+    status.webPort > 65_535
+  ) {
+    const reason = typeof status.webError === "string" && status.webError ? ` (${status.webError})` : ""
+    throw new Error(`selected daemon has no reachable web transport${reason}`)
+  }
+  return String(status.webPort)
+}

--- a/packages/kobe-web/dev.ts
+++ b/packages/kobe-web/dev.ts
@@ -20,9 +20,11 @@
 import { mkdirSync } from "node:fs"
 import { homedir } from "node:os"
 import { resolve } from "node:path"
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-process"
+import { daemonWebPortFromStatus, type DaemonWebStatus } from "./dev-daemon.ts"
 
-const DAEMON_WEB_PORT = process.env.KOBE_DAEMON_WEB_PORT ?? "5174"
+const REQUESTED_DAEMON_WEB_PORT = process.env.KOBE_DAEMON_WEB_PORT ?? "5174"
 const WEB_PORT = process.env.KOBE_WEB_PORT ?? "5173"
 const PTY_PORT = process.env.KOBE_PTY_PORT ?? "5175"
 
@@ -33,16 +35,31 @@ const rawHome = process.env.KOBE_HOME_DIR
 const homeDir = rawHome ? resolve(rawHome) : null
 if (homeDir) mkdirSync(homeDir, { recursive: true })
 if (homeDir) process.env.KOBE_HOME_DIR = homeDir
+process.env.KOBE_DAEMON_WEB_PORT = REQUESTED_DAEMON_WEB_PORT
+
+const sandboxed = homeDir !== null
+
+// The socket is the daemon's identity boundary. Ask that exact process which
+// HTTP port it owns instead of trusting the requested/default port: another
+// production or sandbox daemon may already be answering there.
+const socketPath = await ensureDaemonReachable()
+const daemon = new KobeDaemonClient(socketPath)
+let daemonStatus: DaemonWebStatus
+try {
+  await daemon.connect()
+  daemonStatus = await daemon.request<DaemonWebStatus>("daemon.status", {})
+} finally {
+  daemon.close()
+}
+const DAEMON_WEB_PORT = daemonWebPortFromStatus(daemonStatus, socketPath)
 process.env.KOBE_DAEMON_WEB_PORT = DAEMON_WEB_PORT
 const childEnv = { ...process.env, ...(homeDir ? { KOBE_HOME_DIR: homeDir } : {}) }
 
-const sandboxed = homeDir !== null
 console.log(
   `\x1b[1m[kobe web dev]\x1b[0m ${sandboxed ? "\x1b[33msandbox\x1b[0m" : "\x1b[31mPRODUCTION\x1b[0m"} · home: ${homeDir ?? `${homedir()}/.kobe (production)`}`,
 )
 console.log(`  web :${WEB_PORT}  daemon-web :${DAEMON_WEB_PORT}  pty :${PTY_PORT}`)
 
-await ensureDaemonReachable()
 try {
   const res = await fetch(`http://127.0.0.1:${DAEMON_WEB_PORT}/__kobe_web`, {
     signal: AbortSignal.timeout(1500),

--- a/packages/kobe-web/engine-session-observer.mjs
+++ b/packages/kobe-web/engine-session-observer.mjs
@@ -1,0 +1,46 @@
+/**
+ * Neutral PTY-side trigger for engine-owned session observation.
+ *
+ * The sidecar knows tab/process identity but not provider log formats. After a
+ * terminal commit it asks the daemon to run the selected engine adapter. A
+ * bounded retry window covers both the provider persisting its activation and
+ * a resumed app-server thread completing startup after Enter reaches the PTY.
+ */
+
+const DEFAULT_DELAYS_MS = [0, 100, 300, 750, 1500, 3000]
+
+export function createEngineSessionObservationClient({
+  daemonWebPort,
+  fetchFn = fetch,
+  setTimeoutFn = setTimeout,
+  delaysMs = DEFAULT_DELAYS_MS,
+}) {
+  const generations = new Map()
+
+  function observe({ taskId, tabId, vendor, rootPid }) {
+    if (!taskId || !tabId || !Number.isInteger(rootPid) || rootPid <= 0) return
+    const generation = (generations.get(tabId) ?? 0) + 1
+    generations.set(tabId, generation)
+    for (const delayMs of delaysMs) {
+      const timer = setTimeoutFn(() => {
+        if (generations.get(tabId) !== generation) return
+        void fetchFn(`http://127.0.0.1:${daemonWebPort}/api/rpc`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            name: "engine.observeSession",
+            payload: { taskId, tabId, rootPid, ...(vendor ? { vendor } : {}) },
+          }),
+        }).catch(() => {})
+      }, delayMs)
+      timer?.unref?.()
+    }
+  }
+
+  return {
+    observe,
+    forget(tabId) {
+      generations.delete(tabId)
+    },
+  }
+}

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -25,6 +25,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { spawn } from "node-pty"
 import { WebSocketServer } from "ws"
+import { createEngineSessionObservationClient } from "./engine-session-observer.mjs"
 import { allowedHostForBindHost, originAllowed } from "./origin-policy.mjs"
 import { ptyEnv } from "./pty-env.mjs"
 import { createScrollback } from "./pty-scrollback.mjs"
@@ -37,6 +38,7 @@ const HEALTH_PATH = "/__kobe_web"
 const HEALTH_MARKER = "kobe-web"
 const HOST = process.env.KOBE_WEB_HOST?.trim() || "127.0.0.1"
 const ALLOWED_HOST = allowedHostForBindHost(HOST)
+const sessionObserver = createEngineSessionObservationClient({ daemonWebPort: DAEMON_WEB_PORT })
 
 const CLAUDE_HOME = join(homedir(), ".claude")
 const IMG_MIMES = {
@@ -113,6 +115,7 @@ const ptySessions = createPtySessionManager({
   createScrollback,
   scrollbackCap: SCROLLBACK_CAP,
   env: ptyEnv,
+  onTerminalCommit: sessionObserver.observe,
 })
 
 const server = createServer((req, res) => {
@@ -287,6 +290,7 @@ const server = createServer((req, res) => {
         /* ignore */
       }
       const ok = tab ? ptySessions.closeSession(tab) : false
+      if (tab) sessionObserver.forget(tab)
       res.writeHead(200, {
         "content-type": "application/json",
         "access-control-allow-origin": "*",

--- a/packages/kobe-web/pty-session-lifecycle.mjs
+++ b/packages/kobe-web/pty-session-lifecycle.mjs
@@ -73,6 +73,7 @@ export function createPtySessionManager({
   submitDelays = DEFAULT_SUBMIT_DELAYS,
   maxSessions = DEFAULT_MAX_SESSIONS,
   backpressure = DEFAULT_BACKPRESSURE,
+  onTerminalCommit = () => {},
 }) {
   /** @type {Map<string, { pty: any, scrollback: ReturnType<createScrollback>, sockets: Set<any> }>} */
   const sessions = new Map()
@@ -110,7 +111,7 @@ export function createPtySessionManager({
     }
   }
 
-  function spawnSession(tabId, spec, cols, rows) {
+  function spawnSession(tabId, spec, cols, rows, identity) {
     // Enforce the session cap before allocating another process: evict the
     // oldest unwatched session, or reject when every session is in active use.
     if (sessions.size >= maxSessions && !sessions.has(tabId)) {
@@ -139,6 +140,7 @@ export function createPtySessionManager({
     }
     const entry = {
       pty,
+      ...identity,
       scrollback: createScrollback(scrollbackCap),
       sockets: new Set(),
       paused: false,
@@ -170,7 +172,7 @@ export function createPtySessionManager({
     const p = (async () => {
       // Vendor override only applies to engine PTYs — shell mode has no engine-spec.
       const spec = await fetchSpec(taskId, mode, mode === "engine" ? vendor : undefined, tabId)
-      return sessions.get(tabId) ?? spawnSession(tabId, spec, cols, rows)
+      return sessions.get(tabId) ?? spawnSession(tabId, spec, cols, rows, { taskId, mode, vendor })
     })()
     pendingSpawns.set(tabId, p)
     try {
@@ -210,6 +212,14 @@ export function createPtySessionManager({
         }
       }
       safePty(tabId, entry, (pty) => pty.write(text))
+      if (text.includes("\r") && entry.mode === "engine") {
+        onTerminalCommit({
+          taskId: entry.taskId,
+          tabId,
+          vendor: entry.vendor,
+          rootPid: entry.pty.pid,
+        })
+      }
     })
 
     ws.on("close", () => {
@@ -252,6 +262,14 @@ export function createPtySessionManager({
       setTimeoutFn(() => {
         try {
           target.pty.write("\r")
+          if (target.mode === "engine") {
+            onTerminalCommit({
+              taskId: target.taskId,
+              tabId,
+              vendor: target.vendor,
+              rootPid: target.pty.pid,
+            })
+          }
         } catch {
           /* best-effort */
         }

--- a/packages/kobe-web/src/components/ChatShell.tsx
+++ b/packages/kobe-web/src/components/ChatShell.tsx
@@ -13,17 +13,9 @@
  */
 
 import { PanelRight } from "lucide-react"
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
-import { isMenuRow, type TtyBlock } from "../lib/claude-tty.ts"
-import { type EngineGrammar, grammarFor } from "../lib/engine-grammar.ts"
+import { lazy, Suspense, useEffect, useMemo, useState } from "react"
+import { grammarFor } from "../lib/engine-grammar.ts"
+import { useEngines } from "../lib/engines.ts"
 import {
   closeSettings,
   selectChatTask,
@@ -33,31 +25,19 @@ import {
 import { rpc, useAppState } from "../lib/store.ts"
 import {
   ensureEngineTab,
-  resetTabTitle,
-  setTabTitle,
   type TerminalTab,
   useTabsState,
   type VendorTab,
 } from "../lib/tabs.ts"
-import {
-  type ColoredLine,
-  sameColoredLine,
-  trimLeadingColored,
-} from "../lib/tty-color.ts"
-import { useEngines } from "../lib/engines.ts"
 import { fetchPtyForeground } from "../lib/terminal.ts"
 import { resolveVendor } from "../lib/vendor.ts"
 import { ChatSidebarTree } from "./ChatSidebarTree.tsx"
 import { DaemonBanner } from "./DaemonBanner.tsx"
-import { InputMirror } from "./InputMirror.tsx"
 import { PaneResizer, usePaneWidth } from "./PaneResizer.tsx"
+import { SessionView } from "./SessionView.tsx"
 import { TimelineHost } from "./TimelineHost.tsx"
 import { Toasts } from "./Toasts.tsx"
-import { TtyBlocksView, TtyFooter, useTtyBlocks } from "./TtyBlocksView.tsx"
 
-const ChatTerminal = lazy(() =>
-  import("./ChatTerminal.tsx").then((m) => ({ default: m.ChatTerminal })),
-)
 // Kanban / Routines render INSIDE the /chat main area (a surface switch, not
 // a route jump) — lazy so the chat-first load doesn't pay for them.
 const Board = lazy(() =>
@@ -70,398 +50,15 @@ const SettingsPage = lazy(() =>
   import("./SettingsPage.tsx").then((m) => ({ default: m.SettingsPage })),
 )
 
-/** One status-footer line (branch | ctx | quota | mode), rendered from the
- *  colored buffer so it keeps the engine's own ANSI colors (blue branch,
- *  cyan tok/s, orange diff, red bypass-permissions). Uncolored runs fall to
- *  muted grey. */
-function StatusLine({ line }: { line: ColoredLine }) {
-  return (
-    <div className="truncate font-mono text-[11px] leading-[1.6] text-subtle">
-      {line.segs.map((seg, i) => (
-        <span
-          // biome-ignore lint/suspicious/noArrayIndexKey: colored runs are positional, re-derived per frame
-          key={i}
-          style={seg.color ? { color: seg.color } : undefined}
-        >
-          {seg.text}
-        </span>
-      ))}
-    </div>
-  )
-}
-
-/** A horizontal-rule row (the composer's frame lines) — dropped from status. */
-const STATUS_RULE = /^[─━═╌╍-]{3,}\s*$/
-
-/**
- * One shell PTY per tab. The tab owns the parent shell; an engine CLI is a
- * CHILD process inside it. The translated chat UI engages WHENEVER the
- * engine's input region is detected on screen — regardless of tab kind
- * (vendor auto-types the engine command; shell starts bare) — and falls back
- * to the RAW visible terminal when it isn't (bare shell prompt, engine
- * exited, native full-screen dialog). Launching `claude` by hand in a Shell
- * tab gets the full translated UI; an engine exiting drops you back to a
- * usable shell. Clicking anywhere focuses the PTY so keystrokes drive it
- * directly (slash menus, @-complete, arrow selection).
- */
-function SessionView({
-  tabId,
-  taskId,
-  sessionId,
-  mode,
-  vendor,
-  grammar,
-  onEngineLive,
-  onConversation,
-}: {
-  tabId: string
-  taskId: string
-  sessionId: string | null
-  /** Vendor tabs → 'engine' (auto-types the engine command); terminal tabs → 'shell'. */
-  mode: "engine" | "shell"
-  /** Per-tab engine vendor override (VendorTab.vendor → ChatTerminal). */
-  vendor?: string
-  /** The vendor's screen grammar (engine-grammar.ts) — drives the translation. */
-  grammar: EngineGrammar
-  /** Grammar-derived engine liveness, lifted so the Agent Trace can clear
-   *  when this tab drops to a bare shell / boot screen. */
-  onEngineLive?: (live: boolean) => void
-  /** Screen shows a conversation (a user bubble exists). The trace binds to
-   *  a transcript only then — a fresh boot has NOTHING to trace, so it must
-   *  not parade the previous session (no state to manage: the screen tells). */
-  onConversation?: (has: boolean) => void
-}) {
-  const [colored, setColored] = useState<ColoredLine[]>([])
-  const [focusNonce, setFocusNonce] = useState(0)
-  // Frame stabilizer: reuse previous line OBJECTS for unchanged rows so
-  // memoized children skip re-render — a keystroke only re-renders the input
-  // row's dependents, not the whole transcript.
-  const prevLinesRef = useRef<ColoredLine[]>([])
-  const onColoredBuffer = useCallback((next: ColoredLine[]) => {
-    const prev = prevLinesRef.current
-    let allSame = next.length === prev.length
-    const stable = next.map((line, i) => {
-      const p = prev[i]
-      if (p && sameColoredLine(p, line)) return p
-      allSame = false
-      return line
-    })
-    prevLinesRef.current = allSame ? prev : stable
-    setColored(prevLinesRef.current)
-  }, [])
-  // IME composing string (pinyin buffer) from the hidden textarea — the PTY
-  // only sees committed text, so the composer must mirror this itself.
-  const [composing, setComposing] = useState<string | null>(null)
-  // Real terminal cursor (viewport row + cell col) — the mirror's caret
-  // follows it instead of pinning to the end of the prompt text.
-  const [cursor, setCursor] = useState<{ row: number; col: number } | null>(
-    null,
-  )
-
-  // Split each frame at the engine's input region: everything above it is the
-  // conversation body, the region itself is the current input line + status.
-  const textLines = useMemo(() => colored.map((l) => l.text), [colored])
-  const region = useMemo(
-    () => grammar.findInputRegion(textLines),
-    [grammar, textLines],
-  )
-  // Last exit banner — reverse loop (no findLastIndex typing on ColoredLine[]).
-  const lastExitIdx = useMemo(() => {
-    const banner = grammar.exitBanner
-    if (!banner) return -1
-    for (let i = colored.length - 1; i >= 0; i--) {
-      const line = colored[i]
-      if (line && banner.test(line.text.trim())) return i
-    }
-    return -1
-  }, [grammar, colored])
-  // Resume banner below the input box → box is stale; banner above → relaunched, live.
-  const engineLive =
-    region !== null && !(lastExitIdx >= 0 && lastExitIdx >= region.topRow)
-  if (import.meta.env.DEV) {
-    // Live-translation probe for agent-driven debugging (dev builds only).
-    ;(window as unknown as Record<string, unknown>).__kobeTty = {
-      lines: textLines,
-      region,
-      lastExitIdx,
-      engineLive,
-      tabId,
-      vendorProp: vendor,
-    }
-  }
-  // Engine child exited (ctrl+c → shell) → restore the minted tab title; a
-  // bare shell may never emit an OSC title to overwrite the engine's.
-  const wasLiveRef = useRef(false)
-  useEffect(() => {
-    onEngineLive?.(engineLive)
-    if (wasLiveRef.current && !engineLive) resetTabTitle(taskId, tabId)
-    wasLiveRef.current = engineLive
-  }, [engineLive, taskId, tabId, onEngineLive])
-  const bodyLines = useMemo(
-    () => (region ? colored.slice(0, region.topRow) : colored),
-    [region, colored],
-  )
-  // Lift the right-aligned `● high · /effort` chip out of the scroll body
-  // so it can pin above the composer (matching the CLI's placement).
-  const { chatBodyLines, effortLine } = useMemo(() => {
-    const pattern = grammar.effortLine
-    if (!pattern) return { chatBodyLines: bodyLines, effortLine: null }
-    for (let i = bodyLines.length - 1; i >= 0; i--) {
-      const line = bodyLines[i]
-      if (line && pattern.test(line.text.trim())) {
-        return {
-          chatBodyLines: [...bodyLines.slice(0, i), ...bodyLines.slice(i + 1)],
-          effortLine: line as ColoredLine | null,
-        }
-      }
-    }
-    return { chatBodyLines: bodyLines, effortLine: null }
-  }, [grammar, bodyLines])
-  // The CLI drops its ultracode mode banner (a `✦ ultracode · …` status row
-  // + a `──── ultracode` labeled rule) wherever the conversation happened to
-  // be — strand it there and it drifts mid-scrollback. Lift every marker row
-  // out and pin ONE re-dressed strip above the composer; its presence is
-  // also the LIVE signal that lights the welcome card.
-  const { chatLines, ultraMarker } = useMemo(() => {
-    const marker = /^(?:[✦✧✳+*·]\s*)?ultracode(?:\s*·.*)?$|^─{4,}[─\s]*ultracode\s*─{0,6}$/
-    let found = false
-    const kept = chatBodyLines.filter((l) => {
-      if (!marker.test(l.text.trim())) return true
-      found = true
-      return false
-    })
-    return found
-      ? { chatLines: kept, ultraMarker: true }
-      : { chatLines: chatBodyLines, ultraMarker: false }
-  }, [chatBodyLines])
-  // The mode label is composer chrome (region.modeLabel); stray scrollback
-  // markers count too so the ambience never flickers off mid-conversation.
-  const ultraActive =
-    region?.modeLabel?.toLowerCase() === "ultracode" || ultraMarker
-  // Caret CHAR offset from the cursor's CELL column (>0xFF ≈ 2 cells —
-  // CJK-good; wcwidth if emoji matters). The region's promptText is trimmed
-  // (terminal rows are padded to full width), so TRAILING spaces the user
-  // just typed vanish — when the cursor sits past the trimmed end, restore
-  // them so the caret keeps moving through space runs.
-  const { promptText, caretOffset } = useMemo(() => {
-    const trimmed = region?.promptText ?? ""
-    if (!region || !cursor || cursor.row !== region.promptRow || !trimmed)
-      return { promptText: trimmed, caretOffset: null }
-    const raw = colored[region.promptRow]?.text ?? ""
-    const start = raw.indexOf(trimmed)
-    if (start < 0) return { promptText: trimmed, caretOffset: null }
-    const targetCells = cursor.col - start
-    if (targetCells < 0) return { promptText: trimmed, caretOffset: null }
-    let cells = 0
-    let idx = 0
-    for (const ch of trimmed) {
-      if (cells >= targetCells) break
-      cells += (ch.codePointAt(0) ?? 0) > 0xff ? 2 : 1
-      idx += ch.length
-    }
-    if (targetCells > cells) {
-      const pad = targetCells - cells
-      return {
-        promptText: trimmed + " ".repeat(pad),
-        caretOffset: trimmed.length + pad,
-      }
-    }
-    return { promptText: trimmed, caretOffset: Math.min(idx, trimmed.length) }
-  }, [region, cursor, colored])
-  // Status footer (branch | ctx | quota | mode) as COLORED lines, straight
-  // from the buffer below the prompt — so it keeps the engine's ANSI colors
-  // instead of flattening to grey. Rule/blank rows dropped.
-  // Below-composer tail: true status rows stay in the footer; slash-menu rows
-  // (Codex draws its menu BELOW the composer) lift into the floated menu.
-  const { statusColored, belowMenu } = useMemo(() => {
-    if (!region) return { statusColored: [], belowMenu: [] as TtyBlock[] }
-    const below = colored.slice(region.promptRow + 1)
-    const menuRows = below.filter((l) => isMenuRow(l.text))
-    const menu =
-      menuRows.length >= 2
-        ? grammar.parseBlocks(menuRows).filter((b) => b.kind === "menu")
-        : []
-    const status = below.filter((l) => {
-      const t = l.text.trim()
-      return t !== "" && !STATUS_RULE.test(t) && !isMenuRow(l.text)
-    })
-    return { statusColored: status, belowMenu: menu }
-  }, [region, colored, grammar])
-  // The live footer (spinner/tip/slash-menu below the last gap) is lifted out
-  // of the scroll body and floated just above the input row — where the native
-  // TUI shows it — instead of leaving it adrift in the history.
-  const { body: rawBody, footer: rawFooter } = useTtyBlocks(chatLines, grammar)
-  // Claude's `※ recap` docks above the composer instead of drifting in the
-  // flow — strip every occurrence, pin the newest.
-  const { body, bodyFooter, recap } = useMemo((): {
-    body: readonly TtyBlock[]
-    bodyFooter: readonly TtyBlock[]
-    recap: { kind: "recap"; text: string } | null
-  } => {
-    let last: { kind: "recap"; text: string } | null = null
-    const strip = (arr: readonly TtyBlock[]): readonly TtyBlock[] => {
-      if (!arr.some((b) => b.kind === "recap")) return arr
-      return arr.filter((b) => {
-        if (b.kind === "recap") {
-          last = b
-          return false
-        }
-        return true
-      })
-    }
-    const nextBody = strip(rawBody)
-    const nextFooter = strip(rawFooter)
-    return { body: nextBody, bodyFooter: nextFooter, recap: last }
-  }, [rawBody, rawFooter])
-  const footer = useMemo(
-    () => (belowMenu.length > 0 ? [...bodyFooter, ...belowMenu] : bodyFooter),
-    [bodyFooter, belowMenu],
-  )
-  // A bordered card is only warranted when the engine is WAITING on the user
-  // (spinner / slash-menu / question). Passive notices (clipboard hint) get a
-  // quiet unboxed line instead.
-  // A user bubble on screen = this tab HAS a conversation to trace.
-  const hasConversation = useMemo(
-    () => body.some((b) => b.kind === "user"),
-    [body],
-  )
-  useEffect(() => {
-    onConversation?.(hasConversation)
-  }, [hasConversation, onConversation])
-  const footerInteractive = footer.some(
-    (b) => b.kind === "menu" || b.kind === "options" || b.kind === "activity",
-  )
-  // a. engineLive → translated stack; b. empty buffer → BootLine placeholder;
-  // c. otherwise → raw terminal takeover (no overlay, no composer mirror).
-  const showTranslated = engineLive || colored.length === 0
-
-  return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: a click anywhere focuses the PTY so typing drives the native CLI / shell
-    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard input already routes to the PTY; the click is only a focus assist
-    <div
-      className="relative h-full"
-      onClick={() => {
-        // Click focuses the PTY — but a drag-select stays a selection: don't
-        // steal focus (and collapse the range) when text was just selected.
-        if (window.getSelection()?.toString()) return
-        setFocusNonce((n) => n + 1)
-      }}
-    >
-      {/* Real PTY — data source + input target. opacity-0 while translated so
-          its input stays focusable under the overlay; drops opacity when raw
-          (bare shell / dialog / engine exited). SAME px-4 as the translated
-          column so the native lays out at the width we render. */}
-      <div
-        className={
-          showTranslated
-            ? "absolute inset-0 px-4 opacity-0"
-            : "absolute inset-0 px-4"
-        }
-      >
-        <Suspense fallback={null}>
-          <ChatTerminal
-            key={tabId}
-            tabId={tabId}
-            taskId={taskId}
-            mode={mode}
-            hideComposer
-            focusNonce={focusNonce}
-            vendor={vendor}
-            onColoredBuffer={onColoredBuffer}
-            // Strip the engine's own status glyph (✳/✱) — the row draws its own.
-            onTitle={(t) =>
-              setTabTitle(
-                taskId,
-                tabId,
-                t.replace(/^[✳✱⏺●○]\s*/, "").slice(0, 60),
-              )
-            }
-            onComposition={setComposing}
-            onCursor={setCursor}
-          />
-        </Suspense>
-      </div>
-      {showTranslated && (
-        <div
-          className="relative z-10 flex h-full flex-col bg-bg"
-          data-effort={ultraActive ? "ultracode" : undefined}
-        >
-          <div className="min-h-0 flex-1">
-            <TtyBlocksView blocks={body} sessionId={sessionId} />
-          </div>
-          {/* One composer zone: every row runs edge-to-edge with the input
-              card, so the gaps (not indents) do the grouping. */}
-          <div className="shrink-0 space-y-1.5 px-4 pb-3 pt-1">
-            {footer.length > 0 &&
-              (footerInteractive ? (
-                // A card only when the engine is WAITING on the user (spinner
-                // / slash-menu / question). Passive notices don't earn one.
-                <div className="rounded-2xl border border-line bg-surface/50 px-4 py-2.5">
-                  <TtyFooter blocks={footer} sessionId={sessionId} />
-                </div>
-              ) : (
-                // Passive hints (Image in clipboard…) — quiet line above input.
-                <div className="text-[11px]">
-                  <TtyFooter blocks={footer} sessionId={sessionId} />
-                </div>
-              ))}
-            {effortLine && (
-              <div className="fade-up flex justify-end">
-                <StatusLine line={trimLeadingColored(effortLine)} />
-              </div>
-            )}
-            {recap && (
-              <div className="fade-up text-[12px] leading-relaxed text-muted">
-                <span className="mr-1.5 select-none text-subtle">※</span>
-                {recap.text}
-              </div>
-            )}
-            {/* Mirrors the native placement: the mode label rides the
-                composer's top edge, right-aligned. */}
-            {ultraActive && (
-              <div
-                className="fade-up flex items-center gap-2.5 px-1"
-                title="ultracode — xhigh effort + dynamic workflow orchestration"
-              >
-                <span
-                  aria-hidden="true"
-                  className="ultra-rule h-px min-w-0 flex-1"
-                />
-                <span className="ultra-rule__label font-mono text-[11px]">
-                  ultracode
-                </span>
-              </div>
-            )}
-            {/* No composer until the engine draws one — during boot (empty
-                buffer / harness setup) the mirror has nothing to mirror. */}
-            {engineLive && (
-              <InputMirror
-                promptText={promptText}
-                composing={composing}
-                caretOffset={caretOffset}
-                sessionId={sessionId}
-              />
-            )}
-            {statusColored.length > 0 && (
-              // Dim the whole group instead of the segs — the rows keep the
-              // engine's ANSI colors, just quieter.
-              <div className="opacity-75">
-                {statusColored.map((line, i) => (
-                  // biome-ignore lint/suspicious/noArrayIndexKey: positional status rows re-derived per frame
-                  <StatusLine key={i} line={line} />
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
 export function ChatShell() {
-  const { tasks, activeTaskId, engineStates, engineTabSessions, attentionInbox } =
-    useAppState()
+  const {
+    tasks,
+    activeTaskId,
+    engineStates,
+    engineTabSessions,
+    sessionBindings,
+    attentionInbox,
+  } = useAppState()
   const { tabsByTask, activeByTask } = useTabsState()
   // Surface + selection live in the global-ui store so the root-level command
   // palette can drive the shell (jump task / open Kanban / open Routines).
@@ -565,17 +162,32 @@ export function ChatShell() {
   const [showTimeline, setShowTimeline] = useState(true)
   // Drag-resizable flanks: task sidebar (divider on its right) and Agent
   // Trace (divider on its left). Widths persist per browser.
-  const [sidebarW, dragSidebar] = usePaneWidth("kobe-web.pane.sidebar", 256, 190, 420, 1)
-  const [traceW, dragTrace] = usePaneWidth("kobe-web.pane.trace", 320, 240, 640, -1)
+  const [sidebarW, dragSidebar] = usePaneWidth(
+    "kobe-web.pane.sidebar",
+    256,
+    190,
+    420,
+    1,
+  )
+  const [traceW, dragTrace] = usePaneWidth(
+    "kobe-web.pane.trace",
+    320,
+    240,
+    640,
+    -1,
+  )
   // Active tab's grammar-derived engine liveness (SessionView reports it up).
-  // Off → the trace panel clears instead of parading a dead session.
+  // It decorates live status only; the durable binding keeps history visible.
   const [engineLive, setEngineLive] = useState(false)
-  const [hasConversation, setHasConversation] = useState(false)
   // biome-ignore lint/correctness/useExhaustiveDependencies: tab switch resets liveness until the new SessionView reports
   useEffect(() => {
     setEngineLive(false)
-    setHasConversation(false)
   }, [tabId])
+
+  const activeBinding =
+    selected && tabId ? sessionBindings[selected.id]?.[tabId] : undefined
+  const legacySessionId =
+    selected && tabId ? engineTabSessions[selected.id]?.[tabId] : undefined
 
   return (
     <div className="flex h-full flex-col bg-bg">
@@ -637,17 +249,12 @@ export function ChatShell() {
                   tabId={tabId}
                   taskId={selected.id}
                   sessionId={
-                    (tabId
-                      ? engineTabSessions[selected.id]?.[tabId]
-                      : undefined) ??
-                    engineStates[selected.id]?.sessionId ??
-                    null
+                    activeBinding?.sessionId ?? legacySessionId ?? null
                   }
                   mode={mode}
                   vendor={vendor}
                   grammar={grammarFor(effectiveVendor ?? selected.vendor)}
                   onEngineLive={setEngineLive}
-                  onConversation={setHasConversation}
                 />
               )}
             </div>
@@ -664,14 +271,11 @@ export function ChatShell() {
         {surface === "chat" && selected && showTimeline && (
           <TimelineHost
             taskId={selected.id}
-            worktreePath={selected.worktreePath || null}
             vendor={resolveVendor(effectiveVendor ?? selected.vendor)}
             engineState={engineStates[selected.id]}
-            tabSessionId={
-              tabId ? engineTabSessions[selected.id]?.[tabId] : undefined
-            }
+            binding={activeBinding}
+            legacySessionId={legacySessionId}
             engineActive={engineLive}
-            bound={hasConversation}
             width={traceW}
           />
         )}

--- a/packages/kobe-web/src/components/ChatShell.tsx
+++ b/packages/kobe-web/src/components/ChatShell.tsx
@@ -57,6 +57,7 @@ export function ChatShell() {
     engineStates,
     engineTabSessions,
     sessionBindings,
+    sessionTransitions,
     attentionInbox,
   } = useAppState()
   const { tabsByTask, activeByTask } = useTabsState()
@@ -186,6 +187,8 @@ export function ChatShell() {
 
   const activeBinding =
     selected && tabId ? sessionBindings[selected.id]?.[tabId] : undefined
+  const activeTransition =
+    selected && tabId ? sessionTransitions[selected.id]?.[tabId] : undefined
   const legacySessionId =
     selected && tabId ? engineTabSessions[selected.id]?.[tabId] : undefined
 
@@ -274,6 +277,7 @@ export function ChatShell() {
             vendor={resolveVendor(effectiveVendor ?? selected.vendor)}
             engineState={engineStates[selected.id]}
             binding={activeBinding}
+            transition={activeTransition}
             legacySessionId={legacySessionId}
             engineActive={engineLive}
             width={traceW}

--- a/packages/kobe-web/src/components/SessionView.tsx
+++ b/packages/kobe-web/src/components/SessionView.tsx
@@ -1,0 +1,402 @@
+/** Translated HTML view over one real hosted shell PTY. */
+
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { isMenuRow, type TtyBlock } from "../lib/claude-tty.ts"
+import type { EngineGrammar } from "../lib/engine-grammar.ts"
+import { resetTabTitle, setTabTitle } from "../lib/tabs.ts"
+import {
+  type ColoredLine,
+  sameColoredLine,
+  trimLeadingColored,
+} from "../lib/tty-color.ts"
+import { InputMirror } from "./InputMirror.tsx"
+import { TtyBlocksView, TtyFooter, useTtyBlocks } from "./TtyBlocksView.tsx"
+
+const ChatTerminal = lazy(() =>
+  import("./ChatTerminal.tsx").then((m) => ({ default: m.ChatTerminal })),
+)
+
+/** One status-footer line (branch | ctx | quota | mode), rendered from the
+ *  colored buffer so it keeps the engine's own ANSI colors (blue branch,
+ *  cyan tok/s, orange diff, red bypass-permissions). Uncolored runs fall to
+ *  muted grey. */
+function StatusLine({ line }: { line: ColoredLine }) {
+  return (
+    <div className="truncate font-mono text-[11px] leading-[1.6] text-subtle">
+      {line.segs.map((seg, i) => (
+        <span
+          // biome-ignore lint/suspicious/noArrayIndexKey: colored runs are positional, re-derived per frame
+          key={i}
+          style={seg.color ? { color: seg.color } : undefined}
+        >
+          {seg.text}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** A horizontal-rule row (the composer's frame lines) — dropped from status. */
+const STATUS_RULE = /^[─━═╌╍-]{3,}\s*$/
+
+/**
+ * One shell PTY per tab. The tab owns the parent shell; an engine CLI is a
+ * CHILD process inside it. The translated chat UI engages WHENEVER the
+ * engine's input region is detected on screen — regardless of tab kind
+ * (vendor auto-types the engine command; shell starts bare) — and falls back
+ * to the RAW visible terminal when it isn't (bare shell prompt, engine
+ * exited, native full-screen dialog). Launching `claude` by hand in a Shell
+ * tab gets the full translated UI; an engine exiting drops you back to a
+ * usable shell. Clicking anywhere focuses the PTY so keystrokes drive it
+ * directly (slash menus, @-complete, arrow selection).
+ */
+export function SessionView({
+  tabId,
+  taskId,
+  sessionId,
+  mode,
+  vendor,
+  grammar,
+  onEngineLive,
+}: {
+  tabId: string
+  taskId: string
+  sessionId: string | null
+  /** Vendor tabs → 'engine' (auto-types the engine command); terminal tabs → 'shell'. */
+  mode: "engine" | "shell"
+  /** Per-tab engine vendor override (VendorTab.vendor → ChatTerminal). */
+  vendor?: string
+  /** The vendor's screen grammar (engine-grammar.ts) — drives the translation. */
+  grammar: EngineGrammar
+  /** Grammar-derived engine liveness, lifted so the Agent Trace can clear
+   *  when this tab drops to a bare shell / boot screen. */
+  onEngineLive?: (live: boolean) => void
+}) {
+  const [colored, setColored] = useState<ColoredLine[]>([])
+  const [focusNonce, setFocusNonce] = useState(0)
+  // Frame stabilizer: reuse previous line OBJECTS for unchanged rows so
+  // memoized children skip re-render — a keystroke only re-renders the input
+  // row's dependents, not the whole transcript.
+  const prevLinesRef = useRef<ColoredLine[]>([])
+  const onColoredBuffer = useCallback((next: ColoredLine[]) => {
+    const prev = prevLinesRef.current
+    let allSame = next.length === prev.length
+    const stable = next.map((line, i) => {
+      const p = prev[i]
+      if (p && sameColoredLine(p, line)) return p
+      allSame = false
+      return line
+    })
+    prevLinesRef.current = allSame ? prev : stable
+    setColored(prevLinesRef.current)
+  }, [])
+  // IME composing string (pinyin buffer) from the hidden textarea — the PTY
+  // only sees committed text, so the composer must mirror this itself.
+  const [composing, setComposing] = useState<string | null>(null)
+  // Real terminal cursor (viewport row + cell col) — the mirror's caret
+  // follows it instead of pinning to the end of the prompt text.
+  const [cursor, setCursor] = useState<{ row: number; col: number } | null>(
+    null,
+  )
+
+  // Split each frame at the engine's input region: everything above it is the
+  // conversation body, the region itself is the current input line + status.
+  const textLines = useMemo(() => colored.map((l) => l.text), [colored])
+  const region = useMemo(
+    () => grammar.findInputRegion(textLines),
+    [grammar, textLines],
+  )
+  // Last exit banner — reverse loop (no findLastIndex typing on ColoredLine[]).
+  const lastExitIdx = useMemo(() => {
+    const banner = grammar.exitBanner
+    if (!banner) return -1
+    for (let i = colored.length - 1; i >= 0; i--) {
+      const line = colored[i]
+      if (line && banner.test(line.text.trim())) return i
+    }
+    return -1
+  }, [grammar, colored])
+  // Resume banner below the input box → box is stale; banner above → relaunched, live.
+  const engineLive =
+    region !== null && !(lastExitIdx >= 0 && lastExitIdx >= region.topRow)
+  if (import.meta.env.DEV) {
+    // Live-translation probe for agent-driven debugging (dev builds only).
+    ;(window as unknown as Record<string, unknown>).__kobeTty = {
+      lines: textLines,
+      region,
+      lastExitIdx,
+      engineLive,
+      tabId,
+      vendorProp: vendor,
+    }
+  }
+  // Engine child exited (ctrl+c → shell) → restore the minted tab title; a
+  // bare shell may never emit an OSC title to overwrite the engine's.
+  const wasLiveRef = useRef(false)
+  useEffect(() => {
+    onEngineLive?.(engineLive)
+    if (wasLiveRef.current && !engineLive) resetTabTitle(taskId, tabId)
+    wasLiveRef.current = engineLive
+  }, [engineLive, taskId, tabId, onEngineLive])
+  const bodyLines = useMemo(
+    () => (region ? colored.slice(0, region.topRow) : colored),
+    [region, colored],
+  )
+  // Lift the right-aligned `● high · /effort` chip out of the scroll body
+  // so it can pin above the composer (matching the CLI's placement).
+  const { chatBodyLines, effortLine } = useMemo(() => {
+    const pattern = grammar.effortLine
+    if (!pattern) return { chatBodyLines: bodyLines, effortLine: null }
+    for (let i = bodyLines.length - 1; i >= 0; i--) {
+      const line = bodyLines[i]
+      if (line && pattern.test(line.text.trim())) {
+        return {
+          chatBodyLines: [...bodyLines.slice(0, i), ...bodyLines.slice(i + 1)],
+          effortLine: line as ColoredLine | null,
+        }
+      }
+    }
+    return { chatBodyLines: bodyLines, effortLine: null }
+  }, [grammar, bodyLines])
+  // The CLI drops its ultracode mode banner (a `✦ ultracode · …` status row
+  // + a `──── ultracode` labeled rule) wherever the conversation happened to
+  // be — strand it there and it drifts mid-scrollback. Lift every marker row
+  // out and pin ONE re-dressed strip above the composer; its presence is
+  // also the LIVE signal that lights the welcome card.
+  const { chatLines, ultraMarker } = useMemo(() => {
+    const marker =
+      /^(?:[✦✧✳+*·]\s*)?ultracode(?:\s*·.*)?$|^─{4,}[─\s]*ultracode\s*─{0,6}$/
+    let found = false
+    const kept = chatBodyLines.filter((l) => {
+      if (!marker.test(l.text.trim())) return true
+      found = true
+      return false
+    })
+    return found
+      ? { chatLines: kept, ultraMarker: true }
+      : { chatLines: chatBodyLines, ultraMarker: false }
+  }, [chatBodyLines])
+  // The mode label is composer chrome (region.modeLabel); stray scrollback
+  // markers count too so the ambience never flickers off mid-conversation.
+  const ultraActive =
+    region?.modeLabel?.toLowerCase() === "ultracode" || ultraMarker
+  // Caret CHAR offset from the cursor's CELL column (>0xFF ≈ 2 cells —
+  // CJK-good; wcwidth if emoji matters). The region's promptText is trimmed
+  // (terminal rows are padded to full width), so TRAILING spaces the user
+  // just typed vanish — when the cursor sits past the trimmed end, restore
+  // them so the caret keeps moving through space runs.
+  const { promptText, caretOffset } = useMemo(() => {
+    const trimmed = region?.promptText ?? ""
+    if (!region || !cursor || cursor.row !== region.promptRow || !trimmed)
+      return { promptText: trimmed, caretOffset: null }
+    const raw = colored[region.promptRow]?.text ?? ""
+    const start = raw.indexOf(trimmed)
+    if (start < 0) return { promptText: trimmed, caretOffset: null }
+    const targetCells = cursor.col - start
+    if (targetCells < 0) return { promptText: trimmed, caretOffset: null }
+    let cells = 0
+    let idx = 0
+    for (const ch of trimmed) {
+      if (cells >= targetCells) break
+      cells += (ch.codePointAt(0) ?? 0) > 0xff ? 2 : 1
+      idx += ch.length
+    }
+    if (targetCells > cells) {
+      const pad = targetCells - cells
+      return {
+        promptText: trimmed + " ".repeat(pad),
+        caretOffset: trimmed.length + pad,
+      }
+    }
+    return { promptText: trimmed, caretOffset: Math.min(idx, trimmed.length) }
+  }, [region, cursor, colored])
+  // Status footer (branch | ctx | quota | mode) as COLORED lines, straight
+  // from the buffer below the prompt — so it keeps the engine's ANSI colors
+  // instead of flattening to grey. Rule/blank rows dropped.
+  // Below-composer tail: true status rows stay in the footer; slash-menu rows
+  // (Codex draws its menu BELOW the composer) lift into the floated menu.
+  const { statusColored, belowMenu } = useMemo(() => {
+    if (!region) return { statusColored: [], belowMenu: [] as TtyBlock[] }
+    const below = colored.slice(region.promptRow + 1)
+    const menuRows = below.filter((l) => isMenuRow(l.text))
+    const menu =
+      menuRows.length >= 2
+        ? grammar.parseBlocks(menuRows).filter((b) => b.kind === "menu")
+        : []
+    const status = below.filter((l) => {
+      const t = l.text.trim()
+      return t !== "" && !STATUS_RULE.test(t) && !isMenuRow(l.text)
+    })
+    return { statusColored: status, belowMenu: menu }
+  }, [region, colored, grammar])
+  // The live footer (spinner/tip/slash-menu below the last gap) is lifted out
+  // of the scroll body and floated just above the input row — where the native
+  // TUI shows it — instead of leaving it adrift in the history.
+  const { body: rawBody, footer: rawFooter } = useTtyBlocks(chatLines, grammar)
+  // Claude's `※ recap` docks above the composer instead of drifting in the
+  // flow — strip every occurrence, pin the newest.
+  const { body, bodyFooter, recap } = useMemo((): {
+    body: readonly TtyBlock[]
+    bodyFooter: readonly TtyBlock[]
+    recap: { kind: "recap"; text: string } | null
+  } => {
+    let last: { kind: "recap"; text: string } | null = null
+    const strip = (arr: readonly TtyBlock[]): readonly TtyBlock[] => {
+      if (!arr.some((b) => b.kind === "recap")) return arr
+      return arr.filter((b) => {
+        if (b.kind === "recap") {
+          last = b
+          return false
+        }
+        return true
+      })
+    }
+    const nextBody = strip(rawBody)
+    const nextFooter = strip(rawFooter)
+    return { body: nextBody, bodyFooter: nextFooter, recap: last }
+  }, [rawBody, rawFooter])
+  const footer = useMemo(
+    () => (belowMenu.length > 0 ? [...bodyFooter, ...belowMenu] : bodyFooter),
+    [bodyFooter, belowMenu],
+  )
+  // A bordered card is only warranted when the engine is WAITING on the user
+  // (spinner / slash-menu / question). Passive notices (clipboard hint) get a
+  // quiet unboxed line instead.
+  const footerInteractive = footer.some(
+    (b) => b.kind === "menu" || b.kind === "options" || b.kind === "activity",
+  )
+  // a. engineLive → translated stack; b. empty buffer → BootLine placeholder;
+  // c. otherwise → raw terminal takeover (no overlay, no composer mirror).
+  const showTranslated = engineLive || colored.length === 0
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: a click anywhere focuses the PTY so typing drives the native CLI / shell
+    // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard input already routes to the PTY; the click is only a focus assist
+    <div
+      className="relative h-full"
+      onClick={() => {
+        // Click focuses the PTY — but a drag-select stays a selection: don't
+        // steal focus (and collapse the range) when text was just selected.
+        if (window.getSelection()?.toString()) return
+        setFocusNonce((n) => n + 1)
+      }}
+    >
+      {/* Real PTY — data source + input target. opacity-0 while translated so
+          its input stays focusable under the overlay; drops opacity when raw
+          (bare shell / dialog / engine exited). SAME px-4 as the translated
+          column so the native lays out at the width we render. */}
+      <div
+        className={
+          showTranslated
+            ? "absolute inset-0 px-4 opacity-0"
+            : "absolute inset-0 px-4"
+        }
+      >
+        <Suspense fallback={null}>
+          <ChatTerminal
+            key={tabId}
+            tabId={tabId}
+            taskId={taskId}
+            mode={mode}
+            hideComposer
+            focusNonce={focusNonce}
+            vendor={vendor}
+            onColoredBuffer={onColoredBuffer}
+            // Strip the engine's own status glyph (✳/✱) — the row draws its own.
+            onTitle={(t) =>
+              setTabTitle(
+                taskId,
+                tabId,
+                t.replace(/^[✳✱⏺●○]\s*/, "").slice(0, 60),
+              )
+            }
+            onComposition={setComposing}
+            onCursor={setCursor}
+          />
+        </Suspense>
+      </div>
+      {showTranslated && (
+        <div
+          className="relative z-10 flex h-full flex-col bg-bg"
+          data-effort={ultraActive ? "ultracode" : undefined}
+        >
+          <div className="min-h-0 flex-1">
+            <TtyBlocksView blocks={body} sessionId={sessionId} />
+          </div>
+          {/* One composer zone: every row runs edge-to-edge with the input
+              card, so the gaps (not indents) do the grouping. */}
+          <div className="shrink-0 space-y-1.5 px-4 pb-3 pt-1">
+            {footer.length > 0 &&
+              (footerInteractive ? (
+                // A card only when the engine is WAITING on the user (spinner
+                // / slash-menu / question). Passive notices don't earn one.
+                <div className="rounded-2xl border border-line bg-surface/50 px-4 py-2.5">
+                  <TtyFooter blocks={footer} sessionId={sessionId} />
+                </div>
+              ) : (
+                // Passive hints (Image in clipboard…) — quiet line above input.
+                <div className="text-[11px]">
+                  <TtyFooter blocks={footer} sessionId={sessionId} />
+                </div>
+              ))}
+            {effortLine && (
+              <div className="fade-up flex justify-end">
+                <StatusLine line={trimLeadingColored(effortLine)} />
+              </div>
+            )}
+            {recap && (
+              <div className="fade-up text-[12px] leading-relaxed text-muted">
+                <span className="mr-1.5 select-none text-subtle">※</span>
+                {recap.text}
+              </div>
+            )}
+            {/* Mirrors the native placement: the mode label rides the
+                composer's top edge, right-aligned. */}
+            {ultraActive && (
+              <div
+                className="fade-up flex items-center gap-2.5 px-1"
+                title="ultracode — xhigh effort + dynamic workflow orchestration"
+              >
+                <span
+                  aria-hidden="true"
+                  className="ultra-rule h-px min-w-0 flex-1"
+                />
+                <span className="ultra-rule__label font-mono text-[11px]">
+                  ultracode
+                </span>
+              </div>
+            )}
+            {/* No composer until the engine draws one — during boot (empty
+                buffer / harness setup) the mirror has nothing to mirror. */}
+            {engineLive && (
+              <InputMirror
+                promptText={promptText}
+                composing={composing}
+                caretOffset={caretOffset}
+                sessionId={sessionId}
+              />
+            )}
+            {statusColored.length > 0 && (
+              // Dim the whole group instead of the segs — the rows keep the
+              // engine's ANSI colors, just quieter.
+              <div className="opacity-75">
+                {statusColored.map((line, i) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: positional status rows re-derived per frame
+                  <StatusLine key={i} line={line} />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/kobe-web/src/components/TimelineHost.tsx
+++ b/packages/kobe-web/src/components/TimelineHost.tsx
@@ -18,7 +18,7 @@ export function TimelineHost({
   taskId: string
   vendor: string
   engineState: EngineState | undefined
-  /** Durable daemon-owned tab -> native engine session identity. */
+  /** Durable daemon-owned current EngineRun for this tab. */
   binding?: EngineSessionBinding
   /** Exact-id fallback for an older daemon without the binding contract. */
   legacySessionId?: string
@@ -46,6 +46,7 @@ export function TimelineHost({
         engineLabel={label}
         active={engineActive}
         bindingState={data.bindingState}
+        runId={binding?.runId}
         width={width}
         onExpand={() => setExpanded(true)}
       />
@@ -53,6 +54,7 @@ export function TimelineHost({
         <TimelineSwimlane
           model={data.model}
           engineLabel={label}
+          runId={binding?.runId}
           onClose={() => setExpanded(false)}
         />
       )}

--- a/packages/kobe-web/src/components/TimelineHost.tsx
+++ b/packages/kobe-web/src/components/TimelineHost.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { useEngines } from "../lib/engines.ts"
-import type { EngineState } from "../lib/types.ts"
+import type { EngineSessionBinding, EngineState } from "../lib/types.ts"
 import { useTimelineData } from "../lib/use-timeline-data.ts"
 import { engineLabel } from "../lib/vendor.ts"
 import { TimelinePanel } from "./TimelinePanel.tsx"
@@ -8,25 +8,22 @@ import { TimelineSwimlane } from "./TimelineSwimlane.tsx"
 
 export function TimelineHost({
   taskId,
-  worktreePath,
   vendor,
   engineState,
-  tabSessionId,
+  binding,
+  legacySessionId,
   engineActive = true,
-  bound = true,
   width,
 }: {
   taskId: string
-  worktreePath: string | null
   vendor: string
   engineState: EngineState | undefined
-  /** Active tab's hook-reported session — see useTimelineData. */
-  tabSessionId?: string
-  /** Engine liveness of the active tab (grammar-derived) — off clears the panel. */
+  /** Durable daemon-owned tab -> native engine session identity. */
+  binding?: EngineSessionBinding
+  /** Exact-id fallback for an older daemon without the binding contract. */
+  legacySessionId?: string
+  /** Engine liveness of the active tab; off keeps bound history visible. */
   engineActive?: boolean
-  /** The tab's screen shows a conversation — without it (fresh boot) the
-   *  trace must not bind to the previous session's transcript. */
-  bound?: boolean
   /** Drag-resized panel width (PaneResizer). */
   width?: number
 }) {
@@ -34,11 +31,11 @@ export function TimelineHost({
   const label = engineLabel(engines, vendor)
   const data = useTimelineData({
     taskId,
-    worktreePath,
     vendor,
-    engineState,
-    tabSessionId,
-    bound,
+    // Liveness may decorate the bound session but never chooses its identity.
+    engineState: engineActive ? engineState : undefined,
+    binding,
+    legacySessionId,
   })
   const [expanded, setExpanded] = useState(false)
 
@@ -48,6 +45,7 @@ export function TimelineHost({
         {...data}
         engineLabel={label}
         active={engineActive}
+        bindingState={data.bindingState}
         width={width}
         onExpand={() => setExpanded(true)}
       />

--- a/packages/kobe-web/src/components/TimelineHost.tsx
+++ b/packages/kobe-web/src/components/TimelineHost.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react"
 import { useEngines } from "../lib/engines.ts"
-import type { EngineSessionBinding, EngineState } from "../lib/types.ts"
+import type {
+  EngineSessionBinding,
+  EngineSessionTransition,
+  EngineState,
+} from "../lib/types.ts"
 import { useTimelineData } from "../lib/use-timeline-data.ts"
 import { engineLabel } from "../lib/vendor.ts"
 import { TimelinePanel } from "./TimelinePanel.tsx"
@@ -11,6 +15,7 @@ export function TimelineHost({
   vendor,
   engineState,
   binding,
+  transition,
   legacySessionId,
   engineActive = true,
   width,
@@ -20,6 +25,8 @@ export function TimelineHost({
   engineState: EngineState | undefined
   /** Durable daemon-owned current EngineRun for this tab. */
   binding?: EngineSessionBinding
+  /** Non-durable phase between native resume detection and selected identity. */
+  transition?: EngineSessionTransition
   /** Exact-id fallback for an older daemon without the binding contract. */
   legacySessionId?: string
   /** Engine liveness of the active tab; off keeps bound history visible. */
@@ -35,6 +42,7 @@ export function TimelineHost({
     // Liveness may decorate the bound session but never chooses its identity.
     engineState: engineActive ? engineState : undefined,
     binding,
+    transition,
     legacySessionId,
   })
   const [expanded, setExpanded] = useState(false)

--- a/packages/kobe-web/src/components/TimelinePanel.tsx
+++ b/packages/kobe-web/src/components/TimelinePanel.tsx
@@ -38,6 +38,24 @@ function clockLabel(ms: number): string {
   })
 }
 
+/** A small causal-chain loader: identity → history → normalized events. */
+function TraceLoading({ label }: { label: string }) {
+  return (
+    <output
+      aria-live="polite"
+      data-testid="trace-loading"
+      className="flex items-center gap-3 py-3 font-mono text-[10px] text-subtle"
+    >
+      <span className="trace-loader" aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </span>
+      <span>{label}</span>
+    </output>
+  )
+}
+
 /** One turn: header (user prompt + meta) and its execution nodes, with the
  *  settled intermediate steps folded behind a count chip by default. */
 function TurnSection({
@@ -207,19 +225,13 @@ export function TimelinePanel({
             </div>
           </div>
         ) : bindingState === "pending" ? (
-          <div className="flex items-center gap-2 py-3 font-mono text-[10px] text-subtle">
-            <span className="size-1.5 animate-pulse rounded-full bg-kobe-blue" />
-            Waiting for the engine session id…
-          </div>
+          <TraceLoading label="Waiting for the engine session id…" />
         ) : bindingState === "missing" ? (
           <div className="border-l-2 border-kobe-yellow pl-3 text-[11px] leading-relaxed text-muted">
             Bound engine session is missing
           </div>
         ) : !loaded && model.turns.length === 0 ? (
-          <div className="flex items-center gap-2 py-3 font-mono text-[10px] text-subtle">
-            <span className="size-1.5 animate-pulse rounded-full bg-kobe-blue" />
-            Reading engine events…
-          </div>
+          <TraceLoading label="Reading engine events…" />
         ) : error && model.turns.length === 0 ? (
           <div className="border-l-2 border-kobe-red pl-3 text-[11px] leading-relaxed text-muted">
             Agent trace unavailable

--- a/packages/kobe-web/src/components/TimelinePanel.tsx
+++ b/packages/kobe-web/src/components/TimelinePanel.tsx
@@ -6,6 +6,7 @@ import {
   type TimelineStatus,
   type TimelineTurn,
 } from "../lib/timeline.ts"
+import type { TimelineBindingState } from "../lib/use-timeline-data.ts"
 import { ExecutionGrid, formatExecutionDuration } from "./ExecutionGrid.tsx"
 
 /** Always-visible turn nodes: the RESULT (answer) plus anything not settled
@@ -51,8 +52,7 @@ function TurnSection({
   const [expanded, setExpanded] = useState(false)
   const spotlight = turn.nodes.filter(isSpotlightNode)
   // Never fold down to nothing mid-turn: keep the latest step visible.
-  const visible =
-    spotlight.length > 0 ? spotlight : turn.nodes.slice(-1)
+  const visible = spotlight.length > 0 ? spotlight : turn.nodes.slice(-1)
   const foldedCount = turn.nodes.length - visible.length
   const items = expanded ? turn.nodes : visible
   return (
@@ -106,6 +106,7 @@ export function TimelinePanel({
   error,
   engineLabel,
   active = true,
+  bindingState,
   width,
   onExpand,
 }: {
@@ -113,9 +114,9 @@ export function TimelinePanel({
   loaded: boolean
   error: string | null
   engineLabel: string
-  /** Is an engine live in the ACTIVE tab? Off (bare shell / exited / booting)
-   *  → the trace body clears instead of showing a finished session's events. */
+  /** Is an engine live in the active tab? History remains visible when off. */
   active?: boolean
+  bindingState: TimelineBindingState
   /** Drag-resized width (PaneResizer) — falls back to the basis-80 default. */
   width?: number
   onExpand: () => void
@@ -166,7 +167,9 @@ export function TimelinePanel({
         <div className="min-w-0 flex-1">
           <div className="text-[11px] font-medium text-muted">Agent trace</div>
           <div className="truncate font-mono text-[9px] text-subtle">
-            {active ? `${engineLabel} · ${summary}` : engineLabel}
+            {model.sessionId
+              ? `${engineLabel} · ${active ? "live" : "history"} · ${summary}`
+              : `${engineLabel} · ${bindingState}`}
           </div>
         </div>
         <button
@@ -191,14 +194,23 @@ export function TimelinePanel({
         }}
         className="execution-grid min-h-0 flex-1 overflow-y-auto px-3 py-3"
       >
-        {!active ? (
+        {bindingState === "unavailable" ? (
           <div className="py-8 text-center">
             <div className="font-mono text-[11px] text-muted">
-              No live engine
+              Session binding unavailable
             </div>
             <div className="mt-1 text-[10px] text-subtle">
-              The trace follows the session running in this tab.
+              This daemon has not identified the engine session for this tab.
             </div>
+          </div>
+        ) : bindingState === "pending" ? (
+          <div className="flex items-center gap-2 py-3 font-mono text-[10px] text-subtle">
+            <span className="size-1.5 animate-pulse rounded-full bg-kobe-blue" />
+            Waiting for the engine session id…
+          </div>
+        ) : bindingState === "missing" ? (
+          <div className="border-l-2 border-kobe-yellow pl-3 text-[11px] leading-relaxed text-muted">
+            Bound engine session is missing
           </div>
         ) : !loaded && model.turns.length === 0 ? (
           <div className="flex items-center gap-2 py-3 font-mono text-[10px] text-subtle">

--- a/packages/kobe-web/src/components/TimelinePanel.tsx
+++ b/packages/kobe-web/src/components/TimelinePanel.tsx
@@ -107,6 +107,7 @@ export function TimelinePanel({
   engineLabel,
   active = true,
   bindingState,
+  runId,
   width,
   onExpand,
 }: {
@@ -117,6 +118,8 @@ export function TimelinePanel({
   /** Is an engine live in the active tab? History remains visible when off. */
   active?: boolean
   bindingState: TimelineBindingState
+  /** Kobe-owned temporal run; absent only with a v1 daemon. */
+  runId?: string
   /** Drag-resized width (PaneResizer) — falls back to the basis-80 default. */
   width?: number
   onExpand: () => void
@@ -168,7 +171,7 @@ export function TimelinePanel({
           <div className="text-[11px] font-medium text-muted">Agent trace</div>
           <div className="truncate font-mono text-[9px] text-subtle">
             {model.sessionId
-              ? `${engineLabel} · ${active ? "live" : "history"} · ${summary}`
+              ? `${engineLabel} · ${active ? "live" : "history"}${runId ? ` · run ${runId.slice(0, 8)}` : ""} · ${summary}`
               : `${engineLabel} · ${bindingState}`}
           </div>
         </div>

--- a/packages/kobe-web/src/components/TimelineSwimlane.tsx
+++ b/packages/kobe-web/src/components/TimelineSwimlane.tsx
@@ -17,10 +17,12 @@ function statusClass(status: TimelineStatus): string {
 export function TimelineSwimlane({
   model,
   engineLabel,
+  runId,
   onClose,
 }: {
   model: TimelineModel
   engineLabel: string
+  runId?: string
   onClose: () => void
 }) {
   const running = model.turns.some((turn) => turn.status === "running")
@@ -46,6 +48,7 @@ export function TimelineSwimlane({
           <div className="font-mono text-[10px] text-subtle">
             {engineLabel} · {model.turns.length}{" "}
             {model.turns.length === 1 ? "turn" : "turns"}
+            {runId ? ` · run ${runId.slice(0, 8)}` : ""}
             {model.sessionId ? ` · ${model.sessionId.slice(0, 8)}` : ""}
           </div>
         </div>

--- a/packages/kobe-web/src/lib/store.ts
+++ b/packages/kobe-web/src/lib/store.ts
@@ -16,6 +16,7 @@ import { applyThemeFromPrefs } from "./theme.ts"
 import type {
   AttentionItem,
   EngineSessionBindings,
+  EngineSessionTransitions,
   EngineState,
   RepoIssues,
   SessionDeliver,
@@ -38,6 +39,8 @@ export interface AppState {
   engineTabSessions: Record<string, Record<string, string>>
   /** Durable task+tab -> current EngineRun contract. */
   sessionBindings: EngineSessionBindings
+  /** Ephemeral task+tab native-session transitions. */
+  sessionTransitions: EngineSessionTransitions
   update: UpdateInfo | null
   /** taskId → in-flight long job (e.g. a worktree materializing). */
   jobs: Record<string, TaskJob>
@@ -67,6 +70,7 @@ const initial: AppState = {
   engineStates: {},
   engineTabSessions: {},
   sessionBindings: {},
+  sessionTransitions: {},
   update: null,
   jobs: {},
   worktreeChanges: {},
@@ -184,6 +188,7 @@ function applyTaskList(tasks: Task[]): void {
     engineStates: pruneByTask(state.engineStates, live),
     engineTabSessions: pruneByTask(state.engineTabSessions, live),
     sessionBindings: pruneByTask(state.sessionBindings, live),
+    sessionTransitions: pruneByTask(state.sessionTransitions, live),
     jobs: pruneByTask(state.jobs, live),
     issueSnapshots: pruneSnapshotAliases(state.issueSnapshots, tasks),
   })
@@ -225,6 +230,7 @@ function applyEvent(event: WebTransportEvent): void {
     case "session.bindings":
       set({
         sessionBindings: event.payload.bindings,
+        sessionTransitions: event.payload.transitions ?? {},
         engineTabSessions: sessionIdsFromBindings(event.payload.bindings),
       })
       break
@@ -286,6 +292,7 @@ export function validateSnapshot(raw: unknown): WebTransportSnapshot | null {
   for (const key of [
     "engineTabSessions",
     "sessionBindings",
+    "sessionTransitions",
     "jobs",
     "worktreeChanges",
     "issueSnapshots",
@@ -355,6 +362,7 @@ function applySnapshot(snap: WebTransportSnapshot): void {
     // traces; live engine-state events keep it fresh from here.
     engineTabSessions: snap.engineTabSessions ?? {},
     sessionBindings: snap.sessionBindings ?? {},
+    sessionTransitions: snap.sessionTransitions ?? {},
     update: snap.update,
     jobs: snap.jobs ?? {},
     worktreeChanges: snap.worktreeChanges ?? {},

--- a/packages/kobe-web/src/lib/store.ts
+++ b/packages/kobe-web/src/lib/store.ts
@@ -15,6 +15,7 @@ import { pruneMissingTasks } from "./tabs.ts"
 import { applyThemeFromPrefs } from "./theme.ts"
 import type {
   AttentionItem,
+  EngineSessionBindings,
   EngineState,
   RepoIssues,
   SessionDeliver,
@@ -35,6 +36,8 @@ export interface AppState {
    *  the task-level rollup is last-event-wins across tabs, so the Agent Trace
    *  can follow exactly the session running in the ACTIVE tab. */
   engineTabSessions: Record<string, Record<string, string>>
+  /** Durable task+tab -> engine-native session contract. */
+  sessionBindings: EngineSessionBindings
   update: UpdateInfo | null
   /** taskId → in-flight long job (e.g. a worktree materializing). */
   jobs: Record<string, TaskJob>
@@ -63,6 +66,7 @@ const initial: AppState = {
   activeTaskId: null,
   engineStates: {},
   engineTabSessions: {},
+  sessionBindings: {},
   update: null,
   jobs: {},
   worktreeChanges: {},
@@ -127,6 +131,22 @@ export function applyTabSessionEvent(
   }
 }
 
+/** Compatibility projection for old consumers that only understand ids. */
+export function sessionIdsFromBindings(
+  bindings: EngineSessionBindings,
+): Record<string, Record<string, string>> {
+  const out: Record<string, Record<string, string>> = {}
+  for (const [taskId, tabs] of Object.entries(bindings)) {
+    for (const [tabId, binding] of Object.entries(tabs)) {
+      if (!binding.sessionId) continue
+      const task = out[taskId] ?? {}
+      task[tabId] = binding.sessionId
+      out[taskId] = task
+    }
+  }
+  return out
+}
+
 /** Reduce a task.jobs event into the jobs map: a running job is tracked by
  *  taskId; any terminal phase (done/error) clears its entry. Returns a new map
  *  on a running insert and on a delete that hit; a delete that misses still
@@ -163,6 +183,7 @@ function applyTaskList(tasks: Task[]): void {
     tasks,
     engineStates: pruneByTask(state.engineStates, live),
     engineTabSessions: pruneByTask(state.engineTabSessions, live),
+    sessionBindings: pruneByTask(state.sessionBindings, live),
     jobs: pruneByTask(state.jobs, live),
     issueSnapshots: pruneSnapshotAliases(state.issueSnapshots, tasks),
   })
@@ -201,6 +222,12 @@ function applyEvent(event: WebTransportEvent): void {
       })
       break
     }
+    case "session.bindings":
+      set({
+        sessionBindings: event.payload.bindings,
+        engineTabSessions: sessionIdsFromBindings(event.payload.bindings),
+      })
+      break
     case "update":
       set({ update: event.payload.info })
       break
@@ -256,7 +283,13 @@ export function validateSnapshot(raw: unknown): WebTransportSnapshot | null {
   if (typeof raw.connected !== "boolean") return null
   // Optional maps, when present, must be objects (the store spreads/iterates
   // them); a present-but-wrong type is as fatal as a bad `tasks`.
-  for (const key of ["jobs", "worktreeChanges", "issueSnapshots"] as const) {
+  for (const key of [
+    "engineTabSessions",
+    "sessionBindings",
+    "jobs",
+    "worktreeChanges",
+    "issueSnapshots",
+  ] as const) {
     if (raw[key] !== undefined && !isRecord(raw[key])) return null
   }
   if (
@@ -321,6 +354,7 @@ function applySnapshot(snap: WebTransportSnapshot): void {
     // Daemon-seeded (registry tabSessions) so a reload keeps tab-precise
     // traces; live engine-state events keep it fresh from here.
     engineTabSessions: snap.engineTabSessions ?? {},
+    sessionBindings: snap.sessionBindings ?? {},
     update: snap.update,
     jobs: snap.jobs ?? {},
     worktreeChanges: snap.worktreeChanges ?? {},

--- a/packages/kobe-web/src/lib/store.ts
+++ b/packages/kobe-web/src/lib/store.ts
@@ -36,7 +36,7 @@ export interface AppState {
    *  the task-level rollup is last-event-wins across tabs, so the Agent Trace
    *  can follow exactly the session running in the ACTIVE tab. */
   engineTabSessions: Record<string, Record<string, string>>
-  /** Durable task+tab -> engine-native session contract. */
+  /** Durable task+tab -> current EngineRun contract. */
   sessionBindings: EngineSessionBindings
   update: UpdateInfo | null
   /** taskId → in-flight long job (e.g. a worktree materializing). */

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -100,6 +100,25 @@ export interface EngineState {
   transcriptPath?: string
 }
 
+/** Durable task+tab identity for one engine-native session. */
+export interface EngineSessionBinding {
+  taskId: string
+  tabId: string
+  vendor: string
+  sessionId: string | null
+  state: "pending" | "bound" | "ended" | "missing"
+  source: "spawn" | "hook" | "history-recovery"
+  transcriptPath?: string
+  startedAt: number
+  boundAt?: number
+  updatedAt: number
+}
+
+export type EngineSessionBindings = Record<
+  string,
+  Record<string, EngineSessionBinding>
+>
+
 export interface UpdateInfo {
   latest?: string
   current?: string
@@ -161,6 +180,10 @@ export type WebTransportEvent =
   | { channel: "issue.snapshot"; payload: RepoIssues }
   | { channel: "active-task"; payload: { taskId: string | null } }
   | { channel: "engine-state"; payload: EngineState }
+  | {
+      channel: "session.bindings"
+      payload: { bindings: EngineSessionBindings }
+    }
   | { channel: "update"; payload: { info: UpdateInfo | null } }
   | { channel: "task.jobs"; payload: TaskJob }
   | { channel: "worktree.changes"; payload: { changes: WorktreeChangeCounts } }
@@ -175,6 +198,8 @@ export interface WebTransportSnapshot {
   engineStates: Record<string, EngineState>
   /** taskId → tabId → last known engine session id (tab-precise traces). */
   engineTabSessions?: Record<string, Record<string, string>>
+  /** New daemon contract; absent when connected to an older daemon. */
+  sessionBindings?: EngineSessionBindings
   update: UpdateInfo | null
   /** taskId -> in-flight job (running only; terminal phases are dropped). */
   jobs?: Record<string, TaskJob>

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -100,17 +100,21 @@ export interface EngineState {
   transcriptPath?: string
 }
 
-/** Durable task+tab identity for one engine-native session. */
+/** Current temporal EngineRun for one task+tab. */
 export interface EngineSessionBinding {
+  /** Kobe-owned temporal run. Optional only when connected to a v1 daemon. */
+  runId?: string
   taskId: string
   tabId: string
   vendor: string
   sessionId: string | null
-  state: "pending" | "bound" | "ended" | "missing"
+  state: "pending" | "bound" | "ended" | "superseded" | "missing"
   source: "spawn" | "hook" | "history-recovery"
+  startSource?: "startup" | "resume" | "clear" | "compact"
   transcriptPath?: string
   startedAt: number
   boundAt?: number
+  endedAt?: number
   updatedAt: number
 }
 

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -109,7 +109,7 @@ export interface EngineSessionBinding {
   vendor: string
   sessionId: string | null
   state: "pending" | "bound" | "ended" | "superseded" | "missing"
-  source: "spawn" | "hook" | "history-recovery"
+  source: "spawn" | "observer" | "hook" | "history-recovery"
   startSource?: "startup" | "resume" | "clear" | "compact"
   transcriptPath?: string
   startedAt: number

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -123,6 +123,19 @@ export type EngineSessionBindings = Record<
   Record<string, EngineSessionBinding>
 >
 
+export interface EngineSessionTransition {
+  taskId: string
+  tabId: string
+  vendor: string
+  startSource: "resume"
+  observedAt: number
+}
+
+export type EngineSessionTransitions = Record<
+  string,
+  Record<string, EngineSessionTransition>
+>
+
 export interface UpdateInfo {
   latest?: string
   current?: string
@@ -186,7 +199,10 @@ export type WebTransportEvent =
   | { channel: "engine-state"; payload: EngineState }
   | {
       channel: "session.bindings"
-      payload: { bindings: EngineSessionBindings }
+      payload: {
+        bindings: EngineSessionBindings
+        transitions?: EngineSessionTransitions
+      }
     }
   | { channel: "update"; payload: { info: UpdateInfo | null } }
   | { channel: "task.jobs"; payload: TaskJob }
@@ -204,6 +220,8 @@ export interface WebTransportSnapshot {
   engineTabSessions?: Record<string, Record<string, string>>
   /** New daemon contract; absent when connected to an older daemon. */
   sessionBindings?: EngineSessionBindings
+  /** Ephemeral resume transitions; absent when connected to an older daemon. */
+  sessionTransitions?: EngineSessionTransitions
   update: UpdateInfo | null
   /** taskId -> in-flight job (running only; terminal phases are dropped). */
   jobs?: Record<string, TaskJob>

--- a/packages/kobe-web/src/lib/use-timeline-data.ts
+++ b/packages/kobe-web/src/lib/use-timeline-data.ts
@@ -14,6 +14,16 @@ import type { EngineSessionBinding, EngineState } from "./types.ts"
 
 export type TimelineBindingState = EngineSessionBinding["state"] | "unavailable"
 
+// A local trace fetch often resolves inside one paint. Keep resume transitions
+// visible long enough to communicate that the pane changed session identity.
+const MIN_RESUME_LOADING_MS = 360
+
+function wait(ms: number): Promise<void> {
+  return ms > 0
+    ? new Promise((resolve) => window.setTimeout(resolve, ms))
+    : Promise.resolve()
+}
+
 export interface TimelineData {
   model: TimelineModel
   loaded: boolean
@@ -37,6 +47,9 @@ export function useTimelineData({
   legacySessionId?: string
 }): TimelineData {
   const targetSessionId = binding?.sessionId ?? legacySessionId ?? ""
+  const targetGeneration =
+    binding?.runId ??
+    (targetSessionId ? `legacy:${vendor}:${targetSessionId}` : "")
   const runStartedAt = binding?.startedAt ?? 0
   const bindingState: TimelineBindingState =
     binding?.state ?? (legacySessionId ? "bound" : "unavailable")
@@ -45,34 +58,58 @@ export function useTimelineData({
     turns: [],
   })
   const [loaded, setLoaded] = useState(false)
+  const [loadedGeneration, setLoadedGeneration] = useState("")
   const [error, setError] = useState<string | null>(null)
   const seqRef = useRef(0)
+  const previousGenerationRef = useRef(targetGeneration)
+
+  // Props change before effects run. Mask the previous run synchronously so a
+  // resumed session can never paint the old timeline under its new identity.
+  const generationReady =
+    !targetSessionId ||
+    (loaded &&
+      loadedGeneration === targetGeneration &&
+      trace.sessionId === targetSessionId)
 
   useEffect(() => {
     const seq = ++seqRef.current
+    const previousGeneration = previousGenerationRef.current
+    previousGenerationRef.current = targetGeneration
+    const startedAt = Date.now()
+    const minimumLoadingMs =
+      previousGeneration &&
+      previousGeneration !== targetGeneration &&
+      binding?.startSource === "resume"
+        ? MIN_RESUME_LOADING_MS
+        : 0
     setTrace({ sessionId: targetSessionId, turns: [] })
     setLoaded(false)
     setError(null)
     if (!targetSessionId) {
+      setLoadedGeneration(targetGeneration)
       setLoaded(true)
       return
     }
     void fetchTrace(vendor, targetSessionId)
-      .then((next) => {
+      .then(async (next) => {
+        await wait(minimumLoadingMs - (Date.now() - startedAt))
         if (seq !== seqRef.current) return
         // Engine history is session-scoped. Resuming away from a session and
         // later returning to it must restore its complete persisted timeline;
         // EngineRun timestamps identify the live attachment, not a history
         // retention boundary.
         setTrace(next)
+        setLoadedGeneration(targetGeneration)
         setLoaded(true)
       })
-      .catch((err) => {
+      .catch(async (err) => {
+        await wait(minimumLoadingMs - (Date.now() - startedAt))
         if (seq !== seqRef.current) return
         setError(err instanceof Error ? err.message : String(err))
+        setLoadedGeneration(targetGeneration)
         setLoaded(true)
       })
-  }, [vendor, targetSessionId])
+  }, [vendor, targetSessionId, targetGeneration, binding?.startSource])
 
   useEffect(() => {
     if (!targetSessionId) return
@@ -96,10 +133,22 @@ export function useTimelineData({
     })
   }, [taskId, targetSessionId, runStartedAt])
 
-  const model = useMemo(
-    () => withLiveState(trace, engineState?.state, engineState?.at ?? 0),
-    [trace, engineState?.state, engineState?.at],
-  )
+  const model = useMemo(() => {
+    if (!generationReady)
+      return { sessionId: targetSessionId, turns: [] } satisfies TimelineModel
+    return withLiveState(trace, engineState?.state, engineState?.at ?? 0)
+  }, [
+    generationReady,
+    targetSessionId,
+    trace,
+    engineState?.state,
+    engineState?.at,
+  ])
 
-  return { model, loaded, error, bindingState }
+  return {
+    model,
+    loaded: generationReady,
+    error: generationReady ? error : null,
+    bindingState,
+  }
 }

--- a/packages/kobe-web/src/lib/use-timeline-data.ts
+++ b/packages/kobe-web/src/lib/use-timeline-data.ts
@@ -21,6 +21,18 @@ export interface TimelineData {
   bindingState: TimelineBindingState
 }
 
+/** A native transcript is session-scoped and therefore contains turns from
+ * earlier resumes. The pane is run-scoped: keep turns whose lifetime overlaps
+ * this ChatTab attachment. SessionStart may arrive after an argv prompt has
+ * begun, so start-time containment would incorrectly hide the first turn. */
+export function traceForRun(trace: TimelineModel, startedAt: number): TimelineModel {
+  if (startedAt <= 0) return trace
+  return {
+    ...trace,
+    turns: trace.turns.filter((turn) => (turn.endedAt ?? Number.POSITIVE_INFINITY) >= startedAt),
+  }
+}
+
 export function useTimelineData({
   taskId,
   vendor,
@@ -37,6 +49,8 @@ export function useTimelineData({
   legacySessionId?: string
 }): TimelineData {
   const targetSessionId = binding?.sessionId ?? legacySessionId ?? ""
+  const runKey = binding?.runId ?? targetSessionId
+  const runStartedAt = binding?.startedAt ?? 0
   const bindingState: TimelineBindingState =
     binding?.state ?? (legacySessionId ? "bound" : "unavailable")
   const [trace, setTrace] = useState<TimelineModel>({
@@ -59,7 +73,7 @@ export function useTimelineData({
     void fetchTrace(vendor, targetSessionId)
       .then((next) => {
         if (seq !== seqRef.current) return
-        setTrace(next)
+        setTrace(traceForRun(next, runStartedAt))
         setLoaded(true)
       })
       .catch((err) => {
@@ -67,7 +81,7 @@ export function useTimelineData({
         setError(err instanceof Error ? err.message : String(err))
         setLoaded(true)
       })
-  }, [vendor, targetSessionId])
+  }, [vendor, targetSessionId, runKey, runStartedAt])
 
   useEffect(() => {
     if (!targetSessionId) return
@@ -75,20 +89,21 @@ export function useTimelineData({
       vendor,
       targetSessionId,
       (next) => {
-        setTrace(next)
+        setTrace(traceForRun(next, runStartedAt))
         setLoaded(true)
         setError(null)
       },
       (message) => setError(message),
     )
-  }, [vendor, targetSessionId])
+  }, [vendor, targetSessionId, runKey, runStartedAt])
 
   useEffect(() => {
     if (!targetSessionId) return
     return subscribeLiveTrace(taskId, targetSessionId, (event) => {
+      if (event.at < runStartedAt) return
       setTrace((current) => applyLiveTraceEvent(current, event))
     })
-  }, [taskId, targetSessionId])
+  }, [taskId, targetSessionId, runKey, runStartedAt])
 
   const model = useMemo(
     () => withLiveState(trace, engineState?.state, engineState?.at ?? 0),

--- a/packages/kobe-web/src/lib/use-timeline-data.ts
+++ b/packages/kobe-web/src/lib/use-timeline-data.ts
@@ -21,18 +21,6 @@ export interface TimelineData {
   bindingState: TimelineBindingState
 }
 
-/** A native transcript is session-scoped and therefore contains turns from
- * earlier resumes. The pane is run-scoped: keep turns whose lifetime overlaps
- * this ChatTab attachment. SessionStart may arrive after an argv prompt has
- * begun, so start-time containment would incorrectly hide the first turn. */
-export function traceForRun(trace: TimelineModel, startedAt: number): TimelineModel {
-  if (startedAt <= 0) return trace
-  return {
-    ...trace,
-    turns: trace.turns.filter((turn) => (turn.endedAt ?? Number.POSITIVE_INFINITY) >= startedAt),
-  }
-}
-
 export function useTimelineData({
   taskId,
   vendor,
@@ -49,7 +37,6 @@ export function useTimelineData({
   legacySessionId?: string
 }): TimelineData {
   const targetSessionId = binding?.sessionId ?? legacySessionId ?? ""
-  const runKey = binding?.runId ?? targetSessionId
   const runStartedAt = binding?.startedAt ?? 0
   const bindingState: TimelineBindingState =
     binding?.state ?? (legacySessionId ? "bound" : "unavailable")
@@ -73,7 +60,11 @@ export function useTimelineData({
     void fetchTrace(vendor, targetSessionId)
       .then((next) => {
         if (seq !== seqRef.current) return
-        setTrace(traceForRun(next, runStartedAt))
+        // Engine history is session-scoped. Resuming away from a session and
+        // later returning to it must restore its complete persisted timeline;
+        // EngineRun timestamps identify the live attachment, not a history
+        // retention boundary.
+        setTrace(next)
         setLoaded(true)
       })
       .catch((err) => {
@@ -81,7 +72,7 @@ export function useTimelineData({
         setError(err instanceof Error ? err.message : String(err))
         setLoaded(true)
       })
-  }, [vendor, targetSessionId, runKey, runStartedAt])
+  }, [vendor, targetSessionId])
 
   useEffect(() => {
     if (!targetSessionId) return
@@ -89,13 +80,13 @@ export function useTimelineData({
       vendor,
       targetSessionId,
       (next) => {
-        setTrace(traceForRun(next, runStartedAt))
+        setTrace(next)
         setLoaded(true)
         setError(null)
       },
       (message) => setError(message),
     )
-  }, [vendor, targetSessionId, runKey, runStartedAt])
+  }, [vendor, targetSessionId])
 
   useEffect(() => {
     if (!targetSessionId) return
@@ -103,7 +94,7 @@ export function useTimelineData({
       if (event.at < runStartedAt) return
       setTrace((current) => applyLiveTraceEvent(current, event))
     })
-  }, [taskId, targetSessionId, runKey, runStartedAt])
+  }, [taskId, targetSessionId, runStartedAt])
 
   const model = useMemo(
     () => withLiveState(trace, engineState?.state, engineState?.at ?? 0),

--- a/packages/kobe-web/src/lib/use-timeline-data.ts
+++ b/packages/kobe-web/src/lib/use-timeline-data.ts
@@ -10,7 +10,11 @@ import {
   subscribeLiveTrace,
   subscribeTrace,
 } from "./trace.ts"
-import type { EngineSessionBinding, EngineState } from "./types.ts"
+import type {
+  EngineSessionBinding,
+  EngineSessionTransition,
+  EngineState,
+} from "./types.ts"
 
 export type TimelineBindingState = EngineSessionBinding["state"] | "unavailable"
 
@@ -36,6 +40,7 @@ export function useTimelineData({
   vendor,
   engineState,
   binding,
+  transition,
   legacySessionId,
 }: {
   taskId: string
@@ -43,6 +48,8 @@ export function useTimelineData({
   engineState: EngineState | undefined
   /** Durable daemon-owned identity. Terminal pixels never select history. */
   binding?: EngineSessionBinding
+  /** Adapter-confirmed native resume before the selected session id exists. */
+  transition?: EngineSessionTransition
   /** Exact-id fallback from a pre-binding daemon; never a newest-file guess. */
   legacySessionId?: string
 }): TimelineData {
@@ -51,8 +58,10 @@ export function useTimelineData({
     binding?.runId ??
     (targetSessionId ? `legacy:${vendor}:${targetSessionId}` : "")
   const runStartedAt = binding?.startedAt ?? 0
-  const bindingState: TimelineBindingState =
-    binding?.state ?? (legacySessionId ? "bound" : "unavailable")
+  const transitionPending = transition?.startSource === "resume"
+  const bindingState: TimelineBindingState = transitionPending
+    ? "pending"
+    : (binding?.state ?? (legacySessionId ? "bound" : "unavailable"))
   const [trace, setTrace] = useState<TimelineModel>({
     sessionId: targetSessionId,
     turns: [],
@@ -66,10 +75,11 @@ export function useTimelineData({
   // Props change before effects run. Mask the previous run synchronously so a
   // resumed session can never paint the old timeline under its new identity.
   const generationReady =
-    !targetSessionId ||
-    (loaded &&
-      loadedGeneration === targetGeneration &&
-      trace.sessionId === targetSessionId)
+    !transitionPending &&
+    (!targetSessionId ||
+      (loaded &&
+        loadedGeneration === targetGeneration &&
+        trace.sessionId === targetSessionId))
 
   useEffect(() => {
     const seq = ++seqRef.current
@@ -135,10 +145,14 @@ export function useTimelineData({
 
   const model = useMemo(() => {
     if (!generationReady)
-      return { sessionId: targetSessionId, turns: [] } satisfies TimelineModel
+      return {
+        sessionId: transitionPending ? "" : targetSessionId,
+        turns: [],
+      } satisfies TimelineModel
     return withLiveState(trace, engineState?.state, engineState?.at ?? 0)
   }, [
     generationReady,
+    transitionPending,
     targetSessionId,
     trace,
     engineState?.state,

--- a/packages/kobe-web/src/lib/use-timeline-data.ts
+++ b/packages/kobe-web/src/lib/use-timeline-data.ts
@@ -2,8 +2,7 @@
  * daemon activity overlays an immediate live head while a trace append is
  * still becoming visible. */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { fetchSessions } from "./history.ts"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { type TimelineModel, withLiveState } from "./timeline.ts"
 import {
   applyLiveTraceEvent,
@@ -11,118 +10,70 @@ import {
   subscribeLiveTrace,
   subscribeTrace,
 } from "./trace.ts"
-import type { EngineState } from "./types.ts"
+import type { EngineSessionBinding, EngineState } from "./types.ts"
 
-const POLL_MS = 1_500
+export type TimelineBindingState = EngineSessionBinding["state"] | "unavailable"
 
 export interface TimelineData {
   model: TimelineModel
   loaded: boolean
   error: string | null
+  bindingState: TimelineBindingState
 }
 
 export function useTimelineData({
   taskId,
-  worktreePath,
   vendor,
   engineState,
-  tabSessionId,
-  bound = true,
+  binding,
+  legacySessionId,
 }: {
   taskId: string
-  worktreePath: string | null
   vendor: string
   engineState: EngineState | undefined
-  /** The ACTIVE tab's hook-reported session (store engineTabSessions) — fresh
-   *  by construction: a relaunched engine re-reports on session-start. Wins
-   *  over both the newest transcript and the task-level rollup, which is
-   *  last-event-wins across tabs and can lag a whole session behind. */
-  tabSessionId?: string
-  /** The tab's screen shows a conversation. Without a hook-known session,
-   *  the trace binds to the newest transcript ONLY when true — a fresh boot
-   *  has nothing to trace, not the previous session's history. */
-  bound?: boolean
+  /** Durable daemon-owned identity. Terminal pixels never select history. */
+  binding?: EngineSessionBinding
+  /** Exact-id fallback from a pre-binding daemon; never a newest-file guess. */
+  legacySessionId?: string
 }): TimelineData {
+  const targetSessionId = binding?.sessionId ?? legacySessionId ?? ""
+  const bindingState: TimelineBindingState =
+    binding?.state ?? (legacySessionId ? "bound" : "unavailable")
   const [trace, setTrace] = useState<TimelineModel>({
-    sessionId: engineState?.sessionId ?? "",
+    sessionId: targetSessionId,
     turns: [],
   })
   const [loaded, setLoaded] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [sessionId, setSessionId] = useState(engineState?.sessionId ?? "")
-  const mtimeRef = useRef(-1)
   const seqRef = useRef(0)
-  const preferredSessionId = tabSessionId ?? undefined
-  const taskSessionId = engineState?.sessionId
-
-  const refresh = useCallback(
-    async (force = false): Promise<void> => {
-      if (!worktreePath) return
-      const seq = ++seqRef.current
-      // Unbound and no hook-known session: nothing to trace yet.
-      if (!preferredSessionId && !bound) {
-        setSessionId("")
-        setTrace({ sessionId: "", turns: [] })
-        setError(null)
-        setLoaded(true)
-        return
-      }
-      try {
-        const sessions = await fetchSessions(worktreePath, vendor)
-        if (!force && sessions.latestMtime === mtimeRef.current) return
-        mtimeRef.current = sessions.latestMtime
-        // Active tab's hook session first; otherwise the NEWEST transcript
-        // (the task-level id is the last resort — it can lag a session behind).
-        const latest = sessions.sessions.at(-1)
-        const target = preferredSessionId ?? (bound ? (latest ?? taskSessionId) : undefined)
-        if (import.meta.env.DEV) {
-          ;(window as unknown as Record<string, unknown>).__kobeTrace = {
-            vendor,
-            worktreePath,
-            preferredSessionId,
-            taskSessionId,
-            bound,
-            latest,
-            target,
-            at: new Date().toISOString(),
-          }
-        }
-        const next = target
-          ? await fetchTrace(vendor, target)
-          : { sessionId: "", turns: [] }
-        if (seq !== seqRef.current) return
-        setSessionId(target ?? "")
-        setTrace(next)
-        setError(null)
-      } catch (err) {
-        if (seq === seqRef.current)
-          setError(err instanceof Error ? err.message : String(err))
-      } finally {
-        if (seq === seqRef.current) setLoaded(true)
-      }
-    },
-    [worktreePath, vendor, preferredSessionId, taskSessionId, bound],
-  )
 
   useEffect(() => {
-    mtimeRef.current = -1
-    seqRef.current += 1
-    setTrace({ sessionId: preferredSessionId ?? "", turns: [] })
-    setSessionId(preferredSessionId ?? "")
+    const seq = ++seqRef.current
+    setTrace({ sessionId: targetSessionId, turns: [] })
     setLoaded(false)
     setError(null)
-    void refresh(true)
-    const timer = window.setInterval(() => {
-      if (!document.hidden) void refresh()
-    }, POLL_MS)
-    return () => window.clearInterval(timer)
-  }, [refresh, preferredSessionId])
+    if (!targetSessionId) {
+      setLoaded(true)
+      return
+    }
+    void fetchTrace(vendor, targetSessionId)
+      .then((next) => {
+        if (seq !== seqRef.current) return
+        setTrace(next)
+        setLoaded(true)
+      })
+      .catch((err) => {
+        if (seq !== seqRef.current) return
+        setError(err instanceof Error ? err.message : String(err))
+        setLoaded(true)
+      })
+  }, [vendor, targetSessionId])
 
   useEffect(() => {
-    if (!sessionId) return
+    if (!targetSessionId) return
     return subscribeTrace(
       vendor,
-      sessionId,
+      targetSessionId,
       (next) => {
         setTrace(next)
         setLoaded(true)
@@ -130,19 +81,19 @@ export function useTimelineData({
       },
       (message) => setError(message),
     )
-  }, [vendor, sessionId])
+  }, [vendor, targetSessionId])
 
   useEffect(() => {
-    if (!sessionId) return
-    return subscribeLiveTrace(taskId, sessionId, (event) => {
+    if (!targetSessionId) return
+    return subscribeLiveTrace(taskId, targetSessionId, (event) => {
       setTrace((current) => applyLiveTraceEvent(current, event))
     })
-  }, [taskId, sessionId])
+  }, [taskId, targetSessionId])
 
   const model = useMemo(
     () => withLiveState(trace, engineState?.state, engineState?.at ?? 0),
     [trace, engineState?.state, engineState?.at],
   )
 
-  return { model, loaded, error }
+  return { model, loaded, error, bindingState }
 }

--- a/packages/kobe-web/src/styles.css
+++ b/packages/kobe-web/src/styles.css
@@ -335,6 +335,58 @@ html[data-kobe-desktop="true"] [data-kobe-topbar] [role="button"] {
   animation: execution-node-pulse 1.8s ease-out infinite;
 }
 
+/* Agent Trace loading speaks its own grammar: a causal chain filling from
+ * identity → history → events, rather than a generic spinner. */
+.trace-loader {
+  position: relative;
+  display: inline-flex;
+  width: 38px;
+  flex: 0 0 38px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.trace-loader::before {
+  position: absolute;
+  right: 3px;
+  left: 3px;
+  height: 1px;
+  background: color-mix(in srgb, var(--color-kobe-blue) 32%, transparent);
+  content: "";
+}
+
+.trace-loader > span {
+  z-index: 1;
+  width: 6px;
+  height: 6px;
+  border: 1px solid color-mix(in srgb, var(--color-kobe-blue) 70%, var(--color-line));
+  background: var(--color-surface);
+  animation: trace-loader-node 1.2s ease-in-out infinite;
+}
+
+.trace-loader > span:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+.trace-loader > span:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
+@keyframes trace-loader-node {
+  0%,
+  60%,
+  100% {
+    background: var(--color-surface);
+    box-shadow: none;
+    transform: scale(0.78);
+  }
+  25% {
+    background: var(--color-kobe-blue);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--color-kobe-blue) 55%, transparent);
+    transform: scale(1);
+  }
+}
+
 @keyframes execution-node-pulse {
   0% {
     opacity: 0.45;
@@ -350,6 +402,7 @@ html[data-kobe-desktop="true"] [data-kobe-topbar] [role="button"] {
 @media (prefers-reduced-motion: reduce) {
   .activity-card__pulse,
   .execution-node--running::after,
+  .trace-loader > span,
   .shimmer-text,
   .fade-up,
   .pop-in,

--- a/packages/kobe-web/test/dev-daemon.test.ts
+++ b/packages/kobe-web/test/dev-daemon.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { daemonWebPortFromStatus } from "../dev-daemon.ts"
+
+describe("dev daemon routing", () => {
+  it("uses the web port reported by the daemon reached over the selected socket", () => {
+    expect(
+      daemonWebPortFromStatus(
+        { socketPath: "/tmp/kobe-sandbox.sock", webPort: 5274 },
+        "/tmp/kobe-sandbox.sock",
+      ),
+    ).toBe("5274")
+  })
+
+  it("rejects a status response from a different daemon identity", () => {
+    expect(() =>
+      daemonWebPortFromStatus(
+        { socketPath: "/tmp/kobe-production.sock", webPort: 5174 },
+        "/tmp/kobe-sandbox.sock",
+      ),
+    ).toThrow("daemon identity mismatch")
+  })
+
+  it("surfaces a daemon whose web transport failed to bind", () => {
+    expect(() =>
+      daemonWebPortFromStatus(
+        {
+          socketPath: "/tmp/kobe-sandbox.sock",
+          webPort: null,
+          webError: "port already in use",
+        },
+        "/tmp/kobe-sandbox.sock",
+      ),
+    ).toThrow("port already in use")
+  })
+})

--- a/packages/kobe-web/test/engine-session-observer.test.ts
+++ b/packages/kobe-web/test/engine-session-observer.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest"
+import { createEngineSessionObservationClient } from "../engine-session-observer.mjs"
+
+describe("engine session observation client", () => {
+  it("retries a neutral PID-scoped observation after a terminal commit", async () => {
+    vi.useFakeTimers()
+    const fetchFn = vi.fn().mockResolvedValue(new Response("{}"))
+    const client = createEngineSessionObservationClient({
+      daemonWebPort: 5176,
+      fetchFn,
+      delaysMs: [0, 50],
+    })
+    client.observe({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 4242 })
+    await vi.runAllTimersAsync()
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    const [url, init] = fetchFn.mock.calls[0]
+    expect(url).toBe("http://127.0.0.1:5176/api/rpc")
+    expect(JSON.parse(init.body)).toEqual({
+      name: "engine.observeSession",
+      payload: { taskId: "task-1", tabId: "tab-a", rootPid: 4242, vendor: "codex" },
+    })
+    vi.useRealTimers()
+  })
+
+  it("supersedes the prior retry window for the same tab", async () => {
+    vi.useFakeTimers()
+    const fetchFn = vi.fn().mockResolvedValue(new Response("{}"))
+    const client = createEngineSessionObservationClient({ daemonWebPort: 5176, fetchFn, delaysMs: [50] })
+    client.observe({ taskId: "task-1", tabId: "tab-a", rootPid: 1 })
+    client.observe({ taskId: "task-1", tabId: "tab-a", rootPid: 2 })
+    await vi.runAllTimersAsync()
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).payload.rootPid).toBe(2)
+    vi.useRealTimers()
+  })
+})

--- a/packages/kobe-web/test/pty-session-lifecycle.test.ts
+++ b/packages/kobe-web/test/pty-session-lifecycle.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../pty-session-lifecycle.mjs"
 
 class FakePty {
+  pid = 4242
   data: ((data: string) => void) | null = null
   exit: (() => void) | null = null
   writes: string[] = []
@@ -219,6 +220,28 @@ describe("createPtySessionManager", () => {
       { cols: 1, rows: 48 },
     ])
     expect(ptys[0].writes).toEqual(["abc"])
+  })
+
+  it("reports an engine terminal commit with tab and root PID identity", async () => {
+    const onTerminalCommit = vi.fn()
+    const { manager } = setup({ onTerminalCommit })
+    const ws = new FakeSocket()
+    await manager.attachSocket({
+      ws,
+      tabId: "tab",
+      taskId: "task",
+      mode: "engine",
+      vendor: "codex",
+      cols: 80,
+      rows: 24,
+    })
+    ws.message("\r")
+    expect(onTerminalCommit).toHaveBeenCalledWith({
+      taskId: "task",
+      tabId: "tab",
+      vendor: "codex",
+      rootPid: 4242,
+    })
   })
 
   it("spawn-on-send pastes with bracketed paste, then Enter", async () => {

--- a/packages/kobe-web/test/route-fakes.ts
+++ b/packages/kobe-web/test/route-fakes.ts
@@ -5,7 +5,11 @@
  */
 
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { createDaemonWebRequestHandler, type DaemonWebLink } from "@sma1lboy/kobe-daemon/daemon/web-server"
+import {
+  createDaemonWebRequestHandler,
+  type DaemonWebLink,
+  type DaemonWebSnapshotState,
+} from "@sma1lboy/kobe-daemon/daemon/web-server"
 import { daemonRuntime } from "../../kobe/src/core/daemon-runtime.ts"
 import { vi } from "vitest"
 
@@ -23,7 +27,21 @@ export function fakeLink(opts: FakeOpts = {}): DaemonWebLink & { calls: Array<{ 
       return (opts.onRequest?.(name, payload) ?? {}) as T
     },
     snapshot() {
-      return opts.snapshot ?? { tasks: [], connected: true }
+      return (opts.snapshot ?? {
+        tasks: [],
+        activeTaskId: null,
+        engineStates: {},
+        engineTabSessions: {},
+        sessionBindings: {},
+        update: null,
+        jobs: {},
+        worktreeChanges: {},
+        issueSnapshots: {},
+        deliver: null,
+        uiPrefs: null,
+        attentionInbox: [],
+        connected: true,
+      }) as DaemonWebSnapshotState
     },
   }
 }

--- a/packages/kobe-web/test/route-fakes.ts
+++ b/packages/kobe-web/test/route-fakes.ts
@@ -33,6 +33,7 @@ export function fakeLink(opts: FakeOpts = {}): DaemonWebLink & { calls: Array<{ 
         engineStates: {},
         engineTabSessions: {},
         sessionBindings: {},
+        sessionTransitions: {},
         update: null,
         jobs: {},
         worktreeChanges: {},

--- a/packages/kobe-web/test/server-session.test.ts
+++ b/packages/kobe-web/test/server-session.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from "vitest"
 
-const ensureSessionMock = vi.hoisted(() => vi.fn(async () => true))
-const sessionExistsMock = vi.hoisted(() => vi.fn(async () => false))
+const ensureHostedEngineMock = vi.hoisted(() =>
+  vi.fn(async () => ({ alive: true })),
+)
+const hostedRpc = vi.hoisted(() => ({ request: vi.fn() }))
+const closeHostedSessionMock = vi.hoisted(() => vi.fn())
+const ensureHostedSessionHostMock = vi.hoisted(() =>
+  vi.fn(async () => ({ rpc: hostedRpc, close: closeHostedSessionMock })),
+)
 const resolveEngineLaunchInitMock = vi.hoisted(() =>
   vi.fn((_repo: string, _worktree: string, intent: { kind: string }) => ({
     initScript: `init:${intent.kind}`,
@@ -12,15 +18,12 @@ const resolveEngineLaunchInitMock = vi.hoisted(() =>
   })),
 )
 
-vi.mock("../../kobe/src/tui/panes/terminal/tmux.ts", () => ({
-  ensureSession: ensureSessionMock,
-  sessionExists: sessionExistsMock,
-  tmuxSessionName: (taskId: string) => `kobe-${taskId}`,
-}))
-
-vi.mock("../../kobe/src/tmux/client.ts", () => ({
-  killSession: vi.fn(),
-  switchClientBeforeKill: vi.fn(),
+vi.mock("../../kobe/src/engine/hosted-session.ts", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../kobe/src/engine/hosted-session.ts")
+  >()),
+  ensureHostedEngine: ensureHostedEngineMock,
+  ensureHostedSessionHost: ensureHostedSessionHostMock,
 }))
 
 vi.mock("../../kobe/src/state/repo-init.ts", () => ({
@@ -50,10 +53,11 @@ function link(): DaemonRpcClient {
 }
 
 describe("web session launch init", () => {
-  it("lets canonical tmux sessions receive the repo init first prompt", async () => {
-    ensureSessionMock.mockClear()
+  it("lets canonical hosted sessions receive the repo init first prompt", async () => {
+    ensureHostedEngineMock.mockClear()
+    ensureHostedSessionHostMock.mockClear()
+    closeHostedSessionMock.mockClear()
     resolveEngineLaunchInitMock.mockClear()
-    sessionExistsMock.mockResolvedValueOnce(false)
 
     await ensureTaskSessionAdapter(link(), "task-1")
 
@@ -62,19 +66,20 @@ describe("web session launch init", () => {
       "/worktrees/story",
       { kind: "repo-init" },
     )
-    expect(ensureSessionMock).toHaveBeenCalledWith(
+    expect(ensureHostedEngineMock).toHaveBeenCalledWith(
+      hostedRpc,
+      "/worktrees/story",
       expect.objectContaining({
-        name: "kobe-task-1",
-        cwd: "/worktrees/story",
-        launchInit: {
-          initScript: "init:repo-init",
-          firstMessage: { source: "repo-init", text: "repo prompt" },
-        },
+        key: "task-1::tab-1",
+        command: expect.arrayContaining([
+          expect.stringContaining("repo prompt"),
+        ]),
       }),
     )
+    expect(closeHostedSessionMock).toHaveBeenCalledOnce()
   })
 
-  it("keeps web PTY engine specs from duplicating the repo init prompt", async () => {
+  it("keeps the repo init prompt inside the managed web PTY spawn spec", async () => {
     resolveEngineLaunchInitMock.mockClear()
 
     const spec = await engineSpecAdapter(link(), "task-2")
@@ -82,8 +87,9 @@ describe("web session launch init", () => {
     expect(resolveEngineLaunchInitMock).toHaveBeenCalledWith(
       "/repo/kobe",
       "/worktrees/story",
-      { kind: "none" },
+      { kind: "repo-init" },
     )
-    expect(spec.command.join(" ")).toContain("init:none")
+    expect(spec.command.join(" ")).toContain("init:repo-init")
+    expect(spec.command.join(" ")).toContain("repo prompt")
   })
 })

--- a/packages/kobe-web/test/store-reducer.test.ts
+++ b/packages/kobe-web/test/store-reducer.test.ts
@@ -4,6 +4,7 @@ import {
   applyTabSessionEvent,
   isOrphanIdleEngineState,
   reconnectDelay,
+  sessionIdsFromBindings,
   validateSnapshot,
 } from "../src/lib/store.ts"
 import type { Task, TaskJob, WebTransportSnapshot } from "../src/lib/types.ts"
@@ -204,5 +205,37 @@ describe("applyTabSessionEvent", () => {
   it("same session round-trip is a no-op reference", () => {
     const prev = { t1: { "tab-a": "s-old" } }
     expect(applyTabSessionEvent(prev, ev("tab-a", "s-old"))).toBe(prev)
+  })
+})
+
+describe("sessionIdsFromBindings", () => {
+  it("projects only identified sessions for older consumers", () => {
+    expect(
+      sessionIdsFromBindings({
+        t1: {
+          pending: {
+            taskId: "t1",
+            tabId: "pending",
+            vendor: "codex",
+            sessionId: null,
+            state: "pending",
+            source: "spawn",
+            startedAt: 1,
+            updatedAt: 1,
+          },
+          bound: {
+            taskId: "t1",
+            tabId: "bound",
+            vendor: "codex",
+            sessionId: "session-1",
+            state: "bound",
+            source: "hook",
+            startedAt: 1,
+            boundAt: 2,
+            updatedAt: 2,
+          },
+        },
+      }),
+    ).toEqual({ t1: { bound: "session-1" } })
   })
 })

--- a/packages/kobe-web/test/store-reducer.test.ts
+++ b/packages/kobe-web/test/store-reducer.test.ts
@@ -111,6 +111,7 @@ describe("validateSnapshot", () => {
       ...ok,
       activeTaskId: "t1",
       jobs: {},
+      sessionTransitions: {},
       worktreeChanges: {},
       issueSnapshots: {},
       uiPrefs: { theme: "claude" },
@@ -149,6 +150,7 @@ describe("validateSnapshot", () => {
     expect(validateSnapshot({ ...ok, jobs: [] })).toBeNull()
     expect(validateSnapshot({ ...ok, worktreeChanges: 1 })).toBeNull()
     expect(validateSnapshot({ ...ok, issueSnapshots: "x" })).toBeNull()
+    expect(validateSnapshot({ ...ok, sessionTransitions: [] })).toBeNull()
     expect(validateSnapshot({ ...ok, uiPrefs: 5 })).toBeNull()
   })
 

--- a/packages/kobe-web/test/timeline-loading.test.tsx
+++ b/packages/kobe-web/test/timeline-loading.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { TimelinePanel } from "../src/components/TimelinePanel.tsx"
+
+const emptyModel = { sessionId: "", turns: [] }
+
+describe("TimelinePanel loading", () => {
+  afterEach(cleanup)
+
+  it("animates the causal chain while session identity is pending", () => {
+    render(
+      <TimelinePanel
+        model={emptyModel}
+        loaded={false}
+        error={null}
+        engineLabel="Codex"
+        bindingState="pending"
+        onExpand={() => undefined}
+      />,
+    )
+
+    expect(screen.getByRole("status").textContent).toContain("Waiting for the engine session id")
+    expect(screen.getByTestId("trace-loading").querySelectorAll(".trace-loader > span")).toHaveLength(3)
+  })
+
+  it("keeps the same loading grammar while persisted events are read", () => {
+    render(
+      <TimelinePanel
+        model={{ sessionId: "session-1", turns: [] }}
+        loaded={false}
+        error={null}
+        engineLabel="Codex"
+        bindingState="bound"
+        onExpand={() => undefined}
+      />,
+    )
+
+    expect(screen.getByRole("status").textContent).toContain("Reading engine events")
+  })
+})

--- a/packages/kobe-web/test/timeline.test.ts
+++ b/packages/kobe-web/test/timeline.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { durationMs, withLiveState } from "../src/lib/timeline.ts"
 import type { EngineTrace, TraceTurn } from "../src/lib/trace.ts"
-import { traceForRun } from "../src/lib/use-timeline-data.ts"
 
 const SESSION_ID = "codex-session"
 
@@ -76,17 +75,5 @@ describe("durationMs", () => {
     expect(durationMs(10, 25, 100)).toBe(15)
     expect(durationMs(10, null, 25)).toBe(15)
     expect(durationMs(25, 10, 100)).toBe(0)
-  })
-})
-
-describe("traceForRun", () => {
-  it("hides turns from earlier resumes of the same native session", () => {
-    const oldTurn = turn("success", 15)
-    const spanningTurn = { ...turn("success", 25), id: "turn-2" }
-    const currentTurn = { ...turn("running", null), id: "turn-3", startedAt: 30 }
-    const trace = model([oldTurn, spanningTurn, currentTurn])
-
-    expect(traceForRun(trace, 20).turns).toEqual([spanningTurn, currentTurn])
-    expect(traceForRun(trace, 0)).toBe(trace)
   })
 })

--- a/packages/kobe-web/test/timeline.test.ts
+++ b/packages/kobe-web/test/timeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { durationMs, withLiveState } from "../src/lib/timeline.ts"
 import type { EngineTrace, TraceTurn } from "../src/lib/trace.ts"
+import { traceForRun } from "../src/lib/use-timeline-data.ts"
 
 const SESSION_ID = "codex-session"
 
@@ -75,5 +76,17 @@ describe("durationMs", () => {
     expect(durationMs(10, 25, 100)).toBe(15)
     expect(durationMs(10, null, 25)).toBe(15)
     expect(durationMs(25, 10, 100)).toBe(0)
+  })
+})
+
+describe("traceForRun", () => {
+  it("hides turns from earlier resumes of the same native session", () => {
+    const oldTurn = turn("success", 15)
+    const spanningTurn = { ...turn("success", 25), id: "turn-2" }
+    const currentTurn = { ...turn("running", null), id: "turn-3", startedAt: 30 }
+    const trace = model([oldTurn, spanningTurn, currentTurn])
+
+    expect(traceForRun(trace, 20).turns).toEqual([spanningTurn, currentTurn])
+    expect(traceForRun(trace, 0)).toBe(trace)
   })
 })

--- a/packages/kobe-web/test/use-timeline-data.test.tsx
+++ b/packages/kobe-web/test/use-timeline-data.test.tsx
@@ -85,12 +85,13 @@ describe("useTimelineData", () => {
     expect(result.current.model.turns.map((item) => item.id)).toEqual(["a-old", "a-new"])
 
     act(() => rerender({ currentBinding: binding("run-b", "session-b", 40) }))
-    await waitFor(() => expect(result.current.model.sessionId).toBe("session-b"))
+    await waitFor(() => expect(result.current.model.turns.map((item) => item.id)).toEqual(["b-turn"]))
 
     // The new attachment starts after a-old ended. Run-scoped filtering used
     // to hide it here even though it remains part of session-a's history.
     act(() => rerender({ currentBinding: binding("run-a2", "session-a", 100) }))
-    await waitFor(() => expect(result.current.model.sessionId).toBe("session-a"))
-    expect(result.current.model.turns.map((item) => item.id)).toEqual(["a-old", "a-new"])
+    await waitFor(() =>
+      expect(result.current.model.turns.map((item) => item.id)).toEqual(["a-old", "a-new"]),
+    )
   })
 })

--- a/packages/kobe-web/test/use-timeline-data.test.tsx
+++ b/packages/kobe-web/test/use-timeline-data.test.tsx
@@ -3,7 +3,10 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { EngineTrace, TraceTurn } from "../src/lib/trace.ts"
-import type { EngineSessionBinding } from "../src/lib/types.ts"
+import type {
+  EngineSessionBinding,
+  EngineSessionTransition,
+} from "../src/lib/types.ts"
 
 const { fetchTrace } = vi.hoisted(() => ({
   fetchTrace: vi.fn<(vendor: string, sessionId: string) => Promise<EngineTrace>>(),
@@ -150,5 +153,46 @@ describe("useTimelineData", () => {
     })
     await waitFor(() => expect(result.current.loaded).toBe(true))
     expect(result.current.model.turns[0]?.id).toBe("b-turn")
+  })
+
+  it("starts loading on a transient resume log before the selected session id is bound", async () => {
+    const sessionA: EngineTrace = {
+      sessionId: "session-a",
+      turns: [turn("a-turn", 10, 20)],
+    }
+    fetchTrace.mockResolvedValue(sessionA)
+    const pending: EngineSessionTransition = {
+      taskId: "task-1",
+      tabId: "tab-1",
+      vendor: "codex",
+      startSource: "resume",
+      observedAt: 25,
+    }
+
+    const { result, rerender } = renderHook(
+      ({ currentTransition }) =>
+        useTimelineData({
+          taskId: "task-1",
+          vendor: "codex",
+          engineState: undefined,
+          binding: binding("run-a", "session-a", 1),
+          transition: currentTransition,
+        }),
+      {
+        initialProps: {
+          currentTransition: undefined as EngineSessionTransition | undefined,
+        },
+      },
+    )
+
+    await waitFor(() => expect(result.current.model.turns[0]?.id).toBe("a-turn"))
+    act(() => rerender({ currentTransition: pending }))
+    expect(result.current.bindingState).toBe("pending")
+    expect(result.current.loaded).toBe(false)
+    expect(result.current.model).toEqual({ sessionId: "", turns: [] })
+
+    act(() => rerender({ currentTransition: undefined }))
+    expect(result.current.loaded).toBe(true)
+    expect(result.current.model.turns[0]?.id).toBe("a-turn")
   })
 })

--- a/packages/kobe-web/test/use-timeline-data.test.tsx
+++ b/packages/kobe-web/test/use-timeline-data.test.tsx
@@ -85,6 +85,8 @@ describe("useTimelineData", () => {
     expect(result.current.model.turns.map((item) => item.id)).toEqual(["a-old", "a-new"])
 
     act(() => rerender({ currentBinding: binding("run-b", "session-b", 40) }))
+    expect(result.current.loaded).toBe(false)
+    expect(result.current.model).toEqual({ sessionId: "session-b", turns: [] })
     await waitFor(() => expect(result.current.model.turns.map((item) => item.id)).toEqual(["b-turn"]))
 
     // The new attachment starts after a-old ended. Run-scoped filtering used
@@ -93,5 +95,60 @@ describe("useTimelineData", () => {
     await waitFor(() =>
       expect(result.current.model.turns.map((item) => item.id)).toEqual(["a-old", "a-new"]),
     )
+  })
+
+  it("shows an empty loading generation while a resumed run replaces the current run", async () => {
+    const sessionA: EngineTrace = {
+      sessionId: "session-a",
+      turns: [turn("a-turn", 10, 20)],
+    }
+    let resolveResume: ((trace: EngineTrace) => void) | undefined
+    const resumedTrace = new Promise<EngineTrace>((resolve) => {
+      resolveResume = resolve
+    })
+    fetchTrace.mockImplementation(async (_vendor, sessionId) => {
+      if (sessionId === "session-a") return sessionA
+      return await resumedTrace
+    })
+
+    const { result, rerender } = renderHook(
+      ({ currentBinding, engineState }) =>
+        useTimelineData({
+          taskId: "task-1",
+          vendor: "codex",
+          engineState,
+          binding: currentBinding,
+        }),
+      {
+        initialProps: {
+          currentBinding: binding("run-a", "session-a", 1),
+          engineState: { taskId: "task-1", state: "idle", at: 0 },
+        },
+      },
+    )
+
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.model.turns[0]?.id).toBe("a-turn")
+
+    act(() =>
+      rerender({
+        currentBinding: binding("run-b", "session-b", 30),
+        engineState: { taskId: "task-1", state: "running", at: 31 },
+      }),
+    )
+
+    // The running activity overlay must not synthesize a turn over the loader,
+    // and the previous session must not survive under the new run identity.
+    expect(result.current.loaded).toBe(false)
+    expect(result.current.model).toEqual({ sessionId: "session-b", turns: [] })
+
+    await act(async () => {
+      resolveResume?.({
+        sessionId: "session-b",
+        turns: [turn("b-turn", 30, 40)],
+      })
+    })
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.model.turns[0]?.id).toBe("b-turn")
   })
 })

--- a/packages/kobe-web/test/use-timeline-data.test.tsx
+++ b/packages/kobe-web/test/use-timeline-data.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { EngineTrace, TraceTurn } from "../src/lib/trace.ts"
+import type { EngineSessionBinding } from "../src/lib/types.ts"
+
+const { fetchTrace } = vi.hoisted(() => ({
+  fetchTrace: vi.fn<(vendor: string, sessionId: string) => Promise<EngineTrace>>(),
+}))
+
+vi.mock("../src/lib/trace.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/trace.ts")>()
+  return {
+    ...actual,
+    fetchTrace,
+    subscribeTrace: vi.fn(() => () => undefined),
+    subscribeLiveTrace: vi.fn(() => () => undefined),
+  }
+})
+
+import { useTimelineData } from "../src/lib/use-timeline-data.ts"
+
+function turn(id: string, startedAt: number, endedAt: number): TraceTurn {
+  return {
+    id,
+    title: id,
+    startedAt,
+    endedAt,
+    status: "success",
+    nodes: [],
+  }
+}
+
+function binding(runId: string, sessionId: string, startedAt: number): EngineSessionBinding {
+  return {
+    runId,
+    taskId: "task-1",
+    tabId: "tab-1",
+    vendor: "codex",
+    sessionId,
+    state: "bound",
+    source: "hook",
+    startSource: "resume",
+    startedAt,
+    boundAt: startedAt,
+    updatedAt: startedAt,
+  }
+}
+
+describe("useTimelineData", () => {
+  beforeEach(() => {
+    fetchTrace.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("restores the complete session timeline after resuming away and back", async () => {
+    const sessionA: EngineTrace = {
+      sessionId: "session-a",
+      turns: [turn("a-old", 10, 20), turn("a-new", 110, 120)],
+    }
+    const sessionB: EngineTrace = {
+      sessionId: "session-b",
+      turns: [turn("b-turn", 50, 60)],
+    }
+    fetchTrace.mockImplementation(async (_vendor, sessionId) =>
+      sessionId === "session-a" ? sessionA : sessionB,
+    )
+
+    const { result, rerender } = renderHook(
+      ({ currentBinding }) =>
+        useTimelineData({
+          taskId: "task-1",
+          vendor: "codex",
+          engineState: undefined,
+          binding: currentBinding,
+        }),
+      { initialProps: { currentBinding: binding("run-a1", "session-a", 1) } },
+    )
+
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.model.turns.map((item) => item.id)).toEqual(["a-old", "a-new"])
+
+    act(() => rerender({ currentBinding: binding("run-b", "session-b", 40) }))
+    await waitFor(() => expect(result.current.model.sessionId).toBe("session-b"))
+
+    // The new attachment starts after a-old ended. Run-scoped filtering used
+    // to hide it here even though it remains part of session-a's history.
+    act(() => rerender({ currentBinding: binding("run-a2", "session-a", 100) }))
+    await waitFor(() => expect(result.current.model.sessionId).toBe("session-a"))
+    expect(result.current.model.turns.map((item) => item.id)).toEqual(["a-old", "a-new"])
+  })
+})

--- a/packages/kobe-web/test/web-state-routes.test.ts
+++ b/packages/kobe-web/test/web-state-routes.test.ts
@@ -98,7 +98,7 @@ describe("/api/quick-prompts", () => {
       engines: Array<{ id: string; isBuiltin: boolean; isDefault: boolean }>
     }
     expect(empty.activeTheme).toBe("claude")
-    expect(empty.transparentBackground).toBe(false)
+    expect(empty.transparentBackground).toBe(true)
     expect(empty.focusAccent).toBe("primary")
     expect(empty.editorKind).toBe("auto")
     expect(empty.archivedHistoryPreview).toBe(false)

--- a/packages/kobe/src/cli/hook-cmd.ts
+++ b/packages/kobe/src/cli/hook-cmd.ts
@@ -260,6 +260,7 @@ export async function runHookSubcommand(argv: readonly string[]): Promise<void> 
         ...(detail ? { detail } : {}),
         ...(session ? { sessionId: session.sessionId } : {}),
         ...(session?.transcriptPath ? { transcriptPath: session.transcriptPath } : {}),
+        ...(session?.startSource ? { sessionStartSource: session.startSource } : {}),
       })
     } finally {
       client.close()

--- a/packages/kobe/src/cli/invocation.ts
+++ b/packages/kobe/src/cli/invocation.ts
@@ -33,15 +33,27 @@ export function kobeCliInvocation(): string[] {
 
 /**
  * argv prefix for commands PERSISTED into global config (engine hook files in
- * `~/.claude` / `~/.codex`). Unlike {@link kobeCliInvocation}, a persisted
- * command outlives this process — a dev-run absolute entry path (often inside
- * a task worktree) goes stale the moment that worktree is removed, and every
- * hook fire then fails with "Module not found". So prefer the packaged `kobe`
- * on PATH even in dev; fall back to the dev invocation only when no packaged
- * bin exists.
+ * `~/.claude` / `~/.codex`). A source/dev absolute path cannot be persisted:
+ * it may point into a short-lived worktree. Instead the persisted dispatcher
+ * chooses the current source reporter only when a Kobe-launched engine exports
+ * {@link kobeHookReporterEnv}; every other process falls back to `kobe` on
+ * PATH. Packaged builds need no dispatcher.
  */
 export function kobeHookInvocation(): string[] {
   if (import.meta.url.endsWith(".js")) return ["kobe"]
-  if (Bun.which("kobe")) return ["kobe"]
-  return kobeCliInvocation()
+  return [
+    "sh",
+    "-c",
+    'if [ -n "${KOBE_DEV_CLI_ENTRY:-}" ] && [ -f "$KOBE_DEV_CLI_ENTRY" ] && [ -n "${KOBE_DEV_BUN:-}" ]; then exec "$KOBE_DEV_BUN" --conditions=browser "$KOBE_DEV_CLI_ENTRY" "$@"; fi; exec kobe "$@"',
+    "kobe-hook",
+  ]
+}
+
+/** Environment inherited by engine hook subprocesses in source/dev runs. */
+export function kobeHookReporterEnv(): Readonly<Record<string, string>> {
+  if (import.meta.url.endsWith(".js")) return {}
+  return {
+    KOBE_DEV_BUN: process.execPath,
+    KOBE_DEV_CLI_ENTRY: fileURLToPath(new URL("./index.ts", import.meta.url)),
+  }
 }

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -26,6 +26,7 @@ import {
   deliverPromptToLiveEngineAdapter,
   engineSpecAdapter,
   ensureTaskSessionAdapter,
+  observeEngineSessionActivationAdapter,
   recoverEngineSessionAdapter,
   startTaskSessionWithPromptAdapter,
   tearDownTaskSessionAdapter,
@@ -48,6 +49,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   checkLatestVersion,
   latestTranscriptMtime,
   recoverEngineSession: recoverEngineSessionAdapter,
+  observeEngineSessionActivation: observeEngineSessionActivationAdapter,
   deriveTitleFromSession,
   createEngineTurnDetector,
   async runWorktreeStatus(worktreePath, signal) {

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -26,6 +26,7 @@ import {
   deliverPromptToLiveEngineAdapter,
   engineSpecAdapter,
   ensureTaskSessionAdapter,
+  recoverEngineSessionAdapter,
   startTaskSessionWithPromptAdapter,
   tearDownTaskSessionAdapter,
   terminalSpecAdapter,
@@ -46,6 +47,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   affectsActivityState,
   checkLatestVersion,
   latestTranscriptMtime,
+  recoverEngineSession: recoverEngineSessionAdapter,
   deriveTitleFromSession,
   createEngineTurnDetector,
   async runWorktreeStatus(worktreePath, signal) {

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -11,11 +11,40 @@ import {
   listHostedSessions,
   openHostedSessionHost,
 } from "../engine/hosted-session.ts"
-import { interactiveEngineCommand, withClaudeSessionId } from "../engine/interactive-command.ts"
+import { interactiveEngineCommand, withClaudeSessionId, withManagedHookTrust } from "../engine/interactive-command.ts"
+import { engineEntry } from "../engine/registry.ts"
 import { buildEngineSessionLaunch } from "../engine/session-launch.ts"
 import { TaskDeletingError } from "../orchestrator/errors.ts"
 import type { PromptDeliveryIntent } from "../state/repo-init.ts"
 import type { VendorId } from "../types/task.ts"
+
+const SESSION_RECOVERY_DELAYS_MS = [0, 40, 120] as const
+
+/**
+ * Resolve the session behind a concrete provider `session-start` event.
+ * The daemon calls this only when an older `kobe hook` reporter omitted the
+ * payload's session fields. Vendor filesystem knowledge stays in the engine
+ * history adapter; the daemon and GUI receive only the normalized identity.
+ */
+export async function recoverEngineSessionAdapter(
+  vendor: VendorId,
+  worktreePath: string,
+): Promise<{ sessionId: string; transcriptPath?: string } | null> {
+  const history = engineEntry(vendor).history
+  for (const delayMs of SESSION_RECOVERY_DELAYS_MS) {
+    if (delayMs > 0) await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+    const session = await history.latestSessionForWorktree?.(worktreePath)
+    if (session) return session
+    if (!history.latestSessionForWorktree) {
+      const sessionId = (await history.listSessionIdsForWorktree(worktreePath)).at(-1)
+      if (sessionId) {
+        const transcriptPath = await history.transcriptPath(sessionId, worktreePath)
+        return { sessionId, ...(transcriptPath ? { transcriptPath } : {}) }
+      }
+    }
+  }
+  return null
+}
 
 async function getTask(link: DaemonRpcClient, taskId: string): Promise<SerializedTask> {
   const { task } = await link.request<{ task: SerializedTask }>("task.get", { taskId })
@@ -104,18 +133,20 @@ export async function engineSpecAdapter(
   tabId?: string,
 ) {
   const { task, worktreePath } = await ensureTaskWorktree(link, taskId)
+  const vendorId = vendor ? (vendor as VendorId) : task.vendor
   const baseArgv = vendor
     ? interactiveEngineCommand(vendor as VendorId)
     : interactiveEngineCommand(task.vendor, task.modelEffort)
+  const managedArgv = withManagedHookTrust(baseArgv, vendorId)
   // Pin the session at spawn (claude `--session-id <uuid>`): the GUI then
   // knows this tab's session DETERMINISTICALLY — no hook latency, no
   // wrong-tab ambiguity. Vendors without a caller-set id return null.
-  const { argv, sessionId } = withClaudeSessionId(baseArgv, vendor ?? task.vendor)
+  const { argv, sessionId } = withClaudeSessionId(managedArgv, vendorId)
   const launch = buildEngineSessionLaunch({
     task: {
       id: task.id,
       kind: task.kind,
-      vendor: vendor ? (vendor as VendorId) : task.vendor,
+      vendor: vendorId,
       repo: task.repo,
     },
     worktreePath,

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -47,6 +47,10 @@ export async function recoverEngineSessionAdapter(
   return null
 }
 
+export async function observeEngineSessionActivationAdapter(vendor: VendorId, rootPid: number, afterMs: number) {
+  return (await engineEntry(vendor).observeSessionActivation?.({ rootPid, afterMs })) ?? null
+}
+
 async function getTask(link: DaemonRpcClient, taskId: string): Promise<SerializedTask> {
   const { task } = await link.request<{ task: SerializedTask }>("task.get", { taskId })
   return task

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -1,6 +1,7 @@
 import type { DaemonRpcClient } from "@sma1lboy/kobe-daemon/client/rpc"
 import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { kobeHookReporterEnv } from "../cli/invocation.ts"
 import {
   deliverToHostedKey,
   ensureHostedEngine,
@@ -169,7 +170,11 @@ export async function terminalSpecAdapter(link: DaemonRpcClient, taskId: string,
     command: [resolveLoginShell({ fallback: "/bin/zsh" }), "-il"],
     // A manual `claude`/`codex` typed into this shell inherits the task+tab
     // identity, so its hooks attribute per-tab like a vendor tab's engine.
-    env: { KOBE_TASK_ID: taskId, ...(tabId ? { KOBE_TAB_ID: tabId } : {}) },
+    env: {
+      KOBE_TASK_ID: taskId,
+      ...(tabId ? { KOBE_TAB_ID: tabId } : {}),
+      ...kobeHookReporterEnv(),
+    },
   }
 }
 

--- a/packages/kobe/src/engine/claude-code-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/claude-code-local/hook-adapter.ts
@@ -25,7 +25,7 @@
 
 import { homedir } from "node:os"
 import { join } from "node:path"
-import type { EngineSessionRef } from "../hook-adapter.ts"
+import { type EngineSessionRef, sessionStartSourceFromPayload } from "../hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
 import { JsonHookAdapter, editJsonSettings } from "../json-hook-adapter.ts"
 import {
@@ -192,11 +192,13 @@ export class ClaudeHookAdapter extends JsonHookAdapter {
    *  user-typed `claude` sessions kobe never spawned. */
   override sessionFromPayload(payload: Record<string, unknown>): EngineSessionRef | undefined {
     if (typeof payload.session_id !== "string" || !payload.session_id) return undefined
+    const startSource = sessionStartSourceFromPayload(payload)
     return {
       sessionId: payload.session_id,
       ...(typeof payload.transcript_path === "string" && payload.transcript_path
         ? { transcriptPath: payload.transcript_path }
         : {}),
+      ...(startSource ? { startSource } : {}),
     }
   }
 

--- a/packages/kobe/src/engine/codex-local/history.ts
+++ b/packages/kobe/src/engine/codex-local/history.ts
@@ -137,6 +137,11 @@ export async function findRolloutFile(sessionId: string, deps: HistoryDeps = def
 /** UUID embedded at the tail of a `rollout-<ISO>-<UUID>.jsonl` filename. */
 const UUID_AT_END = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/i
 
+/** Native session id embedded in a rollout path, or null for another file. */
+export function rolloutSessionId(file: string): string | null {
+  return path.basename(file).match(UUID_AT_END)?.[1] ?? null
+}
+
 /** The `cwd` recorded on a rollout's `session_meta` line, or `""`. */
 export function rolloutCwd(raw: string): string {
   for (const line of raw.split("\n")) {

--- a/packages/kobe/src/engine/codex-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/codex-local/hook-adapter.ts
@@ -30,7 +30,7 @@
 
 import { homedir } from "node:os"
 import { join } from "node:path"
-import type { EngineSessionRef } from "../hook-adapter.ts"
+import { type EngineSessionRef, sessionStartSourceFromPayload } from "../hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
 import { JsonHookAdapter } from "../json-hook-adapter.ts"
 import type { HookEventSpec } from "../json-hooks.ts"
@@ -73,11 +73,13 @@ export class CodexHookAdapter extends JsonHookAdapter {
 
   override sessionFromPayload(payload: Record<string, unknown>): EngineSessionRef | undefined {
     if (typeof payload.session_id !== "string" || !payload.session_id) return undefined
+    const startSource = sessionStartSourceFromPayload(payload)
     return {
       sessionId: payload.session_id,
       ...(typeof payload.transcript_path === "string" && payload.transcript_path
         ? { transcriptPath: payload.transcript_path }
         : {}),
+      ...(startSource ? { startSource } : {}),
     }
   }
 

--- a/packages/kobe/src/engine/codex-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/codex-local/hook-adapter.ts
@@ -23,8 +23,9 @@
  *
  * Trust model: Codex won't RUN a non-managed command hook until the user trusts
  * it once via `/hooks` (or launches with `--dangerously-bypass-hook-trust`).
- * kobe writes the definition but never auto-bypasses trust, so codex activity
- * badges light up only after the user approves the hook — by design.
+ * Normal TUI launches preserve that prompt. The Desktop bridge adds the trust
+ * bypass only when the same launch already carries Codex's broader
+ * `--dangerously-bypass-approvals-and-sandbox` flag.
  */
 
 import { homedir } from "node:os"

--- a/packages/kobe/src/engine/codex-local/session-activation.ts
+++ b/packages/kobe/src/engine/codex-local/session-activation.ts
@@ -3,10 +3,10 @@
  *
  * Codex's SessionStart hook is deliberately deferred until the next turn, so
  * it cannot tell a host UI which conversation the native resume picker just
- * activated. Codex does, however, persist PID-scoped structured evidence at
- * selection time: either a rollout-recorder path or the selected `thread.id`
- * inside a `thread/resume` span. This adapter normalizes both shapes; callers
- * never see Codex's SQLite schema or log wording.
+ * activated. Codex does, however, persist PID-scoped structured evidence while
+ * resume is in flight: a `thread/resume` span appears first, followed by either
+ * a rollout-recorder path or the selected `thread.id`. This adapter normalizes
+ * both phases; callers never see Codex's SQLite schema or log wording.
  */
 
 import { homedir } from "node:os"
@@ -28,12 +28,19 @@ interface CodexResumeLogRow {
   readonly feedback_log_body: string | null
 }
 
-export interface EngineSessionActivation {
-  readonly sessionId: string
-  readonly transcriptPath?: string
-  readonly source: "resume"
-  readonly observedAt: number
-}
+export type EngineSessionActivation =
+  | {
+      readonly phase: "pending"
+      readonly source: "resume"
+      readonly observedAt: number
+    }
+  | {
+      readonly phase: "selected"
+      readonly sessionId: string
+      readonly transcriptPath?: string
+      readonly source: "resume"
+      readonly observedAt: number
+    }
 
 export interface CodexSessionActivationInput {
   /** Root child owned by the tab's PTY sidecar. */
@@ -65,6 +72,7 @@ export function parseCodexResumeLog(row: CodexResumeLogRow): EngineSessionActiva
     const sessionId = rolloutSessionId(quoted[1])
     if (!sessionId) return null
     return {
+      phase: "selected",
       sessionId,
       transcriptPath: quoted[1],
       source: "resume",
@@ -80,7 +88,18 @@ export function parseCodexResumeLog(row: CodexResumeLogRow): EngineSessionActiva
     return null
   }
   const sessionId = THREAD_ID.exec(body)?.[1]
-  return sessionId ? { sessionId, source: "resume", observedAt: observedAtMs(row) } : null
+  return sessionId
+    ? {
+        phase: "selected",
+        sessionId,
+        source: "resume",
+        observedAt: observedAtMs(row),
+      }
+    : {
+        phase: "pending",
+        source: "resume",
+        observedAt: observedAtMs(row),
+      }
 }
 
 async function latestResumeFromSqlite(pid: number, afterMs: number): Promise<CodexResumeLogRow | null> {
@@ -107,7 +126,6 @@ async function latestResumeFromSqlite(pid: number, afterMs: number): Promise<Cod
                 feedback_log_body LIKE 'app_server.request{%'
                 AND feedback_log_body LIKE '%otel.name="thread/resume"%'
                 AND feedback_log_body LIKE '%:resume_thread_with_history:%'
-                AND feedback_log_body LIKE '%thread.id=%'
               )
             )
             AND (ts > ?4 OR (ts = ?5 AND ts_nanos > ?6))

--- a/packages/kobe/src/engine/codex-local/session-activation.ts
+++ b/packages/kobe/src/engine/codex-local/session-activation.ts
@@ -1,0 +1,144 @@
+/**
+ * Immediate Codex `/resume` observation.
+ *
+ * Codex's SessionStart hook is deliberately deferred until the next turn, so
+ * it cannot tell a host UI which conversation the native resume picker just
+ * activated. Codex does, however, persist PID-scoped structured evidence at
+ * selection time: either a rollout-recorder path or the selected `thread.id`
+ * inside a `thread/resume` span. This adapter normalizes both shapes; callers
+ * never see Codex's SQLite schema or log wording.
+ */
+
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { foregroundEngine } from "../foreground.ts"
+import { rolloutSessionId } from "./history.ts"
+
+const RESUME_TARGET = "codex_rollout::recorder"
+const RESUME_PREFIX = "Resuming rollout from "
+const RESUME_SPAN_PREFIX = "app_server.request{"
+const RESUME_SPAN_NAME = 'otel.name="thread/resume"'
+const RESUME_WITH_HISTORY = ":resume_thread_with_history:"
+const THREAD_ID = /\bthread\.id=([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i
+
+interface CodexResumeLogRow {
+  readonly id: number
+  readonly ts: number
+  readonly ts_nanos: number
+  readonly feedback_log_body: string | null
+}
+
+export interface EngineSessionActivation {
+  readonly sessionId: string
+  readonly transcriptPath?: string
+  readonly source: "resume"
+  readonly observedAt: number
+}
+
+export interface CodexSessionActivationInput {
+  /** Root child owned by the tab's PTY sidecar. */
+  readonly rootPid: number
+  /** Ignore resume records at or before the current EngineRun update. */
+  readonly afterMs: number
+}
+
+export interface CodexSessionActivationDeps {
+  readonly findEnginePid: (rootPid: number) => Promise<{ vendor: string; pid: number } | null>
+  readonly latestResume: (pid: number, afterMs: number) => CodexResumeLogRow | null | Promise<CodexResumeLogRow | null>
+}
+
+function defaultCodexHome(): string {
+  return process.env.CODEX_HOME?.trim() || join(homedir(), ".codex")
+}
+
+function observedAtMs(row: Pick<CodexResumeLogRow, "ts" | "ts_nanos">): number {
+  return row.ts * 1000 + Math.floor(row.ts_nanos / 1_000_000)
+}
+
+export function parseCodexResumeLog(row: CodexResumeLogRow): EngineSessionActivation | null {
+  const body = row.feedback_log_body
+  if (!body) return null
+
+  if (body.startsWith(RESUME_PREFIX)) {
+    const quoted = /^Resuming rollout from "([^"]+\.jsonl)"$/.exec(body)
+    if (!quoted?.[1]) return null
+    const sessionId = rolloutSessionId(quoted[1])
+    if (!sessionId) return null
+    return {
+      sessionId,
+      transcriptPath: quoted[1],
+      source: "resume",
+      observedAt: observedAtMs(row),
+    }
+  }
+
+  // Newer Codex builds can reconstruct a selected thread through app-server
+  // state without emitting the rollout-recorder line. Restrict this fallback
+  // to the actual resume span so transcript text mentioning these tokens can
+  // never be mistaken for identity evidence.
+  if (!body.startsWith(RESUME_SPAN_PREFIX) || !body.includes(RESUME_SPAN_NAME) || !body.includes(RESUME_WITH_HISTORY)) {
+    return null
+  }
+  const sessionId = THREAD_ID.exec(body)?.[1]
+  return sessionId ? { sessionId, source: "resume", observedAt: observedAtMs(row) } : null
+}
+
+async function latestResumeFromSqlite(pid: number, afterMs: number): Promise<CodexResumeLogRow | null> {
+  const path = join(defaultCodexHome(), "logs_2.sqlite")
+  const { Database } = await import("bun:sqlite")
+  let db: InstanceType<typeof Database> | null = null
+  try {
+    db = new Database(path, { readonly: true, create: false })
+    const seconds = Math.floor(afterMs / 1000)
+    const nanos = Math.floor(afterMs % 1000) * 1_000_000
+    // A lexical range keeps SQLite on the process_uuid index. `LIKE
+    // 'pid:N:%'` scanned the user's ~666MB log DB during diagnosis.
+    const processLo = `pid:${pid}:`
+    const processHi = `pid:${pid};`
+    return db
+      .query<CodexResumeLogRow, [string, string, string, number, number, number]>(
+        `SELECT id, ts, ts_nanos, feedback_log_body
+           FROM logs
+          WHERE process_uuid >= ?1 AND process_uuid < ?2
+            AND thread_id IS NULL
+            AND (
+              (target = ?3 AND feedback_log_body LIKE 'Resuming rollout from %')
+              OR (
+                feedback_log_body LIKE 'app_server.request{%'
+                AND feedback_log_body LIKE '%otel.name="thread/resume"%'
+                AND feedback_log_body LIKE '%:resume_thread_with_history:%'
+                AND feedback_log_body LIKE '%thread.id=%'
+              )
+            )
+            AND (ts > ?4 OR (ts = ?5 AND ts_nanos > ?6))
+          ORDER BY ts DESC, ts_nanos DESC, id DESC
+          LIMIT 1`,
+      )
+      .get(processLo, processHi, RESUME_TARGET, seconds, seconds, nanos)
+  } catch {
+    // Internal telemetry is a compatibility signal, never a reason to break
+    // the engine. SessionStart remains the authoritative fallback.
+    return null
+  } finally {
+    db?.close()
+  }
+}
+
+const defaultDeps: CodexSessionActivationDeps = {
+  async findEnginePid(rootPid) {
+    const engine = await foregroundEngine(rootPid)
+    return engine ? { vendor: engine.vendor, pid: engine.pid } : null
+  },
+  latestResume: latestResumeFromSqlite,
+}
+
+export async function observeCodexSessionActivation(
+  input: CodexSessionActivationInput,
+  deps: CodexSessionActivationDeps = defaultDeps,
+): Promise<EngineSessionActivation | null> {
+  if (!Number.isInteger(input.rootPid) || input.rootPid <= 0 || !Number.isFinite(input.afterMs)) return null
+  const engine = await deps.findEnginePid(input.rootPid)
+  if (!engine || engine.vendor !== "codex") return null
+  const row = await deps.latestResume(engine.pid, Math.max(0, input.afterMs))
+  return row ? parseCodexResumeLog(row) : null
+}

--- a/packages/kobe/src/engine/hook-adapter.ts
+++ b/packages/kobe/src/engine/hook-adapter.ts
@@ -23,10 +23,24 @@ import type { VendorId } from "../types/vendor.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
 import { engineEntry } from "./registry.ts"
 
+export type EngineSessionStartSource = "startup" | "resume" | "clear" | "compact"
+
+/** Normalize the shared SessionStart vocabulary exposed by Claude Code and
+ * Codex. Unknown future values stay vendor-local until the neutral contract
+ * deliberately adopts them. */
+export function sessionStartSourceFromPayload(payload: Record<string, unknown>): EngineSessionStartSource | undefined {
+  if (payload.hook_event_name !== "SessionStart") return undefined
+  const source = payload.source
+  return source === "startup" || source === "resume" || source === "clear" || source === "compact" ? source : undefined
+}
+
 /** An engine session's own identity, as reported by its hook payload. */
 export interface EngineSessionRef {
   readonly sessionId: string
   readonly transcriptPath?: string
+  /** Present only on SessionStart. A resume starts a fresh Kobe run while
+   * compact remains inside the current run. */
+  readonly startSource?: EngineSessionStartSource
 }
 
 export interface EngineHookAdapter {

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -149,6 +149,25 @@ export function withEngineTerminalTitle(argv: readonly string[], vendor: VendorI
 }
 
 /**
+ * Let a managed Desktop Codex launch run kobe's installed observer hooks when
+ * the user has already selected Codex's unrestricted YOLO mode. Codex treats
+ * hook trust as a second approval gate, so without the companion flag a
+ * `--dangerously-bypass-approvals-and-sandbox` session can run normally while
+ * silently withholding its session id from the daemon.
+ *
+ * This helper is intentionally NOT part of {@link interactiveEngineCommand}:
+ * the TUI keeps Codex's normal `/hooks` trust flow. The Desktop bridge calls it
+ * only for the engine process it manages, and only when the broader bypass flag
+ * is already present. Safer Codex launches remain untouched.
+ */
+export function withManagedHookTrust(argv: readonly string[], vendor: VendorId | undefined): readonly string[] {
+  if ((vendor ?? "claude") !== "codex") return argv
+  if (!argv.includes("--dangerously-bypass-approvals-and-sandbox")) return argv
+  if (argv.includes("--dangerously-bypass-hook-trust")) return argv
+  return [...argv, "--dangerously-bypass-hook-trust"]
+}
+
+/**
  * Append the vendor-correct reasoning/effort flag when `effort` is set AND
  * valid for the vendor (per the registry's {@link EngineRegistryEntry.effortLevels}).
  * Codex maps it to `-c model_reasoning_effort=<level>`; other vendors have no

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -47,6 +47,7 @@ import { fetchClaudeQuotaUsage } from "./claude-code-local/quota.ts"
 import { codexCapabilities, codexIdentity } from "./codex-local/capabilities.ts"
 import * as codexHistory from "./codex-local/history.ts"
 import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
+import { type EngineSessionActivation, observeCodexSessionActivation } from "./codex-local/session-activation.ts"
 import * as copilotHistory from "./copilot-local/history.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
 import { CLAUDE_SPINNER_FRAMES } from "./spinner-frames.ts"
@@ -116,6 +117,14 @@ export interface EngineRegistryEntry {
   readonly effortLevels?: readonly string[]
   /** Transcript store reader. Empty (not claude's!) for custom engines. */
   readonly history: EngineHistoryReader
+  /**
+   * Optional engine-owned observer for native context switches that happen
+   * before the provider emits its ordinary lifecycle hook.
+   */
+  readonly observeSessionActivation?: (input: {
+    readonly rootPid: number
+    readonly afterMs: number
+  }) => Promise<EngineSessionActivation | null>
   /**
    * Read-only binary + login probe (Settings → Accounts). `deps` is the
    * injectable fs/env surface from `account-detect.ts`; omit for production.
@@ -274,6 +283,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     // deliberately excluded — CHANGELOG 0.5.17).
     effortLevels: ["none", "low", "medium", "high", "xhigh"],
     history: codexHistoryReader,
+    observeSessionActivation: observeCodexSessionActivation,
 
     detectAccount: (deps) => detectCodexAccount(deps),
     createHookAdapter: () => new CodexHookAdapter(),

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -82,6 +82,8 @@ export interface EngineHistoryReader {
    * `worktree` scopes stores that key by directory (claude's project dir).
    */
   transcriptPath(sessionId: string, worktree: string): Promise<string | null>
+  /** Session whose transcript has the newest activity for this worktree. */
+  latestSessionForWorktree?(worktree: string): Promise<{ sessionId: string; transcriptPath?: string } | null>
   /**
    * Newest transcript mtime (epoch ms) for `worktree`, or 0 when the task
    * has no transcript yet. The Ops pane's activity poll watches this to
@@ -179,6 +181,9 @@ export const EMPTY_HISTORY: EngineHistoryReader = {
   async transcriptPath() {
     return null
   },
+  async latestSessionForWorktree() {
+    return null
+  },
   // No transcript store → no activity signal (the Ops badge stays dark
   // rather than mis-watching another vendor's files).
   async latestTranscriptMtimeForWorktree() {
@@ -204,6 +209,10 @@ const claudeHistoryReader: EngineHistoryReader = {
     const files = await claudeHistory.listSessionFilesForWorktree(worktree)
     return files.find((f) => f.sessionId === sessionId)?.path ?? null
   },
+  async latestSessionForWorktree(worktree) {
+    const file = (await claudeHistory.listSessionFilesForWorktree(worktree))[0]
+    return file ? { sessionId: file.sessionId, transcriptPath: file.path } : null
+  },
   latestTranscriptMtimeForWorktree: (worktree) => claudeHistory.latestTranscriptMtimeForWorktree(worktree),
 }
 
@@ -216,6 +225,11 @@ const codexHistoryReader: EngineHistoryReader = {
   // The rollout filename embeds the UUID; the store is date-keyed, not
   // worktree-keyed, so the worktree argument is unused here.
   transcriptPath: async (sessionId) => (await codexHistory.findRolloutFile(sessionId)) ?? null,
+  async latestSessionForWorktree(worktree) {
+    const latest = await codexHistory.findLatestRolloutForWorktree(worktree)
+    const sessionId = latest ? codexHistory.rolloutSessionId(latest.path) : null
+    return latest && sessionId ? { sessionId, transcriptPath: latest.path } : null
+  },
   latestTranscriptMtimeForWorktree: (worktree) => codexHistory.latestTranscriptMtimeForWorktree(worktree),
 }
 
@@ -227,6 +241,10 @@ const copilotHistoryReader: EngineHistoryReader = {
   },
   // Copilot's store layout isn't mapped to a per-session file kobe can name.
   transcriptPath: async () => null,
+  async latestSessionForWorktree(worktree) {
+    const sessionId = (await copilotHistory.listSessionIdsForWorktree(worktree)).at(-1)
+    return sessionId ? { sessionId } : null
+  },
   latestTranscriptMtimeForWorktree: (worktree) => copilotHistory.latestTranscriptMtimeForWorktree(worktree),
 }
 

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -1,4 +1,5 @@
 import { toPosixPath } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
+import { kobeHookReporterEnv } from "../cli/invocation.ts"
 import { worktreeInitMarkerPath } from "../env.ts"
 import { quoteShellArg, quoteShellArgv } from "../lib/shell-command.ts"
 import { type PromptDeliveryIntent, resolveEngineLaunchInit } from "../state/repo-init.ts"
@@ -155,6 +156,13 @@ export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): Engin
   // event came from — a task's tabs share one worktree, so cwd can't tell
   // them apart. The keepAlive fallback shell inherits it too, so a manual
   // `claude` run in that tab after an engine exit is still attributed.
-  const identity = `export KOBE_TASK_ID=${quoteShellArg(input.task.id)} KOBE_TAB_ID=${quoteShellArg(input.tabId ?? "tab-1")}\n`
+  const hookEnv = {
+    KOBE_TASK_ID: input.task.id,
+    KOBE_TAB_ID: input.tabId ?? "tab-1",
+    ...kobeHookReporterEnv(),
+  }
+  const identity = `export ${Object.entries(hookEnv)
+    .map(([key, value]) => `${key}=${quoteShellArg(value)}`)
+    .join(" ")}\n`
   return { key: engineSessionKey(input.task.id), command: [input.shell, "-ilc", identity + script] }
 }

--- a/packages/kobe/src/tui/workspace/terminal-tab-spawn.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-spawn.ts
@@ -7,6 +7,8 @@
  * shell-quoting rule.
  */
 
+import { kobeHookReporterEnv } from "../../cli/invocation.ts"
+
 /** What a tab's PTY should spawn: an argv, plus optional bytes typed into
  *  it right after spawn (`TaskPtyOpts.initialInput`). */
 export interface TabSpawn {
@@ -54,6 +56,12 @@ export function shellSpawn(argv: readonly string[], shell: string, env?: Readonl
  * ponytail: one visible line flashes before the clear; upgrade path = an
  * `env` field on PtySpawnSpec with a skip-spare rule if cosmetics matter.
  */
-export function shellIdentityInput(taskId: string, tabId: string): string {
-  return ` export KOBE_TASK_ID=${shellCommandLine([taskId])} KOBE_TAB_ID=${shellCommandLine([tabId])} && clear\r`
+export function shellIdentityInput(
+  taskId: string,
+  tabId: string,
+  reporterEnv: Readonly<Record<string, string>> = kobeHookReporterEnv(),
+): string {
+  const env = { KOBE_TASK_ID: taskId, KOBE_TAB_ID: tabId, ...reporterEnv }
+  const exports = Object.entries(env).map(([key, value]) => `${key}=${shellCommandLine([value])}`)
+  return ` export ${exports.join(" ")} && clear\r`
 }

--- a/packages/kobe/test/architecture/active-product-copy.test.ts
+++ b/packages/kobe/test/architecture/active-product-copy.test.ts
@@ -36,7 +36,7 @@ const STALE_CLAIMS: Array<[path: string, phrases: string[]]> = [
       "需要 Bun ≥ 1.3.11、tmux",
     ],
   ],
-  ["packages/kobe-web/src/components/ToolsPanel.tsx", ["tmux session and engine"]],
+  ["packages/kobe-web/src/components/ChatShell.tsx", ["tmux session and engine"]],
   ["packages/kobe-web/README.md", ["kobe-sandbox tmux socket"]],
   [".claude/skills/release/SKILL.md", ["needs tmux", "apt-installed tmux"]],
   ["marketing/brand.meta.yaml", ["git worktrees, tmux sessions", "persistent tmux sessions"]],

--- a/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
+++ b/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
@@ -147,12 +147,21 @@ describe("runHookSubcommand — activity verbs", () => {
   // including user-typed engines. The adapter extracts it from the payload;
   // the dispatcher must forward it (and transcriptPath) on the RPC.
   it("forwards the adapter's session identity on the RPC", async () => {
-    mocks.adapter.sessionFromPayload.mockReturnValue({ sessionId: "sess-9", transcriptPath: "/tmp/sess-9.jsonl" })
+    mocks.adapter.sessionFromPayload.mockReturnValue({
+      sessionId: "sess-9",
+      transcriptPath: "/tmp/sess-9.jsonl",
+      startSource: "resume",
+    })
     stubStdin({ cwd: "/some/task/worktree", session_id: "sess-9" })
-    await runHookSubcommand(["turn-complete"])
+    await runHookSubcommand(["session-start"])
     expect(mocks.request).toHaveBeenCalledWith(
       "engine.reportEvent",
-      expect.objectContaining({ kind: "turn-complete", sessionId: "sess-9", transcriptPath: "/tmp/sess-9.jsonl" }),
+      expect.objectContaining({
+        kind: "session-start",
+        sessionId: "sess-9",
+        transcriptPath: "/tmp/sess-9.jsonl",
+        sessionStartSource: "resume",
+      }),
     )
   })
 

--- a/packages/kobe/test/cli/invocation.test.ts
+++ b/packages/kobe/test/cli/invocation.test.ts
@@ -1,0 +1,35 @@
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+import { kobeHookInvocation, kobeHookReporterEnv } from "../../src/cli/invocation.ts"
+
+describe("source hook invocation", () => {
+  it("persists a stable dispatcher and exports the current source reporter", () => {
+    const invocation = kobeHookInvocation()
+    const reporterEnv = kobeHookReporterEnv()
+
+    expect(invocation.slice(0, 2)).toEqual(["sh", "-c"])
+    expect(invocation[2]).toContain('exec "$KOBE_DEV_BUN" --conditions=browser "$KOBE_DEV_CLI_ENTRY" "$@"')
+    expect(invocation[2]).toContain('exec kobe "$@"')
+    expect(reporterEnv.KOBE_DEV_BUN).toBe(process.execPath)
+    expect(reporterEnv.KOBE_DEV_CLI_ENTRY?.endsWith("/src/cli/index.ts")).toBe(true)
+    expect(existsSync(reporterEnv.KOBE_DEV_CLI_ENTRY as string)).toBe(true)
+  })
+
+  it("dispatches hook arguments through the exported source reporter", () => {
+    const invocation = kobeHookInvocation()
+    const reporterEnv = kobeHookReporterEnv()
+    const result = spawnSync(invocation[0] as string, [...invocation.slice(1), "hook", "session-start"], {
+      env: {
+        ...process.env,
+        ...reporterEnv,
+        KOBE_DEV_BUN: "/bin/echo",
+      },
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.toString().trim()).toBe(
+      `--conditions=browser ${reporterEnv.KOBE_DEV_CLI_ENTRY} hook session-start`,
+    )
+  })
+})

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -81,11 +81,13 @@ describe("daemon session adapter", () => {
     const engine = await engineSpecAdapter(link(), "task-2")
     expect(engine.cwd).toBe("/worktrees/story")
     expect(engine.command).toEqual(["/bin/zsh", "-ilc", "claude 'repo prompt'"])
-    await expect(terminalSpecAdapter(link(), "task-2")).resolves.toEqual({
-      cwd: "/worktrees/story",
-      command: [resolveLoginShell({ fallback: "/bin/zsh" }), "-il"],
-      env: { KOBE_TASK_ID: "task-2" },
-    })
+    await expect(terminalSpecAdapter(link(), "task-2")).resolves.toEqual(
+      expect.objectContaining({
+        cwd: "/worktrees/story",
+        command: [resolveLoginShell({ fallback: "/bin/zsh" }), "-il"],
+        env: expect.objectContaining({ KOBE_TASK_ID: "task-2" }),
+      }),
+    )
   })
 
   it("tears down a task session best-effort", async () => {

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -84,6 +84,7 @@ describe("daemon session adapter", () => {
     await expect(terminalSpecAdapter(link(), "task-2")).resolves.toEqual({
       cwd: "/worktrees/story",
       command: [resolveLoginShell({ fallback: "/bin/zsh" }), "-il"],
+      env: { KOBE_TASK_ID: "task-2" },
     })
   })
 

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -45,6 +45,7 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
     stopped: 0,
     idleReevaluations: 0,
   }
+  const currentBindings: Record<string, Record<string, Record<string, unknown>>> = {}
   const ctx: DaemonHandlerContext = {
     runtime: daemonRuntime,
     orch: {
@@ -90,12 +91,17 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
       begin: async (taskId: string, tabId: string, vendor: string) => {
         const value = { taskId, tabId, vendor, state: "pending" }
         rec.bindings.push(value)
+        currentBindings[taskId] = { ...(currentBindings[taskId] ?? {}), [tabId]: value }
         return value
       },
       bind: async (value: Record<string, unknown>) => {
         rec.bindings.push(value)
+        const taskId = String(value.taskId)
+        const tabId = String(value.tabId)
+        currentBindings[taskId] = { ...(currentBindings[taskId] ?? {}), [tabId]: value }
         return value
       },
+      snapshotByTask: () => currentBindings,
       deleteTask: async () => {},
       deleteTaskBestEffort: async () => {},
     } as unknown as SessionBindingStore,

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -6,6 +6,7 @@ import type { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import type { IssuesStore } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import type { QuotaUsageCache } from "@sma1lboy/kobe-daemon/daemon/quota-usage-cache"
 import type { DaemonHandlerContext } from "@sma1lboy/kobe-daemon/daemon/server"
+import type { SessionBindingStore } from "@sma1lboy/kobe-daemon/daemon/session-bindings"
 import type { WorkItemCache } from "@sma1lboy/kobe-daemon/daemon/work-items"
 import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
 import type { Orchestrator } from "../../src/orchestrator/core.ts"
@@ -19,6 +20,7 @@ export interface RecordedHandlerEffects {
   readonly inboxDeleted: Array<{ taskId: string; tabId: string | null; at?: number }>
   readonly inboxRead: Array<{ taskId: string; tabId: string | null; at: number }>
   readonly inboxTaskDeleted: string[]
+  readonly bindings: Array<Record<string, unknown>>
   readonly deletions: string[]
   stopped: number
   idleReevaluations: number
@@ -38,19 +40,29 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
     inboxDeleted: [],
     inboxRead: [],
     inboxTaskDeleted: [],
+    bindings: [],
     deletions: [],
     stopped: 0,
     idleReevaluations: 0,
   }
   const ctx: DaemonHandlerContext = {
     runtime: daemonRuntime,
-    orch: { listTasks: () => [], ...orch } as unknown as Orchestrator,
+    orch: {
+      listTasks: () => [],
+      getTask: (taskId: string) => {
+        const listTasks = orch.listTasks
+        const tasks = typeof listTasks === "function" ? (listTasks as () => Array<{ id: string }>)() : []
+        return tasks.find((task) => task.id === taskId)
+      },
+      ...orch,
+    } as unknown as Orchestrator,
     bus: {
       publish: (channel: string, payload: unknown) => rec.published.push({ channel, payload }),
     } as unknown as DaemonEventBus,
     activity: {
       report: (taskId: string, kind: string, detail?: unknown) => rec.reported.push({ taskId, kind, detail }),
       clearTask: (taskId: string) => rec.cleared.push(taskId),
+      pinTabSession: () => {},
     } as unknown as DaemonActivityRegistry,
     inbox: {
       record: (taskId: string, kind: string, detail?: unknown, tabId?: string) => {
@@ -74,6 +86,19 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
         return Promise.resolve()
       },
     } as unknown as AttentionInboxStore,
+    bindings: {
+      begin: async (taskId: string, tabId: string, vendor: string) => {
+        const value = { taskId, tabId, vendor, state: "pending" }
+        rec.bindings.push(value)
+        return value
+      },
+      bind: async (value: Record<string, unknown>) => {
+        rec.bindings.push(value)
+        return value
+      },
+      deleteTask: async () => {},
+      deleteTaskBestEffort: async () => {},
+    } as unknown as SessionBindingStore,
     deletions: {
       enqueue: (taskId: string) => rec.deletions.push(taskId),
     },

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -21,6 +21,7 @@ export interface RecordedHandlerEffects {
   readonly inboxRead: Array<{ taskId: string; tabId: string | null; at: number }>
   readonly inboxTaskDeleted: string[]
   readonly bindings: Array<Record<string, unknown>>
+  readonly transitions: Array<Record<string, unknown>>
   readonly deletions: string[]
   stopped: number
   idleReevaluations: number
@@ -41,6 +42,7 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
     inboxRead: [],
     inboxTaskDeleted: [],
     bindings: [],
+    transitions: [],
     deletions: [],
     stopped: 0,
     idleReevaluations: 0,
@@ -101,7 +103,11 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
         currentBindings[taskId] = { ...(currentBindings[taskId] ?? {}), [tabId]: value }
         return value
       },
+      markTransition: (value: Record<string, unknown>) => {
+        rec.transitions.push(value)
+      },
       snapshotByTask: () => currentBindings,
+      transitionSnapshotByTask: () => ({}),
       deleteTask: async () => {},
       deleteTaskBestEffort: async () => {},
     } as unknown as SessionBindingStore,

--- a/packages/kobe/test/daemon/handlers-runtime.test.ts
+++ b/packages/kobe/test/daemon/handlers-runtime.test.ts
@@ -181,6 +181,76 @@ describe("daemon runtime handlers", () => {
   })
 
   describe("engine.reportEvent (payload contract pinned — the activity hooks depend on it)", () => {
+    it("registers a pending spawn before a caller-assigned session is pinned", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => ({ ...TASK, vendor: "claude" }) })
+      await dispatch("engine.beginSession", { taskId: "t1", tabId: "tab-claude" }, ctx)
+      await dispatch("engine.pinSession", { taskId: "t1", tabId: "tab-claude", sessionId: "session-assigned" }, ctx)
+      expect(rec.bindings).toEqual([
+        { taskId: "t1", tabId: "tab-claude", vendor: "claude", state: "pending" },
+        {
+          taskId: "t1",
+          tabId: "tab-claude",
+          vendor: "claude",
+          sessionId: "session-assigned",
+          source: "spawn",
+        },
+      ])
+    })
+
+    it("persists a hook-reported native session against the exact tab", async () => {
+      const { ctx, rec } = fakeCtx({
+        listTasks: () => [TASK],
+        getTask: () => ({ ...TASK, vendor: "codex" }),
+      })
+      await dispatch(
+        "engine.reportEvent",
+        {
+          taskId: "t1",
+          tabId: "tab-codex",
+          kind: "session-start",
+          engine: "codex",
+          sessionId: "session-native",
+          transcriptPath: "/tmp/rollout.jsonl",
+        },
+        ctx,
+      )
+      expect(rec.bindings).toContainEqual({
+        taskId: "t1",
+        tabId: "tab-codex",
+        vendor: "codex",
+        sessionId: "session-native",
+        source: "hook",
+        transcriptPath: "/tmp/rollout.jsonl",
+      })
+    })
+
+    it("recovers a native session only for a tab-scoped session-start from an older hook reporter", async () => {
+      const { ctx, rec } = fakeCtx({
+        listTasks: () => [TASK],
+        getTask: () => ({ ...TASK, vendor: "codex" }),
+      })
+      ;(ctx as { runtime: DaemonHandlerContext["runtime"] }).runtime = {
+        ...ctx.runtime,
+        recoverEngineSession: async () => ({
+          sessionId: "session-recovered",
+          transcriptPath: "/tmp/recovered-rollout.jsonl",
+        }),
+      }
+      await dispatch(
+        "engine.reportEvent",
+        { taskId: "t1", tabId: "tab-codex", kind: "session-start", engine: "codex" },
+        ctx,
+      )
+      expect(rec.bindings).toContainEqual({
+        taskId: "t1",
+        tabId: "tab-codex",
+        vendor: "codex",
+        sessionId: "session-recovered",
+        source: "history-recovery",
+        transcriptPath: "/tmp/recovered-rollout.jsonl",
+      })
+    })
+
     it("maps cwd → task and folds the coerced detail into the activity registry", async () => {
       const { ctx, rec } = fakeCtx({ listTasks: () => [TASK] })
       const result = await dispatch(

--- a/packages/kobe/test/daemon/handlers-runtime.test.ts
+++ b/packages/kobe/test/daemon/handlers-runtime.test.ts
@@ -210,6 +210,7 @@ describe("daemon runtime handlers", () => {
           kind: "session-start",
           engine: "codex",
           sessionId: "session-native",
+          sessionStartSource: "resume",
           transcriptPath: "/tmp/rollout.jsonl",
         },
         ctx,
@@ -220,6 +221,8 @@ describe("daemon runtime handlers", () => {
         vendor: "codex",
         sessionId: "session-native",
         source: "hook",
+        eventKind: "session-start",
+        startSource: "resume",
         transcriptPath: "/tmp/rollout.jsonl",
       })
     })
@@ -247,6 +250,7 @@ describe("daemon runtime handlers", () => {
         vendor: "codex",
         sessionId: "session-recovered",
         source: "history-recovery",
+        eventKind: "session-start",
         transcriptPath: "/tmp/recovered-rollout.jsonl",
       })
     })

--- a/packages/kobe/test/daemon/handlers-runtime.test.ts
+++ b/packages/kobe/test/daemon/handlers-runtime.test.ts
@@ -4,7 +4,7 @@ import {
   createDaemonHandlerRegistry,
   dispatchDaemonRequest,
 } from "@sma1lboy/kobe-daemon/daemon/server"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import type { Task } from "../../src/types/task.ts"
 import { fakeCtx } from "./handler-test-context.ts"
 
@@ -224,6 +224,34 @@ describe("daemon runtime handlers", () => {
         eventKind: "session-start",
         startSource: "resume",
         transcriptPath: "/tmp/rollout.jsonl",
+      })
+    })
+
+    it("binds an adapter-observed resume before SessionStart fires", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => ({ ...TASK, vendor: "codex" }) })
+      const observeEngineSessionActivation = vi.fn(async () => ({
+        sessionId: "session-observed",
+        transcriptPath: "/tmp/observed-rollout.jsonl",
+        source: "resume" as const,
+        observedAt: 1234,
+      }))
+      ;(ctx as { runtime: DaemonHandlerContext["runtime"] }).runtime = {
+        ...ctx.runtime,
+        observeEngineSessionActivation,
+      }
+      await dispatch("engine.beginSession", { taskId: "t1", tabId: "tab-codex", vendor: "codex" }, ctx)
+      await expect(
+        dispatch("engine.observeSession", { taskId: "t1", tabId: "tab-codex", vendor: "codex", rootPid: 4242 }, ctx),
+      ).resolves.toEqual({ observed: true, sessionId: "session-observed" })
+      expect(observeEngineSessionActivation).toHaveBeenCalledWith("codex", 4242, expect.any(Number))
+      expect(rec.bindings.at(-1)).toEqual({
+        taskId: "t1",
+        tabId: "tab-codex",
+        vendor: "codex",
+        sessionId: "session-observed",
+        source: "observer",
+        startSource: "resume",
+        transcriptPath: "/tmp/observed-rollout.jsonl",
       })
     })
 

--- a/packages/kobe/test/daemon/handlers-runtime.test.ts
+++ b/packages/kobe/test/daemon/handlers-runtime.test.ts
@@ -230,6 +230,7 @@ describe("daemon runtime handlers", () => {
     it("binds an adapter-observed resume before SessionStart fires", async () => {
       const { ctx, rec } = fakeCtx({ getTask: () => ({ ...TASK, vendor: "codex" }) })
       const observeEngineSessionActivation = vi.fn(async () => ({
+        phase: "selected" as const,
         sessionId: "session-observed",
         transcriptPath: "/tmp/observed-rollout.jsonl",
         source: "resume" as const,
@@ -242,7 +243,7 @@ describe("daemon runtime handlers", () => {
       await dispatch("engine.beginSession", { taskId: "t1", tabId: "tab-codex", vendor: "codex" }, ctx)
       await expect(
         dispatch("engine.observeSession", { taskId: "t1", tabId: "tab-codex", vendor: "codex", rootPid: 4242 }, ctx),
-      ).resolves.toEqual({ observed: true, sessionId: "session-observed" })
+      ).resolves.toEqual({ observed: true, pending: false, sessionId: "session-observed" })
       expect(observeEngineSessionActivation).toHaveBeenCalledWith("codex", 4242, expect.any(Number))
       expect(rec.bindings.at(-1)).toEqual({
         taskId: "t1",
@@ -253,6 +254,32 @@ describe("daemon runtime handlers", () => {
         startSource: "resume",
         transcriptPath: "/tmp/observed-rollout.jsonl",
       })
+    })
+
+    it("publishes a transient resume transition before Codex identifies the selected session", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => ({ ...TASK, vendor: "codex" }) })
+      ;(ctx as { runtime: DaemonHandlerContext["runtime"] }).runtime = {
+        ...ctx.runtime,
+        observeEngineSessionActivation: async () => ({
+          phase: "pending",
+          source: "resume",
+          observedAt: 1_234,
+        }),
+      }
+
+      await expect(
+        dispatch("engine.observeSession", { taskId: "t1", tabId: "tab-codex", vendor: "codex", rootPid: 4242 }, ctx),
+      ).resolves.toEqual({ observed: true, pending: true })
+      expect(rec.transitions).toEqual([
+        {
+          taskId: "t1",
+          tabId: "tab-codex",
+          vendor: "codex",
+          startSource: "resume",
+          observedAt: 1_234,
+        },
+      ])
+      expect(rec.bindings).toEqual([])
     })
 
     it("recovers a native session only for a tab-scoped session-start from an older hook reporter", async () => {

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -99,6 +99,7 @@ describe("daemon handler registry", () => {
       "worktree.list",
       "worktree.remove",
       "engine.reportEvent",
+      "engine.beginSession",
       "engine.pinSession",
       "attention.dismiss",
       "attention.read",

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -101,6 +101,7 @@ describe("daemon handler registry", () => {
       "engine.reportEvent",
       "engine.beginSession",
       "engine.pinSession",
+      "engine.observeSession",
       "attention.dismiss",
       "attention.read",
       "automation.list",

--- a/packages/kobe/test/daemon/harness.ts
+++ b/packages/kobe/test/daemon/harness.ts
@@ -135,6 +135,7 @@ export function emptyWebSnapshot(): DaemonWebSnapshotState {
     engineStates: {},
     engineTabSessions: {},
     sessionBindings: {},
+    sessionTransitions: {},
     update: null,
     jobs: {},
     worktreeChanges: {},

--- a/packages/kobe/test/daemon/harness.ts
+++ b/packages/kobe/test/daemon/harness.ts
@@ -133,6 +133,8 @@ export function emptyWebSnapshot(): DaemonWebSnapshotState {
     tasks: [],
     activeTaskId: null,
     engineStates: {},
+    engineTabSessions: {},
+    sessionBindings: {},
     update: null,
     jobs: {},
     worktreeChanges: {},

--- a/packages/kobe/test/daemon/session-bindings.test.ts
+++ b/packages/kobe/test/daemon/session-bindings.test.ts
@@ -221,6 +221,51 @@ describe("SessionBindingStore", () => {
     expect(lateObserver.source).toBe("hook")
   })
 
+  it("makes a previously seen session current when the observer sees it resumed again", async () => {
+    const { store } = await fixture()
+    await store.begin("task-1", "tab-a", "codex")
+    const firstSessionRun = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "session-a",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
+    })
+    const secondSessionRun = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "session-b",
+      source: "observer",
+      startSource: "resume",
+    })
+    const resumedAgain = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "session-a",
+      source: "observer",
+      startSource: "resume",
+    })
+
+    expect(resumedAgain).toMatchObject({
+      sessionId: "session-a",
+      state: "bound",
+      source: "observer",
+      startSource: "resume",
+    })
+    expect(resumedAgain.runId).not.toBe(firstSessionRun.runId)
+    expect(resumedAgain.runId).not.toBe(secondSessionRun.runId)
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]?.runId).toBe(resumedAgain.runId)
+    expect(store.runsSnapshot()).toEqual([
+      expect.objectContaining({ runId: firstSessionRun.runId, state: "superseded" }),
+      expect.objectContaining({ runId: secondSessionRun.runId, state: "superseded" }),
+      expect.objectContaining({ runId: resumedAgain.runId, state: "bound", sessionId: "session-a" }),
+    ])
+  })
+
   it("keeps late events on a superseded session from stealing the current tab", async () => {
     const { store } = await fixture()
     await store.begin("task-1", "tab-a", "codex")

--- a/packages/kobe/test/daemon/session-bindings.test.ts
+++ b/packages/kobe/test/daemon/session-bindings.test.ts
@@ -3,14 +3,14 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import { SessionBindingStore } from "@sma1lboy/kobe-daemon/daemon/session-bindings"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
-async function fixture(nowValues = [100, 200, 300, 400]) {
+async function fixture(nowValues = [100, 200, 300, 400], transitionTtlMs = 4_000) {
   const dir = await mkdtemp(join(tmpdir(), "kobe-session-bindings-"))
   const path = join(dir, "session-bindings.json")
   const bus = new DaemonEventBus()
   let index = 0
-  const store = new SessionBindingStore(path, bus, () => nowValues[index++] ?? 999)
+  const store = new SessionBindingStore(path, bus, () => nowValues[index++] ?? 999, transitionTtlMs)
   await store.init()
   return { path, bus, store }
 }
@@ -64,7 +64,7 @@ describe("SessionBindingStore", () => {
     })
     expect(bus.snapshot().at(-1)).toEqual({
       channel: "session.bindings",
-      payload: { bindings: store.snapshotByTask() },
+      payload: { bindings: store.snapshotByTask(), transitions: {} },
     })
     expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ version: 2 })
   })
@@ -346,6 +346,76 @@ describe("SessionBindingStore", () => {
         "tab-b": expect.objectContaining({ taskId: "task-2", tabId: "tab-b" }),
       },
     })
+  })
+
+  it("publishes resume transitions without persisting or replacing the current run", async () => {
+    const { path, bus, store } = await fixture()
+    await store.begin("task-1", "tab-a", "codex")
+    await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "old-session",
+      source: "hook",
+    })
+    const before = await readFile(path, "utf8")
+    const currentRun = store.snapshotByTask()["task-1"]?.["tab-a"]
+
+    store.markTransition({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      startSource: "resume",
+      observedAt: 350,
+    })
+
+    expect(store.transitionSnapshotByTask()).toEqual({
+      "task-1": {
+        "tab-a": expect.objectContaining({ observedAt: 350 }),
+      },
+    })
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toEqual(currentRun)
+    expect(await readFile(path, "utf8")).toBe(before)
+    expect(bus.snapshot().at(-1)).toEqual({
+      channel: "session.bindings",
+      payload: {
+        bindings: store.snapshotByTask(),
+        transitions: store.transitionSnapshotByTask(),
+      },
+    })
+
+    await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "new-session",
+      source: "observer",
+      startSource: "resume",
+    })
+    expect(store.transitionSnapshotByTask()).toEqual({})
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]?.sessionId).toBe("new-session")
+  })
+
+  it("expires an unconfirmed resume transition and restores the current run", async () => {
+    const { bus, store } = await fixture(undefined, 20)
+    vi.useFakeTimers()
+    try {
+      store.markTransition({
+        taskId: "task-1",
+        tabId: "tab-a",
+        vendor: "codex",
+        startSource: "resume",
+        observedAt: 350,
+      })
+      vi.advanceTimersByTime(20)
+      expect(store.transitionSnapshotByTask()).toEqual({})
+      expect(bus.snapshot().at(-1)).toEqual({
+        channel: "session.bindings",
+        payload: { bindings: {}, transitions: {} },
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("loads malformed files as an empty store", async () => {

--- a/packages/kobe/test/daemon/session-bindings.test.ts
+++ b/packages/kobe/test/daemon/session-bindings.test.ts
@@ -33,6 +33,8 @@ describe("SessionBindingStore", () => {
       vendor: "codex",
       sessionId: "019f-session",
       source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
       transcriptPath: "/tmp/rollout.jsonl",
     })
     await store.bind({
@@ -42,14 +44,17 @@ describe("SessionBindingStore", () => {
       sessionId: "019f-session",
       source: "hook",
       state: "ended",
+      eventKind: "session-end",
     })
 
     const reloaded = new SessionBindingStore(path, new DaemonEventBus())
     await reloaded.init()
     expect(reloaded.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({
       sessionId: "019f-session",
+      runId: expect.any(String),
       state: "ended",
       source: "hook",
+      startSource: "startup",
       startedAt: 100,
       boundAt: 200,
       updatedAt: 300,
@@ -61,7 +66,7 @@ describe("SessionBindingStore", () => {
       channel: "session.bindings",
       payload: { bindings: store.snapshotByTask() },
     })
-    expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ version: 1 })
+    expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ version: 2 })
   })
 
   it("a new spawn on the same tab replaces the old session identity", async () => {
@@ -83,19 +88,159 @@ describe("SessionBindingStore", () => {
     })
   })
 
-  it("keeps a bound identity when the same tab re-reads its engine spec", async () => {
+  it("begins a new run for a new same-vendor PTY spawn and deduplicates pending reads", async () => {
     const { store } = await fixture()
-    await store.begin("task-1", "tab-a", "codex")
-    const bound = await store.bind({
+    const initial = await store.begin("task-1", "tab-a", "codex")
+    await store.bind({
       taskId: "task-1",
       tabId: "tab-a",
       vendor: "codex",
       sessionId: "existing",
       source: "hook",
     })
+    const pending = await store.begin("task-1", "tab-a", "codex")
 
-    expect(await store.begin("task-1", "tab-a", "codex")).toEqual(bound)
-    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toEqual(bound)
+    expect(pending.runId).not.toBe(initial.runId)
+    expect(pending).toMatchObject({ sessionId: null, state: "pending", startedAt: 300 })
+    expect(await store.begin("task-1", "tab-a", "codex")).toEqual(pending)
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toEqual(pending)
+  })
+
+  it("lets Claude's SessionStart confirm a caller-pinned spawn without duplicating its run", async () => {
+    const { store } = await fixture()
+    const pending = await store.begin("task-1", "tab-a", "claude")
+    const pinned = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "claude",
+      sessionId: "caller-assigned",
+      source: "spawn",
+    })
+    const confirmed = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "claude",
+      sessionId: "caller-assigned",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
+    })
+
+    expect(pinned.runId).toBe(pending.runId)
+    expect(confirmed.runId).toBe(pending.runId)
+    expect(confirmed).toMatchObject({ source: "hook", startSource: "startup" })
+    expect(store.runsSnapshot()).toHaveLength(1)
+  })
+
+  it("creates a new run when the same native session is resumed, but not when it compacts", async () => {
+    const { store } = await fixture()
+    await store.begin("task-1", "tab-a", "codex")
+    const startup = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "same-session",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
+    })
+    const resumed = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "same-session",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "resume",
+    })
+    const compacted = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "same-session",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "compact",
+    })
+
+    expect(resumed.runId).not.toBe(startup.runId)
+    expect(compacted.runId).toBe(resumed.runId)
+    expect(compacted.startSource).toBe("resume")
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]?.runId).toBe(resumed.runId)
+    expect(store.runsSnapshot()).toEqual([
+      expect.objectContaining({ runId: startup.runId, state: "superseded", sessionId: "same-session" }),
+      expect.objectContaining({ runId: resumed.runId, state: "bound", startSource: "resume" }),
+    ])
+  })
+
+  it("keeps late events on a superseded session from stealing the current tab", async () => {
+    const { store } = await fixture()
+    await store.begin("task-1", "tab-a", "codex")
+    const oldRun = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "old-session",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
+    })
+    const currentRun = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "new-session",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
+    })
+    const late = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "old-session",
+      source: "hook",
+      eventKind: "turn-complete",
+    })
+
+    expect(late).toMatchObject({ runId: oldRun.runId, state: "superseded" })
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]?.runId).toBe(currentRun.runId)
+  })
+
+  it("migrates the v1 overwrite binding into one current v2 run", async () => {
+    const { path } = await fixture()
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        bindings: [
+          {
+            taskId: "task-1",
+            tabId: "tab-a",
+            vendor: "claude",
+            sessionId: "legacy-session",
+            state: "bound",
+            source: "hook",
+            startedAt: 10,
+            boundAt: 11,
+            updatedAt: 12,
+          },
+        ],
+      }),
+      "utf8",
+    )
+    const migrated = new SessionBindingStore(path, new DaemonEventBus())
+    await migrated.init()
+
+    expect(migrated.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({
+      runId: expect.any(String),
+      sessionId: "legacy-session",
+    })
+    expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({
+      version: 2,
+      runs: [expect.objectContaining({ sessionId: "legacy-session" })],
+      currentRuns: [expect.objectContaining({ taskId: "task-1", tabId: "tab-a" })],
+    })
   })
 
   it("removes all bindings when a task is hard-deleted", async () => {

--- a/packages/kobe/test/daemon/session-bindings.test.ts
+++ b/packages/kobe/test/daemon/session-bindings.test.ts
@@ -173,6 +173,54 @@ describe("SessionBindingStore", () => {
     ])
   })
 
+  it("lets SessionStart confirm an observed resume without creating a duplicate run", async () => {
+    const { store } = await fixture()
+    await store.begin("task-1", "tab-a", "codex")
+    await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "old-session",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
+    })
+    const observed = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "resumed-session",
+      source: "observer",
+      startSource: "resume",
+      transcriptPath: "/tmp/resumed.jsonl",
+    })
+    const confirmed = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "resumed-session",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "resume",
+      transcriptPath: "/tmp/resumed.jsonl",
+    })
+
+    expect(confirmed.runId).toBe(observed.runId)
+    expect(confirmed.source).toBe("hook")
+    expect(store.runsSnapshot()).toHaveLength(2)
+
+    const lateObserver = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "resumed-session",
+      source: "observer",
+      startSource: "resume",
+    })
+    expect(lateObserver.runId).toBe(observed.runId)
+    expect(lateObserver.source).toBe("hook")
+  })
+
   it("keeps late events on a superseded session from stealing the current tab", async () => {
     const { store } = await fixture()
     await store.begin("task-1", "tab-a", "codex")

--- a/packages/kobe/test/daemon/session-bindings.test.ts
+++ b/packages/kobe/test/daemon/session-bindings.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { SessionBindingStore } from "@sma1lboy/kobe-daemon/daemon/session-bindings"
+import { describe, expect, it } from "vitest"
+
+async function fixture(nowValues = [100, 200, 300, 400]) {
+  const dir = await mkdtemp(join(tmpdir(), "kobe-session-bindings-"))
+  const path = join(dir, "session-bindings.json")
+  const bus = new DaemonEventBus()
+  let index = 0
+  const store = new SessionBindingStore(path, bus, () => nowValues[index++] ?? 999)
+  await store.init()
+  return { path, bus, store }
+}
+
+describe("SessionBindingStore", () => {
+  it("persists pending -> bound -> ended across daemon instances", async () => {
+    const { path, bus, store } = await fixture()
+
+    await store.begin("task-1", "tab-a", "codex")
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({
+      sessionId: null,
+      state: "pending",
+      source: "spawn",
+      startedAt: 100,
+    })
+
+    await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "019f-session",
+      source: "hook",
+      transcriptPath: "/tmp/rollout.jsonl",
+    })
+    await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "019f-session",
+      source: "hook",
+      state: "ended",
+    })
+
+    const reloaded = new SessionBindingStore(path, new DaemonEventBus())
+    await reloaded.init()
+    expect(reloaded.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({
+      sessionId: "019f-session",
+      state: "ended",
+      source: "hook",
+      startedAt: 100,
+      boundAt: 200,
+      updatedAt: 300,
+    })
+    expect(reloaded.sessionIdsByTask()).toEqual({
+      "task-1": { "tab-a": "019f-session" },
+    })
+    expect(bus.snapshot().at(-1)).toEqual({
+      channel: "session.bindings",
+      payload: { bindings: store.snapshotByTask() },
+    })
+    expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ version: 1 })
+  })
+
+  it("a new spawn on the same tab replaces the old session identity", async () => {
+    const { store } = await fixture()
+    await store.begin("task-1", "tab-a", "claude")
+    await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "claude",
+      sessionId: "old",
+      source: "spawn",
+    })
+    await store.begin("task-1", "tab-a", "codex")
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({
+      vendor: "codex",
+      sessionId: null,
+      state: "pending",
+      startedAt: 300,
+    })
+  })
+
+  it("keeps a bound identity when the same tab re-reads its engine spec", async () => {
+    const { store } = await fixture()
+    await store.begin("task-1", "tab-a", "codex")
+    const bound = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "existing",
+      source: "hook",
+    })
+
+    expect(await store.begin("task-1", "tab-a", "codex")).toEqual(bound)
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toEqual(bound)
+  })
+
+  it("removes all bindings when a task is hard-deleted", async () => {
+    const { store } = await fixture()
+    await store.begin("task-1", "tab-a", "codex")
+    await store.begin("task-2", "tab-b", "claude")
+    await store.deleteTask("task-1")
+    expect(store.snapshotByTask()).toEqual({
+      "task-2": {
+        "tab-b": expect.objectContaining({ taskId: "task-2", tabId: "tab-b" }),
+      },
+    })
+  })
+
+  it("loads malformed files as an empty store", async () => {
+    const { path } = await fixture()
+    await writeFile(path, "{not json", "utf8")
+    const store = new SessionBindingStore(path, new DaemonEventBus())
+    await store.init()
+    expect(store.snapshotByTask()).toEqual({})
+  })
+})

--- a/packages/kobe/test/daemon/web-exposure.test.ts
+++ b/packages/kobe/test/daemon/web-exposure.test.ts
@@ -27,6 +27,7 @@ const EXPOSED: readonly DaemonRequestName[] = [
   "automation.runs",
   "automation.update",
   "daemon.status",
+  "engine.observeSession",
   "task.archive",
   "task.create",
   "task.delete",

--- a/packages/kobe/test/engine/claude-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/claude-hook-adapter.test.ts
@@ -71,6 +71,14 @@ describe("sessionFromPayload", () => {
     expect(
       adapter.sessionFromPayload({ session_id: "abc-123", transcript_path: "/tmp/abc-123.jsonl", cwd: "/wt" }),
     ).toEqual({ sessionId: "abc-123", transcriptPath: "/tmp/abc-123.jsonl" })
+    expect(
+      adapter.sessionFromPayload({
+        hook_event_name: "SessionStart",
+        source: "clear",
+        session_id: "abc-456",
+        transcript_path: "/tmp/abc-456.jsonl",
+      }),
+    ).toEqual({ sessionId: "abc-456", transcriptPath: "/tmp/abc-456.jsonl", startSource: "clear" })
   })
 
   it("omits transcriptPath when absent, and returns undefined without a session_id", () => {
@@ -79,6 +87,9 @@ describe("sessionFromPayload", () => {
     expect(adapter.sessionFromPayload({ session_id: 42 })).toBeUndefined()
     expect(adapter.sessionFromPayload({ session_id: "" })).toBeUndefined()
     expect(adapter.sessionFromPayload({ session_id: "abc", transcript_path: 7 })).toEqual({ sessionId: "abc" })
+    expect(
+      adapter.sessionFromPayload({ hook_event_name: "SessionStart", source: "future", session_id: "abc" }),
+    ).toEqual({ sessionId: "abc" })
   })
 })
 

--- a/packages/kobe/test/engine/codex-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/codex-hook-adapter.test.ts
@@ -61,6 +61,18 @@ describe("CodexHookAdapter", () => {
       transcriptPath: "/tmp/rollout.jsonl",
     })
     expect(
+      adapter.sessionFromPayload({
+        hook_event_name: "SessionStart",
+        source: "resume",
+        session_id: "session-1",
+        transcript_path: "/tmp/rollout.jsonl",
+      }),
+    ).toEqual({
+      sessionId: "session-1",
+      transcriptPath: "/tmp/rollout.jsonl",
+      startSource: "resume",
+    })
+    expect(
       adapter.activityDetailFromPayload("subagent-stop", {
         turn_id: "turn-1",
         agent_id: "agent-7",

--- a/packages/kobe/test/engine/codex-session-activation.test.ts
+++ b/packages/kobe/test/engine/codex-session-activation.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest"
+import { observeCodexSessionActivation, parseCodexResumeLog } from "../../src/engine/codex-local/session-activation.ts"
+
+const SESSION_ID = "019fca97-e324-7351-9bcf-cd0608fd5d80"
+const TRANSCRIPT = `/Users/test/.codex/sessions/2026/08/04/rollout-2026-08-04T10-26-19-${SESSION_ID}.jsonl`
+
+describe("Codex session activation observer", () => {
+  it("normalizes the exact resume log record", () => {
+    expect(
+      parseCodexResumeLog({
+        id: 7,
+        ts: 1_786_022_485,
+        ts_nanos: 925_327_000,
+        feedback_log_body: `Resuming rollout from "${TRANSCRIPT}"`,
+      }),
+    ).toEqual({
+      sessionId: SESSION_ID,
+      transcriptPath: TRANSCRIPT,
+      source: "resume",
+      observedAt: 1_786_022_485_925,
+    })
+  })
+
+  it("normalizes the selected thread id from a resume span when no rollout record exists", () => {
+    expect(
+      parseCodexResumeLog({
+        id: 8,
+        ts: 1_786_081_735,
+        ts_nanos: 42_000_000,
+        feedback_log_body: `app_server.request{otel.kind="server" otel.name="thread/resume"}:resume_thread_with_history:thread_spawn{otel.name="thread_spawn"}:session_init:startup_prewarm{thread.id=${SESSION_ID}}: response started`,
+      }),
+    ).toEqual({
+      sessionId: SESSION_ID,
+      source: "resume",
+      observedAt: 1_786_081_735_042,
+    })
+  })
+
+  it("does not infer a thread id from transcript text outside the resume span", () => {
+    expect(
+      parseCodexResumeLog({
+        id: 9,
+        ts: 1_786_081_736,
+        ts_nanos: 0,
+        feedback_log_body: `The log mentioned otel.name="thread/resume" and thread.id=${SESSION_ID}`,
+      }),
+    ).toBeNull()
+  })
+
+  it("uses the actual Codex descendant PID and forwards the EngineRun timestamp cursor", async () => {
+    const latestResume = vi.fn(() => ({
+      id: 8,
+      ts: 1_786_022_486,
+      ts_nanos: 1_000_000,
+      feedback_log_body: `Resuming rollout from "${TRANSCRIPT}"`,
+    }))
+    await expect(
+      observeCodexSessionActivation(
+        { rootPid: 400, afterMs: 1_786_022_480_000 },
+        {
+          findEnginePid: async () => ({ vendor: "codex", pid: 401 }),
+          latestResume,
+        },
+      ),
+    ).resolves.toMatchObject({ sessionId: SESSION_ID })
+    expect(latestResume).toHaveBeenCalledWith(401, 1_786_022_480_000)
+  })
+
+  it("does not inspect another engine's process", async () => {
+    const latestResume = vi.fn()
+    await expect(
+      observeCodexSessionActivation(
+        { rootPid: 400, afterMs: 0 },
+        {
+          findEnginePid: async () => ({ vendor: "claude", pid: 401 }),
+          latestResume,
+        },
+      ),
+    ).resolves.toBeNull()
+    expect(latestResume).not.toHaveBeenCalled()
+  })
+})

--- a/packages/kobe/test/engine/codex-session-activation.test.ts
+++ b/packages/kobe/test/engine/codex-session-activation.test.ts
@@ -14,6 +14,7 @@ describe("Codex session activation observer", () => {
         feedback_log_body: `Resuming rollout from "${TRANSCRIPT}"`,
       }),
     ).toEqual({
+      phase: "selected",
       sessionId: SESSION_ID,
       transcriptPath: TRANSCRIPT,
       source: "resume",
@@ -30,16 +31,33 @@ describe("Codex session activation observer", () => {
         feedback_log_body: `app_server.request{otel.kind="server" otel.name="thread/resume"}:resume_thread_with_history:thread_spawn{otel.name="thread_spawn"}:session_init:startup_prewarm{thread.id=${SESSION_ID}}: response started`,
       }),
     ).toEqual({
+      phase: "selected",
       sessionId: SESSION_ID,
       source: "resume",
       observedAt: 1_786_081_735_042,
     })
   })
 
-  it("does not infer a thread id from transcript text outside the resume span", () => {
+  it("reports a resume transition before Codex publishes the selected thread id", () => {
     expect(
       parseCodexResumeLog({
         id: 9,
+        ts: 1_786_081_734,
+        ts_nanos: 500_000_000,
+        feedback_log_body:
+          'app_server.request{otel.name="thread/resume"}:resume_thread_with_history: loading session state',
+      }),
+    ).toEqual({
+      phase: "pending",
+      source: "resume",
+      observedAt: 1_786_081_734_500,
+    })
+  })
+
+  it("does not infer a thread id from transcript text outside the resume span", () => {
+    expect(
+      parseCodexResumeLog({
+        id: 10,
         ts: 1_786_081_736,
         ts_nanos: 0,
         feedback_log_body: `The log mentioned otel.name="thread/resume" and thread.id=${SESSION_ID}`,
@@ -62,7 +80,7 @@ describe("Codex session activation observer", () => {
           latestResume,
         },
       ),
-    ).resolves.toMatchObject({ sessionId: SESSION_ID })
+    ).resolves.toMatchObject({ phase: "selected", sessionId: SESSION_ID })
     expect(latestResume).toHaveBeenCalledWith(401, 1_786_022_480_000)
   })
 

--- a/packages/kobe/test/engine/interactive-command-overrides.test.ts
+++ b/packages/kobe/test/engine/interactive-command-overrides.test.ts
@@ -21,6 +21,7 @@ import {
   withClaudeSessionId,
   withEngineEffort,
   withEngineTerminalTitle,
+  withManagedHookTrust,
 } from "../../src/engine/interactive-command.ts"
 import { setPersistedString } from "../../src/state/repos.ts"
 
@@ -94,6 +95,30 @@ describe("withEngineTerminalTitle", () => {
   it("leaves engines without a native-title launch policy untouched", () => {
     expect(withEngineTerminalTitle(["claude"], "claude")).toEqual(["claude"])
     expect(withEngineTerminalTitle(["aider"], "aider")).toEqual(["aider"])
+  })
+})
+
+describe("withManagedHookTrust", () => {
+  it("adds Codex hook trust only to an already-unrestricted managed launch", () => {
+    expect(withManagedHookTrust(["codex", "--dangerously-bypass-approvals-and-sandbox"], "codex")).toEqual([
+      "codex",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--dangerously-bypass-hook-trust",
+    ])
+  })
+
+  it("leaves safer, non-Codex, and already-configured launches unchanged", () => {
+    expect(withManagedHookTrust(["codex"], "codex")).toEqual(["codex"])
+    expect(withManagedHookTrust(["claude", "--dangerously-bypass-approvals-and-sandbox"], "claude")).toEqual([
+      "claude",
+      "--dangerously-bypass-approvals-and-sandbox",
+    ])
+    expect(
+      withManagedHookTrust(
+        ["codex", "--dangerously-bypass-approvals-and-sandbox", "--dangerously-bypass-hook-trust"],
+        "codex",
+      ),
+    ).toEqual(["codex", "--dangerously-bypass-approvals-and-sandbox", "--dangerously-bypass-hook-trust"])
   })
 })
 

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -432,9 +432,12 @@ describe("terminal tabs state", () => {
   // (leading space + clear), NOT the PTY environment — same inheritance
   // path as shellSpawn's env prefix.
   it("shellIdentityInput builds the typed export line for bare shell tabs", () => {
-    expect(shellIdentityInput("t1", "tab-4")).toBe(" export KOBE_TASK_ID=t1 KOBE_TAB_ID=tab-4 && clear\r")
+    expect(shellIdentityInput("t1", "tab-4", {})).toBe(" export KOBE_TASK_ID=t1 KOBE_TAB_ID=tab-4 && clear\r")
     // Hostile ids stay one shell word each.
-    expect(shellIdentityInput("t 1", "tab-4")).toBe(" export KOBE_TASK_ID='t 1' KOBE_TAB_ID=tab-4 && clear\r")
+    expect(shellIdentityInput("t 1", "tab-4", {})).toBe(" export KOBE_TASK_ID='t 1' KOBE_TAB_ID=tab-4 && clear\r")
+    expect(shellIdentityInput("t1", "tab-4", { KOBE_DEV_CLI_ENTRY: "/repo path/index.ts" })).toContain(
+      "KOBE_DEV_CLI_ENTRY='/repo path/index.ts'",
+    )
   })
 
   // Why: the F7 attention jump's tab precision — the launch script exports
@@ -450,7 +453,8 @@ describe("terminal tabs state", () => {
       task: { id: "01TASK", kind: "task" },
       worktreePath: "/wt",
     })
-    expect(spawn.command[2]).toContain("export KOBE_TASK_ID='01TASK' KOBE_TAB_ID='tab-2'\n")
+    expect(spawn.command[2]).toContain("export KOBE_TASK_ID='01TASK' KOBE_TAB_ID='tab-2'")
+    expect(spawn.command[2]).toContain("KOBE_DEV_CLI_ENTRY=")
   })
 
   // Why: collapse decides persistence (null = unsplit fast path) AND the


### PR DESCRIPTION
## Summary

- persist task and ChatTab bindings to engine-owned sessions and model each attachment as a temporal EngineRun
- make Codex resume selections observable immediately, with hook and history recovery fallbacks
- publish an ephemeral resume transition as soon as Codex logs `thread/resume`, before the selected session id exists
- keep Agent Trace history attached to the selected run across resume cycles and daemon restarts
- show an explicit causal-chain loading state while identity and persisted events hydrate, with timeout recovery for incomplete resumes
- route desktop development through its matching development daemon

## Verification

- monorepo typecheck passed
- root and kobe-web lint passed
- kobe-web: 77 files, 610 tests passed
- targeted Codex, daemon binding, and runtime tests: 39 passed
- kobe-web production build passed
- dev Electron restarted against sandbox home and source daemon on :5176; SSE snapshot exposes the new transition contract
- kobe fast suite on the preceding timeline commit: 291 files passed; one pre-existing terminal scrollback cache assertion failed under the parallel full run and is outside this diff

## Scope

This PR intentionally targets feat/gui-chat-shell rather than main. Terminal history scrolling, wheel delegation, and xterm scrollback changes are excluded.
