### PR TITLE
fix: canonicalize Rove repository links

### DIFF
--- a/.changeset/canonical-rove-repository.md
+++ b/.changeset/canonical-rove-repository.md
@@ -1,0 +1,6 @@
+---
+"@sma1lboy/rove": patch
+"@sma1lboy/rove-plugin-sdk": patch
+---
+
+Point new installs, package metadata, documentation, release links, and website GitHub data at the canonical `Sma1lboy/rove` repository. Existing `Sma1lboy/kobe` links continue to work through GitHub's redirect, while the Kobe CLI, packages, state, plugin repository, and deployed website domains remain compatible.

--- a/.claude/skills/changelog-generator/SKILL.md
+++ b/.claude/skills/changelog-generator/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: changelog-generator
-description: Draft kobe release notes as Changesets. Writes user-facing entries as `.changeset/*.md` files for `@sma1lboy/kobe` (consumed into `packages/kobe/CHANGELOG.md` at release time). Use when the user asks for "changelog", "release notes", "what changed", "add a changeset", or before cutting a version. Enforces kobe's no-soft-wrap rule so GitHub release pages render flowing text.
+description: Draft Rove release notes as Changesets. Writes user-facing entries as `.changeset/*.md` files for `@sma1lboy/rove` (consumed into `packages/kobe/CHANGELOG.md` at release time). Use when the user asks for "changelog", "release notes", "what changed", "add a changeset", or before cutting a version. Enforces Rove's no-soft-wrap rule so GitHub release pages render flowing text.
 metadata:
   internal: true
 ---
 
 <!--
 Source (originally): https://github.com/ComposioHQ/awesome-claude-skills/blob/master/changelog-generator/SKILL.md
-Vendored + heavily kobe-overridden. As of the Changesets migration (docs/RELEASING.md) kobe no longer hand-edits a `## [Unreleased]` section — pending notes live as `.changeset/*.md` files and `changeset version` generates the CHANGELOG at release time. The kobe section below takes precedence over anything generic.
+Vendored + heavily Rove-overridden. As of the Changesets migration (docs/RELEASING.md) Rove no longer hand-edits a `## [Unreleased]` section — pending notes live as `.changeset/*.md` files and `changeset version` generates the CHANGELOG at release time. The Rove section below takes precedence over anything generic.
 -->
 
-# Changelog Generator (kobe)
+# Changelog Generator (Rove)
 
-Drafts release notes as **Changesets** — one `.changeset/<name>.md` file per change — in kobe's house style. `scripts/release.sh` (via `changeset version`) later consumes them into [`packages/kobe/CHANGELOG.md`](../../../packages/kobe/CHANGELOG.md) and the GitHub release body. See [`docs/RELEASING.md`](../../../docs/RELEASING.md) for the full flow.
+Drafts release notes as **Changesets** — one `.changeset/<name>.md` file per change — in Rove's house style. `scripts/release.sh` (via `changeset version`) later consumes them into [`packages/kobe/CHANGELOG.md`](../../../packages/kobe/CHANGELOG.md) and the GitHub release body. See [`docs/RELEASING.md`](../../../docs/RELEASING.md) for the full flow.
 
 ## When to use
 
@@ -20,7 +20,7 @@ Drafts release notes as **Changesets** — one `.changeset/<name>.md` file per c
 - After landing a user-facing change that has no changeset yet (e.g. it was committed before this skill existed, or in a batch that skipped them).
 - Before cutting a release tag — to backfill changesets for anything user-facing that slipped through, so the generated notes are complete.
 
-## kobe project conventions (load-bearing)
+## Rove project conventions (load-bearing)
 
 Every rule in this section overrides the generic guidance further down.
 
@@ -31,16 +31,14 @@ Every rule in this section overrides the generic guidance further down.
 
   ```markdown
   ---
-  "@sma1lboy/kobe": minor
+  "@sma1lboy/rove": patch
   ---
 
   Single-line user-facing summary. This text lands verbatim under the next release and in the GitHub release body.
   ```
 
