### PR TITLE
fix: tasks record their dispatcher so replies reach the tab that sent the work (#21)

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: kobe
 description: Use when controlling kobe tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell.
 ---
 
-<!-- kobe-skill-version: 16 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- kobe-skill-version: 17 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # kobe shell control
 
@@ -30,15 +30,21 @@ lifecycle tracking, and an explicit outcome contract.
 - Delegating a scoped piece of work → `add --prompt`, not a raw `claude -p`
   child the user cannot see or manage.
 - Following up on a task you started → `send`; comparing → `collect`;
-  finished your own task and were spawned by another → `send` your outcome
-  back to the spawner (the first-prompt coda carries the exact command).
+  finished your own task and were spawned by another → a bare `send`
+  (no `--task-id`) replies to the DISPATCHER — the exact task + tab that
+  created you, recorded at creation (`.task.dispatcher` on `get-task`).
+  If that tab died it falls back to the dispatcher task's live canonical
+  engine tab; nothing alive fails loud (`DISPATCHER_UNREACHABLE`) — it
+  never spawns a new engine, so a failed reply is visible, not fake-ok.
 - Messaging another task's agent → `send`, and ONLY `send` — never relay
   through the user, a side file, or a generic peer channel. Sent from
   inside a kobe task, the prompt arrives prefixed `[KOBE PEER] from
   "<title>" (task <id> — load the kobe agent skill FIRST …)`, so the
   receiver knows who is talking, that this skill is required reading, and
-  how to answer — peer conversations need no coordinator and no human
-  relay. That prefix is the contract: do not strip it with `--plain` for
+  how to answer — the baked-in reply command is tab-precise
+  (`--task-id <sender> --tab <sender's tab>`), so peer conversations need
+  no coordinator and no human relay. That prefix is the contract: do not
+  strip it with `--plain` for
   coordination messages (`--plain` is only for a verbatim paste the
   receiver should treat as content, not conversation). Received a
   `[KOBE PEER]` message yourself? Load this skill first — required, not
@@ -86,6 +92,9 @@ kobe api fan-out --repo "$PWD" --agents claude:2,codex:1 --prompt "<prompt>"
 # (sender + reply command); --plain sends verbatim.
 kobe api send --task-id <id> --prompt "<complete next turn>"
 
+# Reply home: no --task-id inside a dispatched task = the dispatcher's tab.
+kobe api send --prompt "succeeded: <one line> (branch <final branch>)"
+
 # A task can hold several chat tabs. Enumerate them first (inspect's .tabs is
 # the sidebar's tab snapshot: id, kind, vendor, lastTitle), then address one:
 kobe api inspect --task-id <id>
@@ -98,8 +107,10 @@ kobe api list --pretty
 ```
 
 `.running` means the task's canonical Hosted PTY engine session is alive.
-Omitting `--tab` targets a live engine tab (`tab-1` first, then any surviving
-engine tab). Only when the task has NO live session at all does `send`
+Omitting BOTH `--task-id` and `--tab` inside a task that has a dispatcher
+targets that dispatcher's tab (see the reply rule above); otherwise the
+target is the active task. Omitting only `--tab` targets a live engine tab
+(`tab-1` first, then any surviving engine tab). Only when the task has NO live session at all does `send`
 auto-start the canonical engine in the task's worktree (`started: true` in
 the result marks that fresh session). If live tabs exist but none resolves
 as an engine, it refuses with `NO_ENGINE_TAB` — address one with `--tab
@@ -190,11 +201,12 @@ engine turn.
 Outcomes are explicit, never inferred — and they travel as a MESSAGE to the
 spawning agent's chat tab, not as stored state nobody reads.
 
-**Worker side** — a task created from inside another kobe task gets a coda
-on its first prompt naming its spawner; when the work is finished, run the
-baked-in command: `kobe api send --task-id <spawner> --prompt
-"<succeeded|failed>: <one line> (branch <final branch>)"`. Include the final
-branch name — the spawner needs it to `land`.
+**Worker side** — a task created from inside another kobe task records its
+dispatcher (the creating task + tab); when the work is finished, a bare
+`kobe api send --prompt "<succeeded|failed>: <one line> (branch <final
+branch>)"` routes the outcome back to that exact tab. Include the final
+branch name — the spawner needs it to `land`. The first-prompt coda still
+names the spawner for an explicit `--task-id` send.
 
 **Coordinator side** — do NOT block or poll. Keep working (or end your
 turn); each worker's outcome arrives in your chat as a `[KOBE PEER]` message

--- a/.changeset/dispatcher-reply-address.md
+++ b/.changeset/dispatcher-reply-address.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Tasks now record the kobe session that dispatched them (`dispatcher: {taskId, tabId}`), so a worker's reply reaches the tab the work was dispatched from. `add`/`fan-out` stamp it from the caller's `$KOBE_TASK_ID`/`$KOBE_TAB_ID`; a bare `kobe api send` (no `--task-id`) inside a dispatched task delivers to that exact tab, falls back to the dispatcher task's live canonical engine tab when it died, and fails loud with `DISPATCHER_UNREACHABLE` when nothing there is alive — never a silent new engine. `[KOBE PEER]` reply commands are now tab-precise, and `get-task`/`collect` expose the dispatcher for lineage reads.

--- a/docs/API.md
+++ b/docs/API.md
@@ -32,12 +32,12 @@ kobe api fan-out --repo "$PWD" \
 ```
 
 **Completion** — a worker spawned from another kobe task sends its outcome
-back to the spawner's chat tab (the first-prompt coda carries the exact
-command); no stored report, no blocking wait. Silence is a checkpoint,
-never a verdict:
+back to the dispatching chat tab: creation records the dispatcher
+(task + tab), so a bare `send` routes home without any id in hand; no
+stored report, no blocking wait. Silence is a checkpoint, never a verdict:
 
 ```bash
-kobe api send --task-id <spawner> --prompt "succeeded: auth flow simplified (branch kobe/auth-flow)"
+kobe api send --prompt "succeeded: auth flow simplified (branch kobe/auth-flow)"
 ```
 
 **Observe** — read the engine's own structured session, never scrape a TUI
@@ -92,9 +92,12 @@ paths against `$PWD` (`~` expanded). Engine vendors: `claude`, `codex`,
   (`code`/`signal`/`at`); clean exits stay `exit: null`. A live PTY session
   the persisted snapshot does not list still gets a row, marked
   `unregistered: true` — an alive engine is never invisible here.
+  `.task.dispatcher` (`{taskId, tabId}`) = the kobe session that created the
+  task, when one did — the lineage read for a fan-out round's parent.
 - `collect [--task-ids a,b,c] [--repo PATH]`: read-only comparison
-  snapshot of several tasks: identity, branch, `.running`, uncommitted
-  `.changes`, and committed `.base` (ahead count + diffstat vs base).
+  snapshot of several tasks: identity, branch, lineage (`.dispatcher`,
+  `.groupId`), `.running`, uncommitted `.changes`, and committed `.base`
+  (ahead count + diffstat vs base).
 - `digest --repo PATH [--since-days N]`: the repo's recent agent work —
   tasks touched in the window plus routine outcomes by status. Default
   window 7 days. Task outcomes are deliberately absent: completion travels
@@ -132,6 +135,11 @@ paths against `$PWD` (`~` expanded). Engine vendors: `claude`, `codex`,
   [--vendor V] [--title T] [--base-branch B]`: spawn N tasks of one prompt
   in a single call (parallel attempts). Capped at 10.
 
+A create issued from inside a kobe engine tab (`add`, `fan-out`) records
+the caller as the new task's `dispatcher` (`{taskId, tabId}` from
+`$KOBE_TASK_ID`/`$KOBE_TAB_ID`) — the reply address the worker's bare
+`send` routes back to. Creates from a plain shell or the TUI record none.
+
 A new task's FIRST prompt (`add --prompt`, `fan-out`, quick-fork) gets a
 short coda appended asking the agent to `set-branch` the auto-generated
 placeholder branch to a descriptive name. Prompts into existing sessions
