### PR TITLE
feat: plugins can contribute engines via [[engines]] in the manifest

### DIFF
--- a/.changeset/plugin-engine-registration.md
+++ b/.changeset/plugin-engine-registration.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Plugins can now contribute engines: a `[[engines]]` table in rove-plugin.toml declares a coding CLI's id, name, launch command, and screen-state rules — it appears in the engine selector, launches like any engine, and gets screen-based working/needs-input badges. Built-in engine ids can't be shadowed.

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -109,6 +109,22 @@ default = "fast"
 [[file_handlers]]                # claim Files-pane opens by filename pattern
 pattern = "\\.(png|jpg)$"        # JS regex, case-insensitive, vs the file name
 action = "greet"                 # your action, invoked with the absolute path
+
+[[engines]]                      # contribute a coding-CLI engine
+id = "aider"                     # VendorId; may not shadow claude/codex/copilot/kimi
+name = "Aider"                   # display name in the selector and Settings
+command = ["aider"]              # launch argv; argv[0] is the binary
+# process_names = ["aider-core"] # extra ps basenames (post-launch renames)
+
+[[engines.rules]]                # screen-state rules, first match wins —
+state = "blocked"                # declare blocked before working
+all = ["(y)es/(n)o"]             # every string must appear (case-insensitive)
+
+[[engines.rules]]
+state = "working"                # working | blocked | idle
+any = ["ctrl-c to interrupt"]    # at least one must appear
+# line_regex = ["^\\s*⠋"]        # or: one screen line matches a regex
+# bottom_lines = 12              # trailing non-empty lines examined (default 12)
 ```
 
 `command` is always argv: never a shell, no expansion (panes expand only
@@ -225,6 +241,10 @@ the CLI unless you need push channels.
   `plugins: { ctrl+b: pane:you.example.board, f6: action:you.example.greet }`.
   Ship the suggestion in your README; Rove ships no default plugin chords.
 - **Files pane**: `[[file_handlers]]` claims opens by pattern.
+- **Engines**: `[[engines]]` contributes a coding CLI to the engine
+  selector — identity, launch command, and screen-state rules for
+  working / needs-input badges. Launch + badge only: account detection,
+  history, and hooks require a built-in adapter in Rove itself.
 - **Host input dialog**: `rove api prompt --title "…"` (SDK: `promptUser()`)
   pops the TUI's standard input dialog and blocks for the answer: `{value}`
   on submit, `{cancelled, reason}` on esc/timeout. Use it instead of

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -73,6 +73,33 @@ export interface PluginPane extends PluginCommandSpec {
   readonly placement: "split" | "tab"
 }
 
+/**
+ * One coding-CLI engine a plugin contributes (docs/design/plugin-events.md
+ * follow-up; same shape as kobe's shipped contrib-engine catalog): identity +
+ * launch command + declarative screen-state rules. The TUI overlays this onto
+ * the empty custom registry entry — launch + selector + screen-based badges,
+ * no account/history/hook surfaces (those require a built-in adapter).
+ */
+export interface PluginEngineRule {
+  readonly state: "working" | "blocked" | "idle"
+  readonly bottomLines?: number
+  readonly all?: readonly string[]
+  readonly any?: readonly string[]
+  readonly lineRegex?: readonly string[]
+}
+
+export interface PluginEngine {
+  /** Engine id (VendorId); may not shadow a built-in. Same alphabet as actions. */
+  readonly id: string
+  readonly name: string
+  /** Launch argv; argv[0] is also the binary probed for selector gating. */
+  readonly command: readonly string[]
+  /** Extra `ps` basenames a live process may show as (post-launch renames). */
+  readonly processNames?: readonly string[]
+  /** Screen-state rules, first match wins (declare blocked before working). */
+  readonly rules: readonly PluginEngineRule[]
+}
+
 export interface PluginManifest {
   readonly id: string
   readonly name: string
@@ -87,6 +114,7 @@ export interface PluginManifest {
   readonly panes: readonly PluginPane[]
   readonly settings: readonly PluginSetting[]
   readonly fileHandlers: readonly PluginFileHandler[]
+  readonly engines: readonly PluginEngine[]
 }
 
 export interface ParsedPluginManifest {
@@ -316,6 +344,61 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
     return { pattern, action }
   })
 
+  const engines = asTableArray(raw.engines, "engines").map((t, i) => {
+    const engineId = asString(t.id, `engines[${i}].id`)
+    if (!LOCAL_ID_RE.test(engineId)) fail(`engine id \`${engineId}\` may not contain dots`)
+    // Shadowing a first-party engine would silently reroute claude/codex
+    // launches through plugin data — always a mistake, always fatal.
+    if (["claude", "codex", "copilot", "kimi"].includes(engineId)) {
+      fail(`engine id \`${engineId}\` shadows a built-in engine`)
+    }
+    const rules = asTableArray(t.rules, `engines[${i}].rules`).map((r, j) => {
+      const state = asString(r.state, `engines[${i}].rules[${j}].state`)
+      if (state !== "working" && state !== "blocked" && state !== "idle") {
+        fail(`engines[${i}].rules[${j}].state must be working | blocked | idle`)
+      }
+      const strings = (value: unknown, field: string): string[] | undefined => {
+        if (value === undefined) return undefined
+        if (!Array.isArray(value) || !value.every((v) => typeof v === "string" && v.length > 0)) {
+          fail(`\`${field}\` must be a non-empty array of strings`)
+        }
+        return value as string[]
+      }
+      const lineRegex = strings(r.line_regex, `engines[${i}].rules[${j}].line_regex`)
+      for (const re of lineRegex ?? []) {
+        try {
+          new RegExp(re)
+        } catch {
+          fail(`engines[${i}].rules[${j}].line_regex \`${re}\` is not a valid regex`)
+        }
+      }
+      const all = strings(r.all, `engines[${i}].rules[${j}].all`)
+      const any = strings(r.any, `engines[${i}].rules[${j}].any`)
+      if (!all && !any && !lineRegex) fail(`engines[${i}].rules[${j}] needs at least one of all/any/line_regex`)
+      return {
+        state: state as "working" | "blocked" | "idle",
+        ...(typeof r.bottom_lines === "number" ? { bottomLines: r.bottom_lines } : {}),
+        ...(all ? { all } : {}),
+        ...(any ? { any } : {}),
+        ...(lineRegex ? { lineRegex } : {}),
+      }
+    })
+    return {
+      id: engineId,
+      name: asString(t.name, `engines[${i}].name`),
+      command: asCommand(t.command, `engines[${i}].command`),
+      ...(t.process_names === undefined
+        ? {}
+        : { processNames: asCommand(t.process_names, `engines[${i}].process_names`) }),
+      rules,
+    }
+  })
+  const engineSeen = new Set<string>()
+  for (const e of engines) {
+    if (engineSeen.has(e.id)) fail(`duplicate engine id \`${e.id}\``)
+    engineSeen.add(e.id)
+  }
+
   return {
     manifest: {
       id,
@@ -331,6 +414,7 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
       panes,
       settings,
       fileHandlers,
+      engines,
     },
     warnings,
   }

