### PR TITLE
test: pin api help text to active CLI name

### DIFF
--- a/.changeset/api-cmd-help-active-cli-test.md
+++ b/.changeset/api-cmd-help-active-cli-test.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Harden `api-cmd` tests to catch a regression in `--help` CLI name resolution. Add assertions that `verbHelp()` renders `rove api` when `ROVE_INVOKED_AS=rove` and falls back to `kobe api` when the marker is absent.

--- a/packages/kobe/test/cli/api-cmd.test.ts
+++ b/packages/kobe/test/cli/api-cmd.test.ts
@@ -15,6 +15,18 @@ import {
   verbSchema,
 } from "../../src/cli/api-cmd.ts"
 
+function withEnv(name: string, value: string | undefined, fn: () => void): void {
+  const before = process.env[name]
+  try {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+    fn()
+  } finally {
+    if (before === undefined) delete process.env[name]
+    else process.env[name] = before
+  }
+}
+
 describe("parseFlags", () => {
   it("parses `--key value` pairs", () => {
     const { flags, pretty } = parseFlags(["--repo", "/x", "--prompt", "hello world"])
@@ -262,6 +274,21 @@ describe("API surface (full CRUD)", () => {
       expect(help).toContain(`kobe api ${v.name}`)
       for (const f of v.flags) expect(help).toContain(`--${f.name}`)
     }
+  })
+
+  it("uses the active CLI name (rove) when invoked through the rove wrapper", () => {
+    withEnv("ROVE_INVOKED_AS", "rove", () => {
+      const help = verbHelp(findVerb("add")!)
+      expect(help).toContain("rove api add")
+      expect(help).not.toContain("kobe api add")
+    })
+  })
+
+  it("falls back to kobe when no invocation marker is set", () => {
+    withEnv("ROVE_INVOKED_AS", undefined, () => {
+      const help = verbHelp(findVerb("add")!)
+      expect(help).toContain("kobe api add")
+    })
   })
 })
 


### PR DESCRIPTION
## What

Adds a regression test in `test/cli/api-cmd.test.ts` that verifies `verbHelp()` renders the active CLI name (`rove api ...`) when `ROVE_INVOKED_AS=rove`, and falls back to `kobe api ...` when the marker is absent.

## Why

The existing `verbHelp` test only asserted the default `kobe api <verb>` spelling. A regression where `verbHelp()` ignored `activeCliName()` and hardcoded `kobe` would pass that loop while breaking help text for users running via the `rove` wrapper.

## Scope / behavior

- Test-only change; no production behavior change.
- Introduces a small `withEnv` helper that restores the previous env value with `delete` (not `undefined`) to avoid Node worker env pollution.

## Verification

- `bun run lint` green
- `cd packages/kobe && bun run typecheck` green
- `cd packages/kobe && bun x vitest run test/cli/api-cmd.test.ts` green (31 tests)
- Mutant check: hardcoding `kobe api` in `src/cli/api/schema.ts` makes the new rove test fail; reverting fixes it.

## Changeset

`@sma1lboy/rove`: patch
