### PR TITLE
chore: publish every release as @sma1lboy/rove as well as @sma1lboy/kobe

### DIFF
--- a/.changeset/dual-publish-rove.md
+++ b/.changeset/dual-publish-rove.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+chore: every release now publishes the same build under both `@sma1lboy/rove` and `@sma1lboy/kobe` — same version, same tarball, same `kobe`/`rove` bins, only the package name differs. New installs can use the product's real name; existing `@sma1lboy/kobe` installs keep updating in place with nothing to migrate. The GitHub repo moved to `Sma1lboy/rove` too, so the package's repository/homepage/bugs links and the update-script URL now point there (GitHub redirects the old ones).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,35 @@ jobs:
         working-directory: packages/kobe
         run: npm publish --access public --provenance --tag "${{ steps.channel.outputs.dist_tag }}"
 
+      - name: Publish the same build as @sma1lboy/rove
+        # The product is Rove; `@sma1lboy/kobe` is the compatibility name
+        # ~10k installs/month already point at. So every release ships BOTH
+        # names from ONE build: same tarball, same version, same `kobe` +
+        # `rove` bins — only the `name` field differs. New users get
+        # `npm i -g @sma1lboy/rove`, existing ones keep updating in place.
+        #
+        # Publishing from a rewritten package.json rather than a second
+        # package dir keeps them impossible to skew: there is one source of
+        # version, files, and deps. `--ignore-scripts` skips the
+        # `prepublishOnly` typecheck+build that already ran for the publish
+        # above — dist/ is the artifact both names share.
+        working-directory: packages/kobe
+        run: |
+          V=$(node -p "require('./package.json').version")
+          if npm view "@sma1lboy/rove@$V" version >/dev/null 2>&1; then
+            echo "@sma1lboy/rove@$V already on npm — skipping"
+            exit 0
+          fi
+          cp package.json package.json.bak
+          node -e "
+            const fs = require('fs')
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+            pkg.name = '@sma1lboy/rove'
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
+          "
+          npm publish --access public --provenance --ignore-scripts --tag "${{ steps.channel.outputs.dist_tag }}"
+          mv package.json.bak package.json
+
       - name: Publish plugin SDK (piggyback, idempotent)
         # The SDK versions independently via changesets but has no tag of
         # its own: every kobe release checks whether the SDK's current

--- a/packages/kobe-plugin-sdk/package.json
+++ b/packages/kobe-plugin-sdk/package.json
@@ -20,10 +20,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Sma1lboy/kobe.git",
+    "url": "git+https://github.com/Sma1lboy/rove.git",
     "directory": "packages/kobe-plugin-sdk"
   },
-  "homepage": "https://github.com/Sma1lboy/kobe/blob/main/docs/PLUGIN-AUTHORING.md",
+  "homepage": "https://github.com/Sma1lboy/rove/blob/main/docs/PLUGIN-AUTHORING.md",
   "engines": {
     "node": ">=18"
   },

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -15,11 +15,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Sma1lboy/kobe.git"
+    "url": "git+https://github.com/Sma1lboy/rove.git"
   },
