### PR TITLE
fix: wait for the engine to be reading before pasting a prompt

### DIFF
--- a/.changeset/honest-prompt-delivery.md
+++ b/.changeset/honest-prompt-delivery.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop `api add`/`send` from silently truncating large prompts, and stop them reporting success when nothing arrived.
+
+A prompt written into an engine that had not yet taken its tty into raw mode was discarded past the tty's 1024-byte canonical buffer — an 8.6KB prompt reached the engine as a 1024-byte prefix, with no error at any layer. Delivery now waits for the engine to announce bracketed paste (DECSET 2004) before writing, which is the engine reporting that it is actually reading. The old fixed 1.5s settle was the specific cause for kimi, which announces at ~1.95s.
+
+`delivered` and `engineReady` are now measured rather than assumed — the spawn path hardcoded both to `true`. A new `promptEcho` field reports whether the prompt's tail was seen echoed back, and `bytes` reports how much was written.

--- a/docs/API.md
+++ b/docs/API.md
@@ -289,6 +289,22 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   managed (non-`main`, non-`dir`) task, and a definite `ahead === 0` — an
   unresolvable base reads `null` and never refuses. `--allow-empty` states an
   intentional empty success (an investigation, a review) and delivers.
+
+  **Delivery result fields.** Before writing a byte, delivery waits for the
+  engine to announce bracketed paste (DECSET 2004), which is the engine
+  saying it has taken its tty into raw mode and started reading. This is not
+  a nicety: a pty in canonical mode DISCARDS input past the tty's 1024-byte
+  buffer rather than blocking, so a prompt written into a still-booting
+  engine used to arrive as a 1024-byte prefix with no error anywhere.
+
+  - `engineReady` — the engine was confirmed reading when the write happened.
+  - `delivered` — the prompt was written to the engine's pty.
+  - `bytes` — how many bytes were written (prompt plus paste wrapper).
+  - `promptEcho` — `"confirmed"` when the prompt's tail was seen echoed back,
+    `"unconfirmed"` otherwise. Unconfirmed is INCONCLUSIVE, not failure:
+    engines that collapse a large paste into a `[Pasted text #1]` placeholder
+    never echo the text, so a positive proves delivery while a negative
+    merely fails to.
 - `dispatch --task-id ID --prompt TEXT [--tab TAB]`: route text into a
   task's live session via the daemon's `session.deliver` channel (the
   dispatcher's messenger; see

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -55,6 +55,11 @@ export type { PtyHostStats, PtySessionInfo } from "./pty-observability.ts"
 export { foldOscTitle } from "./pty-observability.ts"
 export type { PtyAttachResult, PtyHostOptions, PtySessionState, PtySink, PtySpawnSpec } from "./pty-host-types.ts"
 
+/** Writes at or above this size get a `daemon.log` line. Above the tty's
+ *  1024-byte canonical buffer, so anything big enough to have been silently
+ *  truncated by the old delivery path is recorded. */
+const LOGGED_WRITE_BYTES = 1024
+
 /** Per-session scrollback cap — same order as the web PTY sidecar's 256KB. */
 export const DEFAULT_SCROLLBACK_CAP = 512 * 1024
 /** Raw ring tail captured into a session's death record. */
@@ -241,11 +246,24 @@ export class PtyHost {
     if (client !== undefined && session.sinks.has(client)) {
       session.lastHumanWriteMs = Date.now()
     }
+    // Audit trail for prompt delivery. `daemon.log` recorded activity only
+    // once the daemon OBSERVED engine output, so there was no record of a
+    // prompt having been written at all — which made a delivered prompt and
+    // a lost one indistinguishable after the fact. Only large writes are
+    // logged: keystrokes would drown the log, and size is what the
+    // truncation bug turned on.
+    if (data.length >= LOGGED_WRITE_BYTES) {
+      this.opts.log?.("pty", `wrote ${data.length} bytes to ${key}`)
+    }
     try {
       session.proc?.write(data)
-    } catch {
-      // A terminal stream error is not proof the subprocess exited. Bun's
-      // `proc.exited` promise below is the single source of truth.
+    } catch (error) {
+      // Still not fatal — a terminal stream error is not proof the subprocess
+      // exited, and `proc.exited` remains the single source of truth for that.
+      // But swallowing it SILENTLY made a failed write indistinguishable from
+      // a successful one all the way up to the API's `delivered: true`, so it
+      // gets a log line even though it does not change control flow.
+      this.opts.log?.("pty", `write failed on ${key} (${data.length} bytes): ${String(error)}`)
     }
   }
 

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -128,6 +128,8 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     engineReady: delivered.engineReady,
     session: delivered.session,
     delivered: delivered.delivered,
+    ...(delivered.bytes === undefined ? {} : { bytes: delivered.bytes }),
+    ...(delivered.promptEcho ? { promptEcho: delivered.promptEcho } : {}),
     ...(delivered.deferred ? { deferred: delivered.deferred } : {}),
   }
 }

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -18,6 +18,7 @@ import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from ".
 import {
   ComposerBusyError,
   type HostedSessionRpc,
+  type PromptWriteOutcome,
   deliverToHostedKey,
   ensureHostedSessionHost,
   findHostedEngineKey,
@@ -114,6 +115,27 @@ export const deliverToKey = deliverToHostedKey
 const writePrompt = writeHostedPromptIfClear
 
 /**
+ * Turn an observed write into the API's outcome fields. One place so every
+ * delivery path reports the same measured facts instead of each inventing
+ * its own optimistic defaults — which is how `delivered: true` came to mean
+ * "we called write()" on one path and "we checked" on another.
+ */
+function outcomeFields(outcome: PromptWriteOutcome | null): {
+  engineReady: boolean
+  delivered: boolean
+  bytes?: number
+  promptEcho?: "confirmed" | "unconfirmed"
+} {
+  if (!outcome) return { engineReady: false, delivered: false }
+  return {
+    engineReady: outcome.ready,
+    delivered: true,
+    bytes: outcome.bytes,
+    promptEcho: outcome.confirmed ? "confirmed" : "unconfirmed",
+  }
+}
+
+/**
  * Deliver to an existing hosted engine tab, or — ONLY when the task has no
  * alive session at all — create the canonical one with the explicit prompt
  * already embedded in its launch argv (avoids racing a paste against a cold
@@ -165,20 +187,14 @@ export async function deliverHostedPrompt(
     // exact-delta restore state as a side effect.
     const deliveryOpts = { screenManifest: resolveComposerManifest(opts?.vendor) }
     const tabId = existingKey.split("::")[1] ?? "tab-1"
-    let delivered: boolean
+    let outcome: PromptWriteOutcome | null
     try {
-      delivered = await deliverToKey(rpc, existingKey, prompt, deliveryOpts)
+      outcome = await deliverToKey(rpc, existingKey, prompt, deliveryOpts)
     } catch (err) {
       if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, target.id, tabId, prompt)
       throw err
     }
-    return {
-      session: existingKey,
-      pane: existingKey,
-      started: false,
-      engineReady: delivered,
-      delivered,
-    }
+    return { session: existingKey, pane: existingKey, started: false, ...outcomeFields(outcome) }
   }
 
   // No engine resolved. Spawning is legitimate ONLY when the task has no
@@ -231,9 +247,9 @@ export async function deliverHostedPrompt(
     // not a delivered prompt.
     if (launch.firstMessage) {
       const tabId = launch.key.split("::")[1] ?? "tab-1"
-      let delivered: boolean
+      let outcome: PromptWriteOutcome | null
       try {
-        delivered = await pastePromptWhenEngineUp(rpc, launch.key, target.engineBin, launch.firstMessage, {
+        outcome = await pastePromptWhenEngineUp(rpc, launch.key, target.engineBin, launch.firstMessage, {
           initMarkerPath: launch.initMarkerPath,
           initTimeoutMs: launch.initTimeoutMs,
           screenManifest: resolveComposerManifest(opts?.vendor),
@@ -246,30 +262,39 @@ export async function deliverHostedPrompt(
         session: launch.key,
         pane: launch.key,
         started: open.created !== false || open.respawned === true,
-        engineReady: delivered,
-        delivered,
+        ...outcomeFields(outcome),
       }
     }
     // Another API process may win the create race after our pty.list. Its
     // launch spec wins, so ours did not carry this prompt; deliver it now.
     // A RESPAWNED restored corpse is the opposite: our launch DID run (the
     // prompt rode its argv), so pasting here would deliver it twice.
+    const started = open.created !== false || open.respawned === true
     if (open.created === false && open.respawned !== true) {
       const tabId = launch.key.split("::")[1] ?? "tab-1"
+      let outcome: PromptWriteOutcome | null
       try {
-        await writePrompt(rpc, launch.key, prompt, { screenManifest: resolveComposerManifest(opts?.vendor) })
+        outcome = await writePrompt(rpc, launch.key, prompt, {
+          screenManifest: resolveComposerManifest(opts?.vendor),
+        })
       } catch (err) {
         if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, target.id, tabId, prompt)
         throw err
       }
+      return { session: launch.key, pane: launch.key, started, ...outcomeFields(outcome) }
     }
-    const delivered = true
+    // OUR launch carried the prompt in its argv, so no paste happened here.
+    // The engine receives the prompt from its own command line — a delivery
+    // this code never observed, and must not claim to have confirmed. It
+    // used to hardcode `delivered = true` (and copy that into engineReady),
+    // which is how a task that received nothing still reported a clean
+    // success on all three fields.
     return {
       session: launch.key,
       pane: launch.key,
-      started: open.created !== false || open.respawned === true,
-      engineReady: delivered,
-      delivered,
+      started,
+      engineReady: open.alive,
+      delivered: true,
     }
   } finally {
     await rpc.request("pty.detach", { key: launch.key }).catch(() => {})
@@ -319,14 +344,14 @@ export async function deliverToExactTab(
   }
   // No pty.detach — see deliverHostedPrompt's existing-key path.
   const deliveryOpts = { screenManifest: resolveComposerManifest(opts?.vendor) }
-  let delivered: boolean
+  let outcome: PromptWriteOutcome | null
   try {
-    delivered = await deliverToKey(rpc, key, prompt, deliveryOpts)
+    outcome = await deliverToKey(rpc, key, prompt, deliveryOpts)
   } catch (err) {
     if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, taskId, tabId, prompt)
     throw err
   }
-  return { session: key, pane: key, started: false, engineReady: delivered, delivered }
+  return { session: key, pane: key, started: false, ...outcomeFields(outcome) }
 }
 
 function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | undefined {

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -118,7 +118,11 @@ async function deliverHosted(
         defer,
       },
     )
-    if (result.started && !result.engineReady) {
+    // `started && !delivered` is the real failure: the session was created but
+    // the prompt never reached it. `engineReady` no longer stands in for that
+    // — it is now an independent readiness observation, and an engine that
+    // never announced bracketed paste can still have been written to.
+    if (result.started && !result.delivered && !result.deferred) {
       throw new ApiError(`failed to start hosted engine session for ${target.id}`, "SESSION_FAILED")
     }
     // Make the session visible to the sidebar tree, which lists a worktree's

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -132,15 +132,45 @@ export interface PromptTarget {
 export interface DeliveredPrompt {
   readonly session: string
   readonly pane: string
+  /** A NEW session was created by this call (never "delivered into one"). */
   readonly started: boolean
+  /**
+   * The engine had its tty in raw mode and was READING when we wrote —
+   * observed via DECSET 2004 in the session ring, not inferred from the
+   * process table. This is the field that decides whether a large prompt
+   * can survive: a write before this is true is silently truncated to the
+   * tty's 1024-byte canonical buffer.
+   *
+   * It used to be a literal copy of {@link delivered}, which made it a
+   * second voice repeating one guess rather than an independent signal.
+   */
   readonly engineReady: boolean
   /**
-   * Whether the paste was CONFIRMED in the engine's composer (its tail
-   * appeared on capture). `false` on a cold boot where the pane never
-   * settled — surfaced so a scripted parallel round's dropped first prompt never
-   * looks like a clean success.
+   * The prompt was written to the engine's pty AFTER it was confirmed
+   * reading. This is a real observation now — previously the spawn path
+   * hardcoded `true` without checking anything.
+   *
+   * It does NOT promise the engine's composer rendered the text; that is
+   * {@link promptEcho}. Delivery is byte-level truth, echo is UI-level
+   * truth, and they are reported separately because an engine may accept a
+   * prompt perfectly while showing only a `[Pasted text #1]` placeholder.
    */
   readonly delivered: boolean
+  /**
+   * Bytes handed to the pty for this prompt (including the bracketed-paste
+   * wrapper when one was used). Present whenever a write was attempted;
+   * pairs with the daemon's `pty` log line for after-the-fact auditing.
+   */
+  readonly bytes?: number
+  /**
+   * Whether the prompt's tail was seen echoed back on capture — the capture
+   * confirmation `delivered` used to claim in its docs but never performed.
+   *
+   * `"confirmed"` is positive proof. `"unconfirmed"` is INCONCLUSIVE, not
+   * failure: engines that collapse a big paste into a placeholder never echo
+   * the text. Absent when no write was attempted.
+   */
+  readonly promptEcho?: "confirmed" | "unconfirmed"
   /**
    * Present when the delivery gate found the composer busy and the prompt was
    * accepted-but-deferred rather than dropped (issue #78 B-layer): the daemon

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -93,10 +93,11 @@ export async function startTaskSessionWithPromptAdapter(
     // lands means the prompt was not delivered — report false.
     if (launch.firstMessage) {
       const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor, effort: task.modelEffort })[0]
-      return await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage, {
+      const outcome = await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage, {
         initMarkerPath: launch.initMarkerPath,
         initTimeoutMs: launch.initTimeoutMs,
       })
+      return outcome !== null
     }
     return true
   } finally {
@@ -149,8 +150,7 @@ export async function deliverPromptToLiveEngineAdapter(
     const key = findHostedEngineKey(sessions, task.id, engineBin)
     if (!key) return false
     const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
-    const delivered = await deliverToHostedKey(host.rpc, key, prompt, { screenManifest: manifest })
-    return delivered
+    return (await deliverToHostedKey(host.rpc, key, prompt, { screenManifest: manifest })) !== null
   } catch (err) {
     // Composer-busy is not a silent failure: let the quota-resume runner log
     // it instead of dropping the prompt without a trace.

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -10,6 +10,7 @@ import { readPersistedTerminalDefaultColors } from "../tui/lib/terminal-colors.t
 import { BUILTIN_VENDORS } from "../types/vendor.ts"
 import { isComposerEmpty } from "./composer-state.ts"
 import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
+import { PASTE_READY_POLL_MS, PASTE_READY_TIMEOUT_MS, bracketedPasteActive, encodePaste } from "./paste-readiness.ts"
 import { engineEntry } from "./registry.ts"
 import type { EngineScreenManifest } from "./screen-state.ts"
 import { type EngineSessionLaunch, REPO_INIT_TIMEOUT_SECONDS } from "./session-launch.ts"
@@ -161,6 +162,8 @@ export interface HostedPromptDeliveryOpts {
   readonly humanWriteQuietMs?: number
   /** Test seam for `Date.now()`. */
   readonly now?: () => number
+  /** Override for the paste-readiness wait (ms). Tests shorten it. */
+  readonly pasteReadyTimeoutMs?: number
 }
 
 function recentHumanWriteBlocks(peek: PtyPeekResult, opts: HostedPromptDeliveryOpts, now: number): boolean {
@@ -186,23 +189,143 @@ async function assertComposerClear(peek: PtyPeekResult, key: string, opts?: Host
   }
 }
 
