### PR TITLE
fix: parse numstat renames with --numstat -z

### DIFF
--- a/.changeset/numstat-z-rename.md
+++ b/.changeset/numstat-z-rename.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix numstat rename parsing for paths containing literal braces
+
+Switch `git diff --numstat` callers to `--numstat -z` so renames are emitted
+as NUL-delimited old/new path pairs instead of brace-compacted `src/{old =>
+new}` syntax. The brace form is inherently ambiguous when a path itself
+contains `{` (e.g. `src/{a{b/f.txt`), which previously produced silently
+wrong filenames. All three file-tree numstat consumers (working diff, cached
+fallback, and branch-scope diff) now pass `-z`; the shared parser in
+`src/lib/git-parsers.ts` no longer tries to split brace-compacted fields.

--- a/packages/kobe/src/lib/git-parsers.ts
+++ b/packages/kobe/src/lib/git-parsers.ts
@@ -1,6 +1,6 @@
 /**
  * One rigorous, shared parser for `git status --porcelain` and
- * `git diff --numstat` output, with correct C-string unquoting.
+ * `git diff --numstat -z` output, with correct C-string unquoting.
  *
  * Why this module exists: the file-tree pane (`tui/panes/filetree/git.ts`)
  * and the sidebar's per-row change chip (`tui/panes/sidebar/worktree-changes.ts`)
@@ -25,11 +25,10 @@
  *   - Porcelain rename: `XY orig -> new`. Each side is quoted INDEPENDENTLY
  *     (only when it needs quoting); the ` -> ` separator is literal. Porcelain
  *     quotes a path that merely contains a space.
- *   - Numstat rename: `<a>\t<d>\t<field>`. When NEITHER side needs C-quoting,
- *     git brace-compacts the unchanged segments: `src/{old => new}.txt`. When
- *     EITHER side needs quoting, git drops the braces and emits each side
- *     quoted independently: `"a\tb" => "a\tc"`. Numstat does NOT quote on a
- *     bare space.
+ *   - Numstat rename (with `-z`): records are NUL-delimited, so git emits the
+ *     old and new paths as separate raw fields. There is no brace-compaction
+ *     and no ` => ` separator to parse, which avoids an inherent ambiguity
+ *     when a path itself contains a literal `{`.
  *   - C-quoting escapes `\a \b \t \n \v \f \r \" \\` and otherwise emits a
  *     three-digit OCTAL escape per BYTE (`\303\274` = the UTF-8 bytes of `ü`),
  *     so octal runs must be decoded as bytes, then UTF-8 decoded.
@@ -179,10 +178,9 @@ export function unquoteGitPath(field: string): string {
 }
 
 /**
- * Split a rename field (`orig<sep>new`) into its two unquoted sides,
- * respecting independent C-quoting on each side. `sep` is `" -> "` for
- * porcelain or `" => "` for numstat. Returns `null` when no separator is
- * present (i.e. not a rename).
+ * Split a porcelain rename field (`orig -> new`) into its two unquoted
+ * sides, respecting independent C-quoting on each side. Returns `null` when
+ * no separator is present (i.e. not a rename).
  */
 function splitRenameField(field: string, sep: string): { orig: string; neu: string } | null {
   if (field[0] === '"') {
@@ -196,57 +194,6 @@ function splitRenameField(field: string, sep: string): { orig: string; neu: stri
   const idx = field.indexOf(sep)
   if (idx < 0) return null
   return { orig: field.slice(0, idx), neu: unquoteGitPath(field.slice(idx + sep.length)) }
-}
-
-/**
- * Rejoin a brace-compacted rename side (`prefix` + the `{…}` segment + `suffix`).
- *
- * When a rename adds or drops a leading/trailing directory level, git empties
- * ONE brace side — `src/{sub => }/a.txt` (moved up out of `sub/`) or
- * `src/{ => sub}/a.txt` (moved down into `sub/`). Naive `prefix + seg + suffix`
- * then doubles the shared separator: `src/` + `""` + `/a.txt` = `src//a.txt`,
- * which no longer key-matches the porcelain row's `src/a.txt` — the exact join
- * this module exists to keep coherent. Collapse the seam: an empty segment
- * flanked by a `/`-terminated prefix and a `/`-led suffix drops one slash.
- */
-function joinBraceParts(prefix: string, seg: string, suffix: string): string {
-  if (seg.length === 0 && prefix.endsWith("/") && suffix.startsWith("/")) {
-    return prefix + suffix.slice(1)
-  }
-  return prefix + seg + suffix
-}
-
-/**
- * Resolve a `git diff --numstat` path field to its canonical (post-rename,
- * unquoted) path, plus the original path when it is a rename.
- *
- * Handles, in order:
- *   1. Brace-compacted rename `a/{old => new}/b` → new `a/new/b`, orig `a/old/b`.
- *      (Brace compaction only ever appears UNQUOTED — git abandons it the
- *      moment either side needs C-quoting.) An empty brace side (a directory
- *      level added/removed) collapses its doubled separator via {@link joinBraceParts}.
- *   2. Non-brace rename `orig => new` (each side independently C-quoted).
- *   3. Plain path (possibly C-quoted, no rename).
- */
-function resolveNumstatField(field: string): { path: string; origPath?: string } {
-  const open = field.indexOf("{")
-  if (open >= 0) {
-    const close = field.indexOf("}", open)
-    const sep = field.indexOf(" => ", open)
-    if (close > open && sep >= 0 && sep < close) {
-      const prefix = field.slice(0, open)
-      const oldSeg = field.slice(open + 1, sep)
-      const newSeg = field.slice(sep + " => ".length, close)
-      const suffix = field.slice(close + 1)
-      return {
-        path: joinBraceParts(prefix, newSeg, suffix),
-        origPath: joinBraceParts(prefix, oldSeg, suffix),
-      }
-    }
-  }
-  const split = splitRenameField(field, " => ")
-  if (split) return { path: split.neu, origPath: split.orig }
-  return { path: unquoteGitPath(field) }
 }
 
 /**
@@ -288,31 +235,54 @@ function parseCount(token: string): number | null {
 }
 
 /**
- * Parse the raw stdout of `git diff --numstat` into typed rows. Each line is
- * `<added>\t<deleted>\t<field>`; binary files use `-` for the counts (→
- * `null`). Renames (brace-compacted or `=>`) resolve to the canonical
- * post-rename, unquoted path so the counts key by the same path the
- * porcelain `R` row reports. Blank / malformed lines are skipped.
+ * Parse the raw stdout of `git diff --numstat -z` into typed rows. Records
+ * are NUL-delimited:
+ *   - non-rename: `<added>\t<deleted>\t<path>\0`
+ *   - rename:     `<added>\t<deleted>\t\0<old>\0<new>\0`
+ *
+ * Binary files use `-` for the counts (→ `null`). Paths are unquoted so the
+ * counts key by the same canonical path the porcelain `R` row reports. With
+ * `-z`, git emits raw paths (no C-quoting), but `unquoteGitPath` is kept as a
+ * harmless no-op for extra robustness. Blank / malformed fields are skipped.
  */
 export function parseNumstatRows(raw: string): NumstatRow[] {
   const rows: NumstatRow[] = []
-  for (const rawLine of raw.split("\n")) {
-    const line = rawLine.replace(/\r$/, "")
-    if (line.length === 0) continue
-    const tab1 = line.indexOf("\t")
-    if (tab1 < 0) continue
-    const tab2 = line.indexOf("\t", tab1 + 1)
-    if (tab2 < 0) continue
-    const field = line.slice(tab2 + 1)
-    if (field.length === 0) continue
-    const resolved = resolveNumstatField(field)
-    if (resolved.path.length === 0) continue
-    rows.push({
-      path: resolved.path,
-      ...(resolved.origPath !== undefined ? { origPath: resolved.origPath } : {}),
-      added: parseCount(line.slice(0, tab1)),
-      deleted: parseCount(line.slice(tab1 + 1, tab2)),
-    })
+  const fields = raw.split("\0")
+  // Real `-z` output ends with a trailing NUL, producing an empty final field.
+  if (fields.length > 0 && fields[fields.length - 1] === "") {
+    fields.pop()
+  }
+  let i = 0
+  while (i < fields.length) {
+    const header = fields[i] as string
+    const tab1 = header.indexOf("\t")
+    if (tab1 < 0) {
+      i++
+      continue
+    }
+    const tab2 = header.indexOf("\t", tab1 + 1)
+    if (tab2 < 0) {
+      i++
+      continue
+    }
+    const added = parseCount(header.slice(0, tab1))
+    const deleted = parseCount(header.slice(tab1 + 1, tab2))
+    const pathField = header.slice(tab2 + 1)
+    if (pathField.length > 0) {
+      // Non-rename: the path is the third field.
+      rows.push({ path: unquoteGitPath(pathField), added, deleted })
+      i++
+    } else {
+      // Rename: the next two fields are the old and new paths.
+      if (i + 2 >= fields.length) break
+      rows.push({
+        path: unquoteGitPath(fields[i + 2] as string),
+        origPath: unquoteGitPath(fields[i + 1] as string),
+        added,
+        deleted,
+      })
+      i += 3
+    }
   }
   return rows
 }

--- a/packages/kobe/src/tui/panes/filetree/git.ts
+++ b/packages/kobe/src/tui/panes/filetree/git.ts
@@ -62,7 +62,7 @@ export type StatusEntry = {
   children?: StatusEntry[]
 }
 
-/** A row from `git diff HEAD --numstat`. */
+/** A row from `git diff HEAD --numstat -z`. */
 export type NumstatEntry = {
   path: string
   /** `null` for binary files (git emits `-`). */
@@ -139,7 +139,7 @@ export async function statusFiles(worktreePath: string, signal?: AbortSignal): P
   // handles missing stats by rendering blanks.
   let stats: Map<string, { added: number | null; deleted: number | null }> = new Map()
   try {
-    const diffOut = await runGit(["diff", "--no-color", "--numstat", "HEAD"], worktreePath, signal)
+    const diffOut = await runGit(["diff", "--no-color", "--numstat", "-z", "HEAD"], worktreePath, signal)
     stats = new Map(parseNumstat(diffOut).map((n) => [n.path, { added: n.added, deleted: n.deleted }]))
   } catch {
     // No HEAD yet (initial commit / unborn branch): `git diff HEAD` exits
@@ -149,7 +149,7 @@ export async function statusFiles(worktreePath: string, signal?: AbortSignal): P
     // even that fails, leave stats empty — the rows already render from the
     // porcelain pass, just with "counts unavailable" (blank) cells.
     try {
-      const cachedOut = await runGit(["diff", "--no-color", "--numstat", "--cached"], worktreePath, signal)
+      const cachedOut = await runGit(["diff", "--no-color", "--numstat", "-z", "--cached"], worktreePath, signal)
       stats = new Map(parseNumstat(cachedOut).map((n) => [n.path, { added: n.added, deleted: n.deleted }]))
     } catch {
       stats = new Map()
@@ -281,7 +281,7 @@ export async function statusFilesBranch(
   const range = `${base}...HEAD`
   const [nameStatusOut, numstatOut] = await Promise.all([
     runGit(["diff", "--no-color", "--name-status", range], worktreePath, signal),
-    runGit(["diff", "--no-color", "--numstat", range], worktreePath, signal),
+    runGit(["diff", "--no-color", "--numstat", "-z", range], worktreePath, signal),
   ])
   const counts = new Map(parseNumstat(numstatOut).map((n) => [n.path, { added: n.added, deleted: n.deleted }]))
   const entries: StatusEntry[] = []
@@ -353,13 +353,13 @@ async function countAddedLines(worktreePath: string, relPath: string, signal?: A
 }
 
 /**
- * Pure parser for `git diff --numstat` output, kept as the pane's typed
+ * Pure parser for `git diff --numstat -z` output, kept as the pane's typed
  * façade ({@link NumstatEntry}) over the shared {@link parseNumstatRows}.
- * The shared parser owns the hard parts — C-string unquoting and rename
- * resolution (numstat's ` => ` + brace-compaction → the canonical
- * post-rename path) — so the counts key by the same unquoted path the
- * porcelain `R` row reports. We drop the shared row's `origPath` here to
- * preserve {@link NumstatEntry}'s `{ path, added, deleted }` shape.
+ * The shared parser owns the hard parts — NUL-delimited records, C-string
+ * unquoting, and rename path pairing — so the counts key by the same
+ * unquoted path the porcelain `R` row reports. We drop the shared row's
+ * `origPath` here to preserve {@link NumstatEntry}'s `{ path, added, deleted }
+ * shape.
  */
 export function parseNumstat(raw: string): NumstatEntry[] {
   return parseNumstatRows(raw).map((r) => ({ path: r.path, added: r.added, deleted: r.deleted }))

--- a/packages/kobe/test/lib/git-parsers.test.ts
+++ b/packages/kobe/test/lib/git-parsers.test.ts
@@ -3,18 +3,18 @@
  * (`src/lib/git-parsers.ts`).
  *
  * The hard cases — verified against real `git status --porcelain` /
- * `git diff --numstat` output — are:
+ * `git diff --numstat -z` output — are:
  *   - C-string unquoting: git wraps any path with a space (porcelain
  *     renames), a tab/newline/quote, or a non-ASCII byte in a double-quoted,
  *     C-escaped string, and emits non-ASCII as three-digit OCTAL bytes
  *     (`\303\274` = the UTF-8 bytes of `ü`).
  *   - rename resolution: porcelain uses ` -> ` with each side quoted
- *     independently; numstat uses ` => ` and brace-compacts unchanged
- *     segments (`src/{old => new}`) ONLY when neither side needs quoting,
- *     else falls back to independently-quoted `"a\tb" => "a\tc"`.
+ *     independently; numstat uses `-z` and emits the old and new paths as
+ *     separate NUL-delimited fields, avoiding brace-compaction ambiguity.
  *   - the join: porcelain quotes a spaced path (`"a b.txt"`) while numstat
- *     does not (`a b.txt`); unquoting BOTH yields one canonical path so a
- *     renamed/modified spaced file's numstat counts key onto its status row.
+ *     with `-z` emits the raw path (`a b.txt\0`); unquoting BOTH yields one
+ *     canonical path so a renamed/modified spaced file's numstat counts key
+ *     onto its status row.
  */
 
 import { describe, expect, test } from "vitest"
@@ -127,109 +127,112 @@ const numstat = (path: string, added: number | null, deleted: number | null, ori
 
 describe("parseNumstatRows", () => {
   test("parses a plain modified file", () => {
-    expect(parseNumstatRows("3\t2\tsrc/app.ts")).toEqual([numstat("src/app.ts", 3, 2)])
+    expect(parseNumstatRows("3\t2\tsrc/app.ts\0")).toEqual([numstat("src/app.ts", 3, 2)])
   })
 
   test("surfaces binary `-` counts as null", () => {
-    expect(parseNumstatRows("-\t-\tassets/logo.png")).toEqual([numstat("assets/logo.png", null, null)])
+    expect(parseNumstatRows("-\t-\tassets/logo.png\0")).toEqual([numstat("assets/logo.png", null, null)])
   })
 
-  test("skips blank and malformed lines", () => {
-    expect(parseNumstatRows("\n3\t1\ta.ts\nnotatabline\n")).toEqual([numstat("a.ts", 3, 1)])
+  test("parses multiple NUL-delimited records", () => {
+    expect(parseNumstatRows("3\t1\ta.ts\0" + "5\t0\tb.ts\0")).toEqual([numstat("a.ts", 3, 1), numstat("b.ts", 5, 0)])
   })
 
-  test("resolves a same-directory brace-compacted rename", () => {
-    expect(parseNumstatRows("0\t0\tsrc/{old.txt => new.txt}")).toEqual([numstat("src/new.txt", 0, 0, "src/old.txt")])
+  test("skips malformed fields", () => {
+    // A field with no tabs and a valid record after it.
+    expect(parseNumstatRows("notatabline\0" + "3\t1\ta.ts\0")).toEqual([numstat("a.ts", 3, 1)])
   })
 
-  test("resolves a cross-directory brace rename (leading segment)", () => {
-    expect(parseNumstatRows("0\t0\t{dir => other}/x.txt")).toEqual([numstat("other/x.txt", 0, 0, "dir/x.txt")])
+  test("resolves a same-directory rename", () => {
+    // `git diff --numstat -z` emits the old and new paths as separate fields.
+    expect(parseNumstatRows("0\t0\t\0src/old.txt\0src/new.txt\0")).toEqual([
+      numstat("src/new.txt", 0, 0, "src/old.txt"),
+    ])
   })
 
-  test("resolves a root-level rename with no common segment (no braces)", () => {
-    expect(parseNumstatRows("0\t0\troot1.txt => root2.txt")).toEqual([numstat("root2.txt", 0, 0, "root1.txt")])
+  test("resolves a cross-directory rename", () => {
+    expect(parseNumstatRows("0\t0\t\0dir/x.txt\0other/x.txt\0")).toEqual([numstat("other/x.txt", 0, 0, "dir/x.txt")])
+  })
+
+  test("resolves a root-level rename", () => {
+    expect(parseNumstatRows("0\t0\t\0root1.txt\0root2.txt\0")).toEqual([numstat("root2.txt", 0, 0, "root1.txt")])
   })
 
   test("keeps content-change counts on a renamed-and-edited file", () => {
-    expect(parseNumstatRows("8\t1\tsrc/{a.ts => b.ts}")).toEqual([numstat("src/b.ts", 8, 1, "src/a.ts")])
+    expect(parseNumstatRows("8\t1\t\0src/a.ts\0src/b.ts\0")).toEqual([numstat("src/b.ts", 8, 1, "src/a.ts")])
   })
 
   test("does not mangle a normal path that merely contains a brace", () => {
-    expect(parseNumstatRows("1\t0\tsrc/{shared}/util.ts")).toEqual([numstat("src/{shared}/util.ts", 1, 0)])
+    expect(parseNumstatRows("1\t0\tsrc/{shared}/util.ts\0")).toEqual([numstat("src/{shared}/util.ts", 1, 0)])
   })
 
-  test("resolves a move OUT of a subdirectory (empty new brace side)", () => {
-    // `git mv src/sub/a.txt src/a.txt` — git empties the new side. Naive
-    // concat would double the seam into `src//a.txt`; the new path must be
-    // `src/a.txt` and the old path `src/sub/a.txt`.
-    expect(parseNumstatRows("0\t0\tsrc/{sub => }/a.txt")).toEqual([numstat("src/a.txt", 0, 0, "src/sub/a.txt")])
+  test("resolves a move OUT of a subdirectory", () => {
+    expect(parseNumstatRows("0\t0\t\0src/sub/a.txt\0src/a.txt\0")).toEqual([
+      numstat("src/a.txt", 0, 0, "src/sub/a.txt"),
+    ])
   })
 
-  test("resolves a move INTO a subdirectory (empty old brace side)", () => {
-    // `git mv src/a.txt src/sub/a.txt` — git empties the old side. The old
-    // path must collapse to `src/a.txt`, not `src//a.txt`.
-    expect(parseNumstatRows("0\t0\tsrc/{ => sub}/a.txt")).toEqual([numstat("src/sub/a.txt", 0, 0, "src/a.txt")])
+  test("resolves a move INTO a subdirectory", () => {
+    expect(parseNumstatRows("0\t0\t\0src/a.txt\0src/sub/a.txt\0")).toEqual([
+      numstat("src/sub/a.txt", 0, 0, "src/a.txt"),
+    ])
   })
 
-  test("collapses the seam for a deeper move-out (empty side, nested prefix)", () => {
-    expect(parseNumstatRows("3\t1\ta/b/{c => }/f.txt")).toEqual([numstat("a/b/f.txt", 3, 1, "a/b/c/f.txt")])
-  })
-
-  test("only collapses at a real directory seam, not any empty side", () => {
-    // Defensive: git only ever empties a WHOLE `/`-bounded component, so a real
-    // seam is always slash-flanked. This synthetic partial-component field
-    // (which git never emits) must NOT collapse, since the suffix (`file.txt`)
-    // is not `/`-led — proving the collapse is scoped to the seam, not any
-    // empty side. Plain concat stands: `src/file.txt` / `src/subfile.txt`.
-    expect(parseNumstatRows("0\t0\tsrc/{sub => }file.txt")).toEqual([numstat("src/file.txt", 0, 0, "src/subfile.txt")])
-  })
-
-  test("resolves a quoted (tab) rename with independent quoting per side", () => {
-    expect(parseNumstatRows('2\t1\t"weird\\tname.txt" => "weird\\trenamed.txt"')).toEqual([
+  test("resolves a rename with a tab in the path", () => {
+    // With `-z`, the tab is a literal byte in the path, not a C escape.
+    expect(parseNumstatRows("2\t1\t\0weird\tname.txt\0weird\trenamed.txt\0")).toEqual([
       numstat("weird\trenamed.txt", 2, 1, "weird\tname.txt"),
     ])
   })
 
-  test("resolves a unicode (octal) rename", () => {
-    expect(parseNumstatRows('0\t0\t"\\303\\274.txt" => "\\303\\274v2.txt"')).toEqual([
-      numstat("üv2.txt", 0, 0, "ü.txt"),
+  test("resolves a unicode rename", () => {
+    expect(parseNumstatRows("0\t0\t\0ü.txt\0üv2.txt\0")).toEqual([numstat("üv2.txt", 0, 0, "ü.txt")])
+  })
+
+  test("issue #63 regression: literal brace in a rename path", () => {
+    // Brace-compaction makes this path unparseable without `-z`:
+    //   path:       src/{a{b/f.txt  →  src/c/f.txt
+    //   non-z:      src/{{a{b => c}/f.txt   (three `{`, ambiguous)
+    // With `-z` the two paths are independent fields.
+    expect(parseNumstatRows("0\t0\t\0src/{a{b/f.txt\0src/c/f.txt\0")).toEqual([
+      numstat("src/c/f.txt", 0, 0, "src/{a{b/f.txt"),
     ])
   })
 })
 
 describe("porcelain ↔ numstat path coherence (the join the bug breaks)", () => {
   test("a spaced rename resolves to the SAME canonical path in both formats", () => {
-    // Porcelain quotes the spaced paths; numstat brace-compacts them WITHOUT
-    // quoting. Both must unquote/resolve to `src/has space2.txt` so the
-    // numstat counts key onto the porcelain `R` row.
+    // Porcelain quotes the spaced paths; numstat with `-z` emits raw paths.
+    // Both must unquote/resolve to `src/has space2.txt` so the numstat counts
+    // key onto the porcelain `R` row.
     const [p] = parsePorcelainRows('R  "src/has space.txt" -> "src/has space2.txt"')
-    const [n] = parseNumstatRows("4\t2\tsrc/{has space.txt => has space2.txt}")
+    const [n] = parseNumstatRows("4\t2\t\0src/has space.txt\0src/has space2.txt\0")
     expect(p?.path).toBe("src/has space2.txt")
     expect(n?.path).toBe("src/has space2.txt")
     expect(p?.path).toBe(n?.path)
   })
 
   test("a spaced (non-rename) modify resolves identically across formats", () => {
-    // Porcelain quotes `"a b.txt"`; numstat leaves `a b.txt` bare.
+    // Porcelain quotes `"a b.txt"`; numstat with `-z` emits the raw path.
     const [p] = parsePorcelainRows(' M "a b.txt"')
-    const [n] = parseNumstatRows("1\t0\ta b.txt")
+    const [n] = parseNumstatRows("1\t0\ta b.txt\0")
     expect(p?.path).toBe("a b.txt")
     expect(n?.path).toBe("a b.txt")
   })
 
   test("a tab-named modify resolves identically across formats", () => {
     const [p] = parsePorcelainRows(' M "a\\tb.txt"')
-    const [n] = parseNumstatRows('1\t0\t"a\\tb.txt"')
+    const [n] = parseNumstatRows("1\t0\ta\tb.txt\0")
     expect(p?.path).toBe("a\tb.txt")
     expect(n?.path).toBe("a\tb.txt")
   })
 
   test("a move OUT of a subdirectory keys onto the same porcelain path", () => {
     // `git mv src/sub/a.txt src/a.txt`. Porcelain reports the full new path;
-    // numstat empties the new brace side (`src/{sub => }/a.txt`). Both must
-    // resolve to `src/a.txt` or the +/- counts orphan from the status row.
+    // numstat with `-z` emits the old and new paths as separate fields. Both
+    // must resolve to `src/a.txt` or the +/- counts orphan from the status row.
     const [p] = parsePorcelainRows("R  src/sub/a.txt -> src/a.txt")
-    const [n] = parseNumstatRows("4\t2\tsrc/{sub => }/a.txt")
+    const [n] = parseNumstatRows("4\t2\t\0src/sub/a.txt\0src/a.txt\0")
     expect(p?.path).toBe("src/a.txt")
     expect(n?.path).toBe("src/a.txt")
     expect(p?.path).toBe(n?.path)

--- a/packages/kobe/test/tui/filetree-git.test.ts
+++ b/packages/kobe/test/tui/filetree-git.test.ts
@@ -1,12 +1,11 @@
 /**
  * Unit tests for the file tree's git wrappers (`filetree/git.ts`).
  *
- * Focus: `parseNumstat` rename handling. `git diff --numstat` renders a
- * rename with ` => ` (NOT porcelain's ` -> `) and brace-compacts the
- * unchanged path segments. The Changes tab merges these counts onto the
- * porcelain `R` row by PATH, so the parser must resolve the numstat field
- * to the same canonical post-rename path porcelain reports — otherwise a
- * renamed file silently shows no +/- line counts.
+ * Focus: `parseNumstat` rename handling. `git diff --numstat -z` renders
+ * renames as NUL-delimited old/new path pairs. The Changes tab merges these
+ * counts onto the porcelain `R` row by PATH, so the parser must resolve the
+ * numstat record to the same canonical post-rename path porcelain reports —
+ * otherwise a renamed file silently shows no +/- line counts.
  *
  * Also covers `parseStatusEntries` (headline collapsing), `buildTree` (dir/file
  * grouping), and the `listFiles`/`statusFiles` git-invoking wrappers, whose
@@ -56,43 +55,45 @@ beforeEach(() => {
 
 describe("parseNumstat", () => {
   test("parses a plain modified file", () => {
-    expect(parseNumstat("3\t2\tsrc/app.ts")).toEqual([{ path: "src/app.ts", added: 3, deleted: 2 }])
+    expect(parseNumstat("3\t2\tsrc/app.ts\0")).toEqual([{ path: "src/app.ts", added: 3, deleted: 2 }])
   })
 
   test("surfaces binary `-` counts as null", () => {
-    expect(parseNumstat("-\t-\tassets/logo.png")).toEqual([{ path: "assets/logo.png", added: null, deleted: null }])
+    expect(parseNumstat("-\t-\tassets/logo.png\0")).toEqual([{ path: "assets/logo.png", added: null, deleted: null }])
   })
 
-  test("ignores blank and malformed lines", () => {
-    expect(parseNumstat("\n3\t1\ta.ts\nnotatabline\n")).toEqual([{ path: "a.ts", added: 3, deleted: 1 }])
+  test("ignores malformed fields", () => {
+    expect(parseNumstat("notatabline\0" + "3\t1\ta.ts\0")).toEqual([{ path: "a.ts", added: 3, deleted: 1 }])
   })
 
   // ── Rename forms (the bug this file pins) ────────────────────────────────
-  // git outputs ` => ` with brace-compaction; the canonical NEW path must
-  // match what `git status --porcelain` reports as the `R` row's path.
+  // With `-z`, git emits the old and new paths as separate NUL-delimited
+  // fields; the canonical NEW path must match what `git status --porcelain`
+  // reports as the `R` row's path.
 
   test("resolves a same-directory rename to the new path", () => {
-    // git: `0\t0\tsrc/{old.txt => new.txt}`  (porcelain row: `src/new.txt`)
-    expect(parseNumstat("0\t0\tsrc/{old.txt => new.txt}")).toEqual([{ path: "src/new.txt", added: 0, deleted: 0 }])
+    // git: `0\t0\t\0src/old.txt\0src/new.txt\0`  (porcelain row: `src/new.txt`)
+    expect(parseNumstat("0\t0\t\0src/old.txt\0src/new.txt\0")).toEqual([{ path: "src/new.txt", added: 0, deleted: 0 }])
   })
 
-  test("resolves a cross-directory rename (brace on the leading segment)", () => {
-    // git: `0\t0\t{dir => other}/x.txt`  (porcelain row: `other/x.txt`)
-    expect(parseNumstat("0\t0\t{dir => other}/x.txt")).toEqual([{ path: "other/x.txt", added: 0, deleted: 0 }])
+  test("resolves a cross-directory rename", () => {
+    // git: `0\t0\t\0dir/x.txt\0other/x.txt\0`  (porcelain row: `other/x.txt`)
+    expect(parseNumstat("0\t0\t\0dir/x.txt\0other/x.txt\0")).toEqual([{ path: "other/x.txt", added: 0, deleted: 0 }])
   })
 
-  test("resolves a root-level rename with no common segment (no braces)", () => {
-    // git: `0\t0\troot1.txt => root2.txt`  (porcelain row: `root2.txt`)
-    expect(parseNumstat("0\t0\troot1.txt => root2.txt")).toEqual([{ path: "root2.txt", added: 0, deleted: 0 }])
+  test("resolves a root-level rename", () => {
+    // git: `0\t0\t\0root1.txt\0root2.txt\0`  (porcelain row: `root2.txt`)
+    expect(parseNumstat("0\t0\t\0root1.txt\0root2.txt\0")).toEqual([{ path: "root2.txt", added: 0, deleted: 0 }])
   })
 
   test("keeps content-change counts on a renamed-and-edited file", () => {
-    expect(parseNumstat("8\t1\tsrc/{a.ts => b.ts}")).toEqual([{ path: "src/b.ts", added: 8, deleted: 1 }])
+    expect(parseNumstat("8\t1\t\0src/a.ts\0src/b.ts\0")).toEqual([{ path: "src/b.ts", added: 8, deleted: 1 }])
   })
 
   test("does not mangle a normal path that merely contains a brace", () => {
-    // No ` => ` inside the braces → not a rename → returned verbatim.
-    expect(parseNumstat("1\t0\tsrc/{shared}/util.ts")).toEqual([{ path: "src/{shared}/util.ts", added: 1, deleted: 0 }])
+    expect(parseNumstat("1\t0\tsrc/{shared}/util.ts\0")).toEqual([
+      { path: "src/{shared}/util.ts", added: 1, deleted: 0 },
+    ])
   })
 })
 
@@ -202,7 +203,7 @@ describe("statusFiles", () => {
   test("merges numstat counts onto porcelain rows by path", async () => {
     runGit.mockImplementation(async (_cwd, args) => {
       if (args[0] === "status") return ok(" M a.ts\n")
-      if (args[0] === "diff") return ok("3\t1\ta.ts\n")
+      if (args[0] === "diff" && args.includes("-z")) return ok("3\t1\ta.ts\0")
       throw new Error(`unexpected args ${args.join(" ")}`)
     })
     const rows = await statusFiles("/repo")
@@ -212,7 +213,7 @@ describe("statusFiles", () => {
   test("collapses an untracked dir to one row with children + summed counts", async () => {
     runGit.mockImplementation(async (_cwd, args) => {
       if (args[0] === "status") return ok(" M a.ts\n?? assets/\n")
-      if (args[0] === "diff") return ok("3\t1\ta.ts\n")
+      if (args[0] === "diff" && args.includes("-z")) return ok("3\t1\ta.ts\0")
       if (args[0] === "ls-files") return ok("assets/x.txt\nassets/y.bin\n")
       throw new Error(`unexpected args ${args.join(" ")}`)
     })
@@ -237,7 +238,7 @@ describe("statusFiles", () => {
     runGit.mockImplementation(async (_cwd, args) => {
       if (args[0] === "status") return ok("A  new.ts\n")
       if (args.includes("HEAD")) return fail("no HEAD")
-      if (args.includes("--cached")) return ok("5\t0\tnew.ts\n")
+      if (args.includes("--cached") && args.includes("-z")) return ok("5\t0\tnew.ts\0")
       throw new Error(`unexpected args ${args.join(" ")}`)
     })
     const rows = await statusFiles("/repo")
@@ -298,7 +299,7 @@ describe("statusFilesBranch", () => {
       // Three-dot merge-base range, never a literal $(merge-base) subshell.
       expect(args).toContain("origin/main...HEAD")
       if (args.includes("--name-status")) return ok("M\tsrc/a.ts\nA\tsrc/b.ts\n")
-      if (args.includes("--numstat")) return ok("3\t1\tsrc/a.ts\n10\t0\tsrc/b.ts\n")
+      if (args.includes("--numstat") && args.includes("-z")) return ok("3\t1\tsrc/a.ts\0" + "10\t0\tsrc/b.ts\0")
       throw new Error(`unexpected args ${args.join(" ")}`)
     })
     const rows = await statusFilesBranch("/repo", "origin/main")


### PR DESCRIPTION
Closes #63.

Switch the three file-tree `git diff --numstat` callers to `--numstat -z` and update the shared parser to consume NUL-delimited records. This removes the brace-compaction parser, which is inherently ambiguous when a path contains a literal `{`.

## Before / after for the #63 counterexample

Path rename: `src/{a{b/f.txt` → `src/c/f.txt`

```text
# git diff --numstat (non -z)
0\t0\tsrc/{{a{b => c}/f.txt
# Three `{` — no anchor position can reliably distinguish the brace syntax
# from the literal brace in the path.

# git diff --numstat -z
0\t0\t\\0src/{a{b/f.txt\\0src/c/f.txt\\0
# Old and new paths are independent NUL-separated fields.
```

## Callers updated

- `src/tui/panes/filetree/git.ts:142` — `diff --numstat -z HEAD`
- `src/tui/panes/filetree/git.ts:152` — `diff --numstat -z --cached`
- `src/tui/panes/filetree/git.ts:284` — `diff --numstat -z <base>...HEAD`

The untracked-file merge logic at `filetree/git.ts:175` is unaffected: it joins numstat counts onto porcelain rows by canonical path, and `-z` emits the same canonical paths.

## Verification

- Added regression test for the literal-brace rename path.
- `bun run typecheck`, `bun run lint`, `bun run test`, and `bun test test/render` all pass.

Note: this PR stays open for review; I will not merge it myself.