### PR TITLE
fix: pre-trust Rove-created worktrees in each vendor's first-run store (issue #28)

### DIFF
--- a/.changeset/engine-trust-worktree.md
+++ b/.changeset/engine-trust-worktree.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+fix: hosted engine sessions no longer die or stall on the vendor's first-run workspace-trust dialog (issue #28). Every vendor gates a never-seen directory — and every Rove task worktree is one: kimi's dialog default-cursor exits the process when the pasted first message's Enter lands on "Don't trust", while claude/codex sit at the prompt forever. Before spawning an engine into a Rove-created worktree, Rove now writes the vendor's own trust record via a new engine-owned `trustWorktree` registry hook (claude: `~/.claude.json` project entry, merge-preserving; codex: `config.toml` trusted-project table, append-only; kimi: `workspace-trust` record file), best-effort and never blocking a launch. Your own directories are untouched.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -43,6 +43,19 @@ Codex accepts `none`, `low`, `medium`, `high`, `xhigh`, passed as
 `-c model_reasoning_effort=<level>`. Other engines have no effort flag Rove
 can drive; a selected effort is ignored there rather than passed through.
 
+### Workspace trust
+
+Claude, Codex, and Kimi each gate a first launch in a never-seen directory
+behind a trust dialog — and every task worktree is such a directory, so a
+hosted session can't answer it (Kimi's dialog even exits the process when a
+pasted first message lands on "Don't trust"). Before spawning an engine into
+a Rove-created worktree, Rove writes the vendor's own trust record for that
+path — `~/.claude.json` `projects[<path>].hasTrustDialogAccepted`,
+`~/.codex/config.toml` `[projects."<path>"] trust_level = "trusted"`, or
+`~/.kimi-code/workspace-trust/` — merging into existing entries, never
+clobbering. This only ever fires for worktrees Rove itself created from a
+repo you already work in; your own directories are untouched.
+
 ### Custom launch commands
 
 Override any engine's launch command in Settings → Engines, or by hand in

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -9,6 +9,7 @@
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { interactiveEngineCommand, withClaudeSessionId } from "../../engine/interactive-command.ts"
 import { buildEngineSessionLaunch } from "../../engine/session-launch.ts"
+import { trustEngineWorktree } from "../../engine/trust-worktree.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
 import {
   deliverHostedPrompt,
@@ -62,6 +63,9 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
       interactiveEngineCommand(target.vendor, target.modelEffort),
       target.vendor,
     )
