### PR TITLE
refactor: one activity state machine instead of two copies

### DIFF
--- a/.changeset/dedupe-activity-reducer.md
+++ b/.changeset/dedupe-activity-reducer.md
@@ -1,0 +1,23 @@
+---
+"@sma1lboy/rove": patch
+---
+
+One activity state machine instead of two copies
+
+The reducer that decides a task's engine-activity badge (the ● lamp, the ?
+attention badge) existed twice — once in `kobe/src/engine/hook-events.ts`, once
+in `kobe-daemon/src/daemon/activity-reduce.ts` — with the daemon copy carrying
+a `// Mirrors kobe's hook-events reducer.` note asking readers to keep them in
+step by hand. Both copies also recorded the same two production bugs, which is
+what a copy that has already drifted once looks like.
+
+The daemon copy is now the only definition (kobe depends on kobe-daemon, never
+the reverse; the daemon's activity registry is the reducer's only production
+caller), and `hook-events.ts` re-exports it. Every comment that a real incident
+paid for is preserved at that one definition: Kimi firing Interrupt instead of
+Stop, a Stop landing on a cold registry after a daemon restart, and the
+automated wake that used to light the ● lamp for a turn nobody started.
+
+No behavior change. The daemon's own tests now pin the cold-registry
+completion and the Kimi interrupt through the registry — before this, breaking
+either one left the daemon-path tests green.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -18,6 +18,7 @@
     "./daemon/agent-turns-store": "./src/daemon/agent-turns-store.ts",
     "./daemon/activity-liveness": "./src/daemon/activity-liveness.ts",
     "./daemon/activity-observer": "./src/daemon/activity-observer.ts",
+    "./daemon/activity-reduce": "./src/daemon/activity-reduce.ts",
     "./daemon/activity-registry": "./src/daemon/activity-registry.ts",
     "./daemon/attention-inbox": "./src/daemon/attention-inbox.ts",
     "./daemon/automations-store": "./src/daemon/automations-store.ts",

--- a/packages/kobe-daemon/src/daemon/activity-reduce.ts
+++ b/packages/kobe-daemon/src/daemon/activity-reduce.ts
@@ -1,12 +1,31 @@
 /**
  * The engine-activity reducer + its policy constants/types — the pure half
  * of the daemon activity registry, split out of `activity-registry.ts`
- * (file-size cap). Moved verbatim; `activity-registry.ts` re-exports the
- * public names so existing importers keep one entry point.
+ * (file-size cap). `activity-registry.ts` re-exports the public names so
+ * existing importers keep one entry point.
+ *
+ * {@link reduceActivity} is the single definition of the activity state
+ * machine for BOTH packages: `kobe/src/engine/hook-events.ts` re-exports it
+ * (kobe depends on kobe-daemon, never the reverse) so a fix lands once.
  */
 
 import type { EngineActivityDetail, EngineActivityKind, TaskActivityState } from "./contracts.ts"
 
