### PR TITLE
feat: ship a contrib-engine catalog for the long tail of coding CLIs

### DIFF
--- a/.changeset/contrib-engine-catalog.md
+++ b/.changeset/contrib-engine-catalog.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Six more coding CLIs work out of the box: Gemini CLI, OpenCode, Cursor Agent, Grok CLI, Droid, and Amp now ship as contrib engines — they appear in the engine selector when their binary is installed, launch with the right command and name, and get screen-based working/needs-input badges. No manual engine registration needed.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -22,10 +22,18 @@ you need git-level isolation and a separate branch.
 | Codex | `codex` | ✓ | ✓ (after you trust hooks) | ✓ | ✓ + effort levels |
 | GitHub Copilot | `copilot` | ✓ | ✓ (screen-based) | ✓ | — |
 | Kimi Code | `kimi` | ✓ | ✓ | handoff only | — |
+| Gemini CLI, OpenCode, Cursor Agent, Grok CLI, Droid, Amp | contrib | binary only | ✓ (screen-based) | — | — |
 | Anything you register | custom | — | — | — | — |
 
 **Claude Code is the default** and the most complete: its quota probe drives
 rate-limit auto-resume and the Settings usage dashboard.
+
+**Contrib engines are launch + badge only.** Rove ships a catalog of
+well-known coding CLIs (`gemini`, `opencode`, `cursor`, `grok`, `droid`,
+`amp`) so they appear in the engine selector whenever the binary is on your
+PATH — with a proper name, a launch command, and screen-based activity
+badges. No account panel, history, or model picker; those need a real
+adapter, which is what promotes an engine to built-in.
 
 **Kimi is partial.** Rove finds the binary, reads its login state, and can
 locate each session's transcript — enough to watch it for activity and to

--- a/packages/kobe/src/engine/account-detect.ts
+++ b/packages/kobe/src/engine/account-detect.ts
@@ -46,6 +46,7 @@ import { getCustomEngineIds } from "@/state/repos"
 import type { VendorId } from "@/types/vendor"
 import { ClaudeBinaryNotFoundError, findClaudeBinary } from "./claude-code-local/binary"
 import { CodexBinaryNotFoundError, findCodexBinary } from "./codex-local/binary"
+import { CONTRIB_ENGINES, CONTRIB_ENGINE_IDS } from "./contrib-engines"
 import { CopilotBinaryNotFoundError, findCopilotBinary } from "./copilot-local/binary"
 import { readTextFileSyncBounded } from "./file-bounds"
 import { KimiBinaryNotFoundError, findKimiBinary } from "./kimi-local/binary"
