### PR TITLE
fix(landing): the home nav keeps its cross-page links on narrow screens

### DIFF
--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -69,7 +69,24 @@ button{font-family:inherit;cursor:pointer}
 .gh-link{display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:12px;font-weight:500;background:var(--ink);color:oklch(97% 0.008 85);padding:7px 14px;margin-left:8px;transition:background 140ms;white-space:nowrap}
 .gh-link:hover{background:var(--accent);color:oklch(99% 0.005 85)}
 .gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
-@media(max-width:820px){.navbar a.nl{display:none}}
+/* This used to hide all five links, leaving `$ Rove [中文] [GitHub]` — the
+   same defect fixed on plugins/themes in #511. The home bar is full-width,
+   so it keeps more than the pill could: the section anchors go first (they
+   scroll to content already on this page), then changelog, which the footer
+   also links. Measured against the real bar, not guessed. */
+@media(max-width:820px){
+  .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
+  .navbar a.nl{padding:6px 8px}
+}
+@media(max-width:460px){
+  .navbar a.nl[href*="changelog"]{display:none}
+  .gh-link>span:not(.gh-stars){display:none}
+  .navbar{padding:10px 12px}
+  .navbar .bin{padding-right:6px}
+  .navbar a.nl{padding:6px 6px}
+  .lang-btn{padding:6px 9px;margin-left:4px}
+  .gh-link{padding:7px 11px;margin-left:5px}
+}
 
 /* ============ HERO ============ */
 /* padding-bottom gives the veil runway below the equation — without it the


### PR DESCRIPTION
## Summary

The follow-up flagged as out-of-scope in #511, done now. `index.html` still shipped the rule that PR diagnosed and removed from the other two pages:

```css
@media(max-width:820px){.navbar a.nl{display:none}}
```

Below 820px the most-trafficked page's nav collapsed to `$ Rove [中文] [GitHub]` — no links at all.

The home bar is full-width rather than a floating pill, so it has room to keep more than plugins/themes could. Tiers measured against the real bar rather than copied:

| width | links kept |
|---|---|
| > 820 | all five |
| ≤ 820 | `--plugins` `--themes` `--changelog` |
| ≤ 460 | `--plugins` `--themes` |

Section anchors (`--primitives`, `--install`) go first — they scroll to content already on this page. `--changelog` goes at 460, where the footer still links it. Two cross-page links survive at 390px with 50px to spare.

The 460 tier also trims control padding: without it the bar overflowed its own viewport by 11px once the links stayed. Verified that's gone — `.navbar` no longer appears in the overflow scan at any width.

## Test plan

- [x] Link counts at 900 / 820 / 700 / 560 / 460 / 390: 5 / 3 / 3 / 3 / 2 / 2 (was 5 / 0 / 0 / 0 / 0 / 0)
- [x] Nav fits its viewport at every width — 50px spare at 390, `.navbar` absent from the overflow scan
- [x] 中文 at 820 / 560 / 390 — no nav overflow
- [ ] Spot-check the deploy preview

Pre-existing and untouched (verified identical with these changes stashed): document overflow at 900px from `.fl-tabsline` / `.stage`, and `.cmd` / `.px-meta` / `.final-band` overflowing at 390. Different elements, separate fix.

Note: `index.html` is now 515 lines, over the ~500 guidance. The CI gate only measures `.ts/.tsx/.js/.jsx/.mjs`, so this does not trip it, but flagging rather than letting it pass silently — the file is a single-page document with inline `<style>`, and splitting it is a larger change than this fix warrants.

Gates: `changeset-cap` is a no-op (no `packages/kobe/src` or `kobe-daemon/src`); `packages/kobe-landing` is outside the root lint scope.