### PR TITLE
fix: keep claude's spinner monochrome on Windows (✳ → ✱)

### DIFF
--- a/.changeset/windows-spinner-emoji-asterisk.md
+++ b/.changeset/windows-spinner-emoji-asterisk.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Claude's running-row spinner no longer flashes a green color-emoji asterisk on Windows. The brand set's third frame `✳` (U+2733) is the only frame with the Unicode Emoji property, so Windows font fallback (Segoe UI Emoji) drew it in color — clashing with the surrounding monochrome frames in the sidebar and Inbox badges — and terminals there ignore the VS15 text-presentation request. The frame is now `✱` (U+2731 HEAVY ASTERISK), which has no emoji mapping anywhere and keeps the ·→✽ size ramp intact.

--- a/packages/kobe/src/engine/spinner-frames.ts
+++ b/packages/kobe/src/engine/spinner-frames.ts
@@ -18,8 +18,15 @@ export const DEFAULT_SPINNER_FRAMES: readonly string[] = ["⠋", "⠙", "⠹", "
  * `src/components/Spinner.tsx` (`getDefaultCharacters()` + the
  * forward-then-reverse concat that makes the glyph oscillate ·→✽→· with a
  * one-frame hold at each end).
+ *
+ * One deviation: claude-code's third frame is `✳` (U+2733), the only glyph in
+ * the set with the Unicode Emoji property. Windows font fallback (Segoe UI
+ * Emoji) draws it as the green color-emoji asterisk — and ignores a VS15
+ * (U+FE0E) text-presentation request — so it clashes with the surrounding
+ * monochrome frames. Kobe substitutes `✱` (U+2731 HEAVY ASTERISK), which has
+ * no emoji mapping anywhere and keeps the ·→✽ size ramp intact.
  */
-const CLAUDE_SPINNER_CHARS: readonly string[] = ["·", "✢", "✳", "✶", "✻", "✽"]
+const CLAUDE_SPINNER_CHARS: readonly string[] = ["·", "✢", "✱", "✶", "✻", "✽"]
 export const CLAUDE_SPINNER_FRAMES: readonly string[] = [
   ...CLAUDE_SPINNER_CHARS,
   ...[...CLAUDE_SPINNER_CHARS].reverse(),

--- a/packages/kobe/test/golden/sidebar-row-state.golden.txt
+++ b/packages/kobe/test/golden/sidebar-row-state.golden.txt
@@ -1147,7 +1147,7 @@ mainBranch=-                       act=permission_needed  | main=1 title=kobe   
 mainBranch=-                       act=error              | main=1 title=kobe             glyph=✕   tone=error       load=0 matz=0 sub=error
 
 ## engine-owned spinner frame sets + withSpinnerFrame overlay
-vendor=claude     frames(0..25)=·✢✳✶✻✽✽✻✶✳✢··✢✳✶✻✽✽✻✶✳✢··✢
+vendor=claude     frames(0..25)=·✢✱✶✻✽✽✻✶✱✢··✢✱✶✻✽✽✻✶✱✢··✢
 vendor=codex      frames(0..25)=⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴
 vendor=copilot    frames(0..25)=⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴
 vendor=kimi       frames(0..25)=⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴
@@ -1162,7 +1162,7 @@ act=idle               frame=14   overlay: base=○ after=○ tone=textMuted   s
 act=idle               frame=99   overlay: base=○ after=○ tone=textMuted   sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
 act=running            frame=0    overlay: base=· after=· tone=primary     sub=feat/sidebar     frameReads=1 sameObject=1 sameAsDirect=1
 act=running            frame=3    overlay: base=· after=✶ tone=primary     sub=feat/sidebar     frameReads=1 sameObject=0 sameAsDirect=1
-act=running            frame=14   overlay: base=· after=✳ tone=primary     sub=feat/sidebar     frameReads=1 sameObject=0 sameAsDirect=1
+act=running            frame=14   overlay: base=· after=✱ tone=primary     sub=feat/sidebar     frameReads=1 sameObject=0 sameAsDirect=1
 act=running            frame=99   overlay: base=· after=✶ tone=primary     sub=feat/sidebar     frameReads=1 sameObject=0 sameAsDirect=1
 act=turn_complete      frame=0    overlay: base=● after=● tone=primary     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
 act=turn_complete      frame=3    overlay: base=● after=● tone=primary     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1


### PR DESCRIPTION
## Problem

On Windows, the Claude running-row badge in the sidebar (and the Inbox pane) flashes a **green color-emoji asterisk** — ugly next to the other monochrome frames:

The brand spinner set lifted from claude-code is `· ✢ ✳ ✶ ✻ ✽`, and `✳` (U+2733) is the only glyph in it with the Unicode Emoji property. Windows font fallback hands it to Segoe UI Emoji, which renders the color-emoji form. Appending VS15 (U+FE0E, text presentation) was tried first, but the affected terminals ignore it and still render color.

## Fix

Replace the frame with `✱` (U+2731 HEAVY ASTERISK) in `CLAUDE_SPINNER_FRAMES`:

- no emoji mapping in any font, on any platform — always monochrome, always tinted by the row's tone
- visually near-identical, keeps the `·→✽` size ramp of the oscillation
- single source: both the sidebar badge (`row-view.ts`) and `AttentionInboxPane` consume the registry's `spinnerFrames`

The registry's `terminalTitle.statusPrefixes` deliberately keep the bare `✳` — that vocabulary matches OSC titles claude-code itself writes, which are unchanged.

## Checks

- `bun run lint`, `bun run typecheck`, `bun run build` — pass
- Golden regenerated (`KOBE_UPDATE_GOLDEN=1`); diff is exactly the two claude frame-sequence lines
- Targeted suites pass: `test/golden`, `status-prefix`, `activity-observer`, `interrupt-observer`, `tab-title-stable`, `tab-last-title`, `title-subscriptions` (77 tests)
- Full `test:fast` has pre-existing Windows-environment failures (unix sockets, `which`/nvm probes, darwin/linux clipboard) — verified identical on a clean tree; relying on CI for the full matrix

## Checklist

- [x] typecheck / lint / build pass
- [x] User-visible change → changeset added