### PR TITLE
fix: say so when the daemon and this binary are different builds

### DIFF
--- a/.changeset/cross-version-defects.md
+++ b/.changeset/cross-version-defects.md
@@ -1,0 +1,28 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Say so when the daemon and this binary are different builds
+
+Rove ships several times a day and the daemon is a long-lived process that
+outlives an `npm i -g`, so "new binary, old daemon" is the ordinary result of
+updating — and until now the only state with no way to find out. Three places
+knew and none of them said:
+
+`daemonStaleSignal()` has been accurate since it was written and its only
+reader was the mock workbench, so the amber "DAEMON OUT OF DATE" banner never
+mounted in the product. The workspace now shows it, and hides it behind the
+red disconnect banner when the socket is down — with no daemon answering there
+is nothing to be out of date with.
+
+A verb whose daemon RPC does not exist came back as a bare `RPC_ERROR`, the
+same code an ordinary handler failure uses. `rove api schema --verb archive`
+would print a full spec and exit 0, then the verb itself failed 200ms later
+with nothing naming the cause. That rejection is now `DAEMON_VERSION_SKEW`,
+carrying `rove daemon restart` as its recovery — in both directions, whether
+the daemon predates the verb or dropped it.
+
+`deferredPrompt.file`'s documented degrade — an older daemon rejects the verb,
+so the send surfaces `COMPOSER_BUSY` and the caller retries — had no test.
+Deleting that catch compiled clean and turned a blocked prompt into a reported
+success held by no queue; it is now covered.

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -141,7 +141,29 @@ export function toApiError(err: unknown): ApiError {
       nextCommandArgs: ["api", "list"],
     })
   }
+  if (/unknown daemon request:/i.test(message)) return versionSkewError(message)
   return new ApiError(message, "RPC_ERROR")
+}
+
+/**
+ * The daemon rejected the RPC the verb is BUILT on — which only happens when
+ * this CLI and the long-lived daemon are different builds. It is a version
+ * skew, not a broken verb, and the recovery is the same in both directions:
+ *
+ *   - new CLI × old daemon — the daemon predates the verb.
+ *   - old CLI × new daemon — the daemon dropped a verb this CLI still ships.
+ *
+ * Untyped, this is the incident that motivated the mapping: an agent asked
+ * `schema --verb archive`, got a full spec and exit 0, ran `archive`, and got
+ * a bare `RPC_ERROR` 200ms later. Schema is how an agent discovers a
+ * capability, so a `RPC_ERROR` there reads as "this call failed, retry" rather
+ * than "this binary and that daemon disagree about what exists".
+ */
+function versionSkewError(message: string): ApiError {
+  return new ApiError(message, "DAEMON_VERSION_SKEW", {
+    hint: "the running daemon is a different build than this CLI, so it does not serve this verb — restart the daemon to pick up this build, then retry (if the verb is gone for good, `rove api schema` lists what this daemon actually serves)",
+    nextCommandArgs: ["daemon", "restart"],
+  })
 }
 
 /**

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -12,16 +12,17 @@ import { useEffect, useRef, useState } from "react"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { SIDEBAR_WIDTH } from "../../tui/panes/sidebar/view-core"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
+import { CURRENT_VERSION } from "../../version.ts"
 import { PrefixHud } from "../component/prefix-hud"
 import { ToastOverlay } from "../component/toast-overlay"
-import { DaemonDownBanner } from "../component/version-skew-banner"
+import { DaemonDownBanner, VersionSkewBanner } from "../component/version-skew-banner"
 import { useFocus } from "../context/focus"
 import { useKV } from "../context/kv"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { bootPaneHost } from "../lib/host-boot"
-import { useDaemonDown } from "../lib/use-accessor"
+import { useAccessor, useDaemonDown } from "../lib/use-accessor"
 import { useDaemonNotices } from "../lib/use-daemon-notices"
 import { useLatest } from "../lib/use-latest"
 import { useSidebarHostState } from "../panes/sidebar/use-sidebar-host-state.tsx"
@@ -45,7 +46,10 @@ import { useScratchShell } from "./use-scratch-shell"
 import { type WorktreeGoneEvent, useWorkspaceSelection } from "./use-workspace-selection"
 import { useZenMode } from "./use-zen-mode"
 
-function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
+/** Exported for the render track: the banner wiring can only be proven by
+ *  mounting the REAL host — a test against the banner component alone stays
+ *  green when the mount is deleted, which is the exact bug being fixed. */
+export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   const { theme } = useTheme()
   const inactiveBorder = theme.borderActive
   const dialog = useDialog()
