### PR TITLE
feat: cross-engine handoff works from every built-in engine

### DIFF
--- a/.changeset/cross-engine-handoff-all-engines.md
+++ b/.changeset/cross-engine-handoff-all-engines.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+feat: cross-engine handoff now works FROM every built-in engine, not just claude/codex. Copilot's refusal was stale — each session dir already holds the `events.jsonl` the reader parses, so it just needed naming. Kimi gets a path-only reader (`session_index.jsonl` → `agents/main/wire.jsonl`): it still parses no messages, but a handoff hands over a path, not a transcript, so that's all it ever needed — and it lights kimi's activity badge as a side effect. Only custom engines are still refused, since Rove can't know their store.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -15,16 +15,18 @@ Task = git worktree + engine session + branch
 | Claude Code | `claude` | ✓ | ✓ | ✓ | ✓ |
 | Codex | `codex` | ✓ | ✓ (after you trust hooks) | ✓ | ✓ + effort levels |
 | GitHub Copilot | `copilot` | ✓ | partial | ✓ | — |
-| Kimi Code | `kimi` | ✓ | — | — | — |
+| Kimi Code | `kimi` | ✓ | ✓ | handoff only | — |
 | Anything you register | custom | — | — | — | — |
 
 **Claude Code is the default** and the most complete: its quota probe drives
 rate-limit auto-resume and the Settings usage dashboard.
 
-**Kimi is partial.** Rove finds the binary and reads its login state, so it
-launches and shows your account. But its session format is unverified, so
-there's no history reader — auto-title keeps the placeholder and
-`rove api read-output` reports `engine_unsupported` rather than guessing.
+**Kimi is partial.** Rove finds the binary, reads its login state, and can
+locate each session's transcript — enough to watch it for activity and to
+hand the conversation to another engine. It still doesn't *parse* that
+transcript (the wire format is unverified), so auto-title keeps the
+placeholder and `rove api read-output` reports `engine_unsupported` rather
+than guessing.
 
 ## Picking an engine
 
@@ -105,9 +107,11 @@ a usage limit mid-task. The new engine starts fresh with a first prompt that
 points it at the old session's transcript and asks it to state where the
 previous one stopped — that sentence is how you check the handoff landed.
 
-Handoffs work claude ⇄ codex in both directions. A handoff *from* Copilot,
-Kimi, or a custom engine is refused with a reason (Rove can't name their
-transcript); a handoff *to* them works fine.
+Handoffs work in every direction between the four built-ins — the receiving
+agent is handed the previous transcript's *path* and reads it in whatever
+format it finds, so no format ever has to be converted. Only a **custom**
+engine can't be a handoff source (Rove doesn't know its session store); that
+case is refused with a reason. A handoff *to* a custom engine works fine.
 
 ## Custom engines
 
@@ -140,7 +144,8 @@ Engines own their own history. Rove reads it, never writes it.
 |---|---|
 | `claude` | `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` |
 | `codex` | `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl` |
-| `copilot` | `~/.copilot/session-state/<id>/` |
+| `copilot` | `~/.copilot/session-state/<id>/events.jsonl` |
+| `kimi` | `~/.kimi-code/sessions/<workspace>/<session>/agents/main/wire.jsonl` |
 
 That's why a crash never loses a conversation, and why history survives
 `rove reset` and a machine reboot.

