### PR TITLE
fix: land refuses zero-commit branches instead of silently merging a no-op (#38)

### DIFF
--- a/.changeset/land-reject-empty-branch.md
+++ b/.changeset/land-reject-empty-branch.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`land` now refuses to merge a branch with zero commits ahead of the base instead of silently landing a no-op. If the task's worktree still holds uncommitted files, the error (`EMPTY_BRANCH_DIRTY_WORKTREE`) lists them and points at committing in the worktree; a clean worktree fails with `EMPTY_BRANCH`, surfacing the "worker reported success but delivered nothing" case.

--- a/.changeset/land-reject-empty-branch.md
+++ b/.changeset/land-reject-empty-branch.md
@@ -2,4 +2,4 @@
 "@sma1lboy/rove": patch
 ---
 
-`land` now refuses to merge a branch with zero commits ahead of the base instead of silently landing a no-op. If the task's worktree still holds uncommitted files, the error (`EMPTY_BRANCH_DIRTY_WORKTREE`) lists them and points at committing in the worktree; a clean worktree fails with `EMPTY_BRANCH`, surfacing the "worker reported success but delivered nothing" case.
+`land` now refuses to merge a branch with zero commits ahead of the base instead of silently landing a no-op. If the task's worktree still holds uncommitted files, the error (`EMPTY_BRANCH_DIRTY_WORKTREE`) lists them and carries an executable recovery path (`hint` + `nextCommandArgs`) that sends the worker back to commit its own work; a clean worktree fails with `EMPTY_BRANCH` and no auto-recovery, surfacing the "worker reported success but delivered nothing" case for a human.

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -5,9 +5,11 @@
  * Split out of `api-cmd.ts` (see that file's header).
  */
 
+import { errorMessage } from "@/lib/error-message"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
 import { kobeApiInvocation } from "../../engine/interactive-command.ts"
+import { EMPTY_BRANCH_DIRTY_WORKTREE_CODE } from "../../orchestrator/errors.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
 import { readOwnDispatcher, resolveDispatcherTab, verifiedSelfSession } from "./dispatcher.ts"
@@ -259,17 +261,51 @@ export async function land(ctx: VerbContext): Promise<unknown> {
   const taskId = ctx.args.require("task-id")
   const strategy = ctx.args.str("strategy") === "squash" ? "squash" : "merge"
   const removeWorktree = ctx.args.bool("remove-worktree") ?? false
-  const res = await daemon.request<{ result: unknown }>("task.land", {
-    taskId,
-    strategy,
-    deleteBranch: ctx.args.bool("delete-branch") ?? false,
-    archive: ctx.args.bool("then-archive") ?? false,
-    removeWorktree,
-    // The daemon refuses to remove the worktree the caller is running from —
-    // it can only know where the caller is if we tell it.
-    ...(removeWorktree ? { callerCwd: process.cwd() } : {}),
-  })
+  let res: { result: unknown }
+  try {
+    res = await daemon.request<{ result: unknown }>("task.land", {
+      taskId,
+      strategy,
+      deleteBranch: ctx.args.bool("delete-branch") ?? false,
+      archive: ctx.args.bool("then-archive") ?? false,
+      removeWorktree,
+      // The daemon refuses to remove the worktree the caller is running from —
+      // it can only know where the caller is if we tell it.
+      ...(removeWorktree ? { callerCwd: process.cwd() } : {}),
+    })
+  } catch (err) {
+    throw landRecoveryError(err, taskId)
+  }
   return { ok: true, taskId, ...(res.result as object) }
+}
+
+/**
+ * Give EMPTY_BRANCH_DIRTY_WORKTREE an executable recovery path (the
+ * self-healing `hint` + `nextCommandArgs` convention, same shape as
+ * TASK_NOT_FOUND): the worker WROTE its work but never committed it, so the
+ * recovery is a `send` back to THAT worker telling it to commit its own work
+ * with its own message — never an auto-commit here, the commit message
+ * belongs to whoever did the work. The branch name rides the daemon's error
+ * message (only the message survives the RPC wire), so it is lifted back out
+ * for the prompt. The clean-worktree variant (EMPTY_BRANCH) deliberately
+ * gets NO recovery path: "worker reported success but delivered nothing" is
+ * a signal a human must look at, not something to auto-retry.
+ */
+function landRecoveryError(err: unknown, taskId: string): unknown {
+  const message = errorMessage(err)
+  if (!message.includes(EMPTY_BRANCH_DIRTY_WORKTREE_CODE)) return err
+  const branch = /EMPTY_BRANCH_DIRTY_WORKTREE: '([^']+)'/.exec(message)?.[1] ?? "your task branch"
+  return new ApiError(message, EMPTY_BRANCH_DIRTY_WORKTREE_CODE, {
+    hint: "the worker wrote files but never committed them — send it back to commit its own work, then land again",
+    nextCommandArgs: [
+      "api",
+      "send",
+      "--task-id",
+      taskId,
+      "--prompt",
+      `your work is uncommitted on ${branch} — commit it yourself with a proper message, then report back`,
+    ],
+  })
 }
 
 export async function adopt(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -429,7 +429,7 @@ export const VERBS: readonly VerbSpec[] = [
   {
     name: "land",
     summary:
-      "Merge a task's branch back into its base repo's current branch. Refuses a dirty base checkout; on conflict, aborts and returns the conflicted files (resolve by hand). Returns { landedOn, commit }.",
+      "Merge a task's branch back into its base repo's current branch. Refuses a dirty base checkout and refuses a branch with zero commits ahead of the base (EMPTY_BRANCH; EMPTY_BRANCH_DIRTY_WORKTREE with a send-back recovery path when the worktree still holds the uncommitted work). On conflict, aborts and returns the conflicted files (resolve by hand). Returns { landedOn, commit }.",
     flags: [
       F.taskId(),
       {

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -107,6 +107,56 @@ export class MainCheckoutDirtyError extends Error {
 }
 
 /**
+ * Stable sentinel embedded in {@link EmptyBranchError}'s message — same
+ * wire-boundary reason as {@link DIRTY_WORKTREE_CODE}.
+ */
+export const EMPTY_BRANCH_CODE = "EMPTY_BRANCH"
+
+/**
+ * Thrown by `landTask` when the task branch has ZERO commits ahead of the base
+ * branch and its worktree is clean (or gone). Merging it would be a no-op —
+ * the classic shape of "worker reported success but delivered nothing" — so we
+ * refuse loudly instead of landing an empty merge into main.
+ */
+export class EmptyBranchError extends Error {
+  constructor(
+    public readonly branch: string,
+    public readonly landedOn: string,
+  ) {
+    super(
+      `${EMPTY_BRANCH_CODE}: '${branch}' has no commits ahead of '${landedOn}' — landing it would be a no-op (the worker may not have delivered anything)`,
+    )
+    this.name = "EmptyBranchError"
+  }
+}
+
+/**
+ * Stable sentinel embedded in {@link EmptyBranchDirtyWorktreeError}'s message.
+ */
+export const EMPTY_BRANCH_DIRTY_WORKTREE_CODE = "EMPTY_BRANCH_DIRTY_WORKTREE"
+
+/**
+ * Thrown by `landTask` when the task branch has ZERO commits ahead of the base
+ * branch AND its worktree still has uncommitted/untracked files: the work was
+ * written but never committed, so landing would silently drop it. The file
+ * list rides in the message; the hint points at committing in the worktree.
+ */
+export class EmptyBranchDirtyWorktreeError extends Error {
+  constructor(
+    public readonly branch: string,
+    public readonly landedOn: string,
+    public readonly worktreePath: string,
+    public readonly files: readonly string[],
+  ) {
+    const list = files.length > 0 ? files.join(", ") : "(none reported)"
+    super(
+      `${EMPTY_BRANCH_DIRTY_WORKTREE_CODE}: '${branch}' has no commits ahead of '${landedOn}' but its worktree ${worktreePath} has uncommitted changes (${list}) — commit them in the worktree first, then land again`,
+    )
+    this.name = "EmptyBranchDirtyWorktreeError"
+  }
+}
+
+/**
  * Stable sentinel embedded in {@link LandConflictError}'s message — same
  * wire-boundary reason as {@link DIRTY_WORKTREE_CODE}. The conflicted-file list
  * rides along in the message so a CLI/TUI caller can print it after matching.

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -20,9 +20,9 @@ import fs from "node:fs"
 import path from "node:path"
 import type { ExecHost } from "../exec/exec-host.ts"
 import type { Task, TaskId } from "../types/task.ts"
-import { LandConflictError, MainCheckoutDirtyError } from "./errors.ts"
+import { EmptyBranchDirtyWorktreeError, EmptyBranchError, LandConflictError, MainCheckoutDirtyError } from "./errors.ts"
 import { type WorktreeExecDeps, defaultExecDeps } from "./worktree/exec-deps.ts"
-import type { GitWorktreeManager } from "./worktree/manager.ts"
+import { GitWorktreeManager } from "./worktree/manager.ts"
 
 export type LandStrategy = "merge" | "squash"
 
@@ -160,13 +160,65 @@ async function conflictedFiles(exec: ExecHost, dir: string): Promise<string[]> {
     .filter((l) => l.length > 0)
 }
 
+/** Uncommitted/untracked paths from `git status --porcelain` output (strip the XY prefix). */
+function porcelainPaths(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => l.slice(3).trim())
+}
+
+/**
+ * Refuse to land a branch with ZERO commits ahead of the base — that merge is
+ * a git-level no-op, and in practice it means "worker reported success but
+ * delivered nothing committed". Two distinct refusals:
+ *   - worktree still dirty → the work exists but was never committed
+ *     ({@link EmptyBranchDirtyWorktreeError}, lists the files + hint);
+ *   - worktree clean/gone → genuine no-op ({@link EmptyBranchError}).
+ * An unreadable worktree (already removed, remote path mismatch) falls through
+ * to the clean case — ambiguity must not hide the no-op signal.
+ */
+async function assertBranchHasWork(
+  task: Task,
+  branch: string,
+  landedOn: string,
+  exec: ExecHost,
+  dir: string,
+  deps: WorktreeExecDeps,
+): Promise<void> {
+  const aheadOut = await git(exec, dir, ["rev-list", "--count", `${landedOn}..${branch}`])
+  const ahead = Number.parseInt(aheadOut.stdout.trim(), 10)
+  if (!Number.isFinite(ahead) || ahead > 0) return
+  const worktreePath = task.worktreePath.trim()
+  if (worktreePath) {
+    const manager = new GitWorktreeManager(deps)
+    let dirty = false
+    try {
+      dirty = await manager.isDirty(worktreePath)
+    } catch {
+      dirty = false // worktree gone/unreadable → treat as the clean no-op case
+    }
+    if (dirty) {
+      const wtExec = deps.execForPath(worktreePath)
+      const files = porcelainPaths((await git(wtExec, worktreePath, ["status", "--porcelain"])).stdout)
+      throw new EmptyBranchDirtyWorktreeError(branch, landedOn, worktreePath, files)
+    }
+  }
+  throw new EmptyBranchError(branch, landedOn)
+}
+
 /**
  * Land `task`'s branch into its base repo's current branch.
  *
  * Preconditions checked here (fail before any git write):
  *   - the task has a branch to land (a never-materialised task has none);
  *   - the base checkout is clean — a merge into a dirty tree would entangle the
- *     user's in-progress work with the landed branch, so we refuse.
+ *     user's in-progress work with the landed branch, so we refuse;
+ *   - the branch has at least one commit ahead of the base — a zero-commit
+ *     branch is a no-op land ("worker reported success, delivered nothing"),
+ *     refused as {@link EmptyBranchError}, or as
+ *     {@link EmptyBranchDirtyWorktreeError} when the worktree still holds the
+ *     never-committed work.
  *
  * On conflict: abort the merge (leaving the base checkout exactly as it was) and
  * throw {@link LandConflictError} with the conflicted paths. On success: return
@@ -193,6 +245,10 @@ export async function landTask(
   }
 
   if (await isDirty(exec, dir)) throw new MainCheckoutDirtyError(task.repo, dir)
+
+  // Fail BEFORE any merge: a branch with zero commits ahead of the base is a
+  // no-op land — refuse it (and its never-committed-work variant) loudly.
+  await assertBranchHasWork(task, branch, landedOn, exec, dir, deps)
 
   if (strategy === "squash") {
     const merge = await git(exec, dir, ["merge", "--squash", branch])

--- a/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
+++ b/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
@@ -186,6 +186,52 @@ describe("task lifecycle handlers", () => {
     expect(payload.callerCwd).toBeUndefined()
   })
 
+  it("land maps EMPTY_BRANCH_DIRTY_WORKTREE to an executable recovery send (worker commits its own work)", async () => {
+    // The daemon wire preserves only the message, so the CLI lifts the branch
+    // back out of it for the prefilled prompt.
+    const client = new FakeClient({
+      "task.land": () => {
+        throw new Error(
+          "EMPTY_BRANCH_DIRTY_WORKTREE: 'rove/wip' has no commits ahead of 'main' but its worktree /tmp/wt has uncommitted changes (wip.txt) — commit them in the worktree first, then land again",
+        )
+      },
+    })
+    try {
+      await invokeVerb("land", ["--task-id", "t1"], { client, runtime: stubRuntime() })
+      expect.unreachable("should have thrown")
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiErr = err as ApiError
+      expect(apiErr.code).toBe("EMPTY_BRANCH_DIRTY_WORKTREE")
+      expect(apiErr.data?.hint).toMatch(/commit its own work/)
+      expect(apiErr.data?.nextCommandArgs).toEqual([
+        "api",
+        "send",
+        "--task-id",
+        "t1",
+        "--prompt",
+        "your work is uncommitted on rove/wip — commit it yourself with a proper message, then report back",
+      ])
+    }
+  })
+
+  it("land passes EMPTY_BRANCH (clean worktree) through with no recovery path — a human must look", async () => {
+    const client = new FakeClient({
+      "task.land": () => {
+        throw new Error(
+          "EMPTY_BRANCH: 'rove/nothing' has no commits ahead of 'main' — landing it would be a no-op (the worker may not have delivered anything)",
+        )
+      },
+    })
+    // No hint/nextCommandArgs mapping — toApiError falls through to RPC_ERROR,
+    // and the EMPTY_BRANCH code still rides the message for matching.
+    await expectApiError(
+      () => invokeVerb("land", ["--task-id", "t1"], { client, runtime: stubRuntime() }),
+      "RPC_ERROR",
+      /EMPTY_BRANCH/,
+    )
+  })
+
   it("sets and clears active task", async () => {
     const client = new FakeClient({ "task.setActive": () => ({}) })
     await invokeVerb("set-active", ["--task-id", "t1"], { client, runtime: stubRuntime() })

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -13,7 +13,14 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
-import { LandConflictError, MainCheckoutDirtyError } from "../../src/orchestrator/errors.ts"
+import {
+  EMPTY_BRANCH_CODE,
+  EMPTY_BRANCH_DIRTY_WORKTREE_CODE,
+  EmptyBranchDirtyWorktreeError,
+  EmptyBranchError,
+  LandConflictError,
+  MainCheckoutDirtyError,
+} from "../../src/orchestrator/errors.ts"
 import { landTask, landTaskWithCleanup } from "../../src/orchestrator/land.ts"
 import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
 import type { Task } from "../../src/types/task.ts"
@@ -113,18 +120,55 @@ describe("landTask", () => {
     expect(status).toBe("")
   })
 
-  test("merge refuses a branch with nothing to land (already merged / no commits ahead)", async () => {
-    // `feat` branches off main but adds no commits of its own, so it is fully
-    // merged into main from the start. `git merge --no-ff` exits 0 ("Already up
-    // to date.") without creating a commit — landTask must reject this rather
-    // than report a fake success on the unchanged base commit.
+  test("merge refuses a branch with no commits ahead (already merged / empty)", async () => {
+    // `feat` branches off main but adds no commits of its own. Landing it
+    // would be a git-level no-op — landTask must reject it as EMPTY_BRANCH
+    // rather than report a fake success on the unchanged base commit.
     git(["branch", "feat"], repo)
     const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
 
-    await expect(landTask(task("feat"))).rejects.toThrow(/nothing to land/)
+    await expect(landTask(task("feat"))).rejects.toBeInstanceOf(EmptyBranchError)
+    await expect(landTask(task("feat"))).rejects.toThrow(EMPTY_BRANCH_CODE)
     // Base checkout must be untouched — no phantom merge commit.
     const after = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
     expect(after).toBe(head)
+  })
+
+  test("empty branch + clean worktree → EMPTY_BRANCH (no-op, worker delivered nothing)", async () => {
+    // A materialised worktree on `feat` with no commits and no local changes:
+    // the worker may have reported success without delivering anything.
+    const wt = path.join(tmpRoot, "wt-clean")
+    git(["worktree", "add", "-b", "feat", wt], repo)
+    const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
+
+    await expect(landTask({ ...task("feat"), worktreePath: wt })).rejects.toBeInstanceOf(EmptyBranchError)
+    await expect(landTask({ ...task("feat"), worktreePath: wt })).rejects.toThrow(/no-op/)
+    const after = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
+    expect(after).toBe(head)
+  })
+
+  test("empty branch + dirty worktree → EMPTY_BRANCH_DIRTY_WORKTREE listing the uncommitted files", async () => {
+    // The work was WRITTEN but never committed: branch has 0 commits ahead,
+    // the worktree still holds the changes. Refuse, name the files, and hint
+    // at committing in the worktree — never silently drop them into a no-op.
+    const wt = path.join(tmpRoot, "wt-dirty")
+    git(["worktree", "add", "-b", "feat", wt], repo)
+    fs.writeFileSync(path.join(wt, "wip.txt"), "uncommitted work\n")
+
+    try {
+      await landTask({ ...task("feat"), worktreePath: wt })
+      expect.unreachable("landTask should refuse an empty branch with a dirty worktree")
+    } catch (err) {
+      expect(err).toBeInstanceOf(EmptyBranchDirtyWorktreeError)
+      const msg = (err as Error).message
+      expect(msg).toContain(EMPTY_BRANCH_DIRTY_WORKTREE_CODE)
+      expect(msg).toContain("wip.txt")
+      expect(msg).toContain(wt)
+      expect(msg).toMatch(/commit them in the worktree/)
+    }
+    // The uncommitted file survives the refusal, and the base is untouched.
+    expect(fs.existsSync(path.join(wt, "wip.txt"))).toBe(true)
+    expect(fs.existsSync(path.join(repo, "wip.txt"))).toBe(false)
   })
 
   test("refuses a dirty base checkout", async () => {


### PR DESCRIPTION
Closes the land-path half of issue #38: a branch with 0 commits ahead of the base merges cleanly at the git level, so `land` returned success while main never changed — the classic "worker reported success but delivered nothing" failure.

## What changed

- `landTask` now checks `git rev-list --count <base>..<branch>` **before** any merge.
  - **0 ahead + worktree dirty** → `EmptyBranchDirtyWorktreeError` (`EMPTY_BRANCH_DIRTY_WORKTREE`): the work was written but never committed — the message lists the uncommitted files and hints to commit them in the worktree. Worktree dirtiness comes from `GitWorktreeManager.isDirty`.
  - **0 ahead + worktree clean/gone** → `EmptyBranchError` (`EMPTY_BRANCH`): a genuine no-op, surfaced loudly instead of a fake success. An unreadable worktree falls through to this case.
  - Error shape follows the existing `MAIN_CHECKOUT_DIRTY` convention: stable wire-visible code embedded in the message + hint.
- The pre-existing post-merge "nothing to land" guards stay as backstops for the already-merged-with-commits edge.

## Tests

- `empty branch + clean worktree → EMPTY_BRANCH`
- `empty branch + dirty worktree → EMPTY_BRANCH_DIRTY_WORKTREE` (asserts the file list, worktree path, and hint; verifies the uncommitted file survives)
- The old "nothing to land" test updated to the new `EMPTY_BRANCH` expectation.

Slice boundary respected: only `orchestrator/land.ts`, `orchestrator/errors.ts`, and the land tests are touched — no delete/archive/GC changes.