### PR TITLE
fix: git worktree add no longer auto-adopts onto the sidebar

### DIFF
--- a/.changeset/no-adopt-on-worktree-add.md
+++ b/.changeset/no-adopt-on-worktree-add.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Creating a git worktree no longer auto-adopts it onto the sidebar. Agents mint worktrees for PR isolation and no engine session ever enters them, so "created" isn't "wanted as a task" — those showed up as ghost tasks with no prompt and no session. Adoption now requires intent: an engine session starting inside a managed worktree root, or an explicit adopt (`rove add .` / New task → Adopt Worktree). Removing a worktree still archives its task.

--- a/docs/design/engine-internals.md
+++ b/docs/design/engine-internals.md
@@ -118,8 +118,12 @@ are always installed.
 
 A global `PostToolUse` (Bash) observer hook reports
 `kobe hook worktree-created` after every Bash call; it no-ops fast unless the
-command was `git worktree add` (adopt the new worktree as a task immediately)
-or `git worktree remove` (archive the pinned task). This is a pure *observer*
+command was `git worktree remove` (archive the pinned task). It once also
+adopted on `git worktree add`; removed 2026-08-24 — creation is mechanical
+(agents mint worktrees for PR isolation and no engine session ever enters),
+so adoption now requires intent: an engine `session-start` inside a managed
+worktree root, or an explicit adopt (`rove add .` / New task → Adopt
+Worktree). This is a pure *observer*
 fired after the tool runs, unlike the old `WorktreeCreate` *provider* hook
 (0.7.4–0.7.9) whose mere presence broke `claude --worktree` everywhere. Rove
 removes any such legacy hook it ever wrote; `kobe hook setup` survives only

--- a/packages/kobe-daemon/src/client/index.ts
+++ b/packages/kobe-daemon/src/client/index.ts
@@ -56,7 +56,6 @@ const RPC_TIMEOUT_EXEMPT: ReadonlySet<DaemonRequestName> = new Set<DaemonRequest
   "task.ensureMain",
   "worktree.discoverAdoptable",
   "worktree.adopt",
-  "worktree.reconcile",
   "worktree.archiveRemoved",
   "worktree.list",
   "worktree.remove",

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -1,10 +1,11 @@
 /**
  * `worktree.*` daemon RPC handlers.
  *
- * The first 4 entries (`discoverAdoptable`/`adopt`/`reconcile`/
- * `archiveRemoved`) are split out of `handlers.ts` (which was over the
- * repo's 500-line file-size cap) purely mechanically — same behavior,
- * moved verbatim.
+ * The first entries (`discoverAdoptable`/`adopt`/`archiveRemoved`) are
+ * split out of `handlers.ts` (which was over the repo's 500-line file-size
+ * cap). `worktree.reconcile` (adopt-on-`git worktree add`) was REMOVED
+ * 2026-08-24: creation is mechanical, not intent — adoption now needs an
+ * engine session-start in a managed root or an explicit `rove add .`/adopt.
  *
  * `list`/`remove` are NEW — the standalone worktree-management TUI page
  * (`tui/component/worktrees-page.tsx`). Unlike the other four, they don't
@@ -17,7 +18,7 @@
  */
 
 import { logDaemonError } from "./crash-log.ts"
-import { matchRepoByCwd, matchTaskByWorktreePath } from "./cwd-task.ts"
+import { matchTaskByWorktreePath } from "./cwd-task.ts"
 import { optionalString, optionalVendor, requireString } from "./handler-validators.ts"
 import type { DaemonRequestHandler } from "./handlers.ts"
 import { serializeTask } from "./protocol.ts"
@@ -45,30 +46,6 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
         ifExists: optionalString(payload, "ifExists") === "return" ? "return" : "error",
       })
       return { task: serializeTask(task) }
