### PR TITLE
fix: close four keyboard gates that dispatch a dead or wrong action

### DIFF
--- a/.changeset/keyboard-gate-guards.md
+++ b/.changeset/keyboard-gate-guards.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix four keyboard gates that let a key look live while doing nothing.
+
+Typing into the sidebar search box no longer triggers the `s`, `x`, `u` and `q` chords — a query containing any of those letters used to dispatch Settings, Worktrees or the Update page instead of reaching the box, because the search reader only sees keystrokes the keymap left unclaimed.
+
+The four `diff.review.*` rows in the keybindings table are now rejected as non-rebindable. They are raw bindings that no keymap handler reads, so an override used to apply cleanly, update the help panel, and change nothing.
+
+The Inbox footer dims its `d clear` hint on RECENT rows, which have nothing to drop.
+
+`h` and `l` now fold untracked directories on the Files Changes tab. Both were dead there — `l` was rejected before it reached the row and `h` was gated off the tab entirely — leaving those rows expandable only by mouse or `enter`.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -109,7 +109,7 @@ is active.
 | `enter` | Open | | `b` | Rename branch |
 | `l` / `space` | Open the row under the cursor | | `v` | Change engine |
 | `o` | Open Task directory in your editor | | `s` | Settings |
-| `u` | Update page | | `/` | Search |
+| `u` | Update page — version check + release notes | | `/` | Search |
 | `d` | Delete Task / forget project | | `x` | Worktrees page |
 | `gg` / `shift+g` | Top / bottom | | | |
 | `shift+p` | Pin / unpin managed Task | | `right` | Focus the current engine pane |
@@ -132,6 +132,9 @@ through a Task row in that project.
 | `o` | Open audio, video, or PDF files in the system application |
 | `a` | Insert an `@path` mention into the engine pane |
 | `[` / `]` | Switch file tabs |
+
+`h` / `l` fold directories on both tabs — on Changes they also expand
+and collapse untracked-directory rows.
 
 The sidebar is a tree (project → Task → Terminal Tab) and it never folds, so
 everything is always visible. Search (`/`) matches titles, repos, branches,

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -392,10 +392,7 @@ export function FileTree(props: FileTreeProps) {
         props.onOpenDiff?.(row.path, scope === "branch" && base != null ? base : undefined)
       },
       expandOrDescend: () => applyNav(expandOrDescendAction(rows, cursorIndex)),
-      collapseOrParent: () => {
-        if (tab !== "all") return
-        applyNav(collapseOrParentAction(rows, cursorIndex))
-      },
+      collapseOrParent: () => applyNav(collapseOrParentAction(rows, cursorIndex)),
     }),
   }))
 

--- a/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
+++ b/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
@@ -430,7 +430,14 @@ export function AttentionInboxPane(props: {
         <text fg={theme.textMuted} wrapMode="none">
           {t("workspace.inbox.openHint")}
         </text>
-        <text fg={theme.textMuted} wrapMode="none">
+        {/* Only attention rows are dismissible — dim the hint on any other
+         row (a recent task has nothing to drop) so the footer doesn't
+         advertise a chord that would silently no-op. */}
+        <text
+          fg={theme.textMuted}
+          attributes={selected()?.kind === "attention" ? undefined : TextAttributes.DIM}
+          wrapMode="none"
+        >
           {t("workspace.inbox.clearHint")}
         </text>
       </box>

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -149,8 +149,12 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
     enabled: pagesClosed && focus.focused !== "sidebar",
     bindings: bindByIds({ "focus.sidebar": () => focus.setFocused("sidebar") }),
   }))
