### PR TITLE
fix(terminal): keep a released selection glued to its content while scrolling

### DIFF
--- a/.changeset/selection-follows-content-after-release.md
+++ b/.changeset/selection-follows-content-after-release.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Terminal selection now stays glued to its content after the mouse is released. In an engine tab, drag-selecting a region and then scrolling with the wheel left the highlight pinned to the same screen rows while the text moved out from under it; the content-following machinery was gated on a drag being in progress, so it stopped the moment the button came up. It is now gated on a selection existing, and both endpoints follow the content — the highlight travels off the top or bottom of the pane the way it does in every terminal emulator.

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -29,11 +29,13 @@
  *
  * When the scroll was FORWARDED to an app that owns its own scrollback (an
  * engine on the alternate screen), the viewport never moves — the app redraws
- * and the content shifts under snapshot row numbers that stay put. While such
- * a drag is live, every snapshot change is measured with `snapshotShift`; the
- * ANCHOR moves by the measured displacement (the head stays pinned to the
- * pointer), and the rows that scrolled off screen are banked in a bounded
- * shadow so the copy contains exactly what the highlight covered.
+ * and the content shifts under snapshot row numbers that stay put. While a
+ * SELECTION EXISTS — during the drag and after the release, until the next
+ * click clears it — every snapshot change is measured with `snapshotShift` and
+ * the endpoints move with the content (`followContentShift`); the rows that
+ * scrolled off screen are banked in a bounded shadow so the copy contains
+ * exactly what the highlight covered. During the drag only the anchor follows,
+ * because the head belongs to the pointer.
  */
 
 import type { BoxRenderable } from "@opentui/core"
@@ -46,11 +48,9 @@ import {
   EMPTY_SHADOW,
   type SelectionRange,
   type SelectionShadow,
-  clampRowToShadow,
   extractShadowedSelection,
+  followContentShift,
   pointerCell,
-  shiftShadow,
-  snapshotShift,
 } from "../../../tui/panes/terminal/terminal-selection"
 
 export type { CellPoint, SelectionRange } from "../../../tui/panes/terminal/terminal-selection"
@@ -88,7 +88,7 @@ export interface UseTerminalSelectionResult {
   endDragging: () => void
   clearSelection: () => void
   copySelection: () => void
-  /** The pane forwarded a wheel to the app mid-drag (outside the edge pull). */
+  /** The pane forwarded a wheel to the app (outside the edge pull). */
   noteAppScroll: () => void
 }
 
@@ -220,22 +220,26 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
   }, [opts.visibleRangeStart])
 
   // App-owned scrolling never moves the viewport — the CONTENT moves under
-  // fixed snapshot rows. Measure each snapshot change during such a drag and
-  // move the anchor with the content (the head stays pinned to the pointer);
-  // rows that scrolled off screen are banked so the copy still has them.
+  // fixed snapshot rows. Measure each snapshot change and move the selection
+  // with the content; rows that scrolled off are banked so the copy still has
+  // them. Gated on a selection EXISTING rather than on a live drag: the
+  // measurement is an O(rows^2) text comparison and must not run on every PTY
+  // frame for nothing, but a RELEASED selection still belongs to its content.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on snapshot pushes; `selHead` is read from the render that pushed them.
   useEffect(() => {
     const prev = lastSnapshotRef.current
     lastSnapshotRef.current = opts.snapshot
-    if (!draggingRef.current || !appScrolledRef.current || prev === opts.snapshot) return
-    const shift = snapshotShift(prev, opts.snapshot)
-    if (shift === 0) return
-    shadowRef.current = shiftShadow(shadowRef.current, prev, shift)
-    const shadow = shadowRef.current
-    const length = opts.snapshot.length
-    const follow = (cell: CellPoint | null): CellPoint | null =>
-      cell ? { row: clampRowToShadow(cell.row + shift, length, shadow), col: cell.col } : cell
-    anchorRef.current = follow(anchorRef.current)
-    setSelAnchor(follow)
+    if (!anchorRef.current || !appScrolledRef.current || prev === opts.snapshot) return
+    const rolled = followContentShift(
+      { anchor: anchorRef.current, head: selHead, shadow: shadowRef.current },
+      prev,
+      opts.snapshot,
+      draggingRef.current,
+    )
+    shadowRef.current = rolled.shadow
+    anchorRef.current = rolled.anchor
+    setSelAnchor(rolled.anchor)
+    setSelHead(rolled.head)
   }, [opts.snapshot])
 
   // Unmount mid-drag (tab closed, pane swapped) must not leave a timer behind.
