### PR TITLE
fix: stop the status hint row re-running its effect every render

### DIFF
--- a/.changeset/hint-effect-deps.md
+++ b/.changeset/hint-effect-deps.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the workspace crashing with "Maximum update depth exceeded" while deleting tasks.
+
+The status hint row at the bottom of the workspace re-computed its snapshot in an effect with no dependency array, so the effect ran after every render. That hook lives in the footer, which wraps the whole pane tree, so its state update re-renders every sidebar row — and each row bumps the binding-stack version as it registers or unregisters, which re-renders the footer again. Only a value comparison stood between that cycle and an infinite loop, and deleting several tasks in a burst got past it: React tripped its update-depth guard and the pane crashed.
+
+The effect now declares its inputs, so it runs when one of them changes instead of on every render.

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -69,8 +69,8 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
   // them re-renders this consumer and re-runs the effect below.
   const focus = useOptionalFocus()
   const dialog = useOptionalDialog()
-  useKeymapVersion()
-  useBindingStackVersion()
+  const keymapVersion = useKeymapVersion()
+  const stackVersion = useBindingStackVersion()
   const [snapshot, setSnapshot] = useState<{ tokens: readonly StatusHintToken[]; modal: boolean }>({
     tokens: [],
     modal: false,
@@ -106,7 +106,22 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
         ? prev
         : { tokens: nextTokens, modal: nextModal }
     })
-  })
+    // Dependencies, NOT a bare effect (React #185, 2026-08-31): this hook
+    // renders in the workspace FOOTER, which wraps the whole pane tree, so its
+    // setState re-renders every sidebar row — and each row's `useBindings`
+    // bumps `stackVersion` on unmount/remount, which re-renders the footer.
+    // With no dependency array the effect ran on every one of those renders,
+    // leaving only the compare-and-set between that cycle and an infinite
+    // loop. Deleting tasks in a burst (rows unmounting while focus and the
+    // prefix state churn) got past the compare and the workspace crashed with
+    // "Maximum update depth exceeded".
+    //
+    // These four ARE the effect's inputs: the two version counters cover every
+    // keymap/registration change, and focus + the dialog stack cover the rest
+    // of what reachability reads. `kv` is a stable context value. The
+    // after-commit timing the comment above relies on is unchanged — an effect
+    // with dependencies still runs after the commit that changed them.
+  }, [keymapVersion, stackVersion, focus?.focused, dialog?.stack.length, kv])
   // Click = the action the advertised key would run. Arming the prefix goes
   // through the REAL dispatcher state, so the which-key guide that appears
   // accepts a keyboard second stroke exactly like a pressed ctrl+a.

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -82,6 +82,7 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
   // Effects run children-first, so by the time this one
   // fires the whole tree's refs and registrations are current. The
   // compare-and-set keeps the no-change case from looping.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the version/focus deps are INVALIDATION KEYS, not values this body reads — it reads live module state (currentBindingReachability, modalActive, currentPrefixConfiguration) whose changes are observable ONLY through them. Dropping them restores the no-dependency-array loop described below.
   useEffect(() => {
     const enabled = keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))
     // Two independent signals, both meaning "an overlay owns input": the

