### PR TITLE
fix: don't mistake a busy daemon for a dead one

### DIFF
--- a/.changeset/daemon-socket-succession-storm.md
+++ b/.changeset/daemon-socket-succession-storm.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop treating a slow `hello` as a dead daemon. A busy daemon that missed the
+3s probe deadline was killed and replaced, which made the old one self-stop
+when it saw a new socket inode, which dropped every client, which made every
+GUI reconnect at once onto a cold-starting daemon — eleven successions in one
+50-minute window, with `rove api` failing intermittently throughout. The
+client now asks the OS whether the daemon PROCESS exists before stopping
+anything, and GUI reconnects are jittered so they no longer arrive in lockstep.

--- a/packages/kobe-daemon/src/client/daemon-process.ts
+++ b/packages/kobe-daemon/src/client/daemon-process.ts
@@ -3,9 +3,10 @@ import { closeSync, existsSync, mkdirSync, openSync, statSync, unlinkSync } from
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { LEGACY_KOBE_PRODUCT_NAME, ROVE_PRODUCT_NAME } from "../compat-env.ts"
-import { stopDaemonProcess } from "../daemon/lifecycle.ts"
+import { isProcessAlive, stopDaemonProcess } from "../daemon/lifecycle.ts"
 import { defaultDaemonLogPath, defaultDaemonPidPath, defaultDaemonSocketPath } from "../daemon/paths.ts"
 import { DAEMON_PROTOCOL_VERSION } from "../daemon/protocol.ts"
+import { readPidFile } from "../daemon/socket-guard.ts"
 import { KobeDaemonClient } from "./index.ts"
 
 const DAEMON_START_ARGS = ["daemon", "start"] as const
@@ -17,6 +18,16 @@ const DAEMON_START_ARGS = ["daemon", "start"] as const
  * so a momentarily-busy daemon is never mistaken for a wedged one.
  */
 const DAEMON_HELLO_TIMEOUT_MS = 3000
+
+/**
+ * How long a daemon whose PROCESS is alive gets to answer hello before we
+ * call it wedged. Deliberately much longer than {@link
+ * DAEMON_HELLO_TIMEOUT_MS}: that timeout decides "is this daemon quick",
+ * this one decides "is this daemon dead", and only the second one licenses
+ * a kill. Covers a cold-start plugin-host scan plus a burst of concurrent
+ * task creation — the shape that produced the 2026-08-29 succession storm.
+ */
+const BUSY_DAEMON_GRACE_MS = 15_000
 
 /**
  * How a background child is cut loose from this process.
@@ -116,11 +127,18 @@ export function autospawnDaemonEnv(env: NodeJS.ProcessEnv = process.env): NodeJS
  * socket, which is how split-brain succession starts. One `wx` lockfile
  * next to the pidfile serializes them; losers wait for the winner's daemon
  * instead of spawning their own. Stale threshold covers the winner's worst
- * case (stop escalation ~7s + spawn poll 5s) so a crashed winner never
- * blocks recovery for long.
+ * case so a crashed winner never blocks recovery for long — see the budget
+ * arithmetic on the constants below.
  */
-const SPAWN_LOCK_STALE_MS = 20_000
-const SPAWN_LOCK_WAIT_MS = 15_000
+// Both budgets must cover the WINNER's worst case, or the losers give up
+// (or steal the lock as stale) while it is still legitimately working:
+//   BUSY_DAEMON_GRACE_MS (15s waiting out a busy daemon)
+// + stopDaemonProcess escalation (~7s graceful → SIGTERM → SIGKILL)
+// + spawn poll (5s)
+// ≈ 27s. Stale must exceed wait so a still-working winner is never robbed
+// of its own lock by a peer that merely got bored.
+const SPAWN_LOCK_STALE_MS = 40_000
+const SPAWN_LOCK_WAIT_MS = 30_000
 
 /** Try to take the spawn lock; returns false when a fresh lock is held by
  *  someone else. Reclaims stale locks. Exported for tests. */
