### PR TITLE
feat: send --tab new takes a --vendor, so one worktree can run two agents

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: kobe
 description: Use when controlling kobe tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell.
 ---
 
-<!-- kobe-skill-version: 18 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- kobe-skill-version: 19 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # kobe shell control
 
@@ -107,6 +107,7 @@ the first row that fits:
 | "split", "side by side", "keep an eye on X while…" | a new region in the CURRENT tab | `kobe api pane-open --command "…"` |
 | names a tab: "tell the agent in tab 3" | that exact tab | `kobe api send --task-id <id> --tab tab-3 --prompt "…"` |
 | a LOCATION word: "in this workspace/worktree/checkout", "on this branch", "here", "same task" | THIS task, a NEW Terminal Tab | `kobe api send --task-id "$KOBE_TASK_ID" --tab new --prompt "…"` |
+| names an ENGINE for the same files: "let codex take over here", "try this one with claude instead" | THIS task, a new tab pinned to that engine | `kobe api send --task-id "$KOBE_TASK_ID" --tab new --vendor codex --prompt "…"` |
 | **anything else — no row above matched** | a NEW task — new worktree + branch | `kobe api add --repo "$PWD" --prompt "…"` |
 
 Order is the tiebreak: a count ("3 ways in this workspace") beats a location
@@ -174,6 +175,10 @@ kobe api send --prompt "succeeded: <one line> (branch <final branch>)"
 kobe api inspect --task-id <id>
 kobe api send --task-id <id> --tab tab-3 --prompt "<turn>"  # exact alive tab
 kobe api send --task-id <id> --tab new --prompt "<turn>"    # fresh engine tab
+# Same worktree, DIFFERENT agent — the API twin of the TUI's ctrl+e pick. The
+# engine is pinned to that tab (survives restarts, unaffected by a later
+# set-vendor) and the task's own vendor is left alone. --tab new only.
+kobe api send --task-id <id> --tab new --vendor codex --prompt "<turn>"
 
 kobe api get-task --task-id <id>
 kobe api collect --task-ids <id1>,<id2>,<id3> --pretty

--- a/.changeset/send-tab-vendor.md
+++ b/.changeset/send-tab-vendor.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+`kobe api send --tab new` takes a `--vendor` now, so one worktree can run two different agents on the same files — hand stuck work to codex without leaving the branch, the API twin of the TUI's ctrl+e engine pick. The engine is pinned to that tab (survives restarts and a later `set-vendor`) while the task's own vendor is left alone; `--vendor` on an existing tab is refused rather than silently downgraded to the task's engine. Skill version 19 documents the routing.

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -13,7 +13,7 @@ import type { DaemonRpc } from "../daemon-session.ts"
 import { dispatcherEnvPayload, readOwnDispatcher, resolveDispatcherTab } from "./dispatcher.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
-import { ApiError, type VerbContext } from "./types.ts"
+import { ApiError, type VerbContext, helpStep } from "./types.ts"
 
 /**
  * Peer provenance: a `send` issued from INSIDE another kobe task is one
@@ -155,6 +155,18 @@ export async function send(ctx: VerbContext): Promise<unknown> {
   if (tab && tab !== "new" && !/^tab-[A-Za-z0-9-]+$/.test(tab)) {
     throw new ApiError(`--tab must be "new" or a tab id like tab-2 (got ${JSON.stringify(tab)})`, "BAD_TAB")
   }
+  // A pinned engine only means something on a tab being CREATED: an alive
+  // tab already runs whatever it runs, and the canonical tab belongs to the
+  // task's own vendor. Refuse rather than silently ignore — a caller that
+  // asked for codex must not get claude and a success exit.
+  const tabVendor = ctx.args.vendor()
+  if (tabVendor && tab !== "new") {
+    throw new ApiError(
+      `--vendor only applies to a new tab; pass --tab new (got --tab ${tab ?? "<canonical>"})`,
+      "BAD_FLAG",
+      helpStep("send"),
+    )
+  }
   let taskId = ctx.args.str("task-id")
   if (!taskId) {
     // Inside a sub-task, a bare `send` is the reply verb: it defaults to the
@@ -186,10 +198,14 @@ export async function send(ctx: VerbContext): Promise<unknown> {
       id: taskId,
       worktreePath: res.task.worktreePath,
       kind: res.task.kind,
-      vendor: res.task.vendor as VendorId | undefined,
-      modelEffort: res.task.modelEffort,
+      // The pinned engine wins for THIS delivery's argv; the task's own
+      // vendor stays untouched (a second agent in the worktree is not a
+      // change of the task's engine).
+      vendor: tabVendor ?? (res.task.vendor as VendorId | undefined),
+      modelEffort: tabVendor ? undefined : res.task.modelEffort,
       repo: res.task.repo,
       tab,
+      tabVendor,
     },
     text,
   )

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -51,7 +51,7 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
       const engineBin = interactiveEngineCommand(target.vendor, target.modelEffort)[0]
       return await deliverToExactTab(host.rpc, target.id, target.tab, worktree, prompt, { engineBin })
     }
-    const newTab = target.tab === "new" ? mintCliTab(target.id) : undefined
+    const newTab = target.tab === "new" ? mintCliTab(target.id, target.tabVendor) : undefined
     const argv = interactiveEngineCommand(target.vendor, target.modelEffort)
     const launch = buildEngineSessionLaunch({
       task: { id: target.id, kind: target.kind, vendor: target.vendor, repo: target.repo },

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -25,6 +25,7 @@ import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { loadStateFile, patchStateFile } from "../../state/store.ts"
 import { terminalTabsKey } from "../../tui-react/workspace/terminal-tabs-persist.ts"
 import { type TabsState, type TerminalTab, initialTabs } from "../../tui/workspace/terminal-tabs-core.ts"
+import type { VendorId } from "../../types/vendor.ts"
 
 /**
  * One tab row `get-task` returns: the persisted snapshot fields the sidebar
@@ -207,7 +208,7 @@ export function publishCliTabSnapshot(taskId: string): void {
  * state.json is unwritable, so the id is returned regardless and the
  * snapshot write failure only costs sidebar visibility.
  */
