### PR TITLE
refactor(daemon): remove deprecated pollMs fallback and report contract findings

### DIFF
--- a/.changeset/remove-ui-prefs-poll-fallback.md
+++ b/.changeset/remove-ui-prefs-poll-fallback.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+refactor(daemon): remove the deprecated `pollMs` fallback from ui-prefs and file-watch-trigger
+
+- `file-watch-trigger.ts` no longer accepts the ignored `pollMs` option (chokidar's directory watch + startup signature catch-up replaced the bespoke poll safety-net).
+- `ui-prefs-watcher.ts` drops its `pollMs` option and `DEFAULT_UI_PREFS_POLL_MS`; the watcher now relies on the directory watch, matching the actual implementation.
+- No behavior change: the poll path was already a no-op.

--- a/packages/kobe-daemon/src/daemon/file-watch-trigger.ts
+++ b/packages/kobe-daemon/src/daemon/file-watch-trigger.ts
@@ -23,12 +23,6 @@ export interface FileWatchTriggerOptions {
   readonly matchBasenames?: readonly string[]
   /** Debounce between a matching fs event and `onTrigger`. `<= 0` disables. */
   readonly debounceMs: number
-  /**
-   * @deprecated Retained for caller/source compatibility only. chokidar's
-   * cross-platform watcher replaces the old bespoke poll safety-net, so this
-   * field is now ignored.
-   */
-  readonly pollMs?: number
   /** Called after a debounced matching event. */
   readonly onTrigger: () => void
   /** Best-effort error sink; trigger and watcher errors are never thrown. */

--- a/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
+++ b/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
@@ -17,10 +17,10 @@
  *     tmp + rename, which swaps the file's inode — an `fs.watch` on the
  *     file itself goes dead after the first atomic write. Watching the
  *     parent dir and filtering on the filename survives every rename.
- *   - **Poll as a safety net.** Bun/macOS can miss that tmp+rename edge in
- *     a long-lived daemon even when the directory watch is alive. The state
- *     file is tiny and publishes are changed-only, so a low-frequency poll
- *     turns the live theme path from best-effort into reliable fan-out.
+ *   - **No recurring poll.** `file-watch-trigger.ts` uses chokidar and a
+ *     startup-signature reconciliation catch-up; the old poll safety-net
+ *     has been removed because it masked watcher-health issues and added
+ *     unnecessary disk churn.
  *   - **Debounce.** A write burst (KVProvider flush + a `setPersisted*`
  *     call) collapses into one read ~{@link DEFAULT_UI_PREFS_DEBOUNCE_MS}
  *     later.
@@ -48,9 +48,6 @@ import type { UiPrefsPayload } from "./protocol.ts"
 
 /** Default debounce between a state-file event and the read+publish. */
 export const DEFAULT_UI_PREFS_DEBOUNCE_MS = 200
-
-/** Safety-net poll cadence for missed fs.watch events. */
-export const DEFAULT_UI_PREFS_POLL_MS = 250
 
 /**
  * Focus-accent slots the TUI understands — mirror of `FOCUS_ACCENT_SLOTS`
@@ -134,24 +131,16 @@ export interface UiPrefsWatcherOptions {
    * same disable convention as the server's other pollers.
    */
   readonly debounceMs?: number
-  /**
-   * Poll fallback cadence in ms. `<= 0` disables only the fallback poll;
-   * the directory watcher still runs. Defaults to
-   * {@link DEFAULT_UI_PREFS_POLL_MS}.
-   */
-  readonly pollMs?: number
 }
 
 /**
  * Start the watcher: publish the current prefs immediately (replay seed),
- * then re-read + publish-on-change after every debounced state-file event
- * and on a small polling fallback. Returns a `stop()` that closes the fs
- * watcher and clears pending timers.
+ * then re-read + publish-on-change after every debounced state-file event.
+ * Returns a `stop()` that closes the fs watcher and clears pending timers.
  */
 export function startUiPrefsWatcher(bus: DaemonEventBus, options: UiPrefsWatcherOptions = {}): () => void {
   const debounceMs = options.debounceMs ?? DEFAULT_UI_PREFS_DEBOUNCE_MS
   if (debounceMs <= 0) return () => {}
-  const pollMs = options.pollMs ?? DEFAULT_UI_PREFS_POLL_MS
   const statePath = options.statePath ?? defaultUiPrefsStatePath()
   const stateFile = basename(statePath)
 
@@ -170,12 +159,11 @@ export function startUiPrefsWatcher(bus: DaemonEventBus, options: UiPrefsWatcher
   }
   // No watcher → panes keep the boot-time prefs they read themselves (the
   // documented degraded mode). The initial publish above still serves the
-  // at-start value to subscribers; the poll fallback continues when enabled.
+  // at-start value to subscribers.
   return startFileWatchTrigger({
     filePath: statePath,
     matchBasenames: [stateFile],
     debounceMs,
-    pollMs,
     onTrigger: publishIfChanged,
     onError: (err) => logDaemonError("ui-prefs-watcher", err),
   })


### PR DESCRIPTION
Second-pass contract/transition audit for `orchestrator/` + `kobe-daemon/`.

## Code change (low-risk)
- Removed the deprecated `pollMs` option from `file-watch-trigger.ts` and `ui-prefs-watcher.ts`.
- The option was already a no-op: `file-watch-trigger.ts` replaced its bespoke poll safety-net with chokidar + startup signature reconciliation, so `ui-prefs-watcher.ts` was advertising and passing a fallback that never ran.
- No behavior change; `DEFAULT_UI_PREFS_POLL_MS` is also removed.

## Verified
- `bun run lint` ✅
- `cd packages/kobe && bun run typecheck` ✅
- `cd packages/kobe-daemon && bun run typecheck` ✅
- `KOBE_INCLUDE_SOCKET=1 bun x vitest run test/daemon/ui-prefs-watcher.test.ts test/daemon/file-watch-trigger.test.ts --pool forks` — 2 files / 18 tests passed ✅

## Unexecuted / stale contracts found — reported, not changed
- **`packages/kobe-daemon/src/daemon/server-types.ts`**: 2-line transitional re-export (`DaemonServer`, `DaemonServerOptions`), 0 consumers. Already flagged in #552; still needs a human decision.
- **`packages/kobe-daemon/src/daemon/cwd-task.ts` — `matchRepoByCwd`**: exported but only used in tests; production path uses `matchTaskByCwd` / `matchTaskByWorktreePath`. Removing it is a public export change, so reported for decision.
- **`packages/kobe-daemon/src/daemon/web-rpc-allowlist.ts` — `WEB_RPC_ALLOWLIST`**: exported and only used in tests; production uses `WEB_RPC_ALLOWSET`. Could be folded into the set-based contract, but that's a public export change.
- **`FileWatchTriggerOptions.pollMs` / `UiPrefsWatcherOptions.pollMs`**: this PR removes the already-ignored wiring. If any external caller still passes `pollMs`, it is now a type error rather than silently ignored.

## Transitional markers checked and left alone
- `handlers-agent-turns.ts` "Socket-only for now" — web dashboard still does not read turns; still accurate.
- `orchestrator/land.ts` "by hand for now (auto-repair-via-engine is v2)" — v2 not landed; still accurate.
- `keep in sync` notes in `ui-prefs-watcher.ts` and `keybindings-watcher.ts` — describe real duplicated constants across package boundaries; still valid.
- Legacy compatibility paths (`cwd-task` legacy roots, `store-codec` legacy path, `protocol.ts` legacy alias, `attention-inbox` `unread` wire field) still serve existing data/users.
