### PR TITLE
fix: a completion you already read stays read across a kobe restart

### DIFF
--- a/.changeset/unread-lamp-survives-restart.md
+++ b/.changeset/unread-lamp-survives-restart.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Sidebar completions you have already read stay read after a restart. The unread lamp's seen bit lived only in the running TUI, while the daemon keeps reporting the same finished turn — so relaunching kobe re-lit every session you had already looked at. The seen mark is now persisted per (task, tab) with the completion's own timestamp, so a new turn still arrives unread.

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -32,9 +32,11 @@ import {
 import { toneColor, truncateBranchLabel } from "../../../tui/panes/sidebar/view-core"
 import { type WorktreeChanges, pickPushedChanges } from "../../../tui/panes/sidebar/worktree-changes"
 import { pollWorktreeChanges, worktreeChanges } from "../../../tui/panes/sidebar/worktree-changes-poller"
+import { useOptionalKV } from "../../context/kv"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { resolveRowSelectionChrome } from "../../ui/row-selection-chrome"
+import { completionSeenAt, completionSeenKey, markCompletionSeen } from "../../workspace/completion-seen"
 import type { SidebarHover } from "./types"
 
 export type SidebarRowCardSharedProps = {
@@ -190,9 +192,13 @@ function RowBody(props: {
  */
 /**
  * Rows whose CURRENT `turn_complete` the user has already looked at
- * (selected while complete) — the herdr "seen" bit driving ● → ✓. Session
- * scope is deliberate: a fresh attach starts everything unseen. Cleared the
+ * (selected while complete) — the herdr "seen" bit driving ● → ✓. Cleared the
  * moment that row's activity state moves off `turn_complete`.
+ *
+ * Process-scoped, and that used to be the whole record: the daemon's activity
+ * registry outlives the TUI, so relaunching kobe re-lit every completion you
+ * had already read (issue #22). The durable mark in `workspace/completion-seen`
+ * is what survives the restart; this Set stays the same-render answer.
  *
  * Keyed per ROW (task, or task+tab in the tree), not per task: a task owns
  * several tab rows, and they render in the same pass. With a task-wide key
@@ -212,20 +218,57 @@ const completionSeenIds = new Set<string>()
  *
  * `tabId` scopes the bit to one tab row; omit it for the flat sidebar's
  * task cards, which own the task's whole activity rollup.
+ *
+ * `durableSeen` is the persisted answer for the SAME completion (see
+ * {@link useDurableCompletionSeen}) — ORed in rather than folded into the
+ * Set, because it is computed against the current completion's timestamp and
+ * therefore un-sets itself the moment a newer turn completes.
  */
 export function completionSeenFor(
   taskId: string,
   activityState: string | undefined,
   viewing: boolean,
   tabId?: string,
+  durableSeen = false,
 ): boolean {
-  const key = tabId === undefined ? taskId : `${taskId} ${tabId}`
+  const key = completionSeenKey(taskId, tabId)
   if (activityState === "turn_complete") {
     if (viewing) completionSeenIds.add(key)
   } else {
     completionSeenIds.delete(key)
   }
-  return completionSeenIds.has(key)
+  return completionSeenIds.has(key) || durableSeen
+}
+
+/** The stamp a row's seen mark is keyed on, or undefined when the row is not
+ *  sitting on a completion at all. */
+export function completionStampOf(activity: TaskEngineState | undefined): number | undefined {
+  return activity?.state === "turn_complete" ? activity.at : undefined
+}
+
+/**
+ * Persisted half of the seen bit (issue #22): read the stored mark at render
+ * time, and record this completion while you are looking at it.
+ *
+ * The write is an EFFECT on purpose — `kv.set` re-renders every KV consumer,
+ * so writing during render would update the provider while another component
+ * renders. A row with no KV provider (render tests, panes mounted outside the
+ * context) keeps the session-only behaviour.
+ */
+export function useDurableCompletionSeen(
+  taskId: string,
+  tabId: string | undefined,
+  completionAt: number | undefined,
+  viewing: boolean,
+): boolean {
+  const kv = useOptionalKV()
+  const key = completionSeenKey(taskId, tabId)
+  const seen = completionSeenAt(kv, key, completionAt)
+  useEffect(() => {
+    if (!kv || !viewing || completionAt === undefined || seen) return
+    markCompletionSeen(kv, key, completionAt)
+  }, [kv, key, completionAt, viewing, seen])
+  return seen
 }
 
 function useRowCardChrome(row: SidebarRow, shared: SidebarRowCardSharedProps, opts: { mainBranch: string }) {
@@ -251,7 +294,8 @@ function useRowCardChrome(row: SidebarRow, shared: SidebarRowCardSharedProps, op
     (changes.added > 0 ? `+${changes.added}`.length + 1 : 0) +
     (changes.deleted > 0 ? `−${changes.deleted}`.length + 1 : 0)
   const subtitleBudget = Math.max(6, shared.subtitleBudget - clusterCells)
-  const completionSeen = completionSeenFor(task.id, activity?.state, isSelected)
+  const durableSeen = useDurableCompletionSeen(task.id, undefined, completionStampOf(activity), isSelected)
+  const completionSeen = completionSeenFor(task.id, activity?.state, isSelected, undefined, durableSeen)
   // This worktree's transcript facts, read OUTSIDE the memo so the row
   // re-derives when its own mtime moves rather than on every map identity
   // change (the collector republishes the whole map per probe round).

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -21,7 +21,15 @@ import type { WorktreeChanges } from "../../../tui/panes/sidebar/worktree-change
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { resolveRowSelectionChrome } from "../../ui/row-selection-chrome"
-import { ChangeStats, JumpDigit, completionSeenFor, useChanges, useSpinnerFrame } from "./row-cards"
+import {
+  ChangeStats,
+  JumpDigit,
+  completionSeenFor,
+  completionStampOf,
+  useChanges,
+  useDurableCompletionSeen,
+  useSpinnerFrame,
+} from "./row-cards"
 
 /** Cells of indent per depth level — one (owner round: the rail is narrow,
  *  and the glyph column already separates the levels visually). */
@@ -206,8 +214,18 @@ export function TabTreeRow(props: {
   // recorded — the ✓ → ● → ✓ flip on every task switch.
   const viewing = shared.selectedTaskId === props.task.id && props.tab.active === true
   // Per-TAB seen bit: sibling tab rows of the same task render in this very
-  // pass and would otherwise share (and clear) one task-wide mark.
-  const completionSeen = carriesState ? completionSeenFor(props.task.id, activity?.state, viewing, props.tab.id) : false
+  // pass and would otherwise share (and clear) one task-wide mark. The
+  // durable half survives a kobe restart, which the daemon's activity entry
+  // does too — without it every read completion came back ● (issue #22).
+  const durableSeen = useDurableCompletionSeen(
+    props.task.id,
+    props.tab.id,
+    carriesState ? completionStampOf(activity) : undefined,
+    viewing,
+  )
+  const completionSeen = carriesState
+    ? completionSeenFor(props.task.id, activity?.state, viewing, props.tab.id, durableSeen)
+    : false
   const baseView = buildSidebarRowView({
     task: props.task,
     activity,

--- a/packages/kobe/src/tui-react/workspace/completion-seen.ts
+++ b/packages/kobe/src/tui-react/workspace/completion-seen.ts
@@ -1,0 +1,90 @@
+/**
+ * Durable "I already looked at this completion" record — the persisted half
+ * of the sidebar's unread lamp (● turn done, not yet viewed).
+ *
+ * The lamp's seen bit used to live ONLY in a process-local Set, so quitting
+ * kobe threw the fact away while the daemon kept publishing the very same
+ * `turn_complete` (its activity registry is daemon-lived, not TUI-lived).
+ * Every completion you had already read came back unread on the next launch
+ * — owner report 2026-08-12, issue #22.
+ *
+ * The mark is the completion's own timestamp: `turn_complete` is a STICKY
+ * activity state, so its `at` is stamped once by the reporting event and
+ * only a new event restamps it. Recording "seen up to `at`" per (task, tab)
+ * therefore reads exactly right across restarts — an older completion is
+ * read, a newer one is not — with no way for a stale entry to swallow a
+ * fresh turn.
+ *
+ * Framework-free so the row cards, the tree's tab rows and unit tests share
+ * one rule; the KV layer just persists the record.
+ */
+
+export const COMPLETION_SEEN_KEY = "completionSeen"
+
+/** Bounded like the visit log — the oldest marks are pruned, and a pruned
+ *  mark can at worst re-light one lamp for a task untouched that long. */
+const SEEN_LIMIT = 200
+
+export type CompletionSeenKv = {
+  get(key: string, defaultValue?: unknown): unknown
+  set(key: string, value: unknown): void
+}
+
+/** Row identity of a seen mark: a task's own rollup, or one of its tabs.
+ *  Same NUL-joined shape the session Set has always used. */
+export function completionSeenKey(taskId: string, tabId?: string): string {
+  return tabId === undefined ? taskId : `${taskId}\0${tabId}`
+}
+
+/** Persisted marks are user-editable JSON — drop anything malformed. */
+export function parseCompletionSeen(stored: unknown): Record<string, number> {
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {}
+  const out: Record<string, number> = {}
+  for (const [key, at] of Object.entries(stored as Record<string, unknown>)) {
+    if (typeof at === "number" && Number.isFinite(at)) out[key] = at
+  }
+  return out
+}
+
+/**
+ * Fold one seen completion into the record, pruning the oldest marks at the
+ * cap. Returns the INPUT object when the record already covers `at`, so the
+ * caller can skip the write (this runs per viewed row, per render).
+ */
+export function foldCompletionSeen(
+  seen: Readonly<Record<string, number>>,
+  key: string,
+  at: number,
+  limit = SEEN_LIMIT,
+): Readonly<Record<string, number>> {
+  const known = seen[key]
+  if (known !== undefined && known >= at) return seen
+  const next: Record<string, number> = { ...seen, [key]: at }
+  const keys = Object.keys(next)
+  if (keys.length <= limit) return next
+  const pruned: Record<string, number> = {}
+  for (const k of keys.sort((a, b) => next[b] - next[a]).slice(0, limit)) pruned[k] = next[k]
+  return pruned
+}
+
+/**
+ * Has this row's CURRENT completion already been looked at? `at` is the
+ * activity entry's stamp; `undefined` means the row isn't sitting on a
+ * completion at all, which is never "seen".
+ */
+export function completionSeenAt(kv: CompletionSeenKv | null, key: string, at: number | undefined): boolean {
+  if (!kv || at === undefined) return false
+  // Read the raw snapshot rather than parsing the whole record: this is a
+  // render-path call, once per row per frame.
+  const stored = kv.get(COMPLETION_SEEN_KEY)
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return false
+  const known = (stored as Record<string, unknown>)[key]
+  return typeof known === "number" && known >= at
+}
+
+/** Record that the user has seen this completion. No-op when already covered. */
+export function markCompletionSeen(kv: CompletionSeenKv, key: string, at: number): void {
+  const seen = parseCompletionSeen(kv.get(COMPLETION_SEEN_KEY))
+  const next = foldCompletionSeen(seen, key, at)
+  if (next !== seen) kv.set(COMPLETION_SEEN_KEY, next)
+}

--- a/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression pin for issue #22 (owner report 2026-08-12, wisp): a session you
+ * have already read must not come back UNREAD after you quit kobe and start
+ * it again.
+ *
+ * The bug is environment-shaped, which is why this test spends two real TUI
+ * processes on it: the daemon's activity registry outlives the TUI, so the
+ * second launch is handed the very same `turn_complete` — while the seen bit
+ * that digests the lamp lived only in the first process's memory. Nothing
+ * short of an actual restart against a live daemon reproduces it.
+ *
+ * Shape: complete a turn on tab-1, let launch #1 sit in that tab (reading
+ * it), then make tab-2 the active tab so launch #2 opens somewhere else and
+ * tab-1's row is one you are NOT looking at — exactly where the lamp shows.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { Terminal } from "@xterm/headless"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { SIDEBAR_WIDTH } from "../../src/tui/panes/sidebar/view-core.ts"
+import { type BehaviorEnv, DIST_CLI, loadNodePty, makeBehaviorEnv, makeScratchRepo, runKobe } from "./harness.ts"
+
+const nodePty = await loadNodePty()
+
+const COLS = 140
+const ROWS = 40
+/** ● an unread completion, ○ one already looked at, ◌ no daemon signal yet. */
+const UNREAD = "●"
+const SEEN = "○"
+
+async function poll(predicate: () => boolean | Promise<boolean>, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+}
+
+describe.skipIf(!nodePty)("Pure TUI unread lamp across a restart (behavior)", () => {
+  let env: BehaviorEnv
+  let repo: string
+  let statePath: string
+  let taskId: string
+  let branch: string
+
+  const readState = async (): Promise<Record<string, unknown>> =>
+    JSON.parse(await readFile(statePath, "utf8")) as Record<string, unknown>
+
+  /**
+   * Boot the real TUI and hand back its screen as plain text lines — the
+   * frame goes through a headless xterm, so a row reads as the cells the user
+   * sees rather than as a stream of escapes with a glyph buried in it.
+   */
+  async function withTui<T>(run: (screen: () => string[]) => Promise<T>): Promise<T> {
+    if (!nodePty) throw new Error("unreachable: suite is skipped without node-pty")
+    const term = new Terminal({ cols: COLS, rows: ROWS, allowProposedApi: true })
+    // This child would inherit vitest's markers, and the host-session poll is
+    // off under a test RUNNER — it is a real TUI in its own process.
+    const { VITEST, NODE_ENV, BUN_TEST, ...tuiEnv } = env.env as Record<string, string>
+    const child = nodePty.spawn("bun", [DIST_CLI], { cols: COLS, rows: ROWS, cwd: repo, env: tuiEnv })
+    const data = child.onData((chunk: string) => term.write(chunk))
+    try {
+      return await run(() => {
+        const buffer = term.buffer.active
+        const lines: string[] = []
+        for (let y = 0; y < ROWS; y++) lines.push(buffer.getLine(y)?.translateToString(true) ?? "")
+        return lines
+      })
+    } finally {
+      data.dispose()
+      child.kill()
+    }
+  }
+
+  /** The rail rows below this task's worktree row — its tabs, in tab order. */
+  function tabRows(lines: readonly string[]): string[] {
+    const rail = lines.map((line) => line.slice(0, SIDEBAR_WIDTH))
+    const worktree = rail.findIndex((line) => line.includes(branch))
+    return worktree < 0 ? [] : rail.slice(worktree + 1)
+  }
+
+  beforeAll(async () => {
+    env = await makeBehaviorEnv()
+    repo = await makeScratchRepo(env)
+    const stateDir = join(env.home, ".config", "kobe")
+    await mkdir(stateDir, { recursive: true })
+    statePath = join(stateDir, "state.json")
+    await writeFile(statePath, JSON.stringify({ onboarded: true }))
+
+    // `--prompt` takes the headless launch path: worktree + hosted engine
+    // session under `<taskId>::tab-1`, plus the snapshot the TUI renders from.
+    // Explicit short branch: the rail row is LABELLED by it, and an
+    // auto-generated `kobe/<slug>-<id>` is long enough to be truncated there.
+    branch = "kobe/pin"
+    const add = runKobe(["api", "add", "--repo", repo, "--branch", branch, "--prompt", "hello"], env)
+    expect(add.code, add.stderr).toBe(0)
+    taskId = (JSON.parse(add.stdout) as { task: { id: string } }).task.id
+
+    await poll(() => {
+      const sessions = JSON.parse(runKobe(["api", "pty-list"], env).stdout) as {
+        sessions?: { key: string; alive?: boolean }[]
+      }
+      return sessions.sessions?.some((s) => s.key === `${taskId}::tab-1` && s.alive) === true
+    }, 30_000)
+
+    // The turn the user is about to read. An engine tab passes `KOBE_TAB_ID`
+    // to its hooks, so the daemon records this completion against tab-1.
+    const hook = runKobe(["hook", "turn-complete", "--engine", "claude-code-local"], {
+      ...env,
+      env: { ...env.env, KOBE_TASK_ID: taskId, KOBE_TAB_ID: "tab-1" },
+    })
+    expect(hook.code, hook.stderr).toBe(0)
+  }, 120_000)
+
+  afterAll(async () => {
+    await env.dispose()
+  })
+
+  it("keeps a completion read after kobe is restarted", async () => {
+    const key = `terminalTabs.${taskId}`
+
+    // Launch #1 — boot lands in the restored session, so tab-1 is the tab the
+    // user is looking at and its completion is read.
+    await withTui(async (screen) => {
+      await poll(() => screen().some((line) => line.includes("scratch-repo")), 30_000)
+      expect(
+        screen().some((line) => line.includes("scratch-repo")),
+        "the rail never hydrated",
+      ).toBe(true)
+      // The durable receipt of that read. Polled, not raced: the KV write is
+      // debounced, and launch #2 must not start before it lands.
+      await poll(async () => (await readState()).completionSeen !== undefined, 30_000)
+      expect(await readState(), "launch #1 never recorded the completion as read").toHaveProperty("completionSeen")
+    })
+
+    // Between launches the user leaves that tab: tab-2 is what the next
+    // launch opens, so tab-1's row is a session nobody is looking at.
+    const state = await readState()
+    const snapshot = state[key] as { tabs: unknown[]; activeId: string; nextOrdinal: number }
+    expect((snapshot?.tabs?.[0] as { id?: string } | undefined)?.id).toBe("tab-1")
+    snapshot.tabs.push({ kind: "engine", id: "tab-2", title: null, ordinal: 2 })
+    snapshot.activeId = "tab-2"
+    snapshot.nextOrdinal = 3
+    await writeFile(statePath, JSON.stringify(state))
+
+    // Launch #2 — the daemon replays the very same turn_complete it never
+    // forgot, against a process whose in-memory seen bits are empty.
+    await withTui(async (screen) => {
+      // Wait for that activity to reach the rail (the row leaves the "no
+      // signal" glyph). Whether it lands on ● or ○ is the question below.
+      await poll(() => {
+        const row = tabRows(screen())[0] ?? ""
+        return row.includes(SEEN) || row.includes(UNREAD)
+      }, 30_000)
+      const row = tabRows(screen())[0] ?? ""
+      expect(row, "a completion already read came back unread after the restart").not.toContain(UNREAD)
+      expect(row, "tab-1's row never received the daemon's activity").toContain(SEEN)
+    })
+  }, 120_000)
+})

--- a/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
@@ -156,6 +156,11 @@ describe.skipIf(!nodePty)("Pure TUI unread lamp across a restart (behavior)", ()
       const row = tabRows(screen())[0] ?? ""
       expect(row, "a completion already read came back unread after the restart").not.toContain(UNREAD)
       expect(row, "tab-1's row never received the daemon's activity").toContain(SEEN)
+      // ...and the row genuinely was one nobody was looking at. Had this
+      // launch landed back in tab-1, the session-only seen bit would digest
+      // the lamp on its own and the assertions above would say nothing.
+      const parked = (await readState())[key] as { activeId?: string } | undefined
+      expect(parked?.activeId, "launch #2 did not stay parked on tab-2").toBe("tab-2")
     })
   }, 120_000)
 })

--- a/packages/kobe/test/render/sidebar-completion-seen.test.ts
+++ b/packages/kobe/test/render/sidebar-completion-seen.test.ts
@@ -47,4 +47,16 @@ describe("completionSeenFor", () => {
     expect(completionSeenFor(task, "turn_complete", false, "tab-2")).toBe(false)
     expect(completionSeenFor(task, "turn_complete", false, "tab-1")).toBe(true)
   })
+
+  // Regression (owner report 2026-08-12, issue #22): quitting kobe empties
+  // this Set while the DAEMON keeps reporting the same `turn_complete`, so a
+  // relaunch re-lit every completion already read. A fresh process is exactly
+  // this: nothing in the Set, and the persisted mark as the only witness.
+  it("a completion the persisted mark covers is read on a fresh process", () => {
+    const task = "task-seen-5"
+    expect(completionSeenFor(task, "turn_complete", false, "tab-1", true)).toBe(true)
+    // A NEWER completion has a stamp the mark doesn't cover, so the durable
+    // answer arrives false and the lamp is unread again.
+    expect(completionSeenFor(task, "turn_complete", false, "tab-1", false)).toBe(false)
+  })
 })

--- a/packages/kobe/test/render/sidebar-unread-restart.test.tsx
+++ b/packages/kobe/test/render/sidebar-unread-restart.test.tsx
@@ -1,0 +1,103 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Issue #22 at the render boundary: a completion this process has never seen
+ * — the state a relaunched kobe is in — must still draw as read when the
+ * persisted mark covers it.
+ *
+ * The end-to-end pin (quit kobe, start it again, look at the rail) lives in
+ * `test/behavior/pure-tui-unread-restart.test.ts`; this one proves the rail
+ * actually consults the durable mark, without a PTY.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { TaskEngineState } from "../../src/client/remote-orchestrator"
+import { SidebarTree } from "../../src/tui-react/panes/sidebar/SidebarTree"
+import { completionSeenKey } from "../../src/tui-react/workspace/completion-seen"
+import { tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import { type Task, toTaskId } from "../../src/types/task"
+import { renderComponent } from "./harness"
+
+/** The completion's stamp — the daemon keeps publishing it after a restart. */
+const AT = 1_760_000_000_000
+const HOME_ENV = process.env.KOBE_HOME_DIR
+
+function task(id: string): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/kobe",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    archived: false,
+    pinned: false,
+    vendor: "claude",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  } as Task
+}
+
+const ALPHA = task("alpha")
+const BRAVO = task("bravo")
+
+function seedState(seen: Record<string, number>): void {
+  const home = mkdtempSync(join(tmpdir(), "kobe-unread-restart-"))
+  mkdirSync(join(home, ".config", "kobe"), { recursive: true })
+  writeFileSync(join(home, ".config", "kobe", "state.json"), JSON.stringify({ completionSeen: seen }))
+  process.env.KOBE_HOME_DIR = home
+}
+
+beforeAll(() => {
+  tabsByTask.set("alpha", {
+    tabs: [{ kind: "engine", id: "tab-1", title: "build", ordinal: 1 }],
+    activeId: "tab-1",
+    nextOrdinal: 2,
+  })
+  tabsByTask.set("bravo", {
+    tabs: [{ kind: "engine", id: "tab-1", title: "tests", ordinal: 1 }],
+    activeId: "tab-1",
+    nextOrdinal: 2,
+  })
+})
+
+afterAll(() => {
+  tabsByTask.clear()
+  if (HOME_ENV === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = HOME_ENV
+})
+
+const tabState: ReadonlyMap<string, ReadonlyMap<string, TaskEngineState>> = new Map([
+  ["alpha", new Map([["tab-1", { state: "turn_complete", at: AT } as TaskEngineState]])],
+])
+
+/** `bravo` is what the restored session opens on, so alpha's completed tab is
+ *  a row you are NOT looking at — exactly where the lamp is meant to show. */
+function tree() {
+  return (
+    <SidebarTree
+      tasks={[ALPHA, BRAVO]}
+      selectedId="bravo"
+      selectedTabId="tab-1"
+      onSelect={() => {}}
+      focused={true}
+      width={30}
+      engineTabState={tabState}
+    />
+  )
+}
+
+test("a completion no persisted mark covers still lights the lamp", async () => {
+  seedState({ [completionSeenKey("alpha", "tab-1")]: AT - 1 })
+  const { frame } = await renderComponent(tree(), { width: 30, height: 20, providers: { kv: true } })
+  expect(await frame()).toContain("●")
+})
+
+test("a completion the persisted mark covers reads as already seen", async () => {
+  seedState({ [completionSeenKey("alpha", "tab-1")]: AT })
+  const { frame } = await renderComponent(tree(), { width: 30, height: 20, providers: { kv: true } })
+  expect(await frame()).not.toContain("●")
+})

--- a/packages/kobe/test/tui-react/completion-seen.test.ts
+++ b/packages/kobe/test/tui-react/completion-seen.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest"
+import {
+  COMPLETION_SEEN_KEY,
+  completionSeenAt,
+  completionSeenKey,
+  foldCompletionSeen,
+  markCompletionSeen,
+  parseCompletionSeen,
+} from "../../src/tui-react/workspace/completion-seen"
+
+function fakeKv(seed?: unknown) {
+  const store = new Map<string, unknown>()
+  if (seed !== undefined) store.set(COMPLETION_SEEN_KEY, seed)
+  let writes = 0
+  return {
+    get: (key: string) => store.get(key),
+    set: (key: string, value: unknown) => {
+      writes++
+      store.set(key, value)
+    },
+    writes: () => writes,
+  }
+}
+
+// Issue #22 (owner report 2026-08-12): the sidebar's unread lamp only knew
+// what THIS process had seen, so relaunching kobe re-lit every completion
+// the daemon still reported. The durable mark is what crosses the restart.
+describe("durable completion-seen marks", () => {
+  test("a mark covers its own completion and every older one", () => {
+    const kv = fakeKv()
+    const key = completionSeenKey("task-a", "tab-1")
+    markCompletionSeen(kv, key, 1_000)
+    expect(completionSeenAt(kv, key, 1_000)).toBe(true)
+    expect(completionSeenAt(kv, key, 900)).toBe(true)
+    // The next turn completes: a NEWER stamp is unread again.
+    expect(completionSeenAt(kv, key, 1_001)).toBe(false)
+  })
+
+  test("a row that is not sitting on a completion is never seen", () => {
+    const kv = fakeKv({ "task-a": 1_000 })
+    expect(completionSeenAt(kv, "task-a", undefined)).toBe(false)
+    // No KV provider at all (render tests, panes outside the context).
+    expect(completionSeenAt(null, "task-a", 1_000)).toBe(false)
+  })
+
+  test("tabs of one task keep independent marks", () => {
+    const kv = fakeKv()
+    markCompletionSeen(kv, completionSeenKey("task-a", "tab-1"), 5)
+    expect(completionSeenAt(kv, completionSeenKey("task-a", "tab-1"), 5)).toBe(true)
+    expect(completionSeenAt(kv, completionSeenKey("task-a", "tab-2"), 5)).toBe(false)
+    // The task-level key (the flat sidebar's cards) is its own row too.
+    expect(completionSeenAt(kv, completionSeenKey("task-a"), 5)).toBe(false)
+  })
+
+  test("re-marking an already-covered completion writes nothing", () => {
+    const kv = fakeKv()
+    const key = completionSeenKey("task-a", "tab-1")
+    markCompletionSeen(kv, key, 10)
+    markCompletionSeen(kv, key, 10)
+    markCompletionSeen(kv, key, 9)
+    expect(kv.writes()).toBe(1)
+  })
+
+  test("malformed persisted state degrades to nothing seen", () => {
+    expect(parseCompletionSeen(["nope"])).toEqual({})
+    expect(parseCompletionSeen(null)).toEqual({})
+    expect(parseCompletionSeen({ good: 1, bad: "later", worse: Number.NaN })).toEqual({ good: 1 })
+    const kv = fakeKv("not-an-object")
+    expect(completionSeenAt(kv, "task-a", 1)).toBe(false)
+  })
+
+  test("prunes the oldest marks at the cap", () => {
+    const seed: Record<string, number> = {}
+    for (let i = 0; i < 5; i++) seed[`task-${i}`] = i
+    const next = foldCompletionSeen(seed, "task-new", 99, 3)
+    expect(Object.keys(next).sort()).toEqual(["task-3", "task-4", "task-new"])
+  })
+})


### PR DESCRIPTION
Fixes issue #22 (owner report 2026-08-12, wisp): a session you had already read came back **unread** after quitting kobe and starting it again.

## Root cause

Not "the mark was never cleared" — the mark was rebuilt. The lamp's seen bit is a process-local `Set` in `row-cards.tsx`, so a fresh launch starts with nothing seen, while the daemon's activity registry (in-memory, but **daemon**-lived, not TUI-lived) hands the new TUI the very same `turn_complete` it was holding before. Confirmed against a live isolated daemon: after the TUI exits, `kobe api inspect` still reports `turn_complete` for the task/tab with its original `at`.

The Inbox episode was NOT the culprit — `resolveVisited` plus the "resolve episodes that arrive while their target is visible" effect do delete it on a visit, and a task whose engine reports cwd-only (no `KOBE_TASK_ID`) never gets an episode at all, so episode presence can't back the lamp either.

## Fix

Persist the seen bit. `turn_complete` is a sticky activity state, so its `at` is stamped once per turn — recording "seen up to `at`" per (task, tab) in the KV store reads exactly right across restarts, and a newer completion is unread again with no stale entry able to swallow it. The session `Set` stays the same-render answer (sitting in a tab digests its lamp immediately); the durable mark is ORed in, and the write happens in an effect, never during render.

## Tests

- `test/behavior/pure-tui-unread-restart.test.ts` — the environment-shaped pin: real daemon, real hosted engine session, two real TUI processes. Complete a turn on tab-1, let launch #1 sit in it, make tab-2 active, relaunch, and assert tab-1's rail row wears `○` (seen) and not `●`. Screen read through a headless xterm so a row is asserted as cells, not as an escape stream.
- `test/render/sidebar-unread-restart.test.tsx` — same claim at the render boundary (no PTY): a persisted mark covering the completion drops the `●`; a mark that predates it keeps the lamp. Verified to fail without the fix.
- `test/tui-react/completion-seen.test.ts` — the pure store (coverage of the new module: 100%).
- `test/render/sidebar-completion-seen.test.ts` — one case added for the fresh-process path.

Local: lint, typecheck, test:fast, test:socket, test:render all green. The behavior suite skips locally (node-pty can't spawn here) and runs in CI.

coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx — this PR's change to the file is the shared seen helper plus three lines of wiring on the flat sidebar's card; both are covered by the render tests above. The file's uncovered bulk is the flat card's rendering, which this PR does not touch and which was already at 27%.
