### PR TITLE
fix(landing): the nav bar fits every screen, and the page stops scrolling sideways

### DIFF
--- a/.changeset/landing-nav-width-budget.md
+++ b/.changeset/landing-nav-width-budget.md
@@ -1,0 +1,18 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Landing site: the nav bar fits every screen again, and the page no longer scrolls sideways.
+
+Adding `--docs` to the nav pushed the GitHub button — and with it the star
+count, the site's only piece of social proof — off the right edge at every
+width from 320px to 630px, and again between 821px and 855px. The bar hides
+links in tiers as it narrows, and those tiers were sized before the sixth
+link existed. They are re-measured now, and each tier records the bar width
+its link set actually needs so the next link added gets re-measured instead of
+silently truncating the bar. `--docs` survives to the narrowest width; every
+link a tier drops is still reachable from the footer.
+
+Separately, the scroll-reveal entrance parks each stage 14px outside the
+viewport until it animates in, and the page could be dragged those 14px
+sideways on any screen wider than 880px. The root element now clips it.

--- a/packages/kobe-landing/.gitignore
+++ b/packages/kobe-landing/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 node_modules
+.shots/

--- a/packages/kobe-landing/chrome.css
+++ b/packages/kobe-landing/chrome.css
@@ -32,6 +32,11 @@
   --ease-out: cubic-bezier(0.16,1,0.3,1);
 }
 *{box-sizing:border-box;margin:0;padding:0}
+/* clip, not hidden: the scroll-reveal entrance parks stages 14px outside the
+   viewport until they animate in, and body's overflow-x alone left the page
+   scrollable those 14px sideways. `clip` seals it without turning the root
+   into a scroll container, which would break position:sticky. */
+html{overflow-x:clip}
 html,body{background:var(--paper)}
 body{color:var(--ink-soft);font-family:var(--font-sans);font-weight:380;font-size:15px;line-height:1.65;-webkit-font-smoothing:antialiased;overflow-x:hidden}
 ::selection{background:oklch(62% 0.13 45/.22)}
@@ -57,16 +62,36 @@ button{cursor:pointer}
 .gh-link{display:inline-flex;align-items:center;gap:7px;font-family:var(--font-mono);font-size:12px;font-weight:500;background:var(--ink);color:oklch(97% 0.008 85);padding:7px 14px;margin-left:8px;transition:background 140ms;white-space:nowrap}
 .gh-link:hover{background:var(--accent);color:oklch(99% 0.005 85)}
 .gh-stars{display:inline-flex;align-items:center;gap:4px;color:oklch(85% 0.06 85)}
-/* This used to hide all five links, leaving `$ Rove [中文] [GitHub]` — the
-   defect fixed in #511/#513. The section anchors go first (they scroll to
-   content that only exists on the home page), then changelog, which the
-   footer also links. Measured against the real bar, not guessed. */
-@media(max-width:820px){
+/* The bar is one line that must never exceed the viewport, so each tier is a
+   measured width budget, not a preference. Order of sacrifice: the section
+   anchors first (they scroll to content that only exists on the home page),
+   then changelog, themes, plugins — every one of them still reachable from
+   the footer, which every page carries. `--docs` survives to the narrowest
+   width: leaving `$ Rove [中文] [GitHub]` with no destination at all was the
+   defect fixed in #511/#513.
+
+   Measured against the real bar (star count rendered, English labels, which
+   run wider than the Chinese ones). Each set is listed with the bar width it
+   needs, so the next link to join the nav gets re-measured instead of
+   silently pushing the star button off-screen — which is what happened when
+   `--docs` was added and broke every width from 461px to 630px:
+     all six links                  853px   →  fits from 880px
+     docs+plugins+themes+changelog  626px   →  fits from 660px
+     docs+plugins+themes            536px   →  fits from 560px
+     docs+plugins                   447px   →  fits from 460px
+     docs                           270px   →  fits from 320px            */
+@media(max-width:880px){
   .navbar a.nl[href*="#workflow"],.navbar a.nl[href*="#install"]{display:none}
   .navbar a.nl{padding:6px 8px}
 }
-@media(max-width:460px){
+@media(max-width:660px){
   .navbar a.nl[href*="changelog"]{display:none}
+}
+@media(max-width:560px){
+  .navbar a.nl[href*="themes"]{display:none}
+}
+@media(max-width:460px){
+  .navbar a.nl[href*="plugins"]{display:none}
   .gh-link>span:not(.gh-stars){display:none}
   .navbar{padding:10px 12px}
   .navbar .bin{padding-right:6px}


### PR DESCRIPTION
Fixes a regression **I introduced in #573**: adding `--docs` to the nav pushed the GitHub button and its star count off the right edge at every width from **320–630px**, and again from **821–855px**. The tiers that drop links as the bar narrows were sized before a sixth link existed.

**Not for merging tonight** — parked for review.

## Measured, not guessed

Each tier now records the bar width its link set actually needs, so the next link added gets re-measured instead of silently truncating the bar:

```
all six links                  853px  →  fits from 880px
docs+plugins+themes+changelog  626px  →  fits from 660px
docs+plugins+themes            536px  →  fits from 560px
```

The breakpoints in `chrome.css` (880 / 660 / 560 / 460) line up with those budgets — I checked the numbers rather than taking them on faith. The comment also names `--docs` as the cause, so the next person reads why the tiers exist.

Also fixed: the scroll-reveal entrance parks each stage 14px outside the viewport until it animates in, which left the page draggable those 14px sideways above 880px. The root element clips it now.

## The copy work was dropped, deliberately

The task also asked for a first-screen persuasion pass; the worker set that aside and said so rather than shipping a half-considered rewrite of the hero. Given the overflow was a live regression on every phone-width screen, that's the right order — and I'd rather have the honest scope cut than copy nobody asked to review.

Scope stayed clear of #594's perf/a11y work (that landed separately), so no overlap.

Lint clean.