### PR TITLE
test: fix behavior + visual-ground-truth CI gates (issue #79)

### DIFF
--- a/.changeset/ci-red-behavior-visual.md
+++ b/.changeset/ci-red-behavior-visual.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the CI behavior and visual-ground-truth gates on main (issue #79). The hosted-PTY lifecycle behavior test still asserted the removed archive semantics and raced the daemon's asynchronous delete pipeline; it now polls for the converged deleted state. The visual fixture no longer seeds an engine tab for the fixture task, which CI (no engine binary) booted straight into a code-127 dead-engine state, hiding the sidebar row every journey asserts.

--- a/packages/kobe-web/e2e/visual-fixture.ts
+++ b/packages/kobe-web/e2e/visual-fixture.ts
@@ -3,7 +3,6 @@ import { basename, join, relative, resolve, sep } from "node:path"
 import {
   assertFixtureIsolation,
   buildFixtureEnv,
-  createTaskWithChatTab,
   fixturePaths,
   fixturePortBase,
   runInFixture,
@@ -88,7 +87,7 @@ export const VISUAL_PTY_COMMAND = `${[
 ].join(" ")} bun run dev:sandbox`
 
 /** Bump when the fixture shape changes so warm reuse rebuilds. */
-const FIXTURE_VERSION = "4"
+const FIXTURE_VERSION = "5"
 const FIXTURE_MARKER = join(VISUAL_ROOT, "fixture-ok")
 
 function assertSafeVisualRoot(): void {
@@ -201,17 +200,24 @@ export default async function setupVisualFixture(): Promise<void> {
     { email: "visual@kobe.local", name: "kobe visual" },
   )
 
-  const taskId = createTaskWithChatTab(
-    ROVE_CLI,
-    {
-      title: "Visual Fixture",
-      repo: VISUAL_REPO,
-      prompt: "Read the README and tell me in one line what this package does.",
-      command: "claude",
-    },
-    KOBE_DIR,
-    VISUAL_ENV,
-  )
+  // Bare task, NO chat tab. The journeys assert the sidebar row label
+  // "Visual Fixture", which a seeded engine tab overwrites with its own
+  // first-turn title — and CI has no engine binary at all, so the tab would
+  // boot straight into the code-127 dead-engine state (issue #79). The
+  // pre-fixture-core seeding did exactly this bare `add`; only hero fixtures
+  // (which run where a real engine exists) seed chat tabs.
+  const added = runRove([
+    "add",
+    "--repo",
+    VISUAL_REPO,
+    "--title",
+    "Visual Fixture",
+    "--command",
+    "claude",
+    "--activate",
+  ]) as { taskId?: unknown }
+  if (typeof added.taskId !== "string") throw new Error("visual fixture task creation returned no taskId")
+  const taskId = added.taskId
 
   const backlogTitle = "Backlog fixture"
   const progressTitle = "In progress fixture"

--- a/packages/kobe/test/behavior/pty-api-autostart.test.ts
+++ b/packages/kobe/test/behavior/pty-api-autostart.test.ts
@@ -20,6 +20,24 @@ interface PtyListResult {
   sessions: Array<{ key: string; alive: boolean; command: string[] }>
 }
 
+/**
+ * Poll `check` until it reports convergence (returns null) or the deadline
+ * passes, then fail with the last observed state. Deletion is deliberately
+ * asynchronous (the daemon owns a durable queued → running → finished
+ * pipeline), so the post-delete state must be awaited, not asserted at one
+ * racily-timed instant.
+ */
+async function waitForConverged(check: () => string | null, timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  let last: string | null = null
+  while (Date.now() < deadline) {
+    last = check()
+    if (last === null) return
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(`delete did not converge within ${timeoutMs}ms: ${last ?? "unknown"}`)
+}
+
 describe("rove api hosted PTY lifecycle (behavior)", () => {
   let env: BehaviorEnv
   let repo: string
@@ -56,16 +74,30 @@ describe("rove api hosted PTY lifecycle (behavior)", () => {
     expect(sessions).toContainEqual(expect.objectContaining({ key: session, alive: true }))
   }, 30_000)
 
-  it("send reuses the canonical session and delete tears it down", () => {
+  it("send reuses the canonical session and delete tears it down", async () => {
     const sent = runRove(["api", "send", "--task-id", taskId, "--prompt", "follow-up", "--pretty"], env)
-    expect(sent.code).toBe(0)
+    expect(sent.code, `send failed: stdout=${JSON.stringify(sent.stdout)} stderr=${sent.stderr}`).toBe(0)
     const afterSend = JSON.parse(runRove(["api", "pty-list", "--pretty"], env).stdout) as PtyListResult
     expect(afterSend.sessions.filter((entry) => entry.key === session && entry.alive)).toHaveLength(1)
 
     const deleted = runRove(["api", "delete", "--task-id", taskId, "--force"], env)
-    expect(deleted.code).toBe(0)
-    const afterDelete = JSON.parse(runRove(["api", "pty-list", "--pretty"], env).stdout) as PtyListResult
-    expect(afterDelete.sessions.filter((entry) => entry.key === session && entry.alive)).toHaveLength(0)
-    expect(existsSync(worktreePath)).toBe(false)
+    expect(deleted.code, `delete failed: stdout=${JSON.stringify(deleted.stdout)} stderr=${deleted.stderr}`).toBe(0)
+
+    // The converged end state: the task is unaddressable (TASK_NOT_FOUND, not
+    // a parse of empty output), its hosted session is dead, and its worktree
+    // is gone. Before the archive removal (issue #75) this asserted the
+    // archived row lingered in the index; delete has no such lingering state.
+    await waitForConverged(() => {
+      const task = runRove(["api", "get-task", "--task-id", taskId, "--pretty"], env)
+      if (task.code !== 1 || !task.stderr.includes("TASK_NOT_FOUND")) {
+        return `get-task: code=${task.code} stdout=${JSON.stringify(task.stdout)} stderr=${task.stderr}`
+      }
+      const listed = runRove(["api", "pty-list", "--pretty"], env)
+      if (listed.code !== 0) return `pty-list: code=${listed.code} stderr=${listed.stderr}`
+      const sessions = (JSON.parse(listed.stdout) as PtyListResult).sessions
+      if (sessions.some((entry) => entry.key === session && entry.alive)) return `session ${session} still alive`
+      if (existsSync(worktreePath)) return `worktree still exists: ${worktreePath}`
+      return null
+    })
   }, 30_000)
 })


### PR DESCRIPTION
## 根因（两条独立的红，各自一个根因）

### behavior gate — `pty-api-autostart.test.ts`
这条红不是 `rove api send` 产品坏了，是 **e52d3130（#75 C2）把测试从 archive 改写到 delete 时断言写错了**：

- delete 在 daemon 里是异步管线（queued → running → finished，`task-deletion-runner.ts`），store 条目在 finish 时才删除。测试在 delete 后立刻 `get-task`，和后台删除竞争 → `TASK_NOT_FOUND` → stdout 空 → :71 `JSON.parse` 炸。
- vitest `--retry=2` 重跑整个 it 时，`send` 指向已被删除的 task → `task.get` 抛错 → 退出 1、stdout 空 → 就是 CI 里反复出现的 :65 `expected 1 to be +0`。CI 日志里 [1/3] 是 :71、[2/3][3/3] 是 :65，就是这个顺序。

修复：测试改为轮询收敛终态（get-task 返回 TASK_NOT_FOUND、session 已死、worktree 已删），并按 issue 要求把 send/delete 的 stderr 带进断言信息。测试覆盖的行为没有丢：add 物化 worktree + 自动启动 canonical session、send 复用同一 session、delete 拆除 session + worktree + index 条目，全部保留。这是该路径唯一的黑盒覆盖，**没有删测试**。

### visual-ground-truth gate — `sandbox.spec.ts`
fixture-core 重构（813cdfe7 + 931d46b3，97f038b7 合入）把 visual fixture 任务从裸 `add` 改成 `createTaskWithChatTab`（send 一个 prompt，必然拉起引擎 tab）。CI 上没有引擎二进制 → tab 启动即 exit 127 → 死引擎 tab 的首轮标题覆盖了 sidebar 的 "Visual Fixture" 行 → 所有 5 个 journey 在 :69 超时。本地（有真引擎）同样会红，因为行标签会被 tab 标题覆盖——这不是 CI 环境问题。

修复：visual fixture 改回裸 `add`（e52d3130 的形状），hero fixture 保留 chat tab（它运行在真有引擎的环境）。FIXTURE_VERSION 4→5，warm 复用会重建。

## 验证
- behavior 单文件 3/3 绿，全套件绿（本地无 PTY 的套件按原样 skip，CI 覆盖）
- fixture seed 本地直接验证：任务创建、无 tab、marker=5、cleanup 正常
- visual 套件本地无法端到端跑（本机 posix_spawnp 被沙箱拒绝，与 ci.yml 注释的 macOS 限制一致），由本 PR 的 CI 验证
- `test:fast` 里 11 个 `Usage: kobe` 失败在干净 main 上同样出现（本会话以 rove 身份运行所致），与本改动无关

## 删测试了吗
没有。两个 job 的根因都是测试/fixture 断言了移除后不再成立的行为（archive 语义、fixture 带活引擎 tab），产品和 fixture 按各自的新语义修正。

Closes 本地 issue #79（daemon issue store，合入后我来标 done）。