### PR TITLE
fix: revive four more A-class fixes from the PR backlog (#556 #400 #421 #447)

### DIFF
--- a/.changeset/precheck-utf8-output.md
+++ b/.changeset/precheck-utf8-output.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Automation precheck output no longer garbles non-ASCII text into `�`: a `gh pr list` or `git log` precheck whose stdout carries CJK or emoji is now decoded as one UTF-8 stream instead of chunk-by-chunk, so the stdout/stderr captured with a skipped run reads cleanly and the tail cap keeps whole code points instead of halving a surrogate pair at the cut.

--- a/.changeset/read-output-tail-keeps-last-line.md
+++ b/.changeset/read-output-tail-keeps-last-line.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api read-output --source terminal` no longer returns an empty tail when the last line of output is larger than the 64 KB byte cap. The tail's byte-budget loop counted the final line first, so a single over-budget line (a minified dump, a long base64 blob, a giant log line with no newline) pushed the window start past the end and blanked the whole response — a coordinator agent reading the pane got nothing. The tail now always keeps at least the last line, mirroring the structured-history page's "never fewer than one" floor, while older lines are still trimmed to fit the cap.

--- a/.changeset/strict-int-flags.md
+++ b/.changeset/strict-int-flags.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api` integer flags now reject a malformed value instead of silently coercing it. Previously a typo like `issue-set-status --id 5abc` parsed as `5` and flipped the status of a real, wrong issue, and `add --count 1e3` parsed as `1` and quietly spawned a single task — because `parseInt` stops at the first non-digit. Integer flags (`--count`, `--id`, `--number`, `--limit`, and `--agents claude:2` counts) now require the whole value to be a positive integer and fail loudly with a clear error, matching how every other flag validator already behaves.

--- a/.changeset/web-origin-case-insensitive-host.md
+++ b/.changeset/web-origin-case-insensitive-host.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the daemon dashboard rejecting every browser request with a 403 when it is bound to a host whose name carries an uppercase letter — routine for mDNS names like `MyMac.local`. Browsers (and the URL parser) lowercase the Origin host they send, but the allowed bind host was compared with its original case, so `mymac.local` never matched `MyMac.local` and the whole LAN dashboard was locked out; hostnames are case-insensitive (RFC 4343) and the Origin check now compares them that way.

--- a/packages/kobe-daemon/src/daemon/automation-precheck.ts
+++ b/packages/kobe-daemon/src/daemon/automation-precheck.ts
@@ -37,9 +37,25 @@ const MAX_OUTPUT_CHARS = 4000
 /** Upper bound on a user-supplied timeout, so a typo can't wedge the sweep. */
 const MAX_TIMEOUT_SECONDS = 600
 
-function tail(chunks: readonly (Buffer | string)[]): string {
-  const text = chunks.map((c) => c.toString()).join("")
-  return text.length <= MAX_OUTPUT_CHARS ? text : text.slice(-MAX_OUTPUT_CHARS)
+/**
+ * Decode captured stream chunks to text, keeping only the last
+ * `MAX_OUTPUT_CHARS`.
+ *
+ * Node splits a pipe's `data` events at arbitrary byte offsets, so a
+ * multi-byte UTF-8 sequence can straddle two Buffers; decoding each chunk on
+ * its own turned that seam into a `�`, so a `gh pr list` full of CJK/emoji
+ * titles came back mojibake. Concatenate the raw bytes and decode once
+ * instead (the odd pre-decoded error string we push ourselves round-trips
+ * through UTF-8 unchanged). Cap by whole code points, not UTF-16 units, so
+ * the tail slice can't halve a surrogate pair and strand a lone surrogate.
+ */
+export function tail(chunks: readonly (Buffer | string)[]): string {
+  const text = Buffer.concat(chunks.map((c) => (typeof c === "string" ? Buffer.from(c) : c))).toString("utf8")
+  // `text.length` (UTF-16 units) >= code-point count, so an under-cap string
+  // is safe as-is; only pay for the code-point split when over.
+  if (text.length <= MAX_OUTPUT_CHARS) return text
+  const points = Array.from(text)
+  return points.length <= MAX_OUTPUT_CHARS ? text : points.slice(-MAX_OUTPUT_CHARS).join("")
 }
 
 /**

--- a/packages/kobe-daemon/src/daemon/web-origin.ts
+++ b/packages/kobe-daemon/src/daemon/web-origin.ts
@@ -37,7 +37,11 @@ export function originAllowed(origin: string | null | undefined, opts: { allowed
   const allowedHost = opts.allowedHost?.trim()
   if (!allowedHost) return false
   const hostname = originHostname(origin)
-  return hostname !== null && hostname === allowedHost
+  // Hostnames are case-insensitive (RFC 4343). `originHostname` returns the
+  // WHATWG-lowercased host the browser puts in Origin; lowercase the bind host
+  // too so a mixed-case bind address (e.g. an mDNS `MyMac.local`) still matches
+  // instead of 403ing every browser request.
+  return hostname !== null && hostname === allowedHost.toLowerCase()
 }
 
 export function allowedHostForBindHost(hostname: unknown): string | undefined {

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -15,6 +15,23 @@ import { ApiError, type FlagSpec, type Flags, type ParsedArgs, type VerbSpec, he
 /** Safety cap on a single `add --count` round so a typo can't spawn a runaway fleet. */
 export const FANOUT_CAP = 10
 
+/**
+ * Parse a strict positive-integer flag value; `undefined` when the whole
+ * value isn't one.
+ *
+ * `Number.parseInt` alone stops at the first non-digit, so it silently
+ * coerces a typo into a confident, wrong number: `--id 5abc` → 5 (flips a
+ * real, wrong issue), `--count 1e3` → 1 (spawns one task without ever
+ * tripping the fan-out cap). Requiring the entire (trimmed) value to be
+ * digits — and a safe integer above zero — makes a malformed flag fail
+ * loudly with BAD_FLAG, like every other validator in this module.
+ */
+export function parsePositiveInt(raw: string): number | undefined {
+  if (!/^\d+$/.test(raw.trim())) return undefined
+  const n = Number.parseInt(raw, 10)
+  return Number.isSafeInteger(n) && n > 0 ? n : undefined
+}
+
 /** Both parallel-plan parsers are only reachable from `add`, so their errors point at its help. */
 const FANOUT_STEP = helpStep("add")
 
@@ -143,10 +160,8 @@ export function validateAgainstSpec(verb: VerbSpec, flags: Flags): void {
     }
     if (f.type === "int") {
       const raw = flags.get(f.name)
-      if (raw !== undefined) {
-        const n = Number.parseInt(raw, 10)
-        if (!Number.isInteger(n) || n <= 0) throw new ApiError(`--${f.name} must be a positive integer`, "BAD_FLAG")
-      }
+      if (raw !== undefined && parsePositiveInt(raw) === undefined)
+        throw new ApiError(`--${f.name} must be a positive integer`, "BAD_FLAG")
     }
   }
 }
