### PR TITLE
fix: audit every task deletion and stop dropping tabs silently

### DIFF
--- a/.changeset/task-deletion-audit.md
+++ b/.changeset/task-deletion-audit.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Record an audit line for every task deletion, and stop dropping a task's tabs silently.
+
+Task deletion previously logged only when the worktree removal FAILED, so a successful delete — the case that actually closes someone's tabs — left no trace, and no delete recorded who asked for it. `~/.rove/daemon.log` now carries a `task-deletion-audit` line per phase (`requested` / `removed` / `failed`) naming the task, its branch and worktree, the flags, and the caller's verified Rove session when `rove api delete` was run from inside one. A `failed` line also spells out that the session teardown and Inbox cleanup already ran while the worktree and task entry remain.
+
+Separately, when a task's worktree disappears out-of-band (another client, the worktrees page, another agent), Rove drops every tab of that task. It now says so in a toast — how many tabs closed and that the branch survives — instead of doing it silently.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -73,9 +73,38 @@ The raw logs live under the active Rove home (normally your OS home):
 
 | Path | Contains |
 |---|---|
-| `~/.rove/daemon.log` | daemon startup, crashes, RPC and web-transport failures |
+| `~/.rove/daemon.log` | daemon startup, crashes, RPC and web-transport failures, task-deletion audit |
 | `~/.rove/pty.log` | Hosted PTY startup and session-host failures |
 | `~/.rove/client.log` | TUI/pane connection, disconnect, and reconnect diagnostics |
