### PR TITLE
fix: revive four A-class fixes from the PR backlog (#368 #366 #371 #377)

### DIFF
--- a/.changeset/revive-368-366-371-377.md
+++ b/.changeset/revive-368-366-371-377.md
@@ -1,0 +1,10 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Four long-standing fixes revived from the PR backlog (#368, #366, #371, #377), re-implemented against current main:
+
+- The published bundle no longer ships React's *development* build. `Bun.build` defaults `process.env.NODE_ENV` to `"development"`, so react/react-reconciler resolved to their dev entries — whose per-update debug bookkeeping grows without bound in a long-lived TUI (#307). Both `build.ts` and `compile.ts` now pin `NODE_ENV=production` (the npm bundle also drops ~150 KB), and an architecture test guards the pin.
+- Claude tasks whose worktree path contains an underscore, a space, or a non-ASCII character get their session transcripts found again: kobe derived Claude Code's on-disk project directory by folding only `/` and `.` to `-`, but Claude folds *every* non-alphanumeric character — so such paths pointed kobe at a directory Claude never wrote, silently disabling the activity badge, turn detection, auto-title, and interrupted-prompt rescue. kobe now matches Claude's encoder exactly.
+- Claude binary discovery no longer picks the oldest nvm-installed Node: the fallback scan sorted version directories as plain strings, so `v8.17.0` outranked `v18.20.0` and the engine could silently launch on an ancient Node. The scan now orders versions numerically, newest first.
+- Prefix keybinding overrides now keep the chords that parsed when one entry in a list is invalid, instead of silently discarding the whole binding — matching how direct-chord overrides already behave. The default is only kept (with a "no valid chords" warning) when nothing in the list is usable.

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -104,6 +104,11 @@ const result = await Bun.build({
   // resolve the optional platform package under isolated installs.
   external: ["node-pty", "@opentui/core"],
   minify: true,
+  // Without this Bun inlines NODE_ENV as "development", so react/react-reconciler
+  // resolve to their *development* builds and ship to users. Those builds keep
+  // per-update debug bookkeeping alive, which grows unboundedly in a long-lived
+  // TUI — the #307 memory leak.
+  define: { "process.env.NODE_ENV": JSON.stringify("production") },
 })
 
 if (!result.success) {

--- a/packages/kobe/scripts/compile.ts
+++ b/packages/kobe/scripts/compile.ts
@@ -39,6 +39,9 @@ const result = await Bun.build({
   conditions: ["browser"],
   external: ["node-pty"],
   minify: true,
+  // Same reason as build.ts: default NODE_ENV is "development", which ships
+  // React's development reconciler and its per-update debug bookkeeping (#307).
+  define: { "process.env.NODE_ENV": JSON.stringify("production") },
   compile: { outfile },
 })
 if (!result.success) {

--- a/packages/kobe/src/engine/claude-code-local/binary.ts
+++ b/packages/kobe/src/engine/claude-code-local/binary.ts
@@ -8,8 +8,8 @@
  *   1. `$PATH` (the user's shell — `which claude`).
  *   2. `~/.claude/local/claude`  (Claude Code's bundled-update install).
  *   3. NVM-active (`$NVM_BIN/claude`).
- *   4. NVM versions (`~/.nvm/versions/node/<v>/bin/claude` — newest first
- *      by directory name string-sort, which is good enough for v1).
+ *   4. NVM versions (`~/.nvm/versions/node/<v>/bin/claude` — newest
+ *      first, compared numerically).
  *   5. Homebrew + system paths (`/opt/homebrew/bin`, `/usr/local/bin`,
  *      `/usr/bin`, `/bin`).
  *   6. Misc user installs (`~/.local/bin`, `~/.npm-global/bin`,
@@ -146,9 +146,11 @@ export async function findClaudeBinary(deps: BinaryDiscoveryDeps = defaultDeps):
     if (candidate) return candidate
   }
 
-  // 4. All NVM-installed node versions (newest by string sort).
+  // 4. All NVM-installed node versions, newest first. A plain string sort
+  //    mis-orders unpadded semver dir names ("v8.17.0" sorts after "v18.20.0"),
+  //    so a single-digit major would shadow newer nodes; compare numerically.
   const nvmRoot = path.join(home, ".nvm", "versions", "node")
-  const nvmVersions = deps.readdir(nvmRoot).sort().reverse()
+  const nvmVersions = deps.readdir(nvmRoot).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
   for (const v of nvmVersions) {
     const candidate = tryPath(path.join(nvmRoot, v, "bin", "claude"))
     if (candidate) return candidate

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -9,7 +9,8 @@
  *
  *     ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
  *
- * `<encoded-cwd>` is the *absolute* cwd with `/` replaced by `-`, e.g.
+ * `<encoded-cwd>` is the *absolute* cwd with every non-alphanumeric
+ * character replaced by `-` (see {@link encodeCwd}), e.g.
  * `/Users/jackson/i/kobe` → `-Users-jackson-i-kobe`. The encoding is
  * **lossy**: a path containing literal `-` collapses to the same
  * directory as a `/`-delimited one (so `foo/bar-baz` and `foo-bar/baz`
@@ -95,14 +96,25 @@ const defaultDeps: HistoryDeps = {
 /**
  * Encode a cwd to Claude Code's on-disk project directory name.
  *
- * `/` and `.` are both replaced with `-`. Claude Code itself does this —
- * a directory named `1.2.3` becomes `1-2-3`. The encoding is lossy
- * (see file-level docstring) and reversal is unreliable.
+ * Claude Code replaces **every** non-alphanumeric character with `-` —
+ * its own encoder is `cwd.replace(/[^a-zA-Z0-9]/g, "-")` (verified in the
+ * shipped CLI bundle), so `/`, `.`, `_`, spaces, and non-ASCII letters
+ * all fold. Matching only `/` and `.` (the old behavior) pointed every
+ * encoding-dependent consumer at a directory Claude never created
+ * whenever the worktree path contained e.g. an underscore — silently
+ * disabling session-file discovery, activity mtime detection, and
+ * interrupted-prompt rescue for that task.
+ *
+ * No legacy fallback on purpose: the dirs under `~/.claude/projects` are
+ * created by Claude with this encoding, so the fix *restores* access to
+ * them. The only dirs the old encoding could name were rescue-created by
+ * kobe itself, holding orphaned prompts Claude's `--resume` never read.
+ *
+ * The encoding is lossy (see file-level docstring) and reversal is
+ * unreliable — we never decode, only iterate/derive.
  */
 export function encodeCwd(cwd: string): string {
-  // Normalize to forward-slashes (paranoia for cross-platform callers
-  // building these paths in tests). Then replace runs of `/` and `.`.
-  return cwd.replace(/[/.]/g, "-")
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-")
 }
 
 /** One persisted Claude session file under a worktree's project dir. */

--- a/packages/kobe/src/tui/lib/keymap-prefix-overrides.ts
+++ b/packages/kobe/src/tui/lib/keymap-prefix-overrides.ts
@@ -50,16 +50,25 @@ function collectEntries(source: unknown, warnings: string[]): Map<string, string
       continue
     }
     const keys: string[] = []
+    let anyError = false
     for (const rawKey of rawKeys) {
       const normalized = normalizeChord(rawKey)
       if ("error" in normalized) {
         warnings.push(`prefix.bindings.${id}: ${normalized.error}`)
+        anyError = true
         continue
       }
-      keys.push(normalized.chord)
+      if (!keys.includes(normalized.chord)) keys.push(normalized.chord)
       if (normalized.warning) warnings.push(`prefix.bindings.${id}: ${normalized.warning}`)
     }
-    if (keys.length === rawKeys.length) out.set(id, keys)
+    // Partial-keep, mirroring extractKeybindingOverrides' direct-chord path:
+    // one bad chord in a list must not discard the siblings that parsed. Only
+    // fall back to the default when NONE survived, and say so explicitly.
+    if (keys.length === 0 && anyError) {
+      warnings.push(`prefix.bindings.${id}: no valid chords — keeping the default`)
+      continue
+    }
+    out.set(id, keys)
   }
   return out
 }

--- a/packages/kobe/test/architecture/production-react-build.test.ts
+++ b/packages/kobe/test/architecture/production-react-build.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression guard for #307: the shipped bundles must NOT contain React's
+ * development build.
+ *
+ * Bun defaults `process.env.NODE_ENV` to "development" during `Bun.build`,
+ * so without an explicit `define` the bundler resolves react and
+ * react-reconciler to their development entries and inlines them. Those
+ * builds keep per-update debug bookkeeping alive (fiber
+ * `_debugTask`/`_debugInfo`, update-timer state), which in a long-lived TUI
+ * grows without bound.
+ *
+ * Asserting on the build SCRIPTS rather than on `dist/` on purpose: `dist/`
+ * is gitignored and absent on a fresh clone, so a bundle assertion would be
+ * a silently-skipped test. The `define` is the invariant that produces the
+ * bundle; guard that.
+ */
+
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+
+const SCRIPTS = ["build.ts", "compile.ts"]
+
+describe("production React build", () => {
+  for (const script of SCRIPTS) {
+    test(`scripts/${script} pins NODE_ENV=production`, () => {
+      const source = readFileSync(fileURLToPath(new URL(`../../scripts/${script}`, import.meta.url)), "utf8")
+      expect(source).toContain('"process.env.NODE_ENV": JSON.stringify("production")')
+    })
+  }
+})

--- a/packages/kobe/test/engine/binary-discovery.test.ts
+++ b/packages/kobe/test/engine/binary-discovery.test.ts
@@ -72,10 +72,14 @@ describe("findClaudeBinary", () => {
     expect(await findClaudeBinary(d)).toBe("/nvm/active/bin/claude")
   })
 
-  it("scans nvm versions newest-first (string sort, reversed)", async () => {
+  it("scans nvm versions newest-first, numerically (a single-digit major must not shadow newer nodes)", async () => {
     const d = claudeDeps({
-      readdir: (p) => (p === "/home/u/.nvm/versions/node" ? ["v18.0.0", "v20.0.0", "v16.0.0"] : []),
-      fileExists: (p) => p === "/home/u/.nvm/versions/node/v20.0.0/bin/claude",
+      readdir: (p) => (p === "/home/u/.nvm/versions/node" ? ["v8.17.0", "v18.0.0", "v20.0.0", "v16.0.0"] : []),
+      // Both the newest node and an old single-digit-major node carry a claude
+      // shim; the newest must win. A plain string sort reverses to "v8.17.0"
+      // first and would launch claude from Node 8.
+      fileExists: (p) =>
+        p === "/home/u/.nvm/versions/node/v20.0.0/bin/claude" || p === "/home/u/.nvm/versions/node/v8.17.0/bin/claude",
     })
     expect(await findClaudeBinary(d)).toBe("/home/u/.nvm/versions/node/v20.0.0/bin/claude")
   })

--- a/packages/kobe/test/engine/history-default-deps.test.ts
+++ b/packages/kobe/test/engine/history-default-deps.test.ts
@@ -89,9 +89,23 @@ afterAll(() => {
 })
 
 describe("encodeCwd", () => {
-  it("replaces both / and . with - (Claude Code's lossy on-disk encoding)", () => {
+  it("replaces / and . with - (Claude Code's lossy on-disk encoding)", () => {
     expect(encodeCwd("/Users/j/i/kobe")).toBe("-Users-j-i-kobe")
     expect(encodeCwd("/v/1.2.3")).toBe("-v-1-2-3")
+  })
+
+  it("replaces every non-alphanumeric char, matching Claude Code's encoder", () => {
+    // Claude Code encodes with `cwd.replace(/[^a-zA-Z0-9]/g, "-")`, so an
+    // underscore, space, or accented letter in the path all fold to `-`.
+    // Matching only `/` and `.` pointed session lookups at a directory
+    // Claude never created for any such worktree path.
+    expect(encodeCwd("/home/jane_doe/my_app")).toBe("-home-jane-doe-my-app")
+    expect(encodeCwd("/tmp/a b/c")).toBe("-tmp-a-b-c")
+    expect(encodeCwd("/home/josé/repo")).toBe("-home-jos--repo")
+  })
+
+  it("preserves case and leaves alphanumerics untouched", () => {
+    expect(encodeCwd("/Repo123/AbC")).toBe("-Repo123-AbC")
   })
 })
 

--- a/packages/kobe/test/tui/keymap-prefix-overrides.test.ts
+++ b/packages/kobe/test/tui/keymap-prefix-overrides.test.ts
@@ -48,6 +48,33 @@ describe("PureTUI prefix settings", () => {
     expect(extracted.warnings.join("\n")).toContain("modifier")
   })
 
+  test("keeps the valid second strokes when a sibling chord in the list is invalid", () => {
+    const extracted = extractPrefixKeybindings(
+      {
+        prefix: { bindings: { "chat.tab.new": ["n", "ctrl+shift+z"] } },
+      },
+      "linux",
+    )
+
+    // The valid "n" survives; only the impossible ctrl+shift+z is dropped.
+    expect(extracted.entries).toEqual([{ id: "chat.tab.new", keys: ["n"] }])
+    expect(extracted.warnings.join("\n")).toContain("ctrl+shift+z")
+    expect(extracted.warnings.join("\n")).not.toContain("keeping the default")
+  })
+
+  test("falls back to the default and says so when every chord in the list is invalid", () => {
+    const extracted = extractPrefixKeybindings(
+      {
+        prefix: { bindings: { "chat.tab.new": ["ctrl+shift+z", "cmd+shift+q"] } },
+      },
+      "linux",
+    )
+
+    // No valid chord survived, so the id is not overridden and the default holds.
+    expect(extracted.entries).toEqual([])
+    expect(extracted.warnings.join("\n")).toContain("no valid chords — keeping the default")
+  })
+
   test("adds declared prefix rows without clearing their direct chords", () => {
     const copy = keymap.map((row) => ({
       ...row,


### PR DESCRIPTION
The first rescue batch from the open-PR triage sweep (`.scratch/pr-triage.md`). All four defects were re-confirmed present on current `main` before any code was written.

**Not for merging tonight** — parked for review.

**Reimplemented, not rebased.** The original branches are weeks old; each fix was rewritten against current `main` as its own commit. The four source PRs are untouched.

## The four

**#368 — the bundled CLI shipped React's *development* build.** `build.ts` had no `NODE_ENV` define, so Bun inlined `"development"` and react/react-reconciler resolved to their debug builds — per-update bookkeeping that grows unboundedly in a long-lived TUI (the #307 leak).

**#366 — Claude project-dir encoding.** `encodeCwd` folded only `/` and `.`, but Claude's own encoder folds **every** non-alphanumeric char. Any worktree path with an underscore, space, or non-ASCII char pointed kobe at a directory Claude never wrote — silently breaking the activity badge, turn detection, auto-title, and prompt rescue.

**#371 — nvm versions sorted as strings** (`.sort().reverse()`), so `v8.x` outranked `v18.x` and the engine silently ran on an ancient Node.

**#377 — prefix keybinding overrides were all-or-nothing**: one invalid chord silently discarded the valid chords sharing its id. Parsing correctness, not a new/moved chord, so no keybinding sign-off applies.

## On #366's compatibility question

I flagged this one as "deeper than it looks" — changing the encoding could orphan existing history dirs. **It doesn't, and here's why the no-fallback choice is right:** the real transcript dirs are created *by Claude* with the full encoding, so the fix **restores** access to them. Dirs under the old encoding only ever existed where kobe itself created one — `appendRescuePrompt` does `mkdir` at `history.ts:294` — and Claude's `--resume` never read those. A fallback would just keep pointing at kobe's own orphans.

## Verification

- **All 6 new tests proven red against the unfixed sources** (worker-verified; the architecture of each test targets the specific defect).
- **#368 checked with a real build, not just tests**: bundle went **1,862,301 → 1,704,068 bytes (−158KB)** versus `main`, and dev-React markers are absent from `dist/cli/index.js`. That's the claim that most needed independent confirmation, since it's a release-path change.
- Traced `encodeCwd`'s three call sites to confirm the write path above.

`test:fast` 3485 passed, lint and typecheck clean.

Triage classifies #368/#366/#371 as top-value A-class saves; landing these makes the corresponding originals redundant, but their disposition is the owner's call.