### PR TITLE
fix: contrast-guard transparent-mode text against the host background

### DIFF
--- a/.changeset/transparent-muted-contrast.md
+++ b/.changeset/transparent-muted-contrast.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Transparent mode: contrast-guard body text against the detected host terminal background. In transparent mode (the default) `text` and `textMuted` render directly on the host terminal's background, which the palette author never saw — a dark-palette muted gray sat near 2.5:1 on a light host. The TUI now queries the terminal's actual background (OSC 11 via the renderer's palette detection) and lifts the lightness of those tokens away from the host (preserving hue) until they clear a 4.5:1 floor; detection failure or timeout leaves the palette untouched. Backgrounds stay fully transparent — no opacity is traded for readability.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,7 +59,7 @@ retired worktree-sync hook was once installed so the next launch (or
 | Key | Type | Default | What it does |
 |---|---|---|---|
 | `activeTheme` | theme name | `"claude"` | See [Themes](#themes) |
-| `transparentBackground` | boolean | `true` | Let the terminal background show through |
+| `transparentBackground` | boolean | `true` | Let the terminal background show through. In transparent mode Rove detects the terminal's actual background (OSC 11) and lifts body/muted text to stay readable on it — no setting needed |
 | `focusAccent` | `primary` \| `success` \| `info` | `primary` | Color of the focused-pane indicator |
 | `appearance.splitStyle` | `box` \| `line` | `box` | `box` frames each split; `line` is the minimal tmux-style look |
 | `locale` | `en` \| `zh` | `en` | UI language |

--- a/packages/kobe-web/e2e/visual-shot.ts
+++ b/packages/kobe-web/e2e/visual-shot.ts
@@ -11,6 +11,7 @@
  *   bun run visual:shot -- ctrl+a c            # Kanban board (prefix chord)
  *   bun run visual:shot -- ctrl+a c n "text:Draft title"
  *   bun run visual:shot -- --scale=2 --out=docs/assets/workspace.png
+ *   bun run visual:shot -- --hostbg=#FFFFFF    # simulated light host terminal
  */
 
 import { resolve } from "node:path"
@@ -47,6 +48,14 @@ const deviceScaleFactor = scaleArg === undefined ? 1 : Number(scaleArg)
 if (!Number.isFinite(deviceScaleFactor) || deviceScaleFactor <= 0) {
   throw new Error(`--scale must be a positive number, got ${JSON.stringify(scaleArg)}`)
 }
+// `--hostbg=#rrggbb` simulates a host terminal with that background color
+// (light-theme terminal being the contrast worst case) — the harness paints
+// it behind the terminal AND makes xterm report it via OSC 11, so the TUI's
+// transparent-mode contrast guard adapts through the real detection path.
+const hostbgArg = args.find((arg) => arg.startsWith("--hostbg="))?.slice(9)
+if (hostbgArg !== undefined && !/^#[0-9a-fA-F]{6}$/.test(hostbgArg)) {
+  throw new Error(`--hostbg must be #rrggbb, got ${JSON.stringify(hostbgArg)}`)
+}
 const tokens = args.filter((arg) => !arg.startsWith("--"))
 const runId = `shot-${Date.now()}`
 
@@ -55,9 +64,12 @@ const browser = await chromium.launch({ headless: true }).catch((error: unknown)
 })
 try {
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 }, deviceScaleFactor })
-  await page.goto(`http://localhost:${VISUAL_WEB_PORT}/harness?run=${runId}`).catch(() => {
-    throw new Error(`no server on :${VISUAL_WEB_PORT} — start \`bun run visual:serve\` first`)
-  })
+  const hostbgQuery = hostbgArg ? `&hostbg=${encodeURIComponent(hostbgArg)}` : ""
+  await page
+    .goto(`http://localhost:${VISUAL_WEB_PORT}/harness?run=${runId}${hostbgQuery}`)
+    .catch(() => {
+      throw new Error(`no server on :${VISUAL_WEB_PORT} — start \`bun run visual:serve\` first`)
+    })
   const harness = page.getByTestId("opentui-harness")
   await harness.waitFor({ timeout: 10_000 })
   // TUI takeover: the fixture project row is the workspace's earliest stable

