### PR TITLE
fix(landing): plugins and themes lose their nav and their commands on narrow screens

### DIFF
--- a/packages/kobe-landing/plugins.html
+++ b/packages/kobe-landing/plugins.html
@@ -67,7 +67,29 @@ button{cursor:pointer}
 .gh-link{display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:12px;font-weight:500;background:var(--ink);color:oklch(97% 0.008 85);border-radius:999px;padding:8px 15px;margin-left:6px;transition:transform 120ms,box-shadow 160ms;white-space:nowrap}
 .gh-link:hover{transform:translateY(-1px);box-shadow:0 6px 18px oklch(25% 0.02 60/.3)}
 .gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
-@media(max-width:820px){.navbar a.nl{display:none}}
+/* Below 820px the pill used to drop ALL five links with `display:none`,
+   leaving `$ Rove [中文] [GitHub]` — a nav bar with no navigation. Keep the
+   cross-page ones and drop only `--primitives` / `--install`, which are
+   home-page section anchors already reachable through `$ Rove`. That fits
+   one row, so the pill keeps its shape instead of stacking over the hero. */
+@media(max-width:820px){
+  .navbar{gap:0;padding:5px 6px;max-width:calc(100vw - 16px)}
+  .navbar .caret{display:none}
+  .navbar a.nl{padding:7px 7px;font-size:11.5px}
+  .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
+  .lang-btn{padding:5px 8px;margin-left:4px}
+  .gh-link{padding:7px 10px;margin-left:4px}
+}
+@media(max-width:460px){
+  /* the label is redundant next to the mark, and dropping it is what keeps
+     the whole pill inside the viewport at 390 */
+  .gh-link>span:not(.gh-stars){display:none}
+  .navbar a.nl{padding:7px 5px}
+  .navbar .bin{padding-right:2px}
+  /* still 34px over at 390 — changelog is the one to go, it sits in the
+     footer of every page while plugins/themes have no other entry point */
+  .navbar a.nl[href*="changelog"]{display:none}
+}
 
 /* ============ PAGE HEAD ============ */
 .head{padding:clamp(112px,14vh,152px) 0 0;text-align:center}
@@ -136,7 +158,12 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 .card-install{display:flex;align-items:center;gap:9px;width:100%;text-align:left;font-family:var(--font-mono);font-size:11.5px;color:var(--ink-soft);background:transparent;border:1px dashed var(--line-2);border-radius:999px;padding:9px 15px;transition:border-color 140ms,color 140ms,background 140ms}
 .card-install:hover{border-style:solid;border-color:var(--accent-line);color:var(--ink);background:var(--accent-wash)}
 .card-install .ps{color:var(--accent);flex:none}
-.card-install .cmd{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+/* The command used to ellipse on one line, and what it cut was the plugin
+   NAME — the only part that differs between cards, so all six read
+   `…/kobe-plugi…`. It fits in two lines, so show the whole thing: this is
+   a command someone copies, and a truncated command is not one. */
+.card-install{align-items:flex-start;border-radius:14px}
+.card-install .cmd{min-width:0;overflow-wrap:anywhere}
 .skel{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius-lg);height:170px;animation:pulse 1.5s ease-in-out infinite}
 @keyframes pulse{50%{opacity:.5}}
 .empty{font-family:var(--font-mono);font-size:13px;color:var(--faint);padding:34px 0}

--- a/packages/kobe-landing/themes.css
+++ b/packages/kobe-landing/themes.css
@@ -45,7 +45,30 @@ button{font-family:inherit;cursor:pointer}
 .lang-btn{background:none;border:1px solid var(--line-2);color:var(--ink-soft);font-family:var(--font-mono);font-size:11.5px;padding:5px 9px;border-radius:999px;transition:border-color 140ms,color 140ms;white-space:nowrap}
 .lang-btn:hover{border-color:var(--accent);color:var(--accent)}
 .gh-link{display:flex;align-items:center;gap:5px;padding:7px 11px;border-radius:999px;background:var(--ink);color:var(--paper);font-family:var(--font-mono);font-size:11.5px;margin-left:2px}
