### PR TITLE
fix(landing): plugins, themes and changelog match the home page again

### DIFF
--- a/.changeset/landing-page-consistency.md
+++ b/.changeset/landing-page-consistency.md
@@ -1,0 +1,17 @@
+---
+"@sma1lboy/rove": patch
+---
+
+fix(landing): plugins, themes and changelog match the home page again
+
+The nav, footer and design tokens were copy-pasted into every page, so the
+home page redesign (flat full-width bar, square frames) never reached the
+others — and the changelog was a different site entirely: dark background,
+Space Grotesk, hardcoded hex, and a nav pointing at three anchors the home
+page no longer has.
+
+All four pages now link one `chrome.css` for tokens, nav and footer. The
+changelog is rebuilt on it, keeps its live GitHub release rendering, and
+gains the nav language toggle the other pages already had (its EN/中文
+segmented control is gone; page copy is now translated too). Its type tags
+were darkened for a paper background.

--- a/packages/kobe-landing/changelog.html
+++ b/packages/kobe-landing/changelog.html
@@ -15,105 +15,106 @@
 <meta name="twitter:card" content="summary_large_image">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=DM+Sans:opsz,wght@9..40,300..700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/chrome.css">
 <style>
-  *{box-sizing:border-box;margin:0;padding:0}
-  body{background:#141413;}
-  ::selection{background:rgba(204,120,92,0.3);color:#eae7df}
-  a{color:inherit;}
-  /* language toggle */
-  .lang{display:inline-flex;border:1px solid #34302a;border-radius:9px;overflow:hidden;background:#1a1917;}
-  .lang button{font-family:inherit;font-size:12.5px;cursor:pointer;border:0;background:transparent;color:#8a847a;padding:6px 14px;transition:all .15s;}
-  .lang button[aria-pressed="true"]{background:rgba(204,120,92,0.14);color:#e6c1b1;}
-  /* release timeline */
-  .rel{position:relative;}
-  .rel-head{display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;margin-bottom:14px;}
-  .rel-tag{font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:24px;letter-spacing:-0.02em;color:#eae7df;text-decoration:none;}
-  .rel-tag:hover{color:#cc785c;}
-  .rel-date{font-size:12.5px;color:#6b655c;}
-  .rel-badge{font-size:10.5px;letter-spacing:0.08em;text-transform:uppercase;border:1px solid rgba(214,168,92,0.4);background:rgba(214,168,92,0.1);color:#d6a85c;border-radius:6px;padding:3px 8px;}
-  .rel-badge.latest{border-color:rgba(154,202,134,0.45);background:rgba(154,202,134,0.08);color:#9aca86;}
-  .rel-body{border:1px solid #2c2823;border-radius:13px;background:#171614;padding:8px 26px;}
-  .rn-h{font-family:'Space Grotesk',sans-serif;font-weight:600;font-size:12px;letter-spacing:0.1em;text-transform:uppercase;color:#cc785c;margin:20px 0 4px;}
-  .rn-ul{list-style:none;}
-  /* each bullet = one clear, scannable point: [type] summary */
-  .rn-li{position:relative;display:flex;align-items:baseline;gap:11px;padding:12px 0 12px 24px;font-size:14px;line-height:1.55;color:#d2ccc1;border-top:1px solid #211f1c;}
-  .rn-li:first-child{border-top:0;}
-  .rn-li::before{content:"";position:absolute;left:3px;top:18px;width:6px;height:6px;border-radius:2px;background:#cc785c;opacity:0.8;transform:rotate(45deg);}
-  .rn-li.tr-loading .sum{opacity:0.4;}
-  .rn-li .tag{flex:none;font-size:10.5px;font-weight:600;letter-spacing:0.03em;border-radius:5px;padding:2px 8px;border:1px solid;white-space:nowrap;}
-  .rn-li .sum{flex:1;min-width:0;}
-  .rn-li code{font-family:'JetBrains Mono',monospace;font-size:12.5px;background:#211f1c;border:1px solid #322d27;border-radius:5px;padding:1px 6px;color:#e6c1b1;}
-  .rn-li strong{color:#eae7df;font-weight:600;}
-  .rn-li a{color:#d98c72;text-decoration:none;border-bottom:1px solid rgba(217,140,114,0.3);}
-  .rn-li a:hover{color:#e6c1b1;}
-  html[data-lang="zh"] .rn-li .sum{font-family:'JetBrains Mono','PingFang SC','Microsoft YaHei',sans-serif;}
-  @media(max-width:760px){.rel-body{padding:6px 18px;}.rel-tag{font-size:21px;}}
+/* ============ PAGE HEAD ============ */
+.top{padding:clamp(112px,14vh,152px) 0 0}
+.kicker{font-family:var(--font-mono);font-size:12px;letter-spacing:.08em;color:var(--muted)}
+h1{margin:14px 0 16px;font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px,5.6vw,70px);font-weight:380;letter-spacing:-.028em;line-height:1.02;color:var(--ink)}
+.lede{font-size:clamp(15px,1.5vw,17px);color:var(--ink-soft);max-width:60ch}
+.lede code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash);border:1px solid oklch(62% 0.13 45/.18);padding:1px 6px;color:oklch(46% 0.11 45)}
+.rule{height:1px;background:var(--line);margin:44px 0 0}
+
+/* ============ RELEASE TIMELINE ============ */
+.releases{display:flex;flex-direction:column;gap:40px;padding:44px 0 0;max-width:900px}
+.loading{font-family:var(--font-mono);font-size:13px;color:var(--faint);padding:20px 0}
+.loading a{color:var(--accent);border-bottom:1px solid var(--accent-line)}
+.rel-head{display:flex;align-items:baseline;gap:14px;flex-wrap:wrap;margin-bottom:14px}
+.rel-tag{font-family:var(--font-mono);font-weight:700;font-size:21px;letter-spacing:-.01em;color:var(--ink);transition:color 140ms}
+.rel-tag:hover{color:var(--accent)}
+.rel-date{font-family:var(--font-mono);font-size:12px;color:var(--faint)}
+.rel-badge{font-family:var(--font-mono);font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;border:1px solid var(--line-2);background:var(--surface);color:var(--muted);padding:3px 8px}
+.rel-badge.latest{border-color:var(--accent-line);background:var(--accent-wash);color:var(--accent)}
+.rel-body{border:1px solid var(--line);border-radius:6px;background:var(--surface);padding:8px 26px}
+.rn-h{font-family:var(--font-mono);font-weight:600;font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--accent);margin:20px 0 4px}
+.rn-ul{list-style:none}
+/* each bullet = one clear, scannable point: [type] summary */
+.rn-li{position:relative;display:flex;align-items:baseline;gap:11px;padding:12px 0 12px 24px;font-size:14px;line-height:1.55;color:var(--ink-soft);border-top:1px solid var(--line)}
+/* the rotated square is the same mark the home page uses between stages */
+.rn-li::before{content:"";position:absolute;left:3px;top:19px;width:6px;height:6px;background:var(--accent);opacity:.75;transform:rotate(45deg)}
+.rn-li:first-child{border-top:0}
+.rn-li.tr-loading .sum{opacity:.4}
+.rn-li .tag{flex:none;font-family:var(--font-mono);font-size:10.5px;font-weight:500;letter-spacing:.03em;padding:2px 8px;border:1px solid;white-space:nowrap}
+/* the long token here is usually a slash-separated field list in prose, not
+   inside <code> — the translation path strips markdown, so the wrap rule has
+   to sit on the summary itself */
+.rn-li .sum{flex:1;min-width:0;overflow-wrap:anywhere}
+/* release bodies come from GitHub, so a bullet can carry an arbitrarily long
+   path or command; without this it pushes the page past the viewport at 390 */
+.rn-li code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash);border:1px solid oklch(62% 0.13 45/.18);padding:1px 6px;color:oklch(46% 0.11 45);overflow-wrap:anywhere}
+.rn-li strong{color:var(--ink);font-weight:600}
+.rn-li a{color:var(--accent);border-bottom:1px solid var(--accent-line)}
+.rn-li a:hover{border-bottom-color:var(--accent)}
+html[data-lang="zh"] .rn-li .sum{font-family:var(--font-mono),'PingFang SC','Microsoft YaHei',sans-serif}
+@media(max-width:760px){.rel-body{padding:6px 18px}.rel-tag{font-size:19px}}
 </style>
 </head>
 <body>
-<div style="background:#141413;color:#d6d0c6;font-family:'JetBrains Mono',monospace;min-height:100vh;overflow-x:hidden;position:relative;">
 
-  <!-- subtle grid bg -->
-  <div style="position:absolute;inset:0;background-image:linear-gradient(rgba(255,255,255,0.015) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,0.015) 1px,transparent 1px);background-size:64px 64px;pointer-events:none;mask-image:radial-gradient(ellipse 90% 60% at 50% 0%,#000 30%,transparent 80%);"></div>
+<!-- NAV · terminal command line (chrome.css) -->
+<header class="navbar">
+  <span class="ps">$</span>
+  <a class="bin" href="/">Rove</a>
+  <a class="nl" data-s="nav.workflow" href="/#workflow">--primitives</a>
+  <a class="nl" data-s="nav.install" href="/#install">--install</a>
+  <a class="nl" data-s="nav.plugins" href="/plugins">--plugins</a>
+  <a class="nl" data-s="nav.themes" href="/themes">--themes</a>
+  <a class="nl" href="/changelog" aria-current="page" data-s="nav.changelog">--changelog</a>
+  <span class="caret" aria-hidden="true"></span>
+  <button id="langToggle" class="lang-btn">中文</button>
+  <a class="gh-link" href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener">
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+    <span>GitHub</span>
+    <span class="gh-stars">
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 .25l2.06 4.18 4.61.67-3.34 3.25.79 4.6L8 10.97l-4.12 2.17.79-4.6L1.33 5.1l4.61-.67L8 .25z"/></svg>
+      <span id="starCount">–</span>
+    </span>
+  </a>
+</header>
 
-  <!-- NAV -->
-  <nav style="position:relative;max-width:1180px;margin:0 auto;padding:26px 40px;display:flex;align-items:center;justify-content:space-between;">
-    <a href="/" style="display:flex;align-items:center;gap:9px;font-weight:700;font-size:18px;letter-spacing:-0.01em;text-decoration:none;">
-      <span style="color:#cc785c;">[</span>
-      <span style="color:#eae7df;">Rove</span>
-      <span style="color:#cc785c;">]</span>
-    </a>
-    <div style="display:flex;align-items:center;gap:30px;font-size:13.5px;color:#8a847a;">
-      <a href="/#workspace" style="color:#8a847a;text-decoration:none;">workspace</a>
-      <a href="/#why" style="color:#8a847a;text-decoration:none;">why</a>
-      <a href="/#engines" style="color:#8a847a;text-decoration:none;">engines</a>
-      <a href="/changelog" style="color:#e6c1b1;text-decoration:none;">changelog</a>
-      <a href="https://github.com/Sma1lboy/rove" target="_blank" rel="noopener" style="color:#eae7df;text-decoration:none;border:1px solid #34302a;padding:7px 12px;border-radius:8px;display:flex;align-items:center;gap:8px;">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style="flex:none;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        <span>GitHub</span>
-        <span style="display:flex;align-items:center;gap:4px;border-left:1px solid #34302a;padding-left:8px;color:#a39d92;">
-          <svg width="13" height="13" viewBox="0 0 16 16" fill="#d6a85c" aria-hidden="true" style="flex:none;"><path d="M8 .25l2.06 4.18 4.61.67-3.34 3.25.79 4.6L8 10.97l-4.12 2.17.79-4.6L1.33 5.1l4.61-.67L8 .25z"/></svg>
-          <span id="starCount">–</span>
-        </span>
-      </a>
-    </div>
-  </nav>
+<div class="wrap">
 
-  <!-- HEADER -->
-  <header style="position:relative;max-width:880px;margin:0 auto;padding:50px 40px 30px;">
-    <span style="color:#cc785c;font-size:13px;">// releases</span>
-    <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:20px;flex-wrap:wrap;margin:12px 0 16px;">
-      <h1 style="font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:clamp(34px,4.6vw,52px);line-height:1.02;letter-spacing:-0.03em;color:#eae7df;">Changelog</h1>
-      <div class="lang" role="group" aria-label="language">
-        <button id="langEn" aria-pressed="true">EN</button>
-        <button id="langZh" aria-pressed="false">中文</button>
-      </div>
-    </div>
-    <p id="sub" style="font-size:15.5px;line-height:1.6;color:#a39d92;max-width:56ch;">Every Rove release, pulled live from GitHub. <code style="font-family:'JetBrains Mono',monospace;font-size:13px;color:#e6c1b1;background:#211f1c;border:1px solid #322d27;border-radius:5px;padding:1px 7px;">bun install -g @sma1lboy/rove</code> to update.</p>
-  </header>
+  <section class="top">
+    <p class="kicker" data-s="kicker">// releases</p>
+    <h1 data-s="title">Changelog</h1>
+    <p class="lede" data-s="lede">Every Rove release, pulled live from GitHub. <code>bun install -g @sma1lboy/rove</code> to update.</p>
+  </section>
 
-  <!-- TIMELINE -->
-  <main style="position:relative;max-width:880px;margin:0 auto;padding:0 40px 110px;">
-    <div id="releases" style="display:flex;flex-direction:column;gap:40px;">
-      <div id="loading" style="color:#6b655c;font-size:14px;padding:20px 0;">Loading releases…</div>
-    </div>
+  <div class="rule"></div>
 
-    <!-- footer -->
-    <div style="margin-top:70px;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:18px;border-top:1px solid #26221d;padding-top:28px;">
-      <a href="/" style="display:flex;align-items:center;gap:9px;color:#6b655c;font-size:13px;font-weight:600;text-decoration:none;">
-        <span style="color:#cc785c;">[</span><span style="color:#a39d92;">Rove</span><span style="color:#cc785c;">]</span>
-        <span style="font-weight:400;margin-left:4px;">parallel coding agents, terminal-native.</span>
-      </a>
-      <div style="display:flex;gap:24px;font-size:13px;color:#6b655c;">
-        <a href="https://github.com/Sma1lboy/rove/releases" target="_blank" rel="noopener" style="color:#6b655c;text-decoration:none;">All releases ↗</a>
-        <a href="https://www.npmjs.com/package/@sma1lboy/rove" style="color:#6b655c;text-decoration:none;">npm</a>
-        <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" style="color:#6b655c;text-decoration:none;">Keybindings</a>
-      </div>
-    </div>
+  <main class="releases" id="releases">
+    <div class="loading" id="loading">Loading releases…</div>
   </main>
 
 </div>
+
+<!-- FOOTER · dense colophon -->
+<footer class="foot-dense foot-spaced">
+  <div class="foot-inner">
+    <p class="foot-id">
+      <span class="mark">[Rove]</span> <span class="tagline" data-s="footer.tagline">a terminal multiplexer for coding agents.</span>
+      <span class="foot-colophon" data-s="footer.colophon">Release notes are pulled live from the GitHub Releases API; 中文 is machine-translated on demand.</span>
+    </p>
+    <nav class="foot-links" aria-label="Footer">
+      <a href="https://github.com/Sma1lboy/rove/releases" target="_blank" rel="noopener" data-s="footer.allReleases">all releases</a>
+      <a href="https://www.npmjs.com/package/@sma1lboy/rove" target="_blank" rel="noopener">npm</a>
+      <a href="/plugins" data-s="footer.plugins">plugins</a>
+      <a href="/themes" data-s="footer.themesLink">themes</a>
+      <a href="https://github.com/Sma1lboy/rove/blob/main/docs/KEYBINDINGS.md" target="_blank" rel="noopener" data-s="footer.keybindings">keybindings</a>
+    </nav>
+  </div>
+</footer>
 
 <script>
   // live GitHub star count (shared with the home page; cache for instant paint)
@@ -134,8 +135,45 @@
     var loading = document.getElementById('loading');
     if (!host) return;
 
+    // same resolution order as index.js: ?lang= → stored pref → browser
     var LANG = 'en';
-    try { if (localStorage.getItem('kobe_lang') === 'zh') LANG = 'zh'; } catch (e) {}
+    try {
+      var fromUrl = new URLSearchParams(location.search).get('lang');
+      var stored = localStorage.getItem('kobe_lang');
+      var nav = (navigator.language || '').toLowerCase().indexOf('zh') === 0 ? 'zh' : 'en';
+      LANG = fromUrl === 'zh' || fromUrl === 'en' ? fromUrl : stored === 'zh' || stored === 'en' ? stored : nav;
+    } catch (e) {}
+
+    // the page's own copy. Release bodies come from GitHub and go through the
+    // translation path below; these six strings do not need a round trip.
+    var STATIC = {
+      'meta.title': { en: 'Rove — changelog', zh: 'Rove — 更新日志' },
+      'meta.desc': { en: 'Release notes for Rove — the local-first TUI orchestrator for parallel AI coding agents. Every version, pulled live from GitHub, in English or Chinese.', zh: 'Rove 的发布说明——本地优先的并行 AI 编码代理 TUI 编排器。每个版本都实时取自 GitHub，中英文皆可。' },
+      'kicker': { en: '// releases', zh: '// 发布' },
+      'title': { en: 'Changelog', zh: '更新日志' },
+      'lede': { en: 'Every Rove release, pulled live from GitHub. <code>bun install -g @sma1lboy/rove</code> to update.', zh: '每一个 Rove 版本，实时取自 GitHub。用 <code>bun install -g @sma1lboy/rove</code> 更新。' },
+      'footer.tagline': { en: 'a terminal multiplexer for coding agents.', zh: '终端里的编码代理多路复用器。' },
+      'footer.colophon': { en: 'Release notes are pulled live from the GitHub Releases API; 中文 is machine-translated on demand.', zh: '发布说明实时取自 GitHub Releases API；中文为按需机器翻译。' },
+      'footer.plugins': { en: 'plugins', zh: '插件' },
+      'footer.themesLink': { en: 'themes', zh: '主题' },
+      'footer.keybindings': { en: 'keybindings', zh: '快捷键' },
+      'footer.allReleases': { en: 'all releases', zh: '全部版本' },
+      'nav.workflow': { en: '--primitives', zh: '--原语' },
+      'nav.install': { en: '--install', zh: '--安装' },
+      'nav.plugins': { en: '--plugins', zh: '--插件' },
+      'nav.themes': { en: '--themes', zh: '--主题' },
+      'nav.changelog': { en: '--changelog', zh: '--更新日志' },
+    };
+    function applyStatic() {
+      document.documentElement.lang = LANG === 'zh' ? 'zh-CN' : 'en';
+      document.title = STATIC['meta.title'][LANG];
+      var desc = document.querySelector('meta[name="description"]');
+      if (desc) desc.setAttribute('content', STATIC['meta.desc'][LANG]);
+      document.querySelectorAll('[data-s]').forEach(function (el) {
+        var v = STATIC[el.getAttribute('data-s')];
+        if (v) el.innerHTML = v[LANG];
+      });
+    }
 
     // ---- tiny markdown (inline) for the EN render ----
     function esc(s) { return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
@@ -153,7 +191,10 @@
     }
 
     // conventional-commit type → tint + Chinese label (the scannable tag on each bullet)
-    var TYPE_TINT = { feat: '#9aca86', fix: '#cc785c', perf: '#7fb5d6', refactor: '#d6a85c', chore: '#8a847a', test: '#a98fd0', ci: '#8a847a', docs: '#7fb5d6', style: '#8a847a', build: '#8a847a', revert: '#cc785c' };
+    // Tints are darkened from the old dark-theme set: the page is paper now,
+    // and the pale versions were unreadable on it. The '55'/'14' suffixes below
+    // are hex alpha, so these stay hex rather than moving to the oklch tokens.
+    var TYPE_TINT = { feat: '#3f7a45', fix: '#a8482c', perf: '#2f6a8e', refactor: '#8a6212', chore: '#6b655c', test: '#6a4d9c', ci: '#6b655c', docs: '#2f6a8e', style: '#6b655c', build: '#6b655c', revert: '#a8482c' };
     var TYPE_ZH = { feat: '新功能', fix: '修复', perf: '性能', refactor: '重构', chore: '杂项', test: '测试', ci: 'CI', docs: '文档', style: '样式', build: '构建', revert: '回退' };
     function splitBullet(raw) {
       raw = raw.replace(/^[0-9a-f]{7,40}:\s*/i, '');                 // drop the commit sha prefix (pre-0.8.139 entries)
@@ -195,7 +236,7 @@
         }
       }
       close();
-      return out.join('') || '<ul class="rn-ul"><li class="rn-li"><span class="sum" style="color:#6b655c;">—</span></li></ul>';
+      return out.join('') || '<ul class="rn-ul"><li class="rn-li"><span class="sum" style="color:var(--faint);">—</span></li></ul>';
     }
 
     function fmtDate(iso) { try { return new Date(iso).toLocaleDateString(LANG === 'zh' ? 'zh-CN' : 'en-US', { year: 'numeric', month: 'short', day: 'numeric' }); } catch (e) { return ''; } }
@@ -257,8 +298,9 @@
 
     function applyLang() {
       document.documentElement.setAttribute('data-lang', LANG);
-      document.getElementById('langEn').setAttribute('aria-pressed', LANG === 'en' ? 'true' : 'false');
-      document.getElementById('langZh').setAttribute('aria-pressed', LANG === 'zh' ? 'true' : 'false');
+      var toggle = document.getElementById('langToggle');
+      if (toggle) toggle.textContent = LANG === 'zh' ? 'EN' : '中文';
+      applyStatic();
       try { localStorage.setItem('kobe_lang', LANG); } catch (e) {}
       // type tags swap label instantly (no API): fix ⇄ 修复, feat ⇄ 新功能, …
       [].slice.call(document.querySelectorAll('.rn-li .tag')).forEach(function (tg) {
@@ -270,13 +312,15 @@
       else { cards.forEach(function (c) { if (io) io.observe(c); else translateCard(c); }); }
     }
 
-    document.getElementById('langEn').addEventListener('click', function () { if (LANG === 'en') return; LANG = 'en'; applyLang(); });
-    document.getElementById('langZh').addEventListener('click', function () { if (LANG === 'zh') return; LANG = 'zh'; applyLang(); });
+    applyLang(); // first paint: nav toggle + page copy, before releases arrive
+
+    var langBtn = document.getElementById('langToggle');
+    if (langBtn) langBtn.addEventListener('click', function () { LANG = LANG === 'zh' ? 'en' : 'zh'; applyLang(); });
 
     fetch('https://api.github.com/repos/Sma1lboy/rove/releases?per_page=100')
       .then(function (r) { if (!r.ok) throw new Error('http ' + r.status); return r.json(); })
       .then(function (rels) {
-        if (!Array.isArray(rels) || !rels.length) { loading.innerHTML = 'No releases yet. See <a href="https://github.com/Sma1lboy/rove/releases" style="color:#d98c72;">GitHub</a>.'; return; }
+        if (!Array.isArray(rels) || !rels.length) { loading.innerHTML = 'No releases yet. See <a href="https://github.com/Sma1lboy/rove/releases" style="color:var(--accent);">GitHub</a>.'; return; }
         host.innerHTML = rels.map(function (rel, idx) {
           var tag = esc(rel.tag_name || rel.name || '');
           var badge = idx === 0 ? '<span class="rel-badge latest">latest</span>' : (rel.prerelease ? '<span class="rel-badge">prerelease</span>' : '');
@@ -290,7 +334,7 @@
         }).join('');
         applyLang();
       })
-      .catch(function () { loading.innerHTML = 'Couldn’t load releases (GitHub API). See the full list on <a href="https://github.com/Sma1lboy/rove/releases" style="color:#d98c72;">GitHub ↗</a>.'; });
+      .catch(function () { loading.innerHTML = 'Couldn’t load releases (GitHub API). See the full list on <a href="https://github.com/Sma1lboy/rove/releases" style="color:var(--accent);">GitHub ↗</a>.'; });
   })();
 </script>
 </body>

--- a/packages/kobe-landing/chrome.css
+++ b/packages/kobe-landing/chrome.css
@@ -1,0 +1,98 @@
+/* Shared page chrome — tokens, reset, nav, footer.
+   Every page links this and adds only its own sections. It used to be a
+   copy of the same ~70 lines inside each <style> block, which is why the
+   home page could be redesigned (flat bar, square frames) while plugins,
+   themes and changelog kept the older rounded-pill language. */
+:root{
+  --paper:     oklch(97.8% 0.007 85);
+  --surface:   oklch(99.4% 0.003 90);
+  --well:      oklch(22% 0.02 50);
+  --well-2:    oklch(27% 0.022 50);
+  --well-ink:  oklch(88% 0.015 85);
+  --ink:       oklch(25% 0.02 60);
+  --ink-soft:  oklch(35% 0.02 55);
+  --muted:     oklch(50% 0.02 60);
+  --faint:     oklch(62% 0.018 65);
+  --line:      oklch(88% 0.014 80);
+  --line-2:    oklch(83% 0.018 75);
+  --accent:    oklch(62% 0.13 45);
+  --accent-2:  oklch(70% 0.11 50);
+  --accent-wash: oklch(62% 0.13 45 / .1);
+  --accent-line: oklch(62% 0.13 45 / .4);
+  --ok:        oklch(58% 0.12 145);
+  --warn:      oklch(62% 0.11 80);
+  --radius:    12px;
+  --radius-lg: 22px;
+  --font-display:'Fraunces', Georgia, serif;
+  --font-sans:'DM Sans', system-ui, sans-serif;
+  --font-mono:'JetBrains Mono', ui-monospace, monospace;
+  --ease-out: cubic-bezier(0.16,1,0.3,1);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html,body{background:var(--paper)}
+body{color:var(--ink-soft);font-family:var(--font-sans);font-weight:380;font-size:15px;line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+::selection{background:oklch(62% 0.13 45/.22)}
+a{color:inherit;text-decoration:none}
+button,input,select{font-family:inherit}
+button{cursor:pointer}
+:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:4px}
+.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px)}
+.acc{color:var(--accent);font-style:italic}
+
+/* ============ NAV — a terminal command line, full width ============ */
+.navbar{position:fixed;top:0;left:0;right:0;z-index:50;display:flex;align-items:center;gap:2px;padding:10px clamp(20px,4vw,52px);background:oklch(97.8% 0.007 85/.82);backdrop-filter:blur(14px);border-bottom:1px solid var(--line);font-family:var(--font-mono);font-size:12.5px}
+.navbar .ps{color:var(--accent);padding-left:8px}
+.navbar .bin{font-weight:700;color:var(--ink);padding:6px 14px 6px 4px}
+.navbar a.nl{color:var(--muted);padding:6px 10px;transition:color 140ms;white-space:nowrap}
+.navbar a.nl:hover{color:var(--accent)}
+.navbar a.nl[aria-current="page"]{color:var(--accent)}
+.navbar .caret{display:inline-block;width:7px;height:14px;background:var(--accent);margin:0 4px 0 2px;animation:blink 1.1s steps(1) infinite;vertical-align:-2px;margin-right:auto}
+@keyframes blink{50%{opacity:0}}
+.lang-btn{font-family:var(--font-mono);font-size:11.5px;border:1px solid var(--line-2);background:transparent;color:var(--muted);padding:6px 12px;margin-left:6px;transition:all 140ms;white-space:nowrap}
+.lang-btn:hover{border-color:var(--accent-line);color:var(--ink)}
+.gh-link{display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:12px;font-weight:500;background:var(--ink);color:oklch(97% 0.008 85);padding:7px 14px;margin-left:8px;transition:background 140ms;white-space:nowrap}
+.gh-link:hover{background:var(--accent);color:oklch(99% 0.005 85)}
+.gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
+/* This used to hide all five links, leaving `$ Rove [中文] [GitHub]` — the
+   defect fixed in #511/#513. The section anchors go first (they scroll to
+   content that only exists on the home page), then changelog, which the
+   footer also links. Measured against the real bar, not guessed. */
+@media(max-width:820px){
+  .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
+  .navbar a.nl{padding:6px 8px}
+}
+@media(max-width:460px){
+  .navbar a.nl[href*="changelog"]{display:none}
+  .gh-link>span:not(.gh-stars){display:none}
+  .navbar{padding:10px 12px}
+  .navbar .bin{padding-right:6px}
+  .navbar a.nl{padding:6px 6px}
+  .lang-btn{padding:6px 9px;margin-left:4px}
+  .gh-link{padding:7px 11px;margin-left:5px}
+}
+
+/* ============ FOOTER ============
+   Two blocks, not one paragraph: identity on the left, navigation on the
+   right. The links get the navbar's mono treatment — the vocabulary the
+   rest of the page already uses for controls. */
+.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:40px 0;font-size:13px;color:var(--faint)}
+/* subpages end on content, so they need the breathing room the home page
+   gets from its final band */
+.foot-dense.foot-spaced{margin-top:clamp(70px,9vw,110px)}
+.foot-inner{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);display:flex;flex-wrap:wrap;justify-content:space-between;gap:22px 44px}
+.foot-id{max-width:56ch;line-height:1.7}
+.foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
+.foot-dense .tagline{color:var(--ink-soft)}
+/* the colophon is credits, not a claim — its own line, one step quieter */
+.foot-colophon{display:block;margin-top:7px;font-size:12px;color:var(--faint)}
+/* no margin-left:auto — space-between already right-aligns it on one line,
+   and once it wraps to its own row the auto margin would strand it right */
+.foot-links{display:flex;flex-wrap:wrap;align-items:baseline;gap:2px;font-family:var(--font-mono);font-size:12.5px}
+.foot-links a{color:var(--muted);padding:5px 11px;transition:color 140ms,background 140ms}
+.foot-links a:hover{color:var(--accent);background:var(--accent-wash)}
+
+@media (prefers-reduced-motion: reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}
+  .rise{opacity:1;transform:none}
+  .reveal{opacity:1;transform:none}
+}

--- a/packages/kobe-landing/index.html
+++ b/packages/kobe-landing/index.html
@@ -16,78 +16,12 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=DM+Sans:opsz,wght@9..40,300..700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/chrome.css">
 <link rel="stylesheet" href="/fleet.css">
 <link rel="stylesheet" href="/fanout.css">
 <link rel="stylesheet" href="/peers.css">
 <link rel="stylesheet" href="/ssh.css">
 <style>
-:root{
-  --paper:     oklch(97.8% 0.007 85);
-  --surface:   oklch(99.4% 0.003 90);
-  --well:      oklch(22% 0.02 50);
-  --well-2:    oklch(27% 0.022 50);
-  --well-ink:  oklch(88% 0.015 85);
-  --ink:       oklch(25% 0.02 60);
-  --ink-soft:  oklch(35% 0.02 55);
-  --muted:     oklch(50% 0.02 60);
-  --faint:     oklch(62% 0.018 65);
-  --line:      oklch(88% 0.014 80);
-  --line-2:    oklch(83% 0.018 75);
-  --accent:    oklch(62% 0.13 45);
-  --accent-2:  oklch(70% 0.11 50);
-  --accent-wash: oklch(62% 0.13 45 / .1);
-  --accent-line: oklch(62% 0.13 45 / .4);
-  --ok:        oklch(58% 0.12 145);
-  --warn:      oklch(62% 0.11 80);
-  --radius:    12px;
-  --radius-lg: 22px;
-  --font-display:'Fraunces', Georgia, serif;
-  --font-sans:'DM Sans', system-ui, sans-serif;
-  --font-mono:'JetBrains Mono', ui-monospace, monospace;
-  --ease-out: cubic-bezier(0.16,1,0.3,1);
-}
-*{box-sizing:border-box;margin:0;padding:0}
-html,body{background:var(--paper)}
-body{color:var(--ink-soft);font-family:var(--font-sans);font-weight:380;font-size:15px;line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-::selection{background:oklch(62% 0.13 45/.22)}
-a{color:inherit;text-decoration:none}
-button{font-family:inherit;cursor:pointer}
-:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:4px}
-.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px)}
-.acc{color:var(--accent);font-style:italic}
-
-/* ============ NAV — glass pill, terminal grammar ============ */
-.navbar{position:fixed;top:0;left:0;right:0;z-index:50;display:flex;align-items:center;gap:2px;padding:10px clamp(20px,4vw,52px);background:oklch(97.8% 0.007 85/.82);backdrop-filter:blur(14px);border-bottom:1px solid var(--line);font-family:var(--font-mono);font-size:12.5px}
-.navbar .ps{color:var(--accent);padding-left:8px}
-.navbar .bin{font-weight:700;color:var(--ink);padding:6px 14px 6px 4px}
-.navbar a.nl{color:var(--muted);padding:6px 10px;transition:color 140ms;white-space:nowrap}
-.navbar a.nl:hover{color:var(--accent)}
-.navbar .caret{display:inline-block;width:7px;height:14px;background:var(--accent);margin:0 4px 0 2px;animation:blink 1.1s steps(1) infinite;vertical-align:-2px;margin-right:auto}
-@keyframes blink{50%{opacity:0}}
-.lang-btn{font-family:var(--font-mono);font-size:11.5px;border:1px solid var(--line-2);background:transparent;color:var(--muted);padding:6px 12px;margin-left:6px;transition:all 140ms;white-space:nowrap}
-.lang-btn:hover{border-color:var(--accent-line);color:var(--ink)}
-.gh-link{display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:12px;font-weight:500;background:var(--ink);color:oklch(97% 0.008 85);padding:7px 14px;margin-left:8px;transition:background 140ms;white-space:nowrap}
-.gh-link:hover{background:var(--accent);color:oklch(99% 0.005 85)}
-.gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
-/* This used to hide all five links, leaving `$ Rove [中文] [GitHub]` — the
-   same defect fixed on plugins/themes in #511. The home bar is full-width,
-   so it keeps more than the pill could: the section anchors go first (they
-   scroll to content already on this page), then changelog, which the footer
-   also links. Measured against the real bar, not guessed. */
-@media(max-width:820px){
-  .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
-  .navbar a.nl{padding:6px 8px}
-}
-@media(max-width:460px){
-  .navbar a.nl[href*="changelog"]{display:none}
-  .gh-link>span:not(.gh-stars){display:none}
-  .navbar{padding:10px 12px}
-  .navbar .bin{padding-right:6px}
-  .navbar a.nl{padding:6px 6px}
-  .lang-btn{padding:6px 9px;margin-left:4px}
-  .gh-link{padding:7px 11px;margin-left:5px}
-}
-
 /* ============ HERO ============ */
 /* padding-bottom gives the veil runway below the equation — without it the
    hero clips exactly at the equation and the fade cuts off as a hard line */
@@ -196,34 +130,11 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(44px
 .final-band .wrap{position:relative;z-index:2;text-align:center}
 .final-band .h2f{font-family:var(--font-display);font-size:clamp(30px,4.6vw,56px);font-weight:400;letter-spacing:-.02em;color:var(--ink);max-width:20ch;margin:0 auto;text-shadow:0 1px 26px oklch(97% 0.01 85/.9)}
 
-/* ============ FOOTER ============
-   Two blocks, not one paragraph: identity on the left, navigation on the
-   right. The links were prose-colored and underlined, so they read as part
-   of the colophon sentence — they get the navbar's mono treatment instead,
-   which is the vocabulary the rest of the page already uses for controls. */
-.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:40px 0;font-size:13px;color:var(--faint)}
-.foot-inner{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);display:flex;flex-wrap:wrap;justify-content:space-between;gap:22px 44px}
-.foot-id{max-width:56ch;line-height:1.7}
-.foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
-.foot-dense .tagline{color:var(--ink-soft)}
-/* the colophon is credits, not a claim — its own line, one step quieter */
-.foot-colophon{display:block;margin-top:7px;font-size:12px;color:var(--faint)}
-/* no margin-left:auto — space-between already right-aligns it on one line,
-   and once it wraps to its own row the auto margin would strand it right */
-.foot-links{display:flex;flex-wrap:wrap;align-items:baseline;gap:2px;font-family:var(--font-mono);font-size:12.5px}
-.foot-links a{color:var(--muted);padding:5px 11px;transition:color 140ms,background 140ms}
-.foot-links a:hover{color:var(--accent);background:var(--accent-wash)}
-
-@media (prefers-reduced-motion: reduce){
-  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}
-  .rise{opacity:1;transform:none}
-  .reveal{opacity:1!important;transform:none!important}
-}
 </style>
 </head>
 <body>
 
-<!-- NAV · terminal command in a glass pill -->
+<!-- NAV · terminal command line (chrome.css) -->
 <header class="navbar">
   <span class="ps">$</span>
   <a class="bin" href="/">Rove</a>

--- a/packages/kobe-landing/plugins.html
+++ b/packages/kobe-landing/plugins.html
@@ -16,84 +16,11 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=DM+Sans:opsz,wght@9..40,300..700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/chrome.css">
 <style>
-:root{
-  --paper:     oklch(97.8% 0.007 85);
-  --surface:   oklch(99.4% 0.003 90);
-  --well:      oklch(22% 0.02 50);
-  --well-2:    oklch(27% 0.022 50);
-  --well-ink:  oklch(88% 0.015 85);
-  --ink:       oklch(25% 0.02 60);
-  --ink-soft:  oklch(35% 0.02 55);
-  --muted:     oklch(50% 0.02 60);
-  --faint:     oklch(62% 0.018 65);
-  --line:      oklch(88% 0.014 80);
-  --line-2:    oklch(83% 0.018 75);
-  --accent:    oklch(62% 0.13 45);
-  --accent-2:  oklch(70% 0.11 50);
-  --accent-wash: oklch(62% 0.13 45 / .1);
-  --accent-line: oklch(62% 0.13 45 / .4);
-  --ok:        oklch(58% 0.12 145);
-  --warn:      oklch(62% 0.11 80);
-  --radius:    12px;
-  --radius-lg: 22px;
-  --font-display:'Fraunces', Georgia, serif;
-  --font-sans:'DM Sans', system-ui, sans-serif;
-  --font-mono:'JetBrains Mono', ui-monospace, monospace;
-  --ease-out: cubic-bezier(0.16,1,0.3,1);
-}
-*{box-sizing:border-box;margin:0;padding:0}
-html,body{background:var(--paper)}
-body{color:var(--ink-soft);font-family:var(--font-sans);font-weight:380;font-size:15px;line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-::selection{background:oklch(62% 0.13 45/.22)}
-a{color:inherit;text-decoration:none}
-button,input,select{font-family:inherit;font-size:inherit}
-button{cursor:pointer}
-:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:4px}
-.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px)}
-.acc{color:var(--accent);font-style:italic}
-
-/* ============ NAV — glass pill, terminal grammar (shared with the home page) ============ */
-.navbar{position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:50;display:flex;align-items:center;gap:2px;padding:6px 8px;border-radius:999px;background:oklch(100% 0 0/.55);backdrop-filter:blur(16px) saturate(1.3);border:1px solid oklch(100% 0 0/.8);box-shadow:0 10px 36px oklch(40% 0.04 60/.16);font-family:var(--font-mono);font-size:12.5px;max-width:calc(100vw - 24px)}
-.navbar .ps{color:var(--accent);padding-left:8px}
-.navbar .bin{font-weight:700;color:var(--ink);padding:8px 6px 8px 4px}
-.navbar a.nl{color:var(--ink-soft);padding:8px 10px;border-radius:999px;transition:background 140ms,color 140ms;white-space:nowrap}
-.navbar a.nl:hover{background:oklch(100% 0 0/.85);color:var(--ink)}
-.navbar a.nl[aria-current="page"]{background:var(--accent-wash);color:var(--accent)}
-.navbar .caret{display:inline-block;width:7px;height:14px;background:var(--accent);margin:0 4px 0 2px;animation:blink 1.1s steps(1) infinite;vertical-align:-2px}
-@keyframes blink{50%{opacity:0}}
-.lang-btn{font-family:var(--font-mono);font-size:11.5px;border:1px solid var(--line-2);background:transparent;color:var(--ink-soft);border-radius:999px;padding:6px 12px;margin-left:6px;transition:all 140ms;white-space:nowrap}
-.lang-btn:hover{border-color:var(--accent-line);color:var(--ink)}
-.gh-link{display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:12px;font-weight:500;background:var(--ink);color:oklch(97% 0.008 85);border-radius:999px;padding:8px 15px;margin-left:6px;transition:transform 120ms,box-shadow 160ms;white-space:nowrap}
-.gh-link:hover{transform:translateY(-1px);box-shadow:0 6px 18px oklch(25% 0.02 60/.3)}
-.gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
-/* Below 820px the pill used to drop ALL five links with `display:none`,
-   leaving `$ Rove [中文] [GitHub]` — a nav bar with no navigation. Keep the
-   cross-page ones and drop only `--primitives` / `--install`, which are
-   home-page section anchors already reachable through `$ Rove`. That fits
-   one row, so the pill keeps its shape instead of stacking over the hero. */
-@media(max-width:820px){
-  .navbar{gap:0;padding:5px 6px;max-width:calc(100vw - 16px)}
-  .navbar .caret{display:none}
-  .navbar a.nl{padding:7px 7px;font-size:11.5px}
-  .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
-  .lang-btn{padding:5px 8px;margin-left:4px}
-  .gh-link{padding:7px 10px;margin-left:4px}
-}
-@media(max-width:460px){
-  /* the label is redundant next to the mark, and dropping it is what keeps
-     the whole pill inside the viewport at 390 */
-  .gh-link>span:not(.gh-stars){display:none}
-  .navbar a.nl{padding:7px 5px}
-  .navbar .bin{padding-right:2px}
-  /* still 34px over at 390 — changelog is the one to go, it sits in the
-     footer of every page while plugins/themes have no other entry point */
-  .navbar a.nl[href*="changelog"]{display:none}
-}
-
 /* ============ PAGE HEAD ============ */
 .head{padding:clamp(112px,14vh,152px) 0 0;text-align:center}
