### PR TITLE
fix: retire archive from the agent skill and point its rejection at delete

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 34 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 35 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -286,7 +286,13 @@ command, or content tab alone does not count.
 Omitting BOTH `--task-id` and `--tab` inside a task that has a dispatcher
 targets that dispatcher's tab (see the reply rule above); otherwise the
 target is the active task. Omitting only `--tab` targets a live engine tab
-(`tab-1` first, then any surviving engine tab). Only when the task has NO live session at all does `send`
+(`tab-1` first, then any surviving engine tab). **Trap: omitting only
+`--task-id` while giving `--tab tab-N` inside a dispatched task delivers to
+`tab-N` of the DISPATCHER's task** — the dispatcher's id fills in for
+`--task-id`, but an explicit `--tab` is kept, so your `send --tab tab-3`
+lands in the middle of another session's tab-3, not yours. Target your own
+task's tab with `--task-id "$ROVE_TASK_ID" --tab tab-N`. Only when the task
+has NO live session at all does `send`
 auto-start the canonical engine in the task's worktree (`started: true` in
 the result marks that fresh session). If live tabs exist but none resolves
 as an engine, it refuses with `NO_ENGINE_TAB` — address one with `--tab
@@ -330,18 +336,19 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `set-branch --task-id ID --branch B` | Rename its branch |
 | `set-command --task-id ID --command CMD` | Change the engine launch command for the next launch |
 | `set-status --task-id ID --status S` | Set lifecycle status |
-| `archive --task-id ID [--archived=false]` | Archive/unarchive; stops live sessions |
 | `pin --task-id ID [--pinned=false]` | Pin/unpin |
 | `set-active --task-id ID` / `--none` | Change shared active task |
 | `ensure-worktree --task-id ID` | Materialize without starting an engine |
-| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--then-archive] [--remove-worktree=false]` | Merge the task's branch into the base repo's current branch; the Worktree is removed by default (`--remove-worktree=false` keeps it). The branch always stays; dirty/self/base removals are refused, outcome in the result's `worktree` field |
+| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--remove-worktree=false]` | Merge the task's branch into the base repo's current branch; the Worktree is removed by default (`--remove-worktree=false` keeps it). The branch always stays; dirty/self/base removals are refused, outcome in the result's `worktree` field |
 | `delete --task-id ID [--force] [--delete-branch]` | Remove task + Worktree; the git branch stays unless `--delete-branch` (and `--force` never implies it) |
 | `discover-adoptable --repo PATH` | Find untracked Worktrees |
 | `adopt --repo PATH --worktree PATH` | Import a Worktree |
 
 Once a task's work is merged, `delete` is the normal cleanup — the branch is
-git's durable record and survives. `archive` remains as a manual "hide the
-row" override. `--delete-branch` (or a dirty-worktree `--force`) still needs
+git's durable record and survives. There is no "hide the row without
+deleting" verb anymore (`archive` was removed); a merged task you want out of
+the way is a `delete`, and its branch is still there if you need the history
+back. `--delete-branch` (or a dirty-worktree `--force`) still needs
 explicit user authorization.
 
 ## Issue tracker
@@ -450,15 +457,17 @@ After comparing attempts, finish the round instead of leaving tasks behind:
 ```bash
 # Land the winner: merge its branch into the base repo's CURRENT branch.
 # Verify the base checkout is on the intended branch first.
-rove api land --task-id <winner> --then-archive
+rove api land --task-id <winner>
 
-# Archive the losers (non-destructive; branches survive).
-rove api archive --task-id <loser1>
-rove api archive --task-id <loser2>
+# Delete the losers: task + worktree go away, the git branch survives
+# (recoverable). NOT --delete-branch — that destroys history and needs
+# explicit user authorization.
+rove api delete --task-id <loser1>
+rove api delete --task-id <loser2>
 ```
 
 `land` refuses a dirty base checkout; on merge conflict it aborts cleanly and
-returns the conflicted files for manual resolution. `delete` removes a loser's
-Worktree but keeps its branch (recoverable); still don't use it — or
-`--delete-branch`, which destroys the history — without explicit user
-authorization.
+returns the conflicted files for manual resolution. `delete` removes a
+loser's Worktree but keeps its branch (recoverable); `--delete-branch`
+destroys the history and is never part of closing a round without explicit
+user authorization.

--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -41,6 +41,7 @@ Four flag names that have actually been guessed wrong here, and what they are:
 
 | Gone | Now |
 |---|---|
+| `archive` | `delete` (task + worktree go; the git branch survives unless `--delete-branch`) |
 | `fan-out` | `add --count N` / `add --agents claude:2,codex:1` |
 | `task-list` | `list` |
 | `send-tab` | `send --tab tab-N` |
@@ -52,7 +53,7 @@ Seeing one of these in guidance means that guidance predates the rename —
 ## read
 
 ```text
