### PR TITLE
refactor(tui): remove outdated tmux/Solid/KV workarounds

### DIFF
--- a/.changeset/tui-second-round-workarounds.md
+++ b/.changeset/tui-second-round-workarounds.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Remove outdated workaround constraints in `tui/` and `tui-react/`.
+
+- `tui/ops/activity-monitor.ts`: drop the dead `@kobe_tab_state` tmux window-option constant and update IO docs; turn state now feeds React consumers, not tmux.
+- `tui/lib/keymap-overrides-parse.ts`: remove the `allowShiftCharacter` normalization option that only existed for the deleted tmux-layer resolver, and delete the unused `chordOptsFor` override hook.
+- `tui-react/context/notifications.tsx`: read sound/toast toggles from the ported React KV provider when one is present, falling back to the mount-time `state.json` snapshot only in test/mock hosts that intentionally omit `KVProvider`.

--- a/packages/kobe/src/tui-react/context/notifications.tsx
+++ b/packages/kobe/src/tui-react/context/notifications.tsx
@@ -1,19 +1,15 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Per-ChatTab completion notifications (React port of
- * `src/tui/context/notifications.tsx`, issue #15 G3). Same three signals
- * (audible cue, transient toast, unread tab mark) and the same gating —
- * the pure state transforms + the "error toasts always show" invariant
- * live in the shared `src/tui/lib/notify-state.ts` consumed by both
- * runtimes; see the Solid header for the full rationale.
+ * Per-ChatTab completion notifications (React port of the Solid
+ * NotificationsProvider, issue #15 G3). Same three signals (audible cue,
+ * transient toast, unread tab mark) and the same gating — the pure state
+ * transforms + the "error toasts always show" invariant live in the
+ * shared `src/tui/lib/notify-state.ts` consumed by both runtimes.
  *
- * Deliberate delta: the Solid provider reads the sound/toast toggles from
- * the live KVProvider. The React KV context isn't ported yet (issue #15
- * G3, settings slice), so this provider reads a one-shot `state.json`
- * snapshot at mount — the same snapshot-only semantics KV documents
- * (another process's writes need a restart to be seen), and no React pane
- * host has an in-process settings surface that could flip the toggles
- * live yet.
+ * The React KV provider is now ported, so sound/toast toggles are read
+ * from it when a KVProvider is present. Render tests and the mock dialogs
+ * host intentionally run without KV, so we fall back to a one-time
+ * `state.json` snapshot in that case.
  */
 
 import { type ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
@@ -29,6 +25,7 @@ import {
   shouldShowToast,
 } from "../../tui/lib/notify-state"
 import { pulse as pulseSound } from "../../tui/lib/sound"
+import { useOptionalKV } from "./kv"
 
 export type { NotificationKind, Toast, NotifyInput } from "../../tui/lib/notify-state"
 
@@ -45,8 +42,19 @@ const ctx = createContext<NotificationsContext | null>(null)
 export function NotificationsProvider(props: { children?: ReactNode }) {
   const [toasts, setToasts] = useState<readonly Toast[]>([])
   const [unread, setUnread] = useState<ReadonlyMap<string, NotificationKind>>(new Map())
-  // ponytail: one-shot toggle snapshot; swap to the React KV context when it lands.
-  const prefs = useMemo(() => loadStateFile(), [])
+  // Read toggles from KV when available; otherwise fall back to the mount-time
+  // snapshot (render tests / mock hosts intentionally omit KVProvider).
+  const kv = useOptionalKV()
+  const snapshot = useMemo(() => loadStateFile(), [])
+  const prefs = useMemo(
+    () => ({
+      "notifications.sound.enabled":
+        (kv?.get("notifications.sound.enabled") as boolean | undefined) ?? snapshot["notifications.sound.enabled"],
+      "notifications.toast.enabled":
+        (kv?.get("notifications.toast.enabled") as boolean | undefined) ?? snapshot["notifications.toast.enabled"],
+    }),
+    [kv, snapshot],
+  )
   const counter = useRef(0)
 
   // Toast auto-dismiss timers are provider-scoped: any still-pending timer

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -34,7 +34,7 @@ import { isNarrowWidth } from "../lib/narrow-mode"
 
 export { tabTitle }
 
-/** Same glyph vocabulary as tmux's `CHAT_TAB_STATUS_FORMAT` (`@kobe_tab_state`). */
+/** Turn-state glyphs mirrored on the tab strip. */
 export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
   running: "●",
   done: "✓",

--- a/packages/kobe/src/tui/lib/keymap-overrides-parse.ts
+++ b/packages/kobe/src/tui/lib/keymap-overrides-parse.ts
@@ -107,21 +107,11 @@ const MOD_ORDER: ReadonlyArray<"ctrl" | "cmd" | "alt" | "shift"> = ["ctrl", "cmd
 
 export type ChordResult = { chord: string; warning?: string } | { error: string }
 
-export type NormalizeChordOpts = {
-  /**
-   * Permit `shift+<single char>` chords. The opentui keymap layer can
-   * never match them (terminals deliver shift+letter as a plain
-   * character), but tmux CAN bind `C-S-T` on extended-keys terminals —
-   * the tmux-layer resolver opts in; everything else keeps the rejection.
-   */
-  allowShiftCharacter?: boolean
-}
-
 /**
  * Normalize one user-written chord into the exact candidate string
  * `matchKey()` mints, or explain why it can't work.
  */
-export function normalizeChord(raw: string, opts?: NormalizeChordOpts): ChordResult {
+export function normalizeChord(raw: string): ChordResult {
   // A BARE single uppercase letter is sugar for the shift+ form ("P" →
   // shift+p) — checked on the raw string BEFORE the lowercase pass erases
   // the case information. Only the modifier-less spelling gets the sugar:
@@ -162,8 +152,8 @@ export function normalizeChord(raw: string, opts?: NormalizeChordOpts): ChordRes
   // uppercase keypress), but shift COMBINED with other modifiers on a
   // single char cannot: legacy terminals send ctrl+shift+z and ctrl+z as
   // the same C0 byte, so such a chord would only fire on kitty-protocol
-  // terminals. The tmux-layer resolver opts in via allowShiftCharacter.
-  if (mods.has("shift") && mods.size > 1 && key.length === 1 && !opts?.allowShiftCharacter) {
+  // terminals.
+  if (mods.has("shift") && mods.size > 1 && key.length === 1) {
     return {
       error: `"${raw}": shift with other modifiers on a single character can never match — legacy terminals send the same byte with and without shift`,
     }
@@ -197,21 +187,12 @@ function extractBindingsMap(section: unknown): Record<string, unknown> | null {
   return section
 }
 
-export type ExtractOverridesOpts = {
-  /** Per-id chord-normalization options for specialized consumers. */
-  chordOptsFor?: (id: string) => NormalizeChordOpts
-}
-
 /**
  * Turn a parsed YAML document into a flat override list for `platform`.
  * Never throws; malformed pieces degrade to warnings. Each warning string
  * is prefixed `"<id>: "` when it concerns a specific binding.
  */
-export function extractKeybindingOverrides(
-  doc: unknown,
-  platform: string,
-  opts?: ExtractOverridesOpts,
-): ExtractedKeybindingOverrides {
+export function extractKeybindingOverrides(doc: unknown, platform: string): ExtractedKeybindingOverrides {
   const warnings: string[] = []
   if (doc === null || doc === undefined) return { entries: [], prefixEntries: [], warnings }
   if (!isRecord(doc)) {
@@ -268,7 +249,7 @@ export function extractKeybindingOverrides(
             anyError = true
             continue
           }
-          const result = normalizeChord(rawChord, opts?.chordOptsFor?.(id))
+          const result = normalizeChord(rawChord)
           if ("error" in result) {
             warnings.push(`${id}: ${result.error}`)
             anyError = true

--- a/packages/kobe/src/tui/lib/keymap-overrides.ts
+++ b/packages/kobe/src/tui/lib/keymap-overrides.ts
@@ -18,9 +18,7 @@ import type { KeymapOverrideEntry } from "./keymap-overrides-parse"
 export {
   type ChordResult,
   type ExtractedKeybindingOverrides,
-  type ExtractOverridesOpts,
   type KeymapOverrideEntry,
-  type NormalizeChordOpts,
   extractKeybindingOverrides,
   normalizeChord,
 } from "./keymap-overrides-parse"

--- a/packages/kobe/src/tui/ops/activity-monitor.ts
+++ b/packages/kobe/src/tui/ops/activity-monitor.ts
@@ -1,11 +1,11 @@
 /**
  * Framework-free poll loop for the Ops pane — the per-window turn-status
- * (capture-pane quiescence) poll, extracted from `tui/ops/host.tsx` so the
- * hosts run the SAME loop body verbatim. Only types are imported (erased at
- * runtime); all IO — tmux capture-pane / window-option writes, the attach
- * gate — is injected (`tui/ops/host-io.ts` builds the real set), which is
- * also what makes the loop unit-testable under vitest with fakes. Cadence
- * math stays in `./activity-poll`.
+ * (capture-pane quiescence) poll, extracted from the Solid host so the React
+ * port runs the SAME loop body verbatim. Only types are imported (erased at
+ * runtime); all IO — PTY capture and the attach gate — is injected by the
+ * React consumer (`tui-react/workspace/use-turn-polls.ts`), which is also
+ * what makes the loop unit-testable under vitest with fakes. Cadence math
+ * stays in `./activity-poll`.
  */
 
 import { createHash } from "node:crypto"
@@ -16,8 +16,6 @@ import { TURN_STATUS_POLL_MS, nextTurnStatusPollDelay } from "./activity-poll"
 
 /** Consecutive unchanged capture-pane reads before a completion marker counts as "done". */
 export const STABLE_POLLS_FOR_DONE = 2
-/** tmux window option the ChatTab turn chip reads. */
-export const CHAT_TAB_STATE_OPTION = "@kobe_tab_state"
 
 export function fingerprint(text: string): string {
   return createHash("sha1").update(text).digest("hex")
@@ -33,9 +31,9 @@ export interface TurnDetectorLike {
 
 export interface TurnStatusIo {
   readonly sessionAttached: () => Promise<boolean>
-  /** `tmux capture-pane` of the paired engine pane (quiescence source). */
+  /** Capture the paired engine pane (quiescence source). */
   readonly capturePane: () => Promise<string>
-  /** Write the ChatTab turn chip ({@link CHAT_TAB_STATE_OPTION}). */
+  /** Publish the current turn state for downstream consumers (toast, unread dot). */
   readonly setTurnState: (state: ChatTabTurnState) => Promise<void>
 }
 


### PR DESCRIPTION
Second-round thermo-nuclear audit focus: outdated workaround constraints now that Solid/tmux are gone and React KV is ported.

Changes:
- `tui/ops/activity-monitor.ts`: remove the dead `@kobe_tab_state` tmux window-option constant and clarify that turn-state IO feeds React consumers, not tmux.
- `tui/lib/keymap-overrides-parse.ts`: delete the `allowShiftCharacter` normalization option and the `chordOptsFor` override hook — both only existed for the deleted tmux-layer resolver.
- `tui-react/context/notifications.tsx`: read sound/toast toggles from the ported React KV provider when one is present; fall back to the mount-time `state.json` snapshot only in test/mock hosts that intentionally omit `KVProvider`.

Verification:
- `bun run lint` ✅
- `cd packages/kobe && bun run typecheck` ✅
- `vitest run test/tui-react/ops-activity-monitor.test.ts test/tui-react/notify-state.test.ts test/tui/keymap-overrides.test.ts test/tui/keymap-reload.test.ts test/tui/keymap-slot-parity.test.ts` ✅
