### PR TITLE
feat(doctor): add a diagnosis-to-fix path via `doctor --fix`

### DIFF
--- a/.changeset/doctor-fix-path.md
+++ b/.changeset/doctor-fix-path.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove doctor --fix`: doctor can now remediate what it diagnoses, not just report it. Every finding maps to either a runnable fix or an explicitly manual step. Safe, reversible fixes (`daemon restart` for a stale/dead daemon or dead hook channel, `skill install` for a missing/stale agent skill) execute only after a per-fix y/N confirmation showing the exact command; anything that kills live sessions or needs a human (`rove reset`, engine-tab restarts, installs, logins) is printed but never executed — including everything when there is no TTY. A plain `rove doctor` run now ends with a `--fix` hint when findings have a known remedy.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -73,7 +73,7 @@ Commands:
   repo <verb>             Per-repo init script + first prompt (show|set|unset)
   api <verb>              Scriptable RPC surface for agents (see `rove api --help`)
   daemon <verb>           Manage the daemon (start|stop|status|restart)
-  doctor [--report]       Diagnose daemon/PTY/engines/git; --report writes a bundle
+  doctor [--report|--fix] Diagnose daemon/PTY/engines/git; --fix walks the remedies
   config [--path]         Open Rove's config file (state.json) in your editor
   reset [--hard]          Stop runtimes; optionally wipe task/UI state
   theme <verb>            Manage user themes (list|add|remove)
@@ -252,14 +252,27 @@ Changes apply to a running daemon without a restart. Writing one:
 ## doctor
 
 ```bash