+
+## Who deleted my task?
+
+Every task deletion is recorded in `~/.rove/daemon.log`, whether it succeeds
+or fails:
+
+```
+grep task-deletion-audit ~/.rove/daemon.log
+```
+
+Each deletion writes a `requested` line when the RPC arrives, then either
+`removed` or `failed`. The `requested` line names the task, its branch and
+worktree path, the `--force`/`--delete-branch` flags, and who asked:
+
+- `by=<taskId>::<tabId>` — another Rove session ran `rove api delete` from
+  inside that tab. This is a verified identity, not the inherited
+  `$ROVE_TASK_ID` env, so an unverifiable caller is simply absent rather than
+  misattributed.
+- `spawnedBy=<taskId>::<tabId>` — the deleted task's own spawner. Useful
+  context, but it names who CREATED the task, not who deleted it.
+- `client=<n>` — the daemon connection id, which distinguishes concurrent
+  callers when neither identity above is present (a TUI keypress, the web UI).
+
+A `failed` line means the deletion ran only partway: the hosted session was
+torn down and the Inbox/activity state cleared, but the worktree directory and
+the task entry remain, and the task is left in `deletion.phase === "error"`
+(the sidebar row shows it). Delete it again once you have fixed whatever the
+reason names — a common one is a worktree directory that is no longer a git
+worktree, which `rove doctor` also reports.
 
 (Installs upgraded from pre-0.8.189 builds may still have a `~/.kobe/`
 directory; runtime files now live under `~/.rove`, with legacy paths honoured

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -11,6 +11,7 @@ import { logDaemonError } from "./crash-log.ts"
 import { optionalBoolean, optionalString, optionalVendor, requireString } from "./handler-validators.ts"
 import type { DaemonHandlerContext, DaemonRequestHandler } from "./handlers.ts"
 import { serializeTask } from "./protocol.ts"
+import { auditDeletionRequested } from "./task-deletion-audit.ts"
 
 export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   {
@@ -114,10 +115,26 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
-      const accepted = await ctx.orch.prepareTaskDeletion(taskId, {
-        force: optionalBoolean(payload, "force"),
-        deleteBranch: optionalBoolean(payload, "deleteBranch"),
-      })
+      const force = optionalBoolean(payload, "force")
+      const deleteBranch = optionalBoolean(payload, "deleteBranch")
+      // Audit BEFORE the accept: `prepareTaskDeletion` can throw
+      // (DirtyWorktreeError), and a refused destructive request is exactly as
+      // worth recording as an accepted one. Read the task here too — by the
+      // time the background runner finishes, it is gone from the index.
+      const task = ctx.orch.getTask(taskId)
+      const byTaskId = optionalString(payload, "requestedByTaskId")
+      auditDeletionRequested(
+        taskId,
+        task,
+        {
+          clientId: ctx.clientId,
+          ...(byTaskId
+            ? { requestedBy: { taskId: byTaskId, tabId: optionalString(payload, "requestedByTabId") || "tab-1" } }
+            : {}),
+        },
+        { force, deleteBranch },
+      )
+      const accepted = await ctx.orch.prepareTaskDeletion(taskId, { force, deleteBranch })
       ctx.activity.clearTask(taskId)
       // A hard task delete is an explicit user deletion, so it is the one
       // lifecycle action allowed to cascade its durable Inbox episodes.

--- a/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
@@ -1,0 +1,108 @@
+/**
+ * Task-deletion audit trail.
+ *
+ * A task delete destroys a worktree and every tab under it, and until this
+ * existed the daemon recorded a line ONLY when the removal FAILED
+ * (`logDaemonError("task-deletion", …)`). A successful delete left no trace at
+ * all, and no delete recorded WHO asked for it — so the owner-reported "a tab
+ * I was working in vanished and it wasn't me" (2026-08-29) was only traceable
+ * because that particular removal happened to fail. Deletes are the most
+ * destructive thing an `rove api` caller can do to somebody else's session;
+ * they get a record whether or not they succeed.
+ *
+ * The record goes to `daemon.log` via {@link logDaemonInfo}/{@link
+ * logDaemonError}, not a separate file: it is already the place a user is
+ * told to look (docs/TROUBLESHOOTING.md), `rove doctor --report` already
+ * bundles its tail, and it is already size-capped + rotated. A second audit
+ * file would be one more thing to find, rotate, and forget.
+ *
+ * One line per phase so a partial deletion is legible as such:
+ *   requested → the RPC was accepted (carries the origin)
+ *   removed   → the worktree + index entry are gone
+ *   failed    → the worktree removal threw; the task is retained in `error`
+ */
+
+import type { DaemonTask } from "./contracts.ts"
+import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
+
+const SUBSYSTEM = "task-deletion-audit"
+
+/**
+ * Who asked for the delete. `dispatcher` is the deleted task's own recorded
+ * spawner (`{taskId, tabId}`), which is the closest thing to provenance the
+ * daemon holds: the daemon process has no caller env, and the RPC frame
+ * carries only a connection id. `clientId` distinguishes concurrent callers
+ * on the socket; the web transport passes its own.
+ */
+export interface DeletionOrigin {
+  readonly clientId: number
+  /**
+   * The CLI caller's own VERIFIED Rove session (`rove api delete` from inside
+   * an engine tab). Verified the way `send` verifies it — the bare
+   * `$ROVE_TASK_ID` env inherits down the whole process tree and would name a
+   * stranger's tab (issue #24) — so an unverifiable caller is absent here
+   * rather than misattributed.
+   */
+  readonly requestedBy?: { readonly taskId: string; readonly tabId: string }
+}
+
+/** Render the caller-identifying half of an audit line. */
+function originText(origin: DeletionOrigin | undefined, task: DaemonTask | undefined): string {
+  const parts: string[] = []
+  if (origin) parts.push(`client=${origin.clientId}`)
+  if (origin?.requestedBy) parts.push(`by=${origin.requestedBy.taskId}::${origin.requestedBy.tabId}`)
+  const dispatcher = task?.dispatcher
+  // The dispatcher is the task's SPAWNER, not necessarily the deleter — but
+  // when an agent deletes a task it created, it is the same session, and it is
+  // the only durable identity the daemon can attribute. Labelled so a reader
+  // never mistakes it for a verified deleter.
+  if (dispatcher) parts.push(`spawnedBy=${dispatcher.taskId}::${dispatcher.tabId}`)
+  return parts.length > 0 ? ` (${parts.join(" ")})` : ""
+}
+
+/** Render what is being destroyed, so the log is readable without tasks.json. */
+function subjectText(task: DaemonTask | undefined, taskId: string): string {
+  if (!task) return `task ${taskId}`
+  const bits = [`task ${taskId}`, `title=${JSON.stringify(task.title)}`, `kind=${task.kind}`]
+  if (task.branch) bits.push(`branch=${task.branch}`)
+  if (task.worktreePath) bits.push(`worktree=${task.worktreePath}`)
+  return bits.join(" ")
+}
+
+/** The RPC was accepted and queued — recorded BEFORE anything is destroyed. */
+export function auditDeletionRequested(
+  taskId: string,
+  task: DaemonTask | undefined,
+  origin: DeletionOrigin | undefined,
+  opts: { force?: boolean; deleteBranch?: boolean } = {},
+): void {
+  logDaemonInfo(
+    SUBSYSTEM,
+    `requested ${subjectText(task, taskId)} force=${opts.force === true} deleteBranch=${opts.deleteBranch === true}${originText(origin, task)}`,
+  )
+}
+
+/** The worktree and index entry are gone. */
+export function auditDeletionRemoved(taskId: string, task: DaemonTask | undefined): void {
+  logDaemonInfo(SUBSYSTEM, `removed ${subjectText(task, taskId)}`)
+}
+
+/**
+ * The worktree removal threw. The task stays in `deletion.phase === "error"`,
+ * but its session was already torn down and its Inbox/activity state cleared —
+ * so this line also names what has ALREADY been undone, which is the half a
+ * bare stack trace never told anyone.
+ */
+export function auditDeletionFailed(taskId: string, task: DaemonTask | undefined, err: unknown): void {
+  // A real Error carrying the ORIGINAL error's stack. `logDaemonError` prints
+  // `err.stack` and JSON-stringifies anything that is not an Error, so neither
+  // a fresh `new Error(...)` (which stack-traces this helper and loses the
+  // failing git call) nor a plain object (an unreadable blob) works here.
+  const cause = err instanceof Error ? err : new Error(String(err))
+  const context = `failed ${subjectText(task, taskId)} — session teardown and activity/inbox cleanup ALREADY ran; the worktree directory and task entry remain. Reason: `
+  const line = new Error(`${context}${cause.message}`)
+  line.name = cause.name
+  const frames = cause.stack?.split("\n").slice(1) ?? []
+  if (frames.length > 0) line.stack = [`${line.name}: ${line.message}`, ...frames].join("\n")
+  logDaemonError(SUBSYSTEM, line)
+}

--- a/packages/kobe-daemon/src/daemon/task-deletion-runner.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-runner.ts
@@ -1,6 +1,7 @@
 import type { DaemonOrchestrator, DaemonTask } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { auditDeletionFailed, auditDeletionRemoved } from "./task-deletion-audit.ts"
 
 export interface TaskDeletionScheduler {
   enqueue(taskId: string): void
@@ -11,7 +12,11 @@ export class TaskDeletionRunner implements TaskDeletionScheduler {
   private readonly inFlight = new Map<string, Promise<void>>()
 
   constructor(
-    private readonly orch: DaemonOrchestrator,
+    // Narrowed to exactly what the runner touches: `getTask` is only here to
+    // snapshot the task for the audit line before the index drops it, and
+    // spelling that out keeps a caller from having to supply the whole
+    // orchestrator surface.
+    private readonly orch: Pick<DaemonOrchestrator, "beginTaskDeletion" | "finishTaskDeletion" | "getTask">,
     private readonly runtime: Pick<DaemonRuntimeAdapter, "tearDownTaskSession">,
     private readonly clearTaskState: (taskId: string) => void | Promise<void>,
   ) {}
@@ -38,8 +43,18 @@ export class TaskDeletionRunner implements TaskDeletionScheduler {
 
   private async run(taskId: string): Promise<void> {
     if (!(await this.orch.beginTaskDeletion(taskId))) return
+    // Snapshot the task BEFORE anything is destroyed: `finishTaskDeletion`
+    // drops it from the index, so an audit line read afterwards would have
+    // nothing but an id to report.
+    const task = this.orch.getTask(taskId)
     await this.clearTaskState(taskId)
     await this.runtime.tearDownTaskSession(taskId).catch((err) => logDaemonError("task-deletion-session-teardown", err))
-    await this.orch.finishTaskDeletion(taskId)
+    try {
+      await this.orch.finishTaskDeletion(taskId)
+    } catch (err) {
+      auditDeletionFailed(taskId, task, err)
+      throw err
+    }
+    auditDeletionRemoved(taskId, task)
   }
 }

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -241,7 +241,17 @@ export async function deleteTask(ctx: VerbContext): Promise<unknown> {
   // Branch deletion is opt-in (same flag as `land`): delete drops the
   // worktree + task entry, git keeps the branch as the durable record.
   const deleteBranch = ctx.args.bool("delete-branch") ?? false
-  const res = await daemon.request("task.delete", { taskId, force, deleteBranch })
+  // Deleting somebody else's task destroys their worktree and every tab in
+  // it, so the daemon's audit line has to name WHO asked. Same verified
+  // identity `send`/`add` use (never the bare env — issue #24): unverifiable
+  // stays unattributed rather than blaming a stranger's session.
+  const self = await verifiedSelfSession()
+  const res = await daemon.request("task.delete", {
+    taskId,
+    force,
+    deleteBranch,
+    ...(self ? { requestedByTaskId: self.taskId, requestedByTabId: self.tabId } : {}),
+  })
   // The daemon's task.delete removes the worktree + index entry but never the
   // hosted session. Without this, a scripted delete
   // orphans the `kobe-<id>` session + its engine — invisible to every kobe UI

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -40,7 +40,7 @@ import { useEditorHandles } from "./use-editor-handles"
 import { useInboxHost } from "./use-inbox-host"
 import { useIssueChat } from "./use-issue-chat"
 import { useScratchShell } from "./use-scratch-shell"
-import { useWorkspaceSelection } from "./use-workspace-selection"
+import { type WorktreeGoneEvent, useWorkspaceSelection } from "./use-workspace-selection"
 import { useZenMode } from "./use-zen-mode"
 
 function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
@@ -75,12 +75,29 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
 
   // Selection + adopt-first-focus + the deleting-task PTY sweep — extracted
   // verbatim to use-workspace-selection.ts (file-size cap split).
+  const t = useT()
+
+  // Declared before useWorkspaceSelection so its worktree-gone callback can
+  // reach the toast surface; `notif.notify` is stable and the sidebar hook's
+  // notifyError/notifyInfo below need `selectedId`, which the selection hook
+  // produces. Same shape those two use (see use-sidebar-host-state).
+  const notifyWorktreeGone = (event: WorktreeGoneEvent): void => {
+    notif.notify({
+      kind: "error",
+      taskId: event.taskId,
+      tabId: "",
+      title: t("tasks.toast.worktreeGoneTitle", { title: event.title }),
+      body: t("tasks.toast.worktreeGoneBody", { count: String(event.closed), branch: event.branch || "—" }),
+    })
+  }
+
   const { selectedId, setSelectedId, selectedTask, selectTask, activateTask } = useWorkspaceSelection({
     orch,
     tasks,
     activeTaskId,
     focusWorkspace: () => focus.setFocused("workspace"),
     kv,
+    notifyWorktreeGone,
   })
   const worktree = selectedTask?.worktreePath || null
 
@@ -103,7 +120,6 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
 
   // Cross-task attention (P0): rising-edge notify for non-selected tasks +
   // the global chord's jump-to-next handler. State is engine-owned/neutral.
-  const t = useT()
   const { jumpToNextAttention } = useAttention({
     tasks,
     engineState,

--- a/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
@@ -11,9 +11,19 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { readLastActiveTaskId } from "../../state/last-active.ts"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import type { Task } from "../../types/task.ts"
+import { useLatest } from "../lib/use-latest"
 import { type TabsSnapshotKv, sweepOrphanTabsSnapshots } from "./terminal-tabs-persist"
-import { forgetTaskTabs } from "./terminal-tabs-shared"
+import { forgetTaskTabs, knownTaskTabs } from "./terminal-tabs-shared"
 import { activateWorkspaceTask, firstSelectableTask } from "./use-task-selection"
+
+/** What {@link useWorkspaceSelection} reports when a worktree vanishes under a task. */
+export interface WorktreeGoneEvent {
+  readonly taskId: string
+  readonly title: string
+  readonly branch: string
+  /** How many tab snapshots were dropped (0 when the task never mounted tabs). */
+  readonly closed: number
+}
 
 export interface WorkspaceSelection {
   readonly selectedId: string | null
@@ -31,6 +41,8 @@ export function useWorkspaceSelection(args: {
   readonly activeTaskId: string | null
   readonly focusWorkspace: () => void
   readonly kv: TabsSnapshotKv
+  /** A task's worktree disappeared out-of-band and its tabs were dropped. */
+  readonly notifyWorktreeGone?: (event: WorktreeGoneEvent) => void
 }): WorkspaceSelection {
   const { orch, tasks, activeTaskId, kv } = args
   // Seed from the daemon's replayed focus, else the persisted lastActive
@@ -73,6 +85,17 @@ export function useWorkspaceSelection(args: {
   // One-time orphan sweep (O19): clear `terminalTabs.*` snapshots whose task
   // no longer exists. Runs once on first hydration; ref not dep, so a later
   // task-list change never re-sweeps a live task's fresh snapshot.
+  //
+  // The `tasks.length === 0` guard is load-bearing and SUFFICIENT, despite
+  // reading like a weak null-check: this list is only ever assigned from the
+  // daemon's own index (`hello.tasks` / `task.snapshot` — nothing else calls
+  // `setTasks`), a corrupt or unreadable manifest recovers to an EMPTY index
+  // rather than a truncated one, and a daemon serving a foreign home is
+  // rejected before its list is believed. So a NON-EMPTY list here is the
+  // daemon's authoritative task set, and anything absent from it is a genuine
+  // orphan. Do not relax the empty check — empty is exactly the shape a
+  // pre-connection render and a corrupt-manifest recovery both take, and
+  // sweeping on it would wipe every live snapshot on the machine.
   const sweptOrphansRef = useRef(false)
   useEffect(() => {
     if (sweptOrphansRef.current || tasks.length === 0) return
@@ -88,6 +111,13 @@ export function useWorkspaceSelection(args: {
   // invisible to the pane once unmounted. Watch the task snapshot and release
   // the corpses; the pane never kills (registry docs), so this is the one
   // place tab shells die with their task.
+  //
+  // The worktree-gone notifier is held by REF, not listed as a dep: the host
+  // rebuilds that callback every render, and depending on it would re-run this
+  // effect each render — which also rewrites `worktreePathsRef`, the very
+  // thing the transition below is measured against. Same useLatest shape
+  // use-inbox-host uses for its notifiers.
+  const notifyWorktreeGoneRef = useLatest(args.notifyWorktreeGone)
   const liveTaskIdsRef = useRef<ReadonlySet<string>>(new Set())
   const worktreePathsRef = useRef<ReadonlyMap<string, string>>(new Map())
   useEffect(() => {
@@ -104,13 +134,31 @@ export function useWorkspaceSelection(args: {
     // shells alive in a deleted directory. A non-empty → empty transition
     // is the observable edge; task deletion itself is already covered by
     // the delete flow's forgetTaskTabs + the live-task sweep above.
+    //
+    // ANNOUNCE IT. This destroys every tab of a task the user did NOT delete,
+    // triggered by something that happened somewhere else (another client, a
+    // web action, another agent's `rove api`) — and it did it silently, which
+    // is how "the tab I was working in just vanished" reached the owner with
+    // nothing to look at (2026-08-29). The toast is deliberately not a
+    // confirm: the worktree is ALREADY gone by the time this runs, so there is
+    // nothing left to consent to, and a modal here would interrupt for a
+    // decision the user cannot make. Telling them what happened, and that the
+    // branch survives, is the whole remedy.
     const paths = new Map<string, string>()
     for (const task of tasks) paths.set(task.id, task.worktreePath)
     for (const [id, prevPath] of worktreePathsRef.current) {
       const now = paths.get(id)
       if (now === "" && prevPath !== "") {
+        const closed = knownTaskTabs(kv, id)?.tabs.length ?? 0
         registry.releaseWhere((key) => key === id || key.startsWith(`${id}::`))
         forgetTaskTabs(kv, id)
+        const task = tasks.find((candidate) => candidate.id === id)
+        notifyWorktreeGoneRef.current?.({
+          taskId: id,
+          title: task?.title ?? id,
+          branch: task?.branch ?? "",
+          closed,
+        })
       }
     }
     worktreePathsRef.current = paths

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -103,6 +103,9 @@ export const en = {
     scratchAdopted: "Adopted into {repo} — save it as a project from New Task if you want it in the picker",
     scratchOpenFailed: "Couldn't open a scratch shell: {message}",
     scratchCloseFailed: "Couldn't close the scratch task: {message}",
+    worktreeGoneTitle: 'Worktree for "{title}" is gone',
+    worktreeGoneBody:
+      "Closed {count} tab(s). The branch {branch} is still there — reopen the task to re-create its worktree.",
   },
 }
 
@@ -188,5 +191,7 @@ export const zh: typeof en = {
     scratchAdopted: "已归入 {repo}——若要出现在项目选择器里,可在新建任务中保存为项目",
     scratchOpenFailed: "无法打开临时 Shell:{message}",
     scratchCloseFailed: "无法关闭临时任务:{message}",
+    worktreeGoneTitle: '"{title}" 的 worktree 已消失',
+    worktreeGoneBody: "已关闭 {count} 个标签页。分支 {branch} 仍在——重新打开该任务会重建 worktree。",
   },
 }

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -57,7 +57,10 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
   }
   const ctx: DaemonHandlerContext = {
     runtime: daemonRuntime,
-    orch: { listTasks: () => [], ...orch } as unknown as Orchestrator,
+    // `getTask` is on the real DaemonOrchestrator contract; defaulted here so
+    // every handler test inherits it (the deletion audit reads the task before
+    // the index drops it). A test that cares supplies its own.
+    orch: { listTasks: () => [], getTask: () => undefined, ...orch } as unknown as Orchestrator,
     bus: {
       publish: (channel: string, payload: unknown) => rec.published.push({ channel, payload }),
     } as unknown as DaemonEventBus,

--- a/packages/kobe/test/daemon/handlers-task-crud.test.ts
+++ b/packages/kobe/test/daemon/handlers-task-crud.test.ts
@@ -7,7 +7,7 @@
  * in `handler-test-context.ts` so neither suite imports the other.
  */
 
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { SERIALIZED_TASK, TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
 
 describe("daemon handler registry — tasks, issues, worktrees", () => {
@@ -112,6 +112,35 @@ describe("daemon handler registry — tasks, issues, worktrees", () => {
       expect(rec.cleared).toEqual([])
       expect(rec.inboxTaskDeleted).toEqual([])
       expect(rec.deletions).toEqual([])
+    })
+
+    // Regression (2026-08-29): a delete left no record of WHO asked, so an
+    // agent deleting somebody's live task was untraceable. The CLI sends its
+    // verified session; the handler must put it in the audit line — and must
+    // write that line even when the delete is REFUSED, since a refused
+    // destructive request is exactly as worth recording.
+    it("task.delete audits the caller's verified session, refusal included", async () => {
+      const lines: string[] = []
+      const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+        lines.push(String(chunk))
+        return true
+      })
+      const { ctx } = fakeCtx({
+        getTask: () => ({ id: "t1", title: "live work", kind: "task", branch: "feat/x", worktreePath: "/wt/x" }),
+        prepareTaskDeletion: async () => {
+          throw new Error("refused: DIRTY_WORKTREE")
+        },
+      })
+      await expect(
+        dispatch("task.delete", { taskId: "t1", requestedByTaskId: "01CALLER", requestedByTabId: "tab-3" }, ctx),
+      ).rejects.toThrow("DIRTY_WORKTREE")
+      spy.mockRestore()
+
+      const log = lines.join("")
+      expect(log).toContain("task-deletion-audit")
+      expect(log).toContain("requested task t1")
+      expect(log).toContain("by=01CALLER::tab-3")
+      expect(log).toContain("/wt/x")
     })
 
     it("task.delete does not enqueue an unknown task", async () => {

--- a/packages/kobe/test/daemon/task-deletion-audit.test.ts
+++ b/packages/kobe/test/daemon/task-deletion-audit.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Task deletion is the most destructive thing an `rove api` caller can do to
+ * someone else's live session, and until this module existed the daemon logged
+ * a line ONLY when the worktree removal FAILED. A successful delete left no
+ * record, and no delete recorded who asked — which is why the owner-reported
+ * "a tab I was working in vanished and it wasn't me" (2026-08-29) was only
+ * traceable by the accident of that removal happening to fail.
+ *
+ * These assert the two properties a reader of `daemon.log` depends on: every
+ * phase leaves a line, and each line carries enough to answer "who and what".
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest"
+import type { DaemonTask } from "../../../kobe-daemon/src/daemon/contracts.ts"
+import {
+  auditDeletionFailed,
+  auditDeletionRemoved,
+  auditDeletionRequested,
+} from "../../../kobe-daemon/src/daemon/task-deletion-audit.ts"
+
+function capture(): { lines: string[]; restore: () => void } {
+  const lines: string[] = []
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    lines.push(String(chunk))
+    return true
+  })
+  return { lines, restore: () => spy.mockRestore() }
+}
+
+function task(overrides: Partial<DaemonTask> = {}): DaemonTask {
+  return {
+    id: "01TASK",
+    title: "fix the thing",
+    repo: "/repo",
+    branch: "fix/thing",
+    worktreePath: "/wt/hammerhead",
+    kind: "task",
+    status: "backlog",
+    createdAt: "2026-08-29T00:00:00.000Z",
+    updatedAt: "2026-08-29T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("task-deletion audit", () => {
+  test("a requested deletion names the subject, the flags, and the caller", () => {
+    const { lines, restore } = capture()
+    auditDeletionRequested(
+      "01TASK",
+      task(),
+      { clientId: 7, requestedBy: { taskId: "01CALLER", tabId: "tab-2" } },
+      { force: true, deleteBranch: false },
+    )
+    restore()
+    const line = lines.join("")
+    expect(line).toContain("task-deletion-audit")
+    expect(line).toContain("requested")
+    expect(line).toContain("01TASK")
+    expect(line).toContain("fix/thing")
+    expect(line).toContain("/wt/hammerhead")
+    expect(line).toContain("force=true")
+    expect(line).toContain("deleteBranch=false")
+    // The whole point: WHO asked.
+    expect(line).toContain("by=01CALLER::tab-2")
+    expect(line).toContain("client=7")
+  })
+
+  test("an unverified caller is left unattributed rather than blamed via the spawner", () => {
+    const { lines, restore } = capture()
+    // `dispatcher` is the task's SPAWNER — reported, but never as the deleter.
+    auditDeletionRequested("01TASK", task({ dispatcher: { taskId: "01SPAWNER", tabId: "tab-1" } }), { clientId: 3 })
+    restore()
+    const line = lines.join("")
+    expect(line).toContain("spawnedBy=01SPAWNER::tab-1")
+    expect(line).not.toContain("by=01SPAWNER")
+  })
+
+  test("a SUCCESSFUL removal is recorded — the case that used to be silent", () => {
+    const { lines, restore } = capture()
+    auditDeletionRemoved("01TASK", task())
+    restore()
+    const line = lines.join("")
+    expect(line).toContain("removed")
+    expect(line).toContain("01TASK")
+    expect(line).toContain("/wt/hammerhead")
+  })
+
+  test("a failed removal says what was ALREADY undone, not just the error", () => {
+    const { lines, restore } = capture()
+    auditDeletionFailed("01TASK", task(), new Error("is not a git worktree"))
+    restore()
+    const line = lines.join("")
+    expect(line).toContain("failed")
+    expect(line).toContain("is not a git worktree")
+    // The half a bare stack never told anyone: the task is half-deleted.
+    expect(line).toContain("ALREADY ran")
+  })
+
+  test("a task already dropped from the index still yields a usable line", () => {
+    const { lines, restore } = capture()
+    auditDeletionRemoved("01GONE", undefined)
+    restore()
+    expect(lines.join("")).toContain("01GONE")
+  })
+})

--- a/packages/kobe/test/daemon/task-deletion-runner.test.ts
+++ b/packages/kobe/test/daemon/task-deletion-runner.test.ts
@@ -33,6 +33,7 @@ describe("TaskDeletionRunner", () => {
             releaseFinish = resolve
           }),
       ),
+      getTask: vi.fn(() => task("t1", "running")),
     } as unknown as DaemonOrchestrator
     const tearDownTaskSession = vi.fn(async () => {
       order.push("teardown")
@@ -60,6 +61,7 @@ describe("TaskDeletionRunner", () => {
         return true
       }),
       finishTaskDeletion: vi.fn(async () => {}),
+      getTask: vi.fn((id: string) => task(id, "running")),
     } as unknown as DaemonOrchestrator
     const runner = new TaskDeletionRunner(orch, { tearDownTaskSession: async () => {} }, () => {})
 
@@ -68,5 +70,38 @@ describe("TaskDeletionRunner", () => {
 
     expect(begun.sort()).toEqual(["queued", "running"])
     expect(orch.finishTaskDeletion).toHaveBeenCalledTimes(2)
+  })
+
+  // Regression (2026-08-29): only a FAILED removal was ever logged, so a
+  // successful delete — the destructive case that actually closes somebody's
+  // tabs — left no trace, and neither line said what was destroyed.
+  it("audits both outcomes, naming the task even though the index has dropped it", async () => {
+    const lines: string[] = []
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      lines.push(String(chunk))
+      return true
+    })
+    const failing = "boom"
+    const orch = {
+      beginTaskDeletion: vi.fn(async () => true),
+      finishTaskDeletion: vi.fn(async (id: string) => {
+        if (id === failing) throw new Error("is not a git worktree")
+      }),
+      // Mirrors production: after `finishTaskDeletion` the task is GONE from
+      // the index, so the audit has to have snapshotted it beforehand.
+      getTask: vi.fn((id: string) => task(id, "running")),
+    } as unknown as DaemonOrchestrator
+    const runner = new TaskDeletionRunner(orch, { tearDownTaskSession: async () => {} }, () => {})
+
+    runner.enqueue("ok")
+    runner.enqueue(failing)
+    await runner.drain()
+    spy.mockRestore()
+
+    const log = lines.join("")
+    expect(log).toContain("removed task ok")
+    expect(log).toContain("/wt/ok")
+    expect(log).toContain("failed task boom")
+    expect(log).toContain("is not a git worktree")
   })
 })

--- a/packages/kobe/test/render/workspace-worktree-gone-notice.test.tsx
+++ b/packages/kobe/test/render/workspace-worktree-gone-notice.test.tsx
@@ -1,0 +1,136 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * A task whose worktree disappears out-of-band (another client, the worktrees
+ * page, another agent's `rove api`) has ALL of its terminal tabs dropped — its
+ * PTYs released and its persisted snapshot deleted. That was silent, which is
+ * how "the tab I was working in just vanished" reached the owner with nothing
+ * to look at (2026-08-29). It must announce itself.
+ *
+ * Deliberately NOT a confirm dialog: the worktree is already gone by the time
+ * this runs, so there is nothing left to consent to.
+ */
+
+import { describe, expect, it } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { useCallback, useEffect, useState } from "react"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { terminalTabsKey } from "../../src/tui-react/workspace/terminal-tabs-persist"
+import { type WorktreeGoneEvent, useWorkspaceSelection } from "../../src/tui-react/workspace/use-workspace-selection"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { act, renderComponent, settle } from "./harness"
+
+function task(id: string, worktreePath: string): Task {
+  return {
+    id: toTaskId(id),
+    title: `work on ${id}`,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  }
+}
+
+function mockOrchestrator() {
+  const activeCell = createStateCell<string | null>(null)
+  return {
+    activeTaskSignal: () => activeCell,
+    setActiveTask: () => Promise.resolve(),
+    ensureWorktree: () => Promise.resolve(),
+    reportUiEvent: () => {},
+  } as unknown as RemoteOrchestrator
+}
+
+/** Drives the worktree-path change through state so one mount observes the
+ *  non-empty → empty transition the hook keys off. */
+function Probe(props: {
+  kv: { store: Record<string, unknown>; set: (key: string, value: unknown) => void }
+  onGone: (event: WorktreeGoneEvent) => void
+  onReady: (removeWorktree: () => void) => void
+}) {
+  const [worktreePath, setWorktreePath] = useState("/wt/alpha")
+  useWorkspaceSelection({
+    orch: mockOrchestrator(),
+    tasks: [task("alpha", worktreePath)],
+    activeTaskId: null,
+    focusWorkspace: () => {},
+    kv: props.kv,
+    notifyWorktreeGone: props.onGone,
+  })
+  useEffect(() => {
+    props.onReady(() => setWorktreePath(""))
+  }, [props.onReady])
+  return null
+}
+
+/** Stable prop identities so the probe's ready-effect runs once. */
+function Harness(props: {
+  kv: { store: Record<string, unknown>; set: (key: string, value: unknown) => void }
+  onGone: (event: WorktreeGoneEvent) => void
+  onReady: (removeWorktree: () => void) => void
+}) {
+  const onGone = useCallback(props.onGone, [])
+  const onReady = useCallback(props.onReady, [])
+  return <Probe kv={props.kv} onGone={onGone} onReady={onReady} />
+}
+
+describe("a worktree vanishing under a live task", () => {
+  it("reports the dropped tabs instead of closing them silently", async () => {
+    process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-wt-gone-"))
+    const store: Record<string, unknown> = {
+      // Two tabs the user was working in.
+      [terminalTabsKey("alpha")]: {
+        tabs: [
+          { kind: "engine", id: "tab-1", title: null, ordinal: 1 },
+          { kind: "engine", id: "tab-2", title: null, ordinal: 2 },
+        ],
+        activeId: "tab-1",
+        nextOrdinal: 3,
+      },
+    }
+    const kv = {
+      store,
+      set: (key: string, value: unknown) => {
+        if (value === undefined) delete store[key]
+        else store[key] = value
+      },
+    }
+    const events: WorktreeGoneEvent[] = []
+
+    let removeWorktree: (() => void) | null = null
+    await renderComponent(
+      <Harness
+        kv={kv}
+        onGone={(e) => events.push(e)}
+        onReady={(fn) => {
+          removeWorktree = fn
+        }}
+      />,
+      { width: 46, height: 10 },
+    )
+    await settle()
+    // Baseline: nothing announced, snapshot intact.
+    expect(events).toEqual([])
+    expect(store[terminalTabsKey("alpha")]).toBeDefined()
+
+    // The worktree is removed elsewhere: the task survives, its path is cleared.
+    act(() => removeWorktree?.())
+    await settle()
+
+    // The tabs really are dropped (the existing behavior) …
+    expect(store[terminalTabsKey("alpha")]).toBeUndefined()
+    // … and the user is told, with enough to know what they lost and that the
+    // branch survived.
+    expect(events.length).toBe(1)
+    expect(events[0].taskId).toBe("alpha")
+    expect(events[0].title).toBe("work on alpha")
+    expect(events[0].branch).toBe("feat/alpha")
+    expect(events[0].closed).toBe(2)
+  })
+})


### PR DESCRIPTION
## Why

Two defects behind the owner's "a tab I was working in vanished and it wasn't me" report (2026-08-29).

**1. Deletions had no audit.** `TaskDeletionRunner` logged only when the worktree removal FAILED. A successful delete — the case that actually closes someone's tabs — left no trace, and no delete recorded who asked. That incident was traceable only by the accident of its removal happening to fail.

**2. Tab destruction was silent.** When a task's `worktreePath` goes non-empty → empty (its worktree removed by another client, the worktrees page, or another agent's `rove api`), `use-workspace-selection` releases every PTY and deletes the whole tab snapshot. No toast, no log, no undo.

## What changed

**Audit** — new `task-deletion-audit.ts` writes one `daemon.log` line per phase:

- `requested` — emitted before `prepareTaskDeletion`, so a REFUSED delete (dirty worktree) is recorded too. Carries the task, branch, worktree path, `force`/`deleteBranch`, and the caller.
- `removed` — the case that used to be silent.
- `failed` — names what has ALREADY been undone (session teardown + Inbox/activity cleanup ran; worktree and task entry remain), preserving the original error's stack rather than wrapping it.

Caller identity: `rove api delete` now sends its VERIFIED session (`verifiedSelfSession`, same check `send`/`add` use), so an agent deleting somebody's task shows as `by=<taskId>::<tabId>`. Never the bare `$ROVE_TASK_ID` env — that inherits down the whole process tree (issue #24), so an unverifiable caller stays unattributed rather than blaming a stranger's session. The task's own `dispatcher` is reported separately as `spawnedBy=` and labelled so it is never mistaken for the deleter.

Chose `daemon.log` over a new audit file: it is already where users are told to look, `rove doctor --report` already bundles its tail, and it is already size-capped and rotated.

**Silent destruction** — the worktree-gone path now reports through a `notifyWorktreeGone` callback; the host raises a toast naming how many tabs closed and that the branch survives. Deliberately not a confirm dialog: the worktree is already gone by the time this runs, so there is nothing left to consent to, and per the brief no blocking prompt was wanted.

**`sweepOrphanTabsSnapshots` risk (asked for an evaluation, not necessarily a fix): not real, left alone.** Its `tasks.length === 0` guard reads weak but holds — `tasks` is only ever assigned from the daemon's own index (`hello.tasks` / `task.snapshot`; nothing else calls `setTasks`), a corrupt manifest recovers to an EMPTY index rather than a truncated one, and a foreign-home daemon is rejected before its list is believed. So a non-empty list here is authoritative. I documented that reasoning in place instead of adding a guard. I did try gating on connection state and reverted it: `connectionStateAcc` initialises to `"online"`, so it would have been decoration, not a guard.

## Deliberately not done

**Half-finished deletion consistency** (brief item 3, scoped out as it allows). When `finishTaskDeletion` throws, the session teardown and Inbox/activity cleanup have already run and are not rolled back; the task is retained in `deletion.phase === "error"` with the worktree still on disk. Rolling back is not obviously right — the session is genuinely dead and re-creating it would be a lie — so this PR makes the intermediate state *legible* (the `failed` line states exactly what ran and what remains, and TROUBLESHOOTING.md explains the recovery) rather than changing the semantics. A real fix should decide whether teardown should move after the worktree removal instead.

Also untouched per the brief: `ctrl+w` keybinding/confirm, and issue #47.

coverage-exemption: packages/kobe/src/tui-react/workspace/host.tsx — structurally untestable integration layer (needs a live daemon + PTY); named as exactly this case in docs/HARNESS.md. The change here is the wiring of one callback into the existing toast surface; the behavior it wires is covered by a bun-test render test on the hook that produces the event (`use-workspace-selection.ts`, 77.7%) plus the behavior and visual-ground-truth tracks.

## Verification

Live, in an isolated named sandbox (`--name delaudit`, never the shared `.dev-sandbox`), against a real daemon:

- plain delete → `requested` + `removed`
- dirty worktree → `requested` recorded, then refused (nothing destroyed)
- **reproduced the owner's exact incident** — stripped a worktree of its `.git` and force-deleted it:

```
daemon [task-deletion-audit]: requested task 01M18049… title="stack v2" kind=task branch=stack-v2 worktree=…/fox force=true deleteBranch=false (client=…)
daemon error [task-deletion-audit]: WorktreeRemoveFailedError: failed task 01M18049… — session teardown and activity/inbox cleanup ALREADY ran; the worktree directory and task entry remain. Reason: … 'is not a working tree'
    at finish (…/orchestrator/task-deletion.ts:85:27)
```

Tests: `bun test test/render` 236 pass, `test:socket` 591 pass, lint/typecheck/check-i18n clean. `test:fast` has 47 failures in CLI/TUI files — verified pre-existing by stashing this branch's changes and re-running to the identical 47.

The render test was mutation-checked: it fails when the notification call is removed.



## CI

All jobs green except `visual-ground-truth`, which fails identically on `main` (run 33282925029, job 99181031913) — the same five `e2e/sandbox.spec.ts` specs (:80, :104, :119, :141, :167), same `toContainText` failures. Pre-existing, unrelated to this change.
