### PR TITLE
fix: stop two concurrency faults that broke work Rove didn't own

### DIFF
--- a/.changeset/calm-pandas-shake.md
+++ b/.changeset/calm-pandas-shake.md
@@ -1,0 +1,22 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop two concurrency faults that broke work Rove didn't own
+
+Pre-trusting a worktree for codex used to read-check-append
+`~/.codex/config.toml` unguarded, so two spawns for the same worktree (a
+retried launch, TUI and daemon at once) could both append the same
+`[projects."<path>"]` table. Codex rejects the whole config on a duplicate
+TOML key — every codex task on the machine fails, not just the raced one.
+The write now serializes on a lock file beside the config and self-heals any
+duplicate stanza in the exact shape it writes, so the file stays valid even
+when a stale lock outlives its holder.
+
+The orchestrator's read-only git probes — the dirty check before worktree
+removal, land's pre-merge checks, branch/ref lookups — ran `git status` and
+friends without the `GIT_OPTIONAL_LOCKS=0` policy the rest of the app
+already honors, so a probe could grab `.git/index.lock` while the engine in
+that worktree was mid-commit and make the agent's own `git commit` fail
+with "Unable to create .git/index.lock". Probes now run lock-free; writes
+(worktree add/remove, merge, branch) deliberately keep taking the lock.

--- a/packages/kobe/src/engine/codex-local/trust.ts
+++ b/packages/kobe/src/engine/codex-local/trust.ts
@@ -7,26 +7,158 @@
  *
  * Append-only: a `[projects.*]` table at EOF attaches to nothing, so the
  * rest of the user's config is never parsed or rewritten.
+ *
+ * Concurrency: the read-check-append sequence used to be unguarded, so
+ * two spawns for the SAME worktree (a retried launch, TUI and daemon at
+ * once) could both append the table. Duplicate TOML keys make codex
+ * reject the ENTIRE config — every codex task on the machine fails, not
+ * just the raced one. Two layers prevent that:
+ *
+ *   1. A lock file next to the config serializes Rove writers. The
+ *      config is a user-home-level file, so the lock lives beside it in
+ *      `~/.codex/`, never in a repo. The critical section is a
+ *      read-plus-append of one small file — held for milliseconds.
+ *   2. Self-heal under the lock: any duplicate `[projects."…"]` stanza
+ *      in the EXACT shape we write (header line immediately followed by
+ *      our trust line) is deduped — later copies dropped, first kept —
+ *      before the header check. This backstops what the lock cannot:
+ *      a stale lock left by a killed process, or codex's own rewrites.
+ *      (`codex mcp add` and friends rewrite config.toml, but a codex
+ *      session run never writes it — the engine doesn't race us; only
+ *      user-run management commands do, and they don't take our lock.)
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { homedir } from "node:os"
 import path from "node:path"
+
+const TRUST_LINE = 'trust_level = "trusted"'
+const LOCK_NAME = "config.toml.rove.lock"
+/**
+ * Longest we'll wait for a rival Rove writer. Its critical section is
+ * milliseconds, so this only ever elapses on a stale lock (holder
+ * crashed) — after which we proceed WITHOUT the lock: correctness no
+ * longer depends on it (the self-heal dedupes whatever a missed race
+ * produced); it only spares us the repair.
+ */
+const LOCK_TIMEOUT_MS = 5_000
+const LOCK_POLL_MS = 10
 
 export function trustCodexWorktree(worktreePath: string, home: string = homedir()): void {
   const dir = path.join(home, ".codex")
   const file = path.join(dir, "config.toml")
   // JSON.stringify doubles as a TOML basic-string quoter for the path.
   const header = `[projects.${JSON.stringify(worktreePath)}]`
-  let text = ""
+  mkdirSync(dir, { recursive: true })
+  withConfigLock(path.join(dir, LOCK_NAME), () => {
+    let text = readConfig(file)
+    const healed = dedupeOurTrustStanzas(text)
+    if (healed.changed) {
+      text = healed.text
+      writeFileSync(file, text)
+    }
+    if (text.includes(header)) return
+    if (!existsSync(file)) writeFileSync(file, "")
+    const lead = text.length > 0 && !text.endsWith("\n") ? "\n" : ""
+    appendFileSync(file, `${lead}\n${header}\n${TRUST_LINE}\n`)
+  })
+}
+
+function readConfig(file: string): string {
   try {
-    text = readFileSync(file, "utf8")
+    return readFileSync(file, "utf8")
   } catch {
     // No config yet — the append below creates it.
+    return ""
   }
-  if (text.includes(header)) return
-  mkdirSync(dir, { recursive: true })
-  if (!existsSync(file)) writeFileSync(file, "")
-  const lead = text.length > 0 && !text.endsWith("\n") ? "\n" : ""
-  appendFileSync(file, `${lead}\n${header}\ntrust_level = "trusted"\n`)
+}
+
+/**
+ * Drop later copies of any duplicate `[projects."…"]` stanza in the
+ * exact shape we append (header line immediately followed by our trust
+ * line). Those are the only duplicates Rove can create. Duplicates in
+ * any other shape are the user's own content and are left verbatim —
+ * TOML would reject them, but silently rewriting user content is worse
+ * than leaving a parse error the user can see. The first occurrence of
+ * a stanza is kept: identical text, identical meaning.
+ */
+function dedupeOurTrustStanzas(text: string): { text: string; changed: boolean } {
+  const lines = text.split("\n")
+  const seenHeaders = new Set<string>()
+  const out: string[] = []
+  let changed = false
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.startsWith("[projects.")) {
+      if (seenHeaders.has(line)) {
+        if (lines[i + 1] === TRUST_LINE) {
+          // Our stanza, duplicated by a missed race — drop header + body.
+          changed = true
+          i++
+          continue
+        }
+        // Not our shape: keep it rather than mangle user content.
+      } else {
+        seenHeaders.add(line)
+      }
+    }
+    out.push(line)
+  }
+  return { text: out.join("\n"), changed }
+}
+
+/**
+ * Serialize Rove writers via atomic create-or-fail (`wx`): exactly one
+ * contender holds the lock. The lock records the holder's PID for
+ * forensics. Waits up to {@link LOCK_TIMEOUT_MS} for a live holder;
+ * past that, runs `fn` unprotected (see the timeout's doc above).
+ */
+function withConfigLock(lockPath: string, fn: () => void): void {
+  let fd: number | undefined
+  const deadline = Date.now() + LOCK_TIMEOUT_MS
+  for (;;) {
+    try {
+      fd = openSync(lockPath, "wx")
+      break
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err
+      if (Date.now() >= deadline) {
+        fd = undefined
+        break
+      }
+      sleepSync(LOCK_POLL_MS)
+    }
+  }
+  if (fd === undefined) {
+    fn()
+    return
+  }
+  try {
+    writeFileSync(fd, String(process.pid))
+    fn()
+  } finally {
+    closeSync(fd)
+    try {
+      unlinkSync(lockPath)
+    } catch {
+      // Already unlinked (forced takeover raced us) — nothing to release.
+    }
+  }
+}
+
+/** Portable synchronous sleep — the trust path is sync end-to-end. */
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms
+  while (Date.now() < end) {
+    // busy-wait; waits here are ~10ms
+  }
 }

