### PR TITLE
fix: six first-run defects that stall or mislead a brand-new user

### DIFF
--- a/.changeset/first-run-defects.md
+++ b/.changeset/first-run-defects.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix six defects on the first-run path
+
+- Creating a task in a repo with no commits failed silently: the dialog accepted a freshly `git init`ed repo, prefilled `main` as the base ref, and `git worktree add` died with `fatal: invalid reference: main` on a path whose only error handler was an invisible `console.error`. The user was left on a new task row that told them to select a task. The dialog now says the repository has no commits yet and hands over the fix.
+- Running `rove` from a repo subdirectory created a ghost project: `ensureMainTask` resolved to the git toplevel but the task record kept the raw subdirectory, so the sidebar showed two projects for one repo. `createTask` now normalizes to the git root like `rove add` and `rove api add` already did.
+- `rove skill install` crashed with `Executable not found in $PATH: "npx"` when Node was absent. The installer now checks first and explains that Node is required — the `install.sh` route installs Bun and Rove but not Node.
+- With git missing, the new-task dialog reported "this folder isn't a git repository yet" and told the user to run three `git` commands that would also fail. It now reports git as missing, matching the welcome pane.
+- Declining the agent skill in the setup wizard no longer re-asks on the next launch.
+- The wizard's closing line now names the command you invoked instead of always saying `rove`.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -56,6 +56,11 @@ winner.
 rove skill install
 ```
 
+This one step needs [Node.js](https://nodejs.org) on your `PATH` — it wraps
+`npx skills add`. The `install.sh` route above installs Bun and Rove but not
+Node, so install Node first if `npx` is missing. Everything else in Rove runs
+without it.
+
 **Claude Code users have a one-stop alternative**: the Rove plugin carries the
 skill AND the activity hooks in one install, with no PATH or settings.json
 setup:

--- a/packages/kobe/src/cli/onboarding.ts
+++ b/packages/kobe/src/cli/onboarding.ts
@@ -15,7 +15,7 @@ import { spawnSync } from "node:child_process"
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { basename, join } from "node:path"
-import { npxSkillsArgv, npxSkillsCommand } from "../lib/skill-install.ts"
+import { isNpxMissing, markSkillHintSeen, npxSkillsArgv, npxSkillsCommand } from "../lib/skill-install.ts"
 import { getPersistedBool, setPersistedBool } from "../state/store.ts"
 import { t } from "../tui/i18n"
 import { activeCliName } from "./rename-compat.ts"
@@ -88,15 +88,27 @@ export function applyOnboardingChoices(choices: OnboardingChoices, shell: ShellK
     }
   }
   if (choices.skill) {
-    out(t("onboarding.installingSkill", { command: npxSkillsCommand() }))
-    const result = spawnSync("npx", npxSkillsArgv(), { stdio: "inherit" })
-    if (result.status !== 0) out(t("onboarding.skillFailed", { command: skillInstall }))
+    if (isNpxMissing()) {
+      // The install.sh path in the QUICKSTART installs Bun and Rove but never
+      // Node, so a missing `npx` is ordinary here. Say what's missing instead
+      // of pointing at `rove skill install`, which needs the same binary.
+      out(t("onboarding.skillNeedsNode", { command: skillInstall }))
+    } else {
+      out(t("onboarding.installingSkill", { command: npxSkillsCommand() }))
+      const result = spawnSync("npx", npxSkillsArgv(), { stdio: "inherit" })
+      if (result.status !== 0) out(t("onboarding.skillFailed", { command: skillInstall }))
+    }
   } else {
     out(t("onboarding.skippedSkill", { command: skillInstall }))
+    // The user just answered this question. Suppress the one-time startup
+    // hint so the next `rove` doesn't ask it again on stderr.
+    markSkillHintSeen()
   }
   out("")
   out(t("onboarding.ready"))
-  out(t("onboarding.readyHint"))
+  // The package ships BOTH bins; every other line here interpolates the name
+  // the user actually invoked, so this one must too.
+  out(t("onboarding.readyHint", { command: cli }))
 }
 
 /**

--- a/packages/kobe/src/cli/skill-cmd.ts
+++ b/packages/kobe/src/cli/skill-cmd.ts
@@ -21,6 +21,7 @@
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import {
+  NPX_MISSING_EXIT,
   bundledSkillDir,
   kobeSkillPaths,
   kobeSkillState,
@@ -164,10 +165,17 @@ export async function runSkillSubcommand(argv: readonly string[]): Promise<void>
   )
   const code = await runNpxSkillsInstall(agents, global)
   if (code !== 0) {
-    process.stderr.write(
-      `\n${CLI_NAME} skill install failed (npx exited ${code}). Is \`npx\` on PATH?\n` +
-        `You can run it yourself: ${npxSkillsCommand({ agent: agents, global })}\n`,
-    )
+    // NPX_MISSING_EXIT means runNpxSkillsInstall already explained that Node
+    // is missing — don't follow it with "run it yourself", which needs the
+    // same absent binary. (Its old "Is `npx` on PATH?" text was unreachable:
+    // it only ran on a non-zero EXIT, and a missing binary made Bun.spawn
+    // throw straight past it.)
+    if (code !== NPX_MISSING_EXIT) {
+      process.stderr.write(
+        `\n${CLI_NAME} skill install failed (npx exited ${code}).\n` +
+          `You can run it yourself: ${npxSkillsCommand({ agent: agents, global })}\n`,
+      )
+    }
     process.exit(code || 1)
   }
   process.stdout.write(`${CLI_NAME} skill: installed.\n`)

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -26,9 +26,9 @@
  * skill version, non-TTY falls back to the old one-shot hint.
  */
 
