### PR TITLE
feat: reveal prefix shortcuts across the live screen

### DIFF
--- a/.changeset/bright-icons-reveal-keys.md
+++ b/.changeset/bright-icons-reveal-keys.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Tap the configured prefix to open the complete clickable command guide and reveal shortcuts on current on-screen controls. Settings can hide the local badges while keeping the full guide; both presentations use the same live prefix session.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -23,11 +23,26 @@ Rove only reserves its explicit chords. The prefix still works there, so
 the command menu is reachable from every pane. Press `ctrl+q` to leave the
 terminal without opening it.
 
+Tap the configured prefix once to open the command layer. By default, Rove
+opens the complete command guide and also shows shortcuts beside clickable
+controls already on screen, such as **New task**, **Inbox**, **Kanban**,
+**Automations**, **Zen**, **Create PR**, and **Settings**. In **Settings →
+Keybindings → Prefix tap**, choose **Complete guide only** to hide the on-screen
+badges while keeping the guide.
+
+Both the badges and guide read the live keymap. A rebound prefix or action
+changes immediately, and an unbound or currently unreachable action is not
+advertised. Clicking a guide row rechecks the current pane and modal scope
+before it runs. The setting changes only whether the pending command layer also
+marks controls in place. Both choices use the same prefix, second stroke,
+timeout, pane scope, and cancellation rules. No hold or key-release support is
+required.
+
 ## The prefix
 
-The default first stroke is `ctrl+a`. Press it, then one more key within 5
-seconds. After a short pause an on-screen command map appears, showing only
-the actions that can actually run right now.
+The default first stroke is `ctrl+a`. Tap it, then press one more key within
+5 seconds. A complete on-screen command map appears after a short pause and
+shows only actions that can run right now.
 
 | Sequence | Action |
 |---|---|

--- a/docs/design/keybinding-decisions.md
+++ b/docs/design/keybinding-decisions.md
@@ -8,6 +8,35 @@ reasoning is recorded so the next agent has the context.
 The user-facing vocabulary lives in [`../KEYBINDINGS.md`](../KEYBINDINGS.md).
 `F1` renders the live keymap and is authoritative over both.
 
+## Prefix tap presentation
+
+**2026-08-28 — the prefix has tap behavior only. Every tap opens the complete
+command guide; Settings chooses whether Rove also marks current clickable
+controls, and the combined presentation is the default. No action chord is
+added or moved (latest owner resolution: the guide and on-screen entries may
+coexist).**
+Each existing control names the stable binding id for the action it already
+performs, then resolves the displayed direct or prefix sequence through the
+live keymap and current binding stack. Rebindings therefore update the badge,
+while unbound or modal-blocked actions disappear instead of showing stale
+help. The current anchors are New task, Inbox, Kanban, Automations, Zen, Create
+PR, and Settings.
+
+The full-width guide is derived from the dispatcher's armed options, not a
+second hand-maintained action list, so it covers every currently reachable
+prefix binding without collapsing labels into the sidebar width. Clicking a
+row invokes a typed action only after the dispatcher confirms that the same
+action and stroke are still armed, in the same terminal-passthrough boundary,
+and reachable under the current LIFO and modal rules.
+
+The setting is presentation-only and persists in the UI state. The dispatcher
+still owns the single prefix session: tap arms it, the next stroke resolves it,
+and Escape, a miss, focus change, or timeout clears it. Both settings subscribe
+to that same armed state, so switching the display does not add a second input
+state machine or require terminal key-repeat/release reporting. The combined
+default keeps spatial teaching on existing controls while the guide remains a
+complete reference and clickable mouse entry.
+
 ## Repo context filter — removed, chord revoked
 
 **2026-08-16 — `ctrl+p` repo filter removed entirely (owner call, same

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -45,9 +45,11 @@ import {
 } from "../lib/keymap"
 import { useOptionalDialog } from "../ui/dialog"
 import { HelpDialog } from "./help-dialog"
+import { ShortcutRevealBadge } from "./shortcut-reveal"
 
 export type StatusKeyHintItem = {
   text: string
+  bindingId?: string
   /** Mouse activation — the same action the advertised key would run. */
   onPress?: () => void
 }
@@ -131,6 +133,7 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
   if (opts?.onOpenSettings && !opts.compact && keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))) {
     items.push({
       text: `[${t("hints.status.settings")}]`,
+      bindingId: "settings.open",
       onPress: snapshot.modal ? undefined : opts.onOpenSettings,
     })
   }
@@ -150,10 +153,11 @@ export function StatusKeyHintBar(props: { onOpenSettings?: () => void; compact?:
             {" · "}
           </text>
         ) : null,
-        <box key={item.text} onMouseUp={item.onPress}>
+        <box key={item.text} position="relative" onMouseUp={item.onPress}>
           <text fg={theme.textMuted} wrapMode="none">
             {item.text}
           </text>
+          {item.bindingId ? <ShortcutRevealBadge bindingId={item.bindingId} cover /> : null}
         </box>,
       ])}
     </box>

--- a/packages/kobe/src/tui-react/component/prefix-hud.tsx
+++ b/packages/kobe/src/tui-react/component/prefix-hud.tsx
@@ -17,8 +17,10 @@ import { PREFIX_GUIDE_DELAY_MS, PREFIX_HUD_TTL_MS, prefixHudState } from "../../
 import { truncateEnd } from "../../tui/lib/truncate"
 import { useTheme } from "../context/theme"
 import { tKeys, useT } from "../i18n"
+import { invokeArmedPrefixActionFromCurrentStack } from "../lib/keymap"
 import { isNarrowWidth } from "../lib/narrow-mode"
 import { useAccessor } from "../lib/use-accessor"
+import { useShortcutRevealPresentation } from "./shortcut-reveal"
 
 const BOTTOM_MARGIN = 1
 
@@ -73,6 +75,8 @@ export function PrefixHud(props: { left: number; width: number }) {
   const t = useT()
   const dims = useTerminalDimensions()
   const hud = useAccessor(prefixHudState)
+  const { activeSurface } = useShortcutRevealPresentation()
+  const showCommandGuide = activeSurface !== null
   const [, setFlushTick] = useState(0)
 
   const now = Date.now()
@@ -90,32 +94,40 @@ export function PrefixHud(props: { left: number; width: number }) {
   }, [oldestAt])
 
   useEffect(() => {
-    if (!hud.armed || hud.armedAt === null) return
+    if (!showCommandGuide || hud.armedAt === null) return
     const remaining = hud.armedAt + PREFIX_GUIDE_DELAY_MS - Date.now()
     if (remaining <= 0) return
     const timer = setTimeout(() => setFlushTick((tick) => tick + 1), remaining)
     return () => clearTimeout(timer)
-  }, [hud.armed, hud.armedAt])
+  }, [showCommandGuide, hud.armedAt])
 
-  const lineCount = fresh.length + (hud.armed ? 1 : 0)
+  const lineCount = fresh.length + (showCommandGuide ? 1 : 0)
   if (lineCount === 0) return null
   const armedKey = currentPrefixConfiguration().key ?? ""
