### PR TITLE
fix: keep the terminal selection on its content across a scrollback trim

### DIFF
--- a/.changeset/terminal-selection-trim-drift.md
+++ b/.changeset/terminal-selection-trim-drift.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the terminal selection drifting off its content on a plain shell tab. Once the pane's local scrollback saturates, every new line drops a row off the front of the snapshot, so the highlight slid downward relative to the text it selected. The selection now translates by the same absolute line id the viewport is already anchored to, and is dropped rather than mis-mapped when a resize reflows history.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -245,6 +245,7 @@ export function Terminal(props: TerminalProps) {
     bodyRows,
     visibleRangeStart: visibleRange.start,
     snapshot,
+    snapshotWindow,
     scrollBy: scrollFromPointer,
   })
 

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -36,6 +36,12 @@
  * scrolled off screen are banked in a bounded shadow so the copy contains
  * exactly what the highlight covered. During the drag only the anchor follows,
  * because the head belongs to the pointer.
+ *
+ * On the NORMAL screen the displacement is known rather than measured: kobe's
+ * own scrollback is bounded, so a saturated buffer drops one row off the front
+ * per new line and `snapshotWindow.startLine` — the absolute line id the
+ * viewport is already anchored to — gives the exact offset to translate the
+ * endpoints by.
  */
 
 import type { BoxRenderable } from "@opentui/core"
@@ -43,13 +49,16 @@ import { useRenderer } from "@opentui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { copyTextToSystemClipboard } from "../../../tui/lib/clipboard-copy"
 import type { TerminalRow } from "../../../tui/panes/terminal/pty"
+import type { TerminalSnapshotWindow } from "../../../tui/panes/terminal/pty-types"
 import {
   type CellPoint,
   EMPTY_SHADOW,
   type SelectionRange,
   type SelectionShadow,
+  type SelectionShiftState,
   extractShadowedSelection,
   followContentShift,
+  followWindowShift,
   pointerCell,
 } from "../../../tui/panes/terminal/terminal-selection"
 