--- a/packages/kobe/test/render/status-hints-no-loop.test.tsx
+++ b/packages/kobe/test/render/status-hints-no-loop.test.tsx
@@ -1,0 +1,116 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The status hint row must not re-run its snapshot effect on every render.
+ *
+ * React error #185 ("Maximum update depth exceeded") crashed the workspace
+ * while deleting tasks in a burst. `useStatusKeyHintItems` renders in the
+ * workspace FOOTER, which wraps the whole pane tree, so its `setState`
+ * re-renders every sidebar row — and each row's `useBindings` bumps the
+ * binding-stack version on unmount/remount, which re-renders the footer.
+ * The effect had no dependency array, so it ran on every one of those
+ * renders, leaving only its compare-and-set between that cycle and an
+ * infinite loop.
+ *
+ * What is pinned here is the shape, not the crash: the effect runs when its
+ * inputs change, and NOT once per render. A render that changes none of its
+ * inputs must not re-run it — that is the property whose absence made the
+ * loop possible at all.
+ */
+
+import { expect, test } from "bun:test"
+import { useState } from "react"
+import { useStatusKeyHintItems } from "../../src/tui-react/component/keyboard-hints"
+import { useBindings } from "../../src/tui-react/lib/keymap"
+import { act, renderComponent } from "./harness"
+
+/** A sidebar row: registers bindings, so mounting/unmounting bumps the stack. */
+function Row(props: { n: number; focused: boolean }) {
+  useBindings(() => ({
+    enabled: props.focused,
+    bindings: [{ key: "x", id: `row.${props.n}`, cmd: () => {} }],
+  }))
+  return <text>{`row ${props.n}`}</text>
+}
+
+let footerRenders = 0
+
+/** The real nesting: the hints hook lives in a PARENT that wraps the rows. */
+function Footer(props: { children: React.ReactNode }) {
+  footerRenders++
+  const items = useStatusKeyHintItems()
+  return (
+    <box flexDirection="column">
+      {props.children}
+      <text>{`hints:${items.length}`}</text>
+    </box>
+  )
+}
+
+function App() {
+  const [rows, setRows] = useState([1, 2, 3, 4, 5])
+  const [focus, setFocus] = useState(1)
+  const [tick, setTick] = useState(0)
+  useBindings(() => ({
+    enabled: true,
+    bindings: [
+      // `d` deletes a row AND moves focus — the churn a real delete produces.
+      {
+        key: "d",
+        id: "probe.del",
+        cmd: () => {
+          setRows((r) => r.slice(1))
+          setFocus((f) => f + 1)
+        },
+      },
+      // `t` re-renders the tree while changing NONE of the hint inputs.
+      { key: "t", id: "probe.tick", cmd: () => setTick((n) => n + 1) },
+    ],
+  }))
+  return (
+    <Footer>
+      <text>{`tick ${tick}`}</text>
+      {rows.map((n) => (
+        <Row key={n} n={n} focused={n === focus} />
+      ))}
+    </Footer>
+  )
+}
+
+test("deleting rows in a burst settles instead of looping", async () => {
+  footerRenders = 0
+  const { frame, mockInput } = await renderComponent(<App />, { width: 80, height: 12 })
+  await act(async () => {})
+  const base = footerRenders
+
+  for (let i = 0; i < 5; i++) {
+    mockInput.typeText("d")
+    await act(async () => {})
+  }
+
+  // Each delete costs a bounded number of renders. An unbounded count is the
+  // loop; React's own #185 guard trips at 50 nested updates, so a per-delete
+  // budget well under that catches the runaway before React has to.
+  expect(footerRenders - base).toBeLessThan(30)
+  // Still alive and rendering (a crashed tree paints the pane-crash box).
+  expect(await frame()).toContain("hints:")
+})
+
+test("a render that changes no hint input does not re-run the snapshot", async () => {
+  // The regression guard proper. Without a dependency array this effect ran
+  // on EVERY render, which is the precondition for the loop above; the
+  // compare-and-set only hid it. Here the tree re-renders with the same
+  // focus, same bindings, same keymap — the effect must stay quiet.
+  const { frame, mockInput } = await renderComponent(<App />, { width: 80, height: 12 })
+  await act(async () => {})
+
+  footerRenders = 0
+  for (let i = 0; i < 10; i++) {
+    mockInput.typeText("t")
+    await act(async () => {})
+  }
+
+  // 10 keypresses, each one render of the tree. If the effect re-ran and
+  // re-set state on every render, this would be 20+.
+  expect(footerRenders).toBeLessThanOrEqual(12)
+  expect(await frame()).toContain("tick 10")
+})


### PR DESCRIPTION
Fixes the React #185 crash reported from `~/.rove/client.log`:

```
[20:30:36.748Z] [pane-crash] pid=32538: Minified React error #185
[20:32:47.274Z] [pane-crash] pid=74883: Minified React error #185
```

#185 is "Maximum update depth exceeded". The timestamps line up exactly with five task-deletion-audit entries in `daemon.log` (20:30:36–41, 60 → 55 tasks).

## The cycle

`useStatusKeyHintItems` snapshots its tokens in an effect with **no dependency array**, so it ran after every render. That matters because of where it renders:

- The hook lives in `WorkspaceFooter`, which wraps `props.children` — **the entire pane tree, sidebar included**.
- So its `setState` re-renders every sidebar row.
- Each row's `useBindings` bumps `stackVersion` when it registers or unregisters.
- The footer subscribes to `stackVersion` via `useSyncExternalStore` → re-renders → the effect runs again.

Deleting several tasks in a burst unmounts rows while focus and prefix state churn. Only the effect's value comparison stood between that and an infinite loop; something in that window got past it, and React tripped its own guard.

## What I did NOT confirm

The first hypothesis — that the token comparison is too weak and reports "changed" every frame — **does not hold**. I extracted that comparison and ran it: it converges in every steady state (hints disabled, modal open, normal), and `statusHintTokens` is pure with at most three stable tokens. Returning a fresh array is not enough to self-sustain.

I also could not reproduce the loop in a render probe, even with the real parent/child nesting and focus churn (five deletes cost 15 footer renders, converging). So the exact value that oscillated during the crash is still unidentified — issue #88 keeps the open threads.

**The fix does not depend on knowing it.** An effect that runs on every render, in a component whose state update re-renders its own trigger, is a loop with a value check for a brake. Declaring the inputs removes the loop's precondition rather than tightening the brake.

## The dependencies

`[keymapVersion, stackVersion, focus?.focused, dialog?.stack.length, kv]` — the two counters cover every keymap and registration change, focus and the dialog stack cover the rest of what reachability reads, and `kv` is a stable context value.

The after-commit timing the existing comment relies on is unchanged: an effect with dependencies still runs after the commit that changed them.

## Verification

`test/render/status-hints-no-loop.test.tsx`. The second case is the real guard — it re-renders the tree ten times while changing **none** of the hint inputs and asserts the effect stays quiet. Removing the dependency array fails it. The first case pins that a burst delete settles within a bounded render budget.

329 render + 3992 vitest + typecheck + lint green.