-  const showGuide = hud.armed && hud.armedAt !== null && now - hud.armedAt >= PREFIX_GUIDE_DELAY_MS
+  const showGuide = showCommandGuide && hud.armedAt !== null && now - hud.armedAt >= PREFIX_GUIDE_DELAY_MS
   const groups = showGuide ? groupPrefixGuideOptions(hud.options) : []
 
   if (showGuide) {
     const narrow = dims.width < 88
-    const columns = narrow ? 1 : Math.min(3, Math.max(1, groups.length))
+    const columns = narrow ? 1 : Math.min(dims.width < 140 ? 2 : 3, Math.max(1, groups.length))
     const groupRows = Array.from({ length: Math.ceil(groups.length / columns) }, (_, index) =>
       groups.slice(index * columns, (index + 1) * columns),
     )
+    const guideWidth = Math.max(20, dims.width - 4)
+    const groupWidth = narrow ? guideWidth - 4 : Math.max(18, Math.floor((guideWidth - 4) / columns))
+    const actionHeight = (action: GuideAction): number => {
+      const strokes = action.strokes.join("/")
+      const keyWidth = Math.min(9, Math.max(3, strokes.length))
+      const labelWidth = Math.max(1, groupWidth - keyWidth - 1)
+      return Math.max(1, Math.ceil(actionLabel(action.action).length / labelWidth))
+    }
     const guideHeight = groupRows.reduce(
-      (height, row) => height + Math.max(1, ...row.map((group) => group.actions.length)) + 1,
+      (height, row) =>
+        height +
+        Math.max(1, ...row.map((group) => 1 + group.actions.reduce((sum, action) => sum + actionHeight(action), 0))),
       3,
     )
-    const guideWidth = Math.max(20, dims.width - 4)
     const top = Math.max(0, dims.height - BOTTOM_MARGIN - guideHeight)
-    const groupWidth = narrow ? guideWidth - 4 : Math.max(18, Math.floor((guideWidth - 4) / columns))
     return (
       <box
         position="absolute"
@@ -142,14 +154,22 @@ export function PrefixHud(props: { left: number; width: number }) {
                   <text fg={theme.accent}>{tKeys("category", group.category)}</text>
                   {group.actions.map((action) => {
                     const strokes = action.strokes.join("/")
-                    const label = truncateEnd(actionLabel(action.action), Math.max(4, groupWidth - strokes.length - 3))
                     return (
-                      <box key={action.action} flexDirection="row" gap={1}>
+                      <box
+                        key={action.action}
+                        flexDirection="row"
+                        gap={1}
+                        onMouseUp={(event: { stopPropagation(): void }) => {
+                          event.stopPropagation()
+                          const stroke = action.strokes[0]
+                          if (stroke) invokeArmedPrefixActionFromCurrentStack(action.action, stroke)
+                        }}
+                      >
                         <box width={Math.min(9, Math.max(3, strokes.length))}>
                           <text fg={theme.primary}>{strokes}</text>
                         </box>
-                        <text fg={theme.text} wrapMode="none">
-                          {label}
+                        <text fg={theme.text} wrapMode="word" flexGrow={1} flexShrink={1}>
+                          {actionLabel(action.action)}
                         </text>
                       </box>
                     )
@@ -187,7 +207,7 @@ export function PrefixHud(props: { left: number; width: number }) {
           </text>
         </box>
       ))}
-      {hud.armed ? (
+      {showCommandGuide ? (
         <box paddingLeft={1} paddingRight={1} backgroundColor={theme.backgroundDialog}>
           <text fg={theme.textMuted} wrapMode="none">
             {`${armedKey} ⋯`}

--- a/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
@@ -1,18 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Settings dialog (issue #15 G3). Two-column layout: left sidebar
- * (sections), right pane (the active section). Row order/indices come from
- * the shared framework-free registry
- * (`../../../tui/component/settings-dialog/model`), so keyboard nav stays
- * in lockstep with the section views; the kv-backed helper closures live
- * in `./use-settings-prefs` / `./use-engine-settings` (file-size cap
- * split) and reach the sections as one `prefs: SettingsPrefs` prop.
- *
- * Bindings inside the dialog:
- *   - `↑` / `↓` / `j` / `k` — navigate the current level.
- *   - `h` / `l`              — switch sidebar/body levels.
- *   - `enter`                — activate the focused row.
- *   - `esc`                  — close (handled by the dialog stack / page).
+ * Two-column Settings dialog. The pure row registry owns order and payloads;
+ * preference hooks own KV reads/writes. j/k navigate, h/l switch levels,
+ * Enter activates, and the surrounding dialog stack owns Escape.
  */
 
 import { errorMessage } from "@/lib/error-message"
@@ -53,21 +43,11 @@ import { useSettingsPrefs } from "./use-settings-prefs"
 
 export type SettingsDialogProps = {
   kv: KVContext
-  /**
-   * The active orchestrator. Used to expose the "Restart backend" Dev
-   * button only when we're attached to a daemon (RemoteOrchestrator).
-   */
+  /** Enables daemon-only Settings actions when present. */
   orchestrator?: KobeOrchestrator
   onVisualPrefsChange?: () => void
   onClose: () => void
-  /**
-   * True when this dialog is the standalone page surface (`kobe settings`),
-   * rendered OUTSIDE the dialog stack. The page mounts this component
-   * permanently, so when a sub-dialog (engine-command / custom-editor text
-   * input) is open we disable our own key bindings — otherwise the
-   * `j/k/l/h/t` nav would swallow those letters from the text input (the
-   * `{file}` "l-is-eaten" bug).
-   */
+  /** Standalone page mode; suspends navigation while a child dialog edits text. */
   standalone?: boolean
 }
 
@@ -245,6 +225,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
     sound: () => prefs.toggleSound(),
     crossTask: () => prefs.toggleCrossTask(),
     keyHints: () => toggleKeyHints(props.kv),
+    prefixTapPresentation: (row) => prefs.selectPrefixTapPresentation(row.presentation),
     splitStyle: (row) => prefs.selectSplitStyle(row.style),
     zenDefaultOn: () => prefs.toggleZenDefaultOn(),
     zenKeepTasks: () => prefs.toggleZenKeepsTasks(),
@@ -419,7 +400,9 @@ export function SettingsDialog(props: SettingsDialogProps) {
               editSetting={(id, key) => void plugins.editSetting(id, key)}
             />
           ) : null}
-          {section === "keys" ? <KeybindingsSettingsSection {...cursorProps} onCreateFile={createKeysFile} /> : null}
+          {section === "keys" ? (
+            <KeybindingsSettingsSection {...cursorProps} prefs={prefs} onCreateFile={createKeysFile} />
+          ) : null}
           {section === "feedback" ? (
             <FeedbackSettingsSection
               {...cursorProps}

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-misc.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-misc.tsx
@@ -10,10 +10,16 @@ import { TextAttributes, type TextareaRenderable } from "@opentui/core"
 import { useEffect, useRef } from "react"
 import { tildify } from "../../../lib/path-home"
 import { stripNewlines } from "../../../tui/component/new-task-dialog/state"
-import { devRows, rowIndex } from "../../../tui/component/settings-dialog/model"
+import {
+  devRows,
+  keybindingRows,
+  prefixTapPresentationRowId,
+  rowIndex,
+} from "../../../tui/component/settings-dialog/model"
 import { userKeybindingsReport } from "../../../tui/context/keybindings-user"
 import { currentPrefixConfiguration } from "../../../tui/lib/keymap-dispatch"
 import { FIXED_BINDING_IDS } from "../../../tui/lib/keymap-overrides"
+import { PREFIX_TAP_PRESENTATIONS } from "../../../tui/lib/prefix-tap-presentation"
 import { useKeymapVersion } from "../../context/keybindings"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
@@ -247,6 +253,7 @@ export function KeybindingsSettingsSection(
   props: SectionCursorProps & {
     /** Write the starter YAML — offered only while the file is absent. */
     onCreateFile: () => void
+    prefs: SettingsPrefs
   },
 ) {
   const { theme } = useTheme()
@@ -256,6 +263,7 @@ export function KeybindingsSettingsSection(
   // truthful after a YAML edit.
   useKeymapVersion()
   const report = userKeybindingsReport()
+  const rows = keybindingRows(report.exists)
   const prefix = currentPrefixConfiguration()
   const fixedIds = Object.keys(FIXED_BINDING_IDS).sort()
   const appliedIdWidth = Math.min(
@@ -282,6 +290,37 @@ export function KeybindingsSettingsSection(
       </box>
       <box flexDirection="column" gap={0}>
         <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          {t("settings.keybindings.tapPresentation")}
+        </text>
+        <text fg={theme.textMuted} wrapMode="word">
+          {t("settings.keybindings.tapPresentationHint")}
+        </text>
+        {PREFIX_TAP_PRESENTATIONS.map((presentation) => {
+          const row = rowIndex(rows, prefixTapPresentationRowId(presentation))
+          const selected = props.prefs.prefixTapPresentation() === presentation
+          return (
+            <Row
+              key={presentation}
+              cursor={props.level === "body" && props.bodyRow === row}
+              onMouseUp={() => {
+                props.setLevel("body")
+                props.setBodyRow(row)
+                props.prefs.selectPrefixTapPresentation(presentation)
+              }}
+              fg={selected ? theme.accent : theme.text}
+              bold={selected || (props.level === "body" && props.bodyRow === row)}
+            >
+              {`${selected ? "(●)" : "( )"} ${t(
+                presentation === "local"
+                  ? "settings.keybindings.tapPresentationLocal"
+                  : "settings.keybindings.tapPresentationGuide",
+              )}`}
+            </Row>
+          )
+        })}
+      </box>
+      <box flexDirection="column" gap={0}>
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
           {t("settings.keybindings.prefixTitle", { prefix: prefix.key ?? t("settings.keybindings.prefixDisabled") })}
         </text>
         <text fg={theme.textMuted} wrapMode="word">
@@ -300,10 +339,10 @@ export function KeybindingsSettingsSection(
             {t("settings.keybindings.createHint")}
           </text>
           <Row
-            cursor={props.level === "body" && props.bodyRow === 0}
+            cursor={props.level === "body" && props.bodyRow === rowIndex(rows, "keys-create")}
             onMouseUp={() => {
               props.setLevel("body")
-              props.setBodyRow(0)
+              props.setBodyRow(rowIndex(rows, "keys-create"))
               props.onCreateFile()
             }}
             fg={theme.text}

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
@@ -40,6 +40,11 @@ import {
   type EditorKind,
   normalizeEditorKind,
 } from "../../../tui/lib/editor-prefs"
+import {
+  PREFIX_TAP_PRESENTATION_KEY,
+  type PrefixTapPresentation,
+  normalizePrefixTapPresentation,
+} from "../../../tui/lib/prefix-tap-presentation"
 import type { KVContext } from "../../context/kv"
 import { useT } from "../../i18n"
 import type { DialogContext } from "../../ui/dialog"
@@ -69,6 +74,13 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
   }
   function toggleCrossTask(): void {
     kv.set("notifications.crossTask.enabled", !crossTaskEnabled())
+  }
+
+  function prefixTapPresentation(): PrefixTapPresentation {
+    return normalizePrefixTapPresentation(kv.get(PREFIX_TAP_PRESENTATION_KEY))
+  }
+  function selectPrefixTapPresentation(next: PrefixTapPresentation): void {
+    kv.set(PREFIX_TAP_PRESENTATION_KEY, next)
   }
   // Sidebar hover tooltips: opt-in, default OFF (owner call 2026-07-28) —
   // the item info they show is nice-to-have, not essential.
@@ -270,6 +282,8 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
     toggleSound,
     crossTaskEnabled,
     toggleCrossTask,
+    prefixTapPresentation,
+    selectPrefixTapPresentation,
     splitStyle,
     selectSplitStyle,
     zenDefaultOn,

--- a/packages/kobe/src/tui-react/component/shortcut-reveal.tsx
+++ b/packages/kobe/src/tui-react/component/shortcut-reveal.tsx
@@ -1,0 +1,91 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * React/OpenTUI adapter for prefix-tap presentation.
+ *
+ * The dispatcher-owned `prefixHudState.armed` is the only interaction state.
+ * Settings changes only whether the complete guide is accompanied by local
+ * control badges.
+ */
+
+import { type ReactNode, createContext, useContext, useMemo } from "react"
+import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
+import { prefixHudState } from "../../tui/lib/prefix-hud"
+import {
+  PREFIX_TAP_PRESENTATION_KEY,
+  type PrefixTapPresentation,
+  normalizePrefixTapPresentation,
+} from "../../tui/lib/prefix-tap-presentation"
+import { shortcutCaption } from "../../tui/lib/shortcut-reveal"
+import { useKeymapVersion } from "../context/keybindings"
+import { useOptionalKV } from "../context/kv"
+import { useTheme } from "../context/theme"
+import { currentBindingReachability, useBindingStackVersion } from "../lib/keymap"
+import { useAccessor } from "../lib/use-accessor"
+
+export type ShortcutRevealPresentation = Readonly<{
+  mode: PrefixTapPresentation
+  activeSurface: PrefixTapPresentation | null
+}>
+
+const DEFAULT_PRESENTATION: ShortcutRevealPresentation = {
+  mode: "local",
+  activeSurface: null,
+}
+
+const ShortcutRevealContext = createContext<ShortcutRevealPresentation>(DEFAULT_PRESENTATION)
+
+export function useShortcutRevealPresentation(): ShortcutRevealPresentation {
+  return useContext(ShortcutRevealContext)
+}
+
+export function ShortcutRevealProvider(props: { readonly children: ReactNode }) {
+  const kv = useOptionalKV()
+  const hud = useAccessor(prefixHudState)
+  const mode = normalizePrefixTapPresentation(kv?.get(PREFIX_TAP_PRESENTATION_KEY))
+  const value = useMemo<ShortcutRevealPresentation>(
+    () => ({
+      mode,
+      activeSurface: hud.armed ? mode : null,
+    }),
+    [mode, hud.armed],
+  )
+  return <ShortcutRevealContext.Provider value={value}>{props.children}</ShortcutRevealContext.Provider>
+}
+
+/** Display-only keycap anchored by a `position="relative"` click target. */
+export function ShortcutRevealBadge(props: { readonly bindingId: string; readonly cover?: boolean }) {
+  const { activeSurface } = useShortcutRevealPresentation()
+  if (activeSurface !== "local") return null
+  return <ActiveShortcutRevealBadge bindingId={props.bindingId} cover={props.cover} />
+}
+
+/** Subscribe to live keymap changes only during the short reveal window. */
+function ActiveShortcutRevealBadge(props: { readonly bindingId: string; readonly cover?: boolean }) {
+  const { theme } = useTheme()
+  useKeymapVersion()
+  useBindingStackVersion()
+  const caption = shortcutCaption({
+    bindingId: props.bindingId,
+    reachability: currentBindingReachability(),
+    prefixKey: currentPrefixConfiguration().key,
+  })
+
+  if (!caption) return null
+  return (
+    <box
+      position="absolute"
+      left={props.cover ? 0 : undefined}
+      right={0}
+      top={0}
+      zIndex={20}
+      paddingLeft={1}
+      paddingRight={1}
+      backgroundColor={theme.backgroundElement}
+      justifyContent="flex-end"
+    >
+      <text fg={theme.primary} wrapMode="none">
+        {caption}
+      </text>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -12,6 +12,7 @@ import { formatChord } from "../../../tui/lib/chord-glyphs"
 import { currentPrefixConfiguration } from "../../../tui/lib/keymap-dispatch"
 import type { GitScope } from "../../../tui/panes/filetree/git"
 import { type FileTreeTab, TAB_ORDER, tabLabelKey } from "../../../tui/panes/filetree/keys-core"
+import { ShortcutRevealBadge } from "../../component/shortcut-reveal"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 
@@ -55,6 +56,7 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
             // the focus-leaves-workspace guard. A chip click is an
             // action, never a background pane click.
             <box
+              position="relative"
               flexDirection="row"
               gap={1}
               // Never squeeze the chip below its content: on a narrow pane the
@@ -72,6 +74,7 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
               <text fg={theme.text} wrapMode="none">
                 {t("files.actions.zen")}
               </text>
+              <ShortcutRevealBadge bindingId="workspace.zenToggle" />
             </box>
           ) : null}
           {props.onCreatePR ? (
@@ -86,9 +89,12 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
               }}
             >
               {createPRChord ? (
-                <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
-                  {createPRChord}
-                </text>
+                <box position="relative">
+                  <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+                    {createPRChord}
+                  </text>
+                  <ShortcutRevealBadge bindingId="files.createPR" cover />
+                </box>
               ) : null}
               <text fg={theme.text} wrapMode="none">
                 {t("files.actions.createPR")}

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -9,6 +9,7 @@
 import { MouseButton, TextAttributes } from "@opentui/core"
 import { legendCap } from "../../../tui/lib/help-groups"
 import { SIDEBAR_NAV_ITEMS, type SidebarNav } from "../../../tui/panes/sidebar/nav-core"
+import { ShortcutRevealBadge } from "../../component/shortcut-reveal"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { zenChipGlyph } from "./zen-glyph"
@@ -120,14 +121,16 @@ export function SidebarBrandHeader(props: {
           ROVE
         </text>
         {props.status ? (
-          <text
-            fg={props.status.emphasize ? theme.warning : theme.textMuted}
-            attributes={props.status.emphasize ? TextAttributes.BOLD : TextAttributes.DIM}
-            wrapMode="none"
-            onMouseUp={() => props.onStatusClick?.()}
-          >
-            {props.status.label}
-          </text>
+          <box position="relative" onMouseUp={() => props.onStatusClick?.()}>
+            <text
+              fg={props.status.emphasize ? theme.warning : theme.textMuted}
+              attributes={props.status.emphasize ? TextAttributes.BOLD : TextAttributes.DIM}
+              wrapMode="none"
+            >
+              {props.status.label}
+            </text>
+            {props.onStatusClick ? <ShortcutRevealBadge bindingId="inbox.show" /> : null}
+          </box>
         ) : null}
       </box>
     </box>
@@ -149,6 +152,7 @@ export function SidebarCreateAction(props: { onAddTask?: () => void }) {
   return (
     <box flexShrink={0} paddingTop={1} paddingBottom={1} paddingLeft={1} paddingRight={1}>
       <box
+        position="relative"
         flexDirection="row"
         flexShrink={0}
         gap={1}
@@ -168,6 +172,7 @@ export function SidebarCreateAction(props: { onAddTask?: () => void }) {
             {keycap}
           </text>
         ) : null}
+        <ShortcutRevealBadge bindingId="task.new" />
       </box>
     </box>
   )
@@ -185,6 +190,7 @@ export function SidebarNavRail(props: { nav: SidebarNav; setNav: (nav: SidebarNa
         return (
           <box
             key={item.nav}
+            position="relative"
             flexDirection="row"
             flexShrink={0}
             paddingLeft={1}
@@ -209,6 +215,7 @@ export function SidebarNavRail(props: { nav: SidebarNav; setNav: (nav: SidebarNa
             >
               {t(item.labelKey)}
             </text>
+            <ShortcutRevealBadge bindingId={item.bindingId} />
           </box>
         )
       })}
@@ -219,7 +226,7 @@ export function SidebarNavRail(props: { nav: SidebarNav; setNav: (nav: SidebarNa
 export function SidebarZenChip(props: { onZenClick?: () => void }) {
   const { theme } = useTheme()
   return (
-    <box flexShrink={0} paddingLeft={1} paddingRight={1} paddingTop={1}>
+    <box position="relative" flexShrink={0} paddingLeft={1} paddingRight={1} paddingTop={1}>
       <text
         fg={theme.accent}
         attributes={TextAttributes.BOLD}
@@ -234,6 +241,7 @@ export function SidebarZenChip(props: { onZenClick?: () => void }) {
       >
         {`${zenChipGlyph()} ZEN`}
       </text>
+      <ShortcutRevealBadge bindingId="workspace.zenToggle" />
     </box>
   )
 }

--- a/packages/kobe/src/tui-react/workspace/host-footer.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-footer.tsx
@@ -22,6 +22,7 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { engineDisplayName } from "../../engine/interactive-command"
 import { StatusKeyHintBar, useStatusKeyHintItems } from "../component/keyboard-hints"
 import { narrowUsageChip, usageChips } from "../component/settings-dialog/usage-core"
+import { ShortcutRevealProvider } from "../component/shortcut-reveal"
 import { useTheme } from "../context/theme"
 import { isNarrowWidth } from "../lib/narrow-mode"
 import { useAccessor } from "../lib/use-accessor"
@@ -96,19 +97,21 @@ export function WorkspaceFrame(props: {
   const hintItems = useStatusKeyHintItems({ onOpenSettings: props.onOpenSettings })
   const footerVisible = (usage != null && usage.size > 0) || hintItems.length > 0
   return (
-    <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
-      <box flexDirection="row" flexGrow={1}>
-        {props.children}
-      </box>
-      {footerVisible ? (
-        <box flexDirection="row" flexShrink={0} height={1} paddingLeft={1} paddingRight={1} gap={2}>
-          <box flexGrow={1} flexDirection="row">
-            <UsageChips orchestrator={props.orchestrator} narrow={narrow} />
-          </box>
-          {/* Narrow drops the verbs and the [settings] chip: `⌃A · F1`. */}
-          <StatusKeyHintBar onOpenSettings={narrow ? undefined : props.onOpenSettings} compact={narrow} />
+    <ShortcutRevealProvider>
+      <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+        <box flexDirection="row" flexGrow={1}>
+          {props.children}
         </box>
-      ) : null}
-    </box>
+        {footerVisible ? (
+          <box flexDirection="row" flexShrink={0} height={1} paddingLeft={1} paddingRight={1} gap={2}>
+            <box flexGrow={1} flexDirection="row">
+              <UsageChips orchestrator={props.orchestrator} narrow={narrow} />
+            </box>
+            {/* Narrow drops the verbs and the [settings] chip: `⌃A · F1`. */}
+            <StatusKeyHintBar onOpenSettings={narrow ? undefined : props.onOpenSettings} compact={narrow} />
+          </box>
+        ) : null}
+      </box>
+    </ShortcutRevealProvider>
   )
 }

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -22,6 +22,7 @@ import type { VendorId } from "../../../types/vendor"
 // React port, which must not reference the Solid .tsx even type-only.
 import type { FocusAccentSlot } from "../../context/theme-core"
 import { LOCALES, type LocaleId } from "../../i18n/catalog"
+import { PREFIX_TAP_PRESENTATIONS, type PrefixTapPresentation } from "../../lib/prefix-tap-presentation"
 
 export type NavLevel = "sidebar" | "body"
 
@@ -53,6 +54,7 @@ export type SettingsRow =
   | { id: "sound"; kind: "sound" }
   | { id: "cross-task"; kind: "crossTask" }
   | { id: "key-hints"; kind: "keyHints" }
+  | { id: string; kind: "prefixTapPresentation"; presentation: PrefixTapPresentation }
   | { id: "zen-default-on"; kind: "zenDefaultOn" }
   | { id: "zen-keep-tasks"; kind: "zenKeepTasks" }
   | { id: "editor-kind"; kind: "editorKind" }
@@ -95,6 +97,10 @@ export function engineRowId(vendor: VendorId): string {
 
 export function splitStyleRowId(style: SplitStyle): string {
   return `split-style:${style}`
+}
+
+export function prefixTapPresentationRowId(presentation: PrefixTapPresentation): string {
+  return `prefix-tap:${presentation}`
 }
 
 export function pluginRowId(pluginId: string): string {
@@ -187,6 +193,19 @@ export function feedbackRows(): SettingsRow[] {
   ]
 }
 
+export function keybindingRows(keybindingsFileExists: boolean): SettingsRow[] {
+  return [
+    ...PREFIX_TAP_PRESENTATIONS.map(
+      (presentation): SettingsRow => ({
+        id: prefixTapPresentationRowId(presentation),
+        kind: "prefixTapPresentation",
+        presentation,
+      }),
+    ),
+    ...(keybindingsFileExists ? [] : [{ id: "keys-create", kind: "keysCreate" } as const]),
+  ]
+}
+
 /**
  * Dev section: Reset (always), Restart (daemon only), then the
  * Experimental remote-projects toggle — kept last so its presence never
@@ -214,10 +233,7 @@ export function sectionRows(section: SectionId, input: SettingsRowsInput): Setti
     case "engines":
       return engineRows(input.engineList)
     case "keys":
-      // One action, and only while there is nothing to edit: writing the
-      // starter file is the whole gap between "here is the YAML" and a file
-      // the user can actually open.
-      return input.keybindingsFileExists ? [] : [{ id: "keys-create", kind: "keysCreate" }]
+      return keybindingRows(input.keybindingsFileExists)
     case "plugins":
       return pluginRows(input.plugins)
     case "feedback":

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -135,7 +135,11 @@ export const en = {
     prefixTitle: "Command layer ({prefix})",
     /** One-paragraph grammar summary; {prefix} live first stroke, {timeout} live second-stroke window in ms */
     prefixHint:
-      "Bare keys act in the focused pane; a small one-press set covers frequent Rove actions; {prefix} opens the command map ({timeout}ms second-stroke window — hold on and a guide appears). Prefix bindings keep their pane scope and modal rules.",
+      "Bare keys act in the focused pane; a small one-press set covers frequent Rove actions; {prefix} opens the command layer ({timeout}ms second-stroke window). Prefix bindings keep their pane scope and modal rules.",
+    tapPresentation: "Prefix tap",
+    tapPresentationHint: "Choose whether the complete guide also marks controls already on screen.",
+    tapPresentationLocal: "On-screen entries + complete guide (default)",
+    tapPresentationGuide: "Complete guide only",
     /** Shown as the {prefix} value when the user disabled the prefix in YAML */
     prefixDisabled: "disabled",
     /** Trailing note listing non-rebindable ids; hidden when there are none */
@@ -309,7 +313,11 @@ export const zh: typeof en = {
     notCreated: "  (尚未创建)",
     prefixTitle: "命令层（{prefix}）",
     prefixHint:
-      "裸键作用于当前聚焦面板；少量单次快捷键覆盖高频 Rove 操作；{prefix} 打开命令层（第二击窗口 {timeout}ms — 稍等会出现命令指南）。Prefix 绑定保持原有的面板作用域和 modal 规则。",
+      "裸键作用于当前聚焦面板；少量单次快捷键覆盖高频 Rove 操作；{prefix} 打开命令层（第二击窗口 {timeout}ms）。Prefix 绑定保持原有的面板作用域和 modal 规则。",
+    tapPresentation: "点按 Prefix",
+    tapPresentationHint: "选择完整指南是否同时标记当前屏幕上的入口。",
+    tapPresentationLocal: "屏幕入口 + 完整指南（默认）",
+    tapPresentationGuide: "仅完整指南",
     prefixDisabled: "已禁用",
     fixed: "固定（不可重绑定）：{ids}。",
     createHint: "还没有覆盖文件。Rove 可以帮你写一份带完整注释的——在你取消注释之前不会改动任何按键。",

--- a/packages/kobe/src/tui/lib/prefix-tap-presentation.ts
+++ b/packages/kobe/src/tui/lib/prefix-tap-presentation.ts
@@ -1,0 +1,12 @@
+/** Persisted presentation choice for one prefix tap. */
+export const PREFIX_TAP_PRESENTATION_KEY = "hints.keyboard.prefixTapPresentation"
+
+export const PREFIX_TAP_PRESENTATIONS = ["local", "guide"] as const
+export type PrefixTapPresentation = (typeof PREFIX_TAP_PRESENTATIONS)[number]
+
+export const DEFAULT_PREFIX_TAP_PRESENTATION: PrefixTapPresentation = "local"
+
+/** Missing, malformed, and obsolete values preserve the product default. */
+export function normalizePrefixTapPresentation(raw: unknown): PrefixTapPresentation {
+  return raw === "guide" ? "guide" : DEFAULT_PREFIX_TAP_PRESENTATION
+}

--- a/packages/kobe/src/tui/lib/shortcut-reveal.ts
+++ b/packages/kobe/src/tui/lib/shortcut-reveal.ts
@@ -1,0 +1,39 @@
+/**
+ * Framework-free policy for shortcut badges shown while the prefix is armed.
+ *
+ * The keymap remains the only shortcut source of truth. Clickable controls
+ * name the binding they already represent; this module resolves that id to
+ * the canonical live chord only when the current binding stack can run it.
+ */
+
+import { findBinding } from "../context/keybindings"
+import { formatChord } from "./chord-glyphs"
+import type { BindingReachability } from "./keymap-reachability"
+
+export type ShortcutCaptionInput = Readonly<{
+  bindingId: string
+  reachability: BindingReachability
+  prefixKey: string | null
+}>
+
+/**
+ * Resolve the control's real current chord. Cosmetic `hint.keys` values are
+ * intentionally ignored: they may be summaries such as `j/k`, while this
+ * badge promises the actual first registered direct or prefix chord.
+ */
+export function shortcutCaption(input: ShortcutCaptionInput): string | null {
+  const binding = findBinding(input.bindingId)
+  if (!binding) return null
+
+  if (input.reachability.direct.has(input.bindingId)) {
+    const direct = binding.keys[0]
+    if (direct) return formatChord(direct)
+  }
+
+  if (input.prefixKey && input.reachability.prefix.has(input.bindingId)) {
+    const stroke = binding.prefixKeys?.[0]
+    if (stroke) return `${formatChord(input.prefixKey)} ${formatChord(stroke)}`
+  }
+
+  return null
+}

--- a/packages/kobe/src/tui/panes/sidebar/nav-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/nav-core.ts
@@ -23,6 +23,8 @@ export interface SidebarNavItem {
   readonly nav: SidebarNav
   /** i18n key — callers translate with their own `t`. */
   readonly labelKey: string
+  /** Existing keymap action represented by this clickable destination. */
+  readonly bindingId: string
 }
 
 /**
@@ -31,8 +33,8 @@ export interface SidebarNavItem {
  * for the same thing — and clicking a task already returns there.
  */
 export const SIDEBAR_NAV_ITEMS: readonly SidebarNavItem[] = [
-  { nav: "kanban", labelKey: "tasks.nav.kanban" },
-  { nav: "automations", labelKey: "tasks.nav.automations" },
+  { nav: "kanban", labelKey: "tasks.nav.kanban", bindingId: "kanban.open" },
+  { nav: "automations", labelKey: "tasks.nav.automations", bindingId: "automations.open" },
   // `issues` is deliberately absent: the external-tracker page works but has
   // had no design pass, so it stays reachable only through `kobe api
   // workitem-*` until it earns a rail row. Its nav value and page stay wired

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -136,6 +136,16 @@ function withGuideKvHome(): void {
   process.env.KOBE_HOME_DIR = home
 }
 
+async function waitForFrameText(frame: () => Promise<string>, text: string): Promise<string> {
+  const deadline = Date.now() + 1_000
+  let current = await frame()
+  while (!current.includes(text) && Date.now() < deadline) {
+    await settle(25)
+    current = await frame()
+  }
+  return current
+}
+
 describe("StatusKeyHintBar", () => {
   it("advertises the live prefix and help chords from the workspace stack", async () => {
     const { frame } = await renderComponent(
@@ -183,8 +193,7 @@ describe("StatusKeyHintBar", () => {
     await settle()
 
     act(() => mockInput.pressKey("a", { ctrl: true }))
-    await settle(300)
-    expect(await frame()).toContain("more Rove commands")
+    expect(await waitForFrameText(frame, "more Rove commands")).toContain("more Rove commands")
 
     act(() => mockInput.pressKey("z"))
     await settle()
@@ -275,9 +284,7 @@ describe("footer hint clicks", () => {
     await settle()
     const spot = locate(await frame(), "commands")
     await mockMouse.click(spot.x + 1, spot.y)
-    // The guide expands after the learner delay (180ms).
-    await settle(300)
-    expect(await frame()).toContain("more Rove commands")
+    expect(await waitForFrameText(frame, "more Rove commands")).toContain("more Rove commands")
     act(() => resetPrefixState())
   })
 })

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "bun:test"
-import { mkdtempSync } from "node:fs"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { useEffect } from "react"
@@ -25,6 +25,7 @@ import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keyb
 import type { HostPagesState } from "../../src/tui-react/workspace/host-pages"
 import { KEY_HINTS_ENABLED_KEY, PANE_HINT_USED_KEYS } from "../../src/tui/lib/keyboard-hints"
 import { resetPrefixState } from "../../src/tui/lib/keymap-dispatch"
+import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
 import { act, renderComponent, settle } from "./harness"
 
 const NOOP = (): void => {}
@@ -127,6 +128,14 @@ function withTempKvHome(): void {
   process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-hints-"))
 }
 
+function withGuideKvHome(): void {
+  const home = mkdtempSync(join(tmpdir(), "kobe-hints-guide-"))
+  const configDir = join(home, ".config", "rove")
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, "state.json"), JSON.stringify({ [PREFIX_TAP_PRESENTATION_KEY]: "guide" }))
+  process.env.KOBE_HOME_DIR = home
+}
+
 describe("StatusKeyHintBar", () => {
   it("advertises the live prefix and help chords from the workspace stack", async () => {
     const { frame } = await renderComponent(
@@ -159,6 +168,7 @@ describe("StatusKeyHintBar", () => {
   })
 
   it("opens and dispatches the command layer with ctrl+a inside the terminal", async () => {
+    withGuideKvHome()
     let zenToggles = 0
     const { frame, mockInput } = await renderComponent(
       <WorkspaceFrame orchestrator={fakeOrchestrator()} onOpenSettings={NOOP}>
@@ -168,7 +178,7 @@ describe("StatusKeyHintBar", () => {
           </TerminalPassthroughDriver>
         </WorkspaceDriver>
       </WorkspaceFrame>,
-      { width: 110, height: 30, providers: { focus: true, dialog: true } },
+      { width: 110, height: 30, providers: { kv: true, focus: true, dialog: true } },
     )
     await settle()
 
@@ -254,12 +264,13 @@ describe("footer hint clicks", () => {
   })
 
   it("clicking the commands caption arms the real prefix and shows the which-key guide", async () => {
+    withGuideKvHome()
     const { frame, mockMouse } = await renderComponent(
       <WorkspaceFrame orchestrator={fakeOrchestrator()} onOpenSettings={NOOP}>
         <WorkspaceDriver />
         <PrefixHud left={1} width={24} />
       </WorkspaceFrame>,
-      { width: 110, height: 30, providers: { focus: true, dialog: true } },
+      { width: 110, height: 30, providers: { kv: true, focus: true, dialog: true } },
     )
     await settle()
     const spot = locate(await frame(), "commands")

--- a/packages/kobe/test/render/settings-dialog.test.tsx
+++ b/packages/kobe/test/render/settings-dialog.test.tsx
@@ -7,11 +7,12 @@
  */
 
 import { describe, expect, it } from "bun:test"
-import { mkdtempSync } from "node:fs"
+import { mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { SettingsDialog } from "../../src/tui-react/component/settings-dialog"
 import { useKV } from "../../src/tui-react/context/kv"
+import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
 import { act, renderComponent, settle } from "./harness"
 
 const NOOP = (): void => {}
@@ -51,10 +52,42 @@ describe("SettingsDialog", () => {
     text = await press("j") // → Keybindings
     expect(text).toContain("Command layer (ctrl+a)")
     expect(text).toContain("5000ms second-stroke window")
+    expect(text).toContain("On-screen entries + complete guide (default)")
+    expect(text).toContain("Complete guide only")
     expect(text).not.toContain("Fixed (not rebindable)") // FIXED_BINDING_IDS is empty
     text = await press("j") // → Feedback
     expect(text).toContain("GitHub Discussion")
     text = await press("j") // → Dev
     expect(text).toContain("Reset UI state")
+  })
+
+  it("selects and persists the prefix-tap presentation with ordinary Settings keys", async () => {
+    const home = mkdtempSync(join(tmpdir(), "kobe-prefix-setting-"))
+    process.env.KOBE_HOME_DIR = home
+    const { frame, mockInput } = await renderComponent(<Driver />, {
+      width: 110,
+      height: 40,
+      providers: { kv: true, dialog: true },
+    })
+
+    for (let i = 0; i < 3; i++) {
+      act(() => mockInput.pressKey("j"))
+      await settle()
+    }
+    expect(await frame()).toContain("(●) On-screen entries + complete guide (default)")
+
+    act(() => mockInput.pressKey("l"))
+    await settle()
+    act(() => mockInput.pressKey("j"))
+    await settle()
+    act(() => mockInput.pressEnter())
+    await settle(320)
+
+    expect(await frame()).toContain("(●) Complete guide only")
+    const persisted = JSON.parse(readFileSync(join(home, ".config", "rove", "state.json"), "utf8")) as Record<
+      string,
+      unknown
+    >
+    expect(persisted[PREFIX_TAP_PRESENTATION_KEY]).toBe("guide")
   })
 })

--- a/packages/kobe/test/render/settings-keybindings-create.test.tsx
+++ b/packages/kobe/test/render/settings-keybindings-create.test.tsx
@@ -40,7 +40,9 @@ test("the Keybindings page writes the starter YAML on enter", async () => {
   for (let i = 0; i < 3; i++) await press("j") // → Keybindings
   expect(await frame()).toContain("not created yet")
 
-  await press("l") // into the body — the section has exactly one row
+  await press("l") // into the body — prefix presentation rows come first
+  await press("j")
+  await press("j") // → Create keybindings.yaml
   // `pressEnter()`, not `pressKey("return")`: the mock's key NAMES are
   // uppercase, so a lowercase one is typed as its six letters.
   act(() => mockInput.pressEnter())

--- a/packages/kobe/test/render/shortcut-reveal.test.tsx
+++ b/packages/kobe/test/render/shortcut-reveal.test.tsx
@@ -1,0 +1,109 @@
+/** @jsxImportSource @opentui/react */
+
+import { expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { PrefixHud } from "../../src/tui-react/component/prefix-hud"
+import { ShortcutRevealProvider } from "../../src/tui-react/component/shortcut-reveal"
+import { useBindings } from "../../src/tui-react/lib/keymap"
+import { SidebarNavRail } from "../../src/tui-react/panes/sidebar/chrome"
+import { bindByIds } from "../../src/tui/context/keybindings"
+import { prefixAction } from "../../src/tui/lib/keymap-dispatch"
+import { PREFIX_GUIDE_DELAY_MS } from "../../src/tui/lib/prefix-hud"
+import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
+import { act, renderComponent, settle } from "./harness"
+
+function locate(frame: string, text: string): { x: number; y: number } {
+  const lines = frame.split("\n")
+  const y = lines.findIndex((line) => line.includes(text))
+  if (y < 0) throw new Error(`missing ${text}`)
+  return { x: lines[y]?.indexOf(text) ?? -1, y }
+}
+
+function RevealFixture(props: { onOpenEditor?: () => void }) {
+  useBindings(() => ({
+    bindings: bindByIds({
+      "kanban.open": prefixAction(() => {}),
+      "automations.open": prefixAction(() => {}),
+      "task.openEditor": prefixAction(() => props.onOpenEditor?.()),
+    }),
+  }))
+  return (
+    <>
+      <SidebarNavRail nav="terminal" setNav={() => {}} />
+      <PrefixHud left={1} width={22} />
+    </>
+  )
+}
+
+function tempHome(mode?: "local" | "guide"): string {
+  const home = mkdtempSync(join(tmpdir(), "rove-prefix-tap-"))
+  if (mode) {
+    const configDir = join(home, ".config", "rove")
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(join(configDir, "state.json"), JSON.stringify({ [PREFIX_TAP_PRESENTATION_KEY]: mode }))
+  }
+  return home
+}
+
+test("the default prefix tap shows local badges and the complete command guide together", async () => {
+  process.env.KOBE_HOME_DIR = tempHome()
+  const { mockInput, frame } = await renderComponent(
+    <ShortcutRevealProvider>
+      <RevealFixture />
+    </ShortcutRevealProvider>,
+    { width: 160, height: 30, providers: { kv: true } },
+  )
+
+  act(() => mockInput.pressKey("a", { ctrl: true }))
+  await settle(PREFIX_GUIDE_DELAY_MS + 40)
+  const local = await frame()
+  expect(local).toContain("⌃ A 1")
+  expect(local).toContain("⌃ A 2")
+  expect(local).toContain("more Rove commands")
+  expect(local).toContain("Open active Task directory in editor")
+  expect(local).not.toContain("Open active…")
+
+  act(() => mockInput.pressKey("escape"))
+  await settle()
+  expect(await frame()).not.toContain("⌃ A 1")
+})
+
+test("a complete-guide row is a real clickable entry in local mode", async () => {
+  process.env.KOBE_HOME_DIR = tempHome()
+  let editorOpens = 0
+  const { mockInput, mockMouse, frame } = await renderComponent(
+    <ShortcutRevealProvider>
+      <RevealFixture onOpenEditor={() => editorOpens++} />
+    </ShortcutRevealProvider>,
+    { width: 160, height: 30, providers: { kv: true } },
+  )
+
+  act(() => mockInput.pressKey("a", { ctrl: true }))
+  await settle(PREFIX_GUIDE_DELAY_MS + 40)
+  const revealed = await frame()
+  const at = locate(revealed, "Open active Task directory in editor")
+  await mockMouse.click(at.x + 1, at.y)
+  await settle()
+
+  expect(editorOpens).toBe(1)
+  expect(await frame()).not.toContain("more Rove commands")
+})
+
+test("the guide setting routes the same prefix tap to the global command guide", async () => {
+  process.env.KOBE_HOME_DIR = tempHome("guide")
+  const { mockInput, frame } = await renderComponent(
+    <ShortcutRevealProvider>
+      <RevealFixture />
+    </ShortcutRevealProvider>,
+    { width: 160, height: 30, providers: { kv: true } },
+  )
+
+  act(() => mockInput.pressKey("a", { ctrl: true }))
+  await settle(PREFIX_GUIDE_DELAY_MS + 40)
+  const guide = await frame()
+  expect(guide).toContain("more Rove commands")
+  expect(guide).toContain("Open active Task directory in editor")
+  expect(guide).not.toContain("⌃ A 1")
+})

--- a/packages/kobe/test/render/shortcut-reveal.test.tsx
+++ b/packages/kobe/test/render/shortcut-reveal.test.tsx
@@ -10,7 +10,6 @@ import { useBindings } from "../../src/tui-react/lib/keymap"
 import { SidebarNavRail } from "../../src/tui-react/panes/sidebar/chrome"
 import { bindByIds } from "../../src/tui/context/keybindings"
 import { prefixAction } from "../../src/tui/lib/keymap-dispatch"
-import { PREFIX_GUIDE_DELAY_MS } from "../../src/tui/lib/prefix-hud"
 import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
 import { act, renderComponent, settle } from "./harness"
 
@@ -47,6 +46,16 @@ function tempHome(mode?: "local" | "guide"): string {
   return home
 }
 
+async function waitForFrameText(frame: () => Promise<string>, text: string): Promise<string> {
+  const deadline = Date.now() + 1_000
+  let current = await frame()
+  while (!current.includes(text) && Date.now() < deadline) {
+    await settle(25)
+    current = await frame()
+  }
+  return current
+}
+
 test("the default prefix tap shows local badges and the complete command guide together", async () => {
   process.env.KOBE_HOME_DIR = tempHome()
   const { mockInput, frame } = await renderComponent(
@@ -57,8 +66,7 @@ test("the default prefix tap shows local badges and the complete command guide t
   )
 
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  await settle(PREFIX_GUIDE_DELAY_MS + 40)
-  const local = await frame()
+  const local = await waitForFrameText(frame, "more Rove commands")
   expect(local).toContain("⌃ A 1")
   expect(local).toContain("⌃ A 2")
   expect(local).toContain("more Rove commands")
@@ -81,8 +89,7 @@ test("a complete-guide row is a real clickable entry in local mode", async () =>
   )
 
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  await settle(PREFIX_GUIDE_DELAY_MS + 40)
-  const revealed = await frame()
+  const revealed = await waitForFrameText(frame, "Open active Task directory in editor")
   const at = locate(revealed, "Open active Task directory in editor")
   await mockMouse.click(at.x + 1, at.y)
   await settle()
@@ -101,8 +108,7 @@ test("the guide setting routes the same prefix tap to the global command guide",
   )
 
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  await settle(PREFIX_GUIDE_DELAY_MS + 40)
-  const guide = await frame()
+  const guide = await waitForFrameText(frame, "more Rove commands")
   expect(guide).toContain("more Rove commands")
   expect(guide).toContain("Open active Task directory in editor")
   expect(guide).not.toContain("⌃ A 1")

--- a/packages/kobe/test/render/which-key-help.test.tsx
+++ b/packages/kobe/test/render/which-key-help.test.tsx
@@ -2,15 +2,28 @@
 /** Real-render coverage for the prefix guide and its F1 reference view. */
 
 import { afterEach, describe, expect, it } from "bun:test"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { PrefixHud } from "../../src/tui-react/component/prefix-hud"
+import { ShortcutRevealProvider } from "../../src/tui-react/component/shortcut-reveal"
 import { useFocus } from "../../src/tui-react/context/focus"
 import { useDialog } from "../../src/tui-react/ui/dialog"
 import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keybindings"
 import type { HostPagesState } from "../../src/tui-react/workspace/host-pages"
 import { PREFIX_GUIDE_DELAY_MS, prefixHudPush, prefixHudSetArmed, resetPrefixHud } from "../../src/tui/lib/prefix-hud"
+import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
 import { act, renderComponent, settle } from "./harness"
 
 const NOOP = (): void => {}
+
+function useGuidePreference(): void {
+  const home = mkdtempSync(join(tmpdir(), "rove-which-key-"))
+  const configDir = join(home, ".config", "rove")
+  mkdirSync(configDir, { recursive: true })
+  writeFileSync(join(configDir, "state.json"), JSON.stringify({ [PREFIX_TAP_PRESENTATION_KEY]: "guide" }))
+  process.env.KOBE_HOME_DIR = home
+}
 
 const CLOSED_PAGES: HostPagesState = {
   nav: "terminal",
@@ -81,14 +94,21 @@ describe("F1 keyboard reference", () => {
 
 describe("which-key prefix guide", () => {
   it("stays compact for a fast sequence", async () => {
+    useGuidePreference()
     prefixHudSetArmed(true, [{ stroke: "f", action: "chat.fork.new" }], Date.now() + 10_000)
-    const { frame } = await renderComponent(<PrefixHud left={1} width={22} />, { width: 80, height: 24 })
+    const { frame } = await renderComponent(
+      <ShortcutRevealProvider>
+        <PrefixHud left={1} width={22} />
+      </ShortcutRevealProvider>,
+      { width: 80, height: 24, providers: { kv: true } },
+    )
     const text = await frame()
     expect(text).toContain("ctrl+a ⋯")
     expect(text).not.toContain("more Rove commands")
   })
 
   it("expands reachable commands after the learner delay", async () => {
+    useGuidePreference()
     prefixHudSetArmed(
       true,
       [
@@ -100,7 +120,12 @@ describe("which-key prefix guide", () => {
       ],
       Date.now() - PREFIX_GUIDE_DELAY_MS,
     )
-    const { frame } = await renderComponent(<PrefixHud left={1} width={22} />, { width: 120, height: 30 })
+    const { frame } = await renderComponent(
+      <ShortcutRevealProvider>
+        <PrefixHud left={1} width={22} />
+      </ShortcutRevealProvider>,
+      { width: 120, height: 30, providers: { kv: true } },
+    )
     const text = await frame()
     expect(text).toContain("ctrl+a — more Rove commands")
     expect(text).toContain("Views")

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -35,6 +35,10 @@ describe("hostRenderOptions", () => {
     expect(hostRenderOptions(onDestroy)).toMatchObject({ onDestroy })
     expect("onDestroy" in hostRenderOptions()).toBe(false)
   })
+
+  it("uses the ordinary Kitty keypress protocol", () => {
+    expect(hostRenderOptions()).toMatchObject({ useKittyKeyboard: {} })
+  })
 })
 
 describe("createHostImeOutput", () => {

--- a/packages/kobe/test/tui/prefix-tap-presentation.test.ts
+++ b/packages/kobe/test/tui/prefix-tap-presentation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_PREFIX_TAP_PRESENTATION,
+  PREFIX_TAP_PRESENTATION_KEY,
+  normalizePrefixTapPresentation,
+} from "../../src/tui/lib/prefix-tap-presentation"
+
+describe("prefix tap presentation", () => {
+  it("defaults missing, malformed, and unknown values to local entries", () => {
+    expect(DEFAULT_PREFIX_TAP_PRESENTATION).toBe("local")
+    expect(normalizePrefixTapPresentation(undefined)).toBe("local")
+    expect(normalizePrefixTapPresentation(null)).toBe("local")
+    expect(normalizePrefixTapPresentation(42)).toBe("local")
+    expect(normalizePrefixTapPresentation("old-value")).toBe("local")
+  })
+
+  it("accepts only the two persisted presentation values", () => {
+    expect(PREFIX_TAP_PRESENTATION_KEY).toBe("hints.keyboard.prefixTapPresentation")
+    expect(normalizePrefixTapPresentation("local")).toBe("local")
+    expect(normalizePrefixTapPresentation("guide")).toBe("guide")
+  })
+})

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -184,8 +184,12 @@ describe("feedbackRows", () => {
 
 describe("sectionRows / bodyRowCount", () => {
   it("keys has no rows once the YAML exists, and one create action while it doesn't", () => {
-    expect(sectionRows("keys", input())).toEqual([])
-    expect(sectionRows("keys", input({ keybindingsFileExists: false })).map((r) => r.kind)).toEqual(["keysCreate"])
+    expect(sectionRows("keys", input()).map((r) => r.kind)).toEqual(["prefixTapPresentation", "prefixTapPresentation"])
+    expect(sectionRows("keys", input({ keybindingsFileExists: false })).map((r) => r.kind)).toEqual([
+      "prefixTapPresentation",
+      "prefixTapPresentation",
+      "keysCreate",
+    ])
   })
 
   it("bodyRowCount is the registry length for every section", () => {
@@ -201,7 +205,7 @@ describe("sectionRows / bodyRowCount", () => {
     const inp = input({ themeNames: themes, engineList: [...ALL_VENDORS, "aider", "goose"], hasDaemon: true })
     expect(bodyRowCount("general", inp)).toBe(12 + LANG + 1 + 3 + 14) // themes + langs + transparent + accents + retained general rows
     expect(bodyRowCount("engines", inp)).toBe(ALL_VENDORS.length + 2 + 1) // 6
-    expect(bodyRowCount("keys", inp)).toBe(0)
+    expect(bodyRowCount("keys", inp)).toBe(2)
     expect(bodyRowCount("feedback", inp)).toBe(3)
     expect(bodyRowCount("dev", inp)).toBe(6)
     expect(bodyRowCount("dev", { ...inp, hasDaemon: false })).toBe(5)

--- a/packages/kobe/test/tui/shortcut-reveal.test.ts
+++ b/packages/kobe/test/tui/shortcut-reveal.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { findBinding, resetKeymapToDefaults } from "../../src/tui/context/keybindings"
+import { shortcutCaption } from "../../src/tui/lib/shortcut-reveal"
+
+const reachable = (direct: string[] = [], prefix: string[] = []) => ({
+  direct: new Set(direct),
+  prefix: new Set(prefix),
+  inputPassthrough: false,
+})
+
+describe("shortcutCaption", () => {
+  afterEach(() => resetKeymapToDefaults())
+
+  it("renders the current direct binding instead of a cosmetic hint", () => {
+    expect(
+      shortcutCaption({
+        bindingId: "task.new",
+        reachability: reachable(["task.new"]),
+        prefixKey: "ctrl+a",
+      }),
+    ).toBe("n")
+
+    const row = findBinding("task.new") as { keys: readonly string[] }
+    row.keys = ["ctrl+r"]
+    expect(
+      shortcutCaption({
+        bindingId: "task.new",
+        reachability: reachable(["task.new"]),
+        prefixKey: "ctrl+a",
+      }),
+    ).toBe("⌃ R")
+  })
+
+  it("composes the live prefix with the action's actual second stroke", () => {
+    expect(
+      shortcutCaption({
+        bindingId: "kanban.open",
+        reachability: reachable([], ["kanban.open"]),
+        prefixKey: "ctrl+b",
+      }),
+    ).toBe("⌃ B 1")
+  })
+
+  it("does not advertise unknown, unreachable, or unbound actions", () => {
+    expect(
+      shortcutCaption({ bindingId: "missing", reachability: reachable(["missing"]), prefixKey: "ctrl+a" }),
+    ).toBeNull()
+    expect(shortcutCaption({ bindingId: "task.new", reachability: reachable(), prefixKey: "ctrl+a" })).toBeNull()
+
+    const row = findBinding("task.new") as { keys: readonly string[] }
+    row.keys = []
+    expect(
+      shortcutCaption({
+        bindingId: "task.new",
+        reachability: reachable(["task.new"]),
+        prefixKey: "ctrl+a",
+      }),
+    ).toBeNull()
+  })
+})

--- a/packages/kobe/test/tui/sidebar-nav.test.ts
+++ b/packages/kobe/test/tui/sidebar-nav.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { SIDEBAR_NAV_ITEMS, cycleNavTarget, focusPaneForNav } from "../../src/tui/panes/sidebar/nav-core"
+
+describe("sidebar navigation metadata", () => {
+  it("maps every visible destination to its live keymap action", () => {
+    expect(SIDEBAR_NAV_ITEMS).toEqual([
+      { nav: "kanban", labelKey: "tasks.nav.kanban", bindingId: "kanban.open" },
+      { nav: "automations", labelKey: "tasks.nav.automations", bindingId: "automations.open" },
+    ])
+  })
+
+  it("cycles visible destinations and preserves pane focus ownership", () => {
+    expect(cycleNavTarget("kanban", 1)).toBe("automations")
+    expect(cycleNavTarget("automations", -1)).toBe("kanban")
+    expect(cycleNavTarget("terminal", 1)).toBeNull()
+
+    expect(focusPaneForNav("terminal")).toBe("sidebar")
+    expect(focusPaneForNav("kanban")).toBe("workspace")
+  })
+})


### PR DESCRIPTION
## Summary

- make a single prefix tap open the complete, full-width command guide from every screen
- keep on-screen shortcut badges alongside that guide by default; Settings can switch to **Complete guide only**
- remove the truncated sidebar fallback, keep command labels complete and responsive, and make every guide row clickable through #613's guarded action path
- derive badges and guide entries from the live keymap and binding stack, so rebound, unbound, shadowed, and modal-blocked actions stay truthful

This is layer 2 of 2 and depends on #613. It implements the accepted coexistence design: complete reference plus spatial hints, with tap-only prefix behavior and no new or moved chord.

## Stack

1. #613 — safe clickable prefix-action contract
2. **#614 — complete shortcut guide and on-screen badges**

## Verification

- `bun run lint`
- `bun --filter @sma1lboy/rove typecheck`
- `bun run changeset:check`
- focused prefix/settings tests — 31 passed
- complete OpenTUI render suite — 238 passed
- real fixed-viewport `/harness` check at 1280×800: complete three-column guide, full labels, local badges, and clickable Zen action verified

## Coverage notes

coverage-exemption: packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts — OpenTUI settings hook; the new preference read/write path is exercised by the real SettingsDialog render test, while the file's unrelated legacy closures predate this PR.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