@@ -140,10 +148,15 @@ placeholder branch to a descriptive name. Prompts into existing sessions
 ## drive
 
 - `send [--task-id ID] --prompt TEXT [--tab TAB] [--plain]`: paste a
-  follow-up into a task's running engine (one full turn). Defaults to the
-  active task and its canonical engine tab. From another kobe task, the
-  message includes `[KOBE PEER]` provenance and a reply command; `--plain`
-  skips that prefix. `--tab new` spawns a fresh engine tab, while `--tab
+  follow-up into a task's running engine (one full turn). Without
+  `--task-id`, a task that has a `dispatcher` on record replies to that
+  exact tab — falling back to the dispatcher task's live canonical engine
+  tab when the tab died, and failing loud (`DISPATCHER_UNREACHABLE`) when
+  nothing on that task is alive, never silently spawning a new engine.
+  Otherwise the default is the active task and its canonical engine tab.
+  From another kobe task, the message includes `[KOBE PEER]` provenance and
+  a tab-precise reply command (`--task-id <sender> --tab <sender's tab>`);
+  `--plain` skips that prefix. `--tab new` spawns a fresh engine tab, while `--tab
   tab-N` targets that exact tab (`TAB_NOT_FOUND` if it is dead or absent).
   Delivery needs a live engine in that tab: one that exited into the
   keep-alive shell refuses with `ENGINE_NOT_RUNNING` and a `--tab new` hint

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -49,6 +49,14 @@ export interface TaskPRStatus {
   readonly lastError?: string
 }
 
+/** The kobe session (task + tab) that dispatched a task's creation — the
+ *  reply address a sub-task's bare `send` routes back to (mirrors
+ *  kobe/types/task.ts). Absent when created outside a kobe session. */
+export interface TaskDispatcher {
+  readonly taskId: string
+  readonly tabId: string
+}
+
 /** Pointer back to the external issue a task was started from. Snapshot for
  *  display; `url` is the durable way to the live item. Never synced. */
 export interface TaskLinkedWorkItem {
@@ -78,6 +86,8 @@ export interface DaemonTask {
   readonly quotaResume?: TaskQuotaResumeState
   /** The external tracker item this task was started from, when it was. */
   readonly linkedWorkItem?: TaskLinkedWorkItem
+  /** The kobe session (task + tab) that dispatched this task, when one did. */
+  readonly dispatcher?: TaskDispatcher
   readonly createdAt: string
   readonly updatedAt: string
 }
@@ -114,6 +124,7 @@ export interface DaemonOrchestrator {
     vendor?: VendorId
     modelEffort?: string
     groupId?: string
+    dispatcher?: TaskDispatcher
   }): Promise<DaemonTask>
   ensureMainTask(repo: string): Promise<DaemonTask>
   /** Open an existing directory as a standalone `kind:"dir"` task (`kobe .`). */

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -35,6 +35,14 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     web: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
+      // Dispatcher provenance (issue #21): the CLI reads its own
+      // $KOBE_TASK_ID/$KOBE_TAB_ID and sends both flat — the daemon process
+      // has no caller env of its own. Recorded only when the task id is
+      // present; the tab floor is tab-1, the canonical first engine tab.
+      const dispatcherTaskId = optionalString(payload, "dispatcherTaskId")
+      const dispatcher = dispatcherTaskId
+        ? { taskId: dispatcherTaskId, tabId: optionalString(payload, "dispatcherTabId") || "tab-1" }
+        : undefined
       const task = await ctx.orch.createTask({
         repo,
         title: optionalString(payload, "title"),
@@ -43,6 +51,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
         vendor: optionalVendor(payload, "vendor"),
         modelEffort: optionalString(payload, "effort"),
         groupId: optionalString(payload, "groupId"),
+        dispatcher,
       })
       return { taskId: task.id, task: serializeTask(task) }
     },

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -386,6 +386,8 @@ export interface SerializedTask {
   /** Durable rate-limit auto-resume schedule. */
   readonly quotaResume?: DaemonTask["quotaResume"]
   readonly linkedWorkItem?: DaemonTask["linkedWorkItem"]
+  /** The kobe session (task + tab) that dispatched this task's creation. */
+  readonly dispatcher?: DaemonTask["dispatcher"]
   readonly createdAt: string
   readonly updatedAt: string
 }
@@ -409,6 +411,7 @@ export function serializeTask(task: DaemonTask): SerializedTask {
     deletion: task.deletion,
     quotaResume: task.quotaResume,
     linkedWorkItem: task.linkedWorkItem,
+    dispatcher: task.dispatcher,
     createdAt: task.createdAt,
     updatedAt: task.updatedAt,
   }

