### PR TITLE
docs: correct the user-facing docs against the shipped binary

### DIFF
--- a/.changeset/docs-accuracy-audit.md
+++ b/.changeset/docs-accuracy-audit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Correct the user-facing docs against the shipped binary: two commands that don't exist, a stale `kobe --help` transcript, a setting kobe never reads, and the worktree-location setting that had no documentation at all.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -91,6 +91,10 @@ As rendered by `kobe --help`:
 ```text
 Usage: kobe [command] [options]
 
+Run with no command to launch PureTUI.
+Run `kobe .` (or `kobe <path>`) to open a directory as a standalone task.
+
+Commands:
   web [options]           Launch the browser dashboard
   completions <shell>     Generate shell completion script (bash/zsh/fish)
   add [path]              Save a repo path for the new-task picker
@@ -100,9 +104,9 @@ Usage: kobe [command] [options]
   repo <verb>             Per-repo init script + first prompt (show|set|unset)
   api <verb>              Scriptable RPC surface for agents (see `kobe api --help`)
   daemon <verb>           Manage the daemon (start|stop|status|restart)
-  doctor [--report]       Diagnose daemon/PTY/engines/git; --report writes a bundle
-  config [--path]         Open kobe's config file (state.json) in your editor
-  reset [--hard]          Stop runtimes; optionally wipe task/UI state
+  doctor [--report]        Diagnose daemon/PTY/engines/git; --report writes a bundle
+  config [--path]          Open kobe's config file (state.json) in your editor
+  reset [--hard]           Stop runtimes; optionally wipe task/UI state
   theme <verb>            Manage user themes (list|add|remove)
   skill <verb>            Install the kobe agent skill (install|status|command)
   plugin <verb>           Install and run plugins (install|link|list|action|…)
@@ -346,6 +350,12 @@ Env vars the binary respects (accessor home: `packages/kobe/src/env.ts`):
 - `KOBE_DAEMON_WEB_PORT`: daemon web transport port (default 5174;
   `0`/`off`/`false` disables it). `KOBE_WEB_HOST`,
   `KOBE_DAEMON_WEB_STATIC_DIR`: web transport host / static dir overrides.
+- `KOBE_OPEN_EDITOR`: command that opens a worktree in an external editor
+  (`code`, `cursor`, `nvim`, …), used by `prefix+o` / the sidebar's `o`.
+  It wins over kobe's auto-detection of installed editors, and the TUI's
+  "No editor found" toast names this variable. Separate from the
+  `editor.*` config keys, which pick the TTY editor for `kobe config` and
+  the file tree's `e` (see [Configuration](./CONFIGURATION.md)).
 - `KOBE_DEV=1`: declares a developer checkout (suppresses the
   update-available chip).
 - `KOBE_DEBUG=1`: print full startup errors instead of the one-line

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,7 +77,9 @@ configuration surface.
 | `activeTheme` | string (theme name) | `"claude"` | Must name a bundled or installed theme; unknown names fall back to the default. See [Themes](#themes). |
 | `transparentBackground` | boolean | `true` | Default-true: only an explicit stored `false` opts out. |
 | `focusAccent` | `"primary"` \| `"success"` \| `"info"` | `"primary"` | Which palette slot paints the focused-pane indicator. |
+| `appearance.splitStyle` | `"box"` \| `"line"` | `"box"` | How split leaves are framed. `box` draws a full frame per leaf (matching the workspace's bordered columns); `line` is the tmux-style minimal look — each leaf draws only the edge it shares with its previous sibling. Unknown values fall back to `box` (`src/state/split-style.ts`). |
 | `locale` | `"en"` \| `"zh"` | `"en"` | UI language. Unknown values fall back to English. |
+| `hints.keyboard.enabled` | boolean | `true` | Master switch for the keyboard-discoverability hints (status-bar micro-hint + first-use pane hints). Only an explicit `false` turns them off; re-enabling relights pane hints that were extinguished by use. Settings → General → Keyboard hints. |
 
 ### Editor
 
@@ -104,6 +106,8 @@ Used by the file tree's `e` key, `prefix+o` (open worktree in editor), and
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `terminal.scrollbackRows` | number | `1000` | Rows of history per embedded terminal's xterm buffer. Clamped between 100 and 100,000; non-numeric values reset to the default. Applies to terminals spawned **after** the change; live PTYs keep the buffer they were born with (`src/state/scrollback.ts`). |
+| `chat.tabStrip.mode` | `"always"` \| `"multipleOnly"` \| `"never"` | `"never"` | Horizontal chat tab strip. Off by default because the sidebar tree already lists every worktree's tabs, so the strip is a second copy of the same list. `always` brings it back for every tab count; `multipleOnly` shows it only once a task has more than one tab (`src/state/tab-strip.ts`). |
+| `chat.tabStrip.hideSingle` | boolean | unset | **Legacy** boolean that `chat.tabStrip.mode` replaced (`true` meant "hide while a task has one tab"). Still honored when the new key was never written, so an old setting keeps working; the moment you touch `chat.tabStrip.mode` the new key wins for good. |
 
 ### Notifications
 
@@ -120,8 +124,36 @@ All three default to `true` (only an explicit `false` opts out). Details in
 
 | Key | Type | Default | Notes |
 |---|---|---|---|
-| `activeSortMode` | `"recent"` \| `"default"` | `"default"` | Sidebar task ordering. `recent` reshuffles as you switch tasks (jump digits follow); `default` is the stored, stable order. |
-| `sidebar.hover.enabled` | boolean | `false` | Hover interactions in the sidebar. |
+| `activeSortMode` | `"recent"` \| `"default"` | `"default"` | Sidebar task ordering, read at startup. `recent` reshuffles as you switch tasks (jump digits follow); `default` is the stored, stable order. **Hand-edit only today**: the `t` chord that flips it (`sidebar.sort`) is in the keymap table but has no handler in the current TUI, so nothing in the UI writes this key. |
+
+### Zen mode
+
+Zen hides the files/Ops pane and the terminal pane across every chat tab so
+each engine pane fills its window. Both keys are read fresh at each toggle, so
+a hand edit needs no daemon restart (`src/state/zen.ts`).
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `zen.active` | boolean | `false` | Global on/off intent. Persisted rather than per-session so switching projects doesn't drop you out of zen; entering any session reconciles its layout to this flag. Toggle with `prefix+z`. |
+| `zen.keepTasks` | boolean | `true` | Whether zen keeps the Tasks rail. Default on so the create-PR bar and the prefix chord stay reachable to leave zen again. |
+
+### Worktree location
+
+By default every LOCAL task worktree lands under
+`~/.kobe/worktrees/<repo-key>/<slug>`. These keys relocate that root
+wholesale; the per-repo `<repo-key>` namespacing is preserved either way, so
+worktrees from different repos never collide under a shared base. Read fresh
+on every worktree-path computation — changing it takes effect for the next
+task with no daemon restart, and **only new tasks move** (existing tasks keep
+their persisted `worktreePath`, and the old default root stays recognized).
+Remote (SSH) projects are unaffected: their worktrees live on the remote host
+under the project's own base path. Settings → General → Worktree location
+(`src/state/worktree-base.ts`).
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `worktree.basePath` | string | `""` (→ `~/.kobe/worktrees`) | Absolute path, or a value starting with the `$project_dir` token, which expands to the task's project root at path-computation time — one global setting that yields a per-project layout. `$project_dir/..` is the "next to project" preset (worktrees land beside each repo). The token is only recognized as the **leading** segment; anywhere else it is a literal directory name. |
+| `worktree.basePath.custom` | string | unset | TUI-only companion that remembers the last custom path you typed, so cycling the setting away from `custom` and back restores it instead of forcing a retype. The daemon never reads it. |
 
 ### Experimental
 
@@ -133,6 +165,7 @@ without notice.
 | `experimental.remoteProjects` | boolean | `false` | Remote (SSH) projects. |
 | `experimental.autoStatus` | boolean | `false` | Auto status flow: `turn-start` moves a backlog task to `in_progress`, and spawned sessions get a system-prompt protocol to self-report `in_review` (`src/state/auto-status.ts`). |
 | `experimental.dispatcher` | boolean | `false` | Per-repo dispatcher: field notes filed by worktree sessions are routed by the repo's main session (`src/state/dispatcher.ts`). |
+| `experimental.archivedHistoryPreview` | boolean | `false` | Read-only engine-history view for archived tasks. The web settings API mirrors this key and the TUI settings dialog can toggle it (`src/state/archived-history.ts`). |
 
 ## Themes
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -169,8 +169,10 @@ makes the feature usable rather than clever:
   reorder with it. Reading them off the screen is the intended interaction:
   the digit is "where this task sits right now", not a permanent address. The
   task you are in sits at the top, so the digits read as distance from where
-  you are. Want fixed addresses instead? `t` switches the sidebar to the
-  **`default`** sort, whose order is stored and never reshuffles on its own.
+  you are. Want fixed addresses instead? The **`default`** sort's order is
+  stored and never reshuffles on its own — but see the `sidebar.sort` note
+  below: the `t` chord that switches between them is currently inert, so
+  today the mode changes only via `activeSortMode` in state.json.
 - A row past the ninth prints no digit, and a chord with no row does nothing.
   A jump that silently lands somewhere else is worse than one that does
   nothing.
@@ -239,9 +241,16 @@ something tree-shaped inside it:
   to kobe; the terminal-side fix (e.g. iTerm2's "Ctrl-click reported to
   apps") lives in [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
 
-`sidebar.sort` is not registered. A tree already carries an order (project →
-worktree → tab) and manual placement lives in move mode, so a second automatic
-ordering would only fight the structure.
+`sidebar.sort` (`t`) is **registered in the keymap table but has no handler**
+in the tree sidebar, so pressing it does nothing today (F1 filters it out by
+reachability, so it is not advertised either). A tree already carries an order
+(project → worktree → tab) and manual placement lives in move mode, so a
+second automatic ordering would only fight the structure — but the row was
+never removed, and `activeSortMode` is still read at startup. Whether to wire
+the chord back or drop the row is an open owner call; the same applies to
+`sidebar.projectFilter` (`ctrl+p`, whose project filter was a fold),
+`sidebar.previewToggle` (`i`), and `tasks.toggleKeys` (`?`), which are also
+table rows with no handler.
 
 Create PR is `prefix+p` / `prefix+P`, global scope, no direct chord (owner
 call 2026-07-18, superseding the 2026-07-17 files-scoped `ctrl+p`): the direct

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -81,7 +81,7 @@ Two scoped exceptions to "everything survives a quit":
 
 - Archiving a task kills its hosted sessions. A daemon janitor sweeps PTY
   sessions whose task is no longer live (`pty.sweep`), so a headless
-  `kobe api task-archive` can't leak an engine that runs forever.
+  `kobe api archive` can't leak an engine that runs forever.
 - An engine that exits on its own is kept as a dead session, scrollback
   intact, so a reattach still shows how it died, until an explicit close or
   the archive sweep removes it.

--- a/docs/design/cli-api.md
+++ b/docs/design/cli-api.md
@@ -575,6 +575,6 @@ implement X three different ways" and the model uses
   the five `kobe api` verbs are a strict subset.
 - `packages/kobe-daemon/src/client/index.ts` — `KobeDaemonClient`, the
   ready-made transport every `kobe api` verb will use.
-- [`bridge.md`](./bridge.md) — sibling design doc for the MCP-bridge
+- `bridge.md` (since removed) — sibling design doc for the MCP-bridge
   path; this file supersedes its skill-distribution discussion (§4)
   but keeps the MCP bridge itself in tree as a fallback.

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -39,7 +39,7 @@ synchronised view).
 | Daemon scope | **Per-user** singleton — one `kobed` owns every repo's tasks. Not per-repo. |
 | Lifecycle | **Explicit** `kobed start` / `kobed stop` / `kobed status`. No auto-spawn from TUI. Hard-cut: TUI errors out with `kobe: no daemon (run \`kobed start\`)` if the socket is missing. |
 | Multi-attach | **Yes.** N TUIs can attach to one daemon. State (tasks, chat history) is broadcast to all attached clients. UI-local state (cursor, focus, composer draft) stays per-client. |
-| Wire protocol | **JSON-lines over unix socket.** Custom `{type, id?, payload}` envelope. No LSP, no gRPC. Re-uses the pattern from [`orchestrator/bridge/server.ts`](../../packages/kobe/src/orchestrator/bridge/server.ts) but bidirectional. |
+| Wire protocol | **JSON-lines over unix socket.** Custom `{type, id?, payload}` envelope. No LSP, no gRPC. Re-uses the pattern from the then-current `orchestrator/bridge/server.ts` (since removed) but bidirectional. |
 | Attach-time sync | **Snapshot + tail.** Daemon sends task list + last N (50?) chat messages per task on attach. Older history loads lazily on scroll. No full-history replay. |
 
 ---
@@ -232,7 +232,7 @@ resume per task via `r` is fine for the first cut.
 | Wave | Title | Scope |
 |---|---|---|
 | **D0** | Core extract | Move `Orchestrator`, `TaskIndexStore`, worktree manager, bridge server out of TUI imports. Define a `KobeCore` boundary that is TUI-free — no dependency on opentui or anything that renders. Solid signals stay as an in-process reactive primitive (the TUI happens to consume the same primitive, but the core doesn't depend on rendering). No behavioural change — kobe still runs as one process, but `KobeCore` is now a self-contained module. |
-| **D1** | Wire protocol + transport | Implement the JSON-line socket server (server-side push + request/response). Reuse [`orchestrator/bridge/server.ts`](../../packages/kobe/src/orchestrator/bridge/server.ts) shape. Build a typed client (now `packages/kobe-daemon/src/client/`). Both still in-process for now — TUI talks to a "loopback" client that calls the server via the socket inside the same process. Validates the protocol end-to-end. |
+| **D1** | Wire protocol + transport | Implement the JSON-line socket server (server-side push + request/response). Reuse the then-current `orchestrator/bridge/server.ts` (since removed) shape. Build a typed client (now `packages/kobe-daemon/src/client/`). Both still in-process for now — TUI talks to a "loopback" client that calls the server via the socket inside the same process. Validates the protocol end-to-end. |
 | **D2** | `kobed` binary | Add `kobed` entry point (`packages/kobe/src/bin/kobed.ts`). Pidfile, signal handling, `kobed start/stop/status/restart`. Default socket: `$XDG_RUNTIME_DIR/kobe.sock` → fallback `~/.kobe/daemon.sock`. TUI now mandatorily talks over the socket; the in-process loopback from D1 is removed. Hard-cut error if no daemon. |
 | **D3** | Multi-attach broadcast | Track all attached clients in the daemon. Broadcast events to all of them. Add the `engine_offline` status + reconnect banner to the TUI. Verify: open two terminals, send a message in one, see it stream in both. |
 | **D4** (deferred) | Resilience polish | Event seq + replay-since-seq, daemon-side per-client backpressure, socket auth token in path, `kobed status --json`, structured logging to `~/.kobe/logs/`. Punt until D3 ships and shows what actually flakes. |

--- a/docs/design/web-dashboard.md
+++ b/docs/design/web-dashboard.md
@@ -56,11 +56,16 @@ the PTY sidecar, and lets Vite proxy `/api`, `/events`, `/pty`.
 
 ## Daemon channels the SPA consumes
 
-The daemon web transport exposes only the SPA channel set
-([`spa-channels.ts`](../../packages/kobe-web/server/spa-channels.ts)); no
-standalone bridge socket is involved. A contract
-test (`test/spa-channels.test.ts`) partitions every protocol channel into
-consumed vs dropped so a new channel can't slip through unaccounted.
+The daemon web transport exposes only what the SPA is allowed to reach; no
+standalone bridge socket is involved. Browser reachability is now declared
+per handler (`web: true` in `packages/kobe-daemon/src/daemon/handlers*.ts`)
+and surfaced as a set by
+[`web-rpc-allowlist.ts`](../../packages/kobe-daemon/src/daemon/web-rpc-allowlist.ts),
+so the list can't drift from the registry it describes — this replaced the
+hand-maintained `spa-channels.ts`. A contract test
+([`packages/kobe-web/test/rpc-allowlist.test.ts`](../../packages/kobe-web/test/rpc-allowlist.test.ts))
+partitions every protocol entry into consumed vs dropped so a new one can't
+slip through unaccounted.
 
 | Channel | What the SPA does with it |
 |---|---|

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -41,7 +41,7 @@ A theme is a JSON object with two top-level fields:
 You don't have to fill every slot; kobe has fallbacks (e.g.
 missing `borderActive` falls through to `border`, missing `border`
 falls through to `text`). The full slot list with fallbacks lives in
-[`packages/kobe/src/tui/context/theme.tsx`](../packages/kobe/src/tui/context/theme.tsx).
+[`packages/kobe/src/tui/context/theme-core.ts`](../packages/kobe/src/tui/context/theme-core.ts).
 The canonical example is
 [`packages/kobe/src/tui/context/theme/claude.json`](../packages/kobe/src/tui/context/theme/claude.json).
 Copy it as a starting point.
@@ -103,7 +103,7 @@ these same JSON files.
   (`.json`) and the directory path printed by `kobe theme list`.
 - **Theme rejected at boot**: kobe writes a `console.warn` line to
   stderr with the file path and the rejection reason. Run
-  `kobe diagnose` for a full environment report and check the recent
+  `kobe doctor` for a full environment report and check the recent
   output above where you ran `kobe`.
 - **Want to override a built-in?** Drop a file with the same name
   (e.g. `~/.kobe/themes/claude.json`). User files load after bundled


### PR DESCRIPTION
Audited every user-facing page against machine-readable ground truth at **v0.8.58** — `kobe api schema`, `kobe --help`, the keymap table, the `*_KEY` state.json constants, and the Settings dialog's row list. This is the doc-only half; the code-side findings are left alone deliberately (see bottom).

## Wrong — a user following the docs would fail

| | |
|---|---|
| `themes.md` | told you to run `kobe diagnose`. **No such command** → `kobe doctor`. |
| `SESSIONS.md` | referenced `kobe api task-archive`. **No such verb** → `kobe api archive`. |
| `themes.md` | linked the theme slot list to `src/tui/context/theme.tsx`, deleted → `theme-core.ts`. |
| `CLI.md` | the quoted `kobe --help` block was stale. Now byte-identical to the real output. |

## Contradicted itself — and both sides were wrong

`KEYBINDINGS.md` said `t` switches the sidebar sort (line 173) *and* that `sidebar.sort` is not registered (line 242). Reality is a third thing: the row **is** registered (`keybindings-sidebar.ts:119`, keys `["t"]`, with i18n), but `toggleSortMode` is defined, destructured in `host.tsx:119`, and never called — so the chord is inert. Both statements now describe that, and name the three other handler-less rows (`sidebar.projectFilter`, `sidebar.previewToggle`, `tasks.toggleKeys`) as an open owner call rather than settled behavior.

Knock-on: `CONFIGURATION.md`'s `activeSortMode` no longer implies a UI toggle exists.

## Documented a setting that does not exist

`sidebar.hover.enabled` was listed as a working boolean. The key is read **nowhere** in `packages/kobe` or `packages/kobe-daemon` — `hoverEnabled` is declared in `types.ts:89` and never passed. Row removed.

## Shipped but undocumented

Biggest one: **`worktree.basePath`** — a real Settings → General → Worktree location row, with the `$project_dir` token for per-project layouts, plus `worktree.basePath.custom`. "Where do my worktrees go and can I move them" had no answer anywhere in the docs. Now has its own section covering the token, that only new tasks move, and that remote projects are unaffected.

Also added: `appearance.splitStyle`, `chat.tabStrip.mode` (+ the legacy `hideSingle` it replaced), `zen.active` / `zen.keepTasks`, `hints.keyboard.enabled`, `experimental.archivedHistoryPreview` (the experimental table listed 3 of 4 flags), and `KOBE_OPEN_EDITOR` — which the TUI names in a "No editor found" toast while no doc explained it.

After this, every `*_KEY` constant in the source is either documented or genuinely internal bookkeeping (`onboarded`, `inboxVisits`, `lastActive.taskId`, `app.lastRunVersion`, `skillHintSeen`, the vestigial `externalWorktreeSync`).

## Links

`design/web-dashboard.md` pointed at `spa-channels.ts` and a contract test, both deleted. Repointed at `web-rpc-allowlist.ts` + `packages/kobe-web/test/rpc-allowlist.test.ts`, and updated the prose — browser reachability is now declared per-handler (`web: true`) instead of a hand-maintained channel list.

Two references in historical docs (`design/cli-api.md` → `bridge.md`, `design/daemon.md` → `orchestrator/bridge/server.ts`) point at files that no longer exist. Rewriting a decision record would be wrong, so they are de-linked to code spans marked "(since removed)" — the record stands, the 404 doesn't.

## Verified accurate, left alone

`docs/API.md` — all 44 verbs, every flag, every `*(offline)*` marker match `kobe api schema` exactly. The `KEYBINDINGS.md` prefix table (15 actions), `ENGINES.md` (4 vendors, detection paths, resume matrix), `themes.md` (3 bundled + 10 hosted), Bun ≥ 1.3.11, ports 5174/5175 — all correct.

## Not in this PR

Code-side findings, left for a separate owner call: wiring or removing the four handler-less keymap rows; the `doctor`/`config`/`reset` column misalignment in `usage.ts:31-33`; and "PureTUI" appearing as an internal codename in user-facing help text.

## Checks

`bun run lint` clean · `packages/kobe-docs` static export green · every relative link in `docs/` now resolves except the gitignored `HANDOFF.md` · changeset: patch.