-import { existsSync, readFileSync } from "node:fs"
+import { accessSync, existsSync, constants as fsConstants, readFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { join, resolve } from "node:path"
+import { delimiter, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { activeCliName } from "../cli/rename-compat.ts"
 import { ROVE_PRODUCT_NAME } from "../product.ts"
@@ -134,10 +134,54 @@ export function npxSkillsCommand(opts: NpxSkillsOpts = {}): string {
 }
 
 /**
+ * Exit code {@link runNpxSkillsInstall} returns when `npx` isn't on PATH.
+ * 127 is the shell's own "command not found" code, so callers that only
+ * print `exited ${code}` still say something true.
+ */
+export const NPX_MISSING_EXIT = 127
+
+/**
+ * True when `npx` is absent from PATH. The install.sh path the QUICKSTART
+ * recommends installs Bun and Rove but never Node, so this is the DEFAULT
+ * state for anyone who followed it — not an edge case.
+ *
+ * Walks PATH directly rather than using `Bun.which`, so the same code runs
+ * (and is testable) under the vitest/node track as under Bun.
+ */
+export function isNpxMissing(): boolean {
+  const parts = (process.env.PATH ?? "").split(delimiter).filter(Boolean)
+  // No PATH at all: don't invent a failure — let the spawn report the truth.
+  if (parts.length === 0) return false
+  return !parts.some((dir) => {
+    try {
+      accessSync(join(dir, "npx"), fsConstants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  })
+}
+
+/** The "install Node" message shown wherever a missing `npx` blocks the install. */
+export function npxMissingMessage(): string {
+  return `${activeCliName()} skill install needs \`npx\` (part of Node.js), which isn't on your PATH.\nInstall Node.js (https://nodejs.org) and run it again — the Rove installer only installs Bun and Rove.`
+}
+
+/**
  * Run the `npx skills add …` install flow, inheriting stdio (so the CLI's
  * own agent picker is fully interactive). Returns the npx exit code.
+ *
+ * Checks for `npx` FIRST: `Bun.spawn` THROWS on a missing binary (unlike
+ * `spawnSync`, which returns `status: undefined`), and no caller on this path
+ * catches — the throw used to escape all the way to `main().catch` and print
+ * `rove failed to start: Executable not found in $PATH: "npx"`. Returning
+ * {@link NPX_MISSING_EXIT} keeps the callers' existing exit-code contract.
  */
 export async function runNpxSkillsInstall(agent?: string | readonly string[], global?: boolean): Promise<number> {
+  if (isNpxMissing()) {
+    process.stderr.write(`\n${npxMissingMessage()}\n\n`)
+    return NPX_MISSING_EXIT
+  }
   const proc = Bun.spawn(["npx", ...npxSkillsArgv({ ...(agent === undefined ? {} : { agent }), global })], {
     stdin: "inherit",
     stdout: "inherit",
@@ -148,6 +192,17 @@ export async function runNpxSkillsInstall(agent?: string | readonly string[], gl
 
 /** Persisted flag: the one-time startup hint has already been shown. */
 const HINT_SEEN_KEY = "skillHintSeen"
+
+/**
+ * Record that the user has already answered the "install the skill?" question,
+ * so {@link maybeHintSkillInstall} never re-asks it on the next launch. The
+ * onboarding wizard's DECLINE branch calls this: the user said no seconds ago,
+ * and nagging them on stderr on the very next `rove` is the same question
+ * asked twice.
+ */
+export function markSkillHintSeen(): void {
+  setPersistedString(HINT_SEEN_KEY, "1")
+}
 
 /**
  * Candidate install locations, in priority order: the user's home dir,

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -209,7 +209,20 @@ export class Orchestrator {
     // the sidebar's PROJECTS rows ARE the main tasks (sidebar/groups.ts),
     // so a task created for a brand-new repo would float with no project
     // row. Every creation path therefore guarantees its own project entry.
-    await this.ensureMainTask(input.repo)
+    // Normalize to the git toplevel BEFORE anything reads `input.repo`.
+    // `ensureMainTask` already normalizes internally, so a caller passing a
+    // SUBDIRECTORY (`rove` run from `my-monorepo/packages/app`, whose path
+    // passes `validateRepoPath` because `rev-parse --git-dir` succeeds in a
+    // subdir) used to split into two sidebar projects: the main row keyed on
+    // `/my-monorepo`, this task keyed on `/my-monorepo/packages/app` — a
+    // ghost project named after a subdirectory, with its own worktree root.
+    // `rove add` (via addSavedRepo) and `rove api add` (via resolveRepoRoot)
+    // both already resolve; this makes the orchestrator entry point agree,
+    // which covers the TUI dialog and every future caller at once.
+    // Dir/scratch tasks do NOT come through here (see openDirectoryTask),
+    // so pinning a user-owned directory is unaffected.
+    const mainTask = await this.ensureMainTask(input.repo)
+    const repo = mainTask.repo
     const title = (input.title ?? PLACEHOLDER_TASK_TITLE).trim() || PLACEHOLDER_TASK_TITLE
     // Leave the branch EMPTY for a lazily-allocated task (unless the caller
     // gave an explicit one): {@link ensureWorktree} derives a repo-convention
@@ -218,7 +231,7 @@ export class Orchestrator {
     // resolved against the repo's live branch list at materialise time, and
     // deferring also lets the branch follow a rename made before first enter.
     const task = await this.store.create({
-      repo: input.repo,
+      repo,
       title,
       branch: input.branch ?? "",
       worktreePath: "",

--- a/packages/kobe/src/tui/i18n/messages/onboarding.ts
+++ b/packages/kobe/src/tui/i18n/messages/onboarding.ts
@@ -43,12 +43,15 @@ export const en = {
   installingSkill: "installing the Rove agent skill ({command})…",
   /** Post-wizard: skill installer failed; {command} retries it */
   skillFailed: "! skill install failed — retry with `{command}`",
+  /** Post-wizard: the skill installer needs Node/npx, which isn't installed */
+  skillNeedsNode:
+    "! agent skill needs `npx` (part of Node.js) — install Node from https://nodejs.org, then run `{command}`",
   /** Post-wizard: skill declined; {command} re-runs it later */
   skippedSkill: "· agent skill skipped — run `{command}` anytime",
   /** Final ready banner */
   ready: "You're ready to go!",
-  /** Final hint: how to start */
-  readyHint: "Run `rove` to launch the TUI.",
+  /** Final hint: how to start; {command} is the CLI name the user invoked */
+  readyHint: "Run `{command}` to launch the TUI.",
 }
 
 export const zh: typeof en = {
@@ -71,7 +74,9 @@ export const zh: typeof en = {
   skippedCompletions: "· 已跳过补全 — 之后可随时运行 `{command}`",
   installingSkill: "正在安装 Rove agent skill（{command}）…",
   skillFailed: "! skill 安装失败 — 可用 `{command}` 重试",
+  skillNeedsNode:
+    "! agent skill 需要 `npx`（Node.js 的一部分）— 请从 https://nodejs.org 安装 Node，然后运行 `{command}`",
   skippedSkill: "· 已跳过 agent skill — 之后可随时运行 `{command}`",
   ready: "一切就绪！",
-  readyHint: "运行 `rove` 启动 TUI。",
+  readyHint: "运行 `{command}` 启动 TUI。",
 }

--- a/packages/kobe/src/tui/lib/git-snapshot.ts
+++ b/packages/kobe/src/tui/lib/git-snapshot.ts
@@ -20,6 +20,7 @@
 
 import { spawnSync } from "node:child_process"
 import * as fs from "node:fs"
+import { t } from "@/tui/i18n"
 
 /** Default base ref when the user leaves the branch field blank or HEAD can't be read. */
 export const DEFAULT_BASE_REF = "main"
@@ -53,6 +54,58 @@ function notAGitRepoReason(path: string): string {
   return `This folder isn't a git repository yet, and a task needs a git branch to work in. To fix it, turn ${path} into a repo:  git init && git add -A && git commit -m "init"  — then create the task again. (Working in non-git folders is coming soon.)`
 }
 
+/**
+ * `git` itself is missing from PATH. Distinct from {@link notAGitRepoReason}
+ * because `spawnSync` reports BOTH as a non-zero `status` — the ENOENT case
+ * used to fall through and tell the user to run `git init && git add -A &&
+ * git commit`, three commands that would each also be `command not found`.
+ * Same wording as the WelcomePane's own (correct) probe so one machine can't
+ * show two contradictory diagnoses.
+ */
+function gitMissingReason(): string {
+  return t("workspace.welcome.gitMissing")
+}
+
+/** True when a spawnSync result means "the binary isn't on PATH". */
+function isBinaryMissing(out: { error?: Error & { code?: string } }): boolean {
+  return out.error !== undefined && (out.error as { code?: string }).code === "ENOENT"
+}
+
+/**
+ * Friendly reason for a repo with an UNBORN HEAD — `git init` ran but nothing
+ * was ever committed. `rev-parse --git-dir` succeeds here, so the repo check
+ * above passes and the dialog happily prefills `DEFAULT_BASE_REF`; the failure
+ * only surfaces later, inside `ensureWorktree`, as `fatal: invalid reference:
+ * main` on a code path whose only error handler is a console.error nobody can
+ * see under alt-screen. Catch it at the dialog instead, where the user can
+ * still act on it.
+ */
+function noCommitsReason(path: string): string {
+  return `This repository has no commits yet, and a task branches off an existing commit. To fix it, make one in ${path}:  git add -A && git commit -m "init"  — then create the task again.`
+}
+
+/**
+ * True when HEAD resolves to no commit. PRECONDITION: `repo` is already known
+ * to be a git repo — `rev-parse --verify HEAD` also exits non-zero for a
+ * non-repo, so this only distinguishes "unborn HEAD" from "has commits" once
+ * the repo check has passed. Kept module-private for exactly that reason;
+ * {@link validateRepoPath} is the only caller and it checks repo-ness first.
+ */
+function hasNoCommits(repo: string): boolean {
+  try {
+    const out = spawnSync("git", ["rev-parse", "--verify", "HEAD"], {
+      cwd: repo,
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    if (isBinaryMissing(out)) return false
+    return out.status !== 0
+  } catch {
+    return false
+  }
+}
+
 export function validateRepoPath(repo: string): string | null {
   const trimmed = repo.trim()
   if (!trimmed) return "repo path is required"
@@ -71,10 +124,14 @@ export function validateRepoPath(repo: string): string | null {
       timeout: 2000,
       stdio: ["ignore", "pipe", "ignore"],
     })
+    if (isBinaryMissing(out)) return gitMissingReason()
     if (out.status !== 0) return notAGitRepoReason(trimmed)
   } catch {
     return notAGitRepoReason(trimmed)
   }
+  // A repo with no commits passes every check above but has nothing for
+  // `git worktree add <path> <baseRef>` to branch from.
+  if (hasNoCommits(trimmed)) return noCommitsReason(trimmed)
   return null
 }
 

--- a/packages/kobe/src/tui/lib/task-create-flow.ts
+++ b/packages/kobe/src/tui/lib/task-create-flow.ts
@@ -85,10 +85,12 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     discoverAdoptable: orch ? (repo) => orch.discoverAdoptableWorktrees(repo) : undefined,
   })
   if (!result) return
-  ctx.rememberVendor(result.repo, result.vendor)
   // Auto-save the chosen repo so the saved list self-populates and
-  // `kobe add` stays optional.
-  addSavedRepo(result.repo)
+  // `kobe add` stays optional. `addSavedRepo` normalizes to the git toplevel
+  // and RETURNS that path — use it, so a repo entered as a subdirectory is
+  // remembered and vendor-keyed under the same root the task record gets.
+  const repo = addSavedRepo(result.repo).path
+  ctx.rememberVendor(repo, result.vendor)
   ctx.onRepoSaved?.()
   if (!orch) {
     // The dialog has already closed by here. Without a toast the submit reads
@@ -115,7 +117,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     for (const w of result.adopt) {
       try {
         const task = await orch.adoptWorktree({
-          repo: result.repo,
+          repo,
           worktreePath: w.worktreePath,
           branch: w.branch,
           vendor: result.vendor,
@@ -136,7 +138,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
   } else {
     try {
       const task = await orch.createTask({
-        repo: result.repo,
+        repo,
         baseRef: result.baseRef,
         vendor: result.vendor,
       })

--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   setPersistedBool: vi.fn(),
   npxSkillsArgv: vi.fn(() => ["skills", "add", "stub"]),
   npxSkillsCommand: vi.fn(() => "npx skills add stub"),
+  isNpxMissing: vi.fn(() => false),
+  markSkillHintSeen: vi.fn(),
   runOnboardingWizard: vi.fn(),
 }))
 
@@ -28,6 +30,8 @@ vi.mock("../../src/state/store.ts", () => ({
 vi.mock("../../src/lib/skill-install.ts", () => ({
   npxSkillsArgv: mocks.npxSkillsArgv,
   npxSkillsCommand: mocks.npxSkillsCommand,
+  isNpxMissing: mocks.isNpxMissing,
+  markSkillHintSeen: mocks.markSkillHintSeen,
 }))
 vi.mock("../../src/tui-react/onboarding/host.tsx", () => ({
   runOnboardingWizard: mocks.runOnboardingWizard,
@@ -119,6 +123,9 @@ describe("applyOnboardingChoices", () => {
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+    // vi.clearAllMocks() wipes the hoisted default return too, so restore the
+    // "npx is present" baseline every test starts from.
+    mocks.isNpxMissing.mockReturnValue(false)
   })
 
   afterEach(() => {
@@ -155,7 +162,53 @@ describe("applyOnboardingChoices", () => {
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("rove completions --help"))).toBe(true)
     expect(lines.some((l) => l.includes("rove skill install"))).toBe(true)
-    expect(lines.some((l) => l.includes("kobe"))).toBe(false)
+  })
+
+  // The package ships BOTH bins. The final "Run `…` to launch the TUI" line
+  // used to be the ONE line in the wizard that didn't interpolate the invoked
+  // name — a `kobe` user was sent to run a command they'd never installed
+  // under that name. Asserting the kobe direction is the point: the previous
+  // test only checked rove, where the hardcoded literal happened to be right.
+  it("tells a kobe user to run kobe, not rove", async () => {
+    setProduct("kobe")
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: false }, "bash")
+    const lines = stdoutLines(stdoutSpy)
+    const readyLine = lines.find((l) => l.includes("launch the TUI"))
+    expect(readyLine).toBeDefined()
+    expect(readyLine).toContain("kobe")
+    expect(readyLine).not.toContain("rove")
+  })
+
+  // Declining the skill in the wizard must silence the one-time startup hint:
+  // the user answered this question seconds ago, and the hint is the same
+  // question again on stderr at the next launch.
+  it("marks the skill hint seen when the user declines in the wizard", async () => {
+    setProduct("rove")
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: false }, "bash")
+    expect(mocks.markSkillHintSeen).toHaveBeenCalled()
+  })
+
+  it("does not mark the hint seen when the user accepts the skill", async () => {
+    setProduct("rove")
+    mocks.spawnSync.mockReturnValue({ status: 0 })
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: true }, "bash")
+    expect(mocks.markSkillHintSeen).not.toHaveBeenCalled()
+  })
+
+  // install.sh installs Bun and Rove but never Node, so a missing `npx` is the
+  // default state for anyone who followed the QUICKSTART. Say Node is missing
+  // rather than spawning and pointing at a retry command that needs it too.
+  it("explains Node is missing instead of spawning npx", async () => {
+    setProduct("rove")
+    mocks.isNpxMissing.mockReturnValue(true)
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: true }, "bash")
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("npx") && l.includes("Node"))).toBe(true)
+    expect(mocks.spawnSync).not.toHaveBeenCalled()
   })
 
   it("prints a failure hint when the skill installer exits non-zero", async () => {

--- a/packages/kobe/test/lib/skill-install-hint.test.ts
+++ b/packages/kobe/test/lib/skill-install-hint.test.ts
@@ -19,7 +19,12 @@ vi.mock("node:os", async (importOriginal) => {
   return { ...actual, homedir: () => tmpHome, default: { ...actual, homedir: () => tmpHome } }
 })
 
-import { KOBE_SKILL_VERSION, kobeSkillState, maybeHintSkillInstall } from "../../src/lib/skill-install.ts"
+import {
+  KOBE_SKILL_VERSION,
+  kobeSkillState,
+  markSkillHintSeen,
+  maybeHintSkillInstall,
+} from "../../src/lib/skill-install.ts"
 import { getPersistedString } from "../../src/state/repos.ts"
 
 let cwd: string
@@ -88,6 +93,19 @@ describe("maybeHintSkillInstall", () => {
 
     await maybeHintSkillInstall()
     expect(stderrSpy).toHaveBeenCalledTimes(1)
+  })
+
+  // The onboarding wizard's DECLINE branch calls markSkillHintSeen(). That
+  // test mocks skill-install.ts, so it can only prove the CALL happens — this
+  // one proves the call actually silences the hint. Without both, gutting
+  // markSkillHintSeen's body leaves every test green while the user gets
+  // nagged on stderr about a question they answered seconds earlier.
+  it("markSkillHintSeen suppresses the absent-skill hint entirely", async () => {
+    markSkillHintSeen()
+    expect(getPersistedString("skillHintSeen")).toBe("1")
+
+    await maybeHintSkillInstall()
+    expect(stderrSpy).not.toHaveBeenCalled()
   })
 
   it("uses the compatibility command when invoked through kobe", async () => {

--- a/packages/kobe/test/lib/skill-install.test.ts
+++ b/packages/kobe/test/lib/skill-install.test.ts
@@ -5,13 +5,16 @@ import { fileURLToPath } from "node:url"
 import { afterEach, describe, expect, it } from "vitest"
 import {
   KOBE_SKILL_VERSION,
+  NPX_MISSING_EXIT,
   bundledSkillDir,
   isKobeSkillInstalled,
+  isNpxMissing,
   kobeSkillPaths,
   kobeSkillState,
   npxSkillsArgv,
   npxSkillsCommand,
   parseSkillVersion,
+  runNpxSkillsInstall,
   skillInstallCommand,
 } from "../../src/lib/skill-install.ts"
 
@@ -170,5 +173,46 @@ describe("skill version / staleness", () => {
       installedVersion: null,
       stale: true,
     })
+  })
+})
+
+/**
+ * `curl https://rove.run/install.sh | sh` installs Bun and Rove and never
+ * Node, so a missing `npx` is the DEFAULT state for anyone who followed the
+ * QUICKSTART. `Bun.spawn` THROWS on a missing binary (unlike `spawnSync`,
+ * which returns a status), and nothing on this path caught it — the throw
+ * escaped to `main().catch` and printed
+ * `rove failed to start: Executable not found in $PATH: "npx"`.
+ */
+describe("npx preflight", () => {
+  it("reports npx missing when it isn't on PATH", () => {
+    const realPath = process.env.PATH
+    process.env.PATH = tempDir()
+    try {
+      expect(isNpxMissing()).toBe(true)
+    } finally {
+      process.env.PATH = realPath
+    }
+  })
+
+  it("returns an exit code instead of throwing when npx is absent", async () => {
+    const realPath = process.env.PATH
+    const stderr: string[] = []
+    const write = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((chunk: string) => {
+      stderr.push(String(chunk))
+      return true
+    }) as typeof process.stderr.write
+    process.env.PATH = tempDir()
+    try {
+      // Must RESOLVE, not reject — the old Bun.spawn path threw here.
+      await expect(runNpxSkillsInstall()).resolves.toBe(NPX_MISSING_EXIT)
+      const said = stderr.join("")
+      expect(said).toContain("npx")
+      expect(said).toContain("Node")
+    } finally {
+      process.env.PATH = realPath
+      process.stderr.write = write
+    }
   })
 })

--- a/packages/kobe/test/orchestrator/main-task.test.ts
+++ b/packages/kobe/test/orchestrator/main-task.test.ts
@@ -56,6 +56,31 @@ describe("ensureMainTask", () => {
     expect(orch.listTasks().filter((t) => t.kind === "main")).toHaveLength(1)
   })
 
+  // `rove` run from a monorepo SUBDIRECTORY (`my-monorepo/packages/app`) used
+  // to split the sidebar into two projects: `ensureMainTask` normalized to the
+  // git toplevel, but the task record two lines below kept `input.repo` raw.
+  // The sidebar groups by string comparison of `task.repo`, so the main row
+  // keyed on `/my-monorepo` and the task on `/my-monorepo/packages/app` — a
+  // ghost project named after a subdirectory, with its own worktree root
+  // (worktreeRootFor hashes path.resolve(repo)). `rove add` and `rove api add`
+  // already resolved to the toplevel; this closes the last entry point.
+  test("a task created from a subdirectory is filed under the repo root, not a ghost project", async () => {
+    const sub = path.join(repo, "packages", "app")
+    fs.mkdirSync(sub, { recursive: true })
+
+    const task = await orch.createTask({ repo: sub, title: "from-subdir" })
+
+    // The subdirectory must not survive into the record at all.
+    expect(task.repo).not.toBe(sub)
+    expect(task.repo.endsWith(path.join("packages", "app"))).toBe(false)
+    // One project row, not two: the sidebar groups by string comparison on
+    // this exact field, so task and main agreeing IS the fix.
+    const mains = orch.listTasks().filter((t) => t.kind === "main")
+    expect(mains).toHaveLength(1)
+    expect(task.repo).toBe(mains[0]?.repo)
+    expect(new Set(orch.listTasks().map((t) => t.repo)).size).toBe(1)
+  })
+
   test("promotes an existing directory task on the same root instead of adding a second row", async () => {
     // Both rows pin the SAME checkout, so minting a main beside a dir task
     // put two rows with the same diff under one project header — one labelled

--- a/packages/kobe/test/tui/create-task-flow.test.ts
+++ b/packages/kobe/test/tui/create-task-flow.test.ts
@@ -16,8 +16,11 @@ import { describe, expect, test, vi } from "vitest"
 
 vi.mock("../../src/state/repos", () => ({
   getSavedRepos: () => ["/repo"],
-  addSavedRepo: vi.fn(() => ({ added: false, path: "/repo", total: 1 })),
+  addSavedRepo: (p: string) => mockAddSavedRepo(p),
 }))
+// addSavedRepo normalizes to the git toplevel and returns it. Default: the
+// identity case; the subdirectory test below makes it actually normalize.
+const mockAddSavedRepo = vi.fn((path: string) => ({ added: false, path, total: 1 }))
 vi.mock("../../src/engine/account-detect", () => ({
   availableEngineIds: () => mockAvailableEngineIds(),
 }))
@@ -231,6 +234,28 @@ describe("createTaskFlow — create mode + guards", () => {
 
     expect(notifyInfo).toHaveBeenCalledWith(expect.stringContaining("No engine CLI detected"))
     expect(createTask).toHaveBeenCalled()
+  })
+
+  // The dialog submits whatever the user typed. If they ran `rove` inside
+  // `my-monorepo/packages/app`, that subdirectory is the prefill and it passes
+  // validation. `addSavedRepo` already normalized to the git toplevel — but
+  // its RETURN was thrown away, so the saved repo list, the vendor preference
+  // key, and the task record all disagreed. This pins that the flow forwards
+  // the normalized path to every downstream consumer.
+  test("forwards addSavedRepo's normalized root to createTask and rememberVendor", async () => {
+    mockAddSavedRepo.mockImplementationOnce(() => ({ added: true, path: "/repo", total: 1 }))
+    const promptNewTask = vi.fn(async () => ({
+      mode: "create" as const,
+      repo: "/repo/packages/app",
+      baseRef: "main",
+      vendor: "claude",
+    }))
+    const { ctx, createTask, rememberVendor } = makeCreateCtx({ promptNewTask })
+
+    await createTaskFlow(ctx)
+
+    expect(createTask).toHaveBeenCalledWith(expect.objectContaining({ repo: "/repo" }))
+    expect(rememberVendor).toHaveBeenCalledWith("/repo", "claude")
   })
 
   test("no daemon (orch null): saves the repo/vendor choice but logs instead of creating", async () => {

--- a/packages/kobe/test/tui/lib/git-snapshot.test.ts
+++ b/packages/kobe/test/tui/lib/git-snapshot.test.ts
@@ -27,6 +27,8 @@ let root: string
 let repo: string
 let notRepo: string
 let plainFile: string
+let emptyRepo: string
+let subdir: string
 
 function git(cwd: string, ...args: string[]): void {
   const out = spawnSync("git", args, { cwd, encoding: "utf-8" })
@@ -38,12 +40,19 @@ beforeAll(() => {
   repo = path.join(root, "repo")
   notRepo = path.join(root, "not-repo")
   plainFile = path.join(root, "file.txt")
+  emptyRepo = path.join(root, "empty-repo")
+  subdir = path.join(repo, "packages", "app")
   fs.mkdirSync(repo)
   fs.mkdirSync(notRepo)
   fs.writeFileSync(plainFile, "x")
   git(repo, "init", "-b", "zeta")
   git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init")
   for (const b of ["develop", "master", "main", "feature-x"]) git(repo, "branch", b)
+  // `git init` with nothing committed: HEAD points at a branch that does not
+  // exist yet (an "unborn" HEAD).
+  fs.mkdirSync(emptyRepo)
+  git(emptyRepo, "init", "-b", "main")
+  fs.mkdirSync(subdir, { recursive: true })
 })
 
 afterAll(() => {
@@ -63,6 +72,48 @@ describe("validateRepoPath", () => {
 
   it("returns null for a usable git repo", () => {
     expect(validateRepoPath(repo)).toBeNull()
+  })
+
+  // A freshly `git init`ed repo passes `rev-parse --git-dir`, so the dialog
+  // used to accept it, prefill baseRef with DEFAULT_BASE_REF (getCurrentBranch
+  // returns null on an unborn HEAD), and only fail later inside ensureWorktree
+  // with `fatal: invalid reference: main` — on a path whose sole error handler
+  // is a console.error invisible under alt-screen. The user was left on a task
+  // row with an empty worktreePath telling them to select a task.
+  it("rejects a repo with no commits, and says so", () => {
+    const reason = validateRepoPath(emptyRepo)
+    expect(reason).not.toBeNull()
+    expect(reason).toContain("no commits")
+    // It must NOT be misreported as "not a git repository" — it IS one.
+    expect(reason).not.toContain("isn't a git repository")
+  })
+
+  // A subdirectory of a repo also passes `rev-parse --git-dir`; validation
+  // stays permissive there on purpose (normalization to the toplevel happens
+  // in createTask). Pinned so the no-commits check above can't over-reject.
+  it("still accepts a subdirectory of a committed repo", () => {
+    expect(validateRepoPath(subdir)).toBeNull()
+  })
+
+  // git absent from PATH makes spawnSync return `status: null` + ENOENT, which
+  // used to satisfy `status !== 0` and produce the not-a-repo copy — telling a
+  // user with no git to run `git init && git add -A && git commit`, three
+  // commands that would each also be `command not found`. The WelcomePane's
+  // own probe already got this right; both surfaces now say the same thing.
+  it("says git is missing, not that the folder isn't a repo, when git is absent", () => {
+    const realPath = process.env.PATH
+    // An empty dir as the entire PATH: no `git` binary is reachable.
+    process.env.PATH = path.join(root, "no-bin")
+    fs.mkdirSync(path.join(root, "no-bin"), { recursive: true })
+    try {
+      const reason = validateRepoPath(repo)
+      expect(reason).not.toBeNull()
+      expect(reason).toContain("git")
+      expect(reason).not.toContain("isn't a git repository")
+      expect(reason).not.toContain("git init")
+    } finally {
+      process.env.PATH = realPath
+    }
   })
 })
 


### PR DESCRIPTION
Six defects on the path a user walks in their first five minutes: `npm i -g @sma1lboy/rove`, then `rove`.

## 1. Creating a task in a commitless repo failed silently

`git init` with nothing committed leaves HEAD unborn. `validateRepoPath` passed (`rev-parse --git-dir` succeeds), `getCurrentBranch` returned null, so the dialog prefilled `baseRef = "main"` — and `git worktree add -b <branch> <path> main` died with `fatal: invalid reference: main`. That failure lands in `enterTask` → `activateTask` → `ensureWorktree`, whose only error handler is a `console.error` that alt-screen swallows. The task record persisted with `worktreePath: ""`, so the row the user just created rendered "Select a task with a worktree".

Caught at the dialog now, before anything is created.

`test/tui/lib/git-snapshot.test.ts` previously passed because it never built a commitless repo.

## 2. Running `rove` from a subdirectory created a ghost project

`createTask` called `ensureMainTask(input.repo)` — which normalizes to the git toplevel — and then stored the **raw** `input.repo` two lines later. The sidebar groups by string comparison on that field, so `cd my-monorepo/packages/app && rove` produced two project headers for one repo, the second named after a subdirectory, with its own worktree root (`worktreeRootFor` hashes `path.resolve(repo)`).

**Fixed at `createTask`, not at the dialog** — `rove add` (via `addSavedRepo`) and `rove api add` (via `resolveRepoRoot`) already resolved to the toplevel; the orchestrator entry point was the last one that didn't. Fixing it there covers the TUI dialog and every future caller in one place, and it costs no extra subprocess: `ensureMainTask` already computed the normalized path, so we just use its return value. Dir/scratch tasks go through `openDirectoryTask` and are unaffected, so pinning a user-owned directory still works.

Also fixed the half of this in `task-create-flow.ts`: `addSavedRepo` normalizes and returns the root, but the return value was discarded, so the saved repo list and the vendor preference key disagreed with the task record.

## 3. `rove skill install` crashed when Node was absent

`curl https://rove.run/install.sh | sh` installs Bun and Rove and never Node, so a missing `npx` is the default state for anyone who followed the QUICKSTART. `Bun.spawn` **throws** on a missing binary (unlike `spawnSync`, which returns a status), and nothing on that path caught it:

```
rove failed to start: Executable not found in $PATH: "npx"
```

Now checked before spawning. The old `Is \`npx\` on PATH?` text in `skill-cmd.ts` was unreachable — it only ran on a non-zero *exit*, and a missing binary never got that far.

QUICKSTART now states the Node prerequisite in the section that needs it.

## 4. With git missing, the error said the folder wasn't a repo

`spawnSync` reports a missing binary as `status: null` + `error.code === "ENOENT"`, which satisfied `status !== 0` and produced the not-a-git-repo copy — telling a user with no git to run `git init && git add -A && git commit`, three commands that would each also be `command not found`. The WelcomePane's own probe already got this right; both surfaces now use the same message.

## 5. Declining the skill in the wizard re-asked on the next launch

The decline branch printed "· agent skill skipped" but never set `skillHintSeen`, so the one-time stderr hint still fired on the next `rove`.

## 6. The wizard's closing line always said `rove`

The package ships both bins and every other line interpolates `activeCliName()`. Only `readyHint` was a literal, sending a `kobe` user to run a command they never installed under that name.

`test/cli/onboarding.test.ts` was **locking this bug in**: it asserted only the `rove` direction (where the hardcoded literal happened to be correct) and that `kobe` never appeared. Replaced with an assertion on the `kobe` direction, which is the one that was broken.

## Verification

- **Mutation testing, 9 sites, re-run after the final rebase onto 0.9.50.** Every site red. Sites targeted wiring, not just leaves: removed call sites, dropped a normalized value mid-chain, forwarded a value to one consumer but not the other, gutted a function body while leaving its call intact.
- One round-2 mutation (gutting `markSkillHintSeen`'s body) stayed **green** — the onboarding test mocks `skill-install.ts`, so it could only prove the call happened, never that it persisted anything. Added an end-to-end test against the real state store; that mutation is now red.
- vitest 3876 pass / render 303 pass / daemon-socket 635 pass / i18n 699 keys × 2 locales in sync / lint + typecheck clean.
- **Live verification on real git**, not just mocks: commitless repo, monorepo subdirectory, and a genuinely git-free `PATH`. The subdirectory case run against a real orchestrator goes from **2 sidebar project keys to 1**.

## Screenshots

Defect 1, before/after through `/harness` (browser → xterm.js → PTY sidecar → real OpenTUI), isolated fixture on port base 5973:

- `/tmp/swallow-shots/D1-BEFORE.png` — a `(new task)` row appears and is selected, workspace says "Select a task with a worktree". No error, no toast.
- `/tmp/swallow-shots/D1-AFTER.png` — dialog stays open, focus returns to the repo field, inline error explains the repo has no commits and gives the fix.

**Defect 2 has no harness screenshot, and I'm not going to claim one.** The visual fixture always seeds `savedRepos` with the repo root, so the dialog prefills the root and the subdirectory path is never exercised; the shots I could produce showed one project both before and after and would have proven nothing. Reproducing it needs the first-run state (empty `savedRepos` + cwd in a subdirectory), and seeding that means writing the store underneath a live daemon, which kills the harness. Evidence for defect 2 is the live-orchestrator before/after above (2 project keys → 1) plus the mutation-verified test in `test/orchestrator/main-task.test.ts`.

Defect 4 was verified live under Bun with a real git-free process `PATH` rather than in the harness — simulating a missing binary in the TUI would mean faking the probe, which measures nothing. Worth noting: Bun ignores a mutated `process.env.PATH` for `spawnSync` lookup while node honors it, so the vitest test and the live probe needed different setups.