### PR TITLE
chore: warn when a touched file is close to the size cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,15 @@ jobs:
               fi
               echo "::error file=$f::$f is $lines lines (cap ~500). Refactor/split it, or add a 'file-size-exemption: $f — <reason>' line to the PR body. See AGENTS.md 'File size cap'."
               fail=1
+            elif [ "$lines" -ge 470 ]; then
+              # Headroom warning, never a failure. The cap is a cliff: a file
+              # at 499 passes, and the NEXT person to touch it inherits a
+              # refactor they did not plan. Worse, a file with no headroom
+              # can't even improve itself — extracting a helper costs a few
+              # lines before it saves any. Surfacing the remaining room here
+              # lets the split happen when someone chooses it, not when the
+              # gate forces it.
+              echo "::warning file=$f::$f is $lines lines — $((500 - lines)) from the ~500 cap. Consider splitting it now; the next edit may have no room left."
             fi
           done < <(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD)
           exit $fail


### PR DESCRIPTION
> **Needs your approval — this touches CI.** Opened as a PR rather than merged, per the unattended-run rules.

Found by the thermo-nuclear sweep, but the evidence for it came from the sweep's own work rather than from reading code.

## The problem

`file-size-cap` is a cliff with no approach lights. Current state of `packages/*/src`:

| lines | files |
|---|---|
| **exactly 500** (zero headroom) | **4** |
| ≥ 490 | 12 |
| ≥ 470 | 23 |
| > 500 | 0 — the gate works |

687 source files, median 115. So the cap is doing its job; the cost is that 23 files sit close enough that an ordinary edit lands on the cliff with no warning.

## Why it's worse than "someone will refactor it later"

A file with zero headroom **cannot improve itself**. I hit this directly while fixing a duplication in `worktree/manager.ts` (499 lines): six methods each re-spelled the same `requireAbsolute` + `execForPath` pair, whose only failure mode is silent. Binding the pair into one private helper *cost more lines than the six copies it saved* — 509, over the cap. The tidying that would fix the file was exactly what the gate blocked. The real fix (#517) was a decomposition, which is correct, but the gate picked the timing, not me.

Same shape earlier in the same session: `core.ts` went 493 → 515 on a small feature and had to be split (`MainTaskCoordinator`) before that feature could land.

## The change

A `::warning::` at 470+, on the same touched-file set the cap already walks. Non-blocking — nothing that passed before fails now. The split happens when someone chooses it, not when the gate forces it.

```
::warning file=packages/kobe/src/cli/api/verbs.ts::… is 500 lines — 0 from the ~500 cap.
Consider splitting it now; the next edit may have no room left.
```

## Threshold

470 gives ~30 lines of runway, which is roughly one helper plus its doc comment. If you'd rather it be quieter, 485 still catches the four zero-headroom files and cuts the warning set from 23 to ~12.