### PR TITLE
feat: read-output learns --tab for tab-precise terminal reads

### DIFF
--- a/.changeset/read-output-tab-flag.md
+++ b/.changeset/read-output-tab-flag.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+fix: `rove api read-output` learns `--tab tab-N` — every API verb's smallest unit is one terminal tab, but read-output could only resolve the task's canonical engine tab, making a sibling tab's screen (e.g. the one actually running the engine after a `--tab new` respawn) unreadable headlessly. A tab read is terminal-only (history is worktree-scoped), refuses `--source history` with a typed `BAD_FLAG`, answers a missing tab with `TAB_NOT_FOUND`, and the cursor now pins the tab alongside the pid so paged reads can't silently hop tabs.

--- a/docs/API.md
+++ b/docs/API.md
@@ -45,6 +45,7 @@ screen:
 
 ```bash
 rove api read-output --task-id <id>    # paged history, honest terminal fallback
+rove api read-output --task-id <id> --tab tab-3   # one exact tab's terminal
 ```
 
 **Fan in** — compare the attempts, then land one:
@@ -106,12 +107,14 @@ alias of `add`.
   to the spawning agent's chat tab (`send`), not into Rove state.
 - `pty-list` *(offline)*: hosted PTY sessions (key, alive, pid, command,
   live window title). Empty when no PTY host runs.
