### PR TITLE
fix: dedupe story prompts and stop wrapping peer messages in English

### DIFF
--- a/.changeset/issue-prompt-dedup.md
+++ b/.changeset/issue-prompt-dedup.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Story prompts: one implementation, and the sender's text stays last
+
+The TUI and the web board each kept a hand-written copy of the prompt sent
+when you start a session from a story, and the copies had drifted — the web
+one interpolated the product name, the TUI one hard-coded "Rove". Both now
+call one shared builder, so the same action sends the same text wherever you
+start it.
+
+The `[ROVE PEER]` and `[ROVE FIELD NOTE]` prefixes now put the sender's
+message last and whole, after the provenance line, instead of splicing it
+into the end of an English sentence. A non-English message reads as itself
+and no longer drags the receiving agent's reply into English.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -79,7 +79,8 @@
     "./plugins/settings-env": "./src/plugins/settings-env.ts",
     "./daemon/pty-exit-watch": "./src/daemon/pty-exit-watch.ts",
     "./plugins/task-diff": "./src/plugins/task-diff.ts",
-    "./daemon/quota-resume": "./src/daemon/quota-resume.ts"
+    "./daemon/quota-resume": "./src/daemon/quota-resume.ts",
+    "./prompts/issue-prompts": "./src/prompts/issue-prompts.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -226,7 +226,10 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       if (routed && main) {
         ctx.bus.publish("session.deliver", {
           taskId: main.id,
-          text: `[ROVE FIELD NOTE] from "${label}" (task ${taskId}): ${text}`,
+          // Note text last and whole, same rule as the [ROVE PEER] prefix
+          // in `cli/api/handlers-tasks.ts`: the dispatcher reads a note in
+          // the filer's own language, not as the tail of an English clause.
+          text: `[ROVE FIELD NOTE] from "${label}" (task ${taskId})\n\n${text}`,
           at: Date.now(),
           source: "note",
         })

--- a/packages/kobe-daemon/src/prompts/issue-prompts.ts
+++ b/packages/kobe-daemon/src/prompts/issue-prompts.ts
@@ -1,0 +1,62 @@
+/**
+ * First/follow-up prompts for a session started from a story in the
+ * daemon-owned issue store.
+ *
+ * ONE implementation, in the package both callers can reach. The TUI
+ * (`kobe/src/state/issue-chat.ts`) and the web board
+ * (`kobe-web/src/lib/issues.ts`) each carried a hand-kept copy of this
+ * wording, and they had already drifted: the web copy interpolated the
+ * product name while the TUI copy hard-coded "Rove", so the same action
+ * sent different text depending on which surface you started it from.
+ *
+ * `product` is a parameter rather than a constant because the two callers
+ * derive the display name differently (kobe-web's `cli-name.ts`, kobe's
+ * `product.ts`) — passing it in is what let the two copies collapse into
+ * this one.
+ */
+
+import type { Issue } from "../daemon/issues-store.ts"
+
+function promptHeader(issue: Issue): string[] {
+  const lines = [`Work on user story #${issue.id}: ${issue.title}`, ""]
+  const body = issue.body.trim()
+  if (body) lines.push(body, "")
+  return lines
+}
+
+/** First message for a worktree-task session. */
+export function issueWorktreePrompt(issue: Issue, api: string, product: string): string {
+  return [
+    ...promptHeader(issue),
+    `Treat this as the story's dedicated ${product} task session: work only in this task worktree, and preserve any repo init instructions already delivered to the session.`,
+    "Before finishing, verify the acceptance criteria implied by the story and summarize what changed plus any verification still needed.",
+    "Then merge the task branch back into the current project's main branch after the worktree is clean and checks pass.",
+    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
+  ].join("\n")
+}
+
+/** First message for a chat directly on the project checkout — no worktree,
+ *  so the worktree/merge instructions are replaced with a stay-put note. */
+export function issueProjectPrompt(issue: Issue, api: string): string {
+  return [
+    ...promptHeader(issue),
+    "You are working directly in the project checkout — no dedicated worktree or branch was created. Keep changes reviewable and do not switch branches unless asked.",
+    "Before finishing, verify the acceptance criteria implied by the story and summarize what changed plus any verification still needed.",
+    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
+  ].join("\n")
+}
+
+/**
+ * Follow-up for a linked issue after implementation has run in its task
+ * worktree. Delivered to the task session rather than merged in the UI: the
+ * engine owns the final code/check/conflict work.
+ */
+export function issueMergePrompt(issue: Issue, api: string): string {
+  return [
+    `Finish user story #${issue.id}: ${issue.title}`,
+    "",
+    "Verify the acceptance criteria implied by the story, then summarize what changed and any verification still needed.",
+    "Then merge this task branch back into the current project's main branch after the worktree is clean and checks pass. Resolve conflicts if needed.",
+    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
+  ].join("\n")
+}

