### PR TITLE
fix: reject malformed integer flags in rove api instead of coercing them

### DIFF
--- a/.changeset/strict-int-flags.md
+++ b/.changeset/strict-int-flags.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api` integer flags now reject a malformed value instead of silently coercing it. Previously a typo like `issue-set-status --id 5abc` parsed as `5` and flipped the status of a real, wrong issue, and `add --count 1e3` parsed as `1` and quietly spawned a single task — because `parseInt` stops at the first non-digit. Integer flags (`--count`, `--id`, `--number`, `--limit`, and `--agents claude:2` counts) now require the whole value to be a positive integer and fail loudly with a clear error, matching how every other flag validator already behaves.

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -15,6 +15,23 @@ import { ApiError, type FlagSpec, type Flags, type ParsedArgs, type VerbSpec, he
 /** Safety cap on a single `add --count` round so a typo can't spawn a runaway fleet. */
 export const FANOUT_CAP = 10
 
+/**
+ * Parse a strict positive-integer flag value, or `undefined` when the whole
+ * value isn't one.
+ *
+ * `Number.parseInt` alone stops at the first non-digit, so it silently coerces
+ * a typo into a confident, wrong number: `--id 5abc` → 5 (flips the status of
+ * a real, wrong issue), `--count 1e3` → 1 (spawns one task, never tripping the
+ * fan-out cap). Requiring the entire (trimmed) value to be digits — and a safe
+ * integer above zero — makes a malformed flag fail loudly with BAD_FLAG, the
+ * way every other validator in this module already does.
+ */
+export function parsePositiveInt(raw: string): number | undefined {
+  if (!/^\d+$/.test(raw.trim())) return undefined
+  const n = Number.parseInt(raw, 10)
+  return Number.isSafeInteger(n) && n > 0 ? n : undefined
+}
+
 /** Both parallel-plan parsers are only reachable from `add`, so their errors point at its help. */
 const FANOUT_STEP = helpStep("add")
 
@@ -143,10 +160,8 @@ export function validateAgainstSpec(verb: VerbSpec, flags: Flags): void {
     }
     if (f.type === "int") {
       const raw = flags.get(f.name)
-      if (raw !== undefined) {
-        const n = Number.parseInt(raw, 10)
-        if (!Number.isInteger(n) || n <= 0) throw new ApiError(`--${f.name} must be a positive integer`, "BAD_FLAG")
-      }
+      if (raw !== undefined && parsePositiveInt(raw) === undefined)
+        throw new ApiError(`--${f.name} must be a positive integer`, "BAD_FLAG")
     }
   }
 }
@@ -241,8 +256,8 @@ export class VerbArgs {
     this.spec(name)
     const raw = this.str(name)
     if (raw === undefined) return undefined
-    const n = Number.parseInt(raw, 10)
-    if (!Number.isInteger(n) || n <= 0) throw new ApiError(`--${name} must be a positive integer`, "BAD_FLAG")
+    const n = parsePositiveInt(raw)
+    if (n === undefined) throw new ApiError(`--${name} must be a positive integer`, "BAD_FLAG")
     return n
   }
 
@@ -283,8 +298,8 @@ export function parseAgentsSpec(spec: string): VendorId[] {
         FANOUT_STEP,
       )
     }
-    const count = Number.parseInt(trimmed.slice(colon + 1), 10)
-    if (!Number.isInteger(count) || count <= 0) {
+    const count = parsePositiveInt(trimmed.slice(colon + 1))
+    if (count === undefined) {
       throw new ApiError(`--agents count for "${vendor}" must be a positive integer`, "BAD_FLAG", FANOUT_STEP)
     }
     // Reject against the fanout cap BEFORE materializing the array — otherwise

--- a/packages/kobe/test/cli/api-cmd.test.ts
+++ b/packages/kobe/test/cli/api-cmd.test.ts
@@ -3,6 +3,7 @@ import {
   API_VERBS,
   ApiError,
   VERBS,
+  VerbArgs,
   apiUsage,
   buildCountPlan,
   findVerb,
@@ -99,6 +100,10 @@ describe("parseAgentsSpec", () => {
   it("rejects a non-positive or malformed count", () => {
     expect(() => parseAgentsSpec("claude:0")).toThrow(/positive integer/)
     expect(() => parseAgentsSpec("claude")).toThrow(/engine:count/)
+    // Trailing garbage must NOT be silently coerced (`parseInt("2x") === 2`).
+    expect(() => parseAgentsSpec("claude:2x")).toThrow(/positive integer/)
+    expect(() => parseAgentsSpec("claude:1e3")).toThrow(/positive integer/)
+    expect(() => parseAgentsSpec("claude:2.5")).toThrow(/positive integer/)
   })
 
   it("rejects an over-cap count before allocating (no OOM on a huge count)", () => {
@@ -319,5 +324,44 @@ describe("validateAgainstSpec", () => {
   it("accepts a well-formed invocation", () => {
     const { flags } = parseFlags(["--repo", "/x", "--status", "in_progress", "--command", "claude"])
     expect(() => validateAgainstSpec(add, flags)).not.toThrow()
+  })
+
+  it("rejects an int flag with trailing garbage instead of coercing it", () => {
+    // `parseInt` stops at the first non-digit: without a shape guard `--count 2x`
+    // would pass as 2 and `--count 1e3` as 1 — a typo becoming a wrong action.
+    for (const bad of ["2x", "1e3", "2.5", "0x10", "  ", "-1", "0"]) {
+      const { flags } = parseFlags(["--repo", "/x", "--prompt", "p", "--count", bad])
+      expect(() => validateAgainstSpec(add, flags)).toThrow(/must be a positive integer/)
+    }
+  })
+
+  it("accepts a clean integer flag (with surrounding whitespace tolerated)", () => {
+    for (const ok of ["3", " 3 "]) {
+      const { flags } = parseFlags(["--repo", "/x", "--prompt", "p", "--count", ok])
+      expect(() => validateAgainstSpec(add, flags)).not.toThrow()
+    }
+  })
+})
+
+describe("VerbArgs.int", () => {
+  const add = findVerb("add")!
+  const intOf = (value: string): number | undefined => {
+    const { flags } = parseFlags(["--count", value])
+    return new VerbArgs(add, flags).int("count")
+  }
+
+  it("returns the parsed value for a clean positive integer", () => {
+    expect(intOf("3")).toBe(3)
+    expect(intOf(" 7 ")).toBe(7)
+  })
+
+  it("is undefined when the flag is absent", () => {
+    expect(new VerbArgs(add, parseFlags(["--repo", "/x"]).flags).int("count")).toBeUndefined()
+  })
+
+  it("rejects trailing garbage, decimals, and non-positive values", () => {
+    for (const bad of ["2x", "1e3", "2.5", "0x10", "0", "-4", "abc"]) {
+      expect(() => intOf(bad)).toThrow(/must be a positive integer/)
+    }
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — found by direct code review of the `rove api` flag-parsing layer (`packages/kobe/src/cli/api/flags.ts`). No existing open PR or issue overlaps this slice.

## Problem

Every integer flag in `rove api` was validated with `Number.parseInt(raw, 10)`, which stops at the first non-digit and silently coerces malformed input into a confident, wrong number:

- `rove api issue-set-status --id 5abc` → `parseInt("5abc") === 5` → passed validation and flipped the status of issue **5** (a real, wrong issue), exiting success.
- `rove api add --count 1e3` → `parseInt("1e3") === 1` → spawned **1** task instead of the ~1000 the typo implied, never tripping the fan-out cap.
- `rove api add --agents claude:2x` → count `2`.
- Decimals (`2.5`), hex (`0x10`), and unsafe-magnitude integers slipped through the same way.

This was the one place in the flag layer where a typo produced a wrong action rather than a loud `BAD_FLAG` — every other validator (enum, bool, required) already rejects malformed input.

## Fix

Added a shared `parsePositiveInt(raw)` helper that requires the whole (trimmed) value to be digits and a safe positive integer, returning `undefined` otherwise. Routed all three integer call sites through it:

- `validateAgainstSpec` — the spec-level gate for every `type: "int"` flag (`--count`, `--id`, `--number`, `--limit`, …).
- `VerbArgs.int` — the handler-side accessor.
- `parseAgentsSpec` — the `claude:2` per-engine count parser.

Whitespace around a clean value (`" 3 "`) is still tolerated, matching the prior `parseInt` behavior; only genuinely malformed values are now rejected.

## Verification

- Extended `test/cli/api-cmd.test.ts` with rejection cases for trailing garbage / decimals / hex / non-positive values across `parseAgentsSpec`, `validateAgainstSpec`, and a new `VerbArgs.int` block, plus a clean-value acceptance case. **36/36** in that file, **755/755** across `test/cli`.
- `bun run lint` and `bun run typecheck` both green.
- `flags.ts` stays at 338 lines (well under the ~500 cap).
- Added a `patch` changeset.

## Follow-ups (deliberately deferred, out of this slice)

- `rove api prompt --timeout` (`verbs-drive.ts`) parses its value with a handler-local `Number.parseInt` and is declared `type: "string"`, so it has the same silent-coercion exposure but a different fix shape (convert to `int` + decide `0` semantics). Left for a separate, focused change.


---
_Generated by [Claude Code](https://claude.ai/code/session_014pjWMLrYipYfgWuQoZVxC2)_