### PR TITLE
fix: surface daemon disconnection instead of rendering stale state as live

### DIFF
--- a/.changeset/daemon-disconnect-visibility.md
+++ b/.changeset/daemon-disconnect-visibility.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Show when the daemon has disconnected instead of rendering the last snapshot as live.
+
+The client already knew: `connectionStateSignal` flips to `disconnected` the moment the socket closes, and it had no production readers — only tests. Every page swallowed its own failed read and kept painting the last good state, so a dead daemon rendered as a healthy routine list counting down to a run that would never fire, and the Routines page asserted "keeping the daemon awake" in green about a process that was gone. A red banner now sits above every workspace surface while the socket is down, and the Routines header reads "daemon unreachable" instead of the stale hold state.
+
+The update page had the same shape from a different cause: a failed registry fetch fell back to the current version and painted it green, so "could not reach npm" and "you are up to date" were the same pixels. It now says the check failed.

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -24,6 +24,7 @@ import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
+import { useDaemonDown } from "../lib/use-accessor"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
 import { AutomationComposer } from "./automation-composer-dialog"
@@ -108,7 +109,11 @@ export function AutomationsPage(props: {
           setKeepsDaemonAlive(result.keepsDaemonAlive)
         })
         .catch(() => {
-          // A failed read leaves the previous rows rather than crashing the page.
+          // A failed read leaves the previous rows rather than crashing the
+          // page. Keeping them IS not calling setState, so there is nothing to
+          // do here — the empty array only covers the very first load, which
+          // has no rows to keep. What the failure means for those rows is the
+          // daemon-down banner's job (`useDaemonDown`), not a per-page catch.
           if (!disposed) setAutomations((prev) => prev ?? [])
         })
     }
@@ -260,6 +265,11 @@ export function AutomationsPage(props: {
   }))
 
   const now = Date.now()
