### PR TITLE
fix: report a half-completed worktree removal instead of failing unretryably

### DIFF
--- a/.changeset/worktree-remove-partial-success.md
+++ b/.changeset/worktree-remove-partial-success.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Report a half-completed worktree removal as what it is, instead of a total failure that cannot be retried.
+
+`git worktree remove` deregisters the worktree's metadata and deletes its directory, and those two halves can fail apart: an unwritable path inside the tree (a `chmod -w` directory, a read-only dependency cache) makes the delete fail after the deregistration has already landed. Rove read git's exit code as the whole truth, so it reported total failure — and left no way forward, because every retry then hit `fatal: is not a working tree` and the task stayed parked in `deletion.phase = "error"` forever.
+
+A removal that got that far now counts as done: the task is deleted, `land` still reports the land as landed, and a notice names the directory left on disk plus git's own reason. Retrying a removal on such a directory converges instead of throwing. Rove never deletes the leftover itself — whatever made it undeletable may be something you want.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -113,6 +113,14 @@ or the web UI (`salvaged worktree <path> — …`). No `salvaged` line means the
 was nothing uncommitted to save. See
 [WORKTREES](./WORKTREES.md#recovering-work-a-force-delete-destroyed).
 
+A `removed` line that also says **"git deregistered the worktree but could NOT
+delete"** means the deletion succeeded and left a directory behind: git dropped
+its registration but could not unlink the tree (most often an unwritable path
+inside it). The task is gone and there is nothing to retry — retrying is
+impossible, because git no longer knows that worktree. The line names the
+directory; delete it by hand if you want the space. See
+[WORKTREES](./WORKTREES.md#when-git-removes-the-worktree-but-not-its-directory).
+
 A `failed` line means the deletion ran only partway: the hosted session was
 torn down and the Inbox/activity state cleared, but the worktree directory and
 the task entry remain, and the task is left in `deletion.phase === "error"`

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -111,6 +111,23 @@ For a worktree tracked by a Task, Rove clears that Task's worktree pointer. It
 does not delete the Task, its branch, or engine history. Opening the Task later
 may materialize a fresh worktree from the retained branch.
 
+### When git removes the worktree but not its directory
+
+`git worktree remove` does two things — deregister the worktree's metadata and
+delete its directory — and they can fail apart. A path inside the tree that the
+current user cannot unlink (a `chmod -w` directory, a read-only dependency
+cache, a directory an external tool holds) makes the directory delete fail
+*after* the deregistration has already landed.
+
+Rove reports that as what it is. The removal counts as done — git no longer
+knows this worktree, so no retry can advance it — and a notice names the
+directory left on disk and git's own reason. A task deleted this way is
+deleted, not parked in an error state, and the same line goes to
+`~/.rove/daemon.log` next to the rest of the deletion trail.
+
+Rove never deletes that directory for you: whatever made it undeletable may be
+something you want. Remove it by hand if you want the disk space.
+
 ## Force-remove a dirty worktree
 
 Dirty removal is deliberately two-stage:

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -129,7 +129,14 @@ export interface LandResult {
    *  explicitly declined (`removeWorktree: false`). `reason` is not
    *  failure-only: it also rides with `removed: true` when the directory went
    *  but clearing the task's worktree path did not. */
-  readonly worktree?: { readonly removed: boolean; readonly reason?: string }
+  readonly worktree?: {
+    readonly removed: boolean
+    readonly reason?: string
+    /** Set when git deregistered the worktree but could not delete its
+     *  directory — the land and its cleanup both succeeded; a directory is
+     *  left on disk that Rove will never list again. */
+    readonly residue?: { readonly path: string; readonly reason: string }
+  }
   /** Ref anchoring a deleted branch's tip when nothing else reached it (the
    *  squash-land case). Absent on a `--no-ff` merge and when no branch was
    *  deleted. */

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -78,7 +78,7 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
           .tearDownTaskSession(taskId)
           .catch((err) => logDaemonError("worktree-remove-session-teardown", err))
       }
-      await ctx.runtime.removeWorktree(path, force)
+      const residue = await ctx.runtime.removeWorktree(path, force)
       // Self-heal the task index: a worktree removed here (worktrees page /
       // web) otherwise leaves the owning task pointing at a dead dir, so the
       // next enter would spawn the engine into a nonexistent cwd. Drop the
@@ -86,8 +86,10 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
       // Exact-path match; unmatched (untracked worktree) is a harmless no-op.
       // Guarded on `ctx.orch` — this handler historically composes runtime
       // primitives directly, so a caller may not wire an orchestrator.
+      // Runs on the residue path too: git has deregistered the worktree, so
+      // the task's pointer is just as dead as after a clean removal.
       if (taskId && ctx.orch) await ctx.orch.clearWorktreePath(taskId)
-      return { removed: true }
+      return { removed: true, ...(residue ? { residue } : {}) }
     },
   },
 ]

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -86,7 +86,10 @@ export interface DaemonRuntimeAdapter {
   runWorktreeStatus(worktreePath: string, signal: AbortSignal): Promise<WorktreeChanges>
   maybeAutoStart(orch: DaemonOrchestrator, taskId: string): Promise<string>
   listWorktreeProjects(network: boolean): Promise<unknown[]>
-  removeWorktree(path: string, force: boolean): Promise<void>
+  /** Remove a worktree. Resolves with the leftover directory when git
+   *  deregistered the worktree but could not delete it (a partial removal that
+   *  no retry can advance); resolves with null on a clean removal. */
+  removeWorktree(path: string, force: boolean): Promise<{ path: string; reason: string } | null>
   availableEngineIds(): Promise<readonly VendorId[]>
   engineDisplayName(vendor: VendorId): string
   kobeApiInvocation(): string

--- a/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
@@ -145,3 +145,33 @@ export function auditDeletionSalvaged(taskId: string, ref: string, commit: strin
 export function auditWorktreeSalvaged(worktreePath: string, ref: string, commit: string): void {
   logDaemonInfo(SUBSYSTEM, `salvaged worktree ${worktreePath} — ${recoveryText(ref, commit)}`)
 }
+
+/**
+ * A deletion's `git worktree remove` deregistered the worktree but could not
+ * delete its directory (an unwritable path inside it, most often).
+ *
+ * Info, not error: the deletion itself completed — the task entry is gone and
+ * git no longer knows this worktree. What is left is an ordinary directory
+ * that Rove will never list again, so this line is the only place its path is
+ * recorded. Rove does not delete it: whatever made it undeletable may be
+ * something the user wants, and removing it would be a destructive act nobody
+ * asked for.
+ */
+export function auditDeletionResidue(taskId: string, worktreePath: string, reason: string): void {
+  const advice = "Nothing further is needed in Rove; remove the directory by hand if you want the disk space."
+  logDaemonInfo(
+    SUBSYSTEM,
+    `removed task ${taskId} — git deregistered the worktree but could NOT delete ${worktreePath} (${reason}). ${advice}`,
+  )
+}
+
+/**
+ * A worktree removal outside the task lifecycle (worktrees page / web DELETE)
+ * deregistered the worktree but could not delete its directory. Same subsystem
+ * as the deletion lines for the same reason {@link auditWorktreeSalvaged} is:
+ * a user hunting for a directory Rove no longer shows should not have to know
+ * which UI removed it.
+ */
+export function auditWorktreeResidue(worktreePath: string, reason: string): void {
+  logDaemonInfo(SUBSYSTEM, `deregistered ${worktreePath} but could NOT delete the directory (${reason})`)
+}

--- a/packages/kobe-web/src/components/WorktreesPage.tsx
+++ b/packages/kobe-web/src/components/WorktreesPage.tsx
@@ -23,7 +23,7 @@ import { useEffect, useMemo, useState } from "react"
 import { displayProductName } from "../lib/cli-name.ts"
 import { useAppState } from "../lib/store.ts"
 import { relativeTimeAgo } from "../lib/time.ts"
-import { reportError } from "../lib/toast.ts"
+import { pushToast, reportError } from "../lib/toast.ts"
 import {
   DirtyWorktreeError,
   fetchWorktreeProjects,
@@ -149,7 +149,16 @@ export function WorktreesPage() {
   const deleteInBackground = (row: WorktreeRow, force: boolean): void => {
     setRemovingPaths((paths) => [...paths, row.path])
     void removeWorktree(row.path, force)
-      .then(() => {
+      .then((residue) => {
+        // git deregistered the worktree but could not delete the directory.
+        // The row still goes — nothing lists that path any more — so this is a
+        // notice, not an error, and it is the only time the leftover is named.
+        if (residue) {
+          pushToast(
+            "info",
+            `Git deregistered the worktree, but couldn't delete ${residue.path} (${residue.reason}). Retrying won't help; delete the directory by hand if you want the space.`,
+          )
+        }
         // Drop the row for real, then stop tracking it as "removing".
         removeRow(row.path)
         setRemovingPaths((paths) => paths.filter((p) => p !== row.path))

--- a/packages/kobe-web/src/lib/worktrees.ts
+++ b/packages/kobe-web/src/lib/worktrees.ts
@@ -35,16 +35,24 @@ export async function fetchWorktreeProjects(): Promise<WorktreeProject[]> {
     : []
 }
 
+/** A directory a removal left behind after git had already deregistered the
+ *  worktree. Reported, never deleted by Rove. */
+export interface WorktreeResidue {
+  path: string
+  reason: string
+}
+
 export async function removeWorktree(
   path: string,
   force: boolean,
-): Promise<void> {
+): Promise<WorktreeResidue | null> {
   try {
-    await api.delete<{ removed: boolean }>(
+    const res = await api.delete<{ removed: boolean; residue?: WorktreeResidue }>(
       "/api/worktrees",
       { path, force },
       { label: "delete worktree" },
     )
+    return res.residue ?? null
   } catch (err) {
     if (
       err instanceof ApiError &&

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -13,6 +13,7 @@ import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { WorkItem } from "@sma1lboy/kobe-daemon/daemon/work-items"
 import type { LandResult } from "../orchestrator/land.ts"
+import type { WorktreeResidue } from "../orchestrator/worktree/manager-remove.ts"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import type { AdoptableWorktree, WorktreeProject } from "../types/worktree.ts"
 import { deserializeTask } from "./remote-orchestrator-payloads.ts"
@@ -225,9 +226,15 @@ export async function listWorktreesOp(
 
 /** Remove a worktree (`worktree.remove`); refuses a dirty one unless
  *  `force` is true — same safety property `GitWorktreeManager.remove`
- *  always had. */
-export async function removeWorktreeOp(client: KobeDaemonClient, path: string, force?: boolean): Promise<void> {
-  await client.request("worktree.remove", { path, force })
+ *  always had. Resolves with the leftover directory when git deregistered the
+ *  worktree but could not delete it, null on a clean removal. */
+export async function removeWorktreeOp(
+  client: KobeDaemonClient,
+  path: string,
+  force?: boolean,
+): Promise<WorktreeResidue | null> {
+  const res = await client.request<{ residue?: WorktreeResidue }>("worktree.remove", { path, force })
+  return res.residue ?? null
 }
 
 /** A repo's daemon-owned issues (`issue.list`) — the TUI kanban page's read. */

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -29,6 +29,7 @@ import {
 } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { type ExternalStore, type ReadableState, createStateCell, mapReadableState } from "../lib/external-store.ts"
 import type { Orchestrator, Unsubscribe } from "../orchestrator/core.ts"
+import type { WorktreeResidue } from "../orchestrator/worktree/manager-remove.ts"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import type { AdoptableWorktree, WorktreeProject } from "../types/worktree.ts"
 import { CURRENT_VERSION, type UpdateInfo } from "../version.ts"
@@ -463,7 +464,7 @@ export class RemoteOrchestrator {
   /** Remove a worktree (`worktree.remove`); refuses a dirty one unless
    *  `force` is true — same safety property `GitWorktreeManager.remove`
    *  always had. */
-  removeWorktree(path: string, force?: boolean): Promise<void> {
+  removeWorktree(path: string, force?: boolean): Promise<WorktreeResidue | null> {
     return removeWorktreeOp(this.client, path, force)
   }
 

--- a/packages/kobe/src/core/daemon-worktree-adapter.ts
+++ b/packages/kobe/src/core/daemon-worktree-adapter.ts
@@ -1,5 +1,5 @@
 import { statSync } from "node:fs"
-import { auditWorktreeSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
+import { auditWorktreeResidue, auditWorktreeSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
 import { execHostForWorktreePath } from "../exec/resolve.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
 import { type PrState, judgeWorktree, parseGhPrList } from "../orchestrator/worktree/staleness.ts"
@@ -112,13 +112,26 @@ export async function listWorktreeProjectsAdapter(network: boolean): Promise<Wor
  * answers the confirm the tree may hold work the confirm never described.
  * `manager.remove` salvages any uncommitted work first; this records where.
  */
-export async function removeWorktreeAdapter(path: string, force: boolean): Promise<void> {
+export async function removeWorktreeAdapter(
+  path: string,
+  force: boolean,
+): Promise<{ path: string; reason: string } | null> {
+  let residue: { path: string; reason: string } | null = null
   await manager.remove(path, {
     force,
     onSalvage: (record) => {
       if (record) auditWorktreeSalvaged(path, record.ref, record.commit)
     },
+    // git deregistered the worktree but could not delete the directory. Not a
+    // failure — the removal is as complete as git can make it and retrying is
+    // fatal by construction — so it is returned to the caller, and logged
+    // because after this nothing in Rove lists that path again.
+    onResidue: (r) => {
+      residue = { path: r.path, reason: r.reason }
+      auditWorktreeResidue(r.path, r.reason)
+    },
   })
+  return residue
 }
 
 export async function handleWorktreesRequestAdapter(request: Request, url: URL): Promise<Response | null> {
@@ -134,8 +147,8 @@ export async function handleWorktreesRequestAdapter(request: Request, url: URL):
     try {
       const body = (await request.json()) as { path?: unknown; force?: unknown }
       if (typeof body.path !== "string" || !body.path) return Response.json({ error: "missing path" }, { status: 400 })
-      await removeWorktreeAdapter(body.path, body.force === true)
-      return Response.json({ removed: true })
+      const residue = await removeWorktreeAdapter(body.path, body.force === true)
+      return Response.json({ removed: true, ...(residue ? { residue } : {}) })
     } catch (error) {
       return Response.json({ error: error instanceof Error ? error.message : String(error) }, { status: 400 })
     }

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -7,7 +7,7 @@
 
 import { homedir } from "node:os"
 import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
-import { auditDeletionSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
+import { auditDeletionResidue, auditDeletionSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
 import { Orchestrator } from "../orchestrator/core.ts"
 import { TaskIndexStore } from "../orchestrator/index/store.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
@@ -39,6 +39,10 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
     // user asking "what happened to my task".
     onSalvage: (taskId, salvage) =>
       auditDeletionSalvaged(String(taskId), salvage.ref, salvage.commit, store.get(taskId)?.repo),
+    // The task IS deleted in this case, so nothing else will ever mention the
+    // directory git could not unlink. Same log, same reason as the salvage
+    // line: it is where a user is already told to look.
+    onWorktreeResidue: (taskId, residue) => auditDeletionResidue(String(taskId), residue.path, residue.reason),
     // A landed worktree is about to be unlinked; anything the engine writes
     // into it after that is written to nothing. Same ordering the task-
     // deletion runner already uses.

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -65,6 +65,11 @@ export interface OrchestratorDeps {
    *  local orchestrator leaves it unset and the snapshot is still findable
    *  via `git for-each-ref refs/rove/salvage`. */
   readonly onSalvage?: (taskId: TaskId, salvage: { readonly ref: string; readonly commit: string }) => void
+  /** Called when a deletion's `git worktree remove` deregistered the worktree
+   *  but could not delete its directory. The deletion still completes; this is
+   *  the only record of the leftover, so the daemon binds it to the same audit
+   *  log the rest of the deletion trail goes to. */
+  readonly onWorktreeResidue?: (taskId: TaskId, residue: { readonly path: string; readonly reason: string }) => void
   /**
    * Kill a task's engine session. Bound by the composition root to the hosted
    * session host; a TUI-local orchestrator leaves it unset. `landTask` calls
@@ -118,6 +123,7 @@ export class Orchestrator {
       this.worktrees,
       (id) => this.worktreeCoordinator.forget(id),
       deps.onSalvage,
+      deps.onWorktreeResidue,
     )
     this.tasksAcc = createStateCell<Task[]>(this.store.list())
     // Seed focus from the persisted `lastActive` record (state/last-active

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -23,6 +23,7 @@ import { READ_ONLY_GIT_ENV } from "../lib/git-env.ts"
 import type { Task, TaskId } from "../types/task.ts"
 import { EmptyBranchDirtyWorktreeError, EmptyBranchError, LandConflictError, MainCheckoutDirtyError } from "./errors.ts"
 import { type WorktreeExecDeps, defaultExecDeps } from "./worktree/exec-deps.ts"
+import type { WorktreeResidue } from "./worktree/manager-remove.ts"
 import { GitWorktreeManager } from "./worktree/manager.ts"
 import type { SalvageRecord } from "./worktree/salvage.ts"
 
@@ -68,8 +69,17 @@ export interface LandDeps {
  * when the directory went but clearing the task's worktree path did not.
  */
 export interface LandWorktreeCleanup {
+  /** Whether git's registration of the worktree is gone. TRUE even when the
+   *  directory survived — see {@link residue}. */
   readonly removed: boolean
   readonly reason?: string
+  /**
+   * Set when git deregistered the worktree but could not delete its directory.
+   * Distinct from `reason`, which reports a bookkeeping failure on a fully
+   * successful removal: this one says the removal is as complete as git can
+   * make it and a directory is left on disk. The land succeeded either way.
+   */
+  readonly residue?: WorktreeResidue
 }
 
 /**
@@ -170,8 +180,17 @@ async function removeLandedWorktree(
       // best-effort; the dirty-refusal in remove() below is the real guard
     }
   }
+  // A removal git half-completed (metadata deregistered, directory undeletable)
+  // resolves rather than throws — the worktree IS deregistered, so the land's
+  // cleanup is done and reporting `removed: false` would send the user to
+  // retry something git can no longer act on.
+  let residue: WorktreeResidue | undefined
   try {
-    await deps.worktrees.remove(worktreePath)
+    await deps.worktrees.remove(worktreePath, {
+      onResidue: (r) => {
+        residue = r
+      },
+    })
   } catch (err) {
     return { removed: false, reason: errText(err) }
   }
@@ -183,9 +202,13 @@ async function removeLandedWorktree(
   try {
     await deps.clearWorktreePath(task.id)
   } catch (err) {
-    return { removed: true, reason: `worktree removed, but clearing the task's worktree path failed: ${errText(err)}` }
+    return {
+      removed: true,
+      reason: `worktree removed, but clearing the task's worktree path failed: ${errText(err)}`,
+      ...(residue ? { residue } : {}),
+    }
   }
-  return { removed: true }
+  return { removed: true, ...(residue ? { residue } : {}) }
 }
 
 function errText(err: unknown): string {

--- a/packages/kobe/src/orchestrator/task-deletion.ts
+++ b/packages/kobe/src/orchestrator/task-deletion.ts
@@ -2,6 +2,7 @@ import { errorMessage } from "../lib/error-message.ts"
 import type { TaskId } from "../types/task.ts"
 import { CannotDeleteMainTaskError, DirtyWorktreeError, WorktreeRemoveFailedError } from "./errors.ts"
 import type { TaskIndexStore } from "./index/store.ts"
+import type { WorktreeResidue } from "./worktree/manager-remove.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
 import type { SalvageRecord } from "./worktree/salvage.ts"
 
@@ -28,6 +29,13 @@ export class TaskDeletionCoordinator {
      * roughly the time, and that is what the audit trail is indexed by.
      */
     private readonly onSalvage?: (taskId: TaskId, record: SalvageRecord) => void,
+    /**
+     * Notified when git deregistered the worktree but could not delete its
+     * directory. Wired to the deletion audit log for the same reason
+     * `onSalvage` is: the deletion itself SUCCEEDS (see `finish`), so this is
+     * the only record that a directory is still on disk.
+     */
+    private readonly onResidue?: (taskId: TaskId, residue: WorktreeResidue) => void,
   ) {}
 
   /** Persist acceptance after the destructive dirty-worktree safety check. */
@@ -97,6 +105,15 @@ export class TaskDeletionCoordinator {
           onSalvage: (record) => {
             if (record) this.onSalvage?.(task.id, record)
           },
+          // A removal git half-completed (metadata deregistered, directory
+          // undeletable) is NOT an error here. Parking the task in `error`
+          // would be a lie the user cannot act on: git no longer knows this
+          // worktree, so every retry is `fatal: is not a working tree` and the
+          // task is stuck forever (issue #89). The deletion finishes; the
+          // leftover directory is reported instead of being made the task's
+          // problem — and never deleted from under the user, since whatever
+          // made it undeletable may be something they want.
+          onResidue: (residue) => this.onResidue?.(task.id, residue),
         })
       }
     } catch (cause) {

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -88,10 +88,11 @@ export interface RemoveDeps {
  * and has lost only its own `worktrees/<name>` admin dir; an orphan has lost
  * the whole thing.
  *
- * Not total: a delete that got far enough to unlink `.git` before failing
- * leaves a directory indistinguishable from any other, and the caller is told
- * (accurately) that it is not a git worktree. Closing that gap would need the
- * owning repo, which is the one thing a deregistered path can no longer name.
+ * Platform-dependent, which is why it is a fast path and not the only one:
+ * macOS git leaves the pointer file, Linux git unlinks it before failing, and
+ * then the directory is indistinguishable from any other. The convergence that
+ * holds everywhere is the post-condition check further down — "the directory
+ * is still there" — not this fingerprint.
  */
 async function deregisteredWorktreeResidue(exec: ExecHost, worktreePath: string): Promise<boolean> {
   const dotGit = await exec.readFile(`${worktreePath}/.git`)
@@ -153,13 +154,15 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
   if (!repo) {
     // Checked BEFORE the orphan handling below, which shares this branch: a
     // deregistered worktree also has no reachable repo, but its own repo is
-    // alive and the correct answer is to converge, not to delete a directory
-    // the previous removal already refused to touch.
+    // alive and the correct answer is to converge without touching a directory
+    // the previous removal already refused to delete.
     //
     // Retrying a removal that already deregistered its worktree must land on
     // the same answer it gave the first time — git can no longer act on this
     // path at all, so a second `worktree remove` only ever says `fatal: is not
-    // a working tree` and the caller is stuck (issue #89).
+    // a working tree` and the caller is stuck (issue #89). Where the pointer
+    // survives (macOS) that is answered here; where it does not (Linux) the
+    // post-`rm -rf` check below answers it.
     if (await deregisteredWorktreeResidue(exec, worktreePath)) {
       opts?.onResidue?.({ path: worktreePath, reason: "a previous removal deregistered the worktree" })
       return
@@ -190,6 +193,15 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     // means git cannot resolve one.
     opts?.onSalvage?.(null)
     await exec.run(["rm", "-rf", worktreePath])
+    // Post-condition, not optimism: `rm -rf` exits 0 having deleted only what
+    // it could, so without this check an undeletable directory is reported as
+    // a clean removal — the caller is told to look for something that is still
+    // on disk. This is also where a retried residue converges on the platforms
+    // whose git unlinks the `.git` pointer before failing, so the fingerprint
+    // above never matches.
+    if (await exec.exists(worktreePath)) {
+      opts?.onResidue?.({ path: worktreePath, reason: "the directory could not be deleted" })
+    }
     return
   }
 

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -5,15 +5,47 @@
  * decision it makes — the dirty gate, the salvage snapshot, the orphaned-repo
  * fallback and its managed-root guard — lives in this single function. Same
  * shape as `manager-branch.ts` / `manager-list.ts`: a free function over a
- * small deps object, with the class method a thin delegator. No behaviour
- * change in the extraction.
+ * small deps object, with the class method a thin delegator.
+ *
+ * The other thing this function has to get right: `git worktree remove` does
+ * TWO jobs — deregister the worktree's metadata and delete its directory — and
+ * they can fail APART. An undeletable path inside the tree (a `chmod -w`
+ * directory, a read-only dependency cache, anything an external tool holds)
+ * produces exit 255 AFTER the deregistration has already landed:
+ *
+ *     error: failed to delete '<path>': Permission denied     # exit 255
+ *     git worktree list                                       # already gone
+ *     ls <path>                                               # still there
+ *     git worktree remove --force <path>                      # fatal: not a working tree
+ *
+ * Reading the exit code as the whole truth reports that as a total failure and
+ * leaves the caller with no forward move: git's own view is that this worktree
+ * no longer exists, so no retry, remove, or prune can ever advance it (issue
+ * #89 — a task parked in `deletion.phase = "error"` forever). So a non-zero
+ * exit is CLASSIFIED, not trusted, and the leftover directory is reported
+ * through `onResidue` rather than deleted: an undeletable tree is exactly the
+ * kind of thing that holds something the user still wants.
  */
 
 import type { ExecHost } from "../../exec/exec-host.ts"
-import type { GitRunOpts, GitRunResult } from "./git.ts"
+import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
 import { type BranchDeps, deleteBranchAnchored } from "./manager-branch.ts"
 import { isUnderManagedWorktreesRoot, requireAbsolute } from "./paths.ts"
 import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
+
+/**
+ * A directory a removal left behind after git had already deregistered the
+ * worktree. Not an error: git's half of the job is done and the task/branch
+ * bookkeeping around it can complete. It is reported so the path and the
+ * reason reach a human — nothing else in Rove will ever list this directory
+ * again, because from git's side the worktree is gone.
+ */
+export interface WorktreeResidue {
+  /** The directory still on disk. */
+  readonly path: string
+  /** git's own reason the delete stopped (its stderr), e.g. "Permission denied". */
+  readonly reason: string
+}
 
 export interface RemoveOpts {
   readonly force?: boolean
@@ -21,6 +53,10 @@ export interface RemoveOpts {
   /** Notified with the snapshot a force-removal took (null = nothing to
    *  save, or the snapshot could not be written). */
   readonly onSalvage?: (record: SalvageRecord | null) => void
+  /** Notified when git deregistered the worktree but could not delete its
+   *  directory. Fires on the retry of such a removal too, so a second call
+   *  converges on the same answer instead of `is not a working tree`. */
+  readonly onResidue?: (residue: WorktreeResidue) => void
 }
 
 /** The manager primitives removal borrows. */
@@ -36,6 +72,39 @@ export interface RemoveDeps {
   isDirty(worktreePath: string): Promise<boolean>
   /** Deps for the opt-in post-removal branch delete. */
   branchDeps(): BranchDeps
+}
+
+/**
+ * Whether `worktreePath` is the residue of a DEREGISTERED worktree — git
+ * dropped its registration and then failed to unlink the tree.
+ *
+ * A linked worktree's `.git` is a FILE holding
+ * `gitdir: <repo>/.git/worktrees/<name>`. That file outlives the
+ * deregistration, so a dangling pointer is the on-disk fingerprint of a
+ * half-done removal — but it is ALSO what an orphaned worktree looks like
+ * after its upstream clone was destroyed, which is a different case with a
+ * different (destructive) handler below. The two are told apart by the repo
+ * end of the pointer: a deregistered worktree still has a live `<repo>/.git`
+ * and has lost only its own `worktrees/<name>` admin dir; an orphan has lost
+ * the whole thing.
+ *
+ * Not total: a delete that got far enough to unlink `.git` before failing
+ * leaves a directory indistinguishable from any other, and the caller is told
+ * (accurately) that it is not a git worktree. Closing that gap would need the
+ * owning repo, which is the one thing a deregistered path can no longer name.
+ */
+async function deregisteredWorktreeResidue(exec: ExecHost, worktreePath: string): Promise<boolean> {
+  const dotGit = await exec.readFile(`${worktreePath}/.git`)
+  const pointer = dotGit
+    ?.trim()
+    .match(/^gitdir:\s*(.+)$/)?.[1]
+    ?.trim()
+  if (!pointer) return false
+  const marker = "/worktrees/"
+  const at = pointer.lastIndexOf(marker)
+  if (at < 0) return false
+  // `<repo>/.git` — alive for a deregistered worktree, gone for an orphan.
+  return await exec.exists(pointer.slice(0, at))
 }
 
 /**
@@ -82,6 +151,19 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
   // repo when the caller hands us only the path.
   const repo = await deps.findRepoFor(exec, worktreePath)
   if (!repo) {
+    // Checked BEFORE the orphan handling below, which shares this branch: a
+    // deregistered worktree also has no reachable repo, but its own repo is
+    // alive and the correct answer is to converge, not to delete a directory
+    // the previous removal already refused to touch.
+    //
+    // Retrying a removal that already deregistered its worktree must land on
+    // the same answer it gave the first time — git can no longer act on this
+    // path at all, so a second `worktree remove` only ever says `fatal: is not
+    // a working tree` and the caller is stuck (issue #89).
+    if (await deregisteredWorktreeResidue(exec, worktreePath)) {
+      opts?.onResidue?.({ path: worktreePath, reason: "a previous removal deregistered the worktree" })
+      return
+    }
     // No owning repo: the upstream checkout's `.git` is gone (a deleted
     // clone, or macOS pruning a checkout under `/tmp`), so there is no
     // `git worktree remove` to run and no metadata left to deregister.
@@ -135,13 +217,26 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
   // so an unlocked-but-untracked-files case (rare — we already checked dirty)
   // doesn't bounce. Dirty refusal lives in our layer, not git's.
   const args = force ? ["worktree", "remove", "--force", worktreePath] : ["worktree", "remove", worktreePath]
-  await deps.runGit(exec, args, { cwd: repo })
+  const result = await deps.runGit(exec, args, { cwd: repo, allowFail: true })
+  if (result.exitCode !== 0) {
+    // Re-probing the path is the whole classification: it answers git's own
+    // question ("is this still a worktree?") rather than re-reading the exit
+    // code we already have. Still registered → nothing happened, throw the
+    // error the caller has always seen. Gone → the deregistration landed and
+    // only the directory is left.
+    if (await deps.findRepoFor(exec, worktreePath)) {
+      throw new GitCommandError(args, repo, result)
+    }
+    opts?.onResidue?.({ path: worktreePath, reason: result.stderr.trim() || result.stdout.trim() || "unknown" })
+  }
 
   // Defensive prune — cleans up `.git/worktrees/<name>/` if the remove left
   // it behind (rare, but documented in vibe-kanban).
   await deps.runGit(exec, ["worktree", "prune"], { cwd: repo, allowFail: true })
 
   // Anchored like `deleteBranch`: `-D` takes the reflog too, and this
-  // worktree's own reflog died with the directory a few lines up.
+  // worktree's own reflog died with the directory a few lines up. Runs on the
+  // residue path too — the branch is no longer checked out anywhere, which is
+  // the only thing that made it undeletable before.
   if (branch) await deleteBranchAnchored(deps.branchDeps(), exec, repo, branch, { force })
 }

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -148,7 +148,11 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
     if (!orch) return
     setRemovingPaths((paths) => [...paths, row.path])
     try {
-      await orch.removeWorktree(row.path, force)
+      const residue = await orch.removeWorktree(row.path, force)
+      // git deregistered the worktree but could not delete the directory. The
+      // row IS gone (nothing lists that path any more), so this is not an
+      // error toast — but it is the only time the leftover path is ever named.
+      if (residue) notifyNeedsInput(t("worktrees.delete.residue", { path: residue.path, reason: residue.reason }))
       // Path stays in `removingPaths`: refetch is async, and dropping it here
       // would flash the dead row back until the fresh list lands.
       refetch()
@@ -220,6 +224,11 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
         notifyNeedsInput(t("worktrees.land.worktreeKept", { reason: cleanup.reason ?? "refused" }))
       } else if (cleanup?.reason) {
         notifyNeedsInput(t("worktrees.land.worktreePathStale", { reason: cleanup.reason }))
+      }
+      if (cleanup?.residue) {
+        notifyNeedsInput(
+          t("worktrees.land.worktreeResidue", { path: cleanup.residue.path, reason: cleanup.residue.reason }),
+        )
       }
       refetch()
     } catch (err) {

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -39,6 +39,8 @@ export const en = {
     forceTitle: "Force delete worktree?",
     forceBody: '"{branch}" has uncommitted or untracked changes that will be PERMANENTLY LOST. Force delete anyway?',
     failed: "Failed to delete worktree: {error}",
+    residue:
+      "Git deregistered the worktree, but couldn't delete {path} ({reason}). Rove is done with it — retrying won't help; delete the directory by hand if you want the space.",
   },
 
   land: {
@@ -54,6 +56,8 @@ export const en = {
     done: 'Landed "{branch}" onto {landedOn} ({commit}).',
     worktreeKept: "Landed, but the worktree was kept: {reason}",
     worktreePathStale: "Landed and removed the worktree, but the task still points at it: {reason}",
+    worktreeResidue:
+      "Landed. Git deregistered the worktree, but couldn't delete {path} ({reason}) — delete the directory by hand if you want the space.",
   },
 
   hint: {},
@@ -94,6 +98,8 @@ export const zh: typeof en = {
     forceTitle: "强制删除 worktree？",
     forceBody: '"{branch}" 存在未提交或未跟踪的改动，强制删除后将永久丢失。仍要强制删除吗？',
     failed: "删除 worktree 失败：{error}",
+    residue:
+      "Git 已注销该 worktree，但没能删掉 {path}（{reason}）。Rove 这边已经处理完了——重试没有用；想要回磁盘空间请手动删除该目录。",
   },
 
   land: {
@@ -109,6 +115,7 @@ export const zh: typeof en = {
     done: '已把 "{branch}" 合入 {landedOn}（{commit}）。',
     worktreeKept: "已合入，但 worktree 保留了：{reason}",
     worktreePathStale: "已合入并移除 worktree，但任务仍指向它：{reason}",
+    worktreeResidue: "已合入。Git 已注销该 worktree，但没能删掉 {path}（{reason}）——想要回磁盘空间请手动删除该目录。",
   },
 
   hint: {},

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -247,6 +247,38 @@ describe("landTaskWithCleanup worktree cleanup", () => {
     expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true) // the merge still landed
   })
 
+  test("a half-removed worktree still counts as landed, and names the leftover directory", async () => {
+    // git deregisters the worktree, then fails to unlink it (an unwritable
+    // directory inside). Before issue #89 this reported `removed: false` and
+    // sent the user to retry a removal git can no longer act on at all.
+    makeWorktree()
+    // Committed, not untracked: an untracked file would trip the dirty
+    // refusal, which is a different (already-covered) branch. The tree is
+    // clean — it is only the FILESYSTEM that will not give the directory up.
+    const locked = path.join(wt, "fixture")
+    fs.mkdirSync(locked)
+    fs.writeFileSync(path.join(locked, "keep.txt"), "x")
+    git(["add", "."], wt)
+    git(["commit", "-m", "fixture"], wt)
+    fs.chmodSync(locked, 0o555)
+    try {
+      const { deps: d, cleared } = deps()
+      const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, {}, d)
+
+      // The merge landed and the bookkeeping ran — the only thing that did not
+      // happen is the directory delete, and that is what `residue` says.
+      expect(res.worktree?.removed).toBe(true)
+      expect(res.worktree?.residue?.path).toBe(wt)
+      expect(res.worktree?.residue?.reason).toMatch(/Permission denied/)
+      expect(cleared).toEqual(["t-land"])
+      expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true)
+      // Reported, not cleaned up: land never deletes what git could not.
+      expect(fs.existsSync(path.join(locked, "keep.txt"))).toBe(true)
+    } finally {
+      fs.chmodSync(locked, 0o755)
+    }
+  })
+
   test("a dirty worktree is refused on the default path, and the land still stands", async () => {
     makeWorktree()
     fs.writeFileSync(path.join(wt, "wip.txt"), "uncommitted\n")

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -121,6 +121,57 @@ describe("durable background task deletion", () => {
     expect(salvages).toEqual([])
   })
 
+  it("a half-completed removal COMPLETES the deletion and reports the leftover directory", async () => {
+    // git deregistered the worktree but could not delete its directory (issue
+    // #89). Parking the task in `error` would be unfixable: git no longer
+    // knows this worktree, so every retry is `fatal: is not a working tree`.
+    // The task must go, and the leftover path must reach the sink — it is the
+    // only place that directory is ever named again.
+    const residues: { taskId: string; path: string; reason: string }[] = []
+    const localStore = new TaskIndexStore({ homeDir: home })
+    await localStore.load()
+    const localOrch = new Orchestrator({
+      store: localStore,
+      worktrees: worktrees as unknown as GitWorktreeManager,
+      onWorktreeResidue: (taskId, residue) => residues.push({ taskId: String(taskId), ...residue }),
+    })
+    worktrees.remove.mockImplementationOnce(
+      async (_path: string, opts: { onResidue?: (r: { path: string; reason: string }) => void }) => {
+        opts.onResidue?.({ path: "/wt/stuck", reason: "Permission denied" })
+      },
+    )
+
+    const task = await localOrch.createTask({ repo: "/repo", title: "stuck", vendor: "claude" })
+    await localStore.update(task.id, { worktreePath: "/wt/stuck" })
+    await localOrch.prepareTaskDeletion(task.id, { force: true })
+    await localOrch.beginTaskDeletion(task.id)
+    await expect(localOrch.finishTaskDeletion(task.id)).resolves.toBeUndefined()
+
+    // Red if the residue is ever treated as a failure: the task would survive
+    // in `deletion.phase = "error"` with no way forward.
+    expect(localOrch.getTask(task.id)).toBeUndefined()
+    expect(residues).toEqual([{ taskId: String(task.id), path: "/wt/stuck", reason: "Permission denied" }])
+    localOrch.dispose()
+  })
+
+  it("a clean removal reports no residue", async () => {
+    const residues: string[] = []
+    const localStore = new TaskIndexStore({ homeDir: home })
+    await localStore.load()
+    const localOrch = new Orchestrator({
+      store: localStore,
+      worktrees: worktrees as unknown as GitWorktreeManager,
+      onWorktreeResidue: (_taskId, residue) => residues.push(residue.path),
+    })
+
+    const task = await localOrch.createTask({ repo: "/repo", title: "clean", vendor: "claude" })
+    await localStore.update(task.id, { worktreePath: "/wt/ok" })
+    await localOrch.deleteTask(task.id)
+    localOrch.dispose()
+
+    expect(residues).toEqual([])
+  })
+
   it("deleting a dir task never touches its directory, forced or not", async () => {
     // The scratch-shell teardown used to pass `force: true` on the reasoning
     // that a scratch row owns no worktree. That is true only while the row is

--- a/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
@@ -1,0 +1,183 @@
+/**
+ * `remove()` when git's two jobs — deregister the metadata, delete the
+ * directory — succeed apart.
+ *
+ * Real git, real `chmod -w`: an unwritable directory inside a worktree makes
+ * `git worktree remove --force` exit 255 AFTER it has already deregistered the
+ * worktree. Reading the exit code as the whole truth reported that as a total
+ * failure and left every retry fatal (`is not a working tree`), so a task
+ * parked in `deletion.phase = "error"` forever (issue #89).
+ *
+ * These are the only tests that ask GIT what actually happened rather than
+ * asserting on a mock's arguments — a stub cannot produce the split.
+ */
+
+import { execSync } from "node:child_process"
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
+import type { WorktreeResidue } from "../../src/orchestrator/worktree/manager-remove.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+
+let root: string
+let repo: string
+let manager: GitWorktreeManager
+/** `<home>/.rove/worktrees` for the temp home — the root that authorizes the
+ *  orphaned-worktree `rm -rf` this file's residues must never fall into. */
+let managedRoot: string
+let previousHome: string | undefined
+/** Paths chmod'd read-only, restored in afterEach so cleanup can delete them. */
+const locked: string[] = []
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+}
+
+/** A worktree whose `fixture/` subdir cannot be unlinked — the shape that
+ *  makes git deregister-but-not-delete. */
+function undeletableWorktree(name: string, branch: string): string {
+  const wt = join(root, name)
+  execSync(`git worktree add -q ${JSON.stringify(wt)} -b ${branch}`, { cwd: repo, env: gitEnv })
+  const fixture = join(wt, "fixture")
+  mkdirSync(fixture, { recursive: true })
+  // Directly under the locked dir, not in a writable child: unlinking needs
+  // WRITE on the parent, so this file is the part git provably cannot take.
+  writeFileSync(join(fixture, "keep.txt"), "x")
+  chmodSync(fixture, 0o555)
+  locked.push(fixture)
+  return wt
+}
+
+function registered(worktreePath: string): boolean {
+  const out = execSync("git worktree list --porcelain", { cwd: repo, env: gitEnv, encoding: "utf8" })
+  return out.split("\n").some((l) => l === `worktree ${worktreePath}` || l === `worktree ${realpathSync(repo)}/../x`)
+}
+
+beforeAll(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), "kobe-wt-partial-")))
+  // The managed-roots guard reads `$KOBE_HOME_DIR`. Pointing it at the temp
+  // root is what lets the ordering test below put a residue INSIDE a real
+  // managed root — the one place the orphan branch would delete it.
+  previousHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = root
+  managedRoot = join(root, ".rove", "worktrees")
+  mkdirSync(managedRoot, { recursive: true })
+  repo = join(root, "repo")
+  mkdirSync(repo)
+  execSync("git init -q -b main && git commit -q --allow-empty -m init", { cwd: repo, env: gitEnv })
+  manager = new GitWorktreeManager()
+})
+
+afterEach(() => {
+  for (const p of locked.splice(0)) {
+    try {
+      chmodSync(p, 0o755)
+    } catch {
+      // already gone — the test that locked it removed the tree
+    }
+  }
+})
+
+afterAll(() => {
+  if (previousHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = previousHome
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe("remove() when git deregisters but cannot delete", () => {
+  it("resolves and reports the leftover directory instead of throwing", async () => {
+    const wt = undeletableWorktree("wt-locked", "kobe/locked")
+    const seen: WorktreeResidue[] = []
+
+    // Red before the fix: `runGit` threw on exit 255 and the caller saw a
+    // GitCommandError for a removal git had already half-applied.
+    await expect(manager.remove(wt, { force: true, onResidue: (r) => seen.push(r) })).resolves.toBeUndefined()
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].path).toBe(wt)
+    // git's own words, not ours — a fabricated reason would not name the path.
+    expect(seen[0].reason).toMatch(/Permission denied/)
+
+    // The two halves really did split: git forgot it, the disk did not.
+    expect(registered(wt)).toBe(false)
+    expect(existsSync(wt)).toBe(true)
+  })
+
+  it("does NOT delete the leftover directory — it is reported, not cleaned up", async () => {
+    const wt = undeletableWorktree("wt-keep", "kobe/keep")
+    await manager.remove(wt, { force: true, onResidue: () => {} })
+    // The whole point of reporting rather than cleaning: whatever made this
+    // undeletable may be something the user wants.
+    expect(existsSync(join(wt, "fixture", "keep.txt"))).toBe(true)
+  })
+
+  it("a second call converges instead of `is not a working tree`", async () => {
+    const wt = undeletableWorktree("wt-retry", "kobe/retry")
+    await manager.remove(wt, { force: true, onResidue: () => {} })
+
+    const second: WorktreeResidue[] = []
+    // Red before the fix AND red if the retry only stops throwing: git can no
+    // longer resolve this path, so without the deregistered-dir probe the call
+    // threw `is not a git worktree` and the caller had no forward move.
+    await expect(manager.remove(wt, { force: true, onResidue: (r) => second.push(r) })).resolves.toBeUndefined()
+    expect(second).toHaveLength(1)
+    expect(second[0].path).toBe(wt)
+  })
+
+  it("still deletes the branch on the opt-in — the residue is not a live worktree", async () => {
+    const wt = undeletableWorktree("wt-branch", "kobe/residue-branch")
+    await manager.remove(wt, { force: true, deleteBranch: true, onResidue: () => {} })
+    // The branch was undeletable only while checked out; the deregistration
+    // released it, so skipping the delete on this path would silently leak it.
+    const out = execSync('git branch --list "kobe/residue-branch"', { cwd: repo, env: gitEnv, encoding: "utf8" })
+    expect(out.trim()).toBe("")
+  })
+
+  it("a residue under a managed root is never swept into the orphan rm -rf", async () => {
+    // A deregistered worktree and an orphaned one look the SAME on disk — both
+    // leave a dangling `gitdir:` pointer — and a Rove-managed residue also
+    // satisfies the orphan branch's managed-root guard. So the residue check
+    // must run FIRST. Move it after the orphan handling (or delete it) and a
+    // forced delete `rm -rf`s the very directory git had just refused to
+    // touch: the user's undeletable files, destroyed by the retry.
+    const wt = join(managedRoot, "residue-in-root")
+    execSync(`git worktree add -q ${JSON.stringify(wt)} -b kobe/residue-in-root`, { cwd: repo, env: gitEnv })
+    const fixture = join(wt, "fixture")
+    mkdirSync(fixture, { recursive: true })
+    writeFileSync(join(fixture, "keep.txt"), "precious")
+    chmodSync(fixture, 0o555)
+    locked.push(fixture)
+
+    await manager.remove(wt, { force: true, onResidue: () => {} })
+    const second: WorktreeResidue[] = []
+    await manager.remove(wt, { force: true, onResidue: (r) => second.push(r) })
+
+    expect(second).toHaveLength(1)
+    // The file git could not take is still there after BOTH calls.
+    expect(existsSync(join(fixture, "keep.txt"))).toBe(true)
+  })
+
+  it("a plain directory that was never a worktree still throws", async () => {
+    // The classification must not swallow the real error: `onResidue` fires on
+    // a DEREGISTERED worktree, never on any directory git doesn't know.
+    const plain = join(root, "plain")
+    mkdirSync(plain)
+    await expect(manager.remove(plain, { onResidue: () => {} })).rejects.toThrow(/is not a git worktree/)
+  })
+
+  it("a clean removal reports no residue at all", async () => {
+    const wt = join(root, "wt-clean")
+    await manager.create(repo, "kobe/clean", wt)
+    const seen: WorktreeResidue[] = []
+    await manager.remove(wt, { onResidue: (r) => seen.push(r) })
+    // Red if the probe fires unconditionally: every ordinary delete would
+    // start telling the user about a directory that is gone.
+    expect(seen).toEqual([])
+    expect(existsSync(wt)).toBe(false)
+  })
+})

--- a/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
@@ -41,7 +41,10 @@ const gitEnv = {
 /** A worktree whose `fixture/` subdir cannot be unlinked — the shape that
  *  makes git deregister-but-not-delete. */
 function undeletableWorktree(name: string, branch: string): string {
-  const wt = join(root, name)
+  // Under the managed root because that is where a real Rove worktree lives —
+  // and on platforms whose git unlinks the `.git` pointer before failing, the
+  // retry's convergence runs through the managed-root path.
+  const wt = join(managedRoot, name)
   execSync(`git worktree add -q ${JSON.stringify(wt)} -b ${branch}`, { cwd: repo, env: gitEnv })
   const fixture = join(wt, "fixture")
   mkdirSync(fixture, { recursive: true })
@@ -159,6 +162,33 @@ describe("remove() when git deregisters but cannot delete", () => {
 
     expect(second).toHaveLength(1)
     // The file git could not take is still there after BOTH calls.
+    expect(existsSync(join(fixture, "keep.txt"))).toBe(true)
+  })
+
+  it("converges on a retry even where git unlinked the `.git` pointer first", async () => {
+    // Platform split, found by CI: macOS git leaves the worktree's `.git`
+    // pointer behind, Linux git unlinks it before failing. So the pointer
+    // fingerprint is a fast path, not the guarantee — the guarantee is the
+    // post-condition check ("is the directory still there?") after the
+    // managed-root cleanup. Removing the pointer by hand reproduces the Linux
+    // shape on any platform.
+    const wt = join(managedRoot, "no-pointer")
+    execSync(`git worktree add -q ${JSON.stringify(wt)} -b kobe/no-pointer`, { cwd: repo, env: gitEnv })
+    const fixture = join(wt, "fixture")
+    mkdirSync(fixture, { recursive: true })
+    writeFileSync(join(fixture, "keep.txt"), "precious")
+    chmodSync(fixture, 0o555)
+    locked.push(fixture)
+
+    await manager.remove(wt, { force: true, onResidue: () => {} })
+    rmSync(join(wt, ".git"), { force: true })
+
+    const second: WorktreeResidue[] = []
+    await expect(manager.remove(wt, { force: true, onResidue: (r) => second.push(r) })).resolves.toBeUndefined()
+    // Red if the orphan branch reports a clean removal: `rm -rf` exits 0
+    // having deleted only what it could, so the caller would be told the
+    // directory is gone while it is still on disk.
+    expect(second).toHaveLength(1)
     expect(existsSync(join(fixture, "keep.txt"))).toBe(true)
   })
 


### PR DESCRIPTION
Closes issue #89 (daemon issue store).

## The bug

`git worktree remove` does two things — deregister the worktree's metadata and delete its directory — and they can fail apart. An unwritable path inside the tree (a `chmod -w` directory, a read-only dependency cache, anything an external tool holds) makes the directory delete fail *after* the deregistration has already landed:

```
$ git worktree remove --force ../wt
error: failed to delete '.../wt': Permission denied   # exit 255
$ git worktree list      # already deregistered
$ ls -A ../wt            # .git  fixture   — still there
$ git worktree remove --force ../wt
fatal: '../wt' is not a working tree                  # unrecoverable
```

`remove()` read the exit code as the whole truth, so it reported a total failure — and left no way forward. Git's own view is that the worktree no longer exists, so no retry, remove, or prune can advance it, and the task stayed in `deletion.phase = "error"` forever. The only exit was a manual `rm -rf`.

## The fix

A non-zero exit is now **classified** rather than trusted: re-probe the path and ask git its own question.

- Still registered → nothing happened; throw the `GitCommandError` callers have always seen.
- Gone → the deregistration landed; resolve, and report the leftover directory through a new `onResidue` callback.

**Rove never deletes the leftover.** It is a result reported to the caller, not debris: whatever made it undeletable may be something the user wants. Deleting it stays a manual, explicit act.

### Converging a retry, on both platform shapes

A retry has to land on the same answer, and the on-disk evidence differs by platform — CI caught this after the first push:

- **macOS** leaves the worktree's `.git` pointer file behind. A dangling `gitdir:` whose *repo* end still exists is a deregistered worktree; one whose repo end is gone is an orphan (#706's case). That fast path tells them apart.
- **Linux** unlinks `.git` before failing, so no fingerprint exists. The guarantee there is a post-condition: #706's `rm -rf` exits 0 having deleted only what it could, so if the directory is still on disk afterwards, that is residue — previously reported as a clean removal, sending the caller to look for something still present.

### Ordering matters, destructively

A deregistered worktree and an orphaned one look identical on disk, and a Rove-managed residue also satisfies #706's managed-root guard. If the residue check ever moved below the orphan branch, a forced delete would `rm -rf` the very directory git had just refused to touch. `manager-remove.ts` runs the residue check first, and a test pins that ordering.

## Callers

- **`TaskDeletionCoordinator`** — a residue completes the deletion instead of parking the task in `error`. No second source of truth: the task is gone (git no longer knows the worktree), and the leftover goes to `daemon.log` beside the rest of the deletion trail, which is the only place its path is ever named again.
- **`land --remove-worktree`** — reports `removed: true` with a `residue` field. The land landed; only the directory delete did not.
- **Worktrees page (TUI + web)** — an attention toast naming the path, git's reason, and that retrying will not help.

## Verification

**Before/after against real git**, same fixture both sides:

```
BEFORE (origin/main 622c2ec1)
attempt 1: THREW ...exited with code 255: failed to delete ...: Permission denied
  residue reported: []          git still registers it: false     directory on disk: true
attempt 2: THREW  remove(): ... has no reachable git repo and is not under a Rove worktrees root

AFTER
attempt 1: resolved
  residue: [{"path":".../wt","reason":"error: failed to delete '.../wt': Permission denied"}]
  git still registers it: false     directory on disk: true     user file kept: true
attempt 2: resolved, residue: [{"path":".../wt","reason":"a previous removal deregistered the worktree"}]
```

For a residue **under a Rove-managed root**, main's retry falls into #706's orphan path and *reports success while the directory is still on disk*; this branch reports it accurately. Simulating the Linux shape (unlinking `.git` between calls) converges the same way, with the user's file intact.

**Mutation validation** — three rounds, nine distinct sites, all caught (restored green after each):

| Mutation | Red |
|---|---|
| drop the "still registered?" classification | 5 |
| drop the deregistered-residue branch | 1 |
| coordinator treats a residue as failure | 1 |
| land drops `residue` from its result | 1 |
| fire `onResidue` unconditionally | 6 |
| residue probe ignores whether the repo survives | 3 |
| skip branch deletion on the residue path | 1 |
| move the residue check below the orphan `rm -rf` | 1 |
| drop the post-`rm -rf` existence check | 1 |
| invert that existence check | 1 |

**Suites** (run at a normal path — this repo's own worktree lives under `~/.rove/worktrees`, which makes 4 unrelated `project-eligibility` / `open-dir-cmd` tests fail on path shape alone, on main too):

- `test:fast` 4006 passed (410 files)
- `test:socket` 660 passed (77 files)
- `bun test test/render` 333 pass, 0 fail
- root lint + typecheck + `check-i18n` (713 keys × 2 locales) green

`manager.ts` stays at 421 lines; `manager-remove.ts` 253. Docs updated in `WORKTREES.md` and `TROUBLESHOOTING.md` (both already synced to docs.rove.run). Changeset: patch.