### PR TITLE
fix: parallel add counts a deferred sibling as a success, not a failure

### DIFF
--- a/.changeset/parallel-add-deferred-delivery.md
+++ b/.changeset/parallel-add-deferred-delivery.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix `add --count`/`--agents` reporting a deferred sibling as a delivery failure. A parallel round only accepted `delivered === true` as success, so a sibling whose prompt was accepted-but-deferred (issue #78 B-layer: the composer was briefly busy, the daemon took ownership of the message and queued an inbox episode) landed in the failure list, tripped `PARTIAL_FANOUT`, and exited non-zero — even though the single-task `add` and `send` paths both treat a deferred delivery as a success the caller must NOT retry. The round now routes a deferred sibling to the success rows with its `deferred` marker, so a scripted fan-out no longer sees a phantom failure and can't double-deliver the same message.

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -252,7 +252,12 @@ async function addParallel(
   const failures: unknown[] = []
   settled.forEach((r, i) => {
     const { taskId, vendor } = created[i]
-    if (r.status === "fulfilled" && r.value.delivered) {
+    if (r.status === "fulfilled" && (r.value.delivered || r.value.deferred)) {
+      // Deferred (issue #78 B-layer) is a SUCCESS, exactly as `addOne`/`send`
+      // treat it: the daemon took ownership of the prompt and queued an inbox
+      // episode, so the caller must NOT retry (a retry stacks a duplicate). It
+      // resolves with `delivered:false`, so route it here — not to `failures` —
+      // and carry the marker through so a script can see it was queued.
       tasks.push({
         ok: true,
         taskId,
@@ -260,12 +265,14 @@ async function addParallel(
         started: r.value.started,
         engineReady: r.value.engineReady,
         session: r.value.session,
+        ...(r.value.deferred ? { deferred: r.value.deferred } : {}),
       })
       return
     }
-    // Either deliverPrompt threw, or it resolved but the paste never landed.
-    // The task IS created (engine already burning tokens) — always carry its
-    // taskId so a script can find/retry it instead of orphaning it.
+    // Either deliverPrompt threw, or it resolved un-delivered AND un-deferred
+    // (the paste never landed). The task IS created (engine already burning
+    // tokens) — always carry its taskId so a script can find/retry it instead
+    // of orphaning it.
     const err =
       r.status === "rejected"
         ? r.reason

--- a/packages/kobe/test/cli/api-add-parallel.test.ts
+++ b/packages/kobe/test/cli/api-add-parallel.test.ts
@@ -213,4 +213,33 @@ describe("add --count (parallel round)", () => {
       })
     }
   })
+
+  it("counts a deferred sibling as a success, not a delivery failure", async () => {
+    // A sibling whose composer is briefly busy resolves accepted-but-deferred
+    // (issue #78 B-layer): `delivered:false` but `deferred` present. The daemon
+    // owns the message and queued an inbox episode — the caller must NOT retry.
+    // It must land in `tasks` (with the marker), never in `failures`, so the
+    // round does not throw PARTIAL_FANOUT and a script does not double-deliver.
+    const deliver: ApiRuntime["deliverPrompt"] = async (_client, target) => ({
+      session: `${target.id}::tab-1`,
+      pane: `${target.id}::tab-1`,
+      started: true,
+      engineReady: true,
+      delivered: target.id !== "t2",
+      ...(target.id === "t2" ? { deferred: { id: "d1", layer: "composer-not-empty" as const } } : {}),
+    })
+    const result = (await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "go", "--count", "3"], {
+      client: fanClient(),
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })) as {
+      count: number
+      tasks: Array<{ taskId: string; deferred?: { id: string; layer: string } }>
+      failures: unknown[]
+    }
+    expect(result.count).toBe(3)
+    expect(result.failures).toEqual([])
+    expect(result.tasks.map((t) => t.taskId)).toEqual(["t1", "t2", "t3"])
+    const deferredRow = result.tasks.find((t) => t.taskId === "t2")
+    expect(deferredRow?.deferred).toEqual({ id: "d1", layer: "composer-not-empty" })
+  })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — found by direct code review of the `rove api` create path (the daemon-owned issue store isn't reachable from this checkout, so this is a self-found bug, not a tracked issue).

## Problem

A parallel `add` round (`add --count N` / `add --agents e:2,f:1`) classifies each sibling's prompt delivery in `addParallel` (`packages/kobe/src/cli/api/handlers-add.ts`). The success gate only accepted `r.value.delivered === true`:

```ts
if (r.status === "fulfilled" && r.value.delivered) { …success… }
// else → failures
```

But `deliverPrompt` has a third, documented outcome: **accepted-but-deferred** (`delivered: false`, `deferred: { id, layer }` — issue #78 B-layer). When a sibling's composer is briefly busy (`recent-human-write` / `composer-not-empty`), the daemon takes ownership of the message and queues a `prompt_deferred` inbox episode. The `DeliveredPrompt` type spells out that this is a **success the caller MUST NOT retry** — a retry stacks a duplicate in the deferred queue.

Both other delivery paths already honor that contract:
- single-task `addOne` (same file): `if (!delivered.delivered && !delivered.deferred) throw …`
- `send` (`handlers-tasks.ts`): identical guard, with a comment saying deferred is a success and must not be retried.

The parallel path did not. A deferred sibling (`delivered: false`) fell through to `failures`, tripping `throw new ApiError('add delivered N/M', 'PARTIAL_FANOUT', …)` → the CLI exits non-zero. A scripted fan-out then reads the sibling as failed and may retry, double-delivering the exact message the daemon already queued.

## Fix

Accept `r.value.delivered || r.value.deferred` as success and carry the `deferred` marker onto the success row, mirroring `addOne`/`send`. One function, one file (plus its test). The failure branch's comment is tightened to say "un-delivered AND un-deferred".

## Verification

- Added a regression test in `test/cli/api-add-parallel.test.ts`: a 3-sibling round where one sibling defers must not throw, must count all three, must place the deferred sibling in `tasks` (with its marker), and leave `failures` empty. Confirmed it **fails** on the old code and **passes** with the fix.
- `bun run lint` — clean.
- `bun run typecheck` — clean.
- `bun x vitest run test/cli/` — 725/725 passing.
- Changeset added (`patch`, `@sma1lboy/rove`).

## Follow-ups (deferred, not in this PR)

Two weaker observations surfaced during review, left alone as out of this slice:
- `codex-local/history.ts` `findLatestRolloutForWorktree` counts its `MAX_MTIME_SCAN` cap over *all* rollouts before the cwd filter, so with many parallel Codex tasks in one sessions tree a given task's older-filename-but-active rollout can fall outside the window. It's documented as an intentional cost cap, so it needs an owner call rather than a drive-by change.
- `session-launch.ts` `markerDirOf` returns `"."` for a root-level `/marker` path (`index === 0`); unreachable in practice since marker paths always live under `~/.rove/…`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016pw8gtVgncy3GE3rgWcg1f)_