### PR TITLE
fix: let rove update install a just-published version

### DIFF
--- a/.changeset/update-no-cache.md
+++ b/.changeset/update-no-cache.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove update` can install a version that was published moments ago.
+
+bun caches the package manifest, so a just-released version came back as `No version matching "0.9.62" found for specifier "@sma1lboy/rove" (but package exists)` — a message that names neither the cache nor a way out, and reads as if the release were broken. The install now asks bun to re-fetch the manifest, and if a stale cache ever surfaces anyway, the error says so and gives the command that clears it.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -210,8 +210,18 @@ if [ "$MIGRATING" = "1" ]; then
   "$MANAGER" uninstall -g $NPM_PREFIX_ARGS "$LEGACY_PACKAGE" >>"$LOG" 2>&1 || true
 fi
 
+# bun caches the package manifest, so a version published minutes ago is
+# "not found" until that cache expires — `bun add` reports it as
+# `No version matching "X" found ... (but package exists)`, which names
+# neither the cache nor a way out. Ask bun to re-fetch the manifest instead:
+# --no-cache on the FIRST attempt costs one registry round-trip and removes
+# the entire class of "I just released it and cannot install it".
+# npm resolves dist-tags per invocation and needs nothing here.
+INSTALL_ARGS=""
+if [ "$MANAGER" = "bun" ]; then INSTALL_ARGS="--no-cache"; fi
+
 # shellcheck disable=SC2086 # empty-or-two-words, needs splitting
-"$MANAGER" install -g $NPM_PREFIX_ARGS "${PACKAGE}@${VERSION:-latest}" >>"$LOG" 2>&1 &
+"$MANAGER" install -g $NPM_PREFIX_ARGS $INSTALL_ARGS "${PACKAGE}@${VERSION:-latest}" >>"$LOG" 2>&1 &
 PID=$!
 
 if [ -t 1 ]; then
@@ -231,6 +241,15 @@ fi
 if ! wait "$PID"; then
   printf '%berror: %s install failed:%b\n' "$RED" "$MANAGER" "$RESET" >&2
   cat "$LOG" >&2
+  # bun says `No version matching "X" ... (but package exists)` for a stale
+  # manifest cache and names neither the cache nor a fix. --no-cache above
+  # should prevent it; if it still happens, say what to do rather than
+  # leaving the user with a message that reads like the version is missing.
+  if grep -q 'but package exists' "$LOG" 2>/dev/null; then
+    printf '%bThat version IS published — this is a stale package-manager cache.%b\n' "$DIM" "$RESET" >&2
+    printf '%bTry: rm -rf ~/.bun/install/cache && %s install -g %s@%s%b\n' \
+      "$DIM" "$MANAGER" "$PACKAGE" "${VERSION:-latest}" "$RESET" >&2
+  fi
   # We removed the legacy package to free the bin names, so a failed
   # install would otherwise leave the user with no kobe at all. Put it
   # back before giving up.


### PR DESCRIPTION
Hit while upgrading to 0.9.62, minutes after it published:

```
Updating @sma1lboy/rove: rove 0.9.61 -> v0.9.62 (via bun)
error: bun install failed:
error: No version matching "0.9.62" found for specifier "@sma1lboy/rove" (but package exists)
```

## Cause

bun caches the package manifest. A version published a few minutes ago is not in that cache yet, so `bun add` refuses it. The `(but package exists)` half is bun telling you it knows the package — it just cannot see that version — but the message names neither the cache nor a way out, so it reads as a broken release.

`npm view` in the same script resolved `latest` to 0.9.62 correctly, which is why the banner said `-> v0.9.62` and the install then failed: two different resolvers, one of them cached.

## Fix

`--no-cache` ("Ignore manifest cache entirely", per `bun add --help`) on the bun path. npm resolves dist-tags per invocation and needs nothing.

Verified both directions on a scratch package:

- `bun add @sma1lboy/rove@0.9.62` → resolves here (my cache was warm)
- `bun add --no-cache @sma1lboy/rove@0.9.62` → resolves, installs 0.9.62, no side effects

The failure path also learns the error: if a stale cache surfaces anyway, it now says the version *is* published and prints `rm -rf ~/.bun/install/cache && …` rather than leaving the raw bun log to speak for itself.

## Verification

`bash -n` under dash / bash / sh; shellcheck clean apart from two pre-existing SC2016 infos on lines I did not touch.