### PR TITLE
fix(landing): the zen workspace keeps its width, and the footer reads as two blocks

### DIFF
--- a/packages/kobe-landing/fleet.js
+++ b/packages/kobe-landing/fleet.js
@@ -292,8 +292,9 @@
   function showView(name) {
     var split = name === 'split' || name === 'inbox';
     document.querySelector('.fl-work').hidden = !split;
-    // zen hides Files regardless of view (host.tsx:448 — `!zen && !openPage`)
-    document.getElementById('fleetFiles').hidden = !split;
+    // zen hides Files regardless of view (host.tsx:448 — `!zen && !openPage`),
+    // and zen only fades it: an un-hidden pane still holds its 26ch grid track
+    document.getElementById('fleetFiles').hidden = !split || zen;
     document.getElementById('fleetKanban').hidden = name !== 'kanban';
     document.getElementById('fleetRoutines').hidden = name !== 'routines';
     // the Inbox is a dialog: it covers the frame instead of replacing a column

--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -161,12 +161,23 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(44px
 .final-band .wrap{position:relative;z-index:2;text-align:center}
 .final-band .h2f{font-family:var(--font-display);font-size:clamp(30px,4.6vw,56px);font-weight:400;letter-spacing:-.02em;color:var(--ink);max-width:20ch;margin:0 auto;text-shadow:0 1px 26px oklch(97% 0.01 85/.9)}
 
-/* ============ FOOTER ============ */
-.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:32px 0;font-size:13px;color:var(--faint)}
-.foot-dense p{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);line-height:1.8}
+/* ============ FOOTER ============
+   Two blocks, not one paragraph: identity on the left, navigation on the
+   right. The links were prose-colored and underlined, so they read as part
+   of the colophon sentence — they get the navbar's mono treatment instead,
+   which is the vocabulary the rest of the page already uses for controls. */
+.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:40px 0;font-size:13px;color:var(--faint)}
+.foot-inner{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);display:flex;flex-wrap:wrap;justify-content:space-between;gap:22px 44px}
+.foot-id{max-width:56ch;line-height:1.7}
 .foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
-.foot-dense a{border-bottom:1px solid var(--line-2);transition:color 140ms,border-color 140ms}
-.foot-dense a:hover{color:var(--ink);border-color:var(--accent-line)}
+.foot-dense .tagline{color:var(--ink-soft)}
+/* the colophon is credits, not a claim — its own line, one step quieter */
+.foot-colophon{display:block;margin-top:7px;font-size:12px;color:var(--faint)}
+/* no margin-left:auto — space-between already right-aligns it on one line,
+   and once it wraps to its own row the auto margin would strand it right */
+.foot-links{display:flex;flex-wrap:wrap;align-items:baseline;gap:2px;font-family:var(--font-mono);font-size:12.5px}
+.foot-links a{color:var(--muted);padding:5px 11px;transition:color 140ms,background 140ms}
+.foot-links a:hover{color:var(--accent);background:var(--accent-wash)}
 
 @media (prefers-reduced-motion: reduce){
   *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}
@@ -439,7 +450,20 @@ c  <span class="ok">+96</span>  <span class="del">−88</span>  · 5 files
 
 <!-- FOOTER · dense colophon -->
 <footer class="foot-dense">
-  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span> <a href="https://github.com/Sma1lboy/rove">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/plugins" data-i18n="footer.plugins">plugins</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
+  <div class="foot-inner">
+    <p class="foot-id">
+      <span class="mark">[Rove]</span> <span class="tagline" data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span>
+      <span class="foot-colophon" data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span>
+    </p>
+    <nav class="foot-links" aria-label="Footer">
+      <a href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.npmjs.com/package/@sma1lboy/rove" target="_blank" rel="noopener">npm</a>
+      <a href="/plugins" data-i18n="footer.plugins">plugins</a>
+      <a href="/themes" data-i18n="footer.themesLink">themes</a>
+      <a href="/changelog" data-i18n="footer.changelog">changelog</a>
+      <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" target="_blank" rel="noopener" data-i18n="footer.keybindings">keybindings</a>
+    </nav>
+  </div>
 </footer>
 
 <script src="/index.js"></script>