-- `read-output [--task-id ID] [--source auto|history|terminal] [--cursor C]
-  [--limit N]`: a task's engine output as bounded, cursor-paged JSON —
-  structured history when the engine has it, else a labeled terminal tail
-  (`fallbackReason`). The cursor is pinned to one source/session and returns
-  `SOURCE_CHANGED` if that moved. A dead session's terminal page includes
-  `terminal.exit` (`code`/`signal`/`at`) while the PTY host still runs.
+- `read-output [--task-id ID] [--tab TAB] [--source auto|history|terminal]
+  [--cursor C] [--limit N]`: a task's engine output as bounded, cursor-paged
+  JSON — structured history when the engine has it, else a labeled terminal
+  tail (`fallbackReason`). The cursor is pinned to one source/session/tab and
+  returns `SOURCE_CHANGED` if that moved. `--tab tab-N` reads exactly that
+  tab's hosted terminal session (terminal-only; `TAB_NOT_FOUND` when the tab
+  has no session). A dead session's terminal page includes `terminal.exit`
+  (`code`/`signal`/`at`) while the PTY host still runs.
 - `inspect [--task-id ID]` *(offline)*: diagnostics in one read, across four
   sections — `daemon` (raw per-task/per-tab activity entries), `sessions`
   (PTY inventory joined with a live process-tree walk; dead sessions carry

--- a/packages/kobe/src/cli/api/read-output-page.ts
+++ b/packages/kobe/src/cli/api/read-output-page.ts
@@ -1,0 +1,190 @@
+/**
+ * Pure paging/shaping half of `kobe api read-output` (split for the 500-line
+ * cap): the envelope + cursor types, the deterministic page builders, and
+ * the terminal-text shaping. No daemon, no PTY host, no vendor imports —
+ * the read logic and the verb live in `read-output.ts`, which re-exports
+ * this module so `@/cli/api/read-output` stays the one import site.
+ */
+
+import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import type { Message } from "../../types/engine.ts"
+import { ApiError } from "./types.ts"
+
+// ── Bounds (deterministic paging) ────────────────────────────────────────────
+
+export const DEFAULT_PAGE_MESSAGES = 40
+export const MAX_PAGE_MESSAGES = 50
+/** Serialized-bytes budget per history page (always at least one message). */
+export const PAGE_BYTE_BUDGET = 128 * 1024
+/** Any single string inside a message is clipped past this many chars. */
+export const STRING_CLIP_CHARS = 16 * 1024
+/** Terminal fallback tail caps — lines and bytes. */
+export const TERMINAL_TAIL_LINES = 200
+export const TERMINAL_TAIL_BYTES = 64 * 1024
+
+// ── Envelope + cursor types ──────────────────────────────────────────────────
+
+export type ReadSource = "history" | "terminal"
+export type ReadSourceArg = "auto" | ReadSource
+export type FallbackReason = "engine_unsupported" | "history_missing" | "history_unreadable"
+
+export interface ReadOutputEnvelope {
+  readonly taskId: string
+  readonly source: ReadSource
+  readonly history?: {
+    /** Vendor session id (flat token, never a path). */
+    readonly sessionId: string
+    readonly messages: readonly unknown[]
+    readonly returnedMessageCount: number
+    readonly totalMessages: number
+    /** True when the byte budget cut the page short of `limit`. */
+    readonly limited: boolean
+  }
+  readonly terminal?: {
+    readonly tail: readonly string[]
+    /** True when older output was dropped to fit the tail caps. */
+    readonly truncated: boolean
+    readonly live: boolean
+    /** How the session died when `live` is false — null while alive or
+     *  when the host predates exit records. */
+    readonly exit?: PtySessionExit | null
+    /** The exact tab read (`--tab`); absent for the canonical engine tab. */
+    readonly tab?: string
+  }
+  /** Opaque next-page cursor; null when there is nothing to page. */
+  readonly cursor: string | null
+  /** Why structured history was NOT used (auto only; null on an explicit source). */
+  readonly fallbackReason: FallbackReason | null
+  readonly warnings: readonly string[]
+}
+
+type HistoryCursor = { v: 1; task: string; src: "history"; sid: string; idx: number }
+type TerminalCursor = {
+  v: 1
+  task: string
+  src: "terminal"
+  pid: number | null
+  off: number
+  fr: FallbackReason | null
+  /** The tab a `--tab` read is pinned to; absent for canonical-tab reads. */
+  tab?: string
+}
+export type Cursor = HistoryCursor | TerminalCursor
+export type { HistoryCursor, TerminalCursor }
+
+export function encodeCursor(cursor: Cursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url")
+}
+
+export function decodeCursor(raw: string, taskId: string): Cursor {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"))
+  } catch {
+    throw new ApiError("invalid cursor (not a read-output cursor)", "CURSOR_INVALID")
+  }
+  const c = parsed as Partial<Cursor>
+  const shapeOk =
+    c !== null &&
+    typeof c === "object" &&
+    c.v === 1 &&
+    typeof c.task === "string" &&
+    ((c.src === "history" &&
+      typeof (c as HistoryCursor).sid === "string" &&
+      typeof (c as HistoryCursor).idx === "number") ||
+      (c.src === "terminal" &&
+        typeof (c as TerminalCursor).off === "number" &&
+        ((c as TerminalCursor).tab === undefined || typeof (c as TerminalCursor).tab === "string")))
+  if (!shapeOk) throw new ApiError("invalid cursor (unknown version or shape)", "CURSOR_INVALID")
+  if (c.task !== taskId) {
+    throw new ApiError(`cursor belongs to task ${c.task}, not ${taskId}`, "CURSOR_TASK_MISMATCH")
+  }
+  return c as Cursor
+}
+
+// ── Bounded page building (pure) ─────────────────────────────────────────────
+
+/** Deep-copy `value` with every long string clipped (bounded pages even
+ *  when a single tool result is huge). Messages are plain parsed JSON. */
+export function clipStrings(value: unknown): unknown {
+  if (typeof value === "string") {
+    if (value.length <= STRING_CLIP_CHARS) return value
+    return `${value.slice(0, STRING_CLIP_CHARS)}…[+${value.length - STRING_CLIP_CHARS} chars clipped]`
+  }
+  if (Array.isArray(value)) return value.map(clipStrings)
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) out[k] = clipStrings(v)
+    return out
+  }
+  return value
+}
+
+export interface HistoryPage {
+  readonly page: readonly unknown[]
+  readonly nextIdx: number
+  readonly limited: boolean
+}
+
+/** Deterministic page: up to `limit` messages from `startIdx`, stopping
+ *  early (but never before one message) when the byte budget is spent. */
+export function buildHistoryPage(messages: readonly Message[], startIdx: number, limit: number): HistoryPage {
+  const page: unknown[] = []
+  let bytes = 0
+  let limited = false
+  let i = startIdx
+  for (; i < messages.length && page.length < limit; i++) {
+    const clipped = clipStrings(messages[i])
+    const size = JSON.stringify(clipped).length
+    if (page.length > 0 && bytes + size > PAGE_BYTE_BUDGET) {
+      limited = true
+      break
+    }
+    page.push(clipped)
+    bytes += size
+  }
+  return { page, nextIdx: i, limited }
+}
+
+// ── Terminal text shaping (pure) ─────────────────────────────────────────────
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping raw ANSI escapes is the point
+const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[@-_]/g
+
+/** Raw PTY bytes → readable lines: strip ANSI, honor CR overwrites. */
+export function terminalLines(text: string): string[] {
+  const plain = text.replace(ANSI_RE, "").replace(/\r\n/g, "\n")
+  return plain.split("\n").map((line) => line.split("\r").pop() ?? "")
+}
+
+export interface TerminalTail {
+  readonly tail: readonly string[]
+  readonly truncated: boolean
+}
+
+/** Bounded tail: at most {@link TERMINAL_TAIL_LINES} lines / {@link TERMINAL_TAIL_BYTES} bytes. */
+export function boundedTail(text: string): TerminalTail {
+  const lines = terminalLines(text)
+  let start = Math.max(0, lines.length - TERMINAL_TAIL_LINES)
+  let bytes = 0
+  for (let i = lines.length - 1; i >= start; i--) {
+    bytes += (lines[i]?.length ?? 0) + 1
+    if (bytes > TERMINAL_TAIL_BYTES) {
+      start = i + 1
+      break
+    }
+  }
+  return { tail: lines.slice(start), truncated: start > 0 }
+}
+
+// ── Terminal peek page (the dep read-output injects) ─────────────────────────
+
+export interface TerminalPeekPage {
+  readonly pid: number | null
+  readonly offset: number
+  readonly text: string
+  /** False when `sinceOffset` was trimmed out of the ring (gap in output). */
+  readonly sinceValid: boolean
+  readonly live: boolean
+  readonly exit?: PtySessionExit | null
+}

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -34,193 +34,57 @@
  * the tab alongside the pid, so paged reads can't silently hop tabs.
  */
 
