### PR TITLE
feat: install Rove with npm, npx, or one curl line

### DIFF
--- a/.changeset/npm-npx-install-path.md
+++ b/.changeset/npm-npx-install-path.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+**Install Rove with npm, npx, or one curl line — Bun no longer has to be there first.** The published `rove` and `kobe` bins are now small node launchers: started by Bun they run the CLI in-process as before, started by node (which is what `npm install -g` and `npx` do) they find a Bun runtime and re-exec through it. When there is no Bun at all, the first launch offers to install it instead of dying with `env: bun: No such file or directory`. Bun is discovered on `PATH`, in `$BUN_INSTALL/bin`, in `~/.bun/bin`, and in a `bun` package installed beside Rove; `ROVE_BUN=/path/to/bun` points at one anywhere else, and `ROVE_NO_BUN_BOOTSTRAP=1` turns the offer back into a plain error for CI and images.
+
+New one-step installer for a machine with nothing on it: `curl -fsSL https://rove.sma1lboy.me/install.sh | sh` installs Bun when it is missing, then Rove, and tells you exactly what to add to `PATH` if the bin directory is not there yet.

--- a/README.md
+++ b/README.md
@@ -32,21 +32,28 @@ The sidebar tracks tasks and their sessions, the workspace embeds the active age
 
 ## Quick start
 
