### PR TITLE
fix: key the workspace TerminalTabs by task, not worktree path

### DIFF
--- a/.changeset/terminal-tabs-key-per-task.md
+++ b/.changeset/terminal-tabs-key-per-task.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+fix: key the workspace TerminalTabs by task, not worktree path — two tasks sharing the same directory (a project-main task plus a dir task on one checkout) reused the mounted component across a task switch, so the previous task's tab state was written under the new task's snapshot key, cloning phantom chattabs (and spawning fresh engine sessions) into the other task on every click.

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -2,8 +2,8 @@
 /**
  * The workspace center column — the terminal-in-the-middle seam (issue #16):
  * either the empty "select a task" placeholder or the selected worktree's
- * TerminalTabs (keyed per worktree so each task keeps its own registry-backed
- * PTYs). Split from host.tsx (file-size cap).
+ * TerminalTabs (keyed per task so tasks sharing a directory never share
+ * component state). Split from host.tsx (file-size cap).
  */
 
 import type { ReactNode } from "react"
@@ -46,10 +46,14 @@ export function ShowWorkspace(props: {
     // The terminal-in-the-middle seam (issue #16): the center column IS
     // the engine — an in-process PTY (Bun.spawn terminal) running the
     // real interactive CLI, so kobe never re-renders the engine's own
-    // TUI. `key={path}` remounts per worktree, giving each task its own
-    // registry-backed PTY (acquire reuses a live one on switch-back).
+    // TUI. Keyed by TASK, not worktree: two tasks can share a directory
+    // (a project-main task + a dir task on the same checkout), and a
+    // path key reused the component across them — the stale task's
+    // TabsState got written under the new task's persistKey, cloning its
+    // tabs into the other task. PTY reuse on switch-back is unaffected:
+    // the registry keys are `taskId::tabId`, not React keys.
     <TerminalTabs
-      key={path}
+      key={props.task?.id ?? path}
       taskId={props.task?.id ?? path}
       worktree={path}
       repo={props.task?.repo}


### PR DESCRIPTION
## Summary
- Clicking a chattab of a task that shares its directory with another task (a project-main task + a dir task on the same checkout, e.g. `codefox` + `codefox-qikl` both on `~/i/codefox`) made a phantom chattab appear — and closing it never stuck.
- Root cause: `ShowWorkspace` mounted `TerminalTabs` with `key={path}`. Two tasks with the same worktree path reused the component instance across the task switch, so the stale task's `TabsState` (held in `useState`) was written under the NEW task's `terminalTabs.<taskId>` snapshot key by the next `update()` — cloning its tab list into the other task and spawning fresh engine PTYs under the wrong task's `taskId::tabId` keys. Evidence: both tasks' persisted snapshots converged to identical shapes (`tabs 6+7, activeId tab-6, nextOrdinal 9`), and the pty log shows repeated spawn→SIGKILL cycles for `…::tab-7` as the user kept closing the resurrecting tab.
- Fix: key by task (`props.task?.id ?? path`). Everything inside the component is already task-keyed (persistKey, `tabsByTask`, PTY registry keys), so the React key now matches the identity the state lives under. PTY reuse on switch-back is unaffected — that comes from the registry's acquire-reuse, not the React key.

## Test plan
- [x] Repo-root `bun run lint` + `bun --filter @sma1lboy/rove typecheck` green
- [ ] dev:sandbox — create a main task + a dir task on the same directory, click between their chattabs: no tab bleeds into the other task, ctrl+w on a tab stays closed


coverage-exemption: packages/kobe/src/tui-react/workspace/show-workspace.tsx — one-line React key change (key={path} → key per task); the behavior is React remount identity on task switch, which the render floor cannot exercise without spawning real PTYs. Verified live in dev:sandbox (two tasks sharing one directory).
