### PR TITLE
docs: say that a repo's .rove/init.sh runs without confirmation

### DIFF
--- a/.changeset/init-sh-trust-note.md
+++ b/.changeset/init-sh-trust-note.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Document that a repo's `.rove/init.sh` runs without confirmation

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -319,6 +319,12 @@ A repo can ship two files in its own `.rove/` directory:
   starts, once per worktree. Use it for `bun install`, direnv, codegen.
 - **`.rove/init-prompt.md`.** Sent as the engine's first message.
 
+`init.sh` comes from the repo, and Rove runs it without asking — in the same
+shell that then execs the engine, with your account's privileges. That is the
+same level of trust you extend by running the repo's own build or test
+command, so it is worth a look at `.rove/init.sh` before you create the first
+task in a repository you did not write.
+
 Files committed in the repo win over any per-user override you set with
 `rove repo set`. Legacy `.kobe/init.sh` and `.kobe/init-prompt.md` remain
 field-by-field fallbacks; a `.rove` file wins when both spellings exist —


### PR DESCRIPTION
## What

One paragraph in `docs/CONFIGURATION.md` § Per-repo init: a repo-committed
`.rove/init.sh` runs **without confirmation**, in the same shell that then
execs the engine, with the user's privileges.

Framed as deliberate design (same trust as running the repo's build), not as
a warning banner — per the owner's call to keep the current behavior and just
write it down.

Verified against `src/state/repo-init.ts:16` ("runs in the worktree cwd, in
the SAME shell that execs…") — there is no confirmation gate on that path.

## Scope note

This PR was dispatched with four items. **Three were dropped because their
premises did not survive verification** — details in the task report:

1. **`ctrl+[` / vim ESC** — the reported bug does not reproduce. On a legacy
   terminal `ctrl+[` arrives as raw `0x1b`, which opentui parses as
   `{name:"escape", ctrl:false}` — *not* as the chord `ctrl+[`. `escape` is in
   `PASSTHROUGH_NAMES` and is not reserved, so the byte already reaches the
   PTY. Measured on `origin/main` through the real pane: pressing `i` then
   `0x1b` writes `["i","\x1b"]` to the PTY — vim leaves insert mode today.
   The codebase aliases `ctrl+h`/`ctrl+j` back to their chord names for
   exactly this legacy-byte problem (`keymap-dispatch.ts:135-136`) and
   deliberately does not do so for `escape`.

2. **`EngineIdentity` fields** — there is no native composer to attach
   `inputPlaceholder` to; the engine runs in a PTY and owns its own input
   line. Wiring the fields would need a consumer invented first.

3. **PTY snapshot chmod** — already implemented **and** test-guarded on `main`
   (`pty-freeze-store.ts:tightenExistingPermissions`, landed in #681, shipped
   in v0.9.47). The 39 lingering `0644` files are because the installed CLI is
   **0.9.14**; the fix has never run on that machine. It needs an upgrade, not
   code.

No test accompanies this PR: the change is one paragraph of prose with no
runtime behavior.