-    },
-  },
-  {
-    name: "worktree.reconcile",
-    async handle(payload, ctx) {
-      // A `kobe hook worktree-created` (global PostToolUse) reporting that a
-      // `git worktree add` just ran in `cwd`, creating `worktreePath`. Adopt
-      // it the MOMENT it's created — no engine session needed (the
-      // creation-time complement to the `session-start` auto-adopt in
-      // `engine.reportEvent` below). Bounded to repos kobe already tracks
-      // (so a stray worktree in an untracked repo is ignored); `adoptWorktree`
-      // is idempotent + git-validated, so a re-fired hook or a bogus path is a
-      // harmless no-op (the path just fails validation → caught → dropped).
-      const cwd = requireString(payload, "cwd")
-      const worktreePath = requireString(payload, "worktreePath")
-      const repo = matchRepoByCwd(ctx.orch.listTasks(), cwd) ?? matchRepoByCwd(ctx.orch.listTasks(), worktreePath)
-      if (!repo) return { adopted: false }
-      try {
-        const task = await ctx.orch.adoptWorktree({ repo, worktreePath, ifExists: "return" })
-        return { adopted: true, taskId: task.id }
-      } catch (err) {
-        logDaemonError("worktree-created", err)
-        return { adopted: false }
-      }
     },
   },
   {

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -181,11 +181,10 @@ export type DaemonRequestName =
   // PostToolUse) reports that a `git worktree add` just ran in `cwd`. The
   // daemon adopts the new worktree as a task the MOMENT it's created — no
   // engine session needed (the complement to session-start auto-adopt).
-  | "worktree.reconcile"
   // Removal-time auto-archive (KOB): the same `kobe hook worktree-created`
   // (global PostToolUse) reports that a `git worktree remove <path>` just ran.
   // The daemon archives the task whose worktree was that path — the symmetric
-  // complement to `worktree.reconcile` (remove a worktree → its task archives).
+  // symmetric complement to worktree adoption (remove a worktree → its task archives).
   | "worktree.archiveRemoved"
   // Cross-project worktree audit (the standalone worktree-management TUI
   // page): list every worktree of every local saved project (kobe-managed

--- a/packages/kobe/src/cli/hook-cmd.ts
+++ b/packages/kobe/src/cli/hook-cmd.ts
@@ -109,32 +109,6 @@ function tokenizeCommand(command: string): string[] {
 }
 
 /**
- * Extract the target path of a `git worktree add` from a (possibly compound)
- * shell command, or undefined when the command isn't a worktree-add. Finds the
- * first positional after the `worktree add` tokens, skipping flags and the
- * values of the value-taking flags (`-b` / `-B` / `--reason`). Stops at a shell
- * operator so a chained `&& rm -rf x` can't be mistaken for the path.
- */
-export function parseWorktreeAddPath(command: string): string | undefined {
-  const tokens = tokenizeCommand(command)
-  const valueFlags = new Set(["-b", "-B", "--reason"])
-  for (let i = 0; i + 1 < tokens.length; i++) {
-    if (tokens[i] !== "worktree" || tokens[i + 1] !== "add") continue
-    let j = i + 2
-    while (j < tokens.length) {
-      const t = tokens[j]
-      if (t === "&&" || t === "||" || t === ";" || t === "|" || t === ">" || t === ">>") break
-      if (t.startsWith("-")) {
-        j += valueFlags.has(t) ? 2 : 1 // `--reason=x` (has `=`) is self-contained → skip 1
-        continue
-      }
-      return t // first positional after the flags is the worktree path
-    }
-  }
-  return undefined
-}
-
-/**
  * Extract the target path of a `git worktree remove` from a (possibly compound)
  * shell command, or undefined when the command isn't a worktree-remove. Mirrors
  * {@link parseWorktreeAddPath}: finds the first positional after the `worktree
@@ -161,11 +135,16 @@ export function parseWorktreeRemovePath(command: string): string | undefined {
 }
 
 /**
- * `kobe hook worktree-created` — the global `PostToolUse` (Bash) callback. Reads
- * the hook payload and asks the daemon (non-spawning) to keep tasks in sync with
- * the two git-worktree lifecycle commands:
- *  - `git worktree add <path>`    → adopt the new worktree as a task.
+ * `kobe hook worktree-created` — the global `PostToolUse` (Bash) callback.
+ * Reads the hook payload and asks the daemon (non-spawning) to keep tasks in
+ * sync with worktree REMOVAL only:
  *  - `git worktree remove <path>` → archive the task pinned to that worktree.
+ *
+ * `git worktree add` no longer adopts (owner decision 2026-08-24): creating a
+ * worktree is a mechanical act — agents mint them for PR isolation and no
+ * engine session ever enters — so "created" is not "wanted on the sidebar".
+ * The intent-carrying adoption paths remain: an engine `session-start` inside
+ * a managed worktree root (handlers.ts) and the explicit `rove add .`.
  * Everything is best-effort + swallowed: a hook must never fail the engine.
  */
 async function runWorktreeCreatedHook(): Promise<void> {
@@ -175,17 +154,12 @@ async function runWorktreeCreatedHook(): Promise<void> {
   const command = typeof toolInput.command === "string" ? toolInput.command : ""
   if (!command.includes("worktree")) return // cheap pre-filter: 99.9% of Bash calls bail here
   const cwd = typeof payload.cwd === "string" && payload.cwd ? payload.cwd : process.cwd()
-  const addPath = parseWorktreeAddPath(command)
-  const removePath = addPath ? undefined : parseWorktreeRemovePath(command)
-  if (!addPath && !removePath) return
+  const removePath = parseWorktreeRemovePath(command)
+  if (!removePath) return
   const client = await connectIfRunning() // NON-spawning by contract
   if (!client) return
   try {
-    if (addPath) {
-      await client.request("worktree.reconcile", { cwd, worktreePath: resolve(cwd, addPath) })
-    } else if (removePath) {
-      await client.request("worktree.archiveRemoved", { worktreePath: resolve(cwd, removePath) })
-    }
+    await client.request("worktree.archiveRemoved", { worktreePath: resolve(cwd, removePath) })
   } finally {
     client.close()
   }
@@ -209,7 +183,7 @@ export async function runHookSubcommand(argv: readonly string[]): Promise<void> 
   }
   // Worktree lifecycle sync: the global `PostToolUse` (Bash) hook. Fires after
   // EVERY Bash tool call machine-wide, so it must no-op fast — it only touches
-  // the daemon when the command was a `git worktree add`/`remove`.
+  // the daemon when the command was a `git worktree remove`.
   if (verb === WORKTREE_CREATED_VERB) {
     try {
       await runWorktreeCreatedHook()
@@ -374,10 +348,9 @@ export async function ensureGlobalKobeHooks(): Promise<void> {
       const enginePath = a.globalSettingsPath()
       if (!enginePath) continue
       await a.installActivityHooks(enginePath, { toolEvents })
-      // PostToolUse(Bash) observer: a `git worktree add` in ANY session adopts
-      // the new worktree as a task immediately (no session needed). Pure
-      // observer — unlike the removed WorktreeCreate provider hook, it can't
-      // break `claude --worktree`.
+      // PostToolUse(Bash) observer: a `git worktree remove` in ANY session
+      // archives the worktree's task. Pure observer — unlike the removed
+      // WorktreeCreate provider hook, it can't break `claude --worktree`.
       await a.installWorktreeWatchHook(enginePath)
     }
     // 2. Remove the removed WorktreeCreate hook wherever it was ever written.

--- a/packages/kobe/src/engine/hook-adapter.ts
+++ b/packages/kobe/src/engine/hook-adapter.ts
@@ -91,14 +91,15 @@ export interface EngineHookAdapter {
   removeWorktreeSyncHook(settingsFilePath: string): Promise<void>
 
   /**
-   * Install the global worktree-WATCH hook: a creation-time observer that, the
-   * moment a `git worktree add` runs in ANY engine session, adopts the new
-   * worktree as a kobe task so it appears in the sidebar WITHOUT a running
-   * session. Unlike the removed `WorktreeCreate` provider hook, this is a pure
-   * OBSERVER fired AFTER the tool runs (Claude Code's `PostToolUse`), so its
-   * presence never changes git/`--worktree` behaviour. Must be IDEMPOTENT,
-   * merge-safe, and never throw fatally. No-op when {@link supportsHooks} is
-   * false.
+   * Install the global worktree-WATCH hook: an observer that, the moment a
+   * `git worktree remove` runs in ANY engine session, archives the task
+   * pinned to that worktree. (It once also adopted on `add`; removed
+   * 2026-08-24 — creation is mechanical, adoption needs an engine
+   * session-start in a managed root or an explicit adopt.) Unlike the removed
+   * `WorktreeCreate` provider hook, this is a pure OBSERVER fired AFTER the
+   * tool runs (Claude Code's `PostToolUse`), so its presence never changes
+   * git/`--worktree` behaviour. Must be IDEMPOTENT, merge-safe, and never
+   * throw fatally. No-op when {@link supportsHooks} is false.
    */
   installWorktreeWatchHook(settingsFilePath: string): Promise<void>
   /** Remove the worktree-watch hook this adapter installed. Idempotent + merge-safe. */

--- a/packages/kobe/src/engine/json-hooks.ts
+++ b/packages/kobe/src/engine/json-hooks.ts
@@ -133,9 +133,11 @@ export function mergeActivityHooks(
 /**
  * Build kobe's worktree-WATCH hook: a global `PostToolUse` observer scoped to
  * the `Bash` tool. After every Bash call, `kobe hook worktree-created` runs and
- * — only when the command was a `git worktree add` — adopts the new worktree as
- * a task. A pure observer (fires AFTER the tool), so its presence never changes
- * git/`--worktree` behaviour.
+ * — only when the command was a `git worktree remove` — archives the task
+ * pinned to that worktree. (`add` no longer adopts, owner decision 2026-08-24:
+ * creation is mechanical, adoption needs an engine session-start or an
+ * explicit adopt.) A pure observer (fires AFTER the tool), so its presence
+ * never changes git/`--worktree` behaviour.
  */
 export function buildWorktreeWatchHook(inv: readonly string[] = kobeHookInvocation()): Record<string, unknown> {
   const command = quoteShellArgv([...inv, "hook", WORKTREE_WATCH_MARKER])

--- a/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
+++ b/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
@@ -203,14 +203,13 @@ describe("runHookSubcommand — activity verbs", () => {
 })
 
 describe("runHookSubcommand worktree-created", () => {
-  it("asks the daemon to reconcile the path of a `git worktree add`", async () => {
+  it("does NOT adopt on `git worktree add` — creation is mechanical, not intent", async () => {
+    // Owner decision 2026-08-24: agents mint worktrees for PR isolation and no
+    // engine session ever enters; adoption needs a session-start in a managed
+    // root or an explicit `rove add .`. The hook never touches the daemon.
     stubStdin({ cwd: "/repo", tool_input: { command: "git worktree add -b feat .claude/worktrees/lynx main" } })
     await runHookSubcommand(["worktree-created"])
-    expect(mocks.request).toHaveBeenCalledWith("worktree.reconcile", {
-      cwd: "/repo",
-      worktreePath: resolve("/repo", ".claude/worktrees/lynx"),
-    })
-    expect(mocks.close).toHaveBeenCalledTimes(1)
+    expect(mocks.connectIfRunning).not.toHaveBeenCalled()
   })
 
   it("asks the daemon to archive the task of a `git worktree remove`", async () => {
@@ -328,8 +327,8 @@ describe("runHookSubcommand cleanup (plugin migration path)", () => {
 })
 
 describe("runHookSubcommand worktree-created failure swallowing", () => {
-  it("swallows a daemon error mid-reconcile — the Bash hook must exit 0", async () => {
-    stubStdin({ cwd: "/repo", tool_input: { command: "git worktree add wt" } })
+  it("swallows a daemon error mid-archive — the Bash hook must exit 0", async () => {
+    stubStdin({ cwd: "/repo", tool_input: { command: "git worktree remove wt" } })
     mocks.request.mockRejectedValue(new Error("daemon blew up"))
     await expect(runHookSubcommand(["worktree-created"])).resolves.toBeUndefined()
     // The socket is still closed on the failure path.

--- a/packages/kobe/test/cli/hook-cmd.test.ts
+++ b/packages/kobe/test/cli/hook-cmd.test.ts
@@ -1,53 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { parseWorktreeAddPath, parseWorktreeRemovePath, readTextWithTimeout } from "../../src/cli/hook-cmd.ts"
-
-/**
- * `parseWorktreeAddPath` extracts the worktree path from a Bash command so the
- * global `PostToolUse` (Bash) hook can adopt a freshly-created worktree. It must
- * find the path past `git worktree add`'s flags, ignore non-worktree commands,
- * and never be fooled by a chained command into adopting the wrong token.
- */
-describe("parseWorktreeAddPath", () => {
-  it("returns undefined for commands that aren't a worktree-add", () => {
-    expect(parseWorktreeAddPath("git status")).toBeUndefined()
-    expect(parseWorktreeAddPath("ls -la")).toBeUndefined()
-    expect(parseWorktreeAddPath("git worktree list")).toBeUndefined()
-    expect(parseWorktreeAddPath("git worktree remove foo")).toBeUndefined()
-  })
-
-  it("extracts a bare path", () => {
-    expect(parseWorktreeAddPath("git worktree add .claude/worktrees/lynx")).toBe(".claude/worktrees/lynx")
-  })
-
-  it("skips the value of `-b` / `-B` and returns the path", () => {
-    expect(parseWorktreeAddPath("git worktree add -b kobe/feat .claude/worktrees/lynx main")).toBe(
-      ".claude/worktrees/lynx",
-    )
-    expect(parseWorktreeAddPath("git worktree add -B kobe/feat /tmp/wt")).toBe("/tmp/wt")
-  })
-
-  it("skips boolean flags like --force / --detach / -q", () => {
-    expect(parseWorktreeAddPath("git worktree add --force --detach -q ../wt")).toBe("../wt")
-  })
-
-  it("skips the value of `--reason`, and `--reason=...` self-contained form", () => {
-    expect(parseWorktreeAddPath('git worktree add --reason "busy" wt')).toBe("wt")
-    expect(parseWorktreeAddPath("git worktree add --reason=busy wt")).toBe("wt")
-  })
-
-  it("strips quotes around the path", () => {
-    expect(parseWorktreeAddPath('git worktree add "my worktrees/lynx"')).toBe("my worktrees/lynx")
-  })
-
-  it("finds the worktree add inside a compound command", () => {
-    expect(parseWorktreeAddPath("cd /repo && git worktree add -b x wt main")).toBe("wt")
-  })
-
-  it("stops at a shell operator so a chained command can't masquerade as the path", () => {
-    // No positional path before `&&` → not a usable worktree-add target.
-    expect(parseWorktreeAddPath("git worktree add -b x && echo done")).toBeUndefined()
-  })
-})
+import { parseWorktreeRemovePath, readTextWithTimeout } from "../../src/cli/hook-cmd.ts"
 
 /**
  * `parseWorktreeRemovePath` is the removal-side mirror: the same global hook

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -58,7 +58,6 @@ describe("daemon handler registry", () => {
       "issue.mutate",
       "worktree.discoverAdoptable",
       "worktree.adopt",
-      "worktree.reconcile",
       "worktree.archiveRemoved",
       "worktree.list",
       "worktree.remove",


### PR DESCRIPTION
## What

Owner decision (2026-08-24): the PostToolUse worktree-watch hook's `add` → adopt branch is removed. Creating a worktree is a mechanical act — agents mint them for PR isolation and no engine session ever enters — so "created" is not "wanted on the sidebar". The observed symptom: ghost tasks with no prompt, no session, title = directory name (4 of them from one agent session).

**What stays** (the intent-carrying adoption paths):
- engine `session-start` inside a managed worktree root (daemon auto-adopt in `engine.reportEvent`) — a `rove api send`-dispatched subagent still lands on the sidebar the moment its engine starts
- explicit adopt: `rove add .` / New task → Adopt Worktree
- `git worktree remove` → archive (the hook's remaining job)

**Removed**: the `worktree.reconcile` daemon RPC, the hook's add branch, and `parseWorktreeAddPath` (dead with it).

## Verified

- Dispatch test now asserts `add` never touches the daemon; remove→archive tests unchanged
- Full suite 3349 green; lint + typecheck green