@@ -273,7 +277,9 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     },
     copySelection,
     noteAppScroll: () => {
-      if (draggingRef.current) appScrolledRef.current = true
+      // Armed by a selection, not by a drag — a wheel AFTER the release has to
+      // start the measuring too, or the highlight stops following its content.
+      if (anchorRef.current) appScrolledRef.current = true
     },
   }
 }

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -293,6 +293,42 @@ export function clampRowToShadow(row: number, snapshotLength: number, shadow: Se
   return Math.min(snapshotLength - 1 + shadow.below.length, Math.max(0 - shadow.above.length, row))
 }
 
+/** Selection endpoints plus the shadow they address, rolled together. */
+export type SelectionShiftState = {
+  readonly anchor: CellPoint | null
+  readonly head: CellPoint | null
+  readonly shadow: SelectionShadow
+}
+
+/**
+ * Roll a selection across one snapshot change: measure the content
+ * displacement, bank the rows that scrolled off, and move the endpoints that
+ * belong to the CONTENT along with it.
+ *
+ * While the drag is LIVE only the anchor follows — the head is pinned to the
+ * pointer, which the pane re-derives from the last pointer position itself.
+ * Once the drag is released both endpoints belong to the content, so both
+ * follow and the highlight scrolls off the top or bottom of the pane the way
+ * every emulator's does, instead of staying pinned to screen rows.
+ *
+ * Returns the input state by reference when there is nothing selected or no
+ * shift is measurable, so callers can skip the update entirely.
+ */
+export function followContentShift(
+  state: SelectionShiftState,
+  prev: readonly (readonly Chunk[])[],
+  next: readonly (readonly Chunk[])[],
+  dragging: boolean,
+): SelectionShiftState {
+  if (!state.anchor) return state
+  const shift = snapshotShift(prev, next)
+  if (shift === 0) return state
+  const shadow = shiftShadow(state.shadow, prev, shift)
+  const follow = (cell: CellPoint | null): CellPoint | null =>
+    cell ? { row: clampRowToShadow(cell.row + shift, next.length, shadow), col: cell.col } : cell
+  return { anchor: follow(state.anchor), head: dragging ? state.head : follow(state.head), shadow }
+}
+
 /**
  * Extract over the composed drag buffer — shadow rows glued around the live
  * snapshot, the range translated into composed space. Same `extractSelection`

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest"
 import { displayWidth } from "../../src/lib/display-width"
 import { ATTR, type Chunk } from "../../src/tui/panes/terminal/sgr"
 import {
+  type CellPoint,
   EMPTY_SHADOW,
+  type SelectionRange,
+  type SelectionShiftState,
   clampRowToShadow,
   extractSelection,
   extractShadowedSelection,
+  followContentShift,
   orderRange,
   overlaySelection,
   pointerCell,
@@ -266,6 +270,43 @@ describe("alt-screen drag scrolling (shadow buffer)", () => {
     // Composed space stays contiguous: above ++ screen(14) ++ below.
     const range = { anchor: { row: -3, col: 0 }, head: { row: 5, col: 10 } }
     expect(extractShadowedSelection(screen(14), shadow, range)).toBe(doc.slice(11, 20).join("\n"))
+  })
+
+  it("keeps a RELEASED selection glued to its content while the app scrolls", () => {
+    // Selection made over lines 17-19, then the mouse released. The app
+    // scrolls up twice by 2: both endpoints must ride the content down and
+    // off the bottom, not stay pinned to screen rows 1 and 3.
+    let state: SelectionShiftState = { anchor: { row: 1, col: 0 }, head: { row: 3, col: 7 }, shadow: EMPTY_SHADOW }
+    let visible = screen(15)
+    for (const top of [13, 11]) {
+      const next = screen(top)
+      state = followContentShift(state, visible, next, false)
+      visible = next
+    }
+    expect(state.anchor).toEqual({ row: 5, col: 0 })
+    expect(state.head).toEqual({ row: 7, col: 7 })
+    // Still the same three lines, now read entirely out of the shadow.
+    const range: SelectionRange = { anchor: state.anchor as CellPoint, head: state.head as CellPoint }
+    expect(extractShadowedSelection(visible, state.shadow, range)).toBe(doc.slice(16, 19).join("\n"))
+  })
+
+  it("moves only the anchor while the drag is still live", () => {
+    // Mid-drag the head belongs to the pointer, which the pane re-derives.
+    const state: SelectionShiftState = {
+      anchor: { row: 1, col: 0 },
+      head: { row: 3, col: 7 },
+      shadow: EMPTY_SHADOW,
+    }
+    const rolled = followContentShift(state, screen(15), screen(13), true)
+    expect(rolled.anchor).toEqual({ row: 3, col: 0 })
+    expect(rolled.head).toBe(state.head)
+  })
+
+  it("leaves the state alone when nothing is selected or nothing moved", () => {
+    const empty: SelectionShiftState = { anchor: null, head: null, shadow: EMPTY_SHADOW }
+    expect(followContentShift(empty, screen(15), screen(13), false)).toBe(empty)
+    const held: SelectionShiftState = { anchor: { row: 1, col: 0 }, head: { row: 3, col: 7 }, shadow: EMPTY_SHADOW }
+    expect(followContentShift(held, screen(15), screen(15), false)).toBe(held)
   })
 
   it("caps the shadow and clamps the anchor to what it can still address", () => {


### PR DESCRIPTION
## The bug

In an engine tab (alternate screen), drag-select a region, release the mouse, then wheel-scroll. The highlight stayed pinned to the same screen rows while the content scrolled out from under it.

## Root cause — confirmed

`use-terminal-selection.ts` already had the content-following machinery (`snapshotShift` / `shiftShadow` / `clampRowToShadow`), built for exactly this and working *during* a drag. It was gated behind `draggingRef.current` in two independent places:

1. `noteAppScroll: () => { if (draggingRef.current) … }` — after mouseup this no-ops, so a post-release wheel never armed the measuring.
2. the snapshot effect: `if (!draggingRef.current || !appScrolledRef.current || prev === opts.snapshot) return`

## The fix

Both gates now read `anchorRef.current` — "there IS a live selection" — instead of "a drag is in progress". `anchorRef` is set in `beginSelection` and nulled only in `clearSelection` (which `Terminal.tsx` calls on a plain click), so it covers the drag and the held-after-release window and nothing else. `snapshotShift` still never runs on an unselected pane.

The effect body moved into a pure `followContentShift(state, prev, next, dragging)` in `terminal-selection.ts`, which is what made the behavior testable at all (the hook needs a renderer; the repo has no `renderHook` and adding one would be a new dependency). It keeps the drag rule intact — while `dragging` the head is returned by reference, since the pointer owns it and the pane re-derives it — and after release moves **both** endpoints. The shadow keeps rolling either way, so `clampRowToShadow` stays honest and the selection can travel fully off-screen instead of piling up on row 0.

## Normal screen: unchanged

`appScrolledRef` is only armed when `scrollFromPointer` reports the wheel was *forwarded to the app*. On the normal screen local scrollback returns `false`, so `noteAppScroll` no-ops and none of this runs. That path stays absolute-snapshot-row addressed with `overlaySelection` mapping through `visibleRangeStart`, which already keeps the highlight on its content. No second mechanism added.

## Tests

`test/tui/terminal-selection.test.ts` gains three cases: the post-release one (selection set, drag ended, two 2-row shifts, both endpoints moved from rows 1/3 to 5/7 and the copy still reads `line-17..19` out of the shadow), the mid-drag one (only the anchor moves, head returned by reference), and the no-op one.

**Proof the post-release test is real:** with `head: dragging ? state.head : follow(state.head)` reverted to `head: state.head` — i.e. main's behavior — it fails:

```
× keeps a RELEASED selection glued to its content while the app scrolls
  AssertionError: expected { row: 3, col: 7 } to deeply equal { row: 7, col: 7 }
```

Restored, 25/25 pass.

`bun run test:fast` — 364 files, 3569 tests, all green. Repo-root `bun run lint` and `bun run typecheck` clean.

## The adjacent question: does a held selection drift when the snapshot is trimmed?

**Yes, it's real — reported, not fixed here.** The snapshot IS trimmed from the front. `snapshotMeta` (`xterm-refresh.ts:98`) computes `start: Math.max(0, active.length - (viewportRows + scrollbackRows))`, and `pty-xterm-snapshot.ts` builds `rowsOut` from `start`. Once the buffer is at its cap, every new line advances `start` by one and every absolute snapshot row index shifts down by one.

The **viewport** is already compensated for this: `snapshotWindow = { epoch, startLine }` carries an absolute line id, and `resolveViewportScrollOffset` re-derives the offset from `anchor.topLine - window.startLine` (`viewport.ts:41`). The **selection** never receives `snapshotWindow` — it is raw array indices. So on the normal screen, with the scrollback at its cap and the app still producing output, a held highlight drifts down relative to its content by exactly the number of dropped rows.

Left alone deliberately: the fix is a different mechanism (translate the endpoints by the `startLine` delta the way the viewport does), it belongs next to the viewport anchor rather than inside the alt-screen shift machinery this PR touches, and the brief said report-don't-fix unless small. Worth its own change.

## Notes

- One changeset, `patch`.
- `rove api set-branch` was refused: the task's recorded branch is `fix/selection-follows-content-after`, which is a real branch in this worktree carrying seven unrelated commits, and renaming it onto this branch's name collides. Left it untouched rather than resetting someone else's work. Final branch: `fix/selection-follows-scroll-after-release`.