### PR TITLE
fix: floor the schedule preview's next-run countdown

### DIFF
--- a/.changeset/schedule-preview-floor-relative.md
+++ b/.changeset/schedule-preview-floor-relative.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Routines schedule preview now floors its "next run in …" countdown instead of rounding up, so it never promises more headroom than a schedule actually has: a run 90 minutes out reads "in 1h" (not "in 2h") and one 36 hours out reads "in 1d" (not "in 2d"), matching how the plugins list already phrases elapsed time.

--- a/packages/kobe/src/tui/component/automation-composer.ts
+++ b/packages/kobe/src/tui/component/automation-composer.ts
@@ -86,11 +86,14 @@ export function previewSchedule(expression: string, nowMs: number): SchedulePrev
 }
 
 function formatRelative(deltaMs: number): string {
-  const minutes = Math.max(1, Math.round(deltaMs / 60_000))
+  // Floor every bucket, matching the elapsed formatter (`formatAgo`): a
+  // countdown reads "in Nh" as *at least* N hours away, so rounding up would
+  // promise headroom that isn't there — 90 minutes out is "in 1h", not "in 2h".
+  const minutes = Math.max(1, Math.floor(deltaMs / 60_000))
   if (minutes < 60) return `in ${minutes}m`
-  const hours = Math.round(minutes / 60)
+  const hours = Math.floor(minutes / 60)
   if (hours < 24) return `in ${hours}h`
-  return `in ${Math.round(hours / 24)}d`
+  return `in ${Math.floor(hours / 24)}d`
 }
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const

--- a/packages/kobe/test/tui/automation-composer.test.ts
+++ b/packages/kobe/test/tui/automation-composer.test.ts
@@ -106,6 +106,14 @@ describe("previewSchedule", () => {
     expect(previewSchedule("0 9 * * *", NOW)).toMatchObject({ relative: "in 23h" })
   })
 
+  test("relative time floors the bucket instead of rounding up", () => {
+    // NOW is 10:00; the coarse unit must never promise more headroom than the
+    // schedule actually has. 11:30 is 90 minutes out — "in 1h", not "in 2h".
+    expect(previewSchedule("30 11 * * *", NOW)).toMatchObject({ relative: "in 1h" })
+    // Aug 1 22:00 is 36 hours out (1d 12h) — "in 1d", not "in 2d".
+    expect(previewSchedule("0 22 1 8 *", NOW)).toMatchObject({ relative: "in 1d" })
+  })
+
   test("the preview's own timestamp is the time it claims", () => {
     // Guards the two formatters drifting from the timestamp they describe.
     const preview = previewSchedule("0 9 * * *", NOW)


### PR DESCRIPTION
## Direction

Code-health / UX-polish, self-found during the daily review — a correctness inconsistency between two sibling relative-time formatters in the TUI.

## Problem

The Routines schedule preview (`previewSchedule` → `formatRelative` in `packages/kobe/src/tui/component/automation-composer.ts`) **rounded** its coarse "next run in …" bucket up:

```ts
const minutes = Math.max(1, Math.round(deltaMs / 60_000))
if (minutes < 60) return `in ${minutes}m`
const hours = Math.round(minutes / 60)   // round(90/60) = 2
if (hours < 24) return `in ${hours}h`
return `in ${Math.round(hours / 24)}d`   // round(36/24) = 2
```

So a run **90 minutes** away rendered `in 2h`, and one **36 hours** away rendered `in 2d` — promising more headroom than the schedule actually has. It also disagreed with the sibling elapsed formatter `formatAgo` (`packages/kobe/src/tui-react/component/settings-dialog/plugins-core.ts:124`), which **floors** every bucket. The same 90-minute gap therefore read "1h" as elapsed but "2h" as time-until-next-run.

## Fix

Floor every bucket in `formatRelative`, matching `formatAgo`. A countdown now reads as "at least N": 90 minutes out is `in 1h`, 36 hours out is `in 1d`. One coherent rule, no behavior change at exact unit boundaries (`in 4h`, `in 15m`, `in 23h`, `in 1h` all stay identical).

## Verification

- Added two regression tests in `test/tui/automation-composer.test.ts` (90-min → `in 1h`, 36-hour → `in 1d`) that fail under the old rounding and pass now.
- `bunx vitest run test/tui/automation-composer.test.ts` → 18 passed.
- `bun test test/render/automations-page-keys.test.tsx` → 8 passed (the `in 1h` render assertion is unchanged).
- `bun run lint` and `bun run typecheck` both green.
- Changeset added (`patch`).

## Follow-ups deferred

- The bug hunt also surfaced `sortByTimestamp` in `engine/history-cache.ts` comparing ISO timestamps lexicographically rather than by parsed instant — real but effectively unreachable with the uniform-UTC timestamps the engines emit, and switching to `Date.parse` needs NaN-safety care, so I left it out of this slice.
- The `jump-digits.ts` doc comment claims `ctrl+9`/`ctrl+0` "send nothing," which contradicts the deliberate owner keybinding decision recorded in `terminal-keys-pure.test.ts` and the CHANGELOG that reserves them; that's a stale comment on an owner-taste call, not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GktqDu5yUGmQuc9RN58CgK)_