### PR TITLE
fix: onboarding says 'ready' only when the machine can actually run a task

### DIFF
--- a/.changeset/onboarding-env-check.md
+++ b/.changeset/onboarding-env-check.md
@@ -3,3 +3,5 @@
 ---
 
 Onboarding checks the machine before saying "ready". The first-run wizard gains a read-only "Environment check" page (the same git + engine probes `rove doctor` runs), and the closing banner only declares "You're ready to go!" when at least one engine is usable and git is present — otherwise it prints what is missing and how to fix it. A wizard killed mid-run also no longer loses the keyboard-basics page forever: a second launch re-runs once in primer mode (environment + keyboard pages, no re-asked questions).
+
+Existing installs are unaffected by the new primer flag: a state file that already records a successful run is settled as done, so upgrading never produces a surprise wizard.

--- a/.changeset/onboarding-env-check.md
+++ b/.changeset/onboarding-env-check.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Onboarding checks the machine before saying "ready". The first-run wizard gains a read-only "Environment check" page (the same git + engine probes `rove doctor` runs), and the closing banner only declares "You're ready to go!" when at least one engine is usable and git is present — otherwise it prints what is missing and how to fix it. A wizard killed mid-run also no longer loses the keyboard-basics page forever: a second launch re-runs once in primer mode (environment + keyboard pages, no re-asked questions).

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -81,10 +81,13 @@ shell completions for the detected shell, and whether to install the companion
 Rove skill for coding agents. Choose with `j`/`k` or the arrow keys and confirm
 with `enter`. `q` or `esc` skips anything you have not answered.
 
-The wizard finishes with a short keyboard primer. It does not sign in to an
-engine; install and authenticate at least one supported engine CLI separately.
-The skill question is the same `rove skill install` from the section above;
-answering it there is enough.
+Next the wizard shows a read-only environment check — the same probes `rove
+doctor` runs: git on `PATH`, and every registered engine CLI's binary and
+login state. If nothing is usable yet, the closing summary says so and prints
+the install command instead of declaring you ready; you can still explore the
+TUI. It does not sign in to an engine; install and authenticate at least one
+supported engine CLI separately. The skill question is the same
+`rove skill install` from the section above; answering it there is enough.
 
 ## Your first task
 

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -13,9 +13,6 @@ import {
   defaultPtyHostSocketPath,
 } from "@sma1lboy/kobe-daemon/daemon/paths"
 import { readPidFile } from "@sma1lboy/kobe-daemon/daemon/server"
-import type { BinaryStatus } from "../engine/account-detect.ts"
-import { listPresetIds } from "../engine/engine-presets.ts"
-import { describeAccount, detectEngineStatuses, engineUsable } from "../engine/engine-status.ts"
 import { homeDir, kvStatePath, roveStateDir } from "../env.ts"
 import { formatBytes } from "../lib/format-bytes.ts"
 import { kobeSkillState, skillInstallCommand } from "../lib/skill-install.ts"
@@ -33,6 +30,7 @@ import {
 } from "./doctor-fix.ts"
 import { classifyHookChannel, hookChannelDoctorLines } from "./doctor-hook-channel.ts"
 import { terminalDoctorLines } from "./doctor-terminal.ts"
+import { probeEngines, probeGit } from "./env-checks.ts"
 import { inspectLegacyTmux, legacyTmuxDoctorLines } from "./legacy-tmux.ts"
 import { activeCliName } from "./rename-compat.ts"
 
@@ -120,51 +118,6 @@ function tailFile(path: string, count: number): string {
   }
 }
 
