### PR TITLE
fix: api schema lists user-registered custom engines in --vendor values

### DIFF
--- a/.changeset/schema-shows-custom-engines.md
+++ b/.changeset/schema-shows-custom-engines.md
@@ -1,5 +1,5 @@
 ---
-"@sma1lboy/kobe": patch
+"@sma1lboy/rove": patch
 ---
 
 fix: `rove api schema` and `--help` now list user-registered custom engines in the `--vendor` values, not just the built-ins. The runtime already accepted custom engine ids, but the discovery surface hid them, so an agent reading the schema never learned they existed.

--- a/.changeset/schema-shows-custom-engines.md
+++ b/.changeset/schema-shows-custom-engines.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+fix: `rove api schema` and `--help` now list user-registered custom engines in the `--vendor` values, not just the built-ins. The runtime already accepted custom engine ids, but the discovery surface hid them, so an agent reading the schema never learned they existed.

--- a/docs/API.md
+++ b/docs/API.md
@@ -72,7 +72,9 @@ be given bare (`--force` ⇒ true) or explicitly (`--archived=false`);
 `--task-id` / enum / positive-int values are validated against the verb's
 spec, and unknown flags are rejected (exit 2). `--repo` resolves relative
 paths against `$PWD` (`~` expanded). Engine vendors: `claude`, `codex`,
-`copilot`, `kimi`. `spawn-task` is an alias of `add`.
+`copilot`, `kimi`, plus any user-registered custom engine id — the `schema`
+and `--help` output for `--vendor` lists those too. `spawn-task` is an
+alias of `add`.
 
 ## Discovery
 

--- a/packages/kobe/src/cli/api/schema.ts
+++ b/packages/kobe/src/cli/api/schema.ts
@@ -9,6 +9,7 @@
  * constraint — they're only called from inside other function bodies.
  */
 
+import { getCustomEngineIds } from "../../state/repos.ts"
 import { CURRENT_VERSION } from "../../version.ts"
 import { activeCliName } from "../rename-compat.ts"
 import { ApiError, type FlagSpec, type VerbSpec } from "./types.ts"
@@ -29,12 +30,29 @@ const GLOBAL_FLAGS = [
   { name: "help", type: "bool", description: "Show usage for the verb and exit." },
 ]
 
