### PR TITLE
fix: session.deliver test expects the clients count from #499

### DIFF
--- a/.changeset/republish-after-red-gate.md
+++ b/.changeset/republish-after-red-gate.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Republish: v0.8.145 and v0.8.146 never reached npm (a stale test assertion turned the release gate red). This release carries their changes — Kimi activity hooks, screen-state badges for hook-less engines, the contrib engine catalog (Gemini CLI, OpenCode, Cursor Agent, Grok CLI, Droid, Amp), plugin-contributed engines, and the worktree auto-adopt fix.

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -222,7 +222,8 @@ describe("daemon handler registry", () => {
     it("publishes with an explicit tabId and rejects an unknown task", async () => {
       const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === "t1" ? TASK : undefined) })
       const result = await dispatch("session.deliver", { taskId: "t1", text: "hi", tabId: "tab-2" }, ctx)
-      expect(result).toEqual({ ok: true })
+      // `clients` counts attached connections (#499's reached-nobody probe).
+      expect(result).toEqual({ ok: true, clients: 1 })
       const event = rec.published[0] as { channel: string; payload: Record<string, unknown> }
       expect(event.channel).toBe("session.deliver")
       expect(event.payload).toMatchObject({ taskId: "t1", text: "hi", tabId: "tab-2", source: "dispatcher" })


### PR DESCRIPTION
## What

v0.8.145 and v0.8.146 both failed to publish: the release workflow's test gate died on `test/daemon/handlers.test.ts > session.deliver` expecting `{ ok: true }` while the handler (since #499's dispatch-reached-nobody probe) returns `{ ok: true, clients: N }`.

Root cause: #512's branch was cut before #499 landed; its squash carried the pre-#499 assertion back onto main. Test-only fix — the assertion now matches the shipped handler. No runtime change.

Unblocks the pending release (5 changesets already consumed into 0.8.146; the release script's resume mode can retag once main is green).