### PR TITLE
fix: locate generated docs pages instead of hardcoding their directory

### DIFF
--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -17,11 +17,24 @@ describe("Rove package distribution", () => {
       stdio: "pipe",
     })
 
+    // Find the page rather than hardcoding its directory: sync-docs.mjs owns
+    // the docs/ source -> site slug mapping, and a module split moves pages
+    // between subdirectories (ad017cbd put these under rove/). Searching keeps
+    // this assertion about the VIDEO EMBED instead of the current tree shape.
+    const contentRoot = join(ROOT, "packages/kobe-docs/content/docs")
+    const findPage = (page: string) => {
+      const hits = readdirSync(contentRoot, { recursive: true, encoding: "utf8" }).filter(
+        (entry) => entry === `${page}.mdx` || entry.endsWith(`/${page}.mdx`),
+      )
+      expect(hits, `${page}.mdx should be generated exactly once`).toHaveLength(1)
+      return join(contentRoot, hits[0])
+    }
+
     for (const [page, video] of [
       ["tui", "kanban"],
       ["routines", "routines"],
     ] as const) {
-      const generated = read(`packages/kobe-docs/content/docs/${page}.mdx`)
+      const generated = readFileSync(findPage(page), "utf8")
       expect(generated).toContain("<video controls playsInline")
       expect(generated).toContain(`poster="/docs-assets/${video}.png"`)
       expect(generated).toContain(`src="/docs-assets/${video}.mp4"`)


### PR DESCRIPTION
## Summary

`main` has been red since `ad017cbd`. This unblocks it.

`package-distribution.test.ts` read `content/docs/<page>.mdx`, but the Rove/Plugins module split moved synced pages under `content/docs/rove/`. Every `main` run since has failed on the same `ENOENT`, so every open PR shows red for a failure it did not cause.

Rather than re-hardcode `rove/`, the test now searches the generated tree for `<page>.mdx` and asserts exactly one match. `sync-docs.mjs` owns the source→slug mapping; importing it here isn't viable (it is a top-level-await script that performs the whole sync on import), so searching is the lazy equivalent that survives the next split.

Fixes daemon issue #52.

## Test plan

- [x] Fails before the change, passes after (`ENOENT ... content/docs/tui.mdx`)
- [x] **Mutation-checked, both failure modes** — a search-based assertion can pass by finding nothing, so I verified it still bites:
  - Broke the embed at its source (`docs/TUI.md`, `<video controls playsInline` → `<video BROKENATTR`) → test fails ✅
  - Removed `['TUI.md', 'rove/tui']` from `SECTIONS` so the page is never generated → fails on `tui.mdx should be generated exactly once` ✅
  - (First attempt sabotaged the *generated* `.mdx` and the test still passed — correctly, since it re-runs `sync-docs.mjs` and regenerates it. Noting it because a mutation test aimed at the wrong layer proves nothing.)
- [x] `bun run test:fast` — 353 files, 3473 tests, all pass
- [x] `bun run lint`, `typecheck` clean
- [x] No changeset: touches `packages/kobe/test/`, not `packages/kobe/src/`, so `changeset-cap` is a no-op by its own rule

## Note

The durable-vs-mechanical call here (search vs hardcode `rove/`) was flagged in #52 as the docs-site owner's judgment. I took the search route because it keeps the assertion about the video embed rather than the tree shape — but a one-line `rove/${page}` is a legitimate alternative if you'd rather the test stay explicit about layout. Happy to switch.