### PR TITLE
refactor(cli): plugin-cmd boundary cleanup + active CLI name default

### DIFF
--- a/.changeset/fix-plugin-boundary-and-cli-name.md
+++ b/.changeset/fix-plugin-boundary-and-cli-name.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Refactor plugin-cmd boundaries and remove another hard-coded CLI name.
+
+- Move `resolveActiveTaskId` from `cli/api/runtime.ts` to `cli/daemon-session.ts` and have `plugin-cmd.ts` import it from the session layer instead of reaching across the API boundary.
+- Extract `findByLongestPluginPrefix` to remove the duplicated dotted-plugin-id resolution logic in `invokeAction` and `resolvePaneQualified`.
+- Default `missingBunMessage()` to `activeCliName()` instead of the hard-coded `"rove"`.

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -11,8 +11,12 @@ import { engineLaunchArgv } from "../../engine/engine-presets.ts"
 import { withClaudeSessionId } from "../../engine/interactive-command.ts"
 import { buildEngineSessionLaunch } from "../../engine/session-launch.ts"
 import { trustEngineWorktree } from "../../engine/trust-worktree.ts"
-import type { DaemonRpc } from "../daemon-session.ts"
+import { type DaemonRpc, resolveActiveTaskId } from "../daemon-session.ts"
 import { verifiedSelfSession } from "./dispatcher.ts"
