### PR TITLE
feat: declarative screen-state classification for marker-less engines

### DIFF
--- a/.changeset/screen-state-manifests.md
+++ b/.changeset/screen-state-manifests.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Engines without hooks or transcript markers no longer sit at "unknown": the quiescence poll now classifies the visible screen against engine-declared rules (working / blocked / idle), so copilot tabs — and kimi sessions before hooks are approved — show real working and needs-input badges. Hooks remain the first authority; the screen read is the fallback layer.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -20,7 +20,7 @@ you need git-level isolation and a separate branch.
 |---|---|---|---|---|---|
 | Claude Code | `claude` | ✓ | ✓ | ✓ | ✓ |
 | Codex | `codex` | ✓ | ✓ (after you trust hooks) | ✓ | ✓ + effort levels |
-| GitHub Copilot | `copilot` | ✓ | partial | ✓ | — |
+| GitHub Copilot | `copilot` | ✓ | ✓ (screen-based) | ✓ | — |
 | Kimi Code | `kimi` | ✓ | ✓ | handoff only | — |
 | Anything you register | custom | — | — | — | — |
 
@@ -87,10 +87,13 @@ The sidebar shows what each session is doing: **working**, **done**, or
 **needs input**. There's nothing to configure — Rove reads the engine's own
 hook events, falling back to its transcript when hooks aren't available.
 
-One thing worth knowing: **only claude, codex, and kimi can show "needs
-input"**. Distinguishing "waiting on a permission prompt" from "thinking"
-requires a hook; the other engines top out at working/done. Rove labels the
-gap honestly rather than guessing.
+One thing worth knowing: **the depth of the badge depends on the engine**.
+Claude, codex, and kimi report through hooks — the full working / done /
+needs-input vocabulary, sub-second. Engines without hooks or a readable
+transcript (copilot today) fall back to screen reading: Rove classifies the
+visible terminal against engine-declared rules, which still distinguishes
+working from waiting-on-you but can't see a completed turn the way a
+transcript marker can. Rove labels the gap honestly rather than guessing.
 
 Codex won't run Rove's hooks until you trust them once via `/hooks`, so Codex
 badges stay dark until you approve. That's by design — Rove writes the hook

--- a/packages/kobe/src/engine/copilot-local/screen.ts
+++ b/packages/kobe/src/engine/copilot-local/screen.ts
@@ -1,0 +1,24 @@
+/**
+ * Copilot CLI screen-state manifest — hint strings observed in the Copilot
+ * CLI's bottom bar (cross-checked against refs/herdr
+ * src/detect/manifests/github-copilot.toml). Copilot persists no
+ * completion marker and has no wired hooks, so this is its ONLY
+ * working/blocked signal; without it every copilot tab reads "unknown".
+ */
+
+import type { EngineScreenManifest } from "../screen-state.ts"
+
+export const COPILOT_SCREEN_MANIFEST: EngineScreenManifest = {
+  rules: [
+    // A selection dialog (permission prompt, picker) shows a confirm hint
+    // NEXT TO the cancel hint — blocked on the user. Declared first so a
+    // dialog under a running turn reads blocked, not working.
+    {
+      state: "blocked",
+      any: ["enter to select", "enter to confirm", "enter to submit", "enter accept"],
+      all: ["esc"],
+    },
+    // A running turn shows only the interrupt hint.
+    { state: "working", any: ["esc to cancel", "esc cancel", "esc again to cancel", "esc interrupt"] },
+  ],
+}

