### PR TITLE
fix: engines declare their own effort argv and system-prompt protocol

### DIFF
--- a/.changeset/engine-declared-vendor-flags.md
+++ b/.changeset/engine-declared-vendor-flags.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Engines declare their own effort flag and system-prompt protocol, so wrapper and contrib engines stop losing settings silently
+
+Three places accepted an engine's declared capability and then dropped it at launch with no error:
+
+- **Reasoning effort was hardcoded to codex.** The gate that validated a level read `effortLevels` off the registry, but the argv that carried it was `if (vendor === "codex")`. An engine declaring `effortLevels` had its level accepted, shown in the TUI and web pickers, and threaded through `/api/engines` — then discarded at spawn, so the user picked "high" and got the default. Engines now declare `effortArgv` alongside `effortLevels`, the same way they already declare `resumeArgv` and `forkArgv`.
+- **Both `--append-system-prompt` injections keyed off the literal id `claude`.** A custom preset declaring the claude protocol (a `claudecpa`-style wrapper) got no status protocol — so its card never moved to `in_review` under `experimental.autoStatus` — and no field notes. Both now resolve the preset's protocol, the same fix session ids and forking already received.
+- **The web fallback engine list still named only Claude and Codex.** Before `/api/engines` answers, the vendor picker offered two of the four built-ins with no other way to reach Copilot or Kimi.

--- a/packages/kobe-web/src/lib/engines.ts
+++ b/packages/kobe-web/src/lib/engines.ts
@@ -23,9 +23,23 @@ export interface EngineOption {
   effortLevels?: readonly string[]
 }
 
+/**
+ * The built-in engines, for the window before `/api/engines` answers and for
+ * a bridge too old to serve the route. Kept in sync with `BUILTIN_VENDORS`
+ * (kobe `src/types/vendor.ts`) — it went stale when copilot and kimi shipped,
+ * and because this list is the ONLY other path to a vendor, the picker
+ * silently offered two of the four with no way to reach the rest.
+ *
+ * Built-ins only, deliberately: contrib and custom engines are user state the
+ * SPA cannot know without the bridge, so they appear when the fetch lands.
+ * No effort levels here either — those are engine-owned and arrive with the
+ * real list, and guessing one would offer a level the engine may not take.
+ */
 const FALLBACK: readonly EngineOption[] = [
   { id: "claude", label: "Claude" },
   { id: "codex", label: "Codex" },
+  { id: "copilot", label: "Copilot" },
+  { id: "kimi", label: "Kimi" },
 ]
 
 const store = createExternalStore<readonly EngineOption[]>(FALLBACK)

--- a/packages/kobe-web/test/engine-fallback.test.ts
+++ b/packages/kobe-web/test/engine-fallback.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import { BUILTIN_VENDORS } from "../../kobe/src/types/vendor.ts"
+
+/**
+ * The SPA's built-in engine fallback — the list every vendor picker shows
+ * before `/api/engines` answers, and the only list it ever gets from a
+ * bridge too old to serve that route.
+ *
+ * It went stale when copilot and kimi shipped: the picker offered two of the
+ * four built-ins, with no other path to reach the rest. Nothing failed —
+ * the missing engines were simply unselectable.
+ *
+ * Read out of the module source rather than imported: `FALLBACK` is private
+ * (the public surface is `useEngines`, which needs a React renderer), and
+ * exporting it just to assert on it would widen the module for the test's
+ * convenience.
+ */
+
+const SOURCE = readFileSync(fileURLToPath(new URL("../src/lib/engines.ts", import.meta.url)), "utf8")
+
+function fallbackIds(): string[] {
+  const block = SOURCE.match(/const FALLBACK: readonly EngineOption\[\] = \[([\s\S]*?)\n\]/)
+  if (!block) throw new Error("FALLBACK list not found — did the declaration change shape?")
+  return [...block[1].matchAll(/id:\s*"([^"]+)"/g)].map((m) => m[1])
+}
+
+describe("engine fallback list", () => {
+  it("covers every built-in vendor", () => {
+    // Sorted: the fallback's own order is cosmetic, its COVERAGE is not.
+    expect(fallbackIds().sort()).toEqual([...BUILTIN_VENDORS].sort())
+  })
+
+  it("offers no engine the registry does not ship", () => {
+    // A picker entry that launches nothing is worse than a missing one.
+    for (const id of fallbackIds()) expect(BUILTIN_VENDORS).toContain(id)
+  })
+})

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -106,6 +106,7 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     // Effort levels real `codex exec` accepts (the broken `minimal` is
     // deliberately excluded — CHANGELOG 0.5.17).
     effortLevels: ["none", "low", "medium", "high", "xhigh"],
+    effortArgv: (base, level) => [...base, "-c", `model_reasoning_effort=${level}`],
     history: codexHistoryReader,
 
     detectAccount: (deps) => detectCodexAccount(deps),

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -25,8 +25,6 @@
 
 import { kobeCliInvocation } from "@/cli/invocation"
 import { engineEntry } from "@/engine/registry"
-import { autoStatusEnabled } from "@/state/auto-status"
-import { dispatcherEnabled } from "@/state/dispatcher"
 import { getPersistedString } from "@/state/repos"
 import type { VendorId } from "@/types/task"
 import { BUILTIN_VENDORS, coerceVendorId } from "@/types/vendor"
