### PR TITLE
fix: land the selection-padding highlight on the dragged cells

### DIFF
--- a/.changeset/selection-padding-highlight-offset.md
+++ b/.changeset/selection-padding-highlight-offset.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Dragging a terminal selection into the blank space to the right of a short line now highlights the cells you actually dragged over, instead of a same-width block shoved back against the end of the text. Rows in the embedded terminal are trimmed, not grid-padded, so a selection that starts in that trailing padding was painting its inverse-video highlight from where the line's text ended rather than from where the drag began — the copied text was already correct, only the on-screen highlight was misplaced.

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -139,8 +139,17 @@ function overlayRowSpan(row: readonly Chunk[], from: number, to: number): Chunk[
     if (after) out.push({ ...chunk, text: after })
   }
   // Selection reaching past the row's painted cells: show the highlight
-  // on the padding too, like terminals do.
-  if (col < to) out.push({ text: " ".repeat(to - Math.max(col, from)), attributes: ATTR.INVERSE })
+  // on the padding too, like terminals do. When the span STARTS past the
+  // painted cells (a drag anchored in the blank padding right of a short
+  // line, `from > col`), the highlight must begin at `from`, not at the
+  // row's painted width — so emit the `from - col` gap as plain spaces
+  // first, then the inverse block. With `from <= col` the gap is zero and
+  // the inverse block fills `[col, to)` exactly as before.
+  if (col < to) {
+    const gap = from - col
+    if (gap > 0) out.push({ text: " ".repeat(gap) })
+    out.push({ text: " ".repeat(to - Math.max(col, from)), attributes: ATTR.INVERSE })
+  }
   return out
 }
 

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -78,6 +78,29 @@ describe("terminal grid selection", () => {
     expect(out[0].map((c) => c.text).join("")).toBe("ab    ")
   })
 
+  it("overlaySelection lands the padding highlight on the selected cells when the span starts past the text", () => {
+    // The drag anchors in the blank padding to the right of a short line
+    // (cols 5-7, past "ab" which paints only cols 0-1). The highlight must
+    // sit on cols 5-7, with cols 2-4 left as unhighlighted padding — not
+    // shifted left onto cols 2-4 (the regression this guards).
+    const short = [row("ab")]
+    const range = { anchor: { row: 0, col: 5 }, head: { row: 0, col: 7 } }
+    const out = overlaySelection(short, range, 0, 10)[0]
+    // Full row is 8 cells: "ab" + three plain spaces + three inverse spaces.
+    expect(out.map((c) => c.text).join("")).toBe("ab      ")
+    expect(displayWidth(out.map((c) => c.text).join(""))).toBe(8)
+    const plain = out
+      .filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) === 0)
+      .map((c) => c.text)
+      .join("")
+    const inverse = out
+      .filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+      .map((c) => c.text)
+      .join("")
+    expect(plain).toBe("ab   ") // "ab" + the 3-cell gap, unhighlighted
+    expect(inverse).toBe("   ") // exactly the 3 selected padding cells
+  })
+
   it("extracts a CJK range by terminal cells in either drag direction", () => {
     const cjk = [row("唯一需要区分的是：")]
     const forward = { anchor: { row: 0, col: 4 }, head: { row: 0, col: 9 } }


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found rendering bug in the embedded terminal's grid selection, surfaced by a review pass over the pure/near-pure logic modules. (Open issues #362/#307/#259 were either awaiting an owner design decision or too broad for one tightly-scoped slice; this is a smaller, fully-verifiable fix.)

## Problem

In `terminal-selection.ts`, `overlayRowSpan` paints a selection's inverse-video highlight over a row. Snapshot rows are **trimmed, not grid-padded** (`xtermLineToChunks` drops trailing blank cells), while the mouse column is clamped to the grid width — so a drag can anchor in the blank padding to the *right* of a short line, giving a span whose start column `from` is greater than the row's painted width `col`.

The trailing-padding branch computed the highlight width as `to - Math.max(col, from)` but appended it immediately after the painted content (at visual column `col`). When `from > col`, the block rendered at `[col, col + (to - from))` instead of the intended `[from, to)` — the highlight was shifted left onto cells the user never dragged over, the gap `[col, from)` was wrongly inverted, and the row came out too short.

Concrete case (grid width 8, row `"ab"`, select cols 5–7): expected inverse on cols 5/6/7 with cols 2–4 left plain; actual output inverted cols 2/3/4 and produced a 5-cell row. The **copied** text was already correct (`extractSelection` slices the trimmed text independently) — only the on-screen highlight was misplaced.

## Fix

When the span starts past the painted cells, emit the `from - col` gap as **plain** spaces first, then the inverse block sized `to - Math.max(col, from)`. When `from <= col` the gap is zero and the inverse block fills `[col, to)` exactly as before, so the common case is byte-identical.

## Verification

- Added a cell-exact test asserting the highlight lands on the selected padding cells (cols 5–7) with the gap (cols 2–4) left unhighlighted — this fails against the old code, which produced `"ab   "` with the highlight on cols 2–4.
- `bun test test/tui/terminal-selection.test.ts` → 13/13 pass.
- `bun run lint` and `bun run typecheck` → both green.
- Full `test/tui/` suite: clean tree 842 pass / 43 fail vs. this branch 843 pass / 43 fail — exactly the one new passing test and zero new failures. (The 43 pre-existing failures are unrelated environment issues in the CI-style checkout — readonly `process.platform` / `Bun`-global reassignment in bun's test runner.)

## Follow-ups deferred

- The `engine/foreground.ts` custom-engine gate matches `basename(argv0)` against `extraBin` without the `binaryName()` normalization the builtin path uses (could false-negative on `aider.exe`), and `handlers-inspect.ts` filters sessions by bare `startsWith(taskId)` rather than `` `${taskId}::` `` — both are lower-confidence and left for a separate, scoped change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ejk4eM3ooZ6M9JYHUNVm9J)_