### PR TITLE
perf: six many-tasks hot-path fixes

### DIFF
--- a/.changeset/many-tasks-perf-pass.md
+++ b/.changeset/many-tasks-perf-pass.md
@@ -1,0 +1,28 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Performance fixes for large installs (hundreds of tasks)
+
+Six hot paths that were tuned for ~20 tasks and turned into the main cost at
+real-install scale:
+
+- `state.json` and `tasks.json` are now written compact. Both files are
+  rewritten whole on every change and read only by machines; the
+  pretty-print indentation tripled their bytes for no reader.
+- The attention Inbox now caps at 500 pending episodes, pruning the oldest
+  (same shape as the other daemon stores). An episode only left on
+  visit / dismiss / a new turn / task deletion, so a task you never reopened
+  kept its episode forever — and every episode rewrote the whole file.
+- Cross-task notification toasts no longer re-scan the whole task list per
+  notification; one index build per pass instead.
+- The sidebar tree's orphan-tab backstop no longer re-scans the task list
+  per orphan row.
+- Sidebar TAB rows memoize their row view on the real inputs, so the ~10Hz
+  spinner tick stops re-deriving every idle tab row (the flat cards already
+  did this).
+- Orphaned `terminalTabs.*` snapshots are swept on every task-list change,
+  not once per launch — a task deleted by another client (`rove api`, web
+  board) used to leave its snapshot taxing every kv write until restart.
+  The empty-list guard that protects a pre-connection render from wiping
+  live snapshots is unchanged.

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -30,6 +30,17 @@ interface AttentionInboxFile {
   readonly items: AttentionInboxItem[]
 }
 
+/**
+ * Retention cap (prune-oldest, shape of `pty-exit-store.ts`'s MAX_RECORDS):
+ * an episode leaves only on visit / dismiss / a newer turn on the same
+ * task+tab / task hard-delete — a task you never revisit keeps its episode
+ * forever, and every recorded episode rewrites the whole file. Without a
+ * cap the queue grows without bound; the size of a real install's task list
+ * is the natural ceiling on live episodes, but forgotten tasks must not
+ * accumulate tax forever.
+ */
+export const MAX_EPISODES = 500
+
 export function defaultAttentionInboxPath(homeDir = readRoveEnv("HOME_DIR") ?? homedir()): string {
   return join(homeDir, ROVE_STATE_DIR_BASENAME, "attention-inbox.json")
 }
