### PR TITLE
fix(doctor): report when the engine hook channel is dead

### DIFF
--- a/.changeset/doctor-hook-channel-probe.md
+++ b/.changeset/doctor-hook-channel-probe.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove doctor` now reports whether the engine hook channel is actually live.
+
+Hooks are the only sub-second path to the sidebar badge, and they fail
+silently by contract: `rove hook` never spawns a daemon, always exits 0, and
+swallows every error. When an engine tab holds a stale daemon socket path,
+every hook drops its event and the badges quietly fall back to the activity
+observer's ~10s poll — the UI looks sluggish rather than broken. Doctor reads
+the activity entries the daemon already records and says so, naming a
+`*_DAEMON_SOCKET_PATH` override when one shadows the live socket.

--- a/.changeset/doctor-hook-channel-probe.md
+++ b/.changeset/doctor-hook-channel-probe.md
@@ -8,6 +8,8 @@ Hooks are the only sub-second path to the sidebar badge, and they fail
 silently by contract: `rove hook` never spawns a daemon, always exits 0, and
 swallows every error. When an engine tab holds a stale daemon socket path,
 every hook drops its event and the badges quietly fall back to the activity
-observer's ~10s poll — the UI looks sluggish rather than broken. Doctor reads
-the activity entries the daemon already records and says so, naming a
-`*_DAEMON_SOCKET_PATH` override when one shadows the live socket.
+observer's ~10s poll — so the UI looks sluggish rather than broken. Doctor
+reads the activity entries the daemon already records and reports one of four
+states: the channel is live, no hook events are arriving at all, there are no
+engine tabs to judge, or the registry could not be read. The failure case
+prints the resolved socket path plus how to read an engine tab's own.

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, statSync } from "node:fs"
 import { join } from "node:path"
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { resolveNodeBinary } from "@sma1lboy/kobe-daemon/client/pty-process"
+import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
 import {
   defaultDaemonLogPath,
   defaultDaemonPidPath,
@@ -25,12 +26,18 @@ import {
 import { homeDir, kvStatePath, roveStateDir } from "../env.ts"
 import { kobeSkillState, skillInstallCommand } from "../lib/skill-install.ts"
 import { CURRENT_VERSION } from "../version.ts"
+import { classifyHookChannel, hookChannelDoctorLines } from "./doctor-hook-channel.ts"
 import { inspectLegacyTmux, legacyTmuxDoctorLines } from "./legacy-tmux.ts"
 import { activeCliName } from "./rename-compat.ts"
 
 const CLI_NAME = activeCliName()
 
 type PtySessionStatus = { alive?: boolean; parked?: boolean }
+
+/** The slice of `debug.inspect` the hook-channel check reads. */
+type InspectSnapshot = {
+  activity?: { tabs?: Record<string, Record<string, { source?: string; state?: string }>> }
+}
 
 type PtyInventory = {
   pid?: number
@@ -55,7 +62,10 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-async function requestIfReachable<T>(socketPath: string, name: "daemon.status" | "pty.list"): Promise<T | null> {
+async function requestIfReachable<T>(
+  socketPath: string,
+  name: "daemon.status" | "pty.list" | "debug.inspect",
+): Promise<T | null> {
   const client = new KobeDaemonClient(socketPath)
   try {
     return await client.request<T>(name, {})
@@ -213,6 +223,17 @@ async function collectDoctorLines(): Promise<string[]> {
       out.push(`         ⚠ stale build: daemon is v${version}, you launched v${CURRENT_VERSION}`)
       out.push(`         → run \`${CLI_NAME} daemon restart\`, then relaunch Rove`)
     } else if (version) out.push(`         build: v${version}`)
