### PR TITLE
fix: persist the delete-branch opt-in across a daemon restart

### DIFF
--- a/.changeset/persist-deletebranch-across-reload.md
+++ b/.changeset/persist-deletebranch-across-reload.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Deleting a task with the "also delete the branch" opt-in now honors that choice even if the daemon restarts mid-deletion: the `deleteBranch` flag is durable state, but the store's load path was dropping it, so a queued deletion that survived a restart tore down the worktree while silently keeping the branch. The flag now round-trips through disk, matching every other persisted deletion field.

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -250,6 +250,10 @@ function coerceDeletion(value: unknown): TaskDeletionState | undefined {
     phase: v.phase,
     force: v.force,
     requestedAt: v.requestedAt,
+    // Round-trip the branch-cleanup opt-in: deletion is a persisted,
+    // daemon-owned state machine, so a deletion queued with `deleteBranch`
+    // that survives a restart must still delete the branch on `finish()`.
+    ...(typeof v.deleteBranch === "boolean" ? { deleteBranch: v.deleteBranch } : {}),
     ...(typeof v.error === "string" ? { error: v.error } : {}),
   }
 }

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -64,6 +64,30 @@ describe("durable background task deletion", () => {
     expect(worktrees.remove).toHaveBeenCalledWith("/wt/opt-in", { force: false, deleteBranch: true })
   })
 
+  it("keeps the deleteBranch opt-in across a store reload", async () => {
+    // Deletion is a durable, daemon-owned state machine: `prepare` persists
+    // the opt-in, and a daemon restart in the queued/running window reloads
+    // it from disk. If the load coercion drops `deleteBranch`, `finish` runs
+    // with `deleteBranch:false` and silently keeps the branch the user asked
+    // to delete. Reload through a fresh store + orchestrator and assert the
+    // opt-in survives the round-trip.
+    const task = await makeTask("/wt/reloaded")
+    await orch.prepareTaskDeletion(task.id, { deleteBranch: true })
+
+    const reloaded = new TaskIndexStore({ homeDir: home })
+    await reloaded.load()
+    expect(reloaded.get(task.id)?.deletion?.deleteBranch).toBe(true)
+
+    const reloadedOrch = new Orchestrator({ store: reloaded, worktrees: worktrees as unknown as GitWorktreeManager })
+    try {
+      await reloadedOrch.beginTaskDeletion(task.id)
+      await reloadedOrch.finishTaskDeletion(task.id)
+      expect(worktrees.remove).toHaveBeenCalledWith("/wt/reloaded", { force: false, deleteBranch: true })
+    } finally {
+      reloadedOrch.dispose()
+    }
+  })
+
   it("force does not escalate into branch deletion", async () => {
     const task = await makeTask("/wt/forced")
     worktrees.isDirty.mockResolvedValue(true)


### PR DESCRIPTION
## Direction

Bugs / correctness — found by code review of the daemon-owned persisted state machines (orchestrator index store codec).

## Problem

Task deletion is a **durable, daemon-owned background state machine** (`TaskDeletionState`): `prepare()` persists a `deletion` block to `tasks.json` (phase, force, `deleteBranch`, requestedAt), then a separate `begin()` → `finish()` run does the physical cleanup. The whole point of persisting it is to survive a daemon restart in the queued/running window (and the error-retry path keeps it on disk indefinitely).

But the load-path coercer `coerceDeletion` in `store-codec.ts` reconstructed every field **except `deleteBranch`**. So:

1. User deletes a task with the branch-cleanup opt-in → `deletion.deleteBranch: true` is written to disk.
2. Daemon restarts before `finish()` runs → the store reloads, and `deleteBranch` is silently dropped (reads back `undefined`).
3. `finish()` computes `deleteBranch: task.deletion.deleteBranch === true` → `false`, and removes the worktree while **keeping the branch the user explicitly asked to delete** — no error, no signal.

Every other optional deletion/task field is round-tripped precisely to avoid this class of "silently forgotten on every daemon restart" bug; `deleteBranch` was the one gap.

## Fix

One line in `coerceDeletion` — round-trip `deleteBranch` when it's a boolean, alongside the existing `error` passthrough:

```ts
...(typeof v.deleteBranch === "boolean" ? { deleteBranch: v.deleteBranch } : {}),
```

## Verification

- Added a test in `test/orchestrator/task-deletion.test.ts` that persists a deletion with `deleteBranch: true`, reloads through a fresh `TaskIndexStore` + `Orchestrator`, and asserts the opt-in survives and `finish()` calls `worktrees.remove(..., { deleteBranch: true })`. Confirmed it **fails without the fix** (reads back `undefined` → `deleteBranch: false`) and **passes with it**.
- `bun run typecheck` and `bun run lint` — both green.
- `test/orchestrator/task-deletion.test.ts` — all 8 tests pass.

Note: the full `bun run test` run has one unrelated pre-existing failure — `test/state/layout-migration.test.ts > … partial failure and retries` — which fails on a clean `origin/main` checkout too, because it injects a failure via a read-only directory that the container's root user bypasses. Not related to this change.

## Follow-ups (deliberately out of scope)

A separate code-review pass surfaced a second, unrelated one-line correctness bug worth its own PR: `hasLiveEngineTab` (`src/cli/api/tab-snapshot.ts`) counts a scratch task's shell `tab-1` as a live *engine* tab because the snapshot-free floor fires unconditionally, making a scratch shell sitting at a prompt report `running: true` to a coordinating agent. Left for a focused follow-up to keep this PR to one slice.


---
_Generated by [Claude Code](https://claude.ai/code/session_0146uyCGNJwSyyh5MKqdQaKk)_