@@ -66,6 +75,12 @@ export interface UseTerminalSelectionOpts {
   /** Absolute snapshot row index of the first VISIBLE row (viewport start). */
   visibleRangeStart: number
   snapshot: readonly TerminalRow[]
+  /**
+   * Absolute line id of `snapshot[0]`, or null when the backend can't number
+   * lines (alternate screen, or no scrollback yet). A bounded scrollback trims
+   * from the front, so this is what keeps the selection on its content.
+   */
+  snapshotWindow: TerminalSnapshotWindow | null
   /**
    * Scroll for a drag hanging past an edge: negative goes up into history,
    * positive toward live. The pointer's absolute coords come along because the
@@ -139,6 +154,7 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     appScrolledRef.current = false
     shadowRef.current = EMPTY_SHADOW
     lastSnapshotRef.current = opts.snapshot
+    lastWindowRef.current = opts.snapshotWindow
     // Mirrored into a ref as well: the drag events of a fast gesture land
     // before React has re-rendered with the new anchor, and the auto-scroll
     // direction check must not read a stale (null) one.
@@ -158,10 +174,19 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
   const appScrolledRef = useRef(false)
   const shadowRef = useRef<SelectionShadow>(EMPTY_SHADOW)
   const lastSnapshotRef = useRef(opts.snapshot)
+  const lastWindowRef = useRef(opts.snapshotWindow)
   const autoScrollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   // The tick closes over render-derived geometry, so it's refreshed after
   // every render rather than captured once when the interval starts.
   const tickRef = useRef<() => void>(() => {})
+
+  const clearSelectionState = (): void => {
+    anchorRef.current = null
+    appScrolledRef.current = false
+    shadowRef.current = EMPTY_SHADOW
+    setSelAnchor(null)
+    setSelHead(null)
+  }
 
   const stopAutoScroll = (): void => {
     if (!autoScrollRef.current) return
@@ -219,28 +244,59 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     if (at) setSelHead(at.cell)
   }, [opts.visibleRangeStart])
 
-  // App-owned scrolling never moves the viewport — the CONTENT moves under
-  // fixed snapshot rows. Measure each snapshot change and move the selection
-  // with the content; rows that scrolled off are banked so the copy still has
-  // them. Gated on a selection EXISTING rather than on a live drag: the
-  // measurement is an O(rows^2) text comparison and must not run on every PTY
-  // frame for nothing, but a RELEASED selection still belongs to its content.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on snapshot pushes; `selHead` is read from the render that pushed them.
-  useEffect(() => {
-    const prev = lastSnapshotRef.current
-    lastSnapshotRef.current = opts.snapshot
-    if (!anchorRef.current || !appScrolledRef.current || prev === opts.snapshot) return
-    const rolled = followContentShift(
-      { anchor: anchorRef.current, head: selHead, shadow: shadowRef.current },
-      prev,
-      opts.snapshot,
-      draggingRef.current,
-    )
+  const applyShift = (rolled: SelectionShiftState): void => {
     shadowRef.current = rolled.shadow
     anchorRef.current = rolled.anchor
     setSelAnchor(rolled.anchor)
     setSelHead(rolled.head)
-  }, [opts.snapshot])
+  }
+
+  // Two ways the content can move out from under a selection, and they are
+  // mutually exclusive by which layer owns the scrollback:
+  //
+  //  - NORMAL screen: kobe owns a BOUNDED scrollback, so once it saturates
+  //    every new line drops one row off the front and each array index means
+  //    content one line newer. `snapshotWindow.startLine` states that
+  //    displacement exactly (`followWindowShift`) — no matching needed.
+  //  - ALTERNATE screen: the app owns its scrollback, the viewport never moves
+  //    and there is no window to number lines with, so the shift has to be read
+  //    back off the content (`followContentShift`) and the rows that scrolled
+  //    off banked in the shadow so the copy still has them.
+  //
+  // The content measurement only runs when the window did NOT move: a trim
+  // already fully explains the array-coordinate displacement, and re-deriving
+  // it would apply the same shift twice. It stays gated on a wheel having been
+  // forwarded, because it is an O(rows^2) text comparison that must not run on
+  // every PTY frame for nothing — and on a selection EXISTING rather than on a
+  // live drag, because a released selection still belongs to its content.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on snapshot pushes; `selHead` is read from the render that pushed them.
+  useEffect(() => {
+    const prevSnapshot = lastSnapshotRef.current
+    const prevWindow = lastWindowRef.current
+    lastSnapshotRef.current = opts.snapshot
+    lastWindowRef.current = opts.snapshotWindow
+    if (!anchorRef.current) return
+    const state: SelectionShiftState = { anchor: anchorRef.current, head: selHead, shadow: shadowRef.current }
+    const windowed = followWindowShift(
+      state,
+      prevWindow,
+      opts.snapshotWindow,
+      opts.snapshot.length,
+      draggingRef.current,
+    )
+    // Line numbering was reset (a resize reflows history): the selection
+    // addresses content that no longer exists under those ids.
+    if (!windowed) {
+      clearSelectionState()
+      return
+    }
+    if (windowed !== state) {
+      applyShift(windowed)
+      return
+    }
+    if (!appScrolledRef.current || prevSnapshot === opts.snapshot) return
+    applyShift(followContentShift(state, prevSnapshot, opts.snapshot, draggingRef.current))
+  }, [opts.snapshot, opts.snapshotWindow])
 
   // Unmount mid-drag (tab closed, pane swapped) must not leave a timer behind.
   useEffect(
@@ -268,13 +324,7 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
       dragPointRef.current = null
       stopAutoScroll()
     },
-    clearSelection: () => {
-      anchorRef.current = null
-      appScrolledRef.current = false
-      shadowRef.current = EMPTY_SHADOW
-      setSelAnchor(null)
-      setSelHead(null)
-    },
+    clearSelection: clearSelectionState,
     copySelection,
     noteAppScroll: () => {
       // Armed by a selection, not by a drag — a wheel AFTER the release has to

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -17,6 +17,7 @@
  */
 
 import { charWidth } from "../../../lib/display-width"
+import type { TerminalSnapshotWindow } from "./pty-types"
 import { ATTR, type Chunk } from "./sgr"
 
 export type CellPoint = { readonly row: number; readonly col: number }
@@ -364,4 +365,48 @@ export function overlaySelection(
     const span = rowSpan(range, firstRow + i, width)
     return span ? overlayRowSpan(row, span[0], span[1]) : row
   })
