### PR TITLE
fix: wait for repo-init marker before paste-delivery first-message timeout

### DIFF
--- a/.changeset/paste-init-marker.md
+++ b/.changeset/paste-init-marker.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Wait for repo-init marker before paste-delivery engine timeout (issue #73)
+
+Paste-delivery engines (kimi) bracketed-paste the first message once the engine process appears, but the engine does not start until `.rove/init.sh` finishes. The 20s engine-startup budget was being consumed by `bun install`, so fresh worktrees silently dropped their first prompt. The spawner now waits for the init marker before starting that budget, and `add` surfaces a `NOT_DELIVERED` error when a prompt still fails to land (issue #72).

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -212,7 +212,10 @@ export async function deliverHostedPrompt(
     // the engine process is up. A paste that never lands is a failed start,
     // not a delivered prompt.
     if (launch.firstMessage) {
-      const delivered = await pastePromptWhenEngineUp(rpc, launch.key, target.engineBin, launch.firstMessage)
+      const delivered = await pastePromptWhenEngineUp(rpc, launch.key, target.engineBin, launch.firstMessage, {
+        initMarkerPath: launch.initMarkerPath,
+        initTimeoutMs: launch.initTimeoutMs,
+      })
       return {
         session: launch.key,
         pane: launch.key,

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -45,7 +45,10 @@ export async function ensureTaskSessionAdapter(link: DaemonRpcClient, taskId: st
     // so a missed paste leaves an idle prompt, not a failed session.
     if (launch.firstMessage) {
       const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor, effort: task.modelEffort })[0]
-      await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage).catch(() => false)
+      await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage, {
+        initMarkerPath: launch.initMarkerPath,
+        initTimeoutMs: launch.initTimeoutMs,
+      }).catch(() => false)
     }
   } finally {
     host.close()
@@ -82,7 +85,10 @@ export async function startTaskSessionWithPromptAdapter(
     // lands means the prompt was not delivered — report false.
     if (launch.firstMessage) {
       const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor, effort: task.modelEffort })[0]
-      return await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage)
+      return await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage, {
+        initMarkerPath: launch.initMarkerPath,
+        initTimeoutMs: launch.initTimeoutMs,
+      })
     }
     return true
   } finally {

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import { basename } from "node:path"
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { ensurePtyHostReachable } from "@sma1lboy/kobe-daemon/client/pty-process"
@@ -9,7 +10,7 @@ import { readPersistedTerminalDefaultColors } from "../tui/lib/terminal-colors.t
 import { BUILTIN_VENDORS } from "../types/vendor.ts"
 import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
 import { engineEntry } from "./registry.ts"
-import type { EngineSessionLaunch } from "./session-launch.ts"
+import { type EngineSessionLaunch, REPO_INIT_TIMEOUT_SECONDS } from "./session-launch.ts"
 
 export interface HostedSessionRpc {
   request<T = unknown>(name: string, payload?: unknown): Promise<T>
@@ -195,6 +196,12 @@ export interface PasteFirstMessageOptions {
   /** Test seam for the process-table read (see `pty-delivery.ts`'s gate). */
   readonly snapshot?: PsSnapshot
   readonly sleep?: (ms: number) => Promise<void>
+  /** When the launch includes a repo-init script, wait for this marker file
+   *  before budgeting the engine-startup wait. Prevents a short paste-delivery
+   *  window from expiring while dependencies are still installing. */
+  readonly initMarkerPath?: string
+  /** How long to wait for {@link initMarkerPath} to appear (ms). */
+  readonly initTimeoutMs?: number
 }
 
 /**
@@ -216,6 +223,22 @@ export async function pastePromptWhenEngineUp(
 ): Promise<boolean> {
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
   const snapshot = opts.snapshot ?? psSnapshot
+
+  // If the session was launched with a repo-init script, the engine child does
+  // not appear until init finishes. Wait for the init marker before starting
+  // the engine-startup budget so a slow `bun install` does not eat the whole
+  // paste-delivery window (issue #73).
+  if (opts.initMarkerPath) {
+    const initDeadline = Date.now() + (opts.initTimeoutMs ?? REPO_INIT_TIMEOUT_SECONDS * 1000)
+    while (Date.now() < initDeadline) {
+      const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
+      const session = sessions.find((s) => s.key === key)
+      if (!session?.alive) return false
+      if (existsSync(opts.initMarkerPath)) break
+      await sleep(opts.intervalMs ?? FIRST_MESSAGE_POLL_INTERVAL_MS)
+    }
+  }
+
   const deadline = Date.now() + (opts.timeoutMs ?? FIRST_MESSAGE_ENGINE_TIMEOUT_MS)
   while (Date.now() < deadline) {
     const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -137,6 +137,17 @@ export interface EngineSessionLaunch {
    * launch argv or there is none.
    */
   readonly firstMessage?: string
+  /**
+   * When the launch includes a repo-init script, this is the marker file the
+   * script creates on success. Paste-delivery spawners wait for it before
+   * starting the engine-startup timer (issue #73).
+   */
+  readonly initMarkerPath?: string
+  /**
+   * How long to wait for {@link initMarkerPath} to appear (ms). Mirrors the
+   * bounded init timeout woven into the launch script.
+   */
+  readonly initTimeoutMs?: number
 }
 
 /** Canonical PTY Host key for a task's interactive engine tab (first by default). */
@@ -184,9 +195,11 @@ export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): Engin
     input.firstMessageDelivery ?? engineEntry(coerceVendorId(input.task.vendor)).firstMessageDelivery ?? "argv"
   const pasteFirstMessage = delivery === "paste" ? launchInit.firstMessage?.text : undefined
   if (launchInit.firstMessage && !pasteFirstMessage) argv = [...argv, launchInit.firstMessage.text]
