### PR TITLE
fix: show engine deaths, and tell a rate limit apart from a crash

### DIFF
--- a/.changeset/engine-death-visible.md
+++ b/.changeset/engine-death-visible.md
@@ -1,0 +1,20 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Show engine deaths, and tell a rate limit apart from a crash
+
+A killed engine used to be a UI no-op. The exit record (code, signal, the
+403/quota text) was already written to `pty-exits.json`, but the only consumer
+was the CLI: the observer folded the death into idle, so a dead tab rendered
+identically to a shell that had never run anything. Deaths now reach the
+sidebar and the tab strip as `†`, and land in the Inbox as their own episode.
+
+The tab strip drew `rate_limited` and `error` with the same `!`, while the
+sidebar has always drawn them apart — one tab, two surfaces, two answers. The
+strip now uses the rail's own glyphs (`◷` rate limited, `†` dead), and a
+rate-limited Inbox card shows when its auto-resume fires ("resumes 3:14 PM")
+— a time the daemon has always persisted and nothing ever displayed.
+
+Kimi can now classify its own failures, so a Kimi rate limit reaches
+`rate_limited` (and arms auto-resume) instead of reducing to a generic error.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -56,8 +56,9 @@ on the **tab rows** underneath:
 | `?` | Needs your input: a permission prompt or a question |
 | `●` | Turn finished, and you haven't looked yet |
 | `○` | Idle or not yet observed. Includes a finished turn you've already seen |
-| `◷` | Rate limited |
+| `◷` | Rate limited — the engine is waiting out a quota window |
 | `×` | Error, including a failed worktree deletion |
+| `†` | The engine process exited or was killed |
 | `·` | Not an agent tab, or a custom engine without activity tracking |
 
 A tab labelled `⚠ <name>` is a live hosted session that was missing from the
@@ -73,9 +74,14 @@ completion has a later timestamp and appears unread as usual.
 
 Each tab row reports its **own** activity, not the task's roll-up. Tab 2 can
 spin while tab 1 rests. The tab strip at the top of the workspace uses a
-similar vocabulary (`●` running, `✓` done, `!` error, `?` needs input, `○`
-idle) over the same saved timestamps: a `✓` you have already read settles
-back to `○`, and stays settled after a restart.
+same vocabulary (`●` running, `✓` done, `!` error, `◷` rate limited, `†`
+exited, `?` needs input, `○` idle) over the same saved timestamps: a `✓` you
+have already read settles back to `○`, and stays settled after a restart.
+
+`†` and `×` are different questions. `×` is an engine that ran and reported a
+failed turn — read the tab. `†` is an engine that is no longer running, so the
+answer is to start it again; the exit code and the last error line are kept
+(`rove api inspect`) even after the session is gone.
 
 ## Managing Tasks in the sidebar
 
@@ -111,10 +117,12 @@ changed. See [Concepts → Task](CONCEPTS.md#task) for the three Task kinds and
 *where was I?*, with one section for each:
 
 - **ATTENTION.** Pending items, oldest first. An item appears when a turn
-  completes, a session asks for input, hits a rate limit, or errors. Most
-  items target one task-and-tab; events without a tab identity target the
-  whole task instead. A newer event for the same target replaces the older
-  one, and starting a new turn clears it.
+  completes, a session asks for input, hits a rate limit, errors, or when the
+  engine process exits. Most items target one task-and-tab; events without a
+  tab identity target the whole task instead. A newer event for the same
+  target replaces the older one, and starting a new turn clears it.
+  A rate-limited item also names when its automatic resume is due
+  (`resumes 3:14 PM`), so you can tell a wait from a dead end.
 - **RECENT.** The last handful of tabs you visited, most recent first. These
   aren't pending work, just jump targets; a spinner marks the ones still
   running.

--- a/packages/kobe-daemon/src/daemon/activity-arbitrate.ts
+++ b/packages/kobe-daemon/src/daemon/activity-arbitrate.ts
@@ -20,8 +20,13 @@
  * source by adding a slot and a rule here, never by special-casing a writer:
  *
  *   1. a hook entry in a STICKY state (`turn_complete` / `permission_needed`
- *      / `error` / `rate_limited`) always wins — those mean "a human should
- *      look", carry no output by nature, and observation must never dim them.
+ *      / `error` / `rate_limited` / `dead`) always wins — those mean "a human
+ *      should look", carry no output by nature, and observation must never dim
+ *      them. `dead` is the strongest case: the process is GONE, so no live
+ *      claim about it can be true, and observation can only ever answer "at
+ *      rest" — which is precisely what made a killed engine read as an idle
+ *      one. It is displaced only by a newer hook event, i.e. a new session in
+ *      the same tab.
  *   2. a hook `running` wins UNLESS an observed `rest` fact is fresher than
  *      the claim (herdr's `fallback_not_older_than_hook` — a stale
  *      observation must never idle a fresh turn) AND the claim is at least
@@ -39,7 +44,9 @@
 import { type EngineSessionInfo, STICKY_STATES } from "./activity-reduce.ts"
 import type { EngineActivityDetail, TaskActivityState } from "./contracts.ts"
 
