### PR TITLE
test: wait for the snapshot, don't sleep past it

### DIFF
--- a/.changeset/selection-trim-flake.md
+++ b/.changeset/selection-trim-flake.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop a terminal-selection test from racing the snapshot refresh in CI.
+
+`terminal-selection-trim` waited a fixed 80ms for the PTY backend to publish, but that backend coalesces refreshes on a 16ms timer, so a loaded CI runner could return before the state the test asserts on existed. It failed twice in one day with two different messages — `expected null not to be null` (no window published yet) and `expected 16 to be 10` (only part of the output folded in) — and blocked a release. The test now waits for the condition instead of a duration.

--- a/packages/kobe/test/tui/terminal-selection-trim.test.ts
+++ b/packages/kobe/test/tui/terminal-selection-trim.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import type { TerminalRow, TerminalSnapshotWindow } from "../../src/tui/panes/terminal/pty-types"
 import { XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
 import {
@@ -37,7 +37,17 @@ const COLS = 40
 const ROWS = 10
 const SCROLLBACK = 50
 
-const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 80))
+/**
+ * Wait for the backend to publish, rather than sleeping and hoping.
+ *
+ * `queueRefresh` coalesces on a 16ms timer, so the state this test asserts on
+ * lands some unknowable time after the last `pump`. A fixed sleep was racing
+ * that timer: on a loaded CI runner it returned early and the test failed on
+ * whatever half-built frame it found — `expected null not to be null` when no
+ * window had been published yet, `expected 16 to be 10` when only part of the
+ * output had been folded in. Both were read as flakes; both were this.
+ */
+const settleUntil = (check: () => void): Promise<void> => vi.waitFor(check, { timeout: 5000, interval: 10 })
 
 type Frame = { snapshot: readonly TerminalRow[]; window: TerminalSnapshotWindow | null }
 
@@ -48,12 +58,14 @@ describe("selection across a bounded-scrollback trim", () => {
     const unsubscribe = pty.onData(() => {})
     try {
       for (let i = 0; i < 200; i++) pty.pump(`line-${i}\r\n`)
-      await settle()
-      const before: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
       // The buffer is saturated: the backend numbers lines, and row 0 is no
-      // longer line-0. Both are preconditions for the drift, so assert them.
-      expect(before.window).not.toBeNull()
-      expect(before.snapshot.length).toBe(ROWS + SCROLLBACK)
+      // longer line-0. Both are preconditions for the drift, so WAIT for them
+      // rather than assert against whatever a fixed sleep happened to catch.
+      await settleUntil(() => {
+        expect(pty.captureWindow()).not.toBeNull()
+        expect(pty.capture().length).toBe(ROWS + SCROLLBACK)
+      })
+      const before: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
 
       // Select two whole rows in the frozen scrollback, far enough down that
       // the coming trim moves them rather than dropping them entirely.
@@ -62,9 +74,14 @@ describe("selection across a bounded-scrollback trim", () => {
       expect(text).toMatch(/^line-\d+\nline-\d+$/)
 
       for (let i = 200; i < 210; i++) pty.pump(`line-${i}\r\n`)
-      await settle()
+      // Ten more lines have to be FULLY folded in before the shift is 10; a
+      // partially-applied refresh reads as a smaller number.
+      const expectedStart = (before.window?.startLine ?? 0) + 10
+      await settleUntil(() => {
+        expect(pty.captureWindow()?.startLine).toBe(expectedStart)
+      })
       const after: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
-      expect(after.window?.startLine).toBe((before.window?.startLine ?? 0) + 10)
+      expect(after.window?.startLine).toBe(expectedStart)
 
       // The bug, stated: the untranslated endpoints now cover ten lines later.
       expect(extractSelection(after.snapshot, selected)).not.toBe(text)


### PR DESCRIPTION
`terminal-selection-trim` failed twice in one day on unrelated PRs, once blocking the 0.9.62 release. It is not random.

## Cause

The test sleeps a flat 80ms for the PTY backend to publish its frame. That backend coalesces refreshes on a **16ms timer** (`queueRefresh` in `pty-xterm-base.ts`), so the frame lands some unknowable time after the last write. On a loaded CI runner the sleep returns first, and the assertions run against a half-built frame.

That explains both observed failures, which had looked unrelated:

| message | what it means |
|---|---|
| `expected null not to be null` | no window published yet |
| `expected 16 to be 10` | only part of the output folded in |

## Fix

Both waits become `vi.waitFor` on the condition — the repo's existing idiom (`pty-hosted-first-message.test.ts`). The test now waits for the state it needs rather than for a duration that happened to be long enough on the author's machine.

## Verification

Shrinking the wait below the refresh interval reproduces the class of failure on demand — the old shape fails (`expected '' to match /^line-\d+\nline-\d+$/`), so the race is real and not inferred. The new version passes 10 consecutive runs.

I could not make the ORIGINAL 80ms version fail locally even under 8-way CPU contention, so the reproduction is of the mechanism rather than of the exact CI timing. The mechanism is enough: asserting on state produced by a timer you did not wait for is a race whether or not this machine loses it.