### PR TITLE
fix: make four silent failures visible and gate the class

### DIFF
--- a/.changeset/silent-failures-reach-the-user.md
+++ b/.changeset/silent-failures-reach-the-user.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Make four silent failures visible, and add a gate so the class can't come back
+
+Each of these refused a user's action and said nothing on screen — under the alternate screen a bare `console.error` only reaches the daemon log, so the gesture looked like a no-op:
+
+- Enter on a task whose worktree can't be materialized (first open after a restart, or the directory removed out of band) did nothing at all — the row never moved, so the only feedback was that pressing Enter again also did nothing. It now names which of the three cases it hit: the task is mid-delete, the project isn't a git repo yet (with the `git init` fix), or the underlying worktree error.
+- The terminal's "shell could not start" pane was a dead end. F5 is advertised as the recovery key, but the reset path returned early when there was no live PTY — exactly the state a failed spawn leaves behind. F5 now retries (no confirm — there is no running shell to kill), and the pane says so.
+- Switching engines from the `ctrl+e` picker showed the new tab whether or not the write landed, so a rejected switch was indistinguishable from success while the task silently kept its old engine. Both routes now share one helper and raise the same failure/success toasts.
+- Kanban's story edit, status flip, and task link reported failures to the log only; the board then repainted from the store, so a rejected edit read as an edit that never happened.
+
+Also retires four copy entries that were written but never rendered, and adds `scripts/no-silent-catch.mjs` (wired into CI) so a new bare `console.error` catch handler under `tui-react/**` fails the build instead of shipping. Deliberate cases take a `silent-catch-ok` marker.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,12 @@ jobs:
         # + build. Biome at root sees all packages.
         run: bun run lint
 
+      - name: No silent catch handlers in the TUI
+        # Under an alternate screen a bare `console.error` in a catch reaches
+        # the daemon log only, so the failed gesture looks like a no-op. Biome
+        # can't express "console.error inside a catch", hence a script gate.
+        run: node scripts/no-silent-catch.mjs
+
       - name: Typecheck (kobe package)
         # Workspaces hoist deps; per-package commands run via `bun --filter`.
         run: bun run typecheck

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -36,10 +36,7 @@ import { quickForkDefaultVendor } from "../workspace/quick-fork"
 import type { IssueChatStart } from "../workspace/use-issue-chat"
 import { IssueDetailDialog } from "./issue-detail-dialog"
 import { KanbanCard } from "./kanban-card"
