### PR TITLE
feat: wire real activity hooks for Kimi Code

### DIFF
--- a/.changeset/kimi-hook-adapter.md
+++ b/.changeset/kimi-hook-adapter.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Kimi Code sessions now report activity through real hooks: Rove installs a marker-delimited `[[hooks]]` block into `~/.kimi-code/config.toml`, so kimi tabs get the same event-driven working/done/needs-input badges as claude and codex — including interrupts (Kimi fires `Interrupt` instead of `Stop`) and permission prompts.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -87,10 +87,10 @@ The sidebar shows what each session is doing: **working**, **done**, or
 **needs input**. There's nothing to configure — Rove reads the engine's own
 hook events, falling back to its transcript when hooks aren't available.
 
-One thing worth knowing: **only claude and codex can show "needs input"**.
-Distinguishing "waiting on a permission prompt" from "thinking" requires a
-hook; the other engines top out at working/done. Rove labels the gap honestly
-rather than guessing.
+One thing worth knowing: **only claude, codex, and kimi can show "needs
+input"**. Distinguishing "waiting on a permission prompt" from "thinking"
+requires a hook; the other engines top out at working/done. Rove labels the
+gap honestly rather than guessing.
 
 Codex won't run Rove's hooks until you trust them once via `/hooks`, so Codex
 badges stay dark until you approve. That's by design — Rove writes the hook

--- a/docs/design/plugin-events.md
+++ b/docs/design/plugin-events.md
@@ -1,6 +1,6 @@
 # Unified agent lifecycle events — the plugin event stream
 
-Status: SHIPPED for Claude Code + Codex (2026-07-28; Kimi adapter pending). Extends [plugins.md](./plugins.md) §Events.
+Status: SHIPPED for Claude Code + Codex (2026-07-28) + Kimi (2026-08-23). Extends [plugins.md](./plugins.md) §Events.
 Goal: one engine-agnostic event taxonomy covering the WHOLE product
 lifecycle — Rove's task/worktree layer plus the engine's session/turn/tool
 layer — so a plugin can hook any point of the flow without knowing which
@@ -184,9 +184,13 @@ builds: notify, log, mirror state, auto-file, auto-bootstrap, dashboards.
 - **Attention split (done for Claude).** `awaiting-input` maps to
   `attention.permission` vs `attention.question` by `detail.waiting`. Codex
   PermissionRequest opt-in and `attention.notification` remain deferred.
