### PR TITLE
fix: revive three more A-class fixes, and skip one that's already covered (#376 #490 #522)

### DIFF
--- a/.changeset/cron-preview-weekday-names.md
+++ b/.changeset/cron-preview-weekday-names.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the automation schedule preview spelling four of the seven weekdays wrong — a `TUE`/`WED`/`THU`/`SAT` cron rendered "Tuedays", "Weddays", "Thudays", "Satdays". The preview also stays silent on an hourly list/range minute (`15,45 * * * *`) instead of asserting a fire time (`:15,45`) the schedule never has.

--- a/.changeset/ulid-backward-clock-monotonic.md
+++ b/.changeset/ulid-backward-clock-monotonic.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Task ids stay strictly sortable when the wall clock steps backward: the ULID generator now holds its last timestamp and increments the random tail whenever an incoming timestamp does not advance past the previous one, so an NTP correction, VM resume, or manual clock change mid-session can no longer mint a task id that sorts before its predecessor and silently reorder the task index. Same-millisecond and forward-clock behavior are unchanged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,32 +66,11 @@ jobs:
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          # Exemptions are PER FILE: each `file-size-exemption: <path> — <reason>`
-          # line in the PR body exempts only the exact path it names (a bare
-          # reason with no path exempts nothing).
-          exempt_paths=$(printf '%s\n' "$PR_BODY" | grep -io 'file-size-exemption:[[:space:]]*[^[:space:]]*' | sed 's/^[^:]*:[[:space:]]*//' || true)
-          fail=0
-          while IFS= read -r f; do
-            [ -f "$f" ] || continue
-            case "$f" in
-              refs/*|*.snap|*fixtures/*|*.lock|*.lockb) continue ;;
-            esac
-            case "$f" in
-              *.ts|*.tsx|*.js|*.jsx|*.mjs) ;;
-              *) continue ;;
-            esac
-            lines=$(wc -l < "$f")
-            if [ "$lines" -gt 500 ]; then
-              if [ -n "$exempt_paths" ] && printf '%s\n' "$exempt_paths" | grep -qxF "$f"; then
-                echo "::notice file=$f::$f is $lines lines but exempted by the PR body."
-                continue
-              fi
-              echo "::error file=$f::$f is $lines lines (cap ~500). Refactor/split it, or add a 'file-size-exemption: $f — <reason>' line to the PR body. See AGENTS.md 'File size cap'."
-              fail=1
-            fi
-          done < <(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD)
-          exit $fail
+        # Cap + near-cap headroom warning; extracted to a script so the
+        # gate's behavior is covered by tests. Exemptions are PER FILE:
+        # each `file-size-exemption: <path> — <reason>` line in the PR body
+        # exempts only the exact path it names.
+        run: bash scripts/file-size-check.sh
 
   changeset-cap:
     # Hard rule sibling (KOB-10, docs/RELEASING.md "add a changeset per

--- a/packages/kobe/src/orchestrator/index/ulid.ts
+++ b/packages/kobe/src/orchestrator/index/ulid.ts
@@ -11,12 +11,17 @@
  *      "created at" tiebreaker. Sidebar grouping/ordering can rely on
  *      string compare instead of parsing `createdAt`.
  *
- *   2. **Monotonic within the same millisecond** — when two tasks are
- *      created back-to-back, the second must sort *after* the first.
- *      We achieve this by remembering the last (timestamp, randomness)
- *      we emitted: if the same millisecond comes around again, we
- *      increment the previous random tail by one instead of generating
- *      fresh randomness. (Spec: github.com/ulid/spec — "Monotonicity".)
+ *   2. **Monotonic across calls** — when two tasks are created
+ *      back-to-back, the second must sort *after* the first. We remember
+ *      the last (timestamp, randomness) we emitted: if the incoming
+ *      timestamp does not advance past it — same millisecond, or a wall
+ *      clock that stepped *backward* (NTP correction, VM resume, manual
+ *      clock change) — we hold the last timestamp and increment the
+ *      previous random tail instead of generating fresh randomness.
+ *      Holding the timestamp keeps a backward clock step from minting an
+ *      id whose prefix sorts before its predecessor and silently
+ *      reordering the task index.
+ *      (Spec: github.com/ulid/spec — "Monotonicity".)
  *
  * Inlined intentionally (~80 LoC, no deps). If we ever need a battle-
  * tested impl, swap to the `ulid` npm package — the public surface
@@ -91,9 +96,17 @@ function indicesToString(indices: number[]): string {
  */
 export function ulid(now: number = Date.now()): string {
   let randIndices: number[]
-  if (now === lastTime) {
-    // Same millisecond: increment the previous tail to preserve
-    // strict monotonic ordering across same-ms calls.
+  let time: number
+  if (now > lastTime) {
+    // The clock advanced: a fresh millisecond gets fresh randomness.
+    time = now
+    randIndices = randomIndices(RAND_LEN)
+  } else {
+    // The clock did NOT advance — same millisecond, or it stepped
+    // backward. Hold the last timestamp (never regress the sortable
+    // prefix) and increment the previous tail to preserve strict
+    // monotonic ordering.
+    time = lastTime
     const next = lastRand.slice()
     if (!incrementIndices(next)) {
       // Astronomically unlikely (16 Z's). Fall back to fresh randomness.
@@ -101,12 +114,10 @@ export function ulid(now: number = Date.now()): string {
     } else {
       randIndices = next
     }
-  } else {
-    randIndices = randomIndices(RAND_LEN)
   }
-  lastTime = now
+  lastTime = time
   lastRand = randIndices
-  return encodeTime(now, TIME_LEN) + indicesToString(randIndices)
+  return encodeTime(time, TIME_LEN) + indicesToString(randIndices)
 }
 
 /** Reset the monotonic state — exported for tests only. */

--- a/packages/kobe/src/tui/component/cron-segments.ts
+++ b/packages/kobe/src/tui/component/cron-segments.ts
@@ -35,6 +35,19 @@ const MONTH_LADDER = ["*", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG
 // describe a schedule, and neither is reachable by stepping single days.
 const DOW_LADDER = ["*", "MON-FRI", "SAT,SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
 
+// Plural weekday names keyed by cron abbreviation. English weekday names
+// don't derive mechanically from their three-letter forms — "TUE" + "days"
+// is "Tuedays" — so each one is spelled out.
+const DOW_NAMES: Record<string, string> = {
+  MON: "Mondays",
+  TUE: "Tuesdays",
+  WED: "Wednesdays",
+  THU: "Thursdays",
+  FRI: "Fridays",
+  SAT: "Saturdays",
+  SUN: "Sundays",
+}
+
 function range(from: number, to: number): string[] {
   const out: string[] = []
   for (let n = from; n <= to; n++) out.push(String(n))
@@ -97,7 +110,8 @@ export function describeCron(expression: string): string | null {
   if (dow === "*") return `every day ${at}`
   if (dow === "MON-FRI") return `weekdays ${at}`
   if (dow === "SAT,SUN") return `weekends ${at}`
-  if (/^[A-Z]{3}$/.test(dow)) return `${dow.charAt(0)}${dow.slice(1).toLowerCase()}days ${at}`
+  const named = DOW_NAMES[dow.toUpperCase()]
+  if (named) return `${named} ${at}`
   return null
 }
 
@@ -105,7 +119,12 @@ function describeTimeOfDay(minute: string, hour: string): string | null {
   if (hour === "*") {
     if (minute === "*") return "every minute"
     if (minute.startsWith("*/")) return `every ${minute.slice(2)}m`
-    return `hourly at :${minute.padStart(2, "0")}`
+    // Only a single clock minute names a real fire time. A list or range
+    // (`15,45`, `10-20`) is not one instant — `:15,45` would assert a time
+    // the schedule never has, so stay silent and let the raw cron plus the
+    // next-run preview carry the truth.
+    if (/^\d+$/.test(minute)) return `hourly at :${minute.padStart(2, "0")}`
+    return null
   }
   if (hour.startsWith("*/") && minute === "0") return `every ${hour.slice(2)}h`
   if (/^\d+$/.test(hour) && /^\d+$/.test(minute)) {

--- a/packages/kobe/test/architecture/file-size-check.test.ts
+++ b/packages/kobe/test/architecture/file-size-check.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Behavior of the CI file-size gate (scripts/file-size-check.sh, run by the
+ * file-size-cap job): over-cap files fail, near-cap files warn without
+ * failing, files with headroom stay silent, and PR-body exemptions still
+ * downgrade an over-cap file to a notice.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterAll, describe, expect, test } from "vitest"
+
+const SCRIPT = fileURLToPath(new URL("../../../../scripts/file-size-check.sh", import.meta.url))
+
+const repo = mkdtempSync(join(tmpdir(), "file-size-check-"))
+const git = (...args: string[]) =>
+  execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", ...args], { cwd: repo, stdio: "pipe" })
+
+// A repo whose origin/main baseline is empty, so every file added on the
+// branch counts as touched.
+git("init", "-q")
+writeFileSync(join(repo, "README.md"), "base\n")
+git("add", ".")
+git("commit", "-qm", "base")
+git("update-ref", "refs/remotes/origin/main", "HEAD")
+
+const tsFile = (name: string, lines: number) => {
+  writeFileSync(join(repo, name), `${Array.from({ length: lines }, (_, i) => `// ${i}`).join("\n")}\n`)
+  git("add", name)
+  git("commit", "-qm", `add ${name}`)
+}
+
+const run = (prBody = "") => {
+  try {
+    const stdout = execFileSync("bash", [SCRIPT], {
+      cwd: repo,
+      env: { ...process.env, BASE_REF: "main", PR_BODY: prBody },
+      encoding: "utf8",
+    })
+    return { code: 0, stdout }
+  } catch (error) {
+    const e = error as { status: number; stdout: string }
+    return { code: e.status, stdout: e.stdout }
+  }
+}
+
+afterAll(() => rmSync(repo, { recursive: true, force: true }))
+
+describe("file-size-check.sh", () => {
+  test("a file with headroom passes silently", () => {
+    tsFile("small.ts", 469)
+    const { code, stdout } = run()
+    expect(code).toBe(0)
+    expect(stdout).not.toContain("small.ts")
+  })
+
+  test("a near-cap file warns without failing the build", () => {
+    tsFile("near.ts", 471)
+    const { code, stdout } = run()
+    expect(code).toBe(0)
+    expect(stdout).toContain("::warning file=near.ts::")
+    expect(stdout).toContain("29 from the ~500 cap")
+  })
+
+  test("an over-cap file fails, and stays an error — not a warning", () => {
+    tsFile("big.ts", 501)
+    const { code, stdout } = run()
+    expect(code).toBe(1)
+    expect(stdout).toContain("::error file=big.ts::")
+    expect(stdout).not.toContain("::warning file=big.ts::")
+  })
+
+  test("a PR-body exemption downgrades the over-cap error to a notice", () => {
+    const { code, stdout } = run("file-size-exemption: big.ts — generated table")
+    expect(code).toBe(0)
+    expect(stdout).toContain("::notice file=big.ts::")
+  })
+})

--- a/packages/kobe/test/orchestrator/ulid.test.ts
+++ b/packages/kobe/test/orchestrator/ulid.test.ts
@@ -36,6 +36,26 @@ describe("ulid", () => {
     expect(first.slice(0, 10)).toBe(third.slice(0, 10))
   })
 
+  it("stays monotonic when the wall clock steps backward", () => {
+    const first = ulid(9000)
+    // Clock jumps back (NTP correction, VM resume). The id must still sort
+    // strictly after the previous one, so the timestamp prefix is held at
+    // the last-seen 9000 rather than regressing to 8000.
+    const second = ulid(8000)
+    expect(second > first).toBe(true)
+    expect(second.slice(0, 10)).toBe(first.slice(0, 10))
+  })
+
+  it("resumes fresh timestamps once the clock catches back up", () => {
+    const first = ulid(9000)
+    const held = ulid(8000)
+    expect(held.slice(0, 10)).toBe(first.slice(0, 10))
+    // A later timestamp advances the prefix normally again.
+    const later = ulid(9001)
+    expect(later > held).toBe(true)
+    expect(later.slice(0, 10) > first.slice(0, 10)).toBe(true)
+  })
+
   it("generates a distinct id per call", () => {
     const ids = new Set([ulid(9000), ulid(9000), ulid(9001), ulid(9001)])
     expect(ids.size).toBe(4)

--- a/packages/kobe/test/tui/cron-segments.test.ts
+++ b/packages/kobe/test/tui/cron-segments.test.ts
@@ -93,6 +93,26 @@ describe("describeCron", () => {
     expect(describeCron("0 */6 * * *")).toBe("every day every 6h")
   })
 
+  test("spells every weekday the ladder can reach", () => {
+    // Mechanical `TUE` + "days" spelled four of the seven wrong
+    // ("Tuedays", "Weddays", "Thudays", "Satdays").
+    expect(describeCron("0 9 * * TUE")).toBe("Tuesdays at 09:00")
+    expect(describeCron("0 9 * * WED")).toBe("Wednesdays at 09:00")
+    expect(describeCron("0 9 * * THU")).toBe("Thursdays at 09:00")
+    expect(describeCron("0 9 * * FRI")).toBe("Fridays at 09:00")
+    expect(describeCron("0 9 * * SAT")).toBe("Saturdays at 09:00")
+    expect(describeCron("0 9 * * SUN")).toBe("Sundays at 09:00")
+  })
+
+  test("stays silent on an hourly list/range minute instead of naming a false time", () => {
+    // `15,45` is two fire times, not one — "hourly at :15,45" asserts a
+    // clock time the schedule never has.
+    expect(describeCron("15,45 * * * *")).toBeNull()
+    expect(describeCron("10-20 * * * *")).toBeNull()
+    // A plain hourly minute still names itself.
+    expect(describeCron("15 * * * *")).toBe("every day hourly at :15")
+  })
+
   test("stays silent rather than describing a shape it does not model", () => {
     // A half-truth about when a schedule fires is worse than the raw cron —
     // the next-run preview already carries the ground truth.

--- a/scripts/file-size-check.sh
+++ b/scripts/file-size-check.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# File-size cap on touched code files (AGENTS.md "File size cap"), run by
+# the CI file-size-cap job. Lives as a script so the gate's behavior is
+# testable — see packages/kobe/test/architecture/file-size-check.test.ts.
+#
+# Env contract (set by ci.yml):
+#   BASE_REF — the PR base branch; touched files are diffed against
+#              origin/$BASE_REF...HEAD.
+#   PR_BODY  — the PR body; `file-size-exemption: <path> — <reason>` lines
+#              exempt only the exact path each names.
+set -u
+
+CAP=500
+# Tunable headroom threshold: a passing file at or past this many lines gets
+# a warning (never a failure). The cap alone is a cliff — a file at 499
+# passes and the NEXT person to touch it inherits a refactor they did not
+# plan, with no room left even to extract a helper.
+WARN_AT=470
+
+exempt_paths=$(printf '%s\n' "${PR_BODY-}" | grep -io 'file-size-exemption:[[:space:]]*[^[:space:]]*' | sed 's/^[^:]*:[[:space:]]*//' || true)
+fail=0
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    refs/*|*.snap|*fixtures/*|*.lock|*.lockb) continue ;;
+  esac
+  case "$f" in
+    *.ts|*.tsx|*.js|*.jsx|*.mjs) ;;
+    *) continue ;;
+  esac
+  lines=$(wc -l < "$f")
+  if [ "$lines" -gt "$CAP" ]; then
+    if [ -n "$exempt_paths" ] && printf '%s\n' "$exempt_paths" | grep -qxF "$f"; then
+      echo "::notice file=$f::$f is $lines lines but exempted by the PR body."
+      continue
+    fi
+    echo "::error file=$f::$f is $lines lines (cap ~$CAP). Refactor/split it, or add a 'file-size-exemption: $f — <reason>' line to the PR body. See AGENTS.md 'File size cap'."
+    fail=1
+  elif [ "$lines" -ge "$WARN_AT" ]; then
+    echo "::warning file=$f::$f is $lines lines — $((CAP - lines)) from the ~$CAP cap. Consider splitting it now; the next edit may have no room left."
+  fi
+done < <(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD)
+exit $fail


### PR DESCRIPTION
Third rescue batch from the open-PR triage sweep (`.scratch/pr-triage.md`). Reimplemented against current `main`, three independent commits; the source PRs are untouched.

**Not for merging tonight** — parked for review.

## #488 was deliberately skipped

The brief listed four. **#488 is fully covered by open PR #580** — the identical `deleteBranch` coerce line is already there, and the finish path is pinned by the existing `task-deletion.test.ts:58` ("deletes the branch only on explicit deleteBranch opt-in"). I verified both before accepting the skip. Reimplementing it would have created a duplicate change to reconcile later.

## The three that landed

**#376 — the schedule preview misspelled weekdays.** `cron-segments.ts` produced "Tuedays / Weddays / Thudays / Satdays". It also fixes a second real bug: `15,45 * * * *` rendered as "hourly at :15,45". (#369 is a strict subset of this and needs no separate rescue.)

**#490 — ULIDs stopped sorting when the clock stepped backward.** The generator only handled `now === lastTime`, so an NTP correction or VM resume could mint an id whose timestamp prefix sorts *before* its predecessor — silently reordering the task index. It now **holds** the last timestamp rather than trusting a regressed wall clock.

**#522 — the 500-line file-size cap was a cliff with no warning.** Adds a warning at 470 lines. **The threshold is the one owner-tunable number here** — 470 comes from the original PR, not from analysis.

Worth noting: this one also **extracted the gate out of inline CI YAML into `scripts/file-size-check.sh`** with its own test. The logic was previously untestable shell embedded in a workflow; it now has 4 passing tests. That's a real improvement beyond the warning itself.

## Verification

- **The ULID test genuinely simulates the failure**, via injectable timestamps: `ulid(9000)` then `ulid(8000)` must still sort forward, plus a recovery case proving the prefix advances again once the clock catches up. That's the specific mode I asked for.
- I ran the extracted script directly (it needs `BASE_REF` set) and its test suite.
- **One flake, not a regression**: the first `test:fast` run showed `1 failed`; two subsequent full runs are clean at **3487 passed / 355 files**. The failure did not reproduce and is unrelated to these commits.

Lint and typecheck clean.