### PR TITLE
feat(engine): upgrade a generic task's protocol from its live session (issue #31, tier b)

### DIFF
--- a/.changeset/protocol-sniff-live-upgrade.md
+++ b/.changeset/protocol-sniff-live-upgrade.md
@@ -1,0 +1,23 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Generic engines now upgrade their protocol from the live session (issue #31,
+tier b).
+
+A task whose `--command` Rove could not name records the generic protocol: it
+launches fine, but history stays unread, no trust dialog is pre-answered, and
+delivery falls back to settle-then-paste. The tier-(b) sniffer landed with
+issue #30 but nothing consumed it — now the daemon's activity observer relays
+each walked live session's evidence (foreground-walk vendor + OSC title) to a
+new upgrade hook: when a generic task's `tab-1` — the engine tab launched
+from the task's own command — identifies exactly one built-in engine, the
+record's protocol is corrected via `setCommand`, metadata only, so the
+history reader, trust store, and delivery mode start applying while what
+launches never changes. Conservative by design: a record that already names a
+protocol is never flipped, a command tier (a) can resolve wins over runtime
+evidence, an engine hand-started in a secondary tab is not evidence, and
+ambiguous or absent fingerprints leave the task generic — a wrong upgrade
+would point Rove at another vendor's files, which is worse than staying
+degraded. The sniff never blocks session startup (it rides the observer's
+existing poll) and writes nothing into the user's session.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -176,7 +176,10 @@ different binary name, a fixed set of flags, a company shim) so the transcript
 reader, workspace-trust pre-answer, and first-message delivery all apply.
 Leave it out and the preset gets the **generic** protocol: it launches and
 runs fine, but Rove reads no history, pre-answers no trust dialog, and falls
