### PR TITLE
perf: stop spawning a process on every Bash call for a dead hook

### DIFF
--- a/.changeset/retire-worktree-watch-hook.md
+++ b/.changeset/retire-worktree-watch-hook.md
@@ -1,0 +1,20 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop spawning a process on every Bash call for a hook that did nothing.
+
+Rove installed a global `PostToolUse` (Bash) observer into `~/.claude/settings.json`
+that ran `rove hook worktree-created` after **every Bash call in every Claude
+session on the machine**. Its only job was to archive the task pinned to a
+removed worktree — and archive was removed in issue #75, so the hook had done
+nothing for a while. It still paid a full process spawn each time: ~170ms
+measured, against ~30ms for bare `node -e ''`.
+
+The hook is no longer installed, and it is now **uninstalled on every launch**,
+so users who already have the entry stop paying for it without doing anything.
+The removal touches only Rove's own group — hooks other tools registered under
+`PostToolUse`, your own hooks, and every other key in the file are preserved,
+including in hand-edited settings files. It is idempotent: when there is nothing
+to remove the file is not rewritten. The bundled Claude Code plugin drops the
+same hook from its `hooks.json`.

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -109,17 +109,6 @@
           }
         ]
       }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"${CLAUDE_PLUGIN_ROOT}/bin/rove\" hook worktree-created"
-          }
-        ]
-      }
     ]
   }
 }

--- a/docs/design/cli-api.md
+++ b/docs/design/cli-api.md
@@ -113,7 +113,7 @@ don't trip parsers.
 - `wait` / blocking poll: the skill teaches `sleep + get-task` loops
   rather than us implementing a server-side wait. Simpler to debug,
   fewer wedge modes.
-- `archive` / `delete`: hard rule says no deletion from automation.
+- `delete`: hard rule says no deletion from automation.
   Keep destructive ops in the TUI.
 - `interrupt`, `steer`, `permission-mode`, `model` changes: power-user
   TUI flows. Not the agent's job.
@@ -443,8 +443,8 @@ single round-trip. ~15 LOC in `daemon/protocol.ts` + `daemon/server.ts`.
 Option B — fetch `task.list`, filter for the id client-side. Zero
 protocol change, one extra serialization round.
 
-Recommended: **A**. The protocol already has `task.archive`,
-`task.rename`, etc. — a `task.get` belongs in the set. The bridge
+Recommended: **A**. The protocol already has `task.rename`,
+`task.setBranch`, etc. — a `task.get` belongs in the set. The bridge
 RPC already exposes `get_task` directly off the orchestrator, so the
 behavior is exactly what we want.
 

--- a/docs/design/engine-internals.md
+++ b/docs/design/engine-internals.md
@@ -114,20 +114,24 @@ enabled plugin declares a `tool.*` event hook** (`pluginsWantToolEvents` in
 such a plugin takes effect on the next Rove start). The other activity hooks
 are always installed.
 
-### Worktree watch
+### Retired worktree hooks
 
-A global `PostToolUse` (Bash) observer hook reports
-`kobe hook worktree-created` after every Bash call; it no-ops fast unless the
-command was `git worktree remove` (archive the pinned task). It once also
-adopted on `git worktree add`; removed 2026-08-24 — creation is mechanical
-(agents mint worktrees for PR isolation and no engine session ever enters),
-so adoption now requires intent: an engine `session-start` inside a managed
-worktree root, or an explicit adopt (`rove add .` / New task → Adopt
-Worktree). This is a pure *observer*
-fired after the tool runs, unlike the old `WorktreeCreate` *provider* hook
-(0.7.4–0.7.9) whose mere presence broke `claude --worktree` everywhere. Rove
-removes any such legacy hook it ever wrote; `kobe hook setup` survives only
-as a deprecated cleanup no-op.
+Rove installs no worktree hook today. Two were removed, and each launch
+uninstalls both wherever they were written:
+
+- **`PostToolUse` (Bash) watch observer** — fired `kobe hook worktree-created`
+  after every Bash call to archive the task pinned to a removed worktree.
+  Archive was removed (issue #75), leaving a hook that did nothing while still
+  spawning a process — ~170ms per Bash call, in every session on the machine.
+  Retired 2026-08-30; the removal path stays so already-registered users get
+  the entry dropped on their next launch.
+- **`WorktreeCreate` provider hook** (0.7.4–0.7.9) — a *provider* hook, so its
+  mere presence made Claude Code delegate worktree creation to Rove's observer
+  (which returns no path) and broke `claude --worktree` everywhere. `kobe hook
+  setup` survives only as a deprecated cleanup no-op.
+
+Adoption is intent-driven instead: an engine `session-start` inside a managed
+worktree root, or an explicit adopt (`rove add .` / New task → Adopt Worktree).
 
 ### Invocation contract
 

--- a/docs/design/pty-freeze.md
+++ b/docs/design/pty-freeze.md
@@ -33,7 +33,7 @@ tricks — rejected as not worth it, same call as the original daemon doc).
   conversation resume composes with scrollback restore with no TUI change.
   A failed respawn clears `restored` and degrades to the ordinary view-only
   corpse behavior (the one-shot resume guard TUI-side stays the backstop).
-- **Forgetting**: explicit `pty.kill` (tab close, archive sweep) drops the
+- **Forgetting**: explicit `pty.kill` (tab close, task delete) drops the
   record — an intentional end is not a restart casualty. `rove reset`'s
   graceful `daemon.stop` wipes the whole store ("starts fresh"); a bare
   SIGTERM/crash/reboot keeps it.

