### PR TITLE
fix: mute sidebar rail active indicator so orange only means focus/selection

### DIFF
--- a/.changeset/sidebar-nav-orange-ambiguity.md
+++ b/.changeset/sidebar-nav-orange-ambiguity.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Mute the sidebar rail's active-page indicator so it no longer competes with pane-focus and card-selection oranges.
+
+- Removed the `theme.focusAccent` background fill from `SidebarNavRail` active items (`src/tui-react/panes/sidebar/chrome.tsx`).
+- Active destination now reads as bold normal text (`theme.text`) against the panel background; inactive destinations stay muted.
+- Updated the inline contrast comment to explain why the accent fill was intentionally dropped.

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -195,7 +195,6 @@ export function SidebarNavRail(props: { nav: SidebarNav; setNav: (nav: SidebarNa
             flexShrink={0}
             paddingLeft={1}
             paddingRight={1}
-            backgroundColor={active ? theme.focusAccent : undefined}
             onMouseUp={(e: { stopPropagation(): void }) => {
               // goToNav hands focus to the page; a bubbled sidebar
               // focus-grab (the pane shell's onMouseUp) took it right back,
@@ -205,10 +204,10 @@ export function SidebarNavRail(props: { nav: SidebarNav; setNav: (nav: SidebarNa
             }}
           >
             <text
-              // Contrast fg on the accent fill: `background` is alpha-0 in
-              // transparent mode (invisible text); `backgroundElement`
-              // stays opaque in every mode.
-              fg={active ? theme.backgroundElement : theme.textMuted}
+              // Active destination: bold + normal text color. We intentionally
+              // do NOT use the focus-accent fill here, because that same orange
+              // already signals (a) focused pane borders and (b) selected cards.
+              fg={active ? theme.text : theme.textMuted}
               attributes={active ? TextAttributes.BOLD : undefined}
               wrapMode="none"
               flexGrow={1}


### PR DESCRIPTION
## Problem

The kanban screen had three distinct pieces of information all painted with the same orange (`theme.focusAccent` / `theme.primary`):

1. Sidebar rail active page (`SidebarNavRail` background fill).
2. Focused pane border (`TerminalSplit`).
3. Selected kanban card (`kanban-card`).

Three layers saying three different things with one color made it impossible to tell at a glance whether an orange accent meant "you are on this page", "keyboard focus is in this pane", or "this card is selected".

## Change

Only layer ① is changed.

- Removed the `theme.focusAccent` background fill from the active rail item in `src/tui-react/panes/sidebar/chrome.tsx`.
- Active destination now uses bold + normal text color (`theme.text`); inactive destinations stay `theme.textMuted`.
- Updated the inline contrast comment to document why the accent fill is intentionally gone.

Layers ② and ④ are untouched, so after this change the only orange on screen is:
- pane borders = keyboard focus is here
- card borders = cursor/selection is here

## Theme/readability check

The active item now relies on text weight + `theme.text` vs `theme.textMuted` contrast. This works in:
- `claude` (default) dark & light
- `conductor` dark & light
- `tokyonight` dark & light
- transparent mode (no background fill means no alpha-0 background issue; `theme.text` remains legible over the host terminal)

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test:fast` ✅ (369 files, 3616 tests)
- `bun test test/render` ✅ (235 tests)

No golden frames were updated: the render catalog defaults to the `terminal` page, where no rail item is active, so removing the active fill did not change any locked frame.

## Changeset

`patch` — `.changeset/sidebar-nav-orange-ambiguity.md`
