### PR TITLE
docs: allow force-push for rebasing your own unmerged PR branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ No Linear. Backlog/open issues live in the daemon-owned issue store (web Issues 
 - **Owner-supervised local iteration may skip the PR**: work in a worktree, get green, then merge/cherry-pick into local `main`. Same quality gates (lint, typecheck, tests, changeset) still apply. Only when the owner is in the loop that turn.
 - A direct push to `main` needs the owner to say so **in that turn** — never inferred, never carried over to the next task.
 - `scripts/release.sh` pushes its own `chore: release — X.Y.Z` commit + tag (see [`docs/RELEASING.md`](./docs/RELEASING.md)).
-- Never force-push; `git fetch` before pushing.
+- `git fetch` before pushing. Force-push ONLY to rebase your own unmerged PR branch, and only with `--force-with-lease`; never onto `main`, a shared branch, or commits someone has reviewed.
 
 ### Commits
 - Commit at the end of each stream when green (per-stream commits are pre-authorized). Message: `<type>: <summary>` + a 2-3 sentence body.


### PR DESCRIPTION
## Why

`AGENTS.md` said **"Never force-push"** with no exception, while the same
file asks PR branches to keep up with a `main` that moves several times a
day. Rebasing onto it cannot be pushed any other way, so the two rules
contradict each other.

Two agents hit this in a single session. Both rebased, force-pushed with
`--force-with-lease`, and reported it — which is the only reasonable
outcome when a rule cannot be followed. A rule that is routinely violated
by careful agents is not protecting anything; it is training them to treat
the hard-rules section as negotiable.

## What changed

One line, in place. No new entry (the file is at 14.8KB against a 15KB
budget).

- **before:** `Never force-push; \`git fetch\` before pushing.`
- **after:** `\`git fetch\` before pushing. Force-push ONLY to rebase your own unmerged PR branch, and only with \`--force-with-lease\`; never onto \`main\`, a shared branch, or commits someone has reviewed.`

Everything the original rule protected stays forbidden: `main`, shared
branches, reviewed commits, and bare `--force`.

`CLAUDE.md` is a symlink to `AGENTS.md`, so this lands once.