--- a/packages/kobe-web/README.md
+++ b/packages/kobe-web/README.md
@@ -55,11 +55,11 @@ rove web --port 5180
 ## What it does
 
 - **Left rail** — live tasks from the daemon (sort, filter, `j`/`k` nav, change
-  chips, PR/activity, archived restore). New Task + Adopt-worktree dialogs.
+  chips, PR/activity). New Task + Adopt-worktree dialogs.
 - **Center** — per-task workspace tabs (client-owned, localStorage): engine PTY
   (with a prompt composer + reattach), shell PTY, structured Chat transcript,
   and diff file previews.
-- **Right** — task metadata (rename/branch/status/vendor/pin/archive/delete),
+- **Right** — task metadata (rename/branch/status/vendor/pin/delete),
   a markdown notes scratchpad (with preview), and a live Changes/diff rail.
 - **More** — command palette (Cmd/Ctrl+K), `?` keyboard help, an Overview
   triage route (`/overview`), deep links (`/task/:id`), live theme sync + a

--- a/packages/kobe-web/src/lib/document-title.ts
+++ b/packages/kobe-web/src/lib/document-title.ts
@@ -18,8 +18,7 @@ export const BASE_TITLE = displayProductName()
  * Count of tasks that need a human right now — the Overview "Needs you"
  * bucket (waiting_permission / error / rate_limited). Attention never depends
  * on worktree dirtiness, so changes is intentionally omitted from triage().
