### PR TITLE
fix: the sidebar context menu dismisses on the next press anywhere

### DIFF
--- a/.changeset/context-menu-outside-dismiss.md
+++ b/.changeset/context-menu-outside-dismiss.md
@@ -1,0 +1,18 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The sidebar's right-click menu dismisses on the next press anywhere
+
+Opening a row's context menu used to leave it up until you re-clicked a row or
+pressed escape — a press in the terminal, the file tree, or the sidebar's empty
+space left it hanging over a row it no longer described. A press anywhere now
+dismisses it, which is what every other popup on the machine does.
+
+The signal is one listener on the renderer root: opentui bubbles a mouse event
+up the renderable chain, and nothing in the TUI stops the DOWN phase (the
+panes' guards all sit on `onMouseUp`), so root-level down means "the user just
+pressed somewhere else" without every pane having to report it. A backdrop box
+could not have done this — an overlay is an absolute child of the pane that
+owns it, and the menu is clipped to the sidebar rail. The menu itself stops its
+own press, so clicking an entry still fires on the mouse-up.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -121,7 +121,8 @@ everything is always visible. Search (`/`) matches titles, repos, branches,
 and live tab titles, and keeps matching rows' parents so a hit is never
 orphaned.
 
-Right-click any row for its context menu; common row actions also have direct
+Right-click any row for its context menu; `j`/`k` and `⏎` drive it, and a press
+anywhere else — or `esc` — dismisses it. Common row actions also have direct
 chords. (If right-click opens your *terminal's* menu instead, see
 [Troubleshooting](./TROUBLESHOOTING.md).)
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -22,7 +22,7 @@ Click a pane or row to focus it. `F4` moves focus forward, `ctrl+a` `h` / `l`
 moves left or right, and `ctrl+q` returns from the workspace to Tasks. From the
 Tasks pane, right arrow enters the current engine tab. Mouse clicks select rows
 and tabs; right-clicking a sidebar row opens the same common actions available
-from the keyboard.
+from the keyboard, and clicking anywhere else dismisses that menu.
 
 Zen mode (`ctrl+a` `z`) hides Files and lets the workspace use the freed width.
 The Tasks rail remains visible. Below 70 columns, the separate

--- a/packages/kobe/src/tui-react/lib/global-mouse-down.ts
+++ b/packages/kobe/src/tui-react/lib/global-mouse-down.ts
@@ -1,0 +1,55 @@
+/**
+ * "Was there a click ANYWHERE?" — one renderer-root mouse-down listener,
+ * shared by every surface that dismisses itself on an outside click.
+ *
+ * opentui bubbles a mouse event up the renderable chain until someone calls
+ * `stopPropagation`, so the root sees every press the app didn't swallow.
+ * Nothing in the TUI stops the DOWN phase (the panes' guards all sit on
+ * `onMouseUp`), which makes root-level down the one signal that means "the
+ * user just pressed somewhere else" without every pane having to report it.
+ *
+ * A surface that must NOT self-dismiss on its own press stops the down event
+ * itself (see `ui/context-menu.tsx`) — that keeps "is this press mine?" a
+ * hit-test opentui already answers, instead of geometry every subscriber
+ * would have to recompute.
+ *
+ * Framework-free on purpose: the React face is `use-global-mouse-down.ts`.
+ */
+
+/** The slice of a renderable this module touches — a structural type so the
+ *  core stays testable with a plain object (and independent of opentui's
+ *  setter-only accessor typing). */
+export interface MouseDownHost {
+  onMouseDown: ((event: unknown) => void) | undefined
+}
+
+const subscribers = new Set<(event: unknown) => void>()
+let installedHost: MouseDownHost | null = null
+
+function dispatch(event: unknown): void {
+  // Copy: a handler may unsubscribe itself (dismiss → unmount) mid-dispatch.
+  for (const handler of [...subscribers]) handler(event)
+}
+
+/**
+ * Subscribe to every mouse-down that reaches `host`. Returns the unsubscribe.
+ * The listener is installed with the first subscriber and removed with the
+ * last, so an app with nothing dismissable up pays nothing.
+ */
+export function subscribeGlobalMouseDown(host: MouseDownHost, handler: (event: unknown) => void): () => void {
+  subscribers.add(handler)
+  // Re-point on a host swap (a test harness builds a fresh renderer per test):
+  // the old root is torn down, and its listener would never fire again.
+  if (installedHost !== host) {
+    if (installedHost) installedHost.onMouseDown = undefined
+    installedHost = host
+    host.onMouseDown = dispatch
+  }
+  return () => {
+    subscribers.delete(handler)
+    if (subscribers.size === 0 && installedHost) {
+      installedHost.onMouseDown = undefined
+      installedHost = null
+    }
+  }
+}

--- a/packages/kobe/src/tui-react/lib/use-global-mouse-down.ts
+++ b/packages/kobe/src/tui-react/lib/use-global-mouse-down.ts
@@ -1,0 +1,24 @@
+/**
+ * React face of `global-mouse-down.ts`: run `handler` on every mouse press
+ * that reaches the renderer root, while `enabled`.
+ *
+ * Why the root and not a full-screen backdrop box: an overlay is an absolute
+ * child of the pane that owns it (the sidebar's menu is clipped to the rail),
+ * so a backdrop could only cover that pane — a press in the workspace would
+ * still leave the popup hanging. The root sees the whole screen.
+ */
+
+import { useRenderer } from "@opentui/react"
+import { useEffect } from "react"
+import { type MouseDownHost, subscribeGlobalMouseDown } from "./global-mouse-down"
+import { useLatest } from "./use-latest"
+
+export function useGlobalMouseDown(enabled: boolean, handler: () => void): void {
+  const renderer = useRenderer()
+  const latest = useLatest(handler)
+  useEffect(() => {
+    const root = (renderer as { root?: MouseDownHost } | null | undefined)?.root
+    if (!enabled || !root) return
+    return subscribeGlobalMouseDown(root, () => latest.current())
+  }, [enabled, renderer])
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -13,6 +13,7 @@ import { useCallback, useState } from "react"
 import type { TreeRow } from "../../../tui/panes/sidebar/tree-core"
 import { type TreeMenuAction, type TreeMenuContext, treeMenuItems } from "../../../tui/panes/sidebar/tree-menu"
 import { useT } from "../../i18n"
+import { useGlobalMouseDown } from "../../lib/use-global-mouse-down"
 import type { ContextMenuEntry } from "../../ui/context-menu"
 import type { SidebarTaskCallbacks } from "./types"
 import type { TreeState } from "./use-tree-state"
@@ -98,6 +99,13 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
   )
 
   const close = useCallback((): void => setMenu(null), [])
+
+  // A press anywhere else dismisses the menu — the click that opened it is
+  // over, so the next one belongs to whatever the user pressed, not to a
+  // popup they have to shoot down first. Presses INSIDE the menu never reach
+  // the root (`ContextMenu` stops the down phase), so picking an entry still
+  // gets its mouse-up.
+  useGlobalMouseDown(menu !== null, close)
 
   const moveCursor = useCallback(
     (delta: 1 | -1): void => {

--- a/packages/kobe/src/tui-react/ui/context-menu.tsx
+++ b/packages/kobe/src/tui-react/ui/context-menu.tsx
@@ -58,6 +58,11 @@ export function ContextMenu(props: {
       backgroundColor={theme.backgroundElement}
       paddingLeft={1}
       paddingRight={1}
+      // The menu swallows its own press so the owner's "a click landed
+      // elsewhere → dismiss" listener (`useGlobalMouseDown`) never sees it —
+      // otherwise the down phase of picking an entry would close the menu
+      // before the up phase could fire it.
+      onMouseDown={(e: { stopPropagation(): void }) => e.stopPropagation()}
     >
       {props.entries.map((entry, i) => {
         const active = i === props.cursor

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -196,3 +196,48 @@ test("a worktree's LAST tab offers no close", async () => {
   expect(after).toContain("Open tab")
   expect(after).not.toContain("Close tab")
 })
+
+/** Screen position of the first occurrence of `needle`. */
+function posOf(text: string, needle: string): { x: number; y: number } {
+  const y = lineOf(text, needle)
+  const x = (text.split("\n")[y] ?? "").indexOf(needle)
+  return { x, y }
+}
+
+test("a press anywhere else dismisses the menu", async () => {
+  // The whole point of the feature: the menu is not a mode you have to shoot
+  // down by re-clicking the row it came from.
+  tabsByTask.clear()
+  const { frame, mockMouse } = await renderComponent(tree(), { width: 40, height: 24 })
+  await settle()
+  await mockMouse.click(2, lineOf(await frame(), "feat/a"), RIGHT)
+  await settle()
+  expect(await frame()).toContain("Rename")
+
+  // Empty space below the last row — no row handler runs, so only the
+  // root-level dismiss can close it.
+  await mockMouse.click(2, 22, 0)
+  await settle()
+  expect(await frame()).not.toContain("Rename")
+})
+
+test("a press ON the menu still picks its entry", async () => {
+  // The dismiss listener must not eat the menu's own press: the pick lands on
+  // the mouse-UP, so a menu closed by the DOWN would never fire anything.
+  tabsByTask.clear()
+  const renamed: string[] = []
+  const { frame, mockMouse } = await renderComponent(tree({ onRenameRequest: (id) => renamed.push(id) }), {
+    width: 40,
+    height: 24,
+  })
+  await settle()
+  await mockMouse.click(2, lineOf(await frame(), "feat/a"), RIGHT)
+  await settle()
+
+  const entry = posOf(await frame(), "Rename")
+  await mockMouse.click(entry.x, entry.y, 0)
+  await settle()
+
+  expect(renamed).toEqual(["a"])
+  expect(await frame()).not.toContain("Delete")
+})

--- a/packages/kobe/test/tui-react/global-mouse-down.test.ts
+++ b/packages/kobe/test/tui-react/global-mouse-down.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { type MouseDownHost, subscribeGlobalMouseDown } from "../../src/tui-react/lib/global-mouse-down.ts"
+
+function fakeHost(): MouseDownHost {
+  return { onMouseDown: undefined }
+}
+
+describe("subscribeGlobalMouseDown", () => {
+  it("installs one root listener and fans it out to every subscriber", () => {
+    const host = fakeHost()
+    const seen: string[] = []
+    const offA = subscribeGlobalMouseDown(host, () => seen.push("a"))
+    const offB = subscribeGlobalMouseDown(host, () => seen.push("b"))
+
+    expect(host.onMouseDown).toBeTypeOf("function")
+    host.onMouseDown?.({})
+    expect(seen).toEqual(["a", "b"])
+
+    offA()
+    // Still one subscriber: the listener stays installed.
+    expect(host.onMouseDown).toBeTypeOf("function")
+    host.onMouseDown?.({})
+    expect(seen).toEqual(["a", "b", "b"])
+
+    offB()
+    expect(host.onMouseDown).toBeUndefined()
+  })
+
+  it("survives a handler that unsubscribes itself mid-dispatch", () => {
+    const host = fakeHost()
+    let calls = 0
+    const off = subscribeGlobalMouseDown(host, () => {
+      calls += 1
+      off()
+    })
+    host.onMouseDown?.({})
+    expect(calls).toBe(1)
+    expect(host.onMouseDown).toBeUndefined()
+  })
+
+  it("re-points at a fresh host (renderer swap) instead of firing into the dead one", () => {
+    const first = fakeHost()
+    const off1 = subscribeGlobalMouseDown(first, () => {})
+    const second = fakeHost()
+    const seen: string[] = []
+    const off2 = subscribeGlobalMouseDown(second, () => seen.push("live"))
+
+    expect(first.onMouseDown).toBeUndefined()
+    expect(second.onMouseDown).toBeTypeOf("function")
+    second.onMouseDown?.({})
+    expect(seen).toEqual(["live"])
+    off1()
+    off2()
+    expect(second.onMouseDown).toBeUndefined()
+  })
+})


### PR DESCRIPTION
A right-click menu in the Tasks sidebar used to stay up until you re-clicked a row or pressed escape, so a press in the terminal, the file tree, or the sidebar's empty space left it hanging over a row it no longer described.

One listener on the renderer root (`lib/global-mouse-down.ts` + its React face) now closes it on the next mouse-down: opentui bubbles mouse events up the renderable chain and nothing in the TUI stops the DOWN phase, so root-level down is the whole-screen "pressed elsewhere" signal a backdrop box could not give — an overlay is an absolute child of the pane that owns it, and the menu is clipped to the sidebar rail. `ContextMenu` stops its own press, so picking an entry still fires on the mouse-up, and the dismiss lives in `use-tree-menu.ts` (the menu's state owner) so `SidebarTree.tsx` stays under the file-size cap.

Verified with real mouse events, not reasoning: two new cases in `test/render/sidebar-tree-menu.test.tsx` ("a press anywhere else dismisses", "a press ON the menu still picks"), each confirmed to fail precisely when its half of the fix is removed, plus three unit cases for the subscription core; `bun test test/render` is 176/176, lint and typecheck clean, and `test:fast`'s 46 failures are identical on unmodified `main`.

Docs (`KEYBINDINGS.md`, `TUI.md`) and a patch changeset are included.