### PR TITLE
fix(engine): make EngineIdentity the consumed source of display-name copy

### DIFF
--- a/.changeset/engine-identity-owned-copy.md
+++ b/.changeset/engine-identity-owned-copy.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Wire `EngineIdentity` into the live display-name path: the built-in registry entries now derive `displayName` from each adapter's `identity.shortName`, so the identity contract AGENTS.md points at is what every neutral layer actually reads through `engineDisplayName()`. A new architecture test (`test/architecture/engine-owned-copy.test.ts`) locks the boundary in: any capitalized vendor name landing in TUI/web/orchestrator/client/daemon source outside the two documented bridge fallbacks fails CI.

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -226,7 +226,10 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
   claude: {
     vendor: "claude",
     builtin: true,
-    displayName: "Claude",
+    // The adapter's EngineIdentity is the source of truth for name copy
+    // (AGENTS.md: engine-owned UI data); displayName is the resolved view
+    // every neutral layer reads via engineDisplayName().
+    displayName: claudeIdentity.shortName,
     defaultCommand: ["claude"],
     history: claudeHistoryReader,
     detectAccount: (deps) => detectClaudeAccount(deps),
@@ -248,7 +251,7 @@ const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineReg
   codex: {
     vendor: "codex",
     builtin: true,
-    displayName: "Codex",
+    displayName: codexIdentity.shortName,
     defaultCommand: ["codex"],
     // Effort levels real `codex exec` accepts (the broken `minimal` is
     // deliberately excluded — CHANGELOG 0.5.17).

--- a/packages/kobe/test/architecture/engine-owned-copy.test.ts
+++ b/packages/kobe/test/architecture/engine-owned-copy.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Architecture guard: engine-owned UI data (AGENTS.md).
+ *
+ * Neutral layers (TUI, web SPA, orchestrator, client, daemon) must not
+ * embed vendor display names — name/label/placeholder copy comes from the
+ * engine registry (`AIEngine.identity` → `engineDisplayName()`), so a new
+ * "Ask Claude…" literal in a pane is a regression, not a style choice.
+ *
+ * The scan strips comments first (vendor names in prose are fine) and then
+ * flags any remaining capitalized vendor word — string literals and bare
+ * JSX text alike. Lowercase vendor IDs (`"claude"`) are data keys, not
+ * display copy, and stay legal.
+ */
+
+import { readFileSync, readdirSync } from "node:fs"
+import { join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url))
+
+/** The neutral layers AGENTS.md names. `src/engine` and `src/cli` are vendor-aware by design. */
+const NEUTRAL_ROOTS = [
+  "packages/kobe/src/tui",
+  "packages/kobe/src/tui-react",
+  "packages/kobe/src/orchestrator",
+  "packages/kobe/src/client",
+  "packages/kobe/src/web",
+  "packages/kobe-web/src",
+  "packages/kobe-daemon/src",
+]
+
+const VENDOR_WORD = /\b(Claude|Codex|Copilot|Kimi)\b/
+
+/**
+ * Documented compatibility fallbacks, allowed line-by-line so the exemption
+ * cannot silently widen: a hit in one of these files passes only when the
+ * line contains one of its allowed fragments.
+ */
+const EXEMPT_LINES: Record<string, readonly string[]> = {
+  // Both serve the engine-owned list; the literal pair only fires against an
+  // older bridge / empty registry (see each file's header comment).
+  "packages/kobe-web/src/lib/engines.ts": ['label: "Claude"', 'label: "Codex"'],
+  "packages/kobe-daemon/src/daemon/web-server.ts": ['label: "Claude"'],
+}
+
+function sourceFiles(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) sourceFiles(path, files)
+    else if (/\.(ts|tsx)$/.test(entry.name) && !/\.test\./.test(entry.name)) files.push(path)
+  }
+  return files
+}
+
+/** Drop block comments, then each line's `//` tail. Good enough for a word scan. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .map((line) => line.replace(/\/\/.*/, ""))
+    .join("\n")
+}
+
+describe("engine-owned copy boundary", () => {
+  test("neutral layers carry no vendor display names", () => {
+    const offenders: string[] = []
+    for (const root of NEUTRAL_ROOTS) {
+      for (const file of sourceFiles(join(REPO_ROOT, root))) {
+        const rel = relative(REPO_ROOT, file)
+        const allowed = EXEMPT_LINES[rel] ?? []
+        const lines = stripComments(readFileSync(file, "utf8")).split("\n")
+        lines.forEach((line, i) => {
+          if (!VENDOR_WORD.test(line)) return
+          if (allowed.some((fragment) => line.includes(fragment))) return
+          offenders.push(`${rel}:${i + 1}: ${line.trim()}`)
+        })
+      }
+    }
+    expect(offenders, `vendor copy belongs to the engine registry:\n${offenders.join("\n")}`).toEqual([])
+  })
+
+  test("exempt fallbacks still exist where the exemption points", () => {
+    for (const [rel, fragments] of Object.entries(EXEMPT_LINES)) {
+      const source = readFileSync(join(REPO_ROOT, rel), "utf8")
+      for (const fragment of fragments) {
+        expect(source, `${rel} no longer contains "${fragment}" — drop its exemption`).toContain(fragment)
+      }
+    }
+  })
+})


### PR DESCRIPTION
Addresses **item 1 only** of rove issue #49. The other five entries need owner adjudication (delete vs. wire up) and are untouched.

**Not for merging tonight** — parked for review.

## What the investigation actually found

The issue says `EngineIdentity` / `EngineCapabilities` have zero runtime readers while AGENTS.md mandates identity-driven copy. True — but the neutral layers were **already literal-free**: `c38014ae` wired them to the registry's `displayName` resolver. So the real finding is **two parallel mechanisms**, not a missing one: the registry hard-coded `displayName: "Claude"` beside an `identity.shortName` that said the same thing and was read by nobody.

This connects the two rather than adding a third: built-in entries now derive `displayName` from `identity.shortName`, which makes `engineDisplayName()` the *resolved view of the identity contract*. Contract shape is unchanged — no fields added or removed.

## The guard

`test/architecture/engine-owned-copy.test.ts` scans the neutral layers AGENTS.md names (`tui`, `tui-react`, `orchestrator`, `client`, `web`, `kobe-web/src`, `kobe-daemon/src`) for capitalized vendor words, comments stripped first (vendor names in prose are fine) and lowercase vendor ids left legal (they're data keys, not copy). Two documented compatibility fallbacks are exempt **line-by-line**, so the exemption can't silently widen.

**Verified the guard actually bites**: injecting `const PROBE = "Ask Claude…"` into `tui-react/ui/dialog.tsx` turns it red with `vendor copy belongs to the engine registry`. Without that check a guard like this can pass forever while testing nothing.

## Still open, deliberately

`getCapabilities()` / `allModels()` remain unconsumed — the model-picker UI they'd feed does not exist. That's a build-it-or-drop-it call for the owner, not something to paper over.

`test:fast` 3481 passed, lint and typecheck clean.