### PR TITLE
fix(ui): align GitHub Issues docs with CLI-only entry point and improve empty-state hints

### DIFF
--- a/.changeset/issues-rail-empty-state.md
+++ b/.changeset/issues-rail-empty-state.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Align GitHub Issues docs with the TUI and improve the page's empty state
+
+The GitHub Issues page is wired behind `ctrl+a 3` but intentionally has no
+sidebar rail row until it earns one through a design pass. The user-facing
+docs previously advertised `ctrl+a 3` as a formal shortcut; they now describe
+`rove api workitem-*` as the only supported entry point. When the current repo
+has no GitHub remote (or `gh` is missing / not authenticated), the page now
+shows an actionable hint and a `q` / `esc` close reminder instead of a bare
+error line.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -53,8 +53,12 @@ shows only actions that can run right now.
 | `ctrl+a` `o` | Open the Task directory in your editor |
 | `ctrl+a` `m` | Reorder sidebar rows (scope-aware: tab / task / project) |
 | `ctrl+a` `w` | Close the active split |
-| `ctrl+a` `1` / `2` / `3` | Kanban / Automations / GitHub Issues |
+| `ctrl+a` `1` / `2` | Kanban / Automations |
 | `ctrl+a` `z` | Toggle zen mode |
+
+The GitHub Issues view is currently a CLI-only preview; use `rove api
+workitem-*` to browse and start work from issues. `ctrl+a 3` is still wired
+but is not a documented shortcut until the page earns a sidebar rail row.
 | `ctrl+a` `,` | Open Settings |
 | `ctrl+a` `p` / `P` | Create a PR from the active task |
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -378,17 +378,20 @@ the daemon alive so schedules fire with no TUI attached.
 Walked through end to end, with the page pictured and the cron and precheck
 rules spelled out: [Routines](ROUTINES.md).
 
-### GitHub Issues (`ctrl+a` `3`)
+### GitHub Issues (CLI-only)
 
 A read-only view of the repo's GitHub issues, fetched through the `gh` CLI.
-If `gh` works in your terminal, this page works too; otherwise the page tells
-you exactly what's missing. `a` filters to issues assigned to you, `tab`
-switches repos, `r` refreshes past the cache.
+Today the only supported entry point is `rove api workitem-*`; use it to
+browse issues and start a task from one. The underlying page is wired and
+`ctrl+a 3` still opens it, but it is not yet documented as a TUI shortcut
+because it has not earned a sidebar rail row.
 
-`enter` starts a Rove task from the selected issue: the issue body arrives as
-the first prompt (fenced, and explicitly marked as an untrusted report), and
-the task keeps a `linkedWorkItem` pointer back to the issue. Nothing is
-imported into the local issue store and nothing is written back to GitHub.
+When the page opens, `a` filters to issues assigned to you, `tab` switches
+repos, and `r` refreshes past the cache. `enter` starts a Rove task from the
+selected issue: the issue body arrives as the first prompt (fenced, and
+explicitly marked as an untrusted report), and the task keeps a
+`linkedWorkItem` pointer back to the issue. Nothing is imported into the local
+issue store and nothing is written back to GitHub.
 
 ## Updates and version warnings
 

--- a/packages/kobe/src/tui-react/component/work-items-page.tsx
+++ b/packages/kobe/src/tui-react/component/work-items-page.tsx
@@ -33,6 +33,21 @@ function reposOf(orch: RemoteOrchestrator | null): string[] {
   return seen
 }
 
+function errorHint(error: string, t: ReturnType<typeof useT>): string {
+  const colon = error.indexOf(": ")
+  const kind = colon >= 0 ? error.slice(0, colon) : "failed"
+  switch (kind) {
+    case "no-remote":
+      return t("workItems.errorHint.noRemote")
+    case "gh-missing":
+      return t("workItems.errorHint.ghMissing")
+    case "auth":
+      return t("workItems.errorHint.auth")
+    default:
+      return t("workItems.errorHint.fallback", { message: error })
+  }
+}
+
 function relativeAge(iso: string, now: number): string {
   const at = Date.parse(iso)
   if (!Number.isFinite(at)) return ""
@@ -160,6 +175,9 @@ export function WorkItemsPage(props: {
       {error ? (
         <box flexDirection="column" marginTop={1}>
           <text fg={theme.error}>{error}</text>
+          <box marginTop={1}>
+            <text fg={theme.textMuted}>{errorHint(error, t)}</text>
+          </box>
         </box>
       ) : items === null ? (
         <text fg={theme.textMuted}>{t("common.loading")}</text>

--- a/packages/kobe/src/tui/i18n/messages/workItems.ts
+++ b/packages/kobe/src/tui/i18n/messages/workItems.ts
@@ -10,6 +10,12 @@ export const en = {
   assignedFilter: "assigned to me",
   starting: "Starting work on #{number}…",
   startedNoEngine: "Created {title}, but its engine did not start.",
+  errorHint: {
+    noRemote: "Add a GitHub remote (`git remote add origin <url>`) and try again, or press q / esc to close.",
+    ghMissing: "Install the `gh` CLI and authenticate, or press q / esc to close.",
+    auth: "Run `gh auth login`, or press q / esc to close.",
+    fallback: "{message} · press q / esc to close",
+  },
 }
 
 export const zh: typeof en = {
@@ -19,4 +25,10 @@ export const zh: typeof en = {
   assignedFilter: "分配给我的",
   starting: "正在开始处理 #{number}…",
   startedNoEngine: "已创建 {title}，但引擎没有启动。",
+  errorHint: {
+    noRemote: "添加 GitHub remote（`git remote add origin <url>`）后重试，或按 q / esc 关闭。",
+    ghMissing: "安装 `gh` CLI 并登录，或按 q / esc 关闭。",
+    auth: "执行 `gh auth login`，或按 q / esc 关闭。",
+    fallback: "{message} · 按 q / esc 关闭",
+  },
 }


### PR DESCRIPTION
This PR addresses issue #70.

Changes:
- Docs: remove the documented `ctrl+a 3` shortcut from `docs/KEYBINDINGS.md` and `docs/TUI.md`. The GitHub Issues page remains reachable via `rove api workitem-*` / `kobe api workitem-*` and the keybinding itself is still wired, but it is no longer advertised as a supported entry point until the page earns a sidebar rail row.
- Empty state: improve the "no GitHub remote" message in the work-items page with actionable guidance and a footer exit hint.
- No rail row is added; that decision stays with the owner/design pass per the recorded note in `nav-core.ts`.

Verification:
- `bun --filter @sma1lboy/rove typecheck` ✅
- `bun --filter @sma1lboy/rove lint` ✅
- `bun --filter @sma1lboy/rove check-i18n` ✅
- `bun run test && bun test test/render` ✅ (238 passed)

Note: I was unable to capture the required atlas harness before/after screenshots because the PTY sidecar fails to spawn on this machine (`node-pty` throws `posix_spawnp failed` for `/bin/sh`). The `.scratch/ui-review/#70/` directories are empty pending either a fix of the local PTY setup or the owner capturing the frames on another machine.
