### PR TITLE
fix: treat a daemon that drops the probe connection as absent

### DIFF
--- a/.changeset/soft-pears-invite.md
+++ b/.changeset/soft-pears-invite.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop reporting a daemon that is shutting down as healthy. `probeDaemonSocket` treated a hello that rejected the same as one that answered, so a probe landing in the shutdown window — where the daemon destroys every client socket — was told the daemon was fine and handed back a socket that vanished milliseconds later. A connection the peer drops before answering is now `absent`, so callers recover instead of using a dying socket. A daemon that answers with a protocol-mismatch error still counts as alive: it is running and serving other clients, and killing it is how split-brain starts.

--- a/packages/kobe-daemon/src/client/daemon-process.ts
+++ b/packages/kobe-daemon/src/client/daemon-process.ts
@@ -323,11 +323,11 @@ export type DaemonSocketState = "alive" | "absent" | "wedged"
  * inside an engine session rather than recover.
  *
  * The discriminator is the CONNECTION dying, not the promise rejecting —
- * conflating the two is what would kill a version-mismatched daemon. We
- * read it off the client's `close` lifecycle rather than the rejection:
- * `onSocketClose` fails pending requests and THEN emits `close`, both
- * synchronously, so by the time the awaited race resumes (a microtask) the
- * flag is already set.
+ * conflating the two is what would kill a version-mismatched daemon, whose
+ * hello rejects while the daemon is perfectly alive. We read it off the
+ * client's `close` lifecycle instead: `onSocketClose` fails the pending
+ * request and emits `close` in the same synchronous step, so the flag is
+ * set before the awaited race resumes on the following microtask.
  *
  * Exported for tests.
  */
@@ -356,6 +356,10 @@ export async function probeDaemonSocket(
   })
   const settled = await Promise.race([replied, timedOut])
   if (timer) clearTimeout(timer)
+  // Unsubscribe before `close()`: plain listener hygiene. `close()` nulls the
+  // socket first, so its own OS close event trips `onSocketClose`'s stale
+  // guard and emits nothing — but the verdict below must depend on the PEER
+  // dropping us, never on our own teardown, so don't leave the listener armed.
   offClose()
   probe.close()
   if (droppedByPeer) return "absent"

--- a/packages/kobe-daemon/src/client/daemon-process.ts
+++ b/packages/kobe-daemon/src/client/daemon-process.ts
@@ -294,16 +294,41 @@ export async function connectIfRunning(): Promise<KobeDaemonClient | null> {
   return client
 }
 