-@media(max-width:820px){.navbar a.nl{display:none}}
+.gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
+/* Below 820px the pill used to drop ALL five links with `display:none`,
+   leaving `$ Rove [中文] [GitHub]` — a nav bar with no navigation. Keep the
+   cross-page ones and drop only `--primitives` / `--install`, which are
+   home-page section anchors already reachable through `$ Rove`. That fits
+   one row, so the pill keeps its shape instead of stacking over the hero. */
+@media(max-width:820px){
+  .navbar{gap:0;padding:5px 6px;max-width:calc(100vw - 16px)}
+  .navbar .caret{display:none}
+  .navbar a.nl{padding:7px 7px;font-size:11.5px}
+  .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
+  .lang-btn{padding:5px 8px;margin-left:4px}
+  .gh-link{padding:7px 10px;margin-left:4px}
+}
+@media(max-width:460px){
+  /* the label is redundant next to the mark, and dropping it is what keeps
+     the whole pill inside the viewport at 390 */
+  .gh-link>span:not(.gh-stars){display:none}
+  .navbar a.nl{padding:7px 5px}
+  .navbar .bin{padding-right:2px}
+  /* still 34px over at 390 — changelog is the one to go, it sits in the
+     footer of every page while plugins/themes have no other entry point */
+  .navbar a.nl[href*="changelog"]{display:none}
+}
 
 /* ============ HEAD ============ */
 .top{padding:132px 0 20px}
@@ -92,9 +115,13 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 .m-warn{color:var(--t-warning)}
 .m-chip{display:inline-block;background:var(--t-element);color:var(--t-text);padding:0 5px;border-radius:3px}
 
-.tc-cmd{display:flex;align-items:center;gap:7px;width:calc(100% - 34px);margin:0 17px 15px;background:var(--well);color:var(--well-ink);border:none;border-radius:9px;padding:9px 11px;font-family:var(--font-mono);font-size:11px;text-align:left}
+.tc-cmd{display:flex;align-items:flex-start;gap:7px;width:calc(100% - 34px);margin:0 17px 15px;background:var(--well);color:var(--well-ink);border:none;border-radius:9px;padding:9px 11px;font-family:var(--font-mono);font-size:11px;text-align:left}
 .tc-cmd .ps{color:var(--accent-2);flex:none}
