### PR TITLE
fix: launch-command guards recognize the attached --flag=value form

### DIFF
--- a/.changeset/attached-flag-launch-guards.md
+++ b/.changeset/attached-flag-launch-guards.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+A launch-command override that pins its own flag in the attached `--flag=value` form is now respected. The engine-command parser deliberately keeps `claude --resume=<id>` or `--append-system-prompt="…"` as one argv token, but the guards that decide "this command already controls its session / sets its own system prompt, don't add ours" only matched the space-separated form — so an override written the common attached way slipped past, kobe appended a second `--session-id` (claude then refuses to launch) or double-injected its worktree/dispatcher prompt over the user's own. All three guards now recognize both forms.

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -176,7 +176,20 @@ export function withEngineEffort(
  * `--session-id` (claude would reject two, or our id would lose to the
  * resumed one). Covers both long and short forms.
  */
-const CLAUDE_SESSION_CONTROL_FLAGS = new Set(["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"])
+const CLAUDE_SESSION_CONTROL_FLAGS = ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"] as const
+
+/**
+ * True when `argv` carries `flag` in EITHER the separated form (`--flag value`,
+ * its own token) or the attached form (`--flag=value`, a single token).
+ * {@link parseEngineCommand} deliberately keeps the attached form — "the common
+ * CLI idiom" per its own doc — as one token, so an exact-equality check alone
+ * silently misses `claude --resume=<id>` / `--append-system-prompt="…"`. Every
+ * "the command already sets this flag, don't add our own" guard must see both.
+ */
+function argvHasFlag(argv: readonly string[], flag: string): boolean {
+  const attached = `${flag}=`
+  return argv.some((a) => a === flag || a.startsWith(attached))
+}
 
 /**
  * For a Claude launch, append a kobe-generated `--session-id <uuid>` so the
@@ -194,7 +207,7 @@ export function withClaudeSessionId(
   vendor: string | undefined,
 ): { argv: readonly string[]; sessionId: string | null } {
   if ((vendor ?? "claude") !== "claude") return { argv, sessionId: null }
-  if (argv.some((a) => CLAUDE_SESSION_CONTROL_FLAGS.has(a))) return { argv, sessionId: null }
+  if (CLAUDE_SESSION_CONTROL_FLAGS.some((flag) => argvHasFlag(argv, flag))) return { argv, sessionId: null }
   const sessionId = randomUUID()
   return { argv: [...argv, "--session-id", sessionId], sessionId }
 }
@@ -371,7 +384,7 @@ export function withWorktreeProtocol(
 ): readonly string[] {
   if (!taskId) return argv
   if ((vendor ?? "claude") !== "claude") return argv
-  if (argv.includes("--append-system-prompt") || argv.includes("--append-system-prompt-file")) {
+  if (argvHasFlag(argv, "--append-system-prompt") || argvHasFlag(argv, "--append-system-prompt-file")) {
     return argv
   }
   const text = worktreeProtocol(taskId, kobeApiInvocation(), gates, notes)
@@ -424,7 +437,7 @@ export function withDispatcherProtocol(
 ): readonly string[] {
   if (!taskId || !enabled()) return argv
   if ((vendor ?? "claude") !== "claude") return argv
-  if (argv.includes("--append-system-prompt") || argv.includes("--append-system-prompt-file")) {
+  if (argvHasFlag(argv, "--append-system-prompt") || argvHasFlag(argv, "--append-system-prompt-file")) {
     return argv
   }
   return [...argv, "--append-system-prompt", dispatcherProtocol(taskId)]

--- a/packages/kobe/test/engine/interactive-command-overrides.test.ts
+++ b/packages/kobe/test/engine/interactive-command-overrides.test.ts
@@ -136,4 +136,14 @@ describe("withClaudeSessionId", () => {
       expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
     }
   })
+
+  it("recognizes the attached --flag=value form the command parser preserves", () => {
+    // `parseEngineCommand` keeps `--resume=<id>` as ONE token; an exact-token
+    // guard would miss it and append a second session control, which claude
+    // then refuses to launch.
+    for (const flag of ["--session-id", "--resume", "--from-pr"]) {
+      const argv = ["claude", `${flag}=x`]
+      expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
+    }
+  })
 })

--- a/packages/kobe/test/engine/status-protocol.test.ts
+++ b/packages/kobe/test/engine/status-protocol.test.ts
@@ -60,6 +60,11 @@ describe("withWorktreeProtocol", () => {
     const customFile = ["claude", "--append-system-prompt-file", "/tmp/p.txt"]
     expect(withWorktreeProtocol(customFile, "claude", "t1", { status: on, notes: on })).toEqual(customFile)
   })
+
+  it("respects the attached --append-system-prompt=… form too", () => {
+    const custom = ["claude", "--append-system-prompt=user's own"]
+    expect(withWorktreeProtocol(custom, "claude", "t1", { status: on, notes: on })).toEqual(custom)
+  })
 })
 
 describe("statusReportProtocol", () => {
@@ -142,6 +147,11 @@ describe("withDispatcherProtocol", () => {
 
   it("never double-injects over a custom command that sets the flag", () => {
     const custom = ["claude", "--append-system-prompt", "user's own"]
+    expect(withDispatcherProtocol(custom, "claude", "m1", on)).toEqual(custom)
+  })
+
+  it("respects the attached --append-system-prompt=… form too", () => {
+    const custom = ["claude", "--append-system-prompt=user's own"]
     expect(withDispatcherProtocol(custom, "claude", "m1", on)).toEqual(custom)
   })
 


### PR DESCRIPTION
## Direction

Self-found bug / correctness (direction **a**), surfaced by reviewing recently-changed engine code. No open issue or in-flight PR covers it.

## Problem

`parseEngineCommand` in `interactive-command.ts` deliberately preserves a flag written in the **attached** form — `claude --resume=<id>`, `--append-system-prompt="…"` — as a single argv token (its own docstring calls this "the common CLI idiom"). But the three guards that decide *"this launch command already controls its session / already sets its own system prompt, so don't add ours"* matched only the **space-separated** form:

- `withClaudeSessionId` used `Set.has(token)` against `CLAUDE_SESSION_CONTROL_FLAGS`.
- `withWorktreeProtocol` and `withDispatcherProtocol` used `argv.includes("--append-system-prompt")`.

So a per-vendor engine override written the common attached way slipped past every guard:

- `claude --session-id=<uuid>` / `--resume=<id>` / `--from-pr=123` → kobe still appended its own `--session-id <uuid>`, pinning two sessions; **claude then refuses to launch**.
- `claude --append-system-prompt="be terse"` → kobe still injected its worktree/dispatcher protocol, **double-injecting over the user's own prompt** — exactly what the guard exists to prevent.

This is an internal inconsistency: the parser handles the attached form on purpose, but the downstream guards never did.

## Fix

One small slice, all in `packages/kobe/src/engine/interactive-command.ts`: a shared `argvHasFlag(argv, flag)` helper that matches both `--flag` (its own token) and `--flag=value` (attached), applied to all three guards. `CLAUDE_SESSION_CONTROL_FLAGS` becomes a plain list iterated through the helper. No UI, daemon-lifecycle, or platform code touched; file stays at 444 lines (under the 500 cap).

## Verification

- New unit tests cover the attached form for all three guards (`interactive-command-overrides.test.ts` for `withClaudeSessionId`; `status-protocol.test.ts` for both protocol guards); the existing space-separated cases still pass.
- `bun test test/engine/interactive-command-overrides.test.ts test/engine/status-protocol.test.ts test/engine/interactive-command.test.ts` → 51 pass, 0 fail.
- `bun run lint` and `bun run typecheck` both green from repo root.
- Note: running the whole `test/engine` directory under `bun test` shows 5 pre-existing failures in `file-bounds.test.ts` from cross-file test-ordering pollution — reproduced identically on clean `main`, unrelated to this change (those files pass in isolation and under CI's vitest).

## Follow-ups (deliberately deferred, out of this slice)

- Short-flag attached values like `-r<id>` (no `=`) are still not recognized; they're an uncommon idiom and were never handled, so left as-is.
- The `file-bounds.test.ts` cross-file pollution under `bun test` is a separate test-hygiene issue worth its own pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoyJo8eYtn1GqWS6y5X6FM)_