### PR TITLE
Make Agent Trace blocks readable and quotable

### DIFF
--- a/.changeset/readable-trace-quotes.md
+++ b/.changeset/readable-trace-quotes.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Make Agent Trace details easier to read by labeling structured tool inputs and results, and let users quote any trace block into the active native composer for editing without automatically sending the next turn.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -271,6 +271,15 @@ output. To add another engine, implement `readTrace` (and optionally
 `traceRevision` plus normalized live hook details) in that engine's registry
 entry; do not add vendor parsing to React components.
 
+Opening a trace card formats JSON-shaped input and result details into labeled
+fields such as command, working directory, duration, exit code, and output;
+plain text stays intact. **Quote to input** inserts a bounded, self-contained
+reference to that card into the active engine's native composer. It uses
+bracketed paste without Enter, strips terminal control bytes, and returns focus
+to the composer, so the user can edit the reference and decide whether to send
+the next turn. This is a presentation/interaction layer over `EngineTrace` —
+the frontend still does not read vendor transcripts or own conversation state.
+
 ## Launching and resuming sessions
 
 Every launch site resolves the engine argv the same way

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -10,6 +10,7 @@
  *
  *   ws  /pty?tab=<id>&taskId=<id>&mode=engine|shell&cols=<n>&rows=<n>
  *   POST /pty/close   { tab }                          kill the tab process
+ *   POST /pty/insert  { tab, text }                    paste without Enter
  *   POST /pty/send    { tab, taskId, text }            paste text + Enter into the tab's engine
  */
 
@@ -212,6 +213,49 @@ const server = createServer((req, res) => {
       "access-control-allow-headers": "content-type",
     })
     res.end()
