### PR TITLE
fix: stop losing engine config to concurrent writes

### DIFF
--- a/.changeset/shared-engine-config-races.md
+++ b/.changeset/shared-engine-config-races.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop losing engine config when Rove and Claude write it at the same time. Worktree pre-trust (`~/.claude.json`) and the global hook install (`~/.claude/settings.json`) read-modify-wrote these files with no coordination, from three Rove processes plus Claude Code itself — a lost merge could silently drop an `allowedTools` grant (the agent re-asks for permission) or a task's trust entry (its session sits at "Do you trust the files in this folder?" forever), both of which read as engine bugs. Both writes now run under a cross-process lock and a compare-and-swap against the engine's own wholesale rewrites, and land via a per-call staging file instead of a shared one.

--- a/packages/kobe/src/engine/claude-code-local/trust.ts
+++ b/packages/kobe/src/engine/claude-code-local/trust.ts
@@ -9,29 +9,34 @@
  * The store is `~/.claude.json` → `projects[<abspath>].hasTrustDialogAccepted`
  * (existing entries also carry `hasCompletedProjectOnboarding`). MERGE, never
  * clobber: project entries accumulate per-project state (allowedTools, MCP
- * choices) that must survive.
+ * choices) that must survive — and claude itself rewrites this file wholesale
+ * on every save, so the merge runs under the compare-and-swap in
+ * `../shared-config-write.ts`. Read its module doc before changing the write.
  */
 
