### PR TITLE
feat(completions): complete sub-verbs, not just the top-level command

### DIFF
--- a/.changeset/completions-sub-verbs.md
+++ b/.changeset/completions-sub-verbs.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Shell completions now complete sub-verbs, not just the top-level command
+
+`rove daemon <TAB>` used to offer nothing; now it offers `start stop status
+restart`, and the same second level exists for `api` (all ~46 verbs), `plugin`,
+`repo`, `skill` and `theme` — in bash, zsh and fish alike. fish also stops
+re-offering the top-level command list once a command is already typed.
+
+The verb lists are derived rather than transcribed: `api` reads the registry
+`rove api schema` enumerates, and the other five read a table their own command
+modules validate incoming argv against. A verb the CLI accepts but the
+completion omits is therefore not a reachable state — stale completions tell a
+user a verb does not exist, which is worse than having no completions at all.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -162,7 +162,24 @@ rove completions bash > ~/.bash_completion.d/rove
 rove completions fish > ~/.config/fish/completions/rove.fish
 ```
 
-Completes subcommands; each subcommand owns its own flags.
+Completes two levels: the subcommand, then its verb.
+
+```text
+rove <TAB>          web completions add remove adopt export repo api daemon …
+rove daemon <TAB>   status start stop restart
+rove theme <TAB>    list add remove
+rove api routine-<TAB>   routine-list routine-create routine-update …
+```
+
+`api`, `daemon`, `plugin`, `repo`, `skill` and `theme` carry verbs; the rest
+take flags only, and get no second level rather than an invented one. Flags
+are never completed — each subcommand owns its own.
+
+Both levels are derived, not transcribed. The `api` verbs come from the same
+registry `rove api schema` enumerates, and the other five from a table each
+command validates its own argv against — so a verb the CLI accepts but the
+completion script omits is not a state the two can reach. Regenerate the
+script after upgrading Rove to pick up new verbs.
 
 ## export
 

--- a/packages/kobe/src/cli/completions-cmd.ts
+++ b/packages/kobe/src/cli/completions-cmd.ts
@@ -11,12 +11,31 @@
  * `#compdef` autoload file; sourced directly it registers itself via
  * `compdef` (the funcstack guard at the end tells the two apart).
  *
- * The generated scripts complete subcommands (and only subcommands — flags
- * are omitted because most kobe subcommands define their own flags).
+ * The generated scripts complete two levels — the top-level subcommand and,
+ * for the commands that take one, its verb (`kobe daemon <TAB>` →
+ * `start stop status restart`). Flags are omitted because most subcommands
+ * define their own.
+ *
+ * Both levels are DERIVED, never transcribed: the top level from
+ * {@link TOP_LEVEL_SUBCOMMANDS}, the verbs from {@link SUBCOMMAND_VERBS}
+ * (which the command modules themselves validate against) and, for `api`,
+ * from the same `VERBS` registry `kobe api schema` enumerates. That registry
+ * is loaded lazily so `completions` stays the only command that pays for it.
  */
 import type { ProductCliName } from "../product.ts"
 import { activeCliName } from "./rename-compat.ts"
