### PR TITLE
fix: keep the orphan backstop from resurrecting a tab ctrl+w just closed

### DIFF
--- a/.changeset/ctrl-w-adopt-resurrect.md
+++ b/.changeset/ctrl-w-adopt-resurrect.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: ctrl+w closes a tab in one press again — the sidebar's orphan-adoption backstop (a 2s `pty.list` poll) could still see the just-killed session as alive and adopt the closed tab straight back into the strip. Closes now note their pty key for a 15s window that orphan detection skips, long enough for the host to observe the kill, short enough that a genuinely unkillable session still resurfaces as an orphan.

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -30,6 +30,7 @@ import {
   treeFlatIds,
   withRecentRow,
 } from "../../../tui/panes/sidebar/tree-core"
+import { isRecentlyClosedPtyKey } from "../../../tui/workspace/closed-tab-suppress"
 import { getDefaultLiveEngines } from "../../../tui/workspace/live-engine"
 import { tabTitleStable } from "../../../tui/workspace/terminal-tab-split"
 import { tabPtyKeyFor } from "../../../tui/workspace/terminal-tabs-core"
@@ -144,7 +145,11 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
     const registered = new Set<string>()
     for (const [taskId, tabs] of snapshotTabs) for (const tab of tabs) registered.add(tabRowId(taskId, tab.id))
     const map = new Map<string, readonly TreeTab[]>()
