### PR TITLE
fix: land --delete-branch removes the worktree so the branch is actually deleted

### DIFF
--- a/.changeset/land-delete-branch-removes-worktree.md
+++ b/.changeset/land-delete-branch-removes-worktree.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`land --delete-branch` now actually deletes the branch. git refuses to delete a branch a live worktree still has checked out, so passing `--delete-branch` without `--remove-worktree` used to silently do nothing — the failed `git branch -D` was swallowed. `--delete-branch` now implies removing the worktree first (branch and worktree drop together, matching the `delete` verb), and the branch is deleted only once that removal succeeds; a removal refused for a dirty worktree, the base checkout, or the caller's own worktree keeps the branch and lets the land stand.

--- a/docs/API.md
+++ b/docs/API.md
@@ -356,6 +356,9 @@ to do) from `dispatch_failed` (needs a human).
   forces: a dirty worktree, the base checkout, and the worktree the caller is
   running from are all refused, and the outcome lands in the result's
   `worktree` field (`{ removed, reason? }`) instead of failing the land.
+  `--delete-branch` implies removing the worktree first — git can't delete a
+  branch a live worktree still has checked out — so the branch is dropped only
+  once that removal succeeds (a refused removal keeps the branch, land stands).
 - `delete --task-id ID [--force] [--delete-branch]`: remove a task and its
   worktree. **The git branch stays** unless `--delete-branch` is passed —
   git is the durable record, the task row is not. Needs `--force` on a

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -261,17 +261,19 @@ export async function land(ctx: VerbContext): Promise<unknown> {
   const taskId = ctx.args.require("task-id")
   const strategy = ctx.args.str("strategy") === "squash" ? "squash" : "merge"
   const removeWorktree = ctx.args.bool("remove-worktree") ?? false
+  const deleteBranch = ctx.args.bool("delete-branch") ?? false
   let res: { result: unknown }
   try {
     res = await daemon.request<{ result: unknown }>("task.land", {
       taskId,
       strategy,
-      deleteBranch: ctx.args.bool("delete-branch") ?? false,
+      deleteBranch,
       archive: ctx.args.bool("then-archive") ?? false,
       removeWorktree,
       // The daemon refuses to remove the worktree the caller is running from —
-      // it can only know where the caller is if we tell it.
-      ...(removeWorktree ? { callerCwd: process.cwd() } : {}),
+      // it can only know where the caller is if we tell it. --delete-branch
+      // removes the worktree too, so it needs the same guard.
+      ...(removeWorktree || deleteBranch ? { callerCwd: process.cwd() } : {}),
     })
   } catch (err) {
     throw landRecoveryError(err, taskId)

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -33,7 +33,9 @@ export interface LandTaskInput {
 /** Options for a full land: strategy + post-land cleanup. */
 export interface LandTaskOpts {
   readonly strategy?: LandStrategy
-  /** Delete the task's branch after a successful land. */
+  /** Delete the task's branch after a successful land. Implies removing the
+   *  worktree first — git can't delete a branch a live worktree has checked
+   *  out — so the branch is dropped only once that removal succeeds. */
   readonly deleteBranch?: boolean
   /** Archive the task after a successful land (moves it off the active board). */
   readonly archive?: boolean
@@ -68,11 +70,24 @@ export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: 
   if (task.kind === "main") throw new Error("landTask: a main task has no branch to land")
   if (task.kind === "dir") throw new Error("landTask: a directory task has no Rove-managed branch to land")
   const result = await landTask(task, { strategy: opts.strategy })
-  // Worktree removal runs BEFORE branch deletion: git refuses to delete a
-  // branch that's still checked out in a live worktree, so the reverse order
-  // would leave --delete-branch a silent no-op when combined with it.
-  const worktree = opts.removeWorktree ? await removeLandedWorktree(task, opts.callerCwd, deps) : undefined
-  if (opts.deleteBranch) await deps.worktrees.deleteBranch(task.repo, result.branch, { force: true })
+  // git refuses to delete a branch that's still checked out in a live worktree,
+  // so --delete-branch can only take effect once the worktree is gone. It
+  // therefore IMPLIES removing the worktree (branch and worktree drop together,
+  // matching the `delete` verb) — and the branch is deleted only once removal
+  // actually succeeds. Without that gate `git branch -D` runs behind
+  // `allowFail` while the worktree still holds the branch, leaving
+  // --delete-branch a silent no-op (the exact trap when it was passed alone).
+  const hadWorktreeOnDisk = task.worktreePath.trim().length > 0
+  const removeWorktree = opts.removeWorktree === true || opts.deleteBranch === true
+  const worktree = removeWorktree ? await removeLandedWorktree(task, opts.callerCwd, deps) : undefined
+  // The branch is checked out nowhere — safe to drop — only when its worktree
+  // was just removed, or the task never had one on disk. A refused removal
+  // (dirty, the caller's own worktree, the base checkout) leaves it checked
+  // out, so we skip the delete rather than let it silently fail.
+  const branchDeletable = !hadWorktreeOnDisk || worktree?.removed === true
+  if (opts.deleteBranch && branchDeletable) {
+    await deps.worktrees.deleteBranch(task.repo, result.branch, { force: true })
+  }
   if (opts.archive) await deps.setArchived(task.id, true)
   return worktree ? { ...result, worktree } : result
 }
@@ -127,7 +142,8 @@ export interface LandResult {
   readonly landedOn: string
   /** Short SHA of the merge/commit that landed the work. */
   readonly commit: string
-  /** Present only when `removeWorktree` was requested — the cleanup outcome. */
+  /** Present when the worktree was removed as part of cleanup — i.e. whenever
+   *  `removeWorktree` OR `deleteBranch` was requested — carrying that outcome. */
   readonly worktree?: LandWorktreeCleanup
 }
 

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -266,3 +266,105 @@ describe("landTaskWithCleanup --remove-worktree", () => {
     expect(fs.existsSync(wt)).toBe(true)
   })
 })
+
+describe("landTaskWithCleanup --delete-branch", () => {
+  let wt: string
+
+  /** Real worktree on branch `feat` with one committed file, base back on main. */
+  function makeWorktree(): void {
+    wt = path.join(tmpRoot, "wt")
+    git(["worktree", "add", "-b", "feat", wt], repo)
+    fs.writeFileSync(path.join(wt, "b.txt"), "feature\n")
+    git(["add", "."], wt)
+    git(["commit", "-m", "feat commit"], wt)
+  }
+
+  function deps() {
+    const cleared: string[] = []
+    return {
+      cleared,
+      deps: {
+        worktrees: new GitWorktreeManager(),
+        setArchived: async () => {},
+        clearWorktreePath: async (id: unknown) => {
+          cleared.push(String(id))
+        },
+      },
+    }
+  }
+
+  function branchExists(name: string): boolean {
+    return spawnSync("git", ["branch", "--list", name], { cwd: repo, encoding: "utf8" }).stdout.trim().length > 0
+  }
+
+  test("--delete-branch alone removes the worktree first, then deletes the branch", async () => {
+    // The regression: git refuses to delete a branch checked out in a live
+    // worktree, so --delete-branch on its own used to silently no-op behind
+    // `allowFail`. It now implies removing the worktree, so the branch goes.
+    makeWorktree()
+    const { deps: d, cleared } = deps()
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { deleteBranch: true }, d)
+    expect(res.worktree).toEqual({ removed: true })
+    expect(fs.existsSync(wt)).toBe(false)
+    expect(branchExists("feat")).toBe(false)
+    expect(cleared).toEqual(["t-land"])
+    expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true) // the merge still landed
+  })
+
+  test("--delete-branch with --remove-worktree drops both", async () => {
+    makeWorktree()
+    const { deps: d } = deps()
+    const res = await landTaskWithCleanup(
+      { ...task("feat"), worktreePath: wt },
+      { deleteBranch: true, removeWorktree: true },
+      d,
+    )
+    expect(res.worktree).toEqual({ removed: true })
+    expect(fs.existsSync(wt)).toBe(false)
+    expect(branchExists("feat")).toBe(false)
+  })
+
+  test("a refused worktree removal keeps the branch and lets the land stand", async () => {
+    // Dirty worktree → removal is refused (no force), so the branch stays
+    // checked out and must NOT be deleted. The land itself still holds.
+    makeWorktree()
+    fs.writeFileSync(path.join(wt, "wip.txt"), "uncommitted\n")
+    const { deps: d, cleared } = deps()
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { deleteBranch: true }, d)
+    expect(res.worktree?.removed).toBe(false)
+    expect(res.worktree?.reason).toMatch(/dirty/)
+    expect(branchExists("feat")).toBe(true)
+    expect(cleared).toEqual([])
+    expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true)
+  })
+
+  test("the caller's own worktree is refused, so its branch survives", async () => {
+    makeWorktree()
+    const { deps: d } = deps()
+    const res = await landTaskWithCleanup(
+      { ...task("feat"), worktreePath: wt },
+      { deleteBranch: true, callerCwd: wt },
+      d,
+    )
+    expect(res.worktree?.removed).toBe(false)
+    expect(res.worktree?.reason).toMatch(/caller's own worktree/)
+    expect(fs.existsSync(wt)).toBe(true)
+    expect(branchExists("feat")).toBe(true)
+  })
+
+  test("a task that never materialised a worktree still gets its branch deleted", async () => {
+    // Branch exists in the repo with a commit ahead of main but is checked out
+    // nowhere (empty worktreePath) — safe to drop directly, no worktree to
+    // remove.
+    git(["checkout", "-b", "feat"], repo)
+    write("b.txt", "feature\n")
+    git(["add", "."], repo)
+    git(["commit", "-m", "feat commit"], repo)
+    git(["checkout", "main"], repo)
+    const { deps: d } = deps()
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: "" }, { deleteBranch: true }, d)
+    expect(res.worktree?.removed).toBe(false)
+    expect(branchExists("feat")).toBe(false)
+    expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Direction

(a) bugs / correctness — found by direct code review of the orchestrator land/cleanup path.

## Problem

`rove api land --task-id X --delete-branch` silently fails to delete the branch unless `--remove-worktree` is *also* passed.

Whenever `landTask` succeeds, the branch is necessarily still checked out in a live worktree (an unmaterialised task has an empty branch and `landTask` throws early). git refuses to delete a branch that a worktree has checked out — even `git branch -D` — and `deleteBranchIn` runs it with `allowFail: true`, so the non-zero exit is swallowed. Nothing is thrown and the `LandResult` carries no signal. The result: `--delete-branch` passed *alone* was **always** a silent no-op, never a rare edge.

```
error: cannot delete branch 'feat' used by worktree at '…'   # exit 1, swallowed
```

The old code even acknowledged the ordering ("worktree removal runs BEFORE branch deletion") but only handled it for the *combined* `--delete-branch --remove-worktree` case; the unpaired case fell straight through the gap. No test exercised the `deleteBranch` path at all.

## Fix

`--delete-branch` now **implies removing the worktree first** — the branch and its worktree drop together, exactly as the `delete` verb already does. The branch is deleted only once that removal actually succeeds; a removal refused for a dirty worktree, the base checkout, or the caller's own worktree keeps the branch checked out and simply lets the land stand (the outcome is reported in the result's `worktree` field, never thrown). A task that never materialised a worktree (branch checked out nowhere) still has its branch dropped directly.

