### PR TITLE
test: harden daemon.status wire-shape assertions

### DIFF
--- a/.changeset/daemon-status-test-hardening.md
+++ b/.changeset/daemon-status-test-hardening.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Harden the `daemon.status` wire-shape test. Replace weak `typeof` checks on `uptimeMs` and `kobeVersion` with concrete assertions: `uptimeMs` must be non-negative and `kobeVersion` must equal the runtime's current version.

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -3,6 +3,7 @@ import { PromptBroker } from "@sma1lboy/kobe-daemon/daemon/prompt-broker"
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { createDaemonHandlerRegistry } from "@sma1lboy/kobe-daemon/daemon/server"
 import { describe, expect, it } from "vitest"
+import { CURRENT_VERSION } from "../../src/version.ts"
 import { TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
 
 /**
@@ -333,8 +334,8 @@ describe("daemon handler registry", () => {
       expect(status.taskCount).toBe(1)
       expect(status.socketPath).toBe("/tmp/fake/daemon.sock")
       expect(status.startedAt).toBe("2026-06-01T00:00:00.000Z")
-      expect(typeof status.uptimeMs).toBe("number")
-      expect(typeof status.kobeVersion).toBe("string")
+      expect(status.uptimeMs).toBeGreaterThanOrEqual(0)
+      expect(status.kobeVersion).toBe(CURRENT_VERSION)
     })
 
     it("daemon.stop drives stopSoon and returns the empty object", async () => {


### PR DESCRIPTION
## What

Replaces weak `typeof` assertions in `test/daemon/handlers.test.ts` for `daemon.status` with concrete value checks:

- `uptimeMs` must be `>= 0`
- `kobeVersion` must equal `CURRENT_VERSION`

## Why

`typeof uptimeMs === "number"` and `typeof kobeVersion === "string"` executed the code but accepted clearly wrong values (e.g. `-1` or `"nope"`). The status response is part of the daemon/client wire contract and is consumed by `kobe doctor` / stale-build detection, so the values matter.

## Scope / behavior

- Test-only change; no production behavior change.
- Adds an import of `CURRENT_VERSION` from `src/version.ts`.

## Verification

- `bun run lint` green
- `cd packages/kobe && bun run typecheck` green
- `KOBE_INCLUDE_SOCKET=1 bun x vitest run test/daemon/handlers.test.ts` green (25 tests)
- Mutant check: returning `uptimeMs: -1` / `kobeVersion: "nope"` from the handler now fails; the old `typeof` assertions stayed green.

## Changeset

`@sma1lboy/rove`: patch