-back to silence-window liveness with settle-then-paste delivery.
+back to silence-window liveness with settle-then-paste delivery. If the
+running session later reveals a built-in engine behind the command, Rove
+upgrades the task's protocol automatically — see
+[engine presets and protocols](#engine-presets-and-protocols).
 
 Press `x` on an engine row in Settings to reset a built-in's overrides, or
 remove a custom engine entirely.
@@ -200,7 +203,15 @@ The protocol is **derived** from the command, never declared beside it:
 2. Otherwise Rove can recognise a known engine binary through wrappers
    (`env FOO=1 claude`, `node …/codex.js`), the same walk the process probe
    uses at runtime.
-3. Neither → **generic**, described above.
+3. Neither → **generic**, described above — until the live session says
+   more. While a generic task's engine tab runs, the daemon watches for a
+   built-in engine's fingerprint in it: the engine's process in the tab's
+   process tree, or a status glyph only one engine writes into its terminal
+   title. When exactly one engine is identified, the task's protocol is
+   upgraded in place (the command it launches never changes), so history,
+   trust pre-answer, and delivery start applying mid-session. The sniff is
+   deliberately conservative: ambiguous or absent evidence leaves the task
+   generic, and a task whose protocol is already known is never flipped.
 
 `rove api engine-list` prints every entry with its raw command and resolved
 protocol; copy one into `rove api add --command` verbatim, or edit a flag

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -31,6 +31,7 @@
     "./daemon/client-writer": "./src/daemon/client-writer.ts",
     "./daemon/conflict-collector": "./src/daemon/conflict-collector.ts",
     "./daemon/crash-log": "./src/daemon/crash-log.ts",
+    "./daemon/collectors": "./src/daemon/collectors.ts",
     "./daemon/cwd-task": "./src/daemon/cwd-task.ts",
     "./daemon/engine-events-log": "./src/daemon/engine-events-log.ts",
     "./daemon/event-bus": "./src/daemon/event-bus.ts",

--- a/packages/kobe-daemon/src/daemon/activity-observer.ts
+++ b/packages/kobe-daemon/src/daemon/activity-observer.ts
@@ -73,6 +73,17 @@ export interface ActivityObserverIo {
   foregroundEngines(pids: readonly number[]): Promise<ReadonlyMap<number, string | null>>
   /** Engine-owned title verdict — see kobe's `engineTitleTurnHint`. */
   titleTurnHint(vendor: string, title: string): "working" | "rest" | null
+  /**
+   * Live naming evidence for each ALIVE, WALKED session (issue #31 tier-b
+   * protocol sniff): relayed as-is once per tick; the consumer owns
+   * eligibility and must never feed it back into activity claims (a sniff
+   * names an engine, it does not resurrect a dot). Optional.
+   */
+  onEngineEvidence?(
+    taskId: string,
+    tabId: string,
+    evidence: { readonly walkVendor: string | null; readonly title: string },
+  ): void
 }
 
 export interface ActivityObserverOptions {
@@ -235,6 +246,7 @@ export function startActivityObserver(
         const key = `${track.taskId}::${track.tabId}`
         const session = sessions.find((s) => s.key === key)
         if (!session || track.vendor === undefined) continue
+        io.onEngineEvidence?.(track.taskId, track.tabId, { walkVendor: track.vendor, title: session.title })
         if (track.vendor === null) {
           applyRest(track, "no engine in foreground")
           continue

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -13,7 +13,7 @@ import { DEFAULT_AUTO_TITLE_POLL_MS, startAutoTitlePoller } from "./auto-title-p
 import { DEFAULT_AUTOMATION_TICK_MS, startAutomationRunner } from "./automation-runner.ts"
 import type { AutomationsStore } from "./automations-store.ts"
 import type { DaemonOrchestrator, UpdateInfo } from "./contracts.ts"
-import { logDaemonError } from "./crash-log.ts"
+import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import {
   DEFAULT_KEYBINDINGS_DEBOUNCE_MS,
@@ -56,6 +56,41 @@ export interface AutomationCollectorDeps {
   readonly link: DaemonRpcClient | (() => DaemonRpcClient)
   /** Plugin host getter (constructed after the collectors start, like `link`). */
   readonly plugins?: () => import("../plugins/runtime.ts").PluginHost | null
+}
+
+/**
+ * Tier-(b) protocol sniff (issue #31): the observer's evidence hook that
+ * upgrades a GENERIC task record from its live session. Only `tab-1` — the
+ * deterministic engine tab launched from the task's own command (kobe's
+ * `hosted-session.ts`) — may speak for the record: an engine a user starts
+ * by hand in another tab says nothing about what the task's command is, and
+ * secondary engine tabs may legitimately run another vendor. Naming +
+ * eligibility are engine-owned (`runtime.resolveProtocolUpgrade`, absent →
+ * never upgrades); the write is fire-and-forget so a slow store never
+ * stalls the observer, and activity claims are untouched — a sniff names an
+ * engine, it does not resurrect a dot. Idempotent by construction: an
+ * upgraded record stops being generic, so the next tick resolves null.
+ */
+export function createProtocolUpgradeReporter(
+  orch: Pick<DaemonOrchestrator, "getTask" | "setCommand">,
+  runtime: Pick<DaemonRuntimeAdapter, "resolveProtocolUpgrade">,
+): (taskId: string, tabId: string, evidence: { readonly walkVendor: string | null; readonly title: string }) => void {
+  return (taskId, tabId, evidence) => {
+    if (tabId !== "tab-1") return
+    const task = orch.getTask(taskId)
+    if (!task) return
+    const upgrade = runtime.resolveProtocolUpgrade?.(task, evidence)
+    if (!upgrade) return
+    void orch
+      .setCommand(taskId, upgrade.command, upgrade.vendor)
+      .then(() =>
+        logDaemonInfo(
+          "protocol-sniff",
+          `upgraded task ${taskId} to the ${upgrade.vendor} protocol from its live session`,
+        ),
+      )
+      .catch((err) => logDaemonError("protocol-sniff", err))
+  }
 }
 
 /**
@@ -109,9 +144,17 @@ export function startDaemonCollectors(
   activity?: DaemonActivityRegistry,
 ): () => void {
   // Activity observer: first tick immediately (restart seeding), then the
-  // slow poll; gated per-tick on subscribers like every collector here.
+  // slow poll; gated per-tick on subscribers like every collector here. Its
+  // per-session evidence also feeds the tier-(b) protocol sniff (#31).
   const stopActivityObserver = activity
-    ? startActivityObserver(activity, createActivityObserverIo(options.homeDir, runtime), hasSubscribers)
+    ? startActivityObserver(
+        activity,
+        {
+          ...createActivityObserverIo(options.homeDir, runtime),
+          onEngineEvidence: createProtocolUpgradeReporter(orch, runtime),
+        },
+        hasSubscribers,
+      )
     : () => {}
   const checkUpdate = options.checkUpdate ?? runtime.checkLatestVersion
   const updatePollMs = options.updatePollMs ?? DEFAULT_UPDATE_POLL_MS

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -59,6 +59,18 @@ export interface DaemonRuntimeAdapter {
    */
   titleTurnHint(vendor: VendorId, title: string): "working" | "rest" | null
   /**
+   * Tier-(b) protocol sniff consumer (issue #31): given a task record and
+   * live evidence from its engine tab (foreground-walk vendor + OSC title),
+   * the `setCommand` payload that upgrades a generic record to the named
+   * protocol — or null to leave the record alone. Naming + eligibility are
+   * engine-owned (kobe's `engine/protocol-sniff.ts`); the daemon only
+   * relays evidence. Optional: a runtime without it never upgrades.
+   */
+  resolveProtocolUpgrade?(
+    task: Pick<DaemonTask, "vendor" | "command">,
+    evidence: { readonly walkVendor: VendorId | null; readonly title: string },
+  ): { command: string; vendor: VendorId } | null
+  /**
    * Engine-owned per-turn telemetry (issue #32): completed turns read out of
    * ONE session transcript by the vendor's own adapter. `[]` when the engine
    * ships no turn reader or the file is unreadable — the daemon never parses

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -5,6 +5,7 @@ import { availableEngineIds } from "../engine/account-detect.ts"
 import { foregroundEngineIn, parsePsSnapshot, psSnapshot } from "../engine/foreground.ts"
 import { affectsActivityState, isEngineActivityKind } from "../engine/hook-events.ts"
 import { engineDisplayName, kobeApiInvocation } from "../engine/interactive-command.ts"
+import { protocolUpgradeFromLiveSession } from "../engine/protocol-sniff.ts"
 import { engineEntry, engineTitleTurnHint, vendorsWithQuotaProbe } from "../engine/registry.ts"
 import { createEngineTurnDetector } from "../engine/turn-detector.ts"
 import { issueAssetsDir } from "../env.ts"
@@ -55,6 +56,9 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
     return out
   },
   titleTurnHint: engineTitleTurnHint,
+  // Tier-(b) protocol sniff (issue #31): the record upgrade for a generic
+  // task identified by its live session — rules live with the sniffer.
+  resolveProtocolUpgrade: protocolUpgradeFromLiveSession,
   // Per-turn telemetry (issue #32) — delegated straight to the vendor's own
   // adapter; an engine without a turn reader simply reports none.
   readEngineTurns: async (vendor, transcriptPath) => (await engineEntry(vendor).readTurns?.(transcriptPath)) ?? [],

--- a/packages/kobe/src/engine/protocol-sniff.ts
+++ b/packages/kobe/src/engine/protocol-sniff.ts
@@ -27,13 +27,21 @@
  * ten braille frames), so that rule costs nothing now and is what keeps a
  * future engine borrowing a glyph from silently stealing its identity.
  *
- * NOTHING CONSUMES THIS YET — issue #31 owns wiring it into the record
- * upgrade (a task that resolved to the generic protocol, whose live session
- * turns out to be a known engine, should have its protocol corrected). Both
- * reads are pure so the consumer can be added without touching them.
+ * The consumer (issue #31) is {@link protocolUpgradeFromLiveSession}: the
+ * daemon's activity observer relays each walked live session's evidence
+ * (foreground-walk vendor + OSC title) and, when a task that recorded the
+ * generic protocol is identified, upgrades the record's `vendor` via
+ * `setCommand` — metadata only, so the history reader / trust store /
+ * delivery mode start applying while WHAT LAUNCHES never changes. The
+ * session-store read stays unconsumed there on purpose: a transcript can
+ * outlive the engine that wrote it (a worktree previously run with claude,
+ * later re-pinned to a genuinely different CLI, would mis-identify), so the
+ * record upgrade only trusts evidence that describes the session running
+ * right now. Both sniff reads stay pure.
  */
 
-import { BUILTIN_VENDORS, type VendorId } from "@/types/vendor"
+import { BUILTIN_VENDORS, type VendorId, isBuiltinVendor } from "@/types/vendor"
+import { GENERIC_PROTOCOL, resolveCommandProtocol } from "./engine-presets.ts"
 import { engineEntry } from "./registry.ts"
 
 /**
@@ -93,4 +101,47 @@ export async function sniffProtocol(input: {
   readonly worktree?: string
 }): Promise<VendorId | null> {
   return sniffProtocolFromTitle(input.title) ?? (await sniffProtocolFromSessions(input.worktree))
+}
+
+/** What the observer knows about one LIVE, walked engine-tab session. */
+export interface LiveSessionEvidence {
+  /** Foreground-walk verdict for the session's pid: a built-in vendor whose
+   *  process is running in the tree, or null for "no recognisable engine"
+   *  (a renamed binary reads as null — that's what the title covers). */
+  readonly walkVendor: string | null
+  /** The session's current OSC title. */
+  readonly title: string
+}
+
+/**
+ * The record upgrade, tier (b)'s consumer: the `setCommand` payload that
+ * names a generic task's protocol from its live engine tab, or null to
+ * leave the record alone. Every refusal is deliberate:
+ *
+ *   - no pinned `command` → null. Pre-`command` records LAUNCH from
+ *     `vendor` (see `types/task.ts`), so writing a sniffed protocol there
+ *     would change what spawns, not just how kobe talks to it.
+ *   - `vendor` already names a built-in → null. A named protocol is
+ *     authoritative; sniffing must never flip one engine to another.
+ *   - tier (a) can resolve the command → null. A declared or derivable
+ *     protocol (including one declared AFTER the task was created) wins
+ *     over runtime evidence.
+ *   - evidence names nothing (walk found no engine, title glyph absent or
+ *     ambiguous) → null. Staying generic is always safe; a wrong upgrade
+ *     points the history reader and trust store at another vendor's files.
+ *
+ * Walk evidence outranks the title: a process in the tree is the engine
+ * itself, while a title is what the engine last wrote.
+ */
+export function protocolUpgradeFromLiveSession(
+  task: { readonly vendor?: string; readonly command?: string },
+  evidence: LiveSessionEvidence,
+): { command: string; vendor: VendorId } | null {
+  const command = task.command?.trim()
+  if (!command) return null
+  if (task.vendor && isBuiltinVendor(task.vendor)) return null
+  if (resolveCommandProtocol(command) !== GENERIC_PROTOCOL) return null
+  const walk = evidence.walkVendor
+  const vendor = walk !== null && isBuiltinVendor(walk) ? walk : sniffProtocolFromTitle(evidence.title)
+  return vendor ? { command, vendor } : null
 }

--- a/packages/kobe/test/engine/protocol-sniff.test.ts
+++ b/packages/kobe/test/engine/protocol-sniff.test.ts
@@ -10,8 +10,15 @@
  * (pinned below), which is what lets a title identify anything at all.
  */
 
-import { describe, expect, it } from "vitest"
-import { sniffProtocolFromSessions, sniffProtocolFromTitle } from "../../src/engine/protocol-sniff.ts"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  protocolUpgradeFromLiveSession,
+  sniffProtocolFromSessions,
+  sniffProtocolFromTitle,
+} from "../../src/engine/protocol-sniff.ts"
 import { engineEntry } from "../../src/engine/registry.ts"
 import { BUILTIN_VENDORS } from "../../src/types/vendor.ts"
 
@@ -65,5 +72,89 @@ describe("sniffProtocolFromSessions", () => {
     // Readers are best-effort by contract, so a nonexistent path resolves to
     // "no store answered" rather than throwing.
     expect(await sniffProtocolFromSessions("/nonexistent/worktree-that-no-engine-touched")).toBeNull()
+  })
+})
+
+describe("protocolUpgradeFromLiveSession", () => {
+  // The eligibility rule reads the preset registry (tier a), so the state
+  // home is pinned to an empty sandbox — the user's real custom engines
+  // must never decide what "generic" means in a test.
+  let home: string
+  let originalHome: string | undefined
+
+  function writeState(state: Record<string, unknown>): void {
+    const dir = join(home, ".config", "rove")
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "state.json"), JSON.stringify(state), "utf8")
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kobe-protocol-sniff-"))
+    originalHome = process.env.KOBE_HOME_DIR
+    process.env.KOBE_HOME_DIR = home
+    writeState({})
+  })
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+      delete process.env.KOBE_HOME_DIR
+    } else process.env.KOBE_HOME_DIR = originalHome
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  const generic = { vendor: "generic", command: "my-wrapper.sh --yolo" }
+
+  it("upgrades a generic record when the walk finds a built-in engine in its tree", () => {
+    expect(protocolUpgradeFromLiveSession(generic, { walkVendor: "claude", title: "zsh" })).toEqual({
+      command: "my-wrapper.sh --yolo",
+      vendor: "claude",
+    })
+  })
+
+  it("upgrades from the title glyph when the walk sees nothing (renamed binary)", () => {
+    // A wrapper that execs a RENAMED claude never matches a process name —
+    // the engine's own title vocabulary is the only fingerprint left.
+    expect(protocolUpgradeFromLiveSession(generic, { walkVendor: null, title: "✳ refactoring" })).toEqual({
+      command: "my-wrapper.sh --yolo",
+      vendor: "claude",
+    })
+  })
+
+  it("refuses when the record already names a built-in protocol", () => {
+    // Sniffing must never flip one engine to another — even against
+    // apparently contradicting live evidence.
+    expect(
+      protocolUpgradeFromLiveSession(
+        { vendor: "codex", command: "my-wrapper.sh" },
+        { walkVendor: "claude", title: "✳ x" },
+      ),
+    ).toBeNull()
+  })
+
+  it("refuses a record with no pinned command — those LAUNCH from `vendor`", () => {
+    expect(protocolUpgradeFromLiveSession({ vendor: "my-preset" }, { walkVendor: "claude", title: "✳ x" })).toBeNull()
+  })
+
+  it("refuses when tier (a) can already name the command", () => {
+    // `claude` resolves deterministically; runtime evidence (even codex's
+    // own glyph) must not override a derivable protocol.
+    expect(
+      protocolUpgradeFromLiveSession({ vendor: "claude", command: "claude" }, { walkVendor: "codex", title: "⠹ x" }),
+    ).toBeNull()
+  })
+
+  it("refuses when the command is a preset with a DECLARED protocol", () => {
+    writeState({ customEngineIds: ["aider"], "engineCommand.aider": "aider", "engineProtocol.aider": "claude" })
+    expect(
+      protocolUpgradeFromLiveSession({ vendor: "claude", command: "aider" }, { walkVendor: "codex", title: "⠹ x" }),
+    ).toBeNull()
+  })
+
+  it("stays generic when the evidence names nothing", () => {
+    expect(protocolUpgradeFromLiveSession(generic, { walkVendor: null, title: "bash" })).toBeNull()
+    expect(protocolUpgradeFromLiveSession(generic, { walkVendor: null, title: "" })).toBeNull()
+    // A walk verdict that is not a built-in identifies no protocol either.
+    expect(protocolUpgradeFromLiveSession(generic, { walkVendor: "mystery-engine", title: "bash" })).toBeNull()
   })
 })

