### PR TITLE
fix(cli): onboarding respects active CLI name (rove vs kobe)

### DIFF
--- a/.changeset/fix-onboarding-cli-name.md
+++ b/.changeset/fix-onboarding-cli-name.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Respect the active CLI name (`rove` vs `kobe`) in onboarding completions.
+
+`kobe onboarding` no longer hard-codes `rove` in the generated shell completion hook, fish autoload file, or user-facing hints. When the binary is invoked as `kobe`, completions now reference `kobe` consistently.

--- a/packages/kobe/src/cli/onboarding.ts
+++ b/packages/kobe/src/cli/onboarding.ts
@@ -18,6 +18,7 @@ import { basename, join } from "node:path"
 import { npxSkillsArgv, npxSkillsCommand } from "../lib/skill-install.ts"
 import { getPersistedBool, setPersistedBool } from "../state/store.ts"
 import { t } from "../tui/i18n"
+import { activeCliName } from "./rename-compat.ts"
 
 const ONBOARDED_KEY = "onboarded"
 
@@ -35,29 +36,27 @@ export function detectShell(env: NodeJS.ProcessEnv = process.env): ShellKind | n
   return shell === "zsh" || shell === "bash" || shell === "fish" ? shell : null
 }
 
-/** Marker that makes the rc-append idempotent across re-runs. */
-const RC_MARKER = "rove completions"
-
 /**
  * Hook completions into the shell, returning the file that was touched.
- * zsh/bash get one guarded `source <(kobe completions <shell>)` line in
+ * zsh/bash get one guarded `source <(<cli> completions <shell>)` line in
  * their rc file (the generated zsh script self-registers via compdef when
  * sourced); fish gets a lazy one-liner completions file, which fish
  * autoloads with no rc edit. All three re-generate from the live binary,
  * so completions never go stale across updates.
  */
