### PR TITLE
fix: drop the sidebar ⚡ engine badge, keep the liveVendor data layer

### DIFF
--- a/.changeset/remove-livevendor-badge.md
+++ b/.changeset/remove-livevendor-badge.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Remove the sidebar ⚡ engine badge introduced with the live shell-tab identity: the row label already tracks the live OSC title, so the badge was a second parallel channel for the same information — and it lit redundantly on engine tabs running their own vendor. The data layer stays: `liveVendor` still feeds get-task/tab-snapshot from the live foreground walk, and a shell tab with a confirmed engine still renders through the same row path as an engine tab.

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -13,7 +13,6 @@ import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator
 import type { Task } from "@/types/task"
 import { type BoxRenderable, MouseButton } from "@opentui/core"
 import { type ReactNode, useEffect } from "react"
-import { engineEntry } from "../../../engine/registry"
 import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
 import { NO_STATE_GLYPH, buildSidebarRowView, prCheckChip, withSpinnerFrame } from "../../../tui/panes/sidebar/row-view"
 import { type TreeTab, tabRowActivity } from "../../../tui/panes/sidebar/tree-core"
@@ -264,16 +263,6 @@ export function TabTreeRow(props: {
         <text fg={theme.textMuted} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
           {props.tab.label}
         </text>
-        {props.tab.liveVendor ? (
-          // Engine badge for a shell tab whose live foreground is a CONFIRMED
-          // engine (issue #33) — name from the engine registry, never a
-          // hard-coded vendor string. Accent-colored: the badge is the "an
-          // agent is live here" signal, the state glyph beside it says what
-          // it's doing.
-          <text fg={theme.accent} wrapMode="none" flexShrink={0}>
-            {`⚡${engineEntry(props.tab.liveVendor).identity?.shortName ?? engineEntry(props.tab.liveVendor).displayName}`}
-          </text>
-        ) : null}
         <JumpDigit flatIndex={props.flatIndex} dim={!isCursor} />
       </box>
     </RowShell>

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -164,10 +164,6 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
             // re-mounts, and demoting the row to a plain dot for that gap
             // reads as a lie.
             engine: tab.kind === "engine" || (live ?? null) !== null,
-            // Engine badge for SHELL tabs only (issue #33): a shell whose
-            // foreground is a confirmed engine wears that engine's badge;
-            // engine-born tabs already name their engine in the label.
-            ...(tab.kind !== "engine" && live ? { liveVendor: live } : {}),
           }
         }),
       )

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -21,7 +21,6 @@
  */
 
 import type { Task } from "@/types/task"
-import type { VendorId } from "@/types/vendor"
 import { fuzzyMatch } from "./fuzzy"
 import { repoBasename, sidebarProjectKey } from "./groups"
 
@@ -42,11 +41,6 @@ export interface TreeTab {
   /** A coding-agent tab. Shell/command/content tabs are outside the state
    *  vocabulary entirely — they always wear the plain dot. */
   readonly engine?: boolean
-  /** CONFIRMED live engine identity of a SHELL tab (issue #33): the process
-   *  walk found this vendor running in the tab right now. Drives the row's
-   *  engine badge; engine-born tabs never set it — their label already names
-   *  the engine, a badge would repeat it. */
-  readonly liveVendor?: VendorId
 }
 
 export type TreeRow =


### PR DESCRIPTION
Owner verdict after dev:sandbox testing of #470: the ⚡ badge was a second parallel channel for information the row label already carries (the label follows the live OSC title, #445), and it lit redundantly on engine tabs running their own declared vendor ("Claude Co ⚡ Claude", truncating the title).

## What

- Removed: `TreeTab.liveVendor` projection (use-tree-state), the ⚡ badge render (tree-rows), and the field on the tree contract (tree-core).
- Kept (untouched): the `liveVendor` data pipeline — live foreground walk into `get-task`/`collect` per-tab rows, the aux-pid probing, OFF-edge debounce, and its tests.
- Kept: a shell tab whose foreground is a confirmed engine still renders through the SAME row path as an engine tab (the existing `engine:` flag + `tabTitleStable` naming) — no new visual element.

No behavior tests removed except none existed for the badge itself; the liveVendor data tests from #470 stay green.