### PR TITLE
fix: hide the tab strip by default again

### DIFF
--- a/.changeset/tab-strip-off-by-default.md
+++ b/.changeset/tab-strip-off-by-default.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The tab strip above the terminal is hidden by default again.
+
+The sidebar tree already lists every worktree's tabs as rows and marks the active one, so the strip was a second copy of a list that is already on screen — spending a row of the content pane to repeat it. Settings → General → Terminal still offers `always` and `multipleOnly` for anyone who wants it back, and an existing preference is untouched.

--- a/packages/kobe/src/state/tab-strip.ts
+++ b/packages/kobe/src/state/tab-strip.ts
@@ -6,12 +6,11 @@
  *
  *   - `always`      — the strip renders for every tab count, even a single
  *                     tab (whose row still carries the engine title and turn
- *                     chip). The default (owner call 2026-08-29, restoring
- *                     the pre-tree behaviour).
+ *                     chip).
  *   - `multipleOnly`— hide the strip while a task has only one tab.
  *   - `never`       — no strip at all: the sidebar tree lists every
  *                     worktree's tabs as rows, so the horizontal strip is a
- *                     second copy of the same list (owner call 2026-08-01).
+ *                     second copy of the same list. The default.
  *
  * kv-persisted; read live by `tui-react/workspace/TerminalTabs.tsx`.
  */
@@ -23,12 +22,15 @@ export type TabStripMode = "always" | "multipleOnly" | "never"
 export const TAB_STRIP_MODES: readonly TabStripMode[] = ["always", "multipleOnly", "never"]
 
 /**
- * On by default (owner call 2026-08-29, superseding the 2026-08-01 "off"):
- * the tree lists tabs, but a boxed strip is the affordance that says WHICH
- * tab the pane below is showing. Users who prefer the tree alone set
- * `never`.
+ * Off by default (owner call 2026-08-31, reverting the 2026-08-29 "always").
+ *
+ * The sidebar tree already lists every worktree's tabs as rows, and the
+ * active one is marked there — so the strip is a second copy of a list that
+ * is already on screen, spending a row of the content pane to say what the
+ * tree says for free. `always` / `multipleOnly` are still there in
+ * Settings → General → Terminal for anyone who wants it back.
  */
