### PR TITLE
feat: Claude Code plugin migration hard-gate — #37 step 3

### DIFF
--- a/.changeset/claude-plugin-migration-gate.md
+++ b/.changeset/claude-plugin-migration-gate.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Claude Code plugin migration hard-gate: when the Rove plugin is enabled, the launch-time settings.json hook install skips Claude (the plugin's hooks.json carries those events — no double firing) and prints a prompt-only warning for leftover settings-managed hooks or a pre-plugin `~/.claude/skills/rove|kobe` directory. New user-invoked `rove hook cleanup` removes only Rove's own settings-managed hook entries; nothing is ever removed silently. Skill install/staleness nags step aside in plugin mode (the bundled skill versions with the plugin), and `rove skill status` says so. Codex and other engines are untouched.

--- a/packages/kobe/src/cli/hook-cmd.ts
+++ b/packages/kobe/src/cli/hook-cmd.ts
@@ -32,6 +32,7 @@ import type { EngineActivityDetail } from "../engine/hook-events.ts"
 import { isEngineActivityKind } from "../engine/hook-events.ts"
 import { getPersistedString, setPersistedString } from "../state/repos.ts"
 import { ALL_VENDORS } from "../types/vendor.ts"
+import { activeCliName } from "./rename-compat.ts"
 
 /** Default timeout for the stdin race — bounds a manual invocation without
  *  stdin so it can't hang. */
@@ -199,6 +200,13 @@ export async function runHookSubcommand(argv: readonly string[]): Promise<void> 
     await runHookSetup(rest)
     return
   }
+  // `cleanup` — the sanctioned migration path (issue #37): remove the
+  // settings-managed Rove hooks after the Claude Code plugin takes over.
+  // User-invoked and loud; the launch-time gate only ever PROMPTS for this.
+  if (verb === "cleanup") {
+    await runHookCleanup()
+    return
+  }
   // Worktree lifecycle sync: the global `PostToolUse` (Bash) hook. Fires after
   // EVERY Bash tool call machine-wide, so it must no-op fast — it only touches
   // the daemon when the command was a `git worktree add`/`remove`.
