### PR TITLE
refactor: one transcript-activity probe factory for both probe paths

### DIFF
--- a/packages/kobe-daemon/src/daemon/transcript-activity-collector.ts
+++ b/packages/kobe-daemon/src/daemon/transcript-activity-collector.ts
@@ -135,31 +135,44 @@ export type TranscriptActivityRunner = (
   signal: AbortSignal,
 ) => Promise<TranscriptActivityEntry>
 
+/** Reads the newest transcript mtime for a markerless vendor's own store. */
+export type LatestTranscriptMtime = (vendor: VendorId, worktreePath: string) => Promise<number>
+
 /**
- * The real probe: the engine-owned latest completion marker AND the newest
- * transcript mtime — from ONE directory scan via `detector.latestActivity`.
- * Before this the probe made TWO independent walks of the same transcript
- * dir per tick (`latestTranscriptMtime` then `latestCompletion`), each doing
- * its own readdir (+ stats / a codex date-tree walk). The detector already
- * stats the newest file while finding the completion, so it surfaces that
- * mtime for free — one listing per probe.
+ * Build the probe: the engine-owned latest completion marker AND the newest
+ * transcript mtime, from ONE directory scan via `detector.latestActivity`.
+ * Before this the probe made TWO independent walks of the same transcript dir
+ * per tick (`latestTranscriptMtime` then `latestCompletion`), each doing its
+ * own readdir (+ stats / a codex date-tree walk). The detector already stats
+ * the newest file while finding the completion, so it surfaces that mtime for
+ * free — one listing per probe.
  *
  * Vendors whose detector can't read a transcript store (copilot/custom →
- * `UnknownTurnDetector`) yield no mtime, so we fall back to the vendor's own
- * `latestTranscriptMtime` for them (copilot has a real store the detector
- * doesn't read) — a SINGLE walk, exactly as before for those vendors.
- * Best-effort and FILESYSTEM-only — no tmux, no subprocess.
+ * `UnknownTurnDetector`) yield no mtime. When a `latestTranscriptMtime` reader
+ * is supplied — the production probe, wired from the daemon runtime — the probe
+ * falls back to it for those vendors (copilot has a real store the detector
+ * doesn't read), a SINGLE walk exactly as before. Without a reader (the default
+ * {@link runTranscriptActivity}, which has no runtime to reach that store) a
+ * markerless vendor reports `mtimeMs: 0`. Best-effort and FILESYSTEM-only —
+ * no tmux, no subprocess.
  */
