### PR TITLE
fix: make command prefix global in terminals

### DIFF
--- a/.changeset/global-terminal-prefix.md
+++ b/.changeset/global-terminal-prefix.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Keep the configured command prefix Kobe-owned inside embedded terminals so its live command map and second-stroke actions remain reachable from every pane.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -159,14 +159,14 @@ surface:
 
 - Discoverability hints (Settings → General → Keyboard hints, default on):
   the status bar keeps a permanent `{prefix} commands · F1 help · [settings]`
-  micro-hint (inside the embedded terminal it advertises the escape hatch
-  instead, since the prefix passes through to the PTY there), and the
+  micro-hint, including inside the embedded terminal. The configured prefix is
+  Kobe-owned there; all other unclaimed keys still pass through to the PTY. The
   sidebar/files panes each show a one-line first-use hint that extinguishes
   permanently once that pane's own keys are used. Every status-bar segment is
   clickable — the `[settings]` button opens Settings even from inside the terminal,
   where mouse clicks don't pass through. Turning the toggle back on relights
   extinguished pane hints. Every advertised chord follows live rebinds; an
-  unbound chord drops out of its hint.
+  unbound prefix is released to the PTY and drops out of its hint.
 
 - Edit `~/.kobe/settings/keybindings.yaml` (`.yml` accepted when `.yaml` is
   absent). This is a hand-authored file; kobe never writes it.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -21,8 +21,9 @@ The user-facing model has two independent dimensions:
 That produces three common patterns: bare keys act in the focused pane; a
 small one-press set owns frequent Kobe actions; and the prefix opens the
 less-frequent command layer. The embedded terminal is the passthrough boundary:
-unreserved keys, including the prefix first stroke, remain engine/shell input.
-Press `ctrl+q` to leave it before opening the command layer.
+unreserved keys remain engine/shell input, while the currently configured prefix
+first stroke stays Kobe-owned so the command layer works from every pane.
+Press `ctrl+q` to leave the terminal without opening the command layer.
 
 ## Discoverability (2026-08-09)
 
