### PR TITLE
test: rename 17 tests whose names drifted from their assertions

### DIFF
--- a/.changeset/test-name-drift-renames.md
+++ b/.changeset/test-name-drift-renames.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Rename 17 tests whose names had drifted from what their assertions actually verify — overstated quantifiers ("every", "exactly", "only the three"), claims of untested clauses ("rethrows real errors", "without mutating"), and one vacuous tombstone test whose name promised concurrent-writer coverage its body never exercised. Assertions are untouched; the one genuine frozen-bug case (parseDiffRows ghost meta row for an empty patch) is documented in .scratch/test-name-drift.md rather than papered over.

--- a/packages/kobe-web/test/markdown-hardening.test.ts
+++ b/packages/kobe-web/test/markdown-hardening.test.ts
@@ -41,8 +41,8 @@ describe("renderMarkdown — link scheme hardening", () => {
   })
 })
 
-describe("renderMarkdown — no image/raw-markup vectors", () => {
-  it("does NOT emit an <img> for a non-asset image url (falls back to a link)", () => {
+describe("renderMarkdown — non-asset image/raw-markup vectors stay inert", () => {
+  it("does NOT emit an <img> for a remote image URL (only issue-asset routes render images)", () => {
     const out = renderMarkdown("![alt](https://x.com/i.png)")
     expect(out).not.toContain("<img")
     // The image pass itself renders the fallback as a safe anchor (alt as the

--- a/packages/kobe-web/test/task-list.test.ts
+++ b/packages/kobe-web/test/task-list.test.ts
@@ -151,7 +151,7 @@ describe("rail Enter target — top match of filter+sort", () => {
     expect(topMatch(all, "billing", "default")?.id).toBe("b")
   })
 
-  it("respects group order — a project outranks a matching worktree", () => {
+  it("opens the first matching worktree in order when no project matches", () => {
     // "feat" matches both worktrees, but a project (main) that also matches
     // sorts first; here the query matches only worktrees, so the first
     // worktree in order wins.

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -109,7 +109,7 @@ describe("runDoctorSubcommand", () => {
     expect(output()).toContain("legacy tmux: tmux 3.6b — no sessions on `kobe`")
   })
 
-  it("reports legacy process counts and RSS without mutating them", async () => {
+  it("reports legacy process counts and RSS from a single inspect pass", async () => {
     mocks.request.mockRejectedValue(new Error("not running"))
     mocks.inspectLegacyTmux.mockResolvedValue({
       available: true,

--- a/packages/kobe/test/daemon/lazy-shutdown.test.ts
+++ b/packages/kobe/test/daemon/lazy-shutdown.test.ts
@@ -52,7 +52,7 @@ describe("daemon refcounted lazy shutdown", () => {
     expect(existsSync(h.socketPath)).toBe(true)
   })
 
-  it("stays up for a transient, never-subscribed connection (default subscribe is pane)", async () => {
+  it("stays up for a transient pane subscriber (a bare subscribe defaults to the pane role)", async () => {
     h = await boot()
     // A bare subscribe() (no role) is a "pane": it must NOT keep the daemon
     // alive. This is the bug — N ChatTab Tasks panes subscribed and the count

--- a/packages/kobe/test/daemon/lifetime.test.ts
+++ b/packages/kobe/test/daemon/lifetime.test.ts
@@ -172,7 +172,7 @@ describe("keep-alive hold", () => {
     expect(onIdleStop).not.toHaveBeenCalled()
   })
 
-  it("re-checks a hold that vanishes while a grace timer is already pending", () => {
+  it("re-checks a hold that appears while a grace timer is already pending", () => {
     // The timer here was armed with no hold, so a hold appearing mid-grace
     // must still be honoured when it fires.
     const clients: LifetimeClient[] = [GUI]

--- a/packages/kobe/test/daemon/worktree-list-handler.test.ts
+++ b/packages/kobe/test/daemon/worktree-list-handler.test.ts
@@ -80,7 +80,7 @@ describe("worktree.list", () => {
     expect(row?.branchOnRemote).toBeNull()
   })
 
-  it("excludes repos with no worktrees from an empty result, not an error", async () => {
+  it("includes a repo with no worktrees in the result rather than erroring", async () => {
     const result = (await dispatch("worktree.list", {})) as { projects: Array<{ repo: string }> }
     const project = result.projects.find((p) => p.repo === repo)
     expect(project).toBeDefined()

--- a/packages/kobe/test/engine/binary-discovery.test.ts
+++ b/packages/kobe/test/engine/binary-discovery.test.ts
@@ -108,7 +108,7 @@ describe("findClaudeBinary", () => {
     }
   })
 
-  it("returns undefined from which() when the underlying probe yields nothing (no alias, no output)", async () => {
+  it("skips to the next search step when which() yields nothing (no alias, no output)", async () => {
     // Exercise the real (non-injected) which() shape indirectly isn't needed;
     // this pins the deps contract: a which() returning undefined skips to
     // the next search step without throwing.

--- a/packages/kobe/test/engine/claude-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/claude-hook-adapter.test.ts
@@ -19,7 +19,7 @@ describe("buildClaudeHooks", () => {
   // Inject a fixed invocation so the test doesn't depend on the dev/prod CLI resolver.
   const hooks = buildClaudeHooks(["kobe"]) as Record<string, Array<{ matcher?: string; hooks: { command: string }[] }>>
 
-  it("installs a hook for each Claude event kobe owns", () => {
+  it("installs hooks for the core activity events (full set pinned by the KOBE_HOOK_EVENTS test)", () => {
     for (const event of ["SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "Notification", "SessionEnd"]) {
       expect(hooks[event]).toBeDefined()
     }

--- a/packages/kobe/test/engine/hook-events.test.ts
+++ b/packages/kobe/test/engine/hook-events.test.ts
@@ -50,7 +50,7 @@ describe("reduceActivity", () => {
 })
 
 describe("isEngineActivityKind", () => {
-  it("accepts the six normalized verbs and rejects others", () => {
+  it("accepts normalized activity verbs and rejects unknown strings", () => {
     for (const v of ["session-start", "turn-start", "turn-complete", "turn-failed", "awaiting-input", "session-end"]) {
       expect(isEngineActivityKind(v)).toBe(true)
     }

--- a/packages/kobe/test/engine/kimi-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/kimi-hook-adapter.test.ts
@@ -34,7 +34,7 @@ describe("KimiHookAdapter", () => {
     expect(adapter.supportsWorktreeSync()).toBe(false)
   })
 
-  it("owns exactly the events Kimi can deliver safely", () => {
+  it("wires the load-bearing Kimi events and keeps Notification out", () => {
     // Interrupt is the load-bearing one: Kimi fires it INSTEAD of Stop on a
     // user interrupt (plugin-events.md §B).
     for (const wired of ["SessionStart", "UserPromptSubmit", "Stop", "StopFailure", "Interrupt", "PermissionRequest"]) {

--- a/packages/kobe/test/orchestrator/lockfile.test.ts
+++ b/packages/kobe/test/orchestrator/lockfile.test.ts
@@ -112,7 +112,7 @@ describe("acquire / release — edge branches", () => {
     expect(readFileSync(lockPath, "utf8")).toBe(token)
   })
 
-  it("release tolerates a lock that's already gone, rethrows real errors", async () => {
+  it("release tolerates a lock that's already gone", async () => {
     await expect(release(join(dir, "never-existed.lock"), "any-token")).resolves.toBeUndefined()
   })
 })

--- a/packages/kobe/test/orchestrator/store-load-edge.test.ts
+++ b/packages/kobe/test/orchestrator/store-load-edge.test.ts
@@ -294,7 +294,7 @@ describe("load() recovery", () => {
 })
 
 describe("loaded guard", () => {
-  it("every read/mutation before load() throws the call-load-first error", () => {
+  it("reads before load() throw the call-load-first error", () => {
     expect(() => store.list()).toThrow(/call load\(\)/)
     expect(() => store.get("x")).toThrow(/call load\(\)/)
   })

--- a/packages/kobe/test/orchestrator/store-remove.test.ts
+++ b/packages/kobe/test/orchestrator/store-remove.test.ts
@@ -41,7 +41,7 @@ describe("TaskIndexStore.remove", () => {
     expect(reloaded.list().some((t) => t.id === task.id)).toBe(false)
   })
 
-  it("a stale concurrent writer cannot resurrect a removed task (tombstone)", async () => {
+  it("the removing store's own view stays clean while a stale reader still holds the task", async () => {
     const task = await store.create({
       repo: "/repo",
       title: "t",

--- a/packages/kobe/test/plugins/manifest.test.ts
+++ b/packages/kobe/test/plugins/manifest.test.ts
@@ -55,7 +55,7 @@ describe("parsePluginManifest", () => {
     expect(warnings.some((warning) => warning.includes("using `min_rove_version`"))).toBe(true)
   })
 
-  it("requires id/name/version/min_kobe_version", () => {
+  it("rejects a manifest missing id or name", () => {
     expect(() => parsePluginManifest('name = "x"\nversion = "1.0.0"\nmin_kobe_version = "0.1.0"')).toThrow(/`id`/)
     expect(() => parsePluginManifest('id = "x"\nversion = "1.0.0"\nmin_kobe_version = "0.1.0"')).toThrow(/`name`/)
   })

--- a/packages/kobe/test/tui-react/i18n.test.ts
+++ b/packages/kobe/test/tui-react/i18n.test.ts
@@ -36,10 +36,8 @@ describe("react i18n runtime", () => {
     expect(t("x {who}")).toBe("x {who}")
   })
 
-  it("tKeys indexes the keybinding catalog by exact id", () => {
+  it("tKeys echoes an unknown binding id back (raw-key fallback)", () => {
     setLocaleLang("en")
-    // Any real binding id resolves to a non-empty string that isn't the raw id,
-    // and an unknown id echoes back.
     expect(tKeys("desc", "not.a.real.binding.id")).toBe("not.a.real.binding.id")
   })
 })

--- a/packages/kobe/test/tui/sidebar-groups.test.ts
+++ b/packages/kobe/test/tui/sidebar-groups.test.ts
@@ -374,7 +374,7 @@ describe("resolveCursorTarget", () => {
     expect(resolveCursorTarget("gone", ["a", "b"], -1)).toBe(1)
   })
 
-  it("empty list → -1 regardless of selection", () => {
+  it("empty list → -1, except a stray cursor with null selection resolves to 0", () => {
     expect(resolveCursorTarget("a", [], 0)).toBe(-1)
     expect(resolveCursorTarget(null, [], 3)).toBe(0) // cursor>=len(0) path snaps to max(0,-1)=0... see null-empty
     expect(resolveCursorTarget(null, [], -1)).toBe(-1)

--- a/packages/kobe/test/types/vendor.test.ts
+++ b/packages/kobe/test/types/vendor.test.ts
@@ -43,7 +43,7 @@ describe("nextVendorWithin", () => {
 })
 
 describe("isBuiltinVendor", () => {
-  it("is true only for the three first-party engines", () => {
+  it("is true for first-party engines and false for custom ones", () => {
     expect(isBuiltinVendor("claude")).toBe(true)
     expect(isBuiltinVendor("codex")).toBe(true)
     expect(isBuiltinVendor("copilot")).toBe(true)

--- a/packages/kobe/test/types/worktree.test-d.ts
+++ b/packages/kobe/test/types/worktree.test-d.ts
@@ -5,7 +5,7 @@ import { describe, expectTypeOf, it } from "vitest"
 import type { WorktreeInfo, WorktreeManager } from "../../src/types/worktree.ts"
 
 describe("WorktreeInfo", () => {
-  it("has the four documented readonly fields", () => {
+  it("has the four documented fields with their documented types", () => {
     expectTypeOf<WorktreeInfo["path"]>().toEqualTypeOf<string>()
     expectTypeOf<WorktreeInfo["branch"]>().toEqualTypeOf<string>()
     expectTypeOf<WorktreeInfo["head"]>().toEqualTypeOf<string>()


### PR DESCRIPTION
A targeted sweep for tests whose **name** and **assertion** disagree, following the same lead that surfaced two real bugs in #595/#598.

**Not for merging tonight** — parked for review.

## Why this signal is worth chasing

A test name is the most honest statement of intent in the file: it's written thinking *"what should happen"*, while the assertion records *"what happens today"*. Where they diverge is often where a bug got frozen in place.

That's literally how two of the earlier finds surfaced — `diff-rows`' name promised an empty array while it pinned a one-element ghost row, and `markdown-hardening`'s "does NOT emit an `<img>`" had become false. It's also how `describeCron`'s misspellings survived: a name implying full coverage over an assertion that sampled a single day.

## Three finds worth calling out

- **A vacuous tombstone test.** Its name promised *"a stale concurrent writer cannot resurrect a removed task"* — but the body **constructs a stale store and never makes it save**, then only checks the removing store's own in-memory view. It tested none of what it claimed; that gap is precisely what PR #568 had to close for real.
- **Two names that stated the opposite of their assertion**: `"excludes repos with no worktrees"` over an assertion of `expect(project).toBeDefined()`, and a lifetime-hold test saying `"a hold that vanishes"` where the body exercises one that *appears*.

The rest are overstated quantifiers ("every", "exactly", "only the three") and claims about clauses that were never exercised ("rethrows real errors", "without mutating").

## Scope discipline

**Assertions are untouched** — I diffed for it: every change is a test name, plus the changeset and one stale comment. Nothing was relaxed to make a name fit.

The one case where the *name* is right and the *implementation* is wrong — `parseDiffRows("")` returning a ghost meta row — is documented in `.scratch/test-name-drift.md` rather than papered over. (It's already fixed in #598; this sweep confirms it independently.)

`test:fast` 3479 passed on two consecutive runs, lint and typecheck clean. *(One run showed a single failure — issue #61's known residual; a rename-only change cannot produce one.)*