### PR TITLE
chore: add a knip config tuned for this repo's dead-code discovery

### DIFF
--- a/.changeset/knip-config.md
+++ b/.changeset/knip-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tooling only: add a knip config for dead-code discovery. Not wired into CI.

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,34 @@
+{
+  "workspaces": {
+    "packages/kobe": {
+      "entry": [
+        "src/cli/rove.ts",
+        "src/cli/kobe.ts",
+        "src/**/*mock-host.tsx",
+        "src/tui-react/mock/**"
+      ],
+      "project": [
+        "src/**/*.{ts,tsx}"
+      ]
+    },
+    "packages/kobe-daemon": {
+      "entry": [
+        "src/compat-env.ts",
+        "src/client/**/*.ts",
+        "src/daemon/pty-host-node-entry.ts"
+      ],
+      "project": [
+        "src/**/*.ts"
+      ]
+    }
+  },
+  "ignore": [
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
+  "ignoreDependencies": [
+    ".*"
+  ],
+  "includeEntryExports": false,
+  "$schema": "https://unpkg.com/knip@latest/schema.json"
+}


### PR DESCRIPTION
A tool, not a gate. Run it when you want to hunt dead code; nothing in CI changes.

## Why a config is the whole point

`npx knip` with no config reports **48 unused files**, nearly all false:

- `packages/kobe-web/e2e/hero-*.ts` — Playwright loads these by path
- `.claude/skills/**`, `.agents/skills/**` — not part of any build graph
- `packages/kobe-landing/*.js` — referenced from HTML `<script>` tags
- `packages/kobe-daemon/src/daemon/pty-host-node-entry.ts` — production reaches it through a **string path** (`const PTY_HOST_NODE_ENTRY = "../daemon/pty-host-node-entry.ts"`), which no static analysis can follow

At that ratio the output is noise. Declaring the real entry points fixes it.

## What the config declares

| workspace | entry |
|---|---|
| `packages/kobe` | both bin wrappers (`rove.ts`, `kobe.ts`), plus the mock hosts `dev:mock` boots |
| `packages/kobe-daemon` | `compat-env`, the whole `client/**` surface, and the node PTY entry |

`kobe-web` is deliberately left out — its Playwright fixtures and HTML-referenced scripts would need entry rules of their own, and that package is a secondary surface.

## Measured result

kobe + kobe-daemon go from 48 candidates to **4**:

| candidate | verdict |
|---|---|
| `daemon/server-types.ts` | **dead** — 2 lines, 0 consumers, self-described "Transitional … retained by the rename branch"; that rename is long done |
| `tui/component/border.ts` | **dead** — `EmptyBorder`/`SplitBorder`/`HSplitBorder` all zero consumers. Its header says it exists "so both the Solid and React pane trees can share it" — Solid was removed 2026-07-07 and React never picked it up (`git log -S"SplitBorder"` shows no consumer ever existed) |
| `cli/launcher.ts` | **false positive** — a build artifact entry; `scripts/build.ts` produces it per bin name, no import reaches it |
| `tui/history/mock-fixtures.ts` | **false positive** — reached through the mock-host chain |

2 real out of 4. Both real ones were confirmed independently before this config existed (issue #46), which is what makes them a fair benchmark rather than a self-fulfilling one.

## Why it isn't a CI gate

The two false positives are exactly the kind a human recognizes in seconds and a rule cannot: "this file is produced by the build" and "this is reached through a mock chain". Gating on that would either block legitimate PRs or push people to write ignore rules until the tool says nothing. Left as something you run deliberately.

Tooling only, empty changeset.