-- **Kimi adapter**: currently `NoopHookAdapter`; Kimi's hooks config is TOML
-  (`~/.kimi-code/config.toml [[hooks]]`, strict keys, 30s timeout). A
-  same-shape adapter is small; wire.jsonl watching covers the F-gaps.
+- **Kimi adapter** (shipped 2026-08-23): `KimiHookAdapter` writes a
+  marker-delimited `[[hooks]]` block into `~/.kimi-code/config.toml`
+  (append-at-EOF, merge-safe; payload fields verified against the installed
+  0.37.2 binary — `SessionStart`/`UserPromptSubmit`/`Stop` live-fired with
+  `session_id` + `cwd` in every payload). `Interrupt` → turn-interrupted and
+  `PermissionRequest` → awaiting-input are wired; `Notification` stays out
+  (no documented type filter). wire.jsonl watching still covers the F-gaps.
 
 Version gates to re-verify against installed binaries at implementation
 time: Codex `SessionEnd`/`Subagent*` (docs ahead of pinned protocol); Kimi

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -1,0 +1,218 @@
+/**
+ * Kimi Code hook adapter (docs/design/plugin-events.md "Kimi adapter") — the
+ * third real {@link EngineHookAdapter}.
+ *
+ * Kimi's hook store is NOT the shared settings.json shape: it's TOML
+ * `[[hooks]]` tables in `~/.kimi-code/config.toml` (keys: event, matcher?,
+ * command, timeout; JSON payload via stdin with `session_id` + `cwd`;
+ * MoonshotAI kimi-cli docs/en/customization/hooks.md, verified against the
+ * installed 0.37.2 binary). So this adapter can't extend {@link JsonHookAdapter};
+ * it implements the same contract over a marker-delimited TOML block —
+ * remove-then-append between `# >>> rove hooks` / `# <<< rove hooks`, which is
+ * merge-safe (the user's config outside the block is never parsed or
+ * rewritten) and idempotent (identical content skips the write).
+ *
+ * Event map notes (vs Claude's):
+ *   - `Interrupt` → turn-interrupted: Kimi does NOT fire Stop after a user
+ *     interrupt, so without this an interrupted Kimi turn strands in
+ *     `running` (the reducer already handles the verb; plugin-events.md §B).
+ *   - `PermissionRequest` → awaiting-input: unlike Codex (where the same
+ *     event is a synchronous allow/deny decision hook kobe stays away from),
+ *     Kimi runs it as a plain command hook — an exit-0 observer is safe.
+ *   - `Notification` is NOT wired: Kimi's notification types are
+ *     undocumented, and an unfiltered install would mark every idle prompt
+ *     as needs-input (the exact trap Claude's `permission_prompt` matcher
+ *     exists to avoid).
+ *   - Worktree-watch is NOT wired: kobe's observer matches the `Bash` tool
+ *     name, and Kimi's shell-tool naming is unverified. The daemon's
+ *     session-start auto-adopt still covers Kimi-created worktrees.
+ */
+
+import { existsSync } from "node:fs"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { kobeHookInvocation } from "../../cli/invocation.ts"
+import { quoteShellArgv } from "../../lib/shell-command.ts"
+import type { EngineHookAdapter, EngineSessionRef } from "../hook-adapter.ts"
+import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
+import type { HookEventSpec } from "../json-hooks.ts"
+
+/** Kimi hook event → normalized kobe verb. The ONE place Kimi event names live. */
+export const KIMI_HOOK_EVENT_MAP: readonly HookEventSpec[] = [
+  { event: "SessionStart", verb: "session-start" },
+  { event: "UserPromptSubmit", verb: "turn-start" },
+  { event: "Stop", verb: "turn-complete" },
+  { event: "StopFailure", verb: "turn-failed" },
+  { event: "Interrupt", verb: "turn-interrupted" },
+  { event: "PermissionRequest", verb: "awaiting-input" },
+  { event: "SessionEnd", verb: "session-end" },
+  // Lifecycle-only verbs (docs/design/plugin-events.md) — forwarded to
+  // plugin event hooks, never folded into the activity badge.
+  { event: "PreCompact", verb: "pre-compact" },
+  { event: "PostCompact", verb: "post-compact" },
+  { event: "SubagentStart", verb: "subagent-start" },
+  { event: "SubagentStop", verb: "subagent-stop" },
+  // Tool family: gated — installed only while an enabled plugin declares a
+  // tool.* hook (same volume gate as the JSON adapters).
+  { event: "PreToolUse", verb: "tool-pre" },
+  { event: "PostToolUse", verb: "tool-post" },
+  { event: "PostToolUseFailure", verb: "tool-failed" },
+]
+
+/** The Kimi events kobe owns — exported for tests (event-ownership parity
+ *  with `KOBE_CODEX_HOOK_EVENTS`). */
+export const KOBE_KIMI_HOOK_EVENTS: readonly string[] = [...new Set(KIMI_HOOK_EVENT_MAP.map((e) => e.event))]
+
+const BLOCK_BEGIN = "# >>> rove hooks"
+const BLOCK_END = "# <<< rove hooks"
+/** Verbs installed only while a plugin subscribes tool.* (volume gate). */
+const GATED_VERBS: ReadonlySet<string> = new Set(["tool-pre", "tool-post", "tool-failed"])
+/** Bound each hook spawn — `kobe hook` is sub-second; Kimi's default is 30s. */
+const HOOK_TIMEOUT_SECONDS = 10
+
+/** Where Kimi reads its config (the hooks live inline in config.toml).
+ *  `KIMI_CODE_HOME` is the same override `kimi-local/history.ts` honors. */
+export function kimiConfigPath(home: string = homedir()): string {
+  const override = process.env.KIMI_CODE_HOME?.trim()
+  return join(override && override.length > 0 ? override : join(home, ".kimi-code"), "config.toml")
+}
+
+/** Render kobe's `[[hooks]]` block. `inv` is injectable for tests. */
+export function renderKimiHookBlock(
+  inv: readonly string[] = kobeHookInvocation(),
+  opts: { toolEvents?: boolean } = {},
+): string {
+  const lines: string[] = [BLOCK_BEGIN]
+  for (const spec of KIMI_HOOK_EVENT_MAP) {
+    if (!opts.toolEvents && GATED_VERBS.has(spec.verb)) continue
+    // JSON.stringify doubles as a TOML basic-string quoter (same trick as
+    // codex-local/trust.ts).
+    const command = quoteShellArgv([...inv, "hook", spec.verb, "--engine", "kimi"])
+    lines.push("[[hooks]]")
+    lines.push(`event = ${JSON.stringify(spec.event)}`)
+    if (spec.matcher) lines.push(`matcher = ${JSON.stringify(spec.matcher)}`)
+    lines.push(`command = ${JSON.stringify(command)}`)
+    lines.push(`timeout = ${HOOK_TIMEOUT_SECONDS}`)
+    lines.push("")
+  }
+  lines.push(BLOCK_END)
+  return lines.join("\n")
+}
+
+/** Drop kobe's marker block (inclusive) from a config, preserving everything
+ *  else byte-for-byte. No block → the input unchanged. */
+export function removeKimiHookBlock(content: string): string {
+  const lines = content.split("\n")
+  const out: string[] = []
+  let inBlock = false
+  for (const line of lines) {
+    if (line.trim() === BLOCK_BEGIN) {
+      inBlock = true
+      // Also swallow the blank separator line the install appended before us.
+      if (out.length > 0 && out[out.length - 1] === "") out.pop()
+      continue
+    }
+    if (inBlock) {
+      if (line.trim() === BLOCK_END) inBlock = false
+      continue
+    }
+    out.push(line)
+  }
+  return out.join("\n")
+}
+
+/** Pure merge: config text → config text with kobe's block replaced (install)
+ *  or removed. The install appends at EOF — a `[[hooks]]` table there attaches
+ *  to nothing above it, so the user's config is never re-parsed. */
+export function mergeKimiHooks(
+  content: string,
+  install: boolean,
+  inv: readonly string[] = kobeHookInvocation(),
+  opts: { toolEvents?: boolean } = {},
+): string {
+  const base = removeKimiHookBlock(content)
+  if (!install) return base
+  const trimmed = base.replace(/\n+$/, "")
+  const lead = trimmed.length > 0 ? `${trimmed}\n\n` : ""
+  return `${lead}${renderKimiHookBlock(inv, opts)}\n`
+}
+
+export class KimiHookAdapter implements EngineHookAdapter {
+  readonly vendor = "kimi" as const
+
+  supportsHooks(): boolean {
+    return true
+  }
+
+  globalSettingsPath(): string {
+    return kimiConfigPath()
+  }
+
+  /** Kimi's stdin payload spells tool fields `tool_name`; the permission
+   *  event is always a permission (Kimi has no elicitation notification). */
+  activityDetailFromPayload(
+    kind: EngineActivityKind,
+    payload: Record<string, unknown>,
+  ): EngineActivityDetail | undefined {
+    if (kind === "awaiting-input") return { waiting: "permission" }
+    if (kind === "tool-pre" || kind === "tool-post" || kind === "tool-failed") {
+      return { tool: { ...(typeof payload.tool_name === "string" ? { name: payload.tool_name } : {}) } }
+    }
+    return undefined
+  }
+
+  /** Kimi pipes `session_id` on every hook; no transcript_path. */
+  sessionFromPayload(payload: Record<string, unknown>): EngineSessionRef | undefined {
+    if (typeof payload.session_id !== "string" || !payload.session_id) return undefined
+    return { sessionId: payload.session_id }
+  }
+
+  async installActivityHooks(settingsFilePath: string, opts: { toolEvents?: boolean } = {}): Promise<void> {
+    // Don't materialize ~/.kimi-code for a user who never installed Kimi —
+    // no config dir means no Kimi to read the hooks anyway.
+    if (!existsSync(dirname(settingsFilePath))) return
+    await editTomlConfig(settingsFilePath, (cur) => mergeKimiHooks(cur, true, undefined, opts))
+  }
+
+  async removeActivityHooks(settingsFilePath: string): Promise<void> {
+    if (!existsSync(settingsFilePath)) return
+    await editTomlConfig(settingsFilePath, (cur) => mergeKimiHooks(cur, false))
+  }
+
+  supportsWorktreeSync(): boolean {
+    return false
+  }
+
+  async removeWorktreeSyncHook(): Promise<void> {
+    /* Kimi never installed the legacy WorktreeCreate hook. */
+  }
+
+  async installWorktreeWatchHook(): Promise<void> {
+    /* Not wired — see module doc (Bash tool-name matcher unverified). */
+  }
+
+  async removeWorktreeWatchHook(): Promise<void> {
+    /* Never installed. */
+  }
+}
+
+/** Read → transform → write a TOML config, skipping the write when the
+ *  transform is a no-op. Best-effort: never blocks a launch (same contract
+ *  as `json-hook-adapter.ts#editJsonSettings`). */
+async function editTomlConfig(path: string, transform: (current: string) => string): Promise<void> {
+  try {
+    let current = ""
+    try {
+      current = await readFile(path, "utf8")
+    } catch (error) {
+      if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) return
+    }
+    const next = transform(current)
+    if (next === current) return
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, next)
+  } catch {
+    /* best-effort — never block launch */
+  }
+}

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -59,6 +59,7 @@ import {
   kimiHistoryReader,
 } from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
