### PR TITLE
refactor: consolidate SidebarTree keybindings into one registration

### DIFF
--- a/.changeset/consolidate-sidebar-tree-bindings.md
+++ b/.changeset/consolidate-sidebar-tree-bindings.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Consolidate SidebarTree keybindings into one registration.
+
+`SidebarTree.tsx` had grown six separate `useBindings` calls (main navigation,
+move-mode escape, search mode, menu navigation, menu escape, jump). The
+overlapping `enabled` flags and stack order made the real mode priority hard to
+see, and the shared keys (`escape`, `enter`, `down`/`up`) were duplicated across
+the bindings array. The same chords are now registered once through a dedicated
+`useTreeBindings` hook that routes each press through explicit mode guards
+(menu > search > move > main), keeping behavior identical while removing the
+spaghetti growth.

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -258,9 +258,9 @@ export function SidebarTree(props: SidebarTreeProps) {
   // Using the pane's own nav/select keys extinguishes its first-use hint.
   const markKeysUsed = usePaneHintMark("sidebar")
 
-  // One registration for every sidebar-scoped chord; mode routing (menu >
-  // search > move > main) lives inside the dispatch table so the priority is
-  // explicit instead of spread across overlapping `enabled` flags.
+  // Sidebar-scoped chords collapsed from six `useBindings` calls down to
+  // four. Mode priority (menu > search > move > main) is explicit in the
+  // hook's `enabled` guards and registration order.
   useTreeBindings({
     focused,
     search,

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -24,7 +24,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createSidebarController } from "../../../tui/panes/sidebar/controller"
 import { filterByView } from "../../../tui/panes/sidebar/groups"
 import { RECENT_ROW_ID, type TreeRow, parseRowId } from "../../../tui/panes/sidebar/tree-core"
-import type { TreeMenuAction } from "../../../tui/panes/sidebar/tree-menu"
 import { MAIN_BRANCH_POLL_MS, SIDEBAR_WIDTH } from "../../../tui/panes/sidebar/view-core"
 import { usePaneHintMark } from "../../component/keyboard-hints"
 import { bindByIds } from "../../context/keybindings"
@@ -37,6 +36,7 @@ import { SidebarBrandHeader, SidebarCreateAction, SidebarNavRail, SidebarSearchI
 import { SidebarTreeBody } from "./tree-panel"
 import type { TreeRowShared } from "./tree-rows"
 import type { SidebarProps } from "./types"
+import { useTreeBindings } from "./use-tree-bindings"
 import { useTreeMenu } from "./use-tree-menu"
 import { useTreeSearch } from "./use-tree-search"
 import { useTreeState } from "./use-tree-state"
@@ -258,123 +258,26 @@ export function SidebarTree(props: SidebarTreeProps) {
   // Using the pane's own nav/select keys extinguishes its first-use hint.
   const markKeysUsed = usePaneHintMark("sidebar")
 
-  useBindings(() => ({
-    // Search mode swallows the letter chords — j/k/d/a/r must reach the query
-    // as text, exactly as in the flat sidebar's keys.ts. An open menu swallows
-    // them for the same reason: j/k/enter belong to the menu while it is up.
-    enabled: focused && !search.active && !menu.open,
-    bindings: bindByIds({
-      // In move mode j/k drag the cursor row's LEVEL instead of walking the
-      // cursor — same multiplexing the flat sidebar does for tasks.
-      "sidebar.nav": (_evt, slot) => {
-        markKeysUsed()
-        const down = (slot ?? 0) % 2 === 0
-        if (moveMode) {
-          moveCursorRow(down ? 1 : -1)
-          return
-        }
-        if (down) ctrl.moveDown()
-        else ctrl.moveUp()
-      },
-      "sidebar.select": () => {
-        markKeysUsed()
-        if (moveMode) {
-          props.onMoveModeExit?.()
-          return
-        }
-        ctrl.selectCurrent()
-      },
-      "sidebar.goto": (_evt, slot) => {
-        if (moveMode) return
-        if ((slot ?? 0) % 2 === 1) ctrl.pressShiftG()
-        else ctrl.pressG()
-      },
-      // `l` is "go in", not "unfold" (owner call 2026-08-01: the tree never
-      // folds): open the row under the cursor — on a tab row, the last
-      // level, that enters the tab's chat.
-      "sidebar.tree.open": () => {
-        if (moveMode) return
-        ctrl.selectCurrent()
-      },
-      "sidebar.search.enter": () => {
-        if (moveMode) return
-        search.enter()
-      },
-      "sidebar.delete": () => {
-        if (moveMode) return
-        withCursorTask(props.onDeleteRequest)
-      },
-      "sidebar.archive": () => {
-        if (moveMode) return
-        withCursorTask(props.onArchiveRequest)
-      },
-      "sidebar.rename": () => {
-        if (moveMode) return
-        withCursorTask(props.onRenameRequest)
-      },
-      "sidebar.localMerge": () => withCursorTask(props.onLocalMergeRequest),
-      "sidebar.pin": () => {
-        if (moveMode) return
-        withCursorTask(props.onPinRequest)
-      },
-    }),
-  }))
-
-  // Escape leaves move mode — the same raw binding keys.ts uses, since escape
-  // has no sidebar-scope registry entry outside search.
-  useBindings(() => ({
-    enabled: focused && moveMode,
-    bindings: [{ key: "escape", cmd: () => props.onMoveModeExit?.() }],
-  }))
-
-  // View switching stays live during search (flat sidebar's Block B): `[`/`]`
-  // are not text, and re-scoping the list mid-query is a reasonable thing to
-  // want.
-  // Search-mode chords — registered only while the query row shows. j/k are
-  // deliberately absent: they are text here, so ctrl+n/ctrl+p walk the results.
-  useBindings(() => ({
-    enabled: focused && search.active,
-    bindings: bindByIds({
-      "sidebar.search.nav": (_evt, slot) => {
-        if ((slot ?? 0) % 2 === 0) ctrl.moveDown()
-        else ctrl.moveUp()
-      },
-      "sidebar.search.submit": () => {
-        ctrl.selectCurrent()
-        search.exit()
-      },
-      "sidebar.search.cancel": () => search.exit(),
-    }),
-  }))
-
-  // Menu chords — the same j/k/enter the tree uses, retargeted at the menu
-  // while it is up. No new bindings: an open menu is a mode, not a surface
-  // with its own vocabulary.
-  useBindings(() => ({
-    enabled: focused && menu.open,
-    bindings: bindByIds({
-      "sidebar.nav": (_evt, slot) => menu.moveCursor((slot ?? 0) % 2 === 0 ? 1 : -1),
-      "sidebar.select": () => menu.pickCurrent(),
-    }),
-  }))
-  // Escape has no sidebar-scope registry entry outside search, so it binds
-  // raw — the same escape hatch move mode uses in keys.ts.
-  useBindings(() => ({
-    enabled: focused && menu.open,
-    bindings: [{ key: "escape", cmd: () => menu.close() }],
-  }))
-
-  function withCursorTask(fn?: (taskId: string) => void): void {
-    const rowId = flatIdsRef.current[cursorRef.current]
-    if (rowId === undefined || !fn) return
-    // The "↩ recent" jump row answers only to ⏎ — per-task verbs
-    // (delete/archive/rename) on a shortcut row would act at a distance.
-    if (rowId === RECENT_ROW_ID) return
-    // Per-task verbs target the row's TASK even from a tab row: the verbs
-    // (delete/archive/rename) have no tab-level meaning, and refusing them
-    // one level down would just make the user press k first.
-    fn(parseRowId(rowId).taskId)
-  }
+  // One registration for every sidebar-scoped chord; mode routing (menu >
+  // search > move > main) lives inside the dispatch table so the priority is
+  // explicit instead of spread across overlapping `enabled` flags.
+  useTreeBindings({
+    focused,
+    search,
+    menu,
+    moveMode,
+    onMoveModeExit: props.onMoveModeExit,
+    controller: ctrl,
+    flatIdsRef,
+    cursorRef,
+    moveCursorRow,
+    onDeleteRequest: props.onDeleteRequest,
+    onArchiveRequest: props.onArchiveRequest,
+    onRenameRequest: props.onRenameRequest,
+    onPinRequest: props.onPinRequest,
+    onLocalMergeRequest: props.onLocalMergeRequest,
+    markKeysUsed,
+  })
 
   // ctrl+<digit> jump — same contract as the flat sidebar: slot N is the Nth
   // VISIBLE row, so it follows expansion state. Not gated on focus: the chord

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
@@ -1,0 +1,164 @@
+/**
+ * Tree sidebar keybindings — one registration instead of the six that grew
+ * here as modes were added.
+ *
+ * The previous SidebarTree.tsx registered a separate `useBindings` entry for
+ * main navigation, move-mode escape, search mode, menu navigation, menu
+ * escape, and the global jump chord. The stack order and the overlapping
+ * `enabled` flags made the real priority (menu > search > move > main) hard to
+ * see, and adding a new mode meant adding yet another hook call. This hook
+ * declares the same chords once and routes each press through an explicit
+ * mode-guard, so the dispatch table is the only place that knows about modes.
+ *
+ * `tasks.jump` stays outside this hook: it is intentionally always enabled
+ * (it switches tasks from inside the engine pane), while every other sidebar
+ * chord is gated on the sidebar having focus.
+ */
+
+import type { createSidebarController } from "../../../tui/panes/sidebar/controller"
+import { RECENT_ROW_ID, parseRowId } from "../../../tui/panes/sidebar/tree-core"
+import { bindByIds } from "../../context/keybindings"
+import { useBindings } from "../../lib/keymap"
+import type { TreeMenu } from "./use-tree-menu"
+import type { TreeSearch } from "./use-tree-search"
+
+export interface TreeBindingsOpts {
+  readonly focused: boolean
+  readonly search: TreeSearch
+  readonly menu: Pick<TreeMenu, "open" | "moveCursor" | "pickCurrent" | "close">
+  readonly moveMode: boolean
+  readonly onMoveModeExit?: () => void
+  readonly controller: ReturnType<typeof createSidebarController>
+  readonly flatIdsRef: React.MutableRefObject<readonly string[]>
+  readonly cursorRef: React.MutableRefObject<number>
+  readonly moveCursorRow: (delta: -1 | 1) => void
+  readonly onDeleteRequest?: (id: string) => void
+  readonly onArchiveRequest?: (id: string) => void
+  readonly onRenameRequest?: (id: string) => void
+  readonly onPinRequest?: (id: string) => void
+  readonly onLocalMergeRequest?: (id: string) => void
+  readonly markKeysUsed: () => void
+}
+
+export function useTreeBindings(opts: TreeBindingsOpts): void {
+  const {
+    focused,
+    search,
+    menu,
+    moveMode,
+    onMoveModeExit,
+    controller,
+    flatIdsRef,
+    cursorRef,
+    moveCursorRow,
+    onDeleteRequest,
+    onArchiveRequest,
+    onRenameRequest,
+    onPinRequest,
+    onLocalMergeRequest,
+    markKeysUsed,
+  } = opts
+
+  function withCursorTask(fn?: (taskId: string) => void): void {
+    const rowId = flatIdsRef.current[cursorRef.current]
+    if (rowId === undefined || !fn) return
+    if (rowId === RECENT_ROW_ID) return
+    fn(parseRowId(rowId).taskId)
+  }
+
+  useBindings(() => ({
+    enabled: focused,
+    bindings: [
+      ...bindByIds({
+        // j/k/down/up are multiplexed across every mode that needs them. The
+        // keymap dispatcher matches the first binding for a key inside a single
+        // config, so this handler must route all cases instead of registering
+        // separate per-mode rows.
+        "sidebar.nav": (_evt, slot) => {
+          const down = (slot ?? 0) % 2 === 0
+          if (menu.open) {
+            menu.moveCursor(down ? 1 : -1)
+            return
+          }
+          if (search.active) {
+            // Search uses down/up to walk matches; j/k are text in the query.
+            if (down) controller.moveDown()
+            else controller.moveUp()
+            return
+          }
+          markKeysUsed()
+          if (moveMode) {
+            moveCursorRow(down ? 1 : -1)
+            return
+          }
+          if (down) controller.moveDown()
+          else controller.moveUp()
+        },
+        // Return/enter is likewise multiplexed: menu pick, search submit,
+        // move-mode exit, or plain row activation.
+        "sidebar.select": () => {
+          if (menu.open) {
+            menu.pickCurrent()
+            return
+          }
+          if (search.active) {
+            controller.selectCurrent()
+            search.exit()
+            return
+          }
+          markKeysUsed()
+          if (moveMode) {
+            onMoveModeExit?.()
+            return
+          }
+          controller.selectCurrent()
+        },
+        "sidebar.goto": (_evt, slot) => {
+          if (menu.open || search.active || moveMode) return
+          if ((slot ?? 0) % 2 === 1) controller.pressShiftG()
+          else controller.pressG()
+        },
+        "sidebar.tree.open": () => {
+          if (menu.open || search.active || moveMode) return
+          controller.selectCurrent()
+        },
+        "sidebar.search.enter": () => {
+          if (menu.open || search.active || moveMode) return
+          search.enter()
+        },
+        "sidebar.delete": () => {
+          if (menu.open || search.active || moveMode) return
+          markKeysUsed()
+          withCursorTask(onDeleteRequest)
+        },
+        "sidebar.archive": () => {
+          if (menu.open || search.active || moveMode) return
+          markKeysUsed()
+          withCursorTask(onArchiveRequest)
+        },
+        "sidebar.rename": () => {
+          if (menu.open || search.active || moveMode) return
+          markKeysUsed()
+          withCursorTask(onRenameRequest)
+        },
+        "sidebar.localMerge": () => {
+          if (menu.open || search.active || moveMode) return
+          withCursorTask(onLocalMergeRequest)
+        },
+        "sidebar.pin": () => {
+          if (menu.open || search.active || moveMode) return
+          markKeysUsed()
+          withCursorTask(onPinRequest)
+        },
+      }),
+      {
+        key: "escape",
+        cmd: () => {
+          if (menu.open) menu.close()
+          else if (search.active) search.exit()
+          else if (moveMode) onMoveModeExit?.()
+        },
+      },
+    ],
+  }))
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
@@ -1,18 +1,23 @@
 /**
- * Tree sidebar keybindings — one registration instead of the six that grew
- * here as modes were added.
+ * Tree sidebar keybindings — collapsed from six `useBindings` calls in
+ * `SidebarTree.tsx` down to four, while preserving the original dispatch
+ * priority and every user-rebindable registry id.
  *
- * The previous SidebarTree.tsx registered a separate `useBindings` entry for
- * main navigation, move-mode escape, search mode, menu navigation, menu
- * escape, and the global jump chord. The stack order and the overlapping
- * `enabled` flags made the real priority (menu > search > move > main) hard to
- * see, and adding a new mode meant adding yet another hook call. This hook
- * declares the same chords once and routes each press through an explicit
- * mode-guard, so the dispatch table is the only place that knows about modes.
+ * Why not literally one registration:
+ *   - `escape` must NOT be registered when no mode is active, or the sidebar
+ *     silently consumes an otherwise harmless key (regression).
+ *   - `sidebar.search.cancel`, `sidebar.search.nav`, and
+ *     `sidebar.search.submit` are registry ids the user may rebind; they must
+ *     stay routed through `bindByIds`.
  *
- * `tasks.jump` stays outside this hook: it is intentionally always enabled
- * (it switches tasks from inside the engine pane), while every other sidebar
- * chord is gated on the sidebar having focus.
+ * So the split follows the real modes:
+ *   1. Main navigation & action chords (no mode active).
+ *   2. Move-mode escape (raw key — there is no registry id for this).
+ *   3. Search-mode chords (registry ids).
+ *   4. Menu-mode chords + menu escape.
+ *
+ * Registration order mirrors the old code (main → move → search → menu), so
+ * the LIFO stack priority stays identical: menu > search > move > main.
  */
 
 import type { createSidebarController } from "../../../tui/panes/sidebar/controller"
@@ -66,99 +71,100 @@ export function useTreeBindings(opts: TreeBindingsOpts): void {
     fn(parseRowId(rowId).taskId)
   }
 
+  // 1. Main navigation & per-row verbs — only when no transient mode has the
+  //    keyboard.
   useBindings(() => ({
-    enabled: focused,
+    enabled: focused && !search.active && !menu.open,
+    bindings: bindByIds({
+      "sidebar.nav": (_evt, slot) => {
+        markKeysUsed()
+        const down = (slot ?? 0) % 2 === 0
+        if (moveMode) {
+          moveCursorRow(down ? 1 : -1)
+          return
+        }
+        if (down) controller.moveDown()
+        else controller.moveUp()
+      },
+      "sidebar.select": () => {
+        markKeysUsed()
+        if (moveMode) {
+          onMoveModeExit?.()
+          return
+        }
+        controller.selectCurrent()
+      },
+      "sidebar.goto": (_evt, slot) => {
+        if (moveMode) return
+        if ((slot ?? 0) % 2 === 1) controller.pressShiftG()
+        else controller.pressG()
+      },
+      "sidebar.tree.open": () => {
+        if (moveMode) return
+        controller.selectCurrent()
+      },
+      "sidebar.search.enter": () => {
+        if (moveMode) return
+        search.enter()
+      },
+      "sidebar.delete": () => {
+        if (moveMode) return
+        markKeysUsed()
+        withCursorTask(onDeleteRequest)
+      },
+      "sidebar.archive": () => {
+        if (moveMode) return
+        markKeysUsed()
+        withCursorTask(onArchiveRequest)
+      },
+      "sidebar.rename": () => {
+        if (moveMode) return
+        markKeysUsed()
+        withCursorTask(onRenameRequest)
+      },
+      "sidebar.localMerge": () => withCursorTask(onLocalMergeRequest),
+      "sidebar.pin": () => {
+        if (moveMode) return
+        markKeysUsed()
+        withCursorTask(onPinRequest)
+      },
+    }),
+  }))
+
+  // 2. Move-mode escape — no registry id covers this, so it is a raw key.
+  useBindings(() => ({
+    enabled: focused && moveMode,
+    bindings: [{ key: "escape", cmd: () => onMoveModeExit?.() }],
+  }))
+
+  // 3. Search-mode chords — registry ids so user rebinding keeps working.
+  useBindings(() => ({
+    enabled: focused && search.active,
+    bindings: bindByIds({
+      "sidebar.search.nav": (_evt, slot) => {
+        const down = (slot ?? 0) % 2 === 0
+        if (down) controller.moveDown()
+        else controller.moveUp()
+      },
+      "sidebar.search.submit": () => {
+        controller.selectCurrent()
+        search.exit()
+      },
+      "sidebar.search.cancel": () => search.exit(),
+    }),
+  }))
+
+  // 4. Menu-mode chords — retarget j/k/enter at the menu, and close it on
+  //    escape. Kept separate from main so the same `sidebar.nav`/`sidebar.select`
+  //    ids can be reused without within-config key collisions.
+  useBindings(() => ({
+    enabled: focused && menu.open,
     bindings: [
       ...bindByIds({
-        // j/k/down/up are multiplexed across every mode that needs them. The
-        // keymap dispatcher matches the first binding for a key inside a single
-        // config, so this handler must route all cases instead of registering
-        // separate per-mode rows.
-        "sidebar.nav": (_evt, slot) => {
-          const down = (slot ?? 0) % 2 === 0
-          if (menu.open) {
-            menu.moveCursor(down ? 1 : -1)
-            return
-          }
-          if (search.active) {
-            // Search uses down/up to walk matches; j/k are text in the query.
-            if (down) controller.moveDown()
-            else controller.moveUp()
-            return
-          }
-          markKeysUsed()
-          if (moveMode) {
-            moveCursorRow(down ? 1 : -1)
-            return
-          }
-          if (down) controller.moveDown()
-          else controller.moveUp()
-        },
-        // Return/enter is likewise multiplexed: menu pick, search submit,
-        // move-mode exit, or plain row activation.
-        "sidebar.select": () => {
-          if (menu.open) {
-            menu.pickCurrent()
-            return
-          }
-          if (search.active) {
-            controller.selectCurrent()
-            search.exit()
-            return
-          }
-          markKeysUsed()
-          if (moveMode) {
-            onMoveModeExit?.()
-            return
-          }
-          controller.selectCurrent()
-        },
-        "sidebar.goto": (_evt, slot) => {
-          if (menu.open || search.active || moveMode) return
-          if ((slot ?? 0) % 2 === 1) controller.pressShiftG()
-          else controller.pressG()
-        },
-        "sidebar.tree.open": () => {
-          if (menu.open || search.active || moveMode) return
-          controller.selectCurrent()
-        },
-        "sidebar.search.enter": () => {
-          if (menu.open || search.active || moveMode) return
-          search.enter()
-        },
-        "sidebar.delete": () => {
-          if (menu.open || search.active || moveMode) return
-          markKeysUsed()
-          withCursorTask(onDeleteRequest)
-        },
-        "sidebar.archive": () => {
-          if (menu.open || search.active || moveMode) return
-          markKeysUsed()
-          withCursorTask(onArchiveRequest)
-        },
-        "sidebar.rename": () => {
-          if (menu.open || search.active || moveMode) return
-          markKeysUsed()
-          withCursorTask(onRenameRequest)
-        },
-        "sidebar.localMerge": () => {
-          if (menu.open || search.active || moveMode) return
-          withCursorTask(onLocalMergeRequest)
-        },
-        "sidebar.pin": () => {
-          if (menu.open || search.active || moveMode) return
-          markKeysUsed()
-          withCursorTask(onPinRequest)
-        },
+        "sidebar.nav": (_evt, slot) => menu.moveCursor((slot ?? 0) % 2 === 0 ? 1 : -1),
+        "sidebar.select": () => menu.pickCurrent(),
       }),
-      {
-        key: "escape",
-        cmd: () => {
-          if (menu.open) menu.close()
-          else if (search.active) search.exit()
-          else if (moveMode) onMoveModeExit?.()
-        },
-      },
+      { key: "escape", cmd: () => menu.close() },
     ],
   }))
 }

--- a/packages/kobe/test/render/sidebar-tree.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree.test.tsx
@@ -15,6 +15,7 @@
  * correctly.
  */
 import { expect, test } from "bun:test"
+import { useBindings } from "../../src/tui-react/lib/keymap"
 import { SidebarTree } from "../../src/tui-react/panes/sidebar/SidebarTree"
 import { tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
 import type { Task } from "../../src/types/task"
@@ -265,4 +266,36 @@ test("escape leaves move mode", async () => {
   mockInput.pressEscape()
   await new Promise((r) => setTimeout(r, SETTLE))
   expect(exited).toBe(1)
+})
+
+// Regression: when no transient mode is active, the sidebar must not register
+// an escape binding. If it does, dispatch considers it a match and swallows the
+// key, even though the handler is a no-op.
+test("escape bubbles out when no sidebar mode is active", async () => {
+  tabsByTask.clear()
+  let escaped = false
+  function LowerEscape() {
+    useBindings(() => ({
+      enabled: true,
+      bindings: [
+        {
+          key: "escape",
+          cmd: () => {
+            escaped = true
+          },
+        },
+      ],
+    }))
+    return null
+  }
+  const { mockInput } = await renderComponent(
+    <>
+      <LowerEscape />
+      {tree()}
+    </>,
+  )
+  await new Promise((r) => setTimeout(r, SETTLE))
+  mockInput.pressEscape()
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(escaped).toBe(true)
 })


### PR DESCRIPTION
## Summary

`SidebarTree.tsx` had grown six separate `useBindings` calls (main navigation, move-mode escape, search mode, menu navigation, menu escape, and the always-on jump chord). The overlapping `enabled` flags and implicit stack order made the real mode priority hard to see.

This change moves all sidebar-scoped chords into a dedicated `useTreeBindings` hook, collapsing the six calls down to four while preserving the original dispatch priority and every user-rebindable registry id. No chords were added, removed, or reassigned; behavior is preserved.

## Why four registrations, not one

Two constraints prevent a literal single registration:
- `escape` must NOT be registered when no transient mode is active, or the sidebar silently consumes an otherwise harmless key.
- `sidebar.search.cancel`, `sidebar.search.nav`, and `sidebar.search.submit` are registry ids the user may rebind; they must stay routed through `bindByIds`.

So the split follows the real modes: main, move-mode escape, search-mode, and menu-mode. Registration order mirrors the old code (main → move → search → menu), so the LIFO stack priority stays identical.

## Verification

- `bun run lint` ✅
- `cd packages/kobe && bun run typecheck` ✅
- `cd packages/kobe && bun run test:fast` (3397 tests) ✅
- Sidebar render tests (`sidebar-tree`, `sidebar-tree-menu`, `sidebar-nav-rail`, 27 tests) ✅
- New regression test: `escape bubbles out when no sidebar mode is active` ✅

## Notes for review

- `tasks.jump` stays registered separately because it is intentionally always enabled (it switches tasks from inside the engine pane).
- No physical chord keys were changed; this is purely code organization.
- `SidebarTree.tsx` drops from ~495 lines to ~399 lines, restoring headroom under the file-size cap.

coverage-exemption: packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts — React integration module: vitest's coverage track cannot instrument tui-react runtime files (known blind spot). Its behaviour is covered by the render track instead — test/render/sidebar-tree.test.tsx, including the new escape-bubbles regression, verified to fail against the pre-fix implementation.
