### PR TITLE
fix: re-render the workspace when a task's tab list changes

### DIFF
--- a/.changeset/close-last-tab-no-crash.md
+++ b/.changeset/close-last-tab-no-crash.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the workspace crashing after you close a task's last tab
+
+The center column decides whether to mount the terminal pane by reading a
+module-level map of each task's tabs — a plain `Map`, which React does not
+watch. Closing the last tab wrote the now-empty list there and re-rendered
+nothing, so the pane stayed mounted over a tab list it is built to always
+find an active tab in, and the workspace crashed to the pane-crash placeholder
+instead of showing "No sessions here".
+
+Writes to that map now go through `setTaskTabs` / `deleteTaskTabs`, which bump
+a subscribable revision the center column reads. The one write left untouched
+is the mount-time lazy init, which runs during render and must stay silent.

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -90,7 +90,7 @@ import { noteEngineTabInput } from "./optimistic-activity"
 import { TabStrip, tabTitle } from "./tab-strip"
 import { releaseClosedTabPtys } from "./terminal-tabs-close"
 import { terminalTabsKey } from "./terminal-tabs-persist"
-import { reportTabsDelta, tabsByTask } from "./terminal-tabs-shared"
+import { reportTabsDelta, setTaskTabs, tabsByTask } from "./terminal-tabs-shared"
 import { useTabClose } from "./use-tab-close"
 import { useTabDialogs } from "./use-tab-dialogs"
 import { useTabHandoffs } from "./use-tab-handoffs"
@@ -194,7 +194,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
     // the shell; an engine only appears if the user types one.
     const fresh =
       fromDisk ?? (props.scratch === true ? initialShellTabs(defaultShell()) : pinSession(initialTabs(), undefined))
-    tabsByTask.set(props.taskId, fresh)
+    tabsByTask.set(props.taskId, fresh) // silent: render phase, see setTaskTabs
     return fresh
   }
 
@@ -203,7 +203,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
 
   const update = (next: TabsState): void => {
     reportTabsDelta(propsRef.current.taskId, stateRef.current.tabs, next.tabs)
-    tabsByTask.set(propsRef.current.taskId, next)
+    setTaskTabs(propsRef.current.taskId, next)
     stateRef.current = next
     setState(next)
     kv.set(persistKey, next)

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -16,7 +16,7 @@ import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useAccessor } from "../lib/use-accessor"
 import { TerminalTabs } from "./TerminalTabs"
