### PR TITLE
fix: stop an unrelated kv write from re-running the status hint effect

### DIFF
--- a/.changeset/hint-effect-kv-identity.md
+++ b/.changeset/hint-effect-kv-identity.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the workspace crashing with "Maximum update depth exceeded" on boot.
+
+The previous fix gave the status hint row's effect a dependency array, but `kv` was one of the dependencies. `KVProvider` rebuilds its context value from a `useMemo` keyed on the kv snapshot, so every `kv.set` anywhere in the app — tab adoption recording a task's tab list, a pane marking a hint used — hands the hook a brand-new `kv` object. That re-ran the effect on all of them, which is the same "runs on every render" the array was added to stop: `setSnapshot` re-renders the footer, the sidebar rows under it remount, `useBindings` bumps the stack version, the rows write kv again. Opening a workspace with a batch of tasks closed that loop and React tripped its update-depth guard before the pane finished painting.
+
+The effect now reads the hints-enabled flag during render and depends on that boolean instead of the `kv` object, so an unrelated write no longer invalidates it.

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -71,6 +71,11 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
   const dialog = useOptionalDialog()
   const keymapVersion = useKeymapVersion()
   const stackVersion = useBindingStackVersion()
+  // The ONE thing the effect needs from kv, read during render as a plain
+  // boolean. `kv` itself must not be a dependency: KVProvider rebuilds its
+  // context value on every snapshot, so any `kv.set` anywhere in the app
+  // hands this hook a new identity — see the effect's note below.
+  const hintsEnabled = keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))
   const [snapshot, setSnapshot] = useState<{ tokens: readonly StatusHintToken[]; modal: boolean }>({
     tokens: [],
     modal: false,
@@ -84,7 +89,7 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
   // compare-and-set keeps the no-change case from looping.
   // biome-ignore lint/correctness/useExhaustiveDependencies: the version/focus deps are INVALIDATION KEYS, not values this body reads — it reads live module state (currentBindingReachability, modalActive, currentPrefixConfiguration) whose changes are observable ONLY through them. Dropping them restores the no-dependency-array loop described below.
   useEffect(() => {
-    const enabled = keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))
+    const enabled = hintsEnabled
     // Two independent signals, both meaning "an overlay owns input": the
     // registered modal barrier, and a non-empty dialog stack. The stack
     // fills a render EARLIER (the workspace bindings gate themselves off
@@ -117,12 +122,24 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
     // prefix state churn) got past the compare and the workspace crashed with
     // "Maximum update depth exceeded".
     //
-    // These four ARE the effect's inputs: the two version counters cover every
+    // These ARE the effect's inputs: the two version counters cover every
     // keymap/registration change, and focus + the dialog stack cover the rest
-    // of what reachability reads. `kv` is a stable context value. The
-    // after-commit timing the comment above relies on is unchanged — an effect
-    // with dependencies still runs after the commit that changed them.
-  }, [keymapVersion, stackVersion, focus?.focused, dialog?.stack.length, kv])
+    // of what reachability reads. The after-commit timing the comment above
+    // relies on is unchanged — an effect with dependencies still runs after
+    // the commit that changed them.
+    //
+    // `kv` is NOT among them, and that is the whole fix (React #185 again,
+    // this time on boot with the dependency array already in place).
+    // `KVProvider` rebuilds its context value from a `useMemo` keyed on the
+    // kv snapshot, so EVERY `kv.set` anywhere in the app — tab adoption
+    // writing a task's tab list, a pane marking a hint used — hands this hook
+    // a brand-new `kv` object. As a dependency that re-ran the effect on all
+    // of them, which is the same "runs on every render" the array was
+    // supposed to stop: setSnapshot -> footer re-render -> sidebar rows
+    // remount -> stackVersion bumps -> kv writes -> round again, 50 deep.
+    // Only the enabled FLAG is read here, so depend on that boolean instead:
+    // it changes when the user toggles hints, not when unrelated state lands.
+  }, [keymapVersion, stackVersion, focus?.focused, dialog?.stack.length, hintsEnabled])
   // Click = the action the advertised key would run. Arming the prefix goes
   // through the REAL dispatcher state, so the which-key guide that appears
   // accepts a keyboard second stroke exactly like a pressed ctrl+a.
@@ -146,7 +163,7 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
   // terminals disagree on whether it takes 1 or 2 cells and the row
   // misaligns per OS/font. Stays on screen while a modal owns input, but
   // inert — Settings must not open under a dialog.
