### PR TITLE
Make Agent Trace readable, quotable, and resume-safe

### DIFF
--- a/.changeset/atomic-engine-session-binding.md
+++ b/.changeset/atomic-engine-session-binding.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep Agent Trace aligned with the process visible in its chat tab. A newly
+spawned engine with no native session id renders an empty trace instead of the
+previous conversation, then binds in place when the id arrives; daemon startup
+also converts abandoned pending runs to this stable empty state. Codex engine
+processes are now watched continuously by the daemon, so native `/resume`
+switches no longer depend on a terminal Enter notification. Agent Trace uses
+one shared session snapshot stream, eliminating the competing history-fetch
+race that could leave a resumed run empty.

--- a/.changeset/readable-trace-quotes.md
+++ b/.changeset/readable-trace-quotes.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Make Agent Trace details easier to read by labeling structured tool inputs and results, and let users quote any trace block into the active native composer for editing without automatically sending the next turn.

--- a/.changeset/readable-trace-quotes.md
+++ b/.changeset/readable-trace-quotes.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-Make Agent Trace details easier to read by labeling structured tool inputs and results, and let users quote any trace block into the active native composer for editing without automatically sending the next turn.
+Make Agent Trace details easier to read by labeling structured tool inputs and results. Trace cards can now be quoted directly into a tab-scoped, removable composer buffer that is serialized into the native engine input only when the user submits the next turn.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -273,12 +273,15 @@ entry; do not add vendor parsing to React components.
 
 Opening a trace card formats JSON-shaped input and result details into labeled
 fields such as command, working directory, duration, exit code, and output;
-plain text stays intact. **Quote to input** inserts a bounded, self-contained
-reference to that card into the active engine's native composer. It uses
-bracketed paste without Enter, strips terminal control bytes, and returns focus
-to the composer, so the user can edit the reference and decide whether to send
-the next turn. This is a presentation/interaction layer over `EngineTrace` —
-the frontend still does not read vendor transcripts or own conversation state.
+plain text stays intact. A card's quote control adds a bounded,
+self-contained reference to a tab-scoped buffer beside the active engine's
+native composer; opening the detail drawer is optional. Buffered references
+stay structured and individually removable until plain Enter submits the next
+turn. At that boundary the client serializes them and strips terminal control
+bytes; the sidecar then delivers the result through bracketed paste and lets
+the native engine submit. Shift+Enter and IME composition remain engine-owned.
+This is a presentation/interaction layer over `EngineTrace` — the frontend
+still does not read vendor transcripts or own conversation history.
 
 ## Launching and resuming sessions
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -271,6 +271,15 @@ output. To add another engine, implement `readTrace` (and optionally
 `traceRevision` plus normalized live hook details) in that engine's registry
 entry; do not add vendor parsing to React components.
 
+Opening a trace card formats JSON-shaped input and result details into labeled
+fields such as command, working directory, duration, exit code, and output;
+plain text stays intact. **Quote to input** inserts a bounded, self-contained
+reference to that card into the active engine's native composer. It uses
+bracketed paste without Enter, strips terminal control bytes, and returns focus
+to the composer, so the user can edit the reference and decide whether to send
+the next turn. This is a presentation/interaction layer over `EngineTrace` —
+the frontend still does not read vendor transcripts or own conversation state.
+
 ## Launching and resuming sessions
 
 Every launch site resolves the engine argv the same way

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -125,29 +125,39 @@ not kobe.
   (vendors that can't take a caller-set id, like Codex, are left untouched).
 - The daemon persists the neutral identity chain
   `Task -> Terminal Tab -> current EngineRun -> native Engine Session` in
-  `<KOBE_HOME>/.kobe/session-bindings.json`. A run starts as `pending`, becomes
-  `bound` when the engine supplies its native id (spawn-time for Claude,
-  hook-time for Codex), and may later become `ended` or `superseded` without
-  losing the transcript identity. The file retains prior run pointers so a
-  tab changing conversations does not rewrite history; conversation content
-  remains exclusively in the engine's own transcript store.
+  `<KOBE_HOME>/.kobe/session-bindings.json`. Starting a new engine process moves
+  the current pointer to an unidentified run immediately: the trace is empty,
+  never borrowed from the tab's previous conversation. The engine then supplies
+  its native id (spawn-time for Claude, hook- or observer-time for Codex) and
+  binds that same run. A daemon restart turns an abandoned `pending` run into
+  the same empty state instead of loading forever or attaching historical
+  identity. Runs may later become `ended` or `superseded` without losing their
+  transcript identity. The file retains prior runs so changing conversations
+  does not rewrite history; content remains in the engine's transcript store.
 - Claude Code and Codex `SessionStart` hooks provide `startup`, `resume`,
   `clear`, or `compact`. Kobe creates a fresh `runId` for the first three
   causes (after filling any pending launch) and keeps the current run for
   `compact`. Consequently, exiting and later resuming a conversation produces
   a new run with the same native `sessionId`.
 - Codex's native `/resume` picker changes conversation before it emits the
-  deferred `SessionStart`. In the browser/Electron PTY path, Enter triggers a
-  bounded adapter observation window keyed by that tab's process id. The Codex
-  adapter reads exact structured resume evidence from Codex's local log
-  database. A `thread/resume` span first publishes an in-memory transition so
-  Agent Trace enters loading before Codex finishes restoring the selected
-  thread; the transition never replaces or persists the current run. A rollout
-  path, or the selected `thread.id` when no path exists, then binds the new run
-  and clears the transition. The later hook confirms that same run. Kobe never
-  parses picker rows or terminal pixels. If the internal log format is absent
-  or changes, the observer returns nothing and the ordinary hook remains the
+  deferred `SessionStart`. In the browser/Electron PTY path, the sidecar
+  registers the tab's engine process when it spawns and heartbeats that lease;
+  the daemon continuously asks the selected engine adapter for context changes.
+  The Codex adapter reads exact structured resume evidence from Codex's local
+  log database behind an opaque monotonic cursor. A `thread/resume` span first
+  publishes an in-memory transition so Agent Trace enters loading before Codex
+  finishes restoring the selected thread; the transition never replaces or
+  persists the current run. A rollout path, or the selected `thread.id` when no
+  path exists, then binds the new run and clears the transition. Heartbeat
+  re-registration restores the monitor after a daemon restart without changing
+  the PTY process. The later hook confirms that same run. Kobe never parses
+  picker rows or terminal pixels. If the internal log format is absent or
+  changes, the observer returns nothing and the ordinary hook remains the
   compatibility fallback.
+- Agent Trace snapshots are keyed by the bound native session. The daemon shares
+  one engine-owned revision/history poll per active session and broadcasts full
+  reconnect-safe snapshots; the frontend only selects the current task/tab and
+  never races a separate history fetch against that stream.
 - Current-run pointers and run history survive a daemon restart. New clients consume the binding
   snapshot directly; they do not choose a transcript from visible terminal
   pixels or from whichever history file happens to be newest.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -26,6 +26,7 @@
     "./daemon/crash-log": "./src/daemon/crash-log.ts",
     "./daemon/cwd-task": "./src/daemon/cwd-task.ts",
     "./daemon/engine-events-log": "./src/daemon/engine-events-log.ts",
+    "./daemon/engine-session-monitor": "./src/daemon/engine-session-monitor.ts",
     "./daemon/event-bus": "./src/daemon/event-bus.ts",
     "./daemon/file-watch-trigger": "./src/daemon/file-watch-trigger.ts",
     "./daemon/issues-store": "./src/daemon/issues-store.ts",

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -13,7 +13,7 @@ export interface EngineRun {
   readonly taskId: string
   readonly tabId: string
   readonly vendor: VendorId
-  /** Null while the engine has started but has not reported its native id. */
+  /** Null until the launched engine process reports its native id. */
   readonly sessionId: string | null
   readonly state: "pending" | "bound" | "ended" | "superseded" | "missing"
   /** Which authoritative boundary supplied the current identity. */

--- a/packages/kobe-daemon/src/daemon/engine-session-monitor.ts
+++ b/packages/kobe-daemon/src/daemon/engine-session-monitor.ts
@@ -1,0 +1,158 @@
+/** Continuously maps a tab-owned engine process to its active native context. */
+
+import type { DaemonActivityRegistry } from "./activity-registry.ts"
+import type { DaemonOrchestrator, VendorId } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
+import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import type { SessionBindingStore } from "./session-bindings.ts"
+
+export interface EngineProcessWatch {
+  readonly taskId: string
+  readonly tabId: string
+  readonly vendor: VendorId
+  readonly rootPid: number
+  readonly startedAt: number
+}
+
+interface WatchState extends EngineProcessWatch {
+  generation: number
+  cursor?: string
+  leaseAt: number
+  inFlight: boolean
+}
+
+export interface EngineSessionMonitorOptions {
+  readonly pollMs?: number
+  readonly leaseMs?: number
+  readonly now?: () => number
+  readonly setIntervalFn?: typeof setInterval
+  readonly clearIntervalFn?: typeof clearInterval
+}
+
+function keyOf(value: Pick<EngineProcessWatch, "taskId" | "tabId">): string {
+  return `${value.taskId}\0${value.tabId}`
+}
+
+export class EngineSessionMonitor {
+  private readonly watches = new Map<string, WatchState>()
+  private readonly now: () => number
+  private readonly leaseMs: number
+  private readonly timer: ReturnType<typeof setInterval>
+
+  constructor(
+    private readonly orch: Pick<DaemonOrchestrator, "getTask">,
+    private readonly runtime: Pick<DaemonRuntimeAdapter, "observeEngineSessionActivation">,
+    private readonly bindings: Pick<SessionBindingStore, "bind" | "markTransition">,
+    private readonly activity: Pick<DaemonActivityRegistry, "pinTabSession">,
+    options: EngineSessionMonitorOptions = {},
+  ) {
+    this.now = options.now ?? Date.now
+    this.leaseMs = options.leaseMs ?? 15_000
+    const setIntervalFn = options.setIntervalFn ?? setInterval
+    this.timer = setIntervalFn(() => void this.tick(), options.pollMs ?? 350)
+    this.timer.unref?.()
+    this.clearIntervalFn = options.clearIntervalFn ?? clearInterval
+  }
+
+  private readonly clearIntervalFn: typeof clearInterval
+
+  watch(input: EngineProcessWatch): void {
+    const key = keyOf(input)
+    const current = this.watches.get(key)
+    if (current && input.startedAt < current.startedAt) return
+    if (
+      current?.rootPid === input.rootPid &&
+      current.vendor === input.vendor &&
+      current.startedAt === input.startedAt
+    ) {
+      current.leaseAt = this.now()
+      return
+    }
+    this.watches.set(key, {
+      ...input,
+      generation: (current?.generation ?? 0) + 1,
+      leaseAt: this.now(),
+      inFlight: false,
+    })
+    void this.check(key)
+  }
+
+  unwatch(input: Pick<EngineProcessWatch, "taskId" | "tabId" | "rootPid">): boolean {
+    const key = keyOf(input)
+    const current = this.watches.get(key)
+    if (!current || current.rootPid !== input.rootPid) return false
+    return this.watches.delete(key)
+  }
+
+  async tick(): Promise<void> {
+    const now = this.now()
+    const checks: Promise<void>[] = []
+    for (const [key, watch] of this.watches) {
+      if (now - watch.leaseAt > this.leaseMs) {
+        this.watches.delete(key)
+        continue
+      }
+      checks.push(this.check(key))
+    }
+    await Promise.all(checks)
+  }
+
+  close(): void {
+    this.clearIntervalFn(this.timer)
+    this.watches.clear()
+  }
+
+  size(): number {
+    return this.watches.size
+  }
+
+  private async check(key: string): Promise<void> {
+    const watch = this.watches.get(key)
+    if (!watch || watch.inFlight) return
+    watch.inFlight = true
+    const generation = watch.generation
+    try {
+      if (!this.orch.getTask(watch.taskId)) {
+        this.watches.delete(key)
+        return
+      }
+      const activation = await this.runtime.observeEngineSessionActivation(
+        watch.vendor,
+        watch.rootPid,
+        watch.startedAt,
+        watch.cursor,
+      )
+      const current = this.watches.get(key)
+      if (!activation || current !== watch || current.generation !== generation) return
+      if (activation.phase === "pending") {
+        current.cursor = activation.cursor
+        this.bindings.markTransition({
+          taskId: watch.taskId,
+          tabId: watch.tabId,
+          vendor: watch.vendor,
+          startSource: activation.source,
+          observedAt: activation.observedAt,
+        })
+        return
+      }
+      await this.bindings.bind({
+        taskId: watch.taskId,
+        tabId: watch.tabId,
+        vendor: watch.vendor,
+        sessionId: activation.sessionId,
+        source: "observer",
+        startSource: activation.source,
+        ...(activation.transcriptPath ? { transcriptPath: activation.transcriptPath } : {}),
+      })
+      if (this.watches.get(key) === watch) {
+        watch.cursor = activation.cursor
+        this.activity.pinTabSession(watch.taskId, watch.tabId, activation.sessionId)
+      }
+    } catch (error) {
+      logDaemonError("engine-session-monitor", error)
+    } finally {
+      const current = this.watches.get(key)
+      if (current === watch) current.inFlight = false
+    }
+  }
+}

--- a/packages/kobe-daemon/src/daemon/handlers-engine.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-engine.ts
@@ -41,10 +41,37 @@ export const ENGINE_HANDLERS: readonly DaemonRequestHandler[] = [
     },
   },
   {
+    name: "engine.watchSession",
+    web: true,
+    handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      const rootPid = requireNumber(payload, "rootPid")
+      const startedAt = requireNumber(payload, "startedAt")
+      if (!Number.isInteger(rootPid) || rootPid <= 0) throw new Error("rootPid must be a positive integer")
+      if (!Number.isFinite(startedAt) || startedAt < 0) throw new Error("startedAt must be a non-negative number")
+      const task = ctx.orch.getTask(taskId)
+      if (!task) throw new Error(`task not found: ${taskId}`)
+      const vendor = optionalString(payload, "vendor") ?? task.vendor ?? ctx.runtime.defaultTaskVendor
+      ctx.engineSessionMonitor.watch({ taskId, tabId, vendor, rootPid, startedAt })
+      return { watching: true }
+    },
+  },
+  {
+    name: "engine.unwatchSession",
+    web: true,
+    handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      const rootPid = requireNumber(payload, "rootPid")
+      if (!Number.isInteger(rootPid) || rootPid <= 0) throw new Error("rootPid must be a positive integer")
+      return { removed: ctx.engineSessionMonitor.unwatch({ taskId, tabId, rootPid }) }
+    },
+  },
+  {
     name: "engine.observeSession",
-    // The localhost PTY sidecar calls this after a terminal commit. It carries
-    // no transcript bytes and can only ask the adapter to inspect the supplied
-    // process; the daemon still validates task/tab ownership before binding.
+    // Backward-compatible one-shot path. New sidecars lease a continuous
+    // daemon monitor through engine.watchSession instead.
     web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -34,6 +34,7 @@ import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import type { AttentionInboxStore } from "./attention-inbox.ts"
 import type { AutomationsStore } from "./automations-store.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
+import type { EngineSessionMonitor } from "./engine-session-monitor.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import { objectPayload, requireString } from "./handler-validators.ts"
 import { ATTENTION_HANDLERS } from "./handlers-attention.ts"
@@ -89,6 +90,8 @@ export interface DaemonHandlerContext {
   readonly inbox: AttentionInboxStore
   /** Durable Terminal Tab -> native engine-session identities. */
   readonly bindings: SessionBindingStore
+  /** Ephemeral process watches that continuously update durable bindings. */
+  readonly engineSessionMonitor: EngineSessionMonitor
   /** Starts deduplicated durable background deletion after RPC acceptance. */
   readonly deletions: TaskDeletionScheduler
   /** Daemon-owned issue tracker store, keyed by git common-dir. */

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -52,8 +52,12 @@ export {
  * event frames). Additive — an older client never sends `pty.*`, a newer
  * client against an older daemon gets "unknown daemon request" and falls back
  * to a local PTY — so MIN stays 2.
+ *
+ * v5: additive `engine.watchSession` / `engine.unwatchSession` process leases
+ * let a browser PTY sidecar hand continuous native-context observation to the
+ * daemon. Older peers keep using hooks or the one-shot observer, so MIN stays 2.
  */
-export const DAEMON_PROTOCOL_VERSION = 4
+export const DAEMON_PROTOCOL_VERSION = 5
 
 /** Oldest protocol version this build can still interoperate with. */
 export const MIN_COMPATIBLE_PROTOCOL_VERSION = 2
@@ -167,13 +171,15 @@ export type DaemonRequestName =
   // normalized engine activity event for a task; the daemon folds it into
   // the task's transient activity state and broadcasts `engine-state`.
   | "engine.reportEvent"
-  // Spawn-time session pin: the engine spec injected a caller-set session id
-  // (claude `--session-id`), record + broadcast it for tab-precise traces.
+  // Begin an unidentified process run, then atomically pin it when the engine
+  // accepts a caller-set session id.
   | "engine.beginSession"
   | "engine.pinSession"
-  // Sidecar commit observation: ask the engine adapter whether the PTY's
-  // native conversation changed before its ordinary hook fires.
+  // Legacy one-shot observation plus the continuous process lease used by the
+  // browser PTY sidecar. Provider parsing stays behind the engine adapter.
   | "engine.observeSession"
+  | "engine.watchSession"
+  | "engine.unwatchSession"
   // Remove the durable Inbox item at the supplied event timestamp. Explicit
   // removal, opening, and visiting the target all use this guarded operation.
   | "attention.dismiss"

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -56,11 +56,13 @@ export interface DaemonRuntimeAdapter {
     vendor: VendorId,
     rootPid: number,
     afterMs: number,
+    afterCursor?: string,
   ): Promise<
     | {
         phase: "pending"
         source: "resume"
         observedAt: number
+        cursor: string
       }
     | {
         phase: "selected"
@@ -68,6 +70,7 @@ export interface DaemonRuntimeAdapter {
         transcriptPath?: string
         source: "resume"
         observedAt: number
+        cursor: string
       }
     | null
   >

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -34,6 +34,7 @@ import { startDaemonCollectors } from "./collectors.ts"
 import type { DaemonOrchestrator, UpdateInfo } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import { EngineEventLog } from "./engine-events-log.ts"
+import { EngineSessionMonitor } from "./engine-session-monitor.ts"
 import { DaemonEventBus } from "./event-bus.ts"
 import {
   type DaemonHandlerContext,
@@ -195,6 +196,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   const quotaUsage = new QuotaUsageCache(runtime, bus)
   // Per-task recent engine events (the TUI event feed / task.recentEvents).
   const engineEvents = new EngineEventLog()
+  const engineSessionMonitor = new EngineSessionMonitor(orch, runtime, bindings, activity)
 
   await mkdir(dirname(socketPath), { recursive: true })
   await mkdir(dirname(pidPath), { recursive: true })
@@ -321,6 +323,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       pluginHost?.stop()
       prompts.clear()
       activity.close()
+      engineSessionMonitor.close()
       // Hosted PTYs are deliberately NOT touched here: they live in the
       // standalone `kobe pty-host` process, so `kobe daemon restart` never
       // ends a running engine session — only `kobe reset` does.
@@ -374,6 +377,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       activity,
       inbox,
       bindings,
+      engineSessionMonitor,
       deletions,
       issues,
       automations,

--- a/packages/kobe-daemon/src/daemon/session-bindings.ts
+++ b/packages/kobe-daemon/src/daemon/session-bindings.ts
@@ -173,7 +173,17 @@ export class SessionBindingStore {
       this.transitions.clear()
       for (const run of loaded.runs) this.runs.set(run.runId, run)
       for (const ref of loaded.currentRuns) this.currentRunIds.set(bindingKey(ref), ref.runId)
-      if (loaded.migrated) await this.persist()
+      const pendingRuns = this.currentRuns().filter((run) => run.state === "pending")
+      const repairedAt = pendingRuns.length ? this.now() : 0
+      for (const pending of pendingRuns) {
+        this.runs.set(pending.runId, {
+          ...pending,
+          state: "missing",
+          endedAt: pending.endedAt ?? repairedAt,
+          updatedAt: repairedAt,
+        })
+      }
+      if (loaded.migrated || pendingRuns.length) await this.persist()
       this.publish()
     })
   }
@@ -242,11 +252,6 @@ export class SessionBindingStore {
   async begin(taskId: string, tabId: string, vendor: VendorId): Promise<EngineSessionBinding> {
     return await this.enqueue(async () => {
       const previous = this.currentRun({ taskId, tabId })
-      // The PTY sidecar asks for engine-spec only when it is about to spawn a
-      // process; socket reattach reuses the existing sidecar session. Mark the
-      // run before spawn so a prompt supplied on argv cannot begin before the
-      // run's time window. Duplicate begin calls while that spawn is pending
-      // remain idempotent.
       if (previous?.vendor === vendor && previous.state === "pending") return previous
       const next = this.newRun({ taskId, tabId, vendor, source: "spawn" })
       await this.replaceCurrent(next, previous)

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -123,7 +123,7 @@ function sseResponse(register: (send: SseSend) => () => void, signal?: AbortSign
         } catch {
           cleanup()
         }
-      }, 15_000)
+      }, 3_000)
       if (signal?.aborted) cleanup()
       else signal?.addEventListener("abort", cleanup, { once: true })
     },
@@ -263,6 +263,19 @@ async function specResponse(
   }
 }
 