@@ -252,6 +253,7 @@ export function detectAvailableVendors(deps: DetectDeps = defaultDeps): Promise<
  *  "rescan" — the Settings Accounts section is the natural caller. */
 export function resetAvailableVendorsCache(): void {
   cachedDefaultVendors = null
+  cachedContribEngines = null
 }
 
 /**
@@ -269,7 +271,34 @@ export function resetAvailableVendorsCache(): void {
  */
 export async function availableEngineIds(deps: DetectDeps = defaultDeps): Promise<readonly VendorId[]> {
   const builtins = await detectAvailableVendors(deps)
-  return [...builtins, ...getCustomEngineIds()]
+  const contrib = await detectContribEngines()
+  // Custom ids win over a same-named contrib entry (dedup keeps the first).
+  return [...new Set([...builtins, ...getCustomEngineIds(), ...contrib])]
+}
+
+/**
+ * Per-process memo of contrib-engine binary discovery (same rationale as
+ * {@link detectAvailableVendors}: installed CLIs don't change mid-session,
+ * `Bun.which` per keypress is waste). A contrib engine is offered when its
+ * `defaultCommand[0]` is on PATH — the exact binary the launch would run.
+ * Reset alongside the built-in cache in {@link resetAvailableVendorsCache}.
+ */
+let cachedContribEngines: Promise<readonly VendorId[]> | null = null
+
+function detectContribEngines(): Promise<readonly VendorId[]> {
+  if (cachedContribEngines) return cachedContribEngines
+  // `Bun.which` is absent under vitest (node runtime) — treat that as "none
+  // detected", the same degradation as a missing binary.
+  const which: ((bin: string) => string | null) | undefined = globalThis.Bun?.which
+  cachedContribEngines = Promise.resolve(
+    which
+      ? CONTRIB_ENGINE_IDS.filter((id) => {
+          const bin = CONTRIB_ENGINES[id]?.defaultCommand[0]
+          return bin ? which(bin) !== null : false
+        })
+      : [],
+  )
+  return cachedContribEngines
 }
 
 export async function detectClaudeAccount(deps: DetectDeps = defaultDeps): Promise<EngineAccountStatus<ClaudeAccount>> {

--- a/packages/kobe/src/engine/contrib-engines.ts
+++ b/packages/kobe/src/engine/contrib-engines.ts
@@ -1,0 +1,124 @@
+/**
+ * Shipped contrib engines — the long tail, as DATA.
+ *
+ * A contrib engine is everything kobe needs to launch a coding CLI and
+ * badge its activity, without a dedicated adapter: an id, a display name,
+ * a launch command, and a screen-state manifest (`./screen-state.ts`).
+ * No account detector, no history reader, no hook adapter — those are what
+ * make an engine a BUILT-IN, and each one is real per-vendor work. A
+ * contrib entry is ~10 lines; a future plugin registers exactly this shape.
+ *
+ * Selection gating: a contrib engine appears in the new-task selector only
+ * when its binary is on PATH (`account-detect.ts` probes `defaultCommand[0]`
+ * with the same generic `which` the custom-engine launch would hit anyway),
+ * so shipping the catalog costs users without these CLIs nothing.
+ *
+ * Screen manifests are adapted from refs/herdr's agent-detection rules
+ * (src/detect/manifests/*.toml, studied with attribution), reduced to the
+ * classifier's vocabulary. Blocked rules go before working rules.
+ */
+
+import type { EngineRegistryEntry } from "./registry.ts"
+import type { EngineScreenManifest } from "./screen-state.ts"
+
+interface ContribEngineSpec {
+  readonly displayName: string
+  readonly defaultCommand: readonly string[]
+  readonly processNames?: readonly string[]
+  readonly screenManifest: EngineScreenManifest
+}
+
+const GEMINI: EngineScreenManifest = {
+  rules: [
+    { state: "blocked", any: ["│ apply this change", "│ allow execution", "waiting for user confirmation"] },
+    { state: "blocked", all: ["do you want to proceed"], any: ["yes"] },
+    { state: "working", any: ["esc to cancel"] },
+  ],
+}
+
+const OPENCODE: EngineScreenManifest = {
+  rules: [
+    { state: "blocked", any: ["△ permission required"] },
+    { state: "blocked", all: ["esc dismiss"], any: ["enter confirm", "enter submit", "enter toggle"] },
+    { state: "working", any: ["esc to interrupt", "ctrl+c to interrupt", "esc again to interrupt"] },
+  ],
+}
+
+const CURSOR: EngineScreenManifest = {
+  rules: [
+    { state: "blocked", all: ["proceed (y)"] },
+    { state: "blocked", any: ["run this command?", "waiting for approval", "skip (esc or n)", "(y) (enter)"] },
+    { state: "working", any: ["esc to cancel", "ctrl+c to stop"] },
+  ],
+}
+
+const GROK: EngineScreenManifest = {
+  rules: [
+    // Permission / question dialogs draw a "┃"-guttered option list with a
+    // select footer; the ⚠ prefix rides the OSC title too but the pane copy
+    // is the portable signal.
+    { state: "blocked", any: ["⚠ action required", "ctrl+o:yolo"] },
+    { state: "blocked", all: ["┃"], lineRegex: ["^\\s*┃\\s+\\S+\\s+\\(○\\)"] },
+    // A working turn anchors on the [stop] chip (the startup splash draws
+    // its logo in braille, so a bare spinner glyph is not usable).
+    { state: "working", any: ["[stop]"], lineRegex: ["^\\s*[\\u2800-\\u28FF]"] },
+  ],
+}
+
+const DROID: EngineScreenManifest = {
+  rules: [
+    { state: "blocked", all: ["enter to select", "esc to cancel"], any: ["> yes, allow", "> no, cancel"] },
+    { state: "blocked", all: ["enter select", "esc cancel"] },
+    { state: "working", any: ["esc to stop"] },
+  ],
+}
+
+const AMP: EngineScreenManifest = {
+  rules: [
+    {
+      state: "blocked",
+      any: [
+        "waiting for approval",
+        "run this command?",
+        "allow editing file:",
+        "allow creating file:",
+        "confirm tool call",
+      ],
+    },
+    { state: "working", lineRegex: ["^\\s*╰\\s+\\S+\\s+(thinking|streaming|running tools|waiting)\\s+─"] },
+  ],
+}
+
+/** The shipped catalog. Key = the engine's VendorId. */
+export const CONTRIB_ENGINES: Record<string, ContribEngineSpec> = {
+  gemini: { displayName: "Gemini CLI", defaultCommand: ["gemini"], screenManifest: GEMINI },
+  opencode: { displayName: "OpenCode", defaultCommand: ["opencode"], screenManifest: OPENCODE },
+  cursor: { displayName: "Cursor Agent", defaultCommand: ["cursor-agent"], screenManifest: CURSOR },
+  grok: { displayName: "Grok CLI", defaultCommand: ["grok"], screenManifest: GROK },
+  droid: { displayName: "Droid", defaultCommand: ["droid"], screenManifest: DROID },
+  amp: { displayName: "Amp", defaultCommand: ["amp"], screenManifest: AMP },
+}
+
+export function isContribEngine(id: string): boolean {
+  return Object.hasOwn(CONTRIB_ENGINES, id)
+}
+
+export const CONTRIB_ENGINE_IDS: readonly string[] = Object.keys(CONTRIB_ENGINES)
+
+/**
+ * Fill a contrib spec into a full registry entry. The base is the caller's
+ * empty custom entry (registry.ts owns that shape and passes it in — this
+ * module must not import registry.ts back, the entry type is imported
+ * type-only), overlaid with the contrib's identity + manifest.
+ */
+export function contribEngineEntry(id: string, base: EngineRegistryEntry): EngineRegistryEntry {
+  const spec = CONTRIB_ENGINES[id]
+  if (!spec) return base
+  return {
+    ...base,
+    displayName: spec.displayName,
+    defaultCommand: spec.defaultCommand,
+    ...(spec.processNames ? { processNames: spec.processNames } : {}),
+    screenManifest: spec.screenManifest,
+  }
+}

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -67,7 +67,9 @@ export function engineNameKey(vendor: VendorId): string {
  */
 export function engineDisplayName(vendor: VendorId): string {
   const override = getPersistedString(engineNameKey(vendor))?.trim()
-  return override || VENDOR_LABEL[vendor] || vendor
+  // engineEntry answers every id: built-in labels, contrib catalog names
+  // ("Gemini CLI"), and the id itself for a plain custom engine.
+  return override || engineEntry(vendor).displayName
 }
 
 /**

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -51,6 +51,7 @@ import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
 import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
 import { codexSessionIdFromTitle } from "./codex-local/terminal-title.ts"
 import { trustCodexWorktree } from "./codex-local/trust.ts"
+import { contribEngineEntry, isContribEngine } from "./contrib-engines.ts"
 import { COPILOT_SCREEN_MANIFEST } from "./copilot-local/screen.ts"
 import {
   EMPTY_HISTORY,
@@ -338,7 +339,11 @@ function customEngineEntry(vendor: VendorId): EngineRegistryEntry {
  * this module deliberately does not read so it stays state-free).
  */
 export function engineEntry(vendor: VendorId): EngineRegistryEntry {
-  return isBuiltinVendor(vendor) ? BUILTIN_ENGINES[vendor] : customEngineEntry(vendor)
+  if (isBuiltinVendor(vendor)) return BUILTIN_ENGINES[vendor]
+  const custom = customEngineEntry(vendor)
+  // Shipped contrib engines (data-only long tail): the custom empty entry
+  // overlaid with the catalog's identity + screen manifest.
+  return isContribEngine(vendor) ? contribEngineEntry(vendor, custom) : custom
 }
 
 /**

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
@@ -10,12 +10,8 @@
 
 import { useState } from "react"
 import { ENGINE_PROTOCOLS, engineProtocolKey } from "../../../engine/engine-presets"
-import {
-  VENDOR_LABEL,
-  defaultEngineCommand,
-  engineCommandKey,
-  engineNameKey,
-} from "../../../engine/interactive-command"
+import { defaultEngineCommand, engineCommandKey, engineNameKey } from "../../../engine/interactive-command"
+import { engineEntry } from "../../../engine/registry"
 import { getGlobalDefaultVendor, setGlobalDefaultVendor } from "../../../state/vendor-prefs"
 import { humanizeSlug } from "../../../tui/component/settings-dialog/model"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "../../../types/task"
@@ -56,8 +52,9 @@ export function useEngineSettings(
     return engineNameOverride(vendor).length > 0
   }
   function engineName(vendor: VendorId): string {
-    // Built-ins fall back to VENDOR_LABEL; a custom engine falls back to its id.
-    return engineNameOverride(vendor) || VENDOR_LABEL[vendor] || vendor
+    // Built-ins fall back to VENDOR_LABEL; contrib engines to their catalog
+    // name; a plain custom engine falls back to its id.
+    return engineNameOverride(vendor) || engineEntry(vendor).displayName
   }
 
   const [defaultEngine, setDefaultEngineState] = useState<VendorId>(

--- a/packages/kobe/test/engine/contrib-engines.test.ts
+++ b/packages/kobe/test/engine/contrib-engines.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { CONTRIB_ENGINES, CONTRIB_ENGINE_IDS, isContribEngine } from "../../src/engine/contrib-engines.ts"
+import { engineEntry } from "../../src/engine/registry.ts"
+import { classifyScreen } from "../../src/engine/screen-state.ts"
+import { isBuiltinVendor } from "../../src/types/vendor.ts"
+
+describe("contrib engine catalog", () => {
+  it("no contrib id shadows a built-in", () => {
+    for (const id of CONTRIB_ENGINE_IDS) expect(isBuiltinVendor(id)).toBe(false)
+  })
+
+  it("resolves through engineEntry with catalog identity + manifest", () => {
+    const gemini = engineEntry("gemini")
+    expect(gemini.builtin).toBe(false)
+    expect(gemini.displayName).toBe("Gemini CLI")
+    expect(gemini.defaultCommand).toEqual(["gemini"])
+    expect(gemini.screenManifest).toBeDefined()
+    // The rest stays the documented empty custom entry.
+    expect(gemini.createHookAdapter().supportsHooks()).toBe(false)
+    expect(gemini.createTurnDetector().supportsCompletionMarkers()).toBe(false)
+  })
+
+  it("a non-catalog custom id keeps the plain custom entry", () => {
+    expect(isContribEngine("my-aider")).toBe(false)
+    const entry = engineEntry("my-aider")
+    expect(entry.displayName).toBe("my-aider")
+    expect(entry.screenManifest).toBeUndefined()
+  })
+
+  it("every catalog manifest declares blocked rules before working rules", () => {
+    for (const [id, spec] of Object.entries(CONTRIB_ENGINES)) {
+      const states = spec.screenManifest.rules.map((r) => r.state)
+      const lastBlocked = states.lastIndexOf("blocked")
+      const firstWorking = states.indexOf("working")
+      if (lastBlocked >= 0 && firstWorking >= 0) {
+        expect(lastBlocked, `${id}: blocked rules must precede working (first match wins)`).toBeLessThan(firstWorking)
+      }
+    }
+  })
+
+  it("classifies representative screens (spot checks per engine)", () => {
+    const cases: ReadonlyArray<[string, string, "working" | "blocked"]> = [
+      ["gemini", "output…\nesc to cancel", "working"],
+      ["gemini", "│ Apply this change\n❯ Yes", "blocked"],
+      ["opencode", "△ Permission required", "blocked"],
+      ["opencode", "thinking…\nesc to interrupt", "working"],
+      ["cursor", "Run this command?\nProceed (y)", "blocked"],
+      ["droid", "streaming…\nEsc to stop", "working"],
+      ["amp", "Waiting for approval\nRun this command?", "blocked"],
+      ["amp", "╰ agent thinking ─ 3s", "working"],
+      ["grok", "⠧ Waiting on subagent… 2.8s [stop]", "working"],
+      ["grok", "┃  2 (○) Yes, proceed", "blocked"],
+    ]
+    for (const [id, capture, expected] of cases) {
+      const manifest = CONTRIB_ENGINES[id]?.screenManifest
+      expect(manifest, id).toBeDefined()
+      if (manifest) expect(classifyScreen(manifest, capture), `${id}: ${capture}`).toBe(expected)
+    }
+  })
+})


### PR DESCRIPTION
## What

Rides on #507's screen-state classifier: six well-known coding CLIs — **Gemini CLI, OpenCode, Cursor Agent, Grok CLI, Droid, Amp** — now ship as **contrib engines**: an id, a display name, a launch command, and a screen-state manifest, declared purely as data in `engine/contrib-engines.ts`. `engineEntry()` overlays the catalog onto the documented empty custom entry, so nothing else in the registry changes.

- **Selector gating**: a contrib engine is offered only when its binary is on PATH (memoized `Bun.which` probe merged into `availableEngineIds`; guarded to report none under the node/vitest runtime). Users without these CLIs see nothing new.
- **Badges**: manifests adapted from refs/herdr's agent-detection rules give working / needs-input via the #507 poll classifier.
- **Names**: `engineDisplayName` and the Settings label fallback now route through `engineEntry(vendor).displayName`, so "Gemini CLI" (not "gemini") reaches the composer chips and Settings.
- **Scope-honest**: no account panel, history reader, hooks, or model picker — that's what promotes an engine to built-in. Docs table labels the tier explicitly.

## Claude/Codex untouched

Built-in resolution is the same early-return; contrib overlay only runs for non-builtin ids. A plain custom engine (not in the catalog) keeps the exact empty entry.

## Why this shape

This IS the plugin-API contract rehearsal: a future plugin registers exactly this spec shape. The catalog proves the seam works before the API surface lands.

## Verified

- 5 new tests: catalog/built-in disjointness, engineEntry overlay, custom-id passthrough, blocked-before-working rule ordering, per-engine screen spot-checks
- Full suite 3357 green; lint + typecheck green

coverage-exemption: packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts — React-integration .ts vitest blind spot; the changed line is a label fallback exercised by contrib-engines.test.ts via engineEntry