### PR TITLE
docs: README covers what kobe grew into, minus the fan-out pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Multiplex your agents like you multiplex your terminals.</strong><br />
-  kobe is an open-source agent multiplexer: it runs <a href="https://claude.com/claude-code">Claude Code</a>, <a href="https://github.com/openai/codex">Codex</a>, and <a href="https://github.com/github/copilot-cli">Copilot</a> in parallel,<br />
+  kobe is an open-source agent multiplexer: it runs <a href="https://claude.com/claude-code">Claude Code</a>, <a href="https://github.com/openai/codex">Codex</a>, <a href="https://github.com/github/copilot-cli">Copilot</a>, Kimi — or any CLI you register — in parallel,<br />
   each session on its own git worktree and branch — attach, detach, reattach; they keep working after you disconnect.
 </p>
 
@@ -29,25 +29,25 @@
   <img src="docs/assets/workspace.png" alt="kobe workspace — task sidebar, embedded engine session, file tree and terminal" />
 </p>
 
-Terminal multiplexers let one terminal hold many shells that survive you. kobe does the same for AI coding agents: one TUI holds many engine sessions, each isolated on its own git worktree and branch, all alive after you close the laptop lid on your SSH connection. Fan a prompt across five attempts, walk away, come back, merge the winner, archive the rest. It runs where your code already lives — laptop, devbox, VPS — with no desktop app and no browser required.
+Terminal multiplexers let one terminal hold many shells that survive you. kobe does the same for AI coding agents: one TUI holds many engine sessions, each isolated on its own git worktree and branch, all alive after you close the laptop lid on your SSH connection. Start the auth refactor, start the flaky-test hunt beside it, walk away, come back to two finished branches. It runs where your code already lives — laptop, devbox, VPS — with no desktop app and no browser required.
 
 ## Why kobe
 
 - **Safe parallelism** — every task is `git worktree + engine session + branch`. Agents never trample each other or your checkout.
 - **Sessions survive you** — quit the TUI, drop SSH, restart the daemon; reattach and the screen comes back. A separate PTY host owns the sessions, so nothing you close kills them.
 - **Real engines, real environment** — kobe embeds the actual interactive CLIs next to your dependencies, services, and credentials. No API wrappers, no re-rendered streams.
-- **Any engine** — `claude`, `codex`, `copilot`, or any command you add via `kobe config`, picked per task.
-- **Terminal first** — notifications and clipboard ride SSH back to your local terminal.
-- **Agents orchestrating agents** — `kobe api` lets a script, or another AI agent, fan out tasks, supervise them, and collect the results headlessly.
+- **Any engine, mid-task** — `claude`, `codex`, `copilot`, `kimi`, or your own command. Hand a stuck conversation to another vendor without losing its context.
+- **Terminal first** — notifications and clipboard ride SSH back to your local terminal, and the whole UI folds down to a phone-width session.
+- **Agents orchestrating agents** — `kobe api` lets a script, or another AI agent, spawn tasks, supervise them, and land the results headlessly.
 
 <p align="center">
-  <img src="docs/assets/demo.gif" alt="kobe demo — fan out attempts, supervise, review the diff, land the winner" /><br />
+  <img src="docs/assets/demo.gif" alt="kobe demo — two tasks running at once, each on its own worktree and branch" /><br />
   <a href="docs/assets/demo.mp4">▶ watch the full-quality mp4</a>
 </p>
 
 ## Install
 