--- a/packages/kobe-web/src/components/ChatTerminal.tsx
+++ b/packages/kobe-web/src/components/ChatTerminal.tsx
@@ -125,8 +125,15 @@ type ChatTerminalProps = {
    * appears. Screencasts turn this on to sit the terminal on a desktop
    * instead of a flat rectangle; normal use leaves it off, where an opaque
    * canvas is both correct and cheaper to composite.
+   *
+   * `hostBackground` (harness only) goes one step further for the
+   * contrast-guard capture: it sets xterm's `theme.background` to the SAME
+   * opaque color the page paints behind the terminal, so OSC 11 background
+   * queries report the color the user actually sees — the TUI's transparent-
+   * mode contrast guard adapts to it exactly as it would in a real terminal.
    */
   transparent?: boolean
+  hostBackground?: string
   onStatusChange?: (status: WsStatus) => void
   onBufferChange?: (text: string) => void
 }
@@ -149,6 +156,7 @@ export function ChatTerminal({
   testId,
   disableWebgl = false,
   transparent = false,
+  hostBackground,
   onStatusChange,
   onBufferChange,
 }: ChatTerminalProps) {
@@ -208,7 +216,10 @@ export function ChatTerminal({
         theme: transparent
           ? {
               ...(xtermTheme() ?? CLAUDE_XTERM_THEME),
-              background: "rgba(0,0,0,0.01)",
+              // Opaque host color when the harness simulates one (so OSC 11
+              // reports it); near-invisible black otherwise so the page
+              // backdrop shows through the unpainted cells.
+              background: hostBackground ?? "rgba(0,0,0,0.01)",
             }
           : (xtermTheme() ?? CLAUDE_XTERM_THEME),
         allowTransparency: transparent,
@@ -336,6 +347,7 @@ export function ChatTerminal({
     epoch,
     disableWebgl,
     transparent,
+    hostBackground,
     onStatusChange,
     onBufferChange,
   ])

--- a/packages/kobe-web/src/routes/harness.tsx
+++ b/packages/kobe-web/src/routes/harness.tsx
@@ -29,6 +29,14 @@ function PtyHarness() {
     "wallpaper",
   )
   const wallpaper = wallpaperParam?.startsWith("/") ? wallpaperParam : null
+  // `?hostbg=<#rrggbb>` simulates a host terminal whose background IS that
+  // color (light-theme terminal, dark-theme terminal — the contrast-guard
+  // matrix). The page paints it behind the terminal AND hands it to xterm as
+  // its `theme.background`, so OSC 11 queries report the color the user
+  // actually sees and the TUI adapts to it through the real detection path.
+  const hostbgParam = new URLSearchParams(window.location.search).get("hostbg")
+  const hostbg =
+    hostbgParam && /^#[0-9a-fA-F]{6}$/.test(hostbgParam) ? hostbgParam : null
   const sessionId = `visual-${runId}`
   const [status, setStatus] = useState<WsStatus>("connecting")
   const [buffer, setBuffer] = useState("")
@@ -44,10 +52,11 @@ function PtyHarness() {
         // transparent background (`transparentBackground`, persisted-ui-prefs),
         // so whatever sits here shows through the cells the product does not
         // paint — which is how a capture can look like a terminal on a desktop
-        // instead of a rectangle of #141413. Plain colour when unset.
+        // instead of a rectangle of #141413. Plain colour when unset;
+        // `?hostbg=` replaces it with the simulated host terminal color.
         background: wallpaper
           ? `#0F0E0D url("${wallpaper}") center/cover no-repeat`
-          : "#141413",
+          : (hostbg ?? "#141413"),
       }}
     >
       {/*
@@ -55,10 +64,11 @@ function PtyHarness() {
         regardless of the theme background or `allowTransparency`, so a page
         backdrop never shows through no matter how transparent every other
         layer is. Overriding it is what actually makes the terminal sit ON the
-        wallpaper. Scoped to the wallpaper case so normal use keeps xterm's own
-        (correct, cheaper) opaque surface.
+        wallpaper (or the simulated host color). Scoped to the transparent
+        cases so normal use keeps xterm's own (correct, cheaper) opaque
+        surface.
       */}
-      {wallpaper ? (
+      {wallpaper || hostbg ? (
         <style>
           {".xterm-viewport{background-color:transparent !important}"}
         </style>
@@ -69,7 +79,8 @@ function PtyHarness() {
         mode="shell"
         testId="opentui-terminal"
         disableWebgl={!useWebgl}
-        transparent={wallpaper !== null}
+        transparent={wallpaper !== null || hostbg !== null}
+        hostBackground={hostbg ?? undefined}
         onStatusChange={setStatus}
         onBufferChange={setBuffer}
       />

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -18,7 +18,7 @@
 
 import { RGBA } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
-import { type ReactNode, createContext, useContext, useEffect, useMemo } from "react"
+import { type ReactNode, createContext, useContext, useEffect, useMemo, useState } from "react"
 import { createExternalStore } from "../../lib/external-store"
 import {
   BUNDLED_THEMES,
@@ -120,6 +120,13 @@ export type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null)
 
+/**
+ * How long the transparent-mode host-background query waits for the
+ * terminal's OSC 11 reply before falling back to the unguarded palette.
+ * Terminals that never answer must not stall the theme.
+ */
+const HOST_PALETTE_QUERY_TIMEOUT_MS = 2_000
+
 function resolveActive(state: State): Theme {
   const active = state.themes[state.active]
   if (active) return resolveTheme(active, state.mode)
@@ -148,9 +155,41 @@ export function ThemeProvider(props: { children?: ReactNode; mode?: "dark" | "li
   const state = useAccessor(store)
   const renderer = useRenderer()
 
+  // Host-background detection for the transparent-mode contrast guard
+  // (contrast-guard.ts). The theme's muted ink renders directly on the
+  // host terminal's background, which the palette author never saw; the
+  // renderer's palette query (OSC 11) is the only honest source of that
+  // color. One-shot per transparent toggle is enough — a terminal
+  // background rarely mid-session changes, and a missed detection just
+  // means the status quo (unguarded) palette. Inline hosts (split-footer)
+  // skip: their stdin is not an interactive terminal worth querying.
+  const [hostBackground, setHostBackground] = useState<RGBA | null>(null)
+  useEffect(() => {
+    if (!state.transparentBackground) return
+    if (renderer?.screenMode === "split-footer") return
+    if (!renderer) return
+    let cancelled = false
+    renderer
+      .getPalette({ timeout: HOST_PALETTE_QUERY_TIMEOUT_MS })
+      .then((colors) => {
+        if (cancelled || !colors.defaultBackground) return
+        setHostBackground(RGBA.fromHex(colors.defaultBackground))
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [renderer, state.transparentBackground])
+
   const theme = useMemo(
-    () => applyDisplayOverlay(resolveActive(state), state.focusAccent, state.transparentBackground),
-    [state],
+    () =>
+      applyDisplayOverlay(
+        resolveActive(state),
+        state.focusAccent,
+        state.transparentBackground,
+        hostBackground ?? undefined,
+      ),
+    [state, hostBackground],
   )
 
   // Push background to the renderer so the terminal background matches

--- a/packages/kobe/src/tui/context/contrast-guard.ts
+++ b/packages/kobe/src/tui/context/contrast-guard.ts
@@ -1,0 +1,134 @@
+/**
+ * Contrast guard for transparent-background mode.
+ *
+ * In transparent mode the theme's foreground tokens render directly on the
+ * host terminal's background — a surface the palette author never saw. A
+ * muted gray tuned for a dark theme (e.g. claude `#A9A39A`) sits at ~2.5:1
+ * on a light host background, and even the primary text (`#EAE7DF`) drops
+ * below readable. The host background is only knowable at runtime (opentui's
+ * palette detection, `renderer.getPalette()`), so the guard takes the
+ * detected background and lifts offending tokens until they clear a floor —
+ * moving lightness AWAY from the host background while preserving hue, so a
+ * muted token stays visually muted relative to the primary text.
+ *
+ * Pure functions only; the overlay in `theme-core.ts` applies it.
+ */
+
+import { RGBA } from "@opentui/core"
+
+/**
+ * WCAG 2.x AA floor for normal-size text. `textMuted` carries real content
+ * (subtitles, footer labels, empty states), so it gets the honest 4.5:1,
+ * not the 3:1 large-text concession.
+ */
+export const HOST_TEXT_MIN_CONTRAST = 4.5
+
+type Rgb = readonly [number, number, number]
+
+function srgbChannelToLinear(c: number): number {
+  const v = c / 255
+  return v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4
+}
+
+/** WCAG relative luminance (0–1) of an 8-bit RGB triplet. */
+export function relativeLuminance([r, g, b]: Rgb): number {
+  return 0.2126 * srgbChannelToLinear(r) + 0.7152 * srgbChannelToLinear(g) + 0.0722 * srgbChannelToLinear(b)
+}
+
+/** WCAG contrast ratio between two 8-bit RGB triplets (≥ 1). */
+export function contrastRatioTriplet(fg: Rgb, bg: Rgb): number {
+  const l1 = relativeLuminance(fg)
+  const l2 = relativeLuminance(bg)
+  const lighter = Math.max(l1, l2)
+  const darker = Math.min(l1, l2)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+/** WCAG contrast ratio between two RGBA colors (alpha ignored). */
+export function contrastRatio(fg: RGBA, bg: RGBA): number {
+  const [fr, fgG, fb] = fg.toInts()
+  const [br, bgG, bb] = bg.toInts()
+  return contrastRatioTriplet([fr, fgG, fb], [br, bgG, bb])
+}
+
+function rgbToHsl([r, g, b]: Rgb): [number, number, number] {
+  const rn = r / 255
+  const gn = g / 255
+  const bn = b / 255
+  const max = Math.max(rn, gn, bn)
+  const min = Math.min(rn, gn, bn)
+  const l = (max + min) / 2
+  if (max === min) return [0, 0, l]
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h: number
+  if (max === rn) h = ((gn - bn) / d + (gn < bn ? 6 : 0)) * 60
+  else if (max === gn) h = ((bn - rn) / d + 2) * 60
+  else h = ((rn - gn) / d + 4) * 60
+  return [h, s, l]
+}
+
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  if (s === 0) {
+    const v = Math.round(l * 255)
+    return [v, v, v]
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  const channel = (t: number): number => {
+    let tn = t
+    if (tn < 0) tn += 1
+    if (tn > 1) tn -= 1
+    const c = tn < 1 / 6 ? p + (q - p) * 6 * tn : tn < 1 / 2 ? q : tn < 2 / 3 ? p + (q - p) * (2 / 3 - tn) * 6 : p
+    return Math.round(c * 255)
+  }
+  return [channel(h / 360 + 1 / 3), channel(h / 360), channel(h / 360 - 1 / 3)]
+}
+
+/**
+ * Return `fg` adjusted to reach at least `minRatio` against `bg`, or `fg`
+ * untouched when it already clears the floor. The adjustment moves HSL
+ * lightness away from the host background's luminance (dark host → lighter
+ * text, light host → darker text), preserving hue and saturation so the
+ * token keeps its identity; a token that already sat far from the floor is
+ * returned unchanged, so dark-host terminals see zero shift.
+ */
+export const MID_HOST_LUMINANCE = 0.5
+
+export function ensureContrast(fg: RGBA, bg: RGBA, minRatio: number = HOST_TEXT_MIN_CONTRAST): RGBA {
+  const fgInts = fg.toInts()
+  const bgInts = bg.toInts()
+  const fgTriplet: Rgb = [fgInts[0], fgInts[1], fgInts[2]]
+  const bgTriplet: Rgb = [bgInts[0], bgInts[1], bgInts[2]]
+  if (contrastRatioTriplet(fgTriplet, bgTriplet) >= minRatio) return fg
+
+  const [h, s, l] = rgbToHsl(fgTriplet)
+  // Direction: a LIGHT host (luminance above 0.5) gets darker text; anything
+  // darker gets lighter text. The luminance gate — not a pole comparison —
+  // matters for mid-tone hosts (wallpapers): darkening would satisfy the
+  // host floor while sinking the token below the still-OPAQUE theme
+  // surfaces (`backgroundDialog`, `backgroundElement`), which keep their
+  // dark palette in transparent mode. Lightening keeps those surfaces
+  // readable at the cost of a below-floor muted on a host nobody ships as
+  // a terminal default.
+  const lighten = relativeLuminance(bgTriplet) <= MID_HOST_LUMINANCE
+
+  const at = (lightness: number): number => contrastRatioTriplet(hslToRgb(h, s, lightness), bgTriplet)
+  // Binary search for the SMALLEST lightness move that clears the floor:
+  // lightening scans [l, 1] for the first passing value, darkening scans
+  // [0, l] for the last passing one.
+  let lo = lighten ? l : 0
+  let hi = lighten ? 1 : l
+  for (let i = 0; i < 32; i++) {
+    const mid = (lo + hi) / 2
+    if (at(mid) >= minRatio) {
+      if (lighten) hi = mid
+      else lo = mid
+    } else {
+      if (lighten) lo = mid
+      else hi = mid
+    }
+  }
+  const [r, g, b] = hslToRgb(h, s, lighten ? hi : lo)
+  return RGBA.fromInts(r, g, b, fgInts[3])
+}

--- a/packages/kobe/src/tui/context/theme-core.ts
+++ b/packages/kobe/src/tui/context/theme-core.ts
@@ -10,6 +10,7 @@
 
 import { RGBA } from "@opentui/core"
 
+import { ensureContrast } from "./contrast-guard"
 import { BUNDLED_THEME_JSONS } from "./theme/bundled"
 
 type HexColor = `#${string}`
@@ -181,15 +182,34 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light" = "dark"):
  *      stays OPAQUE: a translucent modal card lets pane content bleed
  *      through the dialog text. Transparency is for the chrome around
  *      content, never for an overlay you must read.
+ *   3. Also when transparent, foreground tokens that carry body text
+ *      (`text`, `textMuted`) are contrast-guarded against the detected host
+ *      background (see `contrast-guard.ts`): muted ink renders directly on
+ *      the host terminal's background, which the palette author never saw,
+ *      and a dark-palette muted gray is ~2.5:1 on a light host. The guard
+ *      lifts lightness away from the host while preserving hue. When no
+ *      host background is known (detection failed/timed out) the tokens
+ *      pass through unchanged rather than guessing.
  */
-export function applyDisplayOverlay(base: Theme, focusAccent: FocusAccentSlot, transparentBackground: boolean): Theme {
+export function applyDisplayOverlay(
+  base: Theme,
+  focusAccent: FocusAccentSlot,
+  transparentBackground: boolean,
+  hostBackground?: RGBA,
+): Theme {
   const v: Theme = { ...base, focusAccent: base[focusAccent] ?? base.primary }
   if (!transparentBackground) return v
   const [backgroundR, backgroundG, backgroundB] = base.background.toInts()
   const [panelR, panelG, panelB] = base.backgroundPanel.toInts()
-  return {
+  const transparent: Theme = {
     ...v,
     background: RGBA.fromInts(backgroundR, backgroundG, backgroundB, 0),
     backgroundPanel: RGBA.fromInts(panelR, panelG, panelB, 0),
+  }
+  if (!hostBackground) return transparent
+  return {
+    ...transparent,
+    text: ensureContrast(transparent.text, hostBackground),
+    textMuted: ensureContrast(transparent.textMuted, hostBackground),
   }
 }

--- a/packages/kobe/test/tui-react/theme-core.test.ts
+++ b/packages/kobe/test/tui-react/theme-core.test.ts
@@ -1,4 +1,6 @@
+import { RGBA } from "@opentui/core"
 import { describe, expect, it } from "vitest"
+import { contrastRatio } from "../../src/tui/context/contrast-guard"
 import { BUNDLED_THEMES, applyDisplayOverlay, resolveTheme } from "../../src/tui/context/theme-core"
 import { terminalDefaultColorsForTheme } from "../../src/tui/lib/terminal-colors"
 
@@ -37,6 +39,55 @@ describe("applyDisplayOverlay", () => {
       const overlaid = applyDisplayOverlay(resolved, "info", true)
       expect(overlaid.focusAccent, name).toBeDefined()
     }
+  })
+
+  describe("with a detected host background (transparent mode)", () => {
+    const lightHost = RGBA.fromHex("#FFFFFF")
+
+    it("lifts text and textMuted to the readable floor against a light host", () => {
+      const out = applyDisplayOverlay(base, "primary", true, lightHost)
+      // The regression: these sit directly on the host terminal background.
+      expect(contrastRatio(out.text, lightHost)).toBeGreaterThanOrEqual(4.5)
+      expect(contrastRatio(out.textMuted, lightHost)).toBeGreaterThanOrEqual(4.5)
+      // …and the lift moves away from the light host, not toward it.
+      expect(out.textMuted.toInts()[0]).toBeLessThan(base.textMuted.toInts()[0])
+    })
+
+    it("keeps the transparent-background policy untouched", () => {
+      const out = applyDisplayOverlay(base, "primary", true, lightHost)
+      expect(out.background.a).toBe(0)
+      expect(out.backgroundPanel.a).toBe(0)
+      expect(out.backgroundElement).toBe(base.backgroundElement)
+      expect(out.backgroundDialog).toBe(base.backgroundDialog)
+    })
+
+    it("leaves dark-host tokens untouched (zero shift where the palette already works)", () => {
+      const out = applyDisplayOverlay(base, "primary", true, RGBA.fromHex("#141413"))
+      expect(out.text).toBe(base.text)
+      expect(out.textMuted).toBe(base.textMuted)
+    })
+
+    it("ignores the host background when transparent mode is off", () => {
+      const out = applyDisplayOverlay(base, "primary", false, lightHost)
+      expect(out.text).toBe(base.text)
+      expect(out.textMuted).toBe(base.textMuted)
+      expect(out.background).toBe(base.background)
+    })
+
+    it("falls back to the status quo when no host background is known", () => {
+      const out = applyDisplayOverlay(base, "primary", true)
+      expect(out.text).toBe(base.text)
+      expect(out.textMuted).toBe(base.textMuted)
+    })
+
+    it("guards every bundled theme's body text against a light host", () => {
+      for (const [name, json] of Object.entries(BUNDLED_THEMES)) {
+        const resolved = resolveTheme(json, "dark")
+        const out = applyDisplayOverlay(resolved, "primary", true, lightHost)
+        expect(contrastRatio(out.text, lightHost), `${name} text`).toBeGreaterThanOrEqual(4.5)
+        expect(contrastRatio(out.textMuted, lightHost), `${name} textMuted`).toBeGreaterThanOrEqual(4.5)
+      }
+    })
   })
 })
 

--- a/packages/kobe/test/tui/contrast-guard.test.ts
+++ b/packages/kobe/test/tui/contrast-guard.test.ts
@@ -1,0 +1,103 @@
+import { RGBA } from "@opentui/core"
+import { describe, expect, it } from "vitest"
+import {
+  HOST_TEXT_MIN_CONTRAST,
+  contrastRatio,
+  contrastRatioTriplet,
+  ensureContrast,
+  relativeLuminance,
+} from "../../src/tui/context/contrast-guard"
+
+const rgb = (hex: string): RGBA => RGBA.fromHex(hex)
+
+describe("relativeLuminance", () => {
+  it("maps black to 0 and white to 1", () => {
+    expect(relativeLuminance([0, 0, 0])).toBe(0)
+    expect(relativeLuminance([255, 255, 255])).toBe(1)
+  })
+
+  it("orders mid tones between the poles", () => {
+    const gray = relativeLuminance([128, 128, 128])
+    expect(gray).toBeGreaterThan(0)
+    expect(gray).toBeLessThan(1)
+  })
+})
+
+describe("contrastRatio", () => {
+  it("black on white is 21:1", () => {
+    expect(contrastRatioTriplet([0, 0, 0], [255, 255, 255])).toBeCloseTo(21, 5)
+  })
+
+  it("claude textMuted on a white host is below the readable floor (the reported defect)", () => {
+    // #A9A39A carries sidebar subtitles, footer chips, hint bars, and empty
+    // states; on a light host terminal it lands near 2.5:1.
+    const ratio = contrastRatio(rgb("#A9A39A"), rgb("#FFFFFF"))
+    expect(ratio).toBeLessThan(HOST_TEXT_MIN_CONTRAST)
+    expect(ratio).toBeCloseTo(2.5, 0)
+  })
+
+  it("claude primary text on a white host is also below the floor", () => {
+    expect(contrastRatio(rgb("#EAE7DF"), rgb("#FFFFFF"))).toBeLessThan(HOST_TEXT_MIN_CONTRAST)
+  })
+
+  it("claude textMuted on its own dark background clears the floor untouched", () => {
+    expect(contrastRatio(rgb("#A9A39A"), rgb("#141413"))).toBeGreaterThanOrEqual(HOST_TEXT_MIN_CONTRAST)
+  })
+})
+
+describe("ensureContrast", () => {
+  it("returns the same color when it already clears the floor", () => {
+    const fg = rgb("#A9A39A")
+    const bg = rgb("#141413")
+    expect(ensureContrast(fg, bg)).toBe(fg)
+  })
+
+  it("darkens muted ink against a light host until it clears the floor", () => {
+    const out = ensureContrast(rgb("#A9A39A"), rgb("#FFFFFF"))
+    expect(contrastRatio(out, rgb("#FFFFFF"))).toBeGreaterThanOrEqual(HOST_TEXT_MIN_CONTRAST)
+    expect(relativeLuminance([out.toInts()[0], out.toInts()[1], out.toInts()[2]])).toBeLessThan(
+      relativeLuminance([0xa9, 0xa3, 0x9a]),
+    )
+  })
+
+  it("lightens ink against a dark host when needed", () => {
+    const out = ensureContrast(rgb("#3A3A3A"), rgb("#141413"))
+    expect(contrastRatio(out, rgb("#141413"))).toBeGreaterThanOrEqual(HOST_TEXT_MIN_CONTRAST)
+    expect(relativeLuminance([out.toInts()[0], out.toInts()[1], out.toInts()[2]])).toBeGreaterThan(
+      relativeLuminance([0x3a, 0x3a, 0x3a]),
+    )
+  })
+
+  it("can always escape an identical background (white on white)", () => {
+    const out = ensureContrast(rgb("#FFFFFF"), rgb("#FFFFFF"))
+    expect(contrastRatio(out, rgb("#FFFFFF"))).toBeGreaterThanOrEqual(HOST_TEXT_MIN_CONTRAST)
+  })
+
+  it("mid-tone host lightens rather than darkens, keeping opaque dark surfaces readable", () => {
+    // A mid-gray wallpaper: darkening would hit the host floor but sink the
+    // token to ~1:1 on the still-opaque dark dialog/element surfaces.
+    const out = ensureContrast(rgb("#A9A39A"), rgb("#808080"))
+    const outLum = relativeLuminance([out.toInts()[0], out.toInts()[1], out.toInts()[2]])
+    expect(outLum).toBeGreaterThan(relativeLuminance([0xa9, 0xa3, 0x9a]))
+    // …and the result stays legible on the opaque dark theme surfaces.
+    expect(contrastRatio(out, rgb("#141413"))).toBeGreaterThanOrEqual(3)
+  })
+
+  it("preserves hue — channel ordering survives the lightness move", () => {
+    // A warm gray keeps its r ≥ g ≥ b ordering rather than collapsing to a
+    // pure neutral (or inverting).
+    const gray = ensureContrast(rgb("#A9A39A"), rgb("#FFFFFF")).toInts()
+    expect(gray[0]).toBeGreaterThanOrEqual(gray[1])
+    expect(gray[1]).toBeGreaterThanOrEqual(gray[2])
+
+    const blue = ensureContrast(rgb("#828bb8"), rgb("#F5F2EA")).toInts()
+    // blue stays the dominant channel
+    expect(blue[2]).toBeGreaterThan(blue[0])
+    expect(blue[2]).toBeGreaterThan(blue[1])
+  })
+
+  it("preserves alpha", () => {
+    const fg = RGBA.fromInts(169, 163, 154, 128)
+    expect(ensureContrast(fg, rgb("#FFFFFF")).toInts()[3]).toBe(128)
+  })
+})


### PR DESCRIPTION
## Problem

In transparent mode (the default, `transparentBackground: true`), `applyDisplayOverlay` zeroes the alpha of **both** `background` and `backgroundPanel`, so `textMuted` — the dominant ink for sidebar subtitles, footer chips, hint bars, and empty states — renders directly on the host terminal's background. That background is unknown to the palette author: a user with a **light** terminal + the default dark `claude` palette gets ~2.5:1 contrast for muted text and ~1.2:1 for primary text.

## Why not the two suggested fixes

- **(b) keep `backgroundPanel` opaque** doesn't hold: the footer and the main pane draw on `background`, not `backgroundPanel`, so it wouldn't fix them; and the 2026-08-09 row-selection-chrome decision (owner call, recorded in `tui-react/ui/row-selection-chrome.ts`) explicitly rejected opaque tint patches on the host wallpaper.
- **(a) lift `textMuted` toward `text`** as-is makes a **light** host worse, since `text` is itself a light color. The real missing input is the host background's actual color.

## Fix: adapt to the detected host background

- New `src/tui/context/contrast-guard.ts`: WCAG luminance/contrast math + `ensureContrast`, which moves a token's HSL lightness **away** from the host (hue/saturation preserved, smallest sufficient move) until it clears a 4.5:1 floor. Direction is gated on host luminance > 0.5: light host → darken; anything darker → lighten. The luminance gate (not a pole comparison) keeps mid-tone wallpaper hosts from darkening tokens into illegibility on the still-opaque theme surfaces (`backgroundDialog`, `backgroundElement`), which keep their dark palette in transparent mode.
- `applyDisplayOverlay` accepts an optional detected host background and guards `text` + `textMuted` in transparent mode. No host detected (query failed/timed out) → status quo, never a guess.
- `ThemeProvider` queries the host background once per transparent toggle via the renderer's palette detection (`renderer.getPalette()`, OSC 11), 2s timeout, failure-silent. No background alpha changes — transparency is fully preserved; only ink adapts.

## Harness

`/harness` gains `?hostbg=#rrggbb` (and `visual:shot --hostbg=…`): the page backdrop and xterm's reported OSC 11 background are the same color, so the TUI adapts through the **real detection path** — no mock. This is how the light-host screenshots below were produced.

## Verification

- `test/tui/contrast-guard.test.ts` (new): luminance/contrast math, the reported defect ratios, direction, hue preservation, alpha, mid-host behavior.
- `test/tui-react/theme-core.test.ts`: transparent + light host lifts both tokens to ≥4.5:1; dark host is a zero-shift no-op; non-transparent ignores the host; unknown host = status quo; all three bundled themes guarded.
- Mutation check: with the fix reverted, the new overlay tests go red (run twice, post-rebase).
- Visual ground truth (`/harness` → xterm.js → PTY → real OpenTUI), transparent mode + simulated host backgrounds:
  - `.scratch/contrast-shots/light-default.png` — white host: sidebar subtitles, footer chips, hint bars, empty states all readable
  - `.scratch/contrast-shots/dark-default.png` — dark host: unchanged from before (guard is a no-op)
  - `.scratch/contrast-shots/light-help.png` — F1 dialog on a white host: the opaque dialog card still renders on the dark palette (control surface)

## Tradeoff (surfaced, not hidden)

On a light host, muted text that sits on the still-opaque dark surfaces (dialogs, tab strip, kanban cards) is now darkened too — ~3.5–4:1 there instead of the original ~8:1. Dialog/element text remains comfortably above the 3:1 UI floor; the alternative (separate tokens per surface) was a much larger refactor of 60+ call sites.

Follow-ups not in scope: `border`/`borderSubtle` and semantic accents (`primary`, `warning`) on unpainted surfaces are subject to the same host-background gamble; they carry less body text so they were left for a separate pass.

🦋  Patch changeset included.
