### PR TITLE
feat: shell tabs carry a live engine identity (#33 step 1)

### DIFF
--- a/.changeset/live-vendor-shell-tabs.md
+++ b/.changeset/live-vendor-shell-tabs.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Shell tabs now carry a live engine identity (issue #33 step 1): the sidebar probes every hosted session's process tree — not just tabs mounted in this TUI — so a hand-typed `claude`/`codex` in any shell tab lights an engine badge on its row, and dims when the engine exits (debounced against mid-restart flicker). `rove api get-task`'s per-tab `liveVendor` now reflects a fresh foreground walk for live tabs instead of the last TUI-recorded value.

--- a/docs/API.md
+++ b/docs/API.md
@@ -108,6 +108,10 @@ replacement in `nextCommandArgs`.
   hosted engine tabs is live (not just the first); `.tabs` = the task's
   terminal tabs (`id`/`kind`/`title`/`vendor`/`liveVendor`/`lastTitle`/
   `autoTitle` + per-tab `alive`) — the discovery read for `send --tab tab-N`.
+  `liveVendor` on a live tab is a fresh foreground process walk (which
+  engine actually runs in the tab's shell right now — a hand-typed `claude`
+  in a shell tab counts, a ctrl+C'd engine doesn't); dead tabs report the
+  last recorded value.
   A dead tab whose session ended abnormally also carries `exit`
   (`code`/`signal`/`at`); clean exits stay `exit: null`. A live PTY session
   the persisted snapshot does not list still gets a row, marked

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -170,7 +170,7 @@ export const defaultApiRuntime: ApiRuntime = {
   taskTabs: async (taskId) => {
     // No host = no sessions, an honest "nothing alive"; the persisted tabs
     // still return so a stopped task's layout stays inspectable.
-    let sessions: readonly TaskSessionRow[] = []
+    let sessions: readonly (TaskSessionRow & { pid?: number | null })[] = []
     const host = await openPtyHost()
     if (host) {
       try {
@@ -178,6 +178,21 @@ export const defaultApiRuntime: ApiRuntime = {
       } finally {
         host.close()
       }
+    }
+    // Live foreground-walk verdicts per session (issue #33): ONE ps snapshot,
+    // the same shallowest-engine walk inspect/live-engine run — so get-task's
+    // `liveVendor` reflects what runs NOW, not what a mounted TUI last
+    // recorded. Best-effort: a failed ps just keeps the recorded values.
+    let liveVendors: Map<string, string | null> | undefined
+    try {
+      const { foregroundEngineIn, parsePsSnapshot, psSnapshot } = await import("../../engine/foreground.ts")
+      const walkable = sessions.filter((s) => s.alive && typeof s.pid === "number" && s.pid > 0)
+      if (walkable.length > 0) {
+        const rows = parsePsSnapshot(await psSnapshot())
+        liveVendors = new Map(walkable.map((s) => [s.key, foregroundEngineIn(rows, s.pid as number)?.vendor ?? null]))
+      }
+    } catch {
+      /* recorded liveVendor stays */
     }
     // Durable death records outlive the host's idle-exit — a crashed tab
     // still reports its cause here. Best-effort: unreadable = none.
@@ -189,7 +204,7 @@ export const defaultApiRuntime: ApiRuntime = {
     }
     const snapshot = readTabsSnapshot(taskId)
     return {
-      tabs: joinTaskTabs(snapshot, taskId, sessions, exits),
+      tabs: joinTaskTabs(snapshot, taskId, sessions, exits, liveVendors),
       running: hasLiveEngineTab(snapshot, taskId, sessions),
     }
   },

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -108,24 +108,35 @@ const abnormalExit = (exit: PtySessionExit | null | undefined): PtySessionExit |
  * `persistedExits` (the durable `pty-exits.json` records, keyed by session
  * key) answers "how did it die" after the host itself is gone; a live host's
  * in-memory exit wins when both exist.
+ *
+ * `liveVendors` (issue #33) is a fresh foreground-walk verdict per session
+ * key — the same tri-state the TUI's live-engine store speaks: a vendor =
+ * that engine runs under the session's shell NOW, null = walked and
+ * engine-free, absent = couldn't look. Where it answers it overrides the
+ * RECORDED `liveVendor` (a snapshot written only by a mounted TUI, so it
+ * goes stale for tasks never opened): a user-typed `claude` in a shell tab
+ * reads as live claude, and a ctrl+C'd engine reads as a plain shell. A
+ * dead session's verdict is meaningless — only alive rows take it.
  */
 export function joinTaskTabs(
   snapshot: TabsState | undefined,
   taskId: string,
   sessions: readonly TaskSessionRow[],
   persistedExits: Readonly<Record<string, PtySessionExit>> = {},
+  liveVendors?: ReadonlyMap<string, string | null>,
 ): TaskTabRow[] {
   const alive = aliveKeysOf(sessions)
   const sessionExits = new Map(sessions.map((s) => [s.key, s.exit]))
   const rows: TaskTabRow[] = (snapshot?.tabs ?? []).map((t) => {
     const key = `${taskId}::${t.id}`
     const isAlive = alive.has(key)
+    const walked = isAlive && liveVendors?.has(key) === true ? (liveVendors.get(key) ?? null) : undefined
     return {
       id: t.id,
       kind: t.kind,
       title: t.title ?? null,
       vendor: (t as { vendor?: string }).vendor ?? null,
-      liveVendor: t.liveVendor ?? null,
+      liveVendor: walked !== undefined ? walked : (t.liveVendor ?? null),
       lastTitle: t.lastTitle ?? null,
       autoTitle: t.autoTitle ?? null,
       alive: isAlive,

--- a/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
@@ -29,6 +29,9 @@ export interface LiveSession {
   readonly alive?: boolean
   /** OSC window title of the live process, when the host observed one. */
   readonly title?: string | null
+  /** Shell pid of the hosted session — roots the live-engine probe's
+   *  process-tree walk for tabs this TUI never attached (issue #33). */
+  readonly pid?: number | null
 }
 
 /**

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -13,6 +13,7 @@ import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator
 import type { Task } from "@/types/task"
 import { type BoxRenderable, MouseButton } from "@opentui/core"
 import { type ReactNode, useEffect } from "react"
+import { engineEntry } from "../../../engine/registry"
 import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
 import { NO_STATE_GLYPH, buildSidebarRowView, prCheckChip, withSpinnerFrame } from "../../../tui/panes/sidebar/row-view"
 import { type TreeTab, tabRowActivity } from "../../../tui/panes/sidebar/tree-core"
@@ -263,6 +264,16 @@ export function TabTreeRow(props: {
         <text fg={theme.textMuted} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
           {props.tab.label}
         </text>
+        {props.tab.liveVendor ? (
+          // Engine badge for a shell tab whose live foreground is a CONFIRMED
+          // engine (issue #33) — name from the engine registry, never a
+          // hard-coded vendor string. Accent-colored: the badge is the "an
+          // agent is live here" signal, the state glyph beside it says what
+          // it's doing.
+          <text fg={theme.accent} wrapMode="none" flexShrink={0}>
+            {`⚡${engineEntry(props.tab.liveVendor).identity?.shortName ?? engineEntry(props.tab.liveVendor).displayName}`}
+          </text>
+        ) : null}
         <JumpDigit flatIndex={props.flatIndex} dim={!isCursor} />
       </box>
     </RowShell>

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -89,6 +89,21 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   // Live pty-host inventory, for tasks the snapshot can't answer for.
   const hostSessions = useHostSessions()
 
+  // Feed the host inventory's pids into the live-engine probe (issue #33):
+  // the local PTY registry only knows tabs THIS process attached, but the
+  // tree renders every task's hosted tabs — without the aux pids a `claude`
+  // typed into another task's shell tab never lit up until you visited it.
+  useEffect(() => {
+    const pids = new Map<string, number>()
+    for (const session of hostSessions) {
+      if (session.alive !== false && typeof session.pid === "number" && session.pid > 0) {
+        pids.set(session.key, session.pid)
+      }
+    }
+    liveEngines.setAuxPids(pids)
+    return () => liveEngines.setAuxPids(new Map())
+  }, [hostSessions, liveEngines])
+
   // ptyKey → the host's LIVE OSC title. The host scans every session's
   // output whether or not anyone attached, so this answers for tabs whose
   // `TerminalTabs` is not mounted — the ones whose recorded `lastTitle`
@@ -149,6 +164,10 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
             // re-mounts, and demoting the row to a plain dot for that gap
             // reads as a lie.
             engine: tab.kind === "engine" || (live ?? null) !== null,
+            // Engine badge for SHELL tabs only (issue #33): a shell whose
+            // foreground is a confirmed engine wears that engine's badge;
+            // engine-born tabs already name their engine in the label.
+            ...(tab.kind !== "engine" && live ? { liveVendor: live } : {}),
           }
         }),
       )

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -21,6 +21,7 @@
  */
 
 import type { Task } from "@/types/task"
+import type { VendorId } from "@/types/vendor"
 import { fuzzyMatch } from "./fuzzy"
 import { repoBasename, sidebarProjectKey } from "./groups"
 
@@ -41,6 +42,11 @@ export interface TreeTab {
   /** A coding-agent tab. Shell/command/content tabs are outside the state
    *  vocabulary entirely — they always wear the plain dot. */
   readonly engine?: boolean
+  /** CONFIRMED live engine identity of a SHELL tab (issue #33): the process
+   *  walk found this vendor running in the tab right now. Drives the row's
+   *  engine badge; engine-born tabs never set it — their label already names
+   *  the engine, a badge would repeat it. */
+  readonly liveVendor?: VendorId
 }
 
 export type TreeRow =

--- a/packages/kobe/src/tui/workspace/live-engine.ts
+++ b/packages/kobe/src/tui/workspace/live-engine.ts
@@ -40,6 +40,17 @@ export interface LiveEngineStore {
    * cover the spawn window without also resurrecting a dead engine's name.
    */
   resolve(key: string): VendorId | null | undefined
+  /**
+   * Auxiliary ptyKey → shell pid pairs to probe ALONGSIDE the local PTY
+   * registry (issue #33): the registry only knows PTYs this process
+   * attached, but the sidebar tree renders every task's hosted tabs — the
+   * pty host's `pty.list` inventory carries their pids, and feeding them
+   * here lights a shell-turned-agent row for tasks never opened in this
+   * TUI. Hosted sessions only, by construction — the map's source is the
+   * host's own inventory, so a foreign terminal can never be probed.
+   * A key present in both sources uses the registry's pid.
+   */
+  setAuxPids(pids: ReadonlyMap<string, number>): void
   /** Subscribe to identity changes (fires when any key's vendor moved). */
   subscribe(listener: () => void): () => void
   /** Run one probe pass now — the interval calls this; tests await it. */
@@ -52,16 +63,30 @@ export type LiveEngineOpts = {
   snapshot?: PsSnapshot
   /** Engines start and stop on human timescales — one `ps` every 2s. */
   intervalMs?: number
+  /**
+   * Debounce for the OFF edge (issue #33): a lit identity goes dark only
+   * after this many CONSECUTIVE engine-free walks. Engines briefly show an
+   * empty tree mid-restart (claude relaunching after /login, a wrapper
+   *  re-exec), and a 1-probe flicker would strobe the sidebar badge. The ON
+   * edge stays immediate — lighting up needs no debounce, the walk only
+   * answers a vendor on positive argv evidence.
+   */
+  releaseAfterMisses?: number
 }
 
 export function createLiveEngines(opts: LiveEngineOpts = {}): LiveEngineStore {
   const entries = opts.entries ?? (() => getDefaultPtyRegistry().entries())
   const snapshot = opts.snapshot ?? psSnapshot
+  const releaseAfterMisses = Math.max(1, opts.releaseAfterMisses ?? 2)
   const vendors = new Map<string, VendorId>()
+  /** Consecutive engine-free walks per lit key — the OFF-edge debounce. */
+  const misses = new Map<string, number>()
   /** Keys the last successful probe actually walked — the resolve() tri-state:
    *  in here with no vendor means "shell confirmed engine-free", absent means
    *  "couldn't look" (no PTY / no pid / ps failed). */
   const answered = new Set<string>()
+  /** Hosted-session pids the local registry can't see — see setAuxPids. */
+  let auxPids: ReadonlyMap<string, number> = new Map()
   const listeners = new Set<() => void>()
   let disposed = false
 
@@ -74,9 +99,16 @@ export function createLiveEngines(opts: LiveEngineOpts = {}): LiveEngineStore {
       if (disposed) return
       const pids = new Map<string, number>()
       const live = new Set<string>()
+      for (const [key, pid] of auxPids) {
+        live.add(key)
+        pids.set(key, pid)
+      }
       for (const [key, pty] of entries()) {
         live.add(key)
         const pid = pty.shellPid ?? null
+        // The registry's attached PTY outranks the host inventory's row for
+        // the same key — but an attached-yet-unspawned PTY (pid null) must
+        // not erase a host pid we can walk.
         if (pid !== null) pids.set(key, pid)
       }
       let changed = false
@@ -85,6 +117,7 @@ export function createLiveEngines(opts: LiveEngineOpts = {}): LiveEngineStore {
       for (const key of [...vendors.keys()]) {
         if (live.has(key) && pids.has(key)) continue
         vendors.delete(key)
+        misses.delete(key)
         changed = true
       }
       for (const key of [...answered]) {
@@ -104,9 +137,23 @@ export function createLiveEngines(opts: LiveEngineOpts = {}): LiveEngineStore {
           const vendor = foregroundEngineIn(rows, pid)?.vendor ?? null
           answered.add(key)
           const prev = vendors.get(key) ?? null
-          if (prev === vendor) continue
-          if (vendor) vendors.set(key, vendor)
-          else vendors.delete(key)
+          if (vendor) {
+            misses.delete(key)
+            if (prev === vendor) continue
+            vendors.set(key, vendor)
+            changed = true
+            continue
+          }
+          if (prev === null) continue
+          // OFF-edge debounce: hold a lit identity through brief engine-free
+          // walks; only consecutive misses confirm the exit.
+          const count = (misses.get(key) ?? 0) + 1
+          if (count < releaseAfterMisses) {
+            misses.set(key, count)
+            continue
+          }
+          misses.delete(key)
+          vendors.delete(key)
           changed = true
         }
       }
@@ -120,6 +167,9 @@ export function createLiveEngines(opts: LiveEngineOpts = {}): LiveEngineStore {
       if (vendor) return vendor
       return answered.has(key) ? null : undefined
     },
+    setAuxPids(pids) {
+      auxPids = pids
+    },
     subscribe(listener) {
       listeners.add(listener)
       return () => {
@@ -130,6 +180,7 @@ export function createLiveEngines(opts: LiveEngineOpts = {}): LiveEngineStore {
       disposed = true
       listeners.clear()
       vendors.clear()
+      misses.clear()
       answered.clear()
       clearInterval(handle)
     },

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -245,6 +245,39 @@ describe("joinTaskTabs", () => {
     ])
   })
 
+  const vendorSnap = (tabs: unknown[]): TabsState =>
+    ({ tabs, activeId: "tab-1", nextOrdinal: tabs.length + 1 }) as unknown as TabsState
+
+  it("a live foreground-walk verdict overrides the recorded liveVendor (issue #33)", () => {
+    const snap = vendorSnap([
+      { kind: "command", id: "tab-1", title: null, ordinal: 1 }, // shell, user typed claude
+      { kind: "engine", id: "tab-2", title: null, ordinal: 2, liveVendor: "codex" }, // ctrl+C'd
+      { kind: "engine", id: "tab-3", title: null, ordinal: 3, liveVendor: "codex" }, // not walked
+    ])
+    const rows = joinTaskTabs(
+      snap,
+      "t1",
+      [
+        { key: "t1::tab-1", alive: true },
+        { key: "t1::tab-2", alive: true },
+        { key: "t1::tab-3", alive: true },
+      ],
+      {},
+      new Map([
+        ["t1::tab-1", "claude"], // shell running a live engine → lights up
+        ["t1::tab-2", null], // walked, engine-free → goes dark
+        // tab-3 absent: couldn't look → recorded value stands
+      ]),
+    )
+    expect(rows.map((r) => r.liveVendor)).toEqual(["claude", null, "codex"])
+  })
+
+  it("a dead tab never takes a walk verdict — recorded liveVendor stands", () => {
+    const snap = vendorSnap([{ kind: "engine", id: "tab-1", title: null, ordinal: 1, liveVendor: "claude" }])
+    const rows = joinTaskTabs(snap, "t1", [{ key: "t1::tab-1", alive: false }], {}, new Map([["t1::tab-1", null]]))
+    expect(rows[0]?.liveVendor).toBe("claude")
+  })
+
   it("a task with no snapshot still lists its live sessions as unregistered rows", () => {
     // Before issue #20 this returned [] — an alive engine invisible to the
     // discovery read.

--- a/packages/kobe/test/tui/live-engine.test.ts
+++ b/packages/kobe/test/tui/live-engine.test.ts
@@ -41,7 +41,11 @@ describe("createLiveEngines", () => {
 
   it("releases the identity when the engine exits back to the prompt", async () => {
     let tree = TREE
-    const store = createLiveEngines({ entries: () => [["a", pty(100)]], snapshot: async () => tree })
+    const store = createLiveEngines({
+      entries: () => [["a", pty(100)]],
+      snapshot: async () => tree,
+      releaseAfterMisses: 1,
+    })
     await store.probe()
     expect(store.get("a")).toBe("claude")
 
@@ -51,6 +55,53 @@ describe("createLiveEngines", () => {
     await store.probe()
     expect(store.get("a")).toBeNull()
     expect(notified).toBe(1)
+    store.dispose()
+  })
+
+  it("debounces the OFF edge: one engine-free walk holds, consecutive misses release", async () => {
+    let tree = TREE
+    const store = createLiveEngines({
+      entries: () => [["a", pty(100)]],
+      snapshot: async () => tree,
+      releaseAfterMisses: 2,
+    })
+    await store.probe()
+    expect(store.get("a")).toBe("claude")
+
+    // A single engine-free walk (engine mid-restart) must not strobe the badge.
+    tree = IDLE
+    await store.probe()
+    expect(store.get("a")).toBe("claude")
+
+    // The engine came back — the miss counter resets.
+    tree = TREE
+    await store.probe()
+    expect(store.get("a")).toBe("claude")
+    tree = IDLE
+    await store.probe()
+    expect(store.get("a")).toBe("claude")
+
+    // Second consecutive miss: the exit is real.
+    await store.probe()
+    expect(store.get("a")).toBeNull()
+    store.dispose()
+  })
+
+  it("probes aux (host-inventory) pids the local registry doesn't know", async () => {
+    const store = createLiveEngines({
+      entries: () => [],
+      snapshot: async () => TREE,
+      releaseAfterMisses: 1,
+    })
+    store.setAuxPids(new Map([["t1::tab-2", 100]]))
+    await store.probe()
+    expect(store.get("t1::tab-2")).toBe("claude")
+    expect(store.resolve("t1::tab-2")).toBe("claude")
+
+    // Aux key gone (session died / inventory refreshed) → identity released.
+    store.setAuxPids(new Map())
+    await store.probe()
+    expect(store.resolve("t1::tab-2")).toBeUndefined()
     store.dispose()
   })
 
@@ -77,7 +128,7 @@ describe("createLiveEngines", () => {
       ["b", pty(200)],
       ["c", pty(null)], // attached but unspawned — nothing to walk
     ]
-    const store = createLiveEngines({ entries: () => live, snapshot: async () => tree })
+    const store = createLiveEngines({ entries: () => live, snapshot: async () => tree, releaseAfterMisses: 1 })
     await store.probe()
     expect(store.resolve("a")).toBe("claude") // engine live
     expect(store.resolve("b")).toBeNull() // shell walked, confirmed engine-free


### PR DESCRIPTION
Issue #33 (daemon issue store) PR-1 of 3 — tab-level engine identity as a live property.

## What

- **Live-engine probe covers every hosted session** (`live-engine.ts` + `use-tree-state.ts`): the sidebar feeds the pty host inventory's pids into the probe as auxiliary roots, so a hand-typed `claude`/`codex` in ANY task's shell tab is detected — not just tabs this TUI attached. Hosted PTYs only, by construction (aux keys come from `pty.list`); foreign terminals are unreachable.
- **OFF-edge debounce**: a lit identity survives one engine-free walk (engine mid-restart / wrapper re-exec) and goes dark on the second consecutive miss. ON edge stays immediate — the walk only answers on positive argv evidence (`foregroundEngineIn`, shallowest-engine BFS; nested shells/ssh/tmux stay unidentified, same conservatism as before).
- **Sidebar badge**: a shell tab whose confirmed live foreground is an engine wears `⚡<shortName>` (from the engine registry's `identity` — no hard-coded vendor strings) beside its label; engine-born tabs don't repeat their own name. The badge follows the foreground: engine exits → badge drops (after debounce).
- **`rove api get-task` / `collect`**: per-tab `liveVendor` on a live tab is now a fresh foreground walk (one `ps` snapshot for all sessions) instead of the persisted twin only a mounted TUI ever wrote. Dead tabs keep the recorded value. Docs updated (`docs/API.md`).

## What this deliberately reuses

- `foregroundEngineIn` walk — the same primitive `api inspect` and the daemon activity observer already run (#462's tier machinery).
- The existing `liveVendor` tri-state contract (vendor / confirmed-null / can't-look) — no new fields on the wire.
- The tree's existing `engine` row logic — the badge is additive.

## Not in this PR

- Scratch section + temp shell tasks (PR-2), sidebar IA convergence (PR-3).
- Vendor-session-file sniff (`protocol-sniff.ts`) stays unwired for tab identity: argv walk already answers with higher confidence for live processes; session files can outlive the engine that wrote them (its own header says so). If title/session sniff should ALSO feed tab identity, that's issue #31's record-upgrade path.

## Tests

- `live-engine.test.ts`: OFF-edge debounce, aux-pid probing, release on inventory drop.
- `api-tab-snapshot.test.ts`: walk verdict overrides recorded `liveVendor` (lights a shell, darkens a ctrl+C'd engine, absent = recorded stands); dead tabs never take a verdict.

Typecheck, root lint, and full unit track green locally.