+import { KimiHookAdapter } from "./kimi-local/hook-adapter.ts"
 import { trustKimiWorktree } from "./kimi-local/trust.ts"
 import {
   type EngineTerminalTitle,
@@ -294,7 +295,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     trustWorktree: trustKimiWorktree,
     history: kimiHistoryReader,
     detectAccount: (deps) => detectKimiAccount(deps),
-    createHookAdapter: () => new NoopHookAdapter("kimi"),
+    createHookAdapter: () => new KimiHookAdapter(),
     createTurnDetector: () => new UnknownTurnDetector("kimi"),
   },
 }

--- a/packages/kobe/test/engine/kimi-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/kimi-hook-adapter.test.ts
@@ -1,0 +1,175 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  KIMI_HOOK_EVENT_MAP,
+  KOBE_KIMI_HOOK_EVENTS,
+  KimiHookAdapter,
+  kimiConfigPath,
+  mergeKimiHooks,
+  removeKimiHookBlock,
+  renderKimiHookBlock,
+} from "../../src/engine/kimi-local/hook-adapter.ts"
+
+// Pin the CLI invocation module whole (same rule as codex-hook-adapter.test:
+// vi.mock replaces EVERY export; a new invocation.ts function must be stubbed
+// here too or default-arg calls become undefined()).
+vi.mock("../../src/cli/invocation.ts", () => ({
+  kobeCliInvocation: () => ["kobe"],
+  kobeHookInvocation: () => ["kobe"],
+}))
+
+describe("KimiHookAdapter", () => {
+  const adapter = new KimiHookAdapter()
+
+  it("declares itself a wired hook engine writing ~/.kimi-code/config.toml", () => {
+    expect(adapter.vendor).toBe("kimi")
+    expect(adapter.supportsHooks()).toBe(true)
+    expect(adapter.globalSettingsPath()).toBe(kimiConfigPath())
+    expect(adapter.globalSettingsPath().endsWith(join(".kimi-code", "config.toml"))).toBe(true)
+  })
+
+  it("never installed the legacy WorktreeCreate hook → nothing to clean up", () => {
+    expect(adapter.supportsWorktreeSync()).toBe(false)
+  })
+
+  it("owns exactly the events Kimi can deliver safely", () => {
+    // Interrupt is the load-bearing one: Kimi fires it INSTEAD of Stop on a
+    // user interrupt (plugin-events.md §B).
+    for (const wired of ["SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "Interrupt", "PermissionRequest"]) {
+      expect(KOBE_KIMI_HOOK_EVENTS).toContain(wired)
+    }
+    // Notification stays out: no documented type filter → every idle prompt
+    // would read as needs-input.
+    expect(KOBE_KIMI_HOOK_EVENTS).not.toContain("Notification")
+  })
+
+  it("classifies PermissionRequest as a permission wait and reads tool names", () => {
+    expect(adapter.activityDetailFromPayload("awaiting-input", {})).toEqual({ waiting: "permission" })
+    expect(adapter.activityDetailFromPayload("tool-pre", { tool_name: "Bash" })).toEqual({ tool: { name: "Bash" } })
+    expect(adapter.activityDetailFromPayload("turn-complete", {})).toBeUndefined()
+  })
+
+  it("extracts session identity from the stdin payload", () => {
+    expect(adapter.sessionFromPayload({ session_id: "s1" })).toEqual({ sessionId: "s1" })
+    expect(adapter.sessionFromPayload({})).toBeUndefined()
+  })
+})
+
+describe("mergeKimiHooks (pure TOML block merge)", () => {
+  const inv = ["kobe"] as const
+
+  it("appends a marker-delimited block with one table per non-gated event", () => {
+    const out = mergeKimiHooks("", true, inv)
+    expect(out).toContain("# >>> rove hooks")
+    expect(out).toContain("# <<< rove hooks")
+    expect(out).toContain('event = "Interrupt"')
+    expect(out).toContain(`command = "'kobe' 'hook' 'turn-interrupted' '--engine' 'kimi'"`)
+    // Gated tool family is absent by default…
+    expect(out).not.toContain('event = "PreToolUse"')
+    // …and present when a plugin subscribes tool.* events.
+    expect(mergeKimiHooks("", true, inv, { toolEvents: true })).toContain('event = "PreToolUse"')
+  })
+
+  it("preserves the user's config outside the block, byte-for-byte", () => {
+    const user = 'default_model = "kimi-code/k3"\n\n[thinking]\nenabled = true\n'
+    const installed = mergeKimiHooks(user, true, inv)
+    expect(installed.startsWith('default_model = "kimi-code/k3"')).toBe(true)
+    expect(removeKimiHookBlock(installed)).toContain("[thinking]")
+    // remove → exactly the user's content again (modulo trailing whitespace)
+    expect(mergeKimiHooks(installed, false, inv).trim()).toBe(user.trim())
+  })
+
+  it("is idempotent — reinstall replaces kobe's block instead of stacking", () => {
+    const once = mergeKimiHooks("", true, inv)
+    const twice = mergeKimiHooks(once, true, inv)
+    expect(twice).toBe(once)
+  })
+
+  it("keeps the user's own [[hooks]] tables (only the marker block is owned)", () => {
+    const user = '[[hooks]]\nevent = "Stop"\ncommand = "my-own-hook"\n'
+    const installed = mergeKimiHooks(user, true, inv)
+    expect(installed).toContain('command = "my-own-hook"')
+    const removed = mergeKimiHooks(installed, false, inv)
+    expect(removed).toContain('command = "my-own-hook"')
+    expect(removed).not.toContain("# >>> rove hooks")
+  })
+
+  it("every event map row spells a real Kimi hook event", () => {
+    // The 13 documented events + Interrupt/PermissionRequest/PermissionResult
+    // verified against the installed 0.37.2 binary.
+    const known = new Set([
+      "PreToolUse",
+      "PostToolUse",
+      "PostToolUseFailure",
+      "UserPromptSubmit",
+      "Stop",
+      "StopFailure",
+      "SessionStart",
+      "SessionEnd",
+      "SubagentStart",
+      "SubagentStop",
+      "PreCompact",
+      "PostCompact",
+      "Notification",
+      "Interrupt",
+      "PermissionRequest",
+      "PermissionResult",
+    ])
+    for (const spec of KIMI_HOOK_EVENT_MAP) expect(known.has(spec.event)).toBe(true)
+  })
+})
+
+describe("KimiHookAdapter install/remove roundtrip (real file)", () => {
+  let dir: string
+  let file: string
+  const adapter = new KimiHookAdapter()
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "kobe-kimi-hooks-"))
+    file = join(dir, "config.toml")
+  })
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it("creates a missing config.toml inside an existing kimi dir", async () => {
+    await adapter.installActivityHooks(file)
+    const text = await readFile(file, "utf8")
+    expect(text).toContain('event = "SessionStart"')
+    expect(text).toContain('event = "Interrupt"')
+  })
+
+  it("skips entirely when the kimi config dir does not exist", async () => {
+    const missing = join(dir, "no-such-dir", "config.toml")
+    await adapter.installActivityHooks(missing)
+    await expect(readFile(missing, "utf8")).rejects.toThrow()
+  })
+
+  it("install → remove restores the user's config", async () => {
+    const user = 'default_model = "kimi-code/k3"\n'
+    await writeFile(file, user)
+    await adapter.installActivityHooks(file)
+    expect(await readFile(file, "utf8")).toContain("# >>> rove hooks")
+    await adapter.removeActivityHooks(file)
+    expect((await readFile(file, "utf8")).trim()).toBe(user.trim())
+  })
+
+  it("reinstall on an already-installed file skips the write (mtime stable)", async () => {
+    await adapter.installActivityHooks(file)
+    const before = await readFile(file, "utf8")
+    await adapter.installActivityHooks(file)
+    expect(await readFile(file, "utf8")).toBe(before)
+  })
+})
+
+describe("renderKimiHookBlock", () => {
+  it("bounds every hook with an explicit sub-30s timeout", () => {
+    const block = renderKimiHookBlock(["kobe"])
+    const tables = block.split("[[hooks]]").length - 1
+    const timeouts = block.split("timeout = 10").length - 1
+    expect(tables).toBeGreaterThan(0)
+    expect(timeouts).toBe(tables)
+  })
+})


