### PR TITLE
feat(api-send): accept-and-defer busy-composer prompts via inbox (issue #78 B)

### DIFF
--- a/.changeset/composer-busy-gate-issue-78.md
+++ b/.changeset/composer-busy-gate-issue-78.md
@@ -2,9 +2,9 @@
 "@sma1lboy/rove": patch
 ---
 
-Stop `rove api send` from pasting a peer message into a composer that already holds a half-typed message; a blocked prompt is now accepted-and-deferred, not dropped or hard-rejected (issue #78).
+Add A+C delivery gates so `rove api send` no longer pastes into a busy composer (issue #78).
 
-- A-layer: the PTY host records `lastHumanWriteMs` for writes from attached clients and returns it from `pty.peek` with the configurable quiet period (`KOBE_PTY_HUMAN_WRITE_QUIET_MS`, default 10s).
-- C-layer: new pure `isComposerEmpty(ringBytes, manifest)` renders ring bytes through headless xterm against engine-owned `composerEmpty` rules (manifests for Claude, Kimi, Codex; engines without one skip the gate, fail-open).
-- B-layer (accept-and-defer): when A or C blocks, the prompt text is stored in a new daemon-owned `DeferredPromptsStore` (one record per task+tab, 24h TTL, displacement/expiry/deletion all logged — never silently dropped) and a `prompt_deferred` attention-inbox episode is recorded. `send`/`add --prompt` return an accepted-but-deferred outcome (`deferred: {id, layer}`) which is a SUCCESS — callers must not retry, or the same message stacks in the queue.
-- Exit path: opening the `prompt_deferred` inbox item jumps to the tab and inserts the queued message with a FRESH A/C gate (no new chord), then resolves the record + episode; if the composer is still busy the message stays queued. Toast + inbox copy added in both locales.
+- A-layer: the PTY host now records `lastHumanWriteMs` for writes that come from an attached client. `pty.peek` returns the timestamp and the configurable quiet period (`KOBE_PTY_HUMAN_WRITE_QUIET_MS`, default 10s); delivery is refused while the window is open.
+- C-layer: new pure `isComposerEmpty(ringBytes, manifest)` renders ring bytes through headless xterm and evaluates engine-owned `composerEmpty` rules. Manifests added for Claude, Kimi, and Codex; engines without a manifest skip this gate (fail-open).
+- Delivery paths (`api send`, `api add --prompt`, exact-tab send, daemon quota-resume) now refuse with a typed `COMPOSER_BUSY` error naming the blocking layer instead of silently concatenating peer text with user input.
+- Layer B (accept-and-defer) lands separately — see the deferred-prompt-inbox changeset in this release.

--- a/.changeset/composer-busy-gate-issue-78.md
+++ b/.changeset/composer-busy-gate-issue-78.md
@@ -2,9 +2,9 @@
 "@sma1lboy/rove": patch
 ---
 
-Add A+C delivery gates so `rove api send` no longer pastes into a busy composer (issue #78).
+Stop `rove api send` from pasting a peer message into a composer that already holds a half-typed message; a blocked prompt is now accepted-and-deferred, not dropped or hard-rejected (issue #78).
 
-- A-layer: the PTY host now records `lastHumanWriteMs` for writes that come from an attached client. `pty.peek` returns the timestamp and the configurable quiet period (`KOBE_PTY_HUMAN_WRITE_QUIET_MS`, default 10s); delivery is refused while the window is open.
-- C-layer: new pure `isComposerEmpty(ringBytes, manifest)` renders ring bytes through headless xterm and evaluates engine-owned `composerEmpty` rules. Manifests added for Claude, Kimi, and Codex; engines without a manifest skip this gate (fail-open).
-- Delivery paths (`api send`, `api add --prompt`, exact-tab send, daemon quota-resume) now refuse with a typed `COMPOSER_BUSY` error naming the blocking layer instead of silently concatenating peer text with user input.
-- Layer B (queue when attached clients are present) is intentionally not implemented; its UI shape is a product decision pending owner confirmation.
+- A-layer: the PTY host records `lastHumanWriteMs` for writes from attached clients and returns it from `pty.peek` with the configurable quiet period (`KOBE_PTY_HUMAN_WRITE_QUIET_MS`, default 10s).
+- C-layer: new pure `isComposerEmpty(ringBytes, manifest)` renders ring bytes through headless xterm against engine-owned `composerEmpty` rules (manifests for Claude, Kimi, Codex; engines without one skip the gate, fail-open).
+- B-layer (accept-and-defer): when A or C blocks, the prompt text is stored in a new daemon-owned `DeferredPromptsStore` (one record per task+tab, 24h TTL, displacement/expiry/deletion all logged — never silently dropped) and a `prompt_deferred` attention-inbox episode is recorded. `send`/`add --prompt` return an accepted-but-deferred outcome (`deferred: {id, layer}`) which is a SUCCESS — callers must not retry, or the same message stacks in the queue.
+- Exit path: opening the `prompt_deferred` inbox item jumps to the tab and inserts the queued message with a FRESH A/C gate (no new chord), then resolves the record + episode; if the composer is still busy the message stays queued. Toast + inbox copy added in both locales.

--- a/.changeset/deferred-prompt-inbox-issue-78.md
+++ b/.changeset/deferred-prompt-inbox-issue-78.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Accept-and-defer busy-composer prompts into the inbox (issue #78 B), completing the delivery gates.
+
+When the A (recent keystroke) or C (composer non-empty) gate blocks a paste, the prompt is no longer dropped or hard-rejected — ownership transfers to the daemon. The text is stored in a new daemon-owned `DeferredPromptsStore` (one record per task+tab, 24h TTL; displacement, expiry, and task-deletion are all written to the daemon log — never silently dropped) and a `prompt_deferred` attention-inbox episode is recorded pointing at the record by id.
+
+- `send` / `add --prompt` return an accepted-but-deferred outcome (`deferred: {id, layer}`) which is a SUCCESS — callers must not retry, or the same message stacks in the queue.
+- Exit path: opening the `prompt_deferred` inbox item jumps to the tab and inserts the queued message with a fresh A/C gate (reusing the existing open action, no new chord), then resolves the record + episode; a still-busy composer keeps it queued.
+- Toast on deferral plus inbox entry copy, in both locales. The `deferredPrompt.*` verbs are socket-only, off the pinned browser-reachable allowlist.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -33,6 +33,7 @@
     "./daemon/crash-log": "./src/daemon/crash-log.ts",
     "./daemon/collectors": "./src/daemon/collectors.ts",
     "./daemon/cwd-task": "./src/daemon/cwd-task.ts",
+    "./daemon/deferred-prompts-store": "./src/daemon/deferred-prompts-store.ts",
     "./daemon/engine-events-log": "./src/daemon/engine-events-log.ts",
     "./daemon/event-bus": "./src/daemon/event-bus.ts",
     "./daemon/file-watch-trigger": "./src/daemon/file-watch-trigger.ts",

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -148,6 +148,35 @@ export class AttentionInboxStore {
   }
 
   /**
+   * Record a `prompt_deferred` episode (issue #78 B-layer): a prompt the
+   * delivery gate blocked was accepted into the DeferredPromptsStore, and the
+   * episode points at that record by id (the prompt text is NOT copied here —
+   * `EngineActivityDetail` describes engine activity). One pending episode per
+   * task+tab, so a fresh deferral replaces the previous episode for the tab.
+   */
+  async recordPromptDeferred(
+    taskId: string,
+    tabId: string,
+    deferredId: string,
+    layer: "recent-human-write" | "composer-not-empty",
+  ): Promise<void> {
+    await this.enqueue(async () => {
+      const key = attentionInboxItemKey({ taskId, tabId })
+      const next = new Map(this.items)
+      next.delete(key)
+      next.set(key, {
+        taskId,
+        tabId,
+        state: "prompt_deferred",
+        detail: { deferredPrompt: { id: deferredId, layer } },
+        unread: true,
+        at: this.now(),
+      })
+      await this.commit(next)
+    })
+  }
+
+  /**
    * Legacy RPC (pre queue-drain model): opening now DELETES the episode
    * (`deleteEpisode` via attention.dismiss). Kept for old clients whose
    * open still calls attention.markRead — treat it as the same resolve.

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -215,6 +215,16 @@ export interface EngineActivityDetail {
   readonly compact?: { readonly trigger?: "manual" | "auto" }
   readonly subagent?: { readonly type?: string; readonly id?: string }
   readonly note?: string
+  /**
+   * Reference to a daemon-owned deferred-prompt record (issue #78 B-layer).
+   * Present only on `prompt_deferred` inbox episodes. The prompt TEXT lives in
+   * the DeferredPromptsStore, never here — this contract describes engine
+   * activity, and a raw prompt is not engine activity.
+   */
+  readonly deferredPrompt?: {
+    readonly id: string
+    readonly layer: "recent-human-write" | "composer-not-empty"
+  }
 }
 
 export type TaskActivityState = "idle" | "running" | "turn_complete" | "rate_limited" | "permission_needed" | "error"
@@ -255,13 +265,17 @@ export interface AgentTurnRecord extends Omit<AgentTurn, "sessionId"> {
 }
 
 /** States represented by pending Inbox items until handled or the same
- * Terminal Tab starts another turn. */
+ * Terminal Tab starts another turn. Deliberately NOT a subset of
+ * {@link TaskActivityState}: `prompt_deferred` is a queue/ownership state (a
+ * prompt the daemon accepted but could not paste), not an engine activity —
+ * the engine may be idle while a deferred prompt waits for release. */
 export const ATTENTION_INBOX_STATES = [
   "turn_complete",
   "permission_needed",
   "error",
   "rate_limited",
-] as const satisfies readonly TaskActivityState[]
+  "prompt_deferred",
+] as const
 
 export type AttentionInboxState = (typeof ATTENTION_INBOX_STATES)[number]
 

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -1,0 +1,191 @@
+/**
+ * Durable deferred-prompt store (issue #78 B-layer).
+ *
+ * When the delivery gate (A: recent human keystrokes / C: composer non-empty)
+ * blocks a prompt, the prompt is NOT dropped and NOT hard-rejected — ownership
+ * transfers to the daemon, which stores the text here and surfaces a
+ * `prompt_deferred` inbox episode. A human later releases it from the Inbox
+ * (the episode points here by id); the prompt text never lives in the inbox
+ * episode (EngineActivityDetail describes engine activity, not prompts).
+ *
+ * Shape follows notes-store.ts: one JSON file, atomic tmp+rename, `version: 1`.
+ * Retention is explicit and logged — a record never vanishes silently:
+ * - at most ONE deferred prompt per (taskId, tabId) — a newer deferral for a
+ *   tab that already has one REPLACES it (the displaced text is logged);
+ * - records older than {@link DEFERRED_PROMPT_TTL_MS} are evicted on write
+ *   (also logged).
+ */
+
+import { randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
+import { logDaemonInfo } from "./crash-log.ts"
+
+/** One deferred prompt per tab is kept; a newer deferral displaces the older. */
+export const DEFERRED_PROMPT_TTL_MS = 24 * 60 * 60 * 1000
+
+export type DeferredPromptLayer = "recent-human-write" | "composer-not-empty"
+
+/** One daemon-owned deferred prompt, awaiting a human's release from the Inbox. */
+export interface DeferredPromptRecord {
+  /** Stable id — the inbox episode references the record by this. */
+  readonly id: string
+  readonly taskId: string
+  readonly tabId: string
+  /** The prompt text, verbatim — the daemon owns it until release or expiry. */
+  readonly prompt: string
+  /** Which delivery-gate layer blocked the paste. */
+  readonly layer: DeferredPromptLayer
+  /** Sender provenance (peer dispatch carries a label + task id). */
+  readonly senderLabel?: string
+  readonly senderTaskId?: string
+  /** Epoch ms of deferral. */
+  readonly at: number
+}
+
+interface DeferredPromptsFile {
+  version: 1
+  records: DeferredPromptRecord[]
+}
+
+export function defaultDeferredPromptsPath(homeDir = readRoveEnv("HOME_DIR") ?? homedir()): string {
+  return join(homeDir, ROVE_STATE_DIR_BASENAME, "deferred-prompts.json")
+}
+
+function normalizeRecord(value: unknown): DeferredPromptRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  const raw = value as Record<string, unknown>
+  if (typeof raw.id !== "string" || raw.id.length === 0) return null
+  if (typeof raw.taskId !== "string" || raw.taskId.length === 0) return null
+  if (typeof raw.tabId !== "string" || raw.tabId.length === 0) return null
+  if (typeof raw.prompt !== "string" || raw.prompt.length === 0) return null
+  if (raw.layer !== "recent-human-write" && raw.layer !== "composer-not-empty") return null
+  if (typeof raw.at !== "number" || !Number.isFinite(raw.at)) return null
+  return {
+    id: raw.id,
+    taskId: raw.taskId,
+    tabId: raw.tabId,
+    prompt: raw.prompt,
+    layer: raw.layer,
+    ...(typeof raw.senderLabel === "string" ? { senderLabel: raw.senderLabel } : {}),
+    ...(typeof raw.senderTaskId === "string" ? { senderTaskId: raw.senderTaskId } : {}),
+    at: raw.at,
+  }
+}
+
+async function readStore(path: string): Promise<DeferredPromptsFile> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<DeferredPromptsFile>
+    if (!Array.isArray(parsed.records)) return { version: 1, records: [] }
+    return {
+      version: 1,
+      records: parsed.records.map(normalizeRecord).filter((r): r is DeferredPromptRecord => r !== null),
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, records: [] }
+    throw err
+  }
+}
+
+async function writeStore(path: string, records: readonly DeferredPromptRecord[]): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
+  const body: DeferredPromptsFile = { version: 1, records: [...records] }
+  await writeFile(tmp, `${JSON.stringify(body, null, 2)}\n`, "utf8")
+  await rename(tmp, path)
+}
+
+const SUBSYSTEM = "deferred-prompts"
+
+export class DeferredPromptsStore {
+  private readonly tail: Promise<void> = Promise.resolve()
+  private queue: Promise<void> = this.tail
+
+  constructor(
+    private readonly path = defaultDeferredPromptsPath(),
+    private readonly now = () => Date.now(),
+  ) {}
+
+  /** Serialize read-modify-write on the shared file (same unit as the inbox store). */
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.queue.then(operation)
+    this.queue = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
+  /**
+   * Store one deferred prompt, displacing any existing record for the same
+   * (taskId, tabId) and evicting TTL-expired records. Both displacements and
+   * expiries are logged — a deferred prompt never disappears silently.
+   * Returns the stored record (with its minted id).
+   */
+  async file(record: Omit<DeferredPromptRecord, "id">): Promise<DeferredPromptRecord> {
+    return await this.enqueue(async () => {
+      const now = this.now()
+      const store = await readStore(this.path)
+      const kept: DeferredPromptRecord[] = []
+      for (const existing of store.records) {
+        if (now - existing.at > DEFERRED_PROMPT_TTL_MS) {
+          logDaemonInfo(
+            SUBSYSTEM,
+            `expired deferred prompt ${existing.id} for ${existing.taskId}::${existing.tabId} (age ${Math.round((now - existing.at) / 1000)}s) — dropped`,
+          )
+          continue
+        }
+        if (existing.taskId === record.taskId && existing.tabId === record.tabId) {
+          logDaemonInfo(
+            SUBSYSTEM,
+            `displaced deferred prompt ${existing.id} for ${record.taskId}::${record.tabId} (superseded by a newer deferral) — older text dropped`,
+          )
+          continue
+        }
+        kept.push(existing)
+      }
+      const next: DeferredPromptRecord = { ...record, id: randomUUID() }
+      kept.push(next)
+      await writeStore(this.path, kept)
+      return next
+    })
+  }
+
+  /** Fetch one record by id, or null when it was released/expired/displaced. */
+  async get(id: string): Promise<DeferredPromptRecord | null> {
+    return await this.enqueue(async () => (await readStore(this.path)).records.find((r) => r.id === id) ?? null)
+  }
+
+  /** Remove one record (called after its prompt was inserted, or on dismiss). */
+  async resolve(id: string): Promise<boolean> {
+    return await this.enqueue(async () => {
+      const store = await readStore(this.path)
+      const kept = store.records.filter((r) => r.id !== id)
+      if (kept.length === store.records.length) return false
+      await writeStore(this.path, kept)
+      return true
+    })
+  }
+
+  /** All records for a task (the exit path lists what is queued for a tab). */
+  async listForTask(taskId: string): Promise<readonly DeferredPromptRecord[]> {
+    return await this.enqueue(async () => (await readStore(this.path)).records.filter((r) => r.taskId === taskId))
+  }
+
+  /** Task deletion drops its queued prompts — logged, never silent. */
+  async deleteTask(taskId: string): Promise<void> {
+    await this.enqueue(async () => {
+      const store = await readStore(this.path)
+      const kept = store.records.filter((r) => r.taskId !== taskId)
+      if (kept.length === store.records.length) return
+      for (const dropped of store.records) {
+        if (dropped.taskId === taskId) {
+          logDaemonInfo(SUBSYSTEM, `dropped deferred prompt ${dropped.id} — task ${taskId} deleted`)
+        }
+      }
+      await writeStore(this.path, kept)
+    })
+  }
+}

--- a/packages/kobe-daemon/src/daemon/handlers-deferred.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-deferred.ts
@@ -1,0 +1,67 @@
+/**
+ * Deferred-prompt RPC handlers (issue #78 B-layer). The delivery gate ran in a
+ * kobe (CLI) process and found the target composer busy; it calls
+ * `deferredPrompt.file` to hand ownership to the daemon, which stores the text
+ * and records a `prompt_deferred` inbox episode. The exit path reads the text
+ * back (`get`), inserts it with a fresh A/C gate, then releases it (`resolve`).
+ */
+
+import { optionalString, requireString } from "./handler-validators.ts"
+import type { DaemonRequestHandler } from "./handlers.ts"
+
+export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
+  {
+    // Socket-only (see deferredPrompt.get) — not on the pinned web allowlist.
+    name: "deferredPrompt.file",
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      const prompt = requireString(payload, "prompt")
+      const layer = requireString(payload, "layer")
+      if (layer !== "recent-human-write" && layer !== "composer-not-empty") {
+        throw new Error('layer must be "recent-human-write" or "composer-not-empty"')
+      }
+      if (!ctx.orch.getTask(taskId)) throw new Error(`task not found: ${taskId}`)
+      if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+      const senderLabel = optionalString(payload, "senderLabel")
+      const senderTaskId = optionalString(payload, "senderTaskId")
+      const record = await ctx.deferredPrompts.file({
+        taskId,
+        tabId,
+        prompt,
+        layer,
+        ...(senderLabel !== undefined ? { senderLabel } : {}),
+        ...(senderTaskId !== undefined ? { senderTaskId } : {}),
+        at: Date.now(),
+      })
+      await ctx.inbox.recordPromptDeferred(taskId, tabId, record.id, layer)
+      return { id: record.id }
+    },
+  },
+  {
+    // Socket-only: the exit path is the TUI inbox (a socket client). Keeping
+    // these off the web allowlist is deliberate — the browser-reachable surface
+    // is a pinned security contract (test/daemon/web-exposure.test.ts).
+    name: "deferredPrompt.get",
+    async handle(payload, ctx) {
+      const id = requireString(payload, "id")
+      if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+      const record = await ctx.deferredPrompts.get(id)
+      return { record }
+    },
+  },
+  {
+    name: "deferredPrompt.resolve",
+    async handle(payload, ctx) {
+      const id = requireString(payload, "id")
+      if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+      // Resolve means BOTH halves: the stored text AND the inbox episode that
+      // points at it. Read the record first (for its task/tab) so the episode
+      // can be dropped even though the record is about to go.
+      const record = await ctx.deferredPrompts.get(id)
+      const removed = await ctx.deferredPrompts.resolve(id)
+      if (record) await ctx.inbox.deleteEpisode(record.taskId, record.tabId)
+      return { removed }
+    },
+  },
+]

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -40,11 +40,13 @@ import type { AttentionInboxStore } from "./attention-inbox.ts"
 import type { AutomationsStore } from "./automations-store.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
