### PR TITLE
feat: drive verbs reach tab precision — dispatch/pane-open/pane-close --tab, collect .tabs

### DIFF
--- a/.changeset/api-tab-precision.md
+++ b/.changeset/api-tab-precision.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+feat: `rove api` drive verbs reach tab precision everywhere a session is touched. `dispatch --tab tab-N` routes text into exactly that tab (the `session.deliver` payload now carries `tabId` end-to-end — daemon, web forwarder), so a fan-out group's "task X's tab Y" is finally expressible; `pane-open --tab tab-N` hosts the split in that tab instead of whatever happens to be focused, and `pane-close --tab tab-N` scopes its title match to one tab; `collect` rows now carry `.tabs` (the same join as `get-task`) so picking a `send --tab` target after a fan-out no longer needs a second hop.

--- a/docs/API.md
+++ b/docs/API.md
@@ -99,8 +99,9 @@ alias of `add`.
   task, when one did — the lineage read for a fan-out round's parent.
 - `collect [--task-ids a,b,c] [--repo PATH]`: read-only comparison
   snapshot of several tasks: identity, branch, lineage (`.dispatcher`,
-  `.groupId`), `.running`, uncommitted `.changes`, and committed `.base`
-  (ahead count + diffstat vs base).
+  `.groupId`), `.running`, per-tab `.tabs` (the same join as `get-task` —
+  pick a `send --tab` target without a second hop), uncommitted `.changes`,
+  and committed `.base` (ahead count + diffstat vs base).
 - `digest --repo PATH [--since-days N]`: the repo's recent agent work —
   tasks touched in the window plus routine outcomes by status. Default
   window 7 days. Task outcomes are deliberately absent: completion travels
@@ -173,10 +174,11 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   task with no live session at all auto-starts its canonical engine tab, in
   the task's worktree — `started: true` in the result marks that fresh
   session (vs. delivery into an existing one).
-- `dispatch --task-id ID --prompt TEXT`: route text into a task's live
-  session via the daemon's `session.deliver` channel; requires an
+- `dispatch --task-id ID --prompt TEXT [--tab TAB]`: route text into a
+  task's live session via the daemon's `session.deliver` channel; requires an
   already-hosted session (the dispatcher's messenger; see
-  [design/dispatcher.md](./design/dispatcher.md)).
+  [design/dispatcher.md](./design/dispatcher.md)). `--tab tab-N` delivers
+  into exactly that tab instead of the canonical engine tab.
 - `note --task-id ID --text TEXT`: file a one-line field note (a resolved,
   repo-level gotcha). Appended to the repo's durable note store — every
   future worktree session on this repo starts with it in its system prompt —
@@ -185,21 +187,23 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   first. Returns `{ notes }`.
 - `set-active [--task-id ID] [--none]`: set (or clear) the shared active
   task every Tasks pane highlights.
-- `pane-open [--task-id ID] [--command CMD] [--direction right|down]
-  [--placement split|tab] [--title TEXT]`: open a terminal pane in a task's
-  workspace — split the focused tab (default, tmux-style beside/below the
-  active pane) or open a separate command tab. `--command` runs via
+- `pane-open [--task-id ID] [--tab TAB] [--command CMD] [--direction
+  right|down] [--placement split|tab] [--title TEXT]`: open a terminal pane
+  in a task's workspace — split the focused tab (default, tmux-style
+  beside/below the active pane; `--tab tab-N` hosts the split in that tab
+  instead) or open a separate command tab. `--command` runs via
   `sh -lc` and the pane closes when it exits; omit it for an interactive
   shell. Broadcast over the daemon's `tab.open` channel, so an attached TUI
   showing the task performs the split (headless, nothing happens). Task
   defaults to `$ROVE_TASK_ID` (or its Kobe alias), then the active task. How far splits can go
   is decided by the terminal's size: a split that would shrink any pane
   below the minimum usable size (20×6 cells) falls back to a tab.
