### PR TITLE
fix: read-output terminal tail keeps its last line over the byte cap

### DIFF
--- a/.changeset/read-output-tail-keeps-last-line.md
+++ b/.changeset/read-output-tail-keeps-last-line.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+`kobe api read-output --source terminal` no longer returns an empty tail when the last line of output is larger than the 64 KB byte cap. The tail's byte-budget loop counted the final line first, so a single over-budget line (a minified dump, a long base64 blob, a giant log line with no newline) pushed the window start past the end and blanked the whole response — a coordinator agent reading the pane got nothing. The tail now always keeps at least the last line, mirroring the structured-history page's "never fewer than one" floor, while older lines are still trimmed to fit the cap.

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -189,7 +189,12 @@ export function boundedTail(text: string): TerminalTail {
   let bytes = 0
   for (let i = lines.length - 1; i >= start; i--) {
     bytes += (lines[i]?.length ?? 0) + 1
-    if (bytes > TERMINAL_TAIL_BYTES) {
+    // Always keep the last line, even when it alone busts the byte budget —
+    // otherwise a single over-budget final line (a minified dump, a long
+    // base64 blob) sets `start` past the end and blanks the whole tail, so
+    // the read returns nothing to show. Mirrors buildHistoryPage's
+    // "never fewer than one" floor.
+    if (bytes > TERMINAL_TAIL_BYTES && i < lines.length - 1) {
       start = i + 1
       break
     }

--- a/packages/kobe/test/cli/api-read-output.test.ts
+++ b/packages/kobe/test/cli/api-read-output.test.ts
@@ -12,6 +12,7 @@ import {
   type ReadOutputDeps,
   type ReadOutputEnvelope,
   STRING_CLIP_CHARS,
+  TERMINAL_TAIL_BYTES,
   TERMINAL_TAIL_LINES,
   type TerminalPeekPage,
   boundedTail,
@@ -297,5 +298,26 @@ describe("read-output terminal tail shaping", () => {
     expect(capped.tail.length).toBe(TERMINAL_TAIL_LINES)
     expect(capped.truncated).toBe(true)
     expect(capped.tail[0]).toBe("l50")
+  })
+
+  it("keeps the last line even when it alone exceeds the byte budget", () => {
+    // A single line larger than the byte cap (a minified dump / base64 blob
+    // with no newline) must not blank the whole tail — the read has to show
+    // something. Regression: the budget loop counted the final line first and
+    // set `start` past the end, returning an empty tail.
+    const huge = "x".repeat(TERMINAL_TAIL_BYTES + 5000)
+    const shaped = boundedTail(huge)
+    expect(shaped.tail).toEqual([huge])
+    // Nothing older was dropped — there was only the one line.
+    expect(shaped.truncated).toBe(false)
+  })
+
+  it("drops older lines but still returns the over-budget final line", () => {
+    // Older short lines followed by an over-budget final line: the earlier
+    // lines are trimmed to fit the cap, yet the last line still comes back.
+    const huge = "y".repeat(TERMINAL_TAIL_BYTES + 5000)
+    const shaped = boundedTail(`old-1\nold-2\n${huge}`)
+    expect(shaped.tail).toEqual([huge])
+    expect(shaped.truncated).toBe(true)
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found bug in the agent-facing `kobe api read-output` verb, found while reviewing the pure, unit-testable helpers under `cli/api/`.

## The problem

`boundedTail()` (`packages/kobe/src/cli/api/read-output.ts`) caps a terminal tail to `TERMINAL_TAIL_BYTES` (64 KB) by walking lines back-to-front and summing their sizes. The moment the running total exceeds the budget it does `start = i + 1` and breaks.

The failure: the **last** line is counted first. When that single line alone exceeds 64 KB, the loop sets `start = lines.length`, so `lines.slice(start)` is `[]` — an **empty tail**. A coordinator agent calling `kobe api read-output --source terminal` then sees nothing at all, even though there is output to show. This is a common shape: a minified JS/CSS dump, a long base64 blob, or a newline-less log line pasted or printed into the pane.

The sibling `buildHistoryPage()` in the same file guards its byte budget with `page.length > 0 &&`, so a structured-history page always returns at least one message. The terminal tail had no equivalent floor.

Concrete: `boundedTail("x".repeat(70000))` returned `{ tail: [], truncated: true }`.

## The fix

Skip the budget break for the final line (`i < lines.length - 1`), so `boundedTail` always keeps at least the last line — mirroring `buildHistoryPage`'s "never fewer than one" behavior. Older lines are still trimmed to fit the cap. Net change: 6 lines in the helper (one condition + a comment).

- `boundedTail("x".repeat(70000))` → `{ tail: ["xxxx…"], truncated: false }` (one line, nothing older dropped).
- `boundedTail("old-1\nold-2\n" + huge)` → `{ tail: [huge], truncated: true }` (older lines trimmed, final line kept).

## Verification

- Added two regression tests in `test/cli/api-read-output.test.ts`; both **fail** against the unfixed helper (`2 failed | 18 passed`) and **pass** with the fix (`20 passed`).
- `bun run lint` — clean.
- `bun run typecheck` — clean (all three packages).
- Touched file stays at 492 lines (under the ~500 cap).
- Patch changeset added.

## Follow-ups (deliberately out of scope)

- `terminalLines()` in the same file uses `line.split("\r").pop()` for CR overwrites, which truncates when a later write is shorter than an earlier one (e.g. `"Loading...\rOK"` → `"OK"` instead of the terminal's `"OKading..."`). It's arguably an accepted simplification and changes existing tested behavior, so I left it for a separate decision rather than bundling it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149qJ3c3bKQjmDwhNcvuibc)_