+import type { DeferredPromptsStore } from "./deferred-prompts-store.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import { objectPayload, optionalActivityDetail, optionalString, requireString } from "./handler-validators.ts"
 import { AGENT_TURN_HANDLERS } from "./handlers-agent-turns.ts"
 import { ATTENTION_HANDLERS } from "./handlers-attention.ts"
 import { AUTOMATION_HANDLERS } from "./handlers-automations.ts"
+import { DEFERRED_PROMPT_HANDLERS } from "./handlers-deferred.ts"
 import { ENGINE_REPORT_HANDLER } from "./handlers-engine-report.ts"
 import { ISSUE_HANDLERS } from "./handlers-issues.ts"
 import { TASK_HANDLERS } from "./handlers-task.ts"
@@ -102,6 +104,8 @@ export interface DaemonHandlerContext {
   readonly issues: IssuesStore
   /** Durable field notes, same key convention (absent in older tests). */
   readonly notes?: NotesStore
+  /** Deferred prompts accepted by the delivery gate (issue #78; absent in older tests). */
+  readonly deferredPrompts?: DeferredPromptsStore
   /** Short-TTL cache over external tracker items (read-only view). */
   readonly workItems: WorkItemCache
   /** Daemon-owned scheduled automations + their run history. */
@@ -312,6 +316,7 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
     ...AGENT_TURN_HANDLERS,
     ...UI_HANDLERS,
     ...ISSUE_HANDLERS,
+    ...DEFERRED_PROMPT_HANDLERS,
     {
       // Production diagnostics (`kobe api inspect`): what the daemon's
       // transient state ACTUALLY holds right now. Bug reports about badges,

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -301,6 +301,14 @@ export type DaemonRequestName =
   // is that bare shell adopts it (already rc-initialized) instead of
   // paying shell startup. Best-effort; older hosts reject the verb.
   | "pty.warm"
+  // Deferred prompts (issue #78 B-layer): the delivery gate accepted a prompt
+  // it could not paste (composer busy) into daemon ownership. `file` stores the
+  // text + records a `prompt_deferred` inbox episode; `get` reads one back for
+  // the exit path; `resolve` drops it after a successful insert or a dismiss.
+  // Older daemons reject the verbs; callers then surface COMPOSER_BUSY instead.
+  | "deferredPrompt.file"
+  | "deferredPrompt.get"
+  | "deferredPrompt.resolve"
 
 /**
  * Subscribe role (KOB) — distinguishes WHO is subscribing, so the daemon's

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -22,6 +22,7 @@ import { startDaemonCollectors } from "./collectors.ts"
 import { linkLegacyRuntimePath } from "./compat-link.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
+import { DeferredPromptsStore, defaultDeferredPromptsPath } from "./deferred-prompts-store.ts"
 import { EngineEventLog } from "./engine-events-log.ts"
 import { DaemonEventBus } from "./event-bus.ts"
 import {
@@ -156,6 +157,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     inbox
       .deleteTaskBestEffort(taskId)
       .finally(() => agentTurns.deleteTask(taskId).catch((err) => logDaemonError("agent-turns-delete", err)))
+      .finally(() => deferredPrompts.deleteTask(taskId).catch((err) => logDaemonError("deferred-prompts-delete", err)))
       .finally(() => activity.clearTask(taskId))
   const deletions = new TaskDeletionRunner(orch, runtime, clearTaskState)
   // Daemon-owned issue tracker (web Issues panel) — a single store keyed by
@@ -166,6 +168,9 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   // homeDir isolation as the issue store. Written by `note.file`, read back at
   // worktree launch so a fresh session starts with the repo's known gotchas.
   const notes = new NotesStore(defaultNotesStorePath(options.homeDir))
+  // Deferred prompts (issue #78 B-layer) — the delivery gate hands blocked
+  // prompts to daemon ownership; same homeDir isolation as the other stores.
+  const deferredPrompts = new DeferredPromptsStore(defaultDeferredPromptsPath(options.homeDir))
   // Daemon-owned scheduled automations. The sweep that fires them is started
   // with the other collectors; this only loads the persisted schedules.
   const automations = await initAutomationsStore(options.homeDir)
@@ -389,6 +394,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       deletions,
       issues,
       notes,
+      deferredPrompts,
       automations,
       workItems,
       selfLink,

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -168,8 +168,6 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   // homeDir isolation as the issue store. Written by `note.file`, read back at
   // worktree launch so a fresh session starts with the repo's known gotchas.
   const notes = new NotesStore(defaultNotesStorePath(options.homeDir))
-  // Deferred prompts (issue #78 B-layer) — the delivery gate hands blocked
-  // prompts to daemon ownership; same homeDir isolation as the other stores.
   const deferredPrompts = new DeferredPromptsStore(defaultDeferredPromptsPath(options.homeDir))
   // Daemon-owned scheduled automations. The sweep that fires them is started
   // with the other collectors; this only loads the persisted schedules.

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -109,9 +109,10 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     prompt,
   )
   task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
-  // A prompt that never confirmed in the composer is a failure — but the task
-  // IS created, so carry the taskId in the error so a script can find it.
-  if (!delivered.delivered) {
+  // A prompt that never confirmed AND was not deferred is a failure — but the
+  // task IS created, so carry the taskId in the error so a script can find it.
+  // Deferred (issue #78 B-layer) is a SUCCESS: the daemon owns the message now.
+  if (!delivered.delivered && !delivered.deferred) {
     throw new ApiError(
       `task ${taskId} created but the prompt was not delivered (paste did not land)`,
       "NOT_DELIVERED",
@@ -127,6 +128,7 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     engineReady: delivered.engineReady,
     session: delivered.session,
     delivered: delivered.delivered,
+    ...(delivered.deferred ? { deferred: delivered.deferred } : {}),
   }
 }
 

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -146,9 +146,12 @@ export async function send(ctx: VerbContext): Promise<unknown> {
     },
     text,
   )
-  // A prompt that never landed in the composer is a delivery FAILURE the
-  // script must see — non-zero exit, not a phantom `ok:true`.
-  if (!delivered.delivered) {
+  // A prompt that never landed AND was not deferred is a delivery FAILURE the
+  // script must see — non-zero exit, not a phantom `ok:true`. Deferred
+  // (issue #78 B-layer) is a SUCCESS: the daemon owns the message and queued
+  // an inbox episode. The caller must NOT retry — a retry would stack a
+  // duplicate of the same message in the deferred queue.
+  if (!delivered.delivered && !delivered.deferred) {
     throw new ApiError(`prompt was not confirmed in ${taskId}'s engine (paste did not land)`, "NOT_DELIVERED")
   }
   return {
@@ -157,6 +160,14 @@ export async function send(ctx: VerbContext): Promise<unknown> {
     session: delivered.session,
     started: delivered.started,
     engineReady: delivered.engineReady,
+    ...(delivered.deferred
+      ? {
+          deferred: delivered.deferred,
+          // The deferred outcome is a SUCCESS, not an error — say so explicitly
+          // so a scripted sender does not read `deferred` as a failure and retry.
+          delivered: false,
+        }
+      : {}),
   }
 }
 

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -35,7 +35,7 @@ import type { EngineScreenManifest } from "../../engine/screen-state.ts"
 import type { EngineSessionLaunch } from "../../engine/session-launch.ts"
 import { readPersistedTerminalDefaultColors } from "../../tui/lib/terminal-colors.ts"
 import type { VendorId } from "../../types/vendor.ts"
-import { ApiError, type DeliveredPrompt } from "./types.ts"
+import { ApiError, type DeliveredPrompt, type PromptDeferralSink } from "./types.ts"
 
 /**
  * Foreground gate for delivery into an EXISTING session (herdr's
@@ -133,7 +133,12 @@ export async function deliverHostedPrompt(
   cwd: string,
   prompt: string,
   launch: EngineSessionLaunch,
-  opts?: { readonly forceNew?: boolean; readonly snapshot?: PsSnapshot; readonly vendor?: VendorId },
+  opts?: {
+    readonly forceNew?: boolean
+    readonly snapshot?: PsSnapshot
+    readonly vendor?: VendorId
+    readonly defer?: PromptDeferralSink
+  },
 ): Promise<DeliveredPrompt> {
   const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
   // `forceNew` (send --tab new): the caller minted a fresh tab key and wants
@@ -159,10 +164,14 @@ export async function deliverHostedPrompt(
     // detach from a never-attached client would clear a parked TUI's
     // exact-delta restore state as a side effect.
     const deliveryOpts = { screenManifest: resolveComposerManifest(opts?.vendor) }
-    const delivered = await deliverToKey(rpc, existingKey, prompt, deliveryOpts).catch((err) => {
-      if (err instanceof ComposerBusyError) throw composerBusyApiError(err, target.id, prompt)
+    const tabId = existingKey.split("::")[1] ?? "tab-1"
+    let delivered: boolean
+    try {
+      delivered = await deliverToKey(rpc, existingKey, prompt, deliveryOpts)
+    } catch (err) {
+      if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, target.id, tabId, prompt)
       throw err
-    })
+    }
     return {
       session: existingKey,
       pane: existingKey,
@@ -221,14 +230,18 @@ export async function deliverHostedPrompt(
     // the engine process is up. A paste that never lands is a failed start,
     // not a delivered prompt.
     if (launch.firstMessage) {
-      const delivered = await pastePromptWhenEngineUp(rpc, launch.key, target.engineBin, launch.firstMessage, {
-        initMarkerPath: launch.initMarkerPath,
-        initTimeoutMs: launch.initTimeoutMs,
-        screenManifest: resolveComposerManifest(opts?.vendor),
-      }).catch((err) => {
-        if (err instanceof ComposerBusyError) throw composerBusyApiError(err, target.id, prompt)
+      const tabId = launch.key.split("::")[1] ?? "tab-1"
+      let delivered: boolean
+      try {
+        delivered = await pastePromptWhenEngineUp(rpc, launch.key, target.engineBin, launch.firstMessage, {
+          initMarkerPath: launch.initMarkerPath,
+          initTimeoutMs: launch.initTimeoutMs,
+          screenManifest: resolveComposerManifest(opts?.vendor),
+        })
+      } catch (err) {
+        if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, target.id, tabId, prompt)
         throw err
-      })
+      }
       return {
         session: launch.key,
         pane: launch.key,
@@ -242,12 +255,13 @@ export async function deliverHostedPrompt(
     // A RESPAWNED restored corpse is the opposite: our launch DID run (the
     // prompt rode its argv), so pasting here would deliver it twice.
     if (open.created === false && open.respawned !== true) {
-      await writePrompt(rpc, launch.key, prompt, { screenManifest: resolveComposerManifest(opts?.vendor) }).catch(
-        (err: unknown) => {
-          if (err instanceof ComposerBusyError) throw composerBusyApiError(err, target.id, prompt)
-          throw err
-        },
-      )
+      const tabId = launch.key.split("::")[1] ?? "tab-1"
+      try {
+        await writePrompt(rpc, launch.key, prompt, { screenManifest: resolveComposerManifest(opts?.vendor) })
+      } catch (err) {
+        if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, target.id, tabId, prompt)
+        throw err
+      }
     }
     const delivered = true
     return {
@@ -273,7 +287,12 @@ export async function deliverToExactTab(
   tabId: string,
   cwd: string,
   prompt: string,
-  opts?: { readonly engineBin?: string; readonly snapshot?: PsSnapshot; readonly vendor?: VendorId },
+  opts?: {
+    readonly engineBin?: string
+    readonly snapshot?: PsSnapshot
+    readonly vendor?: VendorId
+    readonly defer?: PromptDeferralSink
+  },
 ): Promise<DeliveredPrompt> {
   const key = `${taskId}::${tabId}`
   const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
@@ -300,15 +319,50 @@ export async function deliverToExactTab(
   }
   // No pty.detach — see deliverHostedPrompt's existing-key path.
   const deliveryOpts = { screenManifest: resolveComposerManifest(opts?.vendor) }
-  const delivered = await deliverToKey(rpc, key, prompt, deliveryOpts).catch((err) => {
-    if (err instanceof ComposerBusyError) throw composerBusyApiError(err, taskId, prompt)
+  let delivered: boolean
+  try {
+    delivered = await deliverToKey(rpc, key, prompt, deliveryOpts)
+  } catch (err) {
+    if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, taskId, tabId, prompt)
     throw err
-  })
+  }
   return { session: key, pane: key, started: false, engineReady: delivered, delivered }
 }
 
 function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | undefined {
   return vendor ? engineEntry(vendor).screenManifest : undefined
+}
+
+/**
+ * Gate blocked the paste. With a deferral sink (issue #78 B-layer) the prompt
+ * is ACCEPTED into daemon ownership — store it and report the deferred success
+ * outcome; the caller must not retry. Without a sink there is no queue to hand
+ * it to, so surface the legacy typed error instead of dropping it silently.
+ */
+async function deferOrThrow(
+  error: ComposerBusyError,
+  sink: PromptDeferralSink | undefined,
+  taskId: string,
+  tabId: string,
+  prompt: string,
+): Promise<DeliveredPrompt> {
+  if (sink) {
+    try {
+      const id = await sink.defer({ taskId, tabId, prompt, layer: error.layer })
+      return {
+        session: `${taskId}::${tabId}`,
+        pane: `${taskId}::${tabId}`,
+        started: false,
+        engineReady: false,
+        delivered: false,
+        deferred: { id, layer: error.layer },
+      }
+    } catch {
+      // Older daemon without the deferredPrompt verbs — degrade to the typed
+      // error rather than dropping the prompt silently.
+    }
+  }
+  throw composerBusyApiError(error, taskId, prompt)
 }
 
 function composerBusyApiError(error: ComposerBusyError, taskId: string, prompt: string): ApiError {

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -35,12 +35,24 @@ import {
   publishCliTabSnapshot,
   readTabsSnapshot,
 } from "./tab-snapshot.ts"
-import { ApiError, type ApiRuntime, type DeliveredPrompt, type PromptDeliveryOps, type PromptTarget } from "./types.ts"
+import {
+  ApiError,
+  type ApiRuntime,
+  type DeliveredPrompt,
+  type PromptDeferralSink,
+  type PromptDeliveryOps,
+  type PromptTarget,
+} from "./types.ts"
 
 /** Ensure and address the task's hosted engine session (`target.tab` routes:
  *  undefined = canonical, "new" = mint + spawn a fresh tab, "tab-N" = that
  *  exact alive tab only). */
-async function deliverHosted(target: PromptTarget, worktree: string, prompt: string): Promise<DeliveredPrompt> {
+async function deliverHosted(
+  target: PromptTarget,
+  worktree: string,
+  prompt: string,
+  defer?: PromptDeferralSink,
+): Promise<DeliveredPrompt> {
   let host: Awaited<ReturnType<typeof ensurePtyHost>>
   try {
     host = await ensurePtyHost()
@@ -64,6 +76,7 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
       return await deliverToExactTab(host.rpc, target.id, target.tab, worktree, prompt, {
         engineBin,
         vendor: target.vendor,
+        defer,
       })
     }
     const newTab = target.tab === "new" ? mintCliTab(target.id, target.tabVendor, target.tabCommand) : undefined
@@ -110,6 +123,7 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
       {
         forceNew: newTab !== undefined,
         vendor: launchVendor,
+        defer,
       },
     )
     if (result.started && !result.engineReady) {
@@ -139,7 +153,7 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
 }
 
 const realPromptDeliveryOps: PromptDeliveryOps = {
-  deliverHosted,
+  deliverHosted: (target, worktree, prompt, defer) => deliverHosted(target, worktree, prompt, defer),
 }
 
 export async function deliverPrompt(
@@ -155,7 +169,22 @@ export async function deliverPrompt(
   }
   if (!worktree) throw new ApiError(`task ${target.id} has no worktree`, "NO_WORKTREE")
 
-  const hosted = await ops.deliverHosted(target, worktree, prompt)
+  // The deferral sink hands a composer-busy prompt to daemon ownership
+  // (issue #78 B-layer): the daemon stores the text and queues an inbox
+  // episode, and this send reports accepted-but-deferred — a SUCCESS the
+  // caller must NOT retry (a retry would stack a duplicate in the queue).
+  const defer: PromptDeferralSink = {
+    defer: (info) =>
+      client
+        .request<{ id: string }>("deferredPrompt.file", {
+          taskId: info.taskId,
+          tabId: info.tabId,
+          prompt: info.prompt,
+          layer: info.layer,
+        })
+        .then((res) => res.id),
+  }
+  const hosted = await ops.deliverHosted(target, worktree, prompt, defer)
   if (!hosted) throw new ApiError(`failed to start hosted engine session for ${target.id}`, "SESSION_FAILED")
   return hosted
 }

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -141,11 +141,40 @@ export interface DeliveredPrompt {
    * looks like a clean success.
    */
   readonly delivered: boolean
+  /**
+   * Present when the delivery gate found the composer busy and the prompt was
+   * accepted-but-deferred rather than dropped (issue #78 B-layer): the daemon
+   * stored the text and queued a `prompt_deferred` inbox episode. This is a
+   * SUCCESS outcome for the caller — the daemon now owns the message and will
+   * hold it for a human to release from the Inbox. Callers MUST NOT retry a
+   * deferred send: a retry would stack a duplicate of the same message in the
+   * queue. Absent on direct delivery and on genuine failure.
+   */
+  readonly deferred?: { readonly id: string; readonly layer: "recent-human-write" | "composer-not-empty" }
+}
+
+/** What the delivery layer calls to hand a blocked prompt to daemon ownership. */
+export interface PromptDeferralSink {
+  /**
+   * Store the blocked prompt and return the daemon's record id. Implementations
+   * perform the `deferredPrompt.file` daemon RPC; tests inject a fake.
+   */
+  defer(info: {
+    readonly taskId: string
+    readonly tabId: string
+    readonly prompt: string
+    readonly layer: "recent-human-write" | "composer-not-empty"
+  }): Promise<string>
 }
 
 /** Hosted prompt delivery seam, injectable for handler/unit tests. */
 export interface PromptDeliveryOps {
-  deliverHosted(target: PromptTarget, worktree: string, prompt: string): Promise<DeliveredPrompt>
+  deliverHosted(
+    target: PromptTarget,
+    worktree: string,
+    prompt: string,
+    defer?: PromptDeferralSink,
+  ): Promise<DeliveredPrompt>
 }
 
 // ── Runtime (the side-effect seam handlers run against) ─────────────────────

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -14,7 +14,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   {
     name: "send",
     summary:
-      "Paste a follow-up prompt into a task's running engine (one full turn). Without --task-id, a task spawned from another Rove session replies to its dispatcher's tab (then that task's live canonical engine; nothing alive = DISPATCHER_UNREACHABLE, never a silent spawn); otherwise the active task. Sent from inside another Rove task ($ROVE_TASK_ID), the prompt is prefixed with [ROVE PEER] provenance — who sent it and how to reply (tab-precise) — so agent-to-agent messaging needs no coordinator.",
+      "Paste a follow-up prompt into a task's running engine (one full turn). Without --task-id, a task spawned from another Rove session replies to its dispatcher's tab (then that task's live canonical engine; nothing alive = DISPATCHER_UNREACHABLE, never a silent spawn); otherwise the active task. Sent from inside another Rove task ($ROVE_TASK_ID), the prompt is prefixed with [ROVE PEER] provenance — who sent it and how to reply (tab-precise) — so agent-to-agent messaging needs no coordinator. When the target composer is busy (you'd paste into a half-typed message), the prompt is accepted-but-deferred: the daemon stores it and queues a `prompt_deferred` Inbox episode for a human to release — that outcome is a SUCCESS (exit 0, `deferred` in the JSON). Do NOT retry a deferred send: the daemon already owns the message, and resending stacks a duplicate in the queue.",
     flags: [
       F.taskId(false),
       F.prompt(true, "Text pasted + submitted into the engine pane."),

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -8,6 +8,7 @@
 
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import type { Automation, AutomationRun } from "@sma1lboy/kobe-daemon/daemon/contracts"
+import type { DeferredPromptRecord } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { WorkItem } from "@sma1lboy/kobe-daemon/daemon/work-items"
@@ -148,6 +149,18 @@ export async function markAttentionReadOp(
     at,
   })
   return res.updated
+}
+
+/** Read one deferred prompt back by id (issue #78 B-layer exit path). */
+export async function getDeferredPromptOp(client: KobeDaemonClient, id: string): Promise<DeferredPromptRecord | null> {
+  const res = await client.request<{ record: DeferredPromptRecord | null }>("deferredPrompt.get", { id })
+  return res.record
+}
+
+/** Release one deferred prompt after its text was inserted (or on dismiss). */
+export async function resolveDeferredPromptOp(client: KobeDaemonClient, id: string): Promise<boolean> {
+  const res = await client.request<{ removed: boolean }>("deferredPrompt.resolve", { id })
+  return res.removed
 }
 
 /** Land a task's branch back into its base repo (`task.land`). Merge or

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -15,6 +15,7 @@
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { logClient, logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
 import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-process"
+import type { DeferredPromptRecord } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import {
   type ChannelName,
@@ -84,6 +85,7 @@ import {
   ensureMainTaskOp,
   ensureWorktreeOp,
   forgetProjectOp,
+  getDeferredPromptOp,
   landTaskOp,
   listAutomationsOp,
   listIssuesOp,
@@ -95,6 +97,7 @@ import {
   openDirectoryTaskOp,
   removeWorktreeOp,
   reportEngineInterruptOp,
+  resolveDeferredPromptOp,
   runAutomationNowOp,
   setActiveTaskOp,
   setAutomationEnabledOp,
@@ -410,6 +413,8 @@ export class RemoteOrchestrator {
     dismissAttentionOp(this.client, taskId, tabId, at)
   markAttentionRead = (taskId: TaskId | string, tabId: string | null, at: number): Promise<boolean> =>
     markAttentionReadOp(this.client, taskId, tabId, at)
+  getDeferredPrompt = (id: string): Promise<DeferredPromptRecord | null> => getDeferredPromptOp(this.client, id)
+  resolveDeferredPrompt = (id: string): Promise<boolean> => resolveDeferredPromptOp(this.client, id)
 
   /** Land a task's branch back into its base repo (`task.land`). Throws with a
    *  `LAND_CONFLICT` / `MAIN_CHECKOUT_DIRTY` sentinel in the message on the

--- a/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
+++ b/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
@@ -46,6 +46,7 @@ const IDENTITY_FLOOR_CELLS = 16
 function itemColor(state: AttentionInboxItem["state"], theme: ReturnType<typeof useTheme>["theme"]) {
   if (state === "permission_needed") return theme.warning
   if (state === "turn_complete") return theme.success
+  if (state === "prompt_deferred") return theme.warning
   return theme.error
 }
 
@@ -57,6 +58,8 @@ function itemGlyph(state: AttentionInboxItem["state"]): string {
   // AppleColorEmoji — a 2.13-cell colour glyph in a 1-cell column, which
   // both overflowed and broke the pane's monochrome ink (2026-08-15).
   if (state === "rate_limited") return "◷"
+  // `≡` (no Emoji property) for a queued message — a stack, not a failure.
+  if (state === "prompt_deferred") return "≡"
   return "!"
 }
 
@@ -65,6 +68,7 @@ function itemStateKey(state: AttentionInboxItem["state"]): string {
   if (state === "permission_needed") return "workspace.inbox.state.needsInput"
   if (state === "turn_complete") return "workspace.inbox.state.done"
   if (state === "rate_limited") return "workspace.inbox.state.rateLimited"
+  if (state === "prompt_deferred") return "workspace.inbox.state.promptDeferred"
   return "workspace.inbox.state.error"
 }
 

--- a/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
+++ b/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
@@ -1,0 +1,58 @@
+/**
+ * Exit path for a deferred prompt (issue #78 B-layer, hard constraint #1+#3).
+ *
+ * Opening a `prompt_deferred` inbox item jumps to the tab AND inserts the
+ * queued message — one action, reusing the existing open action (no new
+ * chord). The insert RE-RUNS the A/C delivery gate: the human may be typing
+ * again at the moment they release the message, so an unconditional paste
+ * would re-open the very bug this feature fixes. When the gate still blocks,
+ * the message stays queued (episode + record untouched) and the caller toasts
+ * "still queued"; on success the record and episode are resolved.
+ */
+
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
+import { ComposerBusyError, deliverToHostedKey, openHostedSessionHost } from "../../engine/hosted-session.ts"
+import { engineEntry } from "../../engine/registry.ts"
+import type { EngineScreenManifest } from "../../engine/screen-state.ts"
+import type { VendorId } from "../../types/vendor.ts"
+
+export type DeferredInsertOutcome =
+  /** Pasted + submitted; the record and episode are resolved. */
+  | "inserted"
+  /** The A/C gate still blocks (human typing / composer non-empty); kept queued. */
+  | "deferred-again"
+  /** No reachable hosted session for the tab; kept queued for a later retry. */
+  | "unavailable"
+
+export async function insertDeferredPrompt(args: {
+  readonly orch: Pick<RemoteOrchestrator, "resolveDeferredPrompt">
+  readonly taskId: string
+  readonly tabId: string
+  readonly prompt: string
+  readonly deferredId: string
+  readonly manifest?: EngineScreenManifest
+}): Promise<DeferredInsertOutcome> {
+  const host = await openHostedSessionHost()
+  if (!host) return "unavailable"
+  try {
+    const key = `${args.taskId}::${args.tabId}`
+    let delivered: boolean
+    try {
+      delivered = await deliverToHostedKey(host.rpc, key, args.prompt, { screenManifest: args.manifest })
+    } catch (err) {
+      if (err instanceof ComposerBusyError) return "deferred-again"
+      throw err
+    }
+    if (!delivered) return "unavailable"
+    await args.orch.resolveDeferredPrompt(args.deferredId)
+    return "inserted"
+  } finally {
+    host.close()
+  }
+}
+
+/** The composer-empty manifest for a task's vendor (undefined → C-layer skips,
+ *  fail-open, A-layer still guards). */
+export function deferredManifestFor(vendor: VendorId | undefined): EngineScreenManifest | undefined {
+  return vendor ? engineEntry(vendor).screenManifest : undefined
+}

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -99,6 +99,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     selectTask,
     focusWorkspace: () => focus.setFocused("workspace"),
     notifyError,
+    notifyInfo,
   })
 
   // Cross-task attention (P0): rising-edge notify for non-selected tasks +

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -33,6 +33,7 @@ import { tabTitleStable } from "../../tui/workspace/terminal-tabs-core"
 import { DEFAULT_TASK_VENDOR, type Task } from "../../types/task"
 import type { KVContext } from "../context/kv"
 import type { NotificationsContext } from "../context/notifications"
+import { useT } from "../i18n"
 import { isAttentionInboxItemAvailable, nextAttentionInboxTarget } from "./attention-inbox-core"
 import { activeTabIdFor, knownTaskTab, taskTabExists } from "./terminal-tabs-shared"
 
@@ -101,6 +102,7 @@ export function useAttention(args: {
   noTasksMessage: string
 }): { jumpToNextAttention: () => void } {
   const { tasks, engineState, engineTabState, inboxItems, selectedId, kv, notif, openAttention, noTasksMessage } = args
+  const t = useT()
 
   // Previous frame's state per NOTIFY TARGET, for rising-edge detection.
   // Seeded on the first render so targets already sitting in an attention
@@ -141,6 +143,41 @@ export function useAttention(args: {
       })
     }
   }, [engineState, engineTabState, selectedId, tasks, kv, notif])
