### PR TITLE
fix: write agent output and credential files owner-only

### DIFF
--- a/.changeset/owner-only-secret-files.md
+++ b/.changeset/owner-only-secret-files.md
@@ -1,0 +1,20 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop writing agent output and credentials as world-readable files
+
+The hosted-PTY freeze store persists each session's whole scrollback ring, so
+its records held every byte an agent printed — `env` output, `cat`ed key files,
+a git remote carrying a PAT — at mode 0644 in a 0755 directory, readable by any
+local user. That store, the PTY exit records, plugin settings `.env` (where
+plugin authors are told to keep API keys), `state.json`, `tasks.json`, and the
+agent-turn telemetry now all land 0600, with owner-only directories where the
+directory is dedicated to the sensitive file.
+
+`rove doctor --report` also stopped printing the value of every `ROVE_*` /
+`KOBE_*` variable. That namespace is the plugin env contract, so a token parked
+there went straight into a file meant for public bug reports. Known
+diagnostic keys (paths, ports, mode flags) still show their value; anything
+else is listed as `KEY=(set)`, which keeps the diagnostic signal without the
+secret.

--- a/packages/kobe-daemon/src/daemon/agent-turns-store.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-store.ts
@@ -149,7 +149,9 @@ export class AgentTurnsStore {
     const tmp = `${this.path}.tmp-${process.pid}-${randomUUID()}`
     try {
       await mkdir(dirname(this.path), { recursive: true })
-      await writeFile(tmp, `${JSON.stringify(body)}\n`, "utf8")
+      // 0600: no credentials here, but the records do name every repo you work
+      // in and when — defense in depth, and free.
+      await writeFile(tmp, `${JSON.stringify(body)}\n`, { encoding: "utf8", mode: 0o600 })
       await rename(tmp, this.path)
     } catch (err) {
       logDaemonError("agent-turns-write", err)

--- a/packages/kobe-daemon/src/daemon/pty-exit-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-store.ts
@@ -181,5 +181,7 @@ function writeRecord(storeKey: string, record: PtyExitRecord, path: string): voi
     .sort(([, a], [, b]) => (a.at < b.at ? 1 : -1))
     .slice(0, MAX_RECORDS)
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify(Object.fromEntries(newest), null, 2), "utf8")
+  // 0600: every record carries `plainTail` — the dying process's last output,
+  // same class of content as the scrollback in pty-freeze-store.
+  writeFileSync(path, JSON.stringify(Object.fromEntries(newest), null, 2), { encoding: "utf8", mode: 0o600 })
 }