+    return
+  }
+  if (req.method === "POST" && url.pathname === "/pty/insert") {
+    // Inserting text drives the active terminal, so it shares the websocket
+    // origin policy. Unlike /pty/send it never spawns or presses Enter.
+    if (!originAllowed(req.headers.origin, { allowedHost: ALLOWED_HOST })) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
+    let body = ""
+    req.on("data", (c) => {
+      body += c
+    })
+    req.on("end", () => {
+      let tab
+      let text
+      try {
+        ;({ tab, text } = JSON.parse(body || "{}"))
+      } catch {
+        /* ignore */
+      }
+      const respond = (status, payload) => {
+        res.writeHead(status, {
+          "content-type": "application/json",
+          "access-control-allow-origin": "*",
+        })
+        res.end(JSON.stringify(payload))
+      }
+      if (typeof tab !== "string" || !tab || typeof text !== "string" || !text) {
+        respond(400, { inserted: false, error: "tab and text are required" })
+        return
+      }
+      const result = ptySessions.insertText({ tabId: tab, text })
+      if (!result.inserted) {
+        respond(result.missing ? 404 : 500, {
+          inserted: false,
+          error: result.missing ? "no such tab" : "failed to write to tab",
+        })
+        return
+      }
+      respond(200, { inserted: true })
+    })
     return
   }
   if (req.method === "POST" && url.pathname === "/pty/send") {

--- a/packages/kobe-web/pty-session-lifecycle.d.mts
+++ b/packages/kobe-web/pty-session-lifecycle.d.mts
@@ -78,6 +78,11 @@ export interface SendTextInput {
   text: string
 }
 
+export interface InsertTextInput {
+  tabId: string
+  text: string
+}
+
 export interface PtySessionManager {
   attachSocket(input: AttachSocketInput): Promise<unknown>
   closeSession(tabId: string): boolean
@@ -89,6 +94,10 @@ export interface PtySessionManager {
     rows: number,
     vendor?: string,
   ): Promise<unknown>
+  insertText(input: InsertTextInput): {
+    inserted: boolean
+    missing: boolean
+  }
   sendText(input: SendTextInput): Promise<{ sent: boolean; spawned: boolean; missing?: boolean }>
   shutdown(): void
   sessionCount(): number

--- a/packages/kobe-web/pty-session-lifecycle.mjs
+++ b/packages/kobe-web/pty-session-lifecycle.mjs
@@ -242,6 +242,24 @@ export function createPtySessionManager({
     return true
   }
 
+  /** Paste into an already-hosted PTY without submitting. This is the
+   * composer-fill primitive used by Agent Trace quoting. */
+  function insertText({ tabId, text }) {
+    const entry = sessions.get(tabId)
+    if (!entry) return { inserted: false, missing: true }
+    try {
+      // Trace output is external text. Strip terminal control bytes so it
+      // cannot close the bracketed-paste envelope or synthesize keystrokes.
+      const safeText = text
+        .replace(/\r\n?/g, "\n")
+        .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+      entry.pty.write(`\x1b[200~${safeText}\x1b[201~`)
+      return { inserted: true, missing: false }
+    } catch {
+      return { inserted: false, missing: false }
+    }
+  }
+
   async function sendText({ tabId, taskId, text }) {
     let entry = sessions.get(tabId)
     let spawned = false
@@ -295,6 +313,7 @@ export function createPtySessionManager({
     attachSocket,
     closeSession,
     ensureSession,
+    insertText,
     sendText,
     shutdown,
     sessionCount: () => sessions.size,

--- a/packages/kobe-web/src/components/ChatShell.tsx
+++ b/packages/kobe-web/src/components/ChatShell.tsx
@@ -13,7 +13,14 @@
  */
 
 import { PanelRight } from "lucide-react"
-import { lazy, Suspense, useEffect, useMemo, useState } from "react"
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import { grammarFor } from "../lib/engine-grammar.ts"
 import { useEngines } from "../lib/engines.ts"
 import {
@@ -29,14 +36,14 @@ import {
   useTabsState,
   type VendorTab,
 } from "../lib/tabs.ts"
-import { fetchPtyForeground } from "../lib/terminal.ts"
+import { fetchPtyForeground, insertPtyText } from "../lib/terminal.ts"
+import { pushToast, reportError } from "../lib/toast.ts"
 import { resolveVendor } from "../lib/vendor.ts"
 import { ChatSidebarTree } from "./ChatSidebarTree.tsx"
 import { DaemonBanner } from "./DaemonBanner.tsx"
 import { PaneResizer, usePaneWidth } from "./PaneResizer.tsx"
 import { SessionView } from "./SessionView.tsx"
 import { TimelineHost } from "./TimelineHost.tsx"
-import { Toasts } from "./Toasts.tsx"
 
 // Kanban / Routines render INSIDE the /chat main area (a surface switch, not
 // a route jump) — lazy so the chat-first load doesn't pay for them.
@@ -180,6 +187,7 @@ export function ChatShell() {
   // Active tab's grammar-derived engine liveness (SessionView reports it up).
   // It decorates live status only; the durable binding keeps history visible.
   const [engineLive, setEngineLive] = useState(false)
+  const [quoteFocusRequest, setQuoteFocusRequest] = useState(0)
   // biome-ignore lint/correctness/useExhaustiveDependencies: tab switch resets liveness until the new SessionView reports
   useEffect(() => {
     setEngineLive(false)
@@ -191,6 +199,20 @@ export function ChatShell() {
     selected && tabId ? sessionTransitions[selected.id]?.[tabId] : undefined
   const legacySessionId =
     selected && tabId ? engineTabSessions[selected.id]?.[tabId] : undefined
+  const quoteToInput = useCallback(
+    async (text: string): Promise<void> => {
+      if (!tabId) throw new Error("no active chat tab")
+      try {
+        await insertPtyText(tabId, `\n\n${text}\n\n`)
+        setQuoteFocusRequest((value) => value + 1)
+        pushToast("success", "Quoted block into the next prompt")
+      } catch (err) {
+        reportError("quote block", err)
+        throw err
+      }
+    },
+    [tabId],
+  )
 
   return (
     <div className="flex h-full flex-col bg-bg">
@@ -257,6 +279,7 @@ export function ChatShell() {
                   mode={mode}
                   vendor={vendor}
                   grammar={grammarFor(effectiveVendor ?? selected.vendor)}
+                  focusRequest={quoteFocusRequest}
                   onEngineLive={setEngineLive}
                 />
               )}
@@ -281,10 +304,10 @@ export function ChatShell() {
             legacySessionId={legacySessionId}
             engineActive={engineLive}
             width={traceW}
+            onQuote={quoteToInput}
           />
         )}
       </div>
-      <Toasts />
     </div>
   )
 }

--- a/packages/kobe-web/src/components/ExecutionGrid.tsx
+++ b/packages/kobe-web/src/components/ExecutionGrid.tsx
@@ -4,6 +4,7 @@ import {
   FilePenLine,
   Layers3,
   MessageSquare,
+  Quote,
   TerminalSquare,
 } from "lucide-react"
 import { useState } from "react"
@@ -12,7 +13,8 @@ import {
   type TimelineItem,
   type TimelineStatus,
 } from "../lib/timeline.ts"
-import { CopyButton } from "./CopyButton.tsx"
+import { quoteTraceItem } from "../lib/trace-content.ts"
+import { ReadableTraceContent } from "./ReadableTraceContent.tsx"
 import { SlideOver } from "./SlideOver.tsx"
 import { TracePatch } from "./TracePatch.tsx"
 
@@ -111,39 +113,24 @@ function ExecutionNode({
   )
 }
 
-function DetailSection({ label, text }: { label: string; text: string }) {
-  return (
-    <section className="rounded border border-line bg-surface">
-      <header className="flex h-9 items-center gap-2 border-b border-line px-3">
-        <span className="text-[11px] text-muted">{label}</span>
-        <CopyButton
-          text={text}
-          label={`Copy ${label.toLowerCase()}`}
-          className="ml-auto"
-        />
-      </header>
-      <pre className="max-h-[48vh] overflow-auto whitespace-pre-wrap break-words p-3 font-mono text-[11px] leading-relaxed text-fg">
-        {text || "(empty)"}
-      </pre>
-    </section>
-  )
-}
-
 function ExecutionDetail({
   item,
   parent,
   retryOf,
   now,
+  onQuote,
   onClose,
 }: {
   item: TimelineItem | undefined
   parent: TimelineItem | undefined
   retryOf: TimelineItem | undefined
   now: number
+  onQuote?: (text: string) => Promise<void>
   onClose: () => void
 }) {
   const isTool = item?.kind === "tool" || item?.kind === "change"
   const hasResult = isTool || item?.kind === "subagent"
+  const [quoting, setQuoting] = useState(false)
   return (
     <SlideOver
       open={item !== undefined}
@@ -175,6 +162,24 @@ function ExecutionDetail({
               <span className="rounded-full border border-line px-1.5 py-0.5 text-muted">
                 attempt {item.attempt}
               </span>
+            )}
+            {onQuote && (
+              <button
+                type="button"
+                disabled={quoting}
+                onClick={() => {
+                  setQuoting(true)
+                  void onQuote(quoteTraceItem(item))
+                    .then(onClose)
+                    .catch(() => {})
+                    .finally(() => setQuoting(false))
+                }}
+                className="ml-auto flex items-center gap-1.5 rounded-sm border border-line px-2 py-1 font-sans text-[10px] text-muted transition-colors hover:border-primary hover:text-fg disabled:opacity-50"
+                title="Insert this block into the current prompt without sending"
+              >
+                <Quote size={11} strokeWidth={1.8} />
+                {quoting ? "Quoting…" : "Quote to input"}
+              </button>
             )}
           </div>
           {retryOf && (
@@ -211,7 +216,7 @@ function ExecutionDetail({
           {item.kind === "change" ? (
             <TracePatch patch={item.detail} />
           ) : (
-            <DetailSection
+            <ReadableTraceContent
               label={
                 item.kind === "tool"
                   ? "Input"
@@ -229,7 +234,7 @@ function ExecutionDetail({
             />
           )}
           {hasResult && (
-            <DetailSection
+            <ReadableTraceContent
               label={item.kind === "subagent" ? "Subagent result" : "Result"}
               text={item.resultDetail ?? "No result recorded yet."}
             />
@@ -261,11 +266,13 @@ export function ExecutionGrid({
   items,
   status,
   now,
+  onQuote,
   className = "",
 }: {
   items: readonly TimelineItem[]
   status: TimelineStatus
   now: number
+  onQuote?: (text: string) => Promise<void>
   className?: string
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -341,6 +348,7 @@ export function ExecutionGrid({
         parent={parent}
         retryOf={retryOf}
         now={now}
+        onQuote={onQuote}
         onClose={() => setSelectedId(null)}
       />
     </>

--- a/packages/kobe-web/src/components/ReadableTraceContent.tsx
+++ b/packages/kobe-web/src/components/ReadableTraceContent.tsx
@@ -1,0 +1,54 @@
+import { readableTraceContent } from "../lib/trace-content.ts"
+import { CopyButton } from "./CopyButton.tsx"
+
+export function ReadableTraceContent({
+  label,
+  text,
+}: {
+  label: string
+  text: string
+}) {
+  const fields = readableTraceContent(label, text)
+  const compact = fields.filter((field) => field.tone === "value")
+  const bodies = fields.filter((field) => field.tone !== "value")
+  return (
+    <section className="rounded border border-line bg-surface">
+      <header className="flex h-9 items-center gap-2 border-b border-line px-3">
+        <span className="text-[11px] text-muted">{label}</span>
+        <CopyButton
+          text={text}
+          label={`Copy ${label.toLowerCase()}`}
+          className="ml-auto"
+        />
+      </header>
+      <div className="flex max-h-[48vh] flex-col gap-3 overflow-auto p-3">
+        {compact.length > 0 && (
+          <dl className="grid grid-cols-[minmax(7rem,auto)_minmax(0,1fr)] gap-x-4 gap-y-1.5 border-b border-line-subtle pb-3 text-[10px]">
+            {compact.map((field) => (
+              <div key={field.label} className="contents">
+                <dt className="text-subtle">{field.label}</dt>
+                <dd className="min-w-0 break-words font-mono text-muted">
+                  {field.text}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+        {bodies.map((field) => (
+          <div key={field.label}>
+            {fields.length > 1 && (
+              <div className="mb-1.5 text-[9px] uppercase tracking-[0.12em] text-subtle">
+                {field.label}
+              </div>
+            )}
+            <div
+              className={`whitespace-pre-wrap break-words text-[11px] leading-relaxed text-fg ${field.tone === "code" ? "font-mono" : ""}`}
+            >
+              {field.text}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/packages/kobe-web/src/components/SessionView.tsx
+++ b/packages/kobe-web/src/components/SessionView.tsx
@@ -65,6 +65,7 @@ export function SessionView({
   mode,
   vendor,
   grammar,
+  focusRequest = 0,
   onEngineLive,
 }: {
   tabId: string
@@ -76,12 +77,17 @@ export function SessionView({
   vendor?: string
   /** The vendor's screen grammar (engine-grammar.ts) — drives the translation. */
   grammar: EngineGrammar
+  /** External request to return keyboard focus to the native composer. */
+  focusRequest?: number
   /** Grammar-derived engine liveness, lifted so the Agent Trace can clear
    *  when this tab drops to a bare shell / boot screen. */
   onEngineLive?: (live: boolean) => void
 }) {
   const [colored, setColored] = useState<ColoredLine[]>([])
   const [focusNonce, setFocusNonce] = useState(0)
+  useEffect(() => {
+    if (focusRequest > 0) setFocusNonce((value) => value + 1)
+  }, [focusRequest])
   // Frame stabilizer: reuse previous line OBJECTS for unchanged rows so
   // memoized children skip re-render — a keystroke only re-renders the input
   // row's dependents, not the whole transcript.

--- a/packages/kobe-web/src/components/TimelineHost.tsx
+++ b/packages/kobe-web/src/components/TimelineHost.tsx
@@ -19,6 +19,7 @@ export function TimelineHost({
   legacySessionId,
   engineActive = true,
   width,
+  onQuote,
 }: {
   taskId: string
   vendor: string
@@ -33,6 +34,8 @@ export function TimelineHost({
   engineActive?: boolean
   /** Drag-resized panel width (PaneResizer). */
   width?: number
+  /** Insert one block reference into the active native composer. */
+  onQuote?: (text: string) => Promise<void>
 }) {
   const engines = useEngines()
   const label = engineLabel(engines, vendor)
@@ -56,6 +59,7 @@ export function TimelineHost({
         bindingState={data.bindingState}
         runId={binding?.runId}
         width={width}
+        onQuote={onQuote}
         onExpand={() => setExpanded(true)}
       />
       {expanded && (
@@ -63,6 +67,7 @@ export function TimelineHost({
           model={data.model}
           engineLabel={label}
           runId={binding?.runId}
+          onQuote={onQuote}
           onClose={() => setExpanded(false)}
         />
       )}

--- a/packages/kobe-web/src/components/TimelinePanel.tsx
+++ b/packages/kobe-web/src/components/TimelinePanel.tsx
@@ -62,10 +62,12 @@ function TurnSection({
   turn,
   turnIndex,
   now,
+  onQuote,
 }: {
   turn: TimelineTurn
   turnIndex: number
   now: number
+  onQuote?: (text: string) => Promise<void>
 }) {
   const [expanded, setExpanded] = useState(false)
   const spotlight = turn.nodes.filter(isSpotlightNode)
@@ -113,7 +115,12 @@ function TurnSection({
           {expanded ? "Hide steps" : `${foldedCount} steps`}
         </button>
       )}
-      <ExecutionGrid items={items} status={turn.status} now={now} />
+      <ExecutionGrid
+        items={items}
+        status={turn.status}
+        now={now}
+        onQuote={onQuote}
+      />
     </section>
   )
 }
@@ -127,6 +134,7 @@ export function TimelinePanel({
   bindingState,
   runId,
   width,
+  onQuote,
   onExpand,
 }: {
   model: TimelineModel
@@ -140,6 +148,8 @@ export function TimelinePanel({
   runId?: string
   /** Drag-resized width (PaneResizer) — falls back to the basis-80 default. */
   width?: number
+  /** Insert a trace block into the active native composer without sending. */
+  onQuote?: (text: string) => Promise<void>
   onExpand: () => void
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -252,6 +262,7 @@ export function TimelinePanel({
                 turn={turn}
                 turnIndex={turnIndex}
                 now={now}
+                onQuote={onQuote}
               />
             ))}
           </div>

--- a/packages/kobe-web/src/components/TimelineSwimlane.tsx
+++ b/packages/kobe-web/src/components/TimelineSwimlane.tsx
@@ -18,11 +18,13 @@ export function TimelineSwimlane({
   model,
   engineLabel,
   runId,
+  onQuote,
   onClose,
 }: {
   model: TimelineModel
   engineLabel: string
   runId?: string
+  onQuote?: (text: string) => Promise<void>
   onClose: () => void
 }) {
   const running = model.turns.some((turn) => turn.status === "running")
@@ -102,6 +104,7 @@ export function TimelineSwimlane({
                     items={turn.nodes}
                     status={turn.status}
                     now={now}
+                    onQuote={onQuote}
                     className="execution-node-grid--wide"
                   />
                 </div>

--- a/packages/kobe-web/src/lib/terminal.ts
+++ b/packages/kobe-web/src/lib/terminal.ts
@@ -72,6 +72,29 @@ export async function closePtyTab(tabId: string): Promise<void> {
   }
 }
 
+/** Paste text into an already-hosted native composer without pressing Enter.
+ * The engine remains fully in charge of editing and submitting the next turn. */
+export async function insertPtyText(
+  tabId: string,
+  text: string,
+): Promise<void> {
+  try {
+    const json = await api.post<{ inserted?: boolean }>(
+      `${ptyBase("http")}/pty/insert`,
+      { tab: tabId, text },
+      { label: "insert PTY text" },
+    )
+    if (!json.inserted) throw new Error("insert failed")
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404 && !err.detail) {
+      throw new Error(
+        "the PTY server doesn't know /pty/insert — restart `kobe web` (the sidecar doesn't hot-reload)",
+      )
+    }
+    throw err
+  }
+}
+
 /**
  * Paste text + Enter into a tab's engine — the composer's submit contract,
  * fired from outside any terminal view (board quick actions). The sidecar

--- a/packages/kobe-web/src/lib/trace-content.ts
+++ b/packages/kobe-web/src/lib/trace-content.ts
@@ -1,0 +1,203 @@
+import type { TimelineItem } from "./timeline.ts"
+
+export type TraceFieldTone = "code" | "prose" | "value"
+
+export interface ReadableTraceField {
+  readonly label: string
+  readonly text: string
+  readonly tone: TraceFieldTone
+}
+
+const LABELS: Record<string, string> = {
+  cmd: "Command",
+  command: "Command",
+  cwd: "Working directory",
+  workdir: "Working directory",
+  file_path: "File",
+  max_output_tokens: "Output limit",
+  yield_time_ms: "Wait",
+  wall_time_seconds: "Duration",
+  exit_code: "Exit code",
+  stdout: "Standard output",
+  stderr: "Standard error",
+  output: "Output",
+  error: "Error",
+  path: "Path",
+  pattern: "Pattern",
+  query: "Query",
+  prompt: "Prompt",
+  description: "Description",
+  content: "Content",
+  message: "Message",
+  text: "Text",
+}
+
+const CODE_FIELDS = new Set([
+  "cmd",
+  "command",
+  "stdout",
+  "stderr",
+  "output",
+  "error",
+  "patch",
+  "diff",
+])
+const PROSE_FIELDS = new Set([
+  "prompt",
+  "description",
+  "content",
+  "message",
+  "text",
+  "reasoning",
+])
+const FIELD_PRIORITY = [
+  "cmd",
+  "command",
+  "file_path",
+  "path",
+  "pattern",
+  "query",
+  "prompt",
+  "description",
+  "output",
+  "stdout",
+  "stderr",
+  "error",
+]
+const QUOTE_LIMIT = 16_000
+
+function humanizeKey(key: string): string {
+  const known = LABELS[key]
+  if (known) return known
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+  return words ? `${words[0]?.toUpperCase() ?? ""}${words.slice(1)}` : "Value"
+}
+
+function formatValue(key: string, value: unknown): string {
+  if (value === null) return "None"
+  if (typeof value === "boolean") return value ? "Yes" : "No"
+  if (typeof value === "number") {
+    if (key.endsWith("_ms"))
+      return value >= 1_000 ? `${value / 1_000} s` : `${value} ms`
+    if (key.endsWith("_seconds")) return `${value} s`
+    if (key === "max_output_tokens")
+      return `${value.toLocaleString("en-US")} tokens`
+    if (key === "exit_code")
+      return value === 0 ? "0 · success" : `${value} · failed`
+    return value.toLocaleString("en-US")
+  }
+  if (typeof value === "string") return value
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function toneFor(key: string, value: unknown): TraceFieldTone {
+  if (CODE_FIELDS.has(key)) return "code"
+  if (PROSE_FIELDS.has(key)) return "prose"
+  if (typeof value === "object" && value !== null) return "code"
+  return "value"
+}
+
+function parseStructured(text: string): unknown | undefined {
+  const trimmed = text.trim()
+  if (
+    !(
+      trimmed.startsWith("{") ||
+      trimmed.startsWith("[") ||
+      trimmed.startsWith('"')
+    )
+  )
+    return undefined
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (typeof parsed === "string") {
+      const nested = parsed.trim()
+      if (nested.startsWith("{") || nested.startsWith("[")) {
+        try {
+          return JSON.parse(nested)
+        } catch {
+          return undefined
+        }
+      }
+      return undefined
+    }
+    return parsed
+  } catch {
+    return undefined
+  }
+}
+
+function orderedEntries(
+  record: Record<string, unknown>,
+): Array<[string, unknown]> {
+  const rank = (key: string): number => {
+    const index = FIELD_PRIORITY.indexOf(key)
+    return index < 0 ? FIELD_PRIORITY.length : index
+  }
+  return Object.entries(record).sort(([a], [b]) => rank(a) - rank(b))
+}
+
+/** Generic presentation parser. Engine adapters still own the trace values;
+ * this only turns JSON-shaped strings into labels a person can scan. */
+export function readableTraceContent(
+  label: string,
+  text: string,
+): readonly ReadableTraceField[] {
+  const parsed = parseStructured(text)
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const fields = orderedEntries(parsed as Record<string, unknown>).map(
+      ([key, value]) => ({
+        label: humanizeKey(key),
+        text: formatValue(key, value),
+        tone: toneFor(key, value),
+      }),
+    )
+    if (fields.length > 0) return fields
+  }
+  if (Array.isArray(parsed)) {
+    return [{ label, text: formatValue("items", parsed), tone: "code" }]
+  }
+  return [{ label, text: text || "(empty)", tone: "prose" }]
+}
+
+function itemKindLabel(item: TimelineItem): string {
+  if (item.kind === "commentary") return "Commentary"
+  if (item.kind === "reasoning") return "Reasoning"
+  if (item.kind === "change") return "Change"
+  if (item.kind === "answer") return "Result"
+  if (item.kind === "subagent") return "Subagent"
+  if (item.kind === "compaction") return "Compaction"
+  return "Tool"
+}
+
+function appendContent(lines: string[], label: string, text: string): void {
+  if (!text) return
+  lines.push(label)
+  for (const field of readableTraceContent(label, text)) {
+    if (field.label !== label) lines.push(`${field.label}:`)
+    lines.push(field.text, "")
+  }
+}
+
+/** Self-contained text pasted into the native engine composer. It references
+ * one trace node but never sends the next turn automatically. */
+export function quoteTraceItem(item: TimelineItem): string {
+  const close = "[/Quoted Agent Trace block]"
+  const lines = [
+    `[Quoted Agent Trace block · ${itemKindLabel(item)} · ${item.title}]`,
+    "",
+  ]
+  appendContent(lines, item.kind === "change" ? "Patch" : "Input", item.detail)
+  if (item.resultDetail) appendContent(lines, "Result", item.resultDetail)
+  lines.push(close)
+  const full = lines.join("\n").replace(/\n{3,}/g, "\n\n")
+  if (full.length <= QUOTE_LIMIT) return full
+  const suffix = `\n\n[quoted block truncated]\n${close}`
+  return `${full.slice(0, QUOTE_LIMIT - suffix.length).trimEnd()}${suffix}`
+}

--- a/packages/kobe-web/test/execution-grid.test.tsx
+++ b/packages/kobe-web/test/execution-grid.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { ExecutionGrid } from "../src/components/ExecutionGrid.tsx"
 import type { TimelineItem } from "../src/lib/timeline.ts"
 
@@ -30,8 +36,10 @@ const tool: TimelineItem = {
   status: "success",
   title: "exec",
   summary: "sed -n '1,120p' test.ts",
-  detail: '{\n  "cmd": "sed -n \'1,120p\' test.ts"\n}',
-  resultDetail: "The fixture still uses protocol version 1.",
+  detail:
+    '{\n  "cmd": "sed -n \'1,120p\' test.ts",\n  "workdir": "/repo",\n  "yield_time_ms": 10000\n}',
+  resultDetail:
+    '{"output":"The fixture still uses protocol version 1.","exit_code":0}',
   startedAt: 1_100,
   endedAt: 1_500,
 }
@@ -98,9 +106,37 @@ describe("ExecutionGrid", () => {
     expect(screen.getByText("temporal link")).toBeTruthy()
     expect(screen.getByText("Input")).toBeTruthy()
     expect(screen.getByText("Result")).toBeTruthy()
+    expect(screen.getByText("Command")).toBeTruthy()
+    expect(screen.getByText("Working directory")).toBeTruthy()
+    expect(screen.getByText("10 s")).toBeTruthy()
     expect(
       screen.getByText("The fixture still uses protocol version 1."),
     ).toBeTruthy()
+  })
+
+  it("quotes a readable block into the next input", async () => {
+    const onQuote = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ExecutionGrid
+        items={[tool]}
+        status="success"
+        now={2_000}
+        onQuote={onQuote}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Open Tool details/ }))
+    fireEvent.click(
+      screen.getByRole("button", { name: "Quote to input" }),
+    )
+    await waitFor(() => expect(onQuote).toHaveBeenCalledOnce())
+    expect(onQuote.mock.calls[0]?.[0]).toContain(
+      "[Quoted Agent Trace block · Tool · exec]",
+    )
+    expect(onQuote.mock.calls[0]?.[0]).toContain(
+      "Command:\nsed -n '1,120p' test.ts",
+    )
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
   })
 
   it("renders patch, explicit retry, and subagent completion details", () => {

--- a/packages/kobe-web/test/pty-session-lifecycle.test.ts
+++ b/packages/kobe-web/test/pty-session-lifecycle.test.ts
@@ -262,6 +262,27 @@ describe("createPtySessionManager", () => {
     expect(ptys[0].writes).toEqual(["\x1b[200~hello\x1b[201~", "\r"])
   })
 
+  it("inserts a quote into an existing PTY without submitting", async () => {
+    const onTerminalCommit = vi.fn()
+    const { manager, ptys } = setup({ onTerminalCommit })
+    await manager.ensureSession("tab", "task", "engine", 80, 24)
+
+    expect(
+      manager.insertText({
+        tabId: "tab",
+        text: "quoted\r\nblock\x1b[201~\runsafe",
+      }),
+    ).toEqual({ inserted: true, missing: false })
+    expect(ptys[0].writes).toEqual([
+      "\x1b[200~quoted\nblock[201~\nunsafe\x1b[201~",
+    ])
+    expect(onTerminalCommit).not.toHaveBeenCalled()
+    expect(manager.insertText({ tabId: "missing", text: "x" })).toEqual({
+      inserted: false,
+      missing: true,
+    })
+  })
+
   it("closes sockets and clears the session on process exit", async () => {
     const { manager, ptys } = setup()
     const ws = new FakeSocket()

--- a/packages/kobe-web/test/pty-url.test.ts
+++ b/packages/kobe-web/test/pty-url.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { ptyUrl } from "../src/lib/terminal.ts"
+import { insertPtyText, ptyUrl } from "../src/lib/terminal.ts"
 
 /**
  * ptyUrl builds the PTY WebSocket URL — a bug here breaks every terminal tab.
@@ -46,5 +46,23 @@ describe("ptyUrl", () => {
     withLocation({ port: "" })
     // empty port → defaults to 5173 → +2 = 5175
     expect(ptyUrl("t", "k", "shell", 80, 24)).toContain(":5175/")
+  })
+
+  it("inserts quoted text through the no-submit PTY endpoint", async () => {
+    withLocation({ port: "5173" })
+    const fetch = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify({ inserted: true }))),
+    )
+    vi.stubGlobal("fetch", fetch)
+
+    await insertPtyText("tab-1", "quoted block")
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5175/pty/insert",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ tab: "tab-1", text: "quoted block" }),
+      }),
+    )
   })
 })

--- a/packages/kobe-web/test/trace-content.test.ts
+++ b/packages/kobe-web/test/trace-content.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import type { TimelineItem } from "../src/lib/timeline.ts"
+import {
+  quoteTraceItem,
+  readableTraceContent,
+} from "../src/lib/trace-content.ts"
+
+const tool: TimelineItem = {
+  id: "tool-1",
+  turnId: "turn-1",
+  parentId: null,
+  parentBasis: "none",
+  kind: "tool",
+  status: "success",
+  title: "exec",
+  summary: "git status",
+  detail:
+    '{"cmd":"git status --short","workdir":"/repo","yield_time_ms":10000,"max_output_tokens":3000}',
+  resultDetail:
+    '{"output":" M src/app.ts","exit_code":0,"wall_time_seconds":1.5}',
+  startedAt: 1,
+  endedAt: 2,
+}
+
+describe("trace content presentation", () => {
+  it("turns JSON-shaped tool input into labeled human-readable fields", () => {
+    expect(readableTraceContent("Input", tool.detail)).toEqual([
+      { label: "Command", text: "git status --short", tone: "code" },
+      { label: "Working directory", text: "/repo", tone: "value" },
+      { label: "Wait", text: "10 s", tone: "value" },
+      { label: "Output limit", text: "3,000 tokens", tone: "value" },
+    ])
+  })
+
+  it("keeps plain prose intact instead of treating it as JSON", () => {
+    expect(readableTraceContent("Reasoning summary", "Inspect the adapter first.")).toEqual([
+      {
+        label: "Reasoning summary",
+        text: "Inspect the adapter first.",
+        tone: "prose",
+      },
+    ])
+  })
+
+  it("builds a self-contained block reference for the next prompt", () => {
+    const quote = quoteTraceItem(tool)
+    expect(quote).toContain("[Quoted Agent Trace block · Tool · exec]")
+    expect(quote).toContain("Command:\ngit status --short")
+    expect(quote).toContain("Working directory:\n/repo")
+    expect(quote).toContain("Exit code:\n0 · success")
+    expect(quote).toContain("[/Quoted Agent Trace block]")
+  })
+
+  it("keeps oversized quotes inside the input cap with one closing marker", () => {
+    const quote = quoteTraceItem({ ...tool, resultDetail: "x".repeat(20_000) })
+    expect(quote.length).toBeLessThanOrEqual(16_000)
+    expect(quote).toContain("[quoted block truncated]")
+    expect(quote.match(/\[\/Quoted Agent Trace block\]/g)).toHaveLength(1)
+    expect(quote.endsWith("[/Quoted Agent Trace block]")).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- format JSON-shaped Agent Trace input and result payloads as labeled, human-readable fields while preserving plain prose
- add a Quote to input action that inserts a bounded, self-contained block reference into the active native engine composer without pressing Enter
- route quote insertion through the existing PTY sidecar, strip terminal control bytes before bracketed paste, restore composer focus, and keep the engine as the owner of editing/submission
- keep the global toast renderer mounted once so chat actions produce one notification

## Verification

- `bun run lint`
- `bun run typecheck`
- `cd packages/kobe-web && bun run lint && bun run test && bun run build` (78 files, 617 tests)
- `cd packages/kobe-desktop && bun run check && bun run test` (3 tests)
- real sandbox Electron + Codex: created a one-turn trace, opened its Result card, clicked Quote to input, observed the full quoted block in the native composer, focus returned to Terminal input, and Agent Trace remained at `1 turn · 1 event` (no implicit submit)
- adversarial lifecycle test verifies CR/ESC control bytes are stripped and no Enter or terminal-commit event is emitted

## Release

Patch changeset included for `@sma1lboy/kobe`.