+/**
+ * What one prompt write actually did. `delivered` is the honest answer to
+ * "did this reach the engine", and it is now OBSERVED rather than assumed:
+ * every field below is measured, not defaulted to true.
+ */
+export interface PromptWriteOutcome {
+  /** Bytes handed to the pty (prompt plus any bracketed-paste wrapper). */
+  readonly bytes: number
+  /** The engine had bracketed paste on, i.e. it was reading its tty. */
+  readonly ready: boolean
+  /** The engine echoed the prompt's tail back — the only positive proof it
+   *  landed. `false` means unconfirmed, NOT necessarily lost. */
+  readonly confirmed: boolean
+}
+
+/** Trailing slice of the prompt used as the echo marker. Long enough not to
+ *  collide with ordinary UI chrome, short enough to survive the composer's
+ *  own wrapping and truncation. */
+const CONFIRM_TAIL_CHARS = 24
+
+/** Poll budget for the echo check — the composer redraw follows the write
+ *  within a frame or two; this is slack, not a wait we expect to use. */
+const CONFIRM_TIMEOUT_MS = 2_000
+const CONFIRM_POLL_MS = 100
+
+/** Collapse whitespace so a tail that the composer soft-wrapped across two
+ *  rows still matches the single-line prompt text it came from. */
+function flatten(text: string): string {
+  return text.replace(/\s+/g, " ")
+}
+
+/**
+ * Look for the prompt's tail in everything the engine emitted since
+ * `sinceOffset`. Confirms delivery the way the `delivered` contract always
+ * claimed to — by capture, not by assumption.
+ *
+ * KNOWN CEILING, and the reason `confirmed: false` is reported rather than
+ * treated as failure: an engine may not echo the text at all. Claude Code
+ * collapses a large paste to a `[Pasted text #1]` placeholder, so a big
+ * prompt that arrived perfectly still fails this check. That makes a
+ * positive a proof and a negative merely inconclusive — which is exactly how
+ * the caller reports it.
+ */
+async function confirmPromptLanded(
+  rpc: HostedSessionRpc,
+  key: string,
+  prompt: string,
+  sinceOffset: number,
+): Promise<boolean> {
+  const tail = flatten(prompt).trim().slice(-CONFIRM_TAIL_CHARS)
+  if (tail.length === 0) return false
+  const deadline = Date.now() + CONFIRM_TIMEOUT_MS
+  for (;;) {
+    const peek = await rpc.request<PtyPeekResult>("pty.peek", { key, sinceOffset })
+    if (!peek.alive) return false
+    if (flatten(Buffer.from(peek.data, "base64").toString("utf8")).includes(tail)) return true
+    if (Date.now() >= deadline) return false
+    await new Promise((resolve) => setTimeout(resolve, CONFIRM_POLL_MS))
+  }
+}
+
+/** Wait for readiness, write, then check the echo — the whole delivery in
+ *  one place so every caller reports the same observed facts. */
+async function writeAndConfirm(
+  rpc: HostedSessionRpc,
+  key: string,
+  prompt: string,
+  sinceOffset: number,
+  opts?: HostedPromptDeliveryOpts,
+): Promise<PromptWriteOutcome> {
+  const ready = await awaitPasteReady(rpc, key, { timeoutMs: opts?.pasteReadyTimeoutMs })
+  const bytes = await writeHostedPrompt(rpc, key, prompt, { ready })
+  const confirmed = await confirmPromptLanded(rpc, key, prompt, sinceOffset)
+  return { bytes, ready, confirmed }
+}
+
 export async function writeHostedPromptIfClear(
   rpc: HostedSessionRpc,
   key: string,
   prompt: string,
   opts?: HostedPromptDeliveryOpts,
-): Promise<void> {
+): Promise<PromptWriteOutcome | null> {
   const peek = await rpc.request<PtyPeekResult>("pty.peek", { key })
-  if (!peek.alive) return
+  if (!peek.alive) return null
   await assertComposerClear(peek, key, opts)
-  await writeHostedPrompt(rpc, key, prompt)
+  return writeAndConfirm(rpc, key, prompt, peek.offset, opts)
 }
 