--- a/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
@@ -193,10 +193,13 @@ export function fileFreezeSink(dir = defaultPtyFreezeDir()): PtyFreezeSink {
   return {
     save(record) {
       try {
-        mkdirSync(dir, { recursive: true })
+        // 0700/0600: `ringB64` is the session's whole scrollback, so this file
+        // holds every byte the agent printed — `env` output, `cat`ed credential
+        // files, a git remote carrying a PAT. Owner-only, like a private key.
+        mkdirSync(dir, { recursive: true, mode: 0o700 })
         const target = recordFile(dir, record.key)
         const staging = `${target}.${process.pid}.tmp`
-        writeFileSync(staging, JSON.stringify(record), "utf8")
+        writeFileSync(staging, JSON.stringify(record), { encoding: "utf8", mode: 0o600 })
         renameSync(staging, target)
       } catch {
         /* best-effort by contract — a freeze hiccup never kills the terminal */

--- a/packages/kobe-daemon/src/plugins/settings-env.ts
+++ b/packages/kobe-daemon/src/plugins/settings-env.ts
@@ -60,8 +60,10 @@ export function writePluginSettings(pluginId: string, values: Record<string, str
     if (value !== "") next.push(`${key}=${value}`)
   }
   while (next.length > 0 && next[next.length - 1] === "") next.pop()
-  mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true })
-  writeFileSync(path, next.length > 0 ? `${next.join("\n")}\n` : "")
+  // 0700/0600: this .env is where PLUGIN-AUTHORING tells authors to keep API
+  // keys, so it must not be world-readable like the manifest beside it.
+  mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
+  writeFileSync(path, next.length > 0 ? `${next.join("\n")}\n` : "", { mode: 0o600 })
 }
 
 /**

--- a/packages/kobe/src/cli/doctor-report.ts
+++ b/packages/kobe/src/cli/doctor-report.ts
@@ -3,16 +3,28 @@
  * into one attachable text file, so a bug report carries the context the
  * maintainer needs instead of a screenshot of the summary.
  *
- * Only path-shaped env is emitted (KOBE_*, terminal, editor, shell) — never a
- * credential file's contents. `buildReportBundle` is pure (logs + env injected)
- * so the format is unit-testable without touching disk.
+ * Env discipline: this file gets pasted into public bug reports, so a value is
+ * printed ONLY for a key on {@link REPORT_ENV_KEYS}. Every other ROVE_/KOBE_
+ * var is listed as `KEY=(set)` — the maintainer still learns the knob is on,
+ * which is the diagnostic part, while a credential someone parked in that
+ * namespace (`ROVE_GH_PAT=ghp_…`; the plugin env contract lives there too)
+ * never leaves the machine. Allowlisting VALUES rather than filtering by key
+ * name or entropy is deliberate: a name filter misses what it hasn't seen and
+ * entropy misreads a long path as a secret, whereas an unknown key here fails
+ * closed — the cost is a missing value in one report, not a leaked token.
+ * `buildReportBundle` is pure (logs + env injected) so the format is
+ * unit-testable without touching disk.
  */
 
 import { readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { defaultDaemonLogPath, defaultPtyHostLogPath } from "@sma1lboy/kobe-daemon/daemon/paths"
 
-/** Explicit non-secret env keys worth capturing, plus every ROVE_ and KOBE_ var. */
+/**
+ * Keys whose VALUE is printed verbatim. Everything else is reported as `(set)`.
+ * Add a key here when its value is what you'd ask a reporter for anyway — a
+ * path, a port, a mode flag. Never add one that could hold a credential.
+ */
 const REPORT_ENV_KEYS = [
   "SHELL",
   "TERM",
@@ -21,6 +33,33 @@ const REPORT_ENV_KEYS = [
   "COLORTERM",
   "VISUAL",
   "EDITOR",
+  // Rove's own knobs: where state lives, which transport, which engine.
+  "ROVE_HOME_DIR",
+  "KOBE_HOME_DIR",
+  "ROVE_DAEMON_SOCKET_PATH",
+  "KOBE_DAEMON_SOCKET_PATH",
+  "ROVE_SOCKET_PATH",
+  "KOBE_SOCKET_PATH",
+  "KOBE_PTY_SOCKET_PATH",
+  "ROVE_DAEMON_WEB_PORT",
+  "KOBE_DAEMON_WEB_PORT",
+  "KOBE_PTY_PORT",
+  "KOBE_WEB_HOST",
+  "ROVE_BIN_PATH",
+  "KOBE_BIN_PATH",
+  "KOBE_WORKTREE_ROOT_DIR",
+  "ROVE_INVOKED_AS",
+  "ROVE_PRODUCT_NAME",
+  "ROVE_DEV",
+  "KOBE_DEV",
+  "KOBE_DEBUG",
+  "KOBE_NO_DAEMON",
+  "KOBE_TERMINAL_BACKEND",
+  "KOBE_TEST_ENGINE",
+  "ROVE_TASK_ID",
+  "KOBE_TASK_ID",
+  "ROVE_TAB_ID",
+  "KOBE_TAB_ID",
 ] as const
 
 /** How many trailing log lines each log section carries (also named in its header). */
@@ -38,11 +77,19 @@ function logTail(path: string, count: number): string {
   }
 }
 
-/** `KEY=value` lines for the report's env section (path-shaped vars only). */
+/**
+ * `KEY=value` lines for the report's env section. Allowlisted keys carry their
+ * value; any other ROVE_/KOBE_ var is reported present-but-redacted.
+ */
 export function reportEnvLines(env: NodeJS.ProcessEnv): string[] {
-  const keys = new Set<string>(REPORT_ENV_KEYS)
+  const shown = new Set<string>(REPORT_ENV_KEYS)
+  const keys = new Set<string>(shown)
   for (const key of Object.keys(env)) if (key.startsWith("ROVE_") || key.startsWith("KOBE_")) keys.add(key)
-  return [...keys].sort().map((key) => `${key}=${env[key] ?? "(unset)"}`)
+  return [...keys].sort().map((key) => {
+    const value = env[key]
+    if (value === undefined) return `${key}=(unset)`
+    return shown.has(key) ? `${key}=${value}` : `${key}=(set)`
+  })
 }
 
 /** Pure: assemble the bundle text from the diagnosis lines + injected logs/env. */

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -182,7 +182,9 @@ export class TaskIndexStore {
       // survivor's rename with ENOENT (issue #53).
       const tmpPath = `${this.path}.${process.pid}.${ulid()}.tmp`
       try {
-        const handle = await open(tmpPath, "w", 0o644)
+        // 0600: task titles are free-form user prose and every record names a
+        // repo path — not credentials, but nobody else's business either.
+        const handle = await open(tmpPath, "w", 0o600)
         try {
           await handle.writeFile(json, "utf8")
           await handle.sync()

--- a/packages/kobe/src/state/store.ts
+++ b/packages/kobe/src/state/store.ts
@@ -97,7 +97,10 @@ function writeStateFile(state: StateSnapshot): void {
   mkdirSync(dirname(path), { recursive: true })
   const nonce = Math.random().toString(36).slice(2)
   const tmp = `${path}.${process.pid}.${nonce}.tmp`
-  writeFileSync(tmp, JSON.stringify(state, null, 2), "utf8")
+  // 0600: `engineCommand.*` holds a user-authored shell line, which is exactly
+  // where someone pastes `--api-key=…`. Owner-only costs nothing here — the file
+  // already lives under a single user's ~/.config.
+  writeFileSync(tmp, JSON.stringify(state, null, 2), { encoding: "utf8", mode: 0o600 })
   renameSync(tmp, path)
 }
 

--- a/packages/kobe/test/cli/doctor-report.test.ts
+++ b/packages/kobe/test/cli/doctor-report.test.ts
@@ -34,4 +34,46 @@ describe("buildReportBundle", () => {
     expect(lines).toContain("TERM=xterm")
     expect(lines.some((l) => l.startsWith("SECRET_TOKEN"))).toBe(false)
   })
+
+  /**
+   * The report exists to be pasted into a public bug report, and ROVE_/KOBE_
+   * is the namespace the plugin env contract hands to third-party code — so an
+   * unrecognized key in it is exactly where a token shows up. Presence is the
+   * diagnostic signal; the value is not.
+   */
+  it("redacts the value of an unknown ROVE_/KOBE_ var while keeping it listed", () => {
+    const lines = reportEnvLines({
+      ROVE_GH_PAT: "ghp_realtokenvaluehere",
+      KOBE_PLUGIN_OPENAI_KEY: "sk-live-abc123",
+      ROVE_HOME_DIR: "/tmp/rove-home",
+    })
+    // Listed (the maintainer learns the var is set) …
+    expect(lines).toContain("ROVE_GH_PAT=(set)")
+    expect(lines).toContain("KOBE_PLUGIN_OPENAI_KEY=(set)")
+    // … but no substring of the report carries the secret itself.
+    const text = lines.join("\n")
+    expect(text).not.toContain("ghp_realtokenvaluehere")
+    expect(text).not.toContain("sk-live-abc123")
+    // Allowlisted keys still carry their value — the report stays useful.
+    expect(lines).toContain("ROVE_HOME_DIR=/tmp/rove-home")
+  })
+
+  it("distinguishes an unset allowlisted key from a redacted set one", () => {
+    const lines = reportEnvLines({ ROVE_SECRET_THING: "" })
+    // Empty string is still "set" — reporting it as (unset) would be a lie, and
+    // an empty value can itself be the bug.
+    expect(lines).toContain("ROVE_SECRET_THING=(set)")
+    expect(lines).toContain("SHELL=(unset)")
+  })
+
+  it("never leaks an unknown var's value through the assembled bundle", () => {
+    const text = buildReportBundle(["kobe doctor"], {
+      generatedAt: "2026-07-15T00:00:00.000Z",
+      env: { KOBE_ANTHROPIC_API_KEY: "sk-ant-secret" },
+      daemonLog: "",
+      ptyLog: "",
+    })
+    expect(text).toContain("KOBE_ANTHROPIC_API_KEY=(set)")
+    expect(text).not.toContain("sk-ant-secret")
+  })
 })

--- a/packages/kobe/test/daemon/secret-file-modes.test.ts
+++ b/packages/kobe/test/daemon/secret-file-modes.test.ts
@@ -14,8 +14,8 @@ import { mkdtempSync, rmSync, statSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { AgentTurnsStore } from "@sma1lboy/kobe-daemon/daemon/agent-turns-store"
-import { fileFreezeSink, freezeSession } from "@sma1lboy/kobe-daemon/daemon/pty-freeze-store"
 import { recordPtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
+import { fileFreezeSink, freezeSession } from "@sma1lboy/kobe-daemon/daemon/pty-freeze-store"
 import { pluginConfigDir } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import { writePluginSettings } from "@sma1lboy/kobe-daemon/plugins/settings-env"
 import { afterEach, describe, expect, it } from "vitest"
@@ -50,6 +50,7 @@ describe("stores that hold agent output or credentials are owner-only", () => {
         exit: null,
         // The thing we are protecting: scrollback the agent produced.
         chunks: [Buffer.from("AWS_SECRET_ACCESS_KEY=wJalr")],
+        bytes: 26,
       }),
     )
     expect(mode(join(dir, "t%3A%3Atab-1.json"))).toBe(0o600)

--- a/packages/kobe/test/daemon/secret-file-modes.test.ts
+++ b/packages/kobe/test/daemon/secret-file-modes.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Every store that persists what an agent printed, or what a user typed as a
+ * credential, must land owner-only on disk. The freeze store is the sharp one:
+ * `ringB64` is the session's entire scrollback, so a world-readable record is a
+ * full transcript of `env` output, `cat`ed key files, and PAT-bearing remotes
+ * for any local user to read.
+ *
+ * These assert the REAL mode via `statSync`, not the arguments a write was
+ * called with — a wrapper that drops the option, or an umask interaction, has
+ * to fail here.
+ */
+
+import { mkdtempSync, rmSync, statSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { AgentTurnsStore } from "@sma1lboy/kobe-daemon/daemon/agent-turns-store"
+import { fileFreezeSink, freezeSession } from "@sma1lboy/kobe-daemon/daemon/pty-freeze-store"
+import { recordPtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
+import { pluginConfigDir } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
+import { writePluginSettings } from "@sma1lboy/kobe-daemon/plugins/settings-env"
+import { afterEach, describe, expect, it } from "vitest"
+
+const dirs: string[] = []
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+/** Permission bits only — `statSync().mode` carries the file type too. */
+function mode(path: string): number {
+  return statSync(path).mode & 0o777
+}
+
+describe("stores that hold agent output or credentials are owner-only", () => {
+  it("freezes a PTY session ring into a 0600 file inside a 0700 dir", () => {
+    const dir = join(tmp("kobe-modes-freeze-"), "pty-sessions")
+    fileFreezeSink(dir).save(
+      freezeSession({
+        key: "t::tab-1",
+        cwd: "/tmp",
+        command: ["bash"],
+        cols: 80,
+        rows: 24,
+        title: "t",
+        totalBytes: 5,
+        exit: null,
+        // The thing we are protecting: scrollback the agent produced.
+        chunks: [Buffer.from("AWS_SECRET_ACCESS_KEY=wJalr")],
+      }),
+    )
+    expect(mode(join(dir, "t%3A%3Atab-1.json"))).toBe(0o600)
+    expect(mode(dir)).toBe(0o700)
+  })
+
+  it("writes pty-exits.json (which carries the dying process's last output) as 0600", () => {
+    const path = join(tmp("kobe-modes-exits-"), "pty-exits.json")
+    recordPtyExit(
+      {
+        key: "t::tab-1",
+        pid: 4242,
+        exit: { code: 1, signal: null, at: "2026-08-11T00:00:00.000Z" },
+        tail: "GITHUB_TOKEN=ghp_x\nexiting",
+      },
+      path,
+    )
+    expect(mode(path)).toBe(0o600)
+  })
+
+  it("writes a plugin's settings .env as 0600 inside a 0700 config dir", () => {
+    const home = tmp("kobe-modes-plugin-")
+    writePluginSettings("p", { API_KEY: "sk-live-123" }, home)
+    expect(mode(join(pluginConfigDir("p", home), ".env"))).toBe(0o600)
+    expect(mode(pluginConfigDir("p", home))).toBe(0o700)
+  })
+
+  it("writes agent-turns.json as 0600", async () => {
+    const path = join(tmp("kobe-modes-turns-"), "agent-turns.json")
+    const store = new AgentTurnsStore(path)
+    await store.record([{ id: "turn-1", taskId: "task-1", startedAt: 1, endedAt: 2 }])
+    expect(mode(path)).toBe(0o600)
+  })
+})

--- a/packages/kobe/test/state/file-modes.test.ts
+++ b/packages/kobe/test/state/file-modes.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // biome-ignore lint/performance/noDelete: env cleanup must fully unset when the var was unset before the test (assigning undefined leaves it as the string "undefined"). Same pattern as test/state/store.test.ts.
   if (originalHome === undefined) delete process.env.KOBE_HOME_DIR
   else process.env.KOBE_HOME_DIR = originalHome
   fs.rmSync(tmpHome, { recursive: true, force: true })

--- a/packages/kobe/test/state/file-modes.test.ts
+++ b/packages/kobe/test/state/file-modes.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `state.json` and `tasks.json` are user-scoped records — engine command lines
+ * (where an `--api-key=…` gets pasted), saved repo paths, task titles. None of
+ * that is another local user's business, so both land 0600.
+ *
+ * Asserts the REAL mode via `statSync`, not the options a write was called
+ * with: only the on-disk bits prove the fix survived the write path.
+ */
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+import { patchStateFile } from "../../src/state/store.ts"
+
+let tmpHome: string
+let originalHome: string | undefined
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-file-modes-"))
+  originalHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = tmpHome
+})
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.KOBE_HOME_DIR
+  else process.env.KOBE_HOME_DIR = originalHome
+  fs.rmSync(tmpHome, { recursive: true, force: true })
+})
+
+/** Permission bits only — `statSync().mode` carries the file type too. */
+function mode(file: string): number {
+  return fs.statSync(file).mode & 0o777
+}
+
+describe("user-scoped state files are owner-only", () => {
+  test("state.json is 0600", () => {
+    // The value that motivates it: a custom engine command is a user-authored
+    // shell line, and a shell line is where a key ends up.
+    patchStateFile({ "engineCommand.custom": "claude --api-key=sk-live-123" })
+    expect(mode(path.join(tmpHome, ".config", "rove", "state.json"))).toBe(0o600)
+  })
+
+  test("tasks.json is 0600", async () => {
+    const store = new TaskIndexStore({ homeDir: tmpHome })
+    await store.load()
+    await store.create({
+      title: "alpha",
+      repo: "/repo",
+      branch: "kobe/alpha",
+      worktreePath: "/repo/.kobe/worktrees/alpha",
+      kind: "task",
+      status: "backlog",
+    })
+    expect(mode(path.join(tmpHome, ".rove", "tasks.json"))).toBe(0o600)
+  })
+})


### PR DESCRIPTION
Two credential-exposure fixes from a security audit. Both are a few lines; the consequences are not.

## 1. PTY snapshots stored everything an agent printed, at 0644

`pty-freeze-store.ts` writes one JSON record per hosted session, and `ringB64` is `Buffer.concat(session.chunks).toString("base64")` — the **entire terminal ring buffer**. Whatever the agent printed is in there: `env` output, `cat`ed credential files, a git remote carrying a PAT, `gh auth token`, API responses. The directory got the `mkdirSync` default (0755) and the file got the `writeFileSync` default (0644).

On the reporting machine that meant a 701KB world-readable scrollback:

```
-rw-r--r--  701669  ~/.kobe/pty-sessions/…tab-6.json
```

Reachable on the normal freeze path — no crash or user action needed. `engine/kimi-local/trust.ts` already used `0o700`/`0o600` for a file holding one path and a timestamp; the store holding full transcripts had no mode at all.

Now 0600, with 0700 on directories dedicated to the sensitive file. Same treatment for the siblings:

| File | Why |
|---|---|
| `pty-sessions/*.json` | whole scrollback ring |
| `pty-exits.json` | `plainTail` — the dying process's last output |
| plugin config `.env` | **documented as the place for plugin API keys** |
| `state.json` | `engineCommand.*` is a user-authored shell line |
| `tasks.json` | task titles + every repo path |
| `agent-turns.json` | which repos, when |

Directory mode was applied only where the directory belongs to the sensitive artifact. `~/.rove` itself is untouched — it also holds the daemon socket, and narrowing it is a bigger behavioral question than this PR.

## 2. `doctor --report` printed every `ROVE_*` / `KOBE_*` value

The module comment promised "only path-shaped env … never a credential", but the code was a prefix match that emitted every matching variable's value into `rove-doctor-report.txt` — a file whose whole purpose is being pasted into a public bug report. That namespace is also the plugin env contract (`plugins/env.ts`), so it is exactly where a third-party plugin's key lives.

Now values come from an allowlist; every other `ROVE_*`/`KOBE_*` var is listed as `KEY=(set)`.

**Why allowlist rather than filter by name or entropy:** a name filter (`/token|key|secret/i`) misses `ROVE_GH_PAT`, and entropy scoring misreads a long path as a secret. An unknown key fails *closed* — the cost is one missing value in one report; the cost of failing open is a leaked token. Presence is preserved because presence is the diagnostic signal ("`KOBE_NO_DAEMON` is set" is the finding; its value is `1`).

## Verification

- **Mutation-tested, 9 mutants, 2 passes each, re-run after the rebase onto v0.9.28.** Every reverted mode literal and the redaction branch turn the suite red; all 9 caught in every pass.
- Mode assertions `statSync` the **real file**, not the arguments a write was called with — a dropped option or umask interaction has to fail.
- **Live run:** a real Claude engine in a fully isolated sandbox (own home, socket, pid, ports; verified against the `.kobe` compat-symlink trap in `docs/HARNESS.md`) froze a session and produced `drwx------` / `-rw-------`, versus `drwxr-xr-x` / `-rw-r--r--` in production.
- `test:fast` 3708 passed, `test:socket` 624 passed, `test:render` 268 passed; lint + typecheck clean.

## Open question for the owner (not done here)

Existing 0644 files and 0755 directories **do not change** by shipping this — only newly written ones do. A startup pass that tightens what is already on disk would fix real machines, but that is a behavior change touching files the user owns, so I have not written it. Happy to, on your call.

## Deliberately out of scope

Web-transport authentication and `.rove/init.sh` execution came up in the same audit. Both are product decisions with a much larger blast radius; the reporter is raising them separately.
