### PR TITLE
remove: task.archived plugin event and archive diff field

### DIFF
--- a/.changeset/remove-task-archived-event.md
+++ b/.changeset/remove-task-archived-event.md
@@ -1,0 +1,21 @@
+---
+"@sma1lboy/rove": patch
+"@sma1lboy/rove-plugin-sdk": patch
+---
+
+Remove the `task.archived` plugin event and archive diff field
+
+The archive concept is being retired (issue #75). As the first slice, this
+change removes the public plugin contract surface:
+
+- `task.archived` is no longer emitted from the daemon's snapshot-diff reducer.
+- `archived` is removed from the watched task-diff fields, so `task.changed`
+  will no longer include `archived` in `detail.fields`.
+- The event is removed from `@sma1lboy/rove-plugin-sdk`'s `PLUGIN_EVENT_NAMES`
+  catalog.
+- Plugin-author docs (`PLUGIN-AUTHORING.md`, `PLUGIN-EVENTS.md`, and
+  `docs/design/plugin-events.md`) no longer list `task.archived`.
+
+**Breaking change for plugins:** any plugin subscribing to `task.archived` will
+stop receiving that event. Use `task.changed` / `task.deleted` / `worktree.created`
+if you need to observe task lifecycle or worktree transitions.

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -207,7 +207,6 @@ This table is the one-line index. **Per-event trigger semantics, exact
 | `task.created` / `task.deleted` | task appears/disappears in the index | task context |
 | `task.changed` | any watched task field changed (title/branch/status/pin/vendor/…), fired off the snapshot diff, so EVERY mutation path counts | `fields`, `from`, `to` |
 | `task.landed` | a task's branch merged back into its base repo | `strategy`, `landedOn`, `commit` |
-| `task.archived` | a task was archived, by ANY path: the archive RPC, `land --then-archive`, or a `git worktree remove` sweep (restores don't fire) | task context |
 | `task.pr-changed` | the task's PR status changed (open/merged/closed, checks) | `from`, `to` (TaskPRStatus) |
 | `worktree.created` | a task's worktree materialized: lazy ensure, adopt, or scratch-adopt | task context |
 | `issue.changed` | a daemon-tracker issue mutated (create/edit/status) | `repo`, `op` |

--- a/docs/PLUGIN-EVENTS.md
+++ b/docs/PLUGIN-EVENTS.md
@@ -56,7 +56,7 @@ noise), `updatedAt`/`createdAt` (ride every change), `quotaResume` (the
 
 | detail field | type | meaning |
 |---|---|---|
-| `fields` | `string[]` | which fields changed, from: `title`, `branch`, `worktreePath`, `status`, `archived`, `pinned`, `vendor`, `command`, `modelEffort`, `linkedWorkItem`, `scratch` |
+| `fields` | `string[]` | which fields changed, from: `title`, `branch`, `worktreePath`, `status`, `pinned`, `vendor`, `command`, `modelEffort`, `linkedWorkItem`, `scratch` |
 | `from` | object | previous value per changed field (omitted when it was unset) |
 | `to` | object | new value per changed field (omitted when now unset) |
 
@@ -66,12 +66,6 @@ noise), `updatedAt`/`createdAt` (ride every change), `quotaResume` (the
               "from": { "title": "scratch", "pinned": false },
               "to":   { "title": "fix flaky test", "pinned": true } } }
 ```
-
-### `task.archived`
-
-`archived` flipped false→true, by any path. Restores (true→false) do NOT
-fire this; they show up as a `task.changed` with `archived` in `fields`.
-No extra detail; the task context is the payload.
 
 ### `task.landed`
 

--- a/docs/design/plugin-events.md
+++ b/docs/design/plugin-events.md
@@ -64,7 +64,6 @@ Support: **C** Claude Code · **X** Codex · **K** Kimi Code. `N` native hook,
 | `task.created` / `task.deleted` | task appears/disappears in the index | ✅ |
 | `task.changed` | any watched field changed (title/branch/status/pin/vendor/…) — snapshot-diff sourced, so EVERY mutation path fires (`detail.fields/from/to`) | ✅ (subsumes the deferred `task.status-changed`) |
 | `task.landed` | branch merged back into the base repo (`detail.strategy/landedOn/commit`) | ✅ |
-| `task.archived` | task archived by ANY path (RPC, `land --then-archive`, worktree-removal sweep); restores don't fire | ✅ (snapshot-diff sourced) |
 | `task.pr-changed` | PR status changed on the task (`detail.from/to`) | ✅ |
 | `worktree.created` | worktree materialized for a task (lazy ensure, adopt, scratch-adopt — snapshot-diff sourced) | ✅ |
 | `issue.changed` | daemon-tracker issue mutated (`detail.repo/op`) | ✅ |
@@ -190,12 +189,11 @@ builds: notify, log, mirror state, auto-file, auto-bootstrap, dashboards.
   lifecycle kinds). Async observers only — a `will-` event precedes the
   action but cannot block it.
 - **Snapshot-diff sourcing (done).** `task.changed` / `task.pr-changed` /
-  `task.archived` / `worktree.created` derive from field-level diffs of
-  consecutive `task.snapshot` publishes (`plugins/task-diff.ts`), NOT from
-  RPC handlers — every mutation path (including worktree-removal sweeps and
-  orchestrator-internal archive) funnels through the store and therefore
-  fires. `task.landed` stays handler-emitted: its detail (strategy/commit)
-  never reaches the snapshot.
+  `worktree.created` derive from field-level diffs of consecutive
+  `task.snapshot` publishes (`plugins/task-diff.ts`), NOT from RPC handlers —
+  every mutation path funnels through the store and therefore fires.
+  `task.landed` stays handler-emitted: its detail (strategy/commit) never
+  reaches the snapshot.
 - **[[shutdown]] hooks (done).** Run at daemon stop, bounded (~3s grace,
   then SIGKILL) — a plugin can flush state without ever delaying shutdown.
 - **`session.exited` (done).** The pty-host is a separate process with no

--- a/packages/kobe-daemon/src/plugins/events.ts
+++ b/packages/kobe-daemon/src/plugins/events.ts
@@ -5,7 +5,7 @@
  * edges. This reducer is fed every `bus.publish` and emits the transitions:
  *
  *   task.snapshot diff       → task.created / task.deleted / task.changed /
- *                              task.pr-changed / task.archived / worktree.created
+ *                              task.pr-changed / worktree.created
  *   engine-state transitions → agent.* (per task+tab, deduped)
  *
  * `worktree.created` is snapshot-derived (empty → non-empty worktreePath, or
@@ -160,7 +160,6 @@ export class PluginEventReducer {
           at,
         })
       }
-      if (diff.archivedNow) out.push({ event: "task.archived", taskId: id, task: ctx, at })
       if (diff.worktreeCreated) out.push({ event: "worktree.created", taskId: id, task: ctx, at })
     }
     for (const [id, task] of prev) {

--- a/packages/kobe-daemon/src/plugins/task-diff.ts
+++ b/packages/kobe-daemon/src/plugins/task-diff.ts
@@ -11,7 +11,6 @@
  * Emitted per changed task:
  *   - `task.changed`     — any watched field changed (`detail.fields/from/to`)
  *   - `task.pr-changed`  — prStatus changed (its own event, not in `fields`)
- *   - `task.archived`    — archived flipped false→true (restores don't fire)
  *   - `worktree.created` — a `task`-kind row gained a worktree path (lazy
  *     ensure, adopt, and scratch-adopt all land here; main/dir tasks reuse
  *     user-owned directories and never "materialize" one)
@@ -27,7 +26,6 @@ const WATCHED_FIELDS = [
   "branch",
   "worktreePath",
   "status",
-  "archived",
   "pinned",
   "vendor",
   "command",
@@ -42,7 +40,6 @@ export interface TaskFieldDiff {
   readonly fields: readonly WatchedTaskField[]
   readonly from: Record<string, unknown>
   readonly to: Record<string, unknown>
-  readonly archivedNow: boolean
   readonly prChanged: boolean
   readonly worktreeCreated: boolean
 }
@@ -88,7 +85,6 @@ export function diffTask(prev: SerializedTask, next: SerializedTask): TaskFieldD
     fields,
     from,
     to,
-    archivedNow: !prev.archived && next.archived,
     prChanged,
     worktreeCreated: next.kind === "task" && !prev.worktreePath && !!next.worktreePath,
   }

--- a/packages/kobe-plugin-sdk/src/contract.ts
+++ b/packages/kobe-plugin-sdk/src/contract.ts
@@ -14,7 +14,6 @@ export const PLUGIN_EVENT_NAMES = [
   "task.deleted",
   "task.changed",
   "task.landed",
-  "task.archived",
   "task.pr-changed",
   "worktree.created",
   "issue.changed",

--- a/packages/kobe/test/plugins/events-pipeline.test.ts
+++ b/packages/kobe/test/plugins/events-pipeline.test.ts
@@ -7,13 +7,9 @@
  * so feeding it directly is the same seam). Real git + real store on disk —
  * adopt shells `git worktree list`, so mocking would only test the mock.
  *
- * The two fixed paths:
- *  - `adoptWorktree` creates the task WITH its worktree → both
- *    `task.created` and `worktree.created` (previously: neither the
- *    `ensureWorktree` job nor any handler fired for adopt).
- *  - `setArchived(true)` — the exact orchestrator call the
- *    `worktree.archiveRemoved` sweep and `land --then-archive` make —
- *    → `task.archived` (previously only the archive RPC handler fired it).
+ * The fixed path: `adoptWorktree` creates the task WITH its worktree → both
+ * `task.created` and `worktree.created` (previously: neither the
+ * `ensureWorktree` job nor any handler fired for adopt).
  */
 
 import { spawnSync } from "node:child_process"
@@ -83,21 +79,5 @@ describe("dropped-path regressions through the real orchestrator", () => {
     const mine = events.filter((e) => e.taskId === task.id)
     expect(mine.map((e) => e.event)).toEqual(["task.created", "worktree.created"])
     expect(mine[1]?.task?.worktreePath).toBe(fs.realpathSync(ext))
-  })
-
-  test("setArchived — the sweep/land archive call — fires task.archived; restore does not", async () => {
-    const ext = path.join(tmpRoot, "ext-arch")
-    const r = spawnSync("git", ["worktree", "add", "-b", "arch", ext], { cwd: repo, encoding: "utf8" })
-    if (r.status !== 0) throw new Error(`git worktree add failed: ${r.stderr}`)
-    const task = await orch.adoptWorktree({ repo, worktreePath: ext, branch: "arch" })
-    events.length = 0
-
-    await orch.setArchived(task.id, true)
-    expect(names()).toContain("task.archived")
-
-    events.length = 0
-    await orch.setArchived(task.id, false)
-    expect(names()).not.toContain("task.archived")
-    expect(names()).toContain("task.changed")
   })
 })

--- a/packages/kobe/test/plugins/events.test.ts
+++ b/packages/kobe/test/plugins/events.test.ts
@@ -59,27 +59,29 @@ describe("PluginEventReducer", () => {
     ).toEqual([])
   })
 
-  it("emits task.changed with fields/from/to, task.archived on the flip, and task.pr-changed", () => {
+  it("emits task.changed with fields/from/to and task.pr-changed", () => {
     const reducer = new PluginEventReducer(() => 9)
     const feed = (tasks: Record<string, unknown>[]) =>
       reducer.reduce({ channel: "task.snapshot", payload: { tasks } } as never)
     feed([task("a")])
-    const changed = feed([task("a", { title: "renamed", archived: true })])
-    expect(changed.map((e) => e.event)).toEqual(["task.changed", "task.archived"])
+    const changed = feed([task("a", { title: "renamed", pinned: true })])
+    expect(changed.map((e) => e.event)).toEqual(["task.changed"])
     expect(changed[0]?.detail).toEqual({
-      fields: ["title", "archived"],
-      from: { title: "t-a", archived: false },
-      to: { title: "renamed", archived: true },
+      fields: ["title", "pinned"],
+      from: { title: "t-a", pinned: false },
+      to: { title: "renamed", pinned: true },
     })
-    // Unarchive is a restore: task.changed only, no task.archived.
-    const restored = feed([task("a", { title: "renamed" })])
-    expect(restored.map((e) => e.event)).toEqual(["task.changed"])
+    // `archived` is no longer a watched field; changes to it are ignored.
+    const archivedFlip = feed([task("a", { title: "renamed", pinned: true, archived: true })])
+    expect(archivedFlip.map((e) => e.event)).toEqual([])
     // PR status has its own event and is not a `fields` entry.
-    const pr = feed([task("a", { title: "renamed", prStatus: { state: "open" } })])
+    const pr = feed([task("a", { title: "renamed", pinned: true, archived: true, prStatus: { state: "open" } })])
     expect(pr.map((e) => e.event)).toEqual(["task.pr-changed"])
     expect(pr[0]?.detail).toEqual({ to: { state: "open" } })
     // Identical snapshot → silence.
-    expect(feed([task("a", { title: "renamed", prStatus: { state: "open" } })])).toEqual([])
+    expect(feed([task("a", { title: "renamed", pinned: true, archived: true, prStatus: { state: "open" } })])).toEqual(
+      [],
+    )
   })
 
   it("emits agent.* only on state transitions, keyed per task+tab", () => {

--- a/packages/kobe/test/plugins/task-diff.test.ts
+++ b/packages/kobe/test/plugins/task-diff.test.ts
@@ -33,11 +33,6 @@ describe("diffTask", () => {
     })
   })
 
-  it("flags archivedNow only on the false→true flip", () => {
-    expect(diffTask(task(), task({ archived: true }))?.archivedNow).toBe(true)
-    expect(diffTask(task({ archived: true }), task())?.archivedNow).toBe(false)
-  })
-
   it("flags prChanged via deep compare, outside `fields`", () => {
     const withPr = task({ prStatus: { state: "open" } as never })
     const diff = diffTask(task(), withPr)


### PR DESCRIPTION
Slice A of issue #75: remove the archive concept starting with the public plugin contract and event plumbing.

## What changed
- Removed `task.archived` from the daemon snapshot-diff reducer (`packages/kobe-daemon/src/plugins/events.ts`).
- Removed `archived` from `WATCHED_FIELDS` and deleted the `archivedNow` diff field (`packages/kobe-daemon/src/plugins/task-diff.ts`). `task.changed` will no longer list `archived` in `detail.fields`.
- Removed `task.archived` from `@sma1lboy/rove-plugin-sdk`'s `PLUGIN_EVENT_NAMES` catalog.
- Updated plugin-author docs: `PLUGIN-AUTHORING.md`, `PLUGIN-EVENTS.md`, and `docs/design/plugin-events.md`.
- Updated/removed the tests that asserted `task.archived` / `archivedNow` behavior.

## Breaking change
`task.archived` was a public plugin event. Any plugin with `[[events]] on = "task.archived"` will stop receiving that event. Use `task.changed`, `task.deleted`, or `worktree.created` to observe task/worktree lifecycle transitions instead.

## Verification
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅
- `bun test test/render` ✅ (239 pass, 0 fail)

## Scope notes
This slice intentionally does NOT touch the TUI, `types/task.ts`, CLI handlers, or land flags — those are slices B and C tracked in #75. The `archived` field still exists on `SerializedTask` and is still serialized; the diff reducer simply no longer watches it, so existing persisted tasks with `archived: true` are tolerated.