-Requires [Bun](https://bun.sh) ≥ 1.3.11, git, and at least one supported agent CLI on `PATH`. Rove runs on macOS, Linux, and Windows; Windows also requires Node.js and Git for Windows/Git Bash.
-
-Try it without installing:
+One line, on a machine with nothing installed — it sets up the Bun runtime Rove needs, then Rove itself:
 
 ```bash
-bunx @sma1lboy/rove
+curl -fsSL https://rove.sma1lboy.me/install.sh | sh
 ```
 
-Or install it globally, then launch it in a repository:
+Or use the package manager you already have:
 
 ```bash
-bun install -g @sma1lboy/rove
+npm install -g @sma1lboy/rove   # offers to install Bun on first launch
+bun install -g @sma1lboy/rove   # if you already run Bun
+npx @sma1lboy/rove              # try it without installing
+```
+
+Then launch it in a repository:
+
+```bash
 cd your-repo
 rove
 ```
+
+Rove needs git and at least one supported agent CLI on `PATH`, and runs on macOS, Linux, and Windows; Windows also requires Node.js and Git for Windows/Git Bash. The CLI itself runs on [Bun](https://bun.sh) ≥ 1.3.11 — every install route above brings it along, and `ROVE_BUN=/path/to/bun` points Rove at a Bun installed somewhere unusual.
 
 Press `n`, choose a repository, base branch, and agent, then enter a prompt. Press `F1` for the live keybinding reference; `ctrl+q` returns to the sidebar and quits from there without stopping sessions.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,12 +9,21 @@ surface.
 
 ## Install and update
 
-Needs Bun ≥ 1.3.11, git, and at least one engine CLI on `PATH`.
+Needs git and at least one engine CLI on `PATH`. The CLI runs on the Bun
+runtime (≥ 1.3.11); each route below installs Bun for you when it is missing.
 
 ```bash
-bun install -g @sma1lboy/rove   # install
-bunx @sma1lboy/rove             # try without installing
+curl -fsSL https://rove.sma1lboy.me/install.sh | sh   # installs Bun, then Rove
+npm install -g @sma1lboy/rove                         # npm (asks about Bun on first run)
+bun install -g @sma1lboy/rove                         # bun
+npx @sma1lboy/rove                                    # try without installing
 ```
+
+The `rove` and `kobe` bins are small launchers: they run the CLI directly when
+started by Bun, and find (or offer to install) a Bun when started by node —
+which is what `npm install -g` and `npx` do. Two environment variables steer
+that: `ROVE_BUN` names the Bun binary to use, `ROVE_NO_BUN_BOOTSTRAP=1` turns a
+missing Bun into a plain error instead of an install offer.
 
 The installed package exposes both `rove` and `kobe`. `rove` is the canonical
 entry point; `kobe` remains a fully supported compatibility alias. They run the

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -4,8 +4,10 @@ rove runs many AI coding sessions side by side in your terminal. Each managed
 Task gets its own git worktree and branch, so parallel Tasks never step on
 each other. Extra tabs inside one Task share that Task's directory.
 
-You need [Bun](https://bun.sh) ≥ 1.3.11, git, and at least one engine CLI
-(`claude`, `codex`, `copilot`, or `kimi`) on your `PATH`.
+You need git and at least one engine CLI (`claude`, `codex`, `copilot`, or
+`kimi`) on your `PATH`. The Rove CLI itself runs on the [Bun](https://bun.sh)
+runtime (≥ 1.3.11) — you do not have to install Bun yourself, every route
+below brings it along.
 
 **Windows also requires [Node.js](https://nodejs.org) and Git for Windows.**
 Rove uses Node.js for its Windows PTY host and Git Bash as the POSIX shell
@@ -14,12 +16,33 @@ the new executables are on `PATH`.
 
 ## Install
 
-```bash
-bun install -g @sma1lboy/rove
+One line on a fresh machine — installs Bun if it is missing, then Rove:
 
-# or try it without installing
-bunx @sma1lboy/rove
+```bash
+curl -fsSL https://rove.sma1lboy.me/install.sh | sh
+
+# pin a version
+curl -fsSL https://rove.sma1lboy.me/install.sh | sh -s -- 0.8.136
 ```
+
+Or use a package manager you already have:
+
+```bash
+npm install -g @sma1lboy/rove   # npm — the first launch offers to install Bun
+bun install -g @sma1lboy/rove   # bun
+npx @sma1lboy/rove              # try it without installing
+```
+
+On Windows, use the npm route (the shell script needs a POSIX shell):
+
+```powershell
+npm install -g @sma1lboy/rove
+```
+
+Rove looks for Bun on `PATH`, in `$BUN_INSTALL/bin`, and in `~/.bun/bin`. If
+yours lives somewhere else, point Rove at it with `ROVE_BUN=/path/to/bun`. To
+never be asked about installing Bun (CI, images, locked-down machines), set
+`ROVE_NO_BUN_BOOTSTRAP=1` — Rove then prints the install commands and exits.
 
 ## First launch
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -3,6 +3,29 @@
 User-facing symptom → cause → fix, for the questions that keep coming back.
 One section per symptom; keep entries short and command-exact.
 
+## `rove` exits with "no Bun was found" (or `env: bun: No such file or directory`)
+
+The Rove CLI runs on the [Bun](https://bun.sh) runtime. The published `rove` and
+`kobe` bins are node launchers that re-exec through Bun, so an `npm install -g`
+or `npx` on a machine without Bun still works — the first launch offers to
+install Bun for you. You land on this error when that offer could not be made
+(no TTY, `CI=true`, or `ROVE_NO_BUN_BOOTSTRAP=1`) or was declined.
+
+Fix it with any of:
+
+```bash
+curl -fsSL https://bun.sh/install | bash        # macOS / Linux / WSL
+powershell -c "irm bun.sh/install.ps1 | iex"    # Windows
+npm install -g bun                              # any platform
+```
+
+Bun is discovered on `PATH`, in `$BUN_INSTALL/bin`, in `~/.bun/bin`, and in a
+`bun` npm package installed beside Rove. A Bun anywhere else needs
+`ROVE_BUN=/path/to/bun` — export it from your shell profile so daemon restarts
+see it too. The bare `env: bun: No such file or directory` message comes from an install
+made before the launcher shipped, whose bin needed Bun on `PATH` — `rove update`
+replaces it.
+
 ## Windows opens Rove, but engine and terminal tabs never start
 
 Windows needs three separate runtimes:

--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -197,12 +197,12 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(44px
     <div class="hero-row rise" style="animation-delay:.48s">
       <button id="copyBtn" class="copy-cmd">
         <span class="ps">$</span>
-        <span>bun install -g @sma1lboy/rove</span>
+        <span>npm i -g @sma1lboy/rove</span>
         <span id="copyLabel" class="hint">click to copy</span>
       </button>
       <a class="btn-primary" href="https://github.com/Sma1lboy/rove#readme" data-i18n="hero.getStarted">Get started ↗</a>
     </div>
-    <p class="hero-req rise" style="animation-delay:.58s" data-i18n="hero.requirements">Runs on macOS &amp; Linux (Windows via WSL). Requires Bun ≥ 1.3.11 and one engine CLI on your PATH.</p>
+    <p class="hero-req rise" style="animation-delay:.58s" data-i18n="hero.requirements">Runs on macOS &amp; Linux (Windows via WSL). npm, bun, npx, or one curl line — Rove brings its own Bun runtime. Needs git and one engine CLI on your PATH.</p>
   </div>
 
   <div class="quicklook rise" style="animation-delay:.7s">
@@ -310,7 +310,7 @@ c  <span class="ok">+96</span>  <span class="del">−88</span>  · 5 files
     <h2 data-i18n="install.title">Spin it up where your code lives.</h2>
     <p data-i18n="install.body">Your laptop, a devbox, a VPS, or any machine you can SSH into. No browser, no VNC, no desktop app. Optimize the one metric that matters: merged code per hour of your attention.</p>
     <figure class="term-frame install-term"><div class="tbar" aria-hidden="true"><i class="r"></i><i class="y"></i><i class="g"></i><span>install</span></div>
-    <pre class="term-out"><span class="ps">$</span> bun install -g @sma1lboy/rove
+    <pre class="term-out"><span class="ps">$</span> curl -fsSL https://rove.sma1lboy.me/install.sh | sh
 <span class="ps">$</span> ssh devbox && cd repo
 <span class="ps">$</span> rove
 <span class="d">3 attempts running. Go do something else.</span></pre></figure>

--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -79,12 +79,19 @@ button{font-family:inherit;cursor:pointer}
 .hero-kicker .acc{font-style:normal;font-weight:700}
 h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(44px,6.6vw,88px);font-weight:380;letter-spacing:-.028em;line-height:1.0;color:var(--ink);max-width:16ch;margin:26px 0 22px;text-shadow:0 1px 30px oklch(95% 0.02 210/.8)}
 .hero-sub{font-size:clamp(15px,1.5vw,17.5px);max-width:56ch;color:var(--ink-soft);text-shadow:0 1px 18px oklch(95% 0.02 210/.9)}
-.hero-row{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;align-items:center;margin-top:36px}
+.hero-row{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;align-items:center;margin-top:36px;max-width:100%}
 .copy-cmd{display:inline-flex;align-items:center;gap:12px;font-family:var(--font-mono);font-size:13.5px;color:var(--ink);background:oklch(100% 0 0/.55);border:1px solid oklch(100% 0 0/.85);backdrop-filter:blur(14px);border-radius:999px;padding:13px 20px;box-shadow:0 14px 40px oklch(40% 0.04 60/.18);transition:transform 140ms var(--ease-out),box-shadow 200ms}
 .copy-cmd:hover{transform:translateY(-2px);box-shadow:0 20px 50px oklch(40% 0.04 60/.24)}
 .copy-cmd:active{transform:scale(.98)}
 .copy-cmd .ps{color:var(--accent);font-weight:700}
-.copy-cmd .hint{font-size:11px;color:var(--faint);border-left:1px solid var(--line-2);padding-left:12px}
+.copy-cmd .hint{font-size:11px;color:var(--faint);border-left:1px solid var(--line-2);padding-left:12px;white-space:nowrap}
+/* A flex item defaults to min-width:auto, so without these the pill keeps its
+   intrinsic width and the hero clips the command instead of ellipsing it. */
+.copy-cmd{max-width:100%;min-width:0}
+.copy-cmd .cmd{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}
+/* Phone: drop the copy hint and the URL scheme so the whole command still
+   reads. The clipboard payload keeps https:// (index.js owns that string). */
+@media(max-width:720px){.copy-cmd{font-size:12px;padding:12px 16px;gap:8px}.copy-cmd .hint{display:none}.copy-cmd .scheme{display:none}}
 .btn-primary{display:inline-flex;align-items:center;gap:8px;border-radius:999px;font-size:14.5px;font-weight:520;padding:14px 26px;background:var(--ink);color:oklch(97% 0.008 85);transition:transform 140ms var(--ease-out),box-shadow 200ms}
 .btn-primary:hover{transform:translateY(-2px);box-shadow:0 12px 32px oklch(25% 0.02 60/.3)}
 .btn-quiet{display:inline-flex;align-items:center;gap:8px;border-radius:999px;font-size:14.5px;font-weight:480;padding:14px 26px;background:transparent;color:var(--ink);border:1px solid var(--line-2);transition:transform 140ms,background 140ms,border-color 140ms}
@@ -197,7 +204,7 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(44px
     <div class="hero-row rise" style="animation-delay:.48s">
       <button id="copyBtn" class="copy-cmd">
         <span class="ps">$</span>
-        <span>npm i -g @sma1lboy/rove</span>
+        <span class="cmd">curl -fsSL <span class="scheme">https://</span>rove.sma1lboy.me/install.sh | sh</span>
         <span id="copyLabel" class="hint">click to copy</span>
       </button>
       <a class="btn-primary" href="https://github.com/Sma1lboy/rove#readme" data-i18n="hero.getStarted">Get started ↗</a>

--- a/packages/kobe-landing/index.js
+++ b/packages/kobe-landing/index.js
@@ -9,7 +9,7 @@ var KOBE_I18N = (function () {
     'hero.title': '装在你 shell 里的 agent <span class="acc">多路复用器</span>。',
     'hero.sub': '一个代理是一场对话，五个同时跑就是一张图：节点是隔离的尝试——git worktree + 引擎会话 + 分支——边是依赖，门是你的判断。Rove 是这张图的终端原生运行时。',
     'hero.getStarted': '快速上手 ↗',
-    'hero.requirements': '支持 macOS 和 Linux（Windows 走 WSL）。需要 Bun ≥ 1.3.11，以及 PATH 上任意一个引擎 CLI。',
+    'hero.requirements': '支持 macOS 和 Linux（Windows 走 WSL）。npm、bun、npx 或一行 curl 都能装 —— Bun 运行时由 Rove 自己带上。只需 git 和 PATH 上任意一个引擎 CLI。',
     'copy.hint': '点击复制', 'copy.done': '✓ 已复制',
     'workspace.equation': '一个节点 =', 'workspace.sessions': '托管引擎会话',
     's1.no': '1.0 · 扇出', 's1.title': '一条 prompt 变成 N 个隔离的尝试。',
@@ -38,7 +38,7 @@ var KOBE_I18N = (function () {
     'hero.title': 'The agent <span class="acc">multiplexer</span> in your shell.',
     'hero.sub': 'One agent is a conversation. Five at once are a graph: nodes are isolated attempts — git worktree + engine session + branch — edges are dependencies, and the gates are your judgment. Rove is the terminal-native runtime for that graph.',
     'hero.getStarted': 'Get started ↗',
-    'hero.requirements': 'Runs on macOS & Linux (Windows via WSL). Requires Bun ≥ 1.3.11 and one engine CLI on your PATH.',
+    'hero.requirements': 'Runs on macOS & Linux (Windows via WSL). npm, bun, npx, or one curl line — Rove brings its own Bun runtime. Needs git and one engine CLI on your PATH.',
     'copy.hint': 'click to copy', 'copy.done': '✓ copied',
     'workspace.equation': 'one node =', 'workspace.sessions': 'hosted engine session',
     's1.no': '1.0 · FAN OUT', 's1.title': 'One prompt becomes N isolated attempts.',
@@ -109,7 +109,7 @@ var KOBE_I18N = (function () {
   var timer;
   btn.addEventListener('click', function () {
     try {
-      if (navigator.clipboard) navigator.clipboard.writeText('bun install -g @sma1lboy/rove');
+      if (navigator.clipboard) navigator.clipboard.writeText('npm i -g @sma1lboy/rove');
     } catch (e) {}
     label.textContent = KOBE_I18N.t('copy.done');
     clearTimeout(timer);

--- a/packages/kobe-landing/index.js
+++ b/packages/kobe-landing/index.js
@@ -109,7 +109,7 @@ var KOBE_I18N = (function () {
   var timer;
   btn.addEventListener('click', function () {
     try {
-      if (navigator.clipboard) navigator.clipboard.writeText('npm i -g @sma1lboy/rove');
+      if (navigator.clipboard) navigator.clipboard.writeText('curl -fsSL https://rove.sma1lboy.me/install.sh | sh');
     } catch (e) {}
     label.textContent = KOBE_I18N.t('copy.done');
     clearTimeout(timer);

--- a/packages/kobe-landing/vercel.json
+++ b/packages/kobe-landing/vercel.json
@@ -4,6 +4,12 @@
   "outputDirectory": ".",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
   "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/install.sh",
+      "destination": "https://raw.githubusercontent.com/Sma1lboy/rove/main/scripts/install.sh"
+    }
+  ],
   "redirects": [
     {
       "source": "/docs",

--- a/packages/kobe/README.md
+++ b/packages/kobe/README.md
@@ -2,11 +2,25 @@
 
 The published Rove CLI and PureTUI package.
 
+Install it any of these ways:
+
 ```bash
-bun install -g @sma1lboy/rove
+curl -fsSL https://rove.sma1lboy.me/install.sh | sh   # installs Bun if needed, then Rove
+npm install -g @sma1lboy/rove                         # npm
+bun install -g @sma1lboy/rove                         # bun
+npx @sma1lboy/rove                                    # no install
+```
+
+Then:
+
+```bash
 rove add /path/to/repo
 rove
 ```
+
+The CLI runs on the Bun runtime. The published `rove` / `kobe` bins are node
+launchers that re-exec through Bun, so an `npm install -g` or `npx` on a
+machine without Bun still ends up with a working Rove.
 
 The package also keeps `kobe` as a compatibility alias. Both executable names
 copy supported legacy state into `~/.rove` and `~/.config/rove` without deleting

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -7,7 +7,10 @@
  * default transpiler honours — no build plugin required.
  *
  * Output: `dist/cli/kobe.js` and `dist/cli/rove.js` with executable perms,
- * plus their shared `index.js` implementation. After
+ * plus their shared `index.js` implementation. Those two bins are the NODE
+ * launcher (src/cli/launcher.ts) — installers disagree about which runtime
+ * starts a bin file, and only node is guaranteed under `npm i -g` / `npx` —
+ * so the Bun bundles they front ship beside them as `<name>-run.js`. After
  * the kobed → kobe bin merge (KOB-136), daemon lifecycle lives at
  * `kobe daemon ...`, so there is no separate `kobed` binary to build.
  *
@@ -28,7 +31,9 @@
 import { existsSync } from "node:fs"
 import { chmod, cp, mkdir, rm } from "node:fs/promises"
 
-const OUT_FILES = ["./dist/cli/kobe.js", "./dist/cli/rove.js"]
+/** Both published bin names; each gets a launcher + the Bun bundle behind it. */
+const CLI_NAMES = ["kobe", "rove"] as const
+const OUT_FILES = CLI_NAMES.flatMap((name) => [`./dist/cli/${name}.js`, `./dist/cli/${name}-run.js`])
 /** Canonical skill source (repo root) → its home in the tarball. */
 const SKILL_SRC_DIR = "../../.agents/skills/kobe"
 const SKILL_OUT_DIR = "./dist/skills/rove"
@@ -128,6 +133,36 @@ if (!ptyHostNode.success) {
   for (const log of ptyHostNode.logs) console.error(log)
   process.exit(1)
 }
+
+/** Write a program file with an explicit shebang, replacing any bundled one. */
+async function writeExecutable(file: string, shebang: string, code: string): Promise<void> {
+  const body = code.startsWith("#!") ? code.slice(code.indexOf("\n") + 1) : code
+  await Bun.write(file, `${shebang}\n${body}`)
+}
+
+// Move the Bun bundles aside so the bin names can carry the node launcher.
+for (const name of CLI_NAMES) {
+  const bundle = await Bun.file(`./dist/cli/${name}.js`).text()
+  await writeExecutable(`./dist/cli/${name}-run.js`, "#!/usr/bin/env bun", bundle)
+}
+
+// The launcher itself, as a NODE program: it runs before any Bun exists, so
+// it can only use plain node APIs (see src/cli/bun-runtime.ts).
+const launcher = await Bun.build({
+  entrypoints: ["./src/cli/launcher.ts"],
+  target: "node",
+  format: "esm",
+  minify: true,
+})
+
+if (!launcher.success) {
+  console.error("launcher build failed:")
+  for (const log of launcher.logs) console.error(log)
+  process.exit(1)
+}
+
+const launcherCode = await launcher.outputs[0].text()
+for (const name of CLI_NAMES) await writeExecutable(`./dist/cli/${name}.js`, "#!/usr/bin/env node", launcherCode)
 
 for (const file of OUT_FILES) await chmod(file, 0o755)
 await copyWebUi()

--- a/packages/kobe/src/cli/bun-runtime.ts
+++ b/packages/kobe/src/cli/bun-runtime.ts
@@ -1,0 +1,163 @@
+/**
+ * Bun discovery + relaunch for the published `rove` / `kobe` bins.
+ *
+ * Rove's CLI bundle is a Bun program, but the bin file is started by whatever
+ * runtime the installer chose: `bun install -g` symlinks it (Bun runs it),
+ * while `npm install -g` and `npx` hand it to node. So the bin ships as a
+ * small node launcher that finds a Bun runtime and re-execs the real entry
+ * through it — which is also how a machine with npm but no Bun still gets a
+ * working `rove` (the launcher offers to install Bun once).
+ *
+ * Everything in this file must run under plain node: no Bun globals, no
+ * imports that pull the Bun bundle in.
+ */
+
+import { type SpawnSyncReturns, spawnSync } from "node:child_process"
+import { constants, accessSync } from "node:fs"
+import { homedir } from "node:os"
+import { basename, delimiter, dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+/** Point Rove at a specific Bun binary (skips every other candidate). */
+export const BUN_OVERRIDE_ENV = "ROVE_BUN"
+/** Set to `1` to make a missing Bun a hard error instead of an install offer. */
+export const NO_BOOTSTRAP_ENV = "ROVE_NO_BUN_BOOTSTRAP"
+
+export interface BunLookup {
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+  home?: string
+  /** Directory of the launcher, used to find a Bun installed beside the package. */
+  launcherDir?: string
+  isExecutable?: (path: string) => boolean
+}
+
+const defaultIsExecutable = (path: string): boolean => {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const bunFileName = (platform: NodeJS.Platform): string => (platform === "win32" ? "bun.exe" : "bun")
+
+/**
+ * Every place a Bun runtime plausibly lives, in precedence order: explicit
+ * override, PATH, Bun's own install prefix, the default `~/.bun`, then the
+ * `bun` npm package if someone installed it next to Rove.
+ */
+export function bunCandidates(lookup: BunLookup = {}): string[] {
+  const env = lookup.env ?? process.env
+  const platform = lookup.platform ?? process.platform
+  const home = lookup.home ?? env.HOME ?? env.USERPROFILE ?? homedir()
+  const binary = bunFileName(platform)
+  const candidates: string[] = []
+
+  const override = env[BUN_OVERRIDE_ENV]?.trim()
+  if (override) candidates.push(override)
+
+  for (const dir of (env.PATH ?? env.Path ?? "").split(delimiter)) {
+    if (dir) candidates.push(join(dir, binary))
+  }
+
+  const bunInstall = env.BUN_INSTALL?.trim()
+  if (bunInstall) candidates.push(join(bunInstall, "bin", binary))
+  if (home) candidates.push(join(home, ".bun", "bin", binary))
+
+  // `npm install bun` (or a `bun` dependency hoisted next to the package)
+  // lands here; the binary is never on PATH, so probe it explicitly.
+  const launcherDir = lookup.launcherDir
+  if (launcherDir) {
+    candidates.push(join(launcherDir, "..", "..", "node_modules", "bun", "bin", binary))
+    candidates.push(join(launcherDir, "..", "..", "..", "bun", "bin", binary))
+  }
+  return candidates
+}
+
+/** First candidate that exists and is executable, or `null` when Bun is absent. */
+export function resolveBunBinary(lookup: BunLookup = {}): string | null {
+  const isExecutable = lookup.isExecutable ?? defaultIsExecutable
+  return bunCandidates(lookup).find((candidate) => isExecutable(candidate)) ?? null
+}
+
+/** Directory of the running launcher — the anchor for sibling-file lookups. */
+export function launcherDirOf(moduleUrl: string): string {
+  return dirname(fileURLToPath(moduleUrl))
+}
+
+/** CLI name a launcher was invoked as: `.../dist/cli/rove.js` -> `rove`. */
+export function launcherNameOf(moduleUrl: string): string {
+  return basename(fileURLToPath(moduleUrl)).replace(/\.[cm]?[jt]s$/, "")
+}
+
+/** The official Bun installer for this platform, as an argv. */
+export function bunInstallerCommand(platform: NodeJS.Platform = process.platform): string[] {
+  return platform === "win32"
+    ? ["powershell", "-NoProfile", "-Command", "irm bun.sh/install.ps1 | iex"]
+    : ["bash", "-c", "curl -fsSL https://bun.sh/install | bash"]
+}
+
+/** Copy-pasteable install lines, shown when Rove cannot start Bun itself. */
+export function missingBunMessage(cliName = "rove", platform: NodeJS.Platform = process.platform): string {
+  const primary =
+    platform === "win32" ? 'powershell -c "irm bun.sh/install.ps1 | iex"' : "curl -fsSL https://bun.sh/install | bash"
+  return [
+    `${cliName}: Rove runs on the Bun runtime, and no Bun was found on this machine.`,
+    "",
+    "Install Bun, then run this command again:",
+    `  ${primary}`,
+    "  npm install -g bun          # any platform, if you already have npm",
+    "",
+    "Or install Bun and Rove together in one step:",
+    "  curl -fsSL https://rove.sma1lboy.me/install.sh | sh",
+    "",
+    `Already have Bun somewhere unusual? Point Rove at it: ${BUN_OVERRIDE_ENV}=/path/to/bun`,
+    "",
+  ].join("\n")
+}
+
+/** Whether the launcher may offer to install Bun (needs consent, so needs a TTY). */
+export function canOfferBunInstall(
+  env: NodeJS.ProcessEnv = process.env,
+  input: { isTTY?: boolean } = process.stdin,
+  output: { isTTY?: boolean } = process.stdout,
+): boolean {
+  if (env[NO_BOOTSTRAP_ENV] === "1") return false
+  if (env.CI === "true" || env.CI === "1") return false
+  return Boolean(input.isTTY && output.isTTY)
+}
+
+type Spawn = (command: string, args: readonly string[], options: object) => SpawnSyncReturns<Buffer>
+
+/** Run the official Bun installer; returns the Bun path it produced, if any. */
+export function installBun(lookup: BunLookup = {}, spawn: Spawn = spawnSync): string | null {
+  const platform = lookup.platform ?? process.platform
+  const [command, ...args] = bunInstallerCommand(platform)
+  if (!command) return null
+  const result = spawn(command, args, { stdio: "inherit" })
+  if (result.error || result.status !== 0) return null
+  // The installer edits shell rc files, not this process's PATH, so re-probe
+  // the well-known prefixes rather than trusting PATH to have grown.
+  return resolveBunBinary(lookup)
+}
+
+/** Exit code for a re-exec'd child, mapping a fatal signal the way a shell does. */
+export function exitCodeOf(result: Pick<SpawnSyncReturns<Buffer>, "status" | "signal">): number {
+  if (typeof result.status === "number") return result.status
+  if (result.signal) return 128 + (Object.hasOwn(SIGNAL_NUMBERS, result.signal) ? SIGNAL_NUMBERS[result.signal] : 0)
+  return 1
+}
+
+const SIGNAL_NUMBERS: Record<string, number> = { SIGINT: 2, SIGQUIT: 3, SIGKILL: 9, SIGTERM: 15 }
+
+/** Re-exec the real Bun entry, inheriting stdio so the TUI owns the terminal. */
+export function relaunchWithBun(bun: string, entry: string, argv: readonly string[], spawn: Spawn = spawnSync): number {
+  const result = spawn(bun, [entry, ...argv], { stdio: "inherit" })
+  if (result.error) {
+    process.stderr.write(`rove: could not start Bun at ${bun}: ${result.error.message}\n`)
+    return 1
+  }
+  return exitCodeOf(result)
+}

--- a/packages/kobe/src/cli/bun-runtime.ts
+++ b/packages/kobe/src/cli/bun-runtime.ts
@@ -10,6 +10,12 @@
  *
  * Everything in this file must run under plain node: no Bun globals, no
  * imports that pull the Bun bundle in.
+ *
+ * Deliberately NOT solved by declaring `bun` an optionalDependency (owner,
+ * reaffirmed 2026-08-19): that downloads a ~90MB platform binary on EVERY
+ * install, including `bun install -g`, where a Bun is already present. The
+ * install offer below costs nothing and covers the same gap; the npm-package
+ * path stays a lookup candidate for anyone who installs `bun` themselves.
  */
 
 import { type SpawnSyncReturns, spawnSync } from "node:child_process"

--- a/packages/kobe/src/cli/launcher.ts
+++ b/packages/kobe/src/cli/launcher.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * The `rove` / `kobe` bin, as published.
+ *
+ * Installers disagree about which runtime starts a bin file: `bun install -g`
+ * symlinks it (Bun runs it), `npm install -g` and `npx` hand it to node. This
+ * launcher works under both — under Bun it just imports the real entry, under
+ * node it finds a Bun runtime and re-execs through it, and when there is no
+ * Bun at all it offers to install one instead of dying with
+ * `env: bun: No such file or directory`.
+ *
+ * Built with `target: "node"` and copied to `dist/cli/rove.js` and
+ * `dist/cli/kobe.js`; the Bun bundles it fronts are `<name>-run.js` beside it
+ * (see scripts/build.ts). It must never import Bun-only code at load time.
+ */
+
+import { join } from "node:path"
+import { createInterface } from "node:readline/promises"
+import { pathToFileURL } from "node:url"
+import {
+  canOfferBunInstall,
+  installBun,
+  launcherDirOf,
+  launcherNameOf,
+  missingBunMessage,
+  relaunchWithBun,
+  resolveBunBinary,
+} from "./bun-runtime.ts"
+
+const launcherDir = launcherDirOf(import.meta.url)
+const cliName = launcherNameOf(import.meta.url)
+const entry = join(launcherDir, `${cliName}-run.js`)
+
+async function confirm(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const answer = (await rl.question(question)).trim().toLowerCase()
+    return answer === "" || answer === "y" || answer === "yes"
+  } finally {
+    rl.close()
+  }
+}
+
+async function bunForRelaunch(): Promise<string | null> {
+  const lookup = { launcherDir }
+  const found = resolveBunBinary(lookup)
+  if (found) return found
+  if (!canOfferBunInstall()) return null
+  const prompt = `${cliName}: Rove runs on the Bun runtime, and none is installed. Install Bun now? [Y/n] `
+  if (!(await confirm(prompt))) return null
+  return installBun(lookup)
+}
+
+if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") {
+  // Already under Bun (`bun install -g`, `bunx`, the daemon re-spawning the
+  // CLI with process.execPath): load the real entry in-process, no relaunch.
+  await import(pathToFileURL(entry).href)
+} else {
+  const bun = await bunForRelaunch()
+  if (!bun) {
+    process.stderr.write(missingBunMessage(cliName))
+    process.exit(1)
+  }
+  process.exit(relaunchWithBun(bun, entry, process.argv.slice(2)))
+}

--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -37,6 +37,22 @@ describe("Rove package distribution", () => {
     expect(pkg.bin).toEqual({ kobe: "dist/cli/kobe.js", rove: "dist/cli/rove.js" })
   })
 
+  test("the bins are node launchers fronting the Bun bundles, so npm/npx installs run", () => {
+    const build = read("packages/kobe/scripts/build.ts")
+    const launcher = read("packages/kobe/src/cli/launcher.ts")
+
+    // `npm install -g` and `npx` start a bin with node, `bun install -g`
+    // symlinks it and starts it with Bun. The bin file has one shebang, so
+    // it is the node launcher, and the Bun bundle moves to `<name>-run.js`.
+    expect(launcher.startsWith("#!/usr/bin/env node")).toBe(true)
+    expect(build).toContain('const CLI_NAMES = ["kobe", "rove"] as const')
+    expect(build).toContain('writeExecutable(`./dist/cli/${name}-run.js`, "#!/usr/bin/env bun", bundle)')
+    expect(build).toContain('writeExecutable(`./dist/cli/${name}.js`, "#!/usr/bin/env node", launcherCode)')
+    expect(build).toContain('entrypoints: ["./src/cli/launcher.ts"]')
+    // The launcher runs before any Bun exists: no Bun-only import may reach it.
+    expect(launcher).not.toMatch(/from "\.\/(?!bun-runtime)/)
+  })
+
   test("acceptance tooling defaults to the built Rove artifacts while retaining explicit alias coverage", () => {
     const harness = read("packages/kobe/test/behavior/harness.ts")
     const visualFixture = read("packages/kobe-web/e2e/visual-fixture.ts")

--- a/packages/kobe/test/cli/bun-runtime.test.ts
+++ b/packages/kobe/test/cli/bun-runtime.test.ts
@@ -1,0 +1,159 @@
+/**
+ * The published bins start under whichever runtime the installer chose
+ * (Bun for `bun install -g`, node for `npm i -g` / `npx`), so the launcher's
+ * Bun discovery is what keeps a Bun-less machine from getting
+ * `env: bun: No such file or directory`. Pure functions here; the launcher
+ * itself is a 60-line shell around them.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  BUN_OVERRIDE_ENV,
+  bunCandidates,
+  bunInstallerCommand,
+  canOfferBunInstall,
+  exitCodeOf,
+  installBun,
+  launcherDirOf,
+  launcherNameOf,
+  missingBunMessage,
+  relaunchWithBun,
+  resolveBunBinary,
+} from "../../src/cli/bun-runtime.ts"
+
+const posix = { platform: "linux" as const, home: "/home/dev", env: { PATH: "/usr/bin:/opt/bin" } }
+
+describe("bunCandidates", () => {
+  it("puts an explicit override ahead of everything else", () => {
+    const candidates = bunCandidates({ ...posix, env: { ...posix.env, [BUN_OVERRIDE_ENV]: "/custom/bun" } })
+
+    expect(candidates[0]).toBe("/custom/bun")
+    expect(candidates).toContain("/usr/bin/bun")
+  })
+
+  it("scans PATH, then BUN_INSTALL, then the default ~/.bun prefix", () => {
+    const candidates = bunCandidates({ ...posix, env: { ...posix.env, BUN_INSTALL: "/opt/bun-install" } })
+
+    expect(candidates).toEqual(["/usr/bin/bun", "/opt/bin/bun", "/opt/bun-install/bin/bun", "/home/dev/.bun/bin/bun"])
+  })
+
+  it("probes a `bun` npm package beside the install, which is never on PATH", () => {
+    const candidates = bunCandidates({ ...posix, launcherDir: "/lib/node_modules/@sma1lboy/rove/dist/cli" })
+
+    expect(candidates).toContain("/lib/node_modules/@sma1lboy/rove/node_modules/bun/bin/bun")
+    expect(candidates).toContain("/lib/node_modules/@sma1lboy/bun/bin/bun")
+  })
+
+  it("looks for bun.exe on Windows and accepts USERPROFILE as the home", () => {
+    const candidates = bunCandidates({ platform: "win32", env: { Path: "C:\\tools", USERPROFILE: "C:\\Users\\dev" } })
+
+    expect(candidates.every((candidate) => candidate.endsWith("bun.exe"))).toBe(true)
+  })
+})
+
+describe("resolveBunBinary", () => {
+  it("returns the first executable candidate", () => {
+    const found = resolveBunBinary({ ...posix, isExecutable: (path) => path === "/opt/bin/bun" })
+
+    expect(found).toBe("/opt/bin/bun")
+  })
+
+  it("returns null when no candidate exists", () => {
+    expect(resolveBunBinary({ ...posix, isExecutable: () => false })).toBeNull()
+  })
+})
+
+describe("launcher identity", () => {
+  it("derives the invoked CLI name from the launcher file", () => {
+    expect(launcherNameOf("file:///lib/rove/dist/cli/rove.js")).toBe("rove")
+    expect(launcherNameOf("file:///lib/rove/dist/cli/kobe.mjs")).toBe("kobe")
+    expect(launcherDirOf("file:///lib/rove/dist/cli/rove.js")).toBe("/lib/rove/dist/cli")
+  })
+})
+
+describe("install guidance", () => {
+  it("offers the platform's own installer", () => {
+    expect(bunInstallerCommand("darwin").join(" ")).toContain("https://bun.sh/install")
+    expect(bunInstallerCommand("win32")[0]).toBe("powershell")
+  })
+
+  it("names every install route a user without Bun can take", () => {
+    const message = missingBunMessage("rove", "linux")
+
+    expect(message).toContain("curl -fsSL https://bun.sh/install | bash")
+    expect(message).toContain("npm install -g bun")
+    expect(message).toContain("install.sh")
+    expect(message).toContain(BUN_OVERRIDE_ENV)
+  })
+
+  it("shows the PowerShell installer first on Windows", () => {
+    expect(missingBunMessage("rove", "win32")).toContain("irm bun.sh/install.ps1")
+  })
+})
+
+describe("canOfferBunInstall", () => {
+  const tty = { isTTY: true }
+
+  it("asks only when a human is there to answer", () => {
+    expect(canOfferBunInstall({}, tty, tty)).toBe(true)
+    expect(canOfferBunInstall({}, { isTTY: false }, tty)).toBe(false)
+    expect(canOfferBunInstall({}, tty, { isTTY: false })).toBe(false)
+  })
+
+  it("never prompts in CI or when the escape hatch is set", () => {
+    expect(canOfferBunInstall({ CI: "true" }, tty, tty)).toBe(false)
+    expect(canOfferBunInstall({ ROVE_NO_BUN_BOOTSTRAP: "1" }, tty, tty)).toBe(false)
+  })
+})
+
+const spawnResult = (over: Record<string, unknown> = {}) =>
+  ({ status: 0, signal: null, error: undefined, ...over }) as never
+
+describe("installBun", () => {
+  it("re-probes the well-known prefixes after the installer ran", () => {
+    const calls: string[][] = []
+    const found = installBun({ ...posix, isExecutable: (path) => path === "/home/dev/.bun/bin/bun" }, (cmd, args) => {
+      calls.push([cmd, ...args])
+      return spawnResult()
+    })
+
+    expect(found).toBe("/home/dev/.bun/bin/bun")
+    expect(calls[0]?.[0]).toBe("bash")
+  })
+
+  it("gives up when the installer fails", () => {
+    expect(installBun({ ...posix, isExecutable: () => true }, () => spawnResult({ status: 1 }))).toBeNull()
+  })
+})
+
+describe("relaunchWithBun", () => {
+  it("hands the entry and argv to Bun with inherited stdio", () => {
+    let seen: { cmd: string; args: readonly string[]; options: { stdio?: string } } | null = null
+    const code = relaunchWithBun("/usr/bin/bun", "/dist/rove-run.js", ["api", "--pretty"], (cmd, args, options) => {
+      seen = { cmd, args, options }
+      return spawnResult({ status: 3 })
+    })
+
+    expect(code).toBe(3)
+    expect(seen).toEqual({
+      cmd: "/usr/bin/bun",
+      args: ["/dist/rove-run.js", "api", "--pretty"],
+      options: { stdio: "inherit" },
+    })
+  })
+
+  it("reports a Bun that cannot be started instead of exiting 0", () => {
+    expect(
+      relaunchWithBun("/gone/bun", "/dist/rove-run.js", [], () => spawnResult({ error: new Error("ENOENT") })),
+    ).toBe(1)
+  })
+})
+
+describe("exitCodeOf", () => {
+  it("passes a status through and maps a fatal signal the way a shell does", () => {
+    expect(exitCodeOf({ status: 0, signal: null })).toBe(0)
+    expect(exitCodeOf({ status: 2, signal: null })).toBe(2)
+    expect(exitCodeOf({ status: null, signal: "SIGINT" })).toBe(130)
+    expect(exitCodeOf({ status: null, signal: null })).toBe(1)
+  })
+})

--- a/scripts/coverage-gate.mjs
+++ b/scripts/coverage-gate.mjs
@@ -61,6 +61,13 @@ const SUBPROCESS_ONLY_EXCLUSIONS = new Set([
   // entries and verifies their observable identity and env precedence.
   "packages/kobe/src/cli/kobe.ts",
   "packages/kobe/src/cli/rove.ts",
+  // The published bin: a node launcher that finds a Bun runtime and re-execs
+  // the real entry through it (npm/npx hand a bin to node, `bun install -g`
+  // hands it to Bun). Its module body IS the side effect — importing it from
+  // a test would relaunch the CLI inside the runner. All of its logic lives
+  // in src/cli/bun-runtime.ts, which test/cli/bun-runtime.test.ts covers
+  // directly; test/behavior/rove-alias.test.ts spawns the built launchers.
+  "packages/kobe/src/cli/launcher.ts",
   // `kobe pty-host`: internal subcommand spawned DETACHED by
   // ensurePtyHostReachable() (see src/cli/pty-host-cmd.ts) — it blocks in the
   // foreground running a real server and installs SIGINT/SIGTERM handlers

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env sh
+set -eu
+
+# One-step install for Rove, for a machine that has nothing yet.
+#
+#   curl -fsSL https://rove.sma1lboy.me/install.sh | sh
+#   curl -fsSL https://rove.sma1lboy.me/install.sh | sh -s -- 0.8.136   # pin
+#
+# Rove's CLI is a Bun program, so this script installs Bun first when the
+# machine has none, then installs the package with it. Updating later is
+# `rove update` (scripts/update.sh), which reuses whichever package manager
+# owns the binary on PATH.
+PACKAGE="@sma1lboy/rove"
+LEGACY_PACKAGE="@sma1lboy/kobe"
+VERSION="${1:-}"
+
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  ACCENT='\033[38;2;204;120;92m'
+  GREEN='\033[32m'
+  RED='\033[31m'
+  DIM='\033[2m'
+  RESET='\033[0m'
+else
+  BOLD='' ACCENT='' GREEN='' RED='' DIM='' RESET=''
+fi
+
+say() { printf '%b\n' "$1"; }
+die() { printf '%berror: %b%b\n' "$RED" "$1" "$RESET" >&2; exit 1; }
+
+printf '%b\n' \
+  "${ACCENT}${BOLD}██████╗  ██████╗ ██╗   ██╗███████╗" \
+  "██╔══██╗██╔═══██╗██║   ██║██╔════╝" \
+  "██████╔╝██║   ██║██║   ██║█████╗" \
+  "██╔══██╗██║   ██║╚██╗ ██╔╝██╔══╝" \
+  "██║  ██║╚██████╔╝ ╚████╔╝ ███████╗" \
+  "╚═╝  ╚═╝ ╚═════╝   ╚═══╝  ╚══════╝${RESET}" \
+  "${DIM}many sessions. one terminal.${RESET}" \
+  ""
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  Linux | Darwin | *BSD) ;;
+  MINGW* | MSYS* | CYGWIN*)
+    die "this script needs a POSIX shell. On Windows install Bun and Rove with npm:\n  npm install -g bun\n  npm install -g ${PACKAGE}"
+    ;;
+  *) say "${DIM}unrecognised platform — continuing anyway${RESET}" ;;
+esac
+
+command -v git >/dev/null 2>&1 || say "${DIM}note: git is not on PATH — Rove needs it to create task worktrees${RESET}"
+
+# 1. Bun — the runtime Rove itself executes under.
+BUN="$(command -v bun 2>/dev/null || true)"
+if [ -z "$BUN" ] && [ -x "${BUN_INSTALL:-$HOME/.bun}/bin/bun" ]; then
+  BUN="${BUN_INSTALL:-$HOME/.bun}/bin/bun"
+fi
+
+if [ -z "$BUN" ]; then
+  say "${BOLD}Installing Bun${RESET} ${DIM}(Rove's runtime — https://bun.sh)${RESET}"
+  command -v curl >/dev/null 2>&1 || die "curl is required to install Bun"
+  command -v unzip >/dev/null 2>&1 || say "${DIM}note: Bun's installer wants unzip; install it if the next step fails${RESET}"
+  curl -fsSL https://bun.sh/install | bash || die "Bun install failed — install it manually from https://bun.sh, then re-run this script"
+  BUN="${BUN_INSTALL:-$HOME/.bun}/bin/bun"
+  [ -x "$BUN" ] || die "Bun installed but no binary at $BUN"
+  say ""
+else
+  say "${DIM}bun found: ${BUN}${RESET}"
+fi
+
+BUN_BIN_DIR="$(dirname "$BUN")"
+
+# 2. Rove. Both packages own the `rove` and `kobe` bin names, so an install
+# on top of the pre-rename package dies with EEXIST — clear it first.
+if [ -d "${BUN_INSTALL:-$HOME/.bun}/install/global/node_modules/${LEGACY_PACKAGE}" ]; then
+  say "${DIM}removing the pre-rename ${LEGACY_PACKAGE} first${RESET}"
+  "$BUN" remove -g "$LEGACY_PACKAGE" >/dev/null 2>&1 || true
+fi
+
+say "${BOLD}Installing ${PACKAGE}${VERSION:+@$VERSION}${RESET}"
+"$BUN" install -g "${PACKAGE}@${VERSION:-latest}" >/dev/null 2>&1 ||
+  die "install failed — retry with output: ${BUN} install -g ${PACKAGE}@${VERSION:-latest}"
+
+# 3. Report, and say exactly what to add to PATH when the bin dir is missing.
+hash -r 2>/dev/null || true
+if command -v rove >/dev/null 2>&1; then
+  say "${GREEN}✓ $(rove -v 2>/dev/null || echo 'rove installed')${RESET}"
+  say ""
+  say "Next: ${BOLD}cd${RESET} into a git repo and run ${BOLD}rove${RESET}."
+elif [ -x "${BUN_BIN_DIR}/rove" ]; then
+  say "${GREEN}✓ $(PATH="${BUN_BIN_DIR}:$PATH" "${BUN_BIN_DIR}/rove" -v 2>/dev/null || echo 'rove installed')${RESET}"
+  say ""
+  say "${BOLD}${BUN_BIN_DIR} is not on your PATH yet.${RESET} Add it, then reopen your shell:"
+  say "  echo 'export PATH=\"${BUN_BIN_DIR}:\$PATH\"' >> ~/.$(basename "${SHELL:-sh}")rc"
+else
+  die "installed, but no rove binary landed in ${BUN_BIN_DIR}"
+fi
+
+say ""
+say "${DIM}Rove needs at least one agent CLI on PATH (claude, codex, copilot, kimi).${RESET}"
+say "${DIM}Update later with: rove update${RESET}"


### PR DESCRIPTION
## Why

Every documented install route went through Bun (`bun install -g`, `bunx`), so anyone without Bun — most people with npm/npx — hit `env: bun: No such file or directory` or simply skipped the tool. The CLI genuinely runs on Bun (`target: "bun"` bundle), so the fix is to stop requiring the user to bring it.

## What changed

**The bins are node launchers now.** `dist/cli/rove.js` / `kobe.js` are a small `#!/usr/bin/env node` program (`src/cli/launcher.ts`); the Bun bundles they front ship beside them as `<name>-run.js`.

- started by Bun (`bun install -g` symlink, `bunx`, the daemon re-spawning with `process.execPath`) → imports the entry in-process, no relaunch, no node needed at that step;
- started by node (`npm install -g`, `npx`) → finds Bun and re-execs through it;
- no Bun anywhere → offers to install it (TTY only), otherwise prints every install route and exits 1.

Bun is discovered via `ROVE_BUN` → `PATH` → `$BUN_INSTALL/bin` → `~/.bun/bin` → a `bun` npm package beside the install. `ROVE_NO_BUN_BOOTSTRAP=1` (and `CI=true`) turns the offer back into a plain error.

**`scripts/install.sh`** — one-line install for a bare machine: installs Bun when missing, clears the pre-rename `@sma1lboy/kobe` global that would EEXIST on the shared bin names, installs Rove, and prints the exact `PATH` line when the bin dir isn't on it. Served from `rove.sma1lboy.me/install.sh` via a Vercel rewrite to the raw file, so the script has one home.

**Docs + landing** lead with the no-Bun-required routes (README, QUICKSTART, CLI, package README, hero/install copy, new TROUBLESHOOTING entry).

## Verified locally

- `bun install -g` shape (symlink → shebang), `npm install -g --prefix`, `npx -p <tgz> rove`, direct `./dist/cli/rove.js`, and `bun dist/cli/rove.js` — all print `rove 0.8.136`, both bin names.
- npm-installed bin with Bun removed from `PATH` (only `~/.bun/bin`) → still runs.
- Fresh `HOME`, no Bun at all → prompt → installs Bun → relaunches → `rove 0.8.136`. Non-TTY → instructions + exit 1. `ROVE_BUN` override → runs.
- `install.sh` end-to-end against a sandboxed `BUN_INSTALL`.
- lint, typecheck green. Unit + architecture suites: 46 failures before and after this change (pre-existing on this branch), +18 new passing tests. Behavior suite 10/11 files pass; the one failure (`legacy-tmux-cleanup`) fails identically on the untouched tree.

## Note for the reviewer

`rove.sma1lboy.me/install.sh` only resolves after the landing redeploys (deploy-landing.yml triggers on the `packages/kobe-landing/**` change in this PR). Until then the raw GitHub URL is the working one.