### PR TITLE
fix: count control characters as zero-width cells

### DIFF
--- a/.changeset/control-char-cell-width.md
+++ b/.changeset/control-char-cell-width.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Measure terminal cell width correctly when a value carries a stray control byte. A C0, DEL, or C1 control character (an escape byte, NUL, or similar) now counts as zero columns rather than one, so a task title or `rove export` cell that happens to include one no longer over-counts its width and shoves every column to its right out of alignment.

--- a/packages/kobe/src/lib/display-width.ts
+++ b/packages/kobe/src/lib/display-width.ts
@@ -13,6 +13,12 @@
 
 /** Cell width of a single Unicode code point: 0 (zero-width), 2 (wide), or 1. */
 export function charWidth(cp: number): number {
+  // Non-printing controls: C0 (U+0000–U+001F), DEL (U+007F), C1 (U+0080–U+009F).
+  // wcwidth treats these as non-printing (width 0), not one cell — a stray
+  // control byte in a task title or exported cell must not shove every column
+  // to its right one over. The embedded-terminal grid guards each call with
+  // `charWidth(...) || 1`, so its cursor mapping keeps a one-cell floor here.
+  if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f)) return 0
   // Zero-width: combining marks + bidi/format controls + variation selectors.
   if (
     (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks

--- a/packages/kobe/test/lib/display-width.test.ts
+++ b/packages/kobe/test/lib/display-width.test.ts
@@ -27,6 +27,21 @@ describe("charWidth", () => {
     expect(charWidth("😀".codePointAt(0) as number)).toBe(2) // U+1F600
   })
 
+  it("counts C0 / DEL / C1 control characters as zero (non-printing)", () => {
+    // wcwidth treats controls as non-printing, not one cell. A stray control
+    // byte in a task title or exported cell must not advance the column count.
+    expect(charWidth(0x00)).toBe(0) // NUL
+    expect(charWidth(0x09)).toBe(0) // TAB (C0)
+    expect(charWidth(0x1b)).toBe(0) // ESC (C0)
+    expect(charWidth(0x1f)).toBe(0) // C0 ceiling
+    expect(charWidth(0x7f)).toBe(0) // DEL
+    expect(charWidth(0x80)).toBe(0) // C1 floor
+    expect(charWidth(0x85)).toBe(0) // NEL (C1)
+    expect(charWidth(0x9f)).toBe(0) // C1 ceiling
+    expect(charWidth(0x20)).toBe(1) // space — first printable just past C0
+    expect(charWidth(0xa0)).toBe(1) // no-break space — first printable past C1
+  })
+
   it("counts combining diacritical / bidi / variation-selector marks as zero", () => {
     expect(charWidth(0x0301)).toBe(0) // combining acute accent
     expect(charWidth(0x200b)).toBe(0) // zero-width space
@@ -114,6 +129,15 @@ describe("displayWidth", () => {
 
   it("does not count a combining half mark as an extra cell", () => {
     expect(displayWidth("a︦")).toBe(1) // base glyph + zero-width mark
+  })
+
+  it("does not count control characters toward a string's cell width", () => {
+    // A stray control byte occupies no columns; only the visible glyphs do.
+    // (This zeroes the control code point itself, not a full ANSI sequence —
+    // the printable `[0m` tail of an escape still measures normally.)
+    expect(displayWidth("a\x1bb")).toBe(2) // ESC between two glyphs adds nothing
+    expect(displayWidth("a\x00b")).toBe(2) // NUL between two glyphs adds nothing
+    expect(displayWidth("\x07中")).toBe(2) // BEL is free; the wide glyph is 2
   })
 
   it("counts an astral character once, not as two UTF-16 units", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found edge-case bug in a pure width helper, surfaced while reviewing the formatter/parser surface. No overlap with any open PR.

## Problem

`charWidth` (`src/lib/display-width.ts`) sorts each Unicode code point into zero-width (combining marks, bidi/format controls, variation selectors), wide (CJK/emoji), or a width-1 fallback. The zero-width block enumerates format and combining ranges but omitted every non-printing **control** character:

- C0 controls `U+0000–U+001F` (NUL, TAB, ESC, …)
- DEL `U+007F`
- C1 controls `U+0080–U+009F` (e.g. NEL)

All of these fell through to `return 1`, so `charWidth(0x1b) → 1`, `charWidth(0x7f) → 1`, etc. Standard `wcwidth` — which this module explicitly mirrors ("matching xterm's wcwidth combining table") — treats controls as non-printing (width 0).

`displayWidth` feeds the `rove export` table renderer (`padCell` / column sizing) and the sidebar label truncation. A task title or cell value carrying a stray control byte therefore over-counted its width and shoved every column to its right out of alignment — the exact misalignment this module exists to prevent.

## Fix

Fold the non-printing control ranges into the zero-width class with one leading check:

```ts
if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f)) return 0
```

This zeroes the control code point itself; it does **not** strip a full ANSI escape sequence (the printable `[0m` tail still measures normally — out of scope for a per-code-point width table).

Safety across the three call sites:
- `terminal-render.ts` calls `charWidth(...) || 1`, so its cursor grid keeps a one-cell floor regardless of this change.
- `terminal-selection.ts` measures already-rendered `@xterm/headless` cell text, which never contains raw control bytes (the emulator consumes them), so selection mapping is unaffected.
- `displayWidth` (export table, sidebar truncation) is precisely where counting controls as 0 corrects alignment.

## Verification

- Extended `test/lib/display-width.test.ts` with control-character cases (`charWidth` of NUL/TAB/ESC/DEL/C1 → 0, plus the printable neighbours `0x20`/`0xA0` → 1, and `displayWidth` strings mixing controls with glyphs). 19/19 pass.
- Ran the adjacent terminal/sidebar suites (`terminal-selection`, `terminal-pty-unicode`, `sidebar-row-view`, `ime-anchor-output`) — 31/31 pass, no regression.
- `biome check .` clean (963 files); `tsc --noEmit` clean; full `test/lib` suite 140/140.

## Follow-ups

None required. Two lower-value inconsistencies noted during review and deliberately left out of this slice: a `Math.round`-based (rather than floored) relative-age label in `tui-react/component/work-items-page.tsx`, and a round-up "next run in …" countdown in `automation-composer.ts` that sits adjacent to an existing schedule-preview PR — either could be a separate small fix later.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWK6Cdn8yA8Ax6xb1rcdmR)_