-Requires [Bun](https://bun.sh) ≥ 1.3.11, git, and at least one engine CLI on `PATH`.
+Requires [Bun](https://bun.sh) ≥ 1.3.11, git, and at least one engine CLI on `PATH`. macOS, Linux, and Windows.
 
 ```bash
 bun install -g @sma1lboy/kobe
@@ -70,38 +70,50 @@ Full documentation: **[docs.kobe.sma1lboy.me](https://docs.kobe.sma1lboy.me)** �
 
 > **If kobe saves you an afternoon, [star the repo](https://github.com/Sma1lboy/kobe/stargazers)** — it is the single strongest signal that tells other developers this is worth their time.
 
-## Graph engineering: fan out, complete, observe, fan in
+## Beyond the three panes
 
-Running many agents well is not prompt engineering — it's [graph engineering](https://kobe.sma1lboy.me). Nodes are isolated attempts, edges are dependencies, and the gates are your judgment. kobe gives you a primitive for each step:
+**Review with leverage.** Open a file's diff, `v` a range, `c` a note, and `s` sends every unsent note across the whole task back to the engine as one prompt. The engine gets your words plus file and line numbers — it reads the worktree itself. Notes survive restarts, and sending doesn't switch tabs.
 
-**Fan out** — one prompt, N isolated attempts, one command:
+<p align="center">
+  <img src="docs/assets/diff-review.png" alt="Diff review — a range selected across lines 4-6 and a note being written for the engine" />
+</p>
+
+**Never babysit a rate limit.** The footer carries each usage window the vendor reports (`CLAUDE 5h 42% → 14:00 · 7d 12%`). When Claude hits its subscription window, kobe schedules a resume and continues the task once the window resets. Or don't wait at all: `ctrl+e` continues the same conversation in a *different* engine — the next agent gets the previous transcript's path and picks up from there — and `kobe api send --tab new --vendor codex` puts a second vendor on the same worktree, on the same files.
+
+**Run it from your phone.** Below 70 columns the TUI becomes one panel at a time — task list and workspace alternate, the first row jumps you back where you were, quota shrinks to `CLAUDE 42%`. No setting, no separate app; it follows the terminal width.
+
+<p align="center">
+  <img src="docs/assets/narrow-sidebar.png" alt="Narrow mode — the task list filling a phone-width SSH session" />
+</p>
+
+**Work that runs without you.** Routines are daemon-owned cron prompts: every firing creates a fresh task — worktree, branch, engine session — with the prompt as its first message. A `--precheck` command skips the run when nothing changed, so a nightly schedule doesn't burn a turn on an idle repo. An enabled routine keeps the daemon alive with no TUI attached.
+
+<p align="center">
+  <img src="docs/assets/routines.png" alt="The Routines page — scheduled prompts with their cron expressions and next runs" />
+</p>
+
+And the rest, briefly:
+
+- **Inbox** (`ctrl+a` `i`) — what needs you, and where you were. `F7` jumps to the oldest pending item across every project, even mid-typing inside a session.
+- **Kanban** (`ctrl+a` `1`) — a local issue board where agents move their own cards (`kobe api issue-update --task`), and you start a session straight off one.
+- **GitHub issues** (`ctrl+a` `3`) — browse the repo's issues through `gh` and start a task on one; the body arrives as the first prompt, fenced and marked untrusted. Nothing is written back.
+- **Field notes** — `kobe api note` files a resolved gotcha into the repo's durable store; every future worktree session on that repo starts with it in its system prompt.
+- **Human in the loop** — an agent can toast every attached UI (`notify`), ask you a question through the TUI and block on the answer (`prompt`), or open a split beside itself for a dev server (`pane-open`).
+- **Attachments** — drag an image or PDF onto a session and the path lands in its input; `ctrl+v` a screenshot and kobe saves it first. kobe only ever passes paths.
+- **Themes and plugins** — three bundled themes plus ten hosted (`kobe theme add <url>`), and a manifest plugin system with panes, lifecycle events, chords, and an optional [typed SDK](https://www.npmjs.com/package/@sma1lboy/kobe-plugin-sdk).
+
+## Scripting it
+
+`kobe api` is the same daemon the TUI talks to, one JSON object per call — the surface a shell script or another AI agent drives:
 
 ```bash
-kobe api fan-out --repo "$PWD" \
-  --agents claude:2,codex:2,copilot:1 \
-  --prompt "Try independent approaches to simplify the auth flow."
+kobe api add --repo "$PWD" --prompt "Fix the flaky auth test."  # spawn a task
+kobe api read-output --task-id <id>                             # its own session history, paged
+kobe api send --prompt "succeeded: fixed, branch kobe/auth"     # report home to whoever spawned you
+kobe api land --task-id <id>                                    # merge the winning branch
 ```
 
-**Completion** — a worker messages its explicit outcome back to the spawning agent's chat tab (the exact command is baked into its first prompt). Silence is a checkpoint, never a verdict:
-
-```bash
-kobe api send --task-id <spawner> --prompt "succeeded: auth flow simplified (branch kobe/auth-flow)"
-```
-
-**Observe** — read the engine's own structured session, never scrape a TUI screen:
-
-```bash
-kobe api read-output --task-id <id>    # paged history, honest terminal fallback
-```
-
-**Fan in** — compare attempts, annotate diffs line-by-line and send the notes back to the agent as a prompt, then land the winner:
-
-```bash
-kobe api collect --task-ids a,b,c      # read-only comparison snapshot
-kobe api land --task-id a              # merge the winning branch
-```
-
-Install the companion skill so Claude Code can drive this loop itself — an agent orchestrating agents while you keep the gates:
+A task created from inside another kobe session records its dispatcher, so a bare `send` routes back to the exact tab that asked for the work — no ids to thread through. Install the companion skill and Claude Code drives this loop itself, with you at the gates:
 
 ```bash
 kobe skill install
@@ -122,7 +134,7 @@ Task = git worktree + hosted engine session + branch
 The same tasks are available from a browser — `kobe web` serves a local dashboard on the daemon the TUI uses, so both surfaces stay in sync:
 
 ```bash
-kobe web            # http://localhost:5174
+kobe web            # http://localhost:45174
 ```
 
 ## kobe vs desktop agent IDEs
@@ -138,13 +150,6 @@ Tools like Conductor and orca wrap parallel agents in an Electron desktop app. k
 | UI | terminal (TUI) + optional local web dashboard | Electron |
 
 If your workflow is already SSH + terminal, kobe fits it instead of replacing it. If you want a desktop app, those tools are good — different bet.
-
-## Use cases worth stealing
-
-- **Competing implementations**: fan the same refactor to Claude and Codex, keep whichever diff reads better.
-- **Long-running work from a laptop**: kick off tasks on a devbox over SSH, close everything, reattach after dinner.
-- **Agent-driven delivery**: your local Claude Code session uses `kobe api` to spawn, supervise, and merge remote attempts — you only review the final diff.
-- **Review with leverage**: annotate an attempt's diff line-by-line in the TUI, send all notes back as one prompt, get a corrected attempt.
 
 If you write about developer tools, this README plus the [landing page](https://kobe.sma1lboy.me) (which links right back here) should give you everything you need — the full manual is at [docs.kobe.sma1lboy.me](https://docs.kobe.sma1lboy.me), and architecture details live in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 


### PR DESCRIPTION
The README still led with fan-out — N attempts at one prompt — as the headline move. That multiplies token spend for one deliverable and isn't how people actually run kobe; the demo was already re-shot (#417) around two concurrent tasks on disjoint files, so the prose was behind its own screenshots.

## What changed

**The pitch** — many *different* tasks in parallel, each on its own worktree, rather than N attempts at one prompt. Fan-out is gone from the headline; `kobe api` keeps its scripting section with `add` / `read-output` / `send` / `land`.

**New section: "Beyond the three panes"** — features that shipped over the last ~60 releases and never reached the README:

- Diff-review notes (`v` / `c` / `s` → one prompt back to the engine)
- Quota windows in the footer + Claude rate-limit auto-resume
- Cross-engine handoff (`ctrl+e` continue in another vendor) and `send --tab new --vendor` — two agents, one worktree
- Narrow mode below 70 columns (phone SSH)
- Routines — cron-scheduled tasks with prechecks
- Inbox + `F7`, Kanban, GitHub-issues page, field notes, `notify`/`prompt`/`pane-open`, attachments, themes, plugins + SDK

Four screenshots that were already shot and sitting unused in `docs/assets/` now appear: `diff-review.png`, `narrow-sidebar.png`, `routines.png` (plus the existing hero and demo).

**Three stale facts fixed**

- `kobe web` serves `:45174`, not `:5174` (`DEFAULT_DAEMON_WEB_PORT`, moved out of the dev-server range)
- `kimi` is a fourth built-in engine
- Completion is a bare `kobe api send --prompt` routed through the recorded dispatcher, not `--task-id <spawner>` — the README's own next line already said the command is baked into the first prompt

Deliberately left out: remote projects over SSH, since `docs/design/remote-topology-status.md` records phase 6 as regressed.

Net +5 lines (174 → 179). Docs-only; no changeset (the gate scopes to `packages/*/src`).