### PR TITLE
fix: refuse a succeeded report from a branch with no commits

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 36 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 37 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -456,6 +456,28 @@ Before reporting success: `git status` clean, your work committed with a
 real message (you wrote the code; you write its message). A worker that ran
 everything, passed everything, and committed nothing has delivered nothing —
 that exact mismatch has shipped empty merges before.
+
+Rove now checks this at the moment you claim it: a `succeeded:` report from a
+managed task whose branch has **0 commits** is refused with
+`EMPTY_SUCCESS_REPORT` and never reaches the coordinator. Commit, then send.
+When the task genuinely produced no commits — an investigation, a review, a
+question answered — say so explicitly with `--allow-empty`:
+
+```bash
+rove api send --allow-empty --prompt "succeeded: no bug — root cause is upstream, see notes"
+```
+
+**"CI is green" means `checkState: passing`.** A local test run is not CI: it
+does not run the other jobs, the other platform, or the merge gates. Rove
+polls your PR's checks and keeps the answer on the task —
+
+```bash
+rove api get-task --task-id "$ROVE_TASK_ID"   # .task.prStatus.checkState
+```
+
+`none` (no PR yet) / `pending` (still running) / `passing` / `failing` /
+`unknown`. Anything but `passing` is not green. Report what the field says,
+not what your local run implied.
 
 **Coordinator side** — do NOT block or poll. Keep working (or end your
 turn); each worker's outcome arrives in your chat as a `[ROVE PEER]` message

--- a/.changeset/honest-reports-refuse-empty.md
+++ b/.changeset/honest-reports-refuse-empty.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Refuse a `succeeded:` report from a branch with no commits, and give agents Rove's own CI truth
+
+`rove api send` now checks a completion claim against the sender's own branch. A `succeeded:` report from a managed task whose branch has 0 commits is refused with `EMPTY_SUCCESS_REPORT` and never reaches the coordinator — the evidence was already in hand at that moment, while `land`'s `EMPTY_BRANCH` only caught it two steps later, after the coordinator had believed the report. Work that legitimately produces no commits (an investigation, a review) passes `--allow-empty`.
+
+"CI is green" was being asserted from local test runs because the real answer was out of reach: `get-task` never named `.task.prStatus.checkState`, and the poller that fills it paused whenever no GUI was attached — exactly during an unattended run. The poller now also runs while an engine is live, and `checkState` is documented as what "green" means.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 36 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 37 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -456,6 +456,28 @@ Before reporting success: `git status` clean, your work committed with a
 real message (you wrote the code; you write its message). A worker that ran
 everything, passed everything, and committed nothing has delivered nothing —
 that exact mismatch has shipped empty merges before.
+
+Rove now checks this at the moment you claim it: a `succeeded:` report from a
+managed task whose branch has **0 commits** is refused with
+`EMPTY_SUCCESS_REPORT` and never reaches the coordinator. Commit, then send.
+When the task genuinely produced no commits — an investigation, a review, a
+question answered — say so explicitly with `--allow-empty`:
+
+```bash
+rove api send --allow-empty --prompt "succeeded: no bug — root cause is upstream, see notes"
+```
+
+**"CI is green" means `checkState: passing`.** A local test run is not CI: it
+does not run the other jobs, the other platform, or the merge gates. Rove
+polls your PR's checks and keeps the answer on the task —
+
+```bash
+rove api get-task --task-id "$ROVE_TASK_ID"   # .task.prStatus.checkState
+```
+
+`none` (no PR yet) / `pending` (still running) / `passing` / `failing` /
+`unknown`. Anything but `passing` is not green. Report what the field says,
+not what your local run implied.
 
 **Coordinator side** — do NOT block or poll. Keep working (or end your
 turn); each worker's outcome arrives in your chat as a `[ROVE PEER]` message

--- a/docs/API.md
+++ b/docs/API.md
@@ -126,6 +126,12 @@ replacement in `nextCommandArgs`.
   task, when one did: the lineage read for a parallel round's parent.
   `.task.command` = the raw launch command pinned on the task; `.task.vendor`
   = the protocol derived from it.