-export function mintCliTab(taskId: string): string {
+export function mintCliTab(taskId: string, vendor?: VendorId): string {
   let tabId = "tab-1"
   try {
     const key = terminalTabsKey(taskId)
@@ -218,7 +219,10 @@ export function mintCliTab(taskId: string): string {
     patchStateFile({
       [key]: {
         ...state,
-        tabs: [...state.tabs, { kind: "engine", id: tabId, title: null, ordinal }],
+        // `vendor` present = this tab is PINNED to an engine other than the
+        // task's default (`send --vendor`), the same field the TUI's ctrl+e
+        // pick writes. Absent, the tab follows the task like every other.
+        tabs: [...state.tabs, { kind: "engine", id: tabId, title: null, ordinal, ...(vendor ? { vendor } : {}) }],
         activeId: tabId,
         nextOrdinal: ordinal + 1,
       },

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -106,6 +106,13 @@ export interface PromptTarget {
    */
   readonly tab?: string
   /**
+   * Engine to PIN on a `--tab new` tab (`send --vendor`), when it should not
+   * simply inherit the task's. Recorded on the minted tab exactly like the
+   * TUI's ctrl+e pick, so the tab keeps that engine across restarts and a
+   * later `set-vendor` on the task does not silently move it.
+   */
+  readonly tabVendor?: VendorId
+  /**
    * This delivery is the FIRST prompt of a task the caller just created
    * (`add --prompt` / `fan-out`) — it gets the branch-rename coda (see
    * `PromptDeliveryIntent`'s `new-task` kind). `send` never sets it.

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -190,6 +190,11 @@ export const VERBS: readonly VerbSpec[] = [
           'Tab addressing: "new" spawns the prompt in a fresh engine tab; "tab-N" delivers to that exact alive tab (error when dead/absent). Omitted = the canonical engine tab.',
       },
       {
+        ...F.vendor(),
+        description:
+          "Engine for a `--tab new` tab — the API twin of the TUI's ctrl+e pick. Lets one worktree run two agents on the same files (e.g. hand the stuck work to codex without leaving the branch). Pinned to that tab, so it survives restarts and a later set-vendor. Only valid with --tab new.",
+      },
+      {
         name: "plain",
         type: "bool",
         required: false,

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -38,7 +38,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * marker is below this number is STALE: the binary moved on, the skill
  * didn't, so we prompt the developer to re-run `kobe skill install`.
  */
-export const KOBE_SKILL_VERSION = 18
+export const KOBE_SKILL_VERSION = 19
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -169,6 +169,31 @@ describe("send handler", () => {
     expect(calls[1].target.tab).toBe("tab-3")
   })
 
+  it("a new tab can run a DIFFERENT engine than the task (two agents, one worktree)", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc", vendor: "claude" }) }) })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "new", "--vendor", "codex"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    // The delivery runs codex and the tab records it, while the TASK's own
+    // vendor is untouched — a second agent in the worktree is not a switch.
+    expect(calls[0].target).toMatchObject({ vendor: "codex", tabVendor: "codex" })
+    expect(client.requests.some((r) => r.name === "task.setVendor")).toBe(false)
+  })
+
+  it("refuses --vendor without --tab new instead of silently running the task's engine", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "tab-3", "--vendor", "codex"], {
+          client,
+          runtime: stubRuntime(),
+        }),
+      "BAD_FLAG",
+    )
+  })
+
   it("rejects a malformed --tab before any delivery", async () => {
     const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
     await expectApiError(


### PR DESCRIPTION
## Summary
- Choosing the engine for a NEW chat tab was a TUI-only gesture (ctrl+e → `addTab(state, vendor)`); over the API a new tab always inherited the task's vendor. So the one thing an agent could not do was what the owner does by hand: keep the branch and the files, hand the stuck work to a different engine. `kobe api send --task-id <id> --tab new --vendor codex --prompt "…"` now does exactly that.
- The vendor is **pinned to the minted tab** (`mintCliTab` writes `vendor` on the snapshot tab, the same field ctrl+e writes), so it survives restarts and a later `set-vendor` on the task; the **task's own vendor is untouched** — a second agent in the worktree is not an engine switch.
- `--vendor` without `--tab new` is refused with `BAD_FLAG` + `--help` recovery args. Silently falling back to the task's engine would hand a caller who asked for codex a claude session and a zero exit.
- Skill 17 → 19 documents the routing ("let codex take over here" → tab + `--vendor`, not a new task).

## Test plan
- [x] `vitest run test/cli test/lib` (65 files green), including two new cases: the cross-engine tab threads `vendor` + `tabVendor` and never issues `task.setVendor`; `--vendor` on an existing tab raises `BAD_FLAG`
- [x] `bun run lint`, `bun run typecheck`
- [ ] Owner spot-check: `send --tab new --vendor codex` in a claude task opens a codex tab in the SAME worktree, and the sidebar row still reads claude for the task