-.kicker{display:inline-block;font-family:var(--font-mono);font-size:12px;letter-spacing:.08em;color:var(--ink-soft);background:var(--surface);border:1px solid var(--line-2);padding:8px 18px;border-radius:999px}
+.kicker{display:inline-block;font-family:var(--font-mono);font-size:12px;letter-spacing:.08em;color:var(--muted)}
 h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px,5.6vw,70px);font-weight:380;letter-spacing:-.028em;line-height:1.02;color:var(--ink);max-width:17ch;margin:24px auto 20px}
 .head-sub{font-size:clamp(15px,1.5vw,17px);max-width:60ch;color:var(--ink-soft);margin:0 auto}
 .head-term{max-width:640px;margin:34px auto 0;text-align:left}
@@ -101,7 +28,7 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 @keyframes rise{to{opacity:1;transform:none}}
 
 /* dark terminal block — same well as the home page */
-.term-frame{border-radius:var(--radius-lg);overflow:hidden;background:linear-gradient(180deg,oklch(24% 0.021 50),var(--well) 60%);border:1px solid oklch(32% 0.024 50);box-shadow:0 22px 52px oklch(42% 0.06 50/.2)}
+.term-frame{border-radius:6px;overflow:hidden;background:linear-gradient(180deg,oklch(24% 0.021 50),var(--well) 60%);border:1px solid oklch(32% 0.024 50);box-shadow:0 22px 52px oklch(42% 0.06 50/.2)}
 .tbar{display:flex;align-items:center;gap:8px;padding:11px 18px;background:linear-gradient(180deg,oklch(30% 0.022 50),var(--well-2));font-family:var(--font-mono);font-size:11px;color:oklch(68% 0.035 60);border-bottom:1px solid oklch(19% 0.018 50);box-shadow:inset 0 1px 0 oklch(90% 0.04 70/.08)}
 .tbar i{width:9px;height:9px;border-radius:50%;background:oklch(42% 0.02 55)}
 .tbar i.r{background:oklch(65% 0.16 25)}
