### PR TITLE
fix: unpin five more bugs their tests had locked in (issue #62 remainder)

### DIFF
--- a/.changeset/five-pinned-bugs-unpinned.md
+++ b/.changeset/five-pinned-bugs-unpinned.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix five small bugs that tests had pinned in place: markdown link URLs now keep
+one level of balanced parens (`http://a.com/foo(bar)` links whole instead of
+truncating into a dead href), non-asset image syntax falls back to a safe link
+without leaving a stray `!` artifact, `parseDiffRows("")` returns an empty
+array instead of a phantom blank meta row, the doctor report's pty section
+header now names the real `pty.log` file (and both log headers share the tail
+count with the tail call), and `rove export --json` serializes `archived` as a
+real boolean so `jq 'select(.archived)'` works. Scheme allowlists, escaping,
+and the issue-asset image gate are unchanged and re-verified against XSS
+payloads.

--- a/packages/kobe-web/src/lib/diff-rows.ts
+++ b/packages/kobe-web/src/lib/diff-rows.ts
@@ -49,7 +49,11 @@ export function diffStat(patch: string): { added: number; deleted: number } {
 }
 
 export function parseDiffRows(patch: string): DiffRow[] {
-  const lines = patch.replace(/\n$/, "").split("\n")
+  const body = patch.replace(/\n$/, "")
+  // An empty patch has no rows — without this, "".split("\n") is [""] and the
+  // view would render a phantom empty meta line.
+  if (body === "") return []
+  const lines = body.split("\n")
   const rows: DiffRow[] = []
   let oldLn = 0
   let newLn = 0

--- a/packages/kobe-web/src/lib/markdown.ts
+++ b/packages/kobe-web/src/lib/markdown.ts
@@ -51,37 +51,53 @@ function safeHref(raw: string): string | null {
   return null
 }
 
+/**
+ * URL part of `[…](url)` / `![…](url)`: anything but parens, plus ONE level of
+ * balanced `(…)` (CommonMark-style), so `http://a.com/foo(bar)` stays whole
+ * instead of truncating at the first `)`. The alternation's branches start on
+ * disjoint characters, so it can't backtrack quadratically.
+ */
+const SPAN_URL = /(?:[^()]|\([^()]*\))+/.source
+const IMAGE_SPAN_RE = new RegExp(`!\\[([^\\]]*)\\]\\((${SPAN_URL})\\)`, "g")
+const LINK_SPAN_RE = new RegExp(`\\[([^\\]]+)\\]\\((${SPAN_URL})\\)`, "g")
+
+/**
+ * Render `[text](url)` (already-escaped fragment) as an anchor when the scheme
+ * is safe, else inert text. Shared by the link pass and the non-asset image
+ * fallback. The url was HTML-escaped (e.g. &amp;); unescape &amp; for the
+ * scheme check, then re-escape, so it's HTML-safe inside the href attribute.
+ */
+function renderLinkSpan(text: string, url: string): string {
+  const href = safeHref(url.replace(/&amp;/g, "&"))
+  if (!href) return `${text}(${url})`
+  return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer" class="kobe-md-link">${text}</a>`
+}
+
 /** Image/link/bold/italic on a NON-code, already-escaped fragment. */
 function transformSpans(s: string): string {
   let out = s
   // ![alt](src): MUST run before the link rule (`![…]` is a superset of `[…]`),
   // else the link pass would eat the `[…](…)` and leave a stray `!`. Only the
-  // bridge's own issue-asset route renders as an <img>; anything else falls
-  // back to escaped text. Gated on `]`/`)` for the same backtracking reason.
+  // bridge's own issue-asset route renders as an <img>; a non-asset url falls
+  // back to the same safe-link rendering as `[alt](url)` (no `!` artifact),
+  // and an empty alt stays literal text. Gated on `]`/`)` cheaply.
   if (out.includes("]") && out.includes(")")) {
     out = out.replace(
-      /!\[([^\]]*)\]\(([^)]+)\)/g,
+      IMAGE_SPAN_RE,
       (_m, alt: string, url: string) => {
         // The url was HTML-escaped; unescape &amp; before the route check.
         const src = safeImageSrc(url.replace(/&amp;/g, "&"))
-        if (!src) return `![${alt}](${url})`
+        if (!src) return alt ? renderLinkSpan(alt, url) : `![${alt}](${url})`
         return `<img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}" loading="lazy" class="kobe-md-img">`
       },
     )
   }
   // [text](url): url is from escaped text; validate scheme, drop unsafe.
-  // Skip the link regex when there's no `]`/`(` to match: its `[^\]]+`/`[^)]+`
-  // classes backtrack quadratically on a long run of unmatched `[`.
+  // Skip the link regex when there's no `]`/`(` to match: its `[^\]]+` class
+  // backtracks quadratically on a long run of unmatched `[`.
   if (out.includes("]") && out.includes(")")) {
-    out = out.replace(
-      /\[([^\]]+)\]\(([^)]+)\)/g,
-      (_m, text: string, url: string) => {
-        // The url was HTML-escaped (e.g. &amp;); unescape &amp; for the scheme
-        // check, then re-escape, so it's HTML-safe inside the href attribute.
-        const href = safeHref(url.replace(/&amp;/g, "&"))
-        if (!href) return `${text}(${url})`
-        return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer" class="kobe-md-link">${text}</a>`
-      },
+    out = out.replace(LINK_SPAN_RE, (_m, text: string, url: string) =>
+      renderLinkSpan(text, url),
     )
   }
   // Bold is non-greedy so `**bold *italic* more**` keeps the inner `*…*` for