@@ -241,8 +256,8 @@ export class VerbArgs {
     this.spec(name)
     const raw = this.str(name)
     if (raw === undefined) return undefined
-    const n = Number.parseInt(raw, 10)
-    if (!Number.isInteger(n) || n <= 0) throw new ApiError(`--${name} must be a positive integer`, "BAD_FLAG")
+    const n = parsePositiveInt(raw)
+    if (n === undefined) throw new ApiError(`--${name} must be a positive integer`, "BAD_FLAG")
     return n
   }
 
@@ -283,8 +298,8 @@ export function parseAgentsSpec(spec: string): VendorId[] {
         FANOUT_STEP,
       )
     }
-    const count = Number.parseInt(trimmed.slice(colon + 1), 10)
-    if (!Number.isInteger(count) || count <= 0) {
+    const count = parsePositiveInt(trimmed.slice(colon + 1))
+    if (count === undefined) {
       throw new ApiError(`--agents count for "${vendor}" must be a positive integer`, "BAD_FLAG", FANOUT_STEP)
     }
     // Reject against the fanout cap BEFORE materializing the array — otherwise

--- a/packages/kobe/src/cli/api/read-output-page.ts
+++ b/packages/kobe/src/cli/api/read-output-page.ts
@@ -169,7 +169,12 @@ export function boundedTail(text: string): TerminalTail {
   let bytes = 0
   for (let i = lines.length - 1; i >= start; i--) {
     bytes += (lines[i]?.length ?? 0) + 1
-    if (bytes > TERMINAL_TAIL_BYTES) {
+    // Always keep the last line, even when it alone busts the byte budget —
+    // otherwise a single over-budget final line (a minified dump, a long
+    // base64 blob) sets `start` past the end and blanks the whole tail, so
+    // the read returns nothing at all. Mirrors buildHistoryPage's
+    // "never fewer than one" floor.
+    if (bytes > TERMINAL_TAIL_BYTES && i < lines.length - 1) {
       start = i + 1
       break
     }

--- a/packages/kobe/test/cli/api-cmd.test.ts
+++ b/packages/kobe/test/cli/api-cmd.test.ts
@@ -3,6 +3,7 @@ import {
   API_VERBS,
   ApiError,
   VERBS,
+  VerbArgs,
   apiUsage,
   buildCountPlan,
   findVerb,
@@ -99,6 +100,10 @@ describe("parseAgentsSpec", () => {
   it("rejects a non-positive or malformed count", () => {
     expect(() => parseAgentsSpec("claude:0")).toThrow(/positive integer/)
     expect(() => parseAgentsSpec("claude")).toThrow(/engine:count/)
+    // Trailing garbage must NOT be silently coerced (`parseInt("2x") === 2`).
+    expect(() => parseAgentsSpec("claude:2x")).toThrow(/positive integer/)
+    expect(() => parseAgentsSpec("claude:1e3")).toThrow(/positive integer/)
+    expect(() => parseAgentsSpec("claude:2.5")).toThrow(/positive integer/)
   })
 
   it("rejects an over-cap count before allocating (no OOM on a huge count)", () => {
@@ -320,5 +325,44 @@ describe("validateAgainstSpec", () => {
   it("accepts a well-formed invocation", () => {
     const { flags } = parseFlags(["--repo", "/x", "--status", "in_progress", "--command", "claude"])
     expect(() => validateAgainstSpec(add, flags)).not.toThrow()
+  })
+
+  it("rejects an int flag with trailing garbage instead of coercing it", () => {
+    // `parseInt` stops at the first non-digit: without a shape guard `--count 2x`
+    // passed as 2 and `--count 1e3` as 1 — a typo becoming a wrong action.
+    for (const bad of ["2x", "1e3", "2.5", "0x10", "  ", "-1", "0", "abc"]) {
+      const { flags } = parseFlags(["--repo", "/x", "--prompt", "p", "--count", bad])
+      expect(() => validateAgainstSpec(add, flags)).toThrow(/must be a positive integer/)
+    }
+  })
+
+  it("accepts a clean integer flag (surrounding whitespace tolerated)", () => {
+    for (const ok of ["3", " 3 "]) {
+      const { flags } = parseFlags(["--repo", "/x", "--prompt", "p", "--count", ok])
+      expect(() => validateAgainstSpec(add, flags)).not.toThrow()
+    }
+  })
+})
+
+describe("VerbArgs.int", () => {
+  const add = findVerb("add")!
+  const intOf = (value: string): number | undefined => {
+    const { flags } = parseFlags(["--count", value])
+    return new VerbArgs(add, flags).int("count")
+  }
+
+  it("returns the parsed value for a clean positive integer", () => {
+    expect(intOf("3")).toBe(3)
+    expect(intOf(" 7 ")).toBe(7)
+  })
+
+  it("is undefined when the flag is absent", () => {
+    expect(new VerbArgs(add, parseFlags(["--repo", "/x"]).flags).int("count")).toBeUndefined()
+  })
+
+  it("rejects trailing garbage, decimals, and non-positive values", () => {
+    for (const bad of ["2x", "1e3", "2.5", "0x10", "0", "-4", "abc"]) {
+      expect(() => intOf(bad)).toThrow(/must be a positive integer/)
+    }
   })
 })

--- a/packages/kobe/test/cli/api-read-output.test.ts
+++ b/packages/kobe/test/cli/api-read-output.test.ts
@@ -12,6 +12,7 @@ import {
   type ReadOutputDeps,
   type ReadOutputEnvelope,
   STRING_CLIP_CHARS,
+  TERMINAL_TAIL_BYTES,
   TERMINAL_TAIL_LINES,
   type TerminalPeekPage,
   boundedTail,
@@ -357,5 +358,24 @@ describe("read-output terminal tail shaping", () => {
     expect(capped.tail.length).toBe(TERMINAL_TAIL_LINES)
     expect(capped.truncated).toBe(true)
     expect(capped.tail[0]).toBe("l50")
+  })
+
+  it("keeps the last line even when it alone exceeds the byte budget", () => {
+    // A single line larger than the byte cap (a minified dump / base64 blob
+    // with no newline) must not blank the whole tail — the read has to show
+    // something. Regression: the budget loop counted the final line first and
+    // set `start` past the end, returning an empty tail.
+    const huge = "x".repeat(TERMINAL_TAIL_BYTES + 5000)
+    const shaped = boundedTail(huge)
+    expect(shaped.tail).toEqual([huge])
+    // Nothing older was dropped — there was only the one line.
+    expect(shaped.truncated).toBe(false)
+  })
+
+  it("drops older lines but still returns the over-budget final line", () => {
+    const huge = "y".repeat(TERMINAL_TAIL_BYTES + 5000)
+    const shaped = boundedTail(`old-1\nold-2\n${huge}`)
+    expect(shaped.tail).toEqual([huge])
+    expect(shaped.truncated).toBe(true)
   })
 })

--- a/packages/kobe/test/daemon/automation-precheck.test.ts
+++ b/packages/kobe/test/daemon/automation-precheck.test.ts
@@ -6,9 +6,41 @@ import {
   formatPrecheckSkip,
   precheckPassed,
   runAutomationPrecheck,
+  tail,
 } from "../../../kobe-daemon/src/daemon/automation-precheck.ts"
 
 const CWD = process.cwd()
+
+describe("tail", () => {
+  it("decodes a multi-byte char split across two chunks without mojibake", () => {
+    // Node emits a pipe's `data` events split at arbitrary byte offsets, so a
+    // multi-byte UTF-8 sequence can straddle two Buffers. Slicing the 4-byte
+    // rocket in half is exactly that seam.
+    const bytes = Buffer.from("🚀 café 中文", "utf8")
+    const first = bytes.subarray(0, 2)
+    const second = bytes.subarray(2)
+    expect(tail([first, second])).toBe("🚀 café 中文")
+    expect(tail([first, second])).not.toContain("�")
+  })
+
+  it("keeps a pushed error string in order alongside buffers", () => {
+    expect(tail([Buffer.from("out"), "spawn failed"])).toBe("outspawn failed")
+  })
+
+  it("caps to the last 4000 code points without halving a surrogate pair", () => {
+    // 4001 rockets is past the 4000-char cap; slicing by UTF-16 unit would cut
+    // the boundary rocket in half and strand a lone surrogate.
+    const capped = tail([Buffer.from("🚀".repeat(4001), "utf8")])
+    expect(Array.from(capped)).toHaveLength(4000)
+    expect(capped).not.toContain("�")
+    expect([...capped].every((point) => point === "🚀")).toBe(true)
+  })
+
+  it("returns short output untouched", () => {
+    expect(tail([Buffer.from("hello")])).toBe("hello")
+    expect(tail([])).toBe("")
+  })
+})
 
 describe("runAutomationPrecheck", () => {
   it("reports exit 0 as a pass", async () => {

--- a/packages/kobe/test/daemon/web-origin.test.ts
+++ b/packages/kobe/test/daemon/web-origin.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import { allowedHostForBindHost, isLoopbackOrigin, originAllowed } from "../../../kobe-daemon/src/daemon/web-origin.ts"
+
+/**
+ * Browser-Origin policy for daemon-hosted web routes.
+ *
+ * Regression (this file): a bind host carrying any uppercase letter — routine
+ * for mDNS names like `MyMac.local` — used to 403 every browser request. The
+ * browser (and `new URL().hostname`) lowercase the Origin host, but the allowed
+ * bind host was compared with its original case, so `mymac.local === MyMac.local`
+ * was false. Hostnames are case-insensitive (RFC 4343); the comparison now is.
+ */
+describe("originAllowed", () => {
+  it("allows a request with no Origin (non-browser client)", () => {
+    expect(originAllowed(null)).toBe(true)
+    expect(originAllowed(undefined)).toBe(true)
+    expect(originAllowed("")).toBe(true)
+  })
+
+  it("allows any loopback Origin regardless of the allowed host", () => {
+    expect(originAllowed("http://localhost:45174")).toBe(true)
+    expect(originAllowed("http://127.0.0.1:45174")).toBe(true)
+    expect(originAllowed("http://[::1]:45174")).toBe(true)
+    expect(originAllowed("http://localhost:45174", { allowedHost: "example.local" })).toBe(true)
+  })
+
+  it("rejects a non-loopback Origin when no host is allowed", () => {
+    expect(originAllowed("http://kobe.local:45174")).toBe(false)
+    expect(originAllowed("http://kobe.local:45174", { allowedHost: "" })).toBe(false)
+    expect(originAllowed("http://kobe.local:45174", { allowedHost: "   " })).toBe(false)
+  })
+
+  it("allows the exact allowed host", () => {
+    expect(originAllowed("http://kobe.local:45174", { allowedHost: "kobe.local" })).toBe(true)
+    expect(originAllowed("https://192.168.1.20:45174", { allowedHost: "192.168.1.20" })).toBe(true)
+  })
+
+  it("matches a mixed-case bind host case-insensitively (RFC 4343)", () => {
+    // The browser lowercases the Origin host; the bind host keeps its case.
+    expect(originAllowed("http://mymac.local:45174", { allowedHost: "MyMac.local" })).toBe(true)
+    expect(originAllowed("http://johns-mbp.local:45174", { allowedHost: "Johns-MBP.local" })).toBe(true)
+    expect(originAllowed("http://host.example:45174", { allowedHost: "HOST.EXAMPLE" })).toBe(true)
+  })
+
+  it("rejects a genuinely different host", () => {
+    expect(originAllowed("http://evil.example:45174", { allowedHost: "kobe.local" })).toBe(false)
+  })
+
+  it("rejects a non-http(s) Origin scheme", () => {
+    expect(originAllowed("file:///etc/passwd", { allowedHost: "kobe.local" })).toBe(false)
+    expect(originAllowed("ws://kobe.local", { allowedHost: "kobe.local" })).toBe(false)
+  })
+})
+
+describe("isLoopbackOrigin", () => {
+  it("recognizes loopback hosts and nothing else", () => {
+    expect(isLoopbackOrigin("http://localhost")).toBe(true)
+    expect(isLoopbackOrigin("http://127.0.0.1:45174")).toBe(true)
+    expect(isLoopbackOrigin("http://192.168.1.5")).toBe(false)
+    expect(isLoopbackOrigin(null)).toBe(false)
+  })
+})
+
+describe("allowedHostForBindHost", () => {
+  it("drops loopback bind hosts (nothing to gate — loopback is always allowed)", () => {
+    expect(allowedHostForBindHost("127.0.0.1")).toBeUndefined()
+    expect(allowedHostForBindHost("localhost")).toBeUndefined()
+    expect(allowedHostForBindHost("::1")).toBeUndefined()
+    expect(allowedHostForBindHost("")).toBeUndefined()
+    expect(allowedHostForBindHost(undefined)).toBeUndefined()
+  })
+
+  it("keeps a real LAN bind host, and originAllowed accepts its browser Origin despite case", () => {
+    const allowedHost = allowedHostForBindHost("MyMac.local")
+    expect(allowedHost).toBe("MyMac.local")
+    expect(originAllowed("http://mymac.local:45174", { allowedHost })).toBe(true)
+  })
+})


### PR DESCRIPTION
Second rescue batch from the open-PR triage sweep (`.scratch/pr-triage.md`). Each defect was re-confirmed on current `main` first.

**Not for merging tonight** — parked for review.

**Reimplemented, not rebased** — four fresh commits against current `main`; the source PRs are untouched.

## What these four have in common

They all fail **silently**, which is why they survived this long:

**#556 — malformed integer flags coerced instead of rejected.** `Number.parseInt` stops at the first non-digit, so `--id 5abc` → `5` **flips a real, wrong issue and exits 0**, and `--count 1e3` → `1` quietly sidesteps the fan-out cap. A data-integrity bug at a trust boundary. Fixed root-cause style: one `parsePositiveInt` helper replaces all three bare `parseInt` sites, so a malformed value fails loudly with `BAD_FLAG` like every other validator in the module.

**#400 — `read-output` dropped its last line at the byte cap.** When the final line alone exceeds 64KB, `--source terminal` returned a **completely empty** tail — and an agent coordinating on that output draws confident wrong conclusions from it.

**#421 — dashboard bind host matched case-sensitively.** URL parsing always lowercases the host, but `allowedHostForBindHost` didn't — so binding `MyMac.local` **403s the entire LAN dashboard**.

**#447 — precheck output decoded per chunk.** A multi-byte character straddling a chunk boundary always produced `�`.

## Verification

- **Tests confirmed red against unfixed sources** — I reverted the source files and watched the #421 cases fail with the fix's own assertions, then restored. Each of the four ships its own regression test.
- **The changeset uses `@sma1lboy/rove`.** The original #421 carried the dead `@sma1lboy/kobe` name — one of the stale-green-check casualties from issue #56 — so that trap is avoided here.

`test:fast` 3486 passed, lint and typecheck clean.