### PR TITLE
chore: move standing worker instructions from every prompt into the skill

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 34 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 35 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -427,6 +427,18 @@ branch>)"` routes the outcome back to that exact tab. Include the final
 branch name — the spawner needs it to `land`. Use the BARE form: an explicit
 `--task-id <spawner>` skips dispatcher routing and lands on that task's
 canonical engine tab, which can be a different agent's session.
+
+**Name your branch before you report it.** A new task starts on an
+auto-generated placeholder branch (`new-task`, `duck`, …); you are the only
+party who knows what the work turned out to be. Once the shape is clear,
+rename it to a short descriptive name in this repo's own convention:
+
+```bash
+rove api set-branch --task-id "$ROVE_TASK_ID" --branch <descriptive-slug>
+```
+
+Do this while you work, not at the end — the branch name is what the user
+reads in the sidebar to tell your task from its siblings.
 
 **"Succeeded" means COMMITTED.** Green tests in your working tree are not a
 deliverable — the only thing `land` can merge is commits on your branch.

--- a/.changeset/skill-owns-worker-protocol.md
+++ b/.changeset/skill-owns-worker-protocol.md
@@ -1,0 +1,20 @@
+---
+"@sma1lboy/rove": patch
+---
+
+New tasks start with your prompt and nothing else
+
+Every new task's first prompt used to arrive with two English paragraphs
+stapled to it — how to rename the branch, and how to report the outcome home.
+Writing in any other language, your own words reached the agent trailed by
+English, which pulled its replies to English too.
+
+Both were standing instructions rather than facts about the task, so they now
+live in the Rove agent skill, which the agent reads once. Your prompt reaches
+the engine exactly as you wrote it. Facts that only apply to this worktree —
+the missing-dependency warning — still ride along, because nothing else can
+know them.
+
+Agents without the Rove skill installed will no longer rename their task
+branch; run `rove skill install` if branches are staying on their generated
+placeholder names.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 34 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 35 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -427,6 +427,18 @@ branch>)"` routes the outcome back to that exact tab. Include the final
 branch name — the spawner needs it to `land`. Use the BARE form: an explicit
 `--task-id <spawner>` skips dispatcher routing and lands on that task's
 canonical engine tab, which can be a different agent's session.
+
+**Name your branch before you report it.** A new task starts on an
+auto-generated placeholder branch (`new-task`, `duck`, …); you are the only
+party who knows what the work turned out to be. Once the shape is clear,
+rename it to a short descriptive name in this repo's own convention:
+
+```bash
+rove api set-branch --task-id "$ROVE_TASK_ID" --branch <descriptive-slug>
+```
+
+Do this while you work, not at the end — the branch name is what the user
+reads in the sidebar to tell your task from its siblings.
 
 **"Succeeded" means COMMITTED.** Green tests in your working tree are not a
 deliverable — the only thing `land` can merge is commits on your branch.

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -12,7 +12,6 @@ import { engineLaunchArgv, withPinnedSessionId } from "../../engine/engine-prese
 import { buildEngineSessionLaunch } from "../../engine/session-launch.ts"
 import { trustEngineWorktree } from "../../engine/trust-worktree.ts"
 import { type DaemonRpc, resolveActiveTaskId } from "../daemon-session.ts"
-import { verifiedSelfSession } from "./dispatcher.ts"
 
 // Kept for existing callers in this directory; new callers should import from
 // daemon-session.ts directly to keep the daemon/session boundary clean.