--- a/packages/kobe/src/engine/kimi-local/screen.ts
+++ b/packages/kobe/src/engine/kimi-local/screen.ts
@@ -1,0 +1,24 @@
+/**
+ * Kimi Code screen-state manifest — the poll-side fallback for kimi
+ * sessions whose hooks aren't installed yet (hooks are the first
+ * authority; the hook-wins merge supersedes this whenever they report).
+ * Patterns observed in kimi 0.37.2's TUI (cross-checked against
+ * refs/herdr src/detect/manifests/kimi.toml).
+ */
+
+import type { EngineScreenManifest } from "../screen-state.ts"
+
+export const KIMI_SCREEN_MANIFEST: EngineScreenManifest = {
+  rules: [
+    // Approval panel: "↵ confirm" beside approve/reject choices.
+    { state: "blocked", all: ["↵ confirm"], any: ["approve", "reject", "revise"] },
+    // Question panel.
+    { state: "blocked", all: ["↑↓ select", "esc cancel"] },
+    // Running turn: the moon-phase spinner frames, or a braille spinner
+    // beside a progress verb.
+    {
+      state: "working",
+      lineRegex: ["^\\s*(🌕|🌖|🌗|🌘|🌑|🌒|🌓|🌔)", "^\\s*[\\u2800-\\u28FF]+\\s*(thinking|working|using )"],
+    },
+  ],
+}

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -51,6 +51,7 @@ import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
 import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
 import { codexSessionIdFromTitle } from "./codex-local/terminal-title.ts"
 import { trustCodexWorktree } from "./codex-local/trust.ts"
+import { COPILOT_SCREEN_MANIFEST } from "./copilot-local/screen.ts"
 import {
   EMPTY_HISTORY,
   claudeHistoryReader,
@@ -60,7 +61,9 @@ import {
 } from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
 import { KimiHookAdapter } from "./kimi-local/hook-adapter.ts"
+import { KIMI_SCREEN_MANIFEST } from "./kimi-local/screen.ts"
 import { trustKimiWorktree } from "./kimi-local/trust.ts"
+import type { EngineScreenManifest } from "./screen-state.ts"
 import {
   type EngineTerminalTitle,
   stripStatusPrefix,
@@ -202,6 +205,14 @@ export interface EngineRegistryEntry {
    * per-turn attribution kobe can read (nothing is guessed for it).
    */
   readonly readTurns?: EngineTurnReader
+  /**
+   * Declarative screen-state rules for engines WITHOUT persisted completion
+   * markers (see `engine/screen-state.ts`): the quiescence poll classifies
+   * each pane capture into working/blocked/idle instead of "unknown".
+   * Engines with markers don't declare one — the transcript is the better
+   * authority, and hooks supersede both (`turn-state-merge.ts`).
+   */
+  readonly screenManifest?: EngineScreenManifest
 }
 
 // The per-vendor readers live in `history-readers.ts` (file-size cap);
@@ -280,6 +291,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     createHookAdapter: () => new NoopHookAdapter("copilot"),
     // Copilot persists no turn-completion marker kobe can read yet.
     createTurnDetector: () => new UnknownTurnDetector("copilot"),
+    screenManifest: COPILOT_SCREEN_MANIFEST,
   },
   kimi: {
     vendor: "kimi",
@@ -297,6 +309,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
     detectAccount: (deps) => detectKimiAccount(deps),
     createHookAdapter: () => new KimiHookAdapter(),
     createTurnDetector: () => new UnknownTurnDetector("kimi"),
+    screenManifest: KIMI_SCREEN_MANIFEST,
   },
 }
 