-import { readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import path from "node:path"
+import { updateSharedJsonSync } from "../shared-config-write.ts"
 
 export function trustClaudeWorktree(worktreePath: string, home: string = homedir()): void {
-  const file = path.join(home, ".claude.json")
-  let doc: Record<string, unknown> = {}
-  try {
-    doc = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>
-  } catch {
-    // Missing or corrupt — start from an empty doc; corrupt is claude's own
-    // recovery behavior too (it rewrites the file wholesale on every save).
-  }
-  const projects = { ...((doc.projects as Record<string, unknown> | undefined) ?? {}) }
-  const existing = (projects[worktreePath] ?? {}) as Record<string, unknown>
-  if (existing.hasTrustDialogAccepted === true) return
-  projects[worktreePath] = { ...existing, hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true }
-  doc.projects = projects
-  // tmp + rename so a crash mid-write can't truncate the store.
-  const tmp = `${file}.rove-${process.pid}`
-  writeFileSync(tmp, JSON.stringify(doc, null, 2))
-  renameSync(tmp, file)
+  updateSharedJsonSync(
+    path.join(home, ".claude.json"),
+    (raw) => {
+      if (raw === undefined) return {}
+      try {
+        return JSON.parse(raw) as Record<string, unknown>
+      } catch {
+        // Corrupt — start from an empty doc; that is claude's own recovery
+        // behavior too (it rewrites the file wholesale on every save).
+        return {}
+      }
+    },
+    (doc) => {
+      const projects = { ...((doc.projects as Record<string, unknown> | undefined) ?? {}) }
+      const existing = (projects[worktreePath] ?? {}) as Record<string, unknown>
+      if (existing.hasTrustDialogAccepted === true) return undefined
+      projects[worktreePath] = { ...existing, hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true }
+      return JSON.stringify({ ...doc, projects }, null, 2)
+    },
+  )
 }

--- a/packages/kobe/src/engine/json-hook-adapter.ts
+++ b/packages/kobe/src/engine/json-hook-adapter.ts
@@ -12,8 +12,6 @@
  * adapter file." For a same-shape engine that file is ~3 members.
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises"
-import { dirname } from "node:path"
 import type { VendorId } from "../types/vendor.ts"
 import type { EngineHookAdapter, EngineSessionRef } from "./hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
@@ -24,24 +22,19 @@ import {
   mergeActivityHooks,
   mergeWorktreeWatchHook,
 } from "./json-hooks.ts"
-
-/** Read a JSON object from `path`. A missing file starts empty; any other read
- * or parse failure returns undefined so a best-effort install cannot clobber
- * an existing engine configuration it could not understand. */
-async function readJsonObject(path: string): Promise<Record<string, unknown> | undefined> {
-  try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown
-    return isObject(parsed) ? parsed : undefined
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return {}
-    return undefined
-  }
-}
+import { updateSharedJson } from "./shared-config-write.ts"
 
 /**
  * Read → transform → write a SHARED settings file, skipping the write when the
  * transform is a no-op (the default-on installers run on every launch; don't
  * churn the user's file mtime / VCS status when the hooks are already in place).
+ *
+ * The file is shared with the engine itself and with Rove's other two
+ * processes, so the read-merge-write runs under the compare-and-swap in
+ * `./shared-config-write.ts` (read its module doc — the guarantee is partial by
+ * design) and lands via tmp+rename, never a write straight onto the live file a
+ * starting session may be reading.
+ *
  * Best-effort: a failure to read/parse/write must never block a launch.
  */
 export async function editJsonSettings(
@@ -49,12 +42,26 @@ export async function editJsonSettings(
   transform: (current: Record<string, unknown>) => Record<string, unknown>,
 ): Promise<void> {
   try {
-    const current = await readJsonObject(settingsFilePath)
-    if (!current) return
-    const next = transform(current)
-    if (JSON.stringify(next) === JSON.stringify(current)) return
-    await mkdir(dirname(settingsFilePath), { recursive: true })
-    await writeFile(settingsFilePath, `${JSON.stringify(next, null, 2)}\n`)
+    await updateSharedJson(
+      settingsFilePath,
+      (raw) => {
+        // A missing file starts empty; any other read or parse failure abandons
+        // the write so a best-effort install cannot clobber an existing engine
+        // configuration it could not understand.
+        if (raw === undefined) return {}
+        try {
+          const parsed = JSON.parse(raw) as unknown
+          return isObject(parsed) ? parsed : undefined
+        } catch {
+          return undefined
+        }
+      },
+      (current) => {
+        const next = transform(current)
+        const json = JSON.stringify(next, null, 2)
+        return json === JSON.stringify(current, null, 2) ? undefined : `${json}\n`
+      },
+    )
   } catch {
     /* best-effort — never block launch */
   }

--- a/packages/kobe/src/engine/shared-config-write.ts
+++ b/packages/kobe/src/engine/shared-config-write.ts
@@ -13,11 +13,12 @@
  *
  * TWO writer classes, so two layers — neither alone is enough:
  *
- *   1. **Lock** (`~/.rove/locks/`, reusing `orchestrator/index/lockfile.ts`)
- *      excludes the three Rove processes from each other, which a bare
- *      compare-and-swap cannot: check-then-rename is itself a TOCTOU, and two
- *      Rove writers can both pass the re-read and both rename. Measured on a
- *      3-writer sandbox run, CAS alone dropped ~40% of concurrent Rove updates.
+ *   1. **Lock** (`~/.rove/shared-config-<hash>.lock`, reusing
+ *      `orchestrator/index/lockfile.ts`) excludes the three Rove processes from
+ *      each other, which a bare compare-and-swap cannot: check-then-rename is
+ *      itself a TOCTOU, and two Rove writers can both pass the re-read and both
+ *      rename. Measured on a 3-writer sandbox run, CAS alone dropped ~40% of
+ *      concurrent Rove updates.
  *   2. **Compare-and-swap** (re-read the raw bytes immediately before the
  *      rename, retry when they moved) covers THE ENGINE, which will never take
  *      our lock — it is not our process and has no idea Rove exists.

--- a/packages/kobe/src/engine/shared-config-write.ts
+++ b/packages/kobe/src/engine/shared-config-write.ts
@@ -1,0 +1,176 @@
+/**
+ * Compare-and-swap writes for the config files Rove SHARES with the engine it
+ * launches — Claude Code's `~/.claude.json` (worktree trust) and
+ * `~/.claude/settings.json` / `~/.codex/hooks.json` (activity hooks).
+ *
+ * Three Rove PROCESSES read-modify-write these on every launch (daemon
+ * `core/daemon-session-adapter.ts`, TUI `tui/workspace/terminal-tab-argv.ts`,
+ * CLI `cli/api/runtime.ts`) — and so does the engine itself, which rewrites the
+ * whole document on every save of its own. Losing that race is invisible: an
+ * already-granted `allowedTools` entry disappears and the agent re-asks for
+ * permission, or a task's trust entry vanishes and its session sits at "Do you
+ * trust the files in this folder?" forever. It reads as an engine bug.
+ *
+ * TWO writer classes, so two layers — neither alone is enough:
+ *
+ *   1. **Lock** (`~/.rove/locks/`, reusing `orchestrator/index/lockfile.ts`)
+ *      excludes the three Rove processes from each other, which a bare
+ *      compare-and-swap cannot: check-then-rename is itself a TOCTOU, and two
+ *      Rove writers can both pass the re-read and both rename. Measured on a
+ *      3-writer sandbox run, CAS alone dropped ~40% of concurrent Rove updates.
+ *   2. **Compare-and-swap** (re-read the raw bytes immediately before the
+ *      rename, retry when they moved) covers THE ENGINE, which will never take
+ *      our lock — it is not our process and has no idea Rove exists.
+ *
+ * ponytail: CAS narrows the engine window from "read + parse + merge"
+ * (milliseconds — `~/.claude.json` is routinely 350KB) to "re-read + rename"
+ * (microseconds). It does NOT close it. An engine write landing inside that
+ * window still wins and drops our key; the user's recourse is unchanged
+ * (relaunch). Closing it needs the engine to cooperate — a lock it takes, or an
+ * API — which no vendor offers today. So: do NOT delete the CAS believing the
+ * lock covers it, and do NOT believe the lock makes this safe against claude.
+ *
+ * The lock lives under the RESOLVED `~/.rove/` (`env.ts#roveStateDir`), keyed by
+ * the target file's absolute path. Every Rove install — brew, npm, a dev
+ * checkout — resolves the same `$HOME`, so mixed installs share one lock; only
+ * an explicit `ROVE_HOME_DIR` split (tests, `dev:sandbox`) separates them, which
+ * is exactly what that override is for.
+ */
+
+import { createHash, randomBytes } from "node:crypto"
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs"
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { roveStateDir } from "../env.ts"
+import { acquireSync, release, releaseSync } from "../orchestrator/index/lockfile.ts"
+import { acquireWithRetry } from "../orchestrator/index/store-codec.ts"
+
+/**
+ * Staging path, unique per CALL rather than per process. A shared `<file>.tmp`
+ * — or a pid-only one, the moment a caller gains an `await` — lets a second
+ * writer clobber the first's staging file and fail the survivor's rename with
+ * ENOENT. That is issue #53, already paid for once in the task index
+ * (`orchestrator/index/store.ts`).
+ */
+function stagingPath(file: string): string {
+  return `${file}.rove-${process.pid}-${randomBytes(6).toString("hex")}.tmp`
+}
+
+/**
+ * Lock file for `file`, flat in Rove's own state dir beside `tasks.json.lock` —
+ * these targets live in the ENGINE's home (`~/.claude.json`,
+ * `~/.claude/settings.json`) and we do not scatter Rove sidecars there. Keyed by
+ * a hash of the absolute path so two targets never share a lock and the name
+ * stays filesystem-safe.
+ */
+export function sharedConfigLockPath(file: string): string {
+  return join(roveStateDir(), `shared-config-${createHash("sha256").update(file).digest("hex").slice(0, 16)}.lock`)
+}
+
+/**
+ * Attempts before giving up. Each retry means a real concurrent write landed;
+ * more than a handful in a row means the file is under sustained rewrite and
+ * blocking a launch any longer is worse than surfacing to the caller (both
+ * callers treat a throw as best-effort and continue).
+ */
+const MAX_ATTEMPTS = 5
+
+/**
+ * Turn the file's raw bytes (`undefined` when it does not exist) into the
+ * document to merge into, or `undefined` to abandon the write untouched. This
+ * is where the two callers differ: trust treats a corrupt store as empty
+ * (claude's own recovery behavior), the hook installer refuses to clobber a
+ * config it could not parse.
+ */
+export type LoadSharedDoc = (raw: string | undefined) => Record<string, unknown> | undefined
+
+/**
+ * Produce the exact text to write, or `undefined` when nothing needs to change
+ * (both callers run on every launch — don't churn the user's file mtime).
+ * Callers serialize themselves so neither file's existing bytes shift.
+ */
+export type BuildSharedDoc = (doc: Record<string, unknown>) => string | undefined
+
+/** ENOENT is "no file yet"; every other read failure (EACCES, EISDIR) must
+ *  propagate rather than masquerade as an empty document we would then write
+ *  over the top of. */
+function readRawSync(file: string): string | undefined {
+  try {
+    return readFileSync(file, "utf8")
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined
+    throw err
+  }
+}
+
+async function readRaw(file: string): Promise<string | undefined> {
+  try {
+    return await readFile(file, "utf8")
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined
+    throw err
+  }
+}
+
+export function updateSharedJsonSync(file: string, load: LoadSharedDoc, build: BuildSharedDoc): void {
+  const lockPath = sharedConfigLockPath(file)
+  const lockToken = acquireSync(lockPath)
+  try {
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      const before = readRawSync(file)
+      const doc = load(before)
+      if (!doc) return
+      const text = build(doc)
+      if (text === undefined) return
+      const tmp = stagingPath(file)
+      try {
+        mkdirSync(dirname(file), { recursive: true })
+        writeFileSync(tmp, text)
+        // CAS against the ENGINE (it holds no lock): bytes moved since our read
+        // => our merge is built on a document somebody already replaced, and
+        // writing it would drop their changes.
+        if (readRawSync(file) === before) {
+          renameSync(tmp, file)
+          return
+        }
+      } finally {
+        try {
+          unlinkSync(tmp)
+        } catch {
+          /* renamed into place, or never created */
+        }
+      }
+    }
+    throw new Error(`gave up updating ${file} after ${MAX_ATTEMPTS} concurrent writes`)
+  } finally {
+    releaseSync(lockPath, lockToken)
+  }
+}
+
+export async function updateSharedJson(file: string, load: LoadSharedDoc, build: BuildSharedDoc): Promise<void> {
+  const lockPath = sharedConfigLockPath(file)
+  const lockToken = await acquireWithRetry(lockPath)
+  try {
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      const before = await readRaw(file)
+      const doc = load(before)
+      if (!doc) return
+      const text = build(doc)
+      if (text === undefined) return
+      const tmp = stagingPath(file)
+      try {
+        await mkdir(dirname(file), { recursive: true })
+        await writeFile(tmp, text)
+        if ((await readRaw(file)) === before) {
+          await rename(tmp, file)
+          return
+        }
+      } finally {
+        await unlink(tmp).catch(() => {})
+      }
+    }
+    throw new Error(`gave up updating ${file} after ${MAX_ATTEMPTS} concurrent writes`)
+  } finally {
+    await release(lockPath, lockToken)
+  }
+}