--- a/packages/kobe/test/engine/protocol-upgrade-reporter.test.ts
+++ b/packages/kobe/test/engine/protocol-upgrade-reporter.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tier-(b) protocol sniff CONSUMER (issue #31) — the observer→record chain
+ * that upgrades a `generic` task from its live session. Two layers under
+ * test with the real naming rule (`protocolUpgradeFromLiveSession`) plugged
+ * in end-to-end:
+ *
+ *   - the reporter (`createProtocolUpgradeReporter`): only `tab-1` speaks
+ *     for the record — a claude the user starts BY HAND in another tab must
+ *     never rename the task's protocol.
+ *   - the observer relay: a walked live session's evidence reaches the
+ *     reporter and lands as ONE `setCommand` whose command is unchanged —
+ *     the upgrade is metadata (protocol), never a different launch.
+ *
+ * The refusal matrix itself (wrong-upgrade conservatism) lives in
+ * `protocol-sniff.test.ts`; here the stake is the wiring.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { startActivityObserver } from "@sma1lboy/kobe-daemon/daemon/activity-observer"
+import { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
+import { createProtocolUpgradeReporter } from "@sma1lboy/kobe-daemon/daemon/collectors"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { protocolUpgradeFromLiveSession } from "../../src/engine/protocol-sniff.ts"
+import { engineTitleTurnHint } from "../../src/engine/registry.ts"
+
+let home: string
+let originalHome: string | undefined
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kobe-protocol-upgrade-"))
+  originalHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = home
+  const dir = join(home, ".config", "rove")
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "state.json"), "{}", "utf8")
+})
+
+afterEach(() => {
+  for (const fn of cleanups.splice(0)) fn()
+  if (originalHome === undefined) {
+    // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+    delete process.env.KOBE_HOME_DIR
+  } else process.env.KOBE_HOME_DIR = originalHome
+  rmSync(home, { recursive: true, force: true })
+})
+
+const cleanups: Array<() => void> = []
+
+/** Minimal in-memory task store shaped like the reporter's orch slice. */
+function fakeOrch(initial: { vendor?: string; command?: string }) {
+  const tasks = new Map<string, { vendor?: string; command?: string }>([["task-1", { ...initial }]])
+  const setCommandCalls: Array<{ id: string; command: string; vendor?: string }> = []
+  return {
+    tasks,
+    setCommandCalls,
+    getTask: (id: string) => tasks.get(id) as never,
+    setCommand: (id: string, command: string, vendor?: string) => {
+      setCommandCalls.push({ id, command, ...(vendor ? { vendor } : {}) })
+      const prev = tasks.get(id)
+      if (prev) tasks.set(id, { ...prev, command, ...(vendor ? { vendor } : {}) })
+      return Promise.resolve()
+    },
+  }
+}
+
+const runtime = { resolveProtocolUpgrade: protocolUpgradeFromLiveSession }
+
+describe("createProtocolUpgradeReporter", () => {
+  it("upgrades a generic task's protocol from tab-1 evidence, keeping its command", async () => {
+    const orch = fakeOrch({ vendor: "generic", command: "my-wrapper.sh" })
+    const report = createProtocolUpgradeReporter(orch as never, runtime as never)
+    report("task-1", "tab-1", { walkVendor: "claude", title: "⠂ working" })
+    await Promise.resolve()
+    expect(orch.setCommandCalls).toEqual([{ id: "task-1", command: "my-wrapper.sh", vendor: "claude" }])
+    // Idempotent: the upgraded record is no longer generic, so the next
+    // tick's identical evidence resolves to no write at all.
+    report("task-1", "tab-1", { walkVendor: "claude", title: "⠂ working" })
+    await Promise.resolve()
+    expect(orch.setCommandCalls).toHaveLength(1)
+  })
+
+  it("ignores an engine running in any tab but tab-1", async () => {
+    // A claude the user launched by hand in a secondary tab (or a
+    // cross-vendor `send --tab tab-2`) says nothing about the task's own
+    // command — the record must stay generic.
+    const orch = fakeOrch({ vendor: "generic", command: "my-wrapper.sh" })
+    const report = createProtocolUpgradeReporter(orch as never, runtime as never)
+    report("task-1", "tab-3", { walkVendor: "claude", title: "✳ hand-started" })
+    await Promise.resolve()
+    expect(orch.setCommandCalls).toEqual([])
+  })
+
+  it("ignores evidence for a task the store no longer has", () => {
+    const orch = fakeOrch({ vendor: "generic", command: "my-wrapper.sh" })
+    const report = createProtocolUpgradeReporter(orch as never, runtime as never)
+    expect(() => report("task-gone", "tab-1", { walkVendor: "claude", title: "⠂ x" })).not.toThrow()
+    expect(orch.setCommandCalls).toEqual([])
+  })
+
+  it("never upgrades when the runtime ships no resolver", () => {
+    const orch = fakeOrch({ vendor: "generic", command: "my-wrapper.sh" })
+    const report = createProtocolUpgradeReporter(orch as never, {} as never)
+    report("task-1", "tab-1", { walkVendor: "claude", title: "⠂ x" })
+    expect(orch.setCommandCalls).toEqual([])
+  })
+})
+
+describe("observer → reporter relay", () => {
+  const waitFor = async (cond: () => boolean, timeoutMs = 1500): Promise<void> => {
+    const deadline = Date.now() + timeoutMs
+    while (!cond()) {
+      if (Date.now() > deadline) throw new Error("condition not met in time")
+      await new Promise((r) => setTimeout(r, 10))
+    }
+  }
+
+  function observe(
+    orch: ReturnType<typeof fakeOrch>,
+    sessions: Array<{ key: string; pid: number; title: string }>,
+    engines: Map<number, string | null>,
+  ) {
+    const bus = new DaemonEventBus()
+    const registry = new DaemonActivityRegistry(bus)
+    const stop = startActivityObserver(
+      registry,
+      {
+        listSessions: () =>
+          Promise.resolve(
+            sessions.map((s) => ({ key: s.key, alive: true, pid: s.pid, title: s.title, totalBytes: 1 })),
+          ),
+        foregroundEngines: (pids) => {
+          const out = new Map<number, string | null>()
+          for (const pid of pids) out.set(pid, engines.get(pid) ?? null)
+          return Promise.resolve(out)
+        },
+        titleTurnHint: engineTitleTurnHint,
+        onEngineEvidence: createProtocolUpgradeReporter(orch as never, runtime as never),
+      },
+      () => true,
+      { pollMs: 15, silenceMs: 60, walkEveryTicks: 2, log: () => {} },
+    )
+    cleanups.push(stop, () => registry.close())
+  }
+
+  it("a generic task whose live tab-1 walks to claude gets its record upgraded", async () => {
+    const orch = fakeOrch({ vendor: "generic", command: "my-wrapper.sh" })
+    observe(orch, [{ key: "task-1::tab-1", pid: 42, title: "⠂ 修复构建" }], new Map([[42, "claude"]]))
+    await waitFor(() => orch.tasks.get("task-1")?.vendor === "claude")
+    expect(orch.tasks.get("task-1")).toEqual({ vendor: "claude", command: "my-wrapper.sh" })
+  })
+
+  it("a renamed binary that only its title vocabulary identifies still upgrades", async () => {
+    // The walk answers null ("no engine word in the tree"); the OSC title's
+    // claude-unique glyph is the remaining fingerprint.
+    const orch = fakeOrch({ vendor: "generic", command: "cc-switch" })
+    observe(orch, [{ key: "task-1::tab-1", pid: 42, title: "✳ waiting for input" }], new Map([[42, null]]))
+    await waitFor(() => orch.tasks.get("task-1")?.vendor === "claude")
+    expect(orch.setCommandCalls).toEqual([{ id: "task-1", command: "cc-switch", vendor: "claude" }])
+  })
+
+  it("an undecorated generic session stays generic — no upgrade, ever", async () => {
+    const orch = fakeOrch({ vendor: "generic", command: "my-repl" })
+    observe(orch, [{ key: "task-1::tab-1", pid: 42, title: "my-repl" }], new Map([[42, null]]))
+    // Let several observe ticks (and a walk) pass, then assert nothing wrote.
+    await new Promise((r) => setTimeout(r, 120))
+    expect(orch.setCommandCalls).toEqual([])
+    expect(orch.tasks.get("task-1")?.vendor).toBe("generic")
+  })
+})


