### PR TITLE
fix: terminal text correctness — merge the #500/#384 collision, plus #415 and #373

### DIFF
--- a/.changeset/cell-width-single-authority.md
+++ b/.changeset/cell-width-single-authority.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Make `charWidth` the single authority for terminal cell math: a C0 / DEL / C1 control character (a stray escape byte, NUL, or similar) now counts as zero columns instead of one, and the embedded terminal's cursor overlay / row-end seal stop re-flooring zero-width code points back to one cell. A control byte in a task title or `rove export` cell no longer shoves every column to its right out of alignment, and on a line holding a zero-width mark (NFD combining accents, emoji variation selectors, joiners) the cursor overlay lands on the character it's actually over instead of drifting one column right, while an underlined URL reaching the row edge seals its real last column.

--- a/.changeset/selection-padding-highlight-offset.md
+++ b/.changeset/selection-padding-highlight-offset.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Dragging a terminal selection into the blank space to the right of a short line now highlights the cells you actually dragged over, instead of a same-width block shoved back against the end of the text. Rows in the embedded terminal are trimmed, not grid-padded, so a selection that starts in that trailing padding was painting its inverse-video highlight from where the line's text ended rather than from where the drag began — the copied text was already correct, only the on-screen highlight was misplaced.

--- a/.changeset/tailpath-surrogate-pair.md
+++ b/.changeset/tailpath-surrogate-pair.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the web dashboard rendering a `�` replacement glyph when it truncates a path containing an emoji or a rare astral-plane character: the task rail and the diff file list tail-truncate long paths by keeping the filename end, but the shared `tailPath` helper sliced by UTF-16 code unit, so a cut that landed in the middle of a surrogate pair bisected the character. It now truncates by code point — matching the TUI's `truncateStart` — so every glyph stays intact and a path already within budget by code-point count is no longer needlessly clipped.

--- a/packages/kobe-web/src/lib/path-format.ts
+++ b/packages/kobe-web/src/lib/path-format.ts
@@ -3,9 +3,18 @@
  * the useful part) and prefix an ellipsis. A path within the budget is returned
  * unchanged. Shared so the rail and the diff file list truncate identically.
  *
- * The result is at most `max` chars: the leading `…` plus the last `max - 1`.
+ * The result is at most `max` code points: the leading `…` plus the last
+ * `max - 1`. Iterates by code POINT (`[...path]`), not UTF-16 code unit: a
+ * plain `.slice` can bisect a surrogate pair (an emoji or astral-plane char in
+ * a filename) and render a `�` replacement glyph. `max` stays an approximate
+ * cell budget — a code point can be a wide CJK glyph.
+ *
+ * Mirrors the TUI's `truncateStart` (packages/kobe/src/tui/lib/truncate.ts) —
+ * kept in step by hand because kobe-web's only workspace dependency is the
+ * daemon package; if the daemon ever grows a shared string lib, fold this in.
  */
 export function tailPath(path: string, max = 36): string {
-  if (path.length <= max) return path
-  return `…${path.slice(path.length - max + 1)}`
+  const points = [...path]
+  if (points.length <= max) return path
+  return `…${points.slice(points.length - max + 1).join("")}`
 }

--- a/packages/kobe-web/test/path-format.test.ts
+++ b/packages/kobe-web/test/path-format.test.ts
@@ -34,4 +34,24 @@ describe("tailPath", () => {
     expect(tailPath(long)).toHaveLength(36)
     expect(tailPath(long).startsWith("…")).toBe(true)
   })
+
+  it("does not split a surrogate pair at the truncation seam", () => {
+    // Each 📁 (U+1F4C1) is two UTF-16 units, so a code-unit .slice can begin
+    // the kept tail on a lone low surrogate and emit a `�` glyph. Iterating by
+    // code point keeps every emoji intact.
+    const out = tailPath("📁".repeat(20), 8)
+    expect(out.startsWith("…")).toBe(true)
+    expect(out).not.toContain("�")
+    // Leading `…` + 7 whole emoji, none bisected.
+    expect([...out]).toHaveLength(8)
+    expect(out).toBe(`…${"📁".repeat(7)}`)
+  })
+
+  it("counts astral characters by code point, not UTF-16 unit, when within budget", () => {
+    // 10 emoji is 20 UTF-16 units but only 10 code points — well within a
+    // 36-code-point budget, so the path is returned unchanged rather than
+    // needlessly truncated.
+    const path = "📁".repeat(10)
+    expect(tailPath(path)).toBe(path)
+  })
 })