--- a/packages/kobe/src/cli/api/dispatcher.ts
+++ b/packages/kobe/src/cli/api/dispatcher.ts
@@ -1,0 +1,84 @@
+/**
+ * Dispatcher provenance — the collaboration loop's reply address (issue #21).
+ *
+ * A task created from inside another kobe engine tab records WHO dispatched
+ * it (`dispatcher: {taskId, tabId}`), and a bare `send` from that task
+ * replies to exactly that tab. Completion has always been designed to flow
+ * back through `send` into the dispatching chat tab (the `report`/`await`
+ * verbs were removed in 55c990f34 in favour of it); this module is the
+ * missing address that makes the route computable instead of hand-relayed.
+ *
+ * Both halves live here rather than in `handler-helpers.ts` so the stamping
+ * (create-side) and the routing (send-side) stay one readable concern.
+ */
+
+import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import type { DaemonRpc } from "../daemon-session.ts"
+import { ApiError, type ApiRuntime } from "./types.ts"
+
+/** The dispatcher pair as recorded on a task. */
+export type Dispatcher = NonNullable<SerializedTask["dispatcher"]>
+
+/**
+ * `task.create` payload fields naming the caller as the dispatcher.
+ * `$KOBE_TASK_ID` / `$KOBE_TAB_ID` are exported into every engine tab
+ * (`session-launch.ts`), and are read HERE in the CLI process — the daemon
+ * has no caller env of its own. A create from a plain shell contributes
+ * nothing. Tab floor `tab-1` = the canonical first engine tab.
+ */
+export function dispatcherEnvPayload(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const taskId = env.KOBE_TASK_ID
+  if (!taskId) return {}
+  return { dispatcherTaskId: taskId, dispatcherTabId: env.KOBE_TAB_ID || "tab-1" }
+}
+
+/**
+ * The dispatcher recorded on the CALLER's own task, when the caller is a
+ * kobe session that has one. `null` (keep the active-task default) when the
+ * caller isn't a kobe session, the task predates the field or was created
+ * outside a kobe session, or the env id is stale.
+ */
+export async function readOwnDispatcher(daemon: DaemonRpc): Promise<Dispatcher | null> {
+  const selfId = process.env.KOBE_TASK_ID
+  if (!selfId) return null
+  try {
+    const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId: selfId })
+    return res.task.dispatcher ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Pick the tab a dispatcher-defaulted `send` lands on: the exact tab the
+ * work was dispatched from first, the dispatcher task's canonical live
+ * engine tab when that tab has died, and NEVER a silent spawn — with
+ * nothing alive the send fails loud with a typed error, per the 2026-08-12
+ * collaboration-verb design principle (a fallback must not impersonate
+ * success). `undefined` means "the canonical tab", the delivery layer's own
+ * spelling for it.
+ */
+export async function resolveDispatcherTab(runtime: ApiRuntime, dispatcher: Dispatcher): Promise<string | undefined> {
+  const { tabs, running } = await runtime.taskTabs(dispatcher.taskId)
+  // The dispatched-from tab first, addressed only when it reads ALIVE: the
+  // tab join now also lists live sessions the persisted snapshot never
+  // registered (issue #20), so "present and alive" is the honest liveness
+  // test and a tab that is merely gone from the snapshot still gets the
+  // canonical fallback below instead of a TAB_NOT_FOUND at delivery.
+  if (tabs.some((t) => t.id === dispatcher.tabId && t.alive)) return dispatcher.tabId
+  // Dead dispatcher tab → the task's canonical live engine, gated on a live
+  // engine tab existing. The canonical path legitimately COLD-STARTS an
+  // engine for a task with no alive session at all (issue #19) — correct for
+  // a first prompt, wrong for a reply: it would boot an engine nobody asked
+  // for and address it as if it were the agent that dispatched the work.
+  if (running) return undefined
+  throw new ApiError(
+    `dispatcher tab ${dispatcher.tabId} on task ${dispatcher.taskId} is dead and the task has no live engine tab — the reply has nowhere to land`,
+    "DISPATCHER_UNREACHABLE",
+    {
+      dispatcher,
+      hint: "address an alive target explicitly with --task-id/--tab (see `kobe api pty-list`), or notify the user with `kobe api notify`",
+      nextCommandArgs: ["api", "pty-list"],
+    },
+  )
+}

--- a/packages/kobe/src/cli/api/handler-helpers.ts
+++ b/packages/kobe/src/cli/api/handler-helpers.ts
@@ -22,6 +22,20 @@ export async function simpleRpc(ctx: VerbContext, name: string, payload: Record<
 }
 
 /**
+ * Dispatcher provenance for `task.create` (issue #21): a create issued from
+ * INSIDE a kobe engine tab records who dispatched it — `$KOBE_TASK_ID` +
+ * `$KOBE_TAB_ID` are exported into every engine tab (session-launch.ts), and
+ * the pair is the reply address a sub-task's bare `send` routes back to.
+ * Read HERE in the CLI process (the daemon has no caller env); a create from
+ * a plain shell records nothing. Tab floor tab-1 = the canonical engine tab.
+ */
+export function dispatcherEnvPayload(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const taskId = env.KOBE_TASK_ID
+  if (!taskId) return {}
+  return { dispatcherTaskId: taskId, dispatcherTabId: env.KOBE_TAB_ID || "tab-1" }
+}
+
+/**
  * `pty-list` — inventory of the standalone pty host's sessions (key, pid,
  * command, live OSC window title — the same "实时进程名" stream the TUI tab
  * strip shows). Talks to the PTY HOST socket, not the daemon (offline verb),

--- a/packages/kobe/src/cli/api/handler-helpers.ts
+++ b/packages/kobe/src/cli/api/handler-helpers.ts
@@ -22,20 +22,6 @@ export async function simpleRpc(ctx: VerbContext, name: string, payload: Record<
 }
 
 /**
- * Dispatcher provenance for `task.create` (issue #21): a create issued from
- * INSIDE a kobe engine tab records who dispatched it — `$KOBE_TASK_ID` +
- * `$KOBE_TAB_ID` are exported into every engine tab (session-launch.ts), and
- * the pair is the reply address a sub-task's bare `send` routes back to.
- * Read HERE in the CLI process (the daemon has no caller env); a create from
- * a plain shell records nothing. Tab floor tab-1 = the canonical engine tab.
- */
-export function dispatcherEnvPayload(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
-  const taskId = env.KOBE_TASK_ID
-  if (!taskId) return {}
-  return { dispatcherTaskId: taskId, dispatcherTabId: env.KOBE_TAB_ID || "tab-1" }
-}
-
-/**
  * `pty-list` — inventory of the standalone pty host's sessions (key, pid,
  * command, live OSC window title — the same "实时进程名" stream the TUI tab
  * strip shows). Talks to the PTY HOST socket, not the daemon (offline verb),

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -8,8 +8,9 @@ import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { DEFAULT_FEEDBACK_CATEGORY_SLUG, submitFeedback } from "../../lib/feedback.ts"
 import { ulid } from "../../orchestrator/index/ulid.ts"
 import type { VendorId } from "../../types/vendor.ts"
+import { dispatcherEnvPayload } from "./dispatcher.ts"
 import { FANOUT_CAP, buildCountPlan, parseAgentsSpec } from "./flags.ts"
-import { daemonOf, dispatcherEnvPayload } from "./handler-helpers.ts"
+import { daemonOf } from "./handler-helpers.ts"
 import { ApiError, type VerbContext } from "./types.ts"
 
 export async function fanOut(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -9,7 +9,7 @@ import { DEFAULT_FEEDBACK_CATEGORY_SLUG, submitFeedback } from "../../lib/feedba
 import { ulid } from "../../orchestrator/index/ulid.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import { FANOUT_CAP, buildCountPlan, parseAgentsSpec } from "./flags.ts"
-import { daemonOf } from "./handler-helpers.ts"
+import { daemonOf, dispatcherEnvPayload } from "./handler-helpers.ts"
 import { ApiError, type VerbContext } from "./types.ts"
 
 export async function fanOut(ctx: VerbContext): Promise<unknown> {
@@ -47,8 +47,11 @@ export async function fanOut(ctx: VerbContext): Promise<unknown> {
   // can retry/archive them instead of double-spawning.
   const created: Array<{ taskId: string; vendor: VendorId; task: SerializedTask }> = []
   let createFailure: { vendor: VendorId; error: { message: string; code: string } } | null = null
+  // Every sibling records the same dispatcher (issue #21) — the reply
+  // address each worker's bare `send` routes its outcome back to.
+  const dispatcher = dispatcherEnvPayload()
   for (const [i, vendor] of plan.entries()) {
-    const payload: Record<string, string> = { repo, vendor, groupId }
+    const payload: Record<string, string> = { repo, vendor, groupId, ...dispatcher }
     if (title) payload.title = plan.length > 1 ? `${title} #${i + 1}/${plan.length}` : title
     if (baseRef) payload.baseRef = baseRef
     try {
@@ -165,6 +168,9 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
       vendor: task.vendor,
       status: task.status,
       ...(task.groupId ? { groupId: task.groupId } : {}),
+      // Lineage read (issue #21): who dispatched this task, so a fan-out
+      // round's parent is programmatically discoverable.
+      ...(task.dispatcher ? { dispatcher: task.dispatcher } : {}),
       running,
       changes,
       base,

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -10,9 +10,9 @@ import { kobeApiInvocation } from "../../engine/interactive-command.ts"
 import type { TaskStatus } from "../../types/task.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
-import { daemonOf, simpleRpc } from "./handler-helpers.ts"
+import { daemonOf, dispatcherEnvPayload, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
-import { ApiError, type VerbContext } from "./types.ts"
+import { ApiError, type ApiRuntime, type VerbContext } from "./types.ts"
 
 /**
  * Peer provenance: a `send` issued from INSIDE another kobe task is one
@@ -34,6 +34,13 @@ async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, promp
     /* stale env id — keep id-only provenance rather than dropping it */
   }
   const api = kobeApiInvocation()
