### PR TITLE
docs: add the Coverage gate section that CI already points at

### DIFF
--- a/.changeset/coverage-gate-docs.md
+++ b/.changeset/coverage-gate-docs.md
@@ -1,0 +1,5 @@
+---
+---
+
+Docs only: add the "Coverage gate" section that `scripts/coverage-gate.mjs` and the CI
+error message already point at.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -294,6 +294,48 @@ for post-failure inspection and never points at production state.
 - daemon/orchestrator/engine edits are verified after replacing stale daemon
   processes in the chosen sandbox.
 
+## Coverage gate
+
+`coverage-cap` (vitest lcov) and `render-track` (bun-test render lcov) hold every
+file a PR touches to a 50% line floor. Only touched files are gated, so a legacy
+file with thin coverage stays green until someone edits it.
+
+### The escape hatch, and when it is honest
+
+A `coverage-exemption: <path> — <reason>` line in the PR body waives one file.
+It is a paper trail, not a mute button: the next person reads it as "someone
+evaluated this and concluded the floor does not apply". Three situations come up,
+and only two of them justify one.
+
+- **Structurally untestable** — the render track cannot mount it at all.
+  `tui-react/workspace/host.tsx` and `workspace/TerminalTabs.tsx` are integration
+  layers needing a live daemon + PTY; their behaviour is covered by the behavior
+  track and the visual-ground-truth harness instead. Exemption is correct, and the
+  reason should name the covering track.
+- **Genuinely untested** — the file is ordinary code that vitest reaches fine, and
+  the number is low because nobody wrote the test. **Write the test.** An exemption
+  here turns the gate into a rubber stamp. (Two CLI modules sat at 28% and 41% and
+  went to 100% once someone actually tested them.)
+- **Pre-existing gap, unrelated change** — the file is partly testable, its gap
+  predates the PR, and the diff is something like a constant rename. Exemption is
+  reasonable, but say *that*: "pre-existing gap, not introduced by this PR". Do not
+  dress it up as untestable — the coverage number itself contradicts you.
+
+### Editing the PR body does not re-run CI
+
+The gate reads the body **during a workflow run**, so an exemption added after the
+failing run is invisible until a new run starts:
+
+```bash
+gh pr edit <n> --body-file <file>          # 1. add the exemption
+git commit --allow-empty -m "chore: re-trigger CI"   # 2. THEN force a fresh run
+git push
+```
+
+`gh run rerun` does **not** work here — it replays the frozen event payload, which
+carries the body as it was before the edit. Three PRs hit this in one night; each
+had a correct exemption sitting in the body that no run ever read.
+
 ## Required pre-PR command
 
 ```bash


### PR DESCRIPTION
`scripts/coverage-gate.mjs:48` and the gate's own failure message both tell you to read a section that isn't there:

```
See docs/HARNESS.md 'Coverage gate'
```

`docs/HARNESS.md` has eight headings. None of them is "Coverage gate".

## Why it's worth fixing now

Three PRs in tonight's sweep hit the same wall — #518, #541, #543. Each one added a **correctly worded** exemption to the PR body and stopped, because nothing says the gate reads the body *during a workflow run*. The exemption then sat in a body that no run ever read, and the PR stayed red for reasons its author had already addressed.

What makes it a good candidate for documentation rather than a one-off correction: every individual step in those PRs was right. Correct wording, correct placement, correct ordering (body first). The missing piece was a premise — "a body edit needs a fresh run to take effect" — that appears in no file.

## What the section says

- **The escape hatch and when it's honest.** Three situations reach for an exemption and only two justify one: structurally untestable (`host.tsx`, `TerminalTabs.tsx` — integration layers the render track can't mount); genuinely untested (**write the test** — two CLI modules went 28%/41% → 100% once someone did); and a pre-existing gap under an unrelated diff (fine, but say *that* — the coverage number contradicts any claim of untestability).
- **Editing the PR body does not re-run CI.** The edit-then-empty-commit sequence, and why `gh run rerun` can't substitute for it (it replays the frozen event payload, which carries the pre-edit body).

Docs only, empty changeset.