### PR TITLE
Fix Codex transcript contrast and composer cursor

### DIFF
--- a/.changeset/calm-terminals-report-colors.md
+++ b/.changeset/calm-terminals-report-colors.md
@@ -2,4 +2,4 @@
 "@sma1lboy/rove": patch
 ---
 
-Report the embedded terminal's default foreground and background colors to terminal-aware engines, including sessions started before the TUI attaches, so Codex transcript blocks retain readable contrast.
+Report a stable content-contrast palette to terminal-aware engines, including sessions started before the TUI attaches, so Codex transcript blocks retain their light background and dark text.

--- a/.changeset/calm-terminals-report-colors.md
+++ b/.changeset/calm-terminals-report-colors.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Report the embedded terminal's default foreground and background colors to terminal-aware engines, including sessions started before the TUI attaches, so Codex transcript blocks retain readable contrast.

--- a/.changeset/calm-terminals-report-colors.md
+++ b/.changeset/calm-terminals-report-colors.md
@@ -2,4 +2,4 @@
 "@sma1lboy/rove": patch
 ---
 
-Report a stable content-contrast palette to terminal-aware engines, including sessions started before the TUI attaches, so Codex transcript blocks retain their light background and dark text.
+Report the embedded terminal's real palette to terminal-aware engines, and preserve Codex transcript contrast without changing its dark composer.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -61,6 +61,7 @@
     "./daemon/runtime": "./src/daemon/runtime.ts",
     "./daemon/server": "./src/daemon/server.ts",
     "./daemon/status-disposition": "./src/daemon/status-disposition.ts",
+    "./daemon/terminal-colors": "./src/daemon/terminal-colors.ts",
     "./daemon/transcript-activity-collector": "./src/daemon/transcript-activity-collector.ts",
     "./daemon/ui-prefs-watcher": "./src/daemon/ui-prefs-watcher.ts",
     "./daemon/web-server": "./src/daemon/web-server.ts",

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -259,7 +259,9 @@ export type DaemonRequestName =
   // daemon: the daemon restarts routinely, so the pty host must outlive it.
   // Same frame grammar, so the same client class speaks both. The
   // host owns the raw PTY child + a byte ring buffer per session key; the
-  // TUI keeps VT emulation (xterm-headless) local. `pty.open` attaches
+  // TUI keeps VT emulation (xterm-headless) local. The host answers only
+  // OSC 10/11 default-color queries so headless children see a terminal
+  // palette even while no emulator is attached. `pty.open` attaches
   // the calling CONNECTION (spawning on first open, replaying the ring
   // buffer on reattach); output streams back as targeted `pty.data` event
   // frames written only to attached connections. `pty.sweep` is the

--- a/packages/kobe-daemon/src/daemon/pty-child-controller.ts
+++ b/packages/kobe-daemon/src/daemon/pty-child-controller.ts
@@ -3,7 +3,7 @@
  *
  * Split from `pty-host.ts` for the file-size cap. This module is responsible
  * for starting a PTY child, feeding its output bytes into the session's ring
- * buffer + title scan, observing its exit, and tearing it down. It does NOT
+ * buffer + narrow OSC scans, observing its exit, and tearing it down. It does NOT
  * know about the host's session map, client sinks, or freeze policy — those
  * stay in `PtyHost`.
  */
@@ -15,6 +15,7 @@ import { embeddedTerminalEnv } from "./pty-env.js"
 import { type PtySessionState, type PtySpawnSpec, freshSessionState } from "./pty-host-types.ts"
 import { scanOscTitle } from "./pty-observability.ts"
 import { terminatePtyChild } from "./pty-termination.ts"