-- The frontmatter bump key is the **only** package, `@sma1lboy/kobe`, with value `patch` | `minor` | `major`:
-  - `patch` — bug fix or small behaviour tweak.
-  - `minor` — a new feature or user-visible capability.
-  - `major` — a breaking change. kobe is pre-1.0, so prefer `minor` for breaking changes unless the user says otherwise.
+- The canonical frontmatter bump key is `@sma1lboy/rove`, with value `patch` | `minor` | `major`.
+- Default to `patch` for every change, including features and pre-1.0 breaking changes. Use `minor` or `major` only when the user explicitly requests that bump in the current turn.
 - The bump type *is* the category — Changesets groups output under `### Minor Changes` / `### Patch Changes` automatically. Don't write `### Added`/`### Fixed` headings yourself.
 - One changeset per coherent change. A batch that did three user-visible things → three changesets (or one with three bullets if they're one feature). Prefer the `changeset` CLI: `bun run changeset` (interactive) writes the file for you.
 
@@ -63,7 +61,7 @@ Pull in: features, behaviour changes the user can see/feel, bug fixes affecting 
 
 Skip: pure refactors, internal test additions (UNLESS a milestone), CLAUDE.md / docs / skills / memory / agent-config tweaks, dependency bumps with no behaviour delta, CI tweaks (unless a new gate the user cares about). A change that needs no release can still record that explicitly with `bun run changeset -- --empty`.
 
-When in doubt, ask "would a kobe user reading this on github.com/Sma1lboy/kobe/releases care?" If no → skip (or empty changeset).
+When in doubt, ask "would a Rove user reading this on github.com/Sma1lboy/rove/releases care?" If no → skip (or empty changeset).
 
 ## How to draft
 
@@ -79,7 +77,7 @@ When in doubt, ask "would a kobe user reading this on github.com/Sma1lboy/kobe/r
 
 ```markdown
 ---
-"@sma1lboy/kobe": minor
+"@sma1lboy/rove": patch
 ---
 
 **The Tasks pane fills its tmux pane and adapts to its width** — the task list now stretches to 100% of the pane as you drag the tmux split. On a narrow pane the secondary columns step aside so the task name stays readable: the branch label drops first, then the changes chip, and the title ellipsises only when it must.

--- a/.claude/skills/recent-release/SKILL.md
+++ b/.claude/skills/recent-release/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: recent-release
-description: Render kobe's recent releases as a self-contained, kobe-styled HTML page (Chinese by default). Reads shipped notes from packages/kobe/CHANGELOG.md + git tags, filters to user-facing changes, and emits one standalone .html file in the `claude` theme (terracotta on near-black, JetBrains Mono, terminal chrome). Use when the user asks for a "release page", "发版速览", "recent release html", "把发版做成网页", or wants to share/post what changed.
+description: Render Rove's recent releases as a self-contained, Rove-styled HTML page (Chinese by default). Reads shipped notes from packages/kobe/CHANGELOG.md + git tags, filters to user-facing changes, and emits one standalone .html file in the `claude` theme (terracotta on near-black, JetBrains Mono, terminal chrome). Use when the user asks for a "release page", "发版速览", "recent release html", "把发版做成网页", or wants to share/post what changed.
 metadata:
   internal: true
 ---
 
-# Recent Release Page (kobe)
+# Recent Release Page (Rove)
 
-Turns recent kobe releases into a **single self-contained HTML file** styled like the product itself — the `claude` theme palette, JetBrains Mono, a terminal title bar, FEAT/FIX tags. It is the shareable, human-facing companion to [`changelog-generator`](../changelog-generator/SKILL.md) (which writes the machine-consumed Changesets). This skill only *renders*; it never edits `CHANGELOG.md` or changesets.
+Turns recent Rove releases into a **single self-contained HTML file** styled like the product itself — the `claude` theme palette, JetBrains Mono, a terminal title bar, FEAT/FIX tags. It is the shareable, human-facing companion to [`changelog-generator`](../changelog-generator/SKILL.md) (which writes the machine-consumed Changesets). This skill only *renders*; it never edits `CHANGELOG.md` or changesets.
 
-Default output language is **Chinese (zh-CN)** — kobe's default. Switch to English only if the user asks.
+Default output language is **Chinese (zh-CN)** — Rove's default. Switch to English only if the user asks.
 
 ## When to use
 
@@ -21,29 +21,29 @@ Do NOT use this to draft changelog entries — that's `changelog-generator`. Thi
 
 ## Inputs
 
-- **Version range.** Default: the releases from **today** plus any from the last ~2–3 days so "几个发版" has content (kobe ships multiple releases/day — see the `main moves fast` reality). If the user names a range ("0.7.34 → 0.7.37", "最近 5 个版本", "今天的"), honor it exactly.
+- **Version range.** Default: the releases from **today** plus any from the last ~2–3 days so "几个发版" has content (Rove ships multiple releases/day — see the `main moves fast` reality). If the user names a range ("0.7.34 → 0.7.37", "最近 5 个版本", "今天的"), honor it exactly.
 - **Language.** Default zh-CN. `en` on request.
-- **Output path.** Default `kobe-release-notes-zh.html` at the repo root (`-en` suffix for English). Honor an explicit path.
+- **Output path.** Default `rove-release-notes-zh.html` at the repo root (`-en` suffix for English). Honor an explicit path.
 
 ## How to build
 
 1. **Gather the releases.** Read the top of [`packages/kobe/CHANGELOG.md`](../../../packages/kobe/CHANGELOG.md) for the version sections in range. Cross-check dates with `git log --pretty="%h %ad %s" --date=short | grep -i "chore: release"` so each version gets its real release date and "today" is correct (the env's `currentDate` is the reference for "today").
-2. **Filter to user-facing.** Keep features, visible behaviour changes, bug fixes the user can feel, packaging/install changes. **Drop** entries the changeset marked internal — anything starting `Internal:` / `Internal (web):` / pure refactor / test-only / "No behavior change". Same bar as `changelog-generator`'s Filtering section: "would a user reading github.com/Sma1lboy/kobe/releases care?"
-3. **Classify each kept entry** as `FEAT` (new capability) or `FIX` (bug/behaviour fix). Map from the verb: "Add/新增" → FEAT, "Fix/修复" → FIX. Internal-but-shipped tooling (e.g. `kobe export`) is FEAT.
+2. **Filter to user-facing.** Keep features, visible behaviour changes, bug fixes the user can feel, packaging/install changes. **Drop** entries the changeset marked internal — anything starting `Internal:` / `Internal (web):` / pure refactor / test-only / "No behavior change". Same bar as `changelog-generator`'s Filtering section: "would a user reading github.com/Sma1lboy/rove/releases care?"
+3. **Classify each kept entry** as `FEAT` (new capability) or `FIX` (bug/behaviour fix). Map from the verb: "Add/新增" → FEAT, "Fix/修复" → FIX. Internal-but-shipped tooling (e.g. `rove export`) is FEAT.
 4. **Translate to natural Chinese** (unless `en`). Keep code identifiers, CLI commands, key chords, file paths, and the version numbers verbatim — only prose is translated. Render key chords with the `.kbd` style, code with `<code>`.
 5. **Fill the template.** Copy [`assets/template.html`](assets/template.html) and replace the marked regions; [`assets/example.html`](assets/example.html) is a complete worked output (0.7.34 → 0.7.37) — match its density and voice. The newest version gets the `today` badge (`<span class="ver-badge today">今天</span>`); older versions get a plain date. Keep the styling block byte-for-byte — it encodes the real `claude` theme values; do not invent colors.
 6. **Write the file** to the output path and tell the user how to open it (suggest `! open <path>` so it runs in their session). Do not auto-commit unless asked.
 
 ## Style contract (do not drift)
 
-The look IS the product. The `<style>` block in `assets/template.html` is the source of truth and uses the real kobe `claude` theme values from `src/tui/context/theme/claude.json`:
+The look IS the product. The `<style>` block in `assets/template.html` is the source of truth and uses the real Rove `claude` theme values from `src/tui/context/theme/claude.json`:
 
 - Background `#141413`, raised `#1A1917`, inset `#2B2A27`; primary/accent terracotta `#CC785C`, secondary `#D4967E`.
 - FEAT green `#9ACA86`, FIX blue `#61AAF2`, error/red `#D47563`, yellow `#E8C96B`.
 - Font: JetBrains Mono (the TUI/web font), loaded from Google Fonts.
 - Chrome: a three-dot terminal title bar, a blinking-cursor brand line, BOLD CAPS section headers, dense two-line entries with a fixed-width FEAT/FIX tag column on the left.
 
-If kobe changes its default theme, re-derive these from `claude.json` rather than hard-coding new guesses.
+If Rove changes its default theme, re-derive these from `claude.json` rather than hard-coding new guesses.
 
 ## What to avoid
 
@@ -51,4 +51,4 @@ If kobe changes its default theme, re-derive these from `claude.json` rather tha
 - ❌ Inventing colors or fonts — pull from the template / `claude.json`.
 - ❌ Including `Internal:` / refactor / test-only entries — they're noise on a human page.
 - ❌ Multi-file output or external asset links — the page must be a single openable `.html` with no network deps except the Google Fonts link.
-- ❌ English by default — kobe's default is Chinese.
+- ❌ English by default — Rove's default is Chinese.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ The tech stack is locked: **TypeScript + `@opentui/core` + `@opentui/react` + Re
 ## Setup
 
 ```bash
-git clone https://github.com/Sma1lboy/kobe.git
-cd kobe
+git clone https://github.com/Sma1lboy/rove.git
+cd rove
 bun install
 ```
 
@@ -38,7 +38,7 @@ This is a Bun-workspaces monorepo:
 
 The current ownership map is in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
-Run package scripts from the root via `bun --filter @sma1lboy/kobe <script>`, or `cd packages/kobe` first. Most common scripts are also aliased at the root (`bun run dev`, `bun run test`, etc.).
+Run package scripts from the root via `bun --filter @sma1lboy/rove <script>`, or `cd packages/kobe` first. Most common scripts are also aliased at the root (`bun run dev`, `bun run test`, etc.).
 
 ### Reference repos (optional but recommended)
 
@@ -123,4 +123,4 @@ normal project planning.
 
 ## Questions
 
-Open a [GitHub issue](https://github.com/Sma1lboy/kobe/issues) or start a discussion on your PR. If a doc and the implementation disagree, surface the mismatch — don't silently pick one.
+Open a [GitHub issue](https://github.com/Sma1lboy/rove/issues) or start a discussion on your PR. If a doc and the implementation disagree, surface the mismatch — don't silently pick one.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@sma1lboy/rove"><img src="https://img.shields.io/npm/v/%40sma1lboy%2Frove?style=flat-square&label=npm&color=c96442" alt="npm version" /></a>
-  <a href="https://github.com/Sma1lboy/kobe/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Sma1lboy/kobe/ci.yml?branch=main&style=flat-square" alt="build" /></a>
+  <a href="https://github.com/Sma1lboy/rove/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Sma1lboy/rove/ci.yml?branch=main&style=flat-square" alt="build" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="MIT license" /></a>
 </p>
 
@@ -72,7 +72,7 @@ Press `n`, pick a repo, base branch, and engine, and prompt the embedded session
 
 Full documentation: **[docs.kobe.sma1lboy.me](https://docs.kobe.sma1lboy.me)** — quick start, concepts, CLI, agent API, configuration, keybindings, themes, engines, plugins, troubleshooting.
 
-> **If Rove saves you an afternoon, [star the repo](https://github.com/Sma1lboy/kobe/stargazers)** — it is the single strongest signal that tells other developers this is worth their time.
+> **If Rove saves you an afternoon, [star the repo](https://github.com/Sma1lboy/rove/stargazers)** — it is the single strongest signal that tells other developers this is worth their time.
 
 ## Beyond the three panes
 

--- a/docs/design/rove-rename.md
+++ b/docs/design/rove-rename.md
@@ -32,7 +32,7 @@ Rove is the canonical product name and `rove` is the canonical CLI command. Prod
 | Protocol and persisted field names | `kobeVersion`, `minKobeVersion`, related established identifiers | Wire and manifest compatibility |
 | Plugin discovery | `kobe-plugin.toml`, `min_kobe_version`, `kobe-plugin` topic | Canonical-first manifest resolution and dual-topic search keep existing plugins discoverable |
 | Agent skill id and install paths | `kobe` | Existing installs are still detected and versioned; new installs use the `rove` id |
-| Repository, docs, and website URLs | Current `…/kobe` URLs | URL migration is independent of the package distribution migration |
+| Existing repository redirects and deployed website domains | `github.com/Sma1lboy/kobe`, `kobe.sma1lboy.me`, `docs.kobe.sma1lboy.me` | Old repository links keep redirecting and deployed domains remain reachable; new repository links use `github.com/Sma1lboy/rove` |
 
 New user-facing copy must use Rove/`rove`. New compatibility identifiers should not use `kobe` unless they extend one of the established contracts above. Internal TypeScript symbols may retain `Kobe` when renaming them would create churn without changing a user-visible or serialized contract.
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -13,7 +13,7 @@ A theme is a JSON object with two top-level fields:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "defs": {
     "brand": "#cc785c"
   },

--- a/packages/kobe-docs/lib/layout.shared.tsx
+++ b/packages/kobe-docs/lib/layout.shared.tsx
@@ -5,6 +5,6 @@ export function baseOptions(): BaseLayoutProps {
     nav: {
       title: 'Rove',
     },
-    githubUrl: 'https://github.com/Sma1lboy/kobe',
+    githubUrl: 'https://github.com/Sma1lboy/rove',
   };
 }

--- a/packages/kobe-docs/scripts/sync-docs.mjs
+++ b/packages/kobe-docs/scripts/sync-docs.mjs
@@ -25,7 +25,7 @@ const docsSourceDir = join(repoRoot, 'docs');
 const docsOutDir = join(packageDir, 'content/docs');
 const assetsOutDir = join(packageDir, 'public/docs-assets');
 
-const repoBlob = 'https://github.com/Sma1lboy/kobe/blob/main/';
+const repoBlob = 'https://github.com/Sma1lboy/rove/blob/main/';
 
 /**
  * The sidebar, as ordered sections of `[docs/ source file, site slug]`.

--- a/packages/kobe-landing/TODOS.md
+++ b/packages/kobe-landing/TODOS.md
@@ -27,7 +27,7 @@ Landing page 迭代清单。目标：去掉与项目实际不符的细节，让�
 - 改法：
   - 显示 GitHub 官方 logo（inline SVG）。
   - 显示 repo 当前**实时 star 数**。
-- 实现注意：纯静态页，star 数需前端 fetch GitHub API（`https://api.github.com/repos/Sma1lboy/kobe`，读 `stargazers_count`）；注意未鉴权速率限制（60/h per IP），加 fallback/缓存。
+- 实现注意：纯静态页，star 数需前端 fetch GitHub API（`https://api.github.com/repos/Sma1lboy/rove`，读 `stargazers_count`）；注意未鉴权速率限制（60/h per IP），加 fallback/缓存。
 
 ## 4. Hero CTA 文案
 - 位置：L67 "Read the docs ↗"

--- a/packages/kobe-landing/changelog.html
+++ b/packages/kobe-landing/changelog.html
@@ -69,7 +69,7 @@
       <a href="/#why" style="color:#8a847a;text-decoration:none;">why</a>
       <a href="/#engines" style="color:#8a847a;text-decoration:none;">engines</a>
       <a href="/changelog" style="color:#e6c1b1;text-decoration:none;">changelog</a>
-      <a href="https://github.com/Sma1lboy/kobe" target="_blank" rel="noopener" style="color:#eae7df;text-decoration:none;border:1px solid #34302a;padding:7px 12px;border-radius:8px;display:flex;align-items:center;gap:8px;">
+      <a href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener" style="color:#eae7df;text-decoration:none;border:1px solid #34302a;padding:7px 12px;border-radius:8px;display:flex;align-items:center;gap:8px;">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         <span>GitHub</span>
         <span style="display:flex;align-items:center;gap:4px;border-left:1px solid #34302a;padding-left:8px;color:#a39d92;">
@@ -106,9 +106,9 @@
         <span style="font-weight:400;margin-left:4px;">parallel coding agents, terminal-native.</span>
       </a>
       <div style="display:flex;gap:24px;font-size:13px;color:#6b655c;">
-        <a href="https://github.com/Sma1lboy/kobe/releases" target="_blank" rel="noopener" style="color:#6b655c;text-decoration:none;">All releases ↗</a>
+        <a href="https://github.com/Sma1lboy/rove/releases" target="_blank" rel="noopener" style="color:#6b655c;text-decoration:none;">All releases ↗</a>
         <a href="https://www.npmjs.com/package/@sma1lboy/rove" style="color:#6b655c;text-decoration:none;">npm</a>
-        <a href="https://github.com/Sma1lboy/kobe/blob/main/docs/KEYBINDINGS.md" style="color:#6b655c;text-decoration:none;">Keybindings</a>
+        <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" style="color:#6b655c;text-decoration:none;">Keybindings</a>
       </div>
     </div>
   </main>
@@ -122,7 +122,7 @@
     if (!el) return;
     function render(n) { el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n); }
     try { var c = JSON.parse(localStorage.getItem('kobe_stars') || 'null'); if (c && typeof c.n === 'number') render(c.n); } catch (e) {}
-    fetch('https://api.github.com/repos/Sma1lboy/kobe')
+    fetch('https://api.github.com/repos/Sma1lboy/rove')
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (d) { if (!d || typeof d.stargazers_count !== 'number') return; render(d.stargazers_count); try { localStorage.setItem('kobe_stars', JSON.stringify({ n: d.stargazers_count })); } catch (e) {} })
       .catch(function () { if (el.textContent === '–') el.textContent = '☆'; });
@@ -271,10 +271,10 @@
     document.getElementById('langEn').addEventListener('click', function () { if (LANG === 'en') return; LANG = 'en'; applyLang(); });
     document.getElementById('langZh').addEventListener('click', function () { if (LANG === 'zh') return; LANG = 'zh'; applyLang(); });
 
-    fetch('https://api.github.com/repos/Sma1lboy/kobe/releases?per_page=100')
+    fetch('https://api.github.com/repos/Sma1lboy/rove/releases?per_page=100')
       .then(function (r) { if (!r.ok) throw new Error('http ' + r.status); return r.json(); })
       .then(function (rels) {
-        if (!Array.isArray(rels) || !rels.length) { loading.innerHTML = 'No releases yet. See <a href="https://github.com/Sma1lboy/kobe/releases" style="color:#d98c72;">GitHub</a>.'; return; }
+        if (!Array.isArray(rels) || !rels.length) { loading.innerHTML = 'No releases yet. See <a href="https://github.com/Sma1lboy/rove/releases" style="color:#d98c72;">GitHub</a>.'; return; }
         host.innerHTML = rels.map(function (rel, idx) {
           var tag = esc(rel.tag_name || rel.name || '');
           var badge = idx === 0 ? '<span class="rel-badge latest">latest</span>' : (rel.prerelease ? '<span class="rel-badge">prerelease</span>' : '');
@@ -288,7 +288,7 @@
         }).join('');
         applyLang();
       })
-      .catch(function () { loading.innerHTML = 'Couldn’t load releases (GitHub API). See the full list on <a href="https://github.com/Sma1lboy/kobe/releases" style="color:#d98c72;">GitHub ↗</a>.'; });
+      .catch(function () { loading.innerHTML = 'Couldn’t load releases (GitHub API). See the full list on <a href="https://github.com/Sma1lboy/rove/releases" style="color:#d98c72;">GitHub ↗</a>.'; });
   })();
 </script>
 </body>

--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -175,7 +175,7 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(44px
   <a class="nl" href="/changelog" data-i18n="nav.changelog">--changelog</a>
   <span class="caret" aria-hidden="true"></span>
   <button id="langToggle" class="lang-btn">中文</button>
-  <a class="gh-link" href="https://github.com/Sma1lboy/kobe" target="_blank" rel="noopener">
+  <a class="gh-link" href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">
     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
     <span>GitHub</span>
     <span class="gh-stars">
@@ -199,7 +199,7 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(44px
         <span>bun install -g @sma1lboy/rove</span>
         <span id="copyLabel" class="hint">click to copy</span>
       </button>
-      <a class="btn-primary" href="https://github.com/Sma1lboy/kobe#readme" data-i18n="hero.getStarted">Get started ↗</a>
+      <a class="btn-primary" href="https://github.com/Sma1lboy/rove#readme" data-i18n="hero.getStarted">Get started ↗</a>
     </div>
     <p class="hero-req rise" style="animation-delay:.58s" data-i18n="hero.requirements">Runs on macOS &amp; Linux (Windows via WSL). Requires Bun ≥ 1.3.11 and one engine CLI on your PATH.</p>
   </div>
@@ -313,7 +313,7 @@ c  <span class="ok">+96</span>  <span class="del">−88</span>  · 5 files
 <span class="d">3 attempts running. Go do something else.</span></pre></figure>
     <div class="install-actions">
       <a class="btn-primary" href="https://www.npmjs.com/package/@sma1lboy/rove" data-i18n="install.npm">Install from npm ↗</a>
-      <a class="btn-quiet" href="https://github.com/Sma1lboy/kobe" data-i18n="install.star">Star on GitHub ↗</a>
+      <a class="btn-quiet" href="https://github.com/Sma1lboy/rove" data-i18n="install.star">Star on GitHub ↗</a>
     </div>
   </div>
 </section>
@@ -329,180 +329,9 @@ c  <span class="ok">+96</span>  <span class="del">−88</span>  · 5 files
 
 <!-- FOOTER · dense colophon -->
 <footer class="foot-dense">
-  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span> <a href="https://github.com/Sma1lboy/kobe">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/plugins" data-i18n="footer.plugins">plugins</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/kobe/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
+  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span> <a href="https://github.com/Sma1lboy/rove">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/plugins" data-i18n="footer.plugins">plugins</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
 </footer>
 
-<script>
-  // EN / 中文 — one page, two language versions. Terminal-mock content
-  // (commands, branch names, TUI chrome) deliberately stays English.
-  var KOBE_I18N = (function () {
-    var zh = {
-      'meta.title': 'Rove — 把编码代理跑成一张图，终端原生',
-      'meta.desc': 'Rove 是本地优先的图工程 TUI：把多个 AI 编码代理跑成一张由隔离尝试组成的图——git worktree、托管引擎会话、显式结果上报——最后合入赢家。',
-      'nav.workflow': '--原语', 'nav.install': '--安装', 'nav.plugins': '--插件', 'nav.themes': '--主题', 'nav.changelog': '--更新日志',
-      'hero.kicker': '提示词工程 → 上下文工程 → <span class="acc">图工程</span>',
-      'hero.title': '装在你 shell 里的 agent <span class="acc">多路复用器</span>。',
-      'hero.sub': '一个代理是一场对话，五个同时跑就是一张图：节点是隔离的尝试——git worktree + 引擎会话 + 分支——边是依赖，门是你的判断。Rove 是这张图的终端原生运行时。',
-      'hero.getStarted': '快速上手 ↗',
-      'hero.requirements': '支持 macOS 和 Linux（Windows 走 WSL）。需要 Bun ≥ 1.3.11，以及 PATH 上任意一个引擎 CLI。',
-      'copy.hint': '点击复制', 'copy.done': '✓ 已复制',
-      'workspace.equation': '一个节点 =', 'workspace.sessions': '托管引擎会话',
-      's1.no': '1.0 · 扇出', 's1.title': '一条 prompt 变成 N 个隔离的尝试。',
-      's1.body': '扇出是第一个原语，而隔离正是重点。Rove 为每个尝试建独立的 git worktree 和分支，运行你指定的引擎——claude、codex、copilot、kimi，或你自己的命令。独立节点，没有共享状态，代理之间互不碰文件。',
-      's1.ownCmd': '你自己的命令',
-      's2.no': '2.0 · 监督', 's2.title': '沉默不是一种状态。尝试要报告。',
-      's2.body': '在一排终端机群里，安静的代理可能在思考，也可能已经挂了。所以在 Rove 里，每个尝试结束时都显式上报结果——succeeded 或 failed——编排代理可以阻塞等待整批尝试出结果。代理编排代理，有真正的完成语义。',
-      's3.no': '3.0 · 观察', 's3.title': '读会话本身，不刮终端屏幕。',
-      's3.body': 'Rove 直接读每个引擎自己的会话数据——历史、token、上下文——而不是抓取终端文本。每个会话都运行在代码所在机器的 Hosted PTY 里、由 daemon 托管：退出 TUI、断开 SSH，这张图继续跑。从任何地方重新接上。',
-      's3.body2': '而且是你的真实机器：真实的依赖、服务、凭证和构建缓存。代理跑通的对你也跑通。',
-      's4.no': '4.0 · 扇入', 's4.title': '比较尝试，合入赢家。',
-      's4.body': '扇入是一道人工门。拉一份所有尝试的只读快照——分支、diff 统计、运行状态——并排审阅，合入你满意的分支，归档其余。一次尝试是掷硬币——N 次是选择。',
-      'install.title': '在你代码所在的地方跑起来。',
-      'install.body': '笔记本、devbox、VPS，或任何能 SSH 上去的机器。没有浏览器、没有 VNC、没有桌面应用。优化唯一重要的指标：你每小时注意力换来的已合并代码。',
-      'install.npm': '从 npm 安装 ↗', 'install.star': '去 GitHub 点个 Star ↗',
-      'final.line': '所有支流终会汇合。判断权在你手里。',
-      'footer.tagline': '终端原生的编码代理图工程。',
-      'footer.colophon': '用 Bun、OpenTUI 和 React 构建。字体为 Fraunces、DM Sans 与 JetBrains Mono。MIT 许可。',
-      'footer.plugins': '插件', 'footer.changelog': '更新日志', 'footer.keybindings': '快捷键',
-    };
-    var en = {
-      'meta.title': 'Rove — run coding agents as a graph, terminal-native',
-      'meta.desc': 'Rove is a local-first TUI for graph engineering: run many AI coding agents as a graph of isolated attempts — git worktrees, hosted engine sessions, explicit reports — and merge the winner.',
-      'nav.workflow': '--primitives', 'nav.install': '--install', 'nav.plugins': '--plugins', 'nav.themes': '--themes', 'nav.changelog': '--changelog',
-      'hero.kicker': 'prompt engineering → context engineering → <span class="acc">graph engineering</span>',
-      'hero.title': 'The agent <span class="acc">multiplexer</span> in your shell.',
-      'hero.sub': 'One agent is a conversation. Five at once are a graph: nodes are isolated attempts — git worktree + engine session + branch — edges are dependencies, and the gates are your judgment. Rove is the terminal-native runtime for that graph.',
-      'hero.getStarted': 'Get started ↗',
-      'hero.requirements': 'Runs on macOS & Linux (Windows via WSL). Requires Bun ≥ 1.3.11 and one engine CLI on your PATH.',
-      'copy.hint': 'click to copy', 'copy.done': '✓ copied',
-      'workspace.equation': 'one node =', 'workspace.sessions': 'hosted engine session',
-      's1.no': '1.0 · FAN OUT', 's1.title': 'One prompt becomes N isolated attempts.',
-      's1.body': 'Fan-out is the first primitive, and isolation is the point. Rove spawns every attempt in its own git worktree on its own branch, running whichever engine you point it at — claude, codex, copilot, kimi, or your own command. Independent nodes, no shared state, no agents stepping on each other\'s files.',
-      's1.ownCmd': 'your own command',
-      's2.no': '2.0 · SUPERVISE', 's2.title': 'Silence is not a status. Attempts report.',
-      's2.body': 'In a fleet of terminals, a quiet agent could be thinking or could be dead. So in Rove every attempt ends by reporting an explicit outcome — succeeded or failed — and an orchestrating agent can block until the whole fleet resolves. Agents orchestrating agents, with real completion semantics.',
-      's3.no': '3.0 · OBSERVE', 's3.title': 'Read the session, never scrape the screen.',
-      's3.body': 'Rove reads each engine\'s own session data — history, tokens, context — instead of scraping terminal text. And every session lives in a hosted PTY behind the daemon, on the machine where your code lives: quit the TUI, drop SSH, the graph keeps running. Reattach from anywhere.',
-      's3.body2': 'And it\'s your real machine: real dependencies, services, credentials, build cache. What passes for the agent passes for you.',
-      's4.no': '4.0 · FAN IN', 's4.title': 'Compare the attempts. Merge the winner.',
-      's4.body': 'Fan-in is a human gate. Pull a read-only snapshot of every attempt — branch, diffstat, running state — review them side by side, merge the branch you like, archive the rest. One attempt is a coin flip — N is a choice.',
-      'install.title': 'Spin it up where your code lives.',
-      'install.body': 'Your laptop, a devbox, a VPS, or any machine you can SSH into. No browser, no VNC, no desktop app. Optimize the one metric that matters: merged code per hour of your attention.',
-      'install.npm': 'Install from npm ↗', 'install.star': 'Star on GitHub ↗',
-      'final.line': 'Every stream converges. You keep the judgment.',
-      'footer.tagline': 'graph engineering for coding agents, terminal-native.',
-      'footer.colophon': 'Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.',
-      'footer.plugins': 'plugins', 'footer.changelog': 'changelog', 'footer.keybindings': 'keybindings',
-    };
-    var dicts = { en: en, zh: zh };
-    var lang = 'en';
-    try {
-      var fromUrl = new URLSearchParams(location.search).get('lang');
-      var stored = localStorage.getItem('kobe_lang');
-      var nav = (navigator.language || '').toLowerCase().indexOf('zh') === 0 ? 'zh' : 'en';
-      lang = fromUrl === 'zh' || fromUrl === 'en' ? fromUrl : stored === 'zh' || stored === 'en' ? stored : nav;
-    } catch (e) {}
-
-    function t(key) { return dicts[lang][key] || dicts.en[key] || ''; }
-
-    function apply() {
-      document.documentElement.lang = lang === 'zh' ? 'zh-CN' : 'en';
-      document.title = t('meta.title');
-      var desc = document.querySelector('meta[name="description"]');
-      if (desc) desc.setAttribute('content', t('meta.desc'));
-      document.querySelectorAll('[data-i18n]').forEach(function (el) {
-        var v = t(el.getAttribute('data-i18n'));
-        if (v) el.textContent = v;
-      });
-      document.querySelectorAll('[data-i18n-html]').forEach(function (el) {
-        var v = t(el.getAttribute('data-i18n-html'));
-        if (v) el.innerHTML = v;
-      });
-      var label = document.getElementById('copyLabel');
-      if (label) label.textContent = t('copy.hint');
-      var toggle = document.getElementById('langToggle');
-      if (toggle) toggle.textContent = lang === 'zh' ? 'EN' : '中文';
-    }
-
-    var toggleBtn = document.getElementById('langToggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', function () {
-        lang = lang === 'zh' ? 'en' : 'zh';
-        try { localStorage.setItem('kobe_lang', lang); } catch (e) {}
-        apply();
-      });
-    }
-    apply(); // first paint: honors ?lang= / stored pref / browser language
-
-    return { t: t };
-  })();
-
-  // copy-to-clipboard for the install command
-  (function () {
-    var btn = document.getElementById('copyBtn');
-    var label = document.getElementById('copyLabel');
-    var timer;
-    btn.addEventListener('click', function () {
-      try {
-        if (navigator.clipboard) navigator.clipboard.writeText('bun install -g @sma1lboy/rove');
-      } catch (e) {}
-      label.textContent = KOBE_I18N.t('copy.done');
-      clearTimeout(timer);
-      timer = setTimeout(function () { label.textContent = KOBE_I18N.t('copy.hint'); }, 1800);
-    });
-  })();
-
-  // live GitHub star count (cache for instant first paint, refresh each load, graceful fallback)
-  (function () {
-    var el = document.getElementById('starCount');
-    if (!el) return;
-    function render(n) {
-      el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n);
-    }
-    var CACHE_KEY = 'kobe_stars';
-    try {
-      var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
-      if (cached && typeof cached.n === 'number') render(cached.n);
-    } catch (e) {}
-    fetch('https://api.github.com/repos/Sma1lboy/kobe')
-      .then(function (r) { return r.ok ? r.json() : null; })
-      .then(function (d) {
-        if (!d || typeof d.stargazers_count !== 'number') return;
-        render(d.stargazers_count);
-        try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count })); } catch (e) {}
-      })
-      .catch(function () { if (el.textContent === '–') el.textContent = '☆'; });
-  })();
-
-  // engine selector → updates the stage-1 fan-out (vendor flag + spawned worktree lanes)
-  (function () {
-    var branchMap = {
-      'claude': 'claude', 'codex': 'codex', 'copilot': 'copilot',
-      'kimi': 'kimi', 'your own command': 'my-cli',
-    };
-    var engineEl = document.getElementById('fanEngineName');
-    var linesEl = document.getElementById('fanLines');
-    var pills = document.querySelectorAll('.engine-pill');
-    if (!engineEl || !linesEl) return;
-
-    function render(engine) {
-      var slug = branchMap[engine] || engine;
-      engineEl.textContent = engine === 'your own command' ? 'my-cli' : engine;
-      var pad = function (s) { return (s + '              ').slice(0, 16); };
-      linesEl.innerHTML = ['a', 'b', 'c'].map(function (s) {
-        return '<span class="ok">●</span> ' + pad('kobe/' + slug + '-' + s) + '<span class="d">running</span>';
-      }).join('\n');
-    }
-
-    pills.forEach(function (pill) {
-      pill.addEventListener('click', function () {
-        pills.forEach(function (p) { p.setAttribute('data-active', 'false'); });
-        pill.setAttribute('data-active', 'true');
-        render(pill.getAttribute('data-engine'));
-      });
-    });
-    render('claude');
-  })();
-</script>
+<script src="/index.js"></script>
 </body>
 </html>

--- a/packages/kobe-landing/index.js
+++ b/packages/kobe-landing/index.js
@@ -1,0 +1,170 @@
+// EN / 中文 — one page, two language versions. Terminal-mock content
+// (commands, branch names, TUI chrome) deliberately stays English.
+var KOBE_I18N = (function () {
+  var zh = {
+    'meta.title': 'Rove — 把编码代理跑成一张图，终端原生',
+    'meta.desc': 'Rove 是本地优先的图工程 TUI：把多个 AI 编码代理跑成一张由隔离尝试组成的图——git worktree、托管引擎会话、显式结果上报——最后合入赢家。',
+    'nav.workflow': '--原语', 'nav.install': '--安装', 'nav.plugins': '--插件', 'nav.themes': '--主题', 'nav.changelog': '--更新日志',
+    'hero.kicker': '提示词工程 → 上下文工程 → <span class="acc">图工程</span>',
+    'hero.title': '装在你 shell 里的 agent <span class="acc">多路复用器</span>。',
+    'hero.sub': '一个代理是一场对话，五个同时跑就是一张图：节点是隔离的尝试——git worktree + 引擎会话 + 分支——边是依赖，门是你的判断。Rove 是这张图的终端原生运行时。',
+    'hero.getStarted': '快速上手 ↗',
+    'hero.requirements': '支持 macOS 和 Linux（Windows 走 WSL）。需要 Bun ≥ 1.3.11，以及 PATH 上任意一个引擎 CLI。',
+    'copy.hint': '点击复制', 'copy.done': '✓ 已复制',
+    'workspace.equation': '一个节点 =', 'workspace.sessions': '托管引擎会话',
+    's1.no': '1.0 · 扇出', 's1.title': '一条 prompt 变成 N 个隔离的尝试。',
+    's1.body': '扇出是第一个原语，而隔离正是重点。Rove 为每个尝试建独立的 git worktree 和分支，运行你指定的引擎——claude、codex、copilot、kimi，或你自己的命令。独立节点，没有共享状态，代理之间互不碰文件。',
+    's1.ownCmd': '你自己的命令',
+    's2.no': '2.0 · 监督', 's2.title': '沉默不是一种状态。尝试要报告。',
+    's2.body': '在一排终端机群里，安静的代理可能在思考，也可能已经挂了。所以在 Rove 里，每个尝试结束时都显式上报结果——succeeded 或 failed——编排代理可以阻塞等待整批尝试出结果。代理编排代理，有真正的完成语义。',
+    's3.no': '3.0 · 观察', 's3.title': '读会话本身，不刮终端屏幕。',
+    's3.body': 'Rove 直接读每个引擎自己的会话数据——历史、token、上下文——而不是抓取终端文本。每个会话都运行在代码所在机器的 Hosted PTY 里、由 daemon 托管：退出 TUI、断开 SSH，这张图继续跑。从任何地方重新接上。',
+    's3.body2': '而且是你的真实机器：真实的依赖、服务、凭证和构建缓存。代理跑通的对你也跑通。',
+    's4.no': '4.0 · 扇入', 's4.title': '比较尝试，合入赢家。',
+    's4.body': '扇入是一道人工门。拉一份所有尝试的只读快照——分支、diff 统计、运行状态——并排审阅，合入你满意的分支，归档其余。一次尝试是掷硬币——N 次是选择。',
+    'install.title': '在你代码所在的地方跑起来。',
+    'install.body': '笔记本、devbox、VPS，或任何能 SSH 上去的机器。没有浏览器、没有 VNC、没有桌面应用。优化唯一重要的指标：你每小时注意力换来的已合并代码。',
+    'install.npm': '从 npm 安装 ↗', 'install.star': '去 GitHub 点个 Star ↗',
+    'final.line': '所有支流终会汇合。判断权在你手里。',
+    'footer.tagline': '终端原生的编码代理图工程。',
+    'footer.colophon': '用 Bun、OpenTUI 和 React 构建。字体为 Fraunces、DM Sans 与 JetBrains Mono。MIT 许可。',
+    'footer.plugins': '插件', 'footer.changelog': '更新日志', 'footer.keybindings': '快捷键',
+  };
+  var en = {
+    'meta.title': 'Rove — run coding agents as a graph, terminal-native',
+    'meta.desc': 'Rove is a local-first TUI for graph engineering: run many AI coding agents as a graph of isolated attempts — git worktrees, hosted engine sessions, explicit reports — and merge the winner.',
+    'nav.workflow': '--primitives', 'nav.install': '--install', 'nav.plugins': '--plugins', 'nav.themes': '--themes', 'nav.changelog': '--changelog',
+    'hero.kicker': 'prompt engineering → context engineering → <span class="acc">graph engineering</span>',
+    'hero.title': 'The agent <span class="acc">multiplexer</span> in your shell.',
+    'hero.sub': 'One agent is a conversation. Five at once are a graph: nodes are isolated attempts — git worktree + engine session + branch — edges are dependencies, and the gates are your judgment. Rove is the terminal-native runtime for that graph.',
+    'hero.getStarted': 'Get started ↗',
+    'hero.requirements': 'Runs on macOS & Linux (Windows via WSL). Requires Bun ≥ 1.3.11 and one engine CLI on your PATH.',
+    'copy.hint': 'click to copy', 'copy.done': '✓ copied',
+    'workspace.equation': 'one node =', 'workspace.sessions': 'hosted engine session',
+    's1.no': '1.0 · FAN OUT', 's1.title': 'One prompt becomes N isolated attempts.',
+    's1.body': 'Fan-out is the first primitive, and isolation is the point. Rove spawns every attempt in its own git worktree on its own branch, running whichever engine you point it at — claude, codex, copilot, kimi, or your own command. Independent nodes, no shared state, no agents stepping on each other\'s files.',
+    's1.ownCmd': 'your own command',
+    's2.no': '2.0 · SUPERVISE', 's2.title': 'Silence is not a status. Attempts report.',
+    's2.body': 'In a fleet of terminals, a quiet agent could be thinking or could be dead. So in Rove every attempt ends by reporting an explicit outcome — succeeded or failed — and an orchestrating agent can block until the whole fleet resolves. Agents orchestrating agents, with real completion semantics.',
+    's3.no': '3.0 · OBSERVE', 's3.title': 'Read the session, never scrape the screen.',
+    's3.body': 'Rove reads each engine\'s own session data — history, tokens, context — instead of scraping terminal text. And every session lives in a hosted PTY behind the daemon, on the machine where your code lives: quit the TUI, drop SSH, the graph keeps running. Reattach from anywhere.',
+    's3.body2': 'And it\'s your real machine: real dependencies, services, credentials, build cache. What passes for the agent passes for you.',
+    's4.no': '4.0 · FAN IN', 's4.title': 'Compare the attempts. Merge the winner.',
+    's4.body': 'Fan-in is a human gate. Pull a read-only snapshot of every attempt — branch, diffstat, running state — review them side by side, merge the branch you like, archive the rest. One attempt is a coin flip — N is a choice.',
+    'install.title': 'Spin it up where your code lives.',
+    'install.body': 'Your laptop, a devbox, a VPS, or any machine you can SSH into. No browser, no VNC, no desktop app. Optimize the one metric that matters: merged code per hour of your attention.',
+    'install.npm': 'Install from npm ↗', 'install.star': 'Star on GitHub ↗',
+    'final.line': 'Every stream converges. You keep the judgment.',
+    'footer.tagline': 'graph engineering for coding agents, terminal-native.',
+    'footer.colophon': 'Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.',
+    'footer.plugins': 'plugins', 'footer.changelog': 'changelog', 'footer.keybindings': 'keybindings',
+  };
+  var dicts = { en: en, zh: zh };
+  var lang = 'en';
+  try {
+    var fromUrl = new URLSearchParams(location.search).get('lang');
+    var stored = localStorage.getItem('kobe_lang');
+    var nav = (navigator.language || '').toLowerCase().indexOf('zh') === 0 ? 'zh' : 'en';
+    lang = fromUrl === 'zh' || fromUrl === 'en' ? fromUrl : stored === 'zh' || stored === 'en' ? stored : nav;
+  } catch (e) {}
+
+  function t(key) { return dicts[lang][key] || dicts.en[key] || ''; }
+
+  function apply() {
+    document.documentElement.lang = lang === 'zh' ? 'zh-CN' : 'en';
+    document.title = t('meta.title');
+    var desc = document.querySelector('meta[name="description"]');
+    if (desc) desc.setAttribute('content', t('meta.desc'));
+    document.querySelectorAll('[data-i18n]').forEach(function (el) {
+      var v = t(el.getAttribute('data-i18n'));
+      if (v) el.textContent = v;
+    });
+    document.querySelectorAll('[data-i18n-html]').forEach(function (el) {
+      var v = t(el.getAttribute('data-i18n-html'));
+      if (v) el.innerHTML = v;
+    });
+    var label = document.getElementById('copyLabel');
+    if (label) label.textContent = t('copy.hint');
+    var toggle = document.getElementById('langToggle');
+    if (toggle) toggle.textContent = lang === 'zh' ? 'EN' : '中文';
+  }
+
+  var toggleBtn = document.getElementById('langToggle');
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', function () {
+      lang = lang === 'zh' ? 'en' : 'zh';
+      try { localStorage.setItem('kobe_lang', lang); } catch (e) {}
+      apply();
+    });
+  }
+  apply(); // first paint: honors ?lang= / stored pref / browser language
+
+  return { t: t };
+})();
+
+// copy-to-clipboard for the install command
+(function () {
+  var btn = document.getElementById('copyBtn');
+  var label = document.getElementById('copyLabel');
+  var timer;
+  btn.addEventListener('click', function () {
+    try {
+      if (navigator.clipboard) navigator.clipboard.writeText('bun install -g @sma1lboy/rove');
+    } catch (e) {}
+    label.textContent = KOBE_I18N.t('copy.done');
+    clearTimeout(timer);
+    timer = setTimeout(function () { label.textContent = KOBE_I18N.t('copy.hint'); }, 1800);
+  });
+})();
+
+// live GitHub star count (cache for instant first paint, refresh each load, graceful fallback)
+(function () {
+  var el = document.getElementById('starCount');
+  if (!el) return;
+  function render(n) {
+    el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n);
+  }
+  var CACHE_KEY = 'kobe_stars';
+  try {
+    var cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+    if (cached && typeof cached.n === 'number') render(cached.n);
+  } catch (e) {}
+  fetch('https://api.github.com/repos/Sma1lboy/rove')
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (d) {
+      if (!d || typeof d.stargazers_count !== 'number') return;
+      render(d.stargazers_count);
+      try { localStorage.setItem(CACHE_KEY, JSON.stringify({ n: d.stargazers_count })); } catch (e) {}
+    })
+    .catch(function () { if (el.textContent === '–') el.textContent = '☆'; });
+})();
+
+// engine selector → updates the stage-1 fan-out (vendor flag + spawned worktree lanes)
+(function () {
+  var branchMap = {
+    'claude': 'claude', 'codex': 'codex', 'copilot': 'copilot',
+    'kimi': 'kimi', 'your own command': 'my-cli',
+  };
+  var engineEl = document.getElementById('fanEngineName');
+  var linesEl = document.getElementById('fanLines');
+  var pills = document.querySelectorAll('.engine-pill');
+  if (!engineEl || !linesEl) return;
+
+  function render(engine) {
+    var slug = branchMap[engine] || engine;
+    engineEl.textContent = engine === 'your own command' ? 'my-cli' : engine;
+    var pad = function (s) { return (s + '              ').slice(0, 16); };
+    linesEl.innerHTML = ['a', 'b', 'c'].map(function (s) {
+      return '<span class="ok">●</span> ' + pad('kobe/' + slug + '-' + s) + '<span class="d">running</span>';
+    }).join('\n');
+  }
+
+  pills.forEach(function (pill) {
+    pill.addEventListener('click', function () {
+      pills.forEach(function (p) { p.setAttribute('data-active', 'false'); });
+      pill.setAttribute('data-active', 'true');
+      render(pill.getAttribute('data-engine'));
+    });
+  });
+  render('claude');
+})();

--- a/packages/kobe-landing/plugins.html
+++ b/packages/kobe-landing/plugins.html
@@ -216,7 +216,7 @@ code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash)
   <a class="nl" href="/changelog" data-i18n="nav.changelog">--changelog</a>
   <span class="caret" aria-hidden="true"></span>
   <button id="langToggle" class="lang-btn">中文</button>
-  <a class="gh-link" href="https://github.com/Sma1lboy/kobe" target="_blank" rel="noopener">
+  <a class="gh-link" href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">
     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
     <span>GitHub</span>
     <span class="gh-stars">
@@ -305,7 +305,7 @@ code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash)
 
 <!-- FOOTER · dense colophon -->
 <footer class="foot-dense">
-  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span> <a href="https://github.com/Sma1lboy/kobe">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/kobe/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
+  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span> <a href="https://github.com/Sma1lboy/rove">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
 </footer>
 
 <script>
@@ -426,7 +426,7 @@ code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash)
     if (!el) return;
     function render(n) { el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n); }
     try { var c = JSON.parse(localStorage.getItem('kobe_stars') || 'null'); if (c && typeof c.n === 'number') render(c.n); } catch (e) {}
-    fetch('https://api.github.com/repos/Sma1lboy/kobe')
+    fetch('https://api.github.com/repos/Sma1lboy/rove')
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (d) { if (!d || typeof d.stargazers_count !== 'number') return; render(d.stargazers_count); try { localStorage.setItem('kobe_stars', JSON.stringify({ n: d.stargazers_count })); } catch (e) {} })
       .catch(function () { if (el.textContent === '–') el.textContent = '☆'; });

--- a/packages/kobe-landing/themes.css
+++ b/packages/kobe-landing/themes.css
@@ -1,0 +1,126 @@
+:root{
+  --paper:     oklch(97.8% 0.007 85);
+  --surface:   oklch(99.4% 0.003 90);
+  --well:      oklch(22% 0.02 50);
+  --well-2:    oklch(27% 0.022 50);
+  --well-ink:  oklch(88% 0.015 85);
+  --ink:       oklch(25% 0.02 60);
+  --ink-soft:  oklch(35% 0.02 55);
+  --muted:     oklch(50% 0.02 60);
+  --faint:     oklch(62% 0.018 65);
+  --line:      oklch(88% 0.014 80);
+  --line-2:    oklch(83% 0.018 75);
+  --accent:    oklch(62% 0.13 45);
+  --accent-2:  oklch(70% 0.11 50);
+  --accent-wash: oklch(62% 0.13 45 / .1);
+  --accent-line: oklch(62% 0.13 45 / .4);
+  --ok:        oklch(58% 0.12 145);
+  --warn:      oklch(62% 0.11 80);
+  --radius:    12px;
+  --radius-lg: 22px;
+  --font-display:'Fraunces', Georgia, serif;
+  --font-sans:'DM Sans', system-ui, sans-serif;
+  --font-mono:'JetBrains Mono', ui-monospace, monospace;
+  --ease-out: cubic-bezier(0.16,1,0.3,1);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html,body{background:var(--paper)}
+body{color:var(--ink-soft);font-family:var(--font-sans);font-weight:380;font-size:15px;line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+::selection{background:oklch(62% 0.13 45/.22)}
+a{color:inherit;text-decoration:none}
+button{font-family:inherit;cursor:pointer}
+:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:4px}
+.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px)}
+.acc{color:var(--accent);font-style:italic}
+
+/* ============ NAV — glass pill, terminal grammar ============ */
+.navbar{position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:50;display:flex;align-items:center;gap:2px;padding:6px 8px;border-radius:999px;background:oklch(100% 0 0/.55);backdrop-filter:blur(16px) saturate(1.3);border:1px solid oklch(100% 0 0/.8);box-shadow:0 10px 36px oklch(40% 0.04 60/.16);font-family:var(--font-mono);font-size:12.5px;max-width:calc(100vw - 24px)}
+.navbar .ps{color:var(--accent);padding-left:8px}
+.navbar .bin{font-weight:700;color:var(--ink);padding:8px 6px 8px 4px}
+.navbar a.nl{color:var(--ink-soft);padding:8px 10px;border-radius:999px;transition:background 140ms,color 140ms;white-space:nowrap}
+.navbar a.nl:hover{background:oklch(100% 0 0/.85);color:var(--ink)}
+.navbar a.nl[aria-current="page"]{background:var(--accent-wash);color:var(--accent)}
+.navbar .caret{display:inline-block;width:7px;height:14px;background:var(--accent);margin:0 4px 0 2px;animation:blink 1.1s steps(1) infinite;vertical-align:-2px}
+@keyframes blink{50%{opacity:0}}
+.lang-btn{background:none;border:1px solid var(--line-2);color:var(--ink-soft);font-family:var(--font-mono);font-size:11.5px;padding:5px 9px;border-radius:999px;transition:border-color 140ms,color 140ms;white-space:nowrap}
+.lang-btn:hover{border-color:var(--accent);color:var(--accent)}
+.gh-link{display:flex;align-items:center;gap:5px;padding:7px 11px;border-radius:999px;background:var(--ink);color:var(--paper);font-family:var(--font-mono);font-size:11.5px;margin-left:2px}
+@media(max-width:820px){.navbar a.nl{display:none}}
+
+/* ============ HEAD ============ */
+.top{padding:132px 0 20px}
+.kicker{font-family:var(--font-mono);font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--faint)}
+h1{font-family:var(--font-display);font-weight:340;font-size:clamp(34px,5.4vw,58px);line-height:1.03;letter-spacing:-.022em;color:var(--ink);margin:14px 0 0;font-variation-settings:'SOFT' 30,'WONK' 1}
+.lede{font-size:17px;line-height:1.6;color:var(--ink-soft);max-width:64ch;margin-top:18px}
+.lede code,.body code{font-family:var(--font-mono);font-size:.88em;background:var(--accent-wash);color:var(--accent);padding:1px 5px;border-radius:5px}
+.rule{height:1px;background:var(--line);margin:44px 0 0}
+
+h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px);line-height:1.12;letter-spacing:-.018em;color:var(--ink);font-variation-settings:'SOFT' 30}
+.sec{padding:56px 0 0}
+.sec-no{font-family:var(--font-mono);font-size:11.5px;letter-spacing:.1em;color:var(--accent);text-transform:uppercase}
+.body{font-size:15px;color:var(--ink-soft);max-width:66ch;margin-top:14px}
+
+/* ============ THEME GRID ============ */
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:20px;margin-top:30px}
+.tcard{border:1px solid var(--line);border-radius:var(--radius-lg);background:var(--surface);overflow:hidden;transition:border-color 180ms var(--ease-out),box-shadow 180ms var(--ease-out)}
+.tcard:hover{border-color:var(--line-2);box-shadow:0 14px 40px oklch(40% 0.04 60/.09)}
+.tc-head{display:flex;align-items:baseline;justify-content:space-between;gap:10px;padding:15px 17px 12px}
+.tc-name{font-family:var(--font-mono);font-size:14px;font-weight:700;color:var(--ink)}
+.tc-tag{font-family:var(--font-mono);font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--faint);white-space:nowrap}
+/* Reserve three lines so the mini-TUIs line up across a row no matter how
+   long each blurb runs — a ragged grid reads as broken, not as variety. */
+.tc-note{padding:0 17px 13px;font-size:13px;color:var(--muted);line-height:1.5;min-height:72px}
+@media(max-width:700px){.tc-note{min-height:0}}
+
+/* The mini-TUI: every color comes from the card's own custom properties,
+   which are the theme's real slot values. One rule set, seven palettes. */
+.mock{font-family:var(--font-mono);font-size:10.5px;line-height:1.55;background:var(--t-bg);border-top:1px solid var(--line);border-bottom:1px solid var(--line);display:flex;min-height:158px}
+.mock-side{width:40%;flex:none;background:var(--t-panel);border-right:1px solid var(--t-border);padding:8px 0}
+.mock-main{flex:1;padding:8px 10px;min-width:0}
+.m-hdr{color:var(--t-muted);font-weight:700;letter-spacing:.09em;padding:0 9px;margin-bottom:3px}
+.m-hdr+.m-hdr{margin-top:9px}
+.m-row{padding:1px 9px;color:var(--t-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.m-row.dim{color:var(--t-muted)}
+.m-row.sel{background:var(--t-primary);color:var(--t-seltext);font-weight:700}
+.m-dot{color:var(--t-accent)}
+.m-top{display:flex;align-items:center;gap:6px;padding-bottom:6px;margin-bottom:6px;border-bottom:1px solid var(--t-bordersub);color:var(--t-text)}
+.m-branch{color:var(--t-accent)}
+.m-state{margin-left:auto;color:var(--t-success)}
+.m-add{color:var(--t-success)}
+.m-del{color:var(--t-error)}
+.m-ctx{color:var(--t-muted)}
+.m-warn{color:var(--t-warning)}
+.m-chip{display:inline-block;background:var(--t-element);color:var(--t-text);padding:0 5px;border-radius:3px}
+
+.tc-cmd{display:flex;align-items:center;gap:7px;width:calc(100% - 34px);margin:0 17px 15px;background:var(--well);color:var(--well-ink);border:none;border-radius:9px;padding:9px 11px;font-family:var(--font-mono);font-size:11px;text-align:left}
+.tc-cmd .ps{color:var(--accent-2);flex:none}
+.tc-cmd-t{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+.tc-copy{flex:none;color:oklch(62% 0.02 60);font-size:10px;border-left:1px solid oklch(38% 0.02 55);padding-left:8px}
+.tc-cmd:hover .tc-copy{color:var(--accent-2)}
+.sw{display:flex;gap:0;padding:12px 17px 15px}
+.tcard .sw:last-child{padding-bottom:15px}
+.sw i{flex:1;height:20px;border-radius:3px;position:relative}
+.sw i:first-child{border-radius:5px 0 0 5px}
+.sw i:last-child{border-radius:0 5px 5px 0}
+
+/* ============ RECIPE / PUBLISH ============ */
+.well{background:var(--well);color:var(--well-ink);border-radius:var(--radius-lg);padding:clamp(20px,3vw,30px);margin-top:26px;overflow-x:auto}
+.well pre{font-family:var(--font-mono);font-size:12.5px;line-height:1.7;white-space:pre}
+.well .k{color:oklch(78% 0.11 50)}
+.well .s{color:oklch(76% 0.1 145)}
+.well .c{color:oklch(58% 0.02 60)}
+.steps{counter-reset:s;margin-top:26px;display:grid;gap:14px}
+.step{counter-increment:s;position:relative;padding-left:42px;font-size:14.5px;color:var(--ink-soft);max-width:70ch}
+.step::before{content:counter(s);position:absolute;left:0;top:-1px;width:27px;height:27px;border-radius:50%;background:var(--accent-wash);border:1px solid var(--accent-line);color:var(--accent);font-family:var(--font-mono);font-size:12px;display:grid;place-items:center}
+.step b{color:var(--ink);font-weight:600}
+.step code{font-family:var(--font-mono);font-size:.87em;background:var(--accent-wash);color:var(--accent);padding:1px 5px;border-radius:5px;word-break:break-all}
+
+.copy-cmd{display:inline-flex;align-items:center;gap:9px;background:var(--well);color:var(--well-ink);border:none;border-radius:999px;padding:11px 18px;font-family:var(--font-mono);font-size:13px;margin-top:22px}
+.copy-cmd .ps{color:var(--accent-2)}
+.copy-cmd .hint{color:oklch(62% 0.02 60);font-size:11px;margin-left:4px}
+
+.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:32px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
+.foot-dense p{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);line-height:1.8}
+.foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
+.foot-dense a{border-bottom:1px solid var(--line-2);transition:color 140ms,border-color 140ms}
+.foot-dense a:hover{color:var(--ink);border-color:var(--accent-line)}

--- a/packages/kobe-landing/themes.html
+++ b/packages/kobe-landing/themes.html
@@ -16,134 +16,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=DM+Sans:opsz,wght@9..40,300..700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
-<style>
-:root{
-  --paper:     oklch(97.8% 0.007 85);
-  --surface:   oklch(99.4% 0.003 90);
-  --well:      oklch(22% 0.02 50);
-  --well-2:    oklch(27% 0.022 50);
-  --well-ink:  oklch(88% 0.015 85);
-  --ink:       oklch(25% 0.02 60);
-  --ink-soft:  oklch(35% 0.02 55);
-  --muted:     oklch(50% 0.02 60);
-  --faint:     oklch(62% 0.018 65);
-  --line:      oklch(88% 0.014 80);
-  --line-2:    oklch(83% 0.018 75);
-  --accent:    oklch(62% 0.13 45);
-  --accent-2:  oklch(70% 0.11 50);
-  --accent-wash: oklch(62% 0.13 45 / .1);
-  --accent-line: oklch(62% 0.13 45 / .4);
-  --ok:        oklch(58% 0.12 145);
-  --warn:      oklch(62% 0.11 80);
-  --radius:    12px;
-  --radius-lg: 22px;
-  --font-display:'Fraunces', Georgia, serif;
-  --font-sans:'DM Sans', system-ui, sans-serif;
-  --font-mono:'JetBrains Mono', ui-monospace, monospace;
-  --ease-out: cubic-bezier(0.16,1,0.3,1);
-}
-*{box-sizing:border-box;margin:0;padding:0}
-html,body{background:var(--paper)}
-body{color:var(--ink-soft);font-family:var(--font-sans);font-weight:380;font-size:15px;line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-::selection{background:oklch(62% 0.13 45/.22)}
-a{color:inherit;text-decoration:none}
-button{font-family:inherit;cursor:pointer}
-:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:4px}
-.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px)}
-.acc{color:var(--accent);font-style:italic}
-
-/* ============ NAV — glass pill, terminal grammar ============ */
-.navbar{position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:50;display:flex;align-items:center;gap:2px;padding:6px 8px;border-radius:999px;background:oklch(100% 0 0/.55);backdrop-filter:blur(16px) saturate(1.3);border:1px solid oklch(100% 0 0/.8);box-shadow:0 10px 36px oklch(40% 0.04 60/.16);font-family:var(--font-mono);font-size:12.5px;max-width:calc(100vw - 24px)}
-.navbar .ps{color:var(--accent);padding-left:8px}
-.navbar .bin{font-weight:700;color:var(--ink);padding:8px 6px 8px 4px}
-.navbar a.nl{color:var(--ink-soft);padding:8px 10px;border-radius:999px;transition:background 140ms,color 140ms;white-space:nowrap}
-.navbar a.nl:hover{background:oklch(100% 0 0/.85);color:var(--ink)}
-.navbar a.nl[aria-current="page"]{background:var(--accent-wash);color:var(--accent)}
-.navbar .caret{display:inline-block;width:7px;height:14px;background:var(--accent);margin:0 4px 0 2px;animation:blink 1.1s steps(1) infinite;vertical-align:-2px}
-@keyframes blink{50%{opacity:0}}
-.lang-btn{background:none;border:1px solid var(--line-2);color:var(--ink-soft);font-family:var(--font-mono);font-size:11.5px;padding:5px 9px;border-radius:999px;transition:border-color 140ms,color 140ms;white-space:nowrap}
-.lang-btn:hover{border-color:var(--accent);color:var(--accent)}
-.gh-link{display:flex;align-items:center;gap:5px;padding:7px 11px;border-radius:999px;background:var(--ink);color:var(--paper);font-family:var(--font-mono);font-size:11.5px;margin-left:2px}
-@media(max-width:820px){.navbar a.nl{display:none}}
-
-/* ============ HEAD ============ */
-.top{padding:132px 0 20px}
-.kicker{font-family:var(--font-mono);font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:var(--faint)}
-h1{font-family:var(--font-display);font-weight:340;font-size:clamp(34px,5.4vw,58px);line-height:1.03;letter-spacing:-.022em;color:var(--ink);margin:14px 0 0;font-variation-settings:'SOFT' 30,'WONK' 1}
-.lede{font-size:17px;line-height:1.6;color:var(--ink-soft);max-width:64ch;margin-top:18px}
-.lede code,.body code{font-family:var(--font-mono);font-size:.88em;background:var(--accent-wash);color:var(--accent);padding:1px 5px;border-radius:5px}
-.rule{height:1px;background:var(--line);margin:44px 0 0}
-
-h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px);line-height:1.12;letter-spacing:-.018em;color:var(--ink);font-variation-settings:'SOFT' 30}
-.sec{padding:56px 0 0}
-.sec-no{font-family:var(--font-mono);font-size:11.5px;letter-spacing:.1em;color:var(--accent);text-transform:uppercase}
-.body{font-size:15px;color:var(--ink-soft);max-width:66ch;margin-top:14px}
-
-/* ============ THEME GRID ============ */
-.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:20px;margin-top:30px}
-.tcard{border:1px solid var(--line);border-radius:var(--radius-lg);background:var(--surface);overflow:hidden;transition:border-color 180ms var(--ease-out),box-shadow 180ms var(--ease-out)}
-.tcard:hover{border-color:var(--line-2);box-shadow:0 14px 40px oklch(40% 0.04 60/.09)}
-.tc-head{display:flex;align-items:baseline;justify-content:space-between;gap:10px;padding:15px 17px 12px}
-.tc-name{font-family:var(--font-mono);font-size:14px;font-weight:700;color:var(--ink)}
-.tc-tag{font-family:var(--font-mono);font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--faint);white-space:nowrap}
-/* Reserve three lines so the mini-TUIs line up across a row no matter how
-   long each blurb runs — a ragged grid reads as broken, not as variety. */
-.tc-note{padding:0 17px 13px;font-size:13px;color:var(--muted);line-height:1.5;min-height:72px}
-@media(max-width:700px){.tc-note{min-height:0}}
-
-/* The mini-TUI: every color comes from the card's own custom properties,
-   which are the theme's real slot values. One rule set, seven palettes. */
-.mock{font-family:var(--font-mono);font-size:10.5px;line-height:1.55;background:var(--t-bg);border-top:1px solid var(--line);border-bottom:1px solid var(--line);display:flex;min-height:158px}
-.mock-side{width:40%;flex:none;background:var(--t-panel);border-right:1px solid var(--t-border);padding:8px 0}
-.mock-main{flex:1;padding:8px 10px;min-width:0}
-.m-hdr{color:var(--t-muted);font-weight:700;letter-spacing:.09em;padding:0 9px;margin-bottom:3px}
-.m-hdr+.m-hdr{margin-top:9px}
-.m-row{padding:1px 9px;color:var(--t-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.m-row.dim{color:var(--t-muted)}
-.m-row.sel{background:var(--t-primary);color:var(--t-seltext);font-weight:700}
-.m-dot{color:var(--t-accent)}
-.m-top{display:flex;align-items:center;gap:6px;padding-bottom:6px;margin-bottom:6px;border-bottom:1px solid var(--t-bordersub);color:var(--t-text)}
-.m-branch{color:var(--t-accent)}
-.m-state{margin-left:auto;color:var(--t-success)}
-.m-add{color:var(--t-success)}
-.m-del{color:var(--t-error)}
-.m-ctx{color:var(--t-muted)}
-.m-warn{color:var(--t-warning)}
-.m-chip{display:inline-block;background:var(--t-element);color:var(--t-text);padding:0 5px;border-radius:3px}
-
-.tc-cmd{display:flex;align-items:center;gap:7px;width:calc(100% - 34px);margin:0 17px 15px;background:var(--well);color:var(--well-ink);border:none;border-radius:9px;padding:9px 11px;font-family:var(--font-mono);font-size:11px;text-align:left}
-.tc-cmd .ps{color:var(--accent-2);flex:none}
-.tc-cmd-t{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
-.tc-copy{flex:none;color:oklch(62% 0.02 60);font-size:10px;border-left:1px solid oklch(38% 0.02 55);padding-left:8px}
-.tc-cmd:hover .tc-copy{color:var(--accent-2)}
-.sw{display:flex;gap:0;padding:12px 17px 15px}
-.tcard .sw:last-child{padding-bottom:15px}
-.sw i{flex:1;height:20px;border-radius:3px;position:relative}
-.sw i:first-child{border-radius:5px 0 0 5px}
-.sw i:last-child{border-radius:0 5px 5px 0}
-
-/* ============ RECIPE / PUBLISH ============ */
-.well{background:var(--well);color:var(--well-ink);border-radius:var(--radius-lg);padding:clamp(20px,3vw,30px);margin-top:26px;overflow-x:auto}
-.well pre{font-family:var(--font-mono);font-size:12.5px;line-height:1.7;white-space:pre}
-.well .k{color:oklch(78% 0.11 50)}
-.well .s{color:oklch(76% 0.1 145)}
-.well .c{color:oklch(58% 0.02 60)}
-.steps{counter-reset:s;margin-top:26px;display:grid;gap:14px}
-.step{counter-increment:s;position:relative;padding-left:42px;font-size:14.5px;color:var(--ink-soft);max-width:70ch}
-.step::before{content:counter(s);position:absolute;left:0;top:-1px;width:27px;height:27px;border-radius:50%;background:var(--accent-wash);border:1px solid var(--accent-line);color:var(--accent);font-family:var(--font-mono);font-size:12px;display:grid;place-items:center}
-.step b{color:var(--ink);font-weight:600}
-.step code{font-family:var(--font-mono);font-size:.87em;background:var(--accent-wash);color:var(--accent);padding:1px 5px;border-radius:5px;word-break:break-all}
-
-.copy-cmd{display:inline-flex;align-items:center;gap:9px;background:var(--well);color:var(--well-ink);border:none;border-radius:999px;padding:11px 18px;font-family:var(--font-mono);font-size:13px;margin-top:22px}
-.copy-cmd .ps{color:var(--accent-2)}
-.copy-cmd .hint{color:oklch(62% 0.02 60);font-size:11px;margin-left:4px}
-
-.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:32px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
-.foot-dense p{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);line-height:1.8}
-.foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
-.foot-dense a{border-bottom:1px solid var(--line-2);transition:color 140ms,border-color 140ms}
-.foot-dense a:hover{color:var(--ink);border-color:var(--accent-line)}
-</style>
+<link rel="stylesheet" href="/themes.css">
 </head>
 <body>
 
@@ -157,7 +30,7 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
   <a class="nl" href="/changelog" data-i18n="nav.changelog">--changelog</a>
   <span class="caret" aria-hidden="true"></span>
   <button id="langToggle" class="lang-btn">中文</button>
-  <a class="gh-link" href="https://github.com/Sma1lboy/kobe" target="_blank" rel="noopener">
+  <a class="gh-link" href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">
     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
     <span>GitHub</span>
   </a>
@@ -521,7 +394,7 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
     <div class="well">
 <pre><span class="c">// ~/.kobe/themes/darkside.json</span>
 {
-  <span class="k">"$schema"</span>: <span class="s">"https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json"</span>,
+  <span class="k">"$schema"</span>: <span class="s">"https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json"</span>,
   <span class="k">"defs"</span>: { <span class="k">"brand"</span>: <span class="s">"#cc785c"</span> },
   <span class="k">"theme"</span>: {
     <span class="k">"background"</span>: <span class="s">"#141413"</span>,
@@ -557,173 +430,10 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 </div>
 
 <footer class="foot-dense">
-  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.themes">Previews are rendered from each theme's real color file, not screenshots.</span> <a href="https://github.com/Sma1lboy/kobe">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/kobe/blob/main/docs/themes.md" data-i18n="footer.themedocs">theme docs</a> · <a href="https://github.com/Sma1lboy/kobe/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
+  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.themes">Previews are rendered from each theme's real color file, not screenshots.</span> <a href="https://github.com/Sma1lboy/rove">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/themes.md" data-i18n="footer.themedocs">theme docs</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
 </footer>
 
-<script>
-  // EN / 中文 — same mechanism as the home page (data-i18n + localStorage).
-  // Terminal-mock content (branch names, TUI chrome) deliberately stays English.
-  var KOBE_I18N = (function () {
-    var zh = {
-      'meta.title': 'Rove — 主题',
-      'meta.desc': '每个内置 Rove 主题都由它真实的配色文件渲染，另附如何编写并发布你自己的主题。一个主题就是一个 JSON 文件，没有需要挤进去的注册表。',
-      'nav.workflow': '--原语', 'nav.install': '--安装', 'nav.plugins': '--插件', 'nav.themes': '--主题', 'nav.changelog': '--更新日志',
-      'head.kicker': '外观',
-      'head.title': '内置三套，<span class="acc">另外十套</span>一条命令。',
-      'head.lede': '下面每一块面板都由真实的主题文件绘制——就是 Rove 启动时加载的那份 JSON，不是谁手工调色的截图。在 <code>设置 → General → Theme</code> 里挑内置的三套之一，其余的一条命令装上，或者自己写——一个主题就是一个 JSON 文件，没有需要挤进去的注册表。',
-      'bundled.no': '1.0 · 内置',
-      'bundled.title': '随 Rove 一起发布。',
-      'bundled.body': 'Rove 刻意把内置的一套保持得很小——用 <code>ctrl+,</code> 打开设置直接选，无需安装。每个预览都用该主题自己的色槽绘制侧边栏、选中的任务和一段 diff，所以你看到的就是实际会得到的对比度。每个主题同时定义了浅色模式，预览展示的是深色。',
-      'tag.default': '默认',
-      'note.claude': '暖石墨配陶土色——Rove 自己的身份色，与 Claude Code 的配色一致。',
-      'note.conductor': '近黑与近白。没有色相来跟你的 diff 抢注意力——投屏时首选这套。',
-      'note.dracula': '大家早就有肌肉记忆的那套。这里饱和度最高的一组。',
-      'note.nord': '北极蓝灰，刻意压低对比。长时间工作最不累的选择。',
-      'note.opencode': '中性炭灰加沙色强调色——从 opencode 过来会觉得眼熟。',
-      'note.osaka': '深玉底色配薄荷信号色。最有主张的一套，运行指示也最响。',
-      'note.tokyonight': '靛蓝夜色配珊瑚强调色。和你 nvim 里大概已经在用的 tokyonight 成套。',
-      'note.gruvbox': '复古律动：暖棕底色配一记信号橙。暖色系里对比最强的一套，也是多数人说「终端配色」时想到的那个。',
-      'note.catppuccin': '冷灰底上的柔和粉彩——藕紫作标志色，没有一处喧哗。深色用 Mocha，浅色用 Latte。',
-      'note.rosepine': '近黑的梅色底上低饱和的鸢尾与玫瑰。安静但不发灰；浅色侧是 Dawn。',
-      'note.everforest': '去饱和的森林绿，为暖色底上的长时间工作调过。',
-      'note.kanagawa': '取自葛饰北斋的浪——墨蓝压在墨黑上，浅色侧是 lotus。',
-      'note.solarized': '2011 年那个开创了精确终端配色的原版。深浅两侧共用同一组强调色。',
-      'dl.no': '2.0 · 可下载',
-      'dl.title': '另外十套，一条命令的距离。',
-      'dl.body': '这些不装在二进制里，而是作为纯 JSON 托管在这——主题本来就只是这个。复制命令、运行、重启 Rove。其中几套在早先版本里是内置的；除了存放位置，它们没有任何变化。',
-      'card.copy': '复制', 'card.copied': '已复制',
-      'write.no': '3.0 · 动手写',
-      'write.title': '一个主题就是一个 JSON 文件。',
-      'write.body': '把任意 <code>*.json</code> 丢进 <code>~/.kobe/themes/</code>，下次启动就出现在选择器里。取和内置主题同名，你的那份优先。也不必填满所有色槽——缺失的会向下回落（<code>borderActive</code> → <code>border</code> → <code>text</code>），所以十几行就已经是一套可用的主题。',
-      'write.body2': '<code>defs</code> 是可选的命名色板，色槽可以按名字引用它。色槽的值可以是 hex 字符串、<code>defs</code> 的键，或者一个 <code>{ dark, light }</code> 对——用对偶形式时两边都必填。<code>$schema</code> 那行的作用是让编辑器给你自动补全。',
-      'pub.no': '4.0 · 发布',
-      'pub.title': '分享一个 URL。这就是全部的注册表。',
-      'pub.body': '没有提交队列，也没有清单文件要写。安装走的是 HTTPS 读取原始文件，所以任何你能链接到的地方都能装——一个仓库、一个 gist、或者你自己的服务器。',
-      'pub.s1': '把 JSON 提交到一个 <b>公开仓库或 gist</b>。',
-      'pub.s2': '在 GitHub 上点 <b>Raw</b> 复制地址，形如 <code>raw.githubusercontent.com/&lt;你&gt;/&lt;仓库&gt;/main/&lt;主题&gt;.json</code>。',
-      'pub.s3': '让别人运行 <code>rove theme add &lt;raw-url&gt;</code>。它会先校验 JSON 再写入，且不加 <code>--force</code> 不会覆盖已有主题。',
-      'pub.s4': '给仓库打上 GitHub topic <code>kobe-theme</code> 方便被搜到，再对本页提个 PR，就能带预览收录进来。',
-      'copy.hint': '点击复制', 'copy.done': '已复制',
-      'footer.tagline': '终端原生的编码代理图工程。',
-      'footer.themes': '预览由每个主题真实的配色文件渲染，不是截图。',
-      'footer.changelog': '更新日志', 'footer.themedocs': '主题文档', 'footer.keybindings': '快捷键',
-    };
-    var en = {
-      'meta.title': 'Rove — themes',
-      'meta.desc': "Every bundled Rove theme, rendered from its real color file — plus how to write and publish your own. A theme is one JSON file; there is no registry to get into.",
-      'nav.workflow': '--primitives', 'nav.install': '--install', 'nav.plugins': '--plugins', 'nav.themes': '--themes', 'nav.changelog': '--changelog',
-      'head.kicker': 'Appearance',
-      'head.title': 'Three in the box, <span class="acc">ten more</span> a command away.',
-      'head.lede': "Every panel below is drawn from a real theme file — the same JSON Rove loads at boot, not a screenshot someone re-tinted by hand. Pick one of the three bundled ones in <code>Settings → General → Theme</code>, install any of the rest with one command, or write your own — a theme is one JSON file, and there is no registry to get into.",
-      'bundled.no': '1.0 · Bundled',
-      'bundled.title': 'Ships with Rove.',
-      'bundled.body': "Rove keeps its bundled set deliberately small — open Settings with <code>ctrl+,</code> and pick one, nothing to install. Each preview paints the sidebar, the selected task, and a diff with that theme's own slots, so what you see is the contrast you'll actually get. Every theme also defines a light mode; the previews show dark.",
-      'tag.default': 'default',
-      'note.claude': "Warm graphite and terracotta — Rove's own identity, matched to the Claude Code palette.",
-      'note.conductor': 'Near-black and near-white. No hue competes with your diff — the one to reach for on a projector.',
-      'note.dracula': 'The one everybody already has muscle memory for. Highest-saturation set here.',
-      'note.nord': 'Arctic blue-grey, low contrast by design. The calmest option for long sessions.',
-      'note.opencode': 'Neutral charcoal with a sand accent — familiar if you came from opencode.',
-      'note.osaka': 'Deep jade ground with a mint signal color. The most opinionated set — and the loudest running indicator.',
-      'note.tokyonight': 'Indigo night with a coral accent. Pairs with the tokyonight setup you probably already run in nvim.',
-      'note.gruvbox': 'Retro groove: warm browns under a signal orange. The highest-contrast warm set, and the one most people mean by "terminal colors".',
-      'note.catppuccin': 'Soft pastels on a cool grey base — mauve signature, nothing shouts. Ships Mocha for dark and Latte for light.',
-      'note.rosepine': 'Low-saturation iris and rose on near-black plum. Quiet without going grey; Dawn is the light side.',
-      'note.everforest': 'Desaturated forest greens, tuned for long sessions on a warm background.',
-      'note.kanagawa': "Inspired by Katsushika Hokusai's wave — ink blues over sumi black, lotus for light.",
-      'note.solarized': 'The 2011 original that started precision terminal palettes. Both sides share one accent set.',
-      'dl.no': '2.0 · Downloadable',
-      'dl.title': 'Ten more, one command away.',
-      'dl.body': "These live here as plain JSON instead of inside the binary — which is all a theme ever is. Copy the command, run it, restart Rove. Several of them shipped bundled in earlier versions; nothing changed about them except where they're stored.",
-      'card.copy': 'copy', 'card.copied': 'copied',
-      'write.no': '3.0 · Write one',
-      'write.title': 'A theme is one JSON file.',
-      'write.body': "Drop any <code>*.json</code> into <code>~/.kobe/themes/</code> and it appears in the picker at next boot. Name it after a bundled theme and yours wins. You don't have to fill every slot — missing ones fall through (<code>borderActive</code> → <code>border</code> → <code>text</code>), so a dozen lines is already a usable theme.",
-      'write.body2': "<code>defs</code> is an optional named palette a slot can reference by name. A slot value is a hex string, a <code>defs</code> key, or a <code>{ dark, light }</code> pair — and when you use the pair form, both sides are required. The <code>$schema</code> line is what gives you autocomplete in your editor.",
-      'pub.no': '4.0 · Publish',
-      'pub.title': "Share a URL. That's the whole registry.",
-      'pub.body': 'There is no submission queue and no manifest to write. Installation reads a raw file over HTTPS, so anything you can link to is installable — a repo, a gist, your own host.',
-      'pub.s1': 'Commit the JSON to a <b>public repo or gist</b>.',
-      'pub.s2': 'Hit <b>Raw</b> on GitHub and copy the URL — it looks like <code>raw.githubusercontent.com/&lt;you&gt;/&lt;repo&gt;/main/&lt;theme&gt;.json</code>.',
-      'pub.s3': 'Tell people to run <code>rove theme add &lt;raw-url&gt;</code>. It validates the JSON before writing and refuses to clobber an existing theme without <code>--force</code>.',
-      'pub.s4': "Tag the repo <code>kobe-theme</code> on GitHub so it's findable, and open a PR against this page to get it listed with a preview.",
-      'copy.hint': 'click to copy', 'copy.done': 'copied',
-      'footer.tagline': 'graph engineering for coding agents, terminal-native.',
-      'footer.themes': "Previews are rendered from each theme's real color file, not screenshots.",
-      'footer.changelog': 'changelog', 'footer.themedocs': 'theme docs', 'footer.keybindings': 'keybindings',
-    };
-    var dicts = { en: en, zh: zh };
-    var lang = 'en';
-    try {
-      var fromUrl = new URLSearchParams(location.search).get('lang');
-      var stored = localStorage.getItem('kobe_lang');
-      var nav = (navigator.language || '').toLowerCase().indexOf('zh') === 0 ? 'zh' : 'en';
-      lang = fromUrl === 'zh' || fromUrl === 'en' ? fromUrl : stored === 'zh' || stored === 'en' ? stored : nav;
-    } catch (e) {}
-
-    function t(key) { return dicts[lang][key] || dicts.en[key] || ''; }
-
-    function apply() {
-      document.documentElement.lang = lang === 'zh' ? 'zh-CN' : 'en';
-      document.title = t('meta.title');
-      var desc = document.querySelector('meta[name="description"]');
-      if (desc) desc.setAttribute('content', t('meta.desc'));
-      document.querySelectorAll('[data-i18n]').forEach(function (el) {
-        var v = t(el.getAttribute('data-i18n'));
-        if (v) el.textContent = v;
-      });
-      document.querySelectorAll('[data-i18n-html]').forEach(function (el) {
-        var v = t(el.getAttribute('data-i18n-html'));
-        if (v) el.innerHTML = v;
-      });
-      var label = document.getElementById('copyLabel');
-      if (label) label.textContent = t('copy.hint');
-      var toggle = document.getElementById('langToggle');
-      if (toggle) toggle.textContent = lang === 'zh' ? 'EN' : '中文';
-    }
-
-    var toggleBtn = document.getElementById('langToggle');
-    if (toggleBtn) {
-      toggleBtn.addEventListener('click', function () {
-        lang = lang === 'zh' ? 'en' : 'zh';
-        try { localStorage.setItem('kobe_lang', lang); } catch (e) {}
-        apply();
-      });
-    }
-    apply();
-    return { t: t };
-  })();
-
-  // Per-card install commands (downloadable themes).
-  (function () {
-    document.querySelectorAll('.tc-cmd').forEach(function (b) {
-      var label = b.querySelector('.tc-copy');
-      var timer;
-      b.addEventListener('click', function () {
-        try {
-          if (navigator.clipboard) navigator.clipboard.writeText('rove theme add ' + b.getAttribute('data-cmd'));
-        } catch (e) {}
-        label.textContent = KOBE_I18N.t('card.copied');
-        clearTimeout(timer);
-        timer = setTimeout(function () { label.textContent = KOBE_I18N.t('card.copy'); }, 1600);
-      });
-    });
-  })();
-
-  (function () {
-    var btn = document.getElementById('copyBtn');
-    var label = document.getElementById('copyLabel');
-    var timer;
-    btn.addEventListener('click', function () {
-      try {
-        if (navigator.clipboard) navigator.clipboard.writeText('rove theme add <raw-url>');
-      } catch (e) {}
-      label.textContent = KOBE_I18N.t('copy.done');
-      clearTimeout(timer);
-      timer = setTimeout(function () { label.textContent = KOBE_I18N.t('copy.hint'); }, 1800);
-    });
-  })();
-</script>
+<script src="/themes.js"></script>
 
 </body>
 </html>

--- a/packages/kobe-landing/themes.js
+++ b/packages/kobe-landing/themes.js
@@ -1,0 +1,162 @@
+// EN / 中文 — same mechanism as the home page (data-i18n + localStorage).
+// Terminal-mock content (branch names, TUI chrome) deliberately stays English.
+var KOBE_I18N = (function () {
+  var zh = {
+    'meta.title': 'Rove — 主题',
+    'meta.desc': '每个内置 Rove 主题都由它真实的配色文件渲染，另附如何编写并发布你自己的主题。一个主题就是一个 JSON 文件，没有需要挤进去的注册表。',
+    'nav.workflow': '--原语', 'nav.install': '--安装', 'nav.plugins': '--插件', 'nav.themes': '--主题', 'nav.changelog': '--更新日志',
+    'head.kicker': '外观',
+    'head.title': '内置三套，<span class="acc">另外十套</span>一条命令。',
+    'head.lede': '下面每一块面板都由真实的主题文件绘制——就是 Rove 启动时加载的那份 JSON，不是谁手工调色的截图。在 <code>设置 → General → Theme</code> 里挑内置的三套之一，其余的一条命令装上，或者自己写——一个主题就是一个 JSON 文件，没有需要挤进去的注册表。',
+    'bundled.no': '1.0 · 内置',
+    'bundled.title': '随 Rove 一起发布。',
+    'bundled.body': 'Rove 刻意把内置的一套保持得很小——用 <code>ctrl+,</code> 打开设置直接选，无需安装。每个预览都用该主题自己的色槽绘制侧边栏、选中的任务和一段 diff，所以你看到的就是实际会得到的对比度。每个主题同时定义了浅色模式，预览展示的是深色。',
+    'tag.default': '默认',
+    'note.claude': '暖石墨配陶土色——Rove 自己的身份色，与 Claude Code 的配色一致。',
+    'note.conductor': '近黑与近白。没有色相来跟你的 diff 抢注意力——投屏时首选这套。',
+    'note.dracula': '大家早就有肌肉记忆的那套。这里饱和度最高的一组。',
+    'note.nord': '北极蓝灰，刻意压低对比。长时间工作最不累的选择。',
+    'note.opencode': '中性炭灰加沙色强调色——从 opencode 过来会觉得眼熟。',
+    'note.osaka': '深玉底色配薄荷信号色。最有主张的一套，运行指示也最响。',
+    'note.tokyonight': '靛蓝夜色配珊瑚强调色。和你 nvim 里大概已经在用的 tokyonight 成套。',
+    'note.gruvbox': '复古律动：暖棕底色配一记信号橙。暖色系里对比最强的一套，也是多数人说「终端配色」时想到的那个。',
+    'note.catppuccin': '冷灰底上的柔和粉彩——藕紫作标志色，没有一处喧哗。深色用 Mocha，浅色用 Latte。',
+    'note.rosepine': '近黑的梅色底上低饱和的鸢尾与玫瑰。安静但不发灰；浅色侧是 Dawn。',
+    'note.everforest': '去饱和的森林绿，为暖色底上的长时间工作调过。',
+    'note.kanagawa': '取自葛饰北斋的浪——墨蓝压在墨黑上，浅色侧是 lotus。',
+    'note.solarized': '2011 年那个开创了精确终端配色的原版。深浅两侧共用同一组强调色。',
+    'dl.no': '2.0 · 可下载',
+    'dl.title': '另外十套，一条命令的距离。',
+    'dl.body': '这些不装在二进制里，而是作为纯 JSON 托管在这——主题本来就只是这个。复制命令、运行、重启 Rove。其中几套在早先版本里是内置的；除了存放位置，它们没有任何变化。',
+    'card.copy': '复制', 'card.copied': '已复制',
+    'write.no': '3.0 · 动手写',
+    'write.title': '一个主题就是一个 JSON 文件。',
+    'write.body': '把任意 <code>*.json</code> 丢进 <code>~/.kobe/themes/</code>，下次启动就出现在选择器里。取和内置主题同名，你的那份优先。也不必填满所有色槽——缺失的会向下回落（<code>borderActive</code> → <code>border</code> → <code>text</code>），所以十几行就已经是一套可用的主题。',
+    'write.body2': '<code>defs</code> 是可选的命名色板，色槽可以按名字引用它。色槽的值可以是 hex 字符串、<code>defs</code> 的键，或者一个 <code>{ dark, light }</code> 对——用对偶形式时两边都必填。<code>$schema</code> 那行的作用是让编辑器给你自动补全。',
+    'pub.no': '4.0 · 发布',
+    'pub.title': '分享一个 URL。这就是全部的注册表。',
+    'pub.body': '没有提交队列，也没有清单文件要写。安装走的是 HTTPS 读取原始文件，所以任何你能链接到的地方都能装——一个仓库、一个 gist、或者你自己的服务器。',
+    'pub.s1': '把 JSON 提交到一个 <b>公开仓库或 gist</b>。',
+    'pub.s2': '在 GitHub 上点 <b>Raw</b> 复制地址，形如 <code>raw.githubusercontent.com/&lt;你&gt;/&lt;仓库&gt;/main/&lt;主题&gt;.json</code>。',
+    'pub.s3': '让别人运行 <code>rove theme add &lt;raw-url&gt;</code>。它会先校验 JSON 再写入，且不加 <code>--force</code> 不会覆盖已有主题。',
+    'pub.s4': '给仓库打上 GitHub topic <code>kobe-theme</code> 方便被搜到，再对本页提个 PR，就能带预览收录进来。',
+    'copy.hint': '点击复制', 'copy.done': '已复制',
+    'footer.tagline': '终端原生的编码代理图工程。',
+    'footer.themes': '预览由每个主题真实的配色文件渲染，不是截图。',
+    'footer.changelog': '更新日志', 'footer.themedocs': '主题文档', 'footer.keybindings': '快捷键',
+  };
+  var en = {
+    'meta.title': 'Rove — themes',
+    'meta.desc': "Every bundled Rove theme, rendered from its real color file — plus how to write and publish your own. A theme is one JSON file; there is no registry to get into.",
+    'nav.workflow': '--primitives', 'nav.install': '--install', 'nav.plugins': '--plugins', 'nav.themes': '--themes', 'nav.changelog': '--changelog',
+    'head.kicker': 'Appearance',
+    'head.title': 'Three in the box, <span class="acc">ten more</span> a command away.',
+    'head.lede': "Every panel below is drawn from a real theme file — the same JSON Rove loads at boot, not a screenshot someone re-tinted by hand. Pick one of the three bundled ones in <code>Settings → General → Theme</code>, install any of the rest with one command, or write your own — a theme is one JSON file, and there is no registry to get into.",
+    'bundled.no': '1.0 · Bundled',
+    'bundled.title': 'Ships with Rove.',
+    'bundled.body': "Rove keeps its bundled set deliberately small — open Settings with <code>ctrl+,</code> and pick one, nothing to install. Each preview paints the sidebar, the selected task, and a diff with that theme's own slots, so what you see is the contrast you'll actually get. Every theme also defines a light mode; the previews show dark.",
+    'tag.default': 'default',
+    'note.claude': "Warm graphite and terracotta — Rove's own identity, matched to the Claude Code palette.",
+    'note.conductor': 'Near-black and near-white. No hue competes with your diff — the one to reach for on a projector.',
+    'note.dracula': 'The one everybody already has muscle memory for. Highest-saturation set here.',
+    'note.nord': 'Arctic blue-grey, low contrast by design. The calmest option for long sessions.',
+    'note.opencode': 'Neutral charcoal with a sand accent — familiar if you came from opencode.',
+    'note.osaka': 'Deep jade ground with a mint signal color. The most opinionated set — and the loudest running indicator.',
+    'note.tokyonight': 'Indigo night with a coral accent. Pairs with the tokyonight setup you probably already run in nvim.',
+    'note.gruvbox': 'Retro groove: warm browns under a signal orange. The highest-contrast warm set, and the one most people mean by "terminal colors".',
+    'note.catppuccin': 'Soft pastels on a cool grey base — mauve signature, nothing shouts. Ships Mocha for dark and Latte for light.',
+    'note.rosepine': 'Low-saturation iris and rose on near-black plum. Quiet without going grey; Dawn is the light side.',
+    'note.everforest': 'Desaturated forest greens, tuned for long sessions on a warm background.',
+    'note.kanagawa': "Inspired by Katsushika Hokusai's wave — ink blues over sumi black, lotus for light.",
+    'note.solarized': 'The 2011 original that started precision terminal palettes. Both sides share one accent set.',
+    'dl.no': '2.0 · Downloadable',
+    'dl.title': 'Ten more, one command away.',
+    'dl.body': "These live here as plain JSON instead of inside the binary — which is all a theme ever is. Copy the command, run it, restart Rove. Several of them shipped bundled in earlier versions; nothing changed about them except where they're stored.",
+    'card.copy': 'copy', 'card.copied': 'copied',
+    'write.no': '3.0 · Write one',
+    'write.title': 'A theme is one JSON file.',
+    'write.body': "Drop any <code>*.json</code> into <code>~/.kobe/themes/</code> and it appears in the picker at next boot. Name it after a bundled theme and yours wins. You don't have to fill every slot — missing ones fall through (<code>borderActive</code> → <code>border</code> → <code>text</code>), so a dozen lines is already a usable theme.",
+    'write.body2': "<code>defs</code> is an optional named palette a slot can reference by name. A slot value is a hex string, a <code>defs</code> key, or a <code>{ dark, light }</code> pair — and when you use the pair form, both sides are required. The <code>$schema</code> line is what gives you autocomplete in your editor.",
+    'pub.no': '4.0 · Publish',
+    'pub.title': "Share a URL. That's the whole registry.",
+    'pub.body': 'There is no submission queue and no manifest to write. Installation reads a raw file over HTTPS, so anything you can link to is installable — a repo, a gist, your own host.',
+    'pub.s1': 'Commit the JSON to a <b>public repo or gist</b>.',
+    'pub.s2': 'Hit <b>Raw</b> on GitHub and copy the URL — it looks like <code>raw.githubusercontent.com/&lt;you&gt;/&lt;repo&gt;/main/&lt;theme&gt;.json</code>.',
+    'pub.s3': 'Tell people to run <code>rove theme add &lt;raw-url&gt;</code>. It validates the JSON before writing and refuses to clobber an existing theme without <code>--force</code>.',
+    'pub.s4': "Tag the repo <code>kobe-theme</code> on GitHub so it's findable, and open a PR against this page to get it listed with a preview.",
+    'copy.hint': 'click to copy', 'copy.done': 'copied',
+    'footer.tagline': 'graph engineering for coding agents, terminal-native.',
+    'footer.themes': "Previews are rendered from each theme's real color file, not screenshots.",
+    'footer.changelog': 'changelog', 'footer.themedocs': 'theme docs', 'footer.keybindings': 'keybindings',
+  };
+  var dicts = { en: en, zh: zh };
+  var lang = 'en';
+  try {
+    var fromUrl = new URLSearchParams(location.search).get('lang');
+    var stored = localStorage.getItem('kobe_lang');
+    var nav = (navigator.language || '').toLowerCase().indexOf('zh') === 0 ? 'zh' : 'en';
+    lang = fromUrl === 'zh' || fromUrl === 'en' ? fromUrl : stored === 'zh' || stored === 'en' ? stored : nav;
+  } catch (e) {}
+
+  function t(key) { return dicts[lang][key] || dicts.en[key] || ''; }
+
+  function apply() {
+    document.documentElement.lang = lang === 'zh' ? 'zh-CN' : 'en';
+    document.title = t('meta.title');
+    var desc = document.querySelector('meta[name="description"]');
+    if (desc) desc.setAttribute('content', t('meta.desc'));
+    document.querySelectorAll('[data-i18n]').forEach(function (el) {
+      var v = t(el.getAttribute('data-i18n'));
+      if (v) el.textContent = v;
+    });
+    document.querySelectorAll('[data-i18n-html]').forEach(function (el) {
+      var v = t(el.getAttribute('data-i18n-html'));
+      if (v) el.innerHTML = v;
+    });
+    var label = document.getElementById('copyLabel');
+    if (label) label.textContent = t('copy.hint');
+    var toggle = document.getElementById('langToggle');
+    if (toggle) toggle.textContent = lang === 'zh' ? 'EN' : '中文';
+  }
+
+  var toggleBtn = document.getElementById('langToggle');
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', function () {
+      lang = lang === 'zh' ? 'en' : 'zh';
+      try { localStorage.setItem('kobe_lang', lang); } catch (e) {}
+      apply();
+    });
+  }
+  apply();
+  return { t: t };
+})();
+
+// Per-card install commands (downloadable themes).
+(function () {
+  document.querySelectorAll('.tc-cmd').forEach(function (b) {
+    var label = b.querySelector('.tc-copy');
+    var timer;
+    b.addEventListener('click', function () {
+      try {
+        if (navigator.clipboard) navigator.clipboard.writeText('rove theme add ' + b.getAttribute('data-cmd'));
+      } catch (e) {}
+      label.textContent = KOBE_I18N.t('card.copied');
+      clearTimeout(timer);
+      timer = setTimeout(function () { label.textContent = KOBE_I18N.t('card.copy'); }, 1600);
+    });
+  });
+})();
+
+(function () {
+  var btn = document.getElementById('copyBtn');
+  var label = document.getElementById('copyLabel');
+  var timer;
+  btn.addEventListener('click', function () {
+    try {
+      if (navigator.clipboard) navigator.clipboard.writeText('rove theme add <raw-url>');
+    } catch (e) {}
+    label.textContent = KOBE_I18N.t('copy.done');
+    clearTimeout(timer);
+    timer = setTimeout(function () { label.textContent = KOBE_I18N.t('copy.hint'); }, 1800);
+  });
+})();

--- a/packages/kobe-landing/themes/catppuccin.json
+++ b/packages/kobe-landing/themes/catppuccin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "defs": {
     "darkStep1": "#1e1e2e",
     "darkStep2": "#181825",

--- a/packages/kobe-landing/themes/everforest.json
+++ b/packages/kobe-landing/themes/everforest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "defs": {
     "darkStep1": "#2d353b",
     "darkStep2": "#272e33",

--- a/packages/kobe-landing/themes/gruvbox.json
+++ b/packages/kobe-landing/themes/gruvbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "defs": {
     "darkStep1": "#1d2021",
     "darkStep2": "#282828",

--- a/packages/kobe-landing/themes/kanagawa.json
+++ b/packages/kobe-landing/themes/kanagawa.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "defs": {
     "darkStep1": "#1f1f28",
     "darkStep2": "#16161d",

--- a/packages/kobe-landing/themes/rose-pine.json
+++ b/packages/kobe-landing/themes/rose-pine.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "defs": {
     "darkStep1": "#191724",
     "darkStep2": "#1f1d2e",

--- a/packages/kobe-landing/themes/solarized.json
+++ b/packages/kobe-landing/themes/solarized.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$schema": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "defs": {
     "darkStep1": "#002b36",
     "darkStep2": "#00212b",

--- a/packages/kobe-plugin-sdk/README.md
+++ b/packages/kobe-plugin-sdk/README.md
@@ -1,6 +1,6 @@
 # @sma1lboy/rove-plugin-sdk
 
-Typed SDK for writing [Rove](https://github.com/Sma1lboy/kobe) plugins.
+Typed SDK for writing [Rove](https://github.com/Sma1lboy/rove) plugins.
 
 **Optional by design.** The plugin contract stays plain env + CLI + unix
 socket — any language, no SDK required. This package is TypeScript sugar
@@ -83,7 +83,7 @@ await rove(["api", "issue-create", "--repo", ".", "--title", "found a bug"])
 ```
 
 Full contract (manifest reference, event catalog, env table):
-[docs/PLUGIN-AUTHORING.md](https://github.com/Sma1lboy/kobe/blob/main/docs/PLUGIN-AUTHORING.md).
+[docs/PLUGIN-AUTHORING.md](https://github.com/Sma1lboy/rove/blob/main/docs/PLUGIN-AUTHORING.md).
 
 Existing plugins can keep importing `@sma1lboy/kobe-plugin-sdk`: every SDK
 release publishes the same files and version under both package names. The

--- a/packages/kobe-plugin-sdk/package.json
+++ b/packages/kobe-plugin-sdk/package.json
@@ -23,10 +23,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Sma1lboy/kobe.git",
+    "url": "git+https://github.com/Sma1lboy/rove.git",
     "directory": "packages/kobe-plugin-sdk"
   },
-  "homepage": "https://github.com/Sma1lboy/kobe/blob/main/docs/PLUGIN-AUTHORING.md",
+  "homepage": "https://github.com/Sma1lboy/rove/blob/main/docs/PLUGIN-AUTHORING.md",
   "engines": {
     "node": ">=18"
   },

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -12,7 +12,7 @@
  * `kobe daemon ...`, so there is no separate `kobed` binary to build.
  *
  * The canonical Rove SKILL.md is copied from its compatibility source path
- * into the tarball. `npx skills add Sma1lboy/kobe --skill rove` does a `git clone
+ * into the tarball. `npx skills add Sma1lboy/rove --skill rove` does a `git clone
  * --depth 1`, which for this repo means 198MB of working tree — unusable
  * on a slow connection for a file this size. Since the user already has
  * Rove installed, `rove skill install` points the agent-skills CLI at the

--- a/packages/kobe/src/cli/theme.ts
+++ b/packages/kobe/src/cli/theme.ts
@@ -235,7 +235,7 @@ function printUsage(out: NodeJS.WriteStream = process.stderr): void {
       "  remove <name>                 Remove a user-installed theme",
       "",
       `User themes live under: ${userThemesDir()}`,
-      "Schema: https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+      "Schema: https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
       "",
     ].join("\n"),
   )

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -8,9 +8,9 @@
  * its skills from, which get a real directory vs a symlink into the shared
  * `.agents/skills`. kobe does NOT reimplement any of that.
  *
- * What Rove changes is the packaged SOURCE. The public fallback remains
- * `Sma1lboy/kobe` until the repository URL migrates; `--skill rove` selects
- * the canonical skill from that compatibility URL. Cloning the repository
+ * What Rove changes is the packaged SOURCE. The public fallback is the
+ * canonical `Sma1lboy/rove` repository; `--skill rove` selects the skill.
+ * Cloning the repository
  * (`git clone --depth 1`) means a huge working tree just to deliver one
  * SKILL.md, which is effectively un-installable on a slow connection. But a
  * user running `kobe skill install` already HAS kobe, and the skill ships
@@ -73,7 +73,7 @@ export function skillInstallCommand(env: NodeJS.ProcessEnv = process.env): strin
  * The public repo slug. Only a FALLBACK now (and the documented route for
  * people who don't have Rove installed): resolving it means a large clone.
  */
-export const SKILL_SOURCE_SLUG = "Sma1lboy/kobe"
+export const SKILL_SOURCE_SLUG = "Sma1lboy/rove"
 
 /**
  * The skill directory shipped inside this install, or null in an environment

--- a/packages/kobe/src/tui/context/theme/theme.schema.json
+++ b/packages/kobe/src/tui/context/theme/theme.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/sma1lboy/kobe/main/packages/kobe/src/tui/context/theme/theme.schema.json",
+  "$id": "https://raw.githubusercontent.com/sma1lboy/rove/main/packages/kobe/src/tui/context/theme/theme.schema.json",
   "title": "Rove theme",
   "description": "Color theme for the Rove TUI. Drop the file at ~/.rove/themes/<name>.json (or run `rove theme add <url>`). See packages/kobe/src/tui/context/theme/claude.json for a canonical example with defs + dark/light variants.",
   "type": "object",

--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -38,6 +38,7 @@ describe("Rove package distribution", () => {
       name: string
       exports: Record<string, { types: string; default: string }>
       repository: { url: string }
+      homepage: string
     }>("packages/kobe-plugin-sdk/package.json")
     const daemon = json<{ dependencies: Record<string, string> }>("packages/kobe-daemon/package.json")
 
@@ -46,7 +47,8 @@ describe("Rove package distribution", () => {
       types: "./dist/contract.d.ts",
       default: "./dist/contract.js",
     })
-    expect(sdk.repository.url).toBe("git+https://github.com/Sma1lboy/kobe.git")
+    expect(sdk.repository.url).toBe("git+https://github.com/Sma1lboy/rove.git")
+    expect(sdk.homepage).toBe("https://github.com/Sma1lboy/rove/blob/main/docs/PLUGIN-AUTHORING.md")
     expect(daemon.dependencies["@sma1lboy/rove-plugin-sdk"]).toBe("workspace:*")
     expect(daemon.dependencies["@sma1lboy/kobe-plugin-sdk"]).toBeUndefined()
   })
@@ -116,5 +118,71 @@ describe("Rove package distribution", () => {
         /www\.npmjs\.com\/package\/@sma1lboy\/kobe(?:[/?#"')]|$)/,
       )
     }
+  })
+
+  test("active repository links use the canonical Rove repository", () => {
+    const surfaces = [
+      ".claude/skills/changelog-generator/SKILL.md",
+      ".claude/skills/recent-release/SKILL.md",
+      "CONTRIBUTING.md",
+      "README.md",
+      "docs/themes.md",
+      "packages/kobe-plugin-sdk/README.md",
+      "packages/kobe-plugin-sdk/package.json",
+      "packages/kobe-docs/lib/layout.shared.tsx",
+      "packages/kobe-docs/scripts/sync-docs.mjs",
+      "packages/kobe-landing/TODOS.md",
+      "packages/kobe-landing/changelog.html",
+      "packages/kobe-landing/index.html",
+      "packages/kobe-landing/index.js",
+      "packages/kobe-landing/plugins.html",
+      "packages/kobe-landing/themes.html",
+      "packages/kobe-landing/themes/catppuccin.json",
+      "packages/kobe-landing/themes/everforest.json",
+      "packages/kobe-landing/themes/gruvbox.json",
+      "packages/kobe-landing/themes/kanagawa.json",
+      "packages/kobe-landing/themes/rose-pine.json",
+      "packages/kobe-landing/themes/solarized.json",
+      "packages/kobe/scripts/build.ts",
+      "packages/kobe/src/cli/theme.ts",
+      "packages/kobe/src/lib/skill-install.ts",
+      "packages/kobe/src/tui/context/theme/theme.schema.json",
+      "scripts/release.sh",
+    ]
+    const legacyRepository =
+      /(?:github\.com|raw\.githubusercontent\.com|api\.github\.com\/repos)\/sma1lboy\/kobe(?:\.git|[/?#"'`\s]|$)/i
+
+    for (const path of surfaces) {
+      const source = read(path)
+      expect(source, `${path} does not point at the canonical repository`).toMatch(/sma1lboy\/rove/i)
+      expect(source, `${path} still points at the redirected Kobe repository`).not.toMatch(legacyRepository)
+    }
+
+    expect(read("CONTRIBUTING.md")).toContain("git clone https://github.com/Sma1lboy/rove.git\ncd rove")
+  })
+
+  test("release-note skills target the canonical package and product", () => {
+    const changelogSkill = read(".claude/skills/changelog-generator/SKILL.md")
+    const recentReleaseSkill = read(".claude/skills/recent-release/SKILL.md")
+
+    expect(changelogSkill).toContain('"@sma1lboy/rove": patch')
+    expect(changelogSkill).not.toContain('"@sma1lboy/kobe":')
+    expect(recentReleaseSkill).toContain("Recent Release Page (Rove)")
+    expect(recentReleaseSkill).toContain("rove-release-notes-zh.html")
+  })
+
+  test("landing pages load their extracted static assets", () => {
+    const home = read("packages/kobe-landing/index.html")
+    const homeScript = read("packages/kobe-landing/index.js")
+    const themes = read("packages/kobe-landing/themes.html")
+    const themesScript = read("packages/kobe-landing/themes.js")
+    const themesStyles = read("packages/kobe-landing/themes.css")
+
+    expect(home).toContain('<script src="/index.js"></script>')
+    expect(homeScript).toContain("https://api.github.com/repos/Sma1lboy/rove")
+    expect(themes).toContain('<link rel="stylesheet" href="/themes.css">')
+    expect(themes).toContain('<script src="/themes.js"></script>')
+    expect(themesScript).toContain("var KOBE_I18N")
+    expect(themesStyles).toContain(".tcard")
   })
 })

--- a/packages/kobe/test/cli/skill-cmd.test.ts
+++ b/packages/kobe/test/cli/skill-cmd.test.ts
@@ -155,10 +155,10 @@ describe("kobe skill install", () => {
     await runSkillSubcommand(["install"])
     const [argv, opts] = mocks.bunSpawn.mock.calls[0]
     // The source must be a local directory, never the repo slug: resolving
-    // `Sma1lboy/kobe` is a ~198MB clone to deliver an 8KB file.
+    // `Sma1lboy/rove` is a ~198MB clone to deliver an 8KB file.
     expect(argv.slice(0, 2)).toEqual(["npx", "skills"])
     expect(argv[3]).toMatch(/[/\\]/)
-    expect(argv).not.toContain("Sma1lboy/kobe")
+    expect(argv).not.toContain("Sma1lboy/rove")
     expect(argv).not.toContain("--agent")
     // stdio inherited so the CLI's own agent picker is interactive here.
     expect(opts).toEqual({ stdin: "inherit", stdout: "inherit", stderr: "inherit" })

--- a/packages/kobe/test/lib/skill-install.test.ts
+++ b/packages/kobe/test/lib/skill-install.test.ts
@@ -89,7 +89,7 @@ describe("npxSkillsArgv / npxSkillsCommand", () => {
   })
 
   it("installs from the BUNDLED path, not a repo clone", () => {
-    // `npx skills add Sma1lboy/kobe` is a `git clone --depth 1` = ~198MB of
+    // `npx skills add Sma1lboy/rove` is a `git clone --depth 1` = ~198MB of
     // working tree for an 8KB file. The local path skips the network.
     const dir = bundledSkillDir()
     expect(dir).not.toBeNull()
@@ -97,7 +97,7 @@ describe("npxSkillsArgv / npxSkillsCommand", () => {
   })
 
   it("falls back to the repo slug when nothing is bundled", () => {
-    expect(npxSkillsArgv({ source: null })).toContain("Sma1lboy/kobe")
+    expect(npxSkillsArgv({ source: null })).toContain("Sma1lboy/rove")
   })
 
   it("repeats --agent per agent (the CLI rejects a comma-joined list)", () => {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -92,7 +92,7 @@ await_ci_then_tag() {
   git push origin "$tag"
   echo ""
   echo "✓  Tagged + pushed $tag — publish is running:"
-  echo "   https://github.com/sma1lboy/kobe/actions"
+  echo "   https://github.com/sma1lboy/rove/actions"
 }
 
 # ── safety: there must be pending changesets to release ───────────────────────


### PR DESCRIPTION
## Summary

- Point new clones, package metadata, docs, agent skills, skill-install fallback, release guidance, landing pages, and theme schemas at the canonical `Sma1lboy/rove` repository.
- Keep compatibility contracts intact: old repository URLs remain valid redirects, deployed `kobe.sma1lboy.me` domains stay unchanged, `Sma1lboy/kobe-plugins` remains the plugin repository, and Kobe package/state spellings remain supported.
- Update release-note skills to target the canonical Rove package and the repository patch-default changeset policy.
- Extract the touched landing-page scripts and theme styles into static assets, keeping every new or touched source file below the 500-line cap, with regression guards for asset wiring and active repository URLs.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `cd packages/kobe && bun x vitest run test/architecture/package-distribution.test.ts test/cli/theme.test.ts test/tui/theme-schema.test.ts test/lib/skill-install.test.ts test/cli/skill-cmd.test.ts` (85 tests)
- `cd packages/kobe-docs && bun run sync`
- `cd packages/kobe-plugin-sdk && npm_config_cache=/tmp/rove-npm-cache npm pack --dry-run --json --ignore-scripts`
- `bash -n scripts/release.sh`
- `node --check packages/kobe-landing/index.js`
- `node --check packages/kobe-landing/themes.js`
- Local static HTTP smoke: `/`, `/index.js`, `/themes.html`, `/themes.css`, and `/themes.js` all return 200.

## Local-only note

The product build was not run locally because it clears `dist/`; the PR build gate will run it in CI.