### PR TITLE
chore: make the update script migrate kobe installs to @sma1lboy/rove

### DIFF
--- a/packages/kobe/test/behavior/cli-update.test.ts
+++ b/packages/kobe/test/behavior/cli-update.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { chmod, mkdir, readFile, writeFile } from "node:fs/promises"
+import { chmod, mkdir, readFile, symlink, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
@@ -45,9 +45,15 @@ describe("kobe update (behavior)", () => {
 /**
  * Run scripts/update.sh with PATH shims. `kobeBinDir` decides the manager
  * (a path containing `/.bun/` → bun, else npm). Both managers log to
- * `calls.log` instead of installing anything.
+ * `calls.log` instead of installing anything. `linkTo` makes the on-PATH
+ * `kobe` a symlink to that entry file, which is how the script tells a
+ * legacy @sma1lboy/kobe install from a migrated one.
  */
-async function runUpdateScript(base: string, kobeBinDir: string): Promise<{ code: number; out: string; log: string }> {
+async function runUpdateScript(
+  base: string,
+  kobeBinDir: string,
+  linkTo?: string,
+): Promise<{ code: number; out: string; log: string }> {
   const shims = join(base, "shims")
   await mkdir(shims, { recursive: true })
   await mkdir(kobeBinDir, { recursive: true })
@@ -55,8 +61,12 @@ async function runUpdateScript(base: string, kobeBinDir: string): Promise<{ code
 
   // Post-install `kobe -v` must match `npm view` output or the script exits 1
   // (the shadowed-install guard) — keep both at 9.9.9 for the happy path.
-  await writeFile(join(kobeBinDir, "kobe"), `#!/bin/sh\necho "kobe 9.9.9"\n`)
-  await chmod(join(kobeBinDir, "kobe"), 0o755)
+  if (linkTo) {
+    await symlink(linkTo, join(kobeBinDir, "kobe"))
+  } else {
+    await writeFile(join(kobeBinDir, "kobe"), `#!/bin/sh\necho "kobe 9.9.9"\n`)
+    await chmod(join(kobeBinDir, "kobe"), 0o755)
+  }
   for (const mgr of ["npm", "bun"]) {
     await writeFile(
       join(shims, mgr),
@@ -87,11 +97,10 @@ describe("scripts/update.sh manager detection (issue #205)", () => {
     const base = join(env.home, "case-bun")
     const r = await runUpdateScript(base, join(base, ".bun", "bin"))
     expect(r.code).toBe(0)
-    expect(r.out).toContain("██╗  ██╗ ██████╗")
     expect(r.out).toContain("many sessions. one terminal.")
-    expect(r.out).toContain("Thanks for using kobe. Happy building.")
+    expect(r.out).toContain("Thanks for using Rove. Happy building.")
     expect(r.out).toContain("via bun")
-    expect(r.log).toContain("bun install -g @sma1lboy/kobe@latest")
+    expect(r.log).toContain("bun install -g @sma1lboy/rove@latest")
     expect(r.log).not.toContain("npm install")
   })
 
@@ -100,8 +109,36 @@ describe("scripts/update.sh manager detection (issue #205)", () => {
     const r = await runUpdateScript(base, join(base, "npm-global", "bin"))
     expect(r.code).toBe(0)
     expect(r.out).toContain("via npm")
-    expect(r.log).toContain("npm install -g @sma1lboy/kobe@latest")
+    expect(r.log).toContain("npm install -g @sma1lboy/rove@latest")
     expect(r.log).not.toContain("bun install")
+  })
+
+  // The rename migration: an install whose bin resolves into an
+  // @sma1lboy/kobe package dir must be uninstalled BEFORE rove goes in —
+  // both packages own a `kobe` and a `rove` bin, so a plain install over
+  // the top dies with EEXIST.
+  it("a legacy @sma1lboy/kobe install is uninstalled before rove is installed", async () => {
+    const base = join(env.home, "case-migrate")
+    const pkgDir = join(base, "npm-global/lib/node_modules/@sma1lboy/kobe/dist/cli")
+    await mkdir(pkgDir, { recursive: true })
+    const entry = join(pkgDir, "kobe.js")
+    await writeFile(entry, `#!/bin/sh\necho "kobe 9.9.9"\n`)
+    await chmod(entry, 0o755)
+
+    const r = await runUpdateScript(base, join(base, "npm-global", "bin"), entry)
+    expect(r.code).toBe(0)
+    expect(r.out).toContain("kobe is now Rove.")
+    expect(r.log).toContain("npm uninstall -g @sma1lboy/kobe")
+    expect(r.log).toContain("npm install -g @sma1lboy/rove@latest")
+    // Order matters: uninstall first, or npm bails with EEXIST.
+    expect(r.log.indexOf("uninstall")).toBeLessThan(r.log.indexOf("install -g @sma1lboy/rove"))
+  })
+
+  it("a non-legacy install is not uninstalled", async () => {
+    const base = join(env.home, "case-no-migrate")
+    const r = await runUpdateScript(base, join(base, "npm-global", "bin"))
+    expect(r.out).not.toContain("kobe is now Rove.")
+    expect(r.log).not.toContain("uninstall")
   })
 
   it("a post-install PATH still resolving a stale version fails loudly", async () => {

--- a/scripts/preview-install.sh
+++ b/scripts/preview-install.sh
@@ -26,17 +26,19 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 PKG_SRC="$ROOT/packages/kobe"
 
-BIN="$(command -v kobe 2>/dev/null || true)"
+BIN="$(command -v rove 2>/dev/null || command -v kobe 2>/dev/null || true)"
 if [ -z "$BIN" ]; then
-  echo "preview-install: no global kobe on PATH — install prod first: npm i -g @sma1lboy/kobe" >&2
+  echo "preview-install: no global rove on PATH — install prod first: npm i -g @sma1lboy/rove" >&2
   exit 1
 fi
-ENTRY="$(realpath "$BIN")" # …/node_modules/@sma1lboy/kobe/dist/cli/kobe.js
+ENTRY="$(realpath "$BIN")" # …/node_modules/@sma1lboy/rove/dist/cli/kobe.js
 PKG_DIR="$(cd "$(dirname "$ENTRY")/../.." && pwd)"
+# Either package name is a valid target: installs that haven't run
+# `rove update` since the rename are still on @sma1lboy/kobe.
 case "$PKG_DIR" in
-  */node_modules/@sma1lboy/kobe) ;;
+  */node_modules/@sma1lboy/rove | */node_modules/@sma1lboy/kobe) ;;
   *)
-    echo "preview-install: kobe on PATH ($BIN) doesn't resolve into a global @sma1lboy/kobe install (got: $PKG_DIR)" >&2
+    echo "preview-install: rove on PATH ($BIN) doesn't resolve into a global @sma1lboy/{rove,kobe} install (got: $PKG_DIR)" >&2
     exit 1
     ;;
 esac

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env sh
 set -eu
 
-PACKAGE="@sma1lboy/kobe"
+# The product is Rove. `@sma1lboy/kobe` is the old package name, still
+# published in lockstep, but this script moves everyone onto the new one:
+# it's fetched fresh over curl on every run, so even a year-old install
+# migrates itself the next time the user updates. Nothing is published
+# solely to shepherd them across (no stub package, no deprecation shim).
+PACKAGE="@sma1lboy/rove"
+LEGACY_PACKAGE="@sma1lboy/kobe"
 
 # Optional pin: `curl … | sh -s -- 0.7.90` installs that exact version;
 # `… | sh -s -- --list` prints recent published versions and exits.
@@ -10,12 +16,14 @@ VERSION="${1:-}"
 if [ "$VERSION" = "--list" ]; then
   npm view "$PACKAGE" versions --json 2>/dev/null | sed 's/[][",]//g' | awk 'NF' | tail -n 20
   echo ""
-  echo "install one with: kobe update <version>"
-  echo "            or:   curl -fsSL https://raw.githubusercontent.com/Sma1lboy/kobe/main/scripts/update.sh | sh -s -- <version>"
+  echo "install one with: rove update <version>"
+  echo "            or:   curl -fsSL https://raw.githubusercontent.com/Sma1lboy/rove/main/scripts/update.sh | sh -s -- <version>"
   exit 0
 fi
 
-BIN="$(command -v kobe 2>/dev/null || true)"
+# `rove` first: on a migrated install both commands exist, and the newer
+# name is the one whose absence means "not migrated yet".
+BIN="$(command -v rove 2>/dev/null || command -v kobe 2>/dev/null || true)"
 BEFORE="$("${BIN:-false}" -v 2>/dev/null || true)"
 
 # Update with the same package manager that owns the binary on PATH,
@@ -25,6 +33,17 @@ case "$BIN" in
   */.bun/*) MANAGER="bun" ;;
   *) MANAGER="npm" ;;
 esac
+
+# Is the install on PATH still the legacy package? Resolve the symlink and
+# look at which package dir it lands in — `command -v` alone can't tell,
+# since @sma1lboy/kobe ships a `rove` bin too.
+MIGRATING=0
+if [ -n "$BIN" ]; then
+  ENTRY="$(realpath "$BIN" 2>/dev/null || readlink -f "$BIN" 2>/dev/null || echo "$BIN")"
+  case "$ENTRY" in
+    */@sma1lboy/kobe/*) MIGRATING=1 ;;
+  esac
+fi
 
 if [ -n "$VERSION" ]; then
   TARGET="$VERSION"
@@ -44,14 +63,19 @@ else
 fi
 
 printf '%b\n' \
-  "${ACCENT}${BOLD}██╗  ██╗ ██████╗ ██████╗ ███████╗" \
-  "██║ ██╔╝██╔═══██╗██╔══██╗██╔════╝" \
-  "█████╔╝ ██║   ██║██████╔╝█████╗" \
-  "██╔═██╗ ██║   ██║██╔══██╗██╔══╝" \
-  "██║  ██╗╚██████╔╝██████╔╝███████╗" \
-  "╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝${RESET}" \
+  "${ACCENT}${BOLD}██████╗  ██████╗ ██╗   ██╗███████╗" \
+  "██╔══██╗██╔═══██╗██║   ██║██╔════╝" \
+  "██████╔╝██║   ██║██║   ██║█████╗" \
+  "██╔══██╗██║   ██║╚██╗ ██╔╝██╔══╝" \
+  "██║  ██║╚██████╔╝ ╚████╔╝ ███████╗" \
+  "╚═╝  ╚═╝ ╚═════╝   ╚═══╝  ╚══════╝${RESET}" \
   "${DIM}many sessions. one terminal.${RESET}" \
   ""
+
+if [ "$MIGRATING" = "1" ]; then
+  printf '%bkobe is now Rove.%b %s -> %s — same tool, same `kobe` command, new name.\n' \
+    "$BOLD" "$RESET" "$LEGACY_PACKAGE" "$PACKAGE"
+fi
 
 if [ -n "$TARGET" ]; then
   printf '%bUpdating %s: %s -> v%s%b (via %s)\n' "$BOLD" "$PACKAGE" "${BEFORE:-not installed}" "$TARGET" "$RESET" "$MANAGER"
@@ -62,7 +86,15 @@ fi
 LOG="$(mktemp)"
 trap 'rm -f "$LOG"' EXIT
 
-"$MANAGER" install -g "${PACKAGE}@${VERSION:-latest}" >"$LOG" 2>&1 &
+# Both packages own a `kobe` AND a `rove` bin, so installing one over the
+# other dies with EEXIST (verified on npm 11). The legacy package has to go
+# first — and only once we're about to replace it, so a failed install
+# can't leave the user with nothing.
+if [ "$MIGRATING" = "1" ]; then
+  "$MANAGER" uninstall -g "$LEGACY_PACKAGE" >>"$LOG" 2>&1 || true
+fi
+
+"$MANAGER" install -g "${PACKAGE}@${VERSION:-latest}" >>"$LOG" 2>&1 &
 PID=$!
 
 if [ -t 1 ]; then
@@ -82,17 +114,36 @@ fi
 if ! wait "$PID"; then
   printf '%berror: %s install failed:%b\n' "$RED" "$MANAGER" "$RESET" >&2
   cat "$LOG" >&2
+  # We removed the legacy package to free the bin names, so a failed
+  # install would otherwise leave the user with no kobe at all. Put it
+  # back before giving up.
+  if [ "$MIGRATING" = "1" ]; then
+    printf '%brestoring %s...%b\n' "$DIM" "$LEGACY_PACKAGE" "$RESET" >&2
+    if "$MANAGER" install -g "${LEGACY_PACKAGE}@latest" >/dev/null 2>&1; then
+      printf '%brestored — you are back on %s, nothing was lost.%b\n' "$DIM" "$LEGACY_PACKAGE" "$RESET" >&2
+    else
+      printf '%breinstall by hand: %s install -g %s%b\n' "$RED" "$MANAGER" "$LEGACY_PACKAGE" "$RESET" >&2
+    fi
+  fi
   exit 1
 fi
 
-AFTER="$(kobe -v 2>/dev/null || true)"
+# The shell caches command→path lookups; after swapping packages the cached
+# entry points at a path that no longer exists.
+hash -r 2>/dev/null || true
+
+AFTER="$(rove -v 2>/dev/null || kobe -v 2>/dev/null || true)"
 
 if [ -n "$TARGET" ] && [ "${AFTER##* }" != "$TARGET" ]; then
-  echo "error: 'kobe' on PATH reports '${AFTER:-nothing}' but the target is ${TARGET}." >&2
-  echo "PATH resolves kobe to: $(command -v kobe || echo 'not found')" >&2
+  echo "error: 'rove' on PATH reports '${AFTER:-nothing}' but the target is ${TARGET}." >&2
+  echo "PATH resolves rove to: $(command -v rove || echo 'not found')" >&2
   echo "Another install is likely shadowing it. Remove the stale one or run: ${MANAGER} install -g ${PACKAGE}@${VERSION:-latest}" >&2
   exit 1
 fi
 
-printf '%b✓ %s -> %s%b\n' "$GREEN" "${BEFORE:-kobe (not installed)}" "${AFTER:-unknown}" "$RESET"
-printf '%bThanks for using kobe. Happy building.%b\n' "$DIM" "$RESET"
+printf '%b✓ %s -> %s%b\n' "$GREEN" "${BEFORE:-rove (not installed)}" "${AFTER:-unknown}" "$RESET"
+if [ "$MIGRATING" = "1" ]; then
+  printf '%bYou are on %s now. Both `kobe` and `rove` still work — your tasks, worktrees, and settings are untouched.%b\n' \
+    "$DIM" "$PACKAGE" "$RESET"
+fi
+printf '%bThanks for using Rove. Happy building.%b\n' "$DIM" "$RESET"


### PR DESCRIPTION
## Summary

- `scripts/update.sh` now installs `@sma1lboy/rove`. Since the script is fetched fresh over curl on every run (`UPDATE_SCRIPT_URL` → raw.githubusercontent), landing this on `main` migrates every existing install the next time it updates — no stub package, no deprecation shim, nothing published just to shepherd people across.
- Legacy detection resolves the on-PATH bin to its real package dir and matches `*/@sma1lboy/kobe/*`. `command -v` alone can't tell the two apart: `@sma1lboy/kobe` ships a `rove` bin too.
- The swap **must** uninstall the legacy package first — both packages own a `kobe` AND a `rove` bin, so installing one over the other fails with `EEXIST` (verified on npm 11.12.1). The uninstall happens only immediately before the install, and if the install fails the legacy package is reinstalled so nobody ends up with no `kobe` at all.
- `hash -r` after the swap: the shell caches command→path lookups and the cached entry points at a path that no longer exists.
- `scripts/preview-install.sh` accepts either package dir, otherwise it rejects every migrated install.

No behavior change inside the CLI — scripts only, so no changeset (changeset-cap is scoped to `packages/*/src`). This does not need a release to take effect.

## Test plan

Run against isolated `NPM_CONFIG_PREFIX` sandboxes, all four paths:

- [x] **legacy → migrated**: banner shown, `node_modules/@sma1lboy/` ends up with only `rove`, both `kobe -v` and `rove -v` report 0.8.89
- [x] **re-run on a migrated install**: no banner, clean update (idempotent)
- [x] **never installed**: no banner, installs rove, verify step passes
- [x] `sh -n scripts/update.sh`, `bash -n scripts/preview-install.sh`
- [ ] Reviewer: real `kobe update` on your machine after merge (you're on 0.8.83 / `@sma1lboy/kobe`, the exact migrating case)