### PR TITLE
fix: persist a field-only re-read of an agent turn so it survives a daemon restart

### DIFF
--- a/.changeset/agent-turns-field-update-persist.md
+++ b/.changeset/agent-turns-field-update-persist.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Agent-turn telemetry no longer loses a turn's final token counts across a daemon restart. Every Stop hook re-reads the whole transcript, so a finished turn arrives again — often more complete than before (fuller `usage`, a corrected `endedAt`). The store applied that newer version in memory but skipped the disk write whenever the batch introduced no brand-new turn id, so the last write won only until the next `rove daemon restart`, which reloaded the stale record. The store now persists a re-read whose fields actually changed, while still skipping the write for a byte-identical re-scan (the common no-op), so `rove api agent-turns` reports the same numbers before and after a restart.

--- a/packages/kobe-daemon/src/daemon/agent-turns-store.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-store.ts
@@ -65,6 +65,15 @@ function keyOf(turn: Pick<AgentTurnRecord, "taskId" | "id">): string {
   return `${turn.taskId}\0${turn.id}`
 }
 
+/** Whether a re-read of the same turn carries the same fields. Both sides are
+ *  {@link normalize} output, so their top-level key order is fixed and a stable
+ *  serialization is a sound equality check — it never misses a real field
+ *  change; at worst a differently-ordered `usage` triggers one redundant, and
+ *  harmless, write. */
+function sameRecord(a: AgentTurnRecord, b: AgentTurnRecord): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
 export class AgentTurnsStore {
   private readonly turns = new Map<string, AgentTurnRecord>()
   private tail: Promise<void> = Promise.resolve()
@@ -86,16 +95,23 @@ export class AgentTurnsStore {
   async record(turns: readonly AgentTurnRecord[]): Promise<number> {
     return await this.enqueue(async () => {
       let added = 0
+      let changed = false
       for (const raw of turns) {
         const turn = normalize(raw)
         if (!turn) continue
         const key = keyOf(turn)
-        if (!this.turns.has(key)) added++
+        const prev = this.turns.get(key)
+        if (prev === undefined) added++
+        // Last write wins on the fields: a turn re-read after more assistant
+        // records landed is the more complete one, and that update has to reach
+        // disk. Keying the write only on NEW turns kept it in memory and lost it
+        // on the next restart.
+        else if (!sameRecord(prev, turn)) changed = true
         // Re-insert so Map order tracks recency; the cap evicts from the head.
         this.turns.delete(key)
         this.turns.set(key, turn)
       }
-      if (added === 0) return 0
+      if (added === 0 && !changed) return 0
       while (this.turns.size > MAX_TURNS) {
         const oldest = this.turns.keys().next().value
         if (oldest === undefined) break

--- a/packages/kobe/test/daemon/agent-turns.test.ts
+++ b/packages/kobe/test/daemon/agent-turns.test.ts
@@ -1,6 +1,6 @@
 /** Durable per-turn telemetry: store persistence + the hook-driven ingest (issue #32). */
 
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { ingestAgentTurns } from "@sma1lboy/kobe-daemon/daemon/agent-turns-ingest"
@@ -53,6 +53,28 @@ describe("AgentTurnsStore", () => {
     expect(await store.record([record()])).toBe(1)
     expect(await store.record([record(), record({ id: "msg_b", endedAt: 3000 })])).toBe(1)
     expect(store.list().map((t) => t.id)).toEqual(["msg_b", "msg_a"]) // newest first
+  })
+
+  it("persists a field-only re-read of an existing turn (last write wins, durably)", async () => {
+    const { store, path } = await createStore()
+    expect(await store.record([record({ usage: { input_tokens: 1, output_tokens: 2 } })])).toBe(1)
+    // A later Stop re-reads the same turn with a more complete usage. No NEW
+    // turn, so record() still reports 0 — but the update must reach disk.
+    const fuller = record({ usage: { input_tokens: 1, output_tokens: 99 }, endedAt: 2500 })
+    expect(await store.record([fuller])).toBe(0)
+    expect(store.list()[0].usage?.output_tokens).toBe(99)
+
+    const reloaded = new AgentTurnsStore(path)
+    await reloaded.init()
+    expect(reloaded.list()).toEqual([fuller])
+  })
+
+  it("skips the write when a re-read is byte-identical (the common no-op Stop)", async () => {
+    const { store, path } = await createStore()
+    await store.record([record()])
+    const before = await stat(path)
+    expect(await store.record([record()])).toBe(0)
+    expect((await stat(path)).mtimeMs).toBe(before.mtimeMs) // untouched
   })
 
   it("scopes the dedupe key by task, so two tasks may carry the same engine id", async () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a durability bug found by daily code review of the pure/durable-store layer, not covered by any open PR.

## Problem

`AgentTurnsStore` (`packages/kobe-daemon/src/daemon/agent-turns-store.ts`) is the durable side of the engine-owned agent-turn telemetry contract (issue #32). Its module header states the contract plainly: *"Last write wins on the fields (a turn re-read after more assistant records landed is the more complete one)"*, kept **across daemon restarts**.

`record()` honored last-write-wins **in memory** — it unconditionally re-inserts an existing turn's newer value — but the write-skip optimization keyed only on *new turn ids*:

```ts
if (!this.turns.has(key)) added++
// ...
if (added === 0) return 0   // returns BEFORE this.write()
```

Every Stop hook re-reads the whole transcript, so a finished turn is ingested again on every subsequent turn — frequently **more complete** than the first sighting (fuller `usage`, a corrected `endedAt`/`model`). When a batch carried only turns whose ids already existed but whose *fields* changed, `added` stayed `0`, so the method returned before writing. The updated record lived only in memory; the next `rove daemon restart` reloaded the stale on-disk copy and the update was silently lost — so `rove api agent-turns` could report different token counts before and after a restart.

## Fix

Track whether an existing record's normalized fields actually changed, and write when they did:

- `added` still counts only NEW turns (the return contract callers rely on is unchanged — `agent-turns-ingest.ts` uses it purely for reporting).
- A new `changed` flag is set when an existing key's normalized value differs (`sameRecord`, a stable-serialization equality of two `normalize` outputs).
- The write now fires on `added > 0 || changed`, so a byte-identical re-scan (the common no-op case) still skips the write.

## Verification

- Added two regression tests in `packages/kobe/test/daemon/agent-turns.test.ts`: a field-only re-read is persisted and survives a fresh `init()` (reload), and a byte-identical re-read leaves the file's mtime untouched (no redundant write).
- Confirmed the durability test fails on `main`'s logic (reload keeps the stale `usage`) and passes with the fix.
- `bun run lint` ✓, `bun run typecheck` ✓, and the full `test/daemon/agent-turns.test.ts` suite (10 tests) green under the socket runner.
- Changeset added (`@sma1lboy/rove`, patch).

## Follow-ups deferred

- The related concurrent-peer resurrection concern in `TaskIndexStore` (issue #551) is a separate semantics decision and out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_013yPq6SFhRHQYHodZ52xE5T)_