+  // The baked-in reply command carries the sender's TAB, not just its task
+  // (issue #21): task-granular replies land on canonical-tab resolution,
+  // which is exactly the link that breaks (#19) — tab-precise addressing is
+  // the loop's durable route home. $KOBE_TAB_ID is exported into every
+  // engine tab alongside $KOBE_TASK_ID (session-launch.ts).
+  const senderTab = process.env.KOBE_TAB_ID
+  const replyTarget = `--task-id ${senderId}${senderTab ? ` --tab ${senderTab}` : ""}`
   // The trailing pointer closes the loop for a receiver that has never seen
   // kobe: reply command baked in, and where to learn the rest (the herdr
   // "--skill first" trick) — a pointer, not a curriculum, since every peer
@@ -42,7 +49,7 @@ async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, promp
   // improvises verbs and side-channels (2026-08-10: a peer coordination
   // round-trip fell back to a human relay because neither side had the
   // skill's contract in context).
-  return `[KOBE PEER] from "${label}" (task ${senderId} — load the kobe agent skill FIRST (required, e.g. /kobe), then reply: \`${api} send --task-id ${senderId} --prompt "<text>"\`; verb reference: \`${api} schema\`): ${prompt}`
+  return `[KOBE PEER] from "${label}" (task ${senderId} — load the kobe agent skill FIRST (required, e.g. /kobe), then reply: \`${api} send ${replyTarget} --prompt "<text>"\`; verb reference: \`${api} schema\`): ${prompt}`
 }
 
 export async function issueUpdate(ctx: VerbContext): Promise<unknown> {
@@ -71,7 +78,9 @@ export async function add(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const { args, runtime } = ctx
   const repo = await runtime.resolveRepoRoot(args.requirePath("repo"))
-  const payload: Record<string, string> = { repo }
+  // Record who dispatched this create (issue #21) — the reply address a
+  // sub-task's bare `send` routes its outcome back to.
+  const payload: Record<string, string> = { repo, ...dispatcherEnvPayload() }
   const title = args.str("title")
   if (title) payload.title = title
   const branch = args.str("branch")
@@ -138,23 +147,87 @@ export async function add(ctx: VerbContext): Promise<unknown> {
   }
 }
 
+/**
+ * The dispatcher recorded on the CALLER's own task, when the caller is a
+ * kobe session with one. `null` (keep the active-task default) when the
+ * caller isn't a kobe session, the task predates the field or was created
+ * outside a kobe session, or the env id is stale.
+ */
+async function readOwnDispatcher(daemon: DaemonRpc): Promise<SerializedTask["dispatcher"] | null> {
+  const selfId = process.env.KOBE_TASK_ID
+  if (!selfId) return null
+  try {
+    const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId: selfId })
+    return res.task.dispatcher ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Pick the tab a dispatcher-defaulted `send` lands on: the exact tab the
+ * work was dispatched from first, the dispatcher task's canonical live
+ * engine tab when that tab has died, and NEVER a silent spawn — with
+ * nothing alive the send fails loud with a typed error, per the 2026-08-12
+ * collaboration-verb design principle (a fallback must not impersonate
+ * success).
+ */
+async function resolveDispatcherTab(
+  runtime: ApiRuntime,
+  dispatcher: { readonly taskId: string; readonly tabId: string },
+): Promise<string | undefined> {
+  const { tabs, running } = await runtime.taskTabs(dispatcher.taskId)
+  // The dispatched-from tab first, addressed only when it reads ALIVE: the
+  // tab join now also lists live sessions the persisted snapshot never
+  // registered (issue #20), so "present and alive" is the honest liveness
+  // test and a tab that is merely gone from the snapshot still gets the
+  // canonical fallback below instead of a TAB_NOT_FOUND at delivery.
+  if (tabs.some((t) => t.id === dispatcher.tabId && t.alive)) return dispatcher.tabId
+  // Dead dispatcher tab → the task's canonical live engine (tab omitted).
+  // Gated on a live engine tab existing: entering the canonical delivery
+  // path with nothing alive would silently boot a NEW engine (issue #19's
+  // failure mode) instead of reaching the dispatcher.
+  if (running) return undefined
+  throw new ApiError(
+    `dispatcher tab ${dispatcher.tabId} on task ${dispatcher.taskId} is dead and the task has no live engine tab — the reply has nowhere to land`,
+    "DISPATCHER_UNREACHABLE",
+    {
+      dispatcher,
+      hint: "address an alive target explicitly with --task-id/--tab (see `kobe api pty-list`), or notify the user with `kobe api notify`",
+      nextCommandArgs: ["api", "pty-list"],
+    },
+  )
+}
+
 export async function send(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const prompt = ctx.args.require("prompt")
-  let taskId = ctx.args.str("task-id")
-  if (!taskId) {
-    const active = await resolveActiveTaskId(daemon)
-    if (!active) {
-      throw new ApiError(
-        "no --task-id given and no active task — open a task first or pass --task-id",
-        "MISSING_TARGET",
-      )
-    }
-    taskId = active
-  }
-  const tab = ctx.args.str("tab")
+  let tab = ctx.args.str("tab")
   if (tab && tab !== "new" && !/^tab-[A-Za-z0-9-]+$/.test(tab)) {
     throw new ApiError(`--tab must be "new" or a tab id like tab-2 (got ${JSON.stringify(tab)})`, "BAD_TAB")
+  }
+  let taskId = ctx.args.str("task-id")
+  if (!taskId) {
+    // Inside a sub-task, a bare `send` is the reply verb: it defaults to the
+    // DISPATCHER (task + tab) that created this task, not the global active
+    // task — the loop's outcome contract (55c990f34) routes completion back
+    // to the dispatching chat tab. An explicit --tab keeps its exact-tab
+    // semantics (on the dispatcher task); the fallback chain only runs for
+    // the tab default.
+    const dispatcher = await readOwnDispatcher(daemon)
+    if (dispatcher) {
+      taskId = dispatcher.taskId
+      if (tab === undefined) tab = await resolveDispatcherTab(ctx.runtime, dispatcher)
+    } else {
+      const active = await resolveActiveTaskId(daemon)
+      if (!active) {
+        throw new ApiError(
+          "no --task-id given and no active task — open a task first or pass --task-id",
+          "MISSING_TARGET",
+        )
+      }
+      taskId = active
+    }
   }
   const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
   const text = ctx.args.bool("plain") ? prompt : await withPeerProvenance(daemon, taskId, prompt)

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -10,9 +10,10 @@ import { kobeApiInvocation } from "../../engine/interactive-command.ts"
 import type { TaskStatus } from "../../types/task.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
-import { daemonOf, dispatcherEnvPayload, simpleRpc } from "./handler-helpers.ts"
+import { dispatcherEnvPayload, readOwnDispatcher, resolveDispatcherTab } from "./dispatcher.ts"
+import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
-import { ApiError, type ApiRuntime, type VerbContext } from "./types.ts"
+import { ApiError, type VerbContext } from "./types.ts"
 
 /**
  * Peer provenance: a `send` issued from INSIDE another kobe task is one
@@ -145,58 +146,6 @@ export async function add(ctx: VerbContext): Promise<unknown> {
     session: delivered.session,
     delivered: delivered.delivered,
   }
-}
-
-/**
- * The dispatcher recorded on the CALLER's own task, when the caller is a
- * kobe session with one. `null` (keep the active-task default) when the
- * caller isn't a kobe session, the task predates the field or was created
- * outside a kobe session, or the env id is stale.
- */
-async function readOwnDispatcher(daemon: DaemonRpc): Promise<SerializedTask["dispatcher"] | null> {
-  const selfId = process.env.KOBE_TASK_ID
-  if (!selfId) return null
-  try {
-    const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId: selfId })
-    return res.task.dispatcher ?? null
-  } catch {
-    return null
-  }
-}
-
-/**
- * Pick the tab a dispatcher-defaulted `send` lands on: the exact tab the
- * work was dispatched from first, the dispatcher task's canonical live
- * engine tab when that tab has died, and NEVER a silent spawn — with
- * nothing alive the send fails loud with a typed error, per the 2026-08-12
- * collaboration-verb design principle (a fallback must not impersonate
- * success).
- */
-async function resolveDispatcherTab(
-  runtime: ApiRuntime,
-  dispatcher: { readonly taskId: string; readonly tabId: string },
-): Promise<string | undefined> {
-  const { tabs, running } = await runtime.taskTabs(dispatcher.taskId)
-  // The dispatched-from tab first, addressed only when it reads ALIVE: the
-  // tab join now also lists live sessions the persisted snapshot never
-  // registered (issue #20), so "present and alive" is the honest liveness
-  // test and a tab that is merely gone from the snapshot still gets the
-  // canonical fallback below instead of a TAB_NOT_FOUND at delivery.
-  if (tabs.some((t) => t.id === dispatcher.tabId && t.alive)) return dispatcher.tabId
-  // Dead dispatcher tab → the task's canonical live engine (tab omitted).
-  // Gated on a live engine tab existing: entering the canonical delivery
-  // path with nothing alive would silently boot a NEW engine (issue #19's
-  // failure mode) instead of reaching the dispatcher.
-  if (running) return undefined
-  throw new ApiError(
-    `dispatcher tab ${dispatcher.tabId} on task ${dispatcher.taskId} is dead and the task has no live engine tab — the reply has nowhere to land`,
-    "DISPATCHER_UNREACHABLE",
-    {
-      dispatcher,
-      hint: "address an alive target explicitly with --task-id/--tab (see `kobe api pty-list`), or notify the user with `kobe api notify`",
-      nextCommandArgs: ["api", "pty-list"],
-    },
-  )
 }
 
 export async function send(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -115,7 +115,7 @@ export const VERBS: readonly VerbSpec[] = [
   {
     name: "get-task",
     summary:
-      "Read one task's metadata + terminal tabs. `.running` = any hosted engine tab is live; `.tabs[]` (id/kind/vendor/liveVendor/lastTitle/alive) is the discovery read for `send --tab tab-N`.",
+      "Read one task's metadata + terminal tabs. `.running` = any hosted engine tab is live; `.tabs[]` (id/kind/vendor/liveVendor/lastTitle/alive) is the discovery read for `send --tab tab-N`; `.task.dispatcher` = the kobe session (task+tab) that created it, when one did.",
     flags: [F.taskId()],
     handler: getTask,
   },
@@ -177,7 +177,7 @@ export const VERBS: readonly VerbSpec[] = [
   {
     name: "send",
     summary:
-      "Paste a follow-up prompt into a task's running engine (one full turn). Defaults to the active task. Sent from inside another kobe task ($KOBE_TASK_ID), the prompt is prefixed with [KOBE PEER] provenance — who sent it and how to reply — so agent-to-agent messaging needs no coordinator.",
+      "Paste a follow-up prompt into a task's running engine (one full turn). Without --task-id, a task spawned from another kobe session replies to its dispatcher's tab (then that task's live canonical engine; nothing alive = DISPATCHER_UNREACHABLE, never a silent spawn); otherwise the active task. Sent from inside another kobe task ($KOBE_TASK_ID), the prompt is prefixed with [KOBE PEER] provenance — who sent it and how to reply (tab-precise) — so agent-to-agent messaging needs no coordinator.",
     flags: [
       F.taskId(false),
       F.prompt(true, "Text pasted + submitted into the engine pane."),
@@ -329,7 +329,7 @@ export const VERBS: readonly VerbSpec[] = [
   {
     name: "collect",
     summary:
-      "Read-only comparison snapshot of several tasks: identity, branch, .running, uncommitted .changes, and committed .base (ahead count + diffstat vs the base branch).",
+      "Read-only comparison snapshot of several tasks: identity, branch, lineage (.dispatcher, .groupId), .running, uncommitted .changes, and committed .base (ahead count + diffstat vs the base branch).",
     flags: [
       { name: "task-ids", type: "csv", placeholder: "a,b,c", description: "Comma-separated task ids." },
       F.repo(false),

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -391,6 +391,7 @@ export function deserializeTask(s: SerializedTask): Task {
     modelEffort: s.modelEffort,
     groupId: s.groupId,
     deletion: s.deletion,
+    dispatcher: s.dispatcher,
     createdAt: s.createdAt,
     updatedAt: s.updatedAt,
   }

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -38,7 +38,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * marker is below this number is STALE: the binary moved on, the skill
  * didn't, so we prompt the developer to re-run `kobe skill install`.
  */
-export const KOBE_SKILL_VERSION = 16
+export const KOBE_SKILL_VERSION = 17
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -8,7 +8,7 @@ import { type ReadableState, type StateCell, createStateCell } from "../lib/exte
 import { readLastActiveTaskId, writeLastActiveTaskId } from "../state/last-active.ts"
 import { getRemoteRepoConfig, getSavedRepos, removeSavedRepo } from "../state/repos.ts"
 import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
-import type { Task, TaskId, TaskPRStatus, TaskStatus, VendorId } from "../types/task.ts"
+import type { Task, TaskDispatcher, TaskId, TaskPRStatus, TaskStatus, VendorId } from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 import { canonPath, normalizeMainRepo, randomDirTaskSuffix, titleFromRepo } from "./core-helpers.ts"
@@ -45,6 +45,8 @@ export interface CreateTaskInput {
   readonly modelEffort?: string
   /** Fan-out round marker shared by all siblings of one fan-out call. */
   readonly groupId?: string
+  /** The kobe session (task + tab) dispatching this create, when one is. */
+  readonly dispatcher?: TaskDispatcher
 }
 
 export type Unsubscribe = () => void
@@ -213,6 +215,7 @@ export class Orchestrator {
       vendor: input.vendor ?? DEFAULT_TASK_VENDOR,
       ...(input.modelEffort ? { modelEffort: input.modelEffort } : {}),
       ...(input.groupId ? { groupId: input.groupId } : {}),
+      ...(input.dispatcher ? { dispatcher: input.dispatcher } : {}),
     })
     // Remember the optional baseRef on a side-map so `ensureWorktree`
     // can use it. Not on the Task itself: base-ref is one-shot input

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -20,6 +20,7 @@ import { copyFile } from "node:fs/promises"
 import type {
   Task,
   TaskDeletionState,
+  TaskDispatcher,
   TaskLinkedWorkItem,
   TaskPRStatus,
   TaskQuotaResumeState,
@@ -159,6 +160,7 @@ function coerceTask(value: unknown): Task | null {
   const deletion = coerceDeletion(v.deletion)
   const quotaResume = coerceQuotaResume(v.quotaResume)
   const linkedWorkItem = coerceLinkedWorkItem(v.linkedWorkItem)
+  const dispatcher = coerceDispatcher(v.dispatcher)
 
   return {
     id: toTaskId(v.id),
@@ -189,9 +191,21 @@ function coerceTask(value: unknown): Task | null {
     // lost the tracker item it was started from.
     ...(quotaResume ? { quotaResume } : {}),
     ...(linkedWorkItem ? { linkedWorkItem } : {}),
+    // Reply address for the collaboration loop (issue #21) — must survive the
+    // load coercion or a daemon restart severs every sub-task's route home.
+    // Records that predate the field normalize to undefined.
+    ...(dispatcher ? { dispatcher } : {}),
     createdAt: v.createdAt,
     updatedAt: v.updatedAt,
   }
+}
+
+function coerceDispatcher(value: unknown): TaskDispatcher | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const v = value as Record<string, unknown>
+  if (typeof v.taskId !== "string" || v.taskId.length === 0) return undefined
+  if (typeof v.tabId !== "string" || v.tabId.length === 0) return undefined
+  return { taskId: v.taskId, tabId: v.tabId }
 }
 
 function coerceQuotaResume(value: unknown): TaskQuotaResumeState | undefined {

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -105,6 +105,19 @@ export interface TaskQuotaResumeState {
 }
 
 /**
+ * Provenance of the kobe session that created this task: which task and
+ * which terminal tab dispatched it (from the creating CLI process's
+ * `$KOBE_TASK_ID` / `$KOBE_TAB_ID`). This is the reply address for the
+ * collaboration loop — a sub-task's bare `send` routes its outcome back to
+ * this exact tab. Absent when the task was created outside a kobe session
+ * (TUI dialog, plain shell) and on records that predate the field.
+ */
+export interface TaskDispatcher {
+  readonly taskId: string
+  readonly tabId: string
+}
+
+/**
  * One task. Stored in `~/.kobe/tasks.json` as part of {@link TaskIndex}.
  *
  * Field invariants:
@@ -182,6 +195,8 @@ export interface Task {
   readonly quotaResume?: TaskQuotaResumeState
   /** The external tracker item this task was started from, when it was. */
   readonly linkedWorkItem?: TaskLinkedWorkItem
+  /** The kobe session (task + tab) that dispatched this task, when one did. */
+  readonly dispatcher?: TaskDispatcher
   readonly createdAt: string
   readonly updatedAt: string
 }

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Dispatcher provenance — the collaboration loop's reply address (issue #21).
+ *
+ * The contract under test is RECEIVER-side routing, not sender-side success:
+ * a create records who dispatched it, a worker's bare `send` must land on
+ * that exact tab (then the dispatcher task's live canonical engine, then
+ * fail LOUD) — never on a freshly spawned engine that swallows the reply.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { normalizeIndex } from "../../src/orchestrator/index/store-codec.ts"
+import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
+
+const savedTaskId = process.env.KOBE_TASK_ID
+const savedTabId = process.env.KOBE_TAB_ID
+
+function restoreEnv(name: string, saved: string | undefined): void {
+  if (saved === undefined) {
+    delete process.env[name]
+  } else process.env[name] = saved
+}
+
+beforeEach(() => {
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TASK_ID
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TAB_ID
+})
+afterEach(() => {
+  restoreEnv("KOBE_TASK_ID", savedTaskId)
+  restoreEnv("KOBE_TAB_ID", savedTabId)
+})
+
+describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
+  it("add sends the caller's task + tab to task.create", async () => {
+    process.env.KOBE_TASK_ID = "disp-1"
+    process.env.KOBE_TAB_ID = "tab-2"
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })
+    expect(client.requests[0].payload).toEqual({
+      repo: "/repo/x",
+      dispatcherTaskId: "disp-1",
+      dispatcherTabId: "tab-2",
+    })
+  })
+
+  it("add without $KOBE_TAB_ID floors the tab to the canonical tab-1", async () => {
+    process.env.KOBE_TASK_ID = "disp-1"
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })
+    expect(client.requests[0].payload).toMatchObject({ dispatcherTaskId: "disp-1", dispatcherTabId: "tab-1" })
+  })
+
+  it("add from a plain shell records nothing", async () => {
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })
+    expect(client.requests[0].payload).toEqual({ repo: "/repo/x" })
+  })
+
+  it("fan-out records the same dispatcher on every sibling", async () => {
+    process.env.KOBE_TASK_ID = "disp-1"
+    process.env.KOBE_TAB_ID = "tab-3"
+    const client = new FakeClient({
+      "task.create": (_payload, i) => ({ taskId: `t${i}`, task: taskFixture({ id: `t${i}` }) }),
+    })
+    const { deliver } = recordingDelivery()
+    await invokeVerb("fan-out", ["--repo", "/repo/x", "--count", "2", "--prompt", "go"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    const creates = client.requests.filter((r) => r.name === "task.create")
+    expect(creates).toHaveLength(2)
+    for (const create of creates) {
+      expect(create.payload).toMatchObject({ dispatcherTaskId: "disp-1", dispatcherTabId: "tab-3" })
+    }
+  })
+})
+
+describe("bare send replies to the dispatcher", () => {
+  function workerClient(dispatcher: unknown): FakeClient {
+    return new FakeClient({
+      "task.get": (payload) => {
+        const { taskId } = payload as { taskId: string }
+        if (taskId === "worker-1") return { task: taskFixture({ id: "worker-1", title: "Worker", dispatcher }) }
+        return { task: taskFixture({ id: taskId, title: "Coordinator" }) }
+      },
+    })
+  }
+
+  beforeEach(() => {
+    process.env.KOBE_TASK_ID = "worker-1"
+    process.env.KOBE_TAB_ID = "tab-9"
+  })
+
+  it("lands on the dispatcher's exact tab when it is alive", async () => {
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--prompt", "succeeded: done"], {
+      client,
+      runtime: stubRuntime({
+        deliverPrompt: deliver,
+        taskTabs: async () => ({
+          tabs: [{ id: "tab-2", kind: "engine", alive: true } as never],
+          running: true,
+        }),
+      }),
+    })
+    // Never consults the active task — the dispatcher IS the default target.
+    expect(client.subscribeCount).toBe(0)
+    expect(calls[0].target).toMatchObject({ id: "disp-1", tab: "tab-2" })
+  })
+
+  it("falls back to the dispatcher task's canonical engine when the tab died", async () => {
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--prompt", "succeeded: done"], {
+      client,
+      runtime: stubRuntime({
+        deliverPrompt: deliver,
+        taskTabs: async () => ({
+          tabs: [
+            { id: "tab-2", kind: "engine", alive: false } as never,
+            { id: "tab-3", kind: "engine", alive: true } as never,
+          ],
+          running: true,
+        }),
+      }),
+    })
+    expect(calls[0].target.id).toBe("disp-1")
+    expect(calls[0].target.tab).toBeUndefined()
+  })
+
+  it("falls back the same way when the dispatcher tab is gone from the join entirely", async () => {
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--prompt", "succeeded: done"], {
+      client,
+      runtime: stubRuntime({
+        deliverPrompt: deliver,
+        taskTabs: async () => ({ tabs: [{ id: "tab-3", kind: "engine", alive: true } as never], running: true }),
+      }),
+    })
+    // An absent tab must not be addressed exactly (TAB_NOT_FOUND at
+    // delivery) — the canonical live engine is the next rung down.
+    expect(calls[0].target.tab).toBeUndefined()
+  })
+
+  it("fails LOUD when the dispatcher task has nothing alive — never a silent spawn", async () => {
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    const { calls, deliver } = recordingDelivery()
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--prompt", "succeeded: done"], {
+          client,
+          runtime: stubRuntime({
+            deliverPrompt: deliver,
+            taskTabs: async () => ({
+              tabs: [{ id: "tab-2", kind: "engine", alive: false } as never],
+              running: false,
+            }),
+          }),
+        }),
+      "DISPATCHER_UNREACHABLE",
+    )
+    // The delivery layer is never entered: a dead reply target must not
+    // boot a fresh engine that swallows the outcome (issue #19's mode).
+    expect(calls).toHaveLength(0)
+  })
+
+  it("an explicit --tab keeps exact-tab semantics on the dispatcher task", async () => {
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    const { calls, deliver } = recordingDelivery()
+    const taskTabs = async (): Promise<never> => {
+      throw new Error("explicit --tab must not run the fallback chain")
+    }
+    await invokeVerb("send", ["--tab", "tab-7", "--prompt", "hi"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver, taskTabs }),
+    })
+    expect(calls[0].target).toMatchObject({ id: "disp-1", tab: "tab-7" })
+  })
+
+  it("a task without a dispatcher keeps the active-task default", async () => {
+    const client = workerClient(undefined)
+    client.replay.push({ channel: "active-task", payload: { taskId: "active-1" } })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--prompt", "hi"], { client, runtime: stubRuntime({ deliverPrompt: deliver }) })
+    expect(client.subscribeCount).toBe(1)
+    expect(calls[0].target.id).toBe("active-1")
+  })
+
+  it("the [KOBE PEER] reply command is tab-precise (sender's $KOBE_TAB_ID)", async () => {
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "disp-1", "--prompt", "hi"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(calls[0].prompt).toContain("send --task-id worker-1 --tab tab-9 --prompt")
+  })
+})
+
+describe("persistence codec", () => {
+  function row(over: Record<string, unknown>): Record<string, unknown> {
+    return {
+      id: "01HXTASKAAAAAAAAAAAAAAAAA",
+      title: "T",
+      repo: "/repo/x",
+      branch: "kobe/t",
+      worktreePath: "/wt/t",
+      status: "backlog",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      ...over,
+    }
+  }
+
+  it("dispatcher survives the load coercion", () => {
+    const { tasks } = normalizeIndex(
+      { version: 3, tasks: [row({ dispatcher: { taskId: "disp-1", tabId: "tab-2" } })] },
+      "test",
+    )
+    expect(tasks[0].dispatcher).toEqual({ taskId: "disp-1", tabId: "tab-2" })
+  })
+
+  it("records without the field (and malformed values) normalize to undefined", () => {
+    const { tasks } = normalizeIndex(
+      { version: 3, tasks: [row({}), row({ dispatcher: { taskId: "disp-1" } }), row({ dispatcher: "disp-1" })] },
+      "test",
+    )
+    expect(tasks).toHaveLength(3)
+    for (const task of tasks) expect(task.dispatcher).toBeUndefined()
+  })
+})

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -9,6 +9,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { dispatcherEnvPayload } from "../../src/cli/api/dispatcher.ts"
 import { normalizeIndex } from "../../src/orchestrator/index/store-codec.ts"
 import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
 
