### PR TITLE
fix(engine): argv flag guards recognize the attached --flag=value form

### DIFF
--- a/.changeset/argv-attached-flag-guards.md
+++ b/.changeset/argv-attached-flag-guards.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Every "the launch command already sets this flag" guard now recognizes the attached `--flag=value` form through one exported `argvHasFlag` helper — the engine-command parser deliberately keeps `claude --resume=<id>` or `--append-system-prompt="…"` as a single token, and the exact-token guards missed it, so kobe appended a second `--session-id` (claude refuses to launch) or double-injected its worktree/dispatcher prompt over the user's own. Forking a chat on a base command that already pins its own session now declines instead of composing two `--resume`s, and an architecture test rejects any future exact-token `argv.includes("--…")` guard so the class can't recur.

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -172,12 +172,33 @@ export function withEngineEffort(
 }
 
 /**
+ * True when `argv` carries `flag` — in EITHER the separated form
+ * (`--flag value`, the flag its own token) or the attached form
+ * (`--flag=value`, one token). {@link parseEngineCommand} deliberately keeps
+ * the attached form as a single token ("the common CLI idiom"), so a bare
+ * `argv.includes(flag)` silently misses `--resume=<id>` /
+ * `--append-system-prompt="…"` — the root cause behind double session
+ * control and double prompt injection. Every "the command already sets this
+ * flag, don't add our own" guard must go through this helper; an
+ * architecture test (`test/architecture/argv-flag-guards.test.ts`) rejects
+ * new `argv.includes("--…")` guards. Prefix-safe: `--resume-x` ≠ `--resume`.
+ */
+export function argvHasFlag(argv: readonly string[], flag: string): boolean {
+  return argv.some((a) => a === flag || a.startsWith(`${flag}=`))
+}
+
+/**
  * Claude flags that already pin / fork the conversation's session. If the
  * launch command carries one of these, we must NOT also append our own
  * `--session-id` (claude would reject two, or our id would lose to the
  * resumed one). Covers both long and short forms.
  */
