### PR TITLE
feat: per-turn agent telemetry, engine-owned (#32)

### DIFF
--- a/.changeset/agent-turn-telemetry.md
+++ b/.changeset/agent-turn-telemetry.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Record per-turn agent telemetry. Every completed engine turn now leaves an attributed record — task, tab, engine, model, start/end time, and token usage — read back with `rove api agent-turns` (filter by task or repo; the response carries a totals roll-up alongside the page).
+
+The turn data is engine-owned: each adapter lifts it from its own transcript, so nothing outside the engine layer parses a vendor's files. Claude Code ships the first reader; other engines contribute nothing until theirs lands.

--- a/docs/API.md
+++ b/docs/API.md
@@ -125,6 +125,14 @@ replacement in `nextCommandArgs`.
   tasks touched in the window plus routine outcomes by status. Default
   window 7 days. Task outcomes are deliberately absent: completion travels
   to the spawning agent's engine tab (`send`), not into Rove state.
+- `agent-turns [--task-id ID] [--repo PATH] [--since-days N] [--limit N]`:
+  per-turn agent telemetry — one record per completed engine turn
+  (`taskId`/`tabId`/`vendor`/`model`/`sessionId`/`startedAt`/`endedAt`/
+  `usage`), newest first, plus a `totals` roll-up (token sums, summed
+  wall-clock, turn counts per model). Default window 7 days, 200 records.
+  Records are produced by each engine's own adapter from that vendor's
+  transcript and stored by the daemon on `turn-complete`; engines without a
+  turn reader contribute nothing. Read-only.
 - `pty-list` *(offline)*: hosted PTY sessions (key, alive, pid, command,
   live window title). Empty when no PTY host runs.
 - `read-output [--task-id ID] [--tab TAB] [--source auto|history|terminal]

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -13,6 +13,8 @@
     "./client/pty-process": "./src/client/pty-process.ts",
     "./client/rpc": "./src/client/rpc.ts",
     "./daemon/activity-arbitrate": "./src/daemon/activity-arbitrate.ts",
+    "./daemon/agent-turns-ingest": "./src/daemon/agent-turns-ingest.ts",
+    "./daemon/agent-turns-store": "./src/daemon/agent-turns-store.ts",
     "./daemon/activity-liveness": "./src/daemon/activity-liveness.ts",
     "./daemon/activity-observer": "./src/daemon/activity-observer.ts",
     "./daemon/activity-registry": "./src/daemon/activity-registry.ts",

--- a/packages/kobe-daemon/src/daemon/agent-turns-ingest.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-ingest.ts
@@ -1,0 +1,66 @@
+/**
+ * Turn-telemetry ingest (issue #32): the bridge from an engine hook report to
+ * the durable {@link AgentTurnsStore}.
+ *
+ * Fired on `turn-complete`, the one event that means "a turn just finished and
+ * its records are on disk". Everything here is best-effort and fire-and-forget
+ * — the hook RPC must not wait on a transcript read, and a telemetry failure
+ * must never surface to the engine.
+ *
+ * The vendor read is delegated to the runtime adapter (`readEngineTurns`), so
+ * the daemon stays vendor-blind: it supplies a path and an engine id, and the
+ * engine's own adapter decides what a turn is.
+ */
+
+import type { AgentTurnsStore } from "./agent-turns-store.ts"
+import type { AgentTurnRecord, DaemonOrchestrator, VendorId } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
+import type { DaemonRuntimeAdapter } from "./runtime.ts"
+
+export interface TurnIngestInput {
+  readonly taskId: string
+  readonly tabId?: string
+  /** The `--engine` tag the hook carried; falls back to the task's vendor. */
+  readonly vendor?: string
+  /** The engine's own transcript, from its hook payload. No path = nothing to read. */
+  readonly transcriptPath?: string
+}
+
+/**
+ * Read the finished turns out of `transcriptPath` and merge them into the
+ * store, joined to the task's identity. Resolves to the number of NEW turns
+ * (0 when the transcript held nothing unseen, which is the common case since
+ * every read starts from the top of the file).
+ */
+export async function ingestAgentTurns(
+  store: AgentTurnsStore,
+  runtime: DaemonRuntimeAdapter,
+  orch: DaemonOrchestrator,
+  input: TurnIngestInput,
+): Promise<number> {
+  if (!input.transcriptPath) return 0
+  const task = orch.getTask(input.taskId)
+  const vendor = (input.vendor ?? task?.vendor) as VendorId | undefined
+  if (!vendor) return 0
+  const turns = await runtime.readEngineTurns(vendor, input.transcriptPath)
+  if (turns.length === 0) return 0
+  const records: AgentTurnRecord[] = turns.map((turn) => ({
+    ...turn,
+    taskId: input.taskId,
+    ...(input.tabId ? { tabId: input.tabId } : {}),
+    vendor,
+    ...(task?.repo ? { repo: task.repo } : {}),
+  }))
+  return await store.record(records)
+}
+
+/** Fire-and-forget wrapper for the hook path: never throws, never awaited. */
+export function ingestAgentTurnsBestEffort(
+  store: AgentTurnsStore | undefined,
+  runtime: DaemonRuntimeAdapter,
+  orch: DaemonOrchestrator,
+  input: TurnIngestInput,
+): void {
+  if (!store) return
+  void ingestAgentTurns(store, runtime, orch, input).catch((err) => logDaemonError("agent-turns-ingest", err))
+}

--- a/packages/kobe-daemon/src/daemon/agent-turns-store.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-store.ts
@@ -1,0 +1,169 @@
+/**
+ * Durable per-turn telemetry store (issue #32) — the daemon side of the
+ * engine-owned {@link AgentTurnRecord} contract.
+ *
+ * The engine adapter produces turns from its own transcript; this store does
+ * the ONE thing the engine can't: join them to Rove identity (task, tab,
+ * vendor) and keep them across daemon restarts, so `rove api agent-turns`
+ * can answer "what did this repo's agents actually do" later.
+ *
+ * Dedupe is by the engine's own turn id: a Stop hook re-reads the whole
+ * transcript, so the same finished turn arrives on every subsequent turn's
+ * ingest. Last write wins on the fields (a turn re-read after more assistant
+ * records landed is the more complete one).
+ */
+
+import { randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
+import type { AgentTurnRecord } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
+
+interface AgentTurnsFile {
+  readonly version: 1
+  readonly turns: AgentTurnRecord[]
+}
+
+/**
+ * Cap on retained turns, newest kept. Per-turn records are ~200 bytes, so
+ * this is a few MB worst case — enough for weeks of a busy machine, and the
+ * store is telemetry, not an audit log.
+ * ponytail: one flat cap, not per-task; revisit if a digest needs deeper history.
+ */
+const MAX_TURNS = 10_000
+
+export function defaultAgentTurnsPath(homeDir = readRoveEnv("HOME_DIR") ?? homedir()): string {
+  return join(homeDir, ROVE_STATE_DIR_BASENAME, "agent-turns.json")
+}
+
+function normalize(value: unknown): AgentTurnRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const t = value as Partial<AgentTurnRecord>
+  if (typeof t.id !== "string" || t.id.length === 0) return null
+  if (typeof t.taskId !== "string" || t.taskId.length === 0) return null
+  if (typeof t.startedAt !== "number" || !Number.isFinite(t.startedAt)) return null
+  if (typeof t.endedAt !== "number" || !Number.isFinite(t.endedAt)) return null
+  return {
+    id: t.id,
+    taskId: t.taskId,
+    ...(typeof t.tabId === "string" && t.tabId ? { tabId: t.tabId } : {}),
+    ...(typeof t.vendor === "string" && t.vendor ? { vendor: t.vendor } : {}),
+    ...(typeof t.sessionId === "string" && t.sessionId ? { sessionId: t.sessionId } : {}),
+    ...(typeof t.model === "string" && t.model ? { model: t.model } : {}),
+    ...(typeof t.repo === "string" && t.repo ? { repo: t.repo } : {}),
+    startedAt: t.startedAt,
+    endedAt: t.endedAt,
+    ...(t.usage && typeof t.usage === "object" ? { usage: t.usage } : {}),
+  }
+}
+
+/** Turn key: the engine's id is unique per session, not globally (a resumed
+ *  session could in principle repeat one), so scope it by task. */
+function keyOf(turn: Pick<AgentTurnRecord, "taskId" | "id">): string {
+  return `${turn.taskId}\0${turn.id}`
+}
+
+export class AgentTurnsStore {
+  private readonly turns = new Map<string, AgentTurnRecord>()
+  private tail: Promise<void> = Promise.resolve()
+
+  constructor(private readonly path: string) {}
+
+  async init(): Promise<void> {
+    await this.enqueue(async () => {
+      this.turns.clear()
+      for (const turn of await this.read()) this.turns.set(keyOf(turn), turn)
+    })
+  }
+
+  /**
+   * Merge a batch of turns for one task. Returns how many were NEW — the
+   * ingest path uses that to skip the write when a re-read produced nothing
+   * (the common case: every Stop re-reads the whole transcript).
+   */
+  async record(turns: readonly AgentTurnRecord[]): Promise<number> {
+    return await this.enqueue(async () => {
+      let added = 0
+      for (const raw of turns) {
+        const turn = normalize(raw)
+        if (!turn) continue
+        const key = keyOf(turn)
+        if (!this.turns.has(key)) added++
+        // Re-insert so Map order tracks recency; the cap evicts from the head.
+        this.turns.delete(key)
+        this.turns.set(key, turn)
+      }
+      if (added === 0) return 0
+      while (this.turns.size > MAX_TURNS) {
+        const oldest = this.turns.keys().next().value
+        if (oldest === undefined) break
+        this.turns.delete(oldest)
+      }
+      await this.write()
+      return added
+    })
+  }
+
+  /** Newest-first, optionally filtered. `limit` bounds the answer. */
+  list(filter: { taskId?: string; repo?: string; since?: number; limit?: number } = {}): AgentTurnRecord[] {
+    const limit = filter.limit && filter.limit > 0 ? filter.limit : 200
+    const out: AgentTurnRecord[] = []
+    for (const turn of this.turns.values()) {
+      if (filter.taskId && turn.taskId !== filter.taskId) continue
+      if (filter.repo && turn.repo !== filter.repo) continue
+      if (filter.since !== undefined && turn.endedAt < filter.since) continue
+      out.push(turn)
+    }
+    out.sort((a, b) => b.endedAt - a.endedAt)
+    return out.slice(0, limit)
+  }
+
+  async deleteTask(taskId: string): Promise<void> {
+    await this.enqueue(async () => {
+      let changed = false
+      for (const [key, turn] of this.turns) {
+        if (turn.taskId !== taskId) continue
+        this.turns.delete(key)
+        changed = true
+      }
+      if (changed) await this.write()
+    })
+  }
+
+  private async read(): Promise<AgentTurnRecord[]> {
+    try {
+      const parsed = JSON.parse(await readFile(this.path, "utf8")) as Partial<AgentTurnsFile>
+      if (!Array.isArray(parsed.turns)) return []
+      return parsed.turns.map(normalize).filter((t): t is AgentTurnRecord => t !== null)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return []
+      logDaemonError("agent-turns-load", err)
+      return []
+    }
+  }
+
+  private async write(): Promise<void> {
+    const body: AgentTurnsFile = { version: 1, turns: [...this.turns.values()] }
+    const tmp = `${this.path}.tmp-${process.pid}-${randomUUID()}`
+    try {
+      await mkdir(dirname(this.path), { recursive: true })
+      await writeFile(tmp, `${JSON.stringify(body)}\n`, "utf8")
+      await rename(tmp, this.path)
+    } catch (err) {
+      logDaemonError("agent-turns-write", err)
+    }
+  }
+
+  /** Serialize mutations so two concurrent hook ingests can't interleave a
+   *  read-modify-write and lose turns. */
+  private enqueue<T>(work: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(work, work)
+    this.tail = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+}

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -206,6 +206,41 @@ export interface EngineActivityDetail {
 
 export type TaskActivityState = "idle" | "running" | "turn_complete" | "rate_limited" | "permission_needed" | "error"
 
+/**
+ * The ENGINE half of a turn record (issue #32) — what the vendor's adapter
+ * lifts from its own transcript. Mirrors `kobe/src/engine/agent-turn.ts`,
+ * which is the contract's source of truth; this is the daemon's structural
+ * copy (the daemon package never imports kobe sources).
+ */
+export interface AgentTurn {
+  /** The engine's own stable turn id — dedupe key within a task. */
+  readonly id: string
+  readonly sessionId: string
+  readonly model?: string
+  /** Epoch ms. */
+  readonly startedAt: number
+  readonly endedAt: number
+  readonly usage?: {
+    readonly input_tokens?: number
+    readonly output_tokens?: number
+    readonly cache_read_input_tokens?: number
+    readonly cache_creation_input_tokens?: number
+  }
+}
+
+/**
+ * One agent turn joined to Rove identity: the engine's turn plus the
+ * task/tab/vendor/repo the daemon knows and the engine doesn't.
+ */
+export interface AgentTurnRecord extends Omit<AgentTurn, "sessionId"> {
+  readonly taskId: string
+  readonly tabId?: string
+  readonly vendor?: VendorId
+  readonly sessionId?: string
+  /** Source repo of the task, so a digest can scope by project. */
+  readonly repo?: string
+}
+
 /** States represented by pending Inbox items until handled or the same
  * Terminal Tab starts another turn. */
 export const ATTENTION_INBOX_STATES = [

--- a/packages/kobe-daemon/src/daemon/handler-validators.ts
+++ b/packages/kobe-daemon/src/daemon/handler-validators.ts
@@ -44,6 +44,13 @@ export function requireNumber(payload: Record<string, unknown>, key: string): nu
   return value
 }
 
+export function optionalNumber(payload: Record<string, unknown>, key: string): number | undefined {
+  const value = payload[key]
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${key} must be a finite number`)
+  return value
+}
+
 export function optionalVendor(payload: Record<string, unknown>, key: string): VendorId | undefined {
   // Engines are open: a vendor id may be a built-in OR a user-registered
   // custom engine (its launch command lives in the kobe-side customEngineIds

--- a/packages/kobe-daemon/src/daemon/handlers-agent-turns.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-agent-turns.ts
@@ -1,0 +1,30 @@
+/** Per-turn telemetry read RPC (issue #32). Read-only; the write side is the
+ *  hook-driven ingest in `agent-turns-ingest.ts`. */
+
+import { optionalNumber, optionalString } from "./handler-validators.ts"
+import type { DaemonRequestHandler } from "./handlers.ts"
+
+export const AGENT_TURN_HANDLERS: readonly DaemonRequestHandler[] = [
+  {
+    name: "agentTurn.list",
+    // Socket-only for now: nothing in the browser dashboard reads turns yet,
+    // and the web allowset is a deliberate, test-pinned surface (see
+    // `test/daemon/web-exposure.test.ts`). Flip to `web: true` in the PR that
+    // actually renders them.
+    handle(payload, ctx) {
+      const taskId = optionalString(payload, "taskId")
+      const repo = optionalString(payload, "repoRoot")
+      const since = optionalNumber(payload, "since")
+      const limit = optionalNumber(payload, "limit")
+      return {
+        turns:
+          ctx.agentTurns?.list({
+            ...(taskId ? { taskId } : {}),
+            ...(repo ? { repo } : {}),
+            ...(since !== undefined ? { since } : {}),
+            ...(limit !== undefined ? { limit } : {}),
+          }) ?? [],
+      }
+    },
+  },
+]

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -35,6 +35,8 @@
 
 import type { DaemonRpcClient } from "../client/rpc.ts"
 import type { DaemonActivityRegistry } from "./activity-registry.ts"
+import { ingestAgentTurnsBestEffort } from "./agent-turns-ingest.ts"
+import type { AgentTurnsStore } from "./agent-turns-store.ts"
 import type { AttentionInboxStore } from "./attention-inbox.ts"
 import type { AutomationsStore } from "./automations-store.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
@@ -42,6 +44,7 @@ import { logDaemonError } from "./crash-log.ts"
 import { findAdoptableWorktree, matchTaskByCwd } from "./cwd-task.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import { objectPayload, optionalActivityDetail, optionalString, requireString } from "./handler-validators.ts"
+import { AGENT_TURN_HANDLERS } from "./handlers-agent-turns.ts"
 import { ATTENTION_HANDLERS } from "./handlers-attention.ts"
 import { AUTOMATION_HANDLERS } from "./handlers-automations.ts"
 import { TASK_HANDLERS } from "./handlers-task.ts"
@@ -108,6 +111,8 @@ export interface DaemonHandlerContext {
   readonly selfLink: DaemonRpcClient
   /** Rate-limited cache in front of the engine quota probes. */
   readonly quotaUsage: QuotaUsageCache
+  /** Durable per-turn telemetry (issue #32; absent in older tests). */
+  readonly agentTurns?: AgentTurnsStore
   /** Per-task recent engine events (`task.recentEvents`; absent in older tests). */
   readonly engineEvents?: import("./engine-events-log.ts").EngineEventLog
   /** Pending host-dialog prompts (`ui.prompt` / `ui.promptReply`). */
@@ -300,6 +305,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
     ...ATTENTION_HANDLERS,
     ...AUTOMATION_HANDLERS,
     ...WORK_ITEM_HANDLERS,
+    ...AGENT_TURN_HANDLERS,
     ...UI_HANDLERS,
     {
       name: "issue.list",
@@ -442,6 +448,18 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
           ...(tabId ? { tabId } : {}),
           ...(sessionId ? { sessionId } : {}),
         })
+        // Per-turn telemetry (issue #32): a finished turn is the moment its
+        // records are complete on disk. Fire-and-forget — the transcript read
+        // must not delay the hook RPC, and losing a record is a telemetry
+        // gap, never an engine failure.
+        if (kind === "turn-complete") {
+          ingestAgentTurnsBestEffort(ctx.agentTurns, ctx.runtime, ctx.orch, {
+            taskId,
+            ...(tabId ? { tabId } : {}),
+            ...(vendor ? { vendor } : {}),
+            ...(transcriptPath ? { transcriptPath } : {}),
+          })
+        }
         // Auto status flow (docs/design/web-kanban.md M5): an engine
         // STARTING a turn on a backlog task means work began — a pure rule
         // advances it to in_progress. (in_progress → in_review is the

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -221,6 +221,9 @@ export type DaemonRequestName =
   | "session.deliver"
   // Read one task's recent engine lifecycle events (the TUI event feed).
   | "task.recentEvents"
+  // Per-turn agent telemetry (issue #32): the durable turn store's read side.
+  // Written only by the hook-driven ingest on `turn-complete`.
+  | "agentTurn.list"
   // Production diagnostics (`kobe api inspect`): the activity registry's RAW
   // task/tab entries — probe vendor, armed watchdogs — beyond what the
   // engine-state wire payload carries. Read-only.

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -1,5 +1,6 @@
 import type { DaemonRpcClient } from "../client/rpc.ts"
 import type {
+  AgentTurn,
   DaemonOrchestrator,
   DaemonTask,
   EngineActivityKind,
@@ -57,6 +58,13 @@ export interface DaemonRuntimeAdapter {
    * declares no vocabulary (or the title is empty) — never guessed.
    */
   titleTurnHint(vendor: VendorId, title: string): "working" | "rest" | null
+  /**
+   * Engine-owned per-turn telemetry (issue #32): completed turns read out of
+   * ONE session transcript by the vendor's own adapter. `[]` when the engine
+   * ships no turn reader or the file is unreadable — the daemon never parses
+   * a vendor transcript itself.
+   */
+  readEngineTurns(vendor: VendorId, transcriptPath: string): Promise<readonly AgentTurn[]>
   checkLatestVersion(): Promise<UpdateInfo | null>
   latestTranscriptMtime(vendor: VendorId, worktreePath: string): Promise<number>
   deriveTitleFromSession(worktreePath: string, vendor: VendorId): Promise<string>

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -13,6 +13,7 @@ import { ptyHostHasLiveSessions, sweepPtyHostSessions } from "../client/pty-proc
 import { maybeStartPluginHost } from "../plugins/runtime.ts"
 import { readActivityLiveness } from "./activity-liveness.ts"
 import { type ActivityLivenessProbe, DaemonActivityRegistry } from "./activity-registry.ts"
+import { AgentTurnsStore, defaultAgentTurnsPath } from "./agent-turns-store.ts"
 import { AttentionInboxStore, defaultAttentionInboxPath } from "./attention-inbox.ts"
 import { initAutomationsStore } from "./automation-wiring.ts"
 import { type ClientState, broadcast, drainClientBuffer, writeFrame } from "./client-connection.ts"
@@ -138,8 +139,16 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   const activity = new DaemonActivityRegistry(bus, undefined, undefined, livenessAt)
   const inbox = new AttentionInboxStore(defaultAttentionInboxPath(options.homeDir), bus)
   await inbox.init().catch((err) => logDaemonError("attention-inbox-init", err))
+  // Durable per-turn telemetry (issue #32) — written by the `turn-complete`
+  // hook ingest, read by `agentTurn.list`. Same homeDir isolation as the
+  // other daemon-owned stores so a sandbox home never writes to the real one.
+  const agentTurns = new AgentTurnsStore(defaultAgentTurnsPath(options.homeDir))
+  await agentTurns.init().catch((err) => logDaemonError("agent-turns-init", err))
   const clearTaskState = (taskId: string) =>
-    inbox.deleteTaskBestEffort(taskId).finally(() => activity.clearTask(taskId))
+    inbox
+      .deleteTaskBestEffort(taskId)
+      .finally(() => agentTurns.deleteTask(taskId).catch((err) => logDaemonError("agent-turns-delete", err)))
+      .finally(() => activity.clearTask(taskId))
   const deletions = new TaskDeletionRunner(orch, runtime, clearTaskState)
   // Daemon-owned issue tracker (web Issues panel) — a single store keyed by
   // git common-dir, sharing the server's homeDir so sandbox/test homes
@@ -351,6 +360,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       bus,
       activity,
       inbox,
+      agentTurns,
       deletions,
       issues,
       notes,

--- a/packages/kobe/src/cli/api/handlers-agent-turns.ts
+++ b/packages/kobe/src/cli/api/handlers-agent-turns.ts
@@ -1,0 +1,102 @@
+/**
+ * `agent-turns` — the read end of per-turn agent telemetry (issue #32).
+ *
+ * The records are produced by each engine's own adapter (the turn's model,
+ * timings, and token usage come from that vendor's transcript) and joined to
+ * task/tab identity by the daemon at ingest. This verb only reads them back,
+ * plus a totals roll-up so a caller doesn't have to sum the page itself.
+ */
+
+import type { AgentTurnRecord } from "@sma1lboy/kobe-daemon/daemon/contracts"
+import { daemonOf } from "./handler-helpers.ts"
+import type { VerbContext, VerbSpec } from "./types.ts"
+
+const DEFAULT_SINCE_DAYS = 7
+const DEFAULT_LIMIT = 200
+
+export interface AgentTurnTotals {
+  readonly turns: number
+  readonly inputTokens: number
+  readonly outputTokens: number
+  readonly cacheReadTokens: number
+  readonly cacheCreationTokens: number
+  /** Summed wall-clock of the turns in the page, milliseconds. */
+  readonly durationMs: number
+  /** Turn counts per model, so "which model did the work" needs no second pass. */
+  readonly byModel: Record<string, number>
+}
+
+/** Roll a page of turns into totals. Pure — the unit-tested half. */
+export function summarizeTurns(turns: readonly AgentTurnRecord[]): AgentTurnTotals {
+  const byModel: Record<string, number> = {}
+  let inputTokens = 0
+  let outputTokens = 0
+  let cacheReadTokens = 0
+  let cacheCreationTokens = 0
+  let durationMs = 0
+  for (const turn of turns) {
+    inputTokens += turn.usage?.input_tokens ?? 0
+    outputTokens += turn.usage?.output_tokens ?? 0
+    cacheReadTokens += turn.usage?.cache_read_input_tokens ?? 0
+    cacheCreationTokens += turn.usage?.cache_creation_input_tokens ?? 0
+    durationMs += Math.max(0, turn.endedAt - turn.startedAt)
+    const model = turn.model ?? "unknown"
+    byModel[model] = (byModel[model] ?? 0) + 1
+  }
+  return {
+    turns: turns.length,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+    durationMs,
+    byModel,
+  }
+}
+
+async function agentTurns(ctx: VerbContext): Promise<unknown> {
+  const daemon = daemonOf(ctx)
+  const taskId = ctx.args.str("task-id")
+  const repoPath = ctx.args.path("repo")
+  const repo = repoPath ? await ctx.runtime.resolveRepoRoot(repoPath) : undefined
+  const sinceDays = ctx.args.int("since-days") ?? DEFAULT_SINCE_DAYS
+  const since = Date.now() - sinceDays * 24 * 60 * 60 * 1000
+  const limit = ctx.args.int("limit") ?? DEFAULT_LIMIT
+  const { turns } = await daemon.request<{ turns: AgentTurnRecord[] }>("agentTurn.list", {
+    ...(taskId ? { taskId } : {}),
+    ...(repo ? { repoRoot: repo } : {}),
+    since,
+    limit,
+  })
+  return { since: new Date(since).toISOString(), totals: summarizeTurns(turns), turns }
+}
+
+export const AGENT_TURNS_VERB: VerbSpec = {
+  name: "agent-turns",
+  summary:
+    "Per-turn agent telemetry: one record per completed engine turn (task/tab/vendor/model/timings/tokens), newest first, plus totals. Engine-produced, daemon-stored; read-only.",
+  flags: [
+    { name: "task-id", type: "string", placeholder: "ID", description: "Only this task's turns." },
+    {
+      name: "repo",
+      type: "string",
+      placeholder: "PATH",
+      description: "Only turns of tasks in this repo. Relative paths resolve against $PWD.",
+    },
+    {
+      name: "since-days",
+      type: "int",
+      default: String(DEFAULT_SINCE_DAYS),
+      placeholder: "N",
+      description: "Look-back window in days.",
+    },
+    {
+      name: "limit",
+      type: "int",
+      default: String(DEFAULT_LIMIT),
+      placeholder: "N",
+      description: "Max turns returned.",
+    },
+  ],
+  handler: agentTurns,
+}

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -7,6 +7,7 @@ import type { TaskStatus } from "../../types/task.ts"
 import { F, FANOUT_CAP } from "./flags.ts"
 import { handlePtyList, simpleRpc } from "./handler-helpers.ts"
 import { add } from "./handlers-add.ts"
+import { AGENT_TURNS_VERB } from "./handlers-agent-turns.ts"
 import { DIGEST_VERB } from "./handlers-digest.ts"
 import { ENGINE_LIST_VERB, SET_COMMAND_VERB } from "./handlers-engines.ts"
 import { collect, feedback } from "./handlers-fanout.ts"
@@ -92,7 +93,7 @@ export const RETIRED_VERBS: Readonly<Record<string, { hint: string; nextCommandA
  */
 export const VERB_GROUPS: Readonly<Record<string, readonly string[]>> = {
   discover: ["schema", "engine-list"],
-  read: ["list", "get-task", "collect", "digest", "pty-list", "read-output", "inspect"],
+  read: ["list", "get-task", "collect", "digest", "agent-turns", "pty-list", "read-output", "inspect"],
   create: ["add"],
   drive: ["send", "dispatch", "note", "note-list", "set-active", "pane-open", "pane-close", "notify"],
   edit: ["rename", "set-branch", "set-command", "set-status"],
@@ -354,6 +355,7 @@ export const VERBS: readonly VerbSpec[] = [
   // The ruler: an aggregate read over recent tasks + routine runs. Spec +
   // handler in ./handlers-digest.ts.
   DIGEST_VERB,
+  AGENT_TURNS_VERB,
   // Production diagnostics aggregate (daemon activity registry + pty
   // sessions with live foreground walk + persisted tab snapshots). Spec +
   // handler in ./handlers-inspect.ts.

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -55,6 +55,9 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
     return out
   },
   titleTurnHint: engineTitleTurnHint,
+  // Per-turn telemetry (issue #32) — delegated straight to the vendor's own
+  // adapter; an engine without a turn reader simply reports none.
+  readEngineTurns: async (vendor, transcriptPath) => (await engineEntry(vendor).readTurns?.(transcriptPath)) ?? [],
   checkLatestVersion,
   latestTranscriptMtime,
   deriveTitleFromSession,

--- a/packages/kobe/src/engine/agent-turn.ts
+++ b/packages/kobe/src/engine/agent-turn.ts
@@ -1,0 +1,50 @@
+/**
+ * `AgentTurn` — the engine-owned per-turn attribution record (issue #32).
+ *
+ * One record per completed agent turn: which model ran, how long it took,
+ * what it cost in tokens. The engine adapter is the ONLY thing that knows
+ * how to produce one, because the facts live in the vendor's own transcript
+ * (claude's JSONL `message.model` + `message.usage`, codex's rollout, …).
+ * Neutral layers (daemon, TUI, web) store and render this shape and never
+ * parse a vendor file themselves — CLAUDE.md "Engine-owned UI data".
+ *
+ * `taskId` / `tabId` are deliberately NOT here: a turn is a fact about an
+ * engine session, and the engine has no idea what a Rove task is. The daemon
+ * joins the two when it records the turn (`agent-turns-store.ts`).
+ *
+ * Pure data + a pure reader contract; the reader is exposed on the engine
+ * registry entry as `readTurns`, so adding a vendor is one adapter file.
+ */
+
+import type { EngineUsageSnapshot } from "@/types/engine"
+
+export interface AgentTurn {
+  /**
+   * Vendor-stable identity for this turn, used to dedupe repeated reads of
+   * the same transcript (the hook fires on every Stop, and a transcript is
+   * re-read from the top each time). Claude uses the turn's last assistant
+   * `message.id`; another vendor may use whatever it persists — the only
+   * contract is that the SAME turn yields the SAME id across reads.
+   */
+  readonly id: string
+  /** The engine session this turn belongs to (claude's `sessionId`). */
+  readonly sessionId: string
+  /** Model that ran the turn, as the vendor names it; absent when unrecorded. */
+  readonly model?: string
+  /** Turn start (epoch ms) — when the user's prompt entered the transcript. */
+  readonly startedAt: number
+  /** Turn end (epoch ms) — the last assistant record of the turn. */
+  readonly endedAt: number
+  /** Token usage for the turn, summed across its assistant messages. */
+  readonly usage?: EngineUsageSnapshot
+}
+
+/**
+ * Read completed turns out of ONE session transcript, oldest-first.
+ *
+ * `transcriptPath` is the file the engine's own hook reported (claude pipes
+ * `transcript_path` on every hook payload), so no worktree scan is needed.
+ * Best-effort by contract: a missing, oversize, or unparseable file yields
+ * `[]` rather than throwing — telemetry must never break the hook path.
+ */
+export type EngineTurnReader = (transcriptPath: string) => Promise<readonly AgentTurn[]>

--- a/packages/kobe/src/engine/claude-code-local/turns.ts
+++ b/packages/kobe/src/engine/claude-code-local/turns.ts
@@ -1,0 +1,163 @@
+/**
+ * Claude Code's {@link EngineTurnReader} — per-turn telemetry lifted out of
+ * its own JSONL transcript (issue #32).
+ *
+ * The turn boundary Claude persists: a `user` record with real prompt content
+ * opens a turn, every `assistant` record after it belongs to that turn, and
+ * the turn closes at the next such `user` record. Tool-result `user` records
+ * do NOT open a turn — they are the engine talking to itself mid-turn, so
+ * they're skipped (same predicate the history parser already uses to keep
+ * them out of the title path).
+ *
+ * Usage is summed per assistant MESSAGE id, not per record: Claude writes one
+ * record per content block (thinking, tool_use, …) and repeats the SAME
+ * `message.usage` on each — naively summing records multiplies a turn's cost
+ * by its block count. `model` is the last one seen (a turn that switches
+ * models mid-flight is attributed to what finished it).
+ *
+ * Pure (string in, records out) so it unit-tests without a filesystem; the
+ * bounded file read lives in the reader wrapper below.
+ */
+
+import type { AgentTurn } from "../agent-turn.ts"
+import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds.ts"
+import { isSyntheticClaudeRecord } from "./synthetic.ts"
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+/** True when a `user` record is the human opening a turn — i.e. its content
+ *  is not purely `tool_result` blocks (the engine feeding itself). A plain
+ *  string content is always a human prompt. */
+function opensTurn(content: unknown): boolean {
+  if (typeof content === "string") return content.trim().length > 0
+  if (!Array.isArray(content)) return false
+  return content.some((b) => !isObject(b) || b.type !== "tool_result")
+}
+
+interface Usage {
+  input_tokens: number
+  output_tokens: number
+  cache_read_input_tokens: number
+  cache_creation_input_tokens: number
+}
+
+interface Draft {
+  id: string
+  sessionId: string
+  model?: string
+  startedAt: number
+  endedAt: number
+  /** Per assistant `message.id` — Claude repeats one usage across a message's records. */
+  usageByMessage: Map<string, Usage>
+}
+
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0
+}
+
+function readUsage(v: unknown): Usage | undefined {
+  if (!isObject(v)) return undefined
+  return {
+    input_tokens: num(v.input_tokens),
+    output_tokens: num(v.output_tokens),
+    cache_read_input_tokens: num(v.cache_read_input_tokens),
+    cache_creation_input_tokens: num(v.cache_creation_input_tokens),
+  }
+}
+
+function finish(draft: Draft): AgentTurn | null {
+  // A turn with no assistant reply (interrupted before the model answered)
+  // has no id and nothing to attribute — drop it rather than emit a stub.
+  if (!draft.id) return null
+  const totals: Usage = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+  }
+  for (const u of draft.usageByMessage.values()) {
+    totals.input_tokens += u.input_tokens
+    totals.output_tokens += u.output_tokens
+    totals.cache_read_input_tokens += u.cache_read_input_tokens
+    totals.cache_creation_input_tokens += u.cache_creation_input_tokens
+  }
+  return {
+    id: draft.id,
+    sessionId: draft.sessionId,
+    ...(draft.model ? { model: draft.model } : {}),
+    startedAt: draft.startedAt,
+    endedAt: draft.endedAt,
+    ...(draft.usageByMessage.size > 0 ? { usage: totals } : {}),
+  }
+}
+
+/**
+ * Parse a Claude JSONL transcript into completed turns, oldest-first.
+ * `fallbackSessionId` names the session when a record omits `sessionId`.
+ * Exported for unit tests; production callers use {@link readClaudeTurns}.
+ */
+export function parseClaudeTurns(raw: string, fallbackSessionId = ""): AgentTurn[] {
+  const out: AgentTurn[] = []
+  let draft: Draft | null = null
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || !isJsonlLineWithinBound(trimmed)) continue
+    let record: unknown
+    try {
+      record = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!isObject(record) || isSyntheticClaudeRecord(record)) continue
+
+    const inner = isObject(record.message) ? record.message : record
+    const at = typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN
+    if (!Number.isFinite(at)) continue
+    const sessionId = typeof record.sessionId === "string" ? record.sessionId : fallbackSessionId
+
+    if (inner.role === "user") {
+      if (!opensTurn(inner.content)) continue
+      if (draft) {
+        const done = finish(draft)
+        if (done) out.push(done)
+      }
+      draft = { id: "", sessionId, startedAt: at, endedAt: at, usageByMessage: new Map() }
+      continue
+    }
+    if (inner.role !== "assistant" || !draft) continue
+
+    draft.endedAt = at
+    if (typeof inner.model === "string") draft.model = inner.model
+    const messageId = typeof inner.id === "string" ? inner.id : ""
+    // The turn's id is its LAST assistant message — stable across re-reads of
+    // a finished turn, and never colliding with the next turn's.
+    if (messageId) draft.id = messageId
+    const usage = readUsage(inner.usage)
+    if (usage && messageId) draft.usageByMessage.set(messageId, usage)
+  }
+
+  // The trailing draft IS a completed turn once the engine stopped — the hook
+  // that triggers this read fires on Stop, so the last assistant record it
+  // sees closed the turn. (A turn still running just re-reads next time and
+  // dedupes on the same message id.)
+  if (draft) {
+    const done = finish(draft)
+    if (done) out.push(done)
+  }
+  return out
+}
+
+/** Claude's {@link import("../agent-turn.ts").EngineTurnReader}: bounded file
+ *  read + {@link parseClaudeTurns}. Never throws — an unreadable transcript
+ *  yields no turns. */
+export async function readClaudeTurns(transcriptPath: string): Promise<readonly AgentTurn[]> {
+  try {
+    const raw = await readTextFileBounded(transcriptPath)
+    return parseClaudeTurns(raw)
+  } catch {
+    return []
+  }
+}

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -40,10 +40,12 @@ import {
   detectCopilotAccount,
   detectKimiAccount,
 } from "./account-detect.ts"
+import type { EngineTurnReader } from "./agent-turn.ts"
 import { claudeCapabilities, claudeIdentity } from "./claude-code-local/capabilities.ts"
 import { ClaudeHookAdapter } from "./claude-code-local/hook-adapter.ts"
 import { fetchClaudeQuotaUsage } from "./claude-code-local/quota.ts"
 import { trustClaudeWorktree } from "./claude-code-local/trust.ts"
+import { readClaudeTurns } from "./claude-code-local/turns.ts"
 import { codexCapabilities, codexIdentity } from "./codex-local/capabilities.ts"
 import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
 import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
@@ -210,6 +212,14 @@ export interface EngineRegistryEntry {
    * Absent = the vendor has no gate kobe knows how to pre-answer.
    */
   readonly trustWorktree?: (worktreePath: string) => void
+  /**
+   * Per-turn telemetry reader (issue #32): completed {@link AgentTurn}s
+   * lifted from ONE of this engine's session transcripts. Engine-owned by
+   * construction — only the adapter knows where its vendor records the
+   * model, timings, and token usage of a turn. Absent = this engine has no
+   * per-turn attribution kobe can read (nothing is guessed for it).
+   */
+  readonly readTurns?: EngineTurnReader
 }
 
 // The per-vendor readers live in `history-readers.ts` (file-size cap);
@@ -239,6 +249,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
       workingPrefixes: ["⠂", "⠐", "◐", "◑"],
     },
     quotaUsage: () => fetchClaudeQuotaUsage(),
