### PR TITLE
refactor: reuse the canonical optionalNumber validator in automation and work-item handlers

### DIFF
--- a/.changeset/handler-validator-dedup.md
+++ b/.changeset/handler-validator-dedup.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Reuse the canonical `optionalNumber` payload validator from `handler-validators.ts` in the automation and work-item handler modules, removing two near-duplicate local copies.

--- a/packages/kobe-daemon/src/daemon/handlers-automations.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-automations.ts
@@ -3,15 +3,8 @@
 import { runAutomationOnce } from "./automation-runner.ts"
 import type { AutomationPatch, AutomationPrecheck } from "./contracts.ts"
 import { isValidCron } from "./cron.ts"
-import { optionalBoolean, optionalString, optionalVendor, requireString } from "./handler-validators.ts"
+import { optionalBoolean, optionalNumber, optionalString, optionalVendor, requireString } from "./handler-validators.ts"
 import type { DaemonRequestHandler } from "./handlers.ts"
-
-function optionalNumber(payload: Record<string, unknown>, key: string): number | undefined {
-  const value = payload[key]
-  if (value === undefined || value === null) return undefined
-  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${key} must be a number`)
-  return value
-}
 
 /** Reject an unusable schedule at the boundary — persisting one would leave a
  *  row that can never fire and is only discoverable by watching it not run. */

--- a/packages/kobe-daemon/src/daemon/handlers-work-items.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-work-items.ts
@@ -1,16 +1,9 @@
 /** External work-item RPC handlers — read a tracker, start work on one item. */
 
-import { requireString } from "./handler-validators.ts"
+import { optionalNumber, requireString } from "./handler-validators.ts"
 import type { DaemonRequestHandler } from "./handlers.ts"
 import { startWorkItem } from "./work-item-start.ts"
 import { WorkItemError, fetchWorkItem } from "./work-items.ts"
-
-function optionalNumber(payload: Record<string, unknown>, key: string): number | undefined {
-  const value = payload[key]
-  if (value === undefined || value === null) return undefined
-  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${key} must be a number`)
-  return value
-}
 
 function requireNumberField(payload: Record<string, unknown>, key: string): number {
   const value = optionalNumber(payload, key)

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -75,6 +75,7 @@ export {
   objectPayload,
   optionalActivityDetail,
   optionalBoolean,
+  optionalNumber,
   optionalString,
   optionalVendor,
   requireString,


### PR DESCRIPTION
Thermo-nuclear code-quality audit fix for `packages/kobe-daemon/src/daemon/handlers-automations.ts` and `handlers-work-items.ts`.

Both modules defined an identical `optionalNumber` helper because `handlers.ts` did not re-export the canonical one from `handler-validators.ts`. Re-export it and import the canonical helper in both modules, removing the duplicates and aligning the error wording (`must be a finite number`) with the rest of the daemon RPC surface.

This is a minor wire-contract change for the automation/work-item number-field error messages, but it matches the wording already expected by the existing validator tests.

Checks run:
- `bun run lint`
- `cd packages/kobe && bun run typecheck`
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket -- test/daemon/handlers.test.ts test/daemon/handlers-task-crud.test.ts test/daemon/handlers-attention.test.ts test/daemon/automation-precheck.test.ts`