### PR TITLE
fix: four width-audit layout defects

### DIFF
--- a/.changeset/layout-width-audit.md
+++ b/.changeset/layout-width-audit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix four layout defects found in a width audit. The workspace footer no longer overflows narrow terminals: the quota chip cluster now yields to the key-hint bar (shrink + clip + budget-truncated chips, degrading to compact vendor+percent form) instead of colliding at 80 columns. Section-header divider rules repeat to the terminal width instead of a hardcoded 240 cells, so the rule stops running dry past 240 columns. The sidebar rail grows with the terminal (a sixth of the width, clamped to [24, 40]) so branch names stop truncating on wide terminals. Column math in the prefix HUD and welcome pane measures display cells instead of String.length, so CJK labels and chord glyphs align in the zh-default locale.

--- a/packages/kobe/src/lib/display-width.ts
+++ b/packages/kobe/src/lib/display-width.ts
@@ -94,3 +94,13 @@ export function approxCellWidth(s: string): number {
   for (const ch of s) n += approxCharCells(ch.codePointAt(0) ?? 0)
   return n
 }
+
+/**
+ * `String.padEnd` against a display-CELL target (padEnd counts UTF-16 code
+ * units, so a wide CJK glyph or a `⌘`-class chord under-pads and misaligns
+ * every column to its right). Already-wide strings pass through unchanged.
+ */
+export function padEndCells(s: string, cells: number): string {
+  const deficit = cells - displayWidth(s)
+  return deficit <= 0 ? s : s + " ".repeat(deficit)
+}

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -14,6 +14,7 @@
  */
 
 import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/react"
 import type { Automation, AutomationRun } from "@sma1lboy/kobe-daemon/daemon/contracts"
 import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
@@ -24,6 +25,7 @@ import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
+import { dividerRule } from "../lib/rule-divider"
 import { useDaemonDown } from "../lib/use-accessor"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
