### PR TITLE
feat: persist prompt + baseRef on the task record, stop recommending git stash

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 37 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 38 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -105,6 +105,12 @@ wants a helper in the same checkout, and a bug when they wanted parallel
 attempts. A split isolates nothing at all: it is a layout, for watching
 something (logs, `btop`, a test loop) next to the work — never the answer to
 "do this work".
+
+One boundary the isolation model does NOT cover: **never `git stash` in a
+managed worktree.** The stash stack lives in the repo's common dir
+(`.git/refs/stash`) and is shared by every linked worktree — two tasks that
+stash in parallel can pop or drop each other's work. Commit instead; a
+commit is per-branch and isolates exactly the way the model promises.
 
 ### Where does this work land?
 

--- a/.changeset/persist-prompt-baseref.md
+++ b/.changeset/persist-prompt-baseref.md
@@ -1,0 +1,24 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Persist the task brief and fork point on the task record; stop recommending `git stash`
+
+`add --prompt` read the prompt, delivered it into the engine, and dropped it — the only
+copy lived in the engine's own transcript, so a dead engine (or lost context) took the
+task brief down with it and the only recovery was the user re-pasting it. The prompt is
+now recorded on the task record once delivery confirms, and `get-task` returns it as
+`.task.prompt` — the brief outlives the session it started in.
+
+`add --base-branch` lived only in an in-memory side-map consumed once at worktree
+creation. A daemon restart between create and first enter silently dropped it (the
+branch then forked from the guessed base), and `collect`'s ahead/diffstat signals always
+measured against a re-guessed `origin/HEAD` → `main` → `master` instead of the real fork
+point. `baseRef` is now persisted on the task record; `collect` prefers it and only
+falls back to the guess for records that predate the field.
+
+Also: Rove no longer recommends `git stash` anywhere. The stash stack lives in the
+repo's common dir (`.git/refs/stash`) and is shared by every linked worktree, so two
+parallel tasks that stash can pop or drop each other's work — the one hole in the
+"worktree isolation" model. The land-refusal error, the worktrees page copy, the docs,
+and the agent skill now say commit instead, and say why.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 37 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 38 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -105,6 +105,12 @@ wants a helper in the same checkout, and a bug when they wanted parallel
 attempts. A split isolates nothing at all: it is a layout, for watching
 something (logs, `btop`, a test loop) next to the work — never the answer to
 "do this work".
+
+One boundary the isolation model does NOT cover: **never `git stash` in a
+managed worktree.** The stash stack lives in the repo's common dir
+(`.git/refs/stash`) and is shared by every linked worktree — two tasks that
+stash in parallel can pop or drop each other's work. Commit instead; a
+commit is per-branch and isolates exactly the way the model promises.
 
 ### Where does this work land?
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -125,7 +125,13 @@ replacement in `nextCommandArgs`.
   `.task.dispatcher` (`{taskId, tabId}`) = the Rove session that created the
   task, when one did: the lineage read for a parallel round's parent.
   `.task.command` = the raw launch command pinned on the task; `.task.vendor`
-  = the protocol derived from it.
+  = the protocol derived from it. `.task.prompt` = the full text of the
+  prompt `add --prompt` delivered into the task's engine (verbatim, never
+  truncated), recorded at delivery time — it is the durable copy of the task
+  brief, surviving a dead engine or lost context where the engine transcript
+  does not; absent when the task was created without a prompt or the paste
+  never landed. `.task.baseRef` = the branch the task was cut from
+  (`add --base-branch`), the fork point `collect` measures against.
   `.task.prStatus` = the branch's PR as the daemon last polled it
   (`lifecycle`, `number`, `url`, `lastCheckedAt`) — including
   `.prStatus.checkState`: `none` (no PR) / `pending` / `passing` / `failing` /
@@ -160,7 +166,12 @@ replacement in `nextCommandArgs`.
     task cannot land as-is, however it reported itself.
   - `.base` — committed work: `ahead` (commits vs the base branch) and a
     diffstat. `ahead: 0` against a resolved `baseRef` is the "reported
-    succeeded, committed nothing" tell.
+    succeeded, committed nothing" tell. `baseRef` is the task's RECORDED fork
+    point (`add --base-branch`) when it has one — tasks cut from
+    `release/2.x` are measured against `release/2.x`, not against a guessed
+    `main`; only records predating the field (or a recorded ref that no
+    longer resolves) fall back to the `origin/HEAD` → `main` → `master`
+    guess.
 
   Read-only by contract: it starts no engines, writes nothing, and changes
   no task state.
@@ -215,6 +226,12 @@ replacement in `nextCommandArgs`.
   convention (inferred from its existing local + origin branches, e.g.
   `feat/login-flow` in a type-prefixed repo, `login-flow` in a bare-slug or
   empty repo; name collisions get a short `-2`/`-3` suffix).
+  `--base-branch` cuts the new branch from that ref instead of the repo's
+  current HEAD and is persisted on the task (`.task.baseRef`) — the fork
+  point `collect` measures against, durable across daemon restarts. The
+  delivered `--prompt` text is persisted too (`.task.prompt`) — the durable
+  copy of the task brief; it survives a dead engine or lost context, where
+  the engine's own transcript does not.
 
   **Parallel attempts** live here too: `--count N` spawns N sibling tasks of
   the SAME prompt, each with its own worktree and branch, sharing one

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -35,6 +35,12 @@ will conflict — that's a feature when you asked for a helper, a bug when you
 wanted parallel attempts. When in doubt, take a new task: it is the only
 choice whose isolation cannot corrupt work in progress.
 
