### PR TITLE
docs: ctrl+[ (previous tab) needs a kitty-protocol terminal

### DIFF
--- a/.changeset/ctrl-bracket-kitty-only-doc.md
+++ b/.changeset/ctrl-bracket-kitty-only-doc.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Document that `ctrl+[` (previous tab) needs a kitty-protocol terminal

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -76,7 +76,7 @@ focus or dialog.
 | `ctrl+t` | New engine tab |
 | `ctrl+e` | New-conversation dialog with the engine/shell picker; inside it, `←`/`→` (or `h`/`l`) pick the engine and `enter` confirms, `tab` switches the destination (new tab here ⇄ fork a child task) and `ctrl+f` the context (fresh ⇄ continue this chat). The trailing "scratch shell" choice opens a Scratch shell task |
 | `ctrl+w` | Close the active split, otherwise the tab |
-| `ctrl+[` / `ctrl+]` | Previous / next tab |
+| `ctrl+[` / `ctrl+]` | Previous / next tab (`ctrl+[` needs kitty — see below) |
 | `ctrl+\` | Split right |
 | `ctrl+=` | Split down |
 | `ctrl+2` … `ctrl+9`, `ctrl+0` | Jump to the Nth visible sidebar row (`ctrl+2` = first row) |
@@ -94,6 +94,14 @@ Both split chords need a terminal speaking the kitty keyboard protocol
 reserving `ctrl+\` also costs the embedded shell its SIGQUIT. If a split
 chord does nothing, `rove doctor` says whether your terminal answers the
 protocol query — that is the first thing to check.
+
+`ctrl+[` needs kitty for the same reason. Without the protocol it is not a
+chord at all: it sends the same byte as `Escape`, so the terminal cannot
+tell the two apart and Rove reads it as `Escape` — cycling backwards is
+simply unavailable there, with no second binding to fall back on. `ctrl+]`
+has its own byte and works everywhere. The consolation is that the ambiguity
+resolves in favour of the engine: `ctrl+[` keeps working as `Escape` inside
+the embedded terminal, which is what vim and every CLI's cancel key need.
 
 **Jump digits.** There is no `ctrl+1`; the terminal protocol can't encode it,
 so the first row answers to `2`.


### PR DESCRIPTION
## What

`docs/KEYBINDINGS.md` listed `ctrl+[` / `ctrl+]` in **One-press keys** with no
qualification. Without the kitty keyboard protocol `ctrl+[` is not a chord at
all — it sends the same byte as `Escape` (0x1b), so the terminal cannot tell
the two apart and opentui's legacy parser surfaces it as
`{name:"escape", ctrl:false}`. Rove reads `Escape`, and cycling backwards
never fires.

Follow-up to #690: the behavior is correct, the description was not.

## What the correction says

- Table row now flags the condition inline.
- A short paragraph beside the existing split-chord note (same shape, same
  reason) explains it, and states there is **no fallback**:
  `chat.tab.cycle-prev` is direct-only — verified in
  `keybindings-chat.ts`, which has no `prefixKeys` on that row, unlike
  `chat.tab.new` / `chat.fork.new` / `workspace.split.close`.
- `ctrl+]` has its own byte and is unaffected.
- Notes the upside: the ambiguity resolves in the engine's favour, so
  `ctrl+[` keeps working as `Escape` inside the embedded terminal — which is
  what vim and every CLI's cancel key need.

## Verification

Measured on `origin/main` through the real pane (render track + scripted
PTY), all three wire forms:

| Wire bytes | Parsed as | Reaches PTY |
|---|---|---|
| `0x1b` (legacy `ctrl+[` **and** `Escape`) | `{name:"escape", ctrl:false}` | yes |
| `\x1b[91;5u` (kitty `ctrl+[`) | `{name:"[", ctrl:true}` | yes |
| `\x1b[27u` (kitty `Escape`) | `{name:"escape", ctrl:false}` | yes |

Corroborating: `keymap-dispatch.ts` adds explicit aliases mapping
`{name:"backspace"}` / `{name:"linefeed"}` back to `ctrl+h` / `ctrl+j`
(search `base.push("ctrl+h")`) — those exist precisely because the legacy
parser does not produce chord names by default. `escape` has no such alias,
deliberately.

No test: prose-only change, no runtime behavior.