### PR TITLE
fix: plugin install stages its clone beside the destination

### DIFF
--- a/.changeset/plugin-install-exdev.md
+++ b/.changeset/plugin-install-exdev.md
@@ -1,0 +1,15 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove plugin install` no longer fails with EXDEV when /tmp is its own filesystem
+
+The install cloned into the OS temp dir and finished by renaming that checkout
+into `~/.kobe/plugins/<id>/checkout`. Wherever `/tmp` is a separate filesystem
+— tmpfs on most Linux distros, and always so under WSL2 — `rename(2)` across
+devices fails, so every install died with `EXDEV: cross-device link not
+permitted` *after* cloning, confirming, and running the plugin's build.
+
+The clone now stages in a `.staging-*` directory inside the plugins root
+itself, which keeps the final move a same-device rename, and the move falls
+back to copy-then-delete if the two paths still land on different devices.

--- a/packages/kobe-daemon/src/plugins/plugin-paths.ts
+++ b/packages/kobe-daemon/src/plugins/plugin-paths.ts
@@ -23,8 +23,13 @@ export function pluginRegistryPath(homeDir?: string): string {
   return join(stateRoot(homeDir), "plugins.json")
 }
 
+/** Parent of every per-plugin directory — also where installs stage their clone. */
+export function pluginsRootDir(homeDir?: string): string {
+  return join(stateRoot(homeDir), "plugins")
+}
+
 export function pluginDataDir(id: string, homeDir?: string): string {
-  return join(stateRoot(homeDir), "plugins", id)
+  return join(pluginsRootDir(homeDir), id)
 }
 
 export function pluginCheckoutDir(id: string, homeDir?: string): string {

--- a/packages/kobe/src/cli/plugin-install.ts
+++ b/packages/kobe/src/cli/plugin-install.ts
@@ -10,9 +10,8 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs"
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs"
 import { mkdtempSync } from "node:fs"
-import { tmpdir } from "node:os"
 import { basename, join, resolve } from "node:path"
 import { createInterface } from "node:readline/promises"
 import {
@@ -23,7 +22,12 @@ import {
   pluginManifestPath,
   supportsPlatform,
 } from "@sma1lboy/kobe-daemon/plugins/manifest"
-import { pluginCheckoutDir, pluginConfigDir, pluginStateDir } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
+import {
+  pluginCheckoutDir,
+  pluginConfigDir,
+  pluginStateDir,
+  pluginsRootDir,
+} from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import {
   type PluginRegistryEntry,
   loadPluginRegistry,
@@ -101,6 +105,29 @@ function runBuildCommands(parsed: ParsedPluginManifest, root: string): void {
   }
 }
 
+/**
+ * Stage the clone inside the plugins root, not the OS temp dir: `/tmp` is a
+ * separate filesystem on most Linux setups (tmpfs, and always so under WSL2),
+ * and `rename(2)` across devices fails with EXDEV. Staging next to the
+ * destination keeps the final move an atomic same-device rename.
+ */
+function makeStagingDir(): string {
+  const root = pluginsRootDir()
+  mkdirSync(root, { recursive: true })
+  return mkdtempSync(join(root, ".staging-"))
+}
+
+/** Rename, falling back to copy+delete if the two paths still span devices. */
+function movePluginTree(from: string, to: string): void {
+  try {
+    renameSync(from, to)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err
+    cpSync(from, to, { recursive: true, verbatimSymlinks: true })
+    rmSync(from, { recursive: true, force: true })
+  }
+}
+
 function register(entry: PluginRegistryEntry): void {
   savePluginRegistry(upsertPluginEntry(loadPluginRegistry(), entry))
   mkdirSync(pluginConfigDir(entry.id), { recursive: true })
@@ -114,7 +141,7 @@ export async function installPlugin(spec: string, opts: { yes: boolean; ref?: st
   const [, owner, repo, subdirRaw] = match
   const subdir = subdirRaw?.replace(/^\//, "")
 
-  const tmp = mkdtempSync(join(tmpdir(), "kobe-plugin-"))
+  const tmp = makeStagingDir()
   try {
     const url = `https://github.com/${owner}/${repo}.git`
     console.log(`cloning ${url}${opts.ref ? ` @ ${opts.ref}` : ""}`)
