### PR TITLE
refactor(tui-react): extract Terminal host cursor and resize effects

### DIFF
--- a/.changeset/extract-terminal-host-cursor.md
+++ b/.changeset/extract-terminal-host-cursor.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+refactor(tui-react): extract Terminal host cursor and resize effects
+
+`Terminal.tsx` was pinned at the 500-line file-size cap with zero
+headroom. Move the resize-push-to-PTY effect and the macOS IME host
+cursor-anchor effects into a new `use-terminal-host-cursor.ts` hook
+so the component can focus on rendering and input handling.
+
+No behavior change: all terminal render, IME cursor, and scrollback
+tests pass. `Terminal.tsx` drops from 500 to 427 lines; the new hook
+is 115 lines.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -25,24 +25,18 @@
  *     dependency array during render, so no such ordering constraint
  *     exists — the hooks below are ordered for readability, not
  *     correctness.
- *   - Body-box measurement lives in `use-terminal-geometry.ts`; the
- *     resize-push-to-pty and host-cursor-anchor effects stay HERE
- *     because they need the PTY handle and the computed viewport cursor,
- *     which only exist after the geometry hook's `bodyGeometry` has fed
- *     `useTerminalPty` — splitting them out would just reintroduce the
- *     same chicken-and-egg hook ordering this file avoids.
+ *   - Body-box measurement and the resize-push / host-cursor-anchor
+ *     effects live in `use-terminal-geometry.ts` and
+ *     `use-terminal-host-cursor.ts`. They receive the PTY handle and the
+ *     computed viewport cursor after `useTerminalPty` has produced them,
+ *     so the call order in this file remains the same and there is no
+ *     chicken-and-egg hook-ordering hazard.
  */
 
 import type { BoxRenderable, TextRenderable } from "@opentui/core"
 import { StyledText } from "@opentui/core"
-import { useRenderer } from "@opentui/react"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { imeAnchorController } from "../../../tui/lib/ime-anchor-output"
-import {
-  ImeCursorRetention,
-  type ImeScreenAnchor,
-  ImeScreenAnchorRetention,
-} from "../../../tui/panes/terminal/ime-cursor"
+import { ImeCursorRetention } from "../../../tui/panes/terminal/ime-cursor"
 import { type PtyRegistry, getDefaultPtyRegistry } from "../../../tui/panes/terminal/registry"
 import { rowsToStyledText } from "../../../tui/panes/terminal/sgr-to-text-chunk"
 import { isShellMissing, overlayCursor, sealRowEndAttributes } from "../../../tui/panes/terminal/terminal-render"
@@ -62,6 +56,7 @@ import { useDialog } from "../../ui/dialog"
 import { DialogConfirm } from "../../ui/dialog-confirm"
 import { useTerminalBindings } from "./keys"
 import { useTerminalGeometry } from "./use-terminal-geometry"
+import { useTerminalHostCursor } from "./use-terminal-host-cursor"
 import { useTerminalPty } from "./use-terminal-pty"
 import { useTerminalSelection } from "./use-terminal-selection"
 
