### PR TITLE
engine: clean up stale tmux/Solid/ChatTab comment references

### DIFF
--- a/.changeset/engine-stale-comment-cleanup.md
+++ b/.changeset/engine-stale-comment-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Clean up stale architecture references in `packages/kobe/src/engine/` comments. Replaces mentions of the removed tmux/Solid stack and retired `new-chattab` / `ChatTab` vocabulary with the current hosted-PTY / React / Terminal Tab framing. No behavior changes.

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -153,7 +153,7 @@ export async function listSessionFilesForWorktree(worktree: string): Promise<Wor
  * Newest transcript mtime (epoch ms) for `worktree`, or 0 when the task
  * was never entered / has no session files. The Ops pane polls this to
  * detect "the agent produced new conversation output" without parsing
- * the tmux pane. `listSessionFilesForWorktree` already sorts
+ * the PTY screen. `listSessionFilesForWorktree` already sorts
  * newest-first, so `[0]` is the most recent activity.
  */
 export async function latestTranscriptMtimeForWorktree(worktree: string): Promise<number> {

--- a/packages/kobe/src/engine/codex-local/history.ts
+++ b/packages/kobe/src/engine/codex-local/history.ts
@@ -279,7 +279,7 @@ export async function findLatestRolloutForWorktree(
 /**
  * Newest rollout mtime (epoch ms) for `worktree`, or 0 when none match.
  * The Ops pane polls this to detect new Codex conversation output
- * without parsing the tmux pane. Thin wrapper over
+ * without parsing the PTY screen. Thin wrapper over
  * {@link findLatestRolloutForWorktree}.
  */
 export async function latestTranscriptMtimeForWorktree(

--- a/packages/kobe/src/engine/copilot-local/history.ts
+++ b/packages/kobe/src/engine/copilot-local/history.ts
@@ -73,8 +73,8 @@ export async function listSessionIdsForWorktree(
 /**
  * Newest `events.jsonl` mtime (epoch ms) across the Copilot sessions
  * rooted at `worktree`, or 0 when none match. The Ops pane polls this to
- * detect new Copilot conversation output without parsing the tmux pane
- *. Each session is a dir with a `workspace.yaml` (for the cwd
+ * detect new Copilot conversation output without parsing the PTY screen.
+ * Each session is a dir with a `workspace.yaml` (for the cwd
  * match) and a growing `events.jsonl` (the transcript we stat).
  */
 export async function latestTranscriptMtimeForWorktree(

--- a/packages/kobe/src/engine/copilot-local/usage.ts
+++ b/packages/kobe/src/engine/copilot-local/usage.ts
@@ -6,7 +6,7 @@
  * This collapses that into the neutral {@link EngineUsageSnapshot} the
  * history reader returns, the same way `codex-local/usage.ts` does for
  * Codex. Extracted from the v0.5 Copilot stream adapter that v0.6
- * dropped — the live engine runs in tmux now; we only read its history.
+ * dropped — the live engine runs in a hosted PTY; we only read its history.
  */
 
 import type { EngineUsageSnapshot } from "@/types/engine"

--- a/packages/kobe/src/engine/history-cache.ts
+++ b/packages/kobe/src/engine/history-cache.ts
@@ -4,9 +4,9 @@
  *
  * Why it exists: the history pane polls transcript mtime and re-reads the
  * file every ~2.5s. A full re-parse builds a completely fresh `Message[]`
- * with new object identities each call — Solid's `<For>` keys rows by
- * reference, so all-new identities destroy + recreate every rendered row's
- * native subtree per poll, and the re-parse itself is O(n²) allocation over
+ * with new object identities each call — React keys rows by reference, so
+ * all-new identities destroy + recreate every rendered row's DOM subtree
+ * per poll, and the re-parse itself is O(n²) allocation over
  * a session's lifetime. Transcripts are append-only in the common case, so
  * we cache the parsed prefix and only parse the appended slice, returning
  * the SAME object refs for already-seen records.

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -6,8 +6,7 @@
  * path. The vendor → default-argv mapping itself lives on the engine
  * registry (`registry.ts` `defaultCommand`); this module layers the
  * user's per-vendor override on top. Every launch site (the outer
- * monitor's Handover, the Tasks-pane switch, `new-chattab`) goes
- * through this.
+ * monitor's Handover and the Tasks-pane switch) goes through this.
  *
  * Codex's bare `codex` (no subcommand) opens its interactive TUI, the
  * same way bare `claude` does — `codex exec` is the headless path we
@@ -18,9 +17,9 @@
  * (e.g. it's `cl`) or who wants default flags (`claude --model …`) can
  * set their own. The override is a shell-ish command STRING persisted in
  * the shared `state.json` under {@link engineCommandKey}; we read it with
- * the cross-process {@link getPersistedString} (the Tasks-pane and
- * `new-chattab` run in their own processes, so they can't share the TUI's
- * reactive KV — they all read the same file instead). Empty / unset →
+ * the cross-process {@link getPersistedString} (the Tasks-pane runs in
+ * its own process, so it can't share the TUI's reactive KV — both read
+ * the same file instead). Empty / unset →
  * the built-in default.
  */
 

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -9,7 +9,7 @@
  *   - `history`        — transcript store reader (auto-title, recap).
  *   - `detectAccount`  — read-only login/binary probe (Settings → Accounts).
  *   - `createHookAdapter` — activity-hook installer (claude + codex today).
- *   - `createTurnDetector` — ChatTab turn-completion detection.
+ *   - `createTurnDetector` — Terminal Tab turn-completion detection.
  *   - `defaultCommand` / `displayName` — launch + label defaults.
  *
  * Adding an engine = one new entry here (plus its vendor-local modules);
@@ -137,7 +137,7 @@ export interface EngineRegistryEntry {
   /** Activity-hook adapter — a no-op adapter for engines without wired hooks. */
   readonly createHookAdapter: () => EngineHookAdapter
   /**
-   * Turn-completion detector for ChatTab status (transcript markers +
+   * Turn-completion detector for Terminal Tab status (transcript markers +
    * pane quiescence; see `turn-detector.ts`). Engines without persisted
    * completion markers (copilot, custom) get an {@link UnknownTurnDetector}
    * whose `supportsCompletionMarkers()` is false.

--- a/packages/kobe/src/engine/turn-detector.ts
+++ b/packages/kobe/src/engine/turn-detector.ts
@@ -1,12 +1,12 @@
 /**
- * Engine-owned turn completion detection for tmux ChatTabs.
+ * Engine-owned turn completion detection for hosted PTY sessions.
  *
  * Warp's reliable status model comes from structured response-stream
- * lifecycle events. kobe v0.6 delegates engines to interactive CLIs inside
- * tmux, so we cannot observe the live stream directly. The next-best
- * contract is engine-owned transcript markers: each vendor adapter knows
- * which persisted record means "a turn completed"; UI code only asks this
- * abstraction and combines it with pane quiescence.
+ * lifecycle events. kobe hosts engines in interactive CLIs inside a PTY,
+ * so we cannot observe the live stream directly. The next-best contract is
+ * engine-owned transcript markers: each vendor adapter knows which persisted
+ * record means "a turn completed"; UI code only asks this abstraction and
+ * combines it with pane quiescence.
  */
 
 import { readFile, stat } from "node:fs/promises"


### PR DESCRIPTION
Comment-only cleanup in `packages/kobe/src/engine/`. Replaces stale references to the removed tmux/Solid UI stack and retired `new-chattab` / `ChatTab` vocabulary with the current hosted-PTY / React / Terminal Tab framing.

Affected files:
- `engine/interactive-command.ts`
- `engine/turn-detector.ts`
- `engine/registry.ts`
- `engine/copilot-local/usage.ts`
- `engine/copilot-local/history.ts`
- `engine/codex-local/history.ts`
- `engine/claude-code-local/history.ts`
- `engine/history-cache.ts`

Verification:
- `bun run lint` passes
- `cd packages/kobe && bun run typecheck` passes
- `cd packages/kobe && bun run test:fast` passes (349 test files / 3435 tests)
