### PR TITLE
refactor(tui): extract file-tree path-to-tree builder into filetree/tree.ts

### DIFF
--- a/.changeset/filetree-tree-split.md
+++ b/.changeset/filetree-tree-split.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Extract the path-to-tree builder (`TreeNode`, `buildTree`, `sortTree`) from `filetree/git.ts` into a framework-free `filetree/tree.ts`. The tree builder has no git dependency and is consumed by both the file-tree pane and its React port. `filetree/git.ts` drops from 466 to 412 lines.

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -30,8 +30,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   type GitScope,
   type StatusEntry,
-  type TreeNode,
-  buildTree,
   listFiles,
   resolveBase,
   statusFiles,
@@ -58,6 +56,7 @@ import {
   sameStatusEntries,
   statusRows,
 } from "../../../tui/panes/filetree/rows"
+import { type TreeNode, buildTree } from "../../../tui/panes/filetree/tree"
 import { PaneKeyHint, usePaneHintMark } from "../../component/keyboard-hints"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"

--- a/packages/kobe/src/tui/panes/filetree/git.ts
+++ b/packages/kobe/src/tui/panes/filetree/git.ts
@@ -29,6 +29,7 @@
 
 import { parseNumstatRows, parsePorcelainRows, unquoteGitPath } from "@/lib/git-parsers"
 import { readWorktreeFile, runWorktreeGit } from "../../../worktree/content.ts"
+import type { TreeNode } from "./tree"
 
 /**
  * Which diff the Changes tab shows:
@@ -362,61 +363,6 @@ async function countAddedLines(worktreePath: string, relPath: string, signal?: A
  */
 export function parseNumstat(raw: string): NumstatEntry[] {
   return parseNumstatRows(raw).map((r) => ({ path: r.path, added: r.added, deleted: r.deleted }))
-}
-
-/**
- * Build a directory tree from a flat list of paths. Used by the All
- * tab to render files grouped by their on-disk hierarchy. The returned
- * root has an empty name/path; its children are the top-level entries
- * sorted with directories first, then files, alphabetically within each
- * group (matches VS Code / Finder default).
- */
-export type TreeNode = {
-  /** Path segment (last component). Empty for the root. */
-  name: string
-  /** Full path relative to worktree root. Empty for the root. */
-  path: string
-  /** Directories vs leaves. Directories may have empty `children` if
-   * a file under them is filtered out — but `buildTree` never produces
-   * empty dirs since paths terminate at files. */
-  isDir: boolean
-  children: TreeNode[]
-}
-
-export function buildTree(paths: readonly string[]): TreeNode {
-  const root: TreeNode = { name: "", path: "", isDir: true, children: [] }
-  for (const p of paths) {
-    if (!p) continue
-    const segs = p.split("/").filter((s) => s.length > 0)
-    if (segs.length === 0) continue
-    let cur = root
-    for (let i = 0; i < segs.length; i++) {
-      const seg = segs[i] as string
-      const isLast = i === segs.length - 1
-      const isDir = !isLast
-      let child = cur.children.find((c) => c.name === seg && c.isDir === isDir)
-      if (!child) {
-        child = {
-          name: seg,
-          path: segs.slice(0, i + 1).join("/"),
-          isDir,
-          children: [],
-        }
-        cur.children.push(child)
-      }
-      cur = child
-    }
-  }
-  sortTree(root)
-  return root
-}
-
-function sortTree(node: TreeNode): void {
-  node.children.sort((a, b) => {
-    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1
-    return a.name.localeCompare(b.name)
-  })
-  for (const c of node.children) sortTree(c)
 }
 
 /**

--- a/packages/kobe/src/tui/panes/filetree/rows.ts
+++ b/packages/kobe/src/tui/panes/filetree/rows.ts
@@ -19,7 +19,8 @@
 
 import { reconcileStableRows } from "@/tui/lib/stable-rows"
 import { truncateStart } from "@/tui/lib/truncate"
-import type { FileStatus, StatusEntry, TreeNode } from "./git"
+import type { FileStatus, StatusEntry } from "./git"
+import type { TreeNode } from "./tree"
 
 /**
  * Internal row shape. The All tab renders a tree (files + collapsible

--- a/packages/kobe/src/tui/panes/filetree/tree.ts
+++ b/packages/kobe/src/tui/panes/filetree/tree.ts
@@ -1,0 +1,60 @@
+/** Directory-tree data structure for the file-tree pane.
+ *
+ * {@link buildTree} turns a flat list of file paths into a sorted, nested
+ * {@link TreeNode} hierarchy. This is independent of git: the file list can
+ * come from `git ls-files`, a static snapshot, or any other source. */
+
+export type TreeNode = {
+  /** Path segment (last component). Empty for the root. */
+  name: string
+  /** Full path relative to worktree root. Empty for the root. */
+  path: string
+  /** Directories vs leaves. Directories may have empty `children` if
+   * a file under them is filtered out — but `buildTree` never produces
+   * empty dirs since paths terminate at files. */
+  isDir: boolean
+  children: TreeNode[]
+}
+
+/**
+ * Build a directory tree from a flat list of paths. Used by the All
+ * tab to render files grouped by their on-disk hierarchy. The returned
+ * root has an empty name/path; its children are the top-level entries
+ * sorted with directories first, then files, alphabetically within each
+ * group (matches VS Code / Finder default).
+ */
+export function buildTree(paths: readonly string[]): TreeNode {
+  const root: TreeNode = { name: "", path: "", isDir: true, children: [] }
+  for (const p of paths) {
+    if (!p) continue
+    const segs = p.split("/").filter((s) => s.length > 0)
+    if (segs.length === 0) continue
+    let cur = root
+    for (let i = 0; i < segs.length; i++) {
+      const seg = segs[i] as string
+      const isLast = i === segs.length - 1
+      const isDir = !isLast
+      let child = cur.children.find((c) => c.name === seg && c.isDir === isDir)
+      if (!child) {
+        child = {
+          name: seg,
+          path: segs.slice(0, i + 1).join("/"),
+          isDir,
+          children: [],
+        }
+        cur.children.push(child)
+      }
+      cur = child
+    }
+  }
+  sortTree(root)
+  return root
+}
+
+function sortTree(node: TreeNode): void {
+  node.children.sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+  for (const c of node.children) sortTree(c)
+}