+One boundary the worktree isolation does NOT cover: **`git stash` is never
+safe in a managed worktree.** The stash stack lives in the repo's common dir
+(`.git/refs/stash`) and is shared by every linked worktree — two parallel
+tasks that stash can pop or drop each other's work. Commit instead; a commit
+is per-branch and isolates exactly the way the model promises.
+
 ## Fan out
 
 `add` creates one task; `--count` makes it a parallel round — N sibling

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -188,8 +188,11 @@ never pushed. Delete one you no longer need with
 
 - **Land says the worktree is not tracked.** Adopt it as a Task first, or
   merge the branch manually.
-- **Land refuses a dirty base checkout.** Commit or stash changes in the base
-  checkout, verify its current branch, then retry.
+- **Land refuses a dirty base checkout.** Commit the changes in the base
+  checkout, verify its current branch, then retry. Don't reach for
+  `git stash`: the stash stack lives in the repo's common dir
+  (`.git/refs/stash`) and is shared by every linked worktree, so a stash
+  here can entangle — or be popped by — parallel tasks' work.
 - **Land reports conflicts.** Rove has already aborted the merge. Resolve the
   branch relationship manually before retrying.
 - **A removed row comes back.** The daemon operation failed or git still lists

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -97,6 +97,15 @@ export interface DaemonTask {
   readonly linkedWorkItem?: TaskLinkedWorkItem
   /** The kobe session (task + tab) that dispatched this task, when one did. */
   readonly dispatcher?: TaskDispatcher
+  /** The task brief: the full text of the prompt `add --prompt` delivered
+   *  into this task's engine, persisted so it survives the engine's own
+   *  transcript. Verbatim, never truncated. Absent until delivered. */
+  readonly prompt?: string
+  /** The base ref the task branch was cut from (`add --base-branch`),
+   *  persisted so branch signals measure against the real fork point.
+   *  Absent on records that predate the field (signals fall back to a
+   *  base guess). */
+  readonly baseRef?: string
   readonly createdAt: string
   readonly updatedAt: string
 }