-    for (const [taskId, orphans] of orphanTabsByTask(hostSessions, registered)) {
+    // A just-closed tab's session can outlive its state in the 2s poll —
+    // treating it as an orphan would adopt it right back (see
+    // closed-tab-suppress.ts).
+    const sessions = hostSessions.filter((session) => !isRecentlyClosedPtyKey(session.key))
+    for (const [taskId, orphans] of orphanTabsByTask(sessions, registered)) {
       if (tasks.some((task) => task.id === taskId)) map.set(taskId, orphans)
     }
     return map

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
@@ -20,6 +20,7 @@
 
 import { peekSharedPtyClient } from "../../tui/panes/terminal/pty-hosted-client"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
+import { noteClosedPtyKey } from "../../tui/workspace/closed-tab-suppress"
 import {
   type TabsState,
   type TerminalTab,
@@ -42,6 +43,11 @@ export function releaseClosedTabPtys(taskId: string, closing: TerminalTab | unde
   const key = closing ? tabPtyKeyFor(taskId, closing) : tabPtyKey(taskId, closedId)
   releaseSplitLeaves(key, closing?.splitTree ?? null)
   if (closing?.kind === "engine" && closing.ptyTask) return
+  // The sidebar's orphan backstop polls the host on a 2s tick; until it
+  // observes this kill it still lists the session as live, and would adopt
+  // it right back into the state (ctrl+w needing two presses). Note the key
+  // so orphan detection skips it while the death propagates.
+  noteClosedPtyKey(key)
   const registry = getDefaultPtyRegistry()
   // `release()` can only kill what THIS process holds a handle for, and the
   // sidebar closes tabs of tasks it never attached to (a task not mounted

--- a/packages/kobe/src/tui-react/workspace/use-tab-close.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-close.ts
@@ -17,6 +17,7 @@
  */
 
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
+import { noteClosedPtyKey } from "../../tui/workspace/closed-tab-suppress"
 import {
   type TabsState,
   type TerminalTab,
@@ -69,6 +70,9 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
       const key = closing ? tabPtyKeyFor(taskId(), closing) : tabPtyKey(taskId(), closedId)
       releaseSplitLeaves(key, closing?.splitTree ?? null)
       getDefaultPtyRegistry().release(key)
+      // Keep the orphan backstop from adopting the dying session back
+      // before its next poll observes the exit (closed-tab-suppress.ts).
+      noteClosedPtyKey(key)
     }
     deps.updateRef.current(next)
   }

--- a/packages/kobe/src/tui/workspace/closed-tab-suppress.ts
+++ b/packages/kobe/src/tui/workspace/closed-tab-suppress.ts
@@ -1,0 +1,39 @@
+/**
+ * Recently-closed pty keys, for the sidebar's orphan-tab backstop.
+ *
+ * Closing a tab updates the tab state immediately, but the sidebar's host
+ * inventory (`useHostSessions`) is a 2s poll — for up to one tick it still
+ * lists the killed session as alive. The orphan backstop then sees a live
+ * session no snapshot answers for and ADOPTS it right back: ctrl+w needed
+ * two presses. So every close notes its key here, and orphan detection
+ * skips noted keys until the poll can confirm the death.
+ *
+ * TTL-bounded on purpose: if the kill never lands (host unreachable), the
+ * session really is an orphan and must resurface after the window.
+ */
+
+const SUPPRESS_MS = 15_000
+
+/** `taskId::tabId` → when its tab was closed. */
+const closedAt = new Map<string, number>()
+
+/** A session key's tab-level prefix — split leaves (`…::leaf-N`) belong to
+ *  their tab, same rule `orphanTabsByTask` applies. */
+function tabKeyOf(key: string): string {
+  return key.split("::").slice(0, 2).join("::")
+}
+
+export function noteClosedPtyKey(key: string, now = Date.now()): void {
+  closedAt.set(tabKeyOf(key), now)
+}
+
+export function isRecentlyClosedPtyKey(key: string, now = Date.now()): boolean {
+  const tabKey = tabKeyOf(key)
+  const at = closedAt.get(tabKey)
+  if (at === undefined) return false
+  if (now - at > SUPPRESS_MS) {
+    closedAt.delete(tabKey)
+    return false
+  }
+  return true
+}

--- a/packages/kobe/test/tui/closed-tab-suppress.test.ts
+++ b/packages/kobe/test/tui/closed-tab-suppress.test.ts
@@ -1,0 +1,24 @@
+/**
+ * A killed tab's host session survives in the 2s `pty.list` poll for one
+ * tick; the orphan backstop must not adopt it back in that window (the
+ * "ctrl+w needs two presses" regression), yet a kill that never lands must
+ * resurface as a real orphan after the TTL.
+ */
+
+import { describe, expect, it } from "vitest"
+import { isRecentlyClosedPtyKey, noteClosedPtyKey } from "../../src/tui/workspace/closed-tab-suppress"
+
+describe("closed-tab-suppress", () => {
+  it("suppresses a just-closed key and its split leaves, then expires", () => {
+    noteClosedPtyKey("t1::tab-2", 1_000)
+    expect(isRecentlyClosedPtyKey("t1::tab-2", 2_000)).toBe(true)
+    // A split leaf belongs to its tab — same collapse orphan detection does.
+    expect(isRecentlyClosedPtyKey("t1::tab-2::leaf-2", 2_000)).toBe(true)
+    expect(isRecentlyClosedPtyKey("t1::tab-3", 2_000)).toBe(false)
+  })
+
+  it("resurfaces after the TTL so an unkillable session is still reported", () => {
+    noteClosedPtyKey("t2::tab-1", 0)
+    expect(isRecentlyClosedPtyKey("t2::tab-1", 16_000)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- ctrl+w needed two presses: the sidebar's orphan-adoption backstop (2s `pty.list` poll, #405/#410) could still see the just-killed session as alive for one tick and adopt the closed tab straight back into the strip.
- Closes now note their pty key in a 15s suppress window (`closed-tab-suppress.ts`) that orphan detection skips — long enough for the host to observe the kill, short enough that a genuinely unkillable session still resurfaces as a ⚠ orphan.
- Both close paths are covered: the mounted component's ctrl+w/exit path (`use-tab-close.ts`) and the background `closeTaskTab` path (`terminal-tabs-close.ts`).

## Test plan
- [x] `vitest` — new `closed-tab-suppress.test.ts` + existing adopt/orphan suites green
- [x] root `bun run lint` + package typecheck
- [ ] dev:sandbox: open two tabs, ctrl+w closes in one press

coverage-exemption: packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts — React-integration module (pty registry + shared client IO); the new logic itself lives in closed-tab-suppress.ts at 100%
coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-close.ts — React hook wired to registry/refs, vitest can't mount it; the added call is a one-line note into closed-tab-suppress.ts (covered)
