### PR TITLE
fix: PureTUI capture harness delivers sidebar keys again (issue #12)

### DIFF
--- a/.changeset/puretui-harness-boot-focus.md
+++ b/.changeset/puretui-harness-boot-focus.md
@@ -1,0 +1,17 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The PureTUI live capture harness delivers sidebar keys again (issue #12).
+
+Key injection was never broken — since boot started restoring into the last
+session (2026-08-09), any boot with a seeded task lands focus on the workspace
+pane, so `n`/`j`/Enter dispatched against disabled sidebar bindings and
+vanished without an error. The harness now owns the recipe: the create-task
+flow settles after each `ctrl+a h` stroke (the pane-focus flip is a React
+state update, so a key sent in the same tick hit the old gates), the checked-in
+replay spec waits for sidebar hydration before its first flow and for the
+post-rename `ROVE` title at boot, and `focusLeftmostPane` is exported for raw
+key-driving scripts. A live e2e (`bun run test:replay:e2e` in
+`packages/branding`) boots the real TUI with a seeded task and goes red when
+the recipe or any layer of the injection path breaks.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -231,6 +231,16 @@ What actually works:
 
 What silently produces a false result:
 
+- **A bare sidebar key right after boot.** Boot restores INTO the session
+  (2026-08-09): any non-empty task store lands focus on the workspace pane, so
+  `n`/`j`/Enter dispatch against disabled sidebar bindings and vanish without
+  an error — the issue-#12 "keys are all dead" report; the injection path was
+  never broken. Wait for the sidebar rows to hydrate (the focus flip rides the
+  same commit), then normalize with `focusLeftmostPane` (`C-a` `h`,
+  `packages/branding/src/quicklook/capture-core.ts`) before sidebar-scoped
+  keys, and settle between strokes — the focus flip is a React state update,
+  so a key sent in the same tick still hits the OLD gates.
+  `bun run test:replay:e2e` in `packages/branding` pins the recipe live.
 - **`api read-output` for a vendor TUI.** Claude and Codex run on the alternate
   screen, so the text tail is escape-code noise (`">0q"`) no matter how healthy
   the session is. Absence of output is not absence of a dialog.

--- a/packages/branding/package.json
+++ b/packages/branding/package.json
@@ -20,6 +20,7 @@
     "mp4:glyph": "remotion render src/index.ts glyph-k ../../docs/assets/brand/glyph-k.mp4",
     "capture:puretui": "bun scripts/capture-puretui.ts",
     "test:replay": "bun test tests/replay-spec.test.ts tests/capture-core.test.ts tests/puretui-terminal.test.ts tests/puretui-terminal-colors.test.ts tests/puretui-capture-environment.test.ts tests/puretui-capture.test.ts",
+    "test:replay:e2e": "KOBE_REPLAY_E2E=1 bun test tests/puretui-capture.test.ts",
     "stills:all": "bun run still:bracket && bun run still:grid && bun run still:streams && bun run still:glyph",
     "gifs:all": "bun run gif:bracket && bun run gif:grid && bun run gif:streams && bun run gif:glyph",
     "render:all": "mkdir -p ../../docs/assets/brand && bun run stills:all && bun run gifs:all"

--- a/packages/branding/scripts/capture-puretui.ts
+++ b/packages/branding/scripts/capture-puretui.ts
@@ -92,7 +92,7 @@ export function createClient(baseUrl: string) {
 }
 `
 
-const createFixtureRepository = async (demoRoot: string): Promise<string> => {
+export const createFixtureRepository = async (demoRoot: string): Promise<string> => {
   const fixtureRepo = join(demoRoot, "fixture-repo")
   await mkdir(join(fixtureRepo, "src"), { recursive: true })
   await run("git", ["init", "-q", "-b", "main"], fixtureRepo)
@@ -121,7 +121,7 @@ const createFixtureRepository = async (demoRoot: string): Promise<string> => {
  */
 export const CAPTURE_SKILL_HINT_VERSION = 21
 
-const prepareCaptureState = async (demoRoot: string, fixtureRepo: string, claudeCommand?: string): Promise<void> => {
+export const prepareCaptureState = async (demoRoot: string, fixtureRepo: string, claudeCommand?: string): Promise<void> => {
   const configDir = join(demoRoot, "home", ".config", "kobe")
   await mkdir(configDir, { recursive: true })
   const state: Record<string, unknown> = {

--- a/packages/branding/src/quicklook/capture-core.ts
+++ b/packages/branding/src/quicklook/capture-core.ts
@@ -88,6 +88,41 @@ export interface CaptureClock {
   sleep(ms: number): Promise<void>
 }
 
+/**
+ * Focus the leftmost pane (the sidebar) — the ONE key sequence that makes
+ * sidebar-scoped keys (`n`, `j`, Enter, …) reachable from any pane. Since the
+ * boot-restore change (kobe 1443da8e6, 2026-08-09) a TUI booted with ANY task
+ * in the store lands focused on the WORKSPACE pane, so a bare `n` after boot
+ * is silently swallowed — the issue-#12 "keys are all dead" symptom; the
+ * injection path itself was never broken. `ctrl+a h` ("move focus left",
+ * docs/KEYBINDINGS.md) is idempotent at the leftmost pane, unlike `ctrl+q`,
+ * which focuses the sidebar but QUITS when the sidebar already has focus.
+ */
+export const FOCUS_LEFTMOST_KEYS = ["C-a", "h"] as const
+
+/** Post-stroke settle for the focus flip — see {@link focusLeftmostPane}. */
+// ponytail: fixed settle; poll the focus gate instead if this ever flakes
+export const FOCUS_SETTLE_MS = 300
+
+/**
+ * Drive {@link FOCUS_LEFTMOST_KEYS} on a live terminal, settling between
+ * strokes: the pane-focus flip is a React state update, so a key sent in the
+ * same tick still dispatches against the OLD focus gates. Callers must first
+ * wait for the sidebar rows to hydrate (e.g. `waitFor` a seeded task title) —
+ * the boot-restore focus flip fires on that same hydration, and normalizing
+ * before it would be undone.
+ */
+export async function focusLeftmostPane(
+  terminal: Pick<CaptureTerminal, "key">,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  settleMs = FOCUS_SETTLE_MS,
+): Promise<void> {
+  for (const key of FOCUS_LEFTMOST_KEYS) {
+    await terminal.key(key)
+    await sleep(settleMs)
+  }
+}
+
 export interface CaptureDocument {
   cols: number
   rows: number
@@ -233,14 +268,13 @@ const runCreateTask = async (
 ) => {
   const flow = spec.flows?.createTask
   if (!flow) throw new Error("replay flow createTask is not configured")
-  // The sidebar owns the bare `n` that opens the dialog, and a fresh boot does
-  // not focus it — an unanchored `n` is simply swallowed. Use the `ctrl+a` `h`
-  // prefix sequence from docs/KEYBINDINGS.md ("move focus left"): it is
-  // idempotent at the leftmost pane, unlike `ctrl+q`, which focuses the
-  // sidebar but QUITS when the sidebar already has focus.
   if (flow.focusPaneBeforeOpen === "leftmost") {
-    await sendKey("C-a", terminal, clock, startedAt, frames)
-    await sendKey("h", terminal, clock, startedAt, frames)
+    for (const key of FOCUS_LEFTMOST_KEYS) {
+      await sendKey(key, terminal, clock, startedAt, frames)
+      // The pane-focus flip is a React state update: a key sent in the same
+      // tick dispatches against the OLD focus gates and vanishes (issue #12).
+      await pause(FOCUS_SETTLE_MS, terminal, clock, startedAt, frames)
+    }
   }
   await sendKey(flow.openKey ?? "n", terminal, clock, startedAt, frames)
   await wait(spec, flow.dialogWait, terminal, clock, startedAt, frames)

--- a/packages/branding/src/quicklook/quicklook.replay.json
+++ b/packages/branding/src/quicklook/quicklook.replay.json
@@ -25,8 +25,12 @@
   },
   "waits": {
     "workspaceReady": {
-      "pattern": "KOBE",
+      "pattern": "ROVE",
       "timeoutMs": 20000
+    },
+    "sidebarHydrated": {
+      "pattern": "fix flaky retry test",
+      "timeoutMs": 15000
     },
     "newTaskDialog": {
       "pattern": "from branch",
@@ -53,6 +57,11 @@
     }
   },
   "beats": [
+    {
+      "at": 1,
+      "action": "waitFor",
+      "waitFor": "sidebarHydrated"
+    },
     {
       "at": 2,
       "action": "flow",

--- a/packages/branding/tests/puretui-capture.test.ts
+++ b/packages/branding/tests/puretui-capture.test.ts
@@ -3,7 +3,14 @@ import { mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { defaultDaemonSocketPath, defaultPtyHostSocketPath } from "../../kobe-daemon/src/daemon/paths"
-import { CAPTURE_SKILL_HINT_VERSION, capturePureTui } from "../scripts/capture-puretui"
+import {
+  CAPTURE_SKILL_HINT_VERSION,
+  capturePureTui,
+  createFixtureRepository,
+  prepareCaptureState,
+} from "../scripts/capture-puretui"
+import { focusLeftmostPane } from "../src/quicklook/capture-core"
+import { createPureTuiCapture } from "../src/quicklook/puretui-terminal"
 import quicklookSpec from "../src/quicklook/quicklook.replay.json"
 import { type RawReplaySpec, assertRenderableCapture } from "../src/quicklook/replay-spec"
 
@@ -26,10 +33,16 @@ e2e(
     const spec = structuredClone(quicklookSpec) as unknown as RawReplaySpec
     spec.viewport = { cols: 100, rows: 30, width: 800, height: 480 }
     spec.capture.seconds = 18
-    spec.setup = { seedTasks: [] }
-    // Dialog-only label: "New task" also matches the sidebar's own button,
-    // so it would pass before the dialog ever opened.
-    spec.waits = { newTaskDialog: { pattern: "from branch", timeoutMs: 8000 } }
+    // Keep the checked-in `setup` (readyWait + seed tasks) and `waits`: the
+    // spec's own ready pattern rotting away from the TUI's real title (the
+    // "KOBE" -> "ROVE" rename) and a boot with a NON-EMPTY task store are
+    // exactly the two conditions issue #12's "keys are all dead" hid behind --
+    // a boot-restored store lands focus on the workspace pane, so the flow's
+    // leftmost normalization (after `sidebarHydrated`) is what keeps `n`
+    // reachable. Overriding them here made this e2e green while the real
+    // capture was dead.
+    // Dialog-only label ("from branch"): "New task" also matches the
+    // sidebar's own button, so it would pass before the dialog ever opened.
     spec.text = { prompt: "Brand Studio replay prompt" }
     spec.flows = {
       createTask: {
@@ -43,6 +56,7 @@ e2e(
       },
     }
     spec.beats = [
+      { at: 1, action: "waitFor", waitFor: "sidebarHydrated" },
       { at: 2, action: "flow", flow: "createTask", engine: "claude" },
       { at: 14, action: "typeText", textRef: "prompt", msPerChar: 25 },
       { at: 18, action: "sleep", ms: 0 },
@@ -61,12 +75,55 @@ e2e(
 
     const capture = await Bun.file(outputPath).json()
     const screen = capture.frames.flatMap((frame: { lines: string[] }) => frame.lines).join("\n")
+    expect(screen).toContain("fix flaky retry test")
     expect(screen).toContain("New task")
     expect(screen).toContain("Brand Studio replay prompt")
     expect(await Bun.file(defaultDaemonSocketPath(join(demoRoot, "home"))).exists()).toBe(false)
     expect(await Bun.file(defaultPtyHostSocketPath(join(demoRoot, "home"))).exists()).toBe(false)
   },
-  45_000,
+  90_000,
+)
+
+// The raw `terminal.key` contract -- how agents drive chord-level live
+// verification (issue #12). Boot with a seeded task restores INTO the
+// session (workspace pane focused), so a bare `n` dispatches against
+// disabled sidebar bindings and vanishes without an error; the recipe is
+// waitFor sidebar hydration (the focus flip rides the same commit), then
+// `focusLeftmostPane`, then the sidebar key. Red here means either the key
+// injection path or that recipe broke.
+e2e(
+  "drives sidebar keys through raw terminal.key after boot restores into a task",
+  async () => {
+    // Short prefix on purpose: the demo home's daemon socket must stay under
+    // the sun_path ceiling or it silently falls back to a shared namespace.
+    const root = await mkdtemp(join(tmpdir(), "kobe-pt-live-"))
+    const demoRoot = join(root, "demo")
+    const fixtureRepo = await createFixtureRepository(demoRoot)
+    await prepareCaptureState(demoRoot, fixtureRepo)
+    const seedTitle = "fix flaky retry test"
+    const capture = await createPureTuiCapture({
+      repoRoot: resolve(import.meta.dirname, "../../.."),
+      demoRoot,
+      fixtureRepo,
+      seedTasks: [{ title: seedTitle, status: "in_progress" }],
+      readyPattern: quicklookSpec.waits.workspaceReady.pattern,
+      readyTimeoutMs: 30_000,
+      cols: 120,
+      rows: 36,
+    })
+    try {
+      await capture.terminal.start()
+      await capture.terminal.waitFor(seedTitle, 15_000)
+      await focusLeftmostPane(capture.terminal)
+      await capture.terminal.key("n")
+      await capture.terminal.waitFor("from branch", 8_000)
+    } finally {
+      await capture.cleanup()
+    }
+    expect(await Bun.file(defaultDaemonSocketPath(join(demoRoot, "home"))).exists()).toBe(false)
+    expect(await Bun.file(defaultPtyHostSocketPath(join(demoRoot, "home"))).exists()).toBe(false)
+  },
+  90_000,
 )
 
 describe("capture PureTUI CLI", () => {


### PR DESCRIPTION
Fixes rove issue #12 — **by relocating its root cause.** The issue is titled "键投递全死" (key delivery is entirely dead); key injection was never broken.

**Not for merging tonight** — parked for review.

## What was actually happening

`1443da8e` (2026-08-09) made a boot that restores into a session land focus on the **workspace** pane rather than the sidebar. `use-workspace-selection.ts:58-60`:

```ts
if (!bootFocusRef.current && !userPickedRef.current && selectedId && tasks.some(t => t.id === selectedId)) {
  bootFocusRef.current = true
  args.focusWorkspace()
}
```

Sidebar bindings are gated on `focus.focused === "sidebar"` (`host-keybindings.ts:150,173`). So a harness that seeds **any** task boots focused on the workspace, and every sidebar-scoped key (`n`, `j`, Enter) dispatches against **disabled** bindings and vanishes silently. That reads as "all keys are dead" while the injection path is fine — which is why the symptom pointed at the wrong layer.

That also explains the "works sometimes" shape: a cold start with nothing to restore leaves the sidebar focused, and the harness works.

## The fix

- `focusLeftmostPane` normalizes focus with `ctrl+a h` ("move focus left"), **settling between strokes** — the focus flip is a React state update, so a key sent in the same tick still dispatches against the old gates.
- `ctrl+a h` specifically, **not `ctrl+q`**: `ctrl+q` focuses the sidebar but **quits** when the sidebar already has it. `ctrl+a h` is idempotent at the leftmost pane.
- The replay spec now waits for the post-rename `ROVE` title and for sidebar hydration before its first flow — the boot focus flip fires on that same hydration, so normalizing earlier would just be undone.
- `focusLeftmostPane` is exported so raw key-driving callers get the same guarantee.
- `docs/HARNESS.md` updated — that file is load-bearing precisely for "shortcuts that silently measure nothing", and this was one.

## Verification

I ran the live e2e myself (`KOBE_REPLAY_E2E=1`, 42s, 5 pass) and then **neutered the fix to confirm the test is not hollow**: with `focusLeftmostPane` short-circuited, `drives sidebar keys through raw terminal.key after boot restores into a task` fails. A harness test that passes either way would be worse than none.

Also independently confirmed the blamed commit and the gating mechanism in source rather than taking the report's word for it.

Lint clean.