### PR TITLE
fix: land's review follow-up — stale docs and a false "worktree kept" report

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -330,7 +330,7 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `pin --task-id ID [--pinned=false]` | Pin/unpin |
 | `set-active --task-id ID` / `--none` | Change shared active task |
 | `ensure-worktree --task-id ID` | Materialize without starting an engine |
-| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--then-archive] [--remove-worktree]` | Merge the task's branch into the base repo's current branch; `--remove-worktree` cleans up the Worktree after (branch stays; dirty/self/base refused, outcome in the result's `worktree` field) |
+| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--then-archive] [--remove-worktree=false]` | Merge the task's branch into the base repo's current branch; the Worktree is removed by default (`--remove-worktree=false` keeps it). The branch always stays; dirty/self/base removals are refused, outcome in the result's `worktree` field |
 | `delete --task-id ID [--force] [--delete-branch]` | Remove task + Worktree; the git branch stays unless `--delete-branch` (and `--force` never implies it) |
 | `discover-adoptable --repo PATH` | Find untracked Worktrees |
 | `adopt --repo PATH --worktree PATH` | Import a Worktree |

--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -115,7 +115,7 @@ set-command    --task-id(REQ) --command(REQ)      next launch only
 set-status     --task-id(REQ) --status(REQ)[backlog|in_progress|in_review|done|canceled|error]
 archive        --task-id(REQ) --archived(true)
 pin            --task-id(REQ) --pinned(true)
-land           --task-id(REQ) --strategy[merge|squash] --delete-branch --then-archive --remove-worktree
+land           --task-id(REQ) --strategy[merge|squash] --delete-branch --then-archive --remove-worktree(true)
 delete         --task-id(REQ) --force --delete-branch
 ```
 

--- a/.changeset/land-worktree-kept-report.md
+++ b/.changeset/land-worktree-kept-report.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`land` no longer reports a removed worktree as kept. `removeLandedWorktree` wrapped the git removal and the task-store write in one try/catch, so a failed `clearWorktreePath` returned `{ removed: false }` for a directory that was already gone — sending you to look for a worktree that no longer exists. The two are separated: once the removal succeeds the outcome is `removed: true`, with the bookkeeping failure carried in `reason`.
+
+Also corrects docs that still described `--remove-worktree` as opt-in after it became the default: the fan-out walkthrough in `ORCHESTRATION.md`, the daemon's wire-contract comment, and the agent-facing skill tables (now `--remove-worktree(true)`, matching `--archived(true)`).

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -330,7 +330,7 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `pin --task-id ID [--pinned=false]` | Pin/unpin |
 | `set-active --task-id ID` / `--none` | Change shared active task |
 | `ensure-worktree --task-id ID` | Materialize without starting an engine |
-| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--then-archive] [--remove-worktree]` | Merge the task's branch into the base repo's current branch; `--remove-worktree` cleans up the Worktree after (branch stays; dirty/self/base refused, outcome in the result's `worktree` field) |
+| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--then-archive] [--remove-worktree=false]` | Merge the task's branch into the base repo's current branch; the Worktree is removed by default (`--remove-worktree=false` keeps it). The branch always stays; dirty/self/base removals are refused, outcome in the result's `worktree` field |
 | `delete --task-id ID [--force] [--delete-branch]` | Remove task + Worktree; the git branch stays unless `--delete-branch` (and `--force` never implies it) |
 | `discover-adoptable --repo PATH` | Find untracked Worktrees |
 | `adopt --repo PATH --worktree PATH` | Import a Worktree |

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -115,7 +115,7 @@ set-command    --task-id(REQ) --command(REQ)      next launch only
 set-status     --task-id(REQ) --status(REQ)[backlog|in_progress|in_review|done|canceled|error]
 archive        --task-id(REQ) --archived(true)
 pin            --task-id(REQ) --pinned(true)
-land           --task-id(REQ) --strategy[merge|squash] --delete-branch --then-archive --remove-worktree
+land           --task-id(REQ) --strategy[merge|squash] --delete-branch --then-archive --remove-worktree(true)
 delete         --task-id(REQ) --force --delete-branch
 ```
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -128,9 +128,9 @@ rove api archive --task-id <loser2>
 
 `land` refuses a dirty base checkout, and on merge conflict aborts cleanly
 and returns the conflicted files for manual resolution. `delete` removes a
