### PR TITLE
fix: reopen a session when re-entering a task whose last tab was closed

### DIFF
--- a/.changeset/reopen-emptied-task-tabs.md
+++ b/.changeset/reopen-emptied-task-tabs.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Reopen a session when you re-enter a task whose last tab you closed.
+
+Closing the last tab leaves the task and its sidebar row in place, but nothing could bring it back: selecting the row landed on a "no sessions here" pane with no way out. Entering the task now opens a fresh tab of the kind that was closed — a shell comes back a shell, an engine an engine, keeping that tab's vendor. A task emptied before this release has no record of what it was and reopens the default engine tab.

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -68,11 +68,17 @@ export function ShowWorkspace(props: {
     )
   }
   const path = props.worktree
-  // A task whose last tab you closed (owner call 2026-08-31) has KNOWN, empty
-  // tabs. Mounting TerminalTabs for it would immediately mint a replacement —
-  // its `active` tab is non-null by construction and 17 call sites downstream
-  // rely on that — so the empty state is handled by not mounting at all.
+  // A task whose last tab you closed has KNOWN, empty tabs. Mounting
+  // TerminalTabs over that list would immediately mint a replacement — its
+  // `active` tab is non-null by construction and 17 call sites downstream rely
+  // on that — so the empty state is handled by not mounting at all.
   // `null` (never mounted since restart) is NOT empty and must still mount.