--- a/packages/kobe/src/lib/git-env.ts
+++ b/packages/kobe/src/lib/git-env.ts
@@ -2,9 +2,10 @@
  * Shared environment policy for read-only git inspection.
  *
  * `git status` and some diff/ref probes may opportunistically refresh index
- * metadata and take `.git/index.lock`. Render paths, daemon collectors, and
- * preview helpers must inspect without competing with engine commits, so they
- * all opt into the same lock-free git environment here.
+ * metadata and take `.git/index.lock`. Render paths, daemon collectors,
+ * preview helpers, and the orchestrator's worktree probes must inspect
+ * without competing with engine commits, so they all opt into the same
+ * lock-free git environment here.
  */
 
 export const READ_ONLY_GIT_ENV = { GIT_OPTIONAL_LOCKS: "0" } as const

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -19,6 +19,7 @@
 import fs from "node:fs"
 import path from "node:path"
 import type { ExecHost } from "../exec/exec-host.ts"
+import { READ_ONLY_GIT_ENV } from "../lib/git-env.ts"
 import type { Task, TaskId } from "../types/task.ts"
 import { EmptyBranchDirtyWorktreeError, EmptyBranchError, LandConflictError, MainCheckoutDirtyError } from "./errors.ts"
 import { type WorktreeExecDeps, defaultExecDeps } from "./worktree/exec-deps.ts"