+}
+
+/**
+ * Roll a selection across a snapshot-WINDOW move — the NORMAL screen's
+ * counterpart to {@link followContentShift}.
+ *
+ * The local scrollback is bounded, so once it saturates every new line drops
+ * one row off the front of the snapshot and every array index addresses
+ * content one line newer than it did. `startLine` — the same absolute line id
+ * `resolveViewportScrollOffset` re-derives the viewport from — states that
+ * displacement exactly, so this is arithmetic, not the content matching
+ * `snapshotShift` has to do for an app that owns its own scrollback.
+ *
+ * Rows the trim took are gone from local scrollback, so the endpoints clamp to
+ * what is still addressable rather than being banked in the shadow (that bank
+ * belongs to the alt-screen drag, where the rows still exist inside the app).
+ *
+ * Returns the input by reference when nothing moved, and `null` when line
+ * numbering was RESET (a resize reflows history and bumps `epoch`): the
+ * selection then addresses content that no longer exists under those ids and
+ * must be dropped, not silently mis-mapped.
+ */
+export function followWindowShift(
+  state: SelectionShiftState,
+  prev: TerminalSnapshotWindow | null,
+  next: TerminalSnapshotWindow | null,
+  snapshotLength: number,
+  dragging: boolean,
+): SelectionShiftState | null {
+  if (!state.anchor || !prev || !next) return state
+  if (prev.epoch !== next.epoch) return null
+  const delta = next.startLine - prev.startLine
+  if (delta === 0) return state
+  const follow = (cell: CellPoint): CellPoint => ({
+    row: clampRowToShadow(cell.row - delta, snapshotLength, state.shadow),
+    col: cell.col,
+  })
+  return {
+    shadow: state.shadow,
+    anchor: follow(state.anchor),
+    // The head belongs to the POINTER while the drag is live — the pane
+    // re-derives it from the last pointer position itself.
+    head: dragging || !state.head ? state.head : follow(state.head),
+  }
 }

