### PR TITLE
fix: decode automation precheck output as one UTF-8 stream

### DIFF
--- a/.changeset/precheck-utf8-output.md
+++ b/.changeset/precheck-utf8-output.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Automation precheck output no longer garbles non-ASCII text into `�`: a `gh pr list` or `git log` precheck whose stdout carries CJK or emoji is now decoded as one UTF-8 stream instead of chunk-by-chunk, so the stdout/stderr captured with a skipped run reads cleanly and the tail cap keeps whole code points instead of halving a surrogate pair at the cut.

--- a/packages/kobe-daemon/src/daemon/automation-precheck.ts
+++ b/packages/kobe-daemon/src/daemon/automation-precheck.ts
@@ -32,9 +32,44 @@ const MAX_OUTPUT_CHARS = 4000
 /** Upper bound on a user-supplied timeout, so a typo can't wedge the sweep. */
 const MAX_TIMEOUT_SECONDS = 600
 
-function tail(chunks: readonly (Buffer | string)[]): string {
-  const text = chunks.map((c) => c.toString()).join("")
-  return text.length <= MAX_OUTPUT_CHARS ? text : text.slice(-MAX_OUTPUT_CHARS)
+/**
+ * Decode captured stream chunks to text, keeping only the last
+ * `MAX_OUTPUT_CHARS`.
+ *
+ * The chunks are raw `data`-event payloads: `Buffer`s from the child's pipes,
+ * plus the occasional pre-decoded error string we push ourselves. Node splits
+ * a pipe's `data` events at arbitrary byte offsets, so a multi-byte UTF-8
+ * sequence can straddle two chunks. Decoding each `Buffer` on its own — the
+ * old `chunks.map((c) => c.toString())` — turns that seam into a `�`, so a
+ * `gh pr list` full of CJK/emoji titles came back mojibake. Concatenate each
+ * contiguous run of Buffers and decode it as one instead.
+ *
+ * Cap by whole code points, not UTF-16 units, so the tail slice can't halve a
+ * surrogate pair and strand a lone surrogate at the cut.
+ */
+export function tail(chunks: readonly (Buffer | string)[]): string {
+  let text = ""
+  let pending: Buffer[] = []
+  const flushPending = (): void => {
+    if (pending.length > 0) {
+      text += Buffer.concat(pending).toString("utf8")
+      pending = []
+    }
+  }
+  for (const chunk of chunks) {
+    if (typeof chunk === "string") {
+      flushPending()
+      text += chunk
+    } else {
+      pending.push(chunk)
+    }
+  }
+  flushPending()
+  // `text.length` (UTF-16 units) >= code-point count, so an under-cap string is
+  // safe to return as-is; only pay for the code-point split when over.
+  if (text.length <= MAX_OUTPUT_CHARS) return text
+  const points = Array.from(text)
+  return points.length <= MAX_OUTPUT_CHARS ? text : points.slice(-MAX_OUTPUT_CHARS).join("")
 }
 
 /**

--- a/packages/kobe/test/daemon/automation-precheck.test.ts
+++ b/packages/kobe/test/daemon/automation-precheck.test.ts
@@ -3,9 +3,41 @@ import {
   formatPrecheckSkip,
   precheckPassed,
   runAutomationPrecheck,
+  tail,
 } from "../../../kobe-daemon/src/daemon/automation-precheck.ts"
 
 const CWD = process.cwd()
+
+describe("tail", () => {
+  it("decodes a multi-byte char split across two chunks without mojibake", () => {
+    // Node emits a pipe's `data` events split at arbitrary byte offsets, so a
+    // multi-byte UTF-8 sequence can straddle two Buffers. Slicing the 4-byte
+    // rocket in half is exactly that seam.
+    const bytes = Buffer.from("🚀 café 中文", "utf8")
+    const first = bytes.subarray(0, 2)
+    const second = bytes.subarray(2)
+    expect(tail([first, second])).toBe("🚀 café 中文")
+    expect(tail([first, second])).not.toContain("�")
+  })
+
+  it("keeps a pushed error string in order alongside buffers", () => {
+    expect(tail([Buffer.from("out"), "spawn failed"])).toBe("outspawn failed")
+  })
+
+  it("caps to the last MAX_OUTPUT_CHARS code points without halving a surrogate pair", () => {
+    // 4001 rockets is past the 4000-char cap; slicing by UTF-16 unit would cut
+    // the boundary rocket in half and strand a lone surrogate.
+    const capped = tail([Buffer.from("🚀".repeat(4001), "utf8")])
+    expect(Array.from(capped)).toHaveLength(4000)
+    expect(capped).not.toContain("�")
+    expect([...capped].every((point) => point === "🚀")).toBe(true)
+  })
+
+  it("returns short output untouched", () => {
+    expect(tail([Buffer.from("hello")])).toBe("hello")
+    expect(tail([])).toBe("")
+  })
+})
 
 describe("runAutomationPrecheck", () => {
   it("reports exit 0 as a pass", async () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect surfaced while reviewing the daemon's stateful/behavioral modules (the pure-logic helpers reviewed clean).

## Problem

`runAutomationPrecheck` captures a precheck command's stdout/stderr as raw `data`-event chunks, then `tail()` decoded **each `Buffer` on its own** before joining:

```ts
const text = chunks.map((c) => c.toString()).join("")
```

Node splits a pipe's `data` events at arbitrary byte offsets (no `setEncoding` is set on the spawn), so a multi-byte UTF-8 sequence can straddle two chunks. Per-chunk `.toString()` decodes each half independently and emits a `�` at the seam. A precheck like `gh pr list` or `git log` whose output carries CJK or emoji therefore came back **mojibake** in the recorded skip result the user reads to tell a healthy "nothing to do" from a broken command. Separately, `text.slice(-MAX_OUTPUT_CHARS)` capped by UTF-16 code unit, which can halve a surrogate pair at the cut and strand a lone surrogate.

The pass/skip verdict itself is driven by exit code, so the feature's decision is unaffected — this is a fidelity bug in the captured output shown to the user.

## Fix

`tail()` now concatenates each contiguous run of `Buffer`s and decodes it as **one** UTF-8 stream (`Buffer.concat(...).toString("utf8")`), interleaving the pre-decoded error strings we push ourselves in order, and caps the tail by **whole code points** so the 4000-char limit can't split a surrogate pair. The helper is exported so the decode is unit-testable directly.

## Verification

- `bun run lint` — clean.
- `bun run typecheck` — clean.
- New deterministic unit tests over `tail()` (construct `Buffer`s split mid-character to reproduce the seam without depending on real spawn chunking): the split-`🚀`/CJK case now decodes without `�`, error strings stay ordered, and the over-cap case keeps 4000 whole rockets. `KOBE_INCLUDE_SOCKET=1 vitest run test/daemon/automation-precheck.test.ts` → 11 passed (7 existing + 4 new).

## Follow-ups (deliberately deferred — separate slice)

While verifying, I noticed the test suite is **already red on `main`**, unrelated to this change:

- `test/architecture/package-distribution.test.ts > pending changesets version the canonical package` fails because `.changeset/live-sidebar-tab-title.md` (added by the most recent merge, #445) targets `@sma1lboy/kobe` instead of the canonical `@sma1lboy/rove`. One-line fix to that changeset's frontmatter, but it belongs to #445's slice — flagging rather than folding it in. (My changeset here correctly targets `@sma1lboy/rove`.)
- `test/state/layout-migration.test.ts > … after a partial failure and retries` fails only when the suite runs as **root** (it simulates a write failure via `chmod`, which root bypasses); it passes under a normal CI user.

Neither is caused by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwMPvPcyAGrwVGYvBp63ie)_