### PR TITLE
feat: clickable status-bar hints with a footer settings button

### DIFF
--- a/.changeset/calm-geese-click.md
+++ b/.changeset/calm-geese-click.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+The status-bar key hints are now clickable: the `⚙ settings` button opens Settings from anywhere — including inside the embedded terminal, where mouse clicks don't pass through to the PTY and the keyboard path is longest — clicking `{prefix} commands` arms the real prefix (the which-key guide accepts a keyboard second stroke), the help caption opens F1, and the terminal's `⌃Q sidebar` caption jumps focus back to the sidebar.

--- a/.changeset/calm-geese-click.md
+++ b/.changeset/calm-geese-click.md
@@ -2,4 +2,4 @@
 "@sma1lboy/kobe": patch
 ---
 
-The status-bar key hints are now clickable: the `⚙ settings` button opens Settings from anywhere — including inside the embedded terminal, where mouse clicks don't pass through to the PTY and the keyboard path is longest — clicking `{prefix} commands` arms the real prefix (the which-key guide accepts a keyboard second stroke), the help caption opens F1, and the terminal's `⌃Q sidebar` caption jumps focus back to the sidebar.
+The status-bar key hints are now clickable: the `[settings]` button opens Settings from anywhere — including inside the embedded terminal, where mouse clicks don't pass through to the PTY and the keyboard path is longest — clicking `{prefix} commands` arms the real prefix (the which-key guide accepts a keyboard second stroke), the help caption opens F1, and the terminal's `⌃Q sidebar` caption jumps focus back to the sidebar.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,12 +158,12 @@ surface:
   less-frequent actions. `F1` presents the same live keymap in that order.
 
 - Discoverability hints (Settings → General → Keyboard hints, default on):
-  the status bar keeps a permanent `{prefix} commands · F1 help · ⚙ settings`
+  the status bar keeps a permanent `{prefix} commands · F1 help · [settings]`
   micro-hint (inside the embedded terminal it advertises the escape hatch
   instead, since the prefix passes through to the PTY there), and the
   sidebar/files panes each show a one-line first-use hint that extinguishes
   permanently once that pane's own keys are used. Every status-bar segment is
-  clickable — the `⚙` button opens Settings even from inside the terminal,
+  clickable — the `[settings]` button opens Settings even from inside the terminal,
   where mouse clicks don't pass through. Turning the toggle back on relights
   extinguished pane hints. Every advertised chord follows live rebinds; an
   unbound chord drops out of its hint.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -158,13 +158,15 @@ surface:
   less-frequent actions. `F1` presents the same live keymap in that order.
 
 - Discoverability hints (Settings → General → Keyboard hints, default on):
-  the status bar keeps a permanent `{prefix} commands · F1 help` micro-hint
-  (inside the embedded terminal it advertises the escape hatch instead, since
-  the prefix passes through to the PTY there), and the sidebar/files panes
-  each show a one-line first-use hint that extinguishes permanently once that
-  pane's own keys are used. Turning the toggle back on relights extinguished
-  pane hints. Every advertised chord follows live rebinds; an unbound chord
-  drops out of its hint.
+  the status bar keeps a permanent `{prefix} commands · F1 help · ⚙ settings`
+  micro-hint (inside the embedded terminal it advertises the escape hatch
+  instead, since the prefix passes through to the PTY there), and the
+  sidebar/files panes each show a one-line first-use hint that extinguishes
+  permanently once that pane's own keys are used. Every status-bar segment is
+  clickable — the `⚙` button opens Settings even from inside the terminal,
+  where mouse clicks don't pass through. Turning the toggle back on relights
+  extinguished pane hints. Every advertised chord follows live rebinds; an
+  unbound chord drops out of its hint.
 
 - Edit `~/.kobe/settings/keybindings.yaml` (`.yml` accepted when `.yaml` is
   absent). This is a hand-authored file; kobe never writes it.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -31,11 +31,16 @@ which-key map, and all captions resolve through the live keymap
 (`src/tui/lib/keyboard-hints.ts`), so a rebound chord shows its new key and
 an unbound/disabled one drops out:
 