@@ -307,83 +302,15 @@ export function Terminal(props: TerminalProps) {
 
   /* --------- resize-push + host-cursor anchor ---------- */
 
-  const renderer = useRenderer()
-  const imeAnchorOwner = useRef(Symbol("terminal-ime-anchor")).current
-  const [imeScreenAnchorRetention] = useState(() => new ImeScreenAnchorRetention())
-
-  // Push geometry changes to the backend, deduped against the last push —
-  // real PTY backends may emit SIGWINCH even when geometry is unchanged.
-  const lastResizeRef = useRef<{ pty: typeof pty; cols: number; rows: number } | null>(null)
-  useEffect(() => {
-    if (!pty || !bodyGeometry) return
-    const { cols, rows } = bodyGeometry
-    const last = lastResizeRef.current
-    if (last?.pty === pty && last.cols === cols && last.rows === rows) return
-    lastResizeRef.current = { pty, cols, rows }
-    try {
-      pty.resize(cols, rows)
-    } catch {
-      /* best effort */
-    }
-  }, [pty, bodyGeometry])
-
-  // Keep the native host cursor INVISIBLE (the visible cursor is the inline
-  // inverse cell in `cursorRows`) but ANCHORED to the visible chat terminal's
-  // screen cell — even while Sidebar or Files owns keyboard focus. A transient
-  // PTY cursor-hide retains the last position; the renderer-output adapter
-  // restores it at the end of every diff frame.
-  useEffect(() => {
-    // Dependency-only invalidation keys — see use-terminal-geometry.ts;
-    // screenX/screenY are read imperatively, non-reactive geometry.
-    void dims
-    void geomTick
-    if (!renderer) return
-    if (!imeAnchorActive) {
-      imeScreenAnchorRetention.update(null, null)
-      if (imeAnchorController.release(imeAnchorOwner)) renderer.setCursorPosition(0, 0, false)
-      return
-    }
-    let currentScreenAnchor: ImeScreenAnchor | null = null
-    if (bodyEl && visibleImeCursor && bodyEl.width > 0) {
-      currentScreenAnchor = {
-        x: bodyEl.screenX + visibleImeCursor.x,
-        y: bodyEl.screenY + visibleImeCursor.y,
-      }
-    }
-    // Historical scrollback has no live viewport cursor. Keep the prior
-    // screen-cell anchor for this PTY instead of sending the IME to the outer
-    // origin. A replacement PTY starts at origin until it reports a cursor.
-    const retainedAnchor = imeScreenAnchorRetention.update(pty, currentScreenAnchor)
-    if (retainedAnchor) {
-      imeAnchorController.claim(imeAnchorOwner, retainedAnchor)
-      renderer.setCursorPosition(retainedAnchor.x, retainedAnchor.y, false)
-      return
-    }
-    imeAnchorController.claim(imeAnchorOwner, { x: 0, y: 0 })
-    renderer.setCursorPosition(0, 0, false)
-  }, [
-    renderer,
-    imeAnchorActive,
+  useTerminalHostCursor({
+    pty,
     bodyEl,
+    bodyGeometry,
     visibleImeCursor,
+    imeAnchorActive,
     dims,
     geomTick,
-    imeAnchorOwner,
-    imeScreenAnchorRetention,
-    pty,
-  ])
-
-  // On unmount, hide the cursor so it doesn't leak into whichever pane
-  // gains focus next.
-  useEffect(() => {
-    return () => {
-      try {
-        if (imeAnchorController.release(imeAnchorOwner)) renderer?.setCursorPosition(0, 0, false)
-      } catch {
-        /* renderer may already be torn down */
-      }
-    }
-  }, [renderer, imeAnchorOwner])
+  })
 
   /* --------- view ---------- */
 

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts
@@ -1,0 +1,115 @@
+/**
+ * Host-side terminal output effects: push geometry changes to the PTY and
+ * anchor the native host cursor to the visible terminal cell for macOS IME.
+ *
+ * Split out of `Terminal.tsx` to keep the component under the file-size cap.
+ * The caller still supplies the computed viewport cursor (`visibleImeCursor`);
+ * this hook only owns the imperative renderer/PTY side-effects and the
+ * retention objects that survive across output frames.
+ */
+
+import type { BoxRenderable } from "@opentui/core"
+import { useRenderer } from "@opentui/react"
+import { useEffect, useRef, useState } from "react"
+import { imeAnchorController } from "../../../tui/lib/ime-anchor-output"
+import type { ImeScreenAnchor } from "../../../tui/panes/terminal/ime-cursor"
+import { ImeScreenAnchorRetention } from "../../../tui/panes/terminal/ime-cursor"
+import type { CursorPos, TaskPty } from "../../../tui/panes/terminal/pty"
+
+export interface UseTerminalHostCursorOpts {
+  /** Active PTY handle, null while none is acquired. */
+  pty: TaskPty | null
+  /** Body box element — provides screen-cell origin for the anchor. */
+  bodyEl: BoxRenderable | null
+  /** Latest measured geometry — pushed to the PTY on change. */
+  bodyGeometry: { cols: number; rows: number } | null
+  /** Cursor coordinate within the visible viewport; null hides the anchor. */
+  visibleImeCursor: CursorPos | null
+  /** Whether this terminal owns the shared host cursor anchor. */
+  imeAnchorActive: boolean
+  /** Host-terminal dims — invalidation key for non-reactive screen geometry. */
+  dims: { width: number; height: number }
+  /** Layout tick from the body box's onSizeChange — ditto. */
+  geomTick: number
+}
+
+export function useTerminalHostCursor(opts: UseTerminalHostCursorOpts): void {
+  const { pty, bodyEl, bodyGeometry, visibleImeCursor, imeAnchorActive, dims, geomTick } = opts
+  const renderer = useRenderer()
+  const imeAnchorOwner = useRef(Symbol("terminal-ime-anchor")).current
+  const [imeScreenAnchorRetention] = useState(() => new ImeScreenAnchorRetention())
+
+  // Push geometry changes to the backend, deduped against the last push —
+  // real PTY backends may emit SIGWINCH even when geometry is unchanged.
+  const lastResizeRef = useRef<{ pty: typeof pty; cols: number; rows: number } | null>(null)
+  useEffect(() => {
+    if (!pty || !bodyGeometry) return
+    const { cols, rows } = bodyGeometry
+    const last = lastResizeRef.current
+    if (last?.pty === pty && last.cols === cols && last.rows === rows) return
+    lastResizeRef.current = { pty, cols, rows }
+    try {
+      pty.resize(cols, rows)
+    } catch {
+      /* best effort */
+    }
+  }, [pty, bodyGeometry])
+
+  // Keep the native host cursor INVISIBLE (the visible cursor is the inline
+  // inverse cell in the rendered rows) but ANCHORED to the visible chat
+  // terminal's screen cell — even while Sidebar or Files owns keyboard focus.
+  // A transient PTY cursor-hide retains the last position; the renderer-output
+  // adapter restores it at the end of every diff frame.
+  useEffect(() => {
+    // Dependency-only invalidation keys — screenX/screenY are read
+    // imperatively, non-reactive geometry.
+    void dims
+    void geomTick
+    if (!renderer) return
+    if (!imeAnchorActive) {
+      imeScreenAnchorRetention.update(null, null)
+      if (imeAnchorController.release(imeAnchorOwner)) renderer.setCursorPosition(0, 0, false)
+      return
+    }
+    let currentScreenAnchor: ImeScreenAnchor | null = null
+    if (bodyEl && visibleImeCursor && bodyEl.width > 0) {
+      currentScreenAnchor = {
+        x: bodyEl.screenX + visibleImeCursor.x,
+        y: bodyEl.screenY + visibleImeCursor.y,
+      }
+    }
+    // Historical scrollback has no live viewport cursor. Keep the prior
+    // screen-cell anchor for this PTY instead of sending the IME to the outer
+    // origin. A replacement PTY starts at origin until it reports a cursor.
+    const retainedAnchor = imeScreenAnchorRetention.update(pty, currentScreenAnchor)
+    if (retainedAnchor) {
+      imeAnchorController.claim(imeAnchorOwner, retainedAnchor)
+      renderer.setCursorPosition(retainedAnchor.x, retainedAnchor.y, false)
+      return
+    }
+    imeAnchorController.claim(imeAnchorOwner, { x: 0, y: 0 })
+    renderer.setCursorPosition(0, 0, false)
+  }, [
+    renderer,
+    imeAnchorActive,
+    bodyEl,
+    visibleImeCursor,
+    dims,
+    geomTick,
+    imeAnchorOwner,
+    imeScreenAnchorRetention,
+    pty,
+  ])
+
+  // On unmount, hide the cursor so it doesn't leak into whichever pane
+  // gains focus next.
+  useEffect(() => {
+    return () => {
+      try {
+        if (imeAnchorController.release(imeAnchorOwner)) renderer?.setCursorPosition(0, 0, false)
+      } catch {
+        /* renderer may already be torn down */
+      }
+    }
+  }, [renderer, imeAnchorOwner])
+}


### PR DESCRIPTION
## What

`Terminal.tsx` was pinned at the 500-line file-size cap with zero headroom. This PR moves the two host-side output effects — resize-push-to-PTY and macOS IME host-cursor anchoring — into a new `use-terminal-host-cursor.ts` hook.

## Why this seam

The extracted code owns a coherent bundle of state:
- the deduped last-resize ref,
- the `ImeScreenAnchorRetention` object,
- the per-pane IME anchor owner symbol,
- and the `useRenderer()` handle.

All of these serve the same boundary: syncing the terminal's visible geometry/cursor with the host renderer and the PTY backend. Keeping them together matches the #529 pattern (state + the effects that serve it move as one unit) rather than doing a local line-shuffle that leaves the file still pinned at 500.

## Verification

- `bun run lint` ✅
- `cd packages/kobe && bun run typecheck` ✅
- `bun x vitest run test/tui` ✅ (151 files, 1325 tests)
- `bun test test/render` ✅

## Impact

- `Terminal.tsx`: 500 → 427 lines
- New `use-terminal-host-cursor.ts`: 115 lines
- No behavior change; no chord keys touched.

## Coverage exemption

- coverage-exemption: packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts — Same known instrumentation blind spot as other tui-react runtime hooks: vitest coverage cannot instrument React renderer files; behavior is covered by the render-track tests in test/render/terminal-scrollback-layout.test.tsx.
- render-coverage-exemption: packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts — Same reason; the hook's behavior is exercised through Terminal.tsx in the render track.