-export async function runTranscriptActivity(
-  worktreePath: string,
-  vendor: VendorId,
-  detector: EngineTurnDetector,
-  _signal: AbortSignal,
-): Promise<TranscriptActivityEntry> {
-  const { marker, mtimeMs } = await detector.latestActivity(worktreePath)
-  const resolvedMtime = detector.supportsCompletionMarkers() ? mtimeMs : 0
-  return { mtimeMs: resolvedMtime, completionId: marker?.id ?? null, completionAt: marker?.timestampMs ?? 0 }
+export function makeTranscriptActivityRunner(latestTranscriptMtime?: LatestTranscriptMtime): TranscriptActivityRunner {
+  return async (worktreePath, vendor, detector) => {
+    const { marker, mtimeMs } = await detector.latestActivity(worktreePath)
+    const resolvedMtime = detector.supportsCompletionMarkers()
+      ? mtimeMs
+      : ((await latestTranscriptMtime?.(vendor, worktreePath)) ?? 0)
+    return { mtimeMs: resolvedMtime, completionId: marker?.id ?? null, completionAt: marker?.timestampMs ?? 0 }
+  }
 }
+
+/**
+ * The default probe: no markerless fallback, so a markerless vendor reports
+ * `mtimeMs: 0`. The collector uses this whenever no `run` is injected; the
+ * production {@link startTranscriptActivityCollector} injects the
+ * runtime-aware variant instead.
+ */
+export const runTranscriptActivity: TranscriptActivityRunner = makeTranscriptActivityRunner()
 
 /**
  * The worktree → vendor map the collector tracks: non-archived tasks with a
@@ -336,14 +349,7 @@ export function startTranscriptActivityCollector(
     hasSubscribers,
     createDetector: runtime.createEngineTurnDetector,
     defaultVendor: runtime.defaultTaskVendor,
-    run: async (path, vendor, detector, signal) => {
-      const { marker, mtimeMs } = await detector.latestActivity(path)
-      const resolvedMtime = detector.supportsCompletionMarkers()
-        ? mtimeMs
-        : await runtime.latestTranscriptMtime(vendor, path)
-      void signal
-      return { mtimeMs: resolvedMtime, completionId: marker?.id ?? null, completionAt: marker?.timestampMs ?? 0 }
-    },
+    run: makeTranscriptActivityRunner((vendor, path) => runtime.latestTranscriptMtime(vendor, path)),
   })
   collector.tick()
   const timer = setInterval(() => collector.tick(), tickMs)

--- a/packages/kobe/test/daemon/transcript-activity-collector.test.ts
+++ b/packages/kobe/test/daemon/transcript-activity-collector.test.ts
@@ -29,6 +29,7 @@ import type { TranscriptActivityPayload } from "@sma1lboy/kobe-daemon/daemon/pro
 import {
   TranscriptActivityCollector,
   type TranscriptActivityEntry,
+  makeTranscriptActivityRunner,
   runTranscriptActivity,
   sameTranscriptActivityEntry,
   trackedWorktrees,
@@ -359,5 +360,57 @@ describe("runTranscriptActivity — single codex tree walk", () => {
     // AFTER the fix: exactly ONE day-dir readdir, and half the stats.
     expect(newSide.counts.treeReaddir).toBe(1)
     expect(newSide.counts.stat).toBe(oldSide.counts.stat / 2)
+  })
+})
+
+/**
+ * The markerless-vendor fallback the production collector wires from the daemon
+ * runtime — previously untested, because every collector test injects its own
+ * `run` and the direct `runTranscriptActivity` test only exercises codex (a
+ * marker vendor). A vendor whose detector reads no completion store
+ * (copilot/custom → `UnknownTurnDetector`) yields no mtime; the injected
+ * `latestTranscriptMtime` reader carries it, and the reader-less default reports
+ * `mtimeMs: 0` rather than pretending to reach a store it has no runtime for.
+ */
+describe("makeTranscriptActivityRunner — markerless fallback", () => {
+  const WT = "/wt"
+  const signal = new AbortController().signal
+  // A vendor WITHOUT completion markers (copilot/custom): the detector reads no
+  // store, so it surfaces no marker and mtime 0.
+  const markerless = {
+    latestActivity: async () => ({ marker: null, mtimeMs: 0 }),
+    supportsCompletionMarkers: () => false,
+  }
+  // A vendor WITH markers: the detector reports its own newest mtime + marker.
+  const withMarkers = {
+    latestActivity: async () => ({ marker: { id: "m1", timestampMs: 42 }, mtimeMs: 100 }),
+    supportsCompletionMarkers: () => true,
+  }
+
+  test("a markerless vendor falls back to the injected latestTranscriptMtime", async () => {
+    const seen: Array<[VendorId, string]> = []
+    const run = makeTranscriptActivityRunner(async (vendor, path) => {
+      seen.push([vendor, path])
+      return 777
+    })
+    const got = await run(WT, "copilot", markerless, signal)
+    expect(got).toEqual({ mtimeMs: 777, completionId: null, completionAt: 0 })
+    expect(seen).toEqual([["copilot", WT]])
+  })
+
+  test("the reader-less default reports mtime 0 for a markerless vendor", async () => {
+    const got = await runTranscriptActivity(WT, "copilot", markerless, signal)
+    expect(got).toEqual({ mtimeMs: 0, completionId: null, completionAt: 0 })
+  })
+
+  test("a marker vendor keeps the detector's mtime and never calls the fallback reader", async () => {
+    let called = false
+    const run = makeTranscriptActivityRunner(async () => {
+      called = true
+      return 999
+    })
+    const got = await run(WT, "claude", withMarkers, signal)
+    expect(got).toEqual({ mtimeMs: 100, completionId: "m1", completionAt: 42 })
+    expect(called).toBe(false)
   })
 })


### PR DESCRIPTION
## Direction

Code health / correctness (self-found during the daily review of `packages/kobe-daemon`). Not tied to an open issue or overlapping any of the 15 in-flight PRs.

## Problem

The daemon transcript-activity collector had **two copies of the same probe body** that differed only in the markerless-vendor fallback:

- `runTranscriptActivity` (the exported default the collector uses when no `run` is injected) resolves a markerless vendor's mtime to `0`.
- `startTranscriptActivityCollector` re-implemented the entire probe inline just to fall back to `runtime.latestTranscriptMtime(vendor, path)` for those vendors.

Two problems fell out of that duplication:

1. **The default's doc lied.** Its comment claimed it "falls back to the vendor's own `latestTranscriptMtime`" — but the default has no runtime to reach that store, so a markerless vendor (copilot / custom → `UnknownTurnDetector`) silently got `mtimeMs: 0`. The described behaviour only ever existed in the injected production probe.
2. **The production fallback was untested.** Every collector test injects its own fake `run`, and the direct `runTranscriptActivity` test only exercises codex (a marker vendor), so the `latestTranscriptMtime` fallback branch had zero coverage and the two bodies were free to drift.

## Fix

Extract a single `makeTranscriptActivityRunner(latestTranscriptMtime?)` factory that both paths share:

- Production (`startTranscriptActivityCollector`) passes the runtime reader → markerless vendors fall back to `latestTranscriptMtime`, exactly as before.
- The default `runTranscriptActivity = makeTranscriptActivityRunner()` omits the reader → a markerless vendor reports `mtimeMs: 0`, and the doc now says so plainly.

The single-directory-scan perf shape (one `detector.latestActivity` call instead of two tree walks) is preserved. **Production behaviour is unchanged** — only the shared code path and the honesty of the default's contract change.

Added a `makeTranscriptActivityRunner — markerless fallback` test block covering: the markerless vendor falling back to the injected reader, the reader-less default reporting `0`, and a marker vendor keeping the detector's own mtime without ever calling the fallback.

## Verification

- `bun run typecheck` — green (all three packages)
- `bun run lint` — green (933 files, no fixes)
- `cd packages/kobe && bun run test test/daemon/transcript-activity-collector.test.ts` — 496 passed, including the 3 new tests

## No changeset

Pure internal refactor + test coverage with **no user-facing behaviour change** (the only production construction site always injects the runtime-aware probe), so no changeset per `docs/RELEASING.md` — changesets record what the published package *does*, and that is unchanged here.

## Follow-ups deferred

None in scope. A separate observation from the review (the `resolveCursorTarget` empty-list branch in `sidebar/groups.ts` is asymmetric with its sibling) is already documented as intentional in that function's comment, so it was left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqSowfLMBR4VLTJPAP29bK)_