### PR TITLE
fix: show readable Codex tab titles

### DIFF
--- a/.changeset/codex-readable-tab-titles.md
+++ b/.changeset/codex-readable-tab-titles.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Show a readable first-prompt title for unnamed Codex tabs while retaining Codex's terminal-title UUID as the session identity used to read history, and ignore image attachment metadata when deriving that title.

--- a/.changeset/immediate-tab-auto-titles.md
+++ b/.changeset/immediate-tab-auto-titles.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Name unnamed Codex tabs immediately after their session identity appears, with session-level deduplication, bounded concurrency, and short backoff while the first transcript message reaches disk.

--- a/.changeset/immediate-tab-auto-titles.md
+++ b/.changeset/immediate-tab-auto-titles.md
@@ -2,4 +2,4 @@
 "@sma1lboy/rove": patch
 ---
 
-Name unnamed Codex tabs immediately after their session identity appears, with session-level deduplication, bounded concurrency, and short backoff while the first transcript message reaches disk.
+Name unnamed Codex tabs immediately after their session identity appears, using an engine-declared naming policy with session-level deduplication, bounded concurrency, and short backoff while the first transcript message reaches disk.

--- a/docs/design/engine-internals.md
+++ b/docs/design/engine-internals.md
@@ -195,11 +195,15 @@ Claude and Codex own their OSC title while visible
 (`terminalTitle.ownsStatus`), so neutral tab chrome doesn't prefix a
 duplicate turn glyph. Codex additionally launches with
 `-c tui.terminal_title=["activity","thread-title"]` so tabs show its thread
-title instead of the repo name. Everywhere a live engine title is displayed
-(tab labels, split corner tags) it collapses to the launch binary
-(`✳ Claude Code` renders as `claude`), so all Rove surfaces speak one
-vocabulary for a process. Vendor identity comes from the process tree, never
-from matching the title string.
+title instead of the repo name. Before Codex has a readable thread title, that
+slot contains the session UUID: Rove retains it as history identity but names
+the tab from the first visible user prompt, ignoring image-attachment wrapper
+text. The lookup starts as soon as the UUID appears, is concurrency-bounded,
+and retries briefly while the first transcript record reaches disk. Everywhere
+a live engine title is displayed (tab labels, split corner tags) it collapses
+to the launch binary (`✳ Claude Code` renders as `claude`), so all Rove
+surfaces speak one vocabulary for a process. Vendor identity comes from the
+process tree, never from matching the title string.
 
 ## Transcript readers
 

--- a/docs/design/engine-internals.md
+++ b/docs/design/engine-internals.md
@@ -199,11 +199,20 @@ title instead of the repo name. Before Codex has a readable thread title, that
 slot contains the session UUID: Rove retains it as history identity but names
 the tab from the first visible user prompt, ignoring image-attachment wrapper
 text. The lookup starts as soon as the UUID appears, is concurrency-bounded,
-and retries briefly while the first transcript record reaches disk. Everywhere
-a live engine title is displayed (tab labels, split corner tags) it collapses
-to the launch binary (`✳ Claude Code` renders as `claude`), so all Rove
-surfaces speak one vocabulary for a process. Vendor identity comes from the
-process tree, never from matching the title string.
+and retries briefly while the first transcript record reaches disk.
+
+Those behaviors are separate engine capabilities rather than Codex branches
+in the lifecycle: `terminalTitle.sessionIdFromTitle` optionally recovers
+identity, while `tabNaming` declares the resolution trigger, retry schedule,
+and the adapter-owned projection from neutral history to visible prompt text.
+An engine that declares no naming policy inherits the legacy five-second poll.
+Adding another UUID-title or attachment format therefore changes only its
+registry entry and adapter; the queue and React lifecycle stay vendor-neutral.
+
+Everywhere a live engine title is displayed (tab labels, split corner tags) it
+collapses to the launch binary (`✳ Claude Code` renders as `claude`), so all
+Rove surfaces speak one vocabulary for a process. Vendor identity comes from
+the process tree, never from matching the title string.
 
 ## Transcript readers
 

