### PR TITLE
feat(api): collect reports per-task engine activity and round selection

### DIFF
--- a/.changeset/collect-round-health.md
+++ b/.changeset/collect-round-health.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api collect` answers "what is this parallel round's status right now" in one read. Select a whole fan-out round with `--group <groupId>` (spanning repos, skipping archived siblings) alongside the existing `--repo` and `--task-ids`. Each task now also reports `.activity` — the engine's state and how long it has held it, from the daemon's activity registry, or `null` when the registry genuinely cannot answer rather than a fabricated idle — and a dead tab's `.exit` now carries the session's output `tail` next to its exit code, so a crashed worker comes back with its cause attached.

--- a/docs/API.md
+++ b/docs/API.md
@@ -53,7 +53,8 @@ rove api read-output --task-id <id> --tab tab-3   # one exact tab's terminal
 **Fan in.** Compare the attempts, then land one:
 
 ```bash
-rove api collect --task-ids a,b,c      # read-only comparison snapshot
+rove api collect --group <groupId>     # the whole round's health, one read
+rove api collect --task-ids a,b,c      # or name the attempts yourself
 rove api land --task-id a              # merge the winning branch
 ```
 
@@ -121,11 +122,39 @@ replacement in `nextCommandArgs`.
   task, when one did: the lineage read for a parallel round's parent.
   `.task.command` = the raw launch command pinned on the task; `.task.vendor`
   = the protocol derived from it.
-- `collect [--task-ids a,b,c] [--repo PATH]`: read-only comparison
-  snapshot of several tasks: identity, branch, lineage (`.dispatcher`,
-  `.groupId`), `.running`, per-tab `.tabs` (the same join as `get-task`,
-  pick a `send --tab` target without a second hop), uncommitted `.changes`,
-  and committed `.base` (ahead count + diffstat vs base).
+- `collect [--task-ids a,b,c] [--group GROUPID] [--repo PATH]`: read-only
+  health snapshot of a parallel round — the one read that answers "what is
+  this round's status right now" without fanning out to `get-task` per task.
+  Select the tasks by fan-out round (`--group`, the `groupId` that
+  `add --count` returns), by repo, or by explicit ids; `--group` spans repos
+  and skips archived siblings.
+
+  Per task: identity, branch, lineage (`.dispatcher`, `.groupId`), plus
+
+  - `.running` — is an engine ALIVE, from the pty host's live session
+    inventory. This is process truth, not the cached status field `list`
+    reports, which lags and will happily call a working fleet idle.
+  - `.activity` — `{state, at, forMs}` from the daemon's activity registry:
+    the engine's state (`running` / `idle` / `permission_needed` /
+    `rate_limited` / `error` / `turn_complete`) and how long it has been in
+    it. `forMs` is the "stuck for 40 minutes" number. `null` when the
+    registry cannot answer (daemon restarted, task never observed) — an
+    honest unknown, never a fabricated idle. `.activity.state` disagreeing
+    with `.running` is itself the signal: `running: false` with a
+    `permission_needed` state is a worker that died at a prompt.
+  - `.tabs` — the same per-tab join as `get-task` (pick a `send --tab`
+    target without a second hop). A tab whose session died abnormally
+    carries `.exit` with `code`/`signal`/`at` **and** `tail`, the last lines
+    the session printed, so a crash comes back with its cause attached. The
+    tail rides along only when the durable record describes that same death.
+  - `.changes` — uncommitted files (`added`/`deleted`). Non-zero means the
+    task cannot land as-is, however it reported itself.
+  - `.base` — committed work: `ahead` (commits vs the base branch) and a
+    diffstat. `ahead: 0` against a resolved `baseRef` is the "reported
+    succeeded, committed nothing" tell.
+
+  Read-only by contract: it starts no engines, writes nothing, and changes
+  no task state.
 - `digest --repo PATH [--since-days N]`: the repo's recent agent work,
   tasks touched in the window plus routine outcomes by status. Default
   window 7 days. Task outcomes are deliberately absent: completion travels

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -11,11 +11,15 @@ import { DEFAULT_FEEDBACK_CATEGORY_SLUG, submitFeedback } from "../../lib/feedba
 import { daemonOf } from "./handler-helpers.ts"
 import { ApiError, type VerbContext } from "./types.ts"
 
+/** One entry of the daemon activity registry's task dump (`debug.inspect`). */
+type ActivityEntry = { state: string; at: number }
+
 export async function collect(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const { args, runtime } = ctx
   const idsFlag = args.str("task-ids")
   const repoFlag = args.path("repo")
+  const groupFlag = args.str("group")
 
   let taskIds: string[]
   if (idsFlag) {
@@ -23,16 +27,32 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean)
-  } else if (repoFlag) {
-    const target = await runtime.resolveRepoRoot(repoFlag)
+  } else if (repoFlag || groupFlag) {
+    const target = repoFlag ? await runtime.resolveRepoRoot(repoFlag) : null
     const { tasks } = await daemon.request<{ tasks: SerializedTask[] }>("task.list")
     taskIds = []
     for (const t of tasks) {
       if (t.archived) continue
-      if ((await runtime.resolveRepoRoot(t.repo)) === target) taskIds.push(t.id)
+      if (groupFlag && t.groupId !== groupFlag) continue
+      if (target !== null && (await runtime.resolveRepoRoot(t.repo)) !== target) continue
+      taskIds.push(t.id)
     }
   } else {
-    throw new ApiError("collect needs --task-ids id1,id2 or --repo PATH", "MISSING_TARGET")
+    throw new ApiError("collect needs --task-ids id1,id2, --group GROUPID, or --repo PATH", "MISSING_TARGET")
+  }
+
+  // The daemon's activity registry (one debug.inspect for the whole round) is
+  // the "how long has it been in this state" source: per-task engine state +
+  // the ms timestamp of its last transition. `null` = couldn't ask / no entry
+  // (daemon restarted, task never observed) — an honest unknown, never a
+  // fabricated "idle". Distinct from `running` (pty-host process truth):
+  // the two diverging IS the diagnostic signal.
+  let registry: Record<string, ActivityEntry> | null = null
+  try {
+    const dbg = await daemon.request<{ activity?: { tasks?: Record<string, ActivityEntry> } }>("debug.inspect")
+    registry = dbg?.activity?.tasks ?? {}
+  } catch {
+    registry = null
   }
 
   const out: unknown[] = []
@@ -49,6 +69,12 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
     const base = task.worktreePath
       ? await runtime.readBranchSignals(task.worktreePath)
       : { baseRef: null, ahead: null, diff: null }
+    const entry = registry?.[task.id]
+    // `forMs` = time in the CURRENT state ("idle for 40min" when state is
+    // idle). Clock skew between daemon and CLI clamps to 0, never negative.
+    const activity = entry
+      ? { state: entry.state, at: new Date(entry.at).toISOString(), forMs: Math.max(0, Date.now() - entry.at) }
+      : null
     out.push({
       taskId: task.id,
       title: task.title,
@@ -61,6 +87,7 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
       // round's parent is programmatically discoverable.
       ...(task.dispatcher ? { dispatcher: task.dispatcher } : {}),
       running,
+      activity,
       tabs,
       changes,
       base,

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -44,8 +44,10 @@ export interface TaskTabRow {
   readonly alive: boolean
   /** How the tab's session died — ABNORMAL exits only (clean exit 0 stays
    *  null, per issue #9's no-noise rule); null while alive/unknown. Joined
-   *  from the live host when present, else the durable exit records. */
-  readonly exit: PtySessionExit | null
+   *  from the live host when present, else the durable exit records —
+   *  `tail` (the exit-time output lines the durable record keeps) rides
+   *  along whenever the record describes the same death. */
+  readonly exit: (PtySessionExit & { tail?: readonly string[] }) | null
   /** Present (true) only on rows derived from a LIVE pty session the
    *  persisted snapshot does not list — issue #20's invisible engine. The
    *  snapshot is a record of intent; the pty host holds the truth, and a
@@ -122,11 +124,22 @@ export function joinTaskTabs(
   snapshot: TabsState | undefined,
   taskId: string,
   sessions: readonly TaskSessionRow[],
-  persistedExits: Readonly<Record<string, PtySessionExit>> = {},
+  persistedExits: Readonly<Record<string, PtySessionExit & { tail?: readonly string[] }>> = {},
   liveVendors?: ReadonlyMap<string, string | null>,
 ): TaskTabRow[] {
   const alive = aliveKeysOf(sessions)
   const sessionExits = new Map(sessions.map((s) => [s.key, s.exit]))
+  // Death cause + tail for one dead tab. The live host's in-memory exit wins
+  // (fresher when the key was reopened) but carries no output; the durable
+  // record has the exit-time tail — merge it in only when both describe the
+  // SAME death (`at` matches), so a stale record never captions a newer one.
+  const deadExit = (key: string): TaskTabRow["exit"] => {
+    const ex = abnormalExit(sessionExits.get(key) ?? persistedExits[key])
+    if (!ex) return null
+    const record = persistedExits[key]
+    const tail = record?.at === ex.at ? record.tail : undefined
+    return { code: ex.code, signal: ex.signal, at: ex.at, ...(tail && tail.length > 0 ? { tail } : {}) }
+  }
   const rows: TaskTabRow[] = (snapshot?.tabs ?? []).map((t) => {
     const key = `${taskId}::${t.id}`
     const isAlive = alive.has(key)
@@ -140,7 +153,7 @@ export function joinTaskTabs(
       lastTitle: t.lastTitle ?? null,
       autoTitle: t.autoTitle ?? null,
       alive: isAlive,
-      exit: isAlive ? null : abnormalExit(sessionExits.get(key) ?? persistedExits[key]),
+      exit: isAlive ? null : deadExit(key),
     }
   })
   // Live sessions the snapshot doesn't know still get a row — the discovery

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -34,9 +34,15 @@ export const READ_VERBS: readonly VerbSpec[] = [
   {
     name: "collect",
     summary:
-      "Read-only comparison snapshot of several tasks: identity, branch, lineage (.dispatcher, .groupId), .running, per-tab .tabs (same join as get-task — pick a `send --tab` target without a second hop), uncommitted .changes, and committed .base (ahead count + diffstat vs the base branch).",
+      "Read-only health snapshot of a parallel round: identity, branch, lineage (.dispatcher, .groupId), .running (pty-host process truth, not a cached status), .activity (daemon engine state + how long it has been in it, null when unknowable), per-tab .tabs with a dead tab's exit cause AND output tail, uncommitted .changes (non-zero = it cannot land), and committed .base (ahead count + diffstat — ahead:0 is the `succeeded but committed nothing` tell). Select with --group (one fan-out round), --repo, or --task-ids.",
     flags: [
       { name: "task-ids", type: "csv", placeholder: "a,b,c", description: "Comma-separated task ids." },
+      {
+        name: "group",
+        type: "string",
+        placeholder: "GROUPID",
+        description: "Every unarchived task of one fan-out round (the `groupId` that `add --count` returns).",
+      },
       F.repo(false),
     ],
     handler: collect,

--- a/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
+++ b/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
@@ -121,11 +121,82 @@ describe("collect handler", () => {
     expect(result.tasks.map((task) => task.taskId)).toEqual(["in-repo"])
   })
 
-  it("requires ids or repo", async () => {
+  it("requires ids, group, or repo", async () => {
     await expectApiError(
       () => invokeVerb("collect", [], { client: new FakeClient(), runtime: stubRuntime() }),
       "MISSING_TARGET",
     )
+  })
+
+  it("--group selects one fan-out round across repos, skipping archived siblings", async () => {
+    const client = new FakeClient({
+      "task.list": () => ({
+        tasks: [
+          taskFixture({ id: "sib-1", groupId: "g1" }),
+          taskFixture({ id: "sib-2", groupId: "g1", repo: "/repo/elsewhere" }),
+          taskFixture({ id: "dead-sib", groupId: "g1", archived: true }),
+          taskFixture({ id: "other-round", groupId: "g2" }),
+          taskFixture({ id: "no-group" }),
+        ],
+      }),
+      "task.get": (payload) => ({ task: taskFixture({ id: (payload as { taskId: string }).taskId }) }),
+    })
+    const result = (await invokeVerb("collect", ["--group", "g1"], {
+      client,
+      runtime: stubRuntime(),
+    })) as { tasks: Array<{ taskId: string }> }
+    expect(result.tasks.map((t) => t.taskId)).toEqual(["sib-1", "sib-2"])
+  })
+
+  it("reports engine state and how long it has held it, from the daemon activity registry", async () => {
+    const at = Date.now() - 90_000
+    const client = new FakeClient({
+      "debug.inspect": () => ({ activity: { tasks: { a: { state: "permission_needed", at } } } }),
+      "task.get": (payload) => ({ task: taskFixture({ id: (payload as { taskId: string }).taskId }) }),
+    })
+    const result = (await invokeVerb("collect", ["--task-ids", "a"], {
+      client,
+      runtime: stubRuntime(),
+    })) as { tasks: Array<{ activity: { state: string; at: string; forMs: number } | null }> }
+    const activity = result.tasks[0].activity
+    expect(activity?.state).toBe("permission_needed")
+    expect(activity?.at).toBe(new Date(at).toISOString())
+    // Stuck-for duration, not a bare timestamp — the coordinator's actual question.
+    expect(activity?.forMs).toBeGreaterThanOrEqual(90_000)
+  })
+
+  it("a task the registry has never seen reports activity null — an honest unknown, not a fake idle", async () => {
+    const client = new FakeClient({
+      "debug.inspect": () => ({ activity: { tasks: {} } }),
+      "task.get": () => ({ task: taskFixture({ id: "a" }) }),
+    })
+    const result = (await invokeVerb("collect", ["--task-ids", "a"], {
+      client,
+      runtime: stubRuntime(),
+    })) as { tasks: Array<{ activity: unknown }> }
+    expect(result.tasks[0].activity).toBeNull()
+  })
+
+  it("an unreachable registry degrades to activity null and still returns the git + pty truth", async () => {
+    // `running`/`changes`/`base` come from the pty host and git, not the
+    // daemon's registry — a daemon that just restarted must not blank them.
+    const client = new FakeClient({
+      "debug.inspect": () => {
+        throw new Error("no daemon")
+      },
+      "task.get": () => ({ task: taskFixture({ id: "a" }) }),
+    })
+    const result = (await invokeVerb("collect", ["--task-ids", "a"], {
+      client,
+      runtime: stubRuntime({
+        taskTabs: async () => ({ tabs: [], running: true }),
+        readBranchSignals: async () => ({ baseRef: "origin/main", ahead: 0, diff: null }),
+      }),
+    })) as { tasks: Array<{ activity: unknown; running: boolean; base: { ahead: number | null } }> }
+    expect(result.tasks[0].activity).toBeNull()
+    expect(result.tasks[0].running).toBe(true)
+    // ahead:0 with a resolved base is the "succeeded but committed nothing" tell.
+    expect(result.tasks[0].base.ahead).toBe(0)
   })
 })
 

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -355,4 +355,47 @@ describe("joinTaskTabs", () => {
     const rows = joinTaskTabs(oneTabSnap("tab-1"), "t1", [{ key: "t1::tab-1", alive: true }], { "t1::tab-1": stale })
     expect(rows[0]).toMatchObject({ alive: true, exit: null })
   })
+
+  it("a dead tab carries the durable record's output tail, so the cause is readable", () => {
+    const record = {
+      code: 1,
+      signal: null,
+      at: "2026-08-11T00:00:00.000Z",
+      tail: ["Error: ENOSPC: no space left on device", "  at write (node:fs)"],
+    }
+    const rows = joinTaskTabs(oneTabSnap("tab-1"), "t1", [], { "t1::tab-1": record })
+    expect(rows[0]?.exit).toEqual(record)
+  })
+
+  it("a stale record never captions a NEWER death — different `at`, no tail borrowed", () => {
+    // The key was reopened and died again: the host's fresh exit wins, and the
+    // previous incarnation's tail must not be attached to it as if it were the
+    // cause. Wrong output on a real death is worse than no output.
+    const fresh = { code: 137, signal: "SIGKILL", at: "2026-08-12T00:00:00.000Z" }
+    const older = { code: 1, signal: null, at: "2026-08-11T00:00:00.000Z", tail: ["from the PREVIOUS incarnation"] }
+    const rows = joinTaskTabs(oneTabSnap("tab-1"), "t1", [{ key: "t1::tab-1", alive: false, exit: fresh }], {
+      "t1::tab-1": older,
+    })
+    expect(rows[0]?.exit).toEqual(fresh)
+    expect(rows[0]?.exit).not.toHaveProperty("tail")
+  })
+
+  it("a snapshot claiming a live engine loses to the pty truth: dead reads dead, with its cause", () => {
+    // The round-health divergence (the reason `list`'s cached `running` lies):
+    // a mounted TUI recorded `liveVendor: claude` on this tab, then the engine
+    // crashed. The snapshot still SAYS an engine is there. Process truth must
+    // win on `alive`/`running`, and the exit cause must come back with it —
+    // a coordinator polling this must never be told the worker is still going.
+    const snap = {
+      tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, liveVendor: "claude" }],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    } as unknown as TabsState
+    const record = { code: 1, signal: null, at: "2026-08-11T00:00:00.000Z", tail: ["Fatal: engine exited"] }
+    const sessions = [{ key: "t1::tab-1", alive: false }]
+
+    const rows = joinTaskTabs(snap, "t1", sessions, { "t1::tab-1": record })
+    expect(rows[0]).toMatchObject({ id: "tab-1", alive: false, exit: record })
+    expect(hasLiveEngineTab(snap, "t1", sessions)).toBe(false)
+  })
 })


### PR DESCRIPTION
Extends `rove api collect` so a coordinator can answer *"what is this fan-out round actually doing right now?"* in one read.

**Not for merging tonight** — parked for review.

## Extended rather than adding a verb

The brief allowed a new `doctor-round` verb; the worker judged `collect` was already the right home (its `running` already comes from pty truth) and extended it instead. That's the better call — one read, no second surface to keep in sync.

What's new: `--group` to select a whole round, per-task `.activity` (engine state + how long it's been in it), and a dead tab's exit code with its output tail.

## Why this exists

Tonight I repeatedly needed the state of ~6 parallel workers and had to loop `get-task` per task, because **`rove api list`'s `running` is a stale snapshot** — it showed all six as idle while every one was mid-turn. Then, to know whether a worker had actually committed, I still had to `git log` each worktree by hand.

## Accuracy over prettiness

The constraint I set was that a diagnostic which *might lie* is worse than none — `list`'s stale `running` being the cautionary example. This respects it:

> `null` = couldn't ask / no entry — **not** a fabricated "idle". Distinct from `running` (pty-host process truth).

Two separate sources stay separate instead of being blended into one confident-looking field.

## Verified live

Ran it against a task that was genuinely mid-turn:

```json
"activity": { "state": "running", "at": "2026-08-27T20:04:50Z", "forMs": 449515 },
"running": true
```

Both agree, and `forMs` gives the stuck-duration that `get-task` never surfaced. `docs/API.md` updated in the same change.

`test:fast` 3573 passed, lint and typecheck clean.