### PR TITLE
fix: spell every single weekday correctly in the schedule preview

### DIFF
--- a/.changeset/weekday-schedule-preview-spelling.md
+++ b/.changeset/weekday-schedule-preview-spelling.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The schedule preview now spells every weekday correctly — a routine set for Tuesday, Wednesday, Thursday, or Saturday reads "Tuesdays"/"Wednesdays"/"Thursdays"/"Saturdays" instead of the mangled "Tuedays"/"Weddays"/"Thudays"/"Satdays".

--- a/packages/kobe/src/tui/component/cron-segments.ts
+++ b/packages/kobe/src/tui/component/cron-segments.ts
@@ -41,6 +41,17 @@ function range(from: number, to: number): string[] {
   return out
 }
 
+/** Full weekday name for a cron three-letter abbreviation (uppercase). */
+const WEEKDAY_NAMES: Record<string, string> = {
+  MON: "Monday",
+  TUE: "Tuesday",
+  WED: "Wednesday",
+  THU: "Thursday",
+  FRI: "Friday",
+  SAT: "Saturday",
+  SUN: "Sunday",
+}
+
 const LADDERS: Record<CronSegment, readonly string[]> = {
   minute: MINUTE_LADDER,
   hour: HOUR_LADDER,
@@ -97,7 +108,8 @@ export function describeCron(expression: string): string | null {
   if (dow === "*") return `every day ${at}`
   if (dow === "MON-FRI") return `weekdays ${at}`
   if (dow === "SAT,SUN") return `weekends ${at}`
-  if (/^[A-Z]{3}$/.test(dow)) return `${dow.charAt(0)}${dow.slice(1).toLowerCase()}days ${at}`
+  const weekday = WEEKDAY_NAMES[dow]
+  if (weekday) return `${weekday}s ${at}`
   return null
 }
 

--- a/packages/kobe/test/tui/cron-segments.test.ts
+++ b/packages/kobe/test/tui/cron-segments.test.ts
@@ -88,9 +88,21 @@ describe("describeCron", () => {
     expect(describeCron("0 9 * * MON-FRI")).toBe("weekdays at 09:00")
     expect(describeCron("0 9 * * SAT,SUN")).toBe("weekends at 09:00")
     expect(describeCron("30 6 * * *")).toBe("every day at 06:30")
-    expect(describeCron("0 9 * * MON")).toBe("Mondays at 09:00")
     expect(describeCron("*/15 * * * *")).toBe("every day every 15m")
     expect(describeCron("0 */6 * * *")).toBe("every day every 6h")
+  })
+
+  test("spells every single weekday correctly", () => {
+    // Building the plural from the abbreviation ("TUE" + "days") mangles the
+    // names whose full spelling is not just the abbreviation — every day but
+    // MON/FRI/SUN. Each single-day rung of the picker must read right.
+    expect(describeCron("0 9 * * MON")).toBe("Mondays at 09:00")
+    expect(describeCron("0 9 * * TUE")).toBe("Tuesdays at 09:00")
+    expect(describeCron("0 9 * * WED")).toBe("Wednesdays at 09:00")
+    expect(describeCron("0 9 * * THU")).toBe("Thursdays at 09:00")
+    expect(describeCron("0 9 * * FRI")).toBe("Fridays at 09:00")
+    expect(describeCron("0 9 * * SAT")).toBe("Saturdays at 09:00")
+    expect(describeCron("0 9 * * SUN")).toBe("Sundays at 09:00")
   })
 
   test("stays silent rather than describing a shape it does not model", () => {
@@ -99,5 +111,7 @@ describe("describeCron", () => {
     expect(describeCron("0 9 1 * *")).toBeNull()
     expect(describeCron("0 9 * JAN *")).toBeNull()
     expect(describeCron("0 9-17 * * *")).toBeNull()
+    // An unrecognized three-letter day code invents no weekday name.
+    expect(describeCron("0 9 * * XYZ")).toBeNull()
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in the Routines/automation schedule preview, in the same "spell the schedule right" class as the earlier weekday fixes (#376, #369).

## Problem

`describeCron` in `packages/kobe/src/tui/component/cron-segments.ts` built a single weekday's plural by capitalizing its three-letter cron abbreviation and appending `"days"`:

```ts
if (/^[A-Z]{3}$/.test(dow)) return `${dow.charAt(0)}${dow.slice(1).toLowerCase()}days ${at}`
```

That only reads correctly for the three days whose full name *is* the abbreviation — `MON`→"Mondays", `FRI`→"Fridays", `SUN`→"Sundays". For the rest it produced mangled words:

| cron day | shown (before) | correct |
|----------|----------------|---------|
| `TUE` | Tue**days** | Tuesdays |
| `WED` | Wed**days** | Wednesdays |
| `THU` | Thu**days** | Thursdays |
| `SAT` | Sat**days** | Saturdays |

Every single-weekday rung is reachable from the schedule picker's day-of-week ladder, and the phrase is rendered live in the automation composer dialog (`automation-composer-dialog.tsx:262`), so a user scheduling a Tuesday routine saw "Tuedays at 09:00". The regex also invented a name for any three-letter code (`XYZ`→"Xyzdays").

## Fix

Map each abbreviation to its full weekday name and pluralize that; return `null` for an unrecognized three-letter code (silence beats a made-up day, matching the function's existing "don't describe a shape I can't model" contract). Net +12 lines of source.

## Verification

- `bun x vitest run test/tui/cron-segments.test.ts` — 15/15 pass. Added a case asserting the correct plural for all seven weekdays (MON–SUN) and one asserting an unknown code (`XYZ`) stays `null`. The prior suite only covered `MON`, which was accidentally correct, so the bug slipped through.
- `bun run lint` and `bun run typecheck` — both green.

## Follow-ups

None for this slice. Unrelated to, and does not touch, the open concurrency-contract discussion in #551.

---
_Generated by [Claude Code](https://claude.ai/code/session_019h3VWAqyBMDyZ8XUTXqV3Z)_