### PR TITLE
fix: stop minting project rows nobody asked for, and let a finished project leave the sidebar

### DIFF
--- a/.changeset/close-last-tab-and-hide.md
+++ b/.changeset/close-last-tab-and-hide.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Close a task's last tab, and let a project you're done with leave the sidebar.
+
+`ctrl+w` used to refuse a task's only tab with a toast. It now closes it: the task keeps its sidebar row and its worktree, and `⏎` or `ctrl+e` starts a session there again. Scratch tasks are unchanged — their last tab still ends the task, since the shell is the whole session.
+
+A project whose only row is its main checkout disappears from the sidebar once you close that checkout's last tab. Nothing is deleted: the repo stays in the new-task picker, and opening it there brings the project back. This is deliberately narrower than Forget (`d` on the row), which un-saves the repo — closing the last tab means "done here for now", not "remove this". A project with worktree tasks under it always stays visible, however many tabs are closed, because those rows are how you get back to that work.
+
+Sidebar projects and the new-task picker are now the same set. A project row minted by creating a task never reached the saved-repos list, so it was a project you could see but not pick — 6 of 8 on one machine. Both are written together now, and existing rows are backfilled on daemon start.
+
+The project row's right-click menu also gained "Remove project", which `d` on that row has always done.

--- a/.changeset/project-admission-gate.md
+++ b/.changeset/project-admission-gate.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop the sidebar's project list from growing rows nobody asked for.
+
+Creating a task, adopting a worktree, or starting an issue chat used to mint a permanent `kind:"main"` project row for whatever path was involved — including test fixtures under `/tmp`, repos inside `.dev-sandbox`, and checkouts nested in Rove's own worktrees directory. Those rows were also unremovable: `task.delete` refuses a main row ("remove the repo from saved repos instead") while `rove remove` refuses a repo that was never in `savedRepos`, which is exactly the set they belonged to.
+
+A single admission gate now decides what may become a project, applied inside `addSavedRepo` and the main-row coordinator so no caller can skip it. Inferred projects are held to a stricter rule than ones you name yourself: `rove add /tmp/scratch-repo` still works, while a task created against that same path no longer leaves a project row behind. The task itself is unaffected — it renders under a header derived from its own repo, which simply dies with it.
+
+`rove .` in a git repo's root now opens that repo AS the project, instead of creating a throwaway directory session beside the project row it would later be promoted into. A subdirectory, a plain folder, or a repo at an ineligible path keeps the previous directory-session behaviour.
+
+`rove add` also reports a refusal properly instead of printing "already saved" for a path it declined to store.

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path"
 import { errorMessage } from "@/lib/error-message"
 import { matchPathGlob } from "../lib/path-glob.ts"
 import { expandTilde } from "../lib/path-home.ts"
+import { rejectionReason } from "../state/project-eligibility.ts"
 import { type VendorId, coerceVendorId } from "../types/vendor.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 // Static: open-dir-cmd's own imports are cheap (node builtins); the heavy
@@ -42,17 +43,19 @@ async function runAddSubcommand(rest: readonly string[]): Promise<void> {
     process.exit(2)
   }
   const target = resolve(process.cwd(), expandTilde(arg && arg.length > 0 ? arg : "."))