-const CLAUDE_SESSION_CONTROL_FLAGS = new Set(["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"])
+const CLAUDE_SESSION_CONTROL_FLAGS = ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"] as const
+
+/** The command already controls its own claude session (either flag form). */
+function pinsClaudeSession(argv: readonly string[]): boolean {
+  return CLAUDE_SESSION_CONTROL_FLAGS.some((flag) => argvHasFlag(argv, flag))
+}
 
 /**
  * For a Claude launch, append a kobe-generated `--session-id <uuid>` so the
@@ -195,7 +216,7 @@ export function withClaudeSessionId(
   vendor: string | undefined,
 ): { argv: readonly string[]; sessionId: string | null } {
   if (coerceVendorId(vendor) !== "claude") return { argv, sessionId: null }
-  if (argv.some((a) => CLAUDE_SESSION_CONTROL_FLAGS.has(a))) return { argv, sessionId: null }
+  if (pinsClaudeSession(argv)) return { argv, sessionId: null }
   const sessionId = randomUUID()
   return { argv: [...argv, "--session-id", sessionId], sessionId }
 }
@@ -225,8 +246,11 @@ export function canForkSession(vendor: VendorId | undefined): boolean {
  *     the forked tab stays trackable — the three combine, probed against
  *     claude 2.x: the fork lands in the id we pass).
  *   - codex: the `fork` SUBCOMMAND, options before the positional id.
- * Returns null when the vendor has no fork verb (copilot/custom) or no
- * source id — the caller then opens an ordinary blank tab.
+ * Returns null when the vendor has no fork verb (copilot/custom), there is
+ * no source id, or a claude base already controls its own session (a second
+ * `--resume` would make claude refuse to launch — the user's override wins,
+ * the {@link withClaudeSessionId} precedent) — the caller then opens an
+ * ordinary tab on the base command.
  */
 export function forkSessionArgv(
   base: readonly string[],
@@ -237,6 +261,7 @@ export function forkSessionArgv(
   if (!sourceSessionId) return null
   const v: VendorId = coerceVendorId(vendor)
   if (v === "claude") {
+    if (pinsClaudeSession(base)) return null
     const forked = [...base, "--resume", sourceSessionId, "--fork-session"]
     return newSessionId ? [...forked, "--session-id", newSessionId] : forked
   }
@@ -377,7 +402,7 @@ export function withWorktreeProtocol(
 ): readonly string[] {
   if (!taskId) return argv
   if (coerceVendorId(vendor) !== "claude") return argv
-  if (argv.includes("--append-system-prompt") || argv.includes("--append-system-prompt-file")) {
+  if (argvHasFlag(argv, "--append-system-prompt") || argvHasFlag(argv, "--append-system-prompt-file")) {
     return argv
   }
   const text = worktreeProtocol(taskId, kobeApiInvocation(), gates, notes)
@@ -430,7 +455,7 @@ export function withDispatcherProtocol(
 ): readonly string[] {
   if (!taskId || !enabled()) return argv
   if (coerceVendorId(vendor) !== "claude") return argv
-  if (argv.includes("--append-system-prompt") || argv.includes("--append-system-prompt-file")) {
+  if (argvHasFlag(argv, "--append-system-prompt") || argvHasFlag(argv, "--append-system-prompt-file")) {
     return argv
   }
   return [...argv, "--append-system-prompt", dispatcherProtocol(taskId)]

--- a/packages/kobe/test/architecture/argv-flag-guards.test.ts
+++ b/packages/kobe/test/architecture/argv-flag-guards.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Architecture guard: argv flag checks must see the attached --flag=value form.
+ *
+ * `parseEngineCommand` deliberately keeps `--flag=value` as ONE token, so a
+ * bare `argv.includes("--flag")` guard silently misses the attached form —
+ * the recurring bug class behind double `--session-id` (claude refuses to
+ * launch) and double `--append-system-prompt` injection, fixed one guard at
+ * a time across three PRs (#361 → #365 → #386) before this test existed.
+ * The rule: any "does the command already carry this flag" check goes
+ * through `argvHasFlag` (src/engine/interactive-command.ts), which matches
+ * both forms. A guard that genuinely must match ONLY the bare token needs an
+ * allowlist entry here with its reason.
+ */
+
+import { readFileSync, readdirSync } from "node:fs"
+import { join, relative } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+
+const SRC_ROOT = fileURLToPath(new URL("../../src", import.meta.url))
+
+// Files allowed to keep exact-token argv flag checks, with why.
+const BARE_TOKEN_ALLOWED = new Set([
+  // `kobe reset` parses user-typed process argv against a closed `known` set
+  // and exit(2)s on anything else — an attached `--hard=x` is rejected as an
+  // unknown argument before these checks run, so bare matching is fail-closed.
+  join(SRC_ROOT, "cli", "reset-cmd.ts"),
+])
+
+// An argv-named receiver (`argv`, `baseArgv`, …) probed for a flag literal
+// with an exact-token method. `argvHasFlag` is the correct spelling.
+const BARE_FLAG_GUARD = /[\w$]*[Aa]rgv\.(?:includes|indexOf)\(\s*["'`]-/
+
+function sourceFiles(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) sourceFiles(path, files)
+    else if (/\.(ts|tsx)$/.test(entry.name)) files.push(path)
+  }
+  return files
+}
+
+describe("argv flag guards recognize the attached --flag=value form", () => {
+  test("no exact-token argv flag checks outside the allowlist", () => {
+    const offenders = sourceFiles(SRC_ROOT)
+      .filter((file) => !BARE_TOKEN_ALLOWED.has(file))
+      .flatMap((file) =>
+        readFileSync(file, "utf8")
+          .split("\n")
+          .map((line, i) => ({ line, i }))
+          .filter(({ line }) => !line.trimStart().startsWith("//") && !line.trimStart().startsWith("*"))
+          .filter(({ line }) => BARE_FLAG_GUARD.test(line))
+          .map(({ i }) => `${relative(SRC_ROOT, file)}:${i + 1}`),
+      )
+
+    expect(
+      offenders,
+      `exact-token argv flag check misses the attached --flag=value form; use argvHasFlag (src/engine/interactive-command.ts) or allowlist with a reason: ${offenders.join(", ")}`,
+    ).toEqual([])
+  })
+
+  test("the allowlisted files still exist and still contain the pattern they excuse", () => {
+    for (const file of BARE_TOKEN_ALLOWED) {
+      const source = readFileSync(file, "utf8")
+      expect(BARE_FLAG_GUARD.test(source), `${relative(SRC_ROOT, file)} no longer needs its allowlist entry`).toBe(true)
+    }
+  })
+})

--- a/packages/kobe/test/engine/interactive-command-overrides.test.ts
+++ b/packages/kobe/test/engine/interactive-command-overrides.test.ts
@@ -14,6 +14,7 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
+  argvHasFlag,
   engineCommandKey,
   engineDisplayName,
   engineNameKey,
@@ -135,5 +136,27 @@ describe("withClaudeSessionId", () => {
       const argv = ["claude", flag, "x"]
       expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
     }
+  })
+
+  it("recognizes the attached --flag=value form the command parser preserves", () => {
+    // `parseEngineCommand` keeps `--resume=<id>` as ONE token; an exact-token
+    // guard misses it and appends a second session control, which claude
+    // refuses to launch (issue #58).
+    for (const flag of ["--session-id", "--resume", "--from-pr"]) {
+      const argv = ["claude", `${flag}=x`]
+      expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
+    }
+  })
+})
+
+describe("argvHasFlag", () => {
+  it("matches the separated and attached forms, nothing else", () => {
+    expect(argvHasFlag(["claude", "--resume", "x"], "--resume")).toBe(true)
+    expect(argvHasFlag(["claude", "--resume=x"], "--resume")).toBe(true)
+    expect(argvHasFlag(["claude", "--resume-later"], "--resume")).toBe(false)
+    // A flag NAME appearing as another flag's value is a value, not a flag —
+    // known ceiling shared with every guard here; positional matching would
+    // need a full claude arg spec.
+    expect(argvHasFlag(["claude"], "--resume")).toBe(false)
   })
 })

--- a/packages/kobe/test/engine/status-protocol.test.ts
+++ b/packages/kobe/test/engine/status-protocol.test.ts
@@ -60,6 +60,13 @@ describe("withWorktreeProtocol", () => {
     const customFile = ["claude", "--append-system-prompt-file", "/tmp/p.txt"]
     expect(withWorktreeProtocol(customFile, "claude", "t1", { status: on, notes: on })).toEqual(customFile)
   })
+
+  it("never double-injects over the attached --flag=value form either (issue #58)", () => {
+    const attached = ["claude", "--append-system-prompt=user's own"]
+    expect(withWorktreeProtocol(attached, "claude", "t1", { status: on, notes: on })).toEqual(attached)
+    const attachedFile = ["claude", "--append-system-prompt-file=/tmp/p.txt"]
+    expect(withWorktreeProtocol(attachedFile, "claude", "t1", { status: on, notes: on })).toEqual(attachedFile)
+  })
 })
 
 describe("statusReportProtocol", () => {
@@ -152,9 +159,11 @@ describe("withDispatcherProtocol", () => {
     expect(withDispatcherProtocol(["claude"], "claude", undefined, on)).toEqual(["claude"])
   })
 
-  it("never double-injects over a custom command that sets the flag", () => {
+  it("never double-injects over a custom command that sets the flag — either form (issue #58)", () => {
     const custom = ["claude", "--append-system-prompt", "user's own"]
     expect(withDispatcherProtocol(custom, "claude", "m1", on)).toEqual(custom)
+    const attached = ["claude", "--append-system-prompt=user's own"]
+    expect(withDispatcherProtocol(attached, "claude", "m1", on)).toEqual(attached)
   })
 
   it("composes with the worktree protocol: mutually exclusive task ids → exactly one protocol", () => {

--- a/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
+++ b/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
@@ -54,6 +54,15 @@ describe("forkSessionArgv", () => {
     expect(forkSessionArgv(["opencode"], "opencode", "src")).toBeNull()
     expect(forkSessionArgv(["claude"], "claude", "")).toBeNull()
   })
+
+  it("declines a claude base that already controls its own session — either flag form (issue #58)", () => {
+    // A second --resume makes claude refuse to launch; the user's override
+    // wins and the caller opens an ordinary tab on the base command.
+    expect(forkSessionArgv(["claude", "--resume", "pinned"], "claude", "src", "new")).toBeNull()
+    expect(forkSessionArgv(["claude", "--resume=pinned"], "claude", "src", "new")).toBeNull()
+    expect(forkSessionArgv(["claude", "--session-id=pinned"], "claude", "src", "new")).toBeNull()
+    expect(forkSessionArgv(["claude", "-c"], "claude", "src", "new")).toBeNull()
+  })
 })
 
 // Why: copilot (`--resume`) and kimi (`-S`) can only REOPEN a session, which


### PR DESCRIPTION
Fixes rove issue #58 — the **root-cause layer** under PRs #365 and #386.

**Not for merging tonight** — parked for review.

## Why this is a class, not a bug

`3036b318` (#361) taught the argv parser to keep `--flag=value` as **one token** (the common CLI idiom). Every downstream "does the command already set this flag?" guard compares whole tokens, so `argv.includes("--append-system-prompt")` silently returns false for `--append-system-prompt="…"`.

The tell that this is a class: the same author hit it **twice in one week** — #365 fixed 1 of 3 guards, #386 fixed all 3 — while `forkSessionArgv` had no guard at all. Fixing instances one at a time was never going to converge.

Consequences were real: double `--session-id` makes claude **refuse to launch**; double `--append-system-prompt` injects the prompt twice.

## What landed

- **`argvHasFlag(argv, flag)`**, exported — matches both forms, prefix-safe (`--resume-x` ≠ `--resume`).
- All three `interactive-command.ts` guards go through it, plus a **new guard in `forkSessionArgv`**: a claude base that already controls its own session returns null rather than adding a second `--resume`. That follows the existing `withClaudeSessionId` precedent — the user's explicit override wins.
- **`test/architecture/argv-flag-guards.test.ts`** rejects new `argv.includes("--…")` guards anywhere in `src/`. Without this, the next guard written gets it wrong again.

The allowlist has exactly one entry (`reset-cmd.ts`) with its reason: it parses user argv against a closed `known` set and exits on anything unrecognized, so bare matching is **fail-closed** there.

## Verification

I injected a bare-token guard (`argv.includes("--resume")`) into `interactive-command.ts` and confirmed the architecture test goes red with a message naming the file, line, and the correct spelling. An architecture test that can't fail is decoration.

Plus attached-form regression tests on the actual guards.

`test:fast` 3485 passed, lint and typecheck clean.

## Note on PR #386

This makes **#386 redundant** — it fixed the same three guards one at a time, without the helper or the guard-against-recurrence. Its fate is the owner's call; I have not touched it.