### PR TITLE
fix: validate plugin settings keys and mask secrets

### DIFF
--- a/.changeset/plugin-settings-key-validation.md
+++ b/.changeset/plugin-settings-key-validation.md
@@ -1,0 +1,32 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Plugin settings can no longer smuggle environment variables into the plugin process
+
+A `[[settings]]` row is an env var: the manifest declares the key, Settings →
+Plugins renders it as an ordinary editable row, and the value lands as
+`KEY=value` in the config `.env` that plugin commands source. The key was
+only checked for being non-empty, so a manifest could declare
+`key = "PATH"` with `label = "Search path"` and get a row the user would
+happily edit — likewise `LD_PRELOAD`, `NODE_OPTIONS`, or `GIT_SSH_COMMAND`.
+A value containing a newline could also forge a second `KEY=` line.
+
+Manifests now fail to parse unless every settings key is a plain env var
+name, and a small set of names that steer how a process runs — rather than
+being data the plugin reads — is refused outright. Values are held to one
+line. Asking the user for an API key is unaffected; that is what
+`[[settings]]` is for.
+
+New `type = "secret"`: stores like a string but is masked wherever it is
+shown, so a pasted key is not on screen during a screen share, screenshot,
+or recording.
+
+The plugin registry and each plugin's `log.jsonl` are now written owner-only
+(0600), with plugin config and state directories at 0700 — the log captures
+the plugin's stdout and stderr, so a plugin that prints its own token on
+failure was recording it to a world-readable file that `rove plugin log`
+displays. That log is also size-capped and rotated now, like `daemon.log`; a
+plugin subscribed to `tool.pre`/`tool.post` previously appended a record per
+tool call with nothing ever truncating it. Existing files keep their current
+permissions — only newly written ones are affected.

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -149,11 +149,19 @@ placement = "split"              # split (default: joins the focused chattab's
 command = ["node", "$ROVE_PLUGIN_ROOT/board.js"]   # cwd = the TASK WORKTREE
 
 [[settings]]                     # rendered as an editor in Settings → Plugins
-key = "YOU_EXAMPLE_MODE"         # stored as KEY=value in your config .env
+key = "YOU_EXAMPLE_MODE"         # stored as KEY=value in your config .env;
+                                 # must be a plain env var name, and may not
+                                 # be one that steers how a process runs
+                                 # (PATH, LD_PRELOAD, NODE_OPTIONS, …)
 label = "Mode"
-type = "enum"                    # string | number | boolean | enum
+type = "enum"                    # string | number | boolean | enum | secret
 options = ["fast", "fancy"]
 default = "fast"
+
+[[settings]]                     # `secret` masks the value everywhere it is
+key = "YOU_EXAMPLE_TOKEN"        # shown, for keys the user pastes in
+label = "API token"
+type = "secret"
 
 [[file_handlers]]                # claim Files-pane opens by filename pattern
 pattern = "\\.(png|jpg)$"        # JS regex, case-insensitive, vs the file name
@@ -277,6 +285,16 @@ Never write durable state under `ROVE_PLUGIN_ROOT`. GitHub installs are
 managed checkouts replaced on reinstall. Settings you declare in
 `[[settings]]` arrive as plain vars in your config `.env`; source it
 (`. "$ROVE_PLUGIN_CONFIG_DIR/.env"`) or read it yourself.
+
+Because that file is sourced, a settings `key` must be a plain env var name
+(`^[A-Za-z_][A-Za-z0-9_]*$`), and a small set of names is refused outright:
+those that change how a process runs rather than what it reads — `PATH`,
+`HOME`, `SHELL`, the `LD_*`/`DYLD_*` loader vars, `NODE_OPTIONS` and its
+per-language siblings, `BASH_ENV`, `GIT_SSH_COMMAND`, `EDITOR`/`PAGER`.
+A rejected key fails the whole manifest at parse time, so fix it before
+publishing. Asking for an API key is fine and expected — use `type =
+"secret"` so the value is masked in Settings. Your config `.env`, state
+directory, and `log.jsonl` are all owner-only (0600/0700).
 
 ## Calling back into Rove
 

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -13,6 +13,7 @@ import { existsSync, readFileSync } from "node:fs"
 import { basename, join } from "node:path"
 import { PLUGIN_EVENT_NAMES, type PluginEventName } from "@sma1lboy/rove-plugin-sdk/contract"
 import { parse as parseToml } from "smol-toml"
+import { settingKeyRejection } from "./setting-keys.ts"
 
 export type PluginPlatform = "macos" | "linux" | "windows"
 
