### PR TITLE
fix: stop silently losing and exposing persisted state

### DIFF
--- a/.changeset/persistence-durability.md
+++ b/.changeset/persistence-durability.md
@@ -1,0 +1,26 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix four ways persisted state was silently lost or left exposed.
+
+A `tasks.json` stamped with a version this build doesn't recognize — what you
+get after running a newer Rove and going back to an older one — emptied the
+task index and let the next save replace the file, with no backup. It now
+copies the original bytes aside first, exactly like the corrupt-JSON path
+already did. Both recovery warnings also go to `client.log`, since a pane's
+stdout is painted over by the alternate screen and nobody ever saw them.
+
+Frozen PTY session files carry a session's whole scrollback, and the
+owner-only permissions added for them only ever applied to newly created
+paths — an install that had been freezing sessions before that change kept a
+world-traversable directory and world-readable records indefinitely. The
+pty host now tightens the directory and every existing record at boot.
+
+`pty-sessions/` also had no bound: a task deleted while the pty host was down
+left its snapshot behind forever (the sweep only reaches a running host), and
+every boot re-read and re-thawed the lot. Records are now pruned at load —
+dropped after 14 days, and capped at the 64 most recent.
+
+Finally, `pty.log` is rotated at pty-host boot. It was the one append log that
+issue #26 left uncapped, on the longest-lived process in the system.

