### PR TITLE
feat(plugins): full-lifecycle event catalog, snapshot-diff sourcing, engine self-reporting

### DIFF
--- a/.changeset/plugin-event-catalog.md
+++ b/.changeset/plugin-event-catalog.md
@@ -1,0 +1,19 @@
+---
+"@sma1lboy/rove": patch
+"@sma1lboy/rove-plugin-sdk": patch
+---
+
+Plugins now see the whole product move, not just the corners a handler
+remembered to report. Task events derive from field-level snapshot diffs, so
+`task.archived` fires however a task got archived (including the
+`git worktree remove` sweep and `land --then-archive`) and `worktree.created`
+fires for adopted worktrees too — both previously dropped. New catalog
+entries: `task.changed` (fields/from/to), `task.pr-changed`,
+`automation.dispatched/skipped/failed`, `quota.exhausted/resumed`,
+`session.exited` (the crash signal, off the PTY host's death records),
+`note.filed`, `message.delivered`, `attention.handled`, and
+`plugin.enabled/disabled`. `turn.complete` now carries the finished turn's
+model + token usage. Manifests gain `[[shutdown]]` hooks (bounded ~3s at
+daemon stop) and `[engines.identity]` for composer copy, and
+`rove api engine-report` lets a plugin-contributed engine drive the sidebar
+badge, attention inbox, and event stream without a built-in hook adapter.

--- a/docs/API.md
+++ b/docs/API.md
@@ -381,3 +381,13 @@ to do) from `dispatch_failed` (needs a human).
   ask the human for a line of text through the attached TUI's input dialog;
   blocks until answered/cancelled/timeout (default 120000 ms, max 600000)
   and returns `{ value }` or `{ cancelled, reason }`.
+- `engine-report --kind KIND [--task-id ID] [--engine ID] [--tab TAB]
+  [--detail JSON]`: report a normalized engine-activity verb for a task —
+  the public face of the `engine.reportEvent` RPC the built-in hook adapters
+  use. Lets a plugin-contributed engine (or any wrapper) drive the sidebar
+  badge, attention inbox, and plugin event stream. Task/tab default to
+  `$ROVE_TASK_ID` / `$ROVE_TAB_ID`; without either, the caller's cwd is
+  mapped to a task by worktree path. Kinds: `session-start`, `turn-start`,
+  `turn-complete`, `turn-failed`, `turn-interrupted`, `awaiting-input`,
+  `session-end` (activity state), plus `tool-pre/post/failed`,
+  `pre/post-compact`, `subagent-start/stop` (plugin-only).

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -83,6 +83,9 @@ command = ["npm", "install"]     # self-provision deps INTO the plugin dir; `lin
 [[startup]]                      # once per daemon start, after the socket is ready; one-shot, not a daemon
 command = ["node", "restore.js"]
 
+[[shutdown]]                     # at daemon stop; bounded (~3s) — the host kills a hook that lingers
+command = ["node", "flush.js"]
+
 [[actions]]                      # on-demand: rove plugin action invoke you.example.greet [args…]
 id = "greet"                     # local id, no dots; extra CLI args append to argv
 title = "Say hello"
@@ -116,6 +119,11 @@ name = "Aider"                   # display name in the selector and Settings
 command = ["aider"]              # launch argv; argv[0] is the binary
 # process_names = ["aider-core"] # extra ps basenames (post-launch renames)
 
+[engines.identity]               # optional product identity for UI copy
+product_name = "Aider"           # each field falls back to `name`
+short_name = "Aider"
+input_placeholder = "Ask Aider…" # composer placeholder
+
 [[engines.rules]]                # screen-state rules, first match wins —
 state = "blocked"                # declare blocked before working
 all = ["(y)es/(n)o"]             # every string must appear (case-insensitive)
@@ -146,16 +154,25 @@ Code, X = Codex (Kimi adapter pending).
 | Event | Fires when | Detail highlights |
 |---|---|---|
 | `task.created` / `task.deleted` | task appears/disappears in the index | task context |
+| `task.changed` | any watched task field changed (title/branch/status/pin/vendor/…) — fired off the snapshot diff, so EVERY mutation path counts | `fields`, `from`, `to` |
 | `task.landed` | a task's branch merged back into its base repo | `strategy`, `landedOn`, `commit` |
