### PR TITLE
feat: batch releases and add a nightly channel

### DIFF
--- a/.changeset/nightly-release-channel.md
+++ b/.changeset/nightly-release-channel.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Releases are now batched instead of shipping on every merge to `main`, and there's a new nightly channel for anyone who wants the unbatched stream. Merging a PR banks its changeset; a release happens when the Changesets workflow is run (or `scripts/release.sh`) and consumes everything banked since the last one. `rove update nightly` switches to a daily automated cut of `main` — same test gates as a release, just not reviewed as a set — and `rove update latest` switches back. There's no channel setting to configure: the build you're running is the channel, so update checks follow it and switching is just installing from the other one.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,9 +1,16 @@
-# Fully automatic releases: any push to main carrying pending changesets
-# IS a release. No bot PR, no manual merge — the workflow does what
-# scripts/release.sh does, in Actions:
+# Cut a release from the changesets that have accumulated on main.
 #
-#   1. Wait for the triggering commit's ci.yml run to go green (the full
-#      Linux/macOS gate set). A red or cancelled run releases nothing.
+# ON DEMAND, not on every push. Merging a PR banks its changeset; a release
+# happens when someone runs this workflow (or scripts/release.sh), and it
+# consumes everything banked since the last one. That makes a version a
+# reviewed batch rather than a per-PR side effect — the previous behaviour
+# shipped ~10 versions a day, so "which build are they on" had a different
+# answer per user and no released combination had been exercised as a whole.
+#
+# What runs here is otherwise unchanged from the automatic version:
+#
+#   1. Wait for HEAD's ci.yml run to go green (the full Linux/macOS gate
+#      set). A red or cancelled run releases nothing.
 #   2. `bun run ci:version` — changeset version + lockfile refresh +
 #      lint:fix — then verify with `bun install --frozen-lockfile` and the
 #      lint gate, so the bookkeeping commit can't be the thing that breaks.
@@ -18,14 +25,18 @@
 # bookkeeping, verified in step 2 — and release.yml's own gates still
 # stand between the tag and npm.
 #
-# scripts/release.sh stays as the manual fallback for when Actions is
-# down. Don't run both on the same version: they'd race to tag it.
+# The daily automated cut still exists, on the nightly channel
+# (nightly.yml → npm dist-tag `nightly`), so `main` stays continuously
+# installable for anyone who opts in with `rove update nightly` without
+# that being what every user receives.
+#
+# scripts/release.sh does the same thing locally, with an interactive
+# confirm. Don't run both on the same version: they'd race to tag it.
 
 name: Changesets
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -49,14 +60,15 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Decide what this push needs
+      - name: Decide what this run needs
         id: gate
         run: |
-          if [ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]; then
-            echo "main moved past $GITHUB_SHA — deferring to the newer push's run"
-            echo "mode=skip" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # Deliberately no "main moved past $GITHUB_SHA → skip" guard here.
+          # That existed for the push trigger, where a newer push had its own
+          # run to defer to. On workflow_dispatch nothing follows: a merge
+          # landing between clicking Run and this checkout would make the
+          # release silently do nothing. Releasing whatever main's HEAD is
+          # now is both what was asked for and what gets verified below.
           PENDING=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
           VERSION=$(node -p "require('./packages/kobe/package.json').version")
           if [ "$PENDING" != "0" ]; then
@@ -73,37 +85,36 @@ jobs:
             echo "mode=skip" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Wait for this commit's ci.yml to go green
+      - name: Wait for the released commit's ci.yml to go green
         if: steps.gate.outputs.mode == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # No tag, no release commit, until the triggering push passed the
-          # same Linux/macOS gates that block publish.
+          # Watch the run for the commit being RELEASED — main's HEAD as
+          # checked out above — not $GITHUB_SHA, which on a dispatch is
+          # whatever main pointed at when the run was queued.
+          SHA=$(git rev-parse HEAD)
           run_id=""
           tries=0
           while [ -z "$run_id" ]; do
             tries=$((tries + 1))
             if [ "$tries" -gt 36 ]; then
-              echo "::error::no ci.yml run appeared for $GITHUB_SHA within ~3min"
+              echo "::error::no ci.yml run appeared for $SHA within ~3min"
               exit 1
             fi
             sleep 5
             run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow=ci.yml --branch main \
               --limit 15 --json databaseId,headSha \
-              --jq ".[] | select(.headSha == \"$GITHUB_SHA\") | .databaseId" | head -1)
+              --jq ".[] | select(.headSha == \"$SHA\") | .databaseId" | head -1)
           done
           echo "watching ci.yml run $run_id"
           if ! gh run watch --repo "$GITHUB_REPOSITORY" "$run_id" --exit-status >/dev/null; then
             concl=$(gh run view --repo "$GITHUB_REPOSITORY" "$run_id" --json conclusion --jq .conclusion)
-            if [ "$concl" = "cancelled" ]; then
-              # A newer main push superseded this one (ci.yml cancels
-              # in-progress main runs); that push's own Changesets run
-              # will release the accumulated changesets.
-              echo "ci.yml run cancelled by a newer push — deferring"
-              exit 0
-            fi
-            echo "::error::ci.yml failed on $GITHUB_SHA — nothing released. Land a fix; the next push releases the accumulated changesets."
+            # A cancelled run is a FAILED release now, not a deferral. Under
+            # the push trigger a newer push had its own run to hand off to;
+            # a dispatch has no successor, so exiting 0 here would report
+            # success for a release that never happened.
+            echo "::error::ci.yml $concl on $SHA — nothing released. Land a fix, then run this workflow again."
             exit 1
           fi
           echo "green=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,226 @@