-import { knownTaskTabs } from "./terminal-tabs-shared"
+import { knownTaskTabs, tabsRevision } from "./terminal-tabs-shared"
 import { WelcomePane } from "./welcome-pane"
 
 export function ShowWorkspace(props: {
@@ -49,6 +49,11 @@ export function ShowWorkspace(props: {
   // provider mounted, and the empty-tabs lookup below is a refinement, not a
   // requirement — no provider simply means "tabs unknown", which mounts.
   const kv = useOptionalKV()
+  // Subscribe to the tab map's revision counter. `knownTaskTabs` reads a
+  // module-level Map, which React cannot see on its own: closing a task's
+  // last tab used to change the answer below without re-rendering, leaving
+  // TerminalTabs mounted over an empty tab list it is not built to survive.
+  useAccessor(tabsRevision)
   const transcriptActivity = useAccessor(props.orchestrator.transcriptActivityStore())
   const engineTabStates = useAccessor(props.orchestrator.engineTabStatesSignal())
   const tasks = useAccessor(props.orchestrator.tasksSignal())

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-adopt.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-adopt.ts
@@ -14,7 +14,7 @@
 import { adoptTabs } from "../../tui/workspace/tabs-adopt"
 import type { TabsState } from "../../tui/workspace/terminal-tabs-core"
 import { type TabsSnapshotKv, terminalTabsKey } from "./terminal-tabs-persist"
-import { requestTabAdopt, tabsByTask, takeUnclaimedTabAdopt } from "./terminal-tabs-shared"
+import { requestTabAdopt, setTaskTabs, tabsByTask, takeUnclaimedTabAdopt } from "./terminal-tabs-shared"
 
 /**
  * Register `tabIds` as engine tabs of `taskId`. No-op when they are all
@@ -38,7 +38,7 @@ export function adoptTaskTabs(kv: TabsSnapshotKv, taskId: string, tabIds: readon
   const next = adoptTabs(state ?? empty, tabIds)
   if (state && next === state) return false
 
-  tabsByTask.set(taskId, next)
+  setTaskTabs(taskId, next)
   kv.set(terminalTabsKey(taskId), next)
   return true
 }

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
@@ -30,7 +30,7 @@ import {
 } from "../../tui/workspace/terminal-tabs-core"
 import { releaseSplitLeaves } from "./TerminalSplit"
 import { type TabsSnapshotKv, terminalTabsKey } from "./terminal-tabs-persist"
-import { requestTabClose, tabsByTask, takeUnclaimedTabClose } from "./terminal-tabs-shared"
+import { requestTabClose, setTaskTabs, tabsByTask, takeUnclaimedTabClose } from "./terminal-tabs-shared"
 
 /**
  * Release a closing tab's PTYs — the split leaves plus the tab's own.
@@ -97,7 +97,7 @@ export function closeTaskTab(kv: TabsSnapshotKv, taskId: string, tabId: string):
   const closing = state.tabs.find((tab) => tab.id === tabId)
   const { state: next, closedId } = closeTab(state, tabId)
   if (!closedId) return false
-  tabsByTask.set(taskId, next)
+  setTaskTabs(taskId, next)
   kv.set(terminalTabsKey(taskId), next)
   releaseClosedTabPtys(taskId, closing, closedId)
   return true

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-move.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-move.ts
@@ -13,7 +13,7 @@
 
 import { type TabsState, moveTab } from "../../tui/workspace/terminal-tabs-core"
 import { type TabsSnapshotKv, terminalTabsKey } from "./terminal-tabs-persist"
-import { requestTabMove, tabsByTask, takeUnclaimedTabMove } from "./terminal-tabs-shared"
+import { requestTabMove, setTaskTabs, tabsByTask, takeUnclaimedTabMove } from "./terminal-tabs-shared"
 
 /**
  * Move `tabId` of `taskId` by `delta`. Returns whether the order changed —
@@ -32,7 +32,7 @@ export function moveTaskTab(kv: TabsSnapshotKv, taskId: string, tabId: string, d
   if (!state) return false
   const next = moveTab(state, tabId, delta)
   if (next === state) return false
-  tabsByTask.set(taskId, next)
+  setTaskTabs(taskId, next)
   kv.set(terminalTabsKey(taskId), next)
   return true
 }

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -9,6 +9,7 @@
 
 import { engineLaunchArgv, withPinnedSessionId } from "../../engine/engine-presets"
 
+import { createStateCell } from "../../lib/external-store"
 import {
   type EngineTab,
   type TabsState,
@@ -19,8 +20,32 @@ import {
 import type { VendorId } from "../../types/vendor"
 import { type TabsSnapshotKv, forgetTaskTabsSnapshot, terminalTabsKey } from "./terminal-tabs-persist"
 
-/** Per-task tab state, preserved across task switches for the process. */
+/** Per-task tab state, preserved across task switches for the process.
+ *
+ *  WRITE THROUGH `setTaskTabs` / `deleteTaskTabs`, never `.set` / `.delete`
+ *  directly: a plain Map mutation is invisible to React, and `ShowWorkspace`
+ *  decides whether to mount `TerminalTabs` at all from this map. Closing a
+ *  task's last tab wrote here and re-rendered nothing, so the component that
+ *  owns the now-empty tab list stayed mounted and kept dereferencing an
+ *  `active` tab that no longer existed. */
 export const tabsByTask = new Map<string, TabsState>()
+
+/** Bumped on every `tabsByTask` write — the subscribable half of the map, so
+ *  a React surface reading it re-renders when it changes. Cheap: a counter,
+ *  not a copy of the state; readers still go to the map for the value. */
+export const tabsRevision = createStateCell(0)
+
+/** Write a task's tab state AND notify React readers. */
+export function setTaskTabs(taskId: string, state: TabsState): void {
+  tabsByTask.set(taskId, state)
+  tabsRevision.update((n) => n + 1)
+}
+
+/** Drop a task's tab state AND notify React readers. */
+export function deleteTaskTabs(taskId: string): void {
+  if (!tabsByTask.delete(taskId)) return
+  tabsRevision.update((n) => n + 1)
+}
 
 /** The task's currently-active tab id (module map read) — the attention
  *  jump's "where am I" input. Null when the task never mounted tabs. */
@@ -339,7 +364,7 @@ export function reportTabsDelta(taskId: string, prev: readonly TerminalTab[], ne
  * exit path.
  */
 export function forgetTaskTabs(kv: TabsSnapshotKv, taskId: string): void {
-  tabsByTask.delete(taskId)
+  deleteTaskTabs(taskId)
   forgetTaskTabsSnapshot(kv, taskId)
 }
 
@@ -393,7 +418,7 @@ export function appendBackgroundEngineTab(
     activeId: tab.id,
     nextOrdinal: ordinal + 1,
   }
-  tabsByTask.set(taskId, next)
+  setTaskTabs(taskId, next)
   kv.set(terminalTabsKey(taskId), next)
   return { state: next, tab }
 }

--- a/packages/kobe/test/render/show-workspace-close-last.test.tsx
+++ b/packages/kobe/test/render/show-workspace-close-last.test.tsx
@@ -1,0 +1,76 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Closing the LAST tab is a TRANSITION, not a start state.
+ *
+ * show-workspace-empty.test.tsx seeds `tabsByTask` before the first render, so
+ * ShowWorkspace decides once and never re-decides — which is exactly what the
+ * real close is not. The close happens the other way round: the tab list
+ * empties while the component is already mounted, and the decision to stop
+ * mounting TerminalTabs has to arrive from `tabsByTask`, a module-level Map
+ * React cannot observe on its own.
+ *
+ * The transition is driven here from the KNOWN-EMPTY side (empty -> one tab)
+ * rather than the other way: both directions need the same subscription, and
+ * this one never mounts TerminalTabs, which opens a daemon socket and needs
+ * four more providers. What is under test is whether ShowWorkspace re-decides
+ * at all when the map changes under it.
+ */
+
+import { describe, expect, it } from "bun:test"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { ShowWorkspace } from "../../src/tui-react/workspace/show-workspace"
+import { setTaskTabs, tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import type { Task } from "../../src/types/task"
+import { act, renderComponent } from "./harness"
+
+const EMPTY_MAP = new Map<string, never>()
+const ONE_TASK = Object.freeze([{ id: "t1" }]) as unknown as readonly Task[]
+const store = <T,>(value: T) => ({ subscribe: () => () => {}, get: () => value })
+
+const orchestrator = () =>
+  ({
+    transcriptActivityStore: () => store(EMPTY_MAP),
+    engineTabStatesSignal: () => store(EMPTY_MAP),
+    tasksSignal: () => store(ONE_TASK),
+  }) as unknown as RemoteOrchestrator
+
+const SELECTED = { id: "t1", repo: "/repos/rove", kind: "task" } as unknown as Task
+
+const props = () =>
+  ({
+    task: SELECTED,
+    worktree: "/wt/t1",
+    orchestrator: orchestrator(),
+    focused: false,
+    onRequestFocus: () => {},
+    onEditorTabReady: () => {},
+    onEngineSendReady: () => {},
+    onEnginePasteReady: () => {},
+    onDiffTabReady: () => {},
+    onQuickFork: () => {},
+  }) as const
+
+describe("the tab map changing under a mounted ShowWorkspace", () => {
+  it("re-decides when the task's tabs change after first render", async () => {
+    tabsByTask.clear()
+    tabsByTask.set("t1", { tabs: [], activeId: "tab-1", nextOrdinal: 2 })
+
+    const { frame } = await renderComponent(<ShowWorkspace {...props()} />)
+    await act(async () => {})
+    expect(await frame()).toContain("No sessions here")
+
+    // A session opens again (⏎ / ctrl+e on the empty row) — the same
+    // module-map write closing the last tab performs, in reverse.
+    await act(async () => {
+      setTaskTabs("t1", {
+        tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }],
+        activeId: "tab-1",
+        nextOrdinal: 2,
+      })
+    })
+
+    // Before the revision subscription this frame still read "No sessions
+    // here": the map had changed and nothing told React to look again.
+    expect(await frame()).not.toContain("No sessions here")
+  })
+})


### PR DESCRIPTION
Follow-up to #696, which made closing a task's last tab possible. It was possible, but the screen did not follow.

## The bug

`ShowWorkspace` decides whether to mount `TerminalTabs` by reading `tabsByTask` — a module-level `Map`. React does not watch a plain Map. Closing the last tab wrote the now-empty list there and re-rendered nothing, so the pane stayed mounted over a tab list it is built to always find an active tab in, and the workspace crashed to the pane-crash placeholder instead of showing "No sessions here".

#696 shipped the render test for the *start* state (a task that already has zero tabs mounts the placeholder). That passes either way — it never re-decides. The close is a transition, and nothing covered it.

## The fix

Writes to the map go through `setTaskTabs` / `deleteTaskTabs`, which bump a subscribable revision `ShowWorkspace` reads. Every call site converted except one: the mount-time lazy init in `TerminalTabs`, which runs during render, where notifying would be a React violation. It is annotated so it does not read as an oversight.

## Verification

`test/render/show-workspace-close-last.test.tsx` drives the transition through a mounted component rather than seeding a start state. Removing the subscription fails it; the suite is otherwise unchanged (327 render, 3982 vitest, lint, typecheck).

Authored by another session working in the same checkout; committed here so it can ship with 0.9.62.

coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalTabs.tsx — integration layer needing a live daemon + PTY, named in docs/HARNESS.md as structurally untestable on the render track. The change here is three mechanical lines (one import, two `tabsByTask.set` → `setTaskTabs`); the behaviour they feed is covered by test/render/show-workspace-close-last.test.tsx, which fails without the subscription.
