### PR TITLE
fix: new-conversation dialog tab/ctrl+f toggles close the dialog

### DIFF
--- a/.changeset/new-chat-dialog-tab-toggle.md
+++ b/.changeset/new-chat-dialog-tab-toggle.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix new-conversation dialog tab toggle closing the dialog
+
+`tab` and `ctrl+f` inside the New conversation dialog (ctrl+e) now toggle
+destination and context without dismissing the card. OpenTUI keypress events are
+not React events, so state updates scheduled from the keymap listener were
+batched and committed after the renderer had already painted, dropping the
+updated dialog subtree. The dispatcher now wraps matched commands with
+`flushSync` so React commits the new state before OpenTUI paints.

--- a/packages/kobe/src/tui-react/lib/keymap.ts
+++ b/packages/kobe/src/tui-react/lib/keymap.ts
@@ -24,7 +24,7 @@
  */
 
 import type { KeyEvent, KeyHandler } from "@opentui/core"
-import { useRenderer } from "@opentui/react"
+import { flushSync, useRenderer } from "@opentui/react"
 import { createContext, useContext, useEffect, useRef, useSyncExternalStore } from "react"
 import {
   type Binding,
@@ -87,7 +87,15 @@ function ensureInstalled(renderer: ReturnType<typeof useRenderer>): void {
   installedRenderer = renderer
   installed = renderer.keyInput
   listener = (evt: KeyEvent) => {
-    dispatchKeyEvent(stack, evt)
+    dispatchKeyEvent(stack, evt, Date.now(), {
+      // OpenTUI's renderer renders synchronously on input. React state updates
+      // scheduled from a non-React event listener (the keyInput emitter) are
+      // batched and would otherwise flush *after* that render pass, which can
+      // drop the just-updated subtree (e.g. a dialog body toggled by tab).
+      // Flush synchronously inside the matched cmd so the new state is
+      // committed before the renderer paints.
+      flushSync,
+    })
   }
   installed.on("keypress", listener)
 }

--- a/packages/kobe/src/tui/lib/keymap-dispatch.ts
+++ b/packages/kobe/src/tui/lib/keymap-dispatch.ts
@@ -362,6 +362,7 @@ function dispatchMode(
   evt: KeyEvent,
   candidates: string[],
   prefix: boolean,
+  runCmd: (cmd: () => void) => void,
 ): Binding | null {
   for (let i = snapshot.length - 1; i >= 0; i--) {
     const reg = snapshot[i]
@@ -380,7 +381,7 @@ function dispatchMode(
     }
     if (hit) {
       if (!cfg.modal && isDev()) warnShadowedMatch(snapshot, i, candidates, prefix)
-      hit.cmd(evt, hit.slot)
+      runCmd(() => hit!.cmd(evt, hit!.slot))
       return hit
     }
     if (cfg.modal) return null
@@ -417,10 +418,12 @@ export function dispatchKeyEvent(
     shift?: boolean
   },
   now = Date.now(),
+  opts?: { flushSync?: (fn: () => void) => void },
 ): boolean {
   if (evt.defaultPrevented || dispatching) return false
   const snapshot = bindingStack.slice()
   const candidates = matchKey(evt as KeyEvent)
+  const runCmd = opts?.flushSync ?? ((fn) => fn())
   dispatching = true
   try {
     // A sequence cannot cross the PTY boundary after it is armed: the next
@@ -445,7 +448,7 @@ export function dispatchKeyEvent(
         // A miss is consumed so it cannot type into an input or Terminal pane
         // after the user deliberately started a prefix sequence.
         resetPrefixState()
-        const hit = dispatchMode(snapshot, evt as KeyEvent, candidates, true)
+        const hit = dispatchMode(snapshot, evt as KeyEvent, candidates, true, runCmd)
         prefixHudPush({
           prefixKey: armedPrefixKey,
           stroke: candidates[0] ?? "",
@@ -470,7 +473,7 @@ export function dispatchKeyEvent(
       }
     }
 
-    const direct = dispatchMode(snapshot, evt as KeyEvent, candidates, false)
+    const direct = dispatchMode(snapshot, evt as KeyEvent, candidates, false, runCmd)
     if (direct) {
       // Direct chords land in the HUD too — but only REAL modifier chords
       // (ctrl+t, alt+…): plain pane letters (sidebar j/k) would stream

--- a/packages/kobe/test/render/new-chat-dialog.test.tsx
+++ b/packages/kobe/test/render/new-chat-dialog.test.tsx
@@ -8,7 +8,9 @@
  */
 
 import { describe, expect, test } from "bun:test"
-import { type NewChatChoice, NewChatDialogView } from "../../src/tui-react/component/new-chat-dialog"
+import { type NewChatChoice, NewChatDialog, NewChatDialogView } from "../../src/tui-react/component/new-chat-dialog"
+import { useBindings } from "../../src/tui-react/lib/keymap"
+import { type DialogContext, useDialog } from "../../src/tui-react/ui/dialog"
 import { type RenderHandle, act, renderComponent } from "./harness"
 
 function mount(
@@ -28,6 +30,14 @@ function mount(
   ) as Promise<RenderHandle> & { choices: NewChatChoice[] }
   p.choices = choices
   return p
+}
+
+function SiblingBindings(props: { onTab: () => void }) {
+  useBindings(() => ({
+    enabled: true,
+    bindings: [{ key: "tab", cmd: props.onTab }],
+  }))
+  return null
 }
 
 describe("NewChatDialogView", () => {
@@ -77,6 +87,41 @@ describe("NewChatDialogView", () => {
     act(() => mockInput.pressEnter())
     await frame()
     expect(p.choices).toEqual([{ pick: "claude", destination: "fork", context: "fresh" }])
+  })
+
+  test("dialog tab wins over a sibling binding mounted before the overlay", async () => {
+    const dialogRef: { current: DialogContext | null } = { current: null }
+    let siblingTabFired = false
+    function Host() {
+      const dialog = useDialog()
+      dialogRef.current = dialog
+      return (
+        <>
+          <SiblingBindings
+            onTab={() => {
+              siblingTabFired = true
+            }}
+          />
+          <text>workspace</text>
+        </>
+      )
+    }
+    const { frame, mockInput } = await renderComponent(<Host />, { providers: { dialog: true } })
+    expect(await frame()).toContain("workspace")
+    let choice: NewChatChoice | undefined
+    act(() => {
+      void NewChatDialog.show(dialogRef.current!, ["claude", "codex"], "claude", {
+        allowShell: true,
+      }).then((c) => {
+        choice = c
+      })
+    })
+    await frame()
+    expect(await frame()).toContain("new tab in this worktree")
+    act(() => mockInput.pressTab())
+    await frame()
+    expect(siblingTabFired).toBe(false)
+    expect(await frame()).toContain("fork a child task")
   })
 
   test("preset props open the dialog pre-flipped (prefix entries)", async () => {


### PR DESCRIPTION
## Problem
In the New conversation dialog (ctrl+e), pressing `tab` or `ctrl+f` to toggle destination/context caused the dialog to disappear instead of updating in place.

## Root cause
OpenTUI keypress events are emitted outside of React's event system. State updates scheduled from the keymap listener were batched and committed *after* OpenTUI's synchronous render pass, so the updated dialog subtree was dropped.

## Fix
- `dispatchKeyEvent` in `src/tui/lib/keymap-dispatch.ts` now accepts an optional `flushSync` wrapper.
- `src/tui-react/lib/keymap.ts` passes OpenTUI's `flushSync` into the dispatcher, so binding commands commit React state before the renderer paints.

## Verification
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ (69 files, 584 tests)
- `bun test test/render` ✅ (239 tests)

Added a regression test in `test/render/new-chat-dialog.test.tsx` confirming the dialog's `tab` binding wins over a sibling binding mounted before the overlay.

## Screenshots
Before/after atlas frames are captured in `.scratch/ui-review/tab-dialog/`.

## Notes
PR is left open for owner review.