-/** A hook-claimed state. `state` is never "idle" — hook idle clears the slot. */
+/** A hook-claimed state. `state` is never "idle" — hook idle clears the slot.
+ *  `dead` is written here too (by `recordEngineDeath`, not by a hook event):
+ *  it is a claim about the ENGINE, which is what this slot holds. */
 export interface HookSlot {
   readonly state: TaskActivityState
   readonly at: number

--- a/packages/kobe-daemon/src/daemon/activity-debug-dump.ts
+++ b/packages/kobe-daemon/src/daemon/activity-debug-dump.ts
@@ -1,0 +1,80 @@
+/**
+ * `kobe api inspect`'s raw view of the activity registry — a pure projection,
+ * split out of `activity-registry.ts` (file-size cap).
+ *
+ * Deliberately NOT the wire payload: a production bug report needs the fields
+ * `engine-state` omits — the probe vendor, whether a lapse watchdog is armed,
+ * and which SOURCE won the arbitration — because those are what distinguish
+ * "the hook says running" from "we observed it running" when the two disagree.
+ */
+
+import type { EffectiveActivity } from "./activity-arbitrate.ts"
+import type { EngineActivityDetail, TaskActivityState } from "./contracts.ts"
+
+/** The task-rollup fields the dump reads (the registry owns the real shape). */
+export interface DumpableEntry {
+  readonly state: TaskActivityState
+  readonly at: number
+  readonly vendor?: string
+  readonly detail?: EngineActivityDetail
+  readonly lapse?: unknown
+}
+
+/** The per-tab record the dump reads: its arbitrated result + its hook slot. */
+export interface DumpableTabEntry {
+  readonly effective: EffectiveActivity
+  readonly hook?: { readonly lapse?: unknown }
+}
+
+export interface ActivityDebugTask {
+  readonly state: TaskActivityState
+  readonly at: number
+  readonly vendor?: string
+  readonly lapseArmed: boolean
+}
+
+export interface ActivityDebugTab extends ActivityDebugTask {
+  readonly observed?: true
+  readonly source: "hook" | "observed"
+  /** Present for a `dead` tab: how the engine process died. Without it an
+   *  inspect dump said "dead" and nothing about why, which is the whole
+   *  reason the exit record is worth carrying. */
+  readonly exit?: EngineActivityDetail["exit"]
+}
+
+export interface ActivityDebugSnapshot {
+  readonly tasks: Record<string, ActivityDebugTask>
+  readonly tabs: Record<string, Record<string, ActivityDebugTab>>
+}
+
+export function buildActivityDebugSnapshot(
+  activity: ReadonlyMap<string, DumpableEntry>,
+  tabActivity: ReadonlyMap<string, ReadonlyMap<string, DumpableTabEntry>>,
+): ActivityDebugSnapshot {
+  const tasks: Record<string, ActivityDebugTask> = {}
+  for (const [taskId, e] of activity) {
+    tasks[taskId] = {
+      state: e.state,
+      at: e.at,
+      ...(e.vendor ? { vendor: e.vendor } : {}),
+      lapseArmed: e.lapse !== undefined,
+    }
+  }
+  const tabs: Record<string, Record<string, ActivityDebugTab>> = {}
+  for (const [taskId, tabMap] of tabActivity) {
+    const out: Record<string, ActivityDebugTab> = {}
+    for (const [tabId, e] of tabMap) {
+      out[tabId] = {
+        state: e.effective.state,
+        at: e.effective.at,
+        ...(e.effective.vendor ? { vendor: e.effective.vendor } : {}),
+        ...(e.effective.source === "observed" ? { observed: true as const } : {}),
+        ...(e.effective.detail?.exit ? { exit: e.effective.detail.exit } : {}),
+        lapseArmed: e.hook?.lapse !== undefined,
+        source: e.effective.source,
+      }
+    }
+    tabs[taskId] = out
+  }
+  return { tasks, tabs }
+}

--- a/packages/kobe-daemon/src/daemon/activity-observer.ts
+++ b/packages/kobe-daemon/src/daemon/activity-observer.ts
@@ -287,6 +287,13 @@ export function startActivityObserver(
         if (!session || track.vendor === undefined) continue
         io.onEngineEvidence?.(track.taskId, track.tabId, { walkVendor: track.vendor, title: session.title })
         if (track.vendor === null) {
+          // The engine is gone from this session's foreground. That is
+          // positive evidence against a live claim, so a stale hook `running`
+          // still gets corrected — but it is NOT the death badge: the shell
+          // outlives its engine, and a user who quit their agent on purpose
+          // has an ordinary idle tab. The `dead` state comes from the exit
+          // RECORD (pty-exit-watch.ts), which knows the exit code and the
+          // error text; arbitration rule 0 keeps it from being dimmed here.
           applyRest(track, "no engine in foreground")
           continue
         }

--- a/packages/kobe-daemon/src/daemon/activity-reduce.ts
+++ b/packages/kobe-daemon/src/daemon/activity-reduce.ts
@@ -90,6 +90,10 @@ export const STICKY_STATES: ReadonlySet<TaskActivityState> = new Set([
   "permission_needed",
   "error",
   "rate_limited",
+  // A dead engine writes nothing, ever — the probe reads "stale" forever, so
+  // the watchdog would idle exactly the tab whose engine is gone. It clears
+  // when a new session starts in that tab (session-start → idle).
+  "dead",
 ])
 
 export function resolveEngineStateTtlMs(): number {

--- a/packages/kobe-daemon/src/daemon/activity-registry.ts
+++ b/packages/kobe-daemon/src/daemon/activity-registry.ts
@@ -1,4 +1,5 @@
 import { type EffectiveActivity, type HookSlot, type ObservedSlot, recomputeTabActivity } from "./activity-arbitrate.ts"
+import { type ActivityDebugSnapshot, buildActivityDebugSnapshot } from "./activity-debug-dump.ts"
 import {
   type ActivityLiveness,
   type ActivityLivenessProbe,
@@ -352,6 +353,59 @@ export class DaemonActivityRegistry {
     return prev?.source === "hook" ? "corrected-hook-running" : "observed-idle"
   }
 
+  /**
+   * Record that a tab's ENGINE PROCESS died, from the pty-host's durable exit
+   * record (`pty-exits.json` via `pty-exit-watch.ts`).
+   *
+   * This is the one activity fact no hook can ever report: a killed engine
+   * (SIGTERM/SIGKILL, or a wrapper that exits under it) runs no Stop, no
+   * SessionEnd, nothing. Before this existed the death reached the UI as
+   * `applyRest(... "no engine in foreground")` — folded into idle — so a dead
+   * tab rendered byte-identically to a shell that never ran anything.
+   *
+   * Written into the HOOK slot, because it is a claim about the engine, and
+   * arbitrated by rule 0 (see activity-arbitrate.ts): it outranks a stale
+   * `running`, and a NEWER hook event (a fresh session in the tab) displaces
+   * it. A clean exit is not a death — the caller filters those, matching the
+   * exit store's own noise rule.
+   */
+  recordEngineDeath(
+    taskId: string,
+    tabId: string,
+    exit: { code?: number | null; signal?: string | null; lastLine?: string },
+    at: number,
+  ): void {
+    const tabs = this.tabActivity.get(taskId) ?? new Map<string, TabEntry>()
+    const prev = tabs.get(tabId)
+    // A hook event from AFTER the death is a new session in this tab — the
+    // record is history by then and must not bury a live engine.
+    if (prev?.hook && prev.hook.at > at) return
+    if (prev?.hook?.lapse) clearTimeout(prev.hook.lapse)
+    const detail: EngineActivityDetail = {
+      exit: {
+        ...(exit.code !== undefined ? { code: exit.code } : {}),
+        ...(exit.signal !== undefined ? { signal: exit.signal } : {}),
+        ...(exit.lastLine ? { lastLine: exit.lastLine } : {}),
+      },
+    }
+    const vendor = prev?.hook?.vendor ?? prev?.observed?.vendor
+    const session = prev?.hook?.session ?? prev?.observed?.session
+    // No lapse watchdog: `dead` is sticky (a dead engine writes nothing, so
+    // the liveness probe would idle exactly the tab that needs the badge).
+    const hook: TabHookEntry = {
+      state: "dead",
+      at,
+      detail,
+      ...(vendor ? { vendor } : {}),
+      ...(session ? { session } : {}),
+    }
+    const effective = recomputeTabActivity({ hook, ...(prev?.observed ? { observed: prev.observed } : {}) }, at)
+    if (!effective) return
+    tabs.set(tabId, { hook, ...(prev?.observed ? { observed: prev.observed } : {}), effective })
+    this.tabActivity.set(taskId, tabs)
+    this.bus.publish("engine-state", this.payload(taskId, effective, tabId))
+  }
+
   clearTask(taskId: string): void {
     const gone = this.activity.get(taskId)
     if (gone?.lapse) clearTimeout(gone.lapse)
@@ -394,52 +448,12 @@ export class DaemonActivityRegistry {
   }
 
   /**
-   * Raw diagnostic dump for `kobe api inspect` — every task/tab entry with
-   * the fields the wire payload deliberately omits (probe vendor, whether a
-   * lapse watchdog is armed, which source won the arbitration). Read-only;
-   * production bug reports need to see what the registry ACTUALLY holds, not
-   * the projected payload.
+   * Raw diagnostic dump for `kobe api inspect` — see
+   * {@link buildActivityDebugSnapshot} for what it shows and why it is not
+   * the wire payload.
    */
-  debugSnapshot(): {
-    tasks: Record<string, { state: TaskActivityState; at: number; vendor?: string; lapseArmed: boolean }>
-    tabs: Record<
-      string,
-      Record<
-        string,
-        {
-          state: TaskActivityState
-          at: number
-          vendor?: string
-          lapseArmed: boolean
-          observed?: true
-          source: "hook" | "observed"
-        }
-      >
-    >
-  } {
-    const dump = (e: ActivityEntry) => ({
-      state: e.state,
-      at: e.at,
-      ...(e.vendor ? { vendor: e.vendor } : {}),
-      lapseArmed: e.lapse !== undefined,
-    })
-    const dumpTab = (e: TabEntry) => ({
-      state: e.effective.state,
-      at: e.effective.at,
-      ...(e.effective.vendor ? { vendor: e.effective.vendor } : {}),
-      ...(e.effective.source === "observed" ? { observed: true as const } : {}),
-      lapseArmed: e.hook?.lapse !== undefined,
-      source: e.effective.source,
-    })
-    const tasks: Record<string, ReturnType<typeof dump>> = {}
-    for (const [taskId, entry] of this.activity) tasks[taskId] = dump(entry)
-    const tabs: Record<string, Record<string, ReturnType<typeof dumpTab>>> = {}
-    for (const [taskId, tabMap] of this.tabActivity) {
-      const out: Record<string, ReturnType<typeof dumpTab>> = {}
-      for (const [tabId, entry] of tabMap) out[tabId] = dumpTab(entry)
-      tabs[taskId] = out
-    }
-    return { tasks, tabs }
+  debugSnapshot(): ActivityDebugSnapshot {
+    return buildActivityDebugSnapshot(this.activity, this.tabActivity)
   }
 
   close(): void {

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -159,6 +159,31 @@ export class AttentionInboxStore {
   }
 
   /**
+   * Record a `dead` episode: the tab's engine PROCESS is gone, from the
+   * pty-host's exit record (pty-exit-watch.ts). Its own path rather than a
+   * `record()` kind, for the same reason `recordPromptDeferred` has one —
+   * there is no hook event behind it, so it has no {@link EngineActivityKind}.
+   *
+   * This is the queue's blindest spot until now: every OTHER episode is
+   * something the engine reported about itself, so an engine that was KILLED
+   * (no Stop, no SessionEnd, no hook at all) produced no episode, and the one
+   * surface whose job is "what needs me" stayed silent about seven dead
+   * agents at once (2026-08-30).
+   *
+   * Deduped per task+tab like every other episode: a fresh death replaces the
+   * previous episode for that tab and takes the queue tail.
+   */
+  async recordEngineDeath(taskId: string, tabId: string, detail: EngineActivityDetail, at: number): Promise<void> {
+    await this.enqueue(async () => {
+      const key = attentionInboxItemKey({ taskId, tabId })
+      const next = new Map(this.items)
+      next.delete(key)
+      next.set(key, { taskId, tabId, state: "dead", detail, unread: true, at })
+      await this.commit(next)
+    })
+  }
+
+  /**
    * Record a `prompt_deferred` episode (issue #78 B-layer): a prompt the
    * delivery gate blocked was accepted into the DeferredPromptsStore, and the
    * episode points at that record by id (the prompt text is NOT copied here —

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -232,6 +232,18 @@ export interface EngineActivityDetail {
   readonly subagent?: { readonly type?: string; readonly id?: string }
   readonly note?: string
   /**
+   * For the `dead` state: how the engine process died, straight off the
+   * pty-host's exit record. `code`/`signal` answer "who killed it" (143 =
+   * 128+SIGTERM, an outside signal, not a self-exit) and `lastLine` is the
+   * last non-blank line of the recorded tail — the 403 / auth / quota text
+   * that was already on disk but reached no UI.
+   */
+  readonly exit?: {
+    readonly code?: number | null
+    readonly signal?: string | null
+    readonly lastLine?: string
+  }
+  /**
    * Reference to a daemon-owned deferred-prompt record (issue #78 B-layer).
    * Present only on `prompt_deferred` inbox episodes. The prompt TEXT lives in
    * the DeferredPromptsStore, never here — this contract describes engine
@@ -243,7 +255,21 @@ export interface EngineActivityDetail {
   }
 }
 
-export type TaskActivityState = "idle" | "running" | "turn_complete" | "rate_limited" | "permission_needed" | "error"
+export type TaskActivityState =
+  | "idle"
+  | "running"
+  | "turn_complete"
+  | "rate_limited"
+  | "permission_needed"
+  | "error"
+  /**
+   * The engine PROCESS died — an exit record exists for the tab's session
+   * (`pty-exits.json`). Distinct from `error`: `error` is an engine that ran
+   * and reported a failed turn, `dead` is an engine that is no longer there.
+   * A killed engine fires no hook at all, so this state can only ever be
+   * written from the exit record, never from `reduceActivity`.
+   */
+  | "dead"
 
 /**
  * The ENGINE half of a turn record (issue #32) — what the vendor's adapter
@@ -291,6 +317,9 @@ export const ATTENTION_INBOX_STATES = [
   "error",
   "rate_limited",
   "prompt_deferred",
+  /** The engine PROCESS died (pty-host exit record). An episode a user must
+   *  see: nothing else in the queue tells them the agent is simply gone. */
+  "dead",
 ] as const
 
 export type AttentionInboxState = (typeof ATTENTION_INBOX_STATES)[number]

--- a/packages/kobe-daemon/src/daemon/pty-exit-watch.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-watch.ts
@@ -1,17 +1,24 @@
 /**
- * `session.exited` plugin events from the pty-host's death records.
+ * Engine deaths from the pty-host's durable exit records — TWO consumers.
  *
  * The PTY host is a separate process with no daemon-socket connection, but it
  * already persists every abnormal child exit to `pty-exits.json`
  * (`pty-exit-store.ts`). The daemon watches that file, diffs records by
- * `key + at`, and fires one `session.exited` per NEW record — the only signal
- * that exists when an engine CRASHES (its own `session.end` hook never runs).
+ * `key + at`, and per NEW record:
+ *
+ *   1. fires a `session.exited` PLUGIN event (plugin-host only), and
+ *   2. writes the tab's activity state to `dead` in the registry — the half
+ *      that reaches the UI. Without it a killed engine (SIGTERM: no Stop, no
+ *      SessionEnd, no hook of any kind) folded into idle and the tab rendered
+ *      exactly like a shell that never ran anything.
  *
  * The first read after daemon start is baseline, mirroring the plugin event
  * reducer's first-snapshot rule: pre-existing corpses must not re-fire.
  */
 
 import type { PluginHost } from "../plugins/runtime.ts"
+import type { DaemonActivityRegistry } from "./activity-registry.ts"
+import type { AttentionInboxStore } from "./attention-inbox.ts"
 import { startFileWatchTrigger } from "./file-watch-trigger.ts"
 import { defaultPtyExitsPath } from "./paths.ts"
 import { type PtyExitRecord, readPtyExitRecords } from "./pty-exit-store.ts"
@@ -23,6 +30,11 @@ const KEY_RE = /^(.+?)::(.+)$/
 export interface PtyExitWatchOptions {
   readonly homeDir?: string
   readonly plugins: () => Pick<PluginHost, "handleUiReport"> | null
+  /** Activity registry — where a death becomes the tab's live badge. */
+  readonly activity?: Pick<DaemonActivityRegistry, "recordEngineDeath">
+  /** Attention Inbox — where a death becomes a durable episode, so it is
+   *  still findable after the badge scrolls out of view. */
+  readonly inbox?: Pick<AttentionInboxStore, "recordEngineDeath">
   readonly log?: (line: string) => void
   /** Test seam. */
   readonly path?: string
@@ -43,9 +55,34 @@ export function startPtyExitWatch(opts: PtyExitWatchOptions): () => void {
       if (seen.get(record.key) === record.at) continue
       seen.set(record.key, record.at)
       host.handleUiReport({ kind: "session.exited", ...exitReport(record) })
+      publishDeath(record)
     }
     // The file caps at 50 records; prune dropped keys so `seen` tracks it.
     for (const key of seen.keys()) if (!(key in records)) seen.delete(key)
+  }
+
+  /**
+   * Turn a death record into the tab's `dead` activity state. Skipped when the
+   * key names no tab (task-level records have nothing to badge) and when the
+   * timestamp is unparseable — a death with no clock can't be arbitrated
+   * against a hook claim, and guessing `now` would let an OLD record bury a
+   * live engine on the next daemon start.
+   */
+  const publishDeath = (record: PtyExitRecord): void => {
+    const registry = opts.activity
+    if (!registry && !opts.inbox) return
+    const match = KEY_RE.exec(record.key)
+    const taskId = match?.[1]
+    const tabId = match?.[2]
+    if (!taskId || !tabId) return
+    const at = Date.parse(record.at)
+    if (!Number.isFinite(at)) return
+    const lastLine = lastErrorLine(record.tail)
+    const exit = { code: record.code, signal: record.signal, ...(lastLine ? { lastLine } : {}) }
+    registry?.recordEngineDeath(taskId, tabId, exit, at)
+    opts.inbox
+      ?.recordEngineDeath(taskId, tabId, { exit }, at)
+      .catch((err) => opts.log?.(`pty-exit inbox: ${String(err)}`))
   }
 
   // Watch BEFORE the baseline read (issue #61 pattern): the trigger's
@@ -62,6 +99,15 @@ export function startPtyExitWatch(opts: PtyExitWatchOptions): () => void {
   // Baseline: everything already on disk predates this daemon.
   for (const record of Object.values(readPtyExitRecords(path))) seen.set(record.key, record.at)
   return stop
+}
+
+/** Last non-blank line of a recorded tail — the 403 / auth / quota text. */
+export function lastErrorLine(tail: readonly string[]): string | undefined {
+  for (let i = tail.length - 1; i >= 0; i--) {
+    const line = (tail[i] ?? "").trim()
+    if (line.length > 0) return line
+  }
+  return undefined
 }
 
 function exitReport(record: PtyExitRecord): { taskId?: string; detail: Record<string, unknown> } {

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -260,6 +260,11 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     ? startPtyExitWatch({
         ...(options.homeDir ? { homeDir: options.homeDir } : {}),
         plugins: () => pluginHost,
+        // The halves that reach the UI: a death becomes the tab's `dead`
+        // activity badge AND a durable Inbox episode — not just a plugin
+        // event with no subscribers.
+        activity,
+        inbox,
         log: (line) => logDaemonInfo("plugin-host", line),
       })
     : () => {}

--- a/packages/kobe/src/engine/codex-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/codex-local/hook-adapter.ts
@@ -14,7 +14,8 @@
  *   - `UserPromptSubmit` → turn-start
  *   - `Stop`             → turn-complete
  *   - `PostToolUse`(Bash)→ worktree-created (inherited worktree-watch observer)
- * NOT wired: `turn-failed` (Codex has no StopFailure/error event), `session-end`
+ * NOT wired: `turn-failed` (Codex's hook enum has no failure event at all —
+ * see `activityDetailFromPayload`), `session-end`
  * (no SessionEnd), `awaiting-input` (Codex's only "waiting" event is
  * `PermissionRequest`, an allow/deny DECISION hook — installing kobe's observer
  * on it could interfere with Codex's approval flow, the same provider-hook trap
@@ -68,7 +69,18 @@ export class CodexHookAdapter extends JsonHookAdapter {
   }
 
   /** Codex spells the tool fields `tool_name`/`tool_response`; compaction
-   *  carries the same `trigger` values as Claude. */
+   *  carries the same `trigger` values as Claude.
+   *
+   *  No `turn-failed` branch, and that is not an oversight: Codex's hook
+   *  event enum (verified against codex-cli 0.149.1's binary) is PreToolUse /
+   *  PermissionRequest / PostToolUse / PreCompact / PostCompact / SessionStart
+   *  / SessionEnd / UserPromptSubmit / SubagentStart / SubagentStop / Stop —
+   *  there is no failure event to classify. `TurnFailed` exists in the binary
+   *  but is an app-server THREAD event (`turn.failed`), not a hook, so it
+   *  never reaches a `kobe hook` invocation. Codex therefore cannot reach
+   *  `rate_limited` through hooks at all; its quota probe
+   *  (`vendorsWithQuotaProbe`) is the only path, and adding a classifier here
+   *  would be dead code pretending otherwise. */
   override activityDetailFromPayload(
     kind: EngineActivityKind,
     payload: Record<string, unknown>,

--- a/packages/kobe/src/engine/hook-events.ts
+++ b/packages/kobe/src/engine/hook-events.ts
@@ -85,8 +85,21 @@ export const TASK_ACTIVITY_STATES = [
   "rate_limited",
   "permission_needed",
   "error",
-] as const
-export type TaskActivityState = (typeof TASK_ACTIVITY_STATES)[number]
+  /** The engine PROCESS is gone (pty-host exit record) — see the daemon's
+   *  `TaskActivityState`. Never produced by `reduceActivity`: a killed engine
+   *  fires no hook. */
+  "dead",
+] as const satisfies readonly DaemonTaskActivityState[]
+/**
+ * Re-exported from the daemon, which OWNS this vocabulary (kobe depends on
+ * kobe-daemon, never the reverse). The runtime list above is the same set —
+ * `satisfies` rejects a member the daemon doesn't have, and the assignment
+ * below rejects one it has that the list is missing, so the two cannot drift
+ * the way the reducer once did.
+ */
+export type TaskActivityState = DaemonTaskActivityState
+const _everyStateListed: readonly (typeof TASK_ACTIVITY_STATES)[number][] = [] as readonly TaskActivityState[]
+void _everyStateListed
 
 /**
  * The activity state machine. Defined ONCE, in the daemon package — the
@@ -96,3 +109,4 @@ export type TaskActivityState = (typeof TASK_ACTIVITY_STATES)[number]
  * @see {@link import("@sma1lboy/kobe-daemon/daemon/activity-reduce").reduceActivity}
  */
 export { reduceActivity } from "@sma1lboy/kobe-daemon/daemon/activity-reduce"
+import type { TaskActivityState as DaemonTaskActivityState } from "@sma1lboy/kobe-daemon/daemon/contracts"

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -136,6 +136,42 @@ export function mergeKimiHooks(
   return `${lead}${renderKimiHookBlock(inv, opts)}\n`
 }
 
+/**
+ * Kimi StopFailure payload → the neutral failure class. Kimi vocabulary lives
+ * here with the rest of the translation, never in `kobe hook`.
+ *
+ * Two fields, because Kimi's two StopFailure call sites disagree about what
+ * they put in `error_type` (verified against the installed 0.37.2 binary):
+ *
+ *   - `error_type` is the JS ERROR CLASS name, not a category —
+ *     `APIProviderRateLimitError` / `APIProviderQuotaExhaustedError` for a
+ *     limit, `APIStatusError` for anything else with a status code (a 429
+ *     included, which is why the class name alone is not enough).
+ *   - `error_message` carries a `[provider.*]` code prefix from Kimi's own
+ *     ErrorCodes — `provider.rate_limit` for a limit, and
+ *     `provider.auth_error` for the 403 in the 2026-08-30 incident
+ *     ("You've reached your 5-hour usage limit"), which Kimi files under
+ *     AUTH but is a quota wall.
+ *
+ * `billing`, not `rate_limit`, for the auth/quota-wall case: it needs a human
+ * (re-auth, or a plan change), and the daemon deliberately does NOT arm a
+ * resume timer for `billing`. A plain 429 IS `rate_limit` and does arm one.
+ */
+export function kimiFailureDetail(payload: Record<string, unknown>): EngineActivityDetail {
+  const type = typeof payload.error_type === "string" ? payload.error_type : ""
+  const message = typeof payload.error_message === "string" ? payload.error_message : ""
+  const note = type || undefined
+  const failure = ((): EngineActivityDetail["failure"] => {
+    if (type === "APIProviderRateLimitError" || message.includes("provider.rate_limit")) return "rate_limit"
+    // Quota exhaustion rides a 429 too, but Kimi codes it `provider.api_error`
+    // — the CLASS name is the only thing that distinguishes it.
+    if (type === "APIProviderQuotaExhaustedError") return "rate_limit"
+    if (message.includes("provider.auth_error")) return "billing"
+    return "other"
+  })()
+  return { failure, ...(note ? { note } : {}) }
+}
+
 export class KimiHookAdapter implements EngineHookAdapter {
   readonly vendor = "kimi" as const
 
@@ -148,11 +184,16 @@ export class KimiHookAdapter implements EngineHookAdapter {
   }
 
   /** Kimi's stdin payload spells tool fields `tool_name`; the permission
-   *  event is always a permission (Kimi has no elicitation notification). */
+   *  event is always a permission (Kimi has no elicitation notification).
+   *  `turn-failed` classifies the StopFailure — without it every Kimi
+   *  failure reduced to `error` and Kimi could never reach `rate_limited`
+   *  (so it never armed auto-resume), which is exactly what happened when
+   *  Kimi hit its 5-hour limit on 2026-08-30. */
   activityDetailFromPayload(
     kind: EngineActivityKind,
     payload: Record<string, unknown>,
   ): EngineActivityDetail | undefined {
+    if (kind === "turn-failed") return kimiFailureDetail(payload)
     if (kind === "awaiting-input") return { waiting: "permission" }
     if (kind === "tool-pre" || kind === "tool-post" || kind === "tool-failed") {
       return { tool: { ...(typeof payload.tool_name === "string" ? { name: payload.tool_name } : {}) } }

--- a/packages/kobe/src/engine/turn-detector.ts
+++ b/packages/kobe/src/engine/turn-detector.ts
@@ -17,8 +17,23 @@ import { engineEntry } from "./registry.ts"
 
 /** `needs_input` comes from hooks (permission prompt / question dialog via
  *  `turn-state-merge.ts`) or, for marker-less engines with a screen
- *  manifest, from the poll's screen classifier (`engine/screen-state.ts`). */
-export type ChatTabTurnState = "idle" | "running" | "done" | "error" | "needs_input" | "unknown"
+ *  manifest, from the poll's screen classifier (`engine/screen-state.ts`).
+ *
+ *  `rate_limited` and `dead` are hook/registry-only (the poll cannot see
+ *  either) and are deliberately NOT folded into `error`: the three ask for
+ *  opposite actions — a rate limit clears on its own, an error wants you to
+ *  look, and a dead engine needs restarting. The sidebar has always drawn
+ *  them apart; collapsing them here made the tab strip disagree with the rail
+ *  about the same tab. */
+export type ChatTabTurnState =
+  | "idle"
+  | "running"
+  | "done"
+  | "error"
+  | "rate_limited"
+  | "dead"
+  | "needs_input"
+  | "unknown"
 
 export interface TurnCompletionMarker {
   /**

--- a/packages/kobe/src/tui-react/component/kanban-card.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-card.tsx
@@ -27,6 +27,7 @@ const ACTIVITY_BADGE: Partial<
   rate_limited: { labelKey: "tasks.activity.rateLimited", tone: "warning" },
   permission_needed: { labelKey: "tasks.activity.permissionNeeded", tone: "warning" },
   error: { labelKey: "tasks.activity.error", tone: "error" },
+  dead: { labelKey: "tasks.activity.dead", tone: "error" },
 }
 
 export function KanbanCard(props: {

--- a/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
+++ b/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
@@ -30,6 +30,7 @@ import {
   partitionAttentionInboxAvailability,
   windowInboxRows,
 } from "./attention-inbox-core"
+import { itemColor, itemGlyph, itemStateKey, quotaResumeNote } from "./inbox-item-view"
 import { readInboxVisits } from "./inbox-visits"
 import { activeTabIdFor, knownTaskTab, taskTabExists } from "./terminal-tabs-shared"
 
@@ -42,35 +43,6 @@ const DIALOG_CHROME_ROWS = 12
 const AGE_REFRESH_MS = 30_000
 /** Identity keeps at least this many cells before the badge drops its label. */
 const IDENTITY_FLOOR_CELLS = 16
-
-function itemColor(state: AttentionInboxItem["state"], theme: ReturnType<typeof useTheme>["theme"]) {
-  if (state === "permission_needed") return theme.warning
-  if (state === "turn_complete") return theme.success
-  if (state === "prompt_deferred") return theme.warning
-  return theme.error
-}
-
-function itemGlyph(state: AttentionInboxItem["state"]): string {
-  if (state === "permission_needed") return "?"
-  if (state === "turn_complete") return "✓"
-  // `◷`, the sidebar's rate-limited glyph, not the `⌛` this used to show:
-  // U+231B carries the Unicode Emoji property, so macOS resolved it to
-  // AppleColorEmoji — a 2.13-cell colour glyph in a 1-cell column, which
-  // both overflowed and broke the pane's monochrome ink (2026-08-15).
-  if (state === "rate_limited") return "◷"
-  // `≡` (no Emoji property) for a queued message — a stack, not a failure.
-  if (state === "prompt_deferred") return "≡"
-  return "!"
-}
-
-/** i18n key suffix for the state word shown next to the glyph. */
-function itemStateKey(state: AttentionInboxItem["state"]): string {
-  if (state === "permission_needed") return "workspace.inbox.state.needsInput"
-  if (state === "turn_complete") return "workspace.inbox.state.done"
-  if (state === "rate_limited") return "workspace.inbox.state.rateLimited"
-  if (state === "prompt_deferred") return "workspace.inbox.state.promptDeferred"
-  return "workspace.inbox.state.error"
-}
 
 /**
  * Engine-registry tab title for a (task, tab) pair — "" when unknown.
@@ -397,6 +369,14 @@ export function AttentionInboxPane(props: {
             const task = props.tasks.find((candidate) => candidate.id === item.taskId)
             const tab = tabLabel(item, task, props.kv)
             const title = task?.title ?? item.taskId
+            // A rate-limited task usually has an auto-resume armed
+            // (`Task.quotaResume`, persisted by the daemon's quota probe).
+            // Until 2026-08-30 that clock was written to disk and read by
+            // nothing, so "rate limited" gave a user no way to tell "back at
+            // 3:14, already scheduled" from "stuck, go do something". This
+            // card is where that belongs: the rail's tree row is one cell
+            // wide, and the Inbox's whole job is what-needs-me / when.
+            const resumeNote = quotaResumeNote(item.state, task, t)
             const project = task ? sidebarProjectLabel(task.repo, repos) : ""
             // Identity line: `project › tab` — WHERE the episode happened is
             // the primary key a user scans for (which project, which tab),
@@ -407,7 +387,7 @@ export function AttentionInboxPane(props: {
               <InboxCard
                 key={row.id}
                 identity={tab.label ? `${project} › ${tab.label}` : project || title}
-                subtitle={title}
+                subtitle={resumeNote ? `${title} · ${resumeNote}` : title}
                 badge={{
                   glyph: itemGlyph(item.state),
                   label: t(itemStateKey(item.state)),

--- a/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
@@ -1,0 +1,79 @@
+/**
+ * Attention-Inbox item → its presentation (glyph, tone, state word, and the
+ * rate-limit resume note). Pure and framework-free, split out of
+ * `AttentionInboxPane.tsx` (file-size cap) so the mapping is unit-testable
+ * without mounting the pane.
+ *
+ * One rule holds the four together: the Inbox's vocabulary must MATCH the
+ * sidebar rail's (`row-view.ts`) and the tab strip's (`tab-strip.tsx`). Three
+ * surfaces describing one tab in three vocabularies is how a rate limit and a
+ * crash ended up looking identical.
+ */
+
+import type { Task } from "@/types/task"
+import type { RGBA } from "@opentui/core"
+import type { AttentionInboxItem } from "@sma1lboy/kobe-daemon/daemon/contracts"
+
+type ThemeColors = { warning: RGBA; success: RGBA; error: RGBA }
+
+export function itemColor(state: AttentionInboxItem["state"], theme: ThemeColors): RGBA {
+  if (state === "permission_needed") return theme.warning
+  if (state === "turn_complete") return theme.success
+  if (state === "prompt_deferred") return theme.warning
+  if (state === "rate_limited") return theme.warning
+  return theme.error
+}
+
+export function itemGlyph(state: AttentionInboxItem["state"]): string {
+  if (state === "permission_needed") return "?"
+  if (state === "turn_complete") return "✓"
+  // `◷`, the sidebar's rate-limited glyph, not the `⌛` this used to show:
+  // U+231B carries the Unicode Emoji property, so macOS resolved it to
+  // AppleColorEmoji — a 2.13-cell colour glyph in a 1-cell column, which
+  // both overflowed and broke the pane's monochrome ink (2026-08-15).
+  if (state === "rate_limited") return "◷"
+  // `†` — the engine PROCESS is gone, the sidebar rail's DEAD_GLYPH.
+  if (state === "dead") return "†"
+  // `≡` (no Emoji property) for a queued message — a stack, not a failure.
+  if (state === "prompt_deferred") return "≡"
+  return "!"
+}
+
+/** i18n key for the state word shown next to the glyph. */
+export function itemStateKey(state: AttentionInboxItem["state"]): string {
+  if (state === "permission_needed") return "workspace.inbox.state.needsInput"
+  if (state === "turn_complete") return "workspace.inbox.state.done"
+  if (state === "rate_limited") return "workspace.inbox.state.rateLimited"
+  if (state === "dead") return "workspace.inbox.state.dead"
+  if (state === "prompt_deferred") return "workspace.inbox.state.promptDeferred"
+  return "workspace.inbox.state.error"
+}
+
+/**
+ * "resumes 3:14 PM" for a rate-limited task whose auto-resume is armed, in the
+ * viewer's locale clock. The daemon persists `Task.quotaResume.resumeAt` when
+ * the engine's quota probe answers when the window clears (quota-resume.ts) —
+ * and until 2026-08-30 that timestamp was written to disk and read by NOTHING,
+ * so "rate limited" gave a user no way to tell "back at 3:14, already
+ * scheduled" from "stuck, go do something else".
+ *
+ * Null unless the state is `rate_limited` (the only state the schedule
+ * describes), the task carries a schedule, and its stamp parses — a garbage
+ * timestamp shows nothing rather than "Invalid Date". A time already past is
+ * still shown: the resume runner ticks on an interval, so "due, waiting for
+ * the next sweep" is the honest reading, not "never".
+ */
+export function quotaResumeNote(
+  state: AttentionInboxItem["state"],
+  task: Pick<Task, "quotaResume"> | undefined,
+  t: (key: string, params?: Record<string, string>) => string,
+): string | null {
+  if (state !== "rate_limited") return null
+  const raw = task?.quotaResume?.resumeAt
+  if (!raw) return null
+  const at = Date.parse(raw)
+  if (!Number.isFinite(at)) return null
+  return t("workspace.inbox.resumesAt", {
+    time: new Date(at).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }),
+  })
+}

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -39,6 +39,12 @@ export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
   running: "●",
   done: "✓",
   error: "!",
+  // Borrowed verbatim from the sidebar rail (row-view.ts) so the strip and
+  // the rail never say different things about the same tab: `◷` a limit that
+  // clears itself, `†` an engine process that is gone. Both were `!` until
+  // 2026-08-30 — three states, one glyph, opposite required actions.
+  rate_limited: "◷",
+  dead: "†",
   // Hook-only "blocked on the user" state — same ?/warning pairing as the
   // sidebar's permission_needed badge (row-view.ts). No collision with
   // `unknown`: that placeholder is never rendered (skip below).
@@ -241,9 +247,9 @@ export function TabStrip(props: {
               ? theme.focusAccent
               : turn === "done"
                 ? theme.success
-                : turn === "error"
+                : turn === "error" || turn === "dead"
                   ? theme.error
-                  : turn === "needs_input"
+                  : turn === "needs_input" || turn === "rate_limited"
                     ? theme.warning
                     : theme.textMuted
           const active = tab.id === props.activeId

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -52,6 +52,8 @@ export const en = {
     rateLimited: "rate limited",
     permissionNeeded: "needs permission",
     error: "error",
+    /** The engine PROCESS is gone (pty exit record), not a failed turn. */
+    dead: "engine exited",
   },
   /** Row-view special subtitle words */
   subtitle: {
@@ -145,6 +147,7 @@ export const zh: typeof en = {
     rateLimited: "请求受限",
     permissionNeeded: "等待授权",
     error: "错误",
+    dead: "引擎已退出",
   },
   subtitle: {
     noTracking: "不跟踪活动",

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -53,9 +53,14 @@ export const en = {
       error: "error",
       rateLimited: "rate limited",
       running: "running",
+      /** A dead engine PROCESS (pty exit record), not a failed turn. */
+      dead: "engine exited",
       /** A peer/API message accepted by the daemon but not yet pasted (issue #78). */
       promptDeferred: "message queued",
     },
+    /** Rate-limited card's context line: when the armed auto-resume fires.
+     *  `{time}` is a locale-formatted clock time. */
+    resumesAt: "resumes {time}",
     /** Toast title when a message is deferred because the composer was busy. */
     deferredToast: "Message queued — composer busy",
     /** Insert feedback: the A/C gate still blocked at release time. */
@@ -116,9 +121,11 @@ export const zh: typeof en = {
       error: "出错",
       rateLimited: "限流",
       running: "进行中",
+      dead: "引擎已退出",
       /** peer/API 消息已被 daemon 受理但尚未插入（issue #78）。 */
       promptDeferred: "消息已排队",
     },
+    resumesAt: "{time} 恢复",
     /** composer 忙、消息被受理延后的 toast 标题。 */
     deferredToast: "消息已排队——composer 正忙",
     /** 插入反馈：放行那一刻 A/C 闸门仍拦住。 */

--- a/packages/kobe/src/tui/lib/notify-state.ts
+++ b/packages/kobe/src/tui/lib/notify-state.ts
@@ -90,7 +90,7 @@ export function shouldShowToast(kind: NotificationKind, toastEnabled: boolean): 
  */
 export function attentionKindFor(state: string): NotificationKind | null {
   if (state === "permission_needed") return "needs_input"
-  if (state === "error" || state === "rate_limited") return "error"
+  if (state === "error" || state === "rate_limited" || state === "dead") return "error"
   if (state === "turn_complete") return "done"
   return null
 }
@@ -103,7 +103,11 @@ export function attentionKindFor(state: string): NotificationKind | null {
  */
 export function chipAttentionKind(turn: string): NotificationKind | null {
   if (turn === "done") return "done"
-  if (turn === "error") return "error"
+  // `rate_limited` and `dead` split out of the chip's `error` in 2026-08-30;
+  // they stay attention edges here, matching `attentionKindFor`'s task-level
+  // rule. The chip vocabulary distinguishes them so the GLYPH can; a toast
+  // has only the three kinds, and all three mean "something needs you".
+  if (turn === "error" || turn === "rate_limited" || turn === "dead") return "error"
   if (turn === "needs_input") return "needs_input"
   return null
 }

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -35,20 +35,28 @@ export interface SidebarRowView {
 }
 
 /**
- * Readable subtitle word for the non-normal engine activity states. These
- * outrank the branch in the subtitle so a rate-limited / errored / waiting
- * task spells out *why* it's stuck instead of relying on the tiny title
- * glyph alone. Normal states (`idle` / `running` / `turn_complete`) return
- * null so the row keeps showing the branch.
+ * TONE for the attention states, so a row whose engine needs a human keeps
+ * its warning/error colour even while something else makes it spin (a
+ * materializing worktree, a still-writing transcript) — `loading` otherwise
+ * paints every such row `primary`.
+ *
+ * It used to return a WORD too ("rate limited" / "needs permission" /
+ * "error") that replaced the branch in the subtitle. The subtitle went away
+ * with the two-line cards: the tree row (`tree-rows.tsx`) is one cell and
+ * renders the glyph plus the tab label, nothing else. The words were computed
+ * on every row build, asserted by tests, and read by nobody — so they are
+ * gone, and the glyph carries the state alone. That is the whole reason the
+ * glyphs must stay distinct (`◷` vs `×` vs `†`): with no subtitle there is no
+ * second channel to disambiguate them.
  */
-function activityLabelFor(state: TaskActivityState | undefined): { text: string; tone: SidebarTone } | null {
+function activityToneFor(state: TaskActivityState | undefined): SidebarTone | null {
   switch (state) {
     case "rate_limited":
-      return { text: t("tasks.activity.rateLimited"), tone: "warning" }
     case "permission_needed":
-      return { text: t("tasks.activity.permissionNeeded"), tone: "warning" }
+      return "warning"
     case "error":
-      return { text: t("tasks.activity.error"), tone: "error" }
+    case "dead":
+      return "error"
     default:
       return null
   }
@@ -111,6 +119,16 @@ export const NO_STATE_GLYPH = "·"
  * monospace font on earth has it, at exactly one cell.
  */
 const ERROR_GLYPH = "×"
+
+/**
+ * Dead-engine glyph — the engine PROCESS is gone (killed, or exited under a
+ * wrapper), from the pty-host's exit record. `†` (U+2020 DAGGER), not a
+ * variant of `×`: an errored engine RAN and reported a failed turn, a dead one
+ * is no longer there, and only one of the two can be answered by restarting.
+ * General Punctuation, so every monospace font has it at exactly one cell —
+ * the constraint that retired `◌` (U+25CC fell back oversized) and `✕`.
+ */
+const DEAD_GLYPH = "†"
 
 /**
  * Muted subtitle shown when a custom-engine task has nothing else to say.
@@ -268,7 +286,7 @@ export function buildSidebarRowView(opts: {
   // the badge must agree with the spinner, or the row spins under a ✓.
   const stillWorking = stillWorkingAfterCompletion(opts.activity, opts.transcript)
   const activityBadge = stillWorking ? null : activityBadgeFor(activityState, opts.completionSeen === true)
-  const activityLabel = activityLabelFor(activityState)
+  const activityTone = activityToneFor(activityState)
   // A custom-engine task with no genuine activity signal has nothing to
   // animate — the monitor can't read its transcript (monitor/activity.ts),
   // so a spinner here would lie. Hook-driven words (rate limited / needs
@@ -303,14 +321,14 @@ export function buildSidebarRowView(opts: {
       ? "primary"
       : untrackedCustomEngine
         ? "textMuted"
-        : (activityLabel?.tone ?? (loading ? "primary" : (activityBadge?.tone ?? "textMuted")))
-  // Subtitle priority: the materializing word while a worktree job runs
-  // (there is no branch on disk yet), then a non-normal activity word (rate
-  // limited / needs permission / error), then the branch, then — for an
+        : (activityTone ?? (loading ? "primary" : (activityBadge?.tone ?? "textMuted")))
+  // Subtitle priority: the deletion/materializing word while a daemon job
+  // runs (there is no branch on disk yet), then the branch, then — for an
   // untracked custom engine with no branch — an explicit "no activity
   // tracking" note so the row reads as un-tracked rather than stuck, then a
-  // neutral dash. Persisted task lifecycle belongs to the board, not this
-  // runtime-activity projection.
+  // neutral dash. Engine ACTIVITY does not appear here: its glyph carries it
+  // (see `activityToneFor`). Persisted task lifecycle belongs to the board,
+  // not this runtime-activity projection.
   const fallbackSubtitle = untrackedCustomEngine ? noTrackingSubtitle() : "—"
   // Subagent activity rides as a compact `◇N` prefix ahead of the branch,
   // and ONLY while the row is actually animating: every transient mark is
@@ -325,11 +343,9 @@ export function buildSidebarRowView(opts: {
       ? opts.truncateBranch(deletionSubtitle(deleteFailed), opts.subtitleBudget)
       : materializing
         ? opts.truncateBranch(materializingSubtitle(), opts.subtitleBudget)
-        : activityLabel
-          ? opts.truncateBranch(activityLabel.text, opts.subtitleBudget)
-          : branchWithMarks.length > 0
-            ? opts.truncateBranch(branchWithMarks, opts.subtitleBudget)
-            : opts.truncateBranch(fallbackSubtitle, opts.subtitleBudget)
+        : branchWithMarks.length > 0
+          ? opts.truncateBranch(branchWithMarks, opts.subtitleBudget)
+          : opts.truncateBranch(fallbackSubtitle, opts.subtitleBudget)
   // Untracked custom engine gets a distinct dim dot. Normal tasks fall back
   // to the hollow idle circle because the client deliberately removes an
   // explicit `idle` activity entry; absence is therefore the idle projection.
@@ -384,6 +400,8 @@ function activityBadgeFor(
       return { glyph: "?", tone: "warning" }
     case "error":
       return { glyph: ERROR_GLYPH, tone: "error" }
+    case "dead":
+      return { glyph: DEAD_GLYPH, tone: "error" }
     case "turn_complete":
       return completionSeen ? null : { glyph: "●", tone: "primary" }
     default:

--- a/packages/kobe/src/tui/workspace/turn-state-merge.ts
+++ b/packages/kobe/src/tui/workspace/turn-state-merge.ts
@@ -40,8 +40,15 @@ export function activityTurnState(state: TaskActivityState): ChatTabTurnState | 
     case "turn_complete":
       return "done"
     case "error":
-    case "rate_limited":
       return "error"
+    // NOT folded into `error`: "blocked until the window resets" and "broke,
+    // needs you" ask for opposite actions, and the sidebar rail has always
+    // drawn them apart (`◷` vs `×`). Collapsing them here is what made the
+    // strip and the rail disagree about the same tab.
+    case "rate_limited":
+      return "rate_limited"
+    case "dead":
+      return "dead"
     case "permission_needed":
       return "needs_input"
     case "idle":

--- a/packages/kobe/test/daemon/inbox-death-episode.test.ts
+++ b/packages/kobe/test/daemon/inbox-death-episode.test.ts
@@ -1,0 +1,30 @@
+import { mkdtempSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { describe, expect, it } from "vitest"
+
+/**
+ * A killed engine must leave a durable Inbox episode.
+ *
+ * Every OTHER episode is something the engine reported about ITSELF, so an
+ * engine that was killed (no Stop, no SessionEnd, no hook at all) produced
+ * none — and the one surface whose job is "what needs me" stayed silent
+ * through seven simultaneous deaths on 2026-08-30. The badge is transient;
+ * this is the half that is still there after the tab scrolls away.
+ */
+describe("inbox death episode", () => {
+  it("persists a dead episode carrying the exit detail", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "inbox-")), "attention-inbox.json")
+    const store = new AttentionInboxStore(path, new DaemonEventBus())
+    await store.init()
+    await store.recordEngineDeath("t1", "tab-1", { exit: { code: 143, lastLine: "403 limit" } }, 1000)
+    const parsed = JSON.parse(await readFile(path, "utf8"))
+    expect(parsed.items).toHaveLength(1)
+    expect(parsed.items[0].state).toBe("dead")
+    expect(parsed.items[0].detail.exit.code).toBe(143)
+    expect(store.snapshot()[0]?.state).toBe("dead")
+  })
+})

--- a/packages/kobe/test/daemon/pty-exit-watch.test.ts
+++ b/packages/kobe/test/daemon/pty-exit-watch.test.ts
@@ -1,6 +1,9 @@
 import { mkdtempSync, rmSync } from "node:fs"
+import { readFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { DaemonActivityRegistry, type EngineStatePayload } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import { recordPtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
 import { startPtyExitWatch } from "@sma1lboy/kobe-daemon/daemon/pty-exit-watch"
 import { afterEach, describe, expect, it } from "vitest"
@@ -63,5 +66,105 @@ describe("startPtyExitWatch", () => {
     } finally {
       stop()
     }
+  })
+})
+
+/**
+ * The WIRE, end to end: a real exit record on disk → the watcher → the real
+ * activity registry → a published `engine-state`.
+ *
+ * The mutation this is built to catch is a broken CONNECTION, not a broken
+ * leaf: dropping `activity` from the watch options, dropping the
+ * `publishDeath` call in the sweep, or reverting `recordEngineDeath` all turn
+ * this red. A test that only checked "the record parses" would stay green
+ * through every one of them — which is exactly how the death reached
+ * `pty-exits.json` and no UI for as long as it did.
+ */
+describe("startPtyExitWatch → activity registry", () => {
+  it("publishes a `dead` engine-state carrying the exit code and last error line", async () => {
+    const path = join(tmp(), "pty-exits.json")
+    const bus = new DaemonEventBus()
+    const published: EngineStatePayload[] = []
+    bus.onPublish((event) => {
+      if (event.channel === "engine-state") published.push(event.payload as EngineStatePayload)
+    })
+    const activity = new DaemonActivityRegistry(bus)
+    const stop = startPtyExitWatch({
+      path,
+      plugins: () => ({ handleUiReport: () => {} }),
+      activity,
+    })
+    try {
+      // The 2026-08-30 shape: SIGTERM'd engine, 403 quota text in the tail.
+      recordPtyExit(
+        {
+          key: "task-1::tab-1",
+          pid: 900,
+          exit: { code: 143, signal: null, at: "2026-08-30T12:00:00.000Z" },
+          tail: "Error: [provider.auth_error] 403 You've reached your 5-hour usage limit.\nzsh: terminated kimi -y\n",
+        },
+        path,
+      )
+      await waitFor(() => published.length > 0)
+      const payload = published.at(-1)
+      expect(payload?.state).toBe("dead")
+      expect(payload?.tabId).toBe("tab-1")
+      expect(payload?.detail?.exit?.code).toBe(143)
+      // The error text was always on disk; this is the assertion that it now
+      // travels with the state instead of dying in the file.
+      expect(payload?.detail?.exit?.lastLine).toBe("zsh: terminated kimi -y")
+    } finally {
+      stop()
+      activity.close()
+    }
+  })
+
+  it("does not let an OLD death bury a newer live turn in the same tab", async () => {
+    const path = join(tmp(), "pty-exits.json")
+    const bus = new DaemonEventBus()
+    const activity = new DaemonActivityRegistry(bus)
+    const stop = startPtyExitWatch({
+      path,
+      plugins: () => ({ handleUiReport: () => {} }),
+      activity,
+    })
+    try {
+      // A live turn reported NOW; the record on disk predates it (a corpse
+      // from the previous session in this same tab).
+      activity.report("task-1", "turn-start", undefined, "tab-1")
+      recordPtyExit(
+        {
+          key: "task-1::tab-1",
+          pid: 1,
+          exit: { code: 1, signal: null, at: "2020-01-01T00:00:00.000Z" },
+          tail: "old\n",
+        },
+        path,
+      )
+      await waitFor(() => Object.keys(activity.debugSnapshot().tabs).length > 0)
+      expect(activity.debugSnapshot().tabs["task-1"]?.["tab-1"]?.state).toBe("running")
+    } finally {
+      stop()
+      activity.close()
+    }
+  })
+})
+
+/**
+ * The server must actually HAND the watcher its two consumers.
+ *
+ * The behavioural tests above construct the watcher themselves, so they stay
+ * green if `server.ts` stops passing `activity`/`inbox` — the death would
+ * then reach `pty-exits.json`, the watcher would parse it perfectly, and the
+ * UI would still see nothing. That disconnect is the entire bug this work
+ * fixes, so it gets its own assertion against the wiring itself.
+ */
+describe("server wiring", () => {
+  it("passes both the activity registry and the inbox to startPtyExitWatch", async () => {
+    const src = await readFile(new URL("../../../kobe-daemon/src/daemon/server.ts", import.meta.url), "utf8")
+    const call = /startPtyExitWatch\(\{([\s\S]*?)\n\s*\}\)/.exec(src)?.[1]
+    expect(call, "startPtyExitWatch call not found in server.ts").toBeDefined()
+    expect(call).toMatch(/^\s*activity,\s*$/m)
+    expect(call).toMatch(/^\s*inbox,\s*$/m)
   })
 })

--- a/packages/kobe/test/engine/activity-pipeline.test.ts
+++ b/packages/kobe/test/engine/activity-pipeline.test.ts
@@ -107,13 +107,15 @@ describe("activity pipeline — vendor hook payload to sidebar badge", () => {
     expect(row.loading).toBe(false)
     expect(row.stateGlyph).toBe("◷")
     expect(row.tone).toBe("warning")
-    expect(row.subtitleText).toBe("rate limited")
+    // The subtitle shows the BRANCH, not a state word: the one-line tree row
+    // has no subtitle at all, so the glyph above is the whole signal.
+    expect(row.subtitleText).toBe("feature/sidebar")
   })
 
   it("turn failed (billing classifies as rate-limited too)", () => {
     const row = rowAfterClaudeHook("StopFailure", { error_type: "billing_error" })
     expect(row.stateGlyph).toBe("◷")
-    expect(row.subtitleText).toBe("rate limited")
+    expect(row.subtitleText).toBe("feature/sidebar")
   })
 
   it("turn failed (other): unknown error_type shows the error badge", () => {
@@ -121,7 +123,7 @@ describe("activity pipeline — vendor hook payload to sidebar badge", () => {
     expect(row.loading).toBe(false)
     expect(row.stateGlyph).toBe("×")
     expect(row.tone).toBe("error")
-    expect(row.subtitleText).toBe("error")
+    expect(row.subtitleText).toBe("feature/sidebar")
   })
 
   it("waiting on permission: the Notification permission hook shows the ? badge", () => {
@@ -131,7 +133,7 @@ describe("activity pipeline — vendor hook payload to sidebar badge", () => {
     expect(row.loading).toBe(false)
     expect(row.stateGlyph).toBe("?")
     expect(row.tone).toBe("warning")
-    expect(row.subtitleText).toBe("needs permission")
+    expect(row.subtitleText).toBe("feature/sidebar")
   })
 
   it("session end: the row returns to neutral runtime chrome", () => {

--- a/packages/kobe/test/engine/kimi-failure-classify.test.ts
+++ b/packages/kobe/test/engine/kimi-failure-classify.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Kimi StopFailure → the neutral failure class.
+ *
+ * Kimi was firing StopFailure all along, but its adapter returned no detail
+ * for `turn-failed`, so `reduceActivity` saw `failure: undefined` and every
+ * Kimi failure — including the 5-hour quota wall on 2026-08-30 — reduced to a
+ * generic `error`. That meant Kimi could never reach `rate_limited`, and so
+ * never armed the auto-resume that state triggers.
+ *
+ * The payload shapes below are Kimi's own (verified against the installed
+ * 0.37.2 binary): `error_type` is a JS CLASS name, not a category, and the
+ * `[provider.*]` code lives in the message.
+ *
+ * Mutation target is the PIPELINE, not the classifier: these assert the
+ * reduced STATE, so deleting the `turn-failed` branch in the adapter turns
+ * them red even though `kimiFailureDetail` itself still passes its own tests.
+ */
+import { describe, expect, it } from "vitest"
+import { reduceActivity } from "../../src/engine/hook-events"
+import { KimiHookAdapter } from "../../src/engine/kimi-local/hook-adapter"
+
+const adapter = new KimiHookAdapter()
+const stateFor = (payload: Record<string, unknown>) =>
+  reduceActivity("running", "turn-failed", adapter.activityDetailFromPayload("turn-failed", payload))
+
+describe("kimi turn-failed classification", () => {
+  it("reaches rate_limited for a provider rate limit", () => {
+    expect(stateFor({ error_type: "APIProviderRateLimitError", error_message: "[provider.rate_limit] 429" })).toBe(
+      "rate_limited",
+    )
+  })
+
+  it("reaches rate_limited for quota exhaustion, which rides a 429 under a different code", () => {
+    // `APIProviderQuotaExhaustedError` is coded `provider.api_error`, so the
+    // class name is the only thing that distinguishes it from a plain error.
+    expect(
+      stateFor({ error_type: "APIProviderQuotaExhaustedError", error_message: "[provider.api_error] quota" }),
+    ).toBe("rate_limited")
+  })
+
+  it("treats the 5-hour usage wall (a 403 auth error) as needing a human, not a timer", () => {
+    // The literal 2026-08-30 message. Kimi files it under auth; it is a quota
+    // wall, so it is `billing` — attention, but deliberately NOT auto-resumed.
+    const detail = adapter.activityDetailFromPayload("turn-failed", {
+      error_type: "APIStatusError",
+      error_message: "[provider.auth_error] 403 You've reached your 5-hour usage limit.",
+    })
+    expect(detail?.failure).toBe("billing")
+    expect(reduceActivity("running", "turn-failed", detail)).toBe("rate_limited")
+  })
+
+  it("still reduces an ordinary failure to error", () => {
+    expect(stateFor({ error_type: "TypeError", error_message: "boom" })).toBe("error")
+    expect(stateFor({})).toBe("error")
+  })
+
+  it("keeps the vendor error class as a note for diagnostics", () => {
+    expect(adapter.activityDetailFromPayload("turn-failed", { error_type: "APIProviderRateLimitError" })?.note).toBe(
+      "APIProviderRateLimitError",
+    )
+  })
+})

--- a/packages/kobe/test/golden/sidebar-row-state.golden.txt
+++ b/packages/kobe/test/golden/sidebar-row-state.golden.txt
@@ -642,16 +642,16 @@ act=turn_complete      seen=1 job=1 del=error    vendor=kimi       tx=- | main=0
 act=turn_complete      seen=1 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=turn_complete      seen=1 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=turn_complete      seen=1 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
-act=rate_limited       seen=0 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=0 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
+act=rate_limited       seen=0 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=0 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
 act=rate_limited       seen=0 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=rate_limited       seen=0 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=rate_limited       seen=0 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
@@ -722,16 +722,16 @@ act=rate_limited       seen=0 job=1 del=error    vendor=kimi       tx=- | main=0
 act=rate_limited       seen=0 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=rate_limited       seen=0 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=rate_limited       seen=0 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
-act=rate_limited       seen=1 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-act=rate_limited       seen=1 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
+act=rate_limited       seen=1 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=rate_limited       seen=1 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
 act=rate_limited       seen=1 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=rate_limited       seen=1 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=rate_limited       seen=1 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
@@ -802,16 +802,16 @@ act=rate_limited       seen=1 job=1 del=error    vendor=kimi       tx=- | main=0
 act=rate_limited       seen=1 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=rate_limited       seen=1 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=rate_limited       seen=1 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
-act=permission_needed  seen=0 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=0 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
+act=permission_needed  seen=0 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=0 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
 act=permission_needed  seen=0 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=permission_needed  seen=0 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=permission_needed  seen=0 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
@@ -882,16 +882,16 @@ act=permission_needed  seen=0 job=1 del=error    vendor=kimi       tx=- | main=0
 act=permission_needed  seen=0 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=permission_needed  seen=0 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=permission_needed  seen=0 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
-act=permission_needed  seen=1 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-act=permission_needed  seen=1 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
+act=permission_needed  seen=1 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+act=permission_needed  seen=1 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
 act=permission_needed  seen=1 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=permission_needed  seen=1 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=permission_needed  seen=1 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
@@ -962,16 +962,16 @@ act=permission_needed  seen=1 job=1 del=error    vendor=kimi       tx=- | main=0
 act=permission_needed  seen=1 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=permission_needed  seen=1 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=permission_needed  seen=1 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
-act=error              seen=0 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=0 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+act=error              seen=0 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=0 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
 act=error              seen=0 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=error              seen=0 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=error              seen=0 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
@@ -1042,16 +1042,16 @@ act=error              seen=0 job=1 del=error    vendor=kimi       tx=- | main=0
 act=error              seen=0 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=error              seen=0 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=error              seen=0 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
-act=error              seen=1 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-act=error              seen=1 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+act=error              seen=1 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+act=error              seen=1 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
 act=error              seen=1 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=error              seen=1 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
 act=error              seen=1 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
@@ -1122,29 +1122,192 @@ act=error              seen=1 job=1 del=error    vendor=kimi       tx=- | main=0
 act=error              seen=1 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=error              seen=1 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 act=error              seen=1 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=0 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=queued   vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=running  vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=0 job=0 del=error    vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=0 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=0 job=1 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=0 job=1 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=queued   vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=running  vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=0 job=1 del=error    vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=0 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=0 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+act=dead               seen=1 job=0 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=queued   vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=running  vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=deleting
+act=dead               seen=1 job=0 del=error    vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=0 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=delete failed
+act=dead               seen=1 job=1 del=-        vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=-        vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=materializing
+act=dead               seen=1 job=1 del=queued   vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=queued   vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=running  vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=1 sub=deleting
+act=dead               seen=1 job=1 del=error    vendor=claude     tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=claude     tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=codex      tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=codex      tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=copilot    tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=copilot    tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=kimi       tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=kimi       tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=my-engine  tx=- | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
+act=dead               seen=1 job=1 del=error    vendor=my-engine  tx=after | main=0 title=fix the sidebar  glyph=⠋   tone=error       load=1 matz=1 sub=delete failed
 
 ## project (main) rows — branch resolved from the repo checkout
 mainBranch=main                    act=-                  | main=1 title=rove             glyph=○   tone=textMuted   load=0 matz=0 sub=main
 mainBranch=main                    act=idle               | main=1 title=rove             glyph=○   tone=textMuted   load=0 matz=0 sub=main
 mainBranch=main                    act=running            | main=1 title=rove             glyph=⠋   tone=primary     load=1 matz=0 sub=main
 mainBranch=main                    act=turn_complete      | main=1 title=rove             glyph=●   tone=primary     load=0 matz=0 sub=main
-mainBranch=main                    act=rate_limited       | main=1 title=rove             glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-mainBranch=main                    act=permission_needed  | main=1 title=rove             glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-mainBranch=main                    act=error              | main=1 title=rove             glyph=×   tone=error       load=0 matz=0 sub=error
+mainBranch=main                    act=rate_limited       | main=1 title=rove             glyph=◷   tone=warning     load=0 matz=0 sub=main
+mainBranch=main                    act=permission_needed  | main=1 title=rove             glyph=?   tone=warning     load=0 matz=0 sub=main
+mainBranch=main                    act=error              | main=1 title=rove             glyph=×   tone=error       load=0 matz=0 sub=main
+mainBranch=main                    act=dead               | main=1 title=rove             glyph=†   tone=error       load=0 matz=0 sub=main
 mainBranch=feat/long-running-branch act=-                  | main=1 title=rove             glyph=○   tone=textMuted   load=0 matz=0 sub=feat/long-running-branch
 mainBranch=feat/long-running-branch act=idle               | main=1 title=rove             glyph=○   tone=textMuted   load=0 matz=0 sub=feat/long-running-branch
 mainBranch=feat/long-running-branch act=running            | main=1 title=rove             glyph=⠋   tone=primary     load=1 matz=0 sub=feat/long-running-branch
 mainBranch=feat/long-running-branch act=turn_complete      | main=1 title=rove             glyph=●   tone=primary     load=0 matz=0 sub=feat/long-running-branch
-mainBranch=feat/long-running-branch act=rate_limited       | main=1 title=rove             glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-mainBranch=feat/long-running-branch act=permission_needed  | main=1 title=rove             glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-mainBranch=feat/long-running-branch act=error              | main=1 title=rove             glyph=×   tone=error       load=0 matz=0 sub=error
+mainBranch=feat/long-running-branch act=rate_limited       | main=1 title=rove             glyph=◷   tone=warning     load=0 matz=0 sub=feat/long-running-branch
+mainBranch=feat/long-running-branch act=permission_needed  | main=1 title=rove             glyph=?   tone=warning     load=0 matz=0 sub=feat/long-running-branch
+mainBranch=feat/long-running-branch act=error              | main=1 title=rove             glyph=×   tone=error       load=0 matz=0 sub=feat/long-running-branch
+mainBranch=feat/long-running-branch act=dead               | main=1 title=rove             glyph=†   tone=error       load=0 matz=0 sub=feat/long-running-branch
 mainBranch=-                       act=-                  | main=1 title=rove             glyph=○   tone=textMuted   load=0 matz=0 sub=—
 mainBranch=-                       act=idle               | main=1 title=rove             glyph=○   tone=textMuted   load=0 matz=0 sub=—
 mainBranch=-                       act=running            | main=1 title=rove             glyph=⠋   tone=primary     load=1 matz=0 sub=—
 mainBranch=-                       act=turn_complete      | main=1 title=rove             glyph=●   tone=primary     load=0 matz=0 sub=—
-mainBranch=-                       act=rate_limited       | main=1 title=rove             glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-mainBranch=-                       act=permission_needed  | main=1 title=rove             glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-mainBranch=-                       act=error              | main=1 title=rove             glyph=×   tone=error       load=0 matz=0 sub=error
+mainBranch=-                       act=rate_limited       | main=1 title=rove             glyph=◷   tone=warning     load=0 matz=0 sub=—
+mainBranch=-                       act=permission_needed  | main=1 title=rove             glyph=?   tone=warning     load=0 matz=0 sub=—
+mainBranch=-                       act=error              | main=1 title=rove             glyph=×   tone=error       load=0 matz=0 sub=—
+mainBranch=-                       act=dead               | main=1 title=rove             glyph=†   tone=error       load=0 matz=0 sub=—
 
 ## engine-owned spinner frame sets + withSpinnerFrame overlay
 vendor=claude     frames(0..25)=⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴
@@ -1168,18 +1331,22 @@ act=turn_complete      frame=0    overlay: base=● after=● tone=primary     s
 act=turn_complete      frame=3    overlay: base=● after=● tone=primary     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
 act=turn_complete      frame=14   overlay: base=● after=● tone=primary     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
 act=turn_complete      frame=99   overlay: base=● after=● tone=primary     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
-act=rate_limited       frame=0    overlay: base=◷ after=◷ tone=warning     sub=rate limited     frameReads=0 sameObject=1 sameAsDirect=1
-act=rate_limited       frame=3    overlay: base=◷ after=◷ tone=warning     sub=rate limited     frameReads=0 sameObject=1 sameAsDirect=1
-act=rate_limited       frame=14   overlay: base=◷ after=◷ tone=warning     sub=rate limited     frameReads=0 sameObject=1 sameAsDirect=1
-act=rate_limited       frame=99   overlay: base=◷ after=◷ tone=warning     sub=rate limited     frameReads=0 sameObject=1 sameAsDirect=1
-act=permission_needed  frame=0    overlay: base=? after=? tone=warning     sub=needs permission frameReads=0 sameObject=1 sameAsDirect=1
-act=permission_needed  frame=3    overlay: base=? after=? tone=warning     sub=needs permission frameReads=0 sameObject=1 sameAsDirect=1
-act=permission_needed  frame=14   overlay: base=? after=? tone=warning     sub=needs permission frameReads=0 sameObject=1 sameAsDirect=1
-act=permission_needed  frame=99   overlay: base=? after=? tone=warning     sub=needs permission frameReads=0 sameObject=1 sameAsDirect=1
-act=error              frame=0    overlay: base=× after=× tone=error       sub=error            frameReads=0 sameObject=1 sameAsDirect=1
-act=error              frame=3    overlay: base=× after=× tone=error       sub=error            frameReads=0 sameObject=1 sameAsDirect=1
-act=error              frame=14   overlay: base=× after=× tone=error       sub=error            frameReads=0 sameObject=1 sameAsDirect=1
-act=error              frame=99   overlay: base=× after=× tone=error       sub=error            frameReads=0 sameObject=1 sameAsDirect=1
+act=rate_limited       frame=0    overlay: base=◷ after=◷ tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=rate_limited       frame=3    overlay: base=◷ after=◷ tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=rate_limited       frame=14   overlay: base=◷ after=◷ tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=rate_limited       frame=99   overlay: base=◷ after=◷ tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=permission_needed  frame=0    overlay: base=? after=? tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=permission_needed  frame=3    overlay: base=? after=? tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=permission_needed  frame=14   overlay: base=? after=? tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=permission_needed  frame=99   overlay: base=? after=? tone=warning     sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=error              frame=0    overlay: base=× after=× tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=error              frame=3    overlay: base=× after=× tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=error              frame=14   overlay: base=× after=× tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=error              frame=99   overlay: base=× after=× tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=dead               frame=0    overlay: base=† after=† tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=dead               frame=3    overlay: base=† after=† tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=dead               frame=14   overlay: base=† after=† tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
+act=dead               frame=99   overlay: base=† after=† tone=error       sub=feat/sidebar     frameReads=0 sameObject=1 sameAsDirect=1
 defaultFrames=⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏
 
 ## turn-complete vs transcript growth — the still-working grace window
@@ -1217,12 +1384,14 @@ subagents=0    act=running            branch=feat/sidebar  | main=0 title=fix th
 subagents=0    act=running            branch=-             | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=—
 subagents=0    act=turn_complete      branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
 subagents=0    act=turn_complete      branch=-             | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=—
-subagents=0    act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=0    act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=0    act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=0    act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=0    act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-subagents=0    act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+subagents=0    act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=0    act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=—
+subagents=0    act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=0    act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=—
+subagents=0    act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=0    act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=—
+subagents=0    act=dead               branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=0    act=dead               branch=-             | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=—
 subagents=1    act=-                  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 subagents=1    act=-                  branch=-             | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=—
 subagents=1    act=idle               branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
@@ -1231,12 +1400,14 @@ subagents=1    act=running            branch=feat/sidebar  | main=0 title=fix th
 subagents=1    act=running            branch=-             | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=—
 subagents=1    act=turn_complete      branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
 subagents=1    act=turn_complete      branch=-             | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=—
-subagents=1    act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=1    act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=1    act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=1    act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=1    act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-subagents=1    act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+subagents=1    act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=1    act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=—
+subagents=1    act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=1    act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=—
+subagents=1    act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=1    act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=—
+subagents=1    act=dead               branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=1    act=dead               branch=-             | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=—
 subagents=3    act=-                  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 subagents=3    act=-                  branch=-             | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=—
 subagents=3    act=idle               branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
@@ -1245,12 +1416,14 @@ subagents=3    act=running            branch=feat/sidebar  | main=0 title=fix th
 subagents=3    act=running            branch=-             | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=—
 subagents=3    act=turn_complete      branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
 subagents=3    act=turn_complete      branch=-             | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=—
-subagents=3    act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=3    act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=3    act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=3    act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=3    act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-subagents=3    act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+subagents=3    act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=3    act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=—
+subagents=3    act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=3    act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=—
+subagents=3    act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=3    act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=—
+subagents=3    act=dead               branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=3    act=dead               branch=-             | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=—
 subagents=12   act=-                  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 subagents=12   act=-                  branch=-             | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=—
 subagents=12   act=idle               branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
@@ -1259,12 +1432,14 @@ subagents=12   act=running            branch=feat/sidebar  | main=0 title=fix th
 subagents=12   act=running            branch=-             | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=—
 subagents=12   act=turn_complete      branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
 subagents=12   act=turn_complete      branch=-             | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=—
-subagents=12   act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=12   act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-subagents=12   act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=12   act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-subagents=12   act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
-subagents=12   act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+subagents=12   act=rate_limited       branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=12   act=rate_limited       branch=-             | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=—
+subagents=12   act=permission_needed  branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+subagents=12   act=permission_needed  branch=-             | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=—
+subagents=12   act=error              branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=12   act=error              branch=-             | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=—
+subagents=12   act=dead               branch=feat/sidebar  | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
+subagents=12   act=dead               branch=-             | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=—
 
 ## subtitle truncation budget
 budget=0    act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=
@@ -1277,68 +1452,74 @@ budget=1    act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   t
 budget=1    act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=…
 budget=4    act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=fea…
 budget=4    act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=fea…
-budget=4    act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rat…
-budget=4    act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=err…
+budget=4    act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=fea…
+budget=4    act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=fea…
 budget=8    act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feature…
 budget=8    act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feature…
-budget=8    act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate li…
-budget=8    act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+budget=8    act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feature…
+budget=8    act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feature…
 budget=16   act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feature/a-very-…
 budget=16   act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feature/a-very-…
-budget=16   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-budget=16   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+budget=16   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feature/a-very-…
+budget=16   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feature/a-very-…
 budget=24   act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feature/a-very-long-bra…
 budget=24   act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feature/a-very-long-bra…
-budget=24   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-budget=24   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+budget=24   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feature/a-very-long-bra…
+budget=24   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feature/a-very-long-bra…
 budget=40   act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feature/a-very-long-branch-name-indeed
 budget=40   act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feature/a-very-long-branch-name-indeed
-budget=40   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-budget=40   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+budget=40   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feature/a-very-long-branch-name-indeed
+budget=40   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feature/a-very-long-branch-name-indeed
 
 ## persisted TaskStatus x runtime activity — status must not reach the row
 status=backlog       act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=backlog       act=idle               | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=backlog       act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feat/sidebar
 status=backlog       act=turn_complete      | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
-status=backlog       act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-status=backlog       act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-status=backlog       act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+status=backlog       act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=backlog       act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=backlog       act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+status=backlog       act=dead               | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
 status=in_progress   act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=in_progress   act=idle               | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=in_progress   act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feat/sidebar
 status=in_progress   act=turn_complete      | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
-status=in_progress   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-status=in_progress   act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-status=in_progress   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+status=in_progress   act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=in_progress   act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=in_progress   act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+status=in_progress   act=dead               | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
 status=in_review     act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=in_review     act=idle               | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=in_review     act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feat/sidebar
 status=in_review     act=turn_complete      | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
-status=in_review     act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-status=in_review     act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-status=in_review     act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+status=in_review     act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=in_review     act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=in_review     act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+status=in_review     act=dead               | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
 status=done          act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=done          act=idle               | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=done          act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feat/sidebar
 status=done          act=turn_complete      | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
-status=done          act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-status=done          act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-status=done          act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+status=done          act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=done          act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=done          act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+status=done          act=dead               | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
 status=canceled      act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=canceled      act=idle               | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=canceled      act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feat/sidebar
 status=canceled      act=turn_complete      | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
-status=canceled      act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-status=canceled      act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-status=canceled      act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+status=canceled      act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=canceled      act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=canceled      act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+status=canceled      act=dead               | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
 status=error         act=-                  | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=error         act=idle               | main=0 title=fix the sidebar  glyph=○   tone=textMuted   load=0 matz=0 sub=feat/sidebar
 status=error         act=running            | main=0 title=fix the sidebar  glyph=⠋   tone=primary     load=1 matz=0 sub=feat/sidebar
 status=error         act=turn_complete      | main=0 title=fix the sidebar  glyph=●   tone=primary     load=0 matz=0 sub=feat/sidebar
-status=error         act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=rate limited
-status=error         act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=needs permission
-status=error         act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=error
+status=error         act=rate_limited       | main=0 title=fix the sidebar  glyph=◷   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=error         act=permission_needed  | main=0 title=fix the sidebar  glyph=?   tone=warning     load=0 matz=0 sub=feat/sidebar
+status=error         act=error              | main=0 title=fix the sidebar  glyph=×   tone=error       load=0 matz=0 sub=feat/sidebar
+status=error         act=dead               | main=0 title=fix the sidebar  glyph=†   tone=error       load=0 matz=0 sub=feat/sidebar
 
 ## PR check chip
 checkState=<no prStatus>     chip=<none>

--- a/packages/kobe/test/golden/sidebar-row-state.test.ts
+++ b/packages/kobe/test/golden/sidebar-row-state.test.ts
@@ -125,6 +125,12 @@ test("every rendered glyph is in the font-verified vocabulary", () => {
   const VERIFIED = new Map<string, string>([
     ["·", "U+00B7 Latin-1 — the no-state dot"],
     ["×", "U+00D7 Latin-1 — error / failed deletion"],
+    // U+2020 General Punctuation — dead engine process. Checked with
+    // `fc-list :charset=2020`: present in Fira Code, FiraCode/JetBrainsMono
+    // Nerd Font, and Menlo — the same coverage as `×` above, and strictly
+    // better than the `◌`/`✕` this rule was written for (both absent from
+    // Fira Code, which is what made macOS fall back oversized).
+    ["†", "U+2020 — dead engine; in Fira Code / JetBrainsMono / Menlo"],
     ["○", "U+25CB — idle; in every mono font checked"],
     ["●", "U+25CF — unread completion; ditto"],
     ["◇", "U+25C7 — subagent count prefix"],

--- a/packages/kobe/test/render/tab-strip-state-glyphs.test.ts
+++ b/packages/kobe/test/render/tab-strip-state-glyphs.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The tab strip and the sidebar rail must describe one tab the same way.
+ *
+ * Lives on the render track because `tab-strip.tsx` pulls in opentui, which
+ * needs bun's runner (same reason as `sidebar-completion-seen.test.ts`).
+ *
+ * Mutation target is the WIRE between the two vocabularies, not either table
+ * alone: reverting `activityTurnState`'s `rate_limited → error` fold turns
+ * this red, and so does reverting `TURN_GLYPHS`. Asserting only one of the
+ * two would stay green through a revert of the other — and the bug was
+ * precisely that the two halves disagreed.
+ */
+import { describe, expect, it } from "bun:test"
+import type { TaskActivityState } from "../../src/engine/hook-events"
+import { TURN_GLYPHS } from "../../src/tui-react/workspace/tab-strip"
+import { chipAttentionKind } from "../../src/tui/lib/notify-state"
+import { activityTurnState } from "../../src/tui/workspace/turn-state-merge"
+
+const glyphOf = (state: TaskActivityState): string => {
+  const turn = activityTurnState(state)
+  if (turn === null) throw new Error(`no chip for ${state}`)
+  return TURN_GLYPHS[turn]
+}
+
+describe("tab strip glyphs agree with the sidebar rail", () => {
+  it("draws rate limited, error, and dead as three different marks", () => {
+    // The rail's own vocabulary (row-view.ts): ◷ rate limited, † dead.
+    expect(glyphOf("rate_limited")).toBe("◷")
+    expect(glyphOf("dead")).toBe("†")
+    expect(glyphOf("error")).toBe("!")
+    // Whatever the marks are, they must be DISTINCT: the three ask for three
+    // different actions (wait / look / restart), and one `!` for all three is
+    // the defect.
+    expect(new Set([glyphOf("rate_limited"), glyphOf("error"), glyphOf("dead")]).size).toBe(3)
+  })
+
+  it("still raises an attention notification for all three", () => {
+    // Splitting the chip vocabulary must not silently drop the toast that
+    // `rate_limited` used to get by riding on `error`.
+    for (const state of ["rate_limited", "error", "dead"] as const) {
+      expect(chipAttentionKind(activityTurnState(state) ?? "")).toBe("error")
+    }
+  })
+})
+
+/**
+ * The Inbox pane must actually CALL the resume-note helper.
+ *
+ * `inbox-item-view.test.ts` covers the helper; nothing covered the call site,
+ * so deleting it would put the note back where it started — computed and
+ * discarded. Asserted against the source for the same reason as the
+ * `startPtyExitWatch` wiring check: it is a connection, and a connection is
+ * what went missing.
+ */
+describe("Inbox pane wiring", () => {
+  it("renders the resume note on the card's context line", async () => {
+    const src = await Bun.file(new URL("../../src/tui-react/workspace/AttentionInboxPane.tsx", import.meta.url)).text()
+    expect(src).toContain("quotaResumeNote(item.state, task, t)")
+    // Present in the rendered subtitle, not just assigned to a dead local.
+    expect(src).toMatch(/subtitle=\{resumeNote \?/)
+  })
+})

--- a/packages/kobe/test/tui/inbox-item-view.test.ts
+++ b/packages/kobe/test/tui/inbox-item-view.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Inbox card presentation — the glyph/word/resume-note mapping.
+ *
+ * The `resumesAt` case is the one that matters: `Task.quotaResume.resumeAt`
+ * was persisted by the daemon and read by NOTHING, so "rate limited" could
+ * not be told apart from "stuck forever". Deleting the `quotaResumeNote` call
+ * in `AttentionInboxPane` is caught by the pane test; deleting the function's
+ * body is caught here.
+ */
+import { describe, expect, it } from "vitest"
+import { itemGlyph, itemStateKey, quotaResumeNote } from "../../src/tui-react/workspace/inbox-item-view"
+import type { Task } from "../../src/types/task"
+
+const t = (key: string, params?: Record<string, string>) => (params ? `${key}:${Object.values(params).join(",")}` : key)
+const armed = (resumeAt: string) => ({ quotaResume: { resumeAt } }) as Pick<Task, "quotaResume">
+
+describe("quotaResumeNote", () => {
+  it("names the armed resume time for a rate-limited task", () => {
+    const note = quotaResumeNote("rate_limited", armed("2026-08-30T15:14:00.000Z"), t)
+    expect(note).not.toBeNull()
+    expect(note).toContain("workspace.inbox.resumesAt")
+    // The formatted clock, not the raw ISO stamp.
+    expect(note).not.toContain("2026-08-30T15:14")
+    expect(note).toMatch(/\d{1,2}:\d{2}/)
+  })
+
+  it("says nothing when no resume is armed, or the state is not a rate limit", () => {
+    expect(quotaResumeNote("rate_limited", { quotaResume: undefined }, t)).toBeNull()
+    expect(quotaResumeNote("error", armed("2026-08-30T15:14:00.000Z"), t)).toBeNull()
+    expect(quotaResumeNote("dead", armed("2026-08-30T15:14:00.000Z"), t)).toBeNull()
+  })
+
+  it("shows nothing rather than 'Invalid Date' for a garbage stamp", () => {
+    expect(quotaResumeNote("rate_limited", armed("not-a-date"), t)).toBeNull()
+  })
+})
+
+describe("inbox item glyphs", () => {
+  it("gives a dead engine its own mark and word", () => {
+    expect(itemGlyph("dead")).toBe("†")
+    expect(itemStateKey("dead")).toBe("workspace.inbox.state.dead")
+  })
+
+  it("keeps rate limited distinct from error", () => {
+    expect(itemGlyph("rate_limited")).not.toBe(itemGlyph("error"))
+    expect(itemStateKey("rate_limited")).not.toBe(itemStateKey("error"))
+  })
+})

--- a/packages/kobe/test/tui/turn-state-merge.test.ts
+++ b/packages/kobe/test/tui/turn-state-merge.test.ts
@@ -17,7 +17,10 @@ describe("activityTurnState", () => {
     expect(activityTurnState("running")).toBe("running")
     expect(activityTurnState("turn_complete")).toBe("done")
     expect(activityTurnState("error")).toBe("error")
-    expect(activityTurnState("rate_limited")).toBe("error")
+    // NOT "error": a limit that clears itself and a broken engine ask for
+    // opposite actions, and the sidebar rail has always drawn them apart.
+    expect(activityTurnState("rate_limited")).toBe("rate_limited")
+    expect(activityTurnState("dead")).toBe("dead")
     expect(activityTurnState("permission_needed")).toBe("needs_input")
   })
 


### PR DESCRIPTION
Rove recorded almost everything about a dying engine and rendered almost none
of it. Four gaps, all display-and-channel rather than detection.

## 1. Engine death was a UI no-op

A killed engine (SIGTERM: no Stop, no SessionEnd, no hook of any kind) reached
the UI as `applyRest(… "no engine in foreground")` — folded into idle. A dead
tab rendered **byte-identically to a shell that had never run anything**. The
exit record (code, signal, the 403 text) was already on disk in
`pty-exits.json`; its only consumer was `rove api inspect`, and the
`session.exited` plugin event had no subscribers outside the plugin host.

The record now travels: `pty-exit-watch` → `DaemonActivityRegistry`
(`recordEngineDeath`) → a new `dead` activity state → `†` in the sidebar and
the tab strip, plus its own durable Inbox episode. The state carries the exit
code and the last error line, so the death says *why*.

The observer keeps folding a vanished foreground into idle, deliberately: the
shell outlives its engine, and quitting your agent on purpose is an ordinary
idle tab. `dead` comes only from the exit record, which knows the difference.

## 2. `rate_limited` and `error` were the same `!`

`turn-state-merge.ts` collapsed both into `error`, while the sidebar has always
drawn them apart (`◷` vs `×`) — two surfaces, one tab, two answers. "Blocked
until the window resets" and "broke, needs you" ask for opposite actions. The
strip now uses the rail's own glyphs.

`Task.quotaResume.resumeAt` was persisted by the daemon's quota probe and read
by **nothing** (zero hits across the TUI and web). A rate-limited Inbox card
now shows `resumes 3:14 PM`, so a wait is distinguishable from a dead end.

## 3. The sidebar computed explanatory words and discarded them

`activityLabelFor` produced "rate limited" / "needs permission" / "error" for
`subtitleText`. The one-line tree row renders only the glyph and the tab label
— the words had maintenance cost and no reader, asserted solely by tests.

Deleted the text; **kept the tone**, which is not dead: it is what keeps a
row's warning/error colour when something else makes it spin (`loading` would
otherwise paint it `primary`). That is why the glyphs must stay distinct —
with no subtitle there is no second channel to disambiguate them.

## 4. Kimi could never classify a failure as a rate limit

`kimi-local` returned no detail for `turn-failed`, so `reduceActivity` saw
`failure: undefined` and every Kimi failure — including the 5-hour wall that
triggered this work — reduced to a generic `error`, never reaching
`rate_limited` and so never arming auto-resume. Now classified, against Kimi's
real vocabulary (verified in the installed 0.37.2 binary): `error_type` is a JS
class name, and the `[provider.*]` code rides in the message. The 403 quota
wall maps to `billing` — attention, but deliberately no resume timer.

**Codex is left alone, and that is the finding.** Its hook enum (verified in
codex-cli 0.149.1) has no failure event at all — `TurnFailed` exists but is an
app-server thread event, not a hook. A classifier there would be dead code. Its
quota probe is the only path. **Kimi still has no quota probe** — out of scope
here, and still missing.

## Verification

- Three runners green: 3886 vitest / 639 socket / render.
- **Nine mutations, each → red**, hitting wires as well as leaves: dropping
  `activity` from the server's watch options; deleting the `publishDeath` call;
  reverting the merge fold; reverting `TURN_GLYPHS` (a *different* site for the
  same slice); dropping Kimi's `turn-failed` branch; removing one classifier
  branch; stopping the `quotaResume` read; deleting the pane's call site;
  dropping the Inbox death write. Re-verified after rebase.
- Two of those exist because a behavioural test could not see a disconnect —
  the watcher tests pass their own `activity`, so `server.ts` dropping it stays
  green. Those are asserted against the wiring itself.
- Screenshots below, via `/harness` → xterm.js → PTY sidecar → real OpenTUI,
  driving a **real Claude Code engine** killed by its exact pid from
  `rove api inspect`.

Note for reviewers: full-suite runs are flaky under parallel load on this
machine — clean `origin/main` failed a different test in the same comparison.
Every file involved passes in isolation.