+    // Pre-trust the worktree in the vendor's first-run store (issue #28) —
+    // a hosted session can't answer a trust dialog.
+    trustEngineWorktree(target.vendor, worktree)
     const launch = buildEngineSessionLaunch({
       task: { id: target.id, kind: target.kind, vendor: target.vendor, repo: target.repo },
       worktreePath: worktree,

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -14,6 +14,7 @@ import {
 } from "../engine/hosted-session.ts"
 import { interactiveEngineCommand } from "../engine/interactive-command.ts"
 import { buildEngineSessionLaunch } from "../engine/session-launch.ts"
+import { trustEngineWorktree } from "../engine/trust-worktree.ts"
 import { TaskDeletingError } from "../orchestrator/errors.ts"
 import type { PromptDeliveryIntent } from "../state/repo-init.ts"
 import type { VendorId } from "../types/task.ts"
@@ -90,6 +91,8 @@ export async function startTaskSessionWithPromptAdapter(
 }
 
 function taskEngineLaunch(task: SerializedTask, worktreePath: string, promptIntent: PromptDeliveryIntent) {
+  // Pre-trust the worktree in the vendor's first-run store (issue #28).
+  trustEngineWorktree(task.vendor, worktreePath)
   return buildEngineSessionLaunch({
     task: { id: task.id, kind: task.kind, vendor: task.vendor, repo: task.repo },
     worktreePath,

--- a/packages/kobe/src/engine/claude-code-local/trust.ts
+++ b/packages/kobe/src/engine/claude-code-local/trust.ts
@@ -1,0 +1,37 @@
+/**
+ * Claude Code workspace trust (issue #28). Claude gates a first launch in a
+ * never-seen directory behind a "Do you trust the files in this folder?"
+ * dialog; a Rove task worktree is always such a directory, so a hosted
+ * session would sit at the dialog forever. Rove created the worktree from a
+ * repo the user already drives sessions in — pre-accepting trust for it is
+ * the same trust domain, and the only headless-viable answer.
+ *
+ * The store is `~/.claude.json` → `projects[<abspath>].hasTrustDialogAccepted`
+ * (existing entries also carry `hasCompletedProjectOnboarding`). MERGE, never
+ * clobber: project entries accumulate per-project state (allowedTools, MCP
+ * choices) that must survive.
+ */
+
+import { readFileSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
+
+export function trustClaudeWorktree(worktreePath: string, home: string = homedir()): void {
+  const file = path.join(home, ".claude.json")
+  let doc: Record<string, unknown> = {}
+  try {
+    doc = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>
+  } catch {
+    // Missing or corrupt — start from an empty doc; corrupt is claude's own
+    // recovery behavior too (it rewrites the file wholesale on every save).
+  }
+  const projects = { ...((doc.projects as Record<string, unknown> | undefined) ?? {}) }
+  const existing = (projects[worktreePath] ?? {}) as Record<string, unknown>
+  if (existing.hasTrustDialogAccepted === true) return
+  projects[worktreePath] = { ...existing, hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true }
+  doc.projects = projects
+  // tmp + rename so a crash mid-write can't truncate the store.
+  const tmp = `${file}.rove-${process.pid}`
+  writeFileSync(tmp, JSON.stringify(doc, null, 2))
+  renameSync(tmp, file)
+}

--- a/packages/kobe/src/engine/codex-local/trust.ts
+++ b/packages/kobe/src/engine/codex-local/trust.ts
@@ -1,0 +1,32 @@
+/**
+ * Codex workspace trust (issue #28). Codex gates a never-seen directory
+ * behind its own trust prompt; the store is `~/.codex/config.toml` —
+ * `[projects."<abspath>"] trust_level = "trusted"`. Pre-trusting a
+ * Rove-created worktree is the same trust domain as the repo the user
+ * already runs sessions in, and the only headless-viable answer.
+ *
+ * Append-only: a `[projects.*]` table at EOF attaches to nothing, so the
+ * rest of the user's config is never parsed or rewritten.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
+
+export function trustCodexWorktree(worktreePath: string, home: string = homedir()): void {
+  const dir = path.join(home, ".codex")
+  const file = path.join(dir, "config.toml")
+  // JSON.stringify doubles as a TOML basic-string quoter for the path.
+  const header = `[projects.${JSON.stringify(worktreePath)}]`
+  let text = ""
+  try {
+    text = readFileSync(file, "utf8")
+  } catch {
+    // No config yet — the append below creates it.
+  }
+  if (text.includes(header)) return
+  mkdirSync(dir, { recursive: true })
+  if (!existsSync(file)) writeFileSync(file, "")
+  const lead = text.length > 0 && !text.endsWith("\n") ? "\n" : ""
+  appendFileSync(file, `${lead}\n${header}\ntrust_level = "trusted"\n`)
+}

--- a/packages/kobe/src/engine/kimi-local/trust.ts
+++ b/packages/kobe/src/engine/kimi-local/trust.ts
@@ -1,0 +1,27 @@
+/**
+ * Kimi Code workspace trust (issue #28 / #25 follow-up). Kimi shows a
+ * "Trust this folder?" dialog on first launch in a directory — and its
+ * default cursor sits on "Don't trust", so a pasted first message's submit
+ * Enter EXITS the engine ("Bye!"). The store is one file per workspace:
+ * `~/.kimi-code/workspace-trust/wd_<dirname>_<sha256(abspath)[:12]>`
+ * containing {"root": <abspath>, "trustedAt": <ms epoch>} (naming verified
+ * against live installs 2026-08-15). Pre-trusting a Rove-created worktree
+ * is the same trust domain as the repo the user already runs sessions in.
+ */
+
+import { createHash } from "node:crypto"
+import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import path from "node:path"
+
+export function kimiTrustFilePath(worktreePath: string, home: string = homedir()): string {
+  const hash = createHash("sha256").update(worktreePath).digest("hex").slice(0, 12)
+  return path.join(home, ".kimi-code", "workspace-trust", `wd_${path.basename(worktreePath)}_${hash}`)
+}
+
+export function trustKimiWorktree(worktreePath: string, home: string = homedir()): void {
+  const file = kimiTrustFilePath(worktreePath, home)
+  if (existsSync(file)) return
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+  writeFileSync(file, JSON.stringify({ root: worktreePath, trustedAt: Date.now() }), { mode: 0o600 })
+}

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -43,9 +43,11 @@ import {
 import { claudeCapabilities, claudeIdentity } from "./claude-code-local/capabilities.ts"
 import { ClaudeHookAdapter } from "./claude-code-local/hook-adapter.ts"
 import { fetchClaudeQuotaUsage } from "./claude-code-local/quota.ts"
+import { trustClaudeWorktree } from "./claude-code-local/trust.ts"
 import { codexCapabilities, codexIdentity } from "./codex-local/capabilities.ts"
 import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
 import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
+import { trustCodexWorktree } from "./codex-local/trust.ts"
 import {
   EMPTY_HISTORY,
   claudeHistoryReader,
@@ -54,6 +56,7 @@ import {
   kimiHistoryReader,
 } from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
+import { trustKimiWorktree } from "./kimi-local/trust.ts"
 import { ClaudeTurnDetector, CodexTurnDetector, type EngineTurnDetector, UnknownTurnDetector } from "./turn-detector.ts"
 
 /**
@@ -198,6 +201,15 @@ export interface EngineRegistryEntry {
    * shell and prompt delivery refuses with ENGINE_NOT_RUNNING.
    */
   readonly processNames?: readonly string[]
+  /**
+   * Pre-trust a Rove-created worktree in the vendor's first-run trust
+   * store (issue #28). Every vendor gates a never-seen directory behind a
+   * modal trust dialog; hosted sessions can't answer one (kimi's even
+   * EXITS when the pasted first message's Enter lands on "Don't trust").
+   * Called before a hosted spawn; must be idempotent and merge-preserving.
+   * Absent = the vendor has no gate kobe knows how to pre-answer.
+   */
+  readonly trustWorktree?: (worktreePath: string) => void
 }
 
 // The per-vendor readers live in `history-readers.ts` (file-size cap);
@@ -218,6 +230,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     createTurnDetector: () => new ClaudeTurnDetector(),
     capabilities: claudeCapabilities,
     identity: claudeIdentity,
+    trustWorktree: trustClaudeWorktree,
     terminalTitle: {
       ownsStatus: true,
       // `${prefix} ${title}` where prefix is ✳ at rest and cycles through
@@ -242,6 +255,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     createTurnDetector: () => new CodexTurnDetector(),
     capabilities: codexCapabilities,
     identity: codexIdentity,
+    trustWorktree: trustCodexWorktree,
     // Codex's default is activity + project-name, which makes every tab in
     // one repo say "kobe". Keep its native activity state, but ask Codex to
     // pair it with the thread title it already owns in its local store.
@@ -280,6 +294,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     // The installed Mach-O binary rewrites its process title to `kimi-co`
     // after launch, so a live kimi session's argv[0] never reads `kimi`.
     processNames: ["kimi-co"],
+    trustWorktree: trustKimiWorktree,
     history: kimiHistoryReader,
     detectAccount: (deps) => detectKimiAccount(deps),
     createHookAdapter: () => new NoopHookAdapter("kimi"),

--- a/packages/kobe/src/engine/trust-worktree.ts
+++ b/packages/kobe/src/engine/trust-worktree.ts
@@ -1,0 +1,21 @@
+/**
+ * Worktree pre-trust at spawn time (issue #28). A Rove-created worktree is
+ * a directory the engine has never seen, and every vendor gates that behind
+ * a first-run trust dialog a hosted session cannot answer — kimi's dialog
+ * even EXITS the process when the pasted first message's Enter lands on
+ * "Don't trust"; claude/codex sit at the prompt forever. The vendor-specific
+ * store writes live behind the registry's `trustWorktree` hook; THIS wrapper
+ * owns the call policy every spawn path shares: best-effort, never blocks a
+ * launch (a failed write leaves the pre-#28 status quo — the dialog).
+ */
+
+import type { VendorId } from "../types/vendor.ts"
+import { engineEntry } from "./registry.ts"
+
+export function trustEngineWorktree(vendor: VendorId | undefined, worktreePath: string): void {
+  try {
+    engineEntry(vendor ?? "claude").trustWorktree?.(worktreePath)
+  } catch {
+    /* best-effort — see the module doc */
+  }
+}

--- a/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
@@ -11,6 +11,7 @@ import {
   type EngineSessionProtocolGates,
   buildEngineSessionLaunch,
 } from "@/engine/session-launch"
+import { trustEngineWorktree } from "@/engine/trust-worktree"
 import { forkSessionArgv } from "../../engine/interactive-command"
 import type { TabSpawn } from "./terminal-tab-spawn"
 import type { EngineTab, TabsState, TerminalTab } from "./terminal-tabs-core"
@@ -85,6 +86,9 @@ export function engineTabSpawnFor(
   // task's first tab: its id, worktree, and tab identity — so activity,
   // hooks, and a dead-reattach resume all belong to the story's task.
   const ref = tab.ptyTask
+  // Pre-trust the worktree in the vendor's first-run store (issue #28) — a
+  // hosted session can't answer a trust dialog. The tab's pinned vendor wins.
+  trustEngineWorktree(tab.vendor ?? opts.task.vendor, ref?.worktree ?? opts.worktreePath)
   const launch = buildEngineSessionLaunch({
     task: ref ? { ...opts.task, id: ref.id, kind: "task" } : opts.task,
     worktreePath: ref?.worktree ?? opts.worktreePath,

--- a/packages/kobe/test/engine/trust-worktree.test.ts
+++ b/packages/kobe/test/engine/trust-worktree.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Vendor worktree pre-trust (issue #28): each adapter writes its vendor's
+ * first-run trust record for a Rove-created worktree — merge-preserving and
+ * idempotent, because these stores belong to the user's real CLI installs.
+ * Runs against temp HOME dirs; the real stores are never touched.
+ */
+
+import { createHash } from "node:crypto"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { trustClaudeWorktree } from "../../src/engine/claude-code-local/trust.ts"
+import { trustCodexWorktree } from "../../src/engine/codex-local/trust.ts"
+import { kimiTrustFilePath, trustKimiWorktree } from "../../src/engine/kimi-local/trust.ts"
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+function tempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-trust-"))
+  tempDirs.push(home)
+  return home
+}
+
+const WORKTREE = "/wt/rove-task-1"
+
+describe("trustKimiWorktree", () => {
+  it("writes the workspace-trust record named by sha256(path)[:12]", () => {
+    const home = tempHome()
+    trustKimiWorktree(WORKTREE, home)
+    const hash = createHash("sha256").update(WORKTREE).digest("hex").slice(0, 12)
+    const file = kimiTrustFilePath(WORKTREE, home)
+    expect(file).toBe(path.join(home, ".kimi-code", "workspace-trust", `wd_rove-task-1_${hash}`))
+    const record = JSON.parse(fs.readFileSync(file, "utf8")) as { root: string; trustedAt: number }
+    expect(record.root).toBe(WORKTREE)
+    expect(typeof record.trustedAt).toBe("number")
+  })
+
+  it("is idempotent — an existing record is not rewritten", () => {
+    const home = tempHome()
+    trustKimiWorktree(WORKTREE, home)
+    const file = kimiTrustFilePath(WORKTREE, home)
+    fs.writeFileSync(file, JSON.stringify({ root: WORKTREE, trustedAt: 1 }))
+    trustKimiWorktree(WORKTREE, home)
+    expect(JSON.parse(fs.readFileSync(file, "utf8"))).toEqual({ root: WORKTREE, trustedAt: 1 })
+  })
+})
+
+describe("trustClaudeWorktree", () => {
+  it("merges into an existing store, preserving other projects and keys", () => {
+    const home = tempHome()
+    fs.writeFileSync(
+      path.join(home, ".claude.json"),
+      JSON.stringify({
+        numStartups: 42,
+        projects: {
+          "/repo": { allowedTools: ["Bash(git *)"], hasTrustDialogAccepted: true },
+          [WORKTREE]: { allowedTools: ["Read"] },
+        },
+      }),
+    )
+    trustClaudeWorktree(WORKTREE, home)
+    const doc = JSON.parse(fs.readFileSync(path.join(home, ".claude.json"), "utf8"))
+    expect(doc.numStartups).toBe(42)
+    expect(doc.projects["/repo"]).toEqual({ allowedTools: ["Bash(git *)"], hasTrustDialogAccepted: true })
+    // The worktree's existing per-project state survives the trust merge.
+    expect(doc.projects[WORKTREE]).toMatchObject({
+      allowedTools: ["Read"],
+      hasTrustDialogAccepted: true,
+      hasCompletedProjectOnboarding: true,
+    })
+  })
+
+  it("creates a fresh store when none exists, and skips a second accept", () => {
+    const home = tempHome()
+    trustClaudeWorktree(WORKTREE, home)
+    const file = path.join(home, ".claude.json")
+    expect(JSON.parse(fs.readFileSync(file, "utf8")).projects[WORKTREE].hasTrustDialogAccepted).toBe(true)
+    const before = fs.readFileSync(file, "utf8")
+    trustClaudeWorktree(WORKTREE, home)
+    expect(fs.readFileSync(file, "utf8")).toBe(before)
+  })
+})
+
+describe("trustCodexWorktree", () => {
+  it("appends a trusted project table without touching existing config", () => {
+    const home = tempHome()
+    const dir = path.join(home, ".codex")
+    fs.mkdirSync(dir, { recursive: true })
+    const file = path.join(dir, "config.toml")
+    fs.writeFileSync(file, 'model = "gpt-5"\n\n[projects."/repo"]\ntrust_level = "trusted"\n')
+    trustCodexWorktree(WORKTREE, home)
+    const text = fs.readFileSync(file, "utf8")
+    expect(text).toContain('model = "gpt-5"')
+    expect(text).toContain(`[projects.${JSON.stringify(WORKTREE)}]\ntrust_level = "trusted"`)
+  })
+
+  it("creates the config when absent and never double-appends", () => {
+    const home = tempHome()
+    trustCodexWorktree(WORKTREE, home)
+    trustCodexWorktree(WORKTREE, home)
+    const text = fs.readFileSync(path.join(home, ".codex", "config.toml"), "utf8")
+    expect(text.split(`[projects.${JSON.stringify(WORKTREE)}]`)).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
Every vendor gates a first launch in a never-seen directory behind a modal trust dialog, and every Rove task worktree is such a directory. Hosted sessions can't answer a dialog: **kimi's** default cursor sits on "Don't trust", so a pasted first message's submit Enter exits the process (observed live via `pty.peek`); **claude/codex** sit at the prompt forever and read idle-stuck.

A new engine-owned `trustWorktree` registry hook writes the vendor's own trust record before the three hosted-spawn paths (CLI `add`/`send`, daemon automation, TUI tab spawn) launch:

- **claude**: `~/.claude.json` `projects[<path>].hasTrustDialogAccepted` — merge-preserving (per-project state like allowedTools survives), atomic tmp+rename
- **codex**: `~/.codex/config.toml` `[projects."<path>"] trust_level = "trusted"` — append-only table, existing config never reparsed
- **kimi**: `~/.kimi-code/workspace-trust/wd_<dir>_<sha256(path)[:12]>` record file (naming verified against the live install)

Semantics: this only ever fires for worktrees Rove itself created from a repo the user already runs sessions in — same trust domain; the user's own directories are untouched. A trust-write failure is swallowed (best-effort; a failure leaves the pre-#28 status quo). All store formats verified on a live machine 2026-08-16.

Tests: `test/engine/trust-worktree.test.ts` pins each adapter's write against temp HOMEs (naming, content, merge preservation, idempotence). lint + typecheck + 1980 tests green. Changeset: patch. Docs: ENGINES.md gains a Workspace trust section.