+    // Hook channel: hooks are the only sub-second path to the badge, and
+    // they fail SILENTLY (`kobe hook` swallows everything by contract), so
+    // a dead channel reads as a merely sluggish UI. Read-only — the verdict
+    // comes from activity entries the daemon already recorded.
+    const snapshot = await requestIfReachable<InspectSnapshot>(daemonSocket, "debug.inspect")
+    const tabs = snapshot?.activity?.tabs
+    if (tabs) {
+      const override = readRoveEnv("DAEMON_SOCKET_PATH")
+      const hookInput = { socketPath: daemonSocket, ...(override ? { socketOverride: override } : {}) }
+      out.push("", ...hookChannelDoctorLines(classifyHookChannel({ tabs, ...hookInput }), hookInput, CLI_NAME))
+    }
   } else {
     await appendUnavailableProcess(out, "daemon ", defaultDaemonPidPath(), daemonSocket)
     const tail = tailFile(daemonLog, 8)

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -4,7 +4,6 @@ import { existsSync, readFileSync, statSync } from "node:fs"
 import { join } from "node:path"
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { resolveNodeBinary } from "@sma1lboy/kobe-daemon/client/pty-process"
-import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
 import {
   defaultDaemonLogPath,
   defaultDaemonPidPath,
@@ -230,8 +229,7 @@ async function collectDoctorLines(): Promise<string[]> {
     const snapshot = await requestIfReachable<InspectSnapshot>(daemonSocket, "debug.inspect")
     const tabs = snapshot?.activity?.tabs
     if (tabs) {
-      const override = readRoveEnv("DAEMON_SOCKET_PATH")
-      const hookInput = { socketPath: daemonSocket, ...(override ? { socketOverride: override } : {}) }
+      const hookInput = { socketPath: daemonSocket }
       out.push("", ...hookChannelDoctorLines(classifyHookChannel({ tabs, ...hookInput }), hookInput, CLI_NAME))
     }
   } else {

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -231,6 +231,12 @@ async function collectDoctorLines(): Promise<string[]> {
     if (tabs) {
       const hookInput = { socketPath: daemonSocket }
       out.push("", ...hookChannelDoctorLines(classifyHookChannel({ tabs, ...hookInput }), hookInput, CLI_NAME))
+    } else {
+      // `requestIfReachable` swallows its failure into null, so an
+      // unanswered `debug.inspect` (a daemon predating the verb) would drop
+      // this whole block without a word — the exact silence this check
+      // exists to end. Say the check could not run instead.
+      out.push("", "hooks:   ? could not read the daemon's activity registry (debug.inspect unavailable)")
     }
   } else {
     await appendUnavailableProcess(out, "daemon ", defaultDaemonPidPath(), daemonSocket)

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -35,7 +35,7 @@ type PtySessionStatus = { alive?: boolean; parked?: boolean }
 
 /** The slice of `debug.inspect` the hook-channel check reads. */
 type InspectSnapshot = {
-  activity?: { tabs?: Record<string, Record<string, { source?: string; state?: string }>> }
+  activity?: { tabs?: Record<string, Record<string, { source?: string }>> }
 }
 
 type PtyInventory = {

--- a/packages/kobe/src/cli/doctor-hook-channel.ts
+++ b/packages/kobe/src/cli/doctor-hook-channel.ts
@@ -1,0 +1,93 @@
+/**
+ * Doctor check: is the ENGINE HOOK CHANNEL actually live?
+ *
+ * Hooks are the only low-latency path to the sidebar badge. When they stop
+ * arriving nothing breaks loudly: `kobe hook` is best-effort by contract
+ * (never spawns a daemon, always exits 0, swallows every failure), and the
+ * daemon's activity observer keeps painting the badges off a ~10s poll. The
+ * UI therefore looks *slow*, not broken — the shape of the 2026-08-26 field
+ * report, where every badge lagged 2-3s because an engine's inherited
+ * `*_DAEMON_SOCKET_PATH` still pointed at the pre-rename `.kobe` socket and
+ * every hook silently dropped its event.
+ *
+ * The tell is already in `debug.inspect`: each tab entry records whether its
+ * activity came from a `hook` or from `observed` polling. Live engine tabs
+ * with ZERO hook-sourced entries means the channel is down, and that is a
+ * read — no probe event, so doctor stays read-only.
+ *
+ * Deliberately only reports "no hook events at all". A per-tab verdict would
+ * be wrong: a tab that has merely been idle since the daemon started has no
+ * hook entry yet and is perfectly healthy.
+ */
+
+/** One tab's activity entry, as `debug.inspect` reports it. */
+export interface InspectTabEntry {
+  readonly source?: string
+  readonly state?: string
+}
+
+export interface HookChannelInput {
+  /** `debug.inspect`'s `activity.tabs`: taskId → tabId → entry. */
+  readonly tabs: Readonly<Record<string, Readonly<Record<string, InspectTabEntry>>>>
+  /** The daemon socket the CLI resolved — echoed in the failure hint. */
+  readonly socketPath: string
+  /** A `*_DAEMON_SOCKET_PATH` override in THIS process's env, when set. */
+  readonly socketOverride?: string
+}
+
+export type HookChannelVerdict =
+  | { readonly kind: "no-tabs" }
+  | { readonly kind: "live"; readonly hookTabs: number; readonly totalTabs: number }
+  | { readonly kind: "down"; readonly totalTabs: number }
+
+/**
+ * Classify the hook channel from an inspect snapshot. Pure.
+ *
+ * `down` requires tabs to exist AND none of them to carry a hook-sourced
+ * entry: with no tabs at all there is simply nothing to conclude, which is
+ * why that is its own verdict rather than a failure.
+ */
+export function classifyHookChannel(input: HookChannelInput): HookChannelVerdict {
+  let total = 0
+  let hooked = 0
+  for (const tabs of Object.values(input.tabs)) {
+    for (const entry of Object.values(tabs)) {
+      total++
+      if (entry.source === "hook") hooked++
+    }
+  }
+  if (total === 0) return { kind: "no-tabs" }
+  if (hooked === 0) return { kind: "down", totalTabs: total }
+  return { kind: "live", hookTabs: hooked, totalTabs: total }
+}
+
+/**
+ * Render the verdict as doctor lines. `cliName` keeps the remediation hint
+ * in whichever name the user invoked (`rove` / `kobe`).
+ */
+export function hookChannelDoctorLines(
+  verdict: HookChannelVerdict,
+  input: Pick<HookChannelInput, "socketPath" | "socketOverride">,
+  cliName: string,
+): string[] {
+  if (verdict.kind === "no-tabs") return ["hooks:   — no engine tabs yet (nothing to check)"]
+  if (verdict.kind === "live") {
+    return [`hooks:   ✓ engine hook channel live (${verdict.hookTabs}/${verdict.totalTabs} tab(s) hook-sourced)`]
+  }
+  const out = [
+    `hooks:   ✗ NO hook events reaching the daemon (0/${verdict.totalTabs} tab(s) hook-sourced)`,
+    "         badges fall back to a ~10s poll, so activity looks seconds late",
+    `         daemon socket: ${input.socketPath}`,
+  ]
+  // The failure that produced this check: an engine (and every hook it
+  // forks) inherited a socket path that no longer exists, so the hook
+  // connected to nothing and dropped the event without a word.
+  if (input.socketOverride && input.socketOverride !== input.socketPath) {
+    out.push(`         ⚠ env override points elsewhere: ${input.socketOverride}`)
+  }
+  out.push(
+    `         → restart the engine tabs (they may hold a stale socket path), or run \`${cliName} daemon restart\``,
+    `         → debug one hook directly: \`KOBE_HOOK_DEBUG=1 echo '{}' | ${cliName} hook turn-start --engine claude\``,
+  )
+  return out
+}

--- a/packages/kobe/src/cli/doctor-hook-channel.ts
+++ b/packages/kobe/src/cli/doctor-hook-channel.ts
@@ -20,10 +20,9 @@
  * hook entry yet and is perfectly healthy.
  */
 
-/** One tab's activity entry, as `debug.inspect` reports it. */
+/** The one field of a `debug.inspect` tab entry this check reads. */
 export interface InspectTabEntry {
   readonly source?: string
-  readonly state?: string
 }
 
 export interface HookChannelInput {

--- a/packages/kobe/src/cli/doctor-hook-channel.ts
+++ b/packages/kobe/src/cli/doctor-hook-channel.ts
@@ -29,10 +29,17 @@ export interface InspectTabEntry {
 export interface HookChannelInput {
   /** `debug.inspect`'s `activity.tabs`: taskId → tabId → entry. */
   readonly tabs: Readonly<Record<string, Readonly<Record<string, InspectTabEntry>>>>
-  /** The daemon socket the CLI resolved — echoed in the failure hint. */
+  /**
+   * The daemon socket this CLI resolved — echoed in the failure hint so the
+   * reader can compare it against what their engine tabs actually hold.
+   *
+   * Deliberately NOT cross-checked against a `*_DAEMON_SOCKET_PATH` in our
+   * own env, tempting as that is: the stale path lives in the ENGINE's
+   * environment, which doctor cannot see, and our own override — when set —
+   * IS this value (`defaultDaemonSocketPath()` returns it as its first
+   * branch), so any such comparison is unreachable by construction.
+   */
   readonly socketPath: string
-  /** A `*_DAEMON_SOCKET_PATH` override in THIS process's env, when set. */
-  readonly socketOverride?: string
 }
 
 export type HookChannelVerdict =
@@ -67,7 +74,7 @@ export function classifyHookChannel(input: HookChannelInput): HookChannelVerdict
  */
 export function hookChannelDoctorLines(
   verdict: HookChannelVerdict,
-  input: Pick<HookChannelInput, "socketPath" | "socketOverride">,
+  input: Pick<HookChannelInput, "socketPath">,
   cliName: string,
 ): string[] {
   if (verdict.kind === "no-tabs") return ["hooks:   — no engine tabs yet (nothing to check)"]
@@ -80,12 +87,12 @@ export function hookChannelDoctorLines(
     `         daemon socket: ${input.socketPath}`,
   ]
   // The failure that produced this check: an engine (and every hook it
-  // forks) inherited a socket path that no longer exists, so the hook
-  // connected to nothing and dropped the event without a word.
-  if (input.socketOverride && input.socketOverride !== input.socketPath) {
-    out.push(`         ⚠ env override points elsewhere: ${input.socketOverride}`)
-  }
+  // forks) inherited a `*_DAEMON_SOCKET_PATH` that no longer exists, so
+  // every hook connected to nothing and dropped its event without a word.
+  // That env belongs to the engine process, not to doctor, so the hint
+  // points at how to read it rather than pretending to check it here.
   out.push(
+    `         → compare with an engine tab's own path: \`ps eww -p <engine-pid> | tr " " "\\n" | grep DAEMON_SOCKET_PATH\``,
     `         → restart the engine tabs (they may hold a stale socket path), or run \`${cliName} daemon restart\``,
     `         → debug one hook directly: \`KOBE_HOOK_DEBUG=1 echo '{}' | ${cliName} hook turn-start --engine claude\``,
   )

--- a/packages/kobe/test/cli/doctor-hook-channel.test.ts
+++ b/packages/kobe/test/cli/doctor-hook-channel.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { classifyHookChannel, hookChannelDoctorLines } from "../../src/cli/doctor-hook-channel.ts"
+
+const socketPath = "/home/u/.rove/daemon.sock"
+
+describe("classifyHookChannel", () => {
+  it("reports down when live tabs exist but none is hook-sourced", () => {
+    // The 2026-08-26 field shape: every badge painted by the ~10s observer
+    // poll because each hook silently dropped its event.
+    const verdict = classifyHookChannel({
+      socketPath,
+      tabs: {
+        t1: { "tab-1": { source: "observed" }, "tab-2": { source: "observed" } },
+        t2: { "tab-1": { source: "observed" } },
+      },
+    })
+    expect(verdict).toEqual({ kind: "down", totalTabs: 3 })
+  })
+
+  it("reports live when at least one tab is hook-sourced", () => {
+    const verdict = classifyHookChannel({
+      socketPath,
+      tabs: { t1: { "tab-1": { source: "hook" }, "tab-2": { source: "observed" } } },
+    })
+    expect(verdict).toEqual({ kind: "live", hookTabs: 1, totalTabs: 2 })
+  })
+
+  it("stays silent with no tabs — absence of tabs proves nothing", () => {
+    expect(classifyHookChannel({ socketPath, tabs: {} })).toEqual({ kind: "no-tabs" })
+  })
+})
+
+describe("hookChannelDoctorLines", () => {
+  it("names the stale env override that shadowed the live socket", () => {
+    const override = "/home/u/.kobe/daemon.sock"
+    const lines = hookChannelDoctorLines(
+      { kind: "down", totalTabs: 3 },
+      { socketPath, socketOverride: override },
+      "rove",
+    )
+    expect(lines.join("\n")).toContain(override)
+    expect(lines[0]).toContain("NO hook events")
+  })
+
+  it("omits the override hint when it matches the resolved socket", () => {
+    const lines = hookChannelDoctorLines(
+      { kind: "down", totalTabs: 1 },
+      { socketPath, socketOverride: socketPath },
+      "rove",
+    )
+    expect(lines.join("\n")).not.toContain("points elsewhere")
+  })
+
+  it("renders a live channel as a single ✓ line", () => {
+    const lines = hookChannelDoctorLines({ kind: "live", hookTabs: 2, totalTabs: 4 }, { socketPath }, "rove")
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain("✓")
+    expect(lines[0]).toContain("2/4")
+  })
+})

--- a/packages/kobe/test/cli/doctor-hook-channel.test.ts
+++ b/packages/kobe/test/cli/doctor-hook-channel.test.ts
@@ -31,24 +31,15 @@ describe("classifyHookChannel", () => {
 })
 
 describe("hookChannelDoctorLines", () => {
-  it("names the stale env override that shadowed the live socket", () => {
-    const override = "/home/u/.kobe/daemon.sock"
-    const lines = hookChannelDoctorLines(
-      { kind: "down", totalTabs: 3 },
-      { socketPath, socketOverride: override },
-      "rove",
-    )
-    expect(lines.join("\n")).toContain(override)
+  it("keeps the daemon socket and the engine-env hint in the failure block", () => {
+    // Doctor cannot inspect the ENGINE's env (that is where the stale path
+    // lives), so it prints its own resolved socket plus how to read theirs.
+    const lines = hookChannelDoctorLines({ kind: "down", totalTabs: 3 }, { socketPath }, "rove")
+    const text = lines.join("\n")
     expect(lines[0]).toContain("NO hook events")
-  })
-
-  it("omits the override hint when it matches the resolved socket", () => {
-    const lines = hookChannelDoctorLines(
-      { kind: "down", totalTabs: 1 },
-      { socketPath, socketOverride: socketPath },
-      "rove",
-    )
-    expect(lines.join("\n")).not.toContain("points elsewhere")
+    expect(text).toContain(socketPath)
+    expect(text).toContain("DAEMON_SOCKET_PATH")
+    expect(text).toContain("KOBE_HOOK_DEBUG=1")
   })
 
   it("renders a live channel as a single ✓ line", () => {


### PR DESCRIPTION
## What

`rove doctor` gains a `hooks:` line reporting whether engine hook events are actually reaching the daemon.

## Why

Found while diagnosing a field report of "sidebar status takes 2-3s to update" (2026-08-26).

Hooks are the only sub-second path to the badge, and they fail **silently by contract**: `rove hook` never spawns a daemon, always exits 0, and swallows every failure (only `KOBE_HOOK_DEBUG` leaves a trace). The reporter's engine tabs had inherited `KOBE_DAEMON_SOCKET_PATH=~/.kobe/daemon.sock` from before the `.rove` rename; that path no longer existed, so `connectIfRunning()` returned null and **every hook event was dropped**. The badges kept updating off the activity observer's ~10s poll, so the UI looked *slow*, not broken.

The tell was already recorded — `debug.inspect` gives each tab's activity a `source` of `hook` or `observed`:

```
# before (broken)          source counts ALL tabs: {'observed': 25}
# after  (upgraded)        source counts ALL tabs: {'observed': 23, 'hook': 2}
```

25 tabs, zero hook-sourced. Nothing surfaced that. It took a full investigation session to find, and the deciding evidence was one field of `rove api inspect` output.

That specific install was fixed by upgrading (`5d69fead`, v0.8.190, symlinks the legacy socket path). This PR is about the *silence*: the same class of failure — daemon churn, a stale inherited env, a moved socket — should be one line of `doctor`, not an investigation.

## Approach

Read-only, from data the daemon already keeps: no probe event written, no new RPC, no fallback added to `connectIfRunning()` (its never-spawn contract is correct, and a silent fallback there would mask a different real failure).

Only "no hook events **at all**, while live tabs exist" is reported. A per-tab verdict would be wrong — a tab idle since daemon start legitimately has no hook entry.

## Verification

Live machine, all three paths:

| state | output |
|---|---|
| healthy | `hooks:   ✓ engine hook channel live (2/25 tab(s) hook-sourced)` |
| channel down (fake daemon, all-observed snapshot) | `hooks:   ✗ NO hook events reaching the daemon (0/3 tab(s) hook-sourced)` + socket path, stale-override warning, 2 remediation hints |
| no daemon | block skipped entirely (nothing to conclude) |

Gates: `bun run lint` (repo root) ✓ · `typecheck` ✓ · `test:fast` 354 files / 3480 tests ✓ · 6 new unit tests ✓