### PR TITLE
fix: catch two silent-catch shapes the gate was letting through

### DIFF
--- a/.changeset/silent-catch-arrow-block.md
+++ b/.changeset/silent-catch-arrow-block.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Teach the silent-catch gate two shapes it was letting through: a promise `.catch` with a block body (`.catch((err) => { console.error(...) })`) and the log function handed over bare (`.catch(console.error)`). The block form was the notable miss — the existing check keyed on the `catch` keyword, so a `.catch` method call with a brace never matched, and opening a brace to hold one log line is the most natural way to write the defect.

--- a/packages/kobe/test/architecture/no-silent-catch.test.ts
+++ b/packages/kobe/test/architecture/no-silent-catch.test.ts
@@ -55,6 +55,54 @@ test("a block-form catch whose only statement is the log fails the gate", () => 
   expect(result.stdout).toContain("bare console.error in a catch handler")
 })
 
+test("a promise .catch with a block body whose only statement is the log fails the gate", () => {
+  // The try/catch-keyword pattern misses this: `.catch((err) => {` is a
+  // method call, not the `catch` keyword. Opening a brace to hold one log
+  // line is the most natural way to write the defect.
+  const result = run(`export function go(p: { run: () => Promise<void> }) {
+  void p.run().catch((err) => {
+    console.error("[rove] run failed:", err)
+  })
+}
+`)
+  expect(result.code).toBe(1)
+  expect(result.stdout).toContain("bare console.error in a catch handler")
+})
+
+test("a bare `.catch(console.error)` fails the gate", () => {
+  const result = run(`export function go(p: { run: () => Promise<void> }) {
+  void p.run().catch(console.error)
+}
+`)
+  expect(result.code).toBe(1)
+  expect(result.stdout).toContain("bare console.error in a catch handler")
+})
+
+test("a block-body .catch that also notifies passes", () => {
+  const result = run(`export function go(p: { run: () => Promise<void> }, notifyError: (m: string) => void) {
+  void p.run().catch((err) => {
+    console.error("[rove] run failed:", err)
+    notifyError("Couldn't run it")
+  })
+}
+`)
+  expect(result.code).toBe(0)
+})
+
+test("a silent-catch-ok marker on the line ABOVE exempts a block-body catch", () => {
+  // The repo's live exemptions (use-workspace-selection.ts) are written in
+  // this position, so the block-body shape has to honour it too — otherwise
+  // adding the shape turns legitimate code red.
+  const result = run(`export function go(p: { run: () => Promise<void> }) {
+  // silent-catch-ok: focus bookkeeping, nothing for the user to act on.
+  void p.run().catch((err) => {
+    console.error("[rove] run failed:", err)
+  })
+}
+`)
+  expect(result.code).toBe(0)
+})
+
 test("logging AND notifying passes — that shape is the fix, not the defect", () => {
   const result = run(`export async function go(run: () => Promise<void>, notifyError: (m: string) => void) {
   try {

--- a/scripts/no-silent-catch.mjs
+++ b/scripts/no-silent-catch.mjs
@@ -12,6 +12,13 @@
  * (focus bookkeeping, telemetry) takes a `// silent-catch-ok: <reason>` marker
  * on the offending line or the one above it.
  *
+ * This is a line-shaped scan, so two shapes still get through: an arrow split
+ * across lines (`.catch((err) =>\n  console.error(...))`) and a block body
+ * where the log is not the first statement. Catching either needs a
+ * string/comment-aware paren matcher; the shapes are rare enough that the
+ * matcher costs more than it returns. The gate narrows the class, it does not
+ * close it — a review still has to read the catch.
+ *
  * Behavior is covered by test/architecture/no-silent-catch.test.ts.
  */
 import { readFileSync, readdirSync, statSync } from "node:fs"
@@ -31,7 +38,16 @@ function sources(dir) {
 }
 
 const CATCH_ARROW = /\.catch\s*\(.*=>\s*console\.error/
+// `.catch(console.error)` — the log function handed over bare. Same defect as
+// the arrow form, and the shorter thing to type.
+const CATCH_BARE = /\.catch\s*\(\s*console\.error\s*\)/
 const CATCH_BLOCK_OPEN = /\bcatch\s*(\([^)]*\))?\s*\{\s*$/
+// `.catch((err) => {` — a promise handler with a block body. `CATCH_BLOCK_OPEN`
+// misses it: `\bcatch` there is the try/catch KEYWORD, and the arrow between
+// the parameter list and the brace never matches. Opening a brace and putting
+// one log line inside is the most natural way to write this defect, so the two
+// open-shapes share the only-statement-is-the-log check below.
+const CATCH_ARROW_BLOCK_OPEN = /\.catch\s*\(.*=>\s*\{\s*$/
 const MARKER = /silent-catch-ok/
 
 /**
@@ -53,15 +69,19 @@ for (const file of sources(root)) {
   const lines = readFileSync(file, "utf8").split("\n")
   lines.forEach((line, i) => {
     // Shape 1: one-expression arrow handler, `.catch(e => console.error(…))`.
-    const offending = CATCH_ARROW.test(line)
+    const offending = CATCH_ARROW.test(line) || CATCH_BARE.test(line)
     // Shape 2: a catch block whose ONLY statement is the log — nothing else
     // in the block surfaces the failure. (A block that also notifies is fine,
     // which is exactly the fix, so the closing-brace check is the point.)
-    if (!offending && CATCH_BLOCK_OPEN.test(line)) {
+    if (!offending && (CATCH_BLOCK_OPEN.test(line) || CATCH_ARROW_BLOCK_OPEN.test(line))) {
       const body = lines[i + 1] ?? ""
       const after = lines[i + 2] ?? ""
       if (body.includes("console.error") && /^\s*\}/.test(after)) {
-        if (!MARKER.test(body) && !MARKER.test(line)) hits.push({ file, line: i + 2 })
+        // Same escape hatch as the arrow form: the marker may sit on the log
+        // itself, the opening line, or the line above it — the repo's existing
+        // exemptions are written in that third position.
+        const marked = MARKER.test(body) || MARKER.test(line) || MARKER.test(lines[i - 1] ?? "")
+        if (!marked) hits.push({ file, line: i + 2 })
         return
       }
     }


### PR DESCRIPTION
Follow-up to #666. That PR's gate closes the single-line arrow form; two shapes still got through, verified by running the shipped script against constructed probes.

## What was missed, and why

| shape | before | after |
|---|---|---|
| `.catch(e => console.error(...))` single-line arrow | ✅ | ✅ |
| `.catch(console.error)` bare reference | ❌ | ✅ |
| `.catch(e => { console.error(...) })` **arrow block body** | ❌ | ✅ |
| arrow split across lines | ❌ | ❌ (documented) |
| block body, log preceded by another statement | ❌ | ❌ (documented) |

The block form is the one worth having. `CATCH_BLOCK_OPEN = /\bcatch\s*(\([^)]*\))?\s*\{\s*$/` matches the try/catch **keyword**; `.catch((err) => {` is a method call with an arrow before the brace, so it never matched. Opening a brace and putting one log line inside is the most natural way to write exactly the defect this gate exists to stop.

## Still not caught — on purpose

An arrow split across lines, and a block body where the log is not the first statement. Both need a string/comment-aware paren matcher (~60 lines); the shapes are rarer than the two fixed here, so the matcher costs more than it returns. **The gate narrows this class, it does not close it** — a review still has to read the catch. This is stated in the script header so the next person doesn't assume completeness.

## The regression this could have caused

The tree's live exemptions in `use-workspace-selection.ts:189,194` write `silent-catch-ok` on the line **above** the `.catch`. The arrow form already honoured that position; the block-form check only looked at the log line and the opening line. Adding the block shape without extending the marker rule would have turned two legitimate exemptions red. The block path now checks the same three positions, and a test pins it.

## Verification

- **4 new tests** in `test/architecture/no-silent-catch.test.ts` (9 total, all pass): block form fails, bare reference fails, block-form-that-also-notifies passes, above-line marker exempts a block form.
- **No new false positives.** Ran the changed script against **unmodified `origin/main`** `tui-react/**` (155 files) → exit 0, and the old script on the same input gives the identical result. The `use-workspace-selection.ts` exemptions still pass when that file is scanned alone.
- **Mutation, 3 sites, each red alone:** delete the block-form check → only the block test fails; delete the bare-reference check → only that test fails; delete the above-line marker rule → only the exemption test fails. Restored → 9/9 green.
- Root `lint`, `typecheck`, and `test` all green. Both touched files are ~105 and ~135 lines.