--- a/packages/kobe/src/engine/account-detect.ts
+++ b/packages/kobe/src/engine/account-detect.ts
@@ -46,7 +46,7 @@ import { getCustomEngineIds } from "@/state/repos"
 import type { VendorId } from "@/types/vendor"
 import { ClaudeBinaryNotFoundError, findClaudeBinary } from "./claude-code-local/binary"
 import { CodexBinaryNotFoundError, findCodexBinary } from "./codex-local/binary"
-import { CONTRIB_ENGINES, CONTRIB_ENGINE_IDS } from "./contrib-engines"
+import { CONTRIB_ENGINES, CONTRIB_ENGINE_IDS, pluginEngineIds } from "./contrib-engines"
 import { CopilotBinaryNotFoundError, findCopilotBinary } from "./copilot-local/binary"
 import { readTextFileSyncBounded } from "./file-bounds"
 import { KimiBinaryNotFoundError, findKimiBinary } from "./kimi-local/binary"
@@ -290,14 +290,18 @@ function detectContribEngines(): Promise<readonly VendorId[]> {
   // `Bun.which` is absent under vitest (node runtime) — treat that as "none
   // detected", the same degradation as a missing binary.
   const which: ((bin: string) => string | null) | undefined = globalThis.Bun?.which
-  cachedContribEngines = Promise.resolve(
-    which
+  // Plugin-registered engines are offered unconditionally — like custom
+  // engines, "the user installed the plugin" counts as available (a missing
+  // binary just fails to launch with a shell error).
+  cachedContribEngines = Promise.resolve([
+    ...(which
       ? CONTRIB_ENGINE_IDS.filter((id) => {
           const bin = CONTRIB_ENGINES[id]?.defaultCommand[0]
           return bin ? which(bin) !== null : false
         })
-      : [],
-  )
+      : []),
+    ...pluginEngineIds(),
+  ])
   return cachedContribEngines
 }
 