@@ -32,15 +33,15 @@ which-key map, and all captions resolve through the live keymap
 an unbound/disabled one drops out:
 
 - **Status-bar micro-hint** — a permanent `{prefix} commands · F1 help ·
-  [settings]` row in the workspace footer's right corner. Inside the
-  embedded terminal it swaps the prefix token for the `ctrl+q` escape hatch
-  (the prefix first stroke passes through to the PTY there); with a modal
-  open, or the prefix disabled and help unbound, tokens drop until nothing
-  renders. Every segment is mouse-activatable — clicking `commands` arms the
-  REAL prefix (the guide accepts a keyboard second stroke), clicking the
-  help caption opens F1, and the `[settings]` button opens Settings even while the
-  terminal owns keyboard input, since mouse clicks never pass through
-  (owner call 2026-08-09).
+  [settings]` row in the workspace footer's right corner, including inside
+  the embedded terminal. When no prefix action is reachable there, it falls
+  back to the `ctrl+q` escape hatch; with a modal open, or the prefix disabled
+  and help unbound, tokens drop until nothing renders. Every segment is
+  mouse-activatable — clicking `commands` arms the REAL prefix (the guide
+  accepts a keyboard second stroke), clicking the help caption opens F1, and
+  the `[settings]` button opens Settings even while the terminal owns keyboard
+  input, since mouse clicks never pass through (owner call 2026-08-09; terminal
+  prefix reachability corrected 2026-08-10).
 - **First-use pane hints** — one muted line per vim-style pane (sidebar:
   `j/k move · ⏎ open`; files: move/fold/open/diff). Using that pane's own
   nav/select keys extinguishes its line permanently; the files pane then
@@ -64,6 +65,16 @@ which-key-style command map generated from the live Binding Stack, so it shows
 only actions that can run in the current focus/modal state. It cancels on
 timeout, modal changes, reload, `esc`, or an invalid second stroke.
 
+Owner decision (2026-08-10): the configured prefix first stroke is dynamically
+Kobe-owned even inside the embedded terminal. This makes the command layer and
+content-scoped prefix actions reachable without leaving the pane. The explicit
+cost of the default is that the terminal no longer receives `ctrl+a` for shell
+line-start; disabling the prefix or rebinding it releases the old key to the
+PTY immediately. Unlike fixed global chords, this reservation follows the live
+user configuration. A sequence armed outside the terminal still cancels when
+focus crosses the PTY boundary, so a pending pane command cannot leak into the
+engine accidentally.
+
 Default prefix actions:
 
 | Sequence | Action |
@@ -80,7 +91,7 @@ Default prefix actions:
 | `ctrl+a`, `1` | Point the content pane at the Kanban (kobe's own issue board) |
 | `ctrl+a`, `2` | Point the content pane at Automations (scheduled tasks) |
 | `ctrl+a`, `3` | Point the content pane at GitHub Issues (external tracker) |
-| `ctrl+a`, `z` | Toggle zen mode (prefix-only, owner call 2026-07-17; the old F6 direct chord is released to the shell; not reachable from inside the terminal pane, use the sidebar ☯ ZEN chip there) |
+| `ctrl+a`, `z` | Toggle zen mode (prefix-only, owner call 2026-07-17; the old F6 direct chord is released to the shell) |
 | `ctrl+a`, `,` | Open Settings |
 | `ctrl+a`, `p` / `P` | Create a PR from the active task |
 

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -55,8 +55,8 @@ export type StatusKeyHintItem = {
 /**
  * The status-bar hint segments, empty when there is nothing truthful to say
  * (hints toggled off, prefix disabled AND help unbound, …). Reads the live
- * binding stack, so an open modal or the terminal passthrough boundary
- * reshapes it automatically.
+ * binding stack, so an open modal or a context with no reachable prefix
+ * commands reshapes it automatically.
  */
 export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void }): StatusKeyHintItem[] {
   const t = useT()
@@ -76,9 +76,8 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void }): S
   // Snapshot AFTER every commit, never during render: `enabled` gates like
   // the terminal passthrough table read render-refreshed refs in CHILD
   // components, and this hook renders in a parent (the workspace footer) —
-  // a render-time read sees the PREVIOUS cycle's focus, which showed the
-  // prefix hint inside the terminal and the escape hatch outside it,
-  // exactly inverted. Effects run children-first, so by the time this one
+  // a render-time read sees the PREVIOUS cycle's focus and command set.
+  // Effects run children-first, so by the time this one
   // fires the whole tree's refs and registrations are current. The
   // compare-and-set keeps the no-change case from looping.
   useEffect(() => {

--- a/packages/kobe/src/tui-react/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/keys.ts
@@ -4,9 +4,9 @@
  *
  * Same passthrough contract as the Solid hook: when focused, every
  * keystroke the shell would expect (ctrl+c, ctrl+d, arrows, …) is
- * forwarded verbatim. Only `RESERVED_GLOBAL_CHORDS` and the
- * ctrl+pgup/pgdown scrollback chords stay kobe-owned — see
- * `keys-pure.ts` for the full rationale, unchanged and reused as-is.
+ * forwarded verbatim. The dynamically configured command prefix,
+ * `RESERVED_GLOBAL_CHORDS`, and ctrl+pgup/pgdown scrollback chords stay
+ * kobe-owned — see `keys-pure.ts` for the full rationale.
  *
  * Pure/runtime split preserved: `keys-pure.ts` (constants + the
  * side-effect-free byte encoder) is imported straight from the Solid

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -131,8 +131,8 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
         // f4 — reserved from terminal passthrough, so the cycle behaves
         // identically from every pane including inside the terminal.
         "focus.next": () => cyclePane(1),
-        // prefix+z only (owner call 2026-07-17) — not reachable from
-        // inside the terminal pane, where the prefix key passes through.
+        // prefix+z only (owner call 2026-07-17). The configured prefix is
+        // Kobe-global, so this remains reachable inside the terminal pane.
         "workspace.zenToggle": () => deps.toggleZen(),
         // f7 — reserved from terminal passthrough too, so "jump to the
         // next waiting task" works even while focused inside the engine.

--- a/packages/kobe/src/tui/lib/help-groups.ts
+++ b/packages/kobe/src/tui/lib/help-groups.ts
@@ -88,8 +88,8 @@ function availableOn(row: KobeBinding, surface: HelpSurface | null): boolean {
   if (surface === null) return false
   if (row.scope === surface) return true
   // Terminal is the workspace's embedded input surface. Workspace-owned
-  // reserved direct chords stay relevant there; prefix rows are filtered by
-  // the caller because the prefix key itself passes through to the PTY.
+  // reserved direct chords and the configured global prefix stay relevant
+  // there; other unclaimed keys still pass through to the PTY.
   return surface === "terminal" && row.scope === "workspace"
 }
 
@@ -127,7 +127,7 @@ export function grammarHelpSections(
         else other.set(binding.scope, [row])
       }
     }
-    if (prefixKey && surface !== "terminal" && prefixAvailable && binding.prefixKeys?.length) {
+    if (prefixKey && prefixAvailable && binding.prefixKeys?.length) {
       prefix.push({
         binding,
         primary: `${prefixKey} + ${binding.prefixKeys[0]}`,

--- a/packages/kobe/src/tui/lib/keyboard-hints.ts
+++ b/packages/kobe/src/tui/lib/keyboard-hints.ts
@@ -65,17 +65,18 @@ export type StatusHintToken = {
 
 /**
  * The status-bar micro-hint, derived from the live reachability snapshot:
- * inside the embedded terminal the prefix first stroke passes through to the
- * PTY, so the hint advertises the escape hatch instead of lying about the
- * prefix; a disabled prefix or unbound help chord drops its token.
+ * the configured prefix remains Kobe-owned inside the embedded terminal, so
+ * it stays visible whenever a second stroke can run. If no prefix command is
+ * reachable there, the escape hatch is the truthful fallback; a disabled
+ * prefix or unbound help chord drops its token.
  */
 export function statusHintTokens(reach: BindingReachability, prefixKey: string | null): StatusHintToken[] {
   const tokens: StatusHintToken[] = []
-  if (reach.inputPassthrough) {
+  if (prefixKey !== null && reach.prefix.size > 0) {
+    tokens.push({ chord: prefixKey, msg: "commands" })
+  } else if (reach.inputPassthrough) {
     const cap = reach.direct.has("focus.sidebar") ? legendCap("focus.sidebar") : null
     if (cap) tokens.push({ chord: cap, msg: "sidebar" })
-  } else if (prefixKey !== null && reach.prefix.size > 0) {
-    tokens.push({ chord: prefixKey, msg: "commands" })
   }
   if (reach.direct.has("help.open")) {
     const cap = legendCap("help.open")

--- a/packages/kobe/src/tui/lib/keymap-dispatch.ts
+++ b/packages/kobe/src/tui/lib/keymap-dispatch.ts
@@ -16,7 +16,7 @@ export type Binding = {
   key: string
   /** True when `key` is the second stroke of the PureTUI prefix. */
   prefix?: boolean
-  /** Terminal/shell input that must win over Kobe's configurable prefix. */
+  /** Terminal/shell input used to detect the PTY boundary. The configured prefix remains Kobe-owned. */
   passthrough?: boolean
   /**
    * Owning KobeKeymap binding id (`tab.new`) — `bindByIds` fills it in so
@@ -191,7 +191,7 @@ export type PrefixConfiguration = {
 export type BindingReachability = {
   direct: ReadonlySet<string>
   prefix: ReadonlySet<string>
-  /** An enabled terminal passthrough table owns the current input surface. */
+  /** The current input surface forwards unclaimed keys to a terminal. */
   inputPassthrough: boolean
 }
 
@@ -199,6 +199,7 @@ export const DEFAULT_PREFIX_CONFIGURATION: Readonly<PrefixConfiguration> = { key
 
 let prefixConfiguration: PrefixConfiguration = { ...DEFAULT_PREFIX_CONFIGURATION }
 let prefixArmedAt: number | null = null
+let prefixArmedOnPassthrough = false
 let prefixTimer: ReturnType<typeof setTimeout> | null = null
 
 /** Apply a validated configuration and cancel an in-flight sequence. */
@@ -223,12 +224,14 @@ export function resetPrefixState(): void {
   if (prefixTimer !== null) clearTimeout(prefixTimer)
   prefixTimer = null
   prefixArmedAt = null
+  prefixArmedOnPassthrough = false
   prefixHudSetArmed(false)
 }
 
-function armPrefix(now: number, options: readonly PrefixHudOption[]): void {
+function armPrefix(now: number, options: readonly PrefixHudOption[], inputPassthrough: boolean): void {
   resetPrefixState()
   prefixArmedAt = now
+  prefixArmedOnPassthrough = inputPassthrough
   prefixTimer = setTimeout(resetPrefixState, prefixConfiguration.timeoutMs)
   prefixHudSetArmed(true, options, now)
 }
@@ -236,17 +239,17 @@ function armPrefix(now: number, options: readonly PrefixHudOption[]): void {
 /**
  * Arm the PureTUI prefix programmatically — the mouse path into the command
  * layer (the footer's "commands" hint is clickable). Same guards as the
- * keyboard arm branch in {@link dispatchKeyEvent}: a disabled prefix, an
- * input surface owned by the terminal passthrough, or an unreachable
- * catalogue (modal barrier) is a no-op — the guide must never show commands
- * a second stroke couldn't fire. Returns whether it armed; the armed state
- * is the real one, so the next keypress dispatches as a second stroke.
+ * keyboard arm branch in {@link dispatchKeyEvent}: a disabled prefix or an
+ * unreachable catalogue (modal barrier) is a no-op. Terminal passthrough is
+ * deliberately allowed because the configured prefix is Kobe-global; every
+ * other unclaimed key still reaches the PTY. Returns whether it armed; the
+ * armed state is the real one, so the next keypress dispatches as a second
+ * stroke.
  */
 export function armPrefixNow(snapshot: readonly RegisteredBinding[], now: number = Date.now()): boolean {
   if (prefixConfiguration.key === null) return false
-  if (inputPassthroughReachable(snapshot)) return false
   if (!prefixReachable(snapshot)) return false
-  armPrefix(now, reachablePrefixOptions(snapshot))
+  armPrefix(now, reachablePrefixOptions(snapshot), inputPassthroughReachable(snapshot))
   return true
 }
 
@@ -359,7 +362,6 @@ function dispatchMode(
   evt: KeyEvent,
   candidates: string[],
   prefix: boolean,
-  accepts: (binding: Binding) => boolean = () => true,
 ): Binding | null {
   for (let i = snapshot.length - 1; i >= 0; i--) {
     const reg = snapshot[i]
@@ -373,9 +375,7 @@ function dispatchMode(
     // decide. Candidates are ≤3 strings, so the nested scan stays O(1).
     let hit: Binding | undefined
     for (const candidate of candidates) {
-      hit = cfg.bindings.find(
-        (binding) => Boolean(binding.prefix) === prefix && binding.key === candidate && accepts(binding),
-      )
+      hit = cfg.bindings.find((binding) => Boolean(binding.prefix) === prefix && binding.key === candidate)
       if (hit) break
     }
     if (hit) {
@@ -423,10 +423,12 @@ export function dispatchKeyEvent(
   const candidates = matchKey(evt as KeyEvent)
   dispatching = true
   try {
-    // A sequence armed in another pane cannot cross the terminal boundary:
-    // once PTY passthrough owns input, cancel it and dispatch this key using
-    // the current surface instead.
-    if (prefixArmedAt !== null && inputPassthroughReachable(snapshot)) resetPrefixState()
+    // A sequence cannot cross the PTY boundary after it is armed: the next
+    // key must resolve in the same kind of input surface that showed the
+    // command map. Prefixes armed INSIDE the terminal remain valid there.
+    if (prefixArmedAt !== null && inputPassthroughReachable(snapshot) !== prefixArmedOnPassthrough) {
+      resetPrefixState()
+    }
     if (prefixArmedAt !== null) {
       const armedPrefixKey = prefixConfiguration.key ?? ""
       const expired = now - prefixArmedAt > prefixConfiguration.timeoutMs
@@ -456,18 +458,12 @@ export function dispatchKeyEvent(
     }
 
     if (prefixConfiguration.key !== null && candidates.includes(prefixConfiguration.key)) {
-      // The embedded terminal owns unreserved input, including the prefix
-      // first stroke. Its explicit passthrough row must win before the
-      // global prefix catalogue can arm.
-      const passthrough = dispatchMode(snapshot, evt as KeyEvent, candidates, false, (binding) =>
-        Boolean(binding.passthrough),
-      )
-      if (passthrough) {
-        evt.preventDefault()
-        return true
-      }
+      // The configured first stroke is Kobe-global, including while the
+      // embedded terminal owns every other unreserved key. If no prefix row
+      // is reachable (disabled configuration/modal context), normal direct
+      // dispatch below still lets the terminal's passthrough binding win.
       if (prefixReachable(snapshot)) {
-        armPrefix(now, reachablePrefixOptions(snapshot))
+        armPrefix(now, reachablePrefixOptions(snapshot), inputPassthroughReachable(snapshot))
         evt.preventDefault()
         return true
       }

--- a/packages/kobe/src/tui/panes/terminal/keys-pure.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys-pure.ts
@@ -136,7 +136,9 @@ export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown"] as const
 
 /**
  * Chord strings the terminal pane must NEVER passthrough to the shell.
- * Deliberately MINIMAL: the engine CLI owns
+ * The dispatcher also dynamically claims the configured command prefix;
+ * keeping that out of this static table makes live rebindings release the
+ * old prefix immediately. This list stays deliberately MINIMAL: the engine CLI owns
  * its own chords (shift+tab plan-mode, ctrl+r history, ctrl+hjkl, F1…),
  * so kobe keeps only ctrl+q as the escape hatch plus the tab-management
  * and reset chords. Kobe's other global chords stay reachable from every

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/react */
 /**
  * Real-render coverage for the keyboard-discoverability hints: the
- * status-bar micro-hint (prefix/help, terminal-passthrough aware), the
+ * status-bar micro-hint (prefix/help, including terminal passthrough), the
  * first-use pane hints and their extinguish/fallback behavior, the master
  * toggle, and the onboarding wizard's "Keyboard basics" page.
  */
@@ -45,7 +45,7 @@ function locate(frameText: string, needle: string): { x: number; y: number } {
 }
 
 /** Registers the real workspace chord set so reachability has live data. */
-function WorkspaceDriver(props: { children?: React.ReactNode }) {
+function WorkspaceDriver(props: { children?: React.ReactNode; onToggleZen?: () => void }) {
   const focus = useFocus()
   const dialog = useDialog()
   useWorkspaceKeybindings({
@@ -71,7 +71,7 @@ function WorkspaceDriver(props: { children?: React.ReactNode }) {
     createTask: NOOP,
     renameBranch: NOOP,
     cycleVendor: NOOP,
-    toggleZen: NOOP,
+    toggleZen: props.onToggleZen ?? NOOP,
     jumpToNextAttention: NOOP,
     openInbox: NOOP,
     enterMoveMode: NOOP,
@@ -87,7 +87,7 @@ function TerminalPassthroughDriver(props: { children?: React.ReactNode }) {
   useEffect(() => focus.setFocused("workspace"), [])
   useBindings(() => ({
     enabled: focus.focused === "workspace",
-    bindings: [{ key: "a", cmd: NOOP, passthrough: true }],
+    bindings: [{ key: "ctrl+a", cmd: NOOP, passthrough: true }],
   }))
   return <>{props.children}</>
 }
@@ -127,7 +127,7 @@ describe("StatusKeyHintBar", () => {
     expect(text).toContain("F1 help")
   })
 
-  it("swaps the prefix token for the escape hatch inside the terminal, keeping the [settings] button", async () => {
+  it("keeps the prefix command layer visible inside the terminal", async () => {
     const settingsOpened: true[] = []
     const { frame } = await renderComponent(
       <WorkspaceDriver>
@@ -139,10 +139,34 @@ describe("StatusKeyHintBar", () => {
     )
     await settle()
     const text = await frame()
-    expect(text).toContain("⌃ Q sidebar")
+    expect(text).toContain("⌃ A commands")
     expect(text).toContain("F1 help")
     expect(text).toContain("[settings]")
-    expect(text).not.toContain("commands")
+    expect(text).not.toContain("⌃ Q sidebar")
+  })
+
+  it("opens and dispatches the command layer with ctrl+a inside the terminal", async () => {
+    let zenToggles = 0
+    const { frame, mockInput } = await renderComponent(
+      <WorkspaceFrame orchestrator={fakeOrchestrator()} onOpenSettings={NOOP}>
+        <WorkspaceDriver onToggleZen={() => zenToggles++}>
+          <TerminalPassthroughDriver>
+            <PrefixHud left={1} width={24} />
+          </TerminalPassthroughDriver>
+        </WorkspaceDriver>
+      </WorkspaceFrame>,
+      { width: 110, height: 30, providers: { focus: true, dialog: true } },
+    )
+    await settle()
+
+    act(() => mockInput.pressKey("a", { ctrl: true }))
+    await settle(300)
+    expect(await frame()).toContain("more Kobe commands")
+
+    act(() => mockInput.pressKey("z"))
+    await settle()
+    expect(zenToggles).toBe(1)
+    act(() => resetPrefixState())
   })
 
   it("hides the whole bar — [settings] included — while a modal owns input", async () => {

--- a/packages/kobe/test/tui-react/help-groups.test.ts
+++ b/packages/kobe/test/tui-react/help-groups.test.ts
@@ -56,9 +56,9 @@ describe("grammarHelpSections", () => {
     expect(sections[3]?.scope).toBe("files")
   })
 
-  it("does not advertise the Kobe prefix inside the embedded terminal", () => {
+  it("advertises the Kobe prefix inside the embedded terminal", () => {
     const sections = grammarHelpSections(rows, "terminal", "ctrl+a")
-    expect(sections.some((section) => section.kind === "prefix")).toBe(false)
+    expect(sections.find((section) => section.kind === "prefix")?.rows.map((row) => row.binding.id)).toEqual(["more"])
   })
 
   it("uses the live stack snapshot to hide inactive submode bindings", () => {

--- a/packages/kobe/test/tui/keyboard-hints.test.ts
+++ b/packages/kobe/test/tui/keyboard-hints.test.ts
@@ -3,8 +3,8 @@
  * (`src/tui/lib/keyboard-hints.ts`). The contract that matters: every hint
  * resolves through the LIVE keymap and reachability snapshot — a rebound
  * chord shows its new key, an unbound/disabled one drops its token, and the
- * terminal passthrough boundary is never lied about (the prefix first
- * stroke belongs to the PTY there).
+ * terminal passthrough boundary is never lied about (the configured prefix
+ * remains Kobe-owned there while every other unreserved key reaches the PTY).
  */
 
 import { afterEach, describe, expect, test } from "vitest"
@@ -52,7 +52,16 @@ describe("statusHintTokens", () => {
     ])
   })
 
-  test("terminal passthrough swaps the prefix token for the escape hatch", () => {
+  test("terminal passthrough keeps the reachable global prefix visible", () => {
+    const tokens = statusHintTokens(
+      reach({ direct: ["focus.sidebar", "help.open"], prefix: ["settings.open"], inputPassthrough: true }),
+      "ctrl+a",
+    )
+    expect(tokens.map((t) => t.msg)).toEqual(["commands", "help"])
+    expect(tokens[0]?.chord).toBe("ctrl+a")
+  })
+
+  test("terminal passthrough falls back to the escape hatch when no prefix command is reachable", () => {
     const tokens = statusHintTokens(
       reach({ direct: ["focus.sidebar", "help.open"], prefix: [], inputPassthrough: true }),
       "ctrl+a",

--- a/packages/kobe/test/tui/keymap-dispatch-passthrough.test.ts
+++ b/packages/kobe/test/tui/keymap-dispatch-passthrough.test.ts
@@ -5,7 +5,9 @@ import { beforeEach, describe, expect, test } from "vitest"
 import {
   type RegisteredBinding,
   bindingReachability,
+  configurePrefix,
   dispatchKeyEvent,
+  resetPrefixConfiguration,
   resetPrefixState,
 } from "../../src/tui/lib/keymap-dispatch"
 import { prefixHudState, resetPrefixHud } from "../../src/tui/lib/prefix-hud"
@@ -29,19 +31,104 @@ function makeEvt(name: string, mods: Partial<KeyEvent> = {}): KeyEvent & { defau
 }
 
 beforeEach(() => {
+  resetPrefixConfiguration()
   resetPrefixState()
   resetPrefixHud()
 })
 
 describe("prefix passthrough boundary", () => {
-  test("terminal passthrough owns the configurable prefix first stroke", () => {
+  test("the configured prefix owns its first and second strokes inside terminal passthrough", () => {
+    let prefixFired = false
     let forwarded = false
     const stack: RegisteredBinding[] = [
       {
         id: 1,
         config: () => ({
-          bindings: [{ key: "f", prefix: true, cmd: () => {}, id: "chat.fork.new" }],
+          bindings: [
+            {
+              key: "f",
+              prefix: true,
+              id: "chat.fork.new",
+              cmd: () => {
+                prefixFired = true
+              },
+            },
+          ],
         }),
+      },
+      {
+        id: 2,
+        config: () => ({
+          bindings: [
+            {
+              key: "ctrl+a",
+              passthrough: true,
+              cmd: () => {
+                forwarded = true
+              },
+            },
+            {
+              key: "f",
+              passthrough: true,
+              cmd: () => {
+                forwarded = true
+              },
+            },
+          ],
+        }),
+      },
+    ]
+
+    const evt = makeEvt("a", { ctrl: true })
+    expect(dispatchKeyEvent(stack, evt, 100)).toBe(true)
+    expect(forwarded).toBe(false)
+    expect(evt.defaultPrevented).toBe(true)
+    expect(prefixHudState().armed).toBe(true)
+    expect(bindingReachability(stack).inputPassthrough).toBe(true)
+
+    expect(dispatchKeyEvent(stack, makeEvt("f"), 200)).toBe(true)
+    expect(prefixFired).toBe(true)
+    expect(forwarded).toBe(false)
+    expect(prefixHudState().armed).toBe(false)
+    expect(prefixHudState().entries[0]?.action).toBe("chat.fork.new")
+  })
+
+  test("live prefix reconfiguration releases the old chord and owns the new one", () => {
+    configurePrefix({ key: "ctrl+x", timeoutMs: 5000 })
+    const forwarded: string[] = []
+    const stack: RegisteredBinding[] = [
+      {
+        id: 1,
+        config: () => ({ bindings: [{ key: "f", prefix: true, cmd: () => {}, id: "chat.fork.new" }] }),
+      },
+      {
+        id: 2,
+        config: () => ({
+          bindings: ["ctrl+a", "ctrl+x"].map((key) => ({
+            key,
+            passthrough: true,
+            cmd: () => forwarded.push(key),
+          })),
+        }),
+      },
+    ]
+
+    expect(dispatchKeyEvent(stack, makeEvt("a", { ctrl: true }), 100)).toBe(true)
+    expect(forwarded).toEqual(["ctrl+a"])
+    expect(prefixHudState().armed).toBe(false)
+
+    expect(dispatchKeyEvent(stack, makeEvt("x", { ctrl: true }), 200)).toBe(true)
+    expect(forwarded).toEqual(["ctrl+a"])
+    expect(prefixHudState().armed).toBe(true)
+  })
+
+  test("disabling the prefix releases its former first stroke to the terminal", () => {
+    configurePrefix({ key: null, timeoutMs: 5000 })
+    let forwarded = false
+    const stack: RegisteredBinding[] = [
+      {
+        id: 1,
+        config: () => ({ bindings: [{ key: "f", prefix: true, cmd: () => {}, id: "chat.fork.new" }] }),
       },
       {
         id: 2,
@@ -59,13 +146,9 @@ describe("prefix passthrough boundary", () => {
       },
     ]
 
-    const evt = makeEvt("a", { ctrl: true })
-    expect(dispatchKeyEvent(stack, evt, 100)).toBe(true)
+    expect(dispatchKeyEvent(stack, makeEvt("a", { ctrl: true }), 100)).toBe(true)
     expect(forwarded).toBe(true)
-    expect(evt.defaultPrevented).toBe(true)
     expect(prefixHudState().armed).toBe(false)
-    expect(prefixHudState().entries).toHaveLength(0)
-    expect(bindingReachability(stack).inputPassthrough).toBe(true)
   })
 
   test("entering terminal input cancels a prefix armed in another pane", () => {

--- a/packages/kobe/test/tui/keymap-prefix.test.ts
+++ b/packages/kobe/test/tui/keymap-prefix.test.ts
@@ -134,12 +134,15 @@ describe("armPrefixNow (mouse path into the command layer)", () => {
     expect(armPrefixNow(stack)).toBe(false)
   })
 
-  test("no-ops while the terminal passthrough owns input", () => {
+  test("arms while terminal passthrough owns unrelated input", () => {
+    const calls: string[] = []
     const stack: RegisteredBinding[] = [
-      registration(1, true, "f", () => {}),
+      registration(1, true, "f", () => calls.push("fork")),
       { id: 2, config: () => ({ enabled: true, bindings: [{ key: "a", cmd: () => {}, passthrough: true }] }) },
     ]
-    expect(armPrefixNow(stack)).toBe(false)
+    expect(armPrefixNow(stack)).toBe(true)
+    expect(dispatchKeyEvent(stack, event("f") as never)).toBe(true)
+    expect(calls).toEqual(["fork"])
   })
 
   test("no-ops when a modal barrier hides every prefix row", () => {


### PR DESCRIPTION
## Summary\n- Make the configured command prefix win over embedded-terminal passthrough, so Ctrl+A opens the live command map and second-stroke actions work from every pane.\n- Preserve PTY behavior for unclaimed keys, live rebinds, disabled prefixes, and cross-boundary cancellation.\n- Update status hints, F1 help, keybinding documentation, regression coverage, and add a patch changeset.\n\n## Test plan\n- Verified lint, typecheck, 2,821 fast tests, 495 socket tests, 114 OpenTUI render tests, and 5 hermetic  journeys.