### PR TITLE
fix: codex tabs are named by their conversation, not a thread UUID

### DIFF
--- a/.changeset/codex-tab-title-not-a-uuid.md
+++ b/.changeset/codex-tab-title-not-a-uuid.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Codex tabs are named after their conversation instead of a thread UUID. Codex's terminal-title segment falls back to the raw thread id for any session without a user-assigned name, so every Codex tab read `01a00ea6-79cb-7413-bf83-b897ac2da2ff 1`. Engines now declare which of their titles are identifiers rather than names (`terminalTitle.placeholderTitles`), and Rove falls through to its own first-prompt summary when one shows up — including for titles already recorded in an older snapshot, which heal on display. Engines Rove can't pin a session id on (Codex, Copilot, Kimi) also get that first-prompt name for the first time, derived from the worktree's origin conversation.

--- a/docs/design/engine-internals.md
+++ b/docs/design/engine-internals.md
@@ -194,12 +194,48 @@ needs-input**; every other engine tops out at working/done.
 Claude and Codex own their OSC title while visible
 (`terminalTitle.ownsStatus`), so neutral tab chrome doesn't prefix a
 duplicate turn glyph. Codex additionally launches with
-`-c tui.terminal_title=["activity","thread-title"]` so tabs show its thread
-title instead of the repo name. Everywhere a live engine title is displayed
-(tab labels, split corner tags) it collapses to the launch binary
-(`✳ Claude Code` renders as `claude`), so all Rove surfaces speak one
-vocabulary for a process. Vendor identity comes from the process tree, never
-from matching the title string.
+`-c tui.terminal_title=["activity","thread-title"]` — its default is
+activity + project name, which in Rove is the worktree's animal slug and says
+nothing about the conversation. Vendor identity comes from the process tree,
+never from matching the title string.
+
+Everything an engine writes into that title goes through one projection
+(`engineDisplayTitle`) before any surface renders it, and the vocabulary it
+judges by is declared per engine in `terminalTitle` — no neutral layer names
+a vendor:
+
+| Field | What it declares | Effect |
+|---|---|---|
+| `statusPrefixes` | the turn decoration the engine writes (claude's `✳`/`⠂`, codex's braille spinner) | stripped — Rove draws that state in its own glyph column |
+| `workingPrefixes` | the subset written only mid-turn | feeds the interrupt hint (`engineTitleTurnHint`), which reads the RAW title |
+| `placeholderTitles` | anchored patterns for titles that are an INTERNAL IDENTIFIER, not a name | collapses to "no title" so Rove falls through to its own rungs |
+
+Codex is why `placeholderTitles` exists: its `thread-title` segment resolves
+to the thread's *user-assigned name* and falls back to the thread UUID, and no
+Rove-launched session has a name — so every codex tab read
+`01a00ea6-79cb-7413-bf83-b897ac2da2ff 1` (verified against codex-cli 0.147 on
+both a fresh and a resumed session). An unresolved vendor — the live-engine
+probe is a ~2s `ps` walk — falls back to the union of every built-in's
+vocabulary, for both prefixes and placeholders.
+
+### Tab naming
+
+A tab's label resolves in this order: manual rename → live OSC name →
+recorded name (`lastTitle`) → first-prompt summary (`autoTitle`) → numbered
+vendor default. The first-prompt summary is derived by the naming pass
+(`useTabNaming`), and how it finds the conversation depends on the engine:
+
+- **By session id**, when Rove pinned one at launch. Only claude accepts
+  `--session-id`, so this is claude's path; finding a transcript for that id
+  also proves the tab spawned.
+- **By worktree**, for every other engine. Codex/copilot/kimi tabs carry no
+  pinned id, so the engine's history reader resolves the worktree's sessions
+  by the cwd recorded in the transcript — the same read the daemon's *task*
+  auto-title does, so the tab and the sidebar row agree by construction. It
+  is scoped to the task's **first** engine tab: the worktree's origin
+  conversation is that tab's by construction, while a later tab's session
+  can't be told apart from one the user started by hand in the same
+  directory.
 
 ## Transcript readers
 

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -59,6 +59,7 @@ import {
 } from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
 import { trustKimiWorktree } from "./kimi-local/trust.ts"
+import { type EngineTerminalTitlePolicy, isPlaceholderTitle, stripStatusPrefix, titleTurnHint } from "./title-policy.ts"
 import { ClaudeTurnDetector, CodexTurnDetector, type EngineTurnDetector, UnknownTurnDetector } from "./turn-detector.ts"
 
 /**
@@ -138,39 +139,12 @@ export interface EngineRegistryEntry {
   /** Product identity (composer placeholder etc.). Paired with capabilities. */
   readonly identity?: EngineIdentity
   /**
-   * Native OSC 0/2 title policy for interactive terminal sessions.
-   * `ownsStatus` means the engine's live title is the status surface while
-   * it is visible, so neutral tab chrome must not prefix a duplicate turn
-   * glyph. `launchArgs` lets an adapter select the engine's own title fields
-   * without teaching the launcher vendor-specific config syntax.
+   * Native OSC 0/2 title policy for interactive terminal sessions — the
+   * status decoration this engine writes, the identifiers it writes when it
+   * has no name, and the argv that selects its title fields. Field-by-field
+   * contract: {@link EngineTerminalTitlePolicy} in `./title-policy.ts`.
    */