@@ -191,6 +209,42 @@ export async function ensureDaemonReachable(): Promise<string> {
     // Re-probe under the lock: the previous holder may have brought a
     // daemon up between our probe above and the lock acquisition.
     if ((await probeDaemonSocket(socketPath)) === "alive") return socketPath
+
+    // A SLOW HELLO IS NOT A DEAD DAEMON. `probeDaemonSocket` reports
+    // whether the daemon ANSWERED within `DAEMON_HELLO_TIMEOUT_MS`, which a
+    // healthy-but-busy daemon can miss — spawning three tasks at once was
+    // enough on the owner's machine (2026-08-29). Treating that as death
+    // starts a succession storm that feeds itself:
+    //
+    //   busy daemon misses hello → client kills it and unlinks the socket →
+    //   spawns a replacement → the old daemon's ownership guard sees a
+    //   different inode and self-stops → every client's connection drops →
+    //   each GUI reconnects with ZERO delay → they all probe a daemon that
+    //   is now cold-starting → it misses hello → repeat.
+    //
+    // Eleven successions in one 50-minute window, with `rove api` failing
+    // intermittently throughout. The spawn lock does not help: it
+    // serializes the killing, it does not question it.
+    //
+    // So before killing anything, ask the OS. `kill(pid, 0)` answers
+    // whether the PROCESS exists, which is the question we actually have;
+    // the socket only ever answered whether it was quick enough. A live pid
+    // means the daemon is busy, not wedged — back off and let it finish.
+    // Only an absent (or unreadable) pidfile justifies the stop+spawn.
+    const livePid = await readPidFile(defaultDaemonPidPath())
+    if (livePid !== null && livePid !== process.pid && isProcessAlive(livePid)) {
+      const deadline = Date.now() + BUSY_DAEMON_GRACE_MS
+      while (Date.now() < deadline) {
+        await new Promise((resolveTimer) => setTimeout(resolveTimer, 250))
+        if (await testDaemonResponds(socketPath)) return socketPath
+        // It died on its own while we waited (crash, or a legitimate idle
+        // stop): the pid is gone, so the stop+spawn below is now correct.
+        if (!isProcessAlive(livePid)) break
+      }
+      // Still alive and still not answering after the grace window — this
+      // is a genuinely wedged daemon, and stopDaemonProcess's escalation
+      // (graceful → SIGTERM → SIGKILL) is the right tool.
+    }
 
     // Absent, or wedged outside a session: kill any wedged process FIRST —
     // `stopDaemonProcess` is idempotent (just clears stale socket/pidfile

--- a/packages/kobe-daemon/src/daemon/lifecycle.ts
+++ b/packages/kobe-daemon/src/daemon/lifecycle.ts
@@ -37,8 +37,13 @@ export interface StopDaemonResult {
 }
 
 /** `kill(pid, 0)` throws ESRCH once a process is gone; EPERM means it's
- *  alive but owned by another user. */
-function isProcessAlive(pid: number): boolean {
+ *  alive but owned by another user.
+ *
+ *  Exported because it is the ONLY honest liveness answer we have: a socket
+ *  probe reports whether the daemon ANSWERED, which a busy daemon can fail
+ *  while being perfectly healthy. Callers deciding whether to kill anything
+ *  must ask the OS, not the socket. */
+export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0)
     return true

--- a/packages/kobe/src/client/remote-orchestrator-connect.ts
+++ b/packages/kobe/src/client/remote-orchestrator-connect.ts
@@ -43,7 +43,13 @@ export async function runReconnectLoop(deps: {
   readonly init: () => Promise<void>
   readonly shouldLogAttempt: (attempt: number) => boolean
 }): Promise<void> {
-  let delayMs = deps.spawnDaemon ? 0 : 500
+  // A GUI used to retry with ZERO delay, which made every GUI in the process
+  // wake at the same instant after a shared daemon drop and probe a daemon
+  // that is still cold-starting. Jitter the first GUI attempt so they arrive
+  // staggered: the first one through does the work, the rest find a live
+  // daemon and never enter the spawn path at all. Small enough to stay
+  // imperceptible, wide enough to separate same-tick wakeups.
+  let delayMs = deps.spawnDaemon ? Math.floor(Math.random() * 400) : 500
   let attempt = 0
   while (!deps.isDisposed()) {
     if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs))

--- a/packages/kobe/test/client/daemon-process.test.ts
+++ b/packages/kobe/test/client/daemon-process.test.ts
@@ -1,13 +1,16 @@
+import { spawn } from "node:child_process"
 import { existsSync, mkdtempSync, rmSync, unlinkSync, utimesSync, writeFileSync } from "node:fs"
 import { type Server, createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   ensureDaemonReachable,
+  probeDaemonSocket,
   resolveKobeSpawn,
   testDaemonResponds,
   tryAcquireSpawnLock,
 } from "@sma1lboy/kobe-daemon/client/daemon-process"
+import { isProcessAlive } from "@sma1lboy/kobe-daemon/daemon/lifecycle"
 import { afterEach, describe, expect, it } from "vitest"
 
 // Short paths: macOS caps unix-socket paths at ~104 chars, and tmpdir() can
@@ -89,6 +92,21 @@ describe("testDaemonResponds", () => {
     expect(await testDaemonResponds(path, 300)).toBe(false)
   })
 
+  // KNOWN GAP, pinned deliberately as the behavior that ships today rather
+  // than as a wish. `probeDaemonSocket` treats a hello that REJECTS the same
+  // as one that resolves (`.catch(() => true)`), so a daemon that accepts the
+  // connection and then drops it reads as "alive". A daemon in its shutdown
+  // path does exactly that — `daemon.stopping` destroys every client socket —
+  // so a client probing during that window is told the daemon is fine and
+  // returns a socket that is about to disappear. Change the verdict to
+  // "absent" and this expectation is what tells you the contract moved.
+  it("counts a connection dropped mid-hello as alive", async () => {
+    const path = await listen((sock) => {
+      setTimeout(() => sock.destroy(), 50)
+    })
+    expect(await probeDaemonSocket(path, 1000)).toBe("alive")
+  })
+
   it("is false when no daemon is listening", async () => {
     expect(await testDaemonResponds(join(SOCK_DIR, `kobe-dpr-absent-${process.pid}.sock`), 300)).toBe(false)
   })
@@ -130,6 +148,31 @@ describe("tryAcquireSpawnLock", () => {
   })
 })
 