-import type { PtyPeekResult, PtySessionExit, SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import type { PtyPeekResult, SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { interactiveEngineCommand } from "../../engine/interactive-command.ts"
 import { type EngineHistoryReader, engineEntry, supportsStructuredHistory } from "../../engine/registry.ts"
 import type { Message } from "../../types/engine.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import { daemonOf } from "./handler-helpers.ts"
 import { findEngineKey, listSessions, openPtyHost } from "./pty-delivery.ts"
+import {
+  type Cursor,
+  DEFAULT_PAGE_MESSAGES,
+  decodeCursor,
+  encodeCursor,
+  type FallbackReason,
+  type HistoryCursor,
+  MAX_PAGE_MESSAGES,
+  type ReadOutputEnvelope,
+  type ReadSourceArg,
+  type TerminalCursor,
+  type TerminalPeekPage,
+  boundedTail,
+  buildHistoryPage,
+} from "./read-output-page.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
 import { ApiError, type VerbContext, type VerbSpec } from "./types.ts"
 
-// ── Bounds (deterministic paging) ────────────────────────────────────────────
-
-export const DEFAULT_PAGE_MESSAGES = 40
-export const MAX_PAGE_MESSAGES = 50
-/** Serialized-bytes budget per history page (always at least one message). */
-export const PAGE_BYTE_BUDGET = 128 * 1024
-/** Any single string inside a message is clipped past this many chars. */
-export const STRING_CLIP_CHARS = 16 * 1024
-/** Terminal fallback tail caps — lines and bytes. */
-export const TERMINAL_TAIL_LINES = 200
-export const TERMINAL_TAIL_BYTES = 64 * 1024
-
-// ── Envelope + cursor types ──────────────────────────────────────────────────
-
-export type ReadSource = "history" | "terminal"
-export type ReadSourceArg = "auto" | ReadSource
-export type FallbackReason = "engine_unsupported" | "history_missing" | "history_unreadable"
-
-export interface ReadOutputEnvelope {
-  readonly taskId: string
-  readonly source: ReadSource
-  readonly history?: {
-    /** Vendor session id (flat token, never a path). */
-    readonly sessionId: string
-    readonly messages: readonly unknown[]
-    readonly returnedMessageCount: number
-    readonly totalMessages: number
-    /** True when the byte budget cut the page short of `limit`. */
-    readonly limited: boolean
-  }
-  readonly terminal?: {
-    readonly tail: readonly string[]
-    /** True when older output was dropped to fit the tail caps. */
-    readonly truncated: boolean
-    readonly live: boolean
-    /** How the session died when `live` is false — null while alive or
-     *  when the host predates exit records. */
-    readonly exit?: PtySessionExit | null
-    /** The exact tab read (`--tab`); absent for the canonical engine tab. */
-    readonly tab?: string
-  }
-  /** Opaque next-page cursor; null when there is nothing to page. */
-  readonly cursor: string | null
-  /** Why structured history was NOT used (auto only; null on an explicit source). */
-  readonly fallbackReason: FallbackReason | null
-  readonly warnings: readonly string[]
-}
-
-type HistoryCursor = { v: 1; task: string; src: "history"; sid: string; idx: number }
-type TerminalCursor = {
-  v: 1
-  task: string
-  src: "terminal"
-  pid: number | null
-  off: number
-  fr: FallbackReason | null
-  /** The tab a `--tab` read is pinned to; absent for canonical-tab reads. */
-  tab?: string
-}
-type Cursor = HistoryCursor | TerminalCursor
-
-export function encodeCursor(cursor: Cursor): string {
-  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url")
-}
-
-export function decodeCursor(raw: string, taskId: string): Cursor {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"))
-  } catch {
-    throw new ApiError("invalid cursor (not a read-output cursor)", "CURSOR_INVALID")
-  }
-  const c = parsed as Partial<Cursor>
-  const shapeOk =
-    c !== null &&
-    typeof c === "object" &&
-    c.v === 1 &&
-    typeof c.task === "string" &&
-    ((c.src === "history" &&
-      typeof (c as HistoryCursor).sid === "string" &&
-      typeof (c as HistoryCursor).idx === "number") ||
-      (c.src === "terminal" &&
-        typeof (c as TerminalCursor).off === "number" &&
-        ((c as TerminalCursor).tab === undefined || typeof (c as TerminalCursor).tab === "string")))
-  if (!shapeOk) throw new ApiError("invalid cursor (unknown version or shape)", "CURSOR_INVALID")
-  if (c.task !== taskId) {
-    throw new ApiError(`cursor belongs to task ${c.task}, not ${taskId}`, "CURSOR_TASK_MISMATCH")
-  }
-  return c as Cursor
-}
-
-// ── Bounded page building (pure) ─────────────────────────────────────────────
-
-/** Deep-copy `value` with every long string clipped (bounded pages even
- *  when a single tool result is huge). Messages are plain parsed JSON. */
-export function clipStrings(value: unknown): unknown {
-  if (typeof value === "string") {
-    if (value.length <= STRING_CLIP_CHARS) return value
-    return `${value.slice(0, STRING_CLIP_CHARS)}…[+${value.length - STRING_CLIP_CHARS} chars clipped]`
-  }
-  if (Array.isArray(value)) return value.map(clipStrings)
-  if (value !== null && typeof value === "object") {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value)) out[k] = clipStrings(v)
-    return out
-  }
-  return value
-}
-
-export interface HistoryPage {
-  readonly page: readonly unknown[]
-  readonly nextIdx: number
-  readonly limited: boolean
-}
-
-/** Deterministic page: up to `limit` messages from `startIdx`, stopping
- *  early (but never before one message) when the byte budget is spent. */
-export function buildHistoryPage(messages: readonly Message[], startIdx: number, limit: number): HistoryPage {
-  const page: unknown[] = []
-  let bytes = 0
-  let limited = false
-  let i = startIdx
-  for (; i < messages.length && page.length < limit; i++) {
-    const clipped = clipStrings(messages[i])
-    const size = JSON.stringify(clipped).length
-    if (page.length > 0 && bytes + size > PAGE_BYTE_BUDGET) {
-      limited = true
-      break
-    }
-    page.push(clipped)
-    bytes += size
-  }
-  return { page, nextIdx: i, limited }
-}
-
-// ── Terminal text shaping (pure) ─────────────────────────────────────────────
-
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping raw ANSI escapes is the point
-const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[@-_]/g
-
-/** Raw PTY bytes → readable lines: strip ANSI, honor CR overwrites. */
-export function terminalLines(text: string): string[] {
-  const plain = text.replace(ANSI_RE, "").replace(/\r\n/g, "\n")
-  return plain.split("\n").map((line) => line.split("\r").pop() ?? "")
-}
-
-export interface TerminalTail {
-  readonly tail: readonly string[]
-  readonly truncated: boolean
-}
-
-/** Bounded tail: at most {@link TERMINAL_TAIL_LINES} lines / {@link TERMINAL_TAIL_BYTES} bytes. */
-export function boundedTail(text: string): TerminalTail {
-  const lines = terminalLines(text)
-  let start = Math.max(0, lines.length - TERMINAL_TAIL_LINES)
-  let bytes = 0
-  for (let i = lines.length - 1; i >= start; i--) {
-    bytes += (lines[i]?.length ?? 0) + 1
-    if (bytes > TERMINAL_TAIL_BYTES) {
-      start = i + 1
-      break
-    }
-  }
-  return { tail: lines.slice(start), truncated: start > 0 }
-}
+// The paging/shaping half lives in `read-output-page.ts` (file-size cap);
+// re-exported so `@/cli/api/read-output` stays the one import site.
+export {
+  boundedTail,
+  buildHistoryPage,
+  clipStrings,
+  decodeCursor,
+  DEFAULT_PAGE_MESSAGES,
+  encodeCursor,
+  MAX_PAGE_MESSAGES,
+  STRING_CLIP_CHARS,
+  TERMINAL_TAIL_BYTES,
+  TERMINAL_TAIL_LINES,
+} from "./read-output-page.ts"
+export type {
+  Cursor,
+  FallbackReason,
+  HistoryPage,
+  ReadOutputEnvelope,
+  ReadSource,
+  ReadSourceArg,
+  TerminalPeekPage,
+  TerminalTail,
+} from "./read-output-page.ts"
 
 // ── The read itself (deps-injected, unit-testable) ───────────────────────────
