### PR TITLE
fix: scratch adoption de-dupes against existing tasks — fold, don't mint (#40)

### DIFF
--- a/.changeset/scratch-fold-dedupe.md
+++ b/.changeset/scratch-fold-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Scratch adoption now de-dupes against existing tasks (issue #40): a scratch shell whose settled cwd is a main/directory task's directory — or inside a managed task's worktree — folds into that task as a new terminal tab (the running engine session moves with it via a host-side re-key) instead of minting a duplicate sidebar row. Only a cwd no task owns still takes the mint-a-dir-task path. The fold keeps #472's quiet discipline: no dialog, no focus steal, selection follows only when the scratch row was the selected one.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -33,7 +33,10 @@ confirm; nothing on disk is touched). A scratch row earns a permanent place
 two ways: rename it (naming is the keep gesture), or start a coding harness
 inside a git repository — Rove detects the live harness plus the shell's
 settled directory and quietly migrates the row into that repository's project
-group.
+group. If the settled directory already belongs to a Task — the project's
+main checkout, a directory Task's directory, or inside a managed Task's
+worktree — the shell (running session and all) folds into that Task as a new
+terminal tab instead of becoming a duplicate row.
 
 Each Task has a `status` you set yourself — `backlog`, `in_progress`,
 `in_review`, `done`, `canceled`, `error` — and a separate `archived` flag.

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -272,6 +272,13 @@ export type DaemonRequestName =
   | "pty.detach"
   | "pty.list"
   | "pty.sweep"
+  // Re-key a running session (`{from, to}` → `{renamed: boolean}`) — the
+  // scratch-fold move (issue #40): the child keeps running, only its
+  // ownership label changes so sweeps and future attaches see it under the
+  // adopting task's tab key. Older hosts reject the verb; callers treat
+  // that as "fold the tab record only, session stays under the old key
+  // until the scratch task's teardown" — hence they must check `renamed`.
+  | "pty.rename"
   // Read-only ring-buffer peek for one session key: no attach, no spawn,
   // no resize — the observation primitive `kobe api read-output` uses for
   // its bounded terminal fallback. Older hosts reject the verb; callers

--- a/packages/kobe-daemon/src/daemon/pty-host-types.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host-types.ts
@@ -1,7 +1,7 @@
 /** PtyHost's public contract types — split from `pty-host.ts` for the
  *  file-size cap; behavior and ownership stay with the host. */
 
-import type { StringDecoder } from "node:string_decoder"
+import { StringDecoder } from "node:string_decoder"
 import type { DaemonFrame, PtySessionExit } from "./protocol.ts"
 import type { PtyChild, PtyDriver } from "./pty-driver.ts"
 import type { PtyFreezeSink } from "./pty-freeze-store.ts"
@@ -105,4 +105,30 @@ export interface PtyHostOptions {
   /** How children spawn. Default Bun's; the Windows host injects node-pty's. */
   readonly driver?: PtyDriver
   readonly log?: (event: string, message: string) => void
+}
+
+/** A fresh session's initial state — extracted from `PtyHost.spawn` (file-size
+ *  cap); the host starts the child and owns every mutation after this. */
+export function freshSessionState(key: string, spec: PtySpawnSpec, argv: readonly string[]): PtySessionState {
+  return {
+    key,
+    cwd: spec.cwd,
+    proc: null,
+    alive: true,
+    chunks: [],
+    bytes: 0,
+    totalBytes: 0,
+    cols: spec.cols ?? 80,
+    rows: spec.rows ?? 24,
+    command: argv,
+    title: "",
+    titleCarry: "",
+    titleDecoder: new StringDecoder("utf8"),
+    sinks: new Map(),
+    parked: false,
+    parkedScreenBytes: 0,
+    exit: null,
+    restored: false,
+    lastFreezeAtMs: 0,
+  }
 }

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -32,13 +32,19 @@
  * store) forgets a session for good.
  */
 
-import { StringDecoder } from "node:string_decoder"
 import { resolveLoginShell } from "./platform-shell.js"
 import type { DaemonFrame, PtyPeekResult, PtySessionExit } from "./protocol.ts"
 import { type PtyExit, bunTerminalDriver } from "./pty-driver.ts"
 import { embeddedTerminalEnv } from "./pty-env.js"
 import { type FrozenPtySession, freezeSession, thawSession } from "./pty-freeze-store.ts"
