### PR TITLE
fix: keep ULID task ids sortable when the clock steps backward

### DIFF
--- a/.changeset/ulid-backward-clock-monotonic.md
+++ b/.changeset/ulid-backward-clock-monotonic.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Task ids stay strictly sortable when the wall clock steps backward: the ULID generator now holds its last timestamp (instead of regressing the sortable prefix) and increments the random tail whenever an incoming timestamp does not advance past the previous one, so an NTP correction, VM resume, or manual clock change mid-session can no longer mint a task id that sorts before its predecessor and silently reorder the task index. Same-millisecond monotonicity and forward-clock behavior are unchanged.

--- a/packages/kobe/src/orchestrator/index/ulid.ts
+++ b/packages/kobe/src/orchestrator/index/ulid.ts
@@ -11,12 +11,17 @@
  *      "created at" tiebreaker. Sidebar grouping/ordering can rely on
  *      string compare instead of parsing `createdAt`.
  *
- *   2. **Monotonic within the same millisecond** — when two tasks are
- *      created back-to-back, the second must sort *after* the first.
- *      We achieve this by remembering the last (timestamp, randomness)
- *      we emitted: if the same millisecond comes around again, we
- *      increment the previous random tail by one instead of generating
- *      fresh randomness. (Spec: github.com/ulid/spec — "Monotonicity".)
+ *   2. **Monotonic across calls** — when two tasks are created
+ *      back-to-back, the second must sort *after* the first. We achieve
+ *      this by remembering the last (timestamp, randomness) we emitted:
+ *      if the incoming timestamp does not advance past it — the same
+ *      millisecond, or a wall clock that stepped *backward* (NTP
+ *      correction, VM resume, a manual clock change) — we hold the last
+ *      timestamp and increment the previous random tail by one instead of
+ *      generating fresh randomness. Holding the timestamp is what keeps a
+ *      backward clock step from minting an id whose prefix sorts before its
+ *      predecessor and silently reordering the task index.
+ *      (Spec: github.com/ulid/spec — "Monotonicity".)
  *
  * Inlined intentionally (~80 LoC, no deps). If we ever need a battle-
  * tested impl, swap to the `ulid` npm package — the public surface
@@ -91,9 +96,17 @@ function indicesToString(indices: number[]): string {
  */
 export function ulid(now: number = Date.now()): string {
   let randIndices: number[]
-  if (now === lastTime) {
-    // Same millisecond: increment the previous tail to preserve
-    // strict monotonic ordering across same-ms calls.
+  let time: number
+  if (now > lastTime) {
+    // The clock advanced: a fresh millisecond gets fresh randomness.
+    time = now
+    randIndices = randomIndices(RAND_LEN)
+  } else {
+    // The clock did NOT advance — same millisecond, or it stepped
+    // backward. Hold the last timestamp (never regress the sortable
+    // prefix) and increment the previous tail to preserve strict
+    // monotonic ordering across the call.
+    time = lastTime
     const next = lastRand.slice()
     if (!incrementIndices(next)) {
       // Astronomically unlikely (16 Z's). Fall back to fresh randomness.
@@ -101,12 +114,10 @@ export function ulid(now: number = Date.now()): string {
     } else {
       randIndices = next
     }
-  } else {
-    randIndices = randomIndices(RAND_LEN)
   }
-  lastTime = now
+  lastTime = time
   lastRand = randIndices
-  return encodeTime(now, TIME_LEN) + indicesToString(randIndices)
+  return encodeTime(time, TIME_LEN) + indicesToString(randIndices)
 }
 
 /** Reset the monotonic state — exported for tests only. */

--- a/packages/kobe/test/orchestrator/ulid.test.ts
+++ b/packages/kobe/test/orchestrator/ulid.test.ts
@@ -36,6 +36,27 @@ describe("ulid", () => {
     expect(first.slice(0, 10)).toBe(third.slice(0, 10))
   })
 
+  it("stays monotonic when the wall clock steps backward", () => {
+    const first = ulid(9000)
+    // Clock jumps back (NTP correction, VM resume). The id must still sort
+    // strictly after the previous one, so its timestamp prefix is held at
+    // the last-seen 9000 rather than regressing to 8000.
+    const second = ulid(8000)
+    expect(second > first).toBe(true)
+    expect(second.slice(0, 10)).toBe(first.slice(0, 10))
+  })
+
+  it("resumes fresh randomness once the clock catches back up", () => {
+    const first = ulid(9000)
+    const held = ulid(8000)
+    // Held at 9000 by the backward-step guard...
+    expect(held.slice(0, 10)).toBe(first.slice(0, 10))
+    // ...and a later timestamp advances the prefix normally again.
+    const later = ulid(9001)
+    expect(later > held).toBe(true)
+    expect(later.slice(0, 10) > first.slice(0, 10)).toBe(true)
+  })
+
   it("generates a distinct id per call", () => {
     const ids = new Set([ulid(9000), ulid(9000), ulid(9001), ulid(9001)])
     expect(ids.size).toBe(4)


### PR DESCRIPTION
## Direction

Bugs / correctness — self-found during a code-health review of the pure-logic surface (`src/orchestrator/index/ulid.ts`). No open PR or issue touches this file.

## Problem

`ulid()` is the task-id generator, and its docblock promises two invariants the task index depends on: ids are **lex-sortable by creation time** (`Task.id` doubles as a "created at" tiebreaker for sidebar grouping/ordering) and **monotonic** across back-to-back calls.

The implementation only special-cased `now === lastTime` (same millisecond). Any other timestamp — including one that stepped **backward** — took the else branch and emitted a fresh id at the smaller timestamp. So if the wall clock moves back mid-session (an NTP correction, a VM suspend/resume, a manual clock change), the next task id gets a smaller timestamp prefix and sorts **before** the id created just before it, silently reordering the task index.

Concretely: `ulid(9000)` then `ulid(8000)` produced a second id whose 10-char timestamp prefix (`8000`) sorts ahead of the first (`9000`), violating both stated invariants.

## Fix

Restructure the branch around whether the clock **advanced** rather than whether it exactly matched:

- `now > lastTime` → the clock advanced: fresh randomness at `now` (unchanged behavior).
- otherwise (same ms **or** backward step) → hold `lastTime` (never regress the sortable prefix) and increment the previous random tail, exactly as the same-ms path already did.

This is the standard ULID-spec monotonic-factory behavior. Same-millisecond monotonicity and all forward-clock behavior are unchanged; the fix only adds correct handling for a non-advancing clock. The docblock is updated to describe the guarantee accurately.

## Verification

- `bunx vitest run test/orchestrator/ulid.test.ts` — 7 pass, including two new regression tests: monotonic across a backward step, and clean resume once the clock catches back up.
- `bunx vitest run test/orchestrator` — 227 pass (no regressions in the index/store/worktree suites).
- `bun run lint` and `bun run typecheck` — both green.
- Changeset added (`patch`).

## Follow-ups deliberately deferred

- A separate review candidate — the Codex `usageMetrics` aggregate feeding session-**cumulative** `total_token_usage` alongside `context_window_tokens` — is documented-and-tested as intentional, and I could not trace a consumer that renders it as a wrong context-occupancy percentage, so I left it untouched rather than change engine-owned semantics on a guess. Worth a closer look if a context-% surface is ever added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRrLcX72G2xmzY5q8R3cZD)_