-
-export interface TerminalPeekPage {
-  readonly pid: number | null
-  readonly offset: number
-  readonly text: string
-  /** False when `sinceOffset` was trimmed out of the ring (gap in output). */
-  readonly sinceValid: boolean
-  readonly live: boolean
-  readonly exit?: PtySessionExit | null
-}
 
 export interface ReadOutputDeps {
   /** The engine adapter's transcript reader; null = engine ships none. */

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -25,6 +25,13 @@
  *     (session ids are flat vendor tokens, terminal identity is a pid).
  *   - Strictly read-only: never spawns, attaches, resizes, or mutates
  *     task/engine lifecycle (terminal reads go through `pty.peek`).
+ *
+ * Tab precision (2026-08-16): the default terminal read resolves the
+ * task's CANONICAL engine tab; `--tab tab-N` reads exactly that hosted
+ * session instead (the API's smallest unit is one tab, same as
+ * `send --tab`). A tab read is terminal-only — history is
+ * worktree-scoped and cannot resolve to a tab — and the cursor pins
+ * the tab alongside the pid, so paged reads can't silently hop tabs.
  */
 
 import type { PtyPeekResult, PtySessionExit, SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
@@ -75,6 +82,8 @@ export interface ReadOutputEnvelope {
     /** How the session died when `live` is false — null while alive or
      *  when the host predates exit records. */
     readonly exit?: PtySessionExit | null
+    /** The exact tab read (`--tab`); absent for the canonical engine tab. */
+    readonly tab?: string
   }
   /** Opaque next-page cursor; null when there is nothing to page. */
   readonly cursor: string | null
@@ -91,6 +100,8 @@ type TerminalCursor = {
   pid: number | null
   off: number
   fr: FallbackReason | null
+  /** The tab a `--tab` read is pinned to; absent for canonical-tab reads. */
+  tab?: string
 }
 type Cursor = HistoryCursor | TerminalCursor
 
@@ -114,7 +125,9 @@ export function decodeCursor(raw: string, taskId: string): Cursor {
     ((c.src === "history" &&
       typeof (c as HistoryCursor).sid === "string" &&
       typeof (c as HistoryCursor).idx === "number") ||
-      (c.src === "terminal" && typeof (c as TerminalCursor).off === "number"))
+      (c.src === "terminal" &&
+        typeof (c as TerminalCursor).off === "number" &&
+        ((c as TerminalCursor).tab === undefined || typeof (c as TerminalCursor).tab === "string")))
   if (!shapeOk) throw new ApiError("invalid cursor (unknown version or shape)", "CURSOR_INVALID")
   if (c.task !== taskId) {
     throw new ApiError(`cursor belongs to task ${c.task}, not ${taskId}`, "CURSOR_TASK_MISMATCH")
@@ -212,8 +225,10 @@ export interface TerminalPeekPage {
 export interface ReadOutputDeps {
   /** The engine adapter's transcript reader; null = engine ships none. */
   readonly history: EngineHistoryReader | null
-  /** Bounded ring peek of the task's live engine pane; null = no host / no session. */
-  peekTerminal(sinceOffset?: number): Promise<TerminalPeekPage | null>
+  /** Bounded ring peek of one hosted session; `tab` selects the exact tab
+   *  (`undefined` = the task's canonical engine tab). null = no host / no
+   *  session. */
+  peekTerminal(tab: string | undefined, sinceOffset?: number): Promise<TerminalPeekPage | null>
 }
 
 export interface ReadOutputInput {
@@ -221,6 +236,8 @@ export interface ReadOutputInput {
   /** Task worktree (null when not materialized — history is then missing). */
   readonly worktree: string | null
   readonly source: ReadSourceArg
+  /** Exact terminal tab to read (`tab-N`); implies a terminal-only read. */
+  readonly tab?: string
   readonly cursor?: string
   readonly limit?: number
 }
@@ -232,6 +249,12 @@ function sourceChanged(detail: string): ApiError {
 export async function readTaskOutput(input: ReadOutputInput, deps: ReadOutputDeps): Promise<ReadOutputEnvelope> {
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_PAGE_MESSAGES, 1), MAX_PAGE_MESSAGES)
 
+  // A tab read IS a terminal read: history is worktree-scoped, so there is
+  // no per-tab history to serve. --source history + --tab is a contradiction.
+  if (input.tab && input.source === "history") {
+    throw new ApiError("--tab reads one terminal tab; --source history is task/worktree-scoped", "BAD_FLAG")
+  }
+
   if (input.cursor) {
     const cursor = decodeCursor(input.cursor, input.taskId)
     if (input.source !== "auto" && input.source !== cursor.src) {
@@ -240,12 +263,21 @@ export async function readTaskOutput(input: ReadOutputInput, deps: ReadOutputDep
         "CURSOR_INVALID",
       )
     }
+    if (input.tab && cursor.src !== "terminal") {
+      throw new ApiError(`cursor is pinned to source "${cursor.src}" but --tab reads a terminal tab`, "CURSOR_INVALID")
+    }
+    if (cursor.src === "terminal" && (cursor.tab ?? null) !== (input.tab ?? null)) {
+      throw new ApiError(
+        `cursor is pinned to tab ${cursor.tab ?? "canonical"} — pass the same --tab or restart without the cursor`,
+        "CURSOR_INVALID",
+      )
+    }
     return cursor.src === "history"
       ? continueHistory(input, deps, cursor, limit)
       : continueTerminal(input, deps, cursor)
   }
 
-  if (input.source === "terminal") return firstTerminalPage(input, deps, null)
+  if (input.tab || input.source === "terminal") return firstTerminalPage(input, deps, null)
 
   const first = await tryFirstHistoryPage(input, deps, limit)
   if (typeof first !== "string") return first
@@ -341,12 +373,12 @@ async function firstTerminalPage(
   deps: ReadOutputDeps,
   fallbackReason: FallbackReason | null,
 ): Promise<ReadOutputEnvelope> {
-  const t = await deps.peekTerminal()
+  const t = await deps.peekTerminal(input.tab)
   if (!t) {
     return {
       taskId: input.taskId,
       source: "terminal",
-      terminal: { tail: [], truncated: false, live: false },
+      terminal: { tail: [], truncated: false, live: false, tab: input.tab },
       cursor: null,
       fallbackReason,
       warnings: ["no live terminal session for this task"],
@@ -356,8 +388,16 @@ async function firstTerminalPage(
   return {
     taskId: input.taskId,
     source: "terminal",
-    terminal: { tail, truncated, live: t.live, exit: t.exit ?? null },
-    cursor: encodeCursor({ v: 1, task: input.taskId, src: "terminal", pid: t.pid, off: t.offset, fr: fallbackReason }),
+    terminal: { tail, truncated, live: t.live, exit: t.exit ?? null, tab: input.tab },
+    cursor: encodeCursor({
+      v: 1,
+      task: input.taskId,
+      src: "terminal",
+      pid: t.pid,
+      off: t.offset,
+      fr: fallbackReason,
+      tab: input.tab,
+    }),
     fallbackReason,
     warnings: [],
   }
@@ -368,7 +408,7 @@ async function continueTerminal(
   deps: ReadOutputDeps,
   cursor: TerminalCursor,
 ): Promise<ReadOutputEnvelope> {
-  const t = await deps.peekTerminal(cursor.off)
+  const t = await deps.peekTerminal(cursor.tab, cursor.off)
   if (!t) throw sourceChanged("the terminal session is gone")
   if (t.pid !== cursor.pid) throw sourceChanged("the terminal session restarted (new process)")
   const warnings = t.sinceValid ? [] : ["scrollback trimmed — there is a gap before this page"]
@@ -377,8 +417,8 @@ async function continueTerminal(
   return {
     taskId: input.taskId,
     source: "terminal",
-    terminal: { tail, truncated, live: t.live, exit: t.exit ?? null },
-    cursor: encodeCursor({ v: 1, task: input.taskId, src: "terminal", pid: t.pid, off: t.offset, fr }),
+    terminal: { tail, truncated, live: t.live, exit: t.exit ?? null, tab: cursor.tab },
+    cursor: encodeCursor({ v: 1, task: input.taskId, src: "terminal", pid: t.pid, off: t.offset, fr, tab: cursor.tab }),
     fallbackReason: fr,
     warnings,
   }
@@ -386,26 +426,44 @@ async function continueTerminal(
 
 // ── Real deps + the verb ─────────────────────────────────────────────────────
 
-/** Read-only ring peek of the task's hosted engine pane via `pty.peek`.
- *  Never spawns the host or a session; an old host without the verb (or
- *  any RPC hiccup) reads as "no terminal data". */
+/** Read-only ring peek of one hosted session via `pty.peek`. Never spawns
+ *  the host or a session; an old host without the verb (or any RPC hiccup)
+ *  reads as "no terminal data".
+ *
+ *  `tab` selects the exact session key `<taskId>::<tab>`; an explicit tab
+ *  whose key the host doesn't know is a typed TAB_NOT_FOUND, not an empty
+ *  read. Without it, the canonical engine tab: findEngineKey only matches
+ *  ALIVE sessions; a dead engine's retained scrollback (how it died) is
+ *  still worth reading, so fall back to the deterministic engine-tab key
+ *  the TUI always mints first. */
 async function peekTaskTerminal(
   taskId: string,
   vendor: VendorId | undefined,
+  tab: string | undefined,
   sinceOffset?: number,
 ): Promise<TerminalPeekPage | null> {
   const host = await openPtyHost()
   if (!host) return null
   try {
-    const engineBin = vendor ? interactiveEngineCommand(vendor)[0] : undefined
-    const sessions = await listSessions(host.rpc)
-    // findEngineKey only matches ALIVE sessions; a dead engine's retained
-    // scrollback (how it died) is still worth reading, so fall back to the
-    // deterministic engine-tab key the TUI always mints first.
-    const key = findEngineKey(sessions, taskId, engineBin) ?? sessions.find((s) => s.key === `${taskId}::tab-1`)?.key
+    let key: string | undefined
+    if (tab) {
+      key = `${taskId}::${tab}`
+    } else {
+      const engineBin = vendor ? interactiveEngineCommand(vendor)[0] : undefined
+      const sessions = await listSessions(host.rpc)
+      key = findEngineKey(sessions, taskId, engineBin) ?? sessions.find((s) => s.key === `${taskId}::tab-1`)?.key
+    }
     if (!key) return null
     const res = await host.rpc.request<PtyPeekResult>("pty.peek", { key, sinceOffset })
-    if (!res.exists) return null
+    if (!res.exists) {
+      if (tab) {
+        throw new ApiError(
+          `tab ${tab} has no hosted session on task ${taskId} — see \`rove api pty-list\` for live tabs`,
+          "TAB_NOT_FOUND",
+        )
+      }
+      return null
+    }
     return {
       pid: res.pid,
       offset: res.offset,
@@ -414,7 +472,8 @@ async function peekTaskTerminal(
       live: res.alive,
       exit: res.exit ?? null,
     }
-  } catch {
+  } catch (err) {
+    if (err instanceof ApiError) throw err
     return null
   } finally {
     host.close()
@@ -433,15 +492,17 @@ async function handleReadOutput(ctx: VerbContext): Promise<unknown> {
   }
   const { task } = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
   const vendor = task.vendor as VendorId | undefined
+  const tab = ctx.args.str("tab")
   const deps: ReadOutputDeps = {
     history: vendor && supportsStructuredHistory(vendor) ? engineEntry(vendor).history : null,
-    peekTerminal: (sinceOffset) => peekTaskTerminal(taskId, vendor, sinceOffset),
+    peekTerminal: (tabId, sinceOffset) => peekTaskTerminal(taskId, vendor, tabId, sinceOffset),
   }
   const envelope = await readTaskOutput(
     {
       taskId,
       worktree: task.worktreePath ?? null,
       source: ctx.args.enumOf<ReadSourceArg>("source") ?? "auto",
+      tab,
       cursor: ctx.args.str("cursor"),
       limit: ctx.args.int("limit"),
     },
@@ -454,13 +515,20 @@ async function handleReadOutput(ctx: VerbContext): Promise<unknown> {
 export const READ_OUTPUT_VERB: VerbSpec = {
   name: "read-output",
   summary:
-    "Read a task's engine output as bounded, cursor-paged JSON: the engine's own structured history when available, else a labeled terminal tail (typed fallbackReason). Read-only; the cursor stays pinned to one source/session (SOURCE_CHANGED when it moved).",
+    "Read a task's engine output as bounded, cursor-paged JSON: the engine's own structured history when available, else a labeled terminal tail (typed fallbackReason). --tab tab-N reads one exact terminal tab. Read-only; the cursor stays pinned to one source/session/tab (SOURCE_CHANGED when it moved).",
   flags: [
     {
       name: "task-id",
       type: "string",
       placeholder: "ID",
       description: "Target task id (defaults to the active task).",
+    },
+    {
+      name: "tab",
+      type: "string",
+      placeholder: "TAB",
+      description:
+        "Read exactly this terminal tab's hosted session (e.g. tab-3) instead of the canonical engine tab. Terminal-only read; cannot combine with --source history.",
     },
     {
       name: "source",

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -44,8 +44,6 @@ import { findEngineKey, listSessions, openPtyHost } from "./pty-delivery.ts"
 import {
   type Cursor,
   DEFAULT_PAGE_MESSAGES,
-  decodeCursor,
-  encodeCursor,
   type FallbackReason,
   type HistoryCursor,
   MAX_PAGE_MESSAGES,
@@ -55,6 +53,8 @@ import {
   type TerminalPeekPage,
   boundedTail,
   buildHistoryPage,
+  decodeCursor,
+  encodeCursor,
 } from "./read-output-page.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
 import { ApiError, type VerbContext, type VerbSpec } from "./types.ts"

--- a/packages/kobe/test/cli/api-read-output.test.ts
+++ b/packages/kobe/test/cli/api-read-output.test.ts
@@ -66,9 +66,11 @@ function fakeTerminal(pages: {
   text: string
   sinceValid?: boolean
   live?: boolean
-}): { peek: ReadOutputDeps["peekTerminal"]; offsets: Array<number | undefined> } {
+}): { peek: ReadOutputDeps["peekTerminal"]; offsets: Array<number | undefined>; tabs: Array<string | undefined> } {
   const offsets: Array<number | undefined> = []
-  const peek: ReadOutputDeps["peekTerminal"] = async (sinceOffset) => {
+  const tabs: Array<string | undefined> = []
+  const peek: ReadOutputDeps["peekTerminal"] = async (tab, sinceOffset) => {
+    tabs.push(tab)
     offsets.push(sinceOffset)
     return {
       pid: pages.pid,
@@ -78,7 +80,7 @@ function fakeTerminal(pages: {
       live: pages.live ?? true,
     } satisfies TerminalPeekPage
   }
-  return { peek, offsets }
+  return { peek, offsets, tabs }
 }
 
 function deps(history: EngineHistoryReader | null, peekTerminal: ReadOutputDeps["peekTerminal"]): ReadOutputDeps {
@@ -91,6 +93,7 @@ async function read(
     taskId: string
     worktree: string | null
     source: "auto" | "history" | "terminal"
+    tab: string
     cursor: string
     limit: number
   }> = {},
@@ -100,6 +103,7 @@ async function read(
       taskId: over.taskId ?? "t1",
       worktree: over.worktree === undefined ? WORKTREE : over.worktree,
       source: over.source ?? "auto",
+      tab: over.tab,
       cursor: over.cursor,
       limit: over.limit,
     },
@@ -280,6 +284,62 @@ describe("read-output cursor rules", () => {
     expect(decoded).not.toContain(WORKTREE)
     expect(decoded).not.toContain("/")
     expect(JSON.stringify(p)).not.toContain(WORKTREE)
+  })
+})
+
+describe("read-output --tab (tab-precise terminal reads)", () => {
+  it("reads the exact tab without probing history and carries no fallbackReason", async () => {
+    const calls: string[] = []
+    const history = fakeHistory(["s-current"], { "s-current": [msg("hi")] }, calls)
+    const t = fakeTerminal({ pid: 42, offset: 10, text: "tab-3 screen\n" })
+    const p = await read(deps(history, t.peek), { tab: "tab-3" })
+    expect(p.source).toBe("terminal")
+    expect(p.fallbackReason).toBeNull()
+    expect(p.terminal?.tab).toBe("tab-3")
+    expect(p.terminal?.tail).toContain("tab-3 screen")
+    expect(t.tabs).toEqual(["tab-3"])
+    expect(calls).toEqual([])
+  })
+
+  it("--source history --tab is a contradiction: typed BAD_FLAG", async () => {
+    await expectApiError(() => read(deps(null, noTerminal()), { source: "history", tab: "tab-3" }), "BAD_FLAG")
+  })
+
+  it("the cursor pins the tab: same tab pages on, another tab or none is CURSOR_INVALID", async () => {
+    const t1 = fakeTerminal({ pid: 42, offset: 100, text: "one\n" })
+    const p1 = await read(deps(null, t1.peek), { tab: "tab-3" })
+    expect(t1.tabs).toEqual(["tab-3"])
+
+    const t2 = fakeTerminal({ pid: 42, offset: 160, text: "two\n" })
+    const p2 = await read(deps(null, t2.peek), { cursor: p1.cursor ?? undefined, tab: "tab-3" })
+    expect(t2.tabs).toEqual(["tab-3"])
+    expect(t2.offsets).toEqual([100])
+    expect(p2.terminal?.tab).toBe("tab-3")
+
+    await expectApiError(
+      () => read(deps(null, noTerminal()), { cursor: p1.cursor ?? undefined, tab: "tab-4" }),
+      "CURSOR_INVALID",
+    )
+    await expectApiError(() => read(deps(null, noTerminal()), { cursor: p1.cursor ?? undefined }), "CURSOR_INVALID")
+  })
+
+  it("a canonical-tab cursor rejects a later --tab (and vice versa)", async () => {
+    const t1 = fakeTerminal({ pid: 42, offset: 100, text: "one\n" })
+    const p1 = await read(deps(null, t1.peek), { source: "terminal" })
+    expect(t1.tabs).toEqual([undefined])
+    await expectApiError(
+      () => read(deps(null, noTerminal()), { cursor: p1.cursor ?? undefined, tab: "tab-3" }),
+      "CURSOR_INVALID",
+    )
+  })
+
+  it("a history cursor with --tab is CURSOR_INVALID (history is not tab-scoped)", async () => {
+    const history = fakeHistory(["s-current"], { "s-current": [msg("a")] })
+    const p1 = await read(deps(history, noTerminal()))
+    await expectApiError(
+      () => read(deps(history, noTerminal()), { cursor: p1.cursor ?? undefined, tab: "tab-3" }),
+      "CURSOR_INVALID",
+    )
   })
 })
 


### PR DESCRIPTION
Every other `rove api` verb addresses single terminal tabs, but `read-output` could only resolve the task's canonical engine tab — after a `--tab new` respawn (e.g. a kimi session moved to tab-4), the live tab's screen was invisible headlessly.

- `--tab tab-N` peeks exactly that hosted session via `pty.peek` (terminal-only; history is worktree-scoped, so `--source history --tab` is a typed `BAD_FLAG`)
- A tab with no hosted session answers `TAB_NOT_FOUND` instead of an empty read
- The cursor pins the tab alongside the pid — paged reads can't silently hop tabs (`CURSOR_INVALID`)
- The terminal envelope reports the `tab` it read

Tests: 5 new cases in `api-read-output.test.ts` (23/23 pass); lint + typecheck + full `test/cli` (562) green. Changeset: patch.