+  const markerPath = launchInit.initScript ? worktreeInitMarkerPath(input.worktreePath) : undefined
+  const initTimeoutMs = resolveRepoInitTimeoutSeconds(input.initTimeoutSeconds) * 1000
   const script = engineLaunchLine(quoteShellArgv(argv, { bareSafe: true }), {
     initScript: launchInit.initScript,
-    markerPath: launchInit.initScript ? worktreeInitMarkerPath(input.worktreePath) : undefined,
+    markerPath,
     timeoutSeconds: input.initTimeoutSeconds,
   })
   // Session identity as exported env, ahead of everything: the engine's hook
@@ -201,5 +214,6 @@ export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): Engin
     key: engineSessionKey(input.task.id, input.tabId),
     command: [input.shell, "-ilc", identity + script],
     ...(pasteFirstMessage ? { firstMessage: pasteFirstMessage } : {}),
+    ...(markerPath ? { initMarkerPath: markerPath, initTimeoutMs } : {}),
   }
 }

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -134,6 +134,22 @@ describe("add handler", () => {
     expect(result).toMatchObject({ started: true, engineReady: true, delivered: true, session: "t1::tab-1" })
   })
 
+  it("reports a created task whose prompt never landed (issue #72/#73)", async () => {
+    const task = taskFixture({ kind: "task", vendor: "kimi" })
+    const client = new FakeClient({
+      "task.create": () => ({ taskId: "t1", task }),
+      "task.get": () => ({ task }),
+    })
+    await expectApiError(
+      () =>
+        invokeVerb("add", ["--repo", "/repo/x", "--prompt", "do it"], {
+          client,
+          runtime: stubRuntime({ deliverPrompt: recordingDelivery({ delivered: false }).deliver }),
+        }),
+      "NOT_DELIVERED",
+    )
+  })
+
   it("keeps the spawn-task alias", async () => {
     const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
     const result = (await invokeVerb("spawn-task", ["--repo", "/repo/x"], {

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import { describe, expect, it, vi } from "vitest"
 import {
   type HostedSessionRpc,
@@ -128,5 +131,54 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
 
     expect(delivered).toBe(false)
     expect(request).not.toHaveBeenCalledWith("pty.write", expect.anything())
+  })
+
+  it("waits for the init marker before budgeting engine-startup time (issue #73)", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-hosted-init-marker-"))
+    const marker = path.join(tmp, "marker")
+    const request = vi.fn().mockResolvedValue({ sessions: [session("task-a::tab-1")] })
+    const rpc: HostedSessionRpc = { request }
+
+    let engineChecked = false
+    let markerChecked = false
+    const sleep = vi.fn().mockImplementation(async () => {
+      if (!markerChecked) {
+        fs.writeFileSync(marker, "")
+        markerChecked = true
+      }
+    })
+    const snapshot = vi.fn().mockImplementation(async () => {
+      engineChecked = true
+      return withEngine
+    })
+
+    const delivered = await pastePromptWhenEngineUp(rpc, "task-a::tab-1", "kimi", "fix it", {
+      initMarkerPath: marker,
+      initTimeoutMs: 50,
+      sleep,
+      snapshot,
+    })
+
+    expect(delivered).toBe(true)
+    expect(markerChecked).toBe(true)
+    expect(engineChecked).toBe(true)
+    expect(snapshot).toHaveBeenCalled()
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it("returns false if the session dies while waiting for the init marker", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-hosted-init-marker-"))
+    const marker = path.join(tmp, "marker")
+    const request = vi.fn().mockResolvedValue({ sessions: [{ ...session("task-a::tab-1"), alive: false }] })
+    const rpc: HostedSessionRpc = { request }
+
+    const delivered = await pastePromptWhenEngineUp(rpc, "task-a::tab-1", "kimi", "fix it", {
+      initMarkerPath: marker,
+      initTimeoutMs: 50,
+      sleep: noSleep,
+    })
+
+    expect(delivered).toBe(false)
+    fs.rmSync(tmp, { recursive: true, force: true })
   })
 })

--- a/packages/kobe/test/engine/session-launch.test.ts
+++ b/packages/kobe/test/engine/session-launch.test.ts
@@ -116,6 +116,8 @@ describe("hosted engine session launch", () => {
     expect(script).toContain("sleep 7;")
     expect(script).toContain("worktree-init")
     expect(script.indexOf("sh .rove/init.sh")).toBeLessThan(script.indexOf("claude 'read the repo docs'"))
+    expect(launch.initMarkerPath).toContain("worktree-init")
+    expect(launch.initTimeoutMs).toBe(7_000)
   })
 
   test("writes the init marker in the form the shell reads, not the OS's", () => {


### PR DESCRIPTION
Fixes #73 (root cause) and #72 (symptom).

Paste-delivery engines (kimi) receive their first prompt via bracketed paste once the engine process appears. The launch script runs `.rove/init.sh` before the engine, so a fresh worktree's dependency install consumed the whole 20s engine-startup budget and the prompt was silently dropped.

- `EngineSessionLaunch` now carries `initMarkerPath` + `initTimeoutMs` when a repo-init script is woven into the launch.
- `pastePromptWhenEngineUp` waits for that marker before starting the engine-startup timer, so the 20s budget is spent on engine startup, not dependency install.
- Added regression tests for the marker wait, the launch fields, and the `add` NOT_DELIVERED surface (issue #72).
- Wired the same marker wait through the daemon's `ensureTaskSession` / `startTaskSessionWithPrompt` adapters.

## What was actually happening

The `add` handler already throws `NOT_DELIVERED` when `delivered` is `false`, and the new regression test pins that. The observed silent success means `delivered` was returning `true` — the bytes were written — but they were written too early.

Kimi's process title rewrites to `kimi-co` the moment it execs (`processNames: ["kimi-co"]` in the registry), so `engineProcessIn` matches it before the TUI has entered raw mode and before the composer is ready to read input. `FIRST_MESSAGE_SETTLE_MS = 1500ms` is the only buffer, and after a cold `bun install` that buffer is too short. The paste lands in an engine process that exists but is not yet listening, so `read-output` stays at `source: "terminal"` and the task appears healthy but idle.

Waiting for the init marker aligns the paste with the engine having actually finished bootstrapping, so the prompt reaches the composer instead of being swallowed during startup.

## Verification

The strongest evidence for this issue is the engine's own transcript:

```bash
# repo that ships .rove/init.sh which installs dependencies
rove api add --repo <repo> --command kimi --prompt "say hello and write it to /tmp/hello.txt"
# wait for the session to settle
rove api read-output --task-id <id>
```

- **Before fix:** `source: "terminal"` — engine is alive but sitting at the idle "Tip: /sessions..." screen, never asked anything.
- **After fix:** `source: "history"` — the engine actually has a transcript of the turn starting.

## Local gates

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅
- `bun test test/render` ✅
