### PR TITLE
docs: audit the user-facing pages against source and fix the drift

### DIFF
--- a/.changeset/docs-audit-drift.md
+++ b/.changeset/docs-audit-drift.md
@@ -1,0 +1,15 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Docs audit: verify every checkable claim in the user-facing pages against
+source and fix ~60 drifted assertions — the `~/.kobe` → `~/.rove` runtime
+paths in TROUBLESHOOTING/SESSIONS/CLI/CONFIGURATION, the dead `ctrl+a y`
+resume-picker chord (removed from KEYBINDINGS/ENGINES/SESSIONS/TUI), stale
+CLI flags and undocumented aliases, `rove api` group/flag mismatches, the
+inverted editor precedence, the four-column Kanban, the kimi transcript
+layout, and the plugin event-support matrix (Kimi wires more hooks than
+documented). Fixes the one dead link on the docs site (WORK-TRACKING →
+gitignored HANDOFF.md) and adds two TROUBLESHOOTING entries users actually
+hit: `rove api send` refusing with NO_ENGINE_TAB/ENGINE_NOT_RUNNING, and
+duplicate daemons after upgrading across the 0.8.189 path move.

--- a/docs/API.md
+++ b/docs/API.md
@@ -72,7 +72,7 @@ rove api land --task-id a              # merge the winning branch
 
 Flag parsing: `--key value` and `--key=value` both work; boolean flags may
 be given bare (`--force` ⇒ true) or explicitly (`--archived=false`);
-`--task-id` / enum / positive-int values are validated against the verb's
+`--tab` / enum / positive-int values are validated against the verb's
 spec, and unknown flags are rejected (exit 2). `--repo` resolves relative
 paths against `$PWD` (`~` expanded). `spawn-task` is an alias of `add`.
 
@@ -88,14 +88,15 @@ Two verbs were REMOVED (no aliases): `fan-out` → `add --count N`, and
 `set-vendor` → `set-command`. Calling either returns `UNKNOWN_VERB` with the
 replacement in `nextCommandArgs`.
 
-## Discovery
+## discover
 
 - `schema` *(offline)*: the API, as JSON. Default is a compact index
   (groups + verb summaries, no flags); drill in with `--verb <name>` (full
   flag detail for one verb), `--group <g>`, or `--all` (everything; large).
   Includes an `apiVersion` agents can gate on.
-- `engine-list` *(offline)*: every engine Rove can launch, built-ins and
-  your registered presets, each with the RAW command it runs, its display
+- `engine-list` *(offline)*: every engine Rove can launch — built-ins, your
+  registered presets, and engines contributed by enabled plugins — each with
+  the RAW command it runs, its display
   name, and its `protocol` (the adapter Rove speaks to it: history reads,
   trust pre-answer, first-message delivery; `generic` = none). What it
   prints is what a launch runs, so an entry can be copied into `--command`
@@ -180,8 +181,9 @@ replacement in `nextCommandArgs`.
   with a mixed fleet (engine IDS only; a raw command line can't be
   expressed per-sibling; issue N separate `add --command` calls for that).
   Capped at 10; prefer 3-4. Both require `--prompt` (a parallel round IS its
-  prompt) and reject `--branch` (siblings cannot share one branch). This was
-  the `fan-out` verb, which no longer exists.
+  prompt) and reject `--branch` (siblings cannot share one branch);
+  `--agents` also rejects `--count` and `--command` (it already names each
+  sibling's engine). This was the `fan-out` verb, which no longer exists.
 
   `--command` picks the engine (an id from `engine-list`, or a full command
   line). Omitted, the repo's default engine is used.
@@ -235,10 +237,12 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   the task's worktree. `started: true` in the result marks that fresh
   session (vs. delivery into an existing one).
 - `dispatch --task-id ID --prompt TEXT [--tab TAB]`: route text into a
-  task's live session via the daemon's `session.deliver` channel; requires an
-  already-hosted session (the dispatcher's messenger; see
-  [design/dispatcher.md](./design/dispatcher.md)). `--tab tab-N` delivers
-  into exactly that tab instead of the canonical engine tab.
+  task's live session via the daemon's `session.deliver` channel (the
+  dispatcher's messenger; see
+  [design/dispatcher.md](./design/dispatcher.md)). Broadcast-only: it does
+  not verify a session received the text — the result's `clients` count is
+  the reach signal (`0` = nothing attached performed the paste). `--tab
+  tab-N` delivers into exactly that tab instead of the canonical engine tab.
 - `note --task-id ID --text TEXT`: file a one-line field note (a resolved,
   repo-level gotcha). Appended to the repo's durable note store, so every
   future worktree session on this repo starts with it in its system prompt;
@@ -251,8 +255,9 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   right|down] [--placement split|tab] [--title TEXT]`: open a terminal pane
   in a task's workspace: split the focused tab (default, tmux-style
   beside/below the active pane; `--tab tab-N` hosts the split in that tab
-  instead) or open a separate command tab. `--command` runs via
-  `sh -lc` and the pane closes when it exits; omit it for an interactive
+  instead) or open a separate command tab. `--command` runs via your login
+  shell (`-ilc`, so shell-rc `PATH`/exports apply, same as the engine tab)
+  and the pane closes when it exits; omit it for an interactive
   shell. Broadcast over the daemon's `tab.open` channel, so an attached TUI
   showing the task performs the split (headless, nothing happens). Task
   defaults to `$ROVE_TASK_ID` (or its Kobe alias), then the active task. How far splits can go
@@ -264,6 +269,19 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   one tab. Engine panes are never closed. Broadcast over the daemon's
   `tab.close` channel; an attached TUI performs the close (headless, nothing
   happens).
+- `notify --title TEXT [--kind KIND] [--task-id ID] [--source TAG]`: show
+  a toast in every attached Rove UI. `done` / `needs_input` / `error` get
+  severity styling; any other kind renders neutrally.
+- `engine-report --kind KIND [--task-id ID] [--engine ID] [--tab TAB]
+  [--detail JSON]`: report a normalized engine-activity verb for a task,
+  the public face of the `engine.reportEvent` RPC the built-in hook adapters
+  use. Lets a plugin-contributed engine (or any wrapper) drive the sidebar
+  badge, attention inbox, and plugin event stream. Task/tab default to
+  `$ROVE_TASK_ID` / `$ROVE_TAB_ID`; without either, the caller's cwd is
+  mapped to a task by worktree path. Kinds: `session-start`, `turn-start`,
+  `turn-complete`, `turn-failed`, `turn-interrupted`, `awaiting-input`,
+  `session-end` (activity state), plus `tool-pre/post/failed`,
+  `pre/post-compact`, `subagent-start/stop` (plugin-only).
 
 ## edit
 
@@ -335,14 +353,16 @@ attached. Walkthrough: [Routines](ROUTINES.md). Mechanics:
 **`--precheck`** runs a shell command in the repo before the engine starts;
 a non-zero exit skips the run *without* creating a task. Use it so a schedule
 does not burn a turn when nothing changed (`git log --since=24.hours --oneline
-| grep -q .`). Run statuses distinguish `skipped_precheck` (healthy: nothing
-to do) from `dispatch_failed` (needs a human).
+| grep -q .`). Run statuses: `dispatched`, `skipped_precheck` (healthy:
+nothing to do), `skipped_missed`, `skipped_unavailable`, and
+`dispatch_failed` (needs a human).
 
 ## lifecycle
 
 - `archive --task-id ID [--archived=false]`: archive/unarchive.
   Non-destructive: worktree, branch, and history stay. A manual "hide the
-  row" override. Once work is merged, `delete` (branch survives) is the
+  row" override. Archiving stops the task's live engine session (the data
+  survives; unarchiving rebuilds it on next entry). Once work is merged, `delete` (branch survives) is the
   normal cleanup path; see
   [`design/task-lifecycle.md`](./design/task-lifecycle.md).
 - `pin --task-id ID [--pinned=false]`: pin/unpin a task to the top of the