-export function installCompletions(shell: ShellKind, home: string = homedir()): string {
+export function installCompletions(shell: ShellKind, home: string = homedir(), cli: string = activeCliName()): string {
+  const rcMarker = `${cli} completions`
   if (shell === "fish") {
     const dir = join(home, ".config", "fish", "completions")
-    const path = join(dir, "rove.fish")
+    const path = join(dir, `${cli}.fish`)
     mkdirSync(dir, { recursive: true })
-    writeFileSync(path, "rove completions fish | source\n")
+    writeFileSync(path, `${cli} completions fish | source\n`)
     return path
   }
   const rc = join(home, shell === "zsh" ? ".zshrc" : ".bashrc")
   const existing = existsSync(rc) ? readFileSync(rc, "utf8") : ""
-  if (!existing.includes(RC_MARKER)) {
-    const line = `\n# rove completions\ncommand -v rove >/dev/null && source <(rove completions ${shell})\n`
+  if (!existing.includes(rcMarker)) {
+    const line = `\n# ${cli} completions\ncommand -v ${cli} >/dev/null && source <(${cli} completions ${shell})\n`
     appendFileSync(rc, line)
   }
   return rc
@@ -77,20 +76,23 @@ export function markOnboarded(): void {
  * terminal (npx prompts/progress), and the summary lands in scrollback.
  */
 export function applyOnboardingChoices(choices: OnboardingChoices, shell: ShellKind | null): void {
+  const cli = activeCliName()
+  const completionsHelp = `${cli} completions --help`
+  const skillInstall = `${cli} skill install`
   const out = (line: string) => process.stdout.write(`${line}\n`)
   if (shell !== null) {
     if (choices.completions) {
       out(t("onboarding.appliedCompletions", { path: installCompletions(shell) }))
     } else {
-      out(t("onboarding.skippedCompletions", { command: "rove completions --help" }))
+      out(t("onboarding.skippedCompletions", { command: completionsHelp }))
     }
   }
   if (choices.skill) {
     out(t("onboarding.installingSkill", { command: npxSkillsCommand() }))
     const result = spawnSync("npx", npxSkillsArgv(), { stdio: "inherit" })
-    if (result.status !== 0) out(t("onboarding.skillFailed", { command: "rove skill install" }))
+    if (result.status !== 0) out(t("onboarding.skillFailed", { command: skillInstall }))
   } else {
-    out(t("onboarding.skippedSkill", { command: "rove skill install" }))
+    out(t("onboarding.skippedSkill", { command: skillInstall }))
   }
   out("")
   out(t("onboarding.ready"))

--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -31,7 +31,7 @@ describe("detectShell", () => {
 describe("installCompletions", () => {
   it("appends one guarded source line to a missing .zshrc", () => {
     const home = freshHome()
-    const rc = installCompletions("zsh", home)
+    const rc = installCompletions("zsh", home, "rove")
     expect(rc).toBe(join(home, ".zshrc"))
     const content = readFileSync(rc, "utf8")
     expect(content).toContain("source <(rove completions zsh)")
@@ -40,8 +40,8 @@ describe("installCompletions", () => {
 
   it("is idempotent — a second run never stacks a duplicate line", () => {
     const home = freshHome()
-    installCompletions("zsh", home)
-    installCompletions("zsh", home)
+    installCompletions("zsh", home, "rove")
+    installCompletions("zsh", home, "rove")
     const content = readFileSync(join(home, ".zshrc"), "utf8")
     expect(content.match(/rove completions zsh/g)).toHaveLength(1)
   })
@@ -50,7 +50,7 @@ describe("installCompletions", () => {
     const home = freshHome()
     const rc = join(home, ".bashrc")
     writeFileSync(rc, "# mine\nsource ~/.bash_completion.d/rove # rove completions via fpath\n")
-    installCompletions("bash", home)
+    installCompletions("bash", home, "rove")
     const content = readFileSync(rc, "utf8")
     expect(content).toContain("# mine")
     // The marker was already present → nothing appended.
@@ -59,9 +59,17 @@ describe("installCompletions", () => {
 
   it("fish gets an autoloaded completions file, no rc edit", () => {
     const home = freshHome()
-    const path = installCompletions("fish", home)
+    const path = installCompletions("fish", home, "rove")
     expect(path).toBe(join(home, ".config", "fish", "completions", "rove.fish"))
     expect(readFileSync(path, "utf8")).toBe("rove completions fish | source\n")
     expect(existsSync(join(home, ".config", "fish", "config.fish"))).toBe(false)
+  })
+
+  it("uses the active cli name (kobe) when no product is pinned", () => {
+    const home = freshHome()
+    const rc = installCompletions("zsh", home)
+    const content = readFileSync(rc, "utf8")
+    expect(content).toContain("source <(kobe completions zsh)")
+    expect(content).toContain("command -v kobe")
   })
 })

--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -8,11 +8,51 @@
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { detectShell, installCompletions } from "../../src/cli/onboarding.ts"
+
+const mocks = vi.hoisted(() => ({
+  spawnSync: vi.fn(),
+  getPersistedBool: vi.fn(() => false),
+  setPersistedBool: vi.fn(),
+  npxSkillsArgv: vi.fn(() => ["skills", "add", "stub"]),
+  npxSkillsCommand: vi.fn(() => "npx skills add stub"),
+  runOnboardingWizard: vi.fn(),
+}))
+
+vi.mock("node:child_process", () => ({ spawnSync: mocks.spawnSync }))
+vi.mock("../../src/state/store.ts", () => ({
+  getPersistedBool: mocks.getPersistedBool,
+  setPersistedBool: mocks.setPersistedBool,
+}))
+vi.mock("../../src/lib/skill-install.ts", () => ({
+  npxSkillsArgv: mocks.npxSkillsArgv,
+  npxSkillsCommand: mocks.npxSkillsCommand,
+}))
+vi.mock("../../src/tui-react/onboarding/host.tsx", () => ({
+  runOnboardingWizard: mocks.runOnboardingWizard,
+}))
+
+// Dynamic import of tui/index.tsx only happens in maybeRunOnboarding's happy
+// path AFTER runOnboardingWizard resolves. We stub it so the import itself does
+// not pull React/opentui into the vitest node environment.
+vi.mock("../../src/tui/index.tsx", () => ({ startTui: vi.fn() }))
 
 function freshHome(): string {
   return mkdtempSync(join(tmpdir(), "kobe-onboarding-"))
+}
+
+function setProduct(name: "rove" | "kobe"): void {
+  if (name === "rove") process.env.ROVE_INVOKED_AS = "rove"
+  else process.env.ROVE_INVOKED_AS = undefined
+}
+
+function stdoutLines(spy: MockInstance<typeof process.stdout.write>): string[] {
+  return spy.mock.calls
+    .map((call) => String(call[0]))
+    .join("")
+    .split("\n")
+    .filter(Boolean)
 }
 
 describe("detectShell", () => {
@@ -71,5 +111,110 @@ describe("installCompletions", () => {
     const content = readFileSync(rc, "utf8")
     expect(content).toContain("source <(kobe completions zsh)")
     expect(content).toContain("command -v kobe")
+  })
+})
+
+describe("applyOnboardingChoices", () => {
+  let stdoutSpy: MockInstance<typeof process.stdout.write>
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+    vi.clearAllMocks()
+    process.env.ROVE_INVOKED_AS = undefined
+  })
+
+  it("declines everything when shell is unknown", async () => {
+    setProduct("kobe")
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: false }, null)
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("kobe skill install"))).toBe(true)
+    expect(lines.some((l) => l.includes("kobe completions --help"))).toBe(false)
+    expect(lines.some((l) => l.includes("You're ready to go!"))).toBe(true)
+  })
+
+  it("installs completions and the skill when both chosen (kobe)", async () => {
+    setProduct("kobe")
+    mocks.spawnSync.mockReturnValue({ status: 0 })
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: true, skill: true }, "zsh")
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("completions hooked into"))).toBe(true)
+    expect(lines.some((l) => l.includes("installing the Rove agent skill"))).toBe(true)
+    expect(mocks.spawnSync).toHaveBeenCalledWith("npx", ["skills", "add", "stub"], { stdio: "inherit" })
+  })
+
+  it("uses the rove CLI name when invoked as rove", async () => {
+    setProduct("rove")
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: false }, "bash")
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("rove completions --help"))).toBe(true)
+    expect(lines.some((l) => l.includes("rove skill install"))).toBe(true)
+    expect(lines.some((l) => l.includes("kobe"))).toBe(false)
+  })
+
+  it("prints a failure hint when the skill installer exits non-zero", async () => {
+    setProduct("kobe")
+    mocks.spawnSync.mockReturnValue({ status: 1 })
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: true }, "zsh")
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("skill install failed"))).toBe(true)
+    expect(lines.some((l) => l.includes("kobe skill install"))).toBe(true)
+  })
+})
+
+describe("maybeRunOnboarding", () => {
+  let stdoutSpy: MockInstance<typeof process.stdout.write>
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    mocks.getPersistedBool.mockReturnValue(false)
+    mocks.runOnboardingWizard.mockResolvedValue({ completions: true, skill: false })
+  })
+
+  afterEach(() => {
+    stdoutSpy.mockRestore()
+    vi.clearAllMocks()
+    process.env.ROVE_INVOKED_AS = undefined
+  })
+
+  it("returns false when stdout is not a TTY", async () => {
+    const { maybeRunOnboarding } = await import("../../src/cli/onboarding.ts")
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true })
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+    expect(await maybeRunOnboarding()).toBe(false)
+    expect(mocks.runOnboardingWizard).not.toHaveBeenCalled()
+  })
+
+  it("returns false when already onboarded", async () => {
+    mocks.getPersistedBool.mockReturnValue(true)
+    const { maybeRunOnboarding } = await import("../../src/cli/onboarding.ts")
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true })
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+    expect(await maybeRunOnboarding()).toBe(false)
+    expect(mocks.runOnboardingWizard).not.toHaveBeenCalled()
+  })
+
+  it("marks onboarded, runs the wizard, applies choices, and returns true", async () => {
+    setProduct("kobe")
+    const savedShell = process.env.SHELL
+    process.env.SHELL = "/bin/zsh"
+    const { maybeRunOnboarding } = await import("../../src/cli/onboarding.ts")
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true })
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+    const result = await maybeRunOnboarding()
+    if (savedShell !== undefined) process.env.SHELL = savedShell
+    else process.env.SHELL = undefined
+    expect(result).toBe(true)
+    expect(mocks.setPersistedBool).toHaveBeenCalledWith("onboarded", true)
+    expect(mocks.runOnboardingWizard).toHaveBeenCalledWith("zsh")
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("completions hooked into"))).toBe(true)
   })
 })


### PR DESCRIPTION
## What

Fixes `packages/kobe/src/cli/onboarding.ts` hard-coding the product name `rove` in:

- The shell rc completion hook (`source <(rove completions …)`)
- The fish autoload file name and content (`rove.fish`)
- The idempotency marker checked before appending to rc files
- User-facing hints (`rove completions --help`, `rove skill install`)

`installCompletions` now takes an optional `cli` parameter (defaulting to `activeCliName()`), and `applyOnboardingChoices` builds its hint strings from `activeCliName()`. When the binary is invoked as `kobe`, onboarding now references `kobe` consistently.

## Behavior

- `rove` invocation: unchanged behavior.
- `kobe` invocation: completions hook and hints now say `kobe` instead of `rove`.

## Verification

- `bun run lint` ✅
- `cd packages/kobe && bun run typecheck` ✅
- `bun test test/cli/onboarding.test.ts --run` ✅ (7 pass / 0 fail)

## Changeset

`.changeset/fix-onboarding-cli-name.md` — `"@sma1lboy/rove": patch`.
