### PR TITLE
fix: engines declare their own fork verb; doctor lists every engine

### DIFF
--- a/.changeset/engine-owned-fork-and-doctor.md
+++ b/.changeset/engine-owned-fork-and-doctor.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Engines declare their own fork verb, and `rove doctor` lists every engine
+
+Forking a chat was gated on a hardcoded `claude || codex` list, so an engine
+that ships a fork verb could not fork until someone edited a shared file, and a
+custom preset declaring a built-in protocol was refused despite launching that
+exact binary. The verb is now declared by each engine and resolved through the
+preset's protocol, like its session-id flags.
+
+`rove doctor` listed three hardcoded engines, so Kimi never appeared even
+though Rove detects its login, and no engine you added could show up at all.
+Doctor now loops over the registered engines, and an engine whose login Rove
+cannot read says so instead of reporting a missing account.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -287,7 +287,9 @@ rove doctor [--report] [--fix]
 ```
 
 Read-only check of your build, terminal, git, engine CLIs and logins, daemon,
-running sessions, agent skill, and state files. The plain run never changes
+running sessions, agent skill, and state files. Every registered engine gets a
+row — the built-ins plus any engine you added — so a login Rove can't read is
+reported as such rather than as a missing account. The plain run never changes
 anything. `--report` also writes a bug bundle (diagnosis + recent logs + env)
 and prints its path; attach that to bug reports.
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -139,13 +139,17 @@ conversation. The two resulting tabs keep the source context and then diverge:
 | `codex` | ✓ | `codex fork <src>` |
 | `copilot` | — | starts a fresh Copilot session with a transcript handoff |
 | `kimi` | — | starts a fresh Kimi session with a transcript handoff |
-| custom | — | refused; Rove doesn't know its session store |
+| custom | — | refused, unless the preset declares a built-in protocol (then it forks like that engine) |
 
 Copilot's `--resume` and Kimi's `-S` reopen rather than branch, which would put
 two live processes on one transcript. Rove therefore uses the same transcript
 handoff as a cross-engine continuation: the new tab is a fresh conversation
 that reads where the previous one stopped. A custom engine without a known
 session store is refused instead of silently opening a blank continuation.
+
+Each engine declares its own fork verb, so a custom preset with an
+`engineProtocol` of `claude` or `codex` forks like that engine — the same
+resolution that gives it their session-id flags.
 
 *Different built-in engine* → a handoff. This is the move that saves you when
 you hit a usage limit mid-task. The new engine starts fresh with a first prompt

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -13,15 +13,9 @@ import {
   defaultPtyHostSocketPath,
 } from "@sma1lboy/kobe-daemon/daemon/paths"
 import { readPidFile } from "@sma1lboy/kobe-daemon/daemon/server"
-import {
-  type BinaryStatus,
-  type ClaudeAccount,
-  type CodexAccount,
-  type CopilotAccount,
-  detectClaudeAccount,
-  detectCodexAccount,
-  detectCopilotAccount,
-} from "../engine/account-detect.ts"
+import type { BinaryStatus } from "../engine/account-detect.ts"
+import { listPresetIds } from "../engine/engine-presets.ts"
+import { describeAccount, detectEngineStatuses, engineUsable } from "../engine/engine-status.ts"
 import { homeDir, kvStatePath, roveStateDir } from "../env.ts"
 import { formatBytes } from "../lib/format-bytes.ts"
 import { kobeSkillState, skillInstallCommand } from "../lib/skill-install.ts"
@@ -149,45 +143,33 @@ function binaryLabel(binary: BinaryStatus): string {
   return binary.found ? `✓ ${binary.path}` : `✗ ${binary.error}`
 }
 
-function claudeAccountLabel(account: ClaudeAccount): string {
-  if (account.kind === "none") return "no account"
-  return `logged in (${account.email}${account.organization ? `, ${account.organization}` : ""})`
-}
-
-function codexAccountLabel(account: CodexAccount): string {
-  if (account.kind === "chatgpt") return `logged in (${account.email}${account.plan ? `, ${account.plan}` : ""})`
-  if (account.kind === "apikey") return "API key"
-  return "no account"
-}
-
-function copilotAccountLabel(account: CopilotAccount): string {
-  if (account.kind === "token") return `token (${account.source})`
-  if (account.kind === "oauth") return "logged in"
-  return "no account"
-}
-
-/** One "engines:" block: per-vendor CLI binary + account state (read-only). */
+/**
+ * One "engines:" block: per-engine CLI binary + account state (read-only).
+ *
+ * Loops over the REGISTERED engines rather than three hardcoded rows — kimi
+ * shipped with a real `detectKimiAccount` and never appeared here, and a
+ * contrib/custom engine never could, because adding one meant editing this
+ * neutral CLI file. `detectEngineStatuses` is the same probe Settings →
+ * Accounts uses, so the two surfaces can't disagree.
+ *
+ * Order is `listPresetIds()`: the built-ins in their stable cycle order
+ * (claude, codex, copilot, kimi — the first three exactly where they were),
+ * then the user's own presets in registration order.
+ */
 async function engineDoctorLines(): Promise<{ lines: string[]; anyUsable: boolean }> {
-  const [claude, codex, copilot] = await Promise.all([
-    detectClaudeAccount(),
-    detectCodexAccount(),
-    detectCopilotAccount(),
-  ])
+  const statuses = await detectEngineStatuses(listPresetIds())
   const lines = ["engines:"]
-  const row = (name: string, binary: BinaryStatus, account: string, err?: string): void => {
-    lines.push(`  ${name.padEnd(8)}${binaryLabel(binary)}${binary.found ? ` — ${account}` : ""}`)
-    if (err) lines.push(`          ⚠ ${err}`)
+  for (const status of statuses) {
+    const account = describeAccount(status.account)
+    // padEnd(7)+space, not padEnd(8): a custom id of exactly 8 chars would
+    // otherwise butt straight against the ✓/✗. Built-in columns are unchanged.
+    const name = `${status.vendor.padEnd(7)} `
+    lines.push(`  ${name}${binaryLabel(status.binary)}${status.binary.found ? ` — ${account}` : ""}`)
+    if (status.accountError) lines.push(`          ⚠ ${status.accountError}`)
   }
-  row("claude", claude.binary, claudeAccountLabel(claude.account), claude.accountError)
-  row("codex", codex.binary, codexAccountLabel(codex.account), codex.accountError)
-  row("copilot", copilot.binary, copilotAccountLabel(copilot.account), copilot.accountError)
   // "Usable" = binary present AND some account. One usable engine is enough;
   // a missing vendor the user never launches is not a finding.
-  const anyUsable =
-    (claude.binary.found && claude.account.kind !== "none") ||
-    (codex.binary.found && codex.account.kind !== "none") ||
-    (copilot.binary.found && copilot.account.kind !== "none")
-  return { lines, anyUsable }
+  return { lines, anyUsable: statuses.some(engineUsable) }
 }
 
 async function appendUnavailableProcess(

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -85,6 +85,14 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
       pinFlag: "--session-id",
       sessionControlFlags: ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"],
       resumeArgv: (base, id) => [...base, "--resume", id],
+      // Fork = resume + branch, and claude lets the caller name the branch,
+      // so the forked tab is trackable from its first frame like any other
+      // claude tab. The three flags combine (probed against claude 2.x: the
+      // fork lands in the id we pass).
+      forkArgv: (base, sourceId, newId) => {
+        const forked = [...base, "--resume", sourceId, "--fork-session"]
+        return newId ? [...forked, "--session-id", newId] : forked
+      },
     },
     quotaUsage: () => fetchClaudeQuotaUsage(),
     readTurns: readClaudeTurns,
@@ -135,6 +143,14 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
       resumeArgv: (base, id) => {
         const [bin, ...rest] = base
         return bin ? [bin, "resume", ...rest, id] : base
+      },
+      // `codex fork [OPTIONS] [SESSION_ID]` (probed 2026-08-30) — same
+      // subcommand shape as resume, so the launch flags stay between the
+      // verb and the positional id. Codex mints the forked thread's own id,
+      // so a caller-set one has nowhere to go.
+      forkArgv: (base, sourceId) => {
+        const [bin, ...rest] = base
+        return bin ? [bin, "fork", ...rest, sourceId] : null
       },
     },
     quotaUsage: () => fetchCodexQuotaUsage(),

--- a/packages/kobe/src/engine/engine-presets.ts
+++ b/packages/kobe/src/engine/engine-presets.ts
@@ -43,7 +43,13 @@ import {
   withEngineEffort,
   withEngineTerminalTitle,
 } from "./interactive-command.ts"
-import { acceptsPinnedSession, pinSessionArgv, resumeSessionArgv } from "./session-identity.ts"
+import {
+  acceptsPinnedSession,
+  acceptsSessionFork,
+  forkSessionArgvFor,
+  pinSessionArgv,
+  resumeSessionArgv,
+} from "./session-identity.ts"
 
 /**
  * The protocol id for "kobe cannot name this engine". Deliberately not a
@@ -240,4 +246,34 @@ export function engineResumeArgv(
   sessionId: string,
 ): readonly string[] | null {
   return resumeSessionArgv(engineEntry(sessionProtocol(vendor)).sessionIdentity, base, sessionId)
+}
+
+/**
+ * True when this engine can BRANCH a conversation — declared by the adapter
+ * (`EngineSessionIdentity.forkArgv`), not listed here. Claude and codex ship
+ * a fork verb; copilot's `--resume` and kimi's `-S` only REOPEN a session,
+ * which would put two live processes on one transcript, so Rove refuses
+ * instead of pretending.
+ *
+ * Protocol-resolved like {@link withPinnedSessionId}: a preset `claudecpa`
+ * declaring the claude protocol IS a claude launch, so it forks. Keying off
+ * the raw id instead found the empty custom entry and refused — the same
+ * silent gap `withClaudeSessionId` had.
+ */
+export function engineCanFork(vendor: VendorId | undefined): boolean {
+  return acceptsSessionFork(engineEntry(sessionProtocol(vendor)).sessionIdentity)
+}
+
+/**
+ * Argv that FORKS `sourceId` into a new diverging session, or null when the
+ * engine has no fork verb, there is no source id, or the command already
+ * controls its own session. The caller then opens an ordinary tab.
+ */
+export function engineForkArgv(
+  base: readonly string[],
+  vendor: VendorId | undefined,
+  sourceId: string,
+  newId?: string | null,
+): readonly string[] | null {
+  return forkSessionArgvFor(engineEntry(sessionProtocol(vendor)).sessionIdentity, base, sourceId, newId)
 }

--- a/packages/kobe/src/engine/engine-status.ts
+++ b/packages/kobe/src/engine/engine-status.ts
@@ -124,3 +124,42 @@ export function detectEngineStatuses(
 ): Promise<EngineStatus[]> {
   return Promise.all(vendors.map((v) => detectEngineStatus(v, over)))
 }
+
+/**
+ * One-line description of any built-in engine's account, for plain-text
+ * surfaces (`rove doctor`). Switches on the account KIND, never on a vendor:
+ * the arms (`oauth` / `chatgpt` / `apikey` / `token` / `none`) are already
+ * shared across the union, which is why one function covers every engine —
+ * and why doctor's three per-vendor label functions were three copies of
+ * this. Settings renders the same union its own way (themed + i18n); this is
+ * the string form.
+ *
+ * `null` = no account detector for this engine (contrib / plugin / custom),
+ * which is NOT "not logged in" — say so rather than implying a logged-out
+ * account we never looked for.
+ */
+export function describeAccount(account: EngineAccount | null): string {
+  if (account === null) return "login not detectable"
+  switch (account.kind) {
+    case "oauth":
+      // Claude's oauth carries an identity; copilot's and kimi's don't.
+      return "email" in account
+        ? `logged in (${account.email}${account.organization ? `, ${account.organization}` : ""})`
+        : "logged in"
+    case "chatgpt":
+      return `logged in (${account.email}${account.plan ? `, ${account.plan}` : ""})`
+    case "apikey":
+      return "API key"
+    case "token":
+      return `token (${account.source})`
+    default:
+      return "no account"
+  }
+}
+
+/** True when this engine could actually run a task: its binary is present
+ *  and, for engines whose login Rove CAN read, an account exists. A null
+ *  account (no detector) does not veto — the binary is all we can know. */
+export function engineUsable(status: EngineStatus): boolean {
+  return status.binary.found && status.account?.kind !== "none"
+}

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -25,7 +25,6 @@
 
 import { kobeCliInvocation } from "@/cli/invocation"
 import { engineEntry } from "@/engine/registry"
-import { controlsOwnSession } from "@/engine/session-identity"
 import { autoStatusEnabled } from "@/state/auto-status"
 import { dispatcherEnabled } from "@/state/dispatcher"
 import { getPersistedString } from "@/state/repos"
@@ -198,55 +197,16 @@ export function argvHasFlag(argv: readonly string[], flag: string): boolean {
  */
 
 /**
- * Engines whose CLI can BRANCH a conversation into a new session. Probed
- * against the real binaries (2026-08-01): claude ships `--fork-session`,
- * codex a `fork` subcommand. Copilot and Kimi only RESUME (`--resume` /
- * `-S`), which would put two live processes on one transcript — not a fork,
- * so kobe refuses instead of pretending. Custom engines (opencode &c) are
- * launch-command-only: kobe knows neither their flags nor their session
- * store, so there is nothing to fork from. Teaching one of those to fork
- * means adding its verb here AND a history reader that can name the
- * session — the same two things claude/codex have.
+ * `canForkSession` / `forkSessionArgv` lived here (removed 2026-08-30).
+ * Both were vendor ladders — a hardcoded `v === "claude" || v === "codex"`
+ * and an inline if-chain of argv shapes — so an engine that ships a fork
+ * verb silently could not fork until someone edited this file, and a custom
+ * preset declaring a built-in protocol was refused despite launching that
+ * exact binary. The verb is now DECLARED by each engine
+ * (`EngineSessionIdentity.forkArgv`) and read through `engineCanFork` /
+ * `engineForkArgv` in `engine-presets.ts`, which resolve the preset's
+ * protocol first — the same fix `withClaudeSessionId` got.
  */
-export function canForkSession(vendor: VendorId | undefined): boolean {
-  const v: VendorId = coerceVendorId(vendor)
-  return v === "claude" || v === "codex"
-}
-
-/**
- * Argv that opens `sourceSessionId`'s conversation as a NEW, diverging
- * session — "fork this chat into another tab", same worktree. Both engines
- * ship the verb; the shapes differ, so they live here beside the other
- * per-vendor launch-flag mappings:
- *   - claude: `--resume <src> --fork-session` (+ our own `--session-id` so
- *     the forked tab stays trackable — the three combine, probed against
- *     claude 2.x: the fork lands in the id we pass).
- *   - codex: the `fork` SUBCOMMAND, options before the positional id.
- * Returns null when the vendor has no fork verb (copilot/custom), there is
- * no source id, or a claude base already controls its own session (a second
- * `--resume` would make claude refuse to launch — the user's override wins,
- * the user-flag-wins precedent) — the caller then opens an
- * ordinary tab on the base command.
- */
-export function forkSessionArgv(
-  base: readonly string[],
-  vendor: VendorId | undefined,
-  sourceSessionId: string,
-  newSessionId?: string | null,
-): readonly string[] | null {
-  if (!sourceSessionId) return null
-  const v: VendorId = coerceVendorId(vendor)
-  if (v === "claude") {
-    if (controlsOwnSession(engineEntry(v).sessionIdentity, base)) return null
-    const forked = [...base, "--resume", sourceSessionId, "--fork-session"]
-    return newSessionId ? [...forked, "--session-id", newSessionId] : forked
-  }
-  if (v === "codex") {
-    const [bin, ...rest] = base
-    return bin ? [bin, "fork", ...rest, sourceSessionId] : null
-  }
-  return null
-}
 
 /**
  * Shell-ready `… api` command prefix for protocol prompts. Packaged builds

--- a/packages/kobe/src/engine/session-identity.ts
+++ b/packages/kobe/src/engine/session-identity.ts
@@ -65,6 +65,26 @@ export interface EngineSessionIdentity {
    * would kill the launch.
    */
   readonly resumeArgv?: (base: readonly string[], sessionId: string) => readonly string[]
+  /**
+   * Argv that opens `sourceId`'s conversation as a NEW, diverging session —
+   * "fork this chat into another tab", same worktree. Absent = this engine
+   * has no fork verb, so Rove refuses instead of pretending: kimi's `-S` and
+   * copilot's `--resume` REOPEN a session, which would put two live
+   * processes on one transcript.
+   *
+   * A full-argv rewrite for the same reason {@link resumeArgv} is one — the
+   * shapes differ in kind: claude combines flags on the base command
+   * (`--resume <src> --fork-session`), codex takes a SUBCOMMAND with the id
+   * as a positional (`codex fork [opts] <src>`).
+   *
+   * `newId` is the id Rove wants the FORKED session to carry, for engines
+   * whose CLI accepts a caller-set one (claude's `--session-id`); an engine
+   * that mints its own ignores it. Null/absent = let the engine name it.
+   *
+   * Returning null refuses this particular fork (the caller then opens an
+   * ordinary tab on the base command).
+   */
+  readonly forkArgv?: (base: readonly string[], sourceId: string, newId?: string | null) => readonly string[] | null
 }
 
 /**
@@ -136,4 +156,27 @@ export function pickUnclaimedSessionId(ids: readonly string[], claimed: Readonly
     if (id && !claimed.has(id)) return id
   }
   return null
+}
+
+/**
+ * Argv that FORKS `sourceId` into a new diverging session, or null when this
+ * engine declares no fork verb, there is no source id, or the command already
+ * controls its own session (a second `--resume` makes claude refuse to launch
+ * — the user's explicit flag wins, same precedent as
+ * {@link resumeSessionArgv}). Null means the caller opens an ordinary tab.
+ */
+export function forkSessionArgvFor(
+  identity: EngineSessionIdentity | undefined,
+  base: readonly string[],
+  sourceId: string,
+  newId?: string | null,
+): readonly string[] | null {
+  if (!sourceId || !identity?.forkArgv) return null
+  if (controlsOwnSession(identity, base)) return null
+  return identity.forkArgv(base, sourceId, newId)
+}
+
+/** True when this engine declares a verb that BRANCHES a conversation. */
+export function acceptsSessionFork(identity: EngineSessionIdentity | undefined): boolean {
+  return !!identity?.forkArgv
 }

--- a/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
+++ b/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
@@ -4,11 +4,12 @@
  * `quick-fork.ts`, which forks the WORKTREE into a child task.
  *
  * Split out of `TerminalTabs.tsx` for the file-size cap; the vendor-specific
- * launch flags live in the engine layer (`forkSessionArgv`), the tab-state
+ * launch flags live in the engine layer (`engineForkArgv`), the tab-state
  * transition in `terminal-tabs-core`, so this is just the join.
  */
 
-import { canForkSession, engineDisplayName } from "@/engine/interactive-command"
+import { engineCanFork } from "@/engine/engine-presets"
+import { engineDisplayName } from "@/engine/interactive-command"
 import { engineEntry } from "@/engine/registry"
 import { buildHandoffPrompt } from "@/engine/session-handoff"
 import type { VendorId } from "@/types/vendor"
@@ -51,7 +52,7 @@ export async function planChatContinuation(
 ): Promise<ChatForkPlan> {
   const sessionId = await forkSourceSessionId(active, source, worktree)
   if (!sessionId) return { kind: "no-session" }
-  if (target === source && canForkSession(source)) return { kind: "fork", sessionId }
+  if (target === source && engineCanFork(source)) return { kind: "fork", sessionId }
   const transcriptPath = await engineEntry(source).history.transcriptPath(sessionId, worktree)
   if (!transcriptPath) return { kind: "no-transcript", engine: engineDisplayName(source) }
   return {

--- a/packages/kobe/src/tui/i18n/messages/doctor.ts
+++ b/packages/kobe/src/tui/i18n/messages/doctor.ts
@@ -71,7 +71,7 @@ export const en = {
     /** No engine has both a CLI binary and an account */
     noEngine: "no usable engine — no engine CLI is both installed and logged in",
     /** The manual action for {@link noEngine} */
-    noEngineAction: "install the claude, codex, or copilot CLI and log in",
+    noEngineAction: "install an engine CLI (claude, codex, copilot, or kimi) and log in",
     /** Windows only: no node, so the PTY host cannot start */
     windowsNode: "Node.js is missing — the Windows PTY host cannot start",
     /** The manual action for {@link windowsNode} */
@@ -115,7 +115,7 @@ export const zh: typeof en = {
     git: "PATH 上找不到 git",
     gitAction: "用你的系统包管理器安装 git",
     noEngine: "没有可用引擎 — 没有任何引擎 CLI 同时满足已安装且已登录",
-    noEngineAction: "安装 claude、codex 或 copilot CLI 并登录",
+    noEngineAction: "安装任一引擎 CLI（claude、codex、copilot 或 kimi）并登录",
     windowsNode: "缺少 Node.js — Windows PTY host 无法启动",
     windowsNodeAction: "从 https://nodejs.org 安装 Node.js",
   },

--- a/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
@@ -12,8 +12,7 @@ import {
   buildEngineSessionLaunch,
 } from "@/engine/session-launch"
 import { trustEngineWorktree } from "@/engine/trust-worktree"
-import { engineResumeArgv, withPinnedSessionId } from "../../engine/engine-presets"
-import { forkSessionArgv } from "../../engine/interactive-command"
+import { engineForkArgv, engineResumeArgv, withPinnedSessionId } from "../../engine/engine-presets"
 
 import type { VendorId } from "../../types/vendor"
 import type { TabSpawn } from "./terminal-tab-spawn"
@@ -41,7 +40,7 @@ export function engineTabArgv(
   if (tab.forkFrom && !tab.spawned && !live) {
     // `tab.vendor` is always concrete on a fork tab (the chord pins it) —
     // guard anyway so an inherited-vendor tab can never get claude's flags.
-    const forked = tab.vendor ? forkSessionArgv(base, tab.vendor, tab.forkFrom, tab.sessionId ?? null) : null
+    const forked = tab.vendor ? engineForkArgv(base, tab.vendor, tab.forkFrom, tab.sessionId ?? null) : null
     if (forked) return forked
   }
   if (!tab.sessionId) return base

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -8,7 +8,23 @@ const mocks = vi.hoisted(() => ({
   close: vi.fn(),
   inspectLegacyTmux: vi.fn(),
   kobeSkillState: vi.fn(),
+  detectEngineStatuses: vi.fn(),
+  listPresetIds: vi.fn(),
 }))
+
+// The engines block must be a LOOP over the registered engines, not a fixed
+// set of rows. Stubbing the probe (real ones read this machine's PATH and
+// credential files) keeps the assertions about composition: every id the
+// registry lists gets a row, in that order, with its own account shape.
+vi.mock("../../src/engine/engine-status.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/engine-status.ts")>()
+  return { ...actual, detectEngineStatuses: mocks.detectEngineStatuses }
+})
+
+vi.mock("../../src/engine/engine-presets.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/engine-presets.ts")>()
+  return { ...actual, listPresetIds: mocks.listPresetIds }
+})
 
 vi.mock("@sma1lboy/kobe-daemon/client", () => ({
   KobeDaemonClient: vi.fn().mockImplementation(() => ({
@@ -54,6 +70,14 @@ beforeEach(() => {
     currentVersion: 3,
     stale: false,
   })
+  mocks.listPresetIds.mockReset().mockReturnValue(["claude", "codex", "copilot", "kimi"])
+  mocks.detectEngineStatuses.mockReset().mockImplementation(async (vendors: readonly string[]) =>
+    vendors.map((vendor) => ({
+      vendor,
+      binary: { found: true, path: `/bin/${vendor}` },
+      account: { kind: "none" } as const,
+    })),
+  )
   vi.stubGlobal("Bun", { version: "0.0.0-test" })
   logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
 })
@@ -176,5 +200,98 @@ describe("runDoctorSubcommand", () => {
     expect(bundle).toContain("# Rove doctor report")
     expect(bundle).toContain("## diagnosis")
     cwdSpy.mockRestore()
+  })
+})
+
+// Why: doctor used to hardcode three rows (claude/codex/copilot) with three
+// hand-written label functions, so kimi was INVISIBLE despite shipping a real
+// `detectKimiAccount`, and no contrib/custom engine could ever appear. The
+// test that catches a regression is "every registered id gets a row", not
+// "these four names are present".
+describe("runDoctorSubcommand engines block", () => {
+  beforeEach(() => {
+    mocks.request.mockRejectedValue(new Error("not running"))
+  })
+
+  it("gives every registered engine a row, in registry order", async () => {
+    mocks.listPresetIds.mockReturnValue(["claude", "codex", "copilot", "kimi", "my-agent"])
+    await runDoctorSubcommand([])
+
+    const rows = output()
+      .split("\n")
+      .filter((l) => /^ {2}\w[\w-]*\s+[✓✗]/.test(l))
+    expect(rows.map((l) => l.trim().split(/\s+/)[0])).toEqual(["claude", "codex", "copilot", "kimi", "my-agent"])
+    expect(mocks.detectEngineStatuses).toHaveBeenCalledWith(["claude", "codex", "copilot", "kimi", "my-agent"])
+  })
+
+  it("renders each account shape from the engine's own status", async () => {
+    mocks.listPresetIds.mockReturnValue(["claude", "codex", "copilot", "kimi", "my-agent"])
+    mocks.detectEngineStatuses.mockResolvedValue([
+      { vendor: "claude", binary: { found: true, path: "/bin/claude" }, account: { kind: "oauth", email: "a@b.c" } },
+      {
+        vendor: "codex",
+        binary: { found: true, path: "/bin/codex" },
+        account: { kind: "chatgpt", email: "x@y.z", plan: "pro" },
+      },
+      { vendor: "copilot", binary: { found: false, error: "not found on PATH" }, account: { kind: "none" } },
+      // kimi's JWT carries no email claim — "logged in" with no identity.
+      { vendor: "kimi", binary: { found: true, path: "/bin/kimi" }, account: { kind: "oauth" } },
+      // No detector: NOT the same claim as "not logged in".
+      { vendor: "my-agent", binary: { found: true, path: "/bin/my-agent" }, account: null },
+    ])
+    await runDoctorSubcommand([])
+
+    expect(output()).toContain("claude  ✓ /bin/claude — logged in (a@b.c)")
+    expect(output()).toContain("codex   ✓ /bin/codex — logged in (x@y.z, pro)")
+    expect(output()).toContain("copilot ✗ not found on PATH")
+    expect(output()).toContain("kimi    ✓ /bin/kimi — logged in")
+    expect(output()).toContain("my-agent ✓ /bin/my-agent — login not detectable")
+  })
+
+  it("surfaces an engine's account error without dropping its row", async () => {
+    mocks.listPresetIds.mockReturnValue(["kimi"])
+    mocks.detectEngineStatuses.mockResolvedValue([
+      {
+        vendor: "kimi",
+        binary: { found: true, path: "/bin/kimi" },
+        account: { kind: "none" },
+        accountError: "parse /home/u/.kimi-code/credentials/kimi-code.json: bad json",
+      },
+    ])
+    await runDoctorSubcommand([])
+
+    expect(output()).toContain("kimi    ✓ /bin/kimi — no account")
+    expect(output()).toContain("⚠ parse /home/u/.kimi-code/credentials/kimi-code.json: bad json")
+  })
+
+  it("counts ANY usable engine, not just the three that used to be listed", async () => {
+    // Only kimi is installed and logged in. `anyUsable` used to OR three
+    // hardcoded vendors, so this user was told they had NO engine at all.
+    // The verdict is only visible as a proposed fix, so count them: the
+    // no-engine finding is present in one case and absent in the other.
+    mocks.listPresetIds.mockReturnValue(["claude", "codex", "copilot", "kimi"])
+    const missing = (vendor: string) => ({
+      vendor,
+      binary: { found: false, error: "not found on PATH" },
+      account: { kind: "none" as const },
+    })
+    const kimiUsable = [
+      missing("claude"),
+      missing("codex"),
+      missing("copilot"),
+      { vendor: "kimi", binary: { found: true, path: "/bin/kimi" }, account: { kind: "oauth" as const } },
+    ]
+    mocks.detectEngineStatuses.mockResolvedValue(kimiUsable)
+    await runDoctorSubcommand([])
+    const withKimi = Number(/(\d+) finding/.exec(output())?.[1] ?? -1)
+
+    logSpy.mockClear()
+    mocks.detectEngineStatuses.mockResolvedValue([...kimiUsable.slice(0, 3), missing("kimi")])
+    await runDoctorSubcommand([])
+    const withNone = Number(/(\d+) finding/.exec(output())?.[1] ?? -1)
+
+    expect(withKimi).toBeGreaterThanOrEqual(0)
+    // Nothing usable adds exactly the no-engine finding on top.
+    expect(withNone).toBe(withKimi + 1)
   })
 })

--- a/packages/kobe/test/engine/engine-presets.test.ts
+++ b/packages/kobe/test/engine/engine-presets.test.ts
@@ -12,7 +12,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { engineLaunchArgv, engineLaunchBin } from "../../src/engine/engine-presets.ts"
+import { engineCanFork, engineForkArgv, engineLaunchArgv, engineLaunchBin } from "../../src/engine/engine-presets.ts"
 
 let home: string
 let originalHome: string | undefined
@@ -107,5 +107,46 @@ describe("engineLaunchArgv", () => {
     writeState({ customEngineIds: ["pi"], "engineCommand.pi": "pi-cli --interactive" })
     expect(engineLaunchBin({ command: "pi" })).toBe("pi-cli")
     expect(engineLaunchBin({ command: "aider --model sonnet" })).toBe("aider")
+  })
+})
+
+// Why: `engine-presets.ts:22-26` promises a declared protocol makes the
+// built-in adapter's knowledge apply — but fork used to read the RAW vendor
+// id, find the empty custom entry, and refuse. A `claudecpa` wrapper launches
+// the claude binary and forks exactly like claude; resolving the protocol
+// first is what makes the promise true. Needs state, so it lives here rather
+// than beside the other fork tests.
+describe("fork through a declared protocol", () => {
+  it("forks a custom preset that declares a built-in protocol", () => {
+    writeState({
+      customEngineIds: ["claudecpa"],
+      "engineCommand.claudecpa": "claudecpa",
+      "engineProtocol.claudecpa": "claude",
+    })
+    expect(engineCanFork("claudecpa")).toBe(true)
+    expect(engineForkArgv(["claudecpa"], "claudecpa", "src", "new")).toEqual([
+      "claudecpa",
+      "--resume",
+      "src",
+      "--fork-session",
+      "--session-id",
+      "new",
+    ])
+  })
+
+  it("still refuses a preset with no declared protocol — kobe knows no verb for it", () => {
+    writeState({ customEngineIds: ["mystery"], "engineCommand.mystery": "mystery-cli" })
+    expect(engineCanFork("mystery")).toBe(false)
+    expect(engineForkArgv(["mystery-cli"], "mystery", "src")).toBeNull()
+  })
+
+  it("refuses a preset whose declared protocol has no fork verb", () => {
+    writeState({
+      customEngineIds: ["mykimi"],
+      "engineCommand.mykimi": "kimi-wrapper",
+      "engineProtocol.mykimi": "kimi",
+    })
+    expect(engineCanFork("mykimi")).toBe(false)
+    expect(engineForkArgv(["kimi-wrapper"], "mykimi", "src")).toBeNull()
   })
 })

--- a/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
+++ b/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
@@ -8,7 +8,7 @@
  * on every re-render/restart would replay the parent's history forever.
  */
 
-import { canForkSession, forkSessionArgv } from "@/engine/interactive-command"
+import { engineCanFork, engineForkArgv } from "@/engine/engine-presets"
 import { buildHandoffPrompt } from "@/engine/session-handoff"
 import { planChatContinuation } from "@/tui-react/workspace/fork-chat-tab"
 import { type EngineTab, type TabsState, engineTabArgv, engineTabSpawnFor } from "@/tui/workspace/terminal-tabs-core"
@@ -22,9 +22,9 @@ const tab = (over: Partial<EngineTab>): EngineTab => ({
   ...over,
 })
 
-describe("forkSessionArgv", () => {
+describe("engineForkArgv", () => {
   it("resumes-and-forks claude into the id we pinned", () => {
-    expect(forkSessionArgv(["claude"], "claude", "src", "new")).toEqual([
+    expect(engineForkArgv(["claude"], "claude", "src", "new")).toEqual([
       "claude",
       "--resume",
       "src",
@@ -35,11 +35,11 @@ describe("forkSessionArgv", () => {
   })
 
   it("forks claude without pinning when the caller has no new id", () => {
-    expect(forkSessionArgv(["claude"], "claude", "src", null)).toEqual(["claude", "--resume", "src", "--fork-session"])
+    expect(engineForkArgv(["claude"], "claude", "src", null)).toEqual(["claude", "--resume", "src", "--fork-session"])
   })
 
   it("uses codex's fork subcommand, options before the positional id", () => {
-    expect(forkSessionArgv(["codex", "-c", "model_reasoning_effort=high"], "codex", "src")).toEqual([
+    expect(engineForkArgv(["codex", "-c", "model_reasoning_effort=high"], "codex", "src")).toEqual([
       "codex",
       "fork",
       "-c",
@@ -49,19 +49,19 @@ describe("forkSessionArgv", () => {
   })
 
   it("declines when the vendor has no fork verb, or there is no source", () => {
-    expect(forkSessionArgv(["copilot"], "copilot", "src")).toBeNull()
-    expect(forkSessionArgv(["kimi"], "kimi", "src")).toBeNull()
-    expect(forkSessionArgv(["opencode"], "opencode", "src")).toBeNull()
-    expect(forkSessionArgv(["claude"], "claude", "")).toBeNull()
+    expect(engineForkArgv(["copilot"], "copilot", "src")).toBeNull()
+    expect(engineForkArgv(["kimi"], "kimi", "src")).toBeNull()
+    expect(engineForkArgv(["opencode"], "opencode", "src")).toBeNull()
+    expect(engineForkArgv(["claude"], "claude", "")).toBeNull()
   })
 
   it("declines a claude base that already controls its own session — either flag form (issue #58)", () => {
     // A second --resume makes claude refuse to launch; the user's override
     // wins and the caller opens an ordinary tab on the base command.
-    expect(forkSessionArgv(["claude", "--resume", "pinned"], "claude", "src", "new")).toBeNull()
-    expect(forkSessionArgv(["claude", "--resume=pinned"], "claude", "src", "new")).toBeNull()
-    expect(forkSessionArgv(["claude", "--session-id=pinned"], "claude", "src", "new")).toBeNull()
-    expect(forkSessionArgv(["claude", "-c"], "claude", "src", "new")).toBeNull()
+    expect(engineForkArgv(["claude", "--resume", "pinned"], "claude", "src", "new")).toBeNull()
+    expect(engineForkArgv(["claude", "--resume=pinned"], "claude", "src", "new")).toBeNull()
+    expect(engineForkArgv(["claude", "--session-id=pinned"], "claude", "src", "new")).toBeNull()
+    expect(engineForkArgv(["claude", "-c"], "claude", "src", "new")).toBeNull()
   })
 })
 
@@ -69,13 +69,13 @@ describe("forkSessionArgv", () => {
 // would put a second live process on one transcript — the chord must refuse
 // with a reason, not silently hand the user a blank tab. Custom engines
 // (opencode &c) are launch-command-only: no flags, no session store.
-describe("canForkSession", () => {
+describe("engineCanFork", () => {
   it("is true only for the engines whose CLI branches a conversation", () => {
-    expect(canForkSession("claude")).toBe(true)
-    expect(canForkSession("codex")).toBe(true)
-    expect(canForkSession("copilot")).toBe(false)
-    expect(canForkSession("kimi")).toBe(false)
-    expect(canForkSession("opencode")).toBe(false)
+    expect(engineCanFork("claude")).toBe(true)
+    expect(engineCanFork("codex")).toBe(true)
+    expect(engineCanFork("copilot")).toBe(false)
+    expect(engineCanFork("kimi")).toBe(false)
+    expect(engineCanFork("opencode")).toBe(false)
   })
 })
 


### PR DESCRIPTION
Twin of #636 (`withClaudeSessionId`), plus the doctor half of the same audit.

## 1. `canForkSession` was a hardcoded vendor ladder

`interactive-command.ts` had `return v === "claude" || v === "codex"`, with
`forkSessionArgv` inlining both argv shapes below it. It lived inside
`engine/**`, so a grep of the neutral layers never surfaced it — but it was
exactly the forbidden shape: a capability list the adapters can't declare. An
engine shipping a fork verb **silently could not fork** until someone edited
a shared file. The doc comment said so itself ("adding its verb here").

Now declared per engine as `EngineSessionIdentity.forkArgv`, read through
`engineCanFork` / `engineForkArgv` in `engine-presets.ts` — same seam
`resumeArgv` uses, for the same reason (the shapes differ in kind: claude
combines flags, codex takes a subcommand).

**Also closes an undocumented gap.** `engine-presets.ts:22-26` promises a
declared protocol makes the built-in adapter apply, but fork read the *raw*
vendor id, found the empty custom entry, and refused. A `claudecpa` wrapper
launches the claude binary and now forks like claude.

Kimi honestly reports `false` — probed against the real CLI, it has only
`-S` (resume) and `-c` (continue). A fork would put two live processes on one
transcript.

## 2. `rove doctor` bypassed the registry, so Kimi was invisible

Three hardcoded imports, three hand-written label functions, three literal
rows, and an `anyUsable` that OR'd exactly those three. Kimi never appeared
despite a working `detectKimiAccount`; no contrib/custom engine ever could.

It now loops over registered engines via `detectEngineStatuses` — the probe
Settings → Accounts already uses (it *already* included kimi), so the two
surfaces can't disagree. The three per-vendor labels collapse into one
`describeAccount` that switches on account **kind**, never a vendor.

### Real machine, before → after

```
 engines:                                    engines:
   claude  ✓ …/claude — logged in (…)          claude  ✓ …/claude — logged in (…)
   codex   ✓ …/codex — logged in (…, free)     codex   ✓ …/codex — logged in (…, free)
   copilot ✗ not found on PATH                 copilot ✗ not found on PATH
                                             + kimi    ✓ …/kimi — logged in
                                             + claudecpa ✗ not found on PATH
                                             + kimip   ✓ …/kimi — login not detectable
```

Built-in rows are byte-identical. `kimip` reads "login not detectable" — an
engine with no detector is not the same claim as a logged-out one.

Found while here: an 8-char custom id collided with the ✓/✗ under `padEnd(8)`
(only reachable now that custom engines can appear). Fixed as `padEnd(7)`+space;
built-in columns unchanged.

## Testing

`+7` tests. Every fix passes delete-it→red, run **twice** (round 2 on the final
tree, post-rebase):

| mutation | result |
|---|---|
| A remove `forkArgv` from claude+codex | 7 failed |
| B drop protocol resolution (raw id) | 1 failed — the custom-preset gap |
| C doctor hardcodes 3 vendors | 4 failed |
| D `anyUsable` ignores kimi | 1 failed |
| E `describeAccount(null)` → "no account" | 1 failed |

D initially **survived** — the assertion checked a string that never prints
(the hint is i18n'd). Rewritten to compare fix counts; now red.

Live-verified: `rove doctor` lists kimi; a kimi tab correctly refuses to fork;
a protocol-declaring preset forks with claude's real flags.

`test:fast` shows 47 pre-existing failures in unrelated CLI suites — identical
set on clean HEAD (mine is a strict subset; HEAD also flaked
`terminal-selection-trim`, which passes in isolation). All 8 touched suites +
architecture gates green. File-size cap: doctor 388→370, interactive-command
437→397.

## Out of scope (per the brief — dispatched separately)

Web-layer vendor token metrics, daemon's `VendorId` union missing kimi,
copilot trust-hook docs. Also noticed but not touched: two
`--append-system-prompt` vendor ladders in `interactive-command.ts` — same
shape, different feature.