### PR TITLE
fix: refresh sidebar goldens after the jump-digit removal

### DIFF
--- a/.changeset/golden-drop-jump-digit.md
+++ b/.changeset/golden-drop-jump-digit.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Refresh the sidebar frame goldens so the render track matches the row cards.
+The `ctrl+<digit>` jump hint stopped being printed on rows, but the golden
+frames still carried the digit column, leaving CI red on `main`.

--- a/packages/kobe/test/render/golden/move-mode.frame.txt
+++ b/packages/kobe/test/render/golden/move-mode.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────  move |
-|  feat/alpha                2 |
-|▌  · build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  · build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/recent-jump-row.frame.txt
+++ b/packages/kobe/test/render/golden/recent-jump-row.frame.txt
@@ -13,11 +13,11 @@
 |  ↩ Recent: bravo             |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                3 |
-|▌  · build                  4 |
-|   · review                 5 |
-|  feat/bravo                6 |
-|   · tests                  7 |
+|  feat/alpha                  |
+|▌  · build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-pruned.frame.txt
+++ b/packages/kobe/test/render/golden/search-pruned.frame.txt
@@ -13,8 +13,8 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|▌ feat/bravo                2 |
-|   · tests                  3 |
+|▌ feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-tab-title.frame.txt
+++ b/packages/kobe/test/render/golden/search-tab-title.frame.txt
@@ -13,8 +13,8 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|▌ feat/alpha                2 |
-|   · review                 3 |
+|▌ feat/alpha                  |
+|   · review                   |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-error.frame.txt
+++ b/packages/kobe/test/render/golden/tab-error.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  × build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  × build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-idle.frame.txt
+++ b/packages/kobe/test/render/golden/tab-idle.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  ○ build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  ○ build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-non-agent.frame.txt
+++ b/packages/kobe/test/render/golden/tab-non-agent.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  · build                  3 |
-|   · shell                  4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  · build                    |
+|   · shell                    |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
+++ b/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  ? build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  ? build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
+++ b/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  ◷ build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  ◷ build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  · build                  3 |
-|   ~ review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  · build                    |
+|   ~ review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  ~ build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  ~ build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
+++ b/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|   ● build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|▌  · tests                  6 |
+|  feat/alpha                  |
+|   ● build                    |
+|   · review                   |
+|  feat/bravo                  |
+|▌  · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tree-unknown.frame.txt
+++ b/packages/kobe/test/render/golden/tree-unknown.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  · build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  · build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/view-tabs-archived.frame.txt
+++ b/packages/kobe/test/render/golden/view-tabs-archived.frame.txt
@@ -13,11 +13,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  · build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  · build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
+++ b/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha            ▴ ✓ 2 |
-|▌  · build                  3 |
-|   · review                 4 |
-|  feat/bravo              ✗ 5 |
-|   · tests                  6 |
+|  feat/alpha              ▴ ✓ |
+|▌  · build                    |
+|   · review                   |
+|  feat/bravo                ✗ |
+|   · tests                    |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/zen-chip.frame.txt
+++ b/packages/kobe/test/render/golden/zen-chip.frame.txt
@@ -11,11 +11,11 @@
 | Routines                     |
 |                              |
 | kobe ─────────────────────── |
-|  feat/alpha                2 |
-|▌  · build                  3 |
-|   · review                 4 |
-|  feat/bravo                5 |
-|   · tests                  6 |
+|  feat/alpha                  |
+|▌  · build                    |
+|   · review                   |
+|  feat/bravo                  |
+|   · tests                    |
 |                              |
 |                              |
 |                              |


### PR DESCRIPTION
`render-track` has been red on `main` since #453 — this fixes it.

## What happened

#453 stopped printing the `ctrl+<digit>` jump hint on sidebar rows, but the golden frames still carried the digit column, so every sidebar frame test mismatched:

```
- |  feat/alpha                2 |
+ |  feat/alpha                  |
```

15 golden files, 74 lines.

## Why this is a golden refresh and not a bug fix

Every changed line is the same shape — the trailing digit drops, nothing else moves. I verified that mechanically rather than by eye: strip the `\s\d+\s*\|$` suffix from each old line and it matches the new line exactly, and every row keeps its original width.

Two lines look different at a glance but are correct:

```
- |  feat/alpha            ▴ ✓ 2 |
+ |  feat/alpha              ▴ ✓ |
```

Those are right-aligned badges (pin, PR status) sliding into the two cells the digit vacated. Width unchanged at 32, badge tokens unchanged, still flush right.

## Verification

- `bun run test:render` — 163 pass, 0 fail
- root `bun run lint` — clean
- `bun --filter @sma1lboy/rove typecheck` — clean
- Changeset included (`patch`)