@@ -222,19 +223,24 @@ async function git(
   exec: ExecHost,
   dir: string,
   args: readonly string[],
+  opts?: { readonly readOnly?: boolean },
 ): Promise<{ stdout: string; exitCode: number }> {
-  const r = await exec.run(["git", ...args], { cwd: dir })
+  // Read-only probes (status/diff/rev-parse/rev-list) run lock-free per
+  // READ_ONLY_GIT_ENV — land inspects worktrees an engine may be
+  // committing in right now. Writes (merge/abort/reset/commit) never set
+  // readOnly: they genuinely need `.git/index.lock`.
+  const r = await exec.run(["git", ...args], { cwd: dir, env: opts?.readOnly ? READ_ONLY_GIT_ENV : undefined })
   return { stdout: r.stdout, exitCode: r.exitCode }
 }
 
 /** `git status --porcelain` non-empty in `dir` (untracked counts). */
 async function isDirty(exec: ExecHost, dir: string): Promise<boolean> {
-  return (await git(exec, dir, ["status", "--porcelain"])).stdout.trim().length > 0
+  return (await git(exec, dir, ["status", "--porcelain"], { readOnly: true })).stdout.trim().length > 0
 }
 
 /** Conflicted paths after a failed merge: `git diff --name-only --diff-filter=U`. */
 async function conflictedFiles(exec: ExecHost, dir: string): Promise<string[]> {
-  const out = await git(exec, dir, ["diff", "--name-only", "--diff-filter=U"])
+  const out = await git(exec, dir, ["diff", "--name-only", "--diff-filter=U"], { readOnly: true })
   return out.stdout
     .split("\n")
     .map((l) => l.trim())
@@ -267,7 +273,7 @@ async function assertBranchHasWork(
   dir: string,
   deps: WorktreeExecDeps,
 ): Promise<void> {
-  const aheadOut = await git(exec, dir, ["rev-list", "--count", `${landedOn}..${branch}`])
+  const aheadOut = await git(exec, dir, ["rev-list", "--count", `${landedOn}..${branch}`], { readOnly: true })
   const ahead = Number.parseInt(aheadOut.stdout.trim(), 10)
   if (!Number.isFinite(ahead) || ahead > 0) return
   const worktreePath = task.worktreePath.trim()
@@ -281,7 +287,9 @@ async function assertBranchHasWork(
     }
     if (dirty) {
       const wtExec = deps.execForPath(worktreePath)
-      const files = porcelainPaths((await git(wtExec, worktreePath, ["status", "--porcelain"])).stdout)
+      const files = porcelainPaths(
+        (await git(wtExec, worktreePath, ["status", "--porcelain"], { readOnly: true })).stdout,
+      )
       throw new EmptyBranchDirtyWorktreeError(branch, landedOn, worktreePath, files)
     }
   }
@@ -316,7 +324,7 @@ export async function landTask(
   const { exec, dir } = baseRepoCtx(task.repo, deps)
 
   // The base branch we land onto — surfaced in the result + the merge commit msg.
-  const headOut = await git(exec, dir, ["rev-parse", "--abbrev-ref", "HEAD"])
+  const headOut = await git(exec, dir, ["rev-parse", "--abbrev-ref", "HEAD"], { readOnly: true })
   const landedOn = headOut.stdout.trim()
   if (!landedOn || landedOn === "HEAD") {
     throw new Error(`landTask: base checkout at ${dir} is in detached-HEAD state; check out a branch first`)
@@ -349,7 +357,7 @@ export async function landTask(
       throw new Error(`landTask: '${branch}' has nothing to land onto '${landedOn}' (already merged or empty)`)
     }
   } else {
-    const before = (await git(exec, dir, ["rev-parse", "HEAD"])).stdout.trim()
+    const before = (await git(exec, dir, ["rev-parse", "HEAD"], { readOnly: true })).stdout.trim()
     const merge = await git(exec, dir, ["merge", "--no-ff", "-m", `Land ${branch}`, branch])
     if (merge.exitCode !== 0) {
       const files = await conflictedFiles(exec, dir)
@@ -361,12 +369,12 @@ export async function landTask(
     // it the same way the squash path guards its empty `git commit`, so both
     // strategies reject a nothing-to-land branch instead of the merge path
     // reporting a fake success on the unchanged base commit.
-    const after = (await git(exec, dir, ["rev-parse", "HEAD"])).stdout.trim()
+    const after = (await git(exec, dir, ["rev-parse", "HEAD"], { readOnly: true })).stdout.trim()
     if (before === after) {
       throw new Error(`landTask: '${branch}' has nothing to land onto '${landedOn}' (already merged or empty)`)
     }
   }
 
-  const shaOut = await git(exec, dir, ["rev-parse", "--short", "HEAD"])
+  const shaOut = await git(exec, dir, ["rev-parse", "--short", "HEAD"], { readOnly: true })
   return { branch, strategy, landedOn, commit: shaOut.stdout.trim() }
 }

--- a/packages/kobe/src/orchestrator/worktree/git.ts
+++ b/packages/kobe/src/orchestrator/worktree/git.ts
@@ -21,6 +21,7 @@
  */
 
 import { spawnSync } from "node:child_process"
+import { READ_ONLY_GIT_ENV } from "../../lib/git-env.ts"
 
 export interface GitRunOpts {
   /** Working directory for git. Required — we never default. */
@@ -29,6 +30,14 @@ export interface GitRunOpts {
   readonly allowFail?: boolean
   /** Extra environment to merge with `process.env`. */
   readonly env?: Readonly<Record<string, string>>
+  /**
+   * Read-only probe: merge {@link READ_ONLY_GIT_ENV} (GIT_OPTIONAL_LOCKS=0)
+   * into the child env so `git status` / diff / ref probes never take
+   * `.git/index.lock` from an engine mid-commit (see lib/git-env.ts).
+   * ONLY for commands that never write the repo — marking a writer
+   * read-only would strip a lock it genuinely needs and corrupt the index.
+   */
+  readonly readOnly?: boolean
 }
 
 export interface GitRunResult {
@@ -69,9 +78,10 @@ export function git(args: readonly string[], opts: GitRunOpts): GitRunResult {
     throw new Error("git(): cwd is required; refusing to inherit from process.cwd()")
   }
 
+  const env = { ...process.env, ...opts.env, ...(opts.readOnly ? READ_ONLY_GIT_ENV : {}) }
   const proc = spawnSync("git", [...args], {
     cwd: opts.cwd,
-    env: opts.env ? { ...process.env, ...opts.env } : process.env,
+    env,
     encoding: "utf8",
     // Refuse to fall back to a shell parser. `args` is already an
     // array; if the host adds `shell: true` somewhere upstream, this

--- a/packages/kobe/src/orchestrator/worktree/manager-branch.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-branch.ts
@@ -31,6 +31,7 @@ export async function branchExists(deps: BranchDeps, ctx: ExecCtx, branch: strin
   const out = await deps.runGit(ctx.exec, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
     cwd: ctx.dir,
     allowFail: true,
+    readOnly: true,
   })
   return out.exitCode === 0
 }
@@ -91,6 +92,7 @@ export async function branchHasUpstream(deps: BranchDeps, worktreePath: string, 
     ["for-each-ref", "--format=%(upstream)", `refs/heads/${branch}`],
     {
       cwd: worktreePath,
+      readOnly: true,
     },
   )
   return out.stdout.trim().length > 0
@@ -104,6 +106,7 @@ export async function hasLocalBranch(deps: BranchDeps, worktreePath: string, bra
     {
       cwd: worktreePath,
       allowFail: true,
+      readOnly: true,
     },
   )
   return out.exitCode === 0

--- a/packages/kobe/src/orchestrator/worktree/manager-list.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-list.ts
@@ -8,6 +8,7 @@
  * owns) so the class methods stay thin delegators — no behaviour change.
  */
 
+import fs from "node:fs"
 import path from "node:path"
 import type { AdoptableWorktree, WorktreeInfo } from "../../types/worktree.ts"
 import { PROBE_CONCURRENCY, mapWithLimit } from "./concurrency.ts"
@@ -25,8 +26,35 @@ import { parseWorktreeListPorcelain } from "./worktree-list.ts"
 export interface ListDeps {
   ctxFor(repoKey: string): ExecCtx
   runGitStdout(ctx: ExecCtx, args: readonly string[]): Promise<string>
+  /** Read-only git at an arbitrary (worktree) cwd — the last-activity probe. */
+  runGitStdoutAt(ctx: ExecCtx, cwd: string, args: readonly string[]): Promise<string>
   isDirty(worktreePath: string): Promise<boolean>
-  lastActivityMs(ctx: ExecCtx, worktreePath: string): Promise<number>
+}
+
+/**
+ * Last-activity time of a worktree in epoch ms — the HEAD commit's
+ * committer time, falling back to the directory's mtime when the log
+ * read fails (e.g. an unborn branch). Best-effort: returns 0 on total
+ * failure so sorting still works. Used to order the adopt list.
+ */
+export async function lastActivityMs(deps: ListDeps, ctx: ExecCtx, worktreePath: string): Promise<number> {
+  try {
+    const stdout = await deps.runGitStdoutAt(ctx, worktreePath, ["log", "-1", "--format=%ct"])
+    const secs = Number.parseInt(stdout.trim(), 10)
+    if (Number.isFinite(secs) && secs > 0) return secs * 1000
+  } catch {
+    // no commits yet / not readable — fall through to mtime
+  }
+  // mtime fallback is a local-only convenience; on a remote the git-log
+  // path above is the source of truth and a miss simply sorts as 0.
+  if (!ctx.exec.isRemote) {
+    try {
+      return fs.statSync(worktreePath).mtimeMs
+    } catch {
+      // unreadable — fall through to 0
+    }
+  }
+  return 0
 }
 
 /**
@@ -111,7 +139,7 @@ export async function listAllAdoptable(deps: ListDeps, repo: string): Promise<re
   // Probe dirty + last-activity for every survivor concurrently (bounded) — two
   // git spawns / ssh round-trips each, the slow part of this call.
   const infos = await mapWithLimit(adoptable, PROBE_CONCURRENCY, async (entry) => {
-    const [dirty, lastActivityMs] = await Promise.all([deps.isDirty(entry.path), deps.lastActivityMs(ctx, entry.path)])
+    const [dirty, activityMs] = await Promise.all([deps.isDirty(entry.path), lastActivityMs(deps, ctx, entry.path)])
     return {
       path: entry.path,
       branch: entry.branch,
@@ -120,7 +148,7 @@ export async function listAllAdoptable(deps: ListDeps, repo: string): Promise<re
       kobeManaged: ctx.remote
         ? remoteManagedRootForPath(ctx.dir, entry.path) !== null
         : isKobeManagedPath(repo, entry.path),
-      lastActivityMs,
+      lastActivityMs: activityMs,
     }
   })
   // Most recently active first.

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -25,9 +25,9 @@
  * for cleanup invariants and dirty-state semantics.
  */
 
-import fs from "node:fs"
 import path from "node:path"
 import type { ExecHost } from "../../exec/exec-host.ts"
+import { READ_ONLY_GIT_ENV } from "../../lib/git-env.ts"
 import type { AdoptableWorktree, WorktreeInfo, WorktreeManager } from "../../types/worktree.ts"
 import { type ExecCtx, type WorktreeExecDeps, defaultExecDeps } from "./exec-deps.ts"
 import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
@@ -68,7 +68,13 @@ export class GitWorktreeManager implements WorktreeManager {
     if (!opts.cwd) {
       throw new Error("runGit(): cwd is required; refusing to inherit from process.cwd()")
     }
-    const r = await exec.run(["git", ...args], { cwd: opts.cwd, env: opts.env })
+    // Read-only probes (status/log/rev-parse/show-ref/for-each-ref/worktree
+    // list) must not compete with an engine's `git commit` for
+    // `.git/index.lock` — see lib/git-env.ts and GitRunOpts.readOnly. The
+    // policy flag merges over any caller env; ExecHost layers it over
+    // process.env locally and prefixes it onto the remote command.
+    const env = opts.readOnly ? { ...opts.env, ...READ_ONLY_GIT_ENV } : opts.env
+    const r = await exec.run(["git", ...args], { cwd: opts.cwd, env })
     const result: GitRunResult = { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }
     if (result.exitCode !== 0 && !opts.allowFail) {
       throw new GitCommandError(args, opts.cwd, result)
@@ -313,9 +319,9 @@ export class GitWorktreeManager implements WorktreeManager {
   private listDeps(): ListDeps {
     return {
       ctxFor: (repoKey) => this.ctxFor(repoKey),
-      runGitStdout: async (ctx, args) => (await this.runGit(ctx.exec, args, { cwd: ctx.dir })).stdout,
+      runGitStdout: async (ctx, args) => (await this.runGit(ctx.exec, args, { cwd: ctx.dir, readOnly: true })).stdout,
+      runGitStdoutAt: async (ctx, cwd, args) => (await this.runGit(ctx.exec, args, { cwd, readOnly: true })).stdout,
       isDirty: (worktreePath) => this.isDirty(worktreePath),
-      lastActivityMs: (ctx, worktreePath) => this.lastActivityMs(ctx.exec, worktreePath),
     }
   }
 
@@ -373,32 +379,6 @@ export class GitWorktreeManager implements WorktreeManager {
   }
 
   /**
-   * Last-activity time of a worktree in epoch ms — the HEAD commit's
-   * committer time, falling back to the directory's mtime when the log
-   * read fails (e.g. an unborn branch). Best-effort: returns 0 on total
-   * failure so sorting still works. Used to order the adopt list.
-   */
-  private async lastActivityMs(exec: ExecHost, worktreePath: string): Promise<number> {
-    try {
-      const out = await this.runGit(exec, ["log", "-1", "--format=%ct"], { cwd: worktreePath })
-      const secs = Number.parseInt(out.stdout.trim(), 10)
-      if (Number.isFinite(secs) && secs > 0) return secs * 1000
-    } catch {
-      // no commits yet / not readable — fall through to mtime
-    }
-    // mtime fallback is a local-only convenience; on a remote the git-log
-    // path above is the source of truth and a miss simply sorts as 0.
-    if (!exec.isRemote) {
-      try {
-        return fs.statSync(worktreePath).mtimeMs
-      } catch {
-        // unreadable — fall through to 0
-      }
-    }
-    return 0
-  }
-
-  /**
    * `git -C <path> status --porcelain` non-empty.
    *
    * Untracked files count as dirty (matches `--porcelain` default) —
@@ -406,7 +386,10 @@ export class GitWorktreeManager implements WorktreeManager {
    * yet committed should not be silently nuked by `remove()`.
    */
   async isDirty(worktreePath: string): Promise<boolean> {
-    const out = await this.runGit(this.execAt(worktreePath), ["status", "--porcelain"], { cwd: worktreePath })
+    const out = await this.runGit(this.execAt(worktreePath), ["status", "--porcelain"], {
+      cwd: worktreePath,
+      readOnly: true,
+    })
     return out.stdout.length > 0
   }
 
@@ -421,6 +404,7 @@ export class GitWorktreeManager implements WorktreeManager {
   async currentBranch(worktreePath: string): Promise<string> {
     const out = await this.runGit(this.execAt(worktreePath), ["rev-parse", "--abbrev-ref", "HEAD"], {
       cwd: worktreePath,
+      readOnly: true,
     })
     const name = out.stdout.trim()
     if (!name || name === "HEAD") {
@@ -453,7 +437,7 @@ export class GitWorktreeManager implements WorktreeManager {
    * distinguishes "already done" from "stale debris".
    */
   private async tryDescribe(ctx: ExecCtx, worktreePath: string): Promise<WorktreeInfo | null> {
-    const out = await this.runGit(ctx.exec, ["worktree", "list", "--porcelain"], { cwd: ctx.dir })
+    const out = await this.runGit(ctx.exec, ["worktree", "list", "--porcelain"], { cwd: ctx.dir, readOnly: true })
     const entries = parseWorktreeListPorcelain(out.stdout)
     // Remote paths can't be realpath'd locally; compare them verbatim.
     const norm = (p: string) => (ctx.remote ? p : canonicalize(p))
@@ -483,7 +467,11 @@ export class GitWorktreeManager implements WorktreeManager {
    */
   private async findRepoFor(exec: ExecHost, worktreePath: string): Promise<string | null> {
     try {
-      const out = await this.runGit(exec, ["rev-parse", "--git-common-dir"], { cwd: worktreePath, allowFail: true })
+      const out = await this.runGit(exec, ["rev-parse", "--git-common-dir"], {
+        cwd: worktreePath,
+        allowFail: true,
+        readOnly: true,
+      })
       if (out.exitCode !== 0) return null
       const gitDir = out.stdout.trim()
       if (!gitDir) return null

--- a/packages/kobe/test/engine/trust-worktree.test.ts
+++ b/packages/kobe/test/engine/trust-worktree.test.ts
@@ -5,6 +5,7 @@
  * Runs against temp HOME dirs; the real stores are never touched.
  */
 
+import { spawn, spawnSync } from "node:child_process"
 import { createHash } from "node:crypto"
 import fs from "node:fs"
 import os from "node:os"
@@ -106,4 +107,89 @@ describe("trustCodexWorktree", () => {
     const text = fs.readFileSync(path.join(home, ".codex", "config.toml"), "utf8")
     expect(text.split(`[projects.${JSON.stringify(WORKTREE)}]`)).toHaveLength(2)
   })
+
+  it("leaves no lock file behind after a call", () => {
+    const home = tempHome()
+    trustCodexWorktree(WORKTREE, home)
+    expect(fs.existsSync(path.join(home, ".codex", "config.toml.rove.lock"))).toBe(false)
+  })
+
+  it("repairs duplicate stanzas from a missed race — for any path, not just its own", () => {
+    const home = tempHome()
+    const dir = path.join(home, ".codex")
+    fs.mkdirSync(dir, { recursive: true })
+    const other = `[projects."/wt/other"]\n${'trust_level = "trusted"'}\n`
+    // What a check-then-act race leaves behind: the same table appended
+    // twice. TOML rejects the whole file on the duplicate key — this is
+    // the machine-wide outage the self-heal must clear.
+    fs.writeFileSync(path.join(dir, "config.toml"), `model = "gpt-5"\n\n${other}\n${other}`)
+    trustCodexWorktree(WORKTREE, home)
+    const text = fs.readFileSync(path.join(dir, "config.toml"), "utf8")
+    expect(text.split(`[projects."/wt/other"]`)).toHaveLength(2)
+    expect(text).toContain(`[projects.${JSON.stringify(WORKTREE)}]\ntrust_level = "trusted"`)
+    expect(text).toContain('model = "gpt-5"')
+    // Header lines only ever appear once per path now.
+    const headers = text.split("\n").filter((l) => l.startsWith("[projects."))
+    expect(new Set(headers).size).toBe(headers.length)
+  })
+
+  it("waits for a rival writer holding the lock instead of overwriting it", () => {
+    const home = tempHome()
+    const dir = path.join(home, ".codex")
+    fs.mkdirSync(dir, { recursive: true })
+    const lockFile = path.join(dir, "config.toml.rove.lock")
+    // A rival writer (any process, not just Rove) holds the lock, writes
+    // its stanza, then releases. The trust call must serialize AFTER it.
+    const rival = spawn(
+      process.execPath,
+      [
+        "-e",
+        `const fs = require("node:fs");
+         const lock = ${JSON.stringify(lockFile)};
+         const fd = fs.openSync(lock, "wx");
+         fs.writeFileSync(fd, String(process.pid));
+         setTimeout(() => {
+           fs.writeFileSync(${JSON.stringify(path.join(dir, "config.toml"))},
+             '[projects."/wt/rival"]\\ntrust_level = "trusted"\\n');
+           fs.closeSync(fd);
+           fs.unlinkSync(lock);
+         }, 300);`,
+      ],
+      { stdio: "ignore" },
+    )
+    try {
+      // Wait until the rival actually holds the lock before entering.
+      for (let i = 0; i < 200 && !fs.existsSync(lockFile); i++) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10)
+      }
+      expect(fs.existsSync(lockFile)).toBe(true)
+      trustCodexWorktree(WORKTREE, home)
+      const text = fs.readFileSync(path.join(dir, "config.toml"), "utf8")
+      // Both stanzas survive — without the lock this call reads the file
+      // BEFORE the rival's write and the rival then clobbers it.
+      expect(text).toContain('[projects."/wt/rival"]')
+      expect(text).toContain(`[projects.${JSON.stringify(WORKTREE)}]`)
+    } finally {
+      rival.kill("SIGKILL")
+    }
+  })
+
+  it("parallel spawns for the same worktree append exactly one stanza", async () => {
+    const home = tempHome()
+    const script = [
+      `import { trustCodexWorktree } from ${JSON.stringify(new URL("../../src/engine/codex-local/trust.ts", import.meta.url).pathname)}`,
+      "trustCodexWorktree(process.argv[1], process.argv[2])",
+    ].join("\n")
+    const children = Array.from({ length: 6 }, () => {
+      const child = spawn("bun", ["-e", script, WORKTREE, home], { stdio: "ignore" })
+      return new Promise<void>((resolve, reject) => {
+        child.on("error", reject)
+        child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`child exited ${code}`))))
+      })
+    })
+    await Promise.all(children)
+    const text = fs.readFileSync(path.join(home, ".codex", "config.toml"), "utf8")
+    expect(text.split(`[projects.${JSON.stringify(WORKTREE)}]`)).toHaveLength(2)
+    expect(fs.existsSync(path.join(home, ".codex", "config.toml.rove.lock"))).toBe(false)
+  }, 30_000)
 })

--- a/packages/kobe/test/orchestrator/git-readonly-env.test.ts
+++ b/packages/kobe/test/orchestrator/git-readonly-env.test.ts
@@ -1,0 +1,167 @@
+/**
+ * READ_ONLY_GIT_ENV wiring (orchestrator probes must not steal the engine's
+ * `.git/index.lock`): every read-only git probe the worktree manager and
+ * lander run carries GIT_OPTIONAL_LOCKS=0; every write runs without it.
+ *
+ * A fake ExecHost records the env each git argv was spawned with — the exact
+ * seam where the policy either reaches the child or doesn't. Deterministic:
+ * no real git, no timing.
+ */
+
+import { describe, expect, it } from "vitest"
+import type { ExecHost, ExecResult } from "../../src/exec/exec-host.ts"
+import { READ_ONLY_GIT_ENV } from "../../src/lib/git-env.ts"
+import { landTask } from "../../src/orchestrator/land.ts"
+import type { WorktreeExecDeps } from "../../src/orchestrator/worktree/exec-deps.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import type { Task } from "../../src/types/task.ts"
+import { toTaskId } from "../../src/types/task.ts"
+
+interface RecordedRun {
+  readonly argv: readonly string[]
+  readonly env: Readonly<Record<string, string>> | undefined
+}
+
+/** Fake ExecHost: script git responses, record argv + env for every run. */
+function fakeExec(script: (argv: readonly string[]) => ExecResult) {
+  const runs: RecordedRun[] = []
+  const exec: ExecHost = {
+    isRemote: false,
+    async run(argv, opts) {
+      runs.push({ argv, env: opts?.env })
+      return script(argv)
+    },
+    exists: async () => true,
+    mkdirp: async () => {},
+    readFile: async () => null,
+    readdir: async () => [],
+    wrapCommand: (c) => c,
+    ensureReady: () => {},
+  }
+  return { exec, runs }
+}
+
+function depsFor(exec: ExecHost): WorktreeExecDeps {
+  return { execForRepo: () => exec, execForPath: () => exec, remoteBasePath: () => null }
+}
+
+const ok: ExecResult = { stdout: "", stderr: "", exitCode: 0 }
+
+const flagged = (r: RecordedRun) => r.env?.GIT_OPTIONAL_LOCKS === READ_ONLY_GIT_ENV.GIT_OPTIONAL_LOCKS
+const byToken = (runs: RecordedRun[], token: string) => runs.filter((r) => r.argv.includes(token))
+
+describe("GitWorktreeManager — READ_ONLY_GIT_ENV on probes", () => {
+  it("isDirty / currentBranch run status and rev-parse lock-free", async () => {
+    const { exec, runs } = fakeExec((argv) => {
+      if (argv.includes("status")) return { stdout: " M x\n", stderr: "", exitCode: 0 }
+      if (argv.includes("--abbrev-ref")) return { stdout: "feat\n", stderr: "", exitCode: 0 }
+      return ok
+    })
+    const mgr = new GitWorktreeManager(depsFor(exec))
+    await expect(mgr.isDirty("/wt/a")).resolves.toBe(true)
+    await expect(mgr.currentBranch("/wt/a")).resolves.toBe("feat")
+    expect(byToken(runs, "--porcelain").every(flagged)).toBe(true)
+    expect(byToken(runs, "--abbrev-ref").every(flagged)).toBe(true)
+  })
+
+  it("list() probes (worktree list + status) run lock-free", async () => {
+    const { exec, runs } = fakeExec((argv) => {
+      if (argv.includes("--porcelain")) {
+        return {
+          stdout: "worktree /repo\nHEAD aaa\nbranch refs/heads/main\n\n",
+          stderr: "",
+          exitCode: 0,
+        }
+      }
+      return ok
+    })
+    const mgr = new GitWorktreeManager(depsFor(exec))
+    // /repo itself is the main checkout → no managed worktrees, but the
+    // porcelain list still ran.
+    await expect(mgr.list("/repo")).resolves.toEqual([])
+    expect(byToken(runs, "--porcelain").every(flagged)).toBe(true)
+  })
+
+  it("listBranchNames / hasLocalBranch / branchHasUpstream run lock-free", async () => {
+    const { exec, runs } = fakeExec(() => ok)
+    const mgr = new GitWorktreeManager(depsFor(exec))
+    await mgr.listBranchNames("/repo")
+    await mgr.hasLocalBranch("/wt/a", "feat")
+    await mgr.branchHasUpstream("/wt/a", "feat")
+    expect(byToken(runs, "for-each-ref").every(flagged)).toBe(true)
+    expect(byToken(runs, "show-ref").every(flagged)).toBe(true)
+  })
+
+  it("writes (worktree add/remove/prune, branch -m) run WITHOUT the lock-free env", async () => {
+    const { exec, runs } = fakeExec((argv) => {
+      if (argv.includes("list") && argv.includes("--porcelain")) {
+        return {
+          stdout: "worktree /wt/a\nHEAD aaa\nbranch refs/heads/feat\n\n",
+          stderr: "",
+          exitCode: 0,
+        }
+      }
+      if (argv.includes("--git-common-dir")) return { stdout: "/repo/.git\n", stderr: "", exitCode: 0 }
+      return ok
+    })
+    const mgr = new GitWorktreeManager(depsFor(exec))
+
+    await mgr.create("/repo", "feat", "/wt/a")
+    await mgr.remove("/wt/a")
+    await mgr.renameBranch("/wt/a", "feat", "feat2")
+
+    const writes = runs.filter(
+      (r) =>
+        (r.argv.includes("add") && r.argv.includes("worktree")) ||
+        (r.argv.includes("remove") && r.argv.includes("worktree")) ||
+        r.argv.includes("prune") ||
+        (r.argv.includes("-m") && r.argv.includes("branch")),
+    )
+    expect(writes.length).toBeGreaterThan(0)
+    expect(writes.every((r) => !flagged(r))).toBe(true)
+    // The probes around those writes stayed lock-free.
+    expect(byToken(runs, "show-ref").every(flagged)).toBe(true)
+    expect(byToken(runs, "--porcelain").every(flagged)).toBe(true)
+    expect(byToken(runs, "--git-common-dir").every(flagged)).toBe(true)
+  })
+})
+
+describe("landTask — READ_ONLY_GIT_ENV on probes", () => {
+  it("pre-merge probes run lock-free; the merge itself does not", async () => {
+    let headReads = 0
+    const { exec, runs } = fakeExec((argv) => {
+      if (argv.includes("--abbrev-ref")) return { stdout: "main\n", stderr: "", exitCode: 0 }
+      if (argv.includes("status")) return ok
+      if (argv.includes("rev-list")) return { stdout: "1\n", stderr: "", exitCode: 0 }
+      if (argv.includes("merge")) return ok
+      if (argv.includes("rev-parse") && argv.includes("--short")) {
+        return { stdout: "bbb1234\n", stderr: "", exitCode: 0 }
+      }
+      if (argv.includes("rev-parse")) {
+        headReads++
+        return { stdout: headReads === 1 ? "aaa\n" : "bbb\n", stderr: "", exitCode: 0 }
+      }
+      return ok
+    })
+    const now = new Date().toISOString()
+    const task: Task = {
+      id: toTaskId("t-ro"),
+      title: "t",
+      repo: "/repo",
+      branch: "feat",
+      worktreePath: "",
+      status: "backlog",
+      kind: "task",
+      createdAt: now,
+      updatedAt: now,
+    }
+    const result = await landTask(task, {}, depsFor(exec))
+    expect(result.landedOn).toBe("main")
+
+    const probes = runs.filter((r) => !r.argv.includes("merge"))
+    expect(probes.every(flagged)).toBe(true)
+    const merge = runs.find((r) => r.argv.includes("merge"))
+    expect(merge).toBeDefined()
+    expect(flagged(merge!)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Two concurrency bugs from the same audit, both with outsized blast radius:

**1. codex pre-trust was check-then-act on the whole machine's config.** `trustCodexWorktree` read `~/.codex/config.toml`, checked for the header, and appended — unguarded. Two spawns for the same worktree (a retried launch, TUI and daemon at once) both pass the `includes` guard and append the same `[projects."<path>"]` table. Codex rejects the **entire** config on a duplicate TOML key: every codex task on the machine fails, not just the raced one. Fix: a lock file beside the config serializes Rove writers (atomic `wx` create, wait-with-timeout, proceed-and-heal on stale locks), and a self-heal pass under the lock dedupes any duplicate stanza in the exact shape we write. The self-heal is the backstop the lock can't provide — `codex mcp add` and friends rewrite config.toml without taking our lock (a codex *session run* never writes it, so the engine doesn't race us). Pre-investigation answer: codex only rewrites the file via user-run management commands, so prevention (lock) covers the spawn race we create, detection (self-heal) covers the rest.

**2. orchestrator probes ignored READ_ONLY_GIT_ENV and stole the engine's index lock.** `GitWorktreeManager.runGit` never merged `GIT_OPTIONAL_LOCKS=0`, so `isDirty()` (the removal guard), land's dirty check and `assertBranchHasWork` ran `git status` able to refresh the index under `.git/index.lock` — while the engine in that worktree was mid-commit. The agent's own `git commit` then failed with `Unable to create .git/index.lock`. Fix: `GitRunOpts.readOnly` merges the policy env for exactly the read-only verbs and nothing else.

### Read-only vs write classification (every `runGit` call site)

**Read-only (now `readOnly: true`):**
- `status --porcelain` — `isDirty`, land's `isDirty`, `assertBranchHasWork`'s worktree status
- `rev-parse` (`--abbrev-ref HEAD`, `--git-common-dir`, `HEAD`, `--short HEAD`) — `currentBranch`, `findRepoFor`, land's HEAD reads
- `log -1 --format=%ct` — `lastActivityMs`
- `worktree list --porcelain` — `tryDescribe`, `listManaged`, `adoptablePaths`
- `show-ref --verify --quiet` — `branchExists`, `hasLocalBranch`
- `for-each-ref` — `branchHasUpstream`, `listBranchNames`
- land's `rev-list --count` and `diff --name-only --diff-filter=U`

**Writes (deliberately untouched — they genuinely need the lock):**
- `worktree add` / `worktree remove` / `worktree prune`
- `branch -m` (`renameBranch`), `branch -d/-D` (`deleteBranchIn`) and its `refs/rove/salvage` anchor write from #675
- land's `merge` / `merge --abort` / `reset --hard` / `commit`

## Verification

- New tests are deterministic and were red before the fix (revert → 7 fail, 2 runs, restore → green), re-run after rebasing onto current main.
- Trust: multi-process race (6 parallel `bun` spawns → exactly one stanza), rival-lock wait, duplicate-stanza self-heal, lock-file cleanup.
- Env wiring: fake ExecHost asserts the policy env on every read probe and its absence on every write, for both the manager and `landTask`.
- Real-machine: with an engine `git commit` genuinely holding `.git/index.lock` (2s pre-commit hook), `GitWorktreeManager.isDirty()` keeps working; a status probe *without* the policy in a loop against a 30k-file repo made the engine's commits fail with `Unable to create ... index.lock`, with the policy the failures go to 0.

No docs-page change: no config keys, CLI verbs, or engine behavior changed.

Rebased on main after #675 (salvage anchors / session teardown) — complementary, no overlap.