@@ -124,7 +51,7 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 
 /* ============ MARKETPLACE CONTROLS ============ */
 .controls{display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin:26px 0 14px}
-.field{display:inline-flex;align-items:center;gap:9px;background:var(--surface);border:1px solid var(--line-2);border-radius:999px;padding:10px 18px;transition:border-color 140ms}
+.field{display:inline-flex;align-items:center;gap:9px;background:var(--surface);border:1px solid var(--line-2);padding:10px 18px;transition:border-color 140ms}
 .field:focus-within{border-color:var(--accent-line)}
 .field .ps{font-family:var(--font-mono);color:var(--accent);font-size:13px}
 .field input{border:0;background:transparent;color:var(--ink);font-family:var(--font-mono);font-size:13px;width:min(30vw,240px);outline:0}
@@ -134,7 +61,7 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 .count{font-family:var(--font-mono);font-size:12px;color:var(--faint);margin-left:auto}
 @media(max-width:560px){.field input{width:auto;flex:1;min-width:0}.controls .field:first-child{flex:1 1 100%}.count{margin-left:0}}
 
-.notice{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:var(--muted);background:oklch(62% 0.11 80/.08);border:1px solid oklch(62% 0.11 80/.3);border-radius:var(--radius);padding:12px 16px;margin-bottom:26px}
+.notice{display:flex;gap:10px;align-items:flex-start;font-size:13px;color:var(--muted);background:oklch(62% 0.11 80/.08);border:1px solid oklch(62% 0.11 80/.3);padding:12px 16px;margin-bottom:26px}
 .notice[hidden]{display:none} /* class selector out-specifies the UA [hidden] rule */
 .notice .mk{font-family:var(--font-mono);color:var(--warn);flex:none}
 .notice.err{background:var(--accent-wash);border-color:var(--accent-line)}
