### PR TITLE
test(plugins): pin the SDK examples to the manifest contract

### DIFF
--- a/.changeset/plugin-example-contract-test.md
+++ b/.changeset/plugin-example-contract-test.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Pin the plugin SDK examples to the manifest contract. Every example is now parsed by the real `rove-plugin.toml` parser, checked for a misspelled event name or unsupported pane placement, and required to ship the entrypoint files its commands name — the examples are also inside the SDK's typecheck scope for the first time. Copying a broken example used to be silent; now it turns CI red.

--- a/packages/kobe-plugin-sdk/tsconfig.json
+++ b/packages/kobe-plugin-sdk/tsconfig.json
@@ -12,5 +12,5 @@
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "examples"]
 }

--- a/packages/kobe/test/plugins/example-plugins.test.ts
+++ b/packages/kobe/test/plugins/example-plugins.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The SDK examples are the first thing a plugin author copies, so a drifted
+ * manifest field or a renamed hook costs them their afternoon. Nothing else
+ * loads them: they are outside every runtime path and every other test.
+ *
+ * Discovery is by directory listing — a sixth example is covered the moment
+ * it lands, without editing this file.
+ */
+import { existsSync, readdirSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { readPluginManifest } from "@sma1lboy/kobe-daemon/plugins/manifest"
+import { describe, expect, it } from "vitest"
+
+const EXAMPLES_DIR = join(dirname(fileURLToPath(import.meta.url)), "../../../kobe-plugin-sdk/examples")
+
+const EXAMPLES = readdirSync(EXAMPLES_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort()
+
+/** Every declared command is argv, and every example launches its entrypoint
+ *  by relative path (`$ROVE_PLUGIN_ROOT/` prefixed or bare). */
+const SCRIPT_ARG_RE = /\.(ts|js|mjs|cjs|sh)$/
+
+function declaredScripts(command: readonly string[]): string[] {
+  return command
+    .slice(1)
+    .map((arg) => arg.replace(/^\$ROVE_PLUGIN_ROOT\//, ""))
+    .filter((arg) => SCRIPT_ARG_RE.test(arg))
+}
+
+describe("plugin SDK examples", () => {
+  it("finds the example directories", () => {
+    expect(EXAMPLES.length).toBeGreaterThan(0)
+  })
+
+  it.each(EXAMPLES)("%s parses through the real manifest parser", (name) => {
+    const { manifest, warnings } = readPluginManifest(join(EXAMPLES_DIR, name))
+
+    expect(manifest.id).toBe(`examples.${name}`)
+    // A misspelled event name, an unsupported pane placement and a stale
+    // version key are all warnings, not throws — an example that earns one
+    // still installs and then silently does nothing. The missing `platforms`
+    // note is deliberate: the examples run everywhere.
+    expect(warnings.filter((w) => !w.includes("`platforms`"))).toEqual([])
+  })
+
+  it.each(EXAMPLES)("%s ships every entrypoint it declares", (name) => {
+    const root = join(EXAMPLES_DIR, name)
+    const { manifest } = readPluginManifest(root)
+    const commands = [
+      ...manifest.build,
+      ...manifest.startup,
+      ...manifest.shutdown,
+      ...manifest.actions,
+      ...manifest.events,
+      ...manifest.panes,
+      ...manifest.engines,
+    ]
+
+    const missing = commands
+      .flatMap((spec) => declaredScripts(spec.command))
+      .filter((rel) => !existsSync(join(root, rel)))
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
The five SDK examples had **zero test coverage** — `grep examples/` across the whole test tree returned nothing.

**Not for merging tonight** — parked for review.

## Why this is a real gap

The examples are the first thing a plugin author copies, and `docs/PLUGIN-AUTHORING.md` links straight to them. When the SDK contract shifts — a manifest field renamed, a hook signature changed, an entrypoint moved — the examples go stale silently and **nothing turns red**. Someone then copies a broken example and loses the afternoon.

## What the test does

Auto-discovers every directory under `examples/` with `readdirSync` — **no hardcoded list of five**. Each example must parse through the *real* manifest parser, declare an id matching its directory, and ship every entrypoint it names. The SDK tsconfig now also brings `examples/` into typecheck.

Hardcoding the five names would have reproduced the exact bug that let `describeCron`'s misspellings ship: a check that covers only the cases someone remembered to list.

## Verification

**The examples are all currently valid** — nothing was broken, which is worth stating plainly since the more interesting outcome would have been finding rot.

I proved the guard bites rather than trusting it: dropped a sixth example with a bogus hook event and a missing entrypoint, and it was **caught immediately without touching the test** — 2 failures, both correct (`parses through the real manifest parser`, `ships every entrypoint it declares`). Removed the probe; 11 passed.

`test:fast` 3577 passed, lint and typecheck clean.