@@ -72,6 +74,7 @@ export function AutomationsPage(props: {
   const { theme } = useTheme()
   const dialog = useDialog()
   const t = useT()
+  const dims = useTerminalDimensions()
   /**
    * Failures go to the toast queue, not the inline notice line — a muted
    * `textMuted` line reads as a hint, not a failure, and error toasts show
@@ -281,7 +284,7 @@ export function AutomationsPage(props: {
           {t("automations.title")}
         </text>
         <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
-          {"─".repeat(240)}
+          {dividerRule(dims.width)}
         </text>
         <text
           fg={daemonDown ? theme.error : keepsDaemonAlive ? theme.success : theme.textMuted}
@@ -340,7 +343,7 @@ export function AutomationsPage(props: {
                     two run together, and the strip has no marker column to
                     separate them the way the sidebar's cards do. */}
                 <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
-                  {"─".repeat(240)}
+                  {dividerRule(dims.width)}
                 </text>
                 <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
                   {`${repoLabel(automation.repo)} · ${automation.schedule}`}

--- a/packages/kobe/src/tui-react/component/prefix-hud.tsx
+++ b/packages/kobe/src/tui-react/component/prefix-hud.tsx
@@ -11,6 +11,7 @@
 
 import { useTerminalDimensions } from "@opentui/react"
 import { useEffect, useState } from "react"
+import { displayWidth } from "../../lib/display-width"
 import { KobeKeymap, findBinding } from "../../tui/context/keybindings"
 import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
 import { PREFIX_GUIDE_DELAY_MS, PREFIX_HUD_TTL_MS, prefixHudState } from "../../tui/lib/prefix-hud"
@@ -117,9 +118,12 @@ export function PrefixHud(props: { left: number; width: number }) {
     const groupWidth = narrow ? guideWidth - 4 : Math.max(18, Math.floor((guideWidth - 4) / columns))
     const actionHeight = (action: GuideAction): number => {
       const strokes = action.strokes.join("/")
-      const keyWidth = Math.min(9, Math.max(3, strokes.length))
+      // Cell widths, not String.length: CJK action labels and ⌘-class chord
+      // glyphs occupy 2 (or ambiguous) cells — .length under-measures them
+      // and the guide's height estimate runs off the screen bottom.
+      const keyWidth = Math.min(9, Math.max(3, displayWidth(strokes)))
       const labelWidth = Math.max(1, groupWidth - keyWidth - 1)
-      return Math.max(1, Math.ceil(actionLabel(action.action).length / labelWidth))
+      return Math.max(1, Math.ceil(displayWidth(actionLabel(action.action)) / labelWidth))
     }
     const guideHeight = groupRows.reduce(
       (height, row) =>
@@ -165,7 +169,7 @@ export function PrefixHud(props: { left: number; width: number }) {
                           if (stroke) invokeArmedPrefixActionFromCurrentStack(action.action, stroke)
                         }}
                       >
-                        <box width={Math.min(9, Math.max(3, strokes.length))}>
+                        <box width={Math.min(9, Math.max(3, displayWidth(strokes)))}>
                           <text fg={theme.primary}>{strokes}</text>
                         </box>
                         <text fg={theme.text} wrapMode="word" flexGrow={1} flexShrink={1}>

--- a/packages/kobe/src/tui-react/component/settings-dialog/usage-core.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/usage-core.ts
@@ -4,7 +4,9 @@
  * aligned meter rows. Pure — the React component only maps rows to <text>.
  */
 
+import { approxCharCells, displayWidth } from "../../../lib/display-width.ts"
 import { ratioBar } from "../../../tui/lib/progress-bar.ts"
+import { truncateEndCells } from "../../../tui/lib/truncate.ts"
 import type { EngineQuotaUsage } from "../../../types/engine.ts"
 
 /** Meter track width in cells. */
@@ -80,6 +82,103 @@ export function narrowUsageChip(usage: EngineQuotaUsage, nowMs: number): UsageCh
     resetText: formatReset(w.resetsAt, nowMs),
     tone: toneOf(w.percent),
   }
+}
+
+/** One vendor's full chip block in the footer row (label + tone + reset). */
+export interface FooterVendorFull {
+  readonly vendor: string
+  readonly chips: UsageChipView[]
+}
+
+/** Compact fallback: vendor name + tone percent only (the narrow form). */
+export interface FooterVendorCompact {
+  readonly vendor: string
+  readonly percentText: string
+  readonly tone: UsageTone
+}
+
+export type FooterChipsView =
+  | { form: "full"; vendors: FooterVendorFull[] }
+  | { form: "compact"; vendors: FooterVendorCompact[] }
+
+/** Cell width of one full chip: `· 7d 12% → 8/4 06:00`-style parts + gaps. */
+function fullChipCells(chip: UsageChipView, index: number): number {
+  const label = index === 0 ? chip.label : `· ${chip.label}`
+  const parts = [displayWidth(label), displayWidth(chip.percentText)]
+  if (chip.resetText) parts.push(displayWidth(chip.resetText))
+  return parts.reduce((a, b) => a + b, 0) + (parts.length - 1)
+}
+
+/** Cell width of one vendor block: name + chips, gap 1 between children. */
+function fullVendorCells(vendor: FooterVendorFull): number {
+  return (
+    displayWidth(vendor.vendor) +
+    vendor.chips.reduce((sum, chip, i) => sum + fullChipCells(chip, i), 0) +
+    vendor.chips.length
+  )
+}
+
+/**
+ * The footer row's two halves share one line: padding (1+1), the inter-box
+ * gap (2), and the hint bar all reserve cells before the chips get any.
+ * `hintCells` is the bar's measured width (see host-footer.tsx).
+ */
+export function usageChipsBudget(opts: { terminalWidth: number; hintCells: number }): number {
+  return Math.max(0, opts.terminalWidth - 4 - opts.hintCells)
+}
+
+/**
+ * Fit the quota chips into `budget` cells, degrading instead of overflowing:
+ * full label/reset form when it fits, the compact vendor+percent form when
+ * it doesn't, truncating the LAST kept vendor's name to soak up the
+ * remainder and dropping vendors past it. The percent is the payload — it
+ * survives every squeeze; the vendor name is what yields.
+ */
+export function buildFooterChips(opts: {
+  usage: ReadonlyMap<string, EngineQuotaUsage>
+  budget: number
+  nowMs: number
+  vendorLabel: (vendor: string) => string
+  forceCompact?: boolean
+}): FooterChipsView | null {
+  const entries = [...opts.usage.entries()]
+    .map(([id, snapshot]) => ({
+      vendor: opts.vendorLabel(id).toUpperCase(),
+      snapshot,
+      chips: usageChips(snapshot, opts.nowMs),
+    }))
+    .filter((entry) => entry.chips.length > 0)
+  if (entries.length === 0) return null
+  if (!opts.forceCompact) {
+    const fulls: FooterVendorFull[] = entries.map((entry) => ({ vendor: entry.vendor, chips: entry.chips }))
+    const total = fulls.reduce((sum, v) => sum + fullVendorCells(v), 0) + (fulls.length - 1) * 2
+    if (total <= opts.budget) return { form: "full", vendors: fulls }
+  }
+  const vendors: FooterVendorCompact[] = []
+  let remaining = opts.budget
+  for (const entry of entries) {
+    const chip = narrowUsageChip(entry.snapshot, opts.nowMs)
+    if (!chip) continue
+    const gap = vendors.length > 0 ? 2 : 0
+    const need = displayWidth(entry.vendor) + 1 + displayWidth(chip.percentText)
+    if (need + gap <= remaining) {
+      vendors.push({ vendor: entry.vendor, percentText: chip.percentText, tone: chip.tone })
+      remaining -= need + gap
+      continue
+    }
+    // Does not fit whole: truncate THIS vendor's name to the remainder
+    // (keeping at least `X…`) and drop everything after it.
+    const nameBudget = remaining - gap - 1 - displayWidth(chip.percentText)
+    if (nameBudget >= 3) {
+      vendors.push({
+        vendor: truncateEndCells(entry.vendor, nameBudget, approxCharCells),
+        percentText: chip.percentText,
+        tone: chip.tone,
+      })
+    }
+    break
+  }
+  return { form: "compact", vendors }
 }
 
 /**

--- a/packages/kobe/src/tui-react/lib/rule-divider.ts
+++ b/packages/kobe/src/tui-react/lib/rule-divider.ts
@@ -1,0 +1,20 @@
+/**
+ * Section-header rule fill — the `LABEL ─── suffix` underline shared by the
+ * sidebar chrome and the full-window pages.
+ *
+ * The rule text sits in a `flexGrow={1} flexShrink={1}` slot, so a fixed
+ * repeat count is a silent width ceiling: past it the rule runs dry and the
+ * suffix floats in a gap (240 cols breaks on a dual-monitor tmux). Repeating
+ * to the TERMINAL width instead means the flex slot always has material to
+ * distribute — no row can be wider than the terminal, and the shrunk text
+ * clips cleanly mid-glyph-run.
+ */
+
+/**
+ * Box-drawing rule repeated to `terminalWidth` cells. Callers pass
+ * `useTerminalDimensions().width`; a non-positive width yields a minimal
+ * one-cell rule so the slot never renders an empty string.
+ */
+export function dividerRule(terminalWidth: number): string {
+  return "─".repeat(Math.max(1, terminalWidth))
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -7,11 +7,13 @@
  */
 
 import { MouseButton, TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/react"
 import { legendCap } from "../../../tui/lib/help-groups"
 import { SIDEBAR_NAV_ITEMS, type SidebarNav } from "../../../tui/panes/sidebar/nav-core"
 import { ShortcutRevealBadge } from "../../component/shortcut-reveal"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
+import { dividerRule } from "../../lib/rule-divider"
 import { zenChipGlyph } from "./zen-glyph"
 
 export function SectionHeader(props: {
@@ -26,6 +28,7 @@ export function SectionHeader(props: {
 }) {
   const { theme, transparentBackground } = useTheme()
   const dividerColor = transparentBackground ? theme.border : theme.borderSubtle
+  const dims = useTerminalDimensions()
   return (
     <box flexDirection="column" flexShrink={0}>
       {props.topPad ? (
@@ -60,7 +63,7 @@ export function SectionHeader(props: {
           {props.label}
         </text>
         <text fg={dividerColor} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
-          {"─".repeat(240)}
+          {dividerRule(dims.width)}
         </text>
         {props.suffix ? (
           <text fg={theme.info} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>

--- a/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useTerminalDimensions } from "@opentui/react"
-import { SIDEBAR_WIDTH } from "../../tui/panes/sidebar/view-core"
+import { sidebarWidthFor } from "../../tui/panes/sidebar/view-core"
 import { useFocus } from "../context/focus"
 import { useTheme } from "../context/theme"
 import { FileTree } from "../panes/filetree/FileTree"
@@ -32,7 +32,7 @@ export function HostFilesPane(props: {
   const focus = useFocus()
   const dims = useTerminalDimensions()
   const inactiveBorder = theme.borderActive
-  const available = Math.max(WORKTREE_TOOLS_MIN_WIDTH, dims.width - SIDEBAR_WIDTH)
+  const available = Math.max(WORKTREE_TOOLS_MIN_WIDTH, dims.width - sidebarWidthFor(dims.width))
   const width = Math.max(WORKTREE_TOOLS_MIN_WIDTH, Math.min(WORKTREE_TOOLS_MAX_WIDTH, Math.floor(available / 3)))
   return (
     <box

--- a/packages/kobe/src/tui-react/workspace/host-footer.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-footer.tsx
@@ -12,6 +12,11 @@
  * the hint muted, the row is not rendered, so nothing shifts on terminals
  * that have nothing to show.
  *
+ * Both halves share ONE 1-cell row, and the chips are the yielding half:
+ * their box shrinks + clips and the chip view model is built against an
+ * explicit cell budget (usage-core's buildFooterChips), so an 80-col
+ * terminal degrades to compact chips instead of colliding with the hint bar.
+ *
  * `WorkspaceFrame` owns the column wrapper so `host.tsx` stays under the
  * file-size cap — same extraction reason as `host-sidebar.tsx`.
  */
@@ -20,63 +25,69 @@ import { useTerminalDimensions } from "@opentui/react"
 import type { ReactNode } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { engineDisplayName } from "../../engine/interactive-command"
+import { displayWidth } from "../../lib/display-width"
 import { StatusKeyHintBar, useStatusKeyHintItems } from "../component/keyboard-hints"
-import { narrowUsageChip, usageChips } from "../component/settings-dialog/usage-core"
+import { buildFooterChips, usageChipsBudget } from "../component/settings-dialog/usage-core"
 import { ShortcutRevealProvider } from "../component/shortcut-reveal"
 import { useTheme } from "../context/theme"
 import { isNarrowWidth } from "../lib/narrow-mode"
 import { useAccessor } from "../lib/use-accessor"
 
-function UsageChips(props: { orchestrator: RemoteOrchestrator; narrow: boolean }) {
+function UsageChips(props: { orchestrator: RemoteOrchestrator; narrow: boolean; budget: number }) {
   const { theme } = useTheme()
   const usage = useAccessor(props.orchestrator.usageSnapshotSignal())
-  if (!usage || usage.size === 0) return null
   const toneColor = { ok: theme.success, warn: theme.warning, crit: theme.error } as const
   const now = Date.now()
-  if (props.narrow) {
-    // Narrow footer (issue #14): one session-window chip per vendor —
-    // `CLAUDE 42%` — tone color kept, label/reset dropped for the cells.
+  const view =
+    usage && usage.size > 0
+      ? buildFooterChips({
+          usage,
+          budget: props.budget,
+          nowMs: now,
+          vendorLabel: engineDisplayName,
+          forceCompact: props.narrow,
+        })
+      : null
+  if (!view) return null
+  if (view.form === "full") {
     return (
       <box flexDirection="row" gap={2}>
-        {[...usage.entries()].flatMap(([vendor, snapshot]) => {
-          const chip = narrowUsageChip(snapshot, now)
-          if (!chip) return []
-          return [
-            <box key={vendor} flexDirection="row" gap={1}>
-              <text fg={theme.textMuted} wrapMode="none">
-                {engineDisplayName(vendor).toUpperCase()}
-              </text>
-              <text fg={toneColor[chip.tone]} wrapMode="none">
-                {chip.percentText}
-              </text>
-            </box>,
-          ]
-        })}
+        {view.vendors.map((vendor) => (
+          <box key={vendor.vendor} flexDirection="row" gap={1}>
+            <text fg={theme.textMuted} wrapMode="none">
+              {vendor.vendor}
+            </text>
+            {vendor.chips.map((chip, i) => (
+              <box key={chip.label} flexDirection="row" gap={1}>
+                <text fg={theme.textMuted} wrapMode="none">
+                  {i === 0 ? chip.label : `· ${chip.label}`}
+                </text>
+                <text fg={toneColor[chip.tone]} wrapMode="none">
+                  {chip.percentText}
+                </text>
+                {chip.resetText ? (
+                  <text fg={theme.textMuted} wrapMode="none">
+                    {chip.resetText}
+                  </text>
+                ) : null}
+              </box>
+            ))}
+          </box>
+        ))}
       </box>
     )
   }
+  // Compact form (also the narrow-footer form): vendor + tone percent only.
   return (
     <box flexDirection="row" gap={2}>
-      {[...usage.entries()].map(([vendor, snapshot]) => (
-        <box key={vendor} flexDirection="row" gap={1}>
+      {view.vendors.map((vendor, index) => (
+        <box key={`${vendor.vendor}-${index}`} flexDirection="row" gap={1}>
           <text fg={theme.textMuted} wrapMode="none">
-            {engineDisplayName(vendor).toUpperCase()}
+            {vendor.vendor}
           </text>
-          {usageChips(snapshot, now).map((chip, i) => (
-            <box key={chip.label} flexDirection="row" gap={1}>
-              <text fg={theme.textMuted} wrapMode="none">
-                {i === 0 ? chip.label : `· ${chip.label}`}
-              </text>
-              <text fg={toneColor[chip.tone]} wrapMode="none">
-                {chip.percentText}
-              </text>
-              {chip.resetText ? (
-                <text fg={theme.textMuted} wrapMode="none">
-                  {chip.resetText}
-                </text>
-              ) : null}
-            </box>
-          ))}
+          <text fg={toneColor[vendor.tone]} wrapMode="none">
+            {vendor.percentText}
+          </text>
         </box>
       ))}
     </box>
@@ -98,8 +109,15 @@ export function WorkspaceFrame(props: {
   const dims = useTerminalDimensions()
   const narrow = isNarrowWidth(dims.width)
   const usage = useAccessor(props.orchestrator.usageSnapshotSignal())
-  const hintItems = useStatusKeyHintItems({ onOpenSettings: props.onOpenSettings })
+  // The same options the bar below renders with — the budget must measure
+  // the bar that is actually on screen (compact drops the [settings] chip).
+  const hintItems = useStatusKeyHintItems({
+    onOpenSettings: narrow ? undefined : props.onOpenSettings,
+    compact: narrow,
+  })
   const footerVisible = (usage != null && usage.size > 0) || hintItems.length > 0
+  const hintCells = hintItems.reduce((sum, item, index) => sum + displayWidth(item.text) + (index > 0 ? 3 : 0), 0)
+  const chipsBudget = usageChipsBudget({ terminalWidth: dims.width, hintCells })
   return (
     <ShortcutRevealProvider>
       <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
@@ -109,8 +127,10 @@ export function WorkspaceFrame(props: {
         </box>
         {footerVisible ? (
           <box flexDirection="row" flexShrink={0} height={1} paddingLeft={1} paddingRight={1} gap={2}>
-            <box flexGrow={1} flexDirection="row">
-              <UsageChips orchestrator={props.orchestrator} narrow={narrow} />
+            {/* The chips yield first: shrink + clip is the hard guarantee,
+                the budget-truncated view model the graceful one. */}
+            <box flexGrow={1} flexShrink={1} flexDirection="row" overflow="hidden">
+              <UsageChips orchestrator={props.orchestrator} narrow={narrow} budget={chipsBudget} />
             </box>
             {/* Narrow drops the verbs and the [settings] chip: `⌃A · F1`. */}
             <StatusKeyHintBar onOpenSettings={narrow ? undefined : props.onOpenSettings} compact={narrow} />

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -10,7 +10,7 @@ import { useTerminalDimensions } from "@opentui/react"
 import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { useEffect, useRef, useState } from "react"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
-import { SIDEBAR_WIDTH } from "../../tui/panes/sidebar/view-core"
+import { sidebarWidthFor } from "../../tui/panes/sidebar/view-core"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { CURRENT_VERSION } from "../../version.ts"
 import { PrefixHud } from "../component/prefix-hud"
@@ -332,7 +332,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           the only boundary; sidebar focus shows on the KOBE brand text. */}
       {pageRender.showSidebar ? (
         <HostSidebar
-          width={pageRender.showContent ? SIDEBAR_WIDTH : dims.width}
+          width={pageRender.showContent ? sidebarWidthFor(dims.width) : dims.width}
           nav={pages.nav}
           onNavChange={pages.goToNav}
           tasks={tasks}
@@ -460,7 +460,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           terminal column is off-limits: it collided with the engine's own
           status line). Width-capped to the rail so lines never spill into
           the terminal. */}
-      <PrefixHud left={1} width={SIDEBAR_WIDTH - 2} />
+      <PrefixHud left={1} width={sidebarWidthFor(dims.width) - 2} />
     </WorkspaceFrame>
   )
 }

--- a/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
@@ -14,6 +14,7 @@ import { TextAttributes } from "@opentui/core"
 import type { ReactNode } from "react"
 import { useEffect, useState } from "react"
 import { installedEngineIds } from "../../engine/account-detect.ts"
+import { displayWidth, padEndCells } from "../../lib/display-width"
 import { formatChord } from "../../tui/lib/chord-glyphs"
 import { legendCap } from "../../tui/lib/help-groups"
 import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
@@ -67,7 +68,10 @@ export function WelcomePane(props: { probe?: () => Promise<WelcomeEnv> }): React
   }, [])
 
   const steps = stepLines()
-  const capWidth = Math.max(...steps.map((s) => s.cap.length), 0)
+  // Cell width, not String.length: a ⌘/⌃-class chord cap is one UTF-16 unit
+  // but wider in cells (and CJK caps are 2), so a .length column misaligns
+  // every message row.
+  const capWidth = Math.max(...steps.map((s) => displayWidth(s.cap)), 0)
   const broken = env !== null && (env.engines.length === 0 || !env.git)
 
   return (
@@ -85,7 +89,7 @@ export function WelcomePane(props: { probe?: () => Promise<WelcomeEnv> }): React
           {steps.map((step) => (
             <box key={step.msg} flexDirection="row" gap={2}>
               <text fg={theme.primary} wrapMode="none">
-                {step.cap.padEnd(capWidth)}
+                {padEndCells(step.cap, capWidth)}
               </text>
               <text fg={theme.textMuted} wrapMode="word">
                 {t(`workspace.welcome.${step.msg}`)}

--- a/packages/kobe/src/tui/panes/sidebar/view-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/view-core.ts
@@ -10,9 +10,22 @@ import { charWidth, displayWidth } from "../../../lib/display-width"
 import { truncateEnd, truncateEndCells } from "../../lib/truncate"
 import type { SidebarTone } from "./row-view"
 
-/** Default width of the PureTUI task-list rail (32 → 26 → 24, owner calls
- * 2026-07-27/28 — the herdr-density pass kept shrinking it). */
+/** Minimum width of the PureTUI task-list rail (32 → 26 → 24, owner calls
+ * 2026-07-27/28 — the herdr-density pass kept shrinking it). Also the width
+ * at and below ~144 cols, see {@link sidebarWidthFor}. */
 export const SIDEBAR_WIDTH = 24
+
+/**
+ * Wide-terminal rail width: a sixth of the terminal, clamped to
+ * [SIDEBAR_WIDTH, 40]. A fixed 24 rail never grew, so branch names
+ * truncated on 200-col terminals with the middle pane idle; the Files pane
+ * already scales by the same principle (a third of what's left). Growth
+ * onset is ~150 cols: 120 → 24, 160 → 26, 200 → 33, 240 → 40 — the
+ * workspace keeps ~⅔ of the terminal at every width.
+ */
+export function sidebarWidthFor(terminalWidth: number): number {
+  return Math.max(SIDEBAR_WIDTH, Math.min(40, Math.floor(terminalWidth / 6)))
+}
 
 /** Polling interval for the per-main-row git branch refresh. */
 export const MAIN_BRANCH_POLL_MS = 2_000

--- a/packages/kobe/test/lib/display-width.test.ts
+++ b/packages/kobe/test/lib/display-width.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { charWidth, displayWidth } from "../../src/lib/display-width.ts"
+import { charWidth, displayWidth, padEndCells } from "../../src/lib/display-width.ts"
 
 /**
  * Cell-width contract for `charWidth`/`displayWidth`. These feed the
@@ -150,5 +150,31 @@ describe("displayWidth", () => {
   it("sums wide enclosed-ideograph glyphs over code points, not UTF-16 units", () => {
     expect(displayWidth("🈚x")).toBe(3) // wide (2) + ascii (1)
     expect(displayWidth("🀄🃏")).toBe(4)
+  })
+})
+
+/**
+ * `padEndCells` — the cell-based `String.padEnd`. Callers align columnar
+ * text (welcome-pane key caps); plain padEnd counts UTF-16 units, so a wide
+ * glyph under-pads and every column to its right drifts.
+ */
+describe("padEndCells", () => {
+  it("pads ASCII to the cell target", () => {
+    expect(padEndCells("ab", 4)).toBe("ab  ")
+    expect(padEndCells("ab", 2)).toBe("ab")
+  })
+
+  it("pads a wide CJK string by cells, not code units", () => {
+    expect(padEndCells("中文", 6)).toBe("中文  ") // 4 cells + 2 spaces
+    expect(padEndCells("中文", 4)).toBe("中文") // already at target
+  })
+
+  it("pads a chord cap like ⌘N to the cell target", () => {
+    expect(padEndCells("⌘N", 5)).toBe("⌘N   ")
+  })
+
+  it("passes through strings already at or past the target", () => {
+    expect(padEndCells("abcdef", 3)).toBe("abcdef")
+    expect(padEndCells("中文", 0)).toBe("中文")
   })
 })

--- a/packages/kobe/test/tui-react/layout-contract.test.ts
+++ b/packages/kobe/test/tui-react/layout-contract.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Layout wiring contracts. The logic behind these fixes lives in pure,
+ * unit-tested modules (usage-core, view-core, display-width, rule-divider) — but a pure module can be perfectly correct while a
+ * component stops CALLING it. These tests pin the call sites: they go red
+ * the moment a magic literal or a fixed width sneaks back into the tree.
+ */
+
+const src = (rel: string): string => readFileSync(fileURLToPath(new URL(`../../src/${rel}`, import.meta.url)), "utf8")
+
+describe("divider rules never hardcode a repeat count", () => {
+  it.each(["tui-react/panes/sidebar/chrome.tsx", "tui-react/component/automations-page.tsx"])(
+    "%s renders rules through dividerRule",
+    (file) => {
+      const source = src(file)
+      expect(source).toContain("dividerRule(")
+      expect(source).not.toMatch(/"─"\.repeat\(\d+\)/)
+    },
+  )
+
+  it("dividerRule always covers at least the terminal width", async () => {
+    const { dividerRule } = await import("../../src/tui-react/lib/rule-divider.ts")
+    expect(dividerRule(300)).toBe("─".repeat(300))
+    expect(dividerRule(80)).toBe("─".repeat(80))
+    expect(dividerRule(0)).toBe("─")
+  })
+})
+
+describe("sidebar width is responsive, not a fixed rail", () => {
+  it("the workspace host sizes the rail and prefix HUD from sidebarWidthFor", () => {
+    const host = src("tui-react/workspace/host.tsx")
+    expect(host).toContain("sidebarWidthFor(dims.width)")
+    expect(host).not.toContain("width={pageRender.showContent ? SIDEBAR_WIDTH")
+    expect(host).not.toContain("width={SIDEBAR_WIDTH - 2}")
+  })
+
+  it("the files pane subtracts the responsive rail width", () => {
+    const files = src("tui-react/workspace/host-files-pane.tsx")
+    expect(files).toContain("sidebarWidthFor(dims.width)")
+    expect(files).not.toContain("dims.width - SIDEBAR_WIDTH")
+  })
+})

--- a/packages/kobe/test/tui-react/usage-core.test.ts
+++ b/packages/kobe/test/tui-react/usage-core.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest"
+import { displayWidth } from "../../src/lib/display-width.ts"
 import {
+  type FooterChipsView,
   USAGE_BAR_WIDTH,
+  buildFooterChips,
   formatReset,
   narrowUsageChip,
+  usageChipsBudget,
   usageRows,
 } from "../../src/tui-react/component/settings-dialog/usage-core.ts"
 import { ratioBar } from "../../src/tui/lib/progress-bar.ts"
@@ -100,5 +104,105 @@ describe("narrowUsageChip", () => {
 
   it("returns null for a vendor with no windows", () => {
     expect(narrowUsageChip({ windows: [], capturedAt: NOW }, NOW)).toBeNull()
+  })
+})
+
+/**
+ * Footer-row layout contract: the chips and the key-hint bar share ONE
+ * 1-cell row, so the chip view must never exceed its budget — on an 80-col
+ * terminal the full label/reset form (≈45 cells for two vendors) does not
+ * fit beside the hint bar and must degrade, not collide.
+ */
+describe("footer chips layout", () => {
+  const usageOf = (percent: number) => ({
+    windows: [
+      { kind: "session" as const, label: "5h", percent, resetsAt: null },
+      { kind: "weekly_all" as const, label: "7d", percent: 80, resetsAt: null },
+    ],
+    capturedAt: NOW,
+  })
+  const twoVendors = new Map([
+    ["claude", usageOf(42)],
+    ["codex", usageOf(47)],
+  ])
+  const build = (budget: number, usage: ReadonlyMap<string, ReturnType<typeof usageOf>> = twoVendors) =>
+    buildFooterChips({ usage, budget, nowMs: NOW, vendorLabel: (v) => v })
+
+  /** Cell width of the rendered row, mirroring the component's gaps. */
+  const viewCells = (view: FooterChipsView): number => {
+    const perVendor =
+      view.form === "full"
+        ? view.vendors.map(
+            (v) =>
+              displayWidth(v.vendor) +
+              v.chips.reduce(
+                (sum, chip, i) =>
+                  sum +
+                  displayWidth(i === 0 ? chip.label : `· ${chip.label}`) +
+                  displayWidth(chip.percentText) +
+                  (chip.resetText ? 1 + displayWidth(chip.resetText) : 0) +
+                  1,
+                0,
+              ),
+          )
+        : view.vendors.map((v) => displayWidth(v.vendor) + 1 + displayWidth(v.percentText))
+    return perVendor.reduce((a, b) => a + b, 0) + Math.max(0, perVendor.length - 1) * 2
+  }
+
+  it("usageChipsBudget subtracts padding, gap, and the measured hint bar", () => {
+    expect(usageChipsBudget({ terminalWidth: 80, hintCells: 36 })).toBe(40)
+    expect(usageChipsBudget({ terminalWidth: 200, hintCells: 36 })).toBe(160)
+    expect(usageChipsBudget({ terminalWidth: 20, hintCells: 36 })).toBe(0)
+  })
+
+  it("keeps the full label/reset form when it fits (wide terminal)", () => {
+    const view = build(160)
+    expect(view?.form).toBe("full")
+    expect(view && viewCells(view)).toBeLessThanOrEqual(160)
+    expect(view?.form === "full" ? view.vendors.flatMap((v) => v.chips.map((c) => c.label)) : []).toContain("7d")
+  })
+
+  it("degrades to compact vendor+percent chips at an 80-col budget", () => {
+    const view = build(40)
+    expect(view?.form).toBe("compact")
+    expect(view?.form === "compact" ? view.vendors.map((v) => v.vendor) : []).toEqual(["CLAUDE", "CODEX"])
+    expect(view?.form === "compact" ? view.vendors.map((v) => v.percentText) : []).toEqual(["42%", "47%"])
+    expect(view && viewCells(view)).toBeLessThanOrEqual(40)
+  })
+
+  it("truncates the overflowing vendor's name and drops vendors past it", () => {
+    const view = build(12)
+    expect(view?.form).toBe("compact")
+    // CLAUDE 42% (10 cells) fits; CODEX would not — it is dropped, not overlapped.
+    expect(view?.form === "compact" ? view.vendors.map((v) => v.vendor) : []).toEqual(["CLAUDE"])
+    expect(view && viewCells(view)).toBeLessThanOrEqual(12)
+
+    const truncated = build(8)
+    expect(truncated?.form === "compact" ? truncated.vendors[0] : undefined).toMatchObject({
+      vendor: "CLA…",
+      percentText: "42%",
+    })
+    expect(truncated && viewCells(truncated)).toBeLessThanOrEqual(8)
+  })
+
+  it("forceCompact skips the full form even with a wide budget", () => {
+    const view = buildFooterChips({
+      usage: twoVendors,
+      budget: 160,
+      nowMs: NOW,
+      vendorLabel: (v) => v,
+      forceCompact: true,
+    })
+    expect(view?.form).toBe("compact")
+  })
+
+  it("filters vendors with no windows and returns null for empty usage", () => {
+    const withEmpty = new Map([
+      ["empty", { windows: [], capturedAt: NOW }],
+      ["claude", usageOf(42)],
+    ])
+    const view = build(160, withEmpty)
+    expect(view?.form === "full" ? view.vendors.map((v) => v.vendor) : []).toEqual(["CLAUDE"])
+    expect(build(160, new Map())).toBeNull()
   })
 })

--- a/packages/kobe/test/tui/sidebar-width.test.ts
+++ b/packages/kobe/test/tui/sidebar-width.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { SIDEBAR_WIDTH, sidebarWidthFor } from "../../src/tui/panes/sidebar/view-core.ts"
+
+/**
+ * Rail width contract: 24 was a minimum that never grew, so branch names
+ * truncated on wide terminals while the middle pane sat idle. The rail now
+ * takes a sixth of the terminal, clamped — it must never drop below the
+ * owner-set 24 and never crowd the workspace at the top end.
+ */
+describe("sidebarWidthFor", () => {
+  it("stays at the owner minimum for ordinary terminals", () => {
+    expect(sidebarWidthFor(80)).toBe(SIDEBAR_WIDTH)
+    expect(sidebarWidthFor(120)).toBe(SIDEBAR_WIDTH)
+    expect(sidebarWidthFor(143)).toBe(SIDEBAR_WIDTH)
+  })
+
+  it("grows past ~144 cols so wide terminals stop truncating branch names", () => {
+    expect(sidebarWidthFor(150)).toBe(25)
+    expect(sidebarWidthFor(160)).toBe(26)
+    expect(sidebarWidthFor(200)).toBe(33)
+  })
+
+  it("caps at 40 so the rail never crowds the workspace pane", () => {
+    expect(sidebarWidthFor(240)).toBe(40)
+    expect(sidebarWidthFor(400)).toBe(40)
+  })
+
+  it("never returns below the minimum, even for degenerate widths", () => {
+    expect(sidebarWidthFor(0)).toBe(SIDEBAR_WIDTH)
+    expect(sidebarWidthFor(10)).toBe(SIDEBAR_WIDTH)
+  })
+
+  it("leaves the workspace the majority of the terminal at every width", () => {
+    // Mirror host-files-pane.tsx's clamp: a third of what's left, [22, 34].
+    const filesPaneWidth = (terminal: number, rail: number): number =>
+      Math.max(22, Math.min(34, Math.floor(Math.max(22, terminal - rail) / 3)))
+    for (const width of [80, 120, 160, 200, 240, 300]) {
+      const rail = sidebarWidthFor(width)
+      const workspace = width - rail - filesPaneWidth(width, rail)
+      expect(workspace).toBeGreaterThan(width / 3)
+      expect(workspace).toBeGreaterThanOrEqual(30)
+    }
+  })
+})


### PR DESCRIPTION
Four layout defects found in a width audit of the TUI.

**Footer overflow.** The workspace footer's quota chip cluster was `flexShrink={0}` with nothing else yielding, so at 80 columns the chips collided with the key-hint bar. Chips now shrink, clip, and degrade to a compact `vendor+percent` form against an explicit cell budget.

**Divider cap.** Two section-header rules hardcoded `"─".repeat(240)`. Past 240 columns the rule ran dry and the suffix floated in a gap (a dual-monitor tmux hits this). They now repeat to the terminal width through one shared `dividerRule()` helper.

**Sidebar growth.** The rail was pinned at `SIDEBAR_WIDTH = 24`, so branch names truncated on wide terminals no matter how much room there was. It now takes a sixth of the terminal, clamped to `[24, 40]`.

**Cell-width math.** The prefix HUD and welcome pane measured columns with `String.length`, which under-counts CJK and chord glyphs — the columns drifted in the zh default locale. Both use `displayWidth`/`padEndCells` now.

### Dropped: the fifth defect

The original audit also found the four `ctrl+a` full-window pages each inventing their own left padding. **#684 fixed that independently and more thoroughly** — it unified them on the `x=2` inset *and* removed Kanban's per-child insets, which this branch did not. That half is dropped here rather than reimplemented; `page-layout.ts` and its assertions are gone.

### Verification

- Each remaining fix carries a regression test verified red when the fix is reverted.
- Rebased onto `origin/main` (was 25 commits behind — the pre-rebase diff showed 221 files and a spurious deletion of `scripts/no-silent-catch.mjs`, which this branch never touched).
- `bun run test:fast`: 406 files / 3923 tests green. (The `test/cli` failures seen earlier were `ROVE_INVOKED_AS` leaking from the agent shell, not a code defect — clean with `env -u ROVE_INVOKED_AS`.)
- Root `lint` clean, `typecheck` exit 0.