--- a/packages/kobe/src/orchestrator/index/lockfile.ts
+++ b/packages/kobe/src/orchestrator/index/lockfile.ts
@@ -28,11 +28,18 @@
  *     index) is much worse than the cost of a false positive (kobe refuses
  *     to start, user kills the lockfile manually).
  *
+ * {@link acquireSync}/{@link releaseSync} are the blocking twins, for callers
+ * that cannot be async (worktree pre-trust runs inside a React render path).
+ * They write the SAME `pid:token` format through the same link-or-fail dance,
+ * so a sync holder blocks an async acquirer and vice versa — the two variants
+ * are one lock, not two.
+ *
  * Not goals: cross-machine locking (NFS-safe), advisory POSIX locks
  * (flock — Bun coverage uneven), retry/backoff (caller's choice).
  */
 
 import { randomBytes } from "node:crypto"
+import { linkSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs"
 import { link, mkdir, readFile, unlink, writeFile } from "node:fs/promises"
 import { dirname } from "node:path"
 
@@ -156,5 +163,77 @@ export async function release(lockPath: string, token: string): Promise<void> {
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return
     throw err
+  }
+}
+
+/** Block the calling thread for `ms`. `Atomics.wait` on a throwaway buffer is
+ *  the only real sync sleep in JS; a busy spin would peg a core. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+/**
+ * Blocking {@link acquire}: same protocol, same on-disk format, but it spins on
+ * a live holder instead of rejecting (the async wait policy lives in
+ * `store-codec.ts#acquireWithRetry`; a sync caller has nowhere to put it).
+ * Throws {@link LockfileError} once `timeoutMs` elapses — callers here are all
+ * best-effort and treat that as "skip the write", never as a blocked launch.
+ */
+export function acquireSync(lockPath: string, timeoutMs = 5_000): string {
+  mkdirSync(dirname(lockPath), { recursive: true })
+  const token = `${process.pid}:${randomBytes(8).toString("hex")}`
+  const sidecar = `${lockPath}.${token.replace(":", "-")}`
+  const deadline = Date.now() + timeoutMs
+
+  for (;;) {
+    writeFileSync(sidecar, token)
+    try {
+      linkSync(sidecar, lockPath)
+      return token
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err
+    } finally {
+      try {
+        unlinkSync(sidecar)
+      } catch {
+        /* linked into place, or never created */
+      }
+    }
+
+    let holder: string
+    try {
+      holder = readFileSync(lockPath, "utf8").trim()
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+      continue // released between our EEXIST and the read
+    }
+
+    const holderPid = Number.parseInt(holder, 10)
+    if (Number.isFinite(holderPid) && holderPid > 0 && isProcessAlive(holderPid)) {
+      if (Date.now() >= deadline) {
+        throw new LockfileError(`${lockPath} is locked by another Rove instance (pid ${holderPid})`, holderPid)
+      }
+      sleepSync(25)
+      continue
+    }
+    // Stale holder — same takeover as the async path, warned for the same
+    // reason (a silent takeover in a concurrent context is scary).
+    console.warn(`[rove] removing stale lockfile at ${lockPath} (was held by pid ${holderPid}, process gone)`)
+    try {
+      unlinkSync(lockPath)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+    }
+  }
+}
+
+/** Blocking {@link release}: same ownership check — never unlink a lock that a
+ *  takeover already handed to somebody else. */
+export function releaseSync(lockPath: string, token: string): void {
+  try {
+    if (readFileSync(lockPath, "utf8").trim() !== token) return
+    unlinkSync(lockPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
   }
 }

--- a/packages/kobe/test/engine/shared-config-write.test.ts
+++ b/packages/kobe/test/engine/shared-config-write.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Compare-and-swap on the config files Rove shares with the engine
+ * (`~/.claude.json`, `~/.claude/settings.json`). The failure these guard is a
+ * LOST UPDATE, not a corrupt file: someone else replaces the document between
+ * our read and our write, and our stale merge silently drops their key.
+ *
+ * Both tests construct that interleaving for real by injecting a foreign write
+ * at the exact moment our staging file lands — read → FOREIGN WRITE → rename,
+ * which is what claude does when it saves while a Rove launch is mid-merge.
+ * Delete the CAS re-read and both go red.
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest"
+
+// The modules under test bind `writeFileSync`/`writeFile` as named imports at
+// load time, so a `vi.spyOn(fs, …)` after the fact never reaches them — the
+// interleave has to be injected into the module itself.
+const hook = vi.hoisted(() => ({ onStagingWrite: undefined as ((p: string) => void) | undefined }))
+
+vi.mock("node:fs", async (importActual) => {
+  const actual = await importActual<typeof import("node:fs")>()
+  return {
+    ...actual,
+    default: actual,
+    writeFileSync: (p: string, data: string) => {
+      actual.writeFileSync(p, data)
+      hook.onStagingWrite?.(String(p))
+    },
+  }
+})
+
+vi.mock("node:fs/promises", async (importActual) => {
+  const actual = await importActual<typeof import("node:fs/promises")>()
+  return {
+    ...actual,
+    default: actual,
+    writeFile: async (p: string, data: string) => {
+      await actual.writeFile(p, data)
+      hook.onStagingWrite?.(String(p))
+    },
+  }
+})
+
+const { trustClaudeWorktree } = await import("../../src/engine/claude-code-local/trust.ts")
+const { updateSharedJson, updateSharedJsonSync } = await import("../../src/engine/shared-config-write.ts")
+
+// Locks live under the resolved ~/.rove/; point them at a temp root so the
+// suite never contends with a real Rove on this machine.
+const lockHome = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-cas-lockhome-"))
+process.env.ROVE_HOME_DIR = lockHome
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  hook.onStagingWrite = undefined
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+afterAll(() => {
+  fs.rmSync(lockHome, { recursive: true, force: true })
+})
+
+function tempHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-cas-"))
+  tempDirs.push(home)
+  return home
+}
+
+/** Fire `foreign` exactly once, when the staging file for `file` is written —
+ *  i.e. after the writer read the document and before it renames. */
+function interleaveOnStagingWrite(file: string, foreign: () => void): void {
+  let fired = false
+  hook.onStagingWrite = (p) => {
+    if (fired || !p.startsWith(`${file}.rove-`)) return
+    fired = true
+    foreign()
+  }
+}
+
+describe("trustClaudeWorktree under a concurrent writer", () => {
+  it("keeps a permission claude granted mid-merge instead of writing a stale doc over it", () => {
+    const home = tempHome()
+    const file = path.join(home, ".claude.json")
+    fs.writeFileSync(file, JSON.stringify({ projects: { "/repo": { allowedTools: ["Read"] } } }))
+
+    // Claude itself saves while we're merging: it rewrites the whole document,
+    // adding a permission the user just approved in another session.
+    interleaveOnStagingWrite(file, () => {
+      fs.writeFileSync(file, JSON.stringify({ projects: { "/repo": { allowedTools: ["Read", "Bash(git *)"] } } }))
+    })
+
+    trustClaudeWorktree("/wt/task-1", home)
+
+    const doc = JSON.parse(fs.readFileSync(file, "utf8")) as {
+      projects: Record<string, { allowedTools?: string[]; hasTrustDialogAccepted?: boolean }>
+    }
+    // The retry re-read the winner's document, so BOTH survive.
+    expect(doc.projects["/repo"].allowedTools).toEqual(["Read", "Bash(git *)"])
+    expect(doc.projects["/wt/task-1"].hasTrustDialogAccepted).toBe(true)
+  })
+})
+
+describe("updateSharedJson under a concurrent writer", () => {
+  it("merges onto the winner's bytes rather than clobbering them", async () => {
+    const home = tempHome()
+    const file = path.join(home, "settings.json")
+    fs.writeFileSync(file, JSON.stringify({ hooks: {} }))
+
+    interleaveOnStagingWrite(file, () => {
+      fs.writeFileSync(file, JSON.stringify({ hooks: {}, userSetting: "do not lose me" }))
+    })
+
+    await updateSharedJson(
+      file,
+      (raw) => (raw === undefined ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+      (doc) => JSON.stringify({ ...doc, rove: true }),
+    )
+
+    const doc = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>
+    expect(doc.userSetting).toBe("do not lose me")
+    expect(doc.rove).toBe(true)
+  })
+
+  it("leaves no staging files behind", async () => {
+    const home = tempHome()
+    const file = path.join(home, "settings.json")
+    await updateSharedJson(
+      file,
+      (raw) => (raw === undefined ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+      (doc) => JSON.stringify({ ...doc, rove: true }),
+    )
+    expect(fs.readdirSync(home)).toEqual(["settings.json"])
+  })
+})
+
+describe("staging path", () => {
+  // Uniqueness is per CALL, not per process. The lock normally keeps two
+  // writers from overlapping, so this is unreachable in a healthy run — but the
+  // lock has takeover paths (stale steal, forceTakeover) where mutual exclusion
+  // breaks, and that is exactly when a shared `<file>.tmp` lets writer B clobber
+  // writer A's staging file and fail A's rename with ENOENT (issue #53, already
+  // paid for once in orchestrator/index/store.ts). Asserted directly because a
+  // race test would pass on a pid-only path.
+  it("differs between two calls in the same process", () => {
+    const home = tempHome()
+    const file = path.join(home, "settings.json")
+    const seen = new Set<string>()
+    hook.onStagingWrite = (p) => {
+      if (p.startsWith(`${file}.rove-`)) seen.add(p)
+    }
+    const write = (key: string) =>
+      updateSharedJsonSync(
+        file,
+        (raw) => (raw === undefined ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+        (doc) => JSON.stringify({ ...doc, [key]: true }),
+      )
+    write("a")
+    write("b")
+    expect(seen.size).toBe(2)
+  })
+
+  it("leaves no staging file behind once two writers are done", async () => {
+    const home = tempHome()
+    const file = path.join(home, "settings.json")
+    const write = (key: string) =>
+      updateSharedJson(
+        file,
+        (raw) => (raw === undefined ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+        (doc) => JSON.stringify({ ...doc, [key]: true }),
+      )
+    await Promise.all([write("a"), write("b")])
+    expect(fs.readdirSync(home)).toEqual(["settings.json"])
+  })
+})
+
+describe("cross-process lock", () => {
+  // The CAS covers the engine, which holds no lock. It does NOT cover two Rove
+  // processes: check-then-rename is a TOCTOU, and both can pass the re-read.
+  // A slow build() widens that window until it is deterministic — without the
+  // lock, one writer's key is silently dropped.
+  it("serializes two Rove writers so neither loses the other's key", async () => {
+    const home = tempHome()
+    const file = path.join(home, "settings.json")
+    fs.writeFileSync(file, "{}")
+    const write = (key: string) =>
+      updateSharedJson(
+        file,
+        (raw) => (raw === undefined ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+        (doc) => {
+          const end = Date.now() + 20
+          while (Date.now() < end) {
+            /* hold the read open across the peer's whole critical section */
+          }
+          return JSON.stringify({ ...doc, [key]: true })
+        },
+      )
+    await Promise.all([write("a"), write("b")])
+    const doc = JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, unknown>
+    expect(doc).toEqual({ a: true, b: true })
+  })
+
+  it("releases the lock so a later write is not blocked by the previous one", async () => {
+    const home = tempHome()
+    const file = path.join(home, "settings.json")
+    const write = (key: string) =>
+      updateSharedJson(
+        file,
+        (raw) => (raw === undefined ? {} : (JSON.parse(raw) as Record<string, unknown>)),
+        (doc) => JSON.stringify({ ...doc, [key]: true }),
+      )
+    await write("first")
+    await write("second")
+    expect(JSON.parse(fs.readFileSync(file, "utf8"))).toEqual({ first: true, second: true })
+  })
+})


### PR DESCRIPTION
## Problem

`~/.claude.json` (worktree pre-trust) and `~/.claude/settings.json` (global hook install) were read-modify-written with no coordination — by **three Rove processes** (daemon `core/daemon-session-adapter.ts`, TUI `tui/workspace/terminal-tab-argv.ts`, CLI `cli/api/runtime.ts`) **and by Claude Code itself**, which rewrites both files wholesale on every save.

The interleave: Rove reads the document → claude saves, appending a permission the user just approved → Rove writes its stale copy back → the permission is gone. What the user sees is an already-authorized agent re-asking for Bash/Edit, or a task stuck forever on *"Do you trust the files in this folder?"* — **it reads as an engine bug.** Nothing errors anywhere.

`settings.json` was additionally written **straight onto the live file** (`writeFile(settingsFilePath, …)`) while every other store in this repo uses tmp+rename — so a session starting mid-write could read a truncated config.

## Fix

New `src/engine/shared-config-write.ts`, two layers because there are two writer classes:

1. **Lock** (`~/.rove/shared-config-<hash>.lock`, reusing `orchestrator/index/lockfile.ts`) excludes the three Rove processes. CAS alone cannot: check-then-rename is itself a TOCTOU, and measurably **~40% of concurrent Rove updates were still lost** with CAS only.
2. **Compare-and-swap** (re-read raw bytes immediately before the rename, retry when they moved) covers **the engine**, which will never take our lock.

The module doc states the limit explicitly, so the next reader doesn't assume the lock solved it: CAS narrows the engine window from "read + parse + merge" (ms — `~/.claude.json` is routinely 350KB) to "re-read + rename" (µs), but does **not** close it. Closing it needs engine cooperation no vendor offers.

Also: `settings.json` now lands via tmp+rename, and both files stage through a **per-call** unique path (`randomBytes`) rather than pid-only — issue #53, already paid for once in `orchestrator/index/store.ts`.

`lockfile.ts` gains `acquireSync`/`releaseSync` twins (trust runs on a sync path). Same `pid:token` format through the same link-or-fail dance, so sync and async holders exclude each other — one lock, not two.

## Verification

**Mutation gates — each reverted, run 2×, both red:**

| Removed | Result |
|---|---|
| CAS re-read | 2 failed / 4 passed, ×2 |
| Lock | 1 failed / 5 passed, ×2 |
| Per-call staging | 1 failed / 6 passed, ×2 |

The concurrency tests inject the interleave for real (foreign write fired at the exact moment the staging file lands), not just the sequential path.

**Live, 3 concurrent processes** — Rove A, Rove B, and a simulated claude rewriting `.claude.json` 200×:

```
valid JSON            : True
numStartups preserved : 42
allowedTools preserved: ['Bash(git *)', 'Edit']
engine saves landed   : 200 /200
A worktrees trusted   : 59 /60      B: 59 /60
settings hooks        : 60 /60      B: 60 /60
leftover staging: 0   leftover locks: 0
```

Rove-vs-Rove (`settings.json`) is now **60/60 both writers**, up from 38/34 with CAS alone. The 59/60 on `.claude.json` is the documented engine window — the one case we can detect but not prevent.

**Suites:** root lint ✅ · typecheck ✅ · `test/engine` 55 files / 585 ✅ · `test/render` 240 ✅ · socket 73 files / 604 ✅ (matches clean-HEAD baseline). `test:fast` shows 18 files / 47 tests failing — **identical on clean HEAD**, pre-existing CLI-usage failures unrelated to this change.

## Scope

Only these two files. The other concurrency findings from the same audit (`touchRecency` dirty-flag overwrite, `state.json`'s docblock claiming protection it lacks, two `landTask`s merging into one base checkout, codex's check-then-act trust append) are dispatched separately and untouched here.