### PR TITLE
fix: cursor overlay counts a zero-width mark as part of its base cell

### DIFF
--- a/.changeset/cursor-overlay-zero-width.md
+++ b/.changeset/cursor-overlay-zero-width.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep the embedded terminal's cursor overlay on the character it's actually over when the line holds a zero-width mark. Combining accents (NFD text like café), emoji variation selectors, and joiners fold onto their base cell in the terminal, but the overlay had been counting each as its own column — so a mark to the left of the cursor drifted the inverse cell one column right, highlighting the bare mark instead of the char under the cursor. The same miscount let a row-end attribute (an underlined URL) leak past its last visible cell. Both now measure cells the same way the rest of the app does, so the overlay lands true and the seal covers the real last column.

--- a/packages/kobe/src/tui/panes/terminal/terminal-render.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-render.ts
@@ -12,6 +12,17 @@ export function isShellMissing(message: string): boolean {
   return m.includes("enoent") || m.includes("not found")
 }
 
+/**
+ * Cells a single grapheme code point occupies, matching `displayWidth`'s
+ * accounting exactly: a zero-width mark (combining diacritic, emoji variation
+ * selector, ZWJ/bidi control) contributes 0. xterm folds such a mark onto its
+ * base char's cell, so counting it as 1 drifts the cell-column cursor right by
+ * one column per mark to its left — do NOT `|| 1` this back to a width of one.
+ */
+function cellWidth(ch: string): number {
+  return charWidth(ch.codePointAt(0) as number)
+}
+
 function cloneChunk(c: Chunk, text: string, attrs = c.attributes ?? 0): Chunk {
   return {
     text,
@@ -24,7 +35,7 @@ function cloneChunk(c: Chunk, text: string, attrs = c.attributes ?? 0): Chunk {
 /** Sum the display width (in cells) of a chunk's text. */
 function chunkCells(chars: readonly string[]): number {
   let w = 0
-  for (const ch of chars) w += charWidth(ch.codePointAt(0) as number) || 1
+  for (const ch of chars) w += cellWidth(ch)
   return w
 }
 
@@ -51,7 +62,7 @@ function overlayCursorRow(row: readonly Chunk[], x: number): Chunk[] {
     let localCol = col
     let hit = -1
     for (let idx = 0; idx < chars.length; idx++) {
-      const w = charWidth((chars[idx] as string).codePointAt(0) as number) || 1
+      const w = cellWidth(chars[idx] as string)
       if (x >= localCol && x < localCol + w) {
         hit = idx
         break
@@ -137,7 +148,7 @@ export function sealRowEndAttributes(
       const chars = Array.from(chunk.text)
       for (let j = 0; j < chars.length; j++) {
         const ch = chars[j] as string
-        const w = charWidth(ch.codePointAt(0) as number) || 1
+        const w = cellWidth(ch)
         if (col + w <= lastColumn) {
           col += w
           continue

--- a/packages/kobe/test/tui/terminal-render.test.ts
+++ b/packages/kobe/test/tui/terminal-render.test.ts
@@ -32,6 +32,23 @@ describe("overlayCursor — cell-column aware", () => {
     expect(cursorCell([out], 0)?.text).toBe("b")
   })
 
+  it("counts a zero-width combining mark as part of its base char's cell", () => {
+    // "éx": é in NFD (e + combining acute) is ONE cell, x is the next.
+    // xterm folds the mark onto the base cell, so the mark must add 0 columns
+    // — counting it as 1 drifted the overlay one cell right and inverted the
+    // bare combining mark instead of the char the cursor was actually on.
+    const rows = [[{ text: "éx" } as Chunk]]
+    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }), 0)?.text).toBe("e")
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("x")
+  })
+
+  it("treats an emoji variation selector as zero-width", () => {
+    // "❤️x": U+2764 + VS16 is one narrow-width unit here (matching
+    // displayWidth), so x sits at cell 1, not cell 2.
+    const rows = [[{ text: "❤️x" } as Chunk]]
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("x")
+  })
+
   it("past-the-end cursor (blank cell) appends an inverse space", () => {
     const rows = [[{ text: "你" } as Chunk]]
     // 你 spans cells 0-1; x=2 is the empty cell after it.
@@ -123,6 +140,19 @@ describe("sealRowEndAttributes — opentui row-end attribute leak workaround", (
     expect(out.map((c) => c.text).join("")).toBe("a你好")
     expect(out.find((c) => c.text === "好")?.attributes ?? 0).toBe(0)
     expect(out.find((c) => c.text === "你")?.attributes).toBe(ATTR.UNDERLINE)
+  })
+
+  it("finds the last visible cell past a zero-width combining mark", () => {
+    // "ábc" with á in NFD (a + combining acute) is THREE cells, not four:
+    // the mark folds onto its base. A cols=3 row is full and the seal must
+    // land on "c" — counting the mark as a column sealed "b" and left "c"
+    // (the real last-column cell) still bleeding its attribute.
+    const rows = [[{ text: "ábc", attributes: ATTR.UNDERLINE } as Chunk]]
+    const out = sealRowEndAttributes(rows, 3, FG, BG)[0] as readonly Chunk[]
+    expect(out.map((c) => c.text).join("")).toBe("ábc")
+    const sealed = out.find((c) => c.text === "c") as Chunk
+    expect(sealed.attributes ?? 0).toBe(0)
+    expect(out.find((c) => c.text === "áb")?.attributes).toBe(ATTR.UNDERLINE)
   })
 
   it("is a no-op for unstyled rows", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in a pure rendering function, the same shape as recently merged fixes (surrogate-pair `tailPath`, numstat brace parsing). No open issue or PR covers it.

## Problem

`charWidth` (`src/lib/display-width.ts`) returns `0` for zero-width code points — combining diacritics (NFD text like `café` = `e` + U+0301), emoji variation selectors (U+FE0F), and ZWJ/bidi format controls — and its paired `displayWidth` sums that `0` correctly. But the embedded terminal's cursor overlay used `charWidth(...) || 1` at three sites in `src/tui/panes/terminal/terminal-render.ts`, forcing every zero-width mark to occupy one cell.

Because xterm folds such a mark onto its base char's cell (`cell.getChars()` returns e.g. `"é"` for one cell), the overlay's cell-column math desynced from reality:

- **`overlayCursorRow` / `chunkCells`:** a mark to the *left* of the cursor advanced the column counter by one too many, drifting the inverse cell one column right — so with `"éx"` (NFD) the cursor at column 1 highlighted the bare combining mark instead of `x`. This is the exact "cursor doesn't follow the text" class the surrounding comments say the code exists to fix, just unfixed for width-0 marks.
- **`sealRowEndAttributes`:** the same miscount could pick the wrong "last visible cell," letting a row-end attribute (an underlined URL) bleed past the real final column — the leak this workaround is meant to seal.

## Fix

Route all three sites through one shared, zero-width-aware helper `cellWidth(ch)` that returns `charWidth(...)` without the `|| 1`, so the overlay and seal measure cells exactly as `displayWidth` does. The helper's doc comment records why the `|| 1` must not come back. One file, ~11 net lines; file stays well under the 500-line cap.

## Verification

- Added three regression tests to `test/tui/terminal-render.test.ts` (combining mark, emoji variation selector, row-end seal past a mark). Confirmed each **fails** on the old `|| 1` code and **passes** with the fix.
- `bunx vitest run` on `terminal-render`, `terminal-pty-unicode`, `terminal-ime-cursor` — 21 passed.
- Root `bun run lint` and `bun run typecheck` — both green.
- Changeset added (`patch`).

## Follow-ups (deliberately out of scope)

When the cursor lands directly on the *base* char of a combining sequence, the overlay still splits the grapheme (inverts the base, pushes the mark into the trailing chunk). That's a pre-existing behavior unchanged by this fix and a larger grapheme-cluster concern; this PR only corrects column *accounting* for marks left of the cursor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTDV8Aom5AWWwb6rsisDpz)_