### PR TITLE
feat: land removes the task's worktree by default

### DIFF
--- a/.changeset/land-removes-worktree-by-default.md
+++ b/.changeset/land-removes-worktree-by-default.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`land` now removes the task's worktree by default. A landed branch's worktree is spent, but removal was opt-in behind `--remove-worktree`, so every land left a dead directory behind — eleven of them after one night of fan-out work. Landing from the CLI, the TUI worktrees page, or the API now cleans up unless you pass `--remove-worktree=false`.
+
+The **branch is untouched** — git stays the durable record. Removal still never forces: a dirty worktree, the base checkout, and the worktree the caller is running from are all refused, and the refusal is reported (the TUI now prints why) instead of failing the land. The CLI always tells the daemon where it is running from, so an agent landing its own task can no longer delete its own working directory.

--- a/docs/API.md
+++ b/docs/API.md
@@ -397,18 +397,21 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
 - `pin --task-id ID [--pinned=false]`: pin/unpin a task to the top of the
   sidebar.
 - `land --task-id ID [--strategy merge|squash] [--delete-branch]
-  [--then-archive] [--remove-worktree]`: merge a task's branch back into its
+  [--then-archive] [--remove-worktree=false]`: merge a task's branch back into its
   base repo's current branch (`--no-ff` merge, or one squash commit). Refuses
   a dirty base checkout and a branch with no commits ahead of base
   (`EMPTY_BRANCH`; `EMPTY_BRANCH_DIRTY_WORKTREE` when uncommitted work is
   still sitting in the worktree, with a send-back recovery command); on
   conflict it aborts and returns the conflicted files. Returns
   `{ landedOn, commit }`.
-  `--remove-worktree` removes the task's worktree after a successful land;
-  the branch stays (pair with `--delete-branch` to drop it too). It never
-  forces: a dirty worktree, the base checkout, and the worktree the caller is
-  running from are all refused, and the outcome lands in the result's
-  `worktree` field (`{ removed, reason? }`) instead of failing the land.
+  **A successful land removes the task's worktree by default** — the
+  directory is spent once the branch is in. Pass `--remove-worktree=false` to
+  keep it. The **branch always stays** either way (pair with
+  `--delete-branch` to drop it too); git is the durable record, the working
+  directory is not. Removal never forces: a dirty worktree, the base
+  checkout, and the worktree the caller is running from are all refused, and
+  the outcome lands in the result's `worktree` field
+  (`{ removed, reason? }`) instead of failing the land.
 - `delete --task-id ID [--force] [--delete-branch]`: remove a task and its
   worktree. **The git branch stays** unless `--delete-branch` is passed;
   git is the durable record, the task row is not. Needs `--force` on a

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -90,8 +90,13 @@ a base already on the branch being landed. On a
 merge conflict, Rove aborts the merge and reports the conflicted paths, leaving
 manual conflict resolution to you.
 
-Landing does not remove the worktree, archive the task, or delete the source
-branch. Those are separate lifecycle decisions.
+A successful land removes the worktree — it is spent once its branch is in —
+and the row leaves the page. The **branch survives**: git keeps the durable
+record. If removal is refused (the worktree is dirty, it is the base
+checkout, or it is the directory Rove itself is running from), the land still
+stands and the page reports why the worktree is still there. Archiving the
+task and deleting the source branch remain separate lifecycle decisions;
+from the CLI, `rove api land --remove-worktree=false` keeps the worktree.
 
 ## Remove a clean worktree
 

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -138,7 +138,10 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
         strategy,
         deleteBranch: optionalBoolean(payload, "deleteBranch") === true,
         archive: optionalBoolean(payload, "archive") === true,
-        removeWorktree: optionalBoolean(payload, "removeWorktree") === true,
+        // Passed through as undefined when absent so the orchestrator's
+        // default (remove the landed worktree) applies; only an explicit
+        // `false` from the caller keeps it.
+        removeWorktree: optionalBoolean(payload, "removeWorktree"),
         callerCwd: optionalString(payload, "callerCwd"),
       })
       // landTask throws on refusal/conflict, so reaching here means it landed.

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -271,7 +271,6 @@ export async function land(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const taskId = ctx.args.require("task-id")
   const strategy = ctx.args.str("strategy") === "squash" ? "squash" : "merge"
-  const removeWorktree = ctx.args.bool("remove-worktree") ?? false
   let res: { result: unknown }
   try {
     res = await daemon.request<{ result: unknown }>("task.land", {
@@ -279,10 +278,16 @@ export async function land(ctx: VerbContext): Promise<unknown> {
       strategy,
       deleteBranch: ctx.args.bool("delete-branch") ?? false,
       archive: ctx.args.bool("then-archive") ?? false,
-      removeWorktree,
+      // Left UNDEFINED when the flag is absent so the orchestrator's default
+      // (remove it) applies; only an explicit `--remove-worktree=false` keeps
+      // the worktree. Coercing undefined to false here would pin the CLI to
+      // the old opt-in behaviour.
+      removeWorktree: ctx.args.bool("remove-worktree"),
       // The daemon refuses to remove the worktree the caller is running from —
-      // it can only know where the caller is if we tell it.
-      ...(removeWorktree ? { callerCwd: process.cwd() } : {}),
+      // it can only know where the caller is if we tell it. Removal is the
+      // default path now, so this is sent on EVERY land: send it only for the
+      // explicit flag and an agent landing itself deletes its own cwd.
+      callerCwd: process.cwd(),
     })
   } catch (err) {
     throw landRecoveryError(err, taskId)

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -47,8 +47,9 @@ export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
       {
         name: "remove-worktree",
         type: "bool",
+        default: "true",
         description:
-          "Remove the task's worktree after a successful land (the branch stays). Dirty worktrees, the base checkout, and the caller's own worktree are refused — the outcome is reported in the result's `worktree` field, never thrown.",
+          "Remove the task's worktree after a successful land (default; the branch always stays). Pass --remove-worktree=false to keep it. Dirty worktrees, the base checkout, and the caller's own worktree are refused — the outcome is reported in the result's `worktree` field, never thrown.",
       },
     ],
     handler: land,

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -37,7 +37,12 @@ export interface LandTaskOpts {
   readonly deleteBranch?: boolean
   /** Archive the task after a successful land (moves it off the active board). */
   readonly archive?: boolean
-  /** Remove the task's worktree after a successful land (the branch stays). */
+  /**
+   * Remove the task's worktree after a successful land (the branch stays).
+   * Defaults to ON: once a branch is landed its worktree is dead weight, and
+   * leaving one behind per land piles up directories nobody prunes. Pass
+   * `false` to keep it. Never forces — see {@link LandWorktreeCleanup}.
+   */
   readonly removeWorktree?: boolean
   /** The land caller's cwd — a caller inside the worktree it asks to remove is refused. */
   readonly callerCwd?: string
@@ -51,15 +56,16 @@ export interface LandDeps {
   readonly clearWorktreePath: (id: TaskId | string) => Promise<void>
 }
 
-/** Outcome of the opt-in post-land worktree removal — reported in the result, never thrown. */
+/** Outcome of the post-land worktree removal — reported in the result, never thrown. */
 export interface LandWorktreeCleanup {
   readonly removed: boolean
   readonly reason?: string
 }
 
 /**
- * Land `task`'s branch (via {@link landTask}) and then run the opt-in cleanup:
- * delete the now-landed branch, archive the settled task. The merge has already
+ * Land `task`'s branch (via {@link landTask}) and then run the cleanup: drop
+ * the now-landed worktree (on by default), delete the branch and archive the
+ * settled task (both opt-in). The merge has already
  * committed once cleanup runs, so it must stand — a `deleteBranch` failure is
  * best-effort inside `remove`-style deletion, and archiving is a plain store
  * write. Extracted from the orchestrator so `core.ts` stays a thin delegator.
@@ -71,7 +77,12 @@ export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: 
   // Worktree removal runs BEFORE branch deletion: git refuses to delete a
   // branch that's still checked out in a live worktree, so the reverse order
   // would leave --delete-branch a silent no-op when combined with it.
-  const worktree = opts.removeWorktree ? await removeLandedWorktree(task, opts.callerCwd, deps) : undefined
+  //
+  // Removal is the DEFAULT, not an opt-in: a landed task's worktree is spent,
+  // and the opt-in shape meant every land left one behind. Only an explicit
+  // `removeWorktree: false` keeps it. The BRANCH is untouched either way —
+  // git is the durable record, the directory is not.
+  const worktree = opts.removeWorktree === false ? undefined : await removeLandedWorktree(task, opts.callerCwd, deps)
   if (opts.deleteBranch) await deps.worktrees.deleteBranch(task.repo, result.branch, { force: true })
   if (opts.archive) await deps.setArchived(task.id, true)
   return worktree ? { ...result, worktree } : result
@@ -127,7 +138,8 @@ export interface LandResult {
   readonly landedOn: string
   /** Short SHA of the merge/commit that landed the work. */
   readonly commit: string
-  /** Present only when `removeWorktree` was requested — the cleanup outcome. */
+  /** The post-land worktree cleanup outcome. Present unless removal was
+   *  explicitly declined (`removeWorktree: false`). */
   readonly worktree?: LandWorktreeCleanup
 }
 

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -181,10 +181,20 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
     if (ok !== true) return
     setBusyPath(row.path)
     try {
-      const res = await orch.landTask(taskId)
+      // Land removes the worktree by default — same as the CLI, so the row
+      // clears itself. `callerCwd` lets the daemon refuse the worktree this
+      // TUI is itself running from instead of deleting its own cwd.
+      const res = await orch.landTask(taskId, { callerCwd: process.cwd() })
       console.error(
         `[rove worktrees] ${t("worktrees.land.done", { branch: res.branch, landedOn: res.landedOn, commit: res.commit })}`,
       )
+      // A refused removal is reported, never thrown — the land still stands,
+      // so say why the directory is still there rather than leaving it silent.
+      if (res.worktree && !res.worktree.removed) {
+        console.error(
+          `[rove worktrees] ${t("worktrees.land.worktreeKept", { reason: res.worktree.reason ?? "refused" })}`,
+        )
+      }
       refetch()
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -45,12 +45,13 @@ export const en = {
     button: "Land",
     confirmTitle: "Land branch?",
     confirmBody:
-      'Merge "{branch}" into the base repo\'s current branch? A dirty base checkout is refused; conflicts abort with a file list.',
+      'Merge "{branch}" into the base repo\'s current branch, then remove this worktree? The branch is kept. A dirty base checkout is refused; conflicts abort with a file list.',
     noTask: "This worktree isn't tracked as a Rove task — nothing to land.",
     conflict: "Land hit conflicts (merge aborted). Resolve by hand: {files}",
     dirtyBase: "The base checkout has uncommitted changes — commit or stash them, then land.",
     failed: "Land failed: {error}",
     done: 'Landed "{branch}" onto {landedOn} ({commit}).',
+    worktreeKept: "Landed, but the worktree was kept: {reason}",
   },
 
   hint: {},
@@ -96,12 +97,14 @@ export const zh: typeof en = {
   land: {
     button: "合入",
     confirmTitle: "合入分支？",
-    confirmBody: '把 "{branch}" 合入基仓库当前分支？基础检出有未提交改动会被拒绝；冲突会中止并给出文件清单。',
+    confirmBody:
+      '把 "{branch}" 合入基仓库当前分支，然后移除这个 worktree？分支会保留。基础检出有未提交改动会被拒绝；冲突会中止并给出文件清单。',
     noTask: "该 worktree 未作为 Rove 任务被跟踪——没有可合入的对象。",
     conflict: "合入遇到冲突（已中止）。请手动解决：{files}",
     dirtyBase: "基础检出有未提交改动——请先提交或 stash，再合入。",
     failed: "合入失败：{error}",
     done: '已把 "{branch}" 合入 {landedOn}（{commit}）。',
+    worktreeKept: "已合入，但 worktree 保留了：{reason}",
   },
 
   hint: {},

--- a/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
+++ b/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
@@ -237,24 +237,29 @@ describe("task lifecycle handlers", () => {
     expect(result).toEqual({ task, running: true, tabs })
   })
 
-  it("land --remove-worktree sends the caller's cwd so the daemon can refuse self-removal", async () => {
-    const client = new FakeClient({
-      "task.land": () => ({ result: { branch: "b", strategy: "merge", landedOn: "main", commit: "abc" } }),
-    })
-    await invokeVerb("land", ["--task-id", "t1", "--remove-worktree"], { client, runtime: stubRuntime() })
-    const payload = client.requests[0]?.payload as { removeWorktree?: boolean; callerCwd?: string }
-    expect(payload.removeWorktree).toBe(true)
-    expect(payload.callerCwd).toBe(process.cwd())
-  })
-
-  it("plain land does not leak a callerCwd", async () => {
+  it("plain land leaves removeWorktree undefined (daemon default: remove) and always sends callerCwd", async () => {
+    // Removal is the default path now, so the "refusing to remove the caller's
+    // own worktree" guard must be armed on EVERY land — sending callerCwd only
+    // for the explicit flag would leave an agent free to delete its own cwd.
+    // `removeWorktree` stays undefined so the orchestrator default applies;
+    // coercing it to false here would silently pin the old opt-in behaviour.
     const client = new FakeClient({
       "task.land": () => ({ result: { branch: "b", strategy: "merge", landedOn: "main", commit: "abc" } }),
     })
     await invokeVerb("land", ["--task-id", "t1"], { client, runtime: stubRuntime() })
     const payload = client.requests[0]?.payload as { removeWorktree?: boolean; callerCwd?: string }
+    expect(payload.removeWorktree).toBeUndefined()
+    expect(payload.callerCwd).toBe(process.cwd())
+  })
+
+  it("land --remove-worktree=false opts out of the removal", async () => {
+    const client = new FakeClient({
+      "task.land": () => ({ result: { branch: "b", strategy: "merge", landedOn: "main", commit: "abc" } }),
+    })
+    await invokeVerb("land", ["--task-id", "t1", "--remove-worktree=false"], { client, runtime: stubRuntime() })
+    const payload = client.requests[0]?.payload as { removeWorktree?: boolean; callerCwd?: string }
     expect(payload.removeWorktree).toBe(false)
-    expect(payload.callerCwd).toBeUndefined()
+    expect(payload.callerCwd).toBe(process.cwd())
   })
 
   it("land maps EMPTY_BRANCH_DIRTY_WORKTREE to an executable recovery send (worker commits its own work)", async () => {

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -183,7 +183,7 @@ describe("landTask", () => {
   })
 })
 
-describe("landTaskWithCleanup --remove-worktree", () => {
+describe("landTaskWithCleanup worktree cleanup", () => {
   let wt: string
 
   /** Real worktree on branch `feat` with one committed file, base back on main. */
@@ -224,11 +224,36 @@ describe("landTaskWithCleanup --remove-worktree", () => {
     expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true) // the merge itself landed
   })
 
-  test("dirty worktree is refused (no force) but the land still stands", async () => {
+  test("land with no opts removes the worktree by default, keeping the branch", async () => {
+    // The DEFAULT, not the flag: `{}` is what the TUI and a flagless
+    // `rove api land` send. Revert land.ts to `opts.removeWorktree ? … :
+    // undefined` and this goes red on its first two assertions.
+    makeWorktree()
+    const { deps: d, cleared } = deps()
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, {}, d)
+    expect(res.worktree).toEqual({ removed: true })
+    expect(fs.existsSync(wt)).toBe(false)
+    expect(branchExists("feat")).toBe(true)
+    expect(cleared).toEqual(["t-land"])
+    expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true)
+  })
+
+  test("removeWorktree: false keeps the worktree and reports no cleanup", async () => {
+    makeWorktree()
+    const { deps: d, cleared } = deps()
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { removeWorktree: false }, d)
+    expect(res.worktree).toBeUndefined()
+    expect(fs.existsSync(wt)).toBe(true)
+    expect(branchExists("feat")).toBe(true)
+    expect(cleared).toEqual([])
+    expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true) // the merge still landed
+  })
+
+  test("a dirty worktree is refused on the default path, and the land still stands", async () => {
     makeWorktree()
     fs.writeFileSync(path.join(wt, "wip.txt"), "uncommitted\n")
     const { deps: d, cleared } = deps()
-    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { removeWorktree: true }, d)
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, {}, d)
     expect(res.worktree?.removed).toBe(false)
     expect(res.worktree?.reason).toMatch(/dirty/)
     expect(fs.existsSync(path.join(wt, "wip.txt"))).toBe(true)
