### PR TITLE
fix: keep raw numstat paths that begin with a literal double-quote

### DIFF
--- a/.changeset/numstat-raw-leading-quote.md
+++ b/.changeset/numstat-raw-leading-quote.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A changed file whose name begins with a literal double-quote now keeps its +/- line counts in the file tree and sidebar instead of silently losing them. `git diff --numstat -z` emits raw paths, so such a name was being mistaken for a quoted one and mangled, orphaning its counts from the status row.

--- a/packages/kobe/src/lib/git-parsers.ts
+++ b/packages/kobe/src/lib/git-parsers.ts
@@ -240,10 +240,14 @@ function parseCount(token: string): number | null {
  *   - non-rename: `<added>\t<deleted>\t<path>\0`
  *   - rename:     `<added>\t<deleted>\t\0<old>\0<new>\0`
  *
- * Binary files use `-` for the counts (→ `null`). Paths are unquoted so the
- * counts key by the same canonical path the porcelain `R` row reports. With
- * `-z`, git emits raw paths (no C-quoting), but `unquoteGitPath` is kept as a
- * harmless no-op for extra robustness. Blank / malformed fields are skipped.
+ * Binary files use `-` for the counts (→ `null`). Because `-z` disables git's
+ * path munging, these fields are ALWAYS raw — never C-quoted — so they are used
+ * VERBATIM: the counts key by the same raw bytes the porcelain `R` row unquotes
+ * back to. Unquoting here would be wrong, not merely redundant — a filename that
+ * legitimately begins with a literal `"` (valid on POSIX) looks like the start
+ * of a C-quoted token, so `unquoteGitPath` would strip that leading quote and
+ * the path would no longer match its porcelain row, breaking the very join this
+ * module exists to keep. Blank / malformed fields are skipped.
  */
 export function parseNumstatRows(raw: string): NumstatRow[] {
   const rows: NumstatRow[] = []
@@ -269,15 +273,15 @@ export function parseNumstatRows(raw: string): NumstatRow[] {
     const deleted = parseCount(header.slice(tab1 + 1, tab2))
     const pathField = header.slice(tab2 + 1)
     if (pathField.length > 0) {
-      // Non-rename: the path is the third field.
-      rows.push({ path: unquoteGitPath(pathField), added, deleted })
+      // Non-rename: the path is the third field, raw (see the `-z` note above).
+      rows.push({ path: pathField, added, deleted })
       i++
     } else {
-      // Rename: the next two fields are the old and new paths.
+      // Rename: the next two fields are the old and new paths, both raw.
       if (i + 2 >= fields.length) break
       rows.push({
-        path: unquoteGitPath(fields[i + 2] as string),
-        origPath: unquoteGitPath(fields[i + 1] as string),
+        path: fields[i + 2] as string,
+        origPath: fields[i + 1] as string,
         added,
         deleted,
       })

--- a/packages/kobe/test/lib/git-parsers.test.ts
+++ b/packages/kobe/test/lib/git-parsers.test.ts
@@ -198,6 +198,17 @@ describe("parseNumstatRows", () => {
       numstat("src/c/f.txt", 0, 0, "src/{a{b/f.txt"),
     ])
   })
+
+  test("keeps a raw path that begins with a literal double-quote verbatim", () => {
+    // `-z` disables git's path munging, so this field is raw. It merely
+    // BEGINS with `"`; it is not a C-quoted token, and unquoting it would
+    // strip the leading quote and silently mangle the filename.
+    expect(parseNumstatRows('3\t4\t"weird.txt\0')).toEqual([numstat('"weird.txt', 3, 4)])
+  })
+
+  test("keeps raw leading-quote paths verbatim in a rename", () => {
+    expect(parseNumstatRows('1\t0\t\0"old.txt\0"new.txt\0')).toEqual([numstat('"new.txt', 1, 0, '"old.txt')])
+  })
 })
 
 describe("porcelain ↔ numstat path coherence (the join the bug breaks)", () => {
@@ -225,6 +236,17 @@ describe("porcelain ↔ numstat path coherence (the join the bug breaks)", () =>
     const [n] = parseNumstatRows("1\t0\ta\tb.txt\0")
     expect(p?.path).toBe("a\tb.txt")
     expect(n?.path).toBe("a\tb.txt")
+  })
+
+  test("a leading-quote-named modify resolves identically across formats", () => {
+    // A filename literally starting with `"`. Porcelain quotes it and escapes
+    // the leading quote (`"\"weird.txt"`); numstat with `-z` emits it raw. Both
+    // must resolve to `"weird.txt` or the numstat counts orphan the porcelain row.
+    const [p] = parsePorcelainRows(' M "\\"weird.txt"')
+    const [n] = parseNumstatRows('1\t0\t"weird.txt\0')
+    expect(p?.path).toBe('"weird.txt')
+    expect(n?.path).toBe('"weird.txt')
+    expect(p?.path).toBe(n?.path)
   })
 
   test("a move OUT of a subdirectory keys onto the same porcelain path", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in the shared git parser (`src/lib/git-parsers.ts`), surfaced while reviewing the pure/testable logic in `lib/`.

## Problem

`git diff --numstat -z` disables git's path munging, so its path fields are **always raw — never C-quoted** (this is exactly what `-z` means, and the module's own header notes it). But `parseNumstatRows` still routed every path field through `unquoteGitPath`, which decodes any field that merely *starts* with `"`.

A filename that legitimately begins with a literal double-quote (valid on POSIX) is a raw `-z` field starting with `"`. `unquoteGitPath` mistook it for a C-quoted token, found no closing quote, and returned everything after the opening `"` — silently stripping the leading quote.

Concrete failing input:

```js
parseNumstatRows('3\t4\t"weird.txt\0')
// before: { path: "weird.txt", added: 3, deleted: 4 }   ← leading " dropped
// after:  { path: '"weird.txt', added: 3, deleted: 4 }  ← raw path verbatim
```

Why it matters (in scope): this breaks the very porcelain↔numstat join this module exists to keep. The porcelain side handles the same file correctly — git **does** quote it there (`"\"weird.txt"`), and `parsePorcelainRows` unquotes it back to `"weird.txt`. So porcelain reports `"weird.txt` while numstat reports `weird.txt`; the two never key-match, and the file loses its `+/-` line counts in the file tree and sidebar change chip — the identical class of regression the module header calls out for space-containing names. The rename fields were mangled the same way.

## Fix

Use the `-z` numstat path fields **verbatim** (drop the three `unquoteGitPath` calls in `parseNumstatRows`); `-z` guarantees raw output, so unquoting there is wrong, not merely redundant. `unquoteGitPath` stays correct and in use for the porcelain path, where git genuinely does quote. The stale "harmless no-op for extra robustness" comment is corrected to explain why raw is the only correct choice.

## Verification

- Added 3 regression tests (a raw leading-quote path, the same in a rename, and the porcelain↔numstat coherence case). Confirmed all 3 **fail** on `main`'s code and **pass** with the fix.
- `bun x vitest run test/lib` — 156 passed. `bun run lint` and `bun run typecheck` both green.
- No existing test fed a quoted path into `parseNumstatRows`, so nothing else changes.

## Follow-ups (deliberately not in this PR)

The bug-hunt turned up two weaker near-misses I did **not** touch, both non-triggerable today: `read-output-page.ts` renders a trailing bare `\r` as an empty last line (documented CR-overwrite behavior), and `handlers-inspect.ts` filters sessions with a loose `startsWith(taskId)` rather than the `` `${taskId}::` `` form its siblings use (safe only because task ids are fixed-length ULIDs). Worth a look if either invariant ever shifts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu3H6xxX57KM1s6CzND3jn)_