+export async function prepareEngineSpecSession(
+  link: DaemonRpcClient,
+  taskId: string,
+  tabId?: string,
+  vendor?: string,
+  sessionId?: string,
+): Promise<void> {
+  if (!tabId) return
+  await link.request("engine.beginSession", { taskId, tabId, ...(vendor ? { vendor } : {}) })
+  if (!sessionId) return
+  await link.request("engine.pinSession", { taskId, tabId, sessionId, ...(vendor ? { vendor } : {}) })
+}
+
 const QUICK_PROMPT_KEYS = {
   review: "boardPrompt.review",
   pr: "boardPrompt.pr",
@@ -327,21 +340,7 @@ export function createDaemonWebRequestHandler(deps: RequestHandlerDeps): (req: R
       const tab = url.searchParams.get("tab") ?? undefined
       return specResponse(url, link, async (l, id) => {
         const spec = await engineSpec(runtime, l, id, vendor, tab)
-        if (tab) {
-          await l.request("engine.beginSession", { taskId: id, tabId: tab, ...(vendor ? { vendor } : {}) })
-        }
-        // Spawn-time pin: broadcast the injected session id so the Agent
-        // Trace keys to this tab's session before the engine boots.
-        if (spec.sessionId && tab) {
-          await l
-            .request("engine.pinSession", {
-              taskId: id,
-              tabId: tab,
-              sessionId: spec.sessionId,
-              ...(vendor ? { vendor } : {}),
-            })
-            .catch(() => {})
-        }
+        await prepareEngineSpecSession(l, id, tab, vendor, spec.sessionId)
         return spec
       })
     }

--- a/packages/kobe-web/engine-session-observer.mjs
+++ b/packages/kobe-web/engine-session-observer.mjs
@@ -1,46 +1,53 @@
-/**
- * Neutral PTY-side trigger for engine-owned session observation.
- *
- * The sidecar knows tab/process identity but not provider log formats. After a
- * terminal commit it asks the daemon to run the selected engine adapter. A
- * bounded retry window covers both the provider persisting its activation and
- * a resumed app-server thread completing startup after Enter reaches the PTY.
- */
+/** Registers engine PTY process identity; daemon owns provider observation. */
 
-const DEFAULT_DELAYS_MS = [0, 100, 300, 750, 1500, 3000]
+const DEFAULT_HEARTBEAT_MS = 5_000
 
 export function createEngineSessionObservationClient({
   daemonWebPort,
   fetchFn = fetch,
-  setTimeoutFn = setTimeout,
-  delaysMs = DEFAULT_DELAYS_MS,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  heartbeatMs = DEFAULT_HEARTBEAT_MS,
 }) {
-  const generations = new Map()
+  const watches = new Map()
 
-  function observe({ taskId, tabId, vendor, rootPid }) {
-    if (!taskId || !tabId || !Number.isInteger(rootPid) || rootPid <= 0) return
-    const generation = (generations.get(tabId) ?? 0) + 1
-    generations.set(tabId, generation)
-    for (const delayMs of delaysMs) {
-      const timer = setTimeoutFn(() => {
-        if (generations.get(tabId) !== generation) return
-        void fetchFn(`http://127.0.0.1:${daemonWebPort}/api/rpc`, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            name: "engine.observeSession",
-            payload: { taskId, tabId, rootPid, ...(vendor ? { vendor } : {}) },
-          }),
-        }).catch(() => {})
-      }, delayMs)
-      timer?.unref?.()
+  async function rpc(name, payload) {
+    try {
+      await fetchFn(`http://127.0.0.1:${daemonWebPort}/api/rpc`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name, payload }),
+      })
+    } catch {
+      // Heartbeats reconstruct daemon state after a restart.
     }
   }
 