- * Archived tasks and `kind: "main"` project rows are not sessions, so they
- * never count.
+ * `kind: "main"` project rows are not sessions, so they never count.
  */
 export function attentionCount(
   tasks: readonly Task[],

--- a/packages/kobe/src/cli/hook-cmd.ts
+++ b/packages/kobe/src/cli/hook-cmd.ts
@@ -198,30 +198,31 @@ function persistedSyncPath(stored: string | undefined): string | undefined {
 }
 
 /**
- * Default-ON global hook install (KOB). Called once per kobe launch. Three
- * pieces, all best-effort and idempotent (the adapter skips the write when
+ * Default-ON global hook sync (KOB). Called once per kobe launch. One install
+ * plus two removals, all best-effort and idempotent (the adapter skips the write when
  * nothing changes):
  *
  *  1. **Activity hooks** — Stop / StopFailure / Notification / Session* into the
  *     user's global `~/.claude/settings.json`, so EVERY Claude session reports
  *     normalized events; the daemon maps each hook's cwd to a task. Always
  *     global (a task's badge must light up wherever its engine runs).
- *  2. **Worktree-watch hook** — a global `PostToolUse` (Bash) observer that
- *     adopts a worktree as a task the MOMENT a `git worktree add` runs in any
- *     session, so it shows in the sidebar WITHOUT a running engine (the
- *     creation-time complement to the `session-start` auto-adopt below). This is
- *     a pure OBSERVER fired AFTER the tool, NOT a provider hook — see (3) for why
- *     that distinction is load-bearing.
+ *  2. **Worktree-watch removal** — earlier Rove installed a global `PostToolUse`
+ *     (Bash) observer firing `kobe hook worktree-created` after every Bash call,
+ *     to archive the task pinned to a removed worktree. Archive was removed
+ *     (issue #75), so the hook became a pure tax: a ~170ms process spawn on
+ *     EVERY Bash call of every session machine-wide, for nothing. It is no
+ *     longer installed, and the removal runs on each launch so users who already
+ *     have the entry get it dropped.
  *  3. **WorktreeCreate cleanup** — earlier kobe (0.7.4–0.7.9) installed a global
  *     `WorktreeCreate` hook for external-worktree sync. That was WRONG:
  *     `WorktreeCreate` is a VCS *provider* hook — its mere presence makes Claude
  *     Code delegate worktree creation to it and skip the native git path, so
  *     kobe's observer hook (which returns no path) BROKE `claude --worktree` /
  *     `EnterWorktree` in every repo. We now remove any such hook we ever wrote.
- *     Creation-time sync is reborn via the `PostToolUse` hook in (2) — safe
- *     because `PostToolUse` only observes, it never provides; plus the daemon's
+ *     Nothing replaces it: worktree adoption is intent-driven — the daemon's
  *     `session-start` auto-adopt (`daemon/cwd-task.ts` `findAdoptableWorktree`)
- *     still catches worktrees first entered by an engine session.
+ *     catches worktrees first entered by an engine session, and `rove add .`
+ *     covers the explicit case.
  *
  * Writing the user's global settings.json is intentionally invasive but
  * acceptable for now (current users are developers).
@@ -258,12 +259,16 @@ export async function ensureGlobalKobeHooks(): Promise<void> {
       const enginePath = a.globalSettingsPath()
       if (!enginePath) continue
       await a.installActivityHooks(enginePath, { toolEvents })
-      // PostToolUse(Bash) observer: a `git worktree remove` in ANY session
-      // removes the worktree's task. Pure observer — unlike the removed
-      // WorktreeCreate provider hook, it can't break `claude --worktree`.
-      await a.installWorktreeWatchHook(enginePath)
+      // Uninstall the RETIRED PostToolUse(Bash) watch hook. It spawned `kobe
+      // hook worktree-created` after EVERY Bash call to archive the task
+      // pinned to a removed worktree; archive was removed (issue #75), so the
+      // hook had nothing left to do but cost a ~170ms process spawn per Bash
+      // call, machine-wide. Running the removal on every launch is how
+      // already-registered users get it dropped — idempotent, merge-safe, and
+      // it touches only Rove's own group.
+      await a.removeWorktreeWatchHook(enginePath)
     }
-    // 2. Remove the removed WorktreeCreate hook wherever it was ever written.
+    // 3. Remove the legacy WorktreeCreate hook wherever it was ever written.
     await cleanupWorktreeSyncHook()
   } catch {
     /* best-effort — never block launch */

--- a/packages/kobe/src/engine/claude-code-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/claude-code-local/hook-adapter.ts
@@ -31,13 +31,12 @@ import { JsonHookAdapter, editJsonSettings } from "../json-hook-adapter.ts"
 import {
   type HookEventSpec,
   buildActivityHooks,
-  buildWorktreeWatchHook,
   isObject,
   mergeActivityHooks as mergeActivityHooksCore,
-  mergeWorktreeWatchHook,
+  removeWorktreeWatchHook,
 } from "../json-hooks.ts"
 
-export { buildWorktreeWatchHook, mergeWorktreeWatchHook }
+export { removeWorktreeWatchHook }
 
 /** Claude Code hook event → normalized kobe verb. The ONE place Claude event
  *  names live. `matcher` narrows which Notification types fire. */

--- a/packages/kobe/src/engine/hook-adapter.ts
+++ b/packages/kobe/src/engine/hook-adapter.ts
@@ -91,19 +91,14 @@ export interface EngineHookAdapter {
   removeWorktreeSyncHook(settingsFilePath: string): Promise<void>
 
   /**
-   * Install the global worktree-WATCH hook: an observer that fires after a
-   * `git worktree remove` in ANY engine session. (It once also adopted on
-   * `add` and archived the task on `remove`; removed 2026-08-24 — creation
-   * is mechanical, adoption needs an engine session-start in a managed root
-   * or an explicit adopt, and archive concept was removed in issue #75.)
-   * Unlike the removed `WorktreeCreate` provider hook, this is a pure
-   * OBSERVER fired AFTER the tool runs (Claude Code's `PostToolUse`), so its
-   * presence never changes git/`--worktree` behaviour. Must be IDEMPOTENT,
-   * merge-safe, and never throw fatally. No-op when {@link supportsHooks}
-   * is false.
+   * Remove the retired worktree-WATCH hook — a global `PostToolUse` (Bash)
+   * observer Rove used to install, which spawned `kobe hook worktree-created`
+   * after EVERY Bash call to archive the task pinned to a removed worktree.
+   * Archive was removed (issue #75), leaving the hook a pure ~170ms-per-Bash-call
+   * tax, so it is no longer installed — only uninstalled, on every launch,
+   * until every user's settings file is clean. Idempotent + merge-safe
+   * (touches only Rove's own group). No-op when {@link supportsHooks} is false.
    */
-  installWorktreeWatchHook(settingsFilePath: string): Promise<void>
-  /** Remove the worktree-watch hook this adapter installed. Idempotent + merge-safe. */
   removeWorktreeWatchHook(settingsFilePath: string): Promise<void>
 }
 
@@ -146,9 +141,6 @@ export class NoopHookAdapter implements EngineHookAdapter {
   }
   async removeWorktreeSyncHook(): Promise<void> {
     /* no-op */
-  }
-  async installWorktreeWatchHook(): Promise<void> {
-    /* no-op until this engine's hook format is implemented */
   }
   async removeWorktreeWatchHook(): Promise<void> {
     /* no-op */

--- a/packages/kobe/src/engine/json-hook-adapter.ts
+++ b/packages/kobe/src/engine/json-hook-adapter.ts
@@ -18,9 +18,9 @@ import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
 import {
   GATED_TOOL_VERBS,
   type HookEventSpec,
+  removeWorktreeWatchHook as dropWorktreeWatchHook,
   isObject,
   mergeActivityHooks,
-  mergeWorktreeWatchHook,
 } from "./json-hooks.ts"
 import { updateSharedJson } from "./shared-config-write.ts"
 
@@ -127,11 +127,7 @@ export abstract class JsonHookAdapter implements EngineHookAdapter {
     await editJsonSettings(settingsFilePath, (cur) => mergeActivityHooks(cur, false, this.eventMap))
   }
 
-  async installWorktreeWatchHook(settingsFilePath: string): Promise<void> {
-    await editJsonSettings(settingsFilePath, (cur) => mergeWorktreeWatchHook(cur, true))
-  }
-
   async removeWorktreeWatchHook(settingsFilePath: string): Promise<void> {
-    await editJsonSettings(settingsFilePath, (cur) => mergeWorktreeWatchHook(cur, false))
+    await editJsonSettings(settingsFilePath, dropWorktreeWatchHook)
   }
 }

--- a/packages/kobe/src/engine/json-hooks.ts
+++ b/packages/kobe/src/engine/json-hooks.ts
@@ -32,13 +32,6 @@ export interface HookEventSpec {
   readonly verb: EngineActivityKind
 }
 
-/** The `PostToolUse` event name + tool matcher both engines use for the
- *  creation-time worktree-watch observer. */
-export const WORKTREE_WATCH_EVENT = "PostToolUse"
-export const WORKTREE_WATCH_MATCHER = "Bash"
-/** Command substring identifying kobe's worktree-watch hook in a settings file. */
-export const WORKTREE_WATCH_MARKER = "worktree-created"
-
 export function isObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v)
 }
