### PR TITLE
fix(web): route unset vendor defaults through vendor.ts

### DIFF
--- a/packages/kobe-web/src/components/ArchivedHistoryPeek.tsx
+++ b/packages/kobe-web/src/components/ArchivedHistoryPeek.tsx
@@ -13,6 +13,7 @@
  */
 
 import type { Task } from "../lib/types.ts"
+import { resolveVendor } from "../lib/vendor.ts"
 import { ChatTranscript } from "./ChatTranscript.tsx"
 import { SlideOver } from "./SlideOver.tsx"
 
@@ -44,7 +45,7 @@ export function ArchivedHistoryPeek({
       {task && (
         <ChatTranscript
           worktreePath={task.worktreePath ?? null}
-          vendor={task.vendor ?? "claude"}
+          vendor={resolveVendor(task.vendor)}
           title={task.title || task.branch}
         />
       )}

--- a/packages/kobe-web/src/components/BoardPeek.tsx
+++ b/packages/kobe-web/src/components/BoardPeek.tsx
@@ -19,6 +19,7 @@ import { lazy, Suspense, useEffect, useRef, useState } from "react"
 import { activityColor, activityLabel } from "../lib/activity.ts"
 import { ensureEngineTab } from "../lib/tabs.ts"
 import type { EngineState, Task } from "../lib/types.ts"
+import { resolveVendor } from "../lib/vendor.ts"
 import { useFocusTrap } from "../lib/use-focus-trap.ts"
 import { ChatTranscript } from "./ChatTranscript.tsx"
 
@@ -182,7 +183,7 @@ export function BoardPeek({
           ) : (
             <ChatTranscript
               worktreePath={task.worktreePath}
-              vendor={task.vendor ?? "claude"}
+              vendor={resolveVendor(task.vendor)}
               title={task.title || task.branch}
             />
           )}

--- a/packages/kobe-web/src/components/NewTaskDialog.tsx
+++ b/packages/kobe-web/src/components/NewTaskDialog.tsx
@@ -17,7 +17,7 @@ import { addTab, selectTask, setPendingPrompt } from "../lib/tabs.ts"
 import { pushToast, reportError } from "../lib/toast.ts"
 import type { Task } from "../lib/types.ts"
 import { useFocusTrap } from "../lib/use-focus-trap.ts"
-import { engineLabel } from "../lib/vendor.ts"
+import { DEFAULT_VENDOR, engineLabel } from "../lib/vendor.ts"
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -54,7 +54,7 @@ export function NewTaskDialog({ onClose }: { onClose: () => void }) {
   const [title, setTitle] = useState("")
   const [branch, setBranch] = useState("")
   const [baseRef, setBaseRef] = useState("")
-  const [vendor, setVendor] = useState<string>(engines[0]?.id ?? "claude")
+  const [vendor, setVendor] = useState<string>(engines[0]?.id ?? DEFAULT_VENDOR)
   const [vendorTouched, setVendorTouched] = useState(false)
   const [firstPrompt, setFirstPrompt] = useState("")
   const [busy, setBusy] = useState(false)

--- a/packages/kobe-web/src/components/SettingsSections.tsx
+++ b/packages/kobe-web/src/components/SettingsSections.tsx
@@ -11,6 +11,7 @@ import { setNotificationsEnabled, useNotifyState } from "../lib/notify.ts"
 import { fetchQuickPrompts, saveQuickPrompts } from "../lib/quick-prompts.ts"
 import { DEFAULT_PR_TEMPLATE, defaultReviewTemplate } from "../lib/review.ts"
 import type { WebSettings, WebSettingsEngine } from "../lib/settings.ts"
+import { DEFAULT_VENDOR } from "../lib/vendor.ts"
 import { resetLayout } from "../lib/tabs.ts"
 import { pushToast, reportError } from "../lib/toast.ts"
 import { Card, type PatchSettings, ToggleRow } from "./SettingsShared.tsx"
@@ -248,7 +249,7 @@ export function BoardSection() {
         <textarea
           value={review}
           onChange={(event) => setReview(event.target.value)}
-          placeholder={`default: ${defaultReviewTemplate("claude")}`}
+          placeholder={`default: ${defaultReviewTemplate(DEFAULT_VENDOR)}`}
           rows={3}
           disabled={!loaded}
           className="mt-1 w-full resize-y border border-line bg-bg p-2 font-mono text-[12px] text-fg placeholder:text-subtle focus:border-line-active focus:outline-none"

--- a/packages/kobe-web/src/components/ToolsPanel.tsx
+++ b/packages/kobe-web/src/components/ToolsPanel.tsx
@@ -18,6 +18,7 @@ import {
 } from "../lib/tabs.ts"
 import { pushToast, reportError } from "../lib/toast.ts"
 import type { Task } from "../lib/types.ts"
+import { resolveVendor } from "../lib/vendor.ts"
 import { ConfirmDialog } from "./ConfirmDialog.tsx"
 import { ChangesList } from "./DiffView.tsx"
 import { NotesPanel } from "./NotesPanel.tsx"
@@ -265,7 +266,7 @@ function TaskOverview({ task }: { task: Task | null }) {
             </div>
           </div>
         )}
-        <Field name="Vendor" value={task.vendor ?? "claude"} />
+        <Field name="Vendor" value={resolveVendor(task.vendor)} />
         <Field name="Worktree" value={task.worktreePath} mono />
         <Field name="Repo" value={task.repo} mono />
 
@@ -315,7 +316,7 @@ function TaskOverview({ task }: { task: Task | null }) {
                 }
                 disabled={busy !== null}
                 className={`border px-2 py-1 text-[11px] transition-colors disabled:opacity-40 ${
-                  (task.vendor ?? "claude") === engine.id
+                  resolveVendor(task.vendor) === engine.id
                     ? "border-primary bg-inset text-fg"
                     : "border-line bg-surface text-muted hover:border-primary hover:text-fg"
                 }`}

--- a/packages/kobe-web/src/components/WorkspaceTabs.tsx
+++ b/packages/kobe-web/src/components/WorkspaceTabs.tsx
@@ -21,6 +21,7 @@ import {
   type WorkspaceTab,
 } from "../lib/tabs.ts"
 import { closePtyTab } from "../lib/terminal.ts"
+import { resolveVendor } from "../lib/vendor.ts"
 import { ChatTranscript } from "./ChatTranscript.tsx"
 import { FilePreview } from "./DiffView.tsx"
 
@@ -40,7 +41,7 @@ function TerminalFallback() {
 }
 
 function vendorLabel(vendor: string | undefined): string {
-  return vendor ?? "claude"
+  return resolveVendor(vendor)
 }
 
 function EmptyTabChooser({

--- a/packages/kobe-web/test/engine-label.test.ts
+++ b/packages/kobe-web/test/engine-label.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { EngineOption } from "../src/lib/engines.ts"
-import { engineLabel } from "../src/lib/vendor.ts"
+import { DEFAULT_VENDOR, engineLabel, resolveVendor } from "../src/lib/vendor.ts"
 
 /**
  * engineLabel maps a vendor id to its display label across the New Task,
@@ -35,5 +35,16 @@ describe("engineLabel", () => {
 
   it("falls back to the id even with an empty list", () => {
     expect(engineLabel([], "codex")).toBe("codex")
+  })
+})
+
+describe("resolveVendor", () => {
+  it("returns the given id when present", () => {
+    expect(resolveVendor("codex")).toBe("codex")
+  })
+
+  it("defaults to the configured fallback vendor", () => {
+    expect(resolveVendor(undefined)).toBe(DEFAULT_VENDOR)
+    expect(DEFAULT_VENDOR).toBe("claude")
   })
 })


### PR DESCRIPTION
Scattered `?? "claude"` fallbacks in kobe-web components were bypassing the single `DEFAULT_VENDOR` constant in `lib/vendor.ts`. This PR centralizes them.

Changed:
- `BoardPeek`, `WorkspaceTabs`, `ToolsPanel`, `ArchivedHistoryPeek` now use `resolveVendor(task.vendor)`.
- `NewTaskDialog` initial vendor state uses `engines[0]?.id ?? DEFAULT_VENDOR`.
- `SettingsSections` review-template placeholder uses `defaultReviewTemplate(DEFAULT_VENDOR)`.

Tests:
- Expanded `test/engine-label.test.ts` with explicit `resolveVendor` / `DEFAULT_VENDOR` assertions.

Notes:
- kobe-web is a private package, so no changeset is included.
- This is a targeted fix; larger cross-package concerns (e.g. `TaskKind` mirrored in `kobe-web/src/lib/types.ts` and `kobe-daemon/src/daemon/protocol.ts`, or product-name strings like "rove" in `lib/issues.ts` / `WorktreesPage.tsx`) are left for future work rather than widening scope in the secondary web surface.

Local verification: `bun run lint` and `bun run test` in `packages/kobe-web` both pass.