-/** `git --version` if git is on PATH, else a not-found marker. */
-async function gitDoctorLine(): Promise<{ line: string; found: boolean }> {
-  try {
-    const proc = Bun.spawn(["git", "--version"], { stdin: "ignore", stdout: "pipe", stderr: "ignore" })
-    const text = (await new Response(proc.stdout).text()).trim()
-    if ((await proc.exited) === 0 && text) return { line: `git:      ✓ ${text}`, found: true }
-  } catch {
-    // fall through to not-found
-  }
-  return { line: "git:      ✗ not found on PATH", found: false }
-}
-
-function binaryLabel(binary: BinaryStatus): string {
-  return binary.found ? `✓ ${binary.path}` : `✗ ${binary.error}`
-}
-
-/**
- * One "engines:" block: per-engine CLI binary + account state (read-only).
- *
- * Loops over the REGISTERED engines rather than three hardcoded rows — kimi
- * shipped with a real `detectKimiAccount` and never appeared here, and a
- * contrib/custom engine never could, because adding one meant editing this
- * neutral CLI file. `detectEngineStatuses` is the same probe Settings →
- * Accounts uses, so the two surfaces can't disagree.
- *
- * Order is `listPresetIds()`: the built-ins in their stable cycle order
- * (claude, codex, copilot, kimi — the first three exactly where they were),
- * then the user's own presets in registration order.
- */
-async function engineDoctorLines(): Promise<{ lines: string[]; anyUsable: boolean }> {
-  const statuses = await detectEngineStatuses(listPresetIds())
-  const lines = ["engines:"]
-  for (const status of statuses) {
-    const account = describeAccount(status.account)
-    // padEnd(7)+space, not padEnd(8): a custom id of exactly 8 chars would
-    // otherwise butt straight against the ✓/✗. Built-in columns are unchanged.
-    const name = `${status.vendor.padEnd(7)} `
-    lines.push(`  ${name}${binaryLabel(status.binary)}${status.binary.found ? ` — ${account}` : ""}`)
-    if (status.accountError) lines.push(`          ⚠ ${status.accountError}`)
-  }
-  // "Usable" = binary present AND some account. One usable engine is enough;
-  // a missing vendor the user never launches is not a finding.
-  return { lines, anyUsable: statuses.some(engineUsable) }
-}
-
 async function appendUnavailableProcess(
   out: string[],
   label: string,
@@ -192,9 +145,9 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
   const tasksPath = join(roveStateDir(), "tasks.json")
   const statePath = kvStatePath()
   const fixes: DoctorFix[] = []
-  const git = await gitDoctorLine()
+  const git = await probeGit()
   if (!git.found) fixes.push(humanOnlyFix("git"))
-  const engines = await engineDoctorLines()
+  const engines = await probeEngines()
   if (!engines.anyUsable) fixes.push(humanOnlyFix("noEngine"))
   const out = [
     "Rove doctor",

--- a/packages/kobe/src/cli/env-checks.ts
+++ b/packages/kobe/src/cli/env-checks.ts
@@ -1,0 +1,86 @@
+/**
+ * Read-only environment probes shared by `rove doctor` and the first-run
+ * onboarding wizard: is git on PATH, and can any registered engine actually
+ * run a task (binary present + account where detectable). One implementation
+ * so the wizard's third page and `rove doctor` can never disagree about the
+ * same machine. `doctor-cmd.ts` owns presentation of the full report; the
+ * wizard owns its page.
+ */
+
+import type { BinaryStatus } from "../engine/account-detect.ts"
+import { listPresetIds } from "../engine/engine-presets.ts"
+import { describeAccount, detectEngineStatuses, engineUsable } from "../engine/engine-status.ts"
+
+export interface GitProbeResult {
+  /** The doctor-formatted one-liner (`git: ✓ …` / `git: ✗ …`). */
+  readonly line: string
+  readonly found: boolean
+}
+
+export interface EngineProbeResult {
+  /** The doctor-formatted block (`engines:` header + one row per engine). */
+  readonly lines: string[]
+  /** True when at least one engine could actually run a task right now. */
+  readonly anyUsable: boolean
+}
+
+/** What the onboarding wizard's environment page and closing banner render. */
+export interface OnboardingEnvReport {
+  readonly git: GitProbeResult
+  readonly engines: EngineProbeResult
+}
+
+/** `git --version` if git is on PATH, else a not-found marker. */
+export async function probeGit(): Promise<GitProbeResult> {
+  try {
+    const proc = Bun.spawn(["git", "--version"], { stdin: "ignore", stdout: "pipe", stderr: "ignore" })
+    const text = (await new Response(proc.stdout).text()).trim()
+    if ((await proc.exited) === 0 && text) return { line: `git:      ✓ ${text}`, found: true }
+  } catch {
+    // fall through to not-found
+  }
+  return { line: "git:      ✗ not found on PATH", found: false }
+}
+
+function binaryLabel(binary: BinaryStatus): string {
+  return binary.found ? `✓ ${binary.path}` : `✗ ${binary.error}`
+}
+
+/**
+ * One "engines:" block: per-engine CLI binary + account state (read-only).
+ *
+ * Loops over the REGISTERED engines rather than a fixed set of rows — kimi
+ * shipped with a real `detectKimiAccount` and never appeared here, and a
+ * contrib/custom engine never could, because adding one meant editing a
+ * neutral CLI file. `detectEngineStatuses` is the same probe Settings →
+ * Accounts uses, so the two surfaces can't disagree.
+ *
+ * Order is `listPresetIds()`: the built-ins in their stable cycle order
+ * (claude, codex, copilot, kimi), then the user's own presets in registration
+ * order.
+ */
+export async function probeEngines(): Promise<EngineProbeResult> {
+  const statuses = await detectEngineStatuses(listPresetIds())
+  const lines = ["engines:"]
+  for (const status of statuses) {
+    const account = describeAccount(status.account)
+    // padEnd(7)+space, not padEnd(8): a custom id of exactly 8 chars would
+    // otherwise butt straight against the ✓/✗. Built-in columns are unchanged.
+    const name = `${status.vendor.padEnd(7)} `
+    lines.push(`  ${name}${binaryLabel(status.binary)}${status.binary.found ? ` — ${account}` : ""}`)
+    if (status.accountError) lines.push(`          ⚠ ${status.accountError}`)
+  }
+  // "Usable" = binary present AND some account. One usable engine is enough;
+  // a missing vendor the user never launches is not a finding.
+  return { lines, anyUsable: statuses.some(engineUsable) }
+}
+
+/**
+ * The wizard's pre-flight: both probes in parallel. Runs BEFORE the wizard
+ * renders, so the environment page is static text and a killed wizard never
+ * leaves a probe half-printed.
+ */
+export async function checkOnboardingEnv(): Promise<OnboardingEnvReport> {
+  const [git, engines] = await Promise.all([probeGit(), probeEngines()])
+  return { git, engines }
+}

--- a/packages/kobe/src/cli/onboarding.ts
+++ b/packages/kobe/src/cli/onboarding.ts
@@ -5,10 +5,16 @@
  * (`src/tui-react/onboarding/host.tsx` collects the answers), then this
  * module APPLIES them after the renderer is torn down: hook shell
  * completions into the user's rc file, optionally run the agent-skill
- * installer (npx, inherits the terminal), print the ready banner, and
- * persist the `onboarded` flag so it never runs again. Every install is
- * re-runnable later (`kobe completions --help`, `kobe skill install`), so
+ * installer (npx, inherits the terminal), print the environment summary and
+ * ready banner, and persist the flags so it never runs again. Every install
+ * is re-runnable later (`kobe completions --help`, `kobe skill install`), so
  * declining is always safe.
+ *
+ * Two flags, two guarantees: `onboarded` is set BEFORE the wizard renders, so
+ * a killed wizard never re-asks the questions; `onboardedPrimer` is set only
+ * when the wizard RESOLVES, so a killed wizard (which never reached the
+ * "Keyboard basics" page) re-runs once in primer mode — just the environment
+ * page and the keyboard page, no questions.
  */
 
 import { spawnSync } from "node:child_process"
@@ -18,9 +24,11 @@ import { basename, join } from "node:path"
 import { isNpxMissing, markSkillHintSeen, npxSkillsArgv, npxSkillsCommand } from "../lib/skill-install.ts"
 import { getPersistedBool, setPersistedBool } from "../state/store.ts"
 import { t } from "../tui/i18n"
+import { type OnboardingEnvReport, checkOnboardingEnv } from "./env-checks.ts"
 import { activeCliName } from "./rename-compat.ts"
 
 const ONBOARDED_KEY = "onboarded"
+const PRIMER_KEY = "onboardedPrimer"
 
 export type ShellKind = "zsh" | "bash" | "fish"
 
@@ -70,12 +78,37 @@ export function markOnboarded(): void {
   setPersistedBool(ONBOARDED_KEY, true)
 }
 
+/** The "Keyboard basics" page (and primer-mode re-run) was delivered. */
+export function isPrimerDone(): boolean {
+  return getPersistedBool(PRIMER_KEY, false)
+}
+
+function markPrimerDone(): void {
+  setPersistedBool(PRIMER_KEY, true)
+}
+
 /**
- * Apply the wizard's answers and print the ready banner. Runs AFTER the
- * inline renderer is destroyed — the skill installer inherits the real
- * terminal (npx prompts/progress), and the summary lands in scrollback.
+ * True when the machine can actually run a first task: at least one usable
+ * engine AND git (worktrees need it). The same gates doctor proposes fixes
+ * for, so the closing banner and `rove doctor` tell one story.
  */
-export function applyOnboardingChoices(choices: OnboardingChoices, shell: ShellKind | null): void {
+export function envReadyForTasks(env: OnboardingEnvReport): boolean {
+  return env.engines.anyUsable && env.git.found
+}
+
+/**
+ * Apply the wizard's answers and print the closing summary. Runs AFTER the
+ * inline renderer is destroyed — the skill installer inherits the real
+ * terminal (npx prompts/progress), and the summary lands in scrollback. The
+ * environment report (`git` + `engines`) renders either way: it is the
+ * difference between "You're ready to go!" and an honest list of what is
+ * missing and how to fix it — the remediation lines are doctor's own.
+ */
+export function applyOnboardingChoices(
+  choices: OnboardingChoices,
+  shell: ShellKind | null,
+  env: OnboardingEnvReport,
+): void {
   const cli = activeCliName()
   const completionsHelp = `${cli} completions --help`
   const skillInstall = `${cli} skill install`
@@ -105,28 +138,48 @@ export function applyOnboardingChoices(choices: OnboardingChoices, shell: ShellK
     markSkillHintSeen()
   }
   out("")
-  out(t("onboarding.ready"))
-  // The package ships BOTH bins; every other line here interpolates the name
-  // the user actually invoked, so this one must too.
-  out(t("onboarding.readyHint", { command: cli }))
+  out(env.git.line)
+  for (const line of env.engines.lines) out(line)
+  out("")
+  if (envReadyForTasks(env)) {
+    out(t("onboarding.ready"))
+    // The package ships BOTH bins; every other line here interpolates the name
+    // the user actually invoked, so this one must too.
+    out(t("onboarding.readyHint", { command: cli }))
+  } else {
+    out(t("onboarding.notReadyHeader"))
+    if (!env.engines.anyUsable) out(`  → ${t("doctor.fix.noEngineAction")}`)
+    if (!env.git.found) out(`  → ${t("doctor.fix.gitAction")}`)
+  }
 }
 
 /**
  * The bare-`kobe` gate: on a first interactive launch, run the wizard and
  * return true (the caller exits instead of starting the TUI — the wizard
- * ends with "run `kobe`" so the next launch lands in the app). Returns
- * false when onboarding already happened or there's no TTY to ask on.
+ * ends with "run `kobe`" so the next launch lands in the app). Returns false
+ * when onboarding already happened or there's no TTY to ask on.
+ *
+ * `onboarded` alone never gates entry here — it is set before the wizard
+ * renders, so a killed wizard leaves it set with the primer undelivered.
+ * That launch re-runs in "primer" mode: no questions (a killed wizard must
+ * never re-ask), just the environment page and the keyboard page.
  */
 export async function maybeRunOnboarding(): Promise<boolean> {
   if (!process.stdout.isTTY || !process.stdin.isTTY) return false
-  if (isOnboarded()) return false
-  // Mark BEFORE the wizard even shows: a killed/EOF'd/crashed wizard (or a
-  // failed npx afterwards) must never re-trigger it — one showing, ever,
+  const seen = isOnboarded()
+  if (seen && isPrimerDone()) return false
+  // Mark BEFORE anything runs: a killed/EOF'd/crashed wizard (or a failed npx
+  // afterwards) must never re-trigger the questions — one showing, ever,
   // same never-nag rule as maybeHintSkillInstall.
   markOnboarded()
   const shell = detectShell()
+  const env = await checkOnboardingEnv()
   const { runOnboardingWizard } = await import("../tui-react/onboarding/host.tsx")
-  const choices = await runOnboardingWizard(shell)
-  applyOnboardingChoices(choices, shell)
+  const choices = await runOnboardingWizard(shell, env, seen ? "primer" : "full")
+  // Reaching here the wizard RESOLVED (enter/q/esc all resolve) — only a
+  // process kill leaves the primer undelivered, and that is the one case
+  // that re-runs.
+  markPrimerDone()
+  applyOnboardingChoices(choices, shell, env)
   return true
 }

--- a/packages/kobe/src/cli/onboarding.ts
+++ b/packages/kobe/src/cli/onboarding.ts
@@ -22,10 +22,11 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } fr
 import { homedir } from "node:os"
 import { basename, join } from "node:path"
 import { isNpxMissing, markSkillHintSeen, npxSkillsArgv, npxSkillsCommand } from "../lib/skill-install.ts"
-import { getPersistedBool, setPersistedBool } from "../state/store.ts"
+import { getPersistedBool, loadStateFile, setPersistedBool } from "../state/store.ts"
 import { t } from "../tui/i18n"
 import { type OnboardingEnvReport, checkOnboardingEnv } from "./env-checks.ts"
 import { activeCliName } from "./rename-compat.ts"
+import { LAST_RUN_VERSION_KEY } from "./reset-gate.ts"
 
 const ONBOARDED_KEY = "onboarded"
 const PRIMER_KEY = "onboardedPrimer"
@@ -85,6 +86,23 @@ export function isPrimerDone(): boolean {
 
 function markPrimerDone(): void {
   setPersistedBool(PRIMER_KEY, true)
+}
+
+/**
+ * Settle the primer for anyone who onboarded before it existed.
+ *
+ * `onboardedPrimer` only started being written in this build, so its absence
+ * is ambiguous: a wizard killed mid-render looks exactly like a user who
+ * finished onboarding six months ago. `app.lastRunVersion` disambiguates —
+ * it is written on every successful start, so a user who has ever run the
+ * TUI reached it, which means the wizard resolved. Marking them done keeps
+ * the upgrade silent; only a genuine first run (no recorded version) can
+ * still leave the primer pending.
+ */
+function backfillPrimerForExistingUsers(): boolean {
+  if (typeof loadStateFile()[LAST_RUN_VERSION_KEY] !== "string") return false
+  markPrimerDone()
+  return true
 }
 
 /**
@@ -163,11 +181,19 @@ export function applyOnboardingChoices(
  * renders, so a killed wizard leaves it set with the primer undelivered.
  * That launch re-runs in "primer" mode: no questions (a killed wizard must
  * never re-ask), just the environment page and the keyboard page.
+ *
+ * The primer flag is NEW, so an absent one cannot mean "killed wizard" — every
+ * user who onboarded before this build, and every fixture that seeds
+ * `onboarded: true` to skip the wizard, would otherwise be handed a surprise
+ * primer on upgrade (and no TUI that launch, since a true return means the
+ * caller exits). {@link backfillPrimerForExistingUsers} settles them as done.
  */
 export async function maybeRunOnboarding(): Promise<boolean> {
   if (!process.stdout.isTTY || !process.stdin.isTTY) return false
   const seen = isOnboarded()
-  if (seen && isPrimerDone()) return false
+  // Read the backfill's own verdict rather than re-reading the flag it just
+  // wrote — one decision, no write-then-read round trip through the store.
+  if (seen && (isPrimerDone() || backfillPrimerForExistingUsers())) return false
   // Mark BEFORE anything runs: a killed/EOF'd/crashed wizard (or a failed npx
   // afterwards) must never re-trigger the questions — one showing, ever,
   // same never-nag rule as maybeHintSkillInstall.

--- a/packages/kobe/src/tui-react/onboarding/host.tsx
+++ b/packages/kobe/src/tui-react/onboarding/host.tsx
@@ -3,17 +3,24 @@
  * First-run onboarding wizard — the inline (ink-style) UI half of
  * `src/cli/onboarding.ts`. Renders in a small main-screen footer (the
  * shell prompt history stays visible above), asks the two yes/no
- * questions, shows the "Keyboard basics" page (live-keymap grammar:
- * bare keys / one-press / prefix / help), then destroys the renderer and
- * resolves with the answers — applying them (fs writes, npx) happens back
- * in the CLI layer once the terminal is plain again. `q`/`esc` skips
- * setup: every unanswered step resolves as a decline, never a nag loop.
+ * questions, shows the read-only "Environment check" page (the same git +
+ * engine probes `rove doctor` uses, computed before the wizard renders),
+ * then the "Keyboard basics" page (live-keymap grammar: bare keys /
+ * one-press / prefix / help), then destroys the renderer and resolves with
+ * the answers — applying them (fs writes, npx) happens back in the CLI
+ * layer once the terminal is plain again. `q`/`esc` skips setup: every
+ * unanswered step resolves as a decline, never a nag loop.
+ *
+ * "primer" mode (a first-run wizard killed mid-render re-runs once): no
+ * questions — those were already settled by the never-nag `onboarded` flag —
+ * just the environment page and the keyboard page.
  */
 
 import { TextAttributes } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
 import { useState } from "react"
-import type { OnboardingChoices, ShellKind } from "../../cli/onboarding.ts"
+import type { OnboardingEnvReport } from "../../cli/env-checks.ts"
+import { type OnboardingChoices, type ShellKind, envReadyForTasks } from "../../cli/onboarding.ts"
 import { wizardKeyLines } from "../../tui/lib/keyboard-hints"
 import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
 import { useTheme } from "../context/theme"
@@ -21,25 +28,34 @@ import { useT } from "../i18n"
 import { bootPaneHost } from "../lib/host-boot"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
 
-/** header(2) + blank + answered(2) + keys title + 4 grammar lines + legend + slack */
-const INLINE_ROWS = 15
+/** header(2) + blank + answered(2) + env title/explain + git + ~5 engine rows + verdict + legend + slack */
+const INLINE_ROWS = 20
 
 type StepId = "completions" | "skill"
+type WizardPageKind = "questions" | "env" | "keys"
+
+export type WizardMode = "full" | "primer"
 
 /** Exported for the render tests; production entry is {@link runOnboardingWizard}. */
-export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: OnboardingChoices) => void }) {
+export function WizardPage(props: {
+  shell: ShellKind | null
+  env: OnboardingEnvReport
+  mode?: WizardMode
+  onDone: (choices: OnboardingChoices) => void
+}) {
   const { theme } = useTheme()
   const t = useT()
   const renderer = useRenderer()
+  const mode = props.mode ?? "full"
   // No shell detected → nothing to hook completions into; ask only about
   // the skill. The apply layer skips the completions summary line too.
-  const steps: readonly StepId[] = props.shell === null ? ["skill"] : ["completions", "skill"]
+  const steps: readonly StepId[] = mode === "primer" ? [] : props.shell === null ? ["skill"] : ["completions", "skill"]
   const [stepIndex, setStepIndex] = useState(0)
   const [yes, setYes] = useState(true)
   const [answers, setAnswers] = useState<Partial<Record<StepId, boolean>>>({})
-  // After the questions, one informational "Keyboard basics" page — enter
-  // (or the usual q/esc skip) finishes; there is nothing to answer on it.
-  const [onKeysPage, setOnKeysPage] = useState(false)
+  // After the questions: the environment page, then one informational
+  // "Keyboard basics" page — enter (or the usual q/esc skip) finishes.
+  const [page, setPage] = useState<WizardPageKind>(steps.length === 0 ? "env" : "questions")
 
   const step = steps[stepIndex] as StepId
 
@@ -51,14 +67,18 @@ export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: O
   // `choice` defaults to the keyboard cursor; mouse passes its own option
   // explicitly (setYes + read-back in one handler would see a stale render).
   function confirm(choice: boolean = yes): void {
-    if (onKeysPage) {
+    if (page === "env") {
+      setPage("keys")
+      return
+    }
+    if (page === "keys") {
       finish(answers)
       return
     }
     const next = { ...answers, [step]: choice }
     setAnswers(next)
     if (stepIndex + 1 >= steps.length) {
-      setOnKeysPage(true)
+      setPage("env")
       return
     }
     setStepIndex(stepIndex + 1)
@@ -82,6 +102,7 @@ export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: O
       : t("onboarding.skillQuestion")
   }
   const explain = step === "completions" ? t("onboarding.completionsExplain") : t("onboarding.skillExplain")
+  const ready = envReadyForTasks(props.env)
 
   // Transcript flow, no backgrounds anywhere: answered questions stay on
   // screen as one muted line each (question + chosen answer), the active
@@ -95,7 +116,7 @@ export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: O
         {t("onboarding.subtitle")}
       </text>
       <box flexDirection="column" paddingTop={1}>
-        {steps.slice(0, onKeysPage ? steps.length : stepIndex).map((answered) => (
+        {steps.slice(0, page === "questions" ? stepIndex : steps.length).map((answered) => (
           <box key={answered} flexDirection="row" gap={1}>
             <text fg={theme.success} wrapMode="none">
               ✓
@@ -108,7 +129,32 @@ export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: O
             </text>
           </box>
         ))}
-        {onKeysPage ? (
+        {page === "env" ? (
+          <box flexDirection="column" onMouseUp={() => confirm()}>
+            <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="word">
+              {t("onboarding.envTitle")}
+            </text>
+            <text fg={theme.textMuted} wrapMode="word">
+              {t("onboarding.envExplain")}
+            </text>
+            <box flexDirection="column" paddingTop={1}>
+              <text fg={theme.textMuted} wrapMode="word">
+                {props.env.git.line}
+              </text>
+              {props.env.engines.lines.map((line) => (
+                <text key={line} fg={theme.textMuted} wrapMode="word">
+                  {line}
+                </text>
+              ))}
+            </box>
+            <box paddingTop={1}>
+              <text fg={ready ? theme.success : theme.error} wrapMode="word">
+                {ready ? t("onboarding.envReady") : t("onboarding.envNotReady")}
+              </text>
+            </box>
+          </box>
+        ) : null}
+        {page === "keys" ? (
           <box flexDirection="column" onMouseUp={() => confirm()}>
             <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="word">
               {t("onboarding.keysTitle")}
@@ -119,7 +165,8 @@ export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: O
               </text>
             ))}
           </box>
-        ) : (
+        ) : null}
+        {page === "questions" ? (
           <>
             <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="word">
               {questionFor(step)}
@@ -145,11 +192,11 @@ export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: O
               )
             })}
           </>
-        )}
+        ) : null}
       </box>
       <box paddingTop={1}>
         <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
