### PR TITLE
test(render): fix cross-test fragility in render track (#76)

### DIFF
--- a/.changeset/render-test-isolation.md
+++ b/.changeset/render-test-isolation.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+test(render): fix cross-test fragility in render track
+
+Move the `toast-truncation` Harness toast push from render phase into a mount-only `useEffect`. Calling `useNotifications().notify()` during render set state on `NotificationsProvider` while React was still rendering `Harness`, which corrupted renderer state and leaked across test files, flakily failing later tests such as `worktrees-page-delete`.

--- a/packages/kobe/test/render/toast-truncation.test.tsx
+++ b/packages/kobe/test/render/toast-truncation.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it } from "bun:test"
+import { useEffect, useRef } from "react"
 import { ToastOverlay } from "../../src/tui-react/component/toast-overlay"
 import { useNotifications } from "../../src/tui-react/context/notifications"
 import { act, renderComponent } from "./harness"
@@ -13,11 +14,15 @@ import { act, renderComponent } from "./harness"
 const LONG_TITLE = "Fix the sidebar unread lamp across every repository group"
 const LONG_BODY = "fixture-repo › second opinion: root-cause the stale badge before the sweep"
 
-/** Pushes one toast on mount, then renders the overlay under test. */
+/** Pushes one toast after mount, then renders the overlay under test. */
 function Harness() {
   const notif = useNotifications()
-  if (notif.toasts.length === 0)
+  const pushed = useRef(false)
+  useEffect(() => {
+    if (pushed.current) return
+    pushed.current = true
     notif.notify({ kind: "done", taskId: "t1", tabId: "tab-1", title: LONG_TITLE, body: LONG_BODY })
+  }, [notif])
   return <ToastOverlay />
 }
 


### PR DESCRIPTION
Fixes #76.

The render track was flakily failing later tests (notably `worktrees-page-delete`) with two symptoms:

1. `Cannot update a component (NotificationsProvider) while rendering a different component (Harness)`
2. `useDialog must be used within a DialogProvider`

Root cause: `toast-truncation.test.tsx`'s `Harness` called `useNotifications().notify()` during render. React treats a setState on a parent provider during child render as an error, and the resulting renderer corruption leaked across the bun test process to later files.

This change moves the toast push into a mount-only `useEffect` so provider state updates happen outside the render phase. The existing `await act(async () => {})` in each test already flushes effects, so the toast still appears for assertions.

A related DialogProvider fix for `host-pages.test.tsx` is already on `main` (6d15c125). Together these close the isolation hole that was blocking PR #625.

Verification:
- `bun test test/render` on this branch: 235 pass, 0 fail (run 3× consecutively)
- `bun test test/render` on `remove/archive-tui-surface` with both fixes applied: 235 pass, 0 fail (run 3× consecutively)
- Four gates: `bun run typecheck`, `bun run lint`, `bun run test`, and `bun test test/render` all green.

Includes a patch changeset for `@sma1lboy/rove`.