### PR TITLE
refactor: collapse XtermTaskPty feed/replay into one helper

### DIFF
--- a/.changeset/tui-pty-xterm-cleanup.md
+++ b/.changeset/tui-pty-xterm-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Collapse `XtermTaskPty.feed` and `feedReplay` into one private `feedInternal` helper in the TUI terminal base, and remove an unnecessary `IMarker` cast in scrollback anchor math.

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -297,11 +297,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
    * a chunk boundary is reassembled correctly. Decoding each chunk here
    * instead corrupted any glyph straddling a boundary. */
   protected feed(data: string | Uint8Array): void {
-    if (this._killed) return
-    this.term.write(data, () => {
-      if (!this.refreshTracker.supported) this.refreshTracker.markAll()
-      this.queueRefresh()
-    })
+    this.feedInternal(data, false)
   }
 
   /** Feed a ring-buffer REPLAY: parsed like live output, but the emulator's
@@ -309,10 +305,14 @@ export abstract class XtermTaskPty implements TaskPtyLike {
    * channel). Live chunks fed after this parse in FIFO order, so the
    * un-mute callback lands between the replay's parse and theirs. */
   protected feedReplay(data: string | Uint8Array): void {
+    this.feedInternal(data, true)
+  }
+
+  private feedInternal(data: string | Uint8Array, muteReplies: boolean): void {
     if (this._killed) return
-    this.muteReplies = true
+    if (muteReplies) this.muteReplies = true
     this.term.write(data, () => {
-      this.muteReplies = false
+      if (muteReplies) this.muteReplies = false
       if (!this.refreshTracker.supported) this.refreshTracker.markAll()
       this.queueRefresh()
     })
@@ -395,7 +395,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     }
     const anchorAlive = canAnchor && this.anchor !== undefined && !this.anchor.isDisposed
     // Absolute id of buffer line y — only meaningful while the anchor lives.
-    const absBase = anchorAlive ? this.anchorId - (this.anchor as IMarker).line : 0
+    const absBase = anchorAlive && this.anchor ? this.anchorId - this.anchor.line : 0
     const cache = this.scrollbackCache
     const rows: TerminalRow[] = []
     const cursorY = active.baseY + active.cursorY


### PR DESCRIPTION
Thermo-nuclear code-quality audit fix for `packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts`.

`feed()` and `feedReplay()` only differed in whether emulator auto-replies were muted for the parse. Route both through a private `feedInternal(data, muteReplies)` so the write/refresh path lives once. Also drop an unnecessary `IMarker` cast now that `anchorAlive` narrows `this.anchor`.

No behavior change. The file stays at the 500-line cap (500 lines).

Checks run:
- `bun run lint`
- `cd packages/kobe && bun run typecheck`
- `bun run test:fast -- test/tui/terminal-pty-*.test.ts test/tui/pty-listeners.test.ts test/render/pty-local-env.test.ts test/render/pty-replay-replies.test.ts`