### PR TITLE
fix: rove update installs into the prefix that owns the running binary

### DIFF
--- a/.changeset/update-owning-prefix.md
+++ b/.changeset/update-owning-prefix.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove update` installs into the prefix that owns the binary you are running
+
+On a machine with more than one node install — nvm and homebrew, say —
+`npm install -g` writes to the prefix of whichever node happens to run npm,
+which is not necessarily the prefix holding the `rove` on your PATH. The
+update landed somewhere PATH never looked, and the stale copy kept running.
+
+The update script now resolves the running binary back to its own prefix and
+pins the install there. It also warns when a second install is on PATH,
+naming which one it updated and which ones it left alone.

--- a/packages/kobe/src/version.ts
+++ b/packages/kobe/src/version.ts
@@ -27,6 +27,7 @@
  *     user runs the install command themselves.
  */
 
+import { fileURLToPath } from "node:url"
 import pkg from "../package.json" with { type: "json" }
 import { isDev } from "./env.ts"
 
@@ -58,9 +59,32 @@ export const UPDATE_SCRIPT_URL = "https://raw.githubusercontent.com/Sma1lboy/rov
 /** Standard update command shown in the update dialog. */
 export const UPDATE_COMMAND = `curl -fsSL ${UPDATE_SCRIPT_URL} | sh`
 
-/** Portable manual fallback when the self-update helper is unavailable. */
-export function recommendedGlobalInstallCommand(): string {
-  return `npm install -g ${PACKAGE_NAME}@latest`
+/**
+ * The npm prefix that owns this running build, derived from where this
+ * module actually lives: `<prefix>/lib/node_modules/<pkg>/…`. Returns null
+ * for a bun install, a dev checkout, or any layout that isn't npm-global.
+ *
+ * Exported for the test; callers want {@link recommendedGlobalInstallCommand}.
+ */
+export function owningNpmPrefix(modulePath: string = fileURLToPath(import.meta.url)): string | null {
+  const marker = "/lib/node_modules/"
+  const at = modulePath.indexOf(marker)
+  if (at <= 0) return null
+  return modulePath.slice(0, at)
+}
+
+/**
+ * Portable manual fallback when the self-update helper is unavailable.
+ *
+ * A bare `npm install -g` writes to the prefix of whichever node runs npm,
+ * which on a machine with several node installs (nvm + homebrew, say) is
+ * not necessarily the prefix holding the binary the user just ran — so the
+ * update lands somewhere PATH never looks and the stale copy keeps running.
+ * When we can see which prefix owns this build, pin it explicitly.
+ */
+export function recommendedGlobalInstallCommand(prefix = owningNpmPrefix()): string {
+  const target = `${PACKAGE_NAME}@latest`
+  return prefix === null ? `npm install -g ${target}` : `npm install -g --prefix ${prefix} ${target}`
 }
 
 /**

--- a/packages/kobe/test/behavior/cli-update.test.ts
+++ b/packages/kobe/test/behavior/cli-update.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { chmod, mkdir, readFile, symlink, writeFile } from "node:fs/promises"
+import { chmod, mkdir, readFile, realpath, symlink, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
@@ -55,6 +55,7 @@ async function runUpdateScript(
   kobeBinDir: string,
   linkTo?: string,
   arg?: string,
+  extraPathDirs: readonly string[] = [],
 ): Promise<{ code: number; out: string; log: string }> {
   const shims = join(base, "shims")
   await mkdir(shims, { recursive: true })
@@ -63,11 +64,15 @@ async function runUpdateScript(
 
   // Post-install `kobe -v` must match `npm view` output or the script exits 1
   // (the shadowed-install guard) — keep both at 9.9.9 for the happy path.
-  if (linkTo) {
-    await symlink(linkTo, join(kobeBinDir, "kobe"))
-  } else {
-    await writeFile(join(kobeBinDir, "kobe"), `#!/bin/sh\necho "kobe 9.9.9"\n`)
-    await chmod(join(kobeBinDir, "kobe"), 0o755)
+  // Both packages ship a `kobe` AND a `rove` bin, and the script prefers
+  // `rove`, so the fixture has to carry both like a real install does.
+  for (const name of ["kobe", "rove"]) {
+    if (linkTo) {
+      await symlink(linkTo, join(kobeBinDir, name))
+    } else {
+      await writeFile(join(kobeBinDir, name), `#!/bin/sh\necho "${name} 9.9.9"\n`)
+      await chmod(join(kobeBinDir, name), 0o755)
+    }
   }
   for (const mgr of ["npm", "bun"]) {
     await writeFile(
@@ -78,7 +83,7 @@ async function runUpdateScript(
   }
 
   const r = spawnSync("sh", arg === undefined ? [UPDATE_SH] : [UPDATE_SH, arg], {
-    env: { PATH: `${kobeBinDir}:${shims}:/usr/bin:/bin` },
+    env: { PATH: [kobeBinDir, ...extraPathDirs, shims, "/usr/bin", "/bin"].join(":") },
     encoding: "utf8",
     timeout: 30_000,
   })
@@ -152,10 +157,13 @@ describe("scripts/update.sh manager detection (issue #205)", () => {
     const r = await runUpdateScript(base, join(base, "npm-global", "bin"), entry)
     expect(r.code).toBe(0)
     expect(r.out).toContain("kobe is now Rove.")
-    expect(r.log).toContain("npm uninstall -g @sma1lboy/kobe")
-    expect(r.log).toContain("npm install -g @sma1lboy/rove@latest")
+    // Both halves of the swap are pinned to the prefix that owns the binary,
+    // or the uninstall and the install can hit two different prefixes.
+    const prefix = await realpath(join(base, "npm-global"))
+    expect(r.log).toContain(`npm uninstall -g --prefix ${prefix} @sma1lboy/kobe`)
+    expect(r.log).toContain(`npm install -g --prefix ${prefix} @sma1lboy/rove@latest`)
     // Order matters: uninstall first, or npm bails with EEXIST.
-    expect(r.log.indexOf("uninstall")).toBeLessThan(r.log.indexOf("install -g @sma1lboy/rove"))
+    expect(r.log.indexOf("uninstall")).toBeLessThan(r.log.indexOf("@sma1lboy/rove@latest"))
   })
 
   it("a non-legacy install is not uninstalled", async () => {
@@ -163,6 +171,82 @@ describe("scripts/update.sh manager detection (issue #205)", () => {
     const r = await runUpdateScript(base, join(base, "npm-global", "bin"))
     expect(r.out).not.toContain("kobe is now Rove.")
     expect(r.log).not.toContain("uninstall")
+  })
+
+  // #205's second half. Choosing npm-vs-bun is not enough: with several
+  // npm on one machine, `npm install -g` writes to the prefix of whichever
+  // node runs npm — not the prefix that owns the binary on PATH. The
+  // install must be pinned to the prefix we resolved the binary into.
+  it("pins the install to the prefix that owns the binary on PATH", async () => {
+    const base = join(env.home, "case-prefix")
+    const prefix = join(base, "owning-prefix")
+    const pkgDir = join(prefix, "lib/node_modules/@sma1lboy/rove/dist/cli")
+    await mkdir(pkgDir, { recursive: true })
+    const entry = join(pkgDir, "rove.js")
+    await writeFile(entry, `#!/bin/sh\necho "rove 9.9.9"\n`)
+    await chmod(entry, 0o755)
+
+    const r = await runUpdateScript(base, join(prefix, "bin"), entry)
+    expect(r.code).toBe(0)
+    // The script resolves symlinks, and macOS hides /var behind /private/var.
+    const real = await realpath(prefix)
+    expect(r.log).toContain(`npm install -g --prefix ${real} @sma1lboy/rove@latest`)
+  })
+
+  // No prefix to derive (bin is not under a `lib/node_modules` tree) must
+  // stay exactly as it was — no --prefix, npm decides.
+  it("omits --prefix when the binary is not in an npm global layout", async () => {
+    const base = join(env.home, "case-no-prefix")
+    const r = await runUpdateScript(base, join(base, "loose", "bin"))
+    expect(r.code).toBe(0)
+    expect(r.log).toContain("npm install -g @sma1lboy/rove@latest")
+    expect(r.log).not.toContain("--prefix")
+  })
+
+  // A bun install has no npm prefix to pin; --prefix is npm-only.
+  it("never passes --prefix to bun", async () => {
+    const base = join(env.home, "case-bun-noprefix")
+    const r = await runUpdateScript(base, join(base, ".bun", "bin"))
+    expect(r.code).toBe(0)
+    expect(r.log).toContain("bun install -g @sma1lboy/rove@latest")
+    expect(r.log).not.toContain("--prefix")
+  })
+
+  // The silent half of the incident: two installs, and the one running is
+  // not the one you think. Updating only names the winner, so say so.
+  it("warns when a second install is on PATH, naming which one is updated", async () => {
+    const base = join(env.home, "case-dupes")
+    const prefixA = join(base, "prefix-a")
+    const prefixB = join(base, "prefix-b")
+    const pkgA = join(prefixA, "lib/node_modules/@sma1lboy/rove/dist/cli")
+    const pkgB = join(prefixB, "lib/node_modules/@sma1lboy/rove/dist/cli")
+    await mkdir(pkgA, { recursive: true })
+    await mkdir(pkgB, { recursive: true })
+    for (const entry of [join(pkgA, "rove.js"), join(pkgB, "rove.js")]) {
+      await writeFile(entry, `#!/bin/sh\necho "rove 9.9.9"\n`)
+      await chmod(entry, 0o755)
+    }
+    await mkdir(join(prefixB, "bin"), { recursive: true })
+    await symlink(join(pkgB, "rove.js"), join(prefixB, "bin", "rove"))
+
+    const r = await runUpdateScript(base, join(prefixA, "bin"), join(pkgA, "rove.js"), undefined, [
+      join(prefixB, "bin"),
+    ])
+    expect(r.code).toBe(0)
+    expect(r.out).toContain("rove is installed more than once")
+    expect(r.out).toContain(join(prefixA, "bin", "rove"))
+    expect(r.out).toContain(join(prefixB, "bin", "rove"))
+    // Only the owning prefix is written to.
+    const realA = await realpath(prefixA)
+    expect(r.log).toContain(`npm install -g --prefix ${realA} @sma1lboy/rove@latest`)
+    expect(r.log).not.toContain(await realpath(prefixB))
+  })
+
+  it("stays quiet when there is only one install on PATH", async () => {
+    const base = join(env.home, "case-single")
+    const r = await runUpdateScript(base, join(base, "npm-global", "bin"))
+    expect(r.code).toBe(0)
+    expect(r.out).not.toContain("installed more than once")
   })
 
   it("a post-install PATH still resolving a stale version fails loudly", async () => {

--- a/packages/kobe/test/cli/update.test.ts
+++ b/packages/kobe/test/cli/update.test.ts
@@ -10,7 +10,7 @@ describe("updatePlan", () => {
       display: UPDATE_COMMAND,
     })
     expect(UPDATE_COMMAND).toBe(`curl -fsSL ${UPDATE_SCRIPT_URL} | sh`)
-    expect(recommendedGlobalInstallCommand()).toBe(`npm install -g ${PACKAGE_NAME}@latest`)
+    expect(recommendedGlobalInstallCommand(null)).toBe(`npm install -g ${PACKAGE_NAME}@latest`)
   })
 
   it("a channel rides into the script through the same slot a version does", () => {

--- a/packages/kobe/test/version.test.ts
+++ b/packages/kobe/test/version.test.ts
@@ -10,6 +10,7 @@ import {
   fetchReleaseNotesRange,
   fetchReleaseSummaries,
   isNewerSemver,
+  owningNpmPrefix,
   recommendedGlobalInstallCommand,
   releasePageUrl,
   repoSlug,
@@ -200,7 +201,27 @@ describe("repo slug + static commands", () => {
   })
 
   it("recommendedGlobalInstallCommand targets this package", () => {
-    expect(recommendedGlobalInstallCommand()).toBe(`npm install -g ${PACKAGE_NAME}@latest`)
+    expect(recommendedGlobalInstallCommand(null)).toBe(`npm install -g ${PACKAGE_NAME}@latest`)
+  })
+
+  // A bare `npm install -g` writes to the prefix of whichever node runs
+  // npm, which need not be the prefix holding the binary the user ran.
+  // When we know the owning prefix, the command has to pin it.
+  it("pins the owning prefix when the build lives in an npm global dir", () => {
+    expect(recommendedGlobalInstallCommand("/opt/homebrew")).toBe(
+      `npm install -g --prefix /opt/homebrew ${PACKAGE_NAME}@latest`,
+    )
+  })
+
+  it("derives the prefix from the module path, and only for npm layouts", () => {
+    expect(owningNpmPrefix(`/opt/homebrew/lib/node_modules/${PACKAGE_NAME}/dist/version.js`)).toBe("/opt/homebrew")
+    expect(
+      owningNpmPrefix(`/Users/x/.nvm/versions/node/v22.0.0/lib/node_modules/${PACKAGE_NAME}/dist/version.js`),
+    ).toBe("/Users/x/.nvm/versions/node/v22.0.0")
+    // bun global installs and dev checkouts have no npm prefix to pin.
+    expect(owningNpmPrefix("/Users/x/.bun/install/global/node_modules/pkg/dist/version.js")).toBeNull()
+    expect(owningNpmPrefix("/Users/x/src/rove/packages/kobe/src/version.ts")).toBeNull()
+    expect(owningNpmPrefix("/lib/node_modules/pkg/dist/version.js")).toBeNull()
   })
 
   it("releasePageUrl points at the GitHub tag for a version", () => {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -26,6 +26,41 @@ if [ "$VERSION" = "--list" ]; then
   exit 0
 fi
 
+# Resolve a symlink chain to the real file. `readlink -f` is GNU-only —
+# BSD/macOS readlink has no -f — so try realpath first, then GNU readlink,
+# then walk the chain by hand with plain `readlink`. Prints the input
+# unchanged when nothing resolves.
+resolve_link() {
+  target="$1"
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$target" 2>/dev/null && return 0
+  fi
+  if readlink -f "$target" >/dev/null 2>&1; then
+    readlink -f "$target" 2>/dev/null && return 0
+  fi
+  # Hand-rolled walk for BSD readlink. Bounded so a symlink cycle can't
+  # spin forever.
+  hops=0
+  while [ -L "$target" ] && [ "$hops" -lt 40 ]; do
+    link="$(readlink "$target")" || break
+    case "$link" in
+      /*) target="$link" ;;
+      *) target="$(dirname "$target")/$link" ;;
+    esac
+    hops=$((hops + 1))
+  done
+  # The hand-rolled walk leaves `bin/../lib` style segments behind. `cd -P`
+  # collapses them using only POSIX builtins, so the derived prefix is a
+  # real path and not one that merely resolves by luck.
+  dir="$(dirname "$target")"
+  base="$(basename "$target")"
+  if cd -P "$dir" 2>/dev/null; then
+    printf '%s/%s\n' "$(pwd -P)" "$base"
+  else
+    echo "$target"
+  fi
+}
+
 # `rove` first: on a migrated install both commands exist, and the newer
 # name is the one whose absence means "not migrated yet".
 BIN="$(command -v rove 2>/dev/null || command -v kobe 2>/dev/null || true)"
@@ -34,21 +69,45 @@ BEFORE="$("${BIN:-false}" -v 2>/dev/null || true)"
 # Update with the same package manager that owns the binary on PATH,
 # otherwise the new version lands in another prefix and PATH keeps
 # resolving the stale install (issue #205).
-case "$BIN" in
+#
+# Picking npm-vs-bun is not enough on its own: a machine can have several
+# npm (nvm's and homebrew's, say), and `npm install -g` writes to the
+# prefix of whichever *node* is executing it — NOT the prefix that owns
+# the binary you just ran. So resolve the running binary back to its own
+# prefix and pin the install there with `--prefix`, which overrides both
+# npmrc and npm_config_prefix.
+ENTRY=""
+if [ -n "$BIN" ]; then
+  ENTRY="$(resolve_link "$BIN")"
+fi
+
+PREFIX=""
+case "$BIN$ENTRY" in
   */.bun/*) MANAGER="bun" ;;
-  *) MANAGER="npm" ;;
+  *)
+    MANAGER="npm"
+    # <prefix>/lib/node_modules/@scope/pkg/... -> <prefix>
+    case "$ENTRY" in
+      */lib/node_modules/*) PREFIX="${ENTRY%%/lib/node_modules/*}" ;;
+    esac
+    ;;
 esac
+
+# A prefix is only usable if it is the one npm would build itself: it must
+# hold the package dir we resolved through. Empty PREFIX = let npm decide,
+# same as before.
+NPM_PREFIX_ARGS=""
+if [ -n "$PREFIX" ] && [ -d "$PREFIX/lib/node_modules" ]; then
+  NPM_PREFIX_ARGS="--prefix $PREFIX"
+fi
 
 # Is the install on PATH still the legacy package? Resolve the symlink and
 # look at which package dir it lands in — `command -v` alone can't tell,
 # since @sma1lboy/kobe ships a `rove` bin too.
 MIGRATING=0
-if [ -n "$BIN" ]; then
-  ENTRY="$(realpath "$BIN" 2>/dev/null || readlink -f "$BIN" 2>/dev/null || echo "$BIN")"
-  case "$ENTRY" in
-    */@sma1lboy/kobe/*) MIGRATING=1 ;;
-  esac
-fi
+case "$ENTRY" in
+  */@sma1lboy/kobe/*) MIGRATING=1 ;;
+esac
 
 # What the install will actually land on. A bare dist-tag (`nightly`) has to
 # be resolved through the registry: the verify step at the bottom compares
@@ -87,6 +146,52 @@ if [ "$MIGRATING" = "1" ]; then
     "$BOLD" "$RESET" "$LEGACY_PACKAGE" "$PACKAGE"
 fi
 
+# The failure this script exists to prevent is silent: two installs on
+# PATH, and the one you are running is not the one you think. We are about
+# to update only the prefix that owns the binary on PATH — so if there are
+# others, name them now, while the user is here and looking.
+SEEN=""
+DUPES=""
+DUPE_DIRS=""
+OWN_BINDIR="$(dirname "$BIN")"
+saved_ifs="$IFS"
+IFS=:
+for dir in $PATH; do
+  IFS="$saved_ifs"
+  [ -n "$dir" ] || dir="."
+  for name in rove kobe; do
+    cand="$dir/$name"
+    [ -x "$cand" ] || continue
+    real="$(resolve_link "$cand")"
+    case " $SEEN " in
+      *" $real "*) continue ;;
+    esac
+    SEEN="$SEEN $real"
+    # One install owns both a `rove` and a `kobe`. Group by the directory
+    # they sit in, so a sibling bin is never reported as a rival install —
+    # true whether the bins are symlinks into a package dir or plain files.
+    bindir="$(dirname "$cand")"
+    [ "$bindir" = "$OWN_BINDIR" ] && continue
+    case " $DUPE_DIRS " in
+      *" $bindir "*) continue ;;
+    esac
+    DUPE_DIRS="$DUPE_DIRS $bindir"
+    DUPES="$DUPES $cand"
+  done
+  IFS=:
+done
+IFS="$saved_ifs"
+
+if [ -n "$DUPES" ]; then
+  printf '%bwarning: rove is installed more than once.%b\n' "$BOLD" "$RESET" >&2
+  printf '%b  updating (first on PATH): %s%b\n' "$DIM" "$BIN" "$RESET" >&2
+  for d in $DUPES; do
+    printf '%b  also installed, NOT updated: %s%b\n' "$DIM" "$d" "$RESET" >&2
+  done
+  printf '%b  PATH order decides which one runs. Remove the ones you do not want.%b\n' \
+    "$DIM" "$RESET" >&2
+fi
+
 if [ -n "$TARGET" ]; then
   printf '%bUpdating %s: %s -> v%s%b (via %s)\n' "$BOLD" "$PACKAGE" "${BEFORE:-not installed}" "$TARGET" "$RESET" "$MANAGER"
 else
@@ -101,10 +206,12 @@ trap 'rm -f "$LOG"' EXIT
 # first — and only once we're about to replace it, so a failed install
 # can't leave the user with nothing.
 if [ "$MIGRATING" = "1" ]; then
-  "$MANAGER" uninstall -g "$LEGACY_PACKAGE" >>"$LOG" 2>&1 || true
+  # shellcheck disable=SC2086 # empty-or-two-words, needs splitting
+  "$MANAGER" uninstall -g $NPM_PREFIX_ARGS "$LEGACY_PACKAGE" >>"$LOG" 2>&1 || true
 fi
 
-"$MANAGER" install -g "${PACKAGE}@${VERSION:-latest}" >>"$LOG" 2>&1 &
+# shellcheck disable=SC2086 # empty-or-two-words, needs splitting
+"$MANAGER" install -g $NPM_PREFIX_ARGS "${PACKAGE}@${VERSION:-latest}" >>"$LOG" 2>&1 &
 PID=$!
 
 if [ -t 1 ]; then
@@ -129,7 +236,8 @@ if ! wait "$PID"; then
   # back before giving up.
   if [ "$MIGRATING" = "1" ]; then
     printf '%brestoring %s...%b\n' "$DIM" "$LEGACY_PACKAGE" "$RESET" >&2
-    if "$MANAGER" install -g "${LEGACY_PACKAGE}@latest" >/dev/null 2>&1; then
+    # shellcheck disable=SC2086 # empty-or-two-words, needs splitting
+    if "$MANAGER" install -g $NPM_PREFIX_ARGS "${LEGACY_PACKAGE}@latest" >/dev/null 2>&1; then
       printf '%brestored — you are back on %s, nothing was lost.%b\n' "$DIM" "$LEGACY_PACKAGE" "$RESET" >&2
     else
       printf '%breinstall by hand: %s install -g %s%b\n' "$RED" "$MANAGER" "$LEGACY_PACKAGE" "$RESET" >&2
@@ -147,7 +255,7 @@ AFTER="$(rove -v 2>/dev/null || kobe -v 2>/dev/null || true)"
 if [ -n "$TARGET" ] && [ "${AFTER##* }" != "$TARGET" ]; then
   echo "error: 'rove' on PATH reports '${AFTER:-nothing}' but the target is ${TARGET}." >&2
   echo "PATH resolves rove to: $(command -v rove || echo 'not found')" >&2
-  echo "Another install is likely shadowing it. Remove the stale one or run: ${MANAGER} install -g ${PACKAGE}@${VERSION:-latest}" >&2
+  echo "Another install is likely shadowing it. Remove the stale one or run: ${MANAGER} install -g ${NPM_PREFIX_ARGS} ${PACKAGE}@${VERSION:-latest}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## The incident

Two `@sma1lboy/rove` installs on one machine, and `rove update` kept feeding the wrong one:

```
interactive shell:  rove --version → 0.9.59   (nvm)
agent environment:  rove --version → 0.9.7    (homebrew, 8/29)
```

PATH order decided which ran, the daemon happened to boot from the stale one, and 30 fixes merged that day were live in neither. Nothing reported a problem.

## Root cause

`scripts/update.sh` already had the right instinct (issue #205) but stopped one layer short — it picked npm-vs-bun and left the rest to npm:

```sh
case "$BIN" in
  */.bun/*) MANAGER="bun" ;;
  *) MANAGER="npm" ;;
esac
```

Both installs were npm's, so both runs took the same branch. The part that actually decides where files land is **which node executes npm** — npm derives its global prefix from its own runtime, not from the binary you just ran. Measured on this machine:

```
$ node .../npm-cli.js prefix -g   # nvm node v22
/Users/jacksonc/.nvm/versions/node/v22.23.2
$ node .../npm-cli.js prefix -g   # homebrew node v26 — same npm file
/opt/homebrew/Cellar/node/26.0.0
```

Same `npm-cli.js`, different node, different destination. So `which npm` is a red herring; the prefix has to be pinned explicitly.

## The fix

Resolve the running binary to its real path, walk up to the prefix that owns it (`<prefix>/lib/node_modules/…`), and pin the install there with `--prefix`. Applied to the install, the legacy uninstall, and the restore-on-failure path, so all three can't diverge onto different prefixes.

## The four judgment calls

**1. How to derive the prefix?** From the resolved entry path, cutting at `/lib/node_modules/`. Symlink resolution is a `resolve_link` helper because `readlink -f` is GNU-only — BSD/macOS has no `-f`. It tries `realpath`, then `readlink -f`, then a hand-rolled walk, and normalizes with `cd -P` (POSIX builtins, no coreutils). Without that last step the BSD path yields `<prefix>/bin/../lib/...`, which resolves correctly by luck but reads wrong and prints wrong. All three branches verified to agree, under `dash`.

**2. `--prefix` or call the prefix's own npm?** `--prefix`. I tested the trap first: on npm 10.9.8 the flag wins over both a `prefix=` in npmrc and `npm_config_prefix` in env, and still lands correctly when a *foreign* node runs npm. Calling the prefix's own npm binary is worse — the npm shipped in a prefix is a symlink to `npm-cli.js` and still derives its prefix from `$PATH`'s node, so it would reintroduce the same bug. `--prefix` is also npm-only; bun never receives it.

**3. Warn on multiple installs?** Yes — silence was the actual damage. It names which install is being updated, which are being left alone, and that PATH order decides. Deduped by bin directory, since one install owns both a `rove` and a `kobe` and listing the sibling is noise. Silent when there's only one. First attempt used `command -v -a`, which is a bash/zsh extension that POSIX `sh` rejects — it printed nothing and the warning silently never fired, which is the same failure mode this PR exists to remove. Replaced with an explicit PATH walk.

**4. `version.ts` manual fallback?** Made it correct rather than left as a coin flip. It can see its own module path, so `owningNpmPrefix()` derives the prefix and the printed command pins it. Returns `null` (unchanged bare command) for bun installs and dev checkouts.

## Verification

Baseline first: the bug reproduces on unmodified `origin/main`. Two prefixes, each with a real published version, `rove` on PATH owned by A while PATH's `npm` belongs elsewhere.

```
### BEFORE ###
$ which -a rove
/tmp/rove-prefix-fixture/rovepath/rove
/tmp/rove-prefix-fixture/B/bin/rove
$ command -v npm  ->  /tmp/rove-prefix-fixture/B/bin/npm
$ npm prefix -g   ->  /Users/jacksonc/.nvm/versions/node/v22.23.2   <-- NOT the prefix owning the binary

prefix A (owns the rove on PATH): 0.9.58
prefix B (the other install):     0.9.7

### 1. BASELINE (origin/main) — asked for 0.9.59 ###
Updating @sma1lboy/rove: rove 0.9.58 -> v0.9.59 (via npm)
error: 'rove' on PATH reports 'rove 0.9.58' but the target is 0.9.59.
Another install is likely shadowing it.
A=0.9.58  B=0.9.7          <-- exit 1, A never moved

### 2. FIXED (this branch) — asked for 0.9.59 ###
warning: rove is installed more than once.
  updating (first on PATH): /tmp/rove-prefix-fixture/A/bin/rove
  also installed, NOT updated: /tmp/rove-prefix-fixture/B/bin/rove
  PATH order decides which one runs. Remove the ones you do not want.
Updating @sma1lboy/rove: rove 0.9.58 -> v0.9.59 (via npm)
✓ rove 0.9.58 -> rove 0.9.59

prefix A (owns the rove on PATH): 0.9.59   <-- correct prefix
prefix B (the other install):     0.9.7    <-- untouched
$ rove --version -> rove 0.9.59
```

Also re-run end-to-end with `realpath` and `readlink -f` both unavailable (pure BSD), same result.

Cross-platform: `sh -n` clean under `dash` (Linux `/bin/sh`), `bash`, and `sh`; `shellcheck` reports only two pre-existing SC2016 infos on untouched prose lines. No Docker daemon available, so the GNU path was covered by exercising each `resolve_link` branch under `dash` rather than in a container.

Gates: lint, typecheck, 3938 fast + 26 behavior + 659 socket all green. Mutation-tested twice at two different sites, before and after the rebase — dropping `--prefix` from the install call fails 3 tests, breaking the prefix derivation fails 3, silencing the warning fails 1, and both `version.ts` mutants fail 1 each. The behavior tests execute the real script, not just the pure helper.

## One note on my own environment

While probing how npm derives its prefix, one baseline run reached the real nvm prefix and reinstalled `@sma1lboy/rove` there. It reinstalled **0.9.59, the version that was already there** — verified complete and working (`rove --version` → `rove 0.9.59`, `npm ls -g` clean, `dist/cli` and `node_modules` intact); only the mtime moved. No version change and nothing to undo, but flagging it rather than leaving it in the timestamps. The fixture npms are now pinned so no further run can reach a real prefix.

## Related, not done here

After updating, the daemon keeps running the old code — that was true in this incident too — and `rove update` says nothing about restarting. #688 added a version-skew hint, but it only appears on the next TUI launch. Saying it at the end of `update` would close the gap; separate change, deliberately not bundled.