+/**
+ * Point BOTH env namespaces at the test's throwaway paths, and hand back a
+ * restore function. Writing only `KOBE_*` is not isolation: `readRoveEnv`
+ * prefers `ROVE_*`, so an inherited `ROVE_DAEMON_SOCKET_PATH` would quietly
+ * aim these tests at the developer's real daemon. `undefined` clears a pair,
+ * which is how a test escapes `insideEngineSession()` — this suite itself
+ * normally runs inside a Rove engine tab, where the task id is set.
+ */
+function overrideRoveEnv(vars: Record<string, string | undefined>): () => void {
+  const saved: [string, string | undefined][] = []
+  for (const [suffix, value] of Object.entries(vars)) {
+    for (const name of [`ROVE_${suffix}`, `KOBE_${suffix}`]) {
+      saved.push([name, process.env[name]])
+      if (value === undefined) Reflect.deleteProperty(process.env, name)
+      else process.env[name] = value
+    }
+  }
+  return () => {
+    for (const [name, value] of saved) {
+      if (value === undefined) Reflect.deleteProperty(process.env, name)
+      else process.env[name] = value
+    }
+  }
+}
+
 describe("ensureDaemonReachable under a held spawn lock", () => {
   it("waits for the winner's daemon instead of stacking a second stop+spawn", async () => {
     // Two clients race after the same daemon drop (the 2026-08-11 twin
@@ -137,14 +180,11 @@ describe("ensureDaemonReachable under a held spawn lock", () => {
     // winner's daemon answers, and never releases the winner's lock.
     const dir = mkdtempSync(join(tmpdir(), "kobe-spawn-wait-"))
     const socketPath = join(SOCK_DIR, `kobe-dpr-wait-${process.pid}.sock`)
-    const saved = {
-      sock: process.env.KOBE_DAEMON_SOCKET_PATH,
-      pid: process.env.KOBE_DAEMON_PID_PATH,
-      home: process.env.KOBE_HOME_DIR,
-    }
-    process.env.KOBE_DAEMON_SOCKET_PATH = socketPath
-    process.env.KOBE_DAEMON_PID_PATH = join(dir, "daemon.pid")
-    process.env.KOBE_HOME_DIR = dir
+    const restoreEnv = overrideRoveEnv({
+      DAEMON_SOCKET_PATH: socketPath,
+      DAEMON_PID_PATH: join(dir, "daemon.pid"),
+      HOME_DIR: dir,
+    })
     const lock = join(dir, "daemon.pid.spawn-lock")
     writeFileSync(lock, "")
     try {
@@ -158,92 +198,119 @@ describe("ensureDaemonReachable under a held spawn lock", () => {
       // Still the winner's lock — the waiter neither spawned nor released it.
       expect(existsSync(lock)).toBe(true)
     } finally {
-      for (const [env, value] of [
-        ["KOBE_DAEMON_SOCKET_PATH", saved.sock],
-        ["KOBE_DAEMON_PID_PATH", saved.pid],
-        ["KOBE_HOME_DIR", saved.home],
-      ] as const) {
-        if (value === undefined) Reflect.deleteProperty(process.env, env)
-        else process.env[env] = value
-      }
+      restoreEnv()
       rmSync(dir, { recursive: true, force: true })
     }
   })
 })
+
+/**
+ * A daemon stand-in that is BUSY rather than broken: it accepts connections
+ * and records every request name it is asked for, but stays silent for the
+ * first `silentConnections` clients — long enough to blow the hello deadline
+ * twice — before answering `hello` normally, like a daemon that has caught
+ * up on its backlog.
+ *
+ * Silence is per-connection and decided when the connection opens, so the
+ * handover is driven by the client's own probe sequence rather than by a
+ * timer. It must never DESTROY a connection to simulate the wedge: the
+ * client counts a mid-flight close as a reply (`.catch(() => true)`), which
+ * reports a silent daemon as "alive" and skips the code under test entirely.
+ */
+function busyThenHealthy(silentConnections: number, seen: string[]) {
+  let connections = 0
+  return (sock: import("node:net").Socket): void => {
+    connections += 1
+    const answering = connections > silentConnections
+    sock.on("data", (chunk) => {
+      for (const line of chunk.toString().split("\n").filter(Boolean)) {
+        const frame = JSON.parse(line) as { id: string; name: string }
+        seen.push(frame.name)
+        if (answering && frame.name === "hello") {
+          sock.write(`${JSON.stringify({ type: "response", id: frame.id, payload: { protocolVersion: 2 } })}\n`)
+        }
+      }
+    })
+  }
+}
 
 describe("ensureDaemonReachable when the daemon is busy, not dead", () => {
   it("waits out a live-but-slow daemon instead of stopping it", async () => {
     // The 2026-08-29 succession storm: a busy daemon misses the hello
     // deadline, the client concludes it is dead and kills it, the
     // replacement's arrival makes the old one self-stop, every client
-    // reconnects at once onto a cold-starting daemon, repeat (11 times in
-    // 50 minutes). The fix asks the OS whether the PROCESS exists rather
-    // than whether the socket was quick.
+    // reconnects at once onto a cold-starting daemon, repeat — eleven
+    // successions in fifty minutes.
     //
-    // The observable difference is TIMING, and that is what this asserts:
-    // with the liveness check, a live pid buys a grace window, so a daemon
-    // that starts answering at 400ms is simply waited out and the call
-    // returns shortly after. Without it, the client goes straight into
-    // stopDaemonProcess — whose graceful-RPC leg alone budgets 2s before
-    // it even begins polling — so the call cannot come back this fast.
+    // What must hold is an ACTION, not a duration: a daemon whose PROCESS is
+    // alive must not be stopped merely for being slow. So the stand-in is a
+    // real live process plus a socket that logs what it is asked for, and
+    // both halves of "we did not kill it" are asserted directly —
+    // `daemon.stop` was never sent, and the process is still running after.
+    //
+    // Two earlier versions asserted proxies and stayed green with the fix
+    // deleted, so both traps are pinned here: a pidfile naming THIS process
+    // is skipped by the guard (`livePid !== process.pid`) AND by
+    // `stopDaemonProcess`, leaving nothing at risk; and destroying the
+    // probe's own connection makes `probeDaemonSocket` read the close as a
+    // reply and return "alive", so the branch under test is never entered.
     const dir = mkdtempSync(join(tmpdir(), "kobe-busy-daemon-"))
     const socketPath = join(SOCK_DIR, `kobe-dpr-busy-${process.pid}.sock`)
     const pidPath = join(dir, "daemon.pid")
-    const saved = {
-      sock: process.env.KOBE_DAEMON_SOCKET_PATH,
-      pid: process.env.KOBE_DAEMON_PID_PATH,
-      home: process.env.KOBE_HOME_DIR,
-      task: process.env.KOBE_TASK_ID,
-      roveTask: process.env.ROVE_TASK_ID,
-    }
-    process.env.KOBE_DAEMON_SOCKET_PATH = socketPath
-    process.env.KOBE_DAEMON_PID_PATH = pidPath
-    process.env.KOBE_HOME_DIR = dir
-    // MUST be cleared, or this test measures nothing: `ensureDaemonReachable`
-    // bails out early for a wedged socket when it believes it is running
-    // inside an engine session, never reaching the liveness check under
-    // test. The suite itself routinely runs inside a Rove engine tab, where
-    // KOBE_TASK_ID is set — inheriting it made an earlier version of this
-    // test pass with the fix deleted.
-    Reflect.deleteProperty(process.env, "KOBE_TASK_ID")
-    Reflect.deleteProperty(process.env, "ROVE_TASK_ID")
-
-    // A socket that ACCEPTS but never replies — indistinguishable from a
-    // busy daemon, which is exactly the case that used to get it killed.
-    await listenAt(socketPath, () => {
-      /* accept and stay silent */
+    const restoreEnv = overrideRoveEnv({
+      DAEMON_SOCKET_PATH: socketPath,
+      DAEMON_PID_PATH: pidPath,
+      HOME_DIR: dir,
+      // Cleared, or this measures nothing: inside an engine session
+      // `ensureDaemonReachable` throws on a wedged socket before it ever
+      // reaches the liveness check.
+      TASK_ID: undefined,
+      TAB_ID: undefined,
     })
-    // A pidfile naming a process that is definitely alive: this one. A
-    // real daemon's pid would do the same job; using ours keeps the test
-    // from having to stage (and reap) a second process.
-    writeFileSync(pidPath, String(process.pid))
+
+    // The busy daemon's process. A real child, because the whole question is
+    // what the OS says about a pid that is NOT this one.
+    const busyDaemon = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60000)"], { stdio: "ignore" })
+    const busyPid = busyDaemon.pid
+
+    // Two silent probes: `ensureDaemonReachable` spends one hello deadline
+    // before taking the spawn lock and another re-probing under it. The
+    // third client is whoever runs next — the grace-window poll if the
+    // daemon is given one, `stopDaemonProcess` if it is not.
+    const seen: string[] = []
+    await listenAt(socketPath, busyThenHealthy(2, seen))
 
     try {
-      // The daemon "finishes what it was doing" and starts answering while
-      // ensureDaemonReachable is inside its grace window.
-      const timer = setTimeout(() => {
-        for (const socket of openSockets) socket.destroy()
-        void listenAt(socketPath, helloResponder)
-      }, 400)
-      const startedAt = Date.now()
-      const resolved = await ensureDaemonReachable()
-      const elapsed = Date.now() - startedAt
-      clearTimeout(timer)
-      expect(resolved).toBe(socketPath)
-      // Returned by waiting, not by killing: stopDaemonProcess's graceful
-      // leg alone would push this past 2s.
-      expect(elapsed).toBeLessThan(2000)
+      expect(busyPid).toBeGreaterThan(0)
+      writeFileSync(pidPath, String(busyPid))
+
+      // Capture rather than propagate, so the invariant below is what
+      // reports the failure. Letting the throw escape here would surface as
+      // "daemon did not start" — the downstream symptom of having killed the
+      // daemon, which names neither the rule that was broken nor this bug.
+      const outcome = await ensureDaemonReachable().then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error }),
+      )
+
+      // THE invariant: a daemon whose process is alive is never stopped for
+      // being slow. `stopDaemonProcess` opens with a `daemon.stop` RPC, so
+      // one appearing in the log means the client decided this daemon was
+      // dead. The grace window only ever sends `hello`.
+      expect(seen).not.toContain("daemon.stop")
+      // Still running, and still owning its pidfile — `stopDaemonProcess`
+      // signals the process and unlinks both files on its way out, so these
+      // are two further independent reads of "we did not kill it".
+      expect(isProcessAlive(busyPid as number)).toBe(true)
+      expect(existsSync(pidPath)).toBe(true)
+
+      // And the wait actually paid off: the caller gets the busy daemon's
+      // own socket back, not an error and not a replacement's.
+      expect(outcome.error).toBeUndefined()
+      expect(outcome.value).toBe(socketPath)
     } finally {
-      for (const [env, value] of [
-        ["KOBE_DAEMON_SOCKET_PATH", saved.sock],
-        ["KOBE_DAEMON_PID_PATH", saved.pid],
-        ["KOBE_HOME_DIR", saved.home],
-        ["KOBE_TASK_ID", saved.task],
-        ["ROVE_TASK_ID", saved.roveTask],
-      ] as const) {
-        if (value === undefined) Reflect.deleteProperty(process.env, env)
-        else process.env[env] = value
-      }
+      busyDaemon.kill("SIGKILL")
+      restoreEnv()
       rmSync(dir, { recursive: true, force: true })
     }
   }, 30_000)

--- a/packages/kobe/test/client/daemon-process.test.ts
+++ b/packages/kobe/test/client/daemon-process.test.ts
@@ -170,3 +170,81 @@ describe("ensureDaemonReachable under a held spawn lock", () => {
     }
   })
 })
+
+describe("ensureDaemonReachable when the daemon is busy, not dead", () => {
+  it("waits out a live-but-slow daemon instead of stopping it", async () => {
+    // The 2026-08-29 succession storm: a busy daemon misses the hello
+    // deadline, the client concludes it is dead and kills it, the
+    // replacement's arrival makes the old one self-stop, every client
+    // reconnects at once onto a cold-starting daemon, repeat (11 times in
+    // 50 minutes). The fix asks the OS whether the PROCESS exists rather
+    // than whether the socket was quick.
+    //
+    // The observable difference is TIMING, and that is what this asserts:
+    // with the liveness check, a live pid buys a grace window, so a daemon
+    // that starts answering at 400ms is simply waited out and the call
+    // returns shortly after. Without it, the client goes straight into
+    // stopDaemonProcess — whose graceful-RPC leg alone budgets 2s before
+    // it even begins polling — so the call cannot come back this fast.
+    const dir = mkdtempSync(join(tmpdir(), "kobe-busy-daemon-"))
+    const socketPath = join(SOCK_DIR, `kobe-dpr-busy-${process.pid}.sock`)
+    const pidPath = join(dir, "daemon.pid")
+    const saved = {
+      sock: process.env.KOBE_DAEMON_SOCKET_PATH,
+      pid: process.env.KOBE_DAEMON_PID_PATH,
+      home: process.env.KOBE_HOME_DIR,
+      task: process.env.KOBE_TASK_ID,
+      roveTask: process.env.ROVE_TASK_ID,
+    }
+    process.env.KOBE_DAEMON_SOCKET_PATH = socketPath
+    process.env.KOBE_DAEMON_PID_PATH = pidPath
+    process.env.KOBE_HOME_DIR = dir
+    // MUST be cleared, or this test measures nothing: `ensureDaemonReachable`
+    // bails out early for a wedged socket when it believes it is running
+    // inside an engine session, never reaching the liveness check under
+    // test. The suite itself routinely runs inside a Rove engine tab, where
+    // KOBE_TASK_ID is set — inheriting it made an earlier version of this
+    // test pass with the fix deleted.
+    Reflect.deleteProperty(process.env, "KOBE_TASK_ID")
+    Reflect.deleteProperty(process.env, "ROVE_TASK_ID")
+
+    // A socket that ACCEPTS but never replies — indistinguishable from a
+    // busy daemon, which is exactly the case that used to get it killed.
+    await listenAt(socketPath, () => {
+      /* accept and stay silent */
+    })
+    // A pidfile naming a process that is definitely alive: this one. A
+    // real daemon's pid would do the same job; using ours keeps the test
+    // from having to stage (and reap) a second process.
+    writeFileSync(pidPath, String(process.pid))
+
+    try {
+      // The daemon "finishes what it was doing" and starts answering while
+      // ensureDaemonReachable is inside its grace window.
+      const timer = setTimeout(() => {
+        for (const socket of openSockets) socket.destroy()
+        void listenAt(socketPath, helloResponder)
+      }, 400)
+      const startedAt = Date.now()
+      const resolved = await ensureDaemonReachable()
+      const elapsed = Date.now() - startedAt
+      clearTimeout(timer)
+      expect(resolved).toBe(socketPath)
+      // Returned by waiting, not by killing: stopDaemonProcess's graceful
+      // leg alone would push this past 2s.
+      expect(elapsed).toBeLessThan(2000)
+    } finally {
+      for (const [env, value] of [
+        ["KOBE_DAEMON_SOCKET_PATH", saved.sock],
+        ["KOBE_DAEMON_PID_PATH", saved.pid],
+        ["KOBE_HOME_DIR", saved.home],
+        ["KOBE_TASK_ID", saved.task],
+        ["ROVE_TASK_ID", saved.roveTask],
+      ] as const) {
+        if (value === undefined) Reflect.deleteProperty(process.env, env)
+        else process.env[env] = value
+      }
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/packages/kobe/test/client/remote-orchestrator-reconnect.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-reconnect.test.ts
@@ -143,7 +143,10 @@ describe("RemoteOrchestrator auto-reconnect", () => {
     })
     h.triggerClose()
     expect(orch.connectionStateSignal()()).toBe("disconnected")
-    await sleep(50)
+    // The first GUI attempt carries up to 400ms of jitter (so concurrent
+    // GUIs don't all probe a cold-starting daemon at the same instant);
+    // wait past that window rather than assuming an immediate retry.
+    await sleep(600)
     expect(ensureCalls).toBe(1)
     expect(h.helloCount()).toBe(1)
     expect(orch.connectionStateSignal()()).toBe("online")
@@ -161,7 +164,8 @@ describe("RemoteOrchestrator auto-reconnect", () => {
     })
 
     h.triggerClose()
-    await sleep(800)
+    // jitter (≤400ms) + the failed first attempt's 500ms backoff.
+    await sleep(1400)
 
     expect(ensureCalls).toBe(2)
     expect(h.helloCount()).toBe(1)


### PR DESCRIPTION
## The bug

Eleven daemon successions in a 50-minute window on the owner's machine, with `rove api` intermittently unusable throughout. `~/.rove/daemon.log` shows eleven `socket path was taken over or removed` entries between 2026-08-29T23:33 and 00:25.

It is self-feeding:

1. Daemon is busy (three tasks created at once) → misses the 3s `hello` probe
2. Client calls it dead → `stopDaemonProcess` kills it and unlinks the socket → spawns a replacement
3. The old daemon's ownership guard sees a different inode → self-stops
4. Every client drops → each GUI reconnects with **zero** delay → they all pile onto a cold-starting daemon
5. It misses `hello` → back to 1

The spawn lock does not help: it serializes the killing, it does not question it.

## The fix

1. **Core** — `ensureDaemonReachable`, having taken the spawn lock and before killing anything, asks the OS: `readPidFile` + `isProcessAlive` (`kill -0`). A live process buys `BUSY_DAEMON_GRACE_MS` (15s) of polling. If it dies on its own during the window, we break out and stop+spawn as before. Only a live process that is still silent after the grace window is treated as genuinely wedged. A slow `hello` answers "is this daemon quick"; only `kill -0` answers "is this daemon alive", and only the second question licenses a kill.
2. Spawn-lock WAIT/STALE raised 15s/20s → 30s/40s. The winner's worst case is now ~27s (15s grace + ~7s stop escalation + 5s spawn), so the old budget would have let waiters time out — or steal the lock — while the winner was still legitimately working.
3. GUI first reconnect jittered by `Math.random()*400`ms, so a drop no longer produces a synchronized stampede.

## The test — the disclaimer on the first commit no longer applies

The original commit message ended with a caveat that the accompanying test *was not yet a real guard*. **That is now resolved.** The test fails when the fix is deleted, verified three times across two rewrites.

The earlier version passed with the fix removed for two independent reasons, both now pinned in comments so they can't quietly return:

- Its pidfile named **this** process, which both the new guard (`livePid !== process.pid`) and `stopDaemonProcess` (`oldPid !== process.pid`) deliberately skip — so nothing was ever at risk.
- Its handover `destroy()`ed the probe's own connection. `probeDaemonSocket` treats a rejected `hello` the same as a resolved one (`.catch(() => true)`), so the close read as **"alive"** and the branch under test was never entered at all. Instrumenting each branch showed the call returning at `probe#1 = alive`, having executed none of the code it claimed to cover.

The rewrite drops timing proxies and asserts the invariant as an action: a daemon whose process is alive is never stopped for being slow. It stages a **real child process** as the busy daemon plus a socket that records every request it is asked for, then checks that `daemon.stop` was never sent, the process is still alive, the pidfile survives, and the caller got the busy daemon's own socket back.

Deleting the liveness check fails it on the invariant itself, not on a downstream symptom:

```
AssertionError: expected [ 'hello', 'hello', 'daemon.stop' ] to not include 'daemon.stop'
```

Two probes, then the kill — the bug, stated in the failure message.

## Known gap found while verifying (not fixed here)

`probeDaemonSocket` reports **"alive"** for a daemon that accepts a connection and then drops it, because a rejected `hello` is counted as a reply. A daemon in its shutdown path does exactly that — `daemon.stopping` destroys every client socket — so a client probing during that window is told the daemon is healthy and handed a socket that is about to vanish.

Confirmed empirically against the real function, not inferred. It is a pre-existing flaw in a different function from the one this PR changes, and narrowing the verdict to `"absent"` changes behavior on paths beyond this fix, so it is **pinned as a characterization test** (`counts a connection dropped mid-hello as alive`) rather than silently changed. Tightening it should be its own PR; that test is what will tell you the contract moved.

## Verification

- `bun x vitest run test/client/daemon-process.test.ts` — 10 passed, stable across 3 consecutive runs
- Red gate (delete the liveness check → run → restore) exercised 3× on the final version; only the target test fails
- Root `bun run lint` clean; `typecheck` clean in both `kobe` and `kobe-daemon`
- `test:fast` shows 18 files / 47 tests failing — **identical on the untouched branch** (measured by stashing), so pre-existing and unrelated
- No leaked sockets or child processes after the run

## CI note: one unrelated flake on the first run

The first run failed `render-track` on `shortcut-reveal.test.tsx` — a `ctrl+a` overlay test this PR does not touch (nothing here changes TUI or render code). It passed on rerun with no change, and every other job was green on both runs.

Not left as "probably a flake": its `waitForFrameText` helper hardcodes a **1s** deadline, and the badges and the guide section do not arrive in the same frame. The failing frame already contained `⌃ A 1` / `⌃ A 2` and was missing only `more Rove commands` — a wait that ran out, not a wrong render. Shrinking that deadline to 60ms locally reproduces the identical error message, and restoring it goes back to green, so whether the test passes tracks runner load. Filed as issue #82 with the repro; unrelated to this change.
