### PR TITLE
fix: normalize web theme hex through the TUI's shared resolver

### DIFF
--- a/.changeset/web-theme-hex-normalize.md
+++ b/.changeset/web-theme-hex-normalize.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The web dashboard now resolves theme colours through the TUI's shared hex normalizer, so a theme slot written in the schema-sanctioned `#abc` shorthand or `#aabbccdd` (alpha) form gets the same expanded, alpha-stripped `#rrggbb` the TUI uses — previously the web kept the literal verbatim and fed it into its colour-blend helper, which reads only six digits, so every derived slot (subtle text, hover, border tones) blended the wrong channels; a malformed hex now skips the slot instead of producing a garbage colour.

--- a/packages/kobe/src/web/themes.ts
+++ b/packages/kobe/src/web/themes.ts
@@ -1,6 +1,6 @@
 /**
- * Theme palettes for the web dashboard — the same 7 theme JSONs the TUI
- * ships (tui/context/theme/*.json), resolved to flat hex palettes in the
+ * Theme palettes for the web dashboard — the same bundled theme JSONs the
+ * TUI ships (tui/context/theme/*.json), resolved to flat hex palettes in the
  * web's token vocabulary (the `--color-*` custom properties in
  * packages/kobe-web/src/styles.css). One source of truth for brand colors:
  * a TUI theme switch fans out over the daemon's `ui-prefs` channel and the
@@ -15,6 +15,7 @@
 
 import claude from "../tui/context/theme/claude.json" with { type: "json" }
 import conductor from "../tui/context/theme/conductor.json" with { type: "json" }
+import { normalizeHex } from "../tui/context/theme/hex.ts"
 import tokyonight from "../tui/context/theme/tokyonight.json" with { type: "json" }
 
 type Variant = { dark: string; light: string }
@@ -53,11 +54,22 @@ const THEME_JSONS: Record<string, ThemeJson> = {
   tokyonight: tokyonight as ThemeJson,
 }
 
-function resolveHex(themeJson: ThemeJson, value: ColorValue | undefined, chain: string[] = []): string | null {
+/**
+ * Resolve a slot value to a canonical `#rrggbb` string (or `null` to skip),
+ * following def/slot refs and `{dark,light}` variants. A hex literal is run
+ * through the TUI's shared {@link normalizeHex} — the schema permits `#abc`,
+ * `#aabbcc`, and `#aabbccdd` (theme.schema.json), so shorthand must expand
+ * and the alpha byte must drop, exactly as `resolveTheme()`/`hex.ts` do for
+ * the TUI. Returning the literal verbatim (the earlier behavior) fed `#abc`
+ * and `#aabbccdd` straight into {@link mix}, which parses only 6 digits and
+ * so blended the wrong channels for derived slots. A malformed hex resolves
+ * to `null` (skip the option) rather than a garbage colour.
+ */
+export function resolveHex(themeJson: ThemeJson, value: ColorValue | undefined, chain: string[] = []): string | null {
   if (value === undefined) return null
   if (typeof value !== "string") return resolveHex(themeJson, value.dark, chain)
   if (value === "transparent" || value === "none") return null
-  if (value.startsWith("#")) return value
+  if (value.startsWith("#")) return normalizeHex(value)
   if (chain.includes(value)) return null
   const next = themeJson.defs?.[value] ?? themeJson.theme[value]
   return resolveHex(themeJson, next, [...chain, value])
@@ -68,8 +80,10 @@ function clampByte(n: number): number {
 }
 
 /** Blend `a` toward `b` by `t` (0..1) — for derived slots the theme JSONs
- *  don't carry (subtle text, hover states). */
-function mix(a: string, b: string, t: number): string {
+ *  don't carry (subtle text, hover states). Both inputs are canonical
+ *  `#rrggbb` (resolveHex normalizes, and this returns the same shape), so the
+ *  6-digit parse below is always exact. */
+export function mix(a: string, b: string, t: number): string {
   const pa = Number.parseInt(a.slice(1), 16)
   const pb = Number.parseInt(b.slice(1), 16)
   const ch = (p: number, shift: number): number => (p >> shift) & 0xff

--- a/packages/kobe/test/web/themes.test.ts
+++ b/packages/kobe/test/web/themes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { WEB_THEMES, type WebThemePalette, handleThemesRequest } from "../../src/web/themes.ts"
+import { WEB_THEMES, type WebThemePalette, handleThemesRequest, mix, resolveHex } from "../../src/web/themes.ts"
 
 /**
  * The web theme palettes are resolved at module load from the TUI's theme
@@ -64,6 +64,49 @@ describe("WEB_THEMES", () => {
     const p = WEB_THEMES.claude
     expect(p.bg).not.toBe(p.surface)
     expect(p.surface).not.toBe(p.inset)
+  })
+})
+
+describe("resolveHex", () => {
+  // The theme schema (theme.schema.json) permits `#abc`, `#aabbcc`, and
+  // `#aabbccdd`. The web resolver must canonicalize all three to `#rrggbb`
+  // exactly like the TUI's normalizeHex — a verbatim `#abc`/`#aabbccdd` used
+  // to reach mix() and blend the wrong channels for derived slots.
+  const theme = { theme: {} } as Parameters<typeof resolveHex>[0]
+
+  it("expands 3-digit shorthand hex", () => {
+    expect(resolveHex(theme, "#abc")).toBe("#aabbcc")
+  })
+
+  it("passes 6-digit hex through (lowercased)", () => {
+    expect(resolveHex(theme, "#AABBCC")).toBe("#aabbcc")
+  })
+
+  it("strips the alpha byte off 8-digit hex", () => {
+    expect(resolveHex(theme, "#aabbccdd")).toBe("#aabbcc")
+  })
+
+  it("resolves a {dark,light} variant's shorthand hex", () => {
+    expect(resolveHex(theme, { dark: "#fff", light: "#000" })).toBe("#ffffff")
+  })
+
+  it("returns null for a malformed hex rather than a garbage colour", () => {
+    expect(resolveHex(theme, "#xyz")).toBeNull()
+    expect(resolveHex(theme, "#12345")).toBeNull()
+  })
+})
+
+describe("mix", () => {
+  it("blends the true channels of a shorthand-derived colour", () => {
+    // #abc expands to #aabbcc; mixing fully toward it must yield #aabbcc, not
+    // the mis-parsed value the verbatim `#abc` produced.
+    const white = resolveHex({ theme: {} } as Parameters<typeof resolveHex>[0], "#abc") as string
+    expect(mix("#000000", white, 1)).toBe("#aabbcc")
+  })
+
+  it("returns the first colour at t=0 and the second at t=1", () => {
+    expect(mix("#102030", "#a0b0c0", 0)).toBe("#102030")
+    expect(mix("#102030", "#a0b0c0", 1)).toBe("#a0b0c0")
   })
 })
 


### PR DESCRIPTION
## Direction

Code health / architecture (c) + shipped-behavior-vs-documented-intent (e), from a review of the recently-touched theme surface.

## Problem

`packages/kobe/src/web/themes.ts` resolves the bundled theme JSONs into the web dashboard's flat `--color-*` palette. Its `resolveHex` returned every hex literal **verbatim**:

```ts
if (value.startsWith("#")) return value
```

But the theme schema (`tui/context/theme/theme.schema.json`) explicitly documents three accepted hex forms — `#abc`, `#aabbcc`, and `#aabbccdd` — and the TUI's own resolver canonicalizes all of them (`hex.ts` `normalizeHex`: expand shorthand, strip the alpha byte, reject malformed). The web's `mix()` helper, used for the derived slots the JSONs don't carry (subtle text, hover, border tones), parses only six digits:

```ts
const pa = Number.parseInt(a.slice(1), 16)   // "#abc" -> 0x000abc, wrong channels
```

So a slot written in the schema-sanctioned `#abc` shorthand or `#aabbccdd` (alpha) form would blend the **wrong channels** for every derived colour in the browser, and a malformed hex would produce a garbage `#NaN…` value. The web's own docstring claims it "mirrors the TUI's `resolveTheme`," but this was a divergent, incomplete second copy of that logic.

This is latent today only because the three bundled themes (claude / conductor / tokyonight) happen to use only 6-digit hex — but the schema permits the other forms, so any future bundled-theme edit (or theme the web comes to serve) using them would silently break the web palette while looking correct in the TUI.

## Fix

Route hex resolution through the TUI's canonical `normalizeHex`, so the web and TUI agree on one source of truth:

- `#abc` → `#aabbcc`
- `#aabbccdd` → `#aabbcc` (alpha dropped, matching the TUI)
- `#AABBCC` → `#aabbcc` (lowercased; CSS/consumers are case-insensitive, and the existing assertions already `.toLowerCase()`)
- malformed (`#xyz`, `#12345`) → `null`, so the slot is skipped rather than painted with garbage — the same "skip the option beats paint it black" contract `hex.ts` uses

`resolveHex` and `mix` are exported as test seams. No behavior change for the shipped 6-digit themes.

## Verification

- `bun run typecheck` — green
- `bun run lint` — green
- `bun test test/web/themes.test.ts test/tui/theme-hex.test.ts` — 24 pass (added `resolveHex`/`mix` cases for shorthand, alpha, `{dark,light}` variant, malformed, and endpoint blending; existing palette-contract tests unchanged)

Patch changeset included.

## Follow-ups (deliberately out of scope)

- The web registry still hard-imports its theme list separately from `BUNDLED_THEME_JSONS`; keeping the two in sync is already guarded by an existing test, not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lzwok7W8FSg1iUwJvYP1bs)_