### PR TITLE
fix: read the bundled theme names from the map that owns them

### DIFF
--- a/.changeset/theme-names-single-source.md
+++ b/.changeset/theme-names-single-source.md
@@ -1,0 +1,6 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove theme list` now reads the bundled theme names from the map that owns the JSON
+imports, instead of a hand-mirrored copy that could silently fall out of date.

--- a/packages/kobe/src/cli/theme.ts
+++ b/packages/kobe/src/cli/theme.ts
@@ -25,6 +25,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFile
 import { basename, join, resolve } from "node:path"
 import { errorMessage } from "@/lib/error-message"
 import { expandTilde } from "../lib/path-home.ts"
+import { BUNDLED_THEME_JSONS } from "../tui/context/theme/bundled"
 import { userThemesDir } from "../tui/context/theme/loader"
 import { validateTheme } from "../tui/context/theme/schema"
 import { activeCliName } from "./rename-compat.ts"
@@ -32,19 +33,17 @@ import { activeCliName } from "./rename-compat.ts"
 const CLI_NAME = activeCliName()
 
 /**
- * Filenames in `src/tui/context/theme/` that ship as bundled themes.
- * Hard-coded rather than read from disk because:
- *   - In a published binary the JSON files have been bundled into the
- *     compiled JS via Bun's `with { type: "json" }` import; there is no
- *     `src/tui/context/theme/` directory next to the running binary.
- *   - The bundled set is small and changes rarely; touch this list when
- *     adding a new bundled theme to `src/tui/context/theme.tsx`.
+ * The bundled theme names, read from the map that owns the JSON imports.
  *
- * The single source of truth is `BUNDLED_THEMES` in theme.tsx, but
- * importing that module here would drag in opentui + solid (it builds
- * a Solid store at module load). We mirror the names instead.
+ * This list used to be hand-mirrored here, because importing the theme module
+ * dragged in opentui + Solid (it built a Solid store at module load). That
+ * stopped being true when Solid was removed: `bundled.ts` is now nothing but
+ * three `with { type: "json" }` imports and a type-only import, so the CLI can
+ * read the real map and the two "keep these in sync" comments can go. Still no
+ * disk read — in a published binary those JSONs live inside the compiled JS,
+ * not next to it.
  */
-const BUNDLED_NAMES: readonly string[] = ["claude", "conductor", "tokyonight"]
+const BUNDLED_NAMES: readonly string[] = Object.keys(BUNDLED_THEME_JSONS)
 
 function fail(message: string): never {
   process.stderr.write(`${CLI_NAME} theme: ${message}\n`)

--- a/packages/kobe/src/tui/context/theme/bundled.ts
+++ b/packages/kobe/src/tui/context/theme/bundled.ts
@@ -2,9 +2,8 @@
  * The bundled theme JSONs as a plain map — the SINGLE owner of the static
  * JSON imports. `theme-core.ts` re-exports this map as `BUNDLED_THEMES`
  * for the theme providers; off-render callers (e.g. resolving tmux border
- * colors at session-build time) import it here directly. `cli/theme.ts`
- * mirrors just the NAMES — keep `BUNDLED_NAMES` there in sync with the
- * keys of this map.
+ * colors at session-build time) import it here directly, as does `cli/theme.ts`
+ * for the bundled NAMES — this map is the only place that list exists.
  */
 
 import type { ThemeJson } from "../theme-core"

--- a/packages/kobe/test/cli/theme.test.ts
+++ b/packages/kobe/test/cli/theme.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { runThemeSubcommand } from "../../src/cli/theme.ts"
+import { BUNDLED_THEME_JSONS } from "../../src/tui/context/theme/bundled.ts"
 
 const VALID_THEME = {
   defs: { bg: "#000000", fg: "#ffffff" },
@@ -95,6 +96,21 @@ describe("runThemeSubcommand list", () => {
     const text = out()
     expect(text).toContain("my-theme")
     expect(text).toContain("claude (overrides built-in)")
+  })
+
+  // `theme list` must name every bundled theme, not a copy of the list that
+  // happened to be true when it was written. The CLI used to hand-mirror these
+  // names because importing the theme map pulled in opentui + Solid; once Solid
+  // went away the workaround outlived its reason, leaving two files and two
+  // "keep in sync" comments as the only thing holding them together. This
+  // asserts against the map that owns the JSON imports, so adding a bundled
+  // theme without the CLI picking it up fails here.
+  it("lists every bundled theme in the canonical map", async () => {
+    await runThemeSubcommand(["list"])
+    const text = out()
+    for (const name of Object.keys(BUNDLED_THEME_JSONS)) {
+      expect(text).toContain(name)
+    }
   })
 
   it("rejects extra arguments to list", async () => {


### PR DESCRIPTION
From the thermo-nuclear sweep. A workaround that outlived its reason, leaving a manual sync contract behind.

## What was there

`cli/theme.ts` hand-mirrored the bundled theme names:

```ts
const BUNDLED_NAMES: readonly string[] = ["claude", "conductor", "tokyonight"]
```

with a comment explaining why it couldn't just read the real map:

> The single source of truth is `BUNDLED_THEMES` in theme.tsx, but importing that module here would drag in opentui + solid (it builds a Solid store at module load). We mirror the names instead.

**That reason left with Solid** (removed 2026-07-07). `bundled.ts` today is three `with { type: "json" }` imports and one type-only import — nothing the CLI can't take.

## Why it matters

What outlived the workaround was a *two-way manual contract*. Each file's comment told the next person to keep the other in sync:

- `cli/theme.ts`: *"touch this list when adding a new bundled theme"*
- `bundled.ts`: *"`cli/theme.ts` mirrors just the NAMES — keep `BUNDLED_NAMES` there in sync with the keys of this map"*

The two lists agree today, so there is no bug to report. The failure is scheduled, not present: whoever ships a fourth bundled theme has to notice a comment in a file they have no reason to open, or `rove theme list` silently omits it and `theme set <new>` rejects a theme that exists.

## The change

`Object.keys(BUNDLED_THEME_JSONS)`, both comments dropped. No disk read is introduced — in a published binary those JSONs are inside the compiled JS, which is what the original comment was really protecting.

A test asserts `theme list` names every theme in the canonical map. Verified it fails when the two drift: pinning the CLI back to a two-name list turns it red.

718 tests in `test/cli` green.