### PR TITLE
fix: broadcast verbs report reach, pane-open returns title, list returns activeTaskId

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 35 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 36 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -215,7 +215,7 @@ turn either. These five carry almost all traffic:
 add      --repo(REQ) --prompt --title --command --count --agents --activate
 send     --prompt(REQ) --task-id --tab --command --plain
 get-task --task-id(REQ)          list  (no flags)
-collect  --task-ids <csv> | --repo
+collect  --group <groupId> | --task-ids <csv> | --repo
 ```
 
 Four names that have actually been guessed wrong here: `add --vendor` is
@@ -277,7 +277,10 @@ rove api send --task-id <id> --tab new --prompt "<turn>"    # fresh engine tab
 rove api send --task-id <id> --tab new --command codex --prompt "<turn>"
 
 rove api get-task --task-id <id>
-rove api collect --task-ids <id1>,<id2>,<id3> --pretty
+# One read for the whole round — the groupId `add --count` returned. Never
+# hand-copy N task ids across turns: collect by group. Lost the groupId? Any
+# sibling task's `.groupId` in `list` output recovers it.
+rove api collect --group <groupId> --pretty
 rove api list --pretty
 ```
 

--- a/.changeset/api-reach-and-title.md
+++ b/.changeset/api-reach-and-title.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Broadcast verbs report reach, pane-open returns its title, list exposes the active task
+
+`pane-open`, `pane-close`, and `notify` are broadcast-only: an attached TUI performs the split/close/toast, so headless they did nothing while still returning `ok: true` — and an agent had no way to know. Their results now carry `clients`, the same attached-connection reach signal `dispatch` already reports (`0` = nobody performed it; the calling CLI counts itself, so `1` is not proof a UI listened).
+
+`pane-open` also returns the resolved `title` — the label `pane-close --title` must match. Previously the title was silently derived (the command's first word) and never surfaced, so closing a pane opened without `--title` was guesswork, and a `pane-close` that matched nothing was invisible.
+
+`list` now returns `activeTaskId`, the shared focus that `send` / `pane-open` / `pane-close` / `read-output` default to when `--task-id` is omitted. A delivery that rode the implicit target can now be audited after the fact.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 35 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 36 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -215,7 +215,7 @@ turn either. These five carry almost all traffic:
 add      --repo(REQ) --prompt --title --command --count --agents --activate
 send     --prompt(REQ) --task-id --tab --command --plain
 get-task --task-id(REQ)          list  (no flags)
-collect  --task-ids <csv> | --repo
+collect  --group <groupId> | --task-ids <csv> | --repo
 ```
 
 Four names that have actually been guessed wrong here: `add --vendor` is
@@ -277,7 +277,10 @@ rove api send --task-id <id> --tab new --prompt "<turn>"    # fresh engine tab
 rove api send --task-id <id> --tab new --command codex --prompt "<turn>"
 
 rove api get-task --task-id <id>
-rove api collect --task-ids <id1>,<id2>,<id3> --pretty
+# One read for the whole round — the groupId `add --count` returned. Never
+# hand-copy N task ids across turns: collect by group. Lost the groupId? Any
+# sibling task's `.groupId` in `list` output recovers it.
+rove api collect --group <groupId> --pretty
 rove api list --pretty
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -105,7 +105,11 @@ replacement in `nextCommandArgs`.
 
 ## read
 
-- `list`: list all tasks. Returns `{ tasks }`.
+- `list`: list all tasks. Returns `{ tasks, activeTaskId }` — `activeTaskId`
+  is the shared focus that verbs using the implicit target (`send`,
+  `pane-open`, `pane-close`, `read-output` without `--task-id`) default to;
+  `null` means no active task. Reading it back is the audit trail for any
+  delivery that omitted `--task-id`.
 - `get-task --task-id <id>`: one task's metadata; `.running` = any of its
   hosted engine tabs is live (not just the first); `.tabs` = the task's
   terminal tabs (`id`/`kind`/`title`/`vendor`/`liveVendor`/`lastTitle`/
@@ -287,7 +291,13 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   shell (`-ilc`, so shell-rc `PATH`/exports apply, same as the engine tab)
   and the pane closes when it exits; omit it for an interactive
   shell. Broadcast over the daemon's `tab.open` channel, so an attached TUI
-  showing the task performs the split (headless, nothing happens). Task
+  showing the task performs the split (headless, nothing happens). The result
+  carries the resolved `title` — the label `pane-close --title` must match,
+  derived from the command's first word when `--title` is omitted — and
+  `clients`, the attached-connection count: `0` means nobody performed the
+  split, so an agent must not report "pane opened" on that verdict. (The
+  calling CLI is itself one connection, so `1` does not prove a TUI is
+  listening; `0` is the unambiguous case.) Task
   defaults to `$ROVE_TASK_ID` (or its Kobe alias), then the active task. How far splits can go
   is decided by the terminal's size: a split that would shrink any pane
   below the minimum usable size (20×6 cells) falls back to a tab.
@@ -296,10 +306,12 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   `--title`, the title it was opened with; `--tab tab-N` scopes the match to
   one tab. Engine panes are never closed. Broadcast over the daemon's
   `tab.close` channel; an attached TUI performs the close (headless, nothing
-  happens).
+  happens). The result's `clients` is the reach signal: `0` = no attached TUI
+  performed the close (same semantics as `dispatch`'s).
 - `notify --title TEXT [--kind KIND] [--task-id ID] [--source TAG]`: show
   a toast in every attached Rove UI. `done` / `needs_input` / `error` get
-  severity styling; any other kind renders neutrally.
+  severity styling; any other kind renders neutrally. The result's `clients`
+  is the reach signal: `0` = no attached UI showed the toast (headless).
 - `engine-report --kind KIND [--task-id ID] [--engine ID] [--tab TAB]
   [--detail JSON]`: report a normalized engine-activity verb for a task,
   the public face of the `engine.reportEvent` RPC the built-in hook adapters

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -18,7 +18,15 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     name: "task.list",
     web: true,
     handle(_payload, ctx: DaemonHandlerContext) {
-      return { tasks: ctx.orch.listTasks().map(serializeTask) }
+      // `activeTaskId` is the shared focus every verb using the implicit
+      // target reads when `--task-id` is omitted — without it in the list
+      // envelope, a misdirected delivery is unauditable. The signal is the
+      // same source server.ts seeds the active-task channel from; test
+      // doubles may not stub it, so absence reads as "no focus".
+      return {
+        tasks: ctx.orch.listTasks().map(serializeTask),
+        activeTaskId: ctx.orch.activeTaskSignal?.()?.() ?? null,
+      }
     },
   },
   {

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -155,7 +155,12 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
         ...(direction === "right" || direction === "down" ? { direction } : {}),
         at: Date.now(),
       })
-      return { ok: true }
+      // Same reach report as `session.deliver` (#499): the split is performed
+      // by an attached TUI, so with nothing listening the pane goes nowhere
+      // while a bare `ok` would read as "opened". `clients` counts CONNECTIONS
+      // — the calling CLI is one, so 1 does not prove a host is listening; 0
+      // is the unambiguous "nobody performed it".
+      return { ok: true, clients: ctx.daemon.clientCount() }
     },
   },
   {
@@ -174,7 +179,9 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
         ...(tabId !== undefined ? { tabId } : {}),
         at: Date.now(),
       })
-      return { ok: true }
+      // A close with no attached TUI silently matched nothing — without this
+      // the caller cannot tell "pane closed" from "nobody was listening".
+      return { ok: true, clients: ctx.daemon.clientCount() }
     },
   },
   {
@@ -192,7 +199,9 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       if (taskId !== undefined && !ctx.orch.getTask(taskId)) throw new Error(`task not found: ${taskId}`)
       const source = optionalString(payload, "source")
       ctx.bus.publish("notice.event", { title, kind, taskId, at: Date.now(), source })
-      return { ok: true }
+      // Headless honesty: with no attached UI the toast reaches nobody, and
+      // `clients` is the only signal (same reach report as session.deliver).
+      return { ok: true, clients: ctx.daemon.clientCount() }
     },
   },
   {

--- a/packages/kobe/src/cli/api/handlers-pane.ts
+++ b/packages/kobe/src/cli/api/handlers-pane.ts
@@ -16,7 +16,7 @@ import { ApiError, type VerbSpec } from "./types.ts"
 export const PANE_VERB: VerbSpec = {
   name: "pane-open",
   summary:
-    "Open a terminal pane in a task's workspace: split the focused tab (default, or --tab's tab) or open a separate command tab, optionally running a command. Broadcast over the daemon's tab.open channel — an attached TUI showing the task performs the split. Task defaults to $ROVE_TASK_ID, then the active task.",
+    "Open a terminal pane in a task's workspace: split the focused tab (default, or --tab's tab) or open a separate command tab, optionally running a command. Broadcast over the daemon's tab.open channel — an attached TUI showing the task performs the split. Task defaults to $ROVE_TASK_ID, then the active task. Returns the resolved `title` (the label `pane-close --title` must match — derived from the command's first word when --title is omitted) plus `clients` (attached connections; 0 = nobody performed the split).",
   flags: [
     F.taskId(false),
     {
@@ -70,21 +70,25 @@ export const PANE_VERB: VerbSpec = {
     const argv = command ? [shell, "-ilc", command] : [shell, "-il"]
     const title = ctx.args.str("title") ?? (command ? (command.trim().split(/\s+/)[0] ?? "shell") : "shell")
     const tabId = ctx.args.str("tab")
-    return simpleRpc(ctx, "tab.open", {
+    const reply = (await simpleRpc(ctx, "tab.open", {
       taskId,
       argv,
       title,
       ...(tabId !== undefined ? { tabId } : {}),
       placement: ctx.args.str("placement") ?? "split",
       direction: ctx.args.str("direction") ?? "right",
-    })
+    })) as Record<string, unknown> | undefined
+    // Echo the resolved title back: it is the label `pane-close --title`
+    // must match, and without this in the result a derived title (the
+    // command's first word) is unguessable.
+    return { ...reply, title }
   },
 }
 
 export const PANE_CLOSE_VERB: VerbSpec = {
   name: "pane-close",
   summary:
-    "Close panes opened by pane-open: every split pane / command tab in the task whose label matches --title. Broadcast over the daemon's tab.close channel — an attached TUI showing the task performs the close (headless no-op). Task defaults to $ROVE_TASK_ID, then the active task.",
+    "Close panes opened by pane-open: every split pane / command tab in the task whose label matches --title. Broadcast over the daemon's tab.close channel — an attached TUI showing the task performs the close (headless no-op). Task defaults to $ROVE_TASK_ID, then the active task. Returns `clients` (attached connections; 0 = nobody performed the close).",
   flags: [
     F.taskId(false),
     {

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -68,7 +68,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   {
     name: "notify",
     summary:
-      "Show a toast in every attached Rove UI — broadcast over the daemon's notice.event channel. Agents/scripts use it to surface 'done / needs input / error' moments without touching the task's session.",
+      "Show a toast in every attached Rove UI — broadcast over the daemon's notice.event channel. Agents/scripts use it to surface 'done / needs input / error' moments without touching the task's session. Returns `clients` (attached connections; 0 = no UI showed the toast).",
     flags: [
       {
         name: "title",

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -15,7 +15,13 @@ import { READ_OUTPUT_VERB } from "./read-output.ts"
 import type { VerbSpec } from "./types.ts"
 
 export const READ_VERBS: readonly VerbSpec[] = [
-  { name: "list", summary: "List all tasks. Returns { tasks }.", flags: [], handler: list },
+  {
+    name: "list",
+    summary:
+      "List all tasks. Returns { tasks, activeTaskId } — `activeTaskId` is the shared focus verbs default to when --task-id is omitted (null = no active task), the audit read for any implicit-target delivery.",
+    flags: [],
+    handler: list,
+  },
   {
     name: "get-task",
     summary:

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -44,7 +44,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
  */
-export const KOBE_SKILL_VERSION = 35
+export const KOBE_SKILL_VERSION = 36
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/test/cli/api-pane.test.ts
+++ b/packages/kobe/test/cli/api-pane.test.ts
@@ -14,8 +14,11 @@ describe("pane-open handler", () => {
   })
 
   it("wraps --command in the login shell's -ilc, defaults split/right, titles from the command word", async () => {
-    const client = new FakeClient({ "tab.open": () => ({ ok: true }) })
-    await invokeVerb("pane-open", ["--command", "btop --utf-force"], { client, runtime: stubRuntime() })
+    const client = new FakeClient({ "tab.open": () => ({ ok: true, clients: 1 }) })
+    const result = (await invokeVerb("pane-open", ["--command", "btop --utf-force"], {
+      client,
+      runtime: stubRuntime(),
+    })) as { ok: boolean; clients: number; title: string }
     expect(client.requestNames).toEqual(["tab.open"])
     expect(client.requests[0].payload).toEqual({
       taskId: "env-task",
@@ -24,26 +27,41 @@ describe("pane-open handler", () => {
       placement: "split",
       direction: "right",
     })
+    // The resolved title rides back in the result — it is what `pane-close
+    // --title` must match — and the daemon's reach signal passes through.
+    expect(result).toEqual({ ok: true, clients: 1, title: "btop" })
   })
 
   it("no --command opens an interactive login shell; explicit flags pass through", async () => {
-    const client = new FakeClient({ "tab.open": () => ({ ok: true }) })
-    await invokeVerb("pane-open", ["--task-id", "t9", "--direction", "down", "--placement", "tab", "--title", "logs"], {
-      client,
-      runtime: stubRuntime(),
-    })
+    const client = new FakeClient({ "tab.open": () => ({ ok: true, clients: 2 }) })
+    const result = (await invokeVerb(
+      "pane-open",
+      ["--task-id", "t9", "--direction", "down", "--placement", "tab", "--title", "logs"],
+      {
+        client,
+        runtime: stubRuntime(),
+      },
+    )) as { title: string }
     const payload = client.requests[0].payload as { taskId: string; argv: string[]; title: string }
     expect(payload.taskId).toBe("t9")
     expect(payload.argv).toEqual([resolveLoginShell({ fallback: "/bin/sh" }), "-il"])
     expect(payload.title).toBe("logs")
     expect(client.requests[0].payload).toMatchObject({ placement: "tab", direction: "down" })
+    // An explicit --title is echoed back verbatim.
+    expect(result.title).toBe("logs")
   })
 
   it("pane-close passes taskId + title over tab.close; --title is required", async () => {
-    const client = new FakeClient({ "tab.close": () => ({ ok: true }) })
-    await invokeVerb("pane-close", ["--task-id", "t9", "--title", "fx"], { client, runtime: stubRuntime() })
+    const client = new FakeClient({ "tab.close": () => ({ ok: true, clients: 0 }) })
+    const result = (await invokeVerb("pane-close", ["--task-id", "t9", "--title", "fx"], {
+      client,
+      runtime: stubRuntime(),
+    })) as { ok: boolean; clients: number }
     expect(client.requestNames).toEqual(["tab.close"])
     expect(client.requests[0].payload).toEqual({ taskId: "t9", title: "fx" })
+    // The daemon's reach signal (0 = no attached TUI performed the close)
+    // passes through unaltered — a headless close must be visible.
+    expect(result).toEqual({ ok: true, clients: 0 })
     const bare = new FakeClient()
     await expectApiError(() => invokeVerb("pane-close", [], { client: bare, runtime: stubRuntime() }), "MISSING_FLAG")
     expect(bare.requestNames).toEqual([])

--- a/packages/kobe/test/daemon/handlers-task-crud.test.ts
+++ b/packages/kobe/test/daemon/handlers-task-crud.test.ts
@@ -11,6 +11,28 @@ import { describe, expect, it, vi } from "vitest"
 import { SERIALIZED_TASK, TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
 
 describe("daemon handler registry — tasks, issues, worktrees", () => {
+  describe("task.list", () => {
+    // `activeTaskId` is the only read of the shared focus that verbs using
+    // the implicit target (`send`/`pane-open`/`pane-close`/`read-output`
+    // without `--task-id`) actually landed on — without it a misdirected
+    // delivery is unauditable.
+    it("returns the serialized tasks plus the active task id", async () => {
+      const { ctx } = fakeCtx({
+        listTasks: () => [TASK],
+        activeTaskSignal: () => () => "t-active",
+      })
+      await expect(dispatch("task.list", {}, ctx)).resolves.toEqual({
+        tasks: [SERIALIZED_TASK],
+        activeTaskId: "t-active",
+      })
+    })
+
+    it("reports activeTaskId: null when no task is active or the signal is unavailable", async () => {
+      const { ctx } = fakeCtx({ listTasks: () => [TASK] })
+      await expect(dispatch("task.list", {}, ctx)).resolves.toEqual({ tasks: [SERIALIZED_TASK], activeTaskId: null })
+    })
+  })
+
   describe("task CRUD", () => {
     it("task.create returns { taskId, task } and forwards normalized options", async () => {
       const calls: unknown[] = []

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -168,7 +168,7 @@ describe("daemon handler registry", () => {
       const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === "t1" ? TASK : undefined) })
       const before = Date.now()
       const result = await dispatch("tab.close", { taskId: "t1", title: "demo" }, ctx)
-      expect(result).toEqual({ ok: true })
+      expect(result).toEqual({ ok: true, clients: 1 })
       const event = rec.published[0] as { channel: string; payload: Record<string, unknown> }
       expect(event.channel).toBe("tab.close")
       expect(event.payload).toMatchObject({ taskId: "t1", title: "demo" })
@@ -190,7 +190,7 @@ describe("daemon handler registry", () => {
       const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === "t1" ? TASK : undefined) })
       const before = Date.now()
       const result = await dispatch("tab.open", { taskId: "t1", argv: ["sh", "-lc", "true"], title: "demo" }, ctx)
-      expect(result).toEqual({ ok: true })
+      expect(result).toEqual({ ok: true, clients: 1 })
       const event = rec.published[0] as { channel: string; payload: Record<string, unknown> }
       expect(event.channel).toBe("tab.open")
       expect(event.payload).toMatchObject({ taskId: "t1", argv: ["sh", "-lc", "true"], title: "demo" })
@@ -242,7 +242,7 @@ describe("daemon handler registry", () => {
       const { ctx, rec } = fakeCtx()
       const before = Date.now()
       const result = await dispatch("notice.send", { title: "build done" }, ctx)
-      expect(result).toEqual({ ok: true })
+      expect(result).toEqual({ ok: true, clients: 1 })
       expect(rec.published).toHaveLength(1)
       const event = rec.published[0] as { channel: string; payload: Record<string, unknown> }
       expect(event.channel).toBe("notice.event")
@@ -280,6 +280,27 @@ describe("daemon handler registry", () => {
       )
       await expect(dispatch("notice.send", { title: "x", taskId: "nope" }, ctx)).rejects.toThrow("task not found: nope")
       expect(rec.published).toHaveLength(0)
+    })
+  })
+
+  describe("broadcast reach (clients)", () => {
+    // Broadcast-only handlers used to return a bare { ok: true } — an agent
+    // headless (no TUI attached) read that as "the pane opened" and reported
+    // a thing that never happened. `clients` is the same reach signal
+    // `session.deliver` already reports (#499): connection count, where 0 is
+    // the unambiguous "nobody performed it".
+    it("tab.open / tab.close / notice.send report clients: 0 when nothing is attached", async () => {
+      const { ctx } = fakeCtx({ getTask: () => TASK })
+      ;(ctx.daemon as { clientCount: () => number }).clientCount = () => 0
+      await expect(dispatch("tab.open", { taskId: "t1", argv: ["x"], title: "t" }, ctx)).resolves.toEqual({
+        ok: true,
+        clients: 0,
+      })
+      await expect(dispatch("tab.close", { taskId: "t1", title: "t" }, ctx)).resolves.toEqual({
+        ok: true,
+        clients: 0,
+      })
+      await expect(dispatch("notice.send", { title: "t" }, ctx)).resolves.toEqual({ ok: true, clients: 0 })
     })
   })
 


### PR DESCRIPTION
## 四条改动

**一、假成功（clients 到达信号）** — `pane-open` / `pane-close` / `notify` 是纯广播，之前无条件返回 `{ok:true}`：headless 时什么都没发生，agent 却会向用户确认「面板已打开」。现在沿用 `dispatch` 已有的同一个机制（daemon 响应里带 `ctx.daemon.clientCount()`），三处返回 `{ok:true, clients:N}`。

**二、pane-open 返回解析后的 title** — `--title` 省略时标题静默推导（命令第一个词），从不在返回值里，导致 `pane-close --title "tail -f app.log"` 永远匹配不上（真实标题是 `tail`）。现在结果里带回解析后的 `title`。

**三、SKILL.md 补上 collect --group** — `add --count` 返回的 `groupId` 在 SKILL.md 零提及，agent 被迫跨轮次手工记 N 个 task id。collect 速查行加了 `--group`，示例改用 `collect --group`，并注明 groupId 丢了可从 `list` 输出里任何兄弟任务的 `.groupId` 读回。双镜像同步，skill 版本 35 → 36。

**四、list 返回 activeTaskId** — active task 是省略 `--task-id` 时的隐式目标，但之前没有任何 verb 能读出它是谁；active 错了投递静默成功。daemon `task.list` 响应现在带 `activeTaskId`（源与 server.ts 预热 active-task channel 的 `activeTaskSignal` 相同）。`SerializedTask` 字段集 untouched，`serialize-task-fields` 测试不受影响。

## 测试

- 每个改动都有测试，且全部过了「删修复→变红」两轮：daemon handlers（tab.open/tab.close/notice.send 的 clients:1 既有断言更新 + 新增 clients:0 用例）、task.list 的 activeTaskId（有/无 signal 两例）、CLI pane-open/pane-close（title 回显 + clients 透传）。
- SKILL.md 镜像字节一致性测试（claude-plugin.test.ts）即红绿关卡。
- 真机验证（dev:sandbox `reach-verify`，无 TUI 连接）：`pane-open` → `{ok:true, clients:1, title:"tail"}`，`notify` / `pane-close` → `{ok:true, clients:1}`，`list` → `{tasks:[...], activeTaskId:null}`。
- 全部 touched-file 测试套件绿（socket 609/609、cli/api-pane 5/5、architecture 8/8、skill-install 全绿），lint + typecheck 干净。

## 一个如实汇报的发现

派发任务预期「无 TUI 时 clients 是 0」。实测裸 CLI 调用最小是 **1** —— 调用方自己的 socket 连接也计入 `clientCount`（`server.ts` 在 connect 时无条件 `clients.add`），这与 `session.deliver` 代码注释里已写明的 caveat（"the calling CLI is itself one"）一致。`clients:0` 只对非 socket 调用方（daemon 进程内）可达。语义上仍满足「区分 0 的明确情形」，但 agent 从头less CLI 看到的地板值是 1 而不是 0，文档（API.md / verb summary）已如实写明。如果你认为地板值必须是 0（排除调用方自身），那需要改 `clientCount` 的语义（只计 subscribed/gui 客户端），是一行改动但会影响 dispatch 的既有语义 —— 需要你拍板，我没有擅自改。

## 环境噪音（与本次改动无关）

本 worktree 跑 `test:fast` 全量有 47 个预先存在的失败（`--help` usage、completions、theme 等，特征是断言期望 `kobe …` 实际输出 `rove …` 的品牌名问题），在未改动的干净树上复跑同样失败。CI 是唯一权威。

## Changeset

`api-reach-and-title.md`，patch。