### PR TITLE
fix: a sandbox daemon can no longer blank a real session's task sidebar

### DIFF
--- a/.changeset/tidy-otters-listen.md
+++ b/.changeset/tidy-otters-listen.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Stop a dev-sandbox daemon from blanking the task sidebar of a real session.
+
+An explicit socket-path override outranks the sandbox home, and the TUI stamps the production socket onto every task terminal it spawns — so a `dev:sandbox` started from inside one bound the real socket and served its own empty task index. Attached sessions reconnected onto it and showed "No active tasks" while every task sat intact on disk.
+
+The sandbox now drops inherited socket/pid paths and uses its own web port, and `hello` reports the daemon's home so a client refuses one that belongs somewhere else instead of adopting its task list. Recovery needs no restart: the reconnect loop re-syncs as soon as the right daemon holds the socket.

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -205,6 +205,26 @@ TUI may show any task at any time.
 > nor unlinks the socket/pidfile another daemon now owns. Client-side,
 > `ensureDaemonReachable`'s stop+spawn sequence is serialized by a
 > `daemon.pid.spawn-lock` file so concurrent clients can't twin-spawn daemons.
+>
+> **Home ownership (2026-08-13):** succession answers "who owns the path", not
+> "whose data is behind it". An explicit `*_DAEMON_SOCKET_PATH` outranks
+> `*_HOME_DIR` in `paths.ts`, and the TUI stamps the production socket onto its
+> own env — which every task terminal it spawns inherits. A `dev:sandbox`
+> launched from inside a task terminal therefore bound the REAL socket while
+> serving its own empty task index; attached TUIs reconnected onto it and
+> rendered "No active tasks" with every task intact on disk. Two guards, because
+> either alone leaves the hole open:
+>
+> - **Isolated launchers drop inherited paths.** `sandboxChildEnv()` deletes
+>   `DAEMON_SOCKET_PATH` / `DAEMON_PID_PATH` / `PTY_SOCKET_PATH` / `PTY_PID_PATH`
+>   in BOTH env namespaces before stamping its own home, and takes its web port
+>   from `ROVE_SANDBOX_DAEMON_WEB_PORT` rather than the ambient production one.
+> - **Clients verify the home behind the socket.** `hello` reports the daemon's
+>   `homeDir`; a client whose own home differs throws instead of adopting the
+>   task list (`isForeignDaemonHome`). Fatal, unlike the stale-build check —
+>   serving another home's data silently corrupts what the user sees. The
+>   reconnect loop keeps retrying, so re-syncing needs no TUI restart. A daemon
+>   predating the field omits it and is never falsely rejected.
 
 ```bash
 $ kobed start            # binds ~/.kobe/daemon.sock, writes pidfile

--- a/packages/kobe-daemon/src/compat-env.ts
+++ b/packages/kobe-daemon/src/compat-env.ts
@@ -44,6 +44,21 @@ export function setRoveEnv(suffix: string, value: string, env: NodeJS.ProcessEnv
 }
 
 /**
+ * Unset a control in BOTH namespaces.
+ *
+ * The mirror image of {@link setRoveEnv}, and required for the same reason:
+ * deleting only `KOBE_*` leaves the `ROVE_*` twin behind, which the next
+ * wrapper faithfully mirrors back. Isolated launchers (dev sandbox, e2e
+ * fixtures) use this to drop an INHERITED path override that would otherwise
+ * outrank their own home — see `scripts/dev-sandbox-args.ts`.
+ */
+export function deleteRoveEnv(suffix: string, env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  delete env[`${ROVE_ENV_PREFIX}${suffix}`]
+  delete env[`${LEGACY_KOBE_ENV_PREFIX}${suffix}`]
+  return env
+}
+
+/**
  * Mirror every public ROVE_* control into the legacy internal namespace.
  * Existing KOBE_* values remain when no new-name value was supplied.
  */

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -118,6 +118,12 @@ export interface DaemonHandlerContext {
   readonly daemon: {
     readonly startedAt: Date
     readonly socketPath: string
+    /** The state root this daemon serves (`<homeDir>/.kobe`). Reported by
+     *  `hello` so a client can detect a daemon from a DIFFERENT home sitting
+     *  on its socket — a sandbox/dev daemon that inherited the production
+     *  socket path serves an EMPTY task index, which used to reach the TUI as
+     *  a legitimate "you have no tasks" (prod 2026-08-13). */
+    readonly homeDir?: string
     /** Loopback web transport port, when this daemon is exposing browser routes. */
     readonly webPort?: number
     /** Why the web transport isn't listening (port taken / bind failed), or
@@ -242,6 +248,11 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
           capabilities: [...CHANNEL_NAMES],
           daemonPid: ctx.daemon.pid,
           clientId: ctx.clientId,
+          // The state root behind `tasks` below. A client whose own home
+          // differs is talking to a foreign daemon (a sandbox one that
+          // inherited the production socket path) and must reject the list
+          // instead of rendering an empty sidebar — protocol.isForeignDaemonHome.
+          homeDir: ctx.daemon.homeDir,
           tasks: ctx.orch.listTasks().map(serializeTask),
         }
       },

--- a/packages/kobe-daemon/src/daemon/paths.ts
+++ b/packages/kobe-daemon/src/daemon/paths.ts
@@ -101,6 +101,17 @@ export function defaultDaemonSocketPath(homeDir?: string): string {
   return fitSocketPath(join(home, COMPAT_STATE_DIR_BASENAME, "daemon.sock"), home, "daemon")
 }
 
+/**
+ * The state root a daemon serves: an explicit option, else `*_HOME_DIR`, else
+ * the OS home. Mirrors the client-side `homeDir()` in `kobe/src/env.ts` so the
+ * two sides agree on what "same home" means — `hello` reports this value and
+ * the client compares it against its own before trusting the task list.
+ */
+export function resolveDaemonHomeDir(homeDir?: string): string {
+  const explicit = homeDir ?? readRoveEnv("HOME_DIR")
+  return explicit && explicit.length > 0 ? explicit : homedir()
+}
+
 export function defaultDaemonPidPath(homeDir = readRoveEnv("HOME_DIR") ?? homedir()): string {
   const override = readRoveEnv("DAEMON_PID_PATH")
   if (override && override.length > 0) return override

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -97,6 +97,34 @@ export function isDaemonVersionStale(daemonVersion: string | undefined, clientVe
   return daemonVersion !== clientVersion
 }
 
+/**
+ * Home-ownership check — the third, and bluntest, `hello` guard.
+ *
+ * The protocol range catches a breaking wire change and the build-version
+ * check catches stale code; neither notices a daemon that speaks perfectly but
+ * belongs to a DIFFERENT state root. That happens whenever an explicit
+ * `*_DAEMON_SOCKET_PATH` outranks a sandbox's `*_HOME_DIR` (see
+ * `scripts/dev-sandbox-args.ts`): the sandbox daemon binds the production
+ * socket and answers `hello` with its own empty task index, which the TUI
+ * used to render as a truthful "No active tasks" while every task sat intact
+ * on disk (prod 2026-08-13).
+ *
+ * FATAL by design, unlike {@link isDaemonVersionStale}: serving another home's
+ * data is silent corruption of what the user sees, so the client refuses the
+ * connection and keeps reconnecting rather than trusting the payload.
+ *
+ * Returns `false` when the daemon reports no home (one that predates the
+ * field), so an older daemon is never falsely rejected. Trailing separators
+ * are insignificant — `XDG_RUNTIME_DIR` and friends arrive both ways.
+ *
+ * Pure — unit-tested.
+ */
+export function isForeignDaemonHome(daemonHome: string | undefined, clientHome: string): boolean {
+  if (!daemonHome) return false
+  const strip = (value: string): string => value.replace(/[/\\]+$/, "")
+  return strip(daemonHome) !== strip(clientHome)
+}
+
 export type DaemonFrame =
   | { readonly type: "request"; readonly id: string; readonly name: DaemonRequestName; readonly payload?: unknown }
   | {

--- a/packages/kobe-daemon/src/daemon/server-options.ts
+++ b/packages/kobe-daemon/src/daemon/server-options.ts
@@ -1,0 +1,56 @@
+/**
+ * Construction options + the handle `startDaemonServer` returns.
+ *
+ * Split out of `server.ts` (which was over the repo's 500-line file-size cap)
+ * with no behavior change — both interfaces are re-exported from
+ * `daemon/server` so every existing import path keeps working.
+ */
+
+import type { DaemonClientConnection } from "./client-connection.ts"
+import type { UpdateInfo } from "./contracts.ts"
+import type { DaemonRuntimeAdapter } from "./runtime.ts"
+
+export interface DaemonServerOptions {
+  /** Product/runtime behavior injected by the kobe composition root. */
+  readonly runtime: DaemonRuntimeAdapter
+  readonly socketPath?: string
+  readonly pidPath?: string
+  readonly homeDir?: string
+  readonly startedAt?: Date
+  readonly onStop?: () => void | Promise<void>
+  /** Override the npm version check (tests inject a fake to avoid the network). */
+  readonly checkUpdate?: () => Promise<UpdateInfo | null>
+  /** Re-check interval in ms; `0` disables the poller. Defaults to 6h. */
+  readonly updatePollMs?: number
+  /** Auto-title re-scan interval in ms; `0` disables. Defaults to `DEFAULT_AUTO_TITLE_POLL_MS`. */
+  readonly autoTitlePollMs?: number
+  /** PR-status (`gh pr view`) poll interval in ms; `0` disables. Defaults to `DEFAULT_PR_STATUS_POLL_MS`. */
+  readonly prStatusPollMs?: number
+  /** UI-prefs watcher debounce in ms; `0` disables. Defaults to `DEFAULT_UI_PREFS_DEBOUNCE_MS`. */
+  readonly uiPrefsDebounceMs?: number
+  /** Keybindings watcher debounce in ms; `0` disables. Defaults to `DEFAULT_KEYBINDINGS_DEBOUNCE_MS`. */
+  readonly keybindingsDebounceMs?: number
+  /** Worktree-changes collector tick in ms; `0` disables. Defaults to `DEFAULT_WORKTREE_CHANGES_TICK_MS`. */
+  readonly worktreeChangesTickMs?: number
+  /** Transcript-activity collector tick in ms; `0` disables. Defaults to `DEFAULT_TRANSCRIPT_ACTIVITY_TICK_MS`. */
+  readonly transcriptActivityTickMs?: number
+  /** Optional loopback HTTP/SSE browser transport. Omitted in tests unless explicitly requested. */
+  readonly webPort?: number
+  /** Optional hostname for the browser transport. Defaults to 127.0.0.1. */
+  readonly webHost?: string
+  /** Optional static web UI directory served by the daemon web transport. */
+  readonly webStaticDir?: string
+  /** Enable the plugin runtime; `binPath` becomes plugins' KOBE_BIN_PATH. Omitted in tests. */
+  readonly plugins?: { readonly binPath: string }
+  /** Socket-ownership watch interval in ms; `0` disables the periodic check. */
+  readonly socketWatchMs?: number
+}
+
+export interface DaemonServer {
+  readonly socketPath: string
+  readonly pidPath: string
+  readonly startedAt: Date
+  readonly webPort?: number
+  readonly clients: ReadonlySet<DaemonClientConnection>
+  close(): Promise<void>
+}

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -15,16 +15,10 @@ import { readActivityLiveness } from "./activity-liveness.ts"
 import { type ActivityLivenessProbe, DaemonActivityRegistry } from "./activity-registry.ts"
 import { AttentionInboxStore, defaultAttentionInboxPath } from "./attention-inbox.ts"
 import { initAutomationsStore } from "./automation-wiring.ts"
-import {
-  type ClientState,
-  type DaemonClientConnection,
-  broadcast,
-  drainClientBuffer,
-  writeFrame,
-} from "./client-connection.ts"
+import { type ClientState, broadcast, drainClientBuffer, writeFrame } from "./client-connection.ts"
 import { ClientWriter } from "./client-writer.ts"
 import { startDaemonCollectors } from "./collectors.ts"
-import type { DaemonOrchestrator, UpdateInfo } from "./contracts.ts"
+import type { DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import { EngineEventLog } from "./engine-events-log.ts"
 import { DaemonEventBus } from "./event-bus.ts"
@@ -38,12 +32,12 @@ import {
 import { IssuesStore, defaultIssuesStorePath } from "./issues-store.ts"
 import { DaemonLifetime, FIRST_GUI_GRACE_MS, resolveIdleGraceMs } from "./lifetime.ts"
 import { NotesStore, defaultNotesStorePath } from "./notes-store.ts"
-import { defaultDaemonPidPath, defaultDaemonSocketPath } from "./paths.ts"
+import { defaultDaemonPidPath, defaultDaemonSocketPath, resolveDaemonHomeDir } from "./paths.ts"
 import { PromptBroker } from "./prompt-broker.ts"
 import { type DaemonFrame, normalizeChannelFilter, serializeTask } from "./protocol.ts"
 import { PtyLiveHold } from "./pty-live-hold.ts"
 import { QuotaUsageCache } from "./quota-usage-cache.ts"
-import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import type { DaemonServer, DaemonServerOptions } from "./server-options.ts"
 import { createSocketOwnershipGuard, listenOnUnixSocket } from "./socket-guard.ts"
 import { handleSubscribe } from "./subscribe.ts"
 import { TaskDeletionRunner } from "./task-deletion-runner.ts"
@@ -63,56 +57,17 @@ export { readPidFile } from "./socket-guard.ts"
 export { IssuesStore, defaultIssuesStorePath } from "./issues-store.ts"
 export { NotesStore, defaultNotesStorePath } from "./notes-store.ts"
 export type { DaemonClientConnection } from "./client-connection.ts"
-
-export interface DaemonServerOptions {
-  /** Product/runtime behavior injected by the kobe composition root. */
-  readonly runtime: DaemonRuntimeAdapter
-  readonly socketPath?: string
-  readonly pidPath?: string
-  readonly homeDir?: string
-  readonly startedAt?: Date
-  readonly onStop?: () => void | Promise<void>
-  /** Override the npm version check (tests inject a fake to avoid the network). */
-  readonly checkUpdate?: () => Promise<UpdateInfo | null>
-  /** Re-check interval in ms; `0` disables the poller. Defaults to 6h. */
-  readonly updatePollMs?: number
-  /** Auto-title re-scan interval in ms; `0` disables. Defaults to `DEFAULT_AUTO_TITLE_POLL_MS`. */
-  readonly autoTitlePollMs?: number
-  /** PR-status (`gh pr view`) poll interval in ms; `0` disables. Defaults to `DEFAULT_PR_STATUS_POLL_MS`. */
-  readonly prStatusPollMs?: number
-  /** UI-prefs watcher debounce in ms; `0` disables. Defaults to `DEFAULT_UI_PREFS_DEBOUNCE_MS`. */
-  readonly uiPrefsDebounceMs?: number
-  /** Keybindings watcher debounce in ms; `0` disables. Defaults to `DEFAULT_KEYBINDINGS_DEBOUNCE_MS`. */
-  readonly keybindingsDebounceMs?: number
-  /** Worktree-changes collector tick in ms; `0` disables. Defaults to `DEFAULT_WORKTREE_CHANGES_TICK_MS`. */
-  readonly worktreeChangesTickMs?: number
-  /** Transcript-activity collector tick in ms; `0` disables. Defaults to `DEFAULT_TRANSCRIPT_ACTIVITY_TICK_MS`. */
-  readonly transcriptActivityTickMs?: number
-  /** Optional loopback HTTP/SSE browser transport. Omitted in tests unless explicitly requested. */
-  readonly webPort?: number
-  /** Optional hostname for the browser transport. Defaults to 127.0.0.1. */
-  readonly webHost?: string
-  /** Optional static web UI directory served by the daemon web transport. */
-  readonly webStaticDir?: string
-  /** Enable the plugin runtime; `binPath` becomes plugins' KOBE_BIN_PATH. Omitted in tests. */
-  readonly plugins?: { readonly binPath: string }
-  /** Socket-ownership watch interval in ms; `0` disables the periodic check. */
-  readonly socketWatchMs?: number
-}
-
-export interface DaemonServer {
-  readonly socketPath: string
-  readonly pidPath: string
-  readonly startedAt: Date
-  readonly webPort?: number
-  readonly clients: ReadonlySet<DaemonClientConnection>
-  close(): Promise<void>
-}
+export type { DaemonServer, DaemonServerOptions } from "./server-options.ts"
 
 export async function startDaemonServer(orch: DaemonOrchestrator, options: DaemonServerOptions): Promise<DaemonServer> {
   const runtime = options.runtime
   const socketPath = options.socketPath ?? defaultDaemonSocketPath(options.homeDir)
   const pidPath = options.pidPath ?? defaultDaemonPidPath(options.homeDir)
+  // The state root this daemon actually serves. Reported by `hello` so a
+  // client can refuse a daemon that belongs to a DIFFERENT home before it
+  // renders that daemon's (empty) task list as its own — see
+  // `isForeignDaemonHome` in protocol.ts.
+  const homeDir = resolveDaemonHomeDir(options.homeDir)
   const startedAt = options.startedAt ?? new Date()
   // Never steal a live daemon's socket: an unconditional pre-bind unlink let
   // an autospawned daemon usurp the path while the incumbent kept serving its
@@ -409,6 +364,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       daemon: {
         startedAt,
         socketPath,
+        homeDir,
         webPort: webServer?.port,
         webError,
         pid: process.pid,

--- a/packages/kobe/scripts/dev-sandbox-args.ts
+++ b/packages/kobe/scripts/dev-sandbox-args.ts
@@ -1,7 +1,24 @@
-import { readRoveEnv, setRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
+import { deleteRoveEnv, readRoveEnv, setRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
 
 export type SandboxMode = "run" | "reset" | "home"
 export type SandboxArgs = { mode: SandboxMode }
+
+/** The sandbox daemon's own web port — never production's 45174. */
+export const SANDBOX_DAEMON_WEB_PORT = "5274"
+
+/**
+ * Ambient path overrides the sandbox must DROP rather than inherit.
+ *
+ * `defaultDaemonSocketPath()` / `defaultPtyHostSocketPath()` give an explicit
+ * `*_SOCKET_PATH` override priority OVER `*_HOME_DIR`. The TUI stamps the
+ * production socket onto its own env (`tui-react/workspace/host.tsx`), and
+ * every task terminal it spawns inherits it — so a `dev:sandbox` launched from
+ * inside a kobe task terminal used to bind the PRODUCTION socket while serving
+ * its own empty task index. Attached TUIs then reconnected onto the sandbox
+ * daemon and rendered "No active tasks" with every task still on disk
+ * (prod 2026-08-13). Stamping HOME_DIR is not enough; the override has to go.
+ */
+const INHERITED_PATH_OVERRIDES = ["DAEMON_SOCKET_PATH", "DAEMON_PID_PATH", "PTY_SOCKET_PATH", "PTY_PID_PATH"] as const
 
 function isSandboxMode(value: string | undefined): value is SandboxMode {
   return value === "run" || value === "reset" || value === "home"
@@ -17,7 +34,14 @@ export function parseSandboxArgs(args: readonly string[]): SandboxArgs {
 /** Build a child environment whose sandbox invariants beat ambient aliases. */
 export function sandboxChildEnv(home: string, parent: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const env = { ...parent }
-  const webPort = readRoveEnv("DAEMON_WEB_PORT", parent) ?? "5274"
+  // Drop inherited production paths BEFORE stamping our own, so nothing an
+  // ambient value could outrank survives into the child.
+  for (const suffix of INHERITED_PATH_OVERRIDES) deleteRoveEnv(suffix, env)
+  // The web port is sandbox-scoped too: read it from the SANDBOX_* namespace
+  // (like SANDBOX_HOME_DIR) so a developer can still pick a port, while an
+  // ambient production `DAEMON_WEB_PORT` — stamped by `kobe web` — cannot
+  // drag the sandbox onto production's listener.
+  const webPort = readRoveEnv("SANDBOX_DAEMON_WEB_PORT", parent) ?? SANDBOX_DAEMON_WEB_PORT
   setRoveEnv("DEV", "1", env)
   setRoveEnv("HOME_DIR", home, env)
   setRoveEnv("DAEMON_WEB_PORT", webPort, env)

--- a/packages/kobe/src/client/remote-orchestrator-connect.ts
+++ b/packages/kobe/src/client/remote-orchestrator-connect.ts
@@ -15,8 +15,10 @@ import {
   MIN_COMPATIBLE_PROTOCOL_VERSION,
   type SerializedTask,
   type SubscribeRole,
+  isForeignDaemonHome,
   isProtocolCompatible,
 } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { homeDir } from "../env.ts"
 import { type OrchestratorSignals, deserializeTask } from "./remote-orchestrator-payloads.ts"
 
 export interface PerformInitOptions {
@@ -80,6 +82,9 @@ export async function performInit(
     // Distinct from the protocol versions above: those gate compatibility,
     // this drives the non-fatal stale-build banner (see daemonStaleSignal).
     kobeVersion?: string
+    // The state root the daemon serves. Omitted by a daemon that predates
+    // the field, in which case the ownership check below is skipped.
+    homeDir?: string
     // The daemon's channel/feature set. The client gates the
     // `worktree.changes` consumer on it (see below) — a capability list
     // is the honest rollout mechanism for an additive channel: an old
@@ -102,6 +107,19 @@ export async function performInit(
   ) {
     throw new Error(
       `kobe daemon is protocol v${daemonVersion} (min v${daemonMin}); this client is v${DAEMON_PROTOCOL_VERSION} (min v${MIN_COMPATIBLE_PROTOCOL_VERSION}). Restart the daemon (\`kobe daemon restart\`) or upgrade kobe.`,
+    )
+  }
+  // Reject a daemon serving a DIFFERENT home BEFORE any of its state is
+  // believed. A sandbox daemon that inherited the production socket path
+  // answers hello perfectly and hands back its own empty task list; without
+  // this the TUI adopted it as the truth and blanked the sidebar while every
+  // task sat intact on disk (prod 2026-08-13). Throwing keeps the caller's
+  // reconnect loop running, so the moment the real daemon reclaims the socket
+  // the client re-syncs on its own.
+  const clientHome = homeDir()
+  if (isForeignDaemonHome(hello.homeDir, clientHome)) {
+    throw new Error(
+      `kobe daemon on this socket serves ${hello.homeDir}, but this client uses ${clientHome}. A sandbox or dev daemon has taken the production socket — stop it (\`kobe daemon stop\`), or unset ROVE_DAEMON_SOCKET_PATH / KOBE_DAEMON_SOCKET_PATH before starting it.`,
     )
   }
   // Capture the daemon's BUILD version (NON-fatal — the protocol is already