@@ -136,20 +129,23 @@ export function mergeActivityHooks(
 }
 
 /**
- * Build kobe's worktree-WATCH hook: a global `PostToolUse` observer scoped to
- * the `Bash` tool. After every Bash call, `kobe hook worktree-created` runs and
- * — only when the command was a `git worktree remove` — observes the removal. (`add` no longer adopts, owner decision 2026-08-24:
- * creation is mechanical, adoption needs an engine session-start or an
- * explicit adopt.) A pure observer (fires AFTER the tool), so its presence
- * never changes git/`--worktree` behaviour.
+ * The `PostToolUse` (Bash) hook Rove used to install: an observer that fired
+ * `kobe hook worktree-created` after EVERY Bash call, machine-wide, to archive
+ * the task pinned to a removed worktree. Archive was removed (issue #75), so
+ * the hook had nothing left to do — it just paid a ~170ms process spawn on
+ * every Bash call of every session. Retired 2026-08-30; these two constants
+ * survive only so {@link removeWorktreeWatchHook} can find and delete the
+ * entries already written into users' settings files.
  */
-export function buildWorktreeWatchHook(inv: readonly string[] = kobeHookInvocation()): Record<string, unknown> {
-  const command = quoteShellArgv([...inv, "hook", WORKTREE_WATCH_MARKER])
-  return { [WORKTREE_WATCH_EVENT]: [{ matcher: WORKTREE_WATCH_MATCHER, hooks: [{ type: "command", command }] }] }
-}
+const RETIRED_WATCH_EVENT = "PostToolUse"
+export const WORKTREE_WATCH_MARKER = "worktree-created"
 