-rove doctor [--report]
+rove doctor [--report] [--fix]
 ```
 
 Read-only check of your build, terminal, git, engine CLIs and logins, daemon,
-running sessions, agent skill, and state files. Never changes anything.
-`--report` also writes a bug bundle (diagnosis + recent logs + env) and
-prints its path; attach that to bug reports. See
-[Troubleshooting](./TROUBLESHOOTING.md).
+running sessions, agent skill, and state files. The plain run never changes
+anything. `--report` also writes a bug bundle (diagnosis + recent logs + env)
+and prints its path; attach that to bug reports.
+
+`--fix` walks the remedies for whatever the diagnosis found, one at a time:
+
+- **Safe fixes run after a per-fix `y/N`** — each shows the exact command
+  before asking (e.g. `rove daemon restart` for a stale/dead daemon or a dead
+  hook channel, `rove skill install` for a missing/stale agent skill). Nothing
+  is batched; declining one fix never skips the next prompt.
+- **Risky remedies are printed, never executed** — anything that kills live
+  sessions (`rove reset`, closing engine tabs) or needs a human (installing
+  git/Node.js, engine logins) is shown with the step and why doctor won't run
+  it. Without a TTY (`--fix` in a script), nothing at all is executed.
+
+The remedies mirror [Troubleshooting](./TROUBLESHOOTING.md) — `--fix` is that
+page's executable half.
 
 ## reset
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -83,6 +83,11 @@ host itself is wedged, `rove reset` stops both runtimes and all live terminal
 and engine sessions, but does not touch git worktrees. Read the confirmation
 carefully before proceeding.
 
+`rove doctor --fix` walks these remedies for you, one confirmation per fix:
+safe ones (a daemon restart, a skill install) run after a per-fix `y/N`, while
+anything that would kill live sessions — `rove reset` included — is printed
+for you to run yourself, never executed.
+
 ## What terminal output does Rove persist after a crash?
 
 Hosted PTY output is not always memory-only. Two bounded recovery stores live

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -24,7 +24,18 @@ import {
 } from "../engine/account-detect.ts"
 import { homeDir, kvStatePath, roveStateDir } from "../env.ts"
 import { kobeSkillState, skillInstallCommand } from "../lib/skill-install.ts"
+import { t } from "../tui/i18n"
 import { CURRENT_VERSION } from "../version.ts"
+import {
+  type DoctorFix,
+  applyFixes,
+  daemonRestartFix,
+  defaultFixRuntime,
+  engineTabsManualFix,
+  humanOnlyFix,
+  resetManualFix,
+  skillInstallFix,
+} from "./doctor-fix.ts"
 import { classifyHookChannel, hookChannelDoctorLines } from "./doctor-hook-channel.ts"
 import { inspectLegacyTmux, legacyTmuxDoctorLines } from "./legacy-tmux.ts"
 import { activeCliName } from "./rename-compat.ts"
@@ -128,14 +139,15 @@ function terminalDoctorLines(): string[] {
 }
 
 /** `git --version` if git is on PATH, else a not-found marker. */
-async function gitDoctorLine(): Promise<string> {
+async function gitDoctorLine(): Promise<{ line: string; found: boolean }> {
   try {
     const proc = Bun.spawn(["git", "--version"], { stdin: "ignore", stdout: "pipe", stderr: "ignore" })
     const text = (await new Response(proc.stdout).text()).trim()
-    return (await proc.exited) === 0 && text ? `git:      ✓ ${text}` : "git:      ✗ not found on PATH"
+    if ((await proc.exited) === 0 && text) return { line: `git:      ✓ ${text}`, found: true }
   } catch {
-    return "git:      ✗ not found on PATH"
+    // fall through to not-found
   }
+  return { line: "git:      ✗ not found on PATH", found: false }
 }
 
 function binaryLabel(binary: BinaryStatus): string {
@@ -160,7 +172,7 @@ function copilotAccountLabel(account: CopilotAccount): string {
 }
 
 /** One "engines:" block: per-vendor CLI binary + account state (read-only). */
-async function engineDoctorLines(): Promise<string[]> {
+async function engineDoctorLines(): Promise<{ lines: string[]; anyUsable: boolean }> {
   const [claude, codex, copilot] = await Promise.all([
     detectClaudeAccount(),
     detectCodexAccount(),
@@ -174,7 +186,13 @@ async function engineDoctorLines(): Promise<string[]> {
   row("claude", claude.binary, claudeAccountLabel(claude.account), claude.accountError)
   row("codex", codex.binary, codexAccountLabel(codex.account), codex.accountError)
   row("copilot", copilot.binary, copilotAccountLabel(copilot.account), copilot.accountError)
-  return lines
+  // "Usable" = binary present AND some account. One usable engine is enough;
+  // a missing vendor the user never launches is not a finding.
+  const anyUsable =
+    (claude.binary.found && claude.account.kind !== "none") ||
+    (codex.binary.found && codex.account.kind !== "none") ||
+    (copilot.binary.found && copilot.account.kind !== "none")
+  return { lines, anyUsable }
 }
 
 async function appendUnavailableProcess(
@@ -182,31 +200,41 @@ async function appendUnavailableProcess(
   label: string,
   pidPath: string,
   socketPath: string,
-): Promise<void> {
+): Promise<"wedged" | "down"> {
   const pid = await readPidFile(pidPath)
-  if (pid && isProcessAlive(pid)) out.push(`${label}: ✗ WEDGED — process alive (pid ${pid}) but socket is unreachable`)
+  const wedged = pid !== null && pid !== undefined && isProcessAlive(pid)
+  if (wedged) out.push(`${label}: ✗ WEDGED — process alive (pid ${pid}) but socket is unreachable`)
   else if (pid) out.push(`${label}: ✗ not running (stale pidfile → pid ${pid} is gone)`)
   else out.push(`${label}: ✗ not running (no pidfile)`)
   if (existsSync(socketPath)) out.push(`          orphan socket file present: ${socketPath}`)
+  return wedged ? "wedged" : "down"
 }
 
-/** Assemble the full read-only diagnosis as printable lines. */
-async function collectDoctorLines(): Promise<string[]> {
+/**
+ * Assemble the full read-only diagnosis as printable lines, plus the fixes
+ * each failing check proposes (collected, never executed here).
+ */
+async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }> {
   const daemonSocket = defaultDaemonSocketPath()
   const daemonLog = defaultDaemonLogPath()
   const ptySocket = defaultPtyHostSocketPath()
   const ptyLog = defaultPtyHostLogPath()
   const tasksPath = join(roveStateDir(), "tasks.json")
   const statePath = kvStatePath()
+  const fixes: DoctorFix[] = []
+  const git = await gitDoctorLine()
+  if (!git.found) fixes.push(humanOnlyFix("git"))
+  const engines = await engineDoctorLines()
+  if (!engines.anyUsable) fixes.push(humanOnlyFix("noEngine"))
   const out = [
     "Rove doctor",
     `  build:  v${CURRENT_VERSION} (${process.platform} ${process.arch}, bun ${Bun.version})`,
     `  home:   ${homeDir()}`,
     "",
     ...terminalDoctorLines(),
-    await gitDoctorLine(),
+    git.line,
     "",
-    ...(await engineDoctorLines()),
+    ...engines.lines,
     "",
   ]
 
@@ -221,6 +249,7 @@ async function collectDoctorLines(): Promise<string[]> {
     if (version && version !== CURRENT_VERSION) {
       out.push(`         ⚠ stale build: daemon is v${version}, you launched v${CURRENT_VERSION}`)
       out.push(`         → run \`${CLI_NAME} daemon restart\`, then relaunch Rove`)
+      fixes.push(daemonRestartFix(CLI_NAME, "daemonStale"))
     } else if (version) out.push(`         build: v${version}`)
     // Hook channel: hooks are the only sub-second path to the badge, and
     // they fail SILENTLY (`kobe hook` swallows everything by contract), so