+    readTurns: readClaudeTurns,
   },
   codex: {
     vendor: "codex",

--- a/packages/kobe/test/cli/api-handlers-agent-turns.test.ts
+++ b/packages/kobe/test/cli/api-handlers-agent-turns.test.ts
@@ -1,0 +1,81 @@
+/** `agent-turns` — the totals roll-up and the filter it sends the daemon. */
+
+import type { AgentTurnRecord } from "@sma1lboy/kobe-daemon/daemon/contracts"
+import { describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { summarizeTurns } from "../../src/cli/api/handlers-agent-turns.ts"
+import { FakeClient, stubRuntime } from "./api-handler-fixtures.ts"
+
+const runtime = stubRuntime()
+
+function turn(over: Partial<AgentTurnRecord> = {}): AgentTurnRecord {
+  return {
+    id: "msg_a",
+    taskId: "t1",
+    vendor: "claude",
+    model: "claude-opus-5",
+    startedAt: 1_000,
+    endedAt: 4_000,
+    usage: { input_tokens: 10, output_tokens: 100, cache_read_input_tokens: 5, cache_creation_input_tokens: 2 },
+    ...over,
+  }
+}
+
+describe("summarizeTurns", () => {
+  it("sums tokens and wall-clock, and counts turns per model", () => {
+    expect(summarizeTurns([turn(), turn({ id: "msg_b", model: "claude-sonnet-5", endedAt: 2_000 })])).toEqual({
+      turns: 2,
+      inputTokens: 20,
+      outputTokens: 200,
+      cacheReadTokens: 10,
+      cacheCreationTokens: 4,
+      durationMs: 4_000,
+      byModel: { "claude-opus-5": 1, "claude-sonnet-5": 1 },
+    })
+  })
+
+  it("tolerates missing usage/model and never reports a negative duration", () => {
+    const t = summarizeTurns([turn({ usage: undefined, model: undefined, startedAt: 9_000, endedAt: 1_000 })])
+    expect(t).toMatchObject({ turns: 1, inputTokens: 0, durationMs: 0, byModel: { unknown: 1 } })
+  })
+
+  it("an empty page summarizes to zeros", () => {
+    expect(summarizeTurns([])).toMatchObject({ turns: 0, outputTokens: 0, byModel: {} })
+  })
+})
+
+describe("agent-turns handler", () => {
+  it("passes task/limit through and returns totals alongside the page", async () => {
+    const seen: Record<string, unknown>[] = []
+    const client = new FakeClient({
+      "agentTurn.list": (payload) => {
+        seen.push(payload as Record<string, unknown>)
+        return { turns: [turn()] }
+      },
+    })
+    const result = (await invokeVerb("agent-turns", ["--task-id", "t1", "--limit", "5"], { client, runtime })) as {
+      totals: { turns: number }
+      turns: AgentTurnRecord[]
+    }
+    expect(seen[0]).toMatchObject({ taskId: "t1", limit: 5 })
+    expect(typeof seen[0].since).toBe("number")
+    expect(seen[0].repoRoot).toBeUndefined()
+    expect(result.totals.turns).toBe(1)
+    expect(result.turns).toHaveLength(1)
+  })
+
+  it("resolves --repo to a repo root before filtering", async () => {
+    const seen: Record<string, unknown>[] = []
+    const client = new FakeClient({
+      "agentTurn.list": (payload) => {
+        seen.push(payload as Record<string, unknown>)
+        return { turns: [] }
+      },
+    })
+    await invokeVerb("agent-turns", ["--repo", "/repo/x"], {
+      client,
+      runtime: stubRuntime({ resolveRepoRoot: async () => "/repo/root" }),
+    })
+    expect(seen[0].repoRoot).toBe("/repo/root")
+  })
+})

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -142,6 +142,7 @@ describe("schema drill-ins", () => {
       "get-task",
       "collect",
       "digest",
+      "agent-turns",
       "pty-list",
       "read-output",
       "inspect",

--- a/packages/kobe/test/daemon/agent-turns.test.ts
+++ b/packages/kobe/test/daemon/agent-turns.test.ts
@@ -1,0 +1,146 @@
+/** Durable per-turn telemetry: store persistence + the hook-driven ingest (issue #32). */
+
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { ingestAgentTurns } from "@sma1lboy/kobe-daemon/daemon/agent-turns-ingest"
+import { AgentTurnsStore } from "@sma1lboy/kobe-daemon/daemon/agent-turns-store"
+import type { AgentTurn, AgentTurnRecord, DaemonOrchestrator } from "@sma1lboy/kobe-daemon/daemon/contracts"
+import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
+import { afterEach, describe, expect, it } from "vitest"
+
+let dir: string | null = null
+
+afterEach(async () => {
+  if (dir) await rm(dir, { recursive: true, force: true })
+  dir = null
+})
+
+async function createStore(): Promise<{ store: AgentTurnsStore; path: string }> {
+  dir = await mkdtemp(join(tmpdir(), "kobe-agent-turns-"))
+  const path = join(dir, "agent-turns.json")
+  const store = new AgentTurnsStore(path)
+  await store.init()
+  return { store, path }
+}
+
+function record(over: Partial<AgentTurnRecord> = {}): AgentTurnRecord {
+  return {
+    id: "msg_a",
+    taskId: "task-1",
+    vendor: "claude",
+    model: "claude-opus-5",
+    repo: "/repo",
+    startedAt: 1000,
+    endedAt: 2000,
+    usage: { input_tokens: 1, output_tokens: 2 },
+    ...over,
+  }
+}
+
+describe("AgentTurnsStore", () => {
+  it("persists turns and reloads them", async () => {
+    const { store, path } = await createStore()
+    expect(await store.record([record()])).toBe(1)
+
+    const reloaded = new AgentTurnsStore(path)
+    await reloaded.init()
+    expect(reloaded.list()).toEqual([record()])
+  })
+
+  it("dedupes a re-read of the same turn (the every-Stop re-scan)", async () => {
+    const { store } = await createStore()
+    expect(await store.record([record()])).toBe(1)
+    expect(await store.record([record(), record({ id: "msg_b", endedAt: 3000 })])).toBe(1)
+    expect(store.list().map((t) => t.id)).toEqual(["msg_b", "msg_a"]) // newest first
+  })
+
+  it("scopes the dedupe key by task, so two tasks may carry the same engine id", async () => {
+    const { store } = await createStore()
+    await store.record([record(), record({ taskId: "task-2" })])
+    expect(store.list()).toHaveLength(2)
+  })
+
+  it("filters by task, repo, and since; drops malformed rows", async () => {
+    const { store } = await createStore()
+    await store.record([
+      record(),
+      record({ id: "msg_b", taskId: "task-2", repo: "/other", endedAt: 9000 }),
+      { id: "", taskId: "task-3", startedAt: 1, endedAt: 2 } as AgentTurnRecord,
+    ])
+    expect(store.list({ taskId: "task-2" }).map((t) => t.id)).toEqual(["msg_b"])
+    expect(store.list({ repo: "/repo" }).map((t) => t.id)).toEqual(["msg_a"])
+    expect(store.list({ since: 5000 }).map((t) => t.id)).toEqual(["msg_b"])
+    expect(store.list({ limit: 1 })).toHaveLength(1)
+    expect(store.list().some((t) => t.taskId === "task-3")).toBe(false)
+  })
+
+  it("drops a deleted task's turns", async () => {
+    const { store } = await createStore()
+    await store.record([record(), record({ taskId: "task-2" })])
+    await store.deleteTask("task-1")
+    expect(store.list().map((t) => t.taskId)).toEqual(["task-2"])
+  })
+})
+
+describe("ingestAgentTurns", () => {
+  const engineTurn: AgentTurn = {
+    id: "msg_a",
+    sessionId: "sess-1",
+    model: "claude-opus-5",
+    startedAt: 1000,
+    endedAt: 2000,
+    usage: { input_tokens: 1, output_tokens: 2 },
+  }
+
+  function deps(turns: readonly AgentTurn[] = [engineTurn], task: unknown = { repo: "/repo", vendor: "claude" }) {
+    const asked: { vendor: string; path: string }[] = []
+    const runtime = {
+      readEngineTurns: async (vendor: string, path: string) => {
+        asked.push({ vendor, path })
+        return turns
+      },
+    } as unknown as DaemonRuntimeAdapter
+    const orch = { getTask: () => task } as unknown as DaemonOrchestrator
+    return { runtime, orch, asked }
+  }
+
+  it("joins engine turns to task identity and records them", async () => {
+    const { store } = await createStore()
+    const { runtime, orch, asked } = deps()
+
+    expect(
+      await ingestAgentTurns(store, runtime, orch, {
+        taskId: "task-1",
+        tabId: "tab-2",
+        vendor: "claude",
+        transcriptPath: "/t.jsonl",
+      }),
+    ).toBe(1)
+    expect(asked).toEqual([{ vendor: "claude", path: "/t.jsonl" }])
+    expect(store.list()).toEqual([{ ...engineTurn, taskId: "task-1", tabId: "tab-2", vendor: "claude", repo: "/repo" }])
+  })
+
+  it("no transcript path and no resolvable vendor are both no-ops", async () => {
+    const { store } = await createStore()
+    const { runtime, orch, asked } = deps()
+    expect(await ingestAgentTurns(store, runtime, orch, { taskId: "task-1" })).toBe(0)
+
+    const vendorless = deps(undefined, { repo: "/repo" })
+    expect(
+      await ingestAgentTurns(store, vendorless.runtime, vendorless.orch, {
+        taskId: "task-1",
+        transcriptPath: "/t.jsonl",
+      }),
+    ).toBe(0)
+    expect(asked).toEqual([])
+    expect(store.list()).toEqual([])
+  })
+
+  it("falls back to the task's vendor when the hook carried no --engine tag", async () => {
+    const { store } = await createStore()
+    const { runtime, orch, asked } = deps()
+    await ingestAgentTurns(store, runtime, orch, { taskId: "task-1", transcriptPath: "/t.jsonl" })
+    expect(asked[0].vendor).toBe("claude")
+  })
+})

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -74,6 +74,7 @@ describe("daemon handler registry", () => {
       "workitem.start",
       "session.deliver",
       "task.recentEvents",
+      "agentTurn.list",
       "debug.inspect",
       "ui.reportEvent",
       "ui.prompt",

--- a/packages/kobe/test/engine/claude-turns.test.ts
+++ b/packages/kobe/test/engine/claude-turns.test.ts
@@ -1,0 +1,128 @@
+/** Per-turn telemetry extraction from Claude's JSONL (issue #32). */
+
+import { parseClaudeTurns } from "@/engine/claude-code-local/turns"
+import { describe, expect, test } from "vitest"
+
+const SID = "sess-1"
+
+function line(record: Record<string, unknown>): string {
+  return JSON.stringify(record)
+}
+
+function user(ts: string, text = "do the thing"): string {
+  return line({ type: "user", sessionId: SID, timestamp: ts, message: { role: "user", content: text } })
+}
+
+function assistant(
+  ts: string,
+  id: string,
+  opts: { model?: string; usage?: Record<string, number>; content?: unknown } = {},
+): string {
+  return line({
+    type: "assistant",
+    sessionId: SID,
+    timestamp: ts,
+    message: {
+      role: "assistant",
+      id,
+      model: opts.model ?? "claude-opus-5",
+      content: opts.content ?? [{ type: "text", text: "ok" }],
+      ...(opts.usage ? { usage: opts.usage } : {}),
+    },
+  })
+}
+
+describe("parseClaudeTurns", () => {
+  test("one prompt + reply becomes one turn with model, span, and usage", () => {
+    const raw = [
+      user("2026-08-15T10:00:00.000Z"),
+      assistant("2026-08-15T10:00:05.000Z", "msg_a", {
+        usage: { input_tokens: 10, output_tokens: 200, cache_read_input_tokens: 5000 },
+      }),
+    ].join("\n")
+
+    expect(parseClaudeTurns(raw)).toEqual([
+      {
+        id: "msg_a",
+        sessionId: SID,
+        model: "claude-opus-5",
+        startedAt: Date.parse("2026-08-15T10:00:00.000Z"),
+        endedAt: Date.parse("2026-08-15T10:00:05.000Z"),
+        usage: {
+          input_tokens: 10,
+          output_tokens: 200,
+          cache_read_input_tokens: 5000,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    ])
+  })
+
+  test("usage is counted once per message id, not once per record", () => {
+    // Claude writes one record per content block, repeating the same usage.
+    const usage = { input_tokens: 4, output_tokens: 500 }
+    const raw = [
+      user("2026-08-15T10:00:00.000Z"),
+      assistant("2026-08-15T10:00:01.000Z", "msg_a", { usage, content: [{ type: "thinking", thinking: "hm" }] }),
+      assistant("2026-08-15T10:00:02.000Z", "msg_a", { usage, content: [{ type: "tool_use", name: "Bash" }] }),
+      assistant("2026-08-15T10:00:03.000Z", "msg_a", { usage }),
+    ].join("\n")
+
+    const [turn] = parseClaudeTurns(raw)
+    expect(turn.usage?.output_tokens).toBe(500)
+    expect(turn.endedAt).toBe(Date.parse("2026-08-15T10:00:03.000Z"))
+  })
+
+  test("tool_result user records continue the turn instead of opening one", () => {
+    const raw = [
+      user("2026-08-15T10:00:00.000Z"),
+      assistant("2026-08-15T10:00:01.000Z", "msg_a", { usage: { input_tokens: 1, output_tokens: 10 } }),
+      line({
+        type: "user",
+        sessionId: SID,
+        timestamp: "2026-08-15T10:00:02.000Z",
+        message: { role: "user", content: [{ type: "tool_result", content: "done" }] },
+      }),
+      assistant("2026-08-15T10:00:03.000Z", "msg_b", { usage: { input_tokens: 1, output_tokens: 20 } }),
+    ].join("\n")
+
+    const turns = parseClaudeTurns(raw)
+    expect(turns).toHaveLength(1)
+    expect(turns[0].id).toBe("msg_b") // last assistant message closes the turn
+    expect(turns[0].usage?.output_tokens).toBe(30)
+  })
+
+  test("two prompts yield two turns, each with its own id", () => {
+    const raw = [
+      user("2026-08-15T10:00:00.000Z"),
+      assistant("2026-08-15T10:00:01.000Z", "msg_a"),
+      user("2026-08-15T10:01:00.000Z", "and again"),
+      assistant("2026-08-15T10:01:04.000Z", "msg_b"),
+    ].join("\n")
+
+    expect(parseClaudeTurns(raw).map((t) => t.id)).toEqual(["msg_a", "msg_b"])
+  })
+
+  test("synthetic records, malformed lines, and reply-less turns are dropped", () => {
+    const raw = [
+      line({
+        type: "user",
+        isMeta: true,
+        sessionId: SID,
+        timestamp: "2026-08-15T09:59:00.000Z",
+        message: { role: "user", content: "caveat" },
+      }),
+      "{not json",
+      "",
+      user("2026-08-15T10:00:00.000Z"), // interrupted: never answered
+      user("2026-08-15T10:02:00.000Z", "second"),
+      assistant("2026-08-15T10:02:01.000Z", "msg_b"),
+    ].join("\n")
+
+    expect(parseClaudeTurns(raw).map((t) => t.id)).toEqual(["msg_b"])
+  })
+
+  test("empty transcript yields no turns", () => {
+    expect(parseClaudeTurns("")).toEqual([])
+  })
+})


### PR DESCRIPTION
Step 1 of attribution (issue #32): every completed engine turn now leaves an attributed record.

## Shape

**Engine layer owns the turn.** `src/engine/agent-turn.ts` defines `AgentTurn` (id / sessionId / model / startedAt / endedAt / usage) and the `EngineTurnReader` contract; the registry entry grows an optional `readTurns`. Nothing outside the engine layer parses a vendor transcript — the daemon supplies a path and an engine id and gets records back.

**Claude adapter produces them.** `claude-code-local/turns.ts` walks the JSONL: a real (non-`tool_result`) user record opens a turn, assistant records extend it, the last assistant message id closes and names it. Usage is summed **per `message.id`**, not per record — Claude writes one record per content block and repeats the same usage on each, so summing records multiplies a turn's cost by its block count. Synthetic/meta rows, malformed lines, and reply-less (interrupted) turns are dropped. Reads come from the hook's own `transcript_path`, through the existing bounded-file helper.

No hook changes: `turn-complete` already carries `transcriptPath`, `tabId`, and the `--engine` tag. The global-hook install is untouched.

**Daemon stores + serves.** `agent-turns-store.ts` persists to `<home>/.rove/agent-turns.json` (atomic write, serialized mutations, 10k cap, dedupe keyed `taskId+turnId` — every Stop re-reads the whole transcript, so re-ingest of finished turns is the normal case, not the exception). `agent-turns-ingest.ts` joins task/tab/vendor/repo on `turn-complete`, fire-and-forget so the hook RPC never waits on a file read. A hard-deleted task drops its turns with the rest of its state.

**Read verb.** `rove api agent-turns [--task-id ID] [--repo PATH] [--since-days N] [--limit N]` → newest-first page plus a `totals` roll-up (token sums, summed wall-clock, turns per model). Socket-only: the web allowset is a test-pinned security contract and nothing in the browser reads turns yet.

Out of scope this round: codex/kimi readers, any UI.

## Verification

- `agent-turns` group, daemon suite, and the full kobe unit suite green (3169 tests); root lint + typecheck clean.
- New tests: turn extraction (per-message usage, tool_result continuation, synthetic/malformed/interrupted drops), store persistence + dedupe + filters + task deletion, ingest identity join, totals arithmetic.
- Parser probed against four real Claude transcripts (15/50/59/84 turns) — models, spans, and token sums all plausible.

Two pinned enumerations were updated deliberately, not loosened: the handler-registry name list (new `agentTurn.list`) and the `read` verb group.