### PR TITLE
fix: six visual defects across the rail pages, tab strip, and sidebar

### DIFF
--- a/.changeset/ui-visual-consistency.md
+++ b/.changeset/ui-visual-consistency.md
@@ -1,0 +1,22 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix six visual defects across the TUI: three rail pages (Kanban, Routines,
+Issues) swap the same content panel but each picked its own left inset, so
+the body jumped sideways on every switch — they now share the x=2 inset the
+sibling Versions/Worktrees pages already used, and their static page titles
+render in the neutral text color instead of the accent, which on the default
+palette is the same hue as the focus indicator.
+
+The running-tab chip moves from `focusAccent` to the semantic `info` color:
+several tabs can run at once, so painting them the focus hue drowned the
+"you are here" signal. In transparent mode the condensed tab strip no longer
+paints a row background (matching its own wide branch, and letting the host
+wallpaper through), while the scrolled-back hint gains one — it is an overlay
+you must read, and the panel token it used is forced to alpha-0. The sidebar's
+"New task" row drops its vertical padding, returning two rows to the most
+height-pressured panel in the product.
+
+`visual:shot` gains `--width`/`--height` (narrow-layout captures),
+`--wallpaper` (transparent-mode captures), and a `click:X,Y` token.

--- a/packages/kobe-web/e2e/visual-shot.ts
+++ b/packages/kobe-web/e2e/visual-shot.ts
@@ -12,6 +12,9 @@
  *   bun run visual:shot -- ctrl+a c n "text:Draft title"
  *   bun run visual:shot -- --scale=2 --out=docs/assets/workspace.png
  *   bun run visual:shot -- --hostbg=#FFFFFF    # simulated light host terminal
+ *   bun run visual:shot -- --width=340 --height=400          # narrow layout
+ *   bun run visual:shot -- --wallpaper=/wallpaper.svg ctrl+pageup  # transparent
+ *   bun run visual:shot -- click:29,56         # a row the keyboard can't reach
  */
 
 import { resolve } from "node:path"
@@ -30,6 +33,16 @@ const KEY_NAMES: Record<string, string> = {
   down: "ArrowDown",
   left: "ArrowLeft",
   right: "ArrowRight",
+  // Playwright is case-sensitive here; the generic capitalize below would
+  // produce "Pageup"/"Pagedown", which it rejects outright.
+  pageup: "PageUp",
+  pagedown: "PageDown",
+  pgup: "PageUp",
+  pgdn: "PageDown",
+  home: "Home",
+  end: "End",
+  delete: "Delete",
+  del: "Delete",
 }
 const MODIFIERS: Record<string, string> = { ctrl: "Control", alt: "Alt", shift: "Shift", cmd: "Meta", meta: "Meta" }
 
@@ -56,6 +69,22 @@ const hostbgArg = args.find((arg) => arg.startsWith("--hostbg="))?.slice(9)
 if (hostbgArg !== undefined && !/^#[0-9a-fA-F]{6}$/.test(hostbgArg)) {
   throw new Error(`--hostbg must be #rrggbb, got ${JSON.stringify(hostbgArg)}`)
 }
