### PR TITLE
fix: archive full-screen flash — move selection off the archived task (#34)

### DIFF
--- a/.changeset/archive-selection-flash.md
+++ b/.changeset/archive-selection-flash.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Archiving the selected task no longer flashes the screen or resurrects its engine: selection now moves off an archived/deleting task in the same snapshot tick, so its terminal unmounts instead of answering the PTY sweep with a dead-on-attach respawn (issue #34).

--- a/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
@@ -59,7 +59,13 @@ export function useWorkspaceSelection(args: {
       bootFocusRef.current = true
       args.focusWorkspace()
     }
-    if (selectedId && tasks.some((task) => task.id === selectedId)) return
+    // An archived/deleting task is NOT a valid selection (issue #34): the
+    // snapshot still contains it, but its sidebar row is gone (#473) and the
+    // PTY sweep below kills its sessions — leaving selection on it kept its
+    // Terminal mounted, which answered the kill with a dead-on-attach RESUME:
+    // a fresh engine spawn (full center-pane repaint, the archive "flash")
+    // that resurrected the very session archiving is documented to stop.
+    if (selectedId && tasks.some((task) => task.id === selectedId && !task.archived && !task.deletion)) return
     // Fallback carries the persisted lastActive record too — a stale or
     // freshly-respawned daemon can replay a null focus while disk still
     // knows the real one (the "reopens on the oldest project" bug).

--- a/packages/kobe/test/render/workspace-selection-archive.test.tsx
+++ b/packages/kobe/test/render/workspace-selection-archive.test.tsx
@@ -1,0 +1,101 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Regression pin for issue #34 (archive full-screen flash): archiving the
+ * SELECTED task must move the local selection off it in the same snapshot
+ * tick. Selection lingering on the archived task kept its TerminalTabs
+ * mounted while the PTY sweep killed its sessions — the mounted Terminal
+ * answered with a dead-on-attach resume, respawning the very engine
+ * archiving stops, as a full center-pane repaint (the "flash") and a
+ * resurrected background session.
+ */
+
+import { describe, expect, it } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { useState } from "react"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { useWorkspaceSelection } from "../../src/tui-react/workspace/use-workspace-selection"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { act, renderComponent, settle } from "./harness"
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/kobe",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    archived: false,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+function mockOrchestrator(activeCell: ReturnType<typeof createStateCell<string | null>>) {
+  return {
+    activeTaskSignal: () => activeCell,
+    setActiveTask: (id: string) => {
+      activeCell.set(id)
+      return Promise.resolve()
+    },
+    ensureWorktree: () => Promise.resolve(),
+    reportUiEvent: () => {},
+  } as unknown as RemoteOrchestrator
+}
+
+const KV = { store: {}, set: () => {} }
+
+function Probe(props: {
+  orch: RemoteOrchestrator
+  initialTasks: readonly Task[]
+  activeTaskId: string | null
+  onReady: (selectedId: string | null, setTasks: (tasks: readonly Task[]) => void) => void
+}) {
+  const [tasks, setTasks] = useState<readonly Task[]>(props.initialTasks)
+  const selection = useWorkspaceSelection({
+    orch: props.orch,
+    tasks,
+    activeTaskId: props.activeTaskId,
+    focusWorkspace: () => {},
+    kv: KV,
+  })
+  props.onReady(selection.selectedId, setTasks)
+  return null
+}
+
+describe("selection when the selected task is archived", () => {
+  it("moves off the archived task instead of keeping its terminal mounted", async () => {
+    process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-archive-sel-"))
+    const activeCell = createStateCell<string | null>("bravo")
+    const orch = mockOrchestrator(activeCell)
+    let selectedId = null as string | null
+    let setTasks: ((tasks: readonly Task[]) => void) | null = null
+    await renderComponent(
+      <Probe
+        orch={orch}
+        initialTasks={[task("alpha"), task("bravo")]}
+        activeTaskId="bravo"
+        onReady={(sel, set) => {
+          selectedId = sel
+          setTasks = set
+        }}
+      />,
+      { width: 46, height: 10 },
+    )
+    await settle()
+    expect(selectedId).toBe("bravo")
+
+    // The daemon snapshot flips bravo archived (the TUI archive flow, or an
+    // external `rove api archive`). Same array otherwise — the row is simply
+    // no longer selectable.
+    act(() => setTasks?.([task("alpha"), task("bravo", { archived: true })]))
+    await settle()
+    expect(selectedId).toBe("alpha")
+  })
+})


### PR DESCRIPTION
## What

Fixes issue #34 (daemon issue store): archiving a task flashed the entire screen once (owner report, v0.8.111).

## Root cause

Archiving the **selected** task left `useWorkspaceSelection`'s fallback effect satisfied — the archived task is still in the snapshot, so `selectedId` never moved. Meanwhile:

- the sidebar row vanished (#473 removed the Archived view), and
- the same hook's PTY sweep killed the archived task's sessions (`releaseWhere`),

but `ShowWorkspace` still had the archived task's `TerminalTabs` mounted. The mounted Terminal answered the kill with its dead-on-attach **resume** path — a fresh engine spawn repainting the whole center pane (the visible flash) and resurrecting the very session archiving is documented to stop.

Reproduced against the real TUI on an isolated daemon (Bun-PTY capture, throwaway `KOBE_HOME_DIR`, derived socket paths): after `a`+confirm the archived task's `taskId::tab-1` PTY came back `alive` in `pty-list`, with a full-40-row repaint burst in the raw renderer output. With the fix the PTY stays dead and the post-archive frames are incremental (≤10-row blocks; the one remaining full-screen block is the confirm dialog's dim backdrop, which repaints every row by design).

## Fix

The selection fallback now treats archived/deleting tasks as unselectable (mirroring `firstSelectableTask`'s own rule), so selection moves off in the same snapshot tick, the archived task's tabs unmount, and only the affected panes redraw. One-line predicate change.

## Regression pin

`test/render/workspace-selection-archive.test.tsx` — mounts the real hook, flips the selected task to `archived` in the snapshot, asserts selection moves off it. Red without the fix, green with it.

## Gates

- root lint ✓, typecheck ✓, `bun run test` 562 ✓, `test:render` 168 ✓
- changeset: `@sma1lboy/rove: patch`