### PR TITLE
fix(worktree): converge renameBranch when the recorded old name is stale

### DIFF
--- a/.changeset/set-branch-stale-record-converges.md
+++ b/.changeset/set-branch-stale-record-converges.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api set-branch` no longer fails with "no branch named …" when the rename already happened. The task record's branch name can go stale — a retried call whose first attempt renamed but lost its response, a concurrent rename, or an out-of-band `git branch -m` in the worktree — and the rename then errored against the main checkout even though the worktree was already on the requested name, leaving the caller unable to tell partial success from failure. `renameBranch` now probes the end state on failure: old name gone and new name present is the requested outcome, so it succeeds and the record converges; anything else still fails.

--- a/packages/kobe/src/orchestrator/worktree/manager-branch.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-branch.ts
@@ -10,7 +10,7 @@
 
 import type { ExecHost } from "../../exec/exec-host.ts"
 import type { ExecCtx } from "./exec-deps.ts"
-import type { GitRunOpts, GitRunResult } from "./git.ts"
+import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
 
 /** The manager primitives the branch functions borrow. */
 export interface BranchDeps {
@@ -86,13 +86,21 @@ export async function hasLocalBranch(deps: BranchDeps, worktreePath: string, bra
  *
  * git's `branch -m <old> <new>` updates HEAD on every worktree that was
  * checked out on `<old>` — the engine's session keeps streaming without
- * noticing. Idempotent: returns silently when `from === to`. If `to` already
- * exists, throws.
+ * noticing. Idempotent: returns silently when `from === to`, and also when
+ * `from` is already gone while `to` exists — the recorded `from` can be
+ * stale (a retried call whose first attempt renamed but whose response was
+ * lost, a concurrent rename, an out-of-band `git branch -m`; issue #44), and
+ * branch refs are shared across worktrees, so old-gone + new-present IS the
+ * requested end state. If `to` already exists alongside `from`, throws.
  */
 export async function renameBranch(deps: BranchDeps, worktreePath: string, from: string, to: string): Promise<void> {
   const exec = deps.execAt(worktreePath)
   if (from === to) return
   const repo = await deps.findRepoFor(exec, worktreePath)
   if (!repo) throw new Error(`renameBranch(): ${worktreePath} is not a git worktree`)
-  await deps.runGit(exec, ["branch", "-m", from, to], { cwd: repo })
+  const out = await deps.runGit(exec, ["branch", "-m", from, to], { cwd: repo, allowFail: true })
+  if (out.exitCode === 0) return
+  const ctx: ExecCtx = { exec, dir: repo, remote: exec.isRemote }
+  if (!(await branchExists(deps, ctx, from)) && (await branchExists(deps, ctx, to))) return
+  throw new GitCommandError(["branch", "-m", from, to], repo, out)
 }

--- a/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
@@ -82,3 +82,29 @@ describe("remove() / currentBranch() edges", () => {
     await expect(manager.currentBranch(wt)).rejects.toThrow(/detached-HEAD/)
   })
 })
+
+describe("renameBranch() convergence (issue #44)", () => {
+  it("resolves when the recorded old name is stale but the branch already carries the new name", async () => {
+    const wt = join(root, "wt-stale-rename")
+    await manager.create(repo, "rename-old", wt)
+    // Out-of-band rename in the worktree — what a retried set-branch whose
+    // first attempt renamed-but-lost-its-response leaves behind.
+    execSync("git branch -m rename-old rename-new", { cwd: wt, env: gitEnv })
+    await expect(manager.renameBranch(wt, "rename-old", "rename-new")).resolves.toBeUndefined()
+    expect(await manager.currentBranch(wt)).toBe("rename-new")
+  })
+
+  it("still fails when neither the old nor the new name exists", async () => {
+    const wt = join(root, "wt-rename-missing")
+    await manager.create(repo, "rename-anchor", wt)
+    await expect(manager.renameBranch(wt, "no-such-old", "no-such-new")).rejects.toThrow(/branch -m/)
+  })
+
+  it("still fails on a collision with a different existing branch", async () => {
+    const wt = join(root, "wt-rename-collide")
+    await manager.create(repo, "rename-a", wt)
+    execSync("git branch rename-b", { cwd: repo, env: gitEnv })
+    await expect(manager.renameBranch(wt, "rename-a", "rename-b")).rejects.toThrow(/branch -m/)
+    expect(await manager.currentBranch(wt)).toBe("rename-a")
+  })
+})


### PR DESCRIPTION
Fixes rove issue #44.

`rove api set-branch` from inside a task worktree failed with "no branch named `<old>`" stamped with the main-checkout path — while the worktree was already sitting on the new name. Partial success reported as failure: the caller cannot tell whether to retry, and an unattended agent may "fix" it with a manual `git branch -m` and make things worse.

**The issue's guessed root cause did not hold.** It blamed `setBranch` resolving git ops to `task.repo` instead of `task.worktreePath`, but `renameBranch` derives the owning repo from the worktree via `rev-parse --git-common-dir`, and branch refs are shared across all worktrees — cwd cannot hide a branch. The real failure is that the store's `task.branch` goes stale: a retried call whose first attempt renamed but lost its response, a concurrent rename, or an out-of-band `git branch -m` in the worktree. `git branch -m <stale> <new>` then dies, and the error text points at the main checkout, which is what made it look like a cwd bug.

The fix lands in `renameBranch` — the single layer every rename routes through (CLI/daemon `set-branch`, the TUI rename flow, and follow-branch-to-title all go via `TaskEditor.setBranch`). It runs `branch -m` with `allowFail` and, on failure, probes the end state: old ref gone **and** new ref present is the requested outcome, so it returns success and `setBranch` converges the store record. Any other failure shape still throws the original `GitCommandError`.

The other branch verbs were audited and are unaffected: they either run in the worktree cwd (`branchHasUpstream`, `hasLocalBranch`) or are legitimately repo-scoped best-effort ops (`deleteBranchIn`, `listBranchNames`).

## Tests

Three cases in `worktree-manager-edges.test.ts`, red before the fix:
- stale old name + new name already present → resolves, worktree on the new name
- neither name exists → still throws
- collision with a different existing branch → still throws, branch unchanged