### PR TITLE
feat: derive auto branch names from the repo's own naming convention

### DIFF
--- a/.changeset/repo-convention-branch-names.md
+++ b/.changeset/repo-convention-branch-names.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Auto branch names now follow the target repo's own naming convention instead of `rove/<slug>-<id>`: Rove scans existing local + origin branches to infer the dominant style (type prefixes like `feat/`/`fix/` or bare kebab slugs), applies it to the title-derived slug, and resolves collisions with short `-2`/`-3` suffixes. Generated names never contain rove/kobe branding; empty repos fall back to a bare kebab slug. Explicit `--branch` and `set-branch` are unchanged, and existing branches are never renamed.

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ back to the dispatching engine tab: creation records the dispatcher
 stored report, no blocking wait. Silence is a checkpoint, never a verdict:
 
 ```bash
-rove api send --prompt "succeeded: auth flow simplified (branch rove/auth-flow)"
+rove api send --prompt "succeeded: auth flow simplified (branch fix/auth-flow)"
 ```
 
 **Observe** — read the engine's own structured session, never scrape a TUI
@@ -168,7 +168,11 @@ replacement in `nextCommandArgs`.
   [--pin] [--activate] [--prompt TEXT]`: create a task (appears in the
   sidebar immediately). With `--prompt` it also materializes the worktree,
   starts the engine, and delivers the prompt. Does not steal focus unless
-  `--activate`. Alias: `spawn-task`.
+  `--activate`. Alias: `spawn-task`. Without `--branch`, the branch name is
+  auto-derived from the title following the repo's own branch-naming
+  convention (inferred from its existing local + origin branches — e.g.
+  `feat/login-flow` in a type-prefixed repo, `login-flow` in a bare-slug or
+  empty repo; name collisions get a short `-2`/`-3` suffix).
 
   **Parallel attempts** live here too: `--count N` spawns N sibling tasks of
   the SAME prompt, each with its own worktree and branch, sharing one
@@ -298,8 +302,8 @@ GitHub's, and nothing is copied into Rove's own issue store. Mechanics:
 - `workitem-start --repo PATH --number N [--vendor V] [--base-branch B]`:
   create a task for issue N and start its engine with the issue title, body,
   and URL as the first message. The task keeps a `linkedWorkItem` pointing
-  back, and its branch derives from the issue title
-  (`rove/307-memory-ce2e8j`).
+  back, and its branch derives from the issue title following the repo's
+  branch-naming convention.
 
 Requires `gh` installed and authenticated; failures name which of those is
 missing (`gh-missing` / `auth` / `no-remote`) rather than a generic error.

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -8,6 +8,18 @@ For the difference between a Task, Worktree, Terminal Tab and Split, start
 with [Concepts](CONCEPTS.md). To create or adopt a task, see
 [The TUI](TUI.md#creating-a-task).
 
+## Branch naming
+
+A managed task created without an explicit branch derives its branch name
+from the task title, following the repository's own naming convention: Rove
+scans the repo's existing branches (local + `origin`) and matches the
+dominant style — a type prefix like `feat/`/`fix/`/`chore/` when that's what
+the repo uses, or a bare kebab slug otherwise (also the fallback for an
+empty repo). Name collisions get a short `-2`/`-3` suffix. Generated names
+never contain Rove branding. An explicit `--branch` on creation and
+`set-branch` afterwards override this entirely; existing branches are never
+renamed retroactively.
+
 ## Open and navigate the page
 
 1. Focus the task sidebar with `ctrl+q`.

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -152,8 +152,7 @@ export const VERBS: readonly VerbSpec[] = [
         name: "branch",
         type: "string",
         placeholder: "B",
-        description:
-          "Explicit branch name (else auto-derived from the title, following the repo's own branch-naming convention). Single task only.",
+        description: "Explicit branch name (else derived from the title in the repo's own style). Single task only.",
       },
       { name: "base-branch", type: "string", placeholder: "B", description: "Base ref the worktree branches from." },
       F.command(),

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -152,7 +152,8 @@ export const VERBS: readonly VerbSpec[] = [
         name: "branch",
         type: "string",
         placeholder: "B",
-        description: "Explicit branch name (else auto rove/<slug>-<id>). Single task only.",
+        description:
+          "Explicit branch name (else auto-derived from the title, following the repo's own branch-naming convention). Single task only.",
       },
       { name: "base-branch", type: "string", placeholder: "B", description: "Base ref the worktree branches from." },
       F.command(),

--- a/packages/kobe/src/orchestrator/branch-style.ts
+++ b/packages/kobe/src/orchestrator/branch-style.ts
@@ -1,0 +1,129 @@
+/**
+ * Repo-convention branch naming (issue #39).
+ *
+ * A managed task's auto branch used to be `rove/<slug>-<id6>`, which baked
+ * the tool's brand into the user's git history. Instead we scan the target
+ * repo's existing branch names (local + origin) and infer its dominant
+ * naming style — conventional type prefixes (`feat/`, `fix/`, `chore/`, …)
+ * or bare kebab slugs — then apply that style to a slug derived from the
+ * task title. Guarantees:
+ *
+ *   - The generated name NEVER contains "rove" or "kobe" (brand tokens are
+ *     stripped from the slug; prefixes only come from the conventional set).
+ *   - Collisions get a short `-2` / `-3` suffix, not a machine ulid tail.
+ *   - No inferable convention (empty repo, no branches) → bare kebab slug.
+ *
+ * Everything here is pure; the coordinator supplies the branch-name list
+ * and the taken-set.
+ */
+
+/**
+ * Conventional-commit-style branch type prefixes. Used both to recognise a
+ * "typed" repo convention and to lift a leading type word out of a title
+ * ("Fix login flow" → `fix/login-flow` in a typed repo).
+ */
+const TYPE_PREFIXES = new Set([
+  "feat",
+  "feature",
+  "fix",
+  "bugfix",
+  "hotfix",
+  "chore",
+  "docs",
+  "doc",
+  "refactor",
+  "test",
+  "tests",
+  "ci",
+  "build",
+  "perf",
+  "style",
+  "revert",
+  "release",
+])
+
+/** Tool-brand tokens that must never appear in a generated branch name. */
+const BRAND_TOKENS = new Set(["rove", "kobe"])
+
+export type BranchStyle = { readonly kind: "bare" } | { readonly kind: "typed"; readonly defaultPrefix: string }
+
+/**
+ * Infer the repo's dominant branch-naming style from its branch names
+ * (local + origin, remote prefix already stripped). Votes: a name with a
+ * conventional type prefix counts as "typed"; a name with no slash counts
+ * as "bare"; other prefixes (`user/…`, `backup/…`, legacy `rove/…`) don't
+ * vote — they're neither convention. Ties break toward "typed" so a repo
+ * whose only branches are `main` + `feat/x` reads as typed (the default
+ * branch always votes bare). No votes at all → bare.
+ */
+export function inferBranchStyle(names: readonly string[]): BranchStyle {
+  const typed = new Map<string, number>()
+  let bare = 0
+  for (const raw of new Set(names)) {
+    const name = raw.trim()
+    if (!name || name === "HEAD") continue
+    const slash = name.indexOf("/")
+    if (slash === -1) {
+      bare += 1
+      continue
+    }
+    const prefix = name.slice(0, slash)
+    if (TYPE_PREFIXES.has(prefix)) typed.set(prefix, (typed.get(prefix) ?? 0) + 1)
+  }
+  let typedTotal = 0
+  for (const n of typed.values()) typedTotal += n
+  if (typedTotal === 0 || typedTotal < bare) return { kind: "bare" }
+  // Most common prefix wins; ties resolve alphabetically for determinism.
+  let best = ""
+  let bestN = 0
+  for (const [prefix, n] of typed) {
+    if (n > bestN || (n === bestN && (best === "" || prefix < best))) {
+      best = prefix
+      bestN = n
+    }
+  }
+  return { kind: "typed", defaultPrefix: best }
+}
+
+/** Kebab tokens from a title, with brand tokens removed. */
+function slugTokens(title: string): string[] {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .split("-")
+    .filter((t) => t.length > 0 && !BRAND_TOKENS.has(t))
+}
+
+/** Join tokens, cap at 32 chars, and re-trim a hyphen the cap can expose. */
+function capSlug(tokens: readonly string[]): string {
+  return tokens.join("-").slice(0, 32).replace(/-+$/, "")
+}
+
+/**
+ * Derive a convention-following branch name from a task title. In a typed
+ * repo, a leading type word in the title becomes the prefix ("Fix login
+ * flow" → `fix/login-flow`); otherwise the repo's most common prefix is
+ * used. In a bare repo the slug stands alone. Empty slug → "task".
+ */
+export function deriveConventionBranch(title: string, style: BranchStyle): string {
+  const tokens = slugTokens(title)
+  if (style.kind === "typed") {
+    const first = tokens[0]
+    const prefix = first !== undefined && TYPE_PREFIXES.has(first) ? (tokens.shift() as string) : style.defaultPrefix
+    return `${prefix}/${capSlug(tokens) || "task"}`
+  }
+  return capSlug(tokens) || "task"
+}
+
+/**
+ * First free name among `base`, `base-2` … `base-99`; past that (taken-set
+ * pathology) fall back to a short task-id suffix so allocation never fails.
+ */
+export function uniqueBranchName(base: string, taken: ReadonlySet<string>, taskId: string): string {
+  if (!taken.has(base)) return base
+  for (let n = 2; n <= 99; n += 1) {
+    const candidate = `${base}-${n}`
+    if (!taken.has(candidate)) return candidate
+  }
+  return `${base}-${taskId.slice(-6).toLowerCase()}`
+}

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -201,13 +201,11 @@ export class Orchestrator {
     await this.ensureMainTask(input.repo)
     const title = (input.title ?? PLACEHOLDER_TASK_TITLE).trim() || PLACEHOLDER_TASK_TITLE
     // Leave the branch EMPTY for a lazily-allocated task (unless the caller
-    // gave an explicit one): {@link ensureWorktree} derives a unique
-    // `rove/<slug>-<id>` from the task's OWN id when the worktree
-    // materialises. We must NOT pre-derive a branch here — at create time
-    // there is no task id yet, so every placeholder-titled task would get
-    // the SAME name (`rove/new-task-…`) and the second `git worktree add
-    // -b` would fail on a duplicate branch. Deferring also lets
-    // the branch follow a rename made before first enter.
+    // gave an explicit one): {@link ensureWorktree} derives a repo-convention
+    // name (branch-style.ts) with collision suffixes when the worktree
+    // materialises. We must NOT pre-derive a branch here — uniqueness is
+    // resolved against the repo's live branch list at materialise time, and
+    // deferring also lets the branch follow a rename made before first enter.
     const task = await this.store.create({
       repo: input.repo,
       title,

--- a/packages/kobe/src/orchestrator/task-editor.ts
+++ b/packages/kobe/src/orchestrator/task-editor.ts
@@ -20,9 +20,10 @@ import type {
   TaskStatus,
   VendorId,
 } from "../types/task.ts"
+import { deriveConventionBranch, inferBranchStyle, uniqueBranchName } from "./branch-style.ts"
 import { IllegalTransitionError, TaskNotFoundError } from "./errors.ts"
 import type { TaskIndexStore } from "./index/store.ts"
-import { autoBranch, isPlaceholderDerivedBranch } from "./title.ts"
+import { isPlaceholderDerivedBranch } from "./title.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
 
 /**
@@ -57,9 +58,9 @@ export class TaskEditor {
 
   /**
    * Keep a materialised task's branch in lockstep with its title WHILE the
-   * branch is still the placeholder-derived default (`rove/new-task-<id>`).
-   * This is what lets a task auto-named from its first prompt also pick up a
-   * meaningful branch instead of staying `rove/new-task-…`. It fires at most
+   * branch is still the placeholder-derived default (`new-task`, or a legacy
+   * `rove/`/`kobe/` spelling). This is what lets a task auto-named from its
+   * first prompt also pick up a meaningful branch. It fires at most
    * once: after the first rename the branch no longer matches the placeholder
    * derivation, so a later title change (or a manual `setBranch`) is never
    * clobbered. Skipped for `main` (no branch) and for not-yet-materialised
@@ -78,30 +79,19 @@ export class TaskEditor {
   private async followBranchToTitle(taskBefore: Task, newTitle: string): Promise<void> {
     if (taskBefore.kind === "main" || !taskBefore.worktreePath) return
     if (!isPlaceholderDerivedBranch(taskBefore.branch, taskBefore.id)) return
-    const base = autoBranch(newTitle, taskBefore.id)
-    if (base === taskBefore.branch) return
     try {
+      const names = await this.worktrees.listBranchNames(taskBefore.repo)
+      const base = deriveConventionBranch(newTitle, inferBranchStyle(names))
+      if (base === taskBefore.branch) return
       if (await this.worktrees.branchHasUpstream(taskBefore.worktreePath, taskBefore.branch)) return
-      const nextBranch = await this.uniqueFollowBranch(taskBefore, base)
-      if (!nextBranch) return
+      // Exclude the branch we're renaming FROM so a placeholder like
+      // `new-task` can never block its own successor's `-2` scan.
+      const taken = new Set(names.filter((n) => n !== taskBefore.branch))
+      const nextBranch = uniqueBranchName(base, taken, taskBefore.id)
       await this.setBranch(taskBefore.id, nextBranch)
     } catch (err) {
       console.error(`[rove] follow-branch-to-title failed for ${taskBefore.id}:`, err)
     }
-  }
-
-  /**
-   * `base` if it's free, else the first free `base-2` … `base-9`, else null
-   * (keep the placeholder). The `-<id6>` suffix in {@link autoBranch} makes a
-   * collision near-impossible, so a short bounded scan is plenty.
-   */
-  private async uniqueFollowBranch(task: Task, base: string): Promise<string | null> {
-    if (!(await this.worktrees.hasLocalBranch(task.worktreePath, base))) return base
-    for (let n = 2; n <= 9; n += 1) {
-      const candidate = `${base}-${n}`
-      if (!(await this.worktrees.hasLocalBranch(task.worktreePath, candidate))) return candidate
-    }
-    return null
   }
 
   /**

--- a/packages/kobe/src/orchestrator/title.ts
+++ b/packages/kobe/src/orchestrator/title.ts
@@ -1,11 +1,12 @@
 /**
- * Title and branch derivation (v0.6).
+ * Title derivation + placeholder-branch recognition.
  *
- * Used by the orchestrator's `createTask` when the user gives a title
- * but no explicit branch — we derive a `rove/<slug>-<id>` name.
- * `deriveTitleFromPrompt` is kept for the rare case where we still
- * accept a free-form prompt as a title source (e.g. external callers
- * via the daemon RPC); v0.6 itself doesn't surface that path.
+ * Branch NAMES are no longer derived here — `branch-style.ts` owns the
+ * repo-convention naming (issue #39). This module keeps the title helpers
+ * and the placeholder-branch discriminator that the first-rename
+ * branch-follow flow depends on. `deriveTitleFromPrompt` is kept for the
+ * rare case where we still accept a free-form prompt as a title source
+ * (e.g. external callers via the daemon RPC).
  */
 
 /** Title cap. Kept generous for branch slugs; the compact sidebar truncates visually. */
@@ -38,36 +39,15 @@ export function deriveTitleFromPrompt(prompt: string): string {
 }
 
 /**
- * Build `rove/<slug>-<ulid-suffix-6>` from a user-supplied title and a
- * freshly-minted ulid. The 6-char suffix comes from the ulid's random
- * tail, so two tasks created from the same placeholder title still get
- * distinct branches (branch collisions failed `git worktree
- * add -b`). MUST be passed the real task id, never a fixed placeholder.
- */
-export function autoBranch(title: string, taskId: string): string {
-  const slug = title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 32)
-    // Re-trim after the cap: the 32-char slice can land on a `-` and
-    // re-introduce a trailing hyphen that the template below would then
-    // double into `rove/<slug>--<suffix>`. Only trailing can reappear —
-    // the slice keeps the already-leading-trimmed prefix.
-    .replace(/-+$/, "")
-  const suffix = taskId.slice(-6).toLowerCase()
-  const base = slug || "task"
-  return `rove/${base}-${suffix}`
-}
-
-/**
- * Whether `branch` is still the untouched placeholder-derived default for
- * `taskId`, including the pre-Rove `kobe/` spelling. This is the discriminator
- * `TaskEditor.followBranchToTitle` uses to fire the first-rename branch
- * follow at most once; keeping both accepted spellings beside
- * {@link autoBranch} and {@link PLACEHOLDER_TASK_TITLE} prevents drift.
+ * Whether `branch` is still an untouched placeholder-derived default for
+ * `taskId` — the discriminator `TaskEditor.followBranchToTitle` uses to fire
+ * the first-rename branch follow at most once. Three accepted shapes:
+ * the convention-era `new-task` slug (optionally type-prefixed and/or
+ * `-N`-suffixed, from `branch-style.ts`), and the legacy `rove/` / `kobe/`
+ * `new-task-<id6>` spellings older tasks still carry.
  */
 export function isPlaceholderDerivedBranch(branch: string, taskId: string): boolean {
-  const canonical = autoBranch(PLACEHOLDER_TASK_TITLE, taskId)
-  return branch === canonical || branch === canonical.replace(/^rove\//, "kobe/")
+  const id6 = taskId.slice(-6).toLowerCase()
+  if (branch === `rove/new-task-${id6}` || branch === `kobe/new-task-${id6}`) return true
+  return /^(?:[^/]+\/)?new-task(?:-\d+)?$/.test(branch)
 }

--- a/packages/kobe/src/orchestrator/worktree-coordinator.ts
+++ b/packages/kobe/src/orchestrator/worktree-coordinator.ts
@@ -26,8 +26,9 @@ import { basename } from "node:path"
 import type { Task, TaskId, VendorId } from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
 import type { AdoptableWorktree, WorktreeInfo } from "../types/worktree.ts"
+import { deriveConventionBranch, inferBranchStyle, uniqueBranchName } from "./branch-style.ts"
 import type { TaskIndexStore } from "./index/store.ts"
-import { PLACEHOLDER_TASK_TITLE, autoBranch } from "./title.ts"
+import { PLACEHOLDER_TASK_TITLE } from "./title.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
 import { SlugAllocator } from "./worktree/slug-allocator.ts"
 
@@ -69,6 +70,15 @@ export class WorktreeCoordinator {
   private readonly worktreeLocks = new Map<TaskId, Promise<string>>()
   /** In-flight `adopt` per canonical worktree path — dedupes concurrent adopts. */
   private readonly adoptLocks = new Map<string, Promise<Task>>()
+  /**
+   * Auto branch names currently being materialised. Convention names carry no
+   * random suffix, so two same-titled siblings materialising concurrently (a
+   * parallel round) would both derive the same name and the second
+   * `git worktree add -b` would fail — the git-side taken-set can't see a
+   * branch that doesn't exist yet. Reserved before the git call, released
+   * after (success or failure: on success the branch itself is the guard).
+   */
+  private readonly reservedBranches = new Set<string>()
   /** Optional base-ref per task — consumed once by `ensure`. */
   private readonly pendingBaseRefs = new Map<TaskId, string>()
 
@@ -142,7 +152,7 @@ export class WorktreeCoordinator {
    */
   private async createWorktree(task: Task): Promise<string> {
     const slug = await this.slugs.allocate(task.repo)
-    const branch = task.branch || autoBranch(task.title, task.id)
+    const branch = task.branch || (await this.deriveAutoBranch(task))
     const baseRef = this.pendingBaseRefs.get(task.id)
     let info: WorktreeInfo
     try {
@@ -151,6 +161,10 @@ export class WorktreeCoordinator {
       // Nothing persisted yet — just free the slug for the next attempt.
       this.slugs.cancel(task.repo, slug)
       throw err
+    } finally {
+      // Release the name either way: on success the branch itself now exists
+      // in git (the durable guard); on failure the next attempt re-derives.
+      this.reservedBranches.delete(branch)
     }
     // The worktree now exists on disk. Persist its path BEFORE committing the
     // slug; if the write fails (or the task was deleted concurrently, so the
@@ -166,6 +180,24 @@ export class WorktreeCoordinator {
     this.slugs.commit(task.repo, slug)
     this.pendingBaseRefs.delete(task.id)
     return info.path
+  }
+
+  /**
+   * Derive the auto branch name for a task with no explicit branch: infer
+   * the repo's naming convention from its existing branch names (local +
+   * origin), apply it to the title's slug, and de-collide with a short
+   * `-2` / `-3` suffix against both existing branches and names other
+   * in-flight materialisations just reserved (issue #39). Never contains
+   * a rove/kobe brand token; an unreadable/empty repo falls back to a bare
+   * kebab slug.
+   */
+  private async deriveAutoBranch(task: Task): Promise<string> {
+    const names = await this.worktrees.listBranchNames(task.repo)
+    const base = deriveConventionBranch(task.title, inferBranchStyle(names))
+    const taken = new Set([...names, ...this.reservedBranches])
+    const branch = uniqueBranchName(base, taken, task.id)
+    this.reservedBranches.add(branch)
+    return branch
   }
 
   /**

--- a/packages/kobe/src/orchestrator/worktree/manager-list.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-list.ts
@@ -29,6 +29,35 @@ export interface ListDeps {
   lastActivityMs(ctx: ExecCtx, worktreePath: string): Promise<number>
 }
 
+/**
+ * Branch names of `repo` — local plus `origin`, with the `origin/` prefix
+ * stripped and `HEAD` dropped. The raw material for repo-convention branch
+ * naming (`branch-style.ts`): both the style inference and the taken-set
+ * for uniqueness. Best-effort — an unborn/broken repo yields `[]`, which
+ * the naming layer reads as "no convention".
+ */
+export async function listBranchNames(deps: ListDeps, repo: string): Promise<readonly string[]> {
+  const ctx = deps.ctxFor(repo)
+  requireAbsolute("repo", ctx.dir)
+  let stdout: string
+  try {
+    stdout = await deps.runGitStdout(ctx, [
+      "for-each-ref",
+      "--format=%(refname:short)",
+      "refs/heads",
+      "refs/remotes/origin",
+    ])
+  } catch {
+    return []
+  }
+  const names = new Set<string>()
+  for (const line of stdout.split("\n")) {
+    const name = line.trim().replace(/^origin\//, "")
+    if (name && name !== "HEAD") names.add(name)
+  }
+  return [...names]
+}
+
 /** kobe-managed worktrees under `repo` — see `GitWorktreeManager.list`. */
 export async function listManaged(deps: ListDeps, repo: string): Promise<readonly WorktreeInfo[]> {
   const ctx = deps.ctxFor(repo)

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -31,7 +31,7 @@ import type { ExecHost } from "../../exec/exec-host.ts"
 import type { AdoptableWorktree, WorktreeInfo, WorktreeManager } from "../../types/worktree.ts"
 import { type ExecCtx, type WorktreeExecDeps, defaultExecDeps } from "./exec-deps.ts"
 import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
-import { type ListDeps, adoptablePaths, listAllAdoptable, listManaged } from "./manager-list.ts"
+import { type ListDeps, adoptablePaths, listAllAdoptable, listBranchNames, listManaged } from "./manager-list.ts"
 import { canonicalize, remoteWorktreePathFor, requireAbsolute, worktreePathFor } from "./paths.ts"
 import { parseWorktreeListPorcelain } from "./worktree-list.ts"
 
@@ -300,6 +300,12 @@ export class GitWorktreeManager implements WorktreeManager {
     return adoptablePaths(this.listDeps(), this.ctxFor(repo))
   }
 
+  /** Branch names of `repo` (local + origin, prefix-stripped) — the input
+   *  to repo-convention branch naming. Body in `manager-list.ts`. */
+  listBranchNames(repo: string): Promise<readonly string[]> {
+    return listBranchNames(this.listDeps(), repo)
+  }
+
   /** Whether `worktreePath` still exists on disk (local fs / remote `test -e`). */
   async pathExists(worktreePath: string): Promise<boolean> {
     requireAbsolute("path", worktreePath)
@@ -405,10 +411,8 @@ export class GitWorktreeManager implements WorktreeManager {
   }
 
   /**
-   * Rename a branch in-place. Used by the orchestrator's lazy
-   * branch-naming flow: a fresh worktree is allocated on a temp
-   * `rove/tmp-<ulid>` branch, the engine is asked to suggest a slug, and
-   * we rename once the suggestion lands.
+   * Rename a branch in-place. Used by `setBranch` and the follow-branch-to-
+   * title flow when a placeholder-named task gets its first real title.
    *
    * git's `branch -m <old> <new>` updates HEAD on every worktree that
    * was checked out on `<old>` — the engine's session keeps streaming

--- a/packages/kobe/src/state/repo-init.ts
+++ b/packages/kobe/src/state/repo-init.ts
@@ -75,12 +75,12 @@ export type PromptDeliveryIntent =
  * invocation; tests pass a literal.
  */
 export function newTaskBranchCoda(taskId: string, api: string = kobeApiInvocation(), spawnerTaskId?: string): string {
-  const rename = `PS: this task's git branch name is an auto-generated placeholder. Once you understand the work, rename it to a short descriptive name (keep the rove/ prefix): \`${api} set-branch --task-id ${taskId} --branch rove/<descriptive-slug>\``
+  const rename = `PS: this task's git branch name is an auto-generated placeholder. Once you understand the work, rename it to a short descriptive name following this repo's branch-naming convention: \`${api} set-branch --task-id ${taskId} --branch <descriptive-slug>\``
   if (!spawnerTaskId || spawnerTaskId === taskId) return rename
   // Send-back, not `report`: a stored report only surfaces if the spawner
   // explicitly awaits, which in practice it never does — outcomes silently
   // vanished. `send` lands a full turn in the spawner's chat tab.
-  return `${rename}\n\nYou were spawned by Rove task ${spawnerTaskId}. When the work is finished, send your outcome back to it — include the final branch name: \`${api} send --task-id ${spawnerTaskId} --prompt "<succeeded|failed>: <one-line summary> (branch rove/<slug>)"\``
+  return `${rename}\n\nYou were spawned by Rove task ${spawnerTaskId}. When the work is finished, send your outcome back to it — include the final branch name: \`${api} send --task-id ${spawnerTaskId} --prompt "<succeeded|failed>: <one-line summary> (branch <final-branch>)"\``
 }
 
 const INIT_SCRIPT_RELS = [join(".rove", "init.sh"), join(".kobe", "init.sh")] as const

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -307,7 +307,7 @@ export async function deleteTaskFlow(ctx: TaskActionContext, taskId: string): Pr
 
 /**
  * Rename a task's title via `task.rename` (same RPC from both hosts). The
- * branch follows the title for not-yet-materialised tasks (autoBranch
+ * branch follows the title for not-yet-materialised tasks (the auto branch
  * derives from it); a worktree that already exists keeps its git branch.
  */
 export async function renameTaskFlow(ctx: TaskActionContext, taskId: string): Promise<void> {

--- a/packages/kobe/test/orchestrator/branch-follow.test.ts
+++ b/packages/kobe/test/orchestrator/branch-follow.test.ts
@@ -1,6 +1,6 @@
 /**
  * Branch-follows-title (KOB). When a task's branch is still the
- * placeholder-derived default (`rove/new-task-<id>`, or legacy `kobe/`), renaming the title
+ * placeholder-derived default (`new-task`, or a legacy `rove/`/`kobe/` spelling), renaming the title
  * — including the auto-name from the first prompt — renames the real git
  * branch in lockstep. A manually-set branch, or a branch derived from a
  * non-placeholder title, is never clobbered. Real git + real store on
@@ -14,7 +14,6 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import { Orchestrator } from "../../src/orchestrator/core.ts"
 import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
-import { autoBranch } from "../../src/orchestrator/title.ts"
 import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
 
 const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
@@ -60,13 +59,13 @@ describe("branch follows title", () => {
     const task = await orch.createTask({ repo })
     await orch.ensureWorktree(task.id)
 
-    const placeholderBranch = autoBranch("(new task)", task.id)
+    const placeholderBranch = "new-task"
     expect(orch.getTask(task.id)?.branch).toBe(placeholderBranch)
     expect(gitBranches()).toContain(placeholderBranch)
 
     await orch.setTitle(task.id, "Fix login flow")
 
-    const expected = autoBranch("Fix login flow", task.id)
+    const expected = "fix-login-flow"
     expect(expected).not.toBe(placeholderBranch)
     expect(orch.getTask(task.id)?.branch).toBe(expected)
     // The real git branch moved, not just the recorded name.
@@ -82,7 +81,7 @@ describe("branch follows title", () => {
 
     await orch.setTitle(task.id, "Fix migrated task")
 
-    const expected = autoBranch("Fix migrated task", task.id)
+    const expected = "fix-migrated-task"
     expect(orch.getTask(task.id)?.branch).toBe(expected)
     expect(gitBranches()).toContain(expected)
     expect(gitBranches()).not.toContain(legacyPlaceholder)
@@ -106,7 +105,7 @@ describe("branch follows title", () => {
     await orch.ensureWorktree(task.id)
 
     await orch.setTitle(task.id, "First name")
-    const afterFirst = autoBranch("First name", task.id)
+    const afterFirst = "first-name"
     expect(orch.getTask(task.id)?.branch).toBe(afterFirst)
 
     await orch.setTitle(task.id, "Second name")
@@ -119,7 +118,7 @@ describe("branch follows title", () => {
   test("does not rename a placeholder branch that has an upstream", async () => {
     const task = await orch.createTask({ repo })
     await orch.ensureWorktree(task.id)
-    const placeholderBranch = autoBranch("(new task)", task.id)
+    const placeholderBranch = "new-task"
 
     // Publish the placeholder branch: bare remote + push -u.
     const remote = path.join(tmpRoot, "remote.git")
@@ -143,7 +142,7 @@ describe("branch follows title", () => {
   test("resolves a collision with an existing branch to a -2 suffix", async () => {
     const task = await orch.createTask({ repo })
     await orch.ensureWorktree(task.id)
-    const wanted = autoBranch("Fix login flow", task.id)
+    const wanted = "fix-login-flow"
 
     // Occupy the exact name the follow would pick.
     const r = spawnSync("git", ["-C", repo, "branch", wanted], { encoding: "utf8" })
@@ -160,7 +159,7 @@ describe("branch follows title", () => {
   test("keeps the old name when the upstream probe fails (ambiguity)", async () => {
     const task = await orch.createTask({ repo })
     await orch.ensureWorktree(task.id)
-    const placeholderBranch = autoBranch("(new task)", task.id)
+    const placeholderBranch = "new-task"
 
     // Force the probe to throw: an unreadable probe must not be read as
     // "no upstream". Reaching into the orchestrator's manager is deliberate —
@@ -182,6 +181,6 @@ describe("branch follows title", () => {
     expect(orch.getTask(task.id)?.branch).toBe("")
 
     await orch.ensureWorktree(task.id)
-    expect(orch.getTask(task.id)?.branch).toBe(autoBranch("Pre-materialise name", task.id))
+    expect(orch.getTask(task.id)?.branch).toBe("pre-materialise-name")
   })
 })

--- a/packages/kobe/test/orchestrator/branch-style.test.ts
+++ b/packages/kobe/test/orchestrator/branch-style.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+import { deriveConventionBranch, inferBranchStyle, uniqueBranchName } from "../../src/orchestrator/branch-style.ts"
+
+describe("inferBranchStyle", () => {
+  it("reads an all-feat/ repo as typed with feat as the default prefix", () => {
+    const style = inferBranchStyle(["main", "feat/login", "feat/signup", "feat/billing"])
+    expect(style).toEqual({ kind: "typed", defaultPrefix: "feat" })
+  })
+
+  it("picks the DOMINANT prefix in a mixed typed repo", () => {
+    const style = inferBranchStyle(["main", "fix/a", "fix/b", "fix/c", "feat/x", "chore/deps"])
+    expect(style).toEqual({ kind: "typed", defaultPrefix: "fix" })
+  })
+
+  it("reads a bare-kebab repo as bare", () => {
+    expect(inferBranchStyle(["main", "login-flow", "signup-page", "billing-refactor"])).toEqual({ kind: "bare" })
+  })
+
+  it("falls back to bare for an empty repo (no branches)", () => {
+    expect(inferBranchStyle([])).toEqual({ kind: "bare" })
+  })
+
+  it("ignores non-conventional prefixes (user/, backup/, legacy rove/)", () => {
+    // None of these vote; only `main` votes bare → bare.
+    expect(inferBranchStyle(["main", "alice/spike", "backup/old", "rove/task-abc123"])).toEqual({ kind: "bare" })
+  })
+
+  it("breaks a typed-vs-bare tie toward typed (main always votes bare)", () => {
+    expect(inferBranchStyle(["main", "feat/x"])).toEqual({ kind: "typed", defaultPrefix: "feat" })
+  })
+})
+
+describe("deriveConventionBranch", () => {
+  const typed = { kind: "typed", defaultPrefix: "feat" } as const
+  const bare = { kind: "bare" } as const
+
+  it("applies the repo's default prefix in a typed repo", () => {
+    expect(deriveConventionBranch("Add login flow", typed)).toBe("feat/add-login-flow")
+  })
+
+  it("lifts a leading type word out of the title as the prefix", () => {
+    expect(deriveConventionBranch("Fix login flow", typed)).toBe("fix/login-flow")
+    expect(deriveConventionBranch("docs update quickstart", typed)).toBe("docs/update-quickstart")
+  })
+
+  it("emits a bare kebab slug in a bare repo", () => {
+    expect(deriveConventionBranch("Fix login flow", bare)).toBe("fix-login-flow")
+  })
+
+  it("NEVER contains rove/kobe brand tokens", () => {
+    for (const style of [typed, bare]) {
+      const branch = deriveConventionBranch("rove kobe integration for Rove", style)
+      expect(branch).not.toMatch(/rove|kobe/)
+    }
+  })
+
+  it("falls back to 'task' when the title has no slug-able chars", () => {
+    expect(deriveConventionBranch("!!!", bare)).toBe("task")
+    expect(deriveConventionBranch("", typed)).toBe("feat/task")
+  })
+
+  it("caps the slug at 32 chars without a trailing hyphen", () => {
+    const branch = deriveConventionBranch("fix the very long feature name that exceeds the cap", typed)
+    const slug = branch.slice("fix/".length)
+    expect(slug.length).toBeLessThanOrEqual(32)
+    expect(slug.endsWith("-")).toBe(false)
+    expect(branch).not.toContain("--")
+  })
+})
+
+describe("uniqueBranchName", () => {
+  it("returns the base when free", () => {
+    expect(uniqueBranchName("feat/login", new Set(["main"]), "01HXABCDEF")).toBe("feat/login")
+  })
+
+  it("appends -2 / -3 short suffixes on collision", () => {
+    expect(uniqueBranchName("feat/login", new Set(["feat/login"]), "01HXABCDEF")).toBe("feat/login-2")
+    expect(uniqueBranchName("feat/login", new Set(["feat/login", "feat/login-2"]), "01HXABCDEF")).toBe("feat/login-3")
+  })
+
+  it("falls back to a task-id suffix when -2…-99 are all taken", () => {
+    const taken = new Set(["x", ...Array.from({ length: 98 }, (_, i) => `x-${i + 2}`)])
+    expect(uniqueBranchName("x", taken, "01HXABCDEF")).toBe("x-abcdef")
+  })
+})

--- a/packages/kobe/test/orchestrator/title.test.ts
+++ b/packages/kobe/test/orchestrator/title.test.ts
@@ -1,52 +1,26 @@
 import { describe, expect, it } from "vitest"
-import {
-  TITLE_CHAR_CAP,
-  autoBranch,
-  deriveTitleFromPrompt,
-  isPlaceholderDerivedBranch,
-} from "../../src/orchestrator/title.ts"
+import { TITLE_CHAR_CAP, deriveTitleFromPrompt, isPlaceholderDerivedBranch } from "../../src/orchestrator/title.ts"
 
-describe("autoBranch", () => {
-  it("builds rove/<slug>-<id6> from title + task id", () => {
-    expect(autoBranch("(new task)", "01HXABCDEF")).toBe("rove/new-task-abcdef")
+describe("isPlaceholderDerivedBranch", () => {
+  it("recognizes the convention-era placeholder shapes", () => {
+    const id = "01HXABCDEF"
+    expect(isPlaceholderDerivedBranch("new-task", id)).toBe(true)
+    expect(isPlaceholderDerivedBranch("feat/new-task", id)).toBe(true)
+    expect(isPlaceholderDerivedBranch("new-task-2", id)).toBe(true)
+    expect(isPlaceholderDerivedBranch("fix/new-task-3", id)).toBe(true)
   })
 
-  it("gives placeholder-titled tasks DISTINCT branches via the id suffix", () => {
-    // The bug (KOB-244): every new task derived the same branch and the 2nd
-    // `git worktree add -b` collided. Distinct ids → distinct branches.
-    const a = autoBranch("(new task)", "01HXAAAAAA")
-    const b = autoBranch("(new task)", "01HXBBBBBB")
-    expect(a).not.toBe(b)
-    expect(a).toBe("rove/new-task-aaaaaa")
-    expect(b).toBe("rove/new-task-bbbbbb")
-  })
-
-  it("falls back to 'task' when the title has no slug-able chars", () => {
-    expect(autoBranch("!!!", "01HXZZZZZZ")).toBe("rove/task-zzzzzz")
-    expect(autoBranch("", "01HXZZZZZZ")).toBe("rove/task-zzzzzz")
-  })
-
-  it("lowercases + dash-collapses + caps the slug at 32 chars", () => {
-    const branch = autoBranch("Fix The Very Long Feature Name That Exceeds The Cap!!", "01HXQQQQQQ")
-    const slug = branch.slice("rove/".length, -"-qqqqqq".length)
-    expect(slug.length).toBeLessThanOrEqual(32)
-    expect(slug).toBe("fix-the-very-long-feature-name-t")
-  })
-
-  it("never emits a double hyphen when the 32-char cap lands on a word boundary", () => {
-    // The trailing-hyphen trim runs BEFORE the .slice(0, 32) cap, so a slice
-    // that ends on a `-` used to survive into the template as `rove/<slug>--<id>`.
-    // Reachable whenever char 33 is a word boundary: 31 slug chars + a space + a word.
-    const branch = autoBranch(`${"a".repeat(31)} bar`, "01HXQQQQQQ")
-    expect(branch).toBe(`rove/${"a".repeat(31)}-qqqqqq`)
-    expect(branch).not.toContain("--")
-  })
-
-  it("recognizes canonical and pre-Rove placeholder branches only", () => {
+  it("recognizes the legacy rove/ and kobe/ id-suffixed placeholders", () => {
     const id = "01HXABCDEF"
     expect(isPlaceholderDerivedBranch("rove/new-task-abcdef", id)).toBe(true)
     expect(isPlaceholderDerivedBranch("kobe/new-task-abcdef", id)).toBe(true)
+  })
+
+  it("rejects real branch names", () => {
+    const id = "01HXABCDEF"
     expect(isPlaceholderDerivedBranch("kobe/real-work-abcdef", id)).toBe(false)
+    expect(isPlaceholderDerivedBranch("feat/login-flow", id)).toBe(false)
+    expect(isPlaceholderDerivedBranch("rove/new-task-zzzzzz", id)).toBe(false)
   })
 })
 

--- a/packages/kobe/test/state/repo-init.test.ts
+++ b/packages/kobe/test/state/repo-init.test.ts
@@ -163,7 +163,7 @@ describe("resolveEngineLaunchInit", () => {
   test("new-task without a threaded task id falls back to the $ROVE_TASK_ID env", () => {
     const wt = makeWorktree()
     const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix the bug" }).firstMessage
-    expect(msg?.text).toContain('set-branch --task-id "$ROVE_TASK_ID" --branch rove/')
+    expect(msg?.text).toContain('set-branch --task-id "$ROVE_TASK_ID" --branch')
   })
 
   // Why: outcomes travel as chat back to the spawner, not stored reports —


### PR DESCRIPTION
Implements issue #39: managed-task auto branch names no longer carry the tool brand (`rove/<slug>-<id>`).

## What changed

- **New pure module `src/orchestrator/branch-style.ts`**: `inferBranchStyle` scans the repo's branch names (local + origin, via a new `GitWorktreeManager.listBranchNames`) and votes between conventional type prefixes (`feat/`, `fix/`, `chore/`, …) and bare kebab slugs; `deriveConventionBranch` applies the inferred style to the title-derived slug (a leading type word in the title becomes the prefix in a typed repo); `uniqueBranchName` resolves collisions with short `-2`/`-3` suffixes.
- Generated names **never contain `rove`/`kobe`** (brand tokens stripped from slugs; prefixes only come from the conventional set).
- **Empty repo / no inferable convention → bare kebab slug** fallback.
- `WorktreeCoordinator` derives the name at materialise time against the live branch list, with an in-flight reservation set so concurrent parallel-round siblings can't collide on the same convention name.
- `TaskEditor.followBranchToTitle` (first-rename branch follow) uses the same derivation; `isPlaceholderDerivedBranch` recognises both the new `new-task` shapes and the legacy `rove/`/`kobe/` id-suffixed spellings so older tasks still follow.
- **Unchanged**: explicit `--branch` on `add`, `set-branch`, and existing `rove/*` branches (no retroactive migration).
- Docs: `docs/API.md` (add verb + workitem-start + completion example), `docs/WORKTREES.md` (new Branch naming section), `add --branch` flag description. `.agents/skills/kobe/SKILL.md` has no `rove/<slug>` wording, so no skill bump needed; the first-prompt coda text (repo-init.ts) updated instead.

## Tests

`test/orchestrator/branch-style.test.ts` covers the typical repo shapes: all-`feat/`, mixed typed, bare-slug, empty, non-conventional prefixes, brand-token stripping, collision suffixes. `branch-follow` integration tests updated to the new naming and stay green against real git.

Closes #39 (daemon issue store).