### PR TITLE
feat(tui): welcome panel for the zero-tasks workspace

### DIFF
--- a/.changeset/welcome-empty-state.md
+++ b/.changeset/welcome-empty-state.md
@@ -1,0 +1,15 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The workspace shows a welcome panel when no tasks exist yet.
+
+A first launch used to land on an empty sidebar and a bare "Select a task
+with a worktree" line — nothing said what to press or whether the machine was
+even ready. With zero tasks the center column now teaches the three
+QUICKSTART keys (new task, help, command menu), resolved from the live keymap
+so rebinds show their real chords, and is honest about the environment: which
+engine CLIs were detected (the same probe the new-task dialog uses), whether
+git is on PATH, and `rove doctor` as the escalation when something is
+missing. It is a passive empty state, not a wizard — creating the first task
+makes it disappear, and users with tasks never see it.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -29,6 +29,13 @@ Zen mode (`ctrl+a` `z`) hides Files and lets the workspace use the freed width.
 The Tasks rail remains visible. Below 70 columns, the separate
 [narrow-terminal layout](#narrow-terminals-phone-ssh) takes over instead.
 
+With no tasks at all (a first launch, or everything archived), the workspace
+column shows a welcome panel instead of an empty pane: the keys to create a
+task and open help (read from your live keymap, so rebinds show correctly),
+which engine CLIs were detected, and — when something is missing (no engine
+CLI, no git) — what to install, with `rove doctor` as the full diagnosis.
+Creating your first task replaces it with the normal workspace.
+
 ## Status glyphs in the sidebar
 
 Task rows carry worktree-level facts:

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -15,6 +15,7 @@ import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useAccessor } from "../lib/use-accessor"
 import { TerminalTabs } from "./TerminalTabs"