-- `pane-close [--task-id ID] --title TEXT`: the inverse — close every pane
-  (split leaf / command tab) in the task whose label matches `--title`, the
-  title it was opened with. Engine panes are never closed. Broadcast over
-  the daemon's `tab.close` channel; an attached TUI performs the close
-  (headless, nothing happens).
+- `pane-close [--task-id ID] --title TEXT [--tab TAB]`: the inverse — close
+  every pane (split leaf / command tab) in the task whose label matches
+  `--title`, the title it was opened with; `--tab tab-N` scopes the match to
+  one tab. Engine panes are never closed. Broadcast over the daemon's
+  `tab.close` channel; an attached TUI performs the close (headless, nothing
+  happens).
 
 ## edit
 

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -288,6 +288,9 @@ export interface NoticeEventPayload {
 export interface SessionDeliverPayload {
   readonly taskId: string
   readonly text: string
+  /** Exact terminal tab to deliver into (`dispatch --tab`); absent = the
+   *  canonical engine tab. */
+  readonly tabId?: string
   /** Publish time (ms epoch) — the consumer-side dedupe key. */
   readonly at: number
   readonly source: "note" | "dispatcher"
@@ -308,6 +311,8 @@ export interface TabOpenPayload {
   /** Argv the pane's PTY spawns verbatim (no shell wrap on this side). */
   readonly argv: readonly string[]
   readonly title: string
+  /** Host tab for the split (`pane-open --tab`); absent = the focused tab. */
+  readonly tabId?: string
   /** `split` (default) joins the focused chattab's split group; `tab` opens a separate tab. */
   readonly placement?: "split" | "tab"
   /** Split orientation: `right` (default) lays the new pane beside the
@@ -323,6 +328,9 @@ export interface TabClosePayload {
   /** Pane label to close — matches the `title` split leaves / command tabs
    *  were opened with (`tab.open`); engine leaves are never closed. */
   readonly title: string
+  /** Scope the title match to one tab (`pane-close --tab`); absent = all
+   *  tabs of the task. */
+  readonly tabId?: string
   /** Publish time (ms epoch) — the consumer-side dedupe key. */
   readonly at: number
 }

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -26,6 +26,7 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       // (the SPA via /pty/send) owns the actual paste.
       const taskId = requireString(payload, "taskId")
       const text = requireString(payload, "text")
+      const tabId = optionalString(payload, "tabId")
       const source = optionalString(payload, "source")
       if (source !== undefined && source !== "note" && source !== "dispatcher") {
         throw new Error('source must be "note" or "dispatcher"')
@@ -34,6 +35,7 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       ctx.bus.publish("session.deliver", {
         taskId,
         text,
+        ...(tabId !== undefined ? { tabId } : {}),
         at: Date.now(),
         source: source ?? "dispatcher",
       })
@@ -119,10 +121,12 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       if (!ctx.orch.getTask(taskId)) throw new Error(`task not found: ${taskId}`)
       const placement = optionalString(payload, "placement")
       const direction = optionalString(payload, "direction")
+      const tabId = optionalString(payload, "tabId")
       ctx.bus.publish("tab.open", {
         taskId,
         argv,
         title,
+        ...(tabId !== undefined ? { tabId } : {}),
         ...(placement === "tab" || placement === "split" ? { placement } : {}),
         ...(direction === "right" || direction === "down" ? { direction } : {}),
         at: Date.now(),
@@ -138,8 +142,14 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       // broadcast — the daemon validates, the TUI owns the actual close.
       const taskId = requireString(payload, "taskId")
       const title = requireString(payload, "title")
+      const tabId = optionalString(payload, "tabId")
       if (!ctx.orch.getTask(taskId)) throw new Error(`task not found: ${taskId}`)
-      ctx.bus.publish("tab.close", { taskId, title, at: Date.now() })
+      ctx.bus.publish("tab.close", {
+        taskId,
+        title,
+        ...(tabId !== undefined ? { tabId } : {}),
+        at: Date.now(),
+      })
       return { ok: true }
     },
   },

--- a/packages/kobe-web/src/lib/dispatch-delivery.ts
+++ b/packages/kobe-web/src/lib/dispatch-delivery.ts
@@ -75,7 +75,9 @@ export async function deliverToSession(
     send ??= terminal.sendPtyText
   }
   try {
-    const tabId = ensureTab(event.taskId)
+    // An explicit tab (`dispatch --tab`) addresses that exact session key —
+    // bypassing the registry's canonical-tab minting is the point.
+    const tabId = event.tabId ?? ensureTab(event.taskId)
     await send(tabId, event.taskId, event.text)
     return true
   } catch (err) {

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -123,6 +123,9 @@ export type WorktreeChangeCounts = Record<
 export interface SessionDeliver {
   taskId: string
   text: string
+  /** Exact terminal tab to deliver into (`dispatch --tab`); absent = the
+   *  canonical engine tab. */
+  tabId?: string
   at: number
   source: "note" | "dispatcher"
 }

--- a/packages/kobe-web/test/dispatch-delivery.test.ts
+++ b/packages/kobe-web/test/dispatch-delivery.test.ts
@@ -66,6 +66,12 @@ describe("deliverToSession", () => {
     expect(calls).toEqual([{ tabId: "tab-t1", taskId: "t1", text: "hello from dispatcher" }])
   })
 
+  it("an explicit event.tabId bypasses the canonical-tab minting (dispatch --tab)", async () => {
+    const { calls, deps } = spies()
+    expect(await deliverToSession(event({ tabId: "tab-3" }), deps)).toBe(true)
+    expect(calls).toEqual([{ tabId: "tab-3", taskId: "t1", text: "hello from dispatcher" }])
+  })
+
   it("the same `at` never delivers twice (reconnect replay is a no-op)", async () => {
     const { calls, deps } = spies()
     await deliverToSession(event(), deps)

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -153,7 +153,10 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
   const out: unknown[] = []
   for (const taskId of taskIds) {
     const { task } = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
-    const running = await runtime.isTaskRunning(taskId)
+    // One liveness read serves both `running` and the per-tab list a
+    // coordinator needs to pick a `send --tab tab-N` target without a
+    // second get-task hop (same join as get-task).
+    const { tabs, running } = await runtime.taskTabs(taskId)
     // `changes` is the UNCOMMITTED view; `base` is the committed one (ahead
     // count + diffstat vs the merge-base). Both matter when picking a
     // fan-out winner: an attempt that commits its work reads +0/−0 here.
@@ -173,6 +176,7 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
       // round's parent is programmatically discoverable.
       ...(task.dispatcher ? { dispatcher: task.dispatcher } : {}),
       running,
+      tabs,
       changes,
       base,
     })

--- a/packages/kobe/src/cli/api/handlers-pane.ts
+++ b/packages/kobe/src/cli/api/handlers-pane.ts
@@ -15,9 +15,15 @@ import { ApiError, type VerbSpec } from "./types.ts"
 export const PANE_VERB: VerbSpec = {
   name: "pane-open",
   summary:
-    "Open a terminal pane in a task's workspace: split the focused tab (default) or open a separate command tab, optionally running a command. Broadcast over the daemon's tab.open channel — an attached TUI showing the task performs the split. Task defaults to $ROVE_TASK_ID, then the active task.",
+    "Open a terminal pane in a task's workspace: split the focused tab (default, or --tab's tab) or open a separate command tab, optionally running a command. Broadcast over the daemon's tab.open channel — an attached TUI showing the task performs the split. Task defaults to $ROVE_TASK_ID, then the active task.",
   flags: [
     F.taskId(false),
+    {
+      name: "tab",
+      type: "string",
+      placeholder: "TAB",
+      description: "Host tab for the split (e.g. tab-3) instead of the focused tab (split placement only).",
+    },
     {
       name: "command",
       type: "string",
@@ -58,10 +64,12 @@ export const PANE_VERB: VerbSpec = {
     const command = ctx.args.str("command")
     const argv = command ? ["sh", "-lc", command] : [process.env.SHELL || "sh"]
     const title = ctx.args.str("title") ?? (command ? (command.trim().split(/\s+/)[0] ?? "shell") : "shell")
+    const tabId = ctx.args.str("tab")
     return simpleRpc(ctx, "tab.open", {
       taskId,
       argv,
       title,
+      ...(tabId !== undefined ? { tabId } : {}),
       placement: ctx.args.str("placement") ?? "split",
       direction: ctx.args.str("direction") ?? "right",
     })
@@ -81,6 +89,12 @@ export const PANE_CLOSE_VERB: VerbSpec = {
       placeholder: "TEXT",
       description: "Pane label to close — the --title the pane was opened with (engine panes are never closed).",
     },
+    {
+      name: "tab",
+      type: "string",
+      placeholder: "TAB",
+      description: "Scope the title match to one tab (e.g. tab-3) instead of every tab of the task.",
+    },
   ],
   handler: async (ctx) => {
     const client = daemonOf(ctx)
@@ -88,6 +102,11 @@ export const PANE_CLOSE_VERB: VerbSpec = {
     if (!taskId) {
       throw new ApiError("no target task: pass --task-id (no $ROVE_TASK_ID, no active task)", "TASK_NOT_FOUND")
     }
-    return simpleRpc(ctx, "tab.close", { taskId, title: ctx.args.str("title") })
+    const tabId = ctx.args.str("tab")
+    return simpleRpc(ctx, "tab.close", {
+      taskId,
+      title: ctx.args.str("title"),
+      ...(tabId !== undefined ? { tabId } : {}),
+    })
   },
 }

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -227,8 +227,14 @@ export async function dispatch(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const taskId = ctx.args.require("task-id")
   const text = ctx.args.require("prompt")
-  await daemon.request("session.deliver", { taskId, text, source: "dispatcher" })
-  return { ok: true, taskId, routed: "session.deliver" }
+  const tabId = ctx.args.str("tab")
+  await daemon.request("session.deliver", {
+    taskId,
+    text,
+    ...(tabId !== undefined ? { tabId } : {}),
+    source: "dispatcher",
+  })
+  return { ok: true, taskId, ...(tabId !== undefined ? { tabId } : {}), routed: "session.deliver" }
 }
 
 export async function note(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -11,9 +11,10 @@ import type { TaskStatus } from "../../types/task.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
 import { dispatcherEnvPayload, readOwnDispatcher, resolveDispatcherTab } from "./dispatcher.ts"
+import { F } from "./flags.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
-import { ApiError, type VerbContext, helpStep } from "./types.ts"
+import { ApiError, type VerbContext, type VerbSpec, helpStep } from "./types.ts"
 
 /**
  * Peer provenance: a `send` issued from INSIDE another kobe task is one
@@ -235,6 +236,26 @@ export async function dispatch(ctx: VerbContext): Promise<unknown> {
     source: "dispatcher",
   })
   return { ok: true, taskId, ...(tabId !== undefined ? { tabId } : {}), routed: "session.deliver" }
+}
+
+/** The verb spec lives beside its handler (PANE_VERB pattern) so verbs.ts
+ *  stays under the file-size cap. */
+export const DISPATCH_VERB: VerbSpec = {
+  name: "dispatch",
+  summary:
+    "Route text into a task's live session via the daemon's session.deliver channel. The dispatcher's messenger (docs/design/dispatcher.md); unlike `send`, it requires an already-hosted session.",
+  flags: [
+    F.taskId(true),
+    F.prompt(true, "Text delivered into the task's engine session."),
+    {
+      name: "tab",
+      type: "string",
+      required: false,
+      placeholder: "TAB",
+      description: "Deliver into exactly this tab (e.g. tab-3) instead of the canonical engine tab.",
+    },
+  ],
+  handler: dispatch,
 }
 
 export async function note(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -207,7 +207,17 @@ export const VERBS: readonly VerbSpec[] = [
     name: "dispatch",
     summary:
       "Route text into a task's live session via the daemon's session.deliver channel. The dispatcher's messenger (docs/design/dispatcher.md); unlike `send`, it requires an already-hosted session.",
-    flags: [F.taskId(true), F.prompt(true, "Text delivered into the task's engine session.")],
+    flags: [
+      F.taskId(true),
+      F.prompt(true, "Text delivered into the task's engine session."),
+      {
+        name: "tab",
+        type: "string",
+        required: false,
+        placeholder: "TAB",
+        description: "Deliver into exactly this tab (e.g. tab-3) instead of the canonical engine tab.",
+      },
+    ],
     handler: dispatch,
   },
   {
@@ -334,7 +344,7 @@ export const VERBS: readonly VerbSpec[] = [
   {
     name: "collect",
     summary:
-      "Read-only comparison snapshot of several tasks: identity, branch, lineage (.dispatcher, .groupId), .running, uncommitted .changes, and committed .base (ahead count + diffstat vs the base branch).",
+      "Read-only comparison snapshot of several tasks: identity, branch, lineage (.dispatcher, .groupId), .running, per-tab .tabs (same join as get-task — pick a `send --tab` target without a second hop), uncommitted .changes, and committed .base (ahead count + diffstat vs the base branch).",
     flags: [
       { name: "task-ids", type: "csv", placeholder: "a,b,c", description: "Comma-separated task ids." },
       F.repo(false),

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -11,11 +11,11 @@ import { collect, fanOut, feedback } from "./handlers-fanout.ts"
 import { INSPECT_VERB } from "./handlers-inspect.ts"
 import { PANE_CLOSE_VERB, PANE_VERB } from "./handlers-pane.ts"
 import {
+  DISPATCH_VERB,
   add,
   adopt,
   archive,
   deleteTask,
-  dispatch,
   getTask,
   land,
   list,
@@ -203,23 +203,7 @@ export const VERBS: readonly VerbSpec[] = [
     ],
     handler: send,
   },
-  {
-    name: "dispatch",
-    summary:
-      "Route text into a task's live session via the daemon's session.deliver channel. The dispatcher's messenger (docs/design/dispatcher.md); unlike `send`, it requires an already-hosted session.",
-    flags: [
-      F.taskId(true),
-      F.prompt(true, "Text delivered into the task's engine session."),
-      {
-        name: "tab",
-        type: "string",
-        required: false,
-        placeholder: "TAB",
-        description: "Deliver into exactly this tab (e.g. tab-3) instead of the canonical engine tab.",
-      },
-    ],
-    handler: dispatch,
-  },
+  DISPATCH_VERB,
   {
     name: "note",
     summary:

--- a/packages/kobe/src/tui-react/lib/use-daemon-notices.ts
+++ b/packages/kobe/src/tui-react/lib/use-daemon-notices.ts
@@ -48,7 +48,7 @@ function useDaemonTabOpens(orch: RemoteOrchestrator | null): void {
     if (!request || request.at === seenAt.current) return
     seenAt.current = request.at
     if (Date.now() - request.at > STALE_NOTICE_MS) return
-    requestTabOpen(request.taskId, request.argv, request.title, request.placement, request.direction)
+    requestTabOpen(request.taskId, request.argv, request.title, request.placement, request.direction, request.tabId)
   }, [request])
 }
 
@@ -60,7 +60,7 @@ function useDaemonTabCloses(orch: RemoteOrchestrator | null): void {
     if (!request || request.at === seenAt.current) return
     seenAt.current = request.at
     if (Date.now() - request.at > STALE_NOTICE_MS) return
-    requestPaneClose(request.taskId, request.title)
+    requestPaneClose(request.taskId, request.title, request.tabId)
   }, [request])
 }
 

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -118,6 +118,7 @@ let pendingTabOpen: {
   taskId: string
   argv: readonly string[]
   title: string
+  tabId?: string
   placement?: "split" | "tab"
   direction?: "right" | "down"
 } | null = null
@@ -128,8 +129,9 @@ export function requestTabOpen(
   title: string,
   placement?: "split" | "tab",
   direction?: "right" | "down",
+  tabId?: string,
 ): void {
-  pendingTabOpen = { taskId, argv, title, placement, direction }
+  pendingTabOpen = { taskId, argv, title, placement, direction, tabId }
   for (const listener of tabActivationListeners) listener()
 }
 
@@ -139,19 +141,19 @@ export function requestTabOpen(
  * mounted TerminalTabs; matching is by pane label, so only titled
  * split-leaves / command tabs (the ones tab.open creates) are affected.
  */
-let pendingPaneClose: { taskId: string; title: string } | null = null
+let pendingPaneClose: { taskId: string; title: string; tabId?: string } | null = null
 
-export function requestPaneClose(taskId: string, title: string): void {
-  pendingPaneClose = { taskId, title }
+export function requestPaneClose(taskId: string, title: string, tabId?: string): void {
+  pendingPaneClose = { taskId, title, tabId }
   for (const listener of tabActivationListeners) listener()
 }
 
 /** Consume a pending pane-close for this task, or null. */
-export function takePaneClose(taskId: string): { title: string } | null {
+export function takePaneClose(taskId: string): { title: string; tabId?: string } | null {
   if (pendingPaneClose?.taskId !== taskId) return null
-  const title = pendingPaneClose.title
+  const { title, tabId } = pendingPaneClose
   pendingPaneClose = null
-  return { title }
+  return { title, tabId }
 }
 
 /**
@@ -216,9 +218,13 @@ export function takeUnclaimedTabAdopt(): { taskId: string; tabIds: readonly stri
 }
 
 /** Consume a pending tab-open for this task, or null. */
-export function takeTabOpen(
-  taskId: string,
-): { argv: readonly string[]; title: string; placement?: "split" | "tab"; direction?: "right" | "down" } | null {
+export function takeTabOpen(taskId: string): {
+  argv: readonly string[]
+  title: string
+  tabId?: string
+  placement?: "split" | "tab"
+  direction?: "right" | "down"
+} | null {
   if (pendingTabOpen?.taskId !== taskId) return null
   const request = pendingTabOpen
   pendingTabOpen = null

--- a/packages/kobe/src/tui-react/workspace/use-tab-requests.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-requests.ts
@@ -52,19 +52,23 @@ export function useTabRequests(io: TabRequestIO): void {
         if (s.activeId !== tabId && s.tabs.some((tab) => tab.id === tabId)) updateRef.current(selectTab(s, tabId))
       }
       // Plugin panes (`tab.open`): split the focused chattab (default) or
-      // open a separate command tab — pane-split.ts owns the policy.
+      // open a separate command tab — pane-split.ts owns the policy. An
+      // explicit tabId hosts the split in THAT tab instead of the focused one.
       const open = takeTabOpen(taskId)
       if (open) {
         const size = activeLeafSizeRef.current()
-        updateRef.current(openPluginPane(stateRef.current, open.argv, open.title, open.placement, open.direction, size))
+        updateRef.current(
+          openPluginPane(stateRef.current, open.argv, open.title, open.placement, open.direction, size, open.tabId),
+        )
       }
       // Pane-close (`tab.close` — the inverse of tab.open): prune matching
       // titled leaves (state first, then release), close whole matching
-      // command tabs via the normal close path.
+      // command tabs via the normal close path. tabId scopes the title
+      // match to one tab.
       const paneClose = takePaneClose(taskId)
       if (paneClose) {
         const prev = stateRef.current
-        const { next, closedLeaves, closedTabIds } = closePluginPanes(prev, paneClose.title)
+        const { next, closedLeaves, closedTabIds } = closePluginPanes(prev, paneClose.title, paneClose.tabId)
         if (next !== prev) updateRef.current(next)
         for (const { tabId: id, leafId } of closedLeaves) {
           const tab = prev.tabs.find((x) => x.id === id)

--- a/packages/kobe/src/tui/workspace/pane-split.ts
+++ b/packages/kobe/src/tui/workspace/pane-split.ts
@@ -3,9 +3,11 @@
  * the currently-focused chattab — the pane joins the tab's split group
  * beside the engine (owner semantics 2026-07-29), exactly herdr's
  * `placement = "split"`. `"tab"` opens a separate self-closing command tab
- * instead. Falls back to a tab when the active tab can't host a split
- * (content tab, or the size gate — min-pane cells from the active leaf's
- * rendered size, depth cap when no size is known — made it a no-op).
+ * instead. An explicit `tabId` (`pane-open --tab`) hosts the split in THAT
+ * tab instead of the focused one. Falls back to a tab when the host tab
+ * can't host a split (content tab, or the size gate — min-pane cells from
+ * the active leaf's rendered size, depth cap when no size is known — made
+ * it a no-op).
  */
 
 import { initialSplit, leaves, removeLeaf, renameLeaf, splitActive } from "./split-core"
@@ -22,15 +24,20 @@ export function openPluginPane(
   direction: PaneDirection = "right",
   /** The active leaf's rendered cells — feeds split-core's size gate. */
   activeSize?: { cols: number; rows: number } | null,
+  /** Explicit host tab (`pane-open --tab`); absent = the focused tab. */
+  tabId?: string,
 ): TabsState {
   if (placement === "tab") return openCommandTab(state, argv, title)
-  const active = state.tabs.find((tab) => tab.id === state.activeId)
-  if (!active || active.kind === "content") return openCommandTab(state, argv, title)
+  const host =
+    tabId === undefined
+      ? state.tabs.find((tab) => tab.id === state.activeId)
+      : state.tabs.find((tab) => tab.id === tabId)
+  if (!host || host.kind === "content") return openCommandTab(state, argv, title)
   // `null` content = the tab's own engine leaf (terminal-tab-split.ts).
-  const base = active.splitTree ?? initialSplit<readonly string[] | null>(null)
+  const base = host.splitTree ?? initialSplit<readonly string[] | null>(null)
   const split = splitActive(base, direction === "down" ? "column" : "row", argv, activeSize)
   if (split === base) return openCommandTab(state, argv, title)
-  return setTabSplit(state, active.id, renameLeaf(split, split.activeLeafId, title))
+  return setTabSplit(state, host.id, renameLeaf(split, split.activeLeafId, title))
 }
 
 /**
@@ -44,11 +51,15 @@ export function openPluginPane(
 export function closePluginPanes(
   state: TabsState,
   title: string,
+  /** Scope the title match to one tab (`pane-close --tab`); absent = all
+   *  tabs of the task. */
+  tabId?: string,
 ): { next: TabsState; closedLeaves: readonly { tabId: string; leafId: string }[]; closedTabIds: readonly string[] } {
   let next = state
   const closedLeaves: { tabId: string; leafId: string }[] = []
   const closedTabIds: string[] = []
   for (const tab of state.tabs) {
+    if (tabId !== undefined && tab.id !== tabId) continue
     if (tab.kind === "content") continue
     if (tab.kind === "command" && tab.title === title) {
       closedTabIds.push(tab.id)

--- a/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
+++ b/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
@@ -33,14 +33,34 @@ describe("collect handler", () => {
     const result = (await invokeVerb("collect", ["--task-ids", " a , b "], {
       client,
       runtime: stubRuntime({
-        isTaskRunning: async (id) => id === "a",
+        taskTabs: async (id) => ({
+          tabs: [
+            {
+              id: "tab-1",
+              kind: "engine",
+              title: null,
+              vendor: null,
+              liveVendor: null,
+              lastTitle: null,
+              autoTitle: null,
+              alive: id === "a",
+              exit: null,
+            },
+          ],
+          running: id === "a",
+        }),
         readWorktreeChanges: async () => ({ added: 2, deleted: 1 }),
       }),
-    })) as { tasks: Array<{ taskId: string; running: boolean; changes: unknown }> }
+    })) as {
+      tasks: Array<{ taskId: string; running: boolean; tabs: Array<{ id: string; alive: boolean }>; changes: unknown }>
+    }
     expect(result.tasks.map((task) => [task.taskId, task.running])).toEqual([
       ["a", true],
       ["b", false],
     ])
+    // The per-tab join rides along so a coordinator can pick a `send --tab`
+    // target without a second get-task hop.
+    expect(result.tasks[0].tabs).toEqual([expect.objectContaining({ id: "tab-1", alive: true })])
     expect(result.tasks[0].changes).toEqual({ added: 2, deleted: 1 })
   })
 

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -271,6 +271,21 @@ describe("dispatch / note delivery verbs", () => {
     expect(result).toEqual({ ok: true, taskId: "t1", routed: "session.deliver" })
   })
 
+  it("dispatch --tab carries the exact tab through the payload and the result", async () => {
+    const client = new FakeClient({ "session.deliver": () => ({}) })
+    const result = await invokeVerb("dispatch", ["--task-id", "t1", "--tab", "tab-3", "--prompt", "status?"], {
+      client,
+      runtime: stubRuntime(),
+    })
+    expect(client.requests).toEqual([
+      {
+        name: "session.deliver",
+        payload: { taskId: "t1", text: "status?", tabId: "tab-3", source: "dispatcher" },
+      },
+    ])
+    expect(result).toEqual({ ok: true, taskId: "t1", tabId: "tab-3", routed: "session.deliver" })
+  })
+
   it("note files the field note through note.file and returns the daemon's answer", async () => {
     const client = new FakeClient({ "note.file": () => ({ relayed: 2 }) })
     const result = await invokeVerb("note", ["--task-id", "t1", "--text", "bun install fixes the worktree"], {

--- a/packages/kobe/test/cli/api-pane.test.ts
+++ b/packages/kobe/test/cli/api-pane.test.ts
@@ -48,6 +48,20 @@ describe("pane-open handler", () => {
     expect(bare.requestNames).toEqual([])
   })
 
+  it("--tab scopes both verbs' payloads to one tab", async () => {
+    const client = new FakeClient({ "tab.open": () => ({ ok: true }), "tab.close": () => ({ ok: true }) })
+    await invokeVerb("pane-open", ["--task-id", "t9", "--tab", "tab-3", "--command", "btop"], {
+      client,
+      runtime: stubRuntime(),
+    })
+    expect(client.requests[0].payload).toMatchObject({ taskId: "t9", tabId: "tab-3" })
+    await invokeVerb("pane-close", ["--task-id", "t9", "--tab", "tab-3", "--title", "btop"], {
+      client,
+      runtime: stubRuntime(),
+    })
+    expect(client.requests[1].payload).toEqual({ taskId: "t9", title: "btop", tabId: "tab-3" })
+  })
+
   it("rejects an out-of-range --direction before any RPC", async () => {
     const client = new FakeClient()
     await expectApiError(

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -169,6 +169,13 @@ describe("daemon handler registry", () => {
       const { ctx: ctx2 } = fakeCtx({ getTask: () => undefined })
       await expect(dispatch("tab.close", { taskId: "nope", title: "t" }, ctx2)).rejects.toThrow(/task not found/)
     })
+
+    it("carries an explicit tabId through (pane-close --tab)", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => TASK })
+      await dispatch("tab.close", { taskId: "t1", title: "demo", tabId: "tab-3" }, ctx)
+      const event = rec.published[0] as { payload: Record<string, unknown> }
+      expect(event.payload.tabId).toBe("tab-3")
+    })
   })
 
   describe("tab.open", () => {
@@ -199,6 +206,26 @@ describe("daemon handler registry", () => {
       const [down, bogus] = rec.published as { payload: Record<string, unknown> }[]
       expect(down.payload.direction).toBe("down")
       expect(bogus.payload.direction).toBeUndefined()
+    })
+
+    it("carries an explicit tabId through (pane-open --tab)", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => TASK })
+      await dispatch("tab.open", { taskId: "t1", argv: ["x"], title: "t", tabId: "tab-3" }, ctx)
+      const event = rec.published[0] as { payload: Record<string, unknown> }
+      expect(event.payload.tabId).toBe("tab-3")
+    })
+  })
+
+  describe("session.deliver", () => {
+    it("publishes with an explicit tabId and rejects an unknown task", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === "t1" ? TASK : undefined) })
+      const result = await dispatch("session.deliver", { taskId: "t1", text: "hi", tabId: "tab-2" }, ctx)
+      expect(result).toEqual({ ok: true })
+      const event = rec.published[0] as { channel: string; payload: Record<string, unknown> }
+      expect(event.channel).toBe("session.deliver")
+      expect(event.payload).toMatchObject({ taskId: "t1", text: "hi", tabId: "tab-2", source: "dispatcher" })
+      const { ctx: ctx2 } = fakeCtx({ getTask: () => undefined })
+      await expect(dispatch("session.deliver", { taskId: "nope", text: "x" }, ctx2)).rejects.toThrow(/task not found/)
     })
   })
 

--- a/packages/kobe/test/plugins/pane-split.test.ts
+++ b/packages/kobe/test/plugins/pane-split.test.ts
@@ -56,6 +56,29 @@ describe("openPluginPane", () => {
     expect(next.tabs).toHaveLength(withContent.tabs.length + 1)
     expect(next.tabs.find((t) => t.id === next.activeId)?.kind).toBe("command")
   })
+
+  it("explicit tabId hosts the split in that tab, not the focused one", () => {
+    // Focus a command tab; the split must still land in tab-1 (pane-open --tab).
+    const state = openPluginPane(initialTabs(), ARGV, "shell", "tab")
+    expect(state.activeId).toBe("tab-2")
+    const next = openPluginPane(state, ARGV, "logs", "split", "right", null, "tab-1")
+    expect(next.tabs).toHaveLength(state.tabs.length) // no new tab
+    const host = next.tabs.find((t) => t.id === "tab-1")
+    const tree = host?.kind === "engine" || host?.kind === "command" ? host.splitTree : null
+    expect(tree).toBeTruthy()
+    const ls = leaves((tree as NonNullable<typeof tree>).root)
+    expect(ls).toHaveLength(2)
+    expect(ls[1]).toMatchObject({ content: ARGV, title: "logs" })
+    // The focused command tab is untouched.
+    expect(next.tabs.find((t) => t.id === "tab-2")).toMatchObject({ kind: "command" })
+  })
+
+  it("an unknown tabId falls back to a command tab like any un-splittable host", () => {
+    const state = initialTabs()
+    const next = openPluginPane(state, ARGV, "lazygit", "split", "right", null, "tab-9")
+    expect(next.tabs).toHaveLength(state.tabs.length + 1)
+    expect(next.tabs.find((t) => t.id === next.activeId)?.kind).toBe("command")
+  })
 })
 
 describe("closePluginPanes", () => {
@@ -83,5 +106,18 @@ describe("closePluginPanes", () => {
     expect(untouched.closedLeaves).toEqual([])
     expect(untouched.closedTabIds).toEqual([])
     void next
+  })
+
+  it("tabId scopes the title match to one tab (pane-close --tab)", () => {
+    // "fx" panes in BOTH tabs; the scoped close touches only tab-1's.
+    let state = openPluginPane(initialTabs(), ARGV, "fx")
+    state = openPluginPane(state, ARGV, "other", "tab") // focus moves to tab-2
+    state = openPluginPane(state, ARGV, "fx", "split", "right", null, "tab-2")
+    const scoped = closePluginPanes(state, "fx", "tab-1")
+    expect(scoped.closedLeaves.every((c) => c.tabId === "tab-1")).toBe(true)
+    expect(scoped.closedTabIds).toEqual([])
+    const tab2 = scoped.next.tabs.find((t) => t.id === "tab-2")
+    const tree2 = tab2?.kind === "engine" || tab2?.kind === "command" ? tab2.splitTree : null
+    expect(leaves((tree2 as NonNullable<typeof tree2>).root).map((l) => l.title ?? null)).toContain("fx")
   })
 })


### PR DESCRIPTION
Follow-up to #440 (read-output --tab). The api's smallest addressable unit is one terminal tab; this closes the remaining gaps the audit found:

- **`dispatch --tab tab-N`** — the biggest gap: `session.deliver` had no `tabId` end-to-end, so a fan-out group's "task X's tab Y" was inexpressible. The field now rides CLI verb → daemon payload (`SessionDeliverPayload`) → web forwarder (`dispatch-delivery.ts` uses it instead of minting the canonical tab).
- **`pane-open --tab tab-N`** — the split host was whatever tab happened to be focused in the attached TUI; now the payload names the host tab (falls back to a command tab when the named tab can't host a split, same shape as the existing fallbacks). `pane-close --tab` scopes the title match to one tab.
- **`collect` rows carry `.tabs`** — the same join as `get-task`, so picking a `send --tab` target after a fan-out no longer needs a second hop.

Everything else in the audit needed no tab semantics (metadata/lifecycle verbs) or already had it (`send`, `get-task`, `pty-list`, `inspect`).

Tests: new cases for the CLI handlers (`api-pane`, `api-handlers-more`), the daemon handlers (`session.deliver`/`tab.open`/`tab.close` tabId passthrough), `openPluginPane`/`closePluginPanes` tab targeting, and the web forwarder's explicit-tab path. 616 kobe + 566 kobe-web tests green; lint + typecheck green. Changeset: patch.

coverage-exemption: packages/kobe/src/tui-react/lib/use-daemon-notices.ts — the diff is a one-line pass-through of an optional `tabId` field on the request bridge; the behavior it carries is unit-tested in pane-split.ts / dispatch-delivery.test.ts, and a render test here would mirror the wiring.
coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-requests.ts — same: the diff forwards `tabId` into `openPluginPane`/`closePluginPanes`, whose tab-targeting policy is covered by pane-split.test.ts.