### PR TITLE
fix: verify session identity before recording a dispatcher (#24)

### DIFF
--- a/.changeset/verify-dispatcher-identity.md
+++ b/.changeset/verify-dispatcher-identity.md
@@ -1,0 +1,18 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Verify session identity before recording a dispatcher (issue #24)
+
+`$ROVE_TASK_ID`/`$ROVE_TAB_ID` are ordinary environment variables, so any
+detached descendant of an engine tab — a Claude Code background process, for
+instance — keeps exporting that tab's ids indefinitely. Every task such a
+process created recorded a dispatcher pointing at a stranger's session, which
+is where finished workers sent their reports.
+
+`add`, `send`, and the new-task coda now cross-check the env against the pty
+host before believing it: the named tab must be alive AND its shell must be an
+ancestor of the calling process. Unverified means no dispatcher, no
+`[KOBE PEER]` provenance, and no spawner address in the worker's own
+instructions — with an `identityWarning` on the verb's JSON result so the
+degrade is visible rather than silent.

--- a/docs/API.md
+++ b/docs/API.md
@@ -183,6 +183,17 @@ the caller as the new task's `dispatcher` (`{taskId, tabId}` from
 `$ROVE_TASK_ID`/`$ROVE_TAB_ID`, with Kobe aliases) — the reply address the worker's bare
 `send` routes back to. Creates from a plain shell or the TUI record none.
 
+Those env vars are **verified, not trusted**: an environment variable is
+inherited by every descendant process, so an agent's detached background
+process keeps exporting the ids of a tab it no longer runs in, and every
+task it creates would name a stranger's session as its dispatcher. Rove
+believes the pair only when `<taskId>::<tabId>` is a live session AND that
+session's shell is an ancestor of the calling process. When it isn't, the
+dispatcher / `[KOBE PEER]` provenance / spawner coda are all omitted (a
+wrong reply address delivers to someone else; no address at least fails
+visibly), and the verb's JSON result carries an `identityWarning` field
+saying so.
+
 A new task's FIRST prompt (`add --prompt`, a parallel round, quick-fork) gets a
 short coda appended asking the agent to `set-branch` the auto-generated
 placeholder branch to a descriptive name. Prompts into existing sessions

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -55,6 +55,7 @@
  */
 
 import { errorMessage } from "@/lib/error-message"
+import { takeIdentityWarning } from "./api/dispatcher.ts"
 import { VerbArgs, buildCountPlan, parseAgentsSpec, parseFlags, validateAgainstSpec } from "./api/flags.ts"
 import { defaultApiRuntime, deliverPrompt } from "./api/runtime.ts"
 import { API_SCHEMA_VERSION, apiUsage, fullSchema, schemaIndex, verbHelp, verbSchema } from "./api/schema.ts"
@@ -75,7 +76,14 @@ import { type DaemonSession, openDaemonSession } from "./daemon-session.ts"
 import type { DaemonRpc } from "./daemon-session.ts"
 
 function emit(value: unknown, pretty: boolean): void {
-  const text = pretty ? JSON.stringify(value, null, 2) : JSON.stringify(value)
+  // A verb that refused an UNVERIFIED $ROVE_TASK_ID (issue #24) degraded
+  // quietly — the create/send succeeded, it just recorded no dispatcher. Ride
+  // the notice on the result object so an agent sees it: stderr is reserved
+  // for the one JSON error envelope (docs/API.md), and a silent degrade is
+  // exactly what made the wrong reply address invisible for weeks.
+  const warning = takeIdentityWarning()
+  const payload = warning && value && typeof value === "object" ? { ...value, identityWarning: warning } : value
+  const text = pretty ? JSON.stringify(payload, null, 2) : JSON.stringify(payload)
   process.stdout.write(`${text}\n`)
 }
 

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -82,7 +82,9 @@ function emit(value: unknown, pretty: boolean): void {
   // for the one JSON error envelope (docs/API.md), and a silent degrade is
   // exactly what made the wrong reply address invisible for weeks.
   const warning = takeIdentityWarning()
-  const payload = warning && value && typeof value === "object" ? { ...value, identityWarning: warning } : value
+  // Objects only — spreading an array would flatten it into numeric keys.
+  const mergeable = warning && value && typeof value === "object" && !Array.isArray(value)
+  const payload = mergeable ? { ...value, identityWarning: warning } : value
   const text = pretty ? JSON.stringify(payload, null, 2) : JSON.stringify(payload)
   process.stdout.write(`${text}\n`)
 }

--- a/packages/kobe/src/cli/api/dispatcher.ts
+++ b/packages/kobe/src/cli/api/dispatcher.ts
@@ -110,7 +110,13 @@ async function resolveSelfSession(env: NodeJS.ProcessEnv, probe?: SelfSessionPro
     const session = (await p.sessions()).find((s) => s.key === key && s.alive)
     if (session?.pid) {
       const { hasAncestor, parsePsSnapshot } = await import("../../engine/foreground.ts")
-      if (hasAncestor(parsePsSnapshot(await p.ps()), p.pid, session.pid)) return { taskId, tabId }
+      if (hasAncestor(parsePsSnapshot(await p.ps()), p.pid, session.pid)) {
+        // A verified resolution clears any warning a previous one left. The
+        // memo makes that a single resolution per process today; this keeps
+        // the pair honest if the memo is ever relaxed.
+        identityWarning = null
+        return { taskId, tabId }
+      }
     }
   } catch {
     /* unreadable host/ps — fall through to the refusal below */
@@ -119,7 +125,7 @@ async function resolveSelfSession(env: NodeJS.ProcessEnv, probe?: SelfSessionPro
   // it is a kobe session and its dispatcher/peer fields just vanished. stderr
   // carries exactly one JSON error envelope by contract (docs/API.md), so the
   // notice rides the verb's own stdout result instead — see `takeIdentityWarning`.
-  identityWarning = `$ROVE_TASK_ID names task ${taskId} ${tabId}, but this process is not running inside that tab (an inherited env, not an identity) — dispatcher/peer provenance omitted`
+  identityWarning = `$ROVE_TASK_ID/$KOBE_TASK_ID names task ${taskId} ${tabId}, but this process is not running inside that tab (an inherited env, not an identity) — dispatcher/peer provenance omitted`
   return null
 }
 

--- a/packages/kobe/src/cli/api/dispatcher.ts
+++ b/packages/kobe/src/cli/api/dispatcher.ts
@@ -20,30 +20,145 @@ import { ApiError, type ApiRuntime } from "./types.ts"
 /** The dispatcher pair as recorded on a task. */
 export type Dispatcher = NonNullable<SerializedTask["dispatcher"]>
 
+/** The two reads {@link verifiedSelfSession} needs; injectable for tests. */
+export interface SelfSessionProbe {
+  /** Live pty-host inventory (`pty.list`) — `[]` when the host is gone. */
+  sessions(): Promise<readonly { key: string; pid: number | null; alive: boolean }[]>
+  /** `ps -A -o pid=,ppid=,args=` output. */
+  ps(): Promise<string>
+  /** This process's pid — the far end of the lineage walk. */
+  pid: number
+}
+
+/** One resolution per CLI process — see {@link verifiedSelfSession}. */
+let selfSessionOnce: Promise<Dispatcher | null> | undefined
+
+/** Set by a refused resolution, drained by {@link takeIdentityWarning}. */
+let identityWarning: string | null = null
+
+async function realProbe(): Promise<SelfSessionProbe> {
+  const [{ openPtyHost, listSessions }, { psSnapshot }] = await Promise.all([
+    import("./pty-delivery.ts"),
+    import("../../engine/foreground.ts"),
+  ])
+  return {
+    sessions: async () => {
+      const host = await openPtyHost()
+      if (!host) return []
+      try {
+        return await listSessions(host.rpc)
+      } finally {
+        host.close()
+      }
+    },
+    ps: psSnapshot,
+    pid: process.pid,
+  }
+}
+
 /**
- * `task.create` payload fields naming the caller as the dispatcher.
- * `$KOBE_TASK_ID` / `$KOBE_TAB_ID` are exported into every engine tab
- * (`session-launch.ts`), and are read HERE in the CLI process — the daemon
- * has no caller env of its own. A create from a plain shell contributes
- * nothing. Tab floor `tab-1` = the canonical first engine tab.
+ * The caller's OWN kobe session identity — `$KOBE_TASK_ID`/`$KOBE_TAB_ID`
+ * cross-checked against the pty host, or `null` when it doesn't hold up.
+ *
+ * The env alone is NOT identity (issue #24). It is an ordinary variable and
+ * inherits down the entire process tree, so a Claude Code background daemon
+ * forked out of an engine tab carries that tab's ids for as long as it
+ * lives — and every task IT later creates recorded a dispatcher pointing at
+ * a stranger's session, which is where finished workers reported to. Two
+ * things have to be true for the env to be believed:
+ *
+ *   1. `<taskId>::<tabId>` is a session the pty host lists as ALIVE, and
+ *   2. that session's shell pid is an ANCESTOR of this process.
+ *
+ * (2) is what the inherited env can't fake: a detached background process
+ * reparents to init and stops reaching the tab's shell. A real `kobe api`
+ * call from inside the tab — engine → its Bash tool → this CLI — always
+ * does.
+ *
+ * Unverifiable is UNVERIFIED: no host, no ps, a killed tab. Recording a
+ * wrong reply address is strictly worse than recording none, because the
+ * wrong one delivers (to someone else) instead of failing.
+ *
+ * Memoized: one `pty.list` + one `ps` per CLI process, however many verbs
+ * ask (`send` asks twice — routing and peer provenance).
  */
-export function dispatcherEnvPayload(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+export async function verifiedSelfSession(
+  env: NodeJS.ProcessEnv = process.env,
+  probe?: SelfSessionProbe,
+): Promise<Dispatcher | null> {
+  // An explicit probe always re-resolves (a test walking several env shapes
+  // must not read the previous one's answer) and PRIMES the memo, so the
+  // verbs it then drives resolve the same identity without real IO.
+  if (!probe && selfSessionOnce) return selfSessionOnce
+  const run = resolveSelfSession(env, probe)
+  selfSessionOnce = run
+  return run
+}
+
+/** Drop the memo — tests only (one process, many env fixtures). */
+export function resetVerifiedSelfSession(): void {
+  selfSessionOnce = undefined
+}
+
+async function resolveSelfSession(env: NodeJS.ProcessEnv, probe?: SelfSessionProbe): Promise<Dispatcher | null> {
   const taskId = env.KOBE_TASK_ID
-  if (!taskId) return {}
-  return { dispatcherTaskId: taskId, dispatcherTabId: env.KOBE_TAB_ID || "tab-1" }
+  if (!taskId) return null
+  const tabId = env.KOBE_TAB_ID || "tab-1"
+  try {
+    const p = probe ?? (await realProbe())
+    const key = `${taskId}::${tabId}`
+    const session = (await p.sessions()).find((s) => s.key === key && s.alive)
+    if (session?.pid) {
+      const { hasAncestor, parsePsSnapshot } = await import("../../engine/foreground.ts")
+      if (hasAncestor(parsePsSnapshot(await p.ps()), p.pid, session.pid)) return { taskId, tabId }
+    }
+  } catch {
+    /* unreadable host/ps — fall through to the refusal below */
+  }
+  // Never a SILENT degrade (issue #24's fallback rule): the caller believes
+  // it is a kobe session and its dispatcher/peer fields just vanished. stderr
+  // carries exactly one JSON error envelope by contract (docs/API.md), so the
+  // notice rides the verb's own stdout result instead — see `takeIdentityWarning`.
+  identityWarning = `$ROVE_TASK_ID names task ${taskId} ${tabId}, but this process is not running inside that tab (an inherited env, not an identity) — dispatcher/peer provenance omitted`
+  return null
+}
+
+/**
+ * The one-shot "your session identity didn't verify" notice, merged into the
+ * verb's JSON result by the api dispatcher so an agent SEES the degrade
+ * instead of silently losing its reply address. Read-and-clear.
+ */
+export function takeIdentityWarning(): string | null {
+  const warning = identityWarning
+  identityWarning = null
+  return warning
+}
+
+/**
+ * `task.create` payload fields naming the caller as the dispatcher — empty
+ * from a plain shell, and equally empty when the env fails
+ * {@link verifiedSelfSession}.
+ */
+export async function dispatcherEnvPayload(
+  env: NodeJS.ProcessEnv = process.env,
+  probe?: SelfSessionProbe,
+): Promise<Record<string, string>> {
+  const self = await verifiedSelfSession(env, probe)
+  if (!self) return {}
+  return { dispatcherTaskId: self.taskId, dispatcherTabId: self.tabId }
 }
 
 /**
  * The dispatcher recorded on the CALLER's own task, when the caller is a
- * kobe session that has one. `null` (keep the active-task default) when the
- * caller isn't a kobe session, the task predates the field or was created
- * outside a kobe session, or the env id is stale.
+ * VERIFIED kobe session that has one. `null` (keep the active-task default)
+ * when the caller isn't a kobe session, its env didn't verify, or the task
+ * predates the field / was created outside a kobe session.
  */
 export async function readOwnDispatcher(daemon: DaemonRpc): Promise<Dispatcher | null> {
-  const selfId = process.env.KOBE_TASK_ID
-  if (!selfId) return null
+  const self = await verifiedSelfSession()
+  if (!self) return null
   try {
-    const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId: selfId })
+    const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId: self.taskId })
     return res.task.dispatcher ?? null
   } catch {
     return null

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -63,7 +63,7 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   // Record who dispatched this create (issue #21) — the reply address a
   // sub-task's bare `send` routes its outcome back to.
   const choice = await engineChoice(ctx, repo)
-  const payload: Record<string, string> = { repo, ...dispatcherEnvPayload(), ...enginePayload(choice) }
+  const payload: Record<string, string> = { repo, ...(await dispatcherEnvPayload()), ...enginePayload(choice) }
   const title = args.str("title")
   if (title) payload.title = title
   const branch = args.str("branch")
@@ -208,7 +208,7 @@ async function addParallel(
   let createFailure: { vendor: VendorId; error: { message: string; code: string } } | null = null
   // Every sibling records the same dispatcher (issue #21) — the reply
   // address each worker's bare `send` routes its outcome back to.
-  const dispatcher = dispatcherEnvPayload()
+  const dispatcher = await dispatcherEnvPayload()
   for (const [i, vendor] of plan.entries()) {
     // `--agents` picks each sibling's engine BY ID, so its command is that
     // id; a `--count` round reuses the caller's own `--command` verbatim.

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -10,7 +10,7 @@ import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
 import { kobeApiInvocation } from "../../engine/interactive-command.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
-import { readOwnDispatcher, resolveDispatcherTab } from "./dispatcher.ts"
+import { readOwnDispatcher, resolveDispatcherTab, verifiedSelfSession } from "./dispatcher.ts"
 import { F } from "./flags.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
@@ -22,11 +22,14 @@ import { ApiError, type VerbContext, type VerbSpec, helpStep } from "./types.ts"
  * carries — who is talking and how to answer. Same convention as field
  * notes (`[KOBE FIELD NOTE] from "<label>" (task <id>)`), plus the reply
  * command so a peer conversation is symmetric without any coordinator.
- * Sender identity comes from $KOBE_TASK_ID (exported into every engine
- * tab); a send from a plain shell (no env) or to yourself stays untouched.
+ * Sender identity is the VERIFIED $KOBE_TASK_ID/$KOBE_TAB_ID pair, not the
+ * raw env: an unverified one names a stranger's session as the sender and
+ * bakes their tab into the reply command (issue #24). A send from a plain
+ * shell, an unverified process, or to yourself stays untouched.
  */
 async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, prompt: string): Promise<string> {
-  const senderId = process.env.KOBE_TASK_ID
+  const self = await verifiedSelfSession()
+  const senderId = self?.taskId
   if (!senderId || senderId === targetTaskId) return prompt
   let label = senderId
   try {
@@ -41,8 +44,7 @@ async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, promp
   // which is exactly the link that breaks (#19) — tab-precise addressing is
   // the loop's durable route home. $KOBE_TAB_ID is exported into every
   // engine tab alongside $KOBE_TASK_ID (session-launch.ts).
-  const senderTab = process.env.KOBE_TAB_ID
-  const replyTarget = `--task-id ${senderId}${senderTab ? ` --tab ${senderTab}` : ""}`
+  const replyTarget = `--task-id ${senderId} --tab ${self.tabId}`
   // The trailing pointer closes the loop for a receiver that has never seen
   // kobe: reply command baked in, and where to learn the rest (the herdr
   // "--skill first" trick) — a pointer, not a curriculum, since every peer

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -12,6 +12,7 @@ import { withClaudeSessionId } from "../../engine/interactive-command.ts"
 import { buildEngineSessionLaunch } from "../../engine/session-launch.ts"
 import { trustEngineWorktree } from "../../engine/trust-worktree.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
+import { verifiedSelfSession } from "./dispatcher.ts"
 import {
   deliverHostedPrompt,
   deliverToExactTab,
@@ -81,11 +82,15 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
       worktreePath: worktree,
       shell: process.env.SHELL?.trim() || "/bin/zsh",
       argv,
-      // Spawner identity is read HERE, in the CLI process — an `add`
-      // run from inside an engine tab carries the spawner's $KOBE_TASK_ID, and
-      // the coda tells the new agent to `send` its outcome back (repo-init.ts).
+      // Spawner identity is resolved HERE, in the CLI process — an `add` run
+      // from inside an engine tab carries the spawner's $KOBE_TASK_ID, and
+      // the coda tells the new agent to `send` its outcome back
+      // (repo-init.ts). VERIFIED, not raw env: an inherited id would write a
+      // stranger's task into the worker's own instructions (issue #24), which
+      // is the one place a wrong address survives even after the record is
+      // right — it's baked into the prompt, not read back from the store.
       promptIntent: target.newTask
-        ? { kind: "new-task", prompt, spawnerTaskId: process.env.KOBE_TASK_ID || undefined }
+        ? { kind: "new-task", prompt, spawnerTaskId: (await verifiedSelfSession())?.taskId }
         : { kind: "explicit", prompt },
       tabId: newTab,
     })

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -94,6 +94,31 @@ function childrenIndex(rows: readonly ProcRow[]): Map<number, ProcRow[]> {
 }
 
 /**
+ * Is `ancestorPid` anywhere on `pid`'s parent chain (or `pid` itself)?
+ *
+ * The lineage half of "am I really running inside this tab" (issue #24):
+ * `$KOBE_TASK_ID` is an ordinary env var and inherits down the whole
+ * process tree, so a background daemon forked out of an engine tab keeps
+ * that identity for as long as it lives. A pid chain can't be inherited —
+ * a process that detached (ppid reparented to 1) simply stops reaching the
+ * tab's shell, which is exactly the case we must refuse.
+ *
+ * The walk is bounded by the row count: a `ps` snapshot is a forest, but a
+ * malformed/racy one could still hand us a ppid cycle.
+ */
+export function hasAncestor(rows: readonly ProcRow[], pid: number, ancestorPid: number): boolean {
+  const parents = new Map(rows.map((r) => [r.pid, r.ppid]))
+  let cur = pid
+  for (let hops = 0; hops <= rows.length; hops++) {
+    if (cur === ancestorPid) return true
+    const next = parents.get(cur)
+    if (next === undefined || next <= 1) return false
+    cur = next
+  }
+  return false
+}
+
+/**
  * Breadth-first hunt for an engine among `rootPid`'s descendants —
  * shallowest wins, so a wrapper's engine child is found before that
  * engine's own helper processes (claude spawns `claude bg-pty-host`

--- a/packages/kobe/test/cli/api-cmd-run.test.ts
+++ b/packages/kobe/test/cli/api-cmd-run.test.ts
@@ -28,6 +28,9 @@ vi.mock("../../src/cli/daemon-session.ts", () => ({
 }))
 
 const { runApiSubcommand } = await import("../../src/cli/api-cmd.ts")
+const { resetVerifiedSelfSession, takeIdentityWarning, verifiedSelfSession } = await import(
+  "../../src/cli/api/dispatcher.ts"
+)
 
 let stdoutSpy: MockInstance
 let stderrSpy: MockInstance
@@ -55,6 +58,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks()
+  resetVerifiedSelfSession()
+  takeIdentityWarning()
 })
 
 describe("runApiSubcommand", () => {
@@ -134,6 +139,24 @@ describe("runApiSubcommand", () => {
     expect(fake.request).toHaveBeenCalledWith("task.list")
     expect(fake.closed).toBe(1)
     expect(JSON.parse(stdoutText())).toHaveProperty("tasks")
+  })
+
+  test("an unverified session identity rides the verb's own JSON result (issue #24)", async () => {
+    // The degrade must be VISIBLE: stderr carries one JSON error envelope by
+    // contract, so a plain-text warning there would corrupt it — the notice
+    // goes on stdout, attached to the successful result.
+    fake.request.mockResolvedValue({ tasks: [] })
+    await verifiedSelfSession(
+      { KOBE_TASK_ID: "boccha", KOBE_TAB_ID: "tab-1" },
+      {
+        pid: 500,
+        sessions: async () => [{ key: "boccha::tab-1", pid: 100, alive: true }],
+        ps: async () => "  100     1 /bin/zsh -il\n  500     1 bun kobe api list",
+      },
+    )
+    await runApiSubcommand(["list"])
+    expect(stderrSpy).not.toHaveBeenCalled()
+    expect(JSON.parse(stdoutText()).identityWarning).toContain("not running inside that tab")
   })
 
   test("a handler RPC failure is a JSON error with exit 1 — and the session still closes", async () => {

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -81,6 +81,7 @@ vi.mock("../../src/cli/api/pty-delivery.ts", () => ({
 }))
 
 import { defaultApiRuntime, deliverPrompt, invokeVerb } from "../../src/cli/api-cmd.ts"
+import { resetVerifiedSelfSession, verifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
 import type { DaemonRpc } from "../../src/cli/daemon-session.ts"
 
 beforeEach(() => {
@@ -113,7 +114,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks()
+  vi.restoreAllMocks()
   vi.unstubAllEnvs()
+  resetVerifiedSelfSession()
 })
 
 describe("defaultApiRuntime", () => {
@@ -294,10 +297,19 @@ describe("realPromptDeliveryOps (deliverPrompt with the default ops)", () => {
     )
   })
 
-  it("threads the CLI process's own $KOBE_TASK_ID as the new task's spawner", async () => {
+  it("threads the VERIFIED session as the new task's spawner", async () => {
     // An `add` run from inside another task's engine tab carries that task's
     // id; the coda then tells the new agent where to `send` its outcome.
     vi.stubEnv("KOBE_TASK_ID", "spawner-1")
+    vi.stubEnv("KOBE_TAB_ID", "tab-1")
+    await verifiedSelfSession(
+      { KOBE_TASK_ID: "spawner-1", KOBE_TAB_ID: "tab-1" },
+      {
+        pid: 500,
+        sessions: async () => [{ key: "spawner-1::tab-1", pid: 100, alive: true }],
+        ps: async () => "  100     1 /bin/zsh -il\n  500   100 bun kobe api add",
+      },
+    )
     await deliverPrompt(
       client,
       { id: "t1", kind: "task", worktreePath: "/wt/t1", vendor: "claude", repo: "/repo/x", newTask: true },
@@ -305,6 +317,30 @@ describe("realPromptDeliveryOps (deliverPrompt with the default ops)", () => {
     )
     expect(mocks.buildEngineSessionLaunch).toHaveBeenLastCalledWith(
       expect.objectContaining({ promptIntent: { kind: "new-task", prompt: "go", spawnerTaskId: "spawner-1" } }),
+    )
+  })
+
+  it("omits the spawner when $KOBE_TASK_ID was merely INHERITED (issue #24)", async () => {
+    // The coda is the one address that outlives the record — it is baked
+    // into the worker's own instructions, so a stranger's id here sends
+    // every future report to them. Unproven identity = no coda address.
+    vi.stubEnv("KOBE_TASK_ID", "boccha")
+    await verifiedSelfSession(
+      { KOBE_TASK_ID: "boccha", KOBE_TAB_ID: "tab-1" },
+      {
+        pid: 500,
+        sessions: async () => [{ key: "boccha::tab-1", pid: 100, alive: true }],
+        // Reparented to init: alive tab, but this process is not under it.
+        ps: async () => "  100     1 /bin/zsh -il\n  500     1 bun kobe api add",
+      },
+    )
+    await deliverPrompt(
+      client,
+      { id: "t1", kind: "task", worktreePath: "/wt/t1", vendor: "claude", repo: "/repo/x", newTask: true },
+      "go",
+    )
+    expect(mocks.buildEngineSessionLaunch).toHaveBeenLastCalledWith(
+      expect.objectContaining({ promptIntent: { kind: "new-task", prompt: "go", spawnerTaskId: undefined } }),
     )
   })
 

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -9,7 +9,13 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { invokeVerb } from "../../src/cli/api-cmd.ts"
-import { dispatcherEnvPayload } from "../../src/cli/api/dispatcher.ts"
+import {
+  type SelfSessionProbe,
+  dispatcherEnvPayload,
+  resetVerifiedSelfSession,
+  takeIdentityWarning,
+  verifiedSelfSession,
+} from "../../src/cli/api/dispatcher.ts"
 import { normalizeIndex } from "../../src/orchestrator/index/store-codec.ts"
 import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
 
@@ -22,33 +28,119 @@ function restoreEnv(name: string, saved: string | undefined): void {
   } else process.env[name] = saved
 }
 
+/**
+ * A pty host + process tree where THIS process (pid 500) descends from the
+ * session's shell — the shape a real `kobe api` call inside an engine tab
+ * has: tab shell → engine → its Bash tool → this CLI.
+ */
+function probeFor(
+  key: string,
+  opts: { shellPid?: number; alive?: boolean; detached?: boolean } = {},
+): SelfSessionProbe {
+  const shellPid = opts.shellPid ?? 100
+  return {
+    pid: 500,
+    sessions: async () => [{ key, pid: shellPid, alive: opts.alive ?? true }],
+    ps: async () =>
+      [
+        `  ${shellPid}     1 /bin/zsh -il`,
+        `  200 ${opts.detached ? 1 : shellPid} claude`,
+        "  500   200 bun kobe api add",
+      ].join("\n"),
+  }
+}
+
 beforeEach(() => {
+  resetVerifiedSelfSession()
+  takeIdentityWarning()
   // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
   delete process.env.KOBE_TASK_ID
   // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
   delete process.env.KOBE_TAB_ID
 })
 afterEach(() => {
+  resetVerifiedSelfSession()
   restoreEnv("KOBE_TASK_ID", savedTaskId)
   restoreEnv("KOBE_TAB_ID", savedTabId)
 })
 
-describe("dispatcherEnvPayload", () => {
-  it("carries both ids, floors a missing tab, and stays empty without a task id", () => {
-    expect(dispatcherEnvPayload({ KOBE_TASK_ID: "d1", KOBE_TAB_ID: "tab-4" })).toEqual({
-      dispatcherTaskId: "d1",
-      dispatcherTabId: "tab-4",
+describe("verifiedSelfSession (issue #24: env identity is inheritable, so it must be proven)", () => {
+  it("accepts the env when the named tab is alive AND owns this process", async () => {
+    expect(await verifiedSelfSession({ KOBE_TASK_ID: "d1", KOBE_TAB_ID: "tab-4" }, probeFor("d1::tab-4"))).toEqual({
+      taskId: "d1",
+      tabId: "tab-4",
     })
-    expect(dispatcherEnvPayload({ KOBE_TASK_ID: "d1" })).toEqual({ dispatcherTaskId: "d1", dispatcherTabId: "tab-1" })
-    expect(dispatcherEnvPayload({ KOBE_TAB_ID: "tab-4" })).toEqual({})
-    expect(dispatcherEnvPayload({})).toEqual({})
+  })
+
+  it("floors a missing tab id to the canonical tab-1 and verifies THAT", async () => {
+    expect(await verifiedSelfSession({ KOBE_TASK_ID: "d1" }, probeFor("d1::tab-1"))).toEqual({
+      taskId: "d1",
+      tabId: "tab-1",
+    })
+  })
+
+  it("REFUSES an inherited env: a detached background process no longer descends from the tab", async () => {
+    // The incident shape: a Claude Code background daemon forked out of
+    // boccha's tab-1, reparented to init, and kept exporting boccha's ids.
+    // The session is still perfectly alive — only the lineage is broken.
+    expect(
+      await verifiedSelfSession(
+        { KOBE_TASK_ID: "boccha", KOBE_TAB_ID: "tab-1" },
+        probeFor("boccha::tab-1", { detached: true }),
+      ),
+    ).toBeNull()
+    // The degrade is never silent — it rides the verb's JSON result.
+    expect(takeIdentityWarning()).toContain("not running inside that tab")
+  })
+
+  it("REFUSES when the named session is dead, absent, or the host is gone", async () => {
+    const env = { KOBE_TASK_ID: "d1", KOBE_TAB_ID: "tab-1" }
+    expect(await verifiedSelfSession(env, probeFor("d1::tab-1", { alive: false }))).toBeNull()
+    expect(await verifiedSelfSession(env, probeFor("other::tab-1"))).toBeNull()
+    expect(await verifiedSelfSession(env, { ...probeFor("d1::tab-1"), sessions: async () => [] })).toBeNull()
+  })
+
+  it("REFUSES when the process tree is unreadable — unverifiable is never trusted", async () => {
+    const probe: SelfSessionProbe = {
+      ...probeFor("d1::tab-1"),
+      ps: async () => {
+        throw new Error("ps failed")
+      },
+    }
+    expect(await verifiedSelfSession({ KOBE_TASK_ID: "d1" }, probe)).toBeNull()
+  })
+
+  it("stays silent (no warning) for a plain shell with no env at all", async () => {
+    expect(await verifiedSelfSession({}, probeFor("d1::tab-1"))).toBeNull()
+    expect(takeIdentityWarning()).toBeNull()
   })
 })
 
+describe("dispatcherEnvPayload", () => {
+  it("carries the verified pair, and stays empty when the env can't be proven", async () => {
+    expect(await dispatcherEnvPayload({ KOBE_TASK_ID: "d1", KOBE_TAB_ID: "tab-4" }, probeFor("d1::tab-4"))).toEqual({
+      dispatcherTaskId: "d1",
+      dispatcherTabId: "tab-4",
+    })
+    expect(await dispatcherEnvPayload({ KOBE_TASK_ID: "d1" }, probeFor("d1::tab-1"))).toEqual({
+      dispatcherTaskId: "d1",
+      dispatcherTabId: "tab-1",
+    })
+    expect(await dispatcherEnvPayload({ KOBE_TAB_ID: "tab-4" }, probeFor("d1::tab-1"))).toEqual({})
+    expect(await dispatcherEnvPayload({}, probeFor("d1::tab-1"))).toEqual({})
+    // The pollution case: real ids, real live tab, wrong process.
+    expect(await dispatcherEnvPayload({ KOBE_TASK_ID: "d1" }, probeFor("d1::tab-1", { detached: true }))).toEqual({})
+  })
+})
+
+/** Prime the verified-identity memo so `invokeVerb` runs no real pty/ps IO. */
+async function asSession(taskId: string, tabId: string, opts?: { detached?: boolean }): Promise<void> {
+  await verifiedSelfSession({ KOBE_TASK_ID: taskId, KOBE_TAB_ID: tabId }, probeFor(`${taskId}::${tabId}`, opts))
+}
+
 describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
   it("add sends the caller's task + tab to task.create", async () => {
-    process.env.KOBE_TASK_ID = "disp-1"
-    process.env.KOBE_TAB_ID = "tab-2"
+    await asSession("disp-1", "tab-2")
     const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
     await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })
     expect(client.requests[0].payload).toEqual({
@@ -59,7 +151,7 @@ describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
   })
 
   it("add without $KOBE_TAB_ID floors the tab to the canonical tab-1", async () => {
-    process.env.KOBE_TASK_ID = "disp-1"
+    await verifiedSelfSession({ KOBE_TASK_ID: "disp-1" }, probeFor("disp-1::tab-1"))
     const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
     await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })
     expect(client.requests[0].payload).toMatchObject({ dispatcherTaskId: "disp-1", dispatcherTabId: "tab-1" })
@@ -71,9 +163,34 @@ describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
     expect(client.requests[0].payload).toEqual({ repo: "/repo/x" })
   })
 
+  it("add with an INHERITED env records no dispatcher at all (issue #24)", async () => {
+    // Every field is real — boccha's task exists, its tab-1 is alive — but
+    // this process was forked out of it days ago and detached. Recording
+    // {boccha, tab-1} here is what sent finished workers' reports to a
+    // stranger; the honest record is NO record.
+    await asSession("boccha", "tab-1", { detached: true })
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })
+    expect(client.requests[0].payload).toEqual({ repo: "/repo/x" })
+  })
+
+  it("a parallel `add --count` round with an inherited env records no dispatcher on any sibling", async () => {
+    await asSession("boccha", "tab-1", { detached: true })
+    const client = new FakeClient({
+      "task.create": (_payload, i) => ({ taskId: `t${i}`, task: taskFixture({ id: `t${i}` }) }),
+    })
+    const { deliver } = recordingDelivery()
+    await invokeVerb("add", ["--repo", "/repo/x", "--count", "2", "--prompt", "go"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    for (const create of client.requests.filter((r) => r.name === "task.create")) {
+      expect(create.payload).not.toHaveProperty("dispatcherTaskId")
+    }
+  })
+
   it("a parallel `add --count` round records the same dispatcher on every sibling", async () => {
-    process.env.KOBE_TASK_ID = "disp-1"
-    process.env.KOBE_TAB_ID = "tab-3"
+    await asSession("disp-1", "tab-3")
     const client = new FakeClient({
       "task.create": (_payload, i) => ({ taskId: `t${i}`, task: taskFixture({ id: `t${i}` }) }),
     })
@@ -101,9 +218,8 @@ describe("bare send replies to the dispatcher", () => {
     })
   }
 
-  beforeEach(() => {
-    process.env.KOBE_TASK_ID = "worker-1"
-    process.env.KOBE_TAB_ID = "tab-9"
+  beforeEach(async () => {
+    await asSession("worker-1", "tab-9")
   })
 
   it("lands on the dispatcher's exact tab when it is alive", async () => {
@@ -201,6 +317,28 @@ describe("bare send replies to the dispatcher", () => {
     await invokeVerb("send", ["--prompt", "hi"], { client, runtime: stubRuntime({ deliverPrompt: deliver }) })
     expect(client.subscribeCount).toBe(1)
     expect(calls[0].target.id).toBe("active-1")
+  })
+
+  it("an INHERITED env falls back to the active task instead of the stranger's dispatcher", async () => {
+    await asSession("worker-1", "tab-9", { detached: true })
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    client.replay.push({ channel: "active-task", payload: { taskId: "active-1" } })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--prompt", "hi"], { client, runtime: stubRuntime({ deliverPrompt: deliver }) })
+    // worker-1's own dispatcher is never even looked up — this process has
+    // no proven identity, so it has no reply address to inherit.
+    expect(calls[0].target.id).toBe("active-1")
+  })
+
+  it("an INHERITED env sends no [KOBE PEER] prefix — impersonation is worse than anonymity", async () => {
+    await asSession("worker-1", "tab-9", { detached: true })
+    const client = workerClient({ taskId: "disp-1", tabId: "tab-2" })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "disp-1", "--prompt", "hi"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(calls[0].prompt).toBe("hi")
   })
 
   it("the [KOBE PEER] reply command is tab-precise (sender's $KOBE_TAB_ID)", async () => {

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -110,6 +110,16 @@ describe("verifiedSelfSession (issue #24: env identity is inheritable, so it mus
     expect(await verifiedSelfSession({ KOBE_TASK_ID: "d1" }, probe)).toBeNull()
   })
 
+  it("the warning is read-and-CLEAR, and a verified resolution leaves none behind", async () => {
+    await verifiedSelfSession({ KOBE_TASK_ID: "d1" }, probeFor("d1::tab-1", { detached: true }))
+    expect(takeIdentityWarning()).toBeTruthy()
+    // One notice per degrade: a second read must not re-warn a later verb.
+    expect(takeIdentityWarning()).toBeNull()
+    await verifiedSelfSession({ KOBE_TASK_ID: "d1" }, probeFor("d1::tab-1", { detached: true }))
+    await verifiedSelfSession({ KOBE_TASK_ID: "d1" }, probeFor("d1::tab-1"))
+    expect(takeIdentityWarning()).toBeNull()
+  })
+
   it("stays silent (no warning) for a plain shell with no env at all", async () => {
     expect(await verifiedSelfSession({}, probeFor("d1::tab-1"))).toBeNull()
     expect(takeIdentityWarning()).toBeNull()

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { ApiError, type ApiRuntime, invokeVerb } from "../../src/cli/api-cmd.ts"
+import { resetVerifiedSelfSession, verifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
 import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
 
 // Peer provenance AND dispatcher provenance both key off the caller's own
@@ -242,10 +243,22 @@ describe("send handler", () => {
 
   describe("peer provenance ($KOBE_TASK_ID)", () => {
     const saved = process.env.KOBE_TASK_ID
-    beforeEach(() => {
+    beforeEach(async () => {
       process.env.KOBE_TASK_ID = "sender-1"
+      // Identity is the VERIFIED env pair (issue #24) — prime the memo with a
+      // process tree where this process really does descend from the tab's
+      // shell, so no real pty-host/ps read happens here.
+      await verifiedSelfSession(
+        { KOBE_TASK_ID: "sender-1", KOBE_TAB_ID: "tab-1" },
+        {
+          pid: 500,
+          sessions: async () => [{ key: "sender-1::tab-1", pid: 100, alive: true }],
+          ps: async () => "  100     1 /bin/zsh -il\n  500   100 bun kobe api send",
+        },
+      )
     })
     afterEach(() => {
+      resetVerifiedSelfSession()
       if (saved === undefined) {
         // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
         delete process.env.KOBE_TASK_ID
@@ -310,6 +323,7 @@ describe("send handler", () => {
     })
 
     it("a send from outside any kobe task stays untouched", async () => {
+      resetVerifiedSelfSession()
       // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
       delete process.env.KOBE_TASK_ID
       const { calls, deliver } = recordingDelivery()

--- a/packages/kobe/test/engine/foreground.test.ts
+++ b/packages/kobe/test/engine/foreground.test.ts
@@ -3,6 +3,7 @@ import {
   engineProcessIn,
   foregroundEngine,
   foregroundEngineIn,
+  hasAncestor,
   parsePsSnapshot,
   vendorFromArgv,
 } from "../../src/engine/foreground.ts"
@@ -130,5 +131,33 @@ describe("foregroundEngine", () => {
         throw new Error("ps: command not found")
       }),
     ).toBeNull()
+  })
+})
+
+describe("hasAncestor (issue #24: env inherits, a pid chain doesn't)", () => {
+  // A tab shell (10) → engine (11) → its tool shell (12) → this CLI (13),
+  // plus a sibling (20) that detached out of the same shell days ago and
+  // reparented to init — it still carries the tab's exported env.
+  const rows = parsePsSnapshot(`
+10 1 /bin/zsh -il
+11 10 claude
+12 11 /bin/zsh -c kobe api add
+13 12 bun /kobe/api add
+20 1 claude --fork-session
+`)
+
+  it("is true for a real in-tab call at any depth, and for the shell itself", () => {
+    expect(hasAncestor(rows, 13, 10)).toBe(true)
+    expect(hasAncestor(rows, 11, 10)).toBe(true)
+    expect(hasAncestor(rows, 10, 10)).toBe(true)
+  })
+
+  it("is false for a detached process that merely inherited the env", () => {
+    expect(hasAncestor(rows, 20, 10)).toBe(false)
+  })
+
+  it("is false for an unknown pid, and terminates on a cyclic snapshot", () => {
+    expect(hasAncestor(rows, 999, 10)).toBe(false)
+    expect(hasAncestor(parsePsSnapshot("30 31 a\n31 30 b"), 30, 10)).toBe(false)
   })
 })


### PR DESCRIPTION
Fixes issue #24 — dispatcher/peer addresses were unverifiable, so finished workers reported to unrelated sessions.

## Root cause

`$ROVE_TASK_ID`/`$ROVE_TAB_ID` are exported into every engine tab, and an environment variable is inherited by every descendant process — unconditionally, forever. A Claude Code background process that detached out of one tab (ppid reparented to 1) kept exporting that tab's ids for 12 days. Every task it later created stamped `dispatcher: {stranger, tab-1}`, and every worker's bare `send` delivered its outcome there.

Four sites trusted the raw env: `add` (single + parallel), `send`'s peer provenance, and the new-task coda that bakes a reply address into the worker's own instructions.

## Fix — cross-check against the live session registry

One verified accessor (`verifiedSelfSession`) that all four route through. The env is believed only when **both** hold:

1. `<taskId>::<tabId>` is a session the pty host lists as **alive**, and
2. that session's shell pid is an **ancestor** of the calling process (`hasAncestor`, new in `engine/foreground.ts`).

(2) is what an inherited env cannot fake — a detached process reparents to init and stops reaching the tab's shell, while a genuine in-tab `rove api` call (tab shell → engine → its Bash tool → this CLI) always does. Note (1) alone would NOT have caught the incident: the polluting process named a perfectly alive tab.

Unverifiable is unverified (no host, no `ps`, killed tab): no dispatcher, no `[KOBE PEER]` provenance, no spawner coda. Recording a wrong reply address is strictly worse than recording none — the wrong one delivers, to someone else.

## Not a silent degrade

stderr carries exactly one JSON error envelope by contract, so the notice rides the verb's own stdout result as `identityWarning` instead. Memoized: one `pty.list` + one `ps` per CLI process.

## Verification

- 3173 fast tests green, typecheck + root biome clean.
- New coverage for the inheritance-pollution case at every layer: `verifiedSelfSession` accept/refuse, `hasAncestor` (in-tab at depth vs. detached sibling), `add` and `add --count` recording nothing, bare `send` falling back to the active task instead of the stranger's dispatcher, no `[KOBE PEER]` impersonation, coda omitting the spawner, and the warning reaching stdout.
- Live-checked against a real session both directions: an in-tab call verifies (`{taskId, tabId}`); a process spawned then reparented to init with the identical env is refused with the warning.

## Scope

Dispatcher record/verify chain + tests only. Engine launch path (#25) and skill files untouched.