-list          (none)                     every task, archived included
+list          (none)                     every task
 get-task      --task-id(REQ)             one task + .tabs[] — the read before `send --tab`
 collect       --task-ids <csv> --repo    comparison snapshot across tasks
 inspect       --task-id                  daemon activity + pty walk + tab snapshots
@@ -113,9 +114,8 @@ rename         --task-id(REQ) --title(REQ)
 set-branch     --task-id(REQ) --branch(REQ)
 set-command    --task-id(REQ) --command(REQ)      next launch only
 set-status     --task-id(REQ) --status(REQ)[backlog|in_progress|in_review|done|canceled|error]
-archive        --task-id(REQ) --archived(true)
 pin            --task-id(REQ) --pinned(true)
-land           --task-id(REQ) --strategy[merge|squash] --delete-branch --then-archive --remove-worktree(true)
+land           --task-id(REQ) --strategy[merge|squash] --delete-branch --remove-worktree(true)
 delete         --task-id(REQ) --force --delete-branch
 ```
 

--- a/.changeset/rude-pandas-retire.md
+++ b/.changeset/rude-pandas-retire.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Teach the agent skill the verbs that actually exist
+
+The bundled agent skill still taught `archive` (removed with issue #75) and a
+`land --then-archive` flag that never existed, so an agent closing a parallel
+round hit `BAD_VERB`/`BAD_FLAG` with no useful pointer. `archive` is now a
+retired verb whose rejection names `delete` and says the branch survives, the
+skill's closing-a-round example uses `delete` for losers, and the `send --tab`
+docs warn that an explicit `--tab` without `--task-id` inside a dispatched
+task delivers to that tab on the *dispatcher*'s task.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 34 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 35 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -286,7 +286,13 @@ command, or content tab alone does not count.
 Omitting BOTH `--task-id` and `--tab` inside a task that has a dispatcher
 targets that dispatcher's tab (see the reply rule above); otherwise the
 target is the active task. Omitting only `--tab` targets a live engine tab
-(`tab-1` first, then any surviving engine tab). Only when the task has NO live session at all does `send`
+(`tab-1` first, then any surviving engine tab). **Trap: omitting only
+`--task-id` while giving `--tab tab-N` inside a dispatched task delivers to
+`tab-N` of the DISPATCHER's task** — the dispatcher's id fills in for
+`--task-id`, but an explicit `--tab` is kept, so your `send --tab tab-3`
+lands in the middle of another session's tab-3, not yours. Target your own
+task's tab with `--task-id "$ROVE_TASK_ID" --tab tab-N`. Only when the task
+has NO live session at all does `send`
 auto-start the canonical engine in the task's worktree (`started: true` in
 the result marks that fresh session). If live tabs exist but none resolves
 as an engine, it refuses with `NO_ENGINE_TAB` — address one with `--tab
@@ -330,18 +336,19 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `set-branch --task-id ID --branch B` | Rename its branch |
 | `set-command --task-id ID --command CMD` | Change the engine launch command for the next launch |
 | `set-status --task-id ID --status S` | Set lifecycle status |
-| `archive --task-id ID [--archived=false]` | Archive/unarchive; stops live sessions |
 | `pin --task-id ID [--pinned=false]` | Pin/unpin |
 | `set-active --task-id ID` / `--none` | Change shared active task |
 | `ensure-worktree --task-id ID` | Materialize without starting an engine |
-| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--then-archive] [--remove-worktree=false]` | Merge the task's branch into the base repo's current branch; the Worktree is removed by default (`--remove-worktree=false` keeps it). The branch always stays; dirty/self/base removals are refused, outcome in the result's `worktree` field |
+| `land --task-id ID [--strategy merge\|squash] [--delete-branch] [--remove-worktree=false]` | Merge the task's branch into the base repo's current branch; the Worktree is removed by default (`--remove-worktree=false` keeps it). The branch always stays; dirty/self/base removals are refused, outcome in the result's `worktree` field |
 | `delete --task-id ID [--force] [--delete-branch]` | Remove task + Worktree; the git branch stays unless `--delete-branch` (and `--force` never implies it) |
 | `discover-adoptable --repo PATH` | Find untracked Worktrees |
 | `adopt --repo PATH --worktree PATH` | Import a Worktree |
 
 Once a task's work is merged, `delete` is the normal cleanup — the branch is
-git's durable record and survives. `archive` remains as a manual "hide the
-row" override. `--delete-branch` (or a dirty-worktree `--force`) still needs
+git's durable record and survives. There is no "hide the row without
+deleting" verb anymore (`archive` was removed); a merged task you want out of
+the way is a `delete`, and its branch is still there if you need the history
+back. `--delete-branch` (or a dirty-worktree `--force`) still needs
 explicit user authorization.
 
 ## Issue tracker
@@ -450,15 +457,17 @@ After comparing attempts, finish the round instead of leaving tasks behind:
 ```bash
 # Land the winner: merge its branch into the base repo's CURRENT branch.
 # Verify the base checkout is on the intended branch first.
-rove api land --task-id <winner> --then-archive
+rove api land --task-id <winner>
 
-# Archive the losers (non-destructive; branches survive).
-rove api archive --task-id <loser1>
-rove api archive --task-id <loser2>
+# Delete the losers: task + worktree go away, the git branch survives
+# (recoverable). NOT --delete-branch — that destroys history and needs
+# explicit user authorization.
+rove api delete --task-id <loser1>
+rove api delete --task-id <loser2>
 ```
 
 `land` refuses a dirty base checkout; on merge conflict it aborts cleanly and
-returns the conflicted files for manual resolution. `delete` removes a loser's
-Worktree but keeps its branch (recoverable); still don't use it — or
-`--delete-branch`, which destroys the history — without explicit user
-authorization.
+returns the conflicted files for manual resolution. `delete` removes a
+loser's Worktree but keeps its branch (recoverable); `--delete-branch`
+destroys the history and is never part of closing a round without explicit
+user authorization.

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -41,6 +41,7 @@ Four flag names that have actually been guessed wrong here, and what they are:
 
 | Gone | Now |
 |---|---|
+| `archive` | `delete` (task + worktree go; the git branch survives unless `--delete-branch`) |
 | `fan-out` | `add --count N` / `add --agents claude:2,codex:1` |
 | `task-list` | `list` |
 | `send-tab` | `send --tab tab-N` |
@@ -52,7 +53,7 @@ Seeing one of these in guidance means that guidance predates the rename —
 ## read
 
 ```text
-list          (none)                     every task, archived included
+list          (none)                     every task
 get-task      --task-id(REQ)             one task + .tabs[] — the read before `send --tab`
 collect       --task-ids <csv> --repo    comparison snapshot across tasks
 inspect       --task-id                  daemon activity + pty walk + tab snapshots
@@ -113,9 +114,8 @@ rename         --task-id(REQ) --title(REQ)
 set-branch     --task-id(REQ) --branch(REQ)
 set-command    --task-id(REQ) --command(REQ)      next launch only
 set-status     --task-id(REQ) --status(REQ)[backlog|in_progress|in_review|done|canceled|error]
-archive        --task-id(REQ) --archived(true)
 pin            --task-id(REQ) --pinned(true)
