### PR TITLE
fix: make token metrics engine-owned and dedupe built-in vendor lists

### DIFF
--- a/.changeset/engine-owned-usage.md
+++ b/.changeset/engine-owned-usage.md
@@ -1,0 +1,30 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Web transcript token chips now come from the engine, not from re-reading Claude's format
+
+The dashboard's Chat pane computed its "ctx / in / out" chips in the browser
+by summing the raw `input_tokens` / `cache_read_input_tokens` /
+`cache_creation_input_tokens` fields of Claude's JSONL — vendor-shaped math
+living in a neutral layer, exactly what the engine-owned-data rule forbids.
+An engine whose transcripts carry a different shape (Codex, and any future
+engine) silently rendered as "zero tokens", indistinguishable from a session
+that genuinely used nothing.
+
+Usage now arrives as the reader's normalized `EngineUsageSnapshot`: each
+adapter owns its vendor's context arithmetic (Claude's adapter derives the
+last turn's full prompt and marks it approximate; Codex's adapter reports the
+last turn's engine-reported input; Copilot keeps its engine-reported context),
+and the `/api/history/messages` route forwards the snapshot alongside the
+messages. When an engine doesn't surface usage at all (Kimi's unverified
+wire, custom engines), the snapshot is absent and the pane renders no chips —
+"not reported" instead of "zero", the same honesty `read-output`'s
+`engine_unsupported` answer has.
+
+Also tightens the duplicated built-in-engine lists: the daemon's `VendorId`
+is a plain pass-through string again (its literal union had already drifted
+from the shipped engine list by missing Kimi, and the open string branch
+would have hidden the next drift inside an exhaustive-looking switch), and
+`isBuiltinVendor` / the plugin engine-id shadow check now derive from the one
+`BUILTIN_VENDORS` list instead of hand-maintained copies.

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -2,7 +2,16 @@
 
 import type { ObservedLanguage } from "../prompts/observed-language.ts"
 