@@ -104,16 +103,7 @@ async function deliverHosted(
       worktreePath: worktree,
       shell: process.env.SHELL?.trim() || "/bin/zsh",
       argv,
-      // Spawner identity is resolved HERE, in the CLI process — an `add` run
-      // from inside an engine tab carries the spawner's $KOBE_TASK_ID, and
-      // the coda tells the new agent to `send` its outcome back
-      // (repo-init.ts). VERIFIED, not raw env: an inherited id would write a
-      // stranger's task into the worker's own instructions (issue #24), which
-      // is the one place a wrong address survives even after the record is
-      // right — it's baked into the prompt, not read back from the store.
-      promptIntent: target.newTask
-        ? { kind: "new-task", prompt, spawnerTaskId: (await verifiedSelfSession())?.taskId }
-        : { kind: "explicit", prompt },
+      promptIntent: target.newTask ? { kind: "new-task", prompt } : { kind: "explicit", prompt },
       tabId: newTab,
     })
     const result = await deliverHostedPrompt(

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -44,7 +44,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
  */
-export const KOBE_SKILL_VERSION = 34
+export const KOBE_SKILL_VERSION = 35
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/src/state/repo-init.ts
+++ b/packages/kobe/src/state/repo-init.ts
@@ -55,40 +55,17 @@ export type PromptDeliveryIntent =
   /**
    * The FIRST prompt of a freshly created worktree task (`add --prompt`,
    * `fan-out`, quick-fork, work-item/automation starts). Delivered like
-   * `explicit`, plus a branch-rename coda — the task's branch is an
-   * auto-generated placeholder, and the agent reading this prompt is the one
-   * party that knows what the work is actually about. Prompts into EXISTING
-   * sessions (`send`, `send --tab new`, dispatch, cross-engine handoff) must
-   * stay `explicit` so they never re-append the coda.
+   * `explicit`, plus the codas that describe THIS worktree's state — today
+   * the missing-dependencies warning. Prompts into EXISTING sessions (`send`,
+   * `send --tab new`, dispatch, cross-engine handoff) stay `explicit` so they
+   * never re-append them.
    *
-   * `spawnerTaskId`: the Rove task whose agent created THIS task, when known.
-   * Only the CLI layer may supply it (from its own $KOBE_TASK_ID) — never read
-   * env here: the daemon can be auto-spawned from inside an engine tab and
-   * would bake that stale id into every future automation task.
+   * Standing instructions for a worker (name your branch, report your outcome
+   * home) are NOT here: they live in the Rove agent skill, which the agent
+   * reads once instead of being told again in every prompt.
    */
-  | { readonly kind: "new-task"; readonly prompt: string; readonly spawnerTaskId?: string }
+  | { readonly kind: "new-task"; readonly prompt: string }
   | { readonly kind: "none" }
-
-/**
- * Coda appended to a new worktree task's first prompt. The concrete task id
- * is baked in at spawn time (ids are immutable) — same convention as the
- * status-report protocol. `api` defaults to the environment-correct CLI
- * invocation; tests pass a literal.
- */
-export function newTaskBranchCoda(taskId: string, api: string = kobeApiInvocation(), spawnerTaskId?: string): string {
-  const rename = `PS: this task's git branch name is an auto-generated placeholder. Once you understand the work, rename it to a short descriptive name following this repo's branch-naming convention: \`${api} set-branch --task-id ${taskId} --branch <descriptive-slug>\``
-  if (!spawnerTaskId || spawnerTaskId === taskId) return rename
-  // Send-back, not `report`: a stored report only surfaces if the spawner
-  // explicitly awaits, which in practice it never does — outcomes silently
-  // vanished. `send` lands a full turn in the spawner's chat tab.
-  //
-  // BARE send, no --task-id: only the bare form resolves the dispatcher's
-  // exact TAB (recorded at creation). An explicit `--task-id ${spawnerTaskId}`
-  // skips dispatcher routing and lands on that task's canonical engine tab —
-  // on a main task whose dispatching chat is a command tab, that is a
-  // DIFFERENT agent's session, and outcomes reported to a stranger.
-  return `${rename}\n\nYou were spawned by Rove task ${spawnerTaskId}. When the work is finished, send your outcome back — include the final branch name: \`${api} send --prompt "<succeeded|failed>: <one-line summary> (branch <final-branch>)"\` (bare send, no --task-id: it routes to the exact tab that dispatched you)`
-}
 
 /**
  * Lockfile → the directory its install step produces. A committed lockfile
@@ -189,9 +166,6 @@ function firstMessageFor(
   if (intent.kind === "none") return undefined
   if (intent.kind === "explicit") return { source: "explicit", text: intent.prompt }
   if (intent.kind === "new-task") {
-    // `$ROVE_TASK_ID` fallback: exported into every engine tab's env, so the
-    // agent's shell expands it even if a caller never threaded the id here.
-    const branch = newTaskBranchCoda(taskId ?? '"$ROVE_TASK_ID"', undefined, intent.spawnerTaskId)
     // Only when the repo has no init script: with one, the install already ran
     // (or the repo chose not to), and the warning would be noise. Scoped to
     // new-task so `send`/handoff prompts into existing sessions never see it.
@@ -200,7 +174,7 @@ function firstMessageFor(
       : missingDependenciesCoda(worktreePath, detectLanguage(intent.prompt) ?? undefined)
     return {
       source: "explicit",
-      text: [intent.prompt, branch, deps].filter(Boolean).join("\n\n"),
+      text: [intent.prompt, deps].filter(Boolean).join("\n\n"),
     }
   }
   const text = init.initPrompt?.trim()

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -81,7 +81,7 @@ vi.mock("../../src/cli/api/pty-delivery.ts", () => ({
 }))
 
 import { defaultApiRuntime, deliverPrompt, invokeVerb } from "../../src/cli/api-cmd.ts"
-import { resetVerifiedSelfSession, verifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
+import { resetVerifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
 import type { DaemonRpc } from "../../src/cli/daemon-session.ts"
 
 beforeEach(() => {
@@ -283,9 +283,15 @@ describe("realPromptDeliveryOps (deliverPrompt with the default ops)", () => {
     })
   })
 
-  it("launches a newTask target as the new-task intent (branch-rename coda)", async () => {
-    // add / fan-out mark their first delivery with newTask — the launch spec
-    // then rides the "new-task" intent so the coda is appended (issue #8).
+  it("launches a newTask target as the new-task intent", async () => {
+    // add / fan-out mark their first delivery with newTask; the launch spec
+    // rides the "new-task" intent, which is what gates the per-worktree
+    // codas (today: the missing-dependency warning) in repo-init.ts.
+    //
+    // The spawner id used to ride here too, to address a send-back coda. That
+    // instruction now lives in the Rove agent skill, and the reply address
+    // comes from the task's recorded `dispatcher` — proven identity, covered
+    // by `api-dispatcher.test.ts` (issue #24), not from this payload.
     vi.stubEnv("KOBE_TASK_ID", "")
     await deliverPrompt(
       client,
@@ -293,54 +299,7 @@ describe("realPromptDeliveryOps (deliverPrompt with the default ops)", () => {
       "go",
     )
     expect(mocks.buildEngineSessionLaunch).toHaveBeenLastCalledWith(
-      expect.objectContaining({ promptIntent: { kind: "new-task", prompt: "go", spawnerTaskId: undefined } }),
-    )
-  })
-
-  it("threads the VERIFIED session as the new task's spawner", async () => {
-    // An `add` run from inside another task's engine tab carries that task's
-    // id; the coda then tells the new agent where to `send` its outcome.
-    vi.stubEnv("KOBE_TASK_ID", "spawner-1")
-    vi.stubEnv("KOBE_TAB_ID", "tab-1")
-    await verifiedSelfSession(
-      { KOBE_TASK_ID: "spawner-1", KOBE_TAB_ID: "tab-1" },
-      {
-        pid: 500,
-        sessions: async () => [{ key: "spawner-1::tab-1", pid: 100, alive: true }],
-        ps: async () => "  100     1 /bin/zsh -il\n  500   100 bun kobe api add",
-      },
-    )
-    await deliverPrompt(
-      client,
-      { id: "t1", kind: "task", worktreePath: "/wt/t1", vendor: "claude", repo: "/repo/x", newTask: true },
-      "go",
-    )
-    expect(mocks.buildEngineSessionLaunch).toHaveBeenLastCalledWith(
-      expect.objectContaining({ promptIntent: { kind: "new-task", prompt: "go", spawnerTaskId: "spawner-1" } }),
-    )
-  })
-
-  it("omits the spawner when $KOBE_TASK_ID was merely INHERITED (issue #24)", async () => {
-    // The coda is the one address that outlives the record — it is baked
-    // into the worker's own instructions, so a stranger's id here sends
-    // every future report to them. Unproven identity = no coda address.
-    vi.stubEnv("KOBE_TASK_ID", "boccha")
-    await verifiedSelfSession(
-      { KOBE_TASK_ID: "boccha", KOBE_TAB_ID: "tab-1" },
-      {
-        pid: 500,
-        sessions: async () => [{ key: "boccha::tab-1", pid: 100, alive: true }],
-        // Reparented to init: alive tab, but this process is not under it.
-        ps: async () => "  100     1 /bin/zsh -il\n  500     1 bun kobe api add",
-      },
-    )
-    await deliverPrompt(
-      client,
-      { id: "t1", kind: "task", worktreePath: "/wt/t1", vendor: "claude", repo: "/repo/x", newTask: true },
-      "go",
-    )
-    expect(mocks.buildEngineSessionLaunch).toHaveBeenLastCalledWith(
-      expect.objectContaining({ promptIntent: { kind: "new-task", prompt: "go", spawnerTaskId: undefined } }),
+      expect.objectContaining({ promptIntent: { kind: "new-task", prompt: "go" } }),
     )
   })
 

--- a/packages/kobe/test/engine/session-launch.test.ts
+++ b/packages/kobe/test/engine/session-launch.test.ts
@@ -44,7 +44,10 @@ describe("hosted engine session launch", () => {
     expect(launch.command[2]).toContain('exec "${SHELL:-/bin/sh}"')
   })
 
-  test("new-task intent bakes the launch task's id into the branch-rename coda", () => {
+  test("new-task intent puts the user's prompt on the argv, with nothing appended", () => {
+    // Standing worker instructions (name your branch, report home) moved to
+    // the Rove agent skill; the first prompt is now the user's text plus only
+    // facts about THIS worktree, which no skill can know.
     const launch = buildEngineSessionLaunch({
       task: { id: "task-9", kind: "task", vendor: "claude", repo: "/repo" },
       worktreePath: "/repo/.worktrees/task-9",
@@ -53,8 +56,8 @@ describe("hosted engine session launch", () => {
       promptIntent: { kind: "new-task", prompt: "fix it" },
       protocolGates: { status: () => false, notes: () => false, dispatcher: () => false },
     })
-    expect(launch.command[2]).toContain("fix it")
-    expect(launch.command[2]).toContain("set-branch --task-id task-9")
+    expect(launch.command[2]).toContain("claude 'fix it'")
+    expect(launch.command[2]).not.toContain("set-branch")
   })
 
   test("keeps a paste vendor's first message OUT of the argv and hands it to the spawner (issue #25)", () => {

--- a/packages/kobe/test/state/repo-init.test.ts
+++ b/packages/kobe/test/state/repo-init.test.ts
@@ -148,42 +148,30 @@ describe("resolveEngineLaunchInit", () => {
     expect(resolveEngineLaunchInit(wt, wt, { kind: "none" })).toEqual({ initScript: "sh .kobe/init.sh" })
   })
 
-  // Why: issue #8 — a freshly created worktree task carries an auto-generated
-  // placeholder branch; ONLY its first prompt gets the rename coda. Prompts
-  // into existing sessions (send / handoff) ride "explicit" and stay verbatim
-  // — pinned above by the explicit test's exact-equality assertion.
-  test("new-task intent appends the branch-rename coda with the task id baked in", () => {
+  // Why: standing instructions for a worker — name your branch, report your
+  // outcome home — moved to the Rove agent skill, which the agent reads once.
+  // They used to be appended to EVERY new task's first prompt, which meant a
+  // user writing Chinese had their own words trailed by two English
+  // paragraphs, and the send-back half duplicated what SKILL.md already said.
+  //
+  // What must survive: the user's prompt reaches the engine unchanged, and
+  // the per-worktree FACTS (the missing-dependency warning below) still ride
+  // along, because no skill can know them.
+  test("new-task delivers the user's prompt verbatim — no appended instructions", () => {
     const wt = makeWorktree()
     const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix the bug" }, "task-9").firstMessage
     expect(msg?.source).toBe("explicit")
-    expect(msg?.text.startsWith("fix the bug\n\n")).toBe(true)
-    expect(msg?.text).toContain("set-branch --task-id task-9 --branch")
+    expect(msg?.text).toBe("fix the bug")
   })
 
-  test("new-task without a threaded task id falls back to the $ROVE_TASK_ID env", () => {
+  test("no branch-rename or send-back instruction is injected any more", () => {
+    // Pins the deletion: these strings coming back means the coda returned,
+    // and the user's prompt is once again trailed by English boilerplate.
     const wt = makeWorktree()
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix the bug" }).firstMessage
-    expect(msg?.text).toContain('set-branch --task-id "$ROVE_TASK_ID" --branch')
-  })
-
-  // Why: outcomes travel as chat back to the spawner, not stored reports —
-  // and the coda MUST teach the bare form. Only a bare `send` (no --task-id)
-  // resolves the dispatcher's exact tab; an explicit `--task-id` lands on the
-  // spawner task's canonical engine tab, which on a main task can be a
-  // different agent's session entirely (the 2026-08-24 misrouted reports).
-  test("new-task with a spawner appends the bare send-back coda; without one it does not", () => {
-    const wt = makeWorktree()
-    const spawned = resolveEngineLaunchInit(
-      wt,
-      wt,
-      { kind: "new-task", prompt: "fix the bug", spawnerTaskId: "spawner-1" },
-      "task-9",
-    ).firstMessage
-    expect(spawned?.text).toContain("spawned by Rove task spawner-1")
-    expect(spawned?.text).toContain('send --prompt "<succeeded|failed>')
-    expect(spawned?.text).not.toContain("send --task-id")
-    const solo = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix the bug" }, "task-9").firstMessage
-    expect(solo?.text).not.toContain("spawned by")
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "修一下这个 bug" }, "task-9").firstMessage
+    expect(msg?.text).not.toContain("set-branch")
+    expect(msg?.text).not.toContain("spawned by Rove task")
+    expect(msg?.text).toBe("修一下这个 bug")
   })
 })
 

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -348,9 +348,10 @@ describe("terminal tabs state", () => {
     const firstSpawn = engineTabSpawnFor(s, first, base, opts)
     expect(firstSpawn.command.slice(0, 2)).toEqual(["/bin/zsh", "-ilc"])
     expect(firstSpawn.command[2]).toContain("claude 'fix the bug")
-    // A quick-fork prompt is a fresh worktree task's FIRST prompt — it
-    // carries the branch-rename coda with this task's id (issue #8).
-    expect(firstSpawn.command[2]).toContain("set-branch --task-id task-1")
+    // A quick-fork prompt is a fresh worktree task's FIRST prompt. It used to
+    // carry a branch-rename coda; that standing instruction now lives in the
+    // Rove agent skill, so the prompt reaches the engine as the user wrote it.
+    expect(firstSpawn.command[2]).not.toContain("set-branch")
     // Second engine tab: never gets the prompt.
     expect(engineTabSpawnFor(s, second, base, opts).command[2]).not.toContain("fix the bug")
     // Already spawned: the conversation has begun — never re-deliver.


### PR DESCRIPTION
Block 3, the last of the injected-prompt work. Depends on nothing — cut from main after #643.

## What moved, and why it wasn't just translated

Two paragraphs were appended to **every** new task's first prompt:

1. **Branch-rename** — "your branch is a placeholder, rename it with `set-branch`"
2. **Send-back** — "you were spawned by task X, report your outcome with a bare `send`"

Neither is a fact about the task; both are standing instructions to a worker. And the second one **already appeared in SKILL.md twice** (line 261's example and the "Worker side" section, including "Include the final branch name") — so Rove was injecting a paragraph the receiving agent could already read.

That made a user's own prompt the *first* thing an agent saw and English boilerplate the last, which is what pulled replies toward English regardless of what language the user wrote in.

- **Send-back coda → pure deletion.** SKILL.md already covers it.
- **Branch-rename → added to SKILL.md's "Worker side" section**, beside the outcome-report contract, since that section already tells the worker to *report* a branch name. Previously the skill only listed `set-branch` in the verb table — "this verb exists", not "you should use it".
- **`spawnerTaskId` goes with the coda it addressed.** It existed only to bake an address into the prompt text. The reply route comes from the task's recorded `dispatcher` — proven identity, still covered by `api-dispatcher.test.ts` (issue #24).

**What stays injected:** the missing-dependency warning. It reports what's true of *this* worktree right now, and no skill can know that.

## The cost, stated up front

**An agent without the Rove skill installed will no longer rename its task branch.** Skill install is a skippable onboarding choice, and the codas fired for every vendor while `--append-system-prompt` protocols are claude-only. This trades guaranteed delivery for probable delivery; the failure mode is cosmetic (a branch keeps its generated name), which is why it's an acceptable trade — but it is a real trade, so the changeset tells users to run `rove skill install` if they notice it.

## Verification

Live sandbox, real daemon, real task creation — the engine's actual argv:

```
claude --session-id … '帮我重构登录模块'
```

The user's prompt and nothing else. Before this change that same command carried two English paragraphs after it. This is the originally reported bug, fully closed.

**Mutation-checked:** re-appending any coda to the composed first message turns both new `repo-init` tests red.

The replaced tests are worth noting — four existing tests asserted the coda's *presence* (in `repo-init`, `session-launch`, `terminal-tabs-core`, `api-cmd-runtime`). Rather than deleting them, each now pins the inverse: the prompt arrives verbatim and `set-branch` does **not** appear. A deletion with no test is indistinguishable from a regression later.

Suites: kobe-daemon 604/604, render 240/0, kobe fast failure set **identical to a clean checkout of the same main** (19 files, all pre-existing).

SKILL.md changes are in both mirrors with the version bumped in lockstep (34 → 35) — the byte-identical guard catches a one-sided edit, and did on an earlier branch.
