### PR TITLE
fix: keep sidebar tab titles live for unselected tasks

### DIFF
--- a/.changeset/live-sidebar-tab-title.md
+++ b/.changeset/live-sidebar-tab-title.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Sidebar tab rows now show each session's live title, not the one recorded the last time you opened that task. The title is read from the pty host's OSC observation — which runs whether or not anything is attached — and goes through the same status-prefix strip as before, so a row still shows the conversation name beside kobe's own state glyph rather than the engine's spinner frame.

--- a/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
@@ -20,6 +20,7 @@
  * ordinals, kinds and split state a session key can't.
  */
 
+import { stripEngineStatusPrefix } from "../../../engine/registry"
 import { type TreeTab, parseRowId, tabRowId } from "../../../tui/panes/sidebar/tree-core"
 
 /** One live pty-host session, as this module needs it. */
@@ -39,7 +40,12 @@ export interface LiveSession {
  *
  * The label is the live process title when the host has one, else the tab
  * id, prefixed ⚠ — the row exists because the snapshot does NOT know this
- * session, and that is worth a glance.
+ * session, and that is worth a glance. The title is a RAW OSC string here
+ * (nobody has stripped it — that happens on the mounted-tab path), so the
+ * engine's own status decoration comes off first: kobe draws the state glyph
+ * on this row, and two status languages side by side is what
+ * `stripEngineStatusPrefix` exists to prevent. Vendor-agnostic strip — an
+ * unregistered session has no resolved vendor by construction.
  */
 export function orphanTabsByTask(
   sessions: readonly LiveSession[],
@@ -59,7 +65,7 @@ export function orphanTabsByTask(
     if (tabs.some((tab) => tab.id === tabId)) continue
     tabs.push({
       id: tabId,
-      label: `⚠ ${session.title?.trim() || tabId}`,
+      label: `⚠ ${stripEngineStatusPrefix(session.title?.trim() ?? "", null).trim() || tabId}`,
       // The first unregistered tab of a snapshot-less task reads active; the
       // caller demotes this when merging under a task that has snapshot tabs.
       active: tabs.length === 0,

--- a/packages/kobe/src/tui-react/panes/sidebar/use-host-sessions.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-host-sessions.ts
@@ -23,6 +23,23 @@ const POLL_MS = 2_000
 const EMPTY: readonly LiveSession[] = []
 
 /**
+ * True when two polls report the same sessions in the same state.
+ *
+ * The poll allocates a fresh array every 2s, and its consumers now include
+ * the tab-title projection — which rebuilds the whole tree when this
+ * changes. Comparing the fields the tree actually reads keeps a quiet host
+ * render-free; a title moving (the point of the projection) still gets
+ * through.
+ */
+function sameSessions(a: readonly LiveSession[], b: readonly LiveSession[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((s, i) => {
+    const other = b[i] as LiveSession
+    return s.key === other.key && s.alive === other.alive && s.title === other.title
+  })
+}
+
+/**
  * Off under a test runner. `getSharedPtyClient` caches ONE connection per
  * process, and bun-test runs every render file in one process — so a sidebar
  * mounted by any test would connect to whatever socket was current and pin
@@ -46,11 +63,11 @@ export function useHostSessions(enabled = pollingAllowed()): readonly LiveSessio
       try {
         const client = await getSharedPtyClient()
         const { sessions: live = [] } = await client.request<{ sessions?: LiveSession[] }>("pty.list", {})
-        if (!cancelled) setSessions(live)
+        if (!cancelled) setSessions((prev) => (sameSessions(prev, live) ? prev : live))
       } catch {
         // No host / no verb / socket died — report no orphans and retry on
         // the next tick rather than tearing the poll down.
-        if (!cancelled) setSessions(EMPTY)
+        if (!cancelled) setSessions((prev) => (prev.length === 0 ? prev : EMPTY))
       }
     }
     void poll()

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -89,6 +89,23 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   // Live pty-host inventory, for tasks the snapshot can't answer for.
   const hostSessions = useHostSessions()
 
+  // ptyKey → the host's LIVE OSC title. The host scans every session's
+  // output whether or not anyone attached, so this answers for tabs whose
+  // `TerminalTabs` is not mounted — the ones whose recorded `lastTitle`
+  // only moves when you click into them (owner report: the row's state glyph
+  // is live via the daemon's engine-state channel while its title sat frozen
+  // beside it). Empty titles are dropped: `""` is the host's "child has set
+  // no title yet", not a name, and letting it through would blank a row that
+  // has a perfectly good recorded one.
+  const liveTitles = useMemo<ReadonlyMap<string, string>>(() => {
+    const map = new Map<string, string>()
+    for (const session of hostSessions) {
+      const title = session.title?.trim()
+      if (title) map.set(session.key, title)
+    }
+    return map
+  }, [hostSessions])
+
   // Tab projection. `tasks` identity changes on every daemon snapshot echo,
   // which is also exactly when a tab's live title may have moved — so this
   // recomputing with it is correct, not wasteful.
@@ -109,16 +126,18 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
           // engine-free shell must not resurrect the identity of whatever ran
           // there before (a ctrl+C'd codex kept its tab labelled "codex N"
           // through the old `?? recorded` fallback).
-          const probed = liveEngines.resolve(tabPtyKeyFor(task.id, tab))
+          const ptyKey = tabPtyKeyFor(task.id, tab)
+          const probed = liveEngines.resolve(ptyKey)
           const live = probed === undefined ? tab.liveVendor : probed
           return {
             id: tab.id,
             // `tabTitleStable`, NOT `tabTitle`: for a status-owning engine the
-            // recorded title IS its self-reported status (`⠐ 利用自进化…`), and
-            // the tree has no live stream to refresh it — so the row would
-            // wear a frozen spinner phrase that contradicts the state glyph
-            // right next to it, which kobe derives from daemon activity.
-            label: tabTitleStable(tab, vendor, live),
+            // recorded title IS its self-reported status (`⠐ 利用自进化…`), so
+            // the row would wear a spinner phrase that contradicts the state
+            // glyph right next to it, which kobe derives from daemon activity.
+            // The host's live title rides in as an argument (not painted
+            // directly) so it goes through that same strip.
+            label: tabTitleStable(tab, vendor, live, liveTitles.get(ptyKey)),
             // The active tab carries the task's state glyph (activity is
             // task-scoped; the active tab is the session it describes).
             active: tab.id === known.activeId,
@@ -135,7 +154,7 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
       )
     }
     return map
-  }, [tasks, kv, liveEngines, liveTick])
+  }, [tasks, kv, liveEngines, liveTick, liveTitles])
 
   // Backstop: any LIVE pty session the snapshots don't answer for becomes an
   // explicit unregistered row — tab-granular, so a task whose snapshot lists

--- a/packages/kobe/src/tui/workspace/terminal-tab-split.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-split.ts
@@ -163,8 +163,8 @@ export function meaningfulAutoTitle(autoTitle: string | null | undefined): strin
  * name — but in the tree a lone glyph is not a label, so the caller falls
  * through to the first-prompt summary or the vendor default instead.
  */
-function stableRecordedTitle(tab: TerminalTab, vendor: VendorId): string | null {
-  const recorded = tab.lastTitle?.trim()
+function stableRecordedTitle(raw: string | null | undefined, vendor: VendorId): string | null {
+  const recorded = raw?.trim()
   if (!recorded) return null
   const cleaned = stripEngineStatusPrefix(recorded, vendor)
   // Unchanged AND made only of this engine's glyphs = decoration, not a name.
@@ -196,8 +196,23 @@ function isEngineDecoration(text: string, vendor: VendorId): boolean {
  * display-side, so old snapshots heal without a migration (same approach as
  * `meaningfulAutoTitle`). A manual rename still wins: that is the user's
  * name, not the engine's.
+ *
+ * `liveTitle` is the pty host's CURRENT OSC title for this tab's session,
+ * when the caller has one. `lastTitle` is a recording written only by the
+ * mounted `TerminalTabs`, i.e. only for the selected task — so on every
+ * other row it froze at whatever it said when you last clicked in, beside a
+ * state glyph the daemon keeps live. Passing the live title in here (rather
+ * than painting it directly) is what keeps it subject to the whole rule
+ * below: the same status-prefix strip, the same decoration-only rejection,
+ * and the same manual-rename precedence. Absent → the recorded title, which
+ * is also the flash guard the live probe's ~2s gap needs.
  */
-export function tabTitleStable(tab: TerminalTab, taskVendor: VendorId, liveVendor?: VendorId | null): string {
+export function tabTitleStable(
+  tab: TerminalTab,
+  taskVendor: VendorId,
+  liveVendor?: VendorId | null,
+  liveTitle?: string | null,
+): string {
   // `liveVendor` is tri-state: a vendor = that engine runs in the tab NOW;
   // null = the probe CONFIRMED no engine (a ctrl+C'd tab sitting at its
   // shell prompt); undefined = the probe can't answer, fall back to the pin.
@@ -222,7 +237,12 @@ export function tabTitleStable(tab: TerminalTab, taskVendor: VendorId, liveVendo
   // real claude) that declares nothing. Gating here left exactly those tabs
   // wearing `⠂ …`. What `ownsStatus` still decides is the fallback identity
   // below.
-  const named = vendor ? stableRecordedTitle(tab, vendor) : (tab.lastTitle ?? null)
+  // Live beats recorded — the recording is a snapshot of this same stream,
+  // taken whenever the tab was last mounted. Falling back rather than
+  // replacing keeps the flash guard above intact: a session the host has no
+  // title for yet still shows what it was called.
+  const source = liveTitle?.trim() || tab.lastTitle
+  const named = vendor ? stableRecordedTitle(source, vendor) : (source ?? null)
   if (!vendor || engineEntry(vendor).terminalTitle?.ownsStatus !== true) {
     return tabTitle({ ...tab, lastTitle: named } as TerminalTab, taskVendor)
   }

--- a/packages/kobe/test/behavior/pure-tui-live-tab-title.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-live-tab-title.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression pin (owner report 2026-08-15): a sidebar tab row's TITLE must
+ * track the live session, like the state glyph beside it already does — not
+ * wait for you to click into that task.
+ *
+ * The OSC title only ever reached a tab through `useTabTurnState`, which is
+ * mounted by `TerminalTabs` — and `TerminalTabs` exists only for the SELECTED
+ * task. So every other row rendered the persisted `lastTitle`: a recording of
+ * whatever the tab was called the last time you were in it, sitting next to a
+ * state glyph the daemon keeps live. One row, one live signal and one frozen
+ * one.
+ *
+ * Shape: two tasks, focus pinned to A, and B's snapshot deliberately carrying
+ * a STALE recording while B's engine publishes a different title. B is never
+ * opened. The row must read the live title — which is only knowable from the
+ * pty host, since nothing in this process ever attached to B.
+ */
+
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { Terminal } from "@xterm/headless"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { SIDEBAR_WIDTH } from "../../src/tui/panes/sidebar/view-core.ts"
+import { type BehaviorEnv, DIST_ROVE_CLI, loadNodePty, makeBehaviorEnv, makeScratchRepo, runRove } from "./harness.ts"
+
+const nodePty = await loadNodePty()
+
+const COLS = 140
+const ROWS = 40
+/** What the fake engine publishes as its OSC 0 window title. */
+const LIVE = "LIVEX"
+/** What B's snapshot claims the tab was called — the frozen recording. */
+const STALE = "STALEX"
+
+async function poll(predicate: () => boolean | Promise<boolean>, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+}
+
+describe.skipIf(!nodePty)("Pure TUI sidebar shows an unselected task's live tab title (behavior)", () => {
+  let env: BehaviorEnv
+  let repo: string
+  let statePath: string
+  let taskA: string
+  let taskB: string
+  const branchA = "rove/pin-a"
+  const branchB = "rove/pin-b"
+
+  const readState = async (): Promise<Record<string, unknown>> =>
+    JSON.parse(await readFile(statePath, "utf8")) as Record<string, unknown>
+
+  beforeAll(async () => {
+    env = await makeBehaviorEnv()
+
+    // Local engine shim, overriding the harness default for THIS suite only:
+    // same idle loop, plus one OSC 0 window title at startup. That title is
+    // the whole subject of the test and no other suite should have to care.
+    await writeFile(
+      join(env.bin, "claude"),
+      `#!/bin/sh\nprintf '\\033]0;${LIVE}\\007'\necho "fake-claude ready $*"\nwhile :; do read -r _ignored || sleep 600; done\n`,
+    )
+    await chmod(join(env.bin, "claude"), 0o755)
+
+    repo = await makeScratchRepo(env)
+    const stateDir = join(env.home, ".config", "rove")
+    await mkdir(stateDir, { recursive: true })
+    statePath = join(stateDir, "state.json")
+    await writeFile(statePath, JSON.stringify({ onboarded: true }))
+
+    // `--prompt` takes the headless launch path: worktree + hosted engine
+    // session under `<taskId>::tab-1`, plus the snapshot the TUI renders from.
+    for (const branch of [branchA, branchB]) {
+      const add = runRove(["api", "add", "--repo", repo, "--branch", branch, "--prompt", "hello"], env)
+      expect(add.code, add.stderr).toBe(0)
+      const id = (JSON.parse(add.stdout) as { task: { id: string } }).task.id
+      if (branch === branchA) taskA = id
+      else taskB = id
+    }
+
+    // Focus A, so the TUI boots into A and B's `TerminalTabs` never mounts —
+    // the condition that made B's title go stale in the first place.
+    const active = runRove(["api", "set-active", "--task-id", taskA], env)
+    expect(active.code, active.stderr).toBe(0)
+
+    await poll(() => {
+      const sessions = JSON.parse(runRove(["api", "pty-list"], env).stdout) as {
+        sessions?: { key: string; alive?: boolean; title?: string }[]
+      }
+      return sessions.sessions?.some((s) => s.key === `${taskB}::tab-1` && s.alive && s.title === LIVE) === true
+    }, 30_000)
+    const listed = JSON.parse(runRove(["api", "pty-list"], env).stdout) as {
+      sessions?: { key: string; title?: string }[]
+    }
+    expect(
+      listed.sessions?.find((s) => s.key === `${taskB}::tab-1`)?.title,
+      "the pty host never observed the engine's OSC title — the test cannot say anything about the sidebar",
+    ).toBe(LIVE)
+  }, 180_000)
+
+  afterAll(async () => {
+    await env.dispose()
+  })
+
+  it("renders B's live title on a row nobody opened, over the stale recording", async () => {
+    if (!nodePty) throw new Error("unreachable: suite is skipped without node-pty")
+    const key = `terminalTabs.${taskB}`
+
+    // The frozen recording, in the shape the field one had: the tab was named
+    // once, long ago, and nothing has re-mounted to refresh it since.
+    const state = await readState()
+    const snapshot = state[key] as { tabs: { id: string; lastTitle?: string | null }[] }
+    expect(snapshot?.tabs?.[0]?.id, "B's snapshot never listed tab-1").toBe("tab-1")
+    const firstTab = snapshot.tabs[0] as { lastTitle?: string | null }
+    firstTab.lastTitle = STALE
+    await writeFile(statePath, JSON.stringify(state))
+
+    const term = new Terminal({ cols: COLS, rows: ROWS, allowProposedApi: true })
+    // This child would inherit vitest's markers, and the host-session poll —
+    // the whole delivery path under test — is off under a test RUNNER.
+    const { VITEST, NODE_ENV, BUN_TEST, ...tuiEnv } = env.env as Record<string, string>
+    const child = nodePty.spawn("bun", [DIST_ROVE_CLI], { cols: COLS, rows: ROWS, cwd: repo, env: tuiEnv })
+    const data = child.onData((chunk: string) => term.write(chunk))
+    const screen = (): string[] => {
+      const buffer = term.buffer.active
+      const lines: string[] = []
+      for (let y = 0; y < ROWS; y++) lines.push(buffer.getLine(y)?.translateToString(true) ?? "")
+      return lines
+    }
+    /** The rail rows below B's worktree row, i.e. B's tabs. */
+    const bTabRows = (): string[] => {
+      const rail = screen().map((line) => line.slice(0, SIDEBAR_WIDTH))
+      const worktree = rail.findIndex((line) => line.includes(branchB))
+      return worktree < 0 ? [] : rail.slice(worktree + 1, worktree + 2)
+    }
+
+    try {
+      await poll(() => screen().some((line) => line.includes(branchB)), 30_000)
+      expect(
+        screen().some((line) => line.includes(branchB)),
+        "B's worktree row never appeared in the rail",
+      ).toBe(true)
+      // The sidebar polls the host every 2s, so the live title lands a tick
+      // or two after the row does.
+      await poll(() => bTabRows()[0]?.includes(LIVE) === true, 30_000)
+
+      const row = bTabRows()[0] ?? ""
+      expect(row, "B's tab row never showed the live session title").toContain(LIVE)
+      expect(row, "B's tab row is still rendering the frozen recording").not.toContain(STALE)
+
+      // ...and B genuinely was a task nobody opened. A mounted `TerminalTabs`
+      // RECORDS the live title it sees, so B's `lastTitle` still reading
+      // STALE is the proof that the row above was drawn by the sidebar's own
+      // path and not by the very component whose absence is the bug.
+      const parked = (await readState())[key] as { tabs?: { lastTitle?: string | null }[] }
+      expect(
+        parked?.tabs?.[0]?.lastTitle,
+        "B's TerminalTabs mounted after all — the assertions above prove nothing about the sidebar",
+      ).toBe(STALE)
+    } finally {
+      data.dispose()
+      child.kill()
+    }
+  }, 120_000)
+})


### PR DESCRIPTION
## The bug

A sidebar tab row shows two signals side by side: kobe's state glyph and the tab's title. The glyph is live (daemon `engine-state` channel, independent of selection); the title was not. It only moved when you clicked into that task.

Root cause: the OSC title reaches a tab only through `useTabTurnState`, which mounts inside `TerminalTabs` — and `TerminalTabs` exists only for the **selected** task (`show-workspace.tsx:51`). Every other row rendered the persisted `lastTitle`, a recording of whatever the tab was called the last time you were in it.

## The fix

Both halves already existed and were never connected:

- the pty host scans every session's OSC title in `onData` (`pty-host.ts:426`), attached or not, and `pty.list` returns it;
- the sidebar already polls `pty.list` every 2s (`use-host-sessions.ts`) for orphan-tab detection.

So this is client-side wiring. `use-tree-state` projects the poll into a `ptyKey → title` map and passes it to `tabTitleStable` as a new `liveTitle` argument — **passed in, not painted**, so it still goes through the whole rule: `stripEngineStatusPrefix`, the decoration-only rejection, and manual-rename precedence. Live beats recorded; absent falls back to the recording, which keeps the ~2s-probe-gap flash guard (`terminal-tab-split.ts:209-216`) intact.

Two things came along:

- `useHostSessions` now compares `key`/`alive`/`title` before setting state. It used to allocate a fresh array every 2s, harmless while `orphansByTask` short-circuited on empty; now that the title projection depends on it, an unfiltered poll would rebuild the whole tree every tick.
- `orphan-tabs.ts` was painting the raw OSC title on ⚠ rows — exactly the "engine status prefix fights kobe's glyph" problem the strip exists to prevent. Now stripped (vendor-agnostic; an unregistered session has no resolved vendor).

No daemon protocol change.

## Testing

`test/behavior/pure-tui-live-tab-title.test.ts`: two tasks, focus pinned to A, B's engine publishing a distinct OSC title while B's snapshot carries a stale `lastTitle`. B is never opened. Asserts the row shows the live title and not the stale one — plus an anti-vacuous check that B's `lastTitle` is *still* stale afterwards, which is the proof a `TerminalTabs` didn't quietly mount and do the work. Skips locally (agent env can't spawn node-pty); CI runs it.

Fast suite 3119 pass, render 163 pass, typecheck + root lint clean.

Note: `claude-review` currently fails on an empty `ANTHROPIC_API_KEY` — not a blocker per AGENTS.md.