+  `.task.prStatus` = the branch's PR as the daemon last polled it
+  (`lifecycle`, `number`, `url`, `lastCheckedAt`) — including
+  `.prStatus.checkState`: `none` (no PR) / `pending` / `passing` / `failing` /
+  `unknown`. This is Rove's CI truth for the branch, and `passing` is what
+  "CI is green" means; a local test run is a different claim. Absent until
+  the poller has seen a PR for the branch.
 - `collect [--task-ids a,b,c] [--group GROUPID] [--repo PATH]`: read-only
   health snapshot of a parallel round — the one read that answers "what is
   this round's status right now" without fanning out to `get-task` per task.
@@ -247,7 +253,8 @@ placeholder branch to a descriptive name. Prompts into existing sessions
 
 ## drive
 
-- `send [--task-id ID] --prompt TEXT [--tab TAB] [--command CMD] [--plain]`: paste a
+- `send [--task-id ID] --prompt TEXT [--tab TAB] [--command CMD] [--plain]
+  [--allow-empty]`: paste a
   follow-up into a task's running engine (one full turn). Without
   `--task-id`, a task that has a `dispatcher` on record replies to that
   exact tab, falling back to the dispatcher task's live canonical engine
@@ -271,6 +278,17 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   task with no live session at all auto-starts its canonical engine tab, in
   the task's worktree. `started: true` in the result marks that fresh
   session (vs. delivery into an existing one).