@@ -350,8 +370,11 @@ to do) from `dispatch_failed` (needs a human).
 - `land --task-id ID [--strategy merge|squash] [--delete-branch]
   [--then-archive] [--remove-worktree]`: merge a task's branch back into its
   base repo's current branch (`--no-ff` merge, or one squash commit). Refuses
-  a dirty base checkout; on conflict it aborts and returns the conflicted
-  files. Returns `{ landedOn, commit }`.
+  a dirty base checkout and a branch with no commits ahead of base
+  (`EMPTY_BRANCH`; `EMPTY_BRANCH_DIRTY_WORKTREE` when uncommitted work is
+  still sitting in the worktree, with a send-back recovery command); on
+  conflict it aborts and returns the conflicted files. Returns
+  `{ landedOn, commit }`.
   `--remove-worktree` removes the task's worktree after a successful land;
   the branch stays (pair with `--delete-branch` to drop it too). It never
   forces: a dirty worktree, the base checkout, and the worktree the caller is
@@ -375,20 +398,7 @@ to do) from `dispatch_failed` (needs a human).
 
 - `feedback --title T --body TEXT [--category SLUG]` *(offline)*: create a
   GitHub Discussion in the Rove repository's Feedback category via `gh`.
-- `notify --title TEXT [--kind KIND] [--task-id ID] [--source TAG]`: show
-  a toast in every attached Rove UI. `done` / `needs_input` / `error` get
-  severity styling; any other kind renders neutrally.
 - `prompt --title TEXT [--placeholder T] [--initial T] [--timeout MS]`:
   ask the human for a line of text through the attached TUI's input dialog;
   blocks until answered/cancelled/timeout (default 120000 ms, max 600000)
   and returns `{ value }` or `{ cancelled, reason }`.
-- `engine-report --kind KIND [--task-id ID] [--engine ID] [--tab TAB]
-  [--detail JSON]`: report a normalized engine-activity verb for a task,
-  the public face of the `engine.reportEvent` RPC the built-in hook adapters
-  use. Lets a plugin-contributed engine (or any wrapper) drive the sidebar
-  badge, attention inbox, and plugin event stream. Task/tab default to
-  `$ROVE_TASK_ID` / `$ROVE_TAB_ID`; without either, the caller's cwd is
-  mapped to a task by worktree path. Kinds: `session-start`, `turn-start`,
-  `turn-complete`, `turn-failed`, `turn-interrupted`, `awaiting-input`,
-  `session-end` (activity state), plus `tool-pre/post/failed`,
-  `pre/post-compact`, `subagent-start/stop` (plugin-only).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -29,14 +29,14 @@ The installed package exposes both `rove` and `kobe`. `rove` is the canonical
 entry point; `kobe` remains a fully supported compatibility alias. They run the
 same commands against the same daemon, worktrees, and persisted state. This
 rename uses `~/.rove` and `~/.config/rove/state.json` for canonical product