-          {t(onKeysPage ? "onboarding.keysLegend" : "onboarding.legend")}
+          {t(page === "keys" ? "onboarding.keysLegend" : page === "env" ? "onboarding.envLegend" : "onboarding.legend")}
         </text>
       </box>
     </box>
@@ -157,11 +204,15 @@ export function WizardPage(props: { shell: ShellKind | null; onDone: (choices: O
 }
 
 /** Boot the inline wizard and resolve with the user's answers. */
-export async function runOnboardingWizard(shell: ShellKind | null): Promise<OnboardingChoices> {
+export async function runOnboardingWizard(
+  shell: ShellKind | null,
+  env: OnboardingEnvReport,
+  mode: WizardMode,
+): Promise<OnboardingChoices> {
   return await new Promise<OnboardingChoices>((resolve) => {
     void bootPaneHost({
       inlineRows: INLINE_ROWS,
-      setup: () => ({ root: () => <WizardPage shell={shell} onDone={resolve} /> }),
+      setup: () => ({ root: () => <WizardPage shell={shell} env={env} mode={mode} onDone={resolve} /> }),
     })
   })
 }

--- a/packages/kobe/src/tui/i18n/messages/onboarding.ts
+++ b/packages/kobe/src/tui/i18n/messages/onboarding.ts
@@ -8,7 +8,7 @@ export const en = {
   /** Wizard header */
   title: "Welcome to Rove",
   /** One-liner under the header */
-  subtitle: "Two quick questions before your first launch.",
+  subtitle: "Two quick questions and a quick environment check before your first launch.",
   /** Step 1 question; {shell} is the detected shell name (zsh/bash/fish) */
   completionsQuestion: "Install shell completions for {shell}?",
   /** Step 1 explanation */
@@ -35,6 +35,18 @@ export const en = {
   keysHelp: "{help} shows the full live reference anytime.",
   /** Legend on the keys page */
   keysLegend: "enter finish",
+  /** Environment page: heading */
+  envTitle: "Environment check",
+  /** Environment page: one-liner under the heading */
+  envExplain: "Read-only — what Rove found on this machine:",
+  /** Environment page verdict when at least one engine is usable and git is present */
+  envReady: "✓ You're set — at least one engine is ready.",
+  /** Environment page verdict when no engine is usable (git line above still shows its own result) */
+  envNotReady: "✗ No usable engine yet — Rove needs one to run tasks.",
+  /** Legend on the environment page */
+  envLegend: "enter continue · q skip setup",
+  /** Closing banner when the machine cannot run a first task yet */
+  notReadyHeader: "Not ready yet:",
   /** Post-wizard: completions line was written; {path} is the rc/completions file */
   appliedCompletions: "✓ completions hooked into {path} (takes effect in new shells)",
   /** Post-wizard: completions declined; {command} re-runs it later */
@@ -56,7 +68,7 @@ export const en = {
 
 export const zh: typeof en = {
   title: "欢迎使用 Rove",
-  subtitle: "首次启动前，先回答两个小问题。",
+  subtitle: "首次启动前，先回答两个小问题，再做一次环境检查。",
   completionsQuestion: "为 {shell} 安装 shell 补全吗？",
   completionsExplain: "让 rove 子命令支持 Tab 补全，会在你的 shell 配置里加一行。",
   skillQuestion: "安装 Rove agent skill 吗？",
@@ -70,6 +82,12 @@ export const zh: typeof en = {
   keysPrefix: "{prefix} 打开命令层 — 按住稍等会出现命令指南。",
   keysHelp: "随时按 {help} 查看完整的实时键位表。",
   keysLegend: "enter 完成",
+  envTitle: "环境检查",
+  envExplain: "只读检查 — Rove 在这台机器上发现了什么：",
+  envReady: "✓ 一切就绪 — 至少一个引擎可用。",
+  envNotReady: "✗ 还没有可用引擎 — Rove 需要一个引擎才能运行任务。",
+  envLegend: "enter 继续 · q 跳过设置",
+  notReadyHeader: "还没准备好：",
   appliedCompletions: "✓ 补全已写入 {path}（新开的 shell 生效）",
   skippedCompletions: "· 已跳过补全 — 之后可随时运行 `{command}`",
   installingSkill: "正在安装 Rove agent skill（{command}）…",

--- a/packages/kobe/test/behavior/pure-tui-adopt-orphan-tab.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-adopt-orphan-tab.test.ts
@@ -33,7 +33,10 @@ describe.skipIf(!nodePty)("Pure TUI adopts unregistered live sessions (behavior)
     const stateDir = join(env.home, ".config", "rove")
     await mkdir(stateDir, { recursive: true })
     statePath = join(stateDir, "state.json")
-    await writeFile(statePath, JSON.stringify({ onboarded: true }))
+    // Both flags: `onboarded` alone means "the questions were asked" (it is
+    // set before the wizard renders), not "the wizard finished". Without the
+    // primer, this launch gets the wizard instead of the TUI.
+    await writeFile(statePath, JSON.stringify({ onboarded: true, onboardedPrimer: true }))
 
     // `--prompt` takes the headless launch path: worktree + hosted engine
     // session under `<taskId>::tab-1`, plus the snapshot the CLI writes.

--- a/packages/kobe/test/behavior/pure-tui-live-tab-title.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-live-tab-title.test.ts
@@ -68,7 +68,10 @@ describe.skipIf(!nodePty)("Pure TUI sidebar shows an unselected task's live tab 
     const stateDir = join(env.home, ".config", "rove")
     await mkdir(stateDir, { recursive: true })
     statePath = join(stateDir, "state.json")
-    await writeFile(statePath, JSON.stringify({ onboarded: true }))
+    // Both flags: `onboarded` alone means "the questions were asked" (it is
+    // set before the wizard renders), not "the wizard finished". Without the
+    // primer, this launch gets the wizard instead of the TUI.
+    await writeFile(statePath, JSON.stringify({ onboarded: true, onboardedPrimer: true }))
 
     // `--prompt` takes the headless launch path: worktree + hosted engine
     // session under `<taskId>::tab-1`, plus the snapshot the TUI renders from.

--- a/packages/kobe/test/behavior/pure-tui-open-worktree.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-open-worktree.test.ts
@@ -67,7 +67,10 @@ describe.skipIf(!nodePty)("Pure TUI open-worktree keys (behavior)", () => {
     marker = join(env.home, "editor-opens.log")
     const stateDir = join(env.home, ".config", "rove")
     await mkdir(stateDir, { recursive: true })
-    await writeFile(join(stateDir, "state.json"), JSON.stringify({ onboarded: true }))
+    // Both flags: `onboarded` alone means "the questions were asked" (it is
+    // set before the wizard renders), not "the wizard finished". Without the
+    // primer, this launch gets the wizard instead of the TUI.
+    await writeFile(join(stateDir, "state.json"), JSON.stringify({ onboarded: true, onboardedPrimer: true }))
     const codeShim = join(env.bin, "code")
     await writeFile(codeShim, `#!/bin/sh\nprintf '%s\\n' "$1" >> "${marker}"\n`)
     await chmod(codeShim, 0o755)

--- a/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
@@ -88,7 +88,10 @@ describe.skipIf(!nodePty)("Pure TUI unread lamp across a restart (behavior)", ()
     const stateDir = join(env.home, ".config", "rove")
     await mkdir(stateDir, { recursive: true })
     statePath = join(stateDir, "state.json")
-    await writeFile(statePath, JSON.stringify({ onboarded: true }))
+    // Both flags: `onboarded` alone means "the questions were asked" (it is
+    // set before the wizard renders), not "the wizard finished". Without the
+    // primer, this launch gets the wizard instead of the TUI.
+    await writeFile(statePath, JSON.stringify({ onboarded: true, onboardedPrimer: true }))
 
     // `--prompt` takes the headless launch path: worktree + hosted engine
     // session under `<taskId>::tab-1`, plus the snapshot the TUI renders from.

--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -9,17 +9,19 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { OnboardingEnvReport } from "../../src/cli/env-checks.ts"
 import { detectShell, installCompletions } from "../../src/cli/onboarding.ts"
 
 const mocks = vi.hoisted(() => ({
   spawnSync: vi.fn(),
-  getPersistedBool: vi.fn(() => false),
+  getPersistedBool: vi.fn((_key: string) => false),
   setPersistedBool: vi.fn(),
   npxSkillsArgv: vi.fn(() => ["skills", "add", "stub"]),
   npxSkillsCommand: vi.fn(() => "npx skills add stub"),
   isNpxMissing: vi.fn(() => false),
   markSkillHintSeen: vi.fn(),
   runOnboardingWizard: vi.fn(),
+  checkOnboardingEnv: vi.fn(),
 }))
 
 vi.mock("node:child_process", () => ({ spawnSync: mocks.spawnSync }))
@@ -33,6 +35,11 @@ vi.mock("../../src/lib/skill-install.ts", () => ({
   isNpxMissing: mocks.isNpxMissing,
   markSkillHintSeen: mocks.markSkillHintSeen,
 }))
+// The real probes read this machine's PATH and credential files; the tests
+// assert composition with the report, not the probing.
+vi.mock("../../src/cli/env-checks.ts", () => ({
+  checkOnboardingEnv: mocks.checkOnboardingEnv,
+}))
 vi.mock("../../src/tui-react/onboarding/host.tsx", () => ({
   runOnboardingWizard: mocks.runOnboardingWizard,
 }))
@@ -44,6 +51,33 @@ vi.mock("../../src/tui/index.tsx", () => ({ startTui: vi.fn() }))
 
 function freshHome(): string {
   return mkdtempSync(join(tmpdir(), "kobe-onboarding-"))
+}
+
+/** A passing environment: git present, one usable engine. */
+function readyEnv(): OnboardingEnvReport {
+  return {
+    git: { line: "git:      ✓ git version 2.39.5", found: true },
+    engines: {
+      lines: ["engines:", "  claude  ✓ /bin/claude — logged in (a@b.c)"],
+      anyUsable: true,
+    },
+  }
+}
+
+/**
+ * The audit's abandon scenario: git is fine (every machine that ran
+ * install.sh has it), no engine is usable. git present is the point — a
+ * fixture missing BOTH lets a readiness check that ignores engines entirely
+ * still pass this test.
+ */
+function emptyEnv(): OnboardingEnvReport {
+  return {
+    git: { line: "git:      ✓ git version 2.39.5", found: true },
+    engines: {
+      lines: ["engines:", "  claude  ✗ not found on PATH", "  codex   ✗ not found on PATH"],
+      anyUsable: false,
+    },
+  }
 }
 
 function setProduct(name: "rove" | "kobe"): void {
@@ -137,18 +171,56 @@ describe("applyOnboardingChoices", () => {
   it("declines everything when shell is unknown", async () => {
     setProduct("kobe")
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: false, skill: false }, null)
+    applyOnboardingChoices({ completions: false, skill: false }, null, readyEnv())
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("kobe skill install"))).toBe(true)
     expect(lines.some((l) => l.includes("kobe completions --help"))).toBe(false)
     expect(lines.some((l) => l.includes("You're ready to go!"))).toBe(true)
   })
 
+  it("prints the environment lines and the ready banner only when an engine is usable", async () => {
+    setProduct("kobe")
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: false }, null, readyEnv())
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("git:      ✓ git version 2.39.5"))).toBe(true)
+    expect(lines.some((l) => l.includes("engines:"))).toBe(true)
+    expect(lines.some((l) => l.includes("✓ /bin/claude"))).toBe(true)
+    expect(lines.some((l) => l.includes("You're ready to go!"))).toBe(true)
+  })
+
+  it("never says ready on an engine-less machine — it names the gap and the fix", async () => {
+    setProduct("kobe")
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: false }, null, emptyEnv())
+    const lines = stdoutLines(stdoutSpy)
+    // The audit's abandon moment: "You're ready to go!" printed on a machine
+    // with no engine, four minutes before the first `n` fails. It must not.
+    expect(lines.some((l) => l.includes("You're ready to go!"))).toBe(false)
+    expect(lines.some((l) => l.includes("Not ready yet:"))).toBe(true)
+    // …and the remediation is doctor's own line, not a paraphrase.
+    expect(lines.some((l) => l.includes("install an engine CLI (claude, codex, copilot, or kimi) and log in"))).toBe(
+      true,
+    )
+  })
+
+  it("keeps the banner honest when git is the only thing missing", async () => {
+    setProduct("kobe")
+    const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
+    applyOnboardingChoices({ completions: false, skill: false }, null, {
+      ...readyEnv(),
+      git: { line: "git:      ✗ not found on PATH", found: false },
+    })
+    const lines = stdoutLines(stdoutSpy)
+    expect(lines.some((l) => l.includes("You're ready to go!"))).toBe(false)
+    expect(lines.some((l) => l.includes("install git with your OS package manager"))).toBe(true)
+  })
+
   it("installs completions and the skill when both chosen (kobe)", async () => {
     setProduct("kobe")
     mocks.spawnSync.mockReturnValue({ status: 0 })
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: true, skill: true }, "zsh")
+    applyOnboardingChoices({ completions: true, skill: true }, "zsh", readyEnv())
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("completions hooked into"))).toBe(true)
     expect(lines.some((l) => l.includes("installing the Rove agent skill"))).toBe(true)
@@ -158,7 +230,7 @@ describe("applyOnboardingChoices", () => {
   it("uses the rove CLI name when invoked as rove", async () => {
     setProduct("rove")
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: false, skill: false }, "bash")
+    applyOnboardingChoices({ completions: false, skill: false }, "bash", readyEnv())
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("rove completions --help"))).toBe(true)
     expect(lines.some((l) => l.includes("rove skill install"))).toBe(true)
@@ -172,7 +244,7 @@ describe("applyOnboardingChoices", () => {
   it("tells a kobe user to run kobe, not rove", async () => {
     setProduct("kobe")
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: false, skill: false }, "bash")
+    applyOnboardingChoices({ completions: false, skill: false }, "bash", readyEnv())
     const lines = stdoutLines(stdoutSpy)
     const readyLine = lines.find((l) => l.includes("launch the TUI"))
     expect(readyLine).toBeDefined()
@@ -186,7 +258,7 @@ describe("applyOnboardingChoices", () => {
   it("marks the skill hint seen when the user declines in the wizard", async () => {
     setProduct("rove")
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: false, skill: false }, "bash")
+    applyOnboardingChoices({ completions: false, skill: false }, "bash", readyEnv())
     expect(mocks.markSkillHintSeen).toHaveBeenCalled()
   })
 
@@ -194,7 +266,7 @@ describe("applyOnboardingChoices", () => {
     setProduct("rove")
     mocks.spawnSync.mockReturnValue({ status: 0 })
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: false, skill: true }, "bash")
+    applyOnboardingChoices({ completions: false, skill: true }, "bash", readyEnv())
     expect(mocks.markSkillHintSeen).not.toHaveBeenCalled()
   })
 
@@ -205,7 +277,7 @@ describe("applyOnboardingChoices", () => {
     setProduct("rove")
     mocks.isNpxMissing.mockReturnValue(true)
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: false, skill: true }, "bash")
+    applyOnboardingChoices({ completions: false, skill: true }, "bash", readyEnv())
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("npx") && l.includes("Node"))).toBe(true)
     expect(mocks.spawnSync).not.toHaveBeenCalled()
@@ -215,7 +287,7 @@ describe("applyOnboardingChoices", () => {
     setProduct("kobe")
     mocks.spawnSync.mockReturnValue({ status: 1 })
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
-    applyOnboardingChoices({ completions: false, skill: true }, "zsh")
+    applyOnboardingChoices({ completions: false, skill: true }, "zsh", readyEnv())
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("skill install failed"))).toBe(true)
     expect(lines.some((l) => l.includes("kobe skill install"))).toBe(true)
@@ -227,8 +299,9 @@ describe("maybeRunOnboarding", () => {
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
-    mocks.getPersistedBool.mockReturnValue(false)
+    mocks.getPersistedBool.mockImplementation((key: string) => false)
     mocks.runOnboardingWizard.mockResolvedValue({ completions: true, skill: false })
+    mocks.checkOnboardingEnv.mockResolvedValue(readyEnv())
   })
 
   afterEach(() => {
@@ -245,8 +318,8 @@ describe("maybeRunOnboarding", () => {
     expect(mocks.runOnboardingWizard).not.toHaveBeenCalled()
   })
 
-  it("returns false when already onboarded", async () => {
-    mocks.getPersistedBool.mockReturnValue(true)
+  it("returns false when onboarding AND the primer both completed", async () => {
+    mocks.getPersistedBool.mockImplementation((key: string) => key === "onboarded" || key === "onboardedPrimer")
     const { maybeRunOnboarding } = await import("../../src/cli/onboarding.ts")
     Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true })
     Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
@@ -254,7 +327,7 @@ describe("maybeRunOnboarding", () => {
     expect(mocks.runOnboardingWizard).not.toHaveBeenCalled()
   })
 
-  it("marks onboarded, runs the wizard, applies choices, and returns true", async () => {
+  it("marks onboarded, runs the wizard in full mode, applies choices, and returns true", async () => {
     setProduct("kobe")
     const savedShell = process.env.SHELL
     process.env.SHELL = "/bin/zsh"
@@ -266,8 +339,32 @@ describe("maybeRunOnboarding", () => {
     else process.env.SHELL = undefined
     expect(result).toBe(true)
     expect(mocks.setPersistedBool).toHaveBeenCalledWith("onboarded", true)
-    expect(mocks.runOnboardingWizard).toHaveBeenCalledWith("zsh")
+    // A resolved wizard delivered the keyboard page — the primer is done too.
+    expect(mocks.setPersistedBool).toHaveBeenCalledWith("onboardedPrimer", true)
+    expect(mocks.runOnboardingWizard).toHaveBeenCalledWith("zsh", readyEnv(), "full")
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("completions hooked into"))).toBe(true)
+  })
+
+  it("a killed first-run wizard re-runs once in primer mode — questions stay settled", async () => {
+    setProduct("kobe")
+    // onboarded was set before the wizard rendered, then the process died:
+    // the primer flag never landed.
+    mocks.getPersistedBool.mockImplementation((key: string) => key === "onboarded")
+    mocks.runOnboardingWizard.mockResolvedValue({ completions: false, skill: false })
+    const savedShell = process.env.SHELL
+    process.env.SHELL = undefined
+    const { maybeRunOnboarding } = await import("../../src/cli/onboarding.ts")
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true })
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+    expect(await maybeRunOnboarding()).toBe(true)
+    if (savedShell !== undefined) process.env.SHELL = savedShell
+    expect(mocks.runOnboardingWizard).toHaveBeenCalledWith(null, readyEnv(), "primer")
+    expect(mocks.setPersistedBool).toHaveBeenCalledWith("onboardedPrimer", true)
+    const lines = stdoutLines(stdoutSpy)
+    // Primer mode applies nothing; the environment summary still prints.
+    expect(lines.some((l) => l.includes("completions hooked into"))).toBe(false)
+    expect(lines.some((l) => l.includes("git:      ✓"))).toBe(true)
+    expect(lines.some((l) => l.includes("You're ready to go!"))).toBe(true)
   })
 })

--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -22,12 +22,14 @@ const mocks = vi.hoisted(() => ({
   markSkillHintSeen: vi.fn(),
   runOnboardingWizard: vi.fn(),
   checkOnboardingEnv: vi.fn(),
+  loadStateFile: vi.fn(() => ({}) as Record<string, unknown>),
 }))
 
 vi.mock("node:child_process", () => ({ spawnSync: mocks.spawnSync }))
 vi.mock("../../src/state/store.ts", () => ({
   getPersistedBool: mocks.getPersistedBool,
   setPersistedBool: mocks.setPersistedBool,
+  loadStateFile: mocks.loadStateFile,
 }))
 vi.mock("../../src/lib/skill-install.ts", () => ({
   npxSkillsArgv: mocks.npxSkillsArgv,
@@ -302,6 +304,8 @@ describe("maybeRunOnboarding", () => {
     mocks.getPersistedBool.mockImplementation((key: string) => false)
     mocks.runOnboardingWizard.mockResolvedValue({ completions: true, skill: false })
     mocks.checkOnboardingEnv.mockResolvedValue(readyEnv())
+    // Default: a genuine first run — no version has ever been stamped.
+    mocks.loadStateFile.mockReturnValue({})
   })
 
   afterEach(() => {
@@ -344,6 +348,24 @@ describe("maybeRunOnboarding", () => {
     expect(mocks.runOnboardingWizard).toHaveBeenCalledWith("zsh", readyEnv(), "full")
     const lines = stdoutLines(stdoutSpy)
     expect(lines.some((l) => l.includes("completions hooked into"))).toBe(true)
+  })
+
+  // `onboardedPrimer` is new, so its absence cannot mean "killed wizard":
+  // every user who onboarded before this build looks identical to one. They
+  // must not be handed a surprise wizard on upgrade — and since a `true`
+  // return means the caller exits instead of starting the TUI, that upgrade
+  // would also cost them the launch they asked for.
+  it("never shows the primer to a user who onboarded before the flag existed", async () => {
+    setProduct("kobe")
+    mocks.getPersistedBool.mockImplementation((key: string) => key === "onboarded")
+    // The tell: this install has started successfully at least once.
+    mocks.loadStateFile.mockReturnValue({ "app.lastRunVersion": "0.9.40" })
+    const { maybeRunOnboarding } = await import("../../src/cli/onboarding.ts")
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true })
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true })
+    expect(await maybeRunOnboarding()).toBe(false)
+    expect(mocks.runOnboardingWizard).not.toHaveBeenCalled()
+    expect(mocks.setPersistedBool).toHaveBeenCalledWith("onboardedPrimer", true)
   })
 
   it("a killed first-run wizard re-runs once in primer mode — questions stay settled", async () => {

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -327,13 +327,33 @@ describe("PaneKeyHint", () => {
   })
 })
 
-describe("onboarding wizard — Keyboard basics", () => {
-  it("shows the live-keymap grammar page after the questions", async () => {
-    const { frame, mockInput } = await renderComponent(<WizardPage shell={null} onDone={NOOP} />, {
+describe("onboarding wizard — environment page and keyboard basics", () => {
+  const readyEnv = {
+    git: { line: "git:      ✓ git version 2.39.5", found: true },
+    engines: {
+      lines: ["engines:", "  claude  ✓ /bin/claude — logged in (a@b.c)", "  kimi    ✗ not found on PATH"],
+      anyUsable: true,
+    },
+  }
+  const emptyEnv = {
+    git: { line: "git:      ✓ git version 2.39.5", found: true },
+    engines: { lines: ["engines:", "  claude  ✗ not found on PATH"], anyUsable: false },
+  }
+
+  it("shows the environment page after the questions, then the keyboard page", async () => {
+    const { frame, mockInput } = await renderComponent(<WizardPage shell={null} env={readyEnv} onDone={NOOP} />, {
       width: 100,
       height: 24,
     })
     expect(await frame()).toContain("Rove agent skill")
+    act(() => mockInput.pressEnter())
+    await settle()
+    const envText = await frame()
+    expect(envText).toContain("Environment check")
+    expect(envText).toContain("git:      ✓ git version 2.39.5")
+    expect(envText).toContain("claude  ✓ /bin/claude")
+    expect(envText).toContain("✓ You're set")
+    expect(envText).toContain("enter continue")
     act(() => mockInput.pressEnter())
     await settle()
     const text = await frame()
@@ -342,5 +362,29 @@ describe("onboarding wizard — Keyboard basics", () => {
     expect(text).toContain("⌃ A opens the command map")
     expect(text).toContain("full live reference")
     expect(text).toContain("enter finish")
+  })
+
+  it("shows the not-ready verdict when no engine is usable", async () => {
+    const { frame, mockInput } = await renderComponent(<WizardPage shell={null} env={emptyEnv} onDone={NOOP} />, {
+      width: 100,
+      height: 24,
+    })
+    act(() => mockInput.pressEnter())
+    await settle()
+    const text = await frame()
+    expect(text).toContain("Environment check")
+    expect(text).toContain("✗ No usable engine yet")
+    expect(text).not.toContain("✓ You're set")
+  })
+
+  it("primer mode opens on the environment page — no questions re-asked", async () => {
+    const { frame } = await renderComponent(<WizardPage shell="zsh" env={readyEnv} mode="primer" onDone={NOOP} />, {
+      width: 100,
+      height: 24,
+    })
+    const text = await frame()
+    expect(text).toContain("Environment check")
+    expect(text).not.toContain("shell completions")
+    expect(text).not.toContain("agent skill?")
   })
 })


### PR DESCRIPTION
The first-run wizard could print **"You're ready to go!"** on a machine with no engine installed — four minutes before the user's first `n` fails with nothing to run it. This makes the closing banner tell the truth, and stops a killed wizard from losing the keyboard primer forever.

## 1. "Ready" now means the machine can actually run a task

`applyOnboardingChoices` printed the ready banner unconditionally. It now gates on `envReadyForTasks`: git present **and** at least one usable engine (binary + account). When either is missing it names the gap and prints **doctor's own remediation line** — `t("doctor.fix.noEngineAction")` / `t("doctor.fix.gitAction")`, not a paraphrase that can drift out of sync.

One usable engine is enough; a vendor the user never launches is not a finding.

## 2. A read-only "Environment check" page in the wizard

Between the two questions and the keyboard page, the wizard now shows what Rove found on this machine — git, and every registered engine's binary + login state.

The probes are **extracted, not reimplemented**: `gitDoctorLine` and `engineDoctorLines` moved out of `doctor-cmd.ts` into a shared `src/cli/env-checks.ts` as `probeGit` / `probeEngines`, and both surfaces call the same code. The function bodies are byte-identical to what was in `doctor-cmd.ts` (only the names changed), so `rove doctor` and the wizard cannot disagree about the same machine.

Probes run **before** the wizard renders, so the page is static text and a killed wizard never leaves a probe half-printed. Side effect: `doctor-cmd.ts` drops from 369 to 316 lines.

## 3. A killed wizard no longer loses the keyboard primer forever

`onboarded` is set *before* the wizard renders — deliberately, so a killed or crashed wizard never re-asks the questions. But that also meant a wizard killed mid-render lost the "Keyboard basics" page permanently, with no way back to it.

Two flags now, two guarantees:
- `onboarded` (set before render) — the questions are asked once, ever. Unchanged.
- `onboardedPrimer` (set only when the wizard **resolves**) — a killed wizard re-runs **once** in `"primer"` mode: environment page + keyboard page, **no questions**.

`enter`/`q`/`esc` all resolve, so only an actual process kill triggers the re-run.

## Verification

**Full test suite:** vitest 3927 pass / render 323 pass / lint clean / typecheck clean / i18n 708 keys × 2 locales in sync. Every touched file ≤500 lines.

**Mutation testing, two rounds at different sites** (round 2 targets new sites rather than replaying round 1). Round 1 — four wiring points, all red: `markPrimerDone` gutted, `mode` pinned to `"full"`, `envReadyForTasks` pinned to `true`, `anyUsable` pinned to `true` on the doctor side.

Round 2 found a real gap. **`envReadyForTasks` with the engines term removed stayed green** — because the `emptyEnv()` fixture set git *and* engines missing, so the git term alone satisfied the assertion. The fixture precisely sidestepped the scenario the feature exists for: **git fine, no engine** (the state of every machine that ran `install.sh`, which installs Bun and Rove but never an engine CLI). Fixture corrected to git ✓ + no engine; both that mutation and its converse (dropping the git term) are now red. A correct assertion can still miss its target scenario if the fixture is over-specified.

**Two round-2 mutations survive and I did not write tests for them** — the git probe ignoring exit status, and the `"engines:"` block header. Both live in code moved byte-for-byte from `doctor-cmd.ts`; `Bun.spawn` isn't available under vitest, so `main` doesn't test them either. That's a pre-existing uncovered surface, not coverage this PR lost.

## Rebase note

Rebased onto `origin/main` after #683 (six first-run defects) landed. Two conflicts, both resolved keeping the other side's work: `doctor-cmd.ts` (main extracted `terminalDoctorLines`, this PR extracts the git/engine probes — independent extractions, both kept) and `onboarding.ts` (**#683's `{command}` interpolation on `readyHint` is preserved**, now inside the ready branch). Also added the third argument to the four `applyOnboardingChoices` call sites #683 introduced.