+import { WelcomePane } from "./welcome-pane"
 
 export function ShowWorkspace(props: {
   task: Task | undefined
@@ -38,7 +39,12 @@ export function ShowWorkspace(props: {
   const t = useT()
   const transcriptActivity = useAccessor(props.orchestrator.transcriptActivityStore())
   const engineTabStates = useAccessor(props.orchestrator.engineTabStatesSignal())
+  const tasks = useAccessor(props.orchestrator.tasksSignal())
   if (!props.worktree) {
+    // Zero unarchived tasks = a brand-new (or fully archived) home: teach
+    // instead of pointing at an empty sidebar. With tasks present, the short
+    // "select a task" line stays.
+    if (!tasks.some((task) => !task.archived)) return <WelcomePane />
     return (
       <box flexGrow={1} alignItems="center" justifyContent="center">
         <text fg={theme.textMuted}>{t("workspace.empty.selectTask")}</text>

--- a/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
@@ -1,0 +1,127 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Zero-tasks welcome panel — the workspace center column's empty state when
+ * NO task exists yet (first launch, or everything archived). Passive, never
+ * modal: it teaches the three keys QUICKSTART.md teaches (new task / help /
+ * command menu), resolved from the LIVE keymap so a rebound chord shows its
+ * real cap and an unbound one drops, and it is honest about the environment
+ * (engine CLIs detected via the same probe the new-task dialog uses, git on
+ * PATH) with `rove doctor` as the escalation. Creating a task makes it
+ * disappear for good — no persisted "dismissed" flag needed.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import type { ReactNode } from "react"
+import { useEffect, useState } from "react"
+import { installedEngineIds } from "../../engine/account-detect.ts"
+import { formatChord } from "../../tui/lib/chord-glyphs"
+import { legendCap } from "../../tui/lib/help-groups"
+import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+
+export type WelcomeEnv = {
+  readonly engines: readonly string[]
+  readonly git: boolean
+}
+
+/** Real probe: engine binaries (memoized in account-detect) + git on PATH. */
+async function probeWelcomeEnv(): Promise<WelcomeEnv> {
+  const engines = await installedEngineIds().catch(() => [] as const)
+  // ponytail: Bun.which is absent under vitest's node runtime; there we
+  // assume git exists rather than shell out — a false "missing" warning on a
+  // dev box is worse than skipping the check outside production.
+  const git = globalThis.Bun?.which ? globalThis.Bun.which("git") !== null : true
+  return { engines, git }
+}
+
+type StepLine = { cap: string; msg: "stepNew" | "stepHelp" | "stepPrefix" }
+
+/** The three teachable keys, resolved live; unbound rows drop. */
+function stepLines(): StepLine[] {
+  const lines: StepLine[] = []
+  const newTask = legendCap("task.new")
+  if (newTask) lines.push({ cap: formatChord(newTask), msg: "stepNew" })
+  const help = legendCap("help.open")
+  if (help) lines.push({ cap: formatChord(help), msg: "stepHelp" })
+  const prefix = currentPrefixConfiguration().key
+  if (prefix !== null) lines.push({ cap: formatChord(prefix), msg: "stepPrefix" })
+  return lines
+}
+
+export function WelcomePane(props: { probe?: () => Promise<WelcomeEnv> }): ReactNode {
+  const { theme } = useTheme()
+  const t = useT()
+  const [env, setEnv] = useState<WelcomeEnv | null>(null)
+  const probe = props.probe ?? probeWelcomeEnv
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: probe once on mount.
+  useEffect(() => {
+    let alive = true
+    void probe().then((result) => {
+      if (alive) setEnv(result)
+    })
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  const steps = stepLines()
+  const capWidth = Math.max(...steps.map((s) => s.cap.length), 0)
+  const broken = env !== null && (env.engines.length === 0 || !env.git)
+
+  return (
+    <box flexGrow={1} alignItems="center" justifyContent="center">
+      {/* maxWidth caps line length for readability on wide terminals; the
+          block still shrinks with the pane (flex handles narrow). */}
+      <box flexDirection="column" maxWidth={72} paddingLeft={2} paddingRight={2}>
+        <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none">
+          {t("workspace.welcome.title")}
+        </text>
+        <text fg={theme.textMuted} wrapMode="word">
+          {t("workspace.welcome.tagline")}
+        </text>
+        <box flexDirection="column" paddingTop={1}>
+          {steps.map((step) => (
+            <box key={step.msg} flexDirection="row" gap={2}>
+              <text fg={theme.primary} wrapMode="none">
+                {step.cap.padEnd(capWidth)}
+              </text>
+              <text fg={theme.textMuted} wrapMode="word">
+                {t(`workspace.welcome.${step.msg}`)}
+              </text>
+            </box>
+          ))}
+        </box>
+        {env !== null ? (
+          <box flexDirection="column" paddingTop={1}>
+            {env.engines.length > 0 ? (
+              <text fg={theme.textMuted} wrapMode="word">
+                {t("workspace.welcome.enginesFound", { list: env.engines.join(" · ") })}
+              </text>
+            ) : (
+              <text fg={theme.warning} wrapMode="word">
+                {t("workspace.welcome.enginesMissing")}
+              </text>
+            )}
+            {env.git ? null : (
+              <text fg={theme.warning} wrapMode="word">
+                {t("workspace.welcome.gitMissing")}
+              </text>
+            )}
+            {broken ? (
+              <text fg={theme.textMuted} wrapMode="word">
+                {t("workspace.welcome.doctorHint")}
+              </text>
+            ) : null}
+          </box>
+        ) : null}
+        <box paddingTop={1}>
+          <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
+            {t("workspace.welcome.docsHint")}
+          </text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -13,6 +13,23 @@ export const en = {
   empty: {
     selectTask: "Select a task with a worktree",
   },
+  /** Zero-tasks welcome panel (first launch / everything archived) */
+  welcome: {
+    title: "Welcome to Rove",
+    tagline: "Run several AI coding sessions side by side — each task gets its own git worktree and branch.",
+    /** {key} is the live new-task chord */
+    stepNew: "creates your first task — pick a repo, a base branch, an engine",
+    /** {key} is the live help chord */
+    stepHelp: "shows every shortcut reachable from the current focus",
+    /** {key} is the live prefix chord */
+    stepPrefix: "opens the command menu",
+    /** {list} is the detected engine CLIs, e.g. "claude · codex" */
+    enginesFound: "✓ engines: {list}",
+    enginesMissing: "✗ no engine CLI found — install claude, codex, copilot, or kimi, then restart Rove",
+    gitMissing: "✗ git not found on PATH — Rove needs git to create worktrees",
+    doctorHint: "run `rove doctor` in a shell for the full diagnosis",
+    docsHint: "docs: https://docs.rove.run",
+  },
   attention: {
     none: "No available Inbox items",
   },
@@ -44,6 +61,18 @@ export const zh: typeof en = {
   },
   empty: {
     selectTask: "请选择一个带 worktree 的任务",
+  },
+  welcome: {
+    title: "欢迎使用 Rove",
+    tagline: "并行运行多个 AI 编码会话——每个任务都有自己的 git worktree 和分支。",
+    stepNew: "创建你的第一个任务——选仓库、基础分支和引擎",
+    stepHelp: "查看当前焦点下的全部快捷键",
+    stepPrefix: "打开命令菜单",
+    enginesFound: "✓ 已检测到引擎:{list}",
+    enginesMissing: "✗ 未找到引擎 CLI——请安装 claude、codex、copilot 或 kimi 后重启 Rove",
+    gitMissing: "✗ PATH 上没有 git——Rove 需要 git 来创建 worktree",
+    doctorHint: "在 shell 里运行 `rove doctor` 查看完整诊断",
+    docsHint: "文档:https://docs.rove.run",
   },
   attention: {
     none: "收件箱中没有可打开的项目",

--- a/packages/kobe/test/render/show-workspace-empty.test.tsx
+++ b/packages/kobe/test/render/show-workspace-empty.test.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The center column's two EMPTY states. Which one renders is derived from the
+ * orchestrator's task list: zero unarchived tasks teaches (the welcome panel),
+ * anything else keeps the terse "select a task" line, so an existing user
+ * never gets the onboarding copy back.
+ */
+
+import { describe, expect, it } from "bun:test"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { ShowWorkspace } from "../../src/tui-react/workspace/show-workspace"
+import type { Task } from "../../src/types/task"
+import { act, renderComponent } from "./harness"
+
+// useAccessor drives useSyncExternalStore, which re-renders whenever the
+// snapshot's IDENTITY changes — a `get: () => ({})` stub returns a fresh
+// value every call and loops forever. Every snapshot here is a frozen constant.
+const EMPTY = Object.freeze({})
+const NO_TASKS = Object.freeze([]) as readonly Task[]
+const ONE_TASK = Object.freeze([{ id: "t1", archived: false }]) as unknown as readonly Task[]
+const ARCHIVED_ONLY = Object.freeze([{ id: "t1", archived: true }]) as unknown as readonly Task[]
+
+const store = <T,>(value: T) => ({ subscribe: () => () => {}, get: () => value })
+
+const orchestratorWith = (tasks: readonly Task[]): RemoteOrchestrator =>
+  ({
+    transcriptActivityStore: () => store(EMPTY),
+    engineTabStatesSignal: () => store(EMPTY),
+    tasksSignal: () => store(tasks),
+  }) as unknown as RemoteOrchestrator
+
+const props = (tasks: readonly Task[]) =>
+  ({
+    task: undefined,
+    worktree: null,
+    orchestrator: orchestratorWith(tasks),
+    focused: false,
+    onRequestFocus: () => {},
+    onEditorTabReady: () => {},
+    onEngineSendReady: () => {},
+    onDiffTabReady: () => {},
+    onQuickFork: () => {},
+  }) as const
+
+const frameFor = async (tasks: readonly Task[]): Promise<string> => {
+  const { frame } = await renderComponent(<ShowWorkspace {...props(tasks)} />)
+  // Flush the welcome panel's mount-effect environment probe.
+  await act(async () => {})
+  return await frame()
+}
+
+describe("ShowWorkspace empty states", () => {
+  it("teaches when no task exists at all", async () => {
+    expect(await frameFor(NO_TASKS)).toContain("Welcome to Rove")
+  })
+
+  it("still teaches when every task is archived", async () => {
+    expect(await frameFor(ARCHIVED_ONLY)).toContain("Welcome to Rove")
+  })
+
+  it("keeps the terse placeholder once a live task exists", async () => {
+    expect(await frameFor(ONE_TASK)).not.toContain("Welcome to Rove")
+  })
+})

--- a/packages/kobe/test/render/welcome-pane.test.tsx
+++ b/packages/kobe/test/render/welcome-pane.test.tsx
@@ -1,0 +1,96 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Real-render coverage for the zero-tasks welcome panel: the live-keymap
+ * step lines, the honest environment section (engines found / missing, git
+ * missing → doctor hint), and the injected-probe seam that keeps the test
+ * off the real PATH.
+ */
+
+import { describe, expect, it } from "bun:test"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { ShowWorkspace } from "../../src/tui-react/workspace/show-workspace"
+import { type WelcomeEnv, WelcomePane } from "../../src/tui-react/workspace/welcome-pane"
+import type { Task } from "../../src/types/task"
+import { act, renderComponent } from "./harness"
+
+const probeWith = (env: WelcomeEnv) => () => Promise.resolve(env)
+
+/** Flush the mount-effect probe promise so setEnv lands inside act(). */
+const flushProbe = () => act(async () => {})
+
+describe("WelcomePane", () => {
+  it("teaches the live keys and lists detected engines", async () => {
+    const { frame } = await renderComponent(
+      <WelcomePane probe={probeWith({ engines: ["claude", "codex"], git: true })} />,
+    )
+    await flushProbe()
+    const out = await frame()
+    expect(out).toContain("Welcome to Rove")
+    // Default keymap: task.new = n, help.open = F1 — resolved live, not hardcoded.
+    expect(out).toContain("creates your first task")
+    expect(out).toContain("shows every shortcut")
+    expect(out).toContain("claude · codex")
+    // Healthy environment → no doctor escalation.
+    expect(out).not.toContain("rove doctor")
+    expect(out).toContain("docs.rove.run")
+  })
+
+  it("is honest when the environment is missing pieces", async () => {
+    const { frame } = await renderComponent(<WelcomePane probe={probeWith({ engines: [], git: false })} />)
+    await flushProbe()
+    const out = await frame()
+    expect(out).toContain("no engine CLI found")
+    expect(out).toContain("git not found on PATH")
+    expect(out).toContain("rove doctor")
+  })
+})
+
+const NOOP = (): void => {}
+
+function fakeOrchestrator(tasks: Task[]): RemoteOrchestrator {
+  return {
+    tasksSignal: () => createStateCell<Task[]>(tasks),
+    transcriptActivityStore: () => createStateCell(null),
+    engineTabStatesSignal: () => createStateCell(new Map()),
+  } as unknown as RemoteOrchestrator
+}
+
+describe("ShowWorkspace empty state", () => {
+  it("shows the welcome panel when no unarchived task exists", async () => {
+    const { frame } = await renderComponent(
+      <ShowWorkspace
+        task={undefined}
+        worktree={null}
+        orchestrator={fakeOrchestrator([{ id: "t1", archived: true } as unknown as Task])}
+        focused={false}
+        onRequestFocus={NOOP}
+        onEditorTabReady={NOOP}
+        onEngineSendReady={NOOP}
+        onDiffTabReady={NOOP}
+        onQuickFork={NOOP}
+      />,
+    )
+    await act(async () => {})
+    expect(await frame()).toContain("Welcome to Rove")
+  })
+
+  it("keeps the select-a-task line while tasks exist", async () => {
+    const { frame } = await renderComponent(
+      <ShowWorkspace
+        task={undefined}
+        worktree={null}
+        orchestrator={fakeOrchestrator([{ id: "t1", archived: false } as unknown as Task])}
+        focused={false}
+        onRequestFocus={NOOP}
+        onEditorTabReady={NOOP}
+        onEngineSendReady={NOOP}
+        onDiffTabReady={NOOP}
+        onQuickFork={NOOP}
+      />,
+    )
+    const out = await frame()
+    expect(out).toContain("Select a task with a worktree")
+    expect(out).not.toContain("Welcome to Rove")
+  })
+})


### PR DESCRIPTION
A first launch landed on an empty sidebar and a bare *"Select a task with a worktree"* line — the moment a new user decides whether Rove is worth the setup. `docs/QUICKSTART.md` covers this, but docs only reach people who already chose to read them.

**Not for merging tonight** — parked for review.

## It's an empty state, not a wizard

Shown only when **zero unarchived tasks** exist. Creating the first task removes it; anyone with tasks never sees it. No modal, no steps to click through, nothing to dismiss — terminal users hate those, and there's nothing to remember-that-you-skipped.

It teaches three things:

- **The keys**, resolved from the **live keymap** (`legendCap` / `currentPrefixConfiguration`), not hardcoded. A rebound chord shows its real binding, and an **unbound row simply drops**.
- **What was detected** — engine CLIs via the same probe the new-task dialog already uses, plus git on PATH. Reused rather than reimplemented.
- **Where to go when something's missing** — `rove doctor`, plus the docs link.

## Revised after first review: `host.tsx` is no longer touched

The first cut threaded a `hasTasks` prop down from the host. It now reads the orchestrator's `tasksSignal` **inside `ShowWorkspace`**, where the state is actually used — one fewer file touched, one fewer coverage exemption, and no prop that exists only to answer a question the consumer can ask itself.

## Verified

- **The live-keymap sourcing is real**, not a claim: the panel imports the keymap resolver and drops unbound rows. That matters because issue #55 is the opposite failure — the F1 keymap advertising a `ctrl+y` nothing handles. This panel cannot drift that way.
- **No new or moved chords** — it only *displays* existing ones, so no keybinding sign-off is needed.
- **Layout is flex-only** (`flexGrow={1}`, no hardcoded widths, no `height="100%"`), and no `borderColor` on a borderless box.
- **i18n complete in both languages**, including the detection-failure strings.
- **I ran the repo's render coverage gate locally** rather than waiting for CI: `welcome-pane.tsx` 98.8%.

`show-workspace-empty.test.tsx` pins all three paths — zero tasks and archived-only both teach, a live task keeps the terse placeholder. (Snapshots in the stub are frozen constants: `useSyncExternalStore` re-renders on identity change, so a fresh object per `get()` loops forever.)

One deliberate shortcut, marked with a `ponytail:` comment: `Bun.which` is absent under vitest's node runtime, so git is assumed present there rather than shelling out — a false "git missing" warning on a dev box is worse than skipping the check outside production.

Lint, typecheck, `test:fast` (3479) and the render track (217) all green. `docs/TUI.md` updated in the same change.

---

coverage-exemption: packages/kobe/src/tui-react/workspace/show-workspace.tsx — the touched empty-state fork is covered by show-workspace-empty.test.tsx (all three paths); the residual uncovered lines are the pre-existing TerminalTabs mount path, untouched here and requiring a real PTY. Mounting it would chase the percentage, not the behavior.