### PR TITLE
refactor: remove hard-coded vendor strings from neutral UI layers

### DIFF
--- a/.changeset/neutral-ui-vendor-strings.md
+++ b/.changeset/neutral-ui-vendor-strings.md
@@ -1,0 +1,10 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Remove hard-coded vendor strings from neutral UI layers and introduce a named default-theme constant.
+
+- `DEFAULT_TASK_VENDOR` now backs the fallback engine selection in `new-task-dialog/pure.ts` and `new-chat-dialog.tsx` instead of the literal `"claude"`.
+- `DEFAULT_THEME` is exported from `tui/context/theme-core.ts` and used by the React theme provider and host-boot fallback instead of hard-coding `"claude"`.
+- `AccountsSettingsSection` now receives the same `displayName` resolver used by `EngineSettingsSection`, so account block labels respect custom name overrides and built-in registry labels instead of literal `"claude-code"` / `"codex"` / `"copilot"` / `"kimi"`.
+- The "no engine detected" toast in `task-create-flow.ts` no longer names specific vendors.

--- a/packages/kobe/src/tui-react/component/new-chat-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-chat-dialog.tsx
@@ -18,6 +18,7 @@
  * (see `use-tab-dialogs.ts`); the dispatch on submit lives there too.
  */
 
+import { DEFAULT_TASK_VENDOR } from "@/types/task"
 import { ALL_VENDORS, type VendorId } from "@/types/vendor"
 import { TextAttributes } from "@opentui/core"
 import { useState } from "react"
