### PR TITLE
fix: surface live pty sessions missing from the tab snapshot as unregistered tabs

### DIFF
--- a/.changeset/unregistered-tab-visibility.md
+++ b/.changeset/unregistered-tab-visibility.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Surface live PTY sessions missing from the tab snapshot as explicit unregistered tabs (issue #20). The sidebar tree, `get-task`/`collect` tabs, and `inspect`'s tabs section now reconcile the persisted snapshot against the live session inventory at tab granularity: an alive `<taskId>::tab-N` session the snapshot does not list renders as a ⚠ unregistered row (TUI) / an `unregistered`-marked row (API) instead of being invisible — previously such an engine (e.g. the canonical-spawn fallback's orphan) ran with zero UI presence.

--- a/docs/API.md
+++ b/docs/API.md
@@ -89,7 +89,9 @@ paths against `$PWD` (`~` expanded). Engine vendors: `claude`, `codex`,
   terminal tabs (`id`/`kind`/`title`/`vendor`/`liveVendor`/`lastTitle`/
   `autoTitle` + per-tab `alive`) — the discovery read for `send --tab tab-N`.
   A dead tab whose session ended abnormally also carries `exit`
-  (`code`/`signal`/`at`); clean exits stay `exit: null`.
+  (`code`/`signal`/`at`); clean exits stay `exit: null`. A live PTY session
+  the persisted snapshot does not list still gets a row, marked
+  `unregistered: true` — an alive engine is never invisible here.
 - `collect [--task-ids a,b,c] [--repo PATH]`: read-only comparison
   snapshot of several tasks: identity, branch, `.running`, uncommitted
   `.changes`, and committed `.base` (ahead count + diffstat vs base).
@@ -111,7 +113,11 @@ paths against `$PWD` (`~` expanded). Engine vendors: `claude`, `codex`,
   `exit`), `sessionExits` (durable death records — exit `code`/`signal`/`at`
   plus a plain-text output `tail`, kept in `pty-exits.json` so they survive
   the PTY host's idle-exit; abnormal exits only), and `tabs` (the
-  snapshots the sidebar names its rows from). Non-spawning: a missing daemon
+  snapshots the sidebar names its rows from, reconciled against the live
+  session inventory: a task whose snapshot is missing an alive
+  `<taskId>::tab-N` session reports those tab ids under `unregistered`,
+  and a task with live sessions but no snapshot at all still gets an
+  entry). Non-spawning: a missing daemon
   or PTY host degrades that section to `null`. **Run and paste this first**
   when reporting a badge, label, engine-identity, or engine-crash bug.
 

--- a/packages/kobe/src/cli/api/handlers-inspect.ts
+++ b/packages/kobe/src/cli/api/handlers-inspect.ts
@@ -25,6 +25,7 @@ import { loadStateFile } from "../../state/store.ts"
 import { terminalTabsKey } from "../../tui-react/workspace/terminal-tabs-persist.ts"
 import type { TabsState } from "../../tui/workspace/terminal-tabs-core.ts"
 import { F } from "./flags.ts"
+import { type TaskSessionRow, unregisteredTabIds } from "./tab-snapshot.ts"
 import type { VerbContext, VerbSpec } from "./types.ts"
 
 type PtySessionRow = {
@@ -112,8 +113,18 @@ async function sessionExitsSection(taskId: string | undefined): Promise<unknown>
   }
 }
 
