### PR TITLE
fix(plugins): stat-poll the registry so a write during watcher startup is never lost

### DIFF
--- a/.changeset/plugin-registry-poll-watch.md
+++ b/.changeset/plugin-registry-poll-watch.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Watch the plugin registry by stat-polling instead of `fs.watch`. On macOS the FSEvents stream behind `fs.watch` starts asynchronously, so a `plugins.json` write landing before the stream is live was dropped forever — the daemon never saw the install/enable until the next mutation, and the plugin-runtime test flaked ~8% under a loaded suite (issue #61). The host now takes a synchronous baseline stat before the first registry load and polls every 200ms, so no write can fall between the watcher and the load.

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -106,8 +106,10 @@ local authoring (no build; your tree, your build). `uninstall` removes the
 managed checkout but keeps `config/` + `state/`; `unlink` never touches files.
 
 Registry: `~/.kobe/plugins.json`, written only by the CLI. The daemon
-(`plugins/runtime.ts`, wired in `daemon/server.ts`) file-watches it, so
-install/enable/disable apply to a running daemon without a restart. Run log:
+(`plugins/runtime.ts`, wired in `daemon/server.ts`) stat-polls it (not
+`fs.watch` — macOS FSEvents can permanently drop writes landing in its async
+startup window), so install/enable/disable apply to a running daemon without
+a restart. Run log:
 `~/.kobe/plugins/<id>/log.jsonl` (`rove plugin log <id>`), stdout/stderr
 capped at 8 KB per run.
 

--- a/packages/kobe-daemon/src/plugins/registry.ts
+++ b/packages/kobe-daemon/src/plugins/registry.ts
@@ -1,7 +1,7 @@
 /**
  * `<home>/.kobe/plugins.json` — the installed/linked plugin registry.
  *
- * Written by the `kobe plugin` CLI; read (and file-watched) by the daemon's
+ * Written by the `kobe plugin` CLI; read (and stat-polled) by the daemon's
  * plugin runtime. Registration is global to the user, like herdr's: one list
  * for every session. The file is small and rewritten whole on every mutation.
  */

--- a/packages/kobe-daemon/src/plugins/runtime.ts
+++ b/packages/kobe-daemon/src/plugins/runtime.ts
@@ -5,14 +5,16 @@
  *
  * Plugins are ordinary argv commands — no shell, cwd = plugin root, env
  * carries the ROVE_PLUGIN_* contract plus Kobe compatibility aliases. The host
- * file-watches `plugins.json` so a CLI install/link/enable applies to the
- * running daemon without a restart. Startup hooks run only at daemon start
- * (herdr semantics): a reload swaps hook registrations, nothing more.
+ * stat-polls `plugins.json` so a CLI install/link/enable applies to the
+ * running daemon without a restart — polling, not `fs.watch`: on macOS the
+ * FSEvents stream behind `fs.watch` starts asynchronously, and a write landing
+ * before it is live is dropped forever, with no signal (issue #61). Startup
+ * hooks run only at daemon start (herdr semantics): a reload swaps hook
+ * registrations, nothing more.
  */
 
 import { spawn } from "node:child_process"
-import { type FSWatcher, appendFileSync, mkdirSync, watch } from "node:fs"
-import { dirname } from "node:path"
+import { appendFileSync, mkdirSync, statSync } from "node:fs"
 import type { ChannelEvent } from "../daemon/event-bus.ts"
 import { buildPluginEnv } from "./env.ts"
 import { type PluginEvent, PluginEventReducer, lifecycleEventFor } from "./events.ts"
@@ -42,6 +44,8 @@ interface LoadedPlugin {
 
 const OUTPUT_CAP = 8 * 1024
 const RELOAD_DEBOUNCE_MS = 150
+/** Registry stat-poll cadence; reload latency is this + the debounce. */
+const REGISTRY_POLL_MS = 200
 /** How long a [[shutdown]] hook may run before the host kills it. */
 const SHUTDOWN_GRACE_MS = 3_000
 
@@ -71,7 +75,8 @@ export class PluginHost {
   private readonly opts: PluginHostOptions
   private readonly reducer = new PluginEventReducer()
   private plugins: LoadedPlugin[] = []
-  private watcher: FSWatcher | undefined
+  private pollTimer: ReturnType<typeof setInterval> | undefined
+  private registryStamp = ""
   private reloadTimer: ReturnType<typeof setTimeout> | undefined
   private stopped = false
 
@@ -81,6 +86,11 @@ export class PluginHost {
 
   /** Load the registry, run startup hooks, and begin watching for changes. */
   start(): void {
+    // Watch BEFORE the first load: the baseline stamp is taken synchronously,
+    // so a write landing before it is seen by the load below, and one landing
+    // after it flips the stamp and triggers a reload. No write can fall
+    // between the two.
+    this.watchRegistry()
     this.plugins = this.loadPlugins()
     for (const plugin of this.plugins) {
       for (const [i, hook] of plugin.manifest.startup.entries()) {
@@ -88,7 +98,6 @@ export class PluginHost {
         void this.run(plugin, hook, "startup", { ROVE_PLUGIN_EVENT: "startup" }, `startup[${i}]`)
       }
     }
-    this.watchRegistry()
   }
 
   /**
@@ -103,7 +112,7 @@ export class PluginHost {
     if (this.stopped) return
     this.stopped = true
     if (this.reloadTimer) clearTimeout(this.reloadTimer)
-    this.watcher?.close()
+    if (this.pollTimer) clearInterval(this.pollTimer)
     const runs: Promise<void>[] = []
     for (const plugin of this.plugins) {
       for (const [i, hook] of plugin.manifest.shutdown.entries()) {
@@ -247,39 +256,47 @@ export class PluginHost {
     return out
   }
 
-  private watchRegistry(): void {
-    const path = pluginRegistryPath(this.opts.homeDir)
+  /** mtime(ns) + size + inode of the registry file, or "absent". */
+  private registryStampNow(): string {
     try {
-      mkdirSync(dirname(path), { recursive: true })
-      // Watch the directory: plugins.json may not exist yet, and whole-file
-      // rewrites replace the inode on some platforms.
-      this.watcher = watch(dirname(path), (_kind, filename) => {
-        if (filename && filename !== "plugins.json") return
-        if (this.reloadTimer) clearTimeout(this.reloadTimer)
-        this.reloadTimer = setTimeout(() => {
-          if (this.stopped) return
-          const before = new Map(this.plugins.map((p) => [p.manifest.id, p]))
-          this.plugins = this.loadPlugins()
-          this.opts.log?.(`plugin registry reloaded (${this.plugins.length} enabled)`)
-          // Registry transitions, delivered ONLY to the affected plugin: an
-          // enabled hook fires on the new load, a disabled hook on the last
-          // registration we still hold for it.
-          const at = Date.now()
-          for (const plugin of this.plugins) {
-            if (!before.has(plugin.manifest.id)) {
-              this.dispatchTo(plugin, { event: "plugin.enabled", detail: { pluginId: plugin.manifest.id }, at })
-            }
-          }
-          for (const [id, plugin] of before) {
-            if (!this.plugins.some((p) => p.manifest.id === id)) {
-              this.dispatchTo(plugin, { event: "plugin.disabled", detail: { pluginId: id }, at })
-            }
-          }
-        }, RELOAD_DEBOUNCE_MS)
-      })
-    } catch (err) {
-      this.opts.log?.(`plugin registry watch failed — ${String(err)}`)
+      const s = statSync(pluginRegistryPath(this.opts.homeDir), { bigint: true })
+      return `${s.mtimeNs}:${s.size}:${s.ino}`
+    } catch {
+      return "absent"
     }
+  }
+
+  private watchRegistry(): void {
+    this.registryStamp = this.registryStampNow()
+    this.pollTimer = setInterval(() => {
+      const stamp = this.registryStampNow()
+      if (stamp === this.registryStamp) return
+      this.registryStamp = stamp
+      // Debounce past the poll: a burst of CLI mutations (or a write still in
+      // flight) collapses into one reload after the file settles.
+      if (this.reloadTimer) clearTimeout(this.reloadTimer)
+      this.reloadTimer = setTimeout(() => {
+        if (this.stopped) return
+        const before = new Map(this.plugins.map((p) => [p.manifest.id, p]))
+        this.plugins = this.loadPlugins()
+        this.opts.log?.(`plugin registry reloaded (${this.plugins.length} enabled)`)
+        // Registry transitions, delivered ONLY to the affected plugin: an
+        // enabled hook fires on the new load, a disabled hook on the last
+        // registration we still hold for it.
+        const at = Date.now()
+        for (const plugin of this.plugins) {
+          if (!before.has(plugin.manifest.id)) {
+            this.dispatchTo(plugin, { event: "plugin.enabled", detail: { pluginId: plugin.manifest.id }, at })
+          }
+        }
+        for (const [id, plugin] of before) {
+          if (!this.plugins.some((p) => p.manifest.id === id)) {
+            this.dispatchTo(plugin, { event: "plugin.disabled", detail: { pluginId: id }, at })
+          }
+        }
+      }, RELOAD_DEBOUNCE_MS)
+    }, REGISTRY_POLL_MS)
+    this.pollTimer.unref?.()
   }
 
   private async run(

--- a/packages/kobe/test/plugins/runtime.test.ts
+++ b/packages/kobe/test/plugins/runtime.test.ts
@@ -126,7 +126,11 @@ command = ["sh", "-c", "printf %s \\"$ROVE_PLUGIN_EVENT\\" > enabled.txt"]
     )
     mkdirSync(join(home, ".kobe"), { recursive: true })
     // Start with an EMPTY registry — the plugin is enabled by a later write,
-    // which is exactly the transition plugin.enabled reports.
+    // which is exactly the transition plugin.enabled reports. The write below
+    // lands in the same tick as start(); with fs.watch this sat inside the
+    // FSEvents async-startup window and was dropped forever under load
+    // (issue #61, ~8% of runs at 8 lanes). The stat-poll watcher makes
+    // delivery deterministic — do not reintroduce fs.watch here.
     savePluginRegistry({ plugins: [] }, home)
     const host = new PluginHost({ homeDir: home, socketPath: "/tmp/fake.sock", binPath: "kobe" })
     const read = (name: string): string => {


### PR DESCRIPTION
Root-causes and fixes the largest contributor to rove issue #61 — the intermittent `test:fast` failures I hit repeatedly tonight.

**Not for merging tonight** — parked for review.

## It was a real bug, not test flakiness

On macOS the FSEvents stream behind `fs.watch` **starts asynchronously**. A `plugins.json` write landing in that startup window is **dropped forever, with no signal** — the watcher simply never fires.

Instrumentation showed `fs.watch` delivering **zero events in every failing run**. The falsifiable check: inserting a 250 ms delay before the write took 96 stressed runs from 7–9 failures to **0**. That confirms the window, rather than just correlating with it.

This matters beyond tests: **a `rove plugin install/link/enable` racing daemon startup would be silently ignored** until the next restart.

## The fix is correct by construction, not by widening a window

A synchronous baseline `stat` is taken **before** the first registry load, then polled every 200 ms:

- a write landing *before* the baseline is seen by the load itself
- a write landing *after* it flips the stamp and triggers a reload

No write can fall between the two. That's the property `fs.watch` never had here.

Per the brief this deliberately avoids "add a sleep / raise the timeout / retry" — the same discipline that turned PR #568's "CI flake" into a genuine concurrency defect.

## Verification

I ran my own before/after rather than relying on the report:

- **24 rounds of the sample test**: unfixed → 1 failure; fixed → **0**.
- **8 full `test:fast` runs on the fixed branch**: 7 fully green, 1 showing 2 failed.

**So this is a real improvement but not a total cure.** Before the fix I was seeing a failure roughly every third full run tonight; now it's roughly 1 in 8, and the residual failures did not reproduce often enough in this session to name. Issue #61 should stay open for the remainder rather than be closed on this PR.

## Related, deliberately untouched

The worker flags that `file-watch-trigger.ts` (issue #3's flake) and the filetree pane use the **same `fs.watch` pattern** and are therefore in the same bug class. Not changed here — that's a separate scope call.

`test:fast` green on repeat runs, lint and typecheck clean. `docs/design/plugins.md` updated in the same change.