--- a/packages/kobe/src/lib/display-width.ts
+++ b/packages/kobe/src/lib/display-width.ts
@@ -13,6 +13,13 @@
 
 /** Cell width of a single Unicode code point: 0 (zero-width), 2 (wide), or 1. */
 export function charWidth(cp: number): number {
+  // Non-printing controls: C0 (U+0000–U+001F), DEL (U+007F), C1 (U+0080–U+009F).
+  // wcwidth treats these as non-printing — a stray control byte in a task
+  // title or exported cell must not shove every column to its right one over.
+  // Callers must NOT re-floor this to 1 (`|| 1`): every zero here is a code
+  // point a terminal does not advance the cursor for, and flooring it breaks
+  // the embedded terminal's cell math the same way counting it did.
+  if (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f)) return 0
   // Zero-width: combining marks + bidi/format controls + variation selectors.
   if (
     (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks

--- a/packages/kobe/src/tui/panes/terminal/terminal-render.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-render.ts
@@ -12,6 +12,17 @@ export function isShellMissing(message: string): boolean {
   return m.includes("enoent") || m.includes("not found")
 }
 
+/**
+ * Cells a single code point occupies in the grid, matching `displayWidth`'s
+ * accounting exactly: a zero-width mark (combining diacritic, emoji variation
+ * selector, ZWJ/bidi control) contributes 0. xterm folds such a mark onto its
+ * base char's cell, so counting it as 1 drifts the cell-column cursor right by
+ * one column per mark to its left — do NOT `|| 1` this back to a width of one.
+ */
+function cellWidth(ch: string): number {
+  return charWidth(ch.codePointAt(0) as number)
+}
+
 function cloneChunk(c: Chunk, text: string, attrs = c.attributes ?? 0): Chunk {
   return {
     text,
@@ -24,7 +35,7 @@ function cloneChunk(c: Chunk, text: string, attrs = c.attributes ?? 0): Chunk {
 /** Sum the display width (in cells) of a chunk's text. */
 function chunkCells(chars: readonly string[]): number {
   let w = 0
-  for (const ch of chars) w += charWidth(ch.codePointAt(0) as number) || 1
+  for (const ch of chars) w += cellWidth(ch)
   return w
 }
 
@@ -51,7 +62,7 @@ function overlayCursorRow(row: readonly Chunk[], x: number): Chunk[] {
     let localCol = col
     let hit = -1
     for (let idx = 0; idx < chars.length; idx++) {
-      const w = charWidth((chars[idx] as string).codePointAt(0) as number) || 1
+      const w = cellWidth(chars[idx] as string)
       if (x >= localCol && x < localCol + w) {
         hit = idx
         break
@@ -137,7 +148,7 @@ export function sealRowEndAttributes(
       const chars = Array.from(chunk.text)
       for (let j = 0; j < chars.length; j++) {
         const ch = chars[j] as string
-        const w = charWidth(ch.codePointAt(0) as number) || 1
+        const w = cellWidth(ch)
         if (col + w <= lastColumn) {
           col += w
           continue

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -172,8 +172,17 @@ function overlayRowSpan(row: readonly Chunk[], from: number, to: number): Chunk[
     if (after) out.push({ ...chunk, text: after })
   }
   // Selection reaching past the row's painted cells: show the highlight
-  // on the padding too, like terminals do.
-  if (col < to) out.push({ text: " ".repeat(to - Math.max(col, from)), attributes: ATTR.INVERSE })
+  // on the padding too, like terminals do. When the span STARTS past the
+  // painted cells (a drag anchored in the blank padding right of a short
+  // line, `from > col`), the highlight must begin at `from`, not at the
+  // row's painted width — so emit the `from - col` gap as plain spaces
+  // first, then the inverse block. With `from <= col` the gap is zero and
+  // the inverse block fills `[col, to)` exactly as before.
+  if (col < to) {
+    const gap = from - col
+    if (gap > 0) out.push({ text: " ".repeat(gap) })
+    out.push({ text: " ".repeat(to - Math.max(col, from)), attributes: ATTR.INVERSE })
+  }
   return out
 }
 

--- a/packages/kobe/test/lib/display-width.test.ts
+++ b/packages/kobe/test/lib/display-width.test.ts
@@ -27,6 +27,21 @@ describe("charWidth", () => {
     expect(charWidth("😀".codePointAt(0) as number)).toBe(2) // U+1F600
   })
 
+  it("counts C0 / DEL / C1 control characters as zero (non-printing)", () => {
+    // wcwidth treats controls as non-printing, not one cell. A stray control
+    // byte in a task title or exported cell must not advance the column count.
+    expect(charWidth(0x00)).toBe(0) // NUL
+    expect(charWidth(0x09)).toBe(0) // TAB (C0)
+    expect(charWidth(0x1b)).toBe(0) // ESC (C0)
+    expect(charWidth(0x1f)).toBe(0) // C0 ceiling
+    expect(charWidth(0x7f)).toBe(0) // DEL
+    expect(charWidth(0x80)).toBe(0) // C1 floor
+    expect(charWidth(0x85)).toBe(0) // NEL (C1)
+    expect(charWidth(0x9f)).toBe(0) // C1 ceiling
+    expect(charWidth(0x20)).toBe(1) // space — first printable just past C0
+    expect(charWidth(0xa0)).toBe(1) // no-break space — first printable past C1
+  })
+
   it("counts combining diacritical / bidi / variation-selector marks as zero", () => {
     expect(charWidth(0x0301)).toBe(0) // combining acute accent
     expect(charWidth(0x200b)).toBe(0) // zero-width space
@@ -114,6 +129,16 @@ describe("displayWidth", () => {
 
   it("does not count a combining half mark as an extra cell", () => {
     expect(displayWidth("a︦")).toBe(1) // base glyph + zero-width mark
+  })
+
+  it("does not count control characters toward a string's cell width", () => {
+    // A stray control byte occupies no columns; only the visible glyphs do.
+    // (This zeroes the control code point itself, not a full ANSI sequence —
+    // the printable `[0m` tail of an escape still measures normally.)
+    expect(displayWidth("a\x1bb")).toBe(2) // ESC between two glyphs adds nothing
+    expect(displayWidth("a\x00b")).toBe(2) // NUL between two glyphs adds nothing
+    expect(displayWidth("\x07中")).toBe(2) // BEL is free; the wide glyph is 2
+    expect(displayWidth("a\x1b\u0301b")).toBe(2) // control + combining mark: both zero
   })
 
   it("counts an astral character once, not as two UTF-16 units", () => {

--- a/packages/kobe/test/tui/terminal-render.test.ts
+++ b/packages/kobe/test/tui/terminal-render.test.ts
@@ -32,6 +32,34 @@ describe("overlayCursor — cell-column aware", () => {
     expect(cursorCell([out], 0)?.text).toBe("b")
   })
 
+  it("counts a zero-width combining mark as part of its base char's cell", () => {
+    // "éx": é in NFD (e + combining acute) is ONE cell, x is the next.
+    // xterm folds the mark onto the base cell, so the mark must add 0 columns
+    // — counting it as 1 drifted the overlay one cell right and inverted the
+    // bare combining mark instead of the char the cursor was actually on.
+    const rows = [[{ text: "e\u0301x" } as Chunk]]
+    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }), 0)?.text).toBe("e")
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("x")
+  })
+
+  it("treats an emoji variation selector as zero-width", () => {
+    // "❤️x": U+2764 + VS16 is one narrow-width unit here (matching
+    // displayWidth), so x sits at cell 1, not cell 2.
+    const rows = [[{ text: "❤️x" } as Chunk]]
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("x")
+  })
+
+  it("gives a control byte zero cells WITHOUT a one-cell floor re-widening it", () => {
+    // Merged invariant of the control-char and zero-width fixes: `charWidth`
+    // alone decides cell math (controls AND combining marks are 0), and this
+    // module must not re-floor it with `|| 1`. "a" + BEL + NFD é: a=1, BEL=0,
+    // e=1, mark=0 — so cell 1 is "e". Either half alone fails this: a floor
+    // turns BEL back into a column, and without the control branch BEL is 1.
+    const rows = [[{ text: "a\x07e\u0301" } as Chunk]]
+    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }), 0)?.text).toBe("a")
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("e")
+  })
+
   it("past-the-end cursor (blank cell) appends an inverse space", () => {
     const rows = [[{ text: "你" } as Chunk]]
     // 你 spans cells 0-1; x=2 is the empty cell after it.
@@ -95,6 +123,19 @@ describe("sealRowEndAttributes — opentui row-end attribute leak workaround", (
     expect(out.at(-1)?.attributes ?? 0).toBe(0)
     // ...and the same row is left alone in a wider terminal.
     expect(sealRowEndAttributes(rows, 10, FG, BG)[0]).toBe(rows[0])
+  })
+
+  it("finds the last visible cell past a zero-width combining mark", () => {
+    // "ábc" with á in NFD (a + combining acute) is THREE cells, not four:
+    // the mark folds onto its base. A cols=3 row is full and the seal must
+    // land on "c" — counting the mark as a column sealed "b" and left "c"
+    // (the real last-column cell) still bleeding its attribute.
+    const rows = [[{ text: "a\u0301bc", attributes: ATTR.UNDERLINE } as Chunk]]
+    const out = sealRowEndAttributes(rows, 3, FG, BG)[0] as readonly Chunk[]
+    expect(out.map((c) => c.text).join("")).toBe("a\u0301bc")
+    const sealed = out.find((c) => c.text === "c") as Chunk
+    expect(sealed.attributes ?? 0).toBe(0)
+    expect(out.find((c) => c.text === "a\u0301b")?.attributes).toBe(ATTR.UNDERLINE)
   })
 
   it("seals the last VISIBLE cell when the row is wider than the pane", () => {

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -79,6 +79,29 @@ describe("terminal grid selection", () => {
     expect(out[0].map((c) => c.text).join("")).toBe("ab    ")
   })
 
+  it("overlaySelection lands the padding highlight on the selected cells when the span starts past the text", () => {
+    // The drag anchors in the blank padding to the right of a short line
+    // (cols 5-7, past "ab" which paints only cols 0-1). The highlight must
+    // sit on cols 5-7, with cols 2-4 left as unhighlighted padding — not
+    // shifted left onto cols 2-4 (the regression this guards).
+    const short = [row("ab")]
+    const range = { anchor: { row: 0, col: 5 }, head: { row: 0, col: 7 } }
+    const out = overlaySelection(short, range, 0, 10)[0]
+    // Full row is 8 cells: "ab" + three plain spaces + three inverse spaces.
+    expect(out.map((c) => c.text).join("")).toBe("ab      ")
+    expect(displayWidth(out.map((c) => c.text).join(""))).toBe(8)
+    const plain = out
+      .filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) === 0)
+      .map((c) => c.text)
+      .join("")
+    const inverse = out
+      .filter((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+      .map((c) => c.text)
+      .join("")
+    expect(plain).toBe("ab   ") // "ab" + the 3-cell gap, unhighlighted
+    expect(inverse).toBe("   ") // exactly the 3 selected padding cells
+  })
+
   it("extracts a CJK range by terminal cells in either drag direction", () => {
     const cjk = [row("唯一需要区分的是：")]
     const forward = { anchor: { row: 0, col: 4 }, head: { row: 0, col: 9 } }


### PR DESCRIPTION
Fourth rescue batch from the open-PR triage sweep (`.scratch/pr-triage.md`). Reimplemented against current `main`; the source PRs are untouched.

**Not for merging tonight** — parked for review.

## #500 and #384 had to land together

I flagged these two as a **merge-order hazard** earlier (comments on both PRs): #500's safety argument *depends on* the `charWidth(...) || 1` floor in `terminal-render.ts`, and #384 *removes exactly that floor*. Whichever merged second would have invalidated the first one's reasoning — and neither PR mentioned the interaction.

They're folded into **one commit** with an explicit merged invariant:

> **`charWidth` alone decides cell math** — C0/DEL/C1 controls and combining marks are both zero cells — **and no consumer re-floors it.**

Without it: control bytes mixed into export tables or sidebar labels misalign columns (#500), and NFD / emoji+VS16 text puts the cursor one cell off with the underline overflowing the line end (#384).

### The invariant test fails under *either* half alone

One string exercises both halves: `"a" + BEL + NFD é` → `a`=1, BEL=0, `e`=1, mark=0, so cell 1 must be `"e"`. **I verified both half-states myself** rather than trusting the claim:

- Reverting only `display-width.ts` (i.e. #384 alone) → **1 failed** — BEL is 1 cell again.
- Reverting only `terminal-render.ts` (i.e. #500 alone, floor restored) → **3 failed** — the floor re-widens BEL *and* breaks the combining-mark and variation-selector cases.

A test that passed under either half would have proven nothing about the merge.

## The other two

**#415** — the padding-selection highlight started at the wrong cell when drag-selecting to the right of a short line. **Display-only; the copied text was already correct**, so the extraction path is untouched.

**#373** — `tailPath` sliced by UTF-16 code unit, so a path containing an astral character rendered `�` in the dashboard. Now truncates by code point.

## Notes

- All three changesets use `@sma1lboy/rove` (the dead `@sma1lboy/kobe` name is what stale-green-check issue #56 is about).
- **`display-width.ts`'s hand-maintained Unicode table is now on its 6th patch** (#272/#337/#348/499c99e5d/98ca947b3, and this). The recurrence rate suggests replacing the table wholesale — flagged for the owner rather than acted on, per the brief.

`test:fast` 3486 passed, render track 213 passed, lint and typecheck clean.