@@ -142,8 +69,8 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 
 /* ============ PLUGIN CARDS ============ */
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(310px,1fr));gap:16px}
-.card{display:flex;flex-direction:column;gap:12px;background:var(--surface);border:1px solid var(--line);border-radius:var(--radius-lg);padding:22px 24px;transition:border-color 160ms,transform 160ms var(--ease-out),box-shadow 200ms}
-.card:hover{border-color:var(--line-2);transform:translateY(-2px);box-shadow:0 14px 34px oklch(40% 0.04 60/.1)}
+.card{display:flex;flex-direction:column;gap:12px;background:var(--surface);border:1px solid var(--line);border-radius:6px;padding:22px 24px;transition:border-color 160ms}
+.card:hover{border-color:var(--accent-line)}
 .card-top{display:flex;align-items:baseline;justify-content:space-between;gap:12px}
 .card-name{font-family:var(--font-mono);font-size:14px;font-weight:500;color:var(--ink);min-width:0;overflow-wrap:anywhere}
 .card-name:hover{color:var(--accent)}
@@ -154,17 +81,17 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 .card-meta{display:flex;align-items:center;gap:10px;flex-wrap:wrap;font-family:var(--font-mono);font-size:11.5px;color:var(--faint)}
 .card-meta .dot{width:7px;height:7px;border-radius:50%;background:var(--accent-2);flex:none}
 .card-meta .sep{color:var(--line-2)}
