### PR TITLE
feat: surface the npm update check as a sidebar brand-row chip

### DIFF
--- a/.changeset/sidebar-update-chip.md
+++ b/.changeset/sidebar-update-chip.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Show an update chip on the sidebar brand row when a newer version is on npm. The daemon has polled the registry and pushed `update` events all along, but the TUI consumer was lost when the tmux runtime was removed (#313), so nothing ever surfaced. The chip (`↑ <version>`) sits right-aligned next to the ROVE brand text, and clicking it — or pressing `u` in the sidebar, as before — opens the update page. This restores the behavior docs/TUI.md already promised under "Updates and version warnings".

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -353,6 +353,8 @@ export function SidebarTree(props: SidebarTreeProps) {
         focused={focused}
         status={props.headerStatus ?? null}
         onStatusClick={props.onHeaderStatusClick}
+        update={props.updateChip ?? null}
+        onUpdateClick={props.onUpdateChipClick}
       />
       <SidebarCreateAction onAddTask={props.onAddTask} />
       {search.active ? (

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -115,6 +115,9 @@ export function SidebarBrandHeader(props: {
   focused: boolean
   status: { label: string; emphasize: boolean } | null
   onStatusClick?: () => void
+  /** "a newer build is on npm" chip — right-aligned, opens the update page. */
+  update?: { label: string } | null
+  onUpdateClick?: () => void
 }) {
   const { theme } = useTheme()
   return (
@@ -136,6 +139,14 @@ export function SidebarBrandHeader(props: {
           </box>
         ) : null}
       </box>
+      {props.update ? (
+        <box position="relative" flexShrink={0} onMouseUp={() => props.onUpdateClick?.()}>
+          <text fg={theme.success} attributes={TextAttributes.BOLD} wrapMode="none">
+            {props.update.label}
+          </text>
+          {props.onUpdateClick ? <ShortcutRevealBadge bindingId="tasks.update" /> : null}
+        </box>
+      ) : null}
     </box>
   )
 }

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -64,6 +64,9 @@ export type SidebarProps = SidebarTaskCallbacks & {
   width?: number
   headerStatus?: { label: string; emphasize: boolean } | null
   onHeaderStatusClick?: () => void
+  /** "newer version on npm" brand-row chip; null hides it. */
+  updateChip?: { label: string } | null
+  onUpdateChipClick?: () => void
   onAddTask?: () => void
   zenActive?: boolean
   onZenClick?: () => void

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -51,6 +51,9 @@ export interface HostSidebarProps {
   readonly onSearchActiveChange: (active: boolean) => void
   readonly headerStatus: { label: string; emphasize: boolean }
   readonly onHeaderStatusClick: () => void
+  /** "newer version on npm" chip beside the brand text; null hides it. */
+  readonly updateChip?: { label: string } | null
+  readonly onUpdateChipClick?: () => void
   readonly zenActive: boolean
   readonly onZenClick: () => void
   readonly onFocusRequest: () => void
@@ -125,6 +128,8 @@ export function HostSidebar(props: HostSidebarProps) {
     onAddTask: props.onAddTask,
     headerStatus: props.headerStatus,
     onHeaderStatusClick: props.onHeaderStatusClick,
+    updateChip: props.updateChip,
+    onUpdateChipClick: props.onUpdateChipClick,
     zenActive: props.zenActive,
     onZenClick: props.onZenClick,
     sortMode: props.sortMode,

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -291,6 +291,9 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // date with, and the red banner already says the screen is a photograph.
   const daemonStale = useAccessor(orch.daemonStaleSignal())
   const daemonVersion = useAccessor(orch.daemonVersionSignal())
+  // Daemon-polled npm check (collectors' update channel). The chip is the
+  // passive half of the update surface; `u` / a click opens the page.
+  const updateInfo = useAccessor(orch.updateSignal())
   const banner = daemonDown ? (
     <DaemonDownBanner down={true} width={dims.width} />
   ) : (
@@ -392,6 +395,8 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
             emphasize: inbox.counts.total > 0,
           }}
           onHeaderStatusClick={inbox.show}
+          updateChip={updateInfo?.hasUpdate ? { label: t("update.chip", { version: updateInfo.latest }) } : null}
+          onUpdateChipClick={pages.openUpdate}
           zenActive={zen}
           onZenClick={toggleZen}
           onFocusRequest={() => focus.setFocused("sidebar")}

--- a/packages/kobe/src/tui/i18n/messages/update.ts
+++ b/packages/kobe/src/tui/i18n/messages/update.ts
@@ -5,6 +5,8 @@
 
 export const en = {
   pageTitle: "ROVE UPDATE",
+  /** Brand-row chip — must stay tiny, the rail is the narrowest panel. */
+  chip: "↑ {version}",
   current: "current",
   latest: "latest",
   /** The registry check failed (offline, npm down, timeout). Distinct from
@@ -45,6 +47,7 @@ export const en = {
 
 export const zh: typeof en = {
   pageTitle: "ROVE 更新",
+  chip: "↑ {version}",
   current: "当前",
   latest: "最新",
   latestUnknown: "未知 —— 无法连接到 registry",

--- a/packages/kobe/test/render/sidebar-update-chip.test.tsx
+++ b/packages/kobe/test/render/sidebar-update-chip.test.tsx
@@ -1,0 +1,58 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The brand-row update chip — the passive half of the update surface. The
+ * daemon's npm poll lands in `updateSignal`; this pins that a `hasUpdate`
+ * payload renders a right-aligned, clickable chip on the ROVE brand row and
+ * that no chip renders otherwise (regression: the consumer was lost with the
+ * tmux runtime in #313 and the poll went nowhere for months).
+ */
+
+import { expect, test } from "bun:test"
+import { SidebarBrandHeader } from "../../src/tui-react/panes/sidebar/chrome"
+import { renderComponent } from "./harness"
+
+function lineOf(frame: string, needle: string): number {
+  return frame.split("\n").findIndex((line) => line.includes(needle))
+}
+
+test("renders the update chip right-aligned on the brand row", async () => {
+  const { frame } = await renderComponent(
+    <SidebarBrandHeader
+      focused={false}
+      status={{ label: "Inbox 0", emphasize: false }}
+      update={{ label: "↑ 0.9.99" }}
+    />,
+    { width: 30, height: 3 },
+  )
+  const text = await frame()
+  const row = text.split("\n")[lineOf(text, "ROVE")]
+
+  // Same row as the brand text, version label intact, pushed to the right edge.
+  expect(row).toMatch(/ROVE\s+Inbox 0\s+↑ 0\.9\.99/)
+})
+
+test("no update chip when there is nothing to update to", async () => {
+  const { frame } = await renderComponent(
+    <SidebarBrandHeader focused={false} status={{ label: "Inbox 0", emphasize: false }} update={null} />,
+    { width: 30, height: 3 },
+  )
+  expect(await frame()).not.toContain("↑")
+})
+
+test("clicking the chip opens the update surface", async () => {
+  let calls = 0
+  const { frame, mockMouse } = await renderComponent(
+    <SidebarBrandHeader
+      focused={false}
+      status={{ label: "Inbox 0", emphasize: false }}
+      update={{ label: "↑ 0.9.99" }}
+      onUpdateClick={() => calls++}
+    />,
+    { width: 30, height: 3 },
+  )
+  const text = await frame()
+  const row = lineOf(text, "0.9.99")
+
+  await mockMouse.click(text.split("\n")[row].indexOf("0.9.99"), row)
+  expect(calls).toBe(1)
+})


### PR DESCRIPTION
## What

When the daemon's npm poll reports a newer published version, the sidebar brand row now shows a right-aligned `↑ <version>` chip next to the ROVE brand text. Clicking it (or pressing `u` in the sidebar, unchanged) opens the existing update page. No chip renders when up to date.

## Why

The passive half of the update surface has been dead since July: the daemon polls the registry and publishes `update` events (`collectors.ts`), the client stores them in `updateSignal`, but the only UI consumer lived in the tmux-era tasks-pane host and was deleted with the tmux runtime in #313 — nothing was ever rebuilt on the React side. Since then a newer version was invisible unless the user pressed `u` on a hunch. `docs/TUI.md` ("Updates and version warnings") already promises "the sidebar shows an update affordance", so this restores documented behavior rather than adding new surface.

## How

- `host.tsx` subscribes to `orch.updateSignal()` and passes a chip (`update.chip` i18n, `↑ {version}`) + `pages.openUpdate` down through `HostSidebar` → `SidebarTree` → `SidebarBrandHeader`.
- `SidebarBrandHeader` renders the chip in the empty right slot of its existing space-between row (costs zero extra lines in the row-starved rail), with a `ShortcutRevealBadge` for the existing `tasks.update` binding. No new or moved chords.
- Render tests (`test/render/sidebar-update-chip.test.tsx`): chip renders on the brand row, absent when null, click opens the update surface.

## Verification

- `bun run typecheck` and `bun run lint` green.
- `bun test test/render`: 329 pass.
- `bun run test:fast`: 3981 pass; `test/engine/protocol-sniff.test.ts` timed out under full-suite parallel load but passes in isolation — pre-existing flake, unrelated to this change.