### PR TITLE
fix: spawn panes and prechecks through the login shell like engine tabs

### DIFF
--- a/.changeset/pane-precheck-login-shell.md
+++ b/.changeset/pane-precheck-login-shell.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix shell env inconsistency (#26): `pane-open --command`, plugin panes, and the automation precheck now spawn through the same `resolveLoginShell()` + `-ilc` integration path engine tabs already use, instead of a bare `sh -lc` / non-interactive `-lc` that skips `.zshrc`/`.bashrc`. Panes and prechecks see the same PATH/exports as the engine they accompany.

--- a/packages/kobe-daemon/src/daemon/automation-precheck.ts
+++ b/packages/kobe-daemon/src/daemon/automation-precheck.ts
@@ -15,10 +15,15 @@
  * can tell a healthy "nothing to do" from a broken command.
  *
  * Runs through the user's login shell so the command reads the same as it
- * would typed into a terminal (pipes, `&&`, PATH from their profile).
+ * would typed into a terminal (pipes, `&&`, PATH/exports from their rc
+ * files). It uses the same `-ilc` form `session-launch.ts` spawns engine
+ * tabs with (#26): the interactive bit is what sources `.zshrc`/`.bashrc`,
+ * so a precheck sees the same environment as the engine it gates. Interactive
+ * rc output (e.g. a prompt framework's banner) rides along in the captured
+ * streams; the exit code stays the only decision signal, and the timeout
+ * bounds a slow rc.
  * `resolveLoginShell` resolves to a bash even on Windows (Git Bash — see its
- * WSL caveat), so the `-lc` form is portable, matching the `-ilc` that
- * `session-launch.ts` already uses for engine spawns.
+ * WSL caveat), so the `-ilc` form is portable.
  */
 
 import { spawn } from "node:child_process"
@@ -99,7 +104,7 @@ export function runAutomationPrecheck(
 
     let child: ReturnType<typeof spawn>
     try {
-      child = spawn(shell, ["-lc", precheck.command], {
+      child = spawn(shell, ["-ilc", precheck.command], {
         cwd,
         stdio: ["ignore", "pipe", "pipe"],
         signal: controller.signal,

--- a/packages/kobe-daemon/src/plugins/pane-command.ts
+++ b/packages/kobe-daemon/src/plugins/pane-command.ts
@@ -1,12 +1,13 @@
 /**
  * Pane launch composition — shared by `kobe plugin pane open` (CLI) and the
- * TUI's ctrl+e picker, so both build the IDENTICAL argv: one `sh -lc` script
- * carrying the plugin env contract, with `$ROVE_PLUGIN_ROOT` (or its legacy
- * Kobe alias) expanded in the
+ * TUI's ctrl+e picker, so both build the IDENTICAL argv: one login-shell
+ * `-ilc` script carrying the plugin env contract, with `$ROVE_PLUGIN_ROOT`
+ * (or its legacy Kobe alias) expanded in the
  * manifest command. The pane's PTY runs in the task worktree; no tab/PTY
  * schema knows about plugins (docs/design/plugins.md §Panes).
  */
 
+import { resolveLoginShell } from "../daemon/platform-shell.js"
 import { buildPluginEnv } from "./env.ts"
 import { type PluginPane, currentPluginPlatform, readPluginManifest, supportsPlatform } from "./manifest.ts"
 import { loadPluginRegistry } from "./registry.ts"
@@ -25,12 +26,12 @@ export interface PaneLaunchOpts {
   readonly binPath: string
 }
 
-/** POSIX single-quote for embedding in an `sh -lc` script. */
+/** POSIX single-quote for embedding in a login-shell `-ilc` script. */
 export function shq(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`
 }
 
-/** The `["sh", "-lc", …]` argv that runs one pane with the env contract. */
+/** The `[loginShell, "-ilc", …]` argv that runs one pane with the env contract. */
 export function buildPaneArgv(
   pluginId: string,
   pluginRoot: string,
@@ -51,7 +52,10 @@ export function buildPaneArgv(
   ][]
   const command = pane.command.map((a) => a.replace(/\$\{?(?:ROVE|KOBE)_PLUGIN_ROOT\}?/g, pluginRoot))
   const script = `exec env ${pairs.map(([k, v]) => shq(`${k}=${v}`)).join(" ")} ${command.map(shq).join(" ")}`
-  return ["sh", "-lc", script]
+  // Same integration path as the engine tab (session-launch.ts): the user's
+  // login shell with the interactive bit, so a plugin pane reads the same
+  // PATH/exports as the engine tab does (#26).
+  return [resolveLoginShell(), "-ilc", script]
 }
 
 /** Every pane of every ENABLED plugin that runs on this platform, launch-ready. */

--- a/packages/kobe/src/cli/api/handlers-pane.ts
+++ b/packages/kobe/src/cli/api/handlers-pane.ts
@@ -7,6 +7,7 @@
  * command tab.
  */
 
+import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import { F } from "./flags.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
@@ -29,7 +30,7 @@ export const PANE_VERB: VerbSpec = {
       type: "string",
       placeholder: "CMD",
       description:
-        "Shell command the pane runs (via `sh -lc`, so pipes/args work); the pane closes when it exits. Omit for an interactive shell.",
+        "Shell command the pane runs (via the login shell's `-ilc`, so pipes/args and your shell rc's PATH/exports work); the pane closes when it exits. Omit for an interactive shell.",
     },
     {
       name: "direction",
@@ -62,7 +63,11 @@ export const PANE_VERB: VerbSpec = {
       throw new ApiError("no target task: pass --task-id (no $ROVE_TASK_ID, no active task)", "TASK_NOT_FOUND")
     }
     const command = ctx.args.str("command")
-    const argv = command ? ["sh", "-lc", command] : [process.env.SHELL || "sh"]
+    // Same integration path as the engine tab (session-launch.ts): the user's
+    // login shell with the interactive bit, so a pane command reads the same
+    // PATH/exports as one typed into the engine tab's shell (#26).
+    const shell = resolveLoginShell({ fallback: "/bin/sh" })
+    const argv = command ? [shell, "-ilc", command] : [shell, "-il"]
     const title = ctx.args.str("title") ?? (command ? (command.trim().split(/\s+/)[0] ?? "shell") : "shell")
     const tabId = ctx.args.str("tab")
     return simpleRpc(ctx, "tab.open", {

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -179,7 +179,7 @@ async function openPane(pluginId: string, entrypoint: string, taskFlag: string |
   if (!pane) throw new PluginCliError(`no pane \`${entrypoint}\` in \`${pluginId}\`; declare it under [[panes]]`)
 
   // Shared composition with the TUI's ctrl+e picker (plugins/pane-command.ts):
-  // one `sh -lc` script, env contract riding an `env` prefix, cwd = worktree.
+  // one login-shell `-ilc` script, env contract riding an `env` prefix, cwd = worktree.
   const argv = buildPaneArgv(loaded.entry.id, loaded.entry.root, pane, {
     socketPath: defaultDaemonSocketPath(),
     binPath: CLI_NAME,

--- a/packages/kobe/test/cli/api-pane.test.ts
+++ b/packages/kobe/test/cli/api-pane.test.ts
@@ -1,5 +1,6 @@
 /** Request-traffic tests for the `pane-open` verb. */
 
+import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { invokeVerb } from "../../src/cli/api-cmd.ts"
 import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.ts"
@@ -12,20 +13,20 @@ describe("pane-open handler", () => {
     vi.unstubAllEnvs()
   })
 
-  it("wraps --command in sh -lc, defaults split/right, titles from the command word", async () => {
+  it("wraps --command in the login shell's -ilc, defaults split/right, titles from the command word", async () => {
     const client = new FakeClient({ "tab.open": () => ({ ok: true }) })
     await invokeVerb("pane-open", ["--command", "btop --utf-force"], { client, runtime: stubRuntime() })
     expect(client.requestNames).toEqual(["tab.open"])
     expect(client.requests[0].payload).toEqual({
       taskId: "env-task",
-      argv: ["sh", "-lc", "btop --utf-force"],
+      argv: [resolveLoginShell({ fallback: "/bin/sh" }), "-ilc", "btop --utf-force"],
       title: "btop",
       placement: "split",
       direction: "right",
     })
   })
 
-  it("no --command opens an interactive shell; explicit flags pass through", async () => {
+  it("no --command opens an interactive login shell; explicit flags pass through", async () => {
     const client = new FakeClient({ "tab.open": () => ({ ok: true }) })
     await invokeVerb("pane-open", ["--task-id", "t9", "--direction", "down", "--placement", "tab", "--title", "logs"], {
       client,
@@ -33,7 +34,7 @@ describe("pane-open handler", () => {
     })
     const payload = client.requests[0].payload as { taskId: string; argv: string[]; title: string }
     expect(payload.taskId).toBe("t9")
-    expect(payload.argv).toHaveLength(1) // the shell itself, no -lc wrap
+    expect(payload.argv).toEqual([resolveLoginShell({ fallback: "/bin/sh" }), "-il"])
     expect(payload.title).toBe("logs")
     expect(client.requests[0].payload).toMatchObject({ placement: "tab", direction: "down" })
   })

--- a/packages/kobe/test/daemon/automation-precheck.test.ts
+++ b/packages/kobe/test/daemon/automation-precheck.test.ts
@@ -1,3 +1,6 @@
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
   formatPrecheckSkip,
@@ -53,6 +56,19 @@ describe("runAutomationPrecheck", () => {
       CWD,
     )
     expect(result.exitCode).toBe(0)
+  })
+
+  it("spawns the shell with -ilc, the same interactive login form engine tabs use (#26)", async () => {
+    // A spy shell records the exact argv it was invoked with, so this pins the
+    // flag contract rather than just "a shell ran".
+    const dir = mkdtempSync(join(tmpdir(), "kobe-precheck-spy-"))
+    const spy = join(dir, "spy.sh")
+    const argsFile = join(dir, "args")
+    writeFileSync(spy, `#!/bin/sh\n: > "${argsFile}"\nfor a in "$@"; do echo "$a" >> "${argsFile}"; done\nexit 0\n`)
+    chmodSync(spy, 0o755)
+    const result = await runAutomationPrecheck({ command: "true", timeoutSeconds: 10 }, CWD, spy)
+    expect(result.exitCode).toBe(0)
+    expect(readFileSync(argsFile, "utf8")).toBe("-ilc\ntrue\n")
   })
 
   it("truncates runaway output instead of buffering it all", async () => {

--- a/packages/kobe/test/plugins/pane-command.test.ts
+++ b/packages/kobe/test/plugins/pane-command.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import { buildPaneArgv, listPaneLaunches } from "@sma1lboy/kobe-daemon/plugins/pane-command"
 import { savePluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
 import { afterEach, describe, expect, it } from "vitest"
@@ -18,14 +19,14 @@ afterEach(() => {
 const OPTS = { socketPath: "/tmp/x.sock", binPath: "kobe" }
 
 describe("buildPaneArgv", () => {
-  it("wraps the command in sh -lc with the env contract and root expansion", () => {
+  it("wraps the command in the login shell's -ilc with the env contract and root expansion", () => {
     const argv = buildPaneArgv(
       "p.id",
       "/plug/root",
       { id: "b", title: "B", placement: "split", command: ["sh", "$ROVE_PLUGIN_ROOT/run.sh", "it's"] },
       OPTS,
     )
-    expect(argv.slice(0, 2)).toEqual(["sh", "-lc"])
+    expect(argv.slice(0, 2)).toEqual([resolveLoginShell(), "-ilc"])
     const script = argv[2] as string
     expect(script.startsWith("exec env ")).toBe(true)
     for (const frag of [
@@ -69,6 +70,6 @@ describe("listPaneLaunches", () => {
     const launches = listPaneLaunches({ ...OPTS, homeDir: home })
     expect(launches).toHaveLength(1)
     expect(launches[0]).toMatchObject({ pluginId: "p", paneId: "git", title: "lazygit", placement: "split" })
-    expect(launches[0]?.argv[0]).toBe("sh")
+    expect(launches[0]?.argv[0]).toBe(resolveLoginShell())
   })
 })


### PR DESCRIPTION
## Why

Issue #26: engine tabs already integrate the user's shell env — they spawn through `resolveLoginShell()` + `-ilc` (`packages/kobe/src/engine/session-launch.ts`), so `.zshrc`/`.bashrc` PATH/exports all apply. But three spawn paths bypassed that integration and drifted (PATH/alias/env differences):

1. `rove api pane-open --command` hardcoded `["sh", "-lc", cmd]` — login `sh` reads only `/etc/profile` + `~/.profile`, never `.zshrc`/`.bashrc`.
2. Plugin panes hardcoded `["sh", "-lc", script]` (`packages/kobe-daemon/src/plugins/pane-command.ts`).
3. The automation precheck used `[shell, "-lc"]` — non-interactive login: zsh skips `.zshrc`, bash only reads `.bash_profile`.

## What changed

All three now reuse the exact integration path engine tabs take — `resolveLoginShell()` + `-ilc` (interactive login shell); the no-command pane-open case becomes `[shell, "-il"]`, matching the bare terminal tab. No new spawn path was invented; the pane/precheck sites just call the same primitive.

- `packages/kobe/src/cli/api/handlers-pane.ts` — pane-open argv (command + no-command cases), help text updated
- `packages/kobe-daemon/src/plugins/pane-command.ts` — plugin pane argv
- `packages/kobe-daemon/src/daemon/automation-precheck.ts` — precheck spawn flags; header comment documents the `-i` trade-off (interactive rc output, e.g. a prompt framework's banner, rides into the captured streams; exit code stays the only decision signal and the timeout bounds a slow rc)

## Tests

- Updated `test/cli/api-pane.test.ts` + `test/plugins/pane-command.test.ts` to assert the login-shell `-ilc`/`-il` argv
- New regression test in `test/daemon/automation-precheck.test.ts`: a spy shell pins the exact `-ilc` flag contract
- Green locally: default vitest suite (324 files / 3122 tests), socket track (65 files / 553 tests), `tsc --noEmit`, biome on touched files

Changeset: `@sma1lboy/rove` patch.