@@ -47,7 +48,10 @@ export interface PluginSetting {
   /** Env var name written to the config .env (conventionally ROVE_<PLUGIN>_*). */
   readonly key: string
   readonly label: string
-  readonly type: "string" | "number" | "boolean" | "enum"
+  /** `secret` is a string whose value is masked wherever it is displayed —
+   *  the row shows `••••` instead of the API key the user pasted. Storage is
+   *  unchanged; only rendering differs. */
+  readonly type: "string" | "number" | "boolean" | "enum" | "secret"
   /** Enum choices (required for type = "enum"). */
   readonly options?: readonly string[]
   /** Default shown when the .env has no value; storage is always a string. */
@@ -328,8 +332,8 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
 
   const settings = asTableArray(raw.settings, "settings").map((t, i) => {
     const type = asString(t.type, `settings[${i}].type`)
-    if (type !== "string" && type !== "number" && type !== "boolean" && type !== "enum") {
-      fail(`settings[${i}].type must be string | number | boolean | enum`)
+    if (type !== "string" && type !== "number" && type !== "boolean" && type !== "enum" && type !== "secret") {
+      fail(`settings[${i}].type must be string | number | boolean | enum | secret`)
     }
     const options =
       t.options === undefined
@@ -338,10 +342,13 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
           ? (t.options as string[])
           : fail(`settings[${i}].options must be an array of strings`)
     if (type === "enum" && (!options || options.length === 0)) fail(`settings[${i}] enum needs \`options\``)
+    const key = asString(t.key, `settings[${i}].key`)
+    const rejection = settingKeyRejection(key)
+    if (rejection) fail(`settings[${i}].key ${rejection}`)
     return {
-      key: asString(t.key, `settings[${i}].key`),
+      key,
       label: asString(t.label, `settings[${i}].label`),
-      type: type as "string" | "number" | "boolean" | "enum",
+      type: type as PluginSetting["type"],
       ...(options ? { options } : {}),
       ...(t.default === undefined ? {} : { default: asString(t.default, `settings[${i}].default`) }),
     }

--- a/packages/kobe-daemon/src/plugins/registry.ts
+++ b/packages/kobe-daemon/src/plugins/registry.ts
@@ -64,7 +64,8 @@ function isEntry(v: unknown): v is PluginRegistryEntry {
 export function savePluginRegistry(registry: PluginRegistry, homeDir?: string): void {
   const path = pluginRegistryPath(homeDir)
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`)
+  // 0600: the registry names every installed plugin and its checkout path.
+  writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 })
 }
 
 /** Insert or replace the entry with the same id. */

--- a/packages/kobe-daemon/src/plugins/runtime.ts
+++ b/packages/kobe-daemon/src/plugins/runtime.ts
@@ -16,6 +16,7 @@
 import { spawn } from "node:child_process"
 import { appendFileSync, mkdirSync, statSync } from "node:fs"
 import type { ChannelEvent } from "../daemon/event-bus.ts"
+import { rotateLogIfNeeded } from "../daemon/log-rotate.ts"
 import { buildPluginEnv } from "./env.ts"
 import { type PluginEvent, PluginEventReducer, lifecycleEventFor } from "./events.ts"
 import {
@@ -43,6 +44,12 @@ interface LoadedPlugin {
 }
 
 const OUTPUT_CAP = 8 * 1024
+
+/** Cap for a single plugin's log.jsonl. Smaller than daemon.log's 10MB
+ *  because this is per plugin and every enabled one keeps its own: a plugin
+ *  hooked to `tool.pre`/`tool.post` appends a record per tool call, forever,
+ *  and before this there was no cap at all. One `.old` generation is kept. */
+const PLUGIN_LOG_CAP_BYTES = 4 * 1024 * 1024
 const RELOAD_DEBOUNCE_MS = 150
 /** Registry stat-poll cadence; reload latency is this + the debounce. */
 const REGISTRY_POLL_MS = 200
@@ -309,8 +316,10 @@ export class PluginHost {
   ): Promise<void> {
     const id = plugin.manifest.id
     const startedAt = Date.now()
-    mkdirSync(pluginConfigDir(id, this.opts.homeDir), { recursive: true })
-    mkdirSync(pluginStateDir(id, this.opts.homeDir), { recursive: true })
+    // 0700: config holds the settings .env (documented home for API keys) and
+    // state is plugin-owned durable data; neither is anyone else's business.
+    mkdirSync(pluginConfigDir(id, this.opts.homeDir), { recursive: true, mode: 0o700 })
+    mkdirSync(pluginStateDir(id, this.opts.homeDir), { recursive: true, mode: 0o700 })
     let exitCode: number | null = null
     let stdout = ""
     let stderr = ""
@@ -361,7 +370,12 @@ export class PluginHost {
       ...(spawnError ? { spawnError } : {}),
     }
     try {
-      appendFileSync(pluginLogPath(id, this.opts.homeDir), `${JSON.stringify(record)}\n`)
+      const logPath = pluginLogPath(id, this.opts.homeDir)
+      // The record carries the plugin's captured stdout/stderr, so a plugin
+      // that prints its own token on failure writes it here — 0600, and
+      // capped like daemon.log so a per-tool-call hook can't fill the disk.
+      rotateLogIfNeeded(logPath, PLUGIN_LOG_CAP_BYTES)
+      appendFileSync(logPath, `${JSON.stringify(record)}\n`, { mode: 0o600 })
     } catch {
       // Log write failure must never take the daemon down.
     }

--- a/packages/kobe-daemon/src/plugins/setting-keys.ts
+++ b/packages/kobe-daemon/src/plugins/setting-keys.ts
@@ -1,0 +1,75 @@
+/**
+ * Which env var names a `[[settings]]` row may claim.
+ *
+ * A settings key becomes a bare `KEY=value` line in the plugin's config
+ * `.env`, and that file is what plugin commands source
+ * (`. "$ROVE_PLUGIN_CONFIG_DIR/.env"`). So the key is not a label — it is a
+ * variable that lands in the plugin process's environment, with a value the
+ * user typed into a row the plugin told them to edit.
+ *
+ * That makes this a manifest-validation concern rather than a store concern:
+ * reject the declaration at parse time, so a bad key never reaches Settings
+ * as an editable row in the first place.
+ */
+
+/** Must be a real env var name and nothing else — anything outside this
+ *  shape could smuggle a second assignment, a comment, or shell syntax into
+ *  the `.env`. */
+export const SETTING_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/**
+ * Names a settings row may not claim. Every one of these matches
+ * SETTING_KEY_RE, so the shape check alone would let them through.
+ *
+ * The line is mechanism, not sensitivity: each name here changes HOW the
+ * plugin's process runs — which binary resolves, which library loads, which
+ * interpreter flags apply, which subprocess a tool shells out to — rather
+ * than being data the plugin reads. A plugin can still export any of them
+ * inside its own script; what it may not do is route one through a row the
+ * user is invited to edit, where `label = "Search path"` on `key = "PATH"`
+ * reads as an ordinary preference.
+ *
+ * Deliberately absent: API-key-shaped names. A plugin asking the user to
+ * paste a token is the feature, not the attack.
+ */
+export const RESERVED_SETTING_KEYS = [
+  // resolution + identity
+  "PATH",
+  "HOME",
+  "SHELL",
+  "IFS",
+  // dynamic loader
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "LD_AUDIT",
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "DYLD_FRAMEWORK_PATH",
+  // interpreter flags / auto-sourced startup files
+  "NODE_OPTIONS",
+  "BUN_INSPECT",
+  "PYTHONPATH",
+  "PYTHONSTARTUP",
+  "PERL5OPT",
+  "PERL5LIB",
+  "RUBYOPT",
+  "BASH_ENV",
+  "ENV",
+  // "run this command for me" hooks
+  "GIT_SSH_COMMAND",
+  "GIT_SSH",
+  "GIT_EXTERNAL_DIFF",
+  "GIT_PAGER",
+  "PAGER",
+  "EDITOR",
+  "VISUAL",
+] as const
+
+/** Why `key` may not be used, or null when it is fine. */
+export function settingKeyRejection(key: string): string | null {
+  if (!SETTING_KEY_RE.test(key)) return `\`${key}\` is not a valid env var name (${SETTING_KEY_RE.source})`
+  if ((RESERVED_SETTING_KEYS as readonly string[]).includes(key)) {
+    return `\`${key}\` is reserved; it steers how the plugin's own process runs`
+  }
+  return null
+}

--- a/packages/kobe-daemon/src/plugins/settings-env.ts
+++ b/packages/kobe-daemon/src/plugins/settings-env.ts
@@ -32,6 +32,18 @@ export function readPluginSettings(pluginId: string, homeDir?: string): Record<s
 }
 
 /**
+ * A value is one `KEY=value` line, so it may not contain a line break. A
+ * newline in the middle of a value would end the assignment early and let
+ * everything after it parse as its own `KEY=` line — the user edits one
+ * innocuous-looking setting and silently defines a second variable in a file
+ * plugin commands source. Strip rather than reject: the store is called from
+ * a dialog with no error channel, and no legitimate value wants a newline.
+ */
+function oneLine(value: string): string {
+  return value.replace(/[\r\n]/g, "")
+}
+
+/**
  * Merge `values` into the .env, preserving unrelated lines/comments. An
  * empty-string value REMOVES the key (booleans store "1" or absent).
  */
@@ -49,14 +61,15 @@ export function writePluginSettings(pluginId: string, values: Record<string, str
     const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=/)
     const key = m?.[1]
     if (key && key in remaining) {
-      const value = remaining[key] as string
+      const value = oneLine(remaining[key] as string)
       delete remaining[key]
       if (value !== "") next.push(`${key}=${value}`)
       continue // empty → drop the line
     }
     next.push(line)
   }
-  for (const [key, value] of Object.entries(remaining)) {
+  for (const [key, raw] of Object.entries(remaining)) {
+    const value = oneLine(raw)
     if (value !== "") next.push(`${key}=${value}`)
   }
   while (next.length > 0 && next[next.length - 1] === "") next.pop()

--- a/packages/kobe-plugin-sdk/examples/settings-demo/action.ts
+++ b/packages/kobe-plugin-sdk/examples/settings-demo/action.ts
@@ -13,6 +13,7 @@ const name = setting(ctx.configDir, "EX_DEMO_NAME", "Rover")
 const theme = setting(ctx.configDir, "EX_DEMO_THEME", "system")
 const notifyRaw = setting(ctx.configDir, "EX_DEMO_NOTIFY", "1")
 const notify = notifyRaw === "1" || notifyRaw.toLowerCase() === "true"
+const apiKey = setting(ctx.configDir, "EX_DEMO_API_KEY", "")
 
 console.log("settings-demo effective config:")
 console.log(`  actionId:   ${ctx.actionId ?? "<none>"}`)
@@ -20,7 +21,10 @@ console.log(`  invokeCwd:  ${ctx.invokeCwd ?? "<none>"}`)
 console.log(`  name:       ${name}`)
 console.log(`  theme:      ${theme}`)
 console.log(`  notify:     ${notify}`)
+// A `secret` is masked in Settings; print it the same way. Plugin stdout is
+// captured into log.jsonl, which `rove plugin log` then displays.
+console.log(`  apiKey:     ${apiKey ? "<set>" : "<unset>"}`)
 console.log("raw .env:")
 for (const [key, value] of Object.entries(readSettings(ctx.configDir))) {
-  console.log(`  ${key}=${value}`)
+  console.log(`  ${key}=${key === "EX_DEMO_API_KEY" ? "<redacted>" : value}`)
 }

--- a/packages/kobe-plugin-sdk/examples/settings-demo/rove-plugin.toml
+++ b/packages/kobe-plugin-sdk/examples/settings-demo/rove-plugin.toml
@@ -26,6 +26,13 @@ label = "Send notifications"
 type = "boolean"
 default = "1"
 
+# `secret` stores like a string but is masked wherever it is displayed, so a
+# pasted key does not sit on screen during a screen share or a recording.
+[[settings]]
+key = "EX_DEMO_API_KEY"
+label = "API key"
+type = "secret"
+
 [[actions]]
 id = "print"
 title = "Print effective settings"

--- a/packages/kobe/src/tui-react/component/settings-dialog/plugin-settings-core.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/plugin-settings-core.ts
@@ -46,6 +46,21 @@ export function pluginSettingRows(
 }
 
 /**
+ * What a row shows in place of its value. A `secret` holds an API key the
+ * user pasted, and the settings dialog is on screen during screen shares,
+ * screenshots, and recordings — so the stored value never reaches the
+ * renderer. Length is hidden too (a fixed run of dots, not one per
+ * character), since the length of a token is itself a hint.
+ *
+ * A secret that is unset must stay visibly unset: masking "" into dots would
+ * claim a key is configured when none is.
+ */
+export function displaySettingValue(row: Pick<PluginSettingRowView, "type" | "value">): string {
+  if (row.type !== "secret" || row.value === "") return row.value
+  return "••••••••"
+}
+
+/**
  * A boolean is on unless it's absent or an explicit falsy token. Shells
  * source these files, so "0"/"false" are the spellings a plugin author
  * would write by hand.

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-plugins.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-plugins.tsx
@@ -11,7 +11,7 @@ import { TextAttributes } from "@opentui/core"
 import { relativeAgeMs } from "../../../tui/history/message-core"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
-import { type PluginSettingRowView, isBooleanOn } from "./plugin-settings-core"
+import { type PluginSettingRowView, displaySettingValue, isBooleanOn } from "./plugin-settings-core"
 import type { PluginRowView } from "./plugins-core"
 import type { SectionCursorProps } from "./rows"
 
@@ -44,7 +44,7 @@ function SettingRow(props: { setting: PluginSettingRowView; cursor: boolean; onA
       ? isBooleanOn(setting.value)
         ? t("settings.general.on")
         : t("settings.general.off")
-      : setting.value || t("settings.plugins.settingUnset")
+      : displaySettingValue(setting) || t("settings.plugins.settingUnset")
   return (
     <box
       flexDirection="row"

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-section-data.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-section-data.ts
@@ -98,13 +98,18 @@ export function usePluginSettings(section: SectionId, dialog: DialogContext): Pl
         store(pluginId, key, toggledBooleanValue(setting))
         return
       }
-      const next = await RenameTaskDialog.show(dialog, setting.value, {
+      // A secret opens EMPTY rather than pre-filled: the dialog would
+      // otherwise print the stored key in full, which is exactly what the
+      // masked row exists to prevent. Cancelling still leaves it stored;
+      // submitting empty clears it, like any other string row.
+      const initial = setting.type === "secret" ? "" : setting.value
+      const next = await RenameTaskDialog.show(dialog, initial, {
         // The label is plugin-owned copy, like an action title — shown raw.
         dialogTitle: setting.label,
         fieldLabel: key,
         submitLabel: "save",
         allowEmpty: true,
-        placeholder: setting.defaultValue,
+        placeholder: setting.type === "secret" && setting.value !== "" ? "••••••••" : setting.defaultValue,
       })
       if (next === undefined) return
       if (setting.type !== "number") {

--- a/packages/kobe/test/plugins/plugin-file-modes.test.ts
+++ b/packages/kobe/test/plugins/plugin-file-modes.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Everything the plugin subsystem persists is either a credential the docs
+ * told the user to paste there, or output a plugin printed — and the plugin
+ * log is both, because `run()` captures the child's stdout AND stderr into
+ * the record. A plugin that prints its own token on failure writes it to a
+ * file `rove plugin log` then displays; world-readable is the wrong default
+ * for all of it.
+ *
+ * Modes are asserted with `statSync` on the REAL file, not the arguments a
+ * write was called with — a dropped option or umask interaction has to fail
+ * here. Same shape as `test/daemon/secret-file-modes.test.ts`.
+ */
+
+import { appendFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  pluginConfigDir,
+  pluginLogPath,
+  pluginRegistryPath,
+  pluginStateDir,
+} from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
+import { savePluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
+import { PluginHost } from "@sma1lboy/kobe-daemon/plugins/runtime"
+import { afterEach, describe, expect, it } from "vitest"
+
+const dirs: string[] = []
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+/** Permission bits only — `statSync().mode` carries the file type too. */
+function mode(path: string): number {
+  return statSync(path).mode & 0o777
+}
+
+async function waitFor(predicate: () => boolean, ms = 5_000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > ms) throw new Error("timed out")
+    await new Promise((r) => setTimeout(r, 25))
+  }
+}
+
+/** A plugin whose startup hook prints a secret — the realistic leak: the
+ *  plugin is not malicious, it just logs what it got when something fails. */
+const LEAKY = `
+id = "example.leaky"
+name = "Leaky"
+version = "0.1.0"
+min_rove_version = "0.1.0"
+
+[[startup]]
+command = ["sh", "-c", "echo sk-live-abc123 >&2; exit 1"]
+`
+
+function installPlugin(home: string, root: string, manifest: string, id: string): void {
+  writeFileSync(join(root, "rove-plugin.toml"), manifest)
+  mkdirSync(join(home, ".kobe"), { recursive: true })
+  savePluginRegistry(
+    { plugins: [{ id, source: { kind: "link" }, root, enabled: true, version: "0.1.0", installedAt: 1 }] },
+    home,
+  )
+}
+
+describe("plugin subsystem files are owner-only", () => {
+  it("writes plugins.json as 0600", () => {
+    const home = tmp("kobe-pmode-reg-")
+    mkdirSync(join(home, ".kobe"), { recursive: true })
+    savePluginRegistry({ plugins: [] }, home)
+    expect(mode(pluginRegistryPath(home))).toBe(0o600)
+  })
+
+  it("writes the captured-output log as 0600 in 0700 config/state dirs", async () => {
+    const home = tmp("kobe-pmode-log-")
+    const root = tmp("kobe-pmode-root-")
+    installPlugin(home, root, LEAKY, "example.leaky")
+    const host = new PluginHost({ homeDir: home, socketPath: "/tmp/fake.sock", binPath: "kobe-test-bin" })
+    const logPath = pluginLogPath("example.leaky", home)
+    host.start()
+    try {
+      await waitFor(() => {
+        try {
+          return readFileSync(logPath, "utf8").includes("sk-live-abc123")
+        } catch {
+          return false
+        }
+      })
+      // The secret really is in there — that is why the mode matters.
+      expect(readFileSync(logPath, "utf8")).toContain("sk-live-abc123")
+      expect(mode(logPath)).toBe(0o600)
+      expect(mode(pluginConfigDir("example.leaky", home))).toBe(0o700)
+      expect(mode(pluginStateDir("example.leaky", home))).toBe(0o700)
+    } finally {
+      await host.stop()
+    }
+  })
+})
+
+describe("the plugin log is size-capped", () => {
+  it("rotates an oversized log to .old instead of growing forever", async () => {
+    const home = tmp("kobe-pmode-rot-")
+    const root = tmp("kobe-pmode-rot-root-")
+    installPlugin(home, root, LEAKY, "example.leaky")
+    const logPath = pluginLogPath("example.leaky", home)
+    mkdirSync(pluginConfigDir("example.leaky", home), { recursive: true })
+    // Past the 4MB cap: what a `tool.pre`/`tool.post` subscriber accumulates
+    // over enough sessions when nothing ever truncates.
+    appendFileSync(logPath, `${"x".repeat(5 * 1024 * 1024)}\n`)
+
+    const host = new PluginHost({ homeDir: home, socketPath: "/tmp/fake.sock", binPath: "kobe-test-bin" })
+    host.start()
+    try {
+      await waitFor(() => {
+        try {
+          return statSync(logPath).size < 1024 * 1024
+        } catch {
+          return false
+        }
+      })
+      // Fresh file holding only the new record; one generation preserved.
+      expect(statSync(logPath).size).toBeLessThan(1024 * 1024)
+      expect(readFileSync(logPath, "utf8")).toContain('"kind":"startup"')
+      expect(statSync(`${logPath}.old`).size).toBeGreaterThan(4 * 1024 * 1024)
+    } finally {
+      await host.stop()
+    }
+  })
+})

--- a/packages/kobe/test/plugins/setting-keys.test.ts
+++ b/packages/kobe/test/plugins/setting-keys.test.ts
@@ -1,0 +1,102 @@
+/**
+ * A `[[settings]]` row is an env var injected into the plugin's own process:
+ * the manifest declares the key, Settings → Plugins renders it as an ordinary
+ * editable row, and the value lands as `KEY=value` in the config `.env` that
+ * plugin commands source. So a manifest can hand the user a row labelled
+ * "Search path" that actually rewrites `PATH` — the label is plugin-owned
+ * copy, and nothing about the row says what the key steers.
+ *
+ * These pin both halves: which keys a manifest may declare at all, and that a
+ * value can never break out of its own line.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { parsePluginManifest } from "@sma1lboy/kobe-daemon/plugins/manifest"
+import { pluginConfigDir } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
+import { readPluginSettings, writePluginSettings } from "@sma1lboy/kobe-daemon/plugins/settings-env"
+import { afterEach, describe, expect, it } from "vitest"
+
+const dirs: string[] = []
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+const HEAD = 'id = "e.p"\nname = "P"\nversion = "1.0.0"\nmin_rove_version = "0.1.0"\n'
+
+function manifestWithSetting(body: string): string {
+  return `${HEAD}[[settings]]\n${body}\n`
+}
+
+describe("settings keys a manifest may declare", () => {
+  it("accepts a conventional plugin-namespaced key", () => {
+    const { manifest } = parsePluginManifest(
+      manifestWithSetting('key = "ROVE_EXAMPLE_MODE"\nlabel = "Mode"\ntype = "string"'),
+    )
+    expect(manifest.settings[0]?.key).toBe("ROVE_EXAMPLE_MODE")
+  })
+
+  // Each of these would otherwise become an editable row whose innocuous
+  // label hides that it redirects binary resolution, library loading, or a
+  // subprocess the plugin shells out to.
+  it.each(["PATH", "LD_PRELOAD", "DYLD_INSERT_LIBRARIES", "NODE_OPTIONS", "GIT_SSH_COMMAND", "BASH_ENV", "HOME"])(
+    "rejects the process-steering key %s",
+    (key) => {
+      expect(() =>
+        parsePluginManifest(manifestWithSetting(`key = "${key}"\nlabel = "Search path"\ntype = "string"`)),
+      ).toThrow(/reserved/)
+    },
+  )
+
+  // An API-key-shaped name is the FEATURE — a plugin asking for a token is
+  // why `[[settings]]` exists. The line is mechanism, not sensitivity.
+  it("still allows a plugin to ask for a token", () => {
+    const { manifest } = parsePluginManifest(
+      manifestWithSetting('key = "OPENAI_API_KEY"\nlabel = "API key"\ntype = "secret"'),
+    )
+    expect(manifest.settings[0]).toMatchObject({ key: "OPENAI_API_KEY", type: "secret" })
+  })
+
+  it.each([
+    ['key = "A B"', "a space"],
+    ['key = "FOO=BAR"', "an embedded assignment"],
+    ['key = "FOO\\nBAR"', "a newline"],
+    ['key = "2FA"', "a leading digit"],
+    ['key = "FOO-BAR"', "a dash"],
+    ['key = "# comment"', "shell syntax"],
+  ])("rejects %s (%s) as not an env var name", (keyLine) => {
+    expect(() => parsePluginManifest(manifestWithSetting(`${keyLine}\nlabel = "L"\ntype = "string"`))).toThrow(
+      /not a valid env var name/,
+    )
+  })
+
+  it("rejects the whole manifest rather than dropping the bad row", () => {
+    const toml = `${HEAD}[[settings]]\nkey = "GOOD_ONE"\nlabel = "Fine"\ntype = "string"\n\n[[settings]]\nkey = "PATH"\nlabel = "Search path"\ntype = "string"\n`
+    expect(() => parsePluginManifest(toml)).toThrow()
+  })
+})
+
+describe("settings values stay on one line", () => {
+  it("strips a newline that would forge a second KEY= assignment", () => {
+    const home = tmp("kobe-setkey-nl-")
+    writePluginSettings("p", { ROVE_P_MODE: "fast\nLD_PRELOAD=/tmp/evil.so" }, home)
+    const text = readFileSync(join(pluginConfigDir("p", home), ".env"), "utf8")
+    expect(text.trimEnd().split("\n")).toEqual(["ROVE_P_MODE=fastLD_PRELOAD=/tmp/evil.so"])
+    expect(readPluginSettings("p", home).LD_PRELOAD).toBeUndefined()
+  })
+
+  it("strips a carriage return too, and on the update path as well as the insert path", () => {
+    const home = tmp("kobe-setkey-cr-")
+    writePluginSettings("p", { ROVE_P_MODE: "one" }, home)
+    writePluginSettings("p", { ROVE_P_MODE: "two\r\nPATH=/tmp/bin" }, home)
+    const text = readFileSync(join(pluginConfigDir("p", home), ".env"), "utf8")
+    expect(text.trimEnd().split("\n")).toEqual(["ROVE_P_MODE=twoPATH=/tmp/bin"])
+    expect(readPluginSettings("p", home).PATH).toBeUndefined()
+  })
+})

--- a/packages/kobe/test/render/settings-plugin-secret.test.tsx
+++ b/packages/kobe/test/render/settings-plugin-secret.test.tsx
@@ -1,0 +1,215 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Settings → Plugins renders a `secret` row masked.
+ *
+ * The unit test pins `displaySettingValue` in isolation, which cannot catch
+ * the failure that actually matters here: the row rendering `setting.value`
+ * directly and never calling the masker. The stored key has to be absent from
+ * a REAL rendered frame, next to a plain `string` row that still shows its
+ * value — otherwise "masked" could just mean "this section renders nothing".
+ */
+
+import { afterEach, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { readPluginSettings } from "@sma1lboy/kobe-daemon/plugins/settings-env"
+import { RenameTaskDialog } from "../../src/tui-react/component/rename-task-dialog"
+import { SettingsDialog } from "../../src/tui-react/component/settings-dialog"
+import { displaySettingValue } from "../../src/tui-react/component/settings-dialog/plugin-settings-core"
+import { setPluginSetting } from "../../src/tui-react/component/settings-dialog/plugins-core"
+import { useKV } from "../../src/tui-react/context/kv"
+import { act, renderComponent, settle } from "./harness"
+
+const NOOP = (): void => {}
+
+// Every test here repoints KOBE_HOME_DIR at its own fixture. Left set, it
+// follows the process into every later file in the run (the render track is
+// one bun process), so restore it rather than leaking a plugin fixture into
+// suites that expect the real home.
+const REAL_HOME_DIR = process.env.KOBE_HOME_DIR
+afterEach(() => {
+  if (REAL_HOME_DIR !== undefined) {
+    process.env.KOBE_HOME_DIR = REAL_HOME_DIR
+    return
+  }
+  // Genuinely unset it. `readRoveEnv` uses `??`, so "" resolves to a RELATIVE
+  // `.rove`, and assigning undefined stores the STRING "undefined" — both are
+  // worse than the perf rule this suppresses.
+  // biome-ignore lint/performance/noDelete: restoring an unset env var
+  delete process.env.KOBE_HOME_DIR
+})
+const TOKEN = "sk-live-51H8xQ2eZvKYlo"
+
+const manifestFor = (id: string): string => `id = "${id}"
+name = "Secret Demo"
+version = "0.1.0"
+min_rove_version = "0.1.0"
+
+[[settings]]
+key = "EX_PLAIN_NAME"
+label = "Display name"
+type = "string"
+
+[[settings]]
+key = "EX_SECRET_TOKEN"
+label = "API key"
+type = "secret"
+`
+
+/** A home with the plugin registered and both settings already stored. */
+function seedHome(id: string): string {
+  const home = mkdtempSync(join(tmpdir(), "kobe-secret-row-"))
+  const root = mkdtempSync(join(tmpdir(), "kobe-secret-root-"))
+  writeFileSync(join(root, "rove-plugin.toml"), manifestFor(id))
+  mkdirSync(join(home, ".rove"), { recursive: true })
+  writeFileSync(
+    join(home, ".rove", "plugins.json"),
+    JSON.stringify({
+      plugins: [
+        {
+          id,
+          source: { kind: "link" },
+          root,
+          enabled: true,
+          version: "0.1.0",
+          installedAt: 1,
+        },
+      ],
+    }),
+  )
+  const config = join(home, ".rove", "plugins", id, "config")
+  mkdirSync(config, { recursive: true })
+  writeFileSync(join(config, ".env"), `EX_PLAIN_NAME=Rover\nEX_SECRET_TOKEN=${TOKEN}\n`)
+  return home
+}
+
+function Driver() {
+  const kv = useKV()
+  return <SettingsDialog kv={kv} onClose={NOOP} />
+}
+
+test("the secret's value never reaches the frame, while a plain row still shows its own", async () => {
+  process.env.KOBE_HOME_DIR = seedHome("example.maskrow")
+  const { frame, mockInput } = await renderComponent(<Driver />, {
+    width: 110,
+    height: 40,
+    providers: { kv: true, dialog: true },
+  })
+  // Walk UP to Plugins (general → dev → feedback → keys → plugins): stepping
+  // DOWN crosses Engines, which renders real engine accounts.
+  for (const key of ["k", "k", "k", "k"]) {
+    act(() => mockInput.pressKey(key))
+    await settle()
+  }
+  act(() => mockInput.pressKey("l"))
+  await settle()
+
+  const rendered = await frame()
+  expect(rendered).toContain("API key")
+  expect(rendered).toContain("••••")
+  // The whole point: not the token, and not any usable run of it.
+  expect(rendered).not.toContain(TOKEN)
+  for (let i = 6; i <= TOKEN.length; i++) expect(rendered).not.toContain(TOKEN.slice(0, i))
+  // Proof the section really rendered values — otherwise the absence above
+  // would be satisfied by an empty pane.
+  expect(rendered).toContain("Rover")
+})
+
+/**
+ * Answer the next `RenameTaskDialog.show` with `answer`, recording what the
+ * dialog was opened WITH — the value it pre-fills and the placeholder it
+ * shows. For a secret those are the leak: a dialog seeded with the stored key
+ * reprints in full the thing the masked row exists to hide.
+ *
+ * `settled` resolves once the stub has actually answered: `editSetting` is
+ * async, so restoring `show` before it has run would hand the prompt to the
+ * REAL dialog, which nobody is there to answer.
+ */
+function captureDialog(answer: string | undefined) {
+  const seen: { current: string; placeholder?: string }[] = []
+  let markAnswered: () => void = () => {}
+  const settled = new Promise<void>((resolve) => {
+    markAnswered = resolve
+  })
+  const original = RenameTaskDialog.show
+  RenameTaskDialog.show = (async (_dialog: unknown, current: string, opts?: { placeholder?: string }) => {
+    seen.push({ current, placeholder: opts?.placeholder })
+    markAnswered()
+    return answer
+  }) as typeof RenameTaskDialog.show
+  return {
+    seen,
+    settled,
+    restore: () => {
+      RenameTaskDialog.show = original
+    },
+  }
+}
+
+/**
+ * Open Settings → Plugins, then CLICK the "API key" row.
+ *
+ * The cursor is a background highlight, invisible in the text frame, so
+ * counting `j` presses would be guessing. The row's y is read off the
+ * rendered frame instead, which stays correct if the section grows a row.
+ */
+async function activateSecretRow(
+  mockInput: { pressKey: (k: string) => void },
+  mockMouse: { click: (x: number, y: number) => Promise<void> },
+  frame: () => Promise<string>,
+): Promise<void> {
+  for (const key of ["k", "k", "k", "k", "l"]) {
+    act(() => mockInput.pressKey(key))
+    await settle()
+  }
+  const lines = (await frame()).split("\n")
+  const y = lines.findIndex((line) => line.includes("API key"))
+  if (y < 0) throw new Error("no API key row rendered")
+  const x = (lines[y] as string).indexOf("API key") + 2
+  // `mockMouse.click` is ASYNC: firing it outside an awaited act() leaves the
+  // renderer mid-update, and every LATER test in the run then captures an
+  // empty frame. (The "act without await" warning is the tell.)
+  await act(async () => {
+    await mockMouse.click(x, y)
+  })
+  await settle()
+}
+
+test("editing a secret opens an EMPTY field, never pre-filled with the stored key", async () => {
+  process.env.KOBE_HOME_DIR = seedHome("example.emptyedit")
+  const dialog = captureDialog(undefined) // cancel — no write
+  try {
+    const { frame, mockInput, mockMouse } = await renderComponent(<Driver />, {
+      width: 110,
+      height: 40,
+      providers: { kv: true, dialog: true },
+    })
+    await activateSecretRow(mockInput, mockMouse, frame)
+    // Wait for the edit flow to actually reach the dialog before restoring.
+    await dialog.settled
+    await settle()
+    expect(dialog.seen.length).toBeGreaterThan(0)
+    for (const opened of dialog.seen) {
+      expect(opened.current).toBe("")
+      expect(opened.placeholder ?? "").not.toContain(TOKEN)
+    }
+  } finally {
+    dialog.restore()
+  }
+})
+
+/**
+ * The store side — a submitted secret reaches the plugin verbatim, because
+ * masking is a RENDER decision and must not touch what is written. Driven
+ * through the same edit path, but the write is asserted on disk rather than
+ * from a third mount: the render harness does not survive three mounts of
+ * this dialog in one file (the third reads a stale frame).
+ */
+test("a submitted secret is stored verbatim — masking is display-only", () => {
+  const home = seedHome("example.storeverbatim")
+  setPluginSetting("example.storeverbatim", "EX_SECRET_TOKEN", "sk-live-REPLACEMENT", home)
+  expect(readPluginSettings("example.storeverbatim", home).EX_SECRET_TOKEN).toBe("sk-live-REPLACEMENT")
+  // ...and that stored value still renders masked.
+  expect(displaySettingValue({ type: "secret", value: "sk-live-REPLACEMENT" })).not.toContain("REPLACEMENT")
+})

--- a/packages/kobe/test/tui-react/plugin-settings-core.test.ts
+++ b/packages/kobe/test/tui-react/plugin-settings-core.test.ts
@@ -12,6 +12,7 @@ import type { PluginSetting } from "@sma1lboy/kobe-daemon/plugins/manifest"
 import { describe, expect, it } from "vitest"
 import {
   type PluginSettingRowView,
+  displaySettingValue,
   isBooleanOn,
   nextEnumValue,
   normalizeNumberInput,
@@ -115,5 +116,39 @@ describe("normalizeNumberInput", () => {
     expect(normalizeNumberInput("500ms")).toBeNull()
     expect(normalizeNumberInput("NaN")).toBeNull()
     expect(normalizeNumberInput("Infinity")).toBeNull()
+  })
+})
+
+/**
+ * The settings dialog is on screen during screen shares, screenshots, and
+ * recordings, and `[[settings]]` is the documented place for a plugin's API
+ * key. A `secret` row must therefore never route the stored value to the
+ * renderer — that is the whole point of the type.
+ */
+describe("displaySettingValue", () => {
+  it("never returns any part of a stored secret", () => {
+    const token = "sk-live-51H8xQ2eZvKYlo"
+    const shown = displaySettingValue({ type: "secret", value: token })
+    expect(shown).not.toContain(token)
+    // Not a prefix, suffix, or any run of it either — a masked-but-hinted
+    // value is still a leak on a recording someone can pause.
+    for (let i = 6; i <= token.length; i++) expect(shown).not.toContain(token.slice(0, i))
+    expect(shown).toBe("••••••••")
+  })
+
+  it("hides length, so two different keys look identical", () => {
+    expect(displaySettingValue({ type: "secret", value: "x" })).toBe(
+      displaySettingValue({ type: "secret", value: "x".repeat(64) }),
+    )
+  })
+
+  it("leaves an unset secret unset rather than claiming one is configured", () => {
+    expect(displaySettingValue({ type: "secret", value: "" })).toBe("")
+  })
+
+  it("shows every other type verbatim", () => {
+    expect(displaySettingValue({ type: "string", value: "plain" })).toBe("plain")
+    expect(displaySettingValue({ type: "number", value: "24" })).toBe("24")
+    expect(displaySettingValue({ type: "enum", value: "fast" })).toBe("fast")
   })
 })


### PR DESCRIPTION
Four findings from a plugin-subsystem audit. The first is the sharp one; the rest are the same class of default-permission and unbounded-growth problems #662 fixed elsewhere.

## 1. A `[[settings]]` key could be any string, including `PATH`

A settings row is not a label — it is an env var in the plugin's own process. The manifest declares the key, Settings → Plugins renders it as an ordinary editable row, and the value lands as `KEY=value` in the config `.env` that `PLUGIN-AUTHORING.md` tells authors to source (`. "$ROVE_PLUGIN_CONFIG_DIR/.env"`). The key was checked only for being non-empty.

So a manifest could ship:

```toml
[[settings]]
key = "PATH"
label = "Search path"
```

and get a row a user would happily edit. `LD_PRELOAD`, `NODE_OPTIONS`, `GIT_SSH_COMMAND` the same. Nothing on screen distinguishes that row from a preference — the label is plugin-owned copy.

Separately, a value containing a newline forged a second assignment: the TUI's string editor only `.trim()`s, so `fast\nLD_PRELOAD=/tmp/evil.so` wrote two lines into the sourced file.

Now: keys must match `^[A-Za-z_][A-Za-z0-9_]*$`, a reserved list is refused, and values are held to one line.

**On the reserved list** — the question was whether a name that matches the regex but is still dangerous (`HOME`, `SHELL`) needs blocking, given a plugin can already run arbitrary commands.

The line drawn is **mechanism, not sensitivity**: a name is refused when it changes *how* the process runs — which binary resolves, which library loads, which interpreter flags apply, which subprocess a tool shells out to — rather than being data the plugin reads. That covers `PATH`/`HOME`/`SHELL`/`IFS`, `LD_*`/`DYLD_*`, `NODE_OPTIONS` and its per-language siblings, `BASH_ENV`, `GIT_SSH_COMMAND`, `EDITOR`/`PAGER`.

It is deliberately not a secrets blocklist. `OPENAI_API_KEY` stays legal — a plugin asking the user to paste a token is the feature. And the point is not that the plugin gains capability it lacks (it doesn't; it could export any of these in its own script). It is that routing one through a **user-facing row** turns "plugin does X" into "the user configured X", which is a different thing to explain after the fact. The list is cheap, and each entry has a reason.

## 2. Three write sites #662 didn't reach

`settings-env.ts` was already fixed there; `plugins.json` and `log.jsonl` were not, and the plugin config/state dirs kept the `mkdirSync` default.

`log.jsonl` is the notable one: `runtime.ts` captures the child's **stdout and stderr** (8KB each) into every record. A plugin that prints its own token on failure wrote it to a world-readable file that `rove plugin log` then displays. Now 0600, with 0700 on the config and state directories, following #662's approach exactly.

## 3. `log.jsonl` had no cap and no rotation

`daemon.log` has `rotateLogIfNeeded`; this had nothing. A plugin subscribed to `tool.pre`/`tool.post` appends a record per tool call, per session, forever — the shape of issue #26, which grew `client.log` to 736MB.

Reuses `daemon/log-rotate.ts` at a 4MB cap (smaller than daemon.log's 10MB because it is per plugin and every enabled one keeps its own).

## 4. `type = "secret"`

`PluginSetting.type` had no secret variant, so a plugin's API key rendered in full in Settings — on screen during screen shares, screenshots, and recordings. Added `secret`: stores like a string, masked to a fixed `••••••••` everywhere it is shown. Length is hidden too, since the length of a token is itself a hint. The edit dialog opens **empty** rather than pre-filled, which would have reprinted the key it exists to hide.

**Backward compatibility, both directions.** New Rove on an old manifest: unchanged, `secret` is purely additive. Old Rove on a new manifest: the type check at `manifest.ts` is a hard `fail()`, so an older build **rejects the whole manifest** rather than degrading — which is why the SDK example carries `min_rove_version`. Not silent, but not graceful either; worth knowing before authors adopt it.

## Open questions answered

**Existing plaintext values when a manifest changes a key to `secret`.** Nothing migrates — the `.env` is a flat `KEY=value` store with no type memory, and the manifest is the schema. The practical effect is benign: the stored value is masked from that moment on, because masking is a render-time decision keyed on the manifest's current type. What does *not* happen is scrubbing the value from anywhere it already leaked (a shared screenshot, a `.env` someone copied). That is the author's call, and the honest advice is to rotate the key rather than trust a UI change to have un-shown it.

**Do the mode changes affect existing deployments?** No — same as #662. `writeFileSync`/`appendFileSync` apply `mode` only when *creating*; an existing 0644 file keeps 0644, and `mkdirSync` ignores `mode` on a directory that exists. Verified directly rather than assumed:

```
writeFileSync existing: 644     # mode ignored on an existing file
appendFileSync new:     600     # applied on create
appendFileSync existing 0644: 644
```

So this protects new installs and newly created files; machines with existing plugin data keep their current permissions until those files are recreated. A startup pass that tightens what is already on disk would fix real machines — same open question #662 left, deliberately not done here.

## Verification

**Mutation-tested, 10 mutants, and re-run after the rebase onto 0.9.33** (2 passes post-rebase, 3 before it). Every reverted guard turns the suite red:

| Mutant | Result |
|---|---|
| drop the reserved-key list | 8 failed |
| drop the key regex check | 6 failed |
| drop the newline strip | 2 failed |
| `plugins.json` back to 0644 | 1 failed |
| `log.jsonl` back to 0644 | 1 failed |
| config/state dirs back to 0755 | 1 failed |
| drop log rotation | 1 failed |
| secret mask returns the value | 2 failed |
| secret mask leaks length | 2 failed |
| manifest skips the rejection | 14 failed |

Mode assertions `statSync` the **real file**, not the arguments a write was called with. The log-mode test drives a real `PluginHost` with a plugin that prints `sk-live-abc123` to stderr, then asserts the secret is genuinely in the file — the mode only matters because the content does.

**Live run** against a real isolated fixture (own home, socket, ports):

```
--- 1. manifest declaring key = "PATH"
   REJECTED: settings[0].key `PATH` is reserved; it steers how the plugin's own process runs
--- 2. value carrying a newline
   .env bytes: "ROVE_EVIL_MODE=fastLD_PRELOAD=/tmp/evil.so\n"
   lines: 1
   LD_PRELOAD injected? no
--- 3. modes
   .env: 600   configdir: 700
```

And `rove plugin link` into a real fixture home produced `-rw------- plugins.json` and `-rw------- config/.env`.

`test:fast` 3741 passed, `test:socket` 626 passed, `test:render` 268 passed; lint + typecheck clean. `manifest.ts` was at 465 lines after my edits, so the key policy moved to its own `setting-keys.ts` to stay under the cap.

## Screenshots

Before/after through the `/harness` path — the same fixed-viewport Chromium → xterm.js → PTY sidecar → real OpenTUI, against an isolated fixture with the SDK's `settings-demo` plugin linked and a real key stored in its config `.env`:

| | `API key` row |
|---|---|
| before | `sk-live-51H8xQ2eZvKYloJUBTdM` — fully legible |
| after | `••••••••` |

`Display name Rover` renders plainly in both, so the section is demonstrably rendering values either way.

Files: `/tmp/plugin-secret-shots/{before-secret-plaintext,after-secret-masked}.png` on the dev machine.

(The kobe-web PTY sidecar is node-pty, which cannot spawn in this agent environment. The documented workaround — a `Bun.spawn({terminal})` drop-in for the sidecar — makes `visual:shot` work unchanged; it is capture tooling only and no product source was changed for it.)

## Render coverage

The first CI run failed `render-track`: `sections-plugins.tsx` at 22.8% and `use-section-data.ts` at 38.4% against the 50% floor. Both are "genuinely untested" in `HARNESS.md`'s taxonomy — ordinary code the render track reaches fine — so this adds the test rather than an exemption. Now 88.4% and 60.5%.

The test mounts the real `SettingsDialog` and asserts on a rendered frame, which the unit test structurally cannot: `displaySettingValue` can be correct while the row never calls it. Mutation-checked (2 passes): removing the mask, or pre-filling the edit dialog with the stored key, each turns it red.

One trap worth recording — `mockMouse.click` is async, and firing it outside an awaited `act()` left the renderer mid-update, so every LATER test in the run captured an empty frame: 64 failures in files that have nothing to do with this change. `test:render` is one bun process; a baseline run without the new file was clean, which is what identified it as mine rather than a flake.

## Scope

Only the four findings above. The same audit raised ten more (pane contract missing cwd/direction/singleton, unknown manifest fields dropped silently, warnings visible only at install, plugin engine id collisions, enabling a plugin not refreshing the engine list) — dispatched separately, untouched here.