--- a/packages/kobe-web/src/lib/issues.ts
+++ b/packages/kobe-web/src/lib/issues.ts
@@ -6,6 +6,14 @@
  */
 
 import { ROVE_PRODUCT_NAME } from "@sma1lboy/kobe-daemon/compat-env"
+// One implementation of the story prompts, shared with the TUI
+// (`kobe/src/state/issue-chat.ts`). The copies these two files kept by hand
+// had already drifted apart.
+import {
+  issueMergePrompt,
+  issueProjectPrompt,
+  issueWorktreePrompt,
+} from "@sma1lboy/kobe-daemon/prompts/issue-prompts"
 import { setActiveTaskBestEffort } from "./active-task.ts"
 import { api } from "./api-client.ts"
 import { labelRepo } from "./board.ts"
@@ -295,57 +303,6 @@ export function resolveIssueRepoSelection(
   return options[0]?.repo ?? null
 }
 
-/**
- * The engine's first message for a quick-started issue. The caller has
- * already flipped the issue to `doing`; the prompt asks the agent to report
- * completion through the daemon-owned issue API, not by editing repo files.
- */
-export function quickStartPrompt(issue: Issue, api = DEFAULT_CLI_API): string {
-  const lines = [`Work on user story #${issue.id}: ${issue.title}`, ""]
-  const body = issue.body.trim()
-  if (body) lines.push(body, "")
-  lines.push(
-    `Treat this as the story's dedicated ${displayProductName()} task session: work only in this task worktree, and preserve any repo init instructions already delivered to the session.`,
-    "Before finishing, verify the acceptance criteria implied by the story and summarize what changed plus any verification still needed.",
-    "Then merge the task branch back into the current project's main branch after the worktree is clean and checks pass.",
-    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
-  )
-  return lines.join("\n")
-}
-
-/**
- * The engine's first message for an issue chat opened directly in the project
- * checkout (no dedicated worktree/branch): same story framing as
- * {@link quickStartPrompt}, but without the worktree/merge instructions —
- * the work happens on the checkout as-is.
- */
-export function projectChatPrompt(issue: Issue, api = DEFAULT_CLI_API): string {
-  const lines = [`Work on user story #${issue.id}: ${issue.title}`, ""]
-  const body = issue.body.trim()
-  if (body) lines.push(body, "")
-  lines.push(
-    "You are working directly in the project checkout — no dedicated worktree or branch was created. Keep changes reviewable and do not switch branches unless asked.",
-    "Before finishing, verify the acceptance criteria implied by the story and summarize what changed plus any verification still needed.",
-    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
-  )
-  return lines.join("\n")
-}
-
-/**
- * Follow-up prompt for a linked issue after implementation has run in its task
- * worktree. This is intentionally delivered to the task session instead of
- * merging in the web UI: the engine owns the final code/check/conflict work.
- */
-export function issueMergePrompt(issue: Issue, api = DEFAULT_CLI_API): string {
-  return [
-    `Finish user story #${issue.id}: ${issue.title}`,
-    "",
-    "Verify the acceptance criteria implied by the story, then summarize what changed and any verification still needed.",
-    "Then merge this task branch back into the current project's main branch after the worktree is clean and checks pass. Resolve conflicts if needed.",
-    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
-  ].join("\n")
-}
-
 /* ----- quick start (side-effectful) --------------------------------------- */
 
 /**
@@ -379,7 +336,7 @@ export async function quickStartIssue(
   setActiveTaskBestEffort(taskId)
   const api = await fetchKobeApiInvocation().catch(() => DEFAULT_CLI_API)
   const tabId = ensureEngineTab(taskId)
-  await sendPtyText(tabId, taskId, quickStartPrompt(issue, api))
+  await sendPtyText(tabId, taskId, issueWorktreePrompt(issue, api, displayProductName()))
   return { taskId }
 }
 
@@ -455,7 +412,7 @@ export async function startIssueChat(
     )
     setActiveTaskBestEffort(mainId)
     const tabId = addTab(mainId, taskId)
-    await sendPtyText(tabId, taskId, quickStartPrompt(issue, api))
+    await sendPtyText(tabId, taskId, issueWorktreePrompt(issue, api, displayProductName()))
     return { taskId, workspaceTaskId: mainId }
   }
   // `project` — no worktree, no task link: the engine runs on the checkout.
@@ -469,7 +426,7 @@ export async function startIssueChat(
   // must not fail on a status write.
   await setIssueStatus(repoRoot, issue.id, "doing").catch(() => {})
   const tabId = addTab(mainId)
-  await sendPtyText(tabId, mainId, projectChatPrompt(issue, api))
+  await sendPtyText(tabId, mainId, issueProjectPrompt(issue, api))
   return { taskId: mainId, workspaceTaskId: mainId }
 }
 

--- a/packages/kobe-web/test/issues-actions.test.ts
+++ b/packages/kobe-web/test/issues-actions.test.ts
@@ -6,11 +6,14 @@ vi.mock("../src/lib/terminal.ts", () => ({ sendPtyText: vi.fn() }))
 
 import {
   issueMergePrompt,
+  issueProjectPrompt,
+  issueWorktreePrompt,
+} from "@sma1lboy/kobe-daemon/prompts/issue-prompts"
+import { displayProductName } from "../src/lib/cli-name.ts"
+import {
   linkIssue,
-  projectChatPrompt,
   promptIssueMerge,
   quickStartIssue,
-  quickStartPrompt,
   type RepoIssues,
   startIssueChat,
   unlinkIssue,
@@ -54,7 +57,7 @@ describe("quickStartIssue", () => {
     expect(rpc).toHaveBeenCalledWith("task.setActive", { taskId: "task-1" })
     expect(rpc).not.toHaveBeenCalledWith("task.ensureWorktree", expect.anything())
     expect(ensureEngineTab).toHaveBeenCalledWith("task-1")
-    expect(sendPtyText).toHaveBeenCalledWith("tab-1", "task-1", quickStartPrompt(target, "bun ./src/cli/index.ts api"))
+    expect(sendPtyText).toHaveBeenCalledWith("tab-1", "task-1", issueWorktreePrompt(target, "bun ./src/cli/index.ts api", displayProductName()))
     const issuesPost = fetchMock.mock.calls.find(
       ([url, opts]) => url === "/api/issues" && (opts as RequestInit | undefined)?.method === "POST",
     )
@@ -166,7 +169,7 @@ describe("quickStartIssue", () => {
     ).resolves.toEqual({ taskId: "task-w", workspaceTaskId: "main-1" })
     expect(rpc).toHaveBeenCalledWith("task.ensureMain", { repo: "/u/p/kobe" })
     expect(addTab).toHaveBeenCalledWith("main-1", "task-w")
-    expect(sendPtyText).toHaveBeenCalledWith("tab-w", "task-w", quickStartPrompt(target, "kobe api"))
+    expect(sendPtyText).toHaveBeenCalledWith("tab-w", "task-w", issueWorktreePrompt(target, "kobe api", displayProductName()))
     expect(rpc).toHaveBeenCalledWith("task.setActive", { taskId: "main-1" })
     expect(ensureEngineTab).not.toHaveBeenCalled()
     vi.unstubAllGlobals()
@@ -189,7 +192,7 @@ describe("quickStartIssue", () => {
     expect(rpc).not.toHaveBeenCalledWith("task.create", expect.anything())
     expect(rpc).toHaveBeenCalledWith("task.setVendor", { taskId: "main-2", vendor: "claude" })
     expect(addTab).toHaveBeenCalledWith("main-2")
-    expect(sendPtyText).toHaveBeenCalledWith("tab-p", "main-2", projectChatPrompt(target, "kobe api"))
+    expect(sendPtyText).toHaveBeenCalledWith("tab-p", "main-2", issueProjectPrompt(target, "kobe api"))
     const issuesPost = fetchMock.mock.calls.find(
       ([url, opts]) => url === "/api/issues" && (opts as RequestInit | undefined)?.method === "POST",
     )

--- a/packages/kobe-web/test/issues.test.ts
+++ b/packages/kobe-web/test/issues.test.ts
@@ -9,11 +9,8 @@ import {
   groupByStatus,
   type Issue,
   ISSUE_STATUSES,
-  issueMergePrompt,
   issueRepoOptions,
   overviewRows,
-  projectChatPrompt,
-  quickStartPrompt,
   type RepoIssues,
   resolveIssueRepoSelection,
 } from "../src/lib/issues.ts"
@@ -315,64 +312,11 @@ describe("canQuickStart", () => {
   })
 })
 
-describe("quickStartPrompt", () => {
-  it("contains the issue reference, title, body, and done instruction", () => {
-    const prompt = quickStartPrompt(
-      issue({
-        id: 42,
-        title: "Wire the flux capacitor",
-        body: "It needs 1.21 gigawatts.\nSee the schematic.",
-      }),
-    )
-    expect(prompt).toContain("user story #42")
-    expect(prompt).toContain("Wire the flux capacitor")
-    expect(prompt).toContain("It needs 1.21 gigawatts.\nSee the schematic.")
-    expect(prompt).toContain("dedicated Rove task session")
-    expect(prompt).toContain("verify the acceptance criteria")
-    expect(prompt).toContain(
-      "merge the task branch back into the current project's main branch",
-    )
-    expect(prompt).toContain(
-      "rove api issue-set-status --repo . --id 42 --status done",
-    )
-    // The caller flips to doing; the prompt must NOT tell the agent to.
-    expect(prompt).not.toContain('"doing"')
-  })
-
-  it("omits the body section when the body is blank", () => {
-    const prompt = quickStartPrompt(issue({ id: 7, title: "T", body: "  " }))
-    expect(prompt).toContain("story #7")
-    expect(prompt).not.toContain("\n\n\n")
-  })
-})
-
-describe("issueMergePrompt", () => {
-  it("asks the linked task to summarize, merge to project main, and mark the issue done", () => {
-    const prompt = issueMergePrompt(issue({ id: 9, title: "Ship it" }))
-    expect(prompt).toContain("Finish user story #9")
-    expect(prompt).toContain("Verify the acceptance criteria")
-    expect(prompt).toContain(
-      "merge this task branch back into the current project's main branch",
-    )
-    expect(prompt).toContain(
-      "rove api issue-set-status --repo . --id 9 --status done",
-    )
-  })
-})
-
-describe("projectChatPrompt", () => {
-  it("frames the story without worktree/merge instructions", () => {
-    const prompt = projectChatPrompt(
-      issue({ id: 9, title: "Tune it", body: "the details" }),
-      "kobe api",
-    )
-    expect(prompt).toContain("Work on user story #9: Tune it")
-    expect(prompt).toContain("the details")
-    expect(prompt).toContain("directly in the project checkout")
-    expect(prompt).not.toContain("task worktree")
-    expect(prompt).not.toContain("merge the task branch")
-    expect(prompt).toContain(
-      "kobe api issue-set-status --repo . --id 9 --status done",
-    )
-  })
-})
+/*
+ * The prompt CONTENT contract moved with its single implementation:
+ * `packages/kobe/test/state/issue-chat.test.ts` covers the shared builders in
+ * `kobe-daemon/prompts/issue-prompts.ts` that this dashboard and the TUI both
+ * call, including a parity assertion that fails if a second copy reappears.
+ * `issues-actions.test.ts` still pins that this file delivers exactly those
+ * strings.
+ */

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -55,7 +55,12 @@ async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, promp
   // improvises verbs and side-channels (2026-08-10: a peer coordination
   // round-trip fell back to a human relay because neither side had the
   // skill's contract in context).