@@ -236,14 +261,10 @@ describe("landTaskWithCleanup --remove-worktree", () => {
     expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true)
   })
 
-  test("caller inside the worktree is refused with an explanation", async () => {
+  test("caller inside the worktree is refused on the default path too", async () => {
     makeWorktree()
     const { deps: d } = deps()
-    const res = await landTaskWithCleanup(
-      { ...task("feat"), worktreePath: wt },
-      { removeWorktree: true, callerCwd: wt },
-      d,
-    )
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { callerCwd: wt }, d)
     expect(res.worktree?.removed).toBe(false)
     expect(res.worktree?.reason).toMatch(/caller's own worktree/)
     expect(fs.existsSync(wt)).toBe(true)
@@ -256,13 +277,5 @@ describe("landTaskWithCleanup --remove-worktree", () => {
     expect(res.worktree?.removed).toBe(false)
     expect(res.worktree?.reason).toMatch(/base checkout/)
     expect(fs.existsSync(repo)).toBe(true)
-  })
-
-  test("without removeWorktree the result has no worktree field", async () => {
-    makeWorktree()
-    const { deps: d } = deps()
-    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, {}, d)
-    expect(res.worktree).toBeUndefined()
-    expect(fs.existsSync(wt)).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

`land` collected the branch and left the worktree standing. Removal was opt-in behind `--remove-worktree`, so the common path — `rove api land --task-id X`, or `l` on the TUI worktrees page — always left a dead directory behind. Eleven piled up in one night of fan-out work, and nothing prunes them.

## What changed

**Removal is now the default; `--remove-worktree=false` opts out.** The negative form follows the existing convention (`archive --archived=false`, `pin --pinned=false`) — the parser already handles `--flag=false`, so no new spelling was invented, and no `--keep-worktree` was added.

The default lives in **one** place, `landTaskWithCleanup`:

```ts
const worktree = opts.removeWorktree === false ? undefined : await removeLandedWorktree(...)
```

Everything upstream now passes `undefined` through rather than coercing it to `false`, so the CLI, the TUI, and the daemon all inherit that single default:

- `src/cli/api/handlers-tasks.ts` — sends `ctx.args.bool("remove-worktree")` unchanged (was `?? false`), and **always** sends `callerCwd`. It used to send it only when `--remove-worktree` was set; with removal on the default path that would leave the "refusing to remove the caller's own worktree" guard disarmed exactly when it matters — an agent landing its own task would delete its own cwd.
- `packages/kobe-daemon/src/daemon/handlers-task.ts` — `optionalBoolean(payload, "removeWorktree")` instead of `… === true`. Without this the daemon flattened every absent flag to `false` and masked the new default for every caller.
- `src/cli/api/verbs-lifecycle.ts` — flag now carries `default: "true"` and says how to opt out.

### The TUI gets the same default (point 3)

`worktrees-page.tsx` calls `orch.landTask(taskId)` with no opts. Because the default now lives in the orchestrator, that call inherits it for free — **land cleans up identically from the CLI and the TUI**. A land that tidies up from one entry point but not the other is worse than either: the same key, the same verb, two different amounts of leftover state on disk, and no way for a user to know which they got.

Two things were added there rather than left implicit:

- `{ callerCwd: process.cwd() }` — same reasoning as the CLI. The TUI process can be running from inside the worktree being landed.
- A refused removal is now printed (`worktrees.land.worktreeKept`, en + zh). Refusals are reported in the result, never thrown, so without this the directory would just silently still be there. The confirm dialog copy now also says the worktree goes and the branch stays.

### Not touched

**Branch deletion semantics are unchanged.** The branch is git's durable record and survives every path here; only the working directory is removed. None of the three refusal guards was weakened or bypassed — a refused removal still leaves the land itself standing.

## Relationship to #505 — rebased around, not stacked

#505 (`fix/land-delete-branch-implies-worktree-removal`) is open and edits the same function. **This PR is based on fresh `origin/main` and deliberately does not stack on it.** This repo squash-merges: a branch stacked on #505 would, once #505 squashed into `main`, have to replay #505's own commits over content already there — a messy duplicate-history rebase. Based on `main`, whichever of the two lands second needs one small conflict resolution confined to the `landTaskWithCleanup` body.

The two changes compose cleanly, and the combined intent is:

```ts
const removeWorktree = opts.removeWorktree !== false || opts.deleteBranch === true
const worktree = removeWorktree ? await removeLandedWorktree(task, opts.callerCwd, deps) : undefined
```

i.e. #505's "`--delete-branch` implies removal" still overrides an explicit `--remove-worktree=false` (a branch cannot be deleted while a worktree holds it), and #505's `branchDeletable` gate is untouched. #505 also makes the CLI send `callerCwd` for `--delete-branch`; this PR sends it unconditionally, which subsumes that line.

## Tests

`test/orchestrator/land.test.ts` (real git, no mocks):

- `land with no opts removes the worktree by default, keeping the branch` — the new default
- `removeWorktree: false keeps the worktree and reports no cleanup` — the opt-out
- `a dirty worktree is refused on the default path, and the land still stands`
- `caller inside the worktree is refused on the default path too`

The two refusal tests were switched from `{ removeWorktree: true }` to the default path, so the guards are proven where users now actually hit them.

**Proof the default test is real.** Reverting `land.ts` to `opts.removeWorktree ? … : undefined` and re-running:

```
 × landTaskWithCleanup worktree cleanup > land with no opts removes the worktree by default, keeping the branch
   → expected undefined to deeply equal { removed: true }
 × landTaskWithCleanup worktree cleanup > a dirty worktree is refused on the default path, and the land still stands
   → expected undefined to be false // Object.is equality
 × landTaskWithCleanup worktree cleanup > caller inside the worktree is refused on the default path too
   → expected undefined to be false // Object.is equality

 Tests  3 failed | 10 passed (13)
```

Restored, all 13 pass.

`test/cli/api-handlers-lifecycle.test.ts` had a test pinning the old contract (`plain land does not leak a callerCwd`, asserting `removeWorktree === false`). That contract is exactly what this PR flips, so it was rewritten to assert the new one — `removeWorktree` undefined, `callerCwd` always sent — plus a new case for `--remove-worktree=false`.

## Verification

- `bun run test:fast` — 3592 passed / 365 files
- `bun test test/render/worktrees-page-delete.test.tsx test/render/host-pages.test.tsx` — 17 pass (worktrees page touched)
- repo-root `bun run lint` and `bun run typecheck` — green
- `check-i18n` — 677 keys × 2 locales in sync

## Docs

- `docs/API.md` — the `land` verb signature now reads `[--remove-worktree=false]`, and the paragraph states removal is the default and the branch always stays.
- `docs/WORKTREES.md` — replaced "Landing does not remove the worktree" (now false) with what actually happens, including the refusal case.
- `docs/CLI.md` does not document `land`, so it needed no change.