+/**
+ * The values a flag's schema/help should SHOW. `--vendor` is the one open
+ * enum: its spec `values` lists the built-ins, but user-registered custom
+ * engines are equally valid at runtime (`validateAgainstSpec` /
+ * `VerbArgs.vendor` both accept them) — listing only built-ins here hid them
+ * from every agent that discovers the surface through `schema` / `--help`.
+ * Read at render time, not in the static VERBS table, so a newly registered
+ * engine shows up in the very next invocation.
+ */
+function displayValues(f: FlagSpec): readonly string[] | undefined {
+  if (!f.values) return undefined
+  if (f.name !== "vendor") return f.values
+  const custom = getCustomEngineIds().filter((id) => !f.values!.includes(id))
+  return custom.length > 0 ? [...f.values, ...custom] : f.values
+}
+
 function flagJson(f: FlagSpec): unknown {
+  const values = displayValues(f)
   return {
     name: f.name,
     type: f.type,
     required: f.required ?? false,
-    ...(f.values ? { values: f.values } : {}),
+    ...(values ? { values } : {}),
     ...(f.default !== undefined ? { default: f.default } : {}),
     ...(f.placeholder ? { placeholder: f.placeholder } : {}),
     description: f.description,
@@ -104,7 +122,7 @@ function flagSignature(verb: VerbSpec): string {
   return verb.flags
     .map((f) => {
       const meta =
-        f.type === "enum" && f.values ? f.values.join("|") : (f.placeholder ?? (f.type === "bool" ? "" : "X"))
+        f.type === "enum" && f.values ? displayValues(f)!.join("|") : (f.placeholder ?? (f.type === "bool" ? "" : "X"))
       const core = meta ? `--${f.name} ${meta}` : `--${f.name}`
       return f.required ? core : `[${core}]`
     })
@@ -121,7 +139,7 @@ export function verbHelp(verb: VerbSpec): string {
     for (const f of verb.flags) {
       const req = f.required ? " (required)" : ""
       const def = f.default !== undefined ? ` [default: ${f.default}]` : ""
-      const vals = f.type === "enum" && f.values ? ` {${f.values.join("|")}}` : ""
+      const vals = f.type === "enum" && f.values ? ` {${displayValues(f)!.join("|")}}` : ""
       lines.push(`  --${f.name}${vals}${req}${def}  ${f.description}`)
     }
     lines.push("")

--- a/packages/kobe/test/cli/api-custom-vendor.test.ts
+++ b/packages/kobe/test/cli/api-custom-vendor.test.ts
@@ -11,6 +11,12 @@
  * Two gates had to agree, and both are pinned here: the spec pre-validator
  * (`validateAgainstSpec`, which runs before any handler) and the accessor
  * (`VerbArgs.vendor`).
+ *
+ * The third gate is DISCOVERY: accepting a custom id at runtime is worthless
+ * when `schema` / `--help` still list only the built-ins — an agent reading
+ * the surface never learns the engine exists. The render layer
+ * (`displayValues` in schema.ts) appends the registered ids at render time;
+ * that visibility is pinned here too.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
@@ -18,6 +24,9 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { verbHelp, verbSchema } from "../../src/cli/api/schema.ts"
+import { findVerb } from "../../src/cli/api/verbs.ts"
+import { ALL_VENDORS } from "../../src/types/vendor.ts"
 import { FakeClient, expectApiError, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
 
 let home: string
@@ -85,5 +94,30 @@ describe("other verbs reading --vendor", () => {
     const client = new FakeClient({ "task.create": () => ({ taskId: "t9", task: taskFixture({ id: "t9" }) }) })
     await invokeVerb("add", ["--repo", "/repo/x", "--vendor", "pi"], { client, runtime })
     expect((client.requests[0]?.payload as { vendor: string }).vendor).toBe("pi")
+  })
+})
+
+describe("schema / --help discovery", () => {
+  function vendorValues(detail: unknown): string[] {
+    const flags = (detail as { flags: { name: string; values?: string[] }[] }).flags
+    return flags.find((f) => f.name === "vendor")?.values ?? []
+  }
+
+  it("verbSchema lists registered custom engines in --vendor values", () => {
+    writeState({ customEngineIds: ["claudecpa"] })
+    const detail = verbSchema(findVerb("set-vendor")!)
+    expect(vendorValues(detail)).toContain("claudecpa")
+    expect(vendorValues(detail)).toContain("claude")
+  })
+
+  it("--help text shows the custom engine in the enum brace list", () => {
+    writeState({ customEngineIds: ["claudecpa"] })
+    expect(verbHelp(findVerb("add")!)).toMatch(/--vendor \{[^}]*\bclaudecpa\b[^}]*\}/)
+  })
+
+  it("lists only built-ins when no custom engine is registered", () => {
+    writeState({})
+    const detail = verbSchema(findVerb("set-vendor")!)
+    expect(vendorValues(detail)).toEqual([...ALL_VENDORS])
   })
 })


### PR DESCRIPTION
The runtime accepted custom engine ids (`validateAgainstSpec`, `VerbArgs.vendor`) but `rove api schema` / `--help` rendered only the built-ins, so an agent discovering the surface never learned a registered engine existed.

`displayValues()` in `schema.ts` now appends `getCustomEngineIds()` at render time (per-invocation, so a newly registered engine shows up in the next call). Includes pinning tests, a patch changeset, and a one-line `docs/API.md` update.

Verified: full suite (557 tests), typecheck, lint green; manual smoke with a temp KOBE_HOME_DIR shows the custom id in `schema --verb set-vendor` output.