--- a/packages/kobe-landing/index.js
+++ b/packages/kobe-landing/index.js
@@ -32,7 +32,7 @@ var KOBE_I18N = (function () {
     'final.line': '所有支流终会汇合。判断权在你手里。',
     'footer.tagline': '终端原生的编码代理图工程。',
     'footer.colophon': '用 Bun、OpenTUI 和 React 构建。字体为 Fraunces、DM Sans 与 JetBrains Mono。MIT 许可。',
-    'footer.plugins': '插件', 'footer.changelog': '更新日志', 'footer.keybindings': '快捷键',
+    'footer.plugins': '插件', 'footer.themesLink': '主题', 'footer.changelog': '更新日志', 'footer.keybindings': '快捷键',
   };
   var en = {
     'meta.title': 'Rove — run coding agents as a graph, terminal-native',
@@ -65,7 +65,7 @@ var KOBE_I18N = (function () {
     'final.line': 'Every stream converges. You keep the judgment.',
     'footer.tagline': 'graph engineering for coding agents, terminal-native.',
     'footer.colophon': 'Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.',
-    'footer.plugins': 'plugins', 'footer.changelog': 'changelog', 'footer.keybindings': 'keybindings',
+    'footer.plugins': 'plugins', 'footer.themesLink': 'themes', 'footer.changelog': 'changelog', 'footer.keybindings': 'keybindings',
   };
   var dicts = { en: en, zh: zh };
   var lang = 'en';

--- a/packages/kobe-landing/plugins.html
+++ b/packages/kobe-landing/plugins.html
@@ -191,11 +191,23 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash);border:1px solid oklch(62% 0.13 45/.18);border-radius:5px;padding:1px 6px;color:oklch(46% 0.11 45);overflow-wrap:anywhere}
 
 /* ============ FOOTER ============ */
-.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:32px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
-.foot-dense p{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);line-height:1.8}
+/* ============ FOOTER ============
+   Two blocks, not one paragraph: identity on the left, navigation on the
+   right. The links were prose-colored and underlined, so they read as part
+   of the colophon sentence — they get the navbar's mono treatment instead,
+   which is the vocabulary the rest of the page already uses for controls. */
+.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:40px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
+.foot-inner{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);display:flex;flex-wrap:wrap;justify-content:space-between;gap:22px 44px}
+.foot-id{max-width:56ch;line-height:1.7}
 .foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
-.foot-dense a{border-bottom:1px solid var(--line-2);transition:color 140ms,border-color 140ms}
-.foot-dense a:hover{color:var(--ink);border-color:var(--accent-line)}
+.foot-dense .tagline{color:var(--ink-soft)}
+/* the colophon is credits, not a claim — its own line, one step quieter */
+.foot-colophon{display:block;margin-top:7px;font-size:12px;color:var(--faint)}
+/* no margin-left:auto — space-between already right-aligns it on one line,
+   and once it wraps to its own row the auto margin would strand it right */
+.foot-links{display:flex;flex-wrap:wrap;align-items:baseline;gap:2px;font-family:var(--font-mono);font-size:12.5px}
+.foot-links a{color:var(--muted);padding:5px 11px;transition:color 140ms,background 140ms}
+.foot-links a:hover{color:var(--accent);background:var(--accent-wash)}
 
 @media (prefers-reduced-motion: reduce){
   *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}
@@ -305,7 +317,19 @@ code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash)
 
 <!-- FOOTER · dense colophon -->
 <footer class="foot-dense">
-  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span> <a href="https://github.com/Sma1lboy/rove">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
+  <div class="foot-inner">
+    <p class="foot-id">
+      <span class="mark">[Rove]</span> <span class="tagline" data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span>
+      <span class="foot-colophon" data-i18n="footer.colophon">Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.</span>
+    </p>
+    <nav class="foot-links" aria-label="Footer">
+      <a href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.npmjs.com/package/@sma1lboy/rove" target="_blank" rel="noopener">npm</a>
+      <a href="/themes" data-i18n="footer.themesLink">themes</a>
+      <a href="/changelog" data-i18n="footer.changelog">changelog</a>
+      <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" target="_blank" rel="noopener" data-i18n="footer.keybindings">keybindings</a>
+    </nav>
+  </div>
 </footer>
 
 <script>