-  readonly terminalTitle?: {
-    readonly ownsStatus: boolean
-    readonly launchArgs?: readonly string[]
-    /**
-     * Leading STATUS decoration the engine writes into its own OSC title,
-     * stripped before kobe renders the name. Engine-owned by construction:
-     * only the adapter knows its vendor's glyph vocabulary, and kobe already
-     * draws that state in its own column — showing both is the same fact
-     * twice, and the animated variants make a resting tab look busy.
-     *
-     * Matched anchored at the start, longest-first, with any following
-     * whitespace; the remainder is the title. A pattern that would consume
-     * the WHOLE title is not applied (a session actually named "Working" is
-     * a name, not a status).
-     */
-    readonly statusPrefixes?: readonly string[]
-    /**
-     * The subset of {@link statusPrefixes} the engine ONLY writes while a
-     * turn is running (its animated frames). A title that stops starting
-     * with one of these is the engine's own "I stopped working" signal —
-     * the one observable event an ESC interrupt leaves behind (claude-code
-     * runs no Stop hook on its abort path; issue #15). Consumed by
-     * {@link engineTitleTurnHint}. Omit when the engine's resting title is
-     * indistinguishable from its working one.
-     */
-    readonly workingPrefixes?: readonly string[]
-  }
+  readonly terminalTitle?: EngineTerminalTitlePolicy
   /**
    * Subscription-quota probe: snapshot of the account's usage windows, or
    * null when unknowable. Drives the daemon's rate-limit auto-resume
@@ -268,11 +242,19 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     identity: codexIdentity,
     trustWorktree: trustCodexWorktree,
     // Codex's default is activity + project-name, which makes every tab in
-    // one repo say "kobe". Keep its native activity state, but ask Codex to
-    // pair it with the thread title it already owns in its local store.
+    // one repo say "kobe" (in Rove: the worktree's animal slug). We ask for
+    // its thread title instead — but Codex's `thread-title` segment resolves
+    // to the thread's USER-ASSIGNED name and falls back to the thread UUID,
+    // which is what every Rove-launched session has, so the segment renders
+    // an id (see `placeholderTitles` below). The override is still the right
+    // ask — a slug is no better, and `activity` is what feeds the interrupt
+    // hint — and Rove names the tab from its own first-prompt summary when
+    // Codex hands back an id.
     terminalTitle: {
       ownsStatus: true,
       launchArgs: ["-c", 'tui.terminal_title=["activity","thread-title"]'],
+      // Codex thread ids are UUIDs (v7 today); a bare UUID is never a name.
+      placeholderTitles: [/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i],
       // The `activity` segment is a braille spinner frame joined to the next
       // segment by a space (codex `TERMINAL_TITLE_SPINNER_FRAMES` +
       // `separator_from_previous`). It only appears while a turn runs, so a
@@ -364,15 +346,24 @@ export function supportsStructuredHistory(vendor: VendorId): boolean {
  * `engine/foreground.ts` + `tui/workspace/live-engine.ts`.
  */
 
+// Title-policy MATCHING lives in `./title-policy.ts` (registry-free, so it
+// carries no import cycle back to this table). What stays here is the vendor
+// resolution: which vocabulary applies to a given `VendorId`, including the
+// union fallback for a vendor that declares none of its own.
+export type { EngineTerminalTitlePolicy } from "./title-policy.ts"
+
 /**
- * Every status glyph any built-in engine declares. The fallback vocabulary
- * for a vendor that declares none of its own — see
+ * Every status glyph / placeholder pattern any built-in engine declares. The
+ * fallback vocabulary for a vendor that declares none of its own — see
  * {@link stripEngineStatusPrefix}. Computed once; the built-in table is a
  * module constant.
  */
 const ALL_STATUS_PREFIXES: readonly string[] = [
   ...new Set(Object.values(BUILTIN_ENGINES).flatMap((entry) => entry.terminalTitle?.statusPrefixes ?? [])),
 ]