@@ -168,6 +177,8 @@ export interface DaemonOrchestrator {
   setLinkedWorkItem(id: string, item: TaskLinkedWorkItem | null): Promise<void>
   /** Arm (or clear, with `null`) the rate-limit auto-resume schedule. */
   setQuotaResume(id: string, state: TaskQuotaResumeState | null): Promise<void>
+  /** Record the task brief (the delivered `add --prompt` text) on the task. */
+  setPrompt(id: string, prompt: string): Promise<void>
   reorderTasks(moves: ReadonlyArray<{ taskId: string; position: number }>): Promise<void>
   deleteTask(id: string, options?: { force?: boolean; deleteBranch?: boolean }): Promise<void>
   prepareTaskDeletion(id: string, options?: { force?: boolean; deleteBranch?: boolean }): Promise<boolean>

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -334,6 +334,19 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     },
   },
   {
+    // NOT web-exposed: the only writer is the CLI `add` path, which records
+    // the brief AFTER the prompt is confirmed delivered into the engine. The
+    // field then means exactly "this is the prompt the engine was given" —
+    // an agent reading `get-task` can assert on it without wondering whether
+    // delivery happened.
+    name: "task.setPrompt",
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      await ctx.orch.setPrompt(taskId, requireString(payload, "prompt"))
+      return {}
+    },
+  },
+  {
     name: "task.setActive",
     web: true,
     async handle(payload, ctx) {

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -175,6 +175,12 @@ export type DaemonRequestName =
   | "task.pin"
   | "task.move"
   | "task.status"
+  // Record the task brief on the task row AFTER the prompt was confirmed
+  // delivered into the engine — the engine's own transcript is not durable,
+  // and this field is the copy that survives a dead engine/context loss.
+  // Deliberately NOT web-exposed: the browser has no reason to write another
+  // task's brief, and the web allowlist is a security contract.
+  | "task.setPrompt"
   // Web-board ordering (docs/design/web-kanban.md M3): batch-assign sparse
   // fractional `position` keys for per-status column order. ONE snapshot
   // push per batch; the TUI never reads `position`.
@@ -368,6 +374,10 @@ export interface SerializedTask {
   readonly linkedWorkItem?: DaemonTask["linkedWorkItem"]
   /** The kobe session (task + tab) that dispatched this task's creation. */
   readonly dispatcher?: DaemonTask["dispatcher"]
+  /** The task brief: the full delivered `add --prompt` text (never truncated). */
+  readonly prompt?: DaemonTask["prompt"]
+  /** The recorded fork point (`add --base-branch`) branch signals measure against. */
+  readonly baseRef?: DaemonTask["baseRef"]
   readonly createdAt: string
   readonly updatedAt: string
 }
@@ -407,6 +417,8 @@ export function serializeTask(task: DaemonTask): SerializedTask {
     quotaResume: task.quotaResume,
     linkedWorkItem: task.linkedWorkItem,
     dispatcher: task.dispatcher,
+    prompt: task.prompt,
+    baseRef: task.baseRef,
     createdAt: task.createdAt,
     updatedAt: task.updatedAt,
   }

--- a/packages/kobe/src/cli/api/branch-signals.ts
+++ b/packages/kobe/src/cli/api/branch-signals.ts
@@ -5,12 +5,14 @@
  * choosing a fan-out winner. These helpers add the committed side:
  * ahead-of-base commit count and a diffstat vs the merge-base.
  *
- * The fan-out `--base-branch` is one-shot input (a side-map consumed at
- * worktree creation, not durable Task state), so the base is re-resolved
- * here the same way the worktrees page does: `origin/HEAD` → `origin/main`
- * → `origin/master` → local `main`/`master`. All reads are lock-free
- * (`GIT_OPTIONAL_LOCKS=0`) and best-effort — a repo with no resolvable
- * base yields nulls, never an error.
+ * The base ref comes from the TASK RECORD first: `add --base-branch` is
+ * persisted on the task at create time, so a task cut from `release/2.x`
+ * is measured against `release/2.x`, not against a guess. Records that
+ * predate the field (or whose recorded ref no longer resolves) fall back
+ * to the re-resolution the worktrees page uses: `origin/HEAD` →
+ * `origin/main` → `origin/master` → local `main`/`master`. All reads are
+ * lock-free (`GIT_OPTIONAL_LOCKS=0`) and best-effort — a repo with no
+ * resolvable base yields nulls, never an error.
  */
 
 import { spawnSync } from "node:child_process"
@@ -52,6 +54,20 @@ export function resolveBaseRef(worktreePath: string): string | null {
 }
 
 /**
+ * The base to measure against: the task's RECORDED fork point when present
+ * and still resolvable, else the {@link resolveBaseRef} guess for records
+ * that predate the persisted field. A recorded ref that no longer resolves
+ * (base branch deleted, remote renamed) falls back too — an honest guess
+ * beats a stale certainty.
+ */
+function resolveMeasureBase(worktreePath: string, recordedBaseRef?: string): string | null {
+  if (recordedBaseRef && git(worktreePath, ["rev-parse", "--verify", "--quiet", recordedBaseRef]) !== null) {
+    return recordedBaseRef
+  }
+  return resolveBaseRef(worktreePath)
+}
+
+/**
  * Parse `git diff --shortstat` output, e.g.
  * ` 3 files changed, 40 insertions(+), 2 deletions(-)` — any clause may be
  * absent. An empty string is a real result: zero committed changes.
@@ -68,9 +84,9 @@ export function parseShortstat(text: string): { files: number; insertions: numbe
   }
 }
 
-export function readBranchSignals(worktreePath: string): BranchSignals {
+export function readBranchSignals(worktreePath: string, recordedBaseRef?: string): BranchSignals {
   if (!worktreePath) return NONE
-  const baseRef = resolveBaseRef(worktreePath)
+  const baseRef = resolveMeasureBase(worktreePath, recordedBaseRef)
   if (!baseRef) return NONE
   const aheadOut = git(worktreePath, ["rev-list", "--count", `${baseRef}..HEAD`])
   const ahead = aheadOut === null ? null : Number.parseInt(aheadOut, 10)

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -108,7 +108,6 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     },
     prompt,
   )
-  task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
   // A prompt that never confirmed AND was not deferred is a failure — but the
   // task IS created, so carry the taskId in the error so a script can find it.
   // Deferred (issue #78 B-layer) is a SUCCESS: the daemon owns the message now.
@@ -121,6 +120,14 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
       },
     )
   }
+  // Persist the brief on the task record — the engine's own transcript is
+  // NOT durable, and a delivered prompt that only lived in the session died
+  // with the engine. Recorded only AFTER delivery confirms, so `get-task`'s
+  // `.task.prompt` always means "the engine was given exactly this text".
+  // Best-effort: the engine already has the prompt, so a persist failure
+  // must not turn a delivered task into an error.
+  await daemon.request("task.setPrompt", { taskId, prompt }).catch(() => undefined)
+  task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
   return {
     taskId,
     task,
@@ -252,6 +259,10 @@ async function addParallel(
 
   const tasks: unknown[] = []
   const failures: unknown[] = []
+  // Best-effort per-sibling brief persistence (same contract as addOne) —
+  // collected here, awaited below. A persist failure must NOT flip a
+  // delivered sibling into a failure row: the engine already has the prompt.
+  const persistedPrompts: Promise<unknown>[] = []
   settled.forEach((r, i) => {
     const { taskId, vendor } = created[i]
     if (r.status === "fulfilled" && (r.value.delivered || r.value.deferred)) {
@@ -269,6 +280,7 @@ async function addParallel(
         session: r.value.session,
         ...(r.value.deferred ? { deferred: r.value.deferred } : {}),
       })
+      persistedPrompts.push(daemon.request("task.setPrompt", { taskId, prompt }).catch(() => undefined))
       return
     }
     // Either deliverPrompt threw, or it resolved un-delivered AND un-deferred
@@ -288,6 +300,7 @@ async function addParallel(
   // created for it) — but the siblings created before it are real, engine-
   // burning tasks whose ids must reach the script.
   if (createFailure) failures.push({ ok: false, vendor: createFailure.vendor, error: createFailure.error })
+  await Promise.all(persistedPrompts)
 
   const result = { count: created.length, requested: plan.length, groupId, tasks, failures }
   // Partial (or total) create/delivery failure must not exit 0 — carry the

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -66,7 +66,7 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
     // parallel-round winner: an attempt that commits its work reads +0/−0 here.
     const changes = task.worktreePath ? await runtime.readWorktreeChanges(task.worktreePath) : { added: 0, deleted: 0 }
     const base = task.worktreePath
-      ? await runtime.readBranchSignals(task.worktreePath)
+      ? await runtime.readBranchSignals(task.worktreePath, task.baseRef)
       : { baseRef: null, ahead: null, diff: null }
     const entry = registry?.[task.id]
     // `forMs` = time in the CURRENT state ("idle for 40min" when state is

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -247,7 +247,8 @@ export const defaultApiRuntime: ApiRuntime = {
   },
   readWorktreeChanges: async (worktreePath) =>
     (await import("../../tui/panes/sidebar/worktree-changes.ts")).readWorktreeChanges(worktreePath),
-  readBranchSignals: async (worktreePath) => (await import("./branch-signals.ts")).readBranchSignals(worktreePath),
+  readBranchSignals: async (worktreePath, recordedBaseRef) =>
+    (await import("./branch-signals.ts")).readBranchSignals(worktreePath, recordedBaseRef),
   tearDownSession: async (taskId) => {
     const host = await openPtyHost()
     if (host) {

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -233,8 +233,13 @@ export interface ApiRuntime {
   defaultVendor(repo?: string): Promise<VendorId | undefined>
   /** Uncommitted +/− counts for a worktree. */
   readWorktreeChanges(worktreePath: string): Promise<{ added: number; deleted: number }>
-  /** Committed work vs the branch's base: ahead count + diffstat (`collect`). */
-  readBranchSignals(worktreePath: string): Promise<{
+  /** Committed work vs the branch's base: ahead count + diffstat (`collect`).
+   *  `recordedBaseRef` is the task's persisted fork point (`add --base-branch`);
+   *  when present it wins over the base guess; absent/unresolvable falls back. */
+  readBranchSignals(
+    worktreePath: string,
+    recordedBaseRef?: string,
+  ): Promise<{
     baseRef: string | null
     ahead: number | null
     diff: { files: number; insertions: number; deletions: number } | null

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -44,7 +44,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
  */
-export const KOBE_SKILL_VERSION = 37
+export const KOBE_SKILL_VERSION = 38
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -229,11 +229,13 @@ export class Orchestrator {
       ...(input.modelEffort ? { modelEffort: input.modelEffort } : {}),
       ...(input.groupId ? { groupId: input.groupId } : {}),
       ...(input.dispatcher ? { dispatcher: input.dispatcher } : {}),
+      // Persisted ON the task (not a one-shot side-map): `ensureWorktree`
+      // reads it whenever the worktree materialises — including after a
+      // daemon restart between create and first enter — and `collect`'s
+      // branch signals compare against the recorded fork point instead of
+      // re-guessing the base.
+      ...(input.baseRef?.trim() ? { baseRef: input.baseRef.trim() } : {}),
     })
-    // Remember the optional baseRef on a side-map so `ensureWorktree`
-    // can use it. Not on the Task itself: base-ref is one-shot input
-    // to the worktree create, not durable state.
-    if (input.baseRef) this.worktreeCoordinator.setPendingBaseRef(task.id, input.baseRef)
     return task
   }
 
@@ -354,6 +356,8 @@ export class Orchestrator {
     this.editor.setLinkedWorkItem(id, item)
   setQuotaResume = (id: TaskId | string, state: NonNullable<Task["quotaResume"]> | null): Promise<void> =>
     this.editor.setQuotaResume(id, state)
+  /** Record the task brief (the delivered `add --prompt` text) on the task. */
+  setPrompt = (id: TaskId | string, prompt: string): Promise<void> => this.editor.setPrompt(id, prompt)
 
   /**
    * Permanently remove a task. Refuses to delete `kind: "main"`

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -92,7 +92,9 @@ export const MAIN_CHECKOUT_DIRTY_CODE = "MAIN_CHECKOUT_DIRTY"
  * Thrown by `landTask` when the base repo's checkout has uncommitted changes.
  * Landing merges the task branch INTO that checkout, so a dirty tree would
  * entangle the user's in-progress work with the landed branch — we refuse and
- * let them commit/stash first.
+ * let them commit first. (Never `git stash` here: the stash stack lives in
+ * the repo's common dir and is shared by every linked worktree, so a stash in
+ * the base checkout can entangle parallel tasks' work.)
  */
 export class MainCheckoutDirtyError extends Error {
   constructor(
@@ -100,7 +102,7 @@ export class MainCheckoutDirtyError extends Error {
     public readonly dir: string,
   ) {
     super(
-      `${MAIN_CHECKOUT_DIRTY_CODE}: base checkout at ${dir} has uncommitted changes; commit or stash them before landing`,
+      `${MAIN_CHECKOUT_DIRTY_CODE}: base checkout at ${dir} has uncommitted changes; commit them before landing (never git stash — the stash stack is shared by every worktree of this repo)`,
     )
     this.name = "MainCheckoutDirtyError"
   }

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -319,6 +319,15 @@ function coerceTask(value: unknown): Task | null {
     // load coercion or a daemon restart severs every sub-task's route home.
     // Records that predate the field normalize to undefined.
     ...(dispatcher ? { dispatcher } : {}),
+    // The task brief (`add --prompt`) — must survive the load coercion or a
+    // daemon restart destroys the only durable copy of what the task was
+    // asked to do (the engine transcript does not survive the engine).
+    ...(typeof v.prompt === "string" && v.prompt.length > 0 ? { prompt: v.prompt } : {}),
+    // Recorded fork point (`add --base-branch`) — must survive the load
+    // coercion or a daemon restart loses it before the lazy worktree
+    // materialises (branches then silently cut from the guessed base), and
+    // `collect`'s ahead/diffstat signals revert to the wrong comparison ref.
+    ...(typeof v.baseRef === "string" && v.baseRef.trim().length > 0 ? { baseRef: v.baseRef } : {}),
     createdAt: v.createdAt,
     updatedAt: v.updatedAt,
   }

--- a/packages/kobe/src/orchestrator/task-editor.ts
+++ b/packages/kobe/src/orchestrator/task-editor.ts
@@ -261,4 +261,19 @@ export class TaskEditor {
     if ((task.linkedWorkItem?.url ?? null) === (item?.url ?? null)) return
     await this.store.update(task.id, { linkedWorkItem: item ?? undefined })
   }
+
+  /**
+   * Record the task brief: the full text of the prompt `add --prompt`
+   * delivered into this task's engine. Written on the delivery path so the
+   * brief survives the engine's own transcript — a dead engine used to take
+   * the only copy down with it. Stored verbatim (never truncated); a
+   * whitespace-only prompt is rejected. No-op when the stored text already
+   * matches, so a redundant call never churns a write + broadcast.
+   */
+  async setPrompt(id: TaskId | string, prompt: string): Promise<void> {
+    if (prompt.trim().length === 0) throw new Error("setPrompt: prompt is required (empty or whitespace-only rejected)")
+    const task = this.requireTask(id)
+    if (task.prompt === prompt) return
+    await this.store.update(task.id, { prompt })
+  }
 }

--- a/packages/kobe/src/orchestrator/worktree-coordinator.ts
+++ b/packages/kobe/src/orchestrator/worktree-coordinator.ts
@@ -79,8 +79,6 @@ export class WorktreeCoordinator {
    * after (success or failure: on success the branch itself is the guard).
    */
   private readonly reservedBranches = new Set<string>()
-  /** Optional base-ref per task — consumed once by `ensure`. */
-  private readonly pendingBaseRefs = new Map<TaskId, string>()
 
   constructor(
     store: TaskIndexStore,
@@ -104,14 +102,8 @@ export class WorktreeCoordinator {
     )
   }
 
-  /** Record a one-shot base ref for the next {@link ensure} of `id`. */
-  setPendingBaseRef(id: TaskId, baseRef: string): void {
-    this.pendingBaseRefs.set(id, baseRef)
-  }
-
-  /** Drop a task's pending base-ref + in-flight worktree lock (on delete / forget). */
+  /** Drop a task's in-flight worktree lock (on delete / forget). */
   forget(id: TaskId): void {
-    this.pendingBaseRefs.delete(id)
     this.worktreeLocks.delete(id)
   }
 
@@ -153,7 +145,11 @@ export class WorktreeCoordinator {
   private async createWorktree(task: Task): Promise<string> {
     const slug = await this.slugs.allocate(task.repo)
     const branch = task.branch || (await this.deriveAutoBranch(task))
-    const baseRef = this.pendingBaseRefs.get(task.id)
+    // The recorded fork point (`add --base-branch`), persisted on the task at
+    // create time — durable across daemon restarts between create and this
+    // lazy materialise. Absent on records that predate the field: cut from
+    // the git default (the manager's own resolution).
+    const baseRef = task.baseRef
     let info: WorktreeInfo
     try {
       info = await this.worktrees.createForTask({ repo: task.repo, slug, branch, baseRef })
@@ -178,7 +174,6 @@ export class WorktreeCoordinator {
       throw err
     }
     this.slugs.commit(task.repo, slug)
-    this.pendingBaseRefs.delete(task.id)
     return info.path
   }
 

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -48,7 +48,8 @@ export const en = {
       'Merge "{branch}" into the base repo\'s current branch, then remove this worktree? The branch is kept. A dirty base checkout is refused; conflicts abort with a file list.',
     noTask: "This worktree isn't tracked as a Rove task — nothing to land.",
     conflict: "Land hit conflicts (merge aborted). Resolve by hand: {files}",
-    dirtyBase: "The base checkout has uncommitted changes — commit or stash them, then land.",
+    dirtyBase:
+      "The base checkout has uncommitted changes — commit them, then land. Never `git stash` here: the stash stack lives in the repo's common dir and is shared by every linked worktree, so a stash can entangle other tasks' work.",
     failed: "Land failed: {error}",
     done: 'Landed "{branch}" onto {landedOn} ({commit}).',
     worktreeKept: "Landed, but the worktree was kept: {reason}",
@@ -102,7 +103,8 @@ export const zh: typeof en = {
       '把 "{branch}" 合入基仓库当前分支，然后移除这个 worktree？分支会保留。基础检出有未提交改动会被拒绝；冲突会中止并给出文件清单。',
     noTask: "该 worktree 未作为 Rove 任务被跟踪——没有可合入的对象。",
     conflict: "合入遇到冲突（已中止）。请手动解决：{files}",
-    dirtyBase: "基础检出有未提交改动——请先提交或 stash，再合入。",
+    dirtyBase:
+      "基础检出有未提交改动——请先提交再合入。绝不要在这里 `git stash`：stash 栈存放在仓库的 common dir 中，该仓库所有 linked worktree 共享，一次 stash 可能纠缠其他任务的工作。",
     failed: "合入失败：{error}",
     done: '已把 "{branch}" 合入 {landedOn}（{commit}）。',
     worktreeKept: "已合入，但 worktree 保留了：{reason}",

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -232,6 +232,26 @@ export interface Task {
   readonly linkedWorkItem?: TaskLinkedWorkItem
   /** The kobe session (task + tab) that dispatched this task, when one did. */
   readonly dispatcher?: TaskDispatcher
+  /**
+   * The task brief: the full text of the prompt `add --prompt` delivered
+   * into this task's engine, recorded on the delivery path. The engine's
+   * own transcript is NOT durable — a dead engine used to take the brief
+   * down with it, and the only recovery was the user re-pasting it. Stored
+   * verbatim (never truncated: the constraints an agent needs most often
+   * sit at the END of a long brief). Optional + additive: tasks created
+   * without a prompt never get one.
+   */
+  readonly prompt?: string
+  /**
+   * The base ref the task branch was cut from (`add --base-branch`),
+   * persisted so `collect`'s branch signals (ahead count / diffstat)
+   * compare against the REAL fork point instead of re-guessing
+   * `origin/HEAD` → `main` → `master`, and a daemon restart between
+   * create and lazy worktree materialise cannot silently drop it.
+   * Optional + additive: records predating the field fall back to the
+   * guess.
+   */
+  readonly baseRef?: string
   readonly createdAt: string
   readonly updatedAt: string
 }

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -188,6 +188,7 @@ describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
     await asSession("boccha", "tab-1", { detached: true })
     const client = new FakeClient({
       "task.create": (_payload, i) => ({ taskId: `t${i}`, task: taskFixture({ id: `t${i}` }) }),
+      "task.setPrompt": () => ({}),
     })
     const { deliver } = recordingDelivery()
     await invokeVerb("add", ["--repo", "/repo/x", "--count", "2", "--prompt", "go"], {
@@ -203,6 +204,7 @@ describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
     await asSession("disp-1", "tab-3")
     const client = new FakeClient({
       "task.create": (_payload, i) => ({ taskId: `t${i}`, task: taskFixture({ id: `t${i}` }) }),
+      "task.setPrompt": () => ({}),
     })
     const { deliver } = recordingDelivery()
     await invokeVerb("add", ["--repo", "/repo/x", "--count", "2", "--prompt", "go"], {
@@ -213,6 +215,12 @@ describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
     expect(creates).toHaveLength(2)
     for (const create of creates) {
       expect(create.payload).toMatchObject({ dispatcherTaskId: "disp-1", dispatcherTabId: "tab-3" })
+    }
+    // Every delivered sibling's brief is persisted on its own task record.
+    const persists = client.requests.filter((r) => r.name === "task.setPrompt")
+    expect(persists).toHaveLength(2)
+    for (const persist of persists) {
+      expect(persist.payload).toMatchObject({ prompt: "go" })
     }
   })
 })

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -114,11 +114,12 @@ describe("add handler", () => {
     expect(client.requests[0].payload).toEqual({ repo: "/repo/x", command: "my-wrapper --go", vendor: "generic" })
   })
 
-  it("delivers an explicit prompt to the created task", async () => {
+  it("delivers an explicit prompt to the created task and persists the brief on the record", async () => {
     const task = taskFixture({ kind: "task", vendor: "codex", modelEffort: "high" })
     const client = new FakeClient({
       "task.create": () => ({ taskId: "t1", task }),
       "task.get": () => ({ task }),
+      "task.setPrompt": () => ({}),
     })
     const { calls, deliver } = recordingDelivery()
     const result = (await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "do it"], {
@@ -132,6 +133,10 @@ describe("add handler", () => {
       prompt: "do it",
     })
     expect(result).toMatchObject({ started: true, engineReady: true, delivered: true, session: "t1::tab-1" })
+    // The brief is written to the task record AFTER delivery confirms — the
+    // engine transcript is not durable, and this field is the copy that
+    // survives a dead engine. Never recorded when the paste never landed.
+    expect(client.requests).toContainEqual({ name: "task.setPrompt", payload: { taskId: "t1", prompt: "do it" } })
   })
 
   it("reports a created task whose prompt never landed (issue #72/#73)", async () => {
@@ -139,6 +144,7 @@ describe("add handler", () => {
     const client = new FakeClient({
       "task.create": () => ({ taskId: "t1", task }),
       "task.get": () => ({ task }),
+      "task.setPrompt": () => ({}),
     })
     await expectApiError(
       () =>
@@ -148,6 +154,9 @@ describe("add handler", () => {
         }),
       "NOT_DELIVERED",
     )
+    // A prompt that never reached the engine is never persisted: `get-task`'s
+    // `.task.prompt` must always mean "the engine was given exactly this".
+    expect(client.requestNames).not.toContain("task.setPrompt")
   })
 
   it("keeps the spawn-task alias", async () => {

--- a/packages/kobe/test/cli/branch-signals.test.ts
+++ b/packages/kobe/test/cli/branch-signals.test.ts
@@ -70,3 +70,49 @@ describe("readBranchSignals", () => {
     expect(resolveBaseRef(dir)).toBeNull()
   })
 })
+
+describe("readBranchSignals with a recorded baseRef", () => {
+  /**
+   * main (A) → release/2.x (adds B) → kobe/task cut FROM release/2.x (adds
+   * C). The base guess resolves local `main`; the recorded fork point is
+   * `release/2.x` — measuring against the guess over-counts ahead and
+   * folds the release work into the task's diffstat.
+   */
+  function makeForkedRepo(): string {
+    const repo = mkdtempSync(join(tmpdir(), "kobe-branch-signals-forked-"))
+    cleanups.push(repo)
+    git(repo, "init", "-q", "-b", "main")
+    writeFileSync(join(repo, "a.txt"), "one\n")
+    git(repo, "add", "a.txt")
+    git(repo, "commit", "-q", "-m", "base")
+    git(repo, "checkout", "-q", "-b", "release/2.x")
+    writeFileSync(join(repo, "release.txt"), "rel\n")
+    git(repo, "add", "release.txt")
+    git(repo, "commit", "-q", "-m", "release work")
+    git(repo, "checkout", "-q", "-b", "kobe/task")
+    writeFileSync(join(repo, "task.txt"), "task\n")
+    git(repo, "add", "task.txt")
+    git(repo, "commit", "-q", "-m", "task work")
+    return repo
+  }
+
+  it("measures against the recorded fork point instead of the guess", () => {
+    const repo = makeForkedRepo()
+    const signals = readBranchSignals(repo, "release/2.x")
+    expect(signals.baseRef).toBe("release/2.x")
+    expect(signals.ahead).toBe(1)
+    expect(signals.diff).toEqual({ files: 1, insertions: 1, deletions: 0 })
+    // Sanity anchor: with NO record the guess resolves local main and
+    // over-counts (2 ahead, release work folded into the diffstat).
+    const guessed = readBranchSignals(repo)
+    expect(guessed.baseRef).toBe("main")
+    expect(guessed.ahead).toBe(2)
+  })
+
+  it("falls back to the guess when the recorded ref no longer resolves", () => {
+    const repo = makeForkedRepo()
+    const signals = readBranchSignals(repo, "deleted-branch")
+    expect(signals.baseRef).toBe("main")
+    expect(signals.ahead).toBe(2)
+  })
+})

--- a/packages/kobe/test/daemon/handlers-task-crud.test.ts
+++ b/packages/kobe/test/daemon/handlers-task-crud.test.ts
@@ -79,6 +79,18 @@ describe("daemon handler registry — tasks, issues, worktrees", () => {
       await expect(dispatch("task.rename", { taskId: "t1" }, ctx)).rejects.toThrow("title is required")
     })
 
+    it("task.setPrompt records the delivered brief and validates both fields", async () => {
+      const prompts: Array<[string, string]> = []
+      const { ctx } = fakeCtx({
+        setPrompt: async (id: string, prompt: string) => {
+          prompts.push([id, prompt])
+        },
+      })
+      await expect(dispatch("task.setPrompt", { taskId: "t1", prompt: "the brief" }, ctx)).resolves.toEqual({})
+      expect(prompts).toEqual([["t1", "the brief"]])
+      await expect(dispatch("task.setPrompt", { taskId: "t1" }, ctx)).rejects.toThrow("prompt is required")
+    })
+
     it("task.reorder forwards a validated batch and returns the empty object", async () => {
       const batches: unknown[] = []
       const { ctx } = fakeCtx({

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -48,6 +48,7 @@ describe("daemon handler registry", () => {
       "task.pin",
       "task.move",
       "task.status",
+      "task.setPrompt",
       "task.reorder",
       "task.ensureMain",
       "task.openDir",

--- a/packages/kobe/test/daemon/serialize-task-fields.test.ts
+++ b/packages/kobe/test/daemon/serialize-task-fields.test.ts
@@ -78,6 +78,8 @@ const FULL: DeepRequired<SerializedTask> = {
     url: "https://github.com/o/r/issues/7",
   },
   dispatcher: { taskId: "01ARZ3NDEKTSV4RRFFQ69G5FAX", tabId: "tab-1" },
+  prompt: "the full task brief — never truncated on the way to the wire",
+  baseRef: "release/2.x",
   createdAt: "2026-08-30T00:00:00.000Z",
   updatedAt: "2026-08-30T00:00:00.000Z",
 }

--- a/packages/kobe/test/orchestrator/ensure-worktree.test.ts
+++ b/packages/kobe/test/orchestrator/ensure-worktree.test.ts
@@ -169,3 +169,32 @@ describe("ensureWorktree — concurrent delete after a successful write", () => 
     expect(orch.getTask(task.id)).toBeUndefined()
   })
 })
+
+describe("ensureWorktree — recorded baseRef (durable fork point)", () => {
+  test("persists baseRef on the task and cuts from it even after a daemon restart", async () => {
+    // Stage a side branch with a distinct commit, then move HEAD back to
+    // main so the base choice is observable in the worktree's contents.
+    spawnSync("git", ["checkout", "-q", "-b", "side-base"], { cwd: repo })
+    fs.writeFileSync(path.join(repo, "SIDE.md"), "side\n")
+    spawnSync("git", ["add", "SIDE.md"], { cwd: repo })
+    spawnSync("git", ["commit", "-q", "-m", "side base"], { cwd: repo })
+    const sideSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
+    spawnSync("git", ["checkout", "-q", "main"], { cwd: repo })
+
+    const task = await orch.createTask({ repo, baseRef: "side-base" })
+    // The fork point is durable Task state, not a one-shot in-memory side-map:
+    // it must be ON the record — this is what lets a consumer compare against
+    // the real fork point, and what survives a daemon restart before the
+    // lazy worktree materialises.
+    expect(orch.getTask(task.id)?.baseRef).toBe("side-base")
+
+    // Simulated daemon restart: a brand-new Orchestrator over the SAME store
+    // (the old side-map died with the "process"). The worktree must still
+    // cut from side-base, not silently from the repo's current HEAD.
+    const restarted = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
+    const p = await restarted.ensureWorktree(task.id)
+    const ancestry = spawnSync("git", ["merge-base", "--is-ancestor", sideSha, "HEAD"], { cwd: p })
+    expect(ancestry.status).toBe(0)
+    expect(fs.existsSync(path.join(p, "SIDE.md"))).toBe(true)
+  })
+})

--- a/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
+++ b/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
@@ -90,6 +90,8 @@ const FULL_TASK: DeepRequired<Task> = {
     taskId: "01ARZ3NDEKTSV4RRFFQ69G5FB1",
     tabId: "tab-1",
   },
+  prompt: "the full task brief — never truncated on the way to disk",
+  baseRef: "release/2.x",
   createdAt: "2026-08-27T00:00:00.000Z",
   updatedAt: "2026-08-27T00:00:00.000Z",
 }


### PR DESCRIPTION
## Why

Two of today's incidents trace to fields the daemon computed but never persisted, and one to the product recommending a command that is unsafe under its own isolation model:

1. **`prompt` was never persisted.** `add --prompt` delivered the brief into the engine and dropped it — the only copy lived in the engine's own transcript. Engine dies / context lost → the task brief is gone, and the only recovery was the user re-pasting it.
2. **`baseRef` only lived in an in-memory side-map** (`WorktreeCoordinator.pendingBaseRefs`), consumed once at worktree creation. A daemon restart between `add` and lazy worktree materialise silently dropped it (branch then cut from the guessed base), and `collect`'s ahead/diffstat signals always measured against a re-guessed `origin/HEAD` → `main` → `master` instead of the real fork point — wrong counts for tasks cut from any other branch.
3. **Rove recommended `git stash`** (WORKTREES.md, the land-refusal error, the worktrees page i18n) while the stash stack lives in the repo's common dir (`.git/refs/stash`) and is shared by every linked worktree — two parallel tasks that stash can pop or drop each other's work. The isolation docs never mentioned this exception.

## What

- **`prompt`**: new `task.setPrompt` RPC (not web-exposed); the `add` path records the full brief on the Task after delivery confirms (delivered or deferred), single and parallel rounds alike. `get-task` returns it as `.task.prompt` — verbatim, never truncated. Both codec guards (disk round-trip + wire serialize) pin the field.
- **`baseRef`**: persisted on the Task at create time; the worktree coordinator reads the record (side-map deleted), so a daemon restart between create and materialise no longer loses it. `collect` prefers the recorded fork point and falls back to the guess only for records that predate the field or whose ref no longer resolves.
- **stash copy**: the land-refusal error (`MainCheckoutDirtyError`), worktrees page i18n (en + zh), WORKTREES.md, ORCHESTRATION.md, and the agent skill (both byte-identical mirrors, v38) now say *commit*, and say why stash is repo-level shared.

## Verification

- New red-green anchors: wire guard + disk guard fixtures extended (both go red if either layer drops the field); orchestrator test proves the recorded fork point survives a simulated daemon restart; CLI tests pin `task.setPrompt` after delivery and its absence on NOT_DELIVERED; branch-signal tests pin recorded-over-guess and guess-fallback. Each removal was verified red, then restored.
- Full `test:fast` (3,796 tests) and `test:socket` (627 tests) green; the only flakes are pre-existing timing tests elsewhere (redraw budget, notes eviction, deletion-background) that pass in isolation.
- Real-machine (dev:sandbox) end-to-end: `api add --prompt ... --base-branch main` → `get-task` returns both fields → tasks.json on disk carries both → `daemon restart` → `get-task` still returns both.

## Judgment calls

- **Full prompt, not truncated** — the consumer is an agent re-establishing context; constraints sit at the END of long briefs, and tasks.json size is bounded by task count, not field bytes (same precedent as `displayTaskTitle`: no truncation).
- **Guess fallback kept** — old tasks have no recorded baseRef; signals stay useful for them. Recorded ref wins only when it still resolves.
- **SKILL.md line placement**: immediately after the Task⊃Tab⊃Split isolation paragraph, before the routing table — that's the section every routing decision reads.

Docs: API.md (`get-task`/`collect`/`add`), WORKTREES.md, ORCHESTRATION.md. Changeset: patch.