-/** Bracketed-paste the prompt, wait, then submit — the pty twin of `pasteAndSubmit`. */
-export async function writeHostedPrompt(rpc: HostedSessionRpc, key: string, prompt: string): Promise<void> {
-  await rpc.request("pty.write", { key, data: `\x1b[200~${prompt}\x1b[201~` })
+/**
+ * Wait until the engine has taken its pty into raw mode and started reading,
+ * reported by DECSET 2004 in the ring (see `paste-readiness.ts`). Returns
+ * whether bracketed paste is on — which is BOTH the readiness verdict and
+ * the wrapping decision. `false` means the wait timed out: the caller still
+ * delivers (best effort beats refusing), but sends the prompt bare, exactly
+ * as the interactive backend does for an app that never asked for 2004.
+ */
+export async function awaitPasteReady(
+  rpc: HostedSessionRpc,
+  key: string,
+  opts: { readonly timeoutMs?: number; readonly sleep?: (ms: number) => Promise<void> } = {},
+): Promise<boolean> {
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+  const deadline = Date.now() + (opts.timeoutMs ?? PASTE_READY_TIMEOUT_MS)
+  for (;;) {
+    const peek = await rpc.request<PtyPeekResult>("pty.peek", { key })
+    if (!peek.alive) return false
+    if (bracketedPasteActive(Buffer.from(peek.data, "base64").toString("latin1"))) return true
+    if (Date.now() >= deadline) return false
+    await sleep(PASTE_READY_POLL_MS)
+  }
+}
+
+/**
+ * Paste the prompt, wait, then submit — the pty twin of `pasteAndSubmit`.
+ *
+ * Waits for the engine to be READING before writing a single byte. Skipping
+ * that wait is what silently truncated 8.6KB prompts to their first 1024
+ * bytes: a pty in canonical mode discards past `MAX_INPUT` instead of
+ * blocking, and `pty.write` returns void, so nothing downstream could tell.
+ *
+ * Returns the bytes written, so callers can report what they actually did
+ * rather than assuming. Note this counts bytes HANDED TO the pty; whether
+ * the engine's composer shows them is a separate question that
+ * {@link confirmPromptLanded} answers.
+ */
+export async function writeHostedPrompt(
+  rpc: HostedSessionRpc,
+  key: string,
+  prompt: string,
+  opts?: { readonly ready?: boolean },
+): Promise<number> {
+  const bracketed = opts?.ready ?? (await awaitPasteReady(rpc, key))
+  const data = encodePaste(prompt, bracketed)
+  await rpc.request("pty.write", { key, data })
   await new Promise((resolve) => setTimeout(resolve, SUBMIT_DELAY_MS))
   await rpc.request("pty.write", { key, data: "\r" })
+  return Buffer.byteLength(data, "utf8")
 }
 
 /**
@@ -221,12 +344,11 @@ export async function deliverToHostedKey(
   key: string,
   prompt: string,
   opts?: HostedPromptDeliveryOpts,
-): Promise<boolean> {
+): Promise<PromptWriteOutcome | null> {
   const peek = await rpc.request<PtyPeekResult>("pty.peek", { key })
-  if (!peek.alive) return false
+  if (!peek.alive) return null
   await assertComposerClear(peek, key, opts)
-  await writeHostedPrompt(rpc, key, prompt)
-  return true
+  return writeAndConfirm(rpc, key, prompt, peek.offset, opts)
 }
 
 /** Open or reattach one engine session and immediately release this client.
@@ -251,7 +373,16 @@ export async function ensureHostedEngine(
 /** Bounds for the first-message readiness wait (paste-delivery vendors). */
 export const FIRST_MESSAGE_ENGINE_TIMEOUT_MS = 20_000
 export const FIRST_MESSAGE_POLL_INTERVAL_MS = 500
-/** Post-detection grace so the TUI finishes booting (bracketed-paste mode on). */
+/**
+ * Post-detection grace, kept ONLY as the fallback for an engine that never
+ * announces bracketed paste. The readiness wait (`awaitPasteReady`) is the
+ * real gate now: this sleep was the whole bug. It guessed that 1.5s after
+ * the engine PROCESS appears the engine is reading its tty — but a process
+ * that has forked is not a process that has called `stty raw`, and a write
+ * into that window is discarded past the tty's 1024-byte canonical buffer.
+ * Measured: kimi announces bracketed paste at ~1953ms, i.e. AFTER this
+ * timer fired, which is why kimi was the vendor that lost 8.6KB prompts.
+ */
 export const FIRST_MESSAGE_SETTLE_MS = 1_500
 
 export interface PasteFirstMessageOptions extends HostedPromptDeliveryOpts {
@@ -276,8 +407,8 @@ export interface PasteFirstMessageOptions extends HostedPromptDeliveryOpts {
  * actually up — the same reason `send` into a cold engine embeds nowhere
  * but waits here instead. Polls the session's process tree until an engine
  * child appears (or the session dies / the wait budget runs out), grants a
- * short settle for the TUI to finish initializing, then pastes + submits.
- * Returns whether the paste happened.
+ * waits for it to start READING, then pastes + submits.
+ * Returns what the write observed, or `null` when it never happened.
  */
 export async function pastePromptWhenEngineUp(
   rpc: HostedSessionRpc,
@@ -285,7 +416,7 @@ export async function pastePromptWhenEngineUp(
   engineBin: string | undefined,
   prompt: string,
   opts: PasteFirstMessageOptions = {},
-): Promise<boolean> {
+): Promise<PromptWriteOutcome | null> {
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
   const snapshot = opts.snapshot ?? psSnapshot
 
@@ -298,7 +429,7 @@ export async function pastePromptWhenEngineUp(
     while (Date.now() < initDeadline) {
       const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
       const session = sessions.find((s) => s.key === key)
-      if (!session?.alive) return false
+      if (!session?.alive) return null
       if (existsSync(opts.initMarkerPath)) break
       await sleep(opts.intervalMs ?? FIRST_MESSAGE_POLL_INTERVAL_MS)
     }
@@ -308,7 +439,7 @@ export async function pastePromptWhenEngineUp(
   while (Date.now() < deadline) {
     const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
     const session = sessions.find((s) => s.key === key)
-    if (!session?.alive) return false
+    if (!session?.alive) return null
     if (session.pid) {
       let up = false
       try {
@@ -317,12 +448,16 @@ export async function pastePromptWhenEngineUp(
         up = false // ps hiccup — treat as "not yet", keep polling
       }
       if (up) {
-        await sleep(opts.settleMs ?? FIRST_MESSAGE_SETTLE_MS)
-        await writeHostedPromptIfClear(rpc, key, prompt, opts)
-        return true
+        // The engine process exists; now wait for it to actually be READING
+        // (see `awaitPasteReady`). Only when it never announces bracketed
+        // paste do we fall back to the old blind settle.
+        if (!(await awaitPasteReady(rpc, key, { timeoutMs: opts.pasteReadyTimeoutMs, sleep }))) {
+          await sleep(opts.settleMs ?? FIRST_MESSAGE_SETTLE_MS)
+        }
+        return await writeHostedPromptIfClear(rpc, key, prompt, opts)
       }
     }
     await sleep(opts.intervalMs ?? FIRST_MESSAGE_POLL_INTERVAL_MS)
   }
-  return false
+  return null
 }

--- a/packages/kobe/src/engine/paste-readiness.ts
+++ b/packages/kobe/src/engine/paste-readiness.ts
@@ -1,0 +1,61 @@
+/**
+ * When a hosted engine is actually safe to paste a large prompt into.
+ *
+ * The bug this exists for (9 tasks dispatched with an empty prompt): a cold
+ * engine's pty starts in CANONICAL mode with nothing draining it. The tty's
+ * canonical input buffer is `MAX_INPUT` (1024 bytes on macOS), and a write
+ * past it is DISCARDED, not blocked — so an 8.6KB prompt written into that
+ * window arrives as a 1024-byte prefix and the rest is gone. Measured, not
+ * theorised: a `Bun.spawn` pty whose child had not yet run `stty raw`
+ * received exactly 1024 of 8600 bytes on every run.
+ *
+ * Two things follow, and the second is the one that matters:
+ *
+ *  - Chunking does NOT fix it. 512-byte chunks with a gap between them lost
+ *    exactly the same 1024 bytes — the buffer is never drained, so slower
+ *    writing just refills a full buffer. The old plan of "write in chunks"
+ *    would have shipped a no-op.
+ *  - Once the engine is in RAW mode and reading, a single write is safe at
+ *    any size we care about — 8.6KB, 64KB, 256KB and 1MB all arrived whole.
+ *
+ * So the fix is not how we write, it is WHEN. `\x1b[?2004h` (DECSET 2004,
+ * bracketed paste on) is emitted by an engine only after it has taken the
+ * terminal into raw mode and started reading stdin, which makes it a direct
+ * observation of "this process is draining its tty" rather than a guess.
+ * Measured against the three real engines: claude 258ms, codex 321ms, kimi
+ * 1953ms — kimi lands AFTER the old hardcoded 1500ms settle, which is
+ * exactly why kimi was the vendor that lost prompts.
+ *
+ * It doubles as the bracketed-paste contract the interactive path already
+ * honours (`pty-xterm-base.paste`): wrapping in `\x1b[200~ … \x1b[201~` is
+ * only correct once the app has ASKED for it.
+ */
+
+/** DECSET 2004 set — the engine turned bracketed paste on. */
+const BRACKETED_PASTE_ON = "\x1b[?2004h"
+/** DECSET 2004 reset — emitted while a full-screen app is suspended. */
+const BRACKETED_PASTE_OFF = "\x1b[?2004l"
+
+/** Longest observed real-engine time to bracketed paste is ~2s (kimi); this
+ *  leaves generous room for a loaded machine before we fall back. */
+export const PASTE_READY_TIMEOUT_MS = 15_000
+/** Ring poll interval while waiting for the mode announcement. */
+export const PASTE_READY_POLL_MS = 100
+
+/**
+ * Whether `output` leaves the engine in bracketed-paste mode — the LAST
+ * 2004h/2004l wins, so an engine that turned it on at boot and off again
+ * (suspended into a pager/editor) correctly reads as not-ready.
+ */
+export function bracketedPasteActive(output: string): boolean {
+  const on = output.lastIndexOf(BRACKETED_PASTE_ON)
+  if (on === -1) return false
+  return on > output.lastIndexOf(BRACKETED_PASTE_OFF)
+}
+
+/** Wrap `prompt` for an engine that asked for bracketed paste; send it bare
+ *  otherwise. Mirrors the interactive backend's conditional wrapping — an
+ *  engine that never enabled DECSET 2004 would render `\x1b[200~` as text. */
+export function encodePaste(prompt: string, bracketed: boolean): string {
+  return bracketed ? `\x1b[200~${prompt}\x1b[201~` : prompt
+}

--- a/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
+++ b/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
@@ -38,7 +38,7 @@ export async function insertDeferredPrompt(args: {
     const key = `${args.taskId}::${args.tabId}`
     let delivered: boolean
     try {
-      delivered = await deliverToHostedKey(host.rpc, key, args.prompt, { screenManifest: args.manifest })
+      delivered = (await deliverToHostedKey(host.rpc, key, args.prompt, { screenManifest: args.manifest })) !== null
     } catch (err) {
       if (err instanceof ComposerBusyError) return "deferred-again"
       throw err

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -1,21 +1,12 @@
 /**
- * `pty-delivery.ts` — the hosted-backend engine-key resolver and bracketed
- * paste that `kobe api` delivery routes through. The load-bearing bit is
- * `findEngineKey`: it MUST resolve the engine tab (never a shell tab) and
- * MUST return null when a task has no engine — that null is what stops
- * delivery from double-opening a second engine in the same worktree.
+ * `pty-delivery.ts` — the bracketed paste that `kobe api` delivery routes
+ * through. The engine-key resolver's own tests live in
+ * `pty-engine-key.test.ts`.
  */
 
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
 import { describe, expect, it } from "vitest"
-import {
-  deliverHostedPrompt,
-  deliverToExactTab,
-  deliverToKey,
-  findEngineKey,
-  isTaskKey,
-  taskKeys,
-} from "../../src/cli/api/pty-delivery.ts"
+import { deliverHostedPrompt, deliverToExactTab, deliverToKey } from "../../src/cli/api/pty-delivery.ts"
 import { ApiError } from "../../src/cli/api/types.ts"
 
 function session(key: string, command: string[], alive = true): PtySessionInfo {
@@ -52,113 +43,6 @@ function echoingPeek(): { seen: () => string; onWrite: (data: string) => void; p
     peek: () => readyPeek(buffer),
   }
 }
-
-describe("findEngineKey", () => {
-  it("① picks the deterministic <taskId>::tab-1 engine", () => {
-    const sessions = [session("t1::tab-1", ["claude"])]
-    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-1")
-  })
-
-  it("② with tab-1 engine + tab-2 shell, picks tab-1 (never the shell)", () => {
-    const sessions = [session("t1::tab-1", ["claude"]), session("t1::tab-2", ["/bin/zsh"])]
-    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-1")
-  })
-
-  it("③ no engine tab → null (caller must NOT double-open)", () => {
-    // Only a shell tab, and tab-1 absent: there is no engine to deliver into.
-    const sessions = [session("t1::tab-2", ["/bin/zsh"])]
-    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
-  })
-
-  it("falls back to an argv match when tab-1 is renumbered/absent", () => {
-    // No tab-1, but a session whose command is the vendor's engine binary.
-    const sessions = [session("t1::tab-5", ["codex"]), session("t1::tab-2", ["/bin/bash"])]
-    expect(findEngineKey(sessions, "t1", "codex")).toBe("t1::tab-5")
-  })
-
-  it("resolves a SHELL-WRAPPED engine tab when tab-1 is absent (issue #19)", () => {
-    // Every hosted session launches via `<shell> -ilc '…<engine> …'`
-    // (buildEngineSessionLaunch), so command[0] is NEVER the engine binary.
-    // The old `command[0] === engineBin` fallback was dead code in
-    // production: this surviving engine tab resolved to null and delivery
-    // silently spawned a duplicate engine.
-    const sessions = [
-      session("t1::tab-1", ["/bin/zsh", "-ilc", "export KOBE_TASK_ID='t1'\nclaude 'hi'"], false),
-      session("t1::tab-2", ["/bin/zsh", "-ilc", "export KOBE_TASK_ID='t1' KOBE_TAB_ID='tab-2'\nclaude '--resume' 'x'"]),
-    ]
-    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-2")
-  })
-
-  it("a shell-wrapped SHELL tab still never matches", () => {
-    const sessions = [session("t1::tab-2", ["/bin/zsh", "-il"])]
-    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
-  })
-
-  it("skips a DEAD tab-1 (an exited engine cannot receive a prompt)", () => {
-    const sessions = [session("t1::tab-1", ["claude"], false)]
-    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
-  })
-
-  it("ignores other tasks' sessions", () => {
-    const sessions = [session("t2::tab-1", ["claude"])]
-    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
-  })
-
-  it("without engineBin, still resolves tab-1 (liveness/teardown path)", () => {
-    const sessions = [session("t1::tab-1", ["claude"])]
-    expect(findEngineKey(sessions, "t1")).toBe("t1::tab-1")
-  })
-
-  it("resolves a live engine tab whose binary is NOT the task's vendor (issue #36)", () => {
-    // The reported shape: a long-lived task pinned to the custom preset
-    // `claudecpa` (a zsh wrapper) whose tab-1 is long gone and whose only
-    // live tabs launch plain `claude`. engineBin is `claudecpa`, so the
-    // vendor-strict argv match found nothing and bare send refused with
-    // NO_ENGINE_TAB — while the delivery gate accepts ANY live engine.
-    const sessions = [
-      session("t1::tab-22", ["/bin/zsh", "-ilc", "export KOBE_TAB_ID='tab-22'\nclaude --session-id bf09"]),
-    ]
-    expect(findEngineKey(sessions, "t1", "claudecpa")).toBe("t1::tab-22")
-  })
-
-  it("prefers the task's OWN vendor tab over another engine's tab", () => {
-    const sessions = [
-      session("t1::tab-3", ["/bin/zsh", "-ilc", "codex"]),
-      session("t1::tab-9", ["/bin/zsh", "-ilc", "claude"]),
-    ]
-    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-9")
-  })
-
-  it("picks the LOWEST-numbered engine tab so a bare send is deterministic", () => {
-    const sessions = [
-      session("t1::tab-28", ["/bin/zsh", "-ilc", "claude"]),
-      session("t1::tab-22", ["/bin/zsh", "-ilc", "claude"]),
-    ]
-    expect(findEngineKey(sessions, "t1", "claudecpa")).toBe("t1::tab-22")
-  })
-
-  it("a live SHELL-only tab is still not an engine (no cross-vendor false positive)", () => {
-    const sessions = [session("t1::tab-4", ["/bin/zsh", "-il"])]
-    expect(findEngineKey(sessions, "t1", "claudecpa")).toBeNull()
-  })
-})
-
-describe("isTaskKey / taskKeys", () => {
-  it("matches the segment before the first ::", () => {
-    expect(isTaskKey("t1::tab-1", "t1")).toBe(true)
-    expect(isTaskKey("t1", "t1")).toBe(true)
-    expect(isTaskKey("t10::tab-1", "t1")).toBe(false)
-  })
-
-  it("taskKeys returns every key for the task (alive or not — teardown)", () => {
-    const sessions = [
-      session("t1::tab-1", ["claude"]),
-      session("t1::tab-2", ["/bin/zsh"], false),
-      session("t2::tab-1", ["claude"]),
-    ]
-    expect(taskKeys(sessions, "t1")).toEqual(["t1::tab-1", "t1::tab-2"])
-  })
-})
 
 describe("deliverToKey", () => {
   function recorder() {

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -27,6 +27,32 @@ function psWith(child: string): () => Promise<string> {
   return async () => `123 1 -zsh\n456 123 ${child}\n`
 }
 
+/**
+ * A `pty.peek` reply from an engine that has announced bracketed paste, i.e.
+ * one that is in raw mode and READING. Delivery now waits for exactly this
+ * before writing — a prompt written into the pre-raw window is truncated at
+ * the tty's 1024-byte canonical buffer (see `pty-large-prompt.test.ts`).
+ */
+function readyPeek(echo = ""): { exists: boolean; alive: boolean; data: string; offset: number } {
+  return { exists: true, alive: true, data: Buffer.from(`\x1b[?2004h${echo}`).toString("base64"), offset: 0 }
+}
+
+/**
+ * A fake engine that echoes what it was written, the way a real composer
+ * redraws pasted text. Delivery confirms the prompt's tail on capture, so a
+ * fake that stayed silent would poll until its confirm budget expired.
+ */
+function echoingPeek(): { seen: () => string; onWrite: (data: string) => void; peek: () => unknown } {
+  let buffer = ""
+  return {
+    seen: () => buffer,
+    onWrite: (data: string) => {
+      buffer += data
+    },
+    peek: () => readyPeek(buffer),
+  }
+}
+
 describe("findEngineKey", () => {
   it("① picks the deterministic <taskId>::tab-1 engine", () => {
     const sessions = [session("t1::tab-1", ["claude"])]
@@ -137,10 +163,12 @@ describe("isTaskKey / taskKeys", () => {
 describe("deliverToKey", () => {
   function recorder() {
     const calls: Array<{ name: string; payload: unknown }> = []
+    const engine = echoingPeek()
     const rpc = {
       request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push({ name, payload })
-        if (name === "pty.peek") return { exists: true, alive: true, data: "" } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
         return {} as T
       },
     }
@@ -150,15 +178,18 @@ describe("deliverToKey", () => {
   it("peeks (never attaches/resizes) then writes bracketed prompt + deferred CR", async () => {
     const { rpc, calls } = recorder()
     const ok = await deliverToKey(rpc, "t1::tab-1", "do the thing")
-    expect(ok).toBe(true)
+    // The outcome is OBSERVED now, not assumed: it carries the byte count,
+    // the readiness verdict, and whether the tail was echoed back.
+    expect(ok).toMatchObject({ ready: true, confirmed: true })
     // pty.peek, NOT pty.open: an open would last-attach-wins resize the
     // live session away from its attached TUI (issue #18) — delivery must
     // be indistinguishable from keyboard input (pure pty.write).
-    expect(calls.map((c) => c.name)).toEqual(["pty.peek", "pty.write", "pty.write"])
+    // Peeks (gate, readiness, confirm) then two writes — still no open/resize.
+    expect(calls.map((c) => c.name)).toEqual(["pty.peek", "pty.peek", "pty.write", "pty.write", "pty.peek"])
     expect(calls[0].payload).toEqual({ key: "t1::tab-1" })
     // Bracketed paste markers wrap the prompt; the CR is a SEPARATE write.
-    expect(calls[1].payload).toEqual({ key: "t1::tab-1", data: "\x1b[200~do the thing\x1b[201~" })
-    expect(calls[2].payload).toEqual({ key: "t1::tab-1", data: "\r" })
+    expect(calls[2].payload).toEqual({ key: "t1::tab-1", data: "\x1b[200~do the thing\x1b[201~" })
+    expect(calls[3].payload).toEqual({ key: "t1::tab-1", data: "\r" })
   })
 
   it("returns false without writing when the session is dead", async () => {
@@ -166,11 +197,11 @@ describe("deliverToKey", () => {
     const rpc = {
       request: async <T>(name: string): Promise<T> => {
         calls.push({ name })
-        if (name === "pty.peek") return { exists: true, alive: false } as T
+        if (name === "pty.peek") return { exists: true, alive: false, data: "", offset: 0 } as T
         return {} as T
       },
     }
-    expect(await deliverToKey(rpc, "t1::tab-1", "x")).toBe(false)
+    expect(await deliverToKey(rpc, "t1::tab-1", "x")).toBeNull()
     expect(calls.map((c) => c.name)).toEqual(["pty.peek"]) // no write into a dead pty
   })
 })
@@ -209,12 +240,14 @@ describe("deliverHostedPrompt", () => {
 
   it("delivers once when another caller wins the create race", async () => {
     const calls: Array<{ name: string; payload: unknown }> = []
+    const engine = echoingPeek()
     const rpc = {
       request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push({ name, payload })
         if (name === "pty.list") return { sessions: [] } as T
         if (name === "pty.open") return { replay: "", alive: true, created: false } as T
-        if (name === "pty.peek") return { exists: true, alive: true, data: "" } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
         return {} as T
       },
     }
@@ -228,20 +261,24 @@ describe("deliverHostedPrompt", () => {
       "pty.list",
       "pty.open",
       "pty.peek",
+      "pty.peek",
       "pty.write",
       "pty.write",
+      "pty.peek",
       "pty.detach",
     ])
-    expect(result).toMatchObject({ started: false, delivered: true })
+    expect(result).toMatchObject({ started: false, delivered: true, promptEcho: "confirmed" })
   })
 
   it("delivers into an existing engine when the foreground gate sees the engine process", async () => {
     const calls: string[] = []
+    const engine = echoingPeek()
     const rpc = {
-      request: async <T>(name: string): Promise<T> => {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push(name)
         if (name === "pty.list") return { sessions: [session("t1::tab-1", ["claude"])] } as T
-        if (name === "pty.peek") return { exists: true, alive: true, data: "" } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
         return {} as T
       },
     }
@@ -262,8 +299,9 @@ describe("deliverHostedPrompt", () => {
     // Pre-fix this spawned a fresh unsandboxed engine at launch.key and
     // returned ok while tab-2 never saw the prompt.
     const calls: string[] = []
+    const engine = echoingPeek()
     const rpc = {
-      request: async <T>(name: string): Promise<T> => {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push(name)
         if (name === "pty.list")
           return {
@@ -272,7 +310,8 @@ describe("deliverHostedPrompt", () => {
               session("t1::tab-2", ["/bin/zsh", "-ilc", "claude '--resume' 'x'"]),
             ],
           } as T
-        if (name === "pty.peek") return { exists: true, alive: true, data: "" } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
         return {} as T
       },
     }
@@ -293,8 +332,9 @@ describe("deliverHostedPrompt", () => {
     // brand-new engine at tab-1 and reported ok — sender and receiver both
     // believed the message arrived. It must be a typed error instead.
     const calls: string[] = []
+    const engine = echoingPeek()
     const rpc = {
-      request: async <T>(name: string): Promise<T> => {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push(name)
         if (name === "pty.list") return { sessions: [session("t1::tab-2", ["/bin/zsh", "-il"])] } as T
         return {} as T
@@ -320,14 +360,16 @@ describe("deliverHostedPrompt", () => {
     // preset. Pre-fix the resolver returned null and this threw
     // NO_ENGINE_TAB with the engine sitting right there.
     const calls: string[] = []
+    const engine = echoingPeek()
     const rpc = {
-      request: async <T>(name: string): Promise<T> => {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push(name)
         if (name === "pty.list")
           return {
             sessions: [session("t1::tab-22", ["/bin/zsh", "-ilc", "export KOBE_TAB_ID='tab-22'\nclaude"])],
           } as T
-        if (name === "pty.peek") return { exists: true, alive: true, data: "" } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
         return {} as T
       },
     }
@@ -415,11 +457,13 @@ describe("deliverHostedPrompt", () => {
 describe("deliverToExactTab", () => {
   function rpcWith(sessions: PtySessionInfo[]) {
     const calls: string[] = []
+    const engine = echoingPeek()
     const rpc = {
-      request: async <T>(name: string): Promise<T> => {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push(name)
         if (name === "pty.list") return { sessions } as T
-        if (name === "pty.peek") return { exists: true, alive: true, data: "" } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
         return {} as T
       },
     }

--- a/packages/kobe/test/cli/pty-engine-key.test.ts
+++ b/packages/kobe/test/cli/pty-engine-key.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `pty-delivery.ts`'s engine-key RESOLVER — the pure half, split from the
+ * delivery tests in `pty-delivery.test.ts` to stay under the file-size cap.
+ *
+ * The load-bearing bit is `findEngineKey`: it MUST resolve the engine tab
+ * (never a shell tab) and MUST return null when a task has no engine — that
+ * null is what stops delivery from double-opening a second engine in the
+ * same worktree.
+ */
+
+import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { describe, expect, it } from "vitest"
+import { findEngineKey, isTaskKey, taskKeys } from "../../src/cli/api/pty-delivery.ts"
+
+function session(key: string, command: string[], alive = true): PtySessionInfo {
+  return { key, alive, pid: alive ? 123 : null, command, title: "" }
+}
+
+/** A ps snapshot in which pid 123 (the session shell) hosts `child`. */
+function psWith(child: string): () => Promise<string> {
+  return async () => `123 1 -zsh\n456 123 ${child}\n`
+}
+
+/**
+ * A `pty.peek` reply from an engine that has announced bracketed paste, i.e.
+ * one that is in raw mode and READING. Delivery now waits for exactly this
+ * before writing — a prompt written into the pre-raw window is truncated at
+ * the tty's 1024-byte canonical buffer (see `pty-large-prompt.test.ts`).
+ */
+function readyPeek(echo = ""): { exists: boolean; alive: boolean; data: string; offset: number } {
+  return { exists: true, alive: true, data: Buffer.from(`\x1b[?2004h${echo}`).toString("base64"), offset: 0 }
+}
+
+/**
+ * A fake engine that echoes what it was written, the way a real composer
+ * redraws pasted text. Delivery confirms the prompt's tail on capture, so a
+ * fake that stayed silent would poll until its confirm budget expired.
+ */
+function echoingPeek(): { seen: () => string; onWrite: (data: string) => void; peek: () => unknown } {
+  let buffer = ""
+  return {
+    seen: () => buffer,
+    onWrite: (data: string) => {
+      buffer += data
+    },
+    peek: () => readyPeek(buffer),
+  }
+}
+
+describe("findEngineKey", () => {
+  it("① picks the deterministic <taskId>::tab-1 engine", () => {
+    const sessions = [session("t1::tab-1", ["claude"])]
+    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-1")
+  })
+
+  it("② with tab-1 engine + tab-2 shell, picks tab-1 (never the shell)", () => {
+    const sessions = [session("t1::tab-1", ["claude"]), session("t1::tab-2", ["/bin/zsh"])]
+    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-1")
+  })
+
+  it("③ no engine tab → null (caller must NOT double-open)", () => {
+    // Only a shell tab, and tab-1 absent: there is no engine to deliver into.
+    const sessions = [session("t1::tab-2", ["/bin/zsh"])]
+    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
+  })
+
+  it("falls back to an argv match when tab-1 is renumbered/absent", () => {
+    // No tab-1, but a session whose command is the vendor's engine binary.
+    const sessions = [session("t1::tab-5", ["codex"]), session("t1::tab-2", ["/bin/bash"])]
+    expect(findEngineKey(sessions, "t1", "codex")).toBe("t1::tab-5")
+  })
+
+  it("resolves a SHELL-WRAPPED engine tab when tab-1 is absent (issue #19)", () => {
+    // Every hosted session launches via `<shell> -ilc '…<engine> …'`
+    // (buildEngineSessionLaunch), so command[0] is NEVER the engine binary.
+    // The old `command[0] === engineBin` fallback was dead code in
+    // production: this surviving engine tab resolved to null and delivery
+    // silently spawned a duplicate engine.
+    const sessions = [
+      session("t1::tab-1", ["/bin/zsh", "-ilc", "export KOBE_TASK_ID='t1'\nclaude 'hi'"], false),
+      session("t1::tab-2", ["/bin/zsh", "-ilc", "export KOBE_TASK_ID='t1' KOBE_TAB_ID='tab-2'\nclaude '--resume' 'x'"]),
+    ]
+    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-2")
+  })
+
+  it("a shell-wrapped SHELL tab still never matches", () => {
+    const sessions = [session("t1::tab-2", ["/bin/zsh", "-il"])]
+    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
+  })
+
+  it("skips a DEAD tab-1 (an exited engine cannot receive a prompt)", () => {
+    const sessions = [session("t1::tab-1", ["claude"], false)]
+    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
+  })
+
+  it("ignores other tasks' sessions", () => {
+    const sessions = [session("t2::tab-1", ["claude"])]
+    expect(findEngineKey(sessions, "t1", "claude")).toBeNull()
+  })
+
+  it("without engineBin, still resolves tab-1 (liveness/teardown path)", () => {
+    const sessions = [session("t1::tab-1", ["claude"])]
+    expect(findEngineKey(sessions, "t1")).toBe("t1::tab-1")
+  })
+
+  it("resolves a live engine tab whose binary is NOT the task's vendor (issue #36)", () => {
+    // The reported shape: a long-lived task pinned to the custom preset
+    // `claudecpa` (a zsh wrapper) whose tab-1 is long gone and whose only
+    // live tabs launch plain `claude`. engineBin is `claudecpa`, so the
+    // vendor-strict argv match found nothing and bare send refused with
+    // NO_ENGINE_TAB — while the delivery gate accepts ANY live engine.
+    const sessions = [
+      session("t1::tab-22", ["/bin/zsh", "-ilc", "export KOBE_TAB_ID='tab-22'\nclaude --session-id bf09"]),
+    ]
+    expect(findEngineKey(sessions, "t1", "claudecpa")).toBe("t1::tab-22")
+  })
+
+  it("prefers the task's OWN vendor tab over another engine's tab", () => {
+    const sessions = [
+      session("t1::tab-3", ["/bin/zsh", "-ilc", "codex"]),
+      session("t1::tab-9", ["/bin/zsh", "-ilc", "claude"]),
+    ]
+    expect(findEngineKey(sessions, "t1", "claude")).toBe("t1::tab-9")
+  })
+
+  it("picks the LOWEST-numbered engine tab so a bare send is deterministic", () => {
+    const sessions = [
+      session("t1::tab-28", ["/bin/zsh", "-ilc", "claude"]),
+      session("t1::tab-22", ["/bin/zsh", "-ilc", "claude"]),
+    ]
+    expect(findEngineKey(sessions, "t1", "claudecpa")).toBe("t1::tab-22")
+  })
+
+  it("a live SHELL-only tab is still not an engine (no cross-vendor false positive)", () => {
+    const sessions = [session("t1::tab-4", ["/bin/zsh", "-il"])]
+    expect(findEngineKey(sessions, "t1", "claudecpa")).toBeNull()
+  })
+})
+
+describe("isTaskKey / taskKeys", () => {
+  it("matches the segment before the first ::", () => {
+    expect(isTaskKey("t1::tab-1", "t1")).toBe(true)
+    expect(isTaskKey("t1", "t1")).toBe(true)
+    expect(isTaskKey("t10::tab-1", "t1")).toBe(false)
+  })
+
+  it("taskKeys returns every key for the task (alive or not — teardown)", () => {
+    const sessions = [
+      session("t1::tab-1", ["claude"]),
+      session("t1::tab-2", ["/bin/zsh"], false),
+      session("t2::tab-1", ["claude"]),
+    ]
+    expect(taskKeys(sessions, "t1")).toEqual(["t1::tab-1", "t1::tab-2"])
+  })
+})

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -86,10 +86,21 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
 
   it("waits for the engine process, then bracketed-pastes and submits the prompt", async () => {
     const writes: unknown[] = []
+    let written = ""
     const request = vi.fn().mockImplementation((name: string, payload: unknown) => {
       if (name === "pty.list") return Promise.resolve({ sessions: [session("task-a::tab-1")] })
-      if (name === "pty.peek") return Promise.resolve({ exists: true, alive: true, data: "" })
+      // A READY engine: bracketed paste announced (raw mode, reading) and
+      // the prompt echoed back, so both the readiness wait and the capture
+      // confirmation settle immediately.
+      if (name === "pty.peek")
+        return Promise.resolve({
+          exists: true,
+          alive: true,
+          offset: 0,
+          data: Buffer.from(`\x1b[?2004h${written}`).toString("base64"),
+        })
       if (name === "pty.write") {
+        written += (payload as { data?: string })?.data ?? ""
         writes.push(payload)
         return Promise.resolve({})
       }
@@ -102,7 +113,7 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
       sleep: noSleep,
     })
 
-    expect(delivered).toBe(true)
+    expect(delivered).not.toBeNull()
     expect(writes).toEqual([
       { key: "task-a::tab-1", data: "\x1b[200~fix it\x1b[201~" },
       { key: "task-a::tab-1", data: "\r" },
@@ -118,7 +129,7 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
       sleep: noSleep,
     })
 
-    expect(delivered).toBe(false)
+    expect(delivered).toBeNull()
     expect(request).not.toHaveBeenCalledWith("pty.write", expect.anything())
   })
 
@@ -132,14 +143,30 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
       sleep: noSleep,
     })
 
-    expect(delivered).toBe(false)
+    expect(delivered).toBeNull()
     expect(request).not.toHaveBeenCalledWith("pty.write", expect.anything())
   })
 
   it("waits for the init marker before budgeting engine-startup time (issue #73)", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-hosted-init-marker-"))
     const marker = path.join(tmp, "marker")
-    const request = vi.fn().mockResolvedValue({ sessions: [session("task-a::tab-1")] })
+    let written = ""
+    const request = vi.fn().mockImplementation((name: string, payload: unknown) => {
+      // A ready engine (bracketed paste on) that echoes what it is written,
+      // so the readiness wait and the capture confirmation both settle.
+      if (name === "pty.peek")
+        return Promise.resolve({
+          exists: true,
+          alive: true,
+          offset: 0,
+          data: Buffer.from(`\x1b[?2004h${written}`).toString("base64"),
+        })
+      if (name === "pty.write") {
+        written += (payload as { data?: string })?.data ?? ""
+        return Promise.resolve({})
+      }
+      return Promise.resolve({ sessions: [session("task-a::tab-1")] })
+    })
     const rpc: HostedSessionRpc = { request }
 
     let engineChecked = false
@@ -162,7 +189,7 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
       snapshot,
     })
 
-    expect(delivered).toBe(true)
+    expect(delivered).not.toBeNull()
     expect(markerChecked).toBe(true)
     expect(engineChecked).toBe(true)
     expect(snapshot).toHaveBeenCalled()
@@ -181,7 +208,7 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
       sleep: noSleep,
     })
 
-    expect(delivered).toBe(false)
+    expect(delivered).toBeNull()
     fs.rmSync(tmp, { recursive: true, force: true })
   })
 })
@@ -190,15 +217,29 @@ describe("deliverToHostedKey A+C gates (issue #78)", () => {
   function rpcWith(
     peek: Partial<{ alive: boolean; data: string; lastHumanWriteMs: number; humanWriteQuietMs: number }>,
   ) {
+    let written = ""
     return {
-      request: async <T>(name: string): Promise<T> => {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
+        if (name === "pty.write") {
+          written += (payload as { data?: string })?.data ?? ""
+          return {} as T
+        }
         if (name === "pty.peek") {
           return {
             exists: true,
             alive: peek.alive !== false,
             pid: 42,
             offset: 0,
-            data: peek.data ?? "",
+            // `pty.peek` returns BASE64, so the fake must encode too: the
+            // readiness check decodes before looking for DECSET 2004.
+            // Prefixed with 2004h so readiness passes and suffixed with the
+            // echo so the capture confirmation does — the gates under test
+            // here are the human-write and composer-empty ones.
+            data: Buffer.concat([
+              Buffer.from("\x1b[?2004h"),
+              Buffer.from(peek.data ?? "", "base64"),
+              Buffer.from(written),
+            ]).toString("base64"),
             sinceValid: false,
             exit: null,
             ...(peek.lastHumanWriteMs !== undefined ? { lastHumanWriteMs: peek.lastHumanWriteMs } : {}),
@@ -241,20 +282,25 @@ describe("deliverToHostedKey A+C gates (issue #78)", () => {
 
   it("delivers when both gates pass", async () => {
     const writes: string[] = []
+    let written = ""
     const rpc = {
-      request: async <T>(name: string): Promise<T> => {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
         if (name === "pty.peek") {
           return {
             exists: true,
             alive: true,
             pid: 42,
             offset: 0,
-            data: Buffer.from("❯", "utf8").toString("base64"),
+            // DECSET 2004 (engine is reading) + the empty-composer glyph +
+            // whatever it has been written, so readiness and the capture
+            // confirmation both settle on the first poll.
+            data: Buffer.from(`\x1b[?2004h❯${written}`, "utf8").toString("base64"),
             sinceValid: false,
             exit: null,
           } as T
         }
         if (name === "pty.write") {
+          written += (payload as { data?: string })?.data ?? ""
           writes.push(name)
           return {} as T
         }
@@ -262,7 +308,8 @@ describe("deliverToHostedKey A+C gates (issue #78)", () => {
       },
     }
     const ok = await deliverToHostedKey(rpc as HostedSessionRpc, "t1::tab-1", "go", { screenManifest: manifest })
-    expect(ok).toBe(true)
+    // An observed outcome now, not a bare boolean.
+    expect(ok).toMatchObject({ ready: true, confirmed: true })
     expect(writes).toEqual(["pty.write", "pty.write"])
   })
 })

--- a/packages/kobe/test/render/pty-delivery-size.test.ts
+++ b/packages/kobe/test/render/pty-delivery-size.test.ts
@@ -77,8 +77,14 @@ describe("prompt delivery vs pane size (issue #18)", () => {
     expect(open.alive).toBe(true)
 
     // A peer `kobe api send` lands through the real delivery helper.
-    const delivered = await deliverToHostedKey(deliveryRpc(host), "t1::tab-1", "true")
-    expect(delivered).toBe(true)
+    // `/bin/sh` never announces DECSET 2004, so this also pins the fallback:
+    // the readiness wait times out, delivery still happens, and it reports
+    // `ready: false` rather than pretending the engine was confirmed reading.
+    const delivered = await deliverToHostedKey(deliveryRpc(host), "t1::tab-1", "true", {
+      pasteReadyTimeoutMs: 200,
+    })
+    expect(delivered).not.toBeNull()
+    expect(delivered?.ready).toBe(false)
     // The bracketed-pasted prompt reached the child (pty echoes it back).
     await until(() => dataText(frames).includes("true"))
 
@@ -94,7 +100,7 @@ describe("prompt delivery vs pane size (issue #18)", () => {
     host.open("t1::tab-1", { cwd: process.cwd(), command: ["/bin/sh"], cols: 120, rows: 10 }, {}, sink)
     host.write("t1::tab-1", "exit\n")
     await until(() => host.peek("t1::tab-1").alive === false)
-    expect(await deliverToHostedKey(deliveryRpc(host), "t1::tab-1", "true")).toBe(false)
+    expect(await deliverToHostedKey(deliveryRpc(host), "t1::tab-1", "true", { pasteReadyTimeoutMs: 200 })).toBeNull()
   })
 
   test("a SIZED reattach still resizes (tmux last-attach-wins is preserved)", async () => {

--- a/packages/kobe/test/render/pty-large-prompt.test.ts
+++ b/packages/kobe/test/render/pty-large-prompt.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The 8.6KB-prompt truncation bug: `rove api add/send` reported
+ * `delivered: true` while the engine received nothing (9 tasks dispatched
+ * empty in one afternoon).
+ *
+ * ROOT CAUSE, measured here rather than argued: a cold engine's pty is in
+ * CANONICAL mode until the engine calls `stty raw` and starts reading. The
+ * tty's canonical input buffer is `MAX_INPUT` — 1024 bytes on macOS — and a
+ * write past it is DISCARDED, not blocked. `pty.write` returns void, so the
+ * loss was invisible at every layer above it.
+ *
+ * The failure signature is a TRUNCATED PREFIX, not a total drop, which is
+ * why the control test below asserts the received bytes are a prefix of the
+ * prompt: 1024 of 8600 arriving is kernel-queue overflow, whereas 0 would
+ * have been a different bug entirely.
+ *
+ * These run against a REAL Bun PTY child, not a mock — a mocked pty has no
+ * kernel input queue and cannot reproduce this at all. The child is `sh`
+ * scripted to behave like an engine (stay canonical, then `stty raw`,
+ * announce bracketed paste, drain stdin to a file) so the test owns timing
+ * a real engine only offers by luck. Real-engine measurements behind the
+ * numbers: claude announces DECSET 2004 at ~258ms, codex ~321ms, kimi
+ * ~1953ms — kimi lands AFTER the old hardcoded 1500ms settle, which is
+ * exactly why kimi was the vendor that lost prompts.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { PtyHost } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { type HostedSessionRpc, awaitPasteReady, writeHostedPrompt } from "../../src/engine/hosted-session.ts"
+
+const hosts: PtyHost[] = []
+const dirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(hosts.splice(0).map((host) => host.killAll()))
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+function scratch(): string {
+  const dir = mkdtempSync(join(tmpdir(), "rove-large-prompt-"))
+  dirs.push(dir)
+  return dir
+}
+
+/** Delivery's view of the host: peek + write only, like production. */
+function deliveryRpc(host: PtyHost): HostedSessionRpc {
+  return {
+    request: async <T>(name: string, payload?: unknown): Promise<T> => {
+      const p = payload as { key: string; data?: string; sinceOffset?: number }
+      if (name === "pty.peek") return host.peek(p.key, p.sinceOffset) as T
+      if (name === "pty.write") {
+        host.write(p.key, p.data ?? "")
+        return {} as T
+      }
+      throw new Error(`delivery used forbidden rpc: ${name}`)
+    },
+  }
+}
+
+/**
+ * A stand-in engine: stays canonical for `coldMs`, then goes raw, announces
+ * bracketed paste, and drains stdin into `sink`. That canonical head is the
+ * window that ate the prompts.
+ */
+function spawnFakeEngine(host: PtyHost, key: string, sink: string, coldMs: number): void {
+  host.open(
+    key,
+    {
+      cwd: "/tmp",
+      command: ["/bin/sh", "-c", `sleep ${coldMs / 1000}; stty raw -echo; printf '\\033[?2004h'; cat > ${sink}`],
+      cols: 120,
+      rows: 30,
+    },
+    {},
+    () => {},
+  )
+}
+
+/** Bytes the child received, minus the paste wrapper and the submit CR. */
+function received(sink: string): string {
+  const raw = readFileSync(sink, "utf8")
+  return raw.replaceAll("\x1b[200~", "").replaceAll("\x1b[201~", "").replace(/\r$/, "")
+}
+
+function settle(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** 8.6KB — the incident's size, with a unique tail so a truncated prefix is
+ *  distinguishable from a whole delivery. */
+const BIG_PROMPT = `analyze this repo. ${"padding words to reach the incident size. ".repeat(210)}TAIL-MARKER-7Q`
+
+describe("large prompt delivery into a cold engine", () => {
+  test("the prompt arrives WHOLE, tail included", async () => {
+    expect(Buffer.byteLength(BIG_PROMPT)).toBeGreaterThan(8_000)
+    const host = new PtyHost({})
+    hosts.push(host)
+    const sink = join(scratch(), "got.txt")
+    // Cold for 1.6s: past the old hardcoded 1500ms settle, like kimi.
+    spawnFakeEngine(host, "t1::tab-1", sink, 1_600)
+
+    const bytes = await writeHostedPrompt(deliveryRpc(host), "t1::tab-1", BIG_PROMPT)
+    await settle(1_500)
+
+    const got = received(sink)
+    expect(got.length).toBe(BIG_PROMPT.length)
+    expect(got).toBe(BIG_PROMPT)
+    expect(got.endsWith("TAIL-MARKER-7Q")).toBe(true)
+    expect(bytes).toBeGreaterThan(8_000)
+  }, 30_000)
+
+  test("readiness is observed, not slept for: it waits past a 1500ms-style settle", async () => {
+    const host = new PtyHost({})
+    hosts.push(host)
+    const sink = join(scratch(), "ready.txt")
+    spawnFakeEngine(host, "t2::tab-1", sink, 1_800)
+
+    const start = Date.now()
+    const ready = await awaitPasteReady(deliveryRpc(host), "t2::tab-1", { timeoutMs: 10_000 })
+    const waited = Date.now() - start
+
+    expect(ready).toBe(true)
+    // The old code wrote at ~1500ms and lost the prompt; this must not.
+    expect(waited).toBeGreaterThan(1_500)
+  }, 30_000)
+
+  test("writing into the canonical window truncates at the tty buffer (the bug)", async () => {
+    const host = new PtyHost({})
+    hosts.push(host)
+    const sink = join(scratch(), "lost.txt")
+    spawnFakeEngine(host, "t3::tab-1", sink, 1_600)
+
+    // Reproduce the OLD behaviour exactly: write immediately, no readiness
+    // wait. The control that proves the fix is what does the work.
+    await settle(200)
+    host.write("t3::tab-1", `\x1b[200~${BIG_PROMPT}\x1b[201~`)
+    await settle(2_500)
+
+    const got = received(sink)
+    expect(got.length).toBeLessThan(BIG_PROMPT.length)
+    expect(got.endsWith("TAIL-MARKER-7Q")).toBe(false)
+    // A truncated PREFIX, not a total drop — the kernel-queue signature.
+    expect(got.length).toBeGreaterThan(0)
+    expect(BIG_PROMPT.startsWith(got.slice(0, 200))).toBe(true)
+  }, 30_000)
+})


### PR DESCRIPTION
## The bug

`rove api add/send` reported `{started: true, engineReady: true, delivered: true}` while the engine received nothing. Nine tasks were dispatched with an empty prompt in one afternoon.

## Root cause

A cold engine's pty is in **canonical mode** until the engine calls `stty raw` and starts reading. The tty's canonical input buffer is `MAX_INPUT` — **1024 bytes on macOS** — and a write past it is **discarded, not blocked**. `pty.write` returns `void`, so the loss was invisible at every layer above it.

### Observed failure mode: **truncated prefix**, not a total drop

Measured against a real Bun PTY, 8600-byte payload:

| Scenario | Received |
|---|---|
| Child not yet reading (canonical) | **1024 / 8600** |
| Child in raw mode, reading | 8600 / 8600 |
| Raw mode, 64KB / 256KB / 1MB single write | all whole |

The follow-up `send`s that also "vanished" were the same window, not poisoning: a truncated bracketed paste does **not** break later writes (verified — subsequent sends arrive intact).

### Chunking would have been a no-op

The obvious fix — write in bounded chunks with a gap — was measured and **does not work**:

| Write strategy into the canonical window | Received |
|---|---|
| single 8600-byte write | 1024 |
| 512-byte chunks, 1ms gaps | **1024** |

The buffer is never drained, so writing slower just refills a full buffer. The problem is not *how* we write, it's *when*.

## The fix: wait for the engine to be reading

`\x1b[?2004h` (DECSET 2004) is emitted only after an engine takes the terminal into raw mode and starts reading stdin — a direct observation rather than a guess. Measured against the three real engines:

| Engine | Announces bracketed paste at |
|---|---|
| claude | 258 ms |
| codex | 321 ms |
| kimi | **1953 ms** |

The old code slept a hardcoded `FIRST_MESSAGE_SETTLE_MS = 1_500` after seeing the engine *process*. **kimi announces after that timer fires** — which is precisely why kimi was the vendor losing prompts. A forked process is not a process that has called `stty raw`.

This also fixes the contract violation: `writeHostedPrompt` wrapped in `\x1b[200~…\x1b[201~` unconditionally, while the interactive path (`pty-xterm-base.paste`) correctly wraps only when the app asked for it. Both now honour the same rule.

## Honest signals

| Field | Was | Now |
|---|---|---|
| `started` | unchanged | a new session was created |
| `engineReady` | literal copy of `delivered` | the engine was confirmed **reading** when we wrote |
| `delivered` | hardcoded `true` on the spawn path | the prompt was written after readiness |
| `bytes` | — | bytes handed to the pty |
| `promptEcho` | — | `confirmed` / `unconfirmed` — the capture check the docs promised |

The `delivered` doc-comment promised a capture confirmation that **did not exist anywhere in the codebase**. It exists now as `promptEcho`, reported separately because it has a real ceiling: Claude Code collapses a large paste to `[Pasted text #1]` and never echoes the text, so a positive is proof while a negative is only inconclusive. Conflating the two would have re-created the original sin in the other direction.

`pty-host.write`'s `catch {}` now logs instead of swallowing silently, and writes ≥1024 bytes get a `daemon.log` line (`wrote N bytes to <key>`) — previously there was no record that a prompt had been written at all.

## Verification

**Live A/B on a real `claude` engine**, same 8666-byte prompt, same session:

- old behaviour (write at +1500ms, no readiness wait) → tail marker echoed: **false**
- new behaviour → tail marker echoed: **true** (readiness observed at 150 ms after the trust dialog cleared)

**Test** — `packages/kobe/test/render/pty-large-prompt.test.ts`, three cases against a **real Bun PTY** (a mocked pty has no kernel input queue and cannot reproduce this at all):

```
bun test test/render/pty-large-prompt.test.ts
```

1. an 8.6KB prompt arrives whole, tail included
2. readiness is observed, not slept for — it waits past 1500 ms
3. **control:** writing into the canonical window truncates, and the received bytes are a *prefix* of the prompt (the kernel-queue signature)

**Mutation verified twice, re-run after rebase onto 0.9.34:**

- remove the readiness wait → `Expected: 8853, Received: 1018` (the production signature)
- make the readiness detector always return true → 2 tests red

Full suites green on the rebased base: fast 3741, socket 626, render 274.

## Answers to the five judgment calls

1. **`delivered` — real confirmation or honest weak signal?** Both, split apart. `delivered` is now a true byte-level observation (written after confirmed readiness); the UI-level capture check ships as `promptEcho`. Cost was low — the ring peek already existed. They stay separate because echo has a real ceiling (placeholder rendering) and folding it into `delivered` would make a successful delivery report failure.
2. **`engineReady` — keep or delete?** Kept, with a real meaning. Not a breaking change: the only non-test reader was `runtime.ts`'s `started && !engineReady` throw, which was really asking "was it delivered" and now checks `delivered`.
3. **Chunk size / drain strategy** — none, and that is the finding. Chunking is measurably a no-op here; a single write in raw mode is safe to at least 1MB. Shipping chunking would have looked like a fix and changed nothing.
4. **Readiness probe** — DECSET 2004. All three engines emit it, it is a direct "I am reading" signal rather than a timer, and it doubles as the bracketed-paste wrapping decision. Falls back to the old settle if an engine never announces.
5. **Bracketed paste conditional?** Yes — same rule as the interactive path.

Scope held to the delivery chain; the CLI-surface findings were left alone as instructed.
