### PR TITLE
fix: close three git paths that could destroy user work

### DIFF
--- a/.changeset/git-work-loss-paths.md
+++ b/.changeset/git-work-loss-paths.md
@@ -1,0 +1,26 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Close three git paths that could destroy work.
+
+`land --strategy squash --delete-branch` left the branch's original commits
+reachable from nothing: the squash writes one unrelated commit onto the base,
+the worktree removal takes the only reflog that recorded the branch tip, and
+`git branch -D` takes the branch ref and its reflog. Rove now anchors the tip
+at `refs/rove/salvage/<branch>-<stamp>` before deleting a branch nothing else
+reaches, and returns it as `branchAnchor`. A `--no-ff` merge writes no anchor —
+the merge commit already reaches those commits.
+
+Removing a worktree from the Worktrees page, the web DELETE, or a land no
+longer unlinks the directory while its engine is still running. `git worktree
+remove` succeeds against a live process, so every write the engine made
+afterwards went into an unlinked inode — gone from disk, from the branch, and
+from the salvage snapshot taken before them. Both paths now tear the session
+down first, matching what task deletion already did.
+
+Salvage snapshots no longer drop gitignored work. `.gitignore` covers
+`HANDOFF.md`, `.scratch/`, `.env` and `.rove/` in this repo alone, and a force
+delete destroyed all of them while reporting success. Ignored entries up to
+64 MB each are now included; larger ones (`node_modules/`, build output) stay
+out.

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -126,12 +126,41 @@ The first confirmation can never silently turn into a force deletion. The
 second confirmation is the boundary that authorizes data loss. The branch is
 still retained, but uncommitted and untracked files are not part of it.
 
+### Landing with `--delete-branch`
+
+`land --delete-branch` deletes the branch with `git branch -D`, which removes
+the branch's reflog along with its ref — and the worktree removed just before
+it held the only other reflog for that branch. After a `--strategy merge`
+land that costs nothing: the merge commit on the base still reaches every
+commit. After a `--strategy squash` land it would, because the squash writes
+one new commit that has no link back to the branch's own commits.
+
+So before deleting a branch nothing else keeps reachable, Rove writes its tip
+to `refs/rove/salvage/<branch>-<timestamp>` — the same namespace as the
+force-delete snapshots below, listed by the same command. `rove api land`
+returns it as `branchAnchor`. Recover the pre-squash history with:
+
+```
+git log refs/rove/salvage/<branch>-<timestamp>
+git branch <recovered-name> refs/rove/salvage/<branch>-<timestamp>
+```
+
+No anchor is written when another ref already reaches the tip, which is the
+ordinary merge case.
+
 ### Recovering work a force delete destroyed
 
-Before any forced removal, Rove snapshots everything the removal is about to
+Before any forced removal, Rove snapshots what the removal is about to
 destroy — modified tracked files and files you never `git add`ed — into a git
-ref in the owning repo. Files matched by `.gitignore` (`node_modules/`, build
-output) are excluded.
+ref in the owning repo.
+
+Files matched by `.gitignore` are included too, but only up to 64 MB per
+top-level entry. That threshold is the whole rule: a gitignored note or
+scratch directory is kilobytes and gets snapshotted; `node_modules/` or a
+build directory is far larger and is skipped, because a snapshot carrying one
+is too big to be useful. An ignored entry whose size cannot be read is
+skipped. So a gitignored `HANDOFF.md` or `.scratch/` is recoverable, and a
+gitignored 200 MB `dist/` is not.
 
 List the snapshots, newest last:
 

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -112,6 +112,10 @@ export interface LandResult {
    *  failure-only: it also rides with `removed: true` when the directory went
    *  but clearing the task's worktree path did not. */
   readonly worktree?: { readonly removed: boolean; readonly reason?: string }
+  /** Ref anchoring a deleted branch's tip when nothing else reached it (the
+   *  squash-land case). Absent on a `--no-ff` merge and when no branch was
+   *  deleted. */
+  readonly branchAnchor?: { readonly ref: string; readonly commit: string }
 }
 
 export interface AdoptableWorktree {

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -59,6 +59,25 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
     async handle(payload, ctx) {
       const path = requireString(payload, "path")
       const force = payload.force === true
+      // Tear the engine down BEFORE unlinking its directory. `git worktree
+      // remove` succeeds against a live process — POSIX unlink does not care
+      // that something holds the directory as its cwd — and every write that
+      // engine makes afterwards lands in an unlinked inode: not on disk, not
+      // in the branch, and not in the salvage snapshot (which ran before
+      // them). The task-deletion path already orders it this way
+      // (`task-deletion-runner.ts`); this one did not.
+      //
+      // Ordering, not gating: teardown failure must not block a removal the
+      // user confirmed (the worktrees page's delete is optimistic — the row
+      // is already gone from their screen), and a dead/absent session throws
+      // the same way a stuck one does, which would strand every already-dead
+      // task's worktree. Logged, then the removal proceeds.
+      const taskId = ctx.orch ? matchTaskByWorktreePath(ctx.orch.listTasks(), path) : undefined
+      if (taskId) {
+        await ctx.runtime
+          .tearDownTaskSession(taskId)
+          .catch((err) => logDaemonError("worktree-remove-session-teardown", err))
+      }
       await ctx.runtime.removeWorktree(path, force)
       // Self-heal the task index: a worktree removed here (worktrees page /
       // web) otherwise leaves the owning task pointing at a dead dir, so the
@@ -67,8 +86,7 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
       // Exact-path match; unmatched (untracked worktree) is a harmless no-op.
       // Guarded on `ctx.orch` — this handler historically composes runtime
       // primitives directly, so a caller may not wire an orchestrator.
-      const taskId = ctx.orch ? matchTaskByWorktreePath(ctx.orch.listTasks(), path) : undefined
-      if (taskId) await ctx.orch.clearWorktreePath(taskId)
+      if (taskId && ctx.orch) await ctx.orch.clearWorktreePath(taskId)
       return { removed: true }
     },
   },

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -33,7 +33,12 @@ export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
         default: "merge",
         description: "merge (--no-ff) or squash into one commit.",
       },