@@ -276,7 +280,27 @@ function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // pages added later; the alternative is a catch block per page, which is
   // where the silence came from in the first place.
   const daemonDown = useDaemonDown(orch)
-  const banner = <DaemonDownBanner down={daemonDown} width={dims.width} />
+  // The skew banner's twin problem, and its twin fix. `daemonStaleSignal()`
+  // has been accurate since it was written and its ONLY reader was the mock
+  // workbench — so the state it names has been invisible in the product the
+  // whole time. That state is not an edge case here: Rove ships several times
+  // a day and the daemon is a long-lived process that outlives an `npm i -g`,
+  // which makes "new binary, old daemon" the ordinary result of updating.
+  //
+  // Down beats stale: with the socket gone there is no daemon to be out of
+  // date with, and the red banner already says the screen is a photograph.
+  const daemonStale = useAccessor(orch.daemonStaleSignal())
+  const daemonVersion = useAccessor(orch.daemonVersionSignal())
+  const banner = daemonDown ? (
+    <DaemonDownBanner down={true} width={dims.width} />
+  ) : (
+    <VersionSkewBanner
+      stale={daemonStale}
+      daemonVersion={daemonVersion}
+      clientVersion={CURRENT_VERSION}
+      width={dims.width}
+    />
+  )
 
   // Settings and the full-window pages replace the WHOLE window, frame
   // included, so each needs the banner wrapped around it rather than relying

--- a/packages/kobe/test/cli/api-version-skew.test.ts
+++ b/packages/kobe/test/cli/api-version-skew.test.ts
@@ -1,0 +1,63 @@
+/**
+ * A verb whose daemon RPC does not exist is a VERSION SKEW, not a failed call.
+ *
+ * The incident: `rove api schema --verb archive` printed a full spec and
+ * exited 0, then `rove api archive --task-id …` came back
+ * `{"error":{"message":"unknown daemon request: task.archive","code":"RPC_ERROR"}}`
+ * 200ms later — the CLI was an older build than the daemon that had dropped
+ * the verb. Schema is how an agent DISCOVERS a capability, so the rejection
+ * has to say "these two builds disagree", not "the call failed".
+ */
+
+import { describe, expect, it } from "vitest"
+import { ApiError, invokeVerb, toApiError } from "../../src/cli/api-cmd.ts"
+import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.ts"
+
+describe("unknown daemon request", () => {
+  it("types the daemon's unknown-request rejection as a version skew, with the restart command", async () => {
+    // The daemon's own wording (daemon/handlers.ts) — matched verbatim so a
+    // reworded daemon error can't silently fall back to bare RPC_ERROR.
+    const client = new FakeClient({
+      "task.setActive": () => {
+        throw new Error("unknown daemon request: task.setActive")
+      },
+    })
+    try {
+      await invokeVerb("set-active", ["--task-id", "t1"], { client, runtime: stubRuntime() })
+      expect.unreachable("should have thrown")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError)
+      const err = error as ApiError
+      expect(err.code).toBe("DAEMON_VERSION_SKEW")
+      // The hint must say what the CALLER does, not just that versions differ.
+      expect(err.data?.hint).toMatch(/restart the daemon/i)
+      expect(err.data?.nextCommandArgs).toEqual(["daemon", "restart"])
+      // The daemon's message survives so the caller can see WHICH verb.
+      expect(err.message).toContain("task.setActive")
+    }
+  })
+
+  it("covers both skew directions — old CLI × new daemon is the same rejection", () => {
+    // The removed-verb case from the incident: this CLI still ships `archive`,
+    // the newer daemon does not serve `task.archive`. Identical wire error, so
+    // one branch has to answer both directions.
+    const err = toApiError(new Error("unknown daemon request: task.archive"))
+    expect(err.code).toBe("DAEMON_VERSION_SKEW")
+    expect(err.data?.nextCommandArgs).toEqual(["daemon", "restart"])
+  })
+
+  it("leaves an ordinary handler failure as RPC_ERROR", async () => {
+    // The branch must not swallow every RPC failure — an unrelated daemon
+    // error is still the untyped fall-through.
+    const client = new FakeClient({
+      "task.setActive": () => {
+        throw new Error("disk is full")
+      },
+    })
+    await expectApiError(
+      () => invokeVerb("set-active", ["--task-id", "t1"], { client, runtime: stubRuntime() }),
+      "RPC_ERROR",
+      /disk is full/,
+    )
+  })
+})

