### PR TITLE
test: un-pin four assertions that guarded the wrong thing

### DIFF
--- a/.changeset/test-pinning-audit.md
+++ b/.changeset/test-pinning-audit.md
@@ -1,0 +1,18 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Un-pin four test assertions that guarded the wrong thing.
+
+A targeted audit after PR #585/#594 found more assertions protecting what
+they should prevent. The release-guidance ordering check used bare `indexOf`
+with no presence guard, so deleting the canonical `npm view` line turned it
+green (-1 < anything); it now asserts presence before order. The daemon
+`@types/node` check pinned the literal `25.6.2`, turning every routine bump
+red — it now asserts lockstep with the kobe package's own pin. Two kobe-web
+tests (`ptyEnv`, api-client headers) used whole-object equality where the
+intent was removals-plus-additions and one required header, so any harmless
+new env var or request header broke them. Every relaxation was re-proven:
+deleting the guarded behavior still fails each test. The full audit report
+(including implementation bugs pinned by tests, left for follow-up) lives in
+`.scratch/test-pinning-audit.md`.

--- a/packages/kobe-web/test/api-client.test.ts
+++ b/packages/kobe-web/test/api-client.test.ts
@@ -22,7 +22,9 @@ describe("api client", () => {
     await expect(api.post("/api/rpc", { name: "task.list" })).resolves.toEqual({ ok: true })
     expect(seen?.url).toBe("/api/rpc")
     expect(seen?.init?.method).toBe("POST")
-    expect(seen?.init?.headers).toEqual({ "content-type": "application/json" })
+    // Assert the header that matters, not the whole object — an added accept
+    // or request-id header is not a regression.
+    expect(seen?.init?.headers).toMatchObject({ "content-type": "application/json" })
     expect(JSON.parse(seen?.init?.body as string)).toEqual({ name: "task.list" })
   })
 

--- a/packages/kobe-web/test/pty-env.test.ts
+++ b/packages/kobe-web/test/pty-env.test.ts
@@ -10,7 +10,13 @@ describe("ptyEnv", () => {
       TERM: "xterm-256color",
     }
 
-    expect(ptyEnv(base)).toEqual({
+    // The contract is removals + additions, per the test name — not the exact
+    // key set, which turns every new passthrough var into a red.
+    const env = ptyEnv(base)
+    expect(env).not.toHaveProperty("NO_COLOR")
+    expect(env).not.toHaveProperty("TERM_PROGRAM")
+    expect(env).not.toHaveProperty("TERM_PROGRAM_VERSION")
+    expect(env).toMatchObject({
       TERM: "xterm-256color",
       CLICOLOR: "1",
       COLORTERM: "truecolor",

--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -126,8 +126,13 @@ describe("Rove package distribution", () => {
 
   test("daemon typechecking does not rely on the renamed package's hoisted dependencies", () => {
     const daemon = json<{ devDependencies: Record<string, string> }>("packages/kobe-daemon/package.json")
+    const kobe = json<{ devDependencies: Record<string, string> }>("packages/kobe/package.json")
 
-    expect(daemon.devDependencies["@types/node"]).toBe("25.6.2")
+    // The invariant is "daemon carries its OWN pin, in lockstep with kobe's" —
+    // not a specific version. A frozen literal turns every routine @types/node
+    // bump into an unrelated red.
+    expect(daemon.devDependencies["@types/node"]).toBeDefined()
+    expect(daemon.devDependencies["@types/node"]).toBe(kobe.devDependencies["@types/node"])
   })
 
   test("the plugin SDK workspace and daemon dependency use the canonical Rove package", () => {
@@ -290,9 +295,12 @@ describe("Rove package distribution", () => {
     expect(releaseSkill).toContain("# Release Rove")
     expect(releaseSkill).toContain('"@sma1lboy/rove": minor')
     expect(releaseSkill).not.toContain('"@sma1lboy/kobe": minor')
-    expect(releaseSkill.indexOf("npm view @sma1lboy/rove@<new-version>")).toBeLessThan(
-      releaseSkill.indexOf("npm view @sma1lboy/kobe@<new-version>"),
-    )
+    // indexOf returns -1 when absent, and -1 < anything — without the presence
+    // guards, deleting the canonical `npm view` line would turn this GREEN.
+    const canonicalView = releaseSkill.indexOf("npm view @sma1lboy/rove@<new-version>")
+    const aliasView = releaseSkill.indexOf("npm view @sma1lboy/kobe@<new-version>")
+    expect(canonicalView).toBeGreaterThanOrEqual(0)
+    expect(aliasView).toBeGreaterThan(canonicalView)
     expect(releaseSkill).toContain("npm view @sma1lboy/rove-plugin-sdk@<sdk-version>")
     expect(releaseSkill).toContain("npm view @sma1lboy/kobe-plugin-sdk@<sdk-version>")
     expect(releaseSkill).toContain("Every Rove release checks the SDK's current version")


### PR DESCRIPTION
A targeted sweep for tests that pin the *wrong* behavior, prompted by hitting two of them by accident within two hours (#585 pinned a formatting bug as `"1000.0k"`; #594 pinned a `<script>` tag verbatim so a legitimate `defer` went red).

**Not for merging tonight** — parked for review.

**The answer was: not just those two.** ~559 test files swept; full inventory in `.scratch/test-pinning-audit.md`.

## The worst one rewarded deleting what it guarded

```ts
expect(releaseSkill.indexOf("npm view @sma1lboy/rove@<new-version>")).toBeLessThan(
  releaseSkill.indexOf("npm view @sma1lboy/kobe@<new-version>"))
```

`indexOf` returns `-1` when absent, and `-1 < anything`. **Delete the canonical `npm view` line from the release skill and this assertion turns green.** A guard that passes precisely when the thing it guards disappears.

I verified both directions rather than taking it on faith — same sabotage (canonical line removed):

- **old assertion → 19 passed** (silently green)
- **new assertion → 1 failed** (correctly red)

## The other three

- **`@types/node` pinned to a literal `"25.6.2"`** — the test's own name says the invariant is "the daemon carries its own pin", so every routine bump went red for an unrelated reason. Now asserts presence *and* lockstep with kobe's pin (version skew still fails; deleting either still fails).
- **`pty-env` / `api-client` whole-object `toEqual`** — any added env var or header, however harmless, broke them.

Each fix was self-proven the way #594 established: delete the guarded thing, confirm it still goes red.

## What was deliberately NOT touched

The sweep also found **8 places where the implementation is genuinely buggy and a test pins the bug** — the #585 shape, where fixing the code requires changing the test. Per the brief these were left alone and written up instead. The standout, which I confirmed by running it:

```
MON -> Mondays    TUE -> Tuedays    WED -> Weddays    THU -> Thudays
FRI -> Fridays    SAT -> Satdays    SUN -> Sundays
```

`describeCron` appends `"days"` to the 3-letter code, so **4 of 7 weekdays render as nonsense** — all reachable in the UI — and the test sampled `MON`, one of the three that accidentally reads correctly.

Also documented: markdown double-escaping `alt` attributes (screen readers get `&lt;img...`), a stray `!` artifact two tests guard, and `formatError` rendering objects as `[object Object]`.

`test:fast` 3479 passed, lint and typecheck clean.