### PR TITLE
ci: gate the public docs site build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,11 +170,15 @@ jobs:
   docs-site:
     # The public docs site (packages/kobe-docs) had no CI coverage at all:
     # root `lint` and `typecheck` skip the package, and its only path to
-    # production was a hand-run `bun run deploy` from a laptop. So a broken
-    # MDX page, a docs/ link the sync rewrites into nothing, or a page added
-    # to docs/ but never registered in sync-docs.mjs's SECTIONS stayed green
-    # until someone deployed. `build` = sync + Fumadocs MDX + `next build`
-    # (which also runs tsc), so one job covers all three. ~11s locally.
+    # production is a hand-run `bun run deploy` from a laptop — so a docs/
+    # edit that breaks the site stayed green until someone deployed.
+    # `build` = sync-docs.mjs + Fumadocs MDX + `next build` (which also runs
+    # tsc); the sync script has no try/catch, so it fails the job when a
+    # SECTIONS entry points at a renamed/missing docs/ file, a synced page
+    # loses the H1 its title comes from, or a referenced docs/assets/ image
+    # is gone. It does NOT catch a new docs/ page that was never added to
+    # SECTIONS (silently unsynced) or a dead cross-link (rewritten to a
+    # GitHub blob URL) — those still need review. ~11s locally.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@
 # gates the browser → PTY → real OpenTUI journey on Linux, where the hosted
 # runner grants node-pty a working pseudoterminal.
 #
+# docs-site builds packages/kobe-docs (the public Fumadocs site at
+# docs.kobe.sma1lboy.me). Its content is synced from docs/, so this job is
+# what keeps a Markdown edit from silently breaking the site — deployment is
+# still a manual `bun --filter @sma1lboy/kobe-docs deploy`.
+#
 # changeset-cap (PR only, KOB-10) is the changeset sibling of file-size-cap:
 # a PR that touches published-package source (packages/kobe/src or
 # packages/kobe-daemon/src, since kobe-daemon ships bundled inside the kobe
@@ -161,6 +166,30 @@ jobs:
 
       - name: Build (kobe package)
         run: bun run build
+
+  docs-site:
+    # The public docs site (packages/kobe-docs) had no CI coverage at all:
+    # root `lint` and `typecheck` skip the package, and its only path to
+    # production was a hand-run `bun run deploy` from a laptop. So a broken
+    # MDX page, a docs/ link the sync rewrites into nothing, or a page added
+    # to docs/ but never registered in sync-docs.mjs's SECTIONS stayed green
+    # until someone deployed. `build` = sync + Fumadocs MDX + `next build`
+    # (which also runs tsc), so one job covers all three. ~11s locally.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build docs site (sync + next build)
+        run: bun run --filter @sma1lboy/kobe-docs build
 
   behavior:
     # Black-box behavior suite: the BUILT CLI in a temp KOBE_HOME with an


### PR DESCRIPTION
## What

Adds a `docs-site` job to `ci.yml` that builds `packages/kobe-docs` (the public Fumadocs site behind docs.kobe.sma1lboy.me) on every push to `main` and every PR.

```yaml
- name: Build docs site (sync + next build)
  run: bun run --filter @sma1lboy/kobe-docs build
```

## Why

The docs package had **zero** CI coverage — no workflow referenced it:

| Gate | Covered kobe-docs? |
|---|---|
| root `lint` | ❌ targets `docs packages/kobe packages/kobe-daemon packages/kobe-plugin-sdk` (`docs` = the repo's Markdown, not this package) |
| root `typecheck` | ❌ daemon / kobe / plugin-sdk only |
| `build` | ❌ `--filter @sma1lboy/kobe` |
| deploy | ❌ no workflow; manual `bun run deploy` from a laptop |

So a `docs/` edit that broke the site stayed green until someone happened to deploy.

## What the job actually catches

`build` = `sync-docs.mjs` + Fumadocs MDX + `next build` (which runs tsc itself). The sync script has no try/catch and runs under top-level await, so a throw exits 1 and fails the job:

- a `SECTIONS` entry pointing at a renamed/missing `docs/` file — `readFile`, `sync-docs.mjs:192`
- a synced page that lost the H1 its title is derived from — `sync-docs.mjs:173`
- a referenced `docs/assets/…` image that's gone — `copyFile`, `sync-docs.mjs:219`
- MDX that won't compile, or a TS error in the site's own `app/` / `components/`

**What it does not catch** (worth knowing before treating this as full coverage):

- a new `docs/` page never added to `SECTIONS` — silently unsynced, not an error. `ARCHITECTURE.md`, `DESIGN.md`, `HARNESS.md`, `PLAN.md`, `RELEASING.md` are unregistered today (deliberately — internal docs) and the build is green.
- a dead cross-link — `rewriteTarget` falls back to a GitHub blob URL rather than failing.

## Cost

~11s of build work locally (18 static pages); 50s on the runner including checkout + `bun install` — same order as `behavior` (41s) and `render-track` (1m0s). Runs unconditionally like the other jobs rather than behind a `paths` filter, so it stays clean as a required check.

## Not in scope

Auto-deploy. `kobe-landing` has `deploy-landing.yml` with its Vercel org/project ids inline, but the docs project's id isn't in the repo (no `.vercel/` under `packages/kobe-docs`), so deployment stays manual. Happy to add a sibling `deploy-docs.yml` once that id is available.

## Test plan

- [x] `bun run --filter @sma1lboy/kobe-docs build` — green, exit 0, 18 pages
- [x] `bun run lint` — 975 files, clean
- [x] `ci.yml` parses; jobs = file-size-cap, changeset-cap, typecheck-and-test, **docs-site**, behavior, render-track, visual-ground-truth, coverage-cap
- [x] docs-site green on the runner (50s)

No changeset: CI-only change that doesn't touch the published package (`docs/RELEASING.md`).