--- a/packages/kobe-daemon/src/client/client-log.ts
+++ b/packages/kobe-daemon/src/client/client-log.ts
@@ -96,8 +96,8 @@ async function rotateClientLogIfNeeded(path: string): Promise<void> {
  * On the first write of a fresh home the `.kobe/` dir may not exist yet — an
  * ENOENT triggers one mkdir + retry; any other failure warns once.
  */
-function append(line: string): void {
-  const path = defaultClientLogPath()
+function append(line: string, logPath?: string): void {
+  const path = logPath ?? defaultClientLogPath()
   writeChain = writeChain
     .then(async () => {
       await rotateClientLogIfNeeded(path)
@@ -120,9 +120,16 @@ export function flushClientLog(): Promise<void> {
   return writeChain
 }
 
-/** Record a tagged client info line (connect, subscribe, reconnect, fallback…). */
-export function logClient(subsystem: string, message: string): void {
-  append(formatClientEntry(subsystem, message))
+/**
+ * Record a tagged client info line (connect, subscribe, reconnect, fallback…).
+ *
+ * `logPath` overrides the ambient `<home>/.rove/client.log`. Callers that
+ * already know which home they are operating on (a store constructed with an
+ * explicit `homeDir`) MUST pass it: resolving the ambient default there would
+ * write one home's diagnostics into another's log.
+ */
+export function logClient(subsystem: string, message: string, logPath?: string): void {
+  append(formatClientEntry(subsystem, message), logPath)
 }
 
 /** Record a tagged client error line with the error's message + stack. */

--- a/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
@@ -27,7 +27,7 @@
  * contract); a bare SIGTERM / crash / reboot leaves it for the next host.
  */
 
-import { mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { StringDecoder } from "node:string_decoder"
 import { defaultPtyFreezeDir } from "./paths.ts"
@@ -167,39 +167,133 @@ function parseRecord(raw: string): FrozenPtySession | null {
   }
 }
 
-/** Every restorable record in `dir`; missing/corrupt entries read as none. */
-export function loadFrozenSessions(dir = defaultPtyFreezeDir()): FrozenPtySession[] {
+/**
+ * How stale a record may be before a host boot discards it instead of
+ * thawing it. Restore exists so the session you were just looking at
+ * survives a host restart; a snapshot nobody has touched in a fortnight is
+ * a dead task's leftovers, not a work scene. Two weeks is well past any
+ * plausible "I'll come back to that tab on Monday" and still short enough
+ * that the directory can't grow without bound.
+ */
+export const FREEZE_TTL_MS = 14 * 24 * 60 * 60 * 1000
+
+/**
+ * Hard ceiling on restored sessions, newest first. The TTL handles the
+ * ordinary case; this bounds the pathological one (a burst of tasks inside
+ * the window). 64 is several times any realistic number of open terminal
+ * tabs, and at the 512KB scrollback cap it bounds the boot read at ~32MB
+ * rather than the unbounded read that made a 54MB directory possible.
+ */
+export const FREEZE_MAX_RECORDS = 64
+
+/** Newest-first by `updatedAt`; unparseable stamps sort oldest. */
+function updatedAtMs(record: FrozenPtySession): number {
+  const t = Date.parse(record.updatedAt)
+  return Number.isFinite(t) ? t : 0
+}
+
+/**
+ * Every restorable record in `dir`; missing/corrupt entries read as none.
+ *
+ * Pruned on the way out — expired (older than {@link FREEZE_TTL_MS}) and
+ * over-cap records are DELETED, not merely skipped. Without this the
+ * directory only ever grows: `pty.sweep` reaches only a RUNNING host, so a
+ * task deleted while the host was down leaves its record behind forever,
+ * and every subsequent boot pays the full read AND thaws the dead task's
+ * session back into the live table.
+ */
+export function loadFrozenSessions(dir = defaultPtyFreezeDir(), now = Date.now()): FrozenPtySession[] {
   let names: string[]
   try {
     names = readdirSync(dir)
   } catch {
     return []
   }
-  const out: FrozenPtySession[] = []
+  const kept: Array<{ name: string; record: FrozenPtySession }> = []
+  const stale: string[] = []
   for (const name of names) {
     if (!name.endsWith(".json")) continue
+    let record: FrozenPtySession | null = null
     try {
-      const record = parseRecord(readFileSync(join(dir, name), "utf8"))
-      if (record) out.push(record)
+      record = parseRecord(readFileSync(join(dir, name), "utf8"))
     } catch {
       // One unreadable file must not cost the rest.
     }
+    if (!record) continue
+    if (now - updatedAtMs(record) > FREEZE_TTL_MS) stale.push(name)
+    else kept.push({ name, record })
   }
-  return out
+  kept.sort((a, b) => updatedAtMs(b.record) - updatedAtMs(a.record))
+  for (const over of kept.splice(FREEZE_MAX_RECORDS)) stale.push(over.name)
+  for (const name of stale) {
+    try {
+      rmSync(join(dir, name), { force: true })
+    } catch {
+      /* best-effort: a record we couldn't delete is simply skipped this boot */
+    }
+  }
+  return kept.map((entry) => entry.record)
+}
+
+/** Owner-only. See {@link tightenExistingPermissions} for why the mode
+ *  arguments on mkdir/write are not enough on their own. */
+const DIR_MODE = 0o700
+const FILE_MODE = 0o600
+
+/**
+ * Re-`chmod` the freeze directory and every record already in it.
+ *
+ * The `mode` options on `mkdirSync` / `writeFileSync` apply ONLY when the
+ * path is created — for a path that already exists they are a silent no-op.
+ * So an install that had been freezing sessions before those options landed
+ * keeps its 0755 directory and its 0644 records forever: the directory stays
+ * traversable by every local user, and any session not re-frozen since the
+ * upgrade keeps world-readable scrollback. A one-time remediation is what
+ * actually closes that, and it has to run for the already-affected install,
+ * not only for files created from here on.
+ *
+ * Best-effort and idempotent, like every other write in this module: a
+ * chmod that fails (foreign owner, read-only mount) must never take the
+ * terminal down.
+ */
+export function tightenExistingPermissions(dir: string): void {
+  try {
+    chmodSync(dir, DIR_MODE)
+  } catch {
+    /* absent, or not ours to chmod — the mkdir below still creates it 0700 */
+  }
+  let names: string[]
+  try {
+    names = readdirSync(dir)
+  } catch {
+    return // no directory yet: nothing pre-existing to tighten
+  }
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue
+    try {
+      chmodSync(join(dir, name), FILE_MODE)
+    } catch {
+      /* one stubborn file must not cost the rest */
+    }
+  }
 }
 
 /** The real sink: per-session atomic files under `dir`. Never throws. */
 export function fileFreezeSink(dir = defaultPtyFreezeDir()): PtyFreezeSink {
+  // Remediate on construction (once per host boot), not per save: the mode
+  // arguments below only bind at creation time, so a pre-existing 0755
+  // directory / 0644 record would otherwise stay wide open forever.
+  tightenExistingPermissions(dir)
   return {
     save(record) {
       try {
         // 0700/0600: `ringB64` is the session's whole scrollback, so this file
         // holds every byte the agent printed — `env` output, `cat`ed credential
         // files, a git remote carrying a PAT. Owner-only, like a private key.
-        mkdirSync(dir, { recursive: true, mode: 0o700 })
+        mkdirSync(dir, { recursive: true, mode: DIR_MODE })
         const target = recordFile(dir, record.key)
         const staging = `${target}.${process.pid}.tmp`
-        writeFileSync(staging, JSON.stringify(record), { encoding: "utf8", mode: 0o600 })
+        writeFileSync(staging, JSON.stringify(record), { encoding: "utf8", mode: FILE_MODE })
         renameSync(staging, target)
       } catch {
         /* best-effort by contract — a freeze hiccup never kills the terminal */

--- a/packages/kobe-daemon/src/daemon/pty-host-node-entry.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host-node-entry.ts
@@ -13,10 +13,16 @@
  * a named pipe instead of a unix socket (see paths.ts).
  */
 
+import { rotateLogIfNeeded } from "./log-rotate.ts"
+import { defaultPtyHostLogPath } from "./paths.ts"
 import { nodePtyDriver } from "./pty-driver.ts"
 import { startPtyHostServer } from "./pty-server.ts"
 
 async function main(): Promise<void> {
+  // Same log, same inherited-append-fd constraint as the Bun host in
+  // `cli/pty-host-cmd.ts`: boot is the only safe rotation point.
+  rotateLogIfNeeded(defaultPtyHostLogPath())
+
   // No installDaemonCrashHandlers(): that lives in the Bun-side crash-log
   // module. Keep the net local and dependency-free so this entry stays
   // node-clean.

--- a/packages/kobe/src/cli/pty-host-cmd.ts
+++ b/packages/kobe/src/cli/pty-host-cmd.ts
@@ -8,9 +8,20 @@
  */
 
 import { installDaemonCrashHandlers } from "@sma1lboy/kobe-daemon/daemon/crash-log"
+import { rotateLogIfNeeded } from "@sma1lboy/kobe-daemon/daemon/log-rotate"
+import { defaultPtyHostLogPath } from "@sma1lboy/kobe-daemon/daemon/paths"
 import { startPtyHostServer } from "@sma1lboy/kobe-daemon/daemon/pty-server"
 
 export async function runPtyHostSubcommand(_argv: readonly string[]): Promise<void> {
+  // `pty.log` is stdout/stderr inherited from the parent's
+  // `spawnDetachedDaemon` append fd, so boot is the ONLY safe rotation point
+  // — same reasoning as `daemon-cmd.ts`. It also matters MORE here:
+  // the pty host is the longest-lived process in the system (it survives
+  // `rove daemon restart` by design), so it is the least likely to ever be
+  // restarted and have its log cleaned up. Issue #26 grew client.log to
+  // 736MB; this log was the third one and was left uncapped.
+  rotateLogIfNeeded(defaultPtyHostLogPath())
+
   // Crash net first: a stray rejection must land in the log, not silently
   // kill the process that owns every background engine session.
   installDaemonCrashHandlers()

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -23,6 +23,9 @@
  */
 
 import { copyFile, readFile } from "node:fs/promises"
+import { dirname } from "node:path"
+import { logClient } from "@sma1lboy/kobe-daemon/client/client-log"
+import { defaultClientLogPath } from "@sma1lboy/kobe-daemon/daemon/paths"
 import type {
   Task,
   TaskDeletionState,
@@ -87,23 +90,71 @@ export async function backupCorruptManifest(path: string, now: () => Date = () =
   }
 }
 
+/** Manifest versions this build can read. A manifest stamped with anything
+ *  else is a FUTURE build's — see {@link recoverUnsupportedVersion}. */
+const SUPPORTED_VERSIONS: ReadonlySet<unknown> = new Set([1, 2, 3])
+
+/**
+ * Warn about a manifest recovery on BOTH sinks. `console.warn` alone is
+ * invisible in normal use: every pane runs inside an opentui alternate
+ * screen that paints straight over stdout/stderr, which is the entire
+ * reason `client-log.ts` exists. A recovery that silently empties the task
+ * index must leave a trace a human can actually find afterwards.
+ */
+export function warnManifestRecovery(message: string, manifestPath?: string): void {
+  console.warn(message)
+  // `<home>/.rove|.kobe/tasks.json` → that same home's client.log. Resolved
+  // from the manifest rather than the ambient default so a store opened on an
+  // explicit homeDir logs into ITS home, not the invoking user's.
+  logClient("tasks-index", message, manifestPath ? defaultClientLogPath(dirname(dirname(manifestPath))) : undefined)
+}
+
+/**
+ * A manifest stamped with a version this build doesn't know is a FUTURE
+ * build's file: the user ran a newer Rove, then went back to an older one.
+ * Recovering empty is right (we can't understand the rows), but the next
+ * save read-merge-writes from that empty base and REPLACES the file —
+ * so the bytes have to be copied aside first, exactly like the corrupt-JSON
+ * path does. Same consequence, same protection.
+ *
+ * Returns true when it handled the value (caller recovers empty).
+ */
+export async function recoverUnsupportedVersion(parsed: unknown, sourcePath: string): Promise<boolean> {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false
+  const version = (parsed as { version?: unknown }).version
+  if (version === undefined || SUPPORTED_VERSIONS.has(version)) return false
+  const backup = await backupCorruptManifest(sourcePath)
+  warnManifestRecovery(
+    `[rove] tasks.json at ${sourcePath} has unsupported version=${String(version)}; recovering with empty index.${
+      backup ? ` Original bytes backed up to ${backup}.` : " Backup copy failed; the stale file is left in place."
+    }`,
+    sourcePath,
+  )
+  return true
+}
+
 /**
  * Normalize an arbitrary JSON value into a v3 cache. Migrates v1 / v2
  * manifests by stripping the dropped fields (`tabs`, `activeTabId`,
  * `sessionId`, `model`, `modelEffort`, `permissionMode`). The first
  * save after load persists the v3 shape.
+ *
+ * The unsupported-version guard here is a last-resort net for callers that
+ * skipped {@link recoverUnsupportedVersion}; the async read paths run that
+ * first so the bytes are backed up before anything empties the index.
  */
 export function normalizeIndex(parsed: unknown, source: string): { version: typeof CURRENT_VERSION; tasks: Task[] } {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    console.warn(`[rove] tasks.json at ${source} is not an object; recovering with empty index.`)
+    warnManifestRecovery(`[rove] tasks.json at ${source} is not an object; recovering with empty index.`, source)
     return { version: CURRENT_VERSION, tasks: [] }
   }
 
   const obj = parsed as { version?: unknown; tasks?: unknown }
   const version = obj.version
-  if (version !== undefined && version !== 1 && version !== 2 && version !== 3) {
-    console.warn(
+  if (version !== undefined && !SUPPORTED_VERSIONS.has(version)) {
+    warnManifestRecovery(
       `[rove] tasks.json at ${source} has unsupported version=${String(version)}; recovering with empty index.`,
+      source,
     )
     return { version: CURRENT_VERSION, tasks: [] }
   }
@@ -161,6 +212,9 @@ export async function readDiskIndex(
     await backupCorruptManifest(sourcePath)
     return { tasks: [], removed: [] }
   }
+  // Same protection as the parse branch above: back the bytes up before the
+  // merged write replaces a manifest this build can't read.
+  if (await recoverUnsupportedVersion(parsed, sourcePath)) return { tasks: [], removed: [] }
   return { tasks: normalizeIndex(parsed, sourcePath).tasks, removed: coerceTombstones(parsed) }
 }
 

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -22,6 +22,8 @@ import {
   mergeTasksWithDisk,
   normalizeIndex,
   readDiskIndex,
+  recoverUnsupportedVersion,
+  warnManifestRecovery,
 } from "./store-codec.ts"
 import { ulid } from "./ulid.ts"
 
@@ -129,11 +131,22 @@ export class TaskIndexStore {
       // from this empty recovery base and replaces the corrupt file, so
       // without a copy the user's tasks are gone for good (PR #276).
       const backup = await backupCorruptManifest(sourcePath)
-      console.warn(
+      warnManifestRecovery(
         `[rove] tasks.json at ${sourcePath} is corrupted (${(err as Error).message}); recovering with empty index.${
           backup ? ` Original bytes backed up to ${backup}.` : " Backup copy failed; the stale file is left in place."
         }`,
+        sourcePath,
       )
+      this.cache = { version: CURRENT_VERSION, tasks: [] }
+      this.loaded = true
+      this.notifyListeners()
+      return this.snapshot()
+    }
+
+    // A future build's manifest empties the index just as thoroughly as a
+    // corrupt one does, and the next save replaces the file — so its bytes
+    // get the same copy-aside before we recover empty.
+    if (await recoverUnsupportedVersion(parsed, sourcePath)) {
       this.cache = { version: CURRENT_VERSION, tasks: [] }
       this.loaded = true
       this.notifyListeners()

--- a/packages/kobe/test/cli/pty-host-cmd.test.ts
+++ b/packages/kobe/test/cli/pty-host-cmd.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `kobe pty-host` boot (`runPtyHostSubcommand`).
+ *
+ * The one thing pinned here is log rotation. `pty.log` is stdout/stderr
+ * inherited as an append fd from the parent's `spawnDetachedDaemon`, so boot
+ * is the only point at which it can safely be rotated — and it was the one
+ * log of the three that never got that call (issue #26 capped client.log and
+ * daemon.log only). The PTY host is also the longest-lived process in the
+ * system by design, so it is the least likely to ever restart and clean up
+ * after itself.
+ *
+ * Real filesystem against a ROVE_HOME_DIR tempdir; only the server itself is
+ * mocked, so the path resolution the fix depends on stays real.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { defaultPtyHostLogPath } from "@sma1lboy/kobe-daemon/daemon/paths"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  startPtyHostServer: vi.fn(),
+  installDaemonCrashHandlers: vi.fn(),
+}))
+
+vi.mock("@sma1lboy/kobe-daemon/daemon/pty-server", () => ({
+  startPtyHostServer: mocks.startPtyHostServer,
+}))
+
+vi.mock("@sma1lboy/kobe-daemon/daemon/crash-log", () => ({
+  installDaemonCrashHandlers: mocks.installDaemonCrashHandlers,
+}))
+
+let home: string
+let logPath: string
+const prevHome = process.env.ROVE_HOME_DIR
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kobe-pty-host-cmd-"))
+  process.env.ROVE_HOME_DIR = home
+  logPath = defaultPtyHostLogPath(home)
+  mkdirSync(join(logPath, ".."), { recursive: true })
+  mocks.startPtyHostServer.mockReset().mockResolvedValue({ socketPath: join(home, "pty.sock"), close: async () => {} })
+  mocks.installDaemonCrashHandlers.mockReset()
+  vi.spyOn(console, "log").mockImplementation(() => {})
+})
+
+afterEach(() => {
+  // boot() registers real SIGINT/SIGTERM handlers on this process; leaving
+  // them stacked would have the runner's own signals call process.exit(0).
+  process.removeAllListeners("SIGINT")
+  process.removeAllListeners("SIGTERM")
+  // Assigning undefined would set the literal string "undefined"; the var has
+  // to actually go away or every later test file inherits a bogus home.
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "ROVE_HOME_DIR")
+  else process.env.ROVE_HOME_DIR = prevHome
+  rmSync(home, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+async function boot(): Promise<void> {
+  const { runPtyHostSubcommand } = await import("../../src/cli/pty-host-cmd.ts")
+  await runPtyHostSubcommand([])
+}
+
+describe("pty-host boot rotates pty.log", () => {
+  it("rotates an over-cap log to .old before the host writes a byte", async () => {
+    writeFileSync(logPath, "x".repeat(11 * 1024 * 1024), "utf8")
+
+    await boot()
+
+    expect(existsSync(`${logPath}.old`)).toBe(true)
+    expect(readFileSync(`${logPath}.old`, "utf8").length).toBe(11 * 1024 * 1024)
+    // Rotation is a rename: the live path is free for the inherited fd.
+    expect(existsSync(logPath)).toBe(false)
+    expect(mocks.startPtyHostServer).toHaveBeenCalledOnce()
+  })
+
+  it("leaves an under-cap log alone", async () => {
+    writeFileSync(logPath, "small", "utf8")
+
+    await boot()
+
+    expect(existsSync(`${logPath}.old`)).toBe(false)
+    expect(readFileSync(logPath, "utf8")).toBe("small")
+  })
+
+  it("starts fine with no log yet", async () => {
+    await boot()
+    expect(mocks.startPtyHostServer).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/kobe/test/daemon/pty-freeze-store.test.ts
+++ b/packages/kobe/test/daemon/pty-freeze-store.test.ts
@@ -6,10 +6,12 @@
  * ring cap on thaw, and the reset semantics (clear = starts fresh).
  */
 
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
+  FREEZE_MAX_RECORDS,
+  FREEZE_TTL_MS,
   type FreezeableSession,
   type FrozenPtySession,
   clearFrozenSessions,
@@ -127,5 +129,97 @@ describe("pty freeze store", () => {
     const thawed = thawSession(record, 1024)
     expect(thawed?.restored).toBe(true)
     expect(thawed?.bytes).toBe(0)
+  })
+})
+
+describe("existing-permission remediation", () => {
+  // The whole point: `mode:` on mkdirSync/writeFileSync binds only at
+  // CREATION. An install that froze sessions before PR #662 keeps a 0755
+  // directory and 0644 records, so a mode argument alone fixes nobody who
+  // was already exposed. Asserting the call arguments would pass while the
+  // bug persists — these read the real filesystem bits back.
+  function modeOf(path: string): string {
+    return (statSync(path).mode & 0o777).toString(8)
+  }
+
+  it("tightens a pre-existing 0755 directory and its 0644 records", () => {
+    const legacy = join(dir, "legacy")
+    mkdirSync(legacy, { mode: 0o755 })
+    chmodSync(legacy, 0o755) // umask can shave the mkdir mode; pin it
+    const record = join(legacy, "t1%3A%3Atab-1.json")
+    writeFileSync(record, JSON.stringify(freezeSession(fakeSession())), { encoding: "utf8", mode: 0o644 })
+    chmodSync(record, 0o644)
+
+    expect(modeOf(legacy)).toBe("755")
+    expect(modeOf(record)).toBe("644")
+
+    fileFreezeSink(legacy)
+
+    expect(modeOf(legacy)).toBe("700")
+    expect(modeOf(record)).toBe("600")
+  })
+
+  it("tightens every pre-existing record, not just the one that gets re-frozen", () => {
+    const legacy = join(dir, "many")
+    mkdirSync(legacy, { mode: 0o755 })
+    const names = ["a%3A%3Atab-1.json", "b%3A%3Atab-1.json", "c%3A%3Atab-1.json"]
+    for (const name of names) {
+      writeFileSync(join(legacy, name), JSON.stringify(freezeSession(fakeSession())), "utf8")
+      chmodSync(join(legacy, name), 0o644)
+    }
+
+    // Re-freeze only ONE session; the other two are the upgraded-but-never-
+    // touched-again case that a forward-only fix leaves world-readable.
+    fileFreezeSink(legacy).save(freezeSession(fakeSession({ key: "a::tab-1" })))
+
+    for (const name of names) expect(modeOf(join(legacy, name))).toBe("600")
+  })
+
+  it("survives a directory that does not exist yet", () => {
+    expect(() => fileFreezeSink(join(dir, "absent"))).not.toThrow()
+  })
+})
+
+describe("pruning stale + over-cap records", () => {
+  const DAY = 24 * 60 * 60 * 1000
+
+  function writeRecord(key: string, updatedAt: string): void {
+    fileFreezeSink(dir).save({ ...freezeSession(fakeSession({ key })), updatedAt })
+  }
+
+  it("deletes records past the TTL instead of thawing them", () => {
+    const now = Date.parse("2026-08-30T00:00:00.000Z")
+    writeRecord("fresh::tab-1", new Date(now - DAY).toISOString())
+    // A task deleted while the host was down: `pty.sweep` only reaches a
+    // RUNNING host, so nothing ever removed this record.
+    writeRecord("orphan::tab-1", new Date(now - 30 * DAY).toISOString())
+
+    const loaded = loadFrozenSessions(dir, now)
+
+    expect(loaded.map((r) => r.key)).toEqual(["fresh::tab-1"])
+    // Deleted, not merely skipped — otherwise every later boot re-reads it.
+    expect(readdirSync(dir).filter((n) => n.endsWith(".json"))).toHaveLength(1)
+  })
+
+  it("keeps the newest FREEZE_MAX_RECORDS and deletes the rest", () => {
+    const now = Date.parse("2026-08-30T00:00:00.000Z")
+    const total = FREEZE_MAX_RECORDS + 5
+    for (let i = 0; i < total; i++) {
+      // i=0 newest, ascending index = older.
+      writeRecord(`t${i}::tab-1`, new Date(now - i * 60_000).toISOString())
+    }
+
+    const loaded = loadFrozenSessions(dir, now)
+
+    expect(loaded).toHaveLength(FREEZE_MAX_RECORDS)
+    expect(loaded[0]?.key).toBe("t0::tab-1")
+    expect(loaded.map((r) => r.key)).not.toContain(`t${total - 1}::tab-1`)
+    expect(readdirSync(dir).filter((n) => n.endsWith(".json"))).toHaveLength(FREEZE_MAX_RECORDS)
+  })
+
+  it("keeps a record right at the TTL edge", () => {
+    const now = Date.parse("2026-08-30T00:00:00.000Z")
+    writeRecord("edge::tab-1", new Date(now - FREEZE_TTL_MS).toISOString())
+    expect(loadFrozenSessions(dir, now).map((r) => r.key)).toEqual(["edge::tab-1"])
   })
 })

--- a/packages/kobe/test/orchestrator/store-load-edge.test.ts
+++ b/packages/kobe/test/orchestrator/store-load-edge.test.ts
@@ -14,6 +14,7 @@
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { flushClientLog } from "@sma1lboy/kobe-daemon/client/client-log"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
 
@@ -123,6 +124,55 @@ describe("load() recovery", () => {
     await writeManifest(JSON.stringify({ version: 99, tasks: [] }))
     expect((await store.load()).tasks).toEqual([])
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("unsupported version"))
+    warn.mockRestore()
+  })
+
+  it("an unsupported version backs the original bytes up before recovering empty", async () => {
+    // A user who ran a build that stamped v4 and then went back to this one
+    // loses EVERY task: the empty recovery base is what the next save
+    // read-merge-writes from, so the file is replaced. Identical consequence
+    // to the corrupt-JSON branch above, so it needs the identical backup.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    await primeDir()
+    const future = JSON.stringify({
+      version: 4,
+      tasks: [{ id: "01ARZ3NDEKTSV4RRFFQ69G5FAV", title: "would-be-lost" }],
+    })
+    await writeManifest(future)
+
+    expect((await store.load()).tasks).toEqual([])
+
+    const backups = (await readdir(join(home, ".rove"))).filter((name) => name.startsWith("tasks.json.corrupt-"))
+    expect(backups.length).toBeGreaterThanOrEqual(1)
+    expect(await readFile(join(home, ".rove", backups[0] ?? ""), "utf8")).toBe(future)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("backed up to"))
+
+    // The save that replaces the manifest leaves the copy intact.
+    await store.create({
+      repo: "/r",
+      title: "after-recovery",
+      branch: "",
+      worktreePath: "",
+      status: "backlog",
+      kind: "task",
+      vendor: "claude",
+    })
+    expect(await readFile(join(home, ".rove", backups[0] ?? ""), "utf8")).toBe(future)
+    warn.mockRestore()
+  })
+
+  it("routes the recovery warning to client.log, not only the painted-over stdout", async () => {
+    // Every pane runs under an opentui alternate screen, so a console.warn
+    // about an emptied task index is written where no human will ever see
+    // it — the entire reason client-log.ts exists.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    await primeDir()
+    await writeManifest(JSON.stringify({ version: 4, tasks: [] }))
+    await store.load()
+    await flushClientLog()
+
+    const log = await readFile(join(home, ".rove", "client.log"), "utf8")
+    expect(log).toContain("unsupported version=4")
     warn.mockRestore()
   })
 


### PR DESCRIPTION
Four persistence defects. The first two are the sharp ones: a version mismatch wipes every task with no backup, and the security fix from #662 does nothing for anyone who was already exposed.

## 1. A version mismatch emptied `tasks.json` with no backup

`store-codec.ts` recovered an unrecognized `version` to an empty index — and the next save read-merge-writes from that empty base and **replaces the file**. Three lines away, the JSON-parse branch handles the identical consequence by calling `backupCorruptManifest` first (PR #276). The version branch never got it.

Run a build that stamps v4, go back to one that reads v1–v3, and every task is gone. The only trace was a `console.warn`, printed under opentui's alternate screen where nobody sees it.

The version branch now backs the bytes up the same way, and both recovery warnings also go to `client.log` — the sink that exists precisely because stdout is painted over. The log path is derived from the manifest, so a store opened on an explicit `homeDir` writes into *its* home rather than the invoking user's.

## 2. #662's `mode:` arguments are a no-op on existing paths

`mkdirSync`/`writeFileSync` apply `mode` only when they **create** the path. On the reporting machine: `pty-sessions/` still `drwxr-xr-x`, and 11 of 101 records still `-rw-r--r--`. The directory being 755 is what makes those files reachable. Each one holds a session's whole scrollback — the module's own comment names `env` output, `cat`ed credential files, a git remote carrying a PAT.

`fileFreezeSink` now chmods the directory and every existing record once at construction (host boot). A fix that only covers files written after the upgrade does nothing for the people already affected.

Fixture verification on a 755 dir + three 644 records, **no `save()` call** — the never-re-frozen case:

```
BEFORE  drwxr-xr-x  pty-sessions/
        -rw-r--r--  ta%3A%3Atab-1.json
        -rw-r--r--  tb%3A%3Atab-1.json
        -rw-r--r--  tc%3A%3Atab-1.json

AFTER   drwx------  pty-sessions/
        -rw-------  ta%3A%3Atab-1.json
        -rw-------  tb%3A%3Atab-1.json
        -rw-------  tc%3A%3Atab-1.json
```

The same fixture under mode-args-only (the shipped #662 behavior) keeps `drwxr-xr-x` and `-rw-r--r--`; only the newly written file gets 600. The tests read the real mode bits back — asserting call arguments would pass while the bug persists, since being ignored is the whole bug.

## 3. `pty-sessions/` had no bound

101 files / 54MB / 4 records whose task no longer exists. `pty.sweep` only reaches a **running** host (`pty-process.ts:196-201` is a silent no-op with none), so a task deleted while the host was down leaves its record forever. `loadFrozenSessions` then read and thawed all of it on every boot, resurrecting dead tasks into the live table.

Records already carry `updatedAt`, so pruning is a filter on existing data. **14-day TTL, 64-record cap**, and expired/over-cap files are deleted rather than skipped — skipping leaves every later boot paying the same read.

*Why those numbers:* 14 days is well past any plausible "I'll get back to that tab next week" while still bounding growth; 64 is several times any realistic count of open terminal tabs, and against the 512KB scrollback cap it bounds the boot read at ~32MB instead of unbounded. The TTL is the real mechanism — the cap only bounds a burst inside the window.

Fixture (60 fresh + 41 long-dead, mirroring the reported shape): **101 files → 60**, 60 thawed.

## 4. `pty.log` never rotated

`daemon-cmd.ts:124` rotates at boot — correct, since the fd is inherited, so boot is the only safe point. `pty-host-cmd.ts` never had that call. The PTY host is the longest-lived process here by design (it survives `rove daemon restart`; the reporting machine's had 22h uptime), so it is the least likely to ever restart and clean up after itself. Issue #26 capped two of the three logs; this was the third. Added to both the Bun host and the Windows node entry.

## Verification

- `typecheck` / `lint` clean; every touched file under the 500-line cap
- vitest 3814 pass, socket track 635 pass, render track 291 pass
- **Mutation gate: 3 rounds × 5 mutations, every one red.** Round 2 hit different sites than round 1 — including the *wiring* rather than the leaf (`store.ts` not calling `recoverUnsupportedVersion` while the codec stays correct → red) and a *partial* fix (chmod the directory but not the files → red). Round 3 re-ran post-rebase on 0.9.46.
- All fixture work in `/tmp`; the real `~/.kobe/pty-sessions/` was never touched.

Fix 3 changes restore behavior: a session untouched for 14 days no longer comes back after a host restart. That is the intent — restore exists so the scene you were just looking at survives, not so a deleted task's leftovers do.