@@ -341,7 +365,7 @@ code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash)
       'pub.s3': '<b>就这样。</b>下次有人打开这个页面时它就出现了，任何人都能跑 <code>rove plugin install you/your-repo</code>。',
       'footer.tagline': '终端原生的编码代理图工程。',
       'footer.colophon': '用 Bun、OpenTUI 和 React 构建。字体为 Fraunces、DM Sans 与 JetBrains Mono。MIT 许可。',
-      'footer.changelog': '更新日志', 'footer.keybindings': '快捷键',
+      'footer.themesLink': '主题', 'footer.changelog': '更新日志', 'footer.keybindings': '快捷键',
     };
     var en = {
       'meta.title': 'Rove — plugins',
@@ -373,7 +397,7 @@ code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash)
       'pub.s3': '<b>Done.</b> It shows up on this page on the next load, and anyone can run <code>rove plugin install you/your-repo</code>.',
       'footer.tagline': 'graph engineering for coding agents, terminal-native.',
       'footer.colophon': 'Built with Bun, OpenTUI and React. Set in Fraunces, DM Sans and JetBrains Mono. MIT licensed.',
-      'footer.changelog': 'changelog', 'footer.keybindings': 'keybindings',
+      'footer.themesLink': 'themes', 'footer.changelog': 'changelog', 'footer.keybindings': 'keybindings',
     };
     var dicts = { en: en, zh: zh };
     var lang = 'en';

--- a/packages/kobe-landing/themes.css
+++ b/packages/kobe-landing/themes.css
@@ -119,8 +119,20 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 .copy-cmd .ps{color:var(--accent-2)}
 .copy-cmd .hint{color:oklch(62% 0.02 60);font-size:11px;margin-left:4px}
 
-.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:32px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
-.foot-dense p{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);line-height:1.8}
+/* ============ FOOTER ============
+   Two blocks, not one paragraph: identity on the left, navigation on the
+   right. The links were prose-colored and underlined, so they read as part
+   of the colophon sentence — they get the navbar's mono treatment instead,
+   which is the vocabulary the rest of the page already uses for controls. */
+.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:40px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
+.foot-inner{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);display:flex;flex-wrap:wrap;justify-content:space-between;gap:22px 44px}
+.foot-id{max-width:56ch;line-height:1.7}
 .foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
-.foot-dense a{border-bottom:1px solid var(--line-2);transition:color 140ms,border-color 140ms}
-.foot-dense a:hover{color:var(--ink);border-color:var(--accent-line)}
+.foot-dense .tagline{color:var(--ink-soft)}
+/* the colophon is credits, not a claim — its own line, one step quieter */
+.foot-colophon{display:block;margin-top:7px;font-size:12px;color:var(--faint)}
+/* no margin-left:auto — space-between already right-aligns it on one line,
+   and once it wraps to its own row the auto margin would strand it right */
+.foot-links{display:flex;flex-wrap:wrap;align-items:baseline;gap:2px;font-family:var(--font-mono);font-size:12.5px}
+.foot-links a{color:var(--muted);padding:5px 11px;transition:color 140ms,background 140ms}
+.foot-links a:hover{color:var(--accent);background:var(--accent-wash)}

--- a/packages/kobe-landing/themes.html
+++ b/packages/kobe-landing/themes.html
@@ -430,7 +430,20 @@
 </div>
 
 <footer class="foot-dense">
-  <p><span class="mark">[Rove]</span> — <span data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span> <span data-i18n="footer.themes">Previews are rendered from each theme's real color file, not screenshots.</span> <a href="https://github.com/Sma1lboy/rove">GitHub</a> · <a href="https://www.npmjs.com/package/@sma1lboy/rove">npm</a> · <a href="/changelog" data-i18n="footer.changelog">changelog</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/themes.md" data-i18n="footer.themedocs">theme docs</a> · <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" data-i18n="footer.keybindings">keybindings</a></p>
+  <div class="foot-inner">
+    <p class="foot-id">
+      <span class="mark">[Rove]</span> <span class="tagline" data-i18n="footer.tagline">graph engineering for coding agents, terminal-native.</span>
+      <span class="foot-colophon" data-i18n="footer.themes">Previews are rendered from each theme's real color file, not screenshots.</span>
+    </p>
+    <nav class="foot-links" aria-label="Footer">
+      <a href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.npmjs.com/package/@sma1lboy/rove" target="_blank" rel="noopener">npm</a>
+      <a href="/plugins" data-i18n="footer.plugins">plugins</a>
+      <a href="/changelog" data-i18n="footer.changelog">changelog</a>
+      <a href="https://github.com/Sma1lboy/rove/blob/main/docs/themes.md" target="_blank" rel="noopener" data-i18n="footer.themedocs">theme docs</a>
+      <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" target="_blank" rel="noopener" data-i18n="footer.keybindings">keybindings</a>
+    </nav>
+  </div>
 </footer>
 
 <script src="/themes.js"></script>

