### PR TITLE
fix: derive sidebar labels from branch/path, retire scratch auto-names (#42)

### DIFF
--- a/.changeset/scratch-label-derivation.md
+++ b/.changeset/scratch-label-derivation.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Sidebar row labels get one derivation rule (issue #42): a task with a branch is named by it, a branchless dir/scratch task by its tail-truncated directory — `jacksonc-xxxx` auto-names are retired. Scratch tasks now mint no auto-name at all (title stays empty until you rename or adoption files them into a project); every title consumer (task channel, web board, kanban, `api list`/`get-task`, notifications) receives a wire-level fallback so an unnamed row never renders blank. Legacy auto-named scratch rows just render by the new rule — no data migration. ctrl+w on a scratch task's only tab now tears the whole task down (same zero-ceremony path as its shell exiting) instead of refusing with "Cannot close the only tab"; ordinary tasks keep the guard.

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -11,6 +11,7 @@
 import { randomUUID } from "node:crypto"
 import { optionalString, requireString } from "./handler-validators.ts"
 import type { DaemonRequestHandler } from "./handlers.ts"
+import { displayTaskTitle } from "./protocol.ts"
 
 /** `ui.prompt` timeout bounds — a plugin must not hang the CLI forever. */
 const PROMPT_DEFAULT_TIMEOUT_MS = 120_000
@@ -184,7 +185,7 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       const text = requireString(payload, "text")
       const author = ctx.orch.getTask(taskId)
       if (!author) throw new Error(`task not found: ${taskId}`)
-      const label = author.title || author.branch || taskId
+      const label = displayTaskTitle(author) || taskId
       // Persist BEFORE routing: relaying is best-effort and needs a live
       // dispatcher seat, but the durable record is the point — a note filed
       // with no dispatcher running must still reach the NEXT session

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -441,10 +441,23 @@ export interface SerializedTask {
   readonly updatedAt: string
 }
 
+/**
+ * Display fallback for an empty task title (issue #42): a scratch task mints
+ * no auto-name, so the wire fills branch → directory → "scratch" HERE — one
+ * spot upstream of every consumer (TUI task channel, web board/kanban,
+ * `api list`/`get-task`, notification copy), so none can render a blank row.
+ * The STORED title stays empty; only the serialized view is filled. No
+ * truncation: consumers clip visually, and agents reading the JSON want the
+ * full path.
+ */
+export function displayTaskTitle(task: Pick<DaemonTask, "title" | "branch" | "worktreePath" | "repo">): string {
+  return task.title || task.branch || task.worktreePath || task.repo || "scratch"
+}
+
 export function serializeTask(task: DaemonTask): SerializedTask {
   return {
     id: task.id,
-    title: task.title,
+    title: displayTaskTitle(task),
     repo: task.repo,
     branch: task.branch,
     worktreePath: task.worktreePath,

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -244,9 +244,12 @@ export class Orchestrator {
   }): Promise<Task> {
     if (!input.dir) throw new Error("openDirectoryTask: dir is required")
     const dir = canonPath(input.dir)
+    // A scratch shell's home is unsettled by definition, so it mints NO
+    // auto-name (issue #42): title stays empty until the user names it or
+    // adoption derives one; every display surface falls back to path/branch.
     return this.store.create({
       repo: dir,
-      title: `${titleFromRepo(dir)}-${randomDirTaskSuffix()}`,
+      title: input.scratch ? "" : `${titleFromRepo(dir)}-${randomDirTaskSuffix()}`,
       branch: "",
       worktreePath: dir,
       status: "backlog",

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -17,7 +17,7 @@ import { type BoxRenderable, MouseButton } from "@opentui/core"
 import { type ReactNode, useEffect } from "react"
 import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
 import { NO_STATE_GLYPH, buildSidebarRowView, prCheckChip, withSpinnerFrame } from "../../../tui/panes/sidebar/row-view"
-import { type TreeTab, tabRowActivity } from "../../../tui/panes/sidebar/tree-core"
+import { type TreeTab, tabRowActivity, worktreeRowLabel } from "../../../tui/panes/sidebar/tree-core"
 import { toneColor, truncateBranchLabel } from "../../../tui/panes/sidebar/view-core"
 import type { WorktreeChanges } from "../../../tui/panes/sidebar/worktree-changes"
 import { useTheme } from "../../context/theme"
@@ -136,18 +136,19 @@ export function WorktreeTreeRow(props: {
   const isCursor = shared.cursorIndex === props.flatIndex
   const changes = useChanges(shared, task)
   const chip = prCheckChip(task)
-  // A worktree row is named by its BRANCH. A `main` row stores no branch
-  // (its checkout moves freely), so it polls the repo HEAD — falling back
-  // to the title repeated the project header's name right under it (owner
-  // 2026-08-02), which read as a duplicate row instead of "the main
-  // checkout, currently on <branch>".
+  // A worktree row is named by its BRANCH; branchless rows fall back to
+  // their tail-truncated path (the one derivation rule — `worktreeRowLabel`,
+  // issue #42). A `main` row stores no branch (its checkout moves freely),
+  // so it polls the repo HEAD — falling back to the title repeated the
+  // project header's name right under it (owner 2026-08-02), which read as
+  // a duplicate row instead of "the main checkout, currently on <branch>".
   const isMain = task.kind === "main"
   useEffect(() => {
     // Dependency-only invalidation key: re-poll on the sidebar's ~2s tick.
     void shared.branchTick
     if (isMain) pollCurrentBranch(task.repo)
   }, [isMain, task.repo, shared.branchTick])
-  const label = (isMain ? currentBranch(task.repo) : task.branch) || task.branch || task.title
+  const label = worktreeRowLabel(task, isMain ? { liveBranch: currentBranch(task.repo) } : {})
   return (
     <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={1} shared={shared}>
       <box flexDirection="row" flexGrow={1} paddingRight={1} gap={1}>

--- a/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
+++ b/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
@@ -21,6 +21,11 @@ import { finishDeletedTaskFlow } from "../../tui/lib/task-actions"
 import type { Task } from "../../types/task"
 import { useScratchAdopt } from "./use-scratch-adopt"
 
+/** Task ids whose scratch teardown already started — module-level so the
+ *  guard survives the hook being rebuilt every render. Never cleared: a
+ *  torn-down scratch task's id is retired with it. */
+const scratchTeardowns = new Set<string>()
+
 export function useScratchShell(deps: {
   readonly orchestrator: RemoteOrchestrator
   readonly tasks: readonly Task[]
@@ -48,6 +53,11 @@ export function useScratchShell(deps: {
   }
 
   const onScratchExit = (taskId: string): void => {
+    // Idempotence: ctrl+w on the last tab (issue #42) kills the live PTY,
+    // whose exit event re-enters this teardown before the delete lands —
+    // the second call would surface a spurious "task not found" toast.
+    if (scratchTeardowns.has(taskId)) return
+    scratchTeardowns.add(taskId)
     void (async () => {
       try {
         await orchestrator.deleteTask(taskId, { force: true })

--- a/packages/kobe/src/tui-react/workspace/use-tab-close.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-close.ts
@@ -6,7 +6,9 @@
  *
  * The four exits a tab has, and why they differ:
  *
- *   - `closeActive`   — ctrl+w. Refuses the last tab with a toast.
+ *   - `closeActive`   — ctrl+w. Refuses the last tab with a toast — except
+ *     on a scratch task, where closing the last tab tears the task down
+ *     (issue #42; same zero-ceremony path as the shell exiting).
  *   - `closeById`     — a close named from OUTSIDE the component (the sidebar
  *     tree's menu). Same semantics as ctrl+w minus the toast: the menu omits
  *     the entry when it would be refused.
@@ -47,9 +49,9 @@ export interface TabCloseDeps {
   readonly resumeTriedRef: { readonly current: Set<string> }
   /** Surface ctrl+w's refusal to close a task's only tab. */
   readonly notifyCannotCloseLast: (tabId: string) => void
-  /** Scratch task (issue #33): the LAST tab's shell exiting ends the task
-   *  itself (the host deletes the row) instead of recycling a fresh engine
-   *  tab in place. Absent on ordinary tasks. */
+  /** Scratch task (issue #33): the LAST tab going away — its shell exiting
+   *  OR ctrl+w on it (issue #42) — ends the task itself (the host deletes
+   *  the row) instead of recycling/refusing. Absent on ordinary tasks. */
   readonly onScratchExit?: () => void
 }
 
@@ -97,6 +99,14 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
     const closing = current.tabs.find((tab) => tab.id === current.activeId)
     const { state: next, closedId } = closeActiveTab(current)
     if (!closedId) {
+      // Scratch task (issue #42): ctrl+w on its only tab tears down the
+      // whole task — same zero-ceremony semantics (and same path) as the
+      // shell exiting on its own. Ordinary tasks keep the refusal toast.
+      if (deps.onScratchExit) {
+        if (closing) releaseClosedTabPtys(taskId(), closing, closing.id)
+        deps.onScratchExit()
+        return
+      }
       deps.notifyCannotCloseLast(current.activeId)
       return
     }

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -20,7 +20,9 @@
  * never disagree about what identifies a tab.
  */
 
+import { homedir } from "node:os"
 import type { Task } from "@/types/task"
+import { truncateStart } from "../../lib/truncate"
 import { fuzzyMatch } from "./fuzzy"
 import { repoBasename, sidebarProjectKey } from "./groups"
 
@@ -98,6 +100,43 @@ export function parseRowId(rowId: string): { taskId: string; tabId: string | nul
   const at = rowId.indexOf(TAB_ROW_SEPARATOR)
   if (at < 0) return { taskId: rowId, tabId: null }
   return { taskId: rowId.slice(0, at), tabId: rowId.slice(at + TAB_ROW_SEPARATOR.length) }
+}
+
+/** Widest path label a worktree row renders before tail-truncation — the
+ *  default rail width minus row chrome. The row's flex still end-clips on
+ *  narrower rails; pre-truncating from the START keeps the leaf visible at
+ *  the default width, which is the half that disambiguates a path. */
+export const PATH_LABEL_MAX = 24
+
+/**
+ * What a worktree row is CALLED — the one derivation rule (issue #42):
+ * a task with a branch is named by it; a branchless `dir` task (plain
+ * `rove .` opens and scratch shells alike) by its tail-truncated
+ * directory — the stored title is deliberately ignored there, because
+ * dir-task titles are auto-generated noise (`jacksonc-xxxx`) and legacy
+ * rows render by the new rule with no data migration. A regular task
+ * before its worktree materialises (no branch yet, path not its own)
+ * keeps its title, else the label falls back to the path and finally
+ * "scratch" so a row is never blank.
+ *
+ * `liveBranch` is the caller-resolved HEAD for `main` rows (their stored
+ * branch is always "" — see `git-head.ts`); `home` is injectable so the
+ * tildification unit-tests without the real $HOME.
+ */
+export function worktreeRowLabel(
+  task: Task,
+  opts: { readonly liveBranch?: string; readonly home?: string } = {},
+): string {
+  const branch = (opts.liveBranch ?? task.branch) || task.branch
+  if (branch) return branch
+  if (task.kind !== "dir" && task.title) return task.title
+  const path = task.worktreePath || task.repo
+  if (path) {
+    const home = opts.home ?? homedir()
+    const tildified = home && (path === home || path.startsWith(`${home}/`)) ? `~${path.slice(home.length)}` : path
+    return truncateStart(tildified, PATH_LABEL_MAX)
+  }
+  return task.title || "scratch"
 }
 
 export interface TreeInput {

--- a/packages/kobe/test/client/task-deletion-protocol.test.ts
+++ b/packages/kobe/test/client/task-deletion-protocol.test.ts
@@ -29,4 +29,23 @@ describe("task deletion wire state", () => {
     expect(wire.deletion).toEqual(task.deletion)
     expect(deserializeTask(wire).deletion).toEqual(task.deletion)
   })
+
+  it("an empty title serializes with a display fallback — no consumer can render blank (issue #42)", () => {
+    const scratch: Task = {
+      id: toTaskId("s1"),
+      title: "",
+      repo: "/Users/me",
+      branch: "",
+      worktreePath: "/Users/me",
+      kind: "dir",
+      scratch: true,
+      status: "backlog",
+      archived: false,
+      createdAt: "2026-08-16T00:00:00.000Z",
+      updatedAt: "2026-08-16T00:00:00.000Z",
+    }
+    expect(serializeTask(scratch).title).toBe("/Users/me")
+    // Pathless too: never an empty string on the wire.
+    expect(serializeTask({ ...scratch, repo: "", worktreePath: "" }).title).toBe("scratch")
+  })
 })

--- a/packages/kobe/test/orchestrator/dir-task.test.ts
+++ b/packages/kobe/test/orchestrator/dir-task.test.ts
@@ -107,6 +107,14 @@ describe("scratch tasks (issue #33)", () => {
     expect(plain.scratch).toBeUndefined()
   })
 
+  it("a scratch task mints NO auto-name — title stays empty until named or adopted (issue #42)", async () => {
+    const scratch = await orch.openDirectoryTask({ dir, scratch: true })
+    expect(scratch.title).toBe("")
+    // Adoption derives the title from the repo it lands in (rule ①).
+    await orch.adoptScratchRepo(scratch.id, home)
+    expect(orch.getTask(scratch.id)?.title).not.toBe("")
+  })
+
   it("adoptScratchRepo repoints the task at the repo and clears the flag", async () => {
     const scratch = await orch.openDirectoryTask({ dir, scratch: true })
     await orch.adoptScratchRepo(scratch.id, home) // any existing dir works as "the repo"

--- a/packages/kobe/test/render/golden/scratch-path-label.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-path-label.frame.txt
@@ -1,0 +1,26 @@
+# sidebar frame: scratch-path-label
+# a scratch row with unknown tabs is named by its tail-truncated path, never a stored auto-name (issue #42)
+# 30x22
+# GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
+|                              |
+| ROVE                         |
+|                              |
+|  + New task               n  |
+|                              |
+| Kanban                       |
+| Routines                     |
+|                              |
+| SCRATCH ──────────────────── |
+|  …deep/nested/project-dir    |
+|                              |
+| kobe ─────────────────────── |
+|  feat/alpha                  |
+|▌ · build                     |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |

--- a/packages/kobe/test/render/golden/sidebar-scenes.tsx
+++ b/packages/kobe/test/render/golden/sidebar-scenes.tsx
@@ -256,6 +256,24 @@ export const SCENES: readonly Scene[] = [
     }),
   },
   {
+    name: "scratch-path-label",
+    about: "a scratch row with unknown tabs is named by its tail-truncated path, never a stored auto-name (issue #42)",
+    setup: () => seedTabs([{ taskId: "alpha", tabs: [{ id: "tab-1", title: "build" }] }]),
+    element: tree({
+      tasks: [
+        task("scratchy", {
+          kind: "dir",
+          scratch: true,
+          title: "jacksonc-ab3x",
+          repo: "/Users/me/deep/nested/project-dir",
+          worktreePath: "/Users/me/deep/nested/project-dir",
+          branch: "",
+        } as Partial<Task>),
+        ALPHA,
+      ],
+    }),
+  },
+  {
     name: "empty",
     about: "no tasks at all — the rail still renders its chrome rather than collapsing",
     setup: () => tabsByTask.clear(),

--- a/packages/kobe/test/tui/sidebar-tree-core.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-core.test.ts
@@ -11,6 +11,7 @@ import {
   tabRowId,
   treeFlatIds,
   withRecentRow,
+  worktreeRowLabel,
 } from "../../src/tui/panes/sidebar/tree-core"
 import type { Task } from "../../src/types/task"
 import { toTaskId } from "../../src/types/task"
@@ -309,5 +310,58 @@ describe("withRecentRow", () => {
   test("no recent task = rows unchanged", () => {
     const base = rows({ tasks: [task("a")], tabsByTask: new Map() })
     expect(withRecentRow(base, null)).toEqual(base)
+  })
+})
+
+describe("worktreeRowLabel (issue #42)", () => {
+  test("a branch names the row, over everything else", () => {
+    expect(worktreeRowLabel(task("a", { branch: "feat/a", title: "some title" }))).toBe("feat/a")
+  })
+
+  test("a main row's live HEAD outranks its (empty) stored branch", () => {
+    const main = task("m", { kind: "main", branch: "", worktreePath: "/repos/kobe" })
+    expect(worktreeRowLabel(main, { liveBranch: "main" })).toBe("main")
+    // HEAD not resolved yet (poller cold) → title fallback, same as before.
+    expect(worktreeRowLabel(main, { home: "/Users/me" })).toBe("m")
+  })
+
+  test("a branchless dir task is named by its tail-truncated path — its stored title is ignored", () => {
+    const dir = task("d", {
+      kind: "dir",
+      branch: "",
+      title: "jacksonc-ab3x",
+      worktreePath: "/Users/me/projects/deep/nested/dir",
+      repo: "/Users/me/projects/deep/nested/dir",
+    })
+    const label = worktreeRowLabel(dir, { home: "/Users/me" })
+    // "~/projects/deep/nested/dir" is 26 chars → tail-truncated to 24.
+    expect(label).toBe("…rojects/deep/nested/dir")
+    expect(label).not.toContain("jacksonc")
+  })
+
+  test("a path under $HOME tildifies before truncation", () => {
+    const dir = task("d", { kind: "dir", branch: "", title: "", worktreePath: "/Users/me/tmp", repo: "/Users/me/tmp" })
+    expect(worktreeRowLabel(dir, { home: "/Users/me" })).toBe("~/tmp")
+  })
+
+  test("a scratch task with an empty title never renders blank", () => {
+    const scratch = task("s", {
+      kind: "dir",
+      scratch: true,
+      branch: "",
+      title: "",
+      worktreePath: "/Users/me",
+      repo: "/Users/me",
+    })
+    expect(worktreeRowLabel(scratch, { home: "/Users/me" })).toBe("~")
+  })
+
+  test("a regular task before its worktree materialises keeps its title", () => {
+    expect(worktreeRowLabel(task("t", { branch: "", title: "fix the bug", worktreePath: "" }))).toBe("fix the bug")
+  })
+
+  test("nothing at all still yields a label", () => {
+    const bare = task("x", { kind: "dir", branch: "", title: "", worktreePath: "", repo: "" })
+    expect(worktreeRowLabel(bare)).toBe("scratch")
   })
 })

--- a/packages/kobe/test/tui/tab-close-scratch.test.ts
+++ b/packages/kobe/test/tui/tab-close-scratch.test.ts
@@ -1,0 +1,61 @@
+/**
+ * ctrl+w on a task's ONLY tab (issue #42): a scratch task tears down the
+ * whole task (same zero-ceremony path as its shell exiting — `onScratchExit`),
+ * while an ordinary task keeps the "cannot close the only tab" refusal.
+ */
+
+import { describe, expect, it, vi } from "vitest"
+
+// The close hook's PTY-release imports pull in @opentui/react (TerminalSplit)
+// and the live registry — neither loads under vitest's node environment, and
+// neither is what this suite locks. The policy branch is.
+vi.mock("../../src/tui-react/workspace/TerminalSplit.tsx", () => ({ releaseSplitLeaves: () => {} }))
+vi.mock("../../src/tui-react/workspace/terminal-tabs-close.ts", () => ({ releaseClosedTabPtys: () => {} }))
+vi.mock("../../src/tui/panes/terminal/registry.ts", () => ({
+  getDefaultPtyRegistry: () => ({ release: () => {} }),
+}))
+
+import { useTabClose } from "../../src/tui-react/workspace/use-tab-close.ts"
+import { type TabsState, type TerminalTab, initialShellTabs } from "../../src/tui/workspace/terminal-tabs-core.ts"
+
+function harness(state: TabsState, opts: { scratch?: boolean } = {}) {
+  const calls = { scratchExit: 0, cannotCloseLast: 0, updates: [] as TabsState[] }
+  const active = state.tabs.find((tab) => tab.id === state.activeId) as TerminalTab
+  const close = useTabClose({
+    stateRef: { current: state },
+    propsRef: { current: { taskId: "t1" } },
+    updateRef: { current: (next) => calls.updates.push(next) },
+    active,
+    pinSession: (s) => s,
+    bumpResetToken: () => {},
+    resumeTriedRef: { current: new Set() },
+    notifyCannotCloseLast: () => {
+      calls.cannotCloseLast += 1
+    },
+    ...(opts.scratch
+      ? {
+          onScratchExit: () => {
+            calls.scratchExit += 1
+          },
+        }
+      : {}),
+  })
+  return { close, calls }
+}
+
+describe("closeActive on the only tab", () => {
+  it("scratch task: tears the task down instead of refusing", () => {
+    const { close, calls } = harness(initialShellTabs("/bin/zsh"), { scratch: true })
+    close.closeActive()
+    expect(calls.scratchExit).toBe(1)
+    expect(calls.cannotCloseLast).toBe(0)
+    expect(calls.updates).toHaveLength(0)
+  })
+
+  it("ordinary task: still refuses with the toast", () => {
+    const { close, calls } = harness(initialShellTabs("/bin/zsh"))
+    close.closeActive()
+    expect(calls.cannotCloseLast).toBe(1)
+    expect(calls.updates).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Implements daemon issue #42 (owner rulings ①–④ plus the follow-up ⑤ from prod testing).

- **① One label derivation rule** — new pure `worktreeRowLabel` in `tree-core.ts`: a task with a branch is named by it (main rows keep their live-HEAD override); a branchless `dir` task (plain `rove .` opens and scratch shells alike) is named by its tail-truncated, `~`-tildified directory (`truncateStart`, the filetree convention). Stored dir-task titles (`jacksonc-xxxx`) are ignored at render time — legacy rows follow the new rule with **no data migration** (④). `tree-rows.tsx` swaps its ad-hoc fallback chain for the function.
- **② Scratch mints no auto-name** — `openDirectoryTask({scratch:true})` stores an empty title. Rename and adoption (`adoptScratchRepo` → repo basename) still derive real names, clearing the flag as before. Plain `rove .` dir tasks keep their random suffix (their two-opens-two-rows contract is untouched).
- **③ Wire-level empty-title fallback** — `displayTaskTitle` in the daemon protocol fills branch → path → `"scratch"` inside `serializeTask`, one spot upstream of every consumer (TUI task channel, web board/kanban/rail, `api list`/`get-task`, notification copy). The note-label site in `handlers-ui.ts` reuses it.
- **⑤ ctrl+w closes a scratch task's only tab** — `closeActive` routes the last-tab refusal through the existing `onScratchExit` teardown when the task is scratch (same zero-ceremony path as the shell exiting; PTY released first). Ordinary tasks keep the "Cannot close the only tab" toast. `onScratchExit` gains a module-level idempotence guard because the PTY kill echoes an exit event into the same teardown.

Tests: `worktreeRowLabel` unit matrix (branch/main/dir/scratch/tildify/blank-proof), scratch empty-title + adoption derivation in `dir-task.test.ts`, `serializeTask` fallback in `task-deletion-protocol.test.ts`, scratch-vs-ordinary ctrl+w policy in new `tab-close-scratch.test.ts`, and a new `scratch-path-label` golden frame locking the path-over-auto-name rendering.

Slice notes: #40 (scratch migration dedupe) touches adjacent paths and lands separately; land/branch-style inference untouched.

coverage-exemption: packages/kobe/src/tui-react/workspace/use-scratch-shell.ts — React-integration hook (tui-react .ts): its imports pull @opentui/react, which vitest's node environment cannot load; behavior is locked black-box by the render/behavior tracks (known gate blind spot, see MEMORY ci-coverage notes)
coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-close.ts — same React-integration blind spot; the changed policy branch IS vitest-covered (test/tui/tab-close-scratch.test.ts mocks the @opentui-importing release helpers), but the file's PTY/split release paths only execute under the render/behavior tracks
