### PR TITLE
fix: the daemon dashboard matches its bind host case-insensitively

### DIFF
--- a/.changeset/web-origin-case-insensitive-host.md
+++ b/.changeset/web-origin-case-insensitive-host.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix the daemon dashboard rejecting every browser request with a 403 when it is bound to a host whose name carries an uppercase letter — routine for mDNS names like `MyMac.local`. Browsers (and the URL parser) lowercase the Origin host they send, but the allowed bind host was compared with its original case, so `mymac.local` never matched `MyMac.local` and the whole LAN dashboard was locked out; hostnames are case-insensitive (RFC 4343) and the Origin check now compares them that way.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -56,6 +56,7 @@
     "./daemon/server": "./src/daemon/server.ts",
     "./daemon/transcript-activity-collector": "./src/daemon/transcript-activity-collector.ts",
     "./daemon/ui-prefs-watcher": "./src/daemon/ui-prefs-watcher.ts",
+    "./daemon/web-origin": "./src/daemon/web-origin.ts",
     "./daemon/web-rpc-allowlist": "./src/daemon/web-rpc-allowlist.ts",
     "./daemon/web-server": "./src/daemon/web-server.ts",
     "./daemon/web-session": "./src/daemon/web-session.ts",

--- a/packages/kobe-daemon/src/daemon/web-origin.ts
+++ b/packages/kobe-daemon/src/daemon/web-origin.ts
@@ -37,7 +37,11 @@ export function originAllowed(origin: string | null | undefined, opts: { allowed
   const allowedHost = opts.allowedHost?.trim()
   if (!allowedHost) return false
   const hostname = originHostname(origin)
-  return hostname !== null && hostname === allowedHost
+  // Hostnames are case-insensitive (RFC 4343). `originHostname` returns the
+  // WHATWG-lowercased host the browser puts in Origin; lowercase the bind host
+  // too so a mixed-case bind address (e.g. an mDNS `MyMac.local`) still matches
+  // instead of 403ing every browser request.
+  return hostname !== null && hostname === allowedHost.toLowerCase()
 }
 
 export function allowedHostForBindHost(hostname: unknown): string | undefined {

--- a/packages/kobe/test/daemon/web-origin.test.ts
+++ b/packages/kobe/test/daemon/web-origin.test.ts
@@ -1,0 +1,78 @@
+import { allowedHostForBindHost, isLoopbackOrigin, originAllowed } from "@sma1lboy/kobe-daemon/daemon/web-origin"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Browser-Origin policy for daemon-hosted web routes.
+ *
+ * Regression (this file): a bind host carrying any uppercase letter — routine
+ * for mDNS names like `MyMac.local` — used to 403 every browser request. The
+ * browser (and `new URL().hostname`) lowercase the Origin host, but the allowed
+ * bind host was compared with its original case, so `mymac.local === MyMac.local`
+ * was false. Hostnames are case-insensitive (RFC 4343); the comparison now is.
+ */
+describe("originAllowed", () => {
+  it("allows a request with no Origin (non-browser client)", () => {
+    expect(originAllowed(null)).toBe(true)
+    expect(originAllowed(undefined)).toBe(true)
+    expect(originAllowed("")).toBe(true)
+  })
+
+  it("allows any loopback Origin regardless of the allowed host", () => {
+    expect(originAllowed("http://localhost:45174")).toBe(true)
+    expect(originAllowed("http://127.0.0.1:45174")).toBe(true)
+    expect(originAllowed("http://[::1]:45174")).toBe(true)
+    expect(originAllowed("http://localhost:45174", { allowedHost: "example.local" })).toBe(true)
+  })
+
+  it("rejects a non-loopback Origin when no host is allowed", () => {
+    expect(originAllowed("http://kobe.local:45174")).toBe(false)
+    expect(originAllowed("http://kobe.local:45174", { allowedHost: "" })).toBe(false)
+    expect(originAllowed("http://kobe.local:45174", { allowedHost: "   " })).toBe(false)
+  })
+
+  it("allows the exact allowed host", () => {
+    expect(originAllowed("http://kobe.local:45174", { allowedHost: "kobe.local" })).toBe(true)
+    expect(originAllowed("https://192.168.1.20:45174", { allowedHost: "192.168.1.20" })).toBe(true)
+  })
+
+  it("matches a mixed-case bind host case-insensitively (RFC 4343)", () => {
+    // The browser lowercases the Origin host; the bind host keeps its case.
+    expect(originAllowed("http://mymac.local:45174", { allowedHost: "MyMac.local" })).toBe(true)
+    expect(originAllowed("http://johns-mbp.local:45174", { allowedHost: "Johns-MBP.local" })).toBe(true)
+    expect(originAllowed("http://host.example:45174", { allowedHost: "HOST.EXAMPLE" })).toBe(true)
+  })
+
+  it("rejects a genuinely different host", () => {
+    expect(originAllowed("http://evil.example:45174", { allowedHost: "kobe.local" })).toBe(false)
+  })
+
+  it("rejects a non-http(s) Origin scheme", () => {
+    expect(originAllowed("file:///etc/passwd", { allowedHost: "kobe.local" })).toBe(false)
+    expect(originAllowed("ws://kobe.local", { allowedHost: "kobe.local" })).toBe(false)
+  })
+})
+
+describe("isLoopbackOrigin", () => {
+  it("recognizes loopback hosts and nothing else", () => {
+    expect(isLoopbackOrigin("http://localhost")).toBe(true)
+    expect(isLoopbackOrigin("http://127.0.0.1:45174")).toBe(true)
+    expect(isLoopbackOrigin("http://192.168.1.5")).toBe(false)
+    expect(isLoopbackOrigin(null)).toBe(false)
+  })
+})
+
+describe("allowedHostForBindHost", () => {
+  it("drops loopback bind hosts (nothing to gate — loopback is always allowed)", () => {
+    expect(allowedHostForBindHost("127.0.0.1")).toBeUndefined()
+    expect(allowedHostForBindHost("localhost")).toBeUndefined()
+    expect(allowedHostForBindHost("::1")).toBeUndefined()
+    expect(allowedHostForBindHost("")).toBeUndefined()
+    expect(allowedHostForBindHost(undefined)).toBeUndefined()
+  })
+
+  it("keeps a real LAN bind host, and originAllowed accepts its browser Origin despite case", () => {
+    const allowedHost = allowedHostForBindHost("MyMac.local")
+    expect(allowedHost).toBe("MyMac.local")
+    expect(originAllowed("http://mymac.local:45174", { allowedHost })).toBe(true)
+  })
+})


### PR DESCRIPTION
## Direction

Bugs / correctness — found by daily code review of the daemon web-transport surface (`packages/kobe-daemon/src/daemon/web-origin.ts`).

## Problem

The daemon-hosted dashboard gates cross-origin browser requests with `originAllowed(origin, { allowedHost })`. When the daemon binds to a non-loopback host, `allowedHost` is derived from the bind hostname (`allowedHostForBindHost`) with only a `.trim()` — the original case is preserved.

But the value it is compared against, `originHostname(origin)`, comes from `new URL(origin).hostname`, which the WHATWG URL spec **always lowercases** — and browsers likewise lowercase the host in the `Origin` header. So the comparison was:

```ts
hostname /* lowercased */ === allowedHost /* raw case */
```

Any bind host carrying an uppercase letter therefore never matched. This is routine, not exotic: macOS mDNS names like `MyMac.local` / `Johns-MBP.local` carry uppercase. The result was **every** browser request to the LAN dashboard returning `403 forbidden` — the whole dashboard locked out. DNS hostnames are case-insensitive by RFC 4343, so the comparison was objectively wrong.

## Fix

Lowercase the allowed bind host at the comparison site so both sides are compared case-insensitively, matching the case-folding the loopback check in the same file already does:

```ts
return hostname !== null && hostname === allowedHost.toLowerCase()
```

Loopback origins, missing-Origin (non-browser) requests, the no-allowed-host reject path, and non-http(s) scheme rejection are all unchanged.

## How verified

- Added `packages/kobe/test/daemon/web-origin.test.ts` (10 cases): no-Origin allow, loopback allow, no-allowed-host reject, exact-host match, **mixed-case bind host match (the regression)**, different-host reject, non-http(s) scheme reject, `isLoopbackOrigin`, and `allowedHostForBindHost` loopback-drop + LAN passthrough.
- Confirmed the test **fails without the fix** (the two case-insensitivity cases go red) and **passes with it**.
- Exported `./daemon/web-origin` from `packages/kobe-daemon/package.json` so the pure module is unit-testable via the same import convention as sibling daemon tests.
- Full daemon suite green (527 tests); repo-root `bun run lint` and `bun run typecheck` both green.
- Added a `patch` changeset.

## Follow-ups (deliberately deferred)

- The review also surfaced two lower-confidence edge cases left untouched to keep this slice tight: `terminalLines` CR-overwrite in `cli/api/read-output.ts` keeping only the last `\r` segment (correct for the common `≥`-length redraw / `\x1b[K`-clear cases), and `searchQueryKeystroke` in the sidebar rejecting astral code points (`seq.length !== 1`). Each is a candidate for its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZZ2gqZGyY5ZoZxd5GkgqA)_