--- a/packages/kobe-web/test/diff-rows.test.ts
+++ b/packages/kobe-web/test/diff-rows.test.ts
@@ -72,7 +72,7 @@ describe("parseDiffRows", () => {
   })
 
   it("returns an empty array for an empty patch", () => {
-    expect(parseDiffRows("")).toEqual([{ kind: "meta", oldLn: null, newLn: null, text: "" }])
+    expect(parseDiffRows("")).toEqual([])
   })
 
   it("resets hunk state at a new file header (concatenated patch)", () => {

--- a/packages/kobe-web/test/markdown-hardening.test.ts
+++ b/packages/kobe-web/test/markdown-hardening.test.ts
@@ -42,12 +42,13 @@ describe("renderMarkdown — link scheme hardening", () => {
 })
 
 describe("renderMarkdown — no image/raw-markup vectors", () => {
-  it("does NOT emit an <img> for image syntax (the ! survives as text)", () => {
+  it("does NOT emit an <img> for a non-asset image url (falls back to a link)", () => {
     const out = renderMarkdown("![alt](https://x.com/i.png)")
     expect(out).not.toContain("<img")
-    // Current behavior: the link pass turns the [alt](url) into an anchor and
-    // leaves the leading ! as literal text — never a raw image element.
-    expect(out).toContain("!<a ")
+    // The image pass itself renders the fallback as a safe anchor (alt as the
+    // text) — never a raw image element, and no stray `!` left behind.
+    expect(out).toContain("<a ")
+    expect(out).not.toContain("!<a ")
   })
 
   it("escapes an onerror payload smuggled through image alt text", () => {

--- a/packages/kobe-web/test/markdown-xss.test.ts
+++ b/packages/kobe-web/test/markdown-xss.test.ts
@@ -42,11 +42,11 @@ describe("renderMarkdown — structural inertness", () => {
     expect(out).toContain("[](http://a.com)")
   })
 
-  it("truncates a URL at the first ) without breaking out of the href", () => {
-    // The link regex stops the URL at the first ), so the tail becomes text —
-    // the anchor that IS produced still carries a valid, escaped href.
+  it("keeps balanced parens in the URL without breaking out of the href", () => {
+    // CommonMark-style: one level of balanced (…) belongs to the URL, so the
+    // href stays whole (a working link) and still escaped inside the attribute.
     const out = renderMarkdown("[x](http://a.com/foo(bar))")
-    expect(out).toContain('href="http://a.com/foo(bar"')
+    expect(out).toContain('href="http://a.com/foo(bar)"')
     expect(out).not.toContain("javascript")
     // no unescaped attribute break-out
     expect(out).not.toMatch(/href="[^"]*"[^>]*on\w+=/)

--- a/packages/kobe-web/test/markdown.test.ts
+++ b/packages/kobe-web/test/markdown.test.ts
@@ -69,13 +69,15 @@ describe("renderMarkdown — image rule (issue-asset urls only)", () => {
     expect(out).toContain('alt="&amp;lt;img onerror=1&amp;gt;"')
   })
 
-  it("falls back to inert text for a NON-asset image url (no <img>)", () => {
+  it("falls back to a plain link for a NON-asset image url (no <img>, no stray !)", () => {
     const out = renderMarkdown("![alt](https://evil.example.com/i.png)")
     expect(out).not.toContain("<img")
-    // The `[alt](url)` survives the image pass and is picked up by the link
-    // rule (safe http href), so the worst case is a plain anchor — never an
-    // off-site <img> fetch / tracking pixel.
-    expect(out).toContain("!<a ")
+    // The image pass renders the fallback itself as a safe anchor with the alt
+    // as text — never an off-site <img> fetch / tracking pixel, and no `!`
+    // artifact left in front of the link.
+    expect(out).toContain('href="https://evil.example.com/i.png"')
+    expect(out).toContain(">alt</a>")
+    expect(out).not.toContain("!<a ")
   })
 
   it("falls back to inert ESCAPED text for an image with an unsafe scheme (no <img>, no XSS)", () => {

--- a/packages/kobe/src/cli/doctor-report.ts
+++ b/packages/kobe/src/cli/doctor-report.ts
@@ -23,6 +23,9 @@ const REPORT_ENV_KEYS = [
   "EDITOR",
 ] as const
 
+/** How many trailing log lines each log section carries (also named in its header). */
+const LOG_TAIL_LINES = 200
+
 function logTail(path: string, count: number): string {
   try {
     return readFileSync(path, "utf8")
@@ -57,10 +60,12 @@ export function buildReportBundle(
     "## environment",
     ...reportEnvLines(parts.env),
     "",
-    "## daemon.log (last 200 lines)",
+    `## daemon.log (last ${LOG_TAIL_LINES} lines)`,
     parts.daemonLog || "(empty or absent)",
     "",
-    "## pty-host.log (last 200 lines)",
+    // Section header must match the real file name (<home>/.rove/pty.log) so a
+    // bug-report reader can find the log the tail came from.
+    `## pty.log (last ${LOG_TAIL_LINES} lines)`,
     parts.ptyLog || "(empty or absent)",
     "",
   ].join("\n")
@@ -74,8 +79,8 @@ export function writeReportBundle(doctorLines: readonly string[]): string {
     buildReportBundle(doctorLines, {
       generatedAt: new Date().toISOString(),
       env: process.env,
-      daemonLog: logTail(defaultDaemonLogPath(), 200),
-      ptyLog: logTail(defaultPtyHostLogPath(), 200),
+      daemonLog: logTail(defaultDaemonLogPath(), LOG_TAIL_LINES),
+      ptyLog: logTail(defaultPtyHostLogPath(), LOG_TAIL_LINES),
     }),
   )
   return path

--- a/packages/kobe/src/cli/export-cmd.ts
+++ b/packages/kobe/src/cli/export-cmd.ts
@@ -123,8 +123,16 @@ function renderTable(rows: readonly Record<Column, string>[]): string {
 
 /** Build the export text for a given format (exported for unit tests). */
 export function renderExport(tasks: readonly Task[], format: ExportFormat): string {
+  // JSON keeps `archived` a real boolean (`jq 'select(.archived)'` must work);
+  // the stringified flattening is only for the CSV/table cell shapes.
+  if (format === "json") {
+    return JSON.stringify(
+      tasks.map((t) => ({ ...toRow(t), archived: t.archived })),
+      null,
+      2,
+    )
+  }
   const rows = tasks.map(toRow)
-  if (format === "json") return JSON.stringify(rows, null, 2)
   if (format === "csv") return renderCsv(rows)
   return renderTable(rows)
 }

--- a/packages/kobe/test/cli/doctor-report.test.ts
+++ b/packages/kobe/test/cli/doctor-report.test.ts
@@ -17,7 +17,9 @@ describe("buildReportBundle", () => {
 
   it("includes log tails, falling back when a log is empty", () => {
     expect(bundle).toContain("daemon line")
-    expect(bundle).toContain("## pty-host.log (last 200 lines)\n(empty or absent)")
+    // Header must name the real log file (<home>/.rove/pty.log, pinned by
+    // paths.test.ts) so the bundle points readers at a file that exists.
+    expect(bundle).toContain("## pty.log (last 200 lines)\n(empty or absent)")
   })
 
   it("captures ROVE_*, KOBE_* + known env keys but never arbitrary secrets", () => {

--- a/packages/kobe/test/cli/export-cmd.test.ts
+++ b/packages/kobe/test/cli/export-cmd.test.ts
@@ -27,7 +27,7 @@ describe("renderExport", () => {
       id: "01HZ0000000000000000000001",
       title: "Fix the thing",
       status: "in_progress",
-      archived: "false",
+      archived: false,
       vendor: "claude",
       branch: "kobe/fix-thing-01",
       repo: "/home/u/repo",


### PR DESCRIPTION
Closes the rest of rove issue #62 — the bugs the test suite was holding in place. (#596 did the first three.)

**Not for merging tonight** — parked for review.

## The five

- **Markdown link regex truncated balanced parens** — `[x](http://a.com/foo(bar))` produced a dead `href="…/foo(bar"`. Now supports one level of CommonMark-style balanced parens.
- **Stray `!` artifact** on the non-asset image fallback, which *two* tests guarded via `toContain("!<a ")`. Also renamed `markdown-hardening`'s "does NOT emit an `<img>`" test, whose name had become false.
- **`parseDiffRows("")` returned a ghost meta row** — the test was named "returns an empty array" while pinning a one-element array. `DiffView` rendered that phantom. Now returns `[]`.
- **doctor's report header named a file that doesn't exist** — `## pty-host.log` while it actually tails `<home>/.rove/pty.log`, sending whoever reads a bug bundle hunting for the wrong file. The line count now comes from the same constant as the call site instead of being hardcoded twice.
- **`export --json` serialized `archived` as the string `"false"`** — any downstream `if (task.archived)` was permanently true. JSON now emits a real boolean; CSV/table cells stay strings, which they must.

## Verification of the security-sensitive part

Two of these change regexes in the **XSS boundary file**, so I attacked it rather than reading the reasoning:

| payload | result |
|---|---|
| `javascript:alert(1)` | inert text |
| `javascript&amp;colon;…` (entity smuggle) | inert text |
| `data:text/html,<script>…` | inert, escaped |
| `vbscript:msgbox(1)` | inert text |
| `java&#115;cript:` | inert text |
| `http://a.com/foo(bar)` | **correctly linked, parens intact** |

One payload tripped my own detector — a quote-break attempt — until I compared it against `main` and found **byte-identical escaping** (`&amp;quot;`, attribute never broken). My regex was over-eager; the behavior is unchanged. `safeHref` and the re-escape into the attribute are both intact — the fix teaches the regex to balance parens, it does not relax any escaping or the scheme allowlist.

Each fix self-proven by reverting the implementation: the markdown pair goes red (2 failures) against the old code.

`test:fast` 3479 passed, kobe-web green, lint and typecheck clean.

*(Built on `0.8.197` — a release landed on `main` mid-session.)*