--- a/packages/kobe/test/cli/dev-sandbox-args.test.ts
+++ b/packages/kobe/test/cli/dev-sandbox-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { parseSandboxArgs, sandboxChildEnv } from "../../scripts/dev-sandbox-args"
+import { SANDBOX_DAEMON_WEB_PORT, parseSandboxArgs, sandboxChildEnv } from "../../scripts/dev-sandbox-args"
 
 describe("parseSandboxArgs", () => {
   it("defaults to the sole run mode", () => {
@@ -19,18 +19,57 @@ describe("parseSandboxArgs", () => {
 })
 
 describe("sandboxChildEnv", () => {
-  it("overrides ambient home aliases and preserves ROVE_* port precedence", () => {
+  it("overrides ambient home aliases in both namespaces", () => {
     const env = sandboxChildEnv("/tmp/isolated", {
       ROVE_HOME_DIR: "/real-rove-home",
       KOBE_HOME_DIR: "/real-kobe-home",
-      ROVE_DAEMON_WEB_PORT: "6123",
-      KOBE_DAEMON_WEB_PORT: "4999",
     })
 
     expect(env.ROVE_HOME_DIR).toBe("/tmp/isolated")
     expect(env.KOBE_HOME_DIR).toBe("/tmp/isolated")
     expect(env.ROVE_DEV).toBe("1")
     expect(env.KOBE_DEV).toBe("1")
+  })
+
+  // The prod 2026-08-13 socket hijack: a TUI stamps the production socket onto
+  // every task terminal it spawns, and an explicit socket path outranks
+  // HOME_DIR — so an inherited one made the sandbox daemon bind the REAL
+  // socket and serve its empty task index to attached TUIs.
+  it("drops inherited socket and pid overrides that would outrank the sandbox home", () => {
+    const env = sandboxChildEnv("/tmp/isolated", {
+      KOBE_DAEMON_SOCKET_PATH: "/run/user/1000/kobe.sock",
+      ROVE_DAEMON_SOCKET_PATH: "/run/user/1000/kobe.sock",
+      KOBE_PTY_SOCKET_PATH: "/run/user/1000/kobe-pty.sock",
+      ROVE_PTY_SOCKET_PATH: "/run/user/1000/kobe-pty.sock",
+      KOBE_DAEMON_PID_PATH: "/home/dev/.kobe/daemon.pid",
+      ROVE_DAEMON_PID_PATH: "/home/dev/.kobe/daemon.pid",
+      KOBE_PTY_PID_PATH: "/home/dev/.kobe/pty.pid",
+      ROVE_PTY_PID_PATH: "/home/dev/.kobe/pty.pid",
+    })
+
+    for (const key of ["DAEMON_SOCKET_PATH", "DAEMON_PID_PATH", "PTY_SOCKET_PATH", "PTY_PID_PATH"]) {
+      expect(env[`KOBE_${key}`]).toBeUndefined()
+      expect(env[`ROVE_${key}`]).toBeUndefined()
+    }
+    expect(env.KOBE_HOME_DIR).toBe("/tmp/isolated")
+  })
+
+  it("ignores an ambient production web port and uses the sandbox default", () => {
+    const env = sandboxChildEnv("/tmp/isolated", {
+      ROVE_DAEMON_WEB_PORT: "45174",
+      KOBE_DAEMON_WEB_PORT: "45174",
+    })
+
+    expect(env.ROVE_DAEMON_WEB_PORT).toBe(SANDBOX_DAEMON_WEB_PORT)
+    expect(env.KOBE_DAEMON_WEB_PORT).toBe(SANDBOX_DAEMON_WEB_PORT)
+  })
+
+  it("still honours an explicitly sandbox-scoped web port", () => {
+    const env = sandboxChildEnv("/tmp/isolated", {
+      ROVE_SANDBOX_DAEMON_WEB_PORT: "6123",
+      KOBE_DAEMON_WEB_PORT: "45174",
+    })
+
     expect(env.ROVE_DAEMON_WEB_PORT).toBe("6123")
     expect(env.KOBE_DAEMON_WEB_PORT).toBe("6123")
   })

--- a/packages/kobe/test/client/remote-orchestrator-foreign-home.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-foreign-home.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { RemoteOrchestrator } from "../../src/client/remote-orchestrator.ts"
+
+/**
+ * Home-ownership guard (prod 2026-08-13).
+ *
+ * A `dev:sandbox` daemon inherited `KOBE_DAEMON_SOCKET_PATH` from the task
+ * terminal it was launched in. Because an explicit socket override outranks
+ * `*_HOME_DIR`, it bound the PRODUCTION socket while serving its own — empty —
+ * task index. Attached TUIs reconnected onto it, `hello` succeeded, and the
+ * sidebar went blank ("No active tasks") with all 27 tasks intact on disk.
+ *
+ * Every other handshake check passed, because nothing was wrong with the
+ * wire. What these lock is that a client refuses a daemon belonging to a
+ * DIFFERENT home before adopting a single task from it.
+ */
+
+const FOREIGN_TASK = {
+  id: "01KZZZZZZZZZZZZZZZZZZZZZZZ",
+  title: "a sandbox task that is not ours",
+  repo: "/sandbox/repo",
+  branch: "sandbox/branch",
+  worktreePath: "/sandbox/wt",
+  kind: "main",
+  status: "backlog",
+  archived: false,
+  pinned: false,
+  vendor: "claude",
+  createdAt: "2026-08-13T00:00:00.000Z",
+  updatedAt: "2026-08-13T00:00:00.000Z",
+}
+
+function fakeClient(hello: Record<string, unknown>): KobeDaemonClient {
+  return {
+    on: () => () => {},
+    onLifecycle: () => () => {},
+    get isDisposed() {
+      return false
+    },
+    request: (name: string) =>
+      name === "hello" ? Promise.resolve({ protocolVersion: 2, minProtocolVersion: 2, ...hello }) : Promise.resolve({}),
+    subscribe: () => Promise.resolve({}),
+  } as unknown as KobeDaemonClient
+}
+
+describe("RemoteOrchestrator home-ownership guard", () => {
+  let home: string
+  const prev = process.env.KOBE_HOME_DIR
+
+  beforeEach(async () => {
+    // init() logs to client.log — keep that off the real ~/.kobe.
+    home = await mkdtemp(join(tmpdir(), "kobe-orch-home-"))
+    process.env.KOBE_HOME_DIR = home
+  })
+
+  afterEach(async () => {
+    // biome-ignore lint/performance/noDelete: env must fully unset when it was unset pre-test (assigning undefined leaves the string "undefined").
+    if (prev === undefined) delete process.env.KOBE_HOME_DIR
+    else process.env.KOBE_HOME_DIR = prev
+    await rm(home, { recursive: true, force: true })
+  })
+
+  it("refuses a daemon serving a different home, and adopts none of its tasks", async () => {
+    const orch = new RemoteOrchestrator(fakeClient({ homeDir: "/repo/packages/kobe/.dev-sandbox/home", tasks: [] }), {
+      role: "gui",
+    })
+
+    await expect(orch.init()).rejects.toThrow(/serves \/repo\/packages\/kobe\/\.dev-sandbox\/home/)
+    expect(orch.tasksSignal()()).toEqual([])
+  })
+
+  it("never lets a foreign daemon's task list reach the sidebar", async () => {
+    // The blast radius that mattered: an EMPTY list read as truth. Assert the
+    // inverse too — a foreign daemon's tasks are equally untrusted.
+    const orch = new RemoteOrchestrator(fakeClient({ homeDir: "/elsewhere", tasks: [FOREIGN_TASK] }), { role: "gui" })
+
+    await expect(orch.init()).rejects.toThrow(/A sandbox or dev daemon has taken the production socket/)
+    expect(orch.tasksSignal()()).toEqual([])
+  })
+
+  it("accepts a daemon on the same home and hydrates its tasks", async () => {
+    const orch = new RemoteOrchestrator(fakeClient({ homeDir: home, tasks: [FOREIGN_TASK] }), { role: "gui" })
+
+    await orch.init()
+    expect(orch.tasksSignal()()).toHaveLength(1)
+    expect(orch.connectionStateSignal()()).toBe("online")
+  })
+
+  it("accepts a daemon that predates the homeDir field (rolling upgrade)", async () => {
+    // Same tolerance as the kobeVersion handshake: an old daemon omits the
+    // field and must not be rejected on evidence it cannot supply.
+    const orch = new RemoteOrchestrator(fakeClient({ tasks: [FOREIGN_TASK] }), { role: "gui" })
+
+    await orch.init()
+    expect(orch.tasksSignal()()).toHaveLength(1)
+  })
+})

--- a/packages/kobe/test/daemon/protocol.test.ts
+++ b/packages/kobe/test/daemon/protocol.test.ts
@@ -1,6 +1,7 @@
 import {
   isChannelName,
   isDaemonVersionStale,
+  isForeignDaemonHome,
   isProtocolCompatible,
   normalizeChannelFilter,
 } from "@sma1lboy/kobe-daemon/daemon/protocol"
@@ -34,6 +35,31 @@ describe("isProtocolCompatible", () => {
     const ab = isProtocolCompatible({ ...a, remoteVersion: b.localVersion, remoteMin: b.localMin })
     const ba = isProtocolCompatible({ ...b, remoteVersion: a.localVersion, remoteMin: a.localMin })
     expect(ab).toBe(ba)
+  })
+})
+
+describe("isForeignDaemonHome", () => {
+  it("accepts a daemon serving the same home", () => {
+    expect(isForeignDaemonHome("/home/dev", "/home/dev")).toBe(false)
+  })
+
+  it("rejects a sandbox daemon squatting on the production socket", () => {
+    // prod 2026-08-13: `dev:sandbox` inherited KOBE_DAEMON_SOCKET_PATH from the
+    // task terminal, bound the real socket, and served an EMPTY task index.
+    expect(isForeignDaemonHome("/repo/packages/kobe/.dev-sandbox/home", "/home/dev")).toBe(true)
+  })
+
+  it("ignores trailing separators on either side", () => {
+    // XDG_RUNTIME_DIR and friends arrive with and without the trailing slash;
+    // a cosmetic difference must never look like a foreign daemon.
+    expect(isForeignDaemonHome("/home/dev/", "/home/dev")).toBe(false)
+    expect(isForeignDaemonHome("/home/dev", "/home/dev/")).toBe(false)
+  })
+
+  it("accepts a daemon that reports no home (predates the field)", () => {
+    // Same rolling-upgrade rule as kobeVersion: an old daemon is never
+    // rejected on evidence it cannot supply.
+    expect(isForeignDaemonHome(undefined, "/home/dev")).toBe(false)
   })
 })
 


### PR DESCRIPTION
## The bug

Tasks vanished from the sidebar mid-session — "No active tasks — create one above." — while `~/.kobe/tasks.json` still held all 27 tasks, including the one actively running.

## Root cause

A **dev-sandbox daemon bound the production socket and served its own empty task index.**

```
<worktree>/packages/kobe/.dev-sandbox/home/.kobe/daemon.log
  rove daemon: listening on /run/user/1000/kobe.sock     ← production socket
```

That sandbox home has no `tasks.json` at all. The timestamps line up exactly — sandbox daemon `19:57:57.780 client #8 subscribed as gui` against the client's `19:57:57.781 subscribed as gui (0 tasks)`, and `19:55:34.916 pid=52014 subscribed as gui (0 tasks)` is a long-running TUI going blank without ever restarting. Meanwhile the real daemon could not reclaim the path: `another daemon is already serving /run/user/1000/kobe.sock — refusing to replace it`.

The chain:

1. `tui-react/workspace/host.tsx` stamps `process.env.KOBE_DAEMON_SOCKET_PATH = client.socketPath` — the **production** socket — onto its own env. The PTY host and every task terminal shell it spawns inherit it.
2. `sandboxChildEnv()` stamped `DEV` / `HOME_DIR` / `DAEMON_WEB_PORT` but left the inherited socket path alone.
3. `defaultDaemonSocketPath()` checks the explicit override **before** `HOME_DIR`, so the sandbox daemon resolved production's socket while its task store stayed in the sandbox home.
4. An attached TUI's reconnect landed on it, `hello` succeeded, and `hello.tasks = []` was adopted as truth.

Not introduced by #420 — pre-#420 `dev-sandbox.ts` had the same gap and the `host.tsx` stamp dates to 2026-07-07. #420 did fix exactly this leak for the e2e fixture (`visual-fixture.ts` scrubs all four socket vars) without extending it to `dev:sandbox`. What changed was the workflow: running `dev:sandbox` from inside a kobe task terminal, which the rename verification work was the first to do.

## The fix

Two layers, because either alone leaves the hole open.

**Isolated launchers drop inherited paths.** `sandboxChildEnv()` deletes `DAEMON_SOCKET_PATH` / `DAEMON_PID_PATH` / `PTY_SOCKET_PATH` / `PTY_PID_PATH` in both env namespaces before stamping its own home, and sources its web port from `ROVE_SANDBOX_DAEMON_WEB_PORT` (matching the existing `SANDBOX_HOME_DIR` convention) so an ambient production port can't drag it onto production's listener either.

**Clients verify the home behind the socket.** `hello` now reports the daemon's `homeDir`; `isForeignDaemonHome()` compares it against the client's own and `performInit` throws rather than adopting the task list. Fatal by design, unlike the stale-build check — serving another home's data is silent corruption of what the user sees. The reconnect loop keeps running, so the client re-syncs on its own the moment the right daemon holds the socket; no TUI restart. A daemon predating the field omits it and is never falsely rejected.

`DaemonServerOptions` / `DaemonServer` move to `server-options.ts` — `server.ts` was at 507 lines, over the cap, and this change touches it. Pure type move, re-exported from the same path. 507 → 463.

## Tests

- `isForeignDaemonHome`: same home, sandbox squatter, trailing-separator noise, and the old-daemon-omits-the-field tolerance.
- `sandboxChildEnv`: all four inherited path overrides dropped in both namespaces; ambient production web port ignored; explicit sandbox-scoped port still honoured.
- `remote-orchestrator-foreign-home`: a foreign daemon's task list — empty **and** non-empty — never reaches the sidebar; a same-home daemon hydrates normally; a daemon without the field is accepted.

Full suite green (`2975 + 521` passed), lint and typecheck clean. The 3 pre-existing `kobe-web` failures (`server-session`, `web-state-routes`) reproduce identically on `main` at 062cd2c3 and are untouched by this change.
