### PR TITLE
fix: embed docs demo videos

### DIFF
--- a/.changeset/fuzzy-lions-watch.md
+++ b/.changeset/fuzzy-lions-watch.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Embed the Kanban and Routines MP4 demos directly in the public docs site, with local download fallbacks.

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -44,8 +44,10 @@ change:
 
 ![Walking the routines, pausing one, and composing a new one as the cron preview follows each cell](assets/routines.gif)
 
-Full-quality mp4:
-[routines.mp4](https://github.com/Sma1lboy/rove/blob/main/docs/assets/routines.mp4).
+<video controls playsInline preload="metadata" poster="assets/routines.png" style={{ width: "100%" }}>
+  <source src="assets/routines.mp4" type="video/mp4" />
+  Your browser cannot play this video. [Download the full-quality MP4](assets/routines.mp4).
+</video>
 
 ### From the CLI
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -140,8 +140,10 @@ the page is open, which moves the card into In progress on its own:
 
 ![Filing a story from the board, then an agent moving its card into In progress](assets/kanban.gif)
 
-Full-quality mp4:
-[kanban.mp4](https://github.com/Sma1lboy/rove/blob/main/docs/assets/kanban.mp4).
+<video controls playsInline preload="metadata" poster="assets/kanban.png" style={{ width: "100%" }}>
+  <source src="assets/kanban.mp4" type="video/mp4" />
+  Your browser cannot play this video. [Download the full-quality MP4](assets/kanban.mp4).
+</video>
 
 ### Routines (`ctrl+a` `2`)
 

--- a/packages/kobe-docs/scripts/sync-docs.mjs
+++ b/packages/kobe-docs/scripts/sync-docs.mjs
@@ -27,6 +27,9 @@ const assetsOutDir = join(packageDir, 'public/docs-assets');
 
 const repoBlob = 'https://github.com/Sma1lboy/rove/blob/main/';
 
+/** docs/assets/… paths referenced by synced pages, relative to assets/. */
+const referencedAssets = new Set();
+
 /**
  * The sidebar, as ordered sections of `[docs/ source file, site slug]`.
  * This is the single source of truth: PAGES (what gets synced) is derived
@@ -95,6 +98,10 @@ function rewriteTarget(target) {
     path = path.slice('./'.length);
   }
 
+  // Linked media and downloads live beside images in docs/assets/. Keep the
+  // source repo-relative, but serve the docs site from its own static tree.
+  if (path.startsWith('assets/')) return `${rewriteAssetTarget(path)}${anchor}`;
+
   // Links between synced pages → site paths.
   const slug = PAGE_BY_LOWER_NAME.get(basename(path).toLowerCase());
   if (slug && !path.includes('/')) return `/docs/${slug}${anchor}`;
@@ -122,7 +129,7 @@ function rewriteTarget(target) {
  * on GitHub). For the site they are rewritten to `/docs-assets/foo.png` and
  * the referenced files are copied into public/docs-assets/ below.
  */
-function rewriteImageTarget(target) {
+function rewriteAssetTarget(target) {
   if (/^(?:[a-z][a-z0-9+.-]*:|\/|#)/i.test(target)) return target;
   const path = target.startsWith('./') ? target.slice('./'.length) : target;
   if (path.startsWith('assets/')) {
@@ -132,8 +139,24 @@ function rewriteImageTarget(target) {
   return target;
 }
 
-/** docs/assets/… paths referenced by synced pages, relative to assets/. */
-const referencedAssets = new Set();
+function rewriteImageTarget(target) {
+  return rewriteAssetTarget(target);
+}
+
+/** Raw MDX media attributes are invisible to Markdown link rewriting. */
+function rewriteMediaTargets(markdown) {
+  let inFence = false;
+  return markdown
+    .split('\n')
+    .map((line) => {
+      if (/^\s*```/.test(line)) inFence = !inFence;
+      if (inFence) return line;
+      return line.replace(/\b(src|poster)=(['"])([^'"]+)\2/g, (_match, attribute, quote, target) => {
+        return `${attribute}=${quote}${rewriteAssetTarget(target)}${quote}`;
+      });
+    })
+    .join('\n');
+}
 
 function rewriteLinks(markdown) {
   return (
@@ -184,7 +207,7 @@ function toMdxPage(markdown, sourceFile) {
     '',
   ].join('\n');
 
-  return `${frontmatter}${rewriteAutolinks(rewriteLinks(body))}`;
+  return `${frontmatter}${rewriteAutolinks(rewriteMediaTargets(rewriteLinks(body)))}`;
 }
 
 await mkdir(docsOutDir, { recursive: true });
@@ -212,8 +235,8 @@ const meta = {
 await writeFile(join(docsOutDir, 'meta.json'), `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
 console.log('wrote content/docs/meta.json');
 
-// Copy referenced docs/assets/ files into public/docs-assets/ so the
-// rewritten /docs-assets/… image paths resolve on the static site.
+// Copy referenced docs/assets/ files into public/docs-assets/ so rewritten
+// image, video, and download paths resolve on the static site.
 for (const asset of [...referencedAssets].sort()) {
   const out = join(assetsOutDir, asset);
   await mkdir(dirname(out), { recursive: true });

--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -1,6 +1,7 @@
 /** Distribution contract for the canonical Rove npm package and Kobe alias. */
 
-import { readFileSync, readdirSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import { existsSync, readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
@@ -10,6 +11,25 @@ const read = (path: string) => readFileSync(join(ROOT, path), "utf8")
 const json = <T>(path: string): T => JSON.parse(read(path)) as T
 
 describe("Rove package distribution", () => {
+  test("the docs build embeds demo videos from its own static asset tree", () => {
+    execFileSync("bun", ["packages/kobe-docs/scripts/sync-docs.mjs"], {
+      cwd: ROOT,
+      stdio: "pipe",
+    })
+
+    for (const [page, video] of [
+      ["tui", "kanban"],
+      ["routines", "routines"],
+    ] as const) {
+      const generated = read(`packages/kobe-docs/content/docs/${page}.mdx`)
+      expect(generated).toContain("<video controls playsInline")
+      expect(generated).toContain(`poster="/docs-assets/${video}.png"`)
+      expect(generated).toContain(`src="/docs-assets/${video}.mp4"`)
+      expect(generated).toContain(`](/docs-assets/${video}.mp4)`)
+      expect(existsSync(join(ROOT, `packages/kobe-docs/public/docs-assets/${video}.mp4`))).toBe(true)
+    }
+  })
+
   test("the workspace package is canonical Rove while both CLI names remain available", () => {
     const pkg = json<{ name: string; bin: Record<string, string> }>("packages/kobe/package.json")
 


### PR DESCRIPTION
## Summary
Embeds the Kanban and Routines MP4 demos directly in the public docs with native controls and local download fallbacks.
Extends the docs synchronizer to rewrite raw MDX media attributes and asset links, then copy referenced videos and posters into the static asset tree.
Adds a regression test for both pages and a patch changeset for @sma1lboy/rove.
Validation: full test suite, lint, typecheck, changeset status, and the production docs build all pass.