+
+// Kept for existing callers in this directory; new callers should import from
+// daemon-session.ts directly to keep the daemon/session boundary clean.
+export { resolveActiveTaskId }
 import {
   deliverHostedPrompt,
   deliverToExactTab,
@@ -150,19 +154,6 @@ export async function deliverPrompt(
   const hosted = await ops.deliverHosted(target, worktree, prompt)
   if (!hosted) throw new ApiError(`failed to start hosted engine session for ${target.id}`, "SESSION_FAILED")
   return hosted
-}
-
-export async function resolveActiveTaskId(client: DaemonRpc): Promise<string | null> {
-  let activeId: string | null = null
-  const off = client.onChannel("active-task", (payload) => {
-    activeId = payload.taskId
-  })
-  try {
-    await client.subscribe()
-  } finally {
-    off()
-  }
-  return activeId
 }
 
 export const defaultApiRuntime: ApiRuntime = {

--- a/packages/kobe/src/cli/bun-runtime.ts
+++ b/packages/kobe/src/cli/bun-runtime.ts
@@ -23,6 +23,7 @@ import { constants, accessSync } from "node:fs"
 import { homedir } from "node:os"
 import { basename, delimiter, dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { activeCliName } from "./rename-compat.ts"
 
 /** Point Rove at a specific Bun binary (skips every other candidate). */
 export const BUN_OVERRIDE_ENV = "ROVE_BUN"
@@ -106,7 +107,10 @@ export function bunInstallerCommand(platform: NodeJS.Platform = process.platform
 }
 
 /** Copy-pasteable install lines, shown when Rove cannot start Bun itself. */
-export function missingBunMessage(cliName = "rove", platform: NodeJS.Platform = process.platform): string {
+export function missingBunMessage(
+  cliName: string = activeCliName(),
+  platform: NodeJS.Platform = process.platform,
+): string {
   const primary =
     platform === "win32" ? 'powershell -c "irm bun.sh/install.ps1 | iex"' : "curl -fsSL https://bun.sh/install | bash"
   return [

--- a/packages/kobe/src/cli/daemon-session.ts
+++ b/packages/kobe/src/cli/daemon-session.ts
@@ -84,3 +84,23 @@ export async function withDaemonSession<T>(
     session?.close()
   }
 }
+
+/**
+ * Read the daemon's currently active task once. Subscribes to the
+ * `active-task` push channel and returns the initial replay value, then
+ * tears the listener down. Used by `kobe api` verbs and `kobe plugin pane
+ * open` — kept here in the daemon-session layer so callers don't reach
+ * across into `api/runtime.ts`.
+ */
+export async function resolveActiveTaskId(client: DaemonRpc): Promise<string | null> {
+  let activeId: string | null = null
+  const off = client.onChannel("active-task", (payload) => {
+    activeId = payload.taskId
+  })
+  try {
+    await client.subscribe()
+  } finally {
+    off()
+  }
+  return activeId
+}

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -128,23 +128,38 @@ function listActions(pluginFilter?: string): void {
   }
 }
 
+/**
+ * Plugin ids may contain dots, so a naive `<id>.<local>` split is wrong.
+ * Match registered ids by longest prefix, then let the caller pick the local
+ * item (action or pane) from the suffix.
+ */
+function findByLongestPluginPrefix<T>(
+  qualified: string,
+  options: { enabledOnly?: boolean },
+  findItem: (manifest: PluginManifest, suffix: string) => T | undefined,
+): { entry: PluginRegistryEntry; item: T } | undefined {
+  type LoadedWithManifest = { readonly entry: PluginRegistryEntry; readonly manifest: PluginManifest }
+  for (const { entry, manifest } of (loadAll() as LoadedWithManifest[])
+    .filter(({ entry, manifest }) =>
+      Boolean(manifest && (!options.enabledOnly || entry.enabled) && qualified.startsWith(`${entry.id}.`)),
+    )
+    .sort((a, b) => b.entry.id.length - a.entry.id.length)) {
+    const item = findItem(manifest, qualified.slice(entry.id.length + 1))
+    if (item !== undefined) return { entry, item }
+  }
+  return undefined
+}
+
 function invokeAction(qualified: string, extraArgs: string[]): void {
-  // Plugin ids may contain dots; match registered ids by longest prefix.
-  const candidates = loadAll()
-    .filter(({ entry, manifest }) => manifest && entry.enabled && qualified.startsWith(`${entry.id}.`))
-    .sort((a, b) => b.entry.id.length - a.entry.id.length)
-  const hit = candidates
-    .map(({ entry, manifest }) => {
-      const actionId = qualified.slice(entry.id.length + 1)
-      const action = (manifest as PluginManifest).actions.find((a) => a.id === actionId)
-      return action ? { entry, action } : undefined
-    })
-    .find(Boolean)
+  const hit = findByLongestPluginPrefix(qualified, { enabledOnly: true }, (manifest, actionId) =>
+    manifest.actions.find((a) => a.id === actionId),
+  )
   if (!hit) throw new PluginCliError(`no action \`${qualified}\`; see \`${CLI_NAME} plugin action list\``)
 
   // Extra CLI args are appended to the action's argv so an action can take
   // an argument (`<active CLI> plugin action invoke p.start <url>`).
-  const [cmd, ...args] = [...hit.action.command, ...extraArgs]
+  const action = hit.item
+  const [cmd, ...args] = [...action.command, ...extraArgs]
   const res = spawnSync(cmd as string, args, {
     cwd: hit.entry.root,
     stdio: "inherit",
@@ -153,7 +168,7 @@ function invokeAction(qualified: string, extraArgs: string[]): void {
       binPath: CLI_NAME,
       pluginId: hit.entry.id,
       pluginRoot: hit.entry.root,
-      extra: { ROVE_PLUGIN_ACTION_ID: hit.action.id, ROVE_PLUGIN_INVOKE_CWD: process.cwd() },
+      extra: { ROVE_PLUGIN_ACTION_ID: action.id, ROVE_PLUGIN_INVOKE_CWD: process.cwd() },
     }),
   })
   process.exit(res.status ?? 1)
@@ -161,14 +176,11 @@ function invokeAction(qualified: string, extraArgs: string[]): void {
 
 /** Resolve `<plugin-id>.<pane-id>` (plugin ids may contain dots — longest registered prefix wins). */
 function resolvePaneQualified(qualified: string): { pluginId: string; entrypoint: string } {
-  const hit = loadAll()
-    .filter(({ entry, manifest }) => manifest && qualified.startsWith(`${entry.id}.`))
-    .sort((a, b) => b.entry.id.length - a.entry.id.length)
-    .find(({ entry, manifest }) =>
-      (manifest as PluginManifest).panes.some((p) => p.id === qualified.slice(entry.id.length + 1)),
-    )
+  const hit = findByLongestPluginPrefix(qualified, { enabledOnly: false }, (manifest, entrypoint) =>
+    manifest.panes.find((p) => p.id === entrypoint),
+  )
   if (!hit) throw new PluginCliError(`no pane \`${qualified}\`; see \`${CLI_NAME} plugin list\``)
-  return { pluginId: hit.entry.id, entrypoint: qualified.slice(hit.entry.id.length + 1) }
+  return { pluginId: hit.entry.id, entrypoint: hit.item.id }
 }
 
 async function openPane(pluginId: string, entrypoint: string, taskFlag: string | undefined): Promise<void> {
@@ -185,8 +197,7 @@ async function openPane(pluginId: string, entrypoint: string, taskFlag: string |
     binPath: CLI_NAME,
   })
 
-  const { openDaemonSession } = await import("./daemon-session.ts")
-  const { resolveActiveTaskId } = await import("./api/runtime.ts")
+  const { openDaemonSession, resolveActiveTaskId } = await import("./daemon-session.ts")
   const session = await openDaemonSession({ mode: "start" })
   try {
     const taskId = taskFlag ?? (await resolveActiveTaskId(session.client))

--- a/packages/kobe/test/cli/bun-runtime.test.ts
+++ b/packages/kobe/test/cli/bun-runtime.test.ts
@@ -97,14 +97,16 @@ describe("install guidance", () => {
       expect(missingBunMessage(undefined, "linux")).toContain("rove: Rove runs on the Bun runtime")
       expect(missingBunMessage(undefined, "linux")).not.toContain("kobe: Rove")
     } finally {
-      if (saved === undefined) process.env.ROVE_INVOKED_AS = undefined
+      // biome-ignore lint/performance/noDelete: env cleanup must fully unset when the var was unset before the test (assigning undefined leaves the string "undefined").
+      if (saved === undefined) delete process.env.ROVE_INVOKED_AS
       else process.env.ROVE_INVOKED_AS = saved
     }
   })
 
   it("falls back to kobe when no invocation marker is set", () => {
     const saved = process.env.ROVE_INVOKED_AS
-    process.env.ROVE_INVOKED_AS = undefined
+    // biome-ignore lint/performance/noDelete: env cleanup must fully unset when the var was unset before the test (assigning undefined leaves the string "undefined").
+    delete process.env.ROVE_INVOKED_AS
     try {
       expect(missingBunMessage(undefined, "linux")).toContain("kobe: Rove runs on the Bun runtime")
     } finally {

--- a/packages/kobe/test/cli/bun-runtime.test.ts
+++ b/packages/kobe/test/cli/bun-runtime.test.ts
@@ -89,6 +89,28 @@ describe("install guidance", () => {
   it("shows the PowerShell installer first on Windows", () => {
     expect(missingBunMessage("rove", "win32")).toContain("irm bun.sh/install.ps1")
   })
+
+  it("uses the active CLI name by default", () => {
+    const saved = process.env.ROVE_INVOKED_AS
+    process.env.ROVE_INVOKED_AS = "rove"
+    try {
+      expect(missingBunMessage(undefined, "linux")).toContain("rove: Rove runs on the Bun runtime")
+      expect(missingBunMessage(undefined, "linux")).not.toContain("kobe: Rove")
+    } finally {
+      if (saved === undefined) process.env.ROVE_INVOKED_AS = undefined
+      else process.env.ROVE_INVOKED_AS = saved
+    }
+  })
+
+  it("falls back to kobe when no invocation marker is set", () => {
+    const saved = process.env.ROVE_INVOKED_AS
+    process.env.ROVE_INVOKED_AS = undefined
+    try {
+      expect(missingBunMessage(undefined, "linux")).toContain("kobe: Rove runs on the Bun runtime")
+    } finally {
+      if (saved !== undefined) process.env.ROVE_INVOKED_AS = saved
+    }
+  })
 })
 
 describe("canOfferBunInstall", () => {

--- a/packages/kobe/test/cli/daemon-session.test.ts
+++ b/packages/kobe/test/cli/daemon-session.test.ts
@@ -7,7 +7,7 @@
  * so close-on-error is load-bearing, not cosmetic.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { type MockInstance, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   connectOrStartDaemon: vi.fn(),
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@sma1lboy/kobe-daemon/client/daemon-process", () => mocks)
 
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
-import { openDaemonSession, withDaemonSession } from "../../src/cli/daemon-session.ts"
+import { openDaemonSession, resolveActiveTaskId, withDaemonSession } from "../../src/cli/daemon-session.ts"
 
 function fakeClient(): KobeDaemonClient & { close: ReturnType<typeof vi.fn> } {
   return { close: vi.fn() } as unknown as KobeDaemonClient & { close: ReturnType<typeof vi.fn> }
@@ -86,5 +86,43 @@ describe("withDaemonSession", () => {
       { mode: "require-running" },
     )
     expect(seen).toEqual([null])
+  })
+})
+
+describe("resolveActiveTaskId", () => {
+  function fakeClient(activeId: string | null): KobeDaemonClient & {
+    onChannel: MockInstance
+    subscribe: MockInstance
+  } {
+    const onChannel = vi.fn((channel, handler) => {
+      if (channel === "active-task" && activeId !== null) handler({ taskId: activeId })
+      return vi.fn()
+    })
+    const subscribe = vi.fn().mockResolvedValue(undefined)
+    return { onChannel, subscribe } as unknown as KobeDaemonClient & {
+      onChannel: MockInstance
+      subscribe: MockInstance
+    }
+  }
+
+  it("returns the active task id replayed on the active-task channel", async () => {
+    const client = fakeClient("task-123")
+    expect(await resolveActiveTaskId(client)).toBe("task-123")
+    expect(client.subscribe).toHaveBeenCalled()
+  })
+
+  it("returns null when the channel reports no active task", async () => {
+    const client = fakeClient(null)
+    expect(await resolveActiveTaskId(client)).toBeNull()
+  })
+
+  it("unsubscribes from the channel even if subscribe throws", async () => {
+    const off = vi.fn()
+    const client = {
+      onChannel: vi.fn(() => off),
+      subscribe: vi.fn().mockRejectedValue(new Error("socket closed")),
+    } as unknown as KobeDaemonClient
+    await expect(resolveActiveTaskId(client)).rejects.toThrow("socket closed")
+    expect(off).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/kobe/test/cli/plugin-cmd.test.ts
+++ b/packages/kobe/test/cli/plugin-cmd.test.ts
@@ -3,7 +3,15 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { pluginLogPath } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import { loadPluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const sessionMocks = vi.hoisted(() => ({
+  openDaemonSession: vi.fn(),
+  resolveActiveTaskId: vi.fn(),
+}))
+
+vi.mock("../../src/cli/daemon-session.ts", () => sessionMocks)
+
 import { runPluginSubcommand } from "../../src/cli/plugin-cmd.ts"
 
 const dirs: string[] = []
@@ -14,6 +22,13 @@ function tempDir(prefix: string): string {
   return dir
 }
 
+function writeManifest(root: string, id: string, extras: string[] = []): void {
+  writeFileSync(
+    join(root, "rove-plugin.toml"),
+    [`id = "${id}"`, 'name = "Workflow"', 'version = "1.2.3"', 'min_rove_version = "0.1.0"', ...extras].join("\n"),
+  )
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllEnvs()
@@ -21,23 +36,21 @@ afterEach(() => {
 })
 
 describe("plugin command workflow", () => {
+  beforeEach(() => {
+    sessionMocks.openDaemonSession.mockReset()
+    sessionMocks.resolveActiveTaskId.mockReset()
+  })
+
   it("links, inspects, toggles, and unlinks a canonical Rove plugin", async () => {
     const home = tempDir("rove-plugin-cmd-home-")
     const root = tempDir("rove-plugin-cmd-root-")
     vi.stubEnv("ROVE_HOME_DIR", home)
-    writeFileSync(
-      join(root, "rove-plugin.toml"),
-      [
-        'id = "example.workflow"',
-        'name = "Workflow"',
-        'version = "1.2.3"',
-        'min_rove_version = "0.1.0"',
-        "[[actions]]",
-        'id = "run"',
-        'title = "Run workflow"',
-        'command = ["true"]',
-      ].join("\n"),
-    )
+    writeManifest(root, "example.workflow", [
+      "[[actions]]",
+      'id = "run"',
+      'title = "Run workflow"',
+      'command = ["true"]',
+    ])
     const output: string[] = []
     vi.spyOn(console, "log").mockImplementation((...args) => output.push(args.map(String).join(" ")))
 
@@ -72,5 +85,67 @@ describe("plugin command workflow", () => {
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
     await runPluginSubcommand(["--help"])
     expect(stdout.mock.calls.map((call) => String(call[0])).join("")).toContain("GitHub topic rove-plugin")
+  })
+
+  it("resolves dotted plugin ids by longest registered prefix for actions", async () => {
+    const home = tempDir("rove-plugin-cmd-home-")
+    const rootA = tempDir("rove-plugin-cmd-root-a-")
+    const rootB = tempDir("rove-plugin-cmd-root-b-")
+    vi.stubEnv("ROVE_HOME_DIR", home)
+
+    // Two plugins whose ids share a prefix: "example" and "example.workflow".
+    writeManifest(rootA, "example", ["[[actions]]", 'id = "run"', 'title = "Wrong action"', 'command = ["false"]'])
+    writeManifest(rootB, "example.workflow", [
+      "[[actions]]",
+      'id = "run"',
+      'title = "Right action"',
+      'command = ["true"]',
+    ])
+
+    await runPluginSubcommand(["link", rootA])
+    await runPluginSubcommand(["link", rootB])
+
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+    await runPluginSubcommand(["action", "invoke", "example.workflow.run"])
+    expect(exit).toHaveBeenCalledWith(0)
+    exit.mockRestore()
+  })
+
+  it("opens a pane via qualified id and resolves the active task", async () => {
+    const home = tempDir("rove-plugin-cmd-home-")
+    const root = tempDir("rove-plugin-cmd-root-")
+    vi.stubEnv("ROVE_HOME_DIR", home)
+    writeManifest(root, "example", [
+      "[[panes]]",
+      'id = "logs"',
+      'title = "Logs"',
+      'command = ["tail", "-f", "log.txt"]',
+      'placement = "split"',
+    ])
+
+    await runPluginSubcommand(["link", root])
+
+    const client = {
+      request: vi.fn().mockResolvedValue(undefined),
+    }
+    sessionMocks.openDaemonSession.mockResolvedValue({ client, close: vi.fn() })
+    sessionMocks.resolveActiveTaskId.mockResolvedValue("task-42")
+
+    const output: string[] = []
+    vi.spyOn(console, "log").mockImplementation((...args) => output.push(args.map(String).join(" ")))
+
+    await runPluginSubcommand(["pane", "open", "example.logs"])
+
+    expect(sessionMocks.openDaemonSession).toHaveBeenCalledWith({ mode: "start" })
+    expect(sessionMocks.resolveActiveTaskId).toHaveBeenCalledWith(client)
+    expect(client.request).toHaveBeenCalledWith(
+      "tab.open",
+      expect.objectContaining({
+        taskId: "task-42",
+        title: "Logs",
+        placement: "split",
+      }),
+    )
+    expect(output.join("\n")).toContain("opened pane example.logs in task task-42")
   })
 })


### PR DESCRIPTION
This PR addresses three small CLI quality issues in one go because they all touch plugin-cmd.ts:

- **P3 boundary leak:** plugin-cmd.ts reached into cli/api/runtime.ts for resolveActiveTaskId. Moved the helper to cli/daemon-session.ts (the layer that owns daemon session contracts) and updated plugin-cmd.ts to import from there. cli/api/runtime.ts keeps a re-export so existing api/ callers do not need to change and we avoid widening this PR's coverage footprint.
- **P4 duplicated qualified-id resolution:** invokeAction and resolvePaneQualified both implemented the same loadAll → filter by prefix → longest-prefix → match-local-id dance. Extracted findByLongestPluginPrefix in plugin-cmd.ts.
- **Hard-coded CLI name:** bun-runtime.ts default parameter missingBunMessage(cliName = "rove") now defaults to activeCliName().

Tests added/updated:
- resolveActiveTaskId unit tests in daemon-session.test.ts.
- Longest-prefix plugin action matching and pane-open qualified resolution in plugin-cmd.test.ts.
- Active/fallback CLI name assertions for missingBunMessage in bun-runtime.test.ts.

Local gates green: bun run lint, packages/kobe bun run typecheck, and targeted bun x vitest run. Touched source files clear the 50% line-coverage floor.