--- a/packages/kobe/test/cli/pty-delivery-gates.test.ts
+++ b/packages/kobe/test/cli/pty-delivery-gates.test.ts
@@ -2,6 +2,13 @@
  * `pty-delivery.ts` delivery gates (issue #78): A-layer recent-human-write
  * and C-layer composer-empty rejections surface as typed `COMPOSER_BUSY`
  * errors instead of silently concatenating peer text with user input.
+ *
+ * The last test covers the DEGRADE the protocol promises for
+ * `deferredPrompt.file`: "Older daemons reject the verbs; callers then
+ * surface COMPOSER_BUSY instead" (kobe-daemon/daemon/protocol.ts). That
+ * promise lives in a `catch` with no test on it, so deleting the catch is
+ * silent — and the failure it would cause is the bad kind: an accepted
+ * prompt that reaches neither the composer nor the queue.
  */
 
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
@@ -86,5 +93,64 @@ describe("deliverToExactTab A+C gates", () => {
     expect(err).toBeInstanceOf(ApiError)
     expect((err as ApiError).code).toBe("COMPOSER_BUSY")
     expect((err as ApiError).data?.layer).toBe("composer-not-empty")
+  })
+})
+
+/** A peek whose composer holds text — the C-layer gate rejects it. */
+function busyComposerPeek(rpc: ReturnType<typeof rpcWith>["rpc"]) {
+  const original = rpc.request
+  rpc.request = async <T>(name: string): Promise<T> => {
+    if (name === "pty.peek") {
+      return {
+        exists: true,
+        alive: true,
+        data: Buffer.from("❯ hello", "utf8").toString("base64"),
+        sinceValid: false,
+        exit: null,
+      } as T
+    }
+    return original(name)
+  }
+}
+
+describe("deferral sink against an older daemon", () => {
+  it("defers into the daemon queue when the verb exists", async () => {
+    // The baseline the degrade is measured against: with a working sink the
+    // send is an accepted-and-queued SUCCESS, not an error.
+    const { rpc } = rpcWith([session("t1::tab-2", ["claude"])])
+    busyComposerPeek(rpc)
+    const result = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
+      vendor: "claude",
+      snapshot: psWith("claude"),
+      defer: { defer: async () => "deferred-1" },
+    })
+    expect(result.deferred).toEqual({ id: "deferred-1", layer: "composer-not-empty" })
+    expect(result.delivered).toBe(false)
+  })
+
+  it("falls back to COMPOSER_BUSY when the daemon rejects deferredPrompt.file", async () => {
+    // An older daemon answers the file RPC with `unknown daemon request:`.
+    // The prompt must come back as the typed retryable error — the one
+    // outcome that must NEVER happen here is a reported success, because the
+    // caller would then not retry a message no queue is holding.
+    const { rpc } = rpcWith([session("t1::tab-2", ["claude"])])
+    busyComposerPeek(rpc)
+    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
+      vendor: "claude",
+      snapshot: psWith("claude"),
+      defer: {
+        defer: async () => {
+          throw new Error("unknown daemon request: deferredPrompt.file")
+        },
+      },
+    }).then(
+      () => null,
+      (e) => e,
+    )
+    expect(err).toBeInstanceOf(ApiError)
+    expect((err as ApiError).code).toBe("COMPOSER_BUSY")
+    expect((err as ApiError).data?.layer).toBe("composer-not-empty")
+    // The recovery argv is the original send, so a caller can retry verbatim.
+    expect((err as ApiError).data?.nextCommandArgs).toEqual(["api", "send", "--task-id", "t1", "--prompt", "go"])
   })
 })