-.tc-cmd-t{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+/* Same reason as the plugin cards (plugins.html): a trailing ellipsis cut
+   the theme NAME, so every card read `rove theme add https://rove…`. Wrap
+   instead — a command you cannot read whole is a command you cannot trust
+   you copied. */
+.tc-cmd-t{flex:1;min-width:0;overflow-wrap:break-word;word-break:normal}
 .tc-copy{flex:none;color:oklch(62% 0.02 60);font-size:10px;border-left:1px solid oklch(38% 0.02 55);padding-left:8px}
 .tc-cmd:hover .tc-copy{color:var(--accent-2)}
 .sw{display:flex;gap:0;padding:12px 17px 15px}
@@ -105,7 +132,10 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 
 /* ============ RECIPE / PUBLISH ============ */
 .well{background:var(--well);color:var(--well-ink);border-radius:var(--radius-lg);padding:clamp(20px,3vw,30px);margin-top:26px;overflow-x:auto}
-.well pre{font-family:var(--font-mono);font-size:12.5px;line-height:1.7;white-space:pre}
+/* A JSON sample must not wrap — reflowed code is misleading. Below ~900px
+   it is wider than the well, so it scrolls inside its own box instead of
+   silently clipping. */
+.well pre{font-family:var(--font-mono);font-size:12.5px;line-height:1.7;white-space:pre;overflow-x:auto;-webkit-overflow-scrolling:touch}
 .well .k{color:oklch(78% 0.11 50)}
 .well .s{color:oklch(76% 0.1 145)}
 .well .c{color:oklch(58% 0.02 60)}

--- a/packages/kobe-landing/themes.html
+++ b/packages/kobe-landing/themes.html
@@ -33,6 +33,10 @@
   <a class="gh-link" href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">
     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
     <span>GitHub</span>
+    <span class="gh-stars">
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 .25l2.06 4.18 4.61.67-3.34 3.25.79 4.6L8 10.97l-4.12 2.17.79-4.6L1.33 5.1l4.61-.67L8 .25z"/></svg>
+      <span id="starCount">–</span>
+    </span>
   </a>
 </header>
 
@@ -159,7 +163,7 @@
         <div class="sw">
           <i style="background:#bd93f9"></i><i style="background:#ff79c6"></i><i style="background:#50fa7b"></i><i style="background:#f1fa8c"></i><i style="background:#ff5555"></i><i style="background:#8be9fd"></i>
         </div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/dracula.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/dracula.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/dracula.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>dracula.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#2E3440;--t-panel:#3B4252;--t-element:#434C5E;--t-text:#ECEFF4;--t-muted:#8B95A7;--t-primary:#88C0D0;--t-accent:#8FBCBB;--t-border:#434C5E;--t-bordersub:#434C5E;--t-success:#A3BE8C;--t-warning:#D08770;--t-error:#BF616A;--t-seltext:#2E3440">
         <div class="tc-head"><span class="tc-name">nord</span><span class="tc-tag">cool</span></div>
@@ -185,7 +189,7 @@
         <div class="sw">
           <i style="background:#88C0D0"></i><i style="background:#81A1C1"></i><i style="background:#A3BE8C"></i><i style="background:#D08770"></i><i style="background:#BF616A"></i><i style="background:#8FBCBB"></i>
         </div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/nord.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/nord.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/nord.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>nord.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#161616;--t-panel:#1f1f1f;--t-element:#282828;--t-text:#eeeeee;--t-muted:#808080;--t-primary:#fab283;--t-accent:#7da5c8;--t-border:#545454;--t-bordersub:#484848;--t-success:#7fd88f;--t-warning:#f5a742;--t-error:#e06c75;--t-seltext:#161616">
         <div class="tc-head"><span class="tc-name">opencode</span><span class="tc-tag">warm dark</span></div>
@@ -211,7 +215,7 @@
         <div class="sw">
           <i style="background:#fab283"></i><i style="background:#5c9cf5"></i><i style="background:#7fd88f"></i><i style="background:#f5a742"></i><i style="background:#e06c75"></i><i style="background:#56b6c2"></i>
         </div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/opencode.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/opencode.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/opencode.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>opencode.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#111c18;--t-panel:#1a2520;--t-element:#23372B;--t-text:#C1C497;--t-muted:#53685B;--t-primary:#2DD5B7;--t-accent:#2DD5B7;--t-border:#3d4a44;--t-bordersub:#23372B;--t-success:#549e6a;--t-warning:#E5C736;--t-error:#FF5345;--t-seltext:#111c18">
         <div class="tc-head"><span class="tc-name">osaka-jade</span><span class="tc-tag">high contrast</span></div>
@@ -237,7 +241,7 @@
         <div class="sw">
           <i style="background:#2DD5B7"></i><i style="background:#D2689C"></i><i style="background:#549e6a"></i><i style="background:#E5C736"></i><i style="background:#FF5345"></i><i style="background:#C1C497"></i>
         </div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/osaka-jade.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/osaka-jade.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/osaka-jade.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>osaka-jade.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#1d2021;--t-panel:#282828;--t-element:#32302f;--t-text:#ebdbb2;--t-muted:#a89984;--t-primary:#fe8019;--t-accent:#fabd2f;--t-border:#7c6f64;--t-bordersub:#665c54;--t-success:#b8bb26;--t-warning:#fabd2f;--t-error:#fb4934;--t-seltext:#1d2021">
         <div class="tc-head"><span class="tc-name">gruvbox</span><span class="tc-tag">retro</span></div>
@@ -261,7 +265,7 @@
           </div>
         </div>
         <div class="sw"><i style="background:#fe8019"></i><i style="background:#d3869b"></i><i style="background:#b8bb26"></i><i style="background:#fabd2f"></i><i style="background:#fb4934"></i><i style="background:#fe8019"></i></div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/gruvbox.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/gruvbox.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/gruvbox.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>gruvbox.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#1e1e2e;--t-panel:#181825;--t-element:#313244;--t-text:#cdd6f4;--t-muted:#a6adc8;--t-primary:#cba6f7;--t-accent:#b4befe;--t-border:#7f849c;--t-bordersub:#6c7086;--t-success:#a6e3a1;--t-warning:#f9e2af;--t-error:#f38ba8;--t-seltext:#1e1e2e">
         <div class="tc-head"><span class="tc-name">catppuccin</span><span class="tc-tag">pastel</span></div>
@@ -285,7 +289,7 @@
           </div>
         </div>
         <div class="sw"><i style="background:#cba6f7"></i><i style="background:#cba6f7"></i><i style="background:#a6e3a1"></i><i style="background:#f9e2af"></i><i style="background:#f38ba8"></i><i style="background:#cba6f7"></i></div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/catppuccin.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/catppuccin.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/catppuccin.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>catppuccin.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#191724;--t-panel:#1f1d2e;--t-element:#26233a;--t-text:#e0def4;--t-muted:#908caa;--t-primary:#c4a7e7;--t-accent:#ebbcba;--t-border:#6e6a86;--t-bordersub:#524f67;--t-success:#31748f;--t-warning:#f6c177;--t-error:#eb6f92;--t-seltext:#191724">
         <div class="tc-head"><span class="tc-name">rose-pine</span><span class="tc-tag">muted</span></div>
@@ -309,7 +313,7 @@
           </div>
         </div>
         <div class="sw"><i style="background:#c4a7e7"></i><i style="background:#c4a7e7"></i><i style="background:#31748f"></i><i style="background:#f6c177"></i><i style="background:#eb6f92"></i><i style="background:#c4a7e7"></i></div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/rose-pine.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/rose-pine.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/rose-pine.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>rose-pine.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#2d353b;--t-panel:#272e33;--t-element:#343f44;--t-text:#d3c6aa;--t-muted:#9da9a0;--t-primary:#a7c080;--t-accent:#83c092;--t-border:#56635f;--t-bordersub:#4f585e;--t-success:#a7c080;--t-warning:#dbbc7f;--t-error:#e67e80;--t-seltext:#2d353b">
         <div class="tc-head"><span class="tc-name">everforest</span><span class="tc-tag">forest</span></div>
@@ -333,7 +337,7 @@
           </div>
         </div>
         <div class="sw"><i style="background:#a7c080"></i><i style="background:#d699b6"></i><i style="background:#a7c080"></i><i style="background:#dbbc7f"></i><i style="background:#e67e80"></i><i style="background:#a7c080"></i></div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/everforest.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/everforest.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/everforest.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>everforest.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#1f1f28;--t-panel:#16161d;--t-element:#2a2a37;--t-text:#dcd7ba;--t-muted:#c8c093;--t-primary:#7e9cd8;--t-accent:#7fb4ca;--t-border:#727169;--t-bordersub:#54546d;--t-success:#98bb6c;--t-warning:#e6c384;--t-error:#e46876;--t-seltext:#1f1f28">
         <div class="tc-head"><span class="tc-name">kanagawa</span><span class="tc-tag">ukiyo-e</span></div>
@@ -357,7 +361,7 @@
           </div>
         </div>
         <div class="sw"><i style="background:#7e9cd8"></i><i style="background:#957fb8"></i><i style="background:#98bb6c"></i><i style="background:#e6c384"></i><i style="background:#e46876"></i><i style="background:#7e9cd8"></i></div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/kanagawa.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/kanagawa.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/kanagawa.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>kanagawa.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
       <article class="tcard" style="--t-bg:#002b36;--t-panel:#00212b;--t-element:#073642;--t-text:#eee8d5;--t-muted:#93a1a1;--t-primary:#268bd2;--t-accent:#2aa198;--t-border:#586e75;--t-bordersub:#356266;--t-success:#859900;--t-warning:#b58900;--t-error:#dc322f;--t-seltext:#002b36">
         <div class="tc-head"><span class="tc-name">solarized</span><span class="tc-tag">classic</span></div>
@@ -381,7 +385,7 @@
           </div>
         </div>
         <div class="sw"><i style="background:#268bd2"></i><i style="background:#6c71c4"></i><i style="background:#859900"></i><i style="background:#b58900"></i><i style="background:#dc322f"></i><i style="background:#268bd2"></i></div>
-        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/solarized.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/themes/solarized.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
+        <button class="tc-cmd" data-cmd="https://rove.sma1lboy.me/themes/solarized.json"><span class="ps">$</span><span class="tc-cmd-t">rove theme add https://rove.sma1lboy.me/<wbr>themes/<wbr>solarized.json</span><span class="tc-copy" data-i18n="card.copy">copy</span></button>
       </article>
     </div>
   </section>

--- a/packages/kobe-landing/themes.js
+++ b/packages/kobe-landing/themes.js
@@ -160,3 +160,16 @@ var KOBE_I18N = (function () {
     timer = setTimeout(function () { label.textContent = KOBE_I18N.t('copy.hint'); }, 1800);
   });
 })();
