### PR TITLE
fix(store): atomic token lockfile, per-save tmp, persistent deletion tombstones

### DIFF
--- a/.changeset/task-index-lock-tombstones.md
+++ b/.changeset/task-index-lock-tombstones.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix two concurrency holes in the shared task-index write path. The index lockfile is now created atomically (content-first sidecar + link) and carries a per-acquire token, so a reader can never observe a half-written lock and classify a live holder as stale, two stores in the same process are distinguishable holders, and release can no longer unlink a lock a rival legitimately took over — closing the mutual-exclusion break behind the `rename tasks.json.tmp ENOENT` CI flake (#53); each save also stages through a unique tmp file so writers can't clobber each other's staging even under a broken mutex. Deletions are now persisted as tombstones in `tasks.json` (optional `removed` field, pruned after 30 days), so a peer instance that still holds a deleted task dirty in memory can no longer resurrect it on its next save (#47).

--- a/packages/kobe/src/orchestrator/index/lockfile.ts
+++ b/packages/kobe/src/orchestrator/index/lockfile.ts
@@ -2,8 +2,14 @@
  * PID-based lockfile for the task index.
  *
  * Goal: prevent two Rove instances from racing to write `~/.rove/tasks.json`
- * and corrupting it. We use the simplest mechanism that does the job:
- * an `O_EXCL` lockfile containing the holder's PID.
+ * and corrupting it. The lockfile holds `pid:token` — the holder's PID plus a
+ * per-acquire random token, so two stores in the SAME process are still
+ * distinguishable holders (issue #53).
+ *
+ * Creation is atomic-or-fail: contents are written to a private sidecar file
+ * first, then `link(2)`ed into place. The lockfile is therefore never
+ * observable in a half-written (empty) state — an empty read used to classify
+ * a live holder as stale and break mutual exclusion outright.
  *
  * Failure modes:
  *
@@ -26,7 +32,8 @@
  * (flock — Bun coverage uneven), retry/backoff (caller's choice).
  */
 
-import { mkdir, readFile, unlink, writeFile } from "node:fs/promises"
+import { randomBytes } from "node:crypto"
+import { link, mkdir, readFile, unlink, writeFile } from "node:fs/promises"
 import { dirname } from "node:path"
 
 export interface LockfileOptions {
@@ -70,82 +77,84 @@ export class LockfileError extends Error {
 }
 
 /**
- * Acquire an exclusive lock at `lockPath`. The file's contents are this
- * process's PID, so a future kobe can decide whether to take over.
+ * Acquire an exclusive lock at `lockPath` and return the ownership token to
+ * pass to {@link release}. The lock's contents are `pid:token` — `parseInt`
+ * still extracts the PID, so older builds reading a new lock see the holder
+ * correctly, and a legacy bare-PID lock parses here the same way.
  *
- * Throws {@link LockfileError} if the lock is held by a live process.
+ * Throws {@link LockfileError} if the lock is held by a live process
+ * (including a sibling store in this same process — it will release; wait).
  */
-export async function acquire(lockPath: string, opts: LockfileOptions = {}): Promise<void> {
+export async function acquire(lockPath: string, opts: LockfileOptions = {}): Promise<string> {
   await mkdir(dirname(lockPath), { recursive: true })
+  const token = `${process.pid}:${randomBytes(8).toString("hex")}`
+  const sidecar = `${lockPath}.${token.replace(":", "-")}`
 
-  // Fast path: O_EXCL create. If it succeeds we own the lock.
-  try {
-    await writeFile(lockPath, String(process.pid), { flag: "wx" })
-    return
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-      throw err
+  for (;;) {
+    // Atomic creation: full contents first, then link into place. `link`
+    // either succeeds or fails EEXIST — no observable empty-lockfile window.
+    await writeFile(sidecar, token)
+    try {
+      await link(sidecar, lockPath)
+      return token
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err
+    } finally {
+      await unlink(sidecar).catch(() => {})
     }
-  }
 
-  // Slow path: lock exists. Inspect the holder.
-  let holderPid = -1
-  try {
-    const raw = (await readFile(lockPath, "utf8")).trim()
-    holderPid = Number.parseInt(raw, 10)
-    if (!Number.isFinite(holderPid)) holderPid = -1
-  } catch {
-    // Lockfile vanished between our EEXIST and the read. Retry once.
-    return acquire(lockPath, opts)
-  }
-
-  const alive = holderPid > 0 && isProcessAlive(holderPid)
-  if (alive && !opts.forceTakeover) {
-    throw new LockfileError(`task index is locked by another Rove instance (pid ${holderPid})`, holderPid)
-  }
-
-  // Stale (or stolen): remove and re-create with our pid.
-  // We log to stderr so the user sees the takeover happen — silent
-  // takeovers are scary in concurrent contexts.
-  console.warn(
-    `[rove] removing stale lockfile at ${lockPath} (was held by pid ${holderPid}` +
-      `${alive ? ", forced" : ", process gone"})`,
-  )
-  try {
-    await unlink(lockPath)
-  } catch (err) {
-    // Race: another acquirer also unlinked. EEXIST or ENOENT both fine here.
-    const code = (err as NodeJS.ErrnoException).code
-    if (code !== "ENOENT") throw err
-  }
-  // One more attempt. If we still lose, surface the error.
-  try {
-    await writeFile(lockPath, String(process.pid), { flag: "wx" })
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-      // Someone else won the takeover race. Read their pid and report.
-      let winnerPid = -1
-      try {
-        winnerPid = Number.parseInt((await readFile(lockPath, "utf8")).trim(), 10)
-      } catch {
-        winnerPid = -1
-      }
-      throw new LockfileError(`task index lockfile contended during takeover (winner pid ${winnerPid})`, winnerPid)
+    // Lock exists. Inspect the holder.
+    let holder: string
+    try {
+      holder = (await readFile(lockPath, "utf8")).trim()
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+      // Holder released between our EEXIST and the read — try again.
+      continue
     }
-    throw err
+
+    const holderPid = Number.parseInt(holder, 10)
+    const alive = Number.isFinite(holderPid) && holderPid > 0 && isProcessAlive(holderPid)
+    if (alive && !opts.forceTakeover) {
+      throw new LockfileError(`task index is locked by another Rove instance (pid ${holderPid})`, holderPid)
+    }
+
+    // Stale (or stolen): remove and loop back to the atomic create. If a
+    // rival waiter wins the takeover race, the next iteration observes their
+    // live lock and rejects. We log to stderr so the user sees the takeover
+    // happen — silent takeovers are scary in concurrent contexts.
+    console.warn(
+      `[rove] removing stale lockfile at ${lockPath} (was held by pid ${holderPid}` +
+        `${alive ? ", forced" : ", process gone"})`,
+    )
+    try {
+      await unlink(lockPath)
+    } catch (err) {
+      // Race: another acquirer also unlinked. ENOENT is fine here.
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+    }
   }
 }
 
 /**
- * Release the lock. Tolerant of "already gone" — we don't want a missing
- * lockfile during shutdown to mask a more interesting error.
+ * Release the lock acquired with `token`. Only removes the file while we
+ * still own it: after a (forced) takeover the lockfile belongs to the new
+ * holder, and unlinking it would let a third writer into the critical
+ * section behind their back. Tolerant of "already gone".
  */
-export async function release(lockPath: string): Promise<void> {
+export async function release(lockPath: string, token: string): Promise<void> {
+  let current: string
+  try {
+    current = (await readFile(lockPath, "utf8")).trim()
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return
+    throw err
+  }
+  if (current !== token) return
   try {
     await unlink(lockPath)
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code
-    if (code === "ENOENT") return
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return
     throw err
   }
 }

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -11,11 +11,12 @@
  *     arbitrary parsed JSON value into a v3 task list, migrating v1/v2
  *     manifests by stripping dropped fields and self-healing legacy status
  *     rows.
- *   - **Read-merge-write helpers.** {@link readDiskTasks} + {@link mergeTasksWithDisk}
+ *   - **Read-merge-write helpers.** {@link readDiskIndex} + {@link mergeTasksWithDisk}
  *     implement the disk side of the save protocol: a fresh read of the
- *     manifest and the three-way merge between in-memory intent and on-disk
- *     state. Both are stateless and live here so the store class focuses on
- *     the mutable cache / dirty tracking / persistence orchestration.
+ *     manifest (tasks + deletion tombstones) and the three-way merge between
+ *     in-memory intent and on-disk state. Both are stateless and live here so
+ *     the store class focuses on the mutable cache / dirty tracking /
+ *     persistence orchestration.
  *
  * All functions here are `this`-independent — moved out verbatim so the
  * store class stays under the file-size cap.
@@ -30,6 +31,7 @@ import type {
   TaskPRStatus,
   TaskQuotaResumeState,
   TaskStatus,
+  TaskTombstone,
 } from "../../types/task.ts"
 import { toTaskId } from "../../types/task.ts"
 import { coerceVendorId } from "../../types/vendor.ts"
@@ -50,14 +52,14 @@ const LOCK_MAX_WAIT_MS = 5_000
  * Acquire the index lock, retrying with a fixed backoff while it's held by a
  * *live* peer. {@link acquire} rejects immediately on a live holder (and steals
  * a stale one on its own), so the wait policy lives here. Non-contention errors
- * (and a blown deadline) propagate to the caller.
+ * (and a blown deadline) propagate to the caller. Returns the ownership token
+ * to pass to `release`.
  */
-export async function acquireWithRetry(lockPath: string): Promise<void> {
+export async function acquireWithRetry(lockPath: string): Promise<string> {
   const deadline = Date.now() + LOCK_MAX_WAIT_MS
   for (;;) {
     try {
-      await acquire(lockPath)
-      return
+      return await acquire(lockPath)
     } catch (err) {
       if (!(err instanceof LockfileError) || Date.now() >= deadline) throw err
       await sleep(LOCK_RETRY_DELAY_MS)
@@ -119,13 +121,24 @@ export function normalizeIndex(parsed: unknown, source: string): { version: type
 }
 
 /**
- * Read + parse the manifest fresh from disk, returning just the tasks.
- * Mirrors {@link TaskIndexStore.load}: a missing canonical file falls back
- * to `legacyPath`, while both absent or a corrupt source read as empty.
- * Never touches the store cache or listeners; used so a save reflects peer
- * writes since this process loaded.
+ * How long a deletion tombstone stays in the manifest before save-time
+ * pruning. A tombstone only has to outlive any live writer's in-memory dirty
+ * reference to the task (dirty ids flush on that instance's next save), so
+ * 30 days is generous headroom and growth stays negligible.
  */
-export async function readDiskTasks(path: string, legacyPath: string): Promise<Task[]> {
+const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Read + parse the manifest fresh from disk, returning the tasks and the
+ * deletion tombstones. Mirrors {@link TaskIndexStore.load}: a missing
+ * canonical file falls back to `legacyPath`, while both absent or a corrupt
+ * source read as empty. Never touches the store cache or listeners; used so
+ * a save reflects peer writes since this process loaded.
+ */
+export async function readDiskIndex(
+  path: string,
+  legacyPath: string,
+): Promise<{ tasks: Task[]; removed: TaskTombstone[] }> {
   let raw: string
   let sourcePath = path
   try {
@@ -136,7 +149,7 @@ export async function readDiskTasks(path: string, legacyPath: string): Promise<T
     try {
       raw = await readFile(sourcePath, "utf8")
     } catch (legacyErr) {
-      if ((legacyErr as NodeJS.ErrnoException).code === "ENOENT") return []
+      if ((legacyErr as NodeJS.ErrnoException).code === "ENOENT") return { tasks: [], removed: [] }
       throw legacyErr
     }
   }
@@ -146,28 +159,58 @@ export async function readDiskTasks(path: string, legacyPath: string): Promise<T
   } catch {
     // Preserve bytes before the merged write replaces a corrupt source.
     await backupCorruptManifest(sourcePath)
-    return []
+    return { tasks: [], removed: [] }
   }
-  return normalizeIndex(parsed, sourcePath).tasks
+  return { tasks: normalizeIndex(parsed, sourcePath).tasks, removed: coerceTombstones(parsed) }
+}
+
+/** Coerce the manifest's optional `removed` field; malformed entries drop. */
+function coerceTombstones(parsed: unknown): TaskTombstone[] {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return []
+  const raw = (parsed as { removed?: unknown }).removed
+  if (!Array.isArray(raw)) return []
+  const out: TaskTombstone[] = []
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue
+    const v = entry as Record<string, unknown>
+    if (typeof v.id === "string" && v.id.length > 0 && typeof v.at === "string") out.push({ id: v.id, at: v.at })
+  }
+  return out
 }
 
 /**
- * Read-merge-write core: combine the fresh on-disk tasks with this process's
+ * Read-merge-write core: combine the fresh on-disk index with this process's
  * in-memory intent. Invariants (mirroring `state/store.ts`):
  *
  *   - OUR changes win for ids we touched (`dirty`) — last-write-wins per task.
- *   - A task we removed (`removed`) is NOT resurrected by a stale disk copy.
- *   - A task a peer removed (gone from disk, untouched by us) is NOT
- *     resurrected from our stale cache.
+ *   - A DELETION beats a concurrent edit, from either side: our pending
+ *     removals (`removed`) and the on-disk tombstones a peer persisted both
+ *     suppress the task, even if we hold it dirty (issue #47 — task ids are
+ *     ULIDs and never reused, so a tombstone can't shadow a legit new task).
+ *   - A task a peer removed pre-tombstones (gone from disk, untouched by us)
+ *     is still NOT resurrected from our stale cache.
  *   - A task a peer created/updated (on disk, untouched by us) is preserved —
  *     concurrent creates are never dropped.
+ *
+ * Returns the merged tasks plus the tombstone set to persist (disk ∪ ours,
+ * expired entries pruned).
  */
 export function mergeTasksWithDisk(
   cacheTasks: readonly Task[],
   diskTasks: Task[],
   dirty: ReadonlySet<string>,
-  removed: ReadonlySet<string>,
-): Task[] {
+  removed: ReadonlyMap<string, string>,
+  diskRemoved: readonly TaskTombstone[] = [],
+  now: number = Date.now(),
+): { tasks: Task[]; removed: TaskTombstone[] } {
+  const tombstones = new Map<string, string>()
+  for (const t of diskRemoved) {
+    const at = Date.parse(t.at)
+    if (!Number.isFinite(at) || now - at > TOMBSTONE_TTL_MS) continue // expired (or malformed): prune
+    tombstones.set(t.id, t.at)
+  }
+  for (const [id, at] of removed) tombstones.set(id, at)
+
   const diskById = new Map(diskTasks.map((t) => [t.id, t] as const))
   const result: Task[] = []
   const included = new Set<string>()
@@ -175,6 +218,7 @@ export function mergeTasksWithDisk(
   // 1. Walk our cache in order — it carries our create/update/move intent and
   //    the ordering this process wants persisted.
   for (const task of cacheTasks) {
+    if (tombstones.has(task.id)) continue // deleted (here or by a peer): deletion beats our edit
     if (dirty.has(task.id)) {
       result.push(task) // we changed it: our version wins
     } else {
@@ -188,12 +232,12 @@ export function mergeTasksWithDisk(
   // 2. Fold in concurrent creates: tasks on disk we've never seen and never
   //    removed. Appended after our ordering.
   for (const task of diskTasks) {
-    if (included.has(task.id) || removed.has(task.id)) continue
+    if (included.has(task.id) || tombstones.has(task.id)) continue
     result.push(task)
     included.add(task.id)
   }
 
-  return result
+  return { tasks: result, removed: [...tombstones].map(([id, at]) => ({ id, at })) }
 }
 
 /**

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -21,7 +21,7 @@ import {
   backupCorruptManifest,
   mergeTasksWithDisk,
   normalizeIndex,
-  readDiskTasks,
+  readDiskIndex,
 } from "./store-codec.ts"
 import { ulid } from "./ulid.ts"
 
@@ -54,7 +54,6 @@ export class TaskIndexStore {
   private readonly roveDir: string
   private readonly path: string
   private readonly legacyPath: string
-  private readonly tmpPath: string
   private readonly lockPath: string
   private cache: { version: typeof CURRENT_VERSION; tasks: Task[] } = { version: CURRENT_VERSION, tasks: [] }
   private loaded = false
@@ -62,14 +61,14 @@ export class TaskIndexStore {
   private saveChain: Promise<void> = Promise.resolve()
   /** Pending changed/removed ids used by the read-merge-write in {@link doSave}. */
   private readonly dirtyIds = new Set<string>()
-  private readonly removedIds = new Set<string>()
+  /** Pending removals, id → deletion ISO time (becomes the tombstone's `at`). */
+  private readonly removedIds = new Map<string, string>()
 
   constructor(options: TaskIndexStoreOptions = {}) {
     this.homeDir = options.homeDir ?? homedir()
     this.roveDir = join(this.homeDir, ROVE_STATE_DIR_BASENAME)
     this.path = join(this.roveDir, "tasks.json")
     this.legacyPath = join(this.homeDir, LEGACY_KOBE_STATE_DIR_BASENAME, "tasks.json")
-    this.tmpPath = `${this.path}.tmp`
     this.lockPath = `${this.path}.lock`
   }
 
@@ -164,43 +163,57 @@ export class TaskIndexStore {
     // mutations (queued behind this on `saveChain`) keep accumulating into
     // the live sets and are flushed by their own queued save.
     const dirty = new Set(this.dirtyIds)
-    const removed = new Set(this.removedIds)
+    const removed = new Map(this.removedIds)
 
     // Cross-process mutual exclusion: serialize the read-merge-write so two
     // Rove instances (TUI + daemon + CLI) can't interleave and lose updates.
     // The lock is held only for this critical section, never across saves.
-    await acquireWithRetry(this.lockPath)
+    const lockToken = await acquireWithRetry(this.lockPath)
     try {
-      const diskTasks = await readDiskTasks(this.path, this.legacyPath)
-      const mergedTasks = mergeTasksWithDisk(this.cache.tasks, diskTasks, dirty, removed)
-      const payload: TaskIndex = { version: CURRENT_VERSION, tasks: mergedTasks }
+      const disk = await readDiskIndex(this.path, this.legacyPath)
+      const merged = mergeTasksWithDisk(this.cache.tasks, disk.tasks, dirty, removed, disk.removed)
+      const payload: TaskIndex = {
+        version: CURRENT_VERSION,
+        tasks: merged.tasks,
+        ...(merged.removed.length > 0 ? { removed: merged.removed } : {}),
+      }
       const json = `${JSON.stringify(payload, null, 2)}\n`
 
-      const handle = await open(this.tmpPath, "w", 0o644)
+      // Unique per save: a shared `<path>.tmp` let a second writer clobber the
+      // first's staging file whenever mutual exclusion broke, failing the
+      // survivor's rename with ENOENT (issue #53).
+      const tmpPath = `${this.path}.${process.pid}.${ulid()}.tmp`
       try {
-        await handle.writeFile(json, "utf8")
-        await handle.sync()
-      } finally {
-        await handle.close()
+        const handle = await open(tmpPath, "w", 0o644)
+        try {
+          await handle.writeFile(json, "utf8")
+          await handle.sync()
+        } finally {
+          await handle.close()
+        }
+        await rename(tmpPath, this.path)
+      } catch (err) {
+        await unlink(tmpPath).catch(() => {})
+        throw err
       }
-      await rename(this.tmpPath, this.path)
 
       // The write succeeded, so these changes are now durable: stop protecting
       // them in future merges (clearing only the snapshotted ids leaves any
-      // change queued while we were writing intact for its own save).
+      // change queued while we were writing intact for its own save). Removals
+      // now live on as on-disk tombstones, so dropping them here is safe.
       for (const id of dirty) this.dirtyIds.delete(id)
-      for (const id of removed) this.removedIds.delete(id)
+      for (const id of removed.keys()) this.removedIds.delete(id)
 
       // Surface concurrent creates a peer made: fold any merged task we didn't
       // already have into the cache so this process's UI sees it too. We only
       // ADD ids (never overwrite an existing cache entry) to avoid clobbering a
       // mutation that ran on the live cache while we were writing.
       const present = new Set(this.cache.tasks.map((t) => t.id))
-      for (const task of mergedTasks) {
+      for (const task of merged.tasks) {
         if (!present.has(task.id)) this.cache.tasks.push(task)
       }
     } finally {
-      await release(this.lockPath)
+      await release(this.lockPath, lockToken)
     }
   }
 
@@ -375,9 +388,11 @@ export class TaskIndexStore {
     if (idx < 0) return
     this.cache.tasks.splice(idx, 1)
     // Record the deletion so the read-merge-write doesn't resurrect this task
-    // from a stale on-disk copy, and stop treating it as a pending edit.
+    // from a stale on-disk copy, and stop treating it as a pending edit. The
+    // save persists it as a tombstone so PEER writers that still hold the
+    // task dirty in memory don't write it back either (issue #47).
     this.dirtyIds.delete(String(id))
-    this.removedIds.add(String(id))
+    this.removedIds.set(String(id), new Date().toISOString())
     await this.save()
     this.notifyListeners()
   }
@@ -389,11 +404,6 @@ export class TaskIndexStore {
   async _unlinkForTests(): Promise<void> {
     try {
       await unlink(this.path)
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
-    }
-    try {
-      await unlink(this.tmpPath)
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
     }

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -251,7 +251,26 @@ export interface TaskLinkedWorkItem {
  * manifests are migrated on load by dropping the chat-tab / model /
  * vendor / permissionMode fields. Downgrading is not supported.
  */
+/**
+ * A persisted deletion marker. A concurrent writer that still holds the
+ * deleted task dirty in memory must not write it back — the tombstone makes
+ * the deletion visible to peers (issue #47). Pruned after a TTL at save time.
+ */
+export interface TaskTombstone {
+  readonly id: string
+  /** ISO timestamp of the deletion — the TTL clock for pruning. */
+  readonly at: string
+}
+
 export interface TaskIndex {
   readonly version: 3
   readonly tasks: readonly Task[]
+  /**
+   * Deletion tombstones. Optional and absent when empty: builds that predate
+   * the field ignore it on read and drop it on write, degrading to the old
+   * last-write-wins behavior without corrupting anything (which is also why
+   * `version` stays 3 — older readers treat an unknown version as an empty
+   * index, losing everything).
+   */
+  readonly removed?: readonly TaskTombstone[]
 }

--- a/packages/kobe/test/orchestrator/lockfile.test.ts
+++ b/packages/kobe/test/orchestrator/lockfile.test.ts
@@ -34,12 +34,13 @@ describe("acquire / release", () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  it("creates a lockfile holding our pid, then releases it idempotently", async () => {
-    await acquire(lock)
-    expect((await readFile(lock, "utf8")).trim()).toBe(String(process.pid))
-    await release(lock)
+  it("creates a lockfile holding pid:token, then releases it idempotently", async () => {
+    const token = await acquire(lock)
+    expect(token.startsWith(`${process.pid}:`)).toBe(true)
+    expect((await readFile(lock, "utf8")).trim()).toBe(token)
+    await release(lock, token)
     // A second release of an already-gone lock must not throw.
-    await expect(release(lock)).resolves.toBeUndefined()
+    await expect(release(lock, token)).resolves.toBeUndefined()
   })
 
   it("rejects with LockfileError when held by a live process", async () => {
@@ -47,16 +48,42 @@ describe("acquire / release", () => {
     await expect(acquire(lock)).rejects.toBeInstanceOf(LockfileError)
   })
 
+  it("rejects when a SIBLING holder in this same process holds the lock", async () => {
+    // Same pid, different token — the issue #53 topology (two stores, one
+    // process). The holder is alive, so the second acquirer must wait, not
+    // steal.
+    await writeFile(lock, `${process.pid}:some-other-instance`)
+    await expect(acquire(lock)).rejects.toBeInstanceOf(LockfileError)
+    expect((await readFile(lock, "utf8")).trim()).toBe(`${process.pid}:some-other-instance`)
+  })
+
   it("steals a stale lockfile whose holder is gone", async () => {
     await writeFile(lock, "999999") // a pid that does not exist
-    await expect(acquire(lock)).resolves.toBeUndefined()
-    expect((await readFile(lock, "utf8")).trim()).toBe(String(process.pid))
+    const token = await acquire(lock)
+    expect((await readFile(lock, "utf8")).trim()).toBe(token)
+  })
+
+  it("still reads the holder pid from a legacy bare-pid lock", async () => {
+    await writeFile(lock, String(process.pid)) // pre-token format, alive holder
+    await expect(acquire(lock)).rejects.toBeInstanceOf(LockfileError)
   })
 
   it("forceTakeover steals from a live holder", async () => {
     await acquire(lock) // held by us — alive
-    await expect(acquire(lock, { forceTakeover: true })).resolves.toBeUndefined()
-    expect((await readFile(lock, "utf8")).trim()).toBe(String(process.pid))
+    const token = await acquire(lock, { forceTakeover: true })
+    expect((await readFile(lock, "utf8")).trim()).toBe(token)
+  })
+
+  it("release only removes a lock we still own", async () => {
+    // Victim acquires, thief takes over. The victim's release must NOT unlink
+    // the thief's lock — that would let a third writer into the critical
+    // section while the thief is still inside it (issue #53's cascade).
+    const victim = await acquire(lock)
+    const thief = await acquire(lock, { forceTakeover: true })
+    await release(lock, victim)
+    expect((await readFile(lock, "utf8")).trim()).toBe(thief)
+    await release(lock, thief)
+    await expect(readFile(lock, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
   })
 })
 
@@ -65,7 +92,7 @@ describe("acquire / release — edge branches", () => {
   const lockPath = join(dir, "edge.lock")
 
   afterEach(async () => {
-    await release(lockPath).catch(() => {})
+    await rm(lockPath, { force: true })
   })
 
   it("treats an EPERM kill probe as alive (exists but not signalable)", () => {
@@ -81,11 +108,11 @@ describe("acquire / release — edge branches", () => {
 
   it("steals a lockfile whose content isn't a pid at all", async () => {
     writeFileSync(lockPath, "not-a-pid")
-    await acquire(lockPath)
-    expect(readFileSync(lockPath, "utf8")).toBe(String(process.pid))
+    const token = await acquire(lockPath)
+    expect(readFileSync(lockPath, "utf8")).toBe(token)
   })
 
   it("release tolerates a lock that's already gone, rethrows real errors", async () => {
-    await expect(release(join(dir, "never-existed.lock"))).resolves.toBeUndefined()
+    await expect(release(join(dir, "never-existed.lock"), "any-token")).resolves.toBeUndefined()
   })
 })

--- a/packages/kobe/test/orchestrator/store-concurrency.test.ts
+++ b/packages/kobe/test/orchestrator/store-concurrency.test.ts
@@ -37,7 +37,10 @@ describe("TaskIndexStore multi-process consistency", () => {
   }
 
   /** Read the on-disk manifest directly — the source of truth, not a cache. */
-  async function readDisk(): Promise<{ tasks: Array<{ id: string; title: string }> }> {
+  async function readDisk(): Promise<{
+    tasks: Array<{ id: string; title: string }>
+    removed?: Array<{ id: string; at: string }>
+  }> {
     const raw = await readFile(join(home, ".rove", "tasks.json"), "utf8")
     return JSON.parse(raw)
   }
@@ -81,6 +84,32 @@ describe("TaskIndexStore multi-process consistency", () => {
     const ids = disk.tasks.map((t) => t.id)
     expect(ids).toContain(survivor.id)
     expect(ids).not.toContain(task.id)
+  })
+
+  it("a peer's deletion beats this instance's pending edit (persistent tombstone)", async () => {
+    const procA = new TaskIndexStore({ homeDir: home })
+    await procA.load()
+    const task = await procA.create(input("doomed"))
+
+    const procB = new TaskIndexStore({ homeDir: home })
+    await procB.load()
+
+    // A deletes; B then touches the SAME task without flushing (touchRecency
+    // marks dirty but defers the save). At B's next save the task is dirty in
+    // B's memory while gone from disk — the exact issue #47 resurrection
+    // recipe: the merge's dirty branch used to write it back unconditionally.
+    // A's on-disk tombstone must beat B's pending edit.
+    await procA.remove(task.id)
+    procB.touchRecency(task.id)
+    const survivor = await procB.create(input("survivor"))
+
+    const disk = await readDisk()
+    const ids = disk.tasks.map((t) => t.id)
+    expect(ids).toContain(survivor.id)
+    expect(ids).not.toContain(task.id)
+    // The tombstone itself is preserved by B's merge, so a THIRD stale writer
+    // can't resurrect the task either.
+    expect(disk.removed?.some((r) => r.id === task.id)).toBe(true)
   })
 
   it("does not resurrect a legacy task after a peer creates the canonical index", async () => {

--- a/packages/kobe/test/orchestrator/store-tmp-collision.test.ts
+++ b/packages/kobe/test/orchestrator/store-tmp-collision.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Deterministic reconstruction of the CI flake behind issue #53:
+ * `ENOENT: rename '.../tasks.json.tmp' -> '.../tasks.json'`.
+ *
+ * The flake needed two writers inside the critical section at once (the old
+ * lockfile could be stolen through its empty-content window) PLUS a shared
+ * staging file: writer B renamed `<path>.tmp` away, so writer A's rename hit
+ * ENOENT. Stress runs only reproduced it under a full 8-worker suite; this
+ * test builds the interleaving by construction instead — it pauses writer A
+ * between its tmp write and its rename, force-breaks the lock the way the
+ * old steal did, lets writer B complete a save, then resumes A.
+ *
+ * Own file because it module-mocks `node:fs/promises` to add the pause hook.
+ */
+
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const gate = vi.hoisted(() => ({
+  /** When set, the next rename of a `.tmp` staging file trips this once… */
+  trap: null as ((from: string) => void) | null,
+  /** …and then suspends on this promise until the test releases it. */
+  block: null as Promise<void> | null,
+}))
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const real = await importOriginal<typeof import("node:fs/promises")>()
+  return {
+    ...real,
+    rename: async (from: string, to: string): Promise<void> => {
+      if (gate.trap && String(from).endsWith(".tmp")) {
+        const trip = gate.trap
+        const block = gate.block
+        gate.trap = null
+        trip(String(from))
+        if (block) await block
+      }
+      return real.rename(from, to)
+    },
+  }
+})
+
+import { mkdir, mkdtemp, readFile, rm, unlink } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { type TaskCreateInput, TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+
+describe("TaskIndexStore staging-file isolation (issue #53)", () => {
+  let home: string
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "kobe-store-tmp-collision-"))
+    await mkdir(join(home, ".rove"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    gate.trap = null
+    gate.block = null
+    await rm(home, { recursive: true, force: true })
+  })
+
+  function input(title: string): TaskCreateInput {
+    return {
+      title,
+      repo: "/repo",
+      branch: `kobe/${title}`,
+      worktreePath: `/repo/.kobe/worktrees/${title}`,
+      kind: "task",
+      status: "backlog",
+    }
+  }
+
+  it("a rival writer inside the critical section cannot break this save's rename", async () => {
+    const storeA = new TaskIndexStore({ homeDir: home })
+    const storeB = new TaskIndexStore({ homeDir: home })
+    await storeA.load()
+    await storeB.load()
+
+    // Arm the trap: A's save pauses at the instant its staging file is fully
+    // written, one step before the rename.
+    let releaseA!: () => void
+    gate.block = new Promise<void>((resolve) => {
+      releaseA = resolve
+    })
+    const paused = new Promise<string>((resolve) => {
+      gate.trap = resolve
+    })
+
+    const saveA = storeA.create(input("alpha"))
+    await paused // A holds the lock; tmp written; rename pending
+
+    // Force-break the lock exactly the way the old empty-window steal did:
+    // the lockfile vanishes under A, so B's save enters the critical section
+    // while A is still inside it.
+    await unlink(join(home, ".rove", "tasks.json.lock"))
+    await storeB.create(input("beta"))
+
+    // Resume A. With the old SHARED `<path>.tmp`, B's completed save had
+    // renamed the staging file away and this rename threw ENOENT — the CI
+    // flake. With per-save staging names it completes. (B's task is
+    // legitimately clobbered here: we broke the mutex on purpose, so
+    // last-write-wins on the whole file is the expected data outcome — the
+    // invariant under test is only that A's save cannot CRASH.)
+    releaseA()
+    await expect(saveA).resolves.toBeDefined()
+    const disk = JSON.parse(await readFile(join(home, ".rove", "tasks.json"), "utf8")) as {
+      tasks: Array<{ title: string }>
+    }
+    expect(disk.tasks.some((t) => t.title === "alpha")).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes rove issues #53 and #47 — two faces of the same shared write path (`~/.rove/tasks.json`), smaller together than apart.

**Not for merging tonight** — parked for review; see the stack note at the bottom.

## #53 — the lock did not actually exclude

The chosen direction is *tighten the lock*, not *tmp-only*, because the real mutex break is upstream of the tmp collision: `writeFile(lockPath, pid, {flag:"wx"})` **creates the lockfile before its content lands**. A reader in that window sees an empty file, parses pid `-1`, classifies a live holder as stale, and steals the lock. From there the vanished-lock retry and the shared tmp turn into the CI flake's `rename tasks.json.tmp ENOENT`.

- Lock contents are written to a private sidecar and `link(2)`ed into place — never observable half-written.
- Contents are `pid:token`, so two stores in the **same process** are distinct holders (`parseInt` still reads the pid, so old builds and legacy bare-pid locks stay compatible in both directions).
- `release` only unlinks a lock it still owns, so a forced takeover cannot cascade a third writer into the critical section.
- Each save also stages through a **unique tmp file** — the issue's other direction, kept as defense: a peer running an old build with the broken lock can no longer make our `rename` crash.

## #47 — deletion vs concurrent edit

Chose persistent tombstones over documenting last-write-wins. The racing "edit" is nearly always a trivial recency/status bump; the delete is a deliberate user action that already destroyed the worktree, so a resurrected row is a ghost the user has to delete again.

Deletions persist as an optional `removed: [{id, at}]` field that beats a concurrent dirty edit **from either side**, pruned after 30 days (a tombstone only has to outlive live writers' in-memory dirty refs). Task ids are ULIDs and never reused, so a tombstone cannot shadow a legitimate new task.

`version` stays **3** on purpose: older builds ignore the field on read and drop it on write, degrading to today's behavior — whereas a version bump would make them treat the whole manifest as unsupported and recover empty.

## Tests — deterministic, not stress

The original flake needed a full 8-worker suite to reproduce once, so neither test relies on winning a race:

- `store-tmp-collision.test.ts` pauses one save between its tmp write and its rename (fs mock), force-breaks the lock the way the old steal did, completes a rival save, and reproduces the exact `ENOENT` against the old shared-tmp code.
- `store-concurrency.test.ts` uses `touchRecency` to hold a deleted task dirty across a peer's `remove`.

Both verified red against the reverted fix. Full `test:fast` (3484 tests), lint, and typecheck green.

---

Stacked context: opened alongside #567 (`renameBranch` convergence). Independent file sets, no conflict — both are parked for review rather than merge.