-  if (opts?.onOpenSettings && !opts.compact && keyHintsEnabled(kv?.get(KEY_HINTS_ENABLED_KEY, true))) {
+  if (opts?.onOpenSettings && !opts.compact && hintsEnabled) {
     items.push({
       text: `[${t("hints.status.settings")}]`,
       bindingId: "settings.open",

--- a/packages/kobe/test/render/status-hints-kv-identity.test.tsx
+++ b/packages/kobe/test/render/status-hints-kv-identity.test.tsx
@@ -1,0 +1,103 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The status hint effect must not re-run because unrelated state was
+ * persisted.
+ *
+ * React #185 again, on BOOT this time, with #702's dependency array already
+ * in place: `kv` was one of those dependencies, and `KVProvider` rebuilds
+ * its context value from a `useMemo` keyed on the kv snapshot. Every
+ * `kv.set` anywhere in the app — tab adoption recording a task's tab list,
+ * a pane marking its hint used — therefore handed the hook a NEW `kv`
+ * object and re-ran the effect, which is the same "runs on every render"
+ * the array was added to stop. setSnapshot re-renders the footer, the
+ * sidebar rows under it remount, `useBindings` bumps the stack version, the
+ * rows write kv again, and the workspace crashed 50 nested updates later.
+ *
+ * `status-hints-no-loop.test.tsx` mounts WITHOUT a KV provider, so `kv` is
+ * null there and stays referentially stable — which is why it stayed green
+ * through the crash. This file mounts the real provider and writes to it.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { useStatusKeyHintItems } from "../../src/tui-react/component/keyboard-hints"
+import { useKV } from "../../src/tui-react/context/kv"
+import { useBindings } from "../../src/tui-react/lib/keymap"
+import { act, renderComponent } from "./harness"
+
+// KVProvider persists to `$KOBE_HOME_DIR` — the real ~/.rove without this.
+// Per-FILE (beforeAll), matching host-version-skew-banner.test.tsx: bun runs
+// every file in one process, and a beforeEach snapshot would restore whatever
+// the previous file left behind.
+let previousHome: string | undefined
+
+beforeAll(() => {
+  previousHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-hint-kv-"))
+})
+
+afterAll(() => {
+  if (previousHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = previousHome
+})
+
+let footerRenders = 0
+
+/** A sidebar row: registers bindings, so mounting/unmounting bumps the stack. */
+function Row(props: { n: number }) {
+  useBindings(() => ({ enabled: true, bindings: [{ key: "x", id: `row.${props.n}`, cmd: () => {} }] }))
+  return <text>{`row ${props.n}`}</text>
+}
+
+/** The real nesting: the hints hook lives in a PARENT that wraps the rows. */
+function Footer(props: { children: React.ReactNode }) {
+  footerRenders++
+  const items = useStatusKeyHintItems()
+  return (
+    <box flexDirection="column">
+      {props.children}
+      <text>{`hints:${items.length}`}</text>
+    </box>
+  )
+}
+
+function App() {
+  const kv = useKV()
+  // `w` persists something the hint bar does not read — a stand-in for tab
+  // adoption or any other background write.
+  useBindings(() => ({
+    enabled: true,
+    bindings: [{ key: "w", id: "probe.write", cmd: () => kv.set("probe.counter", Date.now()) }],
+  }))
+  return (
+    <Footer>
+      <Row n={1} />
+      <Row n={2} />
+      <Row n={3} />
+    </Footer>
+  )
+}
+
+test("an unrelated kv write does not re-run the hint snapshot", async () => {
+  const { frame, mockInput } = await renderComponent(<App />, {
+    width: 80,
+    height: 10,
+    providers: { kv: true, focus: true, dialog: true },
+  })
+  await act(async () => {})
+
+  footerRenders = 0
+  for (let i = 0; i < 10; i++) {
+    mockInput.typeText("w")
+    await act(async () => {})
+  }
+
+  // Each write re-renders the footer once (the kv context value is new, and
+  // this hook subscribes to it). What must NOT happen is the effect firing
+  // and re-setting state on top of that — that second render per write is
+  // the feedback edge that closed the loop.
+  expect(footerRenders).toBeLessThanOrEqual(12)
+  expect(await frame()).toContain("hints:")
+})


### PR DESCRIPTION
## What broke

`rove` 0.9.62 crashes the workspace to the pane-crash placeholder on boot — React error #185, "Maximum update depth exceeded". Three crashes in `~/.rove/client.log`, each one right after `subscribed as gui (20 tasks)`.

## Root cause

#702 fixed the same error by giving `useStatusKeyHintItems`' effect a dependency array. `kv` was one of those dependencies.

`KVProvider` builds its context value with `useMemo(..., [core, snapshot])`, and `snapshot` comes from `useSyncExternalStore` — so **every** `kv.set` anywhere in the app produces a new `kv` object. Boot subscribes 20 tasks, each writing its tab list through `adoptTaskTabs` → `kv.set`. Depending on `kv` therefore re-ran the effect on all of them, which is the same "runs on every render" the array was added to stop:

```
setSnapshot → footer re-renders → sidebar rows remount
  → useBindings bumps stackVersion → rows write kv → round again
```

50 nested updates later React trips its guard.

## Fix

Read the hints-enabled flag during render (the only thing the effect wants from `kv`) and depend on that boolean. It changes when the user toggles hints, not when unrelated state lands.

## Why the existing test stayed green

`status-hints-no-loop.test.tsx` mounts without a KV provider, so `kv` is `null` and referentially stable — the crashing dependency was inert there. The new test mounts the real provider and writes to it.

## Verification

Mutation: restoring `kv` to the dependency array turns the new test red at 15 renders vs. the ≤12 budget, stable across 3 runs. Reverting the mutation returns all 3 tests green. Root `bun run lint` and `bun run typecheck` clean.