### PR TITLE
fix: cut dead sidebar hover/sort promises and prove the t sort chord

### DIFF
--- a/.changeset/sidebar-dead-ui.md
+++ b/.changeset/sidebar-dead-ui.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Remove sidebar leftovers that promised UI nobody could reach
+
+The sidebar hover-tooltip path was cut end to end: the flat row cards that
+fed it are gone from the product, the tree sidebar never had hover handlers,
+nothing rendered the tooltip, and the `sidebar.hover.enabled` setting never
+existed outside a comment — so the `hoverEnabled` / `onHoverChange` props and
+the tooltip-line builder were dead weight. Also removed two orphaned task
+callbacks (`onSortModeToggle`, `onPreviewToggleRequest`) whose bindings left
+the keymap in earlier changes, and clarified the doc comment on the pin
+callback: a bare `p` binds nothing, so a mistyped press matches no chord
+rather than churning the pin flag. No visible behavior changes; the `t`
+sort chord keeps working exactly as shipped.

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
@@ -81,9 +81,6 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
   function selectPrefixTapPresentation(next: PrefixTapPresentation): void {
     kv.set(PREFIX_TAP_PRESENTATION_KEY, next)
   }
-  // Sidebar hover tooltips: opt-in, default OFF (owner call 2026-07-28) —
-  // the item info they show is nice-to-have, not essential.
-
   // Appearance: how split leaves draw — full box frames or single dividers.
   function splitStyle(): SplitStyle {
     return normalizeSplitStyle(kv.get(SPLIT_STYLE_KEY))

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -36,7 +36,6 @@ import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { resolveRowSelectionChrome } from "../../ui/row-selection-chrome"
 import { completionSeenAt, completionSeenKey, markCompletionSeen } from "../../workspace/completion-seen"
-import type { SidebarHover } from "./types"
 
 export type SidebarRowCardSharedProps = {
   readonly selectedId: string | null
@@ -46,8 +45,6 @@ export type SidebarRowCardSharedProps = {
   readonly onSelect: (id: string) => void
   readonly activateRow: (id: string) => void
   readonly activateOnClick?: boolean
-  readonly setHover: (hover: SidebarHover | null) => void
-  readonly clearHoverForTask: (taskId: string) => void
   readonly branchTick: number
   readonly titleBudget: number
   readonly subtitleBudget: number
@@ -156,7 +153,6 @@ function RowBody(props: {
   const flatIndex = props.row.flatIndex
   const shared = props.shared
   return (
-    // biome-ignore lint/a11y/useKeyWithMouseEvents: opentui terminal UI has no DOM focus model; hover is pointer-only while keyboard nav exposes the same row detail by selection.
     <box
       ref={(renderable: BoxRenderable | null) => {
         if (!renderable) return
@@ -175,8 +171,6 @@ function RowBody(props: {
         shared.onSelect(task.id)
         if (shared.activateOnClick) shared.activateRow(task.id)
       }}
-      onMouseOver={(event) => shared.setHover({ task, x: event.x, y: event.y })}
-      onMouseOut={() => shared.clearHoverForTask(task.id)}
     >
       {props.children}
     </box>

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -1,60 +1,33 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React sidebar row cards (issue #15, G3) — the
- * `src/tui/panes/sidebar/row-cards.tsx` counterpart. Row derivation
- * (`buildSidebarRowView`), the `+N −M` pollers, and the tone/label helpers
- * are the shared framework-free modules; this file owns only React
- * rendering.
+ * Shared per-row React hooks for the sidebar's rows.
  *
- * Poller contract (async canon): the fire-and-forget `poll*` calls live in
- * effects keyed on the Sidebar's `branchTick` (never in render), while the
- * cached `read` side (`worktreeChanges` / `currentBranch`) is a plain
- * synchronous getter read at render time. A finishing poll surfaces on the
- * next tick re-render (≤100ms via the spinner tick) instead of notifying —
- * the Solid signal's push is replaced by the tick's pull.
+ * History: this file used to own the flat sidebar's two-line row cards
+ * (`ProjectRowCard` / `TaskRowCard`). The flat sidebar is gone from the
+ * product and those cards had zero callers — the hover-tooltip feed lived
+ * in them, which is exactly what made the tooltip path unreachable — so
+ * the cards were removed (2026-08-30). What survives is the seam the tree
+ * sidebar's one-line rows import: the spinner-frame subscription, the
+ * `+N −M` changes hook + chip, the unread-lamp "seen" bookkeeping, and the
+ * (retired-print) jump-digit placeholder.
+ *
+ * Poller contract (async canon): the fire-and-forget `poll*` call lives in
+ * an effect keyed on the Sidebar's `branchTick` (never in render), while
+ * the cached `read` side (`worktreeChanges`) is a plain synchronous getter
+ * read at render time. A finishing poll surfaces on the next tick
+ * re-render (≤100ms via the spinner tick) instead of notifying — the Solid
+ * signal's push is replaced by the tick's pull.
  */
 
-import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
-import { type BoxRenderable, TextAttributes } from "@opentui/core"
-import { type ReactNode, useEffect, useMemo, useSyncExternalStore } from "react"
-import { sweepBar } from "../../../tui/lib/progress-bar"
+import type { TaskEngineState } from "@/client/remote-orchestrator"
+import { useEffect, useSyncExternalStore } from "react"
 import { spinnerFrameSnapshot, subscribeSpinnerFrame } from "../../../tui/lib/spinner-frame-store"
-import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
 import type { SidebarRow } from "../../../tui/panes/sidebar/groups"
-import { spacedTitle } from "../../../tui/panes/sidebar/labels"
-import {
-  type SidebarRowView,
-  buildSidebarRowView,
-  prCheckChip,
-  withSpinnerFrame,
-} from "../../../tui/panes/sidebar/row-view"
-import { toneColor, truncateBranchLabel } from "../../../tui/panes/sidebar/view-core"
 import { type WorktreeChanges, pickPushedChanges } from "../../../tui/panes/sidebar/worktree-changes"
 import { pollWorktreeChanges, worktreeChanges } from "../../../tui/panes/sidebar/worktree-changes-poller"
 import { useOptionalKV } from "../../context/kv"
 import { useTheme } from "../../context/theme"
-import { useT } from "../../i18n"
-import { resolveRowSelectionChrome } from "../../ui/row-selection-chrome"
 import { completionSeenAt, completionSeenKey, markCompletionSeen } from "../../workspace/completion-seen"
-
-export type SidebarRowCardSharedProps = {
-  readonly selectedId: string | null
-  readonly cursorIndex: number
-  readonly setCursorIndex: (index: number) => void
-  readonly rowEls: Map<number, BoxRenderable>
-  readonly onSelect: (id: string) => void
-  readonly activateRow: (id: string) => void
-  readonly activateOnClick?: boolean
-  readonly branchTick: number
-  readonly titleBudget: number
-  readonly subtitleBudget: number
-  readonly engineState?: ReadonlyMap<string, TaskEngineState>
-  readonly engineLifecycle?: ReadonlyMap<string, { readonly subagents: number }>
-  readonly transcriptActivity?: ReadonlyMap<string, { readonly mtimeMs: number }> | null
-  readonly taskJobs?: ReadonlyMap<string, TaskJobState>
-  readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
-  readonly moveMode?: boolean
-}
 
 const NOOP_SUBSCRIBE = () => () => {}
 const ZERO_FRAME = () => 0
@@ -74,51 +47,22 @@ export function useSpinnerFrame(active: boolean): number {
 
 /**
  * Per-row `+N −M` counts: daemon-pushed when available, else the local
- * poller cache (poll scheduled in an effect). `shared` is structural — the
- * card props and the tree's row props both carry the two fields it reads.
+ * poller cache (poll scheduled in an effect). The param is structural —
+ * the tree's row props carry exactly the two fields it reads.
  */
 export function useChanges(
-  shared: Pick<SidebarRowCardSharedProps, "branchTick" | "worktreeChanges">,
+  sources: { readonly branchTick: number; readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null },
   task: SidebarRow["task"],
 ): WorktreeChanges {
-  const pushed = pickPushedChanges(shared.worktreeChanges, task.worktreePath)
+  const pushed = pickPushedChanges(sources.worktreeChanges, task.worktreePath)
   const hasPushed = pushed !== null
   useEffect(() => {
     // Dependency-only invalidation key: re-poll on the sidebar's ~2s tick.
-    void shared.branchTick
+    void sources.branchTick
     if (hasPushed) return
     pollWorktreeChanges(task.worktreePath)
-  }, [hasPushed, task.worktreePath, shared.branchTick])
+  }, [hasPushed, task.worktreePath, sources.branchTick])
   return pushed ?? worktreeChanges(task.worktreePath)
-}
-
-/**
- * Subtitle line of a row card — Solid `SubtitleText`'s React counterpart.
- * Plain muted text, except a materialising row, which renders the
- * indeterminate sweep bar ahead of the word.
- */
-function SubtitleText(props: { readonly view: SidebarRowView }) {
-  const themeCtx = useTheme()
-  const { theme } = themeCtx
-  const animating = props.view.materializing
-  const frame = useSpinnerFrame(animating)
-  if (!animating) {
-    return (
-      <text fg={theme.textMuted} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
-        {props.view.subtitleText}
-      </text>
-    )
-  }
-  return (
-    <box flexDirection="row" gap={1} flexBasis={0} flexGrow={1} flexShrink={1}>
-      <text fg={theme.primary} wrapMode="none">
-        {sweepBar(frame)}
-      </text>
-      <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
-        {props.view.subtitleText}
-      </text>
-    </box>
-  )
 }
 
 /** Right-edge git metrics stay one non-shrinking cluster while metadata takes
@@ -143,45 +87,6 @@ export function ChangeStats(props: { readonly changes: WorktreeChanges }) {
   )
 }
 
-function RowBody(props: {
-  readonly row: SidebarRow
-  readonly shared: SidebarRowCardSharedProps
-  readonly selection: ReturnType<typeof resolveRowSelectionChrome>
-  readonly children: ReactNode
-}) {
-  const task = props.row.task
-  const flatIndex = props.row.flatIndex
-  const shared = props.shared
-  return (
-    <box
-      ref={(renderable: BoxRenderable | null) => {
-        if (!renderable) return
-        shared.rowEls.set(flatIndex, renderable)
-        // React 19 ref cleanup — same "only if still ours" guard as Solid.
-        return () => {
-          if (shared.rowEls.get(flatIndex) === renderable) shared.rowEls.delete(flatIndex)
-        }
-      }}
-      width="100%"
-      flexDirection="column"
-      gap={0}
-      backgroundColor={props.selection.backgroundColor}
-      onMouseUp={() => {
-        shared.setCursorIndex(flatIndex)
-        shared.onSelect(task.id)
-        if (shared.activateOnClick) shared.activateRow(task.id)
-      }}
-    >
-      {props.children}
-    </box>
-  )
-}
-
-/**
- * Shared per-card derivation — cursor/selection chrome, `+N −M` counts, and
- * the framework-free row view — identical between the project and task
- * cards; only `mainBranch` (project rows poll the repo HEAD) differs.
- */
 /**
  * Rows whose CURRENT `turn_complete` the user has already looked at
  * (selected while complete) — the herdr "seen" bit driving ● → ✓. Cleared the
@@ -193,11 +98,11 @@ function RowBody(props: {
  * is what survives the restart; this Set stays the same-render answer.
  *
  * Keyed per ROW (task, or task+tab in the tree), not per task: a task owns
- * several tab rows, and they render in the same pass. With a task-wide key
- * a sibling tab — which legitimately passes `activityState: undefined` —
- * took the clear branch and wiped the bit the completed tab's row had just
- * recorded. Symptom (owner report 2026-08-10): open the tab, the lamp
- * digests to ✓, and it flips back to ● the moment you leave, forever.
+ * several tab rows, and they render in the same pass. A sibling tab — which
+ * legitimately passes `activityState: undefined` — took the clear branch and
+ * wiped the bit the completed tab's row had just recorded. Symptom (owner
+ * report 2026-08-10): open the tab, the lamp digests to ✓, and it flips back
+ * to ● the moment you leave, forever.
  */
 const completionSeenIds = new Set<string>()
 
@@ -263,123 +168,6 @@ export function useDurableCompletionSeen(
   return seen
 }
 
-function useRowCardChrome(row: SidebarRow, shared: SidebarRowCardSharedProps, opts: { mainBranch: string }) {
-  const t = useT()
-  const themeCtx = useTheme()
-  const { theme } = themeCtx
-  const task = row.task
-  const isCursor = row.flatIndex === shared.cursorIndex
-  const isSelected = task.id === shared.selectedId
-  const selection = resolveRowSelectionChrome(theme, { cursor: isCursor, selected: isSelected })
-  const changes = useChanges(shared, task)
-  const activity = shared.engineState?.get(task.id)
-  const lifecycle = shared.engineLifecycle?.get(task.id)
-  const job = shared.taskJobs?.get(task.id)
-  const { mainBranch } = opts
-  // Live line-2 cluster width (pin / PR chip / ±stats, each + its 1-cell
-  // gap): subtracted from the base budget so a quiet row's branch runs the
-  // full rail while a busy row still never collides with its cluster.
-  const isMain = task.kind === "main"
-  const clusterCells =
-    (!isMain && task.pinned === true ? 2 : 0) +
-    (!isMain && prCheckChip(task) ? 2 : 0) +
-    (changes.added > 0 ? `+${changes.added}`.length + 1 : 0) +
-    (changes.deleted > 0 ? `−${changes.deleted}`.length + 1 : 0)
-  const subtitleBudget = Math.max(6, shared.subtitleBudget - clusterCells)
-  const durableSeen = useDurableCompletionSeen(task.id, undefined, completionStampOf(activity), isSelected)
-  const completionSeen = completionSeenFor(task.id, activity?.state, isSelected, undefined, durableSeen)
-  // This worktree's transcript facts, read OUTSIDE the memo so the row
-  // re-derives when its own mtime moves rather than on every map identity
-  // change (the collector republishes the whole map per probe round).
-  const transcriptMtime = task.worktreePath ? shared.transcriptActivity?.get(task.worktreePath)?.mtimeMs : undefined
-  // Memoized on the real inputs so the 10Hz spinner tick (a fresh `shared`
-  // object every render) doesn't re-derive idle rows.
-  const baseView = useMemo(() => {
-    // Dependency-only invalidation key: rebuild when the language changes —
-    // buildSidebarRowView reads the global `t` through the locale store.
-    void t
-    return buildSidebarRowView({
-      task,
-      activity,
-      lifecycle,
-      job,
-      ...(transcriptMtime !== undefined ? { transcript: { mtimeMs: transcriptMtime } } : {}),
-      spinnerFrame: 0,
-      subtitleBudget,
-      truncateBranch: truncateBranchLabel,
-      mainBranch,
-      completionSeen,
-    })
-  }, [task, activity, lifecycle, job, subtitleBudget, mainBranch, completionSeen, transcriptMtime, t])
-  // Frame overlay stays OUTSIDE the memo: non-loading rows come back as the
-  // same object and never subscribe, so an idle row does zero per-frame work.
-  const frame = useSpinnerFrame(baseView.loading)
-  const rowView = withSpinnerFrame(baseView, () => frame)
-  return { theme, task, isCursor, isSelected, selection, changes, rowView }
-}
-
-/** One marker-prefixed line of a two-line row card. */
-function RowLine(props: {
-  readonly selection: ReturnType<typeof resolveRowSelectionChrome>
-  readonly children: ReactNode
-}) {
-  return (
-    <box flexDirection="row" gap={0}>
-      <text fg={props.selection.markerColor} wrapMode="none">
-        {props.selection.marker}
-      </text>
-      {props.children}
-    </box>
-  )
-}
-
-export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
-  const t = useT()
-  const shared = props.shared
-  const task = props.row.task
-  useEffect(() => {
-    // Dependency-only invalidation key: re-poll on the sidebar's ~2s tick.
-    void shared.branchTick
-    pollCurrentBranch(task.repo)
-  }, [task.repo, shared.branchTick])
-  const { theme, isCursor, selection, changes, rowView } = useRowCardChrome(props.row, shared, {
-    mainBranch: currentBranch(task.repo),
-  })
-  // Same tone mapping as a task row: the glyph's COLOR carries state too, so
-  // an idle project must not sit on the brand primary while an idle task is
-  // muted (owner call 2026-07-30 — one vocabulary for both row kinds).
-  const stateColor = toneColor(theme, rowView.tone)
-
-  return (
-    <box flexDirection="column" gap={0} paddingBottom={0}>
-      <RowBody row={props.row} shared={shared} selection={selection}>
-        <RowLine selection={selection}>
-          <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
-            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none" width={1} flexShrink={0}>
-              {rowView.stateGlyph}
-            </text>
-            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none" flexGrow={1}>
-              {spacedTitle(rowView.titleText, shared.titleBudget)}
-            </text>
-            {shared.moveMode && isCursor ? (
-              <text fg={theme.warning} wrapMode="none">
-                {t("tasks.moveChip")}
-              </text>
-            ) : null}
-            <JumpDigit flatIndex={props.row.flatIndex} dim={!isCursor} />
-          </box>
-        </RowLine>
-        <RowLine selection={selection}>
-          <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
-            <SubtitleText view={rowView} />
-            <ChangeStats changes={changes} />
-          </box>
-        </RowLine>
-      </RowBody>
-    </box>
-  )
-}
-
 /**
  * The `ctrl+<digit>` this row answers to, right-stuck on its title line.
  * Printing it is what makes the chord usable at all: the digits follow the
@@ -391,61 +179,4 @@ export function ProjectRowCard(props: { row: SidebarRow; shared: SidebarRowCardS
 // ponytail: ctrl+<digit> jump chord still works, just no longer printed on the row.
 export function JumpDigit(_props: { flatIndex: number; dim: boolean }) {
   return null
-}
-
-export function TaskRowCard(props: { row: SidebarRow; shared: SidebarRowCardSharedProps }) {
-  const t = useT()
-  const shared = props.shared
-  const task = props.row.task
-  const { theme, isCursor, isSelected, selection, changes, rowView } = useRowCardChrome(props.row, shared, {
-    mainBranch: "",
-  })
-  const stateColor = toneColor(theme, rowView.tone)
-  const chip = prCheckChip(task)
-
-  return (
-    // Two-line card + 1-cell spacer between tasks (owner call 2026-07-27,
-    // settled after trying herdr's gap-0 density: tasks read better apart).
-    <box flexDirection="column" gap={0} paddingBottom={1}>
-      <RowBody row={props.row} shared={shared} selection={selection}>
-        <RowLine selection={selection}>
-          <box flexDirection="row" flexGrow={1} paddingRight={1} gap={0}>
-            <text fg={stateColor} attributes={TextAttributes.BOLD} wrapMode="none" width={1} flexShrink={0}>
-              {rowView.stateGlyph}
-            </text>
-            <text
-              fg={theme.text}
-              attributes={isSelected || isCursor ? TextAttributes.BOLD : undefined}
-              wrapMode="none"
-              flexGrow={1}
-            >
-              {spacedTitle(rowView.titleText, shared.titleBudget)}
-            </text>
-            {shared.moveMode && isCursor ? (
-              <text fg={theme.warning} wrapMode="none">
-                {t("tasks.moveChip")}
-              </text>
-            ) : null}
-            <JumpDigit flatIndex={props.row.flatIndex} dim={!isCursor} />
-          </box>
-        </RowLine>
-        <RowLine selection={selection}>
-          <box flexDirection="row" flexGrow={1} paddingLeft={2} paddingRight={1} gap={1}>
-            <SubtitleText view={rowView} />
-            {task.pinned === true ? (
-              <text fg={theme.warning} wrapMode="none">
-                ▴
-              </text>
-            ) : null}
-            {chip ? (
-              <text fg={toneColor(theme, chip.tone)} wrapMode="none">
-                {chip.glyph}
-              </text>
-            ) : null}
-            <ChangeStats changes={changes} />
-          </box>
-        </RowLine>
-      </RowBody>
-    </box>
-  )
 }

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -3,18 +3,15 @@
  * (removed 2026-07-07) with the idiomatic React translation: every
  * `Accessor<T>` prop became a plain `T` — the host re-renders the Sidebar
  * when the value changes, so per-read reactivity has no equivalent.
- * Callback props are unchanged. Shared data shapes (`SidebarHover`,
- * `WorktreeChanges`) are the framework-free originals.
+ * Callback props are unchanged. Shared data shapes (`WorktreeChanges`) are
+ * the framework-free originals.
  */
 
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
 import type { Task } from "@/types/task"
 import type { TaskSortMode } from "../../../tui/panes/sidebar/groups"
 import type { SidebarNav } from "../../../tui/panes/sidebar/nav-core"
-import type { SidebarHover } from "../../../tui/panes/sidebar/types"
 import type { WorktreeChanges } from "../../../tui/panes/sidebar/worktree-changes"
-
-export type { SidebarHover } from "../../../tui/panes/sidebar/types"
 
 /**
  * Task-lifecycle callbacks shared VERBATIM by {@link SidebarProps} (host
@@ -32,10 +29,13 @@ export type SidebarTaskCallbacks = {
   onMoveRequest?: (taskId: string, delta: -1 | 1) => void
   onMoveModeExit?: () => void
   onRenameRequest?: (taskId: string) => void
-  /** Shift+P only — bare `p` is consumed but does nothing (same as Solid). */
+  /**
+   * Shift+P only. A bare `p` binds nothing — the registry row is an explicit
+   * `shift+p` chord — so a mistyped press matches no binding and silently
+   * does nothing rather than churning the pin flag (same contract as the
+   * Solid era; see the sidebar.pin row in context/keybindings-sidebar.ts).
+   */
   onPinRequest?: (taskId: string) => void
-  onPreviewToggleRequest?: (taskId: string) => void
-  onSortModeToggle?: () => void
 }
 
 export type SidebarProps = SidebarTaskCallbacks & {
@@ -75,17 +75,6 @@ export type SidebarProps = SidebarTaskCallbacks & {
   taskJobs?: ReadonlyMap<string, TaskJobState>
   worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
   /** Daemon-collected transcript facts keyed by WORKTREE path — proves a
-   *  "complete" turn whose engine is still writing (hook-silent phases). */
+   * "complete" turn whose engine is still writing (hook-silent phases). */
   transcriptActivity?: ReadonlyMap<string, { readonly mtimeMs: number }> | null
-  /**
-   * Parent-level overlay hook for native workspace. When omitted, Sidebar
-   * renders its own local fallback tooltip for standalone/tmux pane hosts.
-   */
-  onHoverChange?: (hover: SidebarHover | null) => void
-  /**
-   * Hover tooltips are opt-in (owner call 2026-07-28): absent/false means
-   * mouse hover never opens the item tooltip. Hosts read the
-   * `sidebar.hover.enabled` setting (default off).
-   */
-  hoverEnabled?: boolean
 }

--- a/packages/kobe/src/tui/panes/sidebar/hover-layout.ts
+++ b/packages/kobe/src/tui/panes/sidebar/hover-layout.ts
@@ -1,11 +1,14 @@
 import { approxCellWidth } from "../../../lib/display-width"
-import { repoBasename } from "./groups"
-import type { SidebarHover } from "./types"
 
 // Cell measurement moved to the shared width module; re-exported so
 // existing importers (tests, panes) keep compiling.
 export { approxCellWidth }
 
+// The hover TOOLTIP itself was cut with the flat sidebar's row cards
+// (2026-08-30): nothing feeds a SidebarHover anymore and no renderer
+// consumed one. What survives here is the placement math, reused by the
+// right-click ContextMenu — same "a box of text lines pinned near the
+// pointer" problem.
 export const SIDEBAR_HOVER_TOOLTIP_Z_INDEX = 2750
 export const SIDEBAR_HOVER_TOOLTIP_MAX_WIDTH = 72
 
@@ -21,16 +24,6 @@ export type SidebarHoverTooltipLayout = {
   readonly boxHeight: number
   readonly left: number
   readonly top: number
-}
-
-export function sidebarHoverTooltipLines(hover: SidebarHover): SidebarHoverTooltipLine[] {
-  const task = hover.task
-  const out: SidebarHoverTooltipLine[] = []
-  out.push({ text: task.kind === "main" ? repoBasename(task.repo) : task.title, bold: true })
-  if (task.branch.length > 0) out.push({ text: `⎇ ${task.branch}` })
-  // No worktree path line (owner call 2026-07-28): it's noise here — the
-  // path lives in the workspace header when the task is selected.
-  return out
 }
 
 export function resolveSidebarHoverTooltipLayout(opts: {

--- a/packages/kobe/src/tui/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui/panes/sidebar/types.ts
@@ -1,7 +1,0 @@
-import type { Task } from "@/types/task"
-
-export type SidebarHover = {
-  readonly task: Task
-  readonly x: number
-  readonly y: number
-}

--- a/packages/kobe/test/render/sidebar-sort-key.test.tsx
+++ b/packages/kobe/test/render/sidebar-sort-key.test.tsx
@@ -1,0 +1,134 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The `t` sort chord, pressed for real. The wiring that matters lives in the
+ * WORKSPACE host (`useWorkspaceKeybindings` → `toggleSortMode` → the
+ * `sortMode` prop), not in the SidebarTree's own binding block — the tree
+ * only renders the order it is given. So this mounts the real host binding
+ * hook next to the real tree, presses `t` through the mock input, and asserts
+ * the frame's row order actually flips between `default` (stored order) and
+ * `recent` (updatedAt-desc). A frame-only probe can't catch a dead chord; a
+ * binding that was never registered renders identically to one that works.
+ */
+import { expect, test } from "bun:test"
+import { useState } from "react"
+import { useFocus } from "../../src/tui-react/context/focus"
+import { SidebarTree } from "../../src/tui-react/panes/sidebar/SidebarTree"
+import { useDialog } from "../../src/tui-react/ui/dialog"
+import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keybindings"
+import type { HostPagesState } from "../../src/tui-react/workspace/host-pages"
+import type { TaskSortMode } from "../../src/tui/panes/sidebar/groups"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { renderComponent } from "./harness"
+
+const SETTLE = 80
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+/** One project whose regular worktrees sit in stored order by default. */
+const MAIN = task("m", { kind: "main", branch: "", worktreePath: "/repos/rove" })
+const OLDER = task("aaa", { updatedAt: "2026-08-01T00:00:00.000Z" })
+const NEWER = task("zzz", { updatedAt: "2026-08-20T00:00:00.000Z" })
+
+/** All pages closed — the gate `useWorkspaceKeybindings` requires. */
+function closedPages(): HostPagesState {
+  const noop = () => {}
+  return {
+    nav: "terminal",
+    setNav: noop,
+    goToNav: noop,
+    settingsOpen: false,
+    openSettings: noop,
+    closeSettings: noop,
+    worktreesOpen: false,
+    openWorktrees: noop,
+    closeWorktrees: noop,
+    updateOpen: false,
+    openUpdate: noop,
+    closeUpdate: noop,
+    kanbanOpen: false,
+    openKanban: noop,
+    closeKanban: noop,
+    automationsOpen: false,
+    openAutomations: noop,
+    closeAutomations: noop,
+    workItemsOpen: false,
+    openWorkItems: noop,
+    closeWorkItems: noop,
+  }
+}
+
+/** The real host binding hook, minus the app: `t` flips local sort state. */
+function SortHost() {
+  const focus = useFocus()
+  const dialog = useDialog()
+  const [sortMode, setSortMode] = useState<TaskSortMode>("default")
+  useWorkspaceKeybindings({
+    focus,
+    dialog,
+    pages: closedPages(),
+    searchActive: false,
+    selectedId: OLDER.id,
+    openTaskWorktree: () => {},
+    createTask: () => {},
+    renameBranch: () => {},
+    cycleVendor: () => {},
+    toggleZen: () => {},
+    jumpToNextAttention: () => {},
+    openInbox: () => {},
+    enterMoveMode: () => {},
+    createPR: () => {},
+    toggleSortMode: () => setSortMode((mode) => (mode === "default" ? "recent" : "default")),
+  })
+  return (
+    <SidebarTree
+      tasks={[MAIN, OLDER, NEWER]}
+      selectedId={OLDER.id}
+      selectedTabId={null}
+      onSelect={() => {}}
+      focused={focus.focused === "sidebar"}
+      sortMode={sortMode}
+      width={28}
+    />
+  )
+}
+
+function orderOf(frame: string): number {
+  return frame.indexOf("feat/aaa") - frame.indexOf("feat/zzz")
+}
+
+test("t flips the sidebar between default and recent sort", async () => {
+  const { frame, mockInput } = await renderComponent(<SortHost />, {
+    width: 28,
+    height: 20,
+    providers: { focus: true, dialog: true },
+  })
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  // Default sort keeps the stored order: aaa before zzz.
+  expect(orderOf(await frame())).toBeLessThan(0)
+
+  // `t` — the sidebar-scoped chord the F1 keymap advertises — flips to
+  // recency: zzz (touched 2026-08-20) jumps above aaa (2026-08-01).
+  mockInput.typeText("t")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(orderOf(await frame())).toBeGreaterThan(0)
+
+  // And back again — the chord TOGGLES, it doesn't latch.
+  mockInput.typeText("t")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(orderOf(await frame())).toBeLessThan(0)
+})

--- a/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
+++ b/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
@@ -30,10 +30,11 @@ describe("workspace open-worktree bindings", () => {
     mocks.bindingFactories.length = 0
   })
 
-  test("the workspace hook registers both open-worktree bindings", () => {
+  test("the workspace hook registers the sidebar-scoped task bindings", () => {
     const openTaskWorktree = vi.fn()
     const renameBranch = vi.fn()
     const cycleVendor = vi.fn()
+    const toggleSortMode = vi.fn()
     const pages: HostPagesState = {
       nav: "terminal",
       setNav: vi.fn(),
@@ -72,7 +73,7 @@ describe("workspace open-worktree bindings", () => {
       openInbox: vi.fn(),
       enterMoveMode: vi.fn(),
       createPR: vi.fn(),
-      toggleSortMode: vi.fn(),
+      toggleSortMode,
     })
 
     const registrations = mocks.bindingFactories.map((factory) => factory())
@@ -81,18 +82,22 @@ describe("workspace open-worktree bindings", () => {
     const sidebarOpen = sidebarBindings.find((binding) => binding.key === "o" && !binding.prefix)
     const rename = sidebarBindings.find((binding) => binding.key === "b")
     const cycleEngine = sidebarBindings.find((binding) => binding.key === "v")
+    const sort = sidebarBindings.find((binding) => binding.key === "t")
 
     expect(globalOpen).toBeDefined()
     expect(sidebarOpen).toBeDefined()
     expect(rename).toBeDefined()
     expect(cycleEngine).toBeDefined()
+    expect(sort).toBeDefined()
     globalOpen?.cmd({} as never)
     sidebarOpen?.cmd({} as never)
     rename?.cmd({} as never)
     cycleEngine?.cmd({} as never)
+    sort?.cmd({} as never)
     expect(openTaskWorktree).toHaveBeenCalledTimes(2)
     expect(renameBranch).toHaveBeenCalledWith("task-1")
     expect(cycleVendor).toHaveBeenCalledWith("task-1")
+    expect(toggleSortMode).toHaveBeenCalledTimes(1)
   })
 
   // Boot now lands focus in the content pane when a session is restorable,


### PR DESCRIPTION
## 问题

`src/db.ts` 的 `ready()` 用 `??=` 缓存 schema 创建的 promise——**rejected 的也照缓存**。每个 query 都 `await ready()`，而生产上唯一清 `_ready` 的 `close()`/`resetSchema()` 都不跑，所以一次失败（启动瞬间 postgres 未就绪、网络抖一下、Railway 重启 Postgres 服务）就够让进程**永远重放同一个 rejection**：容器 online、日志安静、全站 500，`ON_FAILURE` 只看退出码不重启，`/health` 的异常被兜底成 500——直到有人手工 redeploy。

## 改动

`ready()` 的 promise 在 rejected 时清掉缓存，并连 `_sql`（连接池）一起清、后台 close，然后原样 rethrow。另外把 `client()` 的构造抽成 `defaultFactory` 并导出 test-only 的 `setClientFactory`（注释标明仅测试用，与 `resetSchema`「Used by tests」的先例一致）——这是让该行为在 no-DB CI 档被确定性覆盖所需的注入点。

### 1. 并发

语义不变：`??=` 仍在 pending 期间共享同一个 promise，N 个并发请求仍是 1 次 schema 运行（`CREATE TABLE IF NOT EXISTS` 只跑一次）。失败**当时**共享该 promise 的那批调用一起拿到同一个 rejection（同一个 Error 对象）；清缓存只影响失败**之后**到达的调用。测试用 5 个并发 `ready()` 断言底层只被调 1 次、5 个 rejection 同一对象。

### 2. 重试风暴

**选择自愈，不加退避**，理由：重试是惰性的——没有后台循环，每个到达的 query 最多触发一次 schema 尝试，频率被请求速率约束，且 SCHEMA 全是幂等的 `IF NOT EXISTS` DDL。对比之下旧行为是 100% 永久失败，需要人工 redeploy；重试把「数据库恢复后自动好起来」交给进程自己。若未来观测到恢复瞬间的重试压力，退避可以加，但那是新需求的范围。

### 关于 `_sql = null`

采纳了一起清，理由：失败场景（启动时库未就绪、网络抖动、Railway 重启 Postgres）里连接池是冲着死端点建的，留着它是「可能没问题」的赌注，清掉换一个新池的成本只是一个对象分配 + 后台 close。用 `void dead?.close().catch(() => {})` 而不是同步丢弃，避免泄漏可能还活着的连接。

## 测试

`test/db-ready-retry.test.ts`，no-DB 档（不进 `./setup`，不触真库）：用 `setClientFactory` 注入一个「第一次失败、第二次恢复」的剧本化数据库，

- 失败后第二次 `ready()` 真的重新运行 schema 应用（计数器断言调用 2 次，且工厂只装一次——重试来自 `ready()` 自身，不是测试重新注入）；
- 5 并发共享一次尝试（底层调用 1 次、5 个 rejection 是同一对象），下一调用重试（调用 2 次、新 Error 对象）；
- 成功路径仍被缓存（后续调用不再跑 schema）。

已在旧实现上验证该测试变红（计数停在 1、rejection 被重放）。

## 验收

- no-DB 档：`50 文件 472 pass 0 fail`（基线 49/469 + 本 PR 的 1 文件 3 测试）
- `env -u WISP_DB_URL WISP_CONFIG=off bun test ./test/db-ready-retry.test.ts`：3 pass 0 fail
- `bunx tsc --noEmit`：59 errors，与 main 基线完全相同（`?query` 导入等既有噪音），本 PR 文件 0 个
- `bunx eslint .`：0 error（唯一 warning 在 main 上就有的 `web/components/Pending.tsx`）

不动 `railway.json` 的 restartPolicy（部署配置，需用户批），不动 `/health`（另有任务在动）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