--- a/packages/kobe/test/tui/terminal-selection-trim.test.ts
+++ b/packages/kobe/test/tui/terminal-selection-trim.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import type { TerminalRow, TerminalSnapshotWindow } from "../../src/tui/panes/terminal/pty-types"
+import { XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
+import {
+  EMPTY_SHADOW,
+  type SelectionRange,
+  extractSelection,
+  followWindowShift,
+} from "../../src/tui/panes/terminal/terminal-selection"
+
+/**
+ * The bug this pins, through the REAL snapshot pipeline (xterm → snapshot
+ * engine → published window), not a hand-built fixture:
+ *
+ * The pane addresses a selection by snapshot ARRAY INDEX. Once the local
+ * scrollback saturates, every new line drops one row off the front of that
+ * array, so the same index addresses content one line newer — the highlight
+ * drifts downward relative to what the user selected, by exactly the number of
+ * rows dropped. The viewport already compensates (`resolveViewportScrollOffset`
+ * re-derives its offset from the published `startLine`); the selection did not.
+ *
+ * This is NOT the alternate-screen `snapshotShift` case: there the app owns the
+ * scrollback and the displacement has to be read back off the content. Here the
+ * PTY publishes the exact line id, so the correction is arithmetic.
+ */
+
+class FakeTransportPty extends XtermTaskPty {
+  protected transportWrite(): void {}
+  protected transportResize(): void {}
+  protected transportKill(): void {}
+  pump(data: string): void {
+    this.feed(data)
+  }
+}
+
+const COLS = 40
+const ROWS = 10
+const SCROLLBACK = 50
+
+const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 80))
+
+type Frame = { snapshot: readonly TerminalRow[]; window: TerminalSnapshotWindow | null }
+
+describe("selection across a bounded-scrollback trim", () => {
+  it("keeps the highlight on the content it selected while output streams", async () => {
+    const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt", cols: COLS, rows: ROWS, scrollback: SCROLLBACK })
+    // A subscriber is what makes the backend refresh at output cadence.
+    const unsubscribe = pty.onData(() => {})
+    try {
+      for (let i = 0; i < 200; i++) pty.pump(`line-${i}\r\n`)
+      await settle()
+      const before: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
+      // The buffer is saturated: the backend numbers lines, and row 0 is no
+      // longer line-0. Both are preconditions for the drift, so assert them.
+      expect(before.window).not.toBeNull()
+      expect(before.snapshot.length).toBe(ROWS + SCROLLBACK)
+
+      // Select two whole rows in the frozen scrollback, far enough down that
+      // the coming trim moves them rather than dropping them entirely.
+      const selected = { anchor: { row: 20, col: 0 }, head: { row: 21, col: 7 } } satisfies SelectionRange
+      const text = extractSelection(before.snapshot, selected)
+      expect(text).toMatch(/^line-\d+\nline-\d+$/)
+
+      for (let i = 200; i < 210; i++) pty.pump(`line-${i}\r\n`)
+      await settle()
+      const after: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
+      expect(after.window?.startLine).toBe((before.window?.startLine ?? 0) + 10)
+
+      // The bug, stated: the untranslated endpoints now cover ten lines later.
+      expect(extractSelection(after.snapshot, selected)).not.toBe(text)
+
+      const rolled = followWindowShift(
+        { anchor: selected.anchor, head: selected.head, shadow: EMPTY_SHADOW },
+        before.window,
+        after.window,
+        after.snapshot.length,
+        false,
+      )
+      const moved = rolled?.anchor && rolled.head ? { anchor: rolled.anchor, head: rolled.head } : null
+      expect(moved).not.toBeNull()
+      expect(extractSelection(after.snapshot, moved as SelectionRange)).toBe(text)
+    } finally {
+      unsubscribe()
+      pty.kill()
+    }
+  })
+})

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -10,6 +10,7 @@ import {
   extractSelection,
   extractShadowedSelection,
   followContentShift,
+  followWindowShift,
   orderRange,
   overlaySelection,
   pointerCell,
@@ -316,5 +317,59 @@ describe("alt-screen drag scrolling (shadow buffer)", () => {
     expect(shadow.below.map((r) => r[0]?.text)).toEqual(doc.slice(16, 19))
     expect(clampRowToShadow(8, 5, shadow)).toBe(7)
     expect(clampRowToShadow(-9, 5, shadow)).toBe(0)
+  })
+})
+
+/**
+ * NORMAL screen, bounded local scrollback. Once the buffer saturates every new
+ * line drops one row off the front of the snapshot, so a held selection's array
+ * indices address content that is `startLine` lines newer than what it selected.
+ */
+describe("bounded-scrollback trimming (snapshot window)", () => {
+  const buffer = (from: number, count: number): readonly (readonly Chunk[])[] =>
+    Array.from({ length: count }, (_, i) => row(`line-${from + i}`))
+
+  const held = (state: SelectionShiftState): SelectionRange => ({
+    anchor: state.anchor as CellPoint,
+    head: state.head as CellPoint,
+  })
+
+  it("keeps a released selection on the SAME CONTENT after the snapshot is trimmed from the front", () => {
+    const before = buffer(100, 10)
+    const state: SelectionShiftState = {
+      anchor: { row: 3, col: 0 },
+      head: { row: 4, col: 7 },
+      shadow: EMPTY_SHADOW,
+    }
+    expect(extractSelection(before, held(state))).toBe("line-103\nline-104")
+
+    // Three more lines streamed in; the buffer was already at its cap, so the
+    // window slid forward by three and `after[i]` is `before[i + 3]`.
+    const after = buffer(103, 10)
+    const rolled = followWindowShift(state, { epoch: 1, startLine: 0 }, { epoch: 1, startLine: 3 }, after.length, false)
+    expect(rolled).not.toBeNull()
+    expect(extractSelection(after, held(rolled as SelectionShiftState))).toBe("line-103\nline-104")
+    expect((rolled as SelectionShiftState).anchor).toEqual({ row: 0, col: 0 })
+  })
+
+  it("leaves the head on the pointer during a live drag, and clamps endpoints trimmed away", () => {
+    const state: SelectionShiftState = {
+      anchor: { row: 1, col: 0 },
+      head: { row: 6, col: 3 },
+      shadow: EMPTY_SHADOW,
+    }
+    const dragging = followWindowShift(state, { epoch: 1, startLine: 0 }, { epoch: 1, startLine: 4 }, 10, true)
+    // Anchor's content scrolled off the top — clamp to what is still addressable.
+    expect(dragging?.anchor).toEqual({ row: 0, col: 0 })
+    expect(dragging?.head).toBe(state.head)
+  })
+
+  it("returns the input by reference when the window did not move, and null across an epoch reset", () => {
+    const state: SelectionShiftState = { anchor: { row: 2, col: 0 }, head: { row: 2, col: 4 }, shadow: EMPTY_SHADOW }
+    expect(followWindowShift(state, { epoch: 1, startLine: 7 }, { epoch: 1, startLine: 7 }, 10, false)).toBe(state)
+    // Alternate screen (no line numbering) is the other mechanism's business.
+    expect(followWindowShift(state, null, null, 10, false)).toBe(state)
+    // A resize reflows history: those ids no longer mean anything.
+    expect(followWindowShift(state, { epoch: 1, startLine: 7 }, { epoch: 2, startLine: 0 }, 10, false)).toBeNull()
   })
 })


### PR DESCRIPTION
## Premise: confirmed, with one correction to the stated mechanism

The drift is real. The direction of the described root cause needs one amendment.

