### PR TITLE
fix: formatBytes rounds a just-under-100 size up to "100.0" instead of "100"

### DIFF
--- a/.changeset/format-bytes-round-up-to-100.md
+++ b/.changeset/format-bytes-round-up-to-100.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/kobe": patch
+---
+
+Fix byte sizes just under 100 rendering as "100.0 KB" instead of "100 KB". `formatBytes` chose integer-vs-decimal precision from the raw quotient, but a value in the [99.95, 100) range prints as "100.0" once `toFixed(1)` rounds it up — a three-digit magnitude carrying a decimal, the exact shape the "drop the decimal at 100" branch exists to prevent. Precision is now decided from the string that actually renders, so the file-preview pane and `kobe doctor` show "100 KB"/"100 MB" at that boundary while still rounding the raw value once (no double rounding at unit edges).

--- a/.changeset/format-bytes-round-up-to-100.md
+++ b/.changeset/format-bytes-round-up-to-100.md
@@ -1,5 +1,5 @@
 ---
-"@sma1lboy/kobe": patch
+"@sma1lboy/rove": patch
 ---
 
 Fix byte sizes just under 100 rendering as "100.0 KB" instead of "100 KB". `formatBytes` chose integer-vs-decimal precision from the raw quotient, but a value in the [99.95, 100) range prints as "100.0" once `toFixed(1)` rounds it up — a three-digit magnitude carrying a decimal, the exact shape the "drop the decimal at 100" branch exists to prevent. Precision is now decided from the string that actually renders, so the file-preview pane and `kobe doctor` show "100 KB"/"100 MB" at that boundary while still rounding the raw value once (no double rounding at unit edges).

--- a/packages/kobe/src/lib/format-bytes.ts
+++ b/packages/kobe/src/lib/format-bytes.ts
@@ -18,5 +18,11 @@ export function formatBytes(n: number): string {
     v /= 1024
     i++
   }
-  return `${v >= 100 ? Math.round(v) : v.toFixed(1)} ${units[i]}`
+  // Decide precision from the value we'd actually print, not the raw quotient:
+  // a v in [99.95, 100) renders as "100.0" under toFixed(1), which is the very
+  // three-digit-with-a-decimal the >= 100 integer branch exists to avoid. Branch
+  // on the rounded string's magnitude, but keep Math.round(v) for the integer so
+  // we round the raw value once (no double rounding of e.g. 1023.499 -> 1024).
+  const oneDecimal = v.toFixed(1)
+  return `${Number(oneDecimal) >= 100 ? Math.round(v) : oneDecimal} ${units[i]}`
 }

--- a/packages/kobe/test/lib/format-bytes.test.ts
+++ b/packages/kobe/test/lib/format-bytes.test.ts
@@ -14,6 +14,16 @@ describe("formatBytes", () => {
     expect(formatBytes(128 * 1024)).toBe("128 KB")
   })
 
+  test("a quotient that rounds up to 100 renders as an integer, not 100.0", () => {
+    // 99.9502 KB: below 100 raw, but toFixed(1) rounds it to "100.0" — a
+    // three-digit magnitude with a decimal, exactly what the >= 100 branch kills.
+    expect(formatBytes(102349)).toBe("100 KB")
+    // Same edge one unit up (99.95 MB) must behave identically.
+    expect(formatBytes(Math.round(99.96 * 1024 * 1024))).toBe("100 MB")
+    // Just under the round-up point still keeps its decimal.
+    expect(formatBytes(102297)).toBe("99.9 KB")
+  })
+
   test("promotes at the unit boundary instead of rendering 1024", () => {
     // The bug this helper exists to kill: doctor's old copy compared the raw
     // value against the threshold before rounding and printed "1024.0 KB".


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in a pure formatting helper (`src/lib/format-bytes.ts`), the single byte formatter every "N KB / N MB" string in the package renders through.

## Problem

`formatBytes` decides integer-vs-decimal precision from the **raw quotient** `v`:

```ts
return `${v >= 100 ? Math.round(v) : v.toFixed(1)} ${units[i]}`
```

For a value whose quotient lands in `[99.95, 100)`, `v >= 100` is false, so it takes the `v.toFixed(1)` branch — but `toFixed(1)` **rounds up** to `"100.0"`. The result is a three-digit magnitude carrying a decimal, which is exactly the shape the `>= 100 → Math.round` branch exists to prevent. This is the same bug-class the module header says it was written to kill (`"1024.0 KB"` at the unit boundary); the 1024 boundary got a guard, the 100-decimal boundary did not.

Verified failing inputs before the fix:
- `formatBytes(102349)` → `"100.0 KB"` (99.9502 KB) — expected `"100 KB"`
- `formatBytes(104815657)` → `"100.0 MB"` — expected `"100 MB"`

Surfaces to the user in the file-preview pane (`src/tui-react/ops/preview.tsx`) and `kobe doctor` output (`src/cli/doctor-cmd.ts`).

## Fix

Decide the branch from the string that actually renders (`v.toFixed(1)`), while keeping `Math.round(v)` for the integer output so the raw value is rounded **once** — avoiding a double-rounding regression at unit edges (e.g. `1023.499` must stay `1023 KB`, not become `1024 KB`):

```ts
const oneDecimal = v.toFixed(1)
return `${Number(oneDecimal) >= 100 ? Math.round(v) : oneDecimal} ${units[i]}`
```

## Verification

- Added regression tests for the just-under-100 edge at KB and MB (`102349 → "100 KB"`, the MB equivalent → `"100 MB"`, and `102297 → "99.9 KB"` for the below-threshold case). All 4 `format-bytes` tests pass, including every pre-existing assertion (the `1023 KB` double-rounding guard stays green).
- `bun run lint` and `bun run typecheck` both green.

## Follow-ups

None. A separate candidate (sidebar jump-digit ladder including `9`/`0`, which don't encode on legacy terminals) was left out — it's terminal-dependent and looks like a deliberate best-effort, not a clean correctness bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwtm8FP6g4gmNEdjeRe7i3)_