+// `--width`/`--height` override the 1280×800 default so a capture can cross
+// the narrow-layout breakpoint (below ~70 cols the workspace collapses to one
+// panel and the tab strip switches to its condensed form).
+function dimension(flag: string, fallback: number): number {
+  const raw = args.find((arg) => arg.startsWith(`${flag}=`))?.slice(flag.length + 1)
+  if (raw === undefined) return fallback
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${flag} must be a positive number, got ${JSON.stringify(raw)}`)
+  return value
+}
+const width = dimension("--width", 1280)
+const height = dimension("--height", 800)
+// `--wallpaper=<url>` puts an image behind the harness so TRANSPARENT-mode
+// captures show what actually bleeds through — a panel forced to alpha-0 is
+// indistinguishable from an opaque one against a flat backdrop.
+const wallpaper = args.find((arg) => arg.startsWith("--wallpaper="))?.slice(12)
 const tokens = args.filter((arg) => !arg.startsWith("--"))
 const runId = `shot-${Date.now()}`
 
@@ -63,10 +92,11 @@ const browser = await chromium.launch({ headless: true }).catch((error: unknown)
   throw new Error(`chromium launch failed: ${error instanceof Error ? error.message : String(error)}`)
 })
 try {
-  const page = await browser.newPage({ viewport: { width: 1280, height: 800 }, deviceScaleFactor })
+  const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor })
   const hostbgQuery = hostbgArg ? `&hostbg=${encodeURIComponent(hostbgArg)}` : ""
+  const wallpaperQuery = wallpaper ? `&wallpaper=${encodeURIComponent(wallpaper)}` : ""
   await page
-    .goto(`http://localhost:${VISUAL_WEB_PORT}/harness?run=${runId}${hostbgQuery}`)
+    .goto(`http://localhost:${VISUAL_WEB_PORT}/harness?run=${runId}${hostbgQuery}${wallpaperQuery}`)
     .catch(() => {
       throw new Error(`no server on :${VISUAL_WEB_PORT} — start \`bun run visual:serve\` first`)
     })
@@ -82,12 +112,20 @@ try {
     { timeout: 45_000 },
   )
   // Click the sidebar's EMPTY lower area — (24, 24) would land on the tree's
-  // project header row (same re-anchor rationale as sandbox.spec.ts).
-  await page.getByTestId("opentui-terminal").click({ position: { x: 24, y: 400 } })
+  // project header row (same re-anchor rationale as sandbox.spec.ts). The y
+  // is element-relative, so it scales with --height: a fixed 400 falls
+  // outside a short viewport and Playwright then retries the click forever.
+  await page.getByTestId("opentui-terminal").click({ position: { x: 24, y: Math.floor(height / 2) } })
   for (const token of tokens) {
     if (token.startsWith("text:")) await page.keyboard.type(token.slice(5))
     else if (token.startsWith("wait:")) await page.waitForTimeout(Number(token.slice(5)))
-    else await page.keyboard.press(chord(token))
+    else if (token.startsWith("click:")) {
+      // `click:X,Y` — a raw viewport click, for a row the keyboard cannot
+      // reach without first walking the tree cursor through it.
+      const [x, y] = token.slice(6).split(",").map(Number)
+      if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error(`click: needs X,Y, got ${JSON.stringify(token)}`)
+      await page.mouse.click(x, y)
+    } else await page.keyboard.press(chord(token))
     await page.waitForTimeout(250)
   }
   await page.waitForTimeout(600)

--- a/packages/kobe-web/public/contrast-wallpaper.svg
+++ b/packages/kobe-web/public/contrast-wallpaper.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="800" viewBox="0 0 1280 800">
+  <!--
+    Diagnostic backdrop for TRANSPARENT-mode captures — pass it to
+    `visual:shot --wallpaper=/contrast-wallpaper.svg`.
+
+    Deliberately loud, unlike capture-wallpaper.svg (the near-black desktop
+    used for screencasts): against a dark backdrop a panel forced to alpha-0
+    and a panel painted opaque look identical, so a transparency regression
+    photographs as "no change". A saturated diagonal makes the difference
+    unmistakable in a before/after pair.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1D4ED8"/>
+      <stop offset="50%" stop-color="#7C3AED"/>
+      <stop offset="100%" stop-color="#BE185D"/>
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="800" fill="url(#g)"/>
+</svg>

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -277,7 +277,7 @@ export function AutomationsPage(props: {
       {/* Section header in the sidebar's grammar: BOLD CAPS label, a rule
           filling the gap, the daemon-hold state right-stuck. */}
       <box flexDirection="row" gap={1} flexShrink={0}>
-        <text attributes={TextAttributes.BOLD} fg={theme.primary} wrapMode="none" flexShrink={0}>
+        <text attributes={TextAttributes.BOLD} fg={theme.text} wrapMode="none" flexShrink={0}>
           {t("automations.title")}
         </text>
         <text fg={theme.borderSubtle} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -307,7 +307,7 @@ export function KanbanPage(props: {
    *  wide-layout nicety; narrow keeps only the label that identifies. */
   function projectSelector(active: RepoIssues): ReactNode {
     return (
-      <box flexDirection="row" justifyContent="space-between" paddingTop={1} paddingLeft={3} paddingRight={3}>
+      <box flexDirection="row" justifyContent="space-between" paddingTop={1}>
         <box flexDirection="row" onMouseUp={() => cycleProject(1)}>
           <text fg={theme.primary} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
             {sidebarProjectLabel(active.repoRoot, repoRoots)}
@@ -393,8 +393,8 @@ export function KanbanPage(props: {
       columns[0]
     if (!active) return null
     return (
-      <box flexDirection="column" flexGrow={1} paddingTop={1} paddingLeft={1} paddingRight={1}>
-        <box flexDirection="row" gap={2} paddingLeft={2}>
+      <box flexDirection="column" flexGrow={1} paddingTop={1}>
+        <box flexDirection="row" gap={2}>
           {columns.map((col) => (
             <text
               key={col.key}
@@ -421,7 +421,7 @@ export function KanbanPage(props: {
   function board(): ReactNode {
     if (narrow) return narrowBoard()
     return (
-      <box flexDirection="row" gap={1} flexGrow={1} paddingTop={1} paddingLeft={1} paddingRight={1}>
+      <box flexDirection="row" gap={1} flexGrow={1} paddingTop={1}>
         {columns.map((col) => column(col))}
       </box>
     )
@@ -429,11 +429,19 @@ export function KanbanPage(props: {
 
   const loading = boards === null
 
-  // One shared left baseline at x=3 (board inset one cell + padding) —
-  // Kanban / project / column headers / cards all align on it.
+  // One shared left baseline across rail pages: the root pads x=2 (the same
+  // inset Routines / Issues / Versions / Worktrees use), so the Kanban title,
+  // project selector, and board all start at x=2 — no per-child inset.
   return (
-    <box flexGrow={1} backgroundColor={theme.background} paddingTop={1} paddingBottom={1}>
-      <box flexDirection="row" justifyContent="space-between" gap={2} paddingLeft={3} paddingRight={3}>
+    <box
+      flexGrow={1}
+      backgroundColor={theme.background}
+      paddingTop={1}
+      paddingBottom={1}
+      paddingLeft={2}
+      paddingRight={2}
+    >
+      <box flexDirection="row" justifyContent="space-between" gap={2}>
         <text attributes={TextAttributes.BOLD} fg={theme.text} wrapMode="none" flexShrink={0}>
           {t("kanban.title")}
         </text>
@@ -444,13 +452,9 @@ export function KanbanPage(props: {
         </text>
       </box>
       {loading ? (
-        <text fg={theme.textMuted} paddingLeft={3}>
-          {t("kanban.loading")}
-        </text>
+        <text fg={theme.textMuted}>{t("kanban.loading")}</text>
       ) : boardList.length === 0 || !activeBoard ? (
-        <text fg={theme.textMuted} paddingLeft={3}>
-          {t("kanban.noRepos")}
-        </text>
+        <text fg={theme.textMuted}>{t("kanban.noRepos")}</text>
       ) : (
         <>
           {projectSelector(activeBoard)}

--- a/packages/kobe/src/tui-react/component/work-items-page.tsx
+++ b/packages/kobe/src/tui-react/component/work-items-page.tsx
@@ -170,9 +170,9 @@ export function WorkItemsPage(props: {
   const now = Date.now()
 
   return (
-    <box flexDirection="column" flexGrow={1} padding={1}>
+    <box flexDirection="column" flexGrow={1} paddingTop={1} paddingBottom={1} paddingLeft={2} paddingRight={2}>
       <box flexDirection="row" justifyContent="space-between">
-        <text attributes={TextAttributes.BOLD} fg={theme.accent}>
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
           {t("workItems.title")}
         </text>
         <text fg={theme.textMuted}>

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -150,7 +150,9 @@ export function SidebarCreateAction(props: { onAddTask?: () => void }) {
   if (!props.onAddTask) return null
 
   return (
-    <box flexShrink={0} paddingTop={1} paddingBottom={1} paddingLeft={1} paddingRight={1}>
+    // One content row, no vertical padding: this is the tallest-pressure
+    // panel in the product, so the action must cost exactly one line.
+    <box flexShrink={0} paddingLeft={1} paddingRight={1}>
       <box
         position="relative"
         flexDirection="row"

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -428,7 +428,11 @@ export function Terminal(props: TerminalProps) {
           flexDirection="row"
           paddingLeft={1}
           paddingRight={1}
-          backgroundColor={theme.backgroundPanel}
+          // `backgroundElement`, not `backgroundPanel`: the panel slot is
+          // forced alpha-0 in transparent mode, and this is an overlay you
+          // must read — the policy (theme-core) never lets readable overlays
+          // go transparent. The split-leaf name tag does the same.
+          backgroundColor={theme.backgroundElement}
         >
           <text fg={theme.warning} wrapMode="none">
             {t("terminal.scrolledBack", { lines: scrollOffset })}

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -195,15 +195,11 @@ export function TabStrip(props: {
     const titleCells = Math.max(4, dims.width - 5 - (active.chipShown ? 2 : 0) - counter.length)
     const pulse = pulsing.has(active.tab.id)
     return (
-      <box
-        flexDirection="row"
-        flexShrink={0}
-        paddingLeft={1}
-        paddingRight={1}
-        gap={1}
-        overflow="hidden"
-        backgroundColor={theme.backgroundElement}
-      >
+      // No row background: the strip is panel chrome, and the transparent-mode
+      // policy (theme-core's applyDisplayOverlay) forces panel backgrounds to
+      // alpha-0 so the host wallpaper shows through — only the active tab's
+      // chip fill paints (it must stay legible against any backdrop).
+      <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1} gap={1} overflow="hidden">
         <box flexDirection="row" flexShrink={1} paddingLeft={1} paddingRight={1} backgroundColor={theme.focusAccent}>
           {active.chipShown ? (
             <text fg={theme.backgroundElement} attributes={pulse ? TextAttributes.BOLD : undefined} wrapMode="none">
@@ -238,7 +234,10 @@ export function TabStrip(props: {
           const pulse = pulsing.has(tab.id)
           const turnColor =
             turn === "running"
-              ? theme.focusAccent
+              ? // Semantic activity color, never `focusAccent`: several tabs
+                // can be running at once, and the focus orange must keep
+                // meaning only "you are here" (the active tab's frame).
+                theme.info
               : turn === "done"
                 ? theme.success
                 : turn === "error"

--- a/packages/kobe/test/render/golden/empty.frame.txt
+++ b/packages/kobe/test/render/golden/empty.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -14,6 +12,8 @@
 |                              |
 | No active tasks — create one |
 | above.                       |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/long-labels.frame.txt
+++ b/packages/kobe/test/render/golden/long-labels.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -16,6 +14,8 @@
 |  · persist scrollback acros… |
 |  feat/alpha                  |
 |▌ · build                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/move-mode.frame.txt
+++ b/packages/kobe/test/render/golden/move-mode.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/recent-jump-row.frame.txt
+++ b/packages/kobe/test/render/golden/recent-jump-row.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -19,6 +17,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/scratch-flat.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-flat.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 | rove ─────────────────────── |
 |  feat/alpha                  |
 |▌ · build                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/scratch-path-label.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-path-label.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 | rove ─────────────────────── |
 |  feat/alpha                  |
 |▌ · build                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-pruned.frame.txt
+++ b/packages/kobe/test/render/golden/search-pruned.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | /bravo█ 2/5                  |
 |                              |
 | Kanban                       |
@@ -16,6 +14,8 @@
 | rove ─────────────────────── |
 |▌ feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-tab-title.frame.txt
+++ b/packages/kobe/test/render/golden/search-tab-title.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | /review█ 2/5                 |
 |                              |
 | Kanban                       |
@@ -16,6 +14,8 @@
 | rove ─────────────────────── |
 |▌ feat/alpha                  |
 |  · review                    |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-error.frame.txt
+++ b/packages/kobe/test/render/golden/tab-error.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-idle.frame.txt
+++ b/packages/kobe/test/render/golden/tab-idle.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-non-agent.frame.txt
+++ b/packages/kobe/test/render/golden/tab-non-agent.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · shell                     |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
+++ b/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
+++ b/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  ~ review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
+++ b/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |▌ · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tree-unknown.frame.txt
+++ b/packages/kobe/test/render/golden/tree-unknown.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
+++ b/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                ✗ |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/zen-chip.frame.txt
+++ b/packages/kobe/test/render/golden/zen-chip.frame.txt
@@ -4,9 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|                              |
 |  New task               + n  |
-|                              |
 | Kanban                       |
 | Routines                     |
 | Issues                       |
@@ -17,6 +15,8 @@
 |  · review                    |
 |  feat/bravo                  |
 |  · tests                     |
+|                              |
+|                              |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/rail-pages-baseline.test.tsx
+++ b/packages/kobe/test/render/rail-pages-baseline.test.tsx
@@ -1,0 +1,131 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Rail-page visual baseline: Kanban / Routines / Issues swap the SAME
+ * content panel, so switching between them must not move the text. The
+ * 2026-08-30 visual audit found the three pages each picked their own left
+ * inset (padding 1 / 2 / 3, so the body jumped sideways on every switch)
+ * and two of the three painted their static page titles with the accent
+ * hue, which on the default claude palette IS the focus orange.
+ *
+ * Contract pinned here, against the real render:
+ *   - every rail page's content starts at exactly x=2 (the inset the other
+ *     sibling pages — Versions / Worktrees — already used, so unifying on it
+ *     changes the fewest surfaces);
+ *   - every rail page title renders in `theme.text`, never an accent slot.
+ */
+
+import { expect, test } from "bun:test"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { type HostPageDeps, renderContentPage } from "../../src/tui-react/workspace/host-pages"
+import type { Task } from "../../src/types/task"
+import { renderComponent } from "./harness"
+
+process.env.KOBE_HOME_DIR ??= (await import("node:fs")).mkdtempSync("/tmp/kobe-rail-baseline-")
+
+// claude theme (the render-track default) — pinned as ints so a theme edit
+// fails here loudly instead of silently re-breaking the palette contract.
+const TEXT_RGB: readonly [number, number, number, number] = [234, 231, 223, 255]
+
+const SELECTED_TASK = { id: "t1", repo: "/x/kobe" } as unknown as Task
+const ONLINE = createStateCell("online")
+
+function fakeOrchestrator(): RemoteOrchestrator {
+  return {
+    listTasks: () => [SELECTED_TASK],
+    listAutomations: async () => ({ automations: [], keepsDaemonAlive: false }),
+    automationRuns: async () => ({ runs: [] }),
+    listIssues: async () => ({ repoRoot: "/x/kobe", exists: true, nextId: 99, issues: [] }),
+    listWorkItems: async () => ({ items: [] }),
+    connectionStateSignal: () => ONLINE,
+    activeTaskSignal: () => ({ get: () => null }),
+  } as unknown as RemoteOrchestrator
+}
+
+function deps(overrides: Partial<HostPageDeps>): HostPageDeps {
+  return {
+    orchestrator: fakeOrchestrator(),
+    selectedTask: SELECTED_TASK,
+    worktreesOpen: false,
+    automationsOpen: false,
+    workItemsOpen: false,
+    kanbanOpen: false,
+    updateOpen: false,
+    closeWorktrees: () => {},
+    closeAutomations: () => {},
+    closeWorkItems: () => {},
+    closeKanban: () => {},
+    closeUpdate: () => {},
+    activateTask: () => {},
+    contentFocused: true,
+    startIssueChat: async () => {},
+    engineStates: new Map(),
+    ...overrides,
+  }
+}
+
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 120))
+
+async function renderPage(title: string, overrides: Partial<HostPageDeps>) {
+  const { frame, spans } = await renderComponent(<box>{renderContentPage(deps(overrides))}</box>, {
+    width: 80,
+    height: 24,
+    providers: { dialog: true, kv: true, notifications: true },
+  })
+  await settle()
+  const text = await frame()
+  const line = text.split("\n").find((l) => l.includes(title))
+  expect(line).toBeDefined()
+  const titleSpan = (await spans()).lines.flatMap((l) => l.spans).find((span) => span.text.includes(title))
+  expect(titleSpan).toBeDefined()
+  return { text, line: line as string, titleSpan: titleSpan as NonNullable<typeof titleSpan> }
+}
+
+type RailPage = {
+  title: string
+  /** EVERY distinctive content region below the title row. The title alone
+   *  would pass even if the body kept its own old inset, which is exactly
+   *  the sideways jump this file exists to prevent — and Kanban has two
+   *  independently-padded body children (project selector, board), so both
+   *  are anchored. */
+  body: readonly string[]
+  overrides: Partial<HostPageDeps>
+}
+
+const RAIL_PAGES: readonly RailPage[] = [
+  { title: "Kanban", body: ["kobe", "┌"], overrides: { kanbanOpen: true } },
+  { title: "ROUTINES", body: ["No routines scheduled."], overrides: { automationsOpen: true } },
+  { title: "ISSUES", body: ["No open issues."], overrides: { workItemsOpen: true } },
+]
+
+for (const page of RAIL_PAGES) {
+  test(`rail page ${page.title} starts its title at x=2`, async () => {
+    const { line } = await renderPage(page.title, page.overrides)
+    // Exactly two leading cells before the title — the shared inset. The old
+    // per-page choices were 1 (Issues), 2 (Routines), 3 (Kanban), and the
+    // whole body jumped sideways on every page switch.
+    expect(line.startsWith(`  ${page.title}`)).toBe(true)
+  })
+
+  test(`rail page ${page.title} paints its title in theme.text`, async () => {
+    const { titleSpan } = await renderPage(page.title, page.overrides)
+    expect(titleSpan.fg).toBeDefined()
+    // Never the accent/focus hue: a static page title is not focus, not
+    // selection. On the default claude theme accent === focusAccent
+    // (#CC785C), so an accent-colored title read as a second focus signal.
+    expect(titleSpan.fg?.toInts()).toEqual([...TEXT_RGB])
+  })
+
+  test(`rail page ${page.title} starts its BODY at x=2 too`, async () => {
+    // The title row alone is not the contract — a page can pad its root to 2
+    // and still inset its own body children (Kanban's project selector and
+    // board each carried their own paddingLeft). Pin every content region,
+    // so a partial revert of the per-child insets fails here.
+    const { text } = await renderPage(page.title, page.overrides)
+    for (const anchor of page.body) {
+      const line = text.split("\n").find((l) => l.includes(anchor))
+      expect(line).toBeDefined()
+      expect(line).toMatch(/^ {2}\S/)
+    }
+  })
+}

--- a/packages/kobe/test/render/sidebar-create-action.test.tsx
+++ b/packages/kobe/test/render/sidebar-create-action.test.tsx
@@ -51,3 +51,15 @@ test("clicking anywhere on the action row creates a task", async () => {
   await mockMouse.click(12, lineOf(text, "New task"))
   expect(calls).toBe(1)
 })
+
+test("the action row costs exactly one line — no vertical padding", async () => {
+  // The sidebar is the most row-starved panel in the product; a one-line
+  // button wrapped in vertical padding burned three rows for one row of
+  // content. The row must start on the very first line of its own subtree.
+  const { frame } = await renderComponent(<SidebarCreateAction onAddTask={() => {}} />, {
+    width: 24,
+    height: 3,
+  })
+  const lines = (await frame()).split("\n")
+  expect(lines[0]).toContain("New task")
+})

--- a/packages/kobe/test/render/tab-strip-boxed.test.tsx
+++ b/packages/kobe/test/render/tab-strip-boxed.test.tsx
@@ -20,7 +20,7 @@ import { join } from "node:path"
 import { useState } from "react"
 import type { ChatTabTurnState } from "../../src/engine/turn-detector"
 import { useBindings } from "../../src/tui-react/lib/keymap"
-import { TabStrip } from "../../src/tui-react/workspace/tab-strip"
+import { TURN_GLYPHS, TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 import { renderComponent } from "./harness"
 
@@ -99,4 +99,44 @@ test("the scroll window follows key-driven tab switches and keeps the active tab
   // Wrap back to the first tab: the window returns with it.
   mockInput.pressTab()
   expect(await frame()).toContain("workspace-1")
+})
+
+test("the running chip uses the semantic info color, never the focus accent", async () => {
+  const tabs: readonly TerminalTab[] = [
+    { kind: "engine", id: "tab-1", title: "one", ordinal: 1 },
+    { kind: "engine", id: "tab-2", title: "two", ordinal: 2 },
+    { kind: "engine", id: "tab-3", title: "three", ordinal: 3 },
+  ]
+  const { spans } = await renderComponent(
+    <TabStrip
+      tabs={tabs}
+      activeId="tab-3"
+      turnStates={
+        new Map<string, ChatTabTurnState>([
+          ["tab-1", "running"],
+          ["tab-2", "running"],
+        ])
+      }
+      onSelect={() => {}}
+      vendor="claude"
+      liveTitles={new Map()}
+      turnVendors={new Map()}
+    />,
+    { width: 100, height: 4, providers: { kv: true } },
+  )
+  const chips = (await spans()).lines
+    .flatMap((line) => line.spans)
+    .filter((span) => span.text.includes(TURN_GLYPHS.running))
+  // Two running tabs → two chips. The defect painted them with
+  // `focusAccent`: on the default claude theme that is the SAME #CC785C as
+  // the active tab's frame, so several running tabs drowned the "you are
+  // here" signal. The semantic `info` slot (claude dark: #61AAF2) keeps
+  // activity distinct from focus on every bundled theme.
+  expect(chips.length).toBe(2)
+  const INFO: [number, number, number, number] = [97, 170, 242, 255]
+  const FOCUS: [number, number, number, number] = [204, 120, 92, 255]
+  for (const chip of chips) {
+    expect(chip.fg?.toInts()).toEqual(INFO)
+    expect(chip.fg?.toInts()).not.toEqual(FOCUS)
+  }
 })

--- a/packages/kobe/test/render/tab-strip-narrow.test.tsx
+++ b/packages/kobe/test/render/tab-strip-narrow.test.tsx
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { ChatTabTurnState } from "../../src/engine/turn-detector"
 import { TAB_STRIP_MODE_KEY } from "../../src/state/tab-strip"
+import { setTransparentBackground } from "../../src/tui-react/context/theme"
 import { TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 import { renderComponent } from "./harness"
@@ -67,4 +68,39 @@ test("desktop honours a stored `never`", async () => {
   )
   const { frame } = await renderComponent(strip("tab-2"), { width: 100, height: 4, providers: { kv: true } })
   expect(await frame()).not.toContain("╭")
+})
+
+test("narrow strip paints no row background of its own — in either display mode", async () => {
+  // The strip is panel chrome, and the WIDE branch of this same component
+  // paints no row background at all; the narrow branch must agree. The
+  // contract is "no background OF ITS OWN": the counter cell must show the
+  // exact ambient surface the empty rows below the strip show. Checked in
+  // both display modes, because each catches a different wrong token —
+  //   - `backgroundElement` (#2B2A27) stays opaque under transparency (it
+  //     exists for readable fills — chat input, split name tags) and would
+  //     smear an opaque bar across the host wallpaper;
+  //   - `backgroundPanel` (#1A1917) is invisible under transparency but in
+  //     opaque mode paints a raised bar the wide branch never has.
+  // Only the active tab's chip may paint: it must stay legible on any
+  // backdrop.
+  for (const transparent of [true, false]) {
+    setTransparentBackground(transparent)
+    try {
+      const { spans } = await renderComponent(strip("tab-2"), { width: 46, height: 4, providers: { kv: true } })
+      const lines = (await spans()).lines
+      const counter = lines[0]?.spans.find((span) => span.text.includes("2/3"))
+      // A row below the strip: nothing but the ambient surface.
+      const ambient = lines[2]?.spans[0]
+      expect(counter).toBeDefined()
+      expect(ambient).toBeDefined()
+      expect(counter?.bg?.toInts()).toEqual(ambient?.bg?.toInts())
+      // The active tab's chip fill legitimately stays opaque — sanity that
+      // the assertion above isn't passing because nothing painted at all.
+      const chip = lines[0]?.spans.find((span) => span.text.includes("a much longer"))
+      expect(chip?.bg?.toInts()).not.toEqual(ambient?.bg?.toInts())
+      expect((chip?.bg?.a ?? 0) > 0).toBe(true)
+    } finally {
+      setTransparentBackground(false)
+    }
+  }
 })

--- a/packages/kobe/test/render/terminal-scrollback-layout.test.tsx
+++ b/packages/kobe/test/render/terminal-scrollback-layout.test.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @opentui/react */
 
 import { expect, test } from "bun:test"
+import { setTransparentBackground } from "../../src/tui-react/context/theme"
 import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
 import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
 import { type RenderHandle, act, renderComponent } from "./harness"
@@ -43,5 +44,40 @@ test("entering scrollback does not resize the child PTY", async () => {
     expect(pty.geometry).toEqual(before)
   } finally {
     handle.destroy()
+  }
+})
+
+test("scrolled-back hint keeps an opaque readable background in transparent mode", async () => {
+  // The hint is an overlay you must READ ("scrolled N lines — ctrl+pgdn to
+  // follow") sitting on top of live terminal output. `backgroundPanel` is
+  // forced alpha-0 by the transparent-mode policy, which left the warning
+  // text mashed directly onto the terminal's own characters. Only
+  // `backgroundElement` survives transparency — the split-leaf name tag
+  // already relies on that for the same reason.
+  setTransparentBackground(true)
+  try {
+    const { handle, harness } = await mountTerminal()
+    try {
+      const pty = harness.last()
+      await act(async () => {
+        pty.feed(Array.from({ length: 60 }, (_, index) => `line-${index + 1}`).join("\r\n"))
+        await handle.frame()
+      })
+      await act(async () => {
+        await handle.mockMouse.scroll(20, 8, "up")
+        await handle.frame()
+      })
+      const hint = (await handle.spans()).lines
+        .flatMap((line) => line.spans)
+        .find((span) => /scrolled|已回滚/.test(span.text))
+      expect(hint).toBeDefined()
+      // backgroundElement on the claude dark theme — fully opaque even
+      // while every panel surface around it is alpha-0.
+      expect(hint?.bg?.toInts()).toEqual([43, 42, 39, 255])
+    } finally {
+      handle.destroy()
+    }
+  } finally {
+    setTransparentBackground(false)
   }
 })


### PR DESCRIPTION
## What

Six visual defects found in a 2026-08-30 audit of the real OpenTUI surface.

**Rail pages share one baseline.** Kanban / Routines / Issues swap the *same*
content panel, but each had picked its own left inset — 3, 2, and 1 — so the
body jumped sideways on every page switch. They now use the x=2 inset the
sibling Versions/Worktrees pages already had (fewest surfaces changed), and
Kanban's per-child insets are gone so its title, project selector, and board
all land on that one baseline.

**Static page titles are not focus.** Routines and Issues painted their titles
with an accent slot; on the default claude palette `accent === focusAccent`
(#CC785C), so a title read as a second focus signal. Both are now `theme.text`.

**Running ≠ focused.** The running-tab chip moves from `focusAccent` to the
semantic `info` slot. Several tabs can run at once, and painting them the focus
hue drowned the one thing focus orange should mean — the active tab's frame.

**Transparent-mode surfaces, in both directions.** The condensed tab strip
stops painting a row background: it is panel chrome, its own wide branch never
painted one, and an opaque bar smeared across the host wallpaper. The
scrolled-back hint gains one for the opposite reason — it is an overlay you
must *read*, and the `backgroundPanel` it used is forced to alpha-0, leaving
the warning text mashed onto live terminal output. `backgroundElement` is the
token that survives transparency (the split-leaf name tag relies on the same).

**Two rows back to the sidebar.** The "New task" row wrapped one line of
content in vertical padding, spending three rows in the most height-pressured
panel in the product.

Also folds four capture flags into the committed `visual:shot`
(`--width`/`--height`, `--wallpaper`, `click:X,Y`, plus the PageUp/PageDown key
names Playwright rejects when generically capitalized) and deletes a scratch
duplicate of that script.

## Verification

- **Mutation-tested twice, 16 mutations, all red**, re-run after the final
  rebase. Round 2 changed the mutation *site* rather than replaying round 1:
  deleting the `backgroundColor` prop outright, collapsing the whole `running`
  branch, and partially reverting only Kanban's per-child insets.
- Two round-2 mutations initially **survived** and both were real gaps, now
  closed: the narrow-strip test only checked one display mode (it now compares
  the counter cell against the ambient surface in both, so `backgroundPanel`
  and `backgroundElement` each fail), and the rail-page test pinned only the
  title row (it now anchors every content region, so a body-only revert fails).
- Sidebar goldens regenerated — the diff is exactly the two reclaimed rows.
- All four tracks green: render 316, vitest 3876, socket 635, kobe-web 559.
  Lint, typecheck, i18n (699 keys × 2 locales) clean.

## Screenshots

Before/after for all six, captured through the ground-truth path
(browser `/harness` → xterm.js → PTY sidecar → real OpenTUI), archived at
`.scratch/ui-visual-shots/final/{before,after}/`. Transparent-mode pairs use
the new loud-gradient wallpaper — against the near-black capture wallpaper an
alpha-0 panel and an opaque one photograph identically.

## Note on provenance

This branch was started by an engine that hit its quota; I picked it up cold.
Its Terminal fix was **commented but never applied** (`backgroundPanel` was
still in the source under a comment explaining why it should be
`backgroundElement`) and its tests did not typecheck. Both fixed here.