`snapshotMeta` computes `start: Math.max(0, active.length - (viewportRows + scrollbackRows))`, but in practice **`start` is always 0**: `pty-xterm-base.ts` constructs xterm with `scrollback: this.scrollbackRows` and then calls `refresh(term, this.rows, this.scrollbackRows, …)`, so `active.length` is capped at exactly `rows + scrollbackRows` and the subtraction never goes positive.

The snapshot *is* still trimmed from the front — via the other term. Once xterm's own buffer saturates it drops lines off the top, the anchor marker's `.line` walks down, and `absBase = anchorId - anchor.line` walks up. `startLine = absBase + start` therefore advances one per new line with `start` pinned at 0. Same bug, same exact arithmetic, different summand.

Measured on a real `XtermTaskPty` (cols 40, rows 10, scrollback 50), feeding 200 lines then 10 more:

```
A {"epoch":1,"startLine":0}  len 60  row0 line-141  row5 line-146
B {"epoch":1,"startLine":10} len 60  row0 line-151  row5 line-156
```

Snapshot row 5 held `line-146` and now holds `line-156`. A selection pinned to array index 5 drifted 10 lines downward, exactly `Δ startLine`.

## Did I reuse the viewport anchor machinery?

Yes, its **data**; no, its functions. `resolveViewportScrollOffset` re-derives a scroll *offset* from `anchor.topLine - window.startLine`, which is not what a selection needs — a selection has two endpoints and no notion of a fallback offset. What is reusable is the concept the viewport already established and the PTY already publishes: `TerminalSnapshotWindow { epoch, startLine }`. The selection now consumes that exact value, so there is no parallel epoch concept — one `epoch` counter, one `startLine`, two consumers.

`followWindowShift` (in `terminal-selection.ts`, beside `followContentShift`) is the whole correction: `row - (next.startLine - prev.startLine)`, clamped to what is still addressable. It returns its input by reference when nothing moved, and `null` on an epoch change.

## Not routed through `snapshotShift`

Confirmed as two different problems, and the two paths are now explicitly exclusive in the hook: the content measurement runs only when the window did **not** move. That matters because they are not merely different, they overlap — for a pure trim `snapshotShift` would measure `-delta` and applying both would shift twice. `snapshotWindow` is `null` on the alternate screen (`anchorAlive` requires `!alt`), so the alt-screen path never reaches the new branch at all; the guard covers the one case that can hit both, a normal-screen app with mouse tracking that consumes wheel events.

Rows the trim actually took are **not** banked in the shadow. They are gone from local scrollback, unlike the alt-screen case where they still exist inside the app; the endpoints clamp instead, which is what the viewport does too.

## Epoch

Verified before relying on it. `snapshotEpoch` increments in `XtermSnapshotEngine.refresh` whenever a fresh anchor marker is registered after the cache is cleared — reachable in-place, since `invalidate()` (resize/reflow) disposes the anchor and the next refresh re-registers. Reflow re-wraps history, so those line ids genuinely mean nothing afterwards: `followWindowShift` returns `null` and the hook clears the selection rather than mis-mapping it.

One case epoch cannot catch, left alone as out of scope: a *fresh PTY* nulls the window between epochs, and a selection is not cleared on `onFreshPty` today either — pre-existing, unchanged by this PR.

## Tests

`test/tui/terminal-selection-trim.test.ts` drives the real pipeline (real `XtermTaskPty` → snapshot engine → published window), selects two rows of frozen scrollback, streams 10 more lines, and asserts the endpoints still extract the same text. It also pins the two preconditions (window published, buffer saturated) and asserts the *untranslated* endpoints do drift, so the test cannot pass vacuously.

Red with the fix neutralized (`const delta = 0`, i.e. main's behavior of compensating the viewport only):

```
FAIL  test/tui/terminal-selection-trim.test.ts > selection across a bounded-scrollback trim > keeps the highlight on the content it selected while output streams
AssertionError: expected 'line-171\nline-172' to be 'line-161\nline-162' // Object.is equality

- Expected
+ Received

- line-161
+ line-171
- line-162
+ line-172
```

Ten lines of downward drift, matching the measurement above. Three unit cases in `terminal-selection.test.ts` cover the drag/clamp/epoch branches.

Gates: `bun run test:fast` 3606 passed (366 files), repo-root `bun run lint` clean, `bun --filter @sma1lboy/rove typecheck` clean, and `test/render/terminal-drag-autoscroll` + `terminal-scrollback-layout` pass under bun. The alt-screen shadow tests in `test/tui/terminal-selection.test.ts` are untouched and green.

No render test for the `Terminal.tsx` prop wiring: `snapshotWindow` is a required field on `UseTerminalSelectionOpts`, so dropping it fails typecheck.

One changeset, patch.