-  return `[ROVE PEER] from "${label}" (task ${senderId} — load the Rove agent skill FIRST (registered as /rove; legacy /kobe installs still work), then reply: \`${api} send ${replyTarget} --prompt "<text>"\`; verb reference: \`${api} schema\`): ${prompt}`
+  // The sender's text goes LAST, whole, after a blank line — never as the
+  // object of this English sentence. A model generates in the language of
+  // the tokens nearest its turn, so wrapping a Chinese prompt in an English
+  // clause pulled replies into English; ending on the sender's own words
+  // removes that pull without changing what the prefix says.
+  return `[ROVE PEER] from "${label}" (task ${senderId} — load the Rove agent skill FIRST (registered as /rove; legacy /kobe installs still work), then reply: \`${api} send ${replyTarget} --prompt "<text>"\`; verb reference: \`${api} schema\`)\n\n${prompt}`
 }
 
 export async function issueUpdate(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/state/issue-chat.ts
+++ b/packages/kobe/src/state/issue-chat.ts
@@ -18,9 +18,19 @@
  */
 
 import type { Issue } from "@sma1lboy/kobe-daemon/daemon/issues-store"
+import {
+  issueProjectPrompt as buildIssueProjectPrompt,
+  issueWorktreePrompt as buildIssueWorktreePrompt,
+} from "@sma1lboy/kobe-daemon/prompts/issue-prompts"
+import { ROVE_PRODUCT_NAME } from "../product.ts"
 import { attachmentLabel } from "../tui/lib/attachments"
 
 export type IssueChatPlacement = "worktree" | "projectWorktree" | "project"
+
+/** Capitalized product name ("Rove") — mirror of kobe-web's `cli-name.ts`. */
+function displayProductName(): string {
+  return ROVE_PRODUCT_NAME.charAt(0).toUpperCase() + ROVE_PRODUCT_NAME.slice(1)
+}
 
 /** Next `images[N]:`/`pdf[N]:` placeholder index in a body draft. */
 export function nextPlaceholderIndex(body: string): number {
@@ -53,31 +63,15 @@ export function issueChatTaskTitle(issue: Issue): string {
   return `#${issue.id} ${issue.title}`
 }
 
-function promptHeader(issue: Issue): string[] {
-  const lines = [`Work on user story #${issue.id}: ${issue.title}`, ""]
-  const body = issue.body.trim()
-  if (body) lines.push(body, "")
-  return lines
-}
-
-/** First message for a worktree-task session (web quickStartPrompt parity). */
+/**
+ * Re-exports of the shared builders in `kobe-daemon/prompts/issue-prompts` —
+ * the exact text the web board sends, built once. Thin wrappers so the TUI's
+ * call sites keep their `api`-defaulted signature.
+ */
 export function issueWorktreePrompt(issue: Issue, api = "rove api"): string {
-  return [
-    ...promptHeader(issue),
-    "Treat this as the story's dedicated Rove task session: work only in this task worktree, and preserve any repo init instructions already delivered to the session.",
-    "Before finishing, verify the acceptance criteria implied by the story and summarize what changed plus any verification still needed.",
-    "Then merge the task branch back into the current project's main branch after the worktree is clean and checks pass.",
-    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
-  ].join("\n")
+  return buildIssueWorktreePrompt(issue, api, displayProductName())
 }
 
-/** First message for a chat directly on the project checkout — no worktree,
- *  so the worktree/merge instructions are replaced with a stay-put note. */
 export function issueProjectPrompt(issue: Issue, api = "rove api"): string {
-  return [
-    ...promptHeader(issue),
-    "You are working directly in the project checkout — no dedicated worktree or branch was created. Keep changes reviewable and do not switch branches unless asked.",
-    "Before finishing, verify the acceptance criteria implied by the story and summarize what changed plus any verification still needed.",
-    `When the work lands, run: ${api} issue-set-status --repo . --id ${issue.id} --status done`,
-  ].join("\n")
+  return buildIssueProjectPrompt(issue, api)
 }

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -301,7 +301,25 @@ describe("send handler", () => {
       // The self-teach pointer: a receiver that has never seen kobe learns
       // where the rest of the coordination verbs live.
       expect(calls[0].prompt).toContain("Rove agent skill")
-      expect(calls[0].prompt).toMatch(/: hi$/)
+      // The sender's text is LAST and whole, after a blank line — not the
+      // object of the provenance sentence. A model generates in the language
+      // of the tokens nearest its turn, so a non-English prompt wrapped in an
+      // English clause came back in English.
+      expect(calls[0].prompt).toMatch(/\)\n\nhi$/)
+    })
+
+    it("keeps a non-English prompt intact and last, so nothing follows it", async () => {
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("send", ["--task-id", "abc", "--prompt", "帮我重构登录模块"], {
+        client: peerClient(),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt.endsWith("帮我重构登录模块")).toBe(true)
+      // The prompt is not spliced into the sentence: everything before it is
+      // provenance, and the last thing the receiver reads is the sender's own words.
+      const [provenance, ...rest] = calls[0].prompt.split("\n\n")
+      expect(rest.join("\n\n")).toBe("帮我重构登录模块")
+      expect(provenance).not.toContain("帮我重构登录模块")
     })
 
     it("--plain sends verbatim", async () => {

--- a/packages/kobe/test/daemon/handlers-notes.test.ts
+++ b/packages/kobe/test/daemon/handlers-notes.test.ts
@@ -37,6 +37,25 @@ describe("note.file", () => {
     expect((delivered?.payload as { text: string }).text).toContain("build needs --no-sandbox")
   })
 
+  it("relays the note text LAST and whole, not as the tail of the provenance sentence", async () => {
+    const { ctx, rec } = fakeCtx({
+      getTask: (id: string) => (id === "t1" ? TASK : undefined),
+      listTasks: () => [MAIN, TASK],
+    })
+    await dispatch("note.file", { taskId: "t1", text: "构建要先跑 bun install" }, ctx)
+
+    const delivered = rec.published.find((p) => p.channel === "session.deliver")
+    const text = (delivered?.payload as { text: string }).text
+    // The dispatcher reads the note in the filing session's own language: a
+    // model generates in the language of the tokens nearest its turn, so a
+    // note appended to an English clause came back in English.
+    expect(text.endsWith("构建要先跑 bun install")).toBe(true)
+    const [provenance, ...rest] = text.split("\n\n")
+    expect(rest.join("\n\n")).toBe("构建要先跑 bun install")
+    expect(provenance).toContain("[ROVE FIELD NOTE]")
+    expect(provenance).not.toContain("构建要先跑")
+  })
+
   it("still persists when there is no dispatcher seat — an unrouted note is no longer a loss", async () => {
     const { ctx, rec } = fakeCtx({ getTask: () => TASK, listTasks: () => [TASK] })
     const result = await dispatch("note.file", { taskId: "t1", text: "flaky auth test" }, ctx)

--- a/packages/kobe/test/state/issue-chat.test.ts
+++ b/packages/kobe/test/state/issue-chat.test.ts
@@ -1,6 +1,8 @@
 /**
- * Pins the issue-chat first-prompt contract (state/issue-chat.ts) — web
- * quick-start parity: both prompts frame the story (#id + title + body) and
+ * Pins the issue-chat prompt contract — the shared builders in
+ * `kobe-daemon/prompts/issue-prompts.ts` that BOTH the TUI
+ * (state/issue-chat.ts) and the web board (kobe-web/src/lib/issues.ts) send.
+ * Both prompts frame the story (#id + title + body) and
  * end with the daemon-owned `issue-set-status … done` instruction; the
  * worktree prompt carries the worktree/merge discipline, the project prompt
  * replaces it with the stay-on-checkout note. A drift here changes what
@@ -8,6 +10,11 @@
  */
 
 import type { Issue } from "@sma1lboy/kobe-daemon/daemon/issues-store"
+import {
+  issueMergePrompt,
+  issueProjectPrompt as sharedProjectPrompt,
+  issueWorktreePrompt as sharedWorktreePrompt,
+} from "@sma1lboy/kobe-daemon/prompts/issue-prompts"
 import { describe, expect, test } from "vitest"
 import {
   ISSUE_CHAT_PLACEMENTS,
@@ -47,6 +54,29 @@ describe("issue-chat prompts", () => {
     expect(prompt).not.toContain("task worktree")
     expect(prompt).not.toContain("merge the task branch")
     expect(prompt).toContain("rove api issue-set-status --repo . --id 7 --status done")
+  })
+
+  test("the TUI wrapper is the shared builder verbatim — one implementation, two surfaces", () => {
+    // Before the dedup the TUI and the web board each kept their own copy of
+    // this wording and they had already drifted (the web copy interpolated
+    // the product name, the TUI copy hard-coded it). This fails the moment a
+    // second implementation reappears on either side.
+    expect(issueWorktreePrompt(story, "rove api")).toBe(sharedWorktreePrompt(story, "rove api", "Rove"))
+    expect(issueProjectPrompt(story, "rove api")).toBe(sharedProjectPrompt(story, "rove api"))
+  })
+
+  test("the product name is interpolated, not hard-coded", () => {
+    // The drift the dedup fixed: a caller passing its own display name must
+    // see it, which a hard-coded "Rove" would silently swallow.
+    expect(sharedWorktreePrompt(story, "rove api", "Kobe")).toContain("dedicated Kobe task session")
+  })
+
+  test("merge prompt: finish framing, merge to project main, done instruction", () => {
+    const prompt = issueMergePrompt({ ...story, id: 9, title: "Ship it" }, "rove api")
+    expect(prompt).toContain("Finish user story #9: Ship it")
+    expect(prompt).toContain("Verify the acceptance criteria")
+    expect(prompt).toContain("merge this task branch back into the current project's main branch")
+    expect(prompt).toContain("rove api issue-set-status --repo . --id 9 --status done")
   })
 
   test("a blank body leaves no dangling blank section", () => {


### PR DESCRIPTION
Trimmed from the original i18n PR to the two fixes that stand on their own, independent of how we handle language. The `promptLocale` setting is gone — it was the wrong shape (a switch the user would have to flip to get behavior they already asked for), and the direction changed after review.

## 1. Story prompts: one implementation

The TUI (`kobe/src/state/issue-chat.ts`) and the web board (`kobe-web/src/lib/issues.ts`) each kept a hand-written copy of the prompt sent when you start a session from a story. They had **already drifted**: the web copy interpolated the product name, the TUI copy hard-coded `"Rove"`. Same action, different text depending on where you started it.

Both now call one builder in `kobe-daemon/src/prompts/issue-prompts.ts` — the package both surfaces can reach. `kobe-web/src/lib/issues.ts` drops 484 → 441 lines.

A parity test asserts the TUI wrapper is byte-identical to the shared builder, plus one that fails if the product name goes back to being hard-coded — the exact drift this removes.

## 2. Peer messages end with the sender's own words

`[ROVE PEER]` and `[ROVE FIELD NOTE]` spliced the sender's text into the tail of an English sentence:

```
[ROVE PEER] from "x" (task y — load the skill FIRST …): <your message>
```

A model generates in the language of the tokens nearest its turn, so a Chinese message arriving as the object of an English clause came back in English. Now:

```
[ROVE PEER] from "x" (task y — load the skill FIRST …)

<your message, whole, last>
```

Nothing about what the prefix *says* changed — only where the sender's text sits. `[ROVE FIELD NOTE]` had the identical shape and got the identical fix; its relay had no shape test before, so one was added.

## Verification

Real verb path (`invokeVerb("send", …)` with a primed verified session — production code, not a stub of it):

```
[ROVE PEER] from "登录重构" (task sender-1 — load the Rove agent skill FIRST …)

这条消息应该原样留在最后
```

**Every new test was mutation-checked** — implementation reverted, test confirmed red, implementation restored:
- peer restructure → 2 tests red on revert
- field-note restructure → 1 test red on revert
- product-name interpolation → 1 test red when re-hard-coded

Suites: kobe-daemon 601/601, render 240/0, web 559/561, kobe fast 3585 passed. The failures (62 in `test/cli/*`, 2 in web routes) reproduce identically on a clean checkout of this same main — pre-existing, not from this change.

## Not in this PR

Two follow-ups, deliberately separate:
- **Per-task observed language** for the four async injection points (missing-deps, quota-resume, PR prompt, handoff) that have no user text in hand at injection time.
- **Moving the branch-rename coda and spawner report format into the skill.** The spawner one is a pure deletion — SKILL.md already carries it at lines 261 and 419-425.