-/** What a socket probe found: answering, nothing there, or a socket that
- *  connects but won't answer hello (busy past the timeout, or truly hung). */
+/** What a socket probe found: answering, nothing usable there, or a socket
+ *  that connects but won't answer hello (busy past the timeout, or hung). */
 export type DaemonSocketState = "alive" | "absent" | "wedged"
 
 /**
  * Probe the daemon at `socketPath`: does it accept a connection, and does
- * it answer `hello` within `timeoutMs`? A socket that connects but never
- * replies is WEDGED — distinct from an absent one, and the reason we probe
- * `hello` rather than just `connect` (KOB). Any reply (even a
- * version-mismatch error) counts as alive; only a timeout means wedged.
+ * it answer `hello` within `timeoutMs`? Three outcomes, and each one is a
+ * different question about the SAME socket:
+ *
+ *  - `alive` — the daemon ANSWERED. Any response frame counts, including a
+ *    version-mismatch error: an old daemon that talks back is running and
+ *    serving other clients, and the caller's real connect is where that
+ *    mismatch belongs. Never kill something that answered.
+ *  - `wedged` — connected, STILL connected, and silent past the deadline.
+ *    Busy or genuinely hung; the caller decides which (see
+ *    {@link ensureDaemonReachable}'s pid check).
+ *  - `absent` — nothing usable here: the connect failed, OR the peer
+ *    dropped the connection before answering.
+ *
+ * That last clause is the 2026-08-30 fix (issue #83). A daemon in its
+ * shutdown path destroys every client socket (`server.ts` close()), so a
+ * probe landing in that window used to connect, get dropped, and — because
+ * the hello was `.catch(() => true)` — be reported ALIVE. The caller then
+ * held a socket that vanished milliseconds later. A closing daemon is
+ * `absent`, not `wedged`: it is leaving, so stop+spawn is the right
+ * recovery, whereas `wedged` would make `ensureDaemonReachable` throw
+ * inside an engine session rather than recover.
+ *
+ * The discriminator is the CONNECTION dying, not the promise rejecting —
+ * conflating the two is what would kill a version-mismatched daemon. We
+ * read it off the client's `close` lifecycle rather than the rejection:
+ * `onSocketClose` fails pending requests and THEN emits `close`, both
+ * synchronously, so by the time the awaited race resumes (a microtask) the
+ * flag is already set.
+ *
  * Exported for tests.
  */
 export async function probeDaemonSocket(
@@ -317,6 +342,10 @@ export async function probeDaemonSocket(
     probe.close()
     return "absent"
   }
+  let droppedByPeer = false
+  const offClose = probe.onLifecycle("close", () => {
+    droppedByPeer = true
+  })
   const replied = probe
     .request("hello", { protocolVersion: DAEMON_PROTOCOL_VERSION })
     .then(() => true)
@@ -325,10 +354,12 @@ export async function probeDaemonSocket(
   const timedOut = new Promise<boolean>((resolve) => {
     timer = setTimeout(() => resolve(false), timeoutMs)
   })
-  const alive = await Promise.race([replied, timedOut])
+  const settled = await Promise.race([replied, timedOut])
   if (timer) clearTimeout(timer)
+  offClose()
   probe.close()
-  return alive ? "alive" : "wedged"
+  if (droppedByPeer) return "absent"
+  return settled ? "alive" : "wedged"
 }
 
 /** Back-compat boolean view of {@link probeDaemonSocket}. */

--- a/packages/kobe/test/client/daemon-process.test.ts
+++ b/packages/kobe/test/client/daemon-process.test.ts
@@ -92,17 +92,75 @@ describe("testDaemonResponds", () => {
     expect(await testDaemonResponds(path, 300)).toBe(false)
   })
 
-  // KNOWN GAP, pinned deliberately as the behavior that ships today rather
-  // than as a wish. `probeDaemonSocket` treats a hello that REJECTS the same
-  // as one that resolves (`.catch(() => true)`), so a daemon that accepts the
-  // connection and then drops it reads as "alive". A daemon in its shutdown
-  // path does exactly that — `daemon.stopping` destroys every client socket —
-  // so a client probing during that window is told the daemon is fine and
-  // returns a socket that is about to disappear. Change the verdict to
-  // "absent" and this expectation is what tells you the contract moved.
-  it("counts a connection dropped mid-hello as alive", async () => {
+  // CONTRACT CHANGE, 2026-08-30 (issue #83). This was a characterization
+  // test asserting "alive" — pinned as the behavior that shipped, with a
+  // note saying it was not the DESIRED behavior. It is now the assertion it
+  // always wanted to be.
+  //
+  // Before: the hello was `.catch(() => true)`, so a peer that dropped the
+  // connection counted as having ANSWERED. A daemon in its shutdown path
+  // does exactly that (`server.ts` close() destroys every client socket
+  // after broadcasting `daemon.stopping`), so a probe landing in that
+  // window reported a healthy daemon and handed its caller a socket that
+  // disappeared milliseconds later.
+  //
+  // After: a connection the peer drops before answering is `absent`. Not
+  // `wedged` — a closing daemon is LEAVING, so the caller should stop+spawn
+  // (what absent means), whereas wedged makes `ensureDaemonReachable` throw
+  // instead of recover when called from inside an engine session.
+  it("reports a connection dropped mid-hello as absent, not alive", async () => {
     const path = await listen((sock) => {
       setTimeout(() => sock.destroy(), 50)
+    })
+    expect(await probeDaemonSocket(path, 1000)).toBe("absent")
+  })
+
+  // The shutdown shape verbatim: broadcast `daemon.stopping`, THEN destroy
+  // the socket. The event frame is not a response to our hello, so it must
+  // not be mistaken for one — the drop still decides the verdict.
+  it("reports a daemon that broadcasts daemon.stopping then drops as absent", async () => {
+    const path = await listen((sock) => {
+      sock.on("data", () => {
+        sock.write(`${JSON.stringify({ type: "event", name: "daemon.stopping", payload: {} })}\n`)
+        setTimeout(() => sock.destroy(), 10)
+      })
+    })
+    expect(await probeDaemonSocket(path, 1000)).toBe("absent")
+  })
+
+  // The other half of the contract, and the reason the discriminator is
+  // "the CONNECTION died" rather than "the hello promise rejected". A daemon
+  // on an incompatible protocol answers hello with an ERROR frame: the
+  // promise rejects, but the daemon is running and serving other clients.
+  // Reading that as absent would send the caller into stop+spawn — killing
+  // a live daemon out from under its attached TUI, which is precisely the
+  // split-brain succession this file's scar tissue exists to prevent.
+  it("still counts a version-mismatch error reply as alive", async () => {
+    const path = await listen((sock) => {
+      sock.on("data", (chunk) => {
+        for (const line of chunk.toString().split("\n").filter(Boolean)) {
+          const frame = JSON.parse(line) as { id: string; name: string }
+          if (frame.name !== "hello") continue
+          sock.write(
+            `${JSON.stringify({
+              type: "response",
+              id: frame.id,
+              error: { name: "Error", message: "daemon is protocol v9; this client is v2. Upgrade Rove." },
+            })}\n`,
+          )
+        }
+      })
+    })
+    expect(await probeDaemonSocket(path, 1000)).toBe("alive")
+  })
+
+  // A daemon that answers and only THEN closes (the ordinary case where our
+  // own `probe.close()` races the peer's teardown) answered — it is alive.
+  // The drop only decides the verdict when it beats the reply.
+  it("counts a reply followed by a drop as alive", async () => {
+    const path = await listen((sock) => {
+      helloResponder(sock)
+      setTimeout(() => sock.destroy(), 100)
     })
     expect(await probeDaemonSocket(path, 1000)).toBe("alive")
   })


### PR DESCRIPTION
Closes #83.

## The contract, decided before the code

`probeDaemonSocket` is the single entry point for every "is the daemon there?" question (`ensureDaemonReachable`, `testDaemonResponds`, the daemon boot guard, `rove doctor`). Its three states now mean:

| state | means | caller does |
|---|---|---|
| `alive` | the daemon **answered** — any response frame, including a version-mismatch *error* | use it |
| `wedged` | connected, **still connected**, silent past the deadline | busy-vs-hung call (#641's pid check) |
| `absent` | nothing usable: connect failed, **or the peer dropped us before answering** | stop + spawn |

Answering the three questions the issue posed:

1. **Which state for "connected then dropped"?** `absent`. A closing daemon is *leaving*, and `absent`'s recovery (stop+spawn) is exactly right. `wedged` would be actively worse: inside an engine session `ensureDaemonReachable` **throws** on `wedged` rather than recovering.
2. **Should "silent" and "dropped" be distinguished?** They are, but they don't need a fourth state — every caller would branch on `closing` identically to `absent`. Three states suffice.
3. **Does this collide with #641's liveness grace?** **Verified, not reasoned.** A closing daemon's pid *is* alive, so `absent` + live pid does enter the 15s grace loop. Measured against a real daemon: `ensureDaemonReachable` returned in **207ms** with a respawned daemon — no stall. The grace loop breaks on `!isProcessAlive(livePid)`, and a closing daemon exits in well under one poll interval.

## The trap this avoids

Mapping *every* hello rejection to `absent` is the obvious fix and it is wrong. A protocol-mismatched daemon replies with an **error frame** — the promise rejects, but that daemon is running and serving other clients. Reading it as `absent` sends the caller into stop+spawn, killing a live daemon out from under its attached TUI: precisely the split-brain succession this file's scar tissue exists to prevent. So the discriminator is the **connection dying**, read off the client's `close` lifecycle, not the rejection.

## Red-verified 3× with different mutations

Each mutation is caught by a *different* test, so no test is decorative:

| mutation | test that goes red |
|---|---|
| drop the `droppedByPeer` verdict (restore old behavior) | both drop tests: `expected 'alive' to be 'absent'` |
| naive fix — set the flag in the hello `.catch` | version-mismatch test: `expected 'absent' to be 'alive'` |
| right detection, wrong verdict (`wedged`) | both drop tests: `expected 'wedged' to be 'absent'` |

### One claim I had to walk back

While reviewing my own diff I asserted that the `offClose()` unsubscribe was load-bearing — that without it, `probe.close()` would emit `close` and poison every verdict. I tested that instead of trusting it: removing the line leaves all 13 tests green, because `close()` nulls the socket before its own OS close event arrives, so `onSocketClose`'s stale-socket guard suppresses the emit. The line stays as listener hygiene, and the comment now says that rather than implying the verdict depends on it (commit `d912c73`).

## The characterization test

`counts a connection dropped mid-hello as alive` is **updated, not deleted** — it becomes `reports a connection dropped mid-hello as absent, not alive`, with a comment recording what the contract was, what it is, and why `absent` rather than `wedged`.

## Live verification

Real daemons in an isolated sandbox (own socket/pid/home/web port):
- probe flood across a real `SIGTERM`: `alive=60 absent=339`, **0** alive-while-process-dead
- `ensureDaemonReachable` during shutdown: **207ms**, recovered onto a respawned daemon (no 15s grace stall)
- `rove daemon restart` end-to-end: new pid, `alive` after — the boot guard's `!== "alive"` check now correctly sees a *closing* incumbent as replaceable instead of refusing to boot

## Gates

- `test:socket` (real daemon lifecycle): **600/600 pass**
- `test:fast`: 3599 passed vs **3596 on clean HEAD** — exactly the 3 new tests, zero regressions. The 47 pre-existing CLI-usage failures reproduce identically on `HEAD` in a clean worktree.
- root lint + both typechecks clean; both touched files under the 500-line cap; changeset (patch) included.