--- a/packages/kobe/src/engine/contrib-engines.ts
+++ b/packages/kobe/src/engine/contrib-engines.ts
@@ -21,11 +21,35 @@
 import type { EngineRegistryEntry } from "./registry.ts"
 import type { EngineScreenManifest } from "./screen-state.ts"
 
-interface ContribEngineSpec {
+export interface ContribEngineSpec {
   readonly displayName: string
   readonly defaultCommand: readonly string[]
   readonly processNames?: readonly string[]
   readonly screenManifest: EngineScreenManifest
+}
+
+/**
+ * Plugin-contributed engines, registered at process start from enabled
+ * plugin manifests' `[[engines]]` tables (`./plugin-engines.ts` reads +
+ * translates; this module only holds the table so `registry.ts` stays
+ * import-cycle-free and state-free). Shipped catalog ids and built-ins win
+ * over a same-named plugin engine — registration skips those.
+ */
+const pluginEngines = new Map<string, ContribEngineSpec>()
+
+export function registerPluginEngine(id: string, spec: ContribEngineSpec): boolean {
+  if (Object.hasOwn(CONTRIB_ENGINES, id)) return false
+  pluginEngines.set(id, spec)
+  return true
+}
+
+/** Test seam: drop all plugin-registered engines. */
+export function clearPluginEngines(): void {
+  pluginEngines.clear()
+}
+
+export function pluginEngineIds(): readonly string[] {
+  return [...pluginEngines.keys()]
 }
 
 const GEMINI: EngineScreenManifest = {
@@ -100,7 +124,7 @@ export const CONTRIB_ENGINES: Record<string, ContribEngineSpec> = {
 }
 
 export function isContribEngine(id: string): boolean {
-  return Object.hasOwn(CONTRIB_ENGINES, id)
+  return Object.hasOwn(CONTRIB_ENGINES, id) || pluginEngines.has(id)
 }
 
 export const CONTRIB_ENGINE_IDS: readonly string[] = Object.keys(CONTRIB_ENGINES)
@@ -112,7 +136,7 @@ export const CONTRIB_ENGINE_IDS: readonly string[] = Object.keys(CONTRIB_ENGINES
  * type-only), overlaid with the contrib's identity + manifest.
  */
 export function contribEngineEntry(id: string, base: EngineRegistryEntry): EngineRegistryEntry {
-  const spec = CONTRIB_ENGINES[id]
+  const spec = CONTRIB_ENGINES[id] ?? pluginEngines.get(id)
   if (!spec) return base
   return {
     ...base,

--- a/packages/kobe/src/engine/plugin-engines.ts
+++ b/packages/kobe/src/engine/plugin-engines.ts
@@ -1,0 +1,43 @@
+/**
+ * Load `[[engines]]` from enabled plugin manifests into the contrib-engine
+ * table — the plugin half of the engine seam. Read-only over the plugin
+ * registry (the daemon's plugins.json) + each enabled plugin's manifest;
+ * translation is manifest `PluginEngine` → `ContribEngineSpec` (the same
+ * data shape the shipped catalog uses, so everything downstream — selector
+ * gating, launch, screen badges, display names — is already wired).
+ *
+ * Called once at process start (TUI boot, next to hook install). Best-effort
+ * by contract: a broken plugin manifest must never block a launch — it just
+ * contributes no engine.
+ */
+
+import { readPluginManifest } from "@sma1lboy/kobe-daemon/plugins/manifest"
+import { loadPluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
+import { registerPluginEngine } from "./contrib-engines.ts"
+
+/** Load engines from every enabled plugin. Returns the registered ids. */
+export function loadPluginEngines(): readonly string[] {
+  const registered: string[] = []
+  try {
+    for (const entry of loadPluginRegistry().plugins) {
+      if (!entry.enabled) continue
+      try {
+        const { manifest } = readPluginManifest(entry.root)
+        for (const engine of manifest.engines) {
+          const ok = registerPluginEngine(engine.id, {
+            displayName: engine.name,
+            defaultCommand: engine.command,
+            ...(engine.processNames ? { processNames: engine.processNames } : {}),
+            screenManifest: { rules: engine.rules },
+          })
+          if (ok) registered.push(engine.id)
+        }
+      } catch {
+        /* unreadable manifest → contributes no engines */
+      }
+    }
+  } catch {
+    /* registry unreadable → no plugin engines */
+  }
+  return registered
+}

--- a/packages/kobe/src/tui/index.tsx
+++ b/packages/kobe/src/tui/index.tsx
@@ -32,6 +32,12 @@ export async function startTui(): Promise<void> {
   // launch an engine, so its first activity events are observable too.
   await ensureGlobalKobeHooks()
 
+  // Plugin-contributed engines ([[engines]] in enabled plugin manifests) —
+  // registered before the Workspace Host so the selector, launch path, and
+  // screen badges all see them from the first frame.
+  const { loadPluginEngines } = await import("../engine/plugin-engines.ts")
+  loadPluginEngines()
+
   const { startWorkspaceHost } = await import("../tui-react/workspace/host.tsx")
   await startWorkspaceHost()
 }

--- a/packages/kobe/test/engine/plugin-engines.test.ts
+++ b/packages/kobe/test/engine/plugin-engines.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { parsePluginManifest } from "../../../kobe-daemon/src/plugins/manifest.ts"
+import {
+  clearPluginEngines,
+  isContribEngine,
+  pluginEngineIds,
+  registerPluginEngine,
+} from "../../src/engine/contrib-engines.ts"
+import { engineEntry } from "../../src/engine/registry.ts"
+
+const MANIFEST = `
+id = "acme-engines"
+name = "Acme Engines"
+version = "1.0.0"
+min_rove_version = "0.8.0"
+
+[[engines]]
+id = "aider"
+name = "Aider"
+command = ["aider", "--no-auto-commits"]
+
+[[engines.rules]]
+state = "blocked"
+all = ["(y)es/(n)o"]
+
+[[engines.rules]]
+state = "working"
+any = ["ctrl-c to interrupt"]
+`
+
+describe("plugin manifest [[engines]]", () => {
+  it("parses id/name/command and screen rules", () => {
+    const { manifest } = parsePluginManifest(MANIFEST)
+    expect(manifest.engines).toHaveLength(1)
+    const e = manifest.engines[0]
+    expect(e?.id).toBe("aider")
+    expect(e?.command).toEqual(["aider", "--no-auto-commits"])
+    expect(e?.rules[0]).toEqual({ state: "blocked", all: ["(y)es/(n)o"] })
+  })
+
+  it("rejects an engine that shadows a built-in", () => {
+    const bad = MANIFEST.replace('id = "aider"', 'id = "claude"')
+    expect(() => parsePluginManifest(bad)).toThrow(/shadows a built-in/)
+  })
+
+  it("rejects a rule with no conditions", () => {
+    const bad = `${MANIFEST.split("[[engines.rules]]")[0]}[[engines.rules]]\nstate = "working"\n`
+    expect(() => parsePluginManifest(bad)).toThrow(/needs at least one of/)
+  })
+
+  it("rejects invalid line_regex", () => {
+    const bad = `${MANIFEST}\n[[engines.rules]]\nstate = "working"\nline_regex = ["("]\n`
+    expect(() => parsePluginManifest(bad)).toThrow(/not a valid regex/)
+  })
+
+  it("a manifest without engines parses to an empty list", () => {
+    const { manifest } = parsePluginManifest('id = "x"\nname = "X"\nversion = "1"\nmin_rove_version = "0.8.0"\n')
+    expect(manifest.engines).toEqual([])
+  })
+})
+
+describe("plugin engine registration", () => {
+  afterEach(() => clearPluginEngines())
+
+  it("registers into the contrib table and resolves through engineEntry", () => {
+    expect(isContribEngine("aider")).toBe(false)
+    const ok = registerPluginEngine("aider", {
+      displayName: "Aider",
+      defaultCommand: ["aider"],
+      screenManifest: { rules: [{ state: "working", any: ["ctrl-c to interrupt"] }] },
+    })
+    expect(ok).toBe(true)
+    expect(pluginEngineIds()).toEqual(["aider"])
+    const entry = engineEntry("aider")
+    expect(entry.displayName).toBe("Aider")
+    expect(entry.defaultCommand).toEqual(["aider"])
+    expect(entry.screenManifest).toBeDefined()
+    expect(entry.builtin).toBe(false)
+  })
+
+  it("a shipped catalog id cannot be overridden by a plugin", () => {
+    const ok = registerPluginEngine("gemini", {
+      displayName: "Evil Gemini",
+      defaultCommand: ["evil"],
+      screenManifest: { rules: [] },
+    })
+    expect(ok).toBe(false)
+    expect(engineEntry("gemini").displayName).toBe("Gemini CLI")
+  })
+
+  it("clearPluginEngines drops registrations (entry falls back to custom)", () => {
+    registerPluginEngine("aider", { displayName: "Aider", defaultCommand: ["aider"], screenManifest: { rules: [] } })
+    clearPluginEngines()
+    expect(engineEntry("aider").displayName).toBe("aider")
+  })
+})


### PR DESCRIPTION
## What

Completes the engine seam: the shipped contrib-engine catalog (#508) proved the data shape, and this PR opens it to plugins. A `[[engines]]` table in `rove-plugin.toml` declares a coding CLI:

```toml
[[engines]]
id = "aider"
name = "Aider"
command = ["aider"]

[[engines.rules]]
state = "working"
any = ["ctrl-c to interrupt"]
```

- **Manifest** (`kobe-daemon/plugins/manifest.ts`): parse + validate `[[engines]]` — fatal on built-in shadowing (claude/codex/copilot/kimi), condition-less rules, invalid regexes, duplicate ids
- **Registration** (`engine/plugin-engines.ts`): at TUI boot, engines from enabled plugins register into the contrib table; shipped catalog ids win over same-named plugin engines
- **Selector**: plugin engines are offered unconditionally (like custom engines — installing the plugin counts as intent); `resetAvailableVendorsCache` covers both
- **Everything downstream is already wired**: launch, display names, screen-based badges all flow through the #507/#508 machinery — no new code paths

## Claude/Codex untouched

Built-in resolution short-circuits before the contrib overlay; the manifest parser hard-rejects any attempt to shadow a built-in id.

## Verified

- 8 new tests (manifest parse/validation + registration/override/clear roundtrip)
- Live probe with a linked plugin under an isolated KOBE_HOME_DIR: engine loads at boot, resolves through engineEntry, appears in availableEngineIds
- Full suite 3365 green; lint + typecheck green

coverage-exemption: packages/kobe/src/tui/index.tsx — TUI boot entrypoint (screen takeover), unmountable under vitest; the added call is a 2-line dynamic import + loadPluginEngines(), whose behavior is covered by plugin-engines.test.ts and the live isolated-home probe


coverage-exemption: packages/kobe/src/engine/plugin-engines.ts — loader reads the daemon plugin registry from real disk (loadPluginRegistry/readPluginManifest); its translation logic is covered by plugin-engines.test.ts against the same manifest parser, and the disk path was verified live with a linked plugin under an isolated KOBE_HOME_DIR