+  // `keepsDaemonAlive` came off the last successful read. With the socket
+  // down it is a claim about a process that is not answering — rendered in
+  // `theme.success` green, it asserted "holding daemon" about a daemon that
+  // was gone. The daemon being down is the more specific fact, so it wins.
+  const daemonDown = useDaemonDown(props.orchestrator)
 
   return (
     <box flexDirection="column" flexGrow={1} paddingTop={1} paddingLeft={2} paddingRight={2}>
@@ -272,8 +282,16 @@ export function AutomationsPage(props: {
         <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
           {"─".repeat(240)}
         </text>
-        <text fg={keepsDaemonAlive ? theme.success : theme.textMuted} wrapMode="none" flexShrink={0}>
-          {keepsDaemonAlive ? t("automations.holdingDaemon") : t("automations.notHolding")}
+        <text
+          fg={daemonDown ? theme.error : keepsDaemonAlive ? theme.success : theme.textMuted}
+          wrapMode="none"
+          flexShrink={0}
+        >
+          {daemonDown
+            ? t("automations.daemonUnreachable")
+            : keepsDaemonAlive
+              ? t("automations.holdingDaemon")
+              : t("automations.notHolding")}
         </text>
       </box>
 

--- a/packages/kobe/src/tui-react/component/update-page.tsx
+++ b/packages/kobe/src/tui-react/component/update-page.tsx
@@ -46,12 +46,22 @@ export function UpdatePage(props: { onClose: () => void }) {
   const t = useT()
   const renderer = useRenderer()
   const [info, setInfo] = useState<UpdateInfo | null>(null)
+  /**
+   * Whether the registry check ANSWERED — distinct from what it answered.
+   * `checkLatestVersion` returns null both when the fetch fails (offline, npm
+   * down, timeout) and when it is suppressed, so `info === null` alone could
+   * not tell "we could not look" from "you are up to date". It rendered the
+   * failure as a GREEN latest = CURRENT_VERSION: an affirmative claim built
+   * out of a network error.
+   */
+  const [checked, setChecked] = useState(false)
   const [releaseNotes, setReleaseNotes] = useState<ReleaseNotesRangeItem[]>([])
   const [loadingNotes, setLoadingNotes] = useState(true)
   const [selected, setSelected] = useState<ActionId>("update")
   const [status, setStatus] = useState<string | null>(null)
 
   const latest = info?.latest ?? CURRENT_VERSION
+  const latestUnknown = checked && info === null
   const releaseUrl = releaseNotes[0]?.url ?? releasePageUrl(latest)
   const actions: ReadonlyArray<{ id: ActionId; key: string; label: string; detail: string }> = [
     { id: "update", key: "U", label: t("update.actions.updateNow"), detail: UPDATE_COMMAND },
@@ -70,8 +80,14 @@ export function UpdatePage(props: { onClose: () => void }) {
   }, [])
 
   async function load(): Promise<void> {
+    // `checkLatestVersion` swallows its own fetch errors and answers null, so
+    // there is nothing to catch here — `checked` is what turns that null into
+    // a stated "could not reach the registry" instead of a silent fallback to
+    // the current version. `fetchReleaseNotesRange` is equally total (it
+    // answers []), and the notes section already says so.
     const next = await checkLatestVersion({ force: true })
     setInfo(next)
+    setChecked(true)
     const latestVersion = next?.latest ?? CURRENT_VERSION
     const fetched = await fetchReleaseNotesRange({ current: CURRENT_VERSION, latest: latestVersion })
     setReleaseNotes(fetched)
@@ -144,9 +160,18 @@ export function UpdatePage(props: { onClose: () => void }) {
         <text fg={theme.textMuted} wrapMode="none">
           {t("update.latest")}
         </text>
-        <text fg={info?.hasUpdate ? theme.warning : theme.success} attributes={TextAttributes.BOLD} wrapMode="none">
-          v{latest}
-        </text>
+        {/* A failed lookup must not read as "you are up to date": those two
+            used to be the same green `v{latest}` pixels. Muted prose instead
+            of a version number, since there IS no known latest version. */}
+        {latestUnknown ? (
+          <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none">
+            {t("update.latestUnknown")}
+          </text>
+        ) : (
+          <text fg={info?.hasUpdate ? theme.warning : theme.success} attributes={TextAttributes.BOLD} wrapMode="none">
+            v{latest}
+          </text>
+        )}
       </box>
 
       <box flexDirection="column" flexShrink={0} paddingTop={1} gap={0}>

--- a/packages/kobe/src/tui-react/component/version-skew-banner.tsx
+++ b/packages/kobe/src/tui-react/component/version-skew-banner.tsx
@@ -1,17 +1,95 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Daemon build-version skew banner (React port of
- * `src/tui/component/version-skew-banner.tsx`, issue #15 G3). The visible,
- * NON-fatal signal that the running daemon is an older build than this
- * process: a thin full-width top strip (amber accent rule + BOLD CAPS
- * label + action hint) that auto-hides once the daemon matches again.
- * Theme tokens only, engine-neutral copy — full rationale in the Solid
- * header. React canon: props are plain values, not Accessors.
+ * The workspace's two top-of-window daemon banners, and the strip they share.
+ *
+ * Both are a thin full-width strip (accent rule + BOLD CAPS label + one-line
+ * action hint) that auto-hides once the condition clears. They differ in
+ * severity and in what they mean for what is on screen:
+ *
+ *   - {@link VersionSkewBanner} — amber. The daemon answers fine, it is just
+ *     an older BUILD than this process (React port of
+ *     `src/tui/component/version-skew-banner.tsx`, issue #15 G3).
+ *   - {@link DaemonDownBanner} — red. The socket is DOWN, so every daemon-fed
+ *     surface on screen is a photograph of the last good snapshot.
+ *
+ * Theme tokens only, engine-neutral copy. React canon: props are plain
+ * values, not Accessors.
  */
 
 import { TextAttributes } from "@opentui/core"
+import type { RGBA } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
+
+/**
+ * The strip both banners are: an accent rule, a BOLD CAPS label, one line of
+ * action hint. Extracted when the daemon-disconnect banner needed the exact
+ * same shape — two hand-copied versions would drift the moment either got a
+ * padding tweak.
+ */
+function BannerStrip(props: { tone: RGBA; title: string; hint: string; width: number }) {
+  const { theme } = useTheme()
+  // Accent rule spans the strip, clamped to the pane width minus the 1-cell
+  // selection gutter; a small floor keeps it visible on a very narrow pane.
+  const ruleWidth = Math.max(4, props.width - 2)
+  return (
+    // flexShrink={0} so the strip never gets squeezed away; it owns its own
+    // rows at the very top of the pane.
+    <box flexDirection="column" flexShrink={0} paddingLeft={1} paddingRight={1} paddingBottom={1}>
+      {/* The accent rule — a bar of `▔` (upper block) so it reads as a thin
+          rule above the message, not a heavy fill. */}
+      <text fg={props.tone} wrapMode="none">
+        {"▔".repeat(ruleWidth)}
+      </text>
+      <box flexDirection="row" gap={1}>
+        <text fg={props.tone} attributes={TextAttributes.BOLD} wrapMode="none">
+          {props.title}
+        </text>
+      </box>
+      <box flexDirection="row" gap={1}>
+        <text fg={theme.text} wrapMode="word">
+          {props.hint}
+        </text>
+      </box>
+    </box>
+  )
+}
+
+export type DaemonDownBannerProps = {
+  /** True while the daemon socket is DOWN (`connectionStateSignal`). */
+  down: boolean
+  /** Available width (cells) so the accent rule fills the strip. */
+  width: number
+}
+
+/**
+ * Daemon-disconnect banner — the ONE consumer of
+ * `RemoteOrchestrator.connectionStateSignal()`.
+ *
+ * The signal was accurate and immediate from the day it was written and had
+ * zero production readers: every page swallowed its own failed read and kept
+ * painting the last good snapshot, so a dead daemon rendered as a healthy
+ * schedule with a "fires in 12 minutes" countdown. One banner at the top of
+ * the workspace answers that for every page at once, which is why the fix is
+ * NOT a catch block per page — the next page would omit it again.
+ *
+ * Scoped to DISCONNECTED, not to "a read failed". A single failed RPC against
+ * a live daemon is a transient the reconnect path never sees; only the socket
+ * being down means everything on screen is a photograph.
+ */
+export function DaemonDownBanner(props: DaemonDownBannerProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  if (!props.down) return null
+  return (
+    <BannerStrip
+      tone={theme.error}
+      title={t("workspace.daemonDown.title")}
+      hint={t("workspace.daemonDown.hint")}
+      width={props.width}
+    />
+  )
+}
 
 export type VersionSkewBannerProps = {
   /** True when the daemon is running a different build than this process. */
@@ -31,29 +109,12 @@ export function VersionSkewBanner(props: VersionSkewBannerProps) {
   // One-line action hint: terse + actionable, naming both versions and the
   // two commands that fix it (same copy as the Solid `versionSkewHint`).
   const daemon = props.daemonVersion ? `v${props.daemonVersion}` : t("update.skew.olderBuild")
-  const hint = t("update.skew.hint", { daemon, clientVersion: props.clientVersion })
-  // Accent rule spans the strip, clamped to the pane width minus the 1-cell
-  // selection gutter; a small floor keeps it visible on a very narrow pane.
-  const ruleWidth = Math.max(4, props.width - 2)
   return (
-    // flexShrink={0} so the strip never gets squeezed away; it owns its own
-    // rows at the very top of the pane.
-    <box flexDirection="column" flexShrink={0} paddingLeft={1} paddingRight={1} paddingBottom={1}>
-      {/* The amber accent rule — a warning-toned bar of `▔` (upper block)
-          so it reads as a thin rule above the message, not a heavy fill. */}
-      <text fg={theme.warning} wrapMode="none">
-        {"▔".repeat(ruleWidth)}
-      </text>
-      <box flexDirection="row" gap={1}>
-        <text fg={theme.warning} attributes={TextAttributes.BOLD} wrapMode="none">
-          {t("update.skew.title")}
-        </text>
-      </box>
-      <box flexDirection="row" gap={1}>
-        <text fg={theme.text} wrapMode="word">
-          {hint}
-        </text>
-      </box>
-    </box>
+    <BannerStrip
+      tone={theme.warning}
+      title={t("update.skew.title")}
+      hint={t("update.skew.hint", { daemon, clientVersion: props.clientVersion })}
+      width={props.width}
+    />
   )
 }

--- a/packages/kobe/src/tui-react/lib/use-accessor.ts
+++ b/packages/kobe/src/tui-react/lib/use-accessor.ts
@@ -1,8 +1,26 @@
 /** React adapter for the framework-free Orchestrator state interface. */
 
 import { useSyncExternalStore } from "react"
-import type { ReadableState } from "../../lib/external-store"
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { type ReadableState, createStateCell } from "../../lib/external-store"
 
 export function useAccessor<T>(state: ReadableState<T>): T {
   return useSyncExternalStore(state.subscribe, state.get, state.get)
+}
+
+/** Stand-in for a surface mounted without an orchestrator — never notifies,
+ *  so a no-daemon page reads as "not disconnected" rather than flashing a
+ *  banner it has no evidence for. */
+const NO_ORCHESTRATOR = createStateCell<"online">("online")
+
+/**
+ * True while the daemon SOCKET is down (`connectionStateSignal`), tolerating a
+ * null orchestrator so it can be called unconditionally.
+ *
+ * The distinction this preserves is the point: a single failed RPC against a
+ * live daemon is a transient, and does not set this. Only the socket dropping
+ * does — which is what makes every daemon-fed surface on screen a photograph.
+ */
+export function useDaemonDown(orchestrator: RemoteOrchestrator | null): boolean {
+  return useAccessor(orchestrator?.connectionStateSignal() ?? NO_ORCHESTRATOR) === "disconnected"
 }

--- a/packages/kobe/src/tui-react/workspace/host-footer.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-footer.tsx
@@ -88,6 +88,10 @@ export function WorkspaceFrame(props: {
   orchestrator: RemoteOrchestrator
   /** Wires the footer's clickable [settings] button; absent = no settings segment. */
   onOpenSettings?: () => void
+  /** Top-of-window strip (the daemon-down banner) — rendered above the pane
+   *  row. The host owns it because the surfaces that BYPASS this frame
+   *  (settings, worktrees, update) need the same strip. */
+  banner?: ReactNode
   children: ReactNode
 }) {
   const { theme } = useTheme()
@@ -99,6 +103,7 @@ export function WorkspaceFrame(props: {
   return (
     <ShortcutRevealProvider>
       <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+        {props.banner}
         <box flexDirection="row" flexGrow={1}>
           {props.children}
         </box>

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -14,12 +14,14 @@ import { SIDEBAR_WIDTH } from "../../tui/panes/sidebar/view-core"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { PrefixHud } from "../component/prefix-hud"
 import { ToastOverlay } from "../component/toast-overlay"
+import { DaemonDownBanner } from "../component/version-skew-banner"
 import { useFocus } from "../context/focus"
 import { useKV } from "../context/kv"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { bootPaneHost } from "../lib/host-boot"
+import { useDaemonDown } from "../lib/use-accessor"
 import { useDaemonNotices } from "../lib/use-daemon-notices"
 import { useLatest } from "../lib/use-latest"
 import { useSidebarHostState } from "../panes/sidebar/use-sidebar-host-state.tsx"
@@ -258,11 +260,38 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // live `focus.focused` so the pane frame stays lit under the dim backdrop.
   const activePane = dialog.stack.length > 0 ? null : focus.focused
 
-  if (pageRender.settingsPage) return pageRender.settingsPage
-  if (pageRender.fullWindowPage) return pageRender.fullWindowPage
+  // The one production consumer of `connectionStateSignal()`. Every surface
+  // below is fed by the daemon and every one of them swallows its own failed
+  // read and keeps painting the last good snapshot — a dead daemon rendered
+  // as a healthy routine list counting down to a run that will never happen.
+  // One banner above the surface switch answers it for all of them, including
+  // pages added later; the alternative is a catch block per page, which is
+  // where the silence came from in the first place.
+  const daemonDown = useDaemonDown(orch)
+  const banner = <DaemonDownBanner down={daemonDown} width={dims.width} />
+
+  // Settings and the full-window pages replace the WHOLE window, frame
+  // included, so each needs the banner wrapped around it rather than relying
+  // on WorkspaceFrame.
+  if (pageRender.settingsPage) {
+    return (
+      <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+        {banner}
+        {pageRender.settingsPage}
+      </box>
+    )
+  }
+  if (pageRender.fullWindowPage) {
+    return (
+      <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
+        {banner}
+        {pageRender.fullWindowPage}
+      </box>
+    )
+  }
 
   return (
-    <WorkspaceFrame orchestrator={orch} onOpenSettings={pages.openSettings}>
+    <WorkspaceFrame orchestrator={orch} onOpenSettings={pages.openSettings} banner={banner}>
       {/* Tasks sidebar stays visible in zen (tmux parity) — its
           ☯ ZEN chip is also the exit affordance. */}
       {/* Borderless rail (owner call 2026-07-27): no frame, no divider —

--- a/packages/kobe/src/tui/i18n/messages/automations.ts
+++ b/packages/kobe/src/tui/i18n/messages/automations.ts
@@ -7,6 +7,10 @@ export const en = {
   title: "ROUTINES",
   holdingDaemon: "keeping the daemon awake",
   notHolding: "none active",
+  /** Replaces both of the above while the socket is down: the hold state came
+   *  off the last successful read, so it is a claim about a process that is
+   *  not answering. */
+  daemonUnreachable: "daemon unreachable",
   paused: "paused",
   newTitle: "New routine",
   fieldName: "name",
@@ -54,6 +58,7 @@ export const zh: typeof en = {
   title: "例行任务",
   holdingDaemon: "正在保持守护进程常驻",
   notHolding: "无启用项",
+  daemonUnreachable: "守护进程无响应",
   paused: "已暂停",
   newTitle: "新建例行任务",
   fieldName: "名称",

--- a/packages/kobe/src/tui/i18n/messages/update.ts
+++ b/packages/kobe/src/tui/i18n/messages/update.ts
@@ -7,6 +7,9 @@ export const en = {
   pageTitle: "ROVE UPDATE",
   current: "current",
   latest: "latest",
+  /** The registry check failed (offline, npm down, timeout). Distinct from
+   *  "you are up to date" — those two used to render identically. */
+  latestUnknown: "unknown — could not reach the registry",
   releaseUrlUnavailable: "release URL unavailable",
   statusReleaseOpened: "Opened release page in your browser.",
   statusReleaseError: "Could not open release URL.",
@@ -44,6 +47,7 @@ export const zh: typeof en = {
   pageTitle: "ROVE 更新",
   current: "当前",
   latest: "最新",
+  latestUnknown: "未知 —— 无法连接到 registry",
   releaseUrlUnavailable: "发布链接不可用",
   statusReleaseOpened: "已在浏览器中打开发布说明页面。",
   statusReleaseError: "无法打开发布链接。",

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -65,6 +65,13 @@ export const en = {
     /** Insert feedback: the release attempt errored (RPC/PTY hiccup). */
     deferredInsertFailed: "Couldn't insert the queued message — it's still in the Inbox.",
   },
+  /** Daemon-connection banner (`connectionStateSignal` → workspace host).
+   *  Shown only while the socket is actually DOWN: every page reads daemon
+   *  state, so a dead daemon means every page on screen is a photograph. */
+  daemonDown: {
+    title: "DAEMON DISCONNECTED",
+    hint: "Everything on screen is the last state the daemon reported. Reconnecting…",
+  },
   terminalComing: "Embedded terminal is starting...",
 }
 
@@ -120,6 +127,10 @@ export const zh: typeof en = {
     deferredUnavailable: "该标签页未运行——排队的消息留在收件箱。",
     /** 插入反馈：放行过程出错（RPC/PTY 故障）。 */
     deferredInsertFailed: "无法插入排队的消息——它仍在收件箱中。",
+  },
+  daemonDown: {
+    title: "守护进程已断开",
+    hint: "屏幕上的内容是守护进程最后一次上报的状态。正在重连…",
   },
   terminalComing: "嵌入终端正在启动……",
 }

--- a/packages/kobe/test/render/automations-page-keys.test.tsx
+++ b/packages/kobe/test/render/automations-page-keys.test.tsx
@@ -10,6 +10,7 @@
  */
 
 import { expect, test } from "bun:test"
+import { createStateCell } from "../../src/lib/external-store"
 import { AutomationsPage } from "../../src/tui-react/component/automations-page"
 import { renderComponent } from "./harness"
 
@@ -27,8 +28,15 @@ const AUTOMATION = {
   updatedAt: "2026-07-01T00:00:00Z",
 }
 
+/** Hoisted: `useSyncExternalStore` re-subscribes whenever the store identity
+ *  changes, so a cell built inside the accessor would churn every render. */
+const ONLINE = createStateCell("online")
+
 function orchestrator(automations: unknown[] = []) {
   return {
+    // The page reads the connection signal to decide whether its daemon-hold
+    // state is still a claim it can make (see daemon-down-banner.test.tsx).
+    connectionStateSignal: () => ONLINE,
     listAutomations: async () => ({ automations, keepsDaemonAlive: automations.length > 0 }),
     automationRuns: async () => ({ runs: [] }),
     listTasks: () => [{ repo: "/x/kobe" }],

--- a/packages/kobe/test/render/daemon-down-banner.test.tsx
+++ b/packages/kobe/test/render/daemon-down-banner.test.tsx
@@ -1,0 +1,174 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The daemon-disconnect banner, and the two false affirmations it replaced.
+ *
+ * `connectionStateSignal()` was accurate and immediate from the day it was
+ * written and had ZERO production readers — only tests. Every page swallowed
+ * its own failed read and kept painting the last good snapshot, so a dead
+ * daemon rendered as a healthy routine list with a live countdown, and a
+ * failed registry fetch rendered as a green "you are up to date".
+ *
+ * These tests drive the SIGNAL, not a boolean prop: a banner wired to a prop
+ * nobody sets is exactly the bug being fixed, so the disconnect has to arrive
+ * the way it does in production — through the state cell the socket-close
+ * handler writes.
+ */
+
+import { expect, test } from "bun:test"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import type { DaemonConnectionState } from "../../src/client/remote-orchestrator-payloads"
+import { createStateCell } from "../../src/lib/external-store"
+import { AutomationsPage } from "../../src/tui-react/component/automations-page"
+import { UpdatePage } from "../../src/tui-react/component/update-page"
+import { DaemonDownBanner } from "../../src/tui-react/component/version-skew-banner"
+import { useDaemonDown } from "../../src/tui-react/lib/use-accessor"
+import { WorkspaceFrame } from "../../src/tui-react/workspace/host-footer"
+import { act, renderComponent, settle } from "./harness"
+
+const NOW = Date.now()
+const AUTOMATION = {
+  id: "a1",
+  name: "weekday audit",
+  repo: "/x/kobe",
+  prompt: "audit",
+  schedule: "0 9 * * MON-FRI",
+  enabled: true,
+  nextRunAt: new Date(NOW + 3_600_000).toISOString(),
+  missedRunGraceMinutes: 60,
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+}
+
+/** A fake orchestrator whose connection state is drivable, like the real one:
+ *  the socket-close handler sets the same cell. */
+function fakeOrchestrator(opts: { automations?: unknown[] } = {}) {
+  const connection = createStateCell<DaemonConnectionState>("online")
+  const automations = opts.automations ?? []
+  const orchestrator = {
+    connectionStateSignal: () => connection,
+    listAutomations: async () => ({ automations, keepsDaemonAlive: automations.length > 0 }),
+    automationRuns: async () => ({ runs: [] }),
+    listTasks: () => [{ repo: "/x/kobe" }],
+  } as unknown as RemoteOrchestrator
+  return { orchestrator, connection }
+}
+
+test("the banner is hidden while the daemon answers", async () => {
+  const { frame } = await renderComponent(<DaemonDownBanner down={false} width={60} />)
+  expect(await frame()).not.toContain("DAEMON DISCONNECTED")
+})
+
+test("the banner names the disconnect and says the screen is stale", async () => {
+  const { frame } = await renderComponent(<DaemonDownBanner down={true} width={60} />)
+  const text = await frame()
+  expect(text).toContain("DAEMON DISCONNECTED")
+  // The hint has to say what it means for what is on screen — "disconnected"
+  // alone leaves the healthy-looking list beneath it unexplained.
+  expect(text).toContain("last state the daemon reported")
+})
+
+test("the routines page stops claiming it holds a daemon that is gone", async () => {
+  // The worst of the three: a dead daemon rendered `holding daemon` in
+  // theme.success GREEN — an affirmative claim about a process that is not
+  // answering, built out of the last successful read.
+  const { orchestrator, connection } = fakeOrchestrator({ automations: [AUTOMATION] })
+  const { frame } = await renderComponent(
+    <AutomationsPage orchestrator={orchestrator} focused={true} onClose={() => {}} />,
+    // notifications: the page reports failed MUTATIONS as toasts (#651), so
+    // it calls useNotifications() on every render.
+    { width: 74, height: 20, providers: { dialog: true, notifications: true } },
+  )
+  await settle(150)
+  expect(await frame()).toContain("keeping the daemon awake")
+
+  await act(async () => {
+    connection.set("disconnected")
+  })
+  await settle(60)
+  const text = await frame()
+  expect(text).not.toContain("keeping the daemon awake")
+  expect(text).toContain("daemon unreachable")
+})
+
+test("a failed registry check does not render as green up-to-date", async () => {
+  // `checkLatestVersion` answers null for BOTH "fetch failed" and "suppressed",
+  // so the page fell back to `latest = CURRENT_VERSION` and painted it in
+  // theme.success — the network error and the good news were the same pixels.
+  // Empty, not deleted: `checkLatestVersion` gates on truthiness, and biome
+  // forbids `delete` on process.env (assigning undefined would store the
+  // STRING "undefined", which is truthy).
+  const previous = process.env.KOBE_FAKE_UPDATE ?? ""
+  process.env.KOBE_FAKE_UPDATE = ""
+  // No network in the render track: the fetch fails, which is the case under
+  // test. Force it deterministically rather than depending on that.
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async () => {
+    throw new Error("offline")
+  }) as unknown as typeof fetch
+  try {
+    const { frame } = await renderComponent(<UpdatePage onClose={() => {}} />, { width: 74, height: 20 })
+    await settle(150)
+    const text = await frame()
+    expect(text).toContain("could not reach the registry")
+    expect(text).not.toContain(`latest  v${process.env.npm_package_version ?? ""}`)
+  } finally {
+    globalThis.fetch = realFetch
+    process.env.KOBE_FAKE_UPDATE = previous
+  }
+})
+
+test("useDaemonDown follows the orchestrator's real connection signal", async () => {
+  // The wiring is the fix. `connectionStateSignal()` was correct for months
+  // with nothing reading it, so a banner driven by a hand-set prop would
+  // reproduce the bug rather than catch it: this asserts the hook reads the
+  // ACTUAL signal, and re-renders when the socket-close handler writes it.
+  const { orchestrator, connection } = fakeOrchestrator()
+  function Probe() {
+    return <text>{useDaemonDown(orchestrator) ? "down" : "up"}</text>
+  }
+  const { frame } = await renderComponent(<Probe />, { width: 20, height: 3 })
+  expect(await frame()).toContain("up")
+
+  await act(async () => {
+    connection.set("disconnected")
+  })
+  expect(await frame()).toContain("down")
+
+  // And back: the reconnect loop sets "online" after a successful re-init, so
+  // the banner has to clear itself without anyone remounting the page.
+  await act(async () => {
+    connection.set("online")
+  })
+  expect(await frame()).toContain("up")
+})
+
+test("useDaemonDown reports up with no orchestrator at all", async () => {
+  // A page can mount before the daemon connect resolves. "No orchestrator" is
+  // not evidence of a disconnect — flashing the banner there would train the
+  // user to ignore it.
+  function Probe() {
+    return <text>{useDaemonDown(null) ? "down" : "up"}</text>
+  }
+  const { frame } = await renderComponent(<Probe />, { width: 20, height: 3 })
+  expect(await frame()).toContain("up")
+})
+
+test("WorkspaceFrame renders the banner above the pane row", async () => {
+  // The frame is what every non-full-window surface mounts inside, so the
+  // banner has to sit ABOVE the panes rather than inside one of them.
+  const usage = createStateCell(null)
+  const orch = {
+    usageSnapshotSignal: () => usage,
+  } as unknown as RemoteOrchestrator
+  const { frame } = await renderComponent(
+    <WorkspaceFrame orchestrator={orch} banner={<DaemonDownBanner down={true} width={40} />}>
+      <text>body</text>
+    </WorkspaceFrame>,
+    { width: 44, height: 8 },
+  )
+  const lines = (await frame()).split("\n")
+  const bannerRow = lines.findIndex((line) => line.includes("DAEMON DISCONNECTED"))
+  const bodyRow = lines.findIndex((line) => line.includes("body"))
+  expect(bannerRow).toBeGreaterThanOrEqual(0)
+  expect(bodyRow).toBeGreaterThan(bannerRow)
+})

--- a/packages/kobe/test/render/failure-toast.test.tsx
+++ b/packages/kobe/test/render/failure-toast.test.tsx
@@ -15,6 +15,7 @@
  * overlay draws, which no pre-fix rendering produced.
  */
 import { expect, test } from "bun:test"
+import { createStateCell } from "../../src/lib/external-store"
 import { AutomationsPage } from "../../src/tui-react/component/automations-page"
 import { KanbanPage } from "../../src/tui-react/component/kanban-page"
 import { ToastOverlay } from "../../src/tui-react/component/toast-overlay"
@@ -136,8 +137,14 @@ const AUTOMATION = {
   updatedAt: "2026-07-01T00:00:00Z",
 }
 
+/** The page reads the daemon connection signal to decide whether its
+ *  daemon-hold state is still a claim it can make (daemon-down-banner.test.tsx).
+ *  Hoisted so `useSyncExternalStore` sees one stable store identity. */
+const ONLINE = createStateCell("online")
+
 test("automations: a failed delete shows an error toast instead of a muted line", async () => {
   const orch = {
+    connectionStateSignal: () => ONLINE,
     listAutomations: async () => ({ automations: [AUTOMATION], keepsDaemonAlive: true }),
     automationRuns: async () => ({ runs: [] }),
     listTasks: () => [{ repo: "/x/kobe" }],
@@ -163,6 +170,7 @@ test("automations: a failed delete shows an error toast instead of a muted line"
 
 test("automations: a failed toggle shows an error toast", async () => {
   const orch = {
+    connectionStateSignal: () => ONLINE,
     listAutomations: async () => ({ automations: [AUTOMATION], keepsDaemonAlive: true }),
     automationRuns: async () => ({ runs: [] }),
     listTasks: () => [{ repo: "/x/kobe" }],

--- a/packages/kobe/test/render/host-pages.test.tsx
+++ b/packages/kobe/test/render/host-pages.test.tsx
@@ -15,6 +15,7 @@
 import { expect, test } from "bun:test"
 import { useEffect, useRef } from "react"
 import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
 import type { FocusContextValue } from "../../src/tui-react/context/focus"
 import type { KVContext } from "../../src/tui-react/context/kv"
 import type { DialogContext } from "../../src/tui-react/ui/dialog"
@@ -48,12 +49,16 @@ const WT_ROW = {
 
 const SELECTED_TASK = { id: "t1", repo: "/x/kobe" } as unknown as Task
 
+/** Hoisted so `useSyncExternalStore` sees one stable store identity. */
+const ONLINE = createStateCell("online")
+
 function fakeOrchestrator(): RemoteOrchestrator {
   return {
     listWorktrees: async (opts?: { network?: boolean }) => [
       { repo: "/x/kobe", worktrees: opts?.network === false ? [WT_ROW] : [WT_ROW] },
     ],
     listTasks: () => [SELECTED_TASK],
+    connectionStateSignal: () => ONLINE,
     listAutomations: async () => ({ automations: [], keepsDaemonAlive: false }),
     automationRuns: async () => ({ runs: [] }),
     listIssues: async () => ({ repoRoot: "/x/kobe", exists: true, nextId: 99, issues: [] }),


### PR DESCRIPTION
## The bug

`connectionStateSignal` (`remote-orchestrator.ts:294`) flips to `disconnected` the instant the socket closes. It was accurate and immediate from the day it was written, and had **zero production readers** — only tests. Every page swallowed its own failed read and kept painting the last good snapshot.

The result on screen, with a daemon that is not answering:

- **Routines** rendered a healthy schedule with a live countdown, and asserted `keeping the daemon awake` in **`theme.success` green** — an affirmative claim about a process that is gone.
- **Worktrees** rendered its list with no indication at all (its catches set no state, and the page never polls, so an open page is a permanent photograph).
- **Update** rendered a failed registry fetch as a **green** `v{latest}`: "could not reach npm" and "you are up to date" were the same pixels.

## The fix

One consumer, not a catch block per page. A `DaemonDownBanner` above the workspace's surface switch covers every page at once — including pages added later, which is the failure mode a per-page catch keeps reproducing.

- `useDaemonDown()` (`lib/use-accessor.ts`) is the seam: it reads the real signal, tolerates a null orchestrator, and only reports down on a **socket drop** — a single failed RPC against a live daemon is a transient and does not raise it.
- The banner reuses `VersionSkewBanner`'s strip; both now share one `BannerStrip` (amber = stale build, red = disconnected) instead of two hand-copied layouts.
- Settings and the full-window pages return before `WorkspaceFrame`, so each gets the banner wrapped around it — verified on the Worktrees page, not assumed.
- Routines' header shows `daemon unreachable` instead of the stale hold state.
- Update distinguishes "the check failed" from "you are up to date".

The `setAutomations(prev => prev ?? [])` no-op stays: keeping the previous rows IS not calling setState, so the branch only covers the first load. The comment now says that instead of implying it does work.

## Verified on real OpenTUI

Captured through the only ground-truth path (fixed-viewport Chromium → `/harness` → xterm.js → PTY sidecar → real OpenTUI), against an isolated fixture on its own port base, with a **real daemon killed mid-session** by the pid its own `rove api inspect` reported. The production daemon (86005) was confirmed alive before and after every capture.

| | daemon dead, before | daemon dead, after |
|---|---|---|
| Routines | green `keeping the daemon awake` + live countdown | red banner + `daemon unreachable` |
| Worktrees | ordinary list, no signal | red banner above the page |

Healthy state is unchanged — no banner, no false alarm.

## Tests

`test/render/daemon-down-banner.test.tsx` — 7 tests driving the **signal**, not a prop (a banner wired to a hand-set prop would reproduce the bug rather than catch it). All 7 go red when the fix is deleted, twice; green twice with it.

Also repaired three fake orchestrators that claimed `as never`/`as unknown as RemoteOrchestrator` without the signal — fixing the fakes rather than adding a runtime guard, since a guard would let a genuinely absent signal read "online".

## Scope

Only daemon-disconnect visibility. The other stale-state findings from the same audit (engine-list memo, three copies of the default engine, the issue drawer snapshot) are deliberately untouched. The Worktrees page's missing poll is a separate staleness issue and is not addressed here.

coverage-exemption: packages/kobe/src/tui-react/workspace/host.tsx — structurally untestable on the render track (integration layer needing a live daemon + PTY; the track cannot mount it, hence 0%, not a missing test). The banner logic it hosts IS covered: `useDaemonDown` at 100% and `WorkspaceFrame`'s banner slot at 100% in test/render/daemon-down-banner.test.tsx, plus the visual-ground-truth harness, which photographed the banner on this exact host with a real daemon killed mid-session.