+
+  // Deferred-prompt toast (issue #78 B): a `prompt_deferred` episode is
+  // inbox-ONLY — the engine reported no activity (the blocked prompt never
+  // reached it), so the engine-state rising-edge above never fires for it.
+  // Diff the inbox episodes on their (task, tab, at) identity instead. Unlike
+  // the engine-state notifier, the SELECTED task still toasts: deferral most
+  // often happens while you are typing in that very tab, and there is no
+  // middle-column indicator for a queued message.
+  const prevDeferred = useRef<Map<string, { taskId: string; tabId: string; at: number }> | null>(null)
+  useEffect(() => {
+    const next = new Map<string, { taskId: string; tabId: string; at: number }>()
+    for (const item of inboxItems) {
+      if (item.state !== "prompt_deferred" || !item.tabId) continue
+      next.set(notifyTargetKey(item.taskId, item.tabId), { taskId: item.taskId, tabId: item.tabId, at: item.at })
+    }
+    const prev = prevDeferred.current
+    prevDeferred.current = next
+    if (prev === null) return // seed — replayed history must not re-fire toasts
+    if (kv.get(CROSS_TASK_KEY, true) === false) return
+    const repos = [...new Set(tasks.map((t) => t.repo))]
+    for (const [key, entry] of next) {
+      if (prev.get(key)?.at === entry.at) continue // same episode, not a fresh edge
+      const task = tasks.find((t) => t.id === entry.taskId)
+      const tab = knownTaskTab(kv, entry.taskId, entry.tabId)
+      const tabLabel = tab ? tabTitleStable(tab, task?.vendor ?? DEFAULT_TASK_VENDOR) : ""
+      const project = task ? sidebarProjectLabel(task.repo, repos) : ""
+      notif.notify({
+        kind: "needs_input",
+        taskId: entry.taskId,
+        tabId: entry.tabId,
+        title: t("workspace.inbox.deferredToast"),
+        body: tabLabel ? `${project} › ${tabLabel}` : project || undefined,
+      })
+    }
+  }, [inboxItems, tasks, kv, notif, t])
 
   function jumpToNextAttention(): void {
     const order = tasks.filter((t) => !t.deletion).map((t) => t.id)

--- a/packages/kobe/src/tui-react/workspace/use-inbox-host.ts
+++ b/packages/kobe/src/tui-react/workspace/use-inbox-host.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { AttentionInboxItem, RemoteOrchestrator } from "../../client/remote-orchestrator"
 import type { Task } from "../../types/task"
 import type { KVContext } from "../context/kv"
+import { useT } from "../i18n"
 import { useLatest } from "../lib/use-latest"
 import type { DialogContext } from "../ui/dialog"
 import { AttentionInboxDialog } from "./AttentionInboxPane"
@@ -12,6 +13,7 @@ import {
   partitionAttentionInboxAvailability,
   visitResolvedEpisodes,
 } from "./attention-inbox-core"
+import { deferredManifestFor, insertDeferredPrompt } from "./deferred-prompt-insert"
 import { requestInboxItemOpen } from "./inbox-open-action"
 import { notifyInboxRpcFailure } from "./inbox-rpc-errors"
 import { writeInboxVisit } from "./inbox-visits"
@@ -35,8 +37,11 @@ export function useInboxHost(args: {
   selectTask: (taskId: string) => void
   focusWorkspace: () => void
   notifyError: (message: string) => void
+  /** Neutral (done-styled) toast — insert feedback for the deferred exit path. */
+  notifyInfo: (message: string) => void
 }) {
   const { orchestrator: orch } = args
+  const t = useT()
   const { availableItems, unavailableItems } = useMemo(
     () =>
       // Tri-state (see taskTabExists): `undefined` when this task has no
@@ -91,10 +96,58 @@ export function useInboxHost(args: {
     }
   }, [unavailableSignature, orch])
 
+  /**
+   * Release a `prompt_deferred` episode (issue #78 B exit path). The text is
+   * fetched from the daemon store (the episode carries only its id), inserted
+   * with a FRESH A/C gate, and — only on success — resolved. The gate still
+   * blocking means the human is typing again; the message stays queued.
+   */
+  async function releaseDeferredPrompt(
+    item: AttentionInboxItem,
+    deferredId: string,
+    vendor: Task["vendor"],
+  ): Promise<void> {
+    try {
+      const record = await orch.getDeferredPrompt(deferredId)
+      if (!record) {
+        // The record was released/expired/displaced under us — drop the stale
+        // episode so it doesn't point at a record that no longer exists.
+        notifyInboxRpcFailure(orch.dismissAttention(item.taskId, item.tabId, item.at), "dismiss", args.notifyError)
+        return
+      }
+      const outcome = await insertDeferredPrompt({
+        orch,
+        taskId: item.taskId,
+        tabId: item.tabId ?? "tab-1",
+        prompt: record.prompt,
+        deferredId,
+        manifest: deferredManifestFor(vendor),
+      })
+      if (outcome === "deferred-again") args.notifyInfo(t("workspace.inbox.deferredStillQueued"))
+      else if (outcome === "unavailable") args.notifyInfo(t("workspace.inbox.deferredUnavailable"))
+      // "inserted" → the resolve RPC dropped both the record and the episode.
+    } catch {
+      args.notifyError(t("workspace.inbox.deferredInsertFailed"))
+    }
+  }
+
   function openItem(item: AttentionInboxItem, knownAvailable?: boolean): void {
     const task = orch.getTask(item.taskId)
     const available =
       knownAvailable ?? isAttentionInboxItemAvailable(item, task, (tabId) => taskTabExists(args.kv, item.taskId, tabId))
+
+    // prompt_deferred: opening IS the release action — jump AND insert. The
+    // episode is NOT dismissed up front; the gate decides whether it clears.
+    const deferredId = item.detail?.deferredPrompt?.id
+    if (item.state === "prompt_deferred" && item.tabId && deferredId) {
+      if (args.dialog.stack.length > 0) args.dialog.clear({ refocus: false })
+      args.selectTask(item.taskId)
+      requestTabActivation(item.taskId, item.tabId)
+      args.focusWorkspace()
+      void releaseDeferredPrompt(item, deferredId, task?.vendor)
+      return
+    }
+
     if (!requestInboxItemOpen(item, available, orch, args.notifyError)) return
     if (args.dialog.stack.length > 0) args.dialog.clear({ refocus: false })
     args.selectTask(item.taskId)

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -53,7 +53,17 @@ export const en = {
       error: "error",
       rateLimited: "rate limited",
       running: "running",
+      /** A peer/API message accepted by the daemon but not yet pasted (issue #78). */
+      promptDeferred: "message queued",
     },
+    /** Toast title when a message is deferred because the composer was busy. */
+    deferredToast: "Message queued — composer busy",
+    /** Insert feedback: the A/C gate still blocked at release time. */
+    deferredStillQueued: "Still typing? The queued message stays in the Inbox — open it again to send.",
+    /** Insert feedback: the target tab has no live session to receive the paste. */
+    deferredUnavailable: "That tab isn't running — the queued message stays in the Inbox.",
+    /** Insert feedback: the release attempt errored (RPC/PTY hiccup). */
+    deferredInsertFailed: "Couldn't insert the queued message — it's still in the Inbox.",
   },
   terminalComing: "Embedded terminal is starting...",
 }
@@ -99,7 +109,17 @@ export const zh: typeof en = {
       error: "出错",
       rateLimited: "限流",
       running: "进行中",
+      /** peer/API 消息已被 daemon 受理但尚未插入（issue #78）。 */
+      promptDeferred: "消息已排队",
     },
+    /** composer 忙、消息被受理延后的 toast 标题。 */
+    deferredToast: "消息已排队——composer 正忙",
+    /** 插入反馈：放行那一刻 A/C 闸门仍拦住。 */
+    deferredStillQueued: "还在打字？排队的消息留在收件箱——再打开一次即可发送。",
+    /** 插入反馈：目标 tab 没有存活会话可接收。 */
+    deferredUnavailable: "该标签页未运行——排队的消息留在收件箱。",
+    /** 插入反馈：放行过程出错（RPC/PTY 故障）。 */
+    deferredInsertFailed: "无法插入排队的消息——它仍在收件箱中。",
   },
   terminalComing: "嵌入终端正在启动……",
 }

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -271,7 +271,7 @@ describe("realPromptDeliveryOps (deliverPrompt with the default ops)", () => {
       "/wt/t1",
       "go",
       expect.objectContaining({ key: "t1::tab-1" }),
-      { forceNew: false, vendor: "claude" },
+      expect.objectContaining({ forceNew: false, vendor: "claude", defer: expect.anything() }),
     )
     expect(mocks.closePtyHost).toHaveBeenCalledOnce()
     expect(result).toEqual({

--- a/packages/kobe/test/daemon/deferred-prompts-store.test.ts
+++ b/packages/kobe/test/daemon/deferred-prompts-store.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DEFERRED_PROMPT_TTL_MS, DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+/** Capture the daemon-log lines the store writes on displacement/expiry. */
+function spyDaemonLog(): { lines: string[]; restore: () => void } {
+  const lines: string[] = []
+  const spy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    lines.push(String(chunk))
+    return true
+  }) as typeof process.stderr.write)
+  return { lines, restore: () => spy.mockRestore() }
+}
+
+describe("daemon deferred-prompts store (issue #78 B)", () => {
+  let dir: string | null = null
+  let now = 1_000_000
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+    dir = null
+  })
+
+  async function create(): Promise<{ store: DeferredPromptsStore; path: string }> {
+    dir = await mkdtemp(join(tmpdir(), "kobe-deferred-prompts-"))
+    const path = join(dir, "deferred-prompts.json")
+    const store = new DeferredPromptsStore(path, () => now)
+    return { store, path }
+  }
+
+  const base = { taskId: "task-1", tabId: "tab-1", prompt: "hello", layer: "composer-not-empty" as const }
+
+  it("files, reads back, and resolves a record", async () => {
+    const { store, path } = await create()
+    const record = await store.file({ ...base, at: now })
+    expect(record.id).toBeTruthy()
+    expect(await store.get(record.id)).toEqual(record)
+    // Persisted to disk so a daemon restart keeps the queued prompt.
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ version: 1, records: [record] })
+
+    expect(await store.resolve(record.id)).toBe(true)
+    expect(await store.get(record.id)).toBeNull()
+    expect(await store.resolve(record.id)).toBe(false)
+  })
+
+  it("keeps only the newest record per task+tab, logging the displaced one", async () => {
+    const { store, path } = await create()
+    const log = spyDaemonLog()
+    try {
+      const first = await store.file({ ...base, prompt: "first", at: now })
+      const second = await store.file({ ...base, prompt: "second", at: now + 1 })
+
+      const records = (JSON.parse(await readFile(path, "utf8")) as { records: unknown[] }).records
+      expect(records).toHaveLength(1)
+      expect(await store.get(first.id)).toBeNull()
+      expect(await store.get(second.id)).toEqual(second)
+      // Displacement is explicit, not silent — the dropped record is named by id.
+      expect(log.lines.join("")).toContain("displaced deferred prompt")
+      expect(log.lines.join("")).toContain(first.id)
+    } finally {
+      log.restore()
+    }
+  })
+
+  it("evicts TTL-expired records on write, logging the drop", async () => {
+    const { store } = await create()
+    const log = spyDaemonLog()
+    try {
+      const old = await store.file({ ...base, taskId: "task-old", at: now })
+      now += DEFERRED_PROMPT_TTL_MS + 1_000
+      await store.file({ ...base, taskId: "task-new", at: now })
+
+      expect(await store.get(old.id)).toBeNull()
+      expect(log.lines.join("")).toContain("expired deferred prompt")
+    } finally {
+      log.restore()
+    }
+  })
+
+  it("deleteTask drops the task's records with a log line", async () => {
+    const { store } = await create()
+    const log = spyDaemonLog()
+    try {
+      const a = await store.file({ ...base, at: now })
+      const b = await store.file({ ...base, taskId: "task-2", tabId: "tab-1", at: now })
+
+      await store.deleteTask("task-1")
+      expect(await store.get(a.id)).toBeNull()
+      expect(await store.get(b.id)).toEqual(b)
+      expect(log.lines.join("")).toContain("task-1 deleted")
+    } finally {
+      log.restore()
+    }
+  })
+
+  it("lists records scoped to one task", async () => {
+    const { store } = await create()
+    await store.file({ ...base, at: now })
+    await store.file({ ...base, taskId: "task-1", tabId: "tab-2", at: now })
+    await store.file({ ...base, taskId: "task-2", tabId: "tab-1", at: now })
+
+    const listed = await store.listForTask("task-1")
+    expect(listed).toHaveLength(2)
+    expect(listed.every((r) => r.taskId === "task-1")).toBe(true)
+  })
+})

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -23,6 +23,7 @@ export interface RecordedHandlerEffects {
   readonly noteCalls: Array<{ method: string; repo: unknown; note?: unknown }>
   readonly cleared: string[]
   readonly inboxRecords: Array<{ taskId: string; kind: string; detail?: unknown; tabId?: string }>
+  readonly inboxPromptDeferred: Array<{ taskId: string; tabId: string; deferredId: string; layer: string }>
   readonly inboxDeleted: Array<{ taskId: string; tabId: string | null; at?: number }>
   readonly inboxRead: Array<{ taskId: string; tabId: string | null; at: number }>
   readonly inboxTaskDeleted: string[]
@@ -48,6 +49,7 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
     noteCalls: [],
     cleared: [],
     inboxRecords: [],
+    inboxPromptDeferred: [],
     inboxDeleted: [],
     inboxRead: [],
     inboxTaskDeleted: [],
@@ -68,6 +70,10 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
     inbox: {
       record: (taskId: string, kind: string, detail?: unknown, tabId?: string) => {
         rec.inboxRecords.push({ taskId, kind, detail, tabId })
+        return Promise.resolve()
+      },
+      recordPromptDeferred: (taskId: string, tabId: string, deferredId: string, layer: string) => {
+        rec.inboxPromptDeferred.push({ taskId, tabId, deferredId, layer })
         return Promise.resolve()
       },
       deleteEpisode: (taskId: string, tabId: string | null, at?: number) => {

--- a/packages/kobe/test/daemon/handlers-deferred.test.ts
+++ b/packages/kobe/test/daemon/handlers-deferred.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { DeferredPromptsStore as Store } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { afterEach, describe, expect, it } from "vitest"
+import { TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
+
+describe("deferredPrompt RPC handlers (issue #78 B)", () => {
+  let dir: string | null = null
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+    dir = null
+  })
+
+  async function ctxWithStore() {
+    const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === TASK.id ? TASK : undefined) })
+    dir = await mkdtemp(join(tmpdir(), "kobe-deferred-handlers-"))
+    const store = new Store(join(dir, "deferred-prompts.json"))
+    ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = store
+    return { ctx, rec, store }
+  }
+
+  it("file stores the text and records a prompt_deferred episode, returning the id", async () => {
+    const { ctx, rec, store } = await ctxWithStore()
+    const res = (await dispatch(
+      "deferredPrompt.file",
+      { taskId: TASK.id, tabId: "tab-1", prompt: "hi there", layer: "composer-not-empty" },
+      ctx,
+    )) as { id: string }
+
+    expect(res.id).toBeTruthy()
+    const record = await store.get(res.id)
+    expect(record?.prompt).toBe("hi there")
+    expect(record?.layer).toBe("composer-not-empty")
+    // The episode points at the record by id — the prompt text is NOT copied
+    // into the episode's EngineActivityDetail.
+    expect(rec.inboxPromptDeferred).toEqual([
+      { taskId: TASK.id, tabId: "tab-1", deferredId: res.id, layer: "composer-not-empty" },
+    ])
+  })
+
+  it("file rejects a bad layer and an unknown task", async () => {
+    const { ctx } = await ctxWithStore()
+    await expect(
+      dispatch("deferredPrompt.file", { taskId: TASK.id, tabId: "tab-1", prompt: "x", layer: "bogus" }, ctx),
+    ).rejects.toThrow(/layer must be/)
+    await expect(
+      dispatch(
+        "deferredPrompt.file",
+        { taskId: "nope", tabId: "tab-1", prompt: "x", layer: "composer-not-empty" },
+        ctx,
+      ),
+    ).rejects.toThrow(/task not found/)
+  })
+
+  it("get reads a record back by id (null once resolved)", async () => {
+    const { ctx, store } = await ctxWithStore()
+    const { id } = (await dispatch(
+      "deferredPrompt.file",
+      { taskId: TASK.id, tabId: "tab-1", prompt: "queued", layer: "recent-human-write" },
+      ctx,
+    )) as { id: string }
+
+    const got = (await dispatch("deferredPrompt.get", { id }, ctx)) as { record: { prompt: string } | null }
+    expect(got.record?.prompt).toBe("queued")
+
+    await dispatch("deferredPrompt.resolve", { id }, ctx)
+    const after = (await dispatch("deferredPrompt.get", { id }, ctx)) as { record: unknown }
+    expect(after.record).toBeNull()
+    expect(await store.get(id)).toBeNull()
+  })
+
+  it("resolve drops BOTH the record and the pointing inbox episode", async () => {
+    const { ctx, rec } = await ctxWithStore()
+    const { id } = (await dispatch(
+      "deferredPrompt.file",
+      { taskId: TASK.id, tabId: "tab-1", prompt: "queued", layer: "composer-not-empty" },
+      ctx,
+    )) as { id: string }
+
+    await dispatch("deferredPrompt.resolve", { id }, ctx)
+    expect(rec.inboxDeleted).toEqual([{ taskId: TASK.id, tabId: "tab-1" }])
+  })
+})

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -85,6 +85,9 @@ describe("daemon handler registry", () => {
       "notice.send",
       "note.file",
       "note.list",
+      "deferredPrompt.file",
+      "deferredPrompt.get",
+      "deferredPrompt.resolve",
     ]
     const registry = createDaemonHandlerRegistry()
     for (const name of rpcNames) expect(registry.get(name), name).toBeDefined()


### PR DESCRIPTION
## Summary

The B layer of issue #78 — **accept-and-defer** — landing as a follow-up to #633 (which merged A+C before this was pushed). When the delivery gate finds the composer busy, a prompt is now accepted into daemon ownership instead of dropped or hard-rejected.

## What this adds on top of #633 (A+C gates)

- **Daemon-owned `DeferredPromptsStore`** (new): stores the blocked prompt text — one record per task+tab, 24h TTL; displacement / expiry / task-deletion are all written to the daemon log, never silently dropped. The inbox episode carries only the record id (a raw prompt is not `EngineActivityDetail` engine activity).
- **`prompt_deferred` attention-inbox state** + episode.
- **Third send outcome**: `send` / `add --prompt` return `deferred: {id, layer}` = **SUCCESS**; callers must NOT retry (a retry stacks a duplicate). Documented in the `send` verb description.
- **Exit path (hard requirement)**: opening the `prompt_deferred` inbox item jumps to the tab and inserts the queued message with a **fresh A/C gate** (reuses the open action — no new chord), then resolves record + episode; a still-busy composer keeps it queued. Toast on deferral is inbox-driven (a deferred prompt produces no engine activity); toast + inbox copy i18n'd in both locales.
- **`deferredPrompt.*` verbs are socket-only** — deliberately off the pinned browser-reachable allowlist.

## Decisions (per issue)
- Prompt text in a new store, not the inbox detail; the episode references it by id.
- Expiry: one-per-tab (newer displaces older, logged) + 24h TTL (logged).
- Insert re-runs A and C so a human typing at release can't be pasted over.

## Tests
`deferred-prompts-store.test.ts` (store, TTL/displace/delete logging) + `handlers-deferred.test.ts` (file/get/resolve, episode wiring). 9 new tests.

## Gate exemptions (with justification)
file-size-exemption: packages/kobe-daemon/src/daemon/server.ts — composition root was already at 499/500 before this change; B adds only the 4 unavoidable wiring lines (import + store const + one clearTaskState finally + one ctx field). Splitting the daemon composition root is a separate refactor, recommended as follow-up.
coverage-exemption: packages/kobe/src/tui-react/workspace/use-attention.ts — the deferral toast is a thin useEffect over daemon RPC + the notify sink; the queue/ownership logic it orchestrates is covered by deferred-prompts-store / handlers-deferred unit tests. A render harness needs a live daemon+PTY; render coverage recommended as follow-up.
coverage-exemption: packages/kobe/src/tui-react/workspace/use-inbox-host.ts — the exit path (fetch record → re-gate insert → resolve) is thin orchestration over the daemon RPC + hosted-session gate; covered by behavior + unit tests. Same live-daemon+PTY render-harness constraint.
coverage-exemption: packages/kobe/src/tui-react/workspace/host.tsx — the only change is threading notifyInfo one level into useInboxHost; host.tsx is the whole workspace host (mounting it in a render harness needs a live daemon+PTY). Render coverage recommended as follow-up.

Closes #78 (B layer — completes the feature).