--- a/packages/kobe/src/engine/screen-state.ts
+++ b/packages/kobe/src/engine/screen-state.ts
@@ -1,0 +1,79 @@
+/**
+ * Declarative screen-state classification — the poll-side fallback for
+ * engines WITHOUT persisted completion markers (copilot, kimi's no-hook
+ * mode, future plugin-registered engines).
+ *
+ * The quiescence poll already captures each engine pane's text; for
+ * marker-less engines it could only ever say "unknown". This module turns
+ * that capture into working / blocked / idle by evaluating an engine-owned
+ * rule list against the visible bottom of the screen — the same shape
+ * herdr's agent-detection manifests use (refs/herdr
+ * src/detect/manifests/*.toml, studied with attribution), reduced to the
+ * three checks kobe actually needs: substring conjunction, substring
+ * alternation, and per-line regex.
+ *
+ * DATA, not code, on purpose: an engine (or later a plugin) declares a
+ * manifest; no neutral layer names a vendor. First matching rule wins, so
+ * blocked rules go before working rules. A null answer means "no rule
+ * matched" — callers keep their previous reading rather than flapping.
+ *
+ * Pure (no I/O), so it's unit-tested directly.
+ */
+
+/** One classification rule. All present conditions must hold. */
+export interface ScreenRule {
+  /** State this rule claims when it matches. */
+  readonly state: "working" | "blocked" | "idle"
+  /** Trailing NON-EMPTY capture lines the rule looks at (default 12) —
+   *  engine dialogs and status lines live at the bottom of the screen. */
+  readonly bottomLines?: number
+  /** Every string must appear (case-insensitive) somewhere in the region. */
+  readonly all?: readonly string[]
+  /** At least one of these strings must appear (case-insensitive). */
+  readonly any?: readonly string[]
+  /** At least one region line must match one of these regexes (case-insensitive). */
+  readonly lineRegex?: readonly string[]
+}
+
+/** An engine's screen-state manifest. Rules are evaluated in order; the
+ *  first match wins (declare blocked before working). */
+export interface EngineScreenManifest {
+  readonly rules: readonly ScreenRule[]
+}
+
+const DEFAULT_BOTTOM_LINES = 12
+
+/** The trailing non-empty lines of a capture, oldest→newest. */
+function bottomRegion(captureText: string, lines: number): readonly string[] {
+  const nonEmpty = captureText.split("\n").filter((l) => l.trim().length > 0)
+  return nonEmpty.slice(-lines)
+}
+
+function ruleMatches(rule: ScreenRule, region: readonly string[]): boolean {
+  const haystack = region.join("\n").toLowerCase()
+  if (rule.all && !rule.all.every((s) => haystack.includes(s.toLowerCase()))) return false
+  if (rule.any && !rule.any.some((s) => haystack.includes(s.toLowerCase()))) return false
+  if (rule.lineRegex) {
+    const regexes = rule.lineRegex.map((r) => new RegExp(r, "i"))
+    if (!region.some((line) => regexes.some((re) => re.test(line)))) return false
+  }
+  // A rule with no conditions matches nothing (a bare state claim would
+  // classify every screen).
+  return Boolean(rule.all || rule.any || rule.lineRegex)
+}
+
+/**
+ * Classify a pane capture against an engine's manifest. `null` = no rule
+ * matched — the caller should keep its previous reading.
+ */
+export function classifyScreen(
+  manifest: EngineScreenManifest,
+  captureText: string,
+): "working" | "blocked" | "idle" | null {
+  for (const rule of manifest.rules) {
+    const region = bottomRegion(captureText, rule.bottomLines ?? DEFAULT_BOTTOM_LINES)
+    if (region.length === 0) continue
+    if (ruleMatches(rule, region)) return rule.state
+  }
+  return null
+}

--- a/packages/kobe/src/engine/turn-detector.ts
+++ b/packages/kobe/src/engine/turn-detector.ts
@@ -15,8 +15,9 @@ import * as codexHistory from "@/engine/codex-local/history"
 import type { VendorId } from "@/types/vendor"
 import { engineEntry } from "./registry.ts"
 