### PR DESCRIPTION
## What

Replaces kimi's `NoopHookAdapter` with a real `KimiHookAdapter` — the third wired hook engine after claude/codex.

Kimi's hook store is TOML (`~/.kimi-code/config.toml [[hooks]]`), not the shared settings.json shape, so the adapter implements the `EngineHookAdapter` contract over a marker-delimited block (`# >>> rove hooks` … `# <<< rove hooks`): append-at-EOF, merge-safe (user config outside the block never parsed/rewritten), idempotent (identical content skips the write), and it refuses to materialize `~/.kimi-code` for users who never installed Kimi.

Event map highlights:
- `Interrupt` → `turn-interrupted` — Kimi fires no `Stop` on a user interrupt; without this the turn strands in `running` (the reducer already handled the verb, see plugin-events.md §B)
- `PermissionRequest` → `awaiting-input` — safe as an exit-0 observer on Kimi (unlike Codex, where the same event is a sync decision hook we stay away from)
- `Notification` deliberately NOT wired (no documented type filter → every idle prompt would read as needs-input)
- Tool family gated behind the existing plugin tool.* volume gate

## Claude/Codex untouched

No changes to the claude/codex adapters, json-hooks merge core, hook-cmd dispatch, or reducer — the kimi adapter plugs into the existing `activityHookAdapters()` enumeration and `--engine kimi` tag.

## Verified

- Event vocabulary + payload fields verified against the installed kimi 0.37.2 binary
- Live headless fire with an isolated `KIMI_CODE_HOME`: `SessionStart`/`UserPromptSubmit`/`Stop` all fired `kobe hook <verb> --engine kimi` with `session_id` + `cwd` in the payload
- 15 new unit tests; full suite 3336 green; lint + typecheck green