- `src/orchestrator/land.ts` — `--delete-branch` triggers `removeLandedWorktree`, and branch deletion is gated on the worktree being gone (or never having existed on disk).
- `src/cli/api/handlers-tasks.ts` — the CLI now sends `callerCwd` when `--delete-branch` is set too, so the "refusing to remove the caller's own worktree" safety guard fires for the implied removal (previously it was only sent for `--remove-worktree`).
- `docs/API.md` — documents that `--delete-branch` removes the worktree first.

## Verification

- Added 5 tests to `test/orchestrator/land.test.ts` (real git, no mocks) covering: `--delete-branch` alone (the regression), paired with `--remove-worktree`, a dirty worktree refusing removal (branch kept, land stands), the caller's own worktree refused, and a never-materialised task. All 17 land tests pass.
- `bun run lint` and `bun run typecheck` both green.
- Confirmed the underlying git behavior directly (`git branch -D` on a branch checked out in a linked worktree exits 1).
- Pre-existing, unrelated failures in `test/orchestrator/active-task.test.ts` (`vi.unstubAllEnvs is not a function`, a Bun/vitest-compat issue) reproduce on clean `main` and are not touched by this change.

## Follow-ups (deferred, not in scope)

- The TUI never sets `deleteBranch` (`worktrees-page.tsx` calls `landTask(taskId)` with no opts), so this only surfaces through the CLI/API today — a TUI affordance to delete-on-land could be added separately.
- A separately-reported candidate (Codex binary discovery omitting the `~/.nvm/versions/node/*/bin` scan that Claude's discovery performs) was left out to keep this PR to a single slice.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lp6QmumFycagkNiCp1wmBP)_