@@ -149,12 +147,23 @@ export function withEngineTerminalTitle(argv: readonly string[], vendor: VendorI
 }
 
 /**
- * Append the vendor-correct reasoning/effort flag when `effort` is set AND
- * valid for the vendor (per the registry's {@link EngineRegistryEntry.effortLevels}).
- * Codex maps it to `-c model_reasoning_effort=<level>`; other vendors have no
- * kobe-driveable flag yet, so an effort on them is silently ignored. An
- * unknown / unsupported level is dropped rather than passed through (a bogus
- * value would make the engine refuse to launch).
+ * Apply the engine's own reasoning/effort argv when `effort` is set AND valid
+ * for it (per the registry's {@link EngineRegistryEntry.effortLevels}). Both
+ * halves are DECLARED by the adapter: the levels it accepts and the argv that
+ * carries one ({@link EngineRegistryEntry.effortArgv}). An unknown level is
+ * dropped rather than passed through — a bogus value makes the engine refuse
+ * to launch.
+ *
+ * The argv used to be a `v === "codex"` branch under a data-driven level
+ * gate, so an engine that declared `effortLevels` had its level accepted by
+ * the gate, shown in the TUI and web pickers, threaded through
+ * `/api/engines`, and then silently dropped at launch — the user picked
+ * "high" and got the default with no error. Same shape as the
+ * `withClaudeSessionId` tombstone below.
+ *
+ * `vendor` must already be PROTOCOL-RESOLVED by the caller (both call sites
+ * do): a preset `mycodex` declaring the codex protocol is a codex launch and
+ * takes codex's effort argv.
  */
 export function withEngineEffort(
   argv: readonly string[],
@@ -163,11 +172,9 @@ export function withEngineEffort(
 ): readonly string[] {
   const trimmed = effort?.trim()
   if (!trimmed) return argv
-  const v: VendorId = coerceVendorId(vendor)
-  const levels = engineEntry(v).effortLevels
-  if (!levels?.includes(trimmed)) return argv
-  if (v === "codex") return [...argv, "-c", `model_reasoning_effort=${trimmed}`]
-  return argv
+  const entry = engineEntry(coerceVendorId(vendor))
+  if (!entry.effortLevels?.includes(trimmed)) return argv
+  return entry.effortArgv?.(argv, trimmed) ?? argv
 }
 
 /**
@@ -229,169 +236,19 @@ export function kobeApiInvocation(): string {
 }
 
 /**
- * The status self-report protocol injected into a session's system prompt
- * (docs/design/web-kanban.md M5): the agent itself reports `in_review` when
- * its work is done — it is the one party that KNOWS whether the turn ended
- * "complete" or "asking the user", information the hook layer cannot carry
- * (Stop fires identically for both). The concrete task id is baked in at
- * spawn time (ids are immutable), so the agent never has to guess which
- * task it is. `api` defaults to the environment-correct CLI invocation —
- * tests pass a literal.
- */
-export function statusReportProtocol(taskId: string, api: string = kobeApiInvocation()): string {
-  return [
-    `You are running inside Rove (a local multi-session task manager) as task ${taskId}.`,
-    "Rove tracks a lifecycle status for this task on a board.",
-    "When you have COMPLETED the work requested in this session and verified it, report it by running:",
-    `  ${api} set-status --task-id ${taskId} --status in_review`,
-    "Run it only when the work is genuinely done — never while you are asking the user a question, waiting for input, or mid-task.",
-    "Never set any other status value; everything beyond in_review is the user's decision.",
-  ].join("\n")
-}
-
-/**
- * The note-FILING protocol for worktree (card) sessions (docs/design/
- * dispatcher.md): when a session resolves a non-obvious repo-level gotcha,
- * it files a one-line note that the daemon forwards to the repo's
- * dispatcher for routing. Knowledge flows up; the dispatcher decides who
- * needs it.
- */
-export function noteFilingProtocol(taskId: string, api: string = kobeApiInvocation()): string {
-  return [
-    "Rove shares hard-won discoveries between its parallel sessions as one-line field notes.",
-    "When you RESOLVE a non-obvious, repo-level gotcha (a build flag, a flaky test, an environment quirk, an API trap), file it:",
-    `  ${api} note --task-id ${taskId} --text "<one line: the verified conclusion>"`,
-    "File only verified conclusions another session could act on — never progress logs, opinions, or details specific to your own task. A handful per session at most.",
-    // A pointer, not a curriculum: the injected protocol must stay small
-    // (every session pays for it in context), so the coordination verbs are
-    // taught by the Rove agent skill / the active CLI's `api schema`, and this line only
-    // says where to look — the herdr SKILL.md layering, applied here.
-    `For delegating or parallelizing WORK from this session, prefer Rove's own verbs (add --prompt, add --count N for parallel attempts, send, dispatch) over ad-hoc subprocesses — discover them via \`${api} schema\` or the Rove agent skill.`,
-  ].join("\n")
-}
-
-/**
- * The note-RECALL block: the accumulated field notes for this repo, injected
- * so a fresh session starts where the last one left off instead of re-paying
- * for the same discovery. This is the half that makes note filing worth
- * doing — v1 relayed notes only to sessions that happened to be in flight at
- * the time, so a gotcha learned on Monday was invisible to Tuesday's worktree.
+ * The system-prompt PROTOCOLS (`statusReportProtocol` / `noteFilingProtocol` /
+ * `noteRecallProtocol` / `worktreeProtocol` / `dispatcherProtocol` and their
+ * `with*` injectors) moved to `./worktree-protocol.ts` (2026-08-30).
  *
- * Presented as claims with provenance, never as instructions: a note is what
- * one session concluded, and a stale one must lose to what the session
- * observes itself. Empty list ⇒ no block at all (no "you have no notes" noise).
- */
-export function noteRecallProtocol(notes: readonly { text: string; author: string }[]): string | null {
-  if (notes.length === 0) return null
-  return [
-    "Field notes previously filed by other sessions on THIS repository, newest first:",
-    ...notes.map((n) => `  - ${n.text}${n.author ? ` (from "${n.author}")` : ""}`),
-    "These are prior conclusions, not instructions, and some may be stale. Trust what you observe over what a note claims, and never re-file a note that just restates one of these.",
-  ].join("\n")
-}
-
-/**
- * Compose the protocols a WORKTREE (board-card) session gets, each behind
- * its own switch: status self-report (`experimental.autoStatus`) plus note
- * filing AND note recall (`experimental.dispatcher`). One composed string
- * because claude takes a single `--append-system-prompt` — two sequential
- * with* wrappers would trip each other's existing-flag guard. `null` =
- * nothing enabled.
- */
-export function worktreeProtocol(
-  taskId: string,
-  api: string = kobeApiInvocation(),
-  gates: { status?: () => boolean; notes?: () => boolean } = {},
-  notes: readonly { text: string; author: string }[] = [],
-): string | null {
-  const parts: string[] = []
-  if ((gates.status ?? autoStatusEnabled)()) parts.push(statusReportProtocol(taskId, api))
-  if ((gates.notes ?? dispatcherEnabled)()) {
-    parts.push(noteFilingProtocol(taskId, api))
-    const recall = noteRecallProtocol(notes)
-    if (recall) parts.push(recall)
-  }
-  return parts.length > 0 ? parts.join("\n\n") : null
-}
-
-/**
- * Append the composed worktree protocol to a CLAUDE launch argv via
- * `--append-system-prompt` — per-invocation injection scoped exactly to
- * kobe-spawned sessions. Why a flag and not a file: a dropped
- * CLAUDE.local.md would sit untracked in the worktree and permanently
- * dirty it (polluting the board's ± counts), manual `claude` runs in the
- * same worktree must stay untouched, and a system prompt survives context
- * compaction where a first-message blurb may not.
+ * Two reasons, one move. Both injectors opened with
+ * `coerceVendorId(vendor) !== "claude"` — the third and fourth copies of the
+ * ladder the `withClaudeSessionId` tombstone above describes, so a wrapper
+ * preset (`claudecpa`) got no status protocol and no field notes, silently.
+ * The fix is `sessionProtocol()`, which lives in `engine-presets.ts` — and
+ * that module imports THIS one, so resolving a protocol here would close an
+ * import cycle. Moving the block one file over breaks the cycle and keeps
+ * both files under the size cap.
  *
- * Gates, in order: there is a task to report, the launch targets claude
- * (other vendors have no equivalent flag yet — their cards move by hand
- * until their adapters grow an injection point), a custom command that
- * already sets the flag is left alone (the user-flag-wins precedent), and at least one protocol switch is on.
+ * Anything that gates on "is this launch a claude launch" belongs behind
+ * `sessionProtocol()`, never a literal id compare.
  */
-export function withWorktreeProtocol(
-  argv: readonly string[],
-  vendor: string | undefined,
-  taskId: string | undefined,
-  gates: { status?: () => boolean; notes?: () => boolean } = {},
-  notes: readonly { text: string; author: string }[] = [],
-): readonly string[] {
-  if (!taskId) return argv
-  if (coerceVendorId(vendor) !== "claude") return argv
-  if (argvHasFlag(argv, "--append-system-prompt") || argvHasFlag(argv, "--append-system-prompt-file")) {
-    return argv
-  }
-  const text = worktreeProtocol(taskId, kobeApiInvocation(), gates, notes)
-  if (!text) return argv
-  return [...argv, "--append-system-prompt", text]
-}
-
-/**
- * The DISPATCHER protocol (docs/design/dispatcher.md) — injected into a
- * repo's MAIN session (the complement of the worktree protocol's main-task
- * exclusion). The main session sits in the repo root with no board card of
- * its own, which makes it the natural per-repo knowledge-routing seat:
- * worktree sessions file field notes, the daemon forwards each note here,
- * and this prompt tells the agent how to relay them. Fully autonomous by
- * design (v1 decision: no approval gate) — its only effectors are read
- * (`kobe api collect`) and message (`kobe api dispatch`), so the blast
- * radius of a bad call is a stray FYI, never a mutated worktree. It takes
- * NO action on merge conflicts: the conflict radar is display-only.
- */
-export function dispatcherProtocol(taskId: string, api: string = kobeApiInvocation()): string {
-  return [
-    `You are running inside Rove (a local multi-session task manager) as this repository's DISPATCHER (task ${taskId}, the repo's main session).`,
-    "Rove runs multiple worktree task sessions on this repo in parallel. When one of them resolves a non-obvious gotcha, it files a one-line field note; Rove forwards each note to you as a user message prefixed with [ROVE FIELD NOTE].",
-    "Your job is routing that knowledge, fully autonomously — never ask the user for permission:",
-    `  - See the fleet: \`${api} collect --repo .\` (status, running, change counts per task), or \`--task-ids id1,id2\` for specific tasks.`,
-    `  - Relay a note to a task that would benefit: \`${api} dispatch --task-id <id> --prompt "[dispatcher] FYI from <author task>: <note verbatim>"\`.`,
-    "  - Relay to the in-flight tasks whose work plausibly touches the same area — and to nobody else. If no task benefits, do nothing.",
-    "  - Never relay a note back to its author, never relay the same note to the same task twice, and keep relays verbatim with provenance — no summarizing, no embellishment.",
-    "Use ONLY the dispatch verb to message sessions — it targets an already-hosted session without starting an idle task. If dispatch fails, report the error in your own session and stop; do not fall back to send.",
-    "Take no action on merge conflicts between tasks — the board's conflict radar is display-only by design, and resolution timing belongs to the humans and the tasks themselves.",
-    "Never run git commands inside other tasks' worktrees.",
-  ].join("\n")
-}
-
-/**
- * Append the dispatcher protocol to a MAIN session's claude launch argv —
- * the same `--append-system-prompt` mechanics (and rationale) as
- * {@link withStatusProtocol}. Gates: the `experimental.dispatcher` switch
- * is on, the launch is a main session (callers pass `taskId` only for
- * main, mirroring how they pass the status protocol's taskId only for
- * board cards — the two injections are mutually exclusive by construction,
- * so the existing-flag guard below never trips between them), the vendor
- * is claude, and a custom command that already sets the flag wins.
- */
-export function withDispatcherProtocol(
-  argv: readonly string[],
-  vendor: string | undefined,
-  taskId: string | undefined,
-  enabled: () => boolean = dispatcherEnabled,
-): readonly string[] {
-  if (!taskId || !enabled()) return argv
-  if (coerceVendorId(vendor) !== "claude") return argv
-  if (argvHasFlag(argv, "--append-system-prompt") || argvHasFlag(argv, "--append-system-prompt-file")) {
-    return argv
-  }
-  return [...argv, "--append-system-prompt", dispatcherProtocol(taskId)]
-}

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -100,12 +100,30 @@ export interface EngineRegistryEntry {
    */
   readonly defaultCommand: readonly string[]
   /**
-   * Reasoning/effort levels this engine accepts, lowest→highest. Codex maps
-   * a selected level to `-c model_reasoning_effort=<level>` at launch (see
-   * `interactive-command.ts`). Undefined for engines with no kobe-driveable
-   * effort flag (claude picks reasoning at runtime; copilot/custom have none).
+   * Reasoning/effort levels this engine accepts, lowest→highest. Undefined
+   * for engines with no kobe-driveable effort flag (claude picks reasoning at
+   * runtime; copilot/custom have none).
+   *
+   * Declaring levels only says the picker may OFFER them — {@link effortArgv}
+   * is what carries a chosen level to the process. An engine that declares
+   * levels without argv has its selection accepted by every gate and then
+   * dropped at launch, silently.
    */
   readonly effortLevels?: readonly string[]
+  /**
+   * Argv that asks this engine for reasoning `level` (already validated
+   * against {@link effortLevels}). A full-argv rewrite for the same reason
+   * {@link EngineSessionIdentity.resumeArgv} is one: the shapes differ in
+   * kind, not just spelling — codex takes a config pair
+   * (`-c model_reasoning_effort=high`), and the next engine to grow one may
+   * take a flag or a subcommand.
+   *
+   * Absent = Rove knows no way to pass an effort to this engine, so a level
+   * is dropped rather than guessed at. Pair it with {@link effortLevels}: a
+   * hardcoded `if (vendor === "codex")` here is exactly what let a declared
+   * level reach the UI and die at launch.
+   */
+  readonly effortArgv?: (base: readonly string[], level: string) => readonly string[]
   /** Transcript store reader. Empty (not claude's!) for custom engines. */
   readonly history: EngineHistoryReader
   /**

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -4,8 +4,8 @@ import { quoteShellArg, quoteShellArgv } from "../lib/shell-command.ts"
 import { readFieldNotes } from "../state/field-notes.ts"
 import { type PromptDeliveryIntent, resolveEngineLaunchInit } from "../state/repo-init.ts"
 import { type VendorId, coerceVendorId } from "../types/vendor.ts"
-import { withDispatcherProtocol, withWorktreeProtocol } from "./interactive-command.ts"
 import { engineEntry } from "./registry.ts"
+import { withDispatcherProtocol, withWorktreeProtocol } from "./worktree-protocol.ts"
 
 export const SIGINT_GUARD = "trap ':' INT; "
 

--- a/packages/kobe/src/engine/worktree-protocol.ts
+++ b/packages/kobe/src/engine/worktree-protocol.ts
@@ -1,0 +1,215 @@
+/**
+ * The system-prompt PROTOCOLS Rove injects into an engine launch — the
+ * status self-report (`experimental.autoStatus`), field-note filing +
+ * recall, and the repo main session's dispatcher brief.
+ *
+ * Split out of `interactive-command.ts` (the ~500-line cap) so the protocol
+ * text and its injection gates sit together, and so this module may import
+ * `engine-presets.ts` for protocol resolution — `engine-presets.ts` imports
+ * `interactive-command.ts`, so asking that file to resolve a protocol would
+ * close an import cycle.
+ *
+ * Injection rides `--append-system-prompt`, per-invocation and scoped
+ * exactly to Rove-spawned sessions. Why a flag and not a file: a dropped
+ * CLAUDE.local.md would sit untracked in the worktree and permanently dirty
+ * it (polluting the board's ± counts), manual `claude` runs in the same
+ * worktree must stay untouched, and a system prompt survives context
+ * compaction where a first message may not.
+ */
+
+import { autoStatusEnabled } from "@/state/auto-status"
+import { dispatcherEnabled } from "@/state/dispatcher"
+import { sessionProtocol } from "./engine-presets.ts"
+import { argvHasFlag, kobeApiInvocation } from "./interactive-command.ts"
+
+/**
+ * The engine protocol whose `--append-system-prompt` flag these injections
+ * use. Resolved rather than compared to a raw id: a custom preset
+ * (`claudecpa`) declaring the claude protocol launches the claude binary and
+ * takes the same flag.
+ */
+const SYSTEM_PROMPT_PROTOCOL = "claude"
+
+/**
+ * True when a launch of `vendor` accepts Rove's system-prompt injection —
+ * i.e. it speaks the claude protocol, natively or by declaration.
+ *
+ * PROTOCOL-resolved, not id-compared. The raw
+ * `coerceVendorId(vendor) !== "claude"` this replaced is the same shape as
+ * the `withClaudeSessionId` tombstone in `interactive-command.ts`: only an
+ * engine literally NAMED claude passed, so a wrapper preset silently got no
+ * status protocol (its card never left `in_progress` under
+ * `experimental.autoStatus`) and no field notes — with no error anywhere.
+ */
+function acceptsSystemPrompt(vendor: string | undefined): boolean {
+  return sessionProtocol(vendor) === SYSTEM_PROMPT_PROTOCOL
+}
+
+/** The launch command already carries a system prompt of the user's own. */
+function hasOwnSystemPrompt(argv: readonly string[]): boolean {
+  return argvHasFlag(argv, "--append-system-prompt") || argvHasFlag(argv, "--append-system-prompt-file")
+}
+
+/**
+ * The status self-report protocol injected into a session's system prompt
+ * (docs/design/web-kanban.md M5): the agent itself reports `in_review` when
+ * its work is done — it is the one party that KNOWS whether the turn ended
+ * "complete" or "asking the user", information the hook layer cannot carry
+ * (Stop fires identically for both). The concrete task id is baked in at
+ * spawn time (ids are immutable), so the agent never has to guess which
+ * task it is. `api` defaults to the environment-correct CLI invocation —
+ * tests pass a literal.
+ */
+export function statusReportProtocol(taskId: string, api: string = kobeApiInvocation()): string {
+  return [
+    `You are running inside Rove (a local multi-session task manager) as task ${taskId}.`,
+    "Rove tracks a lifecycle status for this task on a board.",
+    "When you have COMPLETED the work requested in this session and verified it, report it by running:",
+    `  ${api} set-status --task-id ${taskId} --status in_review`,
+    "Run it only when the work is genuinely done — never while you are asking the user a question, waiting for input, or mid-task.",
+    "Never set any other status value; everything beyond in_review is the user's decision.",
+  ].join("\n")
+}
+
+/**
+ * The note-FILING protocol for worktree (card) sessions (docs/design/
+ * dispatcher.md): when a session resolves a non-obvious repo-level gotcha,
+ * it files a one-line note that the daemon forwards to the repo's
+ * dispatcher for routing. Knowledge flows up; the dispatcher decides who
+ * needs it.
+ */
+export function noteFilingProtocol(taskId: string, api: string = kobeApiInvocation()): string {
+  return [
+    "Rove shares hard-won discoveries between its parallel sessions as one-line field notes.",
+    "When you RESOLVE a non-obvious, repo-level gotcha (a build flag, a flaky test, an environment quirk, an API trap), file it:",
+    `  ${api} note --task-id ${taskId} --text "<one line: the verified conclusion>"`,
+    "File only verified conclusions another session could act on — never progress logs, opinions, or details specific to your own task. A handful per session at most.",
+    // A pointer, not a curriculum: the injected protocol must stay small
+    // (every session pays for it in context), so the coordination verbs are
+    // taught by the Rove agent skill / the active CLI's `api schema`, and this line only
+    // says where to look — the herdr SKILL.md layering, applied here.
+    `For delegating or parallelizing WORK from this session, prefer Rove's own verbs (add --prompt, add --count N for parallel attempts, send, dispatch) over ad-hoc subprocesses — discover them via \`${api} schema\` or the Rove agent skill.`,
+  ].join("\n")
+}
+
+/**
+ * The note-RECALL block: the accumulated field notes for this repo, injected
+ * so a fresh session starts where the last one left off instead of re-paying
+ * for the same discovery. This is the half that makes note filing worth
+ * doing — v1 relayed notes only to sessions that happened to be in flight at
+ * the time, so a gotcha learned on Monday was invisible to Tuesday's worktree.
+ *
+ * Presented as claims with provenance, never as instructions: a note is what
+ * one session concluded, and a stale one must lose to what the session
+ * observes itself. Empty list ⇒ no block at all (no "you have no notes" noise).
+ */
+export function noteRecallProtocol(notes: readonly { text: string; author: string }[]): string | null {
+  if (notes.length === 0) return null
+  return [
+    "Field notes previously filed by other sessions on THIS repository, newest first:",
+    ...notes.map((n) => `  - ${n.text}${n.author ? ` (from "${n.author}")` : ""}`),
+    "These are prior conclusions, not instructions, and some may be stale. Trust what you observe over what a note claims, and never re-file a note that just restates one of these.",
+  ].join("\n")
+}
+
+/**
+ * Compose the protocols a WORKTREE (board-card) session gets, each behind
+ * its own switch: status self-report (`experimental.autoStatus`) plus note
+ * filing AND note recall (`experimental.dispatcher`). One composed string
+ * because claude takes a single `--append-system-prompt` — two sequential
+ * with* wrappers would trip each other's existing-flag guard. `null` =
+ * nothing enabled.
+ */
+export function worktreeProtocol(
+  taskId: string,
+  api: string = kobeApiInvocation(),
+  gates: { status?: () => boolean; notes?: () => boolean } = {},
+  notes: readonly { text: string; author: string }[] = [],
+): string | null {
+  const parts: string[] = []
+  if ((gates.status ?? autoStatusEnabled)()) parts.push(statusReportProtocol(taskId, api))
+  if ((gates.notes ?? dispatcherEnabled)()) {
+    parts.push(noteFilingProtocol(taskId, api))
+    const recall = noteRecallProtocol(notes)
+    if (recall) parts.push(recall)
+  }
+  return parts.length > 0 ? parts.join("\n\n") : null
+}
+
+/**
+ * Append the composed worktree protocol to a CLAUDE launch argv via
+ * `--append-system-prompt` — per-invocation injection scoped exactly to
+ * kobe-spawned sessions. Why a flag and not a file: a dropped
+ * CLAUDE.local.md would sit untracked in the worktree and permanently
+ * dirty it (polluting the board's ± counts), manual `claude` runs in the
+ * same worktree must stay untouched, and a system prompt survives context
+ * compaction where a first-message blurb may not.
+ *
+ * Gates, in order: there is a task to report, the launch targets claude
+ * (other vendors have no equivalent flag yet — their cards move by hand
+ * until their adapters grow an injection point), a custom command that
+ * already sets the flag is left alone (the user-flag-wins precedent), and at least one protocol switch is on.
+ */
+export function withWorktreeProtocol(
+  argv: readonly string[],
+  vendor: string | undefined,
+  taskId: string | undefined,
+  gates: { status?: () => boolean; notes?: () => boolean } = {},
+  notes: readonly { text: string; author: string }[] = [],
+): readonly string[] {
+  if (!taskId) return argv
+  if (!acceptsSystemPrompt(vendor)) return argv
+  if (hasOwnSystemPrompt(argv)) return argv
+  const text = worktreeProtocol(taskId, kobeApiInvocation(), gates, notes)
+  if (!text) return argv
+  return [...argv, "--append-system-prompt", text]
+}
+
+/**
+ * The DISPATCHER protocol (docs/design/dispatcher.md) — injected into a
+ * repo's MAIN session (the complement of the worktree protocol's main-task
+ * exclusion). The main session sits in the repo root with no board card of
+ * its own, which makes it the natural per-repo knowledge-routing seat:
+ * worktree sessions file field notes, the daemon forwards each note here,
+ * and this prompt tells the agent how to relay them. Fully autonomous by
+ * design (v1 decision: no approval gate) — its only effectors are read
+ * (`kobe api collect`) and message (`kobe api dispatch`), so the blast
+ * radius of a bad call is a stray FYI, never a mutated worktree. It takes
+ * NO action on merge conflicts: the conflict radar is display-only.
+ */
+export function dispatcherProtocol(taskId: string, api: string = kobeApiInvocation()): string {
+  return [
+    `You are running inside Rove (a local multi-session task manager) as this repository's DISPATCHER (task ${taskId}, the repo's main session).`,
+    "Rove runs multiple worktree task sessions on this repo in parallel. When one of them resolves a non-obvious gotcha, it files a one-line field note; Rove forwards each note to you as a user message prefixed with [ROVE FIELD NOTE].",
+    "Your job is routing that knowledge, fully autonomously — never ask the user for permission:",
+    `  - See the fleet: \`${api} collect --repo .\` (status, running, change counts per task), or \`--task-ids id1,id2\` for specific tasks.`,
+    `  - Relay a note to a task that would benefit: \`${api} dispatch --task-id <id> --prompt "[dispatcher] FYI from <author task>: <note verbatim>"\`.`,
+    "  - Relay to the in-flight tasks whose work plausibly touches the same area — and to nobody else. If no task benefits, do nothing.",
+    "  - Never relay a note back to its author, never relay the same note to the same task twice, and keep relays verbatim with provenance — no summarizing, no embellishment.",
+    "Use ONLY the dispatch verb to message sessions — it targets an already-hosted session without starting an idle task. If dispatch fails, report the error in your own session and stop; do not fall back to send.",
+    "Take no action on merge conflicts between tasks — the board's conflict radar is display-only by design, and resolution timing belongs to the humans and the tasks themselves.",
+    "Never run git commands inside other tasks' worktrees.",
+  ].join("\n")
+}
+
+/**
+ * Append the dispatcher protocol to a MAIN session's claude launch argv —
+ * the same `--append-system-prompt` mechanics (and rationale) as
+ * {@link withStatusProtocol}. Gates: the `experimental.dispatcher` switch
+ * is on, the launch is a main session (callers pass `taskId` only for
+ * main, mirroring how they pass the status protocol's taskId only for
+ * board cards — the two injections are mutually exclusive by construction,
+ * so the existing-flag guard below never trips between them), the vendor
+ * is claude, and a custom command that already sets the flag wins.
+ */
+export function withDispatcherProtocol(
+  argv: readonly string[],
+  vendor: string | undefined,
+  taskId: string | undefined,
+  enabled: () => boolean = dispatcherEnabled,
+): readonly string[] {
+  if (!taskId || !enabled()) return argv
+  if (!acceptsSystemPrompt(vendor)) return argv
+  if (hasOwnSystemPrompt(argv)) return argv
+  return [...argv, "--append-system-prompt", dispatcherProtocol(taskId)]
+}

--- a/packages/kobe/test/architecture/engine-owned-copy.test.ts
+++ b/packages/kobe/test/architecture/engine-owned-copy.test.ts
@@ -38,9 +38,11 @@ const VENDOR_WORD = /\b(Claude|Codex|Copilot|Kimi)\b/
  * line contains one of its allowed fragments.
  */
 const EXEMPT_LINES: Record<string, readonly string[]> = {
-  // Both serve the engine-owned list; the literal pair only fires against an
-  // older bridge / empty registry (see each file's header comment).
-  "packages/kobe-web/src/lib/engines.ts": ['label: "Claude"', 'label: "Codex"'],
+  // Both serve the engine-owned list; the literals only fire against an
+  // older bridge / empty registry (see each file's header comment). The SPA
+  // covers every BUILTIN_VENDOR because that fallback is the only other path
+  // to a vendor — a short list silently made the rest unselectable.
+  "packages/kobe-web/src/lib/engines.ts": ['label: "Claude"', 'label: "Codex"', 'label: "Copilot"', 'label: "Kimi"'],
   "packages/kobe-daemon/src/daemon/web-server.ts": ['label: "Claude"'],
 }
 

--- a/packages/kobe/test/engine/engine-declared-vendor-flags.test.ts
+++ b/packages/kobe/test/engine/engine-declared-vendor-flags.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Engine-DECLARED launch flags, proven with a NON-BUILT-IN engine.
+ *
+ * Both rules under test were data-driven at the gate and hardcoded at the
+ * flag — `if (v === "codex")` for effort, `coerceVendorId(vendor) !== "claude"`
+ * for the system prompt — so a declared level or protocol was accepted
+ * everywhere and then dropped at launch, silently.
+ *
+ * Every case here uses an engine that is NOT literally named codex/claude:
+ * a wrapper preset (`claudecpa`, declaring the claude protocol) and a fake
+ * engine that declares `effortLevels` + `effortArgv`. Asserting on the
+ * built-ins alone proves nothing — they were green while both bugs were live.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const registry = await vi.hoisted(async () => ({ effortArgv: undefined as unknown }))
+
+vi.mock("../../src/engine/registry.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/registry.ts")>()
+  return {
+    ...actual,
+    engineEntry: (vendor: string) =>
+      vendor === "fakeengine"
+        ? {
+            ...actual.engineEntry(vendor),
+            effortLevels: ["low", "high"],
+            effortArgv: (base: readonly string[], level: string) => [...base, "--reasoning", level],
+          }
+        : actual.engineEntry(vendor),
+  }
+})
+
+const { withEngineEffort } = await import("../../src/engine/interactive-command.ts")
+const { engineLaunchArgv } = await import("../../src/engine/engine-presets.ts")
+const { withDispatcherProtocol, withWorktreeProtocol } = await import("../../src/engine/worktree-protocol.ts")
+
+const on = () => true
+
+let home: string
+let originalHome: string | undefined
+
+function writeState(state: Record<string, unknown>): void {
+  const dir = join(home, ".config", "rove")
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "state.json"), JSON.stringify(state), "utf8")
+}
+
+/** A real wrapper preset: its own id + command, declaring the claude protocol. */
+function registerClaudeWrapper(): void {
+  writeState({
+    customEngineIds: ["claudecpa"],
+    "engineCommand.claudecpa": "claudecpa --dangerously-skip-permissions",
+    "engineProtocol.claudecpa": "claude",
+  })
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kobe-declared-flags-"))
+  originalHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = home
+  writeState({})
+})
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+    delete process.env.KOBE_HOME_DIR
+  } else process.env.KOBE_HOME_DIR = originalHome
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe("declared effort reaches the launch argv", () => {
+  it("applies a NON-CODEX engine's own effortArgv", () => {
+    // The whole bug: this engine declares levels, so "high" passes the gate,
+    // shows in the picker and rides /api/engines — and under the old
+    // `if (v === "codex")` it was then dropped with no error.
+    expect(withEngineEffort(["fake-cli"], "fakeengine", "high")).toEqual(["fake-cli", "--reasoning", "high"])
+  })
+
+  it("still drops a level the engine never declared", () => {
+    expect(withEngineEffort(["fake-cli"], "fakeengine", "turbo")).toEqual(["fake-cli"])
+  })
+
+  it("drops a level for an engine that declares levels but no argv", () => {
+    // Honest refusal, not a guess: nothing here knows how to spell it.
+    expect(withEngineEffort(["copilot"], "copilot", "high")).toEqual(["copilot"])
+  })
+
+  it("carries effort through a WRAPPER preset that declares the codex protocol", () => {
+    writeState({
+      customEngineIds: ["mycodex"],
+      "engineCommand.mycodex": "codex-wrapper --yolo",
+      "engineProtocol.mycodex": "codex",
+    })
+    expect(engineLaunchArgv({ command: "mycodex", effort: "high" })).toContain("model_reasoning_effort=high")
+  })
+})
+
+describe("system-prompt protocols reach a wrapper engine", () => {
+  it("injects the worktree protocol into a claudecpa launch", () => {
+    registerClaudeWrapper()
+    const argv = withWorktreeProtocol(["claudecpa"], "claudecpa", "t1", { status: on, notes: on })
+    // Without this, `experimental.autoStatus` never moves the card to
+    // in_review on a wrapper engine — the exact silent gap the removed
+    // `withClaudeSessionId` had.
+    expect(argv).toContain("--append-system-prompt")
+    expect(argv.join("\n")).toContain("api set-status --task-id t1 --status in_review")
+  })
+
+  it("injects the dispatcher protocol into a claudecpa main session", () => {
+    registerClaudeWrapper()
+    const argv = withDispatcherProtocol(["claudecpa"], "claudecpa", "m1", on)
+    expect(argv).toContain("--append-system-prompt")
+    expect(argv.join("\n")).toContain("DISPATCHER")
+  })
+
+  it("still refuses an engine whose protocol is not claude", () => {
+    // A wrapper is not a blanket pass: kimi takes no --append-system-prompt,
+    // and passing one would kill the launch.
+    writeState({
+      customEngineIds: ["mykimi"],
+      "engineCommand.mykimi": "kimi-wrapper",
+      "engineProtocol.mykimi": "kimi",
+    })
+    expect(withWorktreeProtocol(["mykimi"], "mykimi", "t1", { status: on, notes: on })).toEqual(["mykimi"])
+  })
+
+  it("still leaves a wrapper command that sets its own prompt flag alone", () => {
+    registerClaudeWrapper()
+    const own = ["claudecpa", "--append-system-prompt=mine"]
+    expect(withWorktreeProtocol(own, "claudecpa", "t1", { status: on, notes: on })).toEqual(own)
+  })
+})

