### PR TITLE
fix(terminal): drag-selection on the alternate screen follows the app's scroll

### DIFF
--- a/.changeset/alt-screen-drag-selection-follows.md
+++ b/.changeset/alt-screen-drag-selection-follows.md
@@ -1,0 +1,19 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A drag-selection on an engine tab now follows the content the app scrolls
+under it, and the copy contains every line the highlight covered.
+
+Engines run on the alternate screen: the snapshot is one screen, and the
+edge-drag scroll is forwarded to the app as wheel ticks (`fedb8720`). The app
+scrolled, the content moved, but the selection was addressed in snapshot rows
+that never changed — so the highlight sat still as a screen-fixed rectangle
+and rows scrolling in from the top never joined it. The pane now measures how
+far the content actually moved between snapshots (the wheel only *asks* the
+app to scroll, so the displacement is read back from the redraw, not assumed
+from tick counts), moves the anchor with the content while the head stays
+pinned to the pointer, and banks rows that scroll off screen in a bounded
+per-drag buffer. Extraction runs over that composed buffer through the same
+path the highlight's range feeds, so what you see selected is what mouse-up
+copies — including the rows that already scrolled away.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -174,20 +174,23 @@ export function Terminal(props: TerminalProps) {
    * Engine tabs are why this matters for the drag: Claude Code runs on the
    * ALTERNATE screen, where there is no local scrollback to move at all, so a
    * drag held at the edge has to ask the app to scroll, exactly as the wheel
-   * does. `screenX`/`screenY` are absolute pointer coords.
+   * does. `screenX`/`screenY` are absolute pointer coords. Returns true when
+   * the scroll was forwarded — the selection hook then tracks the content
+   * shifts the app's redraws cause under the fixed snapshot rows.
    */
-  const scrollFromPointer = (lines: number, screenX: number, screenY: number): void => {
-    if (lines === 0) return
+  const scrollFromPointer = (lines: number, screenX: number, screenY: number): boolean => {
+    if (lines === 0) return false
     const direction = lines < 0 ? "up" : "down"
     if (pty && !pty.killed && bodyEl) {
       const col = Math.max(1, screenX - bodyEl.screenX + 1)
       const row = Math.max(1, screenY - bodyEl.screenY + 1)
       if (pty.wheel(direction, col, row)) {
         for (let i = 1; i < Math.abs(lines); i++) pty.wheel(direction, col, row)
-        return
+        return true
       }
     }
     scrollBy(lines)
+    return false
   }
 
   /* --------- viewport slicing ---------- */
@@ -384,7 +387,10 @@ export function Terminal(props: TerminalProps) {
         // One line per event — opentui's parser emits delta:1 per wheel
         // tick already granulated by the host terminal.
         const step = Math.max(1, scroll.delta || 1)
-        scrollFromPointer(scroll.direction === "up" ? -step : step, evt.x, evt.y)
+        const forwarded = scrollFromPointer(scroll.direction === "up" ? -step : step, evt.x, evt.y)
+        // A wheel tick mid-drag scrolls the app too — the selection must
+        // follow that shift exactly as it follows the edge pull's.
+        if (forwarded) selection.noteAppScroll()
       }}
     >
       {/* Scroll affordance overlays the historical viewport instead of

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -223,7 +223,6 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
   // fixed snapshot rows. Measure each snapshot change during such a drag and
   // move the anchor with the content (the head stays pinned to the pointer);
   // rows that scrolled off screen are banked so the copy still has them.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on snapshot changes; everything else is refs.
   useEffect(() => {
     const prev = lastSnapshotRef.current
     lastSnapshotRef.current = opts.snapshot

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -26,6 +26,14 @@
  * only scrolls; the head is re-derived from the last pointer position
  * whenever the viewport moves, so it follows the scroll exactly and a wheel
  * tick mid-drag extends the selection too.
+ *
+ * When the scroll was FORWARDED to an app that owns its own scrollback (an
+ * engine on the alternate screen), the viewport never moves — the app redraws
+ * and the content shifts under snapshot row numbers that stay put. While such
+ * a drag is live, every snapshot change is measured with `snapshotShift`; the
+ * ANCHOR moves by the measured displacement (the head stays pinned to the
+ * pointer), and the rows that scrolled off screen are banked in a bounded
+ * shadow so the copy contains exactly what the highlight covered.
  */
 
 import type { BoxRenderable } from "@opentui/core"
@@ -35,9 +43,14 @@ import { copyTextToSystemClipboard } from "../../../tui/lib/clipboard-copy"
 import type { TerminalRow } from "../../../tui/panes/terminal/pty"
 import {
   type CellPoint,
+  EMPTY_SHADOW,
   type SelectionRange,
-  extractSelection,
+  type SelectionShadow,
+  clampRowToShadow,
+  extractShadowedSelection,
   pointerCell,
+  shiftShadow,
+  snapshotShift,
 } from "../../../tui/panes/terminal/terminal-selection"
 
 export type { CellPoint, SelectionRange } from "../../../tui/panes/terminal/terminal-selection"
@@ -58,8 +71,10 @@ export interface UseTerminalSelectionOpts {
    * positive toward live. The pointer's absolute coords come along because the
    * pane may have to forward wheel ticks to an app that owns its own
    * scrollback (an engine on the alternate screen has no local scrollback).
+   * Returns true when the scroll was forwarded to the app that way — the cue
+   * to start measuring content shifts against the snapshot.
    */
-  scrollBy: (lines: number, screenX: number, screenY: number) => void
+  scrollBy: (lines: number, screenX: number, screenY: number) => boolean
 }
 
 export interface UseTerminalSelectionResult {
@@ -73,6 +88,8 @@ export interface UseTerminalSelectionResult {
   endDragging: () => void
   clearSelection: () => void
   copySelection: () => void
+  /** The pane forwarded a wheel to the app mid-drag (outside the edge pull). */
+  noteAppScroll: () => void
 }
 
 export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTerminalSelectionResult {
@@ -119,6 +136,9 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
   const beginSelection = (cell: CellPoint): void => {
     draggingRef.current = true
     captureDrag(opts.bodyEl)
+    appScrolledRef.current = false
+    shadowRef.current = EMPTY_SHADOW
+    lastSnapshotRef.current = opts.snapshot
     // Mirrored into a ref as well: the drag events of a fast gesture land
     // before React has re-rendered with the new anchor, and the auto-scroll
     // direction check must not read a stale (null) one.
@@ -132,6 +152,12 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
   // The last pointer position of the live drag, in absolute screen coords —
   // the auto-scroll tick and the post-scroll head refresh both re-read it.
   const dragPointRef = useRef<{ x: number; y: number } | null>(null)
+  // App-owned scrolling (alt-screen engines): set once a wheel was forwarded
+  // during this drag; from then on snapshot changes are measured and the
+  // anchor + shadow follow the content. All reset by the next beginSelection.
+  const appScrolledRef = useRef(false)
+  const shadowRef = useRef<SelectionShadow>(EMPTY_SHADOW)
+  const lastSnapshotRef = useRef(opts.snapshot)
   const autoScrollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   // The tick closes over render-derived geometry, so it's refreshed after
   // every render rather than captured once when the interval starts.
@@ -177,7 +203,8 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
       }
       // Speed follows how far past the edge the pointer is, capped so a drag
       // to the edge of the screen doesn't fly through the whole scrollback.
-      opts.scrollBy(Math.max(-AUTO_SCROLL_MAX_LINES, Math.min(AUTO_SCROLL_MAX_LINES, pull)), point.x, point.y)
+      const capped = Math.max(-AUTO_SCROLL_MAX_LINES, Math.min(AUTO_SCROLL_MAX_LINES, pull))
+      if (opts.scrollBy(capped, point.x, point.y)) appScrolledRef.current = true
     }
   })
 
@@ -192,6 +219,26 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     if (at) setSelHead(at.cell)
   }, [opts.visibleRangeStart])
 
