### PR TITLE
fix: vercel skips kobe-landing deploys for unrelated changes

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,7 +1,10 @@
 # Vercel CLI walks the whole monorepo (it does not read .gitignore) and dies on
 # the unix sockets scattered under packages/kobe/.dev-*/. Only
 # packages/kobe-landing is ever deployed, so allowlist just that.
+# .git stays in: the ignoreCommand skip-check (vercel.json) needs
+# `git diff HEAD^ HEAD` to decide whether the landing dir changed.
 /*
+!/.git
 !/packages
 /packages/*
 !/packages/kobe-landing

--- a/packages/kobe-landing/vercel.json
+++ b/packages/kobe-landing/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": null,
   "outputDirectory": ".",
-  "ignoreCommand": "exit 1",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
   "cleanUrls": true,
   "redirects": [
     {


### PR DESCRIPTION
Every PR gets a **kobe-landing** preview deployment + Vercel bot comment, even when nothing under `packages/kobe-landing` changed.

## Why it deploys on everything

`packages/kobe-landing/vercel.json` pins `"ignoreCommand": "exit 1"` (= always build). That was a workaround from d9ce95df: the default monorepo skip-check runs `git diff --quiet HEAD^ HEAD -- .`, but the repo-root `.vercelignore` allowlist stripped `.git` from the clone, so the check crashed with *Not a git repository* and every deployment reported failed.

## Fix

Address the cause instead of bypassing the check:

- `.vercelignore`: allowlist `.git` back into the clone (`!/.git`) — it contains no unix sockets, so the original reason for the allowlist (Vercel CLI dying on `packages/kobe/.dev-*/` sockets) is unaffected
- `vercel.json`: `ignoreCommand` → `git diff --quiet HEAD^ HEAD -- .` — runs inside the project Root Directory (`packages/kobe-landing`), so a commit range that doesn't touch the landing dir exits 0 and Vercel skips the build: no deployment, no bot comment

Fail-open: if `HEAD^` is unavailable (first commit / shallow edge) git exits non-zero and the build proceeds.

Note: this PR itself touches `packages/kobe-landing/vercel.json`, so it will still deploy once — the skip takes effect for subsequent unrelated PRs.

No changeset: deployment tooling only, published package behavior unchanged.