@@ -336,12 +344,33 @@ function persistedSyncPath(stored: string | undefined): string | undefined {
  */
 export async function ensureGlobalKobeHooks(): Promise<void> {
   try {
+    // 0. Plugin takeover (issue #37): when the Rove Claude Code PLUGIN is
+    //    enabled, its own hooks.json already carries the Claude activity +
+    //    worktree-watch hooks, so the settings-managed install for CLAUDE is
+    //    skipped — installing both would double-fire every event. Detection
+    //    is prompt-only: legacy settings-managed hooks / a pre-plugin skill
+    //    dir are reported to stderr, never silently removed (the sanctioned
+    //    path is the user-invoked `rove hook cleanup`). Other engines
+    //    (codex/…) are untouched by plugin mode. Note: the volume-gated
+    //    tool-pre/post/failed family is settings-managed only, so a Rove
+    //    plugin subscribing tool.* events needs the settings install (run
+    //    `rove hook cleanup` only after disabling such plugins, or keep the
+    //    Claude plugin off).
+    const { isRovePluginEnabled, detectLegacyInstalls, migrationHint } = await import(
+      "../engine/claude-code-local/plugin-migration.ts"
+    )
+    const pluginMode = isRovePluginEnabled()
+    if (pluginMode) {
+      const hint = migrationHint(detectLegacyInstalls(), activeCliName())
+      if (hint) process.stderr.write(`\n${hint}\n`)
+    }
     // 1. Activity hooks + the creation-time worktree-watch hook — both global,
     //    each written into the ENGINE's own settings file (Claude's
     //    ~/.claude/settings.json, Codex's ~/.codex/hooks.json) so every session
     //    of that engine reports.
     const toolEvents = pluginsWantToolEvents()
     for (const a of activityHookAdapters()) {
+      if (pluginMode && a.vendor === "claude") continue
       const enginePath = a.globalSettingsPath()
       if (!enginePath) continue
       await a.installActivityHooks(enginePath, { toolEvents })
@@ -396,6 +425,34 @@ async function cleanupWorktreeSyncHook(): Promise<void> {
   if (prev) paths.add(prev)
   for (const a of adapters) for (const p of paths) await a.removeWorktreeSyncHook(p)
   if (stored !== "off") setPersistedString(SYNC_SETTING_KEY, "off")
+}
+
+/**
+ * `kobe hook cleanup` — remove Rove's settings-managed activity +
+ * worktree-watch hooks from the CLAUDE settings file. The migration step
+ * after installing the Claude Code plugin: the plugin's hooks.json carries
+ * the same hooks, so the settings copy would double-fire every event. Merge
+ * mechanics are the adapter's own remove path — only Rove-tagged groups are
+ * touched, user hooks and other engines (codex/…) stay intact. Idempotent.
+ */
+async function runHookCleanup(): Promise<void> {
+  const claude = activityHookAdapters().find((a) => a.vendor === "claude")
+  const path = claude?.globalSettingsPath()
+  if (!claude || !path) {
+    process.stdout.write("rove hook cleanup: no Claude hook adapter — nothing to do.\n")
+    return
+  }
+  await claude.removeActivityHooks(path)
+  await claude.removeWorktreeWatchHook(path)
+  process.stdout.write(
+    [
+      `rove hook cleanup: removed Rove's settings-managed hooks from ${path}.`,
+      "Only Rove's own entries were touched; your other hooks are intact.",
+      "The Claude Code plugin's hooks.json now carries these events (if the plugin",
+      "is not installed, the next Rove launch reinstalls the settings-managed set).",
+      "",
+    ].join("\n"),
+  )
 }
 
 /**

--- a/packages/kobe/src/cli/skill-cmd.ts
+++ b/packages/kobe/src/cli/skill-cmd.ts
@@ -124,8 +124,12 @@ export async function runSkillSubcommand(argv: readonly string[]): Promise<void>
   }
 
   if (verb === "status") {
+    const { isRovePluginEnabled } = await import("../engine/claude-code-local/plugin-migration.ts")
     const state = kobeSkillState()
     const paths = kobeSkillPaths()
+    const pluginNote = isRovePluginEnabled()
+      ? "  note: the Rove Claude Code plugin is enabled — for Claude Code the skill ships\n        inside the plugin and versions with it (staleness prompts are suppressed).\n"
+      : ""
     const head = !state.installed
       ? "✗ not installed"
       : state.stale
@@ -137,7 +141,7 @@ export async function runSkillSubcommand(argv: readonly string[]): Promise<void>
         `  looked in: ${paths.join("\n             ")}`,
         state.installed && !state.stale ? "" : `  → run \`${CLI_NAME} skill install\` to install / refresh`,
         "",
-      ].join("\n"),
+      ].join("\n") + pluginNote,
     )
     return
   }

--- a/packages/kobe/src/engine/claude-code-local/plugin-migration.ts
+++ b/packages/kobe/src/engine/claude-code-local/plugin-migration.ts
@@ -1,0 +1,113 @@
+/**
+ * Claude Code plugin takeover detection (issue #37, migration hard-gate).
+ *
+ * Once the user installs the Rove Claude Code plugin (`claude-plugin/` in this
+ * repo, enabled as `rove@<marketplace>` in `~/.claude/settings.json`), the
+ * plugin's own hooks.json + bundled skill carry the 12 activity hooks and the
+ * SKILL.md. Two legacy installs then become DOUBLE registrations:
+ *
+ *   1. the settings.json activity-hook block kobe wrote on every launch
+ *      (every event would fire twice → duplicate daemon reports), and
+ *   2. a pre-plugin skill install under `~/.claude/skills/rove|kobe`
+ *      (Claude Code loads both copies).
+ *
+ * The gate is PROMPT-ONLY by design: detection here never edits the user's
+ * settings.json or deletes a skill directory. The one sanctioned cleanup path
+ * is the explicit `rove hook cleanup` command (user-invoked), plus manually
+ * removing the legacy skill directory. Vendor-specific (file location +
+ * `enabledPlugins` schema are Claude Code's), hence this directory.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { hasKobeActivityHooks, isObject } from "../json-hooks.ts"
+import { CLAUDE_HOOK_EVENT_MAP, claudeSettingsPath } from "./hook-adapter.ts"
+
+/** The plugin name inside `claude-plugin/.claude-plugin/plugin.json`. An
+ *  enabledPlugins key is `<plugin>@<marketplace>`; the marketplace half varies
+ *  (git install vs local dev), so match on the plugin half only. */
+const PLUGIN_NAME = "rove"
+
+function readSettings(path: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown
+    return isObject(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/** True when the Rove Claude Code plugin is installed AND enabled. */
+export function isRovePluginEnabled(settingsFilePath: string = claudeSettingsPath()): boolean {
+  const settings = readSettings(settingsFilePath)
+  if (!settings || !isObject(settings.enabledPlugins)) return false
+  return Object.entries(settings.enabledPlugins).some(([key, on]) => on === true && key.split("@")[0] === PLUGIN_NAME)
+}
+
+/** What the migration gate found — each entry is a double-registration risk. */
+export interface MigrationFindings {
+  /** settings.json still carries kobe's activity/worktree-watch hook groups. */
+  readonly legacyHooks: boolean
+  /** Pre-plugin skill directories Claude Code would load alongside the plugin's copy. */
+  readonly legacySkillDirs: readonly string[]
+}
+
+export function detectLegacyInstalls(opts: { settingsFilePath?: string; home?: string } = {}): MigrationFindings {
+  const settingsFilePath = opts.settingsFilePath ?? claudeSettingsPath()
+  const home = opts.home ?? homedir()
+  const settings = readSettings(settingsFilePath)
+  // The worktree-watch hook shares the activity ownership predicate: its
+  // command is `… hook worktree-created`, and "worktree-created" is not an
+  // activity verb, so check it via its own marker substring.
+  const legacyHooks =
+    settings !== null && (hasKobeActivityHooks(settings, CLAUDE_HOOK_EVENT_MAP) || settingsHasWorktreeWatch(settings))
+  const legacySkillDirs = ["rove", "kobe"]
+    .map((name) => join(home, ".claude", "skills", name))
+    .filter((dir) => existsSync(join(dir, "SKILL.md")))
+  return { legacyHooks, legacySkillDirs }
+}
+
+function settingsHasWorktreeWatch(settings: Record<string, unknown>): boolean {
+  const hooks = isObject(settings.hooks) ? settings.hooks : {}
+  return Object.values(hooks).some(
+    (groups) =>
+      Array.isArray(groups) &&
+      groups.some(
+        (g) =>
+          isObject(g) &&
+          Array.isArray(g.hooks) &&
+          g.hooks.some(
+            (h) =>
+              isObject(h) &&
+              typeof h.command === "string" &&
+              h.command.includes("worktree-created") &&
+              // The plugin's own hook also contains the marker — only the
+              // settings-managed one (kobe/rove invocation, no plugin root)
+              // is legacy.
+              !h.command.includes("CLAUDE_PLUGIN_ROOT"),
+          ),
+      ),
+  )
+}
+
+/** The stderr notice for a detected double registration. Repeats every launch
+ *  until cleaned — a double-firing hook set is an active misconfiguration,
+ *  not a one-shot tip. Never edits anything. */
+export function migrationHint(findings: MigrationFindings, cliName: string): string | null {
+  if (!findings.legacyHooks && findings.legacySkillDirs.length === 0) return null
+  const lines = [`${cliName}: the Rove Claude Code plugin is enabled, but legacy installs remain:`]
+  if (findings.legacyHooks) {
+    lines.push(
+      "  • ~/.claude/settings.json still has the settings-managed Rove hooks (every event fires TWICE).",
+      `    Run \`${cliName} hook cleanup\` to remove them (only Rove's own entries are touched).`,
+    )
+  }
+  for (const dir of findings.legacySkillDirs) {
+    lines.push(
+      `  • legacy skill copy at ${dir} (the plugin bundles the skill — two copies double-register).`,
+      `    Remove that directory to keep the plugin's copy only.`,
+    )
+  }
+  return `${lines.join("\n")}\n`
+}

--- a/packages/kobe/src/engine/json-hooks.ts
+++ b/packages/kobe/src/engine/json-hooks.ts
@@ -57,6 +57,17 @@ function isKobeActivityGroup(group: unknown, markers: readonly string[]): boolea
   )
 }
 
+/** True if a shared settings object still carries any of kobe's activity hook
+ *  groups (the same ownership predicate the merge uses). Detection only — the
+ *  plugin-migration hint needs a read-side answer without editing the file. */
+export function hasKobeActivityHooks(current: Record<string, unknown>, eventMap: readonly HookEventSpec[]): boolean {
+  const markers = activityMarkers(eventMap)
+  const hooks = isObject(current.hooks) ? current.hooks : {}
+  return Object.values(hooks).some(
+    (groups) => Array.isArray(groups) && groups.some((g) => isKobeActivityGroup(g, markers)),
+  )
+}
+
 /** Optional knobs shared by the build/merge pair. */
 export interface ActivityHookOpts {
   /** Extra argv appended after the verb (e.g. `--engine claude`, so `kobe

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -230,6 +230,15 @@ function promptLine(): Promise<string> {
  * Safe to call on every startup.
  */
 export async function maybeHintSkillInstall(io: SkillHintIO = {}): Promise<void> {
+  // Plugin takeover (issue #37): when the Rove Claude Code plugin is enabled
+  // it BUNDLES the skill, and that copy versions with the plugin — not with
+  // KOBE_SKILL_VERSION. Both the install nudge and the staleness prompt step
+  // aside: nagging the user to `skill install` alongside the plugin's copy
+  // would create exactly the double registration the migration gate warns
+  // about. `kobe skill status` still reports the npx-installed state for
+  // anyone running both deliberately (e.g. for non-Claude agents).
+  const { isRovePluginEnabled } = await import("../engine/claude-code-local/plugin-migration.ts")
+  if (isRovePluginEnabled()) return
   const cliName = activeCliName()
   const installCommand = skillInstallCommand()
   const state = kobeSkillState()

--- a/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
+++ b/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
@@ -17,6 +17,10 @@ const mocks = vi.hoisted(() => ({
   connectIfRunning: vi.fn(),
   request: vi.fn(),
   close: vi.fn(),
+  // Plugin takeover flag (issue #37) — mocked so the gate never reads the
+  // developer's real ~/.claude/settings.json (which may genuinely have the
+  // Rove plugin enabled).
+  rovePluginEnabled: vi.fn(() => false),
   adapter: {
     supportsHooks: vi.fn(() => true),
     supportsWorktreeSync: vi.fn(() => true),
@@ -25,6 +29,8 @@ const mocks = vi.hoisted(() => ({
     globalSettingsPath: vi.fn((): string | null => "/fake/.claude/settings.json"),
     installActivityHooks: vi.fn(),
     installWorktreeWatchHook: vi.fn(),
+    removeActivityHooks: vi.fn(),
+    removeWorktreeWatchHook: vi.fn(),
     removeWorktreeSyncHook: vi.fn(),
   },
 }))
@@ -34,7 +40,15 @@ vi.mock("@sma1lboy/kobe-daemon/client/daemon-process", () => ({
 }))
 
 vi.mock("../../src/engine/hook-adapter.ts", () => ({
-  createEngineHookAdapter: vi.fn(() => mocks.adapter),
+  // Same shared method mocks for every vendor; `vendor` is stamped per call so
+  // the plugin-mode gate can tell claude apart from the rest.
+  createEngineHookAdapter: vi.fn((vendor: string) => ({ ...mocks.adapter, vendor })),
+}))
+
+vi.mock("../../src/engine/claude-code-local/plugin-migration.ts", () => ({
+  isRovePluginEnabled: mocks.rovePluginEnabled,
+  detectLegacyInstalls: vi.fn(() => ({ legacyHooks: false, legacySkillDirs: [] })),
+  migrationHint: vi.fn(() => null),
 }))
 
 import { ensureGlobalKobeHooks, runHookSubcommand } from "../../src/cli/hook-cmd.ts"
@@ -64,6 +78,7 @@ beforeEach(() => {
   mocks.connectIfRunning.mockReset().mockResolvedValue({ request: mocks.request, close: mocks.close })
   mocks.request.mockReset().mockResolvedValue({})
   mocks.close.mockReset()
+  mocks.rovePluginEnabled.mockClear().mockReturnValue(false)
   mocks.adapter.supportsHooks.mockClear().mockReturnValue(true)
   mocks.adapter.supportsWorktreeSync.mockClear().mockReturnValue(true)
   mocks.adapter.activityDetailFromPayload.mockClear().mockReturnValue(undefined)
@@ -71,6 +86,8 @@ beforeEach(() => {
   mocks.adapter.globalSettingsPath.mockClear().mockReturnValue("/fake/.claude/settings.json")
   mocks.adapter.installActivityHooks.mockClear()
   mocks.adapter.installWorktreeWatchHook.mockClear()
+  mocks.adapter.removeActivityHooks.mockClear()
+  mocks.adapter.removeWorktreeWatchHook.mockClear()
   mocks.adapter.removeWorktreeSyncHook.mockClear()
   stubStdin({})
 })
@@ -278,6 +295,35 @@ describe("ensureGlobalKobeHooks (default-ON global install)", () => {
   it("never throws when an install fails (best-effort, must not block launch)", async () => {
     mocks.adapter.installActivityHooks.mockRejectedValue(new Error("EACCES"))
     await expect(ensureGlobalKobeHooks()).resolves.toBeUndefined()
+  })
+
+  // Issue #37 plugin takeover: the Claude Code plugin's hooks.json carries
+  // the claude hooks, so the settings-managed install must skip claude —
+  // otherwise every event fires twice. Other engines keep their install.
+  it("plugin mode skips the claude settings install but keeps other engines", async () => {
+    mocks.rovePluginEnabled.mockReturnValue(true)
+    await ensureGlobalKobeHooks()
+    const installedVendors = mocks.adapter.installActivityHooks.mock.contexts.map(
+      (ctx) => (ctx as { vendor: string }).vendor,
+    )
+    expect(installedVendors).not.toContain("claude")
+    expect(installedVendors.length).toBeGreaterThan(0) // codex/… still installed
+  })
+})
+
+describe("runHookSubcommand cleanup (plugin migration path)", () => {
+  it("removes the claude settings-managed hooks and only those", async () => {
+    const outSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    await runHookSubcommand(["cleanup"])
+    expect(mocks.adapter.removeActivityHooks).toHaveBeenCalledWith("/fake/.claude/settings.json")
+    expect(mocks.adapter.removeWorktreeWatchHook).toHaveBeenCalledWith("/fake/.claude/settings.json")
+    // Exactly one adapter (claude) swept — codex's hooks.json is untouched.
+    expect(mocks.adapter.removeActivityHooks).toHaveBeenCalledTimes(1)
+    const cleanedVendors = mocks.adapter.removeActivityHooks.mock.contexts.map(
+      (ctx) => (ctx as { vendor: string }).vendor,
+    )
+    expect(cleanedVendors).toEqual(["claude"])
+    outSpy.mockRestore()
   })
 })
 

--- a/packages/kobe/test/engine/plugin-migration.test.ts
+++ b/packages/kobe/test/engine/plugin-migration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Claude Code plugin takeover detection (`engine/claude-code-local/
+ * plugin-migration.ts`) — the read-only side of the issue #37 migration
+ * hard-gate. Everything here operates on temp files passed in explicitly;
+ * nothing may touch the real ~/.claude (the gate's whole contract is that
+ * detection never writes).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  detectLegacyInstalls,
+  isRovePluginEnabled,
+  migrationHint,
+} from "../../src/engine/claude-code-local/plugin-migration.ts"
+
+let home: string
+let settingsPath: string
+
+function writeSettings(settings: Record<string, unknown>): void {
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2))
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kobe-plugmig-"))
+  mkdirSync(join(home, ".claude"), { recursive: true })
+  settingsPath = join(home, ".claude", "settings.json")
+})
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe("isRovePluginEnabled", () => {
+  it("matches rove@<any-marketplace> when enabled", () => {
+    writeSettings({ enabledPlugins: { "rove@rove": true } })
+    expect(isRovePluginEnabled(settingsPath)).toBe(true)
+    writeSettings({ enabledPlugins: { "rove@local-dev": true } })
+    expect(isRovePluginEnabled(settingsPath)).toBe(true)
+  })
+
+  it("ignores a disabled entry, other plugins, and prefix look-alikes", () => {
+    writeSettings({ enabledPlugins: { "rove@rove": false, "ponytail@ponytail": true, "rover@x": true } })
+    expect(isRovePluginEnabled(settingsPath)).toBe(false)
+  })
+
+  it("is false for a missing or unparsable settings file", () => {
+    expect(isRovePluginEnabled(join(home, "nope.json"))).toBe(false)
+    writeFileSync(settingsPath, "{oops")
+    expect(isRovePluginEnabled(settingsPath)).toBe(false)
+  })
+})
+
+describe("detectLegacyInstalls", () => {
+  it("flags the settings-managed activity hooks", () => {
+    writeSettings({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "'kobe' 'hook' 'turn-complete' '--engine' 'claude'" }] }] },
+    })
+    expect(detectLegacyInstalls({ settingsFilePath: settingsPath, home }).legacyHooks).toBe(true)
+  })
+
+  it("flags the settings-managed worktree-watch hook (not an activity verb)", () => {
+    writeSettings({
+      hooks: {
+        PostToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "'kobe' 'hook' 'worktree-created'" }] }],
+      },
+    })
+    expect(detectLegacyInstalls({ settingsFilePath: settingsPath, home }).legacyHooks).toBe(true)
+  })
+
+  it("does NOT flag the plugin's own hooks or unrelated user hooks", () => {
+    writeSettings({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "my-own-thing" }] }],
+        PostToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: '"${CLAUDE_PLUGIN_ROOT}/bin/rove" hook worktree-created' }],
+          },
+        ],
+      },
+    })
+    expect(detectLegacyInstalls({ settingsFilePath: settingsPath, home }).legacyHooks).toBe(false)
+  })
+
+  it("finds pre-plugin skill directories under ~/.claude/skills", () => {
+    const dir = join(home, ".claude", "skills", "rove")
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "SKILL.md"), "x")
+    const found = detectLegacyInstalls({ settingsFilePath: settingsPath, home })
+    expect(found.legacySkillDirs).toEqual([dir])
+  })
+
+  it("reports clean when nothing legacy exists", () => {
+    writeSettings({})
+    const found = detectLegacyInstalls({ settingsFilePath: settingsPath, home })
+    expect(found.legacyHooks).toBe(false)
+    expect(found.legacySkillDirs).toEqual([])
+  })
+})
+
+describe("migrationHint", () => {
+  it("is null when clean", () => {
+    expect(migrationHint({ legacyHooks: false, legacySkillDirs: [] }, "rove")).toBeNull()
+  })
+
+  it("names the cleanup command for legacy hooks and the dir for legacy skills", () => {
+    const hint = migrationHint({ legacyHooks: true, legacySkillDirs: ["/h/.claude/skills/rove"] }, "rove")
+    expect(hint).toContain("rove hook cleanup")
+    expect(hint).toContain("/h/.claude/skills/rove")
+    // Prompt-only contract: the hint TELLS the user, it never claims to have
+    // removed anything itself.
+    expect(hint).not.toContain("removed")
+  })
+})