-  return {
-    observe,
-    forget(tabId) {
-      generations.delete(tabId)
-    },
+  function watch(input) {
+    if (!input.taskId || !input.tabId || !Number.isInteger(input.rootPid) || input.rootPid <= 0) return
+    unwatch(input.tabId)
+    const payload = { ...input, startedAt: Number.isFinite(input.startedAt) ? input.startedAt : Date.now() }
+    void rpc("engine.watchSession", payload)
+    const timer = setIntervalFn(() => void rpc("engine.watchSession", payload), heartbeatMs)
+    timer?.unref?.()
+    watches.set(input.tabId, { payload, timer })
   }
+
+  function unwatch(tabId, rootPid) {
+    const current = watches.get(tabId)
+    if (!current || (rootPid !== undefined && current.payload.rootPid !== rootPid)) return
+    clearIntervalFn(current.timer)
+    watches.delete(tabId)
+    void rpc("engine.unwatchSession", {
+      taskId: current.payload.taskId,
+      tabId: current.payload.tabId,
+      rootPid: current.payload.rootPid,
+    })
+  }
+
+  function close() {
+    for (const tabId of [...watches.keys()]) unwatch(tabId)
+  }
+
+  return { watch, unwatch, close, watchedCount: () => watches.size }
 }

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -116,7 +116,8 @@ const ptySessions = createPtySessionManager({
   createScrollback,
   scrollbackCap: SCROLLBACK_CAP,
   env: ptyEnv,
-  onTerminalCommit: sessionObserver.observe,
+  onEngineSessionStart: sessionObserver.watch,
+  onEngineSessionStop: ({ tabId, rootPid }) => sessionObserver.unwatch(tabId, rootPid),
 })
 
 const server = createServer((req, res) => {

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -10,6 +10,7 @@
  *
  *   ws  /pty?tab=<id>&taskId=<id>&mode=engine|shell&cols=<n>&rows=<n>
  *   POST /pty/close   { tab }                          kill the tab process
+ *   POST /pty/insert  { tab, text }                    paste without Enter
  *   POST /pty/send    { tab, taskId, text }            paste text + Enter into the tab's engine
  */
 
@@ -212,6 +213,49 @@ const server = createServer((req, res) => {
       "access-control-allow-headers": "content-type",
     })
     res.end()
+    return
+  }
+  if (req.method === "POST" && url.pathname === "/pty/insert") {
+    // Inserting text drives the active terminal, so it shares the websocket
+    // origin policy. Unlike /pty/send it never spawns or presses Enter.
+    if (!originAllowed(req.headers.origin, { allowedHost: ALLOWED_HOST })) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
+    let body = ""
+    req.on("data", (c) => {
+      body += c
+    })
+    req.on("end", () => {
+      let tab
+      let text
+      try {
+        ;({ tab, text } = JSON.parse(body || "{}"))
+      } catch {
+        /* ignore */
+      }
+      const respond = (status, payload) => {
+        res.writeHead(status, {
+          "content-type": "application/json",
+          "access-control-allow-origin": "*",
+        })
+        res.end(JSON.stringify(payload))
+      }
+      if (typeof tab !== "string" || !tab || typeof text !== "string" || !text) {
+        respond(400, { inserted: false, error: "tab and text are required" })
+        return
+      }
+      const result = ptySessions.insertText({ tabId: tab, text })
+      if (!result.inserted) {
+        respond(result.missing ? 404 : 500, {
+          inserted: false,
+          error: result.missing ? "no such tab" : "failed to write to tab",
+        })
+        return
+      }
+      respond(200, { inserted: true })
+    })
     return
   }
   if (req.method === "POST" && url.pathname === "/pty/send") {

--- a/packages/kobe-web/pty-session-lifecycle.d.mts
+++ b/packages/kobe-web/pty-session-lifecycle.d.mts
@@ -78,6 +78,11 @@ export interface SendTextInput {
   text: string
 }
 
+export interface InsertTextInput {
+  tabId: string
+  text: string
+}
+
 export interface PtySessionManager {
   attachSocket(input: AttachSocketInput): Promise<unknown>
   closeSession(tabId: string): boolean
@@ -89,6 +94,10 @@ export interface PtySessionManager {
     rows: number,
     vendor?: string,
   ): Promise<unknown>
+  insertText(input: InsertTextInput): {
+    inserted: boolean
+    missing: boolean
+  }
   sendText(input: SendTextInput): Promise<{ sent: boolean; spawned: boolean; missing?: boolean }>
   shutdown(): void
   sessionCount(): number

--- a/packages/kobe-web/pty-session-lifecycle.d.mts
+++ b/packages/kobe-web/pty-session-lifecycle.d.mts
@@ -10,6 +10,7 @@ export interface PtyLaunchSpec {
 }
 
 export interface PtyLike {
+  readonly pid: number
   onData(cb: (data: string) => void): void
   onExit(cb: () => void): void
   write(data: string): void
@@ -59,6 +60,16 @@ export interface PtySessionManagerOptions {
     lowWaterBytes: number
     drainPollMs: number
   }
+  onEngineSessionStart?(input: EngineSessionIdentity): void
+  onEngineSessionStop?(input: Pick<EngineSessionIdentity, "taskId" | "tabId" | "rootPid">): void
+}
+
+export interface EngineSessionIdentity {
+  taskId: string
+  tabId: string
+  vendor?: string
+  rootPid: number
+  startedAt: number
 }
 
 export interface AttachSocketInput {

--- a/packages/kobe-web/pty-session-lifecycle.mjs
+++ b/packages/kobe-web/pty-session-lifecycle.mjs
@@ -73,7 +73,8 @@ export function createPtySessionManager({
   submitDelays = DEFAULT_SUBMIT_DELAYS,
   maxSessions = DEFAULT_MAX_SESSIONS,
   backpressure = DEFAULT_BACKPRESSURE,
-  onTerminalCommit = () => {},
+  onEngineSessionStart = () => {},
+  onEngineSessionStop = () => {},
 }) {
   /** @type {Map<string, { pty: any, scrollback: ReturnType<createScrollback>, sockets: Set<any> }>} */
   const sessions = new Map()
@@ -141,6 +142,7 @@ export function createPtySessionManager({
     const entry = {
       pty,
       ...identity,
+      startedAt: Date.now(),
       scrollback: createScrollback(scrollbackCap),
       sockets: new Set(),
       paused: false,
@@ -154,6 +156,7 @@ export function createPtySessionManager({
       applyBackpressure(entry)
     })
     pty.onExit(() => {
+      stopEngineWatch(tabId, entry)
       clearDrainTimer(entry)
       for (const ws of entry.sockets) {
         if (ws.readyState === ws.OPEN) ws.close(1000, "engine exited")
@@ -161,7 +164,22 @@ export function createPtySessionManager({
       if (sessions.get(tabId) === entry) sessions.delete(tabId)
     })
     sessions.set(tabId, entry)
+    if (entry.mode === "engine") {
+      onEngineSessionStart({
+        taskId: entry.taskId,
+        tabId,
+        vendor: entry.vendor,
+        rootPid: entry.pty.pid,
+        startedAt: entry.startedAt,
+      })
+    }
     return entry
+  }
+
+  function stopEngineWatch(tabId, entry) {
+    if (entry.mode !== "engine" || entry.watchStopped) return
+    entry.watchStopped = true
+    onEngineSessionStop({ taskId: entry.taskId, tabId, rootPid: entry.pty.pid })
   }
 
   async function ensureSession(tabId, taskId, mode, cols, rows, vendor) {
@@ -212,14 +230,6 @@ export function createPtySessionManager({
         }
       }
       safePty(tabId, entry, (pty) => pty.write(text))
-      if (text.includes("\r") && entry.mode === "engine") {
-        onTerminalCommit({
-          taskId: entry.taskId,
-          tabId,
-          vendor: entry.vendor,
-          rootPid: entry.pty.pid,
-        })
-      }
     })
 
     ws.on("close", () => {
@@ -232,6 +242,7 @@ export function createPtySessionManager({
   function closeSession(tabId) {
     const entry = sessions.get(tabId)
     if (!entry) return false
+    stopEngineWatch(tabId, entry)
     clearDrainTimer(entry)
     try {
       entry.pty.kill()
@@ -280,14 +291,6 @@ export function createPtySessionManager({
       setTimeoutFn(() => {
         try {
           target.pty.write("\r")
-          if (target.mode === "engine") {
-            onTerminalCommit({
-              taskId: target.taskId,
-              tabId,
-              vendor: target.vendor,
-              rootPid: target.pty.pid,
-            })
-          }
         } catch {
           /* best-effort */
         }
@@ -297,7 +300,8 @@ export function createPtySessionManager({
   }
 
   function shutdown() {
-    for (const entry of sessions.values()) {
+    for (const [tabId, entry] of sessions) {
+      stopEngineWatch(tabId, entry)
       clearDrainTimer(entry)
       try {
         entry.pty.kill()

--- a/packages/kobe-web/pty-session-lifecycle.mjs
+++ b/packages/kobe-web/pty-session-lifecycle.mjs
@@ -242,6 +242,24 @@ export function createPtySessionManager({
     return true
   }
 
+  /** Paste into an already-hosted PTY without submitting. This is the
+   * composer-fill primitive used by Agent Trace quoting. */
+  function insertText({ tabId, text }) {
+    const entry = sessions.get(tabId)
+    if (!entry) return { inserted: false, missing: true }
+    try {
+      // Trace output is external text. Strip terminal control bytes so it
+      // cannot close the bracketed-paste envelope or synthesize keystrokes.
+      const safeText = text
+        .replace(/\r\n?/g, "\n")
+        .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+      entry.pty.write(`\x1b[200~${safeText}\x1b[201~`)
+      return { inserted: true, missing: false }
+    } catch {
+      return { inserted: false, missing: false }
+    }
+  }
+
   async function sendText({ tabId, taskId, text }) {
     let entry = sessions.get(tabId)
     let spawned = false
@@ -295,6 +313,7 @@ export function createPtySessionManager({
     attachSocket,
     closeSession,
     ensureSession,
+    insertText,
     sendText,
     shutdown,
     sessionCount: () => sessions.size,

--- a/packages/kobe-web/src/components/ChatShell.tsx
+++ b/packages/kobe-web/src/components/ChatShell.tsx
@@ -13,7 +13,14 @@
  */
 
 import { PanelRight } from "lucide-react"
-import { lazy, Suspense, useEffect, useMemo, useState } from "react"
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import { grammarFor } from "../lib/engine-grammar.ts"
 import { useEngines } from "../lib/engines.ts"
 import {
@@ -29,14 +36,14 @@ import {
   useTabsState,
   type VendorTab,
 } from "../lib/tabs.ts"
-import { fetchPtyForeground } from "../lib/terminal.ts"
+import { fetchPtyForeground, insertPtyText } from "../lib/terminal.ts"
+import { pushToast, reportError } from "../lib/toast.ts"
 import { resolveVendor } from "../lib/vendor.ts"
 import { ChatSidebarTree } from "./ChatSidebarTree.tsx"
 import { DaemonBanner } from "./DaemonBanner.tsx"
 import { PaneResizer, usePaneWidth } from "./PaneResizer.tsx"
 import { SessionView } from "./SessionView.tsx"
 import { TimelineHost } from "./TimelineHost.tsx"
-import { Toasts } from "./Toasts.tsx"
 
 // Kanban / Routines render INSIDE the /chat main area (a surface switch, not
 // a route jump) — lazy so the chat-first load doesn't pay for them.
@@ -180,6 +187,7 @@ export function ChatShell() {
   // Active tab's grammar-derived engine liveness (SessionView reports it up).
   // It decorates live status only; the durable binding keeps history visible.
   const [engineLive, setEngineLive] = useState(false)
+  const [quoteFocusRequest, setQuoteFocusRequest] = useState(0)
   // biome-ignore lint/correctness/useExhaustiveDependencies: tab switch resets liveness until the new SessionView reports
   useEffect(() => {
     setEngineLive(false)
@@ -191,6 +199,20 @@ export function ChatShell() {
     selected && tabId ? sessionTransitions[selected.id]?.[tabId] : undefined
   const legacySessionId =
     selected && tabId ? engineTabSessions[selected.id]?.[tabId] : undefined
+  const quoteToInput = useCallback(
+    async (text: string): Promise<void> => {
+      if (!tabId) throw new Error("no active chat tab")
+      try {
+        await insertPtyText(tabId, `\n\n${text}\n\n`)
+        setQuoteFocusRequest((value) => value + 1)
+        pushToast("success", "Quoted block into the next prompt")
+      } catch (err) {
+        reportError("quote block", err)
+        throw err
+      }
+    },
+    [tabId],
+  )
 
   return (
     <div className="flex h-full flex-col bg-bg">
@@ -257,6 +279,7 @@ export function ChatShell() {
                   mode={mode}
                   vendor={vendor}
                   grammar={grammarFor(effectiveVendor ?? selected.vendor)}
+                  focusRequest={quoteFocusRequest}
                   onEngineLive={setEngineLive}
                 />
               )}
@@ -281,10 +304,10 @@ export function ChatShell() {
             legacySessionId={legacySessionId}
             engineActive={engineLive}
             width={traceW}
+            onQuote={quoteToInput}
           />
         )}
       </div>
-      <Toasts />
     </div>
   )
 }

--- a/packages/kobe-web/src/components/ChatShell.tsx
+++ b/packages/kobe-web/src/components/ChatShell.tsx
@@ -36,8 +36,12 @@ import {
   useTabsState,
   type VendorTab,
 } from "../lib/tabs.ts"
-import { fetchPtyForeground, insertPtyText } from "../lib/terminal.ts"
+import { fetchPtyForeground, sendPtyText } from "../lib/terminal.ts"
 import { pushToast, reportError } from "../lib/toast.ts"
+import {
+  type PendingTraceQuote,
+  serializePendingTraceQuotes,
+} from "../lib/trace-content.ts"
 import { resolveVendor } from "../lib/vendor.ts"
 import { ChatSidebarTree } from "./ChatSidebarTree.tsx"
 import { DaemonBanner } from "./DaemonBanner.tsx"
@@ -188,6 +192,9 @@ export function ChatShell() {
   // It decorates live status only; the durable binding keeps history visible.
   const [engineLive, setEngineLive] = useState(false)
   const [quoteFocusRequest, setQuoteFocusRequest] = useState(0)
+  const [quoteBuffers, setQuoteBuffers] = useState<
+    Record<string, readonly PendingTraceQuote[]>
+  >({})
   // biome-ignore lint/correctness/useExhaustiveDependencies: tab switch resets liveness until the new SessionView reports
   useEffect(() => {
     setEngineLive(false)
@@ -199,20 +206,55 @@ export function ChatShell() {
     selected && tabId ? sessionTransitions[selected.id]?.[tabId] : undefined
   const legacySessionId =
     selected && tabId ? engineTabSessions[selected.id]?.[tabId] : undefined
-  const quoteToInput = useCallback(
-    async (text: string): Promise<void> => {
+  const pendingQuotes = tabId ? (quoteBuffers[tabId] ?? []) : []
+  const quoteToBuffer = useCallback(
+    async (quote: PendingTraceQuote): Promise<void> => {
       if (!tabId) throw new Error("no active chat tab")
-      try {
-        await insertPtyText(tabId, `\n\n${text}\n\n`)
-        setQuoteFocusRequest((value) => value + 1)
-        pushToast("success", "Quoted block into the next prompt")
-      } catch (err) {
-        reportError("quote block", err)
-        throw err
-      }
+      setQuoteBuffers((current) => {
+        const buffered = current[tabId] ?? []
+        if (buffered.some((item) => item.sourceId === quote.sourceId))
+          return current
+        return { ...current, [tabId]: [...buffered, quote] }
+      })
+      setQuoteFocusRequest((value) => value + 1)
+      pushToast("success", "Quote added to the next prompt")
     },
     [tabId],
   )
+  const removeBufferedQuote = useCallback(
+    (sourceId: string): void => {
+      if (!tabId) return
+      setQuoteBuffers((current) => ({
+        ...current,
+        [tabId]: (current[tabId] ?? []).filter(
+          (quote) => quote.sourceId !== sourceId,
+        ),
+      }))
+    },
+    [tabId],
+  )
+  const submitBufferedQuotes = useCallback(async (): Promise<void> => {
+    if (!tabId || !selectedTaskId) throw new Error("no active chat tab")
+    const buffered = quoteBuffers[tabId] ?? []
+    if (buffered.length === 0) return
+    const submittedIds = new Set(buffered.map((quote) => quote.sourceId))
+    try {
+      await sendPtyText(
+        tabId,
+        selectedTaskId,
+        serializePendingTraceQuotes(buffered),
+      )
+      setQuoteBuffers((current) => ({
+        ...current,
+        [tabId]: (current[tabId] ?? []).filter(
+          (quote) => !submittedIds.has(quote.sourceId),
+        ),
+      }))
+    } catch (err) {
+      reportError("submit quoted blocks", err)
+      throw err
+    }
+  }, [quoteBuffers, selectedTaskId, tabId])
 
   return (
     <div className="flex h-full flex-col bg-bg">
@@ -280,6 +322,9 @@ export function ChatShell() {
                   vendor={vendor}
                   grammar={grammarFor(effectiveVendor ?? selected.vendor)}
                   focusRequest={quoteFocusRequest}
+                  pendingQuotes={pendingQuotes}
+                  onRemovePendingQuote={removeBufferedQuote}
+                  onSubmitPendingQuotes={submitBufferedQuotes}
                   onEngineLive={setEngineLive}
                 />
               )}
@@ -304,7 +349,7 @@ export function ChatShell() {
             legacySessionId={legacySessionId}
             engineActive={engineLive}
             width={traceW}
-            onQuote={quoteToInput}
+            onQuote={quoteToBuffer}
           />
         )}
       </div>

--- a/packages/kobe-web/src/components/ExecutionGrid.tsx
+++ b/packages/kobe-web/src/components/ExecutionGrid.tsx
@@ -13,7 +13,10 @@ import {
   type TimelineItem,
   type TimelineStatus,
 } from "../lib/timeline.ts"
-import { quoteTraceItem } from "../lib/trace-content.ts"
+import {
+  type PendingTraceQuote,
+  pendingTraceQuote,
+} from "../lib/trace-content.ts"
 import { ReadableTraceContent } from "./ReadableTraceContent.tsx"
 import { SlideOver } from "./SlideOver.tsx"
 import { TracePatch } from "./TracePatch.tsx"
@@ -68,48 +71,65 @@ function ExecutionNode({
   now,
   main = false,
   onOpen,
+  onQuote,
 }: {
   item: TimelineItem
   now: number
   main?: boolean
   onOpen: () => void
+  onQuote?: (quote: PendingTraceQuote) => Promise<void>
 }) {
   return (
-    <button
-      type="button"
-      onClick={onOpen}
-      className={`execution-node relative z-10 flex min-h-24 w-full min-w-0 flex-col border bg-surface p-2.5 text-left focus-visible:border-primary focus-visible:outline-none ${main ? "execution-node--main" : "execution-node--branch"} ${statusClasses(item.status)}`}
-      title={item.summary || item.title}
-      aria-label={`Open ${kindLabel(item)} details: ${item.title}`}
-    >
-      <div className="flex items-center gap-1.5">
-        <ItemIcon item={item} />
-        <span className="text-[10px] text-current">{kindLabel(item)}</span>
-        {(item.attempt ?? 1) > 1 && (
-          <span className="font-mono text-[9px] text-subtle">
-            A{item.attempt}
-          </span>
-        )}
-        {item.status !== "success" && (
-          <span className="ml-auto font-mono text-[9px] text-current">
-            {statusGlyph(item.status)}
-          </span>
-        )}
-      </div>
-      <div
-        className={`mt-2 text-[11px] font-medium leading-[1.45] text-fg ${main ? "line-clamp-4" : "line-clamp-2"}`}
+    <div className="group relative z-10 min-w-0">
+      <button
+        type="button"
+        onClick={onOpen}
+        className={`execution-node relative flex min-h-24 w-full min-w-0 flex-col border bg-surface p-2.5 text-left focus-visible:border-primary focus-visible:outline-none ${main ? "execution-node--main" : "execution-node--branch"} ${statusClasses(item.status)}`}
+        title={item.summary || item.title}
+        aria-label={`Open ${kindLabel(item)} details: ${item.title}`}
       >
-        {item.title}
-      </div>
-      {item.summary && (
-        <div className="mt-1 truncate font-mono text-[9px] text-subtle">
-          {item.summary}
+        <div className="flex items-center gap-1.5">
+          <ItemIcon item={item} />
+          <span className="text-[10px] text-current">{kindLabel(item)}</span>
+          {(item.attempt ?? 1) > 1 && (
+            <span className="font-mono text-[9px] text-subtle">
+              A{item.attempt}
+            </span>
+          )}
+          {item.status !== "success" && (
+            <span className="ml-auto font-mono text-[9px] text-current">
+              {statusGlyph(item.status)}
+            </span>
+          )}
         </div>
+        <div
+          className={`mt-2 text-[11px] font-medium leading-[1.45] text-fg ${main ? "line-clamp-4" : "line-clamp-2"}`}
+        >
+          {item.title}
+        </div>
+        {item.summary && (
+          <div className="mt-1 truncate font-mono text-[9px] text-subtle">
+            {item.summary}
+          </div>
+        )}
+        <div className="mt-auto pt-2 font-mono text-[8px] text-subtle">
+          {formatExecutionDuration(
+            durationMs(item.startedAt, item.endedAt, now),
+          )}
+        </div>
+      </button>
+      {onQuote && (
+        <button
+          type="button"
+          onClick={() => void onQuote(pendingTraceQuote(item)).catch(() => {})}
+          className="absolute bottom-1.5 right-1.5 z-20 grid size-6 place-items-center border border-line bg-bg/95 text-subtle opacity-60 transition-colors hover:border-primary hover:text-fg hover:opacity-100 focus-visible:border-primary focus-visible:text-fg focus-visible:opacity-100 focus-visible:outline-none"
+          aria-label={`Quote ${kindLabel(item)}: ${item.title}`}
+          title="Quote to next prompt"
+        >
+          <Quote size={11} strokeWidth={1.8} />
+        </button>
       )}
-      <div className="mt-auto pt-2 font-mono text-[8px] text-subtle">
-        {formatExecutionDuration(durationMs(item.startedAt, item.endedAt, now))}
-      </div>
-    </button>
+    </div>
   )
 }
 
@@ -125,7 +145,7 @@ function ExecutionDetail({
   parent: TimelineItem | undefined
   retryOf: TimelineItem | undefined
   now: number
-  onQuote?: (text: string) => Promise<void>
+  onQuote?: (quote: PendingTraceQuote) => Promise<void>
   onClose: () => void
 }) {
   const isTool = item?.kind === "tool" || item?.kind === "change"
@@ -169,7 +189,7 @@ function ExecutionDetail({
                 disabled={quoting}
                 onClick={() => {
                   setQuoting(true)
-                  void onQuote(quoteTraceItem(item))
+                  void onQuote(pendingTraceQuote(item))
                     .then(onClose)
                     .catch(() => {})
                     .finally(() => setQuoting(false))
@@ -272,7 +292,7 @@ export function ExecutionGrid({
   items: readonly TimelineItem[]
   status: TimelineStatus
   now: number
-  onQuote?: (text: string) => Promise<void>
+  onQuote?: (quote: PendingTraceQuote) => Promise<void>
   className?: string
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -311,6 +331,7 @@ export function ExecutionGrid({
                 now={now}
                 main
                 onOpen={() => setSelectedId(item.id)}
+                onQuote={onQuote}
               />
               {branch.length > 0 && (
                 <>
@@ -328,6 +349,7 @@ export function ExecutionGrid({
                           item={child}
                           now={now}
                           onOpen={() => setSelectedId(child.id)}
+                          onQuote={onQuote}
                         />
                       </div>
                     ))}

--- a/packages/kobe-web/src/components/ExecutionGrid.tsx
+++ b/packages/kobe-web/src/components/ExecutionGrid.tsx
@@ -4,6 +4,7 @@ import {
   FilePenLine,
   Layers3,
   MessageSquare,
+  Quote,
   TerminalSquare,
 } from "lucide-react"
 import { useState } from "react"
@@ -12,7 +13,8 @@ import {
   type TimelineItem,
   type TimelineStatus,
 } from "../lib/timeline.ts"
-import { CopyButton } from "./CopyButton.tsx"
+import { quoteTraceItem } from "../lib/trace-content.ts"
+import { ReadableTraceContent } from "./ReadableTraceContent.tsx"
 import { SlideOver } from "./SlideOver.tsx"
 import { TracePatch } from "./TracePatch.tsx"
 
@@ -111,39 +113,24 @@ function ExecutionNode({
   )
 }
 
-function DetailSection({ label, text }: { label: string; text: string }) {
-  return (
-    <section className="rounded border border-line bg-surface">
-      <header className="flex h-9 items-center gap-2 border-b border-line px-3">
-        <span className="text-[11px] text-muted">{label}</span>
-        <CopyButton
-          text={text}
-          label={`Copy ${label.toLowerCase()}`}
-          className="ml-auto"
-        />
-      </header>
-      <pre className="max-h-[48vh] overflow-auto whitespace-pre-wrap break-words p-3 font-mono text-[11px] leading-relaxed text-fg">
-        {text || "(empty)"}
-      </pre>
-    </section>
-  )
-}
-
 function ExecutionDetail({
   item,
   parent,
   retryOf,
   now,
+  onQuote,
   onClose,
 }: {
   item: TimelineItem | undefined
   parent: TimelineItem | undefined
   retryOf: TimelineItem | undefined
   now: number
+  onQuote?: (text: string) => Promise<void>
   onClose: () => void
 }) {
   const isTool = item?.kind === "tool" || item?.kind === "change"
   const hasResult = isTool || item?.kind === "subagent"
+  const [quoting, setQuoting] = useState(false)
   return (
     <SlideOver
       open={item !== undefined}
@@ -175,6 +162,24 @@ function ExecutionDetail({
               <span className="rounded-full border border-line px-1.5 py-0.5 text-muted">
                 attempt {item.attempt}
               </span>
+            )}
+            {onQuote && (
+              <button
+                type="button"
+                disabled={quoting}
+                onClick={() => {
+                  setQuoting(true)
+                  void onQuote(quoteTraceItem(item))
+                    .then(onClose)
+                    .catch(() => {})
+                    .finally(() => setQuoting(false))
+                }}
+                className="ml-auto flex items-center gap-1.5 rounded-sm border border-line px-2 py-1 font-sans text-[10px] text-muted transition-colors hover:border-primary hover:text-fg disabled:opacity-50"
+                title="Insert this block into the current prompt without sending"
+              >
+                <Quote size={11} strokeWidth={1.8} />
+                {quoting ? "Quoting…" : "Quote to input"}
+              </button>
             )}
           </div>
           {retryOf && (
@@ -211,7 +216,7 @@ function ExecutionDetail({
           {item.kind === "change" ? (
             <TracePatch patch={item.detail} />
           ) : (
-            <DetailSection
+            <ReadableTraceContent
               label={
                 item.kind === "tool"
                   ? "Input"
@@ -229,7 +234,7 @@ function ExecutionDetail({
             />
           )}
           {hasResult && (
-            <DetailSection
+            <ReadableTraceContent
               label={item.kind === "subagent" ? "Subagent result" : "Result"}
               text={item.resultDetail ?? "No result recorded yet."}
             />
@@ -261,11 +266,13 @@ export function ExecutionGrid({
   items,
   status,
   now,
+  onQuote,
   className = "",
 }: {
   items: readonly TimelineItem[]
   status: TimelineStatus
   now: number
+  onQuote?: (text: string) => Promise<void>
   className?: string
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null)
@@ -341,6 +348,7 @@ export function ExecutionGrid({
         parent={parent}
         retryOf={retryOf}
         now={now}
+        onQuote={onQuote}
         onClose={() => setSelectedId(null)}
       />
     </>

--- a/packages/kobe-web/src/components/InputMirror.tsx
+++ b/packages/kobe-web/src/components/InputMirror.tsx
@@ -7,7 +7,9 @@
  */
 
 import { CornerDownLeft } from "lucide-react"
+import type { PendingTraceQuote } from "../lib/trace-content.ts"
 import { TokenizedText } from "./TokenizedText.tsx"
+import { TraceQuoteBuffer } from "./TraceQuoteBuffer.tsx"
 
 const caret = (
   <span className="inline-block h-[1.05em] w-[2px] animate-pulse bg-primary align-text-bottom" />
@@ -18,6 +20,9 @@ export function InputMirror({
   composing,
   caretOffset,
   sessionId,
+  pendingQuotes = [],
+  onRemovePendingQuote,
+  submittingQuotes = false,
 }: {
   promptText: string
   /** IME composing string (pinyin buffer) — lives only in the hidden
@@ -27,6 +32,9 @@ export function InputMirror({
    *  end of line (unknown / cursor elsewhere). */
   caretOffset?: number | null
   sessionId: string | null
+  pendingQuotes?: readonly PendingTraceQuote[]
+  onRemovePendingQuote?: (sourceId: string) => void
+  submittingQuotes?: boolean
 }) {
   const composingSeg = composing ? (
     <span className="text-primary underline decoration-dotted underline-offset-2">
@@ -38,43 +46,50 @@ export function InputMirror({
   const splitAt =
     caretOffset != null && caretOffset < promptText.length ? caretOffset : null
   return (
-    <div className="flex items-center gap-3 rounded-2xl border border-line bg-bg px-4 py-3 shadow-lg shadow-black/25">
-      <span className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-[13px] leading-relaxed">
-        {promptText || composingSeg ? (
-          splitAt !== null ? (
-            <>
-              <TokenizedText
-                text={promptText.slice(0, splitAt)}
-                sessionId={sessionId}
-              />
-              {composingSeg}
-              {caret}
-              <TokenizedText
-                text={promptText.slice(splitAt)}
-                sessionId={sessionId}
-              />
-            </>
+    <div className="space-y-1.5">
+      <TraceQuoteBuffer
+        quotes={pendingQuotes}
+        onRemove={onRemovePendingQuote}
+        submitting={submittingQuotes}
+      />
+      <div className="flex items-center gap-3 rounded-2xl border border-line bg-bg px-4 py-3 shadow-lg shadow-black/25">
+        <span className="min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-[13px] leading-relaxed">
+          {promptText || composingSeg ? (
+            splitAt !== null ? (
+              <>
+                <TokenizedText
+                  text={promptText.slice(0, splitAt)}
+                  sessionId={sessionId}
+                />
+                {composingSeg}
+                {caret}
+                <TokenizedText
+                  text={promptText.slice(splitAt)}
+                  sessionId={sessionId}
+                />
+              </>
+            ) : (
+              <>
+                {promptText && (
+                  <TokenizedText text={promptText} sessionId={sessionId} />
+                )}
+                {composingSeg}
+                {caret}
+              </>
+            )
           ) : (
             <>
-              {promptText && (
-                <TokenizedText text={promptText} sessionId={sessionId} />
-              )}
-              {composingSeg}
               {caret}
+              <span className="text-subtle"> Message the agent…</span>
             </>
-          )
-        ) : (
-          <>
-            {caret}
-            <span className="text-subtle"> Message the agent…</span>
-          </>
-        )}
-      </span>
-      <CornerDownLeft
-        size={14}
-        strokeWidth={2}
-        className="shrink-0 text-subtle"
-      />
+          )}
+        </span>
+        <CornerDownLeft
+          size={14}
+          strokeWidth={2}
+          className="shrink-0 text-subtle"
+        />
+      </div>
     </div>
   )
 }

--- a/packages/kobe-web/src/components/ReadableTraceContent.tsx
+++ b/packages/kobe-web/src/components/ReadableTraceContent.tsx
@@ -1,0 +1,54 @@
+import { readableTraceContent } from "../lib/trace-content.ts"
+import { CopyButton } from "./CopyButton.tsx"
+
+export function ReadableTraceContent({
+  label,
+  text,
+}: {
+  label: string
+  text: string
+}) {
+  const fields = readableTraceContent(label, text)
+  const compact = fields.filter((field) => field.tone === "value")
+  const bodies = fields.filter((field) => field.tone !== "value")
+  return (
+    <section className="rounded border border-line bg-surface">
+      <header className="flex h-9 items-center gap-2 border-b border-line px-3">
+        <span className="text-[11px] text-muted">{label}</span>
+        <CopyButton
+          text={text}
+          label={`Copy ${label.toLowerCase()}`}
+          className="ml-auto"
+        />
+      </header>
+      <div className="flex max-h-[48vh] flex-col gap-3 overflow-auto p-3">
+        {compact.length > 0 && (
+          <dl className="grid grid-cols-[minmax(7rem,auto)_minmax(0,1fr)] gap-x-4 gap-y-1.5 border-b border-line-subtle pb-3 text-[10px]">
+            {compact.map((field) => (
+              <div key={field.label} className="contents">
+                <dt className="text-subtle">{field.label}</dt>
+                <dd className="min-w-0 break-words font-mono text-muted">
+                  {field.text}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+        {bodies.map((field) => (
+          <div key={field.label}>
+            {fields.length > 1 && (
+              <div className="mb-1.5 text-[9px] uppercase tracking-[0.12em] text-subtle">
+                {field.label}
+              </div>
+            )}
+            <div
+              className={`whitespace-pre-wrap break-words text-[11px] leading-relaxed text-fg ${field.tone === "code" ? "font-mono" : ""}`}
+            >
+              {field.text}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/packages/kobe-web/src/components/SessionView.tsx
+++ b/packages/kobe-web/src/components/SessionView.tsx
@@ -65,6 +65,7 @@ export function SessionView({
   mode,
   vendor,
   grammar,
+  focusRequest = 0,
   onEngineLive,
 }: {
   tabId: string
@@ -76,12 +77,17 @@ export function SessionView({
   vendor?: string
   /** The vendor's screen grammar (engine-grammar.ts) — drives the translation. */
   grammar: EngineGrammar
+  /** External request to return keyboard focus to the native composer. */
+  focusRequest?: number
   /** Grammar-derived engine liveness, lifted so the Agent Trace can clear
    *  when this tab drops to a bare shell / boot screen. */
   onEngineLive?: (live: boolean) => void
 }) {
   const [colored, setColored] = useState<ColoredLine[]>([])
   const [focusNonce, setFocusNonce] = useState(0)
+  useEffect(() => {
+    if (focusRequest > 0) setFocusNonce((value) => value + 1)
+  }, [focusRequest])
   // Frame stabilizer: reuse previous line OBJECTS for unchanged rows so
   // memoized children skip re-render — a keystroke only re-renders the input
   // row's dependents, not the whole transcript.

--- a/packages/kobe-web/src/components/SessionView.tsx
+++ b/packages/kobe-web/src/components/SessionView.tsx
@@ -1,6 +1,7 @@
 /** Translated HTML view over one real hosted shell PTY. */
 
 import {
+  type KeyboardEvent,
   lazy,
   Suspense,
   useCallback,
@@ -12,6 +13,8 @@ import {
 import { isMenuRow, type TtyBlock } from "../lib/claude-tty.ts"
 import type { EngineGrammar } from "../lib/engine-grammar.ts"
 import { resetTabTitle, setTabTitle } from "../lib/tabs.ts"
+import type { PendingTraceQuote } from "../lib/trace-content.ts"
+import { isBufferedSubmitKey } from "../lib/trace-quote-buffer.ts"
 import {
   type ColoredLine,
   sameColoredLine,
@@ -66,6 +69,9 @@ export function SessionView({
   vendor,
   grammar,
   focusRequest = 0,
+  pendingQuotes = [],
+  onRemovePendingQuote,
+  onSubmitPendingQuotes,
   onEngineLive,
 }: {
   tabId: string
@@ -79,6 +85,10 @@ export function SessionView({
   grammar: EngineGrammar
   /** External request to return keyboard focus to the native composer. */
   focusRequest?: number
+  /** Structured context waiting beside the native composer. */
+  pendingQuotes?: readonly PendingTraceQuote[]
+  onRemovePendingQuote?: (sourceId: string) => void
+  onSubmitPendingQuotes?: () => Promise<void>
   /** Grammar-derived engine liveness, lifted so the Agent Trace can clear
    *  when this tab drops to a bare shell / boot screen. */
   onEngineLive?: (live: boolean) => void
@@ -107,6 +117,7 @@ export function SessionView({
   // IME composing string (pinyin buffer) from the hidden textarea — the PTY
   // only sees committed text, so the composer must mirror this itself.
   const [composing, setComposing] = useState<string | null>(null)
+  const [submittingQuotes, setSubmittingQuotes] = useState(false)
   // Real terminal cursor (viewport row + cell col) — the mirror's caret
   // follows it instead of pinning to the end of the prompt text.
   const [cursor, setCursor] = useState<{ row: number; col: number } | null>(
@@ -283,11 +294,41 @@ export function SessionView({
   // c. otherwise → raw terminal takeover (no overlay, no composer mirror).
   const showTranslated = engineLive || colored.length === 0
 
+  const interceptBufferedSubmit = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>): void => {
+      if (
+        !engineLive ||
+        pendingQuotes.length === 0 ||
+        !onSubmitPendingQuotes ||
+        !isBufferedSubmitKey({
+          key: event.key,
+          shiftKey: event.shiftKey,
+          altKey: event.altKey,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+          isComposing: event.nativeEvent.isComposing,
+        })
+      )
+        return
+      const target = event.target
+      if (target instanceof Element && target.closest("button")) return
+      event.preventDefault()
+      event.stopPropagation()
+      if (submittingQuotes) return
+      setSubmittingQuotes(true)
+      void onSubmitPendingQuotes()
+        .catch(() => {})
+        .finally(() => setSubmittingQuotes(false))
+    },
+    [engineLive, pendingQuotes.length, onSubmitPendingQuotes, submittingQuotes],
+  )
+
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: a click anywhere focuses the PTY so typing drives the native CLI / shell
     // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard input already routes to the PTY; the click is only a focus assist
     <div
       className="relative h-full"
+      onKeyDownCapture={interceptBufferedSubmit}
       onClick={() => {
         // Click focuses the PTY — but a drag-select stays a selection: don't
         // steal focus (and collapse the range) when text was just selected.
@@ -388,6 +429,9 @@ export function SessionView({
                 composing={composing}
                 caretOffset={caretOffset}
                 sessionId={sessionId}
+                pendingQuotes={pendingQuotes}
+                onRemovePendingQuote={onRemovePendingQuote}
+                submittingQuotes={submittingQuotes}
               />
             )}
             {statusColored.length > 0 && (

--- a/packages/kobe-web/src/components/TimelineHost.tsx
+++ b/packages/kobe-web/src/components/TimelineHost.tsx
@@ -19,6 +19,7 @@ export function TimelineHost({
   legacySessionId,
   engineActive = true,
   width,
+  onQuote,
 }: {
   taskId: string
   vendor: string
@@ -33,6 +34,8 @@ export function TimelineHost({
   engineActive?: boolean
   /** Drag-resized panel width (PaneResizer). */
   width?: number
+  /** Insert one block reference into the active native composer. */
+  onQuote?: (text: string) => Promise<void>
 }) {
   const engines = useEngines()
   const label = engineLabel(engines, vendor)
@@ -56,6 +59,7 @@ export function TimelineHost({
         bindingState={data.bindingState}
         runId={binding?.runId}
         width={width}
+        onQuote={onQuote}
         onExpand={() => setExpanded(true)}
       />
       {expanded && (
@@ -63,6 +67,7 @@ export function TimelineHost({
           model={data.model}
           engineLabel={label}
           runId={binding?.runId}
+          onQuote={onQuote}
           onClose={() => setExpanded(false)}
         />
       )}

--- a/packages/kobe-web/src/components/TimelineHost.tsx
+++ b/packages/kobe-web/src/components/TimelineHost.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { useEngines } from "../lib/engines.ts"
+import type { PendingTraceQuote } from "../lib/trace-content.ts"
 import type {
   EngineSessionBinding,
   EngineSessionTransition,
@@ -35,7 +36,7 @@ export function TimelineHost({
   /** Drag-resized panel width (PaneResizer). */
   width?: number
   /** Insert one block reference into the active native composer. */
-  onQuote?: (text: string) => Promise<void>
+  onQuote?: (quote: PendingTraceQuote) => Promise<void>
 }) {
   const engines = useEngines()
   const label = engineLabel(engines, vendor)

--- a/packages/kobe-web/src/components/TimelinePanel.tsx
+++ b/packages/kobe-web/src/components/TimelinePanel.tsx
@@ -62,10 +62,12 @@ function TurnSection({
   turn,
   turnIndex,
   now,
+  onQuote,
 }: {
   turn: TimelineTurn
   turnIndex: number
   now: number
+  onQuote?: (text: string) => Promise<void>
 }) {
   const [expanded, setExpanded] = useState(false)
   const spotlight = turn.nodes.filter(isSpotlightNode)
@@ -113,7 +115,12 @@ function TurnSection({
           {expanded ? "Hide steps" : `${foldedCount} steps`}
         </button>
       )}
-      <ExecutionGrid items={items} status={turn.status} now={now} />
+      <ExecutionGrid
+        items={items}
+        status={turn.status}
+        now={now}
+        onQuote={onQuote}
+      />
     </section>
   )
 }
@@ -127,6 +134,7 @@ export function TimelinePanel({
   bindingState,
   runId,
   width,
+  onQuote,
   onExpand,
 }: {
   model: TimelineModel
@@ -140,6 +148,8 @@ export function TimelinePanel({
   runId?: string
   /** Drag-resized width (PaneResizer) — falls back to the basis-80 default. */
   width?: number
+  /** Insert a trace block into the active native composer without sending. */
+  onQuote?: (text: string) => Promise<void>
   onExpand: () => void
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -252,6 +262,7 @@ export function TimelinePanel({
                 turn={turn}
                 turnIndex={turnIndex}
                 now={now}
+                onQuote={onQuote}
               />
             ))}
           </div>

--- a/packages/kobe-web/src/components/TimelinePanel.tsx
+++ b/packages/kobe-web/src/components/TimelinePanel.tsx
@@ -237,6 +237,13 @@ export function TimelinePanel({
           </div>
         ) : bindingState === "pending" ? (
           <TraceLoading label="Waiting for the engine session id…" />
+        ) : bindingState === "empty" ? (
+          <div className="py-8 text-center">
+            <div className="font-mono text-[11px] text-muted">No turns yet</div>
+            <div className="mt-1 text-[10px] text-subtle">
+              Execution events appear with the next prompt.
+            </div>
+          </div>
         ) : bindingState === "missing" ? (
           <div className="border-l-2 border-kobe-yellow pl-3 text-[11px] leading-relaxed text-muted">
             Bound engine session is missing

--- a/packages/kobe-web/src/components/TimelinePanel.tsx
+++ b/packages/kobe-web/src/components/TimelinePanel.tsx
@@ -6,6 +6,7 @@ import {
   type TimelineStatus,
   type TimelineTurn,
 } from "../lib/timeline.ts"
+import type { PendingTraceQuote } from "../lib/trace-content.ts"
 import type { TimelineBindingState } from "../lib/use-timeline-data.ts"
 import { ExecutionGrid, formatExecutionDuration } from "./ExecutionGrid.tsx"
 
@@ -67,7 +68,7 @@ function TurnSection({
   turn: TimelineTurn
   turnIndex: number
   now: number
-  onQuote?: (text: string) => Promise<void>
+  onQuote?: (quote: PendingTraceQuote) => Promise<void>
 }) {
   const [expanded, setExpanded] = useState(false)
   const spotlight = turn.nodes.filter(isSpotlightNode)
@@ -148,8 +149,8 @@ export function TimelinePanel({
   runId?: string
   /** Drag-resized width (PaneResizer) — falls back to the basis-80 default. */
   width?: number
-  /** Insert a trace block into the active native composer without sending. */
-  onQuote?: (text: string) => Promise<void>
+  /** Buffer a trace block beside the active native composer until submit. */
+  onQuote?: (quote: PendingTraceQuote) => Promise<void>
   onExpand: () => void
 }) {
   const scrollRef = useRef<HTMLDivElement>(null)

--- a/packages/kobe-web/src/components/TimelineSwimlane.tsx
+++ b/packages/kobe-web/src/components/TimelineSwimlane.tsx
@@ -18,11 +18,13 @@ export function TimelineSwimlane({
   model,
   engineLabel,
   runId,
+  onQuote,
   onClose,
 }: {
   model: TimelineModel
   engineLabel: string
   runId?: string
+  onQuote?: (text: string) => Promise<void>
   onClose: () => void
 }) {
   const running = model.turns.some((turn) => turn.status === "running")
@@ -102,6 +104,7 @@ export function TimelineSwimlane({
                     items={turn.nodes}
                     status={turn.status}
                     now={now}
+                    onQuote={onQuote}
                     className="execution-node-grid--wide"
                   />
                 </div>

--- a/packages/kobe-web/src/components/TimelineSwimlane.tsx
+++ b/packages/kobe-web/src/components/TimelineSwimlane.tsx
@@ -5,6 +5,7 @@ import {
   type TimelineModel,
   type TimelineStatus,
 } from "../lib/timeline.ts"
+import type { PendingTraceQuote } from "../lib/trace-content.ts"
 import { ExecutionGrid, formatExecutionDuration } from "./ExecutionGrid.tsx"
 
 function statusClass(status: TimelineStatus): string {
@@ -24,7 +25,7 @@ export function TimelineSwimlane({
   model: TimelineModel
   engineLabel: string
   runId?: string
-  onQuote?: (text: string) => Promise<void>
+  onQuote?: (quote: PendingTraceQuote) => Promise<void>
   onClose: () => void
 }) {
   const running = model.turns.some((turn) => turn.status === "running")

--- a/packages/kobe-web/src/components/TraceQuoteBuffer.tsx
+++ b/packages/kobe-web/src/components/TraceQuoteBuffer.tsx
@@ -1,0 +1,46 @@
+import { Quote, X } from "lucide-react"
+import type { PendingTraceQuote } from "../lib/trace-content.ts"
+
+export function TraceQuoteBuffer({
+  quotes,
+  onRemove,
+  submitting = false,
+}: {
+  quotes: readonly PendingTraceQuote[]
+  onRemove?: (sourceId: string) => void
+  submitting?: boolean
+}) {
+  if (quotes.length === 0) return null
+  return (
+    <div
+      data-testid="trace-quote-buffer"
+      className="flex flex-wrap gap-1.5 border-l-2 border-primary/70 pl-2"
+    >
+      {quotes.map((quote) => (
+        <div
+          key={quote.sourceId}
+          className="group flex min-w-0 max-w-full items-center gap-1.5 border border-line bg-surface px-2 py-1 text-[10px] text-muted"
+        >
+          <Quote
+            size={10}
+            strokeWidth={1.8}
+            className="shrink-0 text-primary"
+          />
+          <span className="truncate font-mono">{quote.label}</span>
+          {onRemove && (
+            <button
+              type="button"
+              onClick={() => onRemove(quote.sourceId)}
+              disabled={submitting}
+              className="grid size-4 shrink-0 place-items-center text-subtle transition-colors hover:text-kobe-red focus-visible:text-kobe-red focus-visible:outline-none disabled:opacity-40"
+              aria-label={`Remove quoted block: ${quote.label}`}
+              title="Remove quoted block"
+            >
+              <X size={10} strokeWidth={2} />
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/kobe-web/src/lib/store.ts
+++ b/packages/kobe-web/src/lib/store.ts
@@ -321,12 +321,12 @@ let source: EventSource | null = null
 let reconnectAttempts = 0
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
-/** Staleness watchdog. The daemon heartbeats a real `ping` event every 15s;
+/** Staleness watchdog. The daemon heartbeats a real `ping` event every 3s;
  *  if NOTHING (snapshot/channel/ping) arrives for this long the stream is
  *  wedged — typically the dev proxy holding our socket open after its
  *  upstream daemon died, which never fires an EventSource error — so we
  *  force-replace it. */
-const STALE_STREAM_MS = 40_000
+const STALE_STREAM_MS = 8_000
 let lastEventAt = 0
 let staleTimer: ReturnType<typeof setInterval> | null = null
 
@@ -339,7 +339,7 @@ function armStaleWatchdog(): void {
     source = null
     set({ streamConnected: false })
     scheduleReconnect()
-  }, 10_000)
+  }, 2_000)
 }
 
 /** A stream is "live enough" to reuse when its EventSource exists and hasn't

--- a/packages/kobe-web/src/lib/terminal.ts
+++ b/packages/kobe-web/src/lib/terminal.ts
@@ -72,6 +72,29 @@ export async function closePtyTab(tabId: string): Promise<void> {
   }
 }
 
+/** Paste text into an already-hosted native composer without pressing Enter.
+ * The engine remains fully in charge of editing and submitting the next turn. */
+export async function insertPtyText(
+  tabId: string,
+  text: string,
+): Promise<void> {
+  try {
+    const json = await api.post<{ inserted?: boolean }>(
+      `${ptyBase("http")}/pty/insert`,
+      { tab: tabId, text },
+      { label: "insert PTY text" },
+    )
+    if (!json.inserted) throw new Error("insert failed")
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404 && !err.detail) {
+      throw new Error(
+        "the PTY server doesn't know /pty/insert — restart `kobe web` (the sidecar doesn't hot-reload)",
+      )
+    }
+    throw err
+  }
+}
+
 /**
  * Paste text + Enter into a tab's engine — the composer's submit contract,
  * fired from outside any terminal view (board quick actions). The sidecar

--- a/packages/kobe-web/src/lib/trace-content.ts
+++ b/packages/kobe-web/src/lib/trace-content.ts
@@ -1,0 +1,203 @@
+import type { TimelineItem } from "./timeline.ts"
+
+export type TraceFieldTone = "code" | "prose" | "value"
+
+export interface ReadableTraceField {
+  readonly label: string
+  readonly text: string
+  readonly tone: TraceFieldTone
+}
+
+const LABELS: Record<string, string> = {
+  cmd: "Command",
+  command: "Command",
+  cwd: "Working directory",
+  workdir: "Working directory",
+  file_path: "File",
+  max_output_tokens: "Output limit",
+  yield_time_ms: "Wait",
+  wall_time_seconds: "Duration",
+  exit_code: "Exit code",
+  stdout: "Standard output",
+  stderr: "Standard error",
+  output: "Output",
+  error: "Error",
+  path: "Path",
+  pattern: "Pattern",
+  query: "Query",
+  prompt: "Prompt",
+  description: "Description",
+  content: "Content",
+  message: "Message",
+  text: "Text",
+}
+
+const CODE_FIELDS = new Set([
+  "cmd",
+  "command",
+  "stdout",
+  "stderr",
+  "output",
+  "error",
+  "patch",
+  "diff",
+])
+const PROSE_FIELDS = new Set([
+  "prompt",
+  "description",
+  "content",
+  "message",
+  "text",
+  "reasoning",
+])
+const FIELD_PRIORITY = [
+  "cmd",
+  "command",
+  "file_path",
+  "path",
+  "pattern",
+  "query",
+  "prompt",
+  "description",
+  "output",
+  "stdout",
+  "stderr",
+  "error",
+]
+const QUOTE_LIMIT = 16_000
+
+function humanizeKey(key: string): string {
+  const known = LABELS[key]
+  if (known) return known
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+  return words ? `${words[0]?.toUpperCase() ?? ""}${words.slice(1)}` : "Value"
+}
+
+function formatValue(key: string, value: unknown): string {
+  if (value === null) return "None"
+  if (typeof value === "boolean") return value ? "Yes" : "No"
+  if (typeof value === "number") {
+    if (key.endsWith("_ms"))
+      return value >= 1_000 ? `${value / 1_000} s` : `${value} ms`
+    if (key.endsWith("_seconds")) return `${value} s`
+    if (key === "max_output_tokens")
+      return `${value.toLocaleString("en-US")} tokens`
+    if (key === "exit_code")
+      return value === 0 ? "0 · success" : `${value} · failed`
+    return value.toLocaleString("en-US")
+  }
+  if (typeof value === "string") return value
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function toneFor(key: string, value: unknown): TraceFieldTone {
+  if (CODE_FIELDS.has(key)) return "code"
+  if (PROSE_FIELDS.has(key)) return "prose"
+  if (typeof value === "object" && value !== null) return "code"
+  return "value"
+}
+
+function parseStructured(text: string): unknown | undefined {
+  const trimmed = text.trim()
+  if (
+    !(
+      trimmed.startsWith("{") ||
+      trimmed.startsWith("[") ||
+      trimmed.startsWith('"')
+    )
+  )
+    return undefined
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (typeof parsed === "string") {
+      const nested = parsed.trim()
+      if (nested.startsWith("{") || nested.startsWith("[")) {
+        try {
+          return JSON.parse(nested)
+        } catch {
+          return undefined
+        }
+      }
+      return undefined
+    }
+    return parsed
+  } catch {
+    return undefined
+  }
+}
+
+function orderedEntries(
+  record: Record<string, unknown>,
+): Array<[string, unknown]> {
+  const rank = (key: string): number => {
+    const index = FIELD_PRIORITY.indexOf(key)
+    return index < 0 ? FIELD_PRIORITY.length : index
+  }
+  return Object.entries(record).sort(([a], [b]) => rank(a) - rank(b))
+}
+
+/** Generic presentation parser. Engine adapters still own the trace values;
+ * this only turns JSON-shaped strings into labels a person can scan. */
+export function readableTraceContent(
+  label: string,
+  text: string,
+): readonly ReadableTraceField[] {
+  const parsed = parseStructured(text)
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const fields = orderedEntries(parsed as Record<string, unknown>).map(
+      ([key, value]) => ({
+        label: humanizeKey(key),
+        text: formatValue(key, value),
+        tone: toneFor(key, value),
+      }),
+    )
+    if (fields.length > 0) return fields
+  }
+  if (Array.isArray(parsed)) {
+    return [{ label, text: formatValue("items", parsed), tone: "code" }]
+  }
+  return [{ label, text: text || "(empty)", tone: "prose" }]
+}
+
+function itemKindLabel(item: TimelineItem): string {
+  if (item.kind === "commentary") return "Commentary"
+  if (item.kind === "reasoning") return "Reasoning"
+  if (item.kind === "change") return "Change"
+  if (item.kind === "answer") return "Result"
+  if (item.kind === "subagent") return "Subagent"
+  if (item.kind === "compaction") return "Compaction"
+  return "Tool"
+}
+
+function appendContent(lines: string[], label: string, text: string): void {
+  if (!text) return
+  lines.push(label)
+  for (const field of readableTraceContent(label, text)) {
+    if (field.label !== label) lines.push(`${field.label}:`)
+    lines.push(field.text, "")
+  }
+}
+
+/** Self-contained text pasted into the native engine composer. It references
+ * one trace node but never sends the next turn automatically. */
+export function quoteTraceItem(item: TimelineItem): string {
+  const close = "[/Quoted Agent Trace block]"
+  const lines = [
+    `[Quoted Agent Trace block · ${itemKindLabel(item)} · ${item.title}]`,
+    "",
+  ]
+  appendContent(lines, item.kind === "change" ? "Patch" : "Input", item.detail)
+  if (item.resultDetail) appendContent(lines, "Result", item.resultDetail)
+  lines.push(close)
+  const full = lines.join("\n").replace(/\n{3,}/g, "\n\n")
+  if (full.length <= QUOTE_LIMIT) return full
+  const suffix = `\n\n[quoted block truncated]\n${close}`
+  return `${full.slice(0, QUOTE_LIMIT - suffix.length).trimEnd()}${suffix}`
+}

--- a/packages/kobe-web/src/lib/trace-content.ts
+++ b/packages/kobe-web/src/lib/trace-content.ts
@@ -201,3 +201,39 @@ export function quoteTraceItem(item: TimelineItem): string {
   const suffix = `\n\n[quoted block truncated]\n${close}`
   return `${full.slice(0, QUOTE_LIMIT - suffix.length).trimEnd()}${suffix}`
 }
+
+export type PendingTraceQuote = Readonly<{
+  sourceId: string
+  label: string
+  text: string
+}>
+
+/** A trace node stays structured in the GUI until the user submits. */
+export function pendingTraceQuote(item: TimelineItem): PendingTraceQuote {
+  return {
+    sourceId: item.id,
+    label: `${itemKindLabel(item)} · ${item.title}`,
+    text: quoteTraceItem(item),
+  }
+}
+
+export function serializePendingTraceQuotes(
+  quotes: readonly PendingTraceQuote[],
+): string {
+  const normalized =
+    `\n\n${quotes.map((quote) => quote.text).join("\n\n")}\n\n`.replace(
+      /\r\n?/g,
+      "\n",
+    )
+  let safe = ""
+  for (const character of normalized) {
+    const codepoint = character.codePointAt(0) ?? 0
+    if (
+      codepoint === 9 ||
+      codepoint === 10 ||
+      (codepoint >= 32 && codepoint !== 127)
+    )
+      safe += character
+  }
+  return safe
+}

--- a/packages/kobe-web/src/lib/trace-quote-buffer.ts
+++ b/packages/kobe-web/src/lib/trace-quote-buffer.ts
@@ -1,0 +1,21 @@
+export type BufferedSubmitKey = Readonly<{
+  key: string
+  shiftKey?: boolean
+  altKey?: boolean
+  ctrlKey?: boolean
+  metaKey?: boolean
+  isComposing?: boolean
+}>
+
+/** Only plain Enter submits buffered context. Native multiline and IME input
+ * must continue to follow the engine's own keyboard grammar. */
+export function isBufferedSubmitKey(event: BufferedSubmitKey): boolean {
+  return (
+    event.key === "Enter" &&
+    !event.shiftKey &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.isComposing
+  )
+}

--- a/packages/kobe-web/src/lib/use-timeline-data.ts
+++ b/packages/kobe-web/src/lib/use-timeline-data.ts
@@ -6,7 +6,6 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { type TimelineModel, withLiveState } from "./timeline.ts"
 import {
   applyLiveTraceEvent,
-  fetchTrace,
   subscribeLiveTrace,
   subscribeTrace,
 } from "./trace.ts"
@@ -16,7 +15,10 @@ import type {
   EngineState,
 } from "./types.ts"
 
-export type TimelineBindingState = EngineSessionBinding["state"] | "unavailable"
+export type TimelineBindingState =
+  | EngineSessionBinding["state"]
+  | "empty"
+  | "unavailable"
 
 // A local trace fetch often resolves inside one paint. Keep resume transitions
 // visible long enough to communicate that the pane changed session identity.
@@ -59,9 +61,14 @@ export function useTimelineData({
     (targetSessionId ? `legacy:${vendor}:${targetSessionId}` : "")
   const runStartedAt = binding?.startedAt ?? 0
   const transitionPending = transition?.startSource === "resume"
+  const unidentified =
+    !targetSessionId &&
+    (binding?.state === "pending" || binding?.state === "missing")
   const bindingState: TimelineBindingState = transitionPending
     ? "pending"
-    : (binding?.state ?? (legacySessionId ? "bound" : "unavailable"))
+    : unidentified
+      ? "empty"
+      : (binding?.state ?? (legacySessionId ? "bound" : "unavailable"))
   const [trace, setTrace] = useState<TimelineModel>({
     sessionId: targetSessionId,
     turns: [],
@@ -76,10 +83,9 @@ export function useTimelineData({
   // resumed session can never paint the old timeline under its new identity.
   const generationReady =
     !transitionPending &&
-    (!targetSessionId ||
-      (loaded &&
-        loadedGeneration === targetGeneration &&
-        trace.sessionId === targetSessionId))
+    loaded &&
+    loadedGeneration === targetGeneration &&
+    trace.sessionId === targetSessionId
 
   useEffect(() => {
     const seq = ++seqRef.current
@@ -100,40 +106,37 @@ export function useTimelineData({
       setLoaded(true)
       return
     }
-    void fetchTrace(vendor, targetSessionId)
-      .then(async (next) => {
-        await wait(minimumLoadingMs - (Date.now() - startedAt))
-        if (seq !== seqRef.current) return
-        // Engine history is session-scoped. Resuming away from a session and
-        // later returning to it must restore its complete persisted timeline;
-        // EngineRun timestamps identify the live attachment, not a history
-        // retention boundary.
-        setTrace(next)
-        setLoadedGeneration(targetGeneration)
-        setLoaded(true)
+    let settled = false
+    let settleSeq = 0
+    const settle = (apply: () => void): void => {
+      const currentSettle = ++settleSeq
+      const delay = settled ? 0 : minimumLoadingMs - (Date.now() - startedAt)
+      void wait(delay).then(() => {
+        if (seq !== seqRef.current || currentSettle !== settleSeq) return
+        apply()
+        settled = true
       })
-      .catch(async (err) => {
-        await wait(minimumLoadingMs - (Date.now() - startedAt))
-        if (seq !== seqRef.current) return
-        setError(err instanceof Error ? err.message : String(err))
-        setLoadedGeneration(targetGeneration)
-        setLoaded(true)
-      })
-  }, [vendor, targetSessionId, targetGeneration, binding?.startSource])
-
-  useEffect(() => {
-    if (!targetSessionId) return
+    }
     return subscribeTrace(
       vendor,
       targetSessionId,
       (next) => {
-        setTrace(next)
-        setLoaded(true)
-        setError(null)
+        settle(() => {
+          setTrace(next)
+          setLoadedGeneration(targetGeneration)
+          setLoaded(true)
+          setError(null)
+        })
       },
-      (message) => setError(message),
+      (message) => {
+        settle(() => {
+          setError(message)
+          setLoadedGeneration(targetGeneration)
+          setLoaded(true)
+        })
+      },
     )
-  }, [vendor, targetSessionId])
+  }, [vendor, targetSessionId, targetGeneration, binding?.startSource])
 
   useEffect(() => {
     if (!targetSessionId) return

--- a/packages/kobe-web/test/engine-session-observer.test.ts
+++ b/packages/kobe-web/test/engine-session-observer.test.ts
@@ -2,36 +2,88 @@ import { describe, expect, it, vi } from "vitest"
 import { createEngineSessionObservationClient } from "../engine-session-observer.mjs"
 
 describe("engine session observation client", () => {
-  it("retries a neutral PID-scoped observation after a terminal commit", async () => {
+  it("registers immediately and heartbeats the same process identity", async () => {
     vi.useFakeTimers()
     const fetchFn = vi.fn().mockResolvedValue(new Response("{}"))
     const client = createEngineSessionObservationClient({
       daemonWebPort: 5176,
       fetchFn,
-      delaysMs: [0, 50],
+      heartbeatMs: 50,
     })
-    client.observe({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 4242 })
-    await vi.runAllTimersAsync()
+    client.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 4242, startedAt: 100 })
+    await vi.advanceTimersByTimeAsync(50)
 
     expect(fetchFn).toHaveBeenCalledTimes(2)
     const [url, init] = fetchFn.mock.calls[0]
     expect(url).toBe("http://127.0.0.1:5176/api/rpc")
     expect(JSON.parse(init.body)).toEqual({
-      name: "engine.observeSession",
-      payload: { taskId: "task-1", tabId: "tab-a", rootPid: 4242, vendor: "codex" },
+      name: "engine.watchSession",
+      payload: { taskId: "task-1", tabId: "tab-a", rootPid: 4242, vendor: "codex", startedAt: 100 },
     })
+    client.close()
     vi.useRealTimers()
   })
 
-  it("supersedes the prior retry window for the same tab", async () => {
+  it("replaces a tab watch and unregisters the prior PID", async () => {
     vi.useFakeTimers()
     const fetchFn = vi.fn().mockResolvedValue(new Response("{}"))
-    const client = createEngineSessionObservationClient({ daemonWebPort: 5176, fetchFn, delaysMs: [50] })
-    client.observe({ taskId: "task-1", tabId: "tab-a", rootPid: 1 })
-    client.observe({ taskId: "task-1", tabId: "tab-a", rootPid: 2 })
-    await vi.runAllTimersAsync()
-    expect(fetchFn).toHaveBeenCalledTimes(1)
-    expect(JSON.parse(fetchFn.mock.calls[0][1].body).payload.rootPid).toBe(2)
+    const client = createEngineSessionObservationClient({ daemonWebPort: 5176, fetchFn, heartbeatMs: 50 })
+    client.watch({ taskId: "task-1", tabId: "tab-a", rootPid: 1, startedAt: 100 })
+    client.watch({ taskId: "task-1", tabId: "tab-a", rootPid: 2, startedAt: 200 })
+    await Promise.resolve()
+    expect(fetchFn.mock.calls.map((call) => JSON.parse(call[1].body))).toEqual([
+      { name: "engine.watchSession", payload: { taskId: "task-1", tabId: "tab-a", rootPid: 1, startedAt: 100 } },
+      { name: "engine.unwatchSession", payload: { taskId: "task-1", tabId: "tab-a", rootPid: 1 } },
+      { name: "engine.watchSession", payload: { taskId: "task-1", tabId: "tab-a", rootPid: 2, startedAt: 200 } },
+    ])
+    client.close()
+    vi.useRealTimers()
+  })
+
+  it("ignores a stale PID-specific unwatch", async () => {
+    vi.useFakeTimers()
+    const fetchFn = vi.fn().mockResolvedValue(new Response("{}"))
+    const client = createEngineSessionObservationClient({ daemonWebPort: 5176, fetchFn, heartbeatMs: 50 })
+    client.watch({ taskId: "task-1", tabId: "tab-a", rootPid: 2, startedAt: 200 })
+    client.unwatch("tab-a", 1)
+    expect(client.watchedCount()).toBe(1)
+    client.unwatch("tab-a", 2)
+    expect(client.watchedCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it("retries registration by heartbeat after the daemon is unavailable", async () => {
+    vi.useFakeTimers()
+    const fetchFn = vi.fn().mockRejectedValueOnce(new Error("daemon restarting")).mockResolvedValue(new Response("{}"))
+    const client = createEngineSessionObservationClient({ daemonWebPort: 5176, fetchFn, heartbeatMs: 50 })
+    client.watch({ taskId: "task-1", tabId: "tab-a", rootPid: 2, startedAt: 200 })
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchFn.mock.calls[1][1].body)).toMatchObject({ name: "engine.watchSession" })
+    client.close()
+    vi.useRealTimers()
+  })
+
+  it("unregisters every watched tab and stops heartbeats on close", async () => {
+    vi.useFakeTimers()
+    const fetchFn = vi.fn().mockResolvedValue(new Response("{}"))
+    const client = createEngineSessionObservationClient({ daemonWebPort: 5176, fetchFn, heartbeatMs: 50 })
+    client.watch({ taskId: "task-1", tabId: "tab-a", rootPid: 1, startedAt: 100 })
+    client.watch({ taskId: "task-1", tabId: "tab-b", rootPid: 2, startedAt: 200 })
+    client.close()
+    const callsAtClose = fetchFn.mock.calls.length
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(client.watchedCount()).toBe(0)
+    expect(fetchFn).toHaveBeenCalledTimes(callsAtClose)
+    expect(fetchFn.mock.calls.map((call) => JSON.parse(call[1].body).name)).toEqual([
+      "engine.watchSession",
+      "engine.watchSession",
+      "engine.unwatchSession",
+      "engine.unwatchSession",
+    ])
     vi.useRealTimers()
   })
 })

--- a/packages/kobe-web/test/execution-grid.test.tsx
+++ b/packages/kobe-web/test/execution-grid.test.tsx
@@ -114,7 +114,7 @@ describe("ExecutionGrid", () => {
     ).toBeTruthy()
   })
 
-  it("quotes a readable block into the next input", async () => {
+  it("quotes a readable block directly from its card", async () => {
     const onQuote = vi.fn().mockResolvedValue(undefined)
     render(
       <ExecutionGrid
@@ -125,18 +125,17 @@ describe("ExecutionGrid", () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole("button", { name: /Open Tool details/ }))
-    fireEvent.click(
-      screen.getByRole("button", { name: "Quote to input" }),
-    )
+    fireEvent.click(screen.getByRole("button", { name: "Quote Tool: exec" }))
     await waitFor(() => expect(onQuote).toHaveBeenCalledOnce())
-    expect(onQuote.mock.calls[0]?.[0]).toContain(
+    expect(onQuote.mock.calls[0]?.[0]?.sourceId).toBe("tool-1")
+    expect(onQuote.mock.calls[0]?.[0]?.label).toBe("Tool · exec")
+    expect(onQuote.mock.calls[0]?.[0]?.text).toContain(
       "[Quoted Agent Trace block · Tool · exec]",
     )
-    expect(onQuote.mock.calls[0]?.[0]).toContain(
+    expect(onQuote.mock.calls[0]?.[0]?.text).toContain(
       "Command:\nsed -n '1,120p' test.ts",
     )
-    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    expect(screen.queryByRole("dialog")).toBeNull()
   })
 
   it("renders patch, explicit retry, and subagent completion details", () => {

--- a/packages/kobe-web/test/execution-grid.test.tsx
+++ b/packages/kobe-web/test/execution-grid.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { ExecutionGrid } from "../src/components/ExecutionGrid.tsx"
 import type { TimelineItem } from "../src/lib/timeline.ts"
 
@@ -30,8 +36,10 @@ const tool: TimelineItem = {
   status: "success",
   title: "exec",
   summary: "sed -n '1,120p' test.ts",
-  detail: '{\n  "cmd": "sed -n \'1,120p\' test.ts"\n}',
-  resultDetail: "The fixture still uses protocol version 1.",
+  detail:
+    '{\n  "cmd": "sed -n \'1,120p\' test.ts",\n  "workdir": "/repo",\n  "yield_time_ms": 10000\n}',
+  resultDetail:
+    '{"output":"The fixture still uses protocol version 1.","exit_code":0}',
   startedAt: 1_100,
   endedAt: 1_500,
 }
@@ -98,9 +106,37 @@ describe("ExecutionGrid", () => {
     expect(screen.getByText("temporal link")).toBeTruthy()
     expect(screen.getByText("Input")).toBeTruthy()
     expect(screen.getByText("Result")).toBeTruthy()
+    expect(screen.getByText("Command")).toBeTruthy()
+    expect(screen.getByText("Working directory")).toBeTruthy()
+    expect(screen.getByText("10 s")).toBeTruthy()
     expect(
       screen.getByText("The fixture still uses protocol version 1."),
     ).toBeTruthy()
+  })
+
+  it("quotes a readable block into the next input", async () => {
+    const onQuote = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ExecutionGrid
+        items={[tool]}
+        status="success"
+        now={2_000}
+        onQuote={onQuote}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Open Tool details/ }))
+    fireEvent.click(
+      screen.getByRole("button", { name: "Quote to input" }),
+    )
+    await waitFor(() => expect(onQuote).toHaveBeenCalledOnce())
+    expect(onQuote.mock.calls[0]?.[0]).toContain(
+      "[Quoted Agent Trace block · Tool · exec]",
+    )
+    expect(onQuote.mock.calls[0]?.[0]).toContain(
+      "Command:\nsed -n '1,120p' test.ts",
+    )
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
   })
 
   it("renders patch, explicit retry, and subagent completion details", () => {

--- a/packages/kobe-web/test/pty-session-lifecycle.test.ts
+++ b/packages/kobe-web/test/pty-session-lifecycle.test.ts
@@ -262,6 +262,27 @@ describe("createPtySessionManager", () => {
     expect(ptys[0].writes).toEqual(["\x1b[200~hello\x1b[201~", "\r"])
   })
 
+  it("inserts a quote into an existing PTY without submitting", async () => {
+    const onTerminalCommit = vi.fn()
+    const { manager, ptys } = setup({ onTerminalCommit })
+    await manager.ensureSession("tab", "task", "engine", 80, 24)
+
+    expect(
+      manager.insertText({
+        tabId: "tab",
+        text: "quoted\r\nblock\x1b[201~\runsafe",
+      }),
+    ).toEqual({ inserted: true, missing: false })
+    expect(ptys[0].writes).toEqual([
+      "\x1b[200~quoted\nblock[201~\nunsafe\x1b[201~",
+    ])
+    expect(onTerminalCommit).not.toHaveBeenCalled()
+    expect(manager.insertText({ tabId: "missing", text: "x" })).toEqual({
+      inserted: false,
+      missing: true,
+    })
+  })
+
   it("closes sockets and clears the session on process exit", async () => {
     const { manager, ptys } = setup()
     const ws = new FakeSocket()

--- a/packages/kobe-web/test/pty-session-lifecycle.test.ts
+++ b/packages/kobe-web/test/pty-session-lifecycle.test.ts
@@ -222,9 +222,9 @@ describe("createPtySessionManager", () => {
     expect(ptys[0].writes).toEqual(["abc"])
   })
 
-  it("reports an engine terminal commit with tab and root PID identity", async () => {
-    const onTerminalCommit = vi.fn()
-    const { manager } = setup({ onTerminalCommit })
+  it("registers an engine process at spawn without waiting for terminal input", async () => {
+    const onEngineSessionStart = vi.fn()
+    const { manager } = setup({ onEngineSessionStart })
     const ws = new FakeSocket()
     await manager.attachSocket({
       ws,
@@ -235,12 +235,12 @@ describe("createPtySessionManager", () => {
       cols: 80,
       rows: 24,
     })
-    ws.message("\r")
-    expect(onTerminalCommit).toHaveBeenCalledWith({
+    expect(onEngineSessionStart).toHaveBeenCalledWith({
       taskId: "task",
       tabId: "tab",
       vendor: "codex",
       rootPid: 4242,
+      startedAt: expect.any(Number),
     })
   })
 
@@ -263,8 +263,8 @@ describe("createPtySessionManager", () => {
   })
 
   it("inserts a quote into an existing PTY without submitting", async () => {
-    const onTerminalCommit = vi.fn()
-    const { manager, ptys } = setup({ onTerminalCommit })
+    const onEngineSessionStart = vi.fn()
+    const { manager, ptys } = setup({ onEngineSessionStart })
     await manager.ensureSession("tab", "task", "engine", 80, 24)
 
     expect(
@@ -276,7 +276,7 @@ describe("createPtySessionManager", () => {
     expect(ptys[0].writes).toEqual([
       "\x1b[200~quoted\nblock[201~\nunsafe\x1b[201~",
     ])
-    expect(onTerminalCommit).not.toHaveBeenCalled()
+    expect(onEngineSessionStart).toHaveBeenCalledOnce()
     expect(manager.insertText({ tabId: "missing", text: "x" })).toEqual({
       inserted: false,
       missing: true,
@@ -284,7 +284,8 @@ describe("createPtySessionManager", () => {
   })
 
   it("closes sockets and clears the session on process exit", async () => {
-    const { manager, ptys } = setup()
+    const onEngineSessionStop = vi.fn()
+    const { manager, ptys } = setup({ onEngineSessionStop })
     const ws = new FakeSocket()
     await manager.attachSocket({
       ws,
@@ -299,6 +300,7 @@ describe("createPtySessionManager", () => {
 
     expect(ws.closes).toEqual([{ code: 1000, reason: "engine exited" }])
     expect(manager.sessionCount()).toBe(0)
+    expect(onEngineSessionStop).toHaveBeenCalledWith({ taskId: "task", tabId: "tab", rootPid: 4242 })
   })
 
   it("kills only the current session mapping on explicit close", async () => {

--- a/packages/kobe-web/test/pty-url.test.ts
+++ b/packages/kobe-web/test/pty-url.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { ptyUrl } from "../src/lib/terminal.ts"
+import { insertPtyText, ptyUrl } from "../src/lib/terminal.ts"
 
 /**
  * ptyUrl builds the PTY WebSocket URL — a bug here breaks every terminal tab.
@@ -46,5 +46,23 @@ describe("ptyUrl", () => {
     withLocation({ port: "" })
     // empty port → defaults to 5173 → +2 = 5175
     expect(ptyUrl("t", "k", "shell", 80, 24)).toContain(":5175/")
+  })
+
+  it("inserts quoted text through the no-submit PTY endpoint", async () => {
+    withLocation({ port: "5173" })
+    const fetch = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify({ inserted: true }))),
+    )
+    vi.stubGlobal("fetch", fetch)
+
+    await insertPtyText("tab-1", "quoted block")
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:5175/pty/insert",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ tab: "tab-1", text: "quoted block" }),
+      }),
+    )
   })
 })

--- a/packages/kobe-web/test/timeline-loading.test.tsx
+++ b/packages/kobe-web/test/timeline-loading.test.tsx
@@ -39,4 +39,20 @@ describe("TimelinePanel loading", () => {
 
     expect(screen.getByRole("status").textContent).toContain("Reading engine events")
   })
+
+  it("renders an unidentified fresh process as an empty trace", () => {
+    render(
+      <TimelinePanel
+        model={emptyModel}
+        loaded={true}
+        error={null}
+        engineLabel="Codex"
+        bindingState="empty"
+        onExpand={() => undefined}
+      />,
+    )
+
+    expect(screen.getByText("No turns yet")).toBeTruthy()
+    expect(screen.queryByText(/Bound engine session is missing/)).toBeNull()
+  })
 })

--- a/packages/kobe-web/test/trace-content.test.ts
+++ b/packages/kobe-web/test/trace-content.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest"
 import type { TimelineItem } from "../src/lib/timeline.ts"
 import {
+  pendingTraceQuote,
   quoteTraceItem,
   readableTraceContent,
+  serializePendingTraceQuotes,
 } from "../src/lib/trace-content.ts"
 
 const tool: TimelineItem = {
@@ -49,6 +51,24 @@ describe("trace content presentation", () => {
     expect(quote).toContain("Working directory:\n/repo")
     expect(quote).toContain("Exit code:\n0 · success")
     expect(quote).toContain("[/Quoted Agent Trace block]")
+  })
+
+  it("keeps a structured identity until buffered quotes are submitted", () => {
+    const pending = pendingTraceQuote(tool)
+    expect(pending.sourceId).toBe("tool-1")
+    expect(pending.label).toBe("Tool · exec")
+    expect(serializePendingTraceQuotes([pending])).toBe(
+      `\n\n${pending.text}\n\n`,
+    )
+  })
+
+  it("strips terminal controls before a buffered quote reaches bracketed paste", () => {
+    const pending = pendingTraceQuote(tool)
+    expect(
+      serializePendingTraceQuotes([
+        { ...pending, text: `safe\u001b[201~\r\nnext\u0000` },
+      ]),
+    ).toBe("\n\nsafe[201~\nnext\n\n")
   })
 
   it("keeps oversized quotes inside the input cap with one closing marker", () => {

--- a/packages/kobe-web/test/trace-content.test.ts
+++ b/packages/kobe-web/test/trace-content.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import type { TimelineItem } from "../src/lib/timeline.ts"
+import {
+  quoteTraceItem,
+  readableTraceContent,
+} from "../src/lib/trace-content.ts"
+
+const tool: TimelineItem = {
+  id: "tool-1",
+  turnId: "turn-1",
+  parentId: null,
+  parentBasis: "none",
+  kind: "tool",
+  status: "success",
+  title: "exec",
+  summary: "git status",
+  detail:
+    '{"cmd":"git status --short","workdir":"/repo","yield_time_ms":10000,"max_output_tokens":3000}',
+  resultDetail:
+    '{"output":" M src/app.ts","exit_code":0,"wall_time_seconds":1.5}',
+  startedAt: 1,
+  endedAt: 2,
+}
+
+describe("trace content presentation", () => {
+  it("turns JSON-shaped tool input into labeled human-readable fields", () => {
+    expect(readableTraceContent("Input", tool.detail)).toEqual([
+      { label: "Command", text: "git status --short", tone: "code" },
+      { label: "Working directory", text: "/repo", tone: "value" },
+      { label: "Wait", text: "10 s", tone: "value" },
+      { label: "Output limit", text: "3,000 tokens", tone: "value" },
+    ])
+  })
+
+  it("keeps plain prose intact instead of treating it as JSON", () => {
+    expect(readableTraceContent("Reasoning summary", "Inspect the adapter first.")).toEqual([
+      {
+        label: "Reasoning summary",
+        text: "Inspect the adapter first.",
+        tone: "prose",
+      },
+    ])
+  })
+
+  it("builds a self-contained block reference for the next prompt", () => {
+    const quote = quoteTraceItem(tool)
+    expect(quote).toContain("[Quoted Agent Trace block · Tool · exec]")
+    expect(quote).toContain("Command:\ngit status --short")
+    expect(quote).toContain("Working directory:\n/repo")
+    expect(quote).toContain("Exit code:\n0 · success")
+    expect(quote).toContain("[/Quoted Agent Trace block]")
+  })
+
+  it("keeps oversized quotes inside the input cap with one closing marker", () => {
+    const quote = quoteTraceItem({ ...tool, resultDetail: "x".repeat(20_000) })
+    expect(quote.length).toBeLessThanOrEqual(16_000)
+    expect(quote).toContain("[quoted block truncated]")
+    expect(quote.match(/\[\/Quoted Agent Trace block\]/g)).toHaveLength(1)
+    expect(quote.endsWith("[/Quoted Agent Trace block]")).toBe(true)
+  })
+})

--- a/packages/kobe-web/test/trace-quote-buffer.test.tsx
+++ b/packages/kobe-web/test/trace-quote-buffer.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { TraceQuoteBuffer } from "../src/components/TraceQuoteBuffer.tsx"
+import { isBufferedSubmitKey } from "../src/lib/trace-quote-buffer.ts"
+
+const quote = {
+  sourceId: "tool-1",
+  label: "Tool · exec",
+  text: "[Quoted Agent Trace block]",
+}
+
+describe("TraceQuoteBuffer", () => {
+  afterEach(cleanup)
+
+  it("renders a removable structured quote", () => {
+    const onRemove = vi.fn()
+    render(<TraceQuoteBuffer quotes={[quote]} onRemove={onRemove} />)
+
+    expect(screen.getByText("Tool · exec")).toBeTruthy()
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove quoted block: Tool · exec",
+      }),
+    )
+    expect(onRemove).toHaveBeenCalledWith("tool-1")
+  })
+
+  it("intercepts only plain Enter for buffered submission", () => {
+    expect(isBufferedSubmitKey({ key: "Enter" })).toBe(true)
+    expect(isBufferedSubmitKey({ key: "Enter", shiftKey: true })).toBe(false)
+    expect(isBufferedSubmitKey({ key: "Enter", isComposing: true })).toBe(false)
+    expect(isBufferedSubmitKey({ key: "Backspace" })).toBe(false)
+  })
+})

--- a/packages/kobe-web/test/use-timeline-data.test.tsx
+++ b/packages/kobe-web/test/use-timeline-data.test.tsx
@@ -8,16 +8,15 @@ import type {
   EngineSessionTransition,
 } from "../src/lib/types.ts"
 
-const { fetchTrace } = vi.hoisted(() => ({
-  fetchTrace: vi.fn<(vendor: string, sessionId: string) => Promise<EngineTrace>>(),
+const { subscribeTrace } = vi.hoisted(() => ({
+  subscribeTrace: vi.fn(),
 }))
 
 vi.mock("../src/lib/trace.ts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/lib/trace.ts")>()
   return {
     ...actual,
-    fetchTrace,
-    subscribeTrace: vi.fn(() => () => undefined),
+    subscribeTrace,
     subscribeLiveTrace: vi.fn(() => () => undefined),
   }
 })
@@ -53,7 +52,7 @@ function binding(runId: string, sessionId: string, startedAt: number): EngineSes
 
 describe("useTimelineData", () => {
   beforeEach(() => {
-    fetchTrace.mockReset()
+    subscribeTrace.mockReset()
   })
 
   afterEach(() => {
@@ -69,9 +68,10 @@ describe("useTimelineData", () => {
       sessionId: "session-b",
       turns: [turn("b-turn", 50, 60)],
     }
-    fetchTrace.mockImplementation(async (_vendor, sessionId) =>
-      sessionId === "session-a" ? sessionA : sessionB,
-    )
+    subscribeTrace.mockImplementation((_vendor, sessionId, onTrace) => {
+      onTrace(sessionId === "session-a" ? sessionA : sessionB)
+      return () => undefined
+    })
 
     const { result, rerender } = renderHook(
       ({ currentBinding }) =>
@@ -106,12 +106,10 @@ describe("useTimelineData", () => {
       turns: [turn("a-turn", 10, 20)],
     }
     let resolveResume: ((trace: EngineTrace) => void) | undefined
-    const resumedTrace = new Promise<EngineTrace>((resolve) => {
-      resolveResume = resolve
-    })
-    fetchTrace.mockImplementation(async (_vendor, sessionId) => {
-      if (sessionId === "session-a") return sessionA
-      return await resumedTrace
+    subscribeTrace.mockImplementation((_vendor, sessionId, onTrace) => {
+      if (sessionId === "session-a") onTrace(sessionA)
+      else resolveResume = onTrace
+      return () => undefined
     })
 
     const { result, rerender } = renderHook(
@@ -160,7 +158,10 @@ describe("useTimelineData", () => {
       sessionId: "session-a",
       turns: [turn("a-turn", 10, 20)],
     }
-    fetchTrace.mockResolvedValue(sessionA)
+    subscribeTrace.mockImplementation((_vendor, _sessionId, onTrace) => {
+      onTrace(sessionA)
+      return () => undefined
+    })
     const pending: EngineSessionTransition = {
       taskId: "task-1",
       tabId: "tab-1",
@@ -194,5 +195,138 @@ describe("useTimelineData", () => {
     act(() => rerender({ currentTransition: undefined }))
     expect(result.current.loaded).toBe(true)
     expect(result.current.model.turns[0]?.id).toBe("a-turn")
+  })
+
+  it("masks the previous trace when a new engine process has no session id yet", async () => {
+    subscribeTrace.mockImplementation((_vendor, _sessionId, onTrace) => {
+      onTrace({ sessionId: "session-a", turns: [turn("old-turn", 10, 20)] })
+      return () => undefined
+    })
+    const { result, rerender } = renderHook(
+      ({ currentBinding }: { currentBinding: EngineSessionBinding }) =>
+        useTimelineData({
+          taskId: "task-1",
+          vendor: "codex",
+          engineState: undefined,
+          binding: currentBinding,
+        }),
+      { initialProps: { currentBinding: binding("old-run", "session-a", 1) } },
+    )
+    await waitFor(() => expect(result.current.model.turns[0]?.id).toBe("old-turn"))
+
+    act(() =>
+      rerender({
+        currentBinding: {
+          ...binding("empty-run", "session-a", 30),
+          sessionId: null,
+          state: "pending",
+          source: "spawn",
+          startSource: undefined,
+        },
+      }),
+    )
+    expect(result.current.bindingState).toBe("empty")
+    expect(result.current.model).toEqual({ sessionId: "", turns: [] })
+  })
+
+  it("settles loading from the SSE error path without a parallel GET", async () => {
+    subscribeTrace.mockImplementation((_vendor, _sessionId, _onTrace, onError) => {
+      onError?.("trace unavailable")
+      return () => undefined
+    })
+    const { result } = renderHook(() =>
+      useTimelineData({
+        taskId: "task-1",
+        vendor: "codex",
+        engineState: undefined,
+        binding: binding("run-a", "session-a", 1),
+      }),
+    )
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.error).toBe("trace unavailable")
+  })
+
+  it("keeps the newest SSE snapshot when updates race inside resume loading", async () => {
+    let onResume: ((trace: EngineTrace) => void) | undefined
+    subscribeTrace.mockImplementation((_vendor, sessionId, onTrace) => {
+      if (sessionId === "session-a") onTrace({ sessionId, turns: [turn("a", 1, 2)] })
+      else onResume = onTrace
+      return () => undefined
+    })
+    const { result, rerender } = renderHook(
+      ({ currentBinding }) =>
+        useTimelineData({
+          taskId: "task-1",
+          vendor: "codex",
+          engineState: undefined,
+          binding: currentBinding,
+        }),
+      { initialProps: { currentBinding: binding("run-a", "session-a", 1) } },
+    )
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    act(() => rerender({ currentBinding: binding("run-b", "session-b", 3) }))
+    act(() => {
+      onResume?.({ sessionId: "session-b", turns: [turn("older", 3, 4)] })
+      onResume?.({ sessionId: "session-b", turns: [turn("newest", 5, 6)] })
+    })
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.model.turns.map((item) => item.id)).toEqual(["newest"])
+  })
+
+  it("ignores a stale snapshot delivered after switching sessions", async () => {
+    const listeners = new Map<string, (trace: EngineTrace) => void>()
+    const unsubscribers = new Map<string, ReturnType<typeof vi.fn>>()
+    subscribeTrace.mockImplementation((_vendor, sessionId, onTrace) => {
+      listeners.set(sessionId, onTrace)
+      const unsubscribe = vi.fn()
+      unsubscribers.set(sessionId, unsubscribe)
+      return unsubscribe
+    })
+    const { result, rerender } = renderHook(
+      ({ currentBinding }) =>
+        useTimelineData({
+          taskId: "task-1",
+          vendor: "codex",
+          engineState: undefined,
+          binding: currentBinding,
+        }),
+      { initialProps: { currentBinding: binding("run-a", "session-a", 1) } },
+    )
+    act(() => listeners.get("session-a")?.({ sessionId: "session-a", turns: [turn("a", 1, 2)] }))
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+
+    act(() => rerender({ currentBinding: binding("run-b", "session-b", 3) }))
+    expect(unsubscribers.get("session-a")).toHaveBeenCalledOnce()
+    act(() => {
+      listeners.get("session-b")?.({ sessionId: "session-b", turns: [turn("b", 3, 4)] })
+      listeners.get("session-a")?.({ sessionId: "session-a", turns: [turn("stale-a", 5, 6)] })
+    })
+
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.model).toEqual({ sessionId: "session-b", turns: [turn("b", 3, 4)] })
+  })
+
+  it("clears a settled stream error when a later full snapshot recovers", async () => {
+    let onTrace: ((trace: EngineTrace) => void) | undefined
+    let onError: ((message: string) => void) | undefined
+    subscribeTrace.mockImplementation((_vendor, _sessionId, traceListener, errorListener) => {
+      onTrace = traceListener
+      onError = errorListener
+      return () => undefined
+    })
+    const { result } = renderHook(() =>
+      useTimelineData({
+        taskId: "task-1",
+        vendor: "codex",
+        engineState: undefined,
+        binding: binding("run-a", "session-a", 1),
+      }),
+    )
+    act(() => onError?.("temporary failure"))
+    await waitFor(() => expect(result.current.error).toBe("temporary failure"))
+
+    act(() => onTrace?.({ sessionId: "session-a", turns: [turn("recovered", 2, 3)] }))
+    await waitFor(() => expect(result.current.error).toBeNull())
+    expect(result.current.model.turns.map((item) => item.id)).toEqual(["recovered"])
   })
 })

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -47,8 +47,13 @@ export async function recoverEngineSessionAdapter(
   return null
 }
 
-export async function observeEngineSessionActivationAdapter(vendor: VendorId, rootPid: number, afterMs: number) {
-  return (await engineEntry(vendor).observeSessionActivation?.({ rootPid, afterMs })) ?? null
+export async function observeEngineSessionActivationAdapter(
+  vendor: VendorId,
+  rootPid: number,
+  afterMs: number,
+  afterCursor?: string,
+) {
+  return (await engineEntry(vendor).observeSessionActivation?.({ rootPid, afterMs, afterCursor })) ?? null
 }
 
 async function getTask(link: DaemonRpcClient, taskId: string): Promise<SerializedTask> {

--- a/packages/kobe/src/engine/codex-local/session-activation.ts
+++ b/packages/kobe/src/engine/codex-local/session-activation.ts
@@ -33,6 +33,7 @@ export type EngineSessionActivation =
       readonly phase: "pending"
       readonly source: "resume"
       readonly observedAt: number
+      readonly cursor: string
     }
   | {
       readonly phase: "selected"
@@ -40,6 +41,7 @@ export type EngineSessionActivation =
       readonly transcriptPath?: string
       readonly source: "resume"
       readonly observedAt: number
+      readonly cursor: string
     }
 
 export interface CodexSessionActivationInput {
@@ -47,11 +49,17 @@ export interface CodexSessionActivationInput {
   readonly rootPid: number
   /** Ignore resume records at or before the current EngineRun update. */
   readonly afterMs: number
+  /** Opaque monotonic cursor returned by the previous observation. */
+  readonly afterCursor?: string
 }
 
 export interface CodexSessionActivationDeps {
   readonly findEnginePid: (rootPid: number) => Promise<{ vendor: string; pid: number } | null>
-  readonly latestResume: (pid: number, afterMs: number) => CodexResumeLogRow | null | Promise<CodexResumeLogRow | null>
+  readonly latestResume: (
+    pid: number,
+    afterMs: number,
+    afterCursor?: string,
+  ) => CodexResumeLogRow | null | Promise<CodexResumeLogRow | null>
 }
 
 function defaultCodexHome(): string {
@@ -77,6 +85,7 @@ export function parseCodexResumeLog(row: CodexResumeLogRow): EngineSessionActiva
       transcriptPath: quoted[1],
       source: "resume",
       observedAt: observedAtMs(row),
+      cursor: String(row.id),
     }
   }
 
@@ -94,15 +103,21 @@ export function parseCodexResumeLog(row: CodexResumeLogRow): EngineSessionActiva
         sessionId,
         source: "resume",
         observedAt: observedAtMs(row),
+        cursor: String(row.id),
       }
     : {
         phase: "pending",
         source: "resume",
         observedAt: observedAtMs(row),
+        cursor: String(row.id),
       }
 }
 
-async function latestResumeFromSqlite(pid: number, afterMs: number): Promise<CodexResumeLogRow | null> {
+async function latestResumeFromSqlite(
+  pid: number,
+  afterMs: number,
+  afterCursor?: string,
+): Promise<CodexResumeLogRow | null> {
   const path = join(defaultCodexHome(), "logs_2.sqlite")
   const { Database } = await import("bun:sqlite")
   let db: InstanceType<typeof Database> | null = null
@@ -110,12 +125,13 @@ async function latestResumeFromSqlite(pid: number, afterMs: number): Promise<Cod
     db = new Database(path, { readonly: true, create: false })
     const seconds = Math.floor(afterMs / 1000)
     const nanos = Math.floor(afterMs % 1000) * 1_000_000
+    const afterId = /^\d+$/.test(afterCursor ?? "") ? Number(afterCursor) : 0
     // A lexical range keeps SQLite on the process_uuid index. `LIKE
     // 'pid:N:%'` scanned the user's ~666MB log DB during diagnosis.
     const processLo = `pid:${pid}:`
     const processHi = `pid:${pid};`
     return db
-      .query<CodexResumeLogRow, [string, string, string, number, number, number]>(
+      .query<CodexResumeLogRow, [string, string, string, number, number, number, number]>(
         `SELECT id, ts, ts_nanos, feedback_log_body
            FROM logs
           WHERE process_uuid >= ?1 AND process_uuid < ?2
@@ -129,10 +145,11 @@ async function latestResumeFromSqlite(pid: number, afterMs: number): Promise<Cod
               )
             )
             AND (ts > ?4 OR (ts = ?5 AND ts_nanos > ?6))
+            AND id > ?7
           ORDER BY ts DESC, ts_nanos DESC, id DESC
           LIMIT 1`,
       )
-      .get(processLo, processHi, RESUME_TARGET, seconds, seconds, nanos)
+      .get(processLo, processHi, RESUME_TARGET, seconds, seconds, nanos, afterId)
   } catch {
     // Internal telemetry is a compatibility signal, never a reason to break
     // the engine. SessionStart remains the authoritative fallback.
@@ -157,6 +174,6 @@ export async function observeCodexSessionActivation(
   if (!Number.isInteger(input.rootPid) || input.rootPid <= 0 || !Number.isFinite(input.afterMs)) return null
   const engine = await deps.findEnginePid(input.rootPid)
   if (!engine || engine.vendor !== "codex") return null
-  const row = await deps.latestResume(engine.pid, Math.max(0, input.afterMs))
+  const row = await deps.latestResume(engine.pid, Math.max(0, input.afterMs), input.afterCursor)
   return row ? parseCodexResumeLog(row) : null
 }

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -124,6 +124,7 @@ export interface EngineRegistryEntry {
   readonly observeSessionActivation?: (input: {
     readonly rootPid: number
     readonly afterMs: number
+    readonly afterCursor?: string
   }) => Promise<EngineSessionActivation | null>
   /**
    * Read-only binary + login probe (Settings → Accounts). `deps` is the

--- a/packages/kobe/src/web/history.ts
+++ b/packages/kobe/src/web/history.ts
@@ -30,12 +30,13 @@
 import { isAbsolute } from "node:path"
 import { errorMessage } from "@/lib/error-message"
 import { engineEntry } from "../engine/registry.ts"
+import { TraceSnapshotMonitor } from "./trace-snapshot-monitor.ts"
 
 const SESSIONS_ROUTE = "/api/history/sessions"
 const MESSAGES_ROUTE = "/api/history/messages"
 const TRACE_ROUTE = "/api/history/trace"
 const TRACE_EVENTS_ROUTE = "/api/history/trace/events"
-const TRACE_REVISION_POLL_MS = 350
+const traceSnapshots = new TraceSnapshotMonitor((vendor) => engineEntry(vendor).history)
 
 /** Vendor ids are registry keys / user-registered slugs — never paths. */
 function isSafeVendor(value: unknown): value is string {
@@ -117,19 +118,16 @@ function handleTraceEvents(req: Request, url: URL): Response {
     return Response.json({ error: "invalid sessionId" }, { status: 400 })
   }
 
-  const reader = engineEntry(vendor).history
   const encoder = new TextEncoder()
-  let timer: ReturnType<typeof setInterval> | undefined
   let closed = false
-  let inFlight = false
-  let lastRevision = Number.NaN
+  let unsubscribe: (() => void) | undefined
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       const close = (): void => {
         if (closed) return
         closed = true
-        if (timer) clearInterval(timer)
+        unsubscribe?.()
       }
       const send = (event: string, data: unknown, id?: number): void => {
         if (closed) return
@@ -140,29 +138,15 @@ function handleTraceEvents(req: Request, url: URL): Response {
           close()
         }
       }
-      const refresh = async (force: boolean): Promise<void> => {
-        if (closed || inFlight) return
-        inFlight = true
-        try {
-          const revision = reader.traceRevision ? await reader.traceRevision(sessionId) : 0
-          if (!force && (!reader.traceRevision || revision === lastRevision)) return
-          const trace = reader.readTrace ? await reader.readTrace(sessionId) : { sessionId, turns: [] }
-          lastRevision = revision
-          send("trace", trace, revision)
-        } catch (err) {
-          send("trace-error", { error: errorMessage(err) })
-        } finally {
-          inFlight = false
-        }
-      }
-
-      void refresh(true)
-      timer = setInterval(() => void refresh(false), TRACE_REVISION_POLL_MS)
+      unsubscribe = traceSnapshots.subscribe(vendor, sessionId, {
+        trace: (trace, revision) => send("trace", trace, revision),
+        error: (err) => send("trace-error", { error: errorMessage(err) }),
+      })
       req.signal.addEventListener("abort", close, { once: true })
     },
     cancel() {
       closed = true
-      if (timer) clearInterval(timer)
+      unsubscribe?.()
     },
   })
 

--- a/packages/kobe/src/web/trace-snapshot-monitor.ts
+++ b/packages/kobe/src/web/trace-snapshot-monitor.ts
@@ -1,0 +1,89 @@
+/** Session-keyed trace polling shared by every SSE subscriber in this process. */
+
+import type { EngineHistoryReader } from "../engine/registry.ts"
+import type { EngineTrace } from "../types/engine-trace.ts"
+
+export interface TraceSnapshotListener {
+  readonly trace: (trace: EngineTrace, revision: number) => void
+  readonly error: (error: unknown) => void
+}
+
+interface TraceWatch {
+  readonly vendor: string
+  readonly sessionId: string
+  readonly reader: EngineHistoryReader
+  readonly listeners: Set<TraceSnapshotListener>
+  timer: ReturnType<typeof setInterval>
+  revision: number
+  snapshot?: EngineTrace
+  inFlight: boolean
+}
+
+export class TraceSnapshotMonitor {
+  private readonly watches = new Map<string, TraceWatch>()
+
+  constructor(
+    private readonly readerFor: (vendor: string) => EngineHistoryReader,
+    private readonly pollMs = 350,
+  ) {}
+
+  subscribe(vendor: string, sessionId: string, listener: TraceSnapshotListener): () => void {
+    const key = `${vendor}\0${sessionId}`
+    let watch = this.watches.get(key)
+    if (!watch) {
+      watch = {
+        vendor,
+        sessionId,
+        reader: this.readerFor(vendor),
+        listeners: new Set(),
+        revision: Number.NaN,
+        inFlight: false,
+        timer: setInterval(() => void this.refresh(key, false), this.pollMs),
+      }
+      watch.timer.unref?.()
+      this.watches.set(key, watch)
+    }
+    watch.listeners.add(listener)
+    if (watch.snapshot) listener.trace(watch.snapshot, watch.revision)
+    else void this.refresh(key, true)
+
+    return () => {
+      const current = this.watches.get(key)
+      if (!current) return
+      current.listeners.delete(listener)
+      if (current.listeners.size > 0) return
+      clearInterval(current.timer)
+      this.watches.delete(key)
+    }
+  }
+
+  async tick(): Promise<void> {
+    await Promise.all([...this.watches.keys()].map((key) => this.refresh(key, false)))
+  }
+
+  size(): number {
+    return this.watches.size
+  }
+
+  private async refresh(key: string, force: boolean): Promise<void> {
+    const watch = this.watches.get(key)
+    if (!watch || watch.inFlight) return
+    watch.inFlight = true
+    try {
+      const revision = watch.reader.traceRevision ? await watch.reader.traceRevision(watch.sessionId) : 0
+      if (!force && (!watch.reader.traceRevision || revision === watch.revision)) return
+      const snapshot = watch.reader.readTrace
+        ? await watch.reader.readTrace(watch.sessionId)
+        : { sessionId: watch.sessionId, turns: [] }
+      if (this.watches.get(key) !== watch) return
+      watch.revision = revision
+      watch.snapshot = snapshot
+      for (const listener of watch.listeners) listener.trace(snapshot, revision)
+    } catch (error) {
+      if (this.watches.get(key) !== watch) return
+      for (const listener of watch.listeners) listener.error(error)
+    } finally {
+      watch.inFlight = false
+    }
+  }
+}

--- a/packages/kobe/test/daemon/engine-session-monitor.test.ts
+++ b/packages/kobe/test/daemon/engine-session-monitor.test.ts
@@ -1,0 +1,175 @@
+import { EngineSessionMonitor } from "@sma1lboy/kobe-daemon/daemon/engine-session-monitor"
+import { describe, expect, it, vi } from "vitest"
+
+function monitorHarness(
+  observe: ReturnType<typeof vi.fn>,
+  options: {
+    getTask?: () => unknown
+    now?: () => number
+    leaseMs?: number
+  } = {},
+) {
+  const bind = vi.fn(async () => ({}))
+  const markTransition = vi.fn()
+  const pinTabSession = vi.fn()
+  const monitor = new EngineSessionMonitor(
+    { getTask: options.getTask ?? (() => ({ id: "task-1" })) } as never,
+    { observeEngineSessionActivation: observe } as never,
+    { bind, markTransition } as never,
+    { pinTabSession },
+    {
+      pollMs: 60_000,
+      ...(options.now ? { now: options.now } : {}),
+      ...(options.leaseMs ? { leaseMs: options.leaseMs } : {}),
+    },
+  )
+  return { monitor, bind, markTransition, pinTabSession }
+}
+
+describe("EngineSessionMonitor", () => {
+  it("keeps observing one PTY across pending and selected resume phases", async () => {
+    const observe = vi
+      .fn()
+      .mockResolvedValueOnce({ phase: "pending", source: "resume", observedAt: 101, cursor: "1" })
+      .mockResolvedValueOnce({
+        phase: "selected",
+        source: "resume",
+        observedAt: 102,
+        cursor: "2",
+        sessionId: "session-2",
+        transcriptPath: "/tmp/session-2.jsonl",
+      })
+    const { monitor, bind, markTransition, pinTabSession } = monitorHarness(observe)
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 42, startedAt: 100 })
+    await vi.waitFor(() => expect(markTransition).toHaveBeenCalledOnce())
+    await monitor.tick()
+
+    expect(observe).toHaveBeenNthCalledWith(1, "codex", 42, 100, undefined)
+    expect(observe).toHaveBeenNthCalledWith(2, "codex", 42, 100, "1")
+    expect(bind).toHaveBeenCalledWith({
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+      sessionId: "session-2",
+      source: "observer",
+      startSource: "resume",
+      transcriptPath: "/tmp/session-2.jsonl",
+    })
+    expect(pinTabSession).toHaveBeenCalledWith("task-1", "tab-a", "session-2")
+    expect(monitor.size()).toBe(1)
+    monitor.close()
+  })
+
+  it("does not let an old PID unregister its replacement", () => {
+    const { monitor } = monitorHarness(vi.fn(async () => null))
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 1, startedAt: 100 })
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 2, startedAt: 200 })
+    expect(monitor.unwatch({ taskId: "task-1", tabId: "tab-a", rootPid: 1 })).toBe(false)
+    expect(monitor.size()).toBe(1)
+    expect(monitor.unwatch({ taskId: "task-1", tabId: "tab-a", rootPid: 2 })).toBe(true)
+    monitor.close()
+  })
+
+  it("ignores a delayed heartbeat from an older process incarnation", () => {
+    const { monitor } = monitorHarness(vi.fn(async () => null))
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 2, startedAt: 200 })
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 1, startedAt: 100 })
+
+    expect(monitor.unwatch({ taskId: "task-1", tabId: "tab-a", rootPid: 1 })).toBe(false)
+    expect(monitor.unwatch({ taskId: "task-1", tabId: "tab-a", rootPid: 2 })).toBe(true)
+    monitor.close()
+  })
+
+  it("replaces a stale watch when the OS reuses the same PID", async () => {
+    const observe = vi.fn(async () => null)
+    const { monitor } = monitorHarness(observe)
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 2, startedAt: 100 })
+    await vi.waitFor(() => expect(observe).toHaveBeenCalledOnce())
+
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 2, startedAt: 200 })
+    await vi.waitFor(() => expect(observe).toHaveBeenCalledTimes(2))
+
+    expect(observe).toHaveBeenNthCalledWith(2, "codex", 2, 200, undefined)
+    monitor.close()
+  })
+
+  it("drops a stale async activation after the watched process is replaced", async () => {
+    let resolveOld: ((value: unknown) => void) | undefined
+    const observe = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOld = resolve
+          }),
+      )
+      .mockResolvedValueOnce({
+        phase: "selected",
+        source: "resume",
+        observedAt: 202,
+        cursor: "2",
+        sessionId: "session-new",
+      })
+    const { monitor, bind } = monitorHarness(observe)
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 1, startedAt: 100 })
+    await vi.waitFor(() => expect(observe).toHaveBeenCalledOnce())
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 2, startedAt: 200 })
+    await vi.waitFor(() => expect(bind).toHaveBeenCalledOnce())
+
+    resolveOld?.({
+      phase: "selected",
+      source: "resume",
+      observedAt: 102,
+      cursor: "1",
+      sessionId: "session-old",
+    })
+    await Promise.resolve()
+
+    expect(bind).toHaveBeenCalledTimes(1)
+    expect(bind).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "session-new" }))
+    monitor.close()
+  })
+
+  it("expires a watch whose sidecar lease stops heartbeating", async () => {
+    let now = 100
+    const { monitor } = monitorHarness(
+      vi.fn(async () => null),
+      { now: () => now, leaseMs: 10 },
+    )
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 1, startedAt: 100 })
+    expect(monitor.size()).toBe(1)
+    now = 111
+    await monitor.tick()
+    expect(monitor.size()).toBe(0)
+    monitor.close()
+  })
+
+  it("stops watching when its task no longer exists", async () => {
+    const { monitor } = monitorHarness(
+      vi.fn(async () => null),
+      { getTask: () => undefined },
+    )
+    monitor.watch({ taskId: "deleted", tabId: "tab-a", vendor: "codex", rootPid: 1, startedAt: 100 })
+    await vi.waitFor(() => expect(monitor.size()).toBe(0))
+    monitor.close()
+  })
+
+  it("retries a selected activation when durable binding fails", async () => {
+    const observe = vi.fn(async () => ({
+      phase: "selected" as const,
+      source: "resume" as const,
+      observedAt: 102,
+      cursor: "2",
+      sessionId: "session-2",
+    }))
+    const { monitor, bind } = monitorHarness(observe)
+    bind.mockRejectedValueOnce(new Error("disk unavailable")).mockResolvedValueOnce({})
+    monitor.watch({ taskId: "task-1", tabId: "tab-a", vendor: "codex", rootPid: 42, startedAt: 100 })
+    await vi.waitFor(() => expect(bind).toHaveBeenCalledOnce())
+    await monitor.tick()
+
+    expect(observe).toHaveBeenNthCalledWith(2, "codex", 42, 100, undefined)
+    expect(bind).toHaveBeenCalledTimes(2)
+    monitor.close()
+  })
+})

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -2,6 +2,7 @@ import type { DaemonRpcClient } from "@sma1lboy/kobe-daemon/client/rpc"
 import type { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
 import type { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
 import type { AutomationsStore } from "@sma1lboy/kobe-daemon/daemon/automations-store"
+import type { EngineSessionMonitor } from "@sma1lboy/kobe-daemon/daemon/engine-session-monitor"
 import type { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import type { IssuesStore } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import type { QuotaUsageCache } from "@sma1lboy/kobe-daemon/daemon/quota-usage-cache"
@@ -111,6 +112,10 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
       deleteTask: async () => {},
       deleteTaskBestEffort: async () => {},
     } as unknown as SessionBindingStore,
+    engineSessionMonitor: {
+      watch: () => {},
+      unwatch: () => false,
+    } as unknown as EngineSessionMonitor,
     deletions: {
       enqueue: (taskId: string) => rec.deletions.push(taskId),
     },

--- a/packages/kobe/test/daemon/handlers-runtime.test.ts
+++ b/packages/kobe/test/daemon/handlers-runtime.test.ts
@@ -235,6 +235,7 @@ describe("daemon runtime handlers", () => {
         transcriptPath: "/tmp/observed-rollout.jsonl",
         source: "resume" as const,
         observedAt: 1234,
+        cursor: "11",
       }))
       ;(ctx as { runtime: DaemonHandlerContext["runtime"] }).runtime = {
         ...ctx.runtime,
@@ -264,6 +265,7 @@ describe("daemon runtime handlers", () => {
           phase: "pending",
           source: "resume",
           observedAt: 1_234,
+          cursor: "12",
         }),
       }
 
@@ -280,6 +282,40 @@ describe("daemon runtime handlers", () => {
         },
       ])
       expect(rec.bindings).toEqual([])
+    })
+
+    it("registers and unregisters a validated continuous engine-process watch", async () => {
+      const { ctx } = fakeCtx({ getTask: () => ({ ...TASK, vendor: "codex" }) })
+      const watch = vi.fn()
+      const unwatch = vi.fn(() => true)
+      ;(ctx as { engineSessionMonitor: DaemonHandlerContext["engineSessionMonitor"] }).engineSessionMonitor = {
+        watch,
+        unwatch,
+      } as unknown as DaemonHandlerContext["engineSessionMonitor"]
+
+      await expect(
+        dispatch("engine.watchSession", { taskId: "t1", tabId: "tab-codex", rootPid: 4242, startedAt: 1_000 }, ctx),
+      ).resolves.toEqual({ watching: true })
+      expect(watch).toHaveBeenCalledWith({
+        taskId: "t1",
+        tabId: "tab-codex",
+        vendor: "codex",
+        rootPid: 4242,
+        startedAt: 1_000,
+      })
+      await expect(
+        dispatch("engine.unwatchSession", { taskId: "t1", tabId: "tab-codex", rootPid: 4242 }, ctx),
+      ).resolves.toEqual({ removed: true })
+    })
+
+    it("rejects invalid process-incarnation watch parameters", async () => {
+      const { ctx } = fakeCtx({ getTask: () => ({ ...TASK, vendor: "codex" }) })
+      await expect(
+        dispatch("engine.watchSession", { taskId: "t1", tabId: "tab-codex", rootPid: 0, startedAt: 1_000 }, ctx),
+      ).rejects.toThrow("rootPid must be a positive integer")
+      await expect(
+        dispatch("engine.watchSession", { taskId: "t1", tabId: "tab-codex", rootPid: 42, startedAt: -1 }, ctx),
+      ).rejects.toThrow("startedAt must be a non-negative number")
     })
 
     it("recovers a native session only for a tab-scoped session-start from an older hook reporter", async () => {

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -102,6 +102,8 @@ describe("daemon handler registry", () => {
       "engine.beginSession",
       "engine.pinSession",
       "engine.observeSession",
+      "engine.watchSession",
+      "engine.unwatchSession",
       "attention.dismiss",
       "attention.read",
       "automation.list",

--- a/packages/kobe/test/daemon/session-bindings-recovery.test.ts
+++ b/packages/kobe/test/daemon/session-bindings-recovery.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { SessionBindingStore } from "@sma1lboy/kobe-daemon/daemon/session-bindings"
+import { describe, expect, it } from "vitest"
+
+async function loadCurrent(runs: unknown[]) {
+  const dir = await mkdtemp(join(tmpdir(), "kobe-session-binding-recovery-"))
+  const path = join(dir, "session-bindings.json")
+  const current = runs.at(-1) as { taskId: string; tabId: string; runId: string }
+  await writeFile(
+    path,
+    JSON.stringify({
+      version: 2,
+      runs,
+      currentRuns: [{ taskId: current.taskId, tabId: current.tabId, runId: current.runId }],
+    }),
+    "utf8",
+  )
+  const store = new SessionBindingStore(path, new DaemonEventBus(), () => 40)
+  await store.init()
+  return store
+}
+
+const orphan = {
+  runId: "orphan",
+  taskId: "task-1",
+  tabId: "tab-a",
+  vendor: "codex",
+  sessionId: null,
+  state: "pending",
+  source: "spawn",
+  startedAt: 30,
+  updatedAt: 30,
+}
+
+describe("SessionBindingStore recovery", () => {
+  it("marks an orphan pending run empty instead of attaching historical identity", async () => {
+    const store = await loadCurrent([
+      {
+        ...orphan,
+        runId: "identified",
+        sessionId: "session-1",
+        state: "superseded",
+        source: "hook",
+        startedAt: 10,
+        updatedAt: 20,
+      },
+      orphan,
+    ])
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({
+      runId: "orphan",
+      sessionId: null,
+      state: "missing",
+    })
+    expect(store.runsSnapshot()).toContainEqual(
+      expect.objectContaining({ runId: "identified", sessionId: "session-1", state: "superseded" }),
+    )
+  })
+
+  it("marks an orphan pending current run missing when no identity can be restored", async () => {
+    const store = await loadCurrent([orphan])
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({ runId: "orphan", state: "missing" })
+  })
+})

--- a/packages/kobe/test/daemon/session-bindings.test.ts
+++ b/packages/kobe/test/daemon/session-bindings.test.ts
@@ -69,7 +69,7 @@ describe("SessionBindingStore", () => {
     expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ version: 2 })
   })
 
-  it("a new spawn on the same tab replaces the old session identity", async () => {
+  it("opens an unidentified run without attaching the previous session", async () => {
     const { store } = await fixture()
     await store.begin("task-1", "tab-a", "claude")
     await store.bind({
@@ -79,18 +79,25 @@ describe("SessionBindingStore", () => {
       sessionId: "old",
       source: "spawn",
     })
-    await store.begin("task-1", "tab-a", "codex")
-    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({
+    const empty = await store.begin("task-1", "tab-a", "codex")
+    expect(empty).toMatchObject({ vendor: "codex", sessionId: null, state: "pending" })
+
+    const bound = await store.bind({
+      taskId: "task-1",
+      tabId: "tab-a",
       vendor: "codex",
-      sessionId: null,
-      state: "pending",
-      startedAt: 300,
+      sessionId: "new",
+      source: "hook",
+      eventKind: "session-start",
+      startSource: "startup",
     })
+    expect(bound.runId).toBe(empty.runId)
+    expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toMatchObject({ vendor: "codex", sessionId: "new" })
   })
 
-  it("begins a new run for a new same-vendor PTY spawn and deduplicates pending reads", async () => {
+  it("deduplicates repeated begins for the same unidentified spawn", async () => {
     const { store } = await fixture()
-    const initial = await store.begin("task-1", "tab-a", "codex")
+    await store.begin("task-1", "tab-a", "codex")
     await store.bind({
       taskId: "task-1",
       tabId: "tab-a",
@@ -100,8 +107,7 @@ describe("SessionBindingStore", () => {
     })
     const pending = await store.begin("task-1", "tab-a", "codex")
 
-    expect(pending.runId).not.toBe(initial.runId)
-    expect(pending).toMatchObject({ sessionId: null, state: "pending", startedAt: 300 })
+    expect(pending).toMatchObject({ sessionId: null, state: "pending" })
     expect(await store.begin("task-1", "tab-a", "codex")).toEqual(pending)
     expect(store.snapshotByTask()["task-1"]?.["tab-a"]).toEqual(pending)
   })
@@ -413,6 +419,35 @@ describe("SessionBindingStore", () => {
         channel: "session.bindings",
         payload: { bindings: {}, transitions: {} },
       })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("refreshes a pending resume transition while the engine is still loading", async () => {
+    const { store } = await fixture(undefined, 4_000)
+    vi.useFakeTimers()
+    try {
+      const transition = {
+        taskId: "task-1",
+        tabId: "tab-a",
+        vendor: "codex" as const,
+        startSource: "resume" as const,
+        observedAt: 350,
+      }
+      store.markTransition(transition)
+      vi.advanceTimersByTime(3_000)
+      store.markTransition(transition)
+      vi.advanceTimersByTime(2_000)
+
+      expect(store.transitionSnapshotByTask()).toEqual({
+        "task-1": {
+          "tab-a": transition,
+        },
+      })
+
+      vi.advanceTimersByTime(2_000)
+      expect(store.transitionSnapshotByTask()).toEqual({})
     } finally {
       vi.useRealTimers()
     }

--- a/packages/kobe/test/daemon/web-exposure.test.ts
+++ b/packages/kobe/test/daemon/web-exposure.test.ts
@@ -1,8 +1,9 @@
+import type { DaemonRpcClient } from "@sma1lboy/kobe-daemon/client/rpc"
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { createDaemonHandlerRegistry, shapeDaemonError } from "@sma1lboy/kobe-daemon/daemon/server"
 import { WEB_RPC_ALLOWLIST, WEB_RPC_ALLOWSET } from "@sma1lboy/kobe-daemon/daemon/web-rpc-allowlist"
-import { webExposedRpcNames, webRpcErrorBody } from "@sma1lboy/kobe-daemon/daemon/web-server"
-import { describe, expect, it } from "vitest"
+import { prepareEngineSpecSession, webExposedRpcNames, webRpcErrorBody } from "@sma1lboy/kobe-daemon/daemon/web-server"
+import { describe, expect, it, vi } from "vitest"
 
 /**
  * Web-exposure policy + error-shape parity for the unified dispatch seam.
@@ -28,6 +29,8 @@ const EXPOSED: readonly DaemonRequestName[] = [
   "automation.update",
   "daemon.status",
   "engine.observeSession",
+  "engine.unwatchSession",
+  "engine.watchSession",
   "task.archive",
   "task.create",
   "task.delete",
@@ -106,5 +109,27 @@ describe("socket/web error-shape parity", () => {
     const err = new TypeError("bad type")
     expect(shapeDaemonError(err)).toEqual({ message: "bad type", name: "TypeError" })
     expect(webRpcErrorBody(err)).toEqual({ error: "bad type", name: "TypeError" })
+  })
+})
+
+describe("engine spec session identity", () => {
+  it("opens an empty run when the engine cannot accept a caller-owned id", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    await prepareEngineSpecSession({ request } as unknown as DaemonRpcClient, "task-1", "tab-a", "codex", undefined)
+    expect(request).toHaveBeenCalledOnce()
+    expect(request).toHaveBeenCalledWith("engine.beginSession", {
+      taskId: "task-1",
+      tabId: "tab-a",
+      vendor: "codex",
+    })
+  })
+
+  it("pins a caller-owned session id into the run it just opened", async () => {
+    const request = vi.fn().mockResolvedValue({})
+    await prepareEngineSpecSession({ request } as unknown as DaemonRpcClient, "task-1", "tab-a", "claude", "session-1")
+    expect(request.mock.calls).toEqual([
+      ["engine.beginSession", { taskId: "task-1", tabId: "tab-a", vendor: "claude" }],
+      ["engine.pinSession", { taskId: "task-1", tabId: "tab-a", vendor: "claude", sessionId: "session-1" }],
+    ])
   })
 })

--- a/packages/kobe/test/engine/codex-session-activation.test.ts
+++ b/packages/kobe/test/engine/codex-session-activation.test.ts
@@ -19,6 +19,7 @@ describe("Codex session activation observer", () => {
       transcriptPath: TRANSCRIPT,
       source: "resume",
       observedAt: 1_786_022_485_925,
+      cursor: "7",
     })
   })
 
@@ -35,6 +36,7 @@ describe("Codex session activation observer", () => {
       sessionId: SESSION_ID,
       source: "resume",
       observedAt: 1_786_081_735_042,
+      cursor: "8",
     })
   })
 
@@ -51,6 +53,7 @@ describe("Codex session activation observer", () => {
       phase: "pending",
       source: "resume",
       observedAt: 1_786_081_734_500,
+      cursor: "9",
     })
   })
 
@@ -74,14 +77,14 @@ describe("Codex session activation observer", () => {
     }))
     await expect(
       observeCodexSessionActivation(
-        { rootPid: 400, afterMs: 1_786_022_480_000 },
+        { rootPid: 400, afterMs: 1_786_022_480_000, afterCursor: "7" },
         {
           findEnginePid: async () => ({ vendor: "codex", pid: 401 }),
           latestResume,
         },
       ),
     ).resolves.toMatchObject({ phase: "selected", sessionId: SESSION_ID })
-    expect(latestResume).toHaveBeenCalledWith(401, 1_786_022_480_000)
+    expect(latestResume).toHaveBeenCalledWith(401, 1_786_022_480_000, "7")
   })
 
   it("does not inspect another engine's process", async () => {
@@ -95,6 +98,27 @@ describe("Codex session activation observer", () => {
         },
       ),
     ).resolves.toBeNull()
+    expect(latestResume).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed rollout evidence instead of binding a guessed session", () => {
+    expect(
+      parseCodexResumeLog({
+        id: 11,
+        ts: 1_786_081_736,
+        ts_nanos: 0,
+        feedback_log_body: "Resuming rollout from an unquoted transcript",
+      }),
+    ).toBeNull()
+  })
+
+  it("rejects invalid root process identity without reading logs", async () => {
+    const findEnginePid = vi.fn()
+    const latestResume = vi.fn()
+    await expect(
+      observeCodexSessionActivation({ rootPid: 0, afterMs: 0 }, { findEnginePid, latestResume }),
+    ).resolves.toBeNull()
+    expect(findEnginePid).not.toHaveBeenCalled()
     expect(latestResume).not.toHaveBeenCalled()
   })
 })

--- a/packages/kobe/test/web/trace-snapshot-monitor.test.ts
+++ b/packages/kobe/test/web/trace-snapshot-monitor.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest"
+import type { EngineHistoryReader } from "../../src/engine/registry.ts"
+import { TraceSnapshotMonitor } from "../../src/web/trace-snapshot-monitor.ts"
+
+describe("TraceSnapshotMonitor", () => {
+  it("shares one history read across subscribers and tears down when the last leaves", async () => {
+    const revision = vi.fn(async () => 1)
+    const readTrace = vi.fn(async (sessionId: string) => ({ sessionId, turns: [] }))
+    const monitor = new TraceSnapshotMonitor(
+      () => ({ traceRevision: revision, readTrace }) as unknown as EngineHistoryReader,
+      60_000,
+    )
+    const a = vi.fn()
+    const b = vi.fn()
+    const offA = monitor.subscribe("codex", "session-1", { trace: a, error: vi.fn() })
+    const offB = monitor.subscribe("codex", "session-1", { trace: b, error: vi.fn() })
+    await vi.waitFor(() => expect(a).toHaveBeenCalledOnce())
+
+    expect(revision).toHaveBeenCalledOnce()
+    expect(readTrace).toHaveBeenCalledOnce()
+    expect(b).toHaveBeenCalledWith({ sessionId: "session-1", turns: [] }, 1)
+    expect(monitor.size()).toBe(1)
+    offA()
+    expect(monitor.size()).toBe(1)
+    offB()
+    expect(monitor.size()).toBe(0)
+  })
+
+  it("broadcasts only when the shared revision advances", async () => {
+    let currentRevision = 1
+    const readTrace = vi.fn(async (sessionId: string) => ({ sessionId, turns: [] }))
+    const monitor = new TraceSnapshotMonitor(
+      () => ({ traceRevision: async () => currentRevision, readTrace }) as unknown as EngineHistoryReader,
+      60_000,
+    )
+    const trace = vi.fn()
+    const off = monitor.subscribe("codex", "session-1", { trace, error: vi.fn() })
+    await vi.waitFor(() => expect(trace).toHaveBeenCalledOnce())
+    await monitor.tick()
+    expect(readTrace).toHaveBeenCalledOnce()
+    currentRevision = 2
+    await monitor.tick()
+    expect(readTrace).toHaveBeenCalledTimes(2)
+    expect(trace).toHaveBeenCalledTimes(2)
+    off()
+  })
+
+  it("serves a late subscriber from the cached full snapshot", async () => {
+    const readTrace = vi.fn(async (sessionId: string) => ({ sessionId, turns: [] }))
+    const monitor = new TraceSnapshotMonitor(
+      () => ({ traceRevision: async () => 1, readTrace }) as unknown as EngineHistoryReader,
+      60_000,
+    )
+    const first = vi.fn()
+    const offFirst = monitor.subscribe("codex", "session-1", { trace: first, error: vi.fn() })
+    await vi.waitFor(() => expect(first).toHaveBeenCalledOnce())
+
+    const late = vi.fn()
+    const offLate = monitor.subscribe("codex", "session-1", { trace: late, error: vi.fn() })
+    expect(late).toHaveBeenCalledWith({ sessionId: "session-1", turns: [] }, 1)
+    expect(readTrace).toHaveBeenCalledOnce()
+    offFirst()
+    offLate()
+  })
+
+  it("recovers on the next poll after a transient history error", async () => {
+    const revision = vi.fn().mockRejectedValueOnce(new Error("temporarily unavailable")).mockResolvedValue(1)
+    const readTrace = vi.fn(async (sessionId: string) => ({ sessionId, turns: [] }))
+    const monitor = new TraceSnapshotMonitor(
+      () => ({ traceRevision: revision, readTrace }) as unknown as EngineHistoryReader,
+      60_000,
+    )
+    const trace = vi.fn()
+    const error = vi.fn()
+    const off = monitor.subscribe("codex", "session-1", { trace, error })
+    await vi.waitFor(() => expect(error).toHaveBeenCalledOnce())
+
+    await monitor.tick()
+    expect(trace).toHaveBeenCalledWith({ sessionId: "session-1", turns: [] }, 1)
+    off()
+  })
+
+  it("keeps sessions isolated when their revisions advance independently", async () => {
+    const revisions = new Map([
+      ["session-a", 1],
+      ["session-b", 1],
+    ])
+    const reader = {
+      traceRevision: async (sessionId: string) => revisions.get(sessionId) ?? 0,
+      readTrace: async (sessionId: string) => ({ sessionId, turns: [] }),
+    } as unknown as EngineHistoryReader
+    const monitor = new TraceSnapshotMonitor(() => reader, 60_000)
+    const a = vi.fn()
+    const b = vi.fn()
+    const offA = monitor.subscribe("codex", "session-a", { trace: a, error: vi.fn() })
+    const offB = monitor.subscribe("codex", "session-b", { trace: b, error: vi.fn() })
+    await vi.waitFor(() => {
+      expect(a).toHaveBeenCalledOnce()
+      expect(b).toHaveBeenCalledOnce()
+    })
+
+    revisions.set("session-a", 2)
+    await monitor.tick()
+    expect(a).toHaveBeenCalledTimes(2)
+    expect(b).toHaveBeenCalledOnce()
+    offA()
+    offB()
+  })
+})


### PR DESCRIPTION
## Summary
- render structured Agent Trace blocks as readable, directly quotable content with a removable tab-scoped composer buffer
- move Codex context detection to a daemon-owned process monitor so native /resume changes no longer depend on an Enter-triggered frontend observer
- identify PTY incarnations by PID plus start time, reject stale heartbeats, and recover watches after daemon restart
- share one engine-owned Trace snapshot poll per native session and make its SSE snapshot the frontend settled source
- repair abandoned pending runs to a stable empty state instead of leaking the previous conversation

## Adversarial coverage
- fresh session and first turn
- resume picker cancellation and active-writer rejection
- A to B to A context switching with pending/loading state
- 20-turn and 514-event history restoration
- cross-ChatTab isolation and rapid switching
- daemon-only restart followed by another successful /resume
- same numeric PID reused by a newer process incarnation
- stale async completion, stale heartbeat, lease expiry, and deleted task
- malformed Codex rollout evidence and invalid process identities
- transient Trace read errors, late subscribers, independent sessions, and stale frontend snapshots

## Validation
- Kobe fast: 293 files, 2746 tests passed
- daemon socket: 60 files, 516 tests passed
- kobe-web: 79 files, 630 tests passed
- Desktop: 3 tests passed
- plugin SDK: 5 files, 11 tests passed
- root typecheck and lint passed
- kobe-web production build passed
- touched-source file-size gate passed; largest touched source is 499 lines
- git diff check passed

The repository-wide kobe-web formatter still reports 19 pre-existing errors in unrelated files. Targeted checks for the touched Web TypeScript files pass, and changed sidecar modules are covered by the full Web suite and production build.

## Base
This PR intentionally targets feat/gui-chat-shell. The desktop shell remains isolated from main.