@@ -227,7 +238,8 @@ export class AttentionInboxStore {
 
   /** Serialize mutations so concurrent hook/RPC writes cannot clobber the file. */
   private async commit(next: ReadonlyMap<string, AttentionInboxItem>): Promise<void> {
-    const items = [...next.values()].sort(compareItems)
+    // Sorted ascending by `at`, so the tail is the newest — prune-oldest.
+    const items = [...next.values()].sort(compareItems).slice(-MAX_EPISODES)
     await writeStore(this.path, items)
     this.items.clear()
     for (const item of items) this.items.set(attentionInboxItemKey(item), item)

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -175,7 +175,9 @@ export class TaskIndexStore {
         tasks: merged.tasks,
         ...(merged.removed.length > 0 ? { removed: merged.removed } : {}),
       }
-      const json = `${JSON.stringify(payload, null, 2)}\n`
+      // Compact (no `null, 2`): every mutation rewrites the whole file, the
+      // file is read only by machines, and pretty-printing tripled the bytes.
+      const json = `${JSON.stringify(payload)}\n`
 
       // Unique per save: a shared `<path>.tmp` let a second writer clobber the
       // first's staging file whenever mutual exclusion broke, failing the

--- a/packages/kobe/src/state/store.ts
+++ b/packages/kobe/src/state/store.ts
@@ -97,10 +97,12 @@ function writeStateFile(state: StateSnapshot): void {
   mkdirSync(dirname(path), { recursive: true })
   const nonce = Math.random().toString(36).slice(2)
   const tmp = `${path}.${process.pid}.${nonce}.tmp`
+  // Compact (no `null, 2`): the file is written on EVERY kv flush and read
+  // only by machines — pretty-printing tripled the bytes for no reader.
   // 0600: `engineCommand.*` holds a user-authored shell line, which is exactly
   // where someone pastes `--api-key=…`. Owner-only costs nothing here — the file
   // already lives under a single user's ~/.config.
-  writeFileSync(tmp, JSON.stringify(state, null, 2), { encoding: "utf8", mode: 0o600 })
+  writeFileSync(tmp, JSON.stringify(state), { encoding: "utf8", mode: 0o600 })
   renameSync(tmp, path)
 }
 

--- a/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
@@ -20,6 +20,7 @@
  * ordinals, kinds and split state a session key can't.
  */
 
+import type { Task } from "@/types/task"
 import { stripEngineStatusPrefix } from "../../../engine/registry"
 import { type TreeTab, parseRowId, tabRowId } from "../../../tui/panes/sidebar/tree-core"
 
@@ -79,4 +80,22 @@ export function orphanTabsByTask(
     byTask.set(taskId, tabs)
   }
   return byTask
+}
+
+/**
+ * Keep only orphan tabs whose task is still in the task list — membership
+ * via ONE Set build, not a per-orphan `tasks.some` scan. This runs inside
+ * the tree's orphan memo; with a few hundred tasks, every orphan row used
+ * to re-scan the whole array to prove its task exists.
+ */
+export function filterKnownOrphanTabs(
+  tasks: readonly Task[],
+  orphans: ReadonlyMap<string, readonly TreeTab[]>,
+): ReadonlyMap<string, readonly TreeTab[]> {
+  const taskIds = new Set<string>(tasks.map((task) => task.id))
+  const known = new Map<string, readonly TreeTab[]>()
+  for (const [taskId, tabs] of orphans) {
+    if (taskIds.has(taskId)) known.set(taskId, tabs)
+  }
+  return known
 }

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -14,7 +14,7 @@
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
 import type { Task } from "@/types/task"
 import { type BoxRenderable, MouseButton } from "@opentui/core"
-import { type ReactNode, useEffect } from "react"
+import { type ReactNode, useEffect, useMemo } from "react"
 import { charWidth } from "../../../lib/display-width"
 import { truncateEndCells } from "../../../tui/lib/truncate"
 import { currentBranch, pollCurrentBranch } from "../../../tui/panes/sidebar/git-head"
@@ -259,6 +259,40 @@ export function WorktreeTreeRow(props: {
   )
 }
 
+/**
+ * The tab row's `buildSidebarRowView`, memoized on the real inputs so the
+ * ~10Hz spinner tick (a fresh `shared` object every render) doesn't
+ * re-derive idle tab rows. Same shape as the flat cards' `useRowCardChrome`
+ * (row-cards.tsx) — non-loading rows come back as the same object and never
+ * subscribe to the tick. Extracted + exported so the memo contract has a
+ * direct test; TabTreeRow is the only caller.
+ */
+export function useTabRowBaseView(args: {
+  readonly task: Task
+  readonly activity: TaskEngineState | undefined
+  readonly lifecycle: { readonly subagents: number } | undefined
+  readonly job: TaskJobState | undefined
+  readonly completionSeen: boolean
+}): ReturnType<typeof buildSidebarRowView> {
+  const t = useT()
+  const { task, activity, lifecycle, job, completionSeen } = args
+  return useMemo(() => {
+    // Dependency-only invalidation key: rebuild when the language changes —
+    // buildSidebarRowView reads the global `t` through the locale store.
+    void t
+    return buildSidebarRowView({
+      task,
+      activity,
+      lifecycle,
+      job,
+      spinnerFrame: 0,
+      subtitleBudget: 0,
+      truncateBranch: truncateBranchLabel,
+      completionSeen,
+    })
+  }, [task, activity, lifecycle, job, completionSeen, t])
+}
+
 export function TabTreeRow(props: {
   readonly rowId: string
   readonly flatIndex: number
@@ -317,14 +351,11 @@ export function TabTreeRow(props: {
   const completionSeen = carriesState
     ? completionSeenFor(props.task.id, activity?.state, viewing, props.tab.id, durableSeen)
     : false
-  const baseView = buildSidebarRowView({
+  const baseView = useTabRowBaseView({
     task: props.task,
     activity,
     lifecycle: carriesState ? shared.engineLifecycle?.get(props.task.id) : undefined,
     job: carriesState ? shared.taskJobs?.get(props.task.id) : undefined,
-    spinnerFrame: 0,
-    subtitleBudget: 0,
-    truncateBranch: truncateBranchLabel,
     completionSeen,
   })
   const frame = useSpinnerFrame(carriesState && baseView.loading)

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -39,7 +39,7 @@ import { tabPtyKeyFor } from "../../../tui/workspace/terminal-tabs-core"
 import { adoptTaskTabs } from "../../workspace/terminal-tabs-adopt"
 import type { TabsSnapshotKv } from "../../workspace/terminal-tabs-persist"
 import { knownTaskTabs } from "../../workspace/terminal-tabs-shared"
-import { orphanTabsByTask } from "./orphan-tabs"
+import { filterKnownOrphanTabs, orphanTabsByTask } from "./orphan-tabs"
 import { useHostSessions } from "./use-host-sessions"
 
 export interface TreeStateOpts {
@@ -186,15 +186,12 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   const orphansByTask = useMemo<ReadonlyMap<string, readonly TreeTab[]>>(() => {
     const registered = new Set<string>()
     for (const [taskId, tabs] of snapshotTabs) for (const tab of tabs) registered.add(tabRowId(taskId, tab.id))
-    const map = new Map<string, readonly TreeTab[]>()
     // A just-closed tab's session can outlive its state in the 2s poll —
     // treating it as an orphan would adopt it right back (see
     // closed-tab-suppress.ts).
     const sessions = hostSessions.filter((session) => !isRecentlyClosedPtyKey(session.key))
-    for (const [taskId, orphans] of orphanTabsByTask(sessions, registered)) {
-      if (tasks.some((task) => task.id === taskId)) map.set(taskId, orphans)
-    }
-    return map
+    // Membership via one Set build (tree-core), not a per-orphan `tasks.some`.
+    return filterKnownOrphanTabs(tasks, orphanTabsByTask(sessions, registered))
   }, [snapshotTabs, hostSessions, tasks])
 
   // …and then it stops being unregistered: a row nobody can open or close is

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -124,10 +124,14 @@ export function useAttention(args: {
     prevStates.current = next
     if (kv.get(CROSS_TASK_KEY, true) === false) return
     const repos = [...new Set(tasks.map((t) => t.repo))]
+    // One O(n) index build instead of a per-edge `tasks.find` scan: with a
+    // few hundred tasks and one edge each, the loop used to re-scan the
+    // whole array for every notification.
+    const taskById = new Map<string, Task>(tasks.map((task) => [task.id, task]))
     for (const { key, kind } of edges) {
       const target = targets.get(key)
       if (!target || target.taskId === selectedId) continue
-      const task = tasks.find((t) => t.id === target.taskId)
+      const task = taskById.get(target.taskId)
       // Toast identity mirrors the Inbox card: task title leads, project
       // (repo label) is the context body line — plus the tab when one is
       // known, so two tabs of one task finishing don't read identically.
@@ -163,9 +167,11 @@ export function useAttention(args: {
     if (prev === null) return // seed — replayed history must not re-fire toasts
     if (kv.get(CROSS_TASK_KEY, true) === false) return
     const repos = [...new Set(tasks.map((t) => t.repo))]
+    // Same hoist as the engine-state effect above: no per-item `tasks.find`.
+    const taskById = new Map<string, Task>(tasks.map((task) => [task.id, task]))
     for (const [key, entry] of next) {
       if (prev.get(key)?.at === entry.at) continue // same episode, not a fresh edge
-      const task = tasks.find((t) => t.id === entry.taskId)
+      const task = taskById.get(entry.taskId)
       const tab = knownTaskTab(kv, entry.taskId, entry.tabId)
       const tabLabel = tab ? tabTitleStable(tab, task?.vendor ?? DEFAULT_TASK_VENDOR) : ""
       const project = task ? sidebarProjectLabel(task.repo, repos) : ""

--- a/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
@@ -82,9 +82,15 @@ export function useWorkspaceSelection(args: {
     setSelectedId(firstSelectableTask(tasks, activeTaskId, readLastActiveTaskId())?.id ?? null)
   }, [tasks, activeTaskId, selectedId, args.focusWorkspace])
 
-  // One-time orphan sweep (O19): clear `terminalTabs.*` snapshots whose task
-  // no longer exists. Runs once on first hydration; ref not dep, so a later
-  // task-list change never re-sweeps a live task's fresh snapshot.
+  // Orphan sweep (O19): clear `terminalTabs.*` snapshots whose task no longer
+  // exists. Runs on EVERY task-list identity change, not once per session:
+  // a sibling client (`rove api` / web board) deleting a task only lands here
+  // as a changed list — forgetTaskTabs is wired to THIS client's delete flow
+  // alone, so a once-per-session sweep left those orphans taxing every later
+  // kv write until the next launch. The sweep itself is idempotent and cheap
+  // (one Set lookup per snapshot key), so re-running it on every list echo
+  // costs nothing: a live task's id is always in the list, so its snapshots
+  // can never be swept by a re-run.
   //
   // The `tasks.length === 0` guard is load-bearing and SUFFICIENT, despite
   // reading like a weak null-check: this list is only ever assigned from the
@@ -96,10 +102,8 @@ export function useWorkspaceSelection(args: {
   // orphan. Do not relax the empty check — empty is exactly the shape a
   // pre-connection render and a corrupt-manifest recovery both take, and
   // sweeping on it would wipe every live snapshot on the machine.
-  const sweptOrphansRef = useRef(false)
   useEffect(() => {
-    if (sweptOrphansRef.current || tasks.length === 0) return
-    sweptOrphansRef.current = true
+    if (tasks.length === 0) return
     sweepOrphanTabsSnapshots(
       kv,
       tasks.map((task) => task.id),

--- a/packages/kobe/test/daemon/attention-inbox.test.ts
+++ b/packages/kobe/test/daemon/attention-inbox.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
+import { AttentionInboxStore, MAX_EPISODES } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
 import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import { afterEach, describe, expect, it } from "vitest"
 
@@ -138,6 +138,53 @@ describe("daemon attention inbox", () => {
     await store.deleteTask("task-1")
 
     expect(store.snapshot().map((item) => item.taskId)).toEqual(["task-2"])
+  })
+
+  it("prunes the oldest episodes past the retention cap", async () => {
+    let now = 1000
+    const { store, path } = await create(() => now)
+    // MAX_EPISODES + 10 distinct episodes, oldest first — the ten oldest
+    // must fall off the tail-ward end and stay off after a reload. Without
+    // the cap these would all persist: episodes of forgotten tasks leave
+    // only on visit / turn-start / hard-delete, so this queue used to grow
+    // without bound (one whole-file rewrite per recorded episode).
+    for (let i = 0; i < MAX_EPISODES + 10; i++) {
+      await store.record(`task-${i}`, "turn-complete", undefined, "tab-1")
+      now += 1
+    }
+    const snapshot = store.snapshot()
+    expect(snapshot).toHaveLength(MAX_EPISODES)
+    expect(snapshot[0]).toMatchObject({ taskId: "task-10" })
+    expect(snapshot.at(-1)).toMatchObject({ taskId: `task-${MAX_EPISODES + 9}` })
+
+    const reloaded = new AttentionInboxStore(path, new DaemonEventBus())
+    await reloaded.init()
+    expect(reloaded.snapshot()).toHaveLength(MAX_EPISODES)
+    expect(reloaded.snapshot()[0]).toMatchObject({ taskId: "task-10" })
+  })
+
+  it("a fresh episode on a capped task re-stamps it to the tail, not past the cap", async () => {
+    let now = 1000
+    const { store } = await create(() => now)
+    for (let i = 0; i < MAX_EPISODES; i++) {
+      await store.record(`task-${i}`, "turn-complete", undefined, "tab-1")
+      now += 1
+    }
+    // Re-recording a task already under the cap REPLACES its episode (dedupe
+    // rule) — nothing is pruned yet, and the re-stamped episode sits at the
+    // newest slot.
+    await store.record("task-0", "awaiting-input", { waiting: "permission" }, "tab-1")
+    let snapshot = store.snapshot()
+    expect(snapshot).toHaveLength(MAX_EPISODES)
+    expect(snapshot.at(-1)).toMatchObject({ taskId: "task-0", state: "permission_needed" })
+
+    // The next NEW episode is the 501st — the cap prunes the OLDEST, which
+    // is task-1 (task-0 just re-stamped itself out of the danger slot).
+    await store.record("task-501", "turn-complete", undefined, "tab-1")
+    snapshot = store.snapshot()
+    expect(snapshot).toHaveLength(MAX_EPISODES)
+    expect(snapshot.some((item) => item.taskId === "task-1")).toBe(false)
+    expect(snapshot.at(-1)).toMatchObject({ taskId: "task-501" })
   })
 
   it("classifies waiting, rate limits, billing failures, and other failures", async () => {

--- a/packages/kobe/test/orchestrator/store-remove.test.ts
+++ b/packages/kobe/test/orchestrator/store-remove.test.ts
@@ -5,7 +5,7 @@
  * the test/uninstall unlink helper, and the accessor surface.
  */
 
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -68,6 +68,21 @@ describe("TaskIndexStore.remove", () => {
   it("exposes filePath + stateDir for tooling", () => {
     expect(store.filePath.endsWith("tasks.json")).toBe(true)
     expect(store.filePath.startsWith(store.stateDir)).toBe(true)
+  })
+
+  it("writes tasks.json compact — no pretty-print indentation", async () => {
+    await store.create({
+      repo: "/repo",
+      title: "t",
+      branch: "kobe/t",
+      worktreePath: "/repo/wt",
+      status: "backlog",
+    })
+    // Every mutation rewrites the whole file; pretty-printing tripled the
+    // bytes for a file no human edits. Round-trip through parse must
+    // reproduce the bytes (plus the trailing newline).
+    const raw = readFileSync(store.filePath, "utf8")
+    expect(raw).toBe(`${JSON.stringify(JSON.parse(raw))}\n`)
   })
 
   it("_unlinkForTests wipes disk + memory and tolerates already-gone files", async () => {

--- a/packages/kobe/test/render/attention-linear-lookups.test.tsx
+++ b/packages/kobe/test/render/attention-linear-lookups.test.tsx
@@ -1,0 +1,134 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Scale guard for the cross-task notifier (use-attention): the toast loops
+ * must not re-scan the whole `tasks` array per notification. Both effects
+ * used `tasks.find(t => t.id === …)` INSIDE their per-edge / per-item loop —
+ * with a few hundred tasks and one edge each, every notification paid an
+ * O(tasks) scan. The fix hoists one Map build per effect run; this probe
+ * counts `Array.prototype.find` calls on the exact array handed to the hook
+ * and pins the count at zero while edges and deferred episodes flow.
+ */
+
+import { expect, test } from "bun:test"
+import { useEffect, useState } from "react"
+import type { AttentionInboxItem, TaskEngineState } from "../../src/client/remote-orchestrator"
+import type { KVContext } from "../../src/tui-react/context/kv"
+import type { NotificationsContext } from "../../src/tui-react/context/notifications"
+import { useAttention } from "../../src/tui-react/workspace/use-attention"
+import type { NotifyInput } from "../../src/tui/lib/notify-state"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { act, renderComponent } from "./harness"
+
+function stubKv(): KVContext {
+  const store: Record<string, unknown> = {}
+  return {
+    ready: true,
+    store,
+    signal: <T,>(name: string, defaultValue: T) => {
+      const read = () => (store[name] ?? defaultValue) as T
+      const write = (next: T) => {
+        store[name] = next
+      }
+      return [read, write] as const
+    },
+    get: (key: string, defaultValue?: unknown) => store[key] ?? defaultValue,
+    set: (key: string, value: unknown) => {
+      store[key] = value
+    },
+    flush: () => true,
+    clear: () => void 0,
+  }
+}
+
+function notifSpy(): { notif: NotificationsContext; calls: NotifyInput[] } {
+  const calls: NotifyInput[] = []
+  const notif = {
+    toasts: [],
+    unread: new Map(),
+    notify: (input: NotifyInput) => {
+      calls.push(input)
+    },
+    dismiss: () => {},
+    markRead: () => {},
+  }
+  return { notif: notif as unknown as NotificationsContext, calls }
+}
+
+function task(id: string): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  }
+}
+
+/** The tasks array with its `find` instrumented — the scale-regression tripwire. */
+class CountingTasks extends Array<Task> {
+  finds = 0
+  override find(predicate: (value: Task, index: number, obj: Task[]) => unknown, thisArg?: unknown): Task | undefined {
+    this.finds += 1
+    return super.find(predicate, thisArg)
+  }
+}
+
+let pushEdge: () => void = () => {}
+let pushDeferred: (at: number) => void = () => {}
+
+function AttentionScaleProbe(props: { tasks: CountingTasks; notif: NotificationsContext }) {
+  const [engineState, setEngineState] = useState<ReadonlyMap<string, TaskEngineState>>(
+    () => new Map([["task-1", { state: "idle", at: 1 }]]),
+  )
+  const [inboxItems, setInboxItems] = useState<AttentionInboxItem[]>([])
+  useEffect(() => {
+    pushEdge = () => setEngineState(new Map([["task-1", { state: "turn_complete", at: 2 }]]))
+    pushDeferred = (at: number) =>
+      setInboxItems((prev) => [
+        ...prev,
+        {
+          taskId: "task-2",
+          tabId: "tab-1",
+          state: "prompt_deferred",
+          unread: true,
+          at,
+          detail: { deferredPrompt: { id: "d1", layer: "composer-not-empty" } },
+        },
+      ])
+  }, [])
+  useAttention({
+    tasks: props.tasks,
+    engineState,
+    inboxItems,
+    selectedId: null,
+    kv: stubKv(),
+    notif: props.notif,
+    openAttention: () => {},
+    noTasksMessage: "none",
+  })
+  return null
+}
+
+test("edge and deferred-episode toasts perform zero per-item tasks.find scans", async () => {
+  const { notif, calls } = notifSpy()
+  const tasks = new CountingTasks(task("task-1"), task("task-2"), task("task-3"))
+  await renderComponent(<AttentionScaleProbe tasks={tasks} notif={notif} />, { width: 80, height: 24 })
+  expect(calls).toHaveLength(0) // seed render fires nothing
+
+  await act(async () => {
+    pushEdge() // rising edge: idle → turn_complete on task-1
+    pushDeferred(1000) // fresh prompt_deferred episode on task-2
+  })
+  await act(async () => {})
+  // Both notifiers fired (proves the loops actually ran)…
+  expect(calls.some((c) => c.kind === "done" && c.taskId === "task-1")).toBe(true)
+  expect(calls.some((c) => c.kind === "needs_input" && c.taskId === "task-2")).toBe(true)
+  // …without a single linear tasks scan. Reverting the Map hoist makes this
+  // count 2 (one find per loop body).
+  expect(tasks.finds).toBe(0)
+})

--- a/packages/kobe/test/render/sidebar-tab-row-view-memo.test.tsx
+++ b/packages/kobe/test/render/sidebar-tab-row-view-memo.test.tsx
@@ -1,0 +1,106 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The tab row's view derivation must be memoized on its real inputs
+ * (`useTabRowBaseView` in tree-rows.tsx). The sidebar re-renders on the
+ * ~10Hz spinner tick with a fresh `shared` object every render, and without
+ * the memo every idle tab row re-ran `buildSidebarRowView` each tick — the
+ * flat cards fixed the same thing in `useRowCardChrome` (row-cards.tsx).
+ * This probe mounts the hook with CONSTANT inputs, forces re-renders the
+ * way the tick does, and pins the returned view to ONE object identity.
+ */
+
+import { expect, test } from "bun:test"
+import { useState } from "react"
+import { useTabRowBaseView } from "../../src/tui-react/panes/sidebar/tree-rows"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { act, renderComponent } from "./harness"
+
+function task(id: string): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  }
+}
+
+const TASK = task("task-1")
+
+let rerender: () => void = () => {}
+let renders = 0
+let latestView: unknown = null
+let firstView: unknown = null
+
+function Probe() {
+  const [, setTick] = useState(0)
+  rerender = () => setTick((n) => n + 1)
+  const view = useTabRowBaseView({
+    task: TASK,
+    activity: undefined,
+    lifecycle: undefined,
+    job: undefined,
+    completionSeen: false,
+  })
+  renders += 1
+  if (renders === 1) firstView = view
+  latestView = view
+  return null
+}
+
+test("constant inputs keep one view object across spinner-tick re-renders", async () => {
+  await renderComponent(<Probe />, { width: 80, height: 24 })
+  const before = renders
+  // Three ticks — each a fresh render with inputs the tick does NOT change.
+  await act(async () => {
+    rerender()
+  })
+  await act(async () => {
+    rerender()
+  })
+  await act(async () => {
+    rerender()
+  })
+  expect(renders).toBeGreaterThan(before)
+  // The memo contract: same reference every render. Without the memo each
+  // tick re-runs buildSidebarRowView and this is a fresh object.
+  expect(latestView).not.toBe(null)
+  expect(latestView).toBe(firstView)
+})
+
+test("a changed input re-derives the view", async () => {
+  renders = 0
+  firstView = null
+  latestView = null
+  let currentActivity: { state: "turn_complete"; at: number } | undefined = undefined
+  let pushActivity: () => void = () => {}
+  function Probe2() {
+    const [activity, setActivity] = useState<typeof currentActivity>(undefined)
+    pushActivity = () => setActivity({ state: "turn_complete", at: 2 })
+    currentActivity = activity
+    const view = useTabRowBaseView({
+      task: TASK,
+      activity,
+      lifecycle: undefined,
+      job: undefined,
+      completionSeen: false,
+    })
+    renders += 1
+    if (renders === 1) firstView = view
+    latestView = view
+    return null
+  }
+  await renderComponent(<Probe2 />, { width: 80, height: 24 })
+  await act(async () => {
+    pushActivity()
+  })
+  await act(async () => {})
+  // A real input change MUST break the memo — a view frozen across input
+  // changes would wear a stale glyph.
+  expect(latestView).not.toBe(firstView)
+})

--- a/packages/kobe/test/render/workspace-orphan-sweep.test.tsx
+++ b/packages/kobe/test/render/workspace-orphan-sweep.test.tsx
@@ -1,0 +1,129 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Orphan-sweep timing in useWorkspaceSelection (O19 follow-up): the sweep of
+ * `terminalTabs.*` snapshots whose task no longer exists must run on EVERY
+ * task-list identity change, not once per session. forgetTaskTabs only fires
+ * for THIS client's delete flow — a sibling client (`rove api` / web board)
+ * removing a task lands here purely as a changed list, and the old
+ * once-per-session ref left those orphans on disk until the next launch,
+ * taxing every later kv write. This probe seeds two snapshots, then removes
+ * a task from the list the way a foreign delete does, and pins the sweep to
+ * follow THAT change — plus the load-bearing `tasks.length === 0` guard.
+ */
+
+import { expect, test } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { useEffect, useState } from "react"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { type TabsSnapshotKv, terminalTabsKey } from "../../src/tui-react/workspace/terminal-tabs-persist"
+import { useWorkspaceSelection } from "../../src/tui-react/workspace/use-workspace-selection"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { act, renderComponent } from "./harness"
+
+function task(id: string): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  }
+}
+
+/** Fake kv: `set(k, undefined)` deletes the key, matching kv-core. */
+function fakeKv(initial: Record<string, unknown> = {}): TabsSnapshotKv {
+  const store: Record<string, unknown> = { ...initial }
+  return {
+    store,
+    set(key, value) {
+      if (value === undefined) delete store[key]
+      else store[key] = value
+    },
+  }
+}
+
+function mockOrchestrator(): RemoteOrchestrator {
+  return {
+    activeTaskSignal: () => createStateCell<string | null>(null),
+    setActiveTask: () => Promise.resolve(),
+    ensureWorktree: () => Promise.resolve(),
+    reportUiEvent: () => {},
+  } as unknown as RemoteOrchestrator
+}
+
+let setTasksList: (tasks: Task[]) => void = () => {}
+
+function Probe(props: { orch: RemoteOrchestrator; kv: TabsSnapshotKv; initial: Task[] }) {
+  const [tasks, setTasks] = useState(props.initial)
+  useEffect(() => {
+    setTasksList = setTasks
+  }, [])
+  useWorkspaceSelection({
+    orch: props.orch,
+    tasks,
+    activeTaskId: null,
+    focusWorkspace: () => {},
+    kv: props.kv,
+  })
+  return null
+}
+
+const savedHome = process.env.KOBE_HOME_DIR
+
+test("a task deleted by a sibling client is swept on the next task-list change, without touching live snapshots", async () => {
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-orphan-sweep-"))
+  const kv = fakeKv({
+    [terminalTabsKey("alpha")]: { tabs: [] },
+    [terminalTabsKey("bravo")]: { tabs: [] },
+  })
+  await renderComponent(<Probe orch={mockOrchestrator()} kv={kv} initial={[task("alpha"), task("bravo")]} />, {
+    width: 80,
+    height: 24,
+  })
+  await act(async () => {})
+  // Both tasks are live — the sweep ran and removed nothing.
+  expect(kv.store[terminalTabsKey("alpha")]).toEqual({ tabs: [] })
+  expect(kv.store[terminalTabsKey("bravo")]).toEqual({ tabs: [] })
+
+  // Sibling client deletes bravo: the change arrives as a new list identity.
+  await act(async () => {
+    setTasksList([task("alpha")])
+  })
+  expect(kv.store[terminalTabsKey("bravo")]).toBeUndefined()
+  expect(kv.store[terminalTabsKey("alpha")]).toEqual({ tabs: [] })
+
+  // A later re-render with a FRESH array identity re-sweeps (idempotent) and
+  // still cannot touch a live task's snapshot.
+  await act(async () => {
+    setTasksList([task("alpha")])
+  })
+  expect(kv.store[terminalTabsKey("alpha")]).toEqual({ tabs: [] })
+
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = savedHome
+})
+
+test("an empty task list sweeps nothing — the guard is load-bearing", async () => {
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-orphan-sweep-empty-"))
+  const kv = fakeKv({
+    [terminalTabsKey("alpha")]: { tabs: [] },
+  })
+  await renderComponent(<Probe orch={mockOrchestrator()} kv={kv} initial={[]} />, { width: 80, height: 24 })
+  await act(async () => {
+    setTasksList([])
+  })
+  // Empty is the shape of a pre-connection render AND a corrupt-manifest
+  // recovery; sweeping on it would wipe every live snapshot on the machine.
+  expect(kv.store[terminalTabsKey("alpha")]).toEqual({ tabs: [] })
+
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = savedHome
+})

--- a/packages/kobe/test/tui-react/kv-core.test.ts
+++ b/packages/kobe/test/tui-react/kv-core.test.ts
@@ -148,6 +148,18 @@ describe("createKvCore", () => {
     expect(readState(home)).toEqual({})
   })
 
+  it("writes state.json compact — no pretty-print indentation", () => {
+    const home = isolatedHome({})
+    const kv = createKvCore()
+    kv.set("nested", { a: 1, b: [1, 2] })
+    expect(kv.flush()).toBe(true)
+    // The file is rewritten whole on EVERY flush and read only by machines;
+    // `null, 2` used to triple its bytes. Round-tripping through parse must
+    // reproduce the exact bytes — the cheapest compactness invariant.
+    const raw = readFileSync(statePath(home), "utf8")
+    expect(raw).toBe(JSON.stringify(JSON.parse(raw)))
+  })
+
   it("notifies subscribers on set and supports unsubscribe", () => {
     isolatedHome()
     const kv = createKvCore()

--- a/packages/kobe/test/tui/sidebar-known-orphans.test.ts
+++ b/packages/kobe/test/tui/sidebar-known-orphans.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Scale guard for the sidebar tree's orphan backstop (`filterKnownOrphanTabs`
+ * in orphan-tabs): orphan tabs are keyed by task id, and each orphan used to
+ * prove its task still exists with a `tasks.some(...)` scan — O(orphans ×
+ * tasks) on every poll tick, i.e. a few hundred scans of a few hundred
+ * entries at real-install scale. The pure keeps ONE Set build for all
+ * orphans; the instrumented array below fails the test on any per-orphan
+ * linear scan, and pins the keep/drop semantics at the same time.
+ */
+
+import { describe, expect, it } from "vitest"
+import { filterKnownOrphanTabs } from "../../src/tui-react/panes/sidebar/orphan-tabs"
+import type { TreeTab } from "../../src/tui/panes/sidebar/tree-core"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+
+function task(id: string): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  }
+}
+
+function tab(id: string): TreeTab {
+  return { id, label: id }
+}
+
+class CountingTasks extends Array<Task> {
+  somes = 0
+  override some(predicate: (value: Task, index: number, array: Task[]) => unknown, thisArg?: unknown): boolean {
+    this.somes += 1
+    return super.some(predicate)
+  }
+}
+
+describe("filterKnownOrphanTabs", () => {
+  it("keeps orphans of live tasks and drops orphans of deleted ones", () => {
+    const tasks = new CountingTasks(task("live-a"), task("live-b"))
+    const orphans = new Map<string, readonly TreeTab[]>([
+      ["live-a", [tab("tab-1")]],
+      ["deleted-c", [tab("tab-9")]],
+      ["live-b", [tab("tab-2"), tab("tab-3")]],
+    ])
+    const known = filterKnownOrphanTabs(tasks, orphans)
+    expect([...known.keys()]).toEqual(["live-a", "live-b"])
+    expect(known.get("live-b")).toHaveLength(2)
+  })
+
+  it("performs zero per-orphan linear scans of the task list", () => {
+    const tasks = new CountingTasks(...Array.from({ length: 400 }, (_, i) => task(`task-${i}`)))
+    const orphans = new Map<string, readonly TreeTab[]>(
+      Array.from({ length: 50 }, (_, i) => [`task-${i}`, [tab(`tab-${i}`)]]),
+    )
+    const known = filterKnownOrphanTabs(tasks, orphans)
+    expect(known.size).toBe(50)
+    // The tripwire: a `tasks.some` inside the orphan loop increments this
+    // once PER ORPHAN. Reverting to the per-orphan scan makes it 50.
+    expect(tasks.somes).toBe(0)
+  })
+})


### PR DESCRIPTION
## Why

A performance audit (verified against a real install that ran 379 tasks / ~370 tab snapshots / 10-20 parallel engines) found six paths tuned for ~20 tasks that cross from "fine" to "main cost" between 100-200 tasks. Each fix is a few lines; each ships a regression test that goes red when the fix is reverted (verified by revert-and-run, twice for the cap and the sweep timing).

## The six

1. **Compact JSON writes** — `state.json` (`src/state/store.ts`) and `tasks.json` (`src/orchestrator/index/store.ts`) lose `JSON.stringify(…, null, 2)`. Both files rewrite whole on every mutation and are read only by machines; indentation tripled the bytes. Grepped the test tree first: no test asserts pretty bytes (all readers `JSON.parse`). The `0o600` mode from #662 is preserved.
2. **Attention Inbox cap** — `MAX_EPISODES = 500`, prune-oldest in `commit`, same shape as `pty-exit-store.ts`'s `MAX_RECORDS`. Episodes only leave on visit / dismiss / new turn / task hard-delete, so a forgotten task kept its episode forever — and every episode rewrites the whole file. Every sibling store already has a cap; this was the only one without.
3. **use-attention linear finds** — both toast loops hoisted one `Map<string, Task>` build; the per-edge / per-item `tasks.find` scanned the whole array per notification.
4. **Orphan backstop linear find** — new pure `filterKnownOrphanTabs` in `orphan-tabs.ts` (its natural home; keeps `tree-core.ts` under the file-size cap) replaces the per-orphan `tasks.some` scan with one Set build.
5. **Tab row view memo** — `useTabRowBaseView` in `tree-rows.tsx` copies the flat cards' `useRowCardChrome` memo exactly (`row-cards.tsx:303-319`): the ~10Hz spinner tick no longer re-derives every idle tab row. Extracted + exported so the memo contract (stable identity across ticks, broken by a real input change) has a direct render-track test.
6. **Orphan snapshot sweep timing** — `use-workspace-selection.ts` sweeps `terminalTabs.*` on every task-list identity change instead of once per session. A sibling client (`rove api` / web board) deleting a task only lands here as a changed list; the old once-per-session ref left orphans taxing every kv write until restart. The load-bearing `tasks.length === 0` guard (12-line comment) is untouched — pinned by a dedicated render-track test.

## Deliberately out of scope (the audit's big-ticket items)

git-status/readdir collectors on all tasks, `task.snapshot` full broadcast, tasks.json lock jitter — tracked separately.

## Validation

- Revert-each-fix → red on the rebased base: fix 1 (both files), fix 2 (×2), fix 3, fix 4, fix 5 (two mutation shapes), fix 6 (×2).
- `bun run typecheck` green; `bun run lint` green.
- `test:fast`: all failures are the pre-existing `test/cli/**` branding/environment set (identical with this patch fully reverted; zero non-CLI failures).
- `test:socket` + `bun test test/render`: only load-sensitive flakes that pass in isolation (notes-store eviction, new-chat-flow, pty-hosted SIGWINCH/park timing); every touched test file passes deterministically.