@@ -30,6 +31,18 @@ beforeEach(() => {
 afterEach(() => {
   restoreEnv("KOBE_TASK_ID", savedTaskId)
   restoreEnv("KOBE_TAB_ID", savedTabId)
+})
+
+describe("dispatcherEnvPayload", () => {
+  it("carries both ids, floors a missing tab, and stays empty without a task id", () => {
+    expect(dispatcherEnvPayload({ KOBE_TASK_ID: "d1", KOBE_TAB_ID: "tab-4" })).toEqual({
+      dispatcherTaskId: "d1",
+      dispatcherTabId: "tab-4",
+    })
+    expect(dispatcherEnvPayload({ KOBE_TASK_ID: "d1" })).toEqual({ dispatcherTaskId: "d1", dispatcherTabId: "tab-1" })
+    expect(dispatcherEnvPayload({ KOBE_TAB_ID: "tab-4" })).toEqual({})
+    expect(dispatcherEnvPayload({})).toEqual({})
+  })
 })
 
 describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -4,6 +4,27 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { ApiError, type ApiRuntime, invokeVerb } from "../../src/cli/api-cmd.ts"
 import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
 
+// Peer provenance AND dispatcher provenance both key off the caller's own
+// $KOBE_TASK_ID/$KOBE_TAB_ID — unset them file-wide so exact-payload
+// assertions stay deterministic when the runner itself lives inside a kobe
+// task. Tests that WANT provenance set them in their own beforeEach.
+const savedEnv = { taskId: process.env.KOBE_TASK_ID, tabId: process.env.KOBE_TAB_ID }
+beforeEach(() => {
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TASK_ID
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TAB_ID
+})
+afterEach(() => {
+  for (const [name, value] of [
+    ["KOBE_TASK_ID", savedEnv.taskId],
+    ["KOBE_TAB_ID", savedEnv.tabId],
+  ] as const) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
 describe("add handler", () => {
   it("creates without stealing focus", async () => {
     const task = taskFixture()
@@ -90,20 +111,6 @@ describe("add handler", () => {
 })
 
 describe("send handler", () => {
-  // Provenance keys off $KOBE_TASK_ID — make the baseline tests deterministic
-  // even when the runner itself lives inside a kobe task.
-  const savedEnvTaskId = process.env.KOBE_TASK_ID
-  beforeEach(() => {
-    // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
-    delete process.env.KOBE_TASK_ID
-  })
-  afterEach(() => {
-    if (savedEnvTaskId === undefined) {
-      // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
-      delete process.env.KOBE_TASK_ID
-    } else process.env.KOBE_TASK_ID = savedEnvTaskId
-  })
-
   it("uses an explicit target without consulting active task", async () => {
     const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
     const { calls, deliver } = recordingDelivery()


### PR DESCRIPTION
Closes the protocol gap in local issue #21: a task never recorded **who dispatched it**, so nothing in the system knew where a reply belonged.

## The failure mode (why this must fail loud)

This session is its own reproduction. Talking to a peer task worked only because every message carried an explicit `--tab tab-2`, hand-copied from `inspect`. That contrast is the whole bug:

| | behavior before |
|---|---|
| `send --task-id X --tab tab-2` | lands in tab-2. Correct — but the tab id has to come from a human or an `inspect` round-trip. |
| `send --task-id X` (no `--tab`) | canonical-tab resolution. When that tab is gone, delivery spawns a **new** engine and returns `ok: true` — sender thinks it replied, receiver never hears anything (#19). |
| `send` (no ids at all, from a spawned worker) | targets the global *active task* — whatever the user happens to be looking at, not the agent that dispatched the work. |

So the loop only closed while a human relayed tab ids. The dispatcher-tab default is the missing piece; `DISPATCHER_UNREACHABLE` is what makes its absence visible instead of fake-successful, per the 2026-08-12 rule that a collaboration verb's fallback must never impersonate success (`workerReport` silently not persisting was the first offence, `send` silently spawning the second).

## What this completes, not what it invents

`report`/`await` verbs existed (f959042b4) and were deliberately removed (55c990f34) in favour of "the outcome flows back through `send` into the dispatching chat tab". That decision stands — it just had no routable address. `dispatcher: {taskId, tabId}` is that address.

## Change

All of it lives in one new module, `packages/kobe/src/cli/api/dispatcher.ts` (stamping + routing as a single concern).

- **`Task.dispatcher?: {taskId, tabId}`** — stamped at creation by `add` / `fan-out` from the calling engine tab's `$KOBE_TASK_ID` / `$KOBE_TAB_ID` (read in the CLI process; the daemon has no caller env). Creates from a plain shell or the TUI record nothing; the tab floor is `tab-1`. Persisted, coerced on load, absent on old records.
- **Bare `send` is the reply verb.** No `--task-id` inside a task that has a dispatcher → deliver to that exact tab → if it isn't alive, the dispatcher task's live canonical engine tab → if nothing there is alive, throw `DISPATCHER_UNREACHABLE` with the dispatcher in the payload and a `pty-list` next-command hint. No dispatcher on record keeps the existing active-task default; an explicit `--tab` keeps exact-tab semantics.
- **`[KOBE PEER]` reply command is tab-precise** — `send --task-id <sender> --tab <sender's tab>` instead of task-only, so a reply doesn't re-enter the canonical-resolution path that breaks.
- **Lineage is readable**: `get-task` returns `.task.dispatcher`, `collect` adds `.dispatcher` per row.
- SKILL.md peer/completion sections rewritten + `KOBE_SKILL_VERSION` 17 (16 is #408's; agreed hand-off since this lands second), `docs/API.md` updated for the changed `send` default and the new fields.

## Tests

`packages/kobe/test/cli/api-dispatcher.test.ts` — 14 cases, **9 of them fail on `main`** (verified by stashing the `src/` half: 9 failed / 3 passed). They assert receiver-side routing, not sender-side success:

- creation stamps task+tab; missing `$KOBE_TAB_ID` floors to `tab-1`; plain-shell create stamps nothing; every fan-out sibling shares one dispatcher.
- alive dispatcher tab → addressed exactly, and the active task is never consulted.
- dead dispatcher tab → canonical fallback; tab absent from the join → same fallback (not a `TAB_NOT_FOUND` at delivery).
- nothing alive → `DISPATCHER_UNREACHABLE` **and the delivery layer is never entered** (`calls` is empty) — the assertion that pins "no silent spawn".
- explicit `--tab` bypasses the fallback chain; no dispatcher keeps the active-task default; peer prefix carries `--tab`.
- codec: dispatcher survives a load round-trip; missing/malformed values normalize to `undefined`.

`api-handlers.test.ts` gains file-level `$KOBE_TASK_ID`/`$KOBE_TAB_ID` isolation — its exact-payload `add` assertions were only deterministic while nothing stamped provenance, and the test runner itself lives inside a kobe task.

## Interaction with the sibling PRs

- **#19** landed as #408 and this branch is rebased on top of it. Its narrowed canonical path (spawn only when the task has *no* alive session) and this PR's `running` gate are complementary: a cold start is right for a first prompt and wrong for a reply, so a reply with nothing alive on the dispatcher task stops at `DISPATCHER_UNREACHABLE` instead of booting an engine nobody asked for. `KOBE_SKILL_VERSION` 16 went to #408 as agreed, so this is 17, and the SKILL.md peer/send text is layered on #408's wording rather than replacing it.
- **#20** landed as #407, and its join is load-bearing here: because unregistered live sessions now appear as tabs, the dispatcher-tab liveness test is a positive `present && alive` check.

Verified on a real machine (isolated `KOBE_HOME_DIR` + private daemon socket, this branch's CLI from source). One of the four checks is the one that proves the bug is *fixed* rather than merely recorded — worth reading first:

> **The failure path has someone watching it.** A bare `send` from the worker, with the dispatcher's tab dead and nothing else alive on that task, prints `DISPATCHER_UNREACHABLE` and **exits 1**. No engine is spawned. The defect was never "can't find the target" — it was "can't find the target *and reports success*".

The other three confirm the record itself: a plain-shell `add` stamps no dispatcher; an `add` carrying `$KOBE_TASK_ID`/`$KOBE_TAB_ID=tab-2` persists `dispatcher: {taskId, tabId: "tab-2"}`; and the field survives a `daemon restart`, showing up in both `get-task` and `collect`.

Full suite green (2945 + 513), repo-root lint + typecheck clean, `scripts/coverage-gate.mjs` clean locally, every touched file ≤500 lines.


