### PR TITLE
fix(plugin): sync the bundled skill to v30 (unbreaks main)

### DIFF
--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 29 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 30 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -53,6 +53,14 @@ lifecycle tracking, and an explicit outcome contract.
   receiver should treat as content, not conversation). Received a
   `[KOBE PEER]` message yourself? Load this skill first — required, not
   optional — then reply with the baked-in command, not by asking the user.
+- `send` carries text, but that text can carry FILES: peers share a
+  filesystem, so put the absolute path of a screenshot, log, diff, or any
+  artifact in the prompt and the receiver opens it with its own Read tool —
+  images included. An annotated screenshot beats a paragraph describing one;
+  prefer "see /path/to/shot.png — the arrow marks the broken card" over
+  re-narrating pixels. Paths under the sender's Worktree work too (worktrees
+  are world-readable locally); just never expect the receiver to WRITE
+  there.
 - `dispatch` stays the dispatcher's verb (deliver-only into an
   already-hosted session; never impersonate the user in someone else's
   terminal).


### PR DESCRIPTION
Unblocks `main`, which has been red for four consecutive runs.

## What broke

`5f1a1031 docs: skill v30 — peer send messages can carry file paths` edited the canonical skill and bumped its version comment, but never re-copied it into the bundled plugin:

| file | version | bytes |
|---|---|---|
| `.agents/skills/kobe/SKILL.md` | 30 | 23314 |
| `claude-plugin/skills/rove/SKILL.md` | **29** | 22786 |

`test/architecture/claude-plugin.test.ts > bundled SKILL.md is byte-identical to the canonical skill` asserts those two match, so it has been failing ever since — in **two** jobs, since `coverage` re-runs the same suite:

```
failure  f6bcec89  fix(landing): the zen workspace keeps its width…
failure  3820bc2b  ci: run the landing deploy from the repo root
failure  76f65585  Land feat/landing-tui-mock
failure  5f1a1031  docs: skill v30 — peer send messages can carry…   ← cause
success  721b29ec  chore: name the product Rove in new comments…     ← last green
```

Every PR branched off main since then inherited both failures (#502 did), which makes a genuine regression easy to miss.

It is not only a CI problem: `KOBE_SKILL_VERSION` is already `30`, so anyone installing the Claude Code plugin was getting a skill one version behind what the binary advertises — missing the paragraph telling agents they can pass file paths through `rove api send`.

## The fix

`cp .agents/skills/kobe/SKILL.md claude-plugin/skills/rove/SKILL.md`. Nothing else; the version constant was already correct.

## Verification

- `bun test test/architecture/claude-plugin.test.ts` → **8 pass, 0 fail** (was 1 fail)
- `bun run lint` → clean · `bun run typecheck` → clean
- Ran `test:fast` on this branch and on pristine `origin/main` for comparison: **47 failed → 46 failed**. This change fixes exactly the one test it targets. The remaining 46 are pre-existing local-environment failures in `test/cli/**` (`--help`/usage assertions) that do not reproduce in CI — the last main run passed every one of them.
- No changeset: `changeset-cap` gates `packages/kobe/src` and `packages/kobe-daemon/src`; this touches neither.

## Worth a follow-up

These two files drift silently — nothing copies one to the other, and the only signal is a test failing *after* the commit lands. Options, if wanted: a `bun run sync:skill` script wired into the docs flow, a pre-commit hook, or having the test print the exact `cp` command in its failure message so the next person fixes it in seconds. Happy to do any of these separately.