--- a/packages/kobe/src/engine/history-readers.ts
+++ b/packages/kobe/src/engine/history-readers.ts
@@ -1,0 +1,104 @@
+/**
+ * The per-vendor {@link EngineHistoryReader} implementations, split out of
+ * `registry.ts` (file-size cap). Each is a thin adapter over its vendor's
+ * `*-local/history.ts` module, normalizing store quirks to the registry's
+ * contract — nothing else in the tree should import these directly; go
+ * through `engineEntry(vendor).history`.
+ *
+ * Must stay importable from vitest and MUST NOT import from `src/tui/`.
+ */
+
+import path from "node:path"
+import * as claudeHistory from "./claude-code-local/history.ts"
+import * as codexHistory from "./codex-local/history.ts"
+import * as copilotHistory from "./copilot-local/history.ts"
+import * as kimiHistory from "./kimi-local/history.ts"
+// Type-only, so the registry↔readers pair is not a runtime cycle.
+import type { EngineHistoryReader } from "./registry.ts"
+
+/**
+ * The documented empty history reader for engines with no on-disk
+ * transcript store (custom engines). Auto-title then keeps the placeholder
+ * title rather than mis-reading claude's transcripts (the old
+ * `else → claude` default would do exactly that for any unknown id).
+ */
+export const EMPTY_HISTORY: EngineHistoryReader = {
+  async listSessionIdsForWorktree() {
+    return []
+  },
+  async readHistory() {
+    return []
+  },
+  async transcriptPath() {
+    return null
+  },
+  // No transcript store → no activity signal (the Ops badge stays dark
+  // rather than mis-watching another vendor's files).
+  async latestTranscriptMtimeForWorktree() {
+    return 0
+  },
+}
+
+/**
+ * Claude's reader. `listSessionFilesForWorktree` sorts NEWEST-first (the
+ * activity callers want that); the registry contract is oldest-first,
+ * so re-sort ascending by mtime here — exactly what auto-title did inline.
+ */
+export const claudeHistoryReader: EngineHistoryReader = {
+  async listSessionIdsForWorktree(worktree) {
+    const files = await claudeHistory.listSessionFilesForWorktree(worktree)
+    return [...files].sort((a, b) => a.mtimeMs - b.mtimeMs).map((f) => f.sessionId)
+  },
+  readHistory: (sessionId) => claudeHistory.readHistory(sessionId),
+  async transcriptPath(sessionId, worktree) {
+    const files = await claudeHistory.listSessionFilesForWorktree(worktree)
+    return files.find((f) => f.sessionId === sessionId)?.path ?? null
+  },
+  latestTranscriptMtimeForWorktree: (worktree) => claudeHistory.latestTranscriptMtimeForWorktree(worktree),
+}
+
+/** Codex's reader — `listSessionIdsForWorktree` is already oldest-first. */
+export const codexHistoryReader: EngineHistoryReader = {
+  listSessionIdsForWorktree: (worktree) => codexHistory.listSessionIdsForWorktree(worktree),
+  readHistory: (sessionId) => codexHistory.readHistory(sessionId),
+  // The rollout filename embeds the UUID; the store is date-keyed, not
+  // worktree-keyed, so the worktree argument is unused here.
+  transcriptPath: async (sessionId) => (await codexHistory.findRolloutFile(sessionId)) ?? null,
+  latestTranscriptMtimeForWorktree: (worktree) => codexHistory.latestTranscriptMtimeForWorktree(worktree),
+}
+
+export const copilotHistoryReader: EngineHistoryReader = {
+  listSessionIdsForWorktree: (worktree) => copilotHistory.listSessionIdsForWorktree(worktree),
+  readHistory: (sessionId) => copilotHistory.readHistory(sessionId),
+  // Each session is a dir holding the `events.jsonl` this reader already
+  // parses — so the handoff has a file to name (the earlier "not mapped to
+  // a per-session file" note predated `findSessionDir`).
+  async transcriptPath(sessionId) {
+    const dir = await copilotHistory.findSessionDir(sessionId)
+    return dir ? path.join(dir, "events.jsonl") : null
+  },
+  latestTranscriptMtimeForWorktree: (worktree) => copilotHistory.latestTranscriptMtimeForWorktree(worktree),
+}
+
+/**
+ * Kimi's reader — PATHS ONLY. Its `wire.jsonl` is a protocol stream whose
+ * message shape Rove hasn't verified, so `readHistory` stays the empty
+ * one (auto-title keeps the placeholder rather than mis-parsing) while
+ * the handoff still gets a real file to hand the next agent. That split is
+ * exactly why the handoff passes a path instead of converting transcripts.
+ */
+export const kimiHistoryReader: EngineHistoryReader = {
+  listSessionIdsForWorktree: (worktree) => kimiHistory.listSessionIdsForWorktree(worktree),
+  // Shares EMPTY_HISTORY's function so `supportsStructuredHistory` reports
+  // kimi honestly as "no message reader".
+  readHistory: EMPTY_HISTORY.readHistory,
+  transcriptPath: (sessionId) => kimiHistory.transcriptPath(sessionId),
+  // Activity = newest stream mtime, which the id walk already stats.
+  async latestTranscriptMtimeForWorktree(worktree) {
+    const ids = await kimiHistory.listSessionIdsForWorktree(worktree)
+    const newest = ids.at(-1)
+    if (!newest) return 0
+    const file = await kimiHistory.transcriptPath(newest)
+    return file ? await kimiHistory.transcriptMtime(file) : 0
+  },
+}