-- **Status-bar micro-hint** — a permanent `{prefix} commands · F1 help` pair
-  in the workspace footer's right corner. Inside the embedded terminal it
-  swaps the prefix token for the `ctrl+q` escape hatch (the prefix first
-  stroke passes through to the PTY there); with a modal open, or the prefix
-  disabled and help unbound, tokens drop until nothing renders.
+- **Status-bar micro-hint** — a permanent `{prefix} commands · F1 help ·
+  ⚙ settings` row in the workspace footer's right corner. Inside the
+  embedded terminal it swaps the prefix token for the `ctrl+q` escape hatch
+  (the prefix first stroke passes through to the PTY there); with a modal
+  open, or the prefix disabled and help unbound, tokens drop until nothing
+  renders. Every segment is mouse-activatable — clicking `commands` arms the
+  REAL prefix (the guide accepts a keyboard second stroke), clicking the
+  help caption opens F1, and the `⚙` button opens Settings even while the
+  terminal owns keyboard input, since mouse clicks never pass through
+  (owner call 2026-08-09).
 - **First-use pane hints** — one muted line per vim-style pane (sidebar:
   `j/k move · ⏎ open`; files: move/fold/open/diff). Using that pane's own
   nav/select keys extinguishes its line permanently; the files pane then

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -32,13 +32,13 @@ which-key map, and all captions resolve through the live keymap
 an unbound/disabled one drops out:
 
 - **Status-bar micro-hint** — a permanent `{prefix} commands · F1 help ·
-  ⚙ settings` row in the workspace footer's right corner. Inside the
+  [settings]` row in the workspace footer's right corner. Inside the
   embedded terminal it swaps the prefix token for the `ctrl+q` escape hatch
   (the prefix first stroke passes through to the PTY there); with a modal
   open, or the prefix disabled and help unbound, tokens drop until nothing
   renders. Every segment is mouse-activatable — clicking `commands` arms the
   REAL prefix (the guide accepts a keyboard second stroke), clicking the
-  help caption opens F1, and the `⚙` button opens Settings even while the
+  help caption opens F1, and the `[settings]` button opens Settings even while the
   terminal owns keyboard input, since mouse clicks never pass through
   (owner call 2026-08-09).
 - **First-use pane hints** — one muted line per vim-style pane (sidebar:

--- a/packages/kobe-web/e2e/sandbox.spec.ts
+++ b/packages/kobe-web/e2e/sandbox.spec.ts
@@ -189,8 +189,9 @@ test("keyboard hints render and extinguish in the real OpenTUI", async ({ page }
     await pressTerminal(terminal, "j")
     await expect(buffer).not.toContainText("j/k move")
 
-    // …while the status-bar hint is permanent.
+    // …while the status-bar hint is permanent, ⚙ button included.
     await expect(buffer).toContainText("F1 help")
+    await expect(buffer).toContainText("⚙ settings")
 
     // NOT asserted here: the terminal-passthrough variant (`⌃Q sidebar`).
     // The fixture task has no started engine session, so the workspace

--- a/packages/kobe-web/e2e/sandbox.spec.ts
+++ b/packages/kobe-web/e2e/sandbox.spec.ts
@@ -189,9 +189,9 @@ test("keyboard hints render and extinguish in the real OpenTUI", async ({ page }
     await pressTerminal(terminal, "j")
     await expect(buffer).not.toContainText("j/k move")
 
-    // …while the status-bar hint is permanent, ⚙ button included.
+    // …while the status-bar hint is permanent, [settings] button included.
     await expect(buffer).toContainText("F1 help")
-    await expect(buffer).toContainText("⚙ settings")
+    await expect(buffer).toContainText("[settings]")
 
     // NOT asserted here: the terminal-passthrough variant (`⌃Q sidebar`).
     // The fixture task has no started engine session, so the workspace

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -3,8 +3,11 @@
  * Keyboard-discoverability hints — the React half of
  * `src/tui/lib/keyboard-hints.ts`:
  *
- *   - `StatusKeyHint` / `useStatusKeyHintText`: the permanent status-bar
- *     micro-hint (`⌃ A commands · F1 help`), terminal-passthrough aware.
+ *   - `StatusKeyHintBar` / `useStatusKeyHintItems`: the permanent status-bar
+ *     micro-hint (`⌃ A commands · F1 help · ⚙ settings`), terminal-
+ *     passthrough aware. Every segment is mouse-activatable (clicks don't
+ *     pass through to the PTY, so the ⚙ button works even inside the
+ *     terminal, where the keyboard path is longest).
  *   - `PaneKeyHint`: one muted line per vim-style pane (sidebar/files);
  *     the fuller first-use variant extinguishes permanently once the pane's
  *     own keys are used (`usePaneHintMark`).
@@ -22,6 +25,7 @@ import {
   type HintPane,
   KEY_HINTS_ENABLED_KEY,
   PANE_HINT_USED_KEYS,
+  type StatusHintToken,
   keyHintsEnabled,
   paneHintTokens,
   paneHintVisible,
@@ -33,25 +37,34 @@ import { useKeymapVersion } from "../context/keybindings"
 import { useOptionalKV } from "../context/kv"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
-import { currentBindingReachability, useBindingStackVersion } from "../lib/keymap"
+import { armPrefixFromCurrentStack, currentBindingReachability, useBindingStackVersion } from "../lib/keymap"
+import { useOptionalDialog } from "../ui/dialog"
+import { HelpDialog } from "./help-dialog"
+
+export type StatusKeyHintItem = {
+  text: string
+  /** Mouse activation — the same action the advertised key would run. */
+  onPress?: () => void
+}
 
 /**
- * The status-bar hint line, or null when it has nothing truthful to say
+ * The status-bar hint segments, empty when there is nothing truthful to say
  * (hints toggled off, prefix disabled AND help unbound, …). Reads the live
  * binding stack, so an open modal or the terminal passthrough boundary
  * reshapes it automatically.
  */
-export function useStatusKeyHintText(): string | null {
+export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void }): StatusKeyHintItem[] {
   const t = useT()
   const kv = useOptionalKV()
   // Reachability is a function of the focused pane, the live keymap, and
   // which bindings are registered (registration happens in mount effects,
   // AFTER the first render) — subscribe to all three so a change in any of
   // them re-renders this consumer and re-runs the effect below.
-  useOptionalFocus()
+  const focus = useOptionalFocus()
+  const dialog = useOptionalDialog()
   useKeymapVersion()
   useBindingStackVersion()
-  const [text, setText] = useState<string | null>(null)
+  const [tokens, setTokens] = useState<readonly StatusHintToken[]>([])
   // Snapshot AFTER every commit, never during render: `enabled` gates like
   // the terminal passthrough table read render-refreshed refs in CHILD
   // components, and this hook renders in a parent (the workspace footer) —
@@ -62,25 +75,51 @@ export function useStatusKeyHintText(): string | null {
   // compare-and-set keeps the no-change case from looping.
   useEffect(() => {
     const enabled = keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))
-    const tokens = enabled ? statusHintTokens(currentBindingReachability(), currentPrefixConfiguration().key) : []
-    const next =
-      tokens.length === 0
-        ? null
-        : tokens.map((tok) => t(`hints.status.${tok.msg}`, { key: formatChord(tok.chord) })).join(" · ")
-    setText((prev) => (prev === next ? prev : next))
+    const next = enabled ? statusHintTokens(currentBindingReachability(), currentPrefixConfiguration().key) : []
+    setTokens((prev) =>
+      prev.length === next.length && prev.every((tok, i) => tok.chord === next[i]?.chord && tok.msg === next[i]?.msg)
+        ? prev
+        : next,
+    )
   })
-  return text
+  // Click = the action the advertised key would run. Arming the prefix goes
+  // through the REAL dispatcher state, so the which-key guide that appears
+  // accepts a keyboard second stroke exactly like a pressed ctrl+a.
+  const actions: Record<StatusHintToken["msg"], (() => void) | undefined> = {
+    commands: () => void armPrefixFromCurrentStack(),
+    sidebar: focus ? () => focus.setFocused("sidebar") : undefined,
+    help: dialog ? () => HelpDialog.show(dialog, focus?.focused ?? "sidebar") : undefined,
+  }
+  const items: StatusKeyHintItem[] = tokens.map((tok) => ({
+    text: t(`hints.status.${tok.msg}`, { key: formatChord(tok.chord) }),
+    onPress: actions[tok.msg],
+  }))
+  if (opts?.onOpenSettings && keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))) {
+    items.push({ text: `⚙ ${t("hints.status.settings")}`, onPress: opts.onOpenSettings })
+  }
+  return items
 }
 
-/** Thin renderable wrapper over {@link useStatusKeyHintText}. */
-export function StatusKeyHint() {
+/** The footer's hint row: muted key captions, each mouse-activatable. */
+export function StatusKeyHintBar(props: { onOpenSettings?: () => void }) {
   const { theme } = useTheme()
-  const text = useStatusKeyHintText()
-  if (text === null) return null
+  const items = useStatusKeyHintItems({ onOpenSettings: props.onOpenSettings })
+  if (items.length === 0) return null
   return (
-    <text fg={theme.textMuted} wrapMode="none">
-      {text}
-    </text>
+    <box flexDirection="row" flexShrink={0}>
+      {items.flatMap((item, index) => [
+        index > 0 ? (
+          <text key={`sep-${item.text}`} fg={theme.textMuted} wrapMode="none">
+            {" · "}
+          </text>
+        ) : null,
+        <box key={item.text} onMouseUp={item.onPress}>
+          <text fg={theme.textMuted} wrapMode="none">
+            {item.text}
+          </text>
+        </box>,
+      ])}
+    </box>
   )
 }
 

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -4,10 +4,10 @@
  * `src/tui/lib/keyboard-hints.ts`:
  *
  *   - `StatusKeyHintBar` / `useStatusKeyHintItems`: the permanent status-bar
- *     micro-hint (`⌃ A commands · F1 help · ⚙ settings`), terminal-
+ *     micro-hint (`⌃ A commands · F1 help · [settings]`), terminal-
  *     passthrough aware. Every segment is mouse-activatable (clicks don't
- *     pass through to the PTY, so the ⚙ button works even inside the
- *     terminal, where the keyboard path is longest).
+ *     pass through to the PTY, so the [settings] button works even inside
+ *     the terminal, where the keyboard path is longest).
  *   - `PaneKeyHint`: one muted line per vim-style pane (sidebar/files);
  *     the fuller first-use variant extinguishes permanently once the pane's
  *     own keys are used (`usePaneHintMark`).
@@ -94,8 +94,12 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void }): S
     text: t(`hints.status.${tok.msg}`, { key: formatChord(tok.chord) }),
     onPress: actions[tok.msg],
   }))
+  // Bracketed like the other clickable chips ([~] Zen, [enter] Send) — and
+  // deliberately NO glyph: U+2699 ⚙ is East-Asian-Ambiguous width, so
+  // terminals disagree on whether it takes 1 or 2 cells and the row
+  // misaligns per OS/font.
   if (opts?.onOpenSettings && keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))) {
-    items.push({ text: `⚙ ${t("hints.status.settings")}`, onPress: opts.onOpenSettings })
+    items.push({ text: `[${t("hints.status.settings")}]`, onPress: opts.onOpenSettings })
   }
   return items
 }

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -37,7 +37,12 @@ import { useKeymapVersion } from "../context/keybindings"
 import { useOptionalKV } from "../context/kv"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
-import { armPrefixFromCurrentStack, currentBindingReachability, useBindingStackVersion } from "../lib/keymap"
+import {
+  armPrefixFromCurrentStack,
+  currentBindingReachability,
+  modalActive,
+  useBindingStackVersion,
+} from "../lib/keymap"
 import { useOptionalDialog } from "../ui/dialog"
 import { HelpDialog } from "./help-dialog"
 
@@ -64,7 +69,10 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void }): S
   const dialog = useOptionalDialog()
   useKeymapVersion()
   useBindingStackVersion()
-  const [tokens, setTokens] = useState<readonly StatusHintToken[]>([])
+  const [snapshot, setSnapshot] = useState<{ tokens: readonly StatusHintToken[]; modal: boolean }>({
+    tokens: [],
+    modal: false,
+  })
   // Snapshot AFTER every commit, never during render: `enabled` gates like
   // the terminal passthrough table read render-refreshed refs in CHILD
   // components, and this hook renders in a parent (the workspace footer) —
@@ -75,11 +83,14 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void }): S
   // compare-and-set keeps the no-change case from looping.
   useEffect(() => {
     const enabled = keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))
-    const next = enabled ? statusHintTokens(currentBindingReachability(), currentPrefixConfiguration().key) : []
-    setTokens((prev) =>
-      prev.length === next.length && prev.every((tok, i) => tok.chord === next[i]?.chord && tok.msg === next[i]?.msg)
+    const nextTokens = enabled ? statusHintTokens(currentBindingReachability(), currentPrefixConfiguration().key) : []
+    const nextModal = modalActive()
+    setSnapshot((prev) =>
+      prev.modal === nextModal &&
+      prev.tokens.length === nextTokens.length &&
+      prev.tokens.every((tok, i) => tok.chord === nextTokens[i]?.chord && tok.msg === nextTokens[i]?.msg)
         ? prev
-        : next,
+        : { tokens: nextTokens, modal: nextModal },
     )
   })
   // Click = the action the advertised key would run. Arming the prefix goes
@@ -90,15 +101,16 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void }): S
     sidebar: focus ? () => focus.setFocused("sidebar") : undefined,
     help: dialog ? () => HelpDialog.show(dialog, focus?.focused ?? "sidebar") : undefined,
   }
-  const items: StatusKeyHintItem[] = tokens.map((tok) => ({
+  const items: StatusKeyHintItem[] = snapshot.tokens.map((tok) => ({
     text: t(`hints.status.${tok.msg}`, { key: formatChord(tok.chord) }),
     onPress: actions[tok.msg],
   }))
   // Bracketed like the other clickable chips ([~] Zen, [enter] Send) — and
   // deliberately NO glyph: U+2699 ⚙ is East-Asian-Ambiguous width, so
   // terminals disagree on whether it takes 1 or 2 cells and the row
-  // misaligns per OS/font.
-  if (opts?.onOpenSettings && keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))) {
+  // misaligns per OS/font. Hidden while a modal owns input — Settings must
+  // not open under a dialog, same reason the keyboard tokens drop.
+  if (opts?.onOpenSettings && !snapshot.modal && keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))) {
     items.push({ text: `[${t("hints.status.settings")}]`, onPress: opts.onOpenSettings })
   }
   return items

--- a/packages/kobe/src/tui-react/lib/keymap.ts
+++ b/packages/kobe/src/tui-react/lib/keymap.ts
@@ -31,6 +31,7 @@ import {
   type BindingReachability,
   type BindingsConfig,
   type RegisteredBinding,
+  armPrefixNow,
   bindingReachability,
   dispatchKeyEvent,
   insertRegistration,
@@ -107,6 +108,11 @@ export function modalActive(): boolean {
 /** Capture what F1 would have been able to dispatch before its modal opens. */
 export function currentBindingReachability(): BindingReachability {
   return bindingReachability(stack)
+}
+
+/** Mouse path into the command layer: arm the prefix against the live stack. */
+export function armPrefixFromCurrentStack(): boolean {
+  return armPrefixNow(stack)
 }
 
 // Registration-change signal. Registrations land in mount EFFECTS (after the

--- a/packages/kobe/src/tui-react/ui/dialog.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog.tsx
@@ -325,6 +325,15 @@ export function useDialog(): DialogContext {
 }
 
 /**
+ * Read the dialog context when present — null outside a provider. For
+ * consumers that degrade gracefully in dialog-less mounts (the footer's
+ * clickable key hints in render tests).
+ */
+export function useOptionalDialog(): DialogContext | null {
+  return useContext(ctx)
+}
+
+/**
  * Open a dialog that resolves a single value — the shared `show` shape:
  * `body` receives the promise's `resolve` and wires it to its
  * submit/cancel props; dismissing through the stack (esc / backdrop /

--- a/packages/kobe/src/tui-react/workspace/host-footer.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-footer.tsx
@@ -19,7 +19,7 @@
 import type { ReactNode } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { engineDisplayName } from "../../engine/interactive-command"
-import { useStatusKeyHintText } from "../component/keyboard-hints"
+import { StatusKeyHintBar, useStatusKeyHintItems } from "../component/keyboard-hints"
 import { usageChips } from "../component/settings-dialog/usage-core"
 import { useTheme } from "../context/theme"
 import { useAccessor } from "../lib/use-accessor"
@@ -49,11 +49,16 @@ function UsageChips(props: { orchestrator: RemoteOrchestrator }) {
 }
 
 /** Sidebar | workspace | files row, with the quota + key-hint line under it. */
-export function WorkspaceFrame(props: { orchestrator: RemoteOrchestrator; children: ReactNode }) {
+export function WorkspaceFrame(props: {
+  orchestrator: RemoteOrchestrator
+  /** Wires the footer's clickable ⚙ button; absent = no settings segment. */
+  onOpenSettings?: () => void
+  children: ReactNode
+}) {
   const { theme } = useTheme()
   const usage = useAccessor(props.orchestrator.usageSnapshotSignal())
-  const hint = useStatusKeyHintText()
-  const footerVisible = (usage != null && usage.size > 0) || hint !== null
+  const hintItems = useStatusKeyHintItems({ onOpenSettings: props.onOpenSettings })
+  const footerVisible = (usage != null && usage.size > 0) || hintItems.length > 0
   return (
     <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
       <box flexDirection="row" flexGrow={1}>
@@ -64,11 +69,7 @@ export function WorkspaceFrame(props: { orchestrator: RemoteOrchestrator; childr
           <box flexGrow={1} flexDirection="row">
             <UsageChips orchestrator={props.orchestrator} />
           </box>
-          {hint !== null ? (
-            <text fg={theme.textMuted} wrapMode="none">
-              {hint}
-            </text>
-          ) : null}
+          <StatusKeyHintBar onOpenSettings={props.onOpenSettings} />
         </box>
       ) : null}
     </box>

--- a/packages/kobe/src/tui-react/workspace/host-footer.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-footer.tsx
@@ -51,7 +51,7 @@ function UsageChips(props: { orchestrator: RemoteOrchestrator }) {
 /** Sidebar | workspace | files row, with the quota + key-hint line under it. */
 export function WorkspaceFrame(props: {
   orchestrator: RemoteOrchestrator
-  /** Wires the footer's clickable ⚙ button; absent = no settings segment. */
+  /** Wires the footer's clickable [settings] button; absent = no settings segment. */
   onOpenSettings?: () => void
   children: ReactNode
 }) {

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -11,7 +11,6 @@ import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-proces
 import { useEffect, useMemo, useRef, useState } from "react"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { SIDEBAR_MODE_KEY, resolveSidebarMode } from "../../state/sidebar-tree"
-import { buildPRPrompt, gatherPRPromptState } from "../../tui/ops/pr-prompt"
 import { SIDEBAR_WIDTH } from "../../tui/panes/sidebar/view-core"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { PrefixHud } from "../component/prefix-hud"
@@ -48,6 +47,7 @@ import { useQuickFork } from "./quick-fork"
 import { ShowWorkspace } from "./show-workspace"
 import { activeTabIdFor, forgetTaskTabs, requestTabActivation, setUiEventReporter } from "./terminal-tabs-shared"
 import { useAttention } from "./use-attention"
+import { useCreatePR } from "./use-create-pr"
 import { useFileOpenActions } from "./use-file-open-actions"
 import { useInboxHost } from "./use-inbox-host"
 import { useIssueChat } from "./use-issue-chat"
@@ -184,19 +184,8 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // have changed — a stale continuation must not deliver into the new task.
   const selectedWorktreeRef = useLatest(worktree)
 
-  /** FileTree `pr` chip + prefix+p — PTY paste+submit of the PR prompt.
-   *  On the target branch (a project main session) it toasts instead. */
-  async function createPR(): Promise<void> {
-    const wt = worktree
-    const send = sendToEngineFn.current
-    if (!wt || !send) return
-    const state = await gatherPRPromptState(wt)
-    if (state.branch === state.targetBranch)
-      return notifyError(t("files.toast.prOnTargetBranch", { branch: state.branch }))
-    const prompt = await buildPRPrompt(wt, state)
-    if (selectedWorktreeRef.current !== wt || sendToEngineFn.current !== send) return
-    send(prompt)
-  }
+  // FileTree `pr` chip + prefix+p — split out for the file-size cap.
+  const createPR = useCreatePR({ worktree, sendToEngineFn, selectedWorktreeRef, notifyError })
 
   // Quick-fork (issue #17, ctrl+f): composer → create+enter → hand the
   // prompt to the new task's TerminalTabs mount (phase 2). Wiring lives in
@@ -338,7 +327,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   }
 
   return (
-    <WorkspaceFrame orchestrator={orch}>
+    <WorkspaceFrame orchestrator={orch} onOpenSettings={pages.openSettings}>
       {/* Tasks sidebar stays visible in zen (tmux parity) — its
           ☯ ZEN chip is also the exit affordance. */}
       {/* Borderless rail (owner call 2026-07-27): no frame, no divider —

--- a/packages/kobe/src/tui-react/workspace/use-create-pr.ts
+++ b/packages/kobe/src/tui-react/workspace/use-create-pr.ts
@@ -5,29 +5,45 @@
  * imperative-ref actions there: after an await, the selected task (and the
  * TerminalTabs mount behind the ref) may have changed, and a stale
  * continuation must not deliver into the new task.
+ *
+ * `createPRAction` is the React-free core (git IO injectable) so vitest can
+ * pin the target-branch toast and both identity guards without a repo;
+ * `useCreatePR` binds it to the live locale.
  */
 
 import type { MutableRefObject } from "react"
 import { buildPRPrompt, gatherPRPromptState } from "../../tui/ops/pr-prompt"
 import { useT } from "../i18n"
 
-export function useCreatePR(args: {
+export type CreatePRDeps = {
   worktree: string | null
   sendToEngineFn: MutableRefObject<((text: string) => void) | null>
   selectedWorktreeRef: { readonly current: string | null }
   notifyError: (message: string) => void
-}): () => Promise<void> {
-  const t = useT()
+  t: (key: string, params?: Record<string, string | number>) => string
+  /** Injectable for tests; default to the real git-backed helpers. */
+  gather?: typeof gatherPRPromptState
+  build?: typeof buildPRPrompt
+}
+
+export function createPRAction(deps: CreatePRDeps): () => Promise<void> {
+  const gather = deps.gather ?? gatherPRPromptState
+  const build = deps.build ?? buildPRPrompt
   /** On the target branch (a project main session) it toasts instead. */
   return async function createPR(): Promise<void> {
-    const wt = args.worktree
-    const send = args.sendToEngineFn.current
+    const wt = deps.worktree
+    const send = deps.sendToEngineFn.current
     if (!wt || !send) return
-    const state = await gatherPRPromptState(wt)
+    const state = await gather(wt)
     if (state.branch === state.targetBranch)
-      return args.notifyError(t("files.toast.prOnTargetBranch", { branch: state.branch }))
-    const prompt = await buildPRPrompt(wt, state)
-    if (args.selectedWorktreeRef.current !== wt || args.sendToEngineFn.current !== send) return
+      return deps.notifyError(deps.t("files.toast.prOnTargetBranch", { branch: state.branch }))
+    const prompt = await build(wt, state)
+    if (deps.selectedWorktreeRef.current !== wt || deps.sendToEngineFn.current !== send) return
     send(prompt)
   }
+}
+
+export function useCreatePR(args: Omit<CreatePRDeps, "t" | "gather" | "build">): () => Promise<void> {
+  const t = useT()
+  return createPRAction({ ...args, t })
 }

--- a/packages/kobe/src/tui-react/workspace/use-create-pr.ts
+++ b/packages/kobe/src/tui-react/workspace/use-create-pr.ts
@@ -1,0 +1,33 @@
+/**
+ * Create-PR action (FileTree `pr` chip + prefix+p) — a PTY paste+submit of
+ * the PR prompt into the selected task's engine session. Split out of
+ * `host.tsx` (file-size cap); the identity guard is the same as the other
+ * imperative-ref actions there: after an await, the selected task (and the
+ * TerminalTabs mount behind the ref) may have changed, and a stale
+ * continuation must not deliver into the new task.
+ */
+
+import type { MutableRefObject } from "react"
+import { buildPRPrompt, gatherPRPromptState } from "../../tui/ops/pr-prompt"
+import { useT } from "../i18n"
+
+export function useCreatePR(args: {
+  worktree: string | null
+  sendToEngineFn: MutableRefObject<((text: string) => void) | null>
+  selectedWorktreeRef: { readonly current: string | null }
+  notifyError: (message: string) => void
+}): () => Promise<void> {
+  const t = useT()
+  /** On the target branch (a project main session) it toasts instead. */
+  return async function createPR(): Promise<void> {
+    const wt = args.worktree
+    const send = args.sendToEngineFn.current
+    if (!wt || !send) return
+    const state = await gatherPRPromptState(wt)
+    if (state.branch === state.targetBranch)
+      return args.notifyError(t("files.toast.prOnTargetBranch", { branch: state.branch }))
+    const prompt = await buildPRPrompt(wt, state)
+    if (args.selectedWorktreeRef.current !== wt || args.sendToEngineFn.current !== send) return
+    send(prompt)
+  }
+}

--- a/packages/kobe/src/tui/i18n/messages/hints.ts
+++ b/packages/kobe/src/tui/i18n/messages/hints.ts
@@ -15,7 +15,7 @@ export const en = {
     help: "{key} help",
     /** {key} = the live escape hatch out of the embedded terminal */
     sidebar: "{key} sidebar",
-    /** Label of the clickable ⚙ footer button (glyph added in code) */
+    /** Label of the clickable footer settings button (brackets added in code) */
     settings: "settings",
   },
   pane: {

--- a/packages/kobe/src/tui/i18n/messages/hints.ts
+++ b/packages/kobe/src/tui/i18n/messages/hints.ts
@@ -15,6 +15,8 @@ export const en = {
     help: "{key} help",
     /** {key} = the live escape hatch out of the embedded terminal */
     sidebar: "{key} sidebar",
+    /** Label of the clickable ⚙ footer button (glyph added in code) */
+    settings: "settings",
   },
   pane: {
     move: "move",
@@ -29,6 +31,7 @@ export const zh: typeof en = {
     commands: "{key} 命令",
     help: "{key} 帮助",
     sidebar: "{key} 侧栏",
+    settings: "设置",
   },
   pane: {
     move: "移动",

--- a/packages/kobe/src/tui/lib/keymap-dispatch.ts
+++ b/packages/kobe/src/tui/lib/keymap-dispatch.ts
@@ -233,6 +233,23 @@ function armPrefix(now: number, options: readonly PrefixHudOption[]): void {
   prefixHudSetArmed(true, options, now)
 }
 
+/**
+ * Arm the PureTUI prefix programmatically — the mouse path into the command
+ * layer (the footer's "commands" hint is clickable). Same guards as the
+ * keyboard arm branch in {@link dispatchKeyEvent}: a disabled prefix, an
+ * input surface owned by the terminal passthrough, or an unreachable
+ * catalogue (modal barrier) is a no-op — the guide must never show commands
+ * a second stroke couldn't fire. Returns whether it armed; the armed state
+ * is the real one, so the next keypress dispatches as a second stroke.
+ */
+export function armPrefixNow(snapshot: readonly RegisteredBinding[], now: number = Date.now()): boolean {
+  if (prefixConfiguration.key === null) return false
+  if (inputPassthroughReachable(snapshot)) return false
+  if (!prefixReachable(snapshot)) return false
+  armPrefix(now, reachablePrefixOptions(snapshot))
+  return true
+}
+
 /** Chords already flagged by the shadowed-match warning (once per process
  *  per chord — a stuck contract violation must not spam every keypress). */
 const shadowWarned = new Set<string>()

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -119,7 +119,7 @@ describe("StatusKeyHintBar", () => {
     expect(text).toContain("F1 help")
   })
 
-  it("swaps the prefix token for the escape hatch inside the terminal, keeping the ⚙ button", async () => {
+  it("swaps the prefix token for the escape hatch inside the terminal, keeping the [settings] button", async () => {
     const settingsOpened: true[] = []
     const { frame } = await renderComponent(
       <WorkspaceDriver>
@@ -133,7 +133,7 @@ describe("StatusKeyHintBar", () => {
     const text = await frame()
     expect(text).toContain("⌃ Q sidebar")
     expect(text).toContain("F1 help")
-    expect(text).toContain("⚙ settings")
+    expect(text).toContain("[settings]")
     expect(text).not.toContain("commands")
   })
 
@@ -153,7 +153,7 @@ describe("StatusKeyHintBar", () => {
 })
 
 describe("footer hint clicks", () => {
-  it("⚙ opens settings from the workspace footer", async () => {
+  it("[settings] opens settings from the workspace footer", async () => {
     const settingsOpened: true[] = []
     const { frame, mockMouse } = await renderComponent(
       <WorkspaceFrame orchestrator={fakeOrchestrator()} onOpenSettings={() => settingsOpened.push(true)}>
@@ -162,7 +162,7 @@ describe("footer hint clicks", () => {
       { width: 70, height: 10, providers: { focus: true, dialog: true } },
     )
     await settle()
-    const spot = locate(await frame(), "⚙ settings")
+    const spot = locate(await frame(), "[settings]")
     await mockMouse.click(spot.x + 1, spot.y)
     await settle()
     expect(settingsOpened.length).toBe(1)

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -11,17 +11,38 @@ import { mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { useEffect } from "react"
-import { PaneKeyHint, StatusKeyHint } from "../../src/tui-react/component/keyboard-hints"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { PaneKeyHint, StatusKeyHintBar } from "../../src/tui-react/component/keyboard-hints"
+import { PrefixHud } from "../../src/tui-react/component/prefix-hud"
 import { useFocus } from "../../src/tui-react/context/focus"
 import { useKV } from "../../src/tui-react/context/kv"
 import { useBindings } from "../../src/tui-react/lib/keymap"
 import { WizardPage } from "../../src/tui-react/onboarding/host"
 import { useDialog } from "../../src/tui-react/ui/dialog"
+import { WorkspaceFrame } from "../../src/tui-react/workspace/host-footer"
 import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keybindings"
 import { KEY_HINTS_ENABLED_KEY, PANE_HINT_USED_KEYS } from "../../src/tui/lib/keyboard-hints"
+import { resetPrefixState } from "../../src/tui/lib/keymap-dispatch"
 import { act, renderComponent, settle } from "./harness"
 
 const NOOP = (): void => {}
+
+/** Minimal orchestrator stand-in — the frame only reads the usage signal. */
+function fakeOrchestrator(): RemoteOrchestrator {
+  const cell = createStateCell(null)
+  return { usageSnapshotSignal: () => cell } as unknown as RemoteOrchestrator
+}
+
+/** Find a substring's cell coordinates in a captured char frame. */
+function locate(frameText: string, needle: string): { x: number; y: number } {
+  const lines = frameText.split("\n")
+  for (let y = 0; y < lines.length; y++) {
+    const x = lines[y]?.indexOf(needle) ?? -1
+    if (x >= 0) return { x, y }
+  }
+  throw new Error(`not on screen: ${needle}`)
+}
 
 /** Registers the real workspace chord set so reachability has live data. */
 function WorkspaceDriver(props: { children?: React.ReactNode }) {
@@ -85,11 +106,11 @@ function withTempKvHome(): void {
   process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-hints-"))
 }
 
-describe("StatusKeyHint", () => {
+describe("StatusKeyHintBar", () => {
   it("advertises the live prefix and help chords from the workspace stack", async () => {
     const { frame } = await renderComponent(
       <WorkspaceDriver>
-        <StatusKeyHint />
+        <StatusKeyHintBar />
       </WorkspaceDriver>,
       { providers: { focus: true, dialog: true } },
     )
@@ -98,11 +119,12 @@ describe("StatusKeyHint", () => {
     expect(text).toContain("F1 help")
   })
 
-  it("swaps the prefix token for the escape hatch inside the terminal", async () => {
+  it("swaps the prefix token for the escape hatch inside the terminal, keeping the ⚙ button", async () => {
+    const settingsOpened: true[] = []
     const { frame } = await renderComponent(
       <WorkspaceDriver>
         <TerminalPassthroughDriver>
-          <StatusKeyHint />
+          <StatusKeyHintBar onOpenSettings={() => settingsOpened.push(true)} />
         </TerminalPassthroughDriver>
       </WorkspaceDriver>,
       { providers: { focus: true, dialog: true } },
@@ -111,6 +133,7 @@ describe("StatusKeyHint", () => {
     const text = await frame()
     expect(text).toContain("⌃ Q sidebar")
     expect(text).toContain("F1 help")
+    expect(text).toContain("⚙ settings")
     expect(text).not.toContain("commands")
   })
 
@@ -119,13 +142,61 @@ describe("StatusKeyHint", () => {
     const { frame } = await renderComponent(
       <WorkspaceDriver>
         <KvSeed entries={[[KEY_HINTS_ENABLED_KEY, false]]}>
-          <StatusKeyHint />
+          <StatusKeyHintBar onOpenSettings={NOOP} />
         </KvSeed>
       </WorkspaceDriver>,
       { providers: { focus: true, dialog: true, kv: true } },
     )
     await settle()
     expect((await frame()).trim()).toBe("")
+  })
+})
+
+describe("footer hint clicks", () => {
+  it("⚙ opens settings from the workspace footer", async () => {
+    const settingsOpened: true[] = []
+    const { frame, mockMouse } = await renderComponent(
+      <WorkspaceFrame orchestrator={fakeOrchestrator()} onOpenSettings={() => settingsOpened.push(true)}>
+        <WorkspaceDriver />
+      </WorkspaceFrame>,
+      { width: 70, height: 10, providers: { focus: true, dialog: true } },
+    )
+    await settle()
+    const spot = locate(await frame(), "⚙ settings")
+    await mockMouse.click(spot.x + 1, spot.y)
+    await settle()
+    expect(settingsOpened.length).toBe(1)
+  })
+
+  it("clicking the help caption opens the F1 reference", async () => {
+    const { frame, mockMouse } = await renderComponent(
+      <WorkspaceFrame orchestrator={fakeOrchestrator()} onOpenSettings={NOOP}>
+        <WorkspaceDriver />
+      </WorkspaceFrame>,
+      { width: 90, height: 30, providers: { focus: true, dialog: true } },
+    )
+    await settle()
+    const spot = locate(await frame(), "F1 help")
+    await mockMouse.click(spot.x + 1, spot.y)
+    await settle()
+    expect(await frame()).toContain("kobe — keybindings")
+  })
+
+  it("clicking the commands caption arms the real prefix and shows the which-key guide", async () => {
+    const { frame, mockMouse } = await renderComponent(
+      <WorkspaceFrame orchestrator={fakeOrchestrator()} onOpenSettings={NOOP}>
+        <WorkspaceDriver />
+        <PrefixHud left={1} width={24} />
+      </WorkspaceFrame>,
+      { width: 110, height: 30, providers: { focus: true, dialog: true } },
+    )
+    await settle()
+    const spot = locate(await frame(), "commands")
+    await mockMouse.click(spot.x + 1, spot.y)
+    // The guide expands after the learner delay (180ms).
+    await settle(300)
+    expect(await frame()).toContain("more Kobe commands")
+    act(() => resetPrefixState())
   })
 })
 

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -92,6 +92,14 @@ function TerminalPassthroughDriver(props: { children?: React.ReactNode }) {
   return <>{props.children}</>
 }
 
+const TEST_MODAL_SCOPE = Symbol("test-modal")
+
+/** Registers a modal barrier, the way an open dialog does. */
+function ModalBarrierDriver(props: { children?: React.ReactNode }) {
+  useBindings(() => ({ modal: true, bindings: [] }), { modalOwner: TEST_MODAL_SCOPE })
+  return <>{props.children}</>
+}
+
 /** Writes KV keys on mount, then renders children — for persisted-state cases. */
 function KvSeed(props: { entries: readonly [string, unknown][]; children?: React.ReactNode }) {
   const kv = useKV()
@@ -135,6 +143,22 @@ describe("StatusKeyHintBar", () => {
     expect(text).toContain("F1 help")
     expect(text).toContain("[settings]")
     expect(text).not.toContain("commands")
+  })
+
+  it("hides the whole bar — [settings] included — while a modal owns input", async () => {
+    // Barrier OUTERMOST: parent effects commit after children, so its
+    // registration lands on top of the stack — the same position an
+    // opening dialog's barrier takes in production.
+    const { frame } = await renderComponent(
+      <ModalBarrierDriver>
+        <WorkspaceDriver>
+          <StatusKeyHintBar onOpenSettings={NOOP} />
+        </WorkspaceDriver>
+      </ModalBarrierDriver>,
+      { providers: { focus: true, dialog: true } },
+    )
+    await settle()
+    expect((await frame()).trim()).toBe("")
   })
 
   it("renders nothing when the master toggle is off", async () => {

--- a/packages/kobe/test/tui-react/use-create-pr.test.ts
+++ b/packages/kobe/test/tui-react/use-create-pr.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The React-free core of the Create-PR action (`createPRAction`): the
+ * target-branch toast and both stale-continuation identity guards. Git IO
+ * is injected, so these pin the control flow, not the prompt content.
+ */
+
+import { describe, expect, test } from "vitest"
+import { createPRAction } from "../../src/tui-react/workspace/use-create-pr"
+
+type Sent = string[]
+
+function deps(over: Partial<Parameters<typeof createPRAction>[0]> = {}) {
+  const sent: Sent = []
+  const errors: string[] = []
+  const send = (text: string) => void sent.push(text)
+  const base = {
+    worktree: "/wt/a",
+    sendToEngineFn: { current: send },
+    selectedWorktreeRef: { current: "/wt/a" },
+    notifyError: (message: string) => void errors.push(message),
+    t: (key: string) => key,
+    gather: async () => ({ branch: "feat/x", targetBranch: "main" }) as never,
+    build: async () => "PR PROMPT",
+    ...over,
+  }
+  return { base, sent, errors }
+}
+
+describe("createPRAction", () => {
+  test("sends the built prompt into the live session", async () => {
+    const { base, sent, errors } = deps()
+    await createPRAction(base)()
+    expect(sent).toEqual(["PR PROMPT"])
+    expect(errors).toEqual([])
+  })
+
+  test("toasts instead of sending when already on the target branch", async () => {
+    const { base, sent, errors } = deps({
+      gather: async () => ({ branch: "main", targetBranch: "main" }) as never,
+    })
+    await createPRAction(base)()
+    expect(sent).toEqual([])
+    expect(errors).toEqual(["files.toast.prOnTargetBranch"])
+  })
+
+  test("drops a stale continuation when the selected worktree changed mid-await", async () => {
+    const { base, sent } = deps()
+    const selectedWorktreeRef = { current: "/wt/a" }
+    const action = createPRAction({
+      ...base,
+      selectedWorktreeRef,
+      gather: async () => {
+        selectedWorktreeRef.current = "/wt/OTHER"
+        return { branch: "feat/x", targetBranch: "main" } as never
+      },
+    })
+    await action()
+    expect(sent).toEqual([])
+  })
+
+  test("drops a stale continuation when the terminal mount behind the ref changed", async () => {
+    const { base, sent } = deps()
+    const action = createPRAction({
+      ...base,
+      build: async () => {
+        base.sendToEngineFn.current = () => {}
+        return "PR PROMPT"
+      },
+    })
+    await action()
+    expect(sent).toEqual([])
+  })
+
+  test("no-ops without a worktree or a live session", async () => {
+    const a = deps({ worktree: null })
+    await createPRAction(a.base)()
+    const b = deps({ sendToEngineFn: { current: null } })
+    await createPRAction(b.base)()
+    expect(a.sent).toEqual([])
+    expect(b.sent).toEqual([])
+  })
+})

--- a/packages/kobe/test/tui/keymap-prefix.test.ts
+++ b/packages/kobe/test/tui/keymap-prefix.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "vitest"
 import { bindByIds } from "../../src/tui/context/keybindings"
 import {
   type RegisteredBinding,
+  armPrefixNow,
   configurePrefix,
   dispatchKeyEvent,
   resetPrefixConfiguration,
@@ -115,5 +116,37 @@ describe("PureTUI prefix dispatch", () => {
     expect(dispatchKeyEvent(stack, event("a", true), 100)).toBe(false)
     expect(dispatchKeyEvent(stack, event("t"), 101)).toBe(false)
     expect(calls).toBe(0)
+  })
+})
+
+describe("armPrefixNow (mouse path into the command layer)", () => {
+  test("arms against a reachable stack and the next key dispatches as a second stroke", () => {
+    const calls: string[] = []
+    const stack: RegisteredBinding[] = [registration(1, true, "f", () => calls.push("fork"))]
+    expect(armPrefixNow(stack)).toBe(true)
+    expect(dispatchKeyEvent(stack, event("f") as never)).toBe(true)
+    expect(calls).toEqual(["fork"])
+  })
+
+  test("no-ops when the prefix is disabled", () => {
+    configurePrefix({ key: null, timeoutMs: 5000 })
+    const stack: RegisteredBinding[] = [registration(1, true, "f", () => {})]
+    expect(armPrefixNow(stack)).toBe(false)
+  })
+
+  test("no-ops while the terminal passthrough owns input", () => {
+    const stack: RegisteredBinding[] = [
+      registration(1, true, "f", () => {}),
+      { id: 2, config: () => ({ enabled: true, bindings: [{ key: "a", cmd: () => {}, passthrough: true }] }) },
+    ]
+    expect(armPrefixNow(stack)).toBe(false)
+  })
+
+  test("no-ops when a modal barrier hides every prefix row", () => {
+    const stack: RegisteredBinding[] = [
+      registration(1, true, "f", () => {}),
+      { id: 2, config: () => ({ enabled: true, modal: true, bindings: [] }) },
+    ]
+    expect(armPrefixNow(stack)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #389 (owner request): make Settings as discoverable as F1 — without adding keyboard noise.

- **Every status-bar hint segment is now mouse-activatable**, and a new **`⚙ settings` button** joins the row. Mouse clicks never pass through to the PTY, so the button works even inside the embedded terminal — exactly where the keyboard path (`⌃Q` → `⌃A` → `,`) is longest. The keyboard captions are unchanged; no chord was added or moved.
- Click semantics mirror the advertised keys: `commands` arms the **real** prefix via a new `armPrefixNow` (same guards as the keyboard arm branch — disabled prefix / passthrough / modal are no-ops — so the which-key guide that appears accepts a keyboard second stroke); the help caption opens F1; the terminal's `⌃Q sidebar` caption jumps focus to the sidebar; `⚙` opens Settings.
- The whole row still respects the Settings → Keyboard hints master toggle and stays text-only on the ambient background (transparent-theme invariant unchanged).
- `createPR` moved out of `host.tsx` into `use-create-pr.ts` (file-size cap: 494 lines after adding the footer prop).

## Test coverage

- Unit: `armPrefixNow` guards (reachable → arms and the next key dispatches as a second stroke; disabled prefix / passthrough / modal → no-op).
- Render (real OpenTUI, real mouse events): `⚙` click opens settings; help-caption click opens the F1 dialog; commands-caption click arms the prefix and the which-key guide expands; terminal-passthrough state keeps `⚙` while swapping the keyboard captions; master toggle hides everything.
- Visual `/harness` journey asserts the `⚙ settings` segment renders; footer screenshot verified.

coverage-exemption: packages/kobe/src/tui-react/workspace/host.tsx — composition root wiring is covered at narrower render-test seams.

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (fast 2808 + socket)
- [x] `bun run test:render` (109)
- [x] `bun run build && bun run test:behavior`
- [x] `bun run check-i18n`
- [x] `bun run visual` (hints journey green; kanban screenshot delta is the known local-vs-CI engine-binary difference, baseline stays CI-flavored)