-.tag-first{border:1px solid var(--accent-line);background:var(--accent-wash);color:var(--accent);border-radius:999px;padding:2px 9px;font-size:10.5px;letter-spacing:.04em}
-.card-install{display:flex;align-items:center;gap:9px;width:100%;text-align:left;font-family:var(--font-mono);font-size:11.5px;color:var(--ink-soft);background:transparent;border:1px dashed var(--line-2);border-radius:999px;padding:9px 15px;transition:border-color 140ms,color 140ms,background 140ms}
+.tag-first{border:1px solid var(--accent-line);background:var(--accent-wash);color:var(--accent);padding:2px 9px;font-size:10.5px;letter-spacing:.04em}
+.card-install{display:flex;align-items:center;gap:9px;width:100%;text-align:left;font-family:var(--font-mono);font-size:11.5px;color:var(--ink-soft);background:transparent;border:1px dashed var(--line-2);padding:9px 15px;transition:border-color 140ms,color 140ms,background 140ms}
 .card-install:hover{border-style:solid;border-color:var(--accent-line);color:var(--ink);background:var(--accent-wash)}
 .card-install .ps{color:var(--accent);flex:none}
 /* The command used to ellipse on one line, and what it cut was the plugin
    NAME — the only part that differs between cards, so all six read
    `…/kobe-plugi…`. It fits in two lines, so show the whole thing: this is
    a command someone copies, and a truncated command is not one. */
