### PR TITLE
fix: make perf-golden park-heap-reclaim probe load-robust

### DIFF
--- a/.changeset/perf-golden-park-heap-robust.md
+++ b/.changeset/perf-golden-park-heap-robust.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the `perf:golden` `park-heap-reclaim` probe's machine-load flake (bimodal 2% vs 52%). The sweep's quiet gate (`PARK_QUIET_MS`) refused to park the just-filled tabs, so nothing ever parked and the old %-of-total-heap formula was really measuring GC laziness — ambient, load-dependent. The probe now fast-forwards the sweep clock so parking actually happens, counts typed-array backing stores (`extraMemorySize`, where xterm cells live) in the heap reading, and reports a self-normalizing ratio — heap freed as a share of the growth the 10 tabs themselves caused — from the median of three settled GC samples.

--- a/packages/kobe/scripts/perf-golden.ts
+++ b/packages/kobe/scripts/perf-golden.ts
@@ -36,7 +36,7 @@ const GOLDEN = {
   "daemon-connect-replay-ms": 500, // socket connect + subscribe → snapshot replayed
   "daemon-rpc-p50-ms": 20, // daemon.status round-trip, median of 20
   "mem-per-tab-mb": 18, // hot-tab RSS cost, 10 visited tabs
-  "park-heap-reclaim-pct-min": 40, // JS-heap % released by parking those tabs
+  "park-heap-reclaim-pct-min": 40, // % of the tabs' own heap growth that parking reclaims
   "binary-size-mb": 150, // standalone `bun build --compile` output (skipped by --fast)
   "binary-compile-ms": 240_000, // scripts/compile.ts wall time (skipped by --fast)
 }
@@ -44,12 +44,14 @@ const GOLDEN = {
 setRoveEnv("HOME_DIR", mkdtempSync(join(tmpdir(), "kobe-perf-golden-")))
 setRoveEnv("PTY_IDLE_EXIT_MS", "2000")
 
-const { PtyRegistry } = await import("../src/tui/panes/terminal/registry.ts")
+const { PtyRegistry, PARK_QUIET_MS } = await import("../src/tui/panes/terminal/registry.ts")
 const { XtermTaskPty } = await import("../src/tui/panes/terminal/pty-xterm-base.ts")
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 const rssMb = () => process.memoryUsage().rss / 1048576
-const heapMb = () => (require("bun:jsc") as { heapStats(): { heapSize: number } }).heapStats().heapSize / 1048576
+const heapStats = () =>
+  (require("bun:jsc") as { heapStats(): { heapSize: number; extraMemorySize: number } }).heapStats()
+const heapMb = () => (heapStats().heapSize + heapStats().extraMemorySize) / 1048576
 const median = (xs: number[]) => xs.slice().sort((a, b) => a - b)[Math.floor(xs.length / 2)] ?? 0
 const text = (p: { capture(): readonly (readonly { text: string }[])[] }) =>
   p
@@ -205,6 +207,12 @@ const reg = new PtyRegistry()
 /* 6+7 — per-tab memory and park reclaim (10 visited tabs). */
 {
   const rss1 = rssMb()
+  Bun.gc(true)
+  // Heap baseline before the tabs exist. The reclaim metric below is a
+  // SELF-NORMALIZING ratio — freed / the growth these 10 tabs caused —
+  // because %-of-total-heap made the denominator ambient (daemon server,
+  // earlier probes, load-driven allocation) and bimodal across machines.
+  const heapBase = heapMb()
   let unsubs: (undefined | (() => void))[] = []
   for (let i = 0; i < 10; i++) {
     const pty = reg.acquire(`perf::mem-${i}`, "/tmp", BASH)
@@ -221,12 +229,31 @@ const reg = new PtyRegistry()
     unsubs[i] = undefined
   }
   unsubs = []
-  const heapBefore = heapMb()
-  reg.parkIdle(0)
   Bun.gc(true)
-  await sleep(800)
+  await sleep(300)
   Bun.gc(true)
-  record("park-heap-reclaim-pct-min", ((heapBefore - heapMb()) / heapBefore) * 100, "%")
+  const heapHot = heapMb()
+  // Fast-forward the sweep clock past the quiet gate: the fill finished
+  // seconds ago (the shells really are idle), but parkIdle refuses to park
+  // anything with output inside PARK_QUIET_MS — passing a future `now` is
+  // the test-only clock injection the sweep API already exposes. Without
+  // it NOTHING parks here and the metric degenerates into measuring GC
+  // laziness — the bimodal 2%-vs-52% flake this probe had.
+  reg.parkIdle(0, Date.now() + PARK_QUIET_MS + 1000)
+  // Multi-sample after repeated GC cycles; parked shells release their
+  // rings asynchronously, so take the median of settled readings instead
+  // of one point sample.
+  const parked: number[] = []
+  for (let i = 0; i < 3; i++) {
+    Bun.gc(true)
+    await sleep(600)
+    Bun.gc(true)
+    parked.push(heapMb())
+  }
+  const heapParked = median(parked)
+  const grown = heapHot - heapBase
+  if (grown < 5) throw new Error(`park probe: tab heap growth too small to measure (${grown.toFixed(1)}MB)`)
+  record("park-heap-reclaim-pct-min", ((heapHot - heapParked) / grown) * 100, "%")
 }
 
 /* Teardown pty sandbox before the (long) compile. */


### PR DESCRIPTION
Fixes daemon issue #2 (perf golden 'park-heap-reclaim' bimodal 2% vs 52% under machine load).

## Root cause

The probe never measured parking at all. `registry.parkIdle`'s quiet gate (`PARK_QUIET_MS = 30s`) refuses to park any tab with output in the last 30s — and the probe fills the tabs with output 5s before calling `parkIdle(0)`, so **nothing ever parked**. The old formula `(heapBefore - heapAfter) / heapBefore` (no GC before `heapBefore`) was actually measuring GC laziness: on a quiet machine JSC stays lazy, `heapBefore` is inflated with fill-phase garbage, and the post-park `Bun.gc(true)` appears to "reclaim" ~52%; under load GC runs continuously, `heapBefore` is already clean → ~2%. Bimodal by construction.

## Fix (test/harness only, no src changes)

- Fast-forward the sweep clock — `parkIdle(0, Date.now() + PARK_QUIET_MS + 1000)` uses the test-only `now` injection the sweep API already exposes, so the genuinely-idle shells actually park.
- Count `heapSize + extraMemorySize`: xterm cell data lives in typed-array backing stores, which JSC reports as `extraMemorySize`, not `heapSize`.
- Self-normalizing ratio instead of %-of-total-heap: reclaimed as a share of `(heapHot - heapBase)`, the growth the 10 tabs themselves caused — ambient heap from other probes / machine load cancels out of numerator and denominator.
- Robust statistics: median of 3 settled readings, each after two `Bun.gc(true)` cycles.
- Loud failure (`throw`) if tab-attributable growth is too small to measure (<5MB) instead of a silent garbage ratio.

No threshold tuned, no test deleted — the 40% floor now asserts a quantity that is actually park-driven.

## Verification

`bun run perf:golden --fast` × 4 on this machine: **107.9 / 108.3 / 108.6 / 108.1 %** (previously 0.9–1.3% measured honestly with GC-first baselines; old formula reported its GC-laziness artifact). All other metrics unchanged and green. `tsc --noEmit` + `biome check` clean.

Side observation (out of scope, not touched): the `pty-wake-ms` probe in the same file has the same quiet-gate issue — it parks nothing either (hence its ~0.2ms readings against a 200ms ceiling). Worth a follow-up issue.