@@ -151,7 +178,7 @@ export async function installPlugin(spec: string, opts: { yes: boolean; ref?: st
     const checkout = pluginCheckoutDir(id)
     rmSync(checkout, { recursive: true, force: true })
     mkdirSync(join(checkout, ".."), { recursive: true })
-    renameSync(tmp, checkout)
+    movePluginTree(tmp, checkout)
     register({
       id,
       source: { kind: "github", spec },

--- a/packages/kobe/test/cli/plugin-install.test.ts
+++ b/packages/kobe/test/cli/plugin-install.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { pluginConfigDir, pluginStateDir } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
+import { pluginConfigDir, pluginStateDir, pluginsRootDir } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import { loadPluginRegistry, savePluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -122,6 +122,30 @@ describe("plugin manifest diagnostics", () => {
       version: "2.0.0",
     })
     expect(existsSync(join(entry?.root ?? "", "rove-plugin.toml"))).toBe(true)
+  })
+
+  it("stages the clone beside the destination so the move never crosses devices", async () => {
+    // Regression: staging in os.tmpdir() made the final rename() fail with
+    // EXDEV wherever /tmp is its own filesystem (tmpfs, WSL2).
+    const home = pluginDir()
+    vi.stubEnv("ROVE_HOME_DIR", home)
+    vi.spyOn(console, "log").mockImplementation(() => {})
+    const cloneTargets: string[] = []
+    mocks.spawnSync.mockImplementation((_command: string, args: string[]) => {
+      const checkout = args.at(-1) as string
+      cloneTargets.push(checkout)
+      writeFileSync(
+        join(checkout, "rove-plugin.toml"),
+        'id = "managed.plugin"\nname = "Managed"\nversion = "2.0.0"\nmin_rove_version = "0.1.0"',
+      )
+      return { status: 0 }
+    })
+
+    await installPlugin("owner/repo", { yes: true })
+
+    expect(cloneTargets).toHaveLength(1)
+    expect(cloneTargets[0]?.startsWith(`${pluginsRootDir(home)}/`)).toBe(true)
+    expect(existsSync(cloneTargets[0] as string)).toBe(false)
   })
 
   it("rejects a build that switches from the previewed legacy manifest to a canonical one", async () => {


### PR DESCRIPTION
## What broke

`rove plugin install <owner/repo>` died at the very last step:

```
rove plugin: EXDEV: cross-device link not permitted,
  rename '/tmp/kobe-plugin-UG0UZG' -> '/home/zhallen/.kobe/plugins/kobe.browser/checkout'
```

The clone was staged in `os.tmpdir()` and the install finished with `renameSync(tmp, checkout)`. `rename(2)` cannot cross filesystems, and `/tmp` is its own filesystem on most Linux distros (tmpfs) and always under WSL2:

```
tmpfs      7.7G  /tmp
/dev/sdd  1007G  /
```

So the failure hit *after* the clone, the confirmation prompt, and the plugin's full build had run — the most expensive possible place to fail.

## Fix

- `pluginsRootDir()` added to `plugin-paths.ts` (`pluginDataDir` now composes from it).
- The install stages into `<plugins root>/.staging-XXXX` instead of the OS temp dir, so the final move is a same-device rename. The existing `finally` still removes the staging dir on any failure path.
- `movePluginTree()` falls back to `cpSync` + `rmSync` if the two paths still land on different devices (bind mount, symlinked plugins dir).

## Verification

- New regression test asserts the clone target lives under the plugins root and is gone afterwards.
- `test/cli/plugin-install.test.ts` 8/8 green; `test:fast` over `test/cli` + `test/plugins` shows the same 46 pre-existing failures before and after (unrelated `kobe`/`rove` CLI-name assertions).
- lint + typecheck clean.
- End-to-end from source: `rove plugin install Sma1lboy/kobe-plugins/browser --yes` → `installed kobe.browser v0.2.0`, no leftover staging dirs.