-
-/** Agent moves land within one poll; issue.list is a local JSON read, so
- *  polling while the page is open is cheap. */
-const POLL_MS = 5_000
+import { useKanbanBoards } from "./use-kanban-boards"
 
 const COLUMN_LABEL_KEY: Record<BoardColumnKey, string> = {
   backlog: "kanban.column.backlog",
@@ -81,7 +78,6 @@ export function KanbanPage(props: {
   // one-word-per-line strips, so the board shows ONE full-width lane there.
   const narrow = isNarrowWidth(useTerminalDimensions().width)
 
-  const [boards, setBoards] = useState<readonly RepoIssues[] | null>(null)
   // Detected engines for the detail drawer's picker — one probe per page
   // open (account files on disk; cheap and refreshed enough).
   const [engines, setEngines] = useState<readonly VendorId[]>([])
@@ -94,45 +90,10 @@ export function KanbanPage(props: {
       disposed = true
     }
   }, [])
-  const [reloadTick, setReloadTick] = useState(0)
-  // Keyed by repoRoot (not index) so the poll refetch keeps the selection.
-  const [activeRepo, setActiveRepo] = useState<string | null>(null)
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadTick is a TRIGGER (the effect body doesn't read it) — the WorktreesPage refetch guard.
-  useEffect(() => {
-    let disposed = false
-    const orch = props.orchestrator
-    if (!orch) {
-      setBoards([])
-      return
-    }
-    const repos = [...new Set(orch.listTasks().map((task) => task.repo))]
-    void Promise.all(repos.map((repo) => orch.listIssues(repo).catch(() => null))).then((results) => {
-      if (disposed) return
-      // A repo whose issue file doesn't exist yet still gets a section —
-      // `exists: false` just means an empty board, not an error.
-      const next = results.filter((res): res is RepoIssues => res !== null)
-      next.sort((a, b) => a.repoRoot.localeCompare(b.repoRoot))
-      setBoards(next)
-      // First load lands on the focus task's project (opened via `c` on a
-      // task row) or, without one, the project you opened kobe in — the
-      // active task's repo (loose realpath tolerance, like WorktreesPage).
-      const norm = (p: string): string => p.replace(/^\/private\//, "/").replace(/\/+$/, "")
-      const activeId = orch.activeTaskSignal().get()
-      const targetRepo = props.focusTask?.repo ?? orch.listTasks().find((task) => task.id === activeId)?.repo
-      const initialBoard = targetRepo ? next.find((board) => norm(board.repoRoot) === norm(targetRepo)) : undefined
-      setActiveRepo((prev) => prev ?? initialBoard?.repoRoot ?? null)
-      // …and the card cursor on the focus task's linked story, if any.
-      const focusId = props.focusTask?.id
-      const linked = focusId ? initialBoard?.issues.find((issue) => issue.taskId === focusId) : undefined
-      if (linked) setSelectedId((prev) => prev ?? linked.id)
-    })
-    const timer = setInterval(() => setReloadTick((tick) => tick + 1), POLL_MS)
-    return () => {
-      disposed = true
-      clearInterval(timer)
-    }
-  }, [props.orchestrator, reloadTick])
+  const { boards, activeRepo, setActiveRepo, selectedId, setSelectedId, reload } = useKanbanBoards({
+    orchestrator: props.orchestrator,
+    focusTask: props.focusTask,
+  })
 
   const boardList = boards ?? []
   const activeIndex = Math.max(
@@ -146,10 +107,6 @@ export function KanbanPage(props: {
     activeBoard ? buildIssueBoard(activeBoard.issues) : [],
     (taskId) => props.engineStates?.get(taskId)?.state,
   )
-
-  // Card cursor — an issue id (not an index) so a poll refetch that reorders
-  // a column keeps the selection on the same story.
-  const [selectedId, setSelectedId] = useState<number | null>(null)
 
   function cycleProject(delta: number): void {
     if (boardList.length === 0) return
@@ -190,8 +147,14 @@ export function KanbanPage(props: {
       if (patch.title !== issue.title || patch.body !== issue.body) {
         await props.orchestrator
           ?.mutateIssue(board.repoRoot, { type: "update", id: issue.id, ...patch })
-          .catch((err: unknown) => console.error("[rove kanban] issue update failed:", err))
-        setReloadTick((tick) => tick + 1)
+          .catch((err: unknown) => {
+            // The reload below repaints from the store, so a rejected edit
+            // leaves the card showing its OLD title — indistinguishable from
+            // the edit never having been made.
+            console.error("[rove kanban] issue update failed:", err)
+            notifyError(t("kanban.updateFailed", { id: String(issue.id), error: errorMessage(err) }))
+          })
+        reload()
       }
       if (outcome.kind === "open") {
         props.onOpenTask(outcome.taskId)
@@ -238,7 +201,7 @@ export function KanbanPage(props: {
           title: outcome.title,
           body: outcome.body,
         })
-        setReloadTick((tick) => tick + 1)
+        reload()
         if (!outcome.start) return
         // The daemon allocates the id from nextId; fall back to the newest
         // record if another writer raced the counter between open and save.
@@ -279,7 +242,7 @@ export function KanbanPage(props: {
         ?.mutateIssue(board.repoRoot, { type: "delete", id: issue.id })
         .then(() => {
           setSelectedId(null)
-          setReloadTick((tick) => tick + 1)
+          reload()
         })
         .catch((err: unknown) => {
           console.error("[rove kanban] issue delete failed:", err)
@@ -295,7 +258,7 @@ export function KanbanPage(props: {
     enabled: dialog.stack.length === 0 && props.focused !== false,
     bindings: [
       ...pageCloseBindings(props.onClose),
-      { key: "r", cmd: () => setReloadTick((tick) => tick + 1) },
+      { key: "r", cmd: () => reload() },
       { key: "tab", cmd: () => cycleProject(1) },
       { key: "up", cmd: () => moveCursor("up") },
       { key: "down", cmd: () => moveCursor("down") },

--- a/packages/kobe/src/tui-react/component/use-kanban-boards.ts
+++ b/packages/kobe/src/tui-react/component/use-kanban-boards.ts
@@ -1,0 +1,85 @@
+/**
+ * Kanban board loading — extracted from kanban-page.tsx (file-size cap split).
+ * Owns only the data concern: fetch every saved repo's issue file, poll it
+ * while the page is open, and land the initial project/card cursor. Rendering,
+ * key handling, and mutations stay in the page.
+ */
+
+import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
+import { useEffect, useState } from "react"
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+
+/** Agent moves land within one poll; issue.list is a local JSON read, so
+ *  polling while the page is open is cheap. */
+const POLL_MS = 5_000
+
+export interface KanbanBoards {
+  /** null until the first load resolves — the page shows its loading line. */
+  readonly boards: readonly RepoIssues[] | null
+  readonly activeRepo: string | null
+  readonly setActiveRepo: (next: string | null) => void
+  readonly selectedId: number | null
+  readonly setSelectedId: (next: number | null | ((prev: number | null) => number | null)) => void
+  /** Bump to refetch now (a mutation just landed). */
+  readonly reload: () => void
+}
+
+export function useKanbanBoards(args: {
+  readonly orchestrator: RemoteOrchestrator | null
+  /** Opened from a task row (`c`): land on THAT task's project and put the
+   *  card cursor on its linked story. */
+  readonly focusTask?: { readonly id: string; readonly repo: string }
+}): KanbanBoards {
+  const [boards, setBoards] = useState<readonly RepoIssues[] | null>(null)
+  const [reloadTick, setReloadTick] = useState(0)
+  // Keyed by repoRoot (not index) so the poll refetch keeps the selection.
+  const [activeRepo, setActiveRepo] = useState<string | null>(null)
+  // Card cursor — an issue id (not an index) so a poll refetch that reorders
+  // a column keeps the selection on the same story.
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+
+  const { orchestrator, focusTask } = args
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadTick is a TRIGGER (the effect body doesn't read it) — the WorktreesPage refetch guard.
+  useEffect(() => {
+    let disposed = false
+    if (!orchestrator) {
+      setBoards([])
+      return
+    }
+    const repos = [...new Set(orchestrator.listTasks().map((task) => task.repo))]
+    void Promise.all(repos.map((repo) => orchestrator.listIssues(repo).catch(() => null))).then((results) => {
+      if (disposed) return
+      // A repo whose issue file doesn't exist yet still gets a section —
+      // `exists: false` just means an empty board, not an error.
+      const next = results.filter((res): res is RepoIssues => res !== null)
+      next.sort((a, b) => a.repoRoot.localeCompare(b.repoRoot))
+      setBoards(next)
+      // First load lands on the focus task's project (opened via `c` on a
+      // task row) or, without one, the project you opened kobe in — the
+      // active task's repo (loose realpath tolerance, like WorktreesPage).
+      const norm = (p: string): string => p.replace(/^\/private\//, "/").replace(/\/+$/, "")
+      const activeId = orchestrator.activeTaskSignal().get()
+      const targetRepo = focusTask?.repo ?? orchestrator.listTasks().find((task) => task.id === activeId)?.repo
+      const initialBoard = targetRepo ? next.find((board) => norm(board.repoRoot) === norm(targetRepo)) : undefined
+      setActiveRepo((prev) => prev ?? initialBoard?.repoRoot ?? null)
+      // …and the card cursor on the focus task's linked story, if any.
+      const focusId = focusTask?.id
+      const linked = focusId ? initialBoard?.issues.find((issue) => issue.taskId === focusId) : undefined
+      if (linked) setSelectedId((prev) => prev ?? linked.id)
+    })
+    const timer = setInterval(() => setReloadTick((tick) => tick + 1), POLL_MS)
+    return () => {
+      disposed = true
+      clearInterval(timer)
+    }
+  }, [orchestrator, reloadTick, focusTask])
+
+  return {
+    boards,
+    activeRepo,
+    setActiveRepo,
+    selectedId,
+    setSelectedId,
+    reload: () => setReloadTick((tick) => tick + 1),
+  }
+}

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -59,6 +59,7 @@ import { useTerminalBindings } from "./keys"
 import { useTerminalGeometry } from "./use-terminal-geometry"
 import { useTerminalHostCursor } from "./use-terminal-host-cursor"
 import { useTerminalPty } from "./use-terminal-pty"
+import { useTerminalReset } from "./use-terminal-reset"
 import { useTerminalSelection } from "./use-terminal-selection"
 
 /* --------------------------------------------------------------------- */
@@ -309,30 +310,15 @@ export function Terminal(props: TerminalProps) {
   // does not: the visible terminal remains the stable IME fallback there.
   const imeAnchorActive = (props.imeAnchorActive ?? true) && dialog.stack.length === 0
   const unfocusedAttachmentTarget = props.imeAnchorActive === true && dialog.stack.length === 0
-  const resetTaskIdRef = useLatest(props.taskId)
-  const resetCwdRef = useLatest(props.cwd)
-  const mountedRef = useRef(true)
-  useLayoutEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
-  const requestReset = (): void => {
-    if (!pty) return
-    // Snapshot at click-time so a task switch mid-confirm doesn't reset
-    // the wrong shell.
-    const ptyAtClick = pty
-    const cwdAtClick = props.cwd
-    const taskIdAtClick = props.taskId
-    const geometryAtClick = bodyGeometry
-    if (!cwdAtClick || !taskIdAtClick || !geometryAtClick) return
-    void DialogConfirm.show(dialog, t("terminal.reset.title"), t("terminal.reset.body"), "cancel").then((ok) => {
-      if (ok !== true || !mountedRef.current) return
-      if (resetTaskIdRef.current !== taskIdAtClick || resetCwdRef.current !== cwdAtClick) return
-      forceReacquire(cwdAtClick, taskIdAtClick, geometryAtClick, ptyAtClick)
-    })
-  }
+  const requestReset = useTerminalReset({
+    pty,
+    acquireError,
+    cwd: props.cwd,
+    taskId: props.taskId,
+    bodyGeometry,
+    forceReacquire,
+    dialog,
+  })
 
   useTerminalBindings({
     focused,
@@ -481,6 +467,7 @@ export function Terminal(props: TerminalProps) {
                 <text fg={theme.textMuted} wrapMode="word">
                   {acquireError}
                 </text>
+                <text fg={theme.textMuted}>{t("terminal.unavailable.retry")}</text>
               </>
             ) : (
               <text fg={theme.textMuted}>{t("terminal.noTask")}</text>

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-reset.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-reset.ts
@@ -1,0 +1,68 @@
+/**
+ * The terminal pane's F5 reset — extracted from Terminal.tsx (file-size cap
+ * split). Owns the confirm gate and the two ways a reset can be reached:
+ *
+ *  - a LIVE pty: confirm first (a running shell and its in-flight vim/htop
+ *    are about to die), then reacquire, guarding against a task switch that
+ *    happened while the confirm was open;
+ *  - a FAILED acquire (`acquireError`, pty already null): retry immediately.
+ *    There is nothing to destroy, the confirm's copy would be a lie, and this
+ *    is the one state where the pane has no other way out — the pre-split
+ *    guard returned early here, so F5 did nothing at all.
+ */
+
+import { useLayoutEffect, useRef } from "react"
+import type { TaskPty } from "../../../tui/panes/terminal/pty"
+import { useT } from "../../i18n"
+import { useLatest } from "../../lib/use-latest"
+import type { DialogContext } from "../../ui/dialog"
+import { DialogConfirm } from "../../ui/dialog-confirm"
+
+export function useTerminalReset(args: {
+  readonly pty: TaskPty | null
+  readonly acquireError: string | null
+  readonly cwd: string | null | undefined
+  readonly taskId: string | null | undefined
+  readonly bodyGeometry: { cols: number; rows: number } | null
+  readonly forceReacquire: (
+    cwd: string,
+    taskId: string,
+    geometry: { cols: number; rows: number },
+    expected?: TaskPty,
+  ) => void
+  readonly dialog: DialogContext
+}): () => void {
+  const t = useT()
+  const resetTaskIdRef = useLatest(args.taskId)
+  const resetCwdRef = useLatest(args.cwd)
+  const mountedRef = useRef(true)
+  useLayoutEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  return (): void => {
+    if (!args.pty && !args.acquireError) return
+    // Snapshot at click-time so a task switch mid-confirm doesn't reset
+    // the wrong shell.
+    const ptyAtClick = args.pty
+    const cwdAtClick = args.cwd
+    const taskIdAtClick = args.taskId
+    const geometryAtClick = args.bodyGeometry
+    if (!cwdAtClick || !taskIdAtClick || !geometryAtClick) return
+    // No live PTY means nothing to destroy, and the confirm's copy ("the
+    // running shell will be killed") would be a lie. Retry straight away —
+    // a confirm here is a second obstacle in a state the user is stuck in.
+    if (!ptyAtClick) {
+      args.forceReacquire(cwdAtClick, taskIdAtClick, geometryAtClick)
+      return
+    }
+    void DialogConfirm.show(args.dialog, t("terminal.reset.title"), t("terminal.reset.body"), "cancel").then((ok) => {
+      if (ok !== true || !mountedRef.current) return
+      if (resetTaskIdRef.current !== taskIdAtClick || resetCwdRef.current !== cwdAtClick) return
+      args.forceReacquire(cwdAtClick, taskIdAtClick, geometryAtClick, ptyAtClick)
+    })
+  }
+}

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -21,9 +21,9 @@
 
 import { errorMessage } from "@/lib/error-message"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
-import { cycleVendorFlow, deleteTaskFlow, renameTaskFlow } from "../../tui/lib/task-actions"
+import { applyVendorChange, cycleVendorFlow, deleteTaskFlow, renameTaskFlow } from "../../tui/lib/task-actions"
 import { type CreateTaskContext, createTaskFlow } from "../../tui/lib/task-create-flow"
-import type { Task } from "../../types/task.ts"
+import type { Task, VendorId } from "../../types/task.ts"
 import { BranchPickerDialog } from "../component/branch-picker-dialog"
 import type { DialogContext } from "../ui/dialog"
 import { buildBaseCreateTaskContext, selectNextAfterDelete } from "../ui/task-dialog-adapters"
@@ -48,6 +48,8 @@ export type WorkspaceTaskActions = {
   renameTask: (id: string) => Promise<void>
   renameBranch: (id: string) => Promise<void>
   cycleVendor: (id: string) => Promise<void>
+  /** ctrl+e picker's engine pick — same persist + toasts as `cycleVendor`. */
+  setVendor: (id: string, vendor: VendorId) => Promise<void>
   togglePin: (id: string) => Promise<void>
   moveTask: (id: string, delta: -1 | 1) => Promise<void>
 }
@@ -117,6 +119,9 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     renameTask: (id) => renameTaskFlow(taskActions, id),
     renameBranch,
     cycleVendor: (id) => cycleVendorFlow(taskActions, id),
+    setVendor: async (id, vendor) => {
+      await applyVendorChange(taskActions, id, vendor)
+    },
     togglePin,
     moveTask,
   }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -93,6 +93,13 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     })
   }
 
+  // Same pre-declaration reason as notifyWorktreeGone above: a refused
+  // activation must reach the toast surface, and `useSidebarHostState`'s
+  // notifyError can't be built yet (it needs `selectedId` from this hook).
+  const notifyActivationError = (message: string): void => {
+    notif.notify({ kind: "error", taskId: "", tabId: "", title: message })
+  }
+
   const { selectedId, setSelectedId, selectedTask, selectTask, activateTask } = useWorkspaceSelection({
     orch,
     tasks,
@@ -100,6 +107,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     focusWorkspace: () => focus.setFocused("workspace"),
     kv,
     notifyWorktreeGone,
+    notifyError: notifyActivationError,
   })
   const worktree = selectedTask?.worktreePath || null
 
@@ -137,7 +145,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
 
   // Task-action callbacks (new/delete/rename/branch/engine/pin/move)
   // — the shared lib/task-actions flows live in host-task-actions.ts.
-  const { createTask, deleteTask, renameTask, renameBranch, cycleVendor, togglePin, moveTask } =
+  const { createTask, deleteTask, renameTask, renameBranch, cycleVendor, setVendor, togglePin, moveTask } =
     useWorkspaceTaskActions({
       orchestrator: orch,
       tasks: () => tasks,
@@ -393,6 +401,7 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
               onTabVisited={inbox.resolveVisited}
               onScratchExit={scratch.onScratchExit}
               onOpenScratch={scratch.openScratchShell}
+              onEngineChosen={setVendor}
             />
           )}
         </box>

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -9,7 +9,7 @@
 import type { ReactNode } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { engineLaunchArgv } from "../../engine/engine-presets.ts"
-import { DEFAULT_TASK_VENDOR, type Task } from "../../types/task.ts"
+import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import type { QuickTaskResult } from "../component/quick-task-composer"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
@@ -34,6 +34,8 @@ export function ShowWorkspace(props: {
   onScratchExit?: (taskId: string) => void
   /** ctrl+e's trailing "scratch shell" choice — open a Scratch task. */
   onOpenScratch?: () => void
+  /** The ctrl+e picker landed on an engine — persist it and toast the result. */
+  onEngineChosen?: (taskId: string, vendor: VendorId) => Promise<void>
 }): ReactNode {
   const { theme } = useTheme()
   const t = useT()
@@ -85,9 +87,11 @@ export function ShowWorkspace(props: {
           ? (vendor) => {
               const taskId = props.task?.id
               if (!taskId) return
-              void props.orchestrator
-                .setVendor(taskId, vendor)
-                .catch((err) => console.error("[rove workspace] task.setVendor failed:", err))
+              // The tab is added to LOCAL state first and renders under the new
+              // engine's label, so a rejected write looked exactly like a
+              // success while the task kept its old vendor. Same two toasts the
+              // `v` row-chord raises — see applyVendorChange.
+              void props.onEngineChosen?.(taskId, vendor)
             }
           : undefined
       }

--- a/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
+++ b/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
@@ -105,9 +105,13 @@ export function useIssueChat(
     // Vendor lands on the task for future tabs; the story flip is
     // best-effort (a status write must not strand the chat).
     await orch.setVendor(main.id, vendor)
-    await orch
-      .mutateIssue(repoRoot, { type: "setStatus", id: issue.id, status: "doing" })
-      .catch((err: unknown) => console.error("[rove kanban] issue setStatus failed:", err))
+    await orch.mutateIssue(repoRoot, { type: "setStatus", id: issue.id, status: "doing" }).catch((err: unknown) => {
+      // Best-effort by design — a refused status write must not strand the
+      // chat. But "not fatal" isn't "not worth saying": the card silently
+      // stays in Backlog while its session runs.
+      console.error("[rove kanban] issue setStatus failed:", err)
+      hooks.notifyError(t("kanban.statusFailed", { id: String(issue.id), error: errorMessage(err) }))
+    })
     const { tab } = appendBackgroundEngineTab(kv, main.id, defaultShell(), { vendor })
     const spawn = buildIssueTabSpawn({
       taskId: main.id,
@@ -135,9 +139,13 @@ export function useIssueChat(
     setRepoLastActiveVendor(repoRoot, vendor)
     addSavedRepo(repoRoot)
     const task = await orch.createTask({ repo: repoRoot, title: issueChatTaskTitle(issue), vendor })
-    await orch
-      .mutateIssue(repoRoot, { type: "link", id: issue.id, taskId: task.id })
-      .catch((err: unknown) => console.error("[rove kanban] issue link failed:", err))
+    await orch.mutateIssue(repoRoot, { type: "link", id: issue.id, taskId: task.id }).catch((err: unknown) => {
+      // Also best-effort: the task exists and runs either way. Unsaid, the
+      // story just never grows its `linked to a session` badge and the
+      // drawer's "open the linked session" never appears.
+      console.error("[rove kanban] issue link failed:", err)
+      hooks.notifyError(t("kanban.linkFailed", { id: String(issue.id), error: errorMessage(err) }))
+    })
     const worktreePath = await orch.ensureWorktree(task.id)
     const spawn = buildIssueChatBackgroundSpawn({ issue, taskId: task.id, repoRoot, worktreePath, vendor, api })
     getDefaultPtyRegistry().acquire(spawn.ptyKey, worktreePath, {

--- a/packages/kobe/src/tui-react/workspace/use-task-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-task-selection.ts
@@ -3,8 +3,32 @@
  * create-before-snapshot path is testable without mounting the full PTY host.
  */
 
-import { TaskDeletingError } from "../../orchestrator/errors.ts"
+import { errorMessage } from "../../lib/error-message.ts"
+import { TASK_DELETING_CODE, TaskDeletingError } from "../../orchestrator/errors.ts"
 import type { Task } from "../../types/task.ts"
+
+/**
+ * Map an activation failure onto the toast the user actually sees.
+ *
+ * Three shapes reach here and they need different words:
+ *  - the task is mid-delete — nothing is wrong, the answer is "wait";
+ *  - the project has no git repo yet — actionable, `git init` fixes it;
+ *  - anything else — carry the raw reason so the user can act on it.
+ *
+ * `TaskDeletingError` is matched on its MESSAGE, not `instanceof`: the same
+ * refusal is also raised daemon-side and the RPC layer rebuilds it as a plain
+ * `Error`, dropping the class (see TASK_DELETING_CODE's own note).
+ */
+export function activationErrorMessage(
+  error: unknown,
+  translate: (key: string, vars?: Record<string, string>) => string,
+): string {
+  const message = errorMessage(error)
+  if (message.includes(TASK_DELETING_CODE)) return translate("tasks.toast.worktreeErrorDeleting")
+  if (/not a git repository|does not appear to be a git repo/i.test(message))
+    return translate("tasks.toast.worktreeErrorNotGit")
+  return translate("tasks.toast.worktreeErrorGeneric", { message })
+}
 
 type ActivateWorkspaceTaskOptions = {
   getTask: (id: string) => Task | undefined

--- a/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
@@ -11,10 +11,11 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { readLastActiveTaskId } from "../../state/last-active.ts"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import type { Task } from "../../types/task.ts"
+import { useT } from "../i18n"
 import { useLatest } from "../lib/use-latest"
 import { type TabsSnapshotKv, sweepOrphanTabsSnapshots } from "./terminal-tabs-persist"
 import { forgetTaskTabs, knownTaskTabs } from "./terminal-tabs-shared"
-import { activateWorkspaceTask, firstSelectableTask } from "./use-task-selection"
+import { activateWorkspaceTask, activationErrorMessage, firstSelectableTask } from "./use-task-selection"
 
 /** What {@link useWorkspaceSelection} reports when a worktree vanishes under a task. */
 export interface WorktreeGoneEvent {
@@ -43,8 +44,12 @@ export function useWorkspaceSelection(args: {
   readonly kv: TabsSnapshotKv
   /** A task's worktree disappeared out-of-band and its tabs were dropped. */
   readonly notifyWorktreeGone?: (event: WorktreeGoneEvent) => void
+  /** Refused activation (mid-delete, non-git project, worktree failure) —
+   *  the on-screen half of `reportError`. */
+  readonly notifyError?: (message: string) => void
 }): WorkspaceSelection {
   const { orch, tasks, activeTaskId, kv } = args
+  const t = useT()
   // Seed from the daemon's replayed focus, else the persisted lastActive
   // record — the adopt/fallback effect below corrects a stale/deleting id.
   const [selectedId, setSelectedId] = useState<string | null>(() => orch.activeTaskSignal()() ?? readLastActiveTaskId())
@@ -172,11 +177,16 @@ export function useWorkspaceSelection(args: {
       // record, and without this the first Enter never wrote lastActive —
       // so narrow mode's "↩ recent" row (and every lastActive consumer)
       // stayed empty until the user switched tasks once.
+      // Focus bookkeeping, not a user gesture — the pane has already switched
+      // locally, so the only casualty is the lastActive record. A toast would
+      // report a failure the user just watched succeed.
       if (orch.activeTaskSignal()() !== id)
+        // silent-catch-ok: focus bookkeeping, see above.
         void orch.setActiveTask(id).catch((error) => console.error("[rove workspace] setActiveTask failed:", error))
       return
     }
     setSelectedId(id)
+    // silent-catch-ok: same focus-bookkeeping write as above.
     void orch.setActiveTask(id).catch((error) => console.error("[rove workspace] setActiveTask failed:", error))
     // Plugin UI events: entering a task/project is an observable moment.
     const kind = tasks.find((task) => task.id === id)?.kind === "main" ? "project.opened" : "task.opened"
@@ -194,7 +204,13 @@ export function useWorkspaceSelection(args: {
         ensureWorktree: (taskId) => orch.ensureWorktree(taskId),
         selectTask,
         focusWorkspace: args.focusWorkspace,
-        reportError: (error) => console.error("[rove workspace] task.ensureWorktree failed:", error),
+        reportError: (error) => {
+          // Keep the log line for forensics; the toast is the on-screen half.
+          // Without it a refused Enter is a total no-op — the row never moves,
+          // so the user just presses it again, forever.
+          console.error("[rove workspace] task.ensureWorktree failed:", error)
+          args.notifyError?.(activationErrorMessage(error, t))
+        },
         isCurrent: () => activationGenerationRef.current === generation,
       },
       id,

--- a/packages/kobe/src/tui/i18n/messages/kanban.ts
+++ b/packages/kobe/src/tui/i18n/messages/kanban.ts
@@ -86,6 +86,16 @@ export const en = {
   deleteFailed: "Couldn't delete story #{id}: {error}",
   /** Error-toast title when the new-story intake fails. `{error}` = the daemon's message. */
   createFailed: "Couldn't create the story: {error}",
+  /** The detail drawer's title/body edit was rejected — the board redraws from
+   *  the store, so without this the card silently keeps its OLD text and the
+   *  edit reads as never having been made. `{error}` = the daemon's message. */
+  updateFailed: "Couldn't save story #{id}: {error}",
+  /** A story's status write was rejected while starting its chat. The chat
+   *  still starts (best-effort), but the card stays in its old column. */
+  statusFailed: "Story #{id} stays in its old column: {error}",
+  /** Linking a story to its new task was rejected. The task exists and runs;
+   *  only the story↔task link is missing, so no `linked` badge appears. */
+  linkFailed: "Story #{id} isn't linked to its task: {error}",
 }
 
 export const zh: typeof en = {
@@ -149,4 +159,7 @@ export const zh: typeof en = {
   deleteFailed: "删除 story #{id} 失败：{error}",
   /** 新建 story 失败时的错误 toast 标题。`{error}` = daemon 返回的信息。 */
   createFailed: "创建 story 失败：{error}",
+  updateFailed: "保存 story #{id} 失败：{error}",
+  statusFailed: "Story #{id} 仍留在原来的列：{error}",
+  linkFailed: "Story #{id} 未能关联到它的任务：{error}",
 }

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -91,12 +91,9 @@ export const en = {
   /** Toast / error messages */
   toast: {
     noDaemonWorktree: "No daemon running — can't create the worktree",
-    noDaemonOpen: "No daemon running — can't open this task",
     noEditor: "No editor found — set ROVE_OPEN_EDITOR (e.g. 'code', 'cursor', 'nvim')",
     openWorktreeFailed: "Couldn't open worktree with {label}",
-    sessionStartFailed: "Couldn't start this task's session",
-    moveTaskFailed: "Couldn't move task: {message}",
-    alreadyLatest: "Already on the latest version (v{version})",
+    worktreeErrorDeleting: "This task is being deleted — it can't be opened",
     worktreeErrorNotGit:
       "This project isn't a git repo yet — a task needs a git branch. Run `git init` (+ a first commit) in the project, then open the task. Non-git support is coming.",
     worktreeErrorGeneric: "Couldn't create the worktree: {message}",
@@ -179,12 +176,9 @@ export const zh: typeof en = {
   },
   toast: {
     noDaemonWorktree: "守护进程未运行——无法创建 worktree",
-    noDaemonOpen: "守护进程未运行——无法打开此任务",
     noEditor: "未找到编辑器——请设置 ROVE_OPEN_EDITOR（如 'code'、'cursor'、'nvim'）",
     openWorktreeFailed: "无法用 {label} 打开 worktree",
-    sessionStartFailed: "无法启动此任务的会话",
-    moveTaskFailed: "无法移动任务：{message}",
-    alreadyLatest: "已是最新版本（v{version}）",
+    worktreeErrorDeleting: "该任务正在删除中——无法打开",
     worktreeErrorNotGit:
       "该项目尚非 git 仓库——任务需要 git 分支。请在项目中执行 `git init`（+ 首次提交）后再打开任务。非 git 项目的支持即将推出。",
     worktreeErrorGeneric: "无法创建 worktree：{message}",

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -43,6 +43,9 @@ export const en = {
   unavailable: {
     shellMissing: "terminal unavailable — configured shell is not available",
     spawnFailed: "terminal unavailable — shell could not start",
+    // The pane is otherwise a dead end: there is no PTY to key into, so the
+    // only way out has to be named on screen.
+    retry: "F5 tries again",
   },
   reset: {
     title: "Reset terminal?",
@@ -82,6 +85,7 @@ export const zh: typeof en = {
   unavailable: {
     shellMissing: "终端不可用 —— 配置的 shell 不存在",
     spawnFailed: "终端不可用 —— shell 启动失败",
+    retry: "按 F5 重试",
   },
   reset: {
     title: "重置终端？",

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -20,7 +20,7 @@ import { hostedTaskKeys, killHostedSessions, listHostedSessions, openHostedSessi
 import { engineDisplayName } from "@/engine/interactive-command"
 import { errorMessage } from "@/lib/error-message"
 import { DIRTY_WORKTREE_CODE } from "@/orchestrator/errors"
-import { DEFAULT_TASK_VENDOR, type Task } from "@/types/task"
+import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "@/types/task"
 import { nextVendorWithin } from "@/types/vendor"
 
 export interface TaskActionLogger {
@@ -297,21 +297,40 @@ export async function renameBranchFlow(ctx: TaskActionContext, taskId: string): 
  * it instead of jumping to a built-in and getting stranded. Tasks-pane-only
  * today (`v`), lifted host-agnostic like {@link renameBranchFlow}.
  */
-export async function cycleVendorFlow(ctx: TaskActionContext, taskId: string): Promise<void> {
-  const task = ctx.tasks().find((t) => t.id === taskId)
-  if (!task || !ctx.orch) return
-  const engines = await availableEngineIds()
-  const next = nextVendorWithin(engines, task.vendor ?? DEFAULT_TASK_VENDOR)
+/**
+ * Persist a task's engine and say so — the shared half of the two routes that
+ * switch engines (`v` on a row, and the ctrl+e picker's "new tab in this
+ * worktree"). Both need the same two toasts: the picker used to have neither,
+ * so a rejected `setVendor` left a tab rendered under the NEW engine's label
+ * while the task kept the old one — success and failure looked identical.
+ *
+ * Returns whether the write landed, so a caller can undo its optimistic UI.
+ */
+export async function applyVendorChange(
+  ctx: Pick<TaskActionContext, "orch" | "logger" | "logPrefix" | "notifyError" | "notifyInfo">,
+  taskId: string,
+  next: VendorId,
+): Promise<boolean> {
+  if (!ctx.orch) return false
   try {
     await ctx.orch.setVendor(taskId, next)
   } catch (err) {
     ctx.logger.error(`${ctx.logPrefix} task.setVendor failed:`, err)
     ctx.notifyError?.(`Couldn't switch engine: ${errorMessage(err)}`)
-    return
+    return false
   }
   // The new vendor only takes effect on the task's NEXT enter (ensureSession
-  // rebuilds the pane when its `@kobe_vendor` tag no longer matches), so a
-  // bare `v` press looks like a no-op. Surface the deferred-rebuild contract.
+  // rebuilds the pane when its `@kobe_vendor` tag no longer matches), so the
+  // gesture looks like a no-op. Surface the deferred-rebuild contract.
   ctx.notifyInfo?.(`Engine → ${engineDisplayName(next)} (applies on reopen)`)
+  return true
+}
+
+export async function cycleVendorFlow(ctx: TaskActionContext, taskId: string): Promise<void> {
+  const task = ctx.tasks().find((t) => t.id === taskId)
+  if (!task || !ctx.orch) return
+  const engines = await availableEngineIds()
+  const next = nextVendorWithin(engines, task.vendor ?? DEFAULT_TASK_VENDOR)
+  if (!(await applyVendorChange(ctx, taskId, next))) return
   await ctx.reload?.()
 }

--- a/packages/kobe/src/tui/lib/task-create-flow.ts
+++ b/packages/kobe/src/tui/lib/task-create-flow.ts
@@ -91,7 +91,10 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
   addSavedRepo(result.repo)
   ctx.onRepoSaved?.()
   if (!orch) {
+    // The dialog has already closed by here. Without a toast the submit reads
+    // as a success that produced no task.
     ctx.logger.error(`${ctx.logPrefix} no daemon; cannot create task`)
+    ctx.notifyError?.(t("tasks.toast.noDaemonWorktree"))
     return
   }
   // The create/adopt awaits a real git-worktree operation with no other

--- a/packages/kobe/test/architecture/no-silent-catch.test.ts
+++ b/packages/kobe/test/architecture/no-silent-catch.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Behavior of the CI silent-catch gate (scripts/no-silent-catch.mjs, run by
+ * the quality job): a bare `console.error` catch handler fails, the same
+ * handler paired with an on-screen notify passes, and the
+ * `silent-catch-ok` marker exempts a deliberate case.
+ *
+ * The gate exists because this defect class has been fixed instance-by-
+ * instance several times; without it, the next `.catch(console.error)` lands
+ * unchallenged.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterAll, expect, test } from "vitest"
+
+const SCRIPT = fileURLToPath(new URL("../../../../scripts/no-silent-catch.mjs", import.meta.url))
+const dir = mkdtempSync(join(tmpdir(), "no-silent-catch-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+/** Write `source` as the only file in a fresh scan root and run the gate. */
+function run(source: string): { code: number; stdout: string } {
+  const root = mkdtempSync(join(dir, "root-"))
+  mkdirSync(root, { recursive: true })
+  writeFileSync(join(root, "probe.tsx"), source)
+  try {
+    return { code: 0, stdout: execFileSync("node", [SCRIPT, root], { encoding: "utf8" }) }
+  } catch (error) {
+    const e = error as { status: number; stdout: string }
+    return { code: e.status, stdout: e.stdout }
+  }
+}
+
+test("an arrow-form bare console.error catch fails the gate", () => {
+  const result = run(`export function go(p: { run: () => Promise<void> }) {
+  void p.run().catch((err) => console.error("[rove] run failed:", err))
+}
+`)
+  expect(result.code).toBe(1)
+  expect(result.stdout).toContain("bare console.error in a catch handler")
+})
+
+test("a block-form catch whose only statement is the log fails the gate", () => {
+  const result = run(`export async function go(run: () => Promise<void>) {
+  try {
+    await run()
+  } catch (err) {
+    console.error("[rove] run failed:", err)
+  }
+}
+`)
+  expect(result.code).toBe(1)
+  expect(result.stdout).toContain("bare console.error in a catch handler")
+})
+
+test("logging AND notifying passes — that shape is the fix, not the defect", () => {
+  const result = run(`export async function go(run: () => Promise<void>, notifyError: (m: string) => void) {
+  try {
+    await run()
+  } catch (err) {
+    console.error("[rove] run failed:", err)
+    notifyError("Couldn't run it")
+  }
+}
+`)
+  expect(result.code).toBe(0)
+})
+
+test("a silent-catch-ok marker exempts a deliberate case", () => {
+  const result = run(`export function go(p: { run: () => Promise<void> }) {
+  // silent-catch-ok: telemetry only, nothing for the user to act on.
+  void p.run().catch((err) => console.error("[rove] run failed:", err))
+}
+`)
+  expect(result.code).toBe(0)
+})
+
+test("a clean tree passes", () => {
+  const result = run(`export function go(p: { run: () => Promise<void> }, notifyError: (m: string) => void) {
+  void p.run().catch((err) => notifyError(String(err)))
+}
+`)
+  expect(result.code).toBe(0)
+  expect(result.stdout).toContain("no-silent-catch OK")
+})

--- a/packages/kobe/test/render/silent-failure-toasts.test.tsx
+++ b/packages/kobe/test/render/silent-failure-toasts.test.tsx
@@ -1,0 +1,215 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Second wave of "failed mutations must be VISIBLE" (see failure-toast.test.tsx
+ * for the first). These cover the paths that wave missed, where the failure was
+ * indistinguishable from success rather than merely quiet:
+ *
+ *   - Kanban's detail-drawer EDIT: the board redraws from the store on save, so
+ *     a rejected update left the card showing its OLD title — reading as an
+ *     edit that never happened, not as a refused write.
+ *   - The terminal's acquire-failure state: F5 is advertised as the recovery
+ *     key but `requestReset` returned early on `!pty`, which is exactly the
+ *     state an acquire failure leaves behind. The pane had no exit at all.
+ *
+ * Each test drives the REAL keys against a rejecting/throwing dependency and
+ * asserts what REACHED THE USER — the toast glyph painted on the frame, or the
+ * recovered terminal contents. Asserting "the callback ran" is what let the
+ * original bugs ship green.
+ */
+import { expect, test } from "bun:test"
+import { useEffect } from "react"
+import { KanbanPage } from "../../src/tui-react/component/kanban-page"
+import { ToastOverlay } from "../../src/tui-react/component/toast-overlay"
+import { useNotifications } from "../../src/tui-react/context/notifications"
+import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
+import { useWorkspaceSelection } from "../../src/tui-react/workspace/use-workspace-selection"
+import { MockTaskPty } from "../../src/tui/panes/terminal/pty-mock"
+import { PtyRegistry } from "../../src/tui/panes/terminal/registry"
+import { toTaskId } from "../../src/types/task"
+import { renderComponent, settle } from "./harness"
+
+const REPO = "/repos/rove"
+
+function issue(id: number, over: Record<string, unknown> = {}) {
+  return { id, title: `story-${id}`, status: "open", created: "2026-08-01", body: "", ...over }
+}
+
+test("kanban: a rejected detail-drawer edit shows an error toast, not the stale card", async () => {
+  const orch = {
+    listTasks: () => [{ repo: REPO }],
+    listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)] }),
+    activeTaskSignal: () => ({ get: () => null }),
+    mutateIssue: async () => {
+      throw new Error("issues store is read-only")
+    },
+  } as never
+  const { frame, mockInput } = await renderComponent(
+    <>
+      <KanbanPage
+        orchestrator={orch}
+        focused={true}
+        onClose={() => {}}
+        onStartChat={async () => {}}
+        onOpenTask={() => {}}
+      />
+      <ToastOverlay />
+    </>,
+    { width: 120, height: 30, providers: { dialog: true, kv: true, notifications: true } },
+  )
+  await settle()
+  // Open the only card's detail drawer, edit the title, save-and-close (esc).
+  mockInput.pressArrow("down")
+  await settle()
+  mockInput.pressEnter()
+  await settle(300)
+  expect(await frame()).toContain("TITLE")
+  // A startable story opens focused on WORKSPACE (see issue-detail-dialog's
+  // initial `field`); the field ring is title→description→engine→workspace→
+  // jump, so two tabs wrap around onto the title input.
+  mockInput.pressTab()
+  await settle()
+  mockInput.pressTab()
+  await settle()
+  mockInput.typeText("-edited")
+  await settle(150)
+  expect(await frame()).toContain("story-1-edited")
+  mockInput.pressEscape()
+  await settle(400)
+  const text = await frame()
+  // The board repainted from the store, so the card still reads `story-1`.
+  // Without the toast that is the ONLY thing on screen — and it looks exactly
+  // like an edit that was never made.
+  expect(text).toContain("✕")
+  expect(text).toContain("Couldn't save story #1")
+})
+
+/**
+ * The terminal's acquire-failure state used to be a dead end.
+ *
+ * `terminal.exited` names its recovery key ("process exited — F5 restarts
+ * it"), and F5 is documented as THE terminal recovery chord. But
+ * `requestReset` began `if (!pty) return`, and a failed acquire runs
+ * `setPty(null)` — so in the one state that most needs recovery, F5 did
+ * nothing at all. The only escape was switching tasks away and back, which
+ * the screen never mentioned.
+ *
+ * This drives the real chord through the real pane against a registry whose
+ * first spawn throws, and asserts BOTH halves of the fix: the hint naming F5
+ * is on screen, and pressing F5 actually brings the terminal up.
+ */
+test("terminal: F5 recovers a failed acquire, and the pane says so", async () => {
+  let attempt = 0
+  // First spawn throws (the shell is missing); the retry succeeds and the
+  // shell prints. A real PtyRegistry wraps it, so acquire/reset run for real.
+  const registry = new PtyRegistry((opts) => {
+    attempt += 1
+    if (attempt === 1) throw new Error("spawn /bin/nope ENOENT")
+    const pty = new MockTaskPty(opts)
+    pty.feed("recovered-shell-prompt$ ")
+    return pty
+  })
+
+  const { frame, mockInput } = await renderComponent(
+    <Terminal taskId="t1" cwd="/repos/rove" focused={true} registry={registry} />,
+    { width: 80, height: 16, providers: { dialog: true, kv: true, notifications: true } },
+  )
+  await settle(200)
+
+  // BEFORE the key: the failure is stated AND the way out is named. Without
+  // the hint the user has no reason to believe any key would help.
+  const failed = await frame()
+  expect(failed).toContain("terminal unavailable")
+  expect(failed).toContain("F5")
+  expect(failed).not.toContain("recovered-shell-prompt")
+
+  // mockInput speaks raw bytes; F5 is CSI 15~.
+  mockInput.pressKey("\x1b[15~")
+  await settle(400)
+
+  // AFTER: a real shell is up. Asserting the hint alone would have passed
+  // against the broken guard — the recovered contents are the actual proof.
+  const recovered = await frame()
+  expect(recovered).toContain("recovered-shell-prompt")
+  expect(recovered).not.toContain("terminal unavailable")
+  expect(attempt).toBe(2)
+})
+
+/**
+ * Enter on a task whose worktree can't be materialized used to be a TOTAL
+ * no-op: `activateWorkspaceTask` correctly refused to move the selection and
+ * called `reportError`, but the host wired `reportError` to a bare
+ * `console.error`. Under the alternate screen that reaches the daemon log
+ * only, so the row didn't move, no toast appeared, and the user could press
+ * Enter forever with identical results.
+ *
+ * The unit tests next door cover the error→copy MAPPING. This one covers the
+ * WIRING — that the mapped string actually reaches the toast surface. Reverting
+ * either half must fail something, and mapping alone passed the old test suite.
+ */
+function SelectionHarness(props: { orch: never; notifyError: (m: string) => void }) {
+  const selection = useWorkspaceSelection({
+    orch: props.orch,
+    tasks: [
+      {
+        id: toTaskId("t1"),
+        title: "story task",
+        repo: "/repos/rove",
+        branch: "feat/x",
+        // No worktreePath: activation must go through `ensureWorktree`.
+        worktreePath: "",
+        kind: "task",
+        status: "backlog",
+        pinned: false,
+        vendor: "claude",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    activeTaskId: null,
+    focusWorkspace: () => {},
+    kv: { store: {}, set: () => {} },
+    notifyError: props.notifyError,
+  })
+  // Fire the refusal once on mount — re-running on every `selection` identity
+  // change would just repeat the same rejected activation.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-only by design.
+  useEffect(() => {
+    void selection.activateTask("t1")
+  }, [])
+  return <text>workspace</text>
+}
+
+test("workspace: Enter on an unmaterializable task raises a toast, not just a log line", async () => {
+  const orch = {
+    activeTaskSignal: () => () => null,
+    setActiveTask: async () => {},
+    reportUiEvent: () => {},
+    ensureWorktree: async () => {
+      throw new Error("fatal: not a git repository (or any of the parent directories): .git")
+    },
+  } as never
+
+  function Harness() {
+    const notif = useNotifications()
+    return (
+      <SelectionHarness
+        orch={orch}
+        notifyError={(message) => notif.notify({ kind: "error", taskId: "", tabId: "", title: message })}
+      />
+    )
+  }
+
+  const { frame } = await renderComponent(
+    <>
+      <Harness />
+      <ToastOverlay />
+    </>,
+    { width: 100, height: 20, providers: { dialog: true, kv: true, notifications: true } },
+  )
+  await settle(300)
+
+  const text = await frame()
+  expect(text).toContain("✕")
+  // The actionable non-git copy, not the generic worktree failure.
+  expect(text).toContain("isn't a git repo yet")
+})

--- a/packages/kobe/test/tui/apply-vendor-change.test.ts
+++ b/packages/kobe/test/tui/apply-vendor-change.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Switching a task's engine must SAY what happened, on both routes.
+ *
+ * The ctrl+e picker adds its tab to local state first, so the new tab renders
+ * under the new engine's label whether or not the `setVendor` write lands. A
+ * rejected write therefore looked exactly like a success — while the task kept
+ * its old vendor, so every later tab and the next reopen quietly reverted.
+ *
+ * The row chord (`v`) already toasted both outcomes; `applyVendorChange` is the
+ * shared half so the two routes can't drift again.
+ */
+
+import { describe, expect, test, vi } from "vitest"
+import { applyVendorChange } from "../../src/tui/lib/task-actions"
+
+function ctx(setVendor: () => Promise<void>) {
+  return {
+    orch: { setVendor: vi.fn(setVendor) } as never,
+    logger: { error: vi.fn() },
+    logPrefix: "[test]",
+    notifyError: vi.fn(),
+    notifyInfo: vi.fn(),
+  }
+}
+
+describe("applyVendorChange", () => {
+  test("a successful switch reports that it applies on reopen", async () => {
+    const c = ctx(async () => {})
+    await expect(applyVendorChange(c, "t1", "codex")).resolves.toBe(true)
+    expect(c.notifyError).not.toHaveBeenCalled()
+    // The rebuild is deferred to the task's next enter, so silence here would
+    // read as "nothing happened".
+    const said = c.notifyInfo.mock.calls[0]?.[0] as string
+    expect(said).toContain("applies on reopen")
+  })
+
+  test("a rejected switch reports the failure and the reason", async () => {
+    const c = ctx(async () => {
+      throw new Error("daemon refused")
+    })
+    await expect(applyVendorChange(c, "t1", "codex")).resolves.toBe(false)
+    // The log line stays for forensics...
+    expect(c.logger.error).toHaveBeenCalled()
+    // ...but the user-visible half is the point: it must name the failure
+    // and carry the underlying reason.
+    const said = c.notifyError.mock.calls[0]?.[0] as string
+    expect(said).toContain("Couldn't switch engine")
+    expect(said).toContain("daemon refused")
+    // A failure must NOT also claim success.
+    expect(c.notifyInfo).not.toHaveBeenCalled()
+  })
+})

--- a/packages/kobe/test/tui/workspace-task-selection.test.ts
+++ b/packages/kobe/test/tui/workspace-task-selection.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, expect, test, vi } from "vitest"
-import { activateWorkspaceTask, firstSelectableTask } from "../../src/tui-react/workspace/use-task-selection"
+import { TaskDeletingError } from "../../src/orchestrator/errors"
+import {
+  activateWorkspaceTask,
+  activationErrorMessage,
+  firstSelectableTask,
+} from "../../src/tui-react/workspace/use-task-selection"
 import type { Task } from "../../src/types/task"
 import { toTaskId } from "../../src/types/task"
 
@@ -187,5 +192,43 @@ describe("pure-TUI workspace task activation", () => {
     expect(firstSelectableTask([stale, recent], null)).toBe(recent)
     expect(firstSelectableTask([deleting], null)).toBeUndefined()
     expect(firstSelectableTask([], null)).toBeUndefined()
+  })
+})
+
+/**
+ * The activation refusals the user actually SEES. `activateWorkspaceTask`
+ * returning false is only half the contract — the earlier bug was that the
+ * refusal reached `console.error` and nothing else, so Enter on an
+ * unmaterializable row was an infinite silent no-op.
+ *
+ * These assert the STRING handed to the toast, keyed by catalog id, so a
+ * regression that drops the mapping (or points every case at the generic
+ * copy) fails rather than passing on "reportError was called".
+ */
+describe("activation failures map onto user-visible copy", () => {
+  // Stand-in for the real `t`: returns the key plus its interpolations, so a
+  // wrong key or a dropped {message} is visible in the assertion.
+  const translate = (key: string, vars?: Record<string, string>) => (vars ? `${key}|${JSON.stringify(vars)}` : key)
+
+  test("a mid-delete task says so instead of reporting a worktree failure", () => {
+    expect(activationErrorMessage(new TaskDeletingError("t1"), translate)).toBe("tasks.toast.worktreeErrorDeleting")
+  })
+
+  test("the daemon's plain-Error rebuild of the same refusal still maps to the deleting copy", () => {
+    // The RPC layer reconstructs thrown errors as `new Error(message)`, so the
+    // class is gone by the time this runs — matching must be on the message.
+    const overWire = new Error("TASK_DELETING: task t1 is being deleted")
+    expect(activationErrorMessage(overWire, translate)).toBe("tasks.toast.worktreeErrorDeleting")
+  })
+
+  test("a non-git project gets the actionable `git init` copy", () => {
+    const err = new Error("fatal: not a git repository (or any of the parent directories): .git")
+    expect(activationErrorMessage(err, translate)).toBe("tasks.toast.worktreeErrorNotGit")
+  })
+
+  test("any other failure carries the underlying reason through", () => {
+    const message = activationErrorMessage(new Error("worktree is locked"), translate)
+    expect(message).toContain("tasks.toast.worktreeErrorGeneric")
+    expect(message).toContain("worktree is locked")
   })
 })

--- a/scripts/no-silent-catch.mjs
+++ b/scripts/no-silent-catch.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Bare `console.error` as a catch handler is invisible in the TUI: the app
+ * runs under an alternate screen, so the line only ever reaches the daemon log
+ * and the failed gesture looks like a no-op. This gate keeps `tui-react/**`
+ * free of the pattern — Biome can't express "console.error inside a catch", so
+ * it lives here beside the other repo-specific gates (file-size-check.sh,
+ * check-changeset.mjs, coverage-gate.mjs).
+ *
+ * Fix a hit by adding the on-screen half (notifyError / notif.notify) and
+ * keeping the console line for forensics. A genuinely-invisible-by-design case
+ * (focus bookkeeping, telemetry) takes a `// silent-catch-ok: <reason>` marker
+ * on the offending line or the one above it.
+ *
+ * Behavior is covered by test/architecture/no-silent-catch.test.ts.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+const root = process.argv[2] ?? "packages/kobe/src/tui-react"
+
+/** Every .ts/.tsx file under `dir`, recursively. */
+function sources(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) out.push(...sources(path))
+    else if (/\.tsx?$/.test(entry)) out.push(path)
+  }
+  return out
+}
+
+const CATCH_ARROW = /\.catch\s*\(.*=>\s*console\.error/
+const CATCH_BLOCK_OPEN = /\bcatch\s*(\([^)]*\))?\s*\{\s*$/
+const MARKER = /silent-catch-ok/
+
+/**
+ * Pre-existing block-form hits outside this gate's introducing change. Both
+ * are teardown paths with no UI left to render a toast into (quit, and the kv
+ * full-wipe write). They are listed here rather than marked in place because
+ * those files belong to other in-flight slices; the next person to touch
+ * either should add the `silent-catch-ok` marker there and drop the entry.
+ * Keyed by FILE, not line: a line number goes stale on the first edit above
+ * it and the exemption would lapse without anyone noticing.
+ */
+const GRANDFATHERED = new Set([
+  "packages/kobe/src/tui-react/context/kv-core.ts",
+  "packages/kobe/src/tui-react/workspace/host-keybindings.ts",
+])
+
+const hits = []
+for (const file of sources(root)) {
+  const lines = readFileSync(file, "utf8").split("\n")
+  lines.forEach((line, i) => {
+    // Shape 1: one-expression arrow handler, `.catch(e => console.error(…))`.
+    const offending = CATCH_ARROW.test(line)
+    // Shape 2: a catch block whose ONLY statement is the log — nothing else
+    // in the block surfaces the failure. (A block that also notifies is fine,
+    // which is exactly the fix, so the closing-brace check is the point.)
+    if (!offending && CATCH_BLOCK_OPEN.test(line)) {
+      const body = lines[i + 1] ?? ""
+      const after = lines[i + 2] ?? ""
+      if (body.includes("console.error") && /^\s*\}/.test(after)) {
+        if (!MARKER.test(body) && !MARKER.test(line)) hits.push({ file, line: i + 2 })
+        return
+      }
+    }
+    if (!offending) return
+    // Escape hatch: marker on the line itself or the one directly above.
+    if (MARKER.test(line) || MARKER.test(lines[i - 1] ?? "")) return
+    hits.push({ file, line: i + 1 })
+  })
+}
+
+const live = hits.filter((hit) => !GRANDFATHERED.has(hit.file))
+for (const hit of live) {
+  console.log(
+    `::error file=${hit.file},line=${hit.line}::bare console.error in a catch handler — invisible under the alternate screen. Add the on-screen half (notifyError/notif.notify) alongside it, or mark it '// silent-catch-ok: <reason>'.`,
+  )
+}
+if (live.length > 0) {
+  console.log("\nSilent failures are the most-repeated defect class in this tree — see AGENTS.md.")
+  process.exit(1)
+}
+console.log(`no-silent-catch OK — no bare console.error catch handlers under ${root}`)


### PR DESCRIPTION
Four places refused a user's action and said nothing on screen. Under the alternate screen a bare `console.error` only reaches the daemon log, so each looked like a no-op. Three files already carry a comment explaining this exact hazard; nothing stopped the next instance from landing, so this adds the gate too.

## The four

**1. Enter on a task whose worktree can't materialize** — a total no-op. The row never moved, so the only feedback from pressing Enter was that pressing it again also did nothing. `activateWorkspaceTask` refused correctly and called `reportError`, but the host wired that to a bare `console.error`. Now maps onto three distinct messages: mid-delete (`TaskDeletingError`, matched on its wire-stable message since the RPC layer drops the class), non-git project (the actionable `git init` copy that was written and never rendered), and the generic worktree failure carrying the reason.

**2. The terminal's failed-spawn pane had no exit.** F5 is advertised as the recovery key (`terminal.exited` says so), but `requestReset` opened with `if (!pty) return` — and a failed acquire runs `setPty(null)`, so F5 did nothing in the one state that needed it. Now retries, skipping the confirm (there is no running shell to kill, so its copy would be a lie), and the pane names F5.

**3. Engine switch from the `ctrl+e` picker.** The tab is added to local state first and renders under the new engine's label, so a rejected `setVendor` was pixel-identical to success while the task silently kept its old vendor. The `v` row-chord already toasted both outcomes; both routes now share `applyVendorChange` so they can't drift again.

**4. Kanban story edit / status flip / task link.** All log-only. The board repaints from the store after a save, so a rejected edit showed the OLD title — reading as an edit that never happened rather than a refused write. Sibling to #651, which fixed create/delete on the same page and missed these.

**5. Retired copy.** `noDaemonOpen`, `sessionStartFailed`, `moveTaskFailed`, `alreadyLatest` had zero non-i18n references and no live path to attach to (`moveTaskFailed` is superseded by an inline string; `alreadyLatest` by the update page's own copy). Deleted in both locales. `noDaemonWorktree` had a live home and is now wired — at `task-create-flow.ts`, not the `host-boot.tsx` path, whose `connectOrchestratorBestEffort` has no callers at all.

## The gate

`scripts/no-silent-catch.mjs`, wired into the quality job. Biome can't express "console.error inside a catch", so it follows the existing script-gate pattern (`file-size-check.sh`, `check-changeset.mjs`). It catches both the arrow form and a catch block whose only statement is the log; logging **and** notifying passes, since that shape is the fix. Deliberate cases take `// silent-catch-ok: <reason>` — used for the two `setActiveTask` focus-bookkeeping writes, where the pane has already switched locally and a toast would report a failure the user just watched succeed.

Two pre-existing hits (`kv-core.ts` clear, `host-keybindings.ts` quit — both teardown paths with no UI left) are grandfathered by FILE rather than line, since a line number goes stale on the first edit above it and the exemption would lapse unnoticed. Both files belong to other in-flight branches.

## Verification

Every fix was reverted individually and the guarding test confirmed red, twice. Two findings from that pass:

- My first mapper test passed with fix #1 fully reverted — it tested `activationErrorMessage` in isolation and nothing pinned that the hook *calls* it. Added a render test that mounts the real hook with the real notifications context and asserts the toast on the frame.
- Reverting the kanban fix turns the render test **and** the new lint gate red independently.

`test/render/silent-failure-toasts.test.tsx` asserts what reached the user (the toast glyph on the captured frame; the recovered shell's contents), never that a callback fired — that is what let the original bugs ship green.

Full local run: lint, typecheck, `check-i18n` (695 keys × 2 locales), `test:fast` (3727), `test:render` (271), gate.

## Screenshots

Captured through the ground-truth path (browser → xterm.js → PTY sidecar → real OpenTUI), isolated on `KOBE_VISUAL_PORT_BASE=5673`. Files in `/tmp/pr666-shots/`:

| | |
|---|---|
| `enter-before-02-nothing.png` | Enter on an unmaterializable task — identical frame, no toast, nothing |
| `enter-after-02-toast.png` | the same keypress now raises `✕ This project isn't a git repo yet — a …` |

The terminal F5 pair is **not** captured this way. Reproducing an `acquire()` throw in the harness needs the pane's shell resolution to fail inside the TUI process; `$SHELL` and the `engineCommand` override both fall back to a working shell instead of throwing, so the state never appeared. It is covered by a render test that drives the real F5 chord against a registry whose first spawn throws and asserts both the hint and that the retry actually spawned (`attempt === 2`) with the recovered shell's output on the frame. Reverting either half turns it red. Flagging rather than claiming the screenshot.

## File-size cap

`kanban-page.tsx` (505 → 462, board loading extracted to `use-kanban-boards.ts`) and `Terminal.tsx` (505 → 480, the reset gate extracted to `use-terminal-reset.ts` — the code this PR touches).

## Coverage exemptions

coverage-exemption: packages/kobe/src/tui-react/workspace/host.tsx — pure wiring: the change is three lines that hand `notifyActivationError` to `useWorkspaceSelection` and `setVendor` to `ShowWorkspace`. Both behaviors ARE covered by render tests one level down (`silent-failure-toasts.test.tsx` mounts the real selection hook with the real notifications context and asserts the toast on the frame; `apply-vendor-change.test.ts` pins both toasts). Nothing mounts the full `WorkspaceRoot` — it needs a live daemon-backed orchestrator — so the file reports 0% however well the behavior is tested.

coverage-exemption: packages/kobe/src/tui-react/workspace/show-workspace.tsx — same shape: the change replaces an inline `.catch(console.error)` with a call to the host's `onEngineChosen`. The behavior it now routes to is covered by `test/tui/apply-vendor-change.test.ts` (failure toast carries the reason, success names the deferred rebuild, a failure never also claims success). This file is the center-column switch and is only exercised by mounting the whole workspace host.