-/** True if a PostToolUse group is kobe's worktree-watch hook. */
-function isKobeWorktreeWatchGroup(group: unknown): boolean {
+/** True if a PostToolUse group is the retired Rove worktree-watch hook.
+ *  Keys on the command substring, so both the quoted (`'hook'
+ *  'worktree-created'`) and legacy unquoted install forms are matched — and
+ *  nothing else in the file is (a user's own PostToolUse hooks, and the hooks
+ *  other tools install, never carry this verb). */
+function isRetiredWatchGroup(group: unknown): boolean {
   if (!isObject(group) || !Array.isArray(group.hooks)) return false
   return group.hooks.some(
     (h) => isObject(h) && typeof h.command === "string" && (h.command as string).includes(WORKTREE_WATCH_MARKER),
@@ -157,22 +153,19 @@ function isKobeWorktreeWatchGroup(group: unknown): boolean {
 }
 
 /**
- * Pure merge: add (`install`) or remove kobe's `PostToolUse` worktree-watch hook
- * in a SHARED settings object, preserving the user's own PostToolUse hooks +
- * every other key. Idempotent + merge-safe (replaces only kobe's group).
+ * Pure merge: drop the retired worktree-watch hook from a SHARED settings
+ * object. Removal-only (there is no install counterpart any more) and
+ * merge-safe: it filters ONLY the groups whose command names Rove's verb, so a
+ * hand-edited settings file keeps the user's own PostToolUse hooks and every
+ * other key untouched. Idempotent — a second pass finds nothing and returns an
+ * equal object, so the write is skipped.
  */
-export function mergeWorktreeWatchHook(
-  current: Record<string, unknown>,
-  install: boolean,
-  inv: readonly string[] = kobeHookInvocation(),
-): Record<string, unknown> {
+export function removeWorktreeWatchHook(current: Record<string, unknown>): Record<string, unknown> {
   const { hooks: rawHooks, ...restSettings } = current
   const hooks: Record<string, unknown> = isObject(rawHooks) ? { ...rawHooks } : {}
-  const key = WORKTREE_WATCH_EVENT
-  const prior = Array.isArray(hooks[key]) ? (hooks[key] as unknown[]) : []
-  const kept = prior.filter((g) => !isKobeWorktreeWatchGroup(g))
-  if (install) kept.push(...(buildWorktreeWatchHook(inv)[key] as unknown[]))
-  if (kept.length > 0) hooks[key] = kept
-  else delete hooks[key]
+  const prior = Array.isArray(hooks[RETIRED_WATCH_EVENT]) ? (hooks[RETIRED_WATCH_EVENT] as unknown[]) : []
+  const kept = prior.filter((g) => !isRetiredWatchGroup(g))
+  if (kept.length > 0) hooks[RETIRED_WATCH_EVENT] = kept
+  else delete hooks[RETIRED_WATCH_EVENT]
   return Object.keys(hooks).length > 0 ? { ...restSettings, hooks } : { ...restSettings }
 }

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -186,12 +186,8 @@ export class KimiHookAdapter implements EngineHookAdapter {
     /* Kimi never installed the legacy WorktreeCreate hook. */
   }
 
-  async installWorktreeWatchHook(): Promise<void> {
-    /* Not wired — see module doc (Bash tool-name matcher unverified). */
-  }
-
   async removeWorktreeWatchHook(): Promise<void> {
-    /* Never installed. */
+    /* Never installed the retired PostToolUse watch hook. */
   }
 }
 

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -67,8 +67,8 @@ export interface LandWorktreeCleanup {
  * Land `task`'s branch (via {@link landTask}) and then run the cleanup: drop
  * the now-landed worktree (on by default), delete the branch after a successful land (both opt-in). The merge has already
  * committed once cleanup runs, so it must stand — a `deleteBranch` failure is
- * best-effort inside `remove`-style deletion, and archiving is a plain store
- * write. Extracted from the orchestrator so `core.ts` stays a thin delegator.
+ * best-effort inside `remove`-style deletion. Extracted from the orchestrator
+ * so `core.ts` stays a thin delegator.
  */
 export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: LandDeps): Promise<LandResult> {
   if (task.kind === "main") throw new Error("landTask: a main task has no branch to land")

--- a/packages/kobe/test/architecture/claude-plugin.test.ts
+++ b/packages/kobe/test/architecture/claude-plugin.test.ts
@@ -19,7 +19,6 @@ import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
 import { CLAUDE_HOOK_EVENT_MAP } from "../../src/engine/claude-code-local/hook-adapter.ts"
-import { WORKTREE_WATCH_EVENT, WORKTREE_WATCH_MARKER, WORKTREE_WATCH_MATCHER } from "../../src/engine/json-hooks.ts"
 
 const ROOT = fileURLToPath(new URL("../../../../", import.meta.url))
 const PLUGIN = join(ROOT, "claude-plugin")
@@ -55,10 +54,12 @@ describe("claude-plugin hooks.json mirrors the Claude hook adapter", () => {
     }
   })
 
-  test("the worktree-watch observer is present with its Bash matcher", () => {
-    const groups = (pluginHooks()[WORKTREE_WATCH_EVENT] ?? []).filter((g) => g.matcher === WORKTREE_WATCH_MATCHER)
-    expect(groups).toHaveLength(1)
-    expect(groups[0].hooks[0].command).toBe(`"\${CLAUDE_PLUGIN_ROOT}/bin/rove" hook ${WORKTREE_WATCH_MARKER}`)
+  // The retired PostToolUse(Bash) observer fired `hook worktree-created` after
+  // EVERY Bash call to archive the task pinned to a removed worktree. Archive
+  // was removed (issue #75), leaving a ~170ms process spawn per Bash call that
+  // did nothing. A plugin install pays that too, so the plugin must not ship it.
+  test("the retired worktree-watch observer is NOT shipped", () => {
+    expect(JSON.stringify(pluginHooks())).not.toContain("worktree-created")
   })
 
   test("no extra events beyond the adapter's map", () => {

--- a/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
+++ b/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
@@ -28,7 +28,6 @@ const mocks = vi.hoisted(() => ({
     sessionFromPayload: vi.fn(() => undefined as unknown),
     globalSettingsPath: vi.fn((): string | null => "/fake/.claude/settings.json"),
     installActivityHooks: vi.fn(),
-    installWorktreeWatchHook: vi.fn(),
     removeActivityHooks: vi.fn(),
     removeWorktreeWatchHook: vi.fn(),
     removeWorktreeSyncHook: vi.fn(),
@@ -85,9 +84,8 @@ beforeEach(() => {
   mocks.adapter.sessionFromPayload.mockClear().mockReturnValue(undefined)
   mocks.adapter.globalSettingsPath.mockClear().mockReturnValue("/fake/.claude/settings.json")
   mocks.adapter.installActivityHooks.mockClear()
-  mocks.adapter.installWorktreeWatchHook.mockClear()
   mocks.adapter.removeActivityHooks.mockClear()
-  mocks.adapter.removeWorktreeWatchHook.mockClear()
+  mocks.adapter.removeWorktreeWatchHook.mockReset()
   mocks.adapter.removeWorktreeSyncHook.mockClear()
   stubStdin({})
 })
@@ -244,14 +242,17 @@ describe("kobe hook setup (deprecated cleanup)", () => {
 })
 
 describe("ensureGlobalKobeHooks (default-ON global install)", () => {
-  it("installs activity + worktree-watch hooks into each engine's own settings file, then cleans the removed WorktreeCreate hook", async () => {
+  it("installs activity hooks into each engine's own settings file, then cleans the removed WorktreeCreate hook", async () => {
     await ensureGlobalKobeHooks()
     // toolEvents:false — no enabled plugin declares a tool.* hook in this
     // test home, so the gated tool family stays out of the engine config.
     expect(mocks.adapter.installActivityHooks).toHaveBeenCalledWith("/fake/.claude/settings.json", {
       toolEvents: false,
     })
-    expect(mocks.adapter.installWorktreeWatchHook).toHaveBeenCalledWith("/fake/.claude/settings.json")
+    // The retired PostToolUse(Bash) watch hook is UNINSTALLED on every launch —
+    // that is how an already-registered user stops paying its per-Bash-call
+    // spawn. Nothing installs it any more.
+    expect(mocks.adapter.removeWorktreeWatchHook).toHaveBeenCalledWith("/fake/.claude/settings.json")
     // The WorktreeCreate provider-hook cleanup runs on every launch.
     expect(mocks.adapter.removeWorktreeSyncHook).toHaveBeenCalledWith(join(homedir(), ".claude", "settings.json"))
     expect(getPersistedString("externalWorktreeSync")).toBe("off")
@@ -261,9 +262,17 @@ describe("ensureGlobalKobeHooks (default-ON global install)", () => {
     mocks.adapter.globalSettingsPath.mockReturnValue(null)
     await ensureGlobalKobeHooks()
     expect(mocks.adapter.installActivityHooks).not.toHaveBeenCalled()
-    expect(mocks.adapter.installWorktreeWatchHook).not.toHaveBeenCalled()
+    expect(mocks.adapter.removeWorktreeWatchHook).not.toHaveBeenCalled()
     // Cleanup still runs — it doesn't depend on the engine settings path.
     expect(mocks.adapter.removeWorktreeSyncHook).toHaveBeenCalled()
+  })
+
+  // A fresh install has no watch hook to remove. The uninstall still runs
+  // (it cannot know in advance) and must be harmless — a failure there would
+  // block the launch of a user who never had the hook at all.
+  it("never throws when the watch-hook uninstall fails on a fresh install", async () => {
+    mocks.adapter.removeWorktreeWatchHook.mockRejectedValue(new Error("ENOENT"))
+    await expect(ensureGlobalKobeHooks()).resolves.toBeUndefined()
   })
 
   it("never throws when an install fails (best-effort, must not block launch)", async () => {

--- a/packages/kobe/test/engine/claude-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/claude-hook-adapter.test.ts
@@ -3,10 +3,9 @@ import {
   ClaudeHookAdapter,
   KOBE_HOOK_EVENTS,
   buildClaudeHooks,
-  buildWorktreeWatchHook,
   mergeActivityHooks,
   mergeWorktreeSyncHook,
-  mergeWorktreeWatchHook,
+  removeWorktreeWatchHook,
 } from "../../src/engine/claude-code-local/hook-adapter.ts"
 
 /**
@@ -217,63 +216,76 @@ describe("mergeWorktreeSyncHook (external worktree sync)", () => {
   })
 })
 
-describe("buildWorktreeWatchHook (creation-time auto-adopt)", () => {
-  const hooks = buildWorktreeWatchHook(["kobe"]) as {
-    PostToolUse: Array<{ matcher?: string; hooks: { command: string }[] }>
+/**
+ * The retired PostToolUse(Bash) observer. Rove installed it into every user's
+ * `~/.claude/settings.json` to archive the task pinned to a removed worktree;
+ * archive was removed (issue #75) and the hook has done nothing since — while
+ * still spawning a ~170ms `kobe hook` process on EVERY Bash call of every
+ * session machine-wide. Nothing installs it now, so these tests cover the only
+ * remaining direction: getting it back OUT of files that already have it,
+ * without disturbing anything the user or another tool put there.
+ */
+describe("removeWorktreeWatchHook (retired PostToolUse observer)", () => {
+  /** What a registered user's settings.json actually holds, verbatim. */
+  const REGISTERED = {
+    matcher: "Bash",
+    hooks: [{ type: "command", command: "'kobe' 'hook' 'worktree-created'" }],
   }
 
-  it("installs a PostToolUse hook scoped to the Bash tool", () => {
-    expect(hooks.PostToolUse).toHaveLength(1)
-    expect(hooks.PostToolUse[0].matcher).toBe("Bash")
+  it("removes the hook from an already-registered user's settings", () => {
+    const out = removeWorktreeWatchHook({ hooks: { PostToolUse: [REGISTERED] } }) as SettingsShape
+    expect(out.hooks).toBeUndefined() // sole entry gone → empty key dropped
   })
 
-  it("points the hook at `kobe hook worktree-created` (shell-quoted argv)", () => {
-    expect(hooks.PostToolUse[0].hooks[0].command).toContain("'hook' 'worktree-created'")
+  it("is a no-op on a fresh install (no hooks at all)", () => {
+    expect(removeWorktreeWatchHook({})).toEqual({})
+    expect(removeWorktreeWatchHook({ model: "opus" })).toEqual({ model: "opus" })
   })
-})
 
-describe("mergeWorktreeWatchHook (PostToolUse observer)", () => {
-  it("adds kobe's Bash hook, preserving the user's other PostToolUse hooks + keys", () => {
-    const userSettings = {
-      hooks: { PostToolUse: [{ matcher: "Edit", hooks: [{ type: "command", command: "user-fmt" }] }] },
+  it("is idempotent — a second pass changes nothing", () => {
+    const once = removeWorktreeWatchHook({ hooks: { PostToolUse: [REGISTERED] } })
+    expect(removeWorktreeWatchHook(once)).toEqual(once)
+  })
+
+  it("leaves OTHER tools' PostToolUse hooks and unrelated keys alone", () => {
+    // A hand-edited settings.json: other tools register Bash PostToolUse hooks
+    // in the same array. Removing ours must not touch theirs.
+    const handEdited = {
+      hooks: {
+        PostToolUse: [
+          { matcher: "Bash", hooks: [{ type: "command", command: "agent-deck hook post-bash" }] },
+          REGISTERED,
+          { matcher: "Edit", hooks: [{ type: "command", command: "user-fmt" }] },
+        ],
+        Stop: [{ hooks: [{ type: "command", command: "claude-pool notify" }] }],
+      },
       model: "opus",
     }
-    const out = mergeWorktreeWatchHook(userSettings, true, ["kobe"]) as SettingsShape
-    expect(out.model).toBe("opus") // untouched
-    const post = out.hooks?.PostToolUse as Array<{ matcher?: string; hooks: { command: string }[] }>
-    expect(post).toHaveLength(2) // user's Edit hook + kobe's Bash hook coexist
-    expect(JSON.stringify(post)).toContain("user-fmt")
-    expect(JSON.stringify(post)).toContain("worktree-created")
+    const out = removeWorktreeWatchHook(handEdited) as SettingsShape
+    expect(out.model).toBe("opus")
+    expect(out.hooks?.Stop).toHaveLength(1)
+    const post = out.hooks?.PostToolUse as unknown[]
+    expect(post).toHaveLength(2)
+    const json = JSON.stringify(post)
+    expect(json).toContain("agent-deck")
+    expect(json).toContain("user-fmt")
+    expect(json).not.toContain("worktree-created")
   })
 
-  it("is idempotent — re-install replaces only kobe's entry, no duplicates", () => {
-    const once = mergeWorktreeWatchHook({}, true, ["kobe"])
-    const twice = mergeWorktreeWatchHook(once, true, ["kobe"]) as SettingsShape
-    expect(twice.hooks?.PostToolUse).toHaveLength(1)
-  })
-
-  it("removes kobe's hook while keeping the user's PostToolUse hooks", () => {
-    const userSettings = {
-      hooks: { PostToolUse: [{ matcher: "Edit", hooks: [{ type: "command", command: "user-fmt" }] }] },
+  it("also matches the legacy unquoted install form", () => {
+    const legacy = {
+      hooks: {
+        PostToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "kobe hook worktree-created" }] }],
+      },
     }
-    const added = mergeWorktreeWatchHook(userSettings, true, ["kobe"]) as SettingsShape
-    expect(added.hooks?.PostToolUse).toHaveLength(2)
-    const removed = mergeWorktreeWatchHook(added, false, ["kobe"]) as SettingsShape
-    expect(removed.hooks?.PostToolUse).toHaveLength(1)
-    expect(JSON.stringify(removed.hooks?.PostToolUse)).toContain("user-fmt")
+    expect(removeWorktreeWatchHook(legacy)).toEqual({})
   })
 
-  it("drops the empty PostToolUse key when only kobe's hook existed", () => {
-    const added = mergeWorktreeWatchHook({}, true, ["kobe"])
-    const removed = mergeWorktreeWatchHook(added, false, ["kobe"]) as SettingsShape
-    expect(removed.hooks).toBeUndefined()
-  })
-
-  it("coexists with activity hooks in one settings file", () => {
-    const withActivity = mergeActivityHooks({}, true, ["kobe"])
-    const both = mergeWorktreeWatchHook(withActivity, true, ["kobe"]) as SettingsShape
-    expect(both.hooks?.Stop).toHaveLength(1)
-    // kobe's tool-post activity group + the worktree-watch observer coexist.
-    expect(both.hooks?.PostToolUse).toHaveLength(2)
+  it("keeps kobe's own activity hooks — only the watch group goes", () => {
+    const withActivity = mergeActivityHooks({}, true, ["kobe"]) as SettingsShape
+    const both = { ...withActivity, hooks: { ...withActivity.hooks, PostToolUse: [REGISTERED] } }
+    const out = removeWorktreeWatchHook(both) as SettingsShape
+    expect(out.hooks?.Stop).toHaveLength(1)
+    expect(out.hooks?.PostToolUse).toBeUndefined()
   })
 })

--- a/packages/kobe/test/engine/codex-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/codex-hook-adapter.test.ts
@@ -79,17 +79,16 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
     await writeFile(file, malformed)
 
     await adapter.installActivityHooks(file)
-    await adapter.installWorktreeWatchHook(file)
+    await adapter.removeWorktreeWatchHook(file)
 
     expect(await readFile(file, "utf8")).toBe(malformed)
   })
 
-  it("installs SessionStart/UserPromptSubmit/Stop + the Bash worktree-watch, preserving the user's hooks", async () => {
+  it("installs SessionStart/UserPromptSubmit/Stop, preserving the user's hooks", async () => {
     // Seed a user-authored hook that must survive kobe's merge.
     await writeFile(file, JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }] } }))
 
     await adapter.installActivityHooks(file)
-    await adapter.installWorktreeWatchHook(file)
 
     const hooks = await readHooks()
     expect(hooks.SessionStart).toBeDefined()
@@ -102,24 +101,48 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
     // kobe's Stop coexists with the user's Stop hook.
     expect(JSON.stringify(hooks.Stop)).toContain("turn-complete")
     expect(JSON.stringify(hooks.Stop)).toContain("user-stop")
-    // Worktree-watch is a PostToolUse(Bash) observer.
-    const post = hooks.PostToolUse as Array<{ matcher?: string }>
-    expect(post[0].matcher).toBe("Bash")
-    expect(JSON.stringify(post)).toContain("worktree-created")
+    // The retired PostToolUse(Bash) watch observer is never installed again.
+    expect(hooks.PostToolUse).toBeUndefined()
   })
 
   it("removal strips kobe's hooks but keeps the user's", async () => {
     await writeFile(file, JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }] } }))
     await adapter.installActivityHooks(file)
-    await adapter.installWorktreeWatchHook(file)
 
     await adapter.removeActivityHooks(file)
-    await adapter.removeWorktreeWatchHook(file)
 
     const hooks = await readHooks()
     expect(JSON.stringify(hooks.Stop)).toContain("user-stop")
     expect(JSON.stringify(hooks.Stop)).not.toContain("turn-complete")
     expect(hooks.SessionStart).toBeUndefined()
-    expect(hooks.PostToolUse).toBeUndefined()
+  })
+
+  // End-to-end uninstall through real file I/O: this is what an upgrading user
+  // gets on their next launch. The retired hook goes; a co-resident hook from
+  // another tool must survive, and a second launch must not churn the file.
+  it("uninstalls an already-registered watch hook, sparing another tool's entry", async () => {
+    await writeFile(
+      file,
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            { matcher: "Bash", hooks: [{ type: "command", command: "'kobe' 'hook' 'worktree-created'" }] },
+            { matcher: "Bash", hooks: [{ type: "command", command: "other-tool post-bash" }] },
+          ],
+        },
+        model: "gpt-5",
+      }),
+    )
+
+    await adapter.removeWorktreeWatchHook(file)
+
+    const after = await readFile(file, "utf8")
+    expect(after).not.toContain("worktree-created")
+    expect(after).toContain("other-tool post-bash")
+    expect(after).toContain("gpt-5")
+
+    // Idempotent: a second launch is a no-op, so the file is not even rewritten.
+    await adapter.removeWorktreeWatchHook(file)
+    expect(await readFile(file, "utf8")).toBe(after)
   })
 })

--- a/packages/kobe/test/engine/hook-adapter.test.ts
+++ b/packages/kobe/test/engine/hook-adapter.test.ts
@@ -43,7 +43,6 @@ describe("NoopHookAdapter", () => {
     await expect(noop.installActivityHooks()).resolves.toBeUndefined()
     await expect(noop.removeActivityHooks()).resolves.toBeUndefined()
     await expect(noop.removeWorktreeSyncHook()).resolves.toBeUndefined()
-    await expect(noop.installWorktreeWatchHook()).resolves.toBeUndefined()
     await expect(noop.removeWorktreeWatchHook()).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
## What

Rove installed a global `PostToolUse` (Bash) observer into `~/.claude/settings.json`:

```json
"PostToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "'kobe' 'hook' 'worktree-created'"}]}]
```

It fired after **every Bash call in every Claude session on the machine**. Its only job was to archive the task pinned to a removed worktree — and archive was removed in #668/issue #75, so the daemon handler and protocol name are already gone. The hook has been reaching a dead end and returning ever since, while still paying a full process spawn each time.

## Measured cost

Installed `rove` 0.9.14, 10 runs, median:

| | wall clock |
|---|---|
| `kobe hook worktree-created` | **~170ms** (min 170, p50 170) |
| same, with a realistic stdin payload | ~200ms |
| `node -e ''` (bare interpreter) | ~30ms |
| `/bin/true` | ~0ms |

So ~140ms of CLI bundle load on top of interpreter startup, on every Bash call. This is the painful end of the range, not a hygiene issue.

## Changes

1. **Never installed again** — `buildWorktreeWatchHook` / the install half of `mergeWorktreeWatchHook` and `installWorktreeWatchHook` are gone from the adapter contract and all three adapters.
2. **Actively uninstalled** — `ensureGlobalKobeHooks` now calls `removeWorktreeWatchHook` on each launch where it used to install. The removal path already existed (it backs `rove hook cleanup`) and is already merge-safe.
3. **Plugin too** — the bundled Claude Code plugin's `hooks.json` drops its `PostToolUse` group; the drift guard now asserts it stays out.
4. **Docs/comments** — `docs/design/engine-internals.md` §Worktree watch rewritten (it still said "archive the pinned task"); `docs/design/cli-api.md` no longer argues from the removed `task.archive` protocol name; four other comments that described archive as live behavior corrected.

## Existing users: uninstalled, not just stopped

I chose to **actively remove** the entry rather than only stopping new registration. The brief said to prefer the conservative option if the deregistration logic were at all uncertain — it isn't:

- The removal code is **not new**. It is the same merge that `rove hook cleanup` has been running.
- Ownership is keyed on the command substring `worktree-created`, which only Rove ever wrote. Another tool's `PostToolUse` (Bash) hook cannot collide.
- Merge-safe and idempotent, both now covered by tests.

Leaving it in place would mean every existing user keeps paying ~170ms per Bash call forever unless they happened to run a cleanup command they have no reason to run.

### Verified on an isolated fixture (not a real settings.json)

Before — our hook alongside two other tools' hooks:

```json
"PostToolUse": [
  { "matcher": "Bash", "hooks": [{ "command": "'kobe' 'hook' 'worktree-created'" }] },
  { "matcher": "Bash", "hooks": [{ "command": "agent-deck hook post-bash" }] },
  { "matcher": "Bash", "hooks": [{ "command": "claude-pool record" }] }
]
```

After one launch:

```json
"PostToolUse": [
  { "matcher": "Bash", "hooks": [{ "command": "agent-deck hook post-bash" }] },
  { "matcher": "Bash", "hooks": [{ "command": "claude-pool record" }] }
]
```

`model`, `enabledPlugins`, and the `Stop` activity hook untouched. A second pass produced a byte-identical file (`IDEMPOTENT: true`) — no rewrite when there is nothing to remove.

## Tests

New/rewritten coverage for the four required cases: **fresh install** (nothing to remove, and a failure there must not block launch), **already-registered user**, **hand-edited settings.json** (other tools' hooks + unrelated keys preserved), and **idempotence** (second pass changes nothing). Plus the legacy unquoted install form, and a real-file-I/O round trip through the codex adapter.

**Mutation verification** — 4 mutants, each red, tree restored byte-identical afterward:

| mutant | result |
|---|---|
| skip the uninstall call | FAIL `hook-cmd-dispatch` |
| removal drops *all* `PostToolUse` groups | FAIL "leaves OTHER tools' hooks alone" (×2 files) |
| leave the empty `PostToolUse` key behind | FAIL 6 tests incl. idempotence |
| plugin re-ships the hook | FAIL drift guard |

## Gates

`lint` / `typecheck` / `test` (3732) / `test:socket` (624) / `bun test test/render` (274) / plugin-sdk (13) all green. kobe-web run separately (not in root gates): 557 tests pass, typecheck at baseline **src 0 / test 9**; its 3 pre-existing biome format failures (`issues.ts`, `markdown.ts`, `settings.ts`) are untouched files.

One flake seen mid-run in `test/tui/terminal-selection-trim.test.ts` under parallel load — passes in isolation and on re-run, unrelated to hooks.

Closing greps re-run **after rebase** (deletion work stays clean through a rebase without conflicting, so the greps are the criterion, not the diff): grep 1 returns CHANGELOG history only; grep 2's remaining hits are history, correct statements that archive is gone, or the new comments here. `docs/design/keybinding-decisions.md` and `task-lifecycle.md` deliberately untouched — those record the removal itself.