--- a/packages/kobe/test/engine/status-protocol.test.ts
+++ b/packages/kobe/test/engine/status-protocol.test.ts
@@ -6,7 +6,7 @@ import {
   withDispatcherProtocol,
   withWorktreeProtocol,
   worktreeProtocol,
-} from "../../src/engine/interactive-command.ts"
+} from "../../src/engine/worktree-protocol.ts"
 
 /**
  * Protocol injection (web-kanban.md M5 + docs/design/dispatcher.md).


### PR DESCRIPTION
Three places read a capability off the engine registry to decide **whether** to act, then hardcoded a vendor name to decide **how**. In each case the declared capability was accepted at every gate and then dropped at launch — no error, no warning.

> **Scope reduced after rebase.** This branch originally carried a fourth fix (the plugin manifest's reserved engine-id list). [#670](https://github.com/Sma1lboy/rove/pull/670) landed the same fix first, and its version is strictly better — see "Dropped in favour of #670" below. That half is gone; `manifest.ts` is byte-identical to `main` here.

### 1. Reasoning effort was hardcoded to codex

`withEngineEffort` validated the level against the registry's `effortLevels`, then carried it with `if (v === "codex")`. An engine declaring `effortLevels` had its level accepted by the gate, shown in the TUI and web pickers, threaded through `/api/engines` → `EngineOption.effortLevels` → the issue drawer — and dropped at spawn. The user picked "high" and the engine ran on its default.

Engines now declare `effortArgv` alongside `effortLevels`, the same shape as the existing `resumeArgv` / `forkArgv`. Declaring levels without argv drops the level honestly rather than guessing a spelling.

### 2. Both `--append-system-prompt` ladders keyed off the literal id

`withWorktreeProtocol` and `withDispatcherProtocol` both opened with `coerceVendorId(vendor) !== "claude"` — the same shape as the `withClaudeSessionId` tombstone sitting in that very file. A custom preset declaring the claude protocol (a `claudecpa`-style wrapper) launches the claude binary but is not *named* claude, so it got no status protocol — its card never moved to `in_review` under `experimental.autoStatus` — and no field notes.

Both now go through `sessionProtocol()`, which already resolves wrapper presets for session ids and forking.

**Layer chosen: `sessionProtocol()`, not a new `systemPromptArgv` declaration.** The engine-owned option is the better end state, but every consumer today is claude-protocol, and the flag guard, the mutual exclusion between the two injections, and the composed-single-prompt rule are all claude-CLI facts. Declaring an interface with exactly one implementation and no second shape to generalise from would be speculative. The protocol resolution is the part that was actually wrong, and it fixes every wrapper today. The seam is marked for whichever engine grows the second injection point.

This required moving the block to `worktree-protocol.ts`: `sessionProtocol` lives in `engine-presets.ts`, which already imports `interactive-command.ts`, so resolving in place would close an import cycle. The move also pays the file-size cap (`interactive-command.ts` was 437 lines and I touched it) — both files now sit well under 500. A tombstone in the original file records why.

### 3. The web fallback engine list was stale

`lib/engines.ts` still named only Claude and Codex. It only fires before `/api/engines` answers or against an older bridge — but it is the *only* other path to a vendor, so the picker silently offered two of the four built-ins with no way to reach Copilot or Kimi. `web-server.ts`'s documented single default and `vendor.ts`'s `DEFAULT_VENDOR` are untouched.

## Dropped in favour of #670

Both branches fixed the reserved-id list; they agree on the mechanism (a daemon-side copy, guarded from kobe) and on all ten ids. **#670's is more complete on three counts**, so this branch keeps none of its own:

- it **exports** `RESERVED_ENGINE_IDS`, which lets its drift guard assert set equality directly (`[...RESERVED_ENGINE_IDS].sort()` vs `[...BUILTIN_VENDORS, ...CONTRIB_ENGINE_IDS].sort()`); mine was private, so my test could only probe the validator's refusals — a weaker proxy;
- it also logs a warning when `registerPluginEngine` drops an id, closing the runtime half of the same silent failure, not just the parse half;
- its error message says "built-in or shipped engine", which is accurate for a contrib id.

No substantive disagreement — same direction, better execution. `manifest.ts` on this branch is now byte-identical to `main`.

## Tests

Every case for #1 and #2 uses an engine that is **not** literally named codex or claude — a `claudecpa` wrapper preset and a fake engine declaring `effortLevels` + `effortArgv`. Asserting on the built-ins proves nothing: they were green while both bugs were live.

Each fix passed a mutation check — revert it, the test goes red — **run twice after the rebase onto 0.9.39** (the pre-rebase red lights were discarded):

| Mutation | Red |
| --- | --- |
| restore `if (v === "codex")` | 1 test |
| restore literal `!== "claude"` | 2 tests (both ladders) |
| revert the stale fallback list | 1 test |

The `engine-owned-copy` architecture gate needed its line-by-line exemption widened for the two new labels — extended in the same deliberately-narrow shape, not loosened.

Local after rebase: typecheck ✅, lint ✅ (root + kobe-web), fast 385/385 files ✅, socket 75/75 ✅, kobe-web 68/68 ✅.

**Pre-existing flakes, not caused by this branch.** Verified against clean `origin/main`: a full render run there fails one test (`requestNewChat dispatch`) while that file passes 5/0 in isolation — the same "different test each run, all pass isolated" signature seen on the socket track (`worktree-changes-collector`, `task-deletion-background`). The earlier `shortcut-reveal` CI red was this family: 3/3 pass isolated on this branch, zero imports of anything touched here, green on rerun. No test was changed to make CI green.

## Screenshot

**Not produced, and it cannot be — stating that rather than substituting a picture of something else.** The effort picker exists only in the web issue drawer (`EngineEffortPicker.tsx`, used by `IssueIntakePanel` / `IssuePeek`); no OpenTUI surface reads `effortLevels` at all. The mandated ground-truth path renders OpenTUI, so there is no TUI frame in which this value can be selected.

Evidence instead — a wrapper preset `mycodex` (protocol `codex`, command `codex-wrapper --yolo`), asking for the argv the spawner uses:

```
low    -> ["codex-wrapper","--yolo","-c","model_reasoning_effort=low", ...]
high   -> ["codex-wrapper","--yolo","-c","model_reasoning_effort=high", ...]
xhigh  -> ["codex-wrapper","--yolo","-c","model_reasoning_effort=xhigh", ...]
```

And the before/after for a **newly declared** engine, which is the bug proper:

```
BEFORE: expected [ 'fake-cli' ] to deeply equal [ 'fake-cli', '--reasoning', 'high' ]
AFTER:  ✓ applies a NON-CODEX engine's own effortArgv
```

The user picked "high"; the argv came back as bare `['fake-cli']`.

## Scope

Untouched as instructed: the `foreground.ts` / `hosted-session.ts` / `protocol-sniff.ts` / `registry.ts` BUILTIN_ENGINES walks, `account-detect.ts`, the i18n engine roster, kobe-daemon's `VendorId` union, and the three unread `EngineIdentity` fields.