### PR TITLE
fix: let each engine own its session id and resume verb

### DIFF
--- a/.changeset/engine-owned-session-identity.md
+++ b/.changeset/engine-owned-session-identity.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Every engine now answers "what is my session id" and "how do I resume it" for itself, so a restart reconnects a kimi or wrapper-engine tab to its conversation instead of opening a blank one.
+
+Session identity was hard-coded to Claude in two places: the launch pinned an id only when the vendor was literally named `claude`, and the restart path always appended Claude's `--resume` flag. Kimi tabs therefore never recorded an id at all — and neither did custom wrapper engines like a `claudecpa` preset, which is a Claude launch under another name. Each engine now declares its own session verbs (`engine/session-identity.ts`): Claude pins `--session-id` and resumes with `--resume`, Codex resumes through its `resume` subcommand, and Kimi — whose CLI can only reopen an existing session, never name a new one — has its id discovered from its session store after the fact and resumes with `-S`. A custom preset inherits the verbs of the protocol it declares. An engine with no resume verb starts a fresh conversation honestly rather than being passed a flag that would kill its launch.
+
+Also fixes the restart existence check, which asked whether Rove could parse a session's messages rather than whether the session existed — so engines that ship no message parser reported every conversation as absent.

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -7,8 +7,8 @@
  */
 
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { engineLaunchArgv } from "../../engine/engine-presets.ts"
-import { withClaudeSessionId } from "../../engine/interactive-command.ts"
+import { engineLaunchArgv, withPinnedSessionId } from "../../engine/engine-presets.ts"
+
 import { buildEngineSessionLaunch } from "../../engine/session-launch.ts"
 import { trustEngineWorktree } from "../../engine/trust-worktree.ts"
 import { type DaemonRpc, resolveActiveTaskId } from "../daemon-session.ts"
@@ -71,12 +71,14 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
     // only; the task's own engine is left alone.
     const launchVendor = target.tabVendor ?? target.vendor
     const launchCommand = target.tabCommand ?? (target.tabVendor ? undefined : target.command)