+
+// live GitHub star count — same shape and same `kobe_stars` cache key as the
+// home and plugins pages, so the count paints instantly once any page has run
+(function () {
+  var el = document.getElementById('starCount');
+  if (!el) return;
+  function render(n) { el.textContent = n >= 1000 ? (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k' : String(n); }
+  try { var c = JSON.parse(localStorage.getItem('kobe_stars') || 'null'); if (c && typeof c.n === 'number') render(c.n); } catch (e) {}
+  fetch('https://api.github.com/repos/Sma1lboy/rove')
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (d) { if (!d || typeof d.stargazers_count !== 'number') return; render(d.stargazers_count); try { localStorage.setItem('kobe_stars', JSON.stringify({ n: d.stargazers_count })); } catch (e) {} })
+    .catch(function () { if (el.textContent === '–') el.textContent = '☆'; });
+})();


### PR DESCRIPTION
## Summary

Follow-up to #498, same two pages the footer pass touched. Three separate defects, all found by driving the real pages rather than reading the CSS.

**1. Every install command was truncated at the part that mattered**

`.card-install .cmd` / `.tc-cmd-t` ellipsed on one line, and what got cut was the *tail* — the plugin or theme name, the only part that differs between cards:

| | before | after |
|---|---|---|
| plugins (×6) | `$ rove plugin install Sma1lboy/kobe-plugi…` | full command, wrapped |
| themes (×10) | `$ rove theme add https://rove.sma1lboy.me/…` | full command, wrapped |

All six plugin cards rendered identically; all ten theme cards rendered identically. These are commands people copy — a truncated one can't be verified. They wrap now. Theme URLs get `<wbr>` after each *path* separator (not inside `https://`) so a URL breaks at `…/themes/` rather than `…/dr` + `acula.json`.

**2. Below 820px the nav had no navigation**

`@media(max-width:820px){.navbar a.nl{display:none}}` hid all five links, leaving `$ Rove [中文] [GitHub]` — on the two pages that are each other's only entry point. Now only the home-page section anchors (`--primitives`, `--install`) drop; `--plugins` / `--themes` / `--changelog` stay. Under 460px the GitHub *label* hides too (the mark and count remain), which is what keeps the pill inside a 390px viewport.

I first tried wrapping the pill to a second row and then a full-width scrolling bar; both were worse (a 4-row tower over the hero, then controls scrolled off-screen). Dropping the two redundant anchors is the version that fits in one row.

**3. The themes page never showed its star count**

Its `.gh-link` was missing the `gh-stars` span entirely, so it rendered a bare `GitHub` button while home and plugins showed `GitHub ★ 104`. Added the markup, the `.gh-stars` rule, and the same fetch with the same `kobe_stars` cache key.

Plus: the `~/.rove/themes/darkside.json` sample now scrolls horizontally inside its well. It must not wrap (reflowed JSON is misleading) and below ~900px it was wider than its container.

## Test plan

- [x] Overflow scan at 1440 / 1280 / 900 / 700 / 560 / 390 on both pages — 0 overflowing elements, no document overflow (was 6 on plugins, 10 on themes, plus the JSON block)
- [x] Nav links reachable at every width: 5 above 820, 3 at ≤820 (`--plugins`/`--themes`/`--changelog`), 2 at ≤460 (`--plugins`/`--themes`) — was 0 below 820
- [x] Nav pill fits its viewport at 390 (scrollWidth == clientWidth on both pages)
- [x] Both languages at 1440 / 900 / 390 — no overflow in either
- [x] Star count renders on all three pages
- [ ] Spot-check the deploy preview — CSS-heavy, and font metrics differ from local

Deliberately out of scope, both worth a follow-up:
- `index.html:72` still has the old `@media(max-width:820px){.navbar a.nl{display:none}}`. Same pattern, but the home page is not a dead end (its footer links to plugins/themes/changelog) and it does not share a stylesheet with these two, so it is a separate change rather than a silent widening of this one.
- The pill nav overlapping content on scroll. It's pre-existing (verified identical with these changes stashed) and belongs to the shared nav, not this fix.

Gates: `changeset-cap` is a no-op (no `packages/kobe/src` or `kobe-daemon/src`); touched files are 491/456/175/168 lines, all under the cap; `packages/kobe-landing` is outside the root lint scope.