+  // App-owned scrolling never moves the viewport — the CONTENT moves under
+  // fixed snapshot rows. Measure each snapshot change during such a drag and
+  // move the anchor with the content (the head stays pinned to the pointer);
+  // rows that scrolled off screen are banked so the copy still has them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on snapshot changes; everything else is refs.
+  useEffect(() => {
+    const prev = lastSnapshotRef.current
+    lastSnapshotRef.current = opts.snapshot
+    if (!draggingRef.current || !appScrolledRef.current || prev === opts.snapshot) return
+    const shift = snapshotShift(prev, opts.snapshot)
+    if (shift === 0) return
+    shadowRef.current = shiftShadow(shadowRef.current, prev, shift)
+    const shadow = shadowRef.current
+    const length = opts.snapshot.length
+    const follow = (cell: CellPoint | null): CellPoint | null =>
+      cell ? { row: clampRowToShadow(cell.row + shift, length, shadow), col: cell.col } : cell
+    anchorRef.current = follow(anchorRef.current)
+    setSelAnchor(follow)
+  }, [opts.snapshot])
+
   // Unmount mid-drag (tab closed, pane swapped) must not leave a timer behind.
   useEffect(
     () => () => {
@@ -202,7 +249,7 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
 
   const copySelection = (): void => {
     if (!selection) return
-    const text = extractSelection(opts.snapshot, selection)
+    const text = extractShadowedSelection(opts.snapshot, shadowRef.current, selection)
     if (text.trim().length > 0) copyTextToSystemClipboard(text, (payload) => renderer?.copyToClipboardOSC52(payload))
   }
 
@@ -220,9 +267,14 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     },
     clearSelection: () => {
       anchorRef.current = null
+      appScrolledRef.current = false
+      shadowRef.current = EMPTY_SHADOW
       setSelAnchor(null)
       setSelHead(null)
     },
     copySelection,
+    noteAppScroll: () => {
+      if (draggingRef.current) appScrolledRef.current = true
+    },
   }
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-mock.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-mock.ts
@@ -84,6 +84,17 @@ export class MockTaskPty implements TaskPtyLike {
     this.writes.push(data)
   }
 