--- a/packages/kobe-landing/themes.js
+++ b/packages/kobe-landing/themes.js
@@ -43,7 +43,7 @@ var KOBE_I18N = (function () {
     'copy.hint': '点击复制', 'copy.done': '已复制',
     'footer.tagline': '终端原生的编码代理图工程。',
     'footer.themes': '预览由每个主题真实的配色文件渲染，不是截图。',
-    'footer.changelog': '更新日志', 'footer.themedocs': '主题文档', 'footer.keybindings': '快捷键',
+    'footer.plugins': '插件', 'footer.changelog': '更新日志', 'footer.themedocs': '主题文档', 'footer.keybindings': '快捷键',
   };
   var en = {
     'meta.title': 'Rove — themes',
@@ -87,7 +87,7 @@ var KOBE_I18N = (function () {
     'copy.hint': 'click to copy', 'copy.done': 'copied',
     'footer.tagline': 'graph engineering for coding agents, terminal-native.',
     'footer.themes': "Previews are rendered from each theme's real color file, not screenshots.",
-    'footer.changelog': 'changelog', 'footer.themedocs': 'theme docs', 'footer.keybindings': 'keybindings',
+    'footer.plugins': 'plugins', 'footer.changelog': 'changelog', 'footer.themedocs': 'theme docs', 'footer.keybindings': 'keybindings',
   };
   var dicts = { en: en, zh: zh };
   var lang = 'en';


### PR DESCRIPTION
## Summary

Two independent landing-page fixes, both reported from the live site.

**1. Leaving Kanban squeezed the workspace** (`fleet.js`)

`showView` un-hid the Files pane on every return to the split view, ignoring zen. Zen only *fades* Files (`opacity: 0`) — an un-hidden pane still holds its 26ch grid track, so clicking Kanban and coming back left the terminal mock 280px narrower with nothing visible in the space it lost. The rule was already stated in the comment above the line and already correct in `applyZen`; the fix is to say it in the code too.

| | workspace width |
|---|---|
| initial (zen) | 993px |
| after Kanban round-trip, before | **714px** |
| after Kanban round-trip, after | 993px |

**2. The footer read as one run-on sentence** (`index.html`, `plugins.html`, `themes.css/html`)

The links were appended to the end of the colophon sentence in body color with underlines, so `GitHub · npm · plugins` parsed as continuing prose rather than as controls, and "MIT licensed" carried the same weight as the tagline.

Identity now sits left (tagline, colophon one step quieter on its own line) and the links sit right as a mono nav — the same vocabulary the navbar already uses for the same job. Below ~900px the nav wraps under the identity and stays left rather than stranding itself against the right edge.

Home and plugins also gained the `themes` link they were missing, and themes gained `plugins`, so every page now reaches every other.

## Test plan

- [x] Zen width measured across the Kanban round-trip (993 → 993, was 714); non-zen path still restores Files (777px both sides)
- [x] Footer at 1440 / 1280 / 900 / 700 / 390 — no horizontal overflow, nav wraps and stays left below 900
- [x] Both languages on all three pages; i18n keys audited by script — every `data-i18n` present in both dicts, no orphan `footer.*` keys
- [ ] Spot-check the deploy preview, since this is CSS-heavy and font metrics differ from local

Gates: `changeset-cap` is a no-op (no `packages/kobe/src` or `kobe-daemon/src` touched); all touched `.js` are well under the 500-line cap; `packages/kobe-landing` is outside the root lint scope.