### PR TITLE
fix: send never silently spawns a duplicate engine (#19)

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: kobe
 description: Use when controlling kobe tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell.
 ---
 
-<!-- kobe-skill-version: 15 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- kobe-skill-version: 16 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # kobe shell control
 
@@ -98,8 +98,13 @@ kobe api list --pretty
 ```
 
 `.running` means the task's canonical Hosted PTY engine session is alive.
-`send` reuses it or auto-starts it when absent; omitting `--tab` targets that
-canonical engine tab.
+Omitting `--tab` targets a live engine tab (`tab-1` first, then any surviving
+engine tab). Only when the task has NO live session at all does `send`
+auto-start the canonical engine in the task's worktree (`started: true` in
+the result marks that fresh session). If live tabs exist but none resolves
+as an engine, it refuses with `NO_ENGINE_TAB` — address one with `--tab
+tab-N` or spawn one with `--tab new`; it never silently spawns a duplicate
+engine.
 
 ## Terminal panes
 

--- a/.changeset/fix-19-send-no-silent-spawn.md
+++ b/.changeset/fix-19-send-no-silent-spawn.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+`send` no longer silently spawns a duplicate engine when the canonical tab cannot be resolved (issue #19). `findHostedEngineKey` now matches the engine binary as a word in the full shell-wrapped launch argv (the old `command[0]` fallback was dead code — hosted sessions always launch via `<shell> -ilc`), so a surviving engine tab receives the prompt even when `tab-1` is gone. When live tabs exist but none resolves as an engine, delivery fails loud with a typed `NO_ENGINE_TAB` error (hint + `nextCommandArgs`) instead of booting an unsandboxed engine and reporting ok to both sides. Auto-start remains only for a task with no live session at all, cwd'd at the task's worktree, with `started: true` marking the fresh session.

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,7 +142,13 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   Delivery needs a live engine in that tab: one that exited into the
   keep-alive shell refuses with `ENGINE_NOT_RUNNING` and a `--tab new` hint
   instead of pasting into a shell. Any registered engine passes, so a tab may
-  run a different vendor than its task.
+  run a different vendor than its task. Without `--tab`, the canonical target
+  is a live engine tab (`tab-1` first, then any surviving engine tab); when
+  live tabs exist but none resolves as an engine, `send` refuses with
+  `NO_ENGINE_TAB` rather than silently spawning a duplicate engine. Only a
+  task with no live session at all auto-starts its canonical engine tab, in
+  the task's worktree — `started: true` in the result marks that fresh
+  session (vs. delivery into an existing one).
 - `dispatch --task-id ID --prompt TEXT`: route text into a task's live
   session via the daemon's `session.deliver` channel; requires an
   already-hosted session (the dispatcher's messenger; see

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -107,9 +107,18 @@ export const deliverToKey = deliverToHostedKey
 const writePrompt = writeHostedPrompt
 
 /**
- * Deliver to an existing canonical hosted engine, or create it once with
- * the explicit prompt already embedded in its launch argv. The latter avoids
- * racing a paste against a cold engine's startup screen.
+ * Deliver to an existing hosted engine tab, or — ONLY when the task has no
+ * alive session at all — create the canonical one with the explicit prompt
+ * already embedded in its launch argv (avoids racing a paste against a cold
+ * engine's startup screen). `started: true` in the result means "a NEW
+ * session was created", never "delivered into an existing one".
+ *
+ * When alive tabs exist but none resolves as an engine, this THROWS
+ * (NO_ENGINE_TAB) instead of spawning. Issue #19: the silent-spawn fallback
+ * booted an unsandboxed `--dangerously-skip-permissions` engine (in the
+ * incident, cwd'd at the MAIN repo) while both sender and receiver believed
+ * the message was delivered. A well-meaning fallback here is
+ * indistinguishable from success on both sides — it must stay loud.
  */
 export async function deliverHostedPrompt(
   rpc: PtyHostRpc,
@@ -149,6 +158,24 @@ export async function deliverHostedPrompt(
       started: false,
       engineReady: delivered,
       delivered,
+    }
+  }
+
+  // No engine resolved. Spawning is legitimate ONLY when the task has no
+  // alive session whatsoever (first start / all-dead resume) — an alive tab
+  // we merely failed to identify means the prompt would land in a duplicate
+  // engine the receiver never sees. Fail loud; the caller picks a tab.
+  if (!opts?.forceNew) {
+    const aliveTabs = sessions.filter((s) => s.alive && isTaskKey(s.key, target.id)).map((s) => s.key)
+    if (aliveTabs.length > 0) {
+      throw new ApiError(
+        `task ${target.id} has live tabs (${aliveTabs.join(", ")}) but none resolves as its engine tab — refusing to spawn a new engine`,
+        "NO_ENGINE_TAB",
+        {
+          hint: "address a live engine tab explicitly with --tab <tab-N> (see pty-list), or spawn a fresh engine tab with --tab new",
+          nextCommandArgs: ["api", "pty-list"],
+        },
+      )
     }
   }
 

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path"
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { ensurePtyHostReachable } from "@sma1lboy/kobe-daemon/client/pty-process"
 import { defaultPtyHostSocketPath } from "@sma1lboy/kobe-daemon/daemon/paths"
@@ -61,10 +62,29 @@ export async function killHostedSessions(rpc: HostedSessionRpc, keys: readonly s
 }
 
 /**
+ * True when a session's spawn argv contains `engineBin` as a standalone
+ * word. Hosted engine tabs launch via `<shell> -ilc '…<engineBin> …'`
+ * (`buildEngineSessionLaunch`), so `command[0]` is ALWAYS the shell — an
+ * argv[0] comparison against the engine binary never matches in production
+ * (issue #19: that dead fallback made delivery silently spawn a duplicate
+ * engine). Bare shell tabs (`[shell, "-il"]`) carry no engine word.
+ */
+export function commandHasEngineWord(command: readonly string[], engineBin: string): boolean {
+  for (const part of command) {
+    for (const token of part.split(/\s+/)) {
+      const bare = token.replace(/^['"]+|['"]+$/g, "")
+      if (bare && basename(bare) === engineBin) return true
+    }
+  }
+  return false
+}
+
+/**
  * Pick the ALIVE engine session key for `taskId`, or `null` when none.
- * Preference order: the deterministic `<taskId>::tab-1` engine tab, then a
- * session whose `command[0]` matches `engineBin` (a reattached/renumbered
- * engine). Bare shell tabs never match — they must never receive a prompt.
+ * Preference order: the deterministic `<taskId>::tab-1` engine tab, then any
+ * alive tab whose launch argv contains `engineBin` as a word (a renumbered
+ * or `--tab new` engine surviving tab-1's death). Bare shell tabs never
+ * match — they must never receive a prompt.
  */
 export function findHostedEngineKey(
   sessions: readonly PtySessionInfo[],
@@ -75,7 +95,7 @@ export function findHostedEngineKey(
   const tab1 = mine.find((s) => s.key === `${taskId}::tab-1`)
   if (tab1) return tab1.key
   if (engineBin) {
-    const byCommand = mine.find((s) => s.command[0] === engineBin)
+    const byCommand = mine.find((s) => commandHasEngineWord(s.command, engineBin))
     if (byCommand) return byCommand.key
   }
   return null

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -38,7 +38,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * marker is below this number is STALE: the binary moved on, the skill
  * didn't, so we prompt the developer to re-run `kobe skill install`.
  */
-export const KOBE_SKILL_VERSION = 15
+export const KOBE_SKILL_VERSION = 16
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -50,6 +50,24 @@ describe("findEngineKey", () => {
     expect(findEngineKey(sessions, "t1", "codex")).toBe("t1::tab-5")
   })
 
+  it("resolves a SHELL-WRAPPED engine tab when tab-1 is absent (issue #19)", () => {
+    // Every hosted session launches via `<shell> -ilc '…<engine> …'`
+    // (buildEngineSessionLaunch), so command[0] is NEVER the engine binary.
+    // The old `command[0] === engineBin` fallback was dead code in
+    // production: this surviving engine tab resolved to null and delivery
+    // silently spawned a duplicate engine.
+    const sessions = [
+      session("t1::tab-1", ["/bin/zsh", "-ilc", "export KOBE_TASK_ID='t1'\nclaude 'hi'"], false),
+      session("t1::tab-2", ["/bin/zsh", "-ilc", "export KOBE_TASK_ID='t1' KOBE_TAB_ID='tab-2'\nclaude '--resume' 'x'"]),
+    ]
+    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-2")
+  })
+
+  it("a shell-wrapped SHELL tab still never matches", () => {
+    const sessions = [session("t1::tab-2", ["/bin/zsh", "-il"])]
+    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
+  })
+
   it("skips a DEAD tab-1 (an exited engine cannot receive a prompt)", () => {
     const sessions = [session("t1::tab-1", ["claude"], false)]
     expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
@@ -196,6 +214,84 @@ describe("deliverHostedPrompt", () => {
     )
     expect(result).toMatchObject({ started: false, delivered: true })
     expect(calls).toContain("pty.write")
+  })
+
+  it("delivers into a surviving shell-wrapped engine tab instead of spawning (issue #19 incident)", async () => {
+    // The incident shape: tab-1 dead, tab-2 a live shell-wrapped engine.
+    // Pre-fix this spawned a fresh unsandboxed engine at launch.key and
+    // returned ok while tab-2 never saw the prompt.
+    const calls: string[] = []
+    const rpc = {
+      request: async <T>(name: string): Promise<T> => {
+        calls.push(name)
+        if (name === "pty.list")
+          return {
+            sessions: [
+              session("t1::tab-1", ["/bin/zsh", "-ilc", "claude 'x'"], false),
+              session("t1::tab-2", ["/bin/zsh", "-ilc", "claude '--resume' 'x'"]),
+            ],
+          } as T
+        if (name === "pty.peek") return { exists: true, alive: true } as T
+        return {} as T
+      },
+    }
+    const result = await deliverHostedPrompt(
+      rpc,
+      { id: "t1", engineBin: "claude" },
+      "/wt/t1",
+      "go",
+      { key: "t1::tab-1", command: ["/bin/zsh", "-ilc", "claude 'go'"] },
+      { snapshot: psWith("claude") },
+    )
+    expect(result).toMatchObject({ session: "t1::tab-2", started: false, delivered: true })
+    expect(calls).not.toContain("pty.open") // NEVER a new engine while one lives
+  })
+
+  it("FAILS LOUD instead of spawning when live tabs exist but none is an engine (issue #19)", async () => {
+    // A live shell tab, no engine anywhere: pre-fix this silently booted a
+    // brand-new engine at tab-1 and reported ok — sender and receiver both
+    // believed the message arrived. It must be a typed error instead.
+    const calls: string[] = []
+    const rpc = {
+      request: async <T>(name: string): Promise<T> => {
+        calls.push(name)
+        if (name === "pty.list") return { sessions: [session("t1::tab-2", ["/bin/zsh", "-il"])] } as T
+        return {} as T
+      },
+    }
+    const err = await deliverHostedPrompt(rpc, { id: "t1", engineBin: "claude" }, "/wt/t1", "go", {
+      key: "t1::tab-1",
+      command: ["/bin/zsh", "-ilc", "claude 'go'"],
+    }).then(
+      () => null,
+      (e) => e,
+    )
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).code).toBe("NO_ENGINE_TAB")
+    expect((err as ApiError).data).toMatchObject({ nextCommandArgs: ["api", "pty-list"] })
+    expect(calls).not.toContain("pty.open") // no session was created
+    expect(calls).not.toContain("pty.write") // and nothing was pasted anywhere
+  })
+
+  it("still first-starts the canonical engine when only DEAD sessions remain, cwd'd at the worktree", async () => {
+    const calls: Array<{ name: string; payload: unknown }> = []
+    const rpc = {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
+        calls.push({ name, payload })
+        if (name === "pty.list")
+          return { sessions: [session("t1::tab-1", ["/bin/zsh", "-ilc", "claude 'x'"], false)] } as T
+        if (name === "pty.open") return { replay: "", alive: true, created: true } as T
+        return {} as T
+      },
+    }
+    const result = await deliverHostedPrompt(rpc, { id: "t1", engineBin: "claude" }, "/wt/t1", "go", {
+      key: "t1::tab-1",
+      command: ["/bin/zsh", "-ilc", "claude 'go'"],
+    })
+    // started:true is the "a NEW session was created" marker.
+    expect(result).toMatchObject({ session: "t1::tab-1", started: true, delivered: true })
+    const open = calls.find((c) => c.name === "pty.open")
+    expect(open?.payload).toMatchObject({ cwd: "/wt/t1" }) // the task's worktree, never the caller's repo
   })
 
   it("REFUSES an existing session whose engine exited into the keepAlive shell", async () => {


### PR DESCRIPTION
Fixes daemon issue #19 ([severity↑] send 静默 spawn 无隔离写权限引擎).

## What was broken

`findHostedEngineKey` had two rules: the literal `<taskId>::tab-1` key, then a fallback comparing `command[0]` against the engine binary. Every hosted session launches via `<shell> -ilc '…<engine> …'`, so `command[0]` is **always the shell** — the fallback was dead code in production. When tab-1 died but another engine tab survived, resolution returned null and `deliverHostedPrompt` fell into its spawn branch: it booted a brand-new engine at `<taskId>::tab-1` with the prompt embedded in its launch argv and returned `ok: true`.

In the 2026-08-12 incident that engine ran `--dangerously-skip-permissions` in the **main repo** for 1h44m, invisible to the UI, while sender and receiver both believed the message was delivered.

## Why the fix must fail loud (do not "improve" this back into a fallback)

The failure mode of a silent spawn is uniquely bad because it is **indistinguishable from success on both sides**: the sender gets `ok: true`, the receiver never sees the prompt, and the spawned engine is a write-capable agent nobody knows exists, executing a message that was never meant to be a task. A future refactor that turns the `NO_ENGINE_TAB` error back into a well-meaning "just start one" fallback recreates exactly this incident — the error, its `hint`, and its `nextCommandArgs` ARE the feature. This is the same lesson as workerReport silently not persisting: collaboration verbs must never fake success (design principle recorded on issues #19/#21).

## What changed

- `findHostedEngineKey` (`packages/kobe/src/engine/hosted-session.ts`): the fallback now matches the engine binary as a standalone word anywhere in the shell-wrapped launch argv (`commandHasEngineWord`), so any surviving engine tab of the task resolves and receives the prompt. Bare shell tabs (`[shell, "-il"]`) still never match, and the downstream `sessionHasEngine` process-tree gate still guards against an exited engine's keepAlive shell. This stays a single exported resolver so #21's dispatcher-fallback chain can call it directly.
- `deliverHostedPrompt` (`packages/kobe/src/cli/api/pty-delivery.ts`): when no engine resolves but the task **has live tabs**, delivery now throws a typed `NO_ENGINE_TAB` `ApiError` with `hint` + `nextCommandArgs` (same self-healing style as `ENGINE_NOT_RUNNING`) instead of spawning. Auto-start survives only for a task with **no live session at all** (first start / all-dead resume), cwd'd at the task's worktree; `started: true` in the result is the explicit "a NEW session was created" marker vs delivery into an existing one.
- Docs: `docs/API.md` send section + kobe skill (`.agents/skills/kobe/SKILL.md`, version 15 → 16 in lockstep with `KOBE_SKILL_VERSION`).

## Tests (fail before the fix — verified by stashing src and re-running)

- `findEngineKey` resolves a shell-wrapped engine tab when tab-1 is absent (was: null → spawn).
- `deliverHostedPrompt` delivers into the surviving engine tab in the exact incident shape (tab-1 dead, tab-2 live) and never calls `pty.open`.
- `deliverHostedPrompt` throws `NO_ENGINE_TAB` with zero `pty.open`/`pty.write` when live tabs exist but none is an engine (was: silent spawn + `ok: true`).
- Boundary locks: dead-only sessions still first-start the canonical engine with `cwd` = the task's worktree; shell-wrapped shell tabs never match.

Pre-fix run: `3 failed | 20 passed`; post-fix: full package suite `304 files / 2924 tests` green.

Also verified live against an isolated daemon/pty-host (`KOBE_HOME_DIR` + socket overrides inlined): reproduced the incident shape with a real engine — tab-1 killed dead, `send` without `--tab` landed in the surviving tab-2 (`session: …::tab-2, started: false`) and pty-list confirmed no respawn.

## Relation to #20 / #21

- #20 (tabs snapshot vs pty truth divergence): the canonical-spawn fallback was the known entry point that minted sessions the tabs snapshot never learned about. Eliminating the silent spawn closes that entry point; #20's general reconciliation (render unregistered live sessions) remains open.
- #21 (dispatcher lineage): the resolver stays a clean exported function (`findHostedEngineKey` / `findEngineKey`) for #21's `dispatcher tab → task canonical → fail loud` fallback chain to reuse.