+  /**
+   * Scripted full-screen repaint: replace the whole snapshot instead of
+   * appending — how an alternate-screen app (an engine tab) redraws after
+   * scrolling its own content.
+   */
+  replaceScreen(data: string): void {
+    if (this._killed) return
+    this.buffer = ""
+    this.feed(data)
+  }
+
   onData(cb: DataListener): () => void {
     this.listeners.add(cb)
     if (this.buffer !== "") {

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -177,6 +177,132 @@ function overlayRowSpan(row: readonly Chunk[], from: number, to: number): Chunk[
   return out
 }
 
+/* --------- alt-screen drag scrolling ---------- */
+
+/**
+ * An app that owns its own scrollback (an engine on the ALTERNATE screen) has
+ * a one-screen snapshot: forwarding wheel ticks scrolls the APP, the content
+ * shifts on screen, and the snapshot row numbers don't move. The pieces below
+ * keep a drag-selection glued to the content anyway:
+ *
+ *  - `snapshotShift` MEASURES how far the content actually moved between two
+ *    snapshots — the wheel only *asks* the app to scroll (`pty.wheel` reports
+ *    "sequence sent", not "app moved N lines"), so the displacement has to be
+ *    read back from what changed on screen.
+ *  - `shiftShadow` banks the rows that scrolled off screen during the drag so
+ *    the copy can include them; `extractShadowedSelection` extracts over the
+ *    composed buffer through the SAME `extractSelection` path the highlight's
+ *    range feeds — see-it = copy-it by construction.
+ *
+ * Coordinates stay snapshot-addressed: shadow rows live at logical indices
+ * below 0 (`above`, top-first) and at `snapshotLength` and beyond (`below`).
+ */
+export type SelectionShadow = {
+  /** Rows scrolled off the TOP, top-first: `above[i]` sits at logical index `i - above.length`. */
+  readonly above: readonly (readonly Chunk[])[]
+  /** Rows scrolled off the BOTTOM, contiguous: `below[0]` sits at logical index `snapshotLength`. */
+  readonly below: readonly (readonly Chunk[])[]
+}
+
+export const EMPTY_SHADOW: SelectionShadow = { above: [], below: [] }
+
+/** Rows banked per drag. ponytail: at the auto-scroll cap (~100 lines/s) this
+ *  is ~20s of held drag; past it the anchor clamps instead of silently
+ *  dropping middle rows. Raise if someone actually drags that long. */
+export const SHADOW_ROW_CAP = 2000
+
+/**
+ * The vertical displacement of the content between two snapshots: positive
+ * means the content moved DOWN on screen (`prev[i]` reappears at
+ * `next[i + shift]`) — a scroll toward older content. 0 when nothing moved or
+ * when no shift explains a majority of the non-blank rows it overlaps (a full
+ * repaint, ambiguous repeated content): the conservative answer, leaving the
+ * selection screen-fixed rather than guessing. Score ties resolve to the
+ * smaller displacement, so screens of identical repeated rows — which "match"
+ * at every shift, best at the largest overlap — settle on 0.
+ */
+export function snapshotShift(prev: readonly (readonly Chunk[])[], next: readonly (readonly Chunk[])[]): number {
+  if (prev === next || prev.length === 0 || next.length === 0) return 0
+  const prevText = prev.map(rowText)
+  const nextText = next.map(rowText)
+  const maxShift = Math.min(prev.length, next.length) - 1
+  let best = 0
+  let bestScore = -1
+  let bestOverlap = 0
+  for (let k = -maxShift; k <= maxShift; k++) {
+    let score = 0
+    let overlap = 0
+    for (let i = 0; i < prevText.length; i++) {
+      const j = i + k
+      if (j < 0 || j >= nextText.length) continue
+      const t = prevText[i] as string
+      if (t.trim() === "") continue
+      overlap++
+      if (t === nextText[j]) score++
+    }
+    if (score > bestScore || (score === bestScore && Math.abs(k) < Math.abs(best))) {
+      best = k
+      bestScore = score
+      bestOverlap = overlap
+    }
+  }
+  // Two corroborating rows minimum: one lone matching row at some extreme
+  // shift is far likelier to be a repaint coincidence than a real scroll.
+  return bestScore > 1 && bestScore * 2 > bestOverlap ? best : 0
+}
+
+/**
+ * Roll the shadow forward across one measured shift: bank the rows of
+ * `previous` that just scrolled off screen, and drop shadow rows the app
+ * re-revealed (a reversed drag) so they aren't extracted twice.
+ */
+export function shiftShadow(
+  shadow: SelectionShadow,
+  previous: readonly (readonly Chunk[])[],
+  shift: number,
+  cap = SHADOW_ROW_CAP,
+): SelectionShadow {
+  if (shift === 0) return shadow
+  let above = shadow.above
+  let below = shadow.below
+  if (shift > 0) {
+    // Content moved down: the last rows fell off the bottom; the nearest
+    // above-shadow rows are back on screen.
+    below = [...previous.slice(Math.max(0, previous.length - shift)), ...below]
+    above = above.slice(0, Math.max(0, above.length - shift))
+  } else {
+    above = [...above, ...previous.slice(0, Math.min(previous.length, -shift))]
+    below = below.slice(Math.min(below.length, -shift))
+  }
+  if (above.length > cap) above = above.slice(above.length - cap)
+  if (below.length > cap) below = below.slice(0, cap)
+  return { above, below }
+}
+
+/** Clamp a logical row to what the shadow can still address (the cap). */
+export function clampRowToShadow(row: number, snapshotLength: number, shadow: SelectionShadow): number {
+  return Math.min(snapshotLength - 1 + shadow.below.length, Math.max(0 - shadow.above.length, row))
+}
+
+/**
+ * Extract over the composed drag buffer — shadow rows glued around the live
+ * snapshot, the range translated into composed space. Same `extractSelection`
+ * the shadow-free path uses; with an empty shadow this IS that path.
+ */
+export function extractShadowedSelection(
+  snapshot: readonly (readonly Chunk[])[],
+  shadow: SelectionShadow,
+  range: SelectionRange,
+): string {
+  if (shadow.above.length === 0 && shadow.below.length === 0) return extractSelection(snapshot, range)
+  const offset = shadow.above.length
+  const rows = [...shadow.above, ...snapshot, ...shadow.below]
+  return extractSelection(rows, {
+    anchor: { row: range.anchor.row + offset, col: range.anchor.col },
+    head: { row: range.head.row + offset, col: range.head.col },
+  })
+}
+
 /**
  * Paint the selection over VIEWPORT rows. `firstRow` is the absolute
  * snapshot index of `rows[0]` (the viewport start), mapping the

--- a/packages/kobe/test/render/terminal-drag-autoscroll.test.tsx
+++ b/packages/kobe/test/render/terminal-drag-autoscroll.test.tsx
@@ -3,10 +3,14 @@
 import { expect, test } from "bun:test"
 import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
 import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
+import { ATTR } from "../../src/tui/panes/terminal/sgr"
 import { type RenderHandle, act, renderComponent } from "./harness"
 
-/** A pane with 80 rows of history, its first visible row at screen y=2. */
-const mountPane = async (taskId: string): Promise<[RenderHandle, ReturnType<typeof createScriptedPtyRegistry>]> => {
+/** A pane fed `content`, its first visible row at screen y=2 (body: 16 rows). */
+const mountPane = async (
+  taskId: string,
+  content = Array.from({ length: 80 }, (_, i) => `line-${i + 1}`).join("\r\n"),
+): Promise<[RenderHandle, ReturnType<typeof createScriptedPtyRegistry>]> => {
   const harness = createScriptedPtyRegistry()
   let handle: RenderHandle | undefined
   await act(async () => {
@@ -24,7 +28,7 @@ const mountPane = async (taskId: string): Promise<[RenderHandle, ReturnType<type
   if (!handle) throw new Error("terminal mount failed")
   const mounted = handle
   await act(async () => {
-    harness.last().feed(Array.from({ length: 80 }, (_, i) => `line-${i + 1}`).join("\r\n"))
+    harness.last().feed(content)
     await mounted.frame()
   })
   return [mounted, harness]
@@ -122,16 +126,41 @@ test("dragging sideways along the top row does not scroll", async () => {
  * wheel scrolls it: by forwarding wheel ticks, not by moving a viewport that
  * cannot move. Claude Code is exactly this case, so without it a drag-select
  * at the edge of an engine tab does nothing at all.
+ *
+ * And forwarding alone is not the fix (issue #54): the app scrolls, the
+ * content shifts, but the snapshot row numbers stay put — so the SELECTION
+ * must follow the measured content shift, not stay a screen-fixed rectangle.
+ * The drag here is held at the edge while the scripted app scrolls itself;
+ * the highlight must keep growing over the rows scrolling in from the top.
  */
 test("a drag held at the edge scrolls an app that owns its own scrollback", async () => {
-  const [handle, harness] = await mountPane("drag-forwards-wheel")
+  // A 16-row alternate screen over an 80-line document, scrolled to the
+  // bottom: exactly an engine tab's snapshot shape (one screen, no history).
+  const doc = Array.from({ length: 80 }, (_, i) => `line-${i + 1}`)
+  let top = 64
+  const [handle, harness] = await mountPane("drag-forwards-wheel", doc.slice(top, top + 16).join("\n"))
   const wheels: string[] = []
-  const pty = harness.last() as unknown as { wheel: (d: string) => boolean }
-  pty.wheel = (direction: string): boolean => {
+  const pty = harness.last()
+  pty.wheel = (direction: "up" | "down"): boolean => {
     wheels.push(direction)
+    // The scripted app scrolls itself: full-screen repaint one line over.
+    top = direction === "up" ? Math.max(0, top - 1) : Math.min(64, top + 1)
+    pty.replaceScreen(doc.slice(top, top + 16).join("\n"))
     return true
   }
+  const highlightedLines = async (): Promise<string[]> => {
+    const frame = await handle.spans()
+    return frame.lines
+      .filter((line) => line.spans.some((s) => (s.attributes & ATTR.INVERSE) !== 0))
+      .map((line) =>
+        line.spans
+          .map((s) => s.text)
+          .join("")
+          .trim(),
+      )
+  }
   try {
+    // Press on line-75 (body row 10), drag up to the edge row and hold.
     await act(async () => {
       await handle.mockMouse.pressDown(20, 12)
       await handle.mockMouse.emitMouseEvent("drag", 20, 2)
@@ -142,6 +171,17 @@ test("a drag held at the edge scrolls an app that owns its own scrollback", asyn
     expect(wheels.every((d) => d === "up")).toBe(true)
     // The app scrolls itself; the pane's own viewport must stay put.
     expect(await handle.frame()).not.toMatch(/scrolled|已回滚/)
+    expect(top).toBeLessThan(64)
+
+    // The selection followed the content: rows scrolled in from the top are
+    // highlighted (the selection GREW past the 11 rows the press-to-edge drag
+    // covered on its own — head row 0 to anchor row 10), and the anchor row's
+    // content stayed selected as it moved down the screen.
+    const after = await highlightedLines()
+    expect(after.length).toBeGreaterThan(11)
+    expect(after[0]).toBe(`line-${top + 1}`) // head still pinned at the top edge
+    const anchorRow = after.indexOf("line-75")
+    expect(anchorRow === -1 || anchorRow > 10).toBe(true) // moved down (or off) with the content
   } finally {
     handle.destroy()
   }

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from "vitest"
 import { displayWidth } from "../../src/lib/display-width"
 import { ATTR, type Chunk } from "../../src/tui/panes/terminal/sgr"
 import {
+  EMPTY_SHADOW,
+  clampRowToShadow,
   extractSelection,
+  extractShadowedSelection,
   orderRange,
   overlaySelection,
   pointerCell,
   rowSpan,
+  shiftShadow,
+  snapshotShift,
 } from "../../src/tui/panes/terminal/terminal-selection"
 
 const row = (text: string): readonly Chunk[] => [{ text }]
@@ -165,5 +170,87 @@ describe("pointerCell", () => {
     expect(at(0, -100, 40).cell.row).toBe(0) // above the buffer → first row
     expect(at(0, 500, 190).cell.row).toBe(199) // past the buffer → last row
     expect(pointerCell(0, 0, grid, 0, 0).cell.row).toBe(0) // empty snapshot
+  })
+})
+
+describe("alt-screen drag scrolling (shadow buffer)", () => {
+  // A 20-line document seen through a 5-row alternate screen. `screen(top)`
+  // is the app's repaint after scrolling to `top` — one full screen, no
+  // scrollback, exactly what an engine tab's snapshot looks like.
+  const doc = Array.from({ length: 20 }, (_, i) => `line-${String(i + 1).padStart(2, "0")}`)
+  const screen = (top: number): (readonly Chunk[])[] => doc.slice(top, top + 5).map(row)
+
+  it("snapshotShift measures the content displacement, not the wheel ticks", () => {
+    // Scroll up (older content): the surviving rows sit LOWER on screen.
+    expect(snapshotShift(screen(15), screen(13))).toBe(2)
+    // Scroll down: they sit higher.
+    expect(snapshotShift(screen(11), screen(14))).toBe(-3)
+    // Nothing moved.
+    expect(snapshotShift(screen(10), screen(10))).toBe(0)
+  })
+
+  it("snapshotShift stays at 0 for a repaint no shift explains", () => {
+    // Full repaint with unrelated content: no candidate shift reaches a
+    // majority — the selection must stay screen-fixed, not jump.
+    const other = ["alpha", "bravo", "charlie", "delta", "echo"].map(row)
+    expect(snapshotShift(screen(0), other)).toBe(0)
+    // All-blank rows match any shift; ambiguity must resolve to "no move".
+    const blank = ["", "", "", "", ""].map(row)
+    expect(snapshotShift(blank, blank)).toBe(0)
+    // A status line changing in place is not a scroll.
+    const spinner = [...screen(5).slice(0, 4), row("busy ⠧")]
+    const spinner2 = [...screen(5).slice(0, 4), row("busy ⠇")]
+    expect(snapshotShift(spinner, spinner2)).toBe(0)
+  })
+
+  it("banks scrolled-off rows and extracts the full drag, off-screen rows included", () => {
+    // Anchor pressed on row 3 (line-19), head dragged to the top edge; the
+    // app then scrolls up twice by 2 lines. The anchor follows the content
+    // off the bottom; the copy must contain every line the drag covered.
+    let shadow = EMPTY_SHADOW
+    let anchor = { row: 3, col: 10 }
+    let visible = screen(15)
+    for (const top of [13, 11]) {
+      const next = screen(top)
+      const shift = snapshotShift(visible, next)
+      expect(shift).toBe(2)
+      shadow = shiftShadow(shadow, visible, shift)
+      anchor = { row: clampRowToShadow(anchor.row + shift, next.length, shadow), col: anchor.col }
+      visible = next
+    }
+    // line-19 started at row 3; after +4 it lives at logical row 7, two rows
+    // past the 5-row screen — inside the shadow.
+    expect(anchor.row).toBe(7)
+    expect(shadow.below.length).toBe(4)
+    const range = { anchor, head: { row: 0, col: 0 } }
+    expect(extractShadowedSelection(visible, shadow, range)).toBe(doc.slice(11, 19).join("\n"))
+    // Highlight and copy agree: every visible row overlaySelection paints is a
+    // line the extraction contains (the overlay sees the same range).
+    const painted = overlaySelection(visible, range, 0, 10)
+    for (let i = 0; i < painted.length; i++) expect(painted[i]).not.toBe(visible[i])
+  })
+
+  it("drops re-revealed rows on a reversed drag instead of extracting them twice", () => {
+    // Up 4 (banks 4 rows below), then back down 3: three of those rows are on
+    // screen again and must leave the shadow, keeping the composed buffer
+    // contiguous.
+    let shadow = shiftShadow(EMPTY_SHADOW, screen(15), 2)
+    shadow = shiftShadow(shadow, screen(13), 2)
+    expect(shadow.below.map((r) => r[0]?.text)).toEqual(doc.slice(16, 20))
+    shadow = shiftShadow(shadow, screen(11), -3)
+    expect(shadow.above.map((r) => r[0]?.text)).toEqual(doc.slice(11, 14))
+    expect(shadow.below.map((r) => r[0]?.text)).toEqual([doc[19]])
+    // Composed space stays contiguous: above ++ screen(14) ++ below.
+    const range = { anchor: { row: -3, col: 0 }, head: { row: 5, col: 10 } }
+    expect(extractShadowedSelection(screen(14), shadow, range)).toBe(doc.slice(11, 20).join("\n"))
+  })
+
+  it("caps the shadow and clamps the anchor to what it can still address", () => {
+    let shadow = shiftShadow(EMPTY_SHADOW, screen(15), 2, 3)
+    shadow = shiftShadow(shadow, screen(13), 2, 3)
+    // Cap 3: the far (anchor-end) row is trimmed, not a middle one.
+    expect(shadow.below.map((r) => r[0]?.text)).toEqual(doc.slice(16, 19))
+    expect(clampRowToShadow(8, 5, shadow)).toBe(7)
+    expect(clampRowToShadow(-9, 5, shadow)).toBe(0)
   })
 })


### PR DESCRIPTION
Fixes rove issue #54 — reported from live use: drag-select to the pane edge scrolls now, but the rows scrolling in **don't join the selection; the highlight stays a fixed-size rectangle**.

**Not for merging tonight** — parked for review alongside #567 and #568.

## Root cause

Selection is addressed in **absolute snapshot row numbers**. That coordinate system only exists for local scrollback.

An engine tab runs on the **alternate screen**: `pty-xterm-snapshot.ts` sets `canAnchor = !alt`, the alt buffer's `length == rows`, so the snapshot is **one screen** and `visibleRangeStart` is permanently 0. `fedb8720` made an edge drag forward wheel ticks so the *app* scrolls itself — the content moves, but **the snapshot row numbers never do**. Anchor and head stay pinned to their original screen rows, so the highlight is a screen-space rectangle with content flowing underneath. Claude Code and codex are both alt-screen, so this is nearly every engine tab.

Worse, and silent: the rows that scrolled away are **not in the snapshot at all**, so they were missing from the copy.

## The fix

- **Measure, don't assume.** `pty.wheel` reports "sequence sent", not "app moved N lines", so `snapshotShift` reads the actual displacement back from what changed between two snapshots. It refuses to guess: no shift explaining a majority of the non-blank rows it overlaps → 0, leaving the selection screen-fixed rather than wrong. Ties resolve to the smaller displacement so a screen of identical repeated rows settles on 0.
- **Anchor follows the content, head stays pinned to the pointer** — so the selection grows from the edge the way it does on a normal screen.
- **Bounded per-drag shadow buffer** banks the scrolled-off rows (cap 2000 ≈ 20s at the auto-scroll ceiling; past it the anchor clamps instead of silently dropping middle rows). Reversing the drag drops re-revealed rows so nothing extracts twice.
- **Extraction and highlight share one range** through the same `extractSelection` path — see-it = copy-it by construction. That divergence was the nastiest half of the bug; the fix closes it rather than adding a second way to compute it.

Pure logic lives in `tui/panes/terminal/terminal-selection.ts` (framework-free, vitest-pinnable); React reactivity stays in `use-terminal-selection.ts`.

## Closes the coverage gap that let this ship

The existing render test `"a drag held at the edge scrolls an app that owns its own scrollback"` only asserted that **wheel ticks went out** — never that the selection followed. That is why `fedb8720` merged green.

It now drives a scripted 16-row alternate screen over an 80-line document that repaints itself one line per wheel tick, and asserts the highlight grows past the rows the press-to-edge drag covered on its own, that the head stays pinned at the top edge, and that the anchor's content moved down with the scroll.

**Verified red against the pre-fix code** (`3 pass / 1 fail` on `expect(after.length).toBeGreaterThan(11)`), green after. Plus 87 lines of unit tests over `snapshotShift` / `shiftShadow` / `extractShadowedSelection`.

Full `test:fast` (3484) + render track (213) green; lint and typecheck clean.