### PR TITLE
fix: let a forced delete clear a task whose worktree lost its repo

### DIFF
--- a/.changeset/orphaned-worktree-force-delete.md
+++ b/.changeset/orphaned-worktree-force-delete.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Let a forced delete clear a task whose worktree lost its repo.
+
+When a worktree's upstream checkout is destroyed — a deleted clone, or macOS pruning one under `/tmp` — `git worktree remove` has nothing to resolve, so removal threw and the task stuck at `deletion.phase: "error"`. Retrying re-ran the same unsatisfiable path, and `--force` never reached: the repo lookup threw before the force flag was read. No supported command could clear the entry; the only way out was moving the directory by hand so Rove took its path-does-not-exist branch.
+
+A forced removal now deletes the orphaned directory outright, guarded by path — only a directory under a Rove-managed worktrees root qualifies, so force is still not permission to delete something Rove never created. Without `force` the case stays an error, as before.

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -1,0 +1,147 @@
+/**
+ * `remove()`, split out of `manager.ts` (file-size cap).
+ *
+ * Worktree removal is the module's one destructive verb, and every safety
+ * decision it makes — the dirty gate, the salvage snapshot, the orphaned-repo
+ * fallback and its managed-root guard — lives in this single function. Same
+ * shape as `manager-branch.ts` / `manager-list.ts`: a free function over a
+ * small deps object, with the class method a thin delegator. No behaviour
+ * change in the extraction.
+ */
+
+import type { ExecHost } from "../../exec/exec-host.ts"
+import type { GitRunOpts, GitRunResult } from "./git.ts"
+import { type BranchDeps, deleteBranchAnchored } from "./manager-branch.ts"
+import { isUnderManagedWorktreesRoot, requireAbsolute } from "./paths.ts"
+import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
+
+export interface RemoveOpts {
+  readonly force?: boolean
+  readonly deleteBranch?: boolean
+  /** Notified with the snapshot a force-removal took (null = nothing to
+   *  save, or the snapshot could not be written). */
+  readonly onSalvage?: (record: SalvageRecord | null) => void
+}
+
+/** The manager primitives removal borrows. */
+export interface RemoveDeps {
+  runGit(exec: ExecHost, args: readonly string[], opts: GitRunOpts): Promise<GitRunResult>
+  /** ExecHost for a worktree path. */
+  execForPath(worktreePath: string): ExecHost
+  /** The repo owning a worktree path, or null when it isn't one. */
+  findRepoFor(exec: ExecHost, worktreePath: string): Promise<string | null>
+  /** The worktree's checked-out branch. */
+  currentBranch(worktreePath: string): Promise<string | null>
+  /** Whether the worktree has uncommitted or untracked changes. */
+  isDirty(worktreePath: string): Promise<boolean>
+  /** Deps for the opt-in post-removal branch delete. */
+  branchDeps(): BranchDeps
+}
+
+/**
+ * Remove a worktree. Refuses to remove a dirty worktree unless `opts.force`
+ * is true.
+ *
+ * On success the directory is gone and the worktree is deregistered from the
+ * repo's metadata. The branch is left in place UNLESS `opts.deleteBranch` is
+ * set — then it's also deleted (`git branch -d`, or `-D` under `force`), so a
+ * task delete/land doesn't leave the loser branch piling up. Branch deletion
+ * is best-effort: it runs after the worktree is gone and a failure (branch
+ * checked out elsewhere, name gone) is swallowed, never masking a successful
+ * removal.
+ *
+ * `force` also covers the case where the worktree has no reachable owning repo
+ * (its upstream `.git` was destroyed): there is no `git worktree remove` to
+ * run, so a forced removal deletes the orphaned directory outright — but only
+ * when it sits under a Rove-managed worktrees root. Without `force` that case
+ * still throws, as before.
+ *
+ * `force` bypasses the dirty check, so uncommitted edits and untracked files
+ * are destroyed. Every force path first takes a salvage snapshot
+ * ({@link salvageWorktree}) into `refs/rove/salvage/<branch>-<stamp>` — this is
+ * the one chokepoint all three force callers share, so the guard lives here
+ * rather than in each of them. `onSalvage` reports the ref so the caller can
+ * surface it; salvage never fails the removal the caller asked for.
+ */
+export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opts?: RemoveOpts): Promise<void> {
+  requireAbsolute("path", worktreePath)
+  const exec = deps.execForPath(worktreePath)
+  const force = opts?.force === true
+
+  if (!(await exec.exists(worktreePath))) {
+    // Best-effort metadata prune — the directory may be gone but a stale
+    // entry can survive in `.git/worktrees/`. `git worktree remove` will
+    // refuse, so we use prune.
+    const goneRepo = await deps.findRepoFor(exec, worktreePath)
+    if (goneRepo) await deps.runGit(exec, ["worktree", "prune"], { cwd: goneRepo, allowFail: true })
+    return
+  }
+
+  // Resolve the owning repo via `rev-parse --git-common-dir` from inside the
+  // worktree itself. This is the only reliable way to get back to the main
+  // repo when the caller hands us only the path.
+  const repo = await deps.findRepoFor(exec, worktreePath)
+  if (!repo) {
+    // No owning repo: the upstream checkout's `.git` is gone (a deleted
+    // clone, or macOS pruning a checkout under `/tmp`), so there is no
+    // `git worktree remove` to run and no metadata left to deregister.
+    //
+    // Without `force` this stays an error — the directory may hold work and
+    // the caller has not said to destroy it. WITH force, refusing is the
+    // worse answer: the deletion state machine marks the task
+    // `deletion.phase: "error"`, and every retry re-runs this same
+    // unsatisfiable path, so the entry can never be removed by any supported
+    // command. `force` already means "delete it even though I can't verify
+    // what's inside"; an unreachable repo is one more case of exactly that.
+    //
+    // Guarded by path, not by trust in the caller: only a directory under a
+    // Rove-managed worktrees root is ours to delete outright.
+    if (!force) {
+      throw new Error(`remove(): ${worktreePath} is not a git worktree`)
+    }
+    if (!isUnderManagedWorktreesRoot(worktreePath)) {
+      throw new Error(
+        `remove(): ${worktreePath} has no reachable git repo and is not under a Rove worktrees root; refusing to delete it`,
+      )
+    }
+    // No salvage: it needs `git` in the worktree, and reaching this point
+    // means git cannot resolve one.
+    opts?.onSalvage?.(null)
+    await exec.run(["rm", "-rf", worktreePath])
+    return
+  }
+
+  // Capture the branch BEFORE removal (once the worktree is gone we can't
+  // read its HEAD) so an opt-in `deleteBranch` can clean it up after.
+  const branch = opts?.deleteBranch ? await deps.currentBranch(worktreePath).catch(() => null) : null
+
+  if (force) {
+    // The last moment at which the doomed files still exist. The dirty check
+    // below is exactly what `force` skips, so this is also the only place
+    // that still sees what is being skipped over.
+    const salvaged = await salvageWorktree({ runGit: (e, a, o) => deps.runGit(e, a, o) }, exec, worktreePath)
+    opts?.onSalvage?.(salvaged)
+  } else {
+    const dirty = await deps.isDirty(worktreePath)
+    if (dirty) {
+      throw new Error(
+        `remove(): refusing to remove dirty worktree at ${worktreePath} (pass { force: true } to override)`,
+      )
+    }
+  }
+
+  // `--force` here is the git CLI's "remove even if locked / has submodule
+  // mods" flag. Even with our `force=false` early-out, we pass --force to git
+  // so an unlocked-but-untracked-files case (rare — we already checked dirty)
+  // doesn't bounce. Dirty refusal lives in our layer, not git's.
+  const args = force ? ["worktree", "remove", "--force", worktreePath] : ["worktree", "remove", worktreePath]
+  await deps.runGit(exec, args, { cwd: repo })
+
+  // Defensive prune — cleans up `.git/worktrees/<name>/` if the remove left
+  // it behind (rare, but documented in vibe-kanban).
+  await deps.runGit(exec, ["worktree", "prune"], { cwd: repo, allowFail: true })
+
+  // Anchored like `deleteBranch`: `-D` takes the reflog too, and this
+  // worktree's own reflog died with the directory a few lines up.
+  if (branch) await deleteBranchAnchored(deps.branchDeps(), exec, repo, branch, { force })
+}

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -40,6 +40,7 @@ import {
   renameBranch,
 } from "./manager-branch.ts"
 import { type ListDeps, adoptablePaths, listAllAdoptable, listBranchNames, listManaged } from "./manager-list.ts"