-/** `needs_input` is hook-only (permission prompt / question dialog) — the
- *  quiescence poll can't observe it; only `turn-state-merge.ts` produces it. */
+/** `needs_input` comes from hooks (permission prompt / question dialog via
+ *  `turn-state-merge.ts`) or, for marker-less engines with a screen
+ *  manifest, from the poll's screen classifier (`engine/screen-state.ts`). */
 export type ChatTabTurnState = "idle" | "running" | "done" | "error" | "needs_input" | "unknown"
 
 export interface TurnCompletionMarker {

--- a/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
+++ b/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
@@ -162,11 +162,15 @@ export function useTurnPolls(deps: {
       // real first capture (the Ops pane's prime-before-poll contract).
       if (!reg.has(target.key)) continue
       const tabId = tab.id
-      const detector = engineEntry(target.vendor).createTurnDetector()
+      const entry = engineEntry(target.vendor)
+      const detector = entry.createTurnDetector()
       const dispose = startTurnStatusPoll(
         {
           worktree: worktreeRef.current,
           detector,
+          // Marker-less engines (copilot/kimi-without-hooks) classify the
+          // capture declaratively instead of publishing "unknown".
+          ...(entry.screenManifest ? { screenManifest: entry.screenManifest } : {}),
           // Shared mode (issue #24): the daemon's transcript.activity push
           // supplies completion reads + drives the adaptive capture
           // cadence; null (no daemon data) falls back to fixed-cadence

--- a/packages/kobe/src/tui/ops/activity-monitor.ts
+++ b/packages/kobe/src/tui/ops/activity-monitor.ts
@@ -9,6 +9,7 @@
  */
 
 import { createHash } from "node:crypto"
+import { type EngineScreenManifest, classifyScreen } from "@/engine/screen-state"
 import type { ChatTabTurnState } from "@/engine/turn-detector"
 import type { TranscriptActivity } from "../../client/remote-orchestrator"
 import { TURN_STATUS_POLL_MS, nextTurnStatusPollDelay } from "./activity-poll"
@@ -41,6 +42,15 @@ export interface TurnStatusIo {
 export interface TurnStatusOpts {
   readonly worktree: string
   readonly detector: TurnDetectorLike
+  /**
+   * Screen-state manifest for engines WITHOUT completion markers — the
+   * declarative working/blocked/idle rules `classifyScreen` evaluates
+   * against each pane capture, so a copilot/kimi tab reads a real state
+   * instead of "unknown". Ignored while the detector supports markers
+   * (the transcript is the better authority). `null` from the classifier
+   * keeps the previous published state (no flapping).
+   */
+  readonly screenManifest?: EngineScreenManifest
   /** Whether the daemon is publishing transcript activity for this worktree. */
   readonly usingShared: () => boolean
   /** This worktree's slice of the daemon push (`null` when absent). */
@@ -85,12 +95,29 @@ export function startTurnStatusPoll(opts: TurnStatusOpts, io: TurnStatusIo): () 
     return (await detector.latestCompletion(opts.worktree))?.id ?? null
   }
 
+  /** Marker-less fallback state: classify the capture when a manifest is
+   *  declared; keep the previous reading on a null answer. */
+  function screenState(captureText: string): ChatTabTurnState | null {
+    if (!opts.screenManifest) return "unknown"
+    const state = classifyScreen(opts.screenManifest, captureText)
+    if (state === "working") return "running"
+    if (state === "blocked") return "needs_input"
+    if (state === "idle") return "idle"
+    return published === null ? "unknown" : null
+  }
+
   async function prime(): Promise<void> {
     try {
-      paneHash = fingerprint(await io.capturePane())
+      const capture = await io.capturePane()
+      paneHash = fingerprint(capture)
       baselineCompletionId = await latestCompletionId()
       baselinePrimed = true
-      await publish(detector.supportsCompletionMarkers() ? "idle" : "unknown")
+      if (detector.supportsCompletionMarkers()) {
+        await publish("idle")
+      } else {
+        const state = screenState(capture)
+        if (state !== null) await publish(state)
+      }
     } catch {
       // Transient failures during the delete→kill teardown window must not
       // crash this crash-net-less pane process; the next poll() re-primes.
@@ -105,7 +132,8 @@ export function startTurnStatusPoll(opts: TurnStatusOpts, io: TurnStatusIo): () 
     }
     const shared = opts.usingShared()
     try {
-      const nextPaneHash = fingerprint(await io.capturePane())
+      const capture = await io.capturePane()
+      const nextPaneHash = fingerprint(capture)
       if (disposed) return
       // Lazily seed the baseline if shared activity arrived only after prime
       // ran with no entry — so the first daemon-pushed completion isn't
@@ -123,9 +151,16 @@ export function startTurnStatusPoll(opts: TurnStatusOpts, io: TurnStatusIo): () 
         paneHash = nextPaneHash
         observedPaneActivity = true
         stablePolls = 0
-        await publish(detector.supportsCompletionMarkers() ? "running" : "unknown")
+        if (detector.supportsCompletionMarkers()) await publish("running")
       } else if (observedPaneActivity) {
         stablePolls++
+      }
+      // Marker-less engines: the screen IS the state source — classify on
+      // every poll (a dialog can appear without the hash logic noticing a
+      // "turn"), not just on hash change.
+      if (!detector.supportsCompletionMarkers()) {
+        const state = screenState(capture)
+        if (state !== null) await publish(state)
       }
 
       if (detector.supportsCompletionMarkers() && observedPaneActivity && stablePolls >= STABLE_POLLS_FOR_DONE) {

--- a/packages/kobe/test/engine/screen-state.test.ts
+++ b/packages/kobe/test/engine/screen-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { COPILOT_SCREEN_MANIFEST } from "../../src/engine/copilot-local/screen.ts"
+import { KIMI_SCREEN_MANIFEST } from "../../src/engine/kimi-local/screen.ts"
+import { type EngineScreenManifest, classifyScreen } from "../../src/engine/screen-state.ts"
+
+describe("classifyScreen", () => {
+  const manifest: EngineScreenManifest = {
+    rules: [
+      { state: "blocked", all: ["proceed?"], any: ["yes", "❯"] },
+      { state: "working", any: ["esc to interrupt"] },
+    ],
+  }
+
+  it("first matching rule wins (blocked declared before working)", () => {
+    const capture = "Do you want to proceed?\n❯ 1. Yes\n  2. No\nesc to interrupt"
+    expect(classifyScreen(manifest, capture)).toBe("blocked")
+  })
+
+  it("matches case-insensitively over the bottom region", () => {
+    expect(classifyScreen(manifest, "thinking…\nESC TO INTERRUPT")).toBe("working")
+  })
+
+  it("returns null when nothing matches (caller keeps previous state)", () => {
+    expect(classifyScreen(manifest, "$ ls\nfile.txt")).toBeNull()
+    expect(classifyScreen(manifest, "")).toBeNull()
+  })
+
+  it("only looks at the trailing bottomLines of the capture", () => {
+    const rule: EngineScreenManifest = { rules: [{ state: "working", bottomLines: 2, any: ["spinner"] }] }
+    const capture = `spinner up here\n${Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n")}`
+    expect(classifyScreen(rule, capture)).toBeNull()
+    expect(classifyScreen(rule, `${capture}\nspinner`)).toBe("working")
+  })
+
+  it("a rule with no conditions never matches", () => {
+    expect(classifyScreen({ rules: [{ state: "idle" }] }, "anything")).toBeNull()
+  })
+
+  it("lineRegex matches per line, not across the joined region", () => {
+    const rule: EngineScreenManifest = { rules: [{ state: "working", lineRegex: ["^\\s*⠋ thinking"] }] }
+    expect(classifyScreen(rule, "  ⠋ thinking hard")).toBe("working")
+    expect(classifyScreen(rule, "prefix ⠋ thinking")).toBeNull()
+  })
+})
+
+describe("COPILOT_SCREEN_MANIFEST", () => {
+  it("reads a selection dialog as blocked even while a cancel hint shows", () => {
+    expect(classifyScreen(COPILOT_SCREEN_MANIFEST, "Choose an option\nEnter to select · Esc to cancel")).toBe("blocked")
+  })
+  it("reads a bare interrupt hint as working", () => {
+    expect(classifyScreen(COPILOT_SCREEN_MANIFEST, "Working on it…\nEsc to cancel")).toBe("working")
+  })
+  it("stays silent on a plain shell", () => {
+    expect(classifyScreen(COPILOT_SCREEN_MANIFEST, "$ git status\nclean")).toBeNull()
+  })
+})
+
+describe("KIMI_SCREEN_MANIFEST", () => {
+  it("reads the approval panel as blocked", () => {
+    expect(classifyScreen(KIMI_SCREEN_MANIFEST, "Run this command?\n▶ Approve\n  Reject\n↵ confirm")).toBe("blocked")
+  })
+  it("reads the moon spinner as working", () => {
+    expect(classifyScreen(KIMI_SCREEN_MANIFEST, "🌖\nsome output")).toBe("working")
+  })
+  it("reads a braille progress line as working", () => {
+    expect(classifyScreen(KIMI_SCREEN_MANIFEST, "⠧ Thinking...")).toBe("working")
+  })
+})

--- a/packages/kobe/test/tui-react/ops-activity-monitor.test.ts
+++ b/packages/kobe/test/tui-react/ops-activity-monitor.test.ts
@@ -129,4 +129,40 @@ describe("startTurnStatusPoll", () => {
     expect(published).toEqual(["unknown"])
     stop()
   })
+
+  it("marker-less engines WITH a screen manifest classify the capture", async () => {
+    let pane = "$ shell prompt"
+    const { published, io } = makeIo(() => pane)
+    const stop = startTurnStatusPoll(
+      {
+        worktree: "/wt",
+        detector: { supportsCompletionMarkers: () => false, latestCompletion: async () => null },
+        usingShared: () => false,
+        sharedEntry: () => null,
+        screenManifest: {
+          rules: [
+            { state: "blocked", all: ["proceed?"] },
+            { state: "working", any: ["esc to cancel"] },
+          ],
+        },
+      },
+      io,
+    )
+    // prime: nothing matches → first read publishes unknown (never silence)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(published).toEqual(["unknown"])
+    // a running turn shows the interrupt hint
+    pane = "output…\nEsc to cancel"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    expect(published).toEqual(["unknown", "running"])
+    // a dialog appears WITHOUT the pane hash logic mattering → needs_input
+    pane = "Do you want to proceed?\n❯ Yes"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS)
+    expect(published).toEqual(["unknown", "running", "needs_input"])
+    // an unrecognized screen keeps the previous reading (no flapping)
+    pane = "something unrecognizable"
+    await vi.advanceTimersByTimeAsync(TURN_STATUS_POLL_MS * 2)
+    expect(published).toEqual(["unknown", "running", "needs_input"])
+    stop()
+  })
 })


### PR DESCRIPTION
## What

Marker-less engines (copilot; kimi sessions before hook approval) sat at a permanent `unknown` in the quiescence poll — the poll could hash the pane for activity but had no vocabulary to say what the engine was doing.

This adds `engine/screen-state.ts`: a pure, declarative classifier that evaluates an **engine-owned rule manifest** (substring conjunction/alternation + per-line regex over the bottom of the pane capture) into working / blocked / idle. The shape follows herdr's agent-detection manifests (refs/herdr, studied with attribution), reduced to the three checks kobe needs.

- `EngineRegistryEntry.screenManifest?` — engines declare rules as data; no neutral layer names a vendor
- Copilot manifest: selection dialog → blocked, interrupt hint → working (its ONLY working/blocked signal today)
- Kimi manifest: approval/question panel → blocked, moon/braille spinner → working (fallback for pre-hook sessions)
- Poll loop: for marker-less engines the screen IS the state source — classified every poll, `null` (no rule matched) keeps the previous reading instead of flapping
- `needs_input` from the poll now reaches the existing tab-strip `?` badge / yellow attention chain unchanged

## Claude/Codex untouched

Engines WITH completion markers declare no manifest and take the exact pre-existing code path (existing 4 poll-loop tests pass unmodified). Hooks remain the first authority — the hook-wins merge in `turn-state-merge.ts` supersedes the poll whenever hooks report.

## Why this shape

This is the foundation for plugin-registered engines: adding an engine's detection becomes declaring data, not writing adapter code. Follow-up PRs ride on it (engine presets for the long tail, plugin API surface).

## Verified

- 12 new classifier tests + 1 new poll-loop roundtrip test (prime → working → dialog → needs_input → no-flap)
- Full suite 3349 green; lint + typecheck green

coverage-exemption: packages/kobe/src/tui-react/workspace/use-turn-polls.ts — React-integration .ts file vitest cannot mount (known tui-react blind spot); the changed behavior (manifest passthrough) is covered by the framework-free poll-loop test in ops-activity-monitor.test.ts
