### PR TITLE
engine: unify gated tool-hook verb constant

### DIFF
--- a/.changeset/engine-gated-tool-verbs.md
+++ b/.changeset/engine-gated-tool-verbs.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Unify the gated tool-hook verb set across engine adapters. Move the `tool-pre` / `tool-post` / `tool-failed` constant from `json-hook-adapter.ts` and `kimi-local/hook-adapter.ts` into a single `GATED_TOOL_VERBS` export in `json-hooks.ts`. No behavior change.

--- a/packages/kobe/src/engine/json-hook-adapter.ts
+++ b/packages/kobe/src/engine/json-hook-adapter.ts
@@ -17,7 +17,13 @@ import { dirname } from "node:path"
 import type { VendorId } from "../types/vendor.ts"
 import type { EngineHookAdapter, EngineSessionRef } from "./hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
-import { type HookEventSpec, isObject, mergeActivityHooks, mergeWorktreeWatchHook } from "./json-hooks.ts"
+import {
+  GATED_TOOL_VERBS,
+  type HookEventSpec,
+  isObject,
+  mergeActivityHooks,
+  mergeWorktreeWatchHook,
+} from "./json-hooks.ts"
 
 /** Read a JSON object from `path`. A missing file starts empty; any other read
  * or parse failure returns undefined so a best-effort install cannot clobber
@@ -95,7 +101,7 @@ export abstract class JsonHookAdapter implements EngineHookAdapter {
    *  hooks) — every tool call machine-wide spawns `kobe hook`, so the family
    *  stays out of the engine config until a plugin actually subscribes. */
   protected gatedVerbs(): ReadonlySet<string> {
-    return new Set(["tool-pre", "tool-post", "tool-failed"])
+    return GATED_TOOL_VERBS
   }
 
   async installActivityHooks(settingsFilePath: string, opts: { toolEvents?: boolean } = {}): Promise<void> {

--- a/packages/kobe/src/engine/json-hooks.ts
+++ b/packages/kobe/src/engine/json-hooks.ts
@@ -19,6 +19,11 @@ import { kobeHookInvocation } from "../cli/invocation.ts"
 import { quoteShellArgv } from "../lib/shell-command.ts"
 import type { EngineActivityKind } from "./hook-events.ts"
 
+/** Verbs installed only while a plugin subscribes to tool.* hooks (volume gate).
+ *  Defined once here so JSON-shaped and TOML-shaped adapters share the same
+ *  gated set and a future change cannot drift between them. */
+export const GATED_TOOL_VERBS: ReadonlySet<string> = new Set(["tool-pre", "tool-post", "tool-failed"])
+
 /** One engine hook event mapped to a normalized kobe verb. `matcher` narrows
  *  which sub-events fire (e.g. only permission notifications). */
 export interface HookEventSpec {

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -36,7 +36,7 @@ import { kobeHookInvocation } from "../../cli/invocation.ts"
 import { quoteShellArgv } from "../../lib/shell-command.ts"
 import type { EngineHookAdapter, EngineSessionRef } from "../hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
-import type { HookEventSpec } from "../json-hooks.ts"
+import { GATED_TOOL_VERBS, type HookEventSpec } from "../json-hooks.ts"
 
 /** Kimi hook event → normalized kobe verb. The ONE place Kimi event names live. */
 export const KIMI_HOOK_EVENT_MAP: readonly HookEventSpec[] = [
@@ -66,8 +66,6 @@ export const KOBE_KIMI_HOOK_EVENTS: readonly string[] = [...new Set(KIMI_HOOK_EV
 
 const BLOCK_BEGIN = "# >>> rove hooks"
 const BLOCK_END = "# <<< rove hooks"
-/** Verbs installed only while a plugin subscribes tool.* (volume gate). */
-const GATED_VERBS: ReadonlySet<string> = new Set(["tool-pre", "tool-post", "tool-failed"])
 /** Bound each hook spawn — `kobe hook` is sub-second; Kimi's default is 30s. */
 const HOOK_TIMEOUT_SECONDS = 10
 
@@ -85,7 +83,7 @@ export function renderKimiHookBlock(
 ): string {
   const lines: string[] = [BLOCK_BEGIN]
   for (const spec of KIMI_HOOK_EVENT_MAP) {
-    if (!opts.toolEvents && GATED_VERBS.has(spec.verb)) continue
+    if (!opts.toolEvents && GATED_TOOL_VERBS.has(spec.verb)) continue
     // JSON.stringify doubles as a TOML basic-string quoter (same trick as
     // codex-local/trust.ts).
     const command = quoteShellArgv([...inv, "hook", spec.verb, "--engine", "kimi"])


### PR DESCRIPTION
## What

Unifies the gated tool-hook verb constant across engine adapters.

- Adds `GATED_TOOL_VERBS` to `packages/kobe/src/engine/json-hooks.ts`.
- `json-hook-adapter.ts` now returns this set from `gatedVerbs()`.
- `kimi-local/hook-adapter.ts` imports and uses the same set.

## Why

The same `tool-pre` / `tool-post` / `tool-failed` set was defined independently in two places. A future gate change would have to be made twice and could drift between Claude/Codex (JSON hooks) and Kimi (TOML hooks).

## Scope / behavior

- Pure refactor, zero behavior change.
- Affected files:
  - `packages/kobe/src/engine/json-hooks.ts`
  - `packages/kobe/src/engine/json-hook-adapter.ts`
  - `packages/kobe/src/engine/kimi-local/hook-adapter.ts`

## Verification

- `bun run lint` green
- `cd packages/kobe && bun run typecheck` green
- `cd packages/kobe && bun x vitest run test/engine/kimi-hook-adapter.test.ts test/engine/hook-adapter.test.ts test/engine/codex-hook-adapter.test.ts test/engine/claude-hook-adapter.test.ts test/engine/hook-events.test.ts` green (57 tests)

## Changeset

`@sma1lboy/rove`: patch
