### PR TITLE
Record engine deaths that happen inside a living terminal

### DIFF
--- a/.changeset/engine-death-records.md
+++ b/.changeset/engine-death-records.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Record engine deaths that happen inside a living terminal. A tab's shell wrapper reaps its engine and drops you at a fallback shell, so the session stays alive and the existing death records — which only fire when the PTY itself exits — never saw it. Seven engines killed by a provider usage limit left zero records.
+
+The activity observer's foreground walk already notices the engine disappear; it now persists that moment to `pty-exits.json` as a `layer: "engine"` record with the engine's pid, its exit code scraped from the wrapper's `Engine exited (code N)` banner, and the terminal tail that holds the provider's error. `rove api inspect` reports both layers, newest first. Every signal Rove sends a terminal subtree is logged to `daemon.log`, so a post-mortem can tell "Rove killed it" from "something else did".

--- a/docs/API.md
+++ b/docs/API.md
@@ -179,9 +179,12 @@ replacement in `nextCommandArgs`.
 - `inspect [--task-id ID]` *(offline)*: diagnostics in one read, across four
   sections: `daemon` (raw per-task/per-tab activity entries), `sessions`
   (PTY inventory joined with a live process-tree walk; dead sessions carry
-  `exit`), `sessionExits` (durable death records: exit `code`/`signal`/`at`
-  plus a plain-text output `tail`, kept in `pty-exits.json` so they survive
-  the PTY host's idle-exit; abnormal exits only), and `tabs` (the
+  `exit`), `sessionExits` (durable death records, newest first: exit
+  `code`/`signal`/`at` plus a plain-text output `tail`, kept in
+  `pty-exits.json` so they survive the PTY host's idle-exit. `layer: "pty"`
+  is the terminal process, abnormal exits only; `layer: "engine"` is the AI
+  process gone from a still-running terminal, and adds `vendor` and
+  `parentAlive`), and `tabs` (the
   snapshots the sidebar names its rows from, reconciled against the live
   session inventory: a task whose snapshot is missing an alive
   `<taskId>::tab-N` session reports those tab ids under `unregistered`,

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -161,12 +161,19 @@ Three related limits are easy to confuse:
   but a reboot or host restart restores the last completed snapshot. Closing
   the tab, archiving its task, or `rove reset` deliberately drops the relevant
   frozen record.
-- **What diagnostics retain after an abnormal PTY death.**
-  `<home>/.rove/pty-exits.json` stores the newest 50 abnormal deaths. Each
-  record has the exit code or signal, time, and the last 40 plain-text lines
-  extracted from up to 16 KiB of raw ring data. Clean exits are omitted. This
-  is a diagnostic tail, not scrollback, and an engine CLI returning to its
-  still-live shell does not create one.
+- **What diagnostics retain after a death.** `<home>/.rove/pty-exits.json`
+  stores the newest 50 records. Each has the exit code or signal, time, and
+  the last 40 plain-text lines extracted from up to 16 KiB of raw ring data.
+  This is a diagnostic tail, not scrollback. Records come in two layers:
+  - `layer: "pty"` — the terminal's own process died. Clean exits are omitted.
+  - `layer: "engine"` — the AI process is gone from a terminal that is still
+    running, which is what you get when an engine crashes and drops you at
+    the fallback shell. Written by the daemon's foreground walk, so it
+    appears within about a minute of the death rather than instantly, and
+    carries `vendor`, the engine's own pid, `parentAlive: true`, and an exit
+    code read from the `Engine exited (code N)` banner when the shell
+    printed one. Recorded whether or not the engine exited cleanly — an
+    engine that vanishes without explanation is the case worth keeping.
 - **How far you can scroll.** `terminal.scrollbackRows` in Settings →
   General → Terminal, default 1000 rows. Applies to terminals started after
   the change.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -126,10 +126,21 @@ for you to run yourself, never executed.
 Hosted PTY output is not always memory-only. Two bounded recovery stores live
 under `~/.rove/` (or the selected Rove home):
 
-- `pty-exits.json` records **abnormal** exits only. It keeps at most the newest
-  50 session records, with exit metadata and up to the last 40 plain-text
-  output lines per session. `rove api inspect` exposes these as
-  `sessionExits`; clean exits are omitted.
+- `pty-exits.json` keeps at most the newest 50 death records, with exit
+  metadata and up to the last 40 plain-text output lines each. `rove api
+  inspect` exposes these as `sessionExits`, newest first. Two layers:
+  `layer: "pty"` is the terminal process itself (abnormal exits only), and
+  `layer: "engine"` is the AI process gone from a terminal that kept running
+  — the case where you return to a shell prompt and want to know what
+  happened. An engine record names the engine's pid, its vendor, and the exit
+  code from the shell's `Engine exited (code N)` banner; code 143 means it
+  was killed with SIGTERM.
+
+  To find out **who** killed it: Rove logs every signal it sends a terminal
+  subtree to `daemon.log` as `[pty-signal]`. POSIX gives a dying process no
+  way to learn its killer's pid, so attribution works by elimination — no
+  `[pty-signal]` line for that session means the signal came from outside
+  Rove (the engine's own wrapper, a provider limit, the OS, or your shell).
 - `pty-sessions/` freezes each hosted session's launch metadata and bounded
   scrollback ring so a PTY-host crash, restart, or machine reboot can restore
   the old screen and respawn the launch command. An explicit tab close or task

--- a/packages/kobe-daemon/src/daemon/activity-observer.ts
+++ b/packages/kobe-daemon/src/daemon/activity-observer.ts
@@ -23,6 +23,15 @@
  *     each session. Walk evidence gates every claim, and "no engine" is
  *     positive proof a `running` claim is stale.
  *
+ * The walk's vendor→no-engine EDGE is also the only place an engine death
+ * inside a still-living PTY is observable: the tab's shell wrapper reaps the
+ * engine and `exec`s a fallback shell, so `pty.list` still reports the
+ * session alive and the PTY-layer exit hook never fires. That edge is
+ * persisted via `onEngineExit` (issue: seven engines died to a provider
+ * usage limit and left zero records). Detection latency is one walk cadence
+ * (~60s) — a sampler, not an event; the tail it captures is what makes it
+ * useful, not the timestamp's precision.
+ *
  * Findings fold into the registry via `observeTab` (hook events outrank
  * observation; only a stale hook `running` is ever corrected — see there).
  * The FIRST tick runs immediately and includes a walk, so a daemon restart
@@ -33,7 +42,8 @@
 import { KobeDaemonClient } from "../client/index.ts"
 import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import { logDaemonInfo } from "./crash-log.ts"
-import { defaultPtyHostSocketPath } from "./paths.ts"
+import { defaultPtyExitsPath, defaultPtyHostSocketPath } from "./paths.ts"
+import { recordEngineExit } from "./pty-exit-store.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
 
 /** Poll cadence — bounds state-flip latency; `pty.list` is one local RPC. */
@@ -68,9 +78,9 @@ export interface ActivityObserverIo {
   /** Current pty-host inventory; `null` when the host is unreachable
    *  (never spawns one). */
   listSessions(): Promise<readonly ObservedPtySession[] | null>
-  /** Foreground engine per session pid (ONE `ps` snapshot walk) — vendor id
-   *  or null for "no engine in this tree". */
-  foregroundEngines(pids: readonly number[]): Promise<ReadonlyMap<number, string | null>>
+  /** Foreground engine per session pid (ONE `ps` snapshot walk) — the
+   *  engine's vendor + its own pid, or null for "no engine in this tree". */
+  foregroundEngines(pids: readonly number[]): Promise<ReadonlyMap<number, { vendor: string; pid: number } | null>>
   /** Engine-owned title verdict — see kobe's `engineTitleTurnHint`. */
   titleTurnHint(vendor: string, title: string): "working" | "rest" | null
   /**
@@ -84,6 +94,13 @@ export interface ActivityObserverIo {
     tabId: string,
     evidence: { readonly walkVendor: string | null; readonly title: string },
   ): void
+  /**
+   * An engine vanished from a session whose PTY is STILL ALIVE — the blind
+   * spot the PTY-layer exit hook cannot see. Fired once per transition
+   * (vendor → no-engine), never on a repeat poll and never for a session
+   * that was never walked with an engine. Optional.
+   */
+  onEngineExit?(info: { taskId: string; tabId: string; vendor: string; pid: number | null }): void
 }
 
 export interface ActivityObserverOptions {
@@ -108,6 +125,10 @@ interface SessionTrack {
   lastActivityAt: number | null
   /** Last walk verdict: vendor id, null = no engine, undefined = never walked. */
   vendor: string | null | undefined
+  /** Pid of the ENGINE the last walk found — what a death record names as
+   *  the process that died. Distinct from the session pid, which outlives
+   *  it; null while no engine is running. */
+  enginePid: number | null
 }
 
 /**
@@ -191,6 +212,7 @@ export function startActivityObserver(
             lastTitle: s.title,
             lastActivityAt: null,
             vendor: undefined,
+            enginePid: null,
           }
           tracks.set(s.key, track)
           newborn.add(s.key)
@@ -225,7 +247,24 @@ export function startActivityObserver(
           const verdicts = await io.foregroundEngines(pids)
           for (const track of toWalk) {
             const pid = pidByKey.get(`${track.taskId}::${track.tabId}`)
-            if (pid !== undefined && verdicts.has(pid)) track.vendor = verdicts.get(pid) ?? null
+            if (pid === undefined || !verdicts.has(pid)) continue
+            const found = verdicts.get(pid) ?? null
+            // The engine-death edge: this walk found no engine where the
+            // previous one found `track.vendor`, and the session is still
+            // alive (it is in `live`). That is the shape the PTY exit hook
+            // structurally cannot report — record it, once, on the edge.
+            // `enginePid` is the DEAD engine's pid, captured on the last
+            // walk that still saw it (it is unresolvable now, by definition).
+            if (found === null && typeof track.vendor === "string") {
+              io.onEngineExit?.({
+                taskId: track.taskId,
+                tabId: track.tabId,
+                vendor: track.vendor,
+                pid: track.enginePid,
+              })
+            }
+            track.vendor = found?.vendor ?? null
+            track.enginePid = found?.pid ?? null
           }
         } catch {
           // ps failed — keep prior verdicts; sessions never walked stay
@@ -290,7 +329,31 @@ export function createActivityObserverIo(
   homeDir: string | undefined,
   runtime: Pick<DaemonRuntimeAdapter, "foregroundEngines" | "titleTurnHint">,
 ): ActivityObserverIo {
+  const peek = async (key: string): Promise<string> => {
+    const client = new KobeDaemonClient(defaultPtyHostSocketPath(homeDir))
+    try {
+      await client.connect()
+      const result = await client.request<{ data?: string }>("pty.peek", { key })
+      return Buffer.from(result.data ?? "", "base64").toString("utf8")
+    } catch {
+      return ""
+    } finally {
+      client.close()
+    }
+  }
   return {
+    // The engine died inside a living PTY: grab that PTY's tail (the
+    // provider error / usage-limit line lives there) and persist a record
+    // the PTY-layer hook would never write. Best-effort by contract.
+    onEngineExit({ taskId, tabId, vendor, pid }) {
+      const key = `${taskId}::${tabId}`
+      void peek(key)
+        .then((tail) =>
+          recordEngineExit({ key, vendor, pid, at: new Date().toISOString(), tail }, defaultPtyExitsPath(homeDir)),
+        )
+        .catch((err) => logDaemonInfo("engine-exit", `record failed for ${key}: ${String(err)}`))
+      logDaemonInfo("engine-exit", `${vendor} (pid ${pid ?? "?"}) gone from live session ${key}`)
+    },
     async listSessions() {
       const client = new KobeDaemonClient(defaultPtyHostSocketPath(homeDir))
       try {

--- a/packages/kobe-daemon/src/daemon/pty-child-controller.ts
+++ b/packages/kobe-daemon/src/daemon/pty-child-controller.ts
@@ -95,7 +95,13 @@ export class PtyChildController {
       this.markExited(session)
       return
     }
-    await terminatePtyChild(proc, () => this.markExited(session))
+    // Log every signal Rove sends: the only way a post-mortem can tell
+    // "Rove killed it" from "something else did" (see pty-termination).
+    await terminatePtyChild(
+      proc,
+      () => this.markExited(session),
+      (line) => this.deps.log?.("pty-signal", `${session.key}: ${line}`),
+    )
   }
 
   /** Record the child's death once and notify the host. Idempotent. */

--- a/packages/kobe-daemon/src/daemon/pty-exit-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-store.ts
@@ -8,8 +8,16 @@
  * `get-task`/`inspect` can answer "how did it die" long after the host is
  * gone.
  *
- * Noise rules: clean exits (code 0, no signal) and internal keys (the warm
- * `::spare`) are never recorded. The file is capped to the newest
+ * TWO layers land here. `pty` records come from the host's exit hook — the
+ * session's own child died. `engine` records come from the daemon's activity
+ * observer noticing the AI process gone from a session that is STILL ALIVE:
+ * a tab's shell wrapper reaps its engine and `exec`s a fallback shell, so
+ * that death is invisible to the hook above and used to leave no trace at
+ * all. Store keys differ (`<key>` vs `<key>#engine`) so both coexist.
+ *
+ * Noise rules: clean PTY exits (code 0, no signal) and internal keys (the
+ * warm `::spare`) are never recorded — engine deaths always are, since an
+ * unexplained one is exactly what we came for. The file is capped to the newest
  * {@link MAX_RECORDS} records; a corrupt/missing file reads as empty.
  * Everything here is best-effort by contract — the host wraps the write in
  * its own fail-safe guard too.
@@ -20,7 +28,17 @@ import { dirname } from "node:path"
 import { defaultPtyExitsPath } from "./paths.ts"
 import type { PtySessionEndInfo } from "./pty-observability.ts"
 
-/** One persisted record, keyed by session key (`taskId::tabId`). */
+/**
+ * Which process died. `pty` is the session's own child (the shell wrapper);
+ * `engine` is the AI process INSIDE a still-living PTY — the layer the PTY
+ * hook is structurally blind to, because the wrapper `exec`s a fallback
+ * shell and keeps the session alive (`session-launch.ts` keepAlive).
+ */
+export type PtyExitLayer = "pty" | "engine"
+
+/** One persisted record. Store key is the session key for `pty` records and
+ *  `<sessionKey>#engine` for engine ones, so both layers of the same tab
+ *  coexist; `key` always names the session either way. */
 export interface PtyExitRecord {
   readonly key: string
   readonly pid: number | null
@@ -29,6 +47,13 @@ export interface PtyExitRecord {
   readonly at: string
   /** Plain-text last lines of output (ANSI stripped, CR-folded). */
   readonly tail: readonly string[]
+  /** Absent on legacy records written before engine-layer deaths existed. */
+  readonly layer?: PtyExitLayer
+  /** Engine layer only: which engine died, per the foreground walk. */
+  readonly vendor?: string
+  /** Engine layer only: always true — the PTY outlived its engine, which is
+   *  exactly what makes this record's existence meaningful. */
+  readonly parentAlive?: boolean
 }
 
 const MAX_RECORDS = 50
@@ -48,7 +73,24 @@ export function plainTail(raw: string): string[] {
   return lines.slice(-TAIL_LINES)
 }
 
-/** All records keyed by session key; empty on missing/corrupt file. */
+/**
+ * Exit code of the dead engine, scraped from the shell wrapper's own
+ * `⚠ Engine exited (code N)` banner (`session-launch.ts` keepAlive) in the
+ * PTY tail. A `ps` walk cannot observe a reaped child's status — the
+ * wrapper shell reaped it, not us — so this line is the ONLY exit code that
+ * exists at this layer. Null when the banner is absent (engine exited 0, or
+ * a launch command without the wrapper). Codes >128 are signal deaths
+ * (143 = 128+SIGTERM), which the shell reports the same way.
+ */
+export function engineExitCodeFromTail(tail: readonly string[]): number | null {
+  for (let i = tail.length - 1; i >= 0; i--) {
+    const m = /Engine exited \(code (\d+)\)/.exec(tail[i] ?? "")
+    if (m?.[1]) return Number.parseInt(m[1], 10)
+  }
+  return null
+}
+
+/** All records keyed by store key; empty on missing/corrupt file. */
 export function readPtyExitRecords(path = defaultPtyExitsPath()): Record<string, PtyExitRecord> {
   try {
     const parsed: unknown = JSON.parse(readFileSync(path, "utf8"))
@@ -68,18 +110,76 @@ export function readPtyExitRecords(path = defaultPtyExitsPath()): Record<string,
 export function recordPtyExit(info: PtySessionEndInfo, path = defaultPtyExitsPath()): void {
   if (info.key.startsWith("::")) return
   if (info.exit.code === 0 && info.exit.signal === null) return
+  writeRecord(
+    info.key,
+    {
+      key: info.key,
+      pid: info.pid,
+      code: info.exit.code,
+      signal: info.exit.signal,
+      at: info.exit.at,
+      tail: plainTail(info.tail),
+      layer: "pty",
+    },
+    path,
+  )
+}
+
+/** What the activity observer hands {@link recordEngineExit}. */
+export interface EngineExitInfo {
+  /** Session key (`taskId::tabId`) of the PTY that OUTLIVED this engine. */
+  readonly key: string
+  readonly vendor: string
+  /** The ENGINE's own pid, from the last walk that still saw it alive; null
+   *  when no walk ever resolved one. Never the surviving session's pid. */
+  readonly pid: number | null
+  readonly at: string
+  /** Raw PTY tail at detection time (ANSI included; stripped here). */
+  readonly tail: string
+}
+
+/**
+ * Persist one ENGINE death — the AI process gone from a PTY that is still
+ * alive. Detected by the foreground walk losing its vendor, so there is no
+ * wait status to read: `signal` is always null and `code` comes from the
+ * wrapper's banner when it printed one ({@link engineExitCodeFromTail}).
+ * Recording an unexplained death is the point, so unlike the PTY layer
+ * there is no clean-exit noise rule — every disappearance is written.
+ */
+export function recordEngineExit(info: EngineExitInfo, path = defaultPtyExitsPath()): void {
+  if (info.key.startsWith("::")) return
+  const tail = plainTail(info.tail)
+  writeRecord(
+    `${info.key}#engine`,
+    {
+      key: info.key,
+      pid: info.pid,
+      code: engineExitCodeFromTail(tail),
+      signal: null,
+      at: info.at,
+      tail,
+      layer: "engine",
+      vendor: info.vendor,
+      parentAlive: true,
+    },
+    path,
+  )
+}
+
+/**
+ * Read-modify-write one record under the cap.
+ *
+ * ponytail: last-writer-wins across the two writer processes (PTY host for
+ * `pty` records, daemon for `engine` ones). An interleave loses a record;
+ * add a lockfile if that is ever observed, not before — the writes are
+ * seconds apart in practice and a lost record is what we had before.
+ */
+function writeRecord(storeKey: string, record: PtyExitRecord, path: string): void {
   const records = readPtyExitRecords(path)
-  records[info.key] = {
-    key: info.key,
-    pid: info.pid,
-    code: info.exit.code,
-    signal: info.exit.signal,
-    at: info.exit.at,
-    tail: plainTail(info.tail),
-  }
-  const newest = Object.values(records)
-    .sort((a, b) => (a.at < b.at ? 1 : -1))
+  records[storeKey] = record
+  const newest = Object.entries(records)
+    .sort(([, a], [, b]) => (a.at < b.at ? 1 : -1))
     .slice(0, MAX_RECORDS)
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify(Object.fromEntries(newest.map((r) => [r.key, r])), null, 2), "utf8")
+  writeFileSync(path, JSON.stringify(Object.fromEntries(newest), null, 2), "utf8")
 }

--- a/packages/kobe-daemon/src/daemon/pty-termination.ts
+++ b/packages/kobe-daemon/src/daemon/pty-termination.ts
@@ -44,16 +44,24 @@ export async function settledWithin(exited: Promise<unknown>, ms: number): Promi
  * calls `TerminateProcess`. That makes even the SIGTERM step a hard kill on
  * Windows, so an engine never gets to flush; tracked separately rather than
  * papered over here.
+ *
+ * Every signal Rove sends a PTY subtree goes through here, so `onSignal` is
+ * the complete record of Rove's own killing. A receiver cannot learn its
+ * killer's pid on POSIX (that needs `SA_SIGINFO`, which Node does not
+ * expose), so post-mortem attribution is elimination only: no line here for
+ * a dead engine's group means something OUTSIDE Rove sent the signal.
  */
 export function signalProcessGroup(
   pid: number,
   signal: NodeJS.Signals,
   fallback: () => void,
   platform: NodeJS.Platform = process.platform,
+  onSignal?: (line: string) => void,
 ): void {
   if (platform !== "win32" && pid > 1) {
     try {
       process.kill(-pid, signal)
+      onSignal?.(`sent ${signal} to process group -${pid}`)
       return
     } catch {
       // Some runtimes do not make the PTY child its own group leader.
@@ -61,6 +69,7 @@ export function signalProcessGroup(
   }
   try {
     fallback()
+    onSignal?.(`sent ${signal} to pid ${pid} (per-process fallback)`)
   } catch {
     /* already gone */
   }
@@ -78,10 +87,14 @@ const TERMINATION_GRACE_MS = 500
  * A child that outlives SIGKILL is already beyond this process's reach;
  * reporting the session dead is strictly better than never returning.
  */
-export async function terminatePtyChild(proc: PtyChild, onSettled: () => void): Promise<void> {
-  signalProcessGroup(proc.pid, "SIGTERM", () => proc.kill("SIGTERM"))
+export async function terminatePtyChild(
+  proc: PtyChild,
+  onSettled: () => void,
+  onSignal?: (line: string) => void,
+): Promise<void> {
+  signalProcessGroup(proc.pid, "SIGTERM", () => proc.kill("SIGTERM"), process.platform, onSignal)
   if (!(await settledWithin(proc.exited, TERMINATION_GRACE_MS))) {
-    signalProcessGroup(proc.pid, "SIGKILL", () => proc.kill("SIGKILL"))
+    signalProcessGroup(proc.pid, "SIGKILL", () => proc.kill("SIGKILL"), process.platform, onSignal)
     await settledWithin(proc.exited, TERMINATION_GRACE_MS)
   }
   onSettled()

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -47,10 +47,12 @@ export interface DaemonRuntimeAdapter {
   /**
    * Foreground engine per session root pid — ONE `ps` snapshot walked per
    * pid (kobe's `engine/foreground.ts`, the same primitive `kobe api
-   * inspect` uses). Vendor id, or null for "no engine in this tree".
-   * Consumed by the daemon activity observer's reconciler (issues #11/#16).
+   * inspect` uses). The engine's own vendor AND pid, or null for "no engine
+   * in this tree". Consumed by the daemon activity observer's reconciler
+   * (issues #11/#16); the pid is what a death record names as the process
+   * that actually died, distinct from the PTY that outlived it.
    */
-  foregroundEngines(pids: readonly number[]): Promise<ReadonlyMap<number, VendorId | null>>
+  foregroundEngines(pids: readonly number[]): Promise<ReadonlyMap<number, { vendor: VendorId; pid: number } | null>>
   /**
    * Engine-owned verdict on a live OSC title (`engineTitleTurnHint`):
    * "working" while the vendor's animated frame prefixes it, "rest" when a

--- a/packages/kobe/src/cli/api/handlers-inspect.ts
+++ b/packages/kobe/src/cli/api/handlers-inspect.ts
@@ -102,11 +102,15 @@ async function sessionsSection(taskId: string | undefined): Promise<unknown> {
 
 /** Durable death records (`pty-exits.json`) — survive the host's idle-exit,
  *  so "how did it die" stays answerable with no host running. Includes the
- *  exit-time output tail (plain text). */
+ *  exit-time output tail (plain text). TWO layers: `layer: "pty"` is the
+ *  session's own child, `layer: "engine"` is the AI process gone from a
+ *  session that stayed alive (`parentAlive: true`). Legacy records predate
+ *  the field and are all PTY-layer. Newest first — a triage read wants
+ *  today's deaths, not the file's key order. */
 async function sessionExitsSection(taskId: string | undefined): Promise<unknown> {
   try {
     const { readPtyExitRecords } = await import("@sma1lboy/kobe-daemon/daemon/pty-exit-store")
-    const records = Object.values(readPtyExitRecords())
+    const records = Object.values(readPtyExitRecords()).sort((a, b) => (a.at < b.at ? 1 : -1))
     return taskId ? records.filter((r) => r.key.startsWith(`${taskId}::`)) : records
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) }

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -51,8 +51,11 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   // snapshot, then the same shallowest-engine walk `kobe api inspect` uses.
   async foregroundEngines(pids) {
     const rows = parsePsSnapshot(await psSnapshot())
-    const out = new Map<number, VendorId | null>()
-    for (const pid of pids) out.set(pid, foregroundEngineIn(rows, pid)?.vendor ?? null)
+    const out = new Map<number, { vendor: VendorId; pid: number } | null>()
+    for (const pid of pids) {
+      const found = foregroundEngineIn(rows, pid)
+      out.set(pid, found ? { vendor: found.vendor, pid: found.pid } : null)
+    }
     return out
   },
   titleTurnHint: engineTitleTurnHint,

--- a/packages/kobe/test/daemon/engine-exit-record.test.ts
+++ b/packages/kobe/test/daemon/engine-exit-record.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Engine-layer death records: the blind spot behind the 2026-08-30 incident
+ * (seven engines killed by a provider usage limit; `pty-exits.json` held
+ * ZERO records, because every wrapper shell survived its engine).
+ *
+ * Two halves, tested where each lives: the store must persist an engine
+ * death with the wrapper's exit code scraped out of the tail, and the
+ * activity observer must FIRE one exactly on the walk's vendor→no-engine
+ * edge of a session that is still alive.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { startActivityObserver } from "@sma1lboy/kobe-daemon/daemon/activity-observer"
+import {
+  engineExitCodeFromTail,
+  readPtyExitRecords,
+  recordEngineExit,
+  recordPtyExit,
+} from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+let dir: string
+let path: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kobe-engine-exit-"))
+  path = join(dir, "pty-exits.json")
+})
+afterEach(() => rmSync(dir, { recursive: true, force: true }))
+
+// The real shape from the incident: provider error, zsh's own kill notice,
+// then the keepAlive wrapper's banner (ANSI-wrapped). 143 = 128 + SIGTERM.
+const INCIDENT_TAIL =
+  "Error: [provider.auth_error] 403 You_ve reached your 5-hour usage limit.\r\n" +
+  "zsh: terminated  kimi -y\r\n" +
+  "\x1b[33m  Engine exited (code 143). Check Settings\x1b[0m\r\n"
+
+describe("engine exit code scrape", () => {
+  it("reads the wrapper banner's code and null when absent", () => {
+    expect(engineExitCodeFromTail(["  Engine exited (code 143). Check Settings"])).toBe(143)
+    expect(engineExitCodeFromTail(["all quiet", "$ "])).toBeNull()
+  })
+
+  it("takes the LAST banner — a tab that restarted its engine twice", () => {
+    expect(engineExitCodeFromTail(["Engine exited (code 1).", "Engine exited (code 143)."])).toBe(143)
+  })
+})
+
+describe("engine death records", () => {
+  it("persists the incident shape: code, vendor, tail, live parent", () => {
+    recordEngineExit(
+      { key: "t1::tab-1", vendor: "kimi", pid: 5150, at: "2026-08-30T12:00:00.000Z", tail: INCIDENT_TAIL },
+      path,
+    )
+    const record = readPtyExitRecords(path)["t1::tab-1#engine"]
+    expect(record).toMatchObject({
+      key: "t1::tab-1",
+      layer: "engine",
+      vendor: "kimi",
+      pid: 5150,
+      code: 143,
+      signal: null,
+      parentAlive: true,
+    })
+    // The 403 line is why this record exists at all.
+    expect(record?.tail.join("\n")).toContain("5-hour usage limit")
+    // Tail is stored plain — no raw escapes leak into the record.
+    expect(record?.tail.join("\n")).not.toContain("\x1b")
+  })
+
+  it("keeps both layers of one tab — an engine death is not a PTY death", () => {
+    recordEngineExit({ key: "t1::tab-1", vendor: "kimi", pid: 1, at: "2026-08-30T12:00:00.000Z", tail: "" }, path)
+    recordPtyExit(
+      { key: "t1::tab-1", pid: 2, exit: { code: 1, signal: null, at: "2026-08-30T13:00:00.000Z" }, tail: "" },
+      path,
+    )
+    const records = readPtyExitRecords(path)
+    expect(records["t1::tab-1#engine"]?.layer).toBe("engine")
+    expect(records["t1::tab-1"]?.layer).toBe("pty")
+  })
+
+  it("records a clean disappearance too (no banner ⇒ null code)", () => {
+    recordEngineExit({ key: "t1::tab-1", vendor: "claude", pid: 9, at: "2026-08-30T12:00:00.000Z", tail: "$ " }, path)
+    expect(readPtyExitRecords(path)["t1::tab-1#engine"]).toMatchObject({ code: null, vendor: "claude" })
+  })
+})
+
+/** Drive the observer's walk with a steerable per-walk vendor table. */
+function observeWalk(steps: readonly (string | null)[]): Promise<Array<Record<string, unknown>>> {
+  const fired: Array<Record<string, unknown>> = []
+  let walk = 0
+  const stop = startActivityObserver(
+    { observeTab: () => "noop", close: () => {} } as never,
+    {
+      listSessions: () => Promise.resolve([{ key: "t1::tab-1", alive: true, pid: 777, title: "", totalBytes: 1 }]),
+      foregroundEngines: (pids) => {
+        const vendor = steps[Math.min(walk, steps.length - 1)] ?? null
+        walk++
+        // Engine pid deliberately differs from the session pid — a record
+        // naming the surviving PTY instead of the dead engine is the bug.
+        return Promise.resolve(new Map(pids.map((pid) => [pid, vendor ? { vendor, pid: 9001 } : null])))
+      },
+      titleTurnHint: () => null,
+      onEngineExit: (info) => fired.push({ ...info }),
+    },
+    () => true,
+    { pollMs: 5, walkEveryTicks: 1, log: () => {} },
+  )
+  return new Promise((resolve) => {
+    setTimeout(
+      () => {
+        stop()
+        resolve(fired)
+      },
+      5 * steps.length + 80,
+    )
+  })
+}
+
+describe("observer engine-death edge", () => {
+  it("fires once on vendor → no-engine, and not again while it stays gone", async () => {
+    const fired = await observeWalk(["kimi", "kimi", null, null, null])
+    expect(fired).toEqual([{ taskId: "t1", tabId: "tab-1", vendor: "kimi", pid: 9001 }])
+  })
+
+  it("stays silent for a session that never had an engine", async () => {
+    expect(await observeWalk([null, null, null])).toEqual([])
+  })
+
+  it("fires again when an engine is restarted and dies a second time", async () => {
+    const fired = await observeWalk(["kimi", null, "kimi", null, null])
+    expect(fired).toHaveLength(2)
+  })
+})

--- a/packages/kobe/test/engine/activity-observer.test.ts
+++ b/packages/kobe/test/engine/activity-observer.test.ts
@@ -59,8 +59,11 @@ function world(opts: { silenceMs?: number; correctAfterMs?: number } = {}) {
     {
       listSessions: () => Promise.resolve(state.sessions),
       foregroundEngines: (pids) => {
-        const out = new Map<number, string | null>()
-        for (const pid of pids) out.set(pid, state.engines.get(pid) ?? null)
+        const out = new Map<number, { vendor: string; pid: number } | null>()
+        for (const pid of pids) {
+          const vendor = state.engines.get(pid)
+          out.set(pid, vendor ? { vendor, pid: pid + 1 } : null)
+        }
         return Promise.resolve(out)
       },
       titleTurnHint: engineTitleTurnHint,

--- a/packages/kobe/test/engine/protocol-upgrade-reporter.test.ts
+++ b/packages/kobe/test/engine/protocol-upgrade-reporter.test.ts
@@ -132,8 +132,11 @@ describe("observer → reporter relay", () => {
             sessions.map((s) => ({ key: s.key, alive: true, pid: s.pid, title: s.title, totalBytes: 1 })),
           ),
         foregroundEngines: (pids) => {
-          const out = new Map<number, string | null>()
-          for (const pid of pids) out.set(pid, engines.get(pid) ?? null)
+          const out = new Map<number, { vendor: string; pid: number } | null>()
+          for (const pid of pids) {
+            const vendor = engines.get(pid)
+            out.set(pid, vendor ? { vendor, pid: pid + 1 } : null)
+          }
           return Promise.resolve(out)
         },
         titleTurnHint: engineTitleTurnHint,


### PR DESCRIPTION
## The blind spot

An engine tab's shell wrapper reaps the engine and `exec`s a fallback shell, so the PTY keeps running. The existing death records only fire when the PTY *itself* exits, so an engine dying inside a live terminal leaves no trace at all.

On 2026-08-30 seven engines hit a provider usage limit and died with code 143. `pty-exits.json` held **zero** records for them.

## What this adds

**Detection.** The activity observer's foreground walk already watches which engine runs in each session. Its vendor → no-engine edge, on a session that is still alive, *is* the engine-death signal — it just wasn't recorded. Now it fires `onEngineExit` once on that edge. Latency is one walk cadence (~60s): a sampler, not an event.

**The record.** Persisted to the same `pty-exits.json`, keyed `<sessionKey>#engine` so both layers of one tab coexist:

| field | value |
|---|---|
| `layer` | `"engine"` (existing records get `"pty"`; legacy ones have neither and are all PTY) |
| `vendor` | which engine died |
| `pid` | the **engine's** pid, from the last walk that saw it alive — not the surviving PTY's |
| `code` | scraped from the wrapper's `Engine exited (code N)` banner |
| `signal` | always `null` — see below |
| `parentAlive` | `true`, the fact that makes the record meaningful |
| `tail` | the PTY tail, which is where the provider's 403 line lives |

Engine records skip the clean-exit noise rule: an engine vanishing without explanation is exactly the case worth keeping.

**Signal attribution.** Every signal Rove sends a PTY subtree now logs a `[pty-signal]` line to `daemon.log`.

## Can we record who sent the signal?

**No, and the code says so rather than approximating.** POSIX gives a receiver its killer's pid only through `sigaction` + `SA_SIGINFO`, which Node/Bun don't expose. Two consequences:

- `signal` on an engine record is always `null`. The engine was reaped by its wrapper shell, not by us, so there is no wait status to read — the banner's exit code is the only exit information that exists at this layer. Code 143 = 128+SIGTERM still tells you it was signalled.
- Attribution works by **elimination**: `[pty-signal]` is the complete record of Rove's own killing, so no line for a session means the signal came from outside Rove.

## Verification

Reproduced the incident shape in an isolated sandbox home: started a real claude engine, took both pids from `rove api inspect` (never `ps | grep`), killed the **engine pid only** with SIGTERM, confirmed the PTY survived, and confirmed the record appeared with `code: 143`, `parentAlive: true`, and the wrapper banner in the tail.

Tests pass the delete-the-fix→red gate on three independent breaks (edge detection, code scrape, layer keying), each turning a distinct subset red. Full socket suite: 74 files / 612 tests green.

## Overlap with `fix/engine-exit-visibility`

None — checked. That branch touches `TerminalTabs.tsx`, `use-tab-close.ts`, and `i18n/messages/terminal.ts` (the user-visible toast); this one touches the daemon observer, the exit store, and docs.