-.card-install{align-items:flex-start;border-radius:14px}
+.card-install{align-items:flex-start}
 .card-install .cmd{min-width:0;overflow-wrap:anywhere}
-.skel{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius-lg);height:170px;animation:pulse 1.5s ease-in-out infinite}
+.skel{background:var(--surface);border:1px solid var(--line);border-radius:6px;height:170px;animation:pulse 1.5s ease-in-out infinite}
 @keyframes pulse{50%{opacity:.5}}
 .empty{font-family:var(--font-mono);font-size:13px;color:var(--faint);padding:34px 0}
 
@@ -201,7 +128,7 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 .md .md-list li{margin-bottom:6px}
 .md .md-list li::marker{color:var(--accent-2)}
 .md .md-hr{border:0;border-top:1px solid var(--line);margin:24px 0}
-.md .md-pre{background:linear-gradient(180deg,oklch(24% 0.021 50),var(--well) 60%);border:1px solid oklch(32% 0.024 50);border-radius:var(--radius);color:var(--well-ink);font-family:var(--font-mono);font-size:12.5px;line-height:1.9;padding:16px 20px;margin:0 0 16px;overflow-x:auto}
+.md .md-pre{background:linear-gradient(180deg,oklch(24% 0.021 50),var(--well) 60%);border:1px solid oklch(32% 0.024 50);border-radius:6px;color:var(--well-ink);font-family:var(--font-mono);font-size:12.5px;line-height:1.9;padding:16px 20px;margin:0 0 16px;overflow-x:auto}
 .md .md-pre code{background:transparent;border:0;padding:0;color:inherit;font-size:inherit}
 .md .md-fail{font-family:var(--font-mono);font-size:12.5px;color:var(--faint)}
 
