### PR TITLE
fix: stop printing the ctrl+<digit> jump hint on sidebar rows

### DIFF
--- a/.changeset/sidebar-hide-jump-digit-suffix.md
+++ b/.changeset/sidebar-hide-jump-digit-suffix.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+fix: stop printing the `ctrl+<digit>` jump hint on sidebar task rows — the chord still works, it's just no longer shown as a trailing digit on the row title.

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -21,7 +21,6 @@ import { sweepBar } from "../../../tui/lib/progress-bar"
 import { spinnerFrameSnapshot, subscribeSpinnerFrame } from "../../../tui/lib/spinner-frame-store"
 import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
 import type { SidebarRow } from "../../../tui/panes/sidebar/groups"
-import { taskJumpDigit } from "../../../tui/panes/sidebar/jump-digits"
 import { spacedTitle } from "../../../tui/panes/sidebar/labels"
 import {
   type SidebarRowView,
@@ -396,20 +395,9 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
  * nothing rather than a digit that jumps somewhere else. Keyed on the flat
  * index directly so the tree's rows (no SidebarRow wrapper) share it.
  */
-export function JumpDigit(props: { flatIndex: number; dim: boolean }) {
-  const { theme } = useTheme()
-  const digit = taskJumpDigit(props.flatIndex)
-  if (digit === null) return null
-  return (
-    <text
-      fg={props.dim ? theme.textMuted : theme.accent}
-      attributes={TextAttributes.DIM}
-      wrapMode="none"
-      flexShrink={0}
-    >
-      {digit}
-    </text>
-  )
+// ponytail: ctrl+<digit> jump chord still works, just no longer printed on the row.
+export function JumpDigit(_props: { flatIndex: number; dim: boolean }) {
+  return null
 }
 
 export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {


### PR DESCRIPTION
## Summary
- The `ctrl+<digit>` jump chord printed its target digit right-stuck on each sidebar task row's title line; this drops the printed hint. The chord itself is untouched — `taskJumpDigit`/the ctrl+digit handler still works.
- `JumpDigit` now unconditionally returns `null` (all 4 render sites: two in `tree-rows.tsx`, two in `row-cards.tsx` share the one component).

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Changeset added (patch)