### PR TITLE
chore: guard the load-bearing node-pty declaration in the published package

### DIFF
--- a/.changeset/guard-node-pty-dependency.md
+++ b/.changeset/guard-node-pty-dependency.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Guard the published package's `node-pty` declaration: an architecture test now pins it in `dependencies` (it is the only thing that installs node-pty for the bundled daemon's external import — `@sma1lboy/kobe-daemon` is private and never published), and knip no longer flags it as unused (the dynamic `import("node-pty")` is invisible to static analysis).

--- a/packages/kobe/knip.json
+++ b/packages/kobe/knip.json
@@ -2,5 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": ["src/cli/kobe.ts!", "src/cli/rove.ts!", "scripts/build.ts", "test/**/*.test.{ts,tsx}"],
   "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
-  "ignoreBinaries": ["tmux", "claude", "codex", "copilot"]
+  "ignoreBinaries": ["tmux", "claude", "codex", "copilot"],
+  "ignoreDependencies": ["node-pty"]
 }

--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -124,6 +124,23 @@ describe("Rove package distribution", () => {
     expect(commands.some((command) => /--filter @sma1lboy\/kobe(?:\s|$)/.test(command))).toBe(false)
   })
 
+  test("the published package declares node-pty even though kobe's own source never imports it", () => {
+    // The runtime consumer is kobe-daemon (pty-driver.ts's `import("node-pty")`,
+    // shipped as dist/cli/pty-host-node.mjs with node-pty external). But
+    // @sma1lboy/kobe-daemon is private and never published — its dependencies
+    // reach no user install. The ONLY thing that puts node-pty on disk under an
+    // installed @sma1lboy/rove is this declaration; removing it breaks the
+    // Windows ConPTY host with MODULE_NOT_FOUND (verified against a packed
+    // tarball installed into a clean npm prefix, issue #50). knip flags it as
+    // unused because it cannot see the dynamic import — that is a false
+    // positive, suppressed in knip.json, not a license to delete.
+    const pkg = json<{ dependencies: Record<string, string> }>("packages/kobe/package.json")
+    const knip = json<{ ignoreDependencies?: string[] }>("packages/kobe/knip.json")
+
+    expect(pkg.dependencies["node-pty"]).toBeDefined()
+    expect(knip.ignoreDependencies).toContain("node-pty")
+  })
+
   test("daemon typechecking does not rely on the renamed package's hoisted dependencies", () => {
     const daemon = json<{ devDependencies: Record<string, string> }>("packages/kobe-daemon/package.json")
 


### PR DESCRIPTION
Closes rove issue #50 — **by refuting it**. The declaration is not redundant; removing it would have shipped a broken global install.

**Not for merging tonight** — parked for review.

## The issue's premise, and why it doesn't hold

#50 observed that `node-pty` sits in `packages/kobe`'s `dependencies` while `packages/kobe/src` never imports it (grep: 0 hits), and that the real consumer is `kobe-daemon/src/daemon/pty-driver.ts`. All true — but the conclusion (drop the kobe-side declaration) is wrong for a reason grep cannot show:

**`@sma1lboy/kobe-daemon` is `private: true` and unpublished** (`npm view` → 404). Its `dependencies` never reach a user's machine. The bundled daemon's `external` import of `node-pty` therefore resolves against the **published kobe package's** own `node_modules` — which exists only because of the declaration the issue proposed deleting.

## Verified in a real install, not a workspace

Local workspace hoisting hides this exact class of bug, so the check was run against a packed tarball in a clean npm prefix:

- with the declaration → `dist/cli/pty-host-node.mjs` resolves and loads `node-pty`
- without it → `MODULE_NOT_FOUND`

## What landed instead

No dependency change; lockfile untouched. Two guards so the next person doesn't re-run this investigation:

- an architecture test in `package-distribution.test.ts` pins the declaration with the reason attached, so deleting it turns CI red instead of turning global installs red
- `knip.json` suppresses the unused-dependency false positive that prompted #50 in the first place

`test:fast` 3480 passed, lint and typecheck clean, real build verified.