### PR TITLE
test: cover the destructive paths that could silently stop guarding

### DIFF
--- a/.changeset/destructive-path-coverage.md
+++ b/.changeset/destructive-path-coverage.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Cover the destructive paths that could silently stop being guarded: deleting a
+`dir` task on the daemon's `prepare → begin → finish` sequence (the path
+`rove api delete` takes) never touches the user's own directory; `remove({
+deleteBranch })` is asserted against real git rather than a mock, including the
+`-d`/`-D` choice and the read-HEAD-before-removal ordering; `rove reset --hard`
+still refuses without `--yes`; and a worktree rollback removes a dirty
+directory instead of leaving debris behind.

--- a/packages/kobe/test/cli/reset-cmd.test.ts
+++ b/packages/kobe/test/cli/reset-cmd.test.ts
@@ -7,6 +7,15 @@ const mocks = vi.hoisted(() => ({
   stopDaemonProcess: vi.fn(),
   stopLegacyTmux: vi.fn(),
   stampResetGate: vi.fn(),
+  /** Answer the reset command's y/N prompt reads off stdin. */
+  promptAnswer: { value: "n" },
+}))
+
+vi.mock("node:readline", () => ({
+  createInterface: () => ({
+    question: (_q: string, cb: (answer: string) => void) => cb(mocks.promptAnswer.value),
+    close: () => undefined,
+  }),
 }))
 
 vi.mock("@sma1lboy/kobe-daemon/daemon/lifecycle", () => ({
@@ -126,6 +135,85 @@ describe("runResetSubcommand", () => {
 
     await expect(runResetSubcommand(["--hard", "--yes"])).rejects.toThrow("failed to remove task index")
     expect(output()).not.toContain("reset complete")
+  })
+
+  it("--hard without --yes on a non-TTY refuses: nothing stopped, nothing wiped", async () => {
+    // Every other test passes --yes, so the whole confirmation block
+    // (reset-cmd.ts:104-116) can be deleted with the suite still green. This
+    // is the regression that block exists to prevent: `rove reset --hard` in
+    // a pipe/CI/agent shell silently wiping the task index with no prompt.
+    const tasksPath = join(home, ".rove", "tasks.json")
+    const statePath = join(home, ".config", "rove", "state.json")
+    mkdirSync(join(home, ".config", "rove"), { recursive: true })
+    writeFileSync(tasksPath, JSON.stringify({ tasks: [{ id: "a" }] }))
+    writeFileSync(statePath, "{}")
+    const tty = process.stdin.isTTY
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true })
+    try {
+      await runResetSubcommand(["--hard"])
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: tty, configurable: true })
+    }
+
+    expect(existsSync(tasksPath)).toBe(true)
+    expect(existsSync(statePath)).toBe(true)
+    // The refusal is a true preflight: it returns BEFORE any runtime is torn
+    // down, so a refused reset leaves the daemon and PTY host running.
+    expect(mocks.stopDaemonProcess).not.toHaveBeenCalled()
+    expect(mocks.stopLegacyTmux).not.toHaveBeenCalled()
+    expect(mocks.stampResetGate).not.toHaveBeenCalled()
+    expect(output()).toContain("re-run with --yes to proceed")
+    expect(output()).not.toContain("reset complete")
+  })
+
+  it("declining the interactive y/N prompt aborts with nothing changed", async () => {
+    const tasksPath = join(home, ".rove", "tasks.json")
+    writeFileSync(tasksPath, JSON.stringify({ tasks: [{ id: "a" }] }))
+    mocks.promptAnswer.value = "n"
+    const tty = process.stdin.isTTY
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+    try {
+      await runResetSubcommand(["--hard"])
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: tty, configurable: true })
+    }
+
+    expect(existsSync(tasksPath)).toBe(true)
+    expect(mocks.stopDaemonProcess).not.toHaveBeenCalled()
+    expect(output()).toContain("aborted — nothing changed")
+  })
+
+  it("accepting the prompt proceeds — the gate blocks, it does not disable --hard", async () => {
+    const tasksPath = join(home, ".rove", "tasks.json")
+    writeFileSync(tasksPath, JSON.stringify({ tasks: [{ id: "a" }] }))
+    mocks.promptAnswer.value = "y"
+    const tty = process.stdin.isTTY
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+    try {
+      await runResetSubcommand(["--hard"])
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: tty, configurable: true })
+    }
+
+    expect(existsSync(tasksPath)).toBe(false)
+    expect(mocks.stopDaemonProcess).toHaveBeenCalled()
+  })
+
+  it("an unknown argument exits 2 before anything is stopped", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("__exit__")
+    }) as never)
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+    try {
+      await expect(runResetSubcommand(["--hardd", "--yes"])).rejects.toThrow("__exit__")
+      expect(exit).toHaveBeenCalledWith(2)
+      expect(stderr.mock.calls.join("")).toContain('unknown argument "--hardd"')
+    } finally {
+      exit.mockRestore()
+      stderr.mockRestore()
+    }
+    // A typo must not be read as a bare `reset` and tear the daemon down.
+    expect(mocks.stopDaemonProcess).not.toHaveBeenCalled()
   })
 
   it("help names Hosted PTY and legacy tmux cleanup", async () => {

--- a/packages/kobe/test/orchestrator/ensure-worktree.test.ts
+++ b/packages/kobe/test/orchestrator/ensure-worktree.test.ts
@@ -30,10 +30,16 @@ const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
 class FlakyStore extends TaskIndexStore {
   failNextUpdate = false
   deleteAfterNextUpdate = false
+  /** Leave an untracked file in the new worktree before failing the write. */
+  dirtyWorktreeBeforeFailing = false
 
   override async update(id: string, patch: Partial<Parameters<TaskIndexStore["update"]>[1]>) {
     if (this.failNextUpdate) {
       this.failNextUpdate = false
+      const created = (patch as { worktreePath?: string }).worktreePath
+      if (this.dirtyWorktreeBeforeFailing && created) {
+        fs.writeFileSync(path.join(created, "scratch.txt"), "left behind by the engine\n")
+      }
       throw new Error("simulated store write failure")
     }
     const result = await super.update(id, patch as never)
@@ -109,6 +115,25 @@ describe("ensureWorktree — partial-failure cleanup (no orphans)", () => {
     // ...and nothing was left on disk: no kobe-managed worktree, no orphan dir
     // under the worktrees root that a retry would collide with.
     expect(await new GitWorktreeManager().list(repo)).toEqual([])
+  })
+
+  test("a DIRTY worktree still rolls back — the rollback removal is forced", async () => {
+    // Realistic: the engine's init script (or a baseRef checkout) already
+    // wrote into the worktree by the time the store write fails. The rollback
+    // must remove it anyway.
+    //
+    // Drop `{ force: true }` from `rollbackWorktree` (worktree-coordinator.ts
+    // :212) and this goes red: `remove()` refuses a dirty worktree, the
+    // rollback swallows that error into a console warning, and the directory
+    // survives as debris a retry then collides with.
+    const task = await orch.createTask({ repo })
+    store.failNextUpdate = true
+    store.dirtyWorktreeBeforeFailing = true
+
+    await expect(orch.ensureWorktree(task.id)).rejects.toThrow(/simulated store write failure/)
+
+    expect(await new GitWorktreeManager().list(repo)).toEqual([])
+    expect(orch.getTask(task.id)?.worktreePath).toBe("")
   })
 
   test("retry after a failed write succeeds cleanly (operation is idempotent/retryable)", async () => {

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -219,3 +219,53 @@ describe("durable background task deletion", () => {
     await expect(orch.ensureWorktree(task.id)).rejects.toThrow(TaskDeletingError)
   })
 })
+
+describe("dir tasks on the daemon's prepare→begin→finish path", () => {
+  it("NEVER removes the user's own directory, and never probes it for dirt", async () => {
+    // This is the path `rove api delete` takes. `finish()` has its OWN
+    // `kind !== "dir"` guard, separate from the one `deleteNow()` reaches
+    // through `prepare()` — dir-task.test.ts covers only the latter, so
+    // deleting the guard at task-deletion.ts:78 goes unnoticed there.
+    //
+    // What the guard protects: a dir task's `worktreePath` IS the user's own
+    // directory (`rove .` — their project root, possibly their $HOME). A
+    // `git worktree remove --force` on it deletes their files.
+    const dir = await mkdtemp(join(tmpdir(), "kobe-user-dir-"))
+    try {
+      const task = await orch.openDirectoryTask({ dir })
+      // Dirty on purpose: a dir task must skip the gate rather than pass it.
+      worktrees.isDirty.mockResolvedValue(true)
+
+      await expect(orch.prepareTaskDeletion(task.id)).resolves.toBe(true)
+      await expect(orch.beginTaskDeletion(task.id)).resolves.toBe(true)
+      await orch.finishTaskDeletion(task.id)
+
+      // Delete the `&& task.kind !== "dir"` in finish() and this goes red.
+      expect(worktrees.remove).not.toHaveBeenCalled()
+      // Delete it in prepare() and this goes red (a dirty dir would also
+      // have thrown DirtyWorktreeError above, blocking a legitimate delete).
+      expect(worktrees.isDirty).not.toHaveBeenCalled()
+      // The row is gone — dropping the index entry is the whole job.
+      expect(orch.getTask(task.id)).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("force + deleteBranch on a dir task still removes nothing on disk", async () => {
+    // The escalating flags (`rove api delete --force --delete-branch`) must
+    // not talk the coordinator past the kind check.
+    const dir = await mkdtemp(join(tmpdir(), "kobe-user-dir-"))
+    try {
+      const task = await orch.openDirectoryTask({ dir })
+      await orch.prepareTaskDeletion(task.id, { force: true, deleteBranch: true })
+      await orch.beginTaskDeletion(task.id)
+      await orch.finishTaskDeletion(task.id)
+
+      expect(worktrees.remove).not.toHaveBeenCalled()
+      expect(orch.getTask(task.id)).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
@@ -108,3 +108,59 @@ describe("renameBranch() convergence (issue #44)", () => {
     expect(await manager.currentBranch(wt)).toBe("rename-a")
   })
 })
+
+/**
+ * `remove({ deleteBranch })` against REAL git. Every other layer (api handler →
+ * daemon → coordinator) asserts the flag as a value being passed along; this is
+ * the only place that asks git whether the branch is actually still there.
+ */
+describe("remove({ deleteBranch }) — the branch actually lives or dies", () => {
+  function branchExists(name: string): boolean {
+    const out = execSync(`git branch --list ${JSON.stringify(name)}`, { cwd: repo, env: gitEnv, encoding: "utf8" })
+    return out.trim().length > 0
+  }
+
+  it("deleteBranch: true removes the branch from the owning repo", async () => {
+    const wt = join(root, "wt-branch-doomed")
+    await manager.create(repo, "kobe/doomed", wt)
+    expect(branchExists("kobe/doomed")).toBe(true)
+
+    await manager.remove(wt, { deleteBranch: true })
+
+    // Red if `deleteBranchIn` is never reached — including if the HEAD capture
+    // moves to AFTER the worktree is removed (manager.ts:225-228): the
+    // worktree is gone by then, `currentBranch` throws, the `.catch(() => null)`
+    // makes `branch` null and the delete is silently skipped.
+    expect(branchExists("kobe/doomed")).toBe(false)
+  })
+
+  it("without the opt-in the branch survives — git is the durable record", async () => {
+    const wt = join(root, "wt-branch-kept")
+    await manager.create(repo, "kobe/kept", wt)
+
+    await manager.remove(wt)
+
+    expect(branchExists("kobe/kept")).toBe(true)
+  })
+
+  it("an unmerged branch is refused by `-d` and force escalates to `-D`", async () => {
+    // The `-d`/`-D` choice in manager-branch.ts:50. Swap the ternary and both
+    // halves of this go red: `-D` would nuke the unmerged branch on the
+    // no-force path, `-d` would refuse it on the force path.
+    const wt = join(root, "wt-branch-unmerged")
+    await manager.create(repo, "kobe/unmerged", wt)
+    writeFileSync(join(wt, "work.txt"), "unmerged work")
+    execSync("git add -A && git commit -q -m work", { cwd: wt, env: gitEnv })
+
+    // Safe delete: the commit isn't on main, so `-d` refuses. Best-effort —
+    // the refusal is swallowed and the worktree removal still succeeds.
+    await manager.remove(wt, { deleteBranch: true })
+    expect(branchExists("kobe/unmerged")).toBe(true)
+
+    // Same branch, re-materialised, this time with force: `-D` drops it.
+    const wt2 = join(root, "wt-branch-unmerged-2")
+    await manager.create(repo, "kobe/unmerged", wt2)
+    await manager.remove(wt2, { force: true, deleteBranch: true })
+    expect(branchExists("kobe/unmerged")).toBe(false)
+  })
+})


### PR DESCRIPTION
Four places where deleting the product code left the suite green. Each new assertion was verified by mutation: delete the guard, confirm the test goes red, restore. Every mutation was run twice.

Test-only change — no `src/` file is modified.

## 1. The `dir` guard on the daemon's deletion sequence

`task-deletion.ts:78` prevents `git worktree remove` on a `kind:"dir"` task's `worktreePath` — which is the user's own directory (`rove .`: their project root, possibly their `$HOME`).

`dir-task.test.ts:79-87` covers the guard, but through `orch.deleteTask` (the `deleteNow` compat path). `finish()` has its **own** `kind !== "dir"` check, and `rove api delete` goes through `prepare → begin → finish`. That check had no test.

Two tests added to `task-deletion.test.ts`: a dir task driven through the full sequence asserting `worktrees.remove` and `worktrees.isDirty` were never called, plus the `--force --delete-branch` escalation.

**Mutation:**

| deleted | result |
|---|---|
| `&& task.kind !== "dir"` in `finish()` (`:78`) | 2 failed / 7 passed — `remove` called with the tmp dir and `{force: true, deleteBranch: true}` |
| `&& task.kind !== "dir"` in `prepare()` (`:36`) | 1 failed / 8 passed |

## 2. `deleteBranch` against real git

`grep deleteBranchIn test/` was zero hits: `manager.ts:225-228` (capture HEAD before removal) and `manager-branch.ts:42-51` (the `-d`/`-D` choice) never ran under real git. Every layer asserted the flag as a value being passed along.

Three tests in `worktree-manager-edges.test.ts`, real temp repo, following the existing `land.test.ts` / sibling-suite conventions: `deleteBranch: true` → `git branch --list` empty; no opt-in → branch survives; unmerged branch refused by `-d`, dropped by `-D` under force.

**Mutation:**

| changed | result |
|---|---|
| branch capture + `deleteBranchIn` call deleted | 2 failed / 9 passed |
| capture moved to **after** the worktree removal | 2 failed / 9 passed — the ordering invariant (`currentBranch` throws once the worktree is gone, `.catch(() => null)` silently skips the delete) |
| `-d`/`-D` ternary inverted | 1 failed / 10 passed |

## 3. The `reset --hard` confirmation gate

Every existing test passed `--yes`, so `reset-cmd.ts:104-116` could be deleted whole with the suite green — a regression making `rove reset --hard` wipe the task index with no prompt would be invisible. The unknown-argument `process.exit(2)` early-out (`:74-80`) was also uncovered.

Four tests: non-TTY without `--yes` (state intact, **nothing stopped** — the refusal is a preflight, so daemon and PTY host stay up), declining the `y/N` prompt, accepting it (proving the gate blocks rather than disables `--hard`), and the unknown-arg exit 2 before any `stopDaemonProcess`.

`node:readline` is module-mocked — `vi.spyOn` on the ESM namespace throws `Cannot redefine property`.

**Mutation:**

| deleted | result |
|---|---|
| the whole `if (!yes) { … }` block | 2 failed / 7 passed |
| the unknown-argument early exit | 1 failed / 8 passed |

## 4. Worktree rollback — scope correction

The brief called `worktree-coordinator.ts` untested (`grep WorktreeCoordinator test/` is indeed zero hits). But the rollback **is** already covered: `ensure-worktree.test.ts` drives it through `Orchestrator.ensureWorktree` with a real git repo and a `FlakyStore` whose `update` rejects, asserting the worktree is gone and a retry succeeds cleanly. The name simply doesn't appear because the coordinator is reached through the orchestrator.

The real gap was narrower: the rollback's `{ force: true }`. Realistically the engine's init script or a baseRef checkout has already written into the worktree by the time the store write fails — and `remove()` refuses a dirty worktree, with `rollbackWorktree` swallowing that into a `console.error`, leaving debris.

One test: `FlakyStore` writes an untracked file into the new worktree before failing, asserting the rollback still removes it.

**Mutation:**

| changed | result |
|---|---|
| `{ force: true }` dropped from `rollbackWorktree` (`:212`) | 1 failed / 5 passed |
| the `rollbackWorktree` call deleted entirely | 3 failed / 3 passed |

## Gates

- `bun run lint` (repo root) — clean
- `bun run typecheck` — clean
- The five touched suites: 50 passed
- `bun run test:fast`: 47 failures in `test/cli/*` help/usage tests — **pre-existing**, verified by stashing this branch's diff to a clean tree and reproducing the identical set. Untouched by this change.
- All files under the 500-line cap (largest: `reset-cmd.test.ts` at 227)
- Changeset: `patch`