### PR DESCRIPTION
Implements rove issue #31, tier (b): a task that resolved to the **generic** protocol has its record corrected once its live session proves which engine is actually running.

**Not for merging tonight** — parked for review.

## Why this matters

`generic` means Rove can launch the engine but reads no history and pre-answers no trust dialog. Custom-registered engines and the contrib-engine catalog's long tail all land there, so the user gets a degraded tab for an engine Rove could have recognised.

## Conservative by construction

A wrong upgrade is worse than no upgrade: it points the history reader and trust store at another vendor's files. So `protocolUpgradeFromLiveSession` refuses on **four** conditions and every refusal leaves the record generic —

- **no pinned `command`** → pre-`command` records launch from `vendor`, so writing a sniffed protocol there would change *what spawns*, not just how Rove talks to it
- **`vendor` already names a built-in** → a named protocol is authoritative; sniffing must never flip one engine to another
- **tier (a) can resolve the command** → a declared or derivable protocol wins over runtime evidence, including one declared *after* the task was created
- **evidence names nothing** — walk found no engine, title glyph absent or ambiguous

Walk evidence outranks the OSC title: a process in the tree *is* the engine; a title is only what the engine last wrote.

On a hit, `setCommand` changes **`vendor` only** — metadata. What launches is never touched, so the history reader / trust store / delivery mode start applying while the command line stays exactly as the user pinned it.

**The session-store read stays deliberately unconsumed here.** A transcript outlives the engine that wrote it: a worktree previously run with claude and later re-pinned to a genuinely different CLI would mis-identify. The record upgrade only trusts evidence describing the session running *right now*.

Not on the startup path — the daemon's existing activity observer relays evidence per tick, so session launch is not slowed.

## Tests

14 + 7 new cases including an explicit **misidentification-refusal matrix** — a sniffer's failure mode is confident wrongness, so the refusals are what's pinned hardest.

`test:fast` 3493 passed, lint and typecheck clean. `docs/ENGINES.md` updated in the same change.