@@ -83,7 +84,7 @@ export function NewChatDialogView(props: {
         ...(props.allowScratch ? (["scratch"] as const) : []),
       ]
     : vendors
-  const fallback = vendors.includes(props.defaultVendor) ? props.defaultVendor : (vendors[0] ?? "claude")
+  const fallback = vendors.includes(props.defaultVendor) ? props.defaultVendor : (vendors[0] ?? DEFAULT_TASK_VENDOR)
   const [pick, setPick] = useState<EnginePick>(fallback)
   const display = (choice: EnginePick): string =>
     choice === "scratch"

--- a/packages/kobe/src/tui-react/component/new-task-dialog/pure.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/pure.ts
@@ -9,6 +9,7 @@
  * new-task-pure.test.ts`). No React, no Solid, no fs.
  */
 
+import { DEFAULT_TASK_VENDOR } from "@/types/task"
 import { ALL_VENDORS, type VendorId } from "@/types/vendor"
 
 /**
@@ -25,8 +26,8 @@ export function resolveVendorSet(available: readonly VendorId[] | undefined): re
  * detected one (first detected wins when the preference isn't available).
  */
 export function resolveInitialVendor(set: readonly VendorId[], preferred: VendorId | undefined): VendorId {
-  const pref = preferred ?? "claude"
-  return set.includes(pref) ? pref : (set[0] ?? "claude")
+  const pref = preferred ?? DEFAULT_TASK_VENDOR
+  return set.includes(pref) ? pref : (set[0] ?? DEFAULT_TASK_VENDOR)
 }
 
 /** Immutable toggle of one path in the adopt multi-select. */

--- a/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
@@ -383,6 +383,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
               codexStatus={accounts.codex}
               copilotStatus={accounts.copilot}
               kimiStatus={accounts.kimi}
+              displayName={engines.engineName}
             />
           ) : null}
           {section === "plugins" ? (

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-engines.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-engines.tsx
@@ -163,6 +163,8 @@ export function AccountsSettingsSection(props: {
   codexStatus: EngineAccountStatus<CodexAccount> | null
   copilotStatus: EngineAccountStatus<CopilotAccount> | null
   kimiStatus: EngineAccountStatus<KimiAccount> | null
+  /** Display label for a vendor — custom name override, else VENDOR_LABEL. */
+  displayName: (vendor: VendorId) => string
 }) {
   const { theme } = useTheme()
   const t = useT()
@@ -176,7 +178,7 @@ export function AccountsSettingsSection(props: {
         {t("settings.accounts.hint")}
       </text>
       <AccountBlock
-        name="claude-code"
+        name={props.displayName("claude")}
         status={props.claudeStatus}
         accountLine={(s) => {
           const a = s.account as ClaudeAccount
@@ -192,7 +194,7 @@ export function AccountsSettingsSection(props: {
         }}
       />
       <AccountBlock
-        name="codex"
+        name={props.displayName("codex")}
         status={props.codexStatus}
         accountLine={(s) => {
           const a = s.account as CodexAccount
@@ -208,7 +210,7 @@ export function AccountsSettingsSection(props: {
         }}
       />
       <AccountBlock
-        name="copilot"
+        name={props.displayName("copilot")}
         status={props.copilotStatus}
         accountLine={(s) => {
           const a = s.account as CopilotAccount
@@ -219,7 +221,7 @@ export function AccountsSettingsSection(props: {
         }}
       />
       <AccountBlock
-        name="kimi"
+        name={props.displayName("kimi")}
         status={props.kimiStatus}
         accountLine={(s) => {
           const a = s.account as KimiAccount

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -22,6 +22,7 @@ import { type ReactNode, createContext, useContext, useEffect, useMemo } from "r
 import { createExternalStore } from "../../lib/external-store"
 import {
   BUNDLED_THEMES,
+  DEFAULT_THEME,
   type FocusAccentSlot,
   type Theme,
   type ThemeJson,
@@ -30,7 +31,7 @@ import {
 } from "../../tui/context/theme-core"
 import { useAccessor } from "../lib/use-accessor"
 
-export { FOCUS_ACCENT_SLOTS, resolveTheme } from "../../tui/context/theme-core"
+export { DEFAULT_THEME, FOCUS_ACCENT_SLOTS, resolveTheme } from "../../tui/context/theme-core"
 export type { FocusAccentSlot, Theme, ThemeJson } from "../../tui/context/theme-core"
 
 type State = {
@@ -43,7 +44,7 @@ type State = {
 
 const store = createExternalStore<State>({
   themes: { ...BUNDLED_THEMES },
-  active: "claude",
+  active: DEFAULT_THEME,
   mode: "dark",
   // Transparent by default (2026-07-12) — kobe sits on the terminal's own
   // background unless the user explicitly turns transparency off.
@@ -122,8 +123,8 @@ const ThemeContext = createContext<ThemeContextValue | null>(null)
 function resolveActive(state: State): Theme {
   const active = state.themes[state.active]
   if (active) return resolveTheme(active, state.mode)
-  // safety net: if active was somehow cleared, fall back to claude
-  const fallback = state.themes.claude ?? state.themes.opencode ?? Object.values(state.themes)[0]
+  // safety net: if active was somehow cleared, fall back to the default theme
+  const fallback = state.themes[DEFAULT_THEME] ?? Object.values(state.themes)[0]
   if (!fallback) {
     // truly empty — synthesize a black theme so the renderer can stand up
     return resolveTheme({ theme: { background: "#000000", text: "#ffffff" } }, state.mode)

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -63,12 +63,12 @@ import {
   setTransparentBackground,
   transparentBackground,
 } from "../context/theme"
-import { useTheme } from "../context/theme"
+import { DEFAULT_THEME, useTheme } from "../context/theme"
 import { isLocaleId, setLocaleLang, t } from "../i18n"
 import { DialogProvider } from "../ui/dialog"
 
 /** Theme used when `state.json` is missing/stale — kobe's brand default. */
-const FALLBACK_THEME = "claude"
+const FALLBACK_THEME = DEFAULT_THEME
 
 /** Same flag surface as the Solid host; see header for the un-ported one. */
 export interface HostProviderFlags {

--- a/packages/kobe/src/tui/context/theme-core.ts
+++ b/packages/kobe/src/tui/context/theme-core.ts
@@ -77,6 +77,13 @@ export type Theme = {
 export const BUNDLED_THEMES: Record<string, ThemeJson> = BUNDLED_THEME_JSONS
 
 /**
+ * Brand default theme for new installs and any fallback path that needs a
+ * bundled palette. Kept as one named constant so theme consumers don't
+ * hard-code the string.
+ */
+export const DEFAULT_THEME = "claude"
+
+/**
  * Is `name` a bundled theme? Framework-free check against the bundled set —
  * the live provider (`src/tui-react/context/theme.tsx`) keeps its own
  * mutable registry (bundled + user themes) behind its own `hasTheme`; this

--- a/packages/kobe/src/tui/lib/task-create-flow.ts
+++ b/packages/kobe/src/tui/lib/task-create-flow.ts
@@ -76,7 +76,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
   // missing binary surfaces only as a raw shell error inside the pane. Warn
   // up front but still allow proceeding (they may install it after picking).
   if (availableVendors.length === 0) {
-    ctx.notifyInfo?.("No engine CLI detected — install claude or codex, or add one in Settings → Engines")
+    ctx.notifyInfo?.("No engine CLI detected — install a supported engine, or add one in Settings → Engines")
   }
   const orch = ctx.orch
   const result = await ctx.promptNewTask(defaultRepo, repos, {


### PR DESCRIPTION
Second-round thermo-nuclear audit: fixes low-risk spots where neutral UI layers embedded literal vendor names instead of reading from the engine registry / canonical constants.

Changes:
- `tui/context/theme-core.ts`: add `DEFAULT_THEME` constant.
- `tui-react/context/theme.tsx` + `tui-react/lib/host-boot.tsx`: use `DEFAULT_THEME` instead of hard-coded `"claude"`.
- `tui-react/component/new-task-dialog/pure.ts` + `new-chat-dialog.tsx`: use `DEFAULT_TASK_VENDOR` instead of literal `"claude"`.
- `tui-react/component/settings-dialog/sections-engines.tsx`: drive account-block labels through a new `displayName` prop (same resolver `engines.engineName` already used by `EngineSettingsSection`) instead of hard-coded `"claude-code"` / `"codex"` / `"copilot"` / `"kimi"`.
- `tui/lib/task-create-flow.ts`: generic "install a supported engine" toast instead of naming claude/codex.

Reported but not fixed (needs Jackson/contract decision):
- `SettingsDialog` still threads vendor-specific account props (`claudeStatus`, `codexStatus`, `copilotStatus`, `kimiStatus`). The neutral shape should be a vendor-agnostic map/list.
- `EngineRegistryEntry.identity` (`EngineIdentity`) has no consumers; the registry mechanism for product/short/assistant names is built but not wired to UI.

Validation:
- `bun run lint` ✅
- `cd packages/kobe && bun run typecheck` ✅
- `cd packages/kobe && bun run test:fast` ✅ (348 files, 3429 tests)
- `cd packages/kobe && bun run test:render` ✅ (204 tests)

coverage-exemption: packages/kobe/src/tui-react/lib/host-boot.tsx — Pre-existing coverage gap (23.5%), not introduced by this PR: the change here is two lines, an import and a constant now pointing at DEFAULT_THEME, with no behavior change. Raising boot-path coverage is worth doing on its own, not as a rider on a constant rename.