@@ -217,29 +144,6 @@ h1{font-family:var(--font-display);font-optical-sizing:auto;font-size:clamp(38px
 .steps b{color:var(--ink);font-weight:600}
 code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash);border:1px solid oklch(62% 0.13 45/.18);border-radius:5px;padding:1px 6px;color:oklch(46% 0.11 45);overflow-wrap:anywhere}
 
-/* ============ FOOTER ============ */
-/* ============ FOOTER ============
-   Two blocks, not one paragraph: identity on the left, navigation on the
-   right. The links were prose-colored and underlined, so they read as part
-   of the colophon sentence — they get the navbar's mono treatment instead,
-   which is the vocabulary the rest of the page already uses for controls. */
-.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:40px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
-.foot-inner{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);display:flex;flex-wrap:wrap;justify-content:space-between;gap:22px 44px}
-.foot-id{max-width:56ch;line-height:1.7}
-.foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
-.foot-dense .tagline{color:var(--ink-soft)}
-/* the colophon is credits, not a claim — its own line, one step quieter */
-.foot-colophon{display:block;margin-top:7px;font-size:12px;color:var(--faint)}
-/* no margin-left:auto — space-between already right-aligns it on one line,
-   and once it wraps to its own row the auto margin would strand it right */
-.foot-links{display:flex;flex-wrap:wrap;align-items:baseline;gap:2px;font-family:var(--font-mono);font-size:12.5px}
-.foot-links a{color:var(--muted);padding:5px 11px;transition:color 140ms,background 140ms}
-.foot-links a:hover{color:var(--accent);background:var(--accent-wash)}
-
-@media (prefers-reduced-motion: reduce){
-  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important}
-  .rise{opacity:1;transform:none}
-}
 </style>
 </head>
 <body>
@@ -343,7 +247,7 @@ code{font-family:var(--font-mono);font-size:12.5px;background:var(--accent-wash)
 </section>
 
 <!-- FOOTER · dense colophon -->
-<footer class="foot-dense">
+<footer class="foot-dense foot-spaced">
   <div class="foot-inner">
     <p class="foot-id">
       <span class="mark">[Rove]</span> <span class="tagline" data-i18n="footer.tagline">a terminal multiplexer for coding agents.</span>

--- a/packages/kobe-landing/themes.css
+++ b/packages/kobe-landing/themes.css
@@ -1,74 +1,4 @@
-:root{
-  --paper:     oklch(97.8% 0.007 85);
-  --surface:   oklch(99.4% 0.003 90);
-  --well:      oklch(22% 0.02 50);
-  --well-2:    oklch(27% 0.022 50);
-  --well-ink:  oklch(88% 0.015 85);
-  --ink:       oklch(25% 0.02 60);
-  --ink-soft:  oklch(35% 0.02 55);
-  --muted:     oklch(50% 0.02 60);
-  --faint:     oklch(62% 0.018 65);
-  --line:      oklch(88% 0.014 80);
-  --line-2:    oklch(83% 0.018 75);
-  --accent:    oklch(62% 0.13 45);
-  --accent-2:  oklch(70% 0.11 50);
-  --accent-wash: oklch(62% 0.13 45 / .1);
-  --accent-line: oklch(62% 0.13 45 / .4);
-  --ok:        oklch(58% 0.12 145);
-  --warn:      oklch(62% 0.11 80);
-  --radius:    12px;
-  --radius-lg: 22px;
-  --font-display:'Fraunces', Georgia, serif;
-  --font-sans:'DM Sans', system-ui, sans-serif;
-  --font-mono:'JetBrains Mono', ui-monospace, monospace;
-  --ease-out: cubic-bezier(0.16,1,0.3,1);
-}
-*{box-sizing:border-box;margin:0;padding:0}
-html,body{background:var(--paper)}
-body{color:var(--ink-soft);font-family:var(--font-sans);font-weight:380;font-size:15px;line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
-::selection{background:oklch(62% 0.13 45/.22)}
-a{color:inherit;text-decoration:none}
-button{font-family:inherit;cursor:pointer}
-:focus-visible{outline:2px solid var(--accent);outline-offset:3px;border-radius:4px}
-.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px)}
-.acc{color:var(--accent);font-style:italic}
-
-/* ============ NAV — glass pill, terminal grammar ============ */
-.navbar{position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:50;display:flex;align-items:center;gap:2px;padding:6px 8px;border-radius:999px;background:oklch(100% 0 0/.55);backdrop-filter:blur(16px) saturate(1.3);border:1px solid oklch(100% 0 0/.8);box-shadow:0 10px 36px oklch(40% 0.04 60/.16);font-family:var(--font-mono);font-size:12.5px;max-width:calc(100vw - 24px)}
-.navbar .ps{color:var(--accent);padding-left:8px}
-.navbar .bin{font-weight:700;color:var(--ink);padding:8px 6px 8px 4px}
-.navbar a.nl{color:var(--ink-soft);padding:8px 10px;border-radius:999px;transition:background 140ms,color 140ms;white-space:nowrap}
-.navbar a.nl:hover{background:oklch(100% 0 0/.85);color:var(--ink)}
-.navbar a.nl[aria-current="page"]{background:var(--accent-wash);color:var(--accent)}
-.navbar .caret{display:inline-block;width:7px;height:14px;background:var(--accent);margin:0 4px 0 2px;animation:blink 1.1s steps(1) infinite;vertical-align:-2px}
-@keyframes blink{50%{opacity:0}}
-.lang-btn{background:none;border:1px solid var(--line-2);color:var(--ink-soft);font-family:var(--font-mono);font-size:11.5px;padding:5px 9px;border-radius:999px;transition:border-color 140ms,color 140ms;white-space:nowrap}
-.lang-btn:hover{border-color:var(--accent);color:var(--accent)}
-.gh-link{display:flex;align-items:center;gap:5px;padding:7px 11px;border-radius:999px;background:var(--ink);color:var(--paper);font-family:var(--font-mono);font-size:11.5px;margin-left:2px}
-.gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
-/* Below 820px the pill used to drop ALL five links with `display:none`,
-   leaving `$ Rove [中文] [GitHub]` — a nav bar with no navigation. Keep the
-   cross-page ones and drop only `--primitives` / `--install`, which are
-   home-page section anchors already reachable through `$ Rove`. That fits
-   one row, so the pill keeps its shape instead of stacking over the hero. */
-@media(max-width:820px){
-  .navbar{gap:0;padding:5px 6px;max-width:calc(100vw - 16px)}
-  .navbar .caret{display:none}
-  .navbar a.nl{padding:7px 7px;font-size:11.5px}
-  .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
-  .lang-btn{padding:5px 8px;margin-left:4px}
-  .gh-link{padding:7px 10px;margin-left:4px}
-}
-@media(max-width:460px){
-  /* the label is redundant next to the mark, and dropping it is what keeps
-     the whole pill inside the viewport at 390 */
-  .gh-link>span:not(.gh-stars){display:none}
-  .navbar a.nl{padding:7px 5px}
-  .navbar .bin{padding-right:2px}
-  /* still 34px over at 390 — changelog is the one to go, it sits in the
-     footer of every page while plugins/themes have no other entry point */
-  .navbar a.nl[href*="changelog"]{display:none}
-}
+/* themes page — chrome (tokens, nav, footer) comes from chrome.css */
 
 /* ============ HEAD ============ */
 .top{padding:132px 0 20px}
