### PR TITLE
fix: surface failed mutations as error toasts on kanban, routines, and issues pages

### DIFF
--- a/.changeset/failure-toasts-for-mutations.md
+++ b/.changeset/failure-toasts-for-mutations.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Surface failed mutations as error toasts instead of invisible logs or muted hint lines
+
+Three pages told the user nothing (or something easy to miss) when a mutation failed:
+
+- Kanban: a failed issue create/delete logged to the daemon log only — under the alternate screen a bare `console.error` is invisible, so the card just stayed on the board.
+- Routines: create/delete/toggle/run-now failures rendered as a gray muted line, reading like a hint rather than a failure.
+- GitHub issues: a failed "start work" did the same.
+
+All three now send failures through the shared toast queue as `error` toasts (red accent, always shown even with toasts disabled), keeping the daemon-log line for forensics and leaving the muted inline line for non-failure status only.

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -17,8 +17,10 @@ import { TextAttributes } from "@opentui/core"
 import type { Automation, AutomationRun } from "@sma1lboy/kobe-daemon/daemon/contracts"
 import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { errorMessage } from "../../lib/error-message"
 import { relativeBuckets } from "../../lib/relative-time"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
+import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
@@ -69,6 +71,17 @@ export function AutomationsPage(props: {
   const { theme } = useTheme()
   const dialog = useDialog()
   const t = useT()
+  /**
+   * Failures go to the toast queue, not the inline notice line — a muted
+   * `textMuted` line reads as a hint, not a failure, and error toasts show
+   * even when toasts are disabled (shared notify-state invariant). Same
+   * empty taskId/tabId pattern as `WorktreesPage`: only the toast queue is
+   * consumed here.
+   */
+  const notif = useNotifications()
+  function notifyError(message: string): void {
+    notif.notify({ kind: "error", taskId: "", tabId: "", title: message })
+  }
 
   const [automations, setAutomations] = useState<readonly Automation[] | null>(null)
   const [keepsDaemonAlive, setKeepsDaemonAlive] = useState(false)
@@ -147,7 +160,8 @@ export function AutomationsPage(props: {
       await orch.setAutomationEnabled(selected.id, !selected.enabled)
       refetch()
     } catch (err) {
-      setNotice(err instanceof Error ? err.message : String(err))
+      console.error("[rove automations] toggle failed:", err)
+      notifyError(t("automations.failed", { error: errorMessage(err) }))
     } finally {
       setBusyId(null)
     }
@@ -163,7 +177,8 @@ export function AutomationsPage(props: {
       setNotice(t("automations.ranWith", { name: selected.name, status: result.status }))
       refetch()
     } catch (err) {
-      setNotice(err instanceof Error ? err.message : String(err))
+      console.error("[rove automations] run now failed:", err)
+      notifyError(t("automations.failed", { error: errorMessage(err) }))
     } finally {
       setBusyId(null)
     }
@@ -189,9 +204,10 @@ export function AutomationsPage(props: {
       await orch.createAutomation(draft)
       refetch()
     } catch (err) {
-      // The daemon re-validates the cron; surface its message, since the fix
-      // is in the input the user just typed.
-      setNotice(err instanceof Error ? err.message : String(err))
+      // The daemon re-validates the cron; its message names the fix, so it
+      // leads the error toast.
+      console.error("[rove automations] create failed:", err)
+      notifyError(t("automations.failed", { error: errorMessage(err) }))
     } finally {
       setBusyId(null)
     }
@@ -213,7 +229,8 @@ export function AutomationsPage(props: {
       await orch.deleteAutomation(selected.id)
       refetch()
     } catch (err) {
-      setNotice(err instanceof Error ? err.message : String(err))
+      console.error("[rove automations] delete failed:", err)
+      notifyError(t("automations.failed", { error: errorMessage(err) }))
     } finally {
       setBusyId(null)
     }

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -4,18 +4,16 @@
  * Parked / Done board. One PROJECT at a time (tab/←/→ or click cycles the
  * rolling selector), four full-height bordered columns matching the workspace
  * host's border grammar. Full-page swap in the workspace host, same shape as
- * WorktreesPage (issue #23 precedent): esc/ctrl+c closes, `r` refetches,
- * plus a light poll so agent-driven moves (`kobe api issue-update --task`)
- * show up while the page is open.
+ * WorktreesPage (issue #23 precedent): esc/ctrl+c closes, `r` refetches, plus
+ * a light poll so agent-driven moves (`kobe api issue-update --task`) show up
+ * while the page is open.
  *
  * The BOARD stays read-only (agents move cards via `kobe api issue-*`); the
- * human surface on top of it is selection + the detail drawer: ←↓↑→ moves
- * the card cursor (highlighted border), Enter (or clicking the selected
- * card) opens {@link IssueDetailDialog}, whose Start action hands an
- * {@link IssueChatStart} up to the host (engine + workspace placement +
- * attachments). Column math is the framework-free `state/issue-board.ts` —
- * columns derive from the issue's own lifecycle (done > parked > linked-task
- * > backlog), never from task status.
+ * human surface on top of it is selection + the detail drawer: ←↓↑→ moves the
+ * card cursor, Enter opens {@link IssueDetailDialog}, whose Start action hands
+ * an {@link IssueChatStart} up to the host. Column math is the framework-free
+ * `state/issue-board.ts` — columns derive from the issue's own lifecycle
+ * (done > parked > linked-task > backlog), never from task status.
  */
 
 import { TextAttributes } from "@opentui/core"
@@ -25,9 +23,11 @@ import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator, TaskEngineState } from "../../client/remote-orchestrator"
 import { availableEngineIds } from "../../engine/account-detect"
 import { engineDisplayName } from "../../engine/interactive-command"
+import { errorMessage } from "../../lib/error-message"
 import { type BoardColumnKey, applyBoardAttention, buildIssueBoard, moveBoardSelection } from "../../state/issue-board"
 import { sidebarProjectLabel } from "../../tui/panes/sidebar/groups"
 import type { VendorId } from "../../types/task"
+import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
@@ -71,6 +71,17 @@ export function KanbanPage(props: {
   const columnBorder = transparentBackground ? theme.border : theme.borderSubtle
   const t = useT()
   const dialog = useDialog()
+  /**
+   * Surface mutation failures as on-screen toasts. Under an alternate screen a
+   * bare `console.error` is invisible (it only reaches the daemon log), so a
+   * failed create/delete would look like a silent no-op — the card just stays.
+   * Empty taskId/tabId match the pattern in `WorktreesPage`: this page is not
+   * scoped to a single chat tab, only the toast queue is consumed.
+   */
+  const notif = useNotifications()
+  function notifyError(message: string): void {
+    notif.notify({ kind: "error", taskId: "", tabId: "", title: message })
+  }
   // Below the narrow breakpoint four side-by-side columns degrade to
   // one-word-per-line strips, so the board shows ONE full-width lane there.
   const narrow = isNarrowWidth(useTerminalDimensions().width)
@@ -157,19 +168,17 @@ export function KanbanPage(props: {
     if (next != null) setSelectedId(next)
   }
 
-  // ←/→ MOVED from project-cycling to card selection when cards exist —
-  // tab still cycles projects. On an empty board they fall through to
-  // project cycling so the old muscle memory keeps working there.
+  // ←/→ select cards when any exist; tab still cycles projects. On an empty
+  // board they fall through to project cycling (the old muscle memory).
   function moveOrCycle(dir: "left" | "right"): void {
     if (columns.some((column) => column.issues.length > 0)) moveCursor(dir)
     else cycleProject(dir === "left" ? -1 : 1)
   }
 
-  /** Enter (or clicking the selected card): the story's detail drawer.
-   *  EVERY outcome carries the drafted title/body — a dirty patch persists
-   *  through `issue.mutate update` (best-effort: an edit must not block the
-   *  start/open the user asked for), then the outcome routes to the host.
-   *  undefined = discarded (ctrl+c / backdrop). */
+  /** Enter (or clicking the selected card): the story's detail drawer. Every
+   *  outcome carries the drafted title/body — a dirty patch persists through
+   *  `issue.mutate update` (best-effort: an edit must not block the start/open
+   *  the user asked for). undefined = discarded (ctrl+c / backdrop). */
   function openDetail(issue: Issue): void {
     const board = activeBoard
     if (!board) return
@@ -256,6 +265,7 @@ export function KanbanPage(props: {
         })
       } catch (err) {
         console.error("[rove kanban] issue create failed:", err)
+        notifyError(t("kanban.createFailed", { error: errorMessage(err) }))
       }
     })
   }
@@ -278,7 +288,10 @@ export function KanbanPage(props: {
           setSelectedId(null)
           setReloadTick((tick) => tick + 1)
         })
-        .catch((err: unknown) => console.error("[rove kanban] issue delete failed:", err))
+        .catch((err: unknown) => {
+          console.error("[rove kanban] issue delete failed:", err)
+          notifyError(t("kanban.deleteFailed", { id: String(issue.id), error: errorMessage(err) }))
+        })
     })
   }
 
@@ -309,9 +322,9 @@ export function KanbanPage(props: {
   } satisfies Record<BoardColumnKey, unknown>
 
   function card(issue: Issue, column: BoardColumnKey): ReactNode {
-    // Linked cards in the live lanes track their task's engine activity —
-    // the stay-on-the-board half of the background-start trigger. Parked
-    // keeps the badge as passive signal; only In progress floats/counts it.
+    // Linked cards in the live lanes track their task's engine activity (the
+    // stay-on-the-board half of the background-start trigger); only In
+    // progress floats/counts the badge, Parked keeps it as passive signal.
     const live = column === "in_progress" || column === "parked"
     const activity = live && issue.taskId ? props.engineStates?.get(issue.taskId)?.state : undefined
     return (
@@ -383,10 +396,8 @@ export function KanbanPage(props: {
           </box>
         ) : null}
         {/* paddingRight keeps a one-cell gutter under the scrollbar thumb —
-            without it the thumb paints over the cards' right borders (the
-            help-dialog / versions-page convention). The horizontal bar is
-            hidden outright: a lane never scrolls sideways, and its arrow
-            glyphs were painting stray diamonds over card borders. */}
+            without it the thumb paints over the cards' right borders. The
+            horizontal bar is hidden outright: a lane never scrolls sideways. */}
         <scrollbox
           flexGrow={1}
           paddingTop={1}
@@ -456,10 +467,8 @@ export function KanbanPage(props: {
 
   const loading = boards === null
 
-  // One shared left baseline at x=3: the board is inset one cell (border at
-  // x=1, +border cell +padding = text at x=3), and every header/selector row
-  // gets paddingLeft=3 — Kanban / project / Backlog / cards all align, with
-  // one cell of air between the borders and the screen edge.
+  // One shared left baseline at x=3 (board inset one cell + padding) —
+  // Kanban / project / column headers / cards all align on it.
   return (
     <box flexGrow={1} backgroundColor={theme.background} paddingTop={1} paddingBottom={1}>
       <box flexDirection="row" justifyContent="space-between" gap={2} paddingLeft={3} paddingRight={3}>

--- a/packages/kobe/src/tui-react/component/work-items-page.tsx
+++ b/packages/kobe/src/tui-react/component/work-items-page.tsx
@@ -16,8 +16,10 @@ import { TextAttributes } from "@opentui/core"
 import type { WorkItem } from "@sma1lboy/kobe-daemon/daemon/work-items"
 import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { errorMessage } from "../../lib/error-message"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
 import { sidebarProjectLabel } from "../../tui/panes/sidebar/groups"
+import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
@@ -71,6 +73,12 @@ export function WorkItemsPage(props: {
 }): ReactNode {
   const { theme } = useTheme()
   const t = useT()
+  // Failure toasts, not the muted inline notice — same contract as the
+  // Worktrees/Automations pages (see AutomationsPage for the rationale).
+  const notif = useNotifications()
+  function notifyError(message: string): void {
+    notif.notify({ kind: "error", taskId: "", tabId: "", title: message })
+  }
 
   const repos = reposOf(props.orchestrator)
   const [repoIndex, setRepoIndex] = useState(() => {
@@ -137,7 +145,8 @@ export function WorkItemsPage(props: {
       // than leaving the user wondering whether anything happened.
       else setNotice(t("workItems.startedNoEngine", { title: result.title }))
     } catch (err) {
-      setNotice(err instanceof Error ? err.message : String(err))
+      console.error("[rove work-items] start failed:", err)
+      notifyError(t("workItems.startFailed", { number: item.number, error: errorMessage(err) }))
     } finally {
       setStarting(false)
     }

--- a/packages/kobe/src/tui/i18n/messages/automations.ts
+++ b/packages/kobe/src/tui/i18n/messages/automations.ts
@@ -46,6 +46,8 @@ export const en = {
   deleteTitle: "Delete routine?",
   deleteBody: "{name} and its run history will be removed. Tasks it already created are untouched.",
   deleteButton: "Delete",
+  /** Error-toast title for a failed create/delete/toggle/run. `{error}` = the daemon's own message. */
+  failed: "{error}",
 }
 
 export const zh: typeof en = {
@@ -91,4 +93,6 @@ export const zh: typeof en = {
   deleteTitle: "删除这条例行任务？",
   deleteBody: "将删除 {name} 及其执行记录。它已经创建的任务不受影响。",
   deleteButton: "删除",
+  /** 创建/删除/开关/立即运行失败时的错误 toast 标题。`{error}` = daemon 返回的信息。 */
+  failed: "{error}",
 }

--- a/packages/kobe/src/tui/i18n/messages/kanban.ts
+++ b/packages/kobe/src/tui/i18n/messages/kanban.ts
@@ -82,6 +82,10 @@ export const en = {
     /** `{title}` = the issue title. Deletes ONLY the record. */
     body: "“{title}” will be removed from the tracker. A linked task, branch, or worktree is left untouched.",
   },
+  /** Error-toast title when `d` confirm fails. `{id}` = issue number, `{error}` = the daemon's message. */
+  deleteFailed: "Couldn't delete story #{id}: {error}",
+  /** Error-toast title when the new-story intake fails. `{error}` = the daemon's message. */
+  createFailed: "Couldn't create the story: {error}",
 }
 
 export const zh: typeof en = {
@@ -141,4 +145,8 @@ export const zh: typeof en = {
     title: "删除 story #{id}?",
     body: "「{title}」将从 tracker 中移除。已关联的任务、分支、worktree 不受影响。",
   },
+  /** 删除失败时的错误 toast 标题。`{id}` = issue 编号，`{error}` = daemon 返回的信息。 */
+  deleteFailed: "删除 story #{id} 失败：{error}",
+  /** 新建 story 失败时的错误 toast 标题。`{error}` = daemon 返回的信息。 */
+  createFailed: "创建 story 失败：{error}",
 }

--- a/packages/kobe/src/tui/i18n/messages/workItems.ts
+++ b/packages/kobe/src/tui/i18n/messages/workItems.ts
@@ -10,6 +10,8 @@ export const en = {
   assignedFilter: "assigned to me",
   starting: "Starting work on #{number}…",
   startedNoEngine: "Created {title}, but its engine did not start.",
+  /** Error-toast title when starting work fails. `{number}` = issue number, `{error}` = the daemon's message. */
+  startFailed: "Couldn't start work on #{number}: {error}",
   errorHint: {
     noRemote: "Add a GitHub remote (`git remote add origin <url>`) and try again, or press q / esc to close.",
     ghMissing: "Install the `gh` CLI and authenticate, or press q / esc to close.",
@@ -25,6 +27,8 @@ export const zh: typeof en = {
   assignedFilter: "分配给我的",
   starting: "正在开始处理 #{number}…",
   startedNoEngine: "已创建 {title}，但引擎没有启动。",
+  /** 开始处理失败时的错误 toast 标题。`{number}` = 议题编号，`{error}` = daemon 返回的信息。 */
+  startFailed: "开始处理 #{number} 失败：{error}",
   errorHint: {
     noRemote: "添加 GitHub remote（`git remote add origin <url>`）后重试，或按 q / esc 关闭。",
     ghMissing: "安装 `gh` CLI 并登录，或按 q / esc 关闭。",

--- a/packages/kobe/test/render/automations-page-keys.test.tsx
+++ b/packages/kobe/test/render/automations-page-keys.test.tsx
@@ -38,7 +38,7 @@ function orchestrator(automations: unknown[] = []) {
 test("n opens the create flow", async () => {
   const { frame, mockInput } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator()} focused={true} onClose={() => {}} />,
-    { width: 60, height: 16, providers: { dialog: true } },
+    { width: 60, height: 16, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 100))
   mockInput.typeText("n")
@@ -51,7 +51,7 @@ test("esc closes the create flow", async () => {
   // as a modal MEMBER it outranked the barrier, so the card never popped.
   const { frame, mockInput } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator()} focused={true} onClose={() => {}} />,
-    { width: 60, height: 16, providers: { dialog: true } },
+    { width: 60, height: 16, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 100))
   mockInput.typeText("n")
@@ -72,7 +72,7 @@ test("esc closes the page", async () => {
         closed = true
       }}
     />,
-    { width: 60, height: 16, providers: { dialog: true } },
+    { width: 60, height: 16, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 100))
   mockInput.pressEscape()
@@ -85,7 +85,7 @@ test("keys stay dead while another pane holds focus", async () => {
   // pages no longer disable the workspace chords, so the page must yield.
   const { frame, mockInput } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator()} focused={false} onClose={() => {}} />,
-    { width: 60, height: 16, providers: { dialog: true } },
+    { width: 60, height: 16, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 100))
   mockInput.typeText("n")
@@ -96,7 +96,7 @@ test("keys stay dead while another pane holds focus", async () => {
 test("each automation renders as a boxed strip", async () => {
   const { frame } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator([AUTOMATION])} focused={true} onClose={() => {}} />,
-    { width: 70, height: 16, providers: { dialog: true } },
+    { width: 70, height: 16, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 120))
   const lines = (await frame()).split("\n")
@@ -115,7 +115,7 @@ test("the schedule row is five editable cells, not a text field", async () => {
   // cron means knowing the field order before you can say anything.
   const { frame, mockInput } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator()} focused={true} onClose={() => {}} />,
-    { width: 72, height: 30, providers: { dialog: true } },
+    { width: 72, height: 30, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 120))
   mockInput.typeText("n")
@@ -150,7 +150,7 @@ test("the detail frame stays mounted with nothing selected", async () => {
   // frame is where a first-time user reads what a routine even carries.
   const { frame } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator()} focused={true} onClose={() => {}} />,
-    { width: 74, height: 16, providers: { dialog: true } },
+    { width: 74, height: 16, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 120))
   const text = await frame()
@@ -163,7 +163,7 @@ test("a selected routine offers an on-demand run", async () => {
   // schedule — the reason it is a visible button, not only the `s` key.
   const { frame } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator([AUTOMATION])} focused={true} onClose={() => {}} />,
-    { width: 74, height: 20, providers: { dialog: true } },
+    { width: 74, height: 20, providers: { dialog: true, notifications: true } },
   )
   await new Promise((r) => setTimeout(r, 150))
   expect(await frame()).toContain("run now")

--- a/packages/kobe/test/render/failure-toast.test.tsx
+++ b/packages/kobe/test/render/failure-toast.test.tsx
@@ -1,0 +1,325 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Failed mutations must be VISIBLE — the regression this branch fixes:
+ *
+ *   - Kanban issue create/delete logged to the daemon log only; under the
+ *     alternate screen a bare `console.error` is invisible, so the card just
+ *     stayed on the board.
+ *   - Automations / Work-items failures rendered as a muted `textMuted`
+ *     inline line — reads as a hint, not a failure.
+ *
+ * All three pages now push failures through the shared toast queue. Each
+ * test mounts the REAL page plus the REAL `ToastOverlay` and drives the REAL
+ * keys (down/d/enter, e, return) against a rejecting orchestrator mock, then
+ * asserts the error toast painted on the frame — the "✕" glyph the toast
+ * overlay draws, which no pre-fix rendering produced.
+ */
+import { expect, test } from "bun:test"
+import { AutomationsPage } from "../../src/tui-react/component/automations-page"
+import { KanbanPage } from "../../src/tui-react/component/kanban-page"
+import { ToastOverlay } from "../../src/tui-react/component/toast-overlay"
+import { WorkItemsPage } from "../../src/tui-react/component/work-items-page"
+import { renderComponent, settle } from "./harness"
+
+const REPO = "/repos/rove"
+
+function issue(id: number, over: Record<string, unknown> = {}) {
+  return { id, title: `story-${id}`, status: "open", created: "2026-08-01", body: "", ...over }
+}
+
+/** Flatten the captured frame into a list of colored spans. */
+async function coloredSpans(spans: () => Promise<import("@opentui/core").CapturedFrame>) {
+  return (await spans()).lines.flatMap((line) => line.spans)
+}
+
+/**
+ * The failure is a TOAST, not the page's muted notice line: some span must
+ * carry the "✕" toast glyph, and the span carrying `message` must not paint
+ * with the same color as `mutedNeedle`'s span (the pre-fix `textMuted` look).
+ */
+async function expectErrorToast(
+  frame: string,
+  spans: () => Promise<import("@opentui/core").CapturedFrame>,
+  message: string,
+  mutedNeedle: string,
+): Promise<void> {
+  expect(frame).toContain("✕")
+  expect(frame).toContain(message)
+  const all = await coloredSpans(spans)
+  const messageSpan = all.find((span) => span.text.includes(message))
+  const mutedSpan = all.find((span) => span.text.includes(mutedNeedle))
+  expect(messageSpan).toBeDefined()
+  expect(mutedSpan).toBeDefined()
+  if (!messageSpan || !mutedSpan) return
+  expect(messageSpan.fg.equals(mutedSpan.fg)).toBe(false)
+}
+
+test("kanban: a failed issue delete shows an error toast, not just a log line", async () => {
+  const orch = {
+    listTasks: () => [{ repo: REPO }],
+    listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)] }),
+    activeTaskSignal: () => ({ get: () => null }),
+    mutateIssue: async () => {
+      throw new Error("issues store is read-only")
+    },
+  } as never
+  const { frame, spans, mockInput } = await renderComponent(
+    <>
+      <KanbanPage
+        orchestrator={orch}
+        focused={true}
+        onClose={() => {}}
+        onStartChat={async () => {}}
+        onOpenTask={() => {}}
+      />
+      <ToastOverlay />
+    </>,
+    { width: 120, height: 30, providers: { dialog: true, kv: true, notifications: true } },
+  )
+  await settle()
+  // Select the only card, request delete, confirm — the RPC rejects.
+  mockInput.pressArrow("down")
+  await settle()
+  mockInput.typeText("d")
+  await settle()
+  expect(await frame()).toContain("Delete story #1?")
+  mockInput.pressEnter()
+  await settle(150)
+  const text = await frame()
+  expect(text).toContain("story-1")
+  await expectErrorToast(text, spans, "Couldn't delete story #1", "No cards")
+})
+
+test("kanban: a failed issue create shows an error toast", async () => {
+  const orch = {
+    listTasks: () => [{ repo: REPO }],
+    listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)] }),
+    activeTaskSignal: () => ({ get: () => null }),
+    mutateIssue: async () => {
+      throw new Error("issues store is read-only")
+    },
+  } as never
+  const { frame, spans, mockInput } = await renderComponent(
+    <>
+      <KanbanPage
+        orchestrator={orch}
+        focused={true}
+        onClose={() => {}}
+        onStartChat={async () => {}}
+        onOpenTask={() => {}}
+      />
+      <ToastOverlay />
+    </>,
+    { width: 120, height: 30, providers: { dialog: true, kv: true, notifications: true } },
+  )
+  await settle()
+  mockInput.typeText("n")
+  await settle()
+  expect(await frame()).toContain("NEW STORY")
+  mockInput.typeText("the new story")
+  await settle()
+  mockInput.typeText("\x13") // ctrl+s — file without starting
+  await settle(150)
+  await expectErrorToast(await frame(), spans, "Couldn't create the story", "No cards")
+})
+
+const AUTOMATION = {
+  id: "a1",
+  name: "weekday audit",
+  repo: "/x/kobe",
+  prompt: "audit",
+  schedule: "0 9 * * MON-FRI",
+  enabled: true,
+  nextRunAt: new Date(Date.now() + 3_600_000).toISOString(),
+  missedRunGraceMinutes: 60,
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+}
+
+test("automations: a failed delete shows an error toast instead of a muted line", async () => {
+  const orch = {
+    listAutomations: async () => ({ automations: [AUTOMATION], keepsDaemonAlive: true }),
+    automationRuns: async () => ({ runs: [] }),
+    listTasks: () => [{ repo: "/x/kobe" }],
+    deleteAutomation: async () => {
+      throw new Error("daemon refused")
+    },
+  } as never
+  const { frame, spans, mockInput } = await renderComponent(
+    <>
+      <AutomationsPage orchestrator={orch} focused={true} onClose={() => {}} />
+      <ToastOverlay />
+    </>,
+    { width: 90, height: 22, providers: { dialog: true, notifications: true } },
+  )
+  await settle(150)
+  mockInput.typeText("d")
+  await settle()
+  expect(await frame()).toContain("Delete routine?")
+  mockInput.pressEnter()
+  await settle(150)
+  await expectErrorToast(await frame(), spans, "daemon refused", "in 1h")
+})
+
+test("automations: a failed toggle shows an error toast", async () => {
+  const orch = {
+    listAutomations: async () => ({ automations: [AUTOMATION], keepsDaemonAlive: true }),
+    automationRuns: async () => ({ runs: [] }),
+    listTasks: () => [{ repo: "/x/kobe" }],
+    setAutomationEnabled: async () => {
+      throw new Error("daemon refused")
+    },
+  } as never
+  const { frame, spans, mockInput } = await renderComponent(
+    <>
+      <AutomationsPage orchestrator={orch} focused={true} onClose={() => {}} />
+      <ToastOverlay />
+    </>,
+    { width: 90, height: 22, providers: { dialog: true, notifications: true } },
+  )
+  await settle(150)
+  mockInput.typeText("e")
+  await settle(150)
+  await expectErrorToast(await frame(), spans, "daemon refused", "in 1h")
+})
+
+const WORK_ITEM = {
+  number: 42,
+  title: "Fix the thing",
+  author: "octocat",
+  labels: ["bug", "p2"],
+  updatedAt: new Date().toISOString(),
+}
+
+function workItemsOrch(over: Record<string, unknown> = {}) {
+  return {
+    listTasks: () => [{ repo: "/x/kobe" }],
+    listWorkItems: async () => ({ items: [WORK_ITEM] }),
+    ...over,
+  } as never
+}
+
+test("work-items: a failed start shows an error toast instead of a muted line", async () => {
+  const orch = workItemsOrch({
+    startWorkItem: async () => {
+      throw new Error("gh CLI missing")
+    },
+  })
+  const { frame, spans, mockInput } = await renderComponent(
+    <>
+      <WorkItemsPage orchestrator={orch} focused={true} onClose={() => {}} />
+      <ToastOverlay />
+    </>,
+    { width: 90, height: 20, providers: { notifications: true } },
+  )
+  await settle(150)
+  mockInput.pressEnter()
+  await settle(150)
+  // Muted reference: the repo label in the header renders `textMuted`; the
+  // toast title must not share that color.
+  await expectErrorToast(await frame(), spans, "Couldn't start work on #42", "kobe")
+})
+
+test("work-items: the muted inline line stays for non-failure progress", async () => {
+  // The notice mechanism survives for status text — "starting" renders as the
+  // quiet inline line, not an error toast.
+  let resolveStart: ((value: { started: boolean; taskId: string; title: string }) => void) | undefined
+  const orch = workItemsOrch({
+    startWorkItem: () =>
+      new Promise((resolve) => {
+        resolveStart = resolve
+      }),
+  })
+  const { frame, mockInput } = await renderComponent(
+    <>
+      <WorkItemsPage orchestrator={orch} focused={true} onClose={() => {}} />
+      <ToastOverlay />
+    </>,
+    { width: 90, height: 20, providers: { notifications: true } },
+  )
+  await settle(150)
+  mockInput.pressEnter()
+  await settle(150)
+  const text = await frame()
+  expect(text).toContain("Starting work on #42")
+  expect(text).not.toContain("✕")
+  resolveStart?.({ started: true, taskId: "T1", title: "Fix the thing" })
+  await settle(150)
+})
+
+test("work-items: a started item opens its task", async () => {
+  let opened: string | undefined
+  const orch = workItemsOrch({
+    startWorkItem: async () => ({ started: true, taskId: "T9", title: "Fix the thing" }),
+  })
+  const { mockInput } = await renderComponent(
+    <WorkItemsPage
+      orchestrator={orch}
+      focused={true}
+      onClose={() => {}}
+      onOpenTask={(id) => {
+        opened = id
+      }}
+    />,
+    { width: 90, height: 20, providers: { notifications: true } },
+  )
+  await settle(150)
+  mockInput.pressEnter()
+  await settle(200)
+  expect(opened).toBe("T9")
+})
+
+test("work-items: an item whose engine did not start says so inline", async () => {
+  const orch = workItemsOrch({
+    startWorkItem: async () => ({ started: false, taskId: "T9", title: "Fix the thing" }),
+  })
+  const { frame, mockInput } = await renderComponent(
+    <WorkItemsPage orchestrator={orch} focused={true} onClose={() => {}} />,
+    { width: 90, height: 20, providers: { notifications: true } },
+  )
+  await settle(150)
+  mockInput.pressEnter()
+  await settle(200)
+  expect(await frame()).toContain("its engine did not start")
+})
+
+test("work-items: list rows render with number, labels, and age", async () => {
+  const { frame } = await renderComponent(
+    <WorkItemsPage orchestrator={workItemsOrch()} focused={true} onClose={() => {}} />,
+    { width: 90, height: 20, providers: { notifications: true } },
+  )
+  await settle(150)
+  const text = await frame()
+  expect(text).toContain("#42")
+  expect(text).toContain("Fix the thing")
+  expect(text).toContain("octocat · bug · p2")
+  expect(text).toContain("0m")
+})
+
+test("work-items: a failed list names the fix inline", async () => {
+  const orch = workItemsOrch({
+    listWorkItems: async () => {
+      throw new Error("no-remote: origin is not a GitHub remote")
+    },
+  })
+  const { frame } = await renderComponent(<WorkItemsPage orchestrator={orch} focused={true} onClose={() => {}} />, {
+    width: 90,
+    height: 20,
+    providers: { notifications: true },
+  })
+  await settle(200)
+  const text = await frame()
+  expect(text).toContain("no-remote: origin is not a GitHub remote")
+  expect(text).toContain("git remote add origin")
+})
+
+test("work-items: no issues renders the empty state", async () => {
+  const orch = workItemsOrch({ listWorkItems: async () => ({ items: [] }) })
+  const { frame } = await renderComponent(<WorkItemsPage orchestrator={orch} focused={true} onClose={() => {}} />, {
+    width: 90,
+    height: 20,
+    providers: { notifications: true },
+  })
+  await settle(150)
+  expect(await frame()).toContain("No open issues.")
+})

--- a/packages/kobe/test/render/host-pages.test.tsx
+++ b/packages/kobe/test/render/host-pages.test.tsx
@@ -118,7 +118,7 @@ test("renderContentPage returns null when no content page is open", async () => 
   const { frame } = await renderComponent(<box>{renderContentPage(deps({}))}</box>, {
     width: 80,
     height: 24,
-    providers: { dialog: true },
+    providers: { dialog: true, notifications: true },
   })
   await settle()
   expect(await frame()).not.toContain("ROUTINES")
@@ -130,7 +130,7 @@ test("renderContentPage renders AutomationsPage with focus repo", async () => {
     {
       width: 70,
       height: 16,
-      providers: { dialog: true },
+      providers: { dialog: true, notifications: true },
     },
   )
   await settle()
@@ -143,7 +143,7 @@ test("renderContentPage renders WorkItemsPage with a selected task repo", async 
     {
       width: 80,
       height: 24,
-      providers: { dialog: true },
+      providers: { dialog: true, notifications: true },
     },
   )
   await settle()
@@ -167,7 +167,7 @@ test("renderContentPage renders AutomationsPage without a selected task", async 
   const { frame } = await renderComponent(<box>{renderContentPage(deps({ automationsOpen: true }))}</box>, {
     width: 70,
     height: 16,
-    providers: { dialog: true },
+    providers: { dialog: true, notifications: true },
   })
   await settle()
   expect(await frame()).toContain("ROUTINES")
@@ -177,7 +177,7 @@ test("renderContentPage renders WorkItemsPage without a selected task", async ()
   const { frame } = await renderComponent(<box>{renderContentPage(deps({ workItemsOpen: true }))}</box>, {
     width: 80,
     height: 24,
-    providers: { dialog: true },
+    providers: { dialog: true, notifications: true },
   })
   await settle()
   expect(await frame()).toContain("ISSUES")
@@ -300,7 +300,7 @@ test("useHostPagesRender surfaces the settings page", async () => {
   const { frame } = await renderComponent(<RenderHarness width={80} initial={(pages) => pages.openSettings()} />, {
     width: 80,
     height: 24,
-    providers: { dialog: true },
+    providers: { dialog: true, notifications: true },
   })
   await settle()
   expect(await frame()).toContain("Settings")


### PR DESCRIPTION
## Problem

「操作失败但用户看不见」— three pages reported failed mutations in ways users could not see:

- **Kanban** — issue create/delete failure went to `console.error` only. Under the alternate screen that reaches the daemon log, never the screen: the user pressed `d`, confirmed, the RPC failed, and the card just stayed with no explanation (`kanban-page.tsx`).
- **Routines (automations)** — create/delete/toggle/run-now failures rendered as a `textMuted` inline line, which reads as a hint, not a failure. Sibling pages (worktrees) use `notif.notify({ kind: "error" })` for the same class of failure.
- **GitHub issues (work-items)** — a failed "start work" did the same muted-line thing.

The correct pattern was already established in `host-task-actions.ts` / `worktrees-page.tsx`: console.error **plus** an on-screen error toast.

## Fix

All three pages now route mutation failures through the shared toast queue (`notif.notify({ kind: "error", ... })`), which shows a red-accent toast even when toasts are disabled. The `console.error` line stays for forensics. The muted inline `notice` line is kept where it is appropriate — non-failure status ("Running X…", "Starting work on #N…") — errors no longer use it.

Judgment calls:

- `setNotice` survives deliberately; only its error usage was moved. One test pins that progress text still renders inline without a toast.
- `kanban-page.tsx` was at 492 lines and this change pushed it over the 500 cap; comment blocks were tightened (same information) to bring it back to exactly 500.
- Out of scope, flagged for follow-up: the best-effort dirty-patch save in `openDetail` (`kanban-page.tsx`) is still log-only on failure — it is deliberately non-blocking by design, so a different UX call than the three fixed paths.

## Verification

- **Render tests** (`test/render/failure-toast.test.tsx`, 11 tests): mount the REAL page + REAL `ToastOverlay`, drive REAL keys (down/`d`/enter, `e`, return, `n`/type/ctrl+s) against a rejecting orchestrator mock, assert the "✕" toast glyph and message painted on the real frame — plus a span-color assertion that the failure is not rendered in the muted `textMuted` color the old notice used.
- **Red check**: reverting the source fix makes the 5 failure tests fail, ran twice, deterministic.
- Existing render suites updated for the new `useNotifications` requirement (`automations-page-keys`, `host-pages`).
- Full gates: lint, typecheck, `test:fast` (3658), `test:socket` (604), `test/render` (251), build + `test:behavior` (24) — all green.

### Before / after (real failure, browser `/harness` → xterm.js → PTY sidecar → real OpenTUI)

Failure injected for real: the fixture daemon's issues store made unwritable (`chmod 555` on its state dir) so the delete RPC returns `EACCES`.

- Before — card stays, zero indication of the failure: `.scratch/failure-toast-shots/before-delete-fails-invisible.png`
- After — red error toast, card correctly stays: `.scratch/failure-toast-shots/after-delete-fails-toast.png`
- Confirm dialog shown for completeness: `.scratch/failure-toast-shots/before-confirm-dialog.png`, `after-confirm-dialog.png`
