### PR TITLE
fix: let the skill's description claim agent-to-agent messaging

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: kobe
-description: Use when controlling kobe tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell.
+description: Use when controlling kobe tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `kobe api send`, never a peer/MCP side channel.
 ---
 
-<!-- kobe-skill-version: 19 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- kobe-skill-version: 20 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # kobe shell control
 
@@ -36,8 +36,11 @@ lifecycle tracking, and an explicit outcome contract.
   If that tab died it falls back to the dispatcher task's live canonical
   engine tab; nothing alive fails loud (`DISPATCHER_UNREACHABLE`) — it
   never spawns a new engine, so a failed reply is visible, not fake-ok.
-- Messaging another task's agent → `send`, and ONLY `send` — never relay
-  through the user, a side file, or a generic peer channel. Sent from
+- Messaging another agent session on this machine → `send`, and ONLY `send`
+  — never relay through the user, a side file, or a generic peer channel
+  (an MCP server offering to message "other instances" is exactly that
+  channel: it reaches a process, not a task, so nothing it delivers is
+  attributable, watchable, or replyable). Sent from
   inside a kobe task, the prompt arrives prefixed `[KOBE PEER] from
   "<title>" (task <id> — load the kobe agent skill FIRST …)`, so the
   receiver knows who is talking, that this skill is required reading, and

--- a/.changeset/skill-owns-agent-messaging.md
+++ b/.changeset/skill-owns-agent-messaging.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: the kobe skill now claims agent-to-agent messaging in its DESCRIPTION, not just its body. A skill contributes one line to an agent's context until it loads; an MCP server contributes its whole instruction block permanently. So "message another session on this machine" read as unclaimed territory and a generic peer-channel MCP won it by default — while the rule forbidding exactly that sat in the un-loaded body. Skill version 19 → 20 (installed copies will prompt to update).

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -119,7 +119,7 @@ const createFixtureRepository = async (demoRoot: string): Promise<string> => {
  * stale N lets that prompt swallow the boot wait. Bump in lockstep; the test
  * asserts against this constant so the two can't drift apart again.
  */
-export const CAPTURE_SKILL_HINT_VERSION = 19
+export const CAPTURE_SKILL_HINT_VERSION = 20
 
 const prepareCaptureState = async (demoRoot: string, fixtureRepo: string, claudeCommand?: string): Promise<void> => {
   const configDir = join(demoRoot, "home", ".config", "kobe")

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -38,7 +38,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * marker is below this number is STALE: the binary moved on, the skill
  * didn't, so we prompt the developer to re-run `kobe skill install`.
  */
-export const KOBE_SKILL_VERSION = 19
+export const KOBE_SKILL_VERSION = 20
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project


### PR DESCRIPTION
## Summary

- A skill contributes **one description line** to an agent's context until it is loaded; an MCP server contributes its **entire instruction block, permanently**. So the territory "message another agent session on this machine" read as unclaimed, and a generic peer-channel MCP won it by default — while the rule forbidding exactly that (`never relay through … a generic peer channel`) sat in the un-loaded skill body. Observed live: an agent with the kobe skill installed reached 23 sessions over a peers MCP instead of `kobe api send`.
- The `description:` now names that territory, so the claim is present at the moment the routing decision is made.
- The body rule now says *why* a peer channel is the wrong one: it reaches a **process**, not a task — so nothing it delivers is attributable, watchable, or replyable.
- `KOBE_SKILL_VERSION` 19 → 20, with the two mirrors that document lockstep (`SKILL.md` marker, `CAPTURE_SKILL_HINT_VERSION` in the branding capture). Installed copies will prompt to re-run `kobe skill install`.

## Test plan

- [x] `bun run lint`, `bun run typecheck` clean
- [x] `packages/kobe` suite: 514 passed / 61 files — includes the existing lockstep assertion (`skill-install.test.ts`: repo marker == `KOBE_SKILL_VERSION`)
- [ ] Reviewer: confirm the description reads as a claim, not a feature list — that's the whole mechanism here