### PR TITLE
chore: drop synchronize from the claude-code-review trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,7 +17,12 @@ name: Claude Code Review
 # are NOT skippable — they are fast, and they are what protects a release.
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    # No `synchronize` — re-reviewing every push is the "review unless
+    # necessary" case this gate exists to avoid. One pass at open/reopen/
+    # ready_for_review is enough; re-request manually (comment
+    # `skip-review:` off, then re-open or push a no-op amend) if a later
+    # revision genuinely needs another look.
+    types: [opened, ready_for_review, reopened]
     paths-ignore:
       - "**/*.md"
       - ".changeset/**"


### PR DESCRIPTION
## Summary
- The Claude Code Review workflow re-ran on every push to a PR (`synchronize`), which is the bulk of its run volume for iterative branches. This drops `synchronize` so it only reviews once at `opened`/`reopened`/`ready_for_review`.
- The hard CI gates (typecheck/test, behavior, file-size-cap, coverage-cap, changeset) are unaffected — they still run on every push. `paths-ignore` and the `skip-review:` body opt-out are unchanged.

## Test plan
- [x] YAML change only, no code path — validated by eye against GitHub Actions `pull_request` event `types` schema.
skip-review: CI trigger config only, no code to review