+# Nightly channel: publish today's `main` to the npm `nightly` dist-tag.
+#
+# This is deliberately NOT release.yml with a different tag. A nightly:
+#
+#   - leaves no git tag and no commit. The version it publishes
+#     (`X.Y.(Z+1)-nightly.<date>`) exists only inside this job's checkout,
+#     so `main` never carries it and the changeset ledger is untouched —
+#     tomorrow's real release still computes its number from the pending
+#     changesets, as if nightlies never happened.
+#   - never moves the `latest` dist-tag, so `npm i @sma1lboy/rove` and every
+#     existing install keep resolving to the stable line. Opting in is
+#     `rove update nightly`; opting out is `rove update latest`.
+#   - publishes ONLY the canonical @sma1lboy/rove name. The compatibility
+#     aliases exist so old installs keep receiving stable updates; nobody
+#     opts a legacy install into a nightly channel.
+#
+# The version's `-nightly.<date>` tail is what the update check sorts on
+# (isNewerSemver in src/version.ts) — two nightlies share an x.y.z core, so
+# the tail is the ONLY thing that tells a nightly user a newer one exists.
+#
+# Gates: the same behavior + render + visual jobs release.yml runs. A
+# nightly is less baked than a release by virtue of WHAT it contains, not
+# by skipping verification — an unverified nightly would just be a way to
+# ship a broken build to the users who volunteered to help.
+
+name: Nightly
+
+on:
+  schedule:
+    # 09:00 UTC daily. Off the hour would be politer to GitHub's scheduler,
+    # but a nightly's whole value is being predictable to the people on it.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  # Skip the whole pipeline when main hasn't moved since the last nightly:
+  # republishing an identical build burns a version number and makes
+  # `rove update` claim an update that changes nothing.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Decide whether there is anything new to ship
+        id: check
+        run: |
+          BASE=$(node -p "require('./packages/kobe/package.json').version")
+          # Next patch + today's date: sorts above the released X.Y.Z it was
+          # cut from... no — BELOW it, per semver (a prerelease ranks under
+          # its release). That's correct and intended: when X.Y.(Z+1) really
+          # ships, every nightly of it is older, so nightly users roll
+          # forward onto the stable build instead of being stranded above it.
+          NEXT=$(node -p "
+            const [maj, min, pat] = require('./packages/kobe/package.json').version.split('-')[0].split('.')
+            \`\${maj}.\${min}.\${Number(pat) + 1}\`
+          ")
+          VERSION="${NEXT}-nightly.$(date -u +%Y%m%d)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          HEAD_SHA=$(git rev-parse HEAD)
+          # The published nightly records the commit it came from, so "has
+          # main moved" is answered by the registry rather than by guessing
+          # from timestamps.
+          LAST_SHA=$(npm view "@sma1lboy/rove@nightly" gitHead 2>/dev/null || true)
+          if [ "$HEAD_SHA" = "$LAST_SHA" ]; then
+            echo "main is unchanged since the last nightly ($HEAD_SHA) — nothing to publish"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publishing $VERSION from $HEAD_SHA"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  behavior:
+    needs: changes
+    if: needs.changes.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build (Rove package)
+        run: bun run build
+
+      - name: Behavior tests (Rove package)
+        run: bun run --filter @sma1lboy/rove test:behavior
+
+  render-track:
+    needs: changes
+    if: needs.changes.outputs.should_publish == 'true'
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Render tests and coverage (kobe package)
+        working-directory: packages/kobe
+        run: bun run test:render
+
+  visual-ground-truth:
+    needs: changes
+    if: needs.changes.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build canonical Rove artifacts
+        working-directory: packages/kobe
+        run: bun run build
+
+      - name: Install Chromium for the visual ground-truth harness
+        working-directory: packages/kobe-web
+        run: bunx playwright install chromium
+
+      - name: Visual journey (browser → PTY → real OpenTUI)
+        working-directory: packages/kobe-web
+        run: bun run visual
+
+  publish:
+    needs: [changes, behavior, render-track, visual-ground-truth]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # npm provenance (OIDC)
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Unit tests
+        working-directory: packages/kobe
+        run: bun run test
+
+      - name: Build
+        run: bun run build
+
+      - name: Stamp the nightly version (working tree only — never committed)
+        working-directory: packages/kobe
+        env:
+          VERSION: ${{ needs.changes.outputs.version }}
+        run: |
+          node -e "
+            const fs = require('fs')
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+            pkg.version = process.env.VERSION
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
+          "
+          echo "stamped $VERSION"
+
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to the nightly dist-tag
+        working-directory: packages/kobe
+        env:
+          VERSION: ${{ needs.changes.outputs.version }}
+        run: |
+          if npm view "@sma1lboy/rove@$VERSION" version >/dev/null 2>&1; then
+            echo "@sma1lboy/rove@$VERSION already published — a second run today, nothing to do"
+            exit 0
+          fi
+          # --ignore-scripts: prepublishOnly re-runs typecheck+build, which
+          # already ran above against this exact tree.
+          npm publish --access public --provenance --ignore-scripts --tag nightly

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,15 +33,27 @@ data. First launch migrates supported legacy data from `~/.kobe` (see
 [Where state lives](#where-state-lives)).
 
 ```bash
-rove update            # latest
+rove update            # newest build on your channel
 rove update 0.7.90     # pin a version
+rove update nightly    # switch to the nightly channel (also: --channel nightly)
+rove update latest     # switch back to stable
 rove update list       # browse recent versions (also: --list)
 rove update dry-run    # print the command without running it (also: --dry-run)
 ```
 
+There are two channels. `latest` is the stable line — batched, reviewed
+releases. `nightly` is an automated daily cut from `main`: it passes the same
+test gates, but its contents haven't been reviewed as a set, so expect rough
+edges in exchange for changes landing days earlier.
+
+You don't configure a channel — the build you're running *is* the channel, so
+update checks follow whichever one you installed from, and switching is just
+installing from the other. `rove update` with no arguments never moves you
+between channels.
+
 rove updates using whichever package manager owns the `rove` on your `PATH`,
 so the new version can't land in a shadowed prefix. Manual fallback:
-`npm install -g @sma1lboy/rove@latest`.
+`npm install -g @sma1lboy/rove@latest` (or `@nightly`).
 
 Some versions are marked breaking. Installing across one prints a heads-up,
 and the next launch asks you to run `rove reset` first. Worktrees are never
@@ -85,7 +97,8 @@ Commands:
   skill <verb>            Install the Rove agent skill (install|status|command|print)
   plugin <verb>           Install and run plugins (install|link|list|action|…)
   feedback                Send feedback to GitHub Discussions
-  update [version|list]   Self-update Rove, or browse versions with `list`
+  update [version|channel|list]   Self-update Rove, switch channel, or browse
+                          versions with `list`
 
 Options:
   -v, --version           Print version

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,23 +30,25 @@ bun run hooks:install           # once per clone — runs the same check on comm
 
 Worth the two seconds: a bad package name is only caught downstream, by `package-distribution.test.ts` inside `typecheck-and-test`. Once it merges, **main and every branch cut from it stay red** until someone retargets that line (PR #445, 2026-08-15). The pre-commit hook exists to move that discovery from "everyone else's CI" to "your keyboard".
 
-### 2. Cutting a release — automatic (default)
+### 2. Cutting a release — on demand
 
-Releases are fully automatic via [`changesets.yml`](../.github/workflows/changesets.yml): **any push to `main` that carries pending changesets IS a release.** No bot PR, no button. The workflow:
+**Merging a PR banks its changeset; it does not release.** A release happens when someone runs [`changesets.yml`](../.github/workflows/changesets.yml) (Actions → Changesets → Run workflow), and it consumes every changeset banked since the last one. The workflow:
 
-1. Waits for the triggering commit's `ci.yml` run to go green (a red run releases nothing — land the fix, and the next push releases the accumulated changesets; a run cancelled by a newer push defers to that push's workflow).
+1. Waits for main's HEAD `ci.yml` run to go green (a red or cancelled run releases nothing — land the fix and run the workflow again).
 2. Runs the same regeneration `release.sh` does (`changeset version` + lockfile refresh + lint:fix), verifies with `bun install --frozen-lockfile` + the lint gate, commits `chore: release — X.Y.Z`, pushes it, and tags `vX.Y.Z`.
 3. Dispatches `release.yml` on the tag (a GITHUB_TOKEN tag push never fires tag triggers — the dispatch is explicit), which re-runs every publish gate from the tag checkout before `npm publish`.
 
-Consequence to keep in mind: a `minor`/`major` changeset auto-ships that bump the moment it lands on `main` — the changeset file in the PR **is** the release decision, so review bump types at PR review time.
+This used to fire on every push to `main`, which meant ~10 published versions on a busy day: no two users were on the same build, and no released combination of changes had been exercised as a whole before shipping. Batching is the point — the accumulated set is what you decide to release.
 
-### 2b. Cutting a release by hand (fallback)
+Between releases, `main` still ships continuously on the **nightly channel** (below), so anyone who wants the unbatched stream can opt into it.
+
+### 2b. Cutting a release from your machine
 
 ```bash
 scripts/release.sh
 ```
 
-Same pipeline driven locally — useful when Actions is down or you want the interactive confirm. Don't run it while the bot's `tag` job is mid-flight on the same version (both would race to push the same tag; harmless when identical, noisy when not).
+Same pipeline, interactive confirm — this is the usual path when you're at a terminal anyway. Don't run it while the workflow's `tag` job is mid-flight on the same version (both would race to push the same tag; harmless when identical, noisy when not).
 
 > **PR-only exception.** Development lands on `main` exclusively via pull
 > requests (AGENTS.md "PR-only mainline"); the `chore: release — X.Y.Z`
@@ -82,6 +84,30 @@ What the list drives:
 
 Worktrees are never part of a reset — the gate's cost to the user is daemon/session teardown (plus the task index only if they choose `--hard`).
 
+## The nightly channel
+
+[`nightly.yml`](../.github/workflows/nightly.yml) publishes today's `main` to the npm `nightly` dist-tag every morning (09:00 UTC), behind the same behavior + render + visual gates a release passes. It is less baked by virtue of *what it contains* — unbatched, unreviewed-as-a-set changes — not by skipping verification.
+
+Users opt in and out with the CLI; there is no setting to configure:
+
+```bash
+rove update nightly     # switch to the nightly channel
+rove update latest      # switch back to stable
+rove update             # stay on whichever channel you're on
+```
+
+The channel an install follows is **derived from the version it is running**, not stored: a nightly build carries a `-nightly.<date>` tail, so `channelOf()` reports `nightly` and the update check resolves against the `nightly` dist-tag. Nothing can drift out of sync with reality, and switching channels is just installing from the other one.
+
+Three properties worth knowing before changing any of this:
+
+- **A nightly leaves no tag and no commit.** Its version (`X.Y.(Z+1)-nightly.<date>`) exists only inside the workflow's checkout, so the changeset ledger is untouched and tomorrow's real release still computes its number as if nightlies never happened.
+- **`latest` never moves.** `npm i @sma1lboy/rove` and every existing install keep resolving to the stable line.
+- **A nightly sorts *below* the release it anticipates** (semver §11), which is what you want: when `X.Y.(Z+1)` really ships, every nightly of it is older, so nightly users roll forward onto the stable build instead of being stranded above it.
+
+That ordering is why `isNewerSemver` compares prerelease tails while `compareSemver` deliberately does not — see the note on each in [`src/version.ts`](../packages/kobe/src/version.ts). The split is load-bearing in both directions: without the tail, consecutive nightlies compare equal and nightly users never see an update; with the tail in `compareSemver`, a nightly carrying a breaking change would stop tripping the `rove reset` boot gate.
+
 ## Prereleases
 
 A prerelease tag (`v0.7.0-experimental.0`) publishes to an npm dist-tag named after the prerelease identifier (`experimental`), so `latest` stays on the stable line while testers opt in with `npm i @sma1lboy/rove@experimental`. The matching `@sma1lboy/kobe@experimental` alias is published in lockstep. Use Changesets' [prerelease mode](https://github.com/changesets/changesets/blob/main/docs/prereleases.md) (`changeset pre enter experimental` … `changeset pre exit`) to generate those versions.
+
+This is the manual, one-off cousin of the nightly channel: same dist-tag mechanism, but tagged and versioned through `main` rather than cut daily into a throwaway tree.

--- a/packages/kobe/src/cli/update.ts
+++ b/packages/kobe/src/cli/update.ts
@@ -19,9 +19,13 @@ import { spawnSync } from "node:child_process"
 import {
   BREAKING_VERSIONS,
   CURRENT_VERSION,
+  DEFAULT_RELEASE_CHANNEL,
+  RELEASE_CHANNELS,
+  type ReleaseChannel,
   UPDATE_COMMAND,
   UPDATE_SCRIPT_URL,
   breakingVersionsCrossed,
+  channelOf,
   checkLatestVersion,
   fetchReleaseSummaries,
   recommendedGlobalInstallCommand,
@@ -43,8 +47,13 @@ type RunDeps = {
   exit: (code: number) => never
 }
 
-export function updatePlan(version?: string): UpdatePlan {
-  const shell = version === undefined ? UPDATE_COMMAND : `${UPDATE_COMMAND} -s -- ${version}`
+/**
+ * The install target passed through to `update.sh`: an exact version, or a
+ * channel name the script resolves as an npm dist-tag. Both take the same
+ * `sh -s -- <arg>` slot, so `nightly` needs no separate flag downstream.
+ */
+export function updatePlan(target?: string): UpdatePlan {
+  const shell = target === undefined ? UPDATE_COMMAND : `${UPDATE_COMMAND} -s -- ${target}`
   return {
     command: "sh",
     args: ["-c", shell],
@@ -56,27 +65,61 @@ type ParsedArgs = {
   help: boolean
   dryRun: boolean
   list: boolean
-  /** Pinned target version (`kobe update 0.7.90`); undefined = latest. */
+  /** Pinned target version (`kobe update 0.7.90`); undefined = channel head. */
   version?: string
+  /**
+   * Explicit `--channel <name>`. Undefined means "stay on whichever channel
+   * this build came from" — switching is an explicit act, never a default.
+   */
+  channel?: ReleaseChannel
 }
 
 const VERSION_SHAPE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/
+
+function isReleaseChannel(value: string): value is ReleaseChannel {
+  return (RELEASE_CHANNELS as readonly string[]).includes(value)
+}
 
 export function parseUpdateArgs(args: readonly string[]): ParsedArgs {
   let dryRun = false
   let list = false
   let version: string | undefined
+  let channel: ReleaseChannel | undefined
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]
     if (arg === undefined) continue
-    if (arg === "--help" || arg === "-h" || arg === "help") return { help: true, dryRun, list, version }
+    if (arg === "--help" || arg === "-h" || arg === "help") return { help: true, dryRun, list, version, channel }
     if (arg === "dry-run" || arg === "--dry-run") {
       dryRun = true
       continue
     }
     if (arg === "list" || arg === "--list") {
       list = true
+      continue
+    }
+    // `--channel nightly` and `--channel=nightly` both land here. An
+    // unknown name is refused rather than passed through: npm resolves an
+    // unpublished dist-tag to a 404 the install script reports as a
+    // generic failure, which reads like a broken network.
+    if (arg === "--channel" || arg.startsWith("--channel=")) {
+      const inline = arg.startsWith("--channel=") ? arg.slice("--channel=".length) : undefined
+      const value = inline ?? args[++i]
+      if (value === undefined || !isReleaseChannel(value)) {
+        process.stderr.write(
+          `${CLI_NAME} update: --channel expects one of ${RELEASE_CHANNELS.join(", ")}${
+            value === undefined ? "" : ` (got "${value}")`
+          }\n\n`,
+        )
+        printUsage(process.stderr)
+        process.exit(2)
+      }
+      channel = value
+      continue
+    }
+    // A bare channel name is the shorthand: `rove update nightly`.
+    if (channel === undefined && isReleaseChannel(arg)) {
+      channel = arg
       continue
     }
     if (version === undefined && VERSION_SHAPE.test(arg)) {
@@ -91,21 +134,31 @@ export function parseUpdateArgs(args: readonly string[]): ParsedArgs {
     process.exit(2)
   }
 
-  return { help: false, dryRun, list, version }
+  return { help: false, dryRun, list, version, channel }
 }
 
 function printUsage(out: Pick<typeof process.stderr, "write">): void {
   out.write(
     [
-      `Usage: ${CLI_NAME} update [version|list|dry-run]`,
+      `Usage: ${CLI_NAME} update [version|channel|list|dry-run]`,
       "",
       "Runs Rove's GitHub-hosted update script. With [version] (e.g.",
-      "0.7.90) the script installs that exact release instead of latest.",
+      "0.7.90) the script installs that exact release instead of the",
+      "head of your channel.",
       "",
       "Verbs (--flag spellings also accepted):",
       "  list      Browse recent versions — a TUI page with release notes",
       "            when interactive, plain text when piped",
       "  dry-run   Print the command without running it",
+      "",
+      "Channels:",
+      "  latest    Stable releases (default)",
+      "  nightly   Automated nightly cut from main — newer, less baked",
+      "",
+      `You are on: ${channelOf()}`,
+      "",
+      "Switching channels is just installing from the other one; there is",
+      "no stored setting. Update checks follow the build you are running.",
       "",
       "Default command:",
       `  ${UPDATE_COMMAND}`,
@@ -119,6 +172,8 @@ function printUsage(out: Pick<typeof process.stderr, "write">): void {
       "Examples:",
       `  ${CLI_NAME} update`,
       `  ${CLI_NAME} update 0.7.90`,
+      `  ${CLI_NAME} update nightly`,
+      `  ${CLI_NAME} update --channel latest`,
       `  ${CLI_NAME} update list`,
       `  ${CLI_NAME} update dry-run`,
       "",
@@ -147,14 +202,14 @@ async function printVersionList(io: RunDeps): Promise<void> {
 
 /**
  * Best-effort heads-up when the move crosses a breaking version. Pinned
- * targets need no network; "latest" resolves via the registry and stays
- * silent when offline — the boot gate is the real enforcement point.
+ * targets need no network; a channel head resolves via the registry and
+ * stays silent when offline — the boot gate is the real enforcement point.
  */
-async function warnBreakingCrossings(target: string | undefined, io: RunDeps): Promise<void> {
-  // Nothing registered → nothing to warn about; skip the "latest" lookup
-  // entirely so the common path (and the test suite) never touches the net.
+async function warnBreakingCrossings(target: string | undefined, channel: ReleaseChannel, io: RunDeps): Promise<void> {
+  // Nothing registered → nothing to warn about; skip the channel-head
+  // lookup entirely so the common path (and the tests) never touch the net.
   if (BREAKING_VERSIONS.length === 0) return
-  const resolved = target ?? (await checkLatestVersion({ force: true }))?.latest
+  const resolved = target ?? (await checkLatestVersion({ force: true, channel }))?.latest
   if (!resolved) return
   const crossed = breakingVersionsCrossed(CURRENT_VERSION, resolved)
   if (crossed.length === 0) return
@@ -193,11 +248,18 @@ export async function runUpdateSubcommand(args: readonly string[], deps?: Partia
     return
   }
 
-  const plan = updatePlan(parsed.version)
-  io.stdout.write(`${CLI_NAME} ${CURRENT_VERSION} -> ${parsed.version ?? "latest"}\n`)
+  // An explicit --channel wins; otherwise stay on the channel this build
+  // came from. A pinned version outranks both — it names one exact build,
+  // and the channel it belongs to is whatever that version says it is.
+  const channel = parsed.channel ?? channelOf()
+  const target = parsed.version ?? (channel === DEFAULT_RELEASE_CHANNEL ? undefined : channel)
+  const plan = updatePlan(target)
+  const switching = parsed.channel !== undefined && parsed.channel !== channelOf()
+  io.stdout.write(`${CLI_NAME} ${CURRENT_VERSION} -> ${target ?? channel}\n`)
+  if (switching) io.stdout.write(`switching channel: ${channelOf()} -> ${channel}\n`)
   io.stdout.write(`running: ${plan.display}\n`)
   if (parsed.dryRun) return
-  await warnBreakingCrossings(parsed.version, io)
+  await warnBreakingCrossings(parsed.version, channel, io)
 
   const result = io.spawn(plan.command, plan.args, { stdio: "inherit" })
   if (result.error) {

--- a/packages/kobe/src/version.ts
+++ b/packages/kobe/src/version.ts
@@ -91,19 +91,46 @@ export function breakingVersionsCrossed(
 /** Network timeout for the registry call. */
 const FETCH_TIMEOUT_MS = 3_000
 
+/**
+ * Which published line an install follows. These are npm dist-tag names —
+ * `latest` is the stable release line, `nightly` is the automated cut from
+ * `main` (see `.github/workflows/nightly.yml`).
+ */
+export type ReleaseChannel = "latest" | "nightly"
+
+export const RELEASE_CHANNELS: readonly ReleaseChannel[] = ["latest", "nightly"]
+
+export const DEFAULT_RELEASE_CHANNEL: ReleaseChannel = "latest"
+
+/**
+ * The channel an install is ON, derived from the version it is RUNNING.
+ * There is no stored preference to drift out of sync with reality: a
+ * nightly build carries a `-nightly.*` tail, so it checks `nightly`, and
+ * `rove update` (no args) reinstalls from whichever channel it names.
+ * Switching channels IS installing from the other one.
+ */
+export function channelOf(version: string = CURRENT_VERSION): ReleaseChannel {
+  const pre = prereleaseOf(version)
+  return pre?.split(".")[0] === "nightly" ? "nightly" : DEFAULT_RELEASE_CHANNEL
+}
+
 export type UpdateInfo = {
   current: string
   latest: string
   hasUpdate: boolean
+  /** The channel `latest` was resolved from — what the UI should name. */
+  channel: ReleaseChannel
 }
 
-async function fetchLatestFromRegistry(packageName: string): Promise<string | null> {
+async function fetchLatestFromRegistry(packageName: string, channel: ReleaseChannel): Promise<string | null> {
   const ctrl = new AbortController()
   const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS)
   try {
     // Encode the scope's "/" — registry expects %2F in the path segment.
+    // The segment AFTER the name is an npm dist-tag, so one endpoint
+    // serves every channel: `/latest` and `/nightly` alike.
     const encoded = packageName.replace("/", "%2F")
-    const res = await fetch(`https://registry.npmjs.org/${encoded}/latest`, {
+    const res = await fetch(`https://registry.npmjs.org/${encoded}/${channel}`, {
       signal: ctrl.signal,
       headers: { accept: "application/json" },
     })
@@ -119,16 +146,71 @@ async function fetchLatestFromRegistry(packageName: string): Promise<string | nu
 }
 
 /**
- * Compare two semver strings — returns true when `latest` is strictly
- * greater than `current`. Handles plain `x.y.z`. Pre-release identifiers
- * (`-rc.1`, `-beta`) are stripped so we don't trigger an "update" chip
- * when the user is intentionally on a pre-release; they can opt back in
- * by bumping past the released version.
+ * Compare two versions the way an UPDATE CHECK must: `x.y.z` first, then
+ * the `-prerelease` tail. Returns true when `latest` outranks `current`.
+ *
+ * The tail is what makes the nightly channel work at all. Two nightlies
+ * share an `x.y.z` core (`0.9.13-nightly.20260830` vs `…20260831`), so
+ * comparing cores alone reports "no update" forever and every nightly user
+ * silently stays on whatever build they first installed.
+ *
+ * Deliberately NOT the same function as {@link compareSemver}: the reset
+ * gate needs the opposite treatment — see that function's note.
  */
 export function isNewerSemver(latest: string, current: string): boolean {
-  return compareSemver(latest, current) > 0
+  const core = compareSemver(latest, current)
+  if (core !== 0) return core > 0
+  return comparePrerelease(prereleaseOf(latest), prereleaseOf(current)) > 0
 }
 