+  //
+  // ENTERING the task revives it (`reviveEmptiedTabs`, called from
+  // `activateTask`), so the normal path replaces this placeholder within the
+  // same gesture. It still renders, because this component is also reached
+  // without an activation — a task selected by restart restore, or one emptied
+  // while already on screen — and a blank pane would say nothing at all.
   const known = props.task ? knownTaskTabs(kv, String(props.task.id)) : null
   if (known && known.tabs.length === 0) {
     return (

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -16,6 +16,7 @@ import {
   type TerminalTab,
   initialTabs,
   rehydrateTabs,
+  reopenTabs,
 } from "../../tui/workspace/terminal-tabs-core"
 import type { VendorId } from "../../types/vendor"
 import { type TabsSnapshotKv, forgetTaskTabsSnapshot, terminalTabsKey } from "./terminal-tabs-persist"
@@ -41,6 +42,25 @@ export function setTaskTabs(taskId: string, state: TabsState): void {
   tabsRevision.update((n) => n + 1)
 }
 
+/**
+ * Revive a task whose last tab was closed, returning true when it did.
+ *
+ * Selecting the task is the affordance (owner call 2026-08-31): the sidebar
+ * row IS the button, so entering an emptied task reopens the kind of tab that
+ * was there rather than landing on a pane with nothing to press. A snapshot
+ * from before `reopenAs` existed reopens the default engine tab — see
+ * {@link reopenTabs}.
+ *
+ * No-op for every other state: a task with tabs, and a task that has never
+ * opened any (`null`, not empty — TerminalTabs mounts and mints its own).
+ */
+export function reviveEmptiedTabs(kv: TabsSnapshotKv | null, taskId: string, shell: string): boolean {
+  const known = knownTabsState(kv, taskId)
+  if (!known || known.tabs.length > 0) return false
+  setTaskTabs(taskId, reopenTabs(known, shell))
+  return true
+}
+
 /** Drop a task's tab state AND notify React readers. */
 export function deleteTaskTabs(taskId: string): void {
   if (!tabsByTask.delete(taskId)) return
@@ -60,7 +80,7 @@ export function activeTabIdFor(taskId: string): string | null {
  *  mounted before the context exists) still sees the live tabs instead of
  *  crashing: the in-memory map is authoritative for anything running now,
  *  and the snapshot only adds tasks that have not mounted since restart. */
-function knownTabsState(kv: TabsSnapshotKv | null, taskId: string): TabsState | null {
+export function knownTabsState(kv: TabsSnapshotKv | null, taskId: string): TabsState | null {
   const live = tabsByTask.get(taskId)
   if (live) return live
   const saved = kv?.store[terminalTabsKey(taskId)] as TabsState | null | undefined

--- a/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
@@ -9,12 +9,13 @@
 import { useEffect, useRef, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { readLastActiveTaskId } from "../../state/last-active.ts"
+import { defaultShell } from "../../tui/panes/terminal/pty-types"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import type { Task } from "../../types/task.ts"
 import { useT } from "../i18n"
 import { useLatest } from "../lib/use-latest"
 import { type TabsSnapshotKv, sweepOrphanTabsSnapshots } from "./terminal-tabs-persist"
-import { forgetTaskTabs, knownTaskTabs } from "./terminal-tabs-shared"
+import { forgetTaskTabs, knownTaskTabs, reviveEmptiedTabs } from "./terminal-tabs-shared"
 import { activateWorkspaceTask, activationErrorMessage, firstSelectableTask } from "./use-task-selection"
 
 /** What {@link useWorkspaceSelection} reports when a worktree vanishes under a task. */
@@ -202,6 +203,11 @@ export function useWorkspaceSelection(args: {
   const activationGenerationRef = useRef(0)
   async function activateTask(id: string): Promise<void> {
     const generation = ++activationGenerationRef.current
+    // Entering a task whose last tab was closed reopens one (owner call
+    // 2026-08-31). Before the worktree await, so the revived tab is published
+    // by the time selection lands and the workspace never paints the blank
+    // frame `show-workspace` renders for an empty tab list.
+    reviveEmptiedTabs(kv, id, defaultShell())
     await activateWorkspaceTask(
       {
         getTask: (taskId) => tasks.find((task) => task.id === taskId),

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -41,11 +41,62 @@ export interface TabsState {
   readonly activeId: string
   /** Next ordinal to hand out (monotonic — close does not recycle). */
   readonly nextOrdinal: number
+  /**
+   * What the LAST tab was, recorded as it closed, so re-entering an emptied
+   * task reopens the same kind of session instead of always an engine
+   * ({@link reopenTabs}). Only set when `tabs` is empty — a task with tabs
+   * doesn't need it, and a stale value would outlive its meaning.
+   *
+   * A snapshot written before this field existed simply lacks it, which is
+   * why {@link reopenTabs} treats absence as "use the default" rather than
+   * as an error: the whole point is that upgrading in place is silent.
+   */
+  readonly reopenAs?: { readonly kind: "engine"; readonly vendor?: VendorId } | { readonly kind: "command" }
 }
 
 /** A task's initial state: one untitled engine tab, active. */
 export function initialTabs(): TabsState {
   return { tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }], activeId: "tab-1", nextOrdinal: 2 }
+}
+
+/**
+ * What to reopen an emptied task as, derived from the tab that just closed.
+ *
+ * Only the SHAPE is carried, never the session: the PTY died with the tab, so
+ * an engine comes back as a fresh engine (its `sessionId` deliberately absent)
+ * and a shell as a fresh shell. A content/preview tab has no session to speak
+ * of and reopens as an engine — reviving a file preview as the whole workspace
+ * would be a strange thing to land in.
+ */
+function reopenHintFor(closed: TerminalTab | undefined): TabsState["reopenAs"] {
+  if (closed?.kind === "command") return { kind: "command" }
+  if (closed?.kind === "engine" && closed.vendor) return { kind: "engine", vendor: closed.vendor }
+  return { kind: "engine" }
+}
+
+/**
+ * Revive a task whose last tab was closed: one fresh tab of the kind that was
+ * there before, active. `shell` is the argv a `command` tab respawns with.
+ *
+ * `reopenAs` is absent for a snapshot written before it existed (an install
+ * upgrading in place), and absence means the default engine tab — the same
+ * thing {@link initialTabs} gives a brand-new task. That is the fallback, not
+ * an error path: a user who upgrades mid-session should not be able to reach a
+ * task that refuses to reopen.
+ */
+export function reopenTabs(state: TabsState, shell: string): TabsState {
+  const ordinal = state.nextOrdinal
+  const id = `tab-${ordinal}`
+  const next = state.nextOrdinal + 1
+  if (state.reopenAs?.kind === "command") {
+    return { tabs: [{ kind: "command", id, title: null, ordinal, command: [shell] }], activeId: id, nextOrdinal: next }
+  }
+  const vendor = state.reopenAs?.kind === "engine" ? state.reopenAs.vendor : undefined
+  return {
+    tabs: [{ kind: "engine", id, title: null, ordinal, ...(vendor ? { vendor } : {}) }],
+    activeId: id,
+    nextOrdinal: next,
+  }
 }
 
 /** A SCRATCH task's initial state (issue #33): one bare shell tab, active —
@@ -169,8 +220,10 @@ export function closeTab(
   if (state.activeId !== id) return { state: { ...state, tabs }, closedId: id }
   // Emptied: keep the id of the tab that just went, so nothing downstream has
   // to special-case an empty string. Nothing renders it — a task with no tabs
-  // is not mounted at all (show-workspace.tsx).
-  if (tabs.length === 0) return { state: { ...state, tabs, activeId: id }, closedId: id }
+  // is not mounted at all (show-workspace.tsx) until `reopenTabs` revives it.
+  if (tabs.length === 0) {
+    return { state: { ...state, tabs, activeId: id, reopenAs: reopenHintFor(state.tabs[i]) }, closedId: id }
+  }
   const next = tabs[Math.max(0, i - 1)]
   return { state: { ...state, tabs, activeId: (next ?? tabs[0]).id }, closedId: id }
 }

--- a/packages/kobe/test/tui-react/revive-emptied-tabs.test.ts
+++ b/packages/kobe/test/tui-react/revive-emptied-tabs.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Re-entering a task whose last tab you closed must give it a tab back.
+ *
+ * `closeTab({ allowEmpty })` (owner call 2026-08-31) lets the last tab go, and
+ * `show-workspace` deliberately renders nothing for an empty tab list — mounting
+ * TerminalTabs over one would mint a replacement it cannot control. That left
+ * the task reachable but dead: its row was still in the sidebar, and selecting
+ * it landed on a blank pane with no way out.
+ *
+ * `reviveEmptiedTabs` is the missing half, and this pins the states it must and
+ * must NOT act on. `terminal-tabs-core.test`-adjacent coverage
+ * (tab-close-scratch) locks the pure transition; this locks the kv-facing
+ * decision, which is where "never opened" and "opened then emptied" are easy to
+ * confuse — they are the same `tabs.length === 0` to a careless reader.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest"
+import { terminalTabsKey } from "../../src/tui-react/workspace/terminal-tabs-persist.ts"
+import { reviveEmptiedTabs, tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared.ts"
+import type { TabsState } from "../../src/tui/workspace/terminal-tabs-core.ts"
+
+/** The `TabsSnapshotKv` surface, backed by a plain object. */
+function fakeKv(store: Record<string, unknown> = {}) {
+  return {
+    store,
+    set(key: string, value: unknown) {
+      store[key] = value
+    },
+  }
+}
+
+const TASK = "task-1"
+
+beforeEach(() => {
+  tabsByTask.clear()
+})
+
+describe("reviveEmptiedTabs", () => {
+  it("reopens an emptied task as the kind of tab that was closed", () => {
+    const emptied: TabsState = {
+      tabs: [],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+      reopenAs: { kind: "command" },
+    }
+    const kv = fakeKv({ [terminalTabsKey(TASK)]: emptied })
+
+    expect(reviveEmptiedTabs(kv, TASK, "/bin/zsh")).toBe(true)
+    const revived = tabsByTask.get(TASK)
+    expect(revived?.tabs).toHaveLength(1)
+    expect(revived?.tabs[0]?.kind).toBe("command")
+  })
+
+  it("reopens a pre-reopenAs snapshot as a default engine tab", () => {
+    // The upgrade path: emptied on an older build, so the hint is absent. It
+    // must still reopen — a user who updates mid-session should not inherit a
+    // task that refuses to open.
+    const legacy: TabsState = { tabs: [], activeId: "tab-1", nextOrdinal: 2 }
+    const kv = fakeKv({ [terminalTabsKey(TASK)]: legacy })
+
+    expect(reviveEmptiedTabs(kv, TASK, "/bin/zsh")).toBe(true)
+    expect(tabsByTask.get(TASK)?.tabs[0]?.kind).toBe("engine")
+  })
+
+  it("leaves a task that still has tabs alone", () => {
+    // The common case by far. Reviving here would add a phantom tab on every
+    // single task activation.
+    const live: TabsState = {
+      tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    }
+    const kv = fakeKv({ [terminalTabsKey(TASK)]: live })
+
+    expect(reviveEmptiedTabs(kv, TASK, "/bin/zsh")).toBe(false)
+    expect(tabsByTask.has(TASK)).toBe(false)
+  })
+
+  it("leaves a task that has NEVER opened tabs alone", () => {
+    // `null`, not empty — the distinction the whole empty-state branch rests
+    // on. TerminalTabs mounts for this task and mints its own first tab;
+    // publishing one here would race that with a second, session-less tab.
+    const kv = fakeKv({})
+
+    expect(reviveEmptiedTabs(kv, TASK, "/bin/zsh")).toBe(false)
+    expect(tabsByTask.has(TASK)).toBe(false)
+  })
+
+  it("prefers live in-memory state over the snapshot", () => {
+    // A task mounted THIS session is authoritative in `tabsByTask`; the kv
+    // snapshot can lag it. Reading the stale snapshot would revive a task that
+    // already has tabs open right now.
+    const kv = fakeKv({ [terminalTabsKey(TASK)]: { tabs: [], activeId: "tab-1", nextOrdinal: 2 } })
+    tabsByTask.set(TASK, {
+      tabs: [{ kind: "engine", id: "tab-9", title: null, ordinal: 9 }],
+      activeId: "tab-9",
+      nextOrdinal: 10,
+    })
+
+    expect(reviveEmptiedTabs(kv, TASK, "/bin/zsh")).toBe(false)
+    expect(tabsByTask.get(TASK)?.tabs[0]?.id).toBe("tab-9")
+  })
+})

--- a/packages/kobe/test/tui/tab-close-scratch.test.ts
+++ b/packages/kobe/test/tui/tab-close-scratch.test.ts
@@ -23,6 +23,7 @@ import {
   closeTab,
   initialShellTabs,
   rehydrateTabs,
+  reopenTabs,
 } from "../../src/tui/workspace/terminal-tabs-core.ts"
 
 function harness(state: TabsState, opts: { scratch?: boolean } = {}) {
@@ -84,6 +85,53 @@ describe("closing down to zero tabs (owner call 2026-08-31)", () => {
     // written for, so the default must keep healing it.
     const corrupt: TabsState = { tabs: [], activeId: "tab-1", nextOrdinal: 2 }
     expect(rehydrateTabs(corrupt, ["/bin/zsh"]).tabs).toHaveLength(1)
+  })
+
+  it("records what the closed tab WAS, so re-entry reopens the same kind", () => {
+    // Owner ask 2026-08-31: re-entering an emptied task should bring back the
+    // kind of session that was there, not always an engine.
+    const shellOnly: TabsState = {
+      tabs: [{ kind: "command", id: "tab-1", title: null, ordinal: 1, command: ["/bin/zsh"] }],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    }
+    const emptied = closeTab(shellOnly, "tab-1", { allowEmpty: true }).state
+    expect(emptied.tabs).toEqual([])
+    expect(emptied.reopenAs).toEqual({ kind: "command" })
+
+    const revived = reopenTabs(emptied, "/bin/zsh")
+    expect(revived.tabs).toHaveLength(1)
+    expect(revived.tabs[0]?.kind).toBe("command")
+    // A fresh id, never the closed tab's: ordinals are monotonic, and the PTY
+    // registry keys on `taskId::tabId` — reusing the id would collide with the
+    // entry the close just released.
+    expect(revived.tabs[0]?.id).toBe("tab-2")
+    expect(revived.activeId).toBe("tab-2")
+  })
+
+  it("an engine tab reopens as an engine, keeping its per-tab vendor", () => {
+    const engineOnly: TabsState = {
+      tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "codex" }],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    }
+    const emptied = closeTab(engineOnly, "tab-1", { allowEmpty: true }).state
+    const revived = reopenTabs(emptied, "/bin/zsh")
+    expect(revived.tabs[0]?.kind).toBe("engine")
+    expect(revived.tabs[0]).toMatchObject({ vendor: "codex" })
+    // The session is NOT carried: that PTY died with the tab, so reviving it
+    // would resume a conversation that no longer has a process.
+    expect(revived.tabs[0]).not.toHaveProperty("sessionId")
+  })
+
+  it("a snapshot written before reopenAs existed falls back to a default engine tab", () => {
+    // The upgrade path (owner ask): an install that emptied a task on an older
+    // build has no `reopenAs`, and must still reopen rather than stay stuck.
+    const legacy: TabsState = { tabs: [], activeId: "tab-1", nextOrdinal: 2 }
+    const revived = reopenTabs(legacy, "/bin/zsh")
+    expect(revived.tabs).toHaveLength(1)
+    expect(revived.tabs[0]?.kind).toBe("engine")
+    expect(revived.activeId).toBe("tab-2")
   })
 
   it("closeTab refuses to empty a task unless asked", () => {


### PR DESCRIPTION
Owner report: "有些 chattab 关闭后 task 还在，理论上点击 task 在 sidebar 就能创建一个新的 tab with last active?"

## The dead end

`closeTab({ allowEmpty })` lets the last tab go and the task stays — that part works. But nothing could bring the task back:

- `activateTask` selects the task and ensures its worktree; it never touches tabs
- `show-workspace` sees `tabs.length === 0` and renders `workspace.empty.noSessions` rather than mounting `TerminalTabs` (whose `active` tab is non-null by construction — mounting would mint a replacement it can't control)

So the row stayed in the sidebar, selecting it landed on a pane with nothing to press, and there was no supported way back into that task.

## The fix

`closeTab` records **what the closed tab was** (`reopenAs`), and `activateTask` calls `reviveEmptiedTabs` before selection lands. Clicking the task/branch row is the whole gesture — a click already fires `onSelect` + `onActivate`.

- shell tab → reopens a shell
- engine tab → reopens an engine, keeping that tab's per-tab `vendor`
- **no hint** (snapshot written before this release) → default engine tab

That last one is the upgrade path the owner asked for: an install that emptied a task on an older build must not inherit a task that refuses to open.

The session is deliberately **not** carried — the PTY died with the tab, so reviving `sessionId` would resume a conversation with no process behind it. The new tab also gets a fresh id: ordinals are monotonic and the PTY registry keys on `taskId::tabId`, so reusing the closed id would collide with the entry the close just released.

The placeholder stays. `ShowWorkspace` is reached without an activation too (restart restore, a task emptied while already on screen), and a blank pane says nothing at all. Three existing render tests pin that, and they caught it when I first tried returning `null`.

## Tests

- `tab-close-scratch.test.ts` — 3 cases on the pure transition: the hint is recorded, an engine keeps its vendor and drops its session, and a pre-`reopenAs` snapshot falls back to a default engine tab
- `revive-emptied-tabs.test.ts` (new) — the kv-facing decision, where "never opened" (`null`) and "opened then emptied" (`[]`) are easy to confuse: both no-op cases pinned, plus live in-memory state winning over a stale snapshot

Mutation-checked in three places: dropping the `reopenAs` write, ignoring the command hint on reopen, and dropping the has-tabs guard each red the matching tests.

Full vitest 4014, render 333, lint + typecheck green.