### PR TITLE
feat: add GitHub Issues to the sidebar rail

### DIFF
--- a/.changeset/sidebar-issues-rail.md
+++ b/.changeset/sidebar-issues-rail.md
@@ -1,0 +1,10 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Add GitHub Issues to the sidebar navigation rail.
+
+- `SIDEBAR_NAV_ITEMS` now includes `{ nav: "issues", labelKey: "tasks.nav.issues", bindingId: "workItems.open" }`.
+- Removed the stale comment that kept Issues off the rail pending a design pass.
+- Updated `docs/KEYBINDINGS.md`, `docs/TUI.md`, and `docs/design/work-items.md` to describe Issues as a first-class rail destination.
+- Updated sidebar navigation unit and render tests to expect the new row and cycling order.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -53,12 +53,8 @@ shows only actions that can run right now.
 | `ctrl+a` `o` | Open the Task directory in your editor |
 | `ctrl+a` `m` | Reorder sidebar rows (scope-aware: tab / task / project) |
 | `ctrl+a` `w` | Close the active split |
-| `ctrl+a` `1` / `2` | Kanban / Automations |
+| `ctrl+a` `1` / `2` / `3` | Kanban / Routines / Issues |
 | `ctrl+a` `z` | Toggle zen mode |
-
-The GitHub Issues view is currently a CLI-only preview; use `rove api
-workitem-*` to browse and start work from issues. `ctrl+a 3` is still wired
-but is not a documented shortcut until the page earns a sidebar rail row.
 | `ctrl+a` `,` | Open Settings |
 | `ctrl+a` `p` / `P` | Create a PR from the active task |
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -378,13 +378,11 @@ the daemon alive so schedules fire with no TUI attached.
 Walked through end to end, with the page pictured and the cron and precheck
 rules spelled out: [Routines](ROUTINES.md).
 
-### GitHub Issues (CLI-only)
+### GitHub Issues (`ctrl+a` `3`)
 
 A read-only view of the repo's GitHub issues, fetched through the `gh` CLI.
-Today the only supported entry point is `rove api workitem-*`; use it to
-browse issues and start a task from one. The underlying page is wired and
-`ctrl+a 3` still opens it, but it is not yet documented as a TUI shortcut
-because it has not earned a sidebar rail row.
+Open it from the sidebar rail or with `ctrl+a` `3`; use `rove api workitem-*`
+to browse and start work from issues when the TUI is not open.
 
 When the page opens, `a` filters to issues assigned to you, `tab` switches
 repos, and `r` refreshes past the cache. `enter` starts a Rove task from the

--- a/docs/design/work-items.md
+++ b/docs/design/work-items.md
@@ -88,10 +88,9 @@ guessing at a fix for something that may not be broken.
 
 ## TUI
 
-**Not on the sidebar rail yet** (owner call 2026-08-01): the page works but has
-had no design pass, so it stays CLI-only until it earns a row. Its `nav` value
-and page component are still wired — re-adding the entry to
-`SIDEBAR_NAV_ITEMS` is the whole change.
+**On the sidebar rail** (owner call 2026-08-29): open it with `ctrl+a` `3` or
+by selecting **Issues** in the rail. The `rove api workitem-*` commands remain
+available when the TUI is not open.
 
 When it is shown, it is pointed at the selected task's project.
 