-export const DEFAULT_TAB_STRIP_MODE: TabStripMode = "always"
+export const DEFAULT_TAB_STRIP_MODE: TabStripMode = "never"
 
 /** Legacy boolean key — `true` meant "hide while a task has one tab". */
 export const TAB_STRIP_HIDE_SINGLE_KEY = "chat.tabStrip.hideSingle"

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -84,9 +84,10 @@ export function TabStrip(props: {
   const { theme } = themeCtx
   const kv = useKV()
   const dims = useTerminalDimensions()
-  // The sidebar tree lists every worktree's tabs, but the boxed strip is the
-  // affordance that says WHICH tab the pane below is showing — on by default
-  // (owner call 2026-08-29); Settings → General → Terminal switches it off.
+  // Off by default (owner call 2026-08-31): the sidebar tree already lists
+  // every worktree's tabs and marks the active one, so the strip is a second
+  // copy of a list that is already on screen. Settings → General → Terminal
+  // turns it back on.
   // Rendered as a late bail so the hooks below always run in the same order.
   const stripMode = resolveTabStripMode(
     kv.get(TAB_STRIP_MODE_KEY, undefined),

--- a/packages/kobe/test/render/tab-strip-boxed.test.tsx
+++ b/packages/kobe/test/render/tab-strip-boxed.test.tsx
@@ -14,17 +14,26 @@
  */
 
 import { expect, test } from "bun:test"
-import { mkdtempSync } from "node:fs"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { useState } from "react"
 import type { ChatTabTurnState } from "../../src/engine/turn-detector"
+import { TAB_STRIP_MODE_KEY } from "../../src/state/tab-strip"
 import { useBindings } from "../../src/tui-react/lib/keymap"
 import { TURN_GLYPHS, TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 import { renderComponent } from "./harness"
 
+// The strip is OFF by default (2026-08-31) — the sidebar tree already lists
+// these tabs. This file is about what it DRAWS when asked for, so the mode is
+// pinned to `always` for every test here.
 process.env.KOBE_HOME_DIR ??= mkdtempSync(join(tmpdir(), "kobe-tab-strip-boxed-"))
+mkdirSync(join(process.env.KOBE_HOME_DIR, ".config", "rove"), { recursive: true })
+writeFileSync(
+  join(process.env.KOBE_HOME_DIR, ".config", "rove", "state.json"),
+  JSON.stringify({ [TAB_STRIP_MODE_KEY]: "always" }),
+)
 
 const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1
 

--- a/packages/kobe/test/render/tab-strip-narrow.test.tsx
+++ b/packages/kobe/test/render/tab-strip-narrow.test.tsx
@@ -41,6 +41,12 @@ function strip(activeId: string) {
 }
 
 test("narrow strip shows the active tab truncated with a position counter", async () => {
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-tab-strip-narrow-"))
+  mkdirSync(join(process.env.KOBE_HOME_DIR, ".config", "rove"), { recursive: true })
+  writeFileSync(
+    join(process.env.KOBE_HOME_DIR, ".config", "rove", "state.json"),
+    JSON.stringify({ [TAB_STRIP_MODE_KEY]: "always" }),
+  )
   const { frame } = await renderComponent(strip("tab-2"), { width: 46, height: 4, providers: { kv: true } })
   const out = await frame()
   expect(out).toContain("2/3")
@@ -49,7 +55,15 @@ test("narrow strip shows the active tab truncated with a position counter", asyn
   expect(out).not.toContain("than fits")
 })
 
-test("desktop renders the boxed strip under the new `always` default", async () => {
+test("desktop renders the boxed strip when the mode is `always`", async () => {
+  // Explicit, because `never` is the default (2026-08-31): the sidebar tree
+  // already lists these tabs. This pins what the strip DRAWS when asked for.
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-tab-strip-always-"))
+  mkdirSync(join(process.env.KOBE_HOME_DIR, ".config", "rove"), { recursive: true })
+  writeFileSync(
+    join(process.env.KOBE_HOME_DIR, ".config", "rove", "state.json"),
+    JSON.stringify({ [TAB_STRIP_MODE_KEY]: "always" }),
+  )
   const { frame } = await renderComponent(strip("tab-2"), { width: 100, height: 4, providers: { kv: true } })
   const out = await frame()
   // No `2/3` counter outside narrow mode, but the strip itself draws: every

--- a/packages/kobe/test/state/tab-strip.test.ts
+++ b/packages/kobe/test/state/tab-strip.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tab-strip visibility: the default, the legacy-boolean migration, and how a
+ * mode turns into "does it render".
+ *
+ * The default is the load-bearing part. It has been flipped twice (off
+ * 2026-08-01, on 2026-08-29, off again 2026-08-31) and nothing pinned it, so
+ * a flip could ride along in an unrelated change and only be noticed on
+ * screen.
+ */
+
+import { DEFAULT_TAB_STRIP_MODE, TAB_STRIP_MODES, resolveTabStripMode, tabStripVisible } from "@/state/tab-strip"
+import { describe, expect, it } from "vitest"
+
+describe("the default mode", () => {
+  it("is `never` — the sidebar tree already lists every tab", () => {
+    expect(DEFAULT_TAB_STRIP_MODE).toBe("never")
+  })
+
+  it("applies when nothing is stored", () => {
+    expect(resolveTabStripMode(undefined, undefined)).toBe("never")
+  })
+
+  it("means the strip does not render, whatever the tab count", () => {
+    expect(tabStripVisible(DEFAULT_TAB_STRIP_MODE, 1)).toBe(false)
+    expect(tabStripVisible(DEFAULT_TAB_STRIP_MODE, 5)).toBe(false)
+  })
+})
+
+describe("resolveTabStripMode", () => {
+  it("honours a stored mode over the default", () => {
+    for (const mode of TAB_STRIP_MODES) expect(resolveTabStripMode(mode, undefined)).toBe(mode)
+  })
+
+  it("falls back for a stored value that is not a mode", () => {
+    // A hand-edited state.json, or a key from a future version.
+    expect(resolveTabStripMode("sometimes", undefined)).toBe("never")
+    expect(resolveTabStripMode(42, undefined)).toBe("never")
+    expect(resolveTabStripMode(null, undefined)).toBe("never")
+  })
+
+  it("migrates the legacy boolean when the new key was never written", () => {
+    expect(resolveTabStripMode(undefined, true)).toBe("multipleOnly")
+    expect(resolveTabStripMode(undefined, false)).toBe("always")
+  })
+
+  it("lets the new key win once it exists", () => {
+    // Someone who set the old toggle and then touched the new setting keeps
+    // the new one — otherwise the legacy value would silently outrank it.
+    expect(resolveTabStripMode("never", false)).toBe("never")
+    expect(resolveTabStripMode("always", true)).toBe("always")
+  })
+})
+
+describe("tabStripVisible", () => {
+  it("`always` renders even for a lone tab", () => {
+    expect(tabStripVisible("always", 1)).toBe(true)
+  })
+
+  it("`multipleOnly` needs a second tab", () => {
+    expect(tabStripVisible("multipleOnly", 1)).toBe(false)
+    expect(tabStripVisible("multipleOnly", 2)).toBe(true)
+  })
+
+  it("`never` renders nothing", () => {
+    expect(tabStripVisible("never", 2)).toBe(false)
+  })
+})


### PR DESCRIPTION
The strip above the terminal is a second copy of a list already on screen: the sidebar tree lists every worktree's tabs as rows and marks the active one. It costs a row of the content pane to repeat that.

Back to `never`, which is where it was before 2026-08-29. Settings → General → Terminal still offers `always` and `multipleOnly`, and anyone who set a preference keeps it — only the default moves.

## Why it also gets a test

The default has now been flipped three times (off 2026-08-01, on 2026-08-29, off again here) and **nothing pinned it**. A flip could ride along in an unrelated diff and only be noticed by looking at the screen.

`test/state/tab-strip.test.ts` covers the default, `tabStripVisible`, and the legacy-boolean migration (`chat.tabStrip.hideSingle`) — which had no test at all, despite deciding what existing users see. Mutation-checked: flipping the default back to `always` trips four of them.

## The two render tests

`tab-strip-boxed` and `tab-strip-narrow` assert what the strip *draws*, so they now pin the mode to `always` explicitly instead of leaning on the default. That is the right shape regardless: a test about appearance should not silently become a test about visibility.

Running `tab-strip-narrow` alone also surfaced that one of its cases was only passing via a state file another test in the same file leaks through `KOBE_HOME_DIR` — it failed in isolation and passed in the suite. Each case now writes its own.

## Verification

typecheck, lint, i18n; 3992 vitest + 327 render + socket green.