+import { foldDefaultColorQueries, formatDefaultColorReply } from "./terminal-colors.ts"
 
 export interface PtyChildControllerDeps {
   /** How children spawn. Default Bun's; the Windows host injects node-pty's. */
@@ -117,6 +118,15 @@ export class PtyChildController {
 
   private onData(session: PtySessionState, data: string | Uint8Array): void {
     const buf = typeof data === "string" ? Buffer.from(data, "utf8") : Buffer.from(data)
+    const colorQueries = foldDefaultColorQueries(session.colorQueryCarry, buf.toString("latin1"))
+    session.colorQueryCarry = colorQueries.carry
+    for (const slot of colorQueries.slots) {
+      try {
+        session.proc?.write(formatDefaultColorReply(slot, session.defaultColors))
+      } catch {
+        /* child may have exited between emitting the query and our reply */
+      }
+    }
     scanOscTitle(session, buf)
     session.chunks.push(buf)
     session.bytes += buf.byteLength

--- a/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
@@ -33,6 +33,7 @@ import { StringDecoder } from "node:string_decoder"
 import { defaultPtyFreezeDir } from "./paths.ts"
 import type { PtySessionExit } from "./protocol.ts"
 import type { PtySessionState } from "./pty-host-types.ts"
+import { DEFAULT_TERMINAL_COLORS } from "./terminal-colors.ts"
 
 /** Record format version — unknown versions read as absent (forward-safe). */
 const FREEZE_VERSION = 1
@@ -131,6 +132,8 @@ export function thawSession(record: FrozenPtySession, cap: number): PtySessionSt
     title: record.title,
     titleCarry: "",
     titleDecoder: new StringDecoder("utf8"),
+    colorQueryCarry: "",
+    defaultColors: DEFAULT_TERMINAL_COLORS,
     sinks: new Map(),
     parked: false,
     parkedScreenBytes: 0,

--- a/packages/kobe-daemon/src/daemon/pty-host-types.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host-types.ts
@@ -6,6 +6,7 @@ import type { DaemonFrame, PtySessionExit } from "./protocol.ts"
 import type { PtyChild, PtyDriver } from "./pty-driver.ts"
 import type { PtyFreezeSink } from "./pty-freeze-store.ts"
 import type { PtySessionEndInfo } from "./pty-observability.ts"
+import { DEFAULT_TERMINAL_COLORS, type TerminalDefaultColors, parseTerminalDefaultColors } from "./terminal-colors.ts"
 
 /** Everything `pty.open` needs to spawn a session's child on first open. */
 export interface PtySpawnSpec {
@@ -20,6 +21,8 @@ export interface PtySpawnSpec {
    *  always sends its real pane size) take last-attach-wins. */
   readonly cols?: number
   readonly rows?: number
+  /** Default colors reported to child applications through OSC 10/11. */
+  readonly defaultColors?: TerminalDefaultColors
 }
 
 /** Attach result — mirrors the wire `PtyOpenResult`. */
@@ -71,6 +74,10 @@ export interface PtySessionState {
   titleCarry: string
   /** UTF-8 decoder for the title scan (a multibyte title may split across chunks). */
   readonly titleDecoder: StringDecoder
+  /** Incomplete OSC 10/11 query carried across PTY output chunks. */
+  colorQueryCarry: string
+  /** Colors this terminal reports to applications running in the child. */
+  defaultColors: TerminalDefaultColors
   /** Attached connections, keyed by connection identity (the server's ClientState). */
   readonly sinks: Map<object, PtySink>
   /** A detached TUI still holds a serialized screen for an exact-delta wake. */
@@ -124,6 +131,8 @@ export function freshSessionState(key: string, spec: PtySpawnSpec, argv: readonl
     title: "",
     titleCarry: "",
     titleDecoder: new StringDecoder("utf8"),
+    colorQueryCarry: "",
+    defaultColors: parseTerminalDefaultColors(spec.defaultColors) ?? DEFAULT_TERMINAL_COLORS,
     sinks: new Map(),
     parked: false,
     parkedScreenBytes: 0,

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -5,8 +5,10 @@
  * daemon owns the raw PTY child (spawned through a `PtyDriver`) plus a
  * capped byte ring buffer per session key, so an engine session keeps
  * running when the TUI exits and replays its screen when a TUI reattaches.
- * VT emulation stays in the TUI (xterm-headless) — this module never parses
- * escape codes, it only moves bytes.
+ * VT emulation stays in the TUI (xterm-headless). The host recognizes only
+ * the narrow OSC 10/11 capability query so detached/headless engines can
+ * learn the same default colors; all output bytes still enter the ring and
+ * cross the socket unchanged.
  *
  * Delivery model: TARGETED, not pub/sub. Each session tracks the
  * connections attached to it; output goes only to those sinks as
@@ -46,6 +48,7 @@ import {
   sessionInfo,
 } from "./pty-observability.ts"
 import { WarmSpare } from "./pty-warm.ts"
+import { parseTerminalDefaultColors } from "./terminal-colors.ts"
 
 export type { PtyHostStats, PtySessionInfo } from "./pty-observability.ts"
 // Re-exported for the cross-chunk title-boundary tests (pure fold).
@@ -171,6 +174,8 @@ export class PtyHost {
       // session out from under its attached TUI garbles the pane (#18).
       this.resize(key, spec.cols, spec.rows)
     }
+    const defaultColors = parseTerminalDefaultColors(spec.defaultColors)
+    if (defaultColors) session.defaultColors = defaultColors
     session.sinks.set(token, sink)
     session.parked = false
     session.parkedScreenBytes = 0
@@ -388,6 +393,7 @@ export class PtyHost {
     if (spec.command && spec.command.length > 0) session.command = [...spec.command]
     session.cols = spec.cols ?? session.cols
     session.rows = spec.rows ?? session.rows
+    session.defaultColors = parseTerminalDefaultColors(spec.defaultColors) ?? session.defaultColors
     this.childController.startChild(session)
     if (!session.alive) return
     this.opts.log?.("pty", `respawned restored session ${session.key} (pid ${session.proc?.pid})`)

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -44,6 +44,7 @@ import type { PtyDriver } from "./pty-driver.ts"
 import { recordPtyExit } from "./pty-exit-store.ts"
 import { clearFrozenSessions, fileFreezeSink, loadFrozenSessions } from "./pty-freeze-store.ts"
 import { PtyHost } from "./pty-host.ts"
+import { parseTerminalDefaultColors } from "./terminal-colors.ts"
 
 /**
  * Grace before a host with ZERO live sessions exits (persistent terminal
@@ -225,6 +226,7 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
             // (spawn defaults live in the host; reattach must not resize).
             cols: typeof payload.cols === "number" ? payload.cols : undefined,
             rows: typeof payload.rows === "number" ? payload.rows : undefined,
+            defaultColors: parseTerminalDefaultColors(payload.defaultColors) ?? undefined,
           },
           client,
           (frame) => writeFrame(client, frame),

--- a/packages/kobe-daemon/src/daemon/pty-warm.ts
+++ b/packages/kobe-daemon/src/daemon/pty-warm.ts
@@ -14,6 +14,7 @@
 
 import { resolveLoginShell } from "./platform-shell.js"
 import type { PtySessionState, PtySpawnSpec } from "./pty-host-types.ts"
+import { parseTerminalDefaultColors } from "./terminal-colors.ts"
 
 export interface WarmSpareDeps {
   readonly spawn: (key: string, spec: PtySpawnSpec, spare: boolean) => PtySessionState
@@ -57,6 +58,7 @@ export class WarmSpare {
     if (want.length !== 1 || want[0] !== spare.command[0]) return null
     this.spare = null
     spare.key = key
+    spare.defaultColors = parseTerminalDefaultColors(spec.defaultColors) ?? spare.defaultColors
     // A size-less spec keeps the spare's dimensions (headless adopters
     // don't care; the first sized attach will resize).
     const cols = spec.cols ?? spare.cols

--- a/packages/kobe-daemon/src/daemon/terminal-colors.ts
+++ b/packages/kobe-daemon/src/daemon/terminal-colors.ts
@@ -8,8 +8,8 @@ export interface TerminalDefaultColors {
 export type DefaultColorSlot = 10 | 11
 
 export const DEFAULT_TERMINAL_COLORS: TerminalDefaultColors = {
-  foreground: "#141413",
-  background: "#eae7df",
+  foreground: "#eae7df",
+  background: "#141413",
 }
 
 const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i

--- a/packages/kobe-daemon/src/daemon/terminal-colors.ts
+++ b/packages/kobe-daemon/src/daemon/terminal-colors.ts
@@ -1,0 +1,72 @@
+/** Default terminal colors and the OSC 10/11 query wire format. */
+
+export interface TerminalDefaultColors {
+  readonly foreground: `#${string}`
+  readonly background: `#${string}`
+}
+
+export type DefaultColorSlot = 10 | 11
+
+export const DEFAULT_TERMINAL_COLORS: TerminalDefaultColors = {
+  foreground: "#eae7df",
+  background: "#141413",
+}
+
+const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i
+// biome-ignore lint/suspicious/noControlCharactersInRegex: OSC is an ESC/BEL terminal protocol.
+const DEFAULT_COLOR_QUERY_RE = /\x1b\](10|11);\?(?:\x07|\x1b\\)/g
+const QUERY_PREFIXES = ["\x1b]10;?", "\x1b]11;?"] as const
+
+function normalizeColor(value: unknown): `#${string}` | null {
+  return typeof value === "string" && HEX_COLOR_RE.test(value) ? (value.toLowerCase() as `#${string}`) : null
+}
+
+/** Validate colors crossing the `pty.open` wire boundary. */
+export function parseTerminalDefaultColors(value: unknown): TerminalDefaultColors | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null
+  const raw = value as Record<string, unknown>
+  const foreground = normalizeColor(raw.foreground)
+  const background = normalizeColor(raw.background)
+  return foreground && background ? { foreground, background } : null
+}
+
+function oscRgb(color: `#${string}`): string {
+  const hex = color.slice(1)
+  return [hex.slice(0, 2), hex.slice(2, 4), hex.slice(4, 6)].map((component) => component.repeat(2)).join("/")
+}
+
+/** One xterm-compatible OSC reply, terminated with ST. */
+export function formatDefaultColorReply(slot: DefaultColorSlot, colors: TerminalDefaultColors): string {
+  const color = slot === 10 ? colors.foreground : colors.background
+  return `\x1b]${slot};rgb:${oscRgb(color)}\x1b\\`
+}
+
+function trailingQueryPrefix(text: string): string {
+  const maxLength = QUERY_PREFIXES[0].length + 1
+  const start = Math.max(0, text.length - maxLength)
+  for (let index = start; index < text.length; index++) {
+    const suffix = text.slice(index)
+    if (QUERY_PREFIXES.some((prefix) => prefix.startsWith(suffix) || suffix === `${prefix}\x1b`)) return suffix
+  }
+  return ""
+}
+
+/**
+ * Find complete OSC 10/11 queries while retaining a query split across PTY
+ * read boundaries. The input is byte-preserving latin1 text; the protocol
+ * itself is ASCII.
+ */
+export function foldDefaultColorQueries(
+  previousCarry: string,
+  chunkText: string,
+): { slots: DefaultColorSlot[]; carry: string } {
+  const text = previousCarry + chunkText
+  const slots: DefaultColorSlot[] = []
+  let end = 0
+  DEFAULT_COLOR_QUERY_RE.lastIndex = 0
+  for (let match = DEFAULT_COLOR_QUERY_RE.exec(text); match; match = DEFAULT_COLOR_QUERY_RE.exec(text)) {
+    slots.push(match[1] === "10" ? 10 : 11)
+    end = match.index + match[0].length
+  }
+  return { slots, carry: trailingQueryPrefix(text.slice(end)) }
+}

--- a/packages/kobe-daemon/src/daemon/terminal-colors.ts
+++ b/packages/kobe-daemon/src/daemon/terminal-colors.ts
@@ -8,8 +8,8 @@ export interface TerminalDefaultColors {
 export type DefaultColorSlot = 10 | 11
 
 export const DEFAULT_TERMINAL_COLORS: TerminalDefaultColors = {
-  foreground: "#eae7df",
-  background: "#141413",
+  foreground: "#141413",
+  background: "#eae7df",
 }
 
 const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -29,6 +29,7 @@ import {
   writeHostedPrompt,
 } from "../../engine/hosted-session.ts"
 import type { EngineSessionLaunch } from "../../engine/session-launch.ts"
+import { readPersistedTerminalDefaultColors } from "../../tui/lib/terminal-colors.ts"
 import { ApiError, type DeliveredPrompt } from "./types.ts"
 
 /**
@@ -194,6 +195,7 @@ export async function deliverHostedPrompt(
     key: launch.key,
     cwd,
     command: launch.command,
+    defaultColors: readPersistedTerminalDefaultColors(),
   })
   try {
     if (!open.alive) {

--- a/packages/kobe/src/engine/codex-local/capabilities.ts
+++ b/packages/kobe/src/engine/codex-local/capabilities.ts
@@ -7,6 +7,7 @@
  */
 
 import type { EngineCapabilities, EngineIdentity } from "@/types/engine"
+import { codexTerminalPresentation } from "./terminal-presentation"
 
 export const CODEX_DEFAULT_MODEL = "gpt-5.3-codex"
 
@@ -17,6 +18,7 @@ export const codexCapabilities: EngineCapabilities = {
   permissionModes: [],
   defaultModelId: () => CODEX_DEFAULT_MODEL,
   contextWindowFor: () => 0,
+  terminalPresentation: codexTerminalPresentation,
 }
 
 export const codexIdentity: EngineIdentity = {

--- a/packages/kobe/src/engine/codex-local/terminal-presentation.ts
+++ b/packages/kobe/src/engine/codex-local/terminal-presentation.ts
@@ -1,0 +1,50 @@
+import type {
+  EngineTerminalPresentation,
+  TerminalPresentationPalette,
+  TerminalRgb,
+  TerminalStyleRewrite,
+} from "@/types/terminal-presentation"
+
+const HEX_RE = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i
+
+function parseHex(value: `#${string}`): TerminalRgb {
+  const match = HEX_RE.exec(value)
+  if (!match) return [0, 0, 0]
+  return [
+    Number.parseInt(match[1] as string, 16),
+    Number.parseInt(match[2] as string, 16),
+    Number.parseInt(match[3] as string, 16),
+  ]
+}
+
+function luminance([red, green, blue]: TerminalRgb): number {
+  return (red * 0.2126 + green * 0.7152 + blue * 0.0722) / 255
+}
+
+function blend(from: TerminalRgb, to: TerminalRgb, amount: number): TerminalRgb {
+  return [
+    Math.round(from[0] + (to[0] - from[0]) * amount),
+    Math.round(from[1] + (to[1] - from[1]) * amount),
+    Math.round(from[2] + (to[2] - from[2]) * amount),
+  ]
+}
+
+function codexUserMessageBackground(background: TerminalRgb): TerminalRgb {
+  return luminance(background) > 0.5 ? blend(background, [0, 0, 0], 0.04) : blend(background, [255, 255, 255], 0.12)
+}
+
+function transcriptRewrite(palette: TerminalPresentationPalette): TerminalStyleRewrite {
+  const foreground = parseHex(palette.foreground)
+  const background = parseHex(palette.background)
+  const backgroundIsLight = luminance(background) > 0.5
+  return {
+    matchBackground: codexUserMessageBackground(background),
+    foreground: backgroundIsLight ? foreground : background,
+    background: backgroundIsLight ? background : foreground,
+  }
+}
+
+/** Codex uses one adaptive style for both its composer and historical user messages. */
+export const codexTerminalPresentation: EngineTerminalPresentation = {
+  alternateScreenStyleRewrites: (palette) => [transcriptRewrite(palette)],
+}

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -4,6 +4,8 @@ import { ensurePtyHostReachable } from "@sma1lboy/kobe-daemon/client/pty-process
 import { defaultPtyHostSocketPath } from "@sma1lboy/kobe-daemon/daemon/paths"
 import type { PtyOpenResult, PtyPeekResult } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import type { TerminalDefaultColors } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
+import { readPersistedTerminalDefaultColors } from "../tui/lib/terminal-colors.ts"
 import { BUILTIN_VENDORS } from "../types/vendor.ts"
 import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
 import { engineEntry } from "./registry.ts"
@@ -168,11 +170,13 @@ export async function ensureHostedEngine(
   rpc: HostedSessionRpc,
   cwd: string,
   launch: EngineSessionLaunch,
+  defaultColors: TerminalDefaultColors = readPersistedTerminalDefaultColors(),
 ): Promise<PtyOpenResult> {
   const result = await rpc.request<PtyOpenResult>("pty.open", {
     key: launch.key,
     cwd,
     command: launch.command,
+    defaultColors,
   })
   await rpc.request("pty.detach", { key: launch.key }).catch(() => {})
   return result

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -141,8 +141,8 @@ export function Terminal(props: TerminalProps) {
 
   const { bodyEl, setBodyEl, bodyRows, bodyGeometry, bumpGeomTick, dims, geomTick } = useTerminalGeometry()
   const defaultColors = useMemo(() => {
-    const [foregroundR, foregroundG, foregroundB] = theme.text.toInts()
-    const [backgroundR, backgroundG, backgroundB] = theme.background.toInts()
+    const [foregroundR, foregroundG, foregroundB] = theme.background.toInts()
+    const [backgroundR, backgroundG, backgroundB] = theme.text.toInts()
     const hex = (r: number, g: number, b: number): `#${string}` =>
       `#${[r, g, b].map((component) => component.toString(16).padStart(2, "0")).join("")}`
     return {

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -248,6 +248,15 @@ export function Terminal(props: TerminalProps) {
     scrollBy: scrollFromPointer,
   })
 
+  const terminalColors = useMemo(() => {
+    const foreground = theme.text.toInts()
+    const background = theme.background.toInts()
+    return {
+      foreground: [foreground[0], foreground[1], foreground[2]],
+      background: [background[0], background[1], background[2]],
+    } as const
+  }, [theme])
+
   const cursorRows = useMemo(() => {
     const withSelection = overlaySelection(
       visibleRows,
@@ -260,8 +269,8 @@ export function Terminal(props: TerminalProps) {
     // inverse styling, so a cursor sitting just past the selection read
     // as the highlight overrunning by one blinking cell.
     const cursorWhileUnselected = focused && !selection.selection ? visibleCursor : null
-    return overlayCursor(withSelection, cursorWhileUnselected)
-  }, [visibleRows, selection.selection, visibleRange.start, bodyGeometry, focused, visibleCursor])
+    return overlayCursor(withSelection, cursorWhileUnselected, terminalColors)
+  }, [visibleRows, selection.selection, visibleRange.start, bodyGeometry, focused, visibleCursor, terminalColors])
 
   // Flatten every visible row into ONE `StyledText` — see the Solid
   // original for why a single element (not per-row `<text>`s) is load-
@@ -272,16 +281,14 @@ export function Terminal(props: TerminalProps) {
   // the "wrapped URL underlines everything below it" report). Its doc comment
   // has the full mechanism; drop this call once opentui resets per row.
   const styledSnapshot = useMemo(() => {
-    const themeFg = theme.text.toInts()
-    const themeBg = theme.background.toInts()
     const sealed = sealRowEndAttributes(
       cursorRows,
       bodyGeometry?.cols ?? 80,
-      [themeFg[0], themeFg[1], themeFg[2]],
-      [themeBg[0], themeBg[1], themeBg[2]],
+      terminalColors.foreground,
+      terminalColors.background,
     )
     return new StyledText(rowsToStyledText(sealed))
-  }, [cursorRows, bodyGeometry, theme])
+  }, [cursorRows, bodyGeometry, terminalColors])
 
   // Imperative content push — opentui 0.4 won't accept StyledText as a
   // JSX child or through the content prop (stringifies it).

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -140,6 +140,16 @@ export function Terminal(props: TerminalProps) {
   const [scrollState, setScrollState] = useState<ViewportScrollState>(FOLLOW_VIEWPORT)
 
   const { bodyEl, setBodyEl, bodyRows, bodyGeometry, bumpGeomTick, dims, geomTick } = useTerminalGeometry()
+  const defaultColors = useMemo(() => {
+    const [foregroundR, foregroundG, foregroundB] = theme.text.toInts()
+    const [backgroundR, backgroundG, backgroundB] = theme.background.toInts()
+    const hex = (r: number, g: number, b: number): `#${string}` =>
+      `#${[r, g, b].map((component) => component.toString(16).padStart(2, "0")).join("")}`
+    return {
+      foreground: hex(foregroundR, foregroundG, foregroundB),
+      background: hex(backgroundR, backgroundG, backgroundB),
+    }
+  }, [theme])
 
   const { pty, snapshot, snapshotWindow, cursor, exited, acquireError, forceReacquire } = useTerminalPty({
     cwd: props.cwd,
@@ -148,6 +158,7 @@ export function Terminal(props: TerminalProps) {
     initialInput: props.initialInput,
     firstMessage: props.firstMessage,
     engineBin: props.engineBin,
+    defaultColors,
     resetToken: props.resetToken,
     onExit: props.onExit,
     registry,

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -33,6 +33,7 @@
  *     chicken-and-egg hook-ordering hazard.
  */
 
+import type { EngineTerminalPresentation } from "@/types/terminal-presentation"
 import type { BoxRenderable, TextRenderable } from "@opentui/core"
 import { StyledText } from "@opentui/core"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
@@ -121,6 +122,8 @@ export type TerminalProps = {
   resetToken?: number
   /** Optional registry override (tests inject a mock-backed registry). */
   registry?: PtyRegistry
+  /** Vendor-owned full-screen presentation policy for the original engine leaf. */
+  terminalPresentation?: EngineTerminalPresentation
 }
 
 /* --------------------------------------------------------------------- */
@@ -141,8 +144,8 @@ export function Terminal(props: TerminalProps) {
 
   const { bodyEl, setBodyEl, bodyRows, bodyGeometry, bumpGeomTick, dims, geomTick } = useTerminalGeometry()
   const defaultColors = useMemo(() => {
-    const [foregroundR, foregroundG, foregroundB] = theme.background.toInts()
-    const [backgroundR, backgroundG, backgroundB] = theme.text.toInts()
+    const [foregroundR, foregroundG, foregroundB] = theme.text.toInts()
+    const [backgroundR, backgroundG, backgroundB] = theme.background.toInts()
     const hex = (r: number, g: number, b: number): `#${string}` =>
       `#${[r, g, b].map((component) => component.toString(16).padStart(2, "0")).join("")}`
     return {
@@ -150,6 +153,10 @@ export function Terminal(props: TerminalProps) {
       background: hex(backgroundR, backgroundG, backgroundB),
     }
   }, [theme])
+  const alternateScreenStyleRewrites = useMemo(
+    () => props.terminalPresentation?.alternateScreenStyleRewrites(defaultColors),
+    [props.terminalPresentation, defaultColors],
+  )
 
   const { pty, snapshot, snapshotWindow, cursor, exited, acquireError, forceReacquire } = useTerminalPty({
     cwd: props.cwd,
@@ -159,6 +166,7 @@ export function Terminal(props: TerminalProps) {
     firstMessage: props.firstMessage,
     engineBin: props.engineBin,
     defaultColors,
+    alternateScreenStyleRewrites,
     resetToken: props.resetToken,
     onExit: props.onExit,
     registry,

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
@@ -22,7 +22,13 @@
 
 import { errorMessage } from "@/lib/error-message"
 import { useCallback, useEffect, useRef, useState } from "react"
-import type { CursorPos, TaskPty, TerminalRow, TerminalSnapshotWindow } from "../../../tui/panes/terminal/pty"
+import type {
+  CursorPos,
+  TaskPty,
+  TaskPtyOpts,
+  TerminalRow,
+  TerminalSnapshotWindow,
+} from "../../../tui/panes/terminal/pty"
 import type { PtyRegistry } from "../../../tui/panes/terminal/registry"
 import { useLatest } from "../../lib/use-latest"
 
@@ -40,6 +46,8 @@ export interface UseTerminalPtyOpts {
   firstMessage?: string
   /** Engine binary name for the first-message engine-up probe. */
   engineBin?: string
+  /** Current Rove theme colors reported to the embedded terminal child. */
+  defaultColors?: TaskPtyOpts["defaultColors"]
   resetToken?: number
   /** `deadOnAttach`: the exit was discovered on reattach (engine died
    *  while the TUI was away), not observed live — see `TaskPtyLike`. */
@@ -79,6 +87,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
   const initialInputRef = useLatest(opts.initialInput)
   const firstMessageRef = useLatest(opts.firstMessage)
   const engineBinRef = useLatest(opts.engineBin)
+  const defaultColorsRef = useLatest(opts.defaultColors)
   const bodyGeometryRef = useLatest(opts.bodyGeometry)
   const registryRef = useLatest(opts.registry)
   const onExitRef = useLatest(opts.onExit)
@@ -112,6 +121,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
         initialInput: initialInputRef.current,
         firstMessage: firstMessageRef.current,
         engineBin: engineBinRef.current,
+        defaultColors: defaultColorsRef.current,
       })
     } catch (err) {
       const message = errorMessage(err)

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
@@ -48,6 +48,8 @@ export interface UseTerminalPtyOpts {
   engineBin?: string
   /** Current Rove theme colors reported to the embedded terminal child. */
   defaultColors?: TaskPtyOpts["defaultColors"]
+  /** Engine-owned cell substitutions for the alternate screen only. */
+  alternateScreenStyleRewrites?: TaskPtyOpts["alternateScreenStyleRewrites"]
   resetToken?: number
   /** `deadOnAttach`: the exit was discovered on reattach (engine died
    *  while the TUI was away), not observed live — see `TaskPtyLike`. */
@@ -88,6 +90,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
   const firstMessageRef = useLatest(opts.firstMessage)
   const engineBinRef = useLatest(opts.engineBin)
   const defaultColorsRef = useLatest(opts.defaultColors)
+  const alternateScreenStyleRewritesRef = useLatest(opts.alternateScreenStyleRewrites)
   const bodyGeometryRef = useLatest(opts.bodyGeometry)
   const registryRef = useLatest(opts.registry)
   const onExitRef = useLatest(opts.onExit)
@@ -122,6 +125,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
         firstMessage: firstMessageRef.current,
         engineBin: engineBinRef.current,
         defaultColors: defaultColorsRef.current,
+        alternateScreenStyleRewrites: alternateScreenStyleRewritesRef.current,
       })
     } catch (err) {
       const message = errorMessage(err)
@@ -195,6 +199,8 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
           initialInput: initialInputRef.current,
           firstMessage: firstMessageRef.current,
           engineBin: engineBinRef.current,
+          defaultColors: defaultColorsRef.current,
+          alternateScreenStyleRewrites: alternateScreenStyleRewritesRef.current,
         }
         const fresh = expected
           ? registryRef.current.resetIfCurrent(nextTaskId, expected, nextCwd, opts)

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -35,6 +35,7 @@
  * a full frame whenever any border styling lands) is preserved verbatim.
  */
 
+import type { EngineTerminalPresentation } from "@/types/terminal-presentation"
 import { type RGBA, TextAttributes } from "@opentui/core"
 import { type ReactNode, useEffect, useMemo, useState } from "react"
 import { SPLIT_STYLE_KEY, normalizeSplitStyle } from "../../state/split-style"
@@ -122,6 +123,8 @@ export function TerminalSplit(props: {
   /** The tab's first-prompt title (title ?? autoTitle) — the engine leaf's
    *  name, matching the group/tab label. Null before the first prompt. */
   engineTitle?: string | null
+  /** Vendor presentation applies to leaf-1 only; split-created shells stay native. */
+  terminalPresentation?: EngineTerminalPresentation
 }): ReactNode {
   const { theme, transparentBackground } = useTheme()
   const inactiveBorder = transparentBackground ? theme.border : theme.borderSubtle
@@ -286,6 +289,7 @@ export function TerminalSplit(props: {
           initialInput={leaf.content === null ? props.initialInput : undefined}
           firstMessage={leaf.content === null ? props.firstMessage : undefined}
           engineBin={leaf.content === null ? props.engineBin : undefined}
+          terminalPresentation={leaf.content === null ? props.terminalPresentation : undefined}
           onUserInput={leaf.content === null ? props.onUserInput : undefined}
           onExit={() => onLeafExit(leaf.id)}
           resetToken={leaf.id === "leaf-1" ? props.resetToken : undefined}
@@ -394,6 +398,7 @@ export function TerminalSplit(props: {
       initialInput={props.initialInput}
       firstMessage={props.firstMessage}
       engineBin={props.engineBin}
+      terminalPresentation={props.terminalPresentation}
       onUserInput={props.onUserInput}
       onExit={props.onExit}
       resetToken={props.resetToken}

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -40,6 +40,7 @@ import type { TranscriptActivity } from "@/client/remote-orchestrator"
 import { availableEngineIds } from "@/engine/account-detect"
 import { engineLaunchArgv } from "@/engine/engine-presets"
 import { withClaudeSessionId } from "@/engine/interactive-command"
+import { getCapabilities } from "@/engine/registry"
 import { resolveMainRepoRoot } from "@/state/repos"
 import { resolvePreferredVendor, setRepoLastActiveVendor } from "@/state/vendor-prefs"
 import type { VendorId } from "@/types/vendor"
@@ -475,6 +476,9 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
           initialInput={spawn.initialInput}
           firstMessage={spawn.firstMessage}
           engineBin={spawn.engineBin}
+          terminalPresentation={
+            active.kind === "engine" ? getCapabilities(active.vendor ?? props.vendor)?.terminalPresentation : undefined
+          }
           onUserInput={
             active.kind === "engine"
               ? (data) => noteEngineTabInput(data, props.taskId, active.id, props.hookTabStates?.get(active.id)?.state)

--- a/packages/kobe/src/tui/context/theme-core.ts
+++ b/packages/kobe/src/tui/context/theme-core.ts
@@ -185,10 +185,11 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light" = "dark"):
 export function applyDisplayOverlay(base: Theme, focusAccent: FocusAccentSlot, transparentBackground: boolean): Theme {
   const v: Theme = { ...base, focusAccent: base[focusAccent] ?? base.primary }
   if (!transparentBackground) return v
-  const transparent = RGBA.fromInts(0, 0, 0, 0)
+  const [backgroundR, backgroundG, backgroundB] = base.background.toInts()
+  const [panelR, panelG, panelB] = base.backgroundPanel.toInts()
   return {
     ...v,
-    background: transparent,
-    backgroundPanel: transparent,
+    background: RGBA.fromInts(backgroundR, backgroundG, backgroundB, 0),
+    backgroundPanel: RGBA.fromInts(panelR, panelG, panelB, 0),
   }
 }

--- a/packages/kobe/src/tui/lib/terminal-colors.ts
+++ b/packages/kobe/src/tui/lib/terminal-colors.ts
@@ -1,0 +1,30 @@
+/** Resolve the terminal colors a headless engine should see from Rove's persisted theme. */
+
+import {
+  DEFAULT_TERMINAL_COLORS,
+  type TerminalDefaultColors,
+  parseTerminalDefaultColors,
+} from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
+import { BUNDLED_THEMES, DEFAULT_THEME, type ThemeJson } from "../context/theme-core"
+import { resolveThemeSlotHex } from "../context/theme/hex"
+import { loadUserThemes } from "../context/theme/loader"
+import { readPersistedUiPrefs } from "./persisted-ui-prefs"
+
+export function terminalDefaultColorsForTheme(theme: ThemeJson): TerminalDefaultColors {
+  return (
+    parseTerminalDefaultColors({
+      foreground: resolveThemeSlotHex(theme, "text", "dark"),
+      background: resolveThemeSlotHex(theme, "background", "dark"),
+    }) ?? DEFAULT_TERMINAL_COLORS
+  )
+}
+
+/** Headless `rove api` launches have no React theme provider to ask. Read the
+ * same persisted selection the next TUI will use, including user themes. */
+export function readPersistedTerminalDefaultColors(): TerminalDefaultColors {
+  const themes: Record<string, ThemeJson> = { ...BUNDLED_THEMES }
+  for (const { name, theme } of loadUserThemes()) themes[name] = theme
+  const prefs = readPersistedUiPrefs(DEFAULT_THEME, (name) => Boolean(themes[name]))
+  const selected = themes[prefs.theme] ?? themes[DEFAULT_THEME]
+  return selected ? terminalDefaultColorsForTheme(selected) : DEFAULT_TERMINAL_COLORS
+}

--- a/packages/kobe/src/tui/lib/terminal-colors.ts
+++ b/packages/kobe/src/tui/lib/terminal-colors.ts
@@ -13,11 +13,8 @@ import { readPersistedUiPrefs } from "./persisted-ui-prefs"
 export function terminalDefaultColorsForTheme(theme: ThemeJson): TerminalDefaultColors {
   return (
     parseTerminalDefaultColors({
-      // The embedded terminal is a content surface inside Rove's chrome.
-      // Give adaptive child UIs the inverse contrast pair so their cards
-      // remain visually distinct from the surrounding pane.
-      foreground: resolveThemeSlotHex(theme, "background", "dark"),
-      background: resolveThemeSlotHex(theme, "text", "dark"),
+      foreground: resolveThemeSlotHex(theme, "text", "dark"),
+      background: resolveThemeSlotHex(theme, "background", "dark"),
     }) ?? DEFAULT_TERMINAL_COLORS
   )
 }

--- a/packages/kobe/src/tui/lib/terminal-colors.ts
+++ b/packages/kobe/src/tui/lib/terminal-colors.ts
@@ -13,8 +13,11 @@ import { readPersistedUiPrefs } from "./persisted-ui-prefs"
 export function terminalDefaultColorsForTheme(theme: ThemeJson): TerminalDefaultColors {
   return (
     parseTerminalDefaultColors({
-      foreground: resolveThemeSlotHex(theme, "text", "dark"),
-      background: resolveThemeSlotHex(theme, "background", "dark"),
+      // The embedded terminal is a content surface inside Rove's chrome.
+      // Give adaptive child UIs the inverse contrast pair so their cards
+      // remain visually distinct from the surrounding pane.
+      foreground: resolveThemeSlotHex(theme, "background", "dark"),
+      background: resolveThemeSlotHex(theme, "text", "dark"),
     }) ?? DEFAULT_TERMINAL_COLORS
   )
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
@@ -74,7 +74,8 @@ export class HostedTaskPty extends XtermTaskPty {
   private hostOffset: number | null = null
 
   constructor(opts: TaskPtyOpts) {
-    super(opts)
+    // The process-owning PTY host answers OSC 10/11 even while detached.
+    super(opts, { respondToDefaultColorQueries: false })
     this.term.loadAddon(this.serializer)
     void this.openRemote(opts)
   }
@@ -111,6 +112,7 @@ export class HostedTaskPty extends XtermTaskPty {
         shell: opts.shell,
         cols: this.cols,
         rows: this.rows,
+        defaultColors: opts.defaultColors,
         sinceOffset: opts.restore?.byteOffset,
         sincePid: opts.restore?.pid ?? undefined,
       })

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -1,3 +1,4 @@
+import type { TerminalStyleRewrite } from "@/types/terminal-presentation"
 import { parse } from "@ansi-tools/parser"
 import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import type { TerminalDefaultColors } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
@@ -17,6 +18,8 @@ export type TaskPtyOpts = {
   rows?: number
   /** Default foreground/background exposed to child terminal applications. */
   defaultColors?: TerminalDefaultColors
+  /** Engine-owned cell substitutions applied only while the alternate screen is active. */
+  alternateScreenStyleRewrites?: readonly TerminalStyleRewrite[]
   /** Scrollback rows for the xterm buffer. Defaults to the persisted
    *  Settings → Terminal preference (`state/scrollback.ts`); tests inject
    *  small buffers here to exercise trimming deterministically. */

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -1,5 +1,6 @@
 import { parse } from "@ansi-tools/parser"
 import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
+import type { TerminalDefaultColors } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
 import type { Chunk } from "./sgr"
 
 /** One rendered row: a list of opentui-ready style runs. */
@@ -14,6 +15,8 @@ export type TaskPtyOpts = {
   cols?: number
   /** Initial pane size. Default 80x24. */
   rows?: number
+  /** Default foreground/background exposed to child terminal applications. */
+  defaultColors?: TerminalDefaultColors
   /** Scrollback rows for the xterm buffer. Defaults to the persisted
    *  Settings → Terminal preference (`state/scrollback.ts`); tests inject
    *  small buffers here to exercise trimming deterministically. */

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -32,7 +32,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
    * their full grid+scrollback at output cadence for a consumer (the
    * 1.5s turn poll) that only reads via capture(). */
   private snapshotDirty = false
-  private readonly snapshotEngine = new XtermSnapshotEngine()
+  private readonly snapshotEngine: XtermSnapshotEngine
   private _title: string | null = null
   /** Since when the pty has had zero data subscribers (epoch ms), null
    * while watched. Fresh instances start "unwatched now" — the mounting
@@ -69,6 +69,17 @@ export abstract class XtermTaskPty implements TaskPtyLike {
       rows: this.rows,
       scrollback: this.scrollbackRows,
     })
+    const foreground = opts.defaultColors?.foreground
+    const rgb = foreground?.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i)
+    this.snapshotEngine = new XtermSnapshotEngine(
+      rgb
+        ? [
+            Number.parseInt(rgb[1] as string, 16),
+            Number.parseInt(rgb[2] as string, 16),
+            Number.parseInt(rgb[3] as string, 16),
+          ]
+        : undefined,
+    )
     // Unicode 11 width tables: the default (Unicode 6) measures emoji as ONE
     // cell while modern apps — and kobe's cursor-overlay math in
     // lib/display-width.ts — measure TWO; emoji desynced cursor/wrap.

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -16,7 +16,7 @@ import {
   type TerminalSnapshotWindow,
 } from "./pty-types"
 import { XtermSnapshotEngine } from "./pty-xterm-snapshot"
-import { XtermRefreshTracker, wireXtermChannels } from "./xterm-refresh"
+import { XtermRefreshTracker, wireXtermChannels, wireXtermDefaultColorQueries } from "./xterm-refresh"
 
 export abstract class XtermTaskPty implements TaskPtyLike {
   readonly taskId: string
@@ -54,7 +54,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
    * (Settings → General → Terminal) — fixed for this PTY's lifetime. */
   private readonly scrollbackRows: number
 
-  constructor(opts: TaskPtyOpts) {
+  constructor(opts: TaskPtyOpts, options: { respondToDefaultColorQueries?: boolean } = {}) {
     this.taskId = opts.taskId
     this.cwd = opts.cwd
     this.cols = opts.cols ?? DEFAULT_COLS
@@ -76,25 +76,29 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     this.term.unicode.activeVersion = "11"
     this.refreshTracker = new XtermRefreshTracker(this.term)
 
+    const reply = (data: string): void => {
+      if (this._killed || this.muteReplies) return
+      try {
+        this.transportWrite(data)
+      } catch {
+        /* best effort — child may have exited */
+      }
+    }
     wireXtermChannels(this.term, {
       // `muteReplies`: replies triggered while parsing a ring-buffer REPLAY
       // answer queries the child asked in the PAST (already answered by the
       // then-attached emulator); re-answering injects unsolicited CPR/DA
       // into the child's stdin (scrambled claude's renderer). Live flows.
-      onReply: (data) => {
-        if (this._killed || this.muteReplies) return
-        try {
-          this.transportWrite(data)
-        } catch {
-          /* best effort — child may have exited */
-        }
-      },
+      onReply: reply,
       onTitle: (title) => {
         if (!title || title === this._title) return
         this._title = title
         this.listeners.publishTitle(title)
       },
     })
+    if (options.respondToDefaultColorQueries !== false) {
+      wireXtermDefaultColorQueries(this.term, opts.defaultColors, reply)
+    }
   }
 
   /** Send input bytes to the child over this backend's transport. */

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -69,17 +69,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
       rows: this.rows,
       scrollback: this.scrollbackRows,
     })
-    const foreground = opts.defaultColors?.foreground
-    const rgb = foreground?.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i)
-    this.snapshotEngine = new XtermSnapshotEngine(
-      rgb
-        ? [
-            Number.parseInt(rgb[1] as string, 16),
-            Number.parseInt(rgb[2] as string, 16),
-            Number.parseInt(rgb[3] as string, 16),
-          ]
-        : undefined,
-    )
+    this.snapshotEngine = new XtermSnapshotEngine(opts.alternateScreenStyleRewrites)
     // Unicode 11 width tables: the default (Unicode 6) measures emoji as ONE
     // cell while modern apps — and kobe's cursor-overlay math in
     // lib/display-width.ts — measure TWO; emoji desynced cursor/wrap.

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-snapshot.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-snapshot.ts
@@ -5,6 +5,7 @@
 
 import type { IMarker, Terminal as XtermHeadless } from "@xterm/headless"
 import type { CursorPos, TerminalRow, TerminalSnapshotWindow } from "./pty-types"
+import type { RGB } from "./sgr"
 import { reconcileTerminalCursor, reconcileTerminalRow, reconcileTerminalRows } from "./terminal-snapshot"
 import { xtermLineToChunks } from "./xterm-chunks"
 import {
@@ -30,6 +31,8 @@ export class XtermSnapshotEngine {
   private anchorId = 0
   private snapshotEpoch = 0
   private publishedMeta: SnapshotMeta | null = null
+
+  constructor(private readonly defaultForeground?: RGB) {}
 
   /** Drop the cache and anchor; called on resize/reflow or teardown. */
   invalidate(): void {
@@ -72,6 +75,7 @@ export class XtermSnapshotEngine {
         refreshTracker.peek(),
         cursorHidden,
         verifyFrozen,
+        this.defaultForeground,
       )
     ) {
       refreshTracker.clear()
@@ -112,7 +116,7 @@ export class XtermSnapshotEngine {
       }
       const line = active.getLine(y)
       const minLast = !cursorHidden && y === cursorY ? active.cursorX - 1 : -1
-      const row: TerminalRow = line ? xtermLineToChunks(line, minLast) : []
+      const row: TerminalRow = line ? xtermLineToChunks(line, minLast, this.defaultForeground) : []
       const stableRow = frozen ? reconcileTerminalRow(previousSnapshot[rowsOut.length], row) : row
       rowsOut.push(stableRow)
       if (frozen) cache.set(absBase + y, stableRow)

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-snapshot.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-snapshot.ts
@@ -3,9 +3,9 @@
  * Owns the scrollback cache, anchor marker, and snapshot metadata so the
  * main PTY class can stay focused on transport/lifecycle. */
 
+import type { TerminalStyleRewrite } from "@/types/terminal-presentation"
 import type { IMarker, Terminal as XtermHeadless } from "@xterm/headless"
 import type { CursorPos, TerminalRow, TerminalSnapshotWindow } from "./pty-types"
-import type { RGB } from "./sgr"
 import { reconcileTerminalCursor, reconcileTerminalRow, reconcileTerminalRows } from "./terminal-snapshot"
 import { xtermLineToChunks } from "./xterm-chunks"
 import {
@@ -32,7 +32,7 @@ export class XtermSnapshotEngine {
   private snapshotEpoch = 0
   private publishedMeta: SnapshotMeta | null = null
 
-  constructor(private readonly defaultForeground?: RGB) {}
+  constructor(private readonly alternateScreenStyleRewrites?: readonly TerminalStyleRewrite[]) {}
 
   /** Drop the cache and anchor; called on resize/reflow or teardown. */
   invalidate(): void {
@@ -55,6 +55,7 @@ export class XtermSnapshotEngine {
     previousWindow: TerminalSnapshotWindow | null,
   ): XtermSnapshotRefreshResult | null {
     const active = term.buffer.active
+    const styleRewrites = active.type === "alternate" ? this.alternateScreenStyleRewrites : undefined
     const cursorHidden = xtermCursorHidden(term)
     const currentMeta = snapshotMeta(active, rows, scrollbackRows)
     const nextCursor = reconcileTerminalCursor(
@@ -75,7 +76,7 @@ export class XtermSnapshotEngine {
         refreshTracker.peek(),
         cursorHidden,
         verifyFrozen,
-        this.defaultForeground,
+        styleRewrites,
       )
     ) {
       refreshTracker.clear()
@@ -116,7 +117,7 @@ export class XtermSnapshotEngine {
       }
       const line = active.getLine(y)
       const minLast = !cursorHidden && y === cursorY ? active.cursorX - 1 : -1
-      const row: TerminalRow = line ? xtermLineToChunks(line, minLast, this.defaultForeground) : []
+      const row: TerminalRow = line ? xtermLineToChunks(line, minLast, styleRewrites) : []
       const stableRow = frozen ? reconcileTerminalRow(previousSnapshot[rowsOut.length], row) : row
       rowsOut.push(stableRow)
       if (frozen) cache.set(absBase + y, stableRow)

--- a/packages/kobe/src/tui/panes/terminal/terminal-render.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-render.ts
@@ -39,7 +39,23 @@ function chunkCells(chars: readonly string[]): number {
   return w
 }
 
-function overlayCursorRow(row: readonly Chunk[], x: number): Chunk[] {
+export interface TerminalRenderColors {
+  readonly foreground: RGB
+  readonly background: RGB
+}
+
+/** Resolve the synthetic cursor to literal colors before OpenTUI sees it. */
+function cursorChunk(source: Chunk, text: string, colors: TerminalRenderColors): Chunk {
+  const attributes = (source.attributes ?? 0) & ~ATTR.INVERSE
+  return {
+    text,
+    fg: source.bg ?? colors.background,
+    bg: source.fg ?? colors.foreground,
+    ...(attributes !== 0 ? { attributes } : {}),
+  }
+}
+
+function overlayCursorRow(row: readonly Chunk[], x: number, colors: TerminalRenderColors): Chunk[] {
   const out: Chunk[] = []
   // `x` is a terminal CELL column. Chunk text is code points, and a wide
   // (CJK / fullwidth / emoji) glyph is ONE code point but TWO cells — so we
@@ -73,7 +89,7 @@ function overlayCursorRow(row: readonly Chunk[], x: number): Chunk[] {
       const before = chars.slice(0, hit).join("")
       const after = chars.slice(hit + 1).join("")
       if (before) out.push(cloneChunk(chunk, before))
-      out.push(cloneChunk(chunk, chars[hit] || " ", (chunk.attributes ?? 0) | ATTR.INVERSE))
+      out.push(cursorChunk(chunk, chars[hit] || " ", colors))
       if (after) out.push(cloneChunk(chunk, after))
       inserted = true
     } else {
@@ -88,7 +104,7 @@ function overlayCursorRow(row: readonly Chunk[], x: number): Chunk[] {
     // end-of-text instead is how the cursor visually froze while xterm's
     // cursor kept advancing over typed spaces.
     if (x > col) out.push({ text: " ".repeat(x - col) })
-    out.push({ text: " ", attributes: ATTR.INVERSE })
+    out.push(cursorChunk({ text: " " }, " ", colors))
   }
   return out
 }
@@ -96,9 +112,10 @@ function overlayCursorRow(row: readonly Chunk[], x: number): Chunk[] {
 export function overlayCursor(
   rows: readonly (readonly Chunk[])[],
   cursor: CursorPos | null,
+  colors: TerminalRenderColors,
 ): readonly (readonly Chunk[])[] {
   if (!cursor) return rows
-  return rows.map((row, y) => (y === cursor.y ? overlayCursorRow(row, cursor.x) : row))
+  return rows.map((row, y) => (y === cursor.y ? overlayCursorRow(row, cursor.x, colors) : row))
 }
 
 /**

--- a/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
@@ -90,9 +90,15 @@ function styleEquals(a: RenderStyle, b: RenderStyle): boolean {
   return a.fg === b.fg && a.bg === b.bg && a.attrs === b.attrs
 }
 
-function renderStyleToChunkFields(style: RenderStyle): Pick<Chunk, "fg" | "bg" | "attributes"> {
-  const fg = colorKeyToRGB(style.fg)
+function renderStyleToChunkFields(
+  style: RenderStyle,
+  defaultForeground?: RGB,
+): Pick<Chunk, "fg" | "bg" | "attributes"> {
   const bg = colorKeyToRGB(style.bg)
+  // A native terminal resolves its default foreground even when an app
+  // paints an explicit background. OpenTUI would otherwise inherit Rove's
+  // outer text color, producing white-on-light adaptive cards.
+  const fg = colorKeyToRGB(style.fg) ?? (bg ? defaultForeground : undefined)
   return {
     ...(fg ? { fg } : {}),
     ...(bg ? { bg } : {}),
@@ -182,7 +188,7 @@ function getCellReusing(line: XtermLineLike, x: number): XtermCellLike | undefin
  * when the trailing cells are blank, mirroring the snapshot the cursor
  * overlay is computed against.
  */
-export function xtermLineToChunks(line: XtermLineLike, minLast = -1): Chunk[] {
+export function xtermLineToChunks(line: XtermLineLike, minLast = -1, defaultForeground?: RGB): Chunk[] {
   // `Math.max` is load-bearing: the `minLast` seed (cursor column) must
   // survive the visible-cell scan. A plain `last = x` let the FIRST
   // visible cell clobber the seed, so trailing BLANK cells (typed spaces
@@ -204,7 +210,7 @@ export function xtermLineToChunks(line: XtermLineLike, minLast = -1): Chunk[] {
   let buf = ""
   const flush = () => {
     if (buf === "") return
-    out.push({ text: buf, ...renderStyleToChunkFields(active) })
+    out.push({ text: buf, ...renderStyleToChunkFields(active, defaultForeground) })
     buf = ""
   }
   for (let x = 0; x <= last; x++) {
@@ -228,9 +234,17 @@ export function xtermLineToChunks(line: XtermLineLike, minLast = -1): Chunk[] {
   return out
 }
 
-function chunkColorMatchesCell(rgb: RGB | undefined, cell: XtermCellLike, kind: "fg" | "bg"): boolean {
+function chunkColorMatchesCell(
+  rgb: RGB | undefined,
+  cell: XtermCellLike,
+  kind: "fg" | "bg",
+  defaultForeground?: RGB,
+): boolean {
   const isDefault = kind === "fg" ? cell.isFgDefault() : cell.isBgDefault()
-  if (isDefault) return rgb === undefined
+  if (isDefault) {
+    if (kind === "fg" && !cell.isBgDefault() && defaultForeground) return sameRgb(rgb, defaultForeground)
+    return rgb === undefined
+  }
   if (!rgb) return false
   const mode = kind === "fg" ? cell.getFgColorMode() : cell.getBgColorMode()
   const color = kind === "fg" ? cell.getFgColor() : cell.getBgColor()
@@ -244,16 +258,25 @@ function chunkColorMatchesCell(rgb: RGB | undefined, cell: XtermCellLike, kind: 
   return false
 }
 
-function chunkStyleMatchesCell(chunk: Chunk, cell: XtermCellLike): boolean {
+function sameRgb(a: RGB | undefined, b: RGB | undefined): boolean {
+  return Boolean(a && b && a[0] === b[0] && a[1] === b[1] && a[2] === b[2])
+}
+
+function chunkStyleMatchesCell(chunk: Chunk, cell: XtermCellLike, defaultForeground?: RGB): boolean {
   return (
     (chunk.attributes ?? 0) === cellAttributes(cell) &&
-    chunkColorMatchesCell(chunk.fg, cell, "fg") &&
+    chunkColorMatchesCell(chunk.fg, cell, "fg", defaultForeground) &&
     chunkColorMatchesCell(chunk.bg, cell, "bg")
   )
 }
 
 /** Compare xterm cells with their rendered chunks without allocating a replacement row. */
-export function xtermLineMatchesChunks(line: XtermLineLike | undefined, row: readonly Chunk[], minLast = -1): boolean {
+export function xtermLineMatchesChunks(
+  line: XtermLineLike | undefined,
+  row: readonly Chunk[],
+  minLast = -1,
+  defaultForeground?: RGB,
+): boolean {
   if (!line) return row.length === 0
   let last = Math.min(line.length - 1, minLast)
   for (let x = 0; x < line.length; x++) {
@@ -269,7 +292,7 @@ export function xtermLineMatchesChunks(line: XtermLineLike | undefined, row: rea
     const cell = getCellReusing(line, x)
     if (!cell || cell.getWidth() === 0) continue
     const chunk = row[chunkIndex]
-    if (!chunk || !chunkStyleMatchesCell(chunk, cell)) return false
+    if (!chunk || !chunkStyleMatchesCell(chunk, cell, defaultForeground)) return false
     const raw = cell.getChars() || " "
     // Same substitution as the converter, from the same `paintsSamePixel`
     // definition. `chunkStyleMatchesCell` above already proved the chunk's

--- a/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
@@ -1,3 +1,4 @@
+import type { TerminalStyleRewrite } from "@/types/terminal-presentation"
 import { ATTR, type Chunk, type RGB, ansi256ToRgb } from "./sgr"
 
 const XTERM_COLOR_MODE_DEFAULT = 0
@@ -78,27 +79,36 @@ function cellAttributes(cell: XtermCellLike): number {
   return attrs
 }
 
-function cellStyle(cell: XtermCellLike): RenderStyle {
-  return {
+function matchingStyleRewrite(
+  cell: XtermCellLike,
+  styleRewrites: readonly TerminalStyleRewrite[] | undefined,
+): TerminalStyleRewrite | undefined {
+  if (!styleRewrites || styleRewrites.length === 0 || !cell.isFgDefault() || cell.isBgDefault()) return undefined
+  const background = colorKeyToRGB(colorKey(cell, "bg"))
+  return styleRewrites.find((rewrite) => sameRgb(background, rewrite.matchBackground))
+}
+
+function rgbKey([red, green, blue]: readonly [number, number, number]): string {
+  return `rgb:${(red << 16) | (green << 8) | blue}`
+}
+
+function cellStyle(cell: XtermCellLike, styleRewrites?: readonly TerminalStyleRewrite[]): RenderStyle {
+  const style = {
     fg: colorKey(cell, "fg"),
     bg: colorKey(cell, "bg"),
     attrs: cellAttributes(cell),
   }
+  const rewrite = matchingStyleRewrite(cell, styleRewrites)
+  return rewrite ? { ...style, fg: rgbKey(rewrite.foreground), bg: rgbKey(rewrite.background) } : style
 }
 
 function styleEquals(a: RenderStyle, b: RenderStyle): boolean {
   return a.fg === b.fg && a.bg === b.bg && a.attrs === b.attrs
 }
 
-function renderStyleToChunkFields(
-  style: RenderStyle,
-  defaultForeground?: RGB,
-): Pick<Chunk, "fg" | "bg" | "attributes"> {
+function renderStyleToChunkFields(style: RenderStyle): Pick<Chunk, "fg" | "bg" | "attributes"> {
+  const fg = colorKeyToRGB(style.fg)
   const bg = colorKeyToRGB(style.bg)
-  // A native terminal resolves its default foreground even when an app
-  // paints an explicit background. OpenTUI would otherwise inherit Rove's
-  // outer text color, producing white-on-light adaptive cards.
-  const fg = colorKeyToRGB(style.fg) ?? (bg ? defaultForeground : undefined)
   return {
     ...(fg ? { fg } : {}),
     ...(bg ? { bg } : {}),
@@ -188,7 +198,11 @@ function getCellReusing(line: XtermLineLike, x: number): XtermCellLike | undefin
  * when the trailing cells are blank, mirroring the snapshot the cursor
  * overlay is computed against.
  */
-export function xtermLineToChunks(line: XtermLineLike, minLast = -1, defaultForeground?: RGB): Chunk[] {
+export function xtermLineToChunks(
+  line: XtermLineLike,
+  minLast = -1,
+  styleRewrites?: readonly TerminalStyleRewrite[],
+): Chunk[] {
   // `Math.max` is load-bearing: the `minLast` seed (cursor column) must
   // survive the visible-cell scan. A plain `last = x` let the FIRST
   // visible cell clobber the seed, so trailing BLANK cells (typed spaces
@@ -210,13 +224,13 @@ export function xtermLineToChunks(line: XtermLineLike, minLast = -1, defaultFore
   let buf = ""
   const flush = () => {
     if (buf === "") return
-    out.push({ text: buf, ...renderStyleToChunkFields(active, defaultForeground) })
+    out.push({ text: buf, ...renderStyleToChunkFields(active) })
     buf = ""
   }
   for (let x = 0; x <= last; x++) {
     const cell = getCellReusing(line, x)
     if (!cell || cell.getWidth() === 0) continue
-    const next = cellStyle(cell)
+    const next = cellStyle(cell, styleRewrites)
     if (!styleEquals(active, next)) {
       flush()
       active = next
@@ -234,17 +248,9 @@ export function xtermLineToChunks(line: XtermLineLike, minLast = -1, defaultFore
   return out
 }
 
-function chunkColorMatchesCell(
-  rgb: RGB | undefined,
-  cell: XtermCellLike,
-  kind: "fg" | "bg",
-  defaultForeground?: RGB,
-): boolean {
+function chunkColorMatchesCell(rgb: RGB | undefined, cell: XtermCellLike, kind: "fg" | "bg"): boolean {
   const isDefault = kind === "fg" ? cell.isFgDefault() : cell.isBgDefault()
-  if (isDefault) {
-    if (kind === "fg" && !cell.isBgDefault() && defaultForeground) return sameRgb(rgb, defaultForeground)
-    return rgb === undefined
-  }
+  if (isDefault) return rgb === undefined
   if (!rgb) return false
   const mode = kind === "fg" ? cell.getFgColorMode() : cell.getBgColorMode()
   const color = kind === "fg" ? cell.getFgColor() : cell.getBgColor()
@@ -258,14 +264,29 @@ function chunkColorMatchesCell(
   return false
 }
 
-function sameRgb(a: RGB | undefined, b: RGB | undefined): boolean {
+function sameRgb(
+  a: readonly [number, number, number] | undefined,
+  b: readonly [number, number, number] | undefined,
+): boolean {
   return Boolean(a && b && a[0] === b[0] && a[1] === b[1] && a[2] === b[2])
 }
 
-function chunkStyleMatchesCell(chunk: Chunk, cell: XtermCellLike, defaultForeground?: RGB): boolean {
+function chunkStyleMatchesCell(
+  chunk: Chunk,
+  cell: XtermCellLike,
+  styleRewrites?: readonly TerminalStyleRewrite[],
+): boolean {
+  const rewrite = matchingStyleRewrite(cell, styleRewrites)
+  if (rewrite) {
+    return (
+      (chunk.attributes ?? 0) === cellAttributes(cell) &&
+      sameRgb(chunk.fg, rewrite.foreground) &&
+      sameRgb(chunk.bg, rewrite.background)
+    )
+  }
   return (
     (chunk.attributes ?? 0) === cellAttributes(cell) &&
-    chunkColorMatchesCell(chunk.fg, cell, "fg", defaultForeground) &&
+    chunkColorMatchesCell(chunk.fg, cell, "fg") &&
     chunkColorMatchesCell(chunk.bg, cell, "bg")
   )
 }
@@ -275,7 +296,7 @@ export function xtermLineMatchesChunks(
   line: XtermLineLike | undefined,
   row: readonly Chunk[],
   minLast = -1,
-  defaultForeground?: RGB,
+  styleRewrites?: readonly TerminalStyleRewrite[],
 ): boolean {
   if (!line) return row.length === 0
   let last = Math.min(line.length - 1, minLast)
@@ -292,7 +313,7 @@ export function xtermLineMatchesChunks(
     const cell = getCellReusing(line, x)
     if (!cell || cell.getWidth() === 0) continue
     const chunk = row[chunkIndex]
-    if (!chunk || !chunkStyleMatchesCell(chunk, cell, defaultForeground)) return false
+    if (!chunk || !chunkStyleMatchesCell(chunk, cell, styleRewrites)) return false
     const raw = cell.getChars() || " "
     // Same substitution as the converter, from the same `paintsSamePixel`
     // definition. `chunkStyleMatchesCell` above already proved the chunk's

--- a/packages/kobe/src/tui/panes/terminal/xterm-refresh.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-refresh.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_TERMINAL_COLORS,
+  type TerminalDefaultColors,
+  formatDefaultColorReply,
+  parseTerminalDefaultColors,
+} from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
 import type { Terminal as XtermHeadless } from "@xterm/headless"
 import type { TerminalRow } from "./pty-types"
 import { type XtermLineLike, xtermLineMatchesChunks } from "./xterm-chunks"
@@ -17,6 +23,23 @@ export function wireXtermChannels(
 ): void {
   term.onData(hooks.onReply)
   term.onTitleChange(hooks.onTitle)
+}
+
+/** Answer OSC 10/11 in local xterm-backed terminals. Hosted PTYs disable
+ * this because their process-owning host answers even with no TUI attached. */
+export function wireXtermDefaultColorQueries(
+  term: XtermHeadless,
+  colors: TerminalDefaultColors | undefined,
+  reply: (data: string) => void,
+): void {
+  const resolved = parseTerminalDefaultColors(colors) ?? DEFAULT_TERMINAL_COLORS
+  for (const slot of [10, 11] as const) {
+    term.parser.registerOscHandler(slot, (payload) => {
+      if (payload !== "?") return false
+      reply(formatDefaultColorReply(slot, resolved))
+      return true
+    })
+  }
 }
 
 export type SnapshotMeta = {

--- a/packages/kobe/src/tui/panes/terminal/xterm-refresh.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-refresh.ts
@@ -1,3 +1,4 @@
+import type { TerminalStyleRewrite } from "@/types/terminal-presentation"
 import {
   DEFAULT_TERMINAL_COLORS,
   type TerminalDefaultColors,
@@ -6,7 +7,6 @@ import {
 } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
 import type { Terminal as XtermHeadless } from "@xterm/headless"
 import type { TerminalRow } from "./pty-types"
-import type { RGB } from "./sgr"
 import { type XtermLineLike, xtermLineMatchesChunks } from "./xterm-chunks"
 
 /**
@@ -160,7 +160,7 @@ export function dirtyRowsMatchSnapshot(
   dirty: DirtyRows | null,
   cursorHidden: boolean,
   frozen: FrozenScrollback | null = null,
-  defaultForeground?: RGB,
+  styleRewrites?: readonly TerminalStyleRewrite[],
 ): boolean {
   if (!previousMeta || !sameMeta(previousMeta, currentMeta) || !dirty) return false
   let first = currentMeta.start
@@ -188,7 +188,7 @@ export function dirtyRowsMatchSnapshot(
     // construction.
     if (frozen && y < frozen.baseY && frozen.cache.get(frozen.absBase + y) === row) continue
     const minLast = !cursorHidden && y === cursorY ? active.cursorX - 1 : -1
-    if (!xtermLineMatchesChunks(active.getLine(y), row, minLast, defaultForeground)) return false
+    if (!xtermLineMatchesChunks(active.getLine(y), row, minLast, styleRewrites)) return false
   }
   return true
 }

--- a/packages/kobe/src/tui/panes/terminal/xterm-refresh.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-refresh.ts
@@ -6,6 +6,7 @@ import {
 } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
 import type { Terminal as XtermHeadless } from "@xterm/headless"
 import type { TerminalRow } from "./pty-types"
+import type { RGB } from "./sgr"
 import { type XtermLineLike, xtermLineMatchesChunks } from "./xterm-chunks"
 
 /**
@@ -159,6 +160,7 @@ export function dirtyRowsMatchSnapshot(
   dirty: DirtyRows | null,
   cursorHidden: boolean,
   frozen: FrozenScrollback | null = null,
+  defaultForeground?: RGB,
 ): boolean {
   if (!previousMeta || !sameMeta(previousMeta, currentMeta) || !dirty) return false
   let first = currentMeta.start
@@ -186,7 +188,7 @@ export function dirtyRowsMatchSnapshot(
     // construction.
     if (frozen && y < frozen.baseY && frozen.cache.get(frozen.absBase + y) === row) continue
     const minLast = !cursorHidden && y === cursorY ? active.cursorX - 1 : -1
-    if (!xtermLineMatchesChunks(active.getLine(y), row, minLast)) return false
+    if (!xtermLineMatchesChunks(active.getLine(y), row, minLast, defaultForeground)) return false
   }
   return true
 }

--- a/packages/kobe/src/types/engine.ts
+++ b/packages/kobe/src/types/engine.ts
@@ -28,6 +28,7 @@
  */
 
 import type { ContentBlock } from "./content"
+import type { EngineTerminalPresentation } from "./terminal-presentation"
 import type { VendorId } from "./vendor"
 export type { ContentBlock } from "./content"
 
@@ -111,6 +112,8 @@ export interface EngineCapabilities {
   contextWindowFor(modelId: string): number
   /** The vendor's small/fast model id for metadata one-shots, if any. */
   smallFastModelId?(): string | undefined
+  /** Optional vendor-owned adjustments for its full-screen terminal UI. */
+  readonly terminalPresentation?: EngineTerminalPresentation
 }
 
 /**

--- a/packages/kobe/src/types/terminal-presentation.ts
+++ b/packages/kobe/src/types/terminal-presentation.ts
@@ -1,0 +1,24 @@
+/** Engine-owned presentation adjustments applied by the embedded terminal renderer. */
+
+export type TerminalRgb = readonly [number, number, number]
+
+export interface TerminalPresentationPalette {
+  readonly foreground: `#${string}`
+  readonly background: `#${string}`
+}
+
+/** Exact cell-style substitution. A rewrite only matches default foreground text. */
+export interface TerminalStyleRewrite {
+  readonly matchBackground: TerminalRgb
+  readonly foreground: TerminalRgb
+  readonly background: TerminalRgb
+}
+
+/**
+ * Vendor-specific visual knowledge compiled into renderer-neutral cell rules.
+ * Only the alternate screen receives these rules; the normal composer screen
+ * keeps the terminal application's native styling.
+ */
+export interface EngineTerminalPresentation {
+  alternateScreenStyleRewrites(palette: TerminalPresentationPalette): readonly TerminalStyleRewrite[]
+}

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -54,7 +54,8 @@ describe("hosted session helpers", () => {
       env: {},
     }
 
-    await expect(ensureHostedEngine(rpc, "/worktree", launch)).resolves.toEqual(opened)
+    const defaultColors = { foreground: "#eae7df", background: "#141413" } as const
+    await expect(ensureHostedEngine(rpc, "/worktree", launch, defaultColors)).resolves.toEqual(opened)
     expect(request.mock.calls).toEqual([
       [
         "pty.open",
@@ -64,6 +65,7 @@ describe("hosted session helpers", () => {
           // No cols/rows: a size-less open must never resize a live
           // session away from its attached TUI (issue #18).
           command: ["engine", "--resume", "session-1"],
+          defaultColors,
         },
       ],
       ["pty.detach", { key: "task-a::tab-1" }],

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -148,6 +148,14 @@ describe("getCapabilities", () => {
     expect(getCapabilities("copilot")).toBeUndefined()
     expect(getCapabilities("aider")).toBeUndefined()
   })
+
+  it("keeps the Codex terminal presentation policy engine-owned", () => {
+    const policy = getCapabilities("codex")?.terminalPresentation
+    expect(policy?.alternateScreenStyleRewrites({ foreground: "#eae7df", background: "#141413" })).toEqual([
+      { matchBackground: [48, 48, 47], foreground: [20, 20, 19], background: [234, 231, 223] },
+    ])
+    expect(getCapabilities("claude")?.terminalPresentation).toBeUndefined()
+  })
 })
 
 describe("engineEntry — custom (user-registered) vendors", () => {

--- a/packages/kobe/test/render/pty-host.test.ts
+++ b/packages/kobe/test/render/pty-host.test.ts
@@ -17,6 +17,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import type { DaemonFrame } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { PtyHost, foldOscTitle } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { foldDefaultColorQueries, parseTerminalDefaultColors } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
 
 const hosts: PtyHost[] = []
 
@@ -357,6 +358,40 @@ describe("PtyHost", () => {
     await until(() => dataText(frames).includes("program="))
     expect(dataText(frames)).toContain("program=unset version=unset")
   })
+
+  test("answers OSC 10/11 queries even when no terminal client is attached", async () => {
+    const host = makeHost()
+    const { frames, sink } = collector()
+    const probe = [
+      "process.stdin.setRawMode?.(true)",
+      "process.stdin.resume()",
+      "let input = ''",
+      "process.stdin.on('data', (chunk) => {",
+      "  input += chunk.toString('latin1')",
+      "  if (input.includes('\\x1b]10;rgb:1212/3434/5656\\x1b\\\\') && input.includes('\\x1b]11;rgb:abab/cdcd/efef\\x1b\\\\')) {",
+      "    process.stdout.write('colors-ok')",
+      "    process.exit(0)",
+      "  }",
+      "})",
+      "process.stdout.write('\\x1b]10;?\\x1b\\\\\\x1b]11;?\\x1b\\\\')",
+      "setTimeout(() => process.exit(2), 1000)",
+    ].join(";")
+
+    host.open(
+      "t1::colors",
+      {
+        ...SPEC,
+        command: [process.execPath, "--eval", probe],
+        defaultColors: { foreground: "#123456", background: "#abcdef" },
+      },
+      {},
+      sink,
+    )
+
+    await until(() => frames.some((frame) => frame.type === "event" && frame.name === "pty.exit"))
+    expect(dataText(frames)).toContain("colors-ok")
+    expect(host.list()[0]?.exit?.code).toBe(0)
+  })
 })
 
 // The pure title/carry fold behind scanOscTitle. Driving this directly
@@ -401,5 +436,24 @@ describe("foldOscTitle", () => {
     const first = foldOscTitle("", `done${ESC}`)
     expect(first).toEqual({ title: null, carry: ESC })
     expect(foldOscTitle(first.carry, `]2;boot${BEL}`)).toEqual({ title: "boot", carry: "" })
+  })
+})
+
+describe("default terminal color protocol", () => {
+  test("recognizes BEL/ST queries and carries a split ST terminator", () => {
+    expect(foldDefaultColorQueries("", "\x1b]10;?\x07\x1b]11;?\x1b\\")).toEqual({ slots: [10, 11], carry: "" })
+
+    const first = foldDefaultColorQueries("", "\x1b]10;?\x1b")
+    expect(first).toEqual({ slots: [], carry: "\x1b]10;?\x1b" })
+    expect(foldDefaultColorQueries(first.carry, "\\")).toEqual({ slots: [10], carry: "" })
+  })
+
+  test("accepts only complete six-digit foreground/background pairs", () => {
+    expect(parseTerminalDefaultColors({ foreground: "#EAE7DF", background: "#141413" })).toEqual({
+      foreground: "#eae7df",
+      background: "#141413",
+    })
+    expect(parseTerminalDefaultColors({ foreground: "#fff", background: "#141413" })).toBeNull()
+    expect(parseTerminalDefaultColors({ foreground: "#eae7df" })).toBeNull()
   })
 })

--- a/packages/kobe/test/render/pty-replay-replies.test.ts
+++ b/packages/kobe/test/render/pty-replay-replies.test.ts
@@ -72,8 +72,8 @@ describe("XtermTaskPty replay reply muting", () => {
     pty.feedLive("\x1b]10;?\x1b\\\x1b]11;?\x1b\\")
     await until(() => pty.writes.filter((w) => DEFAULT_COLOR_REPLY.test(w)).length === 2)
     expect(pty.writes.filter((w) => DEFAULT_COLOR_REPLY.test(w))).toEqual([
-      "\x1b]10;rgb:eaea/e7e7/dfdf\x1b\\",
-      "\x1b]11;rgb:1414/1414/1313\x1b\\",
+      "\x1b]10;rgb:1414/1414/1313\x1b\\",
+      "\x1b]11;rgb:eaea/e7e7/dfdf\x1b\\",
     ])
   })
 })

--- a/packages/kobe/test/render/pty-replay-replies.test.ts
+++ b/packages/kobe/test/render/pty-replay-replies.test.ts
@@ -30,6 +30,8 @@ class ProbeTaskPty extends XtermTaskPty {
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching the raw ESC-prefixed CPR reply is the whole point
 const CPR = /\x1b\[\d+;\d+R/
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching raw OSC color replies is the whole point
+const DEFAULT_COLOR_REPLY = /\x1b\](10|11);rgb:[0-9a-f/]+\x1b\\/
 
 function screenText(pty: ProbeTaskPty): string {
   return pty
@@ -63,5 +65,15 @@ describe("XtermTaskPty replay reply muting", () => {
     pty.feedLive("hello \x1b[6n world")
     await until(() => screenText(pty).includes("world"))
     expect(pty.writes.filter((w) => CPR.test(w))).toHaveLength(1)
+  })
+
+  it("answers live default-color queries for terminal-aware engines", async () => {
+    const pty = probe()
+    pty.feedLive("\x1b]10;?\x1b\\\x1b]11;?\x1b\\")
+    await until(() => pty.writes.filter((w) => DEFAULT_COLOR_REPLY.test(w)).length === 2)
+    expect(pty.writes.filter((w) => DEFAULT_COLOR_REPLY.test(w))).toEqual([
+      "\x1b]10;rgb:eaea/e7e7/dfdf\x1b\\",
+      "\x1b]11;rgb:1414/1414/1313\x1b\\",
+    ])
   })
 })

--- a/packages/kobe/test/render/pty-replay-replies.test.ts
+++ b/packages/kobe/test/render/pty-replay-replies.test.ts
@@ -72,8 +72,8 @@ describe("XtermTaskPty replay reply muting", () => {
     pty.feedLive("\x1b]10;?\x1b\\\x1b]11;?\x1b\\")
     await until(() => pty.writes.filter((w) => DEFAULT_COLOR_REPLY.test(w)).length === 2)
     expect(pty.writes.filter((w) => DEFAULT_COLOR_REPLY.test(w))).toEqual([
-      "\x1b]10;rgb:1414/1414/1313\x1b\\",
-      "\x1b]11;rgb:eaea/e7e7/dfdf\x1b\\",
+      "\x1b]10;rgb:eaea/e7e7/dfdf\x1b\\",
+      "\x1b]11;rgb:1414/1414/1313\x1b\\",
     ])
   })
 })

--- a/packages/kobe/test/render/terminal-chunk-bg.test.tsx
+++ b/packages/kobe/test/render/terminal-chunk-bg.test.tsx
@@ -11,7 +11,9 @@
 import { expect, test } from "bun:test"
 import { StyledText, type TextRenderable } from "@opentui/core"
 import { useEffect, useState } from "react"
+import { ATTR, type Chunk } from "../../src/tui/panes/terminal/sgr"
 import { rowsToStyledText } from "../../src/tui/panes/terminal/sgr-to-text-chunk"
+import { overlayCursor } from "../../src/tui/panes/terminal/terminal-render"
 import { renderComponent } from "./harness"
 
 function HalfBlockRow() {
@@ -21,6 +23,21 @@ function HalfBlockRow() {
       el.content = new StyledText(
         rowsToStyledText([[{ text: "▀▀▀", fg: [255, 0, 0], bg: [0, 0, 255] }], [{ text: "   ", bg: [0, 255, 0] }]]),
       )
+    }
+  }, [el])
+  return <text ref={setEl} />
+}
+
+function DimPlaceholderCursor() {
+  const [el, setEl] = useState<TextRenderable | null>(null)
+  useEffect(() => {
+    if (el && !el.isDestroyed) {
+      const rows = overlayCursor(
+        [[{ text: "Ask Codex", bg: [48, 48, 47], attributes: ATTR.DIM } as Chunk]],
+        { x: 0, y: 0 },
+        { foreground: [234, 231, 223], background: [20, 20, 19] },
+      )
+      el.content = new StyledText(rowsToStyledText(rows))
     }
   }, [el])
   return <text ref={setEl} />
@@ -37,6 +54,19 @@ test("chunk fg AND bg reach the painted frame (half-block zebra regression)", as
     expect(flat).toContain('"0":0,"1":0,"2":255,"3":255') // bg blue
     // bg-only spaces are the carbonyl solid-fill case.
     expect(flat).toContain('"0":0,"1":255,"2":0,"3":255') // bg green
+  } finally {
+    handle.destroy()
+  }
+})
+
+test("materialized cursor stays visible over a dim explicit-background placeholder", async () => {
+  const handle = await renderComponent(<DimPlaceholderCursor />, { width: 20, height: 2 })
+  try {
+    const flat = JSON.stringify(await handle.spans())
+    expect(flat).toContain("A")
+    expect(flat).toContain('"0":48,"1":48,"2":47,"3":255') // cursor glyph fg
+    expect(flat).toContain('"0":234,"1":231,"2":223,"3":255') // cursor block bg
+    expect(flat).toContain(`"attributes":${ATTR.DIM}`)
   } finally {
     handle.destroy()
   }

--- a/packages/kobe/test/tui-react/theme-core.test.ts
+++ b/packages/kobe/test/tui-react/theme-core.test.ts
@@ -41,10 +41,10 @@ describe("applyDisplayOverlay", () => {
 })
 
 describe("terminalDefaultColorsForTheme", () => {
-  it("resolves the same semantic text/background pair used by the TUI", () => {
+  it("resolves a content contrast pair against the surrounding TUI chrome", () => {
     expect(terminalDefaultColorsForTheme(BUNDLED_THEMES.claude as never)).toEqual({
-      foreground: "#eae7df",
-      background: "#141413",
+      foreground: "#141413",
+      background: "#eae7df",
     })
   })
 })

--- a/packages/kobe/test/tui-react/theme-core.test.ts
+++ b/packages/kobe/test/tui-react/theme-core.test.ts
@@ -41,10 +41,10 @@ describe("applyDisplayOverlay", () => {
 })
 
 describe("terminalDefaultColorsForTheme", () => {
-  it("resolves a content contrast pair against the surrounding TUI chrome", () => {
+  it("reports the embedded terminal's actual foreground and background", () => {
     expect(terminalDefaultColorsForTheme(BUNDLED_THEMES.claude as never)).toEqual({
-      foreground: "#141413",
-      background: "#eae7df",
+      foreground: "#eae7df",
+      background: "#141413",
     })
   })
 })

--- a/packages/kobe/test/tui-react/theme-core.test.ts
+++ b/packages/kobe/test/tui-react/theme-core.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { BUNDLED_THEMES, applyDisplayOverlay, resolveTheme } from "../../src/tui/context/theme-core"
+import { terminalDefaultColorsForTheme } from "../../src/tui/lib/terminal-colors"
 
 const base = resolveTheme(BUNDLED_THEMES.claude as never, "dark")
 
@@ -22,6 +23,8 @@ describe("applyDisplayOverlay", () => {
     const out = applyDisplayOverlay(base, "primary", true)
     expect(out.background.a).toBe(0)
     expect(out.backgroundPanel.a).toBe(0)
+    expect(out.background.toInts().slice(0, 3)).toEqual(base.background.toInts().slice(0, 3))
+    expect(out.backgroundPanel.toInts().slice(0, 3)).toEqual(base.backgroundPanel.toInts().slice(0, 3))
     // The composer body tint survives so input stays legible…
     expect(out.backgroundElement).toBe(base.backgroundElement)
     // …and the dialog card stays opaque so overlays stay readable.
@@ -34,5 +37,14 @@ describe("applyDisplayOverlay", () => {
       const overlaid = applyDisplayOverlay(resolved, "info", true)
       expect(overlaid.focusAccent, name).toBeDefined()
     }
+  })
+})
+
+describe("terminalDefaultColorsForTheme", () => {
+  it("resolves the same semantic text/background pair used by the TUI", () => {
+    expect(terminalDefaultColorsForTheme(BUNDLED_THEMES.claude as never)).toEqual({
+      foreground: "#eae7df",
+      background: "#141413",
+    })
   })
 })

--- a/packages/kobe/test/tui/terminal-pty-redraw-budget.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-redraw-budget.test.ts
@@ -176,4 +176,21 @@ describe("XtermTaskPty redraw budget", () => {
     expect(seen[0]?.cursor).toEqual({ x: 14, y: 0 })
     pty.kill()
   })
+
+  it("restores the input cursor after a hidden-cursor alternate-screen pager exits", async () => {
+    const pty = makePty()
+    const seen: Array<CursorPos | null> = []
+    pty.onData((_rows, cursor) => seen.push(cursor))
+
+    pty.pump("input")
+    await settle()
+    pty.pump("\x1b[?1049h\x1b[?25lpager")
+    await settle()
+    expect(seen.at(-1)).toBeNull()
+
+    pty.pump("\x1b[?1049l\x1b[?25h")
+    await settle()
+    expect(seen.at(-1)).toEqual({ x: 5, y: 0 })
+    pty.kill()
+  })
 })

--- a/packages/kobe/test/tui/terminal-pty-redraw-budget.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-redraw-budget.test.ts
@@ -130,6 +130,35 @@ describe("XtermTaskPty redraw budget", () => {
     pty.kill()
   })
 
+  it("applies engine style rewrites only on the alternate screen", async () => {
+    const pty = new FakeTransportPty({
+      taskId: "t1",
+      cwd: "/wt",
+      cols: 40,
+      rows: 10,
+      defaultColors: { foreground: "#eae7df", background: "#141413" },
+      alternateScreenStyleRewrites: [
+        { matchBackground: [48, 48, 47], foreground: [20, 20, 19], background: [234, 231, 223] },
+      ],
+    })
+    pty.onData(() => {})
+
+    pty.pump("\x1b[48;2;48;48;47mcomposer")
+    await settle()
+    expect(pty.capture()[0]?.[0]?.fg).toBeUndefined()
+    expect(pty.capture()[0]?.[0]?.bg).toEqual([48, 48, 47])
+
+    pty.pump("\x1b[?1049h\x1b[0m\x1b[48;2;48;48;47mtranscript")
+    await settle()
+    expect(pty.capture()[0]?.[0]).toMatchObject({ fg: [20, 20, 19], bg: [234, 231, 223] })
+
+    pty.pump("\x1b[?1049l")
+    await settle()
+    expect(pty.capture()[0]?.[0]?.fg).toBeUndefined()
+    expect(pty.capture()[0]?.[0]?.bg).toEqual([48, 48, 47])
+    pty.kill()
+  })
+
   it("publishes cursor-only changes while preserving snapshot identity", async () => {
     const pty = makePty()
     const seen: Array<{ rows: readonly TerminalRow[]; cursor: CursorPos | null }> = []

--- a/packages/kobe/test/tui/terminal-render.test.ts
+++ b/packages/kobe/test/tui/terminal-render.test.ts
@@ -2,32 +2,45 @@ import { describe, expect, it } from "vitest"
 import { ATTR, type Chunk, type RGB } from "../../src/tui/panes/terminal/sgr"
 import { overlayCursor, sealRowEndAttributes } from "../../src/tui/panes/terminal/terminal-render"
 
-/** The single chunk carrying the INVERSE attribute — that's the cursor cell. */
+const CURSOR_FG: RGB = [20, 20, 19]
+const CURSOR_BG: RGB = [234, 231, 223]
+const COLORS = { foreground: CURSOR_BG, background: CURSOR_FG } as const
+
+/** The single chunk carrying the materialized cursor color pair. */
 function cursorCell(rows: readonly (readonly Chunk[])[], y: number): Chunk | undefined {
-  return rows[y]?.find((c) => ((c.attributes ?? 0) & ATTR.INVERSE) !== 0)
+  return rows[y]?.find((c) => c.fg === CURSOR_FG && c.bg === CURSOR_BG)
 }
 
 describe("overlayCursor — cell-column aware", () => {
+  it("materializes a visible cursor over Codex's dim explicit-background placeholder", () => {
+    const source = [[{ text: "Ask Codex", bg: [48, 48, 47], attributes: ATTR.DIM } as Chunk]]
+
+    const out = overlayCursor(source, { x: 0, y: 0 }, COLORS)
+
+    expect(out[0]?.[0]).toEqual({ text: "A", fg: [48, 48, 47], bg: CURSOR_BG, attributes: ATTR.DIM })
+    expect(source[0]?.[0]).toEqual({ text: "Ask Codex", bg: [48, 48, 47], attributes: ATTR.DIM })
+  })
+
   it("lands on the right char when the row has wide (CJK) glyphs", () => {
     // "你好x": 你 = cells 0-1, 好 = cells 2-3, x = cell 4. `cursor.x` is a
     // CELL column, so counting code points (你好x = 3) used to drift the
     // cursor left by one column per wide char — this pins the fix.
     const rows = [[{ text: "你好x" } as Chunk]]
-    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }), 0)?.text).toBe("你")
-    expect(cursorCell(overlayCursor(rows, { x: 2, y: 0 }), 0)?.text).toBe("好")
-    expect(cursorCell(overlayCursor(rows, { x: 4, y: 0 }), 0)?.text).toBe("x")
+    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }, COLORS), 0)?.text).toBe("你")
+    expect(cursorCell(overlayCursor(rows, { x: 2, y: 0 }, COLORS), 0)?.text).toBe("好")
+    expect(cursorCell(overlayCursor(rows, { x: 4, y: 0 }, COLORS), 0)?.text).toBe("x")
   })
 
   it("a wide char's trailing cell resolves to the char itself", () => {
     const rows = [[{ text: "你好" } as Chunk]]
     // x=1 is 你's second cell, x=3 is 好's second cell.
-    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("你")
-    expect(cursorCell(overlayCursor(rows, { x: 3, y: 0 }), 0)?.text).toBe("好")
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }, COLORS), 0)?.text).toBe("你")
+    expect(cursorCell(overlayCursor(rows, { x: 3, y: 0 }, COLORS), 0)?.text).toBe("好")
   })
 
   it("keeps the ascii fast path exact and splits the chunk around the cursor", () => {
     const rows = [[{ text: "abc" } as Chunk]]
-    const out = overlayCursor(rows, { x: 1, y: 0 })[0]
+    const out = overlayCursor(rows, { x: 1, y: 0 }, COLORS)[0]
     expect(out.map((c) => c.text)).toEqual(["a", "b", "c"])
     expect(cursorCell([out], 0)?.text).toBe("b")
   })
@@ -38,15 +51,15 @@ describe("overlayCursor — cell-column aware", () => {
     // — counting it as 1 drifted the overlay one cell right and inverted the
     // bare combining mark instead of the char the cursor was actually on.
     const rows = [[{ text: "e\u0301x" } as Chunk]]
-    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }), 0)?.text).toBe("e")
-    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("x")
+    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }, COLORS), 0)?.text).toBe("e")
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }, COLORS), 0)?.text).toBe("x")
   })
 
   it("treats an emoji variation selector as zero-width", () => {
     // "❤️x": U+2764 + VS16 is one narrow-width unit here (matching
     // displayWidth), so x sits at cell 1, not cell 2.
     const rows = [[{ text: "❤️x" } as Chunk]]
-    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("x")
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }, COLORS), 0)?.text).toBe("x")
   })
 
   it("gives a control byte zero cells WITHOUT a one-cell floor re-widening it", () => {
@@ -56,20 +69,20 @@ describe("overlayCursor — cell-column aware", () => {
     // e=1, mark=0 — so cell 1 is "e". Either half alone fails this: a floor
     // turns BEL back into a column, and without the control branch BEL is 1.
     const rows = [[{ text: "a\x07e\u0301" } as Chunk]]
-    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }), 0)?.text).toBe("a")
-    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }), 0)?.text).toBe("e")
+    expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }, COLORS), 0)?.text).toBe("a")
+    expect(cursorCell(overlayCursor(rows, { x: 1, y: 0 }, COLORS), 0)?.text).toBe("e")
   })
 
-  it("past-the-end cursor (blank cell) appends an inverse space", () => {
+  it("past-the-end cursor (blank cell) appends an explicit cursor space", () => {
     const rows = [[{ text: "你" } as Chunk]]
     // 你 spans cells 0-1; x=2 is the empty cell after it.
-    const out = overlayCursor(rows, { x: 2, y: 0 })[0]
-    expect(out.at(-1)).toEqual({ text: " ", attributes: ATTR.INVERSE })
+    const out = overlayCursor(rows, { x: 2, y: 0 }, COLORS)[0]
+    expect(out.at(-1)).toEqual({ text: " ", fg: CURSOR_FG, bg: CURSOR_BG })
   })
 
   it("only overlays the cursor's row", () => {
     const rows = [[{ text: "你" } as Chunk], [{ text: "好" } as Chunk]]
-    const out = overlayCursor(rows, { x: 0, y: 1 })
+    const out = overlayCursor(rows, { x: 0, y: 1 }, COLORS)
     expect(cursorCell(out, 0)).toBeUndefined()
     expect(cursorCell(out, 1)?.text).toBe("好")
   })
@@ -80,9 +93,9 @@ describe("overlayCursor — cell-column aware", () => {
     // must pad to column 4 — appending straight after the text froze the
     // visual cursor at column 2 no matter how many spaces were typed.
     const rows = [[{ text: "ab" } as Chunk]]
-    const out = overlayCursor(rows, { x: 4, y: 0 })[0]
+    const out = overlayCursor(rows, { x: 4, y: 0 }, COLORS)[0]
     expect(out.map((c) => c.text).join("")).toBe("ab   ")
-    expect(out.at(-1)).toEqual({ text: " ", attributes: ATTR.INVERSE })
+    expect(out.at(-1)).toEqual({ text: " ", fg: CURSOR_FG, bg: CURSOR_BG })
   })
 })
 

--- a/packages/kobe/test/tui/terminal-solid-block.test.ts
+++ b/packages/kobe/test/tui/terminal-solid-block.test.ts
@@ -2,12 +2,28 @@ import { Terminal } from "@xterm/headless"
 import { describe, expect, it } from "vitest"
 import { xtermLineToChunks } from "../../src/tui/panes/terminal/xterm-chunks"
 
-async function rowFor(bytes: string): Promise<ReturnType<typeof xtermLineToChunks>> {
+async function rowFor(
+  bytes: string,
+  defaultForeground?: [number, number, number],
+): Promise<ReturnType<typeof xtermLineToChunks>> {
   const t = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
   await new Promise<void>((r) => t.write(bytes, () => r()))
   // biome-ignore lint/suspicious/noExplicitAny: structural test double
-  return xtermLineToChunks(t.buffer.active.getLine(0) as any)
+  return xtermLineToChunks(t.buffer.active.getLine(0) as any, -1, defaultForeground)
 }
+
+describe("embedded terminal default foreground", () => {
+  it("resolves default text on an explicit app background", async () => {
+    const row = await rowFor("\x1b[48;2;234;231;223mmessage", [20, 20, 19])
+    expect(row[0]).toMatchObject({ fg: [20, 20, 19], bg: [234, 231, 223] })
+  })
+
+  it("leaves fully default cells to inherit the outer Rove theme", async () => {
+    const row = await rowFor("message", [20, 20, 19])
+    expect(row[0]?.fg).toBeUndefined()
+    expect(row[0]?.bg).toBeUndefined()
+  })
+})
 
 describe("solid-block minimum-contrast immunity (issue #1 zebra)", () => {
   it("fg==bg solid blocks become bg-only spaces", async () => {

--- a/packages/kobe/test/tui/terminal-solid-block.test.ts
+++ b/packages/kobe/test/tui/terminal-solid-block.test.ts
@@ -1,27 +1,52 @@
 import { Terminal } from "@xterm/headless"
 import { describe, expect, it } from "vitest"
 import { xtermLineToChunks } from "../../src/tui/panes/terminal/xterm-chunks"
+import type { TerminalStyleRewrite } from "../../src/types/terminal-presentation"
 
 async function rowFor(
   bytes: string,
-  defaultForeground?: [number, number, number],
+  styleRewrites?: readonly TerminalStyleRewrite[],
 ): Promise<ReturnType<typeof xtermLineToChunks>> {
   const t = new Terminal({ cols: 20, rows: 4, allowProposedApi: true })
   await new Promise<void>((r) => t.write(bytes, () => r()))
   // biome-ignore lint/suspicious/noExplicitAny: structural test double
-  return xtermLineToChunks(t.buffer.active.getLine(0) as any, -1, defaultForeground)
+  return xtermLineToChunks(t.buffer.active.getLine(0) as any, -1, styleRewrites)
 }
 
 describe("embedded terminal default foreground", () => {
-  it("resolves default text on an explicit app background", async () => {
-    const row = await rowFor("\x1b[48;2;234;231;223mmessage", [20, 20, 19])
-    expect(row[0]).toMatchObject({ fg: [20, 20, 19], bg: [234, 231, 223] })
+  it("leaves default text on an explicit app background inheritable", async () => {
+    const row = await rowFor("\x1b[48;2;234;231;223mmessage")
+    expect(row[0]?.fg).toBeUndefined()
+    expect(row[0]?.bg).toEqual([234, 231, 223])
   })
 
   it("leaves fully default cells to inherit the outer Rove theme", async () => {
-    const row = await rowFor("message", [20, 20, 19])
+    const row = await rowFor("message")
     expect(row[0]?.fg).toBeUndefined()
     expect(row[0]?.bg).toBeUndefined()
+  })
+})
+
+describe("engine-owned terminal style rewrites", () => {
+  const transcriptRewrite = {
+    matchBackground: [48, 48, 47],
+    foreground: [20, 20, 19],
+    background: [234, 231, 223],
+  } as const
+
+  it("rewrites the Codex user-message surface only when requested", async () => {
+    const bytes = "\x1b[48;2;48;48;47mmessage"
+    const primary = await rowFor(bytes)
+    const transcript = await rowFor(bytes, [transcriptRewrite])
+
+    expect(primary[0]?.fg).toBeUndefined()
+    expect(primary[0]?.bg).toEqual([48, 48, 47])
+    expect(transcript[0]).toMatchObject({ fg: [20, 20, 19], bg: [234, 231, 223] })
+  })
+
+  it("does not overwrite an explicit foreground on the same background", async () => {
+    const row = await rowFor("\x1b[38;2;0;255;255m\x1b[48;2;48;48;47mmessage", [transcriptRewrite])
+    expect(row[0]).toMatchObject({ fg: [0, 255, 255], bg: [48, 48, 47] })
   })
 })
 


### PR DESCRIPTION
## What changed

- Report the embedded terminal palette to terminal-aware engines instead of letting Codex infer the host colors.
- Keep the Codex transcript on its light background while leaving the composer on its native dark palette.
- Render the synthetic cursor with explicit swapped colors so a focused empty composer keeps a visible caret.
- Add a patch changeset and regression coverage for the PTY host, xterm snapshot path, renderer, and Codex presentation rules.

## Verification

- bun run lint
- bun run typecheck
- bun x vitest run test/tui/terminal-render.test.ts
- bun test test/render/terminal-chunk-bg.test.tsx
- Full fast and render suites ran. Two unrelated timing failures passed when rerun in isolation.
- Browser /harness E2E covered native Codex and Rove embedded Codex, including transcript contrast and the focused empty composer cursor.

## Coverage exemptions

coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalTabs.tsx — Integration layer requires a live daemon and PTY; the behavior and visual-ground-truth tracks cover the presentation handoff.
coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalSplit.tsx — Integration layer passes presentation data into live PTY leaves; the behavior and visual-ground-truth tracks cover the split and unsplit paths.