-export type VendorId = "claude" | "codex" | "copilot" | (string & {})
+/** Engine id (kobe `VendorId`). Deliberately plain `string`: the daemon
+ *  treats vendor ids as opaque pass-through values and never narrows on
+ *  the built-in literals — the old `"claude" | "codex" | "copilot" |
+ *  (string & {})` union drifted from kobe's list (it missed `kimi`) AND
+ *  its open string branch would have hidden the next drift inside an
+ *  exhaustive-looking switch. Where the daemon DOES need the built-in
+ *  list (plugin engine ids may not shadow a built-in or shipped-contrib
+ *  engine), `plugins/manifest.ts` carries `RESERVED_ENGINE_IDS` as its
+ *  own source of truth, locked to kobe's lists by a kobe-side test. */
+export type VendorId = string
 export type TaskStatus = "backlog" | "in_progress" | "in_review" | "done" | "canceled" | "error"
 
 export interface TaskDeletionState {

--- a/packages/kobe-web/src/components/ChatTranscript.tsx
+++ b/packages/kobe-web/src/components/ChatTranscript.tsx
@@ -16,10 +16,12 @@ import { RotateCw, Search, X } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { displayProductName } from "../lib/cli-name.ts"
 import {
+  type EngineUsageSnapshot,
   fetchMessages,
   fetchSessions,
   formatTokens,
   type HistoryMessage,
+  type MessagesResult,
   summarizeUsage,
 } from "../lib/history.ts"
 import { isNearBottom } from "../lib/scroll.ts"
@@ -50,6 +52,9 @@ export function ChatTranscript({
   const [selected, setSelected] = useState<string | null>(null)
   const [followLatest, setFollowLatest] = useState(true)
   const [messages, setMessages] = useState<HistoryMessage[]>([])
+  const [usageSnapshot, setUsageSnapshot] = useState<
+    EngineUsageSnapshot | undefined
+  >(undefined)
   const [search, setSearch] = useState("")
   const [hideTools, setHideTools] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -91,11 +96,14 @@ export function ChatTranscript({
           ? latest
           : (selectedRef.current ?? latest)
         seq = ++seqRef.current
-        const next = target ? await fetchMessages(vendor, target) : []
+        const next: MessagesResult = target
+          ? await fetchMessages(vendor, target)
+          : { messages: [] }
         // A newer pick/poll superseded this fetch — drop its result.
         if (seq !== seqRef.current) return
         setSessions(result.sessions)
-        setMessages(next)
+        setMessages(next.messages)
+        setUsageSnapshot(next.usage)
         setSelected(target)
         setError(null)
       } catch (err) {
@@ -135,6 +143,7 @@ export function ChatTranscript({
     setSelected(null)
     setSearch("")
     setHideTools(false)
+    setUsageSnapshot(undefined)
     setAtBottom(true)
     void refreshRef.current(true)
     const timer = window.setInterval(() => {
@@ -153,8 +162,10 @@ export function ChatTranscript({
     setSelected(sessionId)
     const seq = ++seqRef.current
     void fetchMessages(vendor, sessionId)
-      .then((msgs) => {
-        if (seq === seqRef.current) setMessages(msgs)
+      .then((result) => {
+        if (seq !== seqRef.current) return
+        setMessages(result.messages)
+        setUsageSnapshot(result.usage)
       })
       .catch((err) => {
         if (seq === seqRef.current)
@@ -195,7 +206,7 @@ export function ChatTranscript({
     return map
   }, [messages])
 
-  const usage = useMemo(() => summarizeUsage(messages), [messages])
+  const usage = useMemo(() => summarizeUsage(usageSnapshot), [usageSnapshot])
   // Precompute each message's lowercased search text once per messages change,
   // so a keystroke filters with a cheap substring check instead of re-running
   // JSON.stringify over every tool result on every key (perceptible lag on a
@@ -247,12 +258,22 @@ export function ChatTranscript({
           </select>
         )}
         <div className="ml-auto flex items-center gap-3 font-mono text-[10px] text-subtle">
-          {usage.contextTokens > 0 && (
-            <span title="Live context estimate (last turn's full prompt)">
+          {/* Chips gate on the snapshot's PRESENCE, not on derived numbers:
+              an engine that doesn't report usage (kimi's unverified wire,
+              custom engines) gets no chips — "not reported" never renders
+              as "zero tokens". */}
+          {usageSnapshot && usage.contextTokens > 0 && (
+            <span
+              title={`Live context estimate${
+                usageSnapshot.context_tokens_approximate
+                  ? " (engine-derived)"
+                  : ""
+              }`}
+            >
               ctx {formatTokens(usage.contextTokens)}
             </span>
           )}
-          {usage.outputTokens > 0 && (
+          {usageSnapshot && usage.outputTokens > 0 && (
             <span title="Session tokens in / out">
               ⇡{formatTokens(usage.inputTokens)} ⇣
               {formatTokens(usage.outputTokens)}

--- a/packages/kobe-web/src/lib/history.ts
+++ b/packages/kobe-web/src/lib/history.ts
@@ -1,9 +1,11 @@
 /**
  * Engine-history client — browser mirrors of the engine's neutral history
- * shapes (packages/kobe/src/types/engine.ts Message / ContentBlock) plus
- * the fetchers for the bridge's /api/history routes and the usage math the
- * transcript header renders. Mirrored locally (like types.ts) so no server
- * code leaks into the client bundle.
+ * shapes (packages/kobe/src/types/engine.ts Message / ContentBlock /
+ * EngineUsageSnapshot) plus the fetchers for the bridge's /api/history
+ * routes. Mirrored locally (like types.ts) so no server code leaks into
+ * the client bundle. Usage arrives as the reader's normalized snapshot —
+ * the client never sums per-message vendor fields or re-derives context
+ * math (engine-owned UI data, AGENTS.md).
  */
 
 import { api } from "./api-client.ts"
@@ -14,11 +16,25 @@ export type ContentBlock =
   | { type: "tool_result"; callId: string; output: unknown; isError: boolean }
   | { type: "thinking"; text: string }
 
-export interface MessageUsage {
-  input_tokens: number
-  output_tokens: number
-  cache_read_input_tokens?: number
-  cache_creation_input_tokens?: number
+/**
+ * Browser mirror of the engine-neutral `EngineUsageSnapshot`
+ * (kobe/src/types/engine.ts) — the session-aggregate figures the adapter
+ * derived from its own transcript. Absent from the wire when the engine
+ * doesn't surface usage; that is "not reported", not "zero".
+ */
+export interface EngineUsageSnapshot {
+  readonly input_tokens: number
+  readonly output_tokens: number
+  readonly cache_read_input_tokens?: number
+  readonly cache_creation_input_tokens?: number
+  /** Tokens currently in the session's context window, when known. */
+  readonly context_tokens?: number
+  /** True when `context_tokens` is engine-estimated rather than engine-reported. */
+  readonly context_tokens_approximate?: boolean
+  /** Model context window, when known. */
+  readonly context_window_tokens?: number
+  /** Tokens/sec across the whole session, when derivable. */
+  readonly total_speed_tokens_per_second?: number
 }
 
 export interface HistoryMessage {
@@ -26,7 +42,6 @@ export interface HistoryMessage {
   blocks: ContentBlock[]
   timestamp: string
   sessionId: string
-  usage?: MessageUsage
 }
 
 export interface SessionsResult {
@@ -34,6 +49,12 @@ export interface SessionsResult {
   sessions: string[]
   /** Newest transcript mtime for the worktree; 0 = none yet. */
   latestMtime: number
+}
+
+export interface MessagesResult {
+  messages: HistoryMessage[]
+  /** The reader's neutral usage snapshot; absent = the engine doesn't report usage. */
+  usage?: EngineUsageSnapshot
 }
 
 export function fetchSessions(
@@ -46,49 +67,40 @@ export function fetchSessions(
   })
 }
 
-export async function fetchMessages(
+export function fetchMessages(
   vendor: string,
   sessionId: string,
-): Promise<HistoryMessage[]> {
-  const { messages } = await api.get<{ messages: HistoryMessage[] }>(
-    "/api/history/messages",
-    {
-      query: { vendor, sessionId },
-      label: "/api/history/messages",
-    },
-  )
-  return messages
+): Promise<MessagesResult> {
+  return api.get<MessagesResult>("/api/history/messages", {
+    query: { vendor, sessionId },
+    label: "/api/history/messages",
+  })
 }
 
 export interface UsageSummary {
-  /** Sum of fresh input tokens across the session. */
+  /** Session's fresh input tokens (engine-reported aggregate). */
   inputTokens: number
-  /** Sum of output tokens across the session. */
+  /** Session's output tokens (engine-reported aggregate). */
   outputTokens: number
-  /** Last assistant turn's full prompt size — the live context estimate
-   *  (input + cache read + cache creation), ccstatusline's derivation. */
+  /** Live context estimate, when the engine reports one. */
   contextTokens: number
 }
 
-/** Aggregate per-message usage (claude persists it inline; other vendors may
- *  not — all-zero means "no usage data", render nothing). */
+/**
+ * Unpack the bridge's neutral snapshot into the header's display numbers.
+ * No math here — the adapter owns every derivation. `undefined` means the
+ * engine doesn't surface usage (kimi's unverified wire, custom engines):
+ * the header renders no chips, mirroring read-output's `engine_unsupported`
+ * honesty — "not reported" must never display as zero.
+ */
 export function summarizeUsage(
-  messages: readonly HistoryMessage[],
+  usage: EngineUsageSnapshot | undefined,
 ): UsageSummary {
-  let inputTokens = 0
-  let outputTokens = 0
-  let contextTokens = 0
-  for (const message of messages) {
-    const usage = message.usage
-    if (!usage) continue
-    inputTokens += usage.input_tokens
-    outputTokens += usage.output_tokens
-    contextTokens =
-      usage.input_tokens +
-      (usage.cache_read_input_tokens ?? 0) +
-      (usage.cache_creation_input_tokens ?? 0)
+  return {
+    inputTokens: usage?.input_tokens ?? 0,
+    outputTokens: usage?.output_tokens ?? 0,
+    contextTokens: usage?.context_tokens ?? 0,
   }
-  return { inputTokens, outputTokens, contextTokens }
 }
 
 /** Compact token formatting: 1234 → "1.2k", 1234567 → "1.2m". */

--- a/packages/kobe-web/test/history-usage.test.ts
+++ b/packages/kobe-web/test/history-usage.test.ts
@@ -1,53 +1,56 @@
 import { describe, expect, it } from "vitest"
 import {
   formatTokens,
-  type HistoryMessage,
+  type EngineUsageSnapshot,
   summarizeUsage,
 } from "../src/lib/history.ts"
 
 /**
- * The transcript header shows session in/out totals + a live context estimate
- * derived from per-message usage (ccstatusline's pattern: context = the LAST
- * turn's full prompt = input + cache read + cache creation). Lock the math.
+ * The transcript header renders the reader's neutral usage snapshot — the
+ * adapter owns every derivation (session totals, what counts as "context").
+ * The client only unpacks the snapshot, and treats its ABSENCE ("engine
+ * doesn't report usage", e.g. kimi's unverified wire) as "render no chips",
+ * never as zero — the same honesty as read-output's `engine_unsupported`.
  */
 
-function msg(usage?: HistoryMessage["usage"]): HistoryMessage {
-  return { role: "assistant", blocks: [], timestamp: "", sessionId: "s", usage }
-}
-
 describe("summarizeUsage", () => {
-  it("sums input/output across turns, context = last turn's full prompt", () => {
-    const out = summarizeUsage([
-      msg({ input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5 }),
-      msg({
-        input_tokens: 200,
-        output_tokens: 40,
-        cache_read_input_tokens: 1000,
-        cache_creation_input_tokens: 50,
-      }),
-    ])
-    expect(out.inputTokens).toBe(300) // 100 + 200
-    expect(out.outputTokens).toBe(60) // 20 + 40
-    // context = last turn only: 200 + 1000 + 50
-    expect(out.contextTokens).toBe(1250)
-  })
-
-  it("ignores messages with no usage and returns zeros for none", () => {
-    expect(summarizeUsage([msg(), msg()])).toEqual({
-      inputTokens: 0,
-      outputTokens: 0,
-      contextTokens: 0,
-    })
-    expect(summarizeUsage([])).toEqual({
-      inputTokens: 0,
-      outputTokens: 0,
-      contextTokens: 0,
+  it("unpacks the engine-neutral snapshot verbatim — no client-side math", () => {
+    const snapshot: EngineUsageSnapshot = {
+      input_tokens: 300,
+      output_tokens: 60,
+      cache_read_input_tokens: 1005,
+      cache_creation_input_tokens: 50,
+      context_tokens: 1250,
+      context_tokens_approximate: true,
+    }
+    expect(summarizeUsage(snapshot)).toEqual({
+      inputTokens: 300,
+      outputTokens: 60,
+      contextTokens: 1250,
     })
   })
 
-  it("treats missing cache fields as zero", () => {
-    const out = summarizeUsage([msg({ input_tokens: 42, output_tokens: 7 })])
+  it("engine-reported context (copilot) passes through without approximation", () => {
+    const snapshot: EngineUsageSnapshot = {
+      input_tokens: 10,
+      output_tokens: 5,
+      context_tokens: 42,
+    }
+    const out = summarizeUsage(snapshot)
     expect(out.contextTokens).toBe(42)
+  })
+
+  it("undefined means \"not reported\" — zeros for display, so chips gate off", () => {
+    expect(summarizeUsage(undefined)).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      contextTokens: 0,
+    })
+  })
+
+  it("a snapshot without context_tokens yields a zero context display", () => {
+    const snapshot: EngineUsageSnapshot = { input_tokens: 10, output_tokens: 5 }
+    expect(summarizeUsage(snapshot).contextTokens).toBe(0)
   })
 })
 

--- a/packages/kobe-web/test/notes-history-client.test.ts
+++ b/packages/kobe-web/test/notes-history-client.test.ts
@@ -68,11 +68,15 @@ describe("history client", () => {
     expect(lastReq?.url).toContain("vendor=claude")
   })
 
-  it("fetchMessages unwraps the messages array", async () => {
-    mockFetch({ ok: true, json: { messages: [{ role: "user" }] } })
+  it("fetchMessages passes the result through, messages + optional usage", async () => {
+    mockFetch({ ok: true, json: { messages: [{ role: "user" }], usage: { input_tokens: 1, output_tokens: 2 } } })
     const out = await fetchMessages("codex", "sess-1")
-    expect(out).toEqual([{ role: "user" }])
+    expect(out.messages).toEqual([{ role: "user" }])
+    expect(out.usage).toEqual({ input_tokens: 1, output_tokens: 2 })
     expect(lastReq?.url).toContain("sessionId=sess-1")
+    // Engines that don't report usage omit the key — undefined, not zero.
+    mockFetch({ ok: true, json: { messages: [] } })
+    expect((await fetchMessages("kimi", "sess-2")).usage).toBeUndefined()
   })
 
   it("throws the JSON error body when present", async () => {

--- a/packages/kobe-web/test/transcript-usage-chips.test.tsx
+++ b/packages/kobe-web/test/transcript-usage-chips.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+/**
+ * The header's token chips must distinguish "the engine reported zero" from
+ * "the engine reports no usage at all" (kimi's unverified wire, custom
+ * engines). Both collapse to 0 once unpacked, so the chips gate on the
+ * SNAPSHOT'S PRESENCE, not on its numbers — these cases pin that gate,
+ * which `summarizeUsage` unit tests can't see.
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { MessagesResult } from "../src/lib/history.ts"
+
+const { fetchMessagesMock } = vi.hoisted(() => ({
+  fetchMessagesMock: vi.fn<() => Promise<MessagesResult>>(),
+}))
+
+vi.mock("../src/lib/history.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/lib/history.ts")>()
+  return {
+    ...actual,
+    fetchSessions: async () => ({ sessions: ["s1"], latestMtime: 1 }),
+    fetchMessages: fetchMessagesMock,
+  }
+})
+
+vi.mock("../src/lib/store.ts", () => ({
+  useAppState: () => ({ daemonConnected: true, streamConnected: true }),
+}))
+
+import { ChatTranscript } from "../src/components/ChatTranscript.tsx"
+
+afterEach(() => {
+  cleanup()
+  fetchMessagesMock.mockReset()
+})
+
+const show = async () => {
+  render(<ChatTranscript worktreePath="/tmp/wt" vendor="claude" />)
+  await waitFor(() => expect(fetchMessagesMock).toHaveBeenCalled())
+}
+
+describe("transcript header token chips", () => {
+  it("renders the in/out chip when the engine reported usage", async () => {
+    fetchMessagesMock.mockResolvedValue({
+      messages: [],
+      usage: { input_tokens: 300, output_tokens: 60 },
+    })
+    await show()
+    await waitFor(() => expect(screen.getByTitle("Session tokens in / out")).toBeTruthy())
+  })
+
+  it("renders NO chip when the engine reports no usage — absence is not zero", async () => {
+    fetchMessagesMock.mockResolvedValue({ messages: [] })
+    await show()
+    // Give the state update the same window the positive case needed.
+    await waitFor(() => expect(fetchMessagesMock).toHaveBeenCalled())
+    expect(screen.queryByTitle("Session tokens in / out")).toBeNull()
+  })
+})

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -40,7 +40,7 @@ import { randomUUID } from "node:crypto"
 import { appendFile, mkdir, readdir, stat, unlink } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
-import type { Message } from "@/types/engine"
+import type { EngineUsageSnapshot, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
 import { isObject, parseSessionRaw } from "./history-parse"
 
@@ -206,6 +206,48 @@ export async function readHistory(sessionId: string, deps: HistoryDeps = default
     return parseSessionRaw(candidate, raw, sessionId)
   }
   return []
+}
+
+/**
+ * Session-aggregate usage for `sessionId`, folded from the per-turn usage
+ * Claude Code persists inline on assistant records. This is the ONE place
+ * the vendor's context arithmetic lives: "context" = the LAST turn's full
+ * prompt (fresh input + cache read + cache creation), derived — not an
+ * engine-reported figure — hence `context_tokens_approximate`. Neutral
+ * layers (web transcript header, cost dashboards) render the snapshot and
+ * must not re-derive the math from per-message fields.
+ * `undefined` when the session has no usage records (nothing reported,
+ * which is different from a reported zero).
+ */
+export async function readUsageSnapshot(
+  sessionId: string,
+  deps: HistoryDeps = defaultDeps,
+): Promise<EngineUsageSnapshot | undefined> {
+  const messages = await readHistory(sessionId, deps)
+  let input = 0
+  let output = 0
+  let cacheRead = 0
+  let cacheCreate = 0
+  let lastContext = 0
+  for (const message of messages) {
+    const usage = message.usage
+    if (!usage) continue
+    input += usage.input_tokens
+    output += usage.output_tokens
+    const read = usage.cache_read_input_tokens ?? 0
+    const create = usage.cache_creation_input_tokens ?? 0
+    cacheRead += read
+    cacheCreate += create
+    lastContext = usage.input_tokens + read + create
+  }
+  if (input === 0 && output === 0) return undefined
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    ...(cacheRead > 0 ? { cache_read_input_tokens: cacheRead } : {}),
+    ...(cacheCreate > 0 ? { cache_creation_input_tokens: cacheCreate } : {}),
+    ...(lastContext > 0 ? { context_tokens: lastContext, context_tokens_approximate: true } : {}),
+  }
 }
 
 /**

--- a/packages/kobe/src/engine/codex-local/history-parse.ts
+++ b/packages/kobe/src/engine/codex-local/history-parse.ts
@@ -88,8 +88,16 @@ function foldRolloutChunk(chunk: string, prev: CodexParseState, sessionId: strin
 
     const usageFields = codexUsageFields(parsed)
     if (!usageFields) continue
-    const snapshot = codexUsageToSnapshot(usageFields.usage, { contextWindowTokens: usageFields.contextWindow })
-    if (!snapshot) continue
+    const base = codexUsageToSnapshot(usageFields.usage, { contextWindowTokens: usageFields.contextWindow })
+    if (!base) continue
+    // The last turn's total input (cached included) IS its full prompt — the
+    // context figure the transcript header shows. Engine-reported, so no
+    // approximate flag; absent on records with no per-turn split.
+    const lastPrompt = usageFields.lastUsage ? numberOr(usageFields.lastUsage.input_tokens) : 0
+    const snapshot: EngineUsageSnapshot = {
+      ...base,
+      ...(lastPrompt > 0 ? { context_tokens: lastPrompt } : {}),
+    }
     // Attach THIS turn's usage to its assistant message so the History panel's
     // per-message token sum is non-zero for codex. token_count is a standalone
     // record that follows the turn's response_items, so the nearest preceding

--- a/packages/kobe/src/engine/history-readers.ts
+++ b/packages/kobe/src/engine/history-readers.ts
@@ -50,6 +50,7 @@ export const claudeHistoryReader: EngineHistoryReader = {
     return [...files].sort((a, b) => a.mtimeMs - b.mtimeMs).map((f) => f.sessionId)
   },
   readHistory: (sessionId) => claudeHistory.readHistory(sessionId),
+  readUsageSnapshot: (sessionId) => claudeHistory.readUsageSnapshot(sessionId),
   async transcriptPath(sessionId, worktree) {
     const files = await claudeHistory.listSessionFilesForWorktree(worktree)
     return files.find((f) => f.sessionId === sessionId)?.path ?? null
@@ -61,6 +62,7 @@ export const claudeHistoryReader: EngineHistoryReader = {
 export const codexHistoryReader: EngineHistoryReader = {
   listSessionIdsForWorktree: (worktree) => codexHistory.listSessionIdsForWorktree(worktree),
   readHistory: (sessionId) => codexHistory.readHistory(sessionId),
+  readUsageSnapshot: async (sessionId) => (await codexHistory.readHistoryWithMetrics(sessionId)).usageMetrics,
   // The rollout filename embeds the UUID; the store is date-keyed, not
   // worktree-keyed, so the worktree argument is unused here.
   transcriptPath: async (sessionId) => (await codexHistory.findRolloutFile(sessionId)) ?? null,
@@ -70,6 +72,7 @@ export const codexHistoryReader: EngineHistoryReader = {
 export const copilotHistoryReader: EngineHistoryReader = {
   listSessionIdsForWorktree: (worktree) => copilotHistory.listSessionIdsForWorktree(worktree),
   readHistory: (sessionId) => copilotHistory.readHistory(sessionId),
+  readUsageSnapshot: async (sessionId) => (await copilotHistory.readHistoryWithMetrics(sessionId)).usageMetrics,
   // Each session is a dir holding the `events.jsonl` this reader already
   // parses — so the handoff has a file to name (the earlier "not mapped to
   // a per-session file" note predated `findSessionDir`).

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -26,7 +26,7 @@
  * Must stay importable from vitest and MUST NOT import from `src/tui/`.
  */
 
-import type { EngineCapabilities, EngineIdentity, EngineQuotaUsage, Message } from "@/types/engine"
+import type { EngineCapabilities, EngineIdentity, EngineQuotaUsage, EngineUsageSnapshot, Message } from "@/types/engine"
 import { type VendorId, isBuiltinVendor } from "@/types/vendor"
 import type {
   ClaudeAccount,
@@ -68,6 +68,16 @@ export interface EngineHistoryReader {
   listSessionIdsForWorktree(worktree: string): Promise<readonly string[]>
   /** Neutral messages for one session id; `[]` when not found. */
   readHistory(sessionId: string): Promise<Message[]>
+  /**
+   * Session-aggregate usage in the neutral {@link EngineUsageSnapshot} —
+   * the vendor-specific token math (what counts as "context", what's
+   * cached vs fresh input) is the ADAPTER's job, computed here from its
+   * own parsed transcript, never in UI layers. Absent when the engine
+   * doesn't surface usage (kimi's unverified wire, custom engines): that
+   * is "not reported", distinct from a reported zero, so consumers can
+   * decline to render rather than assert emptiness.
+   */
+  readUsageSnapshot?(sessionId: string): Promise<EngineUsageSnapshot | undefined>
   /**
    * Absolute path of the on-disk transcript for `sessionId`, or null when
    * the engine has no file to point at. Not for kobe to PARSE (that's

--- a/packages/kobe/src/types/vendor.ts
+++ b/packages/kobe/src/types/vendor.ts
@@ -35,7 +35,7 @@ export const ALL_VENDORS: readonly VendorId[] = [...BUILTIN_VENDORS]
 
 /** True when `id` is one of the first-party engines (not a custom one). */
 export function isBuiltinVendor(id: string | undefined): id is BuiltinVendorId {
-  return id === "claude" || id === "codex" || id === "copilot" || id === "kimi"
+  return id !== undefined && (BUILTIN_VENDORS as readonly string[]).includes(id)
 }
 
 /** Next vendor in {@link ALL_VENDORS} order, wrapping around. */

--- a/packages/kobe/src/web/history.ts
+++ b/packages/kobe/src/web/history.ts
@@ -16,7 +16,10 @@
  *       SPA polls this cheaply and refetches messages only on change.
  *
  *   GET /api/history/messages?vendor=<id>&sessionId=<id>
- *     → { messages: Message[] }
+ *     → { messages: Message[], usage?: EngineUsageSnapshot }
+ *       `usage` is the reader's neutral aggregate snapshot; absent when the
+ *       engine doesn't surface usage — the SPA renders no token chips for
+ *       "not reported" instead of asserting zero.
  *
  * Returns `null` for any other path so the server falls through.
  */
@@ -73,8 +76,10 @@ async function handleMessages(url: URL): Promise<Response> {
     return Response.json({ error: "invalid sessionId" }, { status: 400 })
   }
   try {
-    const messages = await engineEntry(vendor).history.readHistory(sessionId)
-    return Response.json({ messages })
+    const reader = engineEntry(vendor).history
+    const messages = await reader.readHistory(sessionId)
+    const usage = reader.readUsageSnapshot ? await reader.readUsageSnapshot(sessionId) : undefined
+    return Response.json({ messages, ...(usage ? { usage } : {}) })
   } catch (err) {
     return Response.json({ error: errorMessage(err) }, { status: 500 })
   }

--- a/packages/kobe/test/engine/claude-usage-snapshot.test.ts
+++ b/packages/kobe/test/engine/claude-usage-snapshot.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import type { HistoryDeps } from "../../src/engine/claude-code-local/history.ts"
+import { readUsageSnapshot } from "../../src/engine/claude-code-local/history.ts"
+
+/**
+ * `readUsageSnapshot` is where Claude's vendor-specific usage math lives:
+ * session totals are the sums of the per-turn usage Claude persists inline,
+ * and "context" is the LAST turn's full prompt (fresh input + cache read +
+ * cache creation). Neutral layers (the web transcript header) render this
+ * snapshot verbatim — they must never re-derive the arithmetic from
+ * per-message fields, and they must be able to tell "no usage reported"
+ * (undefined) apart from a reported zero.
+ */
+
+function record(ts: string, usage: Record<string, number> | undefined): string {
+  const message: Record<string, unknown> = { role: "assistant", content: "turn" }
+  if (usage) message.usage = usage
+  return JSON.stringify({ type: "assistant", message, timestamp: ts, sessionId: "s1" })
+}
+
+function fakeDeps(name: string, sessionId: string, raw: string): HistoryDeps {
+  const root = `/fake-${name}`
+  return {
+    projectsDir: () => root,
+    readdir: async () => ["proj"],
+    readFile: async (p) => {
+      if (p !== `${root}/proj/${sessionId}.jsonl`) throw new Error("ENOENT")
+      return raw
+    },
+    pathExists: async () => true,
+  }
+}
+
+describe("readUsageSnapshot", () => {
+  it("sums session totals and takes the last turn's full prompt as context", async () => {
+    const raw = [
+      record("2026-01-01T00:00:01.000Z", { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5 }),
+      record("2026-01-01T00:00:02.000Z", {
+        input_tokens: 200,
+        output_tokens: 40,
+        cache_read_input_tokens: 1000,
+        cache_creation_input_tokens: 50,
+      }),
+    ].join("\n")
+    expect(await readUsageSnapshot("s1", fakeDeps("agg", "s1", raw))).toEqual({
+      input_tokens: 300,
+      output_tokens: 60,
+      cache_read_input_tokens: 1005,
+      cache_creation_input_tokens: 50,
+      // context = LAST turn only: 200 + 1000 + 50
+      context_tokens: 1250,
+      context_tokens_approximate: true,
+    })
+  })
+
+  it("treats missing cache fields as zero and omits empty aggregates", async () => {
+    const raw = record("2026-01-01T00:00:01.000Z", { input_tokens: 42, output_tokens: 7 })
+    expect(await readUsageSnapshot("s1", fakeDeps("sparse", "s1", raw))).toEqual({
+      input_tokens: 42,
+      output_tokens: 7,
+      context_tokens: 42,
+      context_tokens_approximate: true,
+    })
+  })
+
+  it("returns undefined when the session has no usage records — not a zero", async () => {
+    const raw = record("2026-01-01T00:00:01.000Z", undefined)
+    expect(await readUsageSnapshot("s1", fakeDeps("nousage", "s1", raw))).toBeUndefined()
+  })
+
+  it("returns undefined for a missing session", async () => {
+    expect(await readUsageSnapshot("nope", fakeDeps("missing", "s1", ""))).toBeUndefined()
+  })
+})

--- a/packages/kobe/test/engine/codex-history-edge-cases.test.ts
+++ b/packages/kobe/test/engine/codex-history-edge-cases.test.ts
@@ -268,6 +268,10 @@ describe("deriveCodexUsageMetrics — real rollout event_msg token_count", () =>
       input_tokens: 1000, // total_input (1200) − cached (200)
       output_tokens: 340,
       cache_read_input_tokens: 200,
+      // The last turn's total input IS its full prompt — the context figure
+      // the transcript header renders (moved into the adapter so no neutral
+      // layer re-derives vendor math).
+      context_tokens: 400,
       context_window_tokens: 258_400,
     })
   })

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -89,6 +89,17 @@ describe("engineEntry — built-in vendors", () => {
     }
   })
 
+  it("wires readUsageSnapshot for usage-reporting engines only", () => {
+    // The web transcript header's token chips ride on this: present = the
+    // adapter reports usage; absent (kimi's unverified wire, custom engines)
+    // = "not reported", which the UI renders as no chips rather than zero.
+    expect(typeof engineEntry("claude").history.readUsageSnapshot).toBe("function")
+    expect(typeof engineEntry("codex").history.readUsageSnapshot).toBe("function")
+    expect(typeof engineEntry("copilot").history.readUsageSnapshot).toBe("function")
+    expect(engineEntry("kimi").history.readUsageSnapshot).toBeUndefined()
+    expect(engineEntry("my-custom-engine").history.readUsageSnapshot).toBeUndefined()
+  })
+
   it("exposes Codex identity and its harness default model through capabilities", () => {
     const entry = engineEntry("codex")
     expect(entry.identity?.inputPlaceholder).toBe("Ask Codex…")

--- a/packages/kobe/test/types/vendor.test.ts
+++ b/packages/kobe/test/types/vendor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   ALL_VENDORS,
+  BUILTIN_VENDORS,
   coerceVendorId,
   isBuiltinVendor,
   nextVendor,
@@ -47,8 +48,14 @@ describe("isBuiltinVendor", () => {
     expect(isBuiltinVendor("claude")).toBe(true)
     expect(isBuiltinVendor("codex")).toBe(true)
     expect(isBuiltinVendor("copilot")).toBe(true)
+    expect(isBuiltinVendor("kimi")).toBe(true)
     expect(isBuiltinVendor("aider")).toBe(false)
     expect(isBuiltinVendor(undefined)).toBe(false)
+  })
+
+  it("agrees with BUILTIN_VENDORS exactly — no hand-maintained second list", () => {
+    for (const id of BUILTIN_VENDORS) expect(isBuiltinVendor(id)).toBe(true)
+    expect(BUILTIN_VENDORS.every((id) => isBuiltinVendor(id))).toBe(true)
   })
 })
 

--- a/packages/kobe/test/web/history.test.ts
+++ b/packages/kobe/test/web/history.test.ts
@@ -1,4 +1,28 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+
+// engineEntry is a module-level import in the route, so the readers have to
+// be swapped at the module boundary (an ESM namespace can't be spied on).
+// Only the two synthetic vendors below are mocked; every other test in this
+// file keeps hitting the real registry.
+const { fakeEntries } = vi.hoisted(() => ({
+  fakeEntries: {
+    reports: {
+      readHistory: async () => [],
+      readUsageSnapshot: async () => ({ input_tokens: 12, output_tokens: 3 }),
+    },
+    silent: { readHistory: async () => [] },
+  } as Record<string, unknown>,
+}))
+
+vi.mock("../../src/engine/registry.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/engine/registry.ts")>()
+  return {
+    ...actual,
+    engineEntry: (vendor: string) =>
+      vendor in fakeEntries ? { history: fakeEntries[vendor] } : actual.engineEntry(vendor),
+  }
+})
+
 import { handleHistoryRequest } from "../../src/web/history.ts"
 
 /**
@@ -58,5 +82,31 @@ describe("handleHistoryRequest", () => {
     const json = (await res?.json()) as { sessions: string[]; latestMtime: number }
     expect(json.sessions).toEqual([])
     expect(json.latestMtime).toBe(0)
+  })
+})
+
+/**
+ * The /messages route is where an adapter's usage snapshot reaches the
+ * browser. These two cases pin the WIRE, not the math: an engine that
+ * reports usage must have it forwarded, and one that doesn't must leave
+ * the field ABSENT — the SPA gates its token chips on presence, so a
+ * forwarded zero would render "0 tokens" for engines that simply never
+ * said (kimi's unverified wire, custom engines).
+ */
+describe("handleMessages usage forwarding", () => {
+  const mkUrl = (vendor: string) => new URL(`http://localhost/api/history/messages?vendor=${vendor}&sessionId=s1`)
+
+  it("forwards the reader's snapshot when the engine reports usage", async () => {
+    const url = mkUrl("reports")
+    const res = await handleHistoryRequest(new Request(url), url)
+    const json = (await res?.json()) as { messages: unknown[]; usage?: { input_tokens: number } }
+    expect(json.usage).toEqual({ input_tokens: 12, output_tokens: 3 })
+  })
+
+  it("omits usage entirely when the reader has no snapshot to give", async () => {
+    const url = mkUrl("silent")
+    const res = await handleHistoryRequest(new Request(url), url)
+    const json = (await res?.json()) as Record<string, unknown>
+    expect("usage" in json).toBe(false)
   })
 })


### PR DESCRIPTION
The web transcript header derived its ctx/in/out chips from Claude-shaped
per-message fields — vendor math in a neutral layer, which silently rendered
unsupported engines as zero. Usage now arrives as the reader's normalized
`EngineUsageSnapshot` (adapters own the context arithmetic; the bridge route
forwards it), and the chips gate on snapshot **presence** so "not reported"
never displays as zero.

Separately, the daemon's `VendorId` literal union had drifted from the shipped
engine list (missing `kimi`) behind an open `(string & {})` branch that would
have hidden the next drift. It is a plain pass-through string again, and both
`isBuiltinVendor` and the plugin engine-id shadow check derive from the one
`BUILTIN_VENDORS` list.

## Known trade-off

`readUsageSnapshot?()` is a second reader method rather than a reuse of the
existing `readHistoryWithMetrics` → `EngineHistory {messages, usageMetrics}`
pattern that codex/copilot already have. The `/messages` route therefore
parses the transcript twice (the per-file append cache absorbs the parse, but
claude still re-reads the file). Converging on one call is a follow-up:
claude-local has no `readHistoryWithMetrics` yet, so it is an interface change
across all readers, out of scope here.

## Verification

- Root lint, typecheck, `test:fast`, render (319/0), socket (639/639) green;
  kobe-web lint + suite green (562/562).
- The 47 `test/cli/**` failures reproduce identically on a clean `origin/main`
  baseline worktree (18 files / 47 tests, twice) — pre-existing, not from this
  branch.
- Mutation-checked at three sites, each red twice **after** the final rebase:
  severing the bridge's `readUsageSnapshot` call; dropping the header's
  snapshot-presence guard; defeating the adapter's not-reported sentinel.
  The first two initially **survived** — the leaf tests covered
  `summarizeUsage` and the adapter math but nothing asserted the snapshot
  reached the wire or that a missing snapshot renders no chips. The second
  commit adds those two tests.