@@ -230,16 +259,22 @@ async function collectDoctorLines(): Promise<string[]> {
     const tabs = snapshot?.activity?.tabs
     if (tabs) {
       const hookInput = { socketPath: daemonSocket }
-      out.push("", ...hookChannelDoctorLines(classifyHookChannel({ tabs, ...hookInput }), hookInput, CLI_NAME))
+      const verdict = classifyHookChannel({ tabs, ...hookInput })
+      out.push("", ...hookChannelDoctorLines(verdict, hookInput, CLI_NAME))
+      if (verdict.kind === "down") fixes.push(daemonRestartFix(CLI_NAME, "hooksDown"), engineTabsManualFix())
     } else {
       // `requestIfReachable` swallows its failure into null, so an
       // unanswered `debug.inspect` (a daemon predating the verb) would drop
       // this whole block without a word — the exact silence this check
       // exists to end. Say the check could not run instead.
       out.push("", "hooks:   ? could not read the daemon's activity registry (debug.inspect unavailable)")
+      fixes.push(daemonRestartFix(CLI_NAME, "inspectStale"))
     }
   } else {
-    await appendUnavailableProcess(out, "daemon ", defaultDaemonPidPath(), daemonSocket)
+    const state = await appendUnavailableProcess(out, "daemon ", defaultDaemonPidPath(), daemonSocket)
+    fixes.push(
+      state === "wedged" ? resetManualFix(CLI_NAME, "resetDaemonWedged") : daemonRestartFix(CLI_NAME, "daemonDown"),
+    )
     const tail = tailFile(daemonLog, 8)
     if (tail) {
       out.push("         last lines of daemon.log:")
@@ -271,7 +306,10 @@ async function collectDoctorLines(): Promise<string[]> {
       )
     }
   } else {
+    // Both PTY-host failure shapes end in `reset` (TROUBLESHOOTING: "If the
+    // PTY host itself is wedged"), which kills live sessions — print-only.
     await appendUnavailableProcess(out, "pty host", defaultPtyHostPidPath(), ptySocket)
+    fixes.push(resetManualFix(CLI_NAME, "resetPty"))
   }
   // Windows runs the PTY host under node (Bun has no PTY there). A kobe
   // installed with `bun install -g` may have no node at all, and the only
@@ -283,19 +321,24 @@ async function collectDoctorLines(): Promise<string[]> {
         ? `         node: ✓ ${node} (the Windows PTY host runs under it)`
         : "         node: ✗ not found on PATH — the Windows PTY host cannot start\n         → install Node.js from https://nodejs.org",
     )
+    if (!node) fixes.push(humanOnlyFix("windowsNode"))
   }
   out.push("")
 
-  out.push(...legacyTmuxDoctorLines(await inspectLegacyTmux()), "")
+  const legacy = await inspectLegacyTmux()
+  out.push(...legacyTmuxDoctorLines(legacy), "")
+  if (legacy.sessions.length > 0) fixes.push(resetManualFix(CLI_NAME, "resetLegacy"))
 
   const skill = kobeSkillState()
   const installCommand = skillInstallCommand()
   if (!skill.installed) {
     out.push("skill:   ✗ Rove agent skill not installed", `         → ${installCommand}`)
+    fixes.push(skillInstallFix(installCommand, false))
   } else if (skill.stale) {
     const installed = skill.installedVersion === null ? "unstamped" : `v${skill.installedVersion}`
     out.push(`skill:   ⚠ Rove agent skill out of date (${installed}; this Rove wants v${skill.currentVersion})`)
     out.push(`         → ${installCommand}`)
+    fixes.push(skillInstallFix(installCommand, true))
   } else out.push(`skill:   ✓ Rove agent skill installed (v${skill.installedVersion})`)
   out.push("")
 