--- a/packages/kobe/src/engine/kimi-local/history.ts
+++ b/packages/kobe/src/engine/kimi-local/history.ts
@@ -1,0 +1,125 @@
+/**
+ * Kimi Code's transcript store — PATHS ONLY, no message parsing.
+ *
+ * The wire format (`agents/<agent>/wire.jsonl`, a protocol stream rather
+ * than a message log) is still unverified against a real conversation, so
+ * Rove does not parse it: `readHistory` stays empty and auto-title keeps
+ * the placeholder rather than guessing. What IS verified (live install,
+ * 2026-08-13) is the layout, and that is all a cross-engine handoff needs
+ * — it hands the next agent the transcript's PATH and lets it read the
+ * file in whatever format it finds (see `session-handoff.ts`).
+ *
+ *   ~/.kimi-code/session_index.jsonl   one line per session:
+ *                                      {sessionId, sessionDir, workDir}
+ *   <sessionDir>/agents/main/wire.jsonl   the main agent's stream
+ *                                         (sub-agents get their own dirs)
+ *
+ * The index is the worktree map — `workDir` is the cwd kimi was launched
+ * in, matched against the task's worktree exactly like copilot's
+ * `workspace.yaml` `cwd`.
+ */
+
+import { stat } from "node:fs/promises"
+import { homedir } from "node:os"
+import path from "node:path"
+import { readTextFileBounded } from "../file-bounds"
+
+export interface KimiHistoryDeps {
+  kimiDir(): string
+  readFile(p: string): Promise<string>
+  stat(p: string): Promise<{ mtimeMs: number }>
+}
+
+const defaultDeps: KimiHistoryDeps = {
+  kimiDir() {
+    const override = process.env.KIMI_CODE_HOME?.trim()
+    return override || path.join(homedir(), ".kimi-code")
+  },
+  async readFile(p) {
+    // Size-bounded like the other readers: a corrupt index degrades to ""
+    // rather than slurping an unbounded file.
+    return await readTextFileBounded(p)
+  },
+  stat,
+}
+
+export interface KimiSessionEntry {
+  readonly sessionId: string
+  readonly sessionDir: string
+  readonly workDir: string
+}
+
+/** Parse `session_index.jsonl`, skipping malformed or incomplete lines. */
+export function parseSessionIndex(raw: string): KimiSessionEntry[] {
+  const out: KimiSessionEntry[] = []
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue
+    try {
+      const { sessionId, sessionDir, workDir } = JSON.parse(line) as Partial<KimiSessionEntry>
+      if (sessionId && sessionDir && workDir) out.push({ sessionId, sessionDir, workDir })
+    } catch {
+      // partial line from a concurrent append — skip
+    }
+  }
+  return out
+}
+
+async function sessionIndex(deps: KimiHistoryDeps): Promise<KimiSessionEntry[]> {
+  const raw = await deps.readFile(path.join(deps.kimiDir(), "session_index.jsonl")).catch(() => "")
+  return parseSessionIndex(raw)
+}
+
+/** The main agent's stream — the one a handoff points at. Sub-agent dirs
+ *  (`agents/agent-N/`) are that session's internal fan-out, not its
+ *  conversation. */
+export function wirePath(sessionDir: string): string {
+  return path.join(sessionDir, "agents", "main", "wire.jsonl")
+}
+
+/**
+ * Session ids rooted at `worktree`, OLDEST-FIRST per the registry
+ * contract. Ordered by `wire.jsonl` mtime (last activity) rather than the
+ * index's append order, so `.at(-1)` — what the handoff forks from — is the
+ * conversation actually worked in most recently, not merely created last.
+ * Sessions whose stream is missing are dropped: nothing to hand over.
+ */
+export async function listSessionIdsForWorktree(
+  worktree: string,
+  deps: KimiHistoryDeps = defaultDeps,
+): Promise<string[]> {
+  if (!worktree) return []
+  const matches: { id: string; mtimeMs: number }[] = []
+  for (const entry of await sessionIndex(deps)) {
+    if (entry.workDir !== worktree) continue
+    const mtimeMs = await deps
+      .stat(wirePath(entry.sessionDir))
+      .then((s) => s.mtimeMs)
+      .catch(() => null)
+    if (mtimeMs === null) continue
+    matches.push({ id: entry.sessionId, mtimeMs })
+  }
+  return matches.sort((a, b) => a.mtimeMs - b.mtimeMs).map((m) => m.id)
+}
+
+/** mtime (epoch ms) of a stream this module resolved, or 0 when it went
+ *  away between the resolve and the stat. */
+export async function transcriptMtime(file: string, deps: KimiHistoryDeps = defaultDeps): Promise<number> {
+  return await deps
+    .stat(file)
+    .then((s) => s.mtimeMs)
+    .catch(() => 0)
+}
+
+/** Absolute path of `sessionId`'s stream, or null when the index has no
+ *  such id / the file isn't on disk (a handoff must not brief the next
+ *  agent with a path that doesn't resolve). */
+export async function transcriptPath(sessionId: string, deps: KimiHistoryDeps = defaultDeps): Promise<string | null> {
+  if (!sessionId) return null
+  const entry = (await sessionIndex(deps)).find((e) => e.sessionId === sessionId)
+  if (!entry) return null
+  const file = wirePath(entry.sessionDir)
+  return await deps
+    .stat(file)
+    .then(() => file)
+    .catch(() => null)
+}

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -41,14 +41,18 @@ import {
   detectKimiAccount,
 } from "./account-detect.ts"
 import { claudeCapabilities, claudeIdentity } from "./claude-code-local/capabilities.ts"
