### PR TITLE
fix: compact token formatter promotes to m before rounding

### DIFF
--- a/.changeset/token-count-unit-boundary.md
+++ b/.changeset/token-count-unit-boundary.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+The web chat transcript's context readout no longer shows an impossible "1000.0k" just below a million tokens. The compact token formatter tested its unit threshold before rounding, so a value like 999,999 fell into the "k" branch and then `(value / 1000).toFixed(1)` rounded it up to `1000.0k` — a real readout on long-context sessions parked just under 1m. It now promotes to "m" at the boundary the rounding actually crosses (999,950), the same promote-before-rounding rule the file preview's byte formatter already uses, so those sessions read "1.0m".

--- a/packages/kobe-web/src/lib/history.ts
+++ b/packages/kobe-web/src/lib/history.ts
@@ -93,7 +93,12 @@ export function summarizeUsage(
 
 /** Compact token formatting: 1234 → "1.2k", 1234567 → "1.2m". */
 export function formatTokens(value: number): string {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`
+  // Promote to the next unit BEFORE rounding. `(value / 1_000).toFixed(1)`
+  // rounds half-up, so a value just under the 1m boundary — e.g. 999_999 —
+  // would otherwise render the impossible "1000.0k" instead of "1.0m".
+  // 999_950 is the smallest value that rounds up to "1000.0k". (Same reasoning
+  // as preview-core's formatBytes, which promotes at 1023.5, not 1024.)
+  if (value >= 999_950) return `${(value / 1_000_000).toFixed(1)}m`
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
   return String(value)
 }

--- a/packages/kobe-web/test/history-usage.test.ts
+++ b/packages/kobe-web/test/history-usage.test.ts
@@ -64,7 +64,15 @@ describe("formatTokens", () => {
     // The boundary is the bit a `>` refactor would silently break: 999 stays
     // raw, 1000 is already "1.0k", and 1_000_000 is already "1.0m".
     expect(formatTokens(1_000)).toBe("1.0k")
-    expect(formatTokens(999_999)).toBe("1000.0k") // just under 1m → still k
     expect(formatTokens(1_000_000)).toBe("1.0m")
+  })
+
+  it("promotes to m before rounding can render an impossible '1000.0k'", () => {
+    // (value / 1_000).toFixed(1) rounds half-up, so a value just under 1m must
+    // promote to "m" or it prints "1000.0k". 999_950 is the smallest value that
+    // rounds up to 1000.0k; 999_949 still rounds down and stays in "k".
+    expect(formatTokens(999_949)).toBe("999.9k")
+    expect(formatTokens(999_950)).toBe("1.0m")
+    expect(formatTokens(999_999)).toBe("1.0m")
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — found by daily code review, not from an open issue.

## Problem

The web chat transcript header shows a live context estimate via `formatTokens` (`packages/kobe-web/src/lib/history.ts`). The function tested its unit threshold **before** rounding:

```ts
if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`
if (value >= 1_000)     return `${(value / 1_000).toFixed(1)}k`
```

Any value in `[999_950, 999_999]` clears the `1_000_000` check (so it stays in the "k" branch) but then `(value / 1_000).toFixed(1)` rounds `999.95…999.999` **up** to `1000.0`, printing the impossible `"1000.0k"`. This is a real, user-visible readout — long-context sessions routinely sit just under 1,000,000 tokens, and that's exactly the range that renders `ctx 1000.0k` in the transcript.

The repo already had the correct precedent: `preview-core.ts`'s `formatBytes` deliberately promotes at `1023.5`, "not 1024… once v rounds up it would render as the next unit."

## Fix

Promote to `m` at `999_950` — the smallest value that rounds up to `1000.0k` — so the boundary the half-up rounding actually crosses is the boundary the branch switches at. One-line threshold change, mirroring the established `formatBytes` rule.

The existing test **pinned the buggy behavior** (`expect(formatTokens(999_999)).toBe("1000.0k")`, with a comment rationalizing it as "just under 1m → still k"). Corrected it and added boundary coverage: `999_949 → 999.9k`, `999_950 → 1.0m`, `999_999 → 1.0m`.

## Verification

- `bun x vitest run test/history-usage.test.ts` (kobe-web) — 6 passing.
- `bun run lint` and `bun run typecheck` from repo root — both green.
- The 3 unrelated `server-session` / `web-state-routes` test failures are pre-existing on clean `main` (env-dependent), confirmed by re-running with this change stashed.

Patch changeset included.

## Follow-ups (deliberately not in this slice)

`fmtBytes` in `packages/kobe/src/cli/doctor-cmd.ts:74` has the **identical** root cause — `fmtBytes(1_048_550)` prints `"1024.0 KB"` instead of `"1.0 MB"`. It lives in a different surface (`kobe doctor` diagnostics) with no existing test harness, so I left it out to keep this slice tight and surface it here rather than silently widen scope. Happy to fix it in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_012xpgoZ5CYqEf6RMxJWdpA2)_