--- a/packages/kobe/test/tui/filetree-flatten.test.ts
+++ b/packages/kobe/test/tui/filetree-flatten.test.ts
@@ -11,8 +11,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
-import type { TreeNode } from "../../src/tui/panes/filetree/git.ts"
 import { type Row, flattenTree, statusRows, truncatePathTail } from "../../src/tui/panes/filetree/rows.ts"
+import type { TreeNode } from "../../src/tui/panes/filetree/tree.ts"
 import { readWorktreeChanges } from "../../src/tui/panes/sidebar/worktree-changes.ts"
 
 describe("flattenTree", () => {

--- a/packages/kobe/test/tui/filetree-git.test.ts
+++ b/packages/kobe/test/tui/filetree-git.test.ts
@@ -28,7 +28,6 @@ vi.mock("../../src/worktree/content", async (importOriginal) => {
 
 import {
   attachUntrackedChildren,
-  buildTree,
   listFiles,
   parseNameStatus,
   parseNumstat,
@@ -37,6 +36,7 @@ import {
   statusFiles,
   statusFilesBranch,
 } from "../../src/tui/panes/filetree/git"
+import { buildTree } from "../../src/tui/panes/filetree/tree"
 import { readWorktreeFile, runWorktreeGit } from "../../src/worktree/content"
 
 const runGit = vi.mocked(runWorktreeGit)


### PR DESCRIPTION
Thermo-nuclear code-quality audit follow-up for `packages/kobe/src/tui/panes/filetree/git.ts`.

`filetree/git.ts` combined git wrappers with the path-to-tree hierarchy builder. The tree builder has no git dependency and is consumed by both the Solid file-tree pane (via `rows.ts`) and the React port (`FileTree.tsx`). Move `TreeNode`, `buildTree`, and `sortTree` into a dedicated framework-free module so `git.ts` can stay focused on git I/O.

Result:
- `filetree/git.ts`: 466 → 412 lines
- `filetree/tree.ts`: 60 lines

Checks run:
- `bun run lint`
- `cd packages/kobe \&\& bun run typecheck`
- `bun x vitest run test/tui/filetree-*.test.ts` (53 tests)
- `bun x vitest run test/tui test/tui-react` (1325 tests)
- `bun run test:render` (189 tests)