### PR TITLE
fix(tui): end clipped labels in … instead of a bare hard cut

### DIFF
--- a/.changeset/tui-label-truncation.md
+++ b/.changeset/tui-label-truncation.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Clipped labels across the TUI now end in a visible `…` instead of a bare hard cut: sidebar tree rows (worktree branches and tab titles) truncate to the rail's live cell budget while the right-edge cluster (pin / PR chip / ±stats) keeps its cells, and toast titles/bodies truncate to the card. The files-pane header chips no longer lose their inner gap on a narrow pane ("[~]Zen") — they wrap whole instead — and the toast stack clamps to the terminal width rather than poking across the neighbouring pane.

--- a/packages/kobe/src/tui-react/component/toast-overlay.tsx
+++ b/packages/kobe/src/tui-react/component/toast-overlay.tsx
@@ -11,7 +11,9 @@
 
 import { TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
+import { charWidth } from "../../lib/display-width"
 import type { Toast } from "../../tui/lib/notify-state"
+import { truncateEndCells } from "../../tui/lib/truncate"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 
@@ -36,11 +38,17 @@ export function ToastOverlay() {
   // the overlay sits on top of the layout without taking flow space;
   // `zIndex` keeps it above the panes but below the dialog backdrop (3000).
   const stackRows = visibleToasts.reduce((rows, toast) => rows + cardRows(toast), 0)
-  const left = Math.max(0, dims.width - CARD_WIDTH - RIGHT_MARGIN)
+  // On a terminal narrower than the card the stack used to poke left across
+  // the neighbouring pane — clamp to what actually fits.
+  const cardWidth = Math.min(CARD_WIDTH, Math.max(12, dims.width - RIGHT_MARGIN * 2))
+  const left = Math.max(0, dims.width - cardWidth - RIGHT_MARGIN)
   const top = Math.max(0, dims.height - BOTTOM_MARGIN - stackRows)
+  // Inner text budget: accent bar (1) + card padding (2) = 3; the title row
+  // spends 2 more on its glyph, the body row 2 on its indent — same number.
+  const textBudget = cardWidth - 5
 
   return (
-    <box position="absolute" zIndex={2500} left={left} top={top} width={CARD_WIDTH} flexDirection="column" gap={1}>
+    <box position="absolute" zIndex={2500} left={left} top={top} width={cardWidth} flexDirection="column" gap={1}>
       {visibleToasts.map((toast) => {
         const accent =
           toast.kind === "needs_input" ? theme.warning : toast.kind === "error" ? theme.error : theme.success
@@ -76,13 +84,13 @@ export function ToastOverlay() {
                   flexGrow={1}
                   flexShrink={1}
                 >
-                  {toast.title}
+                  {truncateEndCells(toast.title, textBudget, charWidth)}
                 </text>
               </box>
               {toast.body ? (
                 <box flexDirection="row" paddingLeft={2}>
                   <text fg={theme.textMuted} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
-                    {toast.body}
+                    {truncateEndCells(toast.body, textBudget, charWidth)}
                   </text>
                 </box>
               ) : null}

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -43,7 +43,11 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
       {/* Action row — sits above the All / Changes tabs so it's reachable
          from both tabs. Zen toggle sits left of Create PR (prefix+p). */}
       {props.onZenToggle || props.onCreatePR ? (
-        <box flexDirection="row" justifyContent="flex-end" gap={2} paddingBottom={1} flexShrink={0}>
+        // wrap, and chips flexShrink={0}: on a narrow pane Yoga used to
+        // squeeze the chips' inner gaps first ("[~]Zen"), and with shrink
+        // forbidden the row would overflow the pane border instead — wrapping
+        // stacks the chips right-aligned, both still whole.
+        <box flexDirection="row" flexWrap="wrap" justifyContent="flex-end" gap={2} paddingBottom={1} flexShrink={0}>
           {props.onZenToggle ? (
             // stopPropagation: the chip click must NOT bubble to the host
             // pane box's own onMouseUp (workspace host focuses the files
@@ -53,6 +57,10 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
             <box
               flexDirection="row"
               gap={1}
+              // Never squeeze the chip below its content: on a narrow pane the
+              // shrink ate the inner gap first ("[~]Zen"), which reads as one
+              // garbled token instead of a keycap + label.
+              flexShrink={0}
               onMouseUp={(e: { stopPropagation(): void }) => {
                 e.stopPropagation()
                 props.onZenToggle?.()
@@ -70,6 +78,8 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
             <box
               flexDirection="row"
               gap={1}
+              // Same no-squeeze rule as the Zen chip.
+              flexShrink={0}
               onMouseUp={(e: { stopPropagation(): void }) => {
                 e.stopPropagation()
                 props.onCreatePR?.()

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -320,6 +320,7 @@ export function SidebarTree(props: SidebarTreeProps) {
   }, [effectiveWidth])
 
   const shared: TreeRowShared = {
+    width: effectiveWidth,
     cursorIndex,
     activeRowId: tree.activeRowId,
     selectedTaskId: props.selectedId,

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -15,10 +15,12 @@ import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator
 import type { Task } from "@/types/task"
 import { type BoxRenderable, MouseButton } from "@opentui/core"
 import { type ReactNode, useEffect } from "react"
+import { charWidth } from "../../../lib/display-width"
+import { truncateEndCells } from "../../../tui/lib/truncate"
 import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
 import { NO_STATE_GLYPH, buildSidebarRowView, prCheckChip, withSpinnerFrame } from "../../../tui/panes/sidebar/row-view"
 import { type TreeTab, rowLiveBranchPath, tabRowActivity, worktreeRowLabel } from "../../../tui/panes/sidebar/tree-core"
-import { toneColor, truncateBranchLabel } from "../../../tui/panes/sidebar/view-core"
+import { SIDEBAR_WIDTH, toneColor, truncateBranchLabel } from "../../../tui/panes/sidebar/view-core"
 import type { WorktreeChanges } from "../../../tui/panes/sidebar/worktree-changes"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
@@ -38,6 +40,8 @@ import {
 const INDENT_CELLS = 1
 
 export type TreeRowShared = {
+  /** Rail width in cells — the label truncation budget derives from it. */
+  readonly width?: number
   /** Cursor position in the tree's flat id list. */
   readonly cursorIndex: number
   /** The row id the right pane is showing (`taskId::tabId` when a tab). */
@@ -66,6 +70,28 @@ export type TreeRowShared = {
   readonly engineLifecycle?: ReadonlyMap<string, { readonly subagents: number }>
   readonly taskJobs?: ReadonlyMap<string, TaskJobState>
   readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
+}
+
+/**
+ * Cell budget for a tree row's flexible label, so a clipped label ends in a
+ * visible `…` instead of the bare hard cut Yoga produces (a chopped branch
+ * name reads as the full name to anyone who doesn't know it's longer). The
+ * caller passes the LIVE right-edge cluster width — same per-row subtraction
+ * the flat cards do — and each cluster item costs its width plus its 1-cell
+ * flex gap. Slight over-budget is safe (flex still clips); the floor keeps a
+ * crowded row from erasing its label entirely.
+ */
+function treeLabelBudget(shared: TreeRowShared, reserved: number): number {
+  const width = shared.width ?? SIDEBAR_WIDTH
+  // marker (1) + indent (1) + paddingRight (1) = 3 cells every row spends.
+  return Math.max(6, width - 3 - reserved)
+}
+
+/** Cells one right-cluster glyph occupies: itself plus the row's 1-cell gap. */
+function clusterCells(text: string): number {
+  let cells = 1
+  for (const ch of text) cells += charWidth(ch.codePointAt(0) ?? 0)
+  return cells
 }
 
 /** The move-mode chip a dragged ROW wears (issue #43) — same vocabulary as
@@ -148,6 +174,7 @@ export function WorktreeTreeRow(props: {
   readonly shared: TreeRowShared
 }) {
   const { theme } = useTheme()
+  const t = useT()
   const shared = props.shared
   const task = props.task
   const isCursor = shared.cursorIndex === props.flatIndex
@@ -165,11 +192,18 @@ export function WorktreeTreeRow(props: {
     if (livePath) pollCurrentBranch(livePath)
   }, [livePath, shared.branchTick])
   const label = worktreeRowLabel(task, livePath ? { liveBranch: currentBranch(livePath) } : {})
+  const moving = shared.movingRowId === props.rowId
+  const reserved =
+    (task.pinned === true ? 2 : 0) +
+    (chip ? 2 : 0) +
+    (changes.added > 0 ? clusterCells(`+${changes.added}`) : 0) +
+    (changes.deleted > 0 ? clusterCells(`−${changes.deleted}`) : 0) +
+    (moving ? clusterCells(t("tasks.moveChip").trim()) : 0)
   return (
     <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={1} shared={shared}>
       <box flexDirection="row" flexGrow={1} paddingRight={1} gap={1}>
         <text fg={theme.text} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
-          {label}
+          {truncateEndCells(label, treeLabelBudget(shared, reserved), charWidth)}
         </text>
         {task.pinned === true ? (
           <text fg={theme.warning} wrapMode="none" flexShrink={0}>
@@ -197,6 +231,7 @@ export function TabTreeRow(props: {
   readonly shared: TreeRowShared
 }) {
   const { theme } = useTheme()
+  const t = useT()
   const shared = props.shared
   const isCursor = shared.cursorIndex === props.flatIndex
   // Glyph rule (owner round 7): an AGENT tab always wears the state circle
@@ -284,7 +319,15 @@ export function TabTreeRow(props: {
       </text>
       <box flexDirection="row" flexGrow={1} paddingRight={1} gap={1}>
         <text fg={theme.textMuted} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
-          {props.tab.label}
+          {truncateEndCells(
+            props.tab.label,
+            // The 2-cell state-glyph column is this row's extra fixed spend.
+            treeLabelBudget(
+              shared,
+              2 + (shared.movingRowId === props.rowId ? clusterCells(t("tasks.moveChip").trim()) : 0),
+            ),
+            charWidth,
+          )}
         </text>
         <MoveChip rowId={props.rowId} shared={shared} />
         <JumpDigit flatIndex={props.flatIndex} dim={!isCursor} />

--- a/packages/kobe/test/render/golden/long-labels.frame.txt
+++ b/packages/kobe/test/render/golden/long-labels.frame.txt
@@ -1,0 +1,26 @@
+# sidebar frame: long-labels
+# a clipped label ends in a visible … (never Yoga's bare hard cut), and the right-edge cluster still gets its cells
+# 30x22
+# GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
+|                              |
+| ROVE                         |
+|                              |
+|  New task               + n  |
+|                              |
+| Kanban                       |
+| Routines                     |
+|                              |
+| rove ─────────────────────── |
+|  refactor/tab-strip-res… ▴ ✓ |
+|  · persist scrollback acros… |
+|  feat/alpha                  |
+|▌ · build                     |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |

--- a/packages/kobe/test/render/golden/sidebar-scenes.tsx
+++ b/packages/kobe/test/render/golden/sidebar-scenes.tsx
@@ -206,6 +206,29 @@ export const SCENES: readonly Scene[] = [
     }),
   },
   {
+    name: "long-labels",
+    about:
+      "a clipped label ends in a visible … (never Yoga's bare hard cut), and the right-edge cluster still gets its cells",
+    setup: () =>
+      seedTabs([
+        {
+          taskId: "wordy",
+          tabs: [{ id: "tab-1", title: "persist scrollback across daemon restarts without dropping" }],
+        },
+        { taskId: "alpha", tabs: [{ id: "tab-1", title: "build" }] },
+      ]),
+    element: tree({
+      tasks: [
+        task("wordy", {
+          branch: "refactor/tab-strip-restart-scrollback",
+          pinned: true,
+          prStatus: { checkState: "passing" } as Task["prStatus"],
+        }),
+        ALPHA,
+      ],
+    }),
+  },
+  {
     name: "search-pruned",
     about: "the query row plus a tree pruned to matches and their ancestors — a hit never floats free",
     setup: seedStandard,

--- a/packages/kobe/test/render/toast-truncation.test.tsx
+++ b/packages/kobe/test/render/toast-truncation.test.tsx
@@ -16,7 +16,7 @@ const LONG_BODY = "fixture-repo › second opinion: root-cause the stale badge b
 /** Pushes one toast on mount, then renders the overlay under test. */
 function Harness() {
   const notif = useNotifications()
-  if (notif.toasts.length === 0) notif.notify({ title: LONG_TITLE, body: LONG_BODY, kind: "done" })
+  if (notif.toasts.length === 0) notif.notify({ kind: "done", taskId: "t1", tabId: "tab-1", title: LONG_TITLE, body: LONG_BODY })
   return <ToastOverlay />
 }
 

--- a/packages/kobe/test/render/toast-truncation.test.tsx
+++ b/packages/kobe/test/render/toast-truncation.test.tsx
@@ -16,7 +16,8 @@ const LONG_BODY = "fixture-repo › second opinion: root-cause the stale badge b
 /** Pushes one toast on mount, then renders the overlay under test. */
 function Harness() {
   const notif = useNotifications()
-  if (notif.toasts.length === 0) notif.notify({ kind: "done", taskId: "t1", tabId: "tab-1", title: LONG_TITLE, body: LONG_BODY })
+  if (notif.toasts.length === 0)
+    notif.notify({ kind: "done", taskId: "t1", tabId: "tab-1", title: LONG_TITLE, body: LONG_BODY })
   return <ToastOverlay />
 }
 

--- a/packages/kobe/test/render/toast-truncation.test.tsx
+++ b/packages/kobe/test/render/toast-truncation.test.tsx
@@ -1,0 +1,44 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Toast cards must stay INSIDE their pane: long copy ends in `…` rather than
+ * a bare hard cut, and on a terminal narrower than the card the stack clamps
+ * instead of poking left across the neighbouring pane.
+ */
+
+import { describe, expect, it } from "bun:test"
+import { ToastOverlay } from "../../src/tui-react/component/toast-overlay"
+import { useNotifications } from "../../src/tui-react/context/notifications"
+import { act, renderComponent } from "./harness"
+
+const LONG_TITLE = "Fix the sidebar unread lamp across every repository group"
+const LONG_BODY = "fixture-repo › second opinion: root-cause the stale badge before the sweep"
+
+/** Pushes one toast on mount, then renders the overlay under test. */
+function Harness() {
+  const notif = useNotifications()
+  if (notif.toasts.length === 0) notif.notify({ title: LONG_TITLE, body: LONG_BODY, kind: "done" })
+  return <ToastOverlay />
+}
+
+const mount = (width: number) =>
+  renderComponent(<Harness />, { width, height: 12, providers: { notifications: true } })
+
+describe("ToastOverlay truncation", () => {
+  it("ends an over-long title in an ellipsis instead of a hard cut", async () => {
+    const { frame } = await mount(60)
+    await act(async () => {})
+    const out = await frame()
+    expect(out).toContain("…")
+    // The full string never fits a 60-cell terminal's card.
+    expect(out).not.toContain(LONG_TITLE)
+    // But enough of the front survives to identify the toast.
+    expect(out).toContain("Fix the sidebar")
+  })
+
+  it("keeps the card inside a terminal narrower than the card itself", async () => {
+    const { frame } = await mount(24)
+    await act(async () => {})
+    const out = await frame()
+    for (const line of out.split("\n")) expect(line.length).toBeLessThanOrEqual(24)
+  })
+})

--- a/packages/kobe/test/render/toast-truncation.test.tsx
+++ b/packages/kobe/test/render/toast-truncation.test.tsx
@@ -20,8 +20,7 @@ function Harness() {
   return <ToastOverlay />
 }
 
-const mount = (width: number) =>
-  renderComponent(<Harness />, { width, height: 12, providers: { notifications: true } })
+const mount = (width: number) => renderComponent(<Harness />, { width, height: 12, providers: { notifications: true } })
 
 describe("ToastOverlay truncation", () => {
   it("ends an over-long title in an ellipsis instead of a hard cut", async () => {


### PR DESCRIPTION
A TUI polish pass on label truncation and toast overflow.

**Not for merging tonight** — parked for review.

## What was wrong

Yoga clips an overflowing label with a **bare hard cut**, so the sidebar showed rows like `wire the harness jo`, `fix/sidebar-unread-la`, `polish checkout ste`. A chopped branch name reads as the *full* name to anyone who doesn't already know it's longer — the reader can't tell truncation from reality.

Separately, on a terminal narrower than the toast card, the toast stack **poked left across the neighbouring pane**.

## The fix

- Sidebar tree rows and toast copy now end in `…`, via the existing `truncateEndCells` + `charWidth` helpers (reused, not reinvented).
- The label budget is computed from the **live right-edge cluster width** — pin marker, chip, `+N`/`−N` diff counts, move chip — each costing its own width plus its flex gap, rather than a fixed guess. A floor keeps a crowded row from erasing its label entirely.
- The toast card clamps to what actually fits the terminal.
- Narrow-width filetree header chips no longer swallow the gap or overflow the border.

## Verification

Screenshots are real captures through the harness path (browser `/harness` → xterm.js → PTY sidecar → real OpenTUI), copied to `.scratch/shots/` — `before-narrow.png` / `after-narrow.png` are the cleanest pair. I read the before/after myself: the hard cuts above become `wire the harness j…`, `fix/sidebar-unread-l…`, `polish checkout st…`.

*(Note for the reviewer: the wide pair isn't the same fixture state — the after shot has extra toasts and a third changed file — so only the sidebar column is strictly comparable there.)*

**I ran the repo's own coverage gate locally before pushing**, which flagged `toast-overlay.tsx` at 0%. Rather than exempt it, I added `test/render/toast-truncation.test.tsx` covering both new behaviors, and **verified it goes red against the pre-fix component** (1 fail) — a truncation test that passes either way would be worthless. All four touched files now clear the floor: toast-overlay 100%, tree-rows 100%, SidebarTree 97.7%, header-view 56.4%.

Plus a `long-labels` render golden pinning the frame.

Lint, typecheck, `test:fast` (3479) and the render track (216) all green.