### PR TITLE
feat: freeze and restore hosted PTY sessions across host restarts

### DIFF
--- a/.changeset/pty-host-freeze-restore.md
+++ b/.changeset/pty-host-freeze-restore.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+fix: a pty-host restart no longer takes the terminal work scene with it. The host now freezes every session's metadata and scrollback ring to `<home>/.kobe/pty-sessions/` (throttled while streaming, on exit, and at shutdown), and a restarted host — after a crash, a machine reboot, or an idle-exit — thaws each session as a dead "restored" corpse: reattaching replays the old screen and respawns the launch command in place. Engine tabs compose with the existing dead-reattach `--resume`, so the conversation comes back too. CLI-started sessions (`rove api add`/`send`) now pin their claude conversation id up front and record it in the tab snapshot once started, making headless tasks resumable the same way. `rove reset` keeps its starts-fresh contract by wiping the store, and explicitly closed/archived sessions drop their record — an intentional end is never resurrected. Design: `docs/design/pty-freeze.md`.

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -1,7 +1,8 @@
 # Sessions: what survives what
 
-Short answer: **quitting Rove stops nothing.** Only a reboot or an explicit
-`rove reset` ends your running sessions.
+Short answer: **quitting Rove stops nothing.** A reboot ends the running
+processes but restores their screens and relaunches them on attach; only an
+explicit `rove reset` starts truly fresh.
 
 ## What survives
 
@@ -10,14 +11,19 @@ Short answer: **quitting Rove stops nothing.** Only a reboot or an explicit
 | Quit the TUI | ✓ | ✓ | ✓ | ✓ |
 | Drop your SSH connection | ✓ | ✓ | ✓ | ✓ |
 | `rove daemon restart` | ✓ | ✓ | ✓ | ✓ |
-| Reboot, or `rove reset` | — | — | ✓ | ✓ resumable |
+| Reboot, or the pty-host dies | — relaunched on attach | ✓ restored | ✓ | ✓ resumable |
+| `rove reset` | — | — | ✓ | ✓ resumable |
 
 ![The TUI detaches while the engine process, scrollback ring, and task list stay lit below](assets/detach-survives.png)
 
 The first three rows are the whole point: the TUI is a viewport, and the
-daemon is replaceable. The last row is the hard boundary — nothing keeps
-processes alive across a reboot, and raw terminal output is never written to
-disk. Your *conversations* still come back, because the engine wrote them.
+daemon is replaceable. The fourth row is the freeze/restore contract: nothing
+keeps processes alive across a reboot, but the PTY host persists every
+session's metadata and scrollback to disk, so the next boot puts your screen
+back and relaunches the session's command when you look at it. Your
+*conversations* come back either way, because the engine wrote them. The last
+row is the hard boundary — `rove reset` is the deliberate teardown, and it
+wipes the frozen sessions too.
 
 ## Why: three processes, three lifetimes
 
@@ -58,7 +64,14 @@ flowchart TB
   scrollback. It's deliberately a *separate* process from the daemon, so a
   daemon restart never kills a running engine. Like the tmux server, it exits
   on its own only after sitting at zero live sessions. `rove reset` is the
-  explicit teardown.
+  explicit teardown. While it runs, it freezes every session (metadata +
+  scrollback ring) to `<home>/.kobe/pty-sessions/` — throttled to one write
+  per few seconds while streaming, immediately on exit, and in full at
+  shutdown. A host that comes back up (after a crash, a reboot, an idle-exit)
+  thaws each record into a dead *restored* session: reattaching replays the
+  old screen and respawns the command in place. Closing a tab, archiving a
+  task, or `rove reset` deletes the record instead — an intentional end is
+  never resurrected.
 
 ## Detaching and reattaching
 
@@ -86,8 +99,9 @@ local to each one.
 Two buffers, both bounded:
 
 - **What a reattach replays** — the PTY host keeps ~512 KiB of recent output
-  per session, in memory only. When the host ends (reboot, `rove reset`), it's
-  gone.
+  per session. The live copy is in memory, but the host also freezes it to
+  disk (see above), so a host restart or reboot restores it with the session.
+  Only `rove reset` throws it away.
 - **How far you can scroll** — `terminal.scrollbackRows` in Settings →
   General → Terminal, default 1000 rows. Applies to terminals started after
   the change.
@@ -128,8 +142,10 @@ your TUI is attached to.
 
 Stated plainly so this page doesn't overpromise:
 
-- **Surviving a reboot with processes intact.** Tasks, worktrees, and
-  conversations come back from disk; running processes and scrollback don't.
+- **Surviving a reboot with processes intact.** Tasks, worktrees, scrollback,
+  and conversations come back from disk, and sessions relaunch on attach —
+  but the processes themselves die with the machine; any in-flight execution
+  state inside them is gone.
 - **Attaching from another machine.** The sockets are local only. Running the
   TUI over SSH works because both ends are on the same host; there's no
   native remote attach.