+const ALL_PLACEHOLDER_TITLES: readonly RegExp[] = Object.values(BUILTIN_ENGINES).flatMap(
+  (entry) => entry.terminalTitle?.placeholderTitles ?? [],
+)
 
 /**
  * The status-glyph vocabulary to judge a vendor's title by: its own when it
@@ -409,16 +400,40 @@ export function engineStatusPrefixes(vendor: VendorId): readonly string[] {
  * these glyphs keeps its name.
  */
 export function stripEngineStatusPrefix(title: string, vendor: VendorId | null | undefined): string {
-  const prefixes = vendor ? engineStatusPrefixes(vendor) : ALL_STATUS_PREFIXES
-  // Longest-first so a multi-char prefix isn't shadowed by a shorter one.
-  for (const prefix of [...prefixes].sort((a, b) => b.length - a.length)) {
-    if (!title.startsWith(prefix)) continue
-    const rest = title.slice(prefix.length).trimStart()
-    // Whole title was the decoration → it is the name, not a status.
-    if (rest.length === 0) return title
-    return rest
-  }
-  return title
+  return stripStatusPrefix(title, vendor ? engineStatusPrefixes(vendor) : ALL_STATUS_PREFIXES)
+}
+
+/**
+ * True when the engine wrote an INTERNAL IDENTIFIER into its OSC title
+ * instead of a name (`terminalTitle.placeholderTitles`) — so kobe must treat
+ * it as "no title" and fall through to its own rungs (the recorded name, the
+ * first-prompt summary, the numbered vendor default).
+ *
+ * Codex is why this exists: its `thread-title` segment renders the thread
+ * UUID for every session without a user-assigned name, so tabs read
+ * `01a00ea6-79cb-7413-bf83-b897ac2da2ff 1` (owner report 2026-08-17).
+ *
+ * Same `vendor` rule as the strip above — it NARROWS the vocabulary, it does
+ * not gate it. An unresolved vendor (the ~2s `ps` walk hasn't answered, a
+ * user wrapper) falls back to the union of every built-in's patterns, which
+ * is safe for the same reason: no engine writes a bare UUID it wants kept.
+ */
+export function isEnginePlaceholderTitle(title: string, vendor: VendorId | null | undefined): boolean {
+  const declared = vendor ? engineEntry(vendor).terminalTitle?.placeholderTitles : undefined
+  return isPlaceholderTitle(title, declared && declared.length > 0 ? declared : ALL_PLACEHOLDER_TITLES)
+}
+
+/**
+ * The live OSC title as a NAME kobe may render, or `""` when the engine
+ * wrote no name — the ONE entry point every display surface projects a raw
+ * title through. Status decoration stripped, identifier placeholders
+ * collapsed to `""` (an id is worse than no title: `""` is already every
+ * consumer's "no live name", and `setTabLastTitle` refuses to record it, so
+ * a placeholder never overwrites a good recorded name).
+ */
+export function engineDisplayTitle(title: string, vendor: VendorId | null | undefined): string {
+  const name = stripEngineStatusPrefix(title, vendor)
+  return isEnginePlaceholderTitle(name, vendor) ? "" : name
 }
 
 /**
@@ -432,20 +447,11 @@ export function stripEngineStatusPrefix(title: string, vendor: VendorId | null |
  * issue #15). That rewrite is therefore the one event-grade "the turn
  * ended" signal an interrupt produces, and this hint is how consumers
  * (the TUI's interrupt observer, the daemon's activity reconciler) read
- * it without hard-coding any vendor's glyphs.
- *
- * Strict on purpose: `"rest"` is only claimed for a vendor that declares
- * `workingPrefixes` AND wrote a non-empty title without one — an engine
- * that never decorates its title (copilot, custom wrappers) or a session
- * that never set a title answers `null`, never `"rest"`.
+ * it without hard-coding any vendor's glyphs. It reads the RAW title, so a
+ * placeholder name never costs kobe the turn signal riding in front of it.
  */
 export function engineTitleTurnHint(vendor: VendorId, title: string): "working" | "rest" | null {
-  const terminalTitle = engineEntry(vendor).terminalTitle
-  const working = terminalTitle?.workingPrefixes
-  if (terminalTitle?.ownsStatus !== true || !working || working.length === 0) return null
-  const trimmed = title.trim()
-  if (trimmed.length === 0) return null
-  return working.some((prefix) => trimmed.startsWith(prefix)) ? "working" : "rest"
+  return titleTurnHint(engineEntry(vendor).terminalTitle, title)
 }
 
 /**

--- a/packages/kobe/src/engine/title-policy.ts
+++ b/packages/kobe/src/engine/title-policy.ts
@@ -1,0 +1,131 @@
+/**
+ * Engine-owned OSC-title policy — the vocabulary an engine declares about
+ * the titles it writes, plus the pure matchers neutral layers judge a live
+ * title by.
+ *
+ * Split out of `registry.ts` (file-size cap) and deliberately REGISTRY-FREE:
+ * everything here takes the declared vocabulary as an argument, so it holds
+ * no import cycle back to the entry table. `registry.ts` owns the thin
+ * vendor-resolving wrappers (`stripEngineStatusPrefix`, `engineDisplayTitle`,
+ * `engineTitleTurnHint`) and re-exports the type; call those, not these.
+ *
+ * The shape of the problem: an engine that owns its terminal title writes
+ * TWO things into it that are not the conversation's name — a status
+ * decoration (claude's `✳`, codex's braille spinner) and, for some engines,
+ * an internal IDENTIFIER when it has no name to show (codex writes the
+ * thread UUID). Both must be recognized WITHOUT any neutral layer learning a
+ * vendor's spelling, which is what {@link EngineTerminalTitlePolicy}
+ * declares and what the matchers below consume.
+ */
+
+/**
+ * Native OSC 0/2 title policy for an engine's interactive terminal sessions.
+ * Declared per engine in the registry; every field is optional except
+ * `ownsStatus`, and an engine that writes a plain, undecorated title declares
+ * nothing but that.
+ */
+export interface EngineTerminalTitlePolicy {
+  /**
+   * The engine's live title is the status surface while it is visible, so
+   * neutral tab chrome must not prefix a duplicate turn glyph.
+   */
+  readonly ownsStatus: boolean
+  /**
+   * Extra launch argv that selects the engine's own title fields, so the
+   * launcher never learns a vendor's config syntax.
+   */
+  readonly launchArgs?: readonly string[]
+  /**
+   * Leading STATUS decoration the engine writes into its own OSC title,
+   * stripped before kobe renders the name. Engine-owned by construction:
+   * only the adapter knows its vendor's glyph vocabulary, and kobe already
+   * draws that state in its own column — showing both is the same fact
+   * twice, and the animated variants make a resting tab look busy.
+   *
+   * Matched anchored at the start, longest-first, with any following
+   * whitespace; the remainder is the title. A pattern that would consume
+   * the WHOLE title is not applied (a session actually named "Working" is
+   * a name, not a status).
+   */
+  readonly statusPrefixes?: readonly string[]
+  /**
+   * The subset of {@link statusPrefixes} the engine ONLY writes while a
+   * turn is running (its animated frames). A title that stops starting
+   * with one of these is the engine's own "I stopped working" signal —
+   * the one observable event an ESC interrupt leaves behind (claude-code
+   * runs no Stop hook on its abort path; issue #15). Consumed by
+   * `engineTitleTurnHint`. Omit when the engine's resting title is
+   * indistinguishable from its working one.
+   */
+  readonly workingPrefixes?: readonly string[]
+  /**
+   * Titles this engine writes that are an INTERNAL IDENTIFIER rather than a
+   * name — matched against the title with its status decoration already
+   * stripped. A match means "this engine has no name for the session", so
+   * neutral layers treat it as no live title at all and fall through to
+   * kobe's own rungs (the recorded name, the first-prompt summary, the
+   * numbered vendor default) instead of painting the identifier.
+   *
+   * The one place a vendor's placeholder SPELLING is allowed to live. Codex
+   * is the case that forced it: its `thread-title` segment renders the
+   * thread UUID (`01a00ea6-79cb-…`) for every session that has no
+   * user-assigned name, which is all of them — verified against
+   * codex-cli 0.147 on both a fresh session and a resumed one that already
+   * had a stored title. Other engines will have their own shapes (a bare
+   * pid, an "Untitled", a cwd echo), which is why this is declared data and
+   * not a codex branch in the renderer.
+   *
+   * Patterns MUST be anchored (`^…$`) and MUST NOT carry the `g` flag —
+   * `RegExp.test` on a global regex is stateful and would match every other
+   * call. Tested against the TRIMMED title.
+   */
+  readonly placeholderTitles?: readonly RegExp[]
+}
+
+/**
+ * Strip a leading status decoration from `title` using `prefixes`.
+ *
+ * Longest-first so a multi-char prefix isn't shadowed by a shorter one, and
+ * conservative where it matters: a prefix that would consume the whole title
+ * is returned unchanged, so a session genuinely named after one of these
+ * glyphs keeps its name.
+ */
+export function stripStatusPrefix(title: string, prefixes: readonly string[]): string {
+  for (const prefix of [...prefixes].sort((a, b) => b.length - a.length)) {
+    if (!title.startsWith(prefix)) continue
+    const rest = title.slice(prefix.length).trimStart()
+    // Whole title was the decoration → it is the name, not a status.
+    if (rest.length === 0) return title
+    return rest
+  }
+  return title
+}
+
+/**
+ * True when `title` is one of the engine's identifier placeholders — i.e.
+ * the engine wrote something that is not a name. An empty title answers
+ * false: "nothing reported yet" is a different fact from "reported an id",
+ * and the callers already treat empty as absent.
+ */
+export function isPlaceholderTitle(title: string, patterns: readonly RegExp[]): boolean {
+  const trimmed = title.trim()
+  if (trimmed.length === 0) return false
+  return patterns.some((pattern) => pattern.test(trimmed))
+}
+
+/**
+ * What a status-owning engine's live title says about its turn state, or
+ * `null` when the title carries no verdict.
+ *
+ * Strict on purpose: `"rest"` is only claimed for a policy that declares
+ * `workingPrefixes` AND a non-empty title without one — an engine that never
+ * decorates its title (copilot, custom wrappers) or a session that never set
+ * a title answers `null`, never `"rest"`.
+ */
+export function titleTurnHint(policy: EngineTerminalTitlePolicy | undefined, title: string): "working" | "rest" | null {
+  const working = policy?.workingPrefixes
+  if (policy?.ownsStatus !== true || !working || working.length === 0) return null
+  const trimmed = title.trim()
+  if (trimmed.length === 0) return null
+  return working.some((prefix) => trimmed.startsWith(prefix)) ? "working" : "rest"
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
@@ -20,7 +20,7 @@
  * ordinals, kinds and split state a session key can't.
  */
 
-import { stripEngineStatusPrefix } from "../../../engine/registry"
+import { engineDisplayTitle } from "../../../engine/registry"
 import { type TreeTab, parseRowId, tabRowId } from "../../../tui/panes/sidebar/tree-core"
 
 /** One live pty-host session, as this module needs it. */
@@ -44,11 +44,14 @@ export interface LiveSession {
  * The label is the live process title when the host has one, else the tab
  * id, prefixed ⚠ — the row exists because the snapshot does NOT know this
  * session, and that is worth a glance. The title is a RAW OSC string here
- * (nobody has stripped it — that happens on the mounted-tab path), so the
- * engine's own status decoration comes off first: kobe draws the state glyph
- * on this row, and two status languages side by side is what
- * `stripEngineStatusPrefix` exists to prevent. Vendor-agnostic strip — an
- * unregistered session has no resolved vendor by construction.
+ * (nobody has projected it — that happens on the mounted-tab path), so it
+ * goes through `engineDisplayTitle` first: the engine's own status decoration
+ * comes off (kobe draws the state glyph on this row, and two status languages
+ * side by side is what that projection exists to prevent), and an identifier
+ * placeholder (codex's thread UUID) collapses to `""` so the row falls back
+ * to the tab id it would have shown anyway. Vendor-agnostic — an unregistered
+ * session has no resolved vendor by construction, so the union vocabulary
+ * applies.
  */
 export function orphanTabsByTask(
   sessions: readonly LiveSession[],
@@ -68,7 +71,7 @@ export function orphanTabsByTask(
     if (tabs.some((tab) => tab.id === tabId)) continue
     tabs.push({
       id: tabId,
-      label: `⚠ ${stripEngineStatusPrefix(session.title?.trim() ?? "", null).trim() || tabId}`,
+      label: `⚠ ${engineDisplayTitle(session.title?.trim() ?? "", null).trim() || tabId}`,
       // The first unregistered tab of a snapshot-less task reads active; the
       // caller demotes this when merging under a task that has snapshot tabs.
       active: tabs.length === 0,

--- a/packages/kobe/src/tui-react/workspace/title-subscriptions.ts
+++ b/packages/kobe/src/tui-react/workspace/title-subscriptions.ts
@@ -29,13 +29,15 @@
  * detector to attach) still comes from the process tree; display no longer
  * does.
  *
- * What the RENDER projections below (and use-turn-polls' twin) do strip is
- * the engine's leading STATUS decoration — claude's `✳`/`⠂`/`⠐`, codex's
- * spinner frame — because kobe draws that state in its own glyph column and
- * showing both says it twice (owner 2026-08-10). That is a display concern,
+ * What the RENDER projections below (and use-turn-polls' twin) do drop is
+ * the parts of the OSC title that are not a name: the engine's leading
+ * STATUS decoration — claude's `✳`/`⠂`/`⠐`, codex's spinner frame — because
+ * kobe draws that state in its own glyph column and showing both says it
+ * twice (owner 2026-08-10), and a title the engine declared to be an
+ * identifier placeholder (codex's thread UUID). That is a display concern,
  * so it lives in the projection, not in the store, and the vocabulary is
- * declared per engine (`terminalTitle.statusPrefixes`). The name itself is
- * still never rewritten.
+ * declared per engine (`terminalTitle`). The name itself is still never
+ * rewritten.
  *
  * No React, no Solid, no @opentui — plain closures over Maps, unit-testable
  * under vitest. Callers own the tick that drives `reconcile()` (a PTY spawns
@@ -43,7 +45,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
-import { stripEngineStatusPrefix } from "../../engine/registry"
+import { engineDisplayTitle } from "../../engine/registry"
 import type { TaskPtyLike } from "../../tui/panes/terminal/pty-types"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { getDefaultLiveEngines } from "../../tui/workspace/live-engine"
@@ -174,9 +176,10 @@ export function useTitleSubscriptions(ptyKeys: ReadonlyMap<string, string>): Rea
         const title = store.get(key)
         if (title === undefined) continue
         // Same rule as use-turn-polls' projection: the engine's own status
-        // decoration is stripped before anything renders it, so kobe's glyph
-        // column stays the one place turn state is drawn.
-        next.set(id, stripEngineStatusPrefix(title, liveEngines.resolve(key)))
+        // decoration is stripped before anything renders it (so kobe's glyph
+        // column stays the one place turn state is drawn), and an engine that
+        // wrote an identifier instead of a name projects to `""`.
+        next.set(id, engineDisplayTitle(title, liveEngines.resolve(key)))
       }
       if (next.size === prev.size && [...next].every(([id, v]) => prev.get(id) === v)) return prev
       return next

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -9,7 +9,7 @@
  */
 
 import { engineEntry } from "@/engine/registry"
-import { deriveTitleFromSessionId } from "@/monitor/auto-title"
+import { deriveTitleFromSession, deriveTitleFromSessionId } from "@/monitor/auto-title"
 import type { VendorId } from "@/types/vendor"
 import { useEffect, useState } from "react"
 import { type EngineTab, type TabsState, setTabAutoTitle, setTabSpawned } from "../../tui/workspace/terminal-tabs-core"
@@ -19,7 +19,7 @@ const NAMING_POLL_MS = 5000
 
 export interface TabLifecycleIO {
   readonly stateRef: { readonly current: TabsState }
-  readonly propsRef: { readonly current: { readonly vendor: VendorId } }
+  readonly propsRef: { readonly current: { readonly vendor: VendorId; readonly worktree: string } }
   readonly update: (next: TabsState) => void
 }
 
@@ -63,28 +63,65 @@ export function useTabHydration(rehydrated: boolean, io: TabLifecycleIO): boolea
   return hydrating
 }
 
-/** Auto-naming + existence tracking (the tmux naming pass), mount-only. */
+/**
+ * True for the ONE engine tab whose conversation is the worktree's origin
+ * conversation — the first engine tab in the strip. The naming fallback below
+ * is scoped to it, see there.
+ */
+function isFirstEngineTab(state: TabsState, tabId: string): boolean {
+  return state.tabs.find((tab) => tab.kind === "engine")?.id === tabId
+}
+
+/**
+ * Auto-naming + existence tracking (the tmux naming pass), mount-only.
+ *
+ * Two ways a tab finds its name, both engine-neutral:
+ *
+ *  - By SESSION ID, when kobe pinned one at launch. Only claude accepts
+ *    `--session-id` (`withClaudeSessionId`), so this is claude's path, and
+ *    finding a transcript for that id also proves the tab spawned.
+ *  - By WORKTREE, for every other engine — codex/copilot/kimi tabs carry no
+ *    pinned id, so before this they never got a first-prompt name at all and
+ *    fell all the way to the numbered vendor default ("codex 1"). Their
+ *    history readers still resolve a worktree's sessions by the cwd recorded
+ *    in the transcript, which is exactly what the daemon's TASK auto-title
+ *    already reads, so the tab and the sidebar row agree by construction.
+ *
+ * The worktree path is scoped to the task's FIRST engine tab on purpose: the
+ * worktree's ORIGIN conversation is that tab's by construction, while a later
+ * tab's session cannot be told apart from one the user started by hand in the
+ * same directory — and a plausible-but-wrong name is worse than the numbered
+ * default. It also never sets `spawned`: a transcript in the worktree is not
+ * evidence about THIS tab's process, which the session-id path does have.
+ */
 export function useTabNaming(io: TabLifecycleIO): void {
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once interval; reads propsRef/stateRef for freshness.
   useEffect(() => {
     let namingBusy = false
     const timer = setInterval(() => {
       if (namingBusy) return
-      const candidates = io.stateRef.current.tabs.filter(
-        (tab): tab is EngineTab =>
-          tab.kind === "engine" && !!tab.sessionId && (!tab.spawned || (!tab.title && !tab.autoTitle)),
-      )
+      const state = io.stateRef.current
+      const unnamed = (tab: EngineTab): boolean => !tab.title && !tab.autoTitle
+      const candidates = state.tabs.filter((tab): tab is EngineTab => {
+        if (tab.kind !== "engine") return false
+        if (tab.sessionId) return !tab.spawned || unnamed(tab)
+        return unnamed(tab) && isFirstEngineTab(state, tab.id)
+      })
       if (candidates.length === 0) return
       namingBusy = true
       void (async () => {
         try {
           for (const tab of candidates) {
-            if (!tab.sessionId) continue
-            const title = await deriveTitleFromSessionId(tab.vendor ?? io.propsRef.current.vendor, tab.sessionId)
+            const vendor = tab.vendor ?? io.propsRef.current.vendor
+            const title = tab.sessionId
+              ? await deriveTitleFromSessionId(vendor, tab.sessionId)
+              : await deriveTitleFromSession(io.propsRef.current.worktree, vendor)
             if (!title) continue
-            let next = setTabSpawned(io.stateRef.current, tab.id, true)
+            const current = io.stateRef.current
+            let next = current
+            if (tab.sessionId) next = setTabSpawned(next, tab.id, true)
             if (!tab.title && !tab.autoTitle) next = setTabAutoTitle(next, tab.id, title)
-            io.update(next)
+            if (next !== current) io.update(next)
           }
         } finally {
           namingBusy = false

--- a/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
+++ b/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
@@ -33,7 +33,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { TranscriptActivity } from "../../client/remote-orchestrator"
-import { engineEntry, stripEngineStatusPrefix } from "../../engine/registry"
+import { engineDisplayTitle, engineEntry } from "../../engine/registry"
 import type { ChatTabTurnState } from "../../engine/turn-detector"
 import { startTurnStatusPoll } from "../../tui/ops/activity-monitor"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
@@ -131,13 +131,15 @@ export function useTurnPolls(deps: {
       for (const [key, tabId] of soloKeys) {
         const title = titleStore.get(key)
         if (title === undefined) continue
-        // Strip the engine's own status decoration HERE, at the one place the
-        // raw OSC title enters the app: every consumer (the tab strip, the
+        // Project the raw OSC title to a NAME here, at the one place it
+        // enters the app: the engine's status decoration comes off, and a
+        // title the engine declared to be an identifier placeholder (codex's
+        // thread UUID) collapses to `""`. Every consumer (the tab strip, the
         // tree, and the recorder that persists it as `lastTitle`) then works
         // with the name alone, and kobe's glyph column is the single place
         // that draws turn state. Engine-declared vocabulary — see
-        // `stripEngineStatusPrefix`.
-        next.set(tabId, stripEngineStatusPrefix(title, liveEngines.resolve(key)))
+        // `engineDisplayTitle`.
+        next.set(tabId, engineDisplayTitle(title, liveEngines.resolve(key)))
       }
       if (next.size === prev.size && [...next].every(([id, v]) => prev.get(id) === v)) return prev
       return next

--- a/packages/kobe/src/tui/workspace/terminal-tab-split.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-split.ts
@@ -12,7 +12,7 @@
  */
 
 import type { VendorId } from "@/types/vendor"
-import { engineEntry, engineStatusPrefixes, stripEngineStatusPrefix } from "../../engine/registry"
+import { engineDisplayTitle, engineEntry, engineStatusPrefixes, isEnginePlaceholderTitle } from "../../engine/registry"
 import { t } from "../i18n"
 import { pathLeaf } from "../lib/path-helpers"
 import { type SplitState, leaves } from "./split-core"
@@ -156,17 +156,19 @@ export function meaningfulAutoTitle(autoTitle: string | null | undefined): strin
 /**
  * The recorded title as a stable NAME, or null when it is not one.
  *
- * Strips the engine's status decoration (idempotent — a title recorded after
- * the entry-point fix passes through, an older snapshot heals on display),
- * then rejects a recording that was ONLY decoration. `stripEngineStatusPrefix`
- * keeps such a title on purpose — a session genuinely named "✳" owns that
- * name — but in the tree a lone glyph is not a label, so the caller falls
- * through to the first-prompt summary or the vendor default instead.
+ * Projects through {@link engineDisplayTitle} (idempotent — a title recorded
+ * after the entry-point fix passes through, an older snapshot heals on
+ * display): the engine's status decoration comes off, and an identifier
+ * placeholder (codex's thread UUID) collapses to `""` → null. Then it rejects
+ * a recording that was ONLY decoration. `stripEngineStatusPrefix` keeps such
+ * a title on purpose — a session genuinely named "✳" owns that name — but in
+ * the tree a lone glyph is not a label, so the caller falls through to the
+ * first-prompt summary or the vendor default instead.
  */
 function stableRecordedTitle(raw: string | null | undefined, vendor: VendorId): string | null {
   const recorded = raw?.trim()
   if (!recorded) return null
-  const cleaned = stripEngineStatusPrefix(recorded, vendor)
+  const cleaned = engineDisplayTitle(recorded, vendor)
   // Unchanged AND made only of this engine's glyphs = decoration, not a name.
   if (cleaned === recorded && isEngineDecoration(recorded, vendor)) return null
   return cleaned || null
@@ -292,8 +294,20 @@ export function tabTitle(tab: TerminalTab, taskVendor: VendorId, liveName?: stri
   // Inbox), so fall back to the last live title this tab recorded. Without
   // it those surfaces drop straight to `autoTitle`, the FIRST prompt's
   // summary, and a tab that has long moved on still reads as its opening
-  // question.
-  if (tab.lastTitle) return `${tab.lastTitle} ${tab.ordinal}`
+  // question. What IS rejected here is an identifier the engine wrote in
+  // place of a name (codex's thread UUID): a snapshot taken before the engine
+  // declared its placeholder vocabulary still holds one, and `setTabLastTitle`
+  // refuses `""` so nothing ever overwrites it — rejecting on DISPLAY is what
+  // retires it without a state migration, the same rule `meaningfulAutoTitle`
+  // follows. Status decoration is deliberately NOT stripped here; that is
+  // `tabTitleStable`'s job, for the surfaces that draw their own state glyph.
+  // `liveVendor` is the tab's own recorded process identity and outranks the
+  // creation pin; a command tab with neither resolves to null, which is the
+  // union-vocabulary case the check is built for.
+  const recordedVendor = tab.liveVendor ?? (tab.kind === "engine" ? (tab.vendor ?? taskVendor) : null)
+  if (tab.lastTitle && !isEnginePlaceholderTitle(tab.lastTitle, recordedVendor)) {
+    return `${tab.lastTitle} ${tab.ordinal}`
+  }
   const auto = meaningfulAutoTitle(tab.autoTitle)
   if (auto) return auto
   const name =

--- a/packages/kobe/test/engine/title-placeholder.test.ts
+++ b/packages/kobe/test/engine/title-placeholder.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `engineDisplayTitle` / `isEnginePlaceholderTitle` — some engines write an
+ * internal IDENTIFIER into their OSC title when they have no name to show.
+ * Codex is the case that forced this: with Rove's
+ * `tui.terminal_title=["activity","thread-title"]` override, its
+ * `thread-title` segment resolves to the thread's user-assigned NAME and
+ * falls back to the thread UUID — and no Rove-launched session has a name,
+ * so every codex tab read `01a00ea6-79cb-7413-bf83-b897ac2da2ff 1` (owner
+ * report 2026-08-17; reproduced against codex-cli 0.147 on a fresh session
+ * AND on a resumed one that already had a stored title).
+ *
+ * The vocabulary is engine-declared (`terminalTitle.placeholderTitles`), so
+ * no neutral layer learns a vendor's id shape.
+ */
+
+import { describe, expect, it } from "vitest"
+import { engineDisplayTitle, isEnginePlaceholderTitle } from "../../src/engine/registry"
+import { isPlaceholderTitle } from "../../src/engine/title-policy"
+
+/** A real codex thread id (UUIDv7) as it arrives on the OSC stream. */
+const THREAD_ID = "01a00ea6-79cb-7413-bf83-b897ac2da2ff"
+
+describe("engineDisplayTitle — identifier placeholders", () => {
+  it("collapses codex's bare thread id to no-title", () => {
+    expect(engineDisplayTitle(THREAD_ID, "codex")).toBe("")
+    expect(isEnginePlaceholderTitle(THREAD_ID, "codex")).toBe(true)
+  })
+
+  it("collapses it with codex's spinner frame in front (a running turn)", () => {
+    // The spinner is stripped first, so the placeholder check sees the id.
+    expect(engineDisplayTitle(`⠴ ${THREAD_ID}`, "codex")).toBe("")
+    expect(engineDisplayTitle(`⠋ ${THREAD_ID}`, "codex")).toBe("")
+  })
+
+  it("leaves a real name alone", () => {
+    expect(engineDisplayTitle("⠹ add the ruler", "codex")).toBe("add the ruler")
+    expect(engineDisplayTitle("✳ 运行本地Codex处理图片", "claude")).toBe("运行本地Codex处理图片")
+    // A name that merely CONTAINS an id is a name — patterns are anchored.
+    expect(engineDisplayTitle(`resume ${THREAD_ID}`, "codex")).toBe(`resume ${THREAD_ID}`)
+  })
+
+  // Same rule as the status strip: `vendor` narrows the vocabulary, it never
+  // gates the check. The live-engine probe is a ~2s ps walk, so most ticks
+  // have no vendor — and that title is what gets RECORDED as `lastTitle`.
+  it("catches the id without a resolved vendor (union vocabulary)", () => {
+    expect(engineDisplayTitle(THREAD_ID, null)).toBe("")
+    expect(engineDisplayTitle(THREAD_ID, undefined)).toBe("")
+    // A vendor that declares no patterns of its own also falls back to the
+    // union — no engine writes a bare UUID it wants kept.
+    expect(engineDisplayTitle(THREAD_ID, "copilot")).toBe("")
+    expect(engineDisplayTitle(THREAD_ID, "my-custom-engine")).toBe("")
+  })
+
+  it("an empty title is absent, not a placeholder", () => {
+    expect(isEnginePlaceholderTitle("", "codex")).toBe(false)
+    expect(isEnginePlaceholderTitle("   ", "codex")).toBe(false)
+    expect(engineDisplayTitle("", "codex")).toBe("")
+  })
+})
+
+describe("isPlaceholderTitle (pure matcher)", () => {
+  it("matches on the trimmed title and never mutates regex state", () => {
+    const patterns = [/^\d+$/]
+    // A `g` regex would alternate true/false across calls — the contract
+    // forbids one, and a non-global pattern is stable.
+    expect(isPlaceholderTitle(" 123 ", patterns)).toBe(true)
+    expect(isPlaceholderTitle("123", patterns)).toBe(true)
+    expect(isPlaceholderTitle("123 files", patterns)).toBe(false)
+  })
+
+  it("an engine that declares nothing never rejects a title", () => {
+    expect(isPlaceholderTitle(THREAD_ID, [])).toBe(false)
+  })
+})

--- a/packages/kobe/test/tui-react/tab-naming.test.ts
+++ b/packages/kobe/test/tui-react/tab-naming.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `useTabNaming` — the per-tab first-prompt naming pass.
+ *
+ * Two ways a tab finds its name, and the second is why this file exists:
+ * only claude accepts `--session-id`, so kobe pins a session id on claude
+ * tabs and on nothing else. Codex/copilot/kimi tabs therefore had NO id to
+ * look a transcript up by, were skipped entirely, and fell all the way to
+ * the numbered vendor default ("codex 1") — which, once codex's thread-id
+ * OSC title stopped naming them (owner report 2026-08-17), was all they had
+ * left. Their history readers still resolve a worktree's sessions by the cwd
+ * recorded in the transcript, which is the fallback asserted below.
+ *
+ * The hook is mount-only (`useEffect` with an empty dep list) and drives a
+ * plain `setInterval`, so React is mocked down to "run the effect now" and
+ * the pass is driven with fake timers — no renderer needed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  fromSessionId: vi.fn(),
+  fromWorktree: vi.fn(),
+}))
+
+vi.mock("@/monitor/auto-title", () => ({
+  deriveTitleFromSessionId: mocks.fromSessionId,
+  deriveTitleFromSession: mocks.fromWorktree,
+}))
+
+const cleanups: Array<() => void> = []
+vi.mock("react", () => ({
+  useEffect: (fn: () => (() => void) | undefined) => {
+    const cleanup = fn()
+    if (cleanup) cleanups.push(cleanup)
+  },
+  useState: (init: unknown) => [typeof init === "function" ? (init as () => unknown)() : init, () => {}],
+}))
+
+import { useTabNaming } from "../../src/tui-react/workspace/use-tab-lifecycle.ts"
+import { type TabsState, type TerminalTab, initialTabs } from "../../src/tui/workspace/terminal-tabs-core.ts"
+import type { VendorId } from "../../src/types/vendor.ts"
+
+const engineTab = (over: Partial<TerminalTab>): TerminalTab =>
+  ({ kind: "engine", id: "tab-1", title: null, ordinal: 1, ...over }) as TerminalTab
+
+/** A mutable stand-in for the caller's latest-render refs. */
+function harness(tabs: TerminalTab[], vendor: VendorId, worktree = "/wt") {
+  const state: TabsState = { ...initialTabs(), tabs, activeId: tabs[0]?.id ?? "tab-1" }
+  const io = {
+    stateRef: { current: state },
+    propsRef: { current: { vendor, worktree } },
+    update: (next: TabsState) => {
+      io.stateRef.current = next
+    },
+  }
+  return io
+}
+
+/** Run exactly one naming tick and let its async body settle. */
+async function tick(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(5000)
+}
+
+beforeEach(() => {
+  cleanups.length = 0
+  mocks.fromSessionId.mockReset()
+  mocks.fromWorktree.mockReset()
+  mocks.fromSessionId.mockResolvedValue("")
+  mocks.fromWorktree.mockResolvedValue("")
+  vi.useFakeTimers()
+})
+
+describe("useTabNaming", () => {
+  it("names a session-pinned tab by its id, and marks it spawned", async () => {
+    mocks.fromSessionId.mockResolvedValue("wire up the digest verb")
+    const io = harness([engineTab({ vendor: "claude", sessionId: "sess-1" })], "claude")
+    useTabNaming(io)
+    await tick()
+    expect(mocks.fromSessionId).toHaveBeenCalledWith("claude", "sess-1")
+    expect(mocks.fromWorktree).not.toHaveBeenCalled()
+    const tab = io.stateRef.current.tabs[0] as TerminalTab
+    expect(tab.autoTitle).toBe("wire up the digest verb")
+    expect((tab as { spawned?: boolean }).spawned).toBe(true)
+  })
+
+  it("names an UNPINNED tab from the worktree's origin conversation", async () => {
+    mocks.fromWorktree.mockResolvedValue("add the ruler")
+    const io = harness([engineTab({ vendor: "codex" })], "codex", "/wt/warthog")
+    useTabNaming(io)
+    await tick()
+    expect(mocks.fromWorktree).toHaveBeenCalledWith("/wt/warthog", "codex")
+    const tab = io.stateRef.current.tabs[0] as TerminalTab
+    expect(tab.autoTitle).toBe("add the ruler")
+    // A transcript in the worktree says nothing about THIS tab's process.
+    expect((tab as { spawned?: boolean }).spawned).toBeUndefined()
+  })
+
+  // The worktree's ORIGIN conversation belongs to the first engine tab by
+  // construction; a later tab's session can't be told apart from one the user
+  // started by hand in the same directory, and a plausible-but-wrong name is
+  // worse than the numbered default.
+  it("only the FIRST engine tab takes the worktree fallback", async () => {
+    mocks.fromWorktree.mockResolvedValue("add the ruler")
+    const io = harness(
+      [engineTab({ vendor: "codex" }), engineTab({ id: "tab-2", ordinal: 2, vendor: "codex" })],
+      "codex",
+    )
+    useTabNaming(io)
+    await tick()
+    expect(mocks.fromWorktree).toHaveBeenCalledTimes(1)
+    expect((io.stateRef.current.tabs[1] as TerminalTab).autoTitle).toBeUndefined()
+  })
+
+  it("stops asking once a tab has a name — no per-tick rescan", async () => {
+    mocks.fromWorktree.mockResolvedValue("add the ruler")
+    const io = harness([engineTab({ vendor: "codex" })], "codex")
+    useTabNaming(io)
+    await tick()
+    await tick()
+    expect(mocks.fromWorktree).toHaveBeenCalledTimes(1)
+  })
+
+  it("leaves a manual rename alone", async () => {
+    const io = harness([engineTab({ vendor: "codex", title: "my tab" })], "codex")
+    useTabNaming(io)
+    await tick()
+    expect(mocks.fromWorktree).not.toHaveBeenCalled()
+  })
+
+  it("keeps the tab untouched when the engine has no transcript yet", async () => {
+    const io = harness([engineTab({ vendor: "codex" })], "codex")
+    const before = io.stateRef.current
+    useTabNaming(io)
+    await tick()
+    expect(io.stateRef.current).toBe(before)
+  })
+})

--- a/packages/kobe/test/tui/tab-title-stable.test.ts
+++ b/packages/kobe/test/tui/tab-title-stable.test.ts
@@ -132,4 +132,23 @@ describe("tabTitleStable", () => {
     const tab = engineTab({ vendor: "codex", lastTitle: "⠹" })
     expect(tabTitleStable(tab, "codex")).toBe("codex 1")
   })
+
+  // Owner report 2026-08-17: every codex tab read as a UUID. Codex's
+  // `thread-title` segment falls back to the thread id for a session with no
+  // user-assigned name — which is all of them — so the id is what the OSC
+  // stream carries and what older snapshots recorded. It is an identifier,
+  // not a name: reject it on DISPLAY (so those snapshots heal without a
+  // migration) and let the next rung answer.
+  it("rejects codex's thread id and falls through to the first-prompt title", () => {
+    const id = "01a00ea6-79cb-7413-bf83-b897ac2da2ff"
+    const tab = engineTab({ vendor: "codex", lastTitle: id, autoTitle: "add the ruler", liveVendor: "codex" })
+    expect(tabTitleStable(tab, "codex", "codex")).toBe("add the ruler")
+    expect(tabTitle(tab, "codex")).toBe("add the ruler")
+    // The LIVE stream carries it with a spinner frame while a turn runs.
+    expect(tabTitleStable(tab, "codex", "codex", `⠴ ${id}`)).toBe("add the ruler")
+    // With nothing else to say, the numbered vendor default — still not an id.
+    const bare = engineTab({ vendor: "codex", lastTitle: id, liveVendor: "codex" })
+    expect(tabTitleStable(bare, "codex", "codex")).toBe("codex 1")
+    expect(tabTitle(bare, "codex")).toBe("codex 1")
+  })
 })


### PR DESCRIPTION
Codex's `thread-title` terminal-title segment resolves to a thread's *user-assigned* name and falls back to the raw thread id — and no Rove-launched session has one, so every Codex tab read `01a00ea6-79cb-7413-bf83-b897ac2da2ff 1` (reproduced against codex-cli 0.147 on a fresh session **and** on a resumed one that already had a stored title, so there is no text to get out of Codex here).

Engines now declare which of their OSC titles are internal identifiers rather than names (`terminalTitle.placeholderTitles`, next to the existing status/working prefixes in the new `engine/title-policy.ts`), and every display surface projects through one `engineDisplayTitle` that collapses a match to "no title" — so Rove falls through to its own rungs (manual rename → recorded name → first-prompt summary → numbered default) instead of painting an id. Identifiers already sitting in a persisted tab snapshot are rejected on display too, so they heal with no state migration.

Second half of the fix: only claude accepts `--session-id`, so codex/copilot/kimi tabs had no pinned id, were skipped by the naming pass entirely, and had no first-prompt summary to fall back to. They now derive one from the worktree's origin conversation — the same read the daemon's *task* auto-title already does, so the tab and the sidebar row agree by construction — scoped to the task's first engine tab, because a later tab's session can't be told apart from one the user started by hand in the same directory.

Adds 13 tests (`title-placeholder`, `tab-naming`, plus a `tabTitleStable` regression); `docs/design/engine-internals.md` gains the per-engine title-policy table and a tab-naming section, and loses two claims that were no longer true.

---

All three files below are `tui-react/` React-integration hooks, so the gate routes them to the render track (value import of `react`) and the vitest lcov they *are* covered by is never consulted.

coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts — the naming pass added here IS directly tested, in the new test/tui-react/tab-naming.test.ts (vitest, React mocked down to "run the mount effect", fake timers drive the interval); the render track does not execute vitest suites, and mounting the hook for real needs a live PTY registry.

coverage-exemption: packages/kobe/src/tui-react/workspace/use-turn-polls.ts — one-expression change (`stripEngineStatusPrefix` → `engineDisplayTitle` in the display projection) plus comments; the projection rule itself is covered directly in test/engine/title-placeholder.test.ts. File is at 0% baseline on this track.

coverage-exemption: packages/kobe/src/tui-react/workspace/title-subscriptions.ts — the same one-expression projection swap; the store's reconcile logic is covered by test/tui-react/title-subscriptions.test.ts under vitest, which this render floor cannot see.
