### PR TITLE
chore: stop publishing the @sma1lboy/kobe compatibility alias

### DIFF
--- a/.changeset/stop-publishing-kobe-alias.md
+++ b/.changeset/stop-publishing-kobe-alias.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop publishing the `@sma1lboy/kobe` compatibility alias.
+
+Releases shipped the CLI under both names through the rename. The old name is frozen at 0.9.64: an existing install keeps working and its update check reports the newest `@sma1lboy/rove`, but new versions are published under the canonical name only. Reinstall as `@sma1lboy/rove` to keep receiving updates.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -177,8 +177,9 @@ gh run watch <run-id> --exit-status                    # blocks until done; nonz
 On success, verify the canonical package and its compatibility alias actually landed (don't trust the green check alone):
 
 ```bash
-npm view @sma1lboy/rove@<new-version> version          # canonical package; must echo the new version
-npm view @sma1lboy/kobe@<new-version> version          # compatibility alias; must match
+npm view @sma1lboy/rove@<new-version> version          # the published package; must echo the new version
+# @sma1lboy/kobe is NOT published anymore (frozen at 0.9.64) — do not check it,
+# and do not "fix" its absence from a release.
 # Every Rove release checks the SDK's current version and publishes either
 # missing package name, even without a new SDK changeset. Always verify both
 # names at the version recorded in packages/kobe-plugin-sdk/package.json:
@@ -187,8 +188,8 @@ npm view @sma1lboy/kobe-plugin-sdk@<sdk-version> version
 gh release view v<new-version> --json name -q .name    # GitHub release exists
 ```
 
-Confirm: the canonical and compatibility names for both Rove and the SDK report
-their expected versions, the Rove version matches the tag and `packages/kobe/package.json`,
+Confirm: `@sma1lboy/rove` and both SDK names report their expected versions,
+the Rove version matches the tag and `packages/kobe/package.json`,
 and the release landed on `main` (`git log --oneline -1 origin/main` is the `chore: release` commit).
 Then report done with the version, the npm dist-tag it went to (`latest` for
 plain semver), and the release URL.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,8 +234,14 @@ jobs:
 
       - name: Publish canonical @sma1lboy/rove package
         # Workspaces hoist deps to root; publish from the package directory.
-        # The version check makes a rerun continue to the compatibility alias
-        # after a partial release instead of failing on an existing version.
+        # The version check keeps a rerun idempotent instead of failing on an
+        # existing version.
+        #
+        # `@sma1lboy/kobe` is NOT published anymore (0.9.64 is its last
+        # version). Releases shipped both names through the rename; the old
+        # name is now frozen, and `rove update` on an installation of it
+        # reports the newest @sma1lboy/rove. Nothing here should start
+        # publishing it again — see docs/RELEASING.md.
         working-directory: packages/kobe
         run: |
           V=$(node -p "require('./package.json').version")
@@ -244,33 +250,6 @@ jobs:
           else
             npm publish --access public --provenance --tag "${{ steps.channel.outputs.dist_tag }}"
           fi
-
-      - name: Publish compatibility alias @sma1lboy/kobe
-        # Existing installs still point at the old package name. Every release
-        # therefore ships BOTH names from ONE build: same files, version, and
-        # `kobe` + `rove` bins; only package.json#name differs.
-        #
-        # Publishing from a rewritten package.json rather than a second
-        # package dir keeps them impossible to skew: there is one source of
-        # version, files, and deps. `--ignore-scripts` skips the
-        # `prepublishOnly` typecheck+build that already ran for the publish
-        # above — dist/ is the artifact both names share.
-        working-directory: packages/kobe
-        run: |
-          V=$(node -p "require('./package.json').version")
-          if npm view "@sma1lboy/kobe@$V" version >/dev/null 2>&1; then
-            echo "@sma1lboy/kobe@$V already on npm — skipping"
-            exit 0
-          fi
-          cp package.json package.json.bak
-          node -e "
-            const fs = require('fs')
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
-            pkg.name = '@sma1lboy/kobe'
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
-          "
-          npm publish --access public --provenance --ignore-scripts --tag "${{ steps.channel.outputs.dist_tag }}"
-          mv package.json.bak package.json
 
       - name: Publish canonical plugin SDK (piggyback, idempotent)
         # The SDK versions independently via changesets but has no tag of

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ reuse their directory and do not own a Rove-created worktree or branch.
 
 ## 2. Package map
 
-- `packages/kobe/` — CLI and PureTUI, published canonically as `@sma1lboy/rove` and in lockstep as the `@sma1lboy/kobe` compatibility alias.
+- `packages/kobe/` — CLI and PureTUI, published as `@sma1lboy/rove`. (The directory keeps its old name; the `@sma1lboy/kobe` package was published in lockstep until 0.9.64 and is now frozen.)
   - `src/cli/` — command routing, help, API handlers, daemon and PTY-host
     process entrypoints.
   - `src/engine/` — engine registry, command/capability/history adapters,

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,8 @@
 # Releasing Rove
 
-Rove versioning + changelog are managed with [Changesets](https://github.com/changesets/changesets). The canonical package is `@sma1lboy/rove` (`packages/kobe`); the release job republishes that exact build as `@sma1lboy/kobe` for existing installs. `packages/branding` is `private` and never published.
+Rove versioning + changelog are managed with [Changesets](https://github.com/changesets/changesets). The published package is `@sma1lboy/rove` (`packages/kobe`). `packages/branding` is `private` and never published.
+
+`@sma1lboy/kobe` was the package name before the rename and was published in lockstep through 0.9.64. It is frozen there — releases no longer publish it. An install of the old name keeps working and its update check reports the newest `@sma1lboy/rove`; reinstalling under the new name is the way forward.
 
 ## The flow
 
@@ -19,7 +21,7 @@ This prompts for the bump type (**patch** / **minor** / **major**) and a summary
 - The API lookup needs a `GITHUB_TOKEN`: the Changesets workflow passes its Actions token; `scripts/release.sh` takes `gh auth token`. No token → `changeset version` fails loudly rather than shipping uncredited entries.
 - A pure tooling / docs / CI change that doesn't touch the published package needs **no** changeset. If you want to record "intentionally nothing to release", run `bun run changeset -- --empty`.
 - Bump type: default to `patch` for every change, including features and pre-1.0 breaking changes. Use `minor` or `major` only when the maintainer explicitly requests that bump for the change being released.
-- The frontmatter must name a **publishable workspace package** — today `"@sma1lboy/rove"` or `"@sma1lboy/rove-plugin-sdk"`. The `@sma1lboy/kobe` names are compatibility aliases that still publish alongside, but a changeset must not version them (they were canonical before 2026-08-13, so stale examples are all over the git history — don't copy an old changeset).
+- The frontmatter must name a **publishable workspace package** — today `"@sma1lboy/rove"` or `"@sma1lboy/rove-plugin-sdk"`. Never `"@sma1lboy/kobe"`: the CLI under that name is no longer published, and the SDK alias is published from the canonical version rather than versioned on its own. Those names were canonical before 2026-08-13, so stale examples are all over the git history — don't copy an old changeset.
 
 Validate before committing:
 
@@ -108,6 +110,6 @@ That ordering is why `isNewerSemver` compares prerelease tails while `compareSem
 
 ## Prereleases
 
-A prerelease tag (`v0.7.0-experimental.0`) publishes to an npm dist-tag named after the prerelease identifier (`experimental`), so `latest` stays on the stable line while testers opt in with `npm i @sma1lboy/rove@experimental`. The matching `@sma1lboy/kobe@experimental` alias is published in lockstep. Use Changesets' [prerelease mode](https://github.com/changesets/changesets/blob/main/docs/prereleases.md) (`changeset pre enter experimental` … `changeset pre exit`) to generate those versions.
+A prerelease tag (`v0.7.0-experimental.0`) publishes to an npm dist-tag named after the prerelease identifier (`experimental`), so `latest` stays on the stable line while testers opt in with `npm i @sma1lboy/rove@experimental`. Use Changesets' [prerelease mode](https://github.com/changesets/changesets/blob/main/docs/prereleases.md) (`changeset pre enter experimental` … `changeset pre exit`) to generate those versions.
 
 This is the manual, one-off cousin of the nightly channel: same dist-tag mechanism, but tagged and versioned through `main` rather than cut daily into a throwaway tree.

--- a/docs/design/rove-rename.md
+++ b/docs/design/rove-rename.md
@@ -23,7 +23,7 @@ Rove is the canonical product name and `rove` is the canonical CLI command. Prod
 | Surface | Preserved value | Reason |
 |---|---|---|
 | Legacy executable | `kobe` | Existing scripts and global installs keep working |
-| Legacy npm package | `@sma1lboy/kobe` | Published from the same build/version as `@sma1lboy/rove`, so existing global installs keep updating |
+| Legacy npm package | `@sma1lboy/kobe` | Was published from the same build/version as `@sma1lboy/rove`. Frozen at 0.9.64 — releases no longer publish it |
 | Plugin SDK package | `@sma1lboy/kobe-plugin-sdk` | Published from the same SDK artifact/version as the Rove-named package |
 | Existing state and config | `~/.kobe`, `~/.config/kobe` | First Rove launch copies supported product data without overwriting or removing the legacy source |
 | Existing worktrees and branches | `~/.kobe/worktrees/…`, repo-local `.kobe`/`.claude`, `kobe/…` | Task records pin absolute paths and branch names; discovery recognizes every legacy root |
@@ -54,7 +54,7 @@ because their absolute paths are part of the running-plugin compatibility contra
 `packages/kobe/package.json` names `@sma1lboy/rove`, so workspace filters,
 Changesets, update checks, install commands, and the first npm publish all use
 the canonical package. The release job then rewrites only `package.json#name`
-in its checkout and publishes the identical artifact as `@sma1lboy/kobe`.
+in its checkout and published the identical artifact as `@sma1lboy/kobe` (through 0.9.64; that alias is no longer published).
 Both packages contain the `rove` and `kobe` bins and use the same version and
 dist-tag. The updater migrates legacy global installs to `@sma1lboy/rove`,
 while users who never run it continue receiving releases through the alias.

--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -176,14 +176,16 @@ describe("Rove package distribution", () => {
     expect(daemon.dependencies["@sma1lboy/kobe-plugin-sdk"]).toBeUndefined()
   })
 
-  test("release publishes Rove first and rewrites only the compatibility alias", () => {
+  test("release publishes Rove and no longer publishes the @sma1lboy/kobe alias", () => {
+    // The old package name is frozen at 0.9.64 (owner call). The alias step
+    // was a rewrite of package.json#name, so its absence is what this asserts:
+    // a release must never resume publishing that name. The SDK keeps its own
+    // alias — pinned by the next test — so this checks the CLI name only.
     const workflow = read(".github/workflows/release.yml")
-    const canonicalStep = workflow.indexOf("Publish canonical @sma1lboy/rove package")
-    const compatibilityStep = workflow.indexOf("Publish compatibility alias @sma1lboy/kobe")
 
-    expect(canonicalStep).toBeGreaterThanOrEqual(0)
-    expect(compatibilityStep).toBeGreaterThan(canonicalStep)
-    expect(workflow).toContain("pkg.name = '@sma1lboy/kobe'")
+    expect(workflow.indexOf("Publish canonical @sma1lboy/rove package")).toBeGreaterThanOrEqual(0)
+    expect(workflow).not.toContain("Publish compatibility alias @sma1lboy/kobe")
+    expect(workflow).not.toContain("pkg.name = '@sma1lboy/kobe'")
     expect(workflow).not.toContain("pkg.name = '@sma1lboy/rove'")
   })
 
@@ -309,19 +311,19 @@ describe("Rove package distribution", () => {
     }
   })
 
-  test("release guidance verifies the canonical package before compatibility aliases", () => {
+  test("release guidance verifies the published package and the SDK aliases", () => {
     const releaseSkill = read(".claude/skills/release/SKILL.md")
     const releasingDocs = read("docs/RELEASING.md")
 
     expect(releaseSkill).toContain("# Release Rove")
     expect(releaseSkill).toContain('"@sma1lboy/rove": minor')
     expect(releaseSkill).not.toContain('"@sma1lboy/kobe": minor')
-    // indexOf returns -1 when absent, and -1 < anything — without the presence
-    // guards, deleting the canonical `npm view` line would turn this GREEN.
-    const canonicalView = releaseSkill.indexOf("npm view @sma1lboy/rove@<new-version>")
-    const aliasView = releaseSkill.indexOf("npm view @sma1lboy/kobe@<new-version>")
-    expect(canonicalView).toBeGreaterThanOrEqual(0)
-    expect(aliasView).toBeGreaterThan(canonicalView)
+    // The CLI alias is frozen at 0.9.64 and no longer published, so the skill
+    // must NOT tell a release to verify it — a missing @sma1lboy/kobe is the
+    // expected state now, and checking for it would read as a failed release.
+    // Anchored on `@<new-version>` so the SDK's own alias check still stands.
+    expect(releaseSkill.indexOf("npm view @sma1lboy/rove@<new-version>")).toBeGreaterThanOrEqual(0)
+    expect(releaseSkill).not.toContain("npm view @sma1lboy/kobe@<new-version>")
     expect(releaseSkill).toContain("npm view @sma1lboy/rove-plugin-sdk@<sdk-version>")
     expect(releaseSkill).toContain("npm view @sma1lboy/kobe-plugin-sdk@<sdk-version>")
     expect(releaseSkill).toContain("Every Rove release checks the SDK's current version")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -284,7 +284,6 @@ echo ""
 echo "Ready to push the release commit → wait for its CI (ubuntu+macos) →"
 echo "then tag $TAG, which triggers:"
 echo "  • npm publish @sma1lboy/rove@$NEW_VERSION"
-echo "  • compatibility publish @sma1lboy/kobe@$NEW_VERSION"
 echo "  • GitHub release with the notes above"
 echo ""
 read -rp "Push now? [y/N] " REPLY


### PR DESCRIPTION
Owner call: the CLI stops publishing under its pre-rename name. `@sma1lboy/kobe` is frozen at **0.9.64**.

## What changes

- `release.yml` loses the step that rewrote `package.json#name` and published the second name. Its absence is explained where the canonical publish is, so it doesn't read as an oversight.
- `scripts/release.sh` no longer prints `• compatibility publish @sma1lboy/kobe@X.Y.Z` — it would have promised something that no longer happens.
- Docs (`RELEASING.md`, `ARCHITECTURE.md`, `design/rove-rename.md`) and the `release` skill say the name is frozen rather than published in lockstep.

The **SDK** alias (`@sma1lboy/kobe-plugin-sdk`) is untouched — only the CLI name stops.

## Tests

Two architecture tests pinned the alias step's presence. Both now pin its absence, so a future release can't quietly resume publishing it:

- `release publishes Rove and no longer publishes the @sma1lboy/kobe alias`
- `release guidance verifies the published package and the SDK aliases`

Mutation-checked: restoring a step containing `pkg.name = '@sma1lboy/kobe'` reds the first test. The assertions are anchored so they don't accidentally match `@sma1lboy/kobe-plugin-sdk`.

## Worth knowing

`@sma1lboy/kobe` had **12,221** downloads last week vs `@sma1lboy/rove`'s **11,716** — more installs are still on the old name than the new one. (Download counts include CI and mirrors, so this is not a headcount.) Those installs keep working and their update check reports the newest `@sma1lboy/rove`, but they stay on 0.9.64 until someone reinstalls under the canonical name. The changeset says so in the release notes.