-land           --task-id(REQ) --strategy[merge|squash] --delete-branch --then-archive --remove-worktree(true)
+land           --task-id(REQ) --strategy[merge|squash] --delete-branch --remove-worktree(true)
 delete         --task-id(REQ) --force --delete-branch
 ```
 

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -59,7 +59,9 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = { "spawn-task": "a
  * Deliberately not aliases: `fan-out` folded into `add --count` and
  * `set-vendor` became `set-command`, and both changed their flag contract in
  * the process — an alias would silently accept the old flags and do
- * something subtly different. A retired verb instead fails loud with
+ * something subtly different. `archive` (issue #75) had no successor hiding
+ * state — its replacement is the destructive-but-recoverable `delete`. A
+ * retired verb instead fails loud with
  * `UNKNOWN_VERB` plus the `nextCommandArgs` an agent can run verbatim, which
  * is the same self-healing contract every other high-traffic rejection uses.
  */
@@ -71,6 +73,13 @@ export const RETIRED_VERBS: Readonly<Record<string, { hint: string; nextCommandA
   "set-vendor": {
     hint: "set-vendor was replaced by `set-command`, which takes the engine's raw launch command (an engine id from `engine-list`, or a full command line)",
     nextCommandArgs: ["api", "set-command", "--help"],
+  },
+  // `archive` went away with the archived-task dimension itself (issue #75) —
+  // there is no "hide but keep" left; `delete` is the cleanup, and its branch
+  // always survives unless the caller explicitly passes --delete-branch.
+  archive: {
+    hint: "archive was removed: there is no hide-without-delete anymore — use `delete` to remove a finished task and its worktree; the git branch survives (pass --delete-branch explicitly only when the history may go)",
+    nextCommandArgs: ["api", "delete", "--help"],
   },
 }
 

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -44,7 +44,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
  */
-export const KOBE_SKILL_VERSION = 34
+export const KOBE_SKILL_VERSION = 35
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -111,6 +111,10 @@ describe("schema drill-ins", () => {
     it.each([
       ["fan-out", ["api", "add", "--help"], /--count/],
       ["set-vendor", ["api", "set-command", "--help"], /set-command/],
+      // archive died with issue #75; the rejection must point at delete AND
+      // say the branch survives — a coordinator closing a round should not
+      // have to guess between delete and --delete-branch.
+      ["archive", ["api", "delete", "--help"], /branch.*survives/s],
     ])("%s fails with UNKNOWN_VERB and the replacement command", async (verb, nextArgs, hintPattern) => {
       const err = await rejectionOf(verb)
       expect(err.code).toBe("UNKNOWN_VERB")


### PR DESCRIPTION
## What

The bundled agent skill (`SKILL.md`, loaded by every agent session) drifted from the real `rove api` surface:

- It taught `archive` (removed with issue #75) in the lifecycle table, prose, and the "closing a round" example — but `archive` was not in `RETIRED_VERBS`, so an agent hitting it got only a generic unknown-verb dump at the exact moment it is trying to finish a parallel round.
- It taught `land --then-archive`, a flag that never existed (`BAD_FLAG`, exit 2) — on the single most-copied command in the skill.
- `references/api-flags.md` claimed `list` returns "every task, archived included" for an archived dimension that no longer exists.
- The `send --tab` docs never mentioned the trap that inside a dispatched task, omitting `--task-id` while passing an explicit `--tab tab-N` delivers to `tab-N` on the **dispatcher task** (handlers-tasks.ts keeps `--tab` and fills in the dispatcher's id), i.e. into the middle of another agent's session.

## Changes

- `archive` added to `RETIRED_VERBS` (`verbs.ts`), pointing at `delete --help`, with a hint that states the branch survives unless `--delete-branch`. Real run verified: `rove api archive --task-id x` → `UNKNOWN_VERB`, exit 2, hint + `nextCommandArgs` present.
- Skill docs (both byte-identical mirrors, version 34 → 35 in lockstep with `KOBE_SKILL_VERSION`): removed every `archive` / `--then-archive` mention; added `archive → delete` to the retired table in `api-flags.md`; added the dispatcher-`--tab` trap warning.
- Test: `archive` added to the existing retired-verbs table-driven test, asserting the rejection points at `delete` and says the branch survives. Verified red by temporarily removing the fix.

## Semantic gap (stated, not papered over)

There is no "hide the row but keep everything" verb anymore. The closing-a-round example now uses `delete` for losers (worktree removed, **branch kept** — recoverable via git). An agent that wants a merged task out of the sidebar without losing the worktree has no verb for it; `set-status done` marks it finished but does not hide it. That is a product decision left to the owner, not something this PR invents.

## Test plan

- `vitest run test/cli` (794 passed), `test/lib`, `test/architecture/claude-plugin.test.ts` (byte-identity mirror pinned) — note: tests must run without `ROVE_INVOKED_AS=rove` in env, it flips CLI name expectations in `skill-cmd.test.ts`.
- Real binary: `bun run src/cli/index.ts api archive --task-id x` shows the new UNKNOWN_VERB rejection.