-    // Pin the conversation's session id up front (claude only — the same
-    // `withClaudeSessionId` contract the TUI launches with), so a LATER
-    // reattach after a pty-host restart can resume THIS conversation
-    // instead of opening a blank one. The id lands in the persisted tab
-    // snapshot below once the session actually started.
-    const { argv, sessionId } = withClaudeSessionId(
+    // Pin the conversation's session id up front when the engine accepts
+    // one (the same `withPinnedSessionId` contract the TUI launches with),
+    // so a LATER reattach after a pty-host restart can resume THIS
+    // conversation instead of opening a blank one. Engines that mint their
+    // own id (kimi/codex) answer null here and are discovered post-spawn
+    // instead. The id lands in the persisted tab snapshot below once the
+    // session actually started.
+    const { argv, sessionId } = withPinnedSessionId(
       engineLaunchArgv({ command: launchCommand, vendor: launchVendor, effort: target.modelEffort }),
       launchVendor,
     )

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -1,0 +1,182 @@
+/**
+ * The BUILT-IN engine table — the four first-party adapters' wiring, as
+ * data. Split out of `registry.ts` (the ~500-line cap); the module doc
+ * there explains what an entry means and why neutral layers must go
+ * through `engineEntry` instead of reaching in here.
+ *
+ * Adding a built-in engine = one entry here plus its `*-local/` modules.
+ * The entry TYPE stays in `registry.ts` (imported type-only, so the pair is
+ * not a runtime cycle) — same shape as `history-readers.ts` and
+ * `contrib-engines.ts`.
+ *
+ * Must stay importable from vitest and MUST NOT import from `src/tui/`.
+ */
+
+import {
+  type ClaudeAccount,
+  type CodexAccount,
+  type CopilotAccount,
+  type DetectDeps,
+  type EngineAccountStatus,
+  type KimiAccount,
+  detectClaudeAccount,
+  detectCodexAccount,
+  detectCopilotAccount,
+  detectKimiAccount,
+} from "./account-detect.ts"
+import { claudeCapabilities, claudeIdentity } from "./claude-code-local/capabilities.ts"
+import { ClaudeHookAdapter } from "./claude-code-local/hook-adapter.ts"
+import { fetchClaudeQuotaUsage } from "./claude-code-local/quota.ts"
+import { CLAUDE_SCREEN_MANIFEST } from "./claude-code-local/screen.ts"
+import { trustClaudeWorktree } from "./claude-code-local/trust.ts"
+import { readClaudeTurns } from "./claude-code-local/turns.ts"
+import { codexCapabilities, codexIdentity } from "./codex-local/capabilities.ts"
+import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
+import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
+import { CODEX_SCREEN_MANIFEST } from "./codex-local/screen.ts"
+import { codexSessionIdFromTitle } from "./codex-local/terminal-title.ts"
+import { trustCodexWorktree } from "./codex-local/trust.ts"
+import { COPILOT_SCREEN_MANIFEST } from "./copilot-local/screen.ts"
+import {
+  EMPTY_HISTORY,
+  claudeHistoryReader,
+  codexHistoryReader,
+  copilotHistoryReader,
+  kimiHistoryReader,
+} from "./history-readers.ts"
+import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
+import { KimiHookAdapter } from "./kimi-local/hook-adapter.ts"
+import { KIMI_SCREEN_MANIFEST } from "./kimi-local/screen.ts"
+import { trustKimiWorktree } from "./kimi-local/trust.ts"
+// Type-only, so the registry↔table pair is not a runtime cycle.
+import type { EngineRegistryEntry } from "./registry.ts"
+import { ClaudeTurnDetector, CodexTurnDetector, UnknownTurnDetector } from "./turn-detector.ts"
+
+/** The first-party entries — registered here and nowhere else. */
+export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineRegistryEntry> = {
+  claude: {
+    vendor: "claude",
+    builtin: true,
+    // The adapter's EngineIdentity is the source of truth for name copy
+    // (AGENTS.md: engine-owned UI data); displayName is the resolved view
+    // every neutral layer reads via engineDisplayName().
+    displayName: claudeIdentity.shortName,
+    defaultCommand: ["claude"],
+    history: claudeHistoryReader,
+    detectAccount: (deps) => detectClaudeAccount(deps),
+    createHookAdapter: () => new ClaudeHookAdapter(),
+    createTurnDetector: () => new ClaudeTurnDetector(),
+    capabilities: claudeCapabilities,
+    identity: claudeIdentity,
+    trustWorktree: trustClaudeWorktree,
+    terminalTitle: {
+      ownsStatus: true,
+      // `${prefix} ${title}` where prefix is ✳ at rest and cycles through
+      // animated frames while a turn runs (`AnimatedTerminalTitle`).
+      statusPrefixes: ["✳", "⠂", "⠐", "◐", "◑"],
+      workingPrefixes: ["⠂", "⠐", "◐", "◑"],
+    },
+    // Claude is the one engine that lets the CALLER name a new session, so
+    // Rove pins a fresh uuid at launch and the tab is trackable from its
+    // first frame. `--session-id <uuid>` is documented; the control flags
+    // are every documented way a command can already own its session —
+    // appending a second one makes claude refuse to launch (issue #58).
+    sessionIdentity: {
+      pinFlag: "--session-id",
+      sessionControlFlags: ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"],
+      resumeArgv: (base, id) => [...base, "--resume", id],
+    },
+    quotaUsage: () => fetchClaudeQuotaUsage(),
+    readTurns: readClaudeTurns,
+    screenManifest: CLAUDE_SCREEN_MANIFEST,
+  },
+  codex: {
+    vendor: "codex",
+    builtin: true,
+    displayName: codexIdentity.shortName,
+    defaultCommand: ["codex"],
+    // Effort levels real `codex exec` accepts (the broken `minimal` is
+    // deliberately excluded — CHANGELOG 0.5.17).
+    effortLevels: ["none", "low", "medium", "high", "xhigh"],
+    history: codexHistoryReader,
+
+    detectAccount: (deps) => detectCodexAccount(deps),
+    createHookAdapter: () => new CodexHookAdapter(),
+    createTurnDetector: () => new CodexTurnDetector(),
+    capabilities: codexCapabilities,
+    identity: codexIdentity,
+    trustWorktree: trustCodexWorktree,
+    screenManifest: CODEX_SCREEN_MANIFEST,
+    // Codex's default is activity + project-name, which makes every tab in
+    // one repo say "rove". Keep its native activity state, but ask Codex to
+    // pair it with the thread title it already owns in its local store.
+    terminalTitle: {
+      ownsStatus: true,
+      launchArgs: ["-c", 'tui.terminal_title=["activity","thread-title"]'],
+      // The `activity` segment is a braille spinner frame joined to the next
+      // segment by a space (codex `TERMINAL_TITLE_SPINNER_FRAMES` +
+      // `separator_from_previous`). It only appears while a turn runs, so a
+      // resting title has no prefix to strip — every status prefix is a
+      // working prefix.
+      statusPrefixes: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+      workingPrefixes: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+      // `thread-title` falls back to the thread ID until codex names the
+      // thread, so that title is usually a bare UUID. The id names the
+      // rollout the tab's first prompt lives in, which is what Rove shows
+      // instead — see `codex-local/terminal-title.ts`.
+      sessionIdFromTitle: codexSessionIdFromTitle,
+    },
+    // No pin flag — codex mints its own thread id and reports it in the OSC
+    // title (see `terminalTitle.sessionIdFromTitle`), which is origin (2) in
+    // `session-identity.ts`. Resume is a SUBCOMMAND with the id positional
+    // (`codex resume [OPTIONS] [SESSION_ID]`, probed 2026-08-29), so the
+    // launch flags stay between the verb and the id.
+    sessionIdentity: {
+      resumeArgv: (base, id) => {
+        const [bin, ...rest] = base
+        return bin ? [bin, "resume", ...rest, id] : base
+      },
+    },
+    quotaUsage: () => fetchCodexQuotaUsage(),
+  },
+  copilot: {
+    vendor: "copilot",
+    builtin: true,
+    displayName: "Copilot",
+    defaultCommand: ["copilot"],
+    history: copilotHistoryReader,
+    detectAccount: (deps) => detectCopilotAccount(deps),
+    createHookAdapter: () => new NoopHookAdapter("copilot"),
+    // Copilot persists no turn-completion marker kobe can read yet.
+    createTurnDetector: () => new UnknownTurnDetector("copilot"),
+    screenManifest: COPILOT_SCREEN_MANIFEST,
+  },
+  kimi: {
+    vendor: "kimi",
+    builtin: true,
+    displayName: "Kimi",
+    defaultCommand: ["kimi"],
+    // kimi's positional CLI slot is a subcommand (export/provider/acp/…),
+    // not an initial prompt — argv delivery kills it (issue #25).
+    firstMessageDelivery: "paste",
+    // The installed Mach-O binary rewrites its process title to `kimi-co`
+    // after launch, so a live kimi session's argv[0] never reads `kimi`.
+    processNames: ["kimi-co"],
+    trustWorktree: trustKimiWorktree,
+    history: kimiHistoryReader,
+    detectAccount: (deps) => detectKimiAccount(deps),
+    createHookAdapter: () => new KimiHookAdapter(),
+    createTurnDetector: () => new UnknownTurnDetector("kimi"),
+    // Kimi cannot be TOLD what to call a new session — `-S [id]` only
+    // resumes an existing one (probed 2026-08-29: "Resume a session. With
+    // ID: resume that session. Without ID: interactively pick."). So its id
+    // is origin (3): discovered after the fact from the session store this
+    // entry's `history` reader already indexes by worktree. `-c/--continue`
+    // and `-S` both mean the user's command owns the session already.
+    sessionIdentity: {
+      sessionControlFlags: ["-S", "--session", "-c", "--continue"],
+      resumeArgv: (base, id) => [...base, "-S", id],
+    },
+    screenManifest: KIMI_SCREEN_MANIFEST,
+  },
+}

--- a/packages/kobe/src/engine/engine-presets.ts
+++ b/packages/kobe/src/engine/engine-presets.ts
@@ -29,6 +29,7 @@
  * (that module stays state-free so vitest and the daemon can import it).
  */
 
+import { randomUUID } from "node:crypto"
 import { engineEntry } from "@/engine/registry"
 import { getCustomEngineIds, getPersistedString } from "@/state/repos"
 import { BUILTIN_VENDORS, type VendorId, isBuiltinVendor } from "@/types/vendor"
@@ -42,6 +43,7 @@ import {
   withEngineEffort,
   withEngineTerminalTitle,
 } from "./interactive-command.ts"
+import { acceptsPinnedSession, pinSessionArgv, resumeSessionArgv } from "./session-identity.ts"
 
 /**
  * The protocol id for "kobe cannot name this engine". Deliberately not a
@@ -189,4 +191,53 @@ function presetBaseArgv(id: string): readonly string[] | null {
 /** The launch binary a delivery gate should match this spec's engine by. */
 export function engineLaunchBin(spec: EngineLaunchSpec): string | undefined {
   return engineLaunchArgv(spec)[0]
+}
+
+/**
+ * The engine whose SESSION VERBS apply to a launch of `id` — its declared
+ * protocol when it is a custom preset, else the id itself.
+ *
+ * The same rule `engineLaunchArgv` already uses for codex's effort and
+ * terminal-title flags, applied to session identity: a preset `claudecpa`
+ * declaring the claude protocol IS a claude launch, so it takes claude's
+ * `--session-id` / `--resume`. Keying off the id instead would find the
+ * empty custom entry and silently drop both — which is exactly what the old
+ * `withClaudeSessionId` did with its literal `vendor === "claude"` check,
+ * and why every wrapper engine lost its conversation on restart.
+ */
+export function sessionProtocol(vendor: VendorId | undefined): VendorId {
+  const id = vendor?.trim()
+  if (!id) return "claude"
+  return getEngineProtocol(id) ?? id
+}
+
+/**
+ * Argv that PINS a fresh session id, plus the id itself — or
+ * `{ argv, sessionId: null }` when this engine mints its own id
+ * (codex/kimi/custom) or the command already controls its session.
+ * `newId` is a seam for the tab path, which re-pins an id it already holds.
+ */
+export function withPinnedSessionId(
+  argv: readonly string[],
+  vendor: VendorId | undefined,
+  newId: () => string = randomUUID,
+): { argv: readonly string[]; sessionId: string | null } {
+  const identity = engineEntry(sessionProtocol(vendor)).sessionIdentity
+  if (!acceptsPinnedSession(identity, argv)) return { argv, sessionId: null }
+  const sessionId = newId()
+  return { argv: pinSessionArgv(identity, argv, sessionId), sessionId }
+}
+
+/**
+ * Argv that RESUMES `sessionId`, or null when the engine declares no resume
+ * verb / the command already controls its own session. The caller then
+ * launches the bare command — a fresh conversation, honestly, rather than a
+ * flag that would kill the launch (kimi exits on claude's `--resume`).
+ */
+export function engineResumeArgv(
+  base: readonly string[],
+  vendor: VendorId | undefined,
+  sessionId: string,
+): readonly string[] | null {
+  return resumeSessionArgv(engineEntry(sessionProtocol(vendor)).sessionIdentity, base, sessionId)
 }

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -23,9 +23,9 @@
  * the built-in default.
  */
 
-import { randomUUID } from "node:crypto"
 import { kobeCliInvocation } from "@/cli/invocation"
 import { engineEntry } from "@/engine/registry"
+import { controlsOwnSession } from "@/engine/session-identity"
 import { autoStatusEnabled } from "@/state/auto-status"
 import { dispatcherEnabled } from "@/state/dispatcher"
 import { getPersistedString } from "@/state/repos"
@@ -188,38 +188,14 @@ export function argvHasFlag(argv: readonly string[], flag: string): boolean {
 }
 
 /**
- * Claude flags that already pin / fork the conversation's session. If the
- * launch command carries one of these, we must NOT also append our own
- * `--session-id` (claude would reject two, or our id would lose to the
- * resumed one). Covers both long and short forms.
+ * `withClaudeSessionId` lived here (removed 2026-08-29). Its first line was
+ * `coerceVendorId(vendor) !== "claude"`, so only an engine literally NAMED
+ * claude ever got a session id — kimi tabs and custom wrappers (`claudecpa`)
+ * silently got none and lost their conversation on every restart. The pin
+ * flag, the "already controls its own session" flags, and the resume verb
+ * are now DECLARED by each engine (`engine/session-identity.ts`) and read
+ * through `withPinnedSessionId` / `engineResumeArgv` in `registry.ts`.
  */
-const CLAUDE_SESSION_CONTROL_FLAGS = ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"] as const
-
-/** The command already controls its own claude session (either flag form). */
-function pinsClaudeSession(argv: readonly string[]): boolean {
-  return CLAUDE_SESSION_CONTROL_FLAGS.some((flag) => argvHasFlag(argv, flag))
-}
-
-/**
- * For a Claude launch, append a kobe-generated `--session-id <uuid>` so the
- * hosted session can be mapped to its transcript (recorded as the
- * `@kobe_session_id` window option) and auto-named from its first prompt
- * (KOB — per-tab naming). Returns `{ argv, sessionId }` where `sessionId`
- * is the forced UUID, or `null` when not applicable:
- *   - the vendor isn't Claude (Codex/Copilot can't take a caller-set id), or
- *   - the command already controls its session (`--resume`/`--continue`/…).
- * `--session-id` is a documented Claude flag (`<uuid>` required); we leave a
- * non-default custom command that pins its own session untouched.
- */
-export function withClaudeSessionId(
-  argv: readonly string[],
-  vendor: string | undefined,
-): { argv: readonly string[]; sessionId: string | null } {
-  if (coerceVendorId(vendor) !== "claude") return { argv, sessionId: null }
-  if (pinsClaudeSession(argv)) return { argv, sessionId: null }
-  const sessionId = randomUUID()
-  return { argv: [...argv, "--session-id", sessionId], sessionId }
-}
 
 /**
  * Engines whose CLI can BRANCH a conversation into a new session. Probed
@@ -249,7 +225,7 @@ export function canForkSession(vendor: VendorId | undefined): boolean {
  * Returns null when the vendor has no fork verb (copilot/custom), there is
  * no source id, or a claude base already controls its own session (a second
  * `--resume` would make claude refuse to launch — the user's override wins,
- * the {@link withClaudeSessionId} precedent) — the caller then opens an
+ * the user-flag-wins precedent) — the caller then opens an
  * ordinary tab on the base command.
  */
 export function forkSessionArgv(
@@ -261,7 +237,7 @@ export function forkSessionArgv(
   if (!sourceSessionId) return null
   const v: VendorId = coerceVendorId(vendor)
   if (v === "claude") {
-    if (pinsClaudeSession(base)) return null
+    if (controlsOwnSession(engineEntry(v).sessionIdentity, base)) return null
     const forked = [...base, "--resume", sourceSessionId, "--fork-session"]
     return newSessionId ? [...forked, "--session-id", newSessionId] : forked
   }
@@ -390,8 +366,7 @@ export function worktreeProtocol(
  * Gates, in order: there is a task to report, the launch targets claude
  * (other vendors have no equivalent flag yet — their cards move by hand
  * until their adapters grow an injection point), a custom command that
- * already sets the flag is left alone (the {@link withClaudeSessionId}
- * precedent), and at least one protocol switch is on.
+ * already sets the flag is left alone (the user-flag-wins precedent), and at least one protocol switch is on.
  */
 export function withWorktreeProtocol(
   argv: readonly string[],

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -28,45 +28,21 @@
 
 import type { EngineCapabilities, EngineIdentity, EngineQuotaUsage, Message } from "@/types/engine"
 import { type VendorId, isBuiltinVendor } from "@/types/vendor"
-import {
-  type ClaudeAccount,
-  type CodexAccount,
-  type CopilotAccount,
-  type DetectDeps,
-  type EngineAccountStatus,
-  type KimiAccount,
-  detectClaudeAccount,
-  detectCodexAccount,
-  detectCopilotAccount,
-  detectKimiAccount,
+import type {
+  ClaudeAccount,
+  CodexAccount,
+  CopilotAccount,
+  DetectDeps,
+  EngineAccountStatus,
+  KimiAccount,
 } from "./account-detect.ts"
 import type { EngineTurnReader } from "./agent-turn.ts"
-import { claudeCapabilities, claudeIdentity } from "./claude-code-local/capabilities.ts"
-import { ClaudeHookAdapter } from "./claude-code-local/hook-adapter.ts"
-import { fetchClaudeQuotaUsage } from "./claude-code-local/quota.ts"
-import { CLAUDE_SCREEN_MANIFEST } from "./claude-code-local/screen.ts"
-import { trustClaudeWorktree } from "./claude-code-local/trust.ts"
-import { readClaudeTurns } from "./claude-code-local/turns.ts"
-import { codexCapabilities, codexIdentity } from "./codex-local/capabilities.ts"
-import { CodexHookAdapter } from "./codex-local/hook-adapter.ts"
-import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
-import { CODEX_SCREEN_MANIFEST } from "./codex-local/screen.ts"
-import { codexSessionIdFromTitle } from "./codex-local/terminal-title.ts"
-import { trustCodexWorktree } from "./codex-local/trust.ts"
+import { BUILTIN_ENGINES } from "./builtin-engines.ts"
 import { contribEngineEntry, isContribEngine } from "./contrib-engines.ts"
-import { COPILOT_SCREEN_MANIFEST } from "./copilot-local/screen.ts"
-import {
-  EMPTY_HISTORY,
-  claudeHistoryReader,
-  codexHistoryReader,
-  copilotHistoryReader,
-  kimiHistoryReader,
-} from "./history-readers.ts"
+import { EMPTY_HISTORY } from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
-import { KimiHookAdapter } from "./kimi-local/hook-adapter.ts"
-import { KIMI_SCREEN_MANIFEST } from "./kimi-local/screen.ts"
-import { trustKimiWorktree } from "./kimi-local/trust.ts"
 import type { EngineScreenManifest } from "./screen-state.ts"
+import type { EngineSessionIdentity } from "./session-identity.ts"
 import {
   type EngineTerminalTitle,
   stripStatusPrefix,
@@ -74,7 +50,8 @@ import {
   titleSessionId,
   titleTurnHint,
 } from "./terminal-title.ts"
-import { ClaudeTurnDetector, CodexTurnDetector, type EngineTurnDetector, UnknownTurnDetector } from "./turn-detector.ts"
+import type { EngineTurnDetector } from "./turn-detector.ts"
+import { UnknownTurnDetector } from "./turn-detector.ts"
 
 /**
  * Reader over an engine's on-disk transcript store, in the neutral shape
@@ -160,6 +137,14 @@ export interface EngineRegistryEntry {
    */
   readonly terminalTitle?: EngineTerminalTitle
   /**
+   * How this engine's CLI handles session identity — the flag that pins a
+   * caller-set id, the flags that mean the command already controls its own
+   * session, and the argv that resumes one (see `session-identity.ts`,
+   * which owns the shape and every rule that reads it). Absent = Rove knows
+   * no session verbs for this engine.
+   */
+  readonly sessionIdentity?: EngineSessionIdentity
+  /**
    * Subscription-quota probe: snapshot of the account's usage windows, or
    * null when unknowable. Drives the daemon's rate-limit auto-resume
    * schedule and the Settings usage dashboard. The probe hits the vendor's
@@ -222,104 +207,6 @@ export interface EngineRegistryEntry {
 // EMPTY_HISTORY is re-exported so `@/engine/registry` stays the one
 // import site for the whole registry surface.
 export { EMPTY_HISTORY }
-
-/** The first-party entries — registered here and nowhere else. */
-const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", EngineRegistryEntry> = {
-  claude: {
-    vendor: "claude",
-    builtin: true,
-    // The adapter's EngineIdentity is the source of truth for name copy
-    // (AGENTS.md: engine-owned UI data); displayName is the resolved view
-    // every neutral layer reads via engineDisplayName().
-    displayName: claudeIdentity.shortName,
-    defaultCommand: ["claude"],
-    history: claudeHistoryReader,
-    detectAccount: (deps) => detectClaudeAccount(deps),
-    createHookAdapter: () => new ClaudeHookAdapter(),
-    createTurnDetector: () => new ClaudeTurnDetector(),
-    capabilities: claudeCapabilities,
-    identity: claudeIdentity,
-    trustWorktree: trustClaudeWorktree,
-    terminalTitle: {
-      ownsStatus: true,
-      // `${prefix} ${title}` where prefix is ✳ at rest and cycles through
-      // animated frames while a turn runs (`AnimatedTerminalTitle`).
-      statusPrefixes: ["✳", "⠂", "⠐", "◐", "◑"],
-      workingPrefixes: ["⠂", "⠐", "◐", "◑"],
-    },
-    quotaUsage: () => fetchClaudeQuotaUsage(),
-    readTurns: readClaudeTurns,
-    screenManifest: CLAUDE_SCREEN_MANIFEST,
-  },
-  codex: {
-    vendor: "codex",
-    builtin: true,
-    displayName: codexIdentity.shortName,
-    defaultCommand: ["codex"],
-    // Effort levels real `codex exec` accepts (the broken `minimal` is
-    // deliberately excluded — CHANGELOG 0.5.17).
-    effortLevels: ["none", "low", "medium", "high", "xhigh"],
-    history: codexHistoryReader,
-
-    detectAccount: (deps) => detectCodexAccount(deps),
-    createHookAdapter: () => new CodexHookAdapter(),
-    createTurnDetector: () => new CodexTurnDetector(),
-    capabilities: codexCapabilities,
-    identity: codexIdentity,
-    trustWorktree: trustCodexWorktree,
-    // Codex's default is activity + project-name, which makes every tab in
-    // one repo say "rove". Keep its native activity state, but ask Codex to
-    // pair it with the thread title it already owns in its local store.
-    screenManifest: CODEX_SCREEN_MANIFEST,
-    terminalTitle: {
-      ownsStatus: true,
-      launchArgs: ["-c", 'tui.terminal_title=["activity","thread-title"]'],
-      // The `activity` segment is a braille spinner frame joined to the next
-      // segment by a space (codex `TERMINAL_TITLE_SPINNER_FRAMES` +
-      // `separator_from_previous`). It only appears while a turn runs, so a
-      // resting title has no prefix to strip — every status prefix is a
-      // working prefix.
-      statusPrefixes: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
-      workingPrefixes: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
-      // `thread-title` falls back to the thread ID until codex names the
-      // thread, so that title is usually a bare UUID. The id names the
-      // rollout the tab's first prompt lives in, which is what Rove shows
-      // instead — see `codex-local/terminal-title.ts`.
-      sessionIdFromTitle: codexSessionIdFromTitle,
-    },
-    quotaUsage: () => fetchCodexQuotaUsage(),
-  },
-  copilot: {
-    vendor: "copilot",
-    builtin: true,
-    displayName: "Copilot",
-    defaultCommand: ["copilot"],
-    history: copilotHistoryReader,
-    detectAccount: (deps) => detectCopilotAccount(deps),
-    createHookAdapter: () => new NoopHookAdapter("copilot"),
-    // Copilot persists no turn-completion marker kobe can read yet.
-    createTurnDetector: () => new UnknownTurnDetector("copilot"),
-    screenManifest: COPILOT_SCREEN_MANIFEST,
-  },
-  kimi: {
-    vendor: "kimi",
-    builtin: true,
-    displayName: "Kimi",
-    defaultCommand: ["kimi"],
-    // kimi's positional CLI slot is a subcommand (export/provider/acp/…),
-    // not an initial prompt — argv delivery kills it (issue #25).
-    firstMessageDelivery: "paste",
-    // The installed Mach-O binary rewrites its process title to `kimi-co`
-    // after launch, so a live kimi session's argv[0] never reads `kimi`.
-    processNames: ["kimi-co"],
-    trustWorktree: trustKimiWorktree,
-    history: kimiHistoryReader,
-    detectAccount: (deps) => detectKimiAccount(deps),
-    createHookAdapter: () => new KimiHookAdapter(),
-    createTurnDetector: () => new UnknownTurnDetector("kimi"),
-    screenManifest: KIMI_SCREEN_MANIFEST,
-  },
-}
 
 /** See module doc: the explicit empty entry for a user-registered engine id. */
 function customEngineEntry(vendor: VendorId): EngineRegistryEntry {

--- a/packages/kobe/src/engine/session-discovery.ts
+++ b/packages/kobe/src/engine/session-discovery.ts
@@ -1,0 +1,64 @@
+/**
+ * Asking an engine's session store two questions a tab needs answered:
+ * "which session is mine?" and "does the one I recorded still exist?".
+ *
+ * Both are the IO half of `session-identity.ts` (which is pure policy), and
+ * both go through `EngineHistoryReader.listSessionIdsForWorktree` — the one
+ * method EVERY built-in implements, including the readers that ship no
+ * message parser.
+ *
+ * That last point is the whole reason this module exists. The existence
+ * check used to be `readHistory(id).length > 0`, which silently means "this
+ * engine has a message parser": kimi's reader is paths-only, so every kimi
+ * tab answered "your session does not exist", never set `spawned`, and
+ * respawned blank on restart even once its id was known. Listing ids is the
+ * question actually being asked, and every engine can answer it.
+ */
+
+import { type VendorId, coerceVendorId } from "../types/vendor.ts"
+import { engineEntry } from "./registry.ts"
+import { pickUnclaimedSessionId } from "./session-identity.ts"
+
+/** Session ids this engine recorded for `worktree`, oldest-first; `[]` on error. */
+async function sessionIds(vendor: VendorId | undefined, worktree: string): Promise<readonly string[]> {
+  if (!worktree) return []
+  try {
+    return await engineEntry(coerceVendorId(vendor)).history.listSessionIdsForWorktree(worktree)
+  } catch {
+    // Readers are best-effort by contract; an unreadable store is "no
+    // evidence", never an error the tab has to handle.
+    return []
+  }
+}
+
+/**
+ * True when `sessionId` is still recorded in this engine's store for
+ * `worktree` — i.e. the tab has a conversation worth resuming.
+ */
+export async function engineSessionExists(
+  vendor: VendorId | undefined,
+  worktree: string,
+  sessionId: string,
+): Promise<boolean> {
+  if (!sessionId) return false
+  return (await sessionIds(vendor, worktree)).includes(sessionId)
+}
+
+/**
+ * The session id to adopt for a tab that has none — the newest one this
+ * engine recorded for `worktree` that no sibling tab already claims, or
+ * null when the store is empty or every session is spoken for.
+ *
+ * This is origin (3) in `session-identity.ts`: the only way to learn the id
+ * of an engine that mints its own and reports it nowhere (kimi). It is
+ * deliberately the LAST resort — a pinned id (claude) or one the engine put
+ * in its own title (codex) is authoritative and never reaches here, because
+ * those tabs already have a `sessionId`.
+ */
+export async function discoverSessionId(
+  vendor: VendorId | undefined,
+  worktree: string,
+  claimed: ReadonlySet<string>,
+): Promise<string | null> {
+  return pickUnclaimedSessionId(await sessionIds(vendor, worktree), claimed)
+}

--- a/packages/kobe/src/engine/session-identity.ts
+++ b/packages/kobe/src/engine/session-identity.ts
@@ -1,0 +1,139 @@
+/**
+ * Session-identity policy — how an engine answers "what is my current
+ * session id" and "how do I resume it", split out of `registry.ts` (the
+ * ~500-line cap) alongside its sibling `terminal-title.ts`.
+ *
+ * Pure on purpose: every function here takes the engine's declared
+ * {@link EngineSessionIdentity} rather than a vendor id, so nothing in this
+ * file names an engine. The vendor-specific KNOWLEDGE (which flag pins an
+ * id, which flag resumes one, whether the id is even knowable at launch) is
+ * declared by the adapter that owns it.
+ *
+ * The id has THREE possible origins, and which one an engine uses is a
+ * property of its CLI, not a choice Rove gets to make:
+ *
+ *   1. PINNED at launch — the CLI accepts a caller-generated id
+ *      (`claude --session-id <uuid>`). Rove knows the id before the process
+ *      exists, so the tab is trackable from its first frame.
+ *   2. READ FROM THE TITLE — the CLI writes its own id into its OSC title
+ *      until it has a name for the thread (codex). Declared on
+ *      `EngineTerminalTitle.sessionIdFromTitle`, not here.
+ *   3. DISCOVERED AFTER THE FACT — the CLI mints its own id and tells no
+ *      one, so the only way to learn it is to look in the engine's session
+ *      store for what appeared under this worktree (kimi). This is the
+ *      weakest source and the one every engine has, because it is exactly
+ *      `EngineHistoryReader.listSessionIdsForWorktree`.
+ *
+ * (3) is why kimi tabs lost their conversation on every restart: with no
+ * pin flag and a title that is a sentence rather than an id, nothing ever
+ * recorded which session a tab belonged to, so the tab respawned blank.
+ */
+
+/**
+ * How an engine's CLI handles session identity. Absent on a registry entry
+ * = Rove knows no session flags for this engine: its tabs are still named
+ * and tracked from whatever id the history store yields, but a restart
+ * opens a fresh conversation because there is no verb to resume with.
+ */
+export interface EngineSessionIdentity {
+  /**
+   * The flag that pins a CALLER-GENERATED session id at launch
+   * (`--session-id <uuid>`), for the engines whose CLI accepts one. Absent
+   * = this engine mints its own id and the tab learns it later (origin 2
+   * or 3 above) — kimi cannot be told what to call a new session, only
+   * asked which sessions exist.
+   */
+  readonly pinFlag?: string
+  /**
+   * Flags meaning "this launch command already controls its own session".
+   * When the user's `engineCommand.<id>` override carries one, Rove must
+   * NOT append its own pin: the engine would either refuse two session
+   * controls or silently resume something other than the id we recorded.
+   * The user's explicit flag always wins.
+   */
+  readonly sessionControlFlags?: readonly string[]
+  /**
+   * Argv that REOPENS `sessionId`'s conversation, given the launch command.
+   * A full-argv rewrite rather than a flag pair because the shapes differ
+   * in kind, not just spelling: claude and kimi take a flag
+   * (`--resume <id>` / `-S <id>`), codex takes a SUBCOMMAND with the id as
+   * a positional (`codex resume [opts] <id>`). Probed against the real
+   * binaries; see each adapter's declaration.
+   *
+   * Absent = this engine has no resume verb Rove knows, so a restarted tab
+   * honestly starts a new conversation instead of passing a flag that
+   * would kill the launch.
+   */
+  readonly resumeArgv?: (base: readonly string[], sessionId: string) => readonly string[]
+}
+
+/**
+ * True when `argv` carries `flag` — in EITHER the separated form
+ * (`--flag value`) or the attached form (`--flag=value`). Kept local rather
+ * than imported from `interactive-command.ts` so this module stays a leaf
+ * with no engine-module dependencies. Prefix-safe: `--resume-x` is not
+ * `--resume`.
+ */
+function hasFlag(argv: readonly string[], flag: string): boolean {
+  return argv.some((a) => a === flag || a.startsWith(`${flag}=`))
+}
+
+/** The launch command already pins or resumes a session of its own. */
+export function controlsOwnSession(identity: EngineSessionIdentity | undefined, argv: readonly string[]): boolean {
+  return (identity?.sessionControlFlags ?? []).some((flag) => hasFlag(argv, flag))
+}
+
+/**
+ * Append the engine's session-pin flag with `sessionId`, or return `argv`
+ * unchanged when this engine takes no pin (kimi/codex/custom) or the
+ * command already controls its session.
+ */
+export function pinSessionArgv(
+  identity: EngineSessionIdentity | undefined,
+  argv: readonly string[],
+  sessionId: string,
+): readonly string[] {
+  if (!identity?.pinFlag) return argv
+  if (controlsOwnSession(identity, argv)) return argv
+  return [...argv, identity.pinFlag, sessionId]
+}
+
+/** True when this engine accepts a caller-set id on a launch of `argv`. */
+export function acceptsPinnedSession(identity: EngineSessionIdentity | undefined, argv: readonly string[]): boolean {
+  return !!identity?.pinFlag && !controlsOwnSession(identity, argv)
+}
+
+/**
+ * Argv that resumes `sessionId`, or `null` when this engine declares no
+ * resume verb or the command already controls its own session (the user's
+ * `--resume <other>` must not be overridden by ours). Null means the caller
+ * launches the bare command — a fresh conversation, honestly.
+ */
+export function resumeSessionArgv(
+  identity: EngineSessionIdentity | undefined,
+  base: readonly string[],
+  sessionId: string,
+): readonly string[] | null {
+  if (!sessionId || !identity?.resumeArgv) return null
+  if (controlsOwnSession(identity, base)) return null
+  return identity.resumeArgv(base, sessionId)
+}
+
+/**
+ * The newest session id in `ids` (oldest-first, per the history-reader
+ * contract) that no sibling tab has already claimed.
+ *
+ * Claim-tracking is what makes discovery safe with more than one tab per
+ * worktree. The store answers per-WORKTREE, not per-tab, so two kimi tabs
+ * in one task both see the same list; taking the newest unclaimed one
+ * gives the second tab the second-newest session instead of both tabs
+ * fighting over one conversation. Returns null when every session is
+ * spoken for — better a blank tab than a stolen one.
+ */
+export function pickUnclaimedSessionId(ids: readonly string[], claimed: ReadonlySet<string>): string | null {
+  for (let i = ids.length - 1; i >= 0; i--) {
+    const id = ids[i]
+    if (id && !claimed.has(id)) return id
+  }
+  return null
+}

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -37,8 +37,8 @@
 
 import type { TranscriptActivity } from "@/client/remote-orchestrator"
 import { availableEngineIds } from "@/engine/account-detect"
-import { engineLaunchArgv } from "@/engine/engine-presets"
-import { withClaudeSessionId } from "@/engine/interactive-command"
+import { engineLaunchArgv, withPinnedSessionId } from "@/engine/engine-presets"
+
 import { getCapabilities } from "@/engine/registry"
 import { resolveMainRepoRoot } from "@/state/repos"
 import { resolvePreferredVendor, setRepoLastActiveVendor } from "@/state/vendor-prefs"
@@ -172,7 +172,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
    *  the tmux `@kobe_session_id` stash. */
   const pinSession = (s: TabsState, vendor: VendorId | undefined): TabsState => {
     const base = vendor ? engineLaunchArgv({ vendor, effort: props.modelEffort }) : props.command
-    const { sessionId } = withClaudeSessionId(base, vendor ?? props.vendor)
+    const { sessionId } = withPinnedSessionId(base, vendor ?? props.vendor)
     return setTabSessionId(s, s.activeId, sessionId)
   }
 

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -7,8 +7,8 @@
  * tab activation before the target task's tabs ever mount.
  */
 
-import { engineLaunchArgv } from "../../engine/engine-presets"
-import { withClaudeSessionId } from "../../engine/interactive-command"
+import { engineLaunchArgv, withPinnedSessionId } from "../../engine/engine-presets"
+
 import {
   type EngineTab,
   type TabsState,
@@ -377,7 +377,7 @@ export function appendBackgroundEngineTab(
   const sessionId =
     spec.sessionId !== undefined
       ? spec.sessionId
-      : withClaudeSessionId(engineLaunchArgv({ vendor: spec.vendor }), spec.vendor).sessionId
+      : withPinnedSessionId(engineLaunchArgv({ vendor: spec.vendor }), spec.vendor).sessionId
   const tab: EngineTab = {
     kind: "engine",
     id: `tab-${ordinal}`,

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -8,18 +8,34 @@
  * synchronously). See the TerminalTabs file header for why refs.
  */
 
-import { engineEntry, engineSessionIdFromTitle } from "@/engine/registry"
+import { engineSessionIdFromTitle } from "@/engine/registry"
+import { discoverSessionId, engineSessionExists } from "@/engine/session-discovery"
 import { deriveTitleFromSessionId } from "@/monitor/auto-title"
 import type { VendorId } from "@/types/vendor"
 import { useEffect, useState } from "react"
-import { type EngineTab, type TabsState, setTabAutoTitle, setTabSpawned } from "../../tui/workspace/terminal-tabs-core"
+import {
+  type EngineTab,
+  type TabsState,
+  setTabAutoTitle,
+  setTabSessionId,
+  setTabSpawned,
+} from "../../tui/workspace/terminal-tabs-core"
 
 /** Cadence of the tab auto-naming pass (tmux ran its pass on the monitor tick). */
 const NAMING_POLL_MS = 5000
 
+/**
+ * Session ids already spoken for by a tab, so discovery can never hand two
+ * tabs one conversation — the store answers per-WORKTREE, so every tab of a
+ * task sees the same list.
+ */
+function claimedIds(io: TabLifecycleIO): Set<string> {
+  return new Set(io.stateRef.current.tabs.flatMap((t) => (t.kind === "engine" && t.sessionId ? [t.sessionId] : [])))
+}
+
 export interface TabLifecycleIO {
   readonly stateRef: { readonly current: TabsState }
-  readonly propsRef: { readonly current: { readonly vendor: VendorId } }
+  readonly propsRef: { readonly current: { readonly vendor: VendorId; readonly worktree: string } }
   readonly update: (next: TabsState) => void
 }
 
@@ -39,15 +55,26 @@ export function useTabHydration(rehydrated: boolean, io: TabLifecycleIO): boolea
       try {
         await Promise.all(
           io.stateRef.current.tabs.map(async (tab) => {
-            if (tab.kind !== "engine" || !tab.sessionId) return
-            let exists = false
-            try {
-              exists =
-                (await engineEntry(tab.vendor ?? io.propsRef.current.vendor).history.readHistory(tab.sessionId))
-                  .length > 0
-            } catch {
-              /* unreadable store → treat as absent (fresh session) */
+            if (tab.kind !== "engine") return
+            const vendor = tab.vendor ?? io.propsRef.current.vendor
+            const worktree = io.propsRef.current.worktree
+            // No recorded id: this engine mints its own and reports it
+            // nowhere (kimi), so ASK ITS STORE which session this worktree
+            // has. It has to happen here rather than in the naming poll —
+            // `hydrating` is what holds the spawn back, and a tab that
+            // respawns before its id is known opens a blank conversation,
+            // which is the whole bug.
+            if (!tab.sessionId) {
+              const found = await discoverSessionId(vendor, worktree, claimedIds(io))
+              if (cancelled || !found) return
+              io.update(setTabSpawned(setTabSessionId(io.stateRef.current, tab.id, found), tab.id, true))
+              return
             }
+            // Ask whether the session is RECORDED, not whether kobe can
+            // parse its messages: `readHistory` is empty for engines that
+            // ship no message parser (kimi), so the old check reported
+            // every kimi session as absent and the tab respawned blank.
+            const exists = await engineSessionExists(vendor, worktree, tab.sessionId)
             if (cancelled) return
             io.update(setTabSpawned(io.stateRef.current, tab.id, exists))
           }),
@@ -81,14 +108,31 @@ export function useTabNaming(io: TabLifecycleIO): void {
       tab.sessionId ?? engineSessionIdFromTitle(vendorOf(tab), tab.lastTitle ?? "")
     const timer = setInterval(() => {
       if (namingBusy) return
+      // A tab with no id from either authoritative source still needs one:
+      // engines that mint their own and report it nowhere (kimi) can only be
+      // asked after the fact. Ungated — kimi runs in an alt-screen and never
+      // writes an OSC title, so any "has it started yet?" proxy read off the
+      // title would never fire for the engine this exists for. Discovery is
+      // safe to attempt on every tick: a worktree with no session yet simply
+      // answers null and we ask again next tick.
+      const undiscovered = io.stateRef.current.tabs.filter(
+        (tab): tab is EngineTab => tab.kind === "engine" && !namingSessionId(tab),
+      )
       const candidates = io.stateRef.current.tabs.filter(
         (tab): tab is EngineTab =>
           tab.kind === "engine" && !!namingSessionId(tab) && (!tab.spawned || (!tab.title && !tab.autoTitle)),
       )
-      if (candidates.length === 0) return
+      if (candidates.length === 0 && undiscovered.length === 0) return
       namingBusy = true
       void (async () => {
         try {
+          for (const tab of undiscovered) {
+            const found = await discoverSessionId(vendorOf(tab), io.propsRef.current.worktree, claimedIds(io))
+            if (!found) continue
+            // Recording the id is what survives the restart — `spawned`
+            // rides along because a session on disk IS a conversation.
+            io.update(setTabSpawned(setTabSessionId(io.stateRef.current, tab.id, found), tab.id, true))
+          }
           for (const tab of candidates) {
             const sessionId = namingSessionId(tab)
             if (!sessionId) continue

--- a/packages/kobe/src/tui/workspace/issue-chat-spawn.ts
+++ b/packages/kobe/src/tui/workspace/issue-chat-spawn.ts
@@ -15,7 +15,9 @@
  * session and, after a host restart, `--resume` it.
  */
 
-import { interactiveEngineCommand, withClaudeSessionId } from "@/engine/interactive-command"
+import { withPinnedSessionId } from "@/engine/engine-presets"
+import { interactiveEngineCommand } from "@/engine/interactive-command"
+
 import type { VendorId } from "@/types/vendor"
 import type { Issue } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import { issueWorktreePrompt } from "../../state/issue-chat"
@@ -55,7 +57,7 @@ export function buildIssueChatBackgroundSpawn(input: {
   shell?: string
 }): IssueChatBackgroundSpawn {
   const base = interactiveEngineCommand(input.vendor)
-  const { sessionId } = withClaudeSessionId(base, input.vendor)
+  const { sessionId } = withPinnedSessionId(base, input.vendor)
   const fresh = initialTabs()
   const tab: EngineTab = { ...(fresh.tabs[0] as EngineTab), sessionId }
   const state: TabsState = { ...fresh, tabs: [tab] }

--- a/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
@@ -12,7 +12,10 @@ import {
   buildEngineSessionLaunch,
 } from "@/engine/session-launch"
 import { trustEngineWorktree } from "@/engine/trust-worktree"
+import { engineResumeArgv, withPinnedSessionId } from "../../engine/engine-presets"
 import { forkSessionArgv } from "../../engine/interactive-command"
+
+import type { VendorId } from "../../types/vendor"
 import type { TabSpawn } from "./terminal-tab-spawn"
 import type { EngineTab, TabsState, TerminalTab } from "./terminal-tabs-core"
 
@@ -22,13 +25,19 @@ import type { EngineTab, TabsState, TerminalTab } from "./terminal-tabs-core"
  * exists in the registry. A fork tab (see `EngineTab.forkFrom`) opens ON
  * the source conversation's history — engine-owned flag shapes, and it only
  * applies to the tab's FIRST spawn (afterwards the fork is its own session,
- * resumed by id like any other). No pinned session id → the bare command
- * (codex/custom vendors). A tab that already spawned but has NO live PTY
- * (host restart, degrade re-acquire) resumes its conversation; otherwise the
- * id is pinned fresh — the flag shapes ride `withClaudeSessionId`'s existing
- * per-vendor contract, verbatim from the component it was extracted from.
+ * resumed by id like any other). No recorded session id → the bare command.
+ * A tab that already spawned but has NO live PTY (host restart, degrade
+ * re-acquire) resumes its conversation; otherwise the id is pinned fresh.
+ * Every flag shape comes from the engine's own `sessionIdentity`
+ * declaration — `fallbackVendor` is the TASK's engine, used when the tab
+ * pinned no vendor of its own.
  */
-export function engineTabArgv(tab: EngineTab, base: readonly string[], live: boolean): readonly string[] {
+export function engineTabArgv(
+  tab: EngineTab,
+  base: readonly string[],
+  live: boolean,
+  fallbackVendor?: VendorId,
+): readonly string[] {
   if (tab.forkFrom && !tab.spawned && !live) {
     // `tab.vendor` is always concrete on a fork tab (the chord pins it) —
     // guard anyway so an inherited-vendor tab can never get claude's flags.
@@ -36,8 +45,17 @@ export function engineTabArgv(tab: EngineTab, base: readonly string[], live: boo
     if (forked) return forked
   }
   if (!tab.sessionId) return base
-  if (tab.spawned && !live) return [...base, "--resume", tab.sessionId]
-  return [...base, "--session-id", tab.sessionId]
+  const vendor = tab.vendor ?? fallbackVendor
+  // Restart / degrade re-acquire: the conversation exists, so REOPEN it with
+  // whatever verb this engine declared (claude `--resume <id>`, kimi
+  // `-S <id>`, codex `resume <id>`). An engine with no resume verb answers
+  // null and gets the bare command — a fresh conversation, honestly, rather
+  // than a flag that would kill the launch.
+  if (tab.spawned && !live) return engineResumeArgv(base, vendor, tab.sessionId) ?? base
+  // Fresh spawn: re-pin the recorded id, but only for engines that accept a
+  // caller-set one. Kimi's id was DISCOVERED from its session store, so
+  // passing it back as a pin is not a thing its CLI can do.
+  return withPinnedSessionId(base, vendor, () => tab.sessionId as string).argv
 }
 
 /**
@@ -93,7 +111,7 @@ export function engineTabSpawnFor(
     task: ref ? { ...opts.task, id: ref.id, kind: "task" } : opts.task,
     worktreePath: ref?.worktree ?? opts.worktreePath,
     shell,
-    argv: engineTabArgv(tab, base, live),
+    argv: engineTabArgv(tab, base, live, opts.task.vendor),
     promptIntent,
     protocolGates: opts.protocolGates,
     // No firstMessageDelivery override: the registry contract applies, so a

--- a/packages/kobe/test/engine/interactive-command-overrides.test.ts
+++ b/packages/kobe/test/engine/interactive-command-overrides.test.ts
@@ -19,7 +19,6 @@ import {
   engineDisplayName,
   engineNameKey,
   interactiveEngineCommand,
-  withClaudeSessionId,
   withEngineEffort,
   withEngineTerminalTitle,
 } from "../../src/engine/interactive-command.ts"
@@ -112,40 +111,6 @@ describe("withEngineEffort", () => {
     expect(withEngineEffort(["claude"], undefined, "high")).toEqual(["claude"])
     expect(withEngineEffort(["codex"], "codex", "  ")).toEqual(["codex"])
     expect(withEngineEffort(["codex"], "codex", undefined)).toEqual(["codex"])
-  })
-})
-
-describe("withClaudeSessionId", () => {
-  it("appends a fresh --session-id <uuid> to a claude launch", () => {
-    const { argv, sessionId } = withClaudeSessionId(["claude"], "claude")
-    expect(sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
-    expect(argv).toEqual(["claude", "--session-id", sessionId])
-  })
-
-  it("defaults an undefined vendor to claude", () => {
-    const { sessionId } = withClaudeSessionId(["claude"], undefined)
-    expect(sessionId).not.toBeNull()
-  })
-
-  it("leaves non-claude vendors untouched", () => {
-    expect(withClaudeSessionId(["codex"], "codex")).toEqual({ argv: ["codex"], sessionId: null })
-  })
-
-  it("never double-controls a session — a command with --resume/-c/--session-id wins", () => {
-    for (const flag of ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"]) {
-      const argv = ["claude", flag, "x"]
-      expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
-    }
-  })
-
-  it("recognizes the attached --flag=value form the command parser preserves", () => {
-    // `parseEngineCommand` keeps `--resume=<id>` as ONE token; an exact-token
-    // guard misses it and appends a second session control, which claude
-    // refuses to launch (issue #58).
-    for (const flag of ["--session-id", "--resume", "--from-pr"]) {
-      const argv = ["claude", `${flag}=x`]
-      expect(withClaudeSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
-    }
   })
 })
 

--- a/packages/kobe/test/engine/session-discovery.test.ts
+++ b/packages/kobe/test/engine/session-discovery.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Discovery + existence against a REAL kimi session store on disk — the
+ * layout `kimi-local/history.ts` reads, written here exactly as a live kimi
+ * install writes it (`session_index.jsonl` + `<dir>/agents/main/wire.jsonl`).
+ *
+ * Both functions exist because of one bug each:
+ *   - kimi tabs never recorded an id, because kimi's CLI cannot be TOLD one
+ *     and its OSC title is a sentence, so the store is the only source;
+ *   - the restart check asked `readHistory(id).length > 0`, which silently
+ *     means "kobe can parse this engine's messages" — kimi's reader ships no
+ *     parser, so every kimi session reported as absent and its tab respawned
+ *     blank under a fresh conversation.
+ */
+
+import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { discoverSessionId, engineSessionExists } from "@/engine/session-discovery"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+let home: string
+let worktree: string
+// Restored verbatim in afterEach — including `undefined`, which the env
+// object accepts as "unset" for the reader's `?.trim()` lookup.
+const prevHome = process.env.KIMI_CODE_HOME as string
+
+/** Write one kimi session for `wt`, newest-last by wire.jsonl mtime. */
+async function writeSession(id: string, wt: string, mtime: Date): Promise<void> {
+  const dir = path.join(home, "sessions", `wd_${id}`)
+  await mkdir(path.join(dir, "agents", "main"), { recursive: true })
+  const wire = path.join(dir, "agents", "main", "wire.jsonl")
+  await writeFile(wire, '{"type":"whatever-kobe-does-not-parse"}\n')
+  await writeFile(
+    path.join(home, "session_index.jsonl"),
+    `${JSON.stringify({ sessionId: id, sessionDir: dir, workDir: wt })}\n`,
+    { flag: "a" },
+  )
+  await utimes(wire, mtime, mtime)
+}
+
+beforeEach(async () => {
+  home = await mkdtemp(path.join(tmpdir(), "kimi-store-"))
+  worktree = await mkdtemp(path.join(tmpdir(), "wt-"))
+  process.env.KIMI_CODE_HOME = home
+})
+
+afterEach(() => {
+  process.env.KIMI_CODE_HOME = prevHome
+})
+
+describe("discoverSessionId", () => {
+  it("adopts the newest session kimi recorded for this worktree", async () => {
+    await writeSession("session_old", worktree, new Date(1_000_000))
+    await writeSession("session_new", worktree, new Date(2_000_000))
+    expect(await discoverSessionId("kimi", worktree, new Set())).toBe("session_new")
+  })
+
+  it("gives a second tab the next session rather than the one tab 1 holds", async () => {
+    await writeSession("session_old", worktree, new Date(1_000_000))
+    await writeSession("session_new", worktree, new Date(2_000_000))
+    expect(await discoverSessionId("kimi", worktree, new Set(["session_new"]))).toBe("session_old")
+  })
+
+  it("answers null for a worktree with no sessions, and for another worktree's", async () => {
+    expect(await discoverSessionId("kimi", worktree, new Set())).toBeNull()
+    await writeSession("session_elsewhere", "/some/other/worktree", new Date(1_000_000))
+    expect(await discoverSessionId("kimi", worktree, new Set())).toBeNull()
+  })
+
+  it("answers null for an engine with no transcript store at all", async () => {
+    await writeSession("session_new", worktree, new Date(2_000_000))
+    expect(await discoverSessionId("my-custom-engine", worktree, new Set())).toBeNull()
+  })
+})
+
+describe("engineSessionExists", () => {
+  it("sees a kimi session that ships no message parser — the restart-blank bug", async () => {
+    await writeSession("session_new", worktree, new Date(2_000_000))
+    expect(await engineSessionExists("kimi", worktree, "session_new")).toBe(true)
+  })
+
+  it("is false for an id the store never recorded, and for a blank id", async () => {
+    await writeSession("session_new", worktree, new Date(2_000_000))
+    expect(await engineSessionExists("kimi", worktree, "session_gone")).toBe(false)
+    expect(await engineSessionExists("kimi", worktree, "")).toBe(false)
+  })
+})

--- a/packages/kobe/test/engine/session-identity.test.ts
+++ b/packages/kobe/test/engine/session-identity.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The engine-owned session contract: every engine answers "what pins my id"
+ * and "how do I resume one" for itself, so no neutral layer has to name a
+ * vendor. Two regressions this pins:
+ *
+ *   - claude's pin + resume shapes must not drift (they were the only ones
+ *     that ever worked, and the whole feature is worthless if it breaks them);
+ *   - `withPinnedSessionId` must answer for a CUSTOM engine by the protocol
+ *     it declares, not by whether its id spells "claude" — the literal-name
+ *     check in the old `withClaudeSessionId` is exactly why `claudecpa` and
+ *     every kimi tab lost their conversation on restart.
+ */
+
+import { engineResumeArgv, withPinnedSessionId } from "@/engine/engine-presets"
+import { engineEntry } from "@/engine/registry"
+import {
+  acceptsPinnedSession,
+  controlsOwnSession,
+  pickUnclaimedSessionId,
+  resumeSessionArgv,
+} from "@/engine/session-identity"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/state/repos", async (orig) => ({
+  ...(await orig<typeof import("@/state/repos")>()),
+  getPersistedString: (key: string) => (key === "engineProtocol.claudecpa" ? "claude" : ""),
+  getCustomEngineIds: () => ["claudecpa"],
+}))
+
+describe("per-engine session declarations", () => {
+  it("pins claude's id at launch and resumes it with --resume", () => {
+    const { argv, sessionId } = withPinnedSessionId(["claude"], "claude")
+    expect(sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    expect(argv).toEqual(["claude", "--session-id", sessionId])
+    expect(engineResumeArgv(["claude"], "claude", "u1")).toEqual(["claude", "--resume", "u1"])
+  })
+
+  it("defaults an undefined vendor to claude (the launch convention)", () => {
+    expect(withPinnedSessionId(["claude"], undefined).sessionId).not.toBeNull()
+  })
+
+  it("resumes kimi with -S, and never pins — its CLI can only reopen (probed)", () => {
+    expect(withPinnedSessionId(["kimi"], "kimi")).toEqual({ argv: ["kimi"], sessionId: null })
+    expect(engineResumeArgv(["kimi", "-y"], "kimi", "sess-9")).toEqual(["kimi", "-y", "-S", "sess-9"])
+  })
+
+  it("resumes codex with its subcommand, flags before the positional id", () => {
+    expect(withPinnedSessionId(["codex"], "codex")).toEqual({ argv: ["codex"], sessionId: null })
+    expect(engineResumeArgv(["codex", "-c", "x=1"], "codex", "t-1")).toEqual(["codex", "resume", "-c", "x=1", "t-1"])
+  })
+
+  it("declines both verbs for an engine that declares no session identity", () => {
+    expect(withPinnedSessionId(["copilot"], "copilot").sessionId).toBeNull()
+    expect(engineResumeArgv(["copilot"], "copilot", "s")).toBeNull()
+    expect(engineResumeArgv(["opencode"], "opencode", "s")).toBeNull()
+  })
+
+  // The bug the whole change exists for: a wrapper engine is a claude
+  // launch, so it must get claude's session verbs. The old literal
+  // `vendor === "claude"` gate excluded it by NAME.
+  it("gives a custom preset the session verbs of the protocol it declares", () => {
+    const { argv, sessionId } = withPinnedSessionId(["claudecpa"], "claudecpa")
+    expect(sessionId).not.toBeNull()
+    expect(argv).toEqual(["claudecpa", "--session-id", sessionId])
+    expect(engineResumeArgv(["claudecpa"], "claudecpa", "u1")).toEqual(["claudecpa", "--resume", "u1"])
+  })
+})
+
+describe("the user's own session flags always win", () => {
+  const claude = engineEntry("claude").sessionIdentity
+  const kimi = engineEntry("kimi").sessionIdentity
+
+  it("never appends a second session control to a command that has one", () => {
+    for (const flag of ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"]) {
+      const argv = ["claude", flag, "x"]
+      expect(withPinnedSessionId(argv, "claude")).toEqual({ argv, sessionId: null })
+      expect(engineResumeArgv(argv, "claude", "u1")).toBeNull()
+    }
+  })
+
+  it("recognizes the attached --flag=value form the command parser preserves", () => {
+    expect(controlsOwnSession(claude, ["claude", "--resume=x"])).toBe(true)
+    // Prefix-safe: a longer flag that merely starts the same is not a match.
+    expect(controlsOwnSession(claude, ["claude", "--resume-later"])).toBe(false)
+  })
+
+  it("leaves a kimi command that already resumes alone", () => {
+    expect(controlsOwnSession(kimi, ["kimi", "-S", "sess-1"])).toBe(true)
+    expect(engineResumeArgv(["kimi", "-c"], "kimi", "sess-2")).toBeNull()
+  })
+
+  it("acceptsPinnedSession is false without a pin flag, whatever the argv", () => {
+    expect(acceptsPinnedSession(kimi, ["kimi"])).toBe(false)
+    expect(acceptsPinnedSession(claude, ["claude"])).toBe(true)
+    expect(acceptsPinnedSession(undefined, ["x"])).toBe(false)
+  })
+
+  it("resumeSessionArgv refuses an empty id rather than passing a blank flag", () => {
+    expect(resumeSessionArgv(claude, ["claude"], "")).toBeNull()
+  })
+})
+
+// Why: the session store answers per-WORKTREE, so every tab of a task sees
+// the same list. Without claim-tracking two kimi tabs would both adopt the
+// newest session and fight over one conversation.
+describe("pickUnclaimedSessionId", () => {
+  it("takes the newest id no sibling tab already holds", () => {
+    expect(pickUnclaimedSessionId(["old", "mid", "new"], new Set())).toBe("new")
+    expect(pickUnclaimedSessionId(["old", "mid", "new"], new Set(["new"]))).toBe("mid")
+    expect(pickUnclaimedSessionId(["old", "mid", "new"], new Set(["new", "mid"]))).toBe("old")
+  })
+
+  it("answers null rather than handing back a claimed or absent session", () => {
+    expect(pickUnclaimedSessionId([], new Set())).toBeNull()
+    expect(pickUnclaimedSessionId(["a"], new Set(["a"]))).toBeNull()
+  })
+})

--- a/packages/kobe/test/render/tab-naming-codex-title.test.tsx
+++ b/packages/kobe/test/render/tab-naming-codex-title.test.tsx
@@ -60,7 +60,11 @@ async function seedCodexRollout(): Promise<void> {
 }
 
 /** A mutable `TabLifecycleIO` whose `update` refreshes `stateRef` like the host's. */
-function lifecycleIO(state: TabsState, vendor: "claude" | "codex"): TabLifecycleIO & { state: () => TabsState } {
+function lifecycleIO(
+  state: TabsState,
+  vendor: "claude" | "codex",
+  worktree = "/nonexistent-worktree",
+): TabLifecycleIO & { state: () => TabsState } {
   let current = state
   return {
     stateRef: {
@@ -68,7 +72,7 @@ function lifecycleIO(state: TabsState, vendor: "claude" | "codex"): TabLifecycle
         return current
       },
     },
-    propsRef: { current: { vendor } },
+    propsRef: { current: { vendor, worktree } },
     update: (next) => {
       current = next
     },

--- a/packages/kobe/test/render/tab-session-discovery.test.tsx
+++ b/packages/kobe/test/render/tab-session-discovery.test.tsx
@@ -1,0 +1,106 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Session DISCOVERY on the hydration pass (`useTabHydration`), for the engine
+ * whose id Rove can neither pin nor read.
+ *
+ * Claude accepts `--session-id`, so its tabs know their conversation before
+ * the process exists; codex publishes its thread id in its own OSC title. Kimi
+ * does neither — its CLI cannot be told what to call a new session, and its
+ * title is a sentence — so nothing ever recorded which session a kimi tab
+ * belonged to and every restart opened a blank one. The only remaining source
+ * is the session store, which is what this pass asks.
+ *
+ * It runs in HYDRATION rather than the naming poll because `hydrating` is the
+ * gate that holds the spawn back: an id learned after the tab respawned is an
+ * id learned too late, and the poll's 5s tick is well after the fact.
+ *
+ * Lives in the bun-run render track: the hook is a React effect, so it needs a
+ * real renderer to mount against.
+ */
+
+import { afterEach, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import type { ReactNode } from "react"
+import { type TabLifecycleIO, useTabHydration } from "../../src/tui-react/workspace/use-tab-lifecycle"
+import type { EngineTab, TabsState } from "../../src/tui/workspace/terminal-tabs-core"
+import { renderComponent } from "./harness"
+
+const SESSION_ID = "session_fb636b17-73fd-45c2-97f4-4bc4f3235bff"
+
+let kimiHome: string | undefined
+let worktree: string | undefined
+const priorKimiHome = process.env.KIMI_CODE_HOME
+
+afterEach(async () => {
+  // biome-ignore lint/performance/noDelete: env cleanup must fully unset when the var was unset before the test (assigning undefined leaves it as the string "undefined").
+  if (priorKimiHome === undefined) delete process.env.KIMI_CODE_HOME
+  else process.env.KIMI_CODE_HOME = priorKimiHome
+  if (kimiHome) await rm(kimiHome, { recursive: true, force: true })
+  if (worktree) await rm(worktree, { recursive: true, force: true })
+  kimiHome = undefined
+  worktree = undefined
+})
+
+/** A real `~/.kimi-code` tree holding one session rooted at `worktree`. */
+async function seedKimiSession(): Promise<void> {
+  kimiHome = await mkdtemp(path.join(tmpdir(), "rove-kimi-home-"))
+  worktree = await mkdtemp(path.join(tmpdir(), "rove-kimi-wt-"))
+  const dir = path.join(kimiHome, "sessions", `wd_${SESSION_ID}`)
+  await mkdir(path.join(dir, "agents", "main"), { recursive: true })
+  // Deliberately NOT a format kobe parses — kimi ships no message reader, and
+  // the whole point is that discovery works without one.
+  await writeFile(path.join(dir, "agents", "main", "wire.jsonl"), '{"type":"protocol-frame"}\n')
+  await writeFile(
+    path.join(kimiHome, "session_index.jsonl"),
+    `${JSON.stringify({ sessionId: SESSION_ID, sessionDir: dir, workDir: worktree })}\n`,
+  )
+  process.env.KIMI_CODE_HOME = kimiHome
+}
+
+/** Poll until the hydration effect's async store read has landed. */
+async function until(done: () => boolean, ms = 5000): Promise<void> {
+  const deadline = Date.now() + ms
+  while (!done() && Date.now() < deadline) await new Promise((r) => setTimeout(r, 50))
+}
+
+/** A mutable `TabLifecycleIO` whose `update` refreshes `stateRef` like the host's. */
+function lifecycleIO(state: TabsState, wt: string): TabLifecycleIO & { state: () => TabsState } {
+  let current = state
+  return {
+    stateRef: {
+      get current() {
+        return current
+      },
+    },
+    propsRef: { current: { vendor: "kimi", worktree: wt } },
+    update: (next) => {
+      current = next
+    },
+    state: () => current,
+  }
+}
+
+test("a rehydrated kimi tab adopts the session its worktree already has", async () => {
+  await seedKimiSession()
+  const state: TabsState = {
+    // No sessionId — exactly how every kimi tab persisted before this change.
+    tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "kimi" }],
+    activeId: "tab-1",
+    nextOrdinal: 2,
+  }
+  const io = lifecycleIO(state, worktree as string)
+  function Probe(): ReactNode {
+    useTabHydration(true, io)
+    return <text>probe</text>
+  }
+  await renderComponent(<Probe />)
+  await until(() => (io.state().tabs[0] as EngineTab).sessionId != null)
+
+  const tab = io.state().tabs[0] as EngineTab
+  expect(tab.sessionId).toBe(SESSION_ID)
+  // `spawned` rides along: a session on disk IS a conversation, and it is what
+  // makes the next launch take the engine's resume verb instead of a blank one.
+  expect(tab.spawned).toBe(true)
+})

--- a/packages/kobe/test/tui/engine-tab-resume-argv.test.ts
+++ b/packages/kobe/test/tui/engine-tab-resume-argv.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Characterization of a tab's RESUME argv, written before the engine-owned
+ * session contract landed so the claude/codex shapes are pinned against
+ * regression rather than re-derived from the implementation afterwards.
+ *
+ * The gap this file exists to expose: only claude ever had a session id to
+ * resume from (`--session-id` pinned at spawn), so `engineTabArgv`'s
+ * `--resume` was unreachable for every other engine — and hard-coded to
+ * claude's flag if it ever were reached.
+ */
+
+import { type EngineTab, engineTabArgv } from "@/tui/workspace/terminal-tabs-core"
+import { describe, expect, it } from "vitest"
+
+const tab = (over: Partial<EngineTab>): EngineTab => ({
+  kind: "engine",
+  id: "tab-1",
+  title: null,
+  ordinal: 1,
+  ...over,
+})
+
+describe("engineTabArgv session flags", () => {
+  it("pins claude's session on a fresh spawn and resumes it when the PTY died", () => {
+    const t = tab({ vendor: "claude", sessionId: "u1" })
+    expect(engineTabArgv(t, ["claude"], false)).toEqual(["claude", "--session-id", "u1"])
+    expect(engineTabArgv(t, ["claude"], true)).toEqual(["claude", "--session-id", "u1"])
+    expect(engineTabArgv({ ...t, spawned: true }, ["claude"], false)).toEqual(["claude", "--resume", "u1"])
+    // A live PTY is re-render churn, not a restart — never a resume.
+    expect(engineTabArgv({ ...t, spawned: true }, ["claude"], true)).toEqual(["claude", "--session-id", "u1"])
+  })
+
+  it("leaves a tab with no session id on the bare command", () => {
+    expect(engineTabArgv(tab({ vendor: "kimi" }), ["kimi"], false)).toEqual(["kimi"])
+    expect(engineTabArgv(tab({ vendor: "kimi", spawned: true }), ["kimi"], false)).toEqual(["kimi"])
+  })
+})


### PR DESCRIPTION
94% of engine tabs are kimi, and none of them survived a restart with their conversation. On disk: of 366 engine tabs, 7 had a `sessionId` — all claude.

## The two breaks

**No id was ever recorded.** `withClaudeSessionId()` opened with `coerceVendorId(vendor) !== "claude"`, so only an engine *literally named* claude got a `--session-id` pin. Kimi got none. Neither did wrapper presets like `claudecpa` — a zsh function around the real claude, excluded by its name rather than by what it runs.

**The resume flag was hard-coded.** `engineTabArgv` appended `--resume` unconditionally. Kimi's flag is `-S`; even with an id, the launch would have died.

## The shape

Each engine now declares its own session verbs (`engine/session-identity.ts`). Neutral layers ask the engine instead of naming a vendor — the old helper's *name* was itself the AGENTS.md violation.

An id has three possible origins, and which one applies is a property of the CLI, not a choice Rove makes:

| origin | engine | mechanism |
|---|---|---|
| pinned at launch | claude | `--session-id <uuid>`, resumes `--resume <id>` |
| read from OSC title | codex | existing `sessionIdFromTitle`; resumes via the `resume` subcommand |
| discovered after the fact | kimi | store lookup by worktree; resumes `-S <id>` |

Kimi's CLI *cannot* be told what to call a new session — `-S [id]` only reopens an existing one. So its id is discovered from the session store the history reader already indexes. A custom preset inherits the verbs of the protocol it declares, which is what fixes `claudecpa`. An engine with no resume verb starts a fresh conversation honestly rather than being handed a flag that would kill its launch.

Discovery is claim-tracked: the store answers per-*worktree*, so without it two kimi tabs in one task would both adopt the newest session and fight over one conversation.

Also fixes the restart existence check, which asked `readHistory(id).length > 0` — that silently means "Rove can parse this engine's messages". Kimi ships no parser, so every kimi session reported as absent and its tab respawned blank even once its id was known.

## Verification

Two kimi engines were killed by mistake while verifying this change; their conversations are recoverable only through the `kimi -S` path this PR adds.


Claude and codex were pinned with characterization tests written *before* the change, so their shapes are held against regression rather than re-derived afterwards.

Probed against the real binaries (2026-08-29), in an isolated sandbox:

- `kimi -S <id>` resumed and recalled the earlier turn; a bare launch replied *"this is the first message in our conversation"* — the bug and the fix, side by side.
- A real kimi tab's id was discovered and recorded (`session_fb636b17…`, `spawned: true`) and survived a daemon restart.

Testing surfaced a real wiring bug: discovery first sat in the 5s naming poll behind a `lastTitle` gate that kimi never sets (alt-screen, no OSC title), so it ran *after* the tab had already respawned blank. It now runs in the hydration gate, which is what holds the spawn back.

`registry.ts` went over the 500-line cap, so its built-in table moved to `builtin-engines.ts` — same pattern as `history-readers.ts`. Every touched file is now under the cap.

Suites: 209 engine/tui vitest files (1943 tests) and 235 render tests pass; typecheck and lint clean.

coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalTabs.tsx — integration layer needing a live daemon + PTY; the render track cannot mount it. Covered by the behavior track and the visual-ground-truth harness. Pre-existing gap (8.87% on main), and this PR only changes one import line and one call.
coverage-exemption: packages/kobe/src/tui/workspace/terminal-tab-argv.ts — pure argv composition, covered by vitest (test/tui/terminal-tab-fork-argv.test.ts and the new test/tui/engine-tab-resume-argv.test.ts), which the render-track lcov does not see. Pre-existing gap (6.58% on main), not introduced by this PR.