--- a/packages/kobe/test/render/host-version-skew-banner.test.tsx
+++ b/packages/kobe/test/render/host-version-skew-banner.test.tsx
@@ -1,0 +1,153 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The version-skew banner's MOUNT, not its rendering.
+ *
+ * `VersionSkewBanner` has been correct since it was written and its only
+ * caller was the mock workbench — the component was fine, the product never
+ * mounted it. So a test against the component alone stays green with the
+ * wiring deleted, which is exactly the bug: this file mounts the REAL
+ * `WorkspaceRoot` and drives `daemonStaleSignal()`, the cell the `hello`
+ * handshake writes.
+ *
+ * Why it matters here specifically: Rove ships several times a day and the
+ * daemon is a long-lived process that outlives an `npm i -g`, so "new binary,
+ * old daemon" is the ordinary outcome of updating — the one state the user is
+ * most likely to be in and least likely to be told about.
+ */
+
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import type { DaemonConnectionState } from "../../src/client/remote-orchestrator-payloads"
+import { createStateCell } from "../../src/lib/external-store"
+import { WorkspaceRoot } from "../../src/tui-react/workspace/host"
+import { setUiEventReporter } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import { act, renderComponent, settle } from "./harness"
+
+// The host is the widest mount in this track, so its two process-wide side
+// effects have to be undone or they follow the whole file into later tests:
+// KVProvider persists to `$KOBE_HOME_DIR` (the real ~/.rove without this),
+// and the host installs a module-level UI-event reporter closed over THIS
+// orchestrator, which outlives unmount.
+// The env override is per-FILE, not per-test: bun runs every file in one
+// process and interleaves nothing, but a `beforeEach` that snapshots the var
+// would restore whatever the previous file happened to leave — `beforeAll`
+// captures the value once and hands back exactly that.
+let previousHome: string | undefined
+
+beforeAll(() => {
+  previousHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-skew-banner-"))
+})
+
+afterAll(() => {
+  if (previousHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = previousHome
+})
+
+// The reporter is per-MOUNT: the host installs one closed over its own
+// orchestrator, and it outlives the unmount.
+afterEach(() => {
+  setUiEventReporter(null)
+})
+
+// `useAccessor` drives `useSyncExternalStore`, which re-renders whenever the
+// snapshot IDENTITY changes — a getter returning a fresh `{}` each call spins
+// forever. Every constant snapshot below is frozen and hoisted.
+const NULL_CELL = createStateCell(null)
+const EMPTY_MAP = createStateCell(new Map())
+const EMPTY_ARR = createStateCell(Object.freeze([]))
+
+/** A fake whose skew + connection cells are drivable, like the real client:
+ *  `init()`'s handshake writes daemonStale, socket-close writes connection. */
+function fakeOrchestrator() {
+  const stale = createStateCell(false)
+  const daemonVersion = createStateCell<string | null>(null)
+  const connection = createStateCell<DaemonConnectionState>("online")
+  const orchestrator = {
+    connectionStateSignal: () => connection,
+    daemonStaleSignal: () => stale,
+    daemonVersionSignal: () => daemonVersion,
+    tasksSignal: () => EMPTY_ARR,
+    activeTaskSignal: () => NULL_CELL,
+    engineStateSignal: () => EMPTY_MAP,
+    engineLifecycleSignal: () => EMPTY_MAP,
+    engineTabStatesSignal: () => EMPTY_MAP,
+    attentionInboxSignal: () => EMPTY_ARR,
+    taskJobsSignal: () => EMPTY_MAP,
+    worktreeChangesSignal: () => NULL_CELL,
+    transcriptActivitySignal: () => NULL_CELL,
+    transcriptActivityStore: () => NULL_CELL,
+    usageSnapshotSignal: () => NULL_CELL,
+    uiPrefsSignal: () => NULL_CELL,
+    keybindingsRevSignal: () => NULL_CELL,
+    updateSignal: () => NULL_CELL,
+    tabOpenStore: () => NULL_CELL,
+    tabCloseStore: () => NULL_CELL,
+    uiPromptStore: () => NULL_CELL,
+    noticeStore: () => NULL_CELL,
+    reportUiEvent: () => {},
+    reportEngineInterrupt: () => {},
+    listTasks: () => [],
+  } as unknown as RemoteOrchestrator
+  return { orchestrator, stale, daemonVersion, connection }
+}
+
+async function mountHost(orchestrator: RemoteOrchestrator) {
+  const handle = await renderComponent(<WorkspaceRoot orchestrator={orchestrator} />, {
+    width: 80,
+    height: 24,
+    providers: { kv: true, focus: true, dialog: true, notifications: true },
+  })
+  await settle(120)
+  return handle
+}
+
+test("the host mounts the skew banner and drives it from the daemon signal", async () => {
+  // The wiring IS the fix: a banner fed by a hand-set prop reproduces the bug
+  // instead of catching it, so the skew has to arrive the way it does in
+  // production — through the cell the handshake writes.
+  const { orchestrator, stale, daemonVersion } = fakeOrchestrator()
+  const { frame } = await mountHost(orchestrator)
+  expect(await frame()).not.toContain("DAEMON OUT OF DATE")
+
+  await act(async () => {
+    daemonVersion.set("0.9.1")
+    stale.set(true)
+  })
+  await settle(60)
+  const text = await frame()
+  expect(text).toContain("DAEMON OUT OF DATE")
+  // The hint must name BOTH builds and the command — "out of date" alone
+  // leaves the user with nothing to do about it.
+  expect(text).toContain("v0.9.1")
+  expect(text).toContain("rove daemon restart")
+
+  // And it clears itself: a restarted daemon reports the matching version, so
+  // the banner has to go without anyone remounting the workspace.
+  await act(async () => {
+    stale.set(false)
+  })
+  await settle(60)
+  expect(await frame()).not.toContain("DAEMON OUT OF DATE")
+})
+
+test("a disconnected daemon shows the down banner instead of the skew one", async () => {
+  // Down beats stale. With the socket gone there is nothing to be out of date
+  // WITH, and the red banner already says the whole screen is a photograph —
+  // stacking an amber "restart the daemon" on top would send the user to fix
+  // a version when the process is not answering at all.
+  const { orchestrator, stale, daemonVersion, connection } = fakeOrchestrator()
+  const { frame } = await mountHost(orchestrator)
+  await act(async () => {
+    daemonVersion.set("0.9.1")
+    stale.set(true)
+    connection.set("disconnected")
+  })
+  await settle(60)
+  const text = await frame()
+  expect(text).toContain("DAEMON DISCONNECTED")
+  expect(text).not.toContain("DAEMON OUT OF DATE")
+})


### PR DESCRIPTION
Three cross-version defects that all failed the same way: Rove knew the daemon
was a different build than this binary, and never told anyone. Rove ships
several times a day and the daemon is a long-lived process that outlives an
`npm i -g`, so "new binary, old daemon" is the ordinary result of updating —
the state a user is most likely to be in, and least likely to be told about.

### 1. The skew banner was never mounted

`daemonStaleSignal()` has been accurate since it was written and its only
reader was the mock workbench. The component was fine; the product never
mounted it. `host.tsx` now does, and hides it behind the red disconnect banner
when the socket is down — with no daemon answering there is nothing to be out
of date *with*, and the red banner already says the screen is a photograph.

### 2. An unknown daemon RPC was an untyped `RPC_ERROR`

`rove api schema --verb archive` would print a full spec and exit 0; the verb
itself then failed 200ms later with a bare `RPC_ERROR` — the same code an
ordinary handler failure uses. Schema is how an agent *discovers* a
capability, so that rejection read as "retry" rather than "these two builds
disagree". It is now `DAEMON_VERSION_SKEW` carrying `rove daemon restart`,
answering both directions (daemon predates the verb / daemon dropped it).

### 3. The deferral degrade had no test

`protocol.ts` promises: "Older daemons reject the verbs; callers then surface
COMPOSER_BUSY instead." That promise lived in a `catch` nothing covered, so
deleting it compiled clean and turned a blocked prompt into a reported success
held by no queue — the caller would not retry a message that reached neither
the composer nor the daemon.

## Verification

Mutation-tested twice per fix, at six different sites, re-run after each of
the three rebases (final base `a89fc9a4`, v0.9.54):

| # | Site | Mutation | Result |
|---|------|----------|--------|
| 1 | `host.tsx` JSX | banner mount removed | 🔴 |
| 2 | `host.tsx` hook | `daemonStaleSignal()` read severed, mount intact | 🔴 |
| 3 | `api-cmd.ts` | dispatch branch deleted | 🔴 |
| 4 | `api-cmd.ts` | recovery argv → `["api","list"]` | 🔴 |
| 5 | `pty-delivery.ts` | catch returns a fake success | 🔴 |
| 6 | `pty-delivery.ts` | rejection swallowed at the call site | 🔴 |

Mutations 1 and 2 are the point of the render test: it mounts the **real**
`WorkspaceRoot` and drives the signal cell, so deleting the wiring goes red.
A test against `VersionSkewBanner` alone stays green with the mount deleted —
which is the bug, not the fix.

Full suites on the final base: vitest 3903/3903, socket 639/639, render
321/321 (origin/main baseline 319/0 — the two added tests, no leaks).

### One note on the render test

Mounting the whole host leaks two pieces of process-wide state into later
files (bun runs them in one process): `KVProvider` persists to
`$KOBE_HOME_DIR` — the real `~/.config/rove/state.json` if unset — and the
host installs a module-level `setUiEventReporter` that outlives unmount. The
env override is scoped `beforeAll`/`afterAll` (a `beforeEach` snapshot
restores whatever the *previous file* left) and the reporter is cleared
`afterEach`. Without both, three unrelated `new-chat-flow` tests fail.
