### PR TITLE
docs: Claude Code plugin install path + migration guidance — #37 step 4

### DIFF
--- a/.changeset/claude-plugin-docs.md
+++ b/.changeset/claude-plugin-docs.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Document the Claude Code plugin distribution path: install via `/plugin marketplace add Sma1lboy/rove` + `/plugin install rove@rove`, the settings-managed vs plugin handoff, and the `rove hook cleanup` migration step (QUICKSTART, CONFIGURATION, CLI).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -295,6 +295,10 @@ Not in `--help`, listed so they aren't a mystery if you see them:
   survive TUI exits and daemon restarts. Spawned automatically.
 - **`rove hook <verb>`** — fired by an engine's own hooks to report activity.
   It always exits 0 and never starts the daemon, so it can't fail your engine.
+  One verb is user-facing: **`rove hook cleanup`** removes Rove's
+  settings-managed hooks from `~/.claude/settings.json` after the Claude Code
+  plugin takes over — see
+  [Configuration → Claude Code plugin](CONFIGURATION.md#claude-code-plugin).
 
 ## Exit codes
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -241,6 +241,49 @@ A custom engine launches and runs like any other, but Rove deliberately
 doesn't guess at its internals: no history reader, no account detection, no
 activity hooks, no session resume. More in [Engines](./ENGINES.md).
 
+## Claude Code plugin
+
+Rove integrates with Claude Code through global activity hooks (so the
+sidebar can show working / done / needs-input for every session) and the
+companion agent skill. There are two ways to get both, and you should run
+exactly one:
+
+- **Default (no action needed)**: every Rove launch idempotently writes its
+  hooks into `~/.claude/settings.json`, and `rove skill install` places the
+  skill. This is what most existing installs use.
+- **The Claude Code plugin** — one install carries hooks and skill together,
+  with no PATH or settings.json involvement:
+
+  ```text
+  /plugin marketplace add Sma1lboy/rove
+  /plugin install rove@rove
+  ```
+
+  The plugin's hook commands call a bundled wrapper by absolute path, so they
+  work even when `rove` isn't on the shell's PATH. The bundled skill versions
+  with the plugin (`/plugin update` refreshes both), so Rove's skill staleness
+  prompts step aside while the plugin is enabled.
+
+Once Rove sees the plugin enabled, it stops writing the Claude hooks into
+`settings.json` on launch. If you were running Rove **before** installing the
+plugin, the old settings-managed hooks are still there and every event would
+fire twice — Rove warns about this at startup and the fix is one command:
+
+```bash
+rove hook cleanup
+```
+
+That removes only Rove's own entries from `~/.claude/settings.json`; your
+other hooks are untouched. If you also have a pre-plugin skill copy under
+`~/.claude/skills/rove` (or `…/kobe`), delete that directory — the plugin's
+bundled copy replaces it. Rove never edits or removes either one silently.
+
+Uninstalling or disabling the plugin reverses the handoff: the next Rove
+launch reinstalls the settings-managed hooks automatically.
+
+Only Claude Code is affected. Codex (and other engines') hook integration is
+engine-owned and unchanged by the plugin.
+
 ## Per-repo init
 
 A repo can ship two files in its own `.rove/` directory:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -95,6 +95,19 @@ Install the companion skill so your coding agent can run this loop itself:
 rove skill install
 ```
 
+**Claude Code users have a one-stop alternative**: the Rove plugin carries the
+skill AND the activity hooks in one install, with no PATH or settings.json
+setup:
+
+```text
+/plugin marketplace add Sma1lboy/rove
+/plugin install rove@rove
+```
+
+If you were already running Rove before installing the plugin, run
+`rove hook cleanup` once afterwards — details in
+[Configuration → Claude Code plugin](CONFIGURATION.md#claude-code-plugin).
+
 ## If something's wrong
 
 ```bash


### PR DESCRIPTION
Final slice of issue #37 (follows #476 scaffold and #477 migration gate).

## What

- **QUICKSTART → Let your agent drive**: adds the Claude Code one-stop alternative (`/plugin marketplace add Sma1lboy/rove` + `/plugin install rove@rove`) next to `rove skill install`, with a pointer to the migration note.
- **CONFIGURATION → Claude Code plugin** (new section): the two install routes (settings-managed default vs plugin), why you run exactly one, the double-fire warning + `rove hook cleanup` migration step, the pre-plugin skill dir cleanup, the reversal on uninstall, and the codex/kimi non-involvement.
- **CLI → Internal subcommands**: notes `rove hook cleanup` as the one user-facing hook verb.

Both QUICKSTART.md and CONFIGURATION.md are already in the docs-site `SECTIONS` list — no sync-script change needed (verified by running `sync-docs.mjs` locally).

Note: the CONFIGURATION section documents behavior shipped in #477; if this lands first the section is a few hours early, content is accurate either way.