@@ -85,8 +15,8 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 
 /* ============ THEME GRID ============ */
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:20px;margin-top:30px}
-.tcard{border:1px solid var(--line);border-radius:var(--radius-lg);background:var(--surface);overflow:hidden;transition:border-color 180ms var(--ease-out),box-shadow 180ms var(--ease-out)}
-.tcard:hover{border-color:var(--line-2);box-shadow:0 14px 40px oklch(40% 0.04 60/.09)}
+.tcard{border:1px solid var(--line);border-radius:6px;background:var(--surface);overflow:hidden;transition:border-color 180ms var(--ease-out)}
+.tcard:hover{border-color:var(--accent-line)}
 .tc-head{display:flex;align-items:baseline;justify-content:space-between;gap:10px;padding:15px 17px 12px}
 .tc-name{font-family:var(--font-mono);font-size:14px;font-weight:700;color:var(--ink)}
 .tc-tag{font-family:var(--font-mono);font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--faint);white-space:nowrap}
@@ -115,7 +45,7 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 .m-warn{color:var(--t-warning)}
 .m-chip{display:inline-block;background:var(--t-element);color:var(--t-text);padding:0 5px;border-radius:3px}
 
-.tc-cmd{display:flex;align-items:flex-start;gap:7px;width:calc(100% - 34px);margin:0 17px 15px;background:var(--well);color:var(--well-ink);border:none;border-radius:9px;padding:9px 11px;font-family:var(--font-mono);font-size:11px;text-align:left}
+.tc-cmd{display:flex;align-items:flex-start;gap:7px;width:calc(100% - 34px);margin:0 17px 15px;background:var(--well);color:var(--well-ink);border:none;border-radius:6px;padding:9px 11px;font-family:var(--font-mono);font-size:11px;text-align:left}
 .tc-cmd .ps{color:var(--accent-2);flex:none}
 /* Same reason as the plugin cards (plugins.html): a trailing ellipsis cut
    the theme NAME, so every card read `rove theme add https://rove…`. Wrap
@@ -131,7 +61,7 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 .sw i:last-child{border-radius:0 5px 5px 0}
 
 /* ============ RECIPE / PUBLISH ============ */
-.well{background:var(--well);color:var(--well-ink);border-radius:var(--radius-lg);padding:clamp(20px,3vw,30px);margin-top:26px;overflow-x:auto}
+.well{background:var(--well);color:var(--well-ink);border-radius:6px;padding:clamp(20px,3vw,30px);margin-top:26px;overflow-x:auto}
 /* A JSON sample must not wrap — reflowed code is misleading. Below ~900px
    it is wider than the well, so it scrolls inside its own box instead of
    silently clipping. */
@@ -145,24 +75,6 @@ h2{font-family:var(--font-display);font-weight:360;font-size:clamp(24px,3vw,34px
 .step b{color:var(--ink);font-weight:600}
 .step code{font-family:var(--font-mono);font-size:.87em;background:var(--accent-wash);color:var(--accent);padding:1px 5px;border-radius:5px;word-break:break-all}
 
-.copy-cmd{display:inline-flex;align-items:center;gap:9px;background:var(--well);color:var(--well-ink);border:none;border-radius:999px;padding:11px 18px;font-family:var(--font-mono);font-size:13px;margin-top:22px}
+.copy-cmd{display:inline-flex;align-items:center;gap:9px;background:var(--well);color:var(--well-ink);border:none;padding:11px 18px;font-family:var(--font-mono);font-size:13px;margin-top:22px}
 .copy-cmd .ps{color:var(--accent-2)}
 .copy-cmd .hint{color:oklch(62% 0.02 60);font-size:11px;margin-left:4px}
-
-/* ============ FOOTER ============
-   Two blocks, not one paragraph: identity on the left, navigation on the
-   right. The links were prose-colored and underlined, so they read as part
-   of the colophon sentence — they get the navbar's mono treatment instead,
-   which is the vocabulary the rest of the page already uses for controls. */
-.foot-dense{border-top:1px solid var(--line);background:var(--surface);padding:40px 0;margin-top:clamp(70px,9vw,110px);font-size:13px;color:var(--faint)}
-.foot-inner{max-width:1160px;margin:0 auto;padding:0 clamp(20px,4vw,52px);display:flex;flex-wrap:wrap;justify-content:space-between;gap:22px 44px}
-.foot-id{max-width:56ch;line-height:1.7}
-.foot-dense .mark{font-family:var(--font-mono);color:var(--accent)}
-.foot-dense .tagline{color:var(--ink-soft)}
-/* the colophon is credits, not a claim — its own line, one step quieter */
-.foot-colophon{display:block;margin-top:7px;font-size:12px;color:var(--faint)}
-/* no margin-left:auto — space-between already right-aligns it on one line,
-   and once it wraps to its own row the auto margin would strand it right */
-.foot-links{display:flex;flex-wrap:wrap;align-items:baseline;gap:2px;font-family:var(--font-mono);font-size:12.5px}
-.foot-links a{color:var(--muted);padding:5px 11px;transition:color 140ms,background 140ms}
-.foot-links a:hover{color:var(--accent);background:var(--accent-wash)}

--- a/packages/kobe-landing/themes.html
+++ b/packages/kobe-landing/themes.html
@@ -16,6 +16,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=DM+Sans:opsz,wght@9..40,300..700&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/chrome.css">
 <link rel="stylesheet" href="/themes.css">
 </head>
 <body>
@@ -433,7 +434,7 @@
 
 </div>
 
-<footer class="foot-dense">
+<footer class="foot-dense foot-spaced">
   <div class="foot-inner">
     <p class="foot-id">
       <span class="mark">[Rove]</span> <span class="tagline" data-i18n="footer.tagline">a terminal multiplexer for coding agents.</span>


### PR DESCRIPTION
## Summary

The nav, footer and design tokens were copy-pasted into every page, so the home page redesign (flat full-width bar, square 6px frames) never reached the others. The changelog was a different site entirely: dark `#141413` background, Space Grotesk, hardcoded hex throughout, and a nav pointing at `#workspace` / `#why` / `#engines` — three anchors the home page no longer has.

- **New `chrome.css`** (98 lines) owns tokens, nav and footer for all four pages. Each page keeps only its own sections. Net −228 lines.
- **plugins / themes** adopt the flat nav and square frames; every 999px pill and hover-lift is gone.
- **changelog** is rebuilt on the shared chrome — paper palette, Fraunces/DM Sans, the site's real nav and footer. It keeps its live GitHub release rendering; the conventional-commit type tints are darkened so they read on a light background.
- The changelog's EN/中文 segmented control is replaced by the nav `lang-btn` every other page has, and its own page copy is now translated (previously only release bodies were).

Two pre-existing defects fixed on the way: the changelog overflowed its viewport by 101px at 390 on long unbroken tokens in release bodies, and the mobile-nav fix from #511/#513 now covers it for free.

`styles.css` and `tokens.css` are dead — nothing references them — but left in place; removing them is a separate call.

## Test plan

- [x] Real browser at 1440×900: home renders identically to before (chrome extraction is behaviour-neutral), plugins/themes/changelog all on one visual language
- [x] 390×844: all four pages report `scrollWidth === clientWidth`, no horizontal overflow
- [x] Mobile nav keeps its cross-page links on every page, including the changelog
- [x] `?lang=zh` end to end on the changelog: nav, page copy, and machine-translated release bodies
- [ ] Spot-check the deployed preview on rove.sma1lboy.me