-loser's worktree but keeps its branch (git is the durable record); add
-`--remove-worktree` to `land` to clean up the winner's worktree in the same
-call. Finish rounds — a sidebar full of stale attempts is where the next
+loser's worktree but keeps its branch (git is the durable record); `land`
+cleans up the winner's worktree in the same call by default, so a finished
+round leaves no stale directories behind. Finish rounds — a sidebar full of stale attempts is where the next
 round's confusion comes from.
 
 ## Failure modes
@@ -191,7 +191,7 @@ git -C <worktreePath> log --oneline main..HEAD
 git -C <worktreePath> diff main...HEAD
 
 # 4. Land it, archive the rest.
-rove api land --task-id <winner> --then-archive --remove-worktree
+rove api land --task-id <winner> --then-archive
 rove api archive --task-id <loser1>
 rove api archive --task-id <loser2>
 ```

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -129,8 +129,9 @@ rove api archive --task-id <loser2>
 `land` refuses a dirty base checkout, and on merge conflict aborts cleanly
 and returns the conflicted files for manual resolution. `delete` removes a
 loser's worktree but keeps its branch (git is the durable record); `land`
-cleans up the winner's worktree in the same call by default, so a finished
-round leaves no stale directories behind. Finish rounds — a sidebar full of stale attempts is where the next
+removes the winner's worktree in the same call by default. Archiving a loser
+leaves its worktree on disk, so `delete` is what reclaims those directories.
+Finish rounds — a sidebar full of stale attempts is where the next
 round's confusion comes from.
 
 ## Failure modes

--- a/docs/design/task-lifecycle.md
+++ b/docs/design/task-lifecycle.md
@@ -80,9 +80,9 @@ stateDiagram-v2
 Trigger sources:
 
 - **Land success** (`task.land`): the merge just happened locally, so the
-  answer is authoritative. `--remove-worktree` already implements the cleanup
-  half; the remaining work is making it the default behavior of a settled
-  task rather than an opt-in flag.
+  answer is authoritative. Removing the worktree is already the default for
+  a settled task (`--remove-worktree=false` opts out), so the cleanup half is
+  done.
 - **Daemon detection**: a task whose PR merged on the forge (the user merged
   in the browser, or an agent landed it from another checkout). The daemon
   already polls PR status (`pr-status-collector.ts`); a `merged` PR + a clean

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -104,7 +104,9 @@ export interface LandResult {
   readonly landedOn: string
   readonly commit: string
   /** The post-land worktree cleanup outcome. Present unless removal was
-   *  explicitly declined (`removeWorktree: false`). */
+   *  explicitly declined (`removeWorktree: false`). `reason` is not
+   *  failure-only: it also rides with `removed: true` when the directory went
+   *  but clearing the task's worktree path did not. */
   readonly worktree?: { readonly removed: boolean; readonly reason?: string }
 }
 

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -103,7 +103,8 @@ export interface LandResult {
   readonly strategy: "merge" | "squash"
   readonly landedOn: string
   readonly commit: string
-  /** Present only when the land requested worktree removal — the cleanup outcome. */
+  /** The post-land worktree cleanup outcome. Present unless removal was
+   *  explicitly declined (`removeWorktree: false`). */
   readonly worktree?: { readonly removed: boolean; readonly reason?: string }
 }
 

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -283,10 +283,10 @@ export async function land(ctx: VerbContext): Promise<unknown> {
       // the worktree. Coercing undefined to false here would pin the CLI to
       // the old opt-in behaviour.
       removeWorktree: ctx.args.bool("remove-worktree"),
-      // The daemon refuses to remove the worktree the caller is running from —
-      // it can only know where the caller is if we tell it. Removal is the
-      // default path now, so this is sent on EVERY land: send it only for the
-      // explicit flag and an agent landing itself deletes its own cwd.
+      // Sent on EVERY land: the daemon refuses to remove the worktree the
+      // caller is running from, and it can only know where that is if we tell
+      // it. Since removal is now the default rather than an opt-in flag, an
+      // agent landing its own task would otherwise delete its own cwd.
       callerCwd: process.cwd(),
     })
   } catch (err) {

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -124,11 +124,24 @@ async function removeLandedWorktree(
   }
   try {
     await deps.worktrees.remove(worktreePath)
-    await deps.clearWorktreePath(task.id)
-    return { removed: true }
   } catch (err) {
-    return { removed: false, reason: err instanceof Error ? err.message : String(err) }
+    return { removed: false, reason: errText(err) }
   }
+  // Past this point the directory IS gone, so the outcome is `removed: true`
+  // whatever the store write does. Folding the two calls into one try/catch
+  // would report `removed: false` when only the bookkeeping failed — telling
+  // the user to go look for a worktree that no longer exists. The failure is
+  // still reported, in `reason`, because a dangling `worktreePath` is real.
+  try {
+    await deps.clearWorktreePath(task.id)
+  } catch (err) {
+    return { removed: true, reason: `worktree removed, but clearing the task's worktree path failed: ${errText(err)}` }
+  }
+  return { removed: true }
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 export interface LandResult {

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -56,7 +56,11 @@ export interface LandDeps {
   readonly clearWorktreePath: (id: TaskId | string) => Promise<void>
 }
 
-/** Outcome of the post-land worktree removal — reported in the result, never thrown. */
+/**
+ * Outcome of the post-land worktree removal — reported in the result, never
+ * thrown. `reason` is not failure-only: it also accompanies `removed: true`
+ * when the directory went but clearing the task's worktree path did not.
+ */
 export interface LandWorktreeCleanup {
   readonly removed: boolean
   readonly reason?: string

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -188,12 +188,16 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
       console.error(
         `[rove worktrees] ${t("worktrees.land.done", { branch: res.branch, landedOn: res.landedOn, commit: res.commit })}`,
       )
-      // A refused removal is reported, never thrown — the land still stands,
-      // so say why the directory is still there rather than leaving it silent.
-      if (res.worktree?.removed === false) {
-        console.error(
-          `[rove worktrees] ${t("worktrees.land.worktreeKept", { reason: res.worktree.reason ?? "refused" })}`,
-        )
+      // Two cleanup outcomes carry information, and neither is ever thrown —
+      // nothing surfaces them but this. A refused removal leaves the directory
+      // in place; a removal whose bookkeeping write failed takes the directory
+      // but leaves the task still pointing at it. They need different copy:
+      // `worktreeKept` would be actively wrong for the second.
+      const cleanup = res.worktree
+      if (cleanup && !cleanup.removed) {
+        console.error(`[rove worktrees] ${t("worktrees.land.worktreeKept", { reason: cleanup.reason ?? "refused" })}`)
+      } else if (cleanup?.reason) {
+        console.error(`[rove worktrees] ${t("worktrees.land.worktreePathStale", { reason: cleanup.reason })}`)
       }
       refetch()
     } catch (err) {

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -190,7 +190,7 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
       )
       // A refused removal is reported, never thrown — the land still stands,
       // so say why the directory is still there rather than leaving it silent.
-      if (res.worktree && !res.worktree.removed) {
+      if (res.worktree?.removed === false) {
         console.error(
           `[rove worktrees] ${t("worktrees.land.worktreeKept", { reason: res.worktree.reason ?? "refused" })}`,
         )

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -52,6 +52,7 @@ export const en = {
     failed: "Land failed: {error}",
     done: 'Landed "{branch}" onto {landedOn} ({commit}).',
     worktreeKept: "Landed, but the worktree was kept: {reason}",
+    worktreePathStale: "Landed and removed the worktree, but the task still points at it: {reason}",
   },
 
   hint: {},
@@ -105,6 +106,7 @@ export const zh: typeof en = {
     failed: "合入失败：{error}",
     done: '已把 "{branch}" 合入 {landedOn}（{commit}）。',
     worktreeKept: "已合入，但 worktree 保留了：{reason}",
+    worktreePathStale: "已合入并移除 worktree，但任务仍指向它：{reason}",
   },
 
   hint: {},

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -270,6 +270,27 @@ describe("landTaskWithCleanup worktree cleanup", () => {
     expect(fs.existsSync(wt)).toBe(true)
   })
 
+  test("a failed worktreePath clear still reports the worktree as removed", async () => {
+    // The directory really is gone by then, so reporting `removed: false`
+    // because only the store write failed would send the user looking for a
+    // worktree that no longer exists. The failure still rides in `reason`.
+    makeWorktree()
+    const res = await landTaskWithCleanup(
+      { ...task("feat"), worktreePath: wt },
+      {},
+      {
+        worktrees: new GitWorktreeManager(),
+        setArchived: async () => {},
+        clearWorktreePath: async () => {
+          throw new Error("tasks.json write failed")
+        },
+      },
+    )
+    expect(res.worktree?.removed).toBe(true)
+    expect(res.worktree?.reason).toMatch(/tasks\.json write failed/)
+    expect(fs.existsSync(wt)).toBe(false)
+  })
+
   test("never removes the base checkout even if worktreePath points at it", async () => {
     makeWorktree()
     const { deps: d } = deps()

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -271,9 +271,6 @@ describe("landTaskWithCleanup worktree cleanup", () => {
   })
 
   test("a failed worktreePath clear still reports the worktree as removed", async () => {
-    // The directory really is gone by then, so reporting `removed: false`
-    // because only the store write failed would send the user looking for a
-    // worktree that no longer exists. The failure still rides in `reason`.
     makeWorktree()
     const res = await landTaskWithCleanup(
       { ...task("feat"), worktreePath: wt },


### PR DESCRIPTION
Follow-up to #606. That PR was squash-merged at its **first** commit (`commits=1`, head `13e931bb`) and released as 0.8.201, so the review-fix commit that answered its own Claude review never reached `main`. Everything below is verified missing from `main` today — this PR is that commit, cherry-picked onto fresh `origin/main`, plus its own changeset (the original was consumed by the release).

## The bug

`removeLandedWorktree` wrapped two different operations in one try/catch:

```ts
await deps.worktrees.remove(worktreePath)
await deps.clearWorktreePath(task.id)
return { removed: true }
} catch (err) {
  return { removed: false, reason: … }
```

If the git removal succeeds but the task-store write throws, the land reports `{ removed: false }` for a directory that is **already gone from disk** — telling the user to go look for a worktree that no longer exists, while `task.worktreePath` is left dangling. #606 made worktree removal the default, so this path went from a rare opt-in edge case to the one every land takes.

Split: once `remove()` succeeds the outcome is `removed: true` regardless of the store write, and the bookkeeping failure rides in `reason` rather than being swallowed. New real-git test (`a failed worktreePath clear still reports the worktree as removed`) injects a throwing `clearWorktreePath` and asserts `removed: true` with the directory actually gone.

## Docs that are wrong on `main` right now

- **`docs/ORCHESTRATION.md`** — was the Blocking finding. It still tells readers to *add* `--remove-worktree` to `land` for cleanup, and passes it in the fan-out example where it is now redundant. This page is in CLAUDE.md's user-facing docs set, so a CLI-verb behavior change is supposed to update it in the same PR; #606 updated `API.md` and `WORKTREES.md` and missed this one.
- **`packages/kobe-daemon/src/daemon/contracts.ts`** — the wire-contract comment still reads "Present only when the land requested worktree removal", now backwards (it is present *unless* removal was declined). `land.ts` already carries the corrected wording.
- **`.agents/skills/kobe/`** and its identical `claude-plugin/skills/rove/` copy — still list `--remove-worktree` as a plain opt-in flag instead of `--remove-worktree(true)`, the convention already used for `--archived(true)`/`--pinned(true)` in the same tables. Agents drive `land` from these files, so this misleads them into passing a redundant flag and into believing the worktree survives.
- **`docs/design/task-lifecycle.md`** — described removal-by-default as "the remaining work". It shipped.
- **`packages/kobe/src/cli/api/handlers-tasks.ts`** — the `callerCwd` comment contradicted itself ("sent on EVERY land" then "send it only for the explicit flag"), describing the old behavior alongside the new. Rewritten to state only what the code does.

## Deliberately not included

- **Toasting the refusal message instead of `console.error`.** The review is right that refusals matter more now, but every neighbouring message in `worktrees-page.tsx` (`land.done`, `land.failed`, `land.conflict`) uses `console.error`; converting one leaves the page inconsistent. It is a pre-existing gap across the whole file and belongs in its own change.
- **A test pinning "removal runs before branch deletion".** That ordering is exactly what #505 rewrites; a test here would conflict with it for no gain.
- **Making `LandWorktreeCleanup` a discriminated union / repolarising the flag type.** A type redesign beyond this fix.

## Verification

- `bun run test:fast` — 3593 passed / 365 files
- repo-root `bun run lint` and `bun run typecheck` — green
- Cherry-pick onto current `origin/main` applied cleanly (no conflicts with the squashed #606).