+function prereleaseOf(version: string): string | undefined {
+  const dash = version.indexOf("-")
+  return dash === -1 ? undefined : version.slice(dash + 1) || undefined
+}
+
+/**
+ * Order the `-prerelease` tails of two versions with equal `x.y.z` cores,
+ * per semver §11: a version WITHOUT a tail outranks the same version with
+ * one, and otherwise identifiers compare field by field — numeric ones
+ * numerically, the rest as strings.
+ */
+function comparePrerelease(a: string | undefined, b: string | undefined): number {
+  if (a === b) return 0
+  // Absent tail = the release itself, which outranks any of its prereleases.
+  if (a === undefined) return 1
+  if (b === undefined) return -1
+  const aParts = a.split(".")
+  const bParts = b.split(".")
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const av = aParts[i]
+    const bv = bParts[i]
+    // A shorter run of identifiers sorts lower when all preceding ones match.
+    if (av === undefined) return -1
+    if (bv === undefined) return 1
+    if (av === bv) continue
+    const an = /^\d+$/.test(av) ? Number.parseInt(av, 10) : null
+    const bn = /^\d+$/.test(bv) ? Number.parseInt(bv, 10) : null
+    // Numeric identifiers compare numerically and sort below alphanumeric
+    // ones; a mixed pair falls back to that rule.
+    if (an !== null && bn !== null) return an > bn ? 1 : -1
+    if (an !== null) return -1
+    if (bn !== null) return 1
+    return av > bv ? 1 : -1
+  }
+  return 0
+}
+
+/**
+ * Compare the `x.y.z` cores only — `-rc.1` and friends are stripped.
+ *
+ * The reset gate (`cli/reset-gate.ts`) depends on this: a nightly cut from
+ * a main that already carries a breaking change must count as HAVING
+ * crossed it, so `0.9.13-nightly.x` has to read as `0.9.13`. Ordering the
+ * tail here instead would sort the nightly BELOW the release and move the
+ * `rove reset` demand one release later — i.e. the user runs the breaking
+ * nightly ungated, which is the one thing that gate exists to prevent.
+ * Update checks want the opposite; they call {@link isNewerSemver}.
+ */
 export function compareSemver(aVersion: string, bVersion: string): number {
   const norm = (v: string) => v.split("-")[0] ?? v
   const a = norm(aVersion)
@@ -155,8 +237,15 @@ export function compareSemver(aVersion: string, bVersion: string): number {
  *
  * @param opts.force — bypass dev-mode suppression. Useful for an explicit
  *                     "check for updates" command once we wire one up.
+ * @param opts.channel — which dist-tag to resolve against. Defaults to the
+ *                     channel the RUNNING build belongs to, so a nightly
+ *                     install compares itself against nightlies and a
+ *                     stable one against stable.
  */
-export async function checkLatestVersion(opts: { force?: boolean } = {}): Promise<UpdateInfo | null> {
+export async function checkLatestVersion(
+  opts: { force?: boolean; channel?: ReleaseChannel } = {},
+): Promise<UpdateInfo | null> {
+  const channel = opts.channel ?? channelOf()
   // Debug hook: `KOBE_FAKE_UPDATE=<version>` returns a synthetic UpdateInfo
   // (bypassing dev suppression AND the network) so the "update available"
   // UI — the brand-header chip, the update page — can be exercised in the
@@ -164,7 +253,7 @@ export async function checkLatestVersion(opts: { force?: boolean } = {}): Promis
   // semver so a lower fake version still reads as "no update".
   const fake = process.env.KOBE_FAKE_UPDATE
   if (fake) {
-    return { current: CURRENT_VERSION, latest: fake, hasUpdate: isNewerSemver(fake, CURRENT_VERSION) }
+    return { current: CURRENT_VERSION, latest: fake, hasUpdate: isNewerSemver(fake, CURRENT_VERSION), channel }
   }
 
   // Dev runs (KOBE_DEV=1, set by `bun run dev`) suppress the check
@@ -174,12 +263,13 @@ export async function checkLatestVersion(opts: { force?: boolean } = {}): Promis
   // for updates" command still works in dev if we ever wire one up.
   if (isDev() && !opts.force) return null
 
-  const latest = await fetchLatestFromRegistry(PACKAGE_NAME)
+  const latest = await fetchLatestFromRegistry(PACKAGE_NAME, channel)
   if (!latest) return null
   return {
     current: CURRENT_VERSION,
     latest,
     hasUpdate: isNewerSemver(latest, CURRENT_VERSION),
+    channel,
   }
 }
 

--- a/packages/kobe/test/behavior/cli-update.test.ts
+++ b/packages/kobe/test/behavior/cli-update.test.ts
@@ -47,12 +47,14 @@ describe("kobe update (behavior)", () => {
  * (a path containing `/.bun/` → bun, else npm). Both managers log to
  * `calls.log` instead of installing anything. `linkTo` makes the on-PATH
  * `kobe` a symlink to that entry file, which is how the script tells a
- * legacy @sma1lboy/kobe install from a migrated one.
+ * legacy @sma1lboy/kobe install from a migrated one. `arg` is the script's
+ * positional argument — a pinned version or a channel/dist-tag.
  */
 async function runUpdateScript(
   base: string,
   kobeBinDir: string,
   linkTo?: string,
+  arg?: string,
 ): Promise<{ code: number; out: string; log: string }> {
   const shims = join(base, "shims")
   await mkdir(shims, { recursive: true })
@@ -75,7 +77,7 @@ async function runUpdateScript(
     await chmod(join(shims, mgr), 0o755)
   }
 
-  const r = spawnSync("sh", [UPDATE_SH], {
+  const r = spawnSync("sh", arg === undefined ? [UPDATE_SH] : [UPDATE_SH, arg], {
     env: { PATH: `${kobeBinDir}:${shims}:/usr/bin:/bin` },
     encoding: "utf8",
     timeout: 30_000,
@@ -111,6 +113,28 @@ describe("scripts/update.sh manager detection (issue #205)", () => {
     expect(r.out).toContain("via npm")
     expect(r.log).toContain("npm install -g @sma1lboy/rove@latest")
     expect(r.log).not.toContain("bun install")
+  })
+
+  // A channel name rides the same `pkg@<arg>` slot a version does; npm
+  // makes no distinction there.
+  it("a channel name installs that dist-tag", async () => {
+    const base = join(env.home, "case-channel")
+    const r = await runUpdateScript(base, join(base, "npm-global", "bin"), undefined, "nightly")
+    expect(r.code).toBe(0)
+    expect(r.log).toContain("npm install -g @sma1lboy/rove@nightly")
+    expect(r.log).not.toContain("@sma1lboy/rove@latest")
+  })
+
+  // The verify step compares the installed `rove -v` against what the target
+  // RESOLVES to. A bare dist-tag has to be resolved through the registry
+  // first — comparing against the literal string "nightly" would fail every
+  // nightly install with a bogus "another install is shadowing it".
+  it("resolves a channel through the registry before the shadowed-install check", async () => {
+    const base = join(env.home, "case-channel-verify")
+    const r = await runUpdateScript(base, join(base, "npm-global", "bin"), undefined, "nightly")
+    expect(r.code).toBe(0)
+    expect(r.log).toContain("npm view @sma1lboy/rove@nightly version")
+    expect(r.out).not.toContain("shadowing")
   })
 
   // The rename migration: an install whose bin resolves into an

--- a/packages/kobe/test/cli/update.test.ts
+++ b/packages/kobe/test/cli/update.test.ts
@@ -13,6 +13,16 @@ describe("updatePlan", () => {
     expect(recommendedGlobalInstallCommand()).toBe(`npm install -g ${PACKAGE_NAME}@latest`)
   })
 
+  it("a channel rides into the script through the same slot a version does", () => {
+    // npm makes no distinction between a version and a dist-tag in
+    // `pkg@<arg>`, so the channel needs no separate flag downstream.
+    expect(updatePlan("nightly")).toEqual({
+      command: "sh",
+      args: ["-c", `${UPDATE_COMMAND} -s -- nightly`],
+      display: `${UPDATE_COMMAND} -s -- nightly`,
+    })
+  })
+
   it("a pinned version rides into the script as `sh -s -- <version>`", () => {
     expect(updatePlan("0.7.90")).toEqual({
       command: "sh",
@@ -55,6 +65,35 @@ describe("parseUpdateArgs", () => {
     expect(parseUpdateArgs(["help"]).help).toBe(true)
   })
 
+  it("accepts a channel as a bare word or a --channel flag, in either spelling", () => {
+    expect(parseUpdateArgs(["nightly"]).channel).toBe("nightly")
+    expect(parseUpdateArgs(["--channel", "nightly"]).channel).toBe("nightly")
+    expect(parseUpdateArgs(["--channel=nightly"]).channel).toBe("nightly")
+    expect(parseUpdateArgs(["latest"]).channel).toBe("latest")
+    // No channel named = stay on whichever one this build came from.
+    expect(parseUpdateArgs([]).channel).toBeUndefined()
+    expect(parseUpdateArgs(["0.7.90"]).channel).toBeUndefined()
+  })
+
+  it("refuses an unknown channel instead of passing it to npm as a 404 dist-tag", () => {
+    const errSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`)
+    }) as never)
+    try {
+      expect(() => parseUpdateArgs(["--channel", "bleeding"])).toThrow("exit 2")
+      const err = errSpy.mock.calls.map((c) => String(c[0])).join("")
+      expect(err).toContain('--channel expects one of latest, nightly (got "bleeding")')
+      // A trailing --channel with no value is the same refusal, not a crash.
+      errSpy.mockClear()
+      expect(() => parseUpdateArgs(["--channel"])).toThrow("exit 2")
+      expect(errSpy.mock.calls.map((c) => String(c[0])).join("")).toContain("--channel expects one of")
+    } finally {
+      errSpy.mockRestore()
+      exitSpy.mockRestore()
+    }
+  })
+
   it("an unknown argument prints the error + full usage to stderr and exits 2", () => {
     const errSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
@@ -65,7 +104,7 @@ describe("parseUpdateArgs", () => {
       const err = errSpy.mock.calls.map((c) => String(c[0])).join("")
       // The instruction surface, not a bare one-liner: usage + script URL + fallback.
       expect(err).toContain('kobe update: unknown argument "--fast"')
-      expect(err).toContain("Usage: kobe update [version|list|dry-run]")
+      expect(err).toContain("Usage: kobe update [version|channel|list|dry-run]")
       expect(err).toContain(UPDATE_SCRIPT_URL)
       expect(err).toContain(recommendedGlobalInstallCommand())
     } finally {
@@ -176,7 +215,7 @@ describe("runUpdateSubcommand", () => {
       stderr: { write: () => true },
       exit: exit as never,
     })
-    expect(out.join("")).toContain("Usage: kobe update [version|list|dry-run]")
+    expect(out.join("")).toContain("Usage: kobe update [version|channel|list|dry-run]")
     expect(spawn).not.toHaveBeenCalled()
     expect(exit).not.toHaveBeenCalled()
   })

--- a/packages/kobe/test/version.test.ts
+++ b/packages/kobe/test/version.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   CURRENT_VERSION,
   PACKAGE_NAME,
+  breakingVersionsCrossed,
+  channelOf,
   checkLatestVersion,
   compareSemver,
   fetchReleaseNotes,
@@ -84,6 +86,7 @@ describe("checkLatestVersion — dev suppression and the KOBE_FAKE_UPDATE debug 
       current: CURRENT_VERSION,
       latest: "999.0.0",
       hasUpdate: true,
+      channel: channelOf(CURRENT_VERSION),
     })
     // A LOWER fake version still reads as "no update", not a downgrade chip.
     process.env.KOBE_FAKE_UPDATE = "0.0.1"
@@ -129,15 +132,65 @@ describe("checkLatestVersion — dev suppression and the KOBE_FAKE_UPDATE debug 
 })
 
 describe("semver helpers", () => {
-  it("compares plain x.y.z and strips pre-release identifiers", () => {
+  it("compares plain x.y.z", () => {
     expect(isNewerSemver("1.2.3", "1.2.2")).toBe(true)
     expect(isNewerSemver("1.2.2", "1.2.3")).toBe(false)
-    expect(compareSemver("1.2.3-rc.1", "1.2.3")).toBe(0)
     expect(compareSemver("2.0.0", "10.0.0")).toBe(-1)
   })
 
   it("treats an unparseable component as equal (no false update chip)", () => {
     expect(compareSemver("abc", "1.0.0")).toBe(0)
+  })
+
+  // Without this the nightly channel is inert: consecutive nightlies share
+  // an x.y.z core, so a core-only comparison reports "no update" forever and
+  // every nightly user silently stays on the build they first installed.
+  it("orders two nightlies of the same core by their date tail", () => {
+    expect(isNewerSemver("0.9.13-nightly.20260831", "0.9.13-nightly.20260830")).toBe(true)
+    expect(isNewerSemver("0.9.13-nightly.20260830", "0.9.13-nightly.20260831")).toBe(false)
+  })
+
+  it("rolls a nightly user forward onto the stable build of that core, not backwards", () => {
+    expect(isNewerSemver("0.9.13", "0.9.13-nightly.20260831")).toBe(true)
+    expect(isNewerSemver("0.9.13-nightly.20260831", "0.9.13")).toBe(false)
+  })
+
+  // compareSemver stays core-only ON PURPOSE — the reset gate needs a
+  // nightly cut from a breaking main to read as HAVING crossed it. Ordering
+  // the tail here would sort the nightly below the release and defer the
+  // `rove reset` demand by a release, running the breaking build ungated.
+  it("keeps compareSemver core-only so the reset gate still fires on nightlies", () => {
+    expect(compareSemver("1.2.3-rc.1", "1.2.3")).toBe(0)
+    expect(compareSemver("0.9.13-nightly.20260831", "0.9.13")).toBe(0)
+    expect(breakingVersionsCrossed("0.9.12", "0.9.13-nightly.20260831", ["0.9.13"])).toEqual(["0.9.13"])
+  })
+})
+
+describe("release channels", () => {
+  it("derives the channel from the running build, with no stored setting to drift", () => {
+    expect(channelOf("0.9.13")).toBe("latest")
+    expect(channelOf("0.9.13-nightly.20260831")).toBe("nightly")
+    // An unrelated prerelease line is not the nightly channel.
+    expect(channelOf("0.9.13-experimental.0")).toBe("latest")
+  })
+
+  it("resolves the update check against the running build's own dist-tag", async () => {
+    const urls: string[] = []
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: unknown) => {
+        urls.push(String(input))
+        return new Response(JSON.stringify({ version: "999.0.0" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }),
+    )
+
+    await checkLatestVersion({ channel: "nightly" })
+    await checkLatestVersion({ channel: "latest" })
+    // The dist-tag is the last path segment, so one endpoint serves both.
+    expect(urls.map((u) => u.split("/").pop())).toEqual(["nightly", "latest"])
   })
 })
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -9,8 +9,13 @@ set -eu
 PACKAGE="@sma1lboy/rove"
 LEGACY_PACKAGE="@sma1lboy/kobe"
 
-# Optional pin: `curl … | sh -s -- 0.7.90` installs that exact version;
+# Optional argument: `curl … | sh -s -- 0.7.90` installs that exact version,
+# `… | sh -s -- nightly` installs the head of a channel (any npm dist-tag),
 # `… | sh -s -- --list` prints recent published versions and exits.
+#
+# Both forms take the same `pkg@<arg>` slot in the install below — npm makes
+# no distinction between a version and a dist-tag there. The only place they
+# diverge is resolving what the target RESOLVES to, for the verify step.
 VERSION="${1:-}"
 
 if [ "$VERSION" = "--list" ]; then
@@ -45,11 +50,16 @@ if [ -n "$BIN" ]; then
   esac
 fi
 
-if [ -n "$VERSION" ]; then
-  TARGET="$VERSION"
-else
-  TARGET="$(npm view "${PACKAGE}" version 2>/dev/null || true)"
-fi
+# What the install will actually land on. A bare dist-tag (`nightly`) has to
+# be resolved through the registry: the verify step at the bottom compares
+# the installed `rove -v` against TARGET, and comparing it against the literal
+# string "nightly" would fail every nightly install with a bogus "another
+# install is shadowing it".
+case "$VERSION" in
+  "") TARGET="$(npm view "${PACKAGE}" version 2>/dev/null || true)" ;;
+  [0-9]*) TARGET="$VERSION" ;;
+  *) TARGET="$(npm view "${PACKAGE}@${VERSION}" version 2>/dev/null || true)" ;;
+esac
 
 if [ -t 1 ]; then
   BOLD='\033[1m'


### PR DESCRIPTION
## Summary

Releases stopped being a per-PR side effect. `changesets.yml` is `workflow_dispatch` now: merging a PR banks its changeset, and a release consumes everything banked since the last one. The previous behaviour shipped ~10 versions on a busy day, which meant no two users were on the same build and no released combination had been exercised as a whole.

The daily automated cut moves to the **nightly channel** (`nightly.yml` → npm `nightly` dist-tag) so `main` stays continuously installable for anyone who opts in, without that being what every user receives. A nightly leaves no tag and no commit — its version lives only inside the workflow's checkout, so the changeset ledger is untouched and the next real release computes its number as if nightlies never happened. It passes the same behavior/render/visual gates a release does.

Users switch with `rove update nightly` / `rove update latest`. There is no channel setting: the channel is **derived from the version you're running**, so nothing can drift out of sync, and switching is just installing from the other one. Bare `rove update` never moves you between channels.

## Two non-obvious bits

**The semver split is load-bearing in both directions.** `isNewerSemver` now orders prerelease tails — without it, consecutive nightlies share an `x.y.z` core, compare equal, and nightly users would never see an update, i.e. the channel would be silently inert. `compareSemver` deliberately stays core-only, because the reset gate needs a nightly cut from a breaking `main` to read as *having crossed* it; ordering the tail there would defer the `rove reset` demand by a release and run the breaking build ungated. Both are commented at their definitions.

**`update.sh` resolves a dist-tag through the registry** before its shadowed-install check. That check compares the installed `rove -v` against the target, so comparing against the literal string `nightly` would fail every nightly install with a bogus "another install is shadowing it".

Also fixed two guards in `changesets.yml` that had push-only semantics and would have misfired under dispatch: the "main moved past `$GITHUB_SHA` → skip" check (a merge landing while the run queued would make the release silently do nothing) and the cancelled-CI branch (`exit 0` would report success for a release that never happened).

## Test plan

- [x] `lint`, `typecheck`, `build` green
- [x] 3936 fast + 659 socket + 21 behavior tests pass (re-run after rebasing onto 0.9.60)
- [x] Mutation-checked both non-obvious pieces: reverting the semver fix reddens 2 tests, reverting the dist-tag resolution reddens 2 — the new assertions observe real logic, not tautologies
- [x] Exercised the built binary: stable / `nightly` / pinned version / rejected unknown channel (exit 2 onto the usage surface)
- [ ] Reviewer: `nightly.yml`'s 09:00 UTC schedule is a guess — say if you want another hour
- [ ] Reviewer: the first `Changesets` run after this merges is manual (Actions → Changesets → Run workflow); nothing auto-releases anymore
- [ ] Reviewer: `experimental` prereleases are left alongside `nightly` rather than folded together