+
+  A prompt opening with `succeeded:` is checked against the SENDER's own
+  branch before any delivery: sent from a verified managed task whose branch
+  has 0 commits, it is refused with `EMPTY_SUCCESS_REPORT` and nothing is
+  delivered. The claim and the evidence are both in hand at that moment, and
+  a report is what a coordinator acts on — `land`'s `EMPTY_BRANCH` catches
+  the same mismatch two steps later, after the coordinator has believed it.
+  The check is deliberately narrow: it needs a verified sender identity, a
+  managed (non-`main`, non-`dir`) task, and a definite `ahead === 0` — an
+  unresolvable base reads `null` and never refuses. `--allow-empty` states an
+  intentional empty success (an investigation, a review) and delivers.
 - `dispatch --task-id ID --prompt TEXT [--tab TAB]`: route text into a
   task's live session via the daemon's `session.deliver` channel (the
   dispatcher's messenger; see

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -98,6 +98,13 @@ What makes this loop work:
 - **"Succeeded" means committed.** The only thing `land` can merge is
   commits on the worker's branch. Green tests in a dirty working tree are
   not a deliverable — `land` will refuse an empty branch (`EMPTY_BRANCH`).
+  `send` refuses the claim earlier: a `succeeded:` report from a managed task
+  with 0 commits fails with `EMPTY_SUCCESS_REPORT` and never reaches you.
+  A worker whose task legitimately produced no commits passes `--allow-empty`.
+- **"CI is green" means `checkState: passing`.** Rove polls each task's PR
+  checks onto `.task.prStatus.checkState` (`rove api get-task`), so a
+  coordinator reads CI truth instead of trusting a worker's summary of its
+  own local test run.
 - **A report is a claim, not a verification.** Read the winner's actual diff
   before merging it (`collect` shows ahead counts and diffstats; `git log`
   in the worktree shows the truth).

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -203,11 +203,17 @@ export function startDaemonCollectors(
     hasSubscribers,
   )
 
+  // PR status is the only CI truth Rove holds, and an unattended agent is the
+  // consumer that needs it most — so this collector's gate also opens on a
+  // live engine, not just an attached pane (see startPrStatusPoller). With
+  // neither, it still polls nobody.
   const stopPrStatusPoller = startPrStatusPoller(
     orch,
     runtime,
     options.prStatusPollMs ?? DEFAULT_PR_STATUS_POLL_MS,
     hasSubscribers,
+    undefined,
+    activity ? () => activity.currentNonIdle().some((e) => e.state !== "idle") : undefined,
   )
 
   // Quota-resume runner: deliberately NOT gated on `hasSubscribers` — its

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -349,10 +349,22 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
 
 /**
  * Start the live poller. Returns a `stop()` clearing the interval. Pass
- * `intervalMs <= 0` to disable (no-op stop). `hasSubscribers` is the
- * idle-daemon consumer gate: a tick is a no-op while it returns `false`, so a
- * gui-less daemon never hits the network for nobody. The interval keeps
- * running; the first tick after a pane subscribes repopulates.
+ * `intervalMs <= 0` to disable (no-op stop).
+ *
+ * The consumer gate is `hasSubscribers() || hasWorkingAgent()`. `prStatus` is
+ * the ONLY CI truth Rove holds, and the original gate ("no GUI ⇒ nobody wants
+ * this") silently assumed every consumer is a human at a pane. An agent
+ * working unattended is a consumer too, and it is the one whose need is
+ * sharpest: an unattended run is precisely when there is no GUI, so
+ * `checkState` was guaranteed stale or missing at the exact moment a worker
+ * asked whether its PR was green. That gap is one mechanism behind "CI is
+ * green" being asserted from a local test run.
+ *
+ * `hasWorkingAgent` is the engine-activity registry (`currentNonIdle()`), fed
+ * by the ungated `engine.reportEvent` hook path, so it is a free in-memory
+ * read that needs no network and no pane. It keeps the gate's original point
+ * intact — a daemon with no GUI **and** no live engine still polls nobody,
+ * which is the parked-daemon case the gate was written for.
  */
 export function startPrStatusPoller(
   orch: DaemonOrchestrator,
@@ -360,12 +372,13 @@ export function startPrStatusPoller(
   intervalMs: number = DEFAULT_PR_STATUS_POLL_MS,
   hasSubscribers?: () => boolean,
   run: PrViewRunner = makeGhPrViewRunner(runtime.prStatus.classify, runtime.prStatus.viewFields),
+  hasWorkingAgent?: () => boolean,
 ): () => void {
   if (intervalMs <= 0) return () => {}
   const schedule: PrPollSchedule = new Map()
   let running = false
   const tick = (): void => {
-    if (hasSubscribers && !hasSubscribers()) return
+    if (hasSubscribers && !hasSubscribers() && !hasWorkingAgent?.()) return
     if (running) return
     running = true
     void runPrStatusPass(orch, {

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -113,7 +113,10 @@ export async function issueUpdate(ctx: VerbContext): Promise<unknown> {
  */
 async function assertNotEmptySuccess(daemon: DaemonRpc, ctx: VerbContext, prompt: string): Promise<void> {
   if (ctx.args.bool("allow-empty")) return
-  if (!/^\s*succeeded\s*:/i.test(prompt)) return
+  // The fullwidth colon is not a typo — an agent writing Chinese types
+  // `succeeded：` from a CJK IME without noticing, and matching only U+003A
+  // would let exactly the reports this repo's agents write walk past.
+  if (!/^\s*succeeded\s*[:\uff1a]/i.test(prompt)) return
   const self = await verifiedSelfSession()
   if (!self) return
   let sender: SerializedTask

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -85,6 +85,60 @@ export async function issueUpdate(ctx: VerbContext): Promise<unknown> {
   return result
 }
 
+/**
+ * Refuse a `succeeded:` report from a worker whose branch carries no commits.
+ *
+ * `send` is where a completion CLAIM enters the system, and until now it was
+ * the one hop that never looked at the claim. The contradiction was already
+ * detectable AT THAT MOMENT — the sender's worktree is on disk and
+ * `readBranchSignals` is a lock-free read `collect` already makes — but the
+ * only thing that ever checked was `land`'s EMPTY_BRANCH, two steps later,
+ * after the coordinator had believed the report and possibly archived the
+ * siblings. The check was in the right codebase at the wrong end of the loop.
+ *
+ * Scope is deliberately narrow, because a false NEGATIVE here is cheap and a
+ * false POSITIVE blocks a worker from reporting at all:
+ *   - only a VERIFIED self session (the same identity `send` already trusts
+ *     for dispatcher routing) — an unverified env names a stranger's branch;
+ *   - only a MANAGED task: `main`/`dir` tasks have no Rove-created branch, and
+ *     an agent on a main checkout legitimately reads `ahead: 0`;
+ *   - only a DEFINITE `ahead === 0`. An unresolvable base reads null — an
+ *     honest unknown, never grounds to refuse.
+ *
+ * And it is a refusal WITH an exit, not a wall: investigation and review tasks
+ * genuinely succeed with no commits, so `--allow-empty` states that outright
+ * (the `git commit --allow-empty` spelling, same meaning). What the guard
+ * removes is the ACCIDENTAL empty success — the one that shipped as a clean
+ * report — not the deliberate one.
+ */
+async function assertNotEmptySuccess(daemon: DaemonRpc, ctx: VerbContext, prompt: string): Promise<void> {
+  if (ctx.args.bool("allow-empty")) return
+  if (!/^\s*succeeded\s*:/i.test(prompt)) return
+  const self = await verifiedSelfSession()
+  if (!self) return
+  let sender: SerializedTask
+  try {
+    sender = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId: self.taskId })).task
+  } catch {
+    return // stale id / unreadable task — an unknown is never grounds to refuse
+  }
+  if (sender.kind === "main" || sender.kind === "dir") return
+  if (!sender.worktreePath) return
+  const { ahead } = await ctx.runtime.readBranchSignals(sender.worktreePath)
+  if (ahead !== 0) return
+  const branch = sender.branch || "your branch"
+  throw new ApiError(
+    `refusing to report success: ${branch} has 0 commits — "succeeded" means COMMITTED, and this report would reach the coordinator as a clean success with nothing to land`,
+    "EMPTY_SUCCESS_REPORT",
+    {
+      taskId: self.taskId,
+      branch,
+      hint: "commit your work with a real message and send again — or, if this task genuinely produced no commits (an investigation or a review), re-send with --allow-empty to say so explicitly",
+      nextCommandArgs: ["api", "send", "--allow-empty", "--prompt", prompt],
+    },
+  )
+}
+
 export async function send(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const prompt = ctx.args.require("prompt")
@@ -131,6 +185,9 @@ export async function send(ctx: VerbContext): Promise<unknown> {
     }
   }
   const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
+  // Before ANY delivery path (--plain included: a verbatim false claim is the
+  // same false claim) — a refused report must never reach the coordinator.
+  await assertNotEmptySuccess(daemon, ctx, prompt)
   const text = ctx.args.bool("plain") ? prompt : await withPeerProvenance(daemon, taskId, prompt)
   const delivered = await ctx.runtime.deliverPrompt(
     daemon,

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -124,7 +124,15 @@ async function assertNotEmptySuccess(daemon: DaemonRpc, ctx: VerbContext, prompt
   }
   if (sender.kind === "main" || sender.kind === "dir") return
   if (!sender.worktreePath) return
-  const { ahead } = await ctx.runtime.readBranchSignals(sender.worktreePath)
+  // Every failure mode here is an UNKNOWN, and the rule this guard states for
+  // itself is that an unknown never refuses — so a read that throws delivers,
+  // exactly like the `ahead: null` it returns for an unresolvable base.
+  let ahead: number | null
+  try {
+    ahead = (await ctx.runtime.readBranchSignals(sender.worktreePath)).ahead
+  } catch {
+    return
+  }
   if (ahead !== 0) return
   const branch = sender.branch || "your branch"
   throw new ApiError(

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -14,7 +14,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   {
     name: "send",
     summary:
-      "Paste a follow-up prompt into a task's running engine (one full turn). Without --task-id, a task spawned from another Rove session replies to its dispatcher's tab (then that task's live canonical engine; nothing alive = DISPATCHER_UNREACHABLE, never a silent spawn); otherwise the active task. Sent from inside another Rove task ($ROVE_TASK_ID), the prompt is prefixed with [ROVE PEER] provenance — who sent it and how to reply (tab-precise) — so agent-to-agent messaging needs no coordinator. When the target composer is busy (you'd paste into a half-typed message), the prompt is accepted-but-deferred: the daemon stores it and queues a `prompt_deferred` Inbox episode for a human to release — that outcome is a SUCCESS (exit 0, `deferred` in the JSON). Do NOT retry a deferred send: the daemon already owns the message, and resending stacks a duplicate in the queue.",
+      "Paste a follow-up prompt into a task's running engine (one full turn). Without --task-id, a task spawned from another Rove session replies to its dispatcher's tab (then that task's live canonical engine; nothing alive = DISPATCHER_UNREACHABLE, never a silent spawn); otherwise the active task. Sent from inside another Rove task ($ROVE_TASK_ID), the prompt is prefixed with [ROVE PEER] provenance — who sent it and how to reply (tab-precise) — so agent-to-agent messaging needs no coordinator. When the target composer is busy (you'd paste into a half-typed message), the prompt is accepted-but-deferred: the daemon stores it and queues a `prompt_deferred` Inbox episode for a human to release — that outcome is a SUCCESS (exit 0, `deferred` in the JSON). Do NOT retry a deferred send: the daemon already owns the message, and resending stacks a duplicate in the queue. A `succeeded:` report sent from a managed task whose branch has 0 commits is REFUSED (EMPTY_SUCCESS_REPORT) — commit first, or pass --allow-empty when the task genuinely produced no commits.",
     flags: [
       F.taskId(false),
       F.prompt(true, "Text pasted + submitted into the engine pane."),
@@ -36,6 +36,13 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
         type: "bool",
         required: false,
         description: "Deliver the prompt verbatim — skip the [ROVE PEER] provenance prefix.",
+      },
+      {
+        name: "allow-empty",
+        type: "bool",
+        required: false,
+        description:
+          "Report success from a task with zero commits (EMPTY_SUCCESS_REPORT is refused otherwise). For work that legitimately produces no commits — an investigation, a review, a question answered.",
       },
     ],
     handler: send,

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -25,7 +25,7 @@ export const READ_VERBS: readonly VerbSpec[] = [
   {
     name: "get-task",
     summary:
-      "Read one task's metadata + terminal tabs. `.running` = any hosted engine tab is live; `.tabs[]` (id/kind/vendor/liveVendor/lastTitle/alive) is the discovery read for `send --tab tab-N`; `.task.dispatcher` = the Rove session (task+tab) that created it, when one did.",
+      "Read one task's metadata + terminal tabs. `.running` = any hosted engine tab is live; `.tabs[]` (id/kind/vendor/liveVendor/lastTitle/alive) is the discovery read for `send --tab tab-N`; `.task.dispatcher` = the Rove session (task+tab) that created it, when one did; `.task.prStatus.checkState` (none|pending|passing|failing|unknown) is Rove's OWN CI truth for the branch's PR — `passing` is what \"CI is green\" means, never a local test run.",
     flags: [F.taskId()],
     handler: getTask,
   },

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -44,7 +44,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
  */
-export const KOBE_SKILL_VERSION = 36
+export const KOBE_SKILL_VERSION = 37
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/test/cli/api-send-empty-success.test.ts
+++ b/packages/kobe/test/cli/api-send-empty-success.test.ts
@@ -113,6 +113,19 @@ describe("send refuses an empty-branch success report", () => {
     expect(calls).toHaveLength(1)
   })
 
+  it("a FULLWIDTH colon — what a CJK IME types, and what this repo's agents write", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded：全部通过，CI 绿了"], {
+          client: clientWith(),
+          runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+        }),
+      "EMPTY_SUCCESS_REPORT",
+    )
+    expect(calls).toHaveLength(0)
+  })
+
   it("--plain is not an escape hatch — a verbatim false claim is the same false claim", async () => {
     const { calls, deliver } = recordingDelivery()
     await expectApiError(

--- a/packages/kobe/test/cli/api-send-empty-success.test.ts
+++ b/packages/kobe/test/cli/api-send-empty-success.test.ts
@@ -190,6 +190,20 @@ describe("send delivers everything the guard has no business refusing", () => {
     expect(calls).toHaveLength(1)
   })
 
+  it("a branch read that THROWS — every failure mode here is an unknown", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: done"], {
+      client: clientWith(),
+      runtime: stubRuntime({
+        deliverPrompt: deliver,
+        readBranchSignals: async () => {
+          throw new Error("git exploded")
+        },
+      }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
   it("prose that merely mentions the word, rather than opening with the marker", async () => {
     const { calls, deliver } = recordingDelivery()
     await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "the build succeeded: here is the log"], {

--- a/packages/kobe/test/cli/api-send-empty-success.test.ts
+++ b/packages/kobe/test/cli/api-send-empty-success.test.ts
@@ -1,0 +1,201 @@
+/**
+ * `send` refuses a `succeeded:` report from a branch with zero commits.
+ *
+ * The claim and the contradicting evidence are both in hand at the same
+ * moment — the sender's own worktree — so this is the loop's earliest honest
+ * rejection point. `land`'s EMPTY_BRANCH catches the same mismatch two steps
+ * later, after the coordinator has already believed the report.
+ *
+ * What each test pins is a REFUSAL BOUNDARY, not the happy path: the guard is
+ * only allowed to fire on a verified sender, a managed task, and a definite
+ * `ahead === 0`. Every other shape must deliver, because a worker blocked
+ * from reporting at all is worse than an unverified report.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { type SelfSessionProbe, resetVerifiedSelfSession, verifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
+import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
+
+const savedTaskId = process.env.KOBE_TASK_ID
+const savedTabId = process.env.KOBE_TAB_ID
+
+function restoreEnv(name: string, saved: string | undefined): void {
+  if (saved === undefined) delete process.env[name]
+  else process.env[name] = saved
+}
+
+/** A process tree where this process descends from the session's shell. */
+function probeFor(key: string, opts: { detached?: boolean } = {}): SelfSessionProbe {
+  const shellPid = 100
+  return {
+    sessions: async () => [{ key, pid: shellPid, alive: true }],
+    ps: async () =>
+      opts.detached
+        ? `  ${shellPid}     1 /bin/zsh -il\n  500     1 bun kobe api send`
+        : `  ${shellPid}     1 /bin/zsh -il\n  500   ${shellPid} bun kobe api send`,
+    pid: 500,
+  }
+}
+
+async function asSession(taskId: string, tabId: string, opts?: { detached?: boolean }): Promise<void> {
+  await verifiedSelfSession({ KOBE_TASK_ID: taskId, KOBE_TAB_ID: tabId }, probeFor(`${taskId}::${tabId}`, opts))
+}
+
+/** Sender is `worker-1`; every other id answers as the coordinator. */
+function clientWith(senderOverrides: Record<string, unknown> = {}): FakeClient {
+  return new FakeClient({
+    "task.get": (payload) => {
+      const { taskId } = payload as { taskId: string }
+      if (taskId === "worker-1") {
+        return { task: taskFixture({ id: "worker-1", branch: "fix/thing", kind: "task", ...senderOverrides }) }
+      }
+      return { task: taskFixture({ id: taskId, title: "Coordinator" }) }
+    },
+  })
+}
+
+/** The signal that makes the guard fire: a resolvable base, zero commits. */
+const emptyBranch = { readBranchSignals: async () => ({ baseRef: "origin/main", ahead: 0, diff: null }) }
+
+beforeEach(async () => {
+  resetVerifiedSelfSession()
+  process.env.KOBE_TASK_ID = "worker-1"
+  process.env.KOBE_TAB_ID = "tab-1"
+  await asSession("worker-1", "tab-1")
+})
+
+afterEach(() => {
+  resetVerifiedSelfSession()
+  restoreEnv("KOBE_TASK_ID", savedTaskId)
+  restoreEnv("KOBE_TAB_ID", savedTabId)
+})
+
+describe("send refuses an empty-branch success report", () => {
+  it("rejects `succeeded:` from a managed task with 0 commits, and delivers NOTHING", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: all tests pass, CI green"], {
+          client: clientWith(),
+          runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+        }),
+      "EMPTY_SUCCESS_REPORT",
+      /fix\/thing has 0 commits/,
+    )
+    // The refusal is only worth anything if the false claim never lands.
+    expect(calls).toHaveLength(0)
+  })
+
+  it("hands back an executable recovery path naming the escape hatch", async () => {
+    const { deliver } = recordingDelivery()
+    try {
+      await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: done"], {
+        client: clientWith(),
+        runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+      })
+      expect.unreachable("should have thrown")
+    } catch (error) {
+      const data = (error as { data?: Record<string, unknown> }).data ?? {}
+      expect(data.branch).toBe("fix/thing")
+      expect(String(data.hint)).toMatch(/commit your work/)
+      // The retry argv must be runnable verbatim, carrying the original text.
+      expect(data.nextCommandArgs).toEqual(["api", "send", "--allow-empty", "--prompt", "succeeded: done"])
+    }
+  })
+
+  it("--allow-empty is the deliberate empty success (an investigation, a review)", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--allow-empty", "--prompt", "succeeded: no bug, see notes"], {
+      client: clientWith(),
+      runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("--plain is not an escape hatch — a verbatim false claim is the same false claim", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "coord-1", "--plain", "--prompt", "succeeded: done"], {
+          client: clientWith(),
+          runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+        }),
+      "EMPTY_SUCCESS_REPORT",
+    )
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe("send delivers everything the guard has no business refusing", () => {
+  it("a `failed:` report — the whole point is that it reports having nothing", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "failed: blocked on a missing credential"], {
+      client: clientWith(),
+      runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("a `succeeded:` report WITH commits", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: fixed it"], {
+      client: clientWith(),
+      runtime: stubRuntime({
+        deliverPrompt: deliver,
+        readBranchSignals: async () => ({ baseRef: "origin/main", ahead: 3, diff: null }),
+      }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("an UNRESOLVABLE base (ahead: null) — an honest unknown is never grounds to refuse", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: done"], {
+      client: clientWith(),
+      runtime: stubRuntime({
+        deliverPrompt: deliver,
+        readBranchSignals: async () => ({ baseRef: null, ahead: null, diff: null }),
+      }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("a `main` task — a project-main checkout owns no Rove branch to be empty", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: done"], {
+      client: clientWith({ kind: "main" }),
+      runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("a `dir` task — likewise a user-owned directory, not a Rove branch", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: done"], {
+      client: clientWith({ kind: "dir" }),
+      runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("an UNVERIFIED session — an inherited env names a stranger's branch, never a refusal", async () => {
+    resetVerifiedSelfSession()
+    await asSession("worker-1", "tab-1", { detached: true })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: done"], {
+      client: clientWith(),
+      runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it("prose that merely mentions the word, rather than opening with the marker", async () => {
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "coord-1", "--prompt", "the build succeeded: here is the log"], {
+      client: clientWith(),
+      runtime: stubRuntime({ deliverPrompt: deliver, ...emptyBranch }),
+    })
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/packages/kobe/test/daemon/pr-status-poller.test.ts
+++ b/packages/kobe/test/daemon/pr-status-poller.test.ts
@@ -22,8 +22,9 @@ import {
   isPrPollable,
   pickPr,
   runPrStatusPass as runPrStatusPassRaw,
+  startPrStatusPoller,
 } from "@sma1lboy/kobe-daemon/daemon/pr-status-collector"
-import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
 import { Orchestrator } from "../../src/orchestrator/core.ts"
 import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
@@ -291,5 +292,85 @@ describe("decodeSpawnChunks — join bytes before decoding the gh payload", () =
   test("ASCII, mixed string/Buffer chunks, and empty input are unchanged", () => {
     expect(decodeSpawnChunks([Buffer.from("ab"), "cd"])).toBe("abcd")
     expect(decodeSpawnChunks([])).toBe("")
+  })
+})
+
+/**
+ * The consumer gate. `prStatus` is the only CI truth Rove holds, and the
+ * original gate ("no GUI ⇒ nobody wants this") assumed every consumer is a
+ * human at a pane — so an agent running unattended, the consumer whose need
+ * is sharpest, read a stale or missing `checkState` at exactly the moment it
+ * asked whether CI was green. The gate now opens on a live engine too, while
+ * keeping its actual point: neither ⇒ still polls nobody.
+ */
+describe("startPrStatusPoller consumer gate", () => {
+  /** Drive one tick and let the in-flight async pass settle. */
+  async function tickOnce(stop: () => void): Promise<void> {
+    await vi.advanceTimersByTimeAsync(DEFAULT_PR_STATUS_POLL_MS)
+    await vi.waitFor(() => {})
+    stop()
+  }
+
+  function countingRunner(): { runs: () => number; run: PrViewRunner } {
+    let n = 0
+    return {
+      runs: () => n,
+      run: async () => {
+        n++
+        return { kind: "empty" }
+      },
+    }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("polls for a WORKING AGENT with no gui attached — the unattended-run case", async () => {
+    await makeTask()
+    const { runs, run } = countingRunner()
+    const stop = startPrStatusPoller(
+      orch,
+      daemonRuntime,
+      DEFAULT_PR_STATUS_POLL_MS,
+      () => false,
+      run,
+      () => true,
+    )
+    await tickOnce(stop)
+    expect(runs()).toBeGreaterThan(0)
+  })
+
+  test("still polls nobody when there is neither a subscriber nor a live engine", async () => {
+    await makeTask()
+    const { runs, run } = countingRunner()
+    const stop = startPrStatusPoller(
+      orch,
+      daemonRuntime,
+      DEFAULT_PR_STATUS_POLL_MS,
+      () => false,
+      run,
+      () => false,
+    )
+    await tickOnce(stop)
+    expect(runs()).toBe(0)
+  })
+
+  test("an attached subscriber alone still opens the gate (no agent required)", async () => {
+    await makeTask()
+    const { runs, run } = countingRunner()
+    const stop = startPrStatusPoller(
+      orch,
+      daemonRuntime,
+      DEFAULT_PR_STATUS_POLL_MS,
+      () => true,
+      run,
+      () => false,
+    )
+    await tickOnce(stop)
+    expect(runs()).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
An agent can report `succeeded: CI green` and have it arrive as a clean success, with the system holding evidence to the contrary at that exact moment. Two mechanisms, fixed here.

## 1. `send` never read the claim

`send` validated the `--tab` shape, resolved the target, delivered, and confirmed **delivery** — it never looked at the message. So a worker on a zero-commit branch could send `succeeded: all tests pass, CI green` and it landed as a clean report.

The contradicting evidence was already in hand: `readBranchSignals` is a lock-free read `collect` already makes, and the sender's `worktreePath` is one `task.get` away. `land`'s `EMPTY_BRANCH` did catch this — two steps later, after the coordinator had believed the report and possibly archived the siblings. Right codebase, wrong end of the loop.

`send` now refuses `EMPTY_SUCCESS_REPORT` before any delivery path (`--plain` included — a verbatim false claim is the same false claim), with the self-healing `hint` + `nextCommandArgs` shape borrowed from `landRecoveryError`.

**On false positives:** yes, they exist — an investigation or review task genuinely succeeds with nothing committed. Refusal beats a warning, because a warning on stdout is exactly what an agent skims past before reporting success anyway. So the check is narrow on three axes, each a deliver-not-refuse default:

- **verified sender only** — the identity `send` already trusts for dispatcher routing; an inherited env names a stranger's branch
- **managed tasks only** — `main`/`dir` own no Rove branch, and legitimately read `ahead: 0`
- **definite `ahead === 0` only** — an unresolvable base reads `null`, and a read that *throws* also delivers; every failure mode here is an unknown, and an unknown never refuses

`--allow-empty` states a deliberate empty success outright (the `git commit --allow-empty` spelling). What the guard removes is the *accidental* empty success, not the deliberate one.

The marker matches a **fullwidth colon** too (`succeeded：`). This repo's agents write Chinese and type that from a CJK IME without noticing; matching only U+003A would have let exactly the reports they write walk past — a silent bypass in the project's default language.

## 2. CI truth was unreachable, and gated behind a GUI

Rove already computes `checkState: none|pending|passing|failing|unknown` onto `Task.prStatus`. Two things kept agents from it:

- **The subscriber gate.** `if (hasSubscribers && !hasSubscribers()) return` — written for the parked-daemon case, but it assumed every consumer is a human at a pane. An unattended run is *by definition* the no-subscriber case, so `prStatus` was stale or missing at exactly the moment a worker asked whether CI was green. (Observed live: this very task, with PR #660 open, read `prStatus: null`.) The gate now also opens on a live engine — `activity.currentNonIdle()`, fed by the ungated `engine.reportEvent` hook path, so it is a free in-memory read with no network and no pane. Its real point is kept: no GUI **and** no live engine still polls nobody. Same precedent as `automation-runner` / `quota-resume`, which document their own exemptions.
- **Zero documentation.** `get-task`'s summary listed `.running` / `.tabs[]` / `.dispatcher` and never `.task.prStatus`. Now named in the verb summary, `docs/API.md`, `docs/ORCHESTRATION.md`, and SKILL.md — with the contract spelled out: **"CI is green" means `checkState: passing`, not a local test run.**

## Verification

- 13 tests for the guard, 3 for the gate. Every one mutation-checked (fix deleted → red, twice each; restored → green) — including the throw path and the fullwidth colon separately.
- The refusal tests assert `calls).toHaveLength(0)`: a refusal is only worth something if the false claim never lands.
- **Live**, source CLI against the real daemon, from this task's own verified session while its branch was empty: bare `succeeded:` → `EMPTY_SUCCESS_REPORT` exit 1 with the correct branch name and recovery argv; `--allow-empty` and `failed:` → both reached the delivery layer. After committing (`ahead=1`) the refusal stopped — the guard tracks real branch state, not the prompt alone.
- **Live gate probe**, driving the real `startPrStatusPoller` with an injected runner: no-GUI + live-engine → 5 polls (was 0); parked daemon → 0; GUI-only → 5.
- `test:socket` 620/620. `test:fast` has 47 pre-existing failures (a `kobe`→`rove` branding drift); measured on clean HEAD with my files removed: **47 there too, same 18 files** — this branch adds none.

## Note for the reviewer

SKILL.md is 510 lines. The cap gate reads only `.ts/.tsx/.js/.jsx/.mjs`, so `.md` is out of scope by design; every source file touched is under (largest: `handlers-tasks.ts` at 410). Verified by running `scripts/file-size-check.sh` locally.