-import type { PtyAttachResult, PtyHostOptions, PtySessionState, PtySink, PtySpawnSpec } from "./pty-host-types.ts"
+import {
+  type PtyAttachResult,
+  type PtyHostOptions,
+  type PtySessionState,
+  type PtySink,
+  type PtySpawnSpec,
+  freshSessionState,
+} from "./pty-host-types.ts"
 import {
   type PtyHostStats,
   type PtySessionInfo,
@@ -207,6 +213,27 @@ export class PtyHost {
     return this.endChild(session)
   }
 
+  /**
+   * Re-key a running session (`pty.rename`) — the scratch-fold move (issue
+   * #40): the shell keeps running untouched, only its ownership label
+   * changes, so the task-archive sweep and every future attach see it under
+   * the adopting task. No-ops (false) when the source is missing or the
+   * target key is taken — the caller must pick a free tab id first. The
+   * old key's freeze record moves with it; attached sinks keep streaming
+   * (frames carry `session.key`, which is now the new one).
+   */
+  rename(from: string, to: string): boolean {
+    const session = this.sessions.get(from)
+    if (!session || from === to || this.sessions.has(to)) return false
+    this.sessions.delete(from)
+    session.key = to
+    this.sessions.set(to, session)
+    this.opts.freeze?.drop(from)
+    this.maybeFreeze(session, true)
+    this.opts.log?.("pty", `renamed session ${from} → ${to}`)
+    return true
+  }
+
   /** Detach one connection from one session; the child keeps running. */
   detach(key: string, token: object, parked = false, parkedScreenBytes = 0): void {
     const session = this.sessions.get(key)
@@ -359,27 +386,7 @@ export class PtyHost {
    *  open (its adoption fires the callback instead). */
   private spawn(key: string, spec: PtySpawnSpec, spare = false): PtySessionState {
     const argv = spec.command && spec.command.length > 0 ? [...spec.command] : [spec.shell ?? resolveLoginShell()]
-    const session: PtySessionState = {
-      key,
-      cwd: spec.cwd,
-      proc: null,
-      alive: true,
-      chunks: [],
-      bytes: 0,
-      totalBytes: 0,
-      cols: spec.cols ?? 80,
-      rows: spec.rows ?? 24,
-      command: argv,
-      title: "",
-      titleCarry: "",
-      titleDecoder: new StringDecoder("utf8"),
-      sinks: new Map(),
-      parked: false,
-      parkedScreenBytes: 0,
-      exit: null,
-      restored: false,
-      lastFreezeAtMs: 0,
-    }
+    const session = freshSessionState(key, spec, argv)
     this.startChild(session)
     if (session.alive) {
       this.opts.log?.("pty", `spawned ${argv[0]} for ${key} (pid ${session.proc?.pid})`)

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -239,6 +239,10 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
       case "pty.kill":
         ptys.kill(requireString(objectPayload(req.payload), "key"))
         return {}
+      case "pty.rename": {
+        const payload = objectPayload(req.payload)
+        return { renamed: ptys.rename(requireString(payload, "from"), requireString(payload, "to")) }
+      }
       case "pty.detach":
         {
           const payload = objectPayload(req.payload)

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -175,6 +175,9 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   const scratch = useScratchShell({
     orchestrator: orch,
     tasks,
+    kv,
+    selectedId: () => selectedId,
+    selectTask: setSelectedId,
     enterTask: (id) => void activateTask(id),
     forgetTaskTabs: (id) => forgetTaskTabs(kv, id),
     notifyError,

--- a/packages/kobe/src/tui-react/workspace/scratch-fold.ts
+++ b/packages/kobe/src/tui-react/workspace/scratch-fold.ts
@@ -1,0 +1,84 @@
+/**
+ * Fold a scratch shell into the task that already owns its cwd (issue #40)
+ * — the execution half of `decideScratchAdopt`'s `fold` verdict. Instead of
+ * repointing the scratch row at the repo (which minted a duplicate sidebar
+ * row for a directory some task already names), the shell's HOSTED sessions
+ * are re-keyed under the owning task's next free tab ids (`pty.rename` — the
+ * child keeps running, engine and all) and the tab records are adopted
+ * through the ordinary orphan-adoption write (`adoptTaskTabs`), which never
+ * steals the target's active tab. The caller then deletes the emptied
+ * scratch row.
+ *
+ * Hosted backend only: a local (`Bun.spawn`) shell lives inside this
+ * process keyed to the scratch task and cannot change owners host-side —
+ * `rename` answers false and the shell simply STAYS in Scratch (quiet,
+ * retried each tick), which beats minting the duplicate row this fixes.
+ */
+
+import { getSharedPtyClient } from "../../tui/panes/terminal/pty-hosted-client"
+import { tabPtyKey } from "../../tui/workspace/terminal-tabs-core"
+import { adoptTaskTabs } from "./terminal-tabs-adopt"
+import type { TabsSnapshotKv } from "./terminal-tabs-persist"
+import { knownTaskTabs } from "./terminal-tabs-shared"
+
+export interface ScratchFoldIO {
+  readonly kv: TabsSnapshotKv
+  /** Host-side session re-key (`pty.rename`); false = source session gone,
+   *  target key taken, or a host that predates the verb. Injectable for
+   *  tests; defaults to the shared pty-host client. */
+  readonly rename?: (from: string, to: string) => Promise<boolean>
+}
+
+async function renameHostedSession(from: string, to: string): Promise<boolean> {
+  if ((process.env.KOBE_TERMINAL_BACKEND ?? "hosted") !== "hosted") return false
+  try {
+    const client = await getSharedPtyClient()
+    const res = await client.request<{ renamed?: boolean }>("pty.rename", { from, to })
+    return res.renamed === true
+  } catch {
+    return false
+  }
+}
+
+const tabNumber = (id: string): number => Number(/^tab-(\d+)$/.exec(id)?.[1] ?? 0)
+
+/**
+ * Move every hosted session of `scratchTaskId`'s tabs under
+ * `targetTaskId`'s next free tab ids and adopt them into its tab state.
+ * Returns the folded id of the scratch's FIRST tab (the shell — the one the
+ * user was watching, for selection follow-up), or null when nothing moved
+ * (no hosted sessions / old host) — the scratch row must then stay put.
+ */
+export async function foldScratchShell(
+  io: ScratchFoldIO,
+  scratchTaskId: string,
+  targetTaskId: string,
+): Promise<{ activeTabId: string } | null> {
+  const rename = io.rename ?? renameHostedSession
+  // The scratch shell is tab-1 by construction; extra tabs the user opened
+  // in the scratch task ride along under their own new ids.
+  const scratchTabIds = (knownTaskTabs(io.kv, scratchTaskId)?.tabs ?? [{ id: "tab-1" }]).map((tab) => tab.id)
+  let next =
+    1 + (knownTaskTabs(io.kv, targetTaskId)?.tabs ?? []).reduce((max, tab) => Math.max(max, tabNumber(tab.id)), 0)
+  const folded: string[] = []
+  for (const tabId of scratchTabIds) {
+    const from = tabPtyKey(scratchTaskId, tabId)
+    // One bump retry: a stray hosted session (an orphan the sidebar hasn't
+    // adopted yet) can occupy the computed id.
+    let ok = await rename(from, tabPtyKey(targetTaskId, `tab-${next}`))
+    if (!ok) {
+      next++
+      ok = await rename(from, tabPtyKey(targetTaskId, `tab-${next}`))
+    }
+    if (!ok) continue
+    folded.push(`tab-${next}`)
+    next++
+    // The local handle still keyed to `from` is NOT released here: the
+    // scratch row's deletion (the caller's next step) runs the ordinary
+    // task-PTY sweep, whose `pty.kill` on the old key is a host-side no-op
+    // after the rename — the moved session survives, the handle dies.
+  }
+  if (folded.length === 0) return null
+  adoptTaskTabs(io.kv, targetTaskId, folded)
+  return { activeTabId: folded[0] as string }
+}

--- a/packages/kobe/src/tui-react/workspace/use-scratch-adopt.ts
+++ b/packages/kobe/src/tui-react/workspace/use-scratch-adopt.ts
@@ -1,16 +1,26 @@
 /**
- * Scratch-task adoption loop (issue #33) — the React binding over the pure
- * `decideScratchAdopt`. Every poll tick it asks, for each scratch task with
- * an attached live shell: where has the shell settled (live cwd → repo main
- * root), and is a coding harness confirmed running in it (the live-engine
- * store's walk — same confidence bar as tab identity). Both true → the row
- * migrates into that repo's project group via `orch.adoptScratchRepo`.
+ * Scratch-task adoption loop (issues #33/#40) — the React binding over the
+ * pure `decideScratchAdopt`. Every poll tick it asks, for each scratch task
+ * with an attached live shell: where has the shell settled (live cwd → repo
+ * main root), and is a coding harness confirmed running in it (the
+ * live-engine store's walk — same confidence bar as tab identity). Both
+ * true → the pure decision picks one of two moves:
  *
- * Deliberately quiet (owner spec): no dialog, no focus steal — the row
- * simply moves; selection follows because it keys on the task id, which
- * never changes. An UNFAMILIAR repo additionally surfaces a non-modal hint
- * (notifyInfo) that the repo can be saved as a project — the ask is about
- * the savedRepos registry, never a gate on the move itself.
+ *   - `fold` (issue #40): the cwd already belongs to an existing task —
+ *     the shell (engine session and all) becomes that task's new terminal
+ *     tab via `foldScratchShell`, and the emptied scratch row is deleted.
+ *     No new task is minted, so the sidebar never grows a duplicate row
+ *     for a directory it already lists.
+ *   - `adopt`: no owner — the row migrates into that repo's project group
+ *     via `orch.adoptScratchRepo`, exactly as before.
+ *
+ * Deliberately quiet (owner spec): no dialog, no focus steal. On adopt,
+ * selection follows because it keys on the task id. On fold the id goes
+ * away, so the caller's `onFold` re-points selection to the folded tab
+ * ONLY when the scratch row was the selected one. An UNFAMILIAR repo
+ * additionally surfaces a non-modal hint (notifyInfo) that the repo can be
+ * saved as a project — the ask is about the savedRepos registry, never a
+ * gate on the move itself.
  *
  * Only Rove-hosted PTYs are consulted (the local registry — attached tabs
  * of this TUI); an unattached scratch task simply waits. Cost: one lsof per
@@ -20,26 +30,44 @@
 import { useEffect } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { processCwd } from "../../engine/process-cwd"
+import { canonPath } from "../../orchestrator/core-helpers"
 import { getSavedRepos, isGitRepo, resolveMainRepoRoot } from "../../state/repos"
 import { t } from "../../tui/i18n"
 import { repoBasename } from "../../tui/panes/sidebar/groups"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { getDefaultLiveEngines } from "../../tui/workspace/live-engine"
-import { decideScratchAdopt } from "../../tui/workspace/scratch-adopt"
+import { type ScratchOwnerTask, decideScratchAdopt } from "../../tui/workspace/scratch-adopt"
 import { tabPtyKey } from "../../tui/workspace/terminal-tabs-core"
 import type { Task } from "../../types/task"
+import { useLatest } from "../lib/use-latest"
+import { foldScratchShell } from "./scratch-fold"
+import type { TabsSnapshotKv } from "./terminal-tabs-persist"
 
 /** Same human timescale as the live-engine probe. */
 const POLL_MS = 5_000
 
+/** Tasks whose directory can already own a scratch shell's cwd. */
+export function scratchOwnerTasks(tasks: readonly Task[]): ScratchOwnerTask[] {
+  return tasks
+    .filter((task) => !task.archived && !task.deletion && task.scratch !== true && task.worktreePath !== "")
+    .map((task) => ({ id: task.id, kind: task.kind ?? "task", dir: canonPath(task.worktreePath) }))
+}
+
 export function useScratchAdopt(deps: {
   readonly tasks: readonly Task[]
   readonly orchestrator: RemoteOrchestrator
+  readonly kv: TabsSnapshotKv
   /** Non-modal hint channel — the unfamiliar-repo "save as project?" nudge. */
   readonly notifyInfo: (message: string) => void
+  /** The shell folded into `targetTaskId` as `tabId` — delete the emptied
+   *  scratch row and follow selection if it pointed at the scratch task. */
+  readonly onFold: (scratchTaskId: string, targetTaskId: string, tabId: string) => Promise<void>
   readonly enabled?: boolean
 }): void {
-  const { tasks, orchestrator, notifyInfo } = deps
+  const { tasks, orchestrator, kv, notifyInfo } = deps
+  // Latest-render mirror: the fold callback closes over host selection state
+  // and is rebuilt every render — a dep would restart the poll per render.
+  const onFoldRef = useLatest(deps.onFold)
   const enabled = deps.enabled ?? true
   const scratchIds = tasks
     .filter((t) => t.kind === "dir" && t.scratch === true)
@@ -56,6 +84,7 @@ export function useScratchAdopt(deps: {
       const scratch = tasks.filter((t) => t.kind === "dir" && t.scratch === true)
       if (scratch.length === 0) return
       const known = new Set<string>([...getSavedRepos(), ...tasks.map((t) => t.repo)])
+      const owners = scratchOwnerTasks(tasks)
       const registry = getDefaultPtyRegistry()
       const liveEngines = getDefaultLiveEngines()
       for (const task of scratch) {
@@ -66,19 +95,30 @@ export function useScratchAdopt(deps: {
         if (pid === null || pid === undefined) continue
         // Confidence gate: harness confirmed live under this shell.
         if (!liveEngines.get(key)) continue
-        const cwd = await processCwd(pid)
-        if (cancelled || !cwd) continue
+        const rawCwd = await processCwd(pid)
+        if (cancelled || !rawCwd) continue
+        const cwd = canonPath(rawCwd)
         // resolveMainRepoRoot falls back to the input for non-repos, so
         // isGitRepo is the actual repo-semantics gate.
-        const repoRoot = resolveMainRepoRoot(cwd)
+        const repoRoot = canonPath(resolveMainRepoRoot(cwd))
         const decision = decideScratchAdopt({
+          cwd,
           repoRoot: isGitRepo(repoRoot) ? repoRoot : null,
           harnessLive: true,
           knownRepos: known,
+          ownerTasks: owners,
         })
-        if (cancelled || decision.kind !== "adopt") continue
+        if (cancelled || decision.kind === "stay") continue
         inFlight.add(task.id)
         try {
+          if (decision.kind === "fold") {
+            const folded = await foldScratchShell({ kv }, task.id, decision.taskId)
+            // Null = nothing moved (old host / sessions gone): stay put and
+            // retry next tick rather than minting the duplicate row.
+            if (!folded) throw new Error("fold did not move any session")
+            await onFoldRef.current(task.id, decision.taskId, folded.activeTabId)
+            continue
+          }
           await orchestrator.adoptScratchRepo(task.id, decision.repo)
           if (!decision.known) {
             // ponytail: non-modal hint instead of a save dialog — the move
@@ -98,5 +138,5 @@ export function useScratchAdopt(deps: {
       clearInterval(timer)
     }
     // scratchIds is the reactive key — tasks identity churns every snapshot.
-  }, [enabled, scratchIds, orchestrator, notifyInfo, tasks])
+  }, [enabled, scratchIds, orchestrator, kv, notifyInfo, tasks])
 }

--- a/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
+++ b/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
@@ -9,6 +9,12 @@
  *   - `onScratchExit`: the last shell exited — delete the row outright,
  *     zero ceremony (no archive, no confirm; a scratch task owns no
  *     worktree/branch, deletion only drops the index entry).
+ *   - the fold finish (issue #40): the adoption loop moved the shell's
+ *     sessions under an existing task — quietly re-point selection to the
+ *     folded tab (ONLY when the scratch row was the selected one; a
+ *     background fold must not move the user), then delete the emptied
+ *     row. Deletion AFTER the rename, so the daemon's task-snapshot pty
+ *     sweep sees the sessions under a live task id and spares them.
  *
  * The adoption loop (cwd + harness → project migration) is its own hook,
  * `use-scratch-adopt.ts`.
@@ -19,6 +25,8 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { t } from "../../tui/i18n"
 import { finishDeletedTaskFlow } from "../../tui/lib/task-actions"
 import type { Task } from "../../types/task"
+import type { TabsSnapshotKv } from "./terminal-tabs-persist"
+import { requestTabActivation } from "./terminal-tabs-shared"
 import { useScratchAdopt } from "./use-scratch-adopt"
 
 /** Task ids whose scratch teardown already started — module-level so the
@@ -29,6 +37,9 @@ const scratchTeardowns = new Set<string>()
 export function useScratchShell(deps: {
   readonly orchestrator: RemoteOrchestrator
   readonly tasks: readonly Task[]
+  readonly kv: TabsSnapshotKv
+  readonly selectedId: () => string | null
+  readonly selectTask: (taskId: string) => void
   readonly enterTask: (taskId: string) => void
   readonly forgetTaskTabs: (taskId: string) => void
   readonly notifyError: (message: string) => void
@@ -39,9 +50,25 @@ export function useScratchShell(deps: {
 } {
   const { orchestrator, enterTask, forgetTaskTabs, notifyError } = deps
 
-  // The quiet cwd+harness → project adoption loop rides along: one hook is
-  // the whole scratch lifecycle from the host's perspective.
-  useScratchAdopt({ tasks: deps.tasks, orchestrator, notifyInfo: deps.notifyInfo })
+  // The quiet cwd+harness adoption loop rides along: one hook is the whole
+  // scratch lifecycle from the host's perspective. Fold (issue #40) hands
+  // back here for the selection follow-up + row deletion.
+  useScratchAdopt({
+    tasks: deps.tasks,
+    orchestrator,
+    kv: deps.kv,
+    notifyInfo: deps.notifyInfo,
+    onFold: async (scratchTaskId, targetTaskId, tabId) => {
+      // Selection follows the shell the user was watching — before the
+      // delete, so the deleted-selection fallback never picks a stranger.
+      if (deps.selectedId() === scratchTaskId) {
+        deps.selectTask(targetTaskId)
+        requestTabActivation(targetTaskId, tabId)
+      }
+      await orchestrator.deleteTask(scratchTaskId, { force: true })
+      forgetTaskTabs(scratchTaskId)
+    },
+  })
 
   const openScratchShell = (): void => {
     void orchestrator

--- a/packages/kobe/src/tui/workspace/scratch-adopt.ts
+++ b/packages/kobe/src/tui/workspace/scratch-adopt.ts
@@ -1,35 +1,72 @@
 /**
- * Scratch-task adoption decision (issue #33) — pure. A scratch shell earns a
- * project home when TWO facts line up: its live cwd resolved to a git repo,
- * and a coding harness is confirmed running in it (the foreground walk's
- * verdict — the same confidence bar the tab identity uses; a mere `cd` into
- * a repo is browsing, not working).
+ * Scratch-task adoption decision (issues #33/#40) — pure. A scratch shell
+ * earns a project home when TWO facts line up: its live cwd resolved to a
+ * git repo, and a coding harness is confirmed running in it (the foreground
+ * walk's verdict — the same confidence bar the tab identity uses; a mere
+ * `cd` into a repo is browsing, not working).
  *
- *   - cwd inside a KNOWN repo (a saved project or any existing task's repo)
- *     → migrate the row into that project group, silently.
- *   - cwd inside an UNFAMILIAR git repo → migrate, and ask whether to save
- *     the repo as a project (a new group either way — asking is about the
- *     savedRepos registry, not about the move).
- *   - no repo semantics → stay in Scratch.
+ * Once that bar is met, the decision de-dupes against tasks that already
+ * exist (issue #40 — migrating a shell parked in the kobe main checkout
+ * used to mint a second sidebar row for the same directory):
  *
- * The caller supplies already-resolved facts; this module only decides.
+ *   1. cwd equal to or inside a MANAGED task's worktree → FOLD the shell
+ *      into that task as a new terminal tab. Checked first because
+ *      `resolveMainRepoRoot` maps a linked worktree to the MAIN checkout —
+ *      the repo-root match below would misfold into the main task.
+ *   2. cwd equal to a main/dir task's directory — or the repo root the
+ *      adopt would pin equal to one (a shell in a SUBDIR of the main
+ *      checkout adopts the root, which is the same duplicate) → FOLD.
+ *      Main rows win over dir rows: the canonical project row absorbs.
+ *   3. No owner: cwd inside a KNOWN repo → migrate the row into that
+ *      project group, silently. An UNFAMILIAR repo → migrate + surface the
+ *      save-as-project hint (about the savedRepos registry, not the move).
+ *   4. No repo semantics, or no live harness → stay in Scratch.
+ *
+ * The caller supplies already-resolved, canonicalized facts; this module
+ * only decides.
  */
 
+/** An unarchived, non-scratch task that could already own the shell's cwd. */
+export interface ScratchOwnerTask {
+  readonly id: string
+  readonly kind: "main" | "task" | "dir"
+  /** The task's directory (worktreePath), canonicalized like `cwd`. */
+  readonly dir: string
+}
+
 export interface ScratchAdoptInput {
-  /** The scratch shell's live cwd resolved to its repo MAIN root, or null
-   *  when the cwd is not inside a git work tree (or unreadable). */
+  /** The scratch shell's live cwd, canonicalized; null when unreadable. */
+  readonly cwd: string | null
+  /** The cwd resolved to its repo MAIN root, or null when the cwd is not
+   *  inside a git work tree (or unreadable). */
   readonly repoRoot: string | null
   /** A coding harness is confirmed live under the shell (foreground walk). */
   readonly harnessLive: boolean
   /** Known project roots: savedRepos + every existing task's repo. */
   readonly knownRepos: ReadonlySet<string>
+  /** Candidate owners for the fold check (issue #40). */
+  readonly ownerTasks: readonly ScratchOwnerTask[]
 }
 
 export type ScratchAdoptDecision =
   | { readonly kind: "stay" }
+  /** The cwd already belongs to `taskId` — fold the shell in, mint nothing. */
+  | { readonly kind: "fold"; readonly taskId: string }
   | { readonly kind: "adopt"; readonly repo: string; readonly known: boolean }
+
+const inDir = (path: string, dir: string): boolean => path === dir || path.startsWith(`${dir}/`)
 
 export function decideScratchAdopt(input: ScratchAdoptInput): ScratchAdoptDecision {
   if (!input.repoRoot || !input.harnessLive) return { kind: "stay" }
+  const owners = input.ownerTasks.filter((task) => task.dir !== "")
+  if (input.cwd) {
+    const cwd = input.cwd
+    const managed = owners.find((task) => task.kind === "task" && inDir(cwd, task.dir))
+    if (managed) return { kind: "fold", taskId: managed.id }
+  }
+  for (const kind of ["main", "dir"] as const) {
+    const owned = owners.find((task) => task.kind === kind && (task.dir === input.cwd || task.dir === input.repoRoot))
+    if (owned) return { kind: "fold", taskId: owned.id }
+  }
   return { kind: "adopt", repo: input.repoRoot, known: input.knownRepos.has(input.repoRoot) }
 }

--- a/packages/kobe/test/render/pty-host.test.ts
+++ b/packages/kobe/test/render/pty-host.test.ts
@@ -212,6 +212,35 @@ describe("PtyHost", () => {
     expect(host.list()).toMatchObject([{ key: "live-task::tab1", alive: true }])
   })
 
+  // Why: issue #40 — folding a scratch shell into the task that owns its cwd
+  // re-keys the RUNNING session instead of respawning it, so the engine
+  // inside survives the move and the sweep now judges it by its new owner.
+  test("rename re-keys a running session; sweep and reattach see the new owner", async () => {
+    const host = makeHost()
+    const a = collector()
+    host.open("scratch::tab-1", SPEC, {}, a.sink)
+    host.write("scratch::tab-1", "before-move\n")
+    await until(() => dataText(a.frames).includes("before-move"))
+
+    expect(host.rename("scratch::tab-1", "owner::tab-3")).toBe(true)
+    expect(host.list()).toMatchObject([{ key: "owner::tab-3", alive: true }])
+    // The old key is gone: killing it is a no-op, the session lives on.
+    await host.kill("scratch::tab-1")
+    host.sweepTasks(new Set(["owner"]))
+    expect(host.list()).toMatchObject([{ key: "owner::tab-3", alive: true }])
+
+    // Reattach under the new key replays the pre-move scrollback.
+    const b = collector()
+    const res = host.open("owner::tab-3", SPEC, {}, b.sink)
+    expect(res.alive).toBe(true)
+    expect(Buffer.from(res.replay, "base64").toString("utf8")).toContain("before-move")
+
+    // Refusals: unknown source, and an occupied target.
+    expect(host.rename("nope::tab-1", "owner::tab-9")).toBe(false)
+    host.open("owner::tab-4", SPEC, {}, collector().sink)
+    expect(host.rename("owner::tab-4", "owner::tab-3")).toBe(false)
+  })
+
   test("live sessions count toward liveCount, exited ones don't", async () => {
     const host = makeHost()
     const { frames, sink } = collector()

--- a/packages/kobe/test/tui-react/scratch-fold.test.ts
+++ b/packages/kobe/test/tui-react/scratch-fold.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Fold execution (issue #40): the scratch shell's hosted sessions move
+ * under the owning task's next free tab ids and get adopted into its tab
+ * state — quietly (adoption never steals the target's active tab), and
+ * only when the host actually re-keyed something (an old host or a dead
+ * session must NOT delete the scratch row over nothing).
+ */
+
+import { afterEach, describe, expect, it } from "vitest"
+import { foldScratchShell } from "../../src/tui-react/workspace/scratch-fold"
+import type { TabsSnapshotKv } from "../../src/tui-react/workspace/terminal-tabs-persist"
+import { tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import { scratchOwnerTasks } from "../../src/tui-react/workspace/use-scratch-adopt"
+import type { Task } from "../../src/types/task"
+
+const SCRATCH = "01SCRATCHFOLD"
+const TARGET = "01TARGETFOLD"
+
+function fakeKv(seed: Record<string, unknown> = {}): TabsSnapshotKv {
+  const store: Record<string, unknown> = { ...seed }
+  return {
+    store,
+    set(key: string, value: unknown) {
+      store[key] = value
+    },
+  } as TabsSnapshotKv
+}
+
+afterEach(() => {
+  tabsByTask.delete(SCRATCH)
+  tabsByTask.delete(TARGET)
+})
+
+describe("foldScratchShell", () => {
+  it("renames the shell under the target's next free tab id and adopts it", async () => {
+    const kv = fakeKv({
+      [`terminalTabs.${TARGET}`]: {
+        tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }],
+        activeId: "tab-1",
+        nextOrdinal: 2,
+      },
+    })
+    const renames: [string, string][] = []
+    const folded = await foldScratchShell(
+      {
+        kv,
+        rename: async (from, to) => {
+          renames.push([from, to])
+          return true
+        },
+      },
+      SCRATCH,
+      TARGET,
+    )
+    expect(renames).toEqual([[`${SCRATCH}::tab-1`, `${TARGET}::tab-2`]])
+    expect(folded).toEqual({ activeTabId: "tab-2" })
+    const state = kv.store[`terminalTabs.${TARGET}`] as { tabs: { id: string }[]; activeId: string }
+    expect(state.tabs.map((tab) => tab.id)).toEqual(["tab-1", "tab-2"])
+    // Quiet fold: the target's active tab is untouched.
+    expect(state.activeId).toBe("tab-1")
+  })
+
+  it("bumps once past an occupied target key, then gives up on that tab", async () => {
+    const kv = fakeKv()
+    const taken = new Set([`${TARGET}::tab-1`])
+    const folded = await foldScratchShell({ kv, rename: async (_from, to) => !taken.has(to) }, SCRATCH, TARGET)
+    expect(folded).toEqual({ activeTabId: "tab-2" })
+  })
+
+  it("answers null when the host moved nothing — the scratch row must stay", async () => {
+    const kv = fakeKv()
+    const folded = await foldScratchShell({ kv, rename: async () => false }, SCRATCH, TARGET)
+    expect(folded).toBeNull()
+    expect(kv.store[`terminalTabs.${TARGET}`]).toBeUndefined()
+  })
+
+  it("moves every scratch tab, not just the shell", async () => {
+    const kv = fakeKv({
+      [`terminalTabs.${SCRATCH}`]: {
+        tabs: [
+          { kind: "command", id: "tab-1", ordinal: 1 },
+          { kind: "engine", id: "tab-2", ordinal: 2 },
+        ],
+        activeId: "tab-1",
+        nextOrdinal: 3,
+      },
+    })
+    const renames: [string, string][] = []
+    const folded = await foldScratchShell(
+      {
+        kv,
+        rename: async (from, to) => {
+          renames.push([from, to])
+          return true
+        },
+      },
+      SCRATCH,
+      TARGET,
+    )
+    expect(renames.map(([from]) => from)).toEqual([`${SCRATCH}::tab-1`, `${SCRATCH}::tab-2`])
+    // The folded shell (the tab the user was watching) is the follow target.
+    expect(folded).toEqual({ activeTabId: "tab-1" })
+    const state = kv.store[`terminalTabs.${TARGET}`] as { tabs: { id: string }[] }
+    expect(state.tabs.map((tab) => tab.id)).toEqual(["tab-1", "tab-2"])
+  })
+})
+
+describe("scratchOwnerTasks", () => {
+  it("keeps main/dir/managed rows, drops scratch/archived/pathless ones", () => {
+    const base = { repo: "/r", branch: "", status: "backlog", archived: false } as unknown as Task
+    const tasks = [
+      { ...base, id: "a", kind: "main", worktreePath: "/r" },
+      { ...base, id: "b", kind: "task", worktreePath: "/w/b" },
+      { ...base, id: "c", kind: "dir", scratch: true, worktreePath: "/home" },
+      { ...base, id: "d", kind: "dir", worktreePath: "/r/sub", archived: true },
+      { ...base, id: "e", kind: "task", worktreePath: "" },
+    ] as unknown as Task[]
+    expect(scratchOwnerTasks(tasks).map((t) => t.id)).toEqual(["a", "b"])
+  })
+})

--- a/packages/kobe/test/tui/scratch-adopt.test.ts
+++ b/packages/kobe/test/tui/scratch-adopt.test.ts
@@ -1,37 +1,139 @@
 /**
- * Scratch adoption decision + the cwd read behind it (issue #33). The
+ * Scratch adoption decision + the cwd read behind it (issues #33/#40). The
  * decision is the confidence gate: a repo alone (browsing) or a harness
- * alone (working in a non-repo) must both stay in Scratch.
+ * alone (working in a non-repo) must both stay in Scratch. Once confident,
+ * the fold check (#40) de-dupes against existing tasks so migrating a shell
+ * parked in an already-tracked directory never mints a duplicate row.
  */
 
 import { describe, expect, it } from "vitest"
 import { parseLsofCwd, processCwd } from "../../src/engine/process-cwd"
-import { decideScratchAdopt } from "../../src/tui/workspace/scratch-adopt"
+import { type ScratchOwnerTask, decideScratchAdopt } from "../../src/tui/workspace/scratch-adopt"
 
 describe("decideScratchAdopt", () => {
   const known = new Set(["/repos/kobe"])
+  const none: ScratchOwnerTask[] = []
 
-  it("repo + live harness → adopt, flagged known/unfamiliar", () => {
-    expect(decideScratchAdopt({ repoRoot: "/repos/kobe", harnessLive: true, knownRepos: known })).toEqual({
-      kind: "adopt",
-      repo: "/repos/kobe",
-      known: true,
-    })
-    expect(decideScratchAdopt({ repoRoot: "/repos/other", harnessLive: true, knownRepos: known })).toEqual({
-      kind: "adopt",
-      repo: "/repos/other",
-      known: false,
-    })
+  it("repo + live harness, no owner → adopt, flagged known/unfamiliar", () => {
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/kobe/src",
+        repoRoot: "/repos/kobe",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: none,
+      }),
+    ).toEqual({ kind: "adopt", repo: "/repos/kobe", known: true })
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/other",
+        repoRoot: "/repos/other",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: none,
+      }),
+    ).toEqual({ kind: "adopt", repo: "/repos/other", known: false })
   })
 
   it("repo without a harness stays — a cd is browsing, not working", () => {
-    expect(decideScratchAdopt({ repoRoot: "/repos/kobe", harnessLive: false, knownRepos: known })).toEqual({
-      kind: "stay",
-    })
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/kobe",
+        repoRoot: "/repos/kobe",
+        harnessLive: false,
+        knownRepos: known,
+        ownerTasks: none,
+      }),
+    ).toEqual({ kind: "stay" })
   })
 
   it("harness without repo semantics stays in Scratch", () => {
-    expect(decideScratchAdopt({ repoRoot: null, harnessLive: true, knownRepos: known })).toEqual({ kind: "stay" })
+    expect(
+      decideScratchAdopt({ cwd: "/home/me", repoRoot: null, harnessLive: true, knownRepos: known, ownerTasks: none }),
+    ).toEqual({ kind: "stay" })
+  })
+
+  // --- issue #40: fold instead of minting a duplicate row -----------------
+
+  const mainTask: ScratchOwnerTask = { id: "T-main", kind: "main", dir: "/repos/kobe" }
+  const managed: ScratchOwnerTask = { id: "T-wt", kind: "task", dir: "/wt/kobe/feature-x" }
+  const dirTask: ScratchOwnerTask = { id: "T-dir", kind: "dir", dir: "/repos/kobe" }
+
+  it("cwd exactly a main task's directory → fold into it", () => {
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/kobe",
+        repoRoot: "/repos/kobe",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: [mainTask],
+      }),
+    ).toEqual({ kind: "fold", taskId: "T-main" })
+  })
+
+  it("cwd inside a managed task's worktree → fold into that task, not the main row", () => {
+    // resolveMainRepoRoot maps a linked worktree back to the MAIN checkout,
+    // so the managed subtree check must win over the repo-root match.
+    expect(
+      decideScratchAdopt({
+        cwd: "/wt/kobe/feature-x/src",
+        repoRoot: "/repos/kobe",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: [mainTask, managed],
+      }),
+    ).toEqual({ kind: "fold", taskId: "T-wt" })
+  })
+
+  it("cwd in a SUBDIR of the main checkout still folds — the adopt would pin the same root", () => {
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/kobe/packages/kobe",
+        repoRoot: "/repos/kobe",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: [mainTask],
+      }),
+    ).toEqual({ kind: "fold", taskId: "T-main" })
+  })
+
+  it("main row wins over a dir row for the same directory", () => {
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/kobe",
+        repoRoot: "/repos/kobe",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: [dirTask, mainTask],
+      }),
+    ).toEqual({ kind: "fold", taskId: "T-main" })
+  })
+
+  it("cwd with no owning task → the existing adopt path (no fold)", () => {
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/other",
+        repoRoot: "/repos/other",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: [mainTask, managed, dirTask],
+      }),
+    ).toEqual({ kind: "adopt", repo: "/repos/other", known: false })
+  })
+
+  it("a dir task elsewhere in the repo does not capture a shell at the root", () => {
+    // dir tasks own exactly their directory; only the exact-dir or
+    // pinned-root match folds.
+    const sub: ScratchOwnerTask = { id: "T-sub", kind: "dir", dir: "/repos/kobe/packages/kobe" }
+    expect(
+      decideScratchAdopt({
+        cwd: "/repos/kobe/docs",
+        repoRoot: "/repos/kobe",
+        harnessLive: true,
+        knownRepos: known,
+        ownerTasks: [sub],
+      }),
+    ).toEqual({ kind: "adopt", repo: "/repos/kobe", known: true })
   })
 })
 