--- a/packages/kobe/src/tui/panes/sidebar/nav-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/nav-core.ts
@@ -35,10 +35,7 @@ export interface SidebarNavItem {
 export const SIDEBAR_NAV_ITEMS: readonly SidebarNavItem[] = [
   { nav: "kanban", labelKey: "tasks.nav.kanban", bindingId: "kanban.open" },
   { nav: "automations", labelKey: "tasks.nav.automations", bindingId: "automations.open" },
-  // `issues` is deliberately absent: the external-tracker page works but has
-  // had no design pass, so it stays reachable only through `kobe api
-  // workitem-*` until it earns a rail row. Its nav value and page stay wired
-  // so re-adding the row here is the whole change.
+  { nav: "issues", labelKey: "tasks.nav.issues", bindingId: "workItems.open" },
 ]
 
 /**

--- a/packages/kobe/test/render/golden/empty.frame.txt
+++ b/packages/kobe/test/render/golden/empty.frame.txt
@@ -9,11 +9,11 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 |                              |
 | No active tasks — create one |
 | above.                       |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/long-labels.frame.txt
+++ b/packages/kobe/test/render/golden/long-labels.frame.txt
@@ -9,13 +9,13 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  refactor/tab-strip-res… ▴ ✓ |
 |  · persist scrollback acros… |
 |  feat/alpha                  |
 |▌ · build                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/move-mode.frame.txt
+++ b/packages/kobe/test/render/golden/move-mode.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/recent-jump-row.frame.txt
+++ b/packages/kobe/test/render/golden/recent-jump-row.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 |  ↩ Recent: bravo             |
 |                              |
@@ -18,7 +19,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/scratch-flat.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-flat.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | SCRATCH ──────────────────── |
 |  · shell 1                   |
@@ -16,7 +17,6 @@
 | rove ─────────────────────── |
 |  feat/alpha                  |
 |▌ · build                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/scratch-path-label.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-path-label.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | SCRATCH ──────────────────── |
 |  …deep/nested/project-dir    |
@@ -16,7 +17,6 @@
 | rove ─────────────────────── |
 |  feat/alpha                  |
 |▌ · build                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-pruned.frame.txt
+++ b/packages/kobe/test/render/golden/search-pruned.frame.txt
@@ -11,11 +11,11 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |▌ feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-tab-title.frame.txt
+++ b/packages/kobe/test/render/golden/search-tab-title.frame.txt
@@ -11,11 +11,11 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |▌ feat/alpha                  |
 |  · review                    |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-error.frame.txt
+++ b/packages/kobe/test/render/golden/tab-error.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-idle.frame.txt
+++ b/packages/kobe/test/render/golden/tab-idle.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-non-agent.frame.txt
+++ b/packages/kobe/test/render/golden/tab-non-agent.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · shell                     |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
+++ b/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
+++ b/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  ~ review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
+++ b/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |▌ · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tree-unknown.frame.txt
+++ b/packages/kobe/test/render/golden/tree-unknown.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
+++ b/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha              ▴ ✓ |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                ✗ |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/zen-chip.frame.txt
+++ b/packages/kobe/test/render/golden/zen-chip.frame.txt
@@ -9,6 +9,7 @@
 |                              |
 | Kanban                       |
 | Routines                     |
+| Issues                       |
 |                              |
 | rove ─────────────────────── |
 |  feat/alpha                  |
@@ -16,7 +17,6 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
-|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/sidebar-nav-rail.test.tsx
+++ b/packages/kobe/test/render/sidebar-nav-rail.test.tsx
@@ -54,7 +54,7 @@ function tree(over: Partial<Parameters<typeof SidebarTree>[0]> = {}) {
 async function labelLines(frame: () => Promise<string>): Promise<Record<string, number>> {
   const lines = (await frame()).split("\n")
   const out: Record<string, number> = {}
-  for (const label of ["Kanban", "Routines"]) {
+  for (const label of ["Kanban", "Routines", "Issues"]) {
     const index = lines.findIndex((line) => line.includes(label))
     if (index >= 0) out[label] = index
   }
@@ -69,9 +69,9 @@ test("every destination gets its own line, in declared order", async () => {
   const rendered = Object.entries(lines)
     .sort(([, a], [, b]) => a - b)
     .map(([label]) => label)
-  expect(rendered).toEqual(["Kanban", "Routines"])
+  expect(rendered).toEqual(["Kanban", "Routines", "Issues"])
   // Distinct rows — a horizontal strip would share lines.
-  expect(new Set(Object.values(lines)).size).toBe(2)
+  expect(new Set(Object.values(lines)).size).toBe(3)
 })
 
 test("no label is truncated at the 24-cell rail width", async () => {
@@ -104,12 +104,12 @@ test("the task list stays visible whatever the rail selects", async () => {
 
 test("nav-core cycling wraps in both directions", () => {
   expect(cycleNavTarget("kanban", 1)).toBe("automations")
-  expect(cycleNavTarget("automations", 1)).toBe("kanban")
-  expect(cycleNavTarget("kanban", -1)).toBe("automations")
-  // Neither `terminal` nor the hidden `issues` page is on the rail, so there
-  // is nowhere to cycle from either.
+  expect(cycleNavTarget("automations", 1)).toBe("issues")
+  expect(cycleNavTarget("issues", 1)).toBe("kanban")
+  expect(cycleNavTarget("kanban", -1)).toBe("issues")
+  expect(cycleNavTarget("issues", -1)).toBe("automations")
+  // `terminal` is not on the rail — it is reached by selecting a task.
   expect(cycleNavTarget("terminal", 1)).toBeNull()
-  expect(cycleNavTarget("issues", 1)).toBeNull()
 })
 
 test("opening a rail page carries focus into the content pane", () => {

--- a/packages/kobe/test/tui/sidebar-nav.test.ts
+++ b/packages/kobe/test/tui/sidebar-nav.test.ts
@@ -6,15 +6,20 @@ describe("sidebar navigation metadata", () => {
     expect(SIDEBAR_NAV_ITEMS).toEqual([
       { nav: "kanban", labelKey: "tasks.nav.kanban", bindingId: "kanban.open" },
       { nav: "automations", labelKey: "tasks.nav.automations", bindingId: "automations.open" },
+      { nav: "issues", labelKey: "tasks.nav.issues", bindingId: "workItems.open" },
     ])
   })
 
   it("cycles visible destinations and preserves pane focus ownership", () => {
     expect(cycleNavTarget("kanban", 1)).toBe("automations")
-    expect(cycleNavTarget("automations", -1)).toBe("kanban")
+    expect(cycleNavTarget("automations", 1)).toBe("issues")
+    expect(cycleNavTarget("issues", -1)).toBe("automations")
+    expect(cycleNavTarget("issues", 1)).toBe("kanban")
+    expect(cycleNavTarget("kanban", -1)).toBe("issues")
     expect(cycleNavTarget("terminal", 1)).toBeNull()
 
     expect(focusPaneForNav("terminal")).toBe("sidebar")
     expect(focusPaneForNav("kanban")).toBe("workspace")
+    expect(focusPaneForNav("issues")).toBe("workspace")
   })
 })


### PR DESCRIPTION
Adds **Issues** as a third row in the sidebar navigation rail, alongside **Kanban** and **Routines**.

## Before
- The rail showed only two rows: Kanban and Routines.
- GitHub Issues was reachable via `ctrl+a 3` and `rove api workitem-*`, but had no sidebar entry.
- A stale comment in `nav-core.ts` recorded a design-pass gate that the owner has now lifted.

## After
- The rail shows three rows, top-to-bottom: **Kanban**, **Routines**, **Issues**.
- Clicking **Issues** (or pressing `ctrl+a 3`) opens the existing GitHub Issues page.
- `cycleNavTarget` wraps through all three rows.
- Docs and render golden frames updated to match the new rail layout.

## Verification
- `bun run typecheck`, `bun run lint`, `bun run check-i18n` pass.
- `bun run test:fast` and `bun run test:socket` pass.
- `bun test test/render` passes (golden frames regenerated with `KOBE_UPDATE_GOLDEN=1`).

## Scope notes
- No new keybinding is introduced; `workItems.open` (`ctrl+a 3`) already existed.
- `tasks.nav.issues` already existed in both English and Chinese catalogs.
- The rail order places Issues at the end to minimize muscle-memory disruption; happy to reorder if desired.