### PR TITLE
fix: retire a hook running that observation disproved (#27)

### DIFF
--- a/.changeset/tidy-moons-invent.md
+++ b/.changeset/tidy-moons-invent.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix a pty-host blip resurrecting an already-corrected idle tab as a phantom `running` dot. Once observation disproves a stale hook `running` (ESC interrupt, dead engine), the hook slot is now retired instead of left to win the next ungated arbitration — and its lapse watchdog no longer keeps re-arming that claim for the length of a host outage.

--- a/packages/kobe-daemon/src/daemon/activity-arbitrate.ts
+++ b/packages/kobe-daemon/src/daemon/activity-arbitrate.ts
@@ -53,6 +53,10 @@ export interface ObservedSlot {
   readonly state: "running" | "idle"
   readonly at: number
   readonly vendor?: string
+  /** Lineage carried over from the hook slot this observation corrected —
+   *  the hook slot is retired once disproved, so the id has to live on
+   *  somewhere for late subscribers and the liveness probe. */
+  readonly session?: EngineSessionInfo
 }
 
 /** One tab's activity record: one slot per source. */
@@ -90,7 +94,7 @@ function fromObserved(observed: ObservedSlot, hook?: HookSlot): EffectiveActivit
     // Lineage falls back to the hook slot it just corrected: the liveness
     // probe and late subscribers still need to know WHICH engine this was.
     ...((observed.vendor ?? hook?.vendor) ? { vendor: observed.vendor ?? hook?.vendor } : {}),
-    ...(hook?.session ? { session: hook.session } : {}),
+    ...((observed.session ?? hook?.session) ? { session: observed.session ?? hook?.session } : {}),
   }
 }
 