### PR DESCRIPTION
Fixes issue #40 (daemon issue store): migrating a scratch shell parked in the kobe main checkout minted a duplicate `dir` task pointing at the same directory as the existing main task.

## What changed

- **Pure decision** (`tui/workspace/scratch-adopt.ts`): once the repo+harness confidence bar is met, the decision now de-dupes against unarchived, non-scratch tasks before adopting. cwd equal-to-or-inside a managed task's worktree → `fold` into that task (checked first — `resolveMainRepoRoot` maps a linked worktree to the MAIN checkout, so the repo-root match would misfold into the main row); cwd equal to a main/dir task's directory, or the would-be-pinned repo root equal to one → `fold` (main wins over dir). Only an unowned cwd takes the existing mint-a-dir-task `adopt` path.
- **Fold executor** (`tui-react/workspace/scratch-fold.ts`): the scratch task's hosted sessions are re-keyed under the owning task's next free tab ids via the new `pty.rename` host verb — the child process (lit engine included) never restarts — and the tab records ride the existing orphan-adoption write (`adoptTaskTabs`), which never steals the target's active tab. Null when the host moved nothing (old host / dead session): the scratch row then stays put instead of being deleted over nothing.
- **`pty.rename`** (pty-host + pty-server + protocol): re-key a running session; refuses unknown source / occupied target; freeze record moves with it; sweep and future attaches see the new owner.
- **Quiet discipline (#472)**: no dialog, no focus steal; selection follows the folded tab only when the scratch row WAS the selected one; the emptied scratch row is deleted after the rename so the daemon's task-snapshot pty sweep never kills the moved sessions.

## Tests

- `test/tui/scratch-adopt.test.ts`: the three required scenarios — cwd == main task directory (fold), cwd inside a managed worktree (fold, beats the main row), cwd unowned (existing adopt path) — plus subdir-of-main folds, main-over-dir precedence, and dir tasks not capturing repo-root shells.
- `test/tui-react/scratch-fold.test.ts`: rename→adopt under next free tab id, occupied-key bump, null-on-no-move keeps the row, multi-tab fold, and `scratchOwnerTasks` filtering.
- `test/render/pty-host.test.ts`: `rename` re-keys a RUNNING session (scrollback replays under the new key, old-key kill is a no-op, sweep honors the new owner, refusals).

Slice: scratch migration path + tests only; land/branch-style untouched.

## Coverage exemptions

React-integration files on the known tui-react vitest blind spot (hooks importing react — vitest track can't attribute them, render track only sees .tsx mounts):

coverage-exemption: packages/kobe/src/tui-react/workspace/use-scratch-shell.ts — React hook wiring; the extracted pure/executor logic is unit-tested in scratch-adopt.test.ts + scratch-fold.test.ts
coverage-exemption: packages/kobe/src/tui-react/workspace/use-scratch-adopt.ts — React poll-loop binding over the unit-tested decideScratchAdopt/foldScratchShell/scratchOwnerTasks
coverage-exemption: packages/kobe/src/tui-react/workspace/host.tsx — 2-line prop wiring change; host.tsx has no mount test (opentui needs bun)