-import { TOP_LEVEL_SUBCOMMANDS } from "./subcommands.ts"
+import { SUBCOMMAND_VERBS, TOP_LEVEL_SUBCOMMANDS } from "./subcommands.ts"
+
+/** command → its verbs, in the order each source declares them. */
+type SubVerbs = ReadonlyArray<readonly [command: string, verbs: readonly string[]]>
+
+async function collectSubVerbs(): Promise<SubVerbs> {
+  const { API_VERBS } = await import("./api/verbs.ts")
+  const merged: Record<string, readonly string[]> = { ...SUBCOMMAND_VERBS, api: API_VERBS }
+  return Object.keys(merged)
+    .sort()
+    .map((command) => [command, merged[command] ?? []] as const)
+}
 
 function completionUsage(cliName: ProductCliName): string {
   return [
@@ -36,7 +55,7 @@ function completionUsage(cliName: ProductCliName): string {
   ].join("\n")
 }
 
-function generateBashCompletions(cliName: ProductCliName): string {
+function generateBashCompletions(cliName: ProductCliName, subVerbs: SubVerbs): string {
   const subcommands = TOP_LEVEL_SUBCOMMANDS.join(" ")
   const fn = `_${cliName}`
 
@@ -45,11 +64,20 @@ function generateBashCompletions(cliName: ProductCliName): string {
     `# Source: ${cliName} completions bash`,
     "",
     `${fn}() {`,
-    "    local cur",
+    "    local cur prev",
     "    COMPREPLY=()",
     '    cur="${COMP_WORDS[COMP_CWORD]}"',
+    '    prev="${COMP_WORDS[COMP_CWORD-1]}"',
     "    if [[ ${COMP_CWORD} -eq 1 ]]; then",
-    `        COMPREPLY=( $(compgen -W "${subcommands}" -- \${cur}) )`,
+    `        COMPREPLY=( $(compgen -W "${subcommands}" -- "\${cur}") )`,
+    "        return",
+    "    fi",
+    "    if [[ ${COMP_CWORD} -eq 2 ]]; then",
+    '        case "${prev}" in',
+    ...subVerbs.map(
+      ([command, verbs]) => `            ${command}) COMPREPLY=( $(compgen -W "${verbs.join(" ")}" -- "\${cur}") ) ;;`,
+    ),
+    "        esac",
     "    fi",
     "}",
     `complete -F ${fn} ${cliName}`,
@@ -57,7 +85,7 @@ function generateBashCompletions(cliName: ProductCliName): string {
   ].join("\n")
 }
 
-function generateZshCompletions(cliName: ProductCliName): string {
+function generateZshCompletions(cliName: ProductCliName, subVerbs: SubVerbs): string {
   const subcommandsList = TOP_LEVEL_SUBCOMMANDS.map((s) => `"${s}"`).join(" ")
   const fn = `_${cliName}`
 
@@ -67,10 +95,21 @@ function generateZshCompletions(cliName: ProductCliName): string {
     `# Source: ${cliName} completions zsh`,
     "",
     `${fn}() {`,
-    "    local -a subcommands",
+    "    local -a subcommands verbs",
     `    subcommands=(${subcommandsList})`,
     "",
-    '    _arguments "1:subcommand:(${subcommands})"',
+    "    if (( CURRENT == 2 )); then",
+    "        _describe -t commands 'subcommand' subcommands",
+    "        return",
+    "    fi",
+    "",
+    "    verbs=()",
+    '    case "${words[2]}" in',
+    ...subVerbs.map(([command, verbs]) => `        ${command}) verbs=(${verbs.map((v) => `"${v}"`).join(" ")}) ;;`),
+    "    esac",
+    "    if (( CURRENT == 3 && ${#verbs} > 0 )); then",
+    "        _describe -t verbs 'verb' verbs",
+    "    fi",
     "}",
     "",
     "# Autoloaded from $fpath -> run as the completion function;",
@@ -84,8 +123,17 @@ function generateZshCompletions(cliName: ProductCliName): string {
   ].join("\n")
 }
 
-function generateFishCompletions(cliName: ProductCliName): string {
-  const lines = TOP_LEVEL_SUBCOMMANDS.map((s) => `complete -c ${cliName} -f -a ${s}`)
+function generateFishCompletions(cliName: ProductCliName, subVerbs: SubVerbs): string {
+  // `__fish_use_subcommand` keeps the top-level list from reappearing after a
+  // subcommand is already typed; `__fish_seen_subcommand_from` scopes each
+  // verb list to its own command.
+  const lines = [
+    ...TOP_LEVEL_SUBCOMMANDS.map((s) => `complete -c ${cliName} -f -n __fish_use_subcommand -a ${s}`),
+    ...subVerbs.map(
+      ([command, verbs]) =>
+        `complete -c ${cliName} -f -n "__fish_seen_subcommand_from ${command}" -a "${verbs.join(" ")}"`,
+    ),
+  ]
   return `# ${cliName} fish completions\n# Source: ${cliName} completions fish\n\n${lines.join("\n")}\n`
 }
 
@@ -106,13 +154,15 @@ export async function runCompletionsSubcommand(
     process.exit(2)
   }
 
+  const subVerbs = await collectSubVerbs()
+
   let script: string
   if (shell === "bash") {
-    script = generateBashCompletions(cliName)
+    script = generateBashCompletions(cliName, subVerbs)
   } else if (shell === "zsh") {
-    script = generateZshCompletions(cliName)
+    script = generateZshCompletions(cliName, subVerbs)
   } else {
-    script = generateFishCompletions(cliName)
+    script = generateFishCompletions(cliName, subVerbs)
   }
 
   process.stdout.write(script)

--- a/packages/kobe/src/cli/daemon-cmd.ts
+++ b/packages/kobe/src/cli/daemon-cmd.ts
@@ -25,6 +25,7 @@ import { createKobeCore } from "../core/index.ts"
 import { LEGACY_KOBE_PRODUCT_NAME } from "../product.ts"
 import { migrateRoveDaemonStateLayout } from "../state/layout-migration.ts"
 import { activeCliName } from "./rename-compat.ts"
+import { SUBCOMMAND_VERBS } from "./subcommands.ts"
 
 const CLI_NAME = activeCliName()
 
@@ -58,6 +59,15 @@ export async function runDaemonSubcommand(argv: readonly string[]): Promise<void
   if (command === "--help" || command === "-h" || command === "help") {
     printDaemonUsage(process.stdout)
     return
+  }
+
+  // The accept-set lives in `subcommands.ts` so `kobe completions` offers
+  // exactly what this dispatch runs; a verb added below but not there is
+  // rejected here rather than becoming an uncompletable secret.
+  if (!SUBCOMMAND_VERBS.daemon.includes(command)) {
+    process.stderr.write(`${CLI_NAME} daemon: unknown command "${command}"\n\n`)
+    printDaemonUsage(process.stderr)
+    process.exit(2)
   }
 
   if (command === "status") {
@@ -104,12 +114,6 @@ export async function runDaemonSubcommand(argv: readonly string[]): Promise<void
     next.close()
     console.log(`${CLI_NAME} daemon: restarted, listening on ${socketPath}`)
     return
-  }
-
-  if (command !== "start") {
-    process.stderr.write(`${CLI_NAME} daemon: unknown command "${command}"\n\n`)
-    printDaemonUsage(process.stderr)
-    process.exit(2)
   }
 
   // We ARE the daemon process from here on. `daemon.log` is stdout/stderr

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -24,6 +24,7 @@ import {
 } from "@sma1lboy/kobe-daemon/plugins/registry"
 import { PluginCliError, installPlugin, linkPlugin } from "./plugin-install.ts"
 import { activeCliName } from "./rename-compat.ts"
+import { SUBCOMMAND_VERBS } from "./subcommands.ts"
 
 const CLI_NAME = activeCliName()
 
@@ -234,6 +235,15 @@ function flagValue(rest: string[], flag: string): string | undefined {
 
 export async function runPluginSubcommand(rest: string[]): Promise<void> {
   const [command, ...args] = rest
+  // The switch below dispatches, but `subcommands.ts` decides what is a verb
+  // at all — so `kobe completions` offers exactly this set, and a case added
+  // without listing it there is unreachable instead of silently uncompletable.
+  if (command !== undefined && !SUBCOMMAND_VERBS.plugin.includes(command)) {
+    const isHelp = command === "help" || command === "--help" || command === "-h"
+    printUsage(isHelp ? process.stdout : process.stderr)
+    if (!isHelp) process.exit(2)
+    return
+  }
   try {
     switch (command) {
       case "install": {

--- a/packages/kobe/src/cli/repo-cmd.ts
+++ b/packages/kobe/src/cli/repo-cmd.ts
@@ -15,6 +15,7 @@ import { resolve } from "node:path"
 import { errorMessage } from "@/lib/error-message"
 import { expandTilde } from "../lib/path-home.ts"
 import { activeCliName } from "./rename-compat.ts"
+import { SUBCOMMAND_VERBS } from "./subcommands.ts"
 
 const CLI_NAME = activeCliName()
 
@@ -106,6 +107,10 @@ export async function runRepoSubcommand(args: readonly string[]): Promise<void> 
     return
   }
 
+  // Accept-set from `subcommands.ts` so `kobe completions` and this dispatch
+  // cannot drift apart — see the comment there.
+  if (!SUBCOMMAND_VERBS.repo.includes(verb)) usageError(`unknown verb "${verb}"`)
+
   const { getRepoInitOverride, setRepoInitOverride, resolveRepoRoot } = await import("../state/repos.ts")
   const { existsSync } = await import("node:fs")
   const { join } = await import("node:path")
@@ -157,6 +162,8 @@ export async function runRepoSubcommand(args: readonly string[]): Promise<void> 
     return
   }
 
+  // Unreachable via the gate above; kept so a verb added to SUBCOMMAND_VERBS
+  // without a branch here fails loud instead of silently doing nothing.
   usageError(`unknown verb "${verb}"`)
 }
 

--- a/packages/kobe/src/cli/skill-cmd.ts
+++ b/packages/kobe/src/cli/skill-cmd.ts
@@ -28,10 +28,11 @@ import {
   runNpxSkillsInstall,
 } from "../lib/skill-install.ts"
 import { activeCliName } from "./rename-compat.ts"
+import { SUBCOMMAND_VERBS } from "./subcommands.ts"
 
 const CLI_NAME = activeCliName()
 
-const SKILL_VERBS = ["install", "status", "command", "print"] as const
+const SKILL_VERBS = SUBCOMMAND_VERBS.skill
 
 function skillUsage(): string {
   return [
@@ -103,7 +104,7 @@ export async function runSkillSubcommand(argv: readonly string[]): Promise<void>
     if (!verb) process.exitCode = 2
     return
   }
-  if (!SKILL_VERBS.includes(verb as (typeof SKILL_VERBS)[number])) {
+  if (!SKILL_VERBS.includes(verb)) {
     process.stderr.write(`${CLI_NAME} skill: unknown verb "${verb}"\n\n${skillUsage()}\n`)
     process.exit(2)
   }

--- a/packages/kobe/src/cli/subcommands.ts
+++ b/packages/kobe/src/cli/subcommands.ts
@@ -29,3 +29,47 @@ export const TOP_LEVEL_SUBCOMMANDS = [
   "feedback",
   "update",
 ] as const
+
+/**
+ * Sub-verbs of the top-level commands that take one — the second level
+ * `kobe completions` offers.
+ *
+ * This module has no imports on purpose, so the dependency runs the other
+ * way: `daemon-cmd.ts`, `plugin-cmd.ts`, `theme.ts`, `repo-cmd.ts` and
+ * `skill-cmd.ts` each validate their argv against the entry below instead of
+ * keeping a private list. A verb missing from here is therefore unreachable
+ * in the command itself, not merely absent from the completion script — the
+ * drift fails loud at the first invocation rather than silently telling a
+ * user the verb doesn't exist.
+ *
+ * `api` is deliberately NOT here: its verbs come from the `VERBS` registry
+ * (`api/verbs.ts`, the same one `kobe api schema` enumerates), which
+ * `completions-cmd.ts` loads lazily so this module stays import-free.
+ *
+ * Canonical spellings only. Aliases (`theme ls`/`rm`) stay in their command
+ * module — completing both spellings is noise.
+ */
+export type VerbedSubcommand = "daemon" | "plugin" | "repo" | "skill" | "theme"
+
+export const SUBCOMMAND_VERBS: Readonly<Record<VerbedSubcommand, readonly string[]>> = {
+  daemon: ["status", "start", "stop", "restart"],
+  plugin: [
+    "install",
+    "link",
+    "list",
+    "search",
+    "outdated",
+    "update",
+    "enable",
+    "disable",
+    "unlink",
+    "uninstall",
+    "config-dir",
+    "log",
+    "action",
+    "pane",
+  ],
+  repo: ["show", "set", "unset"],
+  skill: ["install", "status", "command", "print"],
+  theme: ["list", "add", "remove"],
+}

--- a/packages/kobe/src/cli/theme.ts
+++ b/packages/kobe/src/cli/theme.ts
@@ -29,8 +29,12 @@ import { BUNDLED_THEME_JSONS } from "../tui/context/theme/bundled"
 import { userThemesDir } from "../tui/context/theme/loader"
 import { validateTheme } from "../tui/context/theme/schema"
 import { activeCliName } from "./rename-compat.ts"
+import { SUBCOMMAND_VERBS } from "./subcommands.ts"
 
 const CLI_NAME = activeCliName()
+
+/** Short spellings accepted on the command line but not offered by completions. */
+const THEME_VERB_ALIASES: Readonly<Record<string, string>> = { ls: "list", rm: "remove" }
 
 /**
  * The bundled theme names, read from the map that owns the JSON imports.
@@ -251,18 +255,27 @@ export async function runThemeSubcommand(args: string[]): Promise<void> {
     if (!action) process.exit(2)
     return
   }
-  if (action === "list" || action === "ls") {
+  // Canonical verbs come from `subcommands.ts` (the same list `kobe
+  // completions` offers); the short spellings stay local because completing
+  // both of every pair is noise.
+  const verb = THEME_VERB_ALIASES[action] ?? action
+  if (!SUBCOMMAND_VERBS.theme.includes(verb)) {
+    failUsage(`unknown action "${action}" (try ${SUBCOMMAND_VERBS.theme.map((v) => `"${v}"`).join(", ")})`)
+  }
+  if (verb === "list") {
     if (rest.length > 0) failUsage(`"${action}" takes no arguments`)
     listThemes()
     return
   }
-  if (action === "add") {
+  if (verb === "add") {
     await addTheme(rest)
     return
   }
-  if (action === "remove" || action === "rm") {
+  if (verb === "remove") {
     removeTheme(rest)
     return
   }
-  failUsage(`unknown action "${action}" (try "list", "add", or "remove")`)
+  // Unreachable via the gate above; kept so a verb added to SUBCOMMAND_VERBS
+  // without a branch here fails loud instead of falling into the last one.
+  failUsage(`unknown action "${action}"`)
 }

--- a/packages/kobe/test/cli/completions-cmd.test.ts
+++ b/packages/kobe/test/cli/completions-cmd.test.ts
@@ -1,13 +1,47 @@
 /**
  * `kobe completions <shell>` — asserts each generated script actually
- * carries every top-level subcommand in that shell's grammar (a completion
- * script that misses a subcommand is silently useless), plus the usage /
- * unknown-shell error surface.
+ * carries every top-level subcommand AND every sub-verb in that shell's
+ * grammar, plus the usage / unknown-shell error surface.
+ *
+ * The set-equality tests below are the anti-drift gate: they re-parse the
+ * verbs back OUT of each generated script and compare them to the registries
+ * the CLI itself dispatches on. A shell generator that drops, mangles or
+ * hand-lists a verb goes red — and so does a verb added to one registry but
+ * not carried into all three shells. Stale completions are worse than none
+ * (they tell a user a verb does not exist), so this is the test that has to
+ * fail before the feature can rot.
  */
 
 import { type MockInstance, afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { API_VERBS } from "../../src/cli/api/verbs.ts"
 import { runCompletionsSubcommand } from "../../src/cli/completions-cmd.ts"
-import { TOP_LEVEL_SUBCOMMANDS } from "../../src/cli/subcommands.ts"
+import { SUBCOMMAND_VERBS, TOP_LEVEL_SUBCOMMANDS } from "../../src/cli/subcommands.ts"
+
+/** What every generated script must offer, keyed by command. */
+const EXPECTED_VERBS: Readonly<Record<string, readonly string[]>> = { ...SUBCOMMAND_VERBS, api: API_VERBS }
+
+/**
+ * Re-read the verb lists out of a generated script. Each parser is anchored
+ * to that shell's emitted shape, so it yields an empty map — never a passing
+ * one — if the generator stops emitting a second level at all.
+ */
+function parseVerbs(script: string, pattern: RegExp): Record<string, string[]> {
+  const found: Record<string, string[]> = {}
+  for (const m of script.matchAll(pattern)) {
+    const command = m[1] as string
+    found[command] = (m[2] as string)
+      .split(/\s+/)
+      .map((v) => v.replace(/"/g, ""))
+      .filter(Boolean)
+  }
+  return found
+}
+
+const PARSERS: Readonly<Record<string, RegExp>> = {
+  bash: /^\s+(\S+)\) COMPREPLY=\( \$\(compgen -W "([^"]*)"/gm,
+  zsh: /^\s+(\S+)\) verbs=\(([^)]*)\)/gm,
+  fish: /^complete -c \w+ -f -n "__fish_seen_subcommand_from (\S+)" -a "([^"]*)"/gm,
+}
 
 let stdoutSpy: MockInstance
 let stderrSpy: MockInstance
@@ -54,10 +88,12 @@ describe("runCompletionsSubcommand", () => {
     expect(script).toContain("compdef _kobe kobe")
   })
 
-  test("fish script emits one complete line per subcommand", async () => {
+  test("fish scopes the top-level list to the first word", async () => {
     await runCompletionsSubcommand(["fish"])
     const script = stdoutText()
-    for (const sub of TOP_LEVEL_SUBCOMMANDS) expect(script).toContain(`complete -c kobe -f -a ${sub}`)
+    for (const sub of TOP_LEVEL_SUBCOMMANDS) {
+      expect(script).toContain(`complete -c kobe -f -n __fish_use_subcommand -a ${sub}`)
+    }
   })
 
   test("rove gets isolated shell registrations and install instructions", async () => {
@@ -73,6 +109,26 @@ describe("runCompletionsSubcommand", () => {
     await runCompletionsSubcommand(["--help"])
     expect(stdoutText()).toContain("Usage: kobe completions")
     expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  test.each(["bash", "zsh", "fish"] as const)(
+    "%s completes exactly the verbs the CLI dispatches on — no drift, no hand-copied list",
+    async (shell) => {
+      await runCompletionsSubcommand([shell])
+      const found = parseVerbs(stdoutText(), PARSERS[shell] as RegExp)
+      expect(Object.keys(found).sort()).toEqual(Object.keys(EXPECTED_VERBS).sort())
+      for (const [command, verbs] of Object.entries(EXPECTED_VERBS)) {
+        expect({ command, verbs: found[command] }).toEqual({ command, verbs: [...verbs] })
+      }
+    },
+  )
+
+  test("a command with no sub-verbs gets no second level", async () => {
+    await runCompletionsSubcommand(["bash"])
+    const found = parseVerbs(stdoutText(), PARSERS.bash as RegExp)
+    // `doctor` takes flags, not verbs — offering it a verb list would invent one.
+    expect(found.doctor).toBeUndefined()
+    expect(found.export).toBeUndefined()
   })
 
   test("an unknown shell prints usage to stderr and exits 2", async () => {


### PR DESCRIPTION
`rove completions` only ever completed the first level. `rove daemon <TAB>` offered nothing, and `rove api <TAB>` — the surface with ~45 verbs, where completion matters most — offered nothing either. The bash script was 12 lines.

**Not for merging tonight** — parked for review.

## Derived from the source of truth, not hand-copied

Sub-verbs come from a shared `SUBCOMMAND_VERBS` constant that **the CLI itself dispatches on** — `repo`, `theme`, `skill` etc. now validate their input against the same list they advertise. A hand-copied list would drift, and *stale completion is worse than none*: it tells the user a verb doesn't exist.

Covers `api` / `daemon` / `plugin` / `repo` / `skill` / `theme` across bash, zsh and fish.

## Verifying the anti-drift test actually bites

My first probe was wrong and worth recording: I injected a bogus verb into `SUBCOMMAND_VERBS` and nothing failed — because the test compares the *generator's output* against that same constant, so poking it moves both sides together.

Testing the direction that can actually rot — making the generator drop `daemon`'s verbs — turns **all three shells red**. That's the real failure mode: the constant grows a verb and the generator forgets it.

Also verified:
- `bash -n` and `zsh -n` both parse the generated scripts clean (24 and 34 lines).
- The runtime rejects unknown sub-verbs from the same constant: `rove daemon bogus` → `unknown command "bogus"`, `rove theme bogus` → `unknown action "bogus" (try "list", "add", "remove")`.
- All six commands appear in the generated bash output with their full verb lists.

`docs/CLI.md` updated. `test:fast` 3570 passed, lint and typecheck clean.