+/**
+ * Pure state machine: fold a normalized event into the next activity state.
+ *   session-start                  → idle
+ *   turn-start                     → running
+ *   turn-complete                  → turn_complete
+ *   turn-failed (rate_limit/billing)→ rate_limited
+ *   turn-failed (other)            → error
+ *   awaiting-input                 → permission_needed (permission prompt OR a
+ *                                    question dialog — either way the engine is
+ *                                    blocked on the user; `detail.waiting` keeps why)
+ *   session-end                    → idle
+ *
+ * The ONE definition: `kobe/src/engine/hook-events.ts` re-exports this rather
+ * than keeping a second copy (the two drifted apart once already).
+ */
 export function reduceActivity(
   previous: TaskActivityState | undefined,
   kind: EngineActivityKind,
@@ -15,35 +34,34 @@ export function reduceActivity(
   switch (kind) {
     case "session-start":
     case "session-end":
-    // Kimi fires Interrupt INSTEAD of Stop on a user interrupt.
+    // Kimi fires Interrupt INSTEAD of Stop on a user interrupt — without
+    // this the turn strands in `running` (docs/design/plugin-events.md §B).
     case "turn-interrupted":
       return "idle"
     case "turn-start":
       return "running"
     case "turn-complete":
-      // Only a TRACKED turn completes: running, or blocked on the user
-      // mid-turn (an approved permission resumes without a new turn-start).
-      // Engines fire Stop on automated wakes too — a background monitor
-      // stream ending "completed" a turn nobody started and lit the ●
-      // lamp (owner bug 2026-08-02); that signature is a Stop on a KNOWN
-      // untracked state (explicit idle/sticky entry) and stays swallowed.
-      // `undefined` is a COLD registry (fresh daemon after a restart) — the
-      // one real way a task's first event is a Stop is a turn that started
-      // before the wipe, so let it complete instead of eating the ● lamp.
-      // Mirrors kobe's hook-events reducer.
+      // A completion is only a completion when a turn was actually in
+      // flight: running, or blocked on the user mid-turn (an approved
+      // permission continues WITHOUT a new turn-start). Engines fire Stop
+      // for automated wakes too — a background monitor stream ending
+      // "completes" a turn the user never started, and the ● lamp lit for
+      // it (owner bug 2026-08-02). That wake signature is a Stop landing on
+      // a KNOWN untracked state (an explicit idle/sticky entry) — keep it.
+      // `undefined` is different: the reducer knows NOTHING (fresh daemon,
+      // registry wiped by a restart), and the one real way a first event is
+      // a Stop is a turn that started before the wipe — swallowing it cost
+      // the ● lamp for every turn that outlived a daemon restart.
       return previous === "running" || previous === "permission_needed" || previous === undefined
         ? "turn_complete"
         : previous
     case "turn-failed":
       return detail?.failure === "rate_limit" || detail?.failure === "billing" ? "rate_limited" : "error"
     case "awaiting-input":
-      // Permission prompt OR a question dialog — either way the engine is
-      // blocked on the user (`detail.waiting` keeps which). Mirrors
-      // kobe/src/engine/hook-events.ts.
       return "permission_needed"
     default:
-      // Lifecycle-only kinds never reach the registry (the handler gates on
-      // affectsActivityState); a direct call is a state no-op.
+      // Lifecycle-only kinds never reach here via the daemon (gated by
+      // affectsActivityState); a direct call is a no-op on the state.
       return previous ?? "idle"
   }
 }

--- a/packages/kobe/src/engine/hook-events.ts
+++ b/packages/kobe/src/engine/hook-events.ts
@@ -1,5 +1,5 @@
 /**
- * Engine-neutral activity-event vocabulary + state reducer.
+ * Engine-neutral activity-event vocabulary (+ the reducer, re-exported).
  *
  * kobe learns "what is this task's engine doing right now" from engine HOOKS
  * (Claude Code's Stop / StopFailure / Notification / Session*; Codex's
@@ -11,7 +11,8 @@
  * vocabulary, so no vendor strings leak past the adapter (CLAUDE.md
  * "Engine-owned UI data").
  *
- * This module is pure (no I/O), so the reducer is unit-tested in isolation.
+ * This module is pure (no I/O). The state machine itself ({@link
+ * reduceActivity}) is defined in the daemon package and re-exported below.
  */
 
 /** The normalized hook verbs a `kobe hook <verb>` invocation carries. */
@@ -88,51 +89,10 @@ export const TASK_ACTIVITY_STATES = [
 export type TaskActivityState = (typeof TASK_ACTIVITY_STATES)[number]
 
 /**
- * Pure state machine: fold a normalized event into the next activity state.
- *   session-start                  → idle
- *   turn-start                     → running
- *   turn-complete                  → turn_complete
- *   turn-failed (rate_limit/billing)→ rate_limited
- *   turn-failed (other)            → error
- *   awaiting-input                 → permission_needed (permission prompt OR a
- *                                    question dialog — either way the engine is
- *                                    blocked on the user; `detail.waiting` keeps why)
- *   session-end                    → idle
+ * The activity state machine. Defined ONCE, in the daemon package — the
+ * daemon is the only production caller (`DaemonActivityRegistry`), and kobe
+ * depends on kobe-daemon (never the reverse), so this side re-exports.
+ * A second copy lived here and drifted; a fix now lands in one place.
+ * @see {@link import("@sma1lboy/kobe-daemon/daemon/activity-reduce").reduceActivity}
  */
-export function reduceActivity(
-  prev: TaskActivityState | undefined,
-  kind: EngineActivityKind,
-  detail?: EngineActivityDetail,
-): TaskActivityState {
-  switch (kind) {
-    case "session-start":
-    case "session-end":
-    // Kimi fires Interrupt INSTEAD of Stop on a user interrupt — without
-    // this the turn strands in `running` (docs/design/plugin-events.md §B).
-    case "turn-interrupted":
-      return "idle"
-    case "turn-start":
-      return "running"
-    case "turn-complete":
-      // A completion is only a completion when a turn was actually in
-      // flight: running, or blocked on the user mid-turn (an approved
-      // permission continues WITHOUT a new turn-start). Engines fire Stop
-      // for automated wakes too — a background monitor stream ending
-      // "completes" a turn the user never started, and the ● lamp lit for
-      // it (owner bug 2026-08-02). That wake signature is a Stop landing on
-      // a KNOWN untracked state (an explicit idle/sticky entry) — keep it.
-      // `undefined` is different: the reducer knows NOTHING (fresh daemon,
-      // registry wiped by a restart), and the one real way a first event is
-      // a Stop is a turn that started before the wipe — swallowing it cost
-      // the ● lamp for every turn that outlived a daemon restart.
-      return prev === "running" || prev === "permission_needed" || prev === undefined ? "turn_complete" : prev
-    case "turn-failed":
-      return detail?.failure === "rate_limit" || detail?.failure === "billing" ? "rate_limited" : "error"
-    case "awaiting-input":
-      return "permission_needed"
-    default:
-      // Lifecycle-only kinds never reach here via the daemon (gated by
-      // affectsActivityState); a direct call is a no-op on the state.
-      return prev ?? "idle"
-  }
-}
+export { reduceActivity } from "@sma1lboy/kobe-daemon/daemon/activity-reduce"

--- a/packages/kobe/test/daemon/activity-state.test.ts
+++ b/packages/kobe/test/daemon/activity-state.test.ts
@@ -99,6 +99,54 @@ describe("daemon activity state", () => {
     registry.close()
   })
 
+  // Why: the reducer now has ONE definition (kobe-daemon activity-reduce;
+  // kobe/src/engine/hook-events.ts re-exports it). These two behaviors were
+  // paid for with production bugs and were only pinned on the kobe side —
+  // this is the daemon path they actually ship on.
+  it("a Stop on a COLD registry completes the turn — it outlived a daemon restart", () => {
+    const bus = new DaemonEventBus()
+    const registry = new DaemonActivityRegistry(bus, 1_000)
+    const published: Array<{ taskId: string; state: string }> = []
+    bus.onPublish((event) => {
+      if (event.channel === "engine-state") {
+        const p = event.payload as { taskId: string; state: string }
+        published.push({ taskId: p.taskId, state: p.state })
+      }
+    })
+
+    // No prior entry for this task: a restart wiped the in-memory registry
+    // while a turn was in flight, so its Stop is the first event since boot.
+    // Swallowing it cost the ● lamp for every turn outliving a restart.
+    registry.report("task-cold", "turn-complete")
+    expect(published).toEqual([{ taskId: "task-cold", state: "turn_complete" }])
+
+    // A Stop on a KNOWN untracked state is the other case — an automated
+    // wake (a background monitor stream ending), which must NOT light the
+    // ● lamp: the state stays idle (owner bug 2026-08-02).
+    registry.report("task-warm", "session-start")
+    published.length = 0
+    registry.report("task-warm", "turn-complete")
+    expect(published).toEqual([{ taskId: "task-warm", state: "idle" }])
+
+    registry.close()
+  })
+
+  // Why: Kimi fires Interrupt INSTEAD of Stop on a user interrupt
+  // (docs/design/plugin-events.md §B) — without the verb landing on idle the
+  // turn strands in `running` and the spinner never stops.
+  it("turn-interrupted lands the state back on idle", () => {
+    const bus = new DaemonEventBus()
+    const registry = new DaemonActivityRegistry(bus, 1_000)
+
+    registry.report("task-1", "turn-start")
+    expect(registry.currentNonIdle().map((p) => p.state)).toEqual(["running"])
+
+    registry.report("task-1", "turn-interrupted")
+    expect(registry.currentNonIdle()).toEqual([])
+
+    registry.close()
+  })
+
   // Why: the F7 attention jump's tab precision rides these — a tabId-carrying
   // report must ledger per-tab (published + replayed with the tabId), the
   // task-level rollup must stay identical for every existing consumer, and a


### PR DESCRIPTION
## What

`reduceActivity` existed twice, with **identical bodies** — differing only in a parameter name (`prev` vs `previous`) and in how much of the comment each copy kept:

- `packages/kobe/src/engine/hook-events.ts`
- `packages/kobe-daemon/src/daemon/activity-reduce.ts`

Both copies recorded the same two production incidents, and the daemon copy ended with `// Mirrors kobe's hook-events reducer.` — a comment asking the next reader to keep two state machines in step by hand. This is the state machine behind the sidebar's ● lamp and ? attention badge.

Now there is one definition.

## Direction, and why

**The daemon copy is the definition; kobe re-exports it.**

- `packages/kobe/package.json` depends on `@sma1lboy/kobe-daemon`; the daemon never depends on kobe (`contracts.ts` states this outright). Re-exporting from kobe is the only direction that doesn't invert the dependency or introduce a cycle.
- `DaemonActivityRegistry.report()` is the **only production caller**. kobe's copy had zero production callers — only two test files imported it.
- No shared package was needed: the ladder stops at "already-installed dependency", and kobe already depends on the daemon.

`./daemon/activity-reduce` is now an explicit export subpath (kobe's tests already deep-import sibling `daemon/activity-*` modules, so this matches existing practice).

## Types were already compatible

`EngineActivityKind` / `EngineActivityDetail` / `TaskActivityState` exist in both packages (the daemon's own copy is deliberate — it never imports kobe). I verified with a bidirectional assignability probe under `--strict` that all three are mutually assignable, so the re-export typechecks in both packages with no change to either type. **This PR does not merge the types** — that's a separate question from the state machine, and the daemon's structural copy is an intentional boundary.

## Comments: nothing lost

The merged definition keeps every incident-bought explanation, taking kobe's fuller wording where the two differed:

- Kimi fires `Interrupt` instead of `Stop` (`docs/design/plugin-events.md` §B) — without this the turn strands in `running`.
- A `Stop` landing on `undefined` is a **cold registry** (turn outlived a daemon restart) and must complete.
- A `Stop` on a **known** untracked state is an automated wake and must not light the ● lamp (owner bug 2026-08-02).

## Tests: a real gap, now closed

The two suites stay where they are (they test different things: `hook-events.test.ts` the state machine, `lifecycle-events.test.ts` the plugin-event surface). But mutation testing found the daemon side under-covered — breaking the cold-registry fix or the Kimi interrupt left **the daemon-path tests green**, even though the daemon is where that code actually ships. Two tests added to `test/daemon/activity-state.test.ts` drive both through `DaemonActivityRegistry`.

Mutation gate, run twice, identical both times:

| Mutation to the single definition | kobe-side | daemon-path |
|---|---|---|
| drop cold-registry (`undefined`) completion | 1 failed | 1 failed |
| drop Kimi `turn-interrupted` → idle | 1 failed | 1 failed |
| `awaiting-input` no longer blocks | 1 failed | 3 failed |
| *(restored)* | green | green |

## Verification

- `bun run test:socket` — 606 passed / 73 files, green.
- `bun run test:fast` — 47 pre-existing failures, **byte-identical to the same run on pristine `origin/main`**; zero delta from this PR.
- `bun test test/render` — 240 pass, 0 fail.
- `typecheck` green in both packages; root `bun run lint` clean.
- **Live**: real hook events through an isolated named sandbox daemon (own home/socket/port; production daemon untouched). Every transition correct — normal turn lights ●, automated wake stays idle, cold-registry Stop completes, Kimi interrupt returns to idle, `awaiting-input` → `permission_needed`, `rate_limit`/`billing` → `rate_limited`, `other` → `error`, mid-turn approval then Stop → `turn_complete`, `session-end` → idle.

## Scope

Only this reducer. `relativeTime`, `classifyGhFailure` and `isProcessAlive` share names across packages but have different contracts — deliberately left alone.

No behavior change. Changeset: patch.