+import { type RemoveOpts, removeWorktree } from "./manager-remove.ts"
 import { canonicalize, remoteWorktreePathFor, requireAbsolute, worktreePathFor } from "./paths.ts"
 import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
 import { parseWorktreeListPorcelain } from "./worktree-list.ts"
@@ -191,90 +192,22 @@ export class GitWorktreeManager implements WorktreeManager {
     return this.create(args.repo, args.branch, target, args.baseRef)
   }
 
-  /**
-   * Remove a worktree. Refuses to remove a dirty worktree unless
-   * `opts.force` is true.
-   *
-   * On success the directory is gone and the worktree is deregistered from the
-   * repo's metadata. The branch is left in place UNLESS `opts.deleteBranch` is
-   * set — then it's also deleted (`git branch -d`, or `-D` under `force`), so a
-   * task delete/land doesn't leave the loser branch piling up. Branch deletion
-   * is best-effort: it runs after the worktree is gone and a failure (branch
-   * checked out elsewhere, name gone) is swallowed, never masking a successful
-   * removal.
-   *
-   * `force` bypasses the dirty check, so uncommitted edits and untracked files
-   * are destroyed. Every force path first takes a salvage snapshot
-   * ({@link salvageWorktree}) into `refs/rove/salvage/<branch>-<stamp>` — this
-   * is the one chokepoint all three force callers share, so the guard lives
-   * here rather than in each of them. `onSalvage` reports the ref so the caller
-   * can surface it; salvage never fails the removal the caller asked for.
-   */
-  async remove(
-    worktreePath: string,
-    opts?: {
-      readonly force?: boolean
-      readonly deleteBranch?: boolean
-      /** Notified with the snapshot a force-removal took (null = nothing to
-       *  save, or the snapshot could not be written). */
-      readonly onSalvage?: (record: SalvageRecord | null) => void
-    },
-  ): Promise<void> {
-    requireAbsolute("path", worktreePath)
-    const exec = this.execDeps.execForPath(worktreePath)
-    const force = opts?.force === true
-
-    if (!(await exec.exists(worktreePath))) {
-      // Best-effort metadata prune — the directory may be gone but a
-      // stale entry can survive in `.git/worktrees/`. `git worktree
-      // remove` will refuse, so we use prune.
-      const repo = await this.findRepoFor(exec, worktreePath)
-      if (repo) await this.runGit(exec, ["worktree", "prune"], { cwd: repo, allowFail: true })
-      return
-    }
-
-    // Resolve the owning repo via `rev-parse --git-common-dir` from
-    // inside the worktree itself. This is the only reliable way to get
-    // back to the main repo when the caller hands us only the path.
-    const repo = await this.findRepoFor(exec, worktreePath)
-    if (!repo) {
-      throw new Error(`remove(): ${worktreePath} is not a git worktree`)
-    }
-
-    // Capture the branch BEFORE removal (once the worktree is gone we can't
-    // read its HEAD) so an opt-in `deleteBranch` can clean it up after.
-    const branch = opts?.deleteBranch ? await this.currentBranch(worktreePath).catch(() => null) : null
-
-    if (force) {
-      // The last moment at which the doomed files still exist. The dirty check
-      // below is exactly what `force` skips, so this is also the only place
-      // that still sees what is being skipped over.
-      const salvaged = await salvageWorktree({ runGit: (e, a, o) => this.runGit(e, a, o) }, exec, worktreePath)
-      opts?.onSalvage?.(salvaged)
-    } else {
-      const dirty = await this.isDirty(worktreePath)
-      if (dirty) {
-        throw new Error(
-          `remove(): refusing to remove dirty worktree at ${worktreePath} (pass { force: true } to override)`,
-        )
-      }
-    }
-
-    // `--force` here is the git CLI's "remove even if locked / has
-    // submodule mods" flag. Even with our `force=false` early-out, we
-    // pass --force to git so an unlocked-but-untracked-files case (rare
-    // — we already checked dirty) doesn't bounce. Dirty refusal lives
-    // in our layer, not git's.
-    const args = force ? ["worktree", "remove", "--force", worktreePath] : ["worktree", "remove", worktreePath]
-    await this.runGit(exec, args, { cwd: repo })
-
-    // Defensive prune — cleans up `.git/worktrees/<name>/` if the
-    // remove left it behind (rare, but documented in vibe-kanban).
-    await this.runGit(exec, ["worktree", "prune"], { cwd: repo, allowFail: true })
-
-    // Anchored like `deleteBranch`: `-D` takes the reflog too, and this
-    // worktree's own reflog died with the directory a few lines up.
-    if (branch) await deleteBranchAnchored(this.branchDeps(), exec, repo, branch, { force })
+  /** Remove a worktree — body in `manager-remove.ts` (file-size cap). Refuses
+   *  a dirty worktree unless `opts.force`; a forced removal salvages first and
+   *  can also clear a worktree whose upstream repo is gone. */
+  async remove(worktreePath: string, opts?: RemoveOpts): Promise<void> {
+    await removeWorktree(
+      {
+        runGit: (exec, args, runOpts) => this.runGit(exec, args, runOpts),
+        execForPath: (p) => this.execDeps.execForPath(p),
+        findRepoFor: (exec, p) => this.findRepoFor(exec, p),
+        currentBranch: (p) => this.currentBranch(p),
+        isDirty: (p) => this.isDirty(p),
+        branchDeps: () => this.branchDeps(),
+      },
+      worktreePath,
+      opts,
+    )
   }
 
   /** Delete a branch in `repo` — body in `manager-branch.ts`. A forced delete

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -214,6 +214,43 @@ export function isKobeManagedPath(repo: string, candidate: string): boolean {
 }
 
 /**
+ * True iff `candidate` sits under a Rove-managed worktrees root, WITHOUT
+ * needing to know which repo owns it.
+ *
+ * `isKobeManagedPath` answers the same question but takes a repo, and the one
+ * caller that needs this is the case where the repo can no longer be resolved:
+ * a worktree whose upstream `.git` was destroyed (macOS pruning `/tmp`, a
+ * deleted checkout) has no discoverable owner, so `remove()` cannot use the
+ * repo-keyed form to decide whether the directory is its own to delete.
+ *
+ * Only the roots THEMSELVES are checked, not the per-repo subdir under them —
+ * that subdir is derived from the repo path this function does not have. The
+ * guard is deliberately narrow: it authorizes deleting a directory tree, so it
+ * must never say yes to a path Rove did not create. A repo-local root
+ * (`<repo>/.rove/worktrees`) is not recognized here — that form needs the repo
+ * to locate, which is exactly what is missing. Same for a `$project_dir`
+ * override: it expands per-repo, so without one it contributes nothing and the
+ * built-in default covers what is left.
+ */
+export function isUnderManagedWorktreesRoot(candidate: string): boolean {
+  if (!path.isAbsolute(candidate)) return false
+  const target = canonicalize(candidate)
+  // The override with no repo resolves the non-`$project_dir` forms; a
+  // `$project_dir` override falls back to the default root without one, which
+  // this list already covers.
+  const roots = [getWorktreeBaseOverride() ?? "", defaultLocalWorktreesRoot(), legacyLocalWorktreesRoot()]
+  for (const rootPath of roots) {
+    if (!rootPath) continue
+    const root = canonicalize(rootPath)
+    const rel = path.relative(root, target)
+    // Non-empty (the root itself is not a worktree), no ".." prefix (outside),
+    // not absolute (different drive on Windows).
+    if (rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel)) return true
+  }
+  return false
+}
+
+/**
  * Worktree layout for a REMOTE project. The local `~/.rove/worktrees/...`
  * root can't be used — the worktree lives on the remote host. We root it
  * under the project's remote `basePath` in a `.rove/worktrees/<slug>` subdir

--- a/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { execSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
@@ -17,6 +17,10 @@ import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
 let root: string
 let repo: string
 let manager: GitWorktreeManager
+/** `<home>/.rove/worktrees` for the temp home below — the root that makes a
+ *  path Rove's to delete outright (see isUnderManagedWorktreesRoot). */
+let managedRoot: string
+let previousHome: string | undefined
 
 const gitEnv = {
   ...process.env,
@@ -28,6 +32,13 @@ const gitEnv = {
 
 beforeAll(() => {
   root = realpathSync(mkdtempSync(join(tmpdir(), "kobe-wtm-edge-")))
+  // The managed-roots guard reads `$KOBE_HOME_DIR`; point it at the temp root
+  // so the orphaned-worktree cases below exercise a REAL managed root instead
+  // of the developer's own `~/.rove`.
+  previousHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = root
+  managedRoot = join(root, ".rove", "worktrees")
+  mkdirSync(managedRoot, { recursive: true })
   repo = join(root, "repo")
   mkdirSync(repo)
   execSync("git init -q -b main && git commit -q --allow-empty -m init", { cwd: repo, env: gitEnv })
@@ -35,6 +46,8 @@ beforeAll(() => {
 })
 
 afterAll(() => {
+  if (previousHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = previousHome
   rmSync(root, { recursive: true, force: true })
 })
 
@@ -61,6 +74,55 @@ describe("remove() / currentBranch() edges", () => {
     const plain = join(root, "plain-dir")
     mkdirSync(plain)
     await expect(manager.remove(plain)).rejects.toThrow(/is not a git worktree/)
+  })
+
+  it("remove({force}) deletes a worktree whose upstream repo is gone", async () => {
+    // Field report: macOS pruned a checkout under `/tmp`, taking its `.git`
+    // with it. The orphaned worktree then had no resolvable owning repo, so
+    // `git worktree remove` could never run — the task sat in
+    // `deletion.phase: "error"` and every retry re-ran the same
+    // unsatisfiable path, with no supported command able to clear it.
+    const owner = join(root, "doomed-repo")
+    mkdirSync(owner)
+    execSync("git init -q -b main && git commit -q --allow-empty -m init", { cwd: owner, env: gitEnv })
+    // Under a managed root, which is what authorizes the outright delete.
+    const wt = join(managedRoot, "orphaned")
+    await manager.create(owner, "kobe/orphaned", wt)
+    writeFileSync(join(wt, "output.txt"), "work")
+    rmSync(join(owner, ".git"), { recursive: true, force: true }) // upstream dies
+
+    await expect(manager.remove(wt, { force: true })).resolves.toBeUndefined()
+    expect(existsSync(wt)).toBe(false)
+  })
+
+  it("remove() without force still refuses an orphaned worktree", async () => {
+    // `force` is what carries the "delete it even though I cannot verify
+    // what's inside" consent. Without it the unresolvable repo stays an error
+    // and the directory stays put.
+    const owner = join(root, "doomed-repo-2")
+    mkdirSync(owner)
+    execSync("git init -q -b main && git commit -q --allow-empty -m init", { cwd: owner, env: gitEnv })
+    const wt = join(managedRoot, "orphaned-keep")
+    await manager.create(owner, "kobe/orphaned-keep", wt)
+    rmSync(join(owner, ".git"), { recursive: true, force: true })
+
+    await expect(manager.remove(wt)).rejects.toThrow(/is not a git worktree/)
+    expect(existsSync(wt)).toBe(true)
+  })
+
+  it("remove({force}) refuses an orphaned directory outside the managed roots", async () => {
+    // The guard that keeps this from becoming "force deletes any path": an
+    // unreachable repo plus force is still not permission to delete a
+    // directory Rove never created.
+    const owner = join(root, "doomed-repo-3")
+    mkdirSync(owner)
+    execSync("git init -q -b main && git commit -q --allow-empty -m init", { cwd: owner, env: gitEnv })
+    const wt = join(root, "outside-managed") // NOT under a managed root
+    await manager.create(owner, "kobe/outside", wt)
+    rmSync(join(owner, ".git"), { recursive: true, force: true })
+
+    await expect(manager.remove(wt, { force: true })).rejects.toThrow(/not under a Rove worktrees root/)
+    expect(existsSync(wt)).toBe(true)
   })
 
   it("remove() of an already-deleted worktree dir resolves quietly (best-effort prune)", async () => {


### PR DESCRIPTION
## The deadlock

A worktree whose upstream checkout was destroyed — a deleted clone, or macOS pruning one under `/tmp` — has no resolvable owning repo. `remove()` threw on that:

```ts
const repo = await this.findRepoFor(exec, worktreePath)
if (!repo) throw new Error(`remove(): ${worktreePath} is not a git worktree`)
```

The task then sat at `deletion.phase: "error"`, and every retry re-ran the same unsatisfiable path. `--force` never got a say — the repo lookup throws *before* the force flag is read — so no supported command could clear the entry. The only way out was moving the directory by hand so Rove took its path-does-not-exist branch.

Field report: `~/.rove/worktrees/claude_arm-cf4e759d0d41/lamprey`, upstream `/private/tmp/ocr-batch/caption_regen/claude_arm/.git` eaten by `/tmp` cleanup. The daemon kept polling PR status for the stuck task every minute.

## The fix

A forced removal deletes the orphaned directory outright. Guarded by path, not by trusting the caller: only a directory under a Rove-managed worktrees root qualifies, so `force` is still not permission to delete something Rove never created. Without `force` the case stays an error, unchanged.

New `isUnderManagedWorktreesRoot()` answers "is this ours" *without* a repo — `isKobeManagedPath` needs one, which is exactly what's missing here.

## Tests

Three cases in `worktree-manager-edges.test.ts`, against real temp git repos with the upstream `.git` deleted mid-test:

- forced removal of an orphaned worktree succeeds and the directory is gone
- without `force` it still refuses, directory intact
- with `force` but outside the managed roots it refuses, directory intact

Verified red before the fix (2 of 3 failed), and both guards mutation-checked: stubbing out the managed-root check reds the safety test, stubbing out the `!force` gate reds the no-force test.

`remove()` moved to `manager-remove.ts` — the change pushed `manager.ts` to 526 lines, over the cap; it is now 421 (baseline was 488). Same extraction shape as the existing `manager-branch.ts` / `manager-list.ts`.