+  // Same search-inactive gate as the task-lifecycle group below: while the
+  // sidebar search box is active, `s`/`x`/`u` (and the group's bare `q`
+  // quit chord) must land in the query, not dispatch — the raw search
+  // listener only sees keystrokes the keymap left unclaimed.
   useBindings(() => ({
-    enabled: pagesClosed && focus.focused === "sidebar",
+    enabled: pagesClosed && focus.focused === "sidebar" && !deps.searchActive,
     bindings: bindByIds({
       // Slot dispatch (SLOT_CONTRACTS): slot 0 = quit confirm, slot 1 =
       // hard exit — so user rebinds keep both verbs without inspecting

--- a/packages/kobe/src/tui/context/keybindings-sidebar.ts
+++ b/packages/kobe/src/tui/context/keybindings-sidebar.ts
@@ -184,7 +184,7 @@ export const SIDEBAR_BINDINGS: readonly KobeBinding[] = [
     scope: "sidebar",
     keys: ["u"],
     category: "Tasks pane",
-    description: "Open the update page (when a new version is available)",
+    description: "Open the update page — version check + release notes",
     hint: { keys: "u" },
   },
   {

--- a/packages/kobe/src/tui/lib/keymap-overrides.ts
+++ b/packages/kobe/src/tui/lib/keymap-overrides.ts
@@ -49,13 +49,19 @@ export type AppliedOverride = {
 
 /**
  * Ids whose event-shape or handler contract cannot be expressed by a rebind.
- * Currently empty — the last entries (`chat.question.*`) left with their
- * display-only rows — but the seam stays: `applyKeymapOverrides` rejects any
- * id listed here, and Settings → Keybindings surfaces the list when non-empty.
- * (sidebar.goto / sidebar.pin / sidebar.localMerge left 2026-07-17 when
- * shift+<letter> chords became expressible.)
+ * The four diff-review chords are raw literal bindings registered by
+ * preview-review.tsx (owner sign-off 2026-07-27: fixed, docs/KEYBINDINGS.md
+ * "Diff review") — the table rows exist so F1 lists them, but no handler
+ * reads the keymap, so an override would apply cleanly and change nothing.
+ * `applyKeymapOverrides` rejects any id listed here, and Settings →
+ * Keybindings surfaces the list.
  */
-export const FIXED_BINDING_IDS: Readonly<Record<string, string>> = {}
+export const FIXED_BINDING_IDS: Readonly<Record<string, string>> = {
+  "diff.review.cursor": "diff-review cursor is a fixed raw binding (j/k), not keymap-driven",
+  "diff.review.range": "diff-review range anchor is a fixed raw binding (v), not keymap-driven",
+  "diff.review.note": "diff-review note is a fixed raw binding (c), not keymap-driven",
+  "diff.review.send": "diff-review send is a fixed raw binding (s), not keymap-driven",
+}
 
 /**
  * Positional slot contract for a direction-multiplexed binding id. The
@@ -123,8 +129,8 @@ function scopesOverlap(a: string, b: string): boolean {
 export function applyKeymapOverrides(
   keymap: readonly OverridableBinding[],
   entries: readonly KeymapOverrideEntry[],
-  // Injectable so the fixed-id rejection stays testable while the shipped
-  // map is empty (FIXED_BINDING_IDS above).
+  // Injectable so the fixed-id rejection stays testable against a synthetic
+  // map (parameter defaults to the shipped FIXED_BINDING_IDS above).
   fixedIds: Readonly<Record<string, string>> = FIXED_BINDING_IDS,
 ): { applied: AppliedOverride[]; warnings: string[] } {
   const warnings: string[] = []

--- a/packages/kobe/src/tui/panes/filetree/pane-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/pane-core.ts
@@ -113,23 +113,38 @@ export type NavAction = { type: "expand" | "collapse"; path: string } | { type: 
  * an open dir, step into its first child; on a file, no-op (use
  * `enter` to open). Keeping `l` purely structural lets the user roam
  * through the tree without accidentally pulling the file into the
- * preview pane. */
+ * preview pane. Changes-tab untracked dirs (status rows carrying a
+ * `fileCount`) follow the same expand/descend semantics. */
 export function expandOrDescendAction(rows: readonly Row[], cursorIndex: number): NavAction | null {
   const row = rows[cursorIndex]
-  if (!row || row.kind !== "dir") return null
+  if (!row) return null
+  if (row.kind === "status") {
+    // Untracked-dir row → expand; already open → step onto its first child.
+    // Plain status rows (incl. children under an expanded untracked dir)
+    // never expand.
+    if (row.fileCount == null) return null
+    if (!row.expanded) return { type: "expand", path: row.path }
+    return cursorIndex + 1 < rows.length ? { type: "cursor", index: cursorIndex + 1 } : null
+  }
+  if (row.kind !== "dir") return null
   if (!row.expanded && row.hasChildren) return { type: "expand", path: row.path }
   if (row.expanded && cursorIndex + 1 < rows.length) return { type: "cursor", index: cursorIndex + 1 }
   return null
 }
 
 /** `h` — collapse the current directory, or jump to the parent dir
- * (depth - 1) walking upward in rows. All-tab behavior; the caller
- * gates on the active tab. */
+ * (depth - 1) walking upward in rows. Tab-agnostic: Changes-tab
+ * untracked dirs (status rows carrying a `fileCount`) collapse too;
+ * the status list is flat (no depth), so its other rows have no
+ * parent to jump to and no-op. */
 export function collapseOrParentAction(rows: readonly Row[], cursorIndex: number): NavAction | null {
   const row = rows[cursorIndex]
   if (!row) return null
   // Open dir → collapse.
   if (row.kind === "dir" && row.expanded) return { type: "collapse", path: row.path }
+  if (row.kind === "status") {
+    return row.fileCount != null && row.expanded ? { type: "collapse", path: row.path } : null
+  }
   if (row.kind !== "dir" && row.kind !== "file") return null
   const targetDepth = row.depth - 1
   if (targetDepth < 0) return null

--- a/packages/kobe/test/render/inbox-window.test.tsx
+++ b/packages/kobe/test/render/inbox-window.test.tsx
@@ -12,11 +12,13 @@
  */
 
 import { expect, test } from "bun:test"
+import { TextAttributes } from "@opentui/core"
 import type { AttentionInboxItem } from "../../src/client/remote-orchestrator"
 import type { KVContext } from "../../src/tui-react/context/kv"
 import { AttentionInboxPane } from "../../src/tui-react/workspace/AttentionInboxPane"
+import { writeInboxVisit } from "../../src/tui-react/workspace/inbox-visits"
 import { type Task, toTaskId } from "../../src/types/task"
-import { renderComponent } from "./harness"
+import { renderComponent, settle } from "./harness"
 
 function task(id: string, over: Partial<Task> = {}): Task {
   return {
@@ -103,4 +105,37 @@ test("a comfortable width keeps the full badge label", async () => {
   const tasks = [task("t0")]
   const text = await pane([item("t0", "permission_needed")], tasks, { width: 80, height: 30 })
   expect(text).toContain("needs input")
+})
+
+test("the clear hint dims on a RECENT row — only attention rows are dismissible", async () => {
+  const tasks = [task("t-att"), task("t-recent")]
+  const items = [item("t-att", "turn_complete")]
+  const kv = stubKv()
+  writeInboxVisit(kv, { taskId: toTaskId("t-recent"), tabId: null, at: Date.now() - 30_000 })
+  const { mockInput, spans } = await renderComponent(
+    <AttentionInboxPane
+      items={items}
+      tasks={tasks}
+      kv={kv}
+      onOpen={() => {}}
+      onOpenTask={() => {}}
+      onDelete={() => {}}
+      onClose={() => {}}
+    />,
+    { width: 80, height: 30 },
+  )
+
+  const clearHintAttrs = async (): Promise<number> => {
+    const hint = (await spans()).lines.flatMap((line) => line.spans).find((span) => span.text.includes("d clear"))
+    if (!hint) throw new Error("clear hint missing from the frame")
+    return hint.attributes ?? 0
+  }
+
+  // Cursor starts on the ATTENTION row: the hint is live.
+  expect((await clearHintAttrs()) & TextAttributes.DIM).toBe(0)
+  // `j` moves onto the RECENT row: a recent task has nothing to drop, so
+  // the hint must read as unavailable instead of advertising a dead chord.
+  mockInput.pressKey("j")
+  await settle()
+  expect((await clearHintAttrs()) & TextAttributes.DIM).not.toBe(0)
 })

--- a/packages/kobe/test/render/settings-dialog.test.tsx
+++ b/packages/kobe/test/render/settings-dialog.test.tsx
@@ -54,7 +54,9 @@ describe("SettingsDialog", () => {
     expect(text).toContain("5000ms second-stroke window")
     expect(text).toContain("On-screen entries + complete guide (default)")
     expect(text).toContain("Complete guide only")
-    expect(text).not.toContain("Fixed (not rebindable)") // FIXED_BINDING_IDS is empty
+    expect(text).toContain("Fixed (not rebindable)") // the four diff.review.* raw bindings
+    expect(text).toContain("diff.review.cursor")
+    expect(text).toContain("review.send") // the line wraps mid-id at this width
     text = await press("j") // → Feedback
     expect(text).toContain("GitHub Discussion")
     text = await press("j") // → Dev

--- a/packages/kobe/test/tui-react/filetree-pane-core.test.ts
+++ b/packages/kobe/test/tui-react/filetree-pane-core.test.ts
@@ -43,6 +43,16 @@ const statusRowsFixture: Row[] = [
   { kind: "status", path: "bin.dat", status: "A", added: null, deleted: null },
 ]
 
+// A small Changes-tab list: a plain modified file, then an untracked
+// directory (collapsed) with its children following once expanded.
+const changesRows: Row[] = [
+  { kind: "status", path: "src/index.ts", status: "M", added: 12, deleted: 202 },
+  { kind: "status", path: "untracked/", status: "?", added: 3, deleted: 0, fileCount: 2, expanded: false },
+  { kind: "status", path: "untracked/a.ts", status: "?", added: 1, deleted: 0, child: true },
+  { kind: "status", path: "untracked/b.ts", status: "?", added: 2, deleted: 0, child: true },
+]
+const changesRowsOpen: Row[] = changesRows.map((row) => (row.path === "untracked/" ? { ...row, expanded: true } : row))
+
 describe("statusToken", () => {
   test("maps every status to its theme token", () => {
     expect(statusToken("M")).toBe("warning")
@@ -120,6 +130,16 @@ describe("expandOrDescendAction (`l`)", () => {
     expect(expandOrDescendAction(treeRows, 1)).toBeNull()
     expect(expandOrDescendAction(treeRows, 99)).toBeNull()
   })
+  test("Changes-tab untracked dir (collapsed) → expand", () => {
+    expect(expandOrDescendAction(changesRows, 1)).toEqual({ type: "expand", path: "untracked/" })
+  })
+  test("Changes-tab untracked dir (open) → step onto its first child", () => {
+    expect(expandOrDescendAction(changesRowsOpen, 1)).toEqual({ type: "cursor", index: 2 })
+  })
+  test("Changes-tab plain status rows (incl. children) → no-op", () => {
+    expect(expandOrDescendAction(changesRows, 0)).toBeNull()
+    expect(expandOrDescendAction(changesRowsOpen, 2)).toBeNull()
+  })
 })
 
 describe("collapseOrParentAction (`h`)", () => {
@@ -130,10 +150,17 @@ describe("collapseOrParentAction (`h`)", () => {
     expect(collapseOrParentAction(treeRows, 1)).toEqual({ type: "cursor", index: 0 })
     expect(collapseOrParentAction(treeRows, 2)).toEqual({ type: "cursor", index: 0 })
   })
-  test("top-level file / status rows / empty → no-op", () => {
+  test("top-level file / empty → no-op", () => {
     expect(collapseOrParentAction(treeRows, 3)).toBeNull()
-    expect(collapseOrParentAction(statusRowsFixture, 0)).toBeNull()
     expect(collapseOrParentAction([], 0)).toBeNull()
+  })
+  test("Changes-tab untracked dir (open) → collapse it", () => {
+    expect(collapseOrParentAction(changesRowsOpen, 1)).toEqual({ type: "collapse", path: "untracked/" })
+  })
+  test("Changes-tab other status rows → no-op (flat list, no parent to jump to)", () => {
+    expect(collapseOrParentAction(changesRows, 1)).toBeNull()
+    expect(collapseOrParentAction(changesRows, 0)).toBeNull()
+    expect(collapseOrParentAction(changesRowsOpen, 2)).toBeNull()
   })
 })
 

--- a/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
+++ b/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
@@ -153,4 +153,87 @@ describe("workspace open-worktree bindings", () => {
     // The global prefix chord stays reachable from any pane.
     expect(registrations[0]?.enabled).not.toBe(false)
   })
+
+  function makeDeps(over: Partial<Parameters<typeof useWorkspaceKeybindings>[0]> = {}) {
+    const pages: HostPagesState = {
+      nav: "terminal",
+      setNav: vi.fn(),
+      goToNav: vi.fn(),
+      settingsOpen: false,
+      openSettings: vi.fn(),
+      closeSettings: vi.fn(),
+      worktreesOpen: false,
+      openWorktrees: vi.fn(),
+      closeWorktrees: vi.fn(),
+      updateOpen: false,
+      openUpdate: vi.fn(),
+      closeUpdate: vi.fn(),
+      kanbanOpen: false,
+      openKanban: vi.fn(),
+      closeKanban: vi.fn(),
+      automationsOpen: false,
+      openAutomations: vi.fn(),
+      closeAutomations: vi.fn(),
+      workItemsOpen: false,
+      openWorkItems: vi.fn(),
+      closeWorkItems: vi.fn(),
+    }
+    return {
+      focus: { focused: "sidebar", setFocused: vi.fn() } as never,
+      dialog: { stack: [] } as never,
+      pages,
+      searchActive: false,
+      selectedId: null,
+      openTaskWorktree: vi.fn(),
+      createTask: vi.fn(),
+      renameBranch: vi.fn(),
+      cycleVendor: vi.fn(),
+      toggleZen: vi.fn(),
+      jumpToNextAttention: vi.fn(),
+      openInbox: vi.fn(),
+      enterMoveMode: vi.fn(),
+      createPR: vi.fn(),
+      toggleSortMode: vi.fn(),
+      ...over,
+    }
+  }
+
+  // Registration order: [0] global, [1] focus.sidebar, [2] the sidebar
+  // page/quit group (s/x/u/q), [3] the task-lifecycle group.
+  const sidebarGroupIndex = 2
+
+  test("sidebar page/quit chords are gated off while the sidebar search box is active", () => {
+    useWorkspaceKeybindings(makeDeps({ searchActive: true }))
+
+    const group = mocks.bindingFactories.map((factory) => factory())[sidebarGroupIndex]
+    expect(group?.enabled).toBe(false)
+    // `s` (settings), `x` (worktrees), `u` (update) and the bare `q` quit
+    // chord must all stand down — the raw search listener only sees keys
+    // the keymap left unclaimed, so a dispatched `s` never reaches the box.
+    for (const key of ["s", "x", "u", "q"]) {
+      expect(group?.bindings.find((binding) => binding.key === key && !binding.prefix)).toBeDefined()
+    }
+  })
+
+  test("the same group is live when the search box is inactive", () => {
+    useWorkspaceKeybindings(makeDeps({ searchActive: false }))
+
+    const group = mocks.bindingFactories.map((factory) => factory())[sidebarGroupIndex]
+    expect(group?.enabled).toBe(true)
+  })
+
+  test("`u` always opens the update page — the page IS the version check", () => {
+    // Gating this on the boot-time update signal would make `u` a silent
+    // no-op whenever that signal is null: dev mode and a failed/offline
+    // registry lookup both answer null, and this chord is the only route
+    // to the page. The page re-checks with `force: true` and always offers
+    // release notes, so it is never actionless.
+    const openUpdate = vi.fn()
+    const deps = makeDeps()
+    deps.pages = { ...deps.pages, openUpdate }
+    useWorkspaceKeybindings(deps)
+    const group = mocks.bindingFactories.map((factory) => factory())[sidebarGroupIndex]
+    group?.bindings.find((binding) => binding.key === "u")?.cmd({} as never)
+    expect(openUpdate).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/kobe/test/tui/keymap-overrides.test.ts
+++ b/packages/kobe/test/tui/keymap-overrides.test.ts
@@ -20,6 +20,7 @@
 
 import { describe, expect, test } from "vitest"
 import {
+  FIXED_BINDING_IDS,
   type OverridableBinding,
   applyKeymapOverrides,
   extractKeybindingOverrides,
@@ -175,8 +176,8 @@ describe("applyKeymapOverrides", () => {
 
   test("unknown ids, fixed ids, and doc-only rows warn without applying", () => {
     const keymap = makeKeymap()
-    // The shipped FIXED_BINDING_IDS map is empty; inject one to keep the
-    // rejection path pinned (the parameter defaults to the shipped map).
+    // Exercise the injectable-map seam with a synthetic entry (the shipped
+    // map's own entries are pinned by the diff-review test below).
     const fixedIds = { "fixed.example": "handled outside the keymap" }
     const { applied, warnings } = applyKeymapOverrides(
       keymap,
@@ -193,6 +194,29 @@ describe("applyKeymapOverrides", () => {
     expect(warnings[1]).toMatch(/not customizable/)
     expect(warnings[2]).toMatch(/doc-only/)
     expect(keymap.find((b) => b.id === "fixed.example")?.keys).toEqual(["j", "k"])
+  })
+
+  test("the shipped FIXED_BINDING_IDS rejects all four diff.review ids", () => {
+    // The diff-review chords are raw literal bindings registered by
+    // preview-review.tsx — the table rows exist so F1 lists them, but no
+    // handler reads the keymap. Before they were listed here, an override
+    // "applied" cleanly and changed nothing.
+    //
+    // The rows carry real `keys` on purpose: with the doc-only `keys: []`
+    // an unlisted id still warns (as doc-only) and the warning COUNT stays
+    // 4, so dropping an entry from the shipped map would not fail. Asserting
+    // the fixed-id reason per id is what actually pins all four.
+    const ids = ["diff.review.cursor", "diff.review.range", "diff.review.note", "diff.review.send"]
+    for (const id of ids) {
+      const keymap: OverridableBinding[] = [{ id, scope: "files", keys: ["j"], hint: { keys: "j/k" } }]
+      const { applied, warnings } = applyKeymapOverrides(keymap, [{ id, keys: ["w"] }])
+      expect(applied).toEqual([])
+      expect(warnings).toHaveLength(1)
+      expect(warnings[0]).toMatch(/not customizable/)
+      // The keys the raw binding owns are untouched by the rejected override.
+      expect(keymap[0]?.keys).toEqual(["j"])
+      expect(FIXED_BINDING_IDS[id]).toBeDefined()
+    }
   })
 
   test("boundary rule: bare characters are dropped on workspace/global scope, kept on sidebar/files", () => {


### PR DESCRIPTION
Four places where a key looked live and did nothing (or did the wrong thing). No chord is added or moved — these are guards and one description.

### 1. Sidebar `s` / `x` / `u` / `q` leak into search

`/` then a query containing any of those letters dispatched Settings, Worktrees or the Update page instead of typing. The search reader (`view-core.ts:122`) bails on `defaultPrevented`, so a key the keymap claims never reaches the box — the character is simply lost. The group now carries the same `!deps.searchActive` gate the task-lifecycle group next to it already had for `n`.

### 2. The four `diff.review.*` bindings accepted overrides that did nothing

They are raw literals in `preview-review.tsx`; the table rows exist only so F1 lists them. An override applied cleanly, updated the help panel, and changed nothing — `docs/KEYBINDINGS.md` already said they can't be rebound. `FIXED_BINDING_IDS` existed for exactly this and was empty; the four ids now live there and an override is rejected with a warning.

### 3. Inbox `d` hint shown on rows that can't be cleared

Only attention rows are dismissible, but the footer rendered `d clear` unconditionally. It is dimmed on any other row.

### 4. `h` / `l` dead on the Files Changes tab

`h` was gated off the tab; `l` was rejected by `expandOrDescendAction` before it reached the row (it bailed on `kind !== "dir"`, and Changes rows are `kind: "status"`). Both now fold untracked directories, which were previously expandable only by mouse or `enter`.

### Not changed: `u` on the latest version

The audit suggested gating `u` on the update signal. Doing that would have made the key **worse**: `updateAcc` starts `null` and `checkLatestVersion` also answers `null` in dev mode and on any failed/offline lookup, so the chord would go silently dead in exactly the cases where you'd want to check. It is also the only route to the page, and the page is not actionless when current — it re-checks with `force: true` and always offers release notes. The stale *description* was the actual defect, so that is what changed, in both the F1 table and `docs/KEYBINDINGS.md`.

## Verification

Every fix passes remove-the-fix-→-tests-go-red, twice, with different mutation points, re-run after the rebase onto 0.9.39.

Round 2 exposed a real hole in the first version of the `FIXED_BINDING_IDS` test: with doc-only rows (`keys: []`) an unlisted id still warns, so the warning count stayed 4 and dropping an entry from the shipped map did not fail. The test now asserts the fixed-id rejection per id against rows carrying real keys.

Defects 1 and 3 were also verified on the real TUI through the `/harness` browser → xterm.js → PTY sidecar path. With the gate removed, `/` + `s` opens the full-window Settings page; with it, the buffer reads `/s█ 1/2` — the character reached the query and filtered the tree.

Tracks green locally: vitest 3758/3758, socket 624/624, typecheck, lint, i18n (694 keys × 2 locales), all touched files under the 500-line cap.