-      { name: "delete-branch", type: "bool", description: "Delete the task's branch after a successful land." },
+      {
+        name: "delete-branch",
+        type: "bool",
+        description:
+          "Delete the task's branch after a successful land. Uses `git branch -D`, which drops the branch's reflog too; with --strategy squash the base's new commit does not reach the branch's own commits, so Rove first anchors the tip at refs/rove/salvage/<branch>-<stamp> and returns it as `branchAnchor`.",
+      },
       {
         name: "remove-worktree",
         type: "bool",

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -11,6 +11,7 @@ import { auditDeletionSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletio
 import { Orchestrator } from "../orchestrator/core.ts"
 import { TaskIndexStore } from "../orchestrator/index/store.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
+import { tearDownTaskSessionAdapter } from "./daemon-session-adapter.ts"
 
 export interface KobeCoreOptions {
   readonly homeDir?: string
@@ -37,6 +38,10 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
     // user asking "what happened to my task".
     onSalvage: (taskId, salvage) =>
       auditDeletionSalvaged(String(taskId), salvage.ref, salvage.commit, store.get(taskId)?.repo),
+    // A landed worktree is about to be unlinked; anything the engine writes
+    // into it after that is written to nothing. Same ordering the task-
+    // deletion runner already uses.
+    tearDownSession: (taskId) => tearDownTaskSessionAdapter(String(taskId)),
   })
 
   return {

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -55,6 +55,13 @@ export interface OrchestratorDeps {
    *  local orchestrator leaves it unset and the snapshot is still findable
    *  via `git for-each-ref refs/rove/salvage`. */
   readonly onSalvage?: (taskId: TaskId, salvage: { readonly ref: string; readonly commit: string }) => void
+  /**
+   * Kill a task's engine session. Bound by the composition root to the hosted
+   * session host; a TUI-local orchestrator leaves it unset. `landTask` calls
+   * it before removing a landed worktree — an engine still writing into a
+   * directory that is about to be unlinked loses everything it writes next.
+   */
+  readonly tearDownSession?: (taskId: TaskId | string) => Promise<void>
 }
 
 // Re-exported from `title.ts` (its single source of truth) so existing
@@ -81,10 +88,13 @@ export class Orchestrator {
   private readonly unsubscribeStore: TaskIndexUnsubscribe
   /** Owns the `kind:"main"` project row (create / adopt / forget). */
   private readonly mainTasks: MainTaskCoordinator
+  /** Injected engine-session teardown — see {@link OrchestratorDeps.tearDownSession}. */
+  private readonly tearDownSession?: (taskId: TaskId | string) => Promise<void>
 
   constructor(deps: OrchestratorDeps) {
     this.store = deps.store
     this.worktrees = deps.worktrees
+    this.tearDownSession = deps.tearDownSession
     this.worktreeCoordinator = new WorktreeCoordinator(this.store, this.worktrees, canonPath, (repo) =>
       this.ensureMainTask(repo),
     )
@@ -383,6 +393,7 @@ export class Orchestrator {
     return landTaskWithCleanup(this.requireTask(id), opts ?? {}, {
       worktrees: this.worktrees,
       clearWorktreePath: (tid) => this.clearWorktreePath(tid),
+      tearDownSession: this.tearDownSession,
     })
   }
 

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -23,6 +23,7 @@ import type { Task, TaskId } from "../types/task.ts"
 import { EmptyBranchDirtyWorktreeError, EmptyBranchError, LandConflictError, MainCheckoutDirtyError } from "./errors.ts"
 import { type WorktreeExecDeps, defaultExecDeps } from "./worktree/exec-deps.ts"
 import { GitWorktreeManager } from "./worktree/manager.ts"
+import type { SalvageRecord } from "./worktree/salvage.ts"
 
 export type LandStrategy = "merge" | "squash"
 
@@ -51,6 +52,13 @@ export interface LandDeps {
   readonly worktrees: Pick<GitWorktreeManager, "deleteBranch" | "remove">
   /** Unlink the task's worktreePath after its worktree is removed. */
   readonly clearWorktreePath: (id: TaskId | string) => Promise<void>
+  /**
+   * Kill the task's engine session before its worktree directory goes.
+   * Injected rather than imported: the session host lives in `core/`, which
+   * already imports this layer. Unset (a TUI-local orchestrator, a test) means
+   * no session to tear down.
+   */
+  readonly tearDownSession?: (id: TaskId | string) => Promise<void>
 }
 
 /**
@@ -83,8 +91,27 @@ export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: 
   // `removeWorktree: false` keeps it. The BRANCH is untouched either way —
   // git is the durable record, the directory is not.
   const worktree = opts.removeWorktree === false ? undefined : await removeLandedWorktree(task, opts.callerCwd, deps)
-  if (opts.deleteBranch) await deps.worktrees.deleteBranch(task.repo, result.branch, { force: true })
-  return worktree ? { ...result, worktree } : result
+  // `deleteBranch` is `branch -D`, which drops the branch's reflog as well as
+  // its ref — and the worktree removed on the line above took the only OTHER
+  // reflog (`.git/worktrees/<slug>/logs/HEAD`) with it. Under `--strategy
+  // squash` the base's new commit has no link back to the branch's commits,
+  // so without an anchor those commits are reachable from nothing at all.
+  // `deleteBranch` writes one and reports it here; on a `--no-ff` merge it
+  // finds the merge commit already reaches the tip and writes nothing.
+  let branchAnchor: SalvageRecord | null = null
+  if (opts.deleteBranch) {
+    await deps.worktrees.deleteBranch(task.repo, result.branch, {
+      force: true,
+      onAnchor: (record) => {
+        branchAnchor = record
+      },
+    })
+  }
+  return {
+    ...result,
+    ...(worktree ? { worktree } : {}),
+    ...(branchAnchor ? { branchAnchor } : {}),
+  }
 }
 
 /** Best-effort realpath for containment/identity checks (`/var` vs `/private/var`). */
@@ -121,6 +148,27 @@ async function removeLandedWorktree(
       }
     }
   }
+  // Kill the engine BEFORE unlinking the directory it is working in. The
+  // dirty check that let this land through ran seconds ago, in `landTask`; an
+  // engine still running has kept writing since. `git worktree remove`
+  // succeeds against a live process anyway — POSIX unlink does not care that
+  // something holds the directory as its cwd — and every write it makes after
+  // that goes to an unlinked inode: not on disk, not on the branch, not
+  // anywhere. Placed after the refusal checks so a land that is not going to
+  // remove anything does not kill a session for nothing.
+  //
+  // Ordering, not gating: the merge has already committed, so a teardown
+  // failure must not strand the worktree. `remove()` without force still
+  // refuses a dirty tree, which is the real guard on unsaved work; a stuck
+  // session that keeps writing is reported through that refusal, not by
+  // aborting here.
+  if (deps.tearDownSession) {
+    try {
+      await deps.tearDownSession(task.id)
+    } catch {
+      // best-effort; the dirty-refusal in remove() below is the real guard
+    }
+  }
   try {
     await deps.worktrees.remove(worktreePath)
   } catch (err) {
@@ -153,6 +201,15 @@ export interface LandResult {
   /** The post-land worktree cleanup outcome. Present unless removal was
    *  explicitly declined (`removeWorktree: false`). */
   readonly worktree?: LandWorktreeCleanup
+  /**
+   * The ref anchoring the deleted branch's tip, when `deleteBranch` deleted a
+   * branch nothing else kept reachable — i.e. after a squash land, where the
+   * base's new commit has no link back to the branch's own commits. Absent on
+   * a `--no-ff` merge (the merge commit already reaches them) and when no
+   * branch was deleted. Reported so a user can recover the pre-squash history
+   * without knowing `refs/rove/salvage` exists.
+   */
+  readonly branchAnchor?: { readonly ref: string; readonly commit: string }
 }
 
 /** Resolve the git working dir + ExecHost for the base repo — local path or remote basePath. */

--- a/packages/kobe/src/orchestrator/worktree/branch-anchor.ts
+++ b/packages/kobe/src/orchestrator/worktree/branch-anchor.ts
@@ -1,0 +1,73 @@
+/**
+ * Anchor a branch tip before a delete that would make it unreachable.
+ *
+ * `git branch -D` deletes the branch ref AND its reflog. For a branch whose
+ * commits are reachable from somewhere else — a `--no-ff` merge leaves them
+ * parented under the merge commit — that is harmless. After a SQUASH land it
+ * is not: the base gets one brand-new commit with no link back, so the
+ * branch's own commits become reachable from nothing at all.
+ *
+ * The per-worktree reflog is not a backstop either. It lives in
+ * `.git/worktrees/<slug>/logs/HEAD`, and `land --delete-branch` removes the
+ * worktree first, so by the time `-D` runs both copies are already gone. What
+ * is left is dangling objects: findable only by `git fsck --lost-found`, and
+ * only until `gc.pruneExpire` (two weeks by default) collects them.
+ *
+ * So: before deleting, write the tip into `refs/rove/salvage/…` — the same
+ * namespace {@link salvageWorktree} uses, so one `for-each-ref` lists every
+ * kind of rescued work. Skipped when the commits are already reachable from
+ * another ref, which is the ordinary `--strategy merge` case: an anchor there
+ * would be noise nobody ever needs.
+ */
+
+import type { ExecHost } from "../../exec/exec-host.ts"
+import type { GitRunOpts, GitRunResult } from "./git.ts"
+import { type SalvageRecord, salvageRef } from "./salvage.ts"
+
+/** The git primitives the anchor borrows from the manager. */
+export interface BranchAnchorDeps {
+  runGit(exec: ExecHost, args: readonly string[], opts: GitRunOpts): Promise<GitRunResult>
+}
+
+/**
+ * Write `refs/rove/salvage/<branch>-<stamp>` at `branch`'s tip when nothing
+ * else would keep it reachable.
+ *
+ * Returns null when no anchor was needed (the tip is already reachable from
+ * another ref) or when one could not be written. NEVER throws: this guards a
+ * deletion the caller has already asked for, so a failure here must not turn
+ * that deletion into an error — the same contract as {@link salvageWorktree}.
+ */
+export async function anchorBranchTip(
+  deps: BranchAnchorDeps,
+  exec: ExecHost,
+  repo: string,
+  branch: string,
+  now: Date = new Date(),
+): Promise<SalvageRecord | null> {
+  if (!branch || branch === "HEAD") return null
+  const git = (args: readonly string[]) => deps.runGit(exec, args, { cwd: repo, allowFail: true })
+  try {
+    const tipOut = await git(["rev-parse", "--verify", `refs/heads/${branch}`])
+    const tip = tipOut.stdout.trim()
+    if (tipOut.exitCode !== 0 || !tip) return null
+
+    // Any ref OTHER than the branch itself containing the tip means the
+    // commits survive the delete on their own — the `--no-ff` merge case.
+    // `--contains` walks history, so a merge commit on the base branch counts.
+    const holders = await git(["for-each-ref", "--contains", tip, "--format=%(refname)"])
+    if (holders.exitCode === 0) {
+      const others = holders.stdout
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0 && l !== `refs/heads/${branch}`)
+      if (others.length > 0) return null
+    }
+
+    const ref = salvageRef(branch, now)
+    if ((await git(["update-ref", ref, tip])).exitCode !== 0) return null
+    return { ref, commit: tip }
+  } catch {
+    return null
+  }
+}

--- a/packages/kobe/src/orchestrator/worktree/manager-branch.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-branch.ts
@@ -9,8 +9,10 @@
  */
 
 import type { ExecHost } from "../../exec/exec-host.ts"
+import { anchorBranchTip } from "./branch-anchor.ts"
 import type { ExecCtx } from "./exec-deps.ts"
 import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
+import type { SalvageRecord } from "./salvage.ts"
 
 /** The manager primitives the branch functions borrow. */
 export interface BranchDeps {
@@ -48,6 +50,33 @@ export async function deleteBranchIn(
 ): Promise<void> {
   if (!branch || branch === "HEAD") return
   await deps.runGit(exec, ["branch", force ? "-D" : "-d", branch], { cwd: repo, allowFail: true })
+}
+
+/**
+ * Delete a branch, anchoring its tip first when `force` would otherwise strand
+ * it.
+ *
+ * `git branch -D` drops the branch ref AND its reflog, so a tip no other ref
+ * reaches becomes a dangling object — findable only by `git fsck` and
+ * collected by `gc` after `gc.pruneExpire`. `land --strategy squash
+ * --delete-branch` produces exactly that: the squash writes an unrelated
+ * commit onto the base, and the worktree (holding the only other reflog) is
+ * already removed by the time this runs.
+ *
+ * {@link anchorBranchTip} no-ops when another ref already contains the tip,
+ * which is the ordinary `--no-ff` merge case, so this only writes a ref when
+ * one is genuinely load-bearing. A failed anchor never fails the deletion the
+ * caller asked for.
+ */
+export async function deleteBranchAnchored(
+  deps: BranchDeps,
+  exec: ExecHost,
+  repo: string,
+  branch: string,
+  opts: { readonly force: boolean; readonly onAnchor?: (record: SalvageRecord | null) => void },
+): Promise<void> {
+  if (opts.force) opts.onAnchor?.(await anchorBranchTip(deps, exec, repo, branch))
+  await deleteBranchIn(deps, exec, repo, branch, opts.force)
 }
 
 /**

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -35,7 +35,7 @@ import {
   type BranchDeps,
   branchExists,
   branchHasUpstream,
-  deleteBranchIn,
+  deleteBranchAnchored,
   hasLocalBranch,
   renameBranch,
 } from "./manager-branch.ts"
@@ -237,10 +237,7 @@ export class GitWorktreeManager implements WorktreeManager {
 
     // Capture the branch BEFORE removal (once the worktree is gone we can't
     // read its HEAD) so an opt-in `deleteBranch` can clean it up after.
-    let branch: string | null = null
-    if (opts?.deleteBranch) {
-      branch = await this.currentBranch(worktreePath).catch(() => null)
-    }
+    const branch = opts?.deleteBranch ? await this.currentBranch(worktreePath).catch(() => null) : null
 
     if (force) {
       // The last moment at which the doomed files still exist. The dirty check
@@ -269,14 +266,30 @@ export class GitWorktreeManager implements WorktreeManager {
     // remove left it behind (rare, but documented in vibe-kanban).
     await this.runGit(exec, ["worktree", "prune"], { cwd: repo, allowFail: true })
 
-    if (branch) await deleteBranchIn(this.branchDeps(), exec, repo, branch, force)
+    // Anchored like `deleteBranch`: `-D` takes the reflog too, and this
+    // worktree's own reflog died with the directory a few lines up.
+    if (branch) await deleteBranchAnchored(this.branchDeps(), exec, repo, branch, { force })
   }
 
-  /** Delete a branch in `repo` — body in `manager-branch.ts`. */
-  async deleteBranch(repo: string, branch: string, opts?: { readonly force?: boolean }): Promise<void> {
+  /** Delete a branch in `repo` — body in `manager-branch.ts`. A forced delete
+   *  anchors the tip first when nothing else would keep it reachable (see
+   *  {@link deleteBranchAnchored}); `onAnchor` reports the ref it wrote. */
+  async deleteBranch(
+    repo: string,
+    branch: string,
+    opts?: {
+      readonly force?: boolean
+      /** Notified with the anchor a forced delete took (null = not needed,
+       *  or the anchor could not be written). */
+      readonly onAnchor?: (record: SalvageRecord | null) => void
+    },
+  ): Promise<void> {
     const ctx = this.ctxFor(repo)
     requireAbsolute("repo", ctx.dir)
-    await deleteBranchIn(this.branchDeps(), ctx.exec, ctx.dir, branch, opts?.force === true)
+    await deleteBranchAnchored(this.branchDeps(), ctx.exec, ctx.dir, branch, {
+      force: opts?.force === true,
+      onAnchor: opts?.onAnchor,
+    })
   }
 
   /** ExecHost for a worktree path, with the absolute-path check bound in — the

--- a/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
@@ -1,0 +1,80 @@
+/**
+ * Which `.gitignore`d paths a salvage snapshot should rescue anyway.
+ *
+ * `git add -A` honours `.gitignore`, which keeps `node_modules/` and build
+ * output out of the snapshot — and also throws away real work. In this repo
+ * alone, `.gitignore` covers `HANDOFF.md` and `.scratch/**`, the two places
+ * AGENTS.md tells agents to keep cross-session reasoning, plus `.env*` and
+ * `.rove/*`. Force-deleting a worktree destroyed all of them while the salvage
+ * ref reported success.
+ *
+ * "Ignored" answers "should git track this", not "is this the user's work".
+ * The distinction that actually matters is SIZE: a hand-written note is
+ * kilobytes, a dependency tree or build output is hundreds of megabytes, and
+ * a snapshot that swallows `node_modules/` is one nobody can use. So the rule
+ * is a byte budget rather than a filename list — no allowlist to maintain, and
+ * an ignored path this repo has never heard of is rescued on the same terms.
+ *
+ * `git status --porcelain --ignored` reports ignored DIRECTORIES collapsed to
+ * one entry (`node_modules/`) and ignored FILES individually (`HANDOFF.md`),
+ * so one `du -sk` per entry measures whole trees without walking them here.
+ */
+
+import type { ExecHost } from "../../exec/exec-host.ts"
+
+/**
+ * Per-entry size ceiling, in kilobytes. 64 MB: comfortably above any plausible
+ * hand-authored file or notes directory (`.scratch/` with a year of markdown
+ * is single-digit MB), comfortably below a dependency tree or build output
+ * (`node_modules/` in this repo is ~1.4 GB). Applied per top-level entry, so
+ * one oversized tree is skipped without costing the others.
+ */
+const MAX_IGNORED_ENTRY_KB = 64 * 1024
+
+/** Parse `git status --porcelain -z --ignored` into the `!!` (ignored) paths. */
+export function parseIgnoredPaths(stdoutZ: string): string[] {
+  return stdoutZ
+    .split("\0")
+    .filter((entry) => entry.startsWith("!! "))
+    .map((entry) => entry.slice(3))
+    .filter((p) => p.length > 0)
+}
+
+/** Parse `du -sk <paths…>` output into path → kilobytes. */
+export function parseDuKb(stdout: string): Map<string, number> {
+  const sizes = new Map<string, number>()
+  for (const line of stdout.split("\n")) {
+    const m = /^(\d+)\s+(.+)$/.exec(line.trim())
+    if (m?.[1] && m[2]) sizes.set(m[2], Number.parseInt(m[1], 10))
+  }
+  return sizes
+}
+
+/**
+ * The ignored paths in `worktreePath` small enough to be worth snapshotting.
+ *
+ * Returns `[]` on any failure — salvage must degrade to its old
+ * ignored-files-excluded behaviour rather than fail the removal a caller
+ * already asked for. An entry whose size cannot be read is SKIPPED, not
+ * guessed at: an unmeasurable path is more likely a huge tree than a note,
+ * and a snapshot that swallows one is worse than one that misses it.
+ */
+export async function smallIgnoredPaths(exec: ExecHost, worktreePath: string): Promise<string[]> {
+  try {
+    const status = await exec.run(["git", "status", "--porcelain", "-z", "--ignored"], { cwd: worktreePath })
+    if (status.exitCode !== 0) return []
+    const paths = parseIgnoredPaths(status.stdout)
+    if (paths.length === 0) return []
+
+    // One `du` for every entry: each ignored directory is reported collapsed,
+    // so this is a handful of arguments, not a walk of the whole tree.
+    const du = await exec.run(["du", "-sk", ...paths], { cwd: worktreePath })
+    const sizes = parseDuKb(du.stdout)
+    return paths.filter((p) => {
+      const kb = sizes.get(p)
+      return kb !== undefined && kb <= MAX_IGNORED_ENTRY_KB
+    })
+  } catch {
+    return []
+  }
+}

--- a/packages/kobe/src/orchestrator/worktree/salvage.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage.ts
@@ -19,8 +19,11 @@
  *     git commit-tree <tree> -p HEAD          → a commit rooted at real history
  *     git update-ref refs/rove/salvage/<slug> → a named, gc-proof anchor
  *
- * `git add -A` honours `.gitignore`, so `node_modules/` and build output stay
- * out; only files a user could actually have authored are captured.
+ * `git add -A` honours `.gitignore` — which keeps `node_modules/` out, and
+ * ALSO threw away real work: `HANDOFF.md`, `.scratch/**`, `.env*` and
+ * `.rove/*` are all gitignored in this very repo. So a second, forced `git
+ * add -f` pass adds back the ignored entries small enough to be a person's
+ * work rather than a dependency tree ({@link smallIgnoredPaths}).
  *
  * The ref (not just the loose object) is the point: a dangling commit is
  * findable only via `git fsck` and expires with gc, while
@@ -30,6 +33,7 @@
 
 import type { ExecHost } from "../../exec/exec-host.ts"
 import type { GitRunOpts, GitRunResult } from "./git.ts"
+import { smallIgnoredPaths } from "./salvage-ignored.ts"
 
 /** The git primitives salvage borrows from the manager. */
 export interface SalvageDeps {
@@ -43,8 +47,11 @@ export interface SalvageRecord {
 }
 
 /** `refs/rove/salvage/<branch>-<utc-stamp>` — a ref name git accepts, keyed by
- *  the two things a user remembers: which branch, and roughly when. */
-function salvageRef(branch: string | null, now: Date): string {
+ *  the two things a user remembers: which branch, and roughly when. Exported
+ *  so {@link anchorBranchTip} writes into the SAME namespace: a user who lost
+ *  work has one place to look and one `for-each-ref` to run, whether the loss
+ *  was a force-removed worktree or a squash-landed branch. */
+export function salvageRef(branch: string | null, now: Date): string {
   const stamp = now
     .toISOString()
     .replace(/[-:]/g, "")
@@ -84,6 +91,12 @@ export async function salvageWorktree(
 
     try {
       if ((await withIndex(["add", "-A"])).exitCode !== 0) return null
+      // Second pass: the ignored entries that are a person's work rather than
+      // build output. `-f` is what overrides `.gitignore`; without it the
+      // first pass silently dropped them. Best-effort — a failure here leaves
+      // the tracked+untracked snapshot the first pass already staged.
+      const ignored = await smallIgnoredPaths(exec, worktreePath)
+      if (ignored.length > 0) await withIndex(["add", "-f", "--", ...ignored])
       const tree = (await withIndex(["write-tree"])).stdout.trim()
       if (!tree) return null
 

--- a/packages/kobe/test/daemon/worktree-list-handler.test.ts
+++ b/packages/kobe/test/daemon/worktree-list-handler.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { execSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
@@ -108,5 +108,75 @@ describe("worktree.remove", () => {
 
   it("rejects a missing path", async () => {
     await expect(dispatch("worktree.remove", {})).rejects.toThrow("path is required")
+  })
+
+  /**
+   * The engine must be killed BEFORE the directory is unlinked.
+   *
+   * `git worktree remove` succeeds against a live process — POSIX unlink does
+   * not care that something holds the directory as its cwd — so an engine
+   * still running writes every subsequent file into an unlinked inode: not on
+   * disk, not in the branch, and not in the salvage snapshot (which ran
+   * before those writes). The task-deletion path already ordered it this way;
+   * this handler did not.
+   *
+   * The assertion is the ORDER, recorded by the teardown fake at the moment
+   * it runs. Asserting only "teardown was called" would pass just as happily
+   * with the calls the wrong way round, which is the bug.
+   */
+  it("tears the engine session down BEFORE unlinking the directory", async () => {
+    const wt = join(root, "live-worktree")
+    execSync(`git worktree add -b feature/live ${JSON.stringify(wt)}`, { cwd: repo, env: gitEnv })
+
+    const order: string[] = []
+    const ctx = {
+      runtime: {
+        ...daemonRuntime,
+        tearDownTaskSession: async (taskId: string) => {
+          // Existing at teardown time is the whole point: after the removal
+          // this is false, and an engine writing here would write to nothing.
+          order.push(`teardown:${taskId}:dirExists=${existsSync(wt)}`)
+        },
+      },
+      orch: {
+        listTasks: () => [{ id: "task-live", worktreePath: wt }],
+        clearWorktreePath: async () => {
+          order.push("clearWorktreePath")
+        },
+      },
+    } as unknown as DaemonHandlerContext
+
+    await expect(
+      dispatchDaemonRequest(createDaemonHandlerRegistry(), "worktree.remove", { path: wt }, ctx),
+    ).resolves.toEqual({ removed: true })
+
+    expect(order).toEqual(["teardown:task-live:dirExists=true", "clearWorktreePath"])
+    expect(existsSync(wt)).toBe(false)
+  })
+
+  /**
+   * Ordering, not gating. The worktrees page's delete is optimistic — the row
+   * has already left the user's screen — and a task whose engine is already
+   * dead throws here the same way a stuck one does. Blocking on that would
+   * strand every such worktree permanently.
+   */
+  it("still removes the worktree when session teardown fails", async () => {
+    const wt = join(root, "teardown-fails")
+    execSync(`git worktree add -b feature/teardown-fails ${JSON.stringify(wt)}`, { cwd: repo, env: gitEnv })
+
+    const ctx = {
+      runtime: {
+        ...daemonRuntime,
+        tearDownTaskSession: async () => {
+          throw new Error("session host unreachable")
+        },
+      },
+      orch: { listTasks: () => [{ id: "task-x", worktreePath: wt }], clearWorktreePath: async () => {} },
+    } as unknown as DaemonHandlerContext
+
+    await expect(
+      dispatchDaemonRequest(createDaemonHandlerRegistry(), "worktree.remove", { path: wt }, ctx),
+    ).resolves.toEqual({ removed: true })
+    expect(existsSync(wt)).toBe(false)
   })
 })

--- a/packages/kobe/test/orchestrator/branch-anchor.test.ts
+++ b/packages/kobe/test/orchestrator/branch-anchor.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Deleting a branch must not make its commits unreachable.
+ *
+ * `land --strategy squash --delete-branch` is the sequence that used to lose
+ * work: the squash writes ONE new commit onto the base with no link back, the
+ * worktree removal takes `.git/worktrees/<slug>/logs/HEAD` (the only reflog
+ * that ever recorded this branch's tip, because the base checkout never had
+ * the branch checked out), and `git branch -D` then takes the branch ref AND
+ * its reflog. The original commits end up reachable from nothing — findable
+ * only by `git fsck --lost-found`, and only until gc collects them.
+ *
+ * Real git and a real land: the assertions run `git rev-list --all` and
+ * `for-each-ref --contains` AFTER the branch is gone, because "the object is
+ * still in the database" is exactly the state that loses the work. What has to
+ * hold is REACHABILITY.
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, expect, test } from "vitest"
+import { landTaskWithCleanup } from "../../src/orchestrator/land.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import type { Task } from "../../src/types/task.ts"
+import { toTaskId } from "../../src/types/task.ts"
+
+let tmpRoot: string
+let repo: string
+
+function git(cwd: string, ...args: string[]): string {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr || r.stdout}`)
+  return r.stdout
+}
+
+function task(branch: string, worktreePath: string): Task {
+  const now = new Date().toISOString()
+  return {
+    id: toTaskId("t-anchor"),
+    kind: "task",
+    repo,
+    title: "anchor",
+    branch,
+    worktreePath,
+    status: "backlog",
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/** Whether `sha` is reachable from ANY ref in the repo. */
+function reachable(sha: string): boolean {
+  return git(repo, "rev-list", "--all")
+    .split("\n")
+    .some((l) => l.trim() === sha)
+}
+
+function deps() {
+  return { worktrees: new GitWorktreeManager(), clearWorktreePath: async () => {} }
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rove-anchor-"))
+  repo = path.join(tmpRoot, "repo")
+  fs.mkdirSync(repo)
+  git(repo, "init", "-b", "main", ".")
+  git(repo, "config", "user.email", "t@t.t")
+  git(repo, "config", "user.name", "t")
+  fs.writeFileSync(path.join(repo, "a.txt"), "base\n")
+  git(repo, "add", "-A")
+  git(repo, "commit", "-qm", "base")
+})
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+/** A worktree on `branch` with `count` separate commits, tip returned. */
+function worktreeWithCommits(branch: string, count: number): { wt: string; tip: string; shas: string[] } {
+  const wt = path.join(tmpRoot, branch)
+  git(repo, "worktree", "add", "-q", wt, "-b", branch)
+  const shas: string[] = []
+  for (let i = 1; i <= count; i++) {
+    fs.appendFileSync(path.join(wt, "work.txt"), `work ${i}\n`)
+    git(wt, "add", "-A")
+    git(wt, "commit", "-qm", `commit ${i}`)
+    shas.push(git(wt, "rev-parse", "HEAD").trim())
+  }
+  return { wt, tip: shas[shas.length - 1] as string, shas }
+}
+
+test("squash land with --delete-branch keeps every original commit reachable", async () => {
+  const { wt, tip, shas } = worktreeWithCommits("feature", 12)
+
+  const res = await landTaskWithCleanup(
+    task("feature", wt),
+    { strategy: "squash", deleteBranch: true, removeWorktree: true },
+    deps(),
+  )
+
+  // The land itself did what it says: one squashed commit, branch gone,
+  // worktree gone. This is the destructive sequence, not a softened one.
+  expect(res.strategy).toBe("squash")
+  expect(fs.existsSync(wt)).toBe(false)
+  expect(git(repo, "branch", "--list", "feature").trim()).toBe("")
+
+  // The anchor is reported, not just written — a ref nobody is told about is
+  // barely better than a dangling object.
+  expect(res.branchAnchor?.ref).toMatch(/^refs\/rove\/salvage\/feature-/)
+  expect(res.branchAnchor?.commit).toBe(tip)
+
+  // The point of the whole exercise: `git rev-parse` finding the object is
+  // NOT enough (a dangling commit answers that too, right up until gc). All
+  // twelve must be reachable from a ref.
+  for (const sha of shas) expect(reachable(sha)).toBe(true)
+  expect(git(repo, "rev-list", "--count", `${res.branchAnchor?.ref}`).trim()).toBe("13") // 12 + base
+
+  // And the recovery path in the docs actually works.
+  git(repo, "branch", "recovered", res.branchAnchor?.ref as string)
+  expect(git(repo, "log", "--oneline", "recovered").split("\n").filter(Boolean)).toHaveLength(13)
+})
+
+test("merge land with --delete-branch writes no anchor — the merge commit already reaches the tip", async () => {
+  const { wt, tip } = worktreeWithCommits("merged", 3)
+
+  const res = await landTaskWithCleanup(
+    task("merged", wt),
+    { strategy: "merge", deleteBranch: true, removeWorktree: true },
+    deps(),
+  )
+
+  expect(git(repo, "branch", "--list", "merged").trim()).toBe("")
+  // No ref written: `--no-ff` parents the commits under the merge, so an
+  // anchor would be permanent clutter for work that was never at risk.
+  expect(res.branchAnchor).toBeUndefined()
+  expect(git(repo, "for-each-ref", "refs/rove/salvage").trim()).toBe("")
+  expect(reachable(tip)).toBe(true)
+})
+
+test("a plain deleteBranch on an unlanded branch anchors its tip", async () => {
+  // Not a land: the same `-D` reached directly (task delete --delete-branch).
+  // Nothing has merged this branch, so every commit on it is at risk.
+  const { wt, tip } = worktreeWithCommits("unlanded", 2)
+  // Remove the worktree first — git refuses to delete a branch checked out in
+  // a live one, which is also why the real caller (task deletion) removes the
+  // directory before deleting the branch, taking the per-worktree reflog with
+  // it. That ordering is precisely what leaves the tip with nothing to hold it.
+  git(repo, "worktree", "remove", "--force", wt)
+  let anchored: { ref: string; commit: string } | null = null
+
+  await new GitWorktreeManager().deleteBranch(repo, "unlanded", {
+    force: true,
+    onAnchor: (record) => {
+      anchored = record
+    },
+  })
+
+  expect(git(repo, "branch", "--list", "unlanded").trim()).toBe("")
+  expect(anchored).not.toBeNull()
+  expect((anchored as unknown as { commit: string }).commit).toBe(tip)
+  expect(reachable(tip)).toBe(true)
+})

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -285,6 +285,79 @@ describe("landTaskWithCleanup worktree cleanup", () => {
     expect(fs.existsSync(wt)).toBe(false)
   })
 
+  /**
+   * Same ordering bug as the worktrees page, reached through land: the dirty
+   * check that let this land through ran seconds earlier in `landTask`, and
+   * an engine still running has kept writing since. Removing its directory
+   * first means every write after that goes to an unlinked inode.
+   *
+   * The assertion is the ORDER — recorded at the moment teardown runs, when
+   * the directory must still exist. "teardown was called" alone would pass
+   * with the calls reversed, which is the bug.
+   */
+  test("tears the engine session down before removing the landed worktree", async () => {
+    makeWorktree()
+    const order: string[] = []
+    const res = await landTaskWithCleanup(
+      { ...task("feat"), worktreePath: wt },
+      {},
+      {
+        worktrees: new GitWorktreeManager(),
+        clearWorktreePath: async () => {
+          order.push("clearWorktreePath")
+        },
+        tearDownSession: async (id) => {
+          order.push(`teardown:${String(id)}:dirExists=${fs.existsSync(wt)}`)
+        },
+      },
+    )
+    expect(res.worktree).toEqual({ removed: true })
+    expect(order).toEqual(["teardown:t-land:dirExists=true", "clearWorktreePath"])
+    expect(fs.existsSync(wt)).toBe(false)
+  })
+
+  test("a refused removal does not tear down the session", async () => {
+    // No directory is going anywhere, so killing a live engine would be pure
+    // collateral damage — the caller keeps working in that worktree.
+    makeWorktree()
+    fs.writeFileSync(path.join(wt, "wip.txt"), "uncommitted\n")
+    const torn: string[] = []
+    const res = await landTaskWithCleanup(
+      { ...task("feat"), worktreePath: wt },
+      { callerCwd: wt },
+      {
+        worktrees: new GitWorktreeManager(),
+        clearWorktreePath: async () => {},
+        tearDownSession: async (id) => {
+          torn.push(String(id))
+        },
+      },
+    )
+    expect(res.worktree?.removed).toBe(false)
+    expect(torn).toEqual([])
+    expect(fs.existsSync(path.join(wt, "wip.txt"))).toBe(true)
+  })
+
+  test("a failing teardown does not strand the landed worktree", async () => {
+    // The merge has already committed; a dead or unreachable session must not
+    // leave the directory behind forever. `remove()`'s own dirty refusal is
+    // the real guard on unsaved work.
+    makeWorktree()
+    const res = await landTaskWithCleanup(
+      { ...task("feat"), worktreePath: wt },
+      {},
+      {
+        worktrees: new GitWorktreeManager(),
+        clearWorktreePath: async () => {},
+        tearDownSession: async () => {
+          throw new Error("session host unreachable")
+        },
+      },
+    )
+    expect(res.worktree).toEqual({ removed: true })
+    expect(fs.existsSync(wt)).toBe(false)
+  })
+
   test("never removes the base checkout even if worktreePath points at it", async () => {
     makeWorktree()
     const { deps: d } = deps()

--- a/packages/kobe/test/orchestrator/salvage-ignored.test.ts
+++ b/packages/kobe/test/orchestrator/salvage-ignored.test.ts
@@ -1,0 +1,114 @@
+/**
+ * A salvage snapshot must not throw away gitignored WORK.
+ *
+ * `git add -A` honours `.gitignore`, which was documented as a `node_modules/`
+ * exclusion — but `.gitignore` says "don't track this", not "this isn't the
+ * user's work". In the Rove repo itself, `HANDOFF.md`, `.scratch/**`, `.env*`
+ * and `.rove/*` are all ignored, and the first two are exactly where AGENTS.md
+ * tells agents to keep cross-session reasoning. Force-deleting a worktree
+ * destroyed all of them while reporting a successful salvage.
+ *
+ * The rule that replaces the exclusion is a size budget, so the assertions
+ * check BOTH directions on one worktree: the small ignored files come back out
+ * of the object database, and the big ignored tree is still left out (a
+ * snapshot that swallows `node_modules/` is one nobody can use).
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, expect, test } from "vitest"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import { parseDuKb, parseIgnoredPaths } from "../../src/orchestrator/worktree/salvage-ignored.ts"
+
+let tmpRoot: string
+let repo: string
+
+function git(cwd: string, ...args: string[]): string {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`)
+  return r.stdout
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rove-salvage-ig-"))
+  repo = path.join(tmpRoot, "repo")
+  fs.mkdirSync(repo)
+  git(repo, "init", "-q", ".")
+  git(repo, "config", "user.email", "test@example.com")
+  git(repo, "config", "user.name", "Test")
+  fs.writeFileSync(path.join(repo, "tracked.txt"), "committed\n")
+  // The Rove repo's own ignore set, near enough: build output plus the files
+  // that actually carry an agent's unpushed reasoning.
+  fs.writeFileSync(path.join(repo, ".gitignore"), "node_modules/\nHANDOFF.md\n.scratch/\n.env\n")
+  git(repo, "add", "-A")
+  git(repo, "commit", "-qm", "init")
+})
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+test("force-removal salvages gitignored work but leaves a bulk ignored tree out", async () => {
+  const wt = path.join(tmpRoot, "feature")
+  git(repo, "worktree", "add", "-q", wt, "-b", "feature")
+
+  // Ordinary dirty state, already covered by the existing salvage test.
+  fs.appendFileSync(path.join(wt, "tracked.txt"), "uncommitted edit\n")
+  fs.writeFileSync(path.join(wt, "never-added.txt"), "brand new file\n")
+
+  // Gitignored, and unambiguously the user's work.
+  fs.writeFileSync(path.join(wt, "HANDOFF.md"), "the handoff nobody committed\n")
+  fs.mkdirSync(path.join(wt, ".scratch", "feat"), { recursive: true })
+  fs.writeFileSync(path.join(wt, ".scratch", "feat", "plan.md"), "the plan\n")
+  fs.writeFileSync(path.join(wt, ".env"), "TOKEN=secret\n")
+
+  // Gitignored bulk: one entry over the 64 MB per-entry budget. Real bytes,
+  // not a sparse file — `du` reports a sparse file's ALLOCATED size, which is
+  // 0 KB, so a sparse "large" file would sail under the budget and prove
+  // nothing. 70 MB of zeros writes in milliseconds.
+  fs.mkdirSync(path.join(wt, "node_modules", "pkg"), { recursive: true })
+  fs.writeFileSync(path.join(wt, "node_modules", "pkg", "bundle.js"), Buffer.alloc(70 * 1024 * 1024))
+
+  let salvaged: { ref: string; commit: string } | null = null
+  await new GitWorktreeManager().remove(wt, {
+    force: true,
+    onSalvage: (record) => {
+      salvaged = record
+    },
+  })
+
+  expect(fs.existsSync(wt)).toBe(false) // the destruction really happened
+  const ref = (salvaged as unknown as { ref: string } | null)?.ref
+  expect(ref).toBeTruthy()
+
+  // Read the content back OUT of the object database, after the directory is
+  // gone: a snapshot nobody can restore from is the failure this prevents.
+  const show = (p: string) => git(repo, "show", `${ref}:${p}`)
+  expect(show("HANDOFF.md")).toBe("the handoff nobody committed\n")
+  expect(show(".scratch/feat/plan.md")).toBe("the plan\n")
+  expect(show(".env")).toBe("TOKEN=secret\n")
+  expect(show("never-added.txt")).toBe("brand new file\n")
+  expect(show("tracked.txt")).toContain("uncommitted edit")
+
+  // The budget still holds the line: the oversized tree is not in the snapshot.
+  const files = git(repo, "ls-tree", "-r", "--name-only", ref as string).split("\n")
+  expect(files).not.toContain("node_modules/pkg/bundle.js")
+  expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false)
+})
+
+test("parseIgnoredPaths reads only the ignored entries of a NUL-separated status", () => {
+  // Real `git status --porcelain -z --ignored` shape: NUL-separated, ignored
+  // directories collapsed to one entry, and a path containing a space (which
+  // is why the parse is NUL-based rather than line-and-split).
+  const raw = " M tracked.txt\0?? new.txt\0!! .env\0!! .scratch/\0!! sp ace/\0!! node_modules/\0"
+  expect(parseIgnoredPaths(raw)).toEqual([".env", ".scratch/", "sp ace/", "node_modules/"])
+})
+
+test("parseDuKb keeps paths that contain spaces intact", () => {
+  const sizes = parseDuKb("4\tHANDOFF.md\n1403144\tnode_modules/\n8\tsp ace/\n")
+  expect(sizes.get("HANDOFF.md")).toBe(4)
+  expect(sizes.get("node_modules/")).toBe(1403144)
+  expect(sizes.get("sp ace/")).toBe(8)
+})

--- a/packages/kobe/test/orchestrator/worktree-salvage.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-salvage.test.ts
@@ -79,10 +79,16 @@ test("a force-removed worktree's uncommitted work is recoverable from the salvag
   expect(git(repo, "for-each-ref", "refs/rove/salvage", "--format=%(refname)")).toContain(record?.ref)
 })
 
-test("ignored files stay out of the snapshot", async () => {
+test("a bulk ignored tree stays out of the snapshot", async () => {
+  // The exclusion is by SIZE, not by ignored-ness — `.gitignore` says "don't
+  // track this", not "this isn't the user's work", and gitignored notes are
+  // now rescued (see `salvage-ignored.test.ts` for both directions). What
+  // still has to hold is that a dependency tree cannot bloat the snapshot, so
+  // this one is genuinely over the per-entry budget: 70 MB of real bytes, not
+  // a sparse file (`du` reports a sparse file's allocated size, which is 0).
   const wt = dirtyWorktree("ignored")
   fs.mkdirSync(path.join(wt, "node_modules"))
-  fs.writeFileSync(path.join(wt, "node_modules", "big.bin"), "vendor junk\n")
+  fs.writeFileSync(path.join(wt, "node_modules", "big.bin"), Buffer.alloc(70 * 1024 * 1024))
 
   let salvaged: { ref: string; commit: string } | null = null
   await new GitWorktreeManager().remove(wt, {
@@ -94,6 +100,9 @@ test("ignored files stay out of the snapshot", async () => {
 
   const ref = (salvaged as { ref: string } | null)?.ref
   expect(git(repo, "ls-tree", "-r", "--name-only", String(ref))).not.toContain("node_modules")
+  // The ordinary dirty work is still there — the budget skipped one entry,
+  // it did not abandon the snapshot.
+  expect(git(repo, "show", `${ref}:never-added.txt`)).toBe("brand new file\n")
 })
 
 test("a clean worktree salvages nothing", async () => {


### PR DESCRIPTION
Three paths where Rove could destroy a user's work without saying so. Each fix is a check, an ordering change, or a teardown — no behavior is removed.

## 1. `land --strategy squash --delete-branch` stranded every pre-squash commit

`landTaskWithCleanup` removed the worktree (taking `.git/worktrees/<slug>/logs/HEAD`, the only reflog that ever recorded this branch's tip — the base checkout never had the branch checked out), then ran `git branch -D`, which takes the branch ref **and its reflog**. Under `--squash` the base gets one brand-new commit with no link back, so the branch's own commits ended up reachable from nothing: recoverable only via `git fsck --lost-found`, and only until `gc.pruneExpire`. Nothing in the UI, the return value, or `daemon.log` mentioned it.

Reordering does not help — `-D` drops the reflog either way. So `deleteBranch` now **anchors the tip** at `refs/rove/salvage/<branch>-<stamp>` first (the same namespace and `for-each-ref` as the existing force-delete salvage), and returns it as `branchAnchor`. A `--no-ff` merge writes nothing: `for-each-ref --contains` finds the merge commit already reaches the tip. The `--delete-branch` help text said nothing about any of this; it does now.

Both `-D` sites are covered — `land --delete-branch` and the task-delete path in `manager.remove`.

## 2. A worktree could be unlinked while its engine was still writing into it

`worktree.remove` (Worktrees page, web DELETE) had no `tearDownTaskSession`, and neither did land. `git worktree remove` succeeds against a live process — POSIX unlink does not care that something holds the directory as its cwd — so every subsequent engine write landed in an unlinked inode: not on disk, not on the branch, and not in the salvage snapshot, which ran *before* those writes. The task-deletion path already ordered this correctly; these two did not.

Both now tear the session down before removal.

**Teardown failure does not abort the removal** — deliberately. It is an ordering fix, not a gate: the Worktrees page's delete is optimistic (the row has already left the user's screen), and a task whose engine is already dead throws exactly like a stuck one, so gating would strand every such worktree permanently. The real guard on unsaved work is `remove()`'s dirty refusal, which still stands; failures are logged.

## 3. Salvage snapshots dropped gitignored work

`git add -A` honours `.gitignore` — documented as a `node_modules/` exclusion. But `.gitignore` means "don't track this", not "this isn't the user's work". In this repo, `HANDOFF.md`, `.scratch/**`, `.env*` and `.rove/*` are all ignored, and the first two are exactly where AGENTS.md tells agents to keep cross-session reasoning. Force-deleting a Rove worktree destroyed all of them **while the salvage ref reported success**.

The replacement rule is size, not a filename allowlist: a second `git add -f` pass adds back ignored entries up to 64 MB each. A hand-written note is kilobytes; `node_modules/` here is ~1.4 GB. `git status --porcelain --ignored` reports ignored directories collapsed, so one `du -sk` measures whole trees without walking them. An entry whose size can't be read is skipped.

`docs/WORKTREES.md` promised "Rove snapshots everything the removal is about to destroy" with the exception written as a parenthetical about `node_modules/`. That page now states the actual rule.

## Verification

Live, on real repos with real git — not only unit tests.

**#1** — 12 commits, real squash land + `--delete-branch`:

Before (reproduced on stock `main`): branch deleted, worktree gone, `git rev-list --all | grep <tip>` → **UNREACHABLE**, `git fsck` → `dangling commit 8617db8…`.

After:
```
$ bun live-land.ts /tmp/live1/wt-squash feature/squashed squash
{ "strategy": "squash", "landedOn": "main", "commit": "4bcb09a",
  "worktree": { "removed": true },
  "branchAnchor": { "ref": "refs/rove/salvage/feature-squashed-20260830T201834Z",
                    "commit": "0e4aa119295136e0c8dcbb9fefec0ad250b64e9c" } }

branch feature/squashed: '' (deleted)   worktree: GONE   per-worktree reflog: GONE
git rev-list --all | grep <tip>  → REACHABLE ✓  via refs/rove/salvage/feature-squashed-…
all 12 commits reachable?        → missing: 0 of 12
git fsck --lost-found            → dangling objects: 0
git branch recovered <ref>       → 13 commits recovered
```
A merge land on the same repo returned **no** `branchAnchor`, its tip reachable via `refs/heads/main`, and left exactly one salvage ref total.

**#2** — a real process writing into a worktree at 20 writes/sec.

Unfixed ordering: `git worktree remove --force` **succeeded against the live process**; 7 lines survived, the writer kept running (`process still alive: YES`) and every later write hit the unlinked inode — file `GONE`.

Fixed, through the real `worktree.remove` handler:
```
teardown ran (dir still exists: true)
writer alive after teardown: false
{"removed":true}
→ snapshot holds all 17 lines the engine wrote
```

**#3** — real force-delete of a worktree with the exact paths from the audit:
```
HANDOFF.md            # Handoff: the reasoning nobody committed
.scratch/feat/plan.md the plan
.env                  TOKEN=secret
.rove/state.json      cfg
untracked.txt         brand new
f.txt (tracked edit)  uncommitted edit
node_modules entries in snapshot: 0      (70 MB tree, correctly excluded)
snapshot tree object: 318 bytes          (not bloated)
```

**Tests** — every fix passes "delete the fix → tests go red", 2 mutations each, re-run after rebase:

| Mutation | Result |
|---|---|
| #1a anchor call removed | 2 failed |
| #1b reachability guard always skips | 2 failed |
| #2a land: teardown moved after removal | 1 failed |
| #2b land: teardown removed | 1 failed |
| #2c daemon: teardown moved after removal | 1 failed |
| #3a ignored rescue removed | 1 failed |
| #3b size budget removed | 2 failed |

The teardown tests assert the **order**, recorded at the moment teardown runs (`dirExists=true`) — asserting only "teardown was called" would pass with the calls reversed, which is the bug.

Suites: vitest 386 files / 3781 tests, socket 75 files / 626 tests, render 274 tests. Two TUI PTY-timing tests (`terminal-selection-trim`, `terminal-pty-scrollback-cache`) flake under parallel load and pass in isolation; this diff touches no TUI file.

`docs/WORKTREES.md` gains the `--delete-branch` anchor section and the corrected snapshot scope. Changeset: patch.

## Not in scope

The lower-risk / needs-a-decision findings from the same audit are deliberately untouched: `--force --delete-branch` destroying an unpushed branch on a clean worktree, dirty checks blind to rebase/cherry-pick state and submodules, repo-wide `git worktree prune`, silent `--delete-branch` failure, queued force-delete describing a different worktree after a daemon restart, and the TUI confirm still saying "PERMANENTLY LOST" when a snapshot exists.