--- a/docs/design/pty-freeze.md
+++ b/docs/design/pty-freeze.md
@@ -1,0 +1,76 @@
+# PTY host freeze/restore — surviving a host restart
+
+> Design note (2026-08-15). The problem: the standalone PTY host
+> (`kobe-daemon/src/daemon/pty-server.ts`) keeps every session's metadata and
+> scrollback ring **in memory only**, so while a `rove daemon restart` is
+> harmless (separate process), the host process itself ending — crash,
+> SIGTERM, machine reboot — took the whole work scene with it. The next host
+> came up empty: `pty.list` showed nothing, a reattach spawned a blank
+> shell/engine, and only the engine's own conversation file was recoverable.
+
+## Decision
+
+Freeze every session to disk, restore lazily, respawn on attach. No attempt
+to keep processes alive across a host death (that needs fd-passing/CRIU-class
+tricks — rejected as not worth it, same call as the original daemon doc).
+
+- **Freeze** (`pty-freeze-store.ts`): one JSON file per session under
+  `<home>/.kobe/pty-sessions/<urlencoded-key>.json` — key, cwd, launch
+  command, size, title, monotonic byte offset, exit record, and the ring
+  buffer (base64, already capped at ~512 KiB). Written at most once per 5s
+  per session while streaming (crash-loss bound), immediately on exit, and
+  for every session during `shutdown()`. Atomic tmp+rename; every operation
+  is best-effort — a freeze hiccup must never take the terminal down.
+- **Restore**: at boot (before listen) the host thaws each record into a
+  dead session marked `restored`, ring intact. It stays a corpse — zero
+  live sessions still idle-exit, and nothing spawns engines the user isn't
+  looking at (a boot must not fan out 20 claude sessions' worth of quota).
+- **Respawn-on-open** (`pty-host.ts`): opening a `restored` session restarts
+  the child **in place** — the old ring is replayed first, live output
+  appends after it, `totalBytes` keeps counting. The caller's spawn spec
+  wins when it carries a command: the TUI's dead-reattach already passes
+  its `--resume <sessionId>` launch (`engineTabArgv`), so engine
+  conversation resume composes with scrollback restore with no TUI change.
+  A failed respawn clears `restored` and degrades to the ordinary view-only
+  corpse behavior (the one-shot resume guard TUI-side stays the backstop).
+- **Forgetting**: explicit `pty.kill` (tab close, archive sweep) drops the
+  record — an intentional end is not a restart casualty. `rove reset`'s
+  graceful `daemon.stop` wipes the whole store ("starts fresh"); a bare
+  SIGTERM/crash/reboot keeps it.
+
+## What changed outside the host
+
+- `pty.open` gained `respawned?: boolean` (distinct from `created`): the
+  respawned launch DID consume the caller's spec, so a prompt embedded in
+  its argv must not be pasted a second time (`pty-delivery.ts`).
+- `pty.list` rows gained `restored?: boolean`; headless delivery
+  (`deliverHostedPrompt`) no longer kills a restored canonical corpse before
+  opening — the open respawns it, keeping scrollback.
+- CLI-started sessions (`rove api add`/`send`) now pin their conversation id
+  up front (`withClaudeSessionId`, the TUI's existing contract) and record
+  `sessionId` + `spawned` in the persisted tab snapshot once the session
+  provably started — so a headless task's engine conversation is resumable
+  after a host restart exactly like a TUI-spawned tab. `send` itself still
+  starts a fresh conversation (a `--resume` of a never-conversed id errors
+  hard; the snapshot only records ids of sessions that started).
+
+## Boundaries kept
+
+- The host stays vendor-neutral: it persists and re-runs launch lines; the
+  `--resume` decision lives in the engine-aware layers (TUI argv builder).
+- The warm spare (`::spare`) never freezes (internal key, same rule as the
+  exit store).
+- `pty-exits.json` (death diagnostics) and the freeze store stay separate:
+  one answers "how did it die", the other "put the scene back".
+
+## Tests
+
+- `test/daemon/pty-freeze-store.test.ts` — record round-trip, corruption
+  tolerance, cap trim, drop/clear semantics.
+- `test/daemon/pty-host-freeze.test.ts` — fake-driver host semantics:
+  throttle, respawn-in-place, spec-wins, failed-respawn degrade, kill-drops,
+  shutdown-keeps.
+- `test/daemon/pty-server-restart.test.ts` — real socket server across a
+  restart: corpse listed, respawn on open, `daemon.stop` wipes.
+- `test/render/pty-freeze.test.ts` — real `/bin/cat` PTY + real file store,
+  end to end.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -46,6 +46,7 @@
     "./daemon/pty-driver": "./src/daemon/pty-driver.ts",
     "./daemon/pty-env": "./src/daemon/pty-env.js",
     "./daemon/pty-exit-store": "./src/daemon/pty-exit-store.ts",
+    "./daemon/pty-freeze-store": "./src/daemon/pty-freeze-store.ts",
     "./daemon/pty-host": "./src/daemon/pty-host.ts",
     "./daemon/pty-host-types": "./src/daemon/pty-host-types.ts",
     "./daemon/pty-live-hold": "./src/daemon/pty-live-hold.ts",

--- a/packages/kobe-daemon/src/daemon/paths.ts
+++ b/packages/kobe-daemon/src/daemon/paths.ts
@@ -212,3 +212,10 @@ export function defaultPtyHostLogPath(homeDir = readRoveEnv("HOME_DIR") ?? homed
 export function defaultPtyExitsPath(homeDir = readRoveEnv("HOME_DIR") ?? homedir()): string {
   return join(homeDir, COMPAT_STATE_DIR_BASENAME, "pty-exits.json")
 }
+
+/** Frozen live-session snapshots (`pty-freeze-store.ts`) — one JSON file per
+ *  session key, so a host restart (crash, reboot) can hand every session's
+ *  metadata + scrollback back to the next host incarnation. */
+export function defaultPtyFreezeDir(homeDir = readRoveEnv("HOME_DIR") ?? homedir()): string {
+  return join(homeDir, COMPAT_STATE_DIR_BASENAME, "pty-sessions")
+}

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -346,6 +346,13 @@ export interface PtyOpenResult {
    *  warm-shell adoption) — the client's cue that `initialInput` may be
    *  typed. False on reattach; absent from pre-warm hosts. */
   readonly created?: boolean
+  /** True when THIS open respawned a freeze-restored corpse in place:
+   *  `replay` is the pre-restart scrollback and the child is brand new
+   *  (the caller's launch spec won — e.g. the TUI's engine `--resume`).
+   *  Distinct from `created` because the spawn spec was NOT swallowed by
+   *  a live session: a prompt embedded in the launch argv DID ride it,
+   *  so the caller must not also paste it. Absent from pre-freeze hosts. */
+  readonly respawned?: boolean
   /** Monotonic per-session byte offset at attach time (total bytes the
    *  child has ever written). A client that detaches records it and asks
    *  the next `pty.open` for only the delta via `sinceOffset`; absent

--- a/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
@@ -1,0 +1,218 @@
+/**
+ * Freeze/restore persistence for hosted PTY sessions.
+ *
+ * The host keeps every session's scrollback ring in memory, so the host
+ * process ending (crash, machine reboot, SIGTERM) used to take the whole
+ * work scene with it: dead children are expected, but the session table
+ * and every byte of scrollback evaporated too, and the next host came up
+ * knowing nothing. This store is the freeze half of the fix: one small
+ * JSON file per session under `<home>/.kobe/pty-sessions/`, holding
+ * everything a LATER host incarnation needs to put the session back —
+ * metadata (key, cwd, launch command, size, title, byte offsets) plus the
+ * ring buffer itself.
+ *
+ * Restore is LAZY and lossy-by-design: a thawed session comes back as a
+ * dead "restored" corpse with its scrollback intact, and the first
+ * `pty.open` respawns the child in place (see `pty-host.ts`). Nothing
+ * pretends a dead process can be resurrected — the contract is "your
+ * screen and your launch line survive the host, your conversation
+ * survives via the engine's own resume".
+ *
+ * Write discipline: atomic tmp+rename per session file, everything
+ * best-effort (a freeze hiccup must never take the terminal down), one
+ * file per session so a flush rewrites only what drifted. Explicitly
+ * killed sessions (`pty.kill`, the archive sweep) drop their record — a
+ * close the user asked for is not a restart casualty. `rove reset`'s
+ * graceful stop clears the whole directory ("starts fresh" is reset's
+ * contract); a bare SIGTERM / crash / reboot leaves it for the next host.
+ */
+
+import { mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { StringDecoder } from "node:string_decoder"
+import { defaultPtyFreezeDir } from "./paths.ts"
+import type { PtySessionExit } from "./protocol.ts"
+import type { PtySessionState } from "./pty-host-types.ts"
+
+/** Record format version — unknown versions read as absent (forward-safe). */
+const FREEZE_VERSION = 1
+
+/** One session, frozen. The ring rides base64; offsets stay monotonic. */
+export interface FrozenPtySession {
+  readonly v: number
+  readonly key: string
+  readonly cwd: string
+  readonly command: readonly string[]
+  readonly cols: number
+  readonly rows: number
+  readonly title: string
+  /** Same monotonic total the live session tracked — restored sessions
+   *  continue it, so a client's parked offset stays comparable. */
+  readonly totalBytes: number
+  /** How the child died when it did; null for a host-death casualty. */
+  readonly exit: PtySessionExit | null
+  readonly ringB64: string
+  readonly updatedAt: string
+}
+
+/** Durable-snapshot sink `PtyHost` reports freezeable moments to. */
+export interface PtyFreezeSink {
+  save(record: FrozenPtySession): void
+  drop(key: string): void
+}
+
+/** The session fields a snapshot needs (structural — `PtySessionState`
+ *  satisfies it, tests can fake it). */
+export interface FreezeableSession {
+  readonly key: string
+  readonly cwd: string
+  readonly command: readonly string[]
+  readonly cols: number
+  readonly rows: number
+  readonly title: string
+  readonly totalBytes: number
+  readonly exit: PtySessionExit | null
+  readonly chunks: readonly Buffer[]
+  readonly bytes: number
+}
+
+/** Session state → its durable record. Pure. */
+export function freezeSession(session: FreezeableSession, now = new Date()): FrozenPtySession {
+  return {
+    v: FREEZE_VERSION,
+    key: session.key,
+    cwd: session.cwd,
+    command: [...session.command],
+    cols: session.cols,
+    rows: session.rows,
+    title: session.title,
+    totalBytes: session.totalBytes,
+    exit: session.exit,
+    ringB64: Buffer.concat(session.chunks as Buffer[]).toString("base64"),
+    updatedAt: now.toISOString(),
+  }
+}
+
+/**
+ * Record → ring buffers, trimmed to `cap` bytes from the FRONT (the tail
+ * is what a reattach repaints). Returns null for a malformed ring. A newer
+ * host with a smaller cap than the freezing host still restores safely.
+ */
+export function thawRing(record: FrozenPtySession, cap: number): { chunks: Buffer[]; bytes: number } | null {
+  let ring: Buffer
+  try {
+    ring = Buffer.from(record.ringB64, "base64")
+  } catch {
+    return null
+  }
+  const trimmed = ring.byteLength > cap ? ring.subarray(ring.byteLength - cap) : ring
+  return { chunks: trimmed.byteLength > 0 ? [trimmed] : [], bytes: trimmed.byteLength }
+}
+
+/**
+ * Record → a restored session state: dead, ring intact, marked `restored`
+ * so the host's next `open` respawns the child in place instead of treating
+ * it as a view-only corpse. Null for a malformed ring.
+ */
+export function thawSession(record: FrozenPtySession, cap: number): PtySessionState | null {
+  const ring = thawRing(record, cap)
+  if (!ring) return null
+  return {
+    key: record.key,
+    cwd: record.cwd,
+    proc: null,
+    alive: false,
+    chunks: [...ring.chunks],
+    bytes: ring.bytes,
+    totalBytes: Math.max(record.totalBytes, ring.bytes),
+    cols: record.cols,
+    rows: record.rows,
+    command: record.command,
+    title: record.title,
+    titleCarry: "",
+    titleDecoder: new StringDecoder("utf8"),
+    sinks: new Map(),
+    parked: false,
+    parkedScreenBytes: 0,
+    exit: record.exit,
+    restored: true,
+    lastFreezeAtMs: 0,
+  }
+}
+
+/** `taskId::tab-1` → a filename every filesystem tolerates. */
+function recordFile(dir: string, key: string): string {
+  return join(dir, `${encodeURIComponent(key)}.json`)
+}
+
+function parseRecord(raw: string): FrozenPtySession | null {
+  try {
+    const parsed = JSON.parse(raw) as FrozenPtySession
+    if (parsed?.v !== FREEZE_VERSION) return null
+    if (typeof parsed.key !== "string" || parsed.key.length === 0) return null
+    if (parsed.key.startsWith("::")) return null // internal keys never freeze
+    if (typeof parsed.cwd !== "string" || !Array.isArray(parsed.command)) return null
+    if (typeof parsed.ringB64 !== "string" || typeof parsed.totalBytes !== "number") return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/** Every restorable record in `dir`; missing/corrupt entries read as none. */
+export function loadFrozenSessions(dir = defaultPtyFreezeDir()): FrozenPtySession[] {
+  let names: string[]
+  try {
+    names = readdirSync(dir)
+  } catch {
+    return []
+  }
+  const out: FrozenPtySession[] = []
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue
+    try {
+      const record = parseRecord(readFileSync(join(dir, name), "utf8"))
+      if (record) out.push(record)
+    } catch {
+      // One unreadable file must not cost the rest.
+    }
+  }
+  return out
+}
+
+/** The real sink: per-session atomic files under `dir`. Never throws. */
+export function fileFreezeSink(dir = defaultPtyFreezeDir()): PtyFreezeSink {
+  return {
+    save(record) {
+      try {
+        mkdirSync(dir, { recursive: true })
+        const target = recordFile(dir, record.key)
+        const staging = `${target}.${process.pid}.tmp`
+        writeFileSync(staging, JSON.stringify(record), "utf8")
+        renameSync(staging, target)
+      } catch {
+        /* best-effort by contract — a freeze hiccup never kills the terminal */
+      }
+    },
+    drop(key) {
+      try {
+        rmSync(recordFile(dir, key), { force: true })
+      } catch {
+        /* absent is the desired end state anyway */
+      }
+    },
+  }
+}
+
+/**
+ * Wipe every frozen session — `rove reset`'s graceful pty-host stop only.
+ * An explicit teardown is not a restart: the next host must come up empty,
+ * not resurrect sessions reset was asked to end.
+ */
+export function clearFrozenSessions(dir = defaultPtyFreezeDir()): void {
+  try {
+    rmSync(dir, { recursive: true, force: true })
+  } catch {
+    /* already gone */
+  }
+}

--- a/packages/kobe-daemon/src/daemon/pty-host-types.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host-types.ts
@@ -1,8 +1,10 @@
 /** PtyHost's public contract types — split from `pty-host.ts` for the
  *  file-size cap; behavior and ownership stay with the host. */
 
-import type { DaemonFrame } from "./protocol.ts"
-import type { PtyDriver } from "./pty-driver.ts"
+import type { StringDecoder } from "node:string_decoder"
+import type { DaemonFrame, PtySessionExit } from "./protocol.ts"
+import type { PtyChild, PtyDriver } from "./pty-driver.ts"
+import type { PtyFreezeSink } from "./pty-freeze-store.ts"
 import type { PtySessionEndInfo } from "./pty-observability.ts"
 
 /** Everything `pty.open` needs to spawn a session's child on first open. */
@@ -28,6 +30,10 @@ export interface PtyAttachResult {
   readonly pid: number | null
   /** True when this open spawned/adopted the session — see `PtyOpenResult.created`. */
   readonly created: boolean
+  /** True when this open RESPAWNED a freeze-restored corpse in place — the
+   *  replay is the pre-restart scrollback and the child is new. See
+   *  `PtyOpenResult.respawned`. */
+  readonly respawned: boolean
   /** Monotonic byte offset at attach — see `PtyOpenResult.offset`. */
   readonly offset: number
   /** `replay` is the exact delta since the request's `sinceOffset` — see `PtyOpenResult.sinceValid`. */
@@ -37,6 +43,52 @@ export interface PtyAttachResult {
 /** Writes one event frame to an attached connection. */
 export type PtySink = (frame: DaemonFrame) => void
 
+/**
+ * One hosted session's full mutable state. Lives here (not in pty-host.ts)
+ * so the freeze store (`pty-freeze-store.ts`) can convert it to/from its
+ * durable record without an import cycle.
+ */
+export interface PtySessionState {
+  /** Mutable: warm-shell adoption re-keys the spare under the opener's key. */
+  key: string
+  readonly cwd: string
+  proc: PtyChild | null
+  alive: boolean
+  chunks: Buffer[]
+  bytes: number
+  /** Total bytes the child has EVER written (monotonic — never reduced by
+   *  ring trimming). `totalBytes - bytes` is the ring window's start
+   *  offset; a detached client's recorded offset stays comparable across
+   *  trims, which makes `sinceOffset` delta replays exact. */
+  totalBytes: number
+  cols: number
+  rows: number
+  /** Mutable: a freeze-restored session's respawn adopts the caller's
+   *  launch (the TUI's dead-reattach passes its `--resume` argv). */
+  command: readonly string[]
+  title: string
+  /** Unterminated escape tail carried between chunks for the title scan. */
+  titleCarry: string
+  /** UTF-8 decoder for the title scan (a multibyte title may split across chunks). */
+  readonly titleDecoder: StringDecoder
+  /** Attached connections, keyed by connection identity (the server's ClientState). */
+  readonly sinks: Map<object, PtySink>
+  /** A detached TUI still holds a serialized screen for an exact-delta wake. */
+  parked: boolean
+  parkedScreenBytes: number
+  /** Death cause, recorded once by markExited; null while alive. */
+  exit: PtySessionExit | null
+  /** True between "rebuilt from a freeze record at host boot" and the first
+   *  `open` that respawns it — the marker that separates a host-death
+   *  casualty (respawn on attach) from an ordinary corpse (view only). */
+  restored: boolean
+  /** Freeze bookkeeping: output/exit drift since the last persisted snapshot. */
+  lastFreezeAtMs: number
+}
+
+/** Durable-snapshot sink the host reports freezeable moments to. */
+export type { PtyFreezeSink }
+
 export interface PtyHostOptions {
   /** A session's child spawned — cancels a pending daemon idle-stop grace. */
   readonly onSessionStart?: () => void
@@ -45,6 +97,9 @@ export interface PtyHostOptions {
   /** Death record (exit status + output tail) per ended session — the
    *  durable-persistence hook. MUST be fail-safe; the host guards it. */
   readonly onSessionExit?: (info: PtySessionEndInfo) => void
+  /** Freeze/restore sink (`pty-freeze-store.ts`). Absent = the pre-freeze
+   *  behavior: session state dies with this process. */
+  readonly freeze?: PtyFreezeSink
   /** Ring-buffer cap in bytes per session. Default 512KiB (`DEFAULT_SCROLLBACK_CAP`). */
   readonly scrollbackCap?: number
   /** How children spawn. Default Bun's; the Windows host injects node-pty's. */

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -19,83 +19,66 @@
  * after code changes) never touches running sessions, exactly like the
  * tmux server outliving everything. An exited session is kept, scrollback
  * intact, so a reattach can still show how the child died; it is removed
- * by an explicit `kill` or the task-archive sweep (`sweepTasks`). Only
- * the host process ending (idle-exit at zero live sessions, or
- * `kobe reset`) ends the children.
+ * by an explicit `kill` or the task-archive sweep (`sweepTasks`).
+ *
+ * Freeze/restore (`pty-freeze-store.ts`): every session's metadata and
+ * ring persist to disk (throttled while streaming, immediately on exit,
+ * fully at shutdown), so the host PROCESS ending — idle-exit, crash, a
+ * machine reboot — no longer takes the work scene with it. The next host
+ * thaws each session as a dead "restored" corpse with its scrollback, and
+ * the first `open` respawns the child in place using the caller's launch
+ * spec (the TUI's dead-reattach passes its engine `--resume` argv). Only
+ * an explicit `kill`, the archive sweep, or `rove reset` (which wipes the
+ * store) forgets a session for good.
  */
 
 import { StringDecoder } from "node:string_decoder"
 import { resolveLoginShell } from "./platform-shell.js"
 import type { DaemonFrame, PtyPeekResult, PtySessionExit } from "./protocol.ts"
-import { type PtyChild, type PtyExit, bunTerminalDriver } from "./pty-driver.ts"
+import { type PtyExit, bunTerminalDriver } from "./pty-driver.ts"
 import { embeddedTerminalEnv } from "./pty-env.js"
-import type { PtyAttachResult, PtyHostOptions, PtySink, PtySpawnSpec } from "./pty-host-types.ts"
+import { type FrozenPtySession, freezeSession, thawSession } from "./pty-freeze-store.ts"
+import type { PtyAttachResult, PtyHostOptions, PtySessionState, PtySink, PtySpawnSpec } from "./pty-host-types.ts"
 import {
   type PtyHostStats,
   type PtySessionInfo,
   describeExit,
+  hostStats,
   peekRing,
   ringTail,
   scanOscTitle,
+  sessionInfo,
 } from "./pty-observability.ts"
-import { settledWithin, signalProcessGroup } from "./pty-termination.ts"
+import { terminatePtyChild } from "./pty-termination.ts"
+import { WarmSpare } from "./pty-warm.ts"
 
 export type { PtyHostStats, PtySessionInfo } from "./pty-observability.ts"
 // Re-exported for the cross-chunk title-boundary tests (pure fold).
 export { foldOscTitle } from "./pty-observability.ts"
-export type { PtyAttachResult, PtyHostOptions, PtySink, PtySpawnSpec } from "./pty-host-types.ts"
+export type { PtyAttachResult, PtyHostOptions, PtySessionState, PtySink, PtySpawnSpec } from "./pty-host-types.ts"
 
 /** Per-session scrollback cap — same order as the web PTY sidecar's 256KB. */
 export const DEFAULT_SCROLLBACK_CAP = 512 * 1024
-/** Let a cooperative terminal child shut down before escalating to SIGKILL. */
-const TERMINATION_GRACE_MS = 500
 /** Raw ring tail captured into a session's death record. */
 const EXIT_TAIL_BYTES = 16 * 1024
 
-interface PtySessionState {
-  /** Mutable: warm-shell adoption re-keys the spare under the opener's key. */
-  key: string
-  readonly cwd: string
-  proc: PtyChild | null
-  alive: boolean
-  chunks: Buffer[]
-  bytes: number
-  /** Total bytes the child has EVER written (monotonic — never reduced by
-   *  ring trimming). `totalBytes - bytes` is the ring window's start
-   *  offset; a detached client's recorded offset stays comparable across
-   *  trims, which is what makes `sinceOffset` delta replays exact. */
-  totalBytes: number
-  cols: number
-  rows: number
-  readonly command: readonly string[]
-  title: string
-  /** Unterminated escape tail carried between chunks for the title scan. */
-  titleCarry: string
-  /** UTF-8 decoder for the title scan (a multibyte title may split across chunks). */
-  readonly titleDecoder: StringDecoder
-  /** Attached connections, keyed by connection identity (the server's ClientState). */
-  readonly sinks: Map<object, PtySink>
-  /** A detached TUI still holds a serialized screen for an exact-delta wake. */
-  parked: boolean
-  parkedScreenBytes: number
-  /** Death cause, recorded once by markExited; null while alive. */
-  exit: PtySessionExit | null
-}
+/** Minimum gap between a session's periodic freeze writes (crash-loss bound).
+ *  Exits and shutdowns flush immediately; this only throttles the live stream. */
+export const FREEZE_INTERVAL_MS = 5_000
 
 export class PtyHost {
   private readonly sessions = new Map<string, PtySessionState>()
   private readonly opts: PtyHostOptions
   private parkRestoreDeltas = 0
   private parkRestoreFallbacks = 0
-  /**
-   * One pre-initialized spare shell (`pty.warm`) kept OUTSIDE the session
-   * map — invisible to `list`/`sweepTasks`/`liveCount` (it must not pin
-   * the host open or be swept as an orphan). A matching `open` adopts it
-   * under the opener's key and a replacement is warmed right away.
-   * ponytail: single global slot keyed by cwd; per-worktree pools if
-   * multi-repo warm hits matter.
-   */
-  private spare: PtySessionState | null = null
+  /** The one warm-spare shell slot (see `pty-warm.ts`). */
+  private readonly warmSpare = new WarmSpare({
+    spawn: (key, spec, spare) => this.spawn(key, spec, spare),
+    endChild: (session) => this.endChild(session),
+    markExited: (session) => this.markExited(session),
+    log: (event, message) => this.opts.log?.(event, message),
+    onSessionStart: () => this.opts.onSessionStart?.(),
+  })
 
   constructor(opts: PtyHostOptions = {}) {
     this.opts = opts
@@ -119,10 +102,18 @@ export class PtyHost {
   ): PtyAttachResult {
     let session = this.sessions.get(key)
     let created = false
+    let respawned = false
     if (!session) {
       created = true
-      session = this.adoptSpare(key, spec) ?? this.spawn(key, spec)
+      session = this.warmSpare.adopt(key, spec) ?? this.spawn(key, spec)
       this.sessions.set(key, session)
+    } else if (!session.alive && session.restored) {
+      // A freeze-restored corpse is a host-death casualty, not a death the
+      // user saw: respawn it in place (scrollback kept) instead of handing
+      // back a post-mortem. The caller's spec wins when it carries a
+      // command — the TUI's dead-reattach passes its engine-resume launch.
+      this.respawn(session, spec)
+      respawned = session.alive
     } else if (
       session.alive &&
       spec.cols !== undefined &&
@@ -170,58 +161,15 @@ export class PtyHost {
       alive: session.alive,
       pid: session.proc?.pid ?? null,
       created,
+      respawned,
       offset: session.totalBytes,
       sinceValid,
     }
   }
 
-  /**
-   * Keep one idle shell pre-spawned for `cwd`. A live spare for the same
-   * cwd+shell is kept; anything else is replaced (single slot — the most
-   * recently warmed worktree wins). The spare deliberately skips
-   * `onSessionStart` so it never cancels the host's idle-exit.
-   */
+  /** Pre-spawn one idle shell for adoption — policy lives in `pty-warm.ts`. */
   warm(cwd: string, shell?: string, cols = 80, rows = 24): void {
-    const argv0 = shell ?? resolveLoginShell()
-    if (this.spare?.alive && this.spare.cwd === cwd && this.spare.command[0] === argv0) return
-    const old = this.spare
-    this.spare = null
-    if (old) this.endChild(old)
-    const session = this.spawn("::spare", { cwd, command: [argv0], cols, rows }, true)
-    this.spare = session.alive ? session : null
-  }
-
-  /**
-   * Hand the spare over to `open(key)` when it matches the spec: same
-   * cwd, and the spec resolves to the spare's bare shell. The adopted
-   * session becomes a REAL one (it now pins the host open) and a
-   * replacement spare is warmed immediately.
-   */
-  private adoptSpare(key: string, spec: PtySpawnSpec): PtySessionState | null {
-    const spare = this.spare
-    if (!spare?.alive || spare.cwd !== spec.cwd) return null
-    const want = spec.command && spec.command.length > 0 ? spec.command : [spec.shell ?? resolveLoginShell()]
-    if (want.length !== 1 || want[0] !== spare.command[0]) return null
-    this.spare = null
-    spare.key = key
-    // A size-less spec keeps the spare's dimensions (headless adopters
-    // don't care; the first sized attach will resize).
-    const cols = spec.cols ?? spare.cols
-    const rows = spec.rows ?? spare.rows
-    if (spare.cols !== cols || spare.rows !== rows) {
-      spare.cols = cols
-      spare.rows = rows
-      try {
-        spare.proc?.resize(cols, rows)
-      } catch {
-        this.markExited(spare)
-        return null
-      }
-    }
-    this.opts.log?.("pty", `adopted warm shell for ${key} (pid ${spare.proc?.pid})`)
-    this.opts.onSessionStart?.()
-    this.warm(spec.cwd, spare.command[0], cols, rows)
-    return spare
+    this.warmSpare.warm(cwd, shell, cols, rows)
   }
 
   /** Forward client input (already UTF-8 text from xterm) to the child. */
@@ -253,6 +201,9 @@ export class PtyHost {
     const session = this.sessions.get(key)
     if (!session) return Promise.resolve()
     this.sessions.delete(key)
+    // An explicit close is not a restart casualty — drop the freeze record
+    // so the next host incarnation does not resurrect what was closed.
+    this.opts.freeze?.drop(key)
     return this.endChild(session)
   }
 
@@ -284,17 +235,7 @@ export class PtyHost {
 
   /** Session inventory — lets a fresh TUI discover background sessions. */
   list(): PtySessionInfo[] {
-    return Array.from(this.sessions.values(), (s) => ({
-      key: s.key,
-      alive: s.alive,
-      pid: s.proc?.pid ?? null,
-      command: s.command,
-      title: s.title,
-      totalBytes: s.totalBytes,
-      parked: s.parked,
-      parkedScreenBytes: s.parkedScreenBytes,
-      exit: s.exit,
-    }))
+    return Array.from(this.sessions.values(), (s) => sessionInfo(s))
   }
 
   /** Read-only ring peek (`pty.peek`) — no attach, no spawn, no resize. */
@@ -304,24 +245,12 @@ export class PtyHost {
 
   /** Retention facts for diagnostics; no terminal bytes leave the host. */
   stats(): PtyHostStats {
-    let ringBytes = 0
-    let parkedSessions = 0
-    let parkedScreenBytes = 0
-    for (const session of this.sessions.values()) {
-      ringBytes += session.bytes
-      if (session.parked) {
-        parkedSessions++
-        parkedScreenBytes += session.parkedScreenBytes
-      }
-    }
-    return {
-      ringBytes,
-      ringCapacityBytes: this.sessions.size * (this.opts.scrollbackCap ?? DEFAULT_SCROLLBACK_CAP),
-      parkedSessions,
-      parkedScreenBytes,
-      parkRestoreDeltas: this.parkRestoreDeltas,
-      parkRestoreFallbacks: this.parkRestoreFallbacks,
-    }
+    return hostStats(
+      this.sessions.values(),
+      this.opts.scrollbackCap ?? DEFAULT_SCROLLBACK_CAP,
+      this.parkRestoreDeltas,
+      this.parkRestoreFallbacks,
+    )
   }
 
   /**
@@ -340,10 +269,82 @@ export class PtyHost {
   /** Kill every session and the warm spare before host shutdown completes. */
   async killAll(): Promise<void> {
     const sessions = Array.from(this.sessions.keys(), (key) => this.kill(key))
-    const spare = this.spare
-    this.spare = null
-    if (spare) sessions.push(this.endChild(spare))
+    sessions.push(this.warmSpare.end())
     await Promise.all(sessions)
+  }
+
+  /**
+   * Host-process teardown (the server's close()): freeze every session
+   * FIRST so the next host incarnation can restore it, then end the live
+   * children. Unlike killAll this never DROPS freeze records — a host
+   * restart is exactly what the freeze store exists for. Explicit kills
+   * (tab close, archive sweep, `rove reset`'s store wipe) stay gone.
+   */
+  async shutdown(): Promise<void> {
+    this.flushFrozen()
+    const endings = Array.from(this.sessions.values(), (session) => this.endChild(session))
+    endings.push(this.warmSpare.end())
+    await Promise.all(endings)
+  }
+
+  /** Persist every session's freeze snapshot now (shutdown path). */
+  flushFrozen(): void {
+    for (const session of this.sessions.values()) this.maybeFreeze(session, true)
+  }
+
+  /**
+   * Rebuild sessions from freeze records at host boot — each comes back as
+   * a dead "restored" corpse with its ring intact; the first `open`
+   * respawns the child in place. Records for keys this host already has
+   * (never in practice — restore runs before listen) lose. Returns how
+   * many sessions thawed.
+   */
+  restoreFrozen(records: readonly FrozenPtySession[]): number {
+    let restoredCount = 0
+    for (const record of records) {
+      if (this.sessions.has(record.key)) continue
+      const session = thawSession(record, this.opts.scrollbackCap ?? DEFAULT_SCROLLBACK_CAP)
+      if (!session) continue
+      this.sessions.set(record.key, session)
+      restoredCount++
+    }
+    if (restoredCount > 0) this.opts.log?.("pty", `restored ${restoredCount} frozen session(s) from disk`)
+    return restoredCount
+  }
+
+  /**
+   * Bring a freeze-restored corpse back to life IN PLACE: the old ring
+   * stays (the reattaching client replays where the session left off and
+   * live output appends after it), the child restarts from the caller's
+   * spec when it carries a command, else the frozen one. `restored` clears
+   * either way — a failed respawn becomes an ordinary view-only corpse,
+   * not a restore candidate retried on every attach.
+   */
+  private respawn(session: PtySessionState, spec: PtySpawnSpec): void {
+    session.restored = false
+    session.exit = null
+    if (spec.command && spec.command.length > 0) session.command = [...spec.command]
+    session.cols = spec.cols ?? session.cols
+    session.rows = spec.rows ?? session.rows
+    this.startChild(session)
+    if (!session.alive) return
+    this.opts.log?.("pty", `respawned restored session ${session.key} (pid ${session.proc?.pid})`)
+    this.opts.onSessionStart?.()
+  }
+
+  /**
+   * Throttled freeze writer. The write happens at most once per
+   * FREEZE_INTERVAL_MS per session (a host crash loses at most that much
+   * scrollback), immediately on exit, and for every session on shutdown.
+   * Internal keys (the warm spare) never freeze.
+   */
+  private maybeFreeze(session: PtySessionState, force = false): void {
+    const freeze = this.opts.freeze
+    if (!freeze || session.key.startsWith("::")) return
+    const now = Date.now()
+    if (!force && now - session.lastFreezeAtMs < FREEZE_INTERVAL_MS) return
+    session.lastFreezeAtMs = now
+    freeze.save(freezeSession(session))
   }
 
   /** Sessions whose child is still running — the host process's reason
@@ -358,8 +359,6 @@ export class PtyHost {
    *  open (its adoption fires the callback instead). */
   private spawn(key: string, spec: PtySpawnSpec, spare = false): PtySessionState {
     const argv = spec.command && spec.command.length > 0 ? [...spec.command] : [spec.shell ?? resolveLoginShell()]
-    const cols = spec.cols ?? 80
-    const rows = spec.rows ?? 24
     const session: PtySessionState = {
       key,
       cwd: spec.cwd,
@@ -368,8 +367,8 @@ export class PtyHost {
       chunks: [],
       bytes: 0,
       totalBytes: 0,
-      cols,
-      rows,
+      cols: spec.cols ?? 80,
+      rows: spec.rows ?? 24,
       command: argv,
       title: "",
       titleCarry: "",
@@ -378,33 +377,48 @@ export class PtyHost {
       parked: false,
       parkedScreenBytes: 0,
       exit: null,
+      restored: false,
+      lastFreezeAtMs: 0,
     }
+    this.startChild(session)
+    if (session.alive) {
+      this.opts.log?.("pty", `spawned ${argv[0]} for ${key} (pid ${session.proc?.pid})`)
+      if (!spare) this.opts.onSessionStart?.()
+    }
+    return session
+  }
+
+  /**
+   * Start `session`'s child process against its current command/cwd/size —
+   * the shared tail of a fresh spawn and a restored session's respawn. On
+   * failure the session flips to dead (a fresh spawn reports it, a respawn
+   * leaves an ordinary view-only corpse).
+   */
+  private startChild(session: PtySessionState): void {
     try {
       session.proc = (this.opts.driver ?? bunTerminalDriver())({
-        argv,
-        cwd: spec.cwd,
+        argv: [...session.command],
+        cwd: session.cwd,
         env: embeddedTerminalEnv(process.env, {
           TERM: "xterm-256color",
-          COLUMNS: String(cols),
-          LINES: String(rows),
+          COLUMNS: String(session.cols),
+          LINES: String(session.rows),
           BASH_SILENCE_DEPRECATION_WARNING: "1",
           KOBE_TERMINAL_PTY: "1",
         }),
-        cols,
-        rows,
+        cols: session.cols,
+        rows: session.rows,
         onData: (data) => this.onData(session, data),
       })
+      session.alive = true
       void session.proc.exited.then(
         (exit) => this.markExited(session, exit),
         () => this.markExited(session),
       )
-      this.opts.log?.("pty", `spawned ${argv[0]} for ${key} (pid ${session.proc.pid})`)
-      if (!spare) this.opts.onSessionStart?.()
     } catch (err) {
       session.alive = false
-      this.opts.log?.("pty", `spawn failed for ${key}: ${err instanceof Error ? err.message : String(err)}`)
+      this.opts.log?.("pty", `spawn failed for ${session.key}: ${err instanceof Error ? err.message : String(err)}`)
     }
-    return session
   }
 
   private onData(session: PtySessionState, data: string | Uint8Array): void {
@@ -420,13 +434,17 @@ export class PtyHost {
       const dropped = session.chunks.shift()
       if (dropped) session.bytes -= dropped.byteLength
     }
-    if (session.sinks.size === 0) return
+    if (session.sinks.size === 0) {
+      this.maybeFreeze(session)
+      return
+    }
     const frame: DaemonFrame = {
       type: "event",
       name: "pty.data",
       payload: { key: session.key, data: buf.toString("base64") },
     }
     for (const sink of session.sinks.values()) sink(frame)
+    this.maybeFreeze(session)
   }
 
   private markExited(session: PtySessionState, exit?: PtyExit): void {
@@ -445,6 +463,9 @@ export class PtyHost {
     }
     for (const sink of session.sinks.values()) sink(frame)
     this.opts.log?.("pty", `session ${session.key} exited${describeExit(session.exit)}`)
+    // Final freeze: the exit record AND the scrollback as it stood at death
+    // must both survive this host's own end (idle-exit, crash).
+    this.maybeFreeze(session, true)
     try {
       this.opts.onSessionExit?.({
         key: session.key,
@@ -465,17 +486,6 @@ export class PtyHost {
       this.markExited(session)
       return
     }
-    signalProcessGroup(proc.pid, "SIGTERM", () => proc.kill("SIGTERM"))
-    if (!(await settledWithin(proc.exited, TERMINATION_GRACE_MS))) {
-      signalProcessGroup(proc.pid, "SIGKILL", () => proc.kill("SIGKILL"))
-      // BOUNDED on purpose. Bun's `proc.exited` always settles, so an
-      // unbounded await was safe; the node-pty driver's resolves only when
-      // ConPTY delivers onExit, and a wedged one would hang killAll() — and
-      // with it the host's shutdown and `kobe reset`. A child that outlives
-      // SIGKILL is already beyond this process's reach; reporting the session
-      // dead is strictly better than never returning.
-      await settledWithin(proc.exited, TERMINATION_GRACE_MS)
-    }
-    this.markExited(session)
+    await terminatePtyChild(proc, () => this.markExited(session))
   }
 }

--- a/packages/kobe-daemon/src/daemon/pty-observability.ts
+++ b/packages/kobe-daemon/src/daemon/pty-observability.ts
@@ -21,6 +21,36 @@ export interface PtySessionInfo {
   readonly parkedScreenBytes?: number
   /** How the child died — null while alive or before exit was observed. */
   readonly exit?: PtySessionExit | null
+  /** True while the session is a freeze-restored corpse awaiting its
+   *  respawn-on-open (a host-death casualty, not a death the user saw). */
+  readonly restored?: boolean
+}
+
+/** One session state → its `pty.list` row (the host's `list()` mapping). */
+export function sessionInfo(s: {
+  key: string
+  alive: boolean
+  proc: { readonly pid: number } | null
+  command: readonly string[]
+  title: string
+  totalBytes: number
+  parked: boolean
+  parkedScreenBytes: number
+  exit: PtySessionExit | null
+  restored: boolean
+}): PtySessionInfo {
+  return {
+    key: s.key,
+    alive: s.alive,
+    pid: s.proc?.pid ?? null,
+    command: s.command,
+    title: s.title,
+    totalBytes: s.totalBytes,
+    parked: s.parked,
+    parkedScreenBytes: s.parkedScreenBytes,
+    exit: s.exit,
+    restored: s.restored || undefined,
+  }
 }
 
 /** What the host hands `onSessionExit` — the death record for one session. */
@@ -61,6 +91,35 @@ export interface PtyHostStats {
   readonly parkRestoreDeltas: number
   /** Park wakes that had to fall back to a full ring replay. */
   readonly parkRestoreFallbacks: number
+}
+
+/** The host's `stats()` aggregation (the cap math included). */
+export function hostStats(
+  sessions: Iterable<{ bytes: number; parked: boolean; parkedScreenBytes: number }>,
+  perSessionCap: number,
+  parkRestoreDeltas: number,
+  parkRestoreFallbacks: number,
+): PtyHostStats {
+  let ringBytes = 0
+  let count = 0
+  let parkedSessions = 0
+  let parkedScreenBytes = 0
+  for (const session of sessions) {
+    count++
+    ringBytes += session.bytes
+    if (session.parked) {
+      parkedSessions++
+      parkedScreenBytes += session.parkedScreenBytes
+    }
+  }
+  return {
+    ringBytes,
+    ringCapacityBytes: count * perSessionCap,
+    parkedSessions,
+    parkedScreenBytes,
+    parkRestoreDeltas,
+    parkRestoreFallbacks,
+  }
 }
 
 type PtyTitleState = {

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -29,10 +29,11 @@ import { StringDecoder } from "node:string_decoder"
 import { ClientWriter } from "./client-writer.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { objectPayload, requireString } from "./handler-validators.ts"
-import { defaultPtyHostPidPath, defaultPtyHostSocketPath, isWindowsPipePath } from "./paths.ts"
+import { defaultPtyFreezeDir, defaultPtyHostPidPath, defaultPtyHostSocketPath, isWindowsPipePath } from "./paths.ts"
 import { DAEMON_PROTOCOL_VERSION, type DaemonFrame, frameToLine } from "./protocol.ts"
 import type { PtyDriver } from "./pty-driver.ts"
 import { recordPtyExit } from "./pty-exit-store.ts"
+import { clearFrozenSessions, fileFreezeSink, loadFrozenSessions } from "./pty-freeze-store.ts"
 import { PtyHost } from "./pty-host.ts"
 
 /**
@@ -57,6 +58,9 @@ export interface PtyHostServerOptions {
   readonly idleExitMs?: number
   /** How PTY children get spawned. Defaults to Bun's; the node host passes node-pty's. */
   readonly driver?: PtyDriver
+  /** Freeze-store directory (`pty-freeze-store.ts`). Defaults to the home's
+   *  `pty-sessions/`; tests pass a temp dir. */
+  readonly freezeDir?: string
   /** Called after close() when the host stops itself (idle / daemon.stop). */
   readonly onStop?: () => void
   readonly log?: (event: string, message: string) => void
@@ -77,10 +81,16 @@ interface PtyClientState {
 export async function startPtyHostServer(options: PtyHostServerOptions = {}): Promise<PtyHostServer> {
   const socketPath = options.socketPath ?? defaultPtyHostSocketPath()
   const pidPath = options.pidPath ?? defaultPtyHostPidPath()
+  const freezeDir = options.freezeDir ?? defaultPtyFreezeDir()
   const idleExitMs = options.idleExitMs || resolveIdleExitMs()
   const log = options.log ?? (() => {})
   const clients = new Set<PtyClientState>()
   let stopping = false
+  /** Set by the `daemon.stop` verb (rove reset): an explicit teardown wipes
+   *  the freeze store so the next host comes up EMPTY — reset's contract is
+   *  "starts fresh". Idle-exit, SIGTERM, and crashes keep it (they are the
+   *  restarts freeze/restore exists for). */
+  let wipeFreezeOnStop = false
   let idleTimer: ReturnType<typeof setTimeout> | null = null
 
   const cancelIdle = (): void => {
@@ -114,9 +124,15 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
         log("pty", `exit record write failed for ${info.key}: ${err instanceof Error ? err.message : String(err)}`)
       }
     },
+    // Freeze/restore: per-session snapshots so a host restart (idle-exit,
+    // crash, reboot) hands the next incarnation every session's metadata +
+    // scrollback. Restore happens BEFORE listen below, so no client open
+    // can race the thaw.
+    freeze: fileFreezeSink(freezeDir),
     driver: options.driver,
     log,
   })
+  ptys.restoreFrozen(loadFrozenSessions(freezeDir))
 
   // A Windows named pipe lives in the `\\.\pipe` namespace, not the
   // filesystem — there is no parent directory to create.
@@ -162,7 +178,11 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
       stopping = true
       cancelIdle()
       // The host process IS the sessions' lifetime — ending it ends them.
-      await ptys.killAll()
+      // shutdown() freezes first: the records outlive us, and the next
+      // host incarnation restores the work scene. An explicit `daemon.stop`
+      // (rove reset) wipes the store instead — starts fresh means fresh.
+      await ptys.shutdown()
+      if (wipeFreezeOnStop) clearFrozenSessions(freezeDir)
       for (const client of Array.from(clients)) client.socket.destroy()
       await new Promise<void>((resolve) => server.close(() => resolve()))
       // A named pipe is reclaimed with its last handle; only a filesystem
@@ -259,7 +279,9 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
       }
       case "daemon.stop":
         // Shared graceful-stop verb so `stopDaemonProcess` (kobe reset)
-        // works against this socket unchanged.
+        // works against this socket unchanged. Reset's "starts fresh"
+        // contract includes NOT resurrecting frozen sessions next boot.
+        wipeFreezeOnStop = true
         setTimeout(() => void stop(), 0).unref()
         return {}
       default:

--- a/packages/kobe-daemon/src/daemon/pty-termination.ts
+++ b/packages/kobe-daemon/src/daemon/pty-termination.ts
@@ -7,6 +7,8 @@
  * which is what makes the platform behaviour below testable without spawning.
  */
 
+import type { PtyChild } from "./pty-driver.ts"
+
 /**
  * True if `exited` settled inside `ms`; false on timeout. A rejection counts
  * as settled — an exit is an exit however the runtime reports it.
@@ -62,4 +64,25 @@ export function signalProcessGroup(
   } catch {
     /* already gone */
   }
+}
+
+/** Let a cooperative terminal child shut down before escalating to SIGKILL. */
+const TERMINATION_GRACE_MS = 500
+
+/**
+ * End one PTY child: SIGTERM its process group, escalate to SIGKILL past a
+ * short grace, then fire `onSettled`. BOUNDED on purpose. Bun's
+ * `proc.exited` always settles, so an unbounded await was safe; the
+ * node-pty driver's resolves only when ConPTY delivers onExit, and a
+ * wedged one would hang the host's shutdown — and with it `kobe reset`.
+ * A child that outlives SIGKILL is already beyond this process's reach;
+ * reporting the session dead is strictly better than never returning.
+ */
+export async function terminatePtyChild(proc: PtyChild, onSettled: () => void): Promise<void> {
+  signalProcessGroup(proc.pid, "SIGTERM", () => proc.kill("SIGTERM"))
+  if (!(await settledWithin(proc.exited, TERMINATION_GRACE_MS))) {
+    signalProcessGroup(proc.pid, "SIGKILL", () => proc.kill("SIGKILL"))
+    await settledWithin(proc.exited, TERMINATION_GRACE_MS)
+  }
+  onSettled()
 }

--- a/packages/kobe-daemon/src/daemon/pty-warm.ts
+++ b/packages/kobe-daemon/src/daemon/pty-warm.ts
@@ -1,0 +1,86 @@
+/**
+ * The warm-spare shell — split from `pty-host.ts` for the file-size cap.
+ *
+ * One pre-initialized spare shell (`pty.warm`) is kept OUTSIDE the host's
+ * session map — invisible to `list`/`sweepTasks`/`liveCount` (it must not
+ * pin the host open or be swept as an orphan). A matching `open` adopts it
+ * under the opener's key and a replacement is warmed right away.
+ * ponytail: single global slot keyed by cwd; per-worktree pools if
+ * multi-repo warm hits matter.
+ *
+ * The host's own concerns (spawn/teardown/exit) arrive as deps, so this
+ * class holds only the spare-slot policy.
+ */
+
+import { resolveLoginShell } from "./platform-shell.js"
+import type { PtySessionState, PtySpawnSpec } from "./pty-host-types.ts"
+
+export interface WarmSpareDeps {
+  readonly spawn: (key: string, spec: PtySpawnSpec, spare: boolean) => PtySessionState
+  readonly endChild: (session: PtySessionState) => Promise<void>
+  readonly markExited: (session: PtySessionState) => void
+  readonly log?: (event: string, message: string) => void
+  readonly onSessionStart?: () => void
+}
+
+export class WarmSpare {
+  private spare: PtySessionState | null = null
+
+  constructor(private readonly deps: WarmSpareDeps) {}
+
+  /**
+   * Keep one idle shell pre-spawned for `cwd`. A live spare for the same
+   * cwd+shell is kept; anything else is replaced (single slot — the most
+   * recently warmed worktree wins). The spare deliberately skips
+   * `onSessionStart` so it never cancels the host's idle-exit.
+   */
+  warm(cwd: string, shell?: string, cols = 80, rows = 24): void {
+    const argv0 = shell ?? resolveLoginShell()
+    if (this.spare?.alive && this.spare.cwd === cwd && this.spare.command[0] === argv0) return
+    const old = this.spare
+    this.spare = null
+    if (old) void this.deps.endChild(old)
+    const session = this.deps.spawn("::spare", { cwd, command: [argv0], cols, rows }, true)
+    this.spare = session.alive ? session : null
+  }
+
+  /**
+   * Hand the spare over to `open(key)` when it matches the spec: same
+   * cwd, and the spec resolves to the spare's bare shell. The adopted
+   * session becomes a REAL one (it now pins the host open) and a
+   * replacement spare is warmed immediately.
+   */
+  adopt(key: string, spec: PtySpawnSpec): PtySessionState | null {
+    const spare = this.spare
+    if (!spare?.alive || spare.cwd !== spec.cwd) return null
+    const want = spec.command && spec.command.length > 0 ? spec.command : [spec.shell ?? resolveLoginShell()]
+    if (want.length !== 1 || want[0] !== spare.command[0]) return null
+    this.spare = null
+    spare.key = key
+    // A size-less spec keeps the spare's dimensions (headless adopters
+    // don't care; the first sized attach will resize).
+    const cols = spec.cols ?? spare.cols
+    const rows = spec.rows ?? spare.rows
+    if (spare.cols !== cols || spare.rows !== rows) {
+      spare.cols = cols
+      spare.rows = rows
+      try {
+        spare.proc?.resize(cols, rows)
+      } catch {
+        this.deps.markExited(spare)
+        return null
+      }
+    }
+    this.deps.log?.("pty", `adopted warm shell for ${key} (pid ${spare.proc?.pid})`)
+    this.deps.onSessionStart?.()
+    this.warm(spec.cwd, spare.command[0], cols, rows)
+    return spare
+  }
+
+  /** End the spare without adopting it (host teardown paths). */
+  async end(): Promise<void> {
+    const spare = this.spare
+    this.spare = null
+    if (spare) await this.deps.endChild(spare)
+  }
+}

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -181,7 +181,11 @@ export async function deliverHostedPrompt(
   }
 
   const staleCanonical = sessions.find((session) => session.key === launch.key && !session.alive)
-  if (staleCanonical) await rpc.request("pty.kill", { key: launch.key })
+  // A FREEZE-RESTORED corpse is not killed: `pty.open` respawns it in place
+  // (pre-restart scrollback kept), so the launch below both revives the tab
+  // and carries this prompt. An ordinary corpse (died while the host lived)
+  // is view-only — open would ignore our spec, so it must be killed first.
+  if (staleCanonical && staleCanonical.restored !== true) await rpc.request("pty.kill", { key: launch.key })
 
   // No cols/rows: the host sizes the fresh spawn itself (80×24 default);
   // on the lost-create-race reattach below, a size-less open never resizes
@@ -196,7 +200,7 @@ export async function deliverHostedPrompt(
       return {
         session: launch.key,
         pane: launch.key,
-        started: open.created !== false,
+        started: open.created !== false || open.respawned === true,
         engineReady: false,
         delivered: false,
       }
@@ -210,19 +214,21 @@ export async function deliverHostedPrompt(
       return {
         session: launch.key,
         pane: launch.key,
-        started: open.created !== false,
+        started: open.created !== false || open.respawned === true,
         engineReady: delivered,
         delivered,
       }
     }
     // Another API process may win the create race after our pty.list. Its
     // launch spec wins, so ours did not carry this prompt; deliver it now.
-    if (open.created === false) await writePrompt(rpc, launch.key, prompt)
+    // A RESPAWNED restored corpse is the opposite: our launch DID run (the
+    // prompt rode its argv), so pasting here would deliver it twice.
+    if (open.created === false && open.respawned !== true) await writePrompt(rpc, launch.key, prompt)
     const delivered = true
     return {
       session: launch.key,
       pane: launch.key,
-      started: open.created !== false,
+      started: open.created !== false || open.respawned === true,
       engineReady: delivered,
       delivered,
     }

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -7,7 +7,7 @@
  */
 
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { interactiveEngineCommand } from "../../engine/interactive-command.ts"
+import { interactiveEngineCommand, withClaudeSessionId } from "../../engine/interactive-command.ts"
 import { buildEngineSessionLaunch } from "../../engine/session-launch.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
 import {
@@ -23,6 +23,7 @@ import {
   type TaskSessionRow,
   hasLiveEngineTab,
   joinTaskTabs,
+  markCliTabSession,
   mintCliTab,
   publishCliTabSnapshot,
   readTabsSnapshot,
@@ -52,7 +53,15 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
       return await deliverToExactTab(host.rpc, target.id, target.tab, worktree, prompt, { engineBin })
     }
     const newTab = target.tab === "new" ? mintCliTab(target.id, target.tabVendor) : undefined
-    const argv = interactiveEngineCommand(target.vendor, target.modelEffort)
+    // Pin the conversation's session id up front (claude only — the same
+    // `withClaudeSessionId` contract the TUI launches with), so a LATER
+    // reattach after a pty-host restart can resume THIS conversation
+    // instead of opening a blank one. The id lands in the persisted tab
+    // snapshot below once the session actually started.
+    const { argv, sessionId } = withClaudeSessionId(
+      interactiveEngineCommand(target.vendor, target.modelEffort),
+      target.vendor,
+    )
     const launch = buildEngineSessionLaunch({
       task: { id: target.id, kind: target.kind, vendor: target.vendor, repo: target.repo },
       worktreePath: worktree,
@@ -83,8 +92,13 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
     // tabs from the task's persisted snapshot — a CLI-started session used to
     // run live with no snapshot, so the tree showed the worktree with no tabs
     // under it at all. Write-once (a --tab new spawn already appended its tab
-    // in mintCliTab); see `tab-snapshot.ts`.
-    if (!newTab) publishCliTabSnapshot(target.id)
+    // in mintCliTab); see `tab-snapshot.ts`. When THIS delivery started the
+    // session, record the pinned session id + spawned flag too, so a later
+    // dead-reattach resumes the conversation (see engineTabArgv).
+    if (result.started && sessionId) {
+      if (newTab) markCliTabSession(target.id, newTab, sessionId)
+      else publishCliTabSnapshot(target.id, sessionId)
+    } else if (!newTab) publishCliTabSnapshot(target.id)
     return result
   } catch (error) {
     if (error instanceof ApiError) throw error

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -176,8 +176,13 @@ export function hasLiveEngineTab(
  * Seed `terminalTabs.<taskId>` with the canonical first engine tab when the
  * task has none. No-op when a snapshot already exists, and never throws — a
  * sidebar-visibility nicety must not fail an otherwise-good session start.
+ *
+ * `sessionId` is the conversation id the launch pinned (`withClaudeSessionId`)
+ * — recording it (with `spawned`, the conversation provably started: the
+ * caller only passes it after a successful delivery) makes a later
+ * dead-reattach `--resume` this conversation, matching a TUI-spawned tab.
  */
-export function publishCliTabSnapshot(taskId: string): void {
+export function publishCliTabSnapshot(taskId: string, sessionId?: string | null): void {
   if (!taskId) return
   try {
     const key = terminalTabsKey(taskId)
@@ -186,10 +191,43 @@ export function publishCliTabSnapshot(taskId: string): void {
     // one engine tab `tab-1`, active — matching the PTY key the CLI launch
     // path uses (`engineSessionKey` → `<taskId>::tab-1`), so the tree's row
     // and the live process agree on which tab this is.
-    patchStateFile({ [key]: initialTabs() })
+    const seeded = initialTabs()
+    patchStateFile({
+      [key]: sessionId
+        ? {
+            ...seeded,
+            tabs: seeded.tabs.map((t): TerminalTab => (t.kind === "engine" ? { ...t, sessionId, spawned: true } : t)),
+          }
+        : seeded,
+    })
   } catch {
     // Unreadable/unwritable state.json: the session is still fine, the tree
     // just won't list its tab until the TUI opens the task.
+  }
+}
+
+/**
+ * Record a CLI-spawned EXTRA tab's pinned session id after its session
+ * actually started (the `send --tab new` twin of {@link publishCliTabSnapshot}'s
+ * sessionId). mintCliTab runs BEFORE the spawn — it deliberately leaves the
+ * id unset so a failed start never claims a resumable conversation that
+ * does not exist (claude errors hard on `--resume` of a missing id).
+ */
+export function markCliTabSession(taskId: string, tabId: string, sessionId: string): void {
+  try {
+    const key = terminalTabsKey(taskId)
+    const existing = loadStateFile()[key] as TabsState | undefined
+    if (!existing || !Array.isArray(existing.tabs)) return
+    patchStateFile({
+      [key]: {
+        ...existing,
+        tabs: existing.tabs.map(
+          (t): TerminalTab => (t.id === tabId && t.kind === "engine" ? { ...t, sessionId, spawned: true } : t),
+        ),
+      },
+    })
+  } catch {
+    // Same best-effort contract as the snapshot writers above.
   }
 }
 

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   readWorktreeChanges: vi.fn(),
   submitFeedback: vi.fn(),
   interactiveEngineCommand: vi.fn(),
+  withClaudeSessionId: vi.fn((argv: readonly string[]) => ({ argv, sessionId: null })),
   ensurePtyHost: vi.fn(),
   deliverHostedPrompt: vi.fn(),
   closePtyHost: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock("../../src/lib/feedback.ts", () => ({
 
 vi.mock("../../src/engine/interactive-command.ts", () => ({
   interactiveEngineCommand: mocks.interactiveEngineCommand,
+  withClaudeSessionId: mocks.withClaudeSessionId,
 }))
 
 vi.mock("../../src/engine/session-launch.ts", () => ({

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
   hasLiveEngineTab,
   joinTaskTabs,
+  markCliTabSession,
   mintCliTab,
   publishCliTabSnapshot,
   readTabsSnapshot,
@@ -91,6 +92,37 @@ describe("publishCliTabSnapshot", () => {
     writeState({})
     publishCliTabSnapshot("")
     expect(Object.keys(readState())).toEqual([])
+  })
+
+  it("records the pinned session id + spawned when the delivery started the session", () => {
+    writeState({})
+    publishCliTabSnapshot("t1", "uuid-abc")
+    const snapshot = readState()["terminalTabs.t1"] as {
+      tabs: { id: string; sessionId?: string; spawned?: boolean }[]
+    }
+    // The dead-reattach rule (engineTabArgv) reads exactly these two fields
+    // to `--resume` the conversation after a pty-host restart.
+    expect(snapshot.tabs[0]).toMatchObject({ id: "tab-1", sessionId: "uuid-abc", spawned: true })
+  })
+})
+
+describe("markCliTabSession", () => {
+  it("patches an existing minted tab with its session id once the session started", () => {
+    writeState({})
+    const id = mintCliTab("t1")
+    markCliTabSession("t1", id, "uuid-xyz")
+    const snapshot = readState()["terminalTabs.t1"] as {
+      tabs: { id: string; sessionId?: string; spawned?: boolean }[]
+    }
+    expect(snapshot.tabs.find((t) => t.id === id)).toMatchObject({ sessionId: "uuid-xyz", spawned: true })
+    // The canonical tab keeps having no id — its session was never CLI-pinned.
+    expect(snapshot.tabs.find((t) => t.id === "tab-1")?.sessionId).toBeUndefined()
+  })
+
+  it("is a no-op for an unknown tab or a missing snapshot", () => {
+    writeState({})
+    markCliTabSession("t1", "tab-9", "uuid-xyz")
+    expect(readState()).toEqual({})
   })
 })
 

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -273,6 +273,31 @@ describe("deliverHostedPrompt", () => {
     expect(calls).not.toContain("pty.write") // and nothing was pasted anywhere
   })
 
+  it("a freeze-RESTORED corpse is respawned in place — never killed, prompt not pasted twice", async () => {
+    // After a pty-host restart the canonical session lists as a dead,
+    // restored corpse. Delivery must NOT pty.kill it (the open respawns it,
+    // keeping the pre-restart scrollback) and must NOT writePrompt after
+    // the respawn (the prompt already rode the launch argv).
+    const calls: Array<{ name: string; payload?: unknown }> = []
+    const rpc = {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
+        calls.push({ name, payload })
+        if (name === "pty.list")
+          return {
+            sessions: [{ ...session("t1::tab-1", ["/bin/zsh", "-ilc", "claude 'x'"], false), restored: true }],
+          } as T
+        if (name === "pty.open") return { replay: "b2xk", alive: true, created: false, respawned: true } as T
+        return {} as T
+      },
+    }
+    const result = await deliverHostedPrompt(rpc, { id: "t1", engineBin: "claude" }, "/wt/t1", "go", {
+      key: "t1::tab-1",
+      command: ["/bin/zsh", "-ilc", "claude 'go'"],
+    })
+    expect(result).toMatchObject({ session: "t1::tab-1", started: true, delivered: true })
+    expect(calls.map((c) => c.name)).toEqual(["pty.list", "pty.open", "pty.detach"])
+  })
+
   it("still first-starts the canonical engine when only DEAD sessions remain, cwd'd at the worktree", async () => {
     const calls: Array<{ name: string; payload: unknown }> = []
     const rpc = {

--- a/packages/kobe/test/daemon/pty-freeze-store.test.ts
+++ b/packages/kobe/test/daemon/pty-freeze-store.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Freeze/restore store (`pty-freeze-store.ts`) — the persistence half of
+ * "a pty-host restart must not take the work scene with it". One JSON file
+ * per session; the pins here are the round-trip, the corruption/malformed
+ * tolerance (a bad file must never block the OTHER sessions' restore), the
+ * ring cap on thaw, and the reset semantics (clear = starts fresh).
+ */
+
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  type FreezeableSession,
+  type FrozenPtySession,
+  clearFrozenSessions,
+  fileFreezeSink,
+  freezeSession,
+  loadFrozenSessions,
+  thawRing,
+  thawSession,
+} from "@sma1lboy/kobe-daemon/daemon/pty-freeze-store"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kobe-pty-freeze-"))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function fakeSession(over: Partial<FreezeableSession> = {}): FreezeableSession {
+  return {
+    key: "t1::tab-1",
+    cwd: "/wt/t1",
+    command: ["/bin/zsh", "-ilc", "claude --session-id abc"],
+    cols: 120,
+    rows: 40,
+    title: "claude",
+    totalBytes: 11,
+    exit: null,
+    chunks: [Buffer.from("hello "), Buffer.from("world")],
+    bytes: 11,
+    ...over,
+  }
+}
+
+describe("pty freeze store", () => {
+  it("round-trips a session: metadata + scrollback + offsets survive", () => {
+    const sink = fileFreezeSink(dir)
+    sink.save(freezeSession(fakeSession()))
+    const [record] = loadFrozenSessions(dir)
+    expect(record).toMatchObject({
+      v: 1,
+      key: "t1::tab-1",
+      cwd: "/wt/t1",
+      command: ["/bin/zsh", "-ilc", "claude --session-id abc"],
+      cols: 120,
+      rows: 40,
+      title: "claude",
+      totalBytes: 11,
+      exit: null,
+    })
+    expect(Buffer.from(record.ringB64, "base64").toString("utf8")).toBe("hello world")
+
+    const thawed = thawSession(record, 512 * 1024)
+    expect(thawed).toMatchObject({ key: "t1::tab-1", alive: false, restored: true, bytes: 11, totalBytes: 11 })
+    expect(Buffer.concat(thawed?.chunks ?? []).toString("utf8")).toBe("hello world")
+  })
+
+  it("encodes :: keys into filesystem-safe, per-session filenames", () => {
+    const sink = fileFreezeSink(dir)
+    sink.save(freezeSession(fakeSession({ key: "t1::tab-1" })))
+    sink.save(freezeSession(fakeSession({ key: "t1::tab-1::leaf-2" })))
+    const names = readdirSync(dir)
+    expect(names.length).toBe(2)
+    for (const name of names) expect(name).toMatch(/^[^/\\:]+\.json$/)
+    expect(
+      loadFrozenSessions(dir)
+        .map((r) => r.key)
+        .sort(),
+    ).toEqual(["t1::tab-1", "t1::tab-1::leaf-2"])
+  })
+
+  it("a corrupt or foreign-version file reads as absent and never blocks the rest", () => {
+    const sink = fileFreezeSink(dir)
+    sink.save(freezeSession(fakeSession({ key: "good::tab-1" })))
+    writeFileSync(join(dir, "broken.json"), "{not json", "utf8")
+    writeFileSync(
+      join(dir, "future.json"),
+      JSON.stringify({ ...freezeSession(fakeSession({ key: "x::tab-1" })), v: 99 }),
+      "utf8",
+    )
+    writeFileSync(join(dir, "internal.json"), JSON.stringify(freezeSession(fakeSession({ key: "::spare" }))), "utf8")
+    expect(loadFrozenSessions(dir).map((r) => r.key)).toEqual(["good::tab-1"])
+  })
+
+  it("drop removes exactly one session; clear wipes the store (rove reset)", () => {
+    const sink = fileFreezeSink(dir)
+    sink.save(freezeSession(fakeSession({ key: "t1::tab-1" })))
+    sink.save(freezeSession(fakeSession({ key: "t2::tab-1" })))
+    sink.drop("t1::tab-1")
+    expect(loadFrozenSessions(dir).map((r) => r.key)).toEqual(["t2::tab-1"])
+    clearFrozenSessions(dir)
+    expect(loadFrozenSessions(dir)).toEqual([])
+    // clear on an absent dir is fine, and drop never throws past the sink.
+    clearFrozenSessions(dir)
+    sink.drop("never-existed")
+  })
+
+  it("thawRing trims an oversized ring to the cap's TAIL (the reattach repaint)", () => {
+    const big = Buffer.alloc(1024, 0x61)
+    const record = freezeSession(fakeSession({ chunks: [big], bytes: 1024, totalBytes: 2048 }))
+    const ring = thawRing(record, 256)
+    expect(ring?.bytes).toBe(256)
+    // totalBytes stays monotonic from the record, not the trimmed window.
+    const thawed = thawSession(record, 256)
+    expect(thawed?.totalBytes).toBe(2048)
+  })
+
+  it("thaw tolerates a garbage ring — no throw, and the session still restores", () => {
+    // Buffer.from(…, "base64") never throws: it decodes the valid subset.
+    // The pin is that a weird ring can never crash the restore path.
+    const record: FrozenPtySession = { ...freezeSession(fakeSession()), ringB64: "%%%" }
+    const thawed = thawSession(record, 1024)
+    expect(thawed?.restored).toBe(true)
+    expect(thawed?.bytes).toBe(0)
+  })
+})

--- a/packages/kobe/test/daemon/pty-host-freeze.test.ts
+++ b/packages/kobe/test/daemon/pty-host-freeze.test.ts
@@ -1,0 +1,206 @@
+/**
+ * PtyHost freeze/restore semantics, driven through a fake `PtyDriver` so
+ * spawn/respawn/exit are fully deterministic (no real PTY under vitest).
+ * The pinned contract:
+ *   - live output freezes THROTTLED; exit and flushFrozen freeze NOW;
+ *   - a thawed session is a dead "restored" corpse whose first `open`
+ *     respawns the child IN PLACE (old ring kept, caller's spec wins);
+ *   - a failed respawn degrades to an ordinary view-only corpse;
+ *   - explicit kill drops the record (a close is not a restart casualty);
+ *   - the warm spare ("::spare") never freezes.
+ */
+
+import type { PtyChild, PtyDriver, PtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-driver"
+import type { FrozenPtySession, PtyFreezeSink } from "@sma1lboy/kobe-daemon/daemon/pty-freeze-store"
+import { PtyHost } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { describe, expect, it } from "vitest"
+
+class FakeChild {
+  static nextPid = 1000
+  readonly pid = FakeChild.nextPid++
+  readonly written: string[] = []
+  resized: { cols: number; rows: number } | null = null
+  killed: NodeJS.Signals[] = []
+  private settle!: (exit: PtyExit) => void
+  readonly exited = new Promise<PtyExit>((resolve) => {
+    this.settle = resolve
+  })
+  constructor(private readonly onData: (data: string | Uint8Array) => void) {}
+  write(data: string): void {
+    this.written.push(data)
+    this.onData(data) // echo, like /bin/cat
+  }
+  resize(cols: number, rows: number): void {
+    this.resized = { cols, rows }
+  }
+  close(): void {}
+  kill(signal: NodeJS.Signals): void {
+    this.killed.push(signal)
+    this.settle({ code: null, signal })
+  }
+  /** Test-only: make the child exit on its own. */
+  exit(code: number): void {
+    this.settle({ code, signal: null })
+  }
+}
+
+interface Harness {
+  host: PtyHost
+  children: FakeChild[]
+  saved: Map<string, FrozenPtySession>
+  requests: Array<{ argv: readonly string[]; cwd: string }>
+  failNextSpawn: () => void
+}
+
+function harness(): Harness {
+  const children: FakeChild[] = []
+  const saved = new Map<string, FrozenPtySession>()
+  const requests: Array<{ argv: readonly string[]; cwd: string }> = []
+  let failSpawn = false
+  const driver: PtyDriver = (request) => {
+    if (failSpawn) {
+      failSpawn = false
+      throw new Error("spawn denied")
+    }
+    requests.push({ argv: request.argv, cwd: request.cwd })
+    const child = new FakeChild(request.onData)
+    children.push(child)
+    return child as unknown as PtyChild
+  }
+  const freeze: PtyFreezeSink = {
+    save: (record) => saved.set(record.key, record),
+    drop: (key) => saved.delete(key),
+  }
+  return {
+    children,
+    saved,
+    requests,
+    failNextSpawn: () => {
+      failSpawn = true
+    },
+    host: new PtyHost({ driver, freeze }),
+  }
+}
+
+const TOKEN = {}
+const SINK = () => {}
+const SPEC = { cwd: "/wt/t1", command: ["/bin/cat"], cols: 80, rows: 24 }
+
+function replayText(replay: string): string {
+  return Buffer.from(replay, "base64").toString("utf8")
+}
+
+describe("PtyHost freeze/restore", () => {
+  it("freezes live output (throttled), on exit, and on flushFrozen", () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+    h.children[0].write("one")
+    expect(h.saved.get("t1::tab-1")).toBeDefined()
+    const first = h.saved.get("t1::tab-1")
+    expect(replayText(first?.ringB64 ?? "")).toContain("one")
+
+    // Inside the throttle window a second chunk marks drift but does not write.
+    h.children[0].write("two")
+    expect(replayText(h.saved.get("t1::tab-1")?.ringB64 ?? "")).not.toContain("two")
+
+    h.host.flushFrozen()
+    expect(replayText(h.saved.get("t1::tab-1")?.ringB64 ?? "")).toContain("two")
+  })
+
+  it("a thawed corpse respawns IN PLACE on open: ring kept, caller spec wins", () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+    h.children[0].write("before-restart")
+    h.host.flushFrozen()
+
+    const h2 = harness()
+    expect(h2.host.restoreFrozen([freezeOf(h.saved, "t1::tab-1")])).toBe(1)
+    const row = h2.host.list().find((s) => s.key === "t1::tab-1")
+    expect(row).toMatchObject({ alive: false, restored: true })
+
+    // The TUI's dead-reattach passes its resume launch as the open spec.
+    const resumeSpec = { cwd: "/wt/t1", command: ["/bin/zsh", "-ilc", "claude --resume abc"] }
+    const res = h2.host.open("t1::tab-1", resumeSpec, {}, () => {})
+    expect(res).toMatchObject({ alive: true, created: false, respawned: true })
+    expect(replayText(res.replay)).toContain("before-restart")
+    expect(h2.requests[0].argv).toEqual(resumeSpec.command)
+    expect(h2.host.list()[0]).toMatchObject({ alive: true, restored: undefined })
+
+    // The respawned child is a working session, and totalBytes continues.
+    h2.children[0].write("after")
+    expect(h2.host.peek("t1::tab-1").offset).toBeGreaterThan(res.offset)
+  })
+
+  it("respawn falls back to the FROZEN command when the open spec carries none", () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+    h.host.flushFrozen()
+    const h2 = harness()
+    h2.host.restoreFrozen([h.saved.get("t1::tab-1")!])
+    const res = h2.host.open("t1::tab-1", { cwd: "/wt/t1" }, {}, () => {})
+    expect(res.respawned).toBe(true)
+    expect(h2.requests[0].argv).toEqual(["/bin/cat"])
+  })
+
+  it("a failed respawn degrades to an ordinary view-only corpse (no retry loop)", () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+    h.children[0].write("last words")
+    h.host.flushFrozen()
+    const h2 = harness()
+    h2.host.restoreFrozen([h.saved.get("t1::tab-1")!])
+    h2.failNextSpawn()
+    const res = h2.host.open("t1::tab-1", SPEC, {}, () => {})
+    expect(res).toMatchObject({ alive: false, created: false, respawned: false })
+    expect(replayText(res.replay)).toContain("last words")
+    expect(h2.host.list()[0]).toMatchObject({ alive: false, restored: undefined })
+  })
+
+  it("an ordinary (non-restored) corpse never respawns on open", async () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+    h.children[0].write("bye")
+    h.children[0].exit(1)
+    await new Promise((r) => setTimeout(r, 0)) // let the exited promise settle
+    const res = h.host.open("t1::tab-1", SPEC, {}, () => {})
+    expect(res).toMatchObject({ alive: false, respawned: false })
+    expect(h.children.length).toBe(1) // no new child
+  })
+
+  it("exit freezes the final state (exit record included); kill DROPS the record", async () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+    h.children[0].write("dying words")
+    h.children[0].exit(3)
+    await new Promise((r) => setTimeout(r, 0))
+    const record = h.saved.get("t1::tab-1")
+    expect(record?.exit).toMatchObject({ code: 3 })
+    expect(replayText(record?.ringB64 ?? "")).toContain("dying words")
+
+    await h.host.kill("t1::tab-1")
+    expect(h.saved.has("t1::tab-1")).toBe(false)
+  })
+
+  it("shutdown freezes everything but keeps the records (host restart ≠ close)", async () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+    h.children[0].write("work")
+    await h.host.shutdown()
+    expect(h.saved.has("t1::tab-1")).toBe(true)
+    expect(h.children[0].killed.length).toBeGreaterThan(0)
+  })
+
+  it("the warm spare never freezes (internal key)", () => {
+    const h = harness()
+    h.host.warm("/wt/t1", "/bin/zsh")
+    h.host.flushFrozen()
+    expect([...h.saved.keys()].every((k) => !k.startsWith("::"))).toBe(true)
+  })
+})
+
+/** Re-read helper kept separate so the respawn test reads linearly. */
+function freezeOf(saved: Map<string, FrozenPtySession>, key: string): FrozenPtySession {
+  const record = saved.get(key)
+  if (!record) throw new Error(`no frozen record for ${key}`)
+  return record
+}

--- a/packages/kobe/test/daemon/pty-server-restart.test.ts
+++ b/packages/kobe/test/daemon/pty-server-restart.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Server-level freeze/restore — the REAL restart story, over the wire:
+ * host A serves a session, the host process ends (close(), the idle-exit /
+ * SIGTERM shape), host B boots against the same freeze dir and must list
+ * the session as a restored corpse with its scrollback, and the first
+ * `pty.open` must respawn it in place. The second pin is `daemon.stop`
+ * (rove reset's graceful path): it must WIPE the store so the next host
+ * comes up empty — "starts fresh" is reset's contract.
+ *
+ * A fake driver keeps this deterministic under vitest (no real PTY); the
+ * socket, protocol, freeze-store files, and server lifecycle are all real.
+ * KOBE_HOME_DIR is redirected so the exit-record side write lands in the
+ * temp home, never the operator's.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import type { PtyOpenResult, PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import type { PtyChild, PtyDriver, PtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-driver"
+import { type PtyHostServer, startPtyHostServer } from "@sma1lboy/kobe-daemon/daemon/pty-server"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+let dir: string
+let socketPath: string
+let pidPath: string
+let freezeDir: string
+let savedHome: string | undefined
+const servers: PtyHostServer[] = []
+const clients: KobeDaemonClient[] = []
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kobe-pty-restart-"))
+  socketPath = join(dir, "pty.sock")
+  pidPath = join(dir, "pty.pid")
+  freezeDir = join(dir, "pty-sessions")
+  savedHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = dir
+})
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.close()
+  for (const server of servers.splice(0)) await server.close().catch(() => {})
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = savedHome
+  rmSync(dir, { recursive: true, force: true })
+})
+
+class FakeChild {
+  static nextPid = 2000
+  readonly pid = FakeChild.nextPid++
+  private settle!: (exit: PtyExit) => void
+  readonly exited = new Promise<PtyExit>((resolve) => {
+    this.settle = resolve
+  })
+  constructor(private readonly onData: (data: string | Uint8Array) => void) {}
+  write(data: string): void {
+    this.onData(data) // echo
+  }
+  resize(): void {}
+  close(): void {}
+  kill(signal: NodeJS.Signals): void {
+    this.settle({ code: null, signal })
+  }
+}
+
+const fakeDriver: PtyDriver = (request) => new FakeChild(request.onData) as unknown as PtyChild
+
+async function bootHost(): Promise<PtyHostServer> {
+  const server = await startPtyHostServer({ socketPath, pidPath, freezeDir, driver: fakeDriver, idleExitMs: 60_000 })
+  servers.push(server)
+  return server
+}
+
+async function connect(): Promise<KobeDaemonClient> {
+  const client = new KobeDaemonClient(socketPath)
+  await client.connect()
+  clients.push(client)
+  return client
+}
+
+interface ListRow {
+  key: string
+  alive: boolean
+  restored?: boolean
+  exit?: PtySessionExit | null
+}
+
+describe("pty-host server freeze/restore across a restart", () => {
+  it("a restarted host lists the frozen corpse and respawns it on open, scrollback intact", async () => {
+    await bootHost()
+    const a = await connect()
+    const opened = await a.request<PtyOpenResult>("pty.open", {
+      key: "t1::tab-1",
+      cwd: "/wt/t1",
+      command: ["/bin/cat"],
+    })
+    expect(opened.created).toBe(true)
+    await a.request("pty.write", { key: "t1::tab-1", data: "scene-of-the-work\n" })
+
+    // Host process ends (idle-exit / SIGTERM shape): children die, records stay.
+    await servers.splice(0)[0].close()
+    a.close()
+
+    await bootHost()
+    const b = await connect()
+    const listed = await b.request<{ sessions: ListRow[] }>("pty.list", {})
+    expect(listed.sessions).toHaveLength(1)
+    expect(listed.sessions[0]).toMatchObject({ key: "t1::tab-1", alive: false, restored: true })
+
+    const reattached = await b.request<PtyOpenResult>("pty.open", {
+      key: "t1::tab-1",
+      cwd: "/wt/t1",
+      command: ["/bin/cat"],
+    })
+    expect(reattached).toMatchObject({ alive: true, created: false, respawned: true })
+    expect(Buffer.from(reattached.replay, "base64").toString("utf8")).toContain("scene-of-the-work")
+  })
+
+  it("daemon.stop (rove reset) WIPES the freeze store — the next host comes up empty", async () => {
+    await bootHost()
+    const a = await connect()
+    await a.request("pty.open", { key: "t1::tab-1", cwd: "/wt/t1", command: ["/bin/cat"] })
+    await a.request("pty.write", { key: "t1::tab-1", data: "x" })
+    await a.request("daemon.stop", {})
+    // The stop is scheduled on a macrotask; wait for the socket to go away.
+    const deadline = Date.now() + 3000
+    for (;;) {
+      await new Promise((r) => setTimeout(r, 25))
+      const probe = new KobeDaemonClient(socketPath)
+      const up = await probe.connect().then(
+        () => true,
+        () => false,
+      )
+      probe.close()
+      if (!up) break
+      if (Date.now() > deadline) throw new Error("host did not stop")
+    }
+
+    await bootHost()
+    const b = await connect()
+    const listed = await b.request<{ sessions: ListRow[] }>("pty.list", {})
+    expect(listed.sessions).toEqual([])
+  })
+})

--- a/packages/kobe/test/render/pty-freeze.test.ts
+++ b/packages/kobe/test/render/pty-freeze.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Freeze/restore against REAL PTY children (`/bin/cat` echo) and the REAL
+ * per-session file store — the end-to-end half of the contract the fake
+ * driver tests in test/daemon can't cover: a thawed session's respawn must
+ * produce a working terminal, and the replay must be the pre-restart bytes.
+ *
+ * Lives in test/render (the bun-test track) for the same reason as
+ * pty-host.test.ts: `Bun.spawn(..., { terminal })` needs the Bun runtime.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { DaemonFrame } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { fileFreezeSink, loadFrozenSessions } from "@sma1lboy/kobe-daemon/daemon/pty-freeze-store"
+import { PtyHost } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+
+const hosts: PtyHost[] = []
+const dirs: string[] = []
+
+function makeHost(opts: ConstructorParameters<typeof PtyHost>[0] = {}): PtyHost {
+  const host = new PtyHost(opts)
+  hosts.push(host)
+  return host
+}
+
+function makeFreezeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-pty-freeze-bun-"))
+  dirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await Promise.all(hosts.splice(0).map((host) => host.killAll()))
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function collector(): { frames: DaemonFrame[]; sink: (frame: DaemonFrame) => void } {
+  const frames: DaemonFrame[] = []
+  return { frames, sink: (frame) => frames.push(frame) }
+}
+
+function dataText(frames: DaemonFrame[]): string {
+  let out = ""
+  for (const frame of frames) {
+    if (frame.type === "event" && frame.name === "pty.data") {
+      out += Buffer.from((frame.payload as { data: string }).data, "base64").toString("utf8")
+    }
+  }
+  return out
+}
+
+async function until(cond: () => boolean, ms = 3000): Promise<void> {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > ms) throw new Error("timeout waiting for condition")
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+const SPEC = { cwd: process.cwd(), command: ["/bin/cat"], cols: 40, rows: 10 }
+
+describe("PtyHost freeze/restore with real PTYs", () => {
+  test("a host restart restores the session: scrollback replays, the respawned child works", async () => {
+    const freezeDir = makeFreezeDir()
+    const hostA = makeHost({ freeze: fileFreezeSink(freezeDir) })
+    const first = collector()
+    hostA.open("t1::tab-1", SPEC, {}, first.sink)
+    hostA.write("t1::tab-1", "before-restart\n")
+    await until(() => dataText(first.frames).includes("before-restart"))
+
+    // The host process ends: children are ended, freeze records stay.
+    await hostA.shutdown()
+    expect(hosts.splice(0).includes(hostA)).toBe(true) // removed so afterEach skips it
+    const records = loadFrozenSessions(freezeDir)
+    expect(records.map((r) => r.key)).toEqual(["t1::tab-1"])
+
+    // The next host incarnation thaws the record; the first open respawns.
+    const hostB = makeHost({ freeze: fileFreezeSink(freezeDir) })
+    expect(hostB.restoreFrozen(records)).toBe(1)
+    const second = collector()
+    const res = hostB.open("t1::tab-1", SPEC, {}, second.sink)
+    expect(res).toMatchObject({ alive: true, created: false, respawned: true })
+    expect(Buffer.from(res.replay, "base64").toString("utf8")).toContain("before-restart")
+
+    hostB.write("t1::tab-1", "after-restart\n")
+    await until(() => dataText(second.frames).includes("after-restart"))
+  })
+})


### PR DESCRIPTION
## What

The standalone pty host kept every session's metadata and scrollback ring **in memory only**, so while `rove daemon restart` was harmless (separate process), the host process itself ending — crash, SIGTERM, machine reboot — took the whole work scene with it: `pty.list` came up empty and reattaching spawned a blank shell/engine.

This PR adds freeze/restore: the host persists every session (key, cwd, launch command, size, title, monotonic byte offset, exit record, and the capped ~512 KiB ring, base64) to `<home>/.kobe/pty-sessions/` — one atomic file per session, throttled to one write per 5s while streaming, immediately on exit, and in full at shutdown. A restarted host thaws each record into a dead `restored` corpse with its scrollback intact.

## Respawn semantics

Restore is **lazy**: nothing spawns at boot (a reboot must not fan out 20 engines' worth of quota). The first `pty.open` on a restored session respawns the child **in place** — the old ring replays first, live output appends, `totalBytes` keeps counting. The caller's spawn spec wins when it carries a command: the TUI's dead-reattach already passes its `--resume <sessionId>` launch, so engine conversation resume composes with scrollback restore with zero TUI changes. A failed respawn clears `restored` and degrades to the ordinary view-only corpse path.

Wire additions (both optional, backward compatible): `pty.open` result gains `respawned` (distinct from `created` — the launch spec *was* consumed, so a prompt riding its argv must not be pasted twice); `pty.list` rows gain `restored`. Headless delivery (`deliverHostedPrompt`) no longer kills a restored canonical corpse before opening.

CLI-started sessions (`rove api add`/`send`) now pin their claude conversation id up front (`withClaudeSessionId`, the TUI's existing contract) and record `sessionId` + `spawned` in the persisted tab snapshot once the session provably started — headless tasks become resumable exactly like TUI-spawned tabs.

## Forget semantics (an intentional end is never resurrected)

- Explicit `pty.kill` (tab close) and the archive sweep **drop** the freeze record.
- `rove reset`'s graceful `daemon.stop` **wipes the whole store** — starts fresh means fresh.
- Idle-exit / SIGTERM / crash / reboot keep the store — those are the restarts freeze/restore exists for.

## Verification

- New tests: store unit (`pty-freeze-store.test.ts`), fake-driver host semantics (`pty-host-freeze.test.ts`), real-socket server across a restart incl. reset-wipe (`pty-server-restart.test.ts`), real `/bin/cat` PTY + real file store end to end (`test/render/pty-freeze.test.ts`), CLI delivery/snapshot pins.
- Gates green on rebased `origin/main`: lint, typecheck, `test:fast` + `test:socket` (552), `test:render` (161), `test:behavior` (19 passed / 4 env-skipped).
- Real-process e2e: seeded a session in a real `kobe pty-host`, `kill -9`'d the host, started a new one — `pty.list` reported the session as a restored corpse and `pty.open` returned `respawned: true` with the pre-crash output in the replay.

Design note: `docs/design/pty-freeze.md`; user-facing survival table updated in `docs/SESSIONS.md`.