### PR TITLE
test: fix render-track flake in prefix-guide waits (issue #82)

### DIFF
--- a/.changeset/render-guide-wait-flake.md
+++ b/.changeset/render-guide-wait-flake.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix a render-track flake that red-lit unrelated PRs (issue #82)
+
+The prefix-tap shortcut tests polled for the command guide with a hardcoded
+1s deadline. The guide is a deliberate delayed reveal — `PrefixHud` opens it
+`PREFIX_GUIDE_DELAY_MS` after the tap — and on a loaded CI runner the 1s
+window expired before the delayed frame rendered, failing PRs that touched no
+TUI code. The wait budget is now anchored to `PREFIX_GUIDE_DELAY_MS` with
+room for slow-runner frame latency, the poll helper is shared from the render
+harness, and a timeout now names the missing text instead of failing an
+unrelated `toContain`.

--- a/packages/kobe/test/render/harness.tsx
+++ b/packages/kobe/test/render/harness.tsx
@@ -122,6 +122,34 @@ export function settle(ms = 60): Promise<void> {
 }
 
 /**
+ * Poll `frame()` until the captured frame contains `text` and return that
+ * frame. Throws with the last frame on timeout.
+ *
+ * Call sites that wait on an INTENTIONAL product delay — e.g. the prefix-HUD
+ * command guide, which only opens PREFIX_GUIDE_DELAY_MS after the tap — must
+ * pass a `timeoutMs` anchored to that product constant, not a bare estimate:
+ * the deadline has to cover the delay plus frame latency on a loaded CI
+ * runner, or the test flakes at random on unrelated PRs (issue #82: a 1s
+ * budget failed at ~1.1s of test wall-clock on a slow runner).
+ */
+export async function waitForFrameText(
+  frame: () => Promise<string>,
+  text: string,
+  { timeoutMs = 5_000, intervalMs = 25 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  let current = await frame()
+  while (!current.includes(text)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`frame did not contain ${JSON.stringify(text)} within ${timeoutMs}ms:\n${current}`)
+    }
+    await settle(intervalMs)
+    current = await frame()
+  }
+  return current
+}
+
+/**
  * Mount `ui` against a real opentui React test renderer and return a handle to
  * drive/inspect it. Renders one initial frame before resolving, so `frame()`
  * immediately after `renderComponent()` reflects the mounted state.

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -25,8 +25,9 @@ import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keyb
 import type { HostPagesState } from "../../src/tui-react/workspace/host-pages"
 import { KEY_HINTS_ENABLED_KEY, PANE_HINT_USED_KEYS } from "../../src/tui/lib/keyboard-hints"
 import { resetPrefixState } from "../../src/tui/lib/keymap-dispatch"
+import { PREFIX_GUIDE_DELAY_MS } from "../../src/tui/lib/prefix-hud"
 import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
-import { act, renderComponent, settle } from "./harness"
+import { act, renderComponent, settle, waitForFrameText } from "./harness"
 
 const NOOP = (): void => {}
 
@@ -137,14 +138,14 @@ function withGuideKvHome(): void {
   process.env.KOBE_HOME_DIR = home
 }
 
-async function waitForFrameText(frame: () => Promise<string>, text: string): Promise<string> {
-  const deadline = Date.now() + 1_000
-  let current = await frame()
-  while (!current.includes(text) && Date.now() < deadline) {
-    await settle(25)
-    current = await frame()
-  }
-  return current
+// The which-key guide is a deliberate delayed reveal: PrefixHud only opens it
+// PREFIX_GUIDE_DELAY_MS after the tap, so the poll budget must cover that
+// product delay plus frame latency on a loaded CI runner (same flake as
+// issue #82 in shortcut-reveal).
+const GUIDE_REVEAL_TIMEOUT_MS = PREFIX_GUIDE_DELAY_MS + 5_000
+
+async function waitForGuideText(frame: () => Promise<string>, text: string): Promise<string> {
+  return waitForFrameText(frame, text, { timeoutMs: GUIDE_REVEAL_TIMEOUT_MS })
 }
 
 describe("StatusKeyHintBar", () => {
@@ -194,7 +195,7 @@ describe("StatusKeyHintBar", () => {
     await settle()
 
     act(() => mockInput.pressKey("a", { ctrl: true }))
-    expect(await waitForFrameText(frame, "more Rove commands")).toContain("more Rove commands")
+    expect(await waitForGuideText(frame, "more Rove commands")).toContain("more Rove commands")
 
     act(() => mockInput.pressKey("z"))
     await settle()
@@ -285,7 +286,7 @@ describe("footer hint clicks", () => {
     await settle()
     const spot = locate(await frame(), "commands")
     await mockMouse.click(spot.x + 1, spot.y)
-    expect(await waitForFrameText(frame, "more Rove commands")).toContain("more Rove commands")
+    expect(await waitForGuideText(frame, "more Rove commands")).toContain("more Rove commands")
     act(() => resetPrefixState())
   })
 })

--- a/packages/kobe/test/render/shortcut-reveal.test.tsx
+++ b/packages/kobe/test/render/shortcut-reveal.test.tsx
@@ -10,8 +10,9 @@ import { useBindings } from "../../src/tui-react/lib/keymap"
 import { SidebarNavRail } from "../../src/tui-react/panes/sidebar/chrome"
 import { bindByIds } from "../../src/tui/context/keybindings"
 import { prefixAction } from "../../src/tui/lib/keymap-dispatch"
+import { PREFIX_GUIDE_DELAY_MS } from "../../src/tui/lib/prefix-hud"
 import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
-import { act, renderComponent, settle } from "./harness"
+import { act, renderComponent, settle, waitForFrameText } from "./harness"
 
 function locate(frame: string, text: string): { x: number; y: number } {
   const lines = frame.split("\n")
@@ -46,14 +47,14 @@ function tempHome(mode?: "local" | "guide"): string {
   return home
 }
 
-async function waitForFrameText(frame: () => Promise<string>, text: string): Promise<string> {
-  const deadline = Date.now() + 1_000
-  let current = await frame()
-  while (!current.includes(text) && Date.now() < deadline) {
-    await settle(25)
-    current = await frame()
-  }
-  return current
+// The complete guide is a deliberate delayed reveal: PrefixHud only opens it
+// PREFIX_GUIDE_DELAY_MS after the tap, so the poll budget must cover that
+// product delay plus frame latency on a loaded CI runner (issue #82: a bare
+// 1s budget flaked at ~1.1s test wall-clock).
+const GUIDE_REVEAL_TIMEOUT_MS = PREFIX_GUIDE_DELAY_MS + 5_000
+
+async function waitForGuideText(frame: () => Promise<string>, text: string): Promise<string> {
+  return waitForFrameText(frame, text, { timeoutMs: GUIDE_REVEAL_TIMEOUT_MS })
 }
 
 test("the default prefix tap shows local badges and the complete command guide together", async () => {
@@ -66,7 +67,7 @@ test("the default prefix tap shows local badges and the complete command guide t
   )
 
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  const local = await waitForFrameText(frame, "more Rove commands")
+  const local = await waitForGuideText(frame, "more Rove commands")
   expect(local).toContain("⌃ A 1")
   expect(local).toContain("⌃ A 2")
   expect(local).toContain("more Rove commands")
@@ -89,7 +90,7 @@ test("a complete-guide row is a real clickable entry in local mode", async () =>
   )
 
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  const revealed = await waitForFrameText(frame, "Open active Task directory in editor")
+  const revealed = await waitForGuideText(frame, "Open active Task directory in editor")
   const at = locate(revealed, "Open active Task directory in editor")
   await mockMouse.click(at.x + 1, at.y)
   await settle()
@@ -108,7 +109,7 @@ test("the guide setting routes the same prefix tap to the global command guide",
   )
 
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  const guide = await waitForFrameText(frame, "more Rove commands")
+  const guide = await waitForGuideText(frame, "more Rove commands")
   expect(guide).toContain("more Rove commands")
   expect(guide).toContain("Open active Task directory in editor")
   expect(guide).not.toContain("⌃ A 1")


### PR DESCRIPTION
## What

Fixes the render-track flake tracked as issue #82, which red-lit unrelated PRs (e.g. PR #647, a state-machine refactor that touched zero TUI code, failed `a complete-guide row is a real clickable entry in local mode` at 1088ms — 88ms over the budget).

The shortcut-reveal and keyboard-hints render tests polled for the prefix command guide with a hardcoded **1s deadline**. But `PrefixHud` intentionally opens the complete guide only `PREFIX_GUIDE_DELAY_MS` (180ms) after the tap — the badges and the guide arriving in different frames is product behavior, not a bug. On a loaded CI runner the fixed 1s window expired before the delayed frame rendered.

## Fix (not just a bigger number)

- Wait mechanism stays **poll-until-condition** (it already was); what changes is the budget: anchored to the product constant — `PREFIX_GUIDE_DELAY_MS + 5_000` — so it tracks the intentional delay if that changes, with headroom for slow-runner frame latency. Fast runners are unaffected (the poll early-exits as soon as the text appears, ~200ms as before).
- The poll helper is hoisted into the shared render harness (`waitForFrameText`) with a descriptive timeout error naming the missing text, instead of failing a downstream `toContain` with an unread frame dump.
- Same-pattern copy in `keyboard-hints.test.tsx` (identical 1s helper, same guide text, two call sites) fixed in the same way — otherwise the flake just moves next door. Other render files' poll budgets (2–12s) were already sane.

**No product code changed.** The two-frame reveal (badges first, guide after the delay) is by design.

## Verification (flake discipline)

- **Baseline on main, 20 consecutive runs** of `bun test test/render/shortcut-reveal.test.tsx`: **0 failures / 20** (local macOS runner is fast; the flake only bites loaded CI runners — that's the point).
- **Negative control**: fix removed, deadline set to 60ms (the previous agent's repro from issue #82): **3 failures / 3 tests**, byte-identical symptom — badges `⌃ A 1`/`⌃ A 2` present, `more Rove commands` missing. Confirms the change addresses the actual timing condition.
- **After fix, 20 consecutive runs** of both touched files: **0 failures / 20**.
- Full render track (`bun run test:render`, 240 tests, 54 files): all pass, `test/render/harness.tsx` at 100% line coverage.
- `bun run lint` and `bun run typecheck`: clean.

## Changeset

patch (`@sma1lboy/rove`).