-| `task.archived` | a task was archived (restores don't fire) | task context |
-| `worktree.created` | a task's worktree materialized | task context |
+| `task.archived` | a task was archived, by ANY path — the archive RPC, `land --then-archive`, or a `git worktree remove` sweep (restores don't fire) | task context |
+| `task.pr-changed` | the task's PR status changed (open/merged/closed, checks) | `from`, `to` (TaskPRStatus) |
+| `worktree.created` | a task's worktree materialized — lazy ensure, adopt, or scratch-adopt | task context |
 | `issue.changed` | a daemon-tracker issue mutated (create/edit/status) | `repo`, `op` |
+| `note.filed` | a session filed a field note (`rove api note`) | `repo`, `author`, `text`, `routed`, `persisted` |
+| `message.delivered` | text was dispatched into a task's live session (`dispatch`/note relay) | `source`, `tabId`, `length` |
+| `attention.handled` | the human resolved an inbox episode | `how: dismissed\|read`, `tabId` |
+| `automation.dispatched` / `automation.skipped` / `automation.failed` | one scheduled-automation run finished with that outcome | `automationId`, `name`, `repo`, `status`, `trigger`, `scheduledFor`, `error` |
+| `quota.exhausted` / `quota.resumed` | rate-limit auto-resume armed / delivered its continue prompt | `vendor`, `resumeAt` / `delivered` |
+| `session.exited` | a hosted PTY child died abnormally (the crash signal — the engine's own `session.end` hook never fires on a crash) | `tabId`, `pid`, `code`, `signal`, `exitedAt`, `tail` |
+| `plugin.enabled` / `plugin.disabled` | YOUR plugin was enabled/disabled in the registry (delivered only to the affected plugin) | `pluginId` |
 | `task.opened` / `project.opened` | the user selects/enters a task / project row | |
 | `file.will-open` / `file.opened` / `file.closed` | Files-pane open, before/after; editor tab closed | `path`, `via: plugin\|editor\|external` |
 | `tab.opened` / `tab.closed` | a workspace tab appeared/went away (restores don't fire) | `tabId`, `kind`, `title`, `vendor`, `purpose` |
 | `agent.running` / `agent.idle` / `agent.turn-complete` / `agent.permission-needed` / `agent.rate-limited` / `agent.error` | activity-STATE transitions, deduped per task+tab | `tabId` when the source state identifies a tab |
 | `session.start` / `session.end` | engine session lifecycle (C; X start only) | |
-| `turn.prompt` / `turn.complete` / `turn.failed` / `turn.interrupted` | one event per turn edge (C, X; interrupted: Kimi-shaped) | `failure` class on failed |
+| `turn.prompt` / `turn.complete` / `turn.failed` / `turn.interrupted` | one event per turn edge (C, X; interrupted: Kimi-shaped) | `failure` class on failed; `turn` (id/model/usage/startedAt/endedAt) on complete when the transcript yielded one |
 | `tool.pre` / `tool.post` / `tool.failed` | every tool call (C, X; failed: C); **installed into engine config only while some enabled plugin subscribes** | `tool.name`, `tool.id` |
 | `attention.permission` / `attention.question` | the engine blocked on a human (C) | `waiting` |
 | `context.pre-compact` / `context.post-compact` | context compaction (C, X) | `compact.trigger: manual\|auto` |
@@ -176,10 +193,12 @@ Envelope (`ROVE_PLUGIN_EVENT_JSON`):
 ```
 
 **The principle: any observable product moment is a candidate event.** The
-catalog grows as subsystems expose their edges (PR status and task status
-transitions are natural next ones). If your plugin needs a
-moment that isn't fired yet, ask via `rove feedback` or a GitHub issue; the
-plumbing (`ui.reportEvent` → plugin sink) makes additions cheap.
+catalog grows as subsystems expose their edges. Threshold policies stay OUT:
+"worktree dirtier than N" is a plugin's own judgment — subscribe to the
+`worktree.changes` channel over the raw socket and decide yourself. If your
+plugin needs a moment that isn't fired yet, ask via `rove feedback` or a
+GitHub issue; the plumbing (`ui.reportEvent` → plugin sink) makes additions
+cheap.
 
 ## Environment contract
 
@@ -195,6 +214,7 @@ Every plugin command gets, on top of the user's environment:
 | `ROVE_PLUGIN_STATE_DIR` | your durable state; survives reinstall |
 | events | `ROVE_PLUGIN_EVENT`, `ROVE_PLUGIN_EVENT_JSON`, `ROVE_PLUGIN_TASK_ID`, `ROVE_PLUGIN_TASK_TITLE` |
 | startup | `ROVE_PLUGIN_EVENT=startup` |
+| shutdown | `ROVE_PLUGIN_EVENT=shutdown` |
 | actions | `ROVE_PLUGIN_ACTION_ID`, `ROVE_PLUGIN_INVOKE_CWD` (where the user invoked, usually "the repo I mean") |
 | panes | `ROVE_PLUGIN_ENTRYPOINT_ID`; cwd is the task worktree |
 
@@ -243,8 +263,14 @@ the CLI unless you need push channels.
 - **Files pane**: `[[file_handlers]]` claims opens by pattern.
 - **Engines**: `[[engines]]` contributes a coding CLI to the engine
   selector — identity, launch command, and screen-state rules for
-  working / needs-input badges. Launch + badge only: account detection,
-  history, and hooks require a built-in adapter in Rove itself.
+  working / needs-input badges. Beyond screen scraping, a wrapper can
+  report PRECISE activity itself: `rove api engine-report --kind
+  turn-complete --engine <id>` drives the same badge / attention-inbox /
+  plugin-event pipeline the built-in hook adapters use (kinds:
+  `session-start|turn-start|turn-complete|turn-failed|turn-interrupted|awaiting-input|session-end`,
+  plus the plugin-only `tool-*`/`*-compact`/`subagent-*` family). Account
+  detection, history readers, and model catalogs still require a built-in
+  adapter in Rove itself — render those surfaces yourself via `[[panes]]`.
 - **Host input dialog**: `rove api prompt --title "…"` (SDK: `promptUser()`)
   pops the TUI's standard input dialog and blocks for the answer: `{value}`
   on submit, `{cancelled, reason}` on esc/timeout. Use it instead of

--- a/docs/design/plugin-events.md
+++ b/docs/design/plugin-events.md
@@ -62,11 +62,19 @@ Support: **C** Claude Code · **X** Codex · **K** Kimi Code. `N` native hook,
 | Event | Fires when | Status |
 |---|---|---|
 | `task.created` / `task.deleted` | task appears/disappears in the index | ✅ |
+| `task.changed` | any watched field changed (title/branch/status/pin/vendor/…) — snapshot-diff sourced, so EVERY mutation path fires (`detail.fields/from/to`) | ✅ (subsumes the deferred `task.status-changed`) |
 | `task.landed` | branch merged back into the base repo (`detail.strategy/landedOn/commit`) | ✅ |
-| `task.archived` | task archived; restores don't fire | ✅ |
-| `worktree.created` | worktree materialized for a task | ✅ |
+| `task.archived` | task archived by ANY path (RPC, `land --then-archive`, worktree-removal sweep); restores don't fire | ✅ (snapshot-diff sourced) |
+| `task.pr-changed` | PR status changed on the task (`detail.from/to`) | ✅ |
+| `worktree.created` | worktree materialized for a task (lazy ensure, adopt, scratch-adopt — snapshot-diff sourced) | ✅ |
 | `issue.changed` | daemon-tracker issue mutated (`detail.repo/op`) | ✅ |
-| `task.status-changed` | backlog → in-progress → done transitions | 💤 (derivable from snapshots; add on demand) |
+| `note.filed` | a session filed a field note (`detail.repo/author/text/routed/persisted`) | ✅ |
+| `message.delivered` | text dispatched into a task's live session (`detail.source/tabId/length`) | ✅ |
+| `attention.handled` | the human resolved an inbox episode (`detail.how: dismissed\|read`) | ✅ |
+| `automation.dispatched` / `.skipped` / `.failed` | one scheduled-automation run's outcome (`detail.automationId/name/status/trigger/error`) | ✅ |
+| `quota.exhausted` / `quota.resumed` | auto-resume armed (`detail.vendor/resumeAt`) / continue prompt delivered (`detail.delivered`) | ✅ |
+| `session.exited` | hosted PTY child died abnormally — the crash signal, watched off `pty-exits.json` (`detail.code/signal/tail`) | ✅ |
+| `plugin.enabled` / `plugin.disabled` | registry transition, delivered only to the affected plugin | ✅ |
 | `file.will-open` / `file.opened` | Files-pane open, before/after (`detail.path`, `detail.via: plugin\|editor\|external`) | ✅ |
 | `file.closed` | the editor tab left the tab strip (fires off the tab-delta seam) | ✅ |
 | `task.opened` / `project.opened` | the user selects/enters a task or project row | ✅ |
@@ -181,6 +189,25 @@ builds: notify, log, mirror state, auto-file, auto-bootstrap, dashboards.
   `ui.reportEvent` RPC → PluginHost direct sink (same no-broadcast path as
   lifecycle kinds). Async observers only — a `will-` event precedes the
   action but cannot block it.
+- **Snapshot-diff sourcing (done).** `task.changed` / `task.pr-changed` /
+  `task.archived` / `worktree.created` derive from field-level diffs of
+  consecutive `task.snapshot` publishes (`plugins/task-diff.ts`), NOT from
+  RPC handlers — every mutation path (including worktree-removal sweeps and
+  orchestrator-internal archive) funnels through the store and therefore
+  fires. `task.landed` stays handler-emitted: its detail (strategy/commit)
+  never reaches the snapshot.
+- **[[shutdown]] hooks (done).** Run at daemon stop, bounded (~3s grace,
+  then SIGKILL) — a plugin can flush state without ever delaying shutdown.
+- **`session.exited` (done).** The pty-host is a separate process with no
+  daemon socket; the daemon watches its durable `pty-exits.json` death
+  records (FileWatchTrigger) and fires one event per NEW record. Clean
+  exits are never recorded, hence never fired.
+- **`rove api engine-report` (done).** The public face of
+  `engine.reportEvent`: plugin-contributed engines (or any wrapper) report
+  normalized activity verbs themselves and get the badge / inbox / plugin
+  event pipeline without a built-in hook adapter.
+- **Threshold policies stay out.** "Worktree dirtier than N" is plugin
+  judgment — subscribe to the `worktree.changes` channel over the socket.
 - **Attention split (done for Claude).** `awaiting-input` maps to
   `attention.permission` vs `attention.question` by `detail.waiting`. Codex
   PermissionRequest opt-in and `attention.notification` remain deferred.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -76,7 +76,8 @@
     "./plugins/runtime": "./src/plugins/runtime.ts",
     "./plugins/settings-env": "./src/plugins/settings-env.ts",
     "./daemon/pty-exit-watch": "./src/daemon/pty-exit-watch.ts",
-    "./plugins/task-diff": "./src/plugins/task-diff.ts"
+    "./plugins/task-diff": "./src/plugins/task-diff.ts",
+    "./daemon/quota-resume": "./src/daemon/quota-resume.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -74,7 +74,9 @@
     "./plugins/plugin-paths": "./src/plugins/plugin-paths.ts",
     "./plugins/registry": "./src/plugins/registry.ts",
     "./plugins/runtime": "./src/plugins/runtime.ts",
-    "./plugins/settings-env": "./src/plugins/settings-env.ts"
+    "./plugins/settings-env": "./src/plugins/settings-env.ts",
+    "./daemon/pty-exit-watch": "./src/daemon/pty-exit-watch.ts",
+    "./plugins/task-diff": "./src/plugins/task-diff.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/kobe-daemon/src/daemon/agent-turns-ingest.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-ingest.ts
@@ -26,6 +26,9 @@ export interface TurnIngestInput {
   readonly transcriptPath?: string
 }
 
+/** The turn that just finished — the newest record of an ingest pass. */
+export type LatestTurn = Pick<AgentTurnRecord, "id" | "model" | "usage" | "startedAt" | "endedAt"> | undefined
+
 /**
  * Read the finished turns out of `transcriptPath` and merge them into the
  * store, joined to the task's identity. Resolves to the number of NEW turns
@@ -37,13 +40,13 @@ export async function ingestAgentTurns(
   runtime: DaemonRuntimeAdapter,
   orch: DaemonOrchestrator,
   input: TurnIngestInput,
-): Promise<number> {
-  if (!input.transcriptPath) return 0
+): Promise<{ recorded: number; latest: LatestTurn }> {
+  if (!input.transcriptPath) return { recorded: 0, latest: undefined }
   const task = orch.getTask(input.taskId)
   const vendor = (input.vendor ?? task?.vendor) as VendorId | undefined
-  if (!vendor) return 0
+  if (!vendor) return { recorded: 0, latest: undefined }
   const turns = await runtime.readEngineTurns(vendor, input.transcriptPath)
-  if (turns.length === 0) return 0
+  if (turns.length === 0) return { recorded: 0, latest: undefined }
   const records: AgentTurnRecord[] = turns.map((turn) => ({
     ...turn,
     taskId: input.taskId,
@@ -51,16 +54,35 @@ export async function ingestAgentTurns(
     vendor,
     ...(task?.repo ? { repo: task.repo } : {}),
   }))
-  return await store.record(records)
+  const recorded = await store.record(records)
+  const last = records[records.length - 1]
+  const latest: LatestTurn = last
+    ? { id: last.id, model: last.model, usage: last.usage, startedAt: last.startedAt, endedAt: last.endedAt }
+    : undefined
+  return { recorded, latest }
 }
 
-/** Fire-and-forget wrapper for the hook path: never throws, never awaited. */
+/**
+ * Fire-and-forget wrapper for the hook path: never throws, never awaited.
+ * `onDone` (when given) ALWAYS runs exactly once — with the just-finished
+ * turn when the transcript yielded one, without it otherwise — so the caller
+ * can defer its turn.complete plugin event onto the enriched data.
+ */
 export function ingestAgentTurnsBestEffort(
   store: AgentTurnsStore | undefined,
   runtime: DaemonRuntimeAdapter,
   orch: DaemonOrchestrator,
   input: TurnIngestInput,
+  onDone?: (latest: LatestTurn) => void,
 ): void {
-  if (!store) return
-  void ingestAgentTurns(store, runtime, orch, input).catch((err) => logDaemonError("agent-turns-ingest", err))
+  if (!store) {
+    onDone?.(undefined)
+    return
+  }
+  void ingestAgentTurns(store, runtime, orch, input)
+    .then(({ latest }) => onDone?.(latest))
+    .catch((err) => {
+      logDaemonError("agent-turns-ingest", err)
+      onDone?.(undefined)
+    })
 }

--- a/packages/kobe-daemon/src/daemon/automation-runner.ts
+++ b/packages/kobe-daemon/src/daemon/automation-runner.ts
@@ -76,11 +76,54 @@ interface RunnerDeps {
    *  self-link is constructed after the collectors start, and the sweep only
    *  needs it on a tick. */
   readonly link: DaemonRpcClient | (() => DaemonRpcClient)
+  /** Plugin event sink (getter for the same construction-order reason as
+   *  `link`). Every recorded run fires one automation.* plugin event. */
+  readonly plugins?: () => { handleUiReport(report: PluginRunReport): void } | null
   readonly now?: () => number
+}
+
+type PluginRunReport = {
+  readonly kind: import("../plugins/manifest.ts").PluginEventName
+  readonly taskId?: string
+  readonly detail?: Record<string, unknown>
+}
+
+/** Run outcome → plugin event name (docs/design/plugin-events.md). */
+function runEventFor(status: AutomationRunStatus): PluginRunReport["kind"] {
+  if (status === "dispatched") return "automation.dispatched"
+  if (status === "dispatch_failed") return "automation.failed"
+  return "automation.skipped"
 }
 
 function resolveLink(link: RunnerDeps["link"]): DaemonRpcClient {
   return typeof link === "function" ? link() : link
+}
+
+/** Best-effort plugin event for one recorded run — never throws. */
+function emitRunEvent(
+  deps: RunnerDeps,
+  automation: Automation,
+  status: AutomationRunStatus,
+  args: { scheduledFor: number; trigger: "scheduled" | "manual" },
+  extra: { taskId?: string; error?: string },
+): void {
+  try {
+    deps.plugins?.()?.handleUiReport({
+      kind: runEventFor(status),
+      ...(extra.taskId ? { taskId: extra.taskId } : {}),
+      detail: {
+        automationId: automation.id,
+        name: automation.name,
+        repo: automation.repo,
+        status,
+        trigger: args.trigger,
+        scheduledFor: new Date(args.scheduledFor).toISOString(),
+        ...(extra.error ? { error: extra.error } : {}),
+      },
+    })
+  } catch {
+    /* plugin fan-out must never fail a run */
+  }
 }
 
 /**
@@ -106,6 +149,7 @@ export async function runAutomationOnce(
       at: new Date(now()).toISOString(),
       ...extra,
     })
+    emitRunEvent(deps, automation, status, args, extra)
     return status
   }
 
@@ -165,14 +209,22 @@ export async function sweepAutomations(deps: RunnerDeps): Promise<void> {
     await deps.store.advanceNextRun(automation.id, occurrence.scheduledFor)
 
     if (occurrence.missed) {
+      const error = `missed by more than the ${automation.missedRunGraceMinutes}m grace window`
       await deps.store.recordRun({
         automationId: automation.id,
         scheduledFor: new Date(occurrence.scheduledFor).toISOString(),
         status: "skipped_missed",
         trigger: "scheduled",
         at: new Date(nowMs).toISOString(),
-        error: `missed by more than the ${automation.missedRunGraceMinutes}m grace window`,
+        error,
       })
+      emitRunEvent(
+        deps,
+        automation,
+        "skipped_missed",
+        { scheduledFor: occurrence.scheduledFor, trigger: "scheduled" },
+        { error },
+      )
       continue
     }
 

--- a/packages/kobe-daemon/src/daemon/automation-runner.ts
+++ b/packages/kobe-daemon/src/daemon/automation-runner.ts
@@ -107,23 +107,21 @@ function emitRunEvent(
   args: { scheduledFor: number; trigger: "scheduled" | "manual" },
   extra: { taskId?: string; error?: string },
 ): void {
-  try {
-    deps.plugins?.()?.handleUiReport({
-      kind: runEventFor(status),
-      ...(extra.taskId ? { taskId: extra.taskId } : {}),
-      detail: {
-        automationId: automation.id,
-        name: automation.name,
-        repo: automation.repo,
-        status,
-        trigger: args.trigger,
-        scheduledFor: new Date(args.scheduledFor).toISOString(),
-        ...(extra.error ? { error: extra.error } : {}),
-      },
-    })
-  } catch {
-    /* plugin fan-out must never fail a run */
-  }
+  // handleUiReport guards its own dispatch — a throw can only come from the
+  // getter, which is a plain closure over the server's pluginHost.
+  deps.plugins?.()?.handleUiReport({
+    kind: runEventFor(status),
+    ...(extra.taskId ? { taskId: extra.taskId } : {}),
+    detail: {
+      automationId: automation.id,
+      name: automation.name,
+      repo: automation.repo,
+      status,
+      trigger: args.trigger,
+      scheduledFor: new Date(args.scheduledFor).toISOString(),
+      ...(extra.error ? { error: extra.error } : {}),
+    },
+  })
 }
 
 /**

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -54,6 +54,8 @@ export interface DaemonCollectorOptions {
 export interface AutomationCollectorDeps {
   readonly store: AutomationsStore
   readonly link: DaemonRpcClient | (() => DaemonRpcClient)
+  /** Plugin host getter (constructed after the collectors start, like `link`). */
+  readonly plugins?: () => import("../plugins/runtime.ts").PluginHost | null
 }
 
 /**
@@ -171,13 +173,21 @@ export function startDaemonCollectors(
     orch,
     runtime,
     options.quotaResumeTickMs ?? DEFAULT_QUOTA_RESUME_TICK_MS,
+    undefined,
+    automations?.plugins,
   )
 
   // Automation sweep: same reasoning as quota-resume, only more so — a
   // schedule that requires an audience is not a schedule. Also ungated.
   const stopAutomationRunner = automations
     ? startAutomationRunner(
-        { store: automations.store, orch, runtime, link: automations.link },
+        {
+          store: automations.store,
+          orch,
+          runtime,
+          link: automations.link,
+          ...(automations.plugins ? { plugins: automations.plugins } : {}),
+        },
         options.automationTickMs ?? DEFAULT_AUTOMATION_TICK_MS,
       )
     : () => {}

--- a/packages/kobe-daemon/src/daemon/handlers-attention.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-attention.ts
@@ -10,7 +10,15 @@ export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
       const taskId = requireString(payload, "taskId")
       const tabId = optionalString(payload, "tabId") ?? null
       const at = payload.at === undefined ? undefined : requireNumber(payload, "at")
-      return { deleted: await ctx.inbox.deleteEpisode(taskId, tabId, at) }
+      const deleted = await ctx.inbox.deleteEpisode(taskId, tabId, at)
+      if (deleted) {
+        ctx.plugins?.handleUiReport({
+          kind: "attention.handled",
+          taskId,
+          detail: { how: "dismissed", ...(tabId ? { tabId } : {}) },
+        })
+      }
+      return { deleted }
     },
   },
   {
@@ -18,7 +26,15 @@ export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       const tabId = optionalString(payload, "tabId") ?? null
-      return { updated: await ctx.inbox.markRead(taskId, tabId, requireNumber(payload, "at")) }
+      const updated = await ctx.inbox.markRead(taskId, tabId, requireNumber(payload, "at"))
+      if (updated) {
+        ctx.plugins?.handleUiReport({
+          kind: "attention.handled",
+          taskId,
+          detail: { how: "read", ...(tabId ? { tabId } : {}) },
+        })
+      }
+      return { updated }
     },
   },
 ]

--- a/packages/kobe-daemon/src/daemon/handlers-engine-report.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-engine-report.ts
@@ -1,0 +1,166 @@
+/**
+ * `engine.reportEvent` — the busiest RPC, split from `handlers.ts` (file-size
+ * cap). A `kobe hook <verb>` (or `rove api engine-report`) process reports a
+ * NORMALIZED engine activity event; this handler folds it into activity
+ * state, the attention inbox, the recent-events feed, plugin event hooks,
+ * turn telemetry, auto-status rules, and quota auto-resume.
+ */
+
+import { ingestAgentTurnsBestEffort } from "./agent-turns-ingest.ts"
+import { logDaemonError } from "./crash-log.ts"
+import { findAdoptableWorktree, matchTaskByCwd } from "./cwd-task.ts"
+import { optionalActivityDetail, optionalString, requireString } from "./handler-validators.ts"
+import type { DaemonRequestHandler } from "./handlers.ts"
+import { scheduleQuotaResume } from "./quota-resume.ts"
+
+export const ENGINE_REPORT_HANDLER: DaemonRequestHandler = {
+  name: "engine.reportEvent",
+  async handle(payload, ctx) {
+    // A `kobe hook <verb>` process reporting a NORMALIZED engine activity
+    // event (the vendor-specific hook was already translated by the
+    // engine's hook adapter). The global hooks carry no task id — they
+    // report their `cwd`, which we map to a task by worktree path. Fold it
+    // into the task's transient activity state + broadcast on
+    // `engine-state`. Unknown kinds are ignored (forward-compat: a newer
+    // adapter, older daemon); an unmatched cwd (an unrelated repo, a
+    // project with no kobe task) is silently dropped.
+    const kind = requireString(payload, "kind")
+    if (!ctx.runtime.isEngineActivityKind(kind)) throw new Error(`unknown engine event kind: ${kind}`)
+    // `taskId` (legacy/direct) wins; otherwise resolve from `cwd`.
+    const explicitId = optionalString(payload, "taskId")
+    const cwd = optionalString(payload, "cwd")
+    // External-worktree sync (replaces the removed WorktreeCreate hook): a
+    // session starting in an unadopted worktree under a tracked repo's
+    // a managed worktree root is auto-adopted as a task, so the cwd then maps
+    // to it below. Gated to `session-start` to bound the work; the path
+    // check is git-free and `adoptWorktree` is idempotent + git-validated
+    // (a bogus dir just throws → caught → dropped).
+    if (!explicitId && cwd && kind === "session-start") {
+      const cand = findAdoptableWorktree(ctx.orch.listTasks(), cwd)
+      if (cand) {
+        try {
+          await ctx.orch.adoptWorktree({ repo: cand.repo, worktreePath: cand.worktreePath, ifExists: "return" })
+        } catch (err) {
+          logDaemonError("worktree-autosync", err)
+        }
+      }
+    }
+    const taskId = explicitId ?? (cwd ? matchTaskByCwd(ctx.orch.listTasks(), cwd) : undefined)
+    if (!taskId) return {} // unmatched cwd → drop
+    const detail = optionalActivityDetail(payload)
+    // Which engine tab the event came from — the inherited KOBE_TAB_ID env.
+    // Sessions outside a Kobe tab remain activity-only via the report below.
+    const tabId = optionalString(payload, "tabId")
+    // The engine's own session identity, from its hook payload (Claude
+    // pipes session_id/transcript_path). Optional + additive: an old
+    // `kobe hook` simply omits it.
+    const sessionId = optionalString(payload, "sessionId")
+    const transcriptPath = optionalString(payload, "transcriptPath")
+    const session = sessionId ? { id: sessionId, transcriptPath } : undefined
+    // Lifecycle-only kinds (tool/compact/subagent) skip the badge + inbox
+    // entirely — folding them into engine-state would broadcast every
+    // tool call to every client. They still reach plugins below.
+    const isStateKind = ctx.runtime.affectsActivityState(kind)
+    // The hook's `--engine` tag — read early so the activity registry's
+    // liveness probe can ask about the engine that actually reported
+    // (a custom wrapper id as task.vendor has no transcript store).
+    const vendor = optionalString(payload, "engine")
+    if (isStateKind) {
+      ctx.activity.report(taskId, kind, detail, tabId, session, vendor)
+      // A tab id makes the episode tab-precise; without one it is still
+      // recorded at TASK level (owner call 2026-08-10) — an engine the
+      // user typed into a bare shell inherits no KOBE_TAB_ID, and
+      // dropping its events is why such a session could finish without
+      // ever appearing in the Inbox. `explicitId` still gates: a
+      // cwd-matched task is a guess, not an identity.
+      if (explicitId) {
+        await ctx.inbox
+          .record(taskId, kind, detail, tabId ?? null)
+          .catch((err) => logDaemonError("attention-inbox-record", err))
+      }
+    }
+    // Per-task recent-events buffer (TUI event feed) + the low-frequency
+    // `engine.lifecycle` channel (sidebar compaction glyph / subagent mark).
+    ctx.engineEvents?.append(taskId, {
+      kind,
+      ...(tabId ? { tabId } : {}),
+      ...(vendor ? { vendor } : {}),
+      ...(detail ? { detail } : {}),
+      at: Date.now(),
+    })
+    if (kind === "pre-compact" || kind === "post-compact" || kind === "subagent-start" || kind === "subagent-stop") {
+      ctx.bus.publish("engine.lifecycle", { taskId, kind, ...(tabId ? { tabId } : {}), at: Date.now() })
+    }
+    // Plugin event hooks: every report becomes one agent-lifecycle event
+    // (docs/design/plugin-events.md); dispatch fans out only to plugins
+    // that declared the event. `turn-complete` is deferred below so its
+    // event can carry the finished turn's usage/model off the ingest.
+    const pluginReport = {
+      kind,
+      taskId,
+      ...(detail ? { detail: detail as unknown as Record<string, unknown> } : {}),
+      ...(vendor ? { vendor } : {}),
+      ...(tabId ? { tabId } : {}),
+      ...(sessionId ? { sessionId } : {}),
+    }
+    if (kind !== "turn-complete") ctx.plugins?.handleEngineReport(pluginReport)
+    // Per-turn telemetry (issue #32): a finished turn is the moment its
+    // records are complete on disk. Fire-and-forget — the transcript read
+    // must not delay the hook RPC, and losing a record is a telemetry
+    // gap, never an engine failure. The turn.complete plugin event rides
+    // the completion callback (fires with or without a readable turn).
+    if (kind === "turn-complete") {
+      ingestAgentTurnsBestEffort(
+        ctx.agentTurns,
+        ctx.runtime,
+        ctx.orch,
+        {
+          taskId,
+          ...(tabId ? { tabId } : {}),
+          ...(vendor ? { vendor } : {}),
+          ...(transcriptPath ? { transcriptPath } : {}),
+        },
+        (latest) =>
+          ctx.plugins?.handleEngineReport(
+            latest ? { ...pluginReport, detail: { ...(pluginReport.detail ?? {}), turn: latest } } : pluginReport,
+          ),
+      )
+    }
+    // Auto status flow (docs/design/web-kanban.md M5): an engine
+    // STARTING a turn on a backlog task means work began — a pure rule
+    // advances it to in_progress. (in_progress → in_review is the
+    // agent's own self-report via the injected status protocol, not a
+    // daemon rule.) Fire-and-forget; gated inside maybeAutoStart
+    // (opt-in state.json flag).
+    if (kind === "turn-start") {
+      ctx.runtime
+        .maybeAutoStart(ctx.orch, taskId)
+        .then((result) => {
+          if (result === "moved") {
+            console.log(`[status-rules] task ${taskId} auto-moved backlog → in_progress`)
+          }
+        })
+        .catch((err) => logDaemonError("status-rules", err))
+      // A turn actually started (the user resumed manually, or our own
+      // continue prompt landed) — any pending auto-resume is now stale.
+      if (ctx.orch.getTask(taskId)?.quotaResume) {
+        void ctx.orch.setQuotaResume(taskId, null).catch((err) => logDaemonError("quota-resume", err))
+      }
+    }
+    // Real subscription-quota limit → ask the engine's quota probe when
+    // the window resets and arm the durable auto-resume schedule.
+    // Fire-and-forget: the probe does network I/O and must not delay the
+    // hook RPC. `billing` is excluded — it needs a human, not a timer.
+    if (kind === "turn-failed" && detail?.failure === "rate_limit") {
+      void scheduleQuotaResume(
+        ctx.orch,
+        ctx.runtime,
+        ctx.quotaUsage,
+        taskId,
+        undefined,
+        () => ctx.plugins ?? null,
+      ).catch((err) => logDaemonError("quota-resume", err))
+    }
+    return {}
+  },
+}

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -63,9 +63,9 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       const archived = optionalBoolean(payload, "archived")
+      // `task.archived` now derives from the snapshot diff (plugins/task-diff.ts)
+      // so archive-via-worktree-removal and land --then-archive fire it too.
       await ctx.orch.setArchived(taskId, archived)
-      // Unarchive (archived: false) is a restore, not an "archived" moment.
-      if (archived !== false) ctx.plugins?.handleUiReport({ kind: "task.archived", taskId })
       return {}
     },
   },

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -40,6 +40,11 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
         at: Date.now(),
         source: source ?? "dispatcher",
       })
+      ctx.plugins?.handleUiReport({
+        kind: "message.delivered",
+        taskId,
+        detail: { source: source ?? "dispatcher", ...(tabId !== undefined ? { tabId } : {}), length: text.length },
+      })
       // Report reach, don't just claim success. `session.deliver` is
       // broadcast-only — an attached client performs the paste — so with
       // nothing listening the text goes into the void while the caller still
@@ -211,14 +216,21 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       // No dispatcher seat, or the dispatcher noting to itself: accepted
       // but unrouted — filing must never error a working agent. Still
       // persisted above, which is why an unrouted note is no longer a loss.
-      if (!main || main.id === author.id) return { ok: true, routed: false, persisted: persisted ?? false }
-      ctx.bus.publish("session.deliver", {
-        taskId: main.id,
-        text: `[ROVE FIELD NOTE] from "${label}" (task ${taskId}): ${text}`,
-        at: Date.now(),
-        source: "note",
+      const routed = !!main && main.id !== author.id
+      if (routed && main) {
+        ctx.bus.publish("session.deliver", {
+          taskId: main.id,
+          text: `[ROVE FIELD NOTE] from "${label}" (task ${taskId}): ${text}`,
+          at: Date.now(),
+          source: "note",
+        })
+      }
+      ctx.plugins?.handleUiReport({
+        kind: "note.filed",
+        taskId,
+        detail: { repo: author.repo, author: label, text, routed, persisted: persisted ?? false },
       })
-      return { ok: true, routed: true, persisted: persisted ?? false }
+      return { ok: true, routed, persisted: persisted ?? false }
     },
   },
   {

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -40,10 +40,18 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
         at: Date.now(),
         source: source ?? "dispatcher",
       })
+      // `clients` mirrors the RPC's own honesty note above: broadcast-only
+      // delivery can't be observed, so the event reports REACH (connection
+      // count; 0 = certainly nobody performed the paste), not a confirmation.
       ctx.plugins?.handleUiReport({
         kind: "message.delivered",
         taskId,
-        detail: { source: source ?? "dispatcher", ...(tabId !== undefined ? { tabId } : {}), length: text.length },
+        detail: {
+          source: source ?? "dispatcher",
+          ...(tabId !== undefined ? { tabId } : {}),
+          length: text.length,
+          clients: ctx.daemon.clientCount(),
+        },
       })
       // Report reach, don't just claim success. `session.deliver` is
       // broadcast-only — an attached client performs the paste — so with
@@ -225,10 +233,20 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
           source: "note",
         })
       }
+      // Text is capped: the envelope rides ROVE_PLUGIN_EVENT_JSON into every
+      // subscriber's spawn env — an unbounded note risks E2BIG. The durable
+      // store holds the full body; plugins read it back via note-list.
       ctx.plugins?.handleUiReport({
         kind: "note.filed",
         taskId,
-        detail: { repo: author.repo, author: label, text, routed, persisted: persisted ?? false },
+        detail: {
+          repo: author.repo,
+          author: label,
+          text: text.length > 512 ? `${text.slice(0, 512)}…` : text,
+          length: text.length,
+          routed,
+          persisted: persisted ?? false,
+        },
       })
       return { ok: true, routed, persisted: persisted ?? false }
     },

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -35,18 +35,17 @@
 
 import type { DaemonRpcClient } from "../client/rpc.ts"
 import type { DaemonActivityRegistry } from "./activity-registry.ts"
-import { ingestAgentTurnsBestEffort } from "./agent-turns-ingest.ts"
 import type { AgentTurnsStore } from "./agent-turns-store.ts"
 import type { AttentionInboxStore } from "./attention-inbox.ts"
 import type { AutomationsStore } from "./automations-store.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
-import { findAdoptableWorktree, matchTaskByCwd } from "./cwd-task.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import { objectPayload, optionalActivityDetail, optionalString, requireString } from "./handler-validators.ts"
 import { AGENT_TURN_HANDLERS } from "./handlers-agent-turns.ts"
 import { ATTENTION_HANDLERS } from "./handlers-attention.ts"
 import { AUTOMATION_HANDLERS } from "./handlers-automations.ts"
+import { ENGINE_REPORT_HANDLER } from "./handlers-engine-report.ts"
 import { ISSUE_HANDLERS } from "./handlers-issues.ts"
 import { TASK_HANDLERS } from "./handlers-task.ts"
 import { UI_HANDLERS } from "./handlers-ui.ts"
@@ -63,7 +62,6 @@ import {
   isProtocolCompatible,
   serializeTask,
 } from "./protocol.ts"
-import { scheduleQuotaResume } from "./quota-resume.ts"
 import type { QuotaUsageCache } from "./quota-usage-cache.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
 import type { TaskDeletionScheduler } from "./task-deletion-runner.ts"
@@ -346,145 +344,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
         return { events: ctx.engineEvents?.recent(taskId) ?? [] }
       },
     },
-    {
-      name: "engine.reportEvent",
-      async handle(payload, ctx) {
-        // A `kobe hook <verb>` process reporting a NORMALIZED engine activity
-        // event (the vendor-specific hook was already translated by the
-        // engine's hook adapter). The global hooks carry no task id — they
-        // report their `cwd`, which we map to a task by worktree path. Fold it
-        // into the task's transient activity state + broadcast on
-        // `engine-state`. Unknown kinds are ignored (forward-compat: a newer
-        // adapter, older daemon); an unmatched cwd (an unrelated repo, a
-        // project with no kobe task) is silently dropped.
-        const kind = requireString(payload, "kind")
-        if (!ctx.runtime.isEngineActivityKind(kind)) throw new Error(`unknown engine event kind: ${kind}`)
-        // `taskId` (legacy/direct) wins; otherwise resolve from `cwd`.
-        const explicitId = optionalString(payload, "taskId")
-        const cwd = optionalString(payload, "cwd")
-        // External-worktree sync (replaces the removed WorktreeCreate hook): a
-        // session starting in an unadopted worktree under a tracked repo's
-        // a managed worktree root is auto-adopted as a task, so the cwd then maps
-        // to it below. Gated to `session-start` to bound the work; the path
-        // check is git-free and `adoptWorktree` is idempotent + git-validated
-        // (a bogus dir just throws → caught → dropped).
-        if (!explicitId && cwd && kind === "session-start") {
-          const cand = findAdoptableWorktree(ctx.orch.listTasks(), cwd)
-          if (cand) {
-            try {
-              await ctx.orch.adoptWorktree({ repo: cand.repo, worktreePath: cand.worktreePath, ifExists: "return" })
-            } catch (err) {
-              logDaemonError("worktree-autosync", err)
-            }
-          }
-        }
-        const taskId = explicitId ?? (cwd ? matchTaskByCwd(ctx.orch.listTasks(), cwd) : undefined)
-        if (!taskId) return {} // unmatched cwd → drop
-        const detail = optionalActivityDetail(payload)
-        // Which engine tab the event came from — the inherited KOBE_TAB_ID env.
-        // Sessions outside a Kobe tab remain activity-only via the report below.
-        const tabId = optionalString(payload, "tabId")
-        // The engine's own session identity, from its hook payload (Claude
-        // pipes session_id/transcript_path). Optional + additive: an old
-        // `kobe hook` simply omits it.
-        const sessionId = optionalString(payload, "sessionId")
-        const transcriptPath = optionalString(payload, "transcriptPath")
-        const session = sessionId ? { id: sessionId, transcriptPath } : undefined
-        // Lifecycle-only kinds (tool/compact/subagent) skip the badge + inbox
-        // entirely — folding them into engine-state would broadcast every
-        // tool call to every client. They still reach plugins below.
-        const isStateKind = ctx.runtime.affectsActivityState(kind)
-        // The hook's `--engine` tag — read early so the activity registry's
-        // liveness probe can ask about the engine that actually reported
-        // (a custom wrapper id as task.vendor has no transcript store).
-        const vendor = optionalString(payload, "engine")
-        if (isStateKind) {
-          ctx.activity.report(taskId, kind, detail, tabId, session, vendor)
-          // A tab id makes the episode tab-precise; without one it is still
-          // recorded at TASK level (owner call 2026-08-10) — an engine the
-          // user typed into a bare shell inherits no KOBE_TAB_ID, and
-          // dropping its events is why such a session could finish without
-          // ever appearing in the Inbox. `explicitId` still gates: a
-          // cwd-matched task is a guess, not an identity.
-          if (explicitId) {
-            await ctx.inbox
-              .record(taskId, kind, detail, tabId ?? null)
-              .catch((err) => logDaemonError("attention-inbox-record", err))
-          }
-        }
-        // Per-task recent-events buffer (TUI event feed) + the low-frequency
-        // `engine.lifecycle` channel (sidebar compaction glyph / subagent mark).
-        ctx.engineEvents?.append(taskId, {
-          kind,
-          ...(tabId ? { tabId } : {}),
-          ...(vendor ? { vendor } : {}),
-          ...(detail ? { detail } : {}),
-          at: Date.now(),
-        })
-        if (
-          kind === "pre-compact" ||
-          kind === "post-compact" ||
-          kind === "subagent-start" ||
-          kind === "subagent-stop"
-        ) {
-          ctx.bus.publish("engine.lifecycle", { taskId, kind, ...(tabId ? { tabId } : {}), at: Date.now() })
-        }
-        // Plugin event hooks: every report becomes one agent-lifecycle event
-        // (docs/design/plugin-events.md); dispatch fans out only to plugins
-        // that declared the event.
-        ctx.plugins?.handleEngineReport({
-          kind,
-          taskId,
-          ...(detail ? { detail: detail as unknown as Record<string, unknown> } : {}),
-          ...(vendor ? { vendor } : {}),
-          ...(tabId ? { tabId } : {}),
-          ...(sessionId ? { sessionId } : {}),
-        })
-        // Per-turn telemetry (issue #32): a finished turn is the moment its
-        // records are complete on disk. Fire-and-forget — the transcript read
-        // must not delay the hook RPC, and losing a record is a telemetry
-        // gap, never an engine failure.
-        if (kind === "turn-complete") {
-          ingestAgentTurnsBestEffort(ctx.agentTurns, ctx.runtime, ctx.orch, {
-            taskId,
-            ...(tabId ? { tabId } : {}),
-            ...(vendor ? { vendor } : {}),
-            ...(transcriptPath ? { transcriptPath } : {}),
-          })
-        }
-        // Auto status flow (docs/design/web-kanban.md M5): an engine
-        // STARTING a turn on a backlog task means work began — a pure rule
-        // advances it to in_progress. (in_progress → in_review is the
-        // agent's own self-report via the injected status protocol, not a
-        // daemon rule.) Fire-and-forget; gated inside maybeAutoStart
-        // (opt-in state.json flag).
-        if (kind === "turn-start") {
-          ctx.runtime
-            .maybeAutoStart(ctx.orch, taskId)
-            .then((result) => {
-              if (result === "moved") {
-                console.log(`[status-rules] task ${taskId} auto-moved backlog → in_progress`)
-              }
-            })
-            .catch((err) => logDaemonError("status-rules", err))
-          // A turn actually started (the user resumed manually, or our own
-          // continue prompt landed) — any pending auto-resume is now stale.
-          if (ctx.orch.getTask(taskId)?.quotaResume) {
-            void ctx.orch.setQuotaResume(taskId, null).catch((err) => logDaemonError("quota-resume", err))
-          }
-        }
-        // Real subscription-quota limit → ask the engine's quota probe when
-        // the window resets and arm the durable auto-resume schedule.
-        // Fire-and-forget: the probe does network I/O and must not delay the
-        // hook RPC. `billing` is excluded — it needs a human, not a timer.
-        if (kind === "turn-failed" && detail?.failure === "rate_limit") {
-          void scheduleQuotaResume(ctx.orch, ctx.runtime, ctx.quotaUsage, taskId).catch((err) =>
-            logDaemonError("quota-resume", err),
-          )
-        }
-        return {}
-      },
-    },
+    ENGINE_REPORT_HANDLER,
   ]
   return new Map(entries.map((entry) => [entry.name, entry]))
 }

--- a/packages/kobe-daemon/src/daemon/pty-exit-watch.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-watch.ts
@@ -36,12 +36,18 @@ export function startPtyExitWatch(opts: PtyExitWatchOptions): () => void {
 
   const sweep = (): void => {
     const host = opts.plugins()
-    for (const record of Object.values(readPtyExitRecords(path))) {
+    // No host = don't mark records seen, so a fire is deferred, not lost.
+    // (Unreachable today — server.ts only starts the watch with a live host —
+    // but cheap insurance against a future caller.)
+    if (!host) return
+    const records = readPtyExitRecords(path)
+    for (const record of Object.values(records)) {
       if (seen.get(record.key) === record.at) continue
       seen.set(record.key, record.at)
-      if (!host) continue
       host.handleUiReport({ kind: "session.exited", ...exitReport(record) })
     }
+    // The file caps at 50 records; prune dropped keys so `seen` tracks it.
+    for (const key of seen.keys()) if (!(key in records)) seen.delete(key)
   }
 
   return startFileWatchTrigger({

--- a/packages/kobe-daemon/src/daemon/pty-exit-watch.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-watch.ts
@@ -1,0 +1,69 @@
+/**
+ * `session.exited` plugin events from the pty-host's death records.
+ *
+ * The PTY host is a separate process with no daemon-socket connection, but it
+ * already persists every abnormal child exit to `pty-exits.json`
+ * (`pty-exit-store.ts`). The daemon watches that file, diffs records by
+ * `key + at`, and fires one `session.exited` per NEW record — the only signal
+ * that exists when an engine CRASHES (its own `session.end` hook never runs).
+ *
+ * The first read after daemon start is baseline, mirroring the plugin event
+ * reducer's first-snapshot rule: pre-existing corpses must not re-fire.
+ */
+
+import type { PluginHost } from "../plugins/runtime.ts"
+import { startFileWatchTrigger } from "./file-watch-trigger.ts"
+import { defaultPtyExitsPath } from "./paths.ts"
+import { type PtyExitRecord, readPtyExitRecords } from "./pty-exit-store.ts"
+
+const DEBOUNCE_MS = 250
+/** Session key shape: `taskId::tabId` (pty registry convention). */
+const KEY_RE = /^(.+?)::(.+)$/
+
+export interface PtyExitWatchOptions {
+  readonly homeDir?: string
+  readonly plugins: () => Pick<PluginHost, "handleUiReport"> | null
+  readonly log?: (line: string) => void
+  /** Test seam. */
+  readonly path?: string
+}
+
+export function startPtyExitWatch(opts: PtyExitWatchOptions): () => void {
+  const path = opts.path ?? defaultPtyExitsPath(opts.homeDir)
+  // Baseline: everything already on disk predates this daemon.
+  const seen = new Map<string, string>()
+  for (const record of Object.values(readPtyExitRecords(path))) seen.set(record.key, record.at)
+
+  const sweep = (): void => {
+    const host = opts.plugins()
+    for (const record of Object.values(readPtyExitRecords(path))) {
+      if (seen.get(record.key) === record.at) continue
+      seen.set(record.key, record.at)
+      if (!host) continue
+      host.handleUiReport({ kind: "session.exited", ...exitReport(record) })
+    }
+  }
+
+  return startFileWatchTrigger({
+    filePath: path,
+    debounceMs: DEBOUNCE_MS,
+    onTrigger: sweep,
+    onError: (err) => opts.log?.(`pty-exit watch: ${String(err)}`),
+  })
+}
+
+function exitReport(record: PtyExitRecord): { taskId?: string; detail: Record<string, unknown> } {
+  const match = KEY_RE.exec(record.key)
+  return {
+    ...(match?.[1] ? { taskId: match[1] } : {}),
+    detail: {
+      key: record.key,
+      ...(match?.[2] ? { tabId: match[2] } : {}),
+      pid: record.pid,
+      code: record.code,
+      signal: record.signal,
+      exitedAt: record.at,
+      tail: record.tail,
+    },
+  }
+}

--- a/packages/kobe-daemon/src/daemon/quota-resume.ts
+++ b/packages/kobe-daemon/src/daemon/quota-resume.ts
@@ -83,15 +83,11 @@ export async function scheduleQuotaResume(
     requestedAt: new Date(now()).toISOString(),
   })
   logDaemonInfo("quota-resume", `armed task=${taskId} resumeAt=${resumeAt}`)
-  try {
-    plugins?.()?.handleUiReport({
-      kind: "quota.exhausted",
-      taskId,
-      detail: { vendor: task.vendor ?? runtime.defaultTaskVendor, resumeAt },
-    })
-  } catch {
-    /* plugin fan-out must never fail the schedule */
-  }
+  plugins?.()?.handleUiReport({
+    kind: "quota.exhausted",
+    taskId,
+    detail: { vendor: task.vendor ?? runtime.defaultTaskVendor, resumeAt },
+  })
 }
 
 /**
@@ -112,11 +108,7 @@ async function resumeDueTask(
     QUOTA_RESUME_CONTINUE_PROMPT,
   )
   logDaemonInfo("quota-resume", `resume task=${task.id} delivered=${delivered}`)
-  try {
-    plugins?.()?.handleUiReport({ kind: "quota.resumed", taskId: task.id, detail: { delivered } })
-  } catch {
-    /* plugin fan-out must never fail the resume */
-  }
+  plugins?.()?.handleUiReport({ kind: "quota.resumed", taskId: task.id, detail: { delivered } })
 }
 
 /**

--- a/packages/kobe-daemon/src/daemon/quota-resume.ts
+++ b/packages/kobe-daemon/src/daemon/quota-resume.ts
@@ -14,6 +14,7 @@
  *    watching is the whole point.
  */
 
+import type { PluginHost } from "../plugins/runtime.ts"
 import type { DaemonOrchestrator, DaemonTask, EngineQuotaUsage } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import type { QuotaUsageCache } from "./quota-usage-cache.ts"
@@ -62,6 +63,7 @@ export async function scheduleQuotaResume(
   cache: QuotaUsageCache,
   taskId: string,
   now: () => number = Date.now,
+  plugins?: () => Pick<PluginHost, "handleUiReport"> | null,
 ): Promise<void> {
   const task = orch.getTask(taskId)
   if (!task || !task.worktreePath || task.deletion) return
@@ -75,11 +77,21 @@ export async function scheduleQuotaResume(
   // A reset already in the past still gets a schedule (the next sweep tick
   // delivers) — the engine said "limited", so an immediate manual retry would
   // just fail again a bit earlier than ours.
+  const resumeAt = new Date(resetAtMs).toISOString()
   await orch.setQuotaResume(taskId, {
-    resumeAt: new Date(resetAtMs).toISOString(),
+    resumeAt,
     requestedAt: new Date(now()).toISOString(),
   })
-  logDaemonInfo("quota-resume", `armed task=${taskId} resumeAt=${new Date(resetAtMs).toISOString()}`)
+  logDaemonInfo("quota-resume", `armed task=${taskId} resumeAt=${resumeAt}`)
+  try {
+    plugins?.()?.handleUiReport({
+      kind: "quota.exhausted",
+      taskId,
+      detail: { vendor: task.vendor ?? runtime.defaultTaskVendor, resumeAt },
+    })
+  } catch {
+    /* plugin fan-out must never fail the schedule */
+  }
 }
 
 /**
@@ -88,13 +100,23 @@ export async function scheduleQuotaResume(
  * alive engine session) is logged and dropped — if the engine later comes
  * back and hits the limit again, a fresh schedule is armed by the hook path.
  */
-async function resumeDueTask(orch: DaemonOrchestrator, runtime: DaemonRuntimeAdapter, task: DaemonTask): Promise<void> {
+async function resumeDueTask(
+  orch: DaemonOrchestrator,
+  runtime: DaemonRuntimeAdapter,
+  task: DaemonTask,
+  plugins?: () => Pick<PluginHost, "handleUiReport"> | null,
+): Promise<void> {
   await orch.setQuotaResume(task.id, null)
   const delivered = await runtime.deliverPromptToLiveEngine(
     { id: task.id, vendor: task.vendor, command: task.command, worktreePath: task.worktreePath },
     QUOTA_RESUME_CONTINUE_PROMPT,
   )
   logDaemonInfo("quota-resume", `resume task=${task.id} delivered=${delivered}`)
+  try {
+    plugins?.()?.handleUiReport({ kind: "quota.resumed", taskId: task.id, detail: { delivered } })
+  } catch {
+    /* plugin fan-out must never fail the resume */
+  }
 }
 
 /**
@@ -107,6 +129,7 @@ export function startQuotaResumeRunner(
   runtime: DaemonRuntimeAdapter,
   tickMs: number = DEFAULT_QUOTA_RESUME_TICK_MS,
   now: () => number = Date.now,
+  plugins?: () => Pick<PluginHost, "handleUiReport"> | null,
 ): () => void {
   let sweeping = false
   const sweep = async (): Promise<void> => {
@@ -114,7 +137,7 @@ export function startQuotaResumeRunner(
     sweeping = true
     try {
       for (const task of dueQuotaResumes(orch.listTasks(), now())) {
-        await resumeDueTask(orch, runtime, task).catch((err) => logDaemonError("quota-resume", err))
+        await resumeDueTask(orch, runtime, task, plugins).catch((err) => logDaemonError("quota-resume", err))
       }
     } finally {
       sweeping = false

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -285,8 +285,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   // Plugin runtime: startup hooks + channel-derived event hooks (plugins/runtime.ts).
   const pluginHost = maybeStartPluginHost(bus, options, socketPath, (line) => logDaemonInfo("plugin-host", line))
   // session.exited plugin events off the pty-host's death records (the host
-  // is a separate process; the file is the channel). Only worth watching
-  // when a plugin host exists to receive them.
+  // is a separate process; the file is the channel — see pty-exit-watch.ts).
   const stopPtyExitWatch = pluginHost
     ? startPtyExitWatch({
         ...(options.homeDir ? { homeDir: options.homeDir } : {}),
@@ -333,8 +332,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       stopCollectors()
       ptyHold.stop()
       stopPtyExitWatch()
-      // Await: [[shutdown]] hooks run inside stop() with a bounded grace
-      // window; returning earlier lets the caller's process.exit orphan them.
+      // Awaited: [[shutdown]] hooks finish inside stop()'s bounded grace.
       await pluginHost?.stop()
       prompts.clear()
       activity.close()

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -333,7 +333,9 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       stopCollectors()
       ptyHold.stop()
       stopPtyExitWatch()
-      pluginHost?.stop()
+      // Await: [[shutdown]] hooks run inside stop() with a bounded grace
+      // window; returning earlier lets the caller's process.exit orphan them.
+      await pluginHost?.stop()
       prompts.clear()
       activity.close()
       // Hosted PTYs are deliberately NOT touched here: they live in the

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -43,6 +43,7 @@ import {
 } from "./paths.ts"
 import { PromptBroker } from "./prompt-broker.ts"
 import { type DaemonFrame, normalizeChannelFilter, serializeTask } from "./protocol.ts"
+import { startPtyExitWatch } from "./pty-exit-watch.ts"
 import { PtyLiveHold } from "./pty-live-hold.ts"
 import { QuotaUsageCache } from "./quota-usage-cache.ts"
 import type { DaemonServer, DaemonServerOptions } from "./server-options.ts"
@@ -274,12 +275,25 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       // over half this function); the sweep only reads it on a tick, long after
       // construction settles.
       link: () => selfLink,
+      // Same construction-order deferral: the plugin host starts right after
+      // the collectors, and the sweep only reads it on a tick.
+      plugins: () => pluginHost,
     },
     activity,
   )
 
   // Plugin runtime: startup hooks + channel-derived event hooks (plugins/runtime.ts).
   const pluginHost = maybeStartPluginHost(bus, options, socketPath, (line) => logDaemonInfo("plugin-host", line))
+  // session.exited plugin events off the pty-host's death records (the host
+  // is a separate process; the file is the channel). Only worth watching
+  // when a plugin host exists to receive them.
+  const stopPtyExitWatch = pluginHost
+    ? startPtyExitWatch({
+        ...(options.homeDir ? { homeDir: options.homeDir } : {}),
+        plugins: () => pluginHost,
+        log: (line) => logDaemonInfo("plugin-host", line),
+      })
+    : () => {}
 
   // Pending host-dialog prompts (`ui.prompt` ↔ `ui.promptReply`).
   const prompts = new PromptBroker()
@@ -318,6 +332,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       webServer = null
       stopCollectors()
       ptyHold.stop()
+      stopPtyExitWatch()
       pluginHost?.stop()
       prompts.clear()
       activity.close()

--- a/packages/kobe-daemon/src/plugins/events.ts
+++ b/packages/kobe-daemon/src/plugins/events.ts
@@ -4,18 +4,23 @@
  * The channels are STATE snapshots (last-value replay); plugin hooks want
  * edges. This reducer is fed every `bus.publish` and emits the transitions:
  *
- *   task.snapshot diff            → task.created / task.deleted
- *   task.jobs ensureWorktree done → worktree.created
- *   engine-state transitions      → agent.* (per task+tab, deduped)
+ *   task.snapshot diff       → task.created / task.deleted / task.changed /
+ *                              task.pr-changed / task.archived / worktree.created
+ *   engine-state transitions → agent.* (per task+tab, deduped)
  *
- * It is deliberately blind to the first snapshot after daemon start — replayed
- * state must not re-fire hooks for tasks that already existed.
+ * `worktree.created` is snapshot-derived (empty → non-empty worktreePath, or
+ * a task-kind row born with one) so EVERY materialization path fires it —
+ * lazy ensure, adopt, scratch-adopt — not just the ensureWorktree job that an
+ * earlier version keyed on. It is deliberately blind to the first snapshot
+ * after daemon start — replayed state must not re-fire hooks for tasks that
+ * already existed.
  */
 
 import type { ChannelEvent } from "../daemon/event-bus.ts"
 import type { ChannelPayloads } from "../daemon/protocol.ts"
 import type { SerializedTask } from "../daemon/protocol.ts"
 import type { PluginEventName } from "./manifest.ts"
+import { bornWithWorktree, diffTask } from "./task-diff.ts"
 
 export interface PluginEvent {
   readonly event: PluginEventName
@@ -108,8 +113,6 @@ export class PluginEventReducer {
     switch (event.channel) {
       case "task.snapshot":
         return this.reduceTasks((event.payload as ChannelPayloads["task.snapshot"]).tasks)
-      case "task.jobs":
-        return this.reduceJobs(event.payload as ChannelPayloads["task.jobs"])
       case "engine-state":
         return this.reduceEngine(event.payload as EngineState)
       default:
@@ -126,24 +129,44 @@ export class PluginEventReducer {
     const at = this.now()
     const out: PluginEvent[] = []
     for (const [id, task] of next) {
-      if (!prev.has(id)) out.push({ event: "task.created", taskId: id, task: taskContext(task), at })
+      const before = prev.get(id)
+      if (!before) {
+        out.push({ event: "task.created", taskId: id, task: taskContext(task), at })
+        // Adopt paths create the row WITH its worktree — same moment.
+        if (bornWithWorktree(task)) out.push({ event: "worktree.created", taskId: id, task: taskContext(task), at })
+        continue
+      }
+      const diff = diffTask(before, task)
+      if (!diff) continue
+      const ctx = taskContext(task)
+      if (diff.fields.length > 0) {
+        out.push({
+          event: "task.changed",
+          taskId: id,
+          task: ctx,
+          detail: { fields: diff.fields, from: diff.from, to: diff.to },
+          at,
+        })
+      }
+      if (diff.prChanged) {
+        out.push({
+          event: "task.pr-changed",
+          taskId: id,
+          task: ctx,
+          detail: {
+            ...(before.prStatus ? { from: before.prStatus } : {}),
+            ...(task.prStatus ? { to: task.prStatus } : {}),
+          },
+          at,
+        })
+      }
+      if (diff.archivedNow) out.push({ event: "task.archived", taskId: id, task: ctx, at })
+      if (diff.worktreeCreated) out.push({ event: "worktree.created", taskId: id, task: ctx, at })
     }
     for (const [id, task] of prev) {
       if (!next.has(id)) out.push({ event: "task.deleted", taskId: id, task: taskContext(task), at })
     }
     return out
-  }
-
-  private reduceJobs(payload: ChannelPayloads["task.jobs"]): PluginEvent[] {
-    if (payload.kind !== "ensureWorktree" || payload.phase !== "done") return []
-    return [
-      {
-        event: "worktree.created",
-        taskId: payload.taskId,
-        task: taskContext(this.tasks?.get(payload.taskId)),
-        at: this.now(),
-      },
-    ]
   }
 
   private reduceEngine(payload: EngineState): PluginEvent[] {

--- a/packages/kobe-daemon/src/plugins/events.ts
+++ b/packages/kobe-daemon/src/plugins/events.ts
@@ -154,8 +154,8 @@ export class PluginEventReducer {
           taskId: id,
           task: ctx,
           detail: {
-            ...(before.prStatus ? { from: before.prStatus } : {}),
-            ...(task.prStatus ? { to: task.prStatus } : {}),
+            ...(before.prStatus !== undefined ? { from: before.prStatus } : {}),
+            ...(task.prStatus !== undefined ? { to: task.prStatus } : {}),
           },
           at,
         })

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -407,11 +407,15 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
       const idt = identityRaw as Record<string, unknown>
       const opt = (key: string): string | undefined =>
         idt[key] === undefined ? undefined : asString(idt[key], `engines[${i}].identity.${key}`)
+      const productName = opt("product_name")
+      const shortName = opt("short_name")
+      const assistantName = opt("assistant_name")
+      const inputPlaceholder = opt("input_placeholder")
       identity = {
-        ...(opt("product_name") !== undefined ? { productName: opt("product_name") } : {}),
-        ...(opt("short_name") !== undefined ? { shortName: opt("short_name") } : {}),
-        ...(opt("assistant_name") !== undefined ? { assistantName: opt("assistant_name") } : {}),
-        ...(opt("input_placeholder") !== undefined ? { inputPlaceholder: opt("input_placeholder") } : {}),
+        ...(productName !== undefined ? { productName } : {}),
+        ...(shortName !== undefined ? { shortName } : {}),
+        ...(assistantName !== undefined ? { assistantName } : {}),
+        ...(inputPlaceholder !== undefined ? { inputPlaceholder } : {}),
       }
     }
     return {

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -98,6 +98,14 @@ export interface PluginEngine {
   readonly processNames?: readonly string[]
   /** Screen-state rules, first match wins (declare blocked before working). */
   readonly rules: readonly PluginEngineRule[]
+  /** Product identity for UI copy (composer placeholder, labels). Absent
+   *  fields fall back to `name`/id derivations. */
+  readonly identity?: {
+    readonly productName?: string
+    readonly shortName?: string
+    readonly assistantName?: string
+    readonly inputPlaceholder?: string
+  }
 }
 
 export interface PluginManifest {
@@ -109,6 +117,9 @@ export interface PluginManifest {
   readonly platforms?: readonly PluginPlatform[]
   readonly build: readonly PluginCommandSpec[]
   readonly startup: readonly PluginCommandSpec[]
+  /** Run at daemon stop (bounded — the host kills a hook that outlives its
+   *  grace window rather than delaying shutdown). */
+  readonly shutdown: readonly PluginCommandSpec[]
   readonly actions: readonly PluginAction[]
   readonly events: readonly PluginEventHook[]
   readonly panes: readonly PluginPane[]
@@ -258,6 +269,10 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
     command: asCommand(t.command, `startup[${i}].command`),
     platforms: asPlatforms(t.platforms, `startup[${i}].platforms`),
   }))
+  const shutdown = asTableArray(raw.shutdown, "shutdown").map((t, i) => ({
+    command: asCommand(t.command, `shutdown[${i}].command`),
+    platforms: asPlatforms(t.platforms, `shutdown[${i}].platforms`),
+  }))
 
   const actions = asTableArray(raw.actions, "actions").map((t, i) => {
     const actionId = asString(t.id, `actions[${i}].id`)
@@ -383,6 +398,22 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
         ...(lineRegex ? { lineRegex } : {}),
       }
     })
+    const identityRaw = t.identity
+    let identity: PluginEngine["identity"]
+    if (identityRaw !== undefined) {
+      if (typeof identityRaw !== "object" || identityRaw === null || Array.isArray(identityRaw)) {
+        fail(`engines[${i}].identity must be a table`)
+      }
+      const idt = identityRaw as Record<string, unknown>
+      const opt = (key: string): string | undefined =>
+        idt[key] === undefined ? undefined : asString(idt[key], `engines[${i}].identity.${key}`)
+      identity = {
+        ...(opt("product_name") !== undefined ? { productName: opt("product_name") } : {}),
+        ...(opt("short_name") !== undefined ? { shortName: opt("short_name") } : {}),
+        ...(opt("assistant_name") !== undefined ? { assistantName: opt("assistant_name") } : {}),
+        ...(opt("input_placeholder") !== undefined ? { inputPlaceholder: opt("input_placeholder") } : {}),
+      }
+    }
     return {
       id: engineId,
       name: asString(t.name, `engines[${i}].name`),
@@ -391,6 +422,7 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
         ? {}
         : { processNames: asCommand(t.process_names, `engines[${i}].process_names`) }),
       rules,
+      ...(identity ? { identity } : {}),
     }
   })
   const engineSeen = new Set<string>()
@@ -409,6 +441,7 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
       platforms,
       build,
       startup,
+      shutdown,
       actions,
       events,
       panes,

--- a/packages/kobe-daemon/src/plugins/runtime.ts
+++ b/packages/kobe-daemon/src/plugins/runtime.ts
@@ -42,6 +42,8 @@ interface LoadedPlugin {
 
 const OUTPUT_CAP = 8 * 1024
 const RELOAD_DEBOUNCE_MS = 150
+/** How long a [[shutdown]] hook may run before the host kills it. */
+const SHUTDOWN_GRACE_MS = 3_000
 
 /** Compose a host onto the daemon's bus: subscribe first, then start. */
 export function startPluginHost(
@@ -90,9 +92,18 @@ export class PluginHost {
   }
 
   stop(): void {
+    if (this.stopped) return
     this.stopped = true
     if (this.reloadTimer) clearTimeout(this.reloadTimer)
     this.watcher?.close()
+    // Shutdown hooks: bounded fire-and-forget — daemon close never waits on
+    // a plugin, and a hook that outlives the grace window is killed.
+    for (const plugin of this.plugins) {
+      for (const [i, hook] of plugin.manifest.shutdown.entries()) {
+        if (!supportsPlatform(hook, plugin.manifest, currentPluginPlatform())) continue
+        void this.run(plugin, hook, "shutdown", { ROVE_PLUGIN_EVENT: "shutdown" }, `shutdown[${i}]`, SHUTDOWN_GRACE_MS)
+      }
+    }
   }
 
   /** Feed every bus publish through here (server wires `bus.onPublish`). */
@@ -144,6 +155,22 @@ export class PluginHost {
       ...(report.detail ? { detail: report.detail } : {}),
       at: Date.now(),
     })
+  }
+
+  /** Fire one event at ONE plugin's matching hooks (registry transitions). */
+  private dispatchTo(plugin: LoadedPlugin, event: PluginEvent): void {
+    const platform = currentPluginPlatform()
+    for (const hook of plugin.manifest.events) {
+      if (hook.on !== event.event) continue
+      if (!supportsPlatform(hook, plugin.manifest, platform)) continue
+      void this.run(
+        plugin,
+        hook,
+        "event",
+        { ROVE_PLUGIN_EVENT: event.event, ROVE_PLUGIN_EVENT_JSON: JSON.stringify(event) },
+        hook.on,
+      )
+    }
   }
 
   private dispatch(event: PluginEvent): void {
@@ -200,8 +227,23 @@ export class PluginHost {
         if (this.reloadTimer) clearTimeout(this.reloadTimer)
         this.reloadTimer = setTimeout(() => {
           if (this.stopped) return
+          const before = new Map(this.plugins.map((p) => [p.manifest.id, p]))
           this.plugins = this.loadPlugins()
           this.opts.log?.(`plugin registry reloaded (${this.plugins.length} enabled)`)
+          // Registry transitions, delivered ONLY to the affected plugin: an
+          // enabled hook fires on the new load, a disabled hook on the last
+          // registration we still hold for it.
+          const at = Date.now()
+          for (const plugin of this.plugins) {
+            if (!before.has(plugin.manifest.id)) {
+              this.dispatchTo(plugin, { event: "plugin.enabled", detail: { pluginId: plugin.manifest.id }, at })
+            }
+          }
+          for (const [id, plugin] of before) {
+            if (!this.plugins.some((p) => p.manifest.id === id)) {
+              this.dispatchTo(plugin, { event: "plugin.disabled", detail: { pluginId: id }, at })
+            }
+          }
         }, RELOAD_DEBOUNCE_MS)
       })
     } catch (err) {
@@ -212,9 +254,10 @@ export class PluginHost {
   private async run(
     plugin: LoadedPlugin,
     spec: PluginCommandSpec,
-    kind: "startup" | "event",
+    kind: "startup" | "event" | "shutdown",
     extraEnv: Record<string, string>,
     label: string,
+    killAfterMs?: number,
   ): Promise<void> {
     const id = plugin.manifest.id
     const startedAt = Date.now()
@@ -252,6 +295,11 @@ export class PluginHost {
         exitCode = code
         resolve()
       })
+      if (killAfterMs !== undefined) {
+        const killer = setTimeout(() => child.kill("SIGKILL"), killAfterMs)
+        killer.unref?.()
+        child.on("close", () => clearTimeout(killer))
+      }
     })
     const record = {
       at: startedAt,

--- a/packages/kobe-daemon/src/plugins/runtime.ts
+++ b/packages/kobe-daemon/src/plugins/runtime.ts
@@ -91,25 +91,44 @@ export class PluginHost {
     this.watchRegistry()
   }
 
-  stop(): void {
+  /**
+   * Stop the host and run every `[[shutdown]]` hook. Resolves once each hook
+   * has exited or been SIGKILLed at the grace deadline — the caller (daemon
+   * close) MUST await it, or `process.exit` destroys the grace timers and the
+   * hook children become unbounded orphans. Total wait is bounded by
+   * {@link SHUTDOWN_GRACE_MS}; a host with no shutdown hooks resolves
+   * immediately.
+   */
+  async stop(): Promise<void> {
     if (this.stopped) return
     this.stopped = true
     if (this.reloadTimer) clearTimeout(this.reloadTimer)
     this.watcher?.close()
-    // Shutdown hooks: bounded fire-and-forget — daemon close never waits on
-    // a plugin, and a hook that outlives the grace window is killed.
+    const runs: Promise<void>[] = []
     for (const plugin of this.plugins) {
       for (const [i, hook] of plugin.manifest.shutdown.entries()) {
         if (!supportsPlatform(hook, plugin.manifest, currentPluginPlatform())) continue
-        void this.run(plugin, hook, "shutdown", { ROVE_PLUGIN_EVENT: "shutdown" }, `shutdown[${i}]`, SHUTDOWN_GRACE_MS)
+        runs.push(
+          this.run(plugin, hook, "shutdown", { ROVE_PLUGIN_EVENT: "shutdown" }, `shutdown[${i}]`, SHUTDOWN_GRACE_MS),
+        )
       }
     }
+    await Promise.all(runs)
   }
 
   /** Feed every bus publish through here (server wires `bus.onPublish`). */
   handleChannel(event: ChannelEvent): void {
     if (this.stopped) return
-    for (const derived of this.reducer.reduce(event)) this.dispatch(derived)
+    // Guarded: the bus sink loop and the orch.subscribeTasks callback have no
+    // catch of their own, so a throw here (a pathological task field breaking
+    // the diff's deep-compare) would kill the whole snapshot pipeline — the
+    // PTY sweep included — on every subsequent publish. One bad diff must
+    // cost one event batch, never the channel.
+    try {
+      for (const derived of this.reducer.reduce(event)) this.dispatch(derived)
+    } catch (err) {
+      this.opts.log?.(`plugin event reduce failed on ${event.channel} — ${String(err)}`)
+    }
   }
 
   /** Direct feed from `ui.reportEvent` — TUI-originated product events
@@ -120,12 +139,19 @@ export class PluginHost {
     readonly detail?: Record<string, unknown>
   }): void {
     if (this.stopped) return
-    this.dispatch({
-      event: report.kind,
-      ...(report.taskId ? { taskId: report.taskId, task: this.reducer.contextFor(report.taskId) } : {}),
-      ...(report.detail ? { detail: report.detail } : {}),
-      at: Date.now(),
-    })
+    // Guarded here, once, so no reporting call site (RPC handlers, runners)
+    // needs its own try/catch — a pathological detail payload breaking
+    // JSON.stringify must never fail the operation that reported it.
+    try {
+      this.dispatch({
+        event: report.kind,
+        ...(report.taskId ? { taskId: report.taskId, task: this.reducer.contextFor(report.taskId) } : {}),
+        ...(report.detail ? { detail: report.detail } : {}),
+        at: Date.now(),
+      })
+    } catch (err) {
+      this.opts.log?.(`plugin ui-report dispatch failed for ${report.kind} — ${String(err)}`)
+    }
   }
 
   /**
@@ -145,16 +171,21 @@ export class PluginHost {
     if (this.stopped) return
     const event = lifecycleEventFor(report.kind, report.detail as { waiting?: string } | undefined)
     if (!event) return
-    this.dispatch({
-      event,
-      taskId: report.taskId,
-      task: this.reducer.contextFor(report.taskId),
-      ...(report.vendor ? { vendor: report.vendor } : {}),
-      ...(report.tabId ? { tabId: report.tabId } : {}),
-      ...(report.sessionId ? { sessionId: report.sessionId } : {}),
-      ...(report.detail ? { detail: report.detail } : {}),
-      at: Date.now(),
-    })
+    // Same single-site guard as handleUiReport.
+    try {
+      this.dispatch({
+        event,
+        taskId: report.taskId,
+        task: this.reducer.contextFor(report.taskId),
+        ...(report.vendor ? { vendor: report.vendor } : {}),
+        ...(report.tabId ? { tabId: report.tabId } : {}),
+        ...(report.sessionId ? { sessionId: report.sessionId } : {}),
+        ...(report.detail ? { detail: report.detail } : {}),
+        at: Date.now(),
+      })
+    } catch (err) {
+      this.opts.log?.(`plugin engine-report dispatch failed for ${event} — ${String(err)}`)
+    }
   }
 
   /** Fire one event at ONE plugin's matching hooks (registry transitions). */

--- a/packages/kobe-daemon/src/plugins/task-diff.ts
+++ b/packages/kobe-daemon/src/plugins/task-diff.ts
@@ -1,0 +1,85 @@
+/**
+ * Field-level task-snapshot diff → product plugin events.
+ *
+ * Every task mutation — whatever RPC, collector, or orchestrator path made it
+ * — funnels through the store and republishes `task.snapshot`, so diffing
+ * consecutive snapshots is the ONE place that observes every change. This is
+ * what fixes the historical drops: archive-via-worktree-removal, archive from
+ * `land --then-archive`, and worktree materialization via adopt all bypassed
+ * the RPC handlers that used to emit events.
+ *
+ * Emitted per changed task:
+ *   - `task.changed`     — any watched field changed (`detail.fields/from/to`)
+ *   - `task.pr-changed`  — prStatus changed (its own event, not in `fields`)
+ *   - `task.archived`    — archived flipped false→true (restores don't fire)
+ *   - `worktree.created` — a `task`-kind row gained a worktree path (lazy
+ *     ensure, adopt, and scratch-adopt all land here; main/dir tasks reuse
+ *     user-owned directories and never "materialize" one)
+ */
+
+import type { SerializedTask } from "../daemon/protocol.ts"
+
+/** Fields worth an event. Excluded on purpose: `position` (drag ordering
+ *  noise), `updatedAt`/`createdAt` (ride every change), `quotaResume`
+ *  (the quota.* events cover it), `deletion` (task.deleted covers it). */
+const WATCHED_FIELDS = [
+  "title",
+  "branch",
+  "worktreePath",
+  "status",
+  "archived",
+  "pinned",
+  "vendor",
+  "command",
+  "modelEffort",
+  "linkedWorkItem",
+  "scratch",
+] as const
+
+export type WatchedTaskField = (typeof WATCHED_FIELDS)[number]
+
+export interface TaskFieldDiff {
+  readonly fields: readonly WatchedTaskField[]
+  readonly from: Record<string, unknown>
+  readonly to: Record<string, unknown>
+  readonly archivedNow: boolean
+  readonly prChanged: boolean
+  readonly worktreeCreated: boolean
+}
+
+function same(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return a == null && b == null
+  if (typeof a === "object" || typeof b === "object") return JSON.stringify(a) === JSON.stringify(b)
+  return false
+}
+
+/** Diff one task across two snapshots; null when nothing watched changed. */
+export function diffTask(prev: SerializedTask, next: SerializedTask): TaskFieldDiff | null {
+  const fields: WatchedTaskField[] = []
+  const from: Record<string, unknown> = {}
+  const to: Record<string, unknown> = {}
+  for (const field of WATCHED_FIELDS) {
+    const a = prev[field]
+    const b = next[field]
+    if (same(a, b)) continue
+    fields.push(field)
+    if (a !== undefined) from[field] = a
+    if (b !== undefined) to[field] = b
+  }
+  const prChanged = !same(prev.prStatus, next.prStatus)
+  if (fields.length === 0 && !prChanged) return null
+  return {
+    fields,
+    from,
+    to,
+    archivedNow: !prev.archived && next.archived,
+    prChanged,
+    worktreeCreated: next.kind === "task" && !prev.worktreePath && !!next.worktreePath,
+  }
+}
+
+/** `worktree.created` for a task BORN with a worktree (adopt paths). */
+export function bornWithWorktree(task: SerializedTask): boolean {
+  return task.kind === "task" && !!task.worktreePath
+}

--- a/packages/kobe-daemon/src/plugins/task-diff.ts
+++ b/packages/kobe-daemon/src/plugins/task-diff.ts
@@ -54,6 +54,21 @@ function same(a: unknown, b: unknown): boolean {
   return false
 }
 
+/**
+ * PR-status compare with the poller's own semantics (`samePrStatus` in
+ * kobe/monitor/pr-status.ts, which this package cannot import): the
+ * per-poll bookkeeping fields must not read as change, or a second writer
+ * would fire `task.pr-changed` on every tick.
+ */
+function samePr(a: unknown, b: unknown): boolean {
+  const strip = (v: unknown): unknown => {
+    if (v == null || typeof v !== "object" || Array.isArray(v)) return v
+    const { lastCheckedAt: _a, lastError: _b, ...rest } = v as Record<string, unknown>
+    return rest
+  }
+  return same(strip(a), strip(b))
+}
+
 /** Diff one task across two snapshots; null when nothing watched changed. */
 export function diffTask(prev: SerializedTask, next: SerializedTask): TaskFieldDiff | null {
   const fields: WatchedTaskField[] = []
@@ -67,7 +82,7 @@ export function diffTask(prev: SerializedTask, next: SerializedTask): TaskFieldD
     if (a !== undefined) from[field] = a
     if (b !== undefined) to[field] = b
   }
-  const prChanged = !same(prev.prStatus, next.prStatus)
+  const prChanged = !samePr(prev.prStatus, next.prStatus)
   if (fields.length === 0 && !prChanged) return null
   return {
     fields,

--- a/packages/kobe-plugin-sdk/src/contract.ts
+++ b/packages/kobe-plugin-sdk/src/contract.ts
@@ -12,10 +12,27 @@ export const PLUGIN_EVENT_NAMES = [
   // Product layer
   "task.created",
   "task.deleted",
+  "task.changed",
   "task.landed",
   "task.archived",
+  "task.pr-changed",
   "worktree.created",
   "issue.changed",
+  "note.filed",
+  "message.delivered",
+  "attention.handled",
+  // Scheduled automations (one event per run outcome)
+  "automation.dispatched",
+  "automation.skipped",
+  "automation.failed",
+  // Quota auto-resume lifecycle
+  "quota.exhausted",
+  "quota.resumed",
+  // Hosted PTY child died abnormally (clean exits are never recorded)
+  "session.exited",
+  // Plugin registry transitions (delivered only to the affected plugin)
+  "plugin.enabled",
+  "plugin.disabled",
   // Reduced activity-state transitions (deduped per task+tab)
   "agent.turn-complete",
   "agent.permission-needed",

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -135,6 +135,59 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
     },
   },
   {
+    name: "engine-report",
+    summary:
+      "Report a normalized engine-activity verb for a task — the public face of the same engine.reportEvent RPC the built-in hook adapters use. Lets a plugin-contributed engine (or any wrapper script) drive the sidebar badge, attention inbox, and plugin event stream without a built-in hook adapter. Kinds: session-start|turn-start|turn-complete|turn-failed|turn-interrupted|awaiting-input|session-end (state kinds) plus tool-pre|tool-post|tool-failed|pre-compact|post-compact|subagent-start|subagent-stop (plugin-only).",
+    flags: [
+      F.taskId(false),
+      {
+        name: "kind",
+        type: "string",
+        required: true,
+        placeholder: "KIND",
+        description: "Normalized activity verb (see summary). Unknown kinds are rejected.",
+      },
+      {
+        name: "engine",
+        type: "string",
+        placeholder: "ID",
+        description: "Engine id producing the report (a plugin engine id, or a built-in vendor).",
+      },
+      {
+        name: "tab",
+        type: "string",
+        placeholder: "TAB",
+        description: "Terminal tab id the session runs in (defaults to $ROVE_TAB_ID / $KOBE_TAB_ID).",
+      },
+      {
+        name: "detail",
+        type: "string",
+        placeholder: "JSON",
+        description: 'Optional detail JSON, e.g. \'{"failure":"rate_limit"}\' or \'{"waiting":"input"}\'.',
+      },
+    ],
+    handler: async (ctx) => {
+      const taskId = ctx.args.str("task-id") ?? process.env.ROVE_TASK_ID ?? process.env.KOBE_TASK_ID
+      const tabId = ctx.args.str("tab") ?? process.env.ROVE_TAB_ID ?? process.env.KOBE_TAB_ID
+      const detailRaw = ctx.args.str("detail")
+      let detail: unknown
+      if (detailRaw !== undefined) {
+        try {
+          detail = JSON.parse(detailRaw)
+        } catch {
+          throw new Error("--detail must be valid JSON")
+        }
+      }
+      return simpleRpc(ctx, "engine.reportEvent", {
+        kind: ctx.args.str("kind"),
+        ...(taskId ? { taskId } : { cwd: process.cwd() }),
+        ...(ctx.args.str("engine") ? { engine: ctx.args.str("engine") } : {}),
+        ...(tabId ? { tabId } : {}),
+        ...(detail !== undefined ? { detail } : {}),
+      })
+    },
+  },
+  {
     name: "set-active",
     summary: "Set the shared active task (the focus every Tasks pane highlights). Pass --none to clear.",
     flags: [

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -83,7 +83,7 @@ export const VERB_GROUPS: Readonly<Record<string, readonly string[]>> = {
   discover: ["schema", "engine-list"],
   read: ["list", "get-task", "collect", "digest", "agent-turns", "pty-list", "read-output", "inspect"],
   create: ["add"],
-  drive: ["send", "dispatch", "note", "note-list", "set-active", "pane-open", "pane-close", "notify"],
+  drive: ["send", "dispatch", "note", "note-list", "set-active", "pane-open", "pane-close", "notify", "engine-report"],
   edit: ["rename", "set-branch", "set-command", "set-status"],
   issues: ["issue-list", "issue-create", "issue-set-status", "issue-update"],
   workitems: ["workitem-list", "workitem-start"],

--- a/packages/kobe/src/engine/contrib-engines.ts
+++ b/packages/kobe/src/engine/contrib-engines.ts
@@ -18,6 +18,7 @@
  * classifier's vocabulary. Blocked rules go before working rules.
  */
 
+import type { EngineIdentity } from "@/types/engine"
 import type { EngineRegistryEntry } from "./registry.ts"
 import type { EngineScreenManifest } from "./screen-state.ts"
 
@@ -26,6 +27,8 @@ export interface ContribEngineSpec {
   readonly defaultCommand: readonly string[]
   readonly processNames?: readonly string[]
   readonly screenManifest: EngineScreenManifest
+  /** Plugin-declared product identity (composer placeholder etc.). */
+  readonly identity?: EngineIdentity
 }
 
 /**
@@ -144,5 +147,6 @@ export function contribEngineEntry(id: string, base: EngineRegistryEntry): Engin
     defaultCommand: spec.defaultCommand,
     ...(spec.processNames ? { processNames: spec.processNames } : {}),
     screenManifest: spec.screenManifest,
+    ...(spec.identity ? { identity: spec.identity } : {}),
   }
 }

--- a/packages/kobe/src/engine/plugin-engines.ts
+++ b/packages/kobe/src/engine/plugin-engines.ts
@@ -24,11 +24,21 @@ export function loadPluginEngines(): readonly string[] {
       try {
         const { manifest } = readPluginManifest(entry.root)
         for (const engine of manifest.engines) {
+          // Identity falls back per-field to the engine's display name — a
+          // plugin declaring nothing still gets sensible composer copy.
+          const identity = {
+            vendorId: engine.id,
+            productName: engine.identity?.productName ?? engine.name,
+            shortName: engine.identity?.shortName ?? engine.name,
+            assistantName: engine.identity?.assistantName ?? engine.name,
+            inputPlaceholder: engine.identity?.inputPlaceholder ?? `Ask ${engine.identity?.shortName ?? engine.name}…`,
+          }
           const ok = registerPluginEngine(engine.id, {
             displayName: engine.name,
             defaultCommand: engine.command,
             ...(engine.processNames ? { processNames: engine.processNames } : {}),
             screenManifest: { rules: engine.rules },
+            identity,
           })
           if (ok) registered.push(engine.id)
         }

--- a/packages/kobe/test/cli/api-cmd.test.ts
+++ b/packages/kobe/test/cli/api-cmd.test.ts
@@ -205,6 +205,7 @@ describe("API surface (full CRUD)", () => {
       "pane-close",
       "notify",
       "prompt",
+      "engine-report",
       "set-active",
       "feedback",
       "issue-list",

--- a/packages/kobe/test/daemon/agent-turns.test.ts
+++ b/packages/kobe/test/daemon/agent-turns.test.ts
@@ -109,14 +109,14 @@ describe("ingestAgentTurns", () => {
     const { store } = await createStore()
     const { runtime, orch, asked } = deps()
 
-    expect(
-      await ingestAgentTurns(store, runtime, orch, {
-        taskId: "task-1",
-        tabId: "tab-2",
-        vendor: "claude",
-        transcriptPath: "/t.jsonl",
-      }),
-    ).toBe(1)
+    const result = await ingestAgentTurns(store, runtime, orch, {
+      taskId: "task-1",
+      tabId: "tab-2",
+      vendor: "claude",
+      transcriptPath: "/t.jsonl",
+    })
+    expect(result.recorded).toBe(1)
+    expect(result.latest).toMatchObject({ id: engineTurn.id })
     expect(asked).toEqual([{ vendor: "claude", path: "/t.jsonl" }])
     expect(store.list()).toEqual([{ ...engineTurn, taskId: "task-1", tabId: "tab-2", vendor: "claude", repo: "/repo" }])
   })
@@ -124,14 +124,16 @@ describe("ingestAgentTurns", () => {
   it("no transcript path and no resolvable vendor are both no-ops", async () => {
     const { store } = await createStore()
     const { runtime, orch, asked } = deps()
-    expect(await ingestAgentTurns(store, runtime, orch, { taskId: "task-1" })).toBe(0)
+    expect((await ingestAgentTurns(store, runtime, orch, { taskId: "task-1" })).recorded).toBe(0)
 
     const vendorless = deps(undefined, { repo: "/repo" })
     expect(
-      await ingestAgentTurns(store, vendorless.runtime, vendorless.orch, {
-        taskId: "task-1",
-        transcriptPath: "/t.jsonl",
-      }),
+      (
+        await ingestAgentTurns(store, vendorless.runtime, vendorless.orch, {
+          taskId: "task-1",
+          transcriptPath: "/t.jsonl",
+        })
+      ).recorded,
     ).toBe(0)
     expect(asked).toEqual([])
     expect(store.list()).toEqual([])

--- a/packages/kobe/test/daemon/plugin-event-emits.test.ts
+++ b/packages/kobe/test/daemon/plugin-event-emits.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The new plugin-event emit sites, each asserted from its real entry point:
+ * the RPC handlers (`note.filed`, `message.delivered`, `attention.handled`),
+ * the automation runner (`automation.*`), and the quota-resume scheduler
+ * (`quota.exhausted` / `quota.resumed`). Event NAME + detail shape are the
+ * contract plugins subscribe against.
+ */
+
+import { runAutomationOnce, sweepAutomations } from "@sma1lboy/kobe-daemon/daemon/automation-runner"
+import type { AutomationsStore } from "@sma1lboy/kobe-daemon/daemon/automations-store"
+import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { scheduleQuotaResume } from "@sma1lboy/kobe-daemon/daemon/quota-resume"
+import type { QuotaUsageCache } from "@sma1lboy/kobe-daemon/daemon/quota-usage-cache"
+import {
+  type DaemonHandlerContext,
+  createDaemonHandlerRegistry,
+  dispatchDaemonRequest,
+} from "@sma1lboy/kobe-daemon/daemon/server"
+import { describe, expect, it } from "vitest"
+import { fakeCtx } from "./handler-test-context.ts"
+
+function dispatch(name: DaemonRequestName, payload: unknown, ctx: DaemonHandlerContext): Promise<unknown> {
+  return dispatchDaemonRequest(createDaemonHandlerRegistry(), name, payload, ctx)
+}
+
+type Report = { kind: string; taskId?: string; detail?: Record<string, unknown> }
+
+function withPluginSink(ctx: DaemonHandlerContext): Report[] {
+  const seen: Report[] = []
+  ;(ctx as { plugins?: unknown }).plugins = {
+    handleEngineReport: () => {},
+    handleUiReport: (r: Report) => seen.push(r),
+  }
+  return seen
+}
+
+const TASK = { id: "t1", repo: "/repo", title: "Task One", archived: false }
+
+describe("handler emit sites", () => {
+  it("note.file fires note.filed with truncated text + length", async () => {
+    const long = "x".repeat(600)
+    const { ctx } = fakeCtx({ getTask: () => TASK, listTasks: () => [TASK] })
+    const seen = withPluginSink(ctx)
+    await dispatch("note.file", { taskId: "t1", text: long }, ctx)
+    expect(seen).toEqual([
+      {
+        kind: "note.filed",
+        taskId: "t1",
+        detail: {
+          repo: "/repo",
+          author: "Task One",
+          text: `${"x".repeat(512)}…`,
+          length: 600,
+          routed: false,
+          persisted: true,
+        },
+      },
+    ])
+  })
+
+  it("session.deliver fires message.delivered with reach, not a delivery claim", async () => {
+    const { ctx } = fakeCtx({ getTask: () => TASK })
+    const seen = withPluginSink(ctx)
+    await dispatch("session.deliver", { taskId: "t1", text: "hello", tabId: "tab-2" }, ctx)
+    expect(seen).toEqual([
+      {
+        kind: "message.delivered",
+        taskId: "t1",
+        detail: { source: "dispatcher", tabId: "tab-2", length: 5, clients: 1 },
+      },
+    ])
+  })
+
+  it("attention.dismiss and attention.read both fire attention.handled", async () => {
+    const { ctx } = fakeCtx()
+    const seen = withPluginSink(ctx)
+    await dispatch("attention.dismiss", { taskId: "t1", tabId: "tab-2" }, ctx)
+    await dispatch("attention.read", { taskId: "t1", at: 42 }, ctx)
+    expect(seen).toEqual([
+      { kind: "attention.handled", taskId: "t1", detail: { how: "dismissed", tabId: "tab-2" } },
+      { kind: "attention.handled", taskId: "t1", detail: { how: "read" } },
+    ])
+  })
+})
+
+describe("automation runner emit sites", () => {
+  const automation = {
+    id: "a1",
+    name: "audit",
+    repo: "/repo",
+    prompt: "p",
+    schedule: "0 9 * * *",
+    enabled: true,
+    createdAt: new Date(0).toISOString(),
+    missedRunGraceMinutes: 30,
+    nextRunAt: new Date(0).toISOString(),
+  }
+
+  function deps(overrides: Record<string, unknown> = {}) {
+    const seen: Report[] = []
+    const runs: unknown[] = []
+    return {
+      seen,
+      runs,
+      deps: {
+        store: {
+          recordRun: async (r: unknown) => void runs.push(r),
+          list: () => [automation],
+          advanceNextRun: async () => {},
+        } as unknown as AutomationsStore,
+        orch: { createTask: async () => ({ id: "task-9" }) },
+        runtime: { startTaskSessionWithPrompt: async () => true },
+        link: (() => ({})) as never,
+        plugins: () => ({ handleUiReport: (r: Report) => seen.push(r) }),
+        ...overrides,
+      },
+    }
+  }
+
+  it("a dispatched run fires automation.dispatched with the run detail", async () => {
+    const { seen, deps: d } = deps()
+    await runAutomationOnce(d as never, automation as never, { scheduledFor: 60_000, trigger: "manual" })
+    expect(seen).toEqual([
+      {
+        kind: "automation.dispatched",
+        taskId: "task-9",
+        detail: {
+          automationId: "a1",
+          name: "audit",
+          repo: "/repo",
+          status: "dispatched",
+          trigger: "manual",
+          scheduledFor: new Date(60_000).toISOString(),
+        },
+      },
+    ])
+  })
+
+  it("a failed engine start fires automation.failed", async () => {
+    const { seen, deps: d } = deps({ runtime: { startTaskSessionWithPrompt: async () => false } })
+    await runAutomationOnce(d as never, automation as never, { scheduledFor: 0, trigger: "manual" })
+    expect(seen[0]).toMatchObject({
+      kind: "automation.failed",
+      taskId: "task-9",
+      detail: { status: "dispatch_failed", error: "engine session did not start" },
+    })
+  })
+
+  it("a missed occurrence fires automation.skipped", async () => {
+    const { seen, deps: d } = deps()
+    // now far past the grace window relative to the last cron occurrence
+    await sweepAutomations({ ...(d as object), now: () => Date.parse("2026-01-10T12:00:00Z") } as never)
+    expect(seen[0]).toMatchObject({ kind: "automation.skipped", detail: { status: "skipped_missed" } })
+  })
+})
+
+describe("quota-resume emit sites", () => {
+  it("arming fires quota.exhausted with vendor + resumeAt", async () => {
+    const seen: Report[] = []
+    const resetsAt = Date.now() + 60_000
+    const orch = {
+      getTask: () => ({ id: "t1", vendor: "claude", worktreePath: "/wt" }),
+      setQuotaResume: async () => {},
+    }
+    const cache = {
+      get: async () => ({ windows: [{ percent: 100, resetsAt }] }),
+    } as unknown as QuotaUsageCache
+    await scheduleQuotaResume(orch as never, { defaultTaskVendor: "claude" } as never, cache, "t1", Date.now, () => ({
+      handleUiReport: (r: Report) => seen.push(r),
+    }))
+    expect(seen).toEqual([
+      {
+        kind: "quota.exhausted",
+        taskId: "t1",
+        detail: { vendor: "claude", resumeAt: new Date(resetsAt).toISOString() },
+      },
+    ])
+  })
+})

--- a/packages/kobe/test/daemon/pty-exit-watch.test.ts
+++ b/packages/kobe/test/daemon/pty-exit-watch.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { recordPtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
+import { startPtyExitWatch } from "@sma1lboy/kobe-daemon/daemon/pty-exit-watch"
+import { afterEach, describe, expect, it } from "vitest"
+
+const dirs: string[] = []
+function tmp(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-pty-exit-watch-"))
+  dirs.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+async function waitFor(predicate: () => boolean, ms = 5_000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > ms) throw new Error("timed out")
+    await new Promise((r) => setTimeout(r, 25))
+  }
+}
+
+function exitInfo(key: string, at: string) {
+  return { key, pid: 42, exit: { code: 1, signal: null, at }, tail: "boom\n" }
+}
+
+describe("startPtyExitWatch", () => {
+  it("fires session.exited for NEW records only, with parsed task/tab", async () => {
+    const path = join(tmp(), "pty-exits.json")
+    // Pre-existing corpse — baseline, must not fire.
+    recordPtyExit(exitInfo("old-task::tab-1", "2026-01-01T00:00:00.000Z"), path)
+
+    const reports: { kind: string; taskId?: string; detail?: Record<string, unknown> }[] = []
+    const stop = startPtyExitWatch({
+      path,
+      plugins: () => ({ handleUiReport: (r) => reports.push(r) }),
+    })
+    try {
+      recordPtyExit(exitInfo("task-9::tab-3", "2026-01-02T00:00:00.000Z"), path)
+      await waitFor(() => reports.length > 0)
+      expect(reports).toEqual([
+        {
+          kind: "session.exited",
+          taskId: "task-9",
+          detail: {
+            key: "task-9::tab-3",
+            tabId: "tab-3",
+            pid: 42,
+            code: 1,
+            signal: null,
+            exitedAt: "2026-01-02T00:00:00.000Z",
+            tail: ["boom"],
+          },
+        },
+      ])
+      // Rewriting the SAME record (same key+at) must not re-fire.
+      recordPtyExit(exitInfo("task-9::tab-3", "2026-01-02T00:00:00.000Z"), path)
+      await new Promise((r) => setTimeout(r, 400))
+      expect(reports.length).toBe(1)
+    } finally {
+      stop()
+    }
+  })
+})

--- a/packages/kobe/test/engine/plugin-engines-load.test.ts
+++ b/packages/kobe/test/engine/plugin-engines-load.test.ts
@@ -17,7 +17,8 @@ function tmp(prefix: string): string {
 const savedHome = process.env.ROVE_HOME_DIR
 afterEach(() => {
   clearPluginEngines()
-  if (savedHome === undefined) delete process.env.ROVE_HOME_DIR
+  // Assigning undefined would store the string "undefined" — a real delete.
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, "ROVE_HOME_DIR")
   else process.env.ROVE_HOME_DIR = savedHome
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
 })

--- a/packages/kobe/test/engine/plugin-engines-load.test.ts
+++ b/packages/kobe/test/engine/plugin-engines-load.test.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { savePluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
+import { afterEach, describe, expect, it } from "vitest"
+import { clearPluginEngines } from "../../src/engine/contrib-engines.ts"
+import { loadPluginEngines } from "../../src/engine/plugin-engines.ts"
+import { engineEntry } from "../../src/engine/registry.ts"
+
+const dirs: string[] = []
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+
+const savedHome = process.env.ROVE_HOME_DIR
+afterEach(() => {
+  clearPluginEngines()
+  if (savedHome === undefined) delete process.env.ROVE_HOME_DIR
+  else process.env.ROVE_HOME_DIR = savedHome
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function homeWith(plugins: { id: string; root: string; enabled?: boolean }[]): string {
+  const home = tmp("kobe-engines-home-")
+  mkdirSync(join(home, ".rove"), { recursive: true })
+  savePluginRegistry(
+    {
+      plugins: plugins.map((p) => ({
+        id: p.id,
+        source: { kind: "link" as const },
+        root: p.root,
+        enabled: p.enabled ?? true,
+        version: "1.0.0",
+        installedAt: 1,
+      })),
+    },
+    home,
+  )
+  process.env.ROVE_HOME_DIR = home
+  return home
+}
+
+function pluginRoot(manifest: string): string {
+  const root = tmp("kobe-engines-plugin-")
+  writeFileSync(join(root, "rove-plugin.toml"), manifest)
+  return root
+}
+
+const MANIFEST = `
+id = "acme.engines"
+name = "Acme"
+version = "1.0.0"
+min_rove_version = "0.8.0"
+
+[[engines]]
+id = "aider"
+name = "Aider"
+command = ["aider"]
+
+[engines.identity]
+input_placeholder = "Ask Aider anything…"
+
+[[engines.rules]]
+state = "working"
+any = ["ctrl-c to interrupt"]
+`
+
+describe("loadPluginEngines", () => {
+  it("registers enabled plugins' engines with identity fallbacks", () => {
+    homeWith([{ id: "acme.engines", root: pluginRoot(MANIFEST) }])
+    expect(loadPluginEngines()).toEqual(["aider"])
+    const entry = engineEntry("aider")
+    expect(entry.displayName).toBe("Aider")
+    // Declared field survives; undeclared ones fall back to the name.
+    expect(entry.identity).toMatchObject({
+      vendorId: "aider",
+      productName: "Aider",
+      shortName: "Aider",
+      inputPlaceholder: "Ask Aider anything…",
+    })
+  })
+
+  it("skips disabled plugins and unreadable manifests without throwing", () => {
+    const broken = tmp("kobe-engines-broken-") // no manifest file at all
+    homeWith([
+      { id: "off.plugin", root: pluginRoot(MANIFEST), enabled: false },
+      { id: "broken.plugin", root: broken },
+    ])
+    expect(loadPluginEngines()).toEqual([])
+  })
+
+  it("an empty registry registers nothing", () => {
+    homeWith([])
+    expect(loadPluginEngines()).toEqual([])
+  })
+})

--- a/packages/kobe/test/engine/plugin-engines.test.ts
+++ b/packages/kobe/test/engine/plugin-engines.test.ts
@@ -102,7 +102,13 @@ describe("plugin engine registration", () => {
     expect(entry.screenManifest).toBeDefined()
     expect(entry.builtin).toBe(false)
     // Identity rides the overlay — TUI copy comes from here, never hard-coded.
-    expect(entry.identity?.inputPlaceholder).toBe("Ask Aider…")
+    expect(entry.identity).toEqual({
+      vendorId: "aider",
+      productName: "Aider",
+      shortName: "Aider",
+      assistantName: "Aider",
+      inputPlaceholder: "Ask Aider…",
+    })
   })
 
   it("a shipped catalog id cannot be overridden by a plugin", () => {

--- a/packages/kobe/test/engine/plugin-engines.test.ts
+++ b/packages/kobe/test/engine/plugin-engines.test.ts
@@ -53,6 +53,24 @@ describe("plugin manifest [[engines]]", () => {
     expect(() => parsePluginManifest(bad)).toThrow(/not a valid regex/)
   })
 
+  it("parses [engines.identity] with snake_case keys", () => {
+    const withIdentity = MANIFEST.replace(
+      'command = ["aider", "--no-auto-commits"]',
+      `command = ["aider", "--no-auto-commits"]
+
+[engines.identity]
+product_name = "Aider"
+short_name = "Aider"
+input_placeholder = "Ask Aider…"`,
+    )
+    const { manifest } = parsePluginManifest(withIdentity)
+    expect(manifest.engines[0]?.identity).toEqual({
+      productName: "Aider",
+      shortName: "Aider",
+      inputPlaceholder: "Ask Aider…",
+    })
+  })
+
   it("a manifest without engines parses to an empty list", () => {
     const { manifest } = parsePluginManifest('id = "x"\nname = "X"\nversion = "1"\nmin_rove_version = "0.8.0"\n')
     expect(manifest.engines).toEqual([])
@@ -68,6 +86,13 @@ describe("plugin engine registration", () => {
       displayName: "Aider",
       defaultCommand: ["aider"],
       screenManifest: { rules: [{ state: "working", any: ["ctrl-c to interrupt"] }] },
+      identity: {
+        vendorId: "aider",
+        productName: "Aider",
+        shortName: "Aider",
+        assistantName: "Aider",
+        inputPlaceholder: "Ask Aider…",
+      },
     })
     expect(ok).toBe(true)
     expect(pluginEngineIds()).toEqual(["aider"])
@@ -76,6 +101,8 @@ describe("plugin engine registration", () => {
     expect(entry.defaultCommand).toEqual(["aider"])
     expect(entry.screenManifest).toBeDefined()
     expect(entry.builtin).toBe(false)
+    // Identity rides the overlay — TUI copy comes from here, never hard-coded.
+    expect(entry.identity?.inputPlaceholder).toBe("Ask Aider…")
   })
 
   it("a shipped catalog id cannot be overridden by a plugin", () => {

--- a/packages/kobe/test/plugins/events-pipeline.test.ts
+++ b/packages/kobe/test/plugins/events-pipeline.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression: the historically DROPPED plugin events now fire from the real
+ * orchestrator calls, not just from hand-built snapshot pairs.
+ *
+ * Wiring mirrors server.ts exactly: `orch.subscribeTasks` → `serializeTask`
+ * → `PluginEventReducer.reduce` (the bus is a pass-through for the reducer,
+ * so feeding it directly is the same seam). Real git + real store on disk —
+ * adopt shells `git worktree list`, so mocking would only test the mock.
+ *
+ * The two fixed paths:
+ *  - `adoptWorktree` creates the task WITH its worktree → both
+ *    `task.created` and `worktree.created` (previously: neither the
+ *    `ensureWorktree` job nor any handler fired for adopt).
+ *  - `setArchived(true)` — the exact orchestrator call the
+ *    `worktree.archiveRemoved` sweep and `land --then-archive` make —
+ *    → `task.archived` (previously only the archive RPC handler fired it).
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { serializeTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { type PluginEvent, PluginEventReducer } from "@sma1lboy/kobe-daemon/plugins/events"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { Orchestrator } from "../../src/orchestrator/core.ts"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+const REPO_INIT = path.resolve(__dirname, "../orchestrator/fixtures/repo-init.sh")
+
+let tmpRoot: string
+let repo: string
+let orch: Orchestrator
+let events: PluginEvent[]
+let unsubscribe: () => void
+
+beforeEach(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-plugin-pipeline-"))
+  repo = path.join(tmpRoot, "repo")
+  const r = spawnSync("bash", [REPO_INIT, repo], { encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}\n${r.stdout}`)
+  const store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  await store.load()
+  orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+  // The server.ts pipeline, minus the bus (a pass-through for the reducer).
+  const reducer = new PluginEventReducer()
+  events = []
+  unsubscribe = orch.subscribeTasks((snapshot) => {
+    events.push(
+      ...reducer.reduce({
+        channel: "task.snapshot",
+        payload: { tasks: snapshot.map((t) => serializeTask(t as never)) },
+      } as never),
+    )
+  })
+  // Drain the baseline snapshot (subscribe replays eagerly).
+  events.length = 0
+})
+
+afterEach(() => {
+  unsubscribe()
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+function names(): string[] {
+  return events.map((e) => e.event)
+}
+
+describe("dropped-path regressions through the real orchestrator", () => {
+  test("adoptWorktree fires task.created AND worktree.created", async () => {
+    const ext = path.join(tmpRoot, "ext-feat")
+    const r = spawnSync("git", ["worktree", "add", "-b", "feat", ext], { cwd: repo, encoding: "utf8" })
+    if (r.status !== 0) throw new Error(`git worktree add failed: ${r.stderr}`)
+
+    const task = await orch.adoptWorktree({ repo, worktreePath: ext, branch: "feat" })
+
+    // Adopt also ensures the project main task; scope to the adopted id.
+    const mine = events.filter((e) => e.taskId === task.id)
+    expect(mine.map((e) => e.event)).toEqual(["task.created", "worktree.created"])
+    expect(mine[1]?.task?.worktreePath).toBe(fs.realpathSync(ext))
+  })
+
+  test("setArchived — the sweep/land archive call — fires task.archived; restore does not", async () => {
+    const ext = path.join(tmpRoot, "ext-arch")
+    const r = spawnSync("git", ["worktree", "add", "-b", "arch", ext], { cwd: repo, encoding: "utf8" })
+    if (r.status !== 0) throw new Error(`git worktree add failed: ${r.stderr}`)
+    const task = await orch.adoptWorktree({ repo, worktreePath: ext, branch: "arch" })
+    events.length = 0
+
+    await orch.setArchived(task.id, true)
+    expect(names()).toContain("task.archived")
+
+    events.length = 0
+    await orch.setArchived(task.id, false)
+    expect(names()).not.toContain("task.archived")
+    expect(names()).toContain("task.changed")
+  })
+})

--- a/packages/kobe/test/plugins/events.test.ts
+++ b/packages/kobe/test/plugins/events.test.ts
@@ -30,8 +30,11 @@ describe("PluginEventReducer", () => {
     const reducer = new PluginEventReducer(() => 42)
     expect(snapshot(reducer, ["a", "b"])).toEqual([])
     const created = snapshot(reducer, ["a", "b", "c"])
-    expect(created).toEqual([
-      { event: "task.created", taskId: "c", task: expect.objectContaining({ id: "c" }), at: 42 },
+    // The helper's tasks are born WITH a worktree path, so adopt semantics
+    // fire worktree.created in the same snapshot as task.created.
+    expect(created.map((e) => [e.event, e.taskId])).toEqual([
+      ["task.created", "c"],
+      ["worktree.created", "c"],
     ])
     const deleted = snapshot(reducer, ["a"])
     expect(deleted.map((e) => [e.event, e.taskId])).toEqual([
@@ -40,21 +43,43 @@ describe("PluginEventReducer", () => {
     ])
   })
 
-  it("emits worktree.created only on ensureWorktree done", () => {
+  it("emits worktree.created when a task's worktree path goes empty → set", () => {
     const reducer = new PluginEventReducer(() => 1)
-    snapshot(reducer, ["a"])
-    const running = reducer.reduce({
-      channel: "task.jobs",
-      payload: { taskId: "a", kind: "ensureWorktree", phase: "running" },
-    } as never)
-    expect(running).toEqual([])
-    const done = reducer.reduce({
-      channel: "task.jobs",
-      payload: { taskId: "a", kind: "ensureWorktree", phase: "done" },
-    } as never)
-    expect(done).toEqual([
-      { event: "worktree.created", taskId: "a", task: expect.objectContaining({ id: "a" }), at: 1 },
-    ])
+    const feed = (tasks: Record<string, unknown>[]) =>
+      reducer.reduce({ channel: "task.snapshot", payload: { tasks } } as never)
+    feed([task("a", { worktreePath: "" })])
+    const events = feed([task("a", { worktreePath: "/wt/a" })])
+    expect(events.map((e) => e.event)).toEqual(["task.changed", "worktree.created"])
+    // task.jobs no longer feeds the reducer at all.
+    expect(
+      reducer.reduce({
+        channel: "task.jobs",
+        payload: { taskId: "a", kind: "ensureWorktree", phase: "done" },
+      } as never),
+    ).toEqual([])
+  })
+
+  it("emits task.changed with fields/from/to, task.archived on the flip, and task.pr-changed", () => {
+    const reducer = new PluginEventReducer(() => 9)
+    const feed = (tasks: Record<string, unknown>[]) =>
+      reducer.reduce({ channel: "task.snapshot", payload: { tasks } } as never)
+    feed([task("a")])
+    const changed = feed([task("a", { title: "renamed", archived: true })])
+    expect(changed.map((e) => e.event)).toEqual(["task.changed", "task.archived"])
+    expect(changed[0]?.detail).toEqual({
+      fields: ["title", "archived"],
+      from: { title: "t-a", archived: false },
+      to: { title: "renamed", archived: true },
+    })
+    // Unarchive is a restore: task.changed only, no task.archived.
+    const restored = feed([task("a", { title: "renamed" })])
+    expect(restored.map((e) => e.event)).toEqual(["task.changed"])
+    // PR status has its own event and is not a `fields` entry.
+    const pr = feed([task("a", { title: "renamed", prStatus: { state: "open" } })])
+    expect(pr.map((e) => e.event)).toEqual(["task.pr-changed"])
+    expect(pr[0]?.detail).toEqual({ to: { state: "open" } })
+    // Identical snapshot → silence.
+    expect(feed([task("a", { title: "renamed", prStatus: { state: "open" } })])).toEqual([])
   })
 
   it("emits agent.* only on state transitions, keyed per task+tab", () => {

--- a/packages/kobe/test/plugins/runtime.test.ts
+++ b/packages/kobe/test/plugins/runtime.test.ts
@@ -105,6 +105,54 @@ describe("PluginHost", () => {
     }
   })
 
+  it("runs [[shutdown]] hooks on stop and fires plugin.enabled on a registry reload", async () => {
+    const home = tmp("kobe-plugin-home-")
+    const root = tmp("kobe-plugin-root-")
+    writeFileSync(
+      join(root, "rove-plugin.toml"),
+      `
+id = "example.life"
+name = "Life"
+version = "0.1.0"
+min_rove_version = "0.1.0"
+
+[[shutdown]]
+command = ["sh", "-c", "printf %s \\"$ROVE_PLUGIN_EVENT\\" > stopped.txt"]
+
+[[events]]
+on = "plugin.enabled"
+command = ["sh", "-c", "printf %s \\"$ROVE_PLUGIN_EVENT\\" > enabled.txt"]
+`,
+    )
+    mkdirSync(join(home, ".kobe"), { recursive: true })
+    // Start with an EMPTY registry — the plugin is enabled by a later write,
+    // which is exactly the transition plugin.enabled reports.
+    savePluginRegistry({ plugins: [] }, home)
+    const host = new PluginHost({ homeDir: home, socketPath: "/tmp/fake.sock", binPath: "kobe" })
+    const read = (name: string): string => {
+      try {
+        return readFileSync(join(root, name), "utf8")
+      } catch {
+        return ""
+      }
+    }
+    host.start()
+    try {
+      savePluginRegistry(
+        {
+          plugins: [
+            { id: "example.life", source: { kind: "link" }, root, enabled: true, version: "0.1.0", installedAt: 1 },
+          ],
+        },
+        home,
+      )
+      await waitFor(() => read("enabled.txt") === "plugin.enabled")
+    } finally {
+      host.stop()
+    }
+    await waitFor(() => read("stopped.txt") === "shutdown")
+  })
+
   it("skips disabled plugins and unreadable manifests without crashing", async () => {
     const home = tmp("kobe-plugin-home-")
     mkdirSync(join(home, ".kobe"), { recursive: true })

--- a/packages/kobe/test/plugins/runtime.test.ts
+++ b/packages/kobe/test/plugins/runtime.test.ts
@@ -101,7 +101,7 @@ describe("PluginHost", () => {
       await waitFor(() => logLines().length >= 2)
       expect(JSON.parse(logLines()[0] as string)).toMatchObject({ exitCode: 0 })
     } finally {
-      host.stop()
+      await host.stop()
     }
   })
 
@@ -148,9 +148,10 @@ command = ["sh", "-c", "printf %s \\"$ROVE_PLUGIN_EVENT\\" > enabled.txt"]
       )
       await waitFor(() => read("enabled.txt") === "plugin.enabled")
     } finally {
-      host.stop()
+      // stop() resolves only after the shutdown hook exited (or was killed).
+      await host.stop()
     }
-    await waitFor(() => read("stopped.txt") === "shutdown")
+    expect(read("stopped.txt")).toBe("shutdown")
   })
 
   it("skips disabled plugins and unreadable manifests without crashing", async () => {
@@ -174,7 +175,7 @@ command = ["sh", "-c", "printf %s \\"$ROVE_PLUGIN_EVENT\\" > enabled.txt"]
     })
     host.start()
     host.handleChannel(snapshotEvent(["a"]))
-    host.stop()
+    await host.stop()
     expect(lines.some((l) => l.includes("broken"))).toBe(true)
   })
 })

--- a/packages/kobe/test/plugins/task-diff.test.ts
+++ b/packages/kobe/test/plugins/task-diff.test.ts
@@ -1,0 +1,63 @@
+import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { bornWithWorktree, diffTask } from "@sma1lboy/kobe-daemon/plugins/task-diff"
+import { describe, expect, it } from "vitest"
+
+function task(extra: Partial<SerializedTask> = {}): SerializedTask {
+  return {
+    id: "a",
+    title: "t",
+    repo: "/repo",
+    branch: "b",
+    worktreePath: "/wt",
+    kind: "task",
+    status: "active",
+    archived: false,
+    pinned: false,
+    createdAt: "x",
+    updatedAt: "x",
+    ...extra,
+  } as SerializedTask
+}
+
+describe("diffTask", () => {
+  it("returns null when nothing watched changed (updatedAt/position excluded)", () => {
+    expect(diffTask(task(), task({ updatedAt: "y", position: 3 }))).toBeNull()
+  })
+
+  it("collects changed fields with from/to", () => {
+    const diff = diffTask(task(), task({ title: "renamed", pinned: true }))
+    expect(diff).toMatchObject({
+      fields: ["title", "pinned"],
+      from: { title: "t", pinned: false },
+      to: { title: "renamed", pinned: true },
+    })
+  })
+
+  it("flags archivedNow only on the false→true flip", () => {
+    expect(diffTask(task(), task({ archived: true }))?.archivedNow).toBe(true)
+    expect(diffTask(task({ archived: true }), task())?.archivedNow).toBe(false)
+  })
+
+  it("flags prChanged via deep compare, outside `fields`", () => {
+    const withPr = task({ prStatus: { state: "open" } as never })
+    const diff = diffTask(task(), withPr)
+    expect(diff).toMatchObject({ fields: [], prChanged: true })
+    // Structurally equal prStatus objects are not a change.
+    expect(diffTask(withPr, task({ prStatus: { state: "open" } as never }))).toBeNull()
+  })
+
+  it("flags worktreeCreated for a task-kind empty→set transition only", () => {
+    expect(diffTask(task({ worktreePath: "" }), task())?.worktreeCreated).toBe(true)
+    expect(diffTask(task({ kind: "main", worktreePath: "" }), task({ kind: "main" }))?.worktreeCreated).toBe(false)
+    // Path CHANGE (move) is a task.changed field, not a new worktree.
+    expect(diffTask(task(), task({ worktreePath: "/other" }))?.worktreeCreated).toBe(false)
+  })
+})
+
+describe("bornWithWorktree", () => {
+  it("true only for task-kind rows created with a path", () => {
+    expect(bornWithWorktree(task())).toBe(true)
+    expect(bornWithWorktree(task({ worktreePath: "" }))).toBe(false)
+    expect(bornWithWorktree(task({ kind: "main" }))).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Closes the plugin-side event gaps found in the catalog audit — everything observable now has an outlet, and the historically dropped paths are fixed at the source.

### Snapshot-diff sourcing (fixes the dropped events)

Task events now derive from field-level diffs of consecutive \`task.snapshot\` publishes (\`plugins/task-diff.ts\`), not from RPC handlers. Every mutation path funnels through the store, so:

- \`task.archived\` fires on archive **by any path** — the archive RPC, \`land --then-archive\`, and the \`git worktree remove\` sweep (the latter two previously never fired it)
- \`worktree.created\` fires for **every** materialization — lazy ensure, adopt, scratch-adopt (adopt paths previously never fired it)
- new \`task.changed\` (\`detail.fields/from/to\`) and \`task.pr-changed\` (\`detail.from/to\`) ride the same diff
- \`task.landed\` stays handler-emitted (its strategy/commit detail never reaches the snapshot)

### New catalog entries

| Event | Source |
|---|---|
| \`automation.dispatched\` / \`.skipped\` / \`.failed\` | one per recorded automation run (incl. \`skipped_missed\`) |
| \`quota.exhausted\` / \`quota.resumed\` | quota auto-resume armed / continue prompt delivered |
| \`session.exited\` | pty-host death records (\`pty-exits.json\`) watched by the daemon — the crash signal \`session.end\` can never deliver |
| \`note.filed\` / \`message.delivered\` | field notes + dispatcher delivery |
| \`attention.handled\` | inbox episode resolved (\`how: dismissed\|read\`) |
| \`plugin.enabled\` / \`plugin.disabled\` | registry transitions, delivered only to the affected plugin |

\`turn.complete\` now carries \`detail.turn\` (id/model/usage/startedAt/endedAt) off the telemetry ingest — the event is deferred onto the ingest callback and fires with or without a readable transcript.

### Mechanism

- \`[[shutdown]]\` manifest hooks: run at daemon stop, 3s grace then SIGKILL — never delays shutdown
- \`[engines.identity]\`: plugin engines declare product identity (composer placeholder etc.); falls back per-field to the display name
- \`rove api engine-report\`: public face of \`engine.reportEvent\` — a plugin-contributed engine (or any wrapper) drives the sidebar badge, attention inbox, and plugin event stream without a built-in hook adapter
- Threshold policies deliberately stay out (documented): "worktree dirtier than N" is plugin judgment over the \`worktree.changes\` channel

### File-size cap

\`engine.reportEvent\` (the biggest handler) moved to \`handlers-engine-report.ts\`; \`handlers.ts\` back to 350 lines.

## Testing

- \`test:fast\`: 3464 passed
- daemon track (\`KOBE_INCLUDE_SOCKET=1\`): 570 passed
- render track (\`bun test test/render\`): 211 passed
- SDK: typecheck + 13 tests passed
- root lint clean, workspace typecheck clean
- new tests: \`task-diff.test.ts\`, \`pty-exit-watch.test.ts\`, reducer field-diff cases, \`[[shutdown]]\` + \`plugin.enabled\` lifecycle, \`[engines.identity]\` parse/overlay