-import * as claudeHistory from "./claude-code-local/history.ts"
 import { ClaudeHookAdapter } from "./claude-code-local/hook-adapter.ts"
 import { fetchClaudeQuotaUsage } from "./claude-code-local/quota.ts"
 import { codexCapabilities, codexIdentity } from "./codex-local/capabilities.ts"
-import * as codexHistory from "./codex-local/history.ts"
 import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
 import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
-import * as copilotHistory from "./copilot-local/history.ts"
+import {
+  EMPTY_HISTORY,
+  claudeHistoryReader,
+  codexHistoryReader,
+  copilotHistoryReader,
+  kimiHistoryReader,
+} from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
 import { CLAUDE_SPINNER_FRAMES } from "./spinner-frames.ts"
 import { ClaudeTurnDetector, CodexTurnDetector, type EngineTurnDetector, UnknownTurnDetector } from "./turn-detector.ts"
@@ -180,64 +184,10 @@ export interface EngineRegistryEntry {
   readonly quotaUsage?: () => Promise<EngineQuotaUsage | null>
 }
 
-/**
- * The documented empty history reader for engines with no on-disk
- * transcript store (custom engines). Auto-title then keeps the placeholder
- * title rather than mis-reading claude's transcripts (the old
- * `else → claude` default would do exactly that for any unknown id).
- */
-export const EMPTY_HISTORY: EngineHistoryReader = {
-  async listSessionIdsForWorktree() {
-    return []
-  },
-  async readHistory() {
-    return []
-  },
-  async transcriptPath() {
-    return null
-  },
-  // No transcript store → no activity signal (the Ops badge stays dark
-  // rather than mis-watching another vendor's files).
-  async latestTranscriptMtimeForWorktree() {
-    return 0
-  },
-}
-
-/**
- * Claude's reader. `listSessionFilesForWorktree` sorts NEWEST-first (the
- * activity callers want that); the registry contract is oldest-first,
- * so re-sort ascending by mtime here — exactly what auto-title did inline.
- */
-const claudeHistoryReader: EngineHistoryReader = {
-  async listSessionIdsForWorktree(worktree) {
-    const files = await claudeHistory.listSessionFilesForWorktree(worktree)
-    return [...files].sort((a, b) => a.mtimeMs - b.mtimeMs).map((f) => f.sessionId)
-  },
-  readHistory: (sessionId) => claudeHistory.readHistory(sessionId),
-  async transcriptPath(sessionId, worktree) {
-    const files = await claudeHistory.listSessionFilesForWorktree(worktree)
-    return files.find((f) => f.sessionId === sessionId)?.path ?? null
-  },
-  latestTranscriptMtimeForWorktree: (worktree) => claudeHistory.latestTranscriptMtimeForWorktree(worktree),
-}
-
-/** Codex's reader — `listSessionIdsForWorktree` is already oldest-first. */
-const codexHistoryReader: EngineHistoryReader = {
-  listSessionIdsForWorktree: (worktree) => codexHistory.listSessionIdsForWorktree(worktree),
-  readHistory: (sessionId) => codexHistory.readHistory(sessionId),
-  // The rollout filename embeds the UUID; the store is date-keyed, not
-  // worktree-keyed, so the worktree argument is unused here.
-  transcriptPath: async (sessionId) => (await codexHistory.findRolloutFile(sessionId)) ?? null,
-  latestTranscriptMtimeForWorktree: (worktree) => codexHistory.latestTranscriptMtimeForWorktree(worktree),
-}
-
-const copilotHistoryReader: EngineHistoryReader = {
-  listSessionIdsForWorktree: (worktree) => copilotHistory.listSessionIdsForWorktree(worktree),
-  readHistory: (sessionId) => copilotHistory.readHistory(sessionId),
-  // Copilot's store layout isn't mapped to a per-session file kobe can name.
-  transcriptPath: async () => null,
-  latestTranscriptMtimeForWorktree: (worktree) => copilotHistory.latestTranscriptMtimeForWorktree(worktree),
-}
+// The per-vendor readers live in `history-readers.ts` (file-size cap);
+// EMPTY_HISTORY is re-exported so `@/engine/registry` stays the one
+// import site for the whole registry surface.
+export { EMPTY_HISTORY }
 
 /** The first-party entries — registered here and nowhere else. */
 const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineRegistryEntry> = {
@@ -309,11 +259,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     builtin: true,
     displayName: "Kimi",
     defaultCommand: ["kimi"],
-    // Kimi persists sessions under ~/.kimi-code/sessions/wd_*/session_*/
-    // (wire.jsonl protocol stream) but the message-record shape is
-    // unverified against a real conversation, so no history reader yet —
-    // EMPTY_HISTORY keeps auto-title/recap honest instead of mis-parsing.
-    history: EMPTY_HISTORY,
+    history: kimiHistoryReader,
     detectAccount: (deps) => detectKimiAccount(deps),
     createHookAdapter: () => new NoopHookAdapter("kimi"),
     createTurnDetector: () => new UnknownTurnDetector("kimi"),
@@ -349,15 +295,17 @@ export function engineEntry(vendor: VendorId): EngineRegistryEntry {
 }
 
 /**
- * True when `vendor`'s adapter ships a REAL transcript-store reader —
- * i.e. its `history` is not the documented {@link EMPTY_HISTORY} sentinel.
- * Neutral layers (e.g. `kobe api read-output`) use this to label an
- * `engine_unsupported` fallback honestly instead of confusing "engine has
- * no reader" with "reader found no sessions". Lives here so the sentinel
- * comparison stays inside the engine-owned module.
+ * True when `vendor`'s adapter can turn a session into neutral MESSAGES —
+ * i.e. its `readHistory` is not {@link EMPTY_HISTORY}'s. Neutral layers
+ * (e.g. `kobe api read-output`) use this to label an `engine_unsupported`
+ * fallback honestly instead of confusing "engine has no reader" with
+ * "reader found no sessions". Compares that one method rather than the
+ * whole object because kimi's reader is a partial: it resolves session
+ * ids and transcript PATHS (enough for a cross-engine handoff) while
+ * still shipping no message parser.
  */
 export function supportsStructuredHistory(vendor: VendorId): boolean {
-  return engineEntry(vendor).history !== EMPTY_HISTORY
+  return engineEntry(vendor).history.readHistory !== EMPTY_HISTORY.readHistory
 }
 
 /*

--- a/packages/kobe/test/engine/kimi-history.test.ts
+++ b/packages/kobe/test/engine/kimi-history.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Kimi's path-only history reader: the store layout is verified (live
+ * install, 2026-08-13) even though the wire format isn't, which is exactly
+ * enough for a cross-engine handoff — it hands over a PATH, not messages.
+ */
+
+import {
+  type KimiHistoryDeps,
+  listSessionIdsForWorktree,
+  parseSessionIndex,
+  transcriptPath,
+} from "@/engine/kimi-local/history"
+import { supportsStructuredHistory } from "@/engine/registry"
+import { describe, expect, it } from "vitest"
+
+const INDEX = [
+  '{"sessionId":"session_a","sessionDir":"/home/.kimi-code/sessions/wd_p_1/session_a","workDir":"/wt"}',
+  '{"sessionId":"session_b","sessionDir":"/home/.kimi-code/sessions/wd_p_1/session_b","workDir":"/wt"}',
+  '{"sessionId":"session_c","sessionDir":"/home/.kimi-code/sessions/wd_q_2/session_c","workDir":"/other"}',
+].join("\n")
+
+/** mtimes keyed by wire path; a path absent from the map doesn't exist. */
+function deps(index: string, mtimes: Record<string, number>): KimiHistoryDeps {
+  return {
+    kimiDir: () => "/home/.kimi-code",
+    readFile: async (p) => (p.endsWith("session_index.jsonl") ? index : ""),
+    stat: async (p) => {
+      const m = mtimes[p]
+      if (m === undefined) throw new Error("ENOENT")
+      return { mtimeMs: m }
+    },
+  }
+}
+
+const wire = (id: string, dir = "wd_p_1") => `/home/.kimi-code/sessions/${dir}/${id}/agents/main/wire.jsonl`
+
+describe("parseSessionIndex", () => {
+  it("keeps complete records and skips a torn trailing line", () => {
+    const entries = parseSessionIndex(`${INDEX}\n{"sessionId":"session_d","sessionD`)
+    expect(entries.map((e) => e.sessionId)).toEqual(["session_a", "session_b", "session_c"])
+  })
+
+  it("skips a record missing a field rather than yielding a half entry", () => {
+    expect(parseSessionIndex('{"sessionId":"x","workDir":"/wt"}')).toEqual([])
+  })
+})
+
+describe("listSessionIdsForWorktree", () => {
+  it("returns this worktree's sessions oldest-first by stream mtime", async () => {
+    // Index order is a,b but b was touched FIRST — the handoff forks from
+    // `.at(-1)`, which must be the most recently worked-in conversation.
+    const d = deps(INDEX, { [wire("session_a")]: 200, [wire("session_b")]: 100 })
+    expect(await listSessionIdsForWorktree("/wt", d)).toEqual(["session_b", "session_a"])
+  })
+
+  it("drops a session whose stream isn't on disk, and other worktrees", async () => {
+    const d = deps(INDEX, { [wire("session_a")]: 1, [wire("session_c", "wd_q_2")]: 9 })
+    expect(await listSessionIdsForWorktree("/wt", d)).toEqual(["session_a"])
+  })
+
+  it("returns nothing for an empty worktree or an unreadable index", async () => {
+    expect(await listSessionIdsForWorktree("", deps(INDEX, {}))).toEqual([])
+    expect(await listSessionIdsForWorktree("/wt", deps("", {}))).toEqual([])
+  })
+})
+
+describe("transcriptPath", () => {
+  it("names the MAIN agent's stream — sub-agents are internal fan-out", async () => {
+    const d = deps(INDEX, { [wire("session_a")]: 5 })
+    expect(await transcriptPath("session_a", d)).toBe(wire("session_a"))
+  })
+
+  it("returns null for an unknown id, and for an id whose file vanished", async () => {
+    const d = deps(INDEX, { [wire("session_a")]: 5 })
+    expect(await transcriptPath("session_zzz", d)).toBeNull()
+    // In the index, but no stream on disk — briefing an agent with a path
+    // that doesn't resolve is worse than refusing the handoff.
+    expect(await transcriptPath("session_b", d)).toBeNull()
+  })
+})
+
+describe("supportsStructuredHistory", () => {
+  it("stays false for kimi: it resolves paths, but parses no messages", () => {
+    expect(supportsStructuredHistory("kimi")).toBe(false)
+    expect(supportsStructuredHistory("copilot")).toBe(true)
+  })
+})

--- a/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
+++ b/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
@@ -81,10 +81,12 @@ describe("planChatContinuation", () => {
   })
 
   it("reports no readable transcript when the source engine keeps none", async () => {
-    // Kimi has no history reader, so there is no file to hand the next engine.
-    expect(await planChatContinuation({ ...engineTab, vendor: "kimi" }, "kimi", "codex", "/wt")).toEqual({
+    // A user-registered engine gets EMPTY_HISTORY — kobe can't know its
+    // store, so there is no file to hand the next engine. (The built-ins
+    // all resolve a transcript path now; only custom ids land here.)
+    expect(await planChatContinuation({ ...engineTab, vendor: "my-engine" }, "my-engine", "codex", "/wt")).toEqual({
       kind: "no-transcript",
-      engine: "Kimi",
+      engine: "my-engine",
     })
   })
 


### PR DESCRIPTION
## Summary

Handoff (`ctrl+a` `c` → a *different* engine) previously refused to start from copilot or kimi. Following Orca's design — the receiving agent is handed the previous transcript's **path**, never a converted transcript — neither engine actually needed a parser, just a path resolver.

- **copilot**: its `transcriptPath` returned `null` with a comment saying sessions aren't mapped to a per-session file. That was stale — `findSessionDir` already resolves a session to a dir holding the `events.jsonl` the reader parses. Now it names that file.
- **kimi**: new path-only reader (`~/.kimi-code/session_index.jsonl` → `<sessionDir>/agents/main/wire.jsonl`). It still parses no messages — the wire format is unverified — but a handoff only ever needed a path. Side effect: kimi's activity badge now has a real mtime signal.
- **custom engines** stay refused, by construction: Rove can't know their session store.
- `supportsStructuredHistory` now compares `readHistory` identity rather than object identity, since kimi's reader is a partial that shares `EMPTY_HISTORY.readHistory`. Without it, `rove api read-output --source history` would report "no sessions" for kimi instead of `engine_unsupported`.
- The ctrl+e picker is untouched — it lists *target* engines (copilot/kimi already appear when installed); this change is entirely source-side.

Per the file-size cap, the four per-vendor readers moved out of `registry.ts` (522 → 442) into `src/engine/history-readers.ts`; `EMPTY_HISTORY` is re-exported so `@/engine/registry` stays the single import site.

## Test plan
- [x] `bun run lint`, `bun run typecheck` (3 packages), `bun run test` — 521 passed / 61 files
- [x] New `test/engine/kimi-history.test.ts` (8 cases): index parsing skips torn/incomplete records; sessions ordered by stream mtime not index order; streams missing on disk and other worktrees dropped; `transcriptPath` names the main agent's stream, null for unknown id or vanished file; `supportsStructuredHistory("kimi") === false` while `("copilot") === true`
- [x] Verified against real installs: the kimi reader resolved this repo's live session to `~/.kimi-code/sessions/wd_kobe_.../agents/main/wire.jsonl`; the copilot reader resolved a `COPILOT_HOME` fixture to its `events.jsonl`
- [ ] Reviewer: real handoff from a kimi tab to claude — the new agent should state where the previous one stopped