### PR TITLE
fix: align the sidebar's New task label with the rest of the rail

### DIFF
--- a/.changeset/sidebar-new-task-alignment.md
+++ b/.changeset/sidebar-new-task-alignment.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Align the sidebar's New task label with the rest of the rail.
+
+It carried a left inset on both its wrapper and the box that paints its background, so the label started one cell right of the ROVE header, the nav rail, the tree rows, and the ZEN chip.

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -166,7 +166,13 @@ export function SidebarCreateAction(props: { onAddTask?: () => void }) {
   return (
     // One content row, no vertical padding: this is the tallest-pressure
     // panel in the product, so the action must cost exactly one line.
-    <box flexShrink={0} paddingLeft={1} paddingRight={1}>
+    //
+    // The left inset lives HERE and nowhere else. The inner box carries the
+    // filled background, so it needs its own horizontal padding to keep the
+    // label off the fill's edge — and adding an inset on this wrapper too put
+    // the label at column 2 while every other sidebar element (the ROVE
+    // header, the nav rail, the tree rows, the ZEN chip) starts at column 1.
+    <box flexShrink={0} paddingRight={1}>
       <box
         position="relative"
         flexDirection="row"

--- a/packages/kobe/test/render/golden/empty.frame.txt
+++ b/packages/kobe/test/render/golden/empty.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/long-labels.frame.txt
+++ b/packages/kobe/test/render/golden/long-labels.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/move-mode.frame.txt
+++ b/packages/kobe/test/render/golden/move-mode.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/recent-jump-row.frame.txt
+++ b/packages/kobe/test/render/golden/recent-jump-row.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/scratch-flat.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-flat.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/scratch-path-label.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-path-label.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/search-pruned.frame.txt
+++ b/packages/kobe/test/render/golden/search-pruned.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | /bravo█ 2/5                  |
 |                              |
 | Kanban                       |

--- a/packages/kobe/test/render/golden/search-tab-title.frame.txt
+++ b/packages/kobe/test/render/golden/search-tab-title.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | /review█ 2/5                 |
 |                              |
 | Kanban                       |

--- a/packages/kobe/test/render/golden/tab-error.frame.txt
+++ b/packages/kobe/test/render/golden/tab-error.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tab-idle.frame.txt
+++ b/packages/kobe/test/render/golden/tab-idle.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tab-non-agent.frame.txt
+++ b/packages/kobe/test/render/golden/tab-non-agent.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
+++ b/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
+++ b/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tab-running.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
+++ b/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/tree-unknown.frame.txt
+++ b/packages/kobe/test/render/golden/tree-unknown.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
+++ b/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |

--- a/packages/kobe/test/render/golden/zen-chip.frame.txt
+++ b/packages/kobe/test/render/golden/zen-chip.frame.txt
@@ -4,7 +4,7 @@
 # GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
 |                              |
 | ROVE                         |
-|  New task               + n  |
+| New task                + n  |
 | Kanban                       |
 | Routines                     |
 | Issues                       |


### PR DESCRIPTION
`SidebarCreateAction` set `paddingLeft={1}` on **both** its wrapper and the inner box that paints the row's background, so the label landed at column 2 while every other element in the rail — the `ROVE` header, the nav rail, the tree rows, the ZEN chip — starts at column 1.

The inner padding is load-bearing (it keeps the label off the filled background's edge), so the wrapper's inset is the one that goes.

## Before / after

```
| ROVE                         |      | ROVE                         |
|  New task               + n  |  →   | New task                + n  |
| Kanban                       |      | Kanban                       |
| Routines                     |      | Routines                     |
```

## Tests

The 19 sidebar frame goldens caught this on their own — regenerated with `KOBE_UPDATE_GOLDEN=1`, and the diff is exactly one line per file:

```
-|  New task               + n  |
+| New task                + n  |
```

Nothing else in any frame changed. Full render track (333) and vitest (3995) green.

## Scope

The owner also asked for a sweep — "这种问题项目中存在很多". I scanned `tui-react/**` for the same nested-inset shape and this row is the only real instance; the other hits were sibling ternary branches, a single padding, or a deliberate chip fill. Any remaining misalignment is a different class and needs the owner to point at specific screens, so this PR fixes the one that was actually named rather than guessing at others.