--- a/packages/kobe/test/lib/skill-install-hint.test.ts
+++ b/packages/kobe/test/lib/skill-install-hint.test.ts
@@ -99,6 +99,19 @@ describe("maybeHintSkillInstall", () => {
     expect(msg).toContain("`kobe doctor`")
   })
 
+  it("plugin mode: absent AND stale skill both stay silent (skill versions with the plugin)", async () => {
+    // The Rove Claude Code plugin bundles the skill, so neither the install
+    // nudge nor the staleness prompt may fire — the mocked homedir means this
+    // reads the test's own settings.json, never the developer's.
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true })
+    writeFileSync(join(tmpHome, ".claude", "settings.json"), JSON.stringify({ enabledPlugins: { "rove@rove": true } }))
+    await maybeHintSkillInstall() // absent
+    writeStaleSkill()
+    await maybeHintSkillInstall() // stale
+    expect(stderrSpy).not.toHaveBeenCalled()
+    rmSync(join(tmpHome, ".claude"), { recursive: true, force: true })
+  })
+
   it("fresh skill: no hint at all", async () => {
     mkdirSync(skillDir(cwd), { recursive: true })
     writeFileSync(join(skillDir(cwd), "SKILL.md"), `<!-- kobe-skill-version: ${KOBE_SKILL_VERSION} -->`)


### PR DESCRIPTION
Second slice of issue #37 (follows #476). The one high-risk step: dedupe between the plugin and the two legacy install paths, without ever touching user config silently.

## What

- **`engine/claude-code-local/plugin-migration.ts`** (new, read-only):
  - `isRovePluginEnabled()` — `rove@<any-marketplace>` enabled in `~/.claude/settings.json` `enabledPlugins` (marketplace half varies between git install and local dev, so matched on the plugin half)
  - `detectLegacyInstalls()` — finds (1) settings-managed Rove hook groups (same ownership predicate the merge core uses, via new `hasKobeActivityHooks` in `json-hooks.ts`, plus the worktree-watch marker with a `CLAUDE_PLUGIN_ROOT` exclusion so the plugin's own hook is never flagged) and (2) pre-plugin `~/.claude/skills/rove|kobe` dirs
  - `migrationHint()` — prompt-only stderr notice naming the cleanup paths; repeats every launch until clean (a double-firing hook set is an active misconfiguration, not a tip)
- **`ensureGlobalKobeHooks`**: plugin mode skips the **claude** settings install (single hook carrier → no double fire) and prints the hint. Codex and every other engine keep their settings-managed install untouched.
- **`rove hook cleanup`** (new verb) — the sanctioned migration action: removes only Rove-tagged activity + worktree-watch groups from the claude settings file via the adapter's existing merge-remove path. User hooks and other engines stay intact. Idempotent.
- **Skill handoff**: `maybeHintSkillInstall` steps aside entirely in plugin mode — the plugin bundles the skill and it versions with the plugin, not `KOBE_SKILL_VERSION`; nagging `skill install` would recreate the double registration. `rove skill status` prints a note explaining this.

## Hard rules honoured

- **Never silently mutates user settings**: detection is pure read; the only write path is the explicit user-invoked `hook cleanup`.
- The gated tool-family hooks (tool-pre/post/failed) remain settings-managed only; the launch comment documents the interaction for users running tool.* plugins.

## Tests

- `test/engine/plugin-migration.test.ts` — 10 cases on temp files (enabled/disabled/lookalikes, legacy vs plugin-own hooks, skill dirs, prompt-only hint contract)
- `hook-cmd-dispatch.test.ts` — plugin mode skips claude but keeps other engines; `cleanup` sweeps exactly the claude adapter
- `skill-install-hint.test.ts` — absent AND stale skill both silent in plugin mode