-/** Persisted tab snapshots (what the sidebar tree names its rows from). */
-function tabsSection(taskId: string | undefined): unknown {
+/**
+ * Persisted tab snapshots (what the sidebar tree names its rows from),
+ * RECONCILED against the live session inventory (issue #20): each task also
+ * reports `unregistered` — alive `<taskId>::tab-N` sessions its snapshot
+ * does not list — and a task with live sessions but no snapshot at all still
+ * gets an entry. A live engine must never be invisible in this read.
+ * Exported for tests; production callers go through the `inspect` verb.
+ */
+export function tabsSection(taskId: string | undefined, sessions: unknown): unknown {
+  const live: TaskSessionRow[] = Array.isArray(sessions)
+    ? sessions.filter((s): s is TaskSessionRow => typeof (s as { key?: unknown })?.key === "string")
+    : []
   try {
     const state = loadStateFile()
     const out: Record<string, unknown> = {}
@@ -124,6 +135,7 @@ function tabsSection(taskId: string | undefined): unknown {
       if (taskId && id !== taskId) continue
       const snap = value as TabsState
       if (!snap || !Array.isArray(snap.tabs)) continue
+      const unregistered = unregisteredTabIds(snap, id, live)
       out[id] = {
         activeId: snap.activeId,
         tabs: snap.tabs.map((t) => ({
@@ -135,7 +147,15 @@ function tabsSection(taskId: string | undefined): unknown {
           lastTitle: t.lastTitle ?? null,
           autoTitle: t.autoTitle ?? null,
         })),
+        ...(unregistered.length > 0 ? { unregistered } : {}),
       }
+    }
+    // Tasks with live sessions but NO snapshot: every session is unregistered.
+    for (const s of live) {
+      const id = s.key.split("::")[0] ?? ""
+      if (!id || out[id] !== undefined || (taskId && id !== taskId)) continue
+      const unregistered = unregisteredTabIds(undefined, id, live)
+      if (unregistered.length > 0) out[id] = { activeId: null, tabs: [], unregistered }
     }
     return out
   } catch (err) {
@@ -150,7 +170,7 @@ async function inspect(ctx: VerbContext): Promise<unknown> {
     sessionsSection(taskId),
     sessionExitsSection(taskId),
   ])
-  return { daemon, sessions, sessionExits, tabs: tabsSection(taskId), at: new Date().toISOString() }
+  return { daemon, sessions, sessionExits, tabs: tabsSection(taskId, sessions), at: new Date().toISOString() }
 }
 
 /** Spec half — spread into {@link VERBS} in `verbs.ts`. */

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -45,6 +45,11 @@ export interface TaskTabRow {
    *  null, per issue #9's no-noise rule); null while alive/unknown. Joined
    *  from the live host when present, else the durable exit records. */
   readonly exit: PtySessionExit | null
+  /** Present (true) only on rows derived from a LIVE pty session the
+   *  persisted snapshot does not list — issue #20's invisible engine. The
+   *  snapshot is a record of intent; the pty host holds the truth, and a
+   *  divergence must render as a row, not vanish. */
+  readonly unregistered?: true
 }
 
 /** The slice of a `pty.list` row the liveness joins below need. */
@@ -67,6 +72,30 @@ export function readTabsSnapshot(taskId: string): TabsState | undefined {
 const aliveKeysOf = (sessions: readonly TaskSessionRow[]): Set<string> =>
   new Set(sessions.filter((s) => s.alive).map((s) => s.key))
 
+/**
+ * Tab ids with a LIVE `<taskId>::<tabId>` pty session the snapshot does not
+ * list — the reconciliation read behind issue #20 (a canonical-spawn
+ * fallback, an older kobe, any future path that opens a session without
+ * writing the snapshot). Split leaves (`::leaf-N` suffix) belong to their
+ * tab and never count on their own, matching `joinTaskTabs`' exact-key rule.
+ */
+export function unregisteredTabIds(
+  snapshot: TabsState | undefined,
+  taskId: string,
+  sessions: readonly TaskSessionRow[],
+): string[] {
+  const known = new Set((snapshot?.tabs ?? []).map((t) => t.id))
+  const prefix = `${taskId}::`
+  const out: string[] = []
+  for (const s of sessions) {
+    if (!s.alive || !s.key.startsWith(prefix)) continue
+    const tabId = s.key.slice(prefix.length)
+    if (tabId.includes("::")) continue // split leaf — its tab is the row
+    if (!known.has(tabId) && !out.includes(tabId)) out.push(tabId)
+  }
+  return out
+}
+
 /** Abnormal death only — exit 0 without a signal is not worth surfacing. */
 const abnormalExit = (exit: PtySessionExit | null | undefined): PtySessionExit | null =>
   exit && (exit.code !== 0 || exit.signal !== null) ? exit : null
@@ -87,7 +116,7 @@ export function joinTaskTabs(
 ): TaskTabRow[] {
   const alive = aliveKeysOf(sessions)
   const sessionExits = new Map(sessions.map((s) => [s.key, s.exit]))
-  return (snapshot?.tabs ?? []).map((t) => {
+  const rows: TaskTabRow[] = (snapshot?.tabs ?? []).map((t) => {
     const key = `${taskId}::${t.id}`
     const isAlive = alive.has(key)
     return {
@@ -102,6 +131,25 @@ export function joinTaskTabs(
       exit: isAlive ? null : abnormalExit(sessionExits.get(key) ?? persistedExits[key]),
     }
   })
+  // Live sessions the snapshot doesn't know still get a row — the discovery
+  // read must show every engine that exists, not just the registered ones.
+  // "engine" is the same assumption the sidebar's orphan backstop documents:
+  // headless paths only ever start engines.
+  for (const tabId of unregisteredTabIds(snapshot, taskId, sessions)) {
+    rows.push({
+      id: tabId,
+      kind: "engine",
+      title: null,
+      vendor: null,
+      liveVendor: null,
+      lastTitle: null,
+      autoTitle: null,
+      alive: true,
+      exit: null,
+      unregistered: true,
+    })
+  }
+  return rows
 }
 
 /**

--- a/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
@@ -9,16 +9,18 @@
  *   - a session started by an older kobe, before the CLI wrote snapshots;
  *   - a snapshot reclaimed by the orphan sweep while its PTY lived on;
  *   - anything that opens a `<taskId>::<tabId>` session without going
- *     through either writer.
+ *     through either writer (issue #20: a canonical-spawn fallback ran a
+ *     live engine for 1h44m that the sidebar never showed).
  *
- * In every one of those the engine is alive and the sidebar showed the
- * worktree with nothing under it. So: derive rows from live sessions for
- * tasks the snapshot has no answer for. Snapshot wins whenever it HAS one —
- * it carries titles, ordinals, kinds and split state that a session key
- * can't, and a live session is only ever used to fill a hole.
+ * In every one of those the engine is alive and the sidebar showed either
+ * nothing or a tab list missing the session. So: reconcile at TAB
+ * granularity — any live session whose exact `<taskId>::<tabId>` key the
+ * snapshots don't answer for becomes an explicit "unregistered" row (⚠).
+ * A registered tab keeps its snapshot projection, which carries titles,
+ * ordinals, kinds and split state a session key can't.
  */
 
-import { type TreeTab, parseRowId } from "../../../tui/panes/sidebar/tree-core"
+import { type TreeTab, parseRowId, tabRowId } from "../../../tui/panes/sidebar/tree-core"
 
 /** One live pty-host session, as this module needs it. */
 export interface LiveSession {
@@ -29,29 +31,37 @@ export interface LiveSession {
 }
 
 /**
- * Group live sessions into tab projections per task, skipping every task in
- * `known` (the snapshot already answered for those).
+ * Group live sessions into UNREGISTERED tab rows per task, skipping every
+ * exact `<taskId>::<tabId>` key in `registered` (a snapshot answered for
+ * those tabs). Tab-granular on purpose: a task whose snapshot lists tab-2
+ * while tab-1 is alive must still surface tab-1 — that divergence is issue
+ * #20's invisible engine, and skipping whole tasks is what hid it.
  *
  * The label is the live process title when the host has one, else the tab
- * id — a headless `<taskId>::tab-1` has no recorded title anywhere, and
- * showing the id beats showing a row with no name.
+ * id, prefixed ⚠ — the row exists because the snapshot does NOT know this
+ * session, and that is worth a glance.
  */
 export function orphanTabsByTask(
   sessions: readonly LiveSession[],
-  known: ReadonlySet<string>,
+  registered: ReadonlySet<string>,
 ): Map<string, readonly TreeTab[]> {
   const byTask = new Map<string, TreeTab[]>()
   for (const session of sessions) {
     if (session.alive === false) continue
     // A pty key IS a tab row id (`<taskId>::<tabId>`) — same separator, same
     // parse rule, so the two can never disagree about what a key means.
-    const { taskId, tabId } = parseRowId(session.key)
-    if (!tabId || known.has(taskId)) continue
+    const { taskId, tabId: rawTabId } = parseRowId(session.key)
+    if (!rawTabId) continue
+    // A split's extra shell leaf (`<tabId>::leaf-N`) belongs to its tab.
+    const tabId = rawTabId.split("::")[0] as string
+    if (registered.has(tabRowId(taskId, tabId))) continue
     const tabs = byTask.get(taskId) ?? []
+    if (tabs.some((tab) => tab.id === tabId)) continue
     tabs.push({
       id: tabId,
-      label: session.title?.trim() || tabId,
-      // The sole tab of an orphaned task is necessarily its active one.
+      label: `⚠ ${session.title?.trim() || tabId}`,
+      // The first unregistered tab of a snapshot-less task reads active; the
+      // caller demotes this when merging under a task that has snapshot tabs.
       active: tabs.length === 0,
       // Assume engine: the headless launch path only ever starts engines,
       // and the state glyph is the reason these rows are worth showing.

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -132,12 +132,19 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
         }),
       )
     }
-    // Backstop: a task with a LIVE pty session but no snapshot renders from
-    // the session itself, so a headless-started engine is never an empty
-    // worktree row. Only fills holes — a task already in `map` keeps its
-    // richer snapshot projection. See `orphan-tabs.ts`.
-    for (const [taskId, tabs] of orphanTabsByTask(hostSessions, new Set(map.keys()))) {
-      if (tasks.some((t) => t.id === taskId)) map.set(taskId, tabs)
+    // Backstop: any LIVE pty session the snapshots don't answer for renders
+    // as an explicit unregistered row — tab-granular, so a task whose
+    // snapshot lists tab-2 while tab-1 is alive still shows tab-1 (issue
+    // #20's invisible engine). A registered tab keeps its richer snapshot
+    // projection. See `orphan-tabs.ts`.
+    const registered = new Set<string>()
+    for (const [taskId, tabs] of map) for (const tab of tabs) registered.add(tabRowId(taskId, tab.id))
+    for (const [taskId, orphans] of orphanTabsByTask(hostSessions, registered)) {
+      if (!tasks.some((t) => t.id === taskId)) continue
+      const existing = map.get(taskId)
+      // Appended under a task with snapshot tabs, an orphan is never the
+      // active one — the snapshot's activeId owns that.
+      map.set(taskId, existing ? [...existing, ...orphans.map((tab) => ({ ...tab, active: false }))] : orphans)
     }
     return map
   }, [tasks, kv, liveEngines, liveTick, hostSessions])

--- a/packages/kobe/test/cli/api-inspect.test.ts
+++ b/packages/kobe/test/cli/api-inspect.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { tabsSection } from "../../src/cli/api/handlers-inspect.ts"
 
 let home: string
 const saved: Record<string, string | undefined> = {}
@@ -108,5 +109,40 @@ describe("kobe api inspect (offline)", () => {
     const res = (await invokeVerb("inspect", [], { client: null })) as InspectResult
     expect(res.sessionExits).toEqual([])
     expect(res.tabs).toEqual({})
+  })
+})
+
+/**
+ * The `tabs` section reconciled against the live session inventory (issue
+ * #20): a live `<taskId>::tab-N` session the snapshot does not list must be
+ * called out as `unregistered`, never silently dropped — that silence is how
+ * a writable engine stayed invisible for 1h44m.
+ */
+describe("inspect tabs section reconciliation (issue #20)", () => {
+  type TabsOut = Record<string, { activeId: string | null; tabs: { id: string }[]; unregistered?: string[] }>
+
+  it("flags an alive session missing from the task's snapshot", () => {
+    seedHome() // snapshot for t1: tab-1 only
+    const out = tabsSection("t1", [
+      { key: "t1::tab-1", alive: true },
+      { key: "t1::tab-9", alive: true }, // alive on the host, unknown to the snapshot
+    ]) as TabsOut
+    expect(out.t1?.tabs.map((t) => t.id)).toEqual(["tab-1"])
+    expect(out.t1?.unregistered).toEqual(["tab-9"])
+  })
+
+  it("reports a task with live sessions but no snapshot at all", () => {
+    seedHome()
+    const out = tabsSection(undefined, [{ key: "ghost::tab-1", alive: true }]) as TabsOut
+    expect(out.ghost).toEqual({ activeId: null, tabs: [], unregistered: ["tab-1"] })
+  })
+
+  it("stays quiet when snapshot and sessions agree (and when sessions are unknowable)", () => {
+    seedHome()
+    const agreed = tabsSection("t1", [{ key: "t1::tab-1", alive: true }]) as TabsOut
+    expect(agreed.t1?.unregistered).toBeUndefined()
+    // Offline inspect passes the degraded sessions section (null) through.
+    const offline = tabsSection("t1", null) as TabsOut
+    expect(offline.t1?.unregistered).toBeUndefined()
   })
 })

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -213,8 +213,55 @@ describe("joinTaskTabs", () => {
     ])
   })
 
-  it("returns [] for a task with no snapshot", () => {
-    expect(joinTaskTabs(undefined, "t1", [{ key: "t1::tab-1", alive: true }])).toEqual([])
+  it("a task with no snapshot still lists its live sessions as unregistered rows", () => {
+    // Before issue #20 this returned [] — an alive engine invisible to the
+    // discovery read.
+    expect(joinTaskTabs(undefined, "t1", [{ key: "t1::tab-1", alive: true }])).toEqual([
+      {
+        id: "tab-1",
+        kind: "engine",
+        title: null,
+        vendor: null,
+        liveVendor: null,
+        lastTitle: null,
+        autoTitle: null,
+        alive: true,
+        exit: null,
+        unregistered: true,
+      },
+    ])
+  })
+
+  it("surfaces an alive session the snapshot does not list — the issue-#20 invisible engine", () => {
+    // The incident replay: snapshot holds only tab-2, yet the pty host has
+    // tab-1 + tab-2 alive. tab-1 ran for 1h44m with zero UI presence.
+    const snap = {
+      tabs: [{ kind: "engine", id: "tab-2", title: null, ordinal: 2 }],
+      activeId: "tab-2",
+      nextOrdinal: 3,
+    } as unknown as TabsState
+    const rows = joinTaskTabs(snap, "t1", [
+      { key: "t1::tab-1", alive: true },
+      { key: "t1::tab-2", alive: true },
+    ])
+    expect(rows.map((r) => ({ id: r.id, alive: r.alive, unregistered: r.unregistered ?? false }))).toEqual([
+      { id: "tab-2", alive: true, unregistered: false },
+      { id: "tab-1", alive: true, unregistered: true },
+    ])
+  })
+
+  it("dead sessions and split leaves never mint unregistered rows", () => {
+    const snap = {
+      tabs: [{ kind: "engine", id: "tab-2", title: null, ordinal: 2 }],
+      activeId: "tab-2",
+      nextOrdinal: 3,
+    } as unknown as TabsState
+    const rows = joinTaskTabs(snap, "t1", [
+      { key: "t1::tab-1", alive: false }, // dead — the exit records answer for it
+      { key: "t1::tab-2::leaf-1", alive: true }, // split leaf — belongs to tab-2
+      { key: "t1::tab-2", alive: true },
+    ])
+    expect(rows.map((r) => r.id)).toEqual(["tab-2"])
   })
 
   const oneTabSnap = (id: string): TabsState =>

--- a/packages/kobe/test/tui-react/sidebar-orphan-tabs.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-orphan-tabs.test.ts
@@ -1,13 +1,17 @@
 /**
- * Orphan-tab backstop: a task with a LIVE pty session but no persisted tab
- * snapshot must still render tab rows. Before this, a headless-started
- * session (`kobe api add --prompt`, `kobe api send`, a routine firing) ran a
- * real engine while the sidebar showed its worktree with nothing under it —
- * and headless start is how agent-driven work enters kobe.
+ * Orphan-tab backstop: any LIVE pty session the persisted snapshots do not
+ * answer for must render as an explicit unregistered tab row. Two shapes:
  *
- * The rule these pin: the backstop only ever FILLS HOLES. A task the
- * snapshot answered for keeps its snapshot projection, which carries titles,
- * ordinals and kinds a bare session key cannot.
+ *   - a task with NO snapshot at all (headless start before the CLI wrote
+ *     snapshots) — the original hole-filling case;
+ *   - a task WITH a snapshot that is missing the session's tab (issue #20:
+ *     the canonical-spawn fallback ran a live engine for 1h44m while the
+ *     sidebar rendered only the snapshot's tab-2 — a writable engine the UI
+ *     never showed).
+ *
+ * The rule these pin: reconciliation is TAB-granular. A registered tab keeps
+ * its snapshot projection (titles, ordinals, kinds); an unregistered live
+ * session becomes a ⚠ row instead of vanishing.
  */
 
 import { describe, expect, it } from "vitest"
@@ -18,22 +22,34 @@ const session = (key: string, over: { alive?: boolean; title?: string | null } =
 describe("orphanTabsByTask", () => {
   it("derives a tab row for a live session whose task has no snapshot", () => {
     const map = orphanTabsByTask([session("t1::tab-1")], new Set())
-    expect(map.get("t1")).toEqual([{ id: "tab-1", label: "tab-1", active: true, engine: true }])
+    expect(map.get("t1")).toEqual([{ id: "tab-1", label: "⚠ tab-1", active: true, engine: true }])
   })
 
   it("prefers the live process title when the host observed one", () => {
     const map = orphanTabsByTask([session("t1::tab-1", { title: "  claude — building  " })], new Set())
-    expect(map.get("t1")?.[0]?.label).toBe("claude — building")
+    expect(map.get("t1")?.[0]?.label).toBe("⚠ claude — building")
   })
 
-  it("never overrides a task the snapshot already answered for", () => {
-    const map = orphanTabsByTask([session("t1::tab-1")], new Set(["t1"]))
+  it("surfaces a live session missing from its task's snapshot — the issue-#20 invisible engine", () => {
+    // Snapshot answered for tab-2 only; tab-1 is alive on the host.
+    const map = orphanTabsByTask([session("t1::tab-1"), session("t1::tab-2")], new Set(["t1::tab-2"]))
+    expect(map.get("t1")?.map((t) => t.id)).toEqual(["tab-1"])
+  })
+
+  it("skips a tab the snapshot already answered for", () => {
+    const map = orphanTabsByTask([session("t1::tab-1")], new Set(["t1::tab-1"]))
     expect(map.has("t1")).toBe(false)
   })
 
   it("ignores dead sessions and keys with no tab part", () => {
     const map = orphanTabsByTask([session("t1::tab-1", { alive: false }), session("bare-task-id")], new Set())
     expect(map.size).toBe(0)
+  })
+
+  it("collapses a split's shell leaf into its tab instead of minting a bogus row", () => {
+    expect(orphanTabsByTask([session("t1::tab-2::leaf-1")], new Set(["t1::tab-2"])).size).toBe(0)
+    const map = orphanTabsByTask([session("t1::tab-2"), session("t1::tab-2::leaf-1")], new Set())
+    expect(map.get("t1")?.map((t) => t.id)).toEqual(["tab-2"])
   })
 
   it("marks only the first tab of a task active", () => {


### PR DESCRIPTION
## Failure mode (issue #20)

The tabs snapshot (`terminalTabs.<taskId>` — what the sidebar tree and `get-task`/`inspect` render from) and the pty host's session inventory are maintained independently, with no reconciliation. `publishCliTabSnapshot` only seeds when a task has NO snapshot; when one exists (e.g. holding only `tab-2`), any path that opens a new `<taskId>::tab-N` pty session without going through the mint/append point leaves the snapshot untouched. Live incident: the canonical-spawn fallback (#19) started a writable engine on `tab-1` while the snapshot listed only `tab-2` — inspect and the sidebar showed nothing for 1h44m, so nobody could discover or act on it.

## Fix — structural reconciliation, not entry-point plugging

Rather than only closing the known spawn entry point (#19's worker owns that), the render/read layers now join against `pty.list` truth, so ANY future divergence path is automatically visible:

- **`joinTaskTabs`** (`get-task`/`collect` tabs): alive sessions the snapshot doesn't list are appended as rows with `unregistered: true` (a task with no snapshot at all also lists them, instead of returning `[]`).
- **`inspect` tabs section**: each task reports `unregistered: [tab-ids]` for alive sessions its snapshot is missing; a task with live sessions and no snapshot still gets an entry.
- **TUI sidebar** (`orphanTabsByTask`): the backstop is now tab-granular instead of task-granular — previously a task whose snapshot answered at all was skipped wholesale, which is exactly what hid the incident. Unregistered live sessions render as `⚠ <title|tab-id>` rows appended after the snapshot's tabs.

Split leaves (`::leaf-N`) collapse into their tab; dead sessions never mint rows (exit records already answer for those).

## Tests (fail before the fix)

10 cases fail on the pre-fix source (verified by stashing `src/` and re-running):
- `api-tab-snapshot.test.ts` — incident replay: snapshot holds only tab-2, pty has tab-1+tab-2 alive → tab-1 appears as an unregistered row.
- `api-inspect.test.ts` — `tabsSection` flags alive-but-unlisted sessions as `unregistered`, reports snapshot-less tasks, stays quiet when reconciled/offline.
- `sidebar-orphan-tabs.test.ts` — tab-granular reconciliation + leaf collapsing.

## Scope

Only the truth-derivation/divergence-exposure layer. #19 (spawn branch in `pty-delivery.ts`) and #21 (dispatcher model) are owned by other workers.

docs/API.md updated for the `get-task`/`inspect` output additions; one patch changeset.