### PR TITLE
fix: make force-deleting a worktree recoverable

### DIFF
--- a/.changeset/salvage-force-delete.md
+++ b/.changeset/salvage-force-delete.md
@@ -1,0 +1,25 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Force-deleting a worktree no longer loses your work for good
+
+Deleting a task with `--force` runs `git worktree remove --force`, which wipes
+uncommitted edits and any file you had not yet `git add`ed. There was no copy
+anywhere, so the only thing standing between you and a lost afternoon was the
+confirmation dialog — and two of the three force-delete paths never showed one.
+
+Rove now snapshots everything a forced removal is about to destroy into a git
+ref in the owning repo, before removing anything. List them with
+`git for-each-ref refs/rove/salvage`, then recover a file with
+`git restore --source=refs/rove/salvage/<branch>-<timestamp> -- path/to/file`.
+Files your `.gitignore` covers stay out, so a snapshot is your work, not your
+`node_modules`.
+
+The ref is also written to `~/.rove/daemon.log` next to the deletion's existing
+audit lines, with the recovery commands already filled in — the log you search
+by task title and time when you notice something is missing.
+
+Closing a scratch shell no longer passes `force` at all. It never needed to (a
+scratch row owns no worktree), and the flag stood ready to authorize a real
+destructive removal if that ever stopped being true.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -99,6 +99,20 @@ worktree path, the `--force`/`--delete-branch` flags, and who asked:
 - `client=<n>` — the daemon connection id, which distinguishes concurrent
   callers when neither identity above is present (a TUI keypress, the web UI).
 
