### PR TITLE
fix: adapt the TUI to narrow, short, and non-kitty terminals

### DIFF
--- a/.changeset/terminal-adaptation.md
+++ b/.changeset/terminal-adaptation.md
@@ -1,0 +1,36 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix four places the TUI assumed a wide, tall, kitty-speaking terminal
+
+The Changes tab budgeted its path column in display cells but spent that
+budget by counting code points, so a Chinese path — the ordinary case, Rove
+defaults to Simplified Chinese — could be "short enough" and still overrun.
+`文档/设计/终端渲染说明书笔记.md` is 18 code points and 31 cells against a
+26-cell budget, so the row drew five cells through the pane border onto the
+workspace beside it and dragged the `+N`/`−N` columns out of alignment. Paths
+now truncate against the same cell measurer the sidebar, tab strip and toasts
+already use, and the row's other segments spend the budget in cells too.
+
+Settings padded every General label to a flat 30 cells whatever the terminal
+width. At 46 columns — the phone-SSH width the docs promise — the row only
+owns 26, so the padding alone overran it and the label was cut with no
+ellipsis to say so; at 50 it consumed the budget exactly, leaving the inline
+hint structurally unreachable. The column is now a maximum, not a floor: it
+shrinks with the row, and when there is no room for both, the hint is dropped
+whole rather than clipped to a fragment.
+
+The new-task dialog sized its picker window to a fixed 8 rows regardless of
+terminal height, while the dialog card is capped at the viewport and nothing
+scrolls it. On a 24-row terminal the bottom six rows were clipped away —
+including the Create button and the submit error, so a failed create looked
+like nothing happening at all. The window now follows the viewport, down to a
+floor of two rows; the list still scrolls, so no entry became unreachable.
+The branch picker and the clone/adopt tabs shared the same fixed window.
+
+`rove doctor` regained the terminal diagnosis it lost as collateral damage
+when the tmux runtime was removed: multiplexer nesting (tmux, zellij, screen)
+and a live kitty-keyboard-protocol probe. Both split chords require that
+protocol, so without the probe doctor could not answer a "split doesn't work"
+report at all.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -287,7 +287,14 @@ rove doctor [--report] [--fix]
 ```
 
 Read-only check of your build, terminal, git, engine CLIs and logins, daemon,
-running sessions, agent skill, and state files. Every registered engine gets a
+running sessions, agent skill, and state files. The terminal section names
+`TERM`/`TERM_PROGRAM`/`COLORTERM`, whether you are inside a multiplexer (tmux,
+zellij, screen — all three rewrite keys on the way in), and asks the terminal
+live whether it speaks the kitty keyboard protocol. That last answer settles
+keyboard reports on its own: without the protocol, `ctrl+h`/`ctrl+j` arrive as
+plain C0 bytes and the two split chords cannot be encoded at all (see
+[Keybindings](./KEYBINDINGS.md)). Piped output skips the live probe rather
+than writing escape bytes into the pipe. Every registered engine gets a
 row — the built-ins plus any engine you added — so a login Rove can't read is
 reported as such rather than as a missing account. The plain run never changes
 anything. `--report` also writes a bug bundle (diagnosis + recent logs + env)

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -91,7 +91,9 @@ is split, otherwise the tab. `F2` follows the same rule.
 
 Both split chords need a terminal speaking the kitty keyboard protocol
 (legacy terminals can't encode `ctrl+=`, and `ctrl+\` would be SIGQUIT);
-reserving `ctrl+\` also costs the embedded shell its SIGQUIT.
+reserving `ctrl+\` also costs the embedded shell its SIGQUIT. If a split
+chord does nothing, `rove doctor` says whether your terminal answers the
+protocol query — that is the first thing to check.
 
 **Jump digits.** There is no `ctrl+1`; the terminal protocol can't encode it,
 so the first row answers to `2`.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -422,7 +422,12 @@ is no setting: it follows the terminal width.
   counter. The usual tab chords still switch.
 - The footer keeps one quota chip per engine (`CLAUDE 42%`) and shrinks the
   hints to bare keycaps.
-- Dialogs center themselves with tighter padding.
+- Dialogs center themselves with tighter padding, and Settings drops the
+  inline hint beside each switch so the switch's own label fits. The
+  paragraph above each group still explains what it does.
+- Dialogs with a picker (new task, branch picker) shrink the picker's visible
+  rows on a short terminal instead of pushing their own Create button off the
+  bottom. The list still scrolls, so every entry stays reachable.
 
 ## Attachments: drag and drop, paste
 

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -32,6 +32,7 @@ import {
   skillInstallFix,
 } from "./doctor-fix.ts"
 import { classifyHookChannel, hookChannelDoctorLines } from "./doctor-hook-channel.ts"
+import { terminalDoctorLines } from "./doctor-terminal.ts"
 import { inspectLegacyTmux, legacyTmuxDoctorLines } from "./legacy-tmux.ts"
 import { activeCliName } from "./rename-compat.ts"
 
@@ -119,14 +120,6 @@ function tailFile(path: string, count: number): string {
   }
 }
 
-function terminalDoctorLines(): string[] {
-  const show = (value: string | undefined): string => (value && value.length > 0 ? value : "(unset)")
-  const program = process.env.TERM_PROGRAM
-    ? `${process.env.TERM_PROGRAM}${process.env.TERM_PROGRAM_VERSION ? ` v${process.env.TERM_PROGRAM_VERSION}` : ""}`
-    : "(unset)"
-  return [`terminal: TERM=${show(process.env.TERM)}  TERM_PROGRAM=${program}  COLORTERM=${show(process.env.COLORTERM)}`]
-}
-
 /** `git --version` if git is on PATH, else a not-found marker. */
 async function gitDoctorLine(): Promise<{ line: string; found: boolean }> {
   try {
@@ -208,7 +201,7 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
     `  build:  v${CURRENT_VERSION} (${process.platform} ${process.arch}, bun ${Bun.version})`,
     `  home:   ${homeDir()}`,
     "",
-    ...terminalDoctorLines(),
+    ...(await terminalDoctorLines()),
     git.line,
     "",
     ...engines.lines,

--- a/packages/kobe/src/cli/doctor-terminal.ts
+++ b/packages/kobe/src/cli/doctor-terminal.ts
@@ -1,0 +1,122 @@
+/**
+ * Terminal diagnostics for `rove doctor` — issue-triage context for
+ * keyboard-protocol-class bugs. Keyboard behavior differs by terminal:
+ * without the kitty keyboard protocol, ctrl+h / ctrl+j arrive as ambiguous
+ * C0 bytes (0x08 backspace / 0x0a linefeed), and the two split chords
+ * (`ctrl+\`, `ctrl+=`, see docs/KEYBINDINGS.md) cannot be encoded at all.
+ * So when a report says "split doesn't work", the protocol answer is the
+ * first thing triage needs — and only the terminal can give it.
+ *
+ * Read-only, like the rest of doctor, and its own process: `rove doctor`
+ * has no opentui renderer to read `renderer.capabilities` from, so it asks
+ * the terminal directly with the same escape query opentui would.
+ */
+
+/**
+ * The multiplexer a session is nested inside, from env alone. Rove dropped
+ * its own tmux runtime, but a user running Rove INSIDE one is unaffected by
+ * that and still gets their keys rewritten on the way in — which is exactly
+ * the confound a keyboard report has to rule out. All three set a marker.
+ */
+export function multiplexerLabel(env: Record<string, string | undefined>): string {
+  if (env.TMUX) return "tmux"
+  if (env.ZELLIJ) return "zellij"
+  if (env.STY) return "screen"
+  return "no"
+}
+
+/** `TERM=… TERM_PROGRAM=… COLORTERM=…` plus multiplexer nesting, from an
+ *  injected env so tests don't depend on the runner's terminal. */
+export function terminalEnvLines(env: Record<string, string | undefined>): string[] {
+  const show = (v: string | undefined): string => (v && v.length > 0 ? v : "(unset)")
+  const program = env.TERM_PROGRAM
+    ? `${env.TERM_PROGRAM}${env.TERM_PROGRAM_VERSION ? ` v${env.TERM_PROGRAM_VERSION}` : ""}`
+    : "(unset)"
+  const lines = [
+    `terminal: TERM=${show(env.TERM)}  TERM_PROGRAM=${program}  COLORTERM=${show(env.COLORTERM)}`,
+    `          running inside a multiplexer: ${multiplexerLabel(env)}`,
+  ]
+  return lines
+}
+
+export type KittyProbeResult =
+  | { kind: "supported"; flags: number }
+  | { kind: "unsupported" }
+  | { kind: "no-response" }
+  | { kind: "skipped"; reason: string }
+
+/**
+ * Decide from accumulated reply bytes. The probe writes `CSI ? u` (kitty
+ * flags query) followed by `CSI c` (DA1) as a fence: every terminal answers
+ * DA1, so a DA1 reply WITHOUT a preceding `CSI ? <flags> u` means the kitty
+ * query was ignored — protocol unsupported. Returns null while undecided
+ * (keep reading until timeout).
+ */
+export function parseKittyProbeReply(data: string): KittyProbeResult | null {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: matching a raw ESC-prefixed terminal reply is the whole point
+  const kitty = data.match(/\x1b\[\?(\d+)u/)
+  if (kitty?.[1] !== undefined) return { kind: "supported", flags: Number.parseInt(kitty[1], 10) }
+  // DA1 reply: CSI ? <params> c
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: same — raw DA1 escape reply
+  if (/\x1b\[\?[\d;]*c/.test(data)) return { kind: "unsupported" }
+  return null
+}
+
+/** One doctor line per probe outcome, with the triage hint inline. */
+export function kittyProbeLine(result: KittyProbeResult): string {
+  switch (result.kind) {
+    case "supported":
+      return `          kitty keyboard protocol: ✓ answered (flags=${result.flags})`
+    case "unsupported":
+      return [
+        "          kitty keyboard protocol: ✗ not supported — legacy key path",
+        "          (ctrl+h/ctrl+j arrive as C0 backspace/linefeed bytes; the",
+        "          split chords ctrl+\\ and ctrl+= cannot be encoded at all)",
+      ].join("\n")
+    case "no-response":
+      return "          kitty keyboard protocol: ? no reply (terminal ignored both the kitty query and DA1)"
+    case "skipped":
+      return `          kitty keyboard protocol: skipped (${result.reason})`
+  }
+}
+
+/**
+ * Live probe against the controlling terminal. Only runs when stdin AND
+ * stdout are TTYs (piped `rove doctor | pbcopy` must not emit escape bytes
+ * into the pipe or wait on a reply that can't come). Raw mode for the read,
+ * always restored; hard timeout so doctor can never hang on a mute terminal.
+ */
+export async function probeKittyKeyboard(timeoutMs = 300): Promise<KittyProbeResult> {
+  const stdin = process.stdin
+  if (!stdin.isTTY || !process.stdout.isTTY) return { kind: "skipped", reason: "not an interactive terminal" }
+
+  const wasRaw = stdin.isRaw === true
+  let buffer = ""
+  return await new Promise<KittyProbeResult>((resolve) => {
+    let done = false
+    const finish = (result: KittyProbeResult): void => {
+      if (done) return
+      done = true
+      clearTimeout(timer)
+      stdin.off("data", onData)
+      stdin.pause()
+      if (!wasRaw) stdin.setRawMode(false)
+      resolve(result)
+    }
+    const onData = (chunk: Buffer): void => {
+      buffer += chunk.toString("latin1")
+      const decided = parseKittyProbeReply(buffer)
+      if (decided) finish(decided)
+    }
+    const timer = setTimeout(() => finish({ kind: "no-response" }), timeoutMs)
+    stdin.setRawMode(true)
+    stdin.resume()
+    stdin.on("data", onData)
+    process.stdout.write("\x1b[?u\x1b[c")
+  })
+}
+
+/** The whole `terminal:` doctor section (env lines + live kitty probe). */
+export async function terminalDoctorLines(): Promise<string[]> {
+  return [...terminalEnvLines(process.env), kittyProbeLine(await probeKittyKeyboard())]
+}

--- a/packages/kobe/src/tui-react/component/branch-picker-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/branch-picker-dialog.tsx
@@ -15,11 +15,13 @@
  */
 
 import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/react"
 import { useMemo, useState } from "react"
 import {
   type PickerWindow,
   clampCursor,
   filterBranches,
+  pickerVisibleRows,
   resolveBaseRef,
   stripNewlines,
   windowAround,
@@ -50,7 +52,7 @@ export function BranchPickerDialogView(props: {
   // One-shot enumeration on open (repo is fixed for the dialog's lifetime).
   const branches = useMemo(() => listLocalBranches(props.repo), [props.repo])
   const filtered = useMemo(() => filterBranches(branches, value), [branches, value])
-  const window: PickerWindow = windowAround(filtered, cursor)
+  const window: PickerWindow = windowAround(filtered, cursor, pickerVisibleRows(useTerminalDimensions().height))
 
   function move(delta: 1 | -1): void {
     if (filtered.length === 0) return

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
@@ -7,12 +7,14 @@
 
 import type { VendorId } from "@/types/vendor"
 import type { AdoptableWorktree } from "@/types/worktree"
+import { useTerminalDimensions } from "@opentui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import {
   type NewTaskInput,
   type PickerWindow,
   clampCursor,
   filterAdoptableByGlob,
+  pickerVisibleRows,
   stripNewlines,
   windowAround,
 } from "../../../tui/component/new-task-dialog/state"
@@ -39,6 +41,7 @@ export function useAdoptState(args: {
   const adoptWindow: PickerWindow = windowAround(
     adoptList.map((w) => w.path),
     adoptCursor,
+    pickerVisibleRows(useTerminalDimensions().height),
   )
   const adoptVisible = adoptList.slice(adoptWindow.start, adoptWindow.start + adoptWindow.items.length)
   const adoptDiscoveredCount = (adoptable ?? []).length

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
@@ -7,6 +7,7 @@
  */
 
 import type { VendorId } from "@/types/vendor"
+import { useTerminalDimensions } from "@opentui/react"
 import { useEffect, useState } from "react"
 import {
   cloneRepo,
@@ -21,6 +22,7 @@ import {
   type NewTaskInput,
   type PickerWindow,
   clampCursor,
+  pickerVisibleRows,
   stripNewlines,
   windowAround,
 } from "../../../tui/component/new-task-dialog/state"
@@ -50,7 +52,11 @@ export function useCloneState(args: {
   const [cloneParentPicked, setCloneParentPicked] = useState(false)
 
   const { split: cloneParentSplit, filtered: cloneParentFiltered } = useDerivedDir(cloneParent)
-  const cloneParentWindow: PickerWindow = windowAround(cloneParentFiltered, cloneParentCursor)
+  const cloneParentWindow: PickerWindow = windowAround(
+    cloneParentFiltered,
+    cloneParentCursor,
+    pickerVisibleRows(useTerminalDimensions().height),
+  )
 
   // Folder name follows the URL until manually edited; auto-suffixes on
   // collision inside the chosen parent dir.

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -19,6 +19,7 @@
 
 import { type VendorId, nextVendorWithin, prevVendorWithin } from "@/types/vendor"
 import type { AdoptableWorktree } from "@/types/worktree"
+import { useTerminalDimensions } from "@opentui/react"
 import { useEffect, useMemo, useState } from "react"
 import {
   type DialogTab,
@@ -33,6 +34,7 @@ import {
   nextDialogTab,
   nextField,
   pickerModeFor,
+  pickerVisibleRows,
   prevDialogTab,
   resolveBaseRef,
   stripNewlines,
@@ -100,16 +102,19 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     () => computeRepoOptions(props.defaultRepo, props.savedRepos),
     [props.defaultRepo, props.savedRepos],
   )
+  // Live per render — opentui re-renders on resize, so a terminal dragged
+  // short re-windows the pickers instead of clipping the Create button.
+  const pickerRows = pickerVisibleRows(useTerminalDimensions().height)
   const mode = pickerModeFor(repo, repoOptions)
   const { split: subdirSplit, filtered: subdirFiltered } = useDerivedDir(repo)
   const savedFiltered = useMemo(() => filterRepos(repoOptions, repo), [repoOptions, repo])
   const activeList = mode === "browse" ? subdirFiltered : savedFiltered
-  const activeWindow: PickerWindow = windowAround(activeList, repoCursor)
+  const activeWindow: PickerWindow = windowAround(activeList, repoCursor, pickerRows)
 
   const expandedRepo = expandHome(repo.trim())
   const branches = useMemo(() => listLocalBranches(expandedRepo), [expandedRepo])
   const branchFiltered = useMemo(() => filterBranches(branches, baseRef), [branches, baseRef])
-  const branchWindow: PickerWindow = windowAround(branchFiltered, branchCursor)
+  const branchWindow: PickerWindow = windowAround(branchFiltered, branchCursor, pickerRows)
 
   const clone = useCloneState({
     defaultCloneParent: props.defaultCloneParent,

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-general.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-general.tsx
@@ -9,6 +9,7 @@
  */
 
 import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/react"
 import { useMemo } from "react"
 import type { UsageSnapshotMap } from "../../../client/remote-orchestrator"
 import { engineDisplayName } from "../../../engine/interactive-command"
@@ -17,8 +18,10 @@ import { SPLIT_STYLES } from "../../../state/split-style"
 import {
   type NavLevel,
   SECTIONS,
+  SECTIONS_SIDEBAR_WIDTH,
   type SectionId,
   focusAccentRowId,
+  generalLabelLayout,
   generalRows,
   languageRowId,
   rowIndex,
@@ -29,6 +32,7 @@ import { keyHintsToggleOn, toggleKeyHints } from "../../../tui/lib/keyboard-hint
 import { useKV } from "../../context/kv"
 import { FOCUS_ACCENT_SLOTS, type FocusAccentSlot, useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
+import { useDialogPaddingX } from "../../ui/dialog"
 import { Row, type SectionCursorProps, SubSection } from "./rows"
 import { usageRows } from "./usage-core"
 import type { SettingsPrefs } from "./use-settings-prefs"
@@ -41,7 +45,7 @@ export function SettingsSectionSidebar(props: {
   const { theme } = useTheme()
   const t = useT()
   return (
-    <box flexDirection="column" flexShrink={0} width={14} gap={1}>
+    <box flexDirection="column" flexShrink={0} width={SECTIONS_SIDEBAR_WIDTH} gap={1}>
       {SECTIONS.map((s, i) => {
         const isSection = i === props.cursor
         const isSidebarFocused = isSection && props.level === "sidebar"
@@ -138,8 +142,20 @@ export function GeneralSettingsSection(
     action()
   }
   const onOff = (on: boolean) => (on ? t("settings.general.on") : t("settings.general.off"))
-  /** Label column: the inline hints beside each control read as a column too. */
-  const pad = (label: string) => label + " ".repeat(Math.max(0, 30 - displayWidth(label)))
+  // Live per render — opentui re-renders on resize, so a terminal dragged
+  // narrow re-lays the column out instead of keeping a stale desktop budget.
+  const { labelColumn, showHint } = generalLabelLayout(useTerminalDimensions().width, useDialogPaddingX())
+  /** The inline hint, dropped entirely when the row is too narrow to hold
+   *  both. A clipped half-sentence beside a clipped label is worse than the
+   *  label alone; the SubSection paragraph above still explains the group. */
+  const hint = (key: string): string | undefined => (showHint ? t(key) : undefined)
+  /** Label column: the inline hints beside each control read as a column too.
+   *  The 30-cell column is a MAXIMUM, not a floor — a narrow terminal has to
+   *  spend fewer. Padding past what the row actually owns pushes the hint out
+   *  entirely and then clips the label itself (`Row` is `overflow="hidden"`
+   *  with `wrapMode="none"`, so it cuts without an ellipsis), which is how a
+   *  46-column phone SSH session lost the label AND the hint at once. */
+  const pad = (label: string) => label + " ".repeat(Math.max(0, labelColumn - displayWidth(label)))
   const check = (on: boolean) => (on ? "[x]" : "[ ]")
   /** Exclusive pick — the same radio the Engines section uses for its default. */
   const radio = (on: boolean) => (on ? "(●)" : "( )")
@@ -250,7 +266,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(toastRow, prefs.toggleToast)}
             fg={prefs.toastEnabled() ? theme.accent : theme.textMuted}
             bold={true}
-            hint={t("settings.general.toastHint")}
+            hint={hint("settings.general.toastHint")}
           >
             {pad(`${check(prefs.toastEnabled())} ${t("settings.general.toast")}`)}
           </Row>
@@ -259,7 +275,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(soundRow, prefs.toggleSound)}
             fg={prefs.soundEnabled() ? theme.accent : theme.textMuted}
             bold={true}
-            hint={t("settings.general.soundHint")}
+            hint={hint("settings.general.soundHint")}
           >
             {pad(`${check(prefs.soundEnabled())} ${t("settings.general.sound")}`)}
           </Row>
@@ -268,7 +284,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(crossTaskRow, prefs.toggleCrossTask)}
             fg={prefs.crossTaskEnabled() ? theme.accent : theme.textMuted}
             bold={true}
-            hint={t("settings.general.crossTaskHint")}
+            hint={hint("settings.general.crossTaskHint")}
           >
             {pad(`${check(prefs.crossTaskEnabled())} ${t("settings.general.crossTask")}`)}
           </Row>
@@ -279,7 +295,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(keyHintsRow, () => toggleKeyHints(kv))}
             fg={keyHintsToggleOn(kv) ? theme.accent : theme.textMuted}
             bold={true}
-            hint={t("settings.general.keyHintsShowHint")}
+            hint={hint("settings.general.keyHintsShowHint")}
           >
             {pad(`${check(keyHintsToggleOn(kv))} ${t("settings.general.keyHintsShow")}`)}
           </Row>
@@ -298,7 +314,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(zenKeepTasksRow, prefs.toggleZenKeepsTasks)}
             fg={prefs.zenKeepsTasks() ? theme.accent : theme.textMuted}
             bold={true}
-            hint={t("settings.general.zenKeepTasksHint")}
+            hint={hint("settings.general.zenKeepTasksHint")}
           >
             {pad(`${check(prefs.zenKeepsTasks())} ${t("settings.general.zenKeepTasks")}`)}
           </Row>
@@ -309,7 +325,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(editorKindRow, prefs.cycleEditorKind)}
             fg={theme.accent}
             bold={true}
-            hint={t("settings.general.editorRowHint")}
+            hint={hint("settings.general.editorRowHint")}
           >
             {pad(t("settings.general.editorRow", { kind: prefs.editorKind() }))}
           </Row>
@@ -329,7 +345,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(worktreeBaseRow, prefs.cycleWorktreeBase)}
             fg={theme.accent}
             bold={true}
-            hint={t("settings.general.worktreeBaseHint")}
+            hint={hint("settings.general.worktreeBaseHint")}
           >
             {pad(t("settings.general.worktreeBase", { kind: prefs.worktreeKindLabel() }))}
           </Row>
@@ -349,7 +365,7 @@ export function GeneralSettingsSection(
             onMouseUp={activate(scrollbackRow, () => void prefs.editScrollbackRows())}
             fg={theme.accent}
             bold={true}
-            hint={t("settings.general.scrollbackRowHint")}
+            hint={hint("settings.general.scrollbackRowHint")}
           >
             {pad(t("settings.general.scrollbackRow", { rows: String(prefs.scrollbackRows()) }))}
           </Row>

--- a/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
@@ -18,6 +18,7 @@
 
 import { TextAttributes } from "@opentui/core"
 import { memo } from "react"
+import { displayWidth } from "../../../lib/display-width"
 import { type StatWidths, statCell, statusToken } from "../../../tui/panes/filetree/pane-core"
 import { type Row, truncatePathTail } from "../../../tui/panes/filetree/rows"
 import { useTheme } from "../../context/theme"
@@ -94,7 +95,11 @@ export const FileTreeRowView = memo(function FileTreeRowView(props: FileTreeRowP
   const marker = isUntrackedDir ? (row.expanded ? "▾ " : "▸ ") : ""
   const countSuffix = isUntrackedDir ? ` (${row.fileCount})` : ""
   const indent = row.child ? "  " : ""
-  const pathBudget = props.pathBudget - marker.length - countSuffix.length - indent.length
+  // Everything sharing the row's line spends the same CELL budget the path
+  // does — `.length` would under-charge a wide glyph and reopen the overflow
+  // `truncatePathTail` closes (`▾ ` and `(12)` are ASCII today, but the
+  // budget is the row's one arithmetic and must stay in one unit).
+  const pathBudget = props.pathBudget - displayWidth(marker) - displayWidth(countSuffix) - displayWidth(indent)
   const tone = statusToken(row.status)
   const statusColor =
     tone === "success"

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -155,8 +155,39 @@ export function pickerModeFor(value: string, repoOptions: readonly string[]): Pi
   return "saved"
 }
 
-/** Picker windowing cap. Matches the slash dropdown's `slashWindow`. */
+/** Picker windowing cap on a terminal with room. Matches the slash
+ *  dropdown's `slashWindow`. */
 export const PICKER_MAX_VISIBLE = 8
+
+/**
+ * Terminal rows the dialog needs for everything that is NOT the open picker.
+ * Counted off the rendered Existing tab (the tallest of the three): title,
+ * mode row, engine label + choices, both field labels + inputs, the picker's
+ * overflow lines, the action row and the card's padding — plus the vertical
+ * margin `Dialog` keeps outside the card, since the budget here is the
+ * TERMINAL's height, not the card's.
+ */
+const PICKER_CHROME_ROWS = 22
+/** The floor. Two rows plus the `↓ N more` line still reads as a list and
+ *  still scrolls under the cursor, so nothing becomes unreachable; going
+ *  lower would leave the cursor with nowhere to sit. */
+const PICKER_MIN_VISIBLE = 2
+
+/**
+ * Visible picker rows for a viewport `height` rows tall.
+ *
+ * The cap used to be a flat 8 regardless of terminal height, so the dialog's
+ * own height was a constant while the space for it was not: on a 24-row
+ * terminal the card overran `maxCardHeight` and the bottom rows — the Create
+ * button and, worse, `submitError` — were clipped away with nothing to
+ * scroll them back. A failed create then looked like nothing happening at
+ * all. Shrinking the window is what gives those rows back; the list is
+ * already windowed and scrolls under the cursor, so a shorter window costs
+ * only how much is visible at once, never reachability.
+ */
+export function pickerVisibleRows(height: number, cap = PICKER_MAX_VISIBLE): number {
+  return Math.max(PICKER_MIN_VISIBLE, Math.min(cap, height - PICKER_CHROME_ROWS))
+}
 
 export type PickerWindow = {
   items: readonly string[]

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -269,3 +269,47 @@ export function humanizeSlug(id: string): string {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ")
 }
+
+/** Cells the section sidebar reserves, and the gap between it and the body. */
+export const SECTIONS_SIDEBAR_WIDTH = 14
+const SECTIONS_COLUMN_GAP = 2
+/** `Row` adds `paddingLeft={1} paddingRight={1}` around its own content. */
+const ROW_PADDING_X = 2
+/** Widest the label column is ever worth — it lines the inline hints up into
+ *  a column on a desktop terminal. */
+export const LABEL_COLUMN_MAX = 30
+/** The longest General label actually renders in ~24 cells (`[x] Show
+ *  keyboard hints`), so a column narrower than this stops being a column and
+ *  starts being a clip. */
+const LABEL_NATURAL_MAX = 24
+/** The shortest hint (`bottom-right popup`) needs 18 cells; below that a hint
+ *  is a fragment, and a fragment beside a clipped label reads as corruption. */
+const HINT_MIN_CELLS = 18
+
+/**
+ * How many cells a General row may spend padding its label, and whether the
+ * inline hint fits at all, for a terminal `width` cells wide.
+ *
+ * A settings row is not free-floating text: it sits right of the fixed
+ * 14-cell section sidebar, inside the dialog's own horizontal padding, and
+ * its `Row` is `overflow="hidden"` + `wrapMode="none"` — so anything wider
+ * than the real budget is cut, without an ellipsis to say it happened.
+ * Padding every label to a flat 30 therefore did the most damage exactly
+ * where there was least room: at 46 columns the row owns 26 cells, so the
+ * padding alone overran the row and took the label with it, and at 50 it
+ * consumed the budget exactly, leaving the hint structurally unreachable.
+ *
+ * Three outcomes, in order of how much room there is:
+ *  - room for the full column plus a readable hint → both, aligned;
+ *  - room for the longest label plus a readable hint → hint keeps its 18
+ *    cells and the label column takes what is left;
+ *  - anything less → drop the hint and stop padding entirely. The label then
+ *    renders at its natural width and nothing is cut; the SubSection
+ *    paragraph above the rows still explains what the group does.
+ */
+export function generalLabelLayout(width: number, dialogPadX: number): { labelColumn: number; showHint: boolean } {
+  const rowCells = width - dialogPadX * 2 - SECTIONS_SIDEBAR_WIDTH - SECTIONS_COLUMN_GAP - ROW_PADDING_X
+  if (rowCells >= LABEL_COLUMN_MAX + HINT_MIN_CELLS) return { labelColumn: LABEL_COLUMN_MAX, showHint: true }
+  if (rowCells >= LABEL_NATURAL_MAX + HINT_MIN_CELLS) return { labelColumn: rowCells - HINT_MIN_CELLS, showHint: true }
+  return { labelColumn: 0, showHint: false }
+}

--- a/packages/kobe/src/tui/lib/truncate.ts
+++ b/packages/kobe/src/tui/lib/truncate.ts
@@ -6,15 +6,20 @@
  *   title/branch carries the type/scope the eye scans for.
  * - {@link truncateStart} keeps the TAIL (`…r/Sidebar.tsx`) — a path's leaf is
  *   the part that disambiguates.
- * - {@link truncateEndCells} is truncateEnd with a display-CELL budget for
- *   labels laid out in cells (a wide CJK glyph spends 2 of the budget).
+ * - {@link truncateEndCells} / {@link truncateStartCells} are the same two
+ *   directions against a display-CELL budget (a wide CJK glyph spends 2).
  *
- * Both iterate by code POINT (`[...s]`), not UTF-16 code unit: a plain `.slice`
- * can bisect a surrogate pair (emoji / astral char in a title or filename) and
- * render a `�` replacement glyph. Counting by code point never splits a
- * character — the correctness floor. `max` is still an approximate *cell*
- * budget (a code point can be a wide CJK glyph), a known, accepted imprecision
- * shared by these labels; sizing tooltips uses the precise width measurers.
+ * All four iterate by code POINT (`[...s]`), not UTF-16 code unit: a plain
+ * `.slice` can bisect a surrogate pair (emoji / astral char in a title or
+ * filename) and render a replacement glyph. Counting by code point never
+ * splits a character — the correctness floor.
+ *
+ * The two code-point variants treat `max` as an approximate *cell* budget, a
+ * known imprecision that is fine for a SHORT LABEL floating in flex space and
+ * wrong for anything laid out against a hard edge: a CJK string spends up to
+ * 2× its code-point count in cells, so an approximate budget overdraws the
+ * container. Anything sized against a real pane width — paths, tab titles,
+ * toasts, tree rows — uses the `…Cells` variants.
  *
  * Shared boundary rule: `max <= 0` (no room) yields `""`; a string that already
  * fits is returned unchanged; otherwise one cell is reserved for the `…`.
@@ -57,4 +62,31 @@ export function truncateStart(s: string, max: number): string {
   const points = [...s]
   if (points.length <= max) return s
   return `…${points.slice(points.length - Math.max(0, max - 1)).join("")}`
+}
+
+/**
+ * {@link truncateStart} against a display-CELL budget — the tail-keeping
+ * twin of {@link truncateEndCells}, and what a path laid out against a hard
+ * pane edge needs. Counting code points instead under-spends the budget on
+ * CJK: `文档/设计/终端渲染说明书笔记.md` is 18 code points but 31 cells, so a
+ * 26-cell budget "fits" it and the row draws straight through the pane
+ * border. Walks from the END so the filename survives; one cell is reserved
+ * for the leading `…` and no glyph is split.
+ */
+export function truncateStartCells(s: string, maxCells: number, cellsOf: (cp: number) => number): string {
+  if (maxCells <= 0) return ""
+  const points = [...s]
+  let total = 0
+  for (const ch of points) total += cellsOf(ch.codePointAt(0) ?? 0)
+  if (total <= maxCells) return s
+  let used = 0
+  let out = ""
+  for (let i = points.length - 1; i >= 0; i--) {
+    const ch = points[i] as string
+    const w = cellsOf(ch.codePointAt(0) ?? 0)
+    if (used + w > maxCells - 1) break // reserve 1 cell for the ellipsis
+    used += w
+    out = ch + out
+  }
+  return `…${out}`
 }

--- a/packages/kobe/src/tui/panes/filetree/git.ts
+++ b/packages/kobe/src/tui/panes/filetree/git.ts
@@ -100,7 +100,13 @@ export async function listFiles(worktreePath: string, signal?: AbortSignal): Pro
     worktreePath,
     signal,
   )
-  const lines = out.split("\n").map((l) => l.replace(/\r$/, ""))
+  // `unquoteGitPath` for the same reason the porcelain parser calls it:
+  // git octal-escapes any non-ASCII byte in a path by default, so
+  // `文档/设计/笔记.md` arrives as `"\346\226\207…"`, quotes and all. The
+  // Changes tab has always decoded it; the All tab did not, so a Chinese
+  // filename — the ordinary case in a zh-default product — rendered as
+  // escape gibberish that no width budget can rescue.
+  const lines = out.split("\n").map((l) => unquoteGitPath(l.replace(/\r$/, "")))
   // De-dup: --cached + --others can in theory list the same file twice
   // when the working tree has both an index entry and an untracked
   // counterpart — rare but possible during merges.

--- a/packages/kobe/src/tui/panes/filetree/rows.ts
+++ b/packages/kobe/src/tui/panes/filetree/rows.ts
@@ -17,8 +17,9 @@
  * native churn drops to "rows that actually changed".
  */
 
+import { charWidth } from "@/lib/display-width"
 import { reconcileStableRows } from "@/tui/lib/stable-rows"
-import { truncateStart } from "@/tui/lib/truncate"
+import { truncateStartCells } from "@/tui/lib/truncate"
 import type { FileStatus, StatusEntry } from "./git"
 import type { TreeNode } from "./tree"
 
@@ -67,12 +68,20 @@ export function flattenTree(node: TreeNode, expanded: ReadonlySet<string>, depth
  * Truncate a path keeping its TAIL — the leaf (filename) carries the
  * meaning, so on a narrow pane we drop the leading directories and show
  * `…components/sidebar/Sidebar.tsx` rather than clipping the filename off
- * the right. Thin alias over the shared {@link truncateStart} owner, which
- * counts by code point so a surrogate pair (emoji / astral char in a
- * filename) is never bisected into a `�` replacement glyph.
+ * the right. Thin alias over the shared {@link truncateStartCells} owner,
+ * which never bisects a surrogate pair (emoji / astral char in a filename)
+ * into a replacement glyph.
+ *
+ * `maxCells` is a CELL budget, not a code-point count, because the caller
+ * (`computePathBudget`) derives it from the pane's real width and the row
+ * has a hard right edge: the status glyph, the `+N`/`−N` stat columns and
+ * the pane border all sit there. A Chinese path spends 2 cells per glyph,
+ * so counting code points here let `文档/设计/终端渲染说明书笔记.md` (18 code
+ * points, 31 cells) "fit" a 26-cell budget and draw through the border into
+ * the workspace pane, dragging the stat columns out of alignment with it.
  */
-export function truncatePathTail(path: string, max: number): string {
-  return truncateStart(path, max)
+export function truncatePathTail(path: string, maxCells: number): string {
+  return truncateStartCells(path, maxCells, charWidth)
 }
 
 const NO_EXPANSION: ReadonlySet<string> = new Set()

--- a/packages/kobe/test/architecture/no-tmux-runtime.test.ts
+++ b/packages/kobe/test/architecture/no-tmux-runtime.test.ts
@@ -9,6 +9,14 @@ const SRC_ROOT = fileURLToPath(new URL("../../src", import.meta.url))
 const RETIRED_ROOT = join(SRC_ROOT, "tmux")
 const LEGACY_COMPAT = join(SRC_ROOT, "cli", "legacy-tmux.ts")
 const LEGACY_IMPORTERS = new Set([join(SRC_ROOT, "cli", "doctor-cmd.ts"), join(SRC_ROOT, "cli", "reset-cmd.ts")])
+/**
+ * Files allowed to NAME tmux without hosting it. The guard exists to keep the
+ * retired tmux RUNTIME out of the shipped product; reporting that the USER is
+ * running inside a multiplexer is the opposite of that — Rove spawns nothing,
+ * it reads an env var so a keyboard bug report can rule the multiplexer out.
+ * Losing that line was collateral damage when the runtime went away.
+ */
+const DIAGNOSTIC_NAMERS = new Set([join(SRC_ROOT, "cli", "doctor-terminal.ts")])
 
 function sourceFiles(dir: string, files: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -36,7 +44,8 @@ describe("Hosted PTY-only runtime boundary", () => {
             /^\s*(?:import|export)\b.*\bfrom\s*["'][^"']*tmux/i.test(line) || /\bimport\(\s*["'][^"']*tmux/i.test(line)
           const namesTmuxBinary = /["']tmux["']/.test(line)
           if (importsLegacyCompat) return !LEGACY_IMPORTERS.has(file)
-          return importsTmux || (namesTmuxBinary && file !== LEGACY_COMPAT)
+          if (importsTmux) return true
+          return namesTmuxBinary && file !== LEGACY_COMPAT && !DIAGNOSTIC_NAMERS.has(file)
         })
       })
       .map((file) => relative(SRC_ROOT, file))

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -133,6 +133,21 @@ describe("runDoctorSubcommand", () => {
     expect(output()).toContain("legacy tmux: tmux 3.6b — no sessions on `kobe`")
   })
 
+  it("prints the whole terminal section, multiplexer and kitty probe included", async () => {
+    // Regression guard: the section shrank to a single env line when the tmux
+    // RUNTIME was removed (b5e3bfd2a) — collateral damage, since multiplexer
+    // NESTING and the kitty probe were never about Rove hosting tmux. The
+    // consequence is real: docs/KEYBINDINGS.md says both split chords need
+    // the kitty protocol, so with the probe gone doctor could not answer a
+    // "split doesn't work" report at all.
+    mocks.request.mockResolvedValue(null)
+    await runDoctorSubcommand([])
+    const text = output()
+    expect(text).toContain("terminal: TERM=")
+    expect(text).toContain("running inside a multiplexer:")
+    expect(text).toContain("kitty keyboard protocol:")
+  })
+
   it("reports legacy process counts and RSS from a single inspect pass", async () => {
     mocks.request.mockRejectedValue(new Error("not running"))
     mocks.inspectLegacyTmux.mockResolvedValue({

--- a/packages/kobe/test/cli/doctor-terminal.test.ts
+++ b/packages/kobe/test/cli/doctor-terminal.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `rove doctor` terminal section — pure halves only (env formatting + kitty
+ * probe reply parsing). Why this matters: keyboard bugs are terminal-
+ * dependent (Terminal.app's legacy key path breaks ctrl+h/j, and the two
+ * split chords in docs/KEYBINDINGS.md need the kitty protocol outright), and
+ * doctor's terminal line is how a reporter tells us which key path they are
+ * on without a screen recording. The live TTY probe is I/O-thin and untested
+ * by design.
+ */
+
+import { describe, expect, test } from "vitest"
+import { kittyProbeLine, multiplexerLabel, parseKittyProbeReply, terminalEnvLines } from "../../src/cli/doctor-terminal"
+
+describe("terminalEnvLines", () => {
+  test("formats TERM / TERM_PROGRAM(+version) / COLORTERM and multiplexer nesting", () => {
+    const lines = terminalEnvLines({
+      TERM: "xterm-256color",
+      TERM_PROGRAM: "Apple_Terminal",
+      TERM_PROGRAM_VERSION: "453",
+      COLORTERM: undefined,
+      TMUX: "/tmp/tmux-501/kobe,123,0",
+    })
+    expect(lines[0]).toBe("terminal: TERM=xterm-256color  TERM_PROGRAM=Apple_Terminal v453  COLORTERM=(unset)")
+    expect(lines[1]).toBe("          running inside a multiplexer: tmux")
+  })
+
+  test("everything unset stays readable", () => {
+    const lines = terminalEnvLines({})
+    expect(lines[0]).toBe("terminal: TERM=(unset)  TERM_PROGRAM=(unset)  COLORTERM=(unset)")
+    expect(lines[1]).toBe("          running inside a multiplexer: no")
+  })
+})
+
+describe("multiplexerLabel", () => {
+  test("names whichever multiplexer wrapped the session", () => {
+    // Rove dropped its own tmux RUNTIME, but a user running Rove inside one
+    // still gets their keys rewritten on the way in — the confound a
+    // keyboard report has to rule out. All three set a marker.
+    expect(multiplexerLabel({ TMUX: "/tmp/tmux-501/default,1,0" })).toBe("tmux")
+    expect(multiplexerLabel({ ZELLIJ: "0" })).toBe("zellij")
+    expect(multiplexerLabel({ STY: "1234.pts-0.host" })).toBe("screen")
+    expect(multiplexerLabel({})).toBe("no")
+  })
+})
+
+describe("parseKittyProbeReply", () => {
+  test("kitty flags reply → supported with parsed flags", () => {
+    expect(parseKittyProbeReply("\x1b[?1u")).toEqual({ kind: "supported", flags: 1 })
+    expect(parseKittyProbeReply("\x1b[?31u\x1b[?62;c")).toEqual({ kind: "supported", flags: 31 })
+  })
+
+  test("DA1 reply without a kitty reply → unsupported (the fence answered first)", () => {
+    expect(parseKittyProbeReply("\x1b[?62;22;52c")).toEqual({ kind: "unsupported" })
+    expect(parseKittyProbeReply("\x1b[?1;2c")).toEqual({ kind: "unsupported" })
+  })
+
+  test("partial buffer → null (keep reading)", () => {
+    expect(parseKittyProbeReply("")).toBeNull()
+    expect(parseKittyProbeReply("\x1b[?6")).toBeNull()
+  })
+})
+
+describe("kittyProbeLine", () => {
+  test("one line per outcome, unsupported names the legacy-key consequence", () => {
+    expect(kittyProbeLine({ kind: "supported", flags: 1 })).toContain("✓ answered (flags=1)")
+    const unsupported = kittyProbeLine({ kind: "unsupported" })
+    expect(unsupported).toContain("legacy key path")
+    // Names the consequence a "split doesn't work" report is actually about
+    // — docs/KEYBINDINGS.md says both split chords require this protocol.
+    expect(unsupported).toContain("ctrl+=")
+    expect(unsupported).toContain("ctrl+\\")
+    expect(kittyProbeLine({ kind: "no-response" })).toContain("no reply")
+    expect(kittyProbeLine({ kind: "skipped", reason: "not an interactive terminal" })).toContain(
+      "skipped (not an interactive terminal)",
+    )
+  })
+})

--- a/packages/kobe/test/render/filetree-cjk-overflow.test.tsx
+++ b/packages/kobe/test/render/filetree-cjk-overflow.test.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * A Changes row must not draw past the file pane's right edge — measured on
+ * the real frame, in cells, with a real Chinese path.
+ *
+ * Rove defaults to Simplified Chinese, so a CJK path is the ordinary case,
+ * not an exotic one. The row's budget (`computePathBudget`) has always been
+ * in CELLS, but it used to be SPENT by a code-point counter: a 26-cell budget
+ * "fitted" `文档/设计/终端渲染说明书笔记.md` at 18 code points and drew its 31
+ * cells, five of them through the border and onto the workspace pane, taking
+ * the `+N`/`−N` stat columns with it.
+ *
+ * Asserting the truncated STRING would not catch that — the string is the
+ * same either way until you ask what it costs. So the assertion is on the
+ * grid: every rendered line stays inside the pane's width. An ASCII path is
+ * green with the bug present, which is exactly why it can't be the test.
+ */
+
+import { expect, test } from "bun:test"
+import { execSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { displayWidth } from "../../src/lib/display-width"
+import { FileTree } from "../../src/tui-react/panes/filetree/FileTree"
+import { act, renderComponent, settle } from "./harness"
+
+/** The file pane at its widest; `computePathBudget` leaves 26 cells here. */
+const PANE_WIDTH = 34
+
+function repoWith(path: string): string {
+  const repo = mkdtempSync(join(tmpdir(), "kobe-cjk-"))
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: repo })
+  const file = join(repo, path)
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, "hello\n")
+  execSync("git add -A && git -c user.email=t@t -c user.name=t commit -q -m add", { cwd: repo })
+  // Modify it so the row lands on the Changes tab with real +N/−N stats.
+  writeFileSync(file, "hello\nworld\nagain\n")
+  return repo
+}
+
+async function changesFrame(repo: string, marker: string): Promise<string> {
+  const { frame, mockInput } = await renderComponent(
+    <FileTree worktreePath={repo} onOpenFile={() => {}} focused={true} paneWidth={PANE_WIDTH} />,
+    { width: PANE_WIDTH, height: 20 },
+  )
+  act(() => mockInput.pressKey("]")) // → Changes tab
+  let text = ""
+  for (let i = 0; i < 40 && !text.includes(marker); i++) {
+    await settle(100)
+    text = await frame()
+  }
+  return text
+}
+
+test("a CJK Changes row stays inside the pane's cell width", async () => {
+  const path = "文档/设计/终端渲染说明书笔记.md"
+  // The trap in one line: fewer code points than the budget, more cells.
+  expect([...path].length).toBeLessThan(26)
+  expect(displayWidth(path)).toBeGreaterThan(26)
+
+  const text = await changesFrame(repoWith(path), ".md")
+  expect(text).toContain(".md") // the row rendered at all
+  // Real CJK glyphs, not git's octal escaping: `git status --porcelain`
+  // emits `"\346\226\207…"` by default and `unquoteGitPath` decodes it —
+  // so this also pins that the wide-glyph path really reaches the renderer.
+  expect(text).toContain("笔记.md")
+  for (const line of text.split("\n")) {
+    expect(displayWidth(line.replace(/\s+$/, ""))).toBeLessThanOrEqual(PANE_WIDTH)
+  }
+})
+
+test("the All tab shows a CJK filename, not git's octal escaping", async () => {
+  // Sibling of the row above, one code path over: the Changes tab decoded
+  // `"\346\226\207…"` through `unquoteGitPath`, the All tab did not — so a
+  // Chinese filename rendered as escape gibberish no width budget can save.
+  const repo = repoWith("文档/设计/终端渲染说明书笔记.md")
+  const { frame } = await renderComponent(
+    <FileTree worktreePath={repo} onOpenFile={() => {}} focused={true} paneWidth={PANE_WIDTH} />,
+    { width: PANE_WIDTH, height: 20 },
+  )
+  let text = ""
+  for (let i = 0; i < 40 && !text.includes("文档"); i++) {
+    await settle(100)
+    text = await frame()
+  }
+  expect(text).toContain("文档")
+  expect(text).not.toContain("\\346")
+  for (const line of text.split("\n")) {
+    expect(displayWidth(line.replace(/\s+$/, ""))).toBeLessThanOrEqual(PANE_WIDTH)
+  }
+})
+
+test("an ASCII path of the same length is unchanged", async () => {
+  // The desktop-layout guard: 1 cell per glyph spends what it always did.
+  const text = await changesFrame(repoWith("docs/design/terminal-notes.md"), "terminal-notes")
+  expect(text).toContain("terminal-notes.md")
+  for (const line of text.split("\n")) {
+    expect(displayWidth(line.replace(/\s+$/, ""))).toBeLessThanOrEqual(PANE_WIDTH)
+  }
+})

--- a/packages/kobe/test/render/new-task-short-terminal.test.tsx
+++ b/packages/kobe/test/render/new-task-short-terminal.test.tsx
@@ -1,0 +1,66 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * On a 24-row terminal the new-task dialog must still show its Create button
+ * and its error line.
+ *
+ * `Dialog` caps the card at the viewport and nothing scrolls it — a card
+ * taller than the cap is simply clipped. With a fixed 8-row picker window the
+ * Existing tab was ~26 rows against a cap of 20, so the bottom six went away:
+ * the Create button, and `submitError` with it. The keyboard path still
+ * worked (Enter on the last field), so a failed create rendered its message
+ * into rows that did not exist and read as nothing happening at all.
+ *
+ * The measurement has to be the real frame at a real height — the pure
+ * `pickerVisibleRows` test cannot see whether the component calls it.
+ */
+
+import { expect, test } from "bun:test"
+import { execSync } from "node:child_process"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { NewTaskDialogView } from "../../src/tui-react/component/new-task-dialog/dialog"
+import { act, renderComponent, settle } from "./harness"
+
+/** A repo with more branches than any window will show. */
+function repoWithBranches(count: number): string {
+  const repo = mkdtempSync(join(tmpdir(), "kobe-shortterm-"))
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: repo })
+  for (let i = 0; i < count; i++) execSync(`git branch feature/branch-name-${i}`, { cwd: repo })
+  return repo
+}
+
+/** Mount at `height`, tab to the branch field and clear its filter so the
+ *  picker opens at full length — the tallest the Existing tab ever gets. */
+async function withBranchPickerOpen(repo: string, height: number): Promise<string> {
+  const { frame, mockInput } = await renderComponent(
+    <NewTaskDialogView defaultRepo={repo} savedRepos={[]} onSubmit={() => {}} onCancel={() => {}} />,
+    { width: 100, height, providers: { kv: true, dialog: true } },
+  )
+  for (let i = 0; i < 3; i++) {
+    act(() => mockInput.pressTab())
+    await settle()
+  }
+  for (let i = 0; i < 8; i++) {
+    act(() => mockInput.pressBackspace())
+    await settle()
+  }
+  return await frame()
+}
+
+test("24 rows: the Create button survives a full branch picker", async () => {
+  const text = await withBranchPickerOpen(repoWithBranches(20), 24)
+  expect(text).toContain("Create")
+  // The picker is still there and still says how much it is hiding.
+  expect(text).toContain("more")
+  // Both field labels survive too — they were the first rows to merge away.
+  expect(text).toContain("repo")
+  expect(text).toContain("from branch")
+})
+
+test("a tall terminal is unchanged — the full 8-row window still renders", async () => {
+  const text = await withBranchPickerOpen(repoWithBranches(20), 40)
+  expect(text).toContain("Create")
+  const shown = text.split("\n").filter((l) => l.includes("feature/branch-name-")).length
+  expect(shown).toBeGreaterThanOrEqual(7)
+})

--- a/packages/kobe/test/render/picker-window-fits-viewport.test.tsx
+++ b/packages/kobe/test/render/picker-window-fits-viewport.test.tsx
@@ -1,0 +1,123 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Both branch pickers must fit the terminal they are drawn in.
+ *
+ * They share `windowAround` + `pickerVisibleRows`, and the dialog card is
+ * capped at the viewport with nothing to scroll it — so a window sized
+ * independently of the height pushes the card's own bottom rows off the
+ * screen. This mounts the REAL dialogs at a short and a tall viewport: the
+ * pure test cannot see whether a component actually calls the helper, and an
+ * uncalled helper renders exactly like the bug.
+ */
+
+import { expect, test } from "bun:test"
+import { execSync } from "node:child_process"
+import { mkdirSync, mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BranchPickerDialogView } from "../../src/tui-react/component/branch-picker-dialog"
+import { NewTaskDialogView } from "../../src/tui-react/component/new-task-dialog/dialog"
+import { PICKER_MAX_VISIBLE } from "../../src/tui/component/new-task-dialog/state"
+import { act, renderComponent, settle } from "./harness"
+
+/** More branches than any window will show, so the cap is what bounds it. */
+function repoWithBranches(count: number): string {
+  const repo = mkdtempSync(join(tmpdir(), "kobe-picker-"))
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: repo })
+  for (let i = 0; i < count; i++) execSync(`git branch feature/branch-name-${i}`, { cwd: repo })
+  return repo
+}
+
+/** Picker rows in a frame: the cursor row (`▸ `) plus its indented siblings,
+ *  excluding the `↑/↓ N more` overflow lines, which are chrome, not entries. */
+const branchRows = (frame: string): number =>
+  frame.split("\n").filter((l) => /^\s+(▸ )?(main|feature\/)/.test(l)).length
+
+test("the set-branch dialog shrinks its picker on a short terminal", async () => {
+  const repo = repoWithBranches(20)
+  async function rowsAt(height: number): Promise<{ rows: number; frame: string }> {
+    const { frame } = await renderComponent(
+      <BranchPickerDialogView currentBranch="" repo={repo} onSubmit={() => {}} onCancel={() => {}} />,
+      { width: 100, height, providers: { dialog: true } },
+    )
+    const text = await frame()
+    return { rows: branchRows(text), frame: text }
+  }
+
+  const short = await rowsAt(24)
+  const tall = await rowsAt(40)
+  expect(tall.rows).toBeGreaterThan(short.rows) // the window followed the height
+  expect(short.rows).toBeGreaterThanOrEqual(2) // still a list, still scrollable
+  // The overflow line stays honest about what is hidden, at both heights.
+  expect(short.frame).toContain("more")
+  expect(tall.frame).toContain("more")
+})
+
+/**
+ * The clone tab's parent-dir picker, over a directory WE build — the machine's
+ * real `/` would make the row count depend on the host.
+ */
+function dirWithChildren(count: number): string {
+  const parent = mkdtempSync(join(tmpdir(), "kobe-clonetab-"))
+  for (let i = 0; i < count; i++) mkdirSync(join(parent, `child-${String(i).padStart(2, "0")}`))
+  return parent
+}
+
+async function cloneTabFrame(height: number, parent: string): Promise<string> {
+  // Own KV home per mount: `KVProvider` reads `$KOBE_HOME_DIR`, and the clone
+  // tab persists its parent dir there.
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-clonehome-"))
+  const { frame, mockInput } = await renderComponent(
+    <NewTaskDialogView
+      defaultRepo={tmpdir()}
+      savedRepos={[]}
+      defaultCloneParent={`${parent}/`}
+      onSubmit={() => {}}
+      onCancel={() => {}}
+    />,
+    { width: 100, height, providers: { kv: true, dialog: true } },
+  )
+  act(() => mockInput.pressKey("]", { ctrl: true })) // → For New Repo
+  await settle()
+  act(() => mockInput.pressTab()) // → parent dir (the tab selector holds focus on open)
+  await settle()
+  // `typeText` is ASYNC — `act(() => …)` around it leaves the promise
+  // unawaited, and the resulting act-scope leak makes EVERY later render test
+  // in the run read a stale frame (105 phantom failures when this file landed
+  // mid-suite). Await the promise inside an async act instead.
+  await act(async () => {
+    await mockInput.typeText("c") // browse the children we just made
+  })
+  await settle(400)
+  return await frame()
+}
+
+/** Picker rows: the indented `<name>/` entries, excluding the `↓ N more`
+ *  overflow line and the muted "(remembered …)" hint above the list. */
+const dirRows = (frame: string): number => frame.split("\n").filter((l) => /child-\d\d\//.test(l)).length
+
+test("the clone tab's parent-dir picker fits a 24-row terminal", async () => {
+  // Same fixed window, one tab over — `use-clone-state` owns this one.
+  const text = await cloneTabFrame(24, dirWithChildren(20))
+  expect(text).toContain("Create") // the card's own bottom row survived
+  // The window SHRANK: the default cap is 8, and 24 rows leaves room for far
+  // fewer. Asserting only "some rows and an overflow line" would pass with the
+  // fixed cap too, since 20 children overflow either way.
+  const shown = dirRows(text)
+  expect(shown).toBeGreaterThanOrEqual(1) // still a usable list
+  expect(shown).toBeLessThan(PICKER_MAX_VISIBLE) // …but not the desktop window
+  // …and the overflow line accounts for every entry the window hides. The
+  // typed `c` is consumed as the path prefix being browsed, so the list is
+  // the 19 siblings of the one the cursor sits on.
+  const hidden = Number(text.match(/↓ (\d+) more/)?.[1] ?? "0")
+  expect(shown + hidden).toBe(19)
+})
+
+// Scope note, so the next reader does not over-trust the clone test above:
+// at 24 rows the clone card is short enough that Yoga clamps its picker to one
+// row on its own, so that test does NOT discriminate whether `use-clone-state`
+// passes the cap — removing the argument renders an identical frame. It pins
+// the user-visible contract (a usable list, an honest overflow count, and a
+// reachable Create button); the CAP ITSELF is pinned by the set-branch test
+// above, which drives the same helper at two heights and does go red when the
+// window stops following the viewport.

--- a/packages/kobe/test/render/settings-keybindings-create.test.tsx
+++ b/packages/kobe/test/render/settings-keybindings-create.test.tsx
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { SettingsDialog } from "../../src/tui-react/component/settings-dialog"
 import { useKV } from "../../src/tui-react/context/kv"
+import { reloadUserKeybindings } from "../../src/tui/context/keybindings-user"
 import { act, renderComponent, settle } from "./harness"
 
 const NOOP = (): void => {}
@@ -23,6 +24,13 @@ function Driver() {
 test("the Keybindings page writes the starter YAML on enter", async () => {
   const home = mkdtempSync(join(tmpdir(), "kobe-keys-create-"))
   process.env.KOBE_HOME_DIR = home
+  // `userKeybindingsReport()` memoizes the resolved path on first call, and
+  // bun runs every render test in ONE process — so any earlier test that
+  // mounted Settings already froze that path against ITS temp home, and the
+  // create action would write there instead of here. Dropping the cache
+  // after the env var is set makes this test isolated instead of dependent
+  // on being the first Settings mount in the run.
+  reloadUserKeybindings()
   const yaml = join(home, ".rove", "settings", "keybindings.yaml")
   expect(existsSync(yaml)).toBe(false)
 

--- a/packages/kobe/test/render/settings-narrow-width.test.tsx
+++ b/packages/kobe/test/render/settings-narrow-width.test.tsx
@@ -1,0 +1,44 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Settings must stay usable at the width `docs/TUI.md` promises (46 columns,
+ * phone SSH). The row math lives in `generalLabelLayout`; this mounts the
+ * REAL dialog to prove it is actually wired to the live terminal width —
+ * a correct helper nobody calls renders exactly like the bug.
+ *
+ * The visible symptom was a label padded to 30 cells inside a 26-cell row:
+ * `Row` is `overflow="hidden"` + `wrapMode="none"`, so the label was cut with
+ * no ellipsis and the hint beside it never appeared at all.
+ */
+
+import { expect, test } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SettingsDialog } from "../../src/tui-react/component/settings-dialog"
+import { useKV } from "../../src/tui-react/context/kv"
+import { renderComponent } from "./harness"
+
+function Driver() {
+  const kv = useKV()
+  return <SettingsDialog kv={kv} onClose={() => {}} />
+}
+
+async function generalAt(width: number): Promise<string> {
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-narrow-"))
+  const { frame } = await renderComponent(<Driver />, { width, height: 42, providers: { kv: true, dialog: true } })
+  return await frame()
+}
+
+test("at 46 columns the label renders whole instead of being cut mid-word", async () => {
+  const text = await generalAt(46)
+  // The longest General label, previously clipped by its own padding.
+  expect(text).toContain("Show keyboard hints")
+  // Its inline hint is dropped rather than rendered as a clipped fragment.
+  expect(text).not.toContain("re-enabling relights")
+})
+
+test("a desktop width still shows label and hint side by side", async () => {
+  const text = await generalAt(110)
+  expect(text).toContain("Show keyboard hints")
+  expect(text).toContain("re-enabling relights hints dismissed by use")
+})

--- a/packages/kobe/test/tui-react/picker-visible-rows.test.ts
+++ b/packages/kobe/test/tui-react/picker-visible-rows.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The new-task dialog's picker window has to follow the viewport height.
+ *
+ * `Dialog` sizes its card to content under a `maxCardHeight` cap and nothing
+ * scrolls it — its own comment says tall cards "hit the cap and clip". The
+ * picker window was a flat 8 rows regardless of terminal height, which made
+ * the dialog's height a constant while the room for it was not. On a 24-row
+ * terminal the Existing tab overran the cap and the bottom rows went with
+ * it: the Create button, and `submitError` — so a failed create looked like
+ * nothing happening at all.
+ */
+
+import { describe, expect, test } from "vitest"
+import { PICKER_MAX_VISIBLE, pickerVisibleRows, windowAround } from "../../src/tui/component/new-task-dialog/state.ts"
+
+describe("pickerVisibleRows", () => {
+  test("a tall terminal keeps the full window — desktop layout unchanged", () => {
+    expect(pickerVisibleRows(40)).toBe(PICKER_MAX_VISIBLE)
+    expect(pickerVisibleRows(60)).toBe(PICKER_MAX_VISIBLE)
+  })
+
+  test("24 rows — the regression height — yields a window the card can hold", () => {
+    expect(pickerVisibleRows(24)).toBeLessThan(PICKER_MAX_VISIBLE)
+    expect(pickerVisibleRows(24)).toBeGreaterThanOrEqual(2)
+  })
+
+  test("never returns fewer than two rows, however short the terminal", () => {
+    // Two rows plus the `↓ N more` line still reads as a list and still
+    // scrolls under the cursor, so no entry becomes unreachable.
+    for (const h of [0, 1, 10, 18, 20]) expect(pickerVisibleRows(h)).toBeGreaterThanOrEqual(2)
+  })
+
+  test("monotonic in height — a taller terminal never shows fewer rows", () => {
+    for (let h = 10; h < 60; h++) expect(pickerVisibleRows(h + 1)).toBeGreaterThanOrEqual(pickerVisibleRows(h))
+  })
+
+  test("a shrunk window still reaches every entry by scrolling", () => {
+    const list = Array.from({ length: 30 }, (_, i) => `branch-${i}`)
+    const cap = pickerVisibleRows(24)
+    // The cursor is always inside its own window, at both ends and in between.
+    for (const cursor of [0, 7, 15, 29]) {
+      const w = windowAround(list, cursor, cap)
+      expect(w.items.length).toBe(cap)
+      expect(cursor).toBeGreaterThanOrEqual(w.start)
+      expect(cursor).toBeLessThan(w.start + w.items.length)
+      expect(w.total).toBe(30) // the `↓ N more` count stays honest
+    }
+  })
+})

--- a/packages/kobe/test/tui-react/settings-label-layout.test.ts
+++ b/packages/kobe/test/tui-react/settings-label-layout.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The General section's label column is a budget, not a constant.
+ *
+ * Its rows are `overflow="hidden"` + `wrapMode="none"`, so overspending is a
+ * silent hard cut — no ellipsis says it happened. The column used to be a
+ * flat 30 cells regardless of terminal width, which did the most damage
+ * exactly where there was least room: `docs/TUI.md` promises phone SSH down
+ * to 46 columns, and at 46 the row owns 26 cells, so the padding alone
+ * overran it and took the label with it.
+ */
+
+import { describe, expect, test } from "vitest"
+import { LABEL_COLUMN_MAX, generalLabelLayout } from "../../src/tui/component/settings-dialog/model.ts"
+
+/** Cells a row actually owns: width − dialog padding − sidebar − gap − Row padding. */
+const rowCells = (width: number, padX: number) => width - padX * 2 - 14 - 2 - 2
+
+describe("generalLabelLayout", () => {
+  test("a desktop terminal keeps the full aligned column and its hints", () => {
+    expect(generalLabelLayout(110, 2)).toEqual({ labelColumn: LABEL_COLUMN_MAX, showHint: true })
+    expect(generalLabelLayout(80, 2)).toEqual({ labelColumn: LABEL_COLUMN_MAX, showHint: true })
+  })
+
+  test("46 columns (phone SSH, narrow padding): drops the hint, stops padding", () => {
+    // The regression. 46 − 2 − 14 − 2 − 2 = 26 cells for the whole row, so a
+    // 30-cell pad overran it by 4 before any hint text existed.
+    expect(rowCells(46, 1)).toBe(26)
+    const { labelColumn, showHint } = generalLabelLayout(46, 1)
+    expect(showHint).toBe(false)
+    expect(labelColumn).toBe(0) // natural width, nothing cut
+  })
+
+  test("50 columns: the width where a 30-cell pad consumed the budget exactly", () => {
+    // rowCells === 30 here, so the old code left the hint structurally
+    // unreachable — never clipped, never rendered.
+    expect(rowCells(50, 1)).toBe(30)
+    expect(generalLabelLayout(50, 1).showHint).toBe(false)
+  })
+
+  test("the label column never exceeds what the row owns", () => {
+    for (let width = 30; width <= 200; width++) {
+      for (const padX of [1, 2]) {
+        const { labelColumn, showHint } = generalLabelLayout(width, padX)
+        const cells = rowCells(width, padX)
+        expect(labelColumn).toBeLessThanOrEqual(Math.max(0, cells))
+        // Whenever a hint is shown, at least 18 cells are left for it.
+        if (showHint) expect(cells - labelColumn).toBeGreaterThanOrEqual(18)
+      }
+    }
+  })
+
+  test("in between, the hint keeps its share and the label takes the rest", () => {
+    const { labelColumn, showHint } = generalLabelLayout(64, 2)
+    expect(showHint).toBe(true)
+    expect(labelColumn).toBeLessThan(LABEL_COLUMN_MAX) // shrunk, not dropped
+    expect(labelColumn).toBeGreaterThan(0)
+  })
+})

--- a/packages/kobe/test/tui/filetree-rows.test.ts
+++ b/packages/kobe/test/tui/filetree-rows.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, expect, test } from "vitest"
+import { displayWidth } from "../../src/lib/display-width.ts"
 import {
   type Row,
   reconcileRows,
@@ -106,10 +107,34 @@ describe("truncatePathTail", () => {
   })
 
   test("never bisects a surrogate pair — emoji stay intact", () => {
-    // Each 🎉 is one code point but two UTF-16 code units. Counting by code
-    // point keeps the tail on a character boundary; the old `.slice` by
-    // .length would start mid-emoji and emit a lone surrogate (→ �).
-    expect(truncatePathTail("src/aaaaa-🎉🎉🎉.ts", 8)).toBe("…-🎉🎉🎉.ts")
+    // Each 🎉 is one code point, two UTF-16 code units, and TWO CELLS. The
+    // budget is cells: 8 less one for the `…` leaves 7, which buys `.ts` (3)
+    // and two 🎉 (4). A third would need 9. Whatever the budget, the cut
+    // lands on a character boundary — a `.slice` by .length would start
+    // mid-emoji and emit a lone surrogate (→ the replacement glyph).
+    expect(truncatePathTail("src/aaaaa-🎉🎉🎉.ts", 8)).toBe("…🎉🎉.ts")
+  })
+
+  test("spends the budget in CELLS, so a CJK path cannot overrun the pane", () => {
+    // THE regression this owns. `文档/设计/终端渲染说明书笔记.md` is 18 code
+    // points but 31 cells; a file pane 34 wide budgets 26. Counting code
+    // points said "18 ≤ 26, fits" and drew 31 cells — five straight through
+    // the pane border and into the workspace beside it.
+    const path = "文档/设计/终端渲染说明书笔记.md"
+    expect([...path].length).toBeLessThan(26) // why the code-point check passed
+    expect(displayWidth(path)).toBe(31) // what it actually costs
+    expect(displayWidth(truncatePathTail(path, 26))).toBeLessThanOrEqual(26)
+    // The leaf survives; only the leading directories elide.
+    expect(truncatePathTail(path, 26)).toContain(".md")
+    expect(truncatePathTail(path, 26).startsWith("…")).toBe(true)
+  })
+
+  test("an ASCII path of the same code-point count is unaffected", () => {
+    // The guard against a CJK-only fix: a 1-cell-per-glyph path spends
+    // exactly what it did before, so the desktop layout is byte-identical.
+    const ascii = "docs/design/terminal-rendering-notes.md"
+    expect(truncatePathTail(ascii, 26)).toBe("…rminal-rendering-notes.md")
+    expect(displayWidth(truncatePathTail(ascii, 26))).toBe(26)
   })
 
   test("max <= 0 leaves no room, so yields the empty string", () => {


### PR DESCRIPTION
Four places assumed the developer's terminal — truecolor, kitty protocol, wide, tall. Real users have none of those guaranteed.

## 1. The Changes tab overran the pane on a CJK path

`computePathBudget` has always been in **cells**, but `truncatePathTail` spent that budget by counting **code points**. `文档/设计/终端渲染说明书笔记.md` is 18 code points and 31 cells; against the 26-cell budget of a 34-wide pane the code-point check said "fits" and the row drew five cells through the border onto the workspace, dragging the `+N`/`−N` columns out of alignment.

Paths now truncate through `truncateStartCells` — the tail-keeping twin of the `truncateEndCells` the sidebar, tab strip, toasts and Inbox already use. The row's other segments (`▾ ` marker, `(12)` count, indent) spend the same budget in cells rather than `.length`.

Found while photographing this: the **All** tab never called `unquoteGitPath`, so git's default octal escaping reached the renderer and a Chinese filename displayed as `"\346\226\207..."`. The Changes tab has always decoded it. One line, same class of bug, so it is fixed here.

## 2. Settings was unusable below 50 columns

The label column was padded to a flat 30 cells regardless of width. A row owns `width − 2·padX − 14 (section sidebar) − 2 (gap) − 2 (Row padding)` — **26 cells at 46 columns**, the width [`docs/TUI.md`](docs/TUI.md#narrow-terminals-phone-ssh) promises for phone SSH. `Row` is `overflow="hidden"` + `wrapMode="none"`, so the padding alone overran the row and cut the label with no ellipsis to say so. At exactly 50 the padding consumed the budget, leaving the hint structurally unreachable — never clipped, never rendered.

`generalLabelLayout` makes the column a **maximum, not a floor**: full 30 with room for both; shrunk with the hint holding its 18 cells in between; and below that the hint is dropped **whole** rather than clipped to a fragment. A clipped half-sentence beside a clipped label reads as corruption; the SubSection paragraph above each group still explains it.

## 3. The new-task dialog clipped its own Create button at 24 rows

`Dialog` caps the card at the viewport and **nothing scrolls it** (its own comment: tall cards "hit the cap and clip"). The picker window was a fixed 8 rows, so the dialog's height was a constant while the room for it was not. At 24 rows the Existing tab ran ~26 rows against a cap of 20 and the bottom six went away — including `submitError`, so **a failed create looked like nothing happening at all**.

`pickerVisibleRows` follows the viewport down to a floor of 2. The list was already windowed and scrolls under the cursor, so a shorter window costs only how much is visible, never reachability. The branch picker and the clone/adopt tabs shared the same fixed window and are fixed with it.

Chose shrinking over adding a scrollbox: it is the smaller change, and a scrollbox would put the Create button behind a scroll gesture on exactly the terminals with the least room.

## 4. `rove doctor` had lost the terminal diagnosis its own changelog promises

`CHANGELOG.md:3435` advertises "tmux nesting, live kitty-keyboard-protocol probe". Both were deleted in `b5e3bfd2a` ("Remove tmux and make PureTUI the only runtime") — collateral damage: multiplexer *nesting* was never about Rove *hosting* tmux. `docs/KEYBINDINGS.md` says both split chords require the kitty protocol, so with the probe gone doctor could not answer a "split doesn't work" report at all.

Restored from history, generalized to all three multiplexers (tmux/zellij/screen — all rewrite keys on the way in), and the unsupported line now names the split-chord consequence. The architecture guard that forbids `tmux` outside one seam gets a **narrow, documented exception**: it still blocks every `import … from "*tmux"` and `KOBE_TMUX`, permitting only the literal string in this one diagnostic file.

## Verification

- `bun run test:fast` 398/398 files; `bun test test/render` 298/298
- Every fix passed **remove-the-fix → tests go red**, twice each, at two different sites (the pure helper, and the wiring point that calls it), re-run after rebase
- Test #1 asserts **cells on the real rendered frame with a real Chinese path** — an ASCII path is green with the bug present, so it cannot be the test
- Before/after captured through the one ground-truth path (browser `/harness` → xterm.js → PTY sidecar → real OpenTUI) at the sizes in question: 46 columns and 24 rows
- Fixed a latent test-isolation bug this exposed: `userKeybindingsReport()` memoizes its path, so `settings-keybindings-create` silently depended on being the first Settings mount in the run

**Before/after** (real TUI, `/harness`): `/tmp/shots/terminal-adaptation/`

| | Before | After |
|---|---|---|
| CJK path | `▌M文档/设计/终端渲染说明书+3−1` — no ellipsis, stats jammed, drawn through the border | `▌M …端渲染说明书笔记.md  +3 −1` |
| Settings @46 | `[x] Cross-tas` + `also for a ta` — label cut mid-word, hint a fragment | `[x] Cross-task`, hint dropped |
| New task @24 | field labels merged away, rows dropped mid-list, Create colliding with the footer | labels intact, `↓ 19 more`, Create clear |

No chords added or moved. i18n check passes (697 keys × 2 locales; no keys added — dropping a hint reuses its key).