-  "homepage": "https://github.com/Sma1lboy/kobe#readme",
+  "homepage": "https://github.com/Sma1lboy/rove#readme",
   "bugs": {
-    "url": "https://github.com/Sma1lboy/kobe/issues"
+    "url": "https://github.com/Sma1lboy/rove/issues"
   },
   "engines": {
     "bun": ">=1.3.11"

--- a/packages/kobe/src/version.ts
+++ b/packages/kobe/src/version.ts
@@ -53,7 +53,7 @@ export function repoSlug(): string | null {
 }
 
 /** Remote update script URL. Kept on GitHub so install flow changes don't require a binary release. */
-export const UPDATE_SCRIPT_URL = "https://raw.githubusercontent.com/Sma1lboy/kobe/main/scripts/update.sh"
+export const UPDATE_SCRIPT_URL = "https://raw.githubusercontent.com/Sma1lboy/rove/main/scripts/update.sh"
 
 /** Standard update command shown in the update dialog. */
 export const UPDATE_COMMAND = `curl -fsSL ${UPDATE_SCRIPT_URL} | sh`

--- a/packages/kobe/test/lib/feedback.test.ts
+++ b/packages/kobe/test/lib/feedback.test.ts
@@ -33,7 +33,7 @@ describe("submitFeedback", () => {
             createDiscussion: {
               discussion: {
                 number: 42,
-                url: "https://github.com/Sma1lboy/kobe/discussions/42",
+                url: "https://github.com/Sma1lboy/rove/discussions/42",
               },
             },
           },
@@ -42,12 +42,12 @@ describe("submitFeedback", () => {
 
     const result = submitFeedback(
       { title: "A small idea", body: "Please add the thing." },
-      { spawn, repoSlug: () => "Sma1lboy/kobe" },
+      { spawn, repoSlug: () => "Sma1lboy/rove" },
     )
 
     expect(result).toEqual({
       number: 42,
-      url: "https://github.com/Sma1lboy/kobe/discussions/42",
+      url: "https://github.com/Sma1lboy/rove/discussions/42",
     })
     expect(spawn).toHaveBeenCalledTimes(2)
     const secondArgs = (spawn as ReturnType<typeof vi.fn>).mock.calls[1]?.[1] as string[]
@@ -74,7 +74,7 @@ describe("submitFeedback", () => {
     expect(() =>
       submitFeedback(
         { title: "Bug", body: "Something happened.", categorySlug: "feedback" },
-        { spawn, repoSlug: () => "Sma1lboy/kobe" },
+        { spawn, repoSlug: () => "Sma1lboy/rove" },
       ),
     ).toThrow("GitHub Discussion category not found: feedback")
   })

--- a/packages/kobe/test/version.test.ts
+++ b/packages/kobe/test/version.test.ts
@@ -131,7 +131,7 @@ describe("semver helpers", () => {
 
 describe("repo slug + static commands", () => {
   it("derives owner/repo from package.json#repository.url", () => {
-    expect(repoSlug()).toBe("Sma1lboy/kobe")
+    expect(repoSlug()).toBe("Sma1lboy/rove")
   })
 
   it("recommendedGlobalInstallCommand targets this package", () => {
@@ -139,7 +139,7 @@ describe("repo slug + static commands", () => {
   })
 
   it("releasePageUrl points at the GitHub tag for a version", () => {
-    expect(releasePageUrl("0.1.2")).toBe("https://github.com/Sma1lboy/kobe/releases/tag/v0.1.2")
+    expect(releasePageUrl("0.1.2")).toBe("https://github.com/Sma1lboy/rove/releases/tag/v0.1.2")
   })
 })
 
@@ -150,7 +150,7 @@ describe("fetchReleaseNotes", () => {
 
   it("returns the release body + html_url for vX.Y.Z", async () => {
     const fetchMock = vi.fn(async (url: string) => {
-      expect(url).toBe("https://api.github.com/repos/Sma1lboy/kobe/releases/tags/v0.7.12")
+      expect(url).toBe("https://api.github.com/repos/Sma1lboy/rove/releases/tags/v0.7.12")
       return new Response(JSON.stringify({ body: "notes!", html_url: "https://gh/rel/v0.7.12" }), { status: 200 })
     })
     vi.stubGlobal("fetch", fetchMock)
@@ -202,9 +202,9 @@ describe("fetchReleaseSummaries", () => {
     const fetchMock = vi.fn(async () => {
       return new Response(
         JSON.stringify([
-          { tag_name: "v0.5.23", html_url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.5.23" },
+          { tag_name: "v0.5.23", html_url: "https://github.com/Sma1lboy/rove/releases/tag/v0.5.23" },
           { tag_name: "not-a-version", html_url: "https://example.test/bad" },
-          { tag_name: "v0.5.22", html_url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.5.22" },
+          { tag_name: "v0.5.22", html_url: "https://github.com/Sma1lboy/rove/releases/tag/v0.5.22" },
         ]),
         { status: 200, headers: { "content-type": "application/json" } },
       )
@@ -212,8 +212,8 @@ describe("fetchReleaseSummaries", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     await expect(fetchReleaseSummaries()).resolves.toEqual([
-      { version: "0.5.23", url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.5.23" },
-      { version: "0.5.22", url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.5.22" },
+      { version: "0.5.23", url: "https://github.com/Sma1lboy/rove/releases/tag/v0.5.23" },
+      { version: "0.5.22", url: "https://github.com/Sma1lboy/rove/releases/tag/v0.5.22" },
     ])
   })
 
@@ -260,10 +260,10 @@ describe("fetchReleaseNotesRange", () => {
     const fetchMock = vi.fn(async () => {
       return new Response(
         JSON.stringify([
-          { tag_name: "v0.7.12", html_url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.7.12", body: "latest" },
-          { tag_name: "v0.7.11", html_url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.7.11", body: "middle" },
-          { tag_name: "v0.7.10", html_url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.7.10", body: "current" },
-          { tag_name: "v0.7.9", html_url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.7.9", body: "old" },
+          { tag_name: "v0.7.12", html_url: "https://github.com/Sma1lboy/rove/releases/tag/v0.7.12", body: "latest" },
+          { tag_name: "v0.7.11", html_url: "https://github.com/Sma1lboy/rove/releases/tag/v0.7.11", body: "middle" },
+          { tag_name: "v0.7.10", html_url: "https://github.com/Sma1lboy/rove/releases/tag/v0.7.10", body: "current" },
+          { tag_name: "v0.7.9", html_url: "https://github.com/Sma1lboy/rove/releases/tag/v0.7.9", body: "old" },
         ]),
         { status: 200, headers: { "content-type": "application/json" } },
       )
@@ -271,8 +271,8 @@ describe("fetchReleaseNotesRange", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     await expect(fetchReleaseNotesRange({ current: "0.7.10", latest: "0.7.12" })).resolves.toEqual([
-      { version: "0.7.12", url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.7.12", body: "latest" },
-      { version: "0.7.11", url: "https://github.com/Sma1lboy/kobe/releases/tag/v0.7.11", body: "middle" },
+      { version: "0.7.12", url: "https://github.com/Sma1lboy/rove/releases/tag/v0.7.12", body: "latest" },
+      { version: "0.7.11", url: "https://github.com/Sma1lboy/rove/releases/tag/v0.7.11", body: "middle" },
     ])
   })
 


### PR DESCRIPTION
## Summary

The product is Rove; `@sma1lboy/kobe` is the compatibility name ~10k installs/month already point at. npm has no rename, so instead of migrating anyone, **every release now ships both names from one build**.

- The publish step republishes the same tarball with only `name` rewritten → version, `files`, deps, and the `kobe`/`rove` bins can never skew between the two. `--ignore-scripts` skips the `prepublishOnly` typecheck+build that already ran for the first publish; `dist/` is the artifact both names share.
- Idempotent, like the plugin-SDK step next to it: if `@sma1lboy/rove@<version>` is already on npm, it skips. A rerun can't fail the pipeline.
- Both go to the same dist-tag, so prereleases stay parallel too (`@sma1lboy/rove@experimental` works the same way).

**Repo rename fallout, in the same PR because it's a release blocker:** the GitHub repo moved to `Sma1lboy/rove`, and `npm publish --provenance` rejects a `repository.url` that doesn't match the building repo ([npm/cli#8036](https://github.com/npm/cli/issues/8036)) — left alone, the *next* release 422s. So `repository`/`homepage`/`bugs` in both published packages, and `UPDATE_SCRIPT_URL`, now point at `rove`. `repoSlug()` derives from `repository.url`, so the update-check and feedback-report URLs follow automatically — the two tests asserting the old slug are updated to match.

Not touched: the `kobe` command, `@sma1lboy/kobe-plugin-sdk`'s name (every existing plugin depends on it), `~/.kobe` paths, protocol fields. Per CLAUDE.md those are compatibility contracts.

## Test plan
- [x] `bun run lint`, `bun run typecheck` (3 packages), `bun run test` — 521 passed / 61 files
- [x] `test/version.test.ts` + `test/lib/feedback.test.ts` pin the new slug, so a stale `repository.url` fails the suite rather than silently pointing users at the old repo
- [ ] Verified on the next release: both `npm view @sma1lboy/rove@<v>` and `@sma1lboy/kobe@<v>` resolve, and `npm i -g @sma1lboy/rove` puts both `kobe` and `rove` on PATH