@@ -304,19 +347,21 @@ async function collectDoctorLines(): Promise<string[]> {
   out.push(`state.json: ${describeFile(statePath)}`)
   out.push(`daemon.log: ${describeFile(daemonLog)}`)
   out.push(`pty-host.log: ${describeFile(ptyLog)}`)
-  return out
+  return { lines: out, fixes }
 }
 
 export async function runDoctorSubcommand(argv: readonly string[] = []): Promise<void> {
   if (argv.some((arg) => arg === "--help" || arg === "-h" || arg === "help")) {
     process.stdout.write(
       [
-        `Usage: ${CLI_NAME} doctor [--report]`,
+        `Usage: ${CLI_NAME} doctor [--report] [--fix]`,
         "",
         "Read-only diagnosis of the daemon / Hosted PTY / engines / git / legacy tmux / state.",
         "",
         "Options:",
         "  --report      Also write a bug bundle (diagnosis + recent logs + env) to a file",
+        "  --fix         Review the fixes one by one: safe ones run after a per-fix y/N,",
+        "                risky ones (kill sessions, install software) are printed only",
         "  -h, --help    Print this help",
         "",
       ].join("\n"),
@@ -324,19 +369,24 @@ export async function runDoctorSubcommand(argv: readonly string[] = []): Promise
     return
   }
   const report = argv.some((arg) => arg === "--report")
-  const unknown = argv.find((arg) => arg.length > 0 && arg !== "--report")
+  const fix = argv.some((arg) => arg === "--fix")
+  const unknown = argv.find((arg) => arg.length > 0 && arg !== "--report" && arg !== "--fix")
   if (unknown !== undefined) {
     process.stderr.write(
-      `${CLI_NAME} doctor: unexpected argument "${unknown}"\n\nUsage: ${CLI_NAME} doctor [--report]\n`,
+      `${CLI_NAME} doctor: unexpected argument "${unknown}"\n\nUsage: ${CLI_NAME} doctor [--report] [--fix]\n`,
     )
     process.exit(2)
   }
 
-  const out = await collectDoctorLines()
-  console.log(out.join("\n"))
+  const { lines, fixes } = await collectDoctor()
+  if (!fix && fixes.length > 0) {
+    lines.push("", t("doctor.fix.hint", { count: fixes.length, command: `${CLI_NAME} doctor --fix` }))
+  }
+  console.log(lines.join("\n"))
+  if (fix) await applyFixes(fixes, defaultFixRuntime())
   if (report) {
     const { writeReportBundle } = await import("./doctor-report.ts")
-    const path = writeReportBundle(out)
+    const path = writeReportBundle(lines)
     console.log(`\nreport written: ${path}`)
     console.log("attach this file to a bug report — it includes recent daemon + pty-host logs and env.")
   }

--- a/packages/kobe/src/cli/doctor-fix.ts
+++ b/packages/kobe/src/cli/doctor-fix.ts
@@ -1,0 +1,197 @@
+/**
+ * `kobe doctor --fix`: the diagnosis-to-remediation path.
+ *
+ * Every fix doctor knows is one of two kinds, and the kind IS the safety
+ * contract:
+ *
+ * - `run` — safe to execute after a per-fix y/N confirmation: the action is
+ *   reversible and never destroys state (a daemon restart — engine PTYs live
+ *   in the separate host and survive it; an idempotent skill install).
+ * - `manual` — doctor PRINTS the step but never executes it. Anything that
+ *   kills live sessions (`kobe reset`, closing engine tabs), installs
+ *   software, or logs in to an account lands here, and {@link applyFixes}
+ *   has no code path that executes a manual fix.
+ *
+ * The criterion between the two: if the action went wrong, could the user
+ * undo it themselves? No → `manual`.
+ *
+ * Each fix mirrors the remedy documented in `docs/TROUBLESHOOTING.md`; where
+ * the documented fix is not runnable from here (engine logins, OS installs,
+ * in-TUI tab restarts) it degrades to a printed pointer, so the two never
+ * disagree.
+ */
+
+import { createInterface } from "node:readline"
+import { t } from "../tui/i18n"
+
+export type DoctorFix =
+  | {
+      readonly kind: "run"
+      /** Stable identity — the same remedy proposed by two checks runs once. */
+      readonly id: string
+      readonly label: string
+      /** The exact argv executed on confirmation; also what the user is shown. */
+      readonly command: readonly string[]
+      readonly why: string
+    }
+  | {
+      readonly kind: "manual"
+      readonly id: string
+      readonly label: string
+      /** The step the user performs — a command or an in-app action. Never executed. */
+      readonly action: string
+      readonly why: string
+    }
+
+type DaemonRestartReason = "daemonStale" | "daemonDown" | "hooksDown" | "inspectStale"
+
+/** All daemon-shaped problems share one remedy — one id, so it runs once. */
+export function daemonRestartFix(cliName: string, reason: DaemonRestartReason): DoctorFix {
+  return {
+    kind: "run",
+    id: "daemon-restart",
+    label: t(`doctor.fix.${reason}`),
+    command: [cliName, "daemon", "restart"],
+    why: t("doctor.fix.daemonRestartWhy"),
+  }
+}
+
+/** `installCommand` is the space-joined wrapper command doctor already prints. */
+export function skillInstallFix(installCommand: string, stale: boolean): DoctorFix {
+  return {
+    kind: "run",
+    id: "skill-install",
+    label: t(stale ? "doctor.fix.skillStale" : "doctor.fix.skillMissing"),
+    command: installCommand.split(" "),
+    why: t("doctor.fix.skillInstallWhy"),
+  }
+}
+
+type ResetReason = "resetDaemonWedged" | "resetPty" | "resetLegacy"
+
+/** `kobe reset` kills live sessions — always print-only, one entry per reason. */
+export function resetManualFix(cliName: string, reason: ResetReason): DoctorFix {
+  return {
+    kind: "manual",
+    id: `reset:${reason}`,
+    label: t(`doctor.fix.${reason}`),
+    action: `${cliName} reset`,
+    why: t("doctor.fix.resetWhy"),
+  }
+}
+
+/** The user-owned half of a dead hook channel: restarting the engine tabs. */
+export function engineTabsManualFix(): DoctorFix {
+  return {
+    kind: "manual",
+    id: "engine-tabs",
+    label: t("doctor.fix.engineTabs"),
+    action: t("doctor.fix.engineTabsAction"),
+    why: t("doctor.fix.engineTabsWhy"),
+  }
+}
+
+type HumanOnlyReason = "git" | "noEngine" | "windowsNode"
+
+/** Installs and logins: doctor can only point, a human has to act. */
+export function humanOnlyFix(reason: HumanOnlyReason): DoctorFix {
+  return {
+    kind: "manual",
+    id: reason,
+    label: t(`doctor.fix.${reason}`),
+    action: t(`doctor.fix.${reason}Action`),
+    why: t("doctor.fix.humanOnlyWhy"),
+  }
+}
+
+/** Drop repeat proposals of the same remedy (first occurrence wins). */
+export function dedupeFixes(fixes: readonly DoctorFix[]): DoctorFix[] {
+  const seen = new Set<string>()
+  return fixes.filter((fix) => {
+    if (seen.has(fix.id)) return false
+    seen.add(fix.id)
+    return true
+  })
+}
+
+/** Injected effects, so tests can prove what was (not) executed. */
+export interface FixRuntime {
+  /** Per-fix y/N gate. Only consulted for `run` fixes on an interactive terminal. */
+  readonly confirm: (question: string) => Promise<boolean>
+  /** Execute a confirmed `run` fix; resolves to its exit code. */
+  readonly exec: (command: readonly string[]) => Promise<number>
+  readonly out: (line: string) => void
+  /** Without a TTY nothing is ever executed — the plan is printed instead. */
+  readonly interactive: boolean
+}
+
+/**
+ * Walk the collected fixes: runnable ones are shown (label, exact command,
+ * why it is safe) and individually confirmed before executing; manual ones
+ * are printed with the step and why doctor refuses to run it.
+ */
+export async function applyFixes(collected: readonly DoctorFix[], rt: FixRuntime): Promise<void> {
+  const fixes = dedupeFixes(collected)
+  if (fixes.length === 0) {
+    rt.out("")
+    rt.out(t("doctor.fix.none"))
+    return
+  }
+  const runnable = fixes.filter((fix) => fix.kind === "run")
+  if (runnable.length > 0) {
+    rt.out("")
+    rt.out(t("doctor.fix.header"))
+    for (const fix of runnable) {
+      rt.out(`  ${fix.label}`)
+      rt.out(`    ${t("doctor.fix.willRun", { command: fix.command.join(" ") })}`)
+      rt.out(`    ${fix.why}`)
+      if (!rt.interactive) continue
+      if (!(await rt.confirm(`    ${t("doctor.fix.confirmPrompt")}`))) {
+        rt.out(`    ${t("doctor.fix.skipped")}`)
+        continue
+      }
+      const code = await rt.exec(fix.command)
+      rt.out(code === 0 ? `    ${t("doctor.fix.done")}` : `    ${t("doctor.fix.failed", { code })}`)
+    }
+    if (!rt.interactive) rt.out(`  ${t("doctor.fix.nonInteractive")}`)
+  }
+  const manual = fixes.filter((fix) => fix.kind === "manual")
+  if (manual.length > 0) {
+    rt.out("")
+    rt.out(t("doctor.fix.manualHeader"))
+    for (const fix of manual) {
+      rt.out(`  ${fix.label}`)
+      rt.out(`    → ${fix.action}`)
+      rt.out(`    ${fix.why}`)
+    }
+  }
+}
+
+async function confirmTty(question: string): Promise<boolean> {
+  const readline = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const answer = await new Promise<string>((resolve) => readline.question(question, resolve))
+    return answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes"
+  } finally {
+    readline.close()
+  }
+}
+
+async function execInherited(command: readonly string[]): Promise<number> {
+  try {
+    const proc = Bun.spawn([...command], { stdin: "inherit", stdout: "inherit", stderr: "inherit" })
+    return await proc.exited
+  } catch {
+    return 127
+  }
+}
+
+/** The real runtime: readline y/N, inherited-stdio spawn, console output. */
+export function defaultFixRuntime(): FixRuntime {
+  return {
+    confirm: confirmTty,
+    exec: execInherited,
+    out: (line) => console.log(line),
+    interactive: process.stdin.isTTY === true,
+  }
+}

--- a/packages/kobe/src/cli/usage.ts
+++ b/packages/kobe/src/cli/usage.ts
@@ -30,7 +30,7 @@ export function topLevelUsage(cliName: ProductCliName = activeCliName()): string
     "  repo <verb>             Per-repo init script + first prompt (show|set|unset)",
     `  api <verb>              Scriptable RPC surface for agents (see \`${cliName} api --help\`)`,
     "  daemon <verb>           Manage the daemon (start|stop|status|restart)",
-    "  doctor [--report]        Diagnose daemon/PTY/engines/git; --report writes a bundle",
+    "  doctor [--report|--fix]  Diagnose daemon/PTY/engines/git; --fix walks the remedies",
     `  config [--path]          Open ${cliName}'s config file (state.json) in your editor`,
     "  reset [--hard]           Stop runtimes; optionally wipe task/UI state",
     "  theme <verb>            Manage user themes (list|add|remove)",

--- a/packages/kobe/src/tui/i18n/catalog.ts
+++ b/packages/kobe/src/tui/i18n/catalog.ts
@@ -19,6 +19,7 @@
 
 import { en as automations, zh as automationsZh } from "./messages/automations"
 import { en as common, zh as commonZh } from "./messages/common"
+import { en as doctor, zh as doctorZh } from "./messages/doctor"
 import { en as files, zh as filesZh } from "./messages/files"
 import { en as help, zh as helpZh } from "./messages/help"
 import { en as hints, zh as hintsZh } from "./messages/hints"
@@ -57,6 +58,7 @@ export const en = {
   kanban,
   automations,
   workItems,
+  doctor,
 }
 
 /**
@@ -86,6 +88,7 @@ export const zh: Messages = {
   kanban: kanbanZh,
   automations: automationsZh,
   workItems: workItemsZh,
+  doctor: doctorZh,
 }
 
 /** Registered locales, in display order. */

--- a/packages/kobe/src/tui/i18n/messages/doctor.ts
+++ b/packages/kobe/src/tui/i18n/messages/doctor.ts
@@ -1,0 +1,122 @@
+/**
+ * `doctor.*` messages — the `rove doctor --fix` remediation flow
+ * (`src/cli/doctor-fix.ts`). English is the source of truth; `zh: typeof en`
+ * keeps the shapes locked together. Shell commands themselves stay literal in
+ * the calling code — only the prose around them is translated.
+ */
+
+export const en = {
+  fix: {
+    /** Appended to a plain `doctor` run when at least one fix applies; {command} is `rove doctor --fix` */
+    hint: "{count} finding(s) above have a known fix — run `{command}` to review them one by one",
+    /** `--fix` found nothing to do */
+    none: "fix: nothing to fix — no known remediation applies to this report",
+    /** Header over the runnable (confirm-then-execute) fixes */
+    header: "fixes — each one asks before running:",
+    /** {command} is the exact command line about to be executed */
+    willRun: "will run: {command}",
+    /** Per-fix y/N prompt (default is No) */
+    confirmPrompt: "apply this fix? [y/N] ",
+    /** Fix command exited 0 */
+    done: "✓ done",
+    /** Fix command failed; {code} is its exit code */
+    failed: "✗ exited with code {code}",
+    /** User answered no */
+    skipped: "· skipped",
+    /** `--fix` without a TTY: nothing is ever executed */
+    nonInteractive: "no interactive terminal — nothing was executed; run the commands above yourself",
+    /** Header over the print-only fixes */
+    manualHeader: "manual steps — doctor prints these but never runs them:",
+
+    /** Shared rationale for every daemon-restart fix */
+    daemonRestartWhy: "safe to run: engine sessions live in the separate PTY host and survive a daemon restart",
+    /** Daemon reachable but running an older build than this CLI */
+    daemonStale: "restart the daemon — it is running an older build than this CLI",
+    /** Daemon not running at all */
+    daemonDown: "start the daemon — it is not running",
+    /** Engine hook channel down: no hook-sourced activity on any tab */
+    hooksDown: "restart the daemon to re-establish the engine hook channel",
+    /** Daemon too old to answer `debug.inspect` */
+    inspectStale: "restart the daemon — it predates the hook-channel check",
+
+    /** Shared rationale for the skill install/update fix */
+    skillInstallWhy: "safe to run: installs skill files only; re-running is idempotent",
+    /** Agent skill absent */
+    skillMissing: "install the Rove agent skill",
+    /** Agent skill older than this build expects */
+    skillStale: "update the Rove agent skill to the version this build expects",
+
+    /** Why every `reset` fix is print-only */
+    resetWhy: "stops the daemon, the PTY host, and every live session — not undoable, so doctor only prints it",
+    /** Daemon process alive but its socket unreachable */
+    resetDaemonWedged: "the daemon process is alive but unreachable (wedged)",
+    /** PTY host unreachable or down */
+    resetPty: "the PTY host is unreachable or not running",
+    /** Pre-v0.8 tmux sessions still resident */
+    resetLegacy: "pre-v0.8 tmux sessions are still holding processes and memory",
+
+    /** Hook channel down: the other half of the remedy, owned by the user */
+    engineTabs: "engine tabs may hold a stale daemon socket path",
+    /** The in-TUI action for {@link engineTabs} */
+    engineTabsAction: "close and reopen the affected engine tabs in the TUI",
+    /** Why engine-tab restarts are print-only */
+    engineTabsWhy: "kills that tab's live engine session — your call, not doctor's",
+
+    /** Why installs/logins are print-only */
+    humanOnlyWhy: "doctor does not install software or log in to accounts for you",
+    /** git missing from PATH */
+    git: "git is not on PATH",
+    /** The manual action for {@link git} */
+    gitAction: "install git with your OS package manager",
+    /** No engine has both a CLI binary and an account */
+    noEngine: "no usable engine — no engine CLI is both installed and logged in",
+    /** The manual action for {@link noEngine} */
+    noEngineAction: "install the claude, codex, or copilot CLI and log in",
+    /** Windows only: no node, so the PTY host cannot start */
+    windowsNode: "Node.js is missing — the Windows PTY host cannot start",
+    /** The manual action for {@link windowsNode} */
+    windowsNodeAction: "install Node.js from https://nodejs.org",
+  },
+}
+
+export const zh: typeof en = {
+  fix: {
+    hint: "上面有 {count} 项发现存在已知修法 — 运行 `{command}` 逐条查看",
+    none: "fix: 无可修项 — 本次报告没有匹配到已知修法",
+    header: "修复项 — 每一条都会先询问再执行:",
+    willRun: "将执行: {command}",
+    confirmPrompt: "执行这条修复吗? [y/N] ",
+    done: "✓ 完成",
+    failed: "✗ 退出码 {code}",
+    skipped: "· 已跳过",
+    nonInteractive: "没有交互终端 — 未执行任何命令; 请自行运行上面的命令",
+    manualHeader: "人工步骤 — doctor 只打印, 永远不会替你执行:",
+
+    daemonRestartWhy: "可安全执行: 引擎会话在独立的 PTY host 里, daemon 重启后仍然存活",
+    daemonStale: "重启 daemon — 它运行的构建比当前 CLI 旧",
+    daemonDown: "启动 daemon — 它当前没有在运行",
+    hooksDown: "重启 daemon 以重建引擎 hook 通道",
+    inspectStale: "重启 daemon — 它的版本早于 hook 通道检查",
+
+    skillInstallWhy: "可安全执行: 只写入 skill 文件; 重复运行是幂等的",
+    skillMissing: "安装 Rove agent skill",
+    skillStale: "把 Rove agent skill 更新到当前构建期望的版本",
+
+    resetWhy: "会停掉 daemon、PTY host 和所有活动会话 — 不可撤销, 所以 doctor 只打印",
+    resetDaemonWedged: "daemon 进程存活但无法连接 (卡死)",
+    resetPty: "PTY host 无法连接或没有在运行",
+    resetLegacy: "v0.8 之前的 tmux 会话仍占用进程和内存",
+
+    engineTabs: "引擎 tab 可能持有过期的 daemon socket 路径",
+    engineTabsAction: "在 TUI 里关闭并重开受影响的引擎 tab",
+    engineTabsWhy: "会杀掉该 tab 的活动引擎会话 — 由你决定, doctor 不代劳",
+
+    humanOnlyWhy: "doctor 不会替你安装软件或登录账号",
+    git: "PATH 上找不到 git",
+    gitAction: "用你的系统包管理器安装 git",
+    noEngine: "没有可用引擎 — 没有任何引擎 CLI 同时满足已安装且已登录",
+    noEngineAction: "安装 claude、codex 或 copilot CLI 并登录",
+    windowsNode: "缺少 Node.js — Windows PTY host 无法启动",
+    windowsNodeAction: "从 https://nodejs.org 安装 Node.js",
+  },
+}

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -140,6 +140,29 @@ describe("runDoctorSubcommand", () => {
     writeSpy.mockRestore()
   })
 
+  it("failing checks add a --fix hint to the plain run", async () => {
+    mocks.request.mockRejectedValue(new Error("not running"))
+
+    await runDoctorSubcommand([])
+
+    expect(output()).toContain("doctor --fix")
+  })
+
+  it("--fix without a TTY prints the per-fix plan and executes nothing", async () => {
+    mocks.request.mockRejectedValue(new Error("not running"))
+
+    await runDoctorSubcommand(["--fix"])
+
+    // Runnable fix shown with its exact command…
+    expect(output()).toContain("will run:")
+    expect(output()).toContain("daemon restart")
+    // …the dangerous remedy is print-only…
+    expect(output()).toContain("reset")
+    // …and nothing ran (no TTY → no confirmations → no executions).
+    expect(output()).toContain("nothing was executed")
+    expect(output()).not.toContain("✓ done")
+  })
+
   it("--report writes a bundle file and points the user at it", async () => {
     mocks.request.mockRejectedValue(new Error("not running"))
     const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(home)

--- a/packages/kobe/test/cli/doctor-fix.test.ts
+++ b/packages/kobe/test/cli/doctor-fix.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  type DoctorFix,
+  type FixRuntime,
+  applyFixes,
+  daemonRestartFix,
+  dedupeFixes,
+  engineTabsManualFix,
+  humanOnlyFix,
+  resetManualFix,
+  skillInstallFix,
+} from "../../src/cli/doctor-fix.ts"
+
+function runtime(overrides: Partial<FixRuntime> = {}): FixRuntime & { lines: string[] } {
+  const lines: string[] = []
+  return {
+    confirm: vi.fn(async () => true),
+    exec: vi.fn(async () => 0),
+    out: (line: string) => lines.push(line),
+    interactive: true,
+    lines,
+    ...overrides,
+  }
+}
+
+describe("fix construction", () => {
+  it("daemon restart is a runnable fix carrying the exact command", () => {
+    const fix = daemonRestartFix("rove", "daemonStale")
+    expect(fix.kind).toBe("run")
+    expect(fix.id).toBe("daemon-restart")
+    expect(fix.kind === "run" && fix.command).toEqual(["rove", "daemon", "restart"])
+  })
+
+  it("skill install runs the wrapper command doctor already prints", () => {
+    const fix = skillInstallFix("kobe skill install", true)
+    expect(fix.kind === "run" && fix.command).toEqual(["kobe", "skill", "install"])
+  })
+
+  it("reset, engine-tab restarts, and installs/logins are manual (print-only)", () => {
+    for (const fix of [
+      resetManualFix("rove", "resetDaemonWedged"),
+      resetManualFix("rove", "resetPty"),
+      resetManualFix("rove", "resetLegacy"),
+      engineTabsManualFix(),
+      humanOnlyFix("git"),
+      humanOnlyFix("noEngine"),
+      humanOnlyFix("windowsNode"),
+    ]) {
+      expect(fix.kind).toBe("manual")
+    }
+    const reset = resetManualFix("rove", "resetPty")
+    expect(reset.kind === "manual" && reset.action).toBe("rove reset")
+  })
+
+  it("dedupes repeat proposals of the same remedy", () => {
+    const fixes = [
+      daemonRestartFix("rove", "daemonStale"),
+      daemonRestartFix("rove", "hooksDown"),
+      resetManualFix("rove", "resetPty"),
+    ]
+    const deduped = dedupeFixes(fixes)
+    expect(deduped).toHaveLength(2)
+    expect(deduped[0].id).toBe("daemon-restart")
+  })
+})
+
+describe("applyFixes", () => {
+  it("executes a runnable fix only after a per-fix confirmation", async () => {
+    const rt = runtime()
+    await applyFixes([daemonRestartFix("rove", "daemonStale")], rt)
+    expect(rt.confirm).toHaveBeenCalledTimes(1)
+    expect(rt.exec).toHaveBeenCalledTimes(1)
+    expect(rt.exec).toHaveBeenCalledWith(["rove", "daemon", "restart"])
+    expect(rt.lines.join("\n")).toContain("will run: rove daemon restart")
+    expect(rt.lines.join("\n")).toContain("✓ done")
+  })
+
+  it("a declined confirmation skips the fix without executing", async () => {
+    const rt = runtime({ confirm: vi.fn(async () => false) })
+    await applyFixes([daemonRestartFix("rove", "daemonStale")], rt)
+    expect(rt.exec).not.toHaveBeenCalled()
+    expect(rt.lines.join("\n")).toContain("skipped")
+  })
+
+  it("NEVER executes a manual fix, even when everything is confirmed", async () => {
+    const rt = runtime()
+    await applyFixes([resetManualFix("rove", "resetDaemonWedged"), humanOnlyFix("git")], rt)
+    expect(rt.confirm).not.toHaveBeenCalled()
+    expect(rt.exec).not.toHaveBeenCalled()
+    expect(rt.lines.join("\n")).toContain("→ rove reset")
+  })
+
+  it("without a TTY nothing is executed — the plan is printed instead", async () => {
+    const rt = runtime({ interactive: false })
+    await applyFixes([daemonRestartFix("rove", "daemonDown")], rt)
+    expect(rt.confirm).not.toHaveBeenCalled()
+    expect(rt.exec).not.toHaveBeenCalled()
+    expect(rt.lines.join("\n")).toContain("will run: rove daemon restart")
+    expect(rt.lines.join("\n")).toContain("nothing was executed")
+  })
+
+  it("reports a failing fix command's exit code", async () => {
+    const rt = runtime({ exec: vi.fn(async () => 1) })
+    await applyFixes([daemonRestartFix("rove", "daemonStale")], rt)
+    expect(rt.lines.join("\n")).toContain("exited with code 1")
+  })
+
+  it("says so when there is nothing to fix", async () => {
+    const rt = runtime()
+    await applyFixes([] as DoctorFix[], rt)
+    expect(rt.exec).not.toHaveBeenCalled()
+    expect(rt.lines.join("\n")).toContain("nothing to fix")
+  })
+})


### PR DESCRIPTION
`rove doctor` could tell you what was broken but not fix any of it. A user reading *"the engine hook channel is dead, resolved socket path: …"* still had to go find the docs and assemble the command themselves — and `docs/TROUBLESHOOTING.md` is, structurally, a list of things doctor already detects plus a command to copy by hand.

**Not for merging tonight** — parked for review.

## The safety model is a type, not a convention

Every finding maps to exactly one of two shapes:

- **`run`** — safe to execute after a **per-item y/N** confirmation (default No): daemon restart, skill install. The user is shown the label, the *exact argv*, and why it's safe, before being asked.
- **`manual`** — doctor **prints the step and never executes it**: reset, engine-tab actions, install, login.

The distinction is enforced structurally rather than by discipline: the `manual` variant has no `command` field at all, so there is no code path that could hand one to `exec`. The test is *"if this went wrong, could the user undo it themselves?"* — No means `manual`.

Two more guards:

- **Non-interactive runs execute nothing.** Without a TTY, doctor prints the commands and says so.
- Fixes carry a stable `id`, so one remedy proposed by two checks (all the daemon-shaped problems share a restart) is offered **once**.

No new checks were added — the value here is that the existing ones became actionable.

## Verified beyond the worker's report

- Confirmed both message dictionaries are complete. `zh: typeof en` makes parity a **compile-time** guarantee, so a missing translation cannot build.
- Confirmed the default answer is `[y/N]` (No), not yes-by-default.
- `doctor-cmd.ts` sits at 393 lines — under the cap, with the fix logic split into its own `doctor-fix.ts` (197) rather than growing the existing file past it.

`test:fast` 3491 passed, lint and typecheck clean. `docs/CLI.md` and `docs/TROUBLESHOOTING.md` updated in the same change, per the docs rule for CLI surface changes.