-data. First launch copies supported legacy data without overwriting or removing
-the old files; runtime and plugin paths retain their compatibility names.
+data. First launch migrates supported legacy data from `~/.kobe` (see
+[Where state lives](#where-state-lives)).
 
 ```bash
 rove update            # latest
 rove update 0.7.90     # pin a version
-rove update list       # browse recent versions
-rove update dry-run    # print the command without running it
+rove update list       # browse recent versions (also: --list)
+rove update dry-run    # print the command without running it (also: --dry-run)
 ```
 
 rove updates using whichever package manager owns the `rove` on your `PATH`,
@@ -61,7 +61,12 @@ exits 2.
 ## All commands
 
 ```text
+rove <version>
+
 Usage: rove [command] [options]
+
+Run with no command to launch PureTUI.
+Run `rove .` (or `rove <path>`) to open a directory as a standalone task.
 
 Commands:
   web [options]           Launch the browser dashboard
@@ -87,6 +92,9 @@ Options:
   -h, --help              Print this help
   --skill                 Print the agent skill file and exit
 ```
+
+Bare `rove version` and `rove help` work too, as spelled-out forms of the
+flags.
 
 ## Managing projects
 
@@ -132,6 +140,8 @@ host.
 rove web [--port <n>] [--routes-only] [--no-takeover]
 ```
 
+(`--bridge-only` is accepted as a legacy alias for `--routes-only`.)
+
 Serves the dashboard on `:45174`, plus a sidecar for browser terminal tabs.
 `--routes-only` starts/verifies only the daemon-hosted HTTP/SSE routes, for a
 separate Vite dev server. Normally Rove may replace an older Rove PTY sidecar
@@ -157,7 +167,7 @@ Completes subcommands; each subcommand owns its own flags.
 ## export
 
 ```bash
-rove export [--json | --csv | --format <json|csv|table>]
+rove export [--json | --csv | --format <json|csv|table>]   # --format=<fmt> works too
 ```
 
 Prints your task list. Read-only and **works with the daemon down**, which is
@@ -168,7 +178,7 @@ table` aligns it for humans.
 ## config
 
 ```bash
-rove config [--path]
+rove config [--path]     # `rove config path` works too
 ```
 
 Opens `~/.config/rove/state.json` in your editor. See
@@ -177,9 +187,9 @@ Opens `~/.config/rove/state.json` in your editor. See
 ## theme
 
 ```bash
-rove theme list
-rove theme add <url|path> [--name <name>] [--force]
-rove theme remove <name>
+rove theme list                                  # alias: ls
+rove theme add <url|path> [--name|-n <name>] [--force|-f]
+rove theme remove <name>                         # alias: rm
 ```
 
 User themes land in `~/.rove/themes/` and can shadow a bundled name. Bundled
@@ -189,8 +199,9 @@ themes can't be removed. See [Themes](./themes.md).
 
 ```bash
 rove repo show [path]
-rove repo set [path] --init-script <text> | --init-script-file <path>
+rove repo set [path] [--init-script <text> | --init-script-file <path>]
                     [--init-prompt <text> | --init-prompt-file <path>]
+                    # at least one of the four
 rove repo unset [path] [--init-script] [--init-prompt]
 ```
 
@@ -218,7 +229,9 @@ detects your installed agents and asks. To name them yourself, repeat the flag
 (`--agent claude-code --agent codex`; `--agent=codex` also works); a
 comma-joined list is rejected rather than silently using only the first.
 
-The skill ships inside the npm package, so nothing is downloaded.
+The SKILL.md ships inside the npm package, so no repo clone is needed; the
+install itself still runs `npx skills add` (which falls back to a repo clone
+only if the bundled copy is missing).
 
 `rove --skill` (top-level flag) is shorthand for `rove skill print`: it dumps
 the bundled SKILL.md to stdout so an agent can learn the `rove api` surface in
@@ -238,10 +251,11 @@ rove plugin enable <id> | disable <id>         toggle without unregistering
 rove plugin unlink <id>                        unregister a linked plugin
 rove plugin uninstall <id-or-spec>             unregister + remove the checkout
 rove plugin config-dir <id>                    print its config directory
-rove plugin log <id> [-n <count>]              tail its command log
+rove plugin log <id> [-n <count>]              tail its command log (default 20)
 rove plugin action list [--plugin <id>]
 rove plugin action invoke <plugin-id.action-id> [args…]
 rove plugin pane open <plugin-id.pane-id> [--task <task-id>]
+rove plugin pane open --plugin <id> --entrypoint <pane-id>   # equivalent form
 ```
 
 Changes apply to a running daemon without a restart. Writing one:
@@ -281,7 +295,8 @@ rove reset [--hard] [--yes]
 ```
 
 Recovers a wedged install: stops the daemon and the PTY host (ending all
-background sessions). **Never touches git worktrees.** `--hard` also deletes
+background sessions), and also stops any pre-v0.8 tmux sessions the retired
+runtime left behind. **Never touches git worktrees.** `--hard` also deletes
 your task index and UI state. Asks for confirmation unless `--yes`.
 
 ## daemon
@@ -292,6 +307,8 @@ rove daemon start      # run in the FOREGROUND (this process becomes it)
 rove daemon stop
 rove daemon restart    # stop, then respawn in the background
 ```
+
+Bare `rove daemon` defaults to `status`.
 
 The daemon auto-starts when the TUI or `rove api` needs it, so `start` is
 mainly for debugging. Logs are at `~/.rove/daemon.log`; read them first when
@@ -307,7 +324,7 @@ rove feedback --title <text> (--body <text> | --body-file <path>) [--category <s
 ```
 
 Opens a GitHub Discussion via the `gh` CLI (needs `gh auth login`).
-`--body-file -` reads from stdin.
+`--body-file -` reads from stdin. `--category` defaults to `feedback`.
 
 ## Internal subcommands
 
@@ -317,10 +334,12 @@ Not in `--help`, listed so they aren't a mystery if you see them:
   survive TUI exits and daemon restarts. Spawned automatically.
 - **`rove hook <verb>`.** Fired by an engine's own hooks to report activity.
   It always exits 0 and never starts the daemon, so it can't fail your engine.
-  One verb is user-facing: **`rove hook cleanup`** removes Rove's
+  Two verbs are user-facing: **`rove hook cleanup`** removes Rove's
   settings-managed hooks from `~/.claude/settings.json` after the Claude Code
-  plugin takes over; see
-  [Configuration → Claude Code plugin](CONFIGURATION.md#claude-code-plugin).
+  plugin takes over (see
+  [Configuration → Claude Code plugin](CONFIGURATION.md#claude-code-plugin)),
+  and **`rove hook setup`** is a deprecated no-op kept so old instructions
+  fail loud instead of silently.
 
 ## Exit codes
 
@@ -347,6 +366,7 @@ are set: `ROVE_HOME_DIR` beats `KOBE_HOME_DIR`, `ROVE_OPEN_EDITOR` beats
 | `ROVE_HOME_DIR` | Move Rove's home-rooted task/runtime data; platform settings and engine-owned history keep their own locations |
 | `ROVE_OPEN_EDITOR` | Command that opens a worktree in a GUI editor (`code`, `cursor`, …) |
 | `ROVE_DAEMON_WEB_PORT` | Daemon web-transport port at daemon startup (default 45174; `0`/`off`/`false` disables). `rove web` itself uses `--port`. |
+| `ROVE_WEB_HOST` | Host the daemon binds its web transport to, read at daemon startup |
 | `ROVE_DEV=1` | Mark a developer checkout; hides the update chip |
 | `ROVE_DEBUG=1` | Print full startup errors instead of one line |
 | `ROVE_TASK_ID` / `ROVE_TAB_ID` | Set inside tabs Rove opens; how `rove api` verbs resolve the calling task |
@@ -364,13 +384,18 @@ Canonical product data under `~/.rove/` (or `ROVE_HOME_DIR`, with
 `KOBE_HOME_DIR` as fallback):
 
 - `tasks.json`: the task index
-- `worktrees/<repo-key>/<task-slug>/`: per-task worktrees
+- `worktrees/<repo-key>/<task-slug>/`: per-task worktrees (unless relocated by
+  Settings → General → Worktree location)
 - `themes/`, `settings/keybindings.yaml`, issues, notes, and automations
 
 Plus `~/.config/rove/state.json`, the settings file `rove config` or
 `kobe config` opens. Existing `~/.kobe/worktrees` paths remain recognized and
-are never copied or rewritten. Daemon/PTY runtime files and `plugins.json` +
-`plugins/<id>/` deliberately remain under `~/.kobe` for continuity. The first
-launch copies other supported legacy data additively and never deletes the
-source or overwrites canonical files. Daemon-owned stores are copied at
+are never copied or rewritten. Daemon/PTY runtime files (sockets, pidfiles,
+logs) and the plugin tree are canonical under `~/.rove/`; a legacy `~/.kobe`
+path is honoured only while a pre-rename daemon, PTY host, or plugin registry
+is still live, and after binding on the new paths Rove leaves symlinks at the
+old ones so older binaries still find the running daemon. The first launch
+copies supported legacy state additively and never overwrites canonical files
+— except the plugin tree (`plugins.json`, `plugins/<id>/`), which is *moved*
+with a compatibility symlink left behind. Daemon-owned stores are copied at
 new-daemon startup, only after the legacy writer has stopped.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,8 +17,11 @@ Setting `ROVE_HOME_DIR` changes the home beneath these paths. `KOBE_HOME_DIR`
 remains a supported fallback; when both are set, `ROVE_HOME_DIR` wins. On first
 launch, Rove copies missing client-owned data from `.kobe` and `.config/kobe`;
 daemon-owned stores are copied when the new daemon starts, after the old writer
-has stopped. Neither phase overwrites or deletes old files. Existing worktrees
-stay where they are; daemon/PTY runtime files and plugins retain their compatibility paths.
+has stopped. Neither phase overwrites old files. Existing worktrees stay
+where they are; daemon/PTY runtime files keep their compatibility paths only
+while a pre-rename process is still live, and the plugin tree is *moved* into
+`~/.rove/` on the first new-daemon start, with a symlink left at the old
+path.
 
 ## Editing settings
 
@@ -27,8 +30,9 @@ rove config          # open state.json in your editor
 rove config --path   # just print the path
 ```
 
-rove picks your editor in this order: `$VISUAL` / `$EDITOR` → your configured
-editor (`editor.kind` below) → the first installed of nvim, vim, emacs, nano.
+rove uses your configured editor (`editor.kind` below) unless it is `auto`
+(the default), which honors `$VISUAL` / `$EDITOR`, then the first installed
+of nvim, vim, emacs, nano.
 
 Restart Rove to apply a hand edit everywhere.
 
@@ -42,7 +46,10 @@ other.
 ## Settings reference
 
 Keys not listed here are internal UI state (saved repos, tab layouts) that
-happen to share the file.
+happen to share the file. Two exceptions worth knowing: `repoConfigs` is what
+`rove repo set` writes (a map of git toplevel → `{initScript, initPrompt}`,
+see [Per-repo init](#per-repo-init)), and `lastSelectedVendor` is the legacy
+engine fallback below `defaultVendor`.
 
 ### Appearance
 
@@ -87,6 +94,7 @@ per-file TTY editor.
 | `engineCommand.<id>` | string | built-in | Launch command, e.g. `"engineCommand.claude": "claude --model opus"` |
 | `engineName.<id>` | string | built-in | Display name |
 | `customEngineIds` | string[] | `[]` | Your own engines; see [Custom engines](#custom-engines) |
+| `engineProtocol.<id>` | built-in engine id | unset | Adapter a custom engine borrows; see [Custom engines](#custom-engines) |
 | `lastActiveVendor.<repo>` | engine id | unset | Per-project last used; outranks `defaultVendor`. Written by Rove |
 
 Launch commands are parsed shell-ish, so quotes group arguments. Clear both
@@ -148,8 +156,9 @@ that gives you a per-project layout. `$project_dir/..` puts worktrees next to
 each repo. The token only counts as the **first** segment.
 
 **Only new tasks move.** Existing tasks keep the path they were created with,
-including legacy global and repo-local roots. New remote (SSH) worktrees use
-`<basePath>/.rove/worktrees`; their existing `.kobe/worktrees` remain
+including legacy global and repo-local roots. `worktree.basePath` is
+local-only: remote (SSH) worktrees go under the *remote project's own* path
+at `<project>/.rove/worktrees`, and their existing `.kobe/worktrees` remain
 discoverable. No restart needed.
 
 ### Sidebar
@@ -193,7 +202,8 @@ same name. Writing one: [Themes](./themes.md).
 
 Full vocabulary: [Keybindings](./KEYBINDINGS.md). The configuration surface:
 
-- Edit `~/.rove/settings/keybindings.yaml` by hand. Rove never writes it.
+- Edit `~/.rove/settings/keybindings.yaml` by hand (`.yml` is accepted when
+  `.yaml` is absent). Rove never writes it.
 - Changes **reload live**, no restart. Problems show up as warnings in
   Settings → Keybindings.
 - A direct override replaces that binding's whole chord list; `null` or `[]`
@@ -214,11 +224,12 @@ red outrank green when both fire for the same tab. Three delivery channels:
 - **Desktop notification.** Rove emits an OSC 9 escape that iTerm2, kitty,
   WezTerm, and Ghostty turn into a real OS notification; other terminals
   ignore it. Because it travels down the terminal stream, **it reaches you
-  over SSH**. No separate switch.
+  over SSH**. No separate switch — it rides the same
+  `notifications.sound.enabled` toggle as the chime.
 - **Sound.** A short chime when a background tab finishes. Rove uses the
-  first player it finds on `PATH` (`afplay`, `ffplay`, `mpv`, `play`,
-  `aplay`, …). With none installed it's silent and the terminal bell is the
-  fallback.
+  first player it finds on `PATH` (`ffplay`, `mpv`, `mpg123`, … `afplay`,
+  `play`, `aplay`, …). With none installed it's silent and the terminal bell
+  is the fallback.
 
 ## Custom engines
 
@@ -238,13 +249,17 @@ Switching an engine OFF in **Settings → Engines** (`space`) records it under
 when you pick an engine for a task. The global default engine can't be left
 disabled; switching it off hands the default to the first engine still on.
 
-Being in `customEngineIds` *is* the registration. There's no other step. Ids
-must match `^[a-z][a-z0-9_-]{0,47}$` and can't collide with a built-in;
-invalid ones are dropped on read.
+Being in `customEngineIds` *is* the registration. There's no other step.
+Stick to `^[a-z][a-z0-9_-]{0,47}$` for ids: the web settings API enforces
+that pattern (and no collision with a built-in) and drops invalid ids on
+read, while the TUI only rejects blank, built-in, and duplicate ids.
 
 A custom engine launches and runs like any other, but Rove deliberately
-doesn't guess at its internals: no history reader, no account detection, no
-activity hooks, no session resume. More in [Engines](./ENGINES.md).
+doesn't guess at its internals — no history reader, no account detection, no
+activity hooks, no session resume — unless you declare
+`"engineProtocol.<id>"` (one of the built-in ids: `claude`, `codex`,
+`copilot`, `kimi`), which borrows that built-in's adapter for transcript
+reads and delivery. More in [Engines](./ENGINES.md).
 
 ## Claude Code plugin
 
@@ -300,8 +315,12 @@ A repo can ship two files in its own `.rove/` directory:
 
 Files committed in the repo win over any per-user override you set with
 `rove repo set`. Legacy `.kobe/init.sh` and `.kobe/init-prompt.md` remain
-field-by-field fallbacks; a `.rove` file wins when both spellings exist.
+field-by-field fallbacks; a `.rove` file wins when both spellings exist —
+for `init.sh` the file merely has to exist (even empty), while
+`init-prompt.md` must be non-empty to win.
 
-The PR action also reads `.rove/pr-instructions.md` as its prompt template.
+The PR action also reads `.rove/pr-instructions.md` as its prompt template;
+`{{branch}}`, `{{targetBranch}}`, `{{dirtyCountSentence}}`, and
+`{{upstreamSentence}}` are substituted (unknown `{{…}}` passes through).
 It falls back to `.kobe/pr-instructions.md`; when both files are present, the
 non-empty `.rove` file wins.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -37,6 +37,12 @@ their binary discovery, and that is all detection can answer for them. No
 login state, history, or model picker; those need a real adapter, which is
 what promotes an engine to built-in.
 
+**Plugins can contribute engines too**: a plugin manifest's `[[engines]]`
+entries register engines with a display name, launch command, screen
+manifest, and identity. Unlike the contrib catalog, plugin engines are
+offered without a binary check — installing the plugin is the opt-in. See
+[Plugin authoring](./PLUGIN-AUTHORING.md).
+
 **Kimi is partial.** Rove finds the binary, reads its login state, and can
 locate each session's transcript, enough to watch it for activity and to
 hand the conversation to another engine. It still doesn't *parse* that
@@ -46,14 +52,16 @@ than guessing.
 
 ## Picking an engine
 
-Per task, at creation time, or with `v` in the sidebar. The default for new
-tasks comes from Settings → Engines (`defaultVendor`), and Rove remembers the
-last engine you used per project. From a script it is
+Per task, at creation time, or with `v` in the sidebar. For new tasks the
+per-project last-used engine wins; Settings → Engines (`defaultVendor`) is
+the fallback, then `claude`. From a script it is
 `rove api add --command <engine-or-command-line>`; see
 [engine presets and protocols](#engine-presets-and-protocols).
 
-Engines whose CLI isn't installed are hidden from the new-task dialog. Custom
-engines always show; you added it, so Rove assumes you meant it.
+Engines whose CLI isn't installed are hidden from the new-task dialog, and
+so are engines you switched off in Settings → Engines (Settings still lists
+them so you can switch them back on). Custom engines always show; you added
+it, so Rove assumes you meant it.
 
 ### Reasoning effort
 
@@ -119,8 +127,6 @@ first message isn't resumed; there's no transcript yet. Codex, Copilot,
 Kimi, and custom engines can't take a caller-set session id, so their tabs
 relaunch fresh.
 
-`ctrl+a` `y` opens the resume picker for the active task.
-
 **Continue in a new tab.** `ctrl+a` `c` opens the continuation flow in the
 *same* worktree. What happens depends on the source and destination engines:
 
@@ -175,11 +181,12 @@ to `claude`". Set it when your CLI is a wrapper around a built-in (a
 different binary name, a fixed set of flags, a company shim) so the transcript
 reader, workspace-trust pre-answer, and first-message delivery all apply.
 Leave it out and the preset gets the **generic** protocol: it launches and
-runs fine, but Rove reads no history, pre-answers no trust dialog, and falls
-back to silence-window liveness with settle-then-paste delivery. If the
-running session later reveals a built-in engine behind the command, Rove
-upgrades the task's protocol automatically — see
-[engine presets and protocols](#engine-presets-and-protocols).
+runs fine with settle-then-paste delivery, but Rove reads no history,
+pre-answers no trust dialog, and shows no working badge (the activity
+observer only recognises engines with an adapter or screen manifest, so a
+generic engine reads as at-rest). If the running session later reveals a
+built-in engine behind the command, Rove upgrades the task's protocol
+automatically — see [engine presets and protocols](#engine-presets-and-protocols).
 
 Press `x` on an engine row in Settings to reset a built-in's overrides, or
 remove a custom engine entirely.
@@ -226,7 +233,7 @@ Engines own their own history. Rove reads it, never writes it.
 | `claude` | `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` |
 | `codex` | `~/.codex/sessions/<YYYY>/<MM>/<DD>/rollout-*.jsonl` |
 | `copilot` | `~/.copilot/session-state/<id>/events.jsonl` |
-| `kimi` | `~/.kimi-code/sessions/<workspace>/<session>/agents/main/wire.jsonl` |
+| `kimi` | `~/.kimi-code/session_index.jsonl` maps each session to its dir; the stream is `<sessionDir>/agents/main/wire.jsonl` |
 
 That's why a crash never loses a conversation, and why history survives
 `rove reset` and a machine reboot.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -34,7 +34,6 @@ the actions that can actually run right now.
 | `ctrl+a` `f` | New-conversation dialog, preset to "fork a child task": new managed worktree, branched off this Task's branch |
 | `ctrl+a` `c` | New-conversation dialog, preset to "continue this chat" in a new tab of the same Task directory |
 | `ctrl+a` `i` | Open the Inbox |
-| `ctrl+a` `y` | Resume a prior engine session |
 | `ctrl+a` `h` / `l` | Move focus left / right across panes |
 | `ctrl+a` `o` | Open the Task directory in your editor |
 | `ctrl+a` `m` | Reorder sidebar rows (scope-aware: tab / task / project) |
@@ -42,7 +41,7 @@ the actions that can actually run right now.
 | `ctrl+a` `1` / `2` / `3` | Kanban / Automations / GitHub Issues |
 | `ctrl+a` `z` | Toggle zen mode |
 | `ctrl+a` `,` | Open Settings |
-| `ctrl+a` `p` | Create a PR from the active task |
+| `ctrl+a` `p` / `P` | Create a PR from the active task |
 
 `ctrl+a` `c` picks an engine first. Claude and Codex can fork their own
 conversations natively. Copilot and Kimi use a transcript handoff even for a
@@ -57,15 +56,15 @@ focus or dialog.
 
 | Key | Action |
 |---|---|
-| `F1` | The live keymap; works everywhere, including inside the terminal |
-| `ctrl+q` | Focus the sidebar; from the sidebar, quit |
+| `F1` | The live keymap; works from every pane, including inside the terminal (not while a dialog or a full-page view — Settings / Worktrees / Update — is open) |
+| `ctrl+q` | Focus the sidebar; pressed again there, quit immediately (`q` in the sidebar quits with a confirm) |
 | `ctrl+t` | New engine tab |
-| `ctrl+e` | New-conversation dialog with the engine/shell picker; inside it, `tab` switches the destination (new tab here ⇄ fork a child task) and `ctrl+f` the context (fresh ⇄ continue this chat). The trailing "scratch shell" choice opens a Scratch shell task |
+| `ctrl+e` | New-conversation dialog with the engine/shell picker; inside it, `←`/`→` (or `h`/`l`) pick the engine and `enter` confirms, `tab` switches the destination (new tab here ⇄ fork a child task) and `ctrl+f` the context (fresh ⇄ continue this chat). The trailing "scratch shell" choice opens a Scratch shell task |
 | `ctrl+w` | Close the active split, otherwise the tab |
 | `ctrl+[` / `ctrl+]` | Previous / next tab |
 | `ctrl+\` | Split right |
 | `ctrl+=` | Split down |
-| `ctrl+2` … `ctrl+9`, `ctrl+0` | Jump to the sidebar row printing that digit |
+| `ctrl+2` … `ctrl+9`, `ctrl+0` | Jump to the Nth visible sidebar row (`ctrl+2` = first row) |
 | `F2` | Rename the active split, otherwise the tab |
 | `F3` | Focus the next split |
 | `F4` | Cycle focus forward |
@@ -75,9 +74,12 @@ focus or dialog.
 Overlap resolves by context: `ctrl+w` closes the innermost split when a tab
 is split, otherwise the tab. `F2` follows the same rule.
 
-**Jump digits.** Each sidebar row prints the digit that jumps to it, so you
-read it off the screen rather than counting. There is no `ctrl+1`; the
-terminal protocol can't encode it, so the first row answers to `2`.
+Both split chords need a terminal speaking the kitty keyboard protocol
+(legacy terminals can't encode `ctrl+=`, and `ctrl+\` would be SIGQUIT);
+reserving `ctrl+\` also costs the embedded shell its SIGQUIT.
+
+**Jump digits.** There is no `ctrl+1`; the terminal protocol can't encode it,
+so the first row answers to `2`.
 
 ## Sidebar and Files
 
@@ -106,8 +108,8 @@ through a Task row in that project.
 
 | Key | Action |
 |---|---|
-| `j` / `k` | Move |
-| `h` / `l` | Collapse / expand |
+| `j` / `k` (or arrows) | Move |
+| `h` / `l` (or `←`/`→`) | Collapse / expand |
 | `enter` | Open in your configured editor; changed files use a Vim/Nvim diff when available, otherwise Rove falls back to its read-only preview |
 | `d` | Open a read-only diff in a workspace tab without moving focus |
 | `r` | Refresh the current file tab |
@@ -159,7 +161,7 @@ In the read-only diff tab, with the workspace focused:
 
 | Key | Action |
 |---|---|
-| `j` / `k` | Move the line cursor |
+| `j` / `k` (or arrows) | Move the line cursor |
 | `v` | Anchor a range (`v` again cancels) |
 | `c` | Write a note |
 | `s` | Send all unsent notes to the engine |
@@ -169,13 +171,13 @@ These four are fixed and can't be rebound. The workflow:
 
 ## Workspace pages
 
-All of these pages close with `q` or `esc`. Their bare letters are active only
-while the page has focus.
+All of these pages close with `q`, `esc`, or `ctrl+c`. Their bare letters are
+active only while the page has focus.
 
 | Page | Keys |
 |---|---|
 | Kanban | arrows move between cards; `tab` changes project; `enter` opens details; `n` creates; `d` deletes; `r` refreshes |
-| Routines | `j`/`k` select; `n` creates; `e` pauses/resumes; `s` runs now; `d` deletes; `r` refreshes; `enter` opens the latest run's Task |
+| Automations | `j`/`k` select; `n` creates; `e` pauses/resumes; `s` runs now; `d` deletes; `r` refreshes; `enter` opens the latest run's Task |
 | GitHub Issues | `j`/`k` select; `tab` changes repo; `a` toggles "assigned to me"; `r` refreshes; `enter` starts a Task |
 | Worktrees | arrows select; `l` lands; `d` starts removal; see [Managing worktrees](WORKTREES.md) |
 | Update | `j`/`k` selects an action; `u` updates; `r` opens the release page; `enter` runs the selected action |

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -96,7 +96,7 @@ platforms = ["macos", "linux", "windows"] # optional; item-level override
 [[build]]                        # runs at GitHub install (after preview confirm), cwd = checkout
 command = ["npm", "install"]     # self-provision deps INTO the plugin dir; `link` skips build
 
-[[startup]]                      # once per daemon start, after the socket is ready; one-shot, not a daemon
+[[startup]]                      # once per daemon start; the socket may not accept connections yet — retry your connect. One-shot, not a daemon
 command = ["node", "restore.js"]
 
 [[shutdown]]                     # at daemon stop; bounded (~3s), the host kills a hook that lingers
@@ -138,6 +138,7 @@ command = ["aider"]              # launch argv; argv[0] is the binary
 [engines.identity]               # optional product identity for UI copy
 product_name = "Aider"           # each field falls back to `name`
 short_name = "Aider"
+assistant_name = "Aider"         # how the assistant is referred to
 input_placeholder = "Ask Aider…" # composer placeholder
 
 [[engines.rules]]                # screen-state rules, first match wins;
@@ -191,12 +192,12 @@ This table is the one-line index. **Per-event trigger semantics, exact
 | `file.will-open` / `file.opened` / `file.closed` | Files-pane open, before/after; editor tab closed | `path`, `via: plugin\|editor\|external` |
 | `tab.opened` / `tab.closed` | a workspace tab appeared/went away (restores don't fire) | `tabId`, `kind`, `title`, `vendor`, `purpose` |
 | `agent.running` / `agent.idle` / `agent.turn-complete` / `agent.permission-needed` / `agent.rate-limited` / `agent.error` | activity-STATE transitions, deduped per task+tab | `tabId` when the source state identifies a tab |
-| `session.start` / `session.end` | engine session lifecycle (C; X start only) | |
-| `turn.prompt` / `turn.complete` / `turn.failed` / `turn.interrupted` | one event per turn edge (C, X; interrupted: Kimi-shaped) | `failure` class on failed; `turn` (id/model/usage/startedAt/endedAt) on complete when the transcript yielded one |
-| `tool.pre` / `tool.post` / `tool.failed` | every tool call (C, X; failed: C); **installed into engine config only while some enabled plugin subscribes** | `tool.name`, `tool.id` |
-| `attention.permission` / `attention.question` | the engine blocked on a human (C) | `waiting` |
+| `session.start` / `session.end` | engine session lifecycle (C, K; X start only) | |
+| `turn.prompt` / `turn.complete` / `turn.failed` / `turn.interrupted` | one event per turn edge (C, X, K; failed: C, K) | `failure` class on failed; `turn` (id/model/usage/startedAt/endedAt) on complete when the transcript yielded one |
+| `tool.pre` / `tool.post` / `tool.failed` | every tool call (C, X, K; failed: C, K); **installed into engine config only while some enabled plugin subscribes** | `tool.name`, `tool.id` |
+| `attention.permission` / `attention.question` | the engine blocked on a human (permission: C, K; question: C) | `waiting` |
 | `context.pre-compact` / `context.post-compact` | context compaction (C, X) | `compact.trigger: manual\|auto` |
-| `subagent.start` / `subagent.stop` | nested agent lifecycle (C) | `subagent.type/id` |
+| `subagent.start` / `subagent.stop` | nested agent lifecycle (C, K) | `subagent.type/id` |
 
 Envelope (`ROVE_PLUGIN_EVENT_JSON`):
 
@@ -298,7 +299,8 @@ the CLI unless you need push channels.
 - **Settings → Plugins**: enable/disable, declared surfaces, last run,
   and your `[[settings]]` editors.
 - **CLI**: `rove plugin action invoke`, `rove plugin pane open`, `rove
-  plugin log`.
+  plugin log`, `rove plugin config-dir` (prints the plugin's config
+  directory).
 
 ## Ground rules
 

--- a/docs/PLUGIN-EVENTS.md
+++ b/docs/PLUGIN-EVENTS.md
@@ -19,7 +19,7 @@ Ground rules that apply to every event here:
   "taskId": "01M0…",              // when the event mapped to a task
   "task": {                       // task context at emit time, when known
     "id": "01M0…", "title": "…", "repo": "/path", "branch": "…",
-    "worktreePath": "/path", "vendor": "claude", "status": "active"
+    "worktreePath": "/path", "vendor": "claude", "status": "in_progress"
   },
   "vendor": "claude",             // agent-layer events: which engine reported
   "tabId": "tab-1",               // when the session is a Rove terminal tab
@@ -91,7 +91,7 @@ The task's PR status changed. Compared with the PR poller's own semantics:
 
 | detail field | type | meaning |
 |---|---|---|
-| `from`, `to` | `TaskPRStatus` | each optional (absent when there was/is no PR): `provider`, `lifecycle`, `checkState`, `number?`, `url?`, `title?`, `baseRef?`, `headRef?`, `reviewDecision?`, `mergeable?` |
+| `from`, `to` | `TaskPRStatus` | each optional (absent when there was/is no PR): `provider`, `lifecycle`, `checkState`, `number?`, `url?`, `title?`, `baseRef?`, `headRef?`, `reviewDecision?`, `mergeable?`, plus `lastCheckedAt?`/`lastError?` (present in the payload, excluded from the change test) |
 
 Typical use: toast when `to.checkState` flips to failing, or auto-archive on
 `to.lifecycle === "merged"`.
@@ -111,7 +111,7 @@ A daemon-tracker issue mutated.
 | detail field | type | meaning |
 |---|---|---|
 | `repo` | string | repo root the issue store is keyed by |
-| `op` | object | the raw mutation op, e.g. `{ "type": "create", "title": "…" }`, `{ "type": "set-status", "id": 3, "status": "done" }` |
+| `op` | object | the raw mutation op, e.g. `{ "type": "create", "title": "…" }`, `{ "type": "setStatus", "id": 3, "status": "done" }` (valid types: `create`, `setStatus`, `update`, `link`, `unlink`, `delete`) |
 
 ### `note.filed`
 
@@ -252,17 +252,17 @@ carries it (absent otherwise, never fabricated):
                         "startedAt": 1690000000000, "endedAt": 1690000042000 } } }
 ```
 
-### `turn.failed` · C, X (emulated), K
+### `turn.failed` · C, K
 
 | detail field | type | meaning |
 |---|---|---|
 | `failure` | `"rate_limit" \| "billing" \| "other"` | normalized failure class |
-| `note` | string? | the raw vendor error type, for humans |
+| `note` | string? | the raw vendor error type, for humans; only present when a wrapper self-reports it via `rove api engine-report --detail` (no built-in adapter sets it) |
 
 A `rate_limit` failure also arms auto-resume, so expect a `quota.exhausted`
 right after when the quota probe finds a reset time.
 
-### `turn.interrupted` · K (native), X (emulated)
+### `turn.interrupted` · C, X (emulated), K (native)
 
 The user interrupted the turn. Exists because Kimi fires `Interrupt` INSTEAD
 of `Stop`. Without this verb an interrupted Kimi turn would strand in
@@ -270,7 +270,7 @@ of `Stop`. Without this verb an interrupted Kimi turn would strand in
 
 ## Tools: the high-volume family
 
-### `tool.pre` / `tool.post` · C, X, K · `tool.failed` · C
+### `tool.pre` / `tool.post` · C, X, K · `tool.failed` · C, K
 
 One event per engine tool call, before/after. **Volume-gated install**: the
 underlying engine hooks are written into engine config only while some
@@ -287,7 +287,7 @@ sub-second and silent.
 
 ## Attention (engine blocked on a human)
 
-### `attention.permission` · C, X, K · `attention.question` · C
+### `attention.permission` · C, K · `attention.question` · C
 
 The engine stopped and is waiting. One `awaiting-input` report splits on why:
 
@@ -305,7 +305,7 @@ The engine stopped and is waiting. One `awaiting-input` report splits on why:
 
 ## Subagents
 
-### `subagent.start` / `subagent.stop` · C
+### `subagent.start` / `subagent.stop` · C, K
 
 A nested agent began/ended under the session.
 

--- a/docs/PLUGIN-SDK.md
+++ b/docs/PLUGIN-SDK.md
@@ -105,8 +105,8 @@ if (answer === null) {
   process.exit(0)
 }
 
-const tasks = await listTasks()
-const first = (tasks as any[])[0]
+const { tasks } = await listTasks<{ tasks: any[] }>()
+const first = tasks[0]
 if (first) await dispatch(first.id, `watch ${answer}`)
 
 await openPane("you.example.board")
@@ -140,6 +140,9 @@ the shape your target Rove version actually emits. The channel names are the
 `attention.inbox`, `ui-prefs`, `keybindings`, `task.jobs`, `worktree.changes`,
 `transcript.activity`, `session.deliver`, `tab.open`, `tab.close`,
 `engine.lifecycle`, `notice.event`, `usage.snapshot`, `ui.prompt`.
+
+Your handler also receives `daemon.stopping` at daemon shutdown — not a
+channel, always delivered regardless of the filter.
 
 ```ts
 import { Pane, RoveSocket } from "@sma1lboy/rove-plugin-sdk"
@@ -179,6 +182,7 @@ draws. Bring your own framework for rich UIs.
 | Export | Signature | Purpose |
 |---|---|---|
 | `Pane` | class | Terminal page surface. |
+| `PaneOptions` | `{ exitOnCtrlC?, input?, output? }` | Constructor options; `exitOnCtrlC` defaults to exiting on `ctrl+c`. |
 | `parseKeys` | `(chunk) => Key[]` | Parse a raw stdin chunk into key events. |
 
 `Key`: `{ name: string, ctrl: boolean }`. Names for specials are `enter`,

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -22,7 +22,7 @@ One line on a fresh machine. It installs Bun if it is missing, then Rove:
 curl -fsSL https://rove.run/install.sh | sh
 
 # pin a version
-curl -fsSL https://rove.run/install.sh | sh -s -- 0.8.136
+curl -fsSL https://rove.run/install.sh | sh -s -- <version>
 ```
 
 Or use a package manager you already have:
@@ -39,7 +39,8 @@ On Windows, use the npm route (the shell script needs a POSIX shell):
 npm install -g @sma1lboy/rove
 ```
 
-Rove looks for Bun on `PATH`, in `$BUN_INSTALL/bin`, and in `~/.bun/bin`. If
+Rove looks for Bun on `PATH`, in `$BUN_INSTALL/bin`, in `~/.bun/bin`, and in
+a `bun` npm package installed beside Rove. If
 yours lives somewhere else, point Rove at it with `ROVE_BUN=/path/to/bun`. To
 never be asked about installing Bun (CI, images, locked-down machines), set
 `ROVE_NO_BUN_BOOTSTRAP=1`. Rove then prints the install commands and exits.

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -158,14 +158,14 @@ Three related limits are easy to confuse:
 
 - **What a reattach replays.** The PTY host keeps ~512 KiB of recent output
   per session. The live copy is in memory; the complete bounded ring is also
-  frozen under `<home>/.kobe/pty-sessions/` at most once every five seconds
+  frozen under `<home>/.rove/pty-sessions/` at most once every five seconds
   while output streams, immediately when the child exits, and in full during
   a clean host shutdown. A crash can therefore lose the newest few seconds,
   but a reboot or host restart restores the last completed snapshot. Closing
   the tab, archiving its task, or `rove reset` deliberately drops the relevant
   frozen record.
 - **What diagnostics retain after an abnormal PTY death.**
-  `<home>/.kobe/pty-exits.json` stores the newest 50 abnormal deaths. Each
+  `<home>/.rove/pty-exits.json` stores the newest 50 abnormal deaths. Each
   record has the exit code or signal, time, and the last 40 plain-text lines
   extracted from up to 16 KiB of raw ring data. Clean exits are omitted. This
   is a diagnostic tail, not scrollback, and an engine CLI returning to its
@@ -192,8 +192,8 @@ process, including a reboot.
 - A resumable engine tab found dead on attach gets **one** automatic resume
   attempt. If that dies too, an extra tab closes; the task's only tab recycles
   into a fresh engine tab rather than respawning forever.
-- `ctrl+a` `y` opens the resume picker for the active task, Rove's mirror of
-  claude-code's `/resume`. It lists every session in the task's worktree.
+- To resume a conversation that is not represented by a tab, use the engine's
+  own picker (e.g. claude-code's `/resume`) inside a fresh engine tab.
 
 ## rove web as a second client
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -73,9 +73,13 @@ The raw logs live under the active Rove home (normally your OS home):
 
 | Path | Contains |
 |---|---|
-| `~/.kobe/daemon.log` | daemon startup, crashes, RPC and web-transport failures |
-| `~/.kobe/pty.log` | Hosted PTY startup and session-host failures |
-| `~/.kobe/client.log` | TUI/pane connection, disconnect, and reconnect diagnostics |
+| `~/.rove/daemon.log` | daemon startup, crashes, RPC and web-transport failures |
+| `~/.rove/pty.log` | Hosted PTY startup and session-host failures |
+| `~/.rove/client.log` | TUI/pane connection, disconnect, and reconnect diagnostics |
+
+(Installs upgraded from pre-0.8.189 builds may still have a `~/.kobe/`
+directory; runtime files now live under `~/.rove`, with legacy paths honoured
+only while a process started before the move is still alive.)
 
 After an upgrade, a daemon can still be running old in-memory code. Doctor
 reports that version mismatch; fix it with `rove daemon restart`. If the PTY
@@ -91,7 +95,7 @@ for you to run yourself, never executed.
 ## What terminal output does Rove persist after a crash?
 
 Hosted PTY output is not always memory-only. Two bounded recovery stores live
-under `~/.kobe/` (or the selected Rove home):
+under `~/.rove/` (or the selected Rove home):
 
 - `pty-exits.json` records **abnormal** exits only. It keeps at most the newest
   50 session records, with exit metadata and up to the last 40 plain-text
@@ -159,6 +163,50 @@ no-op. `rove hook setup` is deprecated and now performs cleanup only. Older
 Rove versions installed a Claude `WorktreeCreate` provider hook that could
 break `claude --worktree`; current launches remove Rove's old entry while
 preserving user hooks and use an observer instead.
+
+## `rove api send` refuses with NO_ENGINE_TAB or ENGINE_NOT_RUNNING
+
+Both errors are deliberate refusals, not delivery failures. Silently spawning
+a fresh engine here would make both sender and receiver believe the prompt
+was delivered while it actually landed in a duplicate session nobody is
+watching — so `send` fails loud instead.
+
+- **`NO_ENGINE_TAB`**: the task has live tabs, but none of them resolves as
+  its engine tab (the engine tab died, or the tabs run something else). List
+  what is actually alive, then address a tab explicitly:
+
+  ```bash
+  rove api pty-list
+  rove api send --task-id <id> --tab tab-N --prompt "..."   # deliver to a live tab
+  rove api send --task-id <id> --tab new --prompt "..."     # or spawn a fresh engine tab
+  ```
+
+- **`ENGINE_NOT_RUNNING`**: the engine tab exists but its engine process has
+  exited into a plain shell — pasting there would execute the prompt as shell
+  commands. Spawn a fresh engine tab with `--tab new` as above.
+
+A bare `send` (no `--task-id`) targets the dispatcher's tab when run from a
+task another Rove session spawned, and otherwise the active task — it never
+silently spawns an engine on a guess.
+
+## Two daemons, or engine tabs split across hosts, after an upgrade
+
+Rove 0.8.189 moved runtime files (sockets, pidfiles, logs) from `~/.kobe` to
+`~/.rove`. A binary predating the move looks only at the legacy paths; if it
+cannot see the new daemon it starts a second one on the same task index, or a
+second PTY host that splits your engine tabs. Current versions leave symlinks
+at the legacy paths after binding, so mixed-version installs find the same
+daemon — you only hit the split if an old global install (`kobe` from npm,
+an old Homebrew bin) is still being launched somewhere.
+
+```bash
+rove --version        # every entry point should report the same version
+rove doctor           # reports version mismatches and duplicate runtimes
+rove daemon restart   # rebinds on the canonical ~/.rove paths
+```
+
+Then update or remove the stale install so both `rove` and `kobe` resolve to
+the same current binary.
 
 ## Copy from the embedded terminal doesn't reach my clipboard (especially over SSH)
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -43,7 +43,7 @@ Task rows carry worktree-level facts:
 | Mark | Meaning |
 |---|---|
 | `▴` | Pinned Task |
-| `+N` / `−N` | Added and deleted lines in the worktree |
+| `+N` / `−N` | Changed and deleted files in the worktree |
 | `✓` / `✗` / `•` | Pull-request checks passing, failing, or pending |
 | jump digit | The `ctrl+2` … `ctrl+0` shortcut currently assigned to this row |
 
@@ -308,8 +308,8 @@ over. Uncommitted changes stay behind; commit first if the child needs them.
 `ctrl+a` `c` (continue in a new tab) and `ctrl+a` `f` (fork a child task)
 open the same dialog with the toggles pre-set.
 
-`ctrl+a` `y` is different: it opens the active Task's engine-owned history
-picker so you can resume a conversation that is not already represented by a
+To resume a conversation that is not already represented by a tab, use the
+engine's own picker (e.g. claude-code's `/resume`) inside a fresh engine
 tab. Availability and restart behavior vary by engine; see
 [Resuming a conversation](SESSIONS.md#resuming-a-conversation).
 
@@ -324,12 +324,14 @@ workspace. The chords stay live, so you can hop between pages directly.
 ![The Kanban board: Backlog, In progress and Done for one project, with the card cursor on an in-progress story](assets/kanban.png)
 
 The [issue store](CONCEPTS.md#the-issue-store) as a board, one project at a
-time (`tab` cycles projects). Three columns:
+time (`tab` cycles projects). Four columns:
 
-- **Backlog.** Open, doing, or on hold, not linked to a task.
+- **Backlog.** Open or doing, not linked to a task.
 - **In progress.** Linked to a task. The link *is* the column: agents move
   cards with `rove api issue-update --task`, and in-progress cards show the
   linked task's live engine activity.
+- **Parked.** Status `hold`, linked or not; sits between In progress and
+  Done.
 - **Done.** Status `done`.
 
 `enter` opens the detail drawer: edit the title and description, then start a

--- a/docs/WORK-TRACKING.md
+++ b/docs/WORK-TRACKING.md
@@ -5,7 +5,7 @@ rove work is tracked locally. There is no external issue tracker. Agents should 
 ## Sources of truth
 
 - **Backlog + open issues**: daemon-owned issue state.
-- **Current risks and follow-ups**: [`../HANDOFF.md`](../HANDOFF.md).
+- **Current risks and follow-ups**: `HANDOFF.md` at the repo root (local and gitignored; absent on a fresh clone).
 - **User-facing shipped behavior**: [`../packages/kobe/CHANGELOG.md`](../packages/kobe/CHANGELOG.md).
 - **Durable product and architecture decisions**: `docs/*.md`.
 - **Proof of work**: git commits and test output.
@@ -32,7 +32,7 @@ common-dir, so the source checkout and its worktrees share one issue record:
 }
 ```
 
-- **`status`**: `open` → `doing` → `done`, plus `hold` for issues parked on purpose (waiting on a decision, blocked, deliberately deferred). `hold` is a parking lot, not a lifecycle step. Resume by flipping back to `open`. The archive sweep ignores it (only `done` moves), so held issues stay visible in the active file. Status is still the only dimension; don't add label/type fields.
+- **`status`**: `open` → `doing` → `done`, plus `hold` for issues parked on purpose (waiting on a decision, blocked, deliberately deferred). `hold` is a parking lot, not a lifecycle step. Resume by flipping back to `open`. Held issues stay visible in the active file like every other status. Status is still the only dimension; don't add label/type fields.
 - **`id`**: take `nextId`, then increment `nextId`. Ids are never reused.
 - **Adding**: use the web Issues page or `rove api issue-create --repo <path> --title ...`. The daemon stores the repo's issue record under the repo's git common-dir, so a source checkout and its task worktrees share the same issues.
 - **Closing**: flip `status` to `done`. Done issues stay visible in the Done column until a future archive/export flow exists.

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -16,9 +16,22 @@ scans the repo's existing branches (local + `origin`) and matches the
 dominant style: a type prefix like `feat/`/`fix/`/`chore/` when that's what
 the repo uses, or a bare kebab slug otherwise (also the fallback for an
 empty repo). Name collisions get a short `-2`/`-3` suffix. Generated names
-never contain Rove branding. An explicit `--branch` on creation and
-`set-branch` afterwards override this entirely; existing branches are never
-renamed retroactively.
+never contain Rove branding. An explicit `--branch` on creation,
+`set-branch` afterwards, and `b` on a task row in the sidebar override this
+entirely. A branch still on its `new-task` placeholder is renamed once,
+automatically, when the task gets a real title (skipped if the branch
+already has an upstream); after that Rove never touches it again. A new
+worktree task started with a prompt also asks its agent to `set-branch` to a
+descriptive name once it understands the work.
+
+## Where worktrees live
+
+By default a managed worktree lands under
+`~/.rove/worktrees/<repo-basename>-<hash>/<slug>`, where `<slug>` is a
+random animal name (`-v2`/`-v3` on collision). Settings → General →
+Worktree location relocates the root (a `$project_dir` token expands to each
+task's project root). Remote (SSH) projects put worktrees under the remote
+project's own path at `<project>/.rove/worktrees/<slug>`.
 
 ## Open and navigate the page
 
@@ -27,7 +40,8 @@ renamed retroactively.
 3. Use the up/down arrows to select a worktree.
 4. Press `esc` or `q` to return to the workspace.
 
-The page lists non-main worktrees from every saved **local** project. Remote
+The page lists non-main worktrees with a branch checked out from every saved
+**local** project (bare and detached-HEAD worktrees are skipped). Remote
 SSH projects are not included. It loads local git facts first, then fills in
 remote and GitHub PR signals; a slow or unavailable network therefore leaves
 useful local rows on screen.
@@ -69,7 +83,10 @@ in the project's base checkout.
 3. Confirm the branch and base-checkout operation.
 
 The page uses a normal `--no-ff` merge. If the selected directory is not
-tracked by a Rove task, Land refuses. A dirty base checkout also refuses. On a
+tracked by a Rove task, Land refuses. A dirty base checkout also refuses, as
+does a branch with no commits ahead of the base (naming the uncommitted
+files when the work was never committed), a detached-HEAD base checkout, and
+a base already on the branch being landed. On a
 merge conflict, Rove aborts the merge and reports the conflicted paths, leaving
 manual conflict resolution to you.
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -27,7 +27,8 @@ A theme is a JSON object with two top-level fields:
 ```
 
 - **`defs`** (optional): a palette of named colors that `theme` entries
-  can reference by name. Values are hex strings.
+  can reference by name. Values are hex strings, or references to other
+  `defs` keys.
 - **`theme`** (required): the slot map. Each value is either a hex
   string (`#abc`, `#aabbcc`, `#aabbccdd`), a bare string referencing a
   key in `defs`, or a `{ dark, light }` pair for theme-mode-aware


### PR DESCRIPTION
A pass over all 17 synced docs pages, checking every *verifiable* claim against the implementation rather than reading for tone. ~60 assertions were stale.

**Not for merging tonight** — parked for review.

## What drifted

- **`~/.kobe` → `~/.rove` runtime paths** retired in 0.8.189, still documented across TROUBLESHOOTING / SESSIONS / CLI / CONFIGURATION. Remaining `~/.kobe` mentions are deliberate legacy-compat prose (verified — see below).
- **The `ctrl+a y` resume-picker chord**, removed from KEYBINDINGS / ENGINES / SESSIONS / TUI.
- Stale CLI flags and undocumented aliases; `rove api` group/flag mismatches.
- Inverted editor precedence, the four-column Kanban, the kimi transcript layout.
- The plugin event-support matrix — **Kimi wires more hooks than were documented**.
- The site's one dead link: WORK-TRACKING → `HANDOFF.md`, which is gitignored and absent on a fresh clone.

## Two new TROUBLESHOOTING entries

Both are things users actually hit: `rove api send` refusing with `NO_ENGINE_TAB` / `ENGINE_NOT_RUNNING`, and **duplicate daemons after upgrading across the 0.8.189 path move**.

## Verification

Docs-only — no source file touched, which was the boundary: a doc/impl mismatch gets reported, not silently "fixed" in code.

Spot-checked the highest-risk claims independently rather than trusting the count:

- **The dead chord is genuinely dead.** `chat.session.resume` has a `prefixKeys: ["y"]` table entry and i18n strings in both languages, but grep finds **no handler anywhere** in `src/`. Removing the doc row is correct.
- Every surviving `~/.kobe` string is legacy-compat prose ("existing `~/.kobe/worktrees/` tasks remain usable"), not a stale instruction.

## One implementation-side leftover, deliberately not fixed here

Because `chat.session.resume` still sits in the keybinding table, **the F1 live keymap advertises `ctrl+y` for an action nothing handles** — the docs are now correct while the app still offers the chord. That's a source change and a keybinding-table change, so it's flagged rather than bundled into a docs PR.

Lint and docs build green. One unrelated pre-existing flake (`test/plugins/runtime.test.ts` shutdown-hook timing) appears under full-suite load — it passes in isolation on this branch and **fails the same way on `main`**, so it is not from this change.