### PR TITLE
fix: filter current Claude title frames

### DIFF
--- a/.changeset/filter-claude-title-circles.md
+++ b/.changeset/filter-claude-title-circles.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Strip Claude Code's current animated circle frames from terminal titles so the sidebar does not render a second state glyph, and recognize those frames as active work.

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -255,10 +255,10 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     spinnerFrames: CLAUDE_SPINNER_FRAMES,
     terminalTitle: {
       ownsStatus: true,
-      // `${prefix} ${title}` where prefix is ✳ at rest and cycles ⠂/⠐ every
-      // 960ms while a turn runs (claude-code `AnimatedTerminalTitle`).
-      statusPrefixes: ["✳", "⠂", "⠐"],
-      workingPrefixes: ["⠂", "⠐"],
+      // `${prefix} ${title}` where prefix is ✳ at rest and cycles through
+      // animated frames while a turn runs (`AnimatedTerminalTitle`).
+      statusPrefixes: ["✳", "⠂", "⠐", "◐", "◑"],
+      workingPrefixes: ["⠂", "⠐", "◐", "◑"],
     },
     quotaUsage: () => fetchClaudeQuotaUsage(),
   },

--- a/packages/kobe/test/engine/status-prefix.test.ts
+++ b/packages/kobe/test/engine/status-prefix.test.ts
@@ -11,10 +11,12 @@ import { stripEngineStatusPrefix } from "../../src/engine/registry"
 
 describe("stripEngineStatusPrefix", () => {
   it("strips claude's resting and animated prefixes", () => {
-    // `${prefix} ${title}` — ✳ at rest, ⠂/⠐ alternating during a turn.
+    // `${prefix} ${title}` — ✳ at rest, with old and current animated frames.
     expect(stripEngineStatusPrefix("✳ 运行本地Codex处理图片", "claude")).toBe("运行本地Codex处理图片")
     expect(stripEngineStatusPrefix("⠂ fixing the watcher", "claude")).toBe("fixing the watcher")
     expect(stripEngineStatusPrefix("⠐ fixing the watcher", "claude")).toBe("fixing the watcher")
+    expect(stripEngineStatusPrefix("◐ 准备golden test集", "claude")).toBe("准备golden test集")
+    expect(stripEngineStatusPrefix("◑ fixing the watcher", "claude")).toBe("fixing the watcher")
   })
 
   it("strips codex's spinner frame", () => {

--- a/packages/kobe/test/tui/interrupt-observer.test.ts
+++ b/packages/kobe/test/tui/interrupt-observer.test.ts
@@ -32,6 +32,8 @@ describe("engineTitleTurnHint", () => {
   it("reads claude's animated frames as working and its static ✳ as rest", () => {
     expect(engineTitleTurnHint("claude", "⠂ 修复构建失败")).toBe("working")
     expect(engineTitleTurnHint("claude", "⠐ 修复构建失败")).toBe("working")
+    expect(engineTitleTurnHint("claude", "◐ 修复构建失败")).toBe("working")
+    expect(engineTitleTurnHint("claude", "◑ 修复构建失败")).toBe("working")
     expect(engineTitleTurnHint("claude", "✳ 修复构建失败")).toBe("rest")
     expect(engineTitleTurnHint("claude", "修复构建失败")).toBe("rest")
   })


### PR DESCRIPTION
## Summary
- Recognizes Claude Code 2.1.228's ◐ and ◑ terminal-title frames as engine-owned working status.
- Removes the duplicated sidebar status glyph and keeps interrupt/activity classification accurate, including for persisted titles.
- Adds regression coverage for title filtering and working-state detection, plus a patch changeset.

## Verification
- Lint, typecheck, fast/socket/plugin suites, build, and behavior tests pass.