--- a/packages/kobe-daemon/src/daemon/activity-registry.ts
+++ b/packages/kobe-daemon/src/daemon/activity-registry.ts
@@ -292,10 +292,11 @@ export class DaemonActivityRegistry {
   /**
    * Fold one OBSERVED per-session fact (issue #11/#16 — the activity
    * observer's PTY output heartbeat + foreground-walk reconciler) into the
-   * per-tab record's OBSERVED slot. The hook slot is never mutated here;
-   * what subscribers see follows {@link recomputeTabActivity}'s priority —
-   * hook claims outrank observation except the one documented correction (a
-   * stale hook `running` vs a fresher observed rest). Sticky attention
+   * per-tab record's OBSERVED slot. What subscribers see follows
+   * {@link recomputeTabActivity}'s priority — hook claims outrank
+   * observation except the one documented correction (a stale hook `running`
+   * vs a fresher observed rest), and a hook slot that loses THAT correction
+   * is retired here (see below) so it cannot come back. Sticky attention
    * states are NEVER touched: they mean "a human is needed" and carry no
    * output by nature.
    *
@@ -316,6 +317,7 @@ export class DaemonActivityRegistry {
       state: claim === "working" ? "running" : "idle",
       at: this.now(),
       vendor: opts.vendor ?? entry?.observed?.vendor ?? entry?.hook?.vendor,
+      session: entry?.observed?.session ?? entry?.hook?.session,
     }
     const effective = recomputeTabActivity(
       { hook: entry?.hook, observed },
@@ -324,15 +326,26 @@ export class DaemonActivityRegistry {
     )
     if (!effective) return "noop" // unreachable — the observed slot was just written
 
+    // A hook `running` that observation just DISPROVED is dead — retire the
+    // slot (and its watchdog) instead of leaving it to win the next
+    // arbitration. Keeping it resurrected the corrected tab as a phantom
+    // `running` on the very next ungated pass (the host-unreachable retire
+    // path passes no correction gate, so the Infinity default re-elects the
+    // stale claim at its original `at`), and its lapse watchdog kept
+    // re-arming that claim for the whole outage — issue #27. A genuinely new
+    // turn arrives as a fresh hook event, which writes the slot again.
+    const hook = effective.source === "observed" ? undefined : entry?.hook
+
     // Same state from the same source ⇒ a quiet refresh of the observed
     // slot's timestamp, no republish churn (a working engine re-asserted
     // every poll must not spam subscribers).
-    if (prev && prev.state === effective.state && prev.source === effective.source) {
-      if (entry) entry.observed = observed
+    if (entry && hook === entry.hook && prev && prev.state === effective.state && prev.source === effective.source) {
+      entry.observed = observed
       return "noop"
     }
+    if (hook === undefined && entry?.hook?.lapse) clearTimeout(entry.hook.lapse)
 
-    tabs.set(tabId, { hook: entry?.hook, observed, effective })
+    tabs.set(tabId, { ...(hook ? { hook } : {}), observed, effective })
     this.tabActivity.set(taskId, tabs)
     this.bus.publish("engine-state", this.payload(taskId, effective, tabId))
 

--- a/packages/kobe/test/daemon/activity-arbitrate.test.ts
+++ b/packages/kobe/test/daemon/activity-arbitrate.test.ts
@@ -94,6 +94,13 @@ describe("recomputeTabActivity", () => {
     expect(eff).toMatchObject({ state: "running", source: "hook" })
   })
 
+  it("a corrected observation carries its own session lineage once the hook slot is retired (#27)", () => {
+    // The registry drops a disproved hook slot, so the lineage it used to
+    // supply has to live on the observed slot instead.
+    const eff = recomputeTabActivity({ observed: { state: "idle", at: T, vendor: "claude", session: { id: "s1" } } }, T)
+    expect(eff).toMatchObject({ state: "idle", source: "observed", vendor: "claude", session: { id: "s1" } })
+  })
+
   it("hook detail rides the effective payload (badge subtitles read it)", () => {
     const eff = recomputeTabActivity(
       { hook: { state: "permission_needed", at: T, detail: { waiting: "permission" } } },

--- a/packages/kobe/test/engine/activity-observer.test.ts
+++ b/packages/kobe/test/engine/activity-observer.test.ts
@@ -174,6 +174,38 @@ describe("activity observer", () => {
     expect(w.row("tab-2")?.state).toBe("running")
   })
 
+  it("a pty-host outage never resurrects an already-corrected idle as phantom running (#27)", async () => {
+    // Regression for 073deeaf: after an ESC correction the tab held
+    // {hook: running@T0, observed: idle}. The host-unreachable retire path
+    // calls observeTab with NO correction gate, so the Infinity default
+    // re-elected the stale hook claim and republished `running` — at the
+    // stale T0 — for the whole outage.
+    const w = world()
+    w.registry.report(TASK, "turn-start", undefined, "tab-1", { id: "s1" }, "claude")
+    w.state.sessions = [{ key: KEY, alive: true, pid: 42, title: "✳ 修复构建失败", totalBytes: 100 }]
+    w.state.engines.set(42, "claude")
+    await waitFor(() => w.row("tab-1")?.state === "idle")
+
+    w.state.sessions = null // host blips
+    await wait(80)
+    expect(w.row("tab-1")?.state).toBe("idle")
+
+    // …and it stays idle once the host comes back still resting.
+    w.state.sessions = [{ key: KEY, alive: true, pid: 42, title: "✳ 修复构建失败", totalBytes: 100 }]
+    await wait(80)
+    expect(w.row("tab-1")?.state).toBe("idle")
+  })
+
+  it("a fresh hook turn after a correction relights the tab (the retire is not permanent)", async () => {
+    const w = world()
+    w.registry.report(TASK, "turn-start", undefined, "tab-1", { id: "s1" }, "claude")
+    w.state.sessions = [{ key: KEY, alive: true, pid: 42, title: "✳ resting", totalBytes: 100 }]
+    w.state.engines.set(42, "claude")
+    await waitFor(() => w.row("tab-1")?.state === "idle")
+    w.registry.report(TASK, "turn-start", undefined, "tab-1", { id: "s1" }, "claude")
+    expect(w.row("tab-1")?.state).toBe("running")
+  })
+
   it("hook events outrank observation: a sticky badge is never overwritten", async () => {
     const w = world()
     w.registry.report(TASK, "awaiting-input", { waiting: "permission" }, "tab-1", { id: "s1" }, "claude")


### PR DESCRIPTION
Fixes daemon issue #27 — the 073deeaf regression where a brief pty-host disconnect resurrects an already-corrected idle tab as a phantom `running` dot.

## Root cause

After an ESC correction (arbitration rule 2) the tab holds `{hook: running@T0 (kept), observed: idle, effective: idle}`. The host-unreachable branch in `activity-observer.ts:146` calls `observeTab(…, "rest", {})` with **no** `correctHookRunningAfterMs`, so the `Infinity` default makes `recomputeTabActivity` re-elect the retained hook slot — republishing `running` at the stale `T0`. The hook slot's lapse watchdog then keeps re-arming it, so the phantom persists for the whole outage. Pre-073deeaf this branch was a noop because the correction had already replaced the entire entry with the observed idle.

## Fix

`observeTab` now **retires** the hook slot (and clears its watchdog) whenever the observation wins arbitration. A disproved hook `running` is dead; a genuinely new turn arrives as a fresh hook event that writes the slot again. This is one guard at the shared arbitration seam, so it covers every `observeTab` caller (session-exited, session-gone, no-engine-in-foreground, silence, resting-title, host-unreachable), not just the path the issue names.

Session lineage that used to be borrowed from the hook slot now rides the observed slot (`ObservedSlot.session`), so late subscribers and the liveness probe still learn which engine it was.

## Tests (red before, green after)

- `activity-observer.test.ts`: "a pty-host outage never resurrects an already-corrected idle as phantom running (#27)" — fails on the pre-fix tree with `expected 'running' to be 'idle'`.
- `activity-observer.test.ts`: "a fresh hook turn after a correction relights the tab" — pins that the retire isn't permanent.
- `activity-arbitrate.test.ts`: observed-slot lineage survives the retire.

Local: root lint clean, typecheck clean, `test:fast` 3124 passed, `test:socket` 553 passed.

## Not in scope

The two non-regression findings recorded in the same audit (dead-engine sticky states never yielding to fallback vs herdr's `hook_authority_is_effective`; host **restart** losing its inventory so vanished sessions skip the session-gone correction) are pre-existing and left for separate issues.