### PR TITLE
docs: retire the archive verb and correct engine resume/sort docs

### DIFF
--- a/.changeset/docs-archive-engine-identity-audit.md
+++ b/.changeset/docs-archive-engine-identity-audit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Docs audit: remove the retired archive verb from SESSIONS, TROUBLESHOOTING, WORKTREES, ARCHITECTURE, and HARNESS (delete — with the 0.9.23 salvage snapshot — is the real teardown); correct the engine resume story now that Codex and Kimi reopen their last conversation via their own resume verbs; document the `activeSortMode` sort toggle and the `externalWorktreeSync` cleanup marker in Configuration.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ The standalone host periodically freezes bounded terminal rings plus launch
 metadata. After a host restart or reboot, it restores dead session records;
 the first attachment replays the last snapshot and respawns the recorded
 command. This recovery is distinct from a still-live child surviving a TUI or
-daemon restart. Explicit close/archive/reset operations remove their frozen
+daemon restart. Explicit close/delete/reset operations remove their frozen
 records.
 
 Tmux is not a session backend. The CLI retains one quarantined compatibility

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,10 +46,13 @@ other.
 ## Settings reference
 
 Keys not listed here are internal UI state (saved repos, tab layouts) that
-happen to share the file. Two exceptions worth knowing: `repoConfigs` is what
+happen to share the file. Three exceptions worth knowing: `repoConfigs` is what
 `rove repo set` writes (a map of git toplevel → `{initScript, initPrompt}`,
-see [Per-repo init](#per-repo-init)), and `lastSelectedVendor` is the legacy
-engine fallback below `defaultVendor`.
+see [Per-repo init](#per-repo-init)); `lastSelectedVendor` is the legacy
+engine fallback below `defaultVendor`; and `externalWorktreeSync` is not a
+setting you configure but a cleanup marker Rove writes — it records where the
+retired worktree-sync hook was once installed so the next launch (or
+`rove hook cleanup`) can remove it, flipping to `"off"` once cleaned.
 
 ### Appearance
 
@@ -166,9 +169,11 @@ discoverable. No restart needed.
 ### Sidebar
 
 The current tree sidebar follows persisted project/task order and supports
-manual project reordering with `shift+m`. Older state files may contain
-`activeSortMode` and `tasksPane.projectFilter`; the daemon still mirrors those
-compatibility values, but the current PureTUI tree does not consume them.
+manual project reordering with `shift+m`. The `t` key switches the task sort
+between that persisted order and most-recently-touched; the choice is saved
+as `activeSortMode` and read back on startup. Older state files may contain
+`tasksPane.projectFilter`; the daemon still mirrors that compatibility value
+for background consumers, but the current PureTUI tree does not consume it.
 
 ### Experimental
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -121,11 +121,16 @@ Mechanics: [design/engine-internals.md](./design/engine-internals.md).
 
 ## Resuming and forking
 
-**Resume.** A Claude tab whose process is gone (reboot, unarchive) relaunches
-into the same conversation instead of a blank one. A tab that never sent a
-first message isn't resumed; there's no transcript yet. Codex, Copilot,
-Kimi, and custom engines can't take a caller-set session id, so their tabs
-relaunch fresh.
+**Resume.** Whether a restarted tab comes back into its old conversation
+depends on the engine. Claude Code accepts a caller-set session id, so Rove
+pins one at launch and a tab whose process is gone (a reboot, say) relaunches
+into the same conversation instead of a blank one. Codex and Kimi mint their
+own ids — Codex announces its in the terminal title, Kimi's is discovered
+from its session store after the fact — and each reopens the last
+conversation with its own resume verb (`codex resume <id>`, `kimi -S <id>`).
+Copilot and custom engines have no resume verb Rove knows, so their tabs
+relaunch fresh. A tab that never sent a first message isn't resumed; there's
+no transcript yet.
 
 **Continue in a new tab.** `ctrl+a` `c` opens the continuation flow in the
 *same* worktree. What happens depends on the source and destination engines:

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -72,7 +72,8 @@ The suite currently pins:
 - PureTUI terminal title publication when native PTY support is available;
 - headless `rove api add --prompt` auto-starting `<taskId>::tab-1`;
 - `send` reusing that exact hosted session;
-- archive stopping the hosted session without deleting the Worktree.
+- delete stopping the hosted session and removing the worktree (the branch
+  survives).
 
 Behavior tests run in CI and the release workflow. They require a build first:
 

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -2,7 +2,7 @@
 
 Short answer: **quitting Rove only detaches.** A PTY-host restart or machine
 reboot ends the child processes, but restores their screens and relaunches
-their commands on attach. Closing a tab, archiving a managed/directory Task,
+their commands on attach. Closing a tab, deleting a managed/directory Task,
 resetting a terminal, or running `rove reset` is an intentional teardown
 instead.
 
@@ -15,7 +15,7 @@ instead.
 | `rove daemon restart` | ✓ | ✓ | ✓ | ✓ |
 | Reboot, or the PTY host dies | — command relaunched on attach | ✓ restored | ✓ | ✓ |
 | Close a tab | — that tab only | — that tab's ring is dropped | ✓ | ✓ |
-| Archive a managed/directory Task | — all of that Task's tabs | — those rings are dropped | ✓ | ✓ |
+| Delete a managed/directory Task | — all of that Task's tabs | — those rings are dropped | task record removed; worktree removed unless it's a directory Task (branch stays; a force-delete salvages uncommitted work under `refs/rove/salvage/`) | ✓ |
 | Stop `rove web` | browser-owned PTYs end; standalone-host PTYs stay | browser sidecar has no freeze/thaw | ✓ | engine-owned files stay |
 | Press F5 | — active terminal is replaced | — old ring is dropped | ✓ | ✓ |
 | `rove reset` | — all hosted sessions | — all frozen rings are dropped | worktrees ✓; task index kept unless `--hard` | ✓ |
@@ -87,7 +87,7 @@ flowchart TB
   per few seconds while streaming, immediately on exit, and in full at
   shutdown. A host that comes back up (after a crash, a reboot, an idle-exit)
   thaws each record into a dead *restored* session: reattaching replays the
-  old screen and respawns the command in place. Closing a tab, archiving a
+  old screen and respawns the command in place. Closing a tab, deleting a
   task, or `rove reset` deletes the record instead. An intentional end is
   never resurrected.
 
@@ -159,7 +159,7 @@ Three related limits are easy to confuse:
   while output streams, immediately when the child exits, and in full during
   a clean host shutdown. A crash can therefore lose the newest few seconds,
   but a reboot or host restart restores the last completed snapshot. Closing
-  the tab, archiving its task, or `rove reset` deliberately drops the relevant
+  the tab, deleting its task, or `rove reset` deliberately drops the relevant
   frozen record.
 - **What diagnostics retain after a death.** `<home>/.rove/pty-exits.json`
   stores the newest 50 records. Each has the exit code or signal, time, and
@@ -191,8 +191,11 @@ process, including a reboot.
 
 - Claude tabs pin their conversation up front, so a tab that already ran
   comes back into the same conversation after a reboot rather than a blank
-  one. Engines that can't take a caller-set session id (Codex and the rest)
-  relaunch fresh.
+  one. Codex and Kimi mint their own ids instead — Codex announces its in the
+  terminal title, Kimi's is discovered from its session store — and Rove
+  reopens the last conversation with the engine's own resume verb. Copilot
+  and custom engines have no resume verb Rove knows, so their tabs relaunch
+  fresh.
 - A resumable engine tab found dead on attach gets **one** automatic resume
   attempt. If that dies too, an extra tab closes; the task's only tab recycles
   into a fresh engine tab rather than respawning forever.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -158,7 +158,7 @@ under `~/.rove/` (or the selected Rove home):
 - `pty-sessions/` freezes each hosted session's launch metadata and bounded
   scrollback ring so a PTY-host crash, restart, or machine reboot can restore
   the old screen and respawn the launch command. An explicit tab close or task
-  archive drops that session's frozen record; a reset asks the running host to
+  delete drops that session's frozen record; a reset asks the running host to
   start fresh.
 
 These files can contain text that was visible in the embedded terminal. Treat
@@ -423,7 +423,7 @@ setting, not a Rove one.
 fallback below.
 
 **Fallback that works everywhere:** every row-menu entry is also a direct
-chord on the row itself (`r` rename, `a` archive, `d` delete, and so on); see
+chord on the row itself (`r` rename, `d` delete, and so on); see
 [KEYBINDINGS.md](./KEYBINDINGS.md). The one right-click-only surface today
 is the project header's menu.
 

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -94,7 +94,7 @@ A successful land removes the worktree — it is spent once its branch is in —
 and the row leaves the page. The **branch survives**: git keeps the durable
 record. If removal is refused (the worktree is dirty, it is the base
 checkout, or it is the directory Rove itself is running from), the land still
-stands and the page reports why the worktree is still there. Archiving the
+stands and the page reports why the worktree is still there. Deleting the
 task and deleting the source branch remain separate lifecycle decisions;
 from the CLI, `rove api land --remove-worktree=false` keeps the worktree.
 


### PR DESCRIPTION
## What

Four-item docs audit against origin/main, all text changes:

**1. Archive remnants.** The audit found 3; there were 6 more in the same class — every user-facing mention of archive-as-current-behavior is now gone:
- `docs/SESSIONS.md`: the survival-matrix row described an impossible operation. Replaced with a **Delete** row that also reflects PR #657's salvage snapshot (force-delete snapshots uncommitted work under `refs/rove/salvage/`), plus three prose spots that said "archiving a task".
- `docs/TROUBLESHOOTING.md`: frozen-record wording + the row-chord list (`a` archive removed).
- `docs/WORKTREES.md`, `docs/ARCHITECTURE.md`, `docs/HARNESS.md`: one line each. HARNESS.md claimed the behavior suite pins archive; it pins delete teardown (`pty-api-autostart.test.ts`).
- Untouched per the brief: the two SKILL.md references (gap explanation + retired-verb mapping table) and all `docs/design/*` + PLAN/spec history.

**2. Engine resume (`docs/ENGINES.md`, `docs/SESSIONS.md`).** Both pages claimed Codex/Copilot/Kimi/custom "can't take a caller-set session id, so their tabs relaunch fresh" — the pre-#636 world. Rewritten around the behavioral question (does my conversation come back after a restart?): Claude pins an id at launch; Codex and Kimi mint their own (title / session-store discovery) and reopen the last conversation via their own resume verb (`codex resume <id>`, `kimi -S <id>`); Copilot and custom have no resume verb and relaunch fresh.

**3. `docs/CONFIGURATION.md`.** Split the sentence: `activeSortMode` is live since #617 (the `t` sidebar key toggles default↔recent, persisted and read at startup — matches KEYBINDINGS.md); `tasksPane.projectFilter` stays mirrored-only.

**4. `externalWorktreeSync`.** Documented as a third "exception worth knowing" in the Settings reference intro — deliberately not in a value table, because it isn't a user setting: it's a cleanup marker recording where the retired WorktreeCreate hook was written, flipped to `"off"` once cleaned (`hook-cmd.ts` `SYNC_SETTING_KEY`).

## Verification
- lint, typecheck, changeset:check green; vitest fast suite 381 files / 3716 tests pass (`env -u ROVE_INVOKED_AS`).
- All touched user-facing pages are already in `sync-docs.mjs` SECTIONS — no site changes needed.

## Out of scope (per brief)
The "jump digit glyph not rendering but documented in TUI.md" finding needs an owner design decision — not touched.