-  const { addSavedRepo, isGitRepo } = await import("../state/repos.ts")
-  // A saved project must be a real local git repository — reject garbage
-  // paths (e.g. `kobe add ,`, which resolves to a non-existent dir) before
-  // they pollute the picker and become un-deletable synthetic rows.
-  if (!isGitRepo(target)) {
+  const { addSavedRepo } = await import("../state/repos.ts")
+  // The admission gate lives inside `addSavedRepo` (state/project-eligibility
+  // .ts) — a real git repo, at a path durable enough to be someone's project.
+  // Reporting the refusal is this command's own job: `added: false` also means
+  // "already saved", and printing that for a rejected path claims we stored
+  // something we refused.
+  const result = addSavedRepo(target)
+  if (result.rejected) {
     process.stderr.write(
-      `${CLI_NAME} add: "${arg && arg.length > 0 ? arg : "."}" is not a git repository (resolved to ${target}).\n`,
+      `${CLI_NAME} add: "${arg && arg.length > 0 ? arg : "."}" cannot be a project — ${rejectionReason(result.rejected)} (resolved to ${result.path}).\n`,
     )
     process.exit(1)
   }
-  const result = addSavedRepo(target)
   if (result.added) {
     console.log(`added ${result.path} (${result.total} saved repo${result.total === 1 ? "" : "s"} total)`)
   } else {

--- a/packages/kobe/src/cli/open-dir-cmd.ts
+++ b/packages/kobe/src/cli/open-dir-cmd.ts
@@ -1,15 +1,22 @@
 /**
- * `kobe <path>` — the `code .` gesture: open an existing directory as a
- * standalone `kind:"dir"` task and land in the TUI focused on it.
+ * `kobe <path>` — the `code .` gesture: open a directory and land in the TUI
+ * focused on it. What it opens depends on WHAT the directory is:
  *
- * Deliberately NO project association: no saved repo, no main task, no
- * worktree/branch — the task pins the directory itself, and deleting it
- * later only drops the index entry (the directory is never touched).
- * Every invocation creates a NEW task — same directory twice is two
- * parallel sessions, distinguished by a random title suffix. Prefers a
- * RUNNING daemon (live TUIs see the row immediately);
- * falls back to the in-process orchestrator, persisting focus for the
- * daemon the TUI is about to boot.
+ *   - **The root of an eligible git repo** → the project itself (owner call
+ *     2026-08-31), i.e. the same outcome as `rove add . && rove`. Opening a
+ *     checkout you work in used to mint a throwaway `dir` row beside the main
+ *     row it would later be promoted into, so the sidebar listed the same
+ *     checkout twice under one header.
+ *   - **Anything else** — a subdirectory, a plain folder, a `/tmp` scratch —
+ *     → a standalone `kind:"dir"` task with NO project association: no saved
+ *     repo, no main task, no worktree/branch. The task pins the directory
+ *     itself, deleting it later only drops the index entry (the directory is
+ *     never touched), and each invocation creates a NEW task, so the same
+ *     directory twice is two parallel sessions with a random title suffix.
+ *
+ * Prefers a RUNNING daemon (live TUIs see the row immediately); falls back to
+ * the in-process orchestrator, persisting focus for the daemon the TUI is
+ * about to boot.
  */
 
 import { statSync } from "node:fs"
@@ -36,6 +43,24 @@ export function isPathLikeArg(arg: string): boolean {
   )
 }
 
+/**
+ * Whether `dir` is the ROOT of a repo eligible to be a project (owner call
+ * 2026-08-31). Only the toplevel qualifies: running `rove .` inside
+ * `my-monorepo/packages/app` should open a session there, not silently
+ * re-target the whole monorepo — and a subdirectory that minted its own
+ * project row was the "ghost project named after a subdirectory" bug.
+ */
+async function projectRootFor(dir: string): Promise<string | null> {
+  const { isGitRepo, resolveRepoRoot } = await import("../state/repos.ts")
+  const { projectRejection } = await import("../state/project-eligibility.ts")
+  const top = resolveRepoRoot(dir)
+  if (top !== dir) return null
+  // `explicit`: the user typed this path, exactly as they would to `rove add`.
+  // The stricter `derived` tier exists for repos Rove infers on its own, and
+  // applying it here would refuse `rove .` in any checkout under /tmp.
+  return projectRejection(top, isGitRepo, "explicit") ? null : top
+}
+
 export async function runOpenDirectory(arg: string): Promise<void> {
   const dir = resolve(process.cwd(), expandTilde(arg))
   let isDir = false
@@ -48,13 +73,26 @@ export async function runOpenDirectory(arg: string): Promise<void> {
     process.stderr.write(`${activeCliName()}: "${arg}" is not a directory (resolved to ${dir}).\n`)
     process.exit(1)
   }
+  // A repo root opens AS THE PROJECT (owner call 2026-08-31): `rove .` in a
+  // checkout you work in is the same gesture as `rove add . && rove`, and
+  // minting a throwaway `dir` row beside the main row it would later be
+  // promoted into just made the sidebar say the same checkout twice.
+  // Anything else — a subdirectory, a non-repo folder, a `/tmp` scratch —
+  // keeps the dir-task behaviour: pinned to that directory, no project row.
+  const projectRoot = await projectRootFor(dir)
   await withDaemonOrLocal({
     daemon: async (client) => {
-      const { taskId } = await client.request<{ taskId: string }>("task.openDir", { dir })
+      let taskId: string
+      if (projectRoot) {
+        const res = await client.request<{ task: { id: string } }>("task.ensureMain", { repo: projectRoot })
+        taskId = res.task.id
+      } else {
+        taskId = (await client.request<{ taskId: string }>("task.openDir", { dir })).taskId
+      }
       await client.request("task.setActive", { taskId })
     },
     local: async (orch) => {
-      const task = await orch.openDirectoryTask({ dir })
+      const task = projectRoot ? await orch.ensureMainTask(projectRoot) : await orch.openDirectoryTask({ dir })
       const { writeLastActiveTaskId } = await import("../state/last-active.ts")
       writeLastActiveTaskId(String(task.id))
     },

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -11,6 +11,7 @@ import { auditDeletionSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletio
 import { Orchestrator } from "../orchestrator/core.ts"
 import { TaskIndexStore } from "../orchestrator/index/store.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
+import { backfillSavedReposFromProjects } from "../state/repos.ts"
 import { tearDownTaskSessionAdapter } from "./daemon-session-adapter.ts"
 
 export interface KobeCoreOptions {
@@ -43,6 +44,20 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
     // deletion runner already uses.
     tearDownSession: (taskId) => tearDownTaskSessionAdapter(String(taskId)),
   })
+
+  // Heal the projects/savedRepos split (see backfillSavedReposFromProjects):
+  // rows minted before 2026-08-31 are in the sidebar but not the picker. Runs
+  // once per daemon boot and is idempotent — after the first pass every row
+  // is already saved and `addSavedRepo` reports nothing added.
+  const backfilled = backfillSavedReposFromProjects(
+    store
+      .list()
+      .filter((task) => task.kind === "main")
+      .map((task) => task.repo),
+  )
+  if (backfilled.length > 0) {
+    console.error(`[rove] added ${backfilled.length} existing project(s) to the new-task picker`)
+  }
 
   return {
     homeDir,

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -6,12 +6,13 @@
 
 import { type ReadableState, type StateCell, createStateCell } from "../lib/external-store.ts"
 import { readLastActiveTaskId, writeLastActiveTaskId } from "../state/last-active.ts"
+import type { ProjectIntent } from "../state/project-eligibility.ts"
 import { getRemoteRepoConfig, getSavedRepos, removeSavedRepo } from "../state/repos.ts"
 import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
 import type { Task, TaskDispatcher, TaskId, TaskPRStatus, TaskStatus, VendorId } from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
-import { canonPath, randomDirTaskSuffix, repoWorkingDir, titleFromRepo } from "./core-helpers.ts"
+import { canonPath, normalizeMainRepo, randomDirTaskSuffix, repoWorkingDir, titleFromRepo } from "./core-helpers.ts"
 import { DirtyWorktreeError, TaskDeletingError, TaskNotFoundError, WorktreeRemoveFailedError } from "./errors.ts"
 import type { TaskIndexStore, TaskIndexUnsubscribe } from "./index/store.ts"
 import { type LandResult, type LandTaskOpts, landTaskWithCleanup } from "./land.ts"
@@ -42,6 +43,15 @@ export interface CreateTaskInput {
   readonly groupId?: string
   /** The kobe session (task + tab) dispatching this create, when one is. */
   readonly dispatcher?: TaskDispatcher
+  /**
+   * How the repo was chosen, for the project-admission gate
+   * (state/project-eligibility.ts). Defaults to `"explicit"`: every caller
+   * today reaches here from a user naming the repo — the new-task dialog,
+   * `rove api add`, a quick-fork of the row you are on. A caller that
+   * INFERRED the repo (a script walking directories, a fixture harness)
+   * should pass `"derived"` to get the stricter gate.
+   */
+  readonly projectIntent?: ProjectIntent
 }
 
 export type Unsubscribe = () => void
@@ -95,8 +105,11 @@ export class Orchestrator {
     this.store = deps.store
     this.worktrees = deps.worktrees
     this.tearDownSession = deps.tearDownSession
+    // `ensureIfEligible`, not `ensureMainTask`: adopting a worktree of a
+    // throwaway repo must still adopt, it just must not mint a permanent
+    // project row for a path that cannot be someone's project.
     this.worktreeCoordinator = new WorktreeCoordinator(this.store, this.worktrees, canonPath, (repo) =>
-      this.ensureMainTask(repo),
+      this.mainTasks.ensureIfEligible(repo),
     )
     this.mainTasks = new MainTaskCoordinator(this.store, (id) => this.worktreeCoordinator.forget(id))
     this.editor = new TaskEditor(this.store, this.worktrees)
@@ -205,24 +218,27 @@ export class Orchestrator {
    */
   async createTask(input: CreateTaskInput): Promise<Task> {
     if (!input.repo) throw new Error("createTask: repo is required")
-    // A task whose repo has no `kind:"main"` task is unrenderable state:
-    // the sidebar's PROJECTS rows ARE the main tasks (sidebar/groups.ts),
-    // so a task created for a brand-new repo would float with no project
-    // row. Every creation path therefore guarantees its own project entry.
-    // Normalize to the git toplevel BEFORE anything reads `input.repo`.
-    // `ensureMainTask` already normalizes internally, so a caller passing a
-    // SUBDIRECTORY (`rove` run from `my-monorepo/packages/app`, whose path
-    // passes `validateRepoPath` because `rev-parse --git-dir` succeeds in a
-    // subdir) used to split into two sidebar projects: the main row keyed on
-    // `/my-monorepo`, this task keyed on `/my-monorepo/packages/app` — a
-    // ghost project named after a subdirectory, with its own worktree root.
-    // `rove add` (via addSavedRepo) and `rove api add` (via resolveRepoRoot)
-    // both already resolve; this makes the orchestrator entry point agree,
-    // which covers the TUI dialog and every future caller at once.
+    // Bring the project row into existence alongside the task — but only if
+    // the repo may BE a project (state/project-eligibility.ts). A `/tmp`
+    // fixture or a checkout inside `.dev-sandbox` still gets its task; it
+    // just stops leaving a permanent sidebar row behind, which is how the
+    // owner's project list reached 12 rows on 2 saved repos. `buildTreeRows`
+    // groups a main-less task under a header derived from its own repo, so
+    // the task still renders — the header just dies with it.
+    //
+    // Normalize to the git toplevel regardless of that outcome. A caller
+    // passing a SUBDIRECTORY (`rove` run from `my-monorepo/packages/app`,
+    // whose path passes `validateRepoPath` because `rev-parse --git-dir`
+    // succeeds in a subdir) otherwise splits into two sidebar projects: the
+    // main row keyed on `/my-monorepo`, this task keyed on
+    // `/my-monorepo/packages/app` — a ghost project named after a
+    // subdirectory, with its own worktree root. That normalization used to
+    // ride on the returned main row, so taking it from `normalizeMainRepo`
+    // directly keeps it working when no row is created.
     // Dir/scratch tasks do NOT come through here (see openDirectoryTask),
     // so pinning a user-owned directory is unaffected.
-    const mainTask = await this.ensureMainTask(input.repo)
-    const repo = mainTask.repo
+    const mainTask = await this.mainTasks.ensureIfEligible(input.repo, input.projectIntent ?? "explicit")
+    const repo = mainTask?.repo ?? normalizeMainRepo(input.repo).repo
     const title = (input.title ?? PLACEHOLDER_TASK_TITLE).trim() || PLACEHOLDER_TASK_TITLE
     // Leave the branch EMPTY for a lazily-allocated task (unless the caller
     // gave an explicit one): {@link ensureWorktree} derives a repo-convention

--- a/packages/kobe/src/orchestrator/main-task.ts
+++ b/packages/kobe/src/orchestrator/main-task.ts
@@ -11,7 +11,8 @@
  * Moved from `core.ts`; the adoption branch is the only new behaviour.
  */
 
-import { getSavedRepos, removeSavedRepo } from "../state/repos.ts"
+import { type ProjectIntent, projectRejection, rejectionReason } from "../state/project-eligibility.ts"
+import { getSavedRepos, isGitRepo, removeSavedRepo } from "../state/repos.ts"
 import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
 import type { Task, TaskId } from "../types/task.ts"
 import { normalizeMainRepo, repoWorkingDir, titleFromRepo } from "./core-helpers.ts"
@@ -39,12 +40,43 @@ export class MainTaskCoordinator {
    * its terminal tabs move under the main row instead of being stranded.
    * Scratch rows are never promoted: their cwd is unsettled by definition and
    * they belong to the Scratch bench (issue #33).
+   *
+   * Ineligible repos throw — see {@link ensureIfEligible} for the variant
+   * every internal caller uses. Direct callers are the ones acting on an
+   * explicit user gesture (`rove add`, `project.ensureMain`), where a silent
+   * no-op would look like the command did nothing.
    */
   async ensure(repo: string): Promise<Task> {
+    const task = await this.ensureIfEligible(repo, "explicit")
+    if (task) return task
+    const { repo: normalizedRepo } = normalizeMainRepo(repo)
+    const rejected = projectRejection(normalizedRepo, isGitRepo, "explicit") ?? "notGitRepo"
+    throw new Error(`cannot add ${normalizedRepo} as a project: ${rejectionReason(rejected)}`)
+  }
+
+  /**
+   * {@link ensure}, but returning null instead of creating a row the path
+   * does not deserve.
+   *
+   * This is the gate on the leak that put four fixture paths permanently in
+   * the owner's sidebar (12 project rows behind 2 saved repos). `createTask`
+   * and `adopt` call this while doing their real work: a task whose repo is a
+   * `/tmp` fixture still gets created, it just does not also mint a permanent
+   * project row. Nothing breaks downstream — `buildTreeRows` derives a
+   * project header from the task's own repo when no main row exists ("then
+   * main-less projects in first-seen order"), so the task still renders under
+   * a header; the header simply stops outliving it.
+   */
+  async ensureIfEligible(repo: string, intent: ProjectIntent = "derived"): Promise<Task | null> {
     const { repo: normalizedRepo, key } = normalizeMainRepo(repo)
     const onThisRoot = (task: Task): boolean => normalizeMainRepo(task.repo).key === key
     const existing = this.store.list().find((task) => task.kind === "main" && onThisRoot(task))
+    // An existing row short-circuits BEFORE the gate: the rule governs what
+    // may BECOME a project, not what already is one. Re-gating here would
+    // make a row that predates the gate start failing every task creation
+    // under it — punishing the user for state we produced.
     if (existing) return existing
+    if (projectRejection(normalizedRepo, isGitRepo, intent)) return null
     const inflight = this.locks.get(key)
     if (inflight) return inflight
     const promise = (async () => {

--- a/packages/kobe/src/orchestrator/main-task.ts
+++ b/packages/kobe/src/orchestrator/main-task.ts
@@ -12,7 +12,7 @@
  */
 
 import { type ProjectIntent, projectRejection, rejectionReason } from "../state/project-eligibility.ts"
-import { getSavedRepos, isGitRepo, removeSavedRepo } from "../state/repos.ts"
+import { addSavedRepo, getSavedRepos, isGitRepo, removeSavedRepo } from "../state/repos.ts"
 import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
 import type { Task, TaskId } from "../types/task.ts"
 import { normalizeMainRepo, repoWorkingDir, titleFromRepo } from "./core-helpers.ts"
@@ -80,6 +80,14 @@ export class MainTaskCoordinator {
     const inflight = this.locks.get(key)
     if (inflight) return inflight
     const promise = (async () => {
+      // A project row and a saved-repos entry are the same fact: the sidebar
+      // shows what the new-task picker offers. They used to be written by
+      // separate paths, so a row minted here (`createTask` on a fresh repo)
+      // was a project you could SEE but could not pick — and closing its last
+      // tab, which now hides it, would have lost it with no way back.
+      // Writing both here keeps them from diverging again. `explicit`: this
+      // path already passed the admission gate above.
+      addSavedRepo(normalizedRepo, { intent: "explicit" })
       const adoptable = this.store
         .list()
         .find((task) => task.kind === "dir" && task.scratch !== true && onThisRoot(task))

--- a/packages/kobe/src/state/project-eligibility.ts
+++ b/packages/kobe/src/state/project-eligibility.ts
@@ -1,0 +1,155 @@
+/**
+ * Who is allowed to become a PROJECT — the one gate every path that mints a
+ * `kind:"main"` row or a `savedRepos` entry passes through.
+ *
+ * The sidebar's project list grew to 12 rows on a machine whose `savedRepos`
+ * held 2. `ensureMainTask` is called by `createTask`, by the worktree
+ * coordinator, by the issue-chat flow and by quick-fork, and none of them
+ * asked whether the path deserved a permanent row: test fixtures under
+ * `/tmp`, a repo inside `.dev-sandbox`, and a checkout nested in Rove's own
+ * worktrees dir all became permanent sidebar entries. Worse, they became
+ * UNREMOVABLE — `task.delete` refuses a main row ("remove the repo from
+ * saved repos instead") while `rove remove` refuses a repo that was never in
+ * `savedRepos`, which is precisely the set these rows belong to.
+ *
+ * `addSavedRepo` used to say validation was the caller's job. Eight callers,
+ * one of which validated. So the rule lives here and the mutators apply it
+ * themselves — a caller cannot forget a check it does not perform.
+ *
+ * Deliberately NOT a taste filter: "I'm not working on codefox right now" is
+ * the user's Forget action, not this function's call. It rejects only paths
+ * structurally incapable of being someone's project — throwaway directories,
+ * and Rove's own state.
+ *
+ * And it is stricter about a project Rove INFERRED than one the user asked
+ * for by name (see {@link ProjectIntent}). Every leaked row was inferred; a
+ * `rove add` on a `/tmp` checkout is a deliberate, reversible choice, and
+ * banning it would also ban every test that builds its fixture repo there.
+ *
+ * Pure path logic, no fs and no import of `repos.ts` (which imports THIS
+ * module). The one filesystem question — "is this a git repo" — is injected
+ * by the caller, which also keeps the `git` subprocess out of bulk scans.
+ */
+
+import { tmpdir } from "node:os"
+import { isAbsolute, join, relative, resolve, sep } from "node:path"
+import { homeDir, legacyKobeStateDir, roveStateDir } from "../env.ts"
+
+/** Why a path may not become a project. `null` = eligible. */
+export type ProjectRejection = "notAbsolute" | "notGitRepo" | "temporary" | "roveInternal" | "insideSandbox"
+
+/**
+ * Path segments that can never hold a durable project.
+ *
+ * Matched by SEGMENT rather than by prefix: `.dev-sandbox` lives inside the
+ * Rove checkout, so a prefix rule would hard-code this repo's location, and
+ * an agent running `dev:sandbox` from a worktree produces a different
+ * absolute path every time.
+ */
+const THROWAWAY_SEGMENTS = new Set([".dev-sandbox", ".scratch"])
+
+/** True for a synthetic remote-project key. One `startsWith`, duplicated
+ *  from `repos.ts` rather than imported so this module stays out of the
+ *  cycle — `repos.ts` calls into here. */
+function isRemoteKey(key: string): boolean {
+  return key.startsWith("ssh://")
+}
+
+/** Is `candidate` at or below `root`? Pure string comparison on resolved
+ *  paths — no fs access, so it answers the same way for a directory that has
+ *  since been deleted. */
+function isInside(candidate: string, root: string): boolean {
+  const rel = relative(resolve(root), resolve(candidate))
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
+}
+
+/**
+ * Rove's own state directories — `~/.rove` (worktrees, plugins, issue
+ * assets), the pre-rename `~/.kobe`, and the config dir. A repo checked out
+ * INSIDE a task worktree is the clearest case: it is a fixture some test
+ * created under the worktree it was handed, and it dies with that task.
+ */
+function roveInternalRoots(): readonly string[] {
+  return [roveStateDir(), legacyKobeStateDir(), join(homeDir(), ".config", "rove")]
+}
+
+/* Checked BEFORE the `temporary` rule: a test that redirects `ROVE_HOME_DIR`
+ * into a tmpdir puts Rove's own state under `/tmp`, and reporting that as
+ * "temporary" would hide the more specific reason. */
+
+/**
+ * How the path was offered, which decides how strict the gate is.
+ *
+ *   - `"explicit"` — the user asked for this exact path (`rove add`,
+ *     `rove .` on a repo root). A checkout under `/tmp` is unusual but it is
+ *     THEIR call, and `rove remove` can undo it.
+ *   - `"derived"` — Rove inferred a project while doing something else
+ *     (`createTask`, worktree adopt). This is where the leak lived: nobody
+ *     asked for these rows, nobody saw them appear, and they outlived the
+ *     tasks that spawned them.
+ *
+ * Only `temporary` differs between the two. Everything else — Rove's own
+ * state dir, a sandbox path, a non-repo — is wrong under any intent.
+ */
+export type ProjectIntent = "explicit" | "derived"
+
+/**
+ * Why `absPath` may not become a project, considering PATH SHAPE only.
+ *
+ * Structural rejections are deliberately decided before any filesystem
+ * question, so a fixture that has already been deleted still reports
+ * `temporary` — the answer a cleanup scan needs — rather than `notGitRepo`,
+ * which reads like a user's repo that merely moved.
+ */
+export function pathRejection(absPath: string, intent: ProjectIntent = "derived"): ProjectRejection | null {
+  const raw = absPath.trim()
+  if (!raw) return "notAbsolute"
+  // A remote project's key is a synthetic ssh:// URL validated by the
+  // remote-add flow — none of the local path rules can speak about it.
+  if (isRemoteKey(raw)) return null
+  if (!isAbsolute(raw)) return "notAbsolute"
+  if (raw.split(sep).some((s) => THROWAWAY_SEGMENTS.has(s))) return "insideSandbox"
+  for (const root of roveInternalRoots()) {
+    if (isInside(raw, root)) return "roveInternal"
+  }
+  if (intent === "derived" && (isInside(raw, tmpdir()) || isInside(raw, "/tmp") || isInside(raw, "/private/tmp"))) {
+    return "temporary"
+  }
+  return null
+}
+
+/**
+ * The full gate: path shape plus "is it actually a git repo".
+ *
+ * `isRepo` is injected (callers pass `isGitRepo` from `repos.ts`) so this
+ * module stays import-free of the module that calls it, and so a scan over
+ * stale records can skip the subprocess by omitting it.
+ */
+export function projectRejection(
+  absPath: string,
+  isRepo?: (p: string) => boolean,
+  intent: ProjectIntent = "derived",
+): ProjectRejection | null {
+  const shape = pathRejection(absPath, intent)
+  if (shape) return shape
+  const raw = absPath.trim()
+  if (isRemoteKey(raw)) return null
+  if (isRepo && !isRepo(raw)) return "notGitRepo"
+  return null
+}
+
+/** One-line reason for a rejection — CLI stderr, daemon errors, toasts. */
+export function rejectionReason(rejection: ProjectRejection): string {
+  switch (rejection) {
+    case "notAbsolute":
+      return "not an absolute path"
+    case "notGitRepo":
+      return "not a git repository"
+    case "temporary":
+      return "inside a temporary directory"
+    case "roveInternal":
+      return "inside Rove's own state directory"
+    case "insideSandbox":
+      return "inside a sandbox or scratch directory"
+  }
+}

--- a/packages/kobe/src/state/repos.ts
+++ b/packages/kobe/src/state/repos.ts
@@ -23,6 +23,7 @@
 import { spawnSync } from "node:child_process"
 import { realpathSync } from "node:fs"
 import { kvStatePath } from "../env.ts"
+import { type ProjectIntent, type ProjectRejection, projectRejection } from "./project-eligibility.ts"
 import { type StateSnapshot, getPersistedBool, loadStateFile, patchStateFile, updateStateFile } from "./store.ts"
 
 /**
@@ -174,10 +175,35 @@ export function getDisabledEngineIds(): readonly string[] {
   return raw.filter((s): s is string => typeof s === "string" && s.trim().length > 0)
 }
 
-export type AddResult = { added: boolean; path: string; total: number }
+export type AddResult = {
+  added: boolean
+  path: string
+  total: number
+  /** Set when the path was refused — see {@link projectRejection}. `added`
+   *  is false and nothing was written. */
+  rejected?: ProjectRejection
+}
+
+export interface AddSavedRepoOpts {
+  /** How the path was chosen — see {@link ProjectIntent}. Defaults to
+   *  `"explicit"`: every production caller reaches here from a user naming
+   *  the repo (`rove add`, the new-task dialog, a quick-fork). */
+  readonly intent?: ProjectIntent
+  /**
+   * Write the entry without consulting the admission gate.
+   *
+   * ONLY for exercising the persistence mechanics themselves — atomic
+   * rename, sibling-key preservation, list ordering — where the path is an
+   * arbitrary stand-in (`/repos/alpha`) and its eligibility is beside the
+   * point. Production code must never pass this: the whole reason the gate
+   * moved inside this function is that callers cannot be trusted to
+   * remember it.
+   */
+  readonly skipGate?: boolean
+}
 
 /**
- * Append `absPath` to `savedRepos` if not already present.
+ * Append `absPath` to `savedRepos` if it is eligible and not already present.
  * Returns whether the entry was newly added and the resulting list size.
  *
  * The input is resolved to its git toplevel before storage (see
@@ -185,17 +211,24 @@ export type AddResult = { added: boolean; path: string; total: number }
  * stores the repo root, not the subdir. The returned `path` is the
  * normalized form so callers report what was actually saved.
  *
- * Deliberately does NOT validate `absPath` is a real git repo — this is a
- * pure state mutation callers may exercise on synthetic paths in tests.
- * Callers that take a path from an untrusted source (bare-`kobe` cwd,
- * `kobe add` CLI arg) must check {@link isGitRepo} themselves first; see
- * `kobe add`'s guard in `cli/index.ts` and `tui/direct.ts`'s `ensureRepos`.
+ * VALIDATES (changed 2026-08-31): this used to document validation as the
+ * caller's job. Of the eight call sites exactly one did it, and the other
+ * seven put test fixtures and sandbox paths into the user's project list —
+ * where nothing could remove them again. The gate now lives HERE, applied to
+ * the normalized path, so no caller can skip it by forgetting; a refusal
+ * comes back as `rejected` rather than an exception, because most callers
+ * are opportunistic ("remember this repo while doing something else") and
+ * must not fail their real work over it.
  */
-export function addSavedRepo(absPath: string): AddResult {
+export function addSavedRepo(absPath: string, opts: AddSavedRepoOpts = {}): AddResult {
   // Resolve BEFORE the transaction — `git rev-parse` (a subprocess) inside
   // the read-merge-write window would widen the race we're trying to keep
   // narrow.
   const normalized = resolveRepoRoot(absPath)
+  // Gate the RESOLVED path: a subdirectory of a rejected repo must not slip
+  // through by having an innocent-looking name of its own.
+  const rejected = opts.skipGate ? null : projectRejection(normalized, isGitRepo, opts.intent ?? "explicit")
+  if (rejected) return { added: false, path: normalized, total: getSavedRepos().length, rejected }
   let result: AddResult = { added: false, path: normalized, total: 0 }
   updateStateFile((state) => {
     const cur = readSavedRepos(state)

--- a/packages/kobe/src/state/repos.ts
+++ b/packages/kobe/src/state/repos.ts
@@ -244,6 +244,31 @@ export function addSavedRepo(absPath: string, opts: AddSavedRepoOpts = {}): AddR
 }
 
 /**
+ * Backfill `savedRepos` from the project rows that already exist.
+ *
+ * The sidebar's projects and the new-task picker's repos are meant to be the
+ * same set, but until 2026-08-31 they were written by different paths: a row
+ * minted by `createTask` on a fresh repo appeared in the sidebar while never
+ * reaching `savedRepos`. On the owner's machine that was 6 of 8 projects —
+ * visible, unpickable, and (once closing the last tab hides a project) not
+ * recoverable.
+ *
+ * `mainRepos` is the caller's list of `kind:"main"` task repos; this module
+ * cannot read the task index (the daemon owns it). Entries that fail the
+ * admission gate are skipped rather than healed — a leaked fixture row is not
+ * something to make MORE permanent. Returns the paths actually added.
+ */
+export function backfillSavedReposFromProjects(mainRepos: readonly string[]): readonly string[] {
+  const added: string[] = []
+  for (const repo of mainRepos) {
+    // `explicit`: these rows are already in the user's sidebar. The stricter
+    // tier is for paths Rove is about to infer, not ones it has been showing.
+    if (addSavedRepo(repo, { intent: "explicit" }).added) added.push(repo)
+  }
+  return added
+}
+
+/**
  * One-shot migration: rewrite the on-disk `savedRepos` list so each
  * entry is its git toplevel. Heals state files written before
  * {@link addSavedRepo} normalized at write time. Duplicates that

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -136,6 +136,14 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
       setMenu(null)
       if (row.kind === "project") {
         if (action === "newTask") deps.onAddTask?.()
+        // Forget routes to the SAME flow `d` runs (task-actions.ts sends a
+        // main row to `forgetProject` behind a confirm). The header itself is
+        // not navigable, so the row the flow needs is the project's main
+        // checkout — the one `d` would have been pressed on.
+        if (action === "forgetProject") {
+          const mainId = deps.tree.mainTaskIdOfProject(row.id)
+          if (mainId) actions.onDeleteRequest?.(mainId)
+        }
         return
       }
       const taskId = row.task.id
@@ -169,7 +177,7 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
           break
       }
     },
-    [menu, activateRow, actions, deps.onAddTask, deps.onCloseTab, deps.onNewTab],
+    [menu, activateRow, actions, deps.onAddTask, deps.onCloseTab, deps.onNewTab, deps.tree.mainTaskIdOfProject],
   )
 
   const pickCurrent = useCallback((): void => fire(menu?.actions[cursor]), [fire, menu, cursor])

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -11,10 +11,12 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { engineLaunchArgv } from "../../engine/engine-presets.ts"
 import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import type { QuickTaskResult } from "../component/quick-task-composer"
+import { useOptionalKV } from "../context/kv"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useAccessor } from "../lib/use-accessor"
 import { TerminalTabs } from "./TerminalTabs"
+import { knownTaskTabs } from "./terminal-tabs-shared"
 import { WelcomePane } from "./welcome-pane"
 
 export function ShowWorkspace(props: {
@@ -43,6 +45,10 @@ export function ShowWorkspace(props: {
 }): ReactNode {
   const { theme } = useTheme()
   const t = useT()
+  // Optional: this component renders in tests and previews with no KV
+  // provider mounted, and the empty-tabs lookup below is a refinement, not a
+  // requirement — no provider simply means "tabs unknown", which mounts.
+  const kv = useOptionalKV()
   const transcriptActivity = useAccessor(props.orchestrator.transcriptActivityStore())
   const engineTabStates = useAccessor(props.orchestrator.engineTabStatesSignal())
   const tasks = useAccessor(props.orchestrator.tasksSignal())
@@ -57,6 +63,19 @@ export function ShowWorkspace(props: {
     )
   }
   const path = props.worktree
+  // A task whose last tab you closed (owner call 2026-08-31) has KNOWN, empty
+  // tabs. Mounting TerminalTabs for it would immediately mint a replacement —
+  // its `active` tab is non-null by construction and 17 call sites downstream
+  // rely on that — so the empty state is handled by not mounting at all.
+  // `null` (never mounted since restart) is NOT empty and must still mount.
+  const known = props.task ? knownTaskTabs(kv, String(props.task.id)) : null
+  if (known && known.tabs.length === 0) {
+    return (
+      <box flexGrow={1} alignItems="center" justifyContent="center">
+        <text fg={theme.textMuted}>{t("workspace.empty.noSessions")}</text>
+      </box>
+    )
+  }
   return (
     // The terminal-in-the-middle seam (issue #16): the center column IS
     // the engine — an in-process PTY (Bun.spawn terminal) running the

--- a/packages/kobe/src/tui-react/workspace/use-tab-close.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-close.ts
@@ -6,12 +6,12 @@
  *
  * The four exits a tab has, and why they differ:
  *
- *   - `closeActive`   — ctrl+w. Refuses the last tab with a toast — except
- *     on a scratch task, where closing the last tab tears the task down
- *     (issue #42; same zero-ceremony path as the shell exiting).
+ *   - `closeActive`   — ctrl+w. Closes the last tab too (owner call
+ *     2026-08-31), leaving the task with none: its sidebar row stays and
+ *     re-opens on ⏎ / ctrl+e. On a scratch task the last tab still tears the
+ *     task down instead (issue #42) — its whole life IS that one shell.
  *   - `closeById`     — a close named from OUTSIDE the component (the sidebar
- *     tree's menu). Same semantics as ctrl+w minus the toast: the menu omits
- *     the entry when it would be refused.
+ *     tree's menu). Same semantics as ctrl+w minus the toast.
  *   - `closeExited`   — the tab's process ended. No viewport carve-out is
  *     needed: that process is already gone.
  *   - `handleActiveExit` — the policy layer above `closeExited`, deciding
@@ -47,7 +47,8 @@ export interface TabCloseDeps {
   /** One-shot-per-tab dead-on-attach resume marks, owned by the component so
    *  they survive this hook being rebuilt every render. */
   readonly resumeTriedRef: { readonly current: Set<string> }
-  /** Surface ctrl+w's refusal to close a task's only tab. */
+  /** Surface a refused close. Reachable only on a scratch task whose
+   *  teardown hook is missing — an ordinary task's last tab now closes. */
   readonly notifyCannotCloseLast: (tabId: string) => void
   /** Scratch task (issue #33): the LAST tab going away — its shell exiting
    *  OR ctrl+w on it (issue #42) — ends the task itself (the host deletes
@@ -86,9 +87,12 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
   function closeById(id: string): void {
     const current = deps.stateRef.current
     const closing = current.tabs.find((tab) => tab.id === id)
-    const { state: next, closedId } = closeTab(current, id)
-    // Refused (the task's last tab): leave the state alone. The tree's menu
-    // omits the entry in that case, so this is the defensive half.
+    // A task may be closed down to zero tabs (owner call 2026-08-31): its
+    // sidebar row stays and re-opens on ⏎ / ctrl+e. Scratch tasks keep the
+    // old shape — their last tab going away ends the task, which
+    // `closeActive` routes through `onScratchExit`.
+    const { state: next, closedId } = closeTab(current, id, { allowEmpty: deps.onScratchExit === undefined })
+    // Refused: nothing named `id`, or a scratch task's last tab.
     if (!closedId) return
     deps.updateRef.current(next)
     releaseClosedTabPtys(taskId(), closing, closedId)
@@ -97,7 +101,13 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
   function closeActive(): void {
     const current = deps.stateRef.current
     const closing = current.tabs.find((tab) => tab.id === current.activeId)
-    const { state: next, closedId } = closeActiveTab(current)
+    // Ordinary task: ctrl+w on the last tab empties it (the row stays, and
+    // re-opens on ⏎ / ctrl+e). Scratch: `closeActiveTab` still refuses, and
+    // the refusal below tears the task down — its whole life IS that shell.
+    const { state: next, closedId } =
+      deps.onScratchExit === undefined
+        ? closeTab(current, current.activeId, { allowEmpty: true })
+        : closeActiveTab(current)
     if (!closedId) {
       // Scratch task (issue #42): ctrl+w on its only tab tears down the
       // whole task — same zero-ceremony semantics (and same path) as the

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -31,6 +31,8 @@ export const en = {
     newChat: "New conversation",
     newShell: "New shell",
     newTask: "New task",
+    /** Project row: un-save the repo + drop its row. Mirrors `d` on that row. */
+    forgetProject: "Remove project",
     rename: "Rename",
     pin: "Pin",
     unpin: "Unpin",
@@ -130,6 +132,7 @@ export const zh: typeof en = {
     newChat: "新建会话",
     newShell: "新建终端",
     newTask: "新建任务",
+    forgetProject: "移除项目",
     rename: "重命名",
     pin: "置顶",
     unpin: "取消置顶",

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -12,6 +12,8 @@ export const en = {
   },
   empty: {
     selectTask: "Select a task with a worktree",
+    /** Every tab of this task was closed — the task and its worktree remain. */
+    noSessions: "No sessions here — press ⏎ or ctrl+e to start one",
   },
   /** Zero-tasks welcome panel (first launch) */
   welcome: {
@@ -88,6 +90,7 @@ export const zh: typeof en = {
   },
   empty: {
     selectTask: "请选择一个带 worktree 的任务",
+    noSessions: "这里没有会话——按 ⏎ 或 ctrl+e 开一个",
   },
   welcome: {
     title: "欢迎使用 Rove",

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -26,6 +26,10 @@ import { truncateStart } from "../../lib/truncate"
 import { fuzzyMatch } from "./fuzzy"
 import { compareRecent, repoBasename, sidebarProjectKey, sidebarProjectLabel } from "./groups"
 
+// Search lives in its own module (file-size cap) but stays part of tree-core's
+// public surface — every caller imports the tree's vocabulary from one place.
+export { filterTreeRows } from "./tree-search"
+
 /** Separator between a task id and a tab id in a tab row's id. Matches the
  *  PTY registry's key format so one parse rule covers both. */
 export const TAB_ROW_SEPARATOR = "::"
@@ -166,6 +170,32 @@ export interface TreeInput {
 }
 
 /**
+ * A project you closed down to nothing: its ONLY row is the repo's main
+ * checkout, and that checkout's last tab has been closed.
+ *
+ * Such a project is hidden from the tree (owner call 2026-08-31). Nothing is
+ * deleted — the main task and the `savedRepos` entry both stay, so the repo
+ * is still there in the new-task picker to open again. This is the whole
+ * difference from Forget (`d` on the row → `forgetProject`), which un-saves
+ * the repo: closing the last tab is a "I'm done here for now" gesture, not a
+ * "remove this from my machine" one.
+ *
+ * Deliberately narrow. It requires:
+ *   - exactly one task in the project, and that task is the `main` row, and
+ *   - its tabs are KNOWN and empty — an absent entry means "never mounted
+ *     since restart", which is every project on a fresh TUI. Hiding on that
+ *     would make the sidebar boot empty.
+ *
+ * A project with any worktree task under it always renders, even with every
+ * tab closed: those rows are how you get back to that work.
+ */
+function isClosedDownProject(tasks: readonly Task[], tabsByTask: TreeInput["tabsByTask"]): boolean {
+  const only = tasks.length === 1 ? tasks[0] : undefined
+  if (!only || only.kind !== "main") return false
+  return tabsByTask.get(only.id)?.length === 0
+}
+
+/**
  * Build the flat tree rows.
  *
  * Ordering: projects follow their MAIN task's stored order (the same rule the
@@ -279,8 +309,15 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
   // while the toast that had just named one of them said `work/api`. Same
   // helper every other surface already uses (Inbox, Kanban, work items,
   // automations) — the tree was the last holdout.
-  const projectRepos = orderedKeys.map((key) => byProject.get(key)?.repo ?? "")
-  for (const key of orderedKeys) {
+  // Projects closed down to nothing drop out of the tree entirely — header
+  // and row (see `isClosedDownProject`). Computed BEFORE the label pass so a
+  // hidden project can't influence how the visible ones disambiguate.
+  const visibleKeys = orderedKeys.filter((key) => {
+    const entry = byProject.get(key)
+    return entry ? !isClosedDownProject(entry.tasks, tabsByTask) : false
+  })
+  const projectRepos = visibleKeys.map((key) => byProject.get(key)?.repo ?? "")
+  for (const key of visibleKeys) {
     const entry = byProject.get(key)
     if (!entry) continue
     rows.push({
@@ -319,105 +356,13 @@ export function treeFlatIds(rows: readonly TreeRow[]): string[] {
   return ids
 }
 
-/** The project a row belongs to. A `dir` task's project is its directory —
+/** The project a row belongs to — exported for `tree-search`, which prunes
+ *  by the same grouping the tree builds with. A `dir` task's project is its
+ *  directory. A `dir` task's project is its directory —
  *  the same key `buildTreeRows` groups it under. */
-function ownerProjectKey(task: Task): string | null {
+export function ownerProjectKey(task: Task): string | null {
   if (task.kind === "dir" && task.scratch === true) return SCRATCH_SECTION_ID
   return sidebarProjectKey(task.repo)
-}
-
-/**
- * The fields a row's query is matched against, ONE AT A TIME (see
- * `matchesRow`) — the criterion is that what you can
- * FIND is exactly what you can SEE, so a worktree row's haystack starts from
- * the very label `worktreeRowLabel` renders it with.
- *
- * Two kinds of row were unsearchable by their own visible text before that:
- *   - a `main` row is labelled by its LIVE polled HEAD (its stored `branch` is
- *     always `""`), so searching the branch name printed on the row missed it;
- *   - a `dir` / scratch row is labelled by its tail-truncated path while its
- *     stored title is deliberately ignored as auto-generated noise — and the
- *     haystack searched precisely that ignored title and never the path.
- *
- * `liveBranch` resolves the polled HEAD for the rows that own no branch (see
- * {@link rowLiveBranchPath}); without it the label falls back to the stored
- * branch, which is what a pure unit test wants.
- */
-function rowHaystacks(row: TreeRow, liveBranch?: (task: Task) => string): readonly string[] {
-  if (row.kind === "project") return [row.label]
-  if (row.kind === "tab") return [row.tab.label]
-  const task = row.task
-  // A `dir` task's stored title is the noise the row refuses to show; it must
-  // not be findable either, or the search hits text that is nowhere on screen.
-  const title = task.kind === "dir" ? "" : task.title
-  return [worktreeRowLabel(task, { liveBranch: liveBranch?.(task) }), title, repoBasename(task.repo)]
-}
-
-/**
- * Match the query against each of a row's fields SEPARATELY, never against
- * their concatenation. `fuzzyMatch` is a subsequence test, so one joined
- * string lets a query straddle a boundary and hit a row that shows the
- * matched characters nowhere together: `feat/tree` found a `feat/chat` row by
- * spending `feat/` on the branch and `tree` on the title beside it.
- */
-function matchesRow(query: string, row: TreeRow, liveBranch?: (task: Task) => string): boolean {
-  return rowHaystacks(row, liveBranch).some((field) => field !== "" && fuzzyMatch(query, field))
-}
-
-/**
- * Prune the tree to what matches `query`, keeping every hit's ANCESTORS so a
- * match never floats free of the worktree and project it lives in.
- *
- * Match semantics per kind, chosen so one query answers all three questions
- * the tree can be asked:
- *   - project  → repo basename. A hit keeps the WHOLE subtree ("show me
- *     everything in kobe").
- *   - worktree → the row's own RENDERED label (branch, live HEAD, or path)
- *     plus its title and repo basename. A hit keeps the worktree's tabs
- *     ("that branch, and what's running in it").
- *   - tab      → the tab's label, i.e. its live OSC window title. This is the
- *     tree's own increment over the flat sidebar, which can only search task
- *     titles: it answers "which tab is running that thing".
- */
-export function filterTreeRows(
-  rows: readonly TreeRow[],
-  query: string,
-  liveBranch?: (task: Task) => string,
-): TreeRow[] {
-  const q = query.trim()
-  if (q === "") return [...rows]
-
-  // Pass 1 — rows matching on their own text, plus the ancestors each hit
-  // keeps alive.
-  const selfMatch = new Set<string>()
-  const keep = new Set<string>()
-  for (const row of rows) {
-    if (!matchesRow(q, row, liveBranch)) continue
-    selfMatch.add(row.id)
-    keep.add(row.id)
-    if (row.kind === "project") continue
-    if (row.kind === "tab") keep.add(row.task.id)
-    const project = ownerProjectKey(row.task)
-    if (project !== null) keep.add(project)
-  }
-
-  // Pass 2 — emit a row when it matched, when a descendant kept it, or when
-  // an ancestor matched outright (a project hit brings its subtree along).
-  const out: TreeRow[] = []
-  for (const row of rows) {
-    if (row.kind === "project") {
-      if (keep.has(row.id)) out.push(row)
-      continue
-    }
-    const project = ownerProjectKey(row.task)
-    const underMatchedProject = project !== null && selfMatch.has(project)
-    if (row.kind === "worktree") {
-      if (underMatchedProject || keep.has(row.id)) out.push(row)
-      continue
-    }
-    if (underMatchedProject || selfMatch.has(row.task.id) || keep.has(row.id)) out.push(row)
-  }
-  return out
 }
 
 /**

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -26,6 +26,7 @@ import type { TreeRow } from "./tree-core"
 
 export type TreeMenuAction =
   | "open"
+  | "forgetProject"
   | "closeTab"
   | "newChat"
   | "newShell"
@@ -44,9 +45,9 @@ export interface TreeMenuItem {
 }
 
 export interface TreeMenuContext {
-  /** How many tabs the row's worktree has. Closing is only offered above 1:
-   *  `closeTab` refuses to remove a task's last tab, and an entry that does
-   *  nothing is worse than no entry. */
+  /** How many tabs the row's worktree has. Closing the LAST one is allowed
+   *  now (owner call 2026-08-31) — the task keeps its row and re-opens on
+   *  ⏎ / ctrl+e — so the entry shows for any tab that exists. */
   readonly tabCount?: number
 }
 
@@ -75,7 +76,14 @@ function taskVerbs(pinned: boolean, kind: Task["kind"]): TreeMenuItem[] {
 
 export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenuItem[] {
   if (row.kind === "project") {
-    return [{ action: "newTask", labelKey: "tasks.menu.newTask" }]
+    // `d` on a project row already forgets it (task-actions.ts routes main
+    // rows to `forgetProject` behind a confirm). The menu was missing the
+    // entry, which broke this module's own rule: a row's menu is what that
+    // row's keyboard already does.
+    return [
+      { action: "newTask", labelKey: "tasks.menu.newTask" },
+      { action: "forgetProject", labelKey: "tasks.menu.forgetProject", danger: true },
+    ]
   }
   if (row.kind === "worktree") {
     return [
@@ -85,6 +93,6 @@ export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenu
     ]
   }
   const tabItems: TreeMenuItem[] = [{ action: "open", labelKey: "tasks.menu.openTab" }]
-  if ((ctx.tabCount ?? 0) > 1) tabItems.push({ action: "closeTab", labelKey: "tasks.menu.closeTab" })
+  if ((ctx.tabCount ?? 0) > 0) tabItems.push({ action: "closeTab", labelKey: "tasks.menu.closeTab" })
   return [...tabItems, ...newTabVerbs(), ...taskVerbs(row.task.pinned === true, row.task.kind)]
 }

--- a/packages/kobe/src/tui/panes/sidebar/tree-search.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-search.ts
@@ -1,0 +1,114 @@
+/**
+ * Searching the sidebar tree — pruning `buildTreeRows`' output to a query.
+ *
+ * Split from `tree-core.ts` at the file-size cap. It is a genuinely separate
+ * concern: `tree-core` decides what rows EXIST, this decides which of them
+ * survive a query, and the two share only the row shape. `filterTreeRows` is
+ * re-exported from `tree-core` so callers still import the tree's vocabulary
+ * from one place.
+ *
+ * The governing rule, and the reason the haystacks look the way they do: what
+ * you can FIND is exactly what you can SEE. A row is matched on the text it
+ * actually renders, never on a stored field the row refuses to show.
+ *
+ * Pure: no Solid, no React, no opentui.
+ */
+
+import type { Task } from "@/types/task"
+import { fuzzyMatch } from "./fuzzy"
+import { repoBasename } from "./groups"
+import { type TreeRow, ownerProjectKey, worktreeRowLabel } from "./tree-core"
+
+/**
+ * The fields a row's query is matched against, ONE AT A TIME (see
+ * `matchesRow`) — the criterion is that what you can
+ * FIND is exactly what you can SEE, so a worktree row's haystack starts from
+ * the very label `worktreeRowLabel` renders it with.
+ *
+ * Two kinds of row were unsearchable by their own visible text before that:
+ *   - a `main` row is labelled by its LIVE polled HEAD (its stored `branch` is
+ *     always `""`), so searching the branch name printed on the row missed it;
+ *   - a `dir` / scratch row is labelled by its tail-truncated path while its
+ *     stored title is deliberately ignored as auto-generated noise — and the
+ *     haystack searched precisely that ignored title and never the path.
+ *
+ * `liveBranch` resolves the polled HEAD for the rows that own no branch (see
+ * {@link rowLiveBranchPath}); without it the label falls back to the stored
+ * branch, which is what a pure unit test wants.
+ */
+function rowHaystacks(row: TreeRow, liveBranch?: (task: Task) => string): readonly string[] {
+  if (row.kind === "project") return [row.label]
+  if (row.kind === "tab") return [row.tab.label]
+  const task = row.task
+  // A `dir` task's stored title is the noise the row refuses to show; it must
+  // not be findable either, or the search hits text that is nowhere on screen.
+  const title = task.kind === "dir" ? "" : task.title
+  return [worktreeRowLabel(task, { liveBranch: liveBranch?.(task) }), title, repoBasename(task.repo)]
+}
+
+/**
+ * Match the query against each of a row's fields SEPARATELY, never against
+ * their concatenation. `fuzzyMatch` is a subsequence test, so one joined
+ * string lets a query straddle a boundary and hit a row that shows the
+ * matched characters nowhere together: `feat/tree` found a `feat/chat` row by
+ * spending `feat/` on the branch and `tree` on the title beside it.
+ */
+function matchesRow(query: string, row: TreeRow, liveBranch?: (task: Task) => string): boolean {
+  return rowHaystacks(row, liveBranch).some((field) => field !== "" && fuzzyMatch(query, field))
+}
+
+/**
+ * Prune the tree to what matches `query`, keeping every hit's ANCESTORS so a
+ * match never floats free of the worktree and project it lives in.
+ *
+ * Match semantics per kind, chosen so one query answers all three questions
+ * the tree can be asked:
+ *   - project  → repo basename. A hit keeps the WHOLE subtree ("show me
+ *     everything in kobe").
+ *   - worktree → the row's own RENDERED label (branch, live HEAD, or path)
+ *     plus its title and repo basename. A hit keeps the worktree's tabs
+ *     ("that branch, and what's running in it").
+ *   - tab      → the tab's label, i.e. its live OSC window title. This is the
+ *     tree's own increment over the flat sidebar, which can only search task
+ *     titles: it answers "which tab is running that thing".
+ */
+export function filterTreeRows(
+  rows: readonly TreeRow[],
+  query: string,
+  liveBranch?: (task: Task) => string,
+): TreeRow[] {
+  const q = query.trim()
+  if (q === "") return [...rows]
+
+  // Pass 1 — rows matching on their own text, plus the ancestors each hit
+  // keeps alive.
+  const selfMatch = new Set<string>()
+  const keep = new Set<string>()
+  for (const row of rows) {
+    if (!matchesRow(q, row, liveBranch)) continue
+    selfMatch.add(row.id)
+    keep.add(row.id)
+    if (row.kind === "project") continue
+    if (row.kind === "tab") keep.add(row.task.id)
+    const project = ownerProjectKey(row.task)
+    if (project !== null) keep.add(project)
+  }
+
+  // Pass 2 — emit a row when it matched, when a descendant kept it, or when
+  // an ancestor matched outright (a project hit brings its subtree along).
+  const out: TreeRow[] = []
+  for (const row of rows) {
+    if (row.kind === "project") {
+      if (keep.has(row.id)) out.push(row)
+      continue
+    }
+    const project = ownerProjectKey(row.task)
+    const underMatchedProject = project !== null && selfMatch.has(project)
+    if (row.kind === "worktree") {
+      if (underMatchedProject || keep.has(row.id)) out.push(row)
+      continue
+    }
+    if (underMatchedProject || selfMatch.has(row.task.id) || keep.has(row.id)) out.push(row)
+  }
+  return out
+}

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -153,12 +153,24 @@ export function openContentTab(state: TabsState, relPath: string, label: string,
  * Refuses to close the only tab; no-op (`closedId: null`) if `id` isn't
  * present.
  */
-export function closeTab(state: TabsState, id: string): { state: TabsState; closedId: string | null } {
-  if (state.tabs.length <= 1) return { state, closedId: null }
+export function closeTab(
+  state: TabsState,
+  id: string,
+  /** Allow the task's LAST tab to close, leaving `tabs` empty (owner call
+   *  2026-08-31). Off by default: `closeActive`'s scratch branch reads a
+   *  refusal as "this task is ending", so flipping this unconditionally would
+   *  turn every scratch ctrl+w into a task teardown. */
+  opts: { readonly allowEmpty?: boolean } = {},
+): { state: TabsState; closedId: string | null } {
+  if (state.tabs.length <= 1 && !opts.allowEmpty) return { state, closedId: null }
   const i = state.tabs.findIndex((t) => t.id === id)
   if (i < 0) return { state, closedId: null }
   const tabs = state.tabs.filter((t) => t.id !== id)
   if (state.activeId !== id) return { state: { ...state, tabs }, closedId: id }
+  // Emptied: keep the id of the tab that just went, so nothing downstream has
+  // to special-case an empty string. Nothing renders it — a task with no tabs
+  // is not mounted at all (show-workspace.tsx).
+  if (tabs.length === 0) return { state: { ...state, tabs, activeId: id }, closedId: id }
   const next = tabs[Math.max(0, i - 1)]
   return { state: { ...state, tabs, activeId: (next ?? tabs[0]).id }, closedId: id }
 }
@@ -291,11 +303,19 @@ export { type TabSpawn, shellCommandLine, shellIdentityInput, shellSpawn } from 
  * corrupt/empty snapshot by falling back to `initialTabs()`; re-anchors
  * `activeId` if it pointed at a tab that no longer exists.
  */
-export function rehydrateTabs(persisted: TabsState, shell: readonly string[]): TabsState {
+export function rehydrateTabs(
+  persisted: TabsState,
+  shell: readonly string[],
+  /** Keep an intentionally-empty snapshot empty (owner call 2026-08-31).
+   *  Without this a task whose last tab you closed grows one back on the next
+   *  mount, so the close never appears to take. Off by default so a CORRUPT
+   *  snapshot (the case this fallback was written for) still recovers. */
+  opts: { readonly allowEmpty?: boolean } = {},
+): TabsState {
   const tabs = persisted.tabs.map(
     (t): TerminalTab => (t.kind === "command" ? { ...t, command: shell, purpose: undefined } : t),
   )
-  if (tabs.length === 0) return initialTabs()
+  if (tabs.length === 0) return opts.allowEmpty ? persisted : initialTabs()
   const activeId = tabs.some((t) => t.id === persisted.activeId) ? persisted.activeId : tabs[0].id
   const maxOrdinal = tabs.reduce((max, t) => Math.max(max, t.ordinal), 0)
   return { tabs, activeId, nextOrdinal: Math.max(persisted.nextOrdinal, maxOrdinal + 1) }

--- a/packages/kobe/test/cli/index-add-remove-adopt.test.ts
+++ b/packages/kobe/test/cli/index-add-remove-adopt.test.ts
@@ -17,7 +17,12 @@ const fake = vi.hoisted(() => ({
   repoRootOf: {} as Record<string, string>,
   adoptable: [] as Array<{ path: string; branch: string; dirty?: boolean; kobeManaged?: boolean }>,
   discoverError: null as Error | null,
-  addSavedRepo: vi.fn((p: string) => ({ added: true, path: p, total: 1 })),
+  // Mirrors the real `addSavedRepo`, which owns the admission gate as of
+  // 2026-08-31: an ineligible path comes back `rejected` instead of being
+  // written. `rove add` turns that into its exit-1 error.
+  addSavedRepo: vi.fn((p: string) =>
+    fake.isGitRepo ? { added: true, path: p, total: 1 } : { added: false, path: p, total: 0, rejected: "notGitRepo" },
+  ),
   adoptWorktree: vi.fn(async (args: { worktreePath: string }) => ({
     id: `task-${args.worktreePath.split("/").pop()}`,
     title: "adopted",
@@ -129,9 +134,12 @@ describe("kobe add", () => {
   test("rejects a non-git path with exit 1 before polluting the picker", async () => {
     fake.isGitRepo = false
     await runCli("add", ",")
-    expect(fake.addSavedRepo).not.toHaveBeenCalled()
+    // The gate moved INSIDE addSavedRepo (state/project-eligibility.ts), so
+    // the call happens and returns a refusal — what must not happen is a
+    // saved entry, and what must happen is a non-zero exit naming the reason.
+    expect(fake.addSavedRepo).toHaveReturnedWith(expect.objectContaining({ added: false, rejected: "notGitRepo" }))
     expect(exitSpy).toHaveBeenCalledWith(1)
-    expect(stderrText()).toContain("is not a git repository")
+    expect(stderrText()).toContain("not a git repository")
   })
 
   test("rejects an unknown flag with exit 2 and the usage text", async () => {

--- a/packages/kobe/test/cli/open-dir-cmd.test.ts
+++ b/packages/kobe/test/cli/open-dir-cmd.test.ts
@@ -11,6 +11,15 @@ const mocks = vi.hoisted(() => ({
   writeLastActiveTaskId: vi.fn(),
   publishKobeTerminalTitle: vi.fn(),
   startTui: vi.fn(),
+  /** Git toplevel of the opened dir. Equal to the dir = it IS a repo root. */
+  repoRootOf: vi.fn((p: string) => p),
+  isGitRepo: vi.fn(() => false),
+  ensureMainTask: vi.fn(async (repo: string) => ({ id: 456, kind: "main", repo })),
+}))
+
+vi.mock("../../src/state/repos.ts", () => ({
+  resolveRepoRoot: mocks.repoRootOf,
+  isGitRepo: mocks.isGitRepo,
 }))
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -41,6 +50,9 @@ vi.mock("../../src/orchestrator/core.ts", () => ({
     async openDirectoryTask(args: { dir: string }) {
       return { id: 123, dir: args.dir }
     }
+    ensureMainTask(repo: string) {
+      return mocks.ensureMainTask(repo)
+    }
   },
 }))
 
@@ -62,6 +74,10 @@ beforeEach(() => {
   mocks.writeLastActiveTaskId.mockReset()
   mocks.publishKobeTerminalTitle.mockReset()
   mocks.startTui.mockReset().mockResolvedValue(undefined)
+  // Default: not a repo — the dir-task path every pre-existing test expects.
+  mocks.repoRootOf.mockReset().mockImplementation((p: string) => p)
+  mocks.isGitRepo.mockReset().mockReturnValue(false)
+  mocks.ensureMainTask.mockReset().mockImplementation(async (repo: string) => ({ id: 456, kind: "main", repo }))
 })
 
 afterEach(() => {
@@ -128,5 +144,69 @@ describe("runOpenDirectory", () => {
     expect(mocks.writeLastActiveTaskId).toHaveBeenCalledWith("123")
     expect(mocks.publishKobeTerminalTitle).toHaveBeenCalled()
     expect(mocks.startTui).toHaveBeenCalled()
+  })
+
+  describe("a git repo ROOT opens as the project (owner call 2026-08-31)", () => {
+    /** The opened dir is its own git toplevel = a repo root. */
+    function asRepoRoot(): void {
+      mocks.statSync.mockReturnValue({ isDirectory: () => true })
+      mocks.isGitRepo.mockReturnValue(true)
+      mocks.repoRootOf.mockImplementation((p: string) => p)
+    }
+
+    it("ensures the project's main row instead of a throwaway dir task", async () => {
+      asRepoRoot()
+      mocks.connectIfRunning.mockResolvedValue(null)
+
+      await runOpenDirectory("./my-repo")
+
+      // The row the sidebar shows as the PROJECT — not a `dir` task beside it.
+      expect(mocks.ensureMainTask).toHaveBeenCalledWith(expect.stringContaining("my-repo"))
+      expect(mocks.writeLastActiveTaskId).toHaveBeenCalledWith("456")
+    })
+
+    it("routes through task.ensureMain over a running daemon", async () => {
+      asRepoRoot()
+      const client = {
+        request: vi.fn().mockResolvedValue({ task: { id: "daemon-main-1" } }),
+        close: vi.fn(),
+      }
+      mocks.connectIfRunning.mockResolvedValue(client)
+
+      await runOpenDirectory("./my-repo")
+
+      expect(client.request).toHaveBeenCalledWith("task.ensureMain", {
+        repo: expect.stringContaining("my-repo"),
+      })
+      expect(client.request).toHaveBeenCalledWith("task.setActive", { taskId: "daemon-main-1" })
+      expect(client.request).not.toHaveBeenCalledWith("task.openDir", expect.anything())
+    })
+
+    it("keeps the dir task for a SUBDIRECTORY of a repo", async () => {
+      // Opening `my-repo/packages/app` must not silently re-target the whole
+      // monorepo — and must not mint a project named after a subdirectory.
+      mocks.statSync.mockReturnValue({ isDirectory: () => true })
+      mocks.isGitRepo.mockReturnValue(true)
+      mocks.repoRootOf.mockImplementation(() => "/somewhere/my-repo")
+      mocks.connectIfRunning.mockResolvedValue(null)
+
+      await runOpenDirectory("./my-repo/packages/app")
+
+      expect(mocks.ensureMainTask).not.toHaveBeenCalled()
+      expect(mocks.writeLastActiveTaskId).toHaveBeenCalledWith("123")
+    })
+
+    it("keeps the dir task for a repo at a path that cannot be a project", async () => {
+      // A real checkout inside `.dev-sandbox` — the shape that leaked.
+      mocks.statSync.mockReturnValue({ isDirectory: () => true })
+      mocks.isGitRepo.mockReturnValue(true)
+      mocks.repoRootOf.mockImplementation((p: string) => p)
+      mocks.connectIfRunning.mockResolvedValue(null)
+
+      await runOpenDirectory("/tmp/x/.dev-sandbox/fake-repo")
+
+      expect(mocks.ensureMainTask).not.toHaveBeenCalled()
+      expect(mocks.writeLastActiveTaskId).toHaveBeenCalledWith("123")
+    })
   })
 })

--- a/packages/kobe/test/core/daemon-worktree-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-worktree-adapter.test.ts
@@ -87,7 +87,10 @@ describe("daemon worktree adapter", () => {
     const malformed = await handleWorktreesRequestAdapter(new Request(url, { method: "DELETE", body: "not-json" }), url)
     expect(malformed?.status).toBe(400)
 
-    addSavedRepo(join(root, "missing"))
+    // A saved repo whose directory does not exist — the audit must fail on
+    // it. `skipGate` because the admission gate would (correctly) refuse a
+    // non-repo path, and this test needs the broken entry to EXIST.
+    addSavedRepo(join(root, "missing"), { skipGate: true })
     const failedAudit = await handleWorktreesRequestAdapter(new Request(url), url)
     expect(failedAudit?.status).toBe(500)
   })

--- a/packages/kobe/test/core/kobe-core.test.ts
+++ b/packages/kobe/test/core/kobe-core.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 const fake = vi.hoisted(() => ({
   storeHomeDirs: [] as (string | undefined)[],
+  tasks: [] as { kind?: string; repo: string }[],
   loadCalls: 0,
   disposeCalls: 0,
 }))
@@ -21,6 +22,12 @@ vi.mock("../../src/orchestrator/index/store.ts", () => ({
     }
     async load() {
       fake.loadCalls++
+    }
+    /** Boot reads the project rows to backfill `savedRepos` (see
+     *  `backfillSavedReposFromProjects`). Empty here — this file pins the
+     *  wiring, not the backfill. */
+    list() {
+      return fake.tasks
     }
   },
 }))

--- a/packages/kobe/test/orchestrator/core-mutations.test.ts
+++ b/packages/kobe/test/orchestrator/core-mutations.test.ts
@@ -347,13 +347,14 @@ describe("signals + subscription surface", () => {
       seen.push(snapshot.length)
     })
     await makeTask()
-    // createTask auto-ensures the repo's main row, so the first create
-    // lands TWO tasks (main + task).
-    expect(seen.at(-1)).toBe(2)
-    expect(orch.tasksSignal()()).toHaveLength(2)
+    // ONE task: `/repo` is a synthetic path, not a git repo, so the project
+    // row is refused (state/project-eligibility.ts). createTask still creates
+    // the task — the gate withholds the permanent project row, nothing else.
+    expect(seen.at(-1)).toBe(1)
+    expect(orch.tasksSignal()()).toHaveLength(1)
     unsub()
     await makeTask({ title: "second" })
-    expect(seen.at(-1)).toBe(2) // unsubscribed — no further notifications
+    expect(seen.at(-1)).toBe(1) // unsubscribed — no further notifications
   })
 
   it("setActiveTask publishes to activeTaskSignal and clears with null", async () => {

--- a/packages/kobe/test/orchestrator/main-task.test.ts
+++ b/packages/kobe/test/orchestrator/main-task.test.ts
@@ -219,3 +219,28 @@ describe("project admission (state/project-eligibility.ts)", () => {
     expect(found.kind).toBe("main")
   })
 })
+
+describe("a project row and a saved-repos entry are the same fact", () => {
+  test("ensureMainTask saves the repo, so the sidebar and the picker agree", async () => {
+    // They used to be written by separate paths: a row minted by createTask
+    // was a project you could SEE but not pick. Once closing the last tab
+    // hides such a project, that gap loses it with no way back.
+    expect(getSavedRepos()).not.toContain(repo)
+    await orch.ensureMainTask(repo)
+    expect(getSavedRepos()).toContain(repo)
+  })
+
+  test("createTask on a fresh repo saves it too", async () => {
+    await orch.createTask({ repo, title: "t" })
+    expect(getSavedRepos()).toContain(repo)
+  })
+
+  test("an ineligible repo is saved by neither", async () => {
+    const sandboxed = path.join(tmpRoot, ".dev-sandbox", "paired-repo")
+    const r = spawnSync("bash", [REPO_INIT, sandboxed], { encoding: "utf8" })
+    if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}`)
+    await orch.createTask({ repo: sandboxed, title: "fixture" })
+    expect(orch.listTasks().filter((t) => t.kind === "main")).toHaveLength(0)
+    expect(getSavedRepos()).not.toContain(sandboxed)
+  })
+})

--- a/packages/kobe/test/orchestrator/main-task.test.ts
+++ b/packages/kobe/test/orchestrator/main-task.test.ts
@@ -13,6 +13,7 @@ const REPO_INIT = path.resolve(__dirname, "./fixtures/repo-init.sh")
 let tmpRoot: string
 let repo: string
 let orch: Orchestrator
+let store: TaskIndexStore
 let originalHome: string | undefined
 
 beforeEach(async () => {
@@ -24,7 +25,7 @@ beforeEach(async () => {
   // tests never touch the developer's real ~/.config/rove.
   originalHome = process.env.KOBE_HOME_DIR
   process.env.KOBE_HOME_DIR = path.join(tmpRoot, "home")
-  const store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
+  store = new TaskIndexStore({ homeDir: path.join(tmpRoot, "home") })
   await store.load()
   orch = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
 })
@@ -157,5 +158,64 @@ describe("forgetProject", () => {
   test("idempotent: forgetting a never-saved repo no-ops", async () => {
     await expect(orch.forgetProject(repo)).resolves.toBeUndefined()
     expect(orch.listTasks().filter((t) => t.kind === "main")).toHaveLength(0)
+  })
+})
+
+describe("project admission (state/project-eligibility.ts)", () => {
+  test("createTask makes the task but NOT a project row for an ineligible repo", async () => {
+    // The leak this gate closes: four fixture paths became permanent sidebar
+    // projects that neither `task.delete` (refuses main rows) nor `rove
+    // remove` (refuses unsaved repos) could remove.
+    const sandboxed = path.join(tmpRoot, ".dev-sandbox", "smoke-repo")
+    const r = spawnSync("bash", [REPO_INIT, sandboxed], { encoding: "utf8" })
+    if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}`)
+
+    const task = await orch.createTask({ repo: sandboxed, title: "fixture work" })
+
+    // The task exists and is usable — the gate withholds the PROJECT row only.
+    expect(task.kind).toBe("task")
+    expect(orch.getTask(task.id)).toBeTruthy()
+    expect(orch.listTasks().filter((t) => t.kind === "main")).toHaveLength(0)
+  })
+
+  test("ensureMainTask throws for an ineligible repo, naming the reason", async () => {
+    // `rove add` / `project.ensureMain` are explicit gestures: a silent no-op
+    // would read as the command having done nothing.
+    const sandboxed = path.join(tmpRoot, ".dev-sandbox", "explicit-repo")
+    const r = spawnSync("bash", [REPO_INIT, sandboxed], { encoding: "utf8" })
+    if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}`)
+
+    await expect(orch.ensureMainTask(sandboxed)).rejects.toThrow(/sandbox or scratch/)
+    expect(orch.listTasks().filter((t) => t.kind === "main")).toHaveLength(0)
+  })
+
+  test("an ALREADY-EXISTING project row keeps working after the gate lands", async () => {
+    // The gate governs what may BECOME a project. Re-gating an existing row
+    // would punish the user for rows we created before the rule existed.
+    const sandboxed = path.join(tmpRoot, ".dev-sandbox", "legacy-repo")
+    const r = spawnSync("bash", [REPO_INIT, sandboxed], { encoding: "utf8" })
+    if (r.status !== 0) throw new Error(`repo-init.sh failed: ${r.stderr}`)
+    // Simulate the pre-gate world: a main row that already exists on disk.
+    await store.create({
+      kind: "main",
+      title: "legacy-repo",
+      repo: sandboxed,
+      branch: "",
+      worktreePath: sandboxed,
+      status: "backlog",
+      vendor: "claude",
+    })
+
+    const task = await orch.createTask({ repo: sandboxed, title: "still works" })
+    expect(task.kind).toBe("task")
+    // Still exactly one main row — found, not re-created and not refused.
+    expect(orch.listTasks().filter((t) => t.kind === "main")).toHaveLength(1)
+    // And the existing row is RETURNED, not merely left alone: the lookup has
+    // to happen BEFORE the gate. With the two reordered, an ineligible repo
+    // returns null here and every caller that relies on the row (the repo
+    // path `createTask` normalizes through it) silently loses it.
+    const found = await orch.ensureMainTask(sandboxed)
+    expect(found.repo).toBe(sandboxed)
+    expect(found.kind).toBe("main")
   })
 })

--- a/packages/kobe/test/render/show-workspace-empty.test.tsx
+++ b/packages/kobe/test/render/show-workspace-empty.test.tsx
@@ -1,14 +1,22 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The center column's two EMPTY states. Which one renders is derived from the
- * orchestrator's task list: zero tasks teaches (the welcome panel), anything
- * else keeps the terse "select a task" line, so an existing user never gets
- * the onboarding copy back.
+ * The center column's EMPTY states.
+ *
+ * Two are derived from the orchestrator's task list: zero tasks teaches (the
+ * welcome panel), anything else keeps the terse "select a task" line, so an
+ * existing user never gets the onboarding copy back.
+ *
+ * The third is per-task: a task whose tabs are KNOWN and empty (you closed the
+ * last one) renders a placeholder INSTEAD of mounting TerminalTabs. That
+ * component's `active` tab is non-null by construction, so mounting it for an
+ * empty task would immediately mint a replacement and the close would never
+ * appear to take.
  */
 
 import { describe, expect, it } from "bun:test"
 import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
 import { ShowWorkspace } from "../../src/tui-react/workspace/show-workspace"
+import { tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
 import type { Task } from "../../src/types/task"
 import { act, renderComponent } from "./harness"
 
@@ -56,5 +64,40 @@ describe("ShowWorkspace empty states", () => {
 
   it("keeps the terse placeholder once a live task exists", async () => {
     expect(await frameFor(ONE_TASK)).not.toContain("Welcome to Rove")
+  })
+})
+
+/** A selected task with a worktree — the shape that normally mounts tabs. */
+const SELECTED = { id: "t1", repo: "/repos/rove", kind: "task" } as unknown as Task
+
+const frameForTask = async (task: Task): Promise<string> => {
+  const { frame } = await renderComponent(<ShowWorkspace {...props(ONE_TASK)} task={task} worktree="/wt/t1" />)
+  await act(async () => {})
+  return await frame()
+}
+
+describe("a task whose last tab was closed", () => {
+  it("renders the no-sessions placeholder instead of mounting tabs", async () => {
+    tabsByTask.clear()
+    // KNOWN and empty: the user closed the last tab.
+    tabsByTask.set("t1", { tabs: [], activeId: "tab-1", nextOrdinal: 2 })
+    expect(await frameForTask(SELECTED)).toContain("No sessions here")
+  })
+
+  it("mounts normally when the tabs are merely UNKNOWN", async () => {
+    // Absent from the map = never mounted since restart, which is every task
+    // on a cold boot. Treating that as empty would leave the workspace blank.
+    tabsByTask.clear()
+    expect(await frameForTask(SELECTED)).not.toContain("No sessions here")
+  })
+
+  it("mounts normally while a tab is open", async () => {
+    tabsByTask.clear()
+    tabsByTask.set("t1", {
+      tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    })
+    expect(await frameForTask(SELECTED)).not.toContain("No sessions here")
   })
 })

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -129,7 +129,11 @@ test("right-click on a project header offers the project's own actions", async (
 
   const after = await frame()
   expect(after).toContain("New task")
+  // Forget mirrors `d` on the project's row (task-actions.ts sends a main row
+  // to `forgetProject` behind a confirm) — the menu was missing it.
+  expect(after).toContain("Remove project")
   // A project is not a checkout — no per-task verbs on its header.
+  expect(after).not.toContain("Rename")
   expect(after).not.toContain("Delete")
 })
 
@@ -224,9 +228,9 @@ test("a tab row's menu opens a new shell in its worktree", async () => {
   expect(asked).toEqual([["a", "shell"]])
 })
 
-test("a worktree's LAST tab offers no close", async () => {
-  // The refusal lives in closeTab core; the menu just doesn't offer what
-  // would be refused.
+test("a worktree's LAST tab DOES offer a close (owner call 2026-08-31)", async () => {
+  // Closing it leaves the task with no sessions — the row stays and re-opens
+  // on ⏎ / ctrl+e — so there is nothing for the menu to withhold.
   tabsByTask.clear()
   seedTabs("a", ["tab-1"])
   const { frame, mockMouse } = await renderComponent(tree(), { width: 40, height: 24 })
@@ -236,7 +240,7 @@ test("a worktree's LAST tab offers no close", async () => {
 
   const after = await frame()
   expect(after).toContain("Open tab")
-  expect(after).not.toContain("Close tab")
+  expect(after).toContain("Close tab")
 })
 
 /** Screen position of the first occurrence of `needle`. */

--- a/packages/kobe/test/state/project-eligibility.test.ts
+++ b/packages/kobe/test/state/project-eligibility.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The project-admission gate. The rejection cases are the four shapes that
+ * actually leaked onto the owner's machine (12 sidebar projects behind 2
+ * saved repos); the acceptance cases are the paths that must keep working.
+ */
+
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { pathRejection, projectRejection, rejectionReason } from "@/state/project-eligibility"
+import { isGitRepo } from "@/state/repos"
+import { describe, expect, it } from "vitest"
+
+/** The repo this test runs in — a real checkout at a durable path. */
+const REPO_ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "")
+
+describe("pathRejection", () => {
+  it("rejects the four shapes that leaked into the real sidebar", () => {
+    expect(pathRejection("/private/tmp/rove-fixture-probe/repo")).toBe("temporary")
+    expect(pathRejection("/tmp/rove-i18n-repo-62375")).toBe("temporary")
+    expect(pathRejection("/Users/x/i/kobe/packages/kobe/.dev-sandbox/named/ex-gif/home/smoke-repo")).toBe(
+      "insideSandbox",
+    )
+    expect(pathRejection(join(homedir(), ".rove/worktrees/kobe-0aff/manatee/fixture"))).toBe("roveInternal")
+  })
+
+  it("rejects a .scratch checkout wherever it sits", () => {
+    expect(pathRejection("/Users/x/i/kobe/.scratch/opentui-visual-5401/fixture-repo")).toBe("insideSandbox")
+  })
+
+  it("rejects relative and empty paths", () => {
+    expect(pathRejection("")).toBe("notAbsolute")
+    expect(pathRejection("./relative")).toBe("notAbsolute")
+  })
+
+  it("passes remote project keys through untouched", () => {
+    // Their eligibility was settled by the remote-add flow; none of the local
+    // path rules can speak about an ssh:// key.
+    expect(pathRejection("ssh://user@host/srv/repo")).toBeNull()
+  })
+
+  it("accepts an ordinary checkout on path shape alone", () => {
+    expect(pathRejection(REPO_ROOT)).toBeNull()
+    expect(pathRejection("/Users/jacksonc/i/codefox")).toBeNull()
+  })
+
+  it("answers without touching the filesystem", () => {
+    // The cleanup scan runs over records whose directory is already gone. A
+    // vanished fixture must still report WHY it never belonged, rather than
+    // reading as a user's repo that merely moved.
+    const gone = "/tmp/rove-i18n-repo-62375/deleted/long/ago"
+    expect(pathRejection(gone)).toBe("temporary")
+  })
+})
+
+describe("projectRejection", () => {
+  it("adds the git check on top of path shape", () => {
+    // A durable-looking path that path shape alone accepts — so the injected
+    // check is the only thing that can reject it. No fs needed: neither
+    // function touches the disk.
+    const durable = join(homedir(), "Documents", "not-a-repo")
+    expect(pathRejection(durable)).toBeNull()
+    expect(projectRejection(durable, () => false)).toBe("notGitRepo")
+    expect(projectRejection(durable, () => true)).toBeNull()
+  })
+
+  it("reports the structural reason even when the git check would also fail", () => {
+    // Order matters: a deleted /tmp fixture is `temporary`, not `notGitRepo`.
+    expect(projectRejection("/tmp/vanished", () => false)).toBe("temporary")
+  })
+
+  it("skips the git check for remote keys", () => {
+    // `isGitRepo` returns false for an ssh:// key by design — consulting it
+    // would reject every remote project.
+    expect(projectRejection("ssh://user@host/srv/repo", () => false)).toBeNull()
+  })
+
+  it("accepts this repo with the real git check wired in", () => {
+    // The end-to-end shape `addSavedRepo` and `ensureIfEligible` both use.
+    expect(projectRejection(REPO_ROOT, isGitRepo)).toBeNull()
+  })
+
+  it("skips the fs question entirely when no checker is passed", () => {
+    // Bulk scans omit it to save one `git` subprocess per row, so a
+    // durable-looking path that is NOT a repo comes back eligible.
+    expect(projectRejection("/Users/x/not-a-repo-at-all")).toBeNull()
+  })
+})
+
+describe("rejectionReason", () => {
+  it("has a sentence for every rejection", () => {
+    // A missing case would surface to the user as `undefined` in a CLI error.
+    for (const r of ["notAbsolute", "notGitRepo", "temporary", "roveInternal", "insideSandbox"] as const) {
+      expect(rejectionReason(r)).toMatch(/\w/)
+    }
+  })
+})

--- a/packages/kobe/test/state/repos-roots.test.ts
+++ b/packages/kobe/test/state/repos-roots.test.ts
@@ -143,7 +143,9 @@ describe("normalizeSavedRepos", () => {
   })
 
   test("no-op when every entry is already canonical (file left untouched)", () => {
-    addSavedRepo("/already/canonical")
+    // Synthetic stand-in: what's pinned is that normalization leaves an
+    // already-canonical file untouched, not whether the path is admissible.
+    addSavedRepo("/already/canonical", { skipGate: true })
     const before = fs.statSync(statePath()).mtimeMs
     normalizeSavedRepos()
     expect(getSavedRepos()).toEqual(["/already/canonical"])

--- a/packages/kobe/test/state/repos.test.ts
+++ b/packages/kobe/test/state/repos.test.ts
@@ -33,6 +33,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import {
   addRemoteRepo,
   addSavedRepo,
+  backfillSavedReposFromProjects,
   getCustomEngineIds,
   getRemoteRepoConfig,
   getSavedRepos,
@@ -303,5 +304,39 @@ describe("addSavedRepo admission gate", () => {
     const plain = path.join(tmpHome, "not-a-repo")
     fs.mkdirSync(plain, { recursive: true })
     expect(addSavedRepo(plain).path).toBe(plain)
+  })
+})
+
+describe("backfillSavedReposFromProjects", () => {
+  function initRepo(name: string): string {
+    const dir = path.join(tmpHome, name)
+    fs.mkdirSync(dir, { recursive: true })
+    spawnSync("git", ["init", "-q"], { cwd: dir, encoding: "utf8" })
+    return dir
+  }
+
+  test("adds project rows that never reached savedRepos", () => {
+    // The owner's machine: 8 sidebar projects, 2 saved repos.
+    const a = initRepo("proj-a")
+    const b = initRepo("proj-b")
+    addSavedRepo(a)
+    expect(getSavedRepos()).toEqual([a])
+
+    expect(backfillSavedReposFromProjects([a, b])).toEqual([b])
+    expect(getSavedRepos()).toEqual([a, b])
+  })
+
+  test("is idempotent — a second pass adds nothing", () => {
+    const a = initRepo("proj-a")
+    backfillSavedReposFromProjects([a])
+    expect(backfillSavedReposFromProjects([a])).toEqual([])
+    expect(getSavedRepos()).toEqual([a])
+  })
+
+  test("skips a row that fails the admission gate", () => {
+    // A leaked fixture row is not something to make MORE permanent.
+    const leaked = initRepo(path.join(".dev-sandbox", "smoke-repo"))
+    expect(backfillSavedReposFromProjects([leaked])).toEqual([])
+    expect(getSavedRepos()).toEqual([])
   })
 })

--- a/packages/kobe/test/state/repos.test.ts
+++ b/packages/kobe/test/state/repos.test.ts
@@ -17,6 +17,12 @@
  *     wipe the user's `lastSelectedTaskId` / `activeTheme` / etc.
  *   - `addSavedRepo()` preserves order of existing entries.
  *   - The total in `AddResult` matches the post-write list size.
+ *
+ * The persistence tests pass `{ skipGate: true }` and synthetic paths
+ * (`/repos/alpha`): what they pin is the WRITE — atomic rename, sibling-key
+ * preservation, ordering — and the path is an arbitrary stand-in. Admission
+ * itself is covered in `test/state/project-eligibility.test.ts`, plus the
+ * gated cases at the bottom of this file.
  */
 
 import { spawnSync } from "node:child_process"
@@ -142,23 +148,23 @@ describe("getSavedRepos", () => {
 describe("addSavedRepo", () => {
   test("creates the file + directory on first write and reports added=true", () => {
     expect(fs.existsSync(statePath())).toBe(false)
-    const r = addSavedRepo("/repos/alpha")
+    const r = addSavedRepo("/repos/alpha", { skipGate: true })
     expect(r).toEqual({ added: true, path: "/repos/alpha", total: 1 })
     expect(getSavedRepos()).toEqual(["/repos/alpha"])
     expect(fs.existsSync(statePath())).toBe(true)
   })
 
   test("is idempotent — re-adding the same path returns added=false and doesn't grow", () => {
-    addSavedRepo("/repos/alpha")
-    const r = addSavedRepo("/repos/alpha")
+    addSavedRepo("/repos/alpha", { skipGate: true })
+    const r = addSavedRepo("/repos/alpha", { skipGate: true })
     expect(r).toEqual({ added: false, path: "/repos/alpha", total: 1 })
     expect(getSavedRepos()).toEqual(["/repos/alpha"])
   })
 
   test("appends to existing entries in insertion order", () => {
-    addSavedRepo("/repos/alpha")
-    addSavedRepo("/repos/beta")
-    addSavedRepo("/repos/gamma")
+    addSavedRepo("/repos/alpha", { skipGate: true })
+    addSavedRepo("/repos/beta", { skipGate: true })
+    addSavedRepo("/repos/gamma", { skipGate: true })
     expect(getSavedRepos()).toEqual(["/repos/alpha", "/repos/beta", "/repos/gamma"])
   })
 
@@ -175,7 +181,7 @@ describe("addSavedRepo", () => {
       "utf8",
     )
 
-    addSavedRepo("/new")
+    addSavedRepo("/new", { skipGate: true })
 
     const after = JSON.parse(fs.readFileSync(p, "utf8")) as Record<string, unknown>
     expect(after.activeTheme).toBe("dracula")
@@ -184,7 +190,7 @@ describe("addSavedRepo", () => {
   })
 
   test("write is atomic — no leftover .tmp after a successful add", () => {
-    addSavedRepo("/repos/alpha")
+    addSavedRepo("/repos/alpha", { skipGate: true })
     const dir = path.dirname(statePath())
     const entries = fs.readdirSync(dir)
     expect(entries).toContain("state.json")
@@ -194,15 +200,15 @@ describe("addSavedRepo", () => {
 
 describe("removeSavedRepo (KOB-15)", () => {
   test("removes an entry and reports removed=true with the new total", () => {
-    addSavedRepo("/repos/alpha")
-    addSavedRepo("/repos/beta")
+    addSavedRepo("/repos/alpha", { skipGate: true })
+    addSavedRepo("/repos/beta", { skipGate: true })
     const r = removeSavedRepo("/repos/alpha")
     expect(r).toEqual({ removed: true, path: "/repos/alpha", total: 1 })
     expect(getSavedRepos()).toEqual(["/repos/beta"])
   })
 
   test("is idempotent — removing a path that's not present returns removed=false", () => {
-    addSavedRepo("/repos/alpha")
+    addSavedRepo("/repos/alpha", { skipGate: true })
     const r = removeSavedRepo("/repos/never-added")
     expect(r).toEqual({ removed: false, path: "/repos/never-added", total: 1 })
     expect(getSavedRepos()).toEqual(["/repos/alpha"])
@@ -228,17 +234,17 @@ describe("removeSavedRepo (KOB-15)", () => {
   })
 
   test("returns total=0 when removing the last entry", () => {
-    addSavedRepo("/only")
+    addSavedRepo("/only", { skipGate: true })
     const r = removeSavedRepo("/only")
     expect(r).toEqual({ removed: true, path: "/only", total: 0 })
     expect(getSavedRepos()).toEqual([])
   })
 
   test("preserves order of remaining entries", () => {
-    addSavedRepo("/a")
-    addSavedRepo("/b")
-    addSavedRepo("/c")
-    addSavedRepo("/d")
+    addSavedRepo("/a", { skipGate: true })
+    addSavedRepo("/b", { skipGate: true })
+    addSavedRepo("/c", { skipGate: true })
+    addSavedRepo("/d", { skipGate: true })
     removeSavedRepo("/b")
     expect(getSavedRepos()).toEqual(["/a", "/c", "/d"])
   })
@@ -251,5 +257,51 @@ describe("removeSavedRepo (KOB-15)", () => {
     expect(r.removed).toBe(true)
     expect(getSavedRepos()).not.toContain(key)
     expect(getRemoteRepoConfig(key)).toBeNull()
+  })
+})
+
+describe("addSavedRepo admission gate", () => {
+  /** A real git repo under the per-test tmpdir. */
+  function initRepo(name: string): string {
+    const dir = path.join(tmpHome, name)
+    fs.mkdirSync(dir, { recursive: true })
+    spawnSync("git", ["init", "-q"], { cwd: dir, encoding: "utf8" })
+    return dir
+  }
+
+  test("refuses a path that is not a git repo, and writes nothing", () => {
+    const plain = path.join(tmpHome, "just-a-folder")
+    fs.mkdirSync(plain, { recursive: true })
+    const r = addSavedRepo(plain)
+    expect(r.added).toBe(false)
+    expect(r.rejected).toBe("notGitRepo")
+    expect(getSavedRepos()).toEqual([])
+  })
+
+  test("refuses a repo inside a .dev-sandbox, however real the checkout is", () => {
+    // The exact shape that leaked: a genuine git repo, at a path that cannot
+    // be anyone's project. Without the gate this is indistinguishable from a
+    // user's own checkout.
+    const sandboxed = initRepo(path.join(".dev-sandbox", "named", "smoke-repo"))
+    const r = addSavedRepo(sandboxed)
+    expect(r.added).toBe(false)
+    expect(r.rejected).toBe("insideSandbox")
+    expect(getSavedRepos()).toEqual([])
+  })
+
+  test("accepts an ordinary repo", () => {
+    const repo = initRepo("my-project")
+    const r = addSavedRepo(repo)
+    expect(r.rejected).toBeUndefined()
+    expect(r.added).toBe(true)
+    expect(getSavedRepos()).toEqual([repo])
+  })
+
+  test("a rejection still reports the normalized path, so callers can name it", () => {
+    // `rove add` prints this path in its error, and `createTaskFlow` uses it
+    // as the task's repo — a rejection must not degrade it to the raw input.
+    const plain = path.join(tmpHome, "not-a-repo")
+    fs.mkdirSync(plain, { recursive: true })
+    expect(addSavedRepo(plain).path).toBe(plain)
   })
 })

--- a/packages/kobe/test/tui/sidebar-tree-core.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-core.test.ts
@@ -352,3 +352,74 @@ describe("worktreeRowLabel (issue #42)", () => {
     expect(worktreeRowLabel(bare)).toBe("scratch")
   })
 })
+
+describe("a project closed down to nothing (owner call 2026-08-31)", () => {
+  const mainOf = (repo: string, id = "m") => task(id, { kind: "main", repo, title: repo.split("/").pop() ?? repo })
+
+  test("hides the project when its only row is main and its tabs are closed", () => {
+    const out = rows({
+      tasks: [mainOf("/repos/codefox")],
+      // KNOWN and empty — the user closed the last tab.
+      tabsByTask: new Map([["m", []]]),
+    })
+    expect(out).toEqual([])
+  })
+
+  test("still shows it when its tabs are merely UNKNOWN (fresh TUI)", () => {
+    // Absent from the map = never mounted since restart, which is every
+    // project on a cold boot. Hiding on that would make the sidebar start
+    // empty — the difference this whole rule turns on.
+    const out = rows({ tasks: [mainOf("/repos/codefox")], tabsByTask: new Map() })
+    expect(out.map((r) => r.kind)).toEqual(["project", "worktree"])
+  })
+
+  test("still shows it while any tab is open", () => {
+    const out = rows({
+      tasks: [mainOf("/repos/codefox")],
+      tabsByTask: new Map([["m", [tab("t1")]]]),
+    })
+    expect(out.map((r) => r.kind)).toEqual(["project", "worktree", "tab"])
+  })
+
+  test("keeps a project that has worktree tasks, even with every tab closed", () => {
+    // The worktree rows are how you get back to that work — losing them would
+    // strand the branches. Only the main-only case hides.
+    const out = rows({
+      tasks: [mainOf("/repos/kobe"), task("a", { repo: "/repos/kobe" })],
+      tabsByTask: new Map([
+        ["m", []],
+        ["a", []],
+      ]),
+    })
+    expect(out.map((r) => r.kind)).toEqual(["project", "worktree", "worktree"])
+  })
+
+  test("hiding one project does not disturb the others", () => {
+    const out = rows({
+      tasks: [mainOf("/repos/codefox", "m1"), mainOf("/repos/kobe", "m2")],
+      tabsByTask: new Map([
+        ["m1", []],
+        ["m2", [tab("t1")]],
+      ]),
+    })
+    expect(out.filter((r) => r.kind === "project").map((r) => (r as { label: string }).label)).toEqual(["kobe"])
+  })
+
+  test("keeps a project whose ONLY row is a worktree task with no tabs", () => {
+    // A main-less project (the tree supports these — "then main-less projects
+    // in first-seen order"). Hiding it would strand the task: no main row
+    // means nothing to re-open it from.
+    const out = rows({
+      tasks: [task("a", { repo: "/repos/orphan" })],
+      tabsByTask: new Map([["a", []]]),
+    })
+    expect(out.map((r) => r.kind)).toEqual(["project", "worktree"])
+  })
+
+  test("a hidden project is not navigable", () => {
+    // The cursor indexes flatIds; leaving a hidden project's row in there
+    // would let j/k land on something the user cannot see.
+    const out = rows({ tasks: [mainOf("/repos/codefox")], tabsByTask: new Map([["m", []]]) })
+    expect(treeFlatIds(out)).toEqual([])
+  })
+})

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -35,8 +35,11 @@ const tabRow: TreeRow = { kind: "tab", id: "a::tab-2", task: task(), tab: { id: 
 const actions = (row: TreeRow, ctx = {}) => treeMenuItems(row, ctx).map((item) => item.action)
 
 describe("treeMenuItems", () => {
-  test("a project header only offers New task", () => {
-    expect(actions(projectRow)).toEqual(["newTask"])
+  test("a project header offers New task and Remove project", () => {
+    // Both mirror a chord the row already answers to — `d` on a project row
+    // has always routed to `forgetProject` behind a confirm; the menu was
+    // simply missing it.
+    expect(actions(projectRow)).toEqual(["newTask", "forgetProject"])
   })
 
   test("a worktree row opens, adds a session, then the task verbs", () => {
@@ -83,11 +86,18 @@ describe("treeMenuItems", () => {
     ])
   })
 
-  test("the LAST tab is not offered a close (closeTab would refuse it)", () => {
-    expect(actions(tabRow, { tabCount: 1 })).not.toContain("closeTab")
-    // …but it can still start a new session, which is what makes the refusal
-    // reachable in the first place.
+  test("the LAST tab IS offered a close (owner call 2026-08-31)", () => {
+    // Closing it leaves the task with no sessions; its sidebar row stays and
+    // re-opens on ⏎ / ctrl+e. The entry used to be withheld because closeTab
+    // refused the last tab, which is no longer true.
+    expect(actions(tabRow, { tabCount: 1 })).toContain("closeTab")
     expect(actions(tabRow, { tabCount: 1 })).toContain("newChat")
+  })
+
+  test("a tab row with NO known tabs is offered no close", () => {
+    // `tabCount` 0 means the count could not be read; offering an action that
+    // names nothing is the entry-that-does-nothing this module rules out.
+    expect(actions(tabRow, { tabCount: 0 })).not.toContain("closeTab")
   })
 
   test("pin reads the task's own state", () => {

--- a/packages/kobe/test/tui/tab-close-scratch.test.ts
+++ b/packages/kobe/test/tui/tab-close-scratch.test.ts
@@ -1,7 +1,8 @@
 /**
- * ctrl+w on a task's ONLY tab (issue #42): a scratch task tears down the
- * whole task (same zero-ceremony path as its shell exiting — `onScratchExit`),
- * while an ordinary task keeps the "cannot close the only tab" refusal.
+ * ctrl+w on a task's ONLY tab: a scratch task tears down the whole task
+ * (issue #42 — same zero-ceremony path as its shell exiting,
+ * `onScratchExit`), while an ordinary task is simply left with no tabs
+ * (owner call 2026-08-31): the row stays and re-opens on ⏎ / ctrl+e.
  */
 
 import { describe, expect, it, vi } from "vitest"
@@ -16,7 +17,13 @@ vi.mock("../../src/tui/panes/terminal/registry.ts", () => ({
 }))
 
 import { useTabClose } from "../../src/tui-react/workspace/use-tab-close.ts"
-import { type TabsState, type TerminalTab, initialShellTabs } from "../../src/tui/workspace/terminal-tabs-core.ts"
+import {
+  type TabsState,
+  type TerminalTab,
+  closeTab,
+  initialShellTabs,
+  rehydrateTabs,
+} from "../../src/tui/workspace/terminal-tabs-core.ts"
 
 function harness(state: TabsState, opts: { scratch?: boolean } = {}) {
   const calls = { scratchExit: 0, cannotCloseLast: 0, updates: [] as TabsState[] }
@@ -52,10 +59,40 @@ describe("closeActive on the only tab", () => {
     expect(calls.updates).toHaveLength(0)
   })
 
-  it("ordinary task: still refuses with the toast", () => {
+  it("ordinary task: closes it, leaving the task with no tabs", () => {
+    // Owner call 2026-08-31. The task and its worktree stay — its sidebar row
+    // remains and re-opens on ⏎ / ctrl+e — so there is nothing to warn about.
     const { close, calls } = harness(initialShellTabs("/bin/zsh"))
     close.closeActive()
-    expect(calls.cannotCloseLast).toBe(1)
-    expect(calls.updates).toHaveLength(0)
+    expect(calls.cannotCloseLast).toBe(0)
+    expect(calls.updates).toHaveLength(1)
+    expect(calls.updates[0]?.tabs).toEqual([])
+  })
+})
+
+describe("closing down to zero tabs (owner call 2026-08-31)", () => {
+  it("an emptied task keeps its snapshot empty across a remount", () => {
+    // The close only appears to take if rehydration honours it. Without
+    // `allowEmpty` the task grows a fresh tab back on the next mount, and
+    // ctrl+w reads as a no-op.
+    const emptied: TabsState = { tabs: [], activeId: "tab-1", nextOrdinal: 2 }
+    expect(rehydrateTabs(emptied, ["/bin/zsh"], { allowEmpty: true }).tabs).toEqual([])
+  })
+
+  it("a CORRUPT snapshot still recovers a tab", () => {
+    // Same empty shape, opposite intent: this is the case the fallback was
+    // written for, so the default must keep healing it.
+    const corrupt: TabsState = { tabs: [], activeId: "tab-1", nextOrdinal: 2 }
+    expect(rehydrateTabs(corrupt, ["/bin/zsh"]).tabs).toHaveLength(1)
+  })
+
+  it("closeTab refuses to empty a task unless asked", () => {
+    const one: TabsState = {
+      tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    }
+    expect(closeTab(one, "tab-1").closedId).toBeNull()
+    expect(closeTab(one, "tab-1", { allowEmpty: true }).closedId).toBe("tab-1")
   })
 })


### PR DESCRIPTION
Two commits. The first closes a leak; the second builds the feature that leak was blocking.

## Why now

The sidebar showed 12 projects on a machine whose `savedRepos` held 2. Four of them were test fixtures — `/tmp/rove-fixture-probe/repo`, a repo inside `.dev-sandbox`, a checkout nested in `~/.rove/worktrees` — and none could be removed: `task.delete` refuses a main row ("remove the repo from saved repos instead") while `rove remove` refuses a repo that was never in `savedRepos`, which is exactly the set they belonged to.

`createTask`, worktree adopt, the issue-chat flow and quick-fork all called `ensureMainTask` without asking whether the path could be a project. `addSavedRepo` documented validation as the caller's job; of its eight call sites, one did it.

## 1 — the admission gate

One predicate (`state/project-eligibility.ts`), applied inside `addSavedRepo` and `MainTaskCoordinator` so no caller can skip it by forgetting.

It is stricter about a project Rove **inferred** than one you **named**. Every leaked row was inferred; `rove add /tmp/scratch-repo` is a deliberate, reversible choice — and banning it would also ban every test that builds its fixture repo there. An ineligible repo still gets its task, it just stops leaving a permanent sidebar row behind; `buildTreeRows` groups a main-less task under a header derived from its own repo, so nothing becomes unreachable.

`rove .` on a git repo's root now opens that repo **as** the project, instead of a throwaway dir session beside the project row it would later be promoted into. A subdirectory, a plain folder, or a repo at an ineligible path keeps the old behaviour.

`rove add` also reports a refusal instead of printing "already saved" for a path it declined to store.

## 2 — closing the last tab

`ctrl+w` refused a task's only tab with a toast. It now closes it: the task keeps its row and worktree, and `⏎` / `ctrl+e` starts a session there again. Scratch tasks are unchanged — their last tab still ends the task, since the shell *is* the session.

A project whose only row is its main checkout leaves the sidebar once that checkout's last tab closes. Nothing is deleted — the repo stays in the new-task picker, and opening it there brings the project back. Deliberately narrower than Forget (`d` on the row), which un-saves the repo. A project with worktree tasks under it always stays visible, however many tabs are closed: those rows are how you get back to that work.

**Sidebar projects and the new-task picker are now the same set.** A row minted by `createTask` never reached `savedRepos`, so it was a project you could see but not pick — 6 of 8 on the reporting machine. Without fixing that, hiding a project would lose it with no way back. Both are written together now, and existing rows backfill on daemon start.

The project row's right-click menu gained "Remove project", which `d` on that row has always done — the menu was breaking its own rule that a row's menu is what that row's keyboard already does.

## Verification

- typecheck, root lint, i18n (710 keys × 2 locales)
- 3980 vitest + 323 render + 660 socket, all green
- Mutation-verified at 6 sites; each trips a test that names the behaviour. One (`kind !== "main"`) survived the first round — nothing pinned that a main-less project keeps rendering — so that test was added.
- Live-verified against a real daemon, not just tests: a sandboxed repo refused with exit 1, a real repo accepted, `createTask` on a sandboxed repo producing a task but no project row, and `rove .` routing correctly for repo-root / subdirectory / ineligible-path. That last one **caught a real bug** — `rove .` was using the strict tier, which only misbehaves for a repo under `/tmp`, so every test passed. Fixed, with four tests added.
- `tree-core.ts` crossed the 500-line cap, so its search half moved to `tree-search.ts` (432 / 114), re-exported so callers are unchanged.

## Note

The reporting machine's four leaked rows were cleaned up separately (7 index records; no files on disk touched, `tasks.json` backed up first).
