### PR TITLE
fix: explain worktree concept on zero-tasks welcome pane (#68)

### DIFF
--- a/.changeset/free-signs-know.md
+++ b/.changeset/free-signs-know.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Explain the worktree concept on the zero-tasks welcome pane so first-time users understand why each Rove task gets its own directory and branch. Onboarding wizard pages and keybindings are unchanged; review/land concepts are left out per #66.

--- a/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
@@ -93,6 +93,11 @@ export function WelcomePane(props: { probe?: () => Promise<WelcomeEnv> }): React
             </box>
           ))}
         </box>
+        <box paddingTop={1}>
+          <text fg={theme.textMuted} wrapMode="word">
+            {t("workspace.welcome.worktreeExplain")}
+          </text>
+        </box>
         {env !== null ? (
           <box flexDirection="column" paddingTop={1}>
             {env.engines.length > 0 ? (

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -17,6 +17,9 @@ export const en = {
   welcome: {
     title: "Welcome to Rove",
     tagline: "Run several AI coding sessions side by side — each task gets its own git worktree and branch.",
+    /** What a worktree is and why every task has one. */
+    worktreeExplain:
+      "Each task creates its own git worktree directory and branch, so multiple AI sessions can edit the same codebase in parallel without colliding.",
     /** {key} is the live new-task chord */
     stepNew: "creates your first task — pick a repo, a base branch, an engine",
     /** {key} is the live help chord */
@@ -67,6 +70,7 @@ export const zh: typeof en = {
   welcome: {
     title: "欢迎使用 Rove",
     tagline: "并行运行多个 AI 编码会话——每个任务都有自己的 git worktree 和分支。",
+    worktreeExplain: "每个任务都会创建独立的 git worktree 目录和分支，多个 AI 会话可以并行修改同一份代码库，互不干扰。",
     stepNew: "创建你的第一个任务——选仓库、基础分支和引擎",
     stepHelp: "查看当前焦点下的全部快捷键",
     stepPrefix: "打开命令菜单",

--- a/packages/kobe/test/render/welcome-pane.test.tsx
+++ b/packages/kobe/test/render/welcome-pane.test.tsx
@@ -30,6 +30,7 @@ describe("WelcomePane", () => {
     // Default keymap: task.new = n, help.open = F1 — resolved live, not hardcoded.
     expect(out).toContain("creates your first task")
     expect(out).toContain("shows every shortcut")
+    expect(out).toContain("Each task creates its own git worktree")
     expect(out).toContain("claude · codex")
     // Healthy environment → no doctor escalation.
     expect(out).not.toContain("rove doctor")


### PR DESCRIPTION
修复 #68：onboarding 教键盘不教产品。

## 改动前后用户看到什么

**之前（零任务欢迎面）**
- 标题：Welcome to Rove
- tagline：Run several AI coding sessions side by side — each task gets its own git worktree and branch.
- 三行实时键位
- 环境自检：引擎 / git / `rove doctor`

**之后（零任务欢迎面）**
- 同上，但在三行键位和环境自检之间新增一句：
  > Each task creates its own git worktree directory and branch, so multiple AI sessions can edit the same codebase in parallel without colliding.

中文界面同步显示：
> 每个任务都会创建独立的 git worktree 目录和分支，多个 AI 会话可以并行修改同一份代码库，互不干扰。

## 设计选择
- 没有往 onboarding 向导里加新页，保持了原有的克制流程。
- 把说明放在欢迎面，紧接在三个可教键位之后、环境自检之前——这里已经在回答“你的环境是什么状态”，自然衔接“每个任务为什么有自己的目录”。
- 只讲 worktree，不讲 review/land，避免触及 #66 未定的产品决策。

## 验证
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅
- `bun test test/render` ✅
- `bun run check-i18n`（packages/kobe）✅
- 同步更新了中英文文案；render 测试已断言新文案出现。