+A `salvaged` line appears between `requested` and `removed` when a **forced**
+deletion had uncommitted work to destroy. It names the git ref holding a
+snapshot of that work and the exact commands to recover it:
+
+```
+salvaged task <id> — uncommitted work saved to refs/rove/salvage/<branch>-<stamp> (<sha>).
+Recover with: git -C <repo> show refs/rove/salvage/<branch>-<stamp> | ...
+```
+
+The same line is written for a forced worktree removal from the worktrees page
+or the web UI (`salvaged worktree <path> — …`). No `salvaged` line means there
+was nothing uncommitted to save. See
+[WORKTREES](./WORKTREES.md#recovering-work-a-force-delete-destroyed).
+
 A `failed` line means the deletion ran only partway: the hosted session was
 torn down and the Inbox/activity state cleared, but the worktree directory and
 the task entry remain, and the task is left in `deletion.phase === "error"`

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -124,8 +124,36 @@ Dirty removal is deliberately two-stage:
 
 The first confirmation can never silently turn into a force deletion. The
 second confirmation is the boundary that authorizes data loss. The branch is
-still retained, but uncommitted and untracked files are not recoverable from
-that branch.
+still retained, but uncommitted and untracked files are not part of it.
+
+### Recovering work a force delete destroyed
+
+Before any forced removal, Rove snapshots everything the removal is about to
+destroy — modified tracked files and files you never `git add`ed — into a git
+ref in the owning repo. Files matched by `.gitignore` (`node_modules/`, build
+output) are excluded.
+
+List the snapshots, newest last:
+
+```
+git for-each-ref refs/rove/salvage
+```
+
+Then inspect and restore from one, run inside the owning repository:
+
+```
+git show refs/rove/salvage/<branch>-<timestamp>
+git restore --source=refs/rove/salvage/<branch>-<timestamp> -- path/to/file
+```
+
+The snapshot's exact ref is also written to `~/.rove/daemon.log` beside the
+deletion's audit lines, with the recovery commands filled in — see
+[TROUBLESHOOTING](./TROUBLESHOOTING.md#who-deleted-my-task) for how to find the
+deletion by task title and time.
+
+The refs are ordinary git refs: they are not garbage-collected, and they are
+never pushed. Delete one you no longer need with
+`git update-ref -d refs/rove/salvage/<branch>-<timestamp>`.
 
 ## Troubleshooting
 

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -63,6 +63,7 @@
     "./daemon/runtime": "./src/daemon/runtime.ts",
     "./daemon/server": "./src/daemon/server.ts",
     "./daemon/status-disposition": "./src/daemon/status-disposition.ts",
+    "./daemon/task-deletion-audit": "./src/daemon/task-deletion-audit.ts",
     "./daemon/terminal-colors": "./src/daemon/terminal-colors.ts",
     "./daemon/transcript-activity-collector": "./src/daemon/transcript-activity-collector.ts",
     "./daemon/ui-prefs-watcher": "./src/daemon/ui-prefs-watcher.ts",

--- a/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
@@ -18,6 +18,7 @@
  *
  * One line per phase so a partial deletion is legible as such:
  *   requested → the RPC was accepted (carries the origin)
+ *   salvaged  → a FORCED removal snapshotted uncommitted work first
  *   removed   → the worktree + index entry are gone
  *   failed    → the worktree removal threw; the task is retained in `error`
  */
@@ -105,4 +106,42 @@ export function auditDeletionFailed(taskId: string, task: DaemonTask | undefined
   const frames = cause.stack?.split("\n").slice(1) ?? []
   if (frames.length > 0) line.stack = [`${line.name}: ${line.message}`, ...frames].join("\n")
   logDaemonError(SUBSYSTEM, line)
+}
+
+/**
+ * The recovery half of a salvage line: where the snapshot is and what to type.
+ * A bare SHA leaves the last step as an exercise for somebody who has just
+ * lost work, so the commands ship with it. `repo` scopes them with `-C` when
+ * known (a task carries its repo; a bare worktree path does not).
+ */
+function recoveryText(ref: string, commit: string, repo?: string): string {
+  const at = repo ? ` -C ${repo}` : ""
+  return (
+    `uncommitted work saved to ${ref} (${commit}). Recover with: ` +
+    `git${at} show ${ref}  |  git${at} restore --source=${ref} -- <path>  |  ` +
+    `list all: git${at} for-each-ref refs/rove/salvage`
+  )
+}
+
+/**
+ * A forced task deletion snapshotted the uncommitted work it was about to
+ * destroy.
+ *
+ * Logged next to the `requested`/`removed` pair on purpose: someone who has
+ * just noticed that work is gone knows the task title and roughly when, which
+ * is exactly how this log reads. Finding the snapshot from a bare git ref
+ * listing would instead require already knowing that it exists.
+ */
+export function auditDeletionSalvaged(taskId: string, ref: string, commit: string, repo?: string): void {
+  logDaemonInfo(SUBSYSTEM, `salvaged task ${taskId} — ${recoveryText(ref, commit, repo)}`)
+}
+
+/**
+ * A forced worktree removal outside the task lifecycle (worktrees page / web
+ * DELETE) salvaged uncommitted work. Same subsystem as the task-deletion
+ * lines: this is the same class of loss, and a user searching `daemon.log`
+ * for their vanished work should not have to know which UI destroyed it.
+ */
+export function auditWorktreeSalvaged(worktreePath: string, ref: string, commit: string): void {
+  logDaemonInfo(SUBSYSTEM, `salvaged worktree ${worktreePath} — ${recoveryText(ref, commit)}`)
 }

--- a/packages/kobe/src/core/daemon-worktree-adapter.ts
+++ b/packages/kobe/src/core/daemon-worktree-adapter.ts
@@ -1,4 +1,5 @@
 import { statSync } from "node:fs"
+import { auditWorktreeSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
 import { execHostForWorktreePath } from "../exec/resolve.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
 import { type PrState, judgeWorktree, parseGhPrList } from "../orchestrator/worktree/staleness.ts"
@@ -105,8 +106,19 @@ export async function listWorktreeProjectsAdapter(network: boolean): Promise<Wor
   )
 }
 
-export function removeWorktreeAdapter(path: string, force: boolean): Promise<void> {
-  return manager.remove(path, { force })
+/**
+ * The worktrees page / web DELETE path. Its force retry re-uses a `row`
+ * captured BEFORE the first attempt's dirty refusal, so by the time the user
+ * answers the confirm the tree may hold work the confirm never described.
+ * `manager.remove` salvages any uncommitted work first; this records where.
+ */
+export async function removeWorktreeAdapter(path: string, force: boolean): Promise<void> {
+  await manager.remove(path, {
+    force,
+    onSalvage: (record) => {
+      if (record) auditWorktreeSalvaged(path, record.ref, record.commit)
+    },
+  })
 }
 
 export async function handleWorktreesRequestAdapter(request: Request, url: URL): Promise<Response | null> {

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -7,6 +7,7 @@
 
 import { homedir } from "node:os"
 import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
+import { auditDeletionSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
 import { Orchestrator } from "../orchestrator/core.ts"
 import { TaskIndexStore } from "../orchestrator/index/store.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
@@ -28,7 +29,15 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
   const store = new TaskIndexStore({ homeDir })
   await store.load()
   const worktrees = new GitWorktreeManager()
-  const orchestrator = new Orchestrator({ store, worktrees })
+  const orchestrator = new Orchestrator({
+    store,
+    worktrees,
+    // A forced delete's salvage ref goes to daemon.log beside the rest of the
+    // deletion audit trail, which is where TROUBLESHOOTING already sends a
+    // user asking "what happened to my task".
+    onSalvage: (taskId, salvage) =>
+      auditDeletionSalvaged(String(taskId), salvage.ref, salvage.commit, store.get(taskId)?.repo),
+  })
 
   return {
     homeDir,

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -50,6 +50,11 @@ export type TaskListListener = (snapshot: readonly Task[]) => void
 export interface OrchestratorDeps {
   readonly store: TaskIndexStore
   readonly worktrees: GitWorktreeManager
+  /** Called when a forced task deletion snapshotted uncommitted work before
+   *  destroying it. The daemon binds this to its deletion audit log; a TUI-
+   *  local orchestrator leaves it unset and the snapshot is still findable
+   *  via `git for-each-ref refs/rove/salvage`. */
+  readonly onSalvage?: (taskId: TaskId, salvage: { readonly ref: string; readonly commit: string }) => void
 }
 
 // Re-exported from `title.ts` (its single source of truth) so existing
@@ -85,8 +90,11 @@ export class Orchestrator {
     )
     this.mainTasks = new MainTaskCoordinator(this.store, (id) => this.worktreeCoordinator.forget(id))
     this.editor = new TaskEditor(this.store, this.worktrees)
-    this.deletions = new TaskDeletionCoordinator(this.store, this.worktrees, (id) =>
-      this.worktreeCoordinator.forget(id),
+    this.deletions = new TaskDeletionCoordinator(
+      this.store,
+      this.worktrees,
+      (id) => this.worktreeCoordinator.forget(id),
+      deps.onSalvage,
     )
     this.tasksAcc = createStateCell<Task[]>(this.store.list())
     // Seed focus from the persisted `lastActive` record (state/last-active

--- a/packages/kobe/src/orchestrator/task-deletion.ts
+++ b/packages/kobe/src/orchestrator/task-deletion.ts
@@ -3,6 +3,7 @@ import type { TaskId } from "../types/task.ts"
 import { CannotDeleteMainTaskError, DirtyWorktreeError, WorktreeRemoveFailedError } from "./errors.ts"
 import type { TaskIndexStore } from "./index/store.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
+import type { SalvageRecord } from "./worktree/salvage.ts"
 
 /** Caller options for a task deletion. `deleteBranch` is a separate opt-in,
  *  never implied by `force`. */
@@ -20,6 +21,13 @@ export class TaskDeletionCoordinator {
     private readonly store: TaskIndexStore,
     private readonly worktrees: GitWorktreeManager,
     private readonly forgetTask: (id: TaskId) => void,
+    /**
+     * Notified when a forced removal salvaged uncommitted work. The daemon
+     * wires this to the deletion audit log so the recovery ref lands beside
+     * the `removed` line — a user who just lost a tab has the task title and
+     * roughly the time, and that is what the audit trail is indexed by.
+     */
+    private readonly onSalvage?: (taskId: TaskId, record: SalvageRecord) => void,
   ) {}
 
   /** Persist acceptance after the destructive dirty-worktree safety check. */
@@ -79,6 +87,16 @@ export class TaskDeletionCoordinator {
         await this.worktrees.remove(task.worktreePath, {
           force: task.deletion.force,
           deleteBranch: task.deletion.deleteBranch === true,
+          // `force` was frozen at prepare() time and this runs on a later
+          // tick — possibly in a later daemon process (`resume()` replays a
+          // queued deletion after a restart), so the worktree may have gone
+          // dirty since the check that authorised the force. Re-evaluating
+          // the gate here would be a behavior change (a delete the user
+          // already confirmed would start failing); salvaging instead keeps
+          // the delete as asked and makes the loss recoverable.
+          onSalvage: (record) => {
+            if (record) this.onSalvage?.(task.id, record)
+          },
         })
       }
     } catch (cause) {

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -41,6 +41,7 @@ import {
 } from "./manager-branch.ts"
 import { type ListDeps, adoptablePaths, listAllAdoptable, listBranchNames, listManaged } from "./manager-list.ts"
 import { canonicalize, remoteWorktreePathFor, requireAbsolute, worktreePathFor } from "./paths.ts"
+import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
 import { parseWorktreeListPorcelain } from "./worktree-list.ts"
 
 export class GitWorktreeManager implements WorktreeManager {
@@ -195,10 +196,23 @@ export class GitWorktreeManager implements WorktreeManager {
    * is best-effort: it runs after the worktree is gone and a failure (branch
    * checked out elsewhere, name gone) is swallowed, never masking a successful
    * removal.
+   *
+   * `force` bypasses the dirty check, so uncommitted edits and untracked files
+   * are destroyed. Every force path first takes a salvage snapshot
+   * ({@link salvageWorktree}) into `refs/rove/salvage/<branch>-<stamp>` — this
+   * is the one chokepoint all three force callers share, so the guard lives
+   * here rather than in each of them. `onSalvage` reports the ref so the caller
+   * can surface it; salvage never fails the removal the caller asked for.
    */
   async remove(
     worktreePath: string,
-    opts?: { readonly force?: boolean; readonly deleteBranch?: boolean },
+    opts?: {
+      readonly force?: boolean
+      readonly deleteBranch?: boolean
+      /** Notified with the snapshot a force-removal took (null = nothing to
+       *  save, or the snapshot could not be written). */
+      readonly onSalvage?: (record: SalvageRecord | null) => void
+    },
   ): Promise<void> {
     requireAbsolute("path", worktreePath)
     const exec = this.execDeps.execForPath(worktreePath)
@@ -228,7 +242,13 @@ export class GitWorktreeManager implements WorktreeManager {
       branch = await this.currentBranch(worktreePath).catch(() => null)
     }
 
-    if (!force) {
+    if (force) {
+      // The last moment at which the doomed files still exist. The dirty check
+      // below is exactly what `force` skips, so this is also the only place
+      // that still sees what is being skipped over.
+      const salvaged = await salvageWorktree({ runGit: (e, a, o) => this.runGit(e, a, o) }, exec, worktreePath)
+      opts?.onSalvage?.(salvaged)
+    } else {
       const dirty = await this.isDirty(worktreePath)
       if (dirty) {
         throw new Error(

--- a/packages/kobe/src/orchestrator/worktree/salvage.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage.ts
@@ -1,0 +1,114 @@
+/**
+ * Salvage: make a force-delete recoverable.
+ *
+ * `remove(path, { force: true })` runs `git worktree remove --force`, which
+ * deletes uncommitted edits AND untracked files with no copy anywhere. Three
+ * callers reach it without a fresh dirty check — the queued task deletion
+ * (whose `force` was frozen a daemon restart ago), the scratch-shell teardown,
+ * and the worktrees page's force retry on a row captured before the confirm.
+ * Salvage runs first and writes what is about to be destroyed into the repo's
+ * object database, so "gone" becomes "recoverable".
+ *
+ * Why not `git stash create`: it CANNOT capture untracked files. `-u` is
+ * accepted and silently ignored (the resulting commit has two parents, no
+ * untracked tree) — and a new file nobody has `git add`ed yet is exactly the
+ * kind most easily lost. So the snapshot is built by hand:
+ *
+ *     GIT_INDEX_FILE=<throwaway> git add -A   → stages tracked edits + untracked
+ *     git write-tree                          → a tree of the whole worktree
+ *     git commit-tree <tree> -p HEAD          → a commit rooted at real history
+ *     git update-ref refs/rove/salvage/<slug> → a named, gc-proof anchor
+ *
+ * `git add -A` honours `.gitignore`, so `node_modules/` and build output stay
+ * out; only files a user could actually have authored are captured.
+ *
+ * The ref (not just the loose object) is the point: a dangling commit is
+ * findable only via `git fsck` and expires with gc, while
+ * `git for-each-ref refs/rove/salvage` lists every snapshot by branch and
+ * timestamp — the two things a user who just lost work actually has.
+ */
+
+import type { ExecHost } from "../../exec/exec-host.ts"
+import type { GitRunOpts, GitRunResult } from "./git.ts"
+
+/** The git primitives salvage borrows from the manager. */
+export interface SalvageDeps {
+  runGit(exec: ExecHost, args: readonly string[], opts: GitRunOpts): Promise<GitRunResult>
+}
+
+/** A recorded snapshot: the ref a user recovers from, and the commit it names. */
+export interface SalvageRecord {
+  readonly ref: string
+  readonly commit: string
+}
+
+/** `refs/rove/salvage/<branch>-<utc-stamp>` — a ref name git accepts, keyed by
+ *  the two things a user remembers: which branch, and roughly when. */
+function salvageRef(branch: string | null, now: Date): string {
+  const stamp = now
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d+Z$/, "Z")
+  const slug = (branch ?? "detached").replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^[-.]+|[-.]+$/g, "")
+  return `refs/rove/salvage/${slug || "detached"}-${stamp}`
+}
+
+/**
+ * Snapshot everything in `worktreePath` that a force-remove would destroy.
+ *
+ * Returns null when there is nothing to save (clean worktree) or when the
+ * snapshot could not be taken. NEVER throws: salvage is a safety net around
+ * a delete the caller already asked for, so a failure here must not turn a
+ * requested deletion into an error. A null return is the caller's cue to log
+ * "no snapshot" rather than to abort.
+ */
+export async function salvageWorktree(
+  deps: SalvageDeps,
+  exec: ExecHost,
+  worktreePath: string,
+  now: Date = new Date(),
+): Promise<SalvageRecord | null> {
+  const git = (args: readonly string[]) => deps.runGit(exec, args, { cwd: worktreePath, allowFail: true })
+  try {
+    // Nothing uncommitted (tracked or untracked) → nothing a force-remove
+    // could destroy that HEAD doesn't already hold.
+    const status = await git(["status", "--porcelain"])
+    if (status.exitCode !== 0 || status.stdout.trim().length === 0) return null
+
+    // A throwaway index INSIDE the worktree's own git dir, so staging never
+    // touches the real index and the file dies with the worktree either way.
+    const indexPath = (await git(["rev-parse", "--git-path", "rove-salvage-index"])).stdout.trim()
+    if (!indexPath) return null
+    const withIndex = (args: readonly string[]) =>
+      deps.runGit(exec, args, { cwd: worktreePath, allowFail: true, env: { GIT_INDEX_FILE: indexPath } })
+
+    try {
+      if ((await withIndex(["add", "-A"])).exitCode !== 0) return null
+      const tree = (await withIndex(["write-tree"])).stdout.trim()
+      if (!tree) return null
+
+      // Parent the snapshot on HEAD so `git show <ref>` diffs against the
+      // real history. An unborn branch has no HEAD — commit a root instead
+      // of losing the files.
+      const head = (await git(["rev-parse", "HEAD"])).stdout.trim()
+      const branch = (await git(["rev-parse", "--abbrev-ref", "HEAD"])).stdout.trim()
+      const message = `rove salvage: force-removed worktree ${worktreePath}`
+      const commitArgs = head ? ["commit-tree", tree, "-p", head, "-m", message] : ["commit-tree", tree, "-m", message]
+      const commit = (await withIndex(commitArgs)).stdout.trim()
+      if (!commit) return null
+
+      const ref = salvageRef(branch && branch !== "HEAD" ? branch : null, now)
+      if ((await git(["update-ref", ref, commit])).exitCode !== 0) return null
+      return { ref, commit }
+    } finally {
+      // The index file lives in `.git/worktrees/<name>/`, which the removal
+      // prunes anyway; clearing it keeps a failed salvage from leaving debris
+      // when the caller's remove then also fails. Plain `rm` (not `git rm`,
+      // which only unstages TRACKED paths) through the exec seam so a remote
+      // worktree cleans up over the same ssh connection.
+      await exec.run(["rm", "-f", indexPath], { cwd: worktreePath }).catch(() => undefined)
+    }
+  } catch {
+    return null
+  }
+}

--- a/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
+++ b/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
@@ -8,7 +8,10 @@
  *     sidebar's Scratch section.
  *   - `onScratchExit`: the last shell exited — delete the row outright,
  *     zero ceremony (no confirm; a scratch task owns no
- *     worktree/branch, deletion only drops the index entry).
+ *     worktree/branch, deletion only drops the index entry). Deliberately
+ *     UNFORCED: `kind: "dir"` already skips the dirty gate and never removes
+ *     the directory, so `force` here would only be a standing licence to
+ *     destroy a real worktree if the row's kind ever changed.
  *   - the fold finish (issue #40): the adoption loop moved the shell's
  *     sessions under an existing task — quietly re-point selection to the
  *     folded tab (ONLY when the scratch row was the selected one; a
@@ -65,7 +68,12 @@ export function useScratchShell(deps: {
         deps.selectTask(targetTaskId)
         requestTabActivation(targetTaskId, tabId)
       }
-      await orchestrator.deleteTask(scratchTaskId, { force: true })
+      // No `force`: a scratch row is `kind: "dir"`, and BOTH deletion gates
+      // already special-case that kind (the dirty check is skipped, and
+      // `finish()` never removes a dir task's directory). So `force` bought
+      // nothing here — it only stood ready to authorise a real destructive
+      // removal if this row ever stopped being a dir task.
+      await orchestrator.deleteTask(scratchTaskId)
       forgetTaskTabs(scratchTaskId)
     },
   })
@@ -87,7 +95,8 @@ export function useScratchShell(deps: {
     scratchTeardowns.add(taskId)
     void (async () => {
       try {
-        await orchestrator.deleteTask(taskId, { force: true })
+        // Unforced, for the reason spelled out on the fold path above.
+        await orchestrator.deleteTask(taskId)
         forgetTaskTabs(taskId)
         await finishDeletedTaskFlow({
           orch: orchestrator,

--- a/packages/kobe/test/orchestrator/core-mutations.test.ts
+++ b/packages/kobe/test/orchestrator/core-mutations.test.ts
@@ -302,7 +302,10 @@ describe("deleteTask — safety ladder", () => {
     await orch.deleteTask(t.id, { force: true })
 
     expect(fakeWorktrees.isDirty).not.toHaveBeenCalled()
-    expect(fakeWorktrees.remove).toHaveBeenCalledWith("/wt/dirty", { force: true, deleteBranch: false })
+    expect(fakeWorktrees.remove).toHaveBeenCalledWith(
+      "/wt/dirty",
+      expect.objectContaining({ force: true, deleteBranch: false }),
+    )
     expect(orch.getTask(t.id)).toBeUndefined()
   })
 
@@ -312,7 +315,10 @@ describe("deleteTask — safety ladder", () => {
 
     await orch.deleteTask(t.id)
 
-    expect(fakeWorktrees.remove).toHaveBeenCalledWith("/wt/gone", { force: false, deleteBranch: false })
+    expect(fakeWorktrees.remove).toHaveBeenCalledWith(
+      "/wt/gone",
+      expect.objectContaining({ force: false, deleteBranch: false }),
+    )
     expect(orch.getTask(t.id)).toBeUndefined()
   })
 

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -51,7 +51,10 @@ describe("durable background task deletion", () => {
     await orch.finishTaskDeletion(task.id)
     // Design guarantee (issue #29): delete keeps the branch by default —
     // git is the durable record, the task row is not.
-    expect(worktrees.remove).toHaveBeenCalledWith("/wt/task", { force: false, deleteBranch: false })
+    expect(worktrees.remove).toHaveBeenCalledWith(
+      "/wt/task",
+      expect.objectContaining({ force: false, deleteBranch: false }),
+    )
     expect(orch.getTask(task.id)).toBeUndefined()
   })
 
@@ -61,7 +64,84 @@ describe("durable background task deletion", () => {
     await orch.prepareTaskDeletion(task.id, { deleteBranch: true })
     await orch.beginTaskDeletion(task.id)
     await orch.finishTaskDeletion(task.id)
-    expect(worktrees.remove).toHaveBeenCalledWith("/wt/opt-in", { force: false, deleteBranch: true })
+    expect(worktrees.remove).toHaveBeenCalledWith(
+      "/wt/opt-in",
+      expect.objectContaining({ force: false, deleteBranch: true }),
+    )
+  })
+
+  it("a forced delete reports the salvage ref so the loss is recoverable", async () => {
+    // The queued deletion's `force` was frozen at prepare() time and the
+    // removal runs on a later tick (possibly a later daemon process), so the
+    // worktree can go dirty in between. The gate is deliberately NOT
+    // re-evaluated — instead the manager snapshots, and that ref must reach
+    // the orchestrator's sink or the user has no way to find it.
+    const salvages: { taskId: string; ref: string }[] = []
+    const localStore = new TaskIndexStore({ homeDir: home })
+    await localStore.load()
+    const localOrch = new Orchestrator({
+      store: localStore,
+      worktrees: worktrees as unknown as GitWorktreeManager,
+      onSalvage: (taskId, salvage) => salvages.push({ taskId: String(taskId), ref: salvage.ref }),
+    })
+    worktrees.remove.mockImplementationOnce(
+      async (_path: string, opts: { onSalvage?: (r: { ref: string; commit: string } | null) => void }) => {
+        opts.onSalvage?.({ ref: "refs/rove/salvage/feature-20260830T101500Z", commit: "abc1234" })
+      },
+    )
+
+    const task = await localOrch.createTask({ repo: "/repo", title: "forced", vendor: "claude" })
+    await localStore.update(task.id, { worktreePath: "/wt/salvaged" })
+    await localOrch.prepareTaskDeletion(task.id, { force: true })
+    await localOrch.beginTaskDeletion(task.id)
+    await localOrch.finishTaskDeletion(task.id)
+    localOrch.dispose()
+
+    expect(salvages).toEqual([{ taskId: String(task.id), ref: "refs/rove/salvage/feature-20260830T101500Z" }])
+  })
+
+  it("an unforced delete with nothing to salvage reports nothing", async () => {
+    const salvages: string[] = []
+    const localStore = new TaskIndexStore({ homeDir: home })
+    await localStore.load()
+    const localOrch = new Orchestrator({
+      store: localStore,
+      worktrees: worktrees as unknown as GitWorktreeManager,
+      onSalvage: (_taskId, salvage) => salvages.push(salvage.ref),
+    })
+    worktrees.remove.mockImplementationOnce(
+      async (_path: string, opts: { onSalvage?: (r: null) => void }) => void opts.onSalvage?.(null),
+    )
+
+    const task = await localOrch.createTask({ repo: "/repo", title: "clean", vendor: "claude" })
+    await localStore.update(task.id, { worktreePath: "/wt/clean" })
+    await localOrch.deleteTask(task.id)
+    localOrch.dispose()
+
+    expect(salvages).toEqual([])
+  })
+
+  it("deleting a dir task never touches its directory, forced or not", async () => {
+    // The scratch-shell teardown used to pass `force: true` on the reasoning
+    // that a scratch row owns no worktree. That is true only while the row is
+    // `kind: "dir"` — and the flag was unconditional, so it stood ready to
+    // authorise a real destructive removal if the row's kind ever changed.
+    // Both gates already special-case `dir`, which is what makes the flag
+    // redundant; this pins that, so dropping it stays safe.
+    for (const force of [false, true]) {
+      const task = await orch.createTask({ repo: "/repo", title: "dir", vendor: "claude" })
+      await store.update(task.id, { worktreePath: "/home/me/project", kind: "dir" })
+      worktrees.isDirty.mockResolvedValueOnce(true)
+
+      await expect(orch.prepareTaskDeletion(task.id, { force })).resolves.toBe(true)
+      await orch.beginTaskDeletion(task.id)
+      await orch.finishTaskDeletion(task.id)
+
+      expect(orch.getTask(task.id)).toBeUndefined()
+    }
+    // A dirty `dir` task neither refuses (the gate is skipped) nor removes
+    // anything — with force, and equally without it.
+    expect(worktrees.remove).not.toHaveBeenCalled()
   })
 
   it("force does not escalate into branch deletion", async () => {
@@ -71,7 +151,10 @@ describe("durable background task deletion", () => {
     await orch.prepareTaskDeletion(task.id, { force: true })
     await orch.beginTaskDeletion(task.id)
     await orch.finishTaskDeletion(task.id)
-    expect(worktrees.remove).toHaveBeenCalledWith("/wt/forced", { force: true, deleteBranch: false })
+    expect(worktrees.remove).toHaveBeenCalledWith(
+      "/wt/forced",
+      expect.objectContaining({ force: true, deleteBranch: false }),
+    )
   })
 
   it("keeps a visible error after cleanup failure and supports an explicit retry", async () => {
@@ -121,7 +204,10 @@ describe("durable background task deletion", () => {
     await expect(orch.prepareTaskDeletion(task.id)).resolves.toBe(true)
     await orch.beginTaskDeletion(task.id)
     await orch.finishTaskDeletion(task.id)
-    expect(worktrees.remove).toHaveBeenCalledWith("/wt/gone", { force: false, deleteBranch: false })
+    expect(worktrees.remove).toHaveBeenCalledWith(
+      "/wt/gone",
+      expect.objectContaining({ force: false, deleteBranch: false }),
+    )
     expect(orch.getTask(task.id)).toBeUndefined()
   })
 

--- a/packages/kobe/test/orchestrator/worktree-salvage.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-salvage.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Force-removing a worktree must leave the destroyed work recoverable.
+ *
+ * `remove(path, { force: true })` runs `git worktree remove --force`, which
+ * deletes uncommitted edits AND untracked files with no copy anywhere. Three
+ * callers reach it without a fresh dirty check (a queued task deletion whose
+ * `force` was frozen a daemon restart earlier, the scratch-shell teardown, and
+ * the worktrees page's force retry on a stale row), so the salvage guard lives
+ * at the shared chokepoint rather than in each of them.
+ *
+ * Real git, real files, real destruction: the assertions read the recovered
+ * content back out of the object database AFTER the directory is gone, because
+ * a snapshot nobody can restore from is the failure this exists to prevent.
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, expect, test } from "vitest"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+let tmpRoot: string
+let repo: string
+
+function git(cwd: string, ...args: string[]): string {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`)
+  return r.stdout
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rove-salvage-"))
+  repo = path.join(tmpRoot, "repo")
+  fs.mkdirSync(repo)
+  git(repo, "init", "-q", ".")
+  git(repo, "config", "user.email", "test@example.com")
+  git(repo, "config", "user.name", "Test")
+  fs.writeFileSync(path.join(repo, "tracked.txt"), "committed\n")
+  fs.writeFileSync(path.join(repo, ".gitignore"), "node_modules/\n")
+  git(repo, "add", "-A")
+  git(repo, "commit", "-qm", "init")
+})
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+/** A worktree holding one modified tracked file and one never-added file. */
+function dirtyWorktree(branch: string): string {
+  const wt = path.join(tmpRoot, branch)
+  git(repo, "worktree", "add", "-q", wt, "-b", branch)
+  fs.appendFileSync(path.join(wt, "tracked.txt"), "uncommitted edit\n")
+  fs.writeFileSync(path.join(wt, "never-added.txt"), "brand new file\n")
+  return wt
+}
+
+test("a force-removed worktree's uncommitted work is recoverable from the salvage ref", async () => {
+  const wt = dirtyWorktree("feature")
+  let salvaged: { ref: string; commit: string } | null = null
+
+  await new GitWorktreeManager().remove(wt, {
+    force: true,
+    onSalvage: (record) => {
+      salvaged = record
+    },
+  })
+
+  expect(fs.existsSync(wt)).toBe(false)
+  const record = salvaged as { ref: string; commit: string } | null
+  expect(record).not.toBeNull()
+  expect(record?.ref).toMatch(/^refs\/rove\/salvage\/feature-\d{8}T\d{6}Z$/)
+
+  // The recovery a user actually performs, against the destroyed worktree.
+  expect(git(repo, "show", `${record?.ref}:never-added.txt`)).toBe("brand new file\n")
+  expect(git(repo, "show", `${record?.ref}:tracked.txt`)).toBe("committed\nuncommitted edit\n")
+
+  // Reachable by ref, so `gc` can't reap it and `for-each-ref` finds it.
+  expect(git(repo, "for-each-ref", "refs/rove/salvage", "--format=%(refname)")).toContain(record?.ref)
+})
+
+test("ignored files stay out of the snapshot", async () => {
+  const wt = dirtyWorktree("ignored")
+  fs.mkdirSync(path.join(wt, "node_modules"))
+  fs.writeFileSync(path.join(wt, "node_modules", "big.bin"), "vendor junk\n")
+
+  let salvaged: { ref: string; commit: string } | null = null
+  await new GitWorktreeManager().remove(wt, {
+    force: true,
+    onSalvage: (record) => {
+      salvaged = record
+    },
+  })
+
+  const ref = (salvaged as { ref: string } | null)?.ref
+  expect(git(repo, "ls-tree", "-r", "--name-only", String(ref))).not.toContain("node_modules")
+})
+
+test("a clean worktree salvages nothing", async () => {
+  const wt = path.join(tmpRoot, "clean")
+  git(repo, "worktree", "add", "-q", wt, "-b", "clean")
+
+  let called = false
+  let salvaged: { ref: string } | null = null
+  await new GitWorktreeManager().remove(wt, {
+    force: true,
+    onSalvage: (r) => {
+      called = true
+      salvaged = r
+    },
+  })
+
+  expect(called).toBe(true)
+  expect(salvaged).toBeNull()
+  expect(git(repo, "for-each-ref", "refs/rove/salvage", "--format=%(refname)").trim()).toBe("")
+})
+
+test("an unforced removal of a clean worktree takes no snapshot", async () => {
+  const wt = path.join(tmpRoot, "quiet")
+  git(repo, "worktree", "add", "-q", wt, "-b", "quiet")
+
+  let called = false
+  await new GitWorktreeManager().remove(wt, {
+    onSalvage: () => {
+      called = true
+    },
+  })
+
+  expect(called).toBe(false)
+})


### PR DESCRIPTION
## What

Every force-delete path runs `git worktree remove --force`, which destroys uncommitted edits and never-added files with **no copy anywhere**. This adds a salvage snapshot before the destruction, turning three permanent-loss paths into recoverable ones.

Audit of the three paths (`grep -rn stash` over both packages returns 4 hits, all comments — Rove never stashed anything):

1. **`task-deletion.ts`** — `prepare()` checks `isDirty()` then queues; the removal runs in `finish()` on a later tick, possibly in a **later daemon process** (`resume()` replays queued deletions after a restart). The `force` value is frozen at prepare time and never re-evaluated.
2. **`use-scratch-shell.ts:68,90`** — both passed `{ force: true }` with zero user interaction.
3. **`worktrees-page.tsx:150-171`** — the force retry recurses with the `row` captured *before* the first attempt's dirty refusal.

## How

The fix is one guard at the chokepoint all three share — `GitWorktreeManager.remove()`. Before a forced removal it snapshots the doomed work into `refs/rove/salvage/<branch>-<timestamp>`, and reports the ref via a new `onSalvage` callback that the daemon writes to `daemon.log` beside the existing deletion audit lines.

**`git stash create` cannot do this.** Verified against git 2.50.1: `-u` is accepted and silently ignored — the resulting commit has two parents and no untracked tree, so a never-`git add`ed file (the most easily lost kind) is exactly what it drops. The snapshot is built by hand instead: a throwaway `GIT_INDEX_FILE` + `git add -A` + `write-tree` + `commit-tree -p HEAD` + `update-ref`. `git add -A` honours `.gitignore`, so `node_modules/` stays out.

Salvage never throws — it is a safety net around a delete the caller already asked for, so a failure must not turn a requested deletion into an error.

## Also: dropped a redundant `force: true`

The scratch teardown's `force` bought nothing — both gates already special-case `kind: "dir"` (the dirty check is skipped, and `finish()` never removes a dir task's directory), and `kind` is never mutated after creation. It only stood ready to authorize a real destructive removal if that ever stopped being true. Removed, with a test pinning that a dirty `dir` task is safe either way.

**Not** attempted: re-evaluating the dirty gate in `finish()`. That is a behavior change (a delete the user already confirmed would start failing) and needs an owner decision. This PR only makes the loss recoverable.

## Verification

Mutation-tested — deleting the salvage call, the `onSalvage` forwarding, and the `dir` guard each turns the suite red; run twice each.

Live end-to-end in an isolated sandbox daemon (own `ROVE_HOME_DIR` + socket): created a real task, materialized its worktree, made a real uncommitted edit plus a never-added file plus an ignored `node_modules/`, force-deleted it, and recovered both files byte-for-byte from the logged ref **after the directory was gone** — including `git restore` putting them back on disk. `node_modules` correctly excluded. The worktrees-page path was exercised separately through `removeWorktreeAdapter` and recovered the same way.

The 18 failing `test/cli/**` files are pre-existing (`kobe`→`rove` product-name branding); confirmed by running them on a pristine `origin/main` checkout. No CLI files are touched here.

## Docs

`docs/WORKTREES.md` gains a recovery section; `docs/TROUBLESHOOTING.md` documents the new `salvaged` audit line under the existing "Who deleted my task?" heading.