--- a/packages/kobe/src/engine/codex-local/tab-naming.ts
+++ b/packages/kobe/src/engine/codex-local/tab-naming.ts
@@ -1,0 +1,22 @@
+import type { EngineTabNamingPolicy } from "../tab-naming-policy"
+
+/** Codex-only transcript decorations that must not become a tab name. */
+function isAttachmentMetadata(text: string): boolean {
+  const trimmed = text.trim()
+  return (
+    /^<image name=\[Image #\d+\] path="[^"]+">$/.test(trimmed) ||
+    trimmed === "</image>" ||
+    /^\[codex: (?:input_)?image\]$/.test(trimmed)
+  )
+}
+
+export const codexTabNamingPolicy: EngineTabNamingPolicy = {
+  trigger: "immediate",
+  retryDelaysMs: [250, 1_000, 2_000, 5_000],
+  promptText: (message) =>
+    message.blocks
+      .filter((block): block is { type: "text"; text: string } => block.type === "text")
+      .map((block) => block.text)
+      .filter((text) => !isAttachmentMetadata(text))
+      .join(" "),
+}

--- a/packages/kobe/src/engine/history-reader.ts
+++ b/packages/kobe/src/engine/history-reader.ts
@@ -1,0 +1,28 @@
+import type { Message } from "@/types/engine"
+
+/**
+ * Vendor-neutral reader over one engine's on-disk transcript store.
+ * Native paths and formats stay behind the adapter; auto-title, handoff,
+ * activity polling, and history rendering consume this contract only.
+ */
+export interface EngineHistoryReader {
+  /**
+   * Session ids for `worktree`, oldest first so the task's origin
+   * conversation wins auto-naming. Empty when none exist; never throws.
+   */
+  listSessionIdsForWorktree(worktree: string): Promise<readonly string[]>
+  /** Neutral messages for one session id; empty when not found. */
+  readHistory(sessionId: string): Promise<Message[]>
+  /**
+   * Native transcript path, or null when the engine has none to expose.
+   * Cross-engine handoff gives this path to the next agent; neutral code
+   * must use `readHistory` instead of parsing the file itself.
+   */
+  transcriptPath(sessionId: string, worktree: string): Promise<string | null>
+  /**
+   * Newest transcript mtime for `worktree`, or zero when none exists.
+   * Best-effort and non-throwing because the activity poll treats zero as
+   * "no activity seen".
+   */
+  latestTranscriptMtimeForWorktree(worktree: string): Promise<number>
+}

--- a/packages/kobe/src/engine/history-readers.ts
+++ b/packages/kobe/src/engine/history-readers.ts
@@ -12,9 +12,8 @@ import path from "node:path"
 import * as claudeHistory from "./claude-code-local/history.ts"
 import * as codexHistory from "./codex-local/history.ts"
 import * as copilotHistory from "./copilot-local/history.ts"
+import type { EngineHistoryReader } from "./history-reader.ts"
 import * as kimiHistory from "./kimi-local/history.ts"
-// Type-only, so the registry↔readers pair is not a runtime cycle.
-import type { EngineHistoryReader } from "./registry.ts"
 
 /**
  * The documented empty history reader for engines with no on-disk

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -147,8 +147,7 @@ export interface EngineRegistryEntry {
   readonly terminalTitle?: {
     readonly ownsStatus: boolean
     readonly launchArgs?: readonly string[]
-    /** Recover a vendor session id when an unnamed session emits identity
-     *  instead of a display name. The adapter owns that wire format. */
+    /** Recover the vendor session id emitted as an unnamed session's title. */
     readonly sessionIdFromTitle?: (title: string) => string | null
     /**
      * Leading STATUS decoration the engine writes into its own OSC title,

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -26,7 +26,7 @@
  * Must stay importable from vitest and MUST NOT import from `src/tui/`.
  */
 
-import type { EngineCapabilities, EngineIdentity, EngineQuotaUsage, Message } from "@/types/engine"
+import type { EngineCapabilities, EngineIdentity, EngineQuotaUsage } from "@/types/engine"
 import { type VendorId, isBuiltinVendor } from "@/types/vendor"
 import {
   type ClaudeAccount,
@@ -49,7 +49,9 @@ import { readClaudeTurns } from "./claude-code-local/turns.ts"
 import { codexCapabilities, codexIdentity } from "./codex-local/capabilities.ts"
 import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
 import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
+import { codexTabNamingPolicy } from "./codex-local/tab-naming.ts"
 import { trustCodexWorktree } from "./codex-local/trust.ts"
+import type { EngineHistoryReader } from "./history-reader.ts"
 import {
   EMPTY_HISTORY,
   claudeHistoryReader,
@@ -59,39 +61,10 @@ import {
 } from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
 import { trustKimiWorktree } from "./kimi-local/trust.ts"
+import { DEFAULT_TAB_NAMING_POLICY, type EngineTabNamingPolicy } from "./tab-naming-policy.ts"
 import { ClaudeTurnDetector, CodexTurnDetector, type EngineTurnDetector, UnknownTurnDetector } from "./turn-detector.ts"
 
-/**
- * Reader over an engine's on-disk transcript store, in the neutral shape
- * auto-title (and future recap) consumes. Vendor formats stay behind it:
- * claude's per-worktree `~/.claude/projects/*` dirs, codex's global
- * `~/.codex/sessions/**` rollouts, copilot's `~/.copilot/session-state`.
- */
-export interface EngineHistoryReader {
-  /**
-   * Session ids recorded for `worktree`, OLDEST-FIRST (the task's origin
-   * conversation comes first — auto-title depends on this order). `[]`
-   * when the worktree has no transcripts. Never throws.
-   */
-  listSessionIdsForWorktree(worktree: string): Promise<readonly string[]>
-  /** Neutral messages for one session id; `[]` when not found. */
-  readHistory(sessionId: string): Promise<Message[]>
-  /**
-   * Absolute path of the on-disk transcript for `sessionId`, or null when
-   * the engine has no file to point at. Not for kobe to PARSE (that's
-   * `readHistory`) — it is what the cross-engine handoff hands the next
-   * agent to read itself, so its native format never has to be converted.
-   * `worktree` scopes stores that key by directory (claude's project dir).
-   */
-  transcriptPath(sessionId: string, worktree: string): Promise<string | null>
-  /**
-   * Newest transcript mtime (epoch ms) for `worktree`, or 0 when the task
-   * has no transcript yet. The Ops pane's activity poll watches this to
-   * light its "new activity" badge. Never throws — readers are
-   * best-effort and the poller treats 0 as "no activity seen".
-   */
-  latestTranscriptMtimeForWorktree(worktree: string): Promise<number>
-}
+export type { EngineHistoryReader } from "./history-reader.ts"
 
 /** Any built-in engine's account shape (each union already has a `none` arm). */
 export type EngineAccount = ClaudeAccount | CodexAccount | CopilotAccount | KimiAccount
@@ -116,6 +89,8 @@ export interface EngineRegistryEntry {
   readonly effortLevels?: readonly string[]
   /** Transcript store reader. Empty (not claude's!) for custom engines. */
   readonly history: EngineHistoryReader
+  /** First-prompt tab naming schedule and engine-owned text projection. */
+  readonly tabNaming?: EngineTabNamingPolicy
   /**
    * Read-only binary + login probe (Settings → Accounts). `deps` is the
    * injectable fs/env surface from `account-detect.ts`; omit for production.
@@ -262,6 +237,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     // deliberately excluded — CHANGELOG 0.5.17).
     effortLevels: ["none", "low", "medium", "high", "xhigh"],
     history: codexHistoryReader,
+    tabNaming: codexTabNamingPolicy,
 
     detectAccount: (deps) => detectCodexAccount(deps),
     createHookAdapter: () => new CodexHookAdapter(),
@@ -430,6 +406,11 @@ export function stripEngineStatusPrefix(title: string, vendor: VendorId | null |
 /** Session identity encoded in an engine's already-undecorated OSC title. */
 export function engineSessionIdFromTitle(vendor: VendorId, title: string): string | null {
   return engineEntry(vendor).terminalTitle?.sessionIdFromTitle?.(title.trim()) ?? null
+}
+
+/** Explicit naming policy, with the legacy polling behavior as the default. */
+export function engineTabNamingPolicy(vendor: VendorId): EngineTabNamingPolicy {
+  return engineEntry(vendor).tabNaming ?? DEFAULT_TAB_NAMING_POLICY
 }
 
 /**

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -145,6 +145,9 @@ export interface EngineRegistryEntry {
   readonly terminalTitle?: {
     readonly ownsStatus: boolean
     readonly launchArgs?: readonly string[]
+    /** Recover a vendor session id when an unnamed session emits identity
+     *  instead of a display name. The adapter owns that wire format. */
+    readonly sessionIdFromTitle?: (title: string) => string | null
     /**
      * Leading STATUS decoration the engine writes into its own OSC title,
      * stripped before kobe renders the name. Engine-owned by construction:
@@ -262,6 +265,10 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     terminalTitle: {
       ownsStatus: true,
       launchArgs: ["-c", 'tui.terminal_title=["activity","thread-title"]'],
+      // An unnamed Codex thread renders its UUID for `thread-title`. Keep
+      // that as session identity so history can provide the readable name.
+      sessionIdFromTitle: (title) =>
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(title) ? title : null,
       // The `activity` segment is a braille spinner frame joined to the next
       // segment by a space (codex `TERMINAL_TITLE_SPINNER_FRAMES` +
       // `separator_from_previous`). It only appears while a turn runs, so a
@@ -408,6 +415,11 @@ export function stripEngineStatusPrefix(title: string, vendor: VendorId | null |
     return rest
   }
   return title
+}
+
+/** Session identity encoded in an engine's already-undecorated OSC title. */
+export function engineSessionIdFromTitle(vendor: VendorId, title: string): string | null {
+  return engineEntry(vendor).terminalTitle?.sessionIdFromTitle?.(title.trim()) ?? null
 }
 
 /**

--- a/packages/kobe/src/engine/tab-naming-policy.ts
+++ b/packages/kobe/src/engine/tab-naming-policy.ts
@@ -1,0 +1,23 @@
+import type { Message } from "@/types/engine"
+
+export interface EngineTabNamingPolicy {
+  /** When a known session should first be resolved into a readable title. */
+  readonly trigger: "poll" | "immediate"
+  /** Optional engine-specific backoff while an announced transcript lands. */
+  readonly retryDelaysMs?: readonly number[]
+  /** Project one neutral user message into title-worthy visible text. */
+  readonly promptText: (message: Message) => string
+}
+
+export function defaultPromptText(message: Message): string {
+  return message.blocks
+    .filter((block): block is { type: "text"; text: string } => block.type === "text")
+    .map((block) => block.text)
+    .join(" ")
+}
+
+/** Backward-compatible policy for engines that do not declare one. */
+export const DEFAULT_TAB_NAMING_POLICY: EngineTabNamingPolicy = {
+  trigger: "poll",
+  promptText: defaultPromptText,
+}

--- a/packages/kobe/src/monitor/auto-title.ts
+++ b/packages/kobe/src/monitor/auto-title.ts
@@ -20,33 +20,22 @@
  * transcripts.
  */
 
-import { engineEntry } from "@/engine/registry"
+import { engineEntry, engineTabNamingPolicy } from "@/engine/registry"
+import { defaultPromptText } from "@/engine/tab-naming-policy"
 import { deriveTitleFromPrompt } from "@/orchestrator/title"
 import type { Message } from "@/types/engine"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
 
 const MAX_SESSIONS_SCANNED = 8
 
-/** Attachment wrapper text is useful in history but must never name a task. */
-function isAttachmentMetadataText(text: string): boolean {
-  const trimmed = text.trim()
-  return (
-    /^<image name=\[Image #\d+\] path="[^"]+">$/.test(trimmed) ||
-    trimmed === "</image>" ||
-    /^\[codex: (?:input_)?image\]$/.test(trimmed)
-  )
-}
-
 /** First user message's visible text, truncated to a title, or `""`. */
-export function deriveTitleFromMessages(messages: Message[]): string {
+export function deriveTitleFromMessages(
+  messages: Message[],
+  promptText: (message: Message) => string = defaultPromptText,
+): string {
   const firstUser = messages.find((m) => m.role === "user")
   if (!firstUser) return ""
-  const text = firstUser.blocks
-    .filter((b): b is { type: "text"; text: string } => b.type === "text")
-    .map((b) => b.text)
-    .filter((block) => !isAttachmentMetadataText(block))
-    .join(" ")
-  const title = deriveTitleFromPrompt(text)
+  const title = deriveTitleFromPrompt(promptText(firstUser))
   // Force-copy before the title escapes into long-lived state (the task
   // store in the daemon process, via orch.setTitle). `deriveTitleFromPrompt`
   // truncates with `.slice(...)`, and in JSC (Bun) a slice SHARES the parent
@@ -68,6 +57,7 @@ export async function deriveTitleFromSession(
 ): Promise<string> {
   if (!worktree) return ""
   const { history } = engineEntry(vendor)
+  const { promptText } = engineTabNamingPolicy(vendor)
   const ids = await history.listSessionIdsForWorktree(worktree)
   // Walk sessions oldest-first (the task's origin conversation comes
   // first) and return the first that yields a usable title. We don't
@@ -76,7 +66,7 @@ export async function deriveTitleFromSession(
   // give an empty title. Capped so a busy worktree doesn't read dozens
   // of transcripts.
   for (const sessionId of ids.slice(0, MAX_SESSIONS_SCANNED)) {
-    const title = deriveTitleFromMessages(await history.readHistory(sessionId))
+    const title = deriveTitleFromMessages(await history.readHistory(sessionId), promptText)
     if (title) return title
   }
   return ""
@@ -92,7 +82,8 @@ export async function deriveTitleFromSession(
 export async function deriveTitleFromSessionId(vendor: VendorId, sessionId: string): Promise<string> {
   if (!sessionId) return ""
   try {
-    return deriveTitleFromMessages(await engineEntry(vendor).history.readHistory(sessionId))
+    const entry = engineEntry(vendor)
+    return deriveTitleFromMessages(await entry.history.readHistory(sessionId), engineTabNamingPolicy(vendor).promptText)
   } catch {
     return ""
   }

--- a/packages/kobe/src/monitor/auto-title.ts
+++ b/packages/kobe/src/monitor/auto-title.ts
@@ -27,13 +27,24 @@ import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
 
 const MAX_SESSIONS_SCANNED = 8
 
-/** First user message's text, truncated to a title, or `""` if none yet. */
-function titleFromMessages(messages: Message[]): string {
+/** Attachment wrapper text is useful in history but must never name a task. */
+function isAttachmentMetadataText(text: string): boolean {
+  const trimmed = text.trim()
+  return (
+    /^<image name=\[Image #\d+\] path="[^"]+">$/.test(trimmed) ||
+    trimmed === "</image>" ||
+    /^\[codex: (?:input_)?image\]$/.test(trimmed)
+  )
+}
+
+/** First user message's visible text, truncated to a title, or `""`. */
+export function deriveTitleFromMessages(messages: Message[]): string {
   const firstUser = messages.find((m) => m.role === "user")
   if (!firstUser) return ""
   const text = firstUser.blocks
     .filter((b): b is { type: "text"; text: string } => b.type === "text")
     .map((b) => b.text)
+    .filter((block) => !isAttachmentMetadataText(block))
     .join(" ")
   const title = deriveTitleFromPrompt(text)
   // Force-copy before the title escapes into long-lived state (the task
@@ -65,7 +76,7 @@ export async function deriveTitleFromSession(
   // give an empty title. Capped so a busy worktree doesn't read dozens
   // of transcripts.
   for (const sessionId of ids.slice(0, MAX_SESSIONS_SCANNED)) {
-    const title = titleFromMessages(await history.readHistory(sessionId))
+    const title = deriveTitleFromMessages(await history.readHistory(sessionId))
     if (title) return title
   }
   return ""
@@ -81,7 +92,7 @@ export async function deriveTitleFromSession(
 export async function deriveTitleFromSessionId(vendor: VendorId, sessionId: string): Promise<string> {
   if (!sessionId) return ""
   try {
-    return titleFromMessages(await engineEntry(vendor).history.readHistory(sessionId))
+    return deriveTitleFromMessages(await engineEntry(vendor).history.readHistory(sessionId))
   } catch {
     return ""
   }

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -11,7 +11,8 @@
 import { engineEntry } from "@/engine/registry"
 import { deriveTitleFromSessionId } from "@/monitor/auto-title"
 import type { VendorId } from "@/types/vendor"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
+import { TabNamingQueue, type TabNamingTarget } from "../../tui/workspace/tab-naming-queue"
 import { type EngineTab, type TabsState, setTabAutoTitle, setTabSpawned } from "../../tui/workspace/terminal-tabs-core"
 
 /** Cadence of the tab auto-naming pass (tmux ran its pass on the monitor tick). */
@@ -63,34 +64,86 @@ export function useTabHydration(rehydrated: boolean, io: TabLifecycleIO): boolea
   return hydrating
 }
 
-/** Auto-naming + existence tracking (the tmux naming pass), mount-only. */
+/** Immediate auto-naming + existence tracking, with a mount-owned fallback. */
 export function useTabNaming(io: TabLifecycleIO): void {
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once interval; reads propsRef/stateRef for freshness.
-  useEffect(() => {
-    let namingBusy = false
-    const timer = setInterval(() => {
-      if (namingBusy) return
-      const candidates = io.stateRef.current.tabs.filter(
+  const ioRef = useRef(io)
+  ioRef.current = io
+  const queueRef = useRef<TabNamingQueue | null>(null)
+
+  const candidates = (): TabNamingTarget[] =>
+    ioRef.current.stateRef.current.tabs
+      .filter(
         (tab): tab is EngineTab =>
           tab.kind === "engine" && !!tab.sessionId && (!tab.spawned || (!tab.title && !tab.autoTitle)),
       )
-      if (candidates.length === 0) return
+      .map((tab) => ({
+        tabId: tab.id,
+        sessionId: tab.sessionId as string,
+        vendor: tab.vendor ?? ioRef.current.propsRef.current.vendor,
+      }))
+
+  const isCurrent = (target: TabNamingTarget): boolean => {
+    const tab = ioRef.current.stateRef.current.tabs.find((candidate) => candidate.id === target.tabId)
+    return (
+      tab?.kind === "engine" && tab.sessionId === target.sessionId && (!tab.spawned || (!tab.title && !tab.autoTitle))
+    )
+  }
+
+  const applyTitle = (target: TabNamingTarget, title: string): void => {
+    const current = ioRef.current.stateRef.current
+    const tab = current.tabs.find((candidate) => candidate.id === target.tabId)
+    if (tab?.kind !== "engine" || tab.sessionId !== target.sessionId) return
+    let next = setTabSpawned(current, tab.id, true)
+    if (!tab.title && !tab.autoTitle) next = setTabAutoTitle(next, tab.id, title)
+    ioRef.current.update(next)
+  }
+
+  const needsImmediateTitle = (target: TabNamingTarget): boolean =>
+    engineEntry(target.vendor).terminalTitle?.sessionIdFromTitle !== undefined
+
+  const queue = (): TabNamingQueue => {
+    if (queueRef.current) return queueRef.current
+    queueRef.current = new TabNamingQueue({
+      readTitle: (target) => deriveTitleFromSessionId(target.vendor, target.sessionId),
+      isCurrent,
+      applyTitle,
+    })
+    return queueRef.current
+  }
+
+  // Immediate path: a render carrying a newly-discovered session id queues
+  // its history read now. Keep this scoped to Codex: other engines retain
+  // the existing interval behavior in this Codex-title-focused change.
+  useEffect(() => queue().enqueue(candidates().filter(needsImmediateTitle)))
+
+  // Slow safety net for Codex plus the unchanged naming pass for other
+  // engines. The direct loop deliberately preserves their previous cadence.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once fallback; callbacks read ioRef for freshness.
+  useEffect(() => {
+    const namingQueue = queue()
+    let namingBusy = false
+    const timer = setInterval(() => {
+      const current = candidates()
+      namingQueue.enqueue(current.filter(needsImmediateTitle))
+      const intervalTargets = current.filter((target) => !needsImmediateTitle(target))
+      if (namingBusy || intervalTargets.length === 0) return
       namingBusy = true
       void (async () => {
         try {
-          for (const tab of candidates) {
-            if (!tab.sessionId) continue
-            const title = await deriveTitleFromSessionId(tab.vendor ?? io.propsRef.current.vendor, tab.sessionId)
-            if (!title) continue
-            let next = setTabSpawned(io.stateRef.current, tab.id, true)
-            if (!tab.title && !tab.autoTitle) next = setTabAutoTitle(next, tab.id, title)
-            io.update(next)
+          for (const target of intervalTargets) {
+            if (!isCurrent(target)) continue
+            const title = await deriveTitleFromSessionId(target.vendor, target.sessionId)
+            if (title) applyTitle(target, title)
           }
         } finally {
           namingBusy = false
         }
       })()
     }, NAMING_POLL_MS)
-    return () => clearInterval(timer)
+    return () => {
+      clearInterval(timer)
+      namingQueue.stop()
+      if (queueRef.current === namingQueue) queueRef.current = null
+    }
   }, [])
 }

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -8,7 +8,7 @@
  * synchronously). See the TerminalTabs file header for why refs.
  */
 
-import { engineEntry } from "@/engine/registry"
+import { engineEntry, engineTabNamingPolicy } from "@/engine/registry"
 import { deriveTitleFromSessionId } from "@/monitor/auto-title"
 import type { VendorId } from "@/types/vendor"
 import { useEffect, useRef, useState } from "react"
@@ -76,11 +76,17 @@ export function useTabNaming(io: TabLifecycleIO): void {
         (tab): tab is EngineTab =>
           tab.kind === "engine" && !!tab.sessionId && (!tab.spawned || (!tab.title && !tab.autoTitle)),
       )
-      .map((tab) => ({
-        tabId: tab.id,
-        sessionId: tab.sessionId as string,
-        vendor: tab.vendor ?? ioRef.current.propsRef.current.vendor,
-      }))
+      .map((tab) => {
+        const vendor = tab.vendor ?? ioRef.current.propsRef.current.vendor
+        const policy = engineTabNamingPolicy(vendor)
+        return {
+          tabId: tab.id,
+          sessionId: tab.sessionId as string,
+          vendor,
+          trigger: policy.trigger,
+          retryDelaysMs: policy.retryDelaysMs,
+        }
+      })
 
   const isCurrent = (target: TabNamingTarget): boolean => {
     const tab = ioRef.current.stateRef.current.tabs.find((candidate) => candidate.id === target.tabId)
@@ -98,8 +104,7 @@ export function useTabNaming(io: TabLifecycleIO): void {
     ioRef.current.update(next)
   }
 
-  const needsImmediateTitle = (target: TabNamingTarget): boolean =>
-    engineEntry(target.vendor).terminalTitle?.sessionIdFromTitle !== undefined
+  const needsImmediateTitle = (target: TabNamingTarget): boolean => target.trigger === "immediate"
 
   const queue = (): TabNamingQueue => {
     if (queueRef.current) return queueRef.current
@@ -111,13 +116,12 @@ export function useTabNaming(io: TabLifecycleIO): void {
     return queueRef.current
   }
 
-  // Immediate path: a render carrying a newly-discovered session id queues
-  // its history read now. Keep this scoped to Codex: other engines retain
-  // the existing interval behavior in this Codex-title-focused change.
+  // Engines opt into immediate resolution through their registry policy;
+  // undeclared and custom engines retain the legacy polling behavior.
   useEffect(() => queue().enqueue(candidates().filter(needsImmediateTitle)))
 
-  // Slow safety net for Codex plus the unchanged naming pass for other
-  // engines. The direct loop deliberately preserves their previous cadence.
+  // Slow safety net for immediate engines plus the unchanged naming pass for
+  // poll-triggered engines. No vendor identity is encoded in this scheduler.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once fallback; callbacks read ioRef for freshness.
   useEffect(() => {
     const namingQueue = queue()

--- a/packages/kobe/src/tui-react/workspace/use-tab-turn-state.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-turn-state.ts
@@ -19,13 +19,8 @@ import type { ChatTabTurnState } from "../../engine/turn-detector"
 import { attentionEdges, chipAttentionKind } from "../../tui/lib/notify-state"
 import { defaultShell } from "../../tui/panes/terminal/pty-types"
 import { InterruptObserver } from "../../tui/workspace/interrupt-observer"
-import { demoteExitedEngine } from "../../tui/workspace/terminal-tab-identity"
-import {
-  type TabsState,
-  type TerminalTab,
-  setTabLastTitle,
-  setTabLiveVendor,
-} from "../../tui/workspace/terminal-tabs-core"
+import { recordLiveTabTitle } from "../../tui/workspace/terminal-tab-recording"
+import type { TabsState, TerminalTab } from "../../tui/workspace/terminal-tabs-core"
 import { type HookTabState, mergeTurnStates } from "../../tui/workspace/turn-state-merge"
 import type { VendorId } from "../../types/vendor"
 import type { NotificationsContext } from "../context/notifications"
@@ -112,19 +107,7 @@ export function useTabTurnState(deps: {
     let next = current
     for (const [tabId, title] of liveTitles) {
       const live = turnVendors.get(tabId) ?? null
-      // The engine this tab was running is gone (vendor → confirmed null):
-      // reset the tab to the shell it always was, BEFORE recording the new
-      // identity. `kind` describes what runs here now — leaving it at
-      // "engine" is what kept a dot on the sidebar row and made every
-      // keystroke mark an optimistic turn for a session that had exited.
-      const tab = next.tabs.find((t) => t.id === tabId)
-      const demoted = tab ? demoteExitedEngine(tab, tab.liveVendor, live, [defaultShell()]) : undefined
-      if (tab && demoted && demoted !== tab) {
-        next = { ...next, tabs: next.tabs.map((t) => (t.id === tabId ? demoted : t)) }
-        continue // the reset already cleared lastTitle/liveVendor
-      }
-      next = setTabLastTitle(next, tabId, title)
-      next = setTabLiveVendor(next, tabId, live)
+      next = recordLiveTabTitle(next, tabId, title, live, [defaultShell()])
     }
     if (next !== current) apply(next)
   }, [liveTitles, turnVendors])

--- a/packages/kobe/src/tui/workspace/tab-naming-queue.ts
+++ b/packages/kobe/src/tui/workspace/tab-naming-queue.ts
@@ -1,0 +1,146 @@
+import type { VendorId } from "../../types/vendor"
+
+export interface TabNamingTarget {
+  readonly tabId: string
+  readonly sessionId: string
+  readonly vendor: VendorId
+}
+
+export interface TabNamingQueueDeps {
+  readonly readTitle: (target: TabNamingTarget) => Promise<string>
+  readonly isCurrent: (target: TabNamingTarget) => boolean
+  readonly applyTitle: (target: TabNamingTarget, title: string) => void
+  readonly maxConcurrent?: number
+  readonly retryDelaysMs?: readonly number[]
+}
+
+interface NamingEntry {
+  readonly targets: Map<string, TabNamingTarget>
+  attempt: number
+  state: "queued" | "running" | "waiting"
+  timer?: ReturnType<typeof setTimeout>
+}
+
+const DEFAULT_RETRY_DELAYS_MS = [250, 1_000, 2_000, 5_000] as const
+
+/**
+ * Session-keyed, bounded queue for first-prompt tab naming.
+ *
+ * Repeated renders and OSC spinner frames collapse into one lookup per
+ * session. Empty history retries with backoff because an engine can announce
+ * its session id just before its first user message reaches disk.
+ */
+export class TabNamingQueue {
+  private readonly entries = new Map<string, NamingEntry>()
+  private readonly queuedKeys: string[] = []
+  private readonly resolvedTitles = new Map<string, string>()
+  private readonly maxConcurrent: number
+  private readonly retryDelaysMs: readonly number[]
+  private running = 0
+  private generation = 0
+  private stopped = false
+
+  constructor(private readonly deps: TabNamingQueueDeps) {
+    this.maxConcurrent = Math.max(1, deps.maxConcurrent ?? 3)
+    this.retryDelaysMs = deps.retryDelaysMs?.length ? deps.retryDelaysMs : DEFAULT_RETRY_DELAYS_MS
+  }
+
+  enqueue(targets: readonly TabNamingTarget[]): void {
+    if (this.stopped) return
+    for (const target of targets) {
+      if (!this.deps.isCurrent(target)) continue
+      const key = this.key(target)
+      const resolved = this.resolvedTitles.get(key)
+      if (resolved) {
+        this.deps.applyTitle(target, resolved)
+        continue
+      }
+      const existing = this.entries.get(key)
+      if (existing) {
+        existing.targets.set(target.tabId, target)
+        continue
+      }
+      this.entries.set(key, {
+        targets: new Map([[target.tabId, target]]),
+        attempt: 0,
+        state: "queued",
+      })
+      this.queuedKeys.push(key)
+    }
+    this.pump()
+  }
+
+  stop(): void {
+    this.stopped = true
+    this.generation += 1
+    for (const entry of this.entries.values()) {
+      if (entry.timer) clearTimeout(entry.timer)
+    }
+    this.entries.clear()
+    this.queuedKeys.length = 0
+    this.resolvedTitles.clear()
+    this.running = 0
+  }
+
+  private key(target: TabNamingTarget): string {
+    return `${target.vendor}\0${target.sessionId}`
+  }
+
+  private prune(entry: NamingEntry): void {
+    for (const [tabId, target] of entry.targets) {
+      if (!this.deps.isCurrent(target)) entry.targets.delete(tabId)
+    }
+  }
+
+  private pump(): void {
+    while (!this.stopped && this.running < this.maxConcurrent) {
+      const key = this.queuedKeys.shift()
+      if (!key) return
+      const entry = this.entries.get(key)
+      if (!entry || entry.state !== "queued") continue
+      this.prune(entry)
+      const target = entry.targets.values().next().value as TabNamingTarget | undefined
+      if (!target) {
+        this.entries.delete(key)
+        continue
+      }
+      entry.state = "running"
+      this.running += 1
+      const generation = this.generation
+      void this.resolve(key, entry, target, generation)
+    }
+  }
+
+  private async resolve(key: string, entry: NamingEntry, target: TabNamingTarget, generation: number): Promise<void> {
+    let title = ""
+    try {
+      title = await this.deps.readTitle(target)
+    } catch {
+      // A rollout caught between creation and its first write is retryable.
+    }
+    if (this.stopped || generation !== this.generation || this.entries.get(key) !== entry) return
+
+    this.running -= 1
+    this.prune(entry)
+    if (title) {
+      this.resolvedTitles.set(key, title)
+      this.entries.delete(key)
+      for (const current of entry.targets.values()) this.deps.applyTitle(current, title)
+    } else if (entry.targets.size === 0) {
+      this.entries.delete(key)
+    } else {
+      const retryIndex = Math.min(entry.attempt, this.retryDelaysMs.length - 1)
+      const delay = this.retryDelaysMs[retryIndex] ?? 5_000
+      entry.attempt += 1
+      entry.state = "waiting"
+      entry.timer = setTimeout(() => {
+        if (this.stopped || this.entries.get(key) !== entry) return
+        entry.timer = undefined
+        entry.state = "queued"
+        this.queuedKeys.push(key)
+        this.pump()
+      }, delay)
+    }
+    this.pump()
+  }
+}

--- a/packages/kobe/src/tui/workspace/tab-naming-queue.ts
+++ b/packages/kobe/src/tui/workspace/tab-naming-queue.ts
@@ -4,6 +4,8 @@ export interface TabNamingTarget {
   readonly tabId: string
   readonly sessionId: string
   readonly vendor: VendorId
+  readonly trigger: "poll" | "immediate"
+  readonly retryDelaysMs?: readonly number[]
 }
 
 export interface TabNamingQueueDeps {
@@ -19,6 +21,7 @@ interface NamingEntry {
   attempt: number
   state: "queued" | "running" | "waiting"
   timer?: ReturnType<typeof setTimeout>
+  readonly retryDelaysMs: readonly number[]
 }
 
 const DEFAULT_RETRY_DELAYS_MS = [250, 1_000, 2_000, 5_000] as const
@@ -64,6 +67,7 @@ export class TabNamingQueue {
         targets: new Map([[target.tabId, target]]),
         attempt: 0,
         state: "queued",
+        retryDelaysMs: target.retryDelaysMs?.length ? target.retryDelaysMs : this.retryDelaysMs,
       })
       this.queuedKeys.push(key)
     }
@@ -129,8 +133,8 @@ export class TabNamingQueue {
     } else if (entry.targets.size === 0) {
       this.entries.delete(key)
     } else {
-      const retryIndex = Math.min(entry.attempt, this.retryDelaysMs.length - 1)
-      const delay = this.retryDelaysMs[retryIndex] ?? 5_000
+      const retryIndex = Math.min(entry.attempt, entry.retryDelaysMs.length - 1)
+      const delay = entry.retryDelaysMs[retryIndex] ?? 5_000
       entry.attempt += 1
       entry.state = "waiting"
       entry.timer = setTimeout(() => {

--- a/packages/kobe/src/tui/workspace/terminal-tab-recording.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-recording.ts
@@ -1,0 +1,34 @@
+/**
+ * Persist one terminal-title observation without depending on the React UI.
+ * The live-title hook and golden tests share this transition so session
+ * identity and display-title recording cannot drift apart.
+ */
+
+import { engineSessionIdFromTitle } from "../../engine/registry"
+import type { VendorId } from "../../types/vendor"
+import { demoteExitedEngine } from "./terminal-tab-identity"
+import { type TabsState, setTabLastTitle, setTabLiveVendor, setTabSessionId } from "./terminal-tabs-core"
+
+/** One live-title observation → the persisted tab identity snapshot. */
+export function recordLiveTabTitle(
+  state: TabsState,
+  tabId: string,
+  title: string,
+  live: VendorId | null,
+  shellCommand: readonly string[],
+): TabsState {
+  const tab = state.tabs.find((candidate) => candidate.id === tabId)
+  if (!tab) return state
+  const demoted = demoteExitedEngine(tab, tab.liveVendor, live, shellCommand)
+  if (demoted !== tab)
+    return { ...state, tabs: state.tabs.map((candidate) => (candidate.id === tabId ? demoted : candidate)) }
+
+  let next = state
+  const discoveredSessionId = live ? engineSessionIdFromTitle(live, title) : null
+  if (tab.kind === "engine" && discoveredSessionId && tab.sessionId !== discoveredSessionId) {
+    next = setTabSessionId(next, tabId, discoveredSessionId)
+  }
+  // A vendor fallback id is useful for history/resume, but it is not a name.
+  if (!discoveredSessionId) next = setTabLastTitle(next, tabId, title)
+  return setTabLiveVendor(next, tabId, live)
+}

--- a/packages/kobe/src/tui/workspace/terminal-tab-split.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-split.ts
@@ -12,7 +12,12 @@
  */
 
 import type { VendorId } from "@/types/vendor"
-import { engineEntry, engineStatusPrefixes, stripEngineStatusPrefix } from "../../engine/registry"
+import {
+  engineEntry,
+  engineSessionIdFromTitle,
+  engineStatusPrefixes,
+  stripEngineStatusPrefix,
+} from "../../engine/registry"
 import { t } from "../i18n"
 import { pathLeaf } from "../lib/path-helpers"
 import { type SplitState, leaves } from "./split-core"
@@ -167,6 +172,7 @@ function stableRecordedTitle(raw: string | null | undefined, vendor: VendorId): 
   const recorded = raw?.trim()
   if (!recorded) return null
   const cleaned = stripEngineStatusPrefix(recorded, vendor)
+  if (engineSessionIdFromTitle(vendor, cleaned)) return null
   // Unchanged AND made only of this engine's glyphs = decoration, not a name.
   if (cleaned === recorded && isEngineDecoration(recorded, vendor)) return null
   return cleaned || null
@@ -287,13 +293,22 @@ export function tabTitle(tab: TerminalTab, taskVendor: VendorId, liveName?: stri
   // only the pre-title fallback. Deriving from the task's CURRENT vendor
   // relabelled every inherit-mode tab the moment a new tab switched the
   // task engine, while their PTYs kept running the old one.
-  if (liveName) return `${liveName} ${tab.ordinal}`
+  const titleVendor =
+    tab.liveVendor === null
+      ? undefined
+      : (tab.liveVendor ?? (tab.kind === "engine" ? (tab.vendor ?? taskVendor) : undefined))
+  const isSessionIdentity = (value: string): boolean => {
+    if (!titleVendor) return false
+    const cleaned = stripEngineStatusPrefix(value.trim(), titleVendor)
+    return engineSessionIdFromTitle(titleVendor, cleaned) !== null
+  }
+  if (liveName && !isSessionIdentity(liveName)) return `${liveName} ${tab.ordinal}`
   // No LIVE title here (a surface rendering a tab it doesn't host — the
   // Inbox), so fall back to the last live title this tab recorded. Without
   // it those surfaces drop straight to `autoTitle`, the FIRST prompt's
   // summary, and a tab that has long moved on still reads as its opening
   // question.
-  if (tab.lastTitle) return `${tab.lastTitle} ${tab.ordinal}`
+  if (tab.lastTitle && !isSessionIdentity(tab.lastTitle)) return `${tab.lastTitle} ${tab.ordinal}`
   const auto = meaningfulAutoTitle(tab.autoTitle)
   if (auto) return auto
   const name =

--- a/packages/kobe/test/golden/title-recording.test.ts
+++ b/packages/kobe/test/golden/title-recording.test.ts
@@ -14,14 +14,15 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { stripEngineStatusPrefix } from "../../src/engine/registry"
-import { demoteExitedEngine } from "../../src/tui/workspace/terminal-tab-identity"
+import { engineSessionIdFromTitle, stripEngineStatusPrefix } from "../../src/engine/registry"
+import { deriveTitleFromMessages } from "../../src/monitor/auto-title"
+import { recordLiveTabTitle } from "../../src/tui/workspace/terminal-tab-recording"
 import {
   type TabsState,
   type TerminalTab,
   initialTabs,
+  setTabAutoTitle,
   setTabLastTitle,
-  setTabLiveVendor,
   tabTitle,
   tabTitleStable,
 } from "../../src/tui/workspace/terminal-tabs-core"
@@ -34,13 +35,7 @@ const SHELL = ["/bin/zsh"]
  *  on the persisted tab, demoting first when the engine exited. */
 function recordTitle(state: TabsState, tabId: string, raw: string, live: VendorId | null): TabsState {
   const projected = stripEngineStatusPrefix(raw, live ?? undefined)
-  const tab = state.tabs.find((t) => t.id === tabId)
-  if (!tab) return state
-  const demoted = demoteExitedEngine(tab, tab.liveVendor, live, SHELL)
-  if (demoted !== tab) return { ...state, tabs: state.tabs.map((t) => (t.id === tabId ? demoted : t)) }
-  let next = setTabLastTitle(state, tabId, projected)
-  next = setTabLiveVendor(next, tabId, live)
-  return next
+  return recordLiveTabTitle(state, tabId, projected, live, SHELL)
 }
 
 const tabOf = (state: TabsState, id: string): TerminalTab => {
@@ -50,6 +45,44 @@ const tabOf = (state: TabsState, id: string): TerminalTab => {
 }
 
 describe("golden: title stream → recording → display", () => {
+  it("uses Codex's unnamed-thread UUID as identity and shows the first-prompt title", () => {
+    const id = "01a00808-9b77-7083-8f32-1f21b99e5eb3"
+    expect(engineSessionIdFromTitle("codex", id)).toBe(id)
+    expect(engineSessionIdFromTitle("claude", id)).toBeNull()
+
+    let state = recordTitle(initialTabs(), "tab-1", `⠹ ${id}`, "codex")
+    expect(tabOf(state, "tab-1")).toMatchObject({ sessionId: id, liveVendor: "codex" })
+    expect(tabOf(state, "tab-1").lastTitle).toBeUndefined()
+    expect(tabTitle(tabOf(state, "tab-1"), "codex", id)).toBe("codex 1")
+
+    state = setTabAutoTitle(state, "tab-1", "显示可读的 Codex 标签标题")
+    expect(tabTitle(tabOf(state, "tab-1"), "codex", id)).toBe("显示可读的 Codex 标签标题")
+    expect(tabTitleStable(tabOf(state, "tab-1"), "codex", "codex", id)).toBe("显示可读的 Codex 标签标题")
+
+    // Existing snapshots that already recorded the UUID heal on display.
+    const old = { ...tabOf(state, "tab-1"), lastTitle: id } as TerminalTab
+    expect(tabTitle(old, "codex")).toBe("显示可读的 Codex 标签标题")
+    expect(tabTitleStable(old, "codex", "codex")).toBe("显示可读的 Codex 标签标题")
+  })
+
+  it("ignores image attachment metadata when deriving the readable title", () => {
+    expect(
+      deriveTitleFromMessages([
+        {
+          role: "user",
+          sessionId: "codex-session",
+          timestamp: "2026-08-16T00:00:00.000Z",
+          blocks: [
+            { type: "text", text: '<image name=[Image #1] path="/tmp/sidebar.png">' },
+            { type: "text", text: "[codex: input_image]" },
+            { type: "text", text: "</image>" },
+            { type: "text", text: "让 Codex tab 显示可读标题" },
+          ],
+        },
+      ]),
+    ).toBe("让 Codex tab 显示可读标题")
+  })
+
   it("an engine's status stream records the NAME; the tree shows it beside kobe's own glyph", () => {
     let state = initialTabs()
     state = recordTitle(state, "tab-1", "✳ 修复构建失败", "claude")

--- a/packages/kobe/test/golden/title-recording.test.ts
+++ b/packages/kobe/test/golden/title-recording.test.ts
@@ -81,6 +81,38 @@ describe("golden: title stream → recording → display", () => {
         },
       ]),
     ).toBe("让 Codex tab 显示可读标题")
+
+    expect(
+      deriveTitleFromMessages([
+        {
+          role: "user",
+          sessionId: "codex-session",
+          timestamp: "2026-08-16T00:00:00.000Z",
+          blocks: [
+            { type: "text", text: "[codex: image]" },
+            { type: "text", text: '<image name=[Image #2] path="/tmp/other.png">' },
+            { type: "text", text: "</image>" },
+          ],
+        },
+      ]),
+    ).toBe("")
+  })
+
+  it("accepts only complete Codex UUID titles", () => {
+    const uppercase = "01A00808-9B77-7083-8F32-1F21B99E5EB3"
+    expect(engineSessionIdFromTitle("codex", `  ${uppercase}  `)).toBe(uppercase)
+    expect(engineSessionIdFromTitle("codex", `${uppercase}-extra`)).toBeNull()
+    expect(engineSessionIdFromTitle("codex", "01a00808-9b77-7083-8f32")).toBeNull()
+  })
+
+  it("leaves unknown tabs and non-engine tabs untouched by Codex UUID observations", () => {
+    const state = initialTabs()
+    expect(recordLiveTabTitle(state, "missing", "01a00808-9b77-7083-8f32-1f21b99e5eb3", "codex", SHELL)).toBe(state)
+
+    const shellTab = { ...tabOf(state, "tab-1"), kind: "command" as const, command: SHELL }
+    const shellState = { ...state, tabs: [shellTab] }
+    const next = recordLiveTabTitle(shellState, "tab-1", "01a00808-9b77-7083-8f32-1f21b99e5eb3", "codex", SHELL)
+    expect("sessionId" in tabOf(next, "tab-1")).toBe(false)
   })
 
   it("an engine's status stream records the NAME; the tree shows it beside kobe's own glyph", () => {

--- a/packages/kobe/test/golden/title-recording.test.ts
+++ b/packages/kobe/test/golden/title-recording.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { engineSessionIdFromTitle, stripEngineStatusPrefix } from "../../src/engine/registry"
+import { engineSessionIdFromTitle, engineTabNamingPolicy, stripEngineStatusPrefix } from "../../src/engine/registry"
 import { deriveTitleFromMessages } from "../../src/monitor/auto-title"
 import { recordLiveTabTitle } from "../../src/tui/workspace/terminal-tab-recording"
 import {
@@ -67,34 +67,40 @@ describe("golden: title stream → recording → display", () => {
 
   it("ignores image attachment metadata when deriving the readable title", () => {
     expect(
-      deriveTitleFromMessages([
-        {
-          role: "user",
-          sessionId: "codex-session",
-          timestamp: "2026-08-16T00:00:00.000Z",
-          blocks: [
-            { type: "text", text: '<image name=[Image #1] path="/tmp/sidebar.png">' },
-            { type: "text", text: "[codex: input_image]" },
-            { type: "text", text: "</image>" },
-            { type: "text", text: "让 Codex tab 显示可读标题" },
-          ],
-        },
-      ]),
+      deriveTitleFromMessages(
+        [
+          {
+            role: "user",
+            sessionId: "codex-session",
+            timestamp: "2026-08-16T00:00:00.000Z",
+            blocks: [
+              { type: "text", text: '<image name=[Image #1] path="/tmp/sidebar.png">' },
+              { type: "text", text: "[codex: input_image]" },
+              { type: "text", text: "</image>" },
+              { type: "text", text: "让 Codex tab 显示可读标题" },
+            ],
+          },
+        ],
+        engineTabNamingPolicy("codex").promptText,
+      ),
     ).toBe("让 Codex tab 显示可读标题")
 
     expect(
-      deriveTitleFromMessages([
-        {
-          role: "user",
-          sessionId: "codex-session",
-          timestamp: "2026-08-16T00:00:00.000Z",
-          blocks: [
-            { type: "text", text: "[codex: image]" },
-            { type: "text", text: '<image name=[Image #2] path="/tmp/other.png">' },
-            { type: "text", text: "</image>" },
-          ],
-        },
-      ]),
+      deriveTitleFromMessages(
+        [
+          {
+            role: "user",
+            sessionId: "codex-session",
+            timestamp: "2026-08-16T00:00:00.000Z",
+            blocks: [
+              { type: "text", text: "[codex: image]" },
+              { type: "text", text: '<image name=[Image #2] path="/tmp/other.png">' },
+              { type: "text", text: "</image>" },
+            ],
+          },
+        ],
+        engineTabNamingPolicy("codex").promptText,
+      ),
     ).toBe("")
   })
 
@@ -103,6 +109,12 @@ describe("golden: title stream → recording → display", () => {
     expect(engineSessionIdFromTitle("codex", `  ${uppercase}  `)).toBe(uppercase)
     expect(engineSessionIdFromTitle("codex", `${uppercase}-extra`)).toBeNull()
     expect(engineSessionIdFromTitle("codex", "01a00808-9b77-7083-8f32")).toBeNull()
+  })
+
+  it("declares title decoding and naming cadence as independent engine capabilities", () => {
+    expect(engineTabNamingPolicy("codex").trigger).toBe("immediate")
+    expect(engineTabNamingPolicy("claude").trigger).toBe("poll")
+    expect(engineTabNamingPolicy("my-custom-engine").trigger).toBe("poll")
   })
 
   it("leaves unknown tabs and non-engine tabs untouched by Codex UUID observations", () => {

--- a/packages/kobe/test/render/codex-tab-auto-title.test.tsx
+++ b/packages/kobe/test/render/codex-tab-auto-title.test.tsx
@@ -1,0 +1,148 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Codex's unnamed OSC title is a session UUID, not a user-facing name. This
+ * render test drives the real React effects that record that identity and
+ * immediately resolve the first prompt, proving the visible title changes
+ * without a keypress or the five-second fallback tick.
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { useRef, useState } from "react"
+import type { NotificationsContext } from "../../src/tui-react/context/notifications"
+import { tabTitle } from "../../src/tui-react/workspace/tab-strip"
+import type { TabsState } from "../../src/tui/workspace/terminal-tabs-core"
+import { type RenderHandle, act, renderComponent, settle } from "./harness"
+
+const SESSION_ID = "01a00808-9b77-7083-8f32-1f21b99e5eb3"
+const PROMPT_TITLE = "让 Codex 标签立即显示可读标题"
+const LIVE_TITLES = new Map([["tab-1", SESSION_ID]])
+const LIVE_VENDORS = new Map([["tab-1", "codex" as const]])
+
+// Keep the renderer real while replacing only the PTY poll boundary. The
+// production hook still receives the same maps an OSC title push produces.
+mock.module("../../src/tui-react/workspace/use-turn-polls", () => ({
+  useTurnPolls: () => ({
+    turnStates: new Map(),
+    liveTitles: LIVE_TITLES,
+    rawTitles: LIVE_TITLES,
+    turnVendors: LIVE_VENDORS,
+  }),
+}))
+
+const [{ useTabNaming }, { useTabTurnState }] = await Promise.all([
+  import("../../src/tui-react/workspace/use-tab-lifecycle"),
+  import("../../src/tui-react/workspace/use-tab-turn-state"),
+])
+
+const notifications: NotificationsContext = {
+  toasts: [],
+  unread: new Map(),
+  notify: () => {},
+  dismiss: () => {},
+  markRead: () => {},
+}
+
+let codexHome: string
+let sessionsDir: string
+let previousCodexHome: string | undefined
+
+beforeAll(() => {
+  previousCodexHome = process.env.CODEX_HOME
+  codexHome = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "rove-codex-title-render-")))
+  process.env.CODEX_HOME = codexHome
+  sessionsDir = path.join(codexHome, "sessions", "2026", "08", "16")
+  fs.mkdirSync(sessionsDir, { recursive: true })
+})
+
+function writeRollout(): void {
+  const rollout = [
+    { type: "session_meta", payload: { id: SESSION_ID, cwd: "/tmp/worktree" } },
+    {
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: PROMPT_TITLE }],
+      },
+    },
+  ]
+  fs.writeFileSync(
+    path.join(sessionsDir, `rollout-2026-08-16T00-00-00-${SESSION_ID}.jsonl`),
+    `${rollout.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+  )
+}
+
+afterAll(() => {
+  if (previousCodexHome === undefined) Reflect.deleteProperty(process.env, "CODEX_HOME")
+  else process.env.CODEX_HOME = previousCodexHome
+  fs.rmSync(codexHome, { recursive: true, force: true })
+  mock.restore()
+})
+
+const initialState = (): TabsState => ({
+  tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "codex" }],
+  activeId: "tab-1",
+  nextOrdinal: 2,
+})
+
+function Driver(props: { updates: TabsState[]; onTitle: () => void }) {
+  const [state, setState] = useState(initialState)
+  const stateRef = useRef(state)
+  stateRef.current = state
+  const propsRef = useRef({ vendor: "codex" as const })
+  const update = (next: TabsState): void => {
+    stateRef.current = next
+    props.updates.push(next)
+    setState(next)
+    if (next.tabs[0]?.autoTitle === PROMPT_TITLE) props.onTitle()
+  }
+
+  useTabTurnState({
+    taskId: "task-1",
+    worktree: "/tmp/worktree",
+    vendor: "codex",
+    state,
+    notif: notifications,
+    update,
+  })
+  useTabNaming({ stateRef, propsRef, update })
+
+  return <text>{tabTitle(state.tabs[0]!, "codex", LIVE_TITLES.get("tab-1"))}</text>
+}
+
+describe("Codex tab auto-title React chain", () => {
+  test("records the UUID and renders the first prompt without a click or fallback tick", async () => {
+    const updates: TabsState[] = []
+    let resolveTitle: () => void = () => {}
+    const titleObserved = new Promise<void>((resolve) => {
+      resolveTitle = resolve
+    })
+    let handle: RenderHandle | undefined
+    await act(async () => {
+      handle = await renderComponent(<Driver updates={updates} onTitle={resolveTitle} />)
+    })
+    if (!handle) throw new Error("renderer did not mount")
+    const mounted = handle
+    await act(async () => {
+      // The session id can precede the first rollout write. Land history
+      // after mount and let the follow-up render resolve it without input.
+      writeRollout()
+      await titleObserved
+      await settle(0)
+    })
+    let rendered = ""
+    await act(async () => {
+      rendered = await mounted.frame()
+    })
+
+    expect(updates.some((state) => state.tabs[0]?.kind === "engine" && state.tabs[0].sessionId === SESSION_ID)).toBe(
+      true,
+    )
+    expect(updates.some((state) => state.tabs[0]?.autoTitle === PROMPT_TITLE)).toBe(true)
+    expect(rendered).toContain(PROMPT_TITLE)
+    expect(rendered).not.toContain(SESSION_ID)
+  })
+})

--- a/packages/kobe/test/render/codex-tab-auto-title.test.tsx
+++ b/packages/kobe/test/render/codex-tab-auto-title.test.tsx
@@ -65,7 +65,12 @@ function writeRollout(): void {
       payload: {
         type: "message",
         role: "user",
-        content: [{ type: "input_text", text: PROMPT_TITLE }],
+        content: [
+          { type: "input_text", text: '<image name=[Image #1] path="/tmp/sidebar.png">' },
+          { type: "input_image" },
+          { type: "input_text", text: "</image>" },
+          { type: "input_text", text: PROMPT_TITLE },
+        ],
       },
     },
   ]

--- a/packages/kobe/test/tui/tab-naming-queue.test.ts
+++ b/packages/kobe/test/tui/tab-naming-queue.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { TabNamingQueue, type TabNamingTarget } from "../../src/tui/workspace/tab-naming-queue"
+
+const target = (n: number, sessionId = `session-${n}`): TabNamingTarget => ({
+  tabId: `tab-${n}`,
+  sessionId,
+  vendor: "codex",
+})
+
+afterEach(() => vi.useRealTimers())
+
+describe("TabNamingQueue", () => {
+  it("starts immediately and deduplicates repeated observations of one session", async () => {
+    let resolveRead: (title: string) => void = () => {}
+    const readTitle = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRead = resolve
+        }),
+    )
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({ readTitle, isCurrent: () => true, applyTitle })
+
+    queue.enqueue([target(1)])
+    queue.enqueue([target(1)])
+    expect(readTitle).toHaveBeenCalledTimes(1)
+    resolveRead("可读标题")
+    await vi.waitFor(() => expect(applyTitle).toHaveBeenCalledWith(target(1), "可读标题"))
+  })
+
+  it("shares one resolved session title across tabs without another read", async () => {
+    const readTitle = vi.fn().mockResolvedValue("共享会话标题")
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({ readTitle, isCurrent: () => true, applyTitle })
+
+    queue.enqueue([target(1, "shared")])
+    await vi.waitFor(() => expect(applyTitle).toHaveBeenCalledWith(target(1, "shared"), "共享会话标题"))
+    queue.enqueue([target(2, "shared")])
+
+    expect(readTitle).toHaveBeenCalledTimes(1)
+    expect(applyTitle).toHaveBeenCalledWith(target(2, "shared"), "共享会话标题")
+  })
+
+  it("applies one in-flight session read to every tab that joins it", async () => {
+    let resolveRead: (title: string) => void = () => {}
+    const readTitle = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRead = resolve
+        }),
+    )
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({ readTitle, isCurrent: () => true, applyTitle })
+
+    queue.enqueue([target(1, "shared")])
+    queue.enqueue([target(2, "shared")])
+    resolveRead("共享会话标题")
+    await vi.waitFor(() => expect(applyTitle).toHaveBeenCalledTimes(2))
+
+    expect(readTitle).toHaveBeenCalledTimes(1)
+    expect(applyTitle).toHaveBeenCalledWith(target(1, "shared"), "共享会话标题")
+    expect(applyTitle).toHaveBeenCalledWith(target(2, "shared"), "共享会话标题")
+  })
+
+  it("does not share cached titles across vendors", async () => {
+    const codex = target(1, "same-id")
+    const claude = { ...target(2, "same-id"), vendor: "claude" as const }
+    const readTitle = vi.fn().mockResolvedValueOnce("Codex title").mockResolvedValueOnce("Claude title")
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({ readTitle, isCurrent: () => true, applyTitle })
+
+    queue.enqueue([codex])
+    await vi.waitFor(() => expect(applyTitle).toHaveBeenCalledWith(codex, "Codex title"))
+    queue.enqueue([claude])
+    await vi.waitFor(() => expect(applyTitle).toHaveBeenCalledWith(claude, "Claude title"))
+
+    expect(readTitle).toHaveBeenCalledTimes(2)
+  })
+
+  it("caps concurrent history reads while draining many new tabs", async () => {
+    const resolvers: Array<(title: string) => void> = []
+    const readTitle = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolvers.push(resolve)
+        }),
+    )
+    const queue = new TabNamingQueue({ readTitle, isCurrent: () => true, applyTitle: vi.fn(), maxConcurrent: 3 })
+
+    queue.enqueue([target(1), target(2), target(3), target(4), target(5)])
+    expect(readTitle).toHaveBeenCalledTimes(3)
+    resolvers[0]?.("one")
+    await vi.waitFor(() => expect(readTitle).toHaveBeenCalledTimes(4))
+  })
+
+  it("retries an unwritten transcript with short backoff", async () => {
+    vi.useFakeTimers()
+    const readTitle = vi.fn().mockResolvedValueOnce("").mockResolvedValueOnce("落盘后的标题")
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({
+      readTitle,
+      isCurrent: () => true,
+      applyTitle,
+      retryDelaysMs: [250],
+    })
+
+    queue.enqueue([target(1)])
+    await vi.runAllTicks()
+    expect(readTitle).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(249)
+    expect(readTitle).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(readTitle).toHaveBeenCalledTimes(2)
+    await vi.runAllTicks()
+    expect(applyTitle).toHaveBeenCalledWith(target(1), "落盘后的标题")
+  })
+
+  it("retries a failed history read and follows the configured backoff steps", async () => {
+    vi.useFakeTimers()
+    const readTitle = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("not written"))
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("第三次读到")
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({
+      readTitle,
+      isCurrent: () => true,
+      applyTitle,
+      retryDelaysMs: [250, 1_000],
+    })
+
+    queue.enqueue([target(1)])
+    await vi.runAllTicks()
+    await vi.advanceTimersByTimeAsync(250)
+    expect(readTitle).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(999)
+    expect(readTitle).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(readTitle).toHaveBeenCalledTimes(3)
+    await vi.runAllTicks()
+    expect(applyTitle).toHaveBeenCalledWith(target(1), "第三次读到")
+  })
+
+  it("stops pending reads and retries without applying stale titles", async () => {
+    vi.useFakeTimers()
+    let resolveRead: (title: string) => void = () => {}
+    const readTitle = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRead = resolve
+        }),
+    )
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({ readTitle, isCurrent: () => true, applyTitle, retryDelaysMs: [250] })
+
+    queue.enqueue([target(1)])
+    queue.stop()
+    resolveRead("stale")
+    await vi.runAllTicks()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(applyTitle).not.toHaveBeenCalled()
+    expect(readTitle).toHaveBeenCalledTimes(1)
+  })
+
+  it("cancels a scheduled retry when stopped while waiting", async () => {
+    vi.useFakeTimers()
+    const readTitle = vi.fn().mockResolvedValue("")
+    const queue = new TabNamingQueue({
+      readTitle,
+      isCurrent: () => true,
+      applyTitle: vi.fn(),
+      retryDelaysMs: [250],
+    })
+
+    queue.enqueue([target(1)])
+    await vi.runAllTicks()
+    queue.stop()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(readTitle).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not apply a title when the running target changes session", async () => {
+    let currentSession = "session-1"
+    let resolveRead: (title: string) => void = () => {}
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({
+      readTitle: () =>
+        new Promise<string>((resolve) => {
+          resolveRead = resolve
+        }),
+      isCurrent: (item) => item.sessionId === currentSession,
+      applyTitle,
+    })
+
+    queue.enqueue([target(1)])
+    currentSession = "session-2"
+    resolveRead("旧会话标题")
+    await vi.waitFor(() => expect(applyTitle).not.toHaveBeenCalled())
+  })
+
+  it("drops a tab that changed session before its queued read starts", async () => {
+    const live = new Set(["tab-1", "tab-2"])
+    let releaseFirst: (title: string) => void = () => {}
+    const readTitle = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            releaseFirst = resolve
+          }),
+      )
+      .mockResolvedValue("second")
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({
+      readTitle,
+      isCurrent: (item) => live.has(item.tabId),
+      applyTitle,
+      maxConcurrent: 1,
+    })
+
+    queue.enqueue([target(1), target(2)])
+    live.delete("tab-2")
+    releaseFirst("first")
+    await vi.waitFor(() => expect(applyTitle).toHaveBeenCalledWith(target(1), "first"))
+    expect(readTitle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/kobe/test/tui/tab-naming-queue.test.ts
+++ b/packages/kobe/test/tui/tab-naming-queue.test.ts
@@ -5,6 +5,7 @@ const target = (n: number, sessionId = `session-${n}`): TabNamingTarget => ({
   tabId: `tab-${n}`,
   sessionId,
   vendor: "codex",
+  trigger: "immediate",
 })
 
 afterEach(() => vi.useRealTimers())
@@ -113,6 +114,27 @@ describe("TabNamingQueue", () => {
     expect(readTitle).toHaveBeenCalledTimes(2)
     await vi.runAllTicks()
     expect(applyTitle).toHaveBeenCalledWith(target(1), "落盘后的标题")
+  })
+
+  it("honors the target engine's retry policy", async () => {
+    vi.useFakeTimers()
+    const readTitle = vi.fn().mockResolvedValueOnce("").mockResolvedValueOnce("vendor title")
+    const applyTitle = vi.fn()
+    const queue = new TabNamingQueue({
+      readTitle,
+      isCurrent: () => true,
+      applyTitle,
+      retryDelaysMs: [9_999],
+    })
+
+    queue.enqueue([{ ...target(1), retryDelaysMs: [75] }])
+    await vi.runAllTicks()
+    await vi.advanceTimersByTimeAsync(74)
+    expect(readTitle).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(readTitle).toHaveBeenCalledTimes(2)
+    await vi.runAllTicks()
+    expect(applyTitle).toHaveBeenCalledWith(expect.objectContaining({ tabId: "tab-1" }), "vendor title")
   })
 
   it("retries a failed history read and follows the configured backoff steps", async () => {


### PR DESCRIPTION
## Summary

- Treat unnamed Codex terminal-title UUIDs as session identity, then derive the visible tab label from the session's first user prompt.
- Declare each engine's naming trigger, retry schedule, and visible-prompt projection through an engine-owned registry policy; undeclared engines keep the existing five-second cadence.
- Keep Codex UUID parsing and image-attachment filtering inside its adapter, so the lifecycle and queue contain no vendor-specific branches.
- Start immediate title reads with per-session deduplication, a maximum of three concurrent reads, and bounded backoff while the transcript reaches disk.

## Scope

- This PR fixes Codex title display for the mounted task only.
- Background first-prompt naming for unmounted tasks and Claude refresh behavior remain out of scope.

## Test coverage

- Covers UUID recognition and rejection, image-only prompts, title display fallback, session-keyed deduplication/cache isolation, concurrent-read limits, retry/backoff, stale-session rejection, and queue shutdown.
- Adds a real OpenTUI render test that mounts the title-recording and auto-naming hooks, follows a Codex OSC UUID through history lookup, and verifies the tab repaints with the first prompt without a click or keypress.
- Verifies the engine-policy default, independent session decoding/naming capabilities, and per-engine retry overrides.
- Render coverage for the two changed lifecycle hooks is 58.1% and 86.8%, above the 50% gate.

## Pre-landing review

- No critical or informational findings.
- All touched source files remain at or below the 500-line cap.
- No layout, CSS, prompt, config, keybinding, or distribution changes.

## Verification

- `bun run lint`
- `bun run typecheck`
- `env -u ROVE_INVOKED_AS bun run test:fast` — 3,217 passed, 1 skipped
- `bun run test:render` — 168 passed
- render coverage gate — changed lifecycle hooks at 58.1% and 86.8%
- `bun run build`
- `git diff --check origin/main...HEAD`

## Release

- Includes two patch Changesets for `@sma1lboy/rove`.

## Documentation

- Updated `docs/design/engine-internals.md` with the UUID identity/display-title split and the extensible engine-owned naming policy.
