### PR TITLE
fix: let a hidden project be opened again, and back the empty pane's keys

### DIFF
--- a/.changeset/open-a-hidden-project.md
+++ b/.changeset/open-a-hidden-project.md
@@ -1,0 +1,21 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Give a project that left the sidebar a way back, and make the empty pane's own keys work.
+
+Closing a project's last tab hides it from the sidebar. Nothing is deleted, and
+the rule claimed the repo was "still there in the new-task picker to open again"
+— but every submit path went through `createTask`, which always mints a task
+worktree, so picking the hidden repo added a worktree beside the project and
+still produced no project row. The only real way back was `rove add` in a shell.
+
+The New task dialog's For Existing tab now offers, for a repository Rove already
+tracks as a project, a choice between opening a new task worktree and opening
+the project itself. The second routes to `ensureMainTask`, so it resolves the
+existing checkout rather than creating anything.
+
+Separately, the "No sessions here — press ⏎ or ctrl+e to start one" pane named
+two keys that had no handler: both are registered inside the tab component,
+which is deliberately not mounted over an empty tab list. The pane now binds
+them itself, and reopens the kind of tab that was closed.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -75,7 +75,8 @@ focus or dialog.
 | `ctrl+q` | Focus the sidebar; pressed again there, quit immediately (`q` in the sidebar quits with a confirm) |
 | `ctrl+t` | New engine tab |
 | `ctrl+e` | New-conversation dialog with the engine/shell picker; inside it, `←`/`→` (or `h`/`l`) pick the engine and `enter` confirms, `tab` switches the destination (new tab here ⇄ fork a child task) and `ctrl+f` the context (fresh ⇄ continue this chat). The trailing "scratch shell" choice opens a Scratch shell task |
-| `ctrl+w` | Close the active split, otherwise the tab |
+| `ctrl+w` | Close the active split, otherwise the tab — closing the last tab leaves the task open with no session |
+| `enter` | Reopen a session in a task whose tabs are all closed (only while that empty pane is showing; `ctrl+e` does the same there) |
 | `ctrl+[` / `ctrl+]` | Previous / next tab (`ctrl+[` needs kitty — see below) |
 | `ctrl+\` | Split right |
 | `ctrl+=` | Split down |
@@ -87,7 +88,9 @@ focus or dialog.
 | `F7` | Jump to the next Inbox item across all projects |
 
 Overlap resolves by context: `ctrl+w` closes the innermost split when a tab
-is split, otherwise the tab. `F2` follows the same rule.
+is split, otherwise the tab. `F2` follows the same rule. `enter` is bound only
+by the "no sessions here" pane, which has no input and no tab of its own —
+everywhere else in the workspace it reaches the terminal as usual.
 
 Both split chords need a terminal speaking the kitty keyboard protocol
 (legacy terminals can't encode `ctrl+=`, and `ctrl+\` would be SIGQUIT);

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -206,6 +206,12 @@ mode selector and use the left/right arrows.
 - **For Existing** picks a local repository and the ref to branch from. Rove
   creates a new task branch and worktree, then opens it ready for the first
   prompt. The current repository and its checked-out branch are the defaults.
+  For a repository Rove already tracks as a project, an extra **opens** row
+  appears: leave it on "a new task worktree" for the behaviour above, or
+  choose "the project itself" to open that repository's own checkout instead
+  of branching off it. That is how you return to a project that left the
+  sidebar after you closed its last tab — the branch field disappears,
+  because opening a checkout forks from nothing.
 - **For New Repo** clones a Git URL into a chosen parent directory, derives an
   available folder name, then creates a task from the requested base branch.
   The parent directory is remembered for the next clone.
@@ -224,8 +230,10 @@ another row fails, and Rove reports the result count.
 `ctrl+t` starts a fresh engine tab immediately; `ctrl+e` opens the full engine,
 shell, and plugin picker. Tabs share the Task's worktree but keep separate
 processes, scrollback, titles, and engine conversations. `ctrl+[` / `ctrl+]`
-switch tabs, `F2` renames one, and `ctrl+w` closes it. A Task always keeps at
-least one tab.
+switch tabs, `F2` renames one, and `ctrl+w` closes it — including the last
+one, which leaves the Task open with no session. Re-entering that Task from
+the sidebar reopens the kind of tab that was there; from the empty pane
+itself, `enter` or `ctrl+e` does the same.
 
 Inside a terminal tab, `ctrl+\` splits right and `ctrl+=` splits down. New
 leaves run your login shell in the same worktree. `F3` cycles split focus;

--- a/docs/design/keybinding-decisions.md
+++ b/docs/design/keybinding-decisions.md
@@ -332,6 +332,27 @@ transparent themes both stay readable — pinned by
 `test/tui-react/keyboard-overlay-theme.test.ts` and the `/harness` visual
 journey `keyboard hints render and extinguish in the real OpenTUI`.
 
+## Reopening a closed-down session (issue #90)
+
+**2026-08-31 — `workspace.reopenSession` = plain `return`, workspace scope
+(owner sign-off).** `ctrl+w` on a task's last tab now empties it, and the
+pane left behind (`tui-react/workspace/empty-workspace-pane.tsx`) reads
+"press ⏎ or ctrl+e to start one" — copy that shipped in #696 naming two keys
+neither of which had a handler. Both live in `TerminalTabs`, and that
+component is deliberately not mounted over an empty tab list.
+
+A bare `return` is normally too cheap a key to spend at workspace scope. It
+is safe here because the binding is registered BY that pane, which holds no
+input, no tab strip and no terminal: while it is on screen there is nothing
+else Enter could mean, and when it is not, the binding does not exist. The
+alternative — rewording the copy down to `ctrl+e` only — was rejected: Enter
+is what the sidebar already uses to open the row, and the pane is the same
+gesture one pane over.
+
+`ctrl+e` (`chat.tab.chooseEngine`) is re-registered on the same pane. That is
+not a second chord for one action; it is the existing chord staying
+answerable in the one state where its usual owner is unmounted.
+
 ## Adding or moving a chord
 
 Get owner sign-off on direct versus prefix placement, the selected key, and

--- a/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
@@ -44,6 +44,7 @@ function show(
         defaultVendor={options?.defaultVendor}
         availableVendors={options?.availableVendors}
         discoverAdoptable={options?.discoverAdoptable}
+        mainRepos={options?.mainRepos}
         onSubmit={(v) => resolve(v)}
         onCancel={() => resolve(undefined)}
       />

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
@@ -73,11 +73,14 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
           so it stays absent rather than disabled. */}
       {vm.canOpenProject ? (
         <box gap={0} paddingBottom={1}>
-          <text fg={theme.textMuted}>{t("newTask.field.opens")}</text>
+          <text {...labelStyle(theme, vm.field, "intent")}>{t("newTask.field.opens")}</text>
           <ChoiceRow
             choices={intents}
             selected={vm.intent}
-            onPick={(next) => vm.setIntent(next)}
+            onPick={(next) => {
+              vm.setIntent(next)
+              vm.setField("intent")
+            }}
             display={(choice) => intentLabel[choice]}
           />
         </box>

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
@@ -7,11 +7,11 @@
  * All behavior lives in the view-model; this file is JSX only.
  */
 
-import { splitRepoRow } from "../../../tui/component/new-task-dialog/state"
+import { type ExistingIntent, splitRepoRow } from "../../../tui/component/new-task-dialog/state"
 import { DEFAULT_BASE_REF } from "../../../tui/lib/git-snapshot"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
-import { PickerList, labelStyle } from "./picker-list"
+import { ChoiceRow, PickerList, labelStyle } from "./picker-list"
 import type { NewTaskVm } from "./view-model"
 
 export function ExistingTab({ vm }: { vm: NewTaskVm }) {
@@ -44,6 +44,12 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
     accent: vm.baseRef.trim() === name,
   }))
 
+  const intents: readonly ExistingIntent[] = ["task", "project"]
+  const intentLabel: Record<ExistingIntent, string> = {
+    task: t("newTask.intent.task"),
+    project: t("newTask.intent.project"),
+  }
+
   return (
     <>
       <box gap={0}>
@@ -62,19 +68,37 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
       {vm.field === "repo" && vm.activeList.length > 0 && !vm.repoPicked ? (
         <PickerList window={vm.activeWindow} cursor={vm.repoCursor} rows={repoRows} onPick={vm.selectRepoAt} />
       ) : null}
-      <box gap={0}>
-        <text {...labelStyle(theme, vm.field, "baseRef")}>{t("newTask.field.fromBranch")}</text>
-        <input
-          value={vm.baseRef}
-          placeholder={DEFAULT_BASE_REF}
-          focused={vm.field === "baseRef"}
-          onMouseUp={() => vm.setField("baseRef")}
-          onInput={(v: string) => vm.setBaseRefText(v)}
-          // Last field on the tab — Enter resolves the highlighted branch
-          // and creates straight away.
-          onSubmit={() => vm.onBaseRefSubmit()}
-        />
-      </box>
+      {/* Only for a repo that HAS a project checkout (issue #90). Everywhere
+          else this row would be a control whose second option does nothing,
+          so it stays absent rather than disabled. */}
+      {vm.canOpenProject ? (
+        <box gap={0} paddingBottom={1}>
+          <text fg={theme.textMuted}>{t("newTask.field.opens")}</text>
+          <ChoiceRow
+            choices={intents}
+            selected={vm.intent}
+            onPick={(next) => vm.setIntent(next)}
+            display={(choice) => intentLabel[choice]}
+          />
+        </box>
+      ) : null}
+      {/* Opening the project has no branch to fork from — it enters the
+          repo's own checkout — so the field goes away with the verb. */}
+      {vm.intent === "project" && vm.canOpenProject ? null : (
+        <box gap={0}>
+          <text {...labelStyle(theme, vm.field, "baseRef")}>{t("newTask.field.fromBranch")}</text>
+          <input
+            value={vm.baseRef}
+            placeholder={DEFAULT_BASE_REF}
+            focused={vm.field === "baseRef"}
+            onMouseUp={() => vm.setField("baseRef")}
+            onInput={(v: string) => vm.setBaseRefText(v)}
+            // Last field on the tab — Enter resolves the highlighted branch
+            // and creates straight away.
+            onSubmit={() => vm.onBaseRefSubmit()}
+          />
+        </box>
+      )}
       {vm.field === "baseRef" && vm.branchFiltered.length === 0 && vm.submitError == null ? (
         <box gap={0} paddingLeft={2} paddingBottom={1}>
           <text fg={theme.textMuted} wrapMode="none">

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -225,7 +225,9 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
    * focus on an invisible input and swallow every keystroke.
    */
   function advanceField(from: Field): Field {
-    const next = nextField(from, tab)
+    const next = nextField(from, tab, { intentVisible: tab === "existing" && canOpenProject })
+    // The branch field is gone under the "project" intent, so skip its stop
+    // too — same reason, one field further along.
     if (next === "baseRef" && tab === "existing" && intent === "project" && canOpenProject) {
       return nextField(next, tab)
     }
@@ -342,10 +344,24 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       // ←/→/Enter ONLY while a selector is focused — an always-on binding
       // would preventDefault the keys away from focused text inputs (same
       // registration-gating rationale as the Solid shell).
-      ...(field === "tabs" || field === "engine"
+      ...(field === "tabs" || field === "engine" || field === "intent"
         ? [
-            { key: "left", cmd: () => (field === "tabs" ? cycleTab(-1) : cycleEngine(-1)) },
-            { key: "right", cmd: () => (field === "tabs" ? cycleTab(1) : cycleEngine(1)) },
+            {
+              key: "left",
+              cmd: () => {
+                if (field === "tabs") cycleTab(-1)
+                else if (field === "engine") cycleEngine(-1)
+                else setIntent("task")
+              },
+            },
+            {
+              key: "right",
+              cmd: () => {
+                if (field === "tabs") cycleTab(1)
+                else if (field === "engine") cycleEngine(1)
+                else setIntent("project")
+              },
+            },
             { key: "return", cmd: () => setField(advanceField) },
           ]
         : []),

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -208,8 +208,14 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     // "Open the project" is a different verb, not a create with a flag: it
     // resolves to the repo's EXISTING main row, so it carries no baseRef —
     // there is no branch to fork from when you are opening the checkout
-    // itself. Guarded on `canOpenProject` so an intent left over from a
-    // repo swap can never submit a mode this repo has nothing to satisfy.
+    // itself.
+    //
+    // `canOpenProject` is re-read here rather than trusted from when the
+    // choice was made: it derives from the CURRENT repo, so this cannot
+    // submit `open` for a path that has no main row to resolve. `changeRepo`
+    // already resets the intent on every repo change, which makes the two
+    // agree in practice — this is the half that does not depend on every
+    // future caller remembering to go through it.
     if (intent === "project" && canOpenProject) {
       props.onSubmit({ mode: "open", repo: r, vendor })
       dialog.clear()

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -165,14 +165,28 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
 
   /* ── Input handlers (strip newlines + reset the affected cursor) ── */
 
+  /**
+   * The repo changed — by ANY route (typing, Enter on the picker, a click).
+   *
+   * Owns the intent reset: a different repo may have no project checkout at
+   * all, and the choice is per-repo, so carrying "project" across a change
+   * leaves the row asserting something about the previous path. `submit` is
+   * separately guarded on `canOpenProject` (derived from the CURRENT repo),
+   * so this is about the row telling the truth, not about safety.
+   *
+   * Three call sites used to write `setRepo` directly and skip it — typing
+   * reset the intent, picking the same repo from the dropdown did not.
+   */
+  function changeRepo(next: string): void {
+    setRepo(next)
+    setIntent("task")
+  }
+
   function setRepoText(v: string): void {
     setRepoPicked(false)
-    setRepo(stripNewlines(v))
+    changeRepo(stripNewlines(v))
     setRepoCursor(0)
     setBranchCursor(0)
-    // A different repo may have no project at all, and a stale "project"
-    // intent would then submit a mode the flow has nothing to open.
-    setIntent("task")
   }
   function setBaseRefText(v: string): void {
     setBaseRefTouched(true)
@@ -262,7 +276,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     if (!repo.trim() && mode === "saved") {
       const picked = activeList[0]
       if (picked) {
-        setRepo(picked)
+        changeRepo(picked)
         setField(advanceField("repo"))
         return
       }
@@ -271,7 +285,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       const picked = subdirFiltered[repoCursor]
       if (picked) {
         // Enter = SELECT this dir as the repo and advance (no drill).
-        setRepo(joinPicked(repo, subdirSplit.base, picked))
+        changeRepo(joinPicked(repo, subdirSplit.base, picked))
         setRepoCursor(0)
         setRepoPicked(true)
       }
@@ -279,7 +293,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       return
     }
     const picked = activeList[repoCursor]
-    if (picked) setRepo(picked)
+    if (picked) changeRepo(picked)
     setField(advanceField("repo"))
   }
 
@@ -287,10 +301,10 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     const picked = activeList[absoluteIndex]
     if (!picked) return
     if (mode === "browse") {
-      setRepo(joinPicked(repo, subdirSplit.base, picked))
+      changeRepo(joinPicked(repo, subdirSplit.base, picked))
       setRepoPicked(true)
     } else {
-      setRepo(picked)
+      changeRepo(picked)
     }
     setRepoCursor(absoluteIndex)
     setField(advanceField("repo"))

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -23,6 +23,7 @@ import { useTerminalDimensions } from "@opentui/react"
 import { useEffect, useMemo, useState } from "react"
 import {
   type DialogTab,
+  type ExistingIntent,
   type Field,
   type NewTaskInput,
   type PickerWindow,
@@ -33,6 +34,7 @@ import {
   firstFieldFor,
   nextDialogTab,
   nextField,
+  offersProjectIntent,
   pickerModeFor,
   pickerVisibleRows,
   prevDialogTab,
@@ -64,7 +66,13 @@ export type NewTaskDialogProps = {
   availableVendors?: readonly VendorId[]
   /** Adopt-tab discovery. Omit to leave the tab empty. */
   discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
+  /** Repos that already have a project checkout — gates the intent choice. */
+  mainRepos?: ReadonlySet<string>
 }
+
+/** Shared default for `mainRepos` — a fresh `new Set()` per render would be a
+ *  new identity every time and defeat any memo keyed on it. */
+const EMPTY_MAIN_REPOS: ReadonlySet<string> = new Set()
 
 export function useNewTaskViewModel(props: NewTaskDialogProps) {
   const dialog = useDialog()
@@ -92,6 +100,10 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   // Enter/click; typing resumes browsing.
   const [repoPicked, setRepoPicked] = useState(false)
   const [branchCursor, setBranchCursor] = useState(0)
+  // Existing-tab intent (issue #90). Defaults to "task" so the tab keeps
+  // doing what it always did; the choice only RENDERS when the picked repo
+  // already has a project checkout to open.
+  const [intent, setIntent] = useState<ExistingIntent>("task")
 
   // Validation error shown inline on submit; cleared on any input edit.
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -112,6 +124,9 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   const activeWindow: PickerWindow = windowAround(activeList, repoCursor, pickerRows)
 
   const expandedRepo = expandHome(repo.trim())
+  // Offered against the EXPANDED path: `mainRepos` holds absolute repo roots,
+  // and a `~/`-typed entry would otherwise never match its own project.
+  const canOpenProject = offersProjectIntent(expandedRepo, props.mainRepos ?? EMPTY_MAIN_REPOS)
   const branches = useMemo(() => listLocalBranches(expandedRepo), [expandedRepo])
   const branchFiltered = useMemo(() => filterBranches(branches, baseRef), [branches, baseRef])
   const branchWindow: PickerWindow = windowAround(branchFiltered, branchCursor, pickerRows)
@@ -155,6 +170,9 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     setRepo(stripNewlines(v))
     setRepoCursor(0)
     setBranchCursor(0)
+    // A different repo may have no project at all, and a stale "project"
+    // intent would then submit a mode the flow has nothing to open.
+    setIntent("task")
   }
   function setBaseRefText(v: string): void {
     setBaseRefTouched(true)
@@ -173,6 +191,16 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       setField("repo")
       return
     }
+    // "Open the project" is a different verb, not a create with a flag: it
+    // resolves to the repo's EXISTING main row, so it carries no baseRef —
+    // there is no branch to fork from when you are opening the checkout
+    // itself. Guarded on `canOpenProject` so an intent left over from a
+    // repo swap can never submit a mode this repo has nothing to satisfy.
+    if (intent === "project" && canOpenProject) {
+      props.onSubmit({ mode: "open", repo: r, vendor })
+      dialog.clear()
+      return
+    }
     const b = baseRef.trim() || DEFAULT_BASE_REF
     props.onSubmit({ repo: r, baseRef: b, vendor })
     dialog.clear()
@@ -188,6 +216,20 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       return
     }
     commitExisting()
+  }
+
+  /**
+   * Tab/Enter's next stop, honouring the intent. Opening a project hides the
+   * branch field (`tab-existing.tsx`), and the pure `nextField` chain knows
+   * nothing about that — walking into a field that isn't rendered would park
+   * focus on an invisible input and swallow every keystroke.
+   */
+  function advanceField(from: Field): Field {
+    const next = nextField(from, tab)
+    if (next === "baseRef" && tab === "existing" && intent === "project" && canOpenProject) {
+      return nextField(next, tab)
+    }
+    return next
   }
 
   /* ── Navigation / selection handlers ── */
@@ -219,7 +261,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       const picked = activeList[0]
       if (picked) {
         setRepo(picked)
-        setField("baseRef")
+        setField(advanceField("repo"))
         return
       }
     }
@@ -231,12 +273,12 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
         setRepoCursor(0)
         setRepoPicked(true)
       }
-      setField("baseRef")
+      setField(advanceField("repo"))
       return
     }
     const picked = activeList[repoCursor]
     if (picked) setRepo(picked)
-    setField("baseRef")
+    setField(advanceField("repo"))
   }
 
   function selectRepoAt(absoluteIndex: number): void {
@@ -249,7 +291,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       setRepo(picked)
     }
     setRepoCursor(absoluteIndex)
-    setField("baseRef")
+    setField(advanceField("repo"))
   }
 
   function pickBranchAt(absoluteIndex: number): void {
@@ -291,7 +333,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
 
   useBindings(() => ({
     bindings: [
-      { key: "tab", cmd: () => setField((f) => nextField(f, tab)) },
+      { key: "tab", cmd: () => setField(advanceField) },
       { key: "ctrl+]", cmd: () => switchToTab(nextDialogTab(tab)) },
       { key: "ctrl+[", cmd: () => switchToTab(prevDialogTab(tab)) },
       { key: "ctrl+e", cmd: () => cycleEngine(1) },
@@ -304,7 +346,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
         ? [
             { key: "left", cmd: () => (field === "tabs" ? cycleTab(-1) : cycleEngine(-1)) },
             { key: "right", cmd: () => (field === "tabs" ? cycleTab(1) : cycleEngine(1)) },
-            { key: "return", cmd: () => setField((f) => nextField(f, tab)) },
+            { key: "return", cmd: () => setField(advanceField) },
           ]
         : []),
       // Ctrl+A select-all exists ONLY on the Adopt tab; elsewhere it must
@@ -342,6 +384,9 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     branchFiltered,
     branchWindow,
     branchCursor,
+    intent,
+    setIntent,
+    canOpenProject,
     submitError,
     setRepoText,
     setBaseRefText,

--- a/packages/kobe/src/tui-react/workspace/empty-workspace-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/empty-workspace-pane.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The placeholder for a task whose last tab was closed — and the keys that
+ * get out of it.
+ *
+ * `show-workspace` deliberately does NOT mount `TerminalTabs` over an empty
+ * tab list, which means every "open a session here" chord is unreachable in
+ * this state: they are all registered inside that component. Entering the
+ * task from the sidebar revives it (`reviveEmptiedTabs`), but this pane is
+ * also reached WITHOUT an activation — restart restore, or a task emptied
+ * while already on screen — and there the placeholder used to name two keys
+ * that had no handler at all.
+ *
+ * So the placeholder owns them itself. Both chords do the same thing (revive
+ * this task's session), because from here there is only one thing to do:
+ *   - `workspace.reopenSession` (⏎) — owner sign-off 2026-08-31.
+ *   - `chat.tab.chooseEngine` (ctrl+e) — the SAME id `TerminalTabs` binds.
+ *     Registering it here is not a second chord, it is the one chord staying
+ *     answerable in the state where its usual owner is unmounted.
+ */
+
+import type { ReactNode } from "react"
+import { bindByIds } from "../../tui/context/keybindings"
+import { defaultShell } from "../../tui/panes/terminal/pty-types"
+import { useOptionalKV } from "../context/kv"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { reviveEmptiedTabs } from "./terminal-tabs-shared"
+
+export function EmptyWorkspacePane(props: { taskId: string; focused: boolean }): ReactNode {
+  const { theme } = useTheme()
+  const t = useT()
+  const kv = useOptionalKV()
+
+  // `reviveEmptiedTabs` writes through `setTaskTabs`, so the revision counter
+  // `show-workspace` subscribes to bumps and this pane is replaced by the
+  // mounted TerminalTabs on the next render — no callback up to the host.
+  const reopen = (): void => {
+    reviveEmptiedTabs(kv, props.taskId, defaultShell())
+  }
+
+  useBindings(() => ({
+    enabled: props.focused,
+    bindings: bindByIds({
+      "workspace.reopenSession": reopen,
+      "chat.tab.chooseEngine": reopen,
+    }),
+  }))
+
+  return (
+    <box flexGrow={1} alignItems="center" justifyContent="center">
+      <text fg={theme.textMuted}>{t("workspace.empty.noSessions")}</text>
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -16,6 +16,7 @@ import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useAccessor } from "../lib/use-accessor"
 import { TerminalTabs } from "./TerminalTabs"
+import { EmptyWorkspacePane } from "./empty-workspace-pane"
 import { knownTaskTabs, tabsRevision } from "./terminal-tabs-shared"
 import { WelcomePane } from "./welcome-pane"
 
@@ -78,14 +79,12 @@ export function ShowWorkspace(props: {
   // `activateTask`), so the normal path replaces this placeholder within the
   // same gesture. It still renders, because this component is also reached
   // without an activation — a task selected by restart restore, or one emptied
-  // while already on screen — and a blank pane would say nothing at all.
+  // while already on screen — and a blank pane would say nothing at all. The
+  // keys it advertises are bound by the pane itself: with no TerminalTabs
+  // mounted there is nothing else in this subtree to register them.
   const known = props.task ? knownTaskTabs(kv, String(props.task.id)) : null
-  if (known && known.tabs.length === 0) {
-    return (
-      <box flexGrow={1} alignItems="center" justifyContent="center">
-        <text fg={theme.textMuted}>{t("workspace.empty.noSessions")}</text>
-      </box>
-    )
+  if (known && known.tabs.length === 0 && props.task) {
+    return <EmptyWorkspacePane taskId={String(props.task.id)} focused={props.focused} />
   }
   return (
     // The terminal-in-the-middle seam (issue #16): the center column IS

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -38,11 +38,16 @@ import { DEFAULT_BASE_REF } from "../../lib/git-snapshot"
  * next time.
  */
 /**
- * Dialog result. Two shapes, discriminated by `mode`:
+ * Dialog result. Three shapes, discriminated by `mode`:
  *   - create (default) — make a fresh task on `repo` at `baseRef`.
  *   - adopt — import one or more EXISTING git worktrees as tasks
  *. `adopt` carries the chosen worktrees; the caller loops
  *     `orchestrator.adoptWorktree` over them.
+ *   - open — open `repo`'s OWN checkout (its `main` row) rather than
+ *     branching a worktree off it. The only way back to a project the
+ *     sidebar has hidden (`isClosedDownProject`): every other path through
+ *     this dialog mints a `kind: "task"`, so picking the repo used to leave
+ *     the user with an extra worktree and still no project row.
  */
 export type NewTaskInput =
   | {
@@ -58,6 +63,11 @@ export type NewTaskInput =
       repo: string
       vendor: VendorId
       adopt: readonly { worktreePath: string; branch: string }[]
+    }
+  | {
+      mode: "open"
+      repo: string
+      vendor: VendorId
     }
 
 /**
@@ -84,6 +94,13 @@ export type NewTaskDialogOptions = {
   availableVendors?: readonly VendorId[]
   /** Adopt-tab discovery of unlinked worktrees on `repo`; omit to disable adoption. */
   discoverAdoptable?: (repo: string) => Promise<readonly AdoptableWorktree[]>
+  /**
+   * Repos that already have a project checkout (a `main` task), trimmed of
+   * trailing slashes. The Existing tab offers "open the project" only for
+   * these — see {@link offersProjectIntent}. Omitted/empty simply means the
+   * choice never appears and the tab behaves as it always did.
+   */
+  mainRepos?: ReadonlySet<string>
 }
 
 export type DialogTab = "existing" | "clone" | "adopt"
@@ -391,4 +408,41 @@ export function resolveBaseRef(typed: string, filteredBranches: readonly string[
   const picked = filteredBranches[cursor]
   if (picked) return picked
   return t || DEFAULT_BASE_REF
+}
+
+/* --------------------------------------------------------------------- */
+/*  Existing-tab intent (issue #90)                                       */
+/* --------------------------------------------------------------------- */
+
+/**
+ * What submitting the Existing tab should DO with the chosen repo:
+ *   - "task"    — branch a fresh worktree task off it (what this tab
+ *                 has always done, and still the default).
+ *   - "project" — open the repo's OWN checkout, its `main` row.
+ *
+ * The second exists because it was the missing half. Closing a project's
+ * last tab hides it from the sidebar (`isClosedDownProject`), and the
+ * comment there promised the repo was "still there in the new-task picker
+ * to open again" — but every submit path went through `createTask`, which
+ * always mints a `kind: "task"`. Picking the hidden repo therefore added a
+ * worktree beside the project instead of returning to it.
+ */
+export type ExistingIntent = "task" | "project"
+
+/**
+ * Whether the Existing tab should offer the intent choice for `repo`.
+ *
+ * Only when that repo ALREADY has a project checkout: opening the main row
+ * of a repo that has none is not a thing this dialog can do — `createTask`
+ * is what mints one, via `ensureIfEligible`, and only for a repo the
+ * admission gate accepts (state/project-eligibility.ts). Offering the
+ * choice everywhere would put a second control on the tab that silently
+ * means nothing most of the time.
+ *
+ * `mainRepos` is the set of repo paths that have a `main` task, normalized
+ * by the caller with the same key the sidebar groups on.
+ */
+export function offersProjectIntent(repo: string, mainRepos: ReadonlySet<string>): boolean {
+  const trimmed = repo.trim().replace(/[\\/]+$/, "")
+  return trimmed.length > 0 && mainRepos.has(trimmed)
 }

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -137,6 +137,9 @@ export type Field =
   | "tabs"
   | "engine"
   | "repo"
+  /** The Existing tab's task-vs-project selector (issue #90). Reachable only
+   *  while it renders — see `nextField`. */
+  | "intent"
   | "baseRef"
   | "cloneUrl"
   | "cloneParent"
@@ -262,7 +265,7 @@ export function isBlankText(v: string): boolean {
  * the user. A stale cross-tab input field restarts the active tab's
  * cycle at its first input.
  */
-export function nextField(field: Field, tab: DialogTab = "existing"): Field {
+export function nextField(field: Field, tab: DialogTab = "existing", opts: { intentVisible?: boolean } = {}): Field {
   // Shared trailer — the selectors + Create button common to every tab.
   if (field === "confirm") return "tabs"
   if (field === "tabs") return "engine"
@@ -279,7 +282,12 @@ export function nextField(field: Field, tab: DialogTab = "existing"): Field {
     // List navigation is up/down on the rows, not Tab.
     return field === "adoptFilter" ? "confirm" : "adoptFilter"
   }
-  if (field === "repo") return "baseRef"
+  // `intent` renders only for a repo that has a project checkout, and under
+  // the "project" choice it REPLACES the branch field. Both are conditional,
+  // so the walk is told what is on screen rather than guessing: parking focus
+  // on an unrendered stop swallows every keystroke that follows.
+  if (field === "repo") return opts.intentVisible ? "intent" : "baseRef"
+  if (field === "intent") return "baseRef"
   if (field === "baseRef") return "confirm"
   return "repo"
 }

--- a/packages/kobe/src/tui/context/keybindings-chat.ts
+++ b/packages/kobe/src/tui/context/keybindings-chat.ts
@@ -126,6 +126,24 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     presentation: "onePress",
   },
   {
+    // The other half of ctrl+w on a task's LAST tab: that close leaves the
+    // task with no tabs, and the pane it leaves behind (`EmptyWorkspacePane`)
+    // has no TerminalTabs mounted — so every workspace chord is unreachable
+    // there and the placeholder's own copy named keys that did nothing.
+    //
+    // Plain `return` is safe in this scope precisely because that pane holds
+    // no input and no tab: there is nothing else for Enter to mean while it
+    // is on screen, and the binding is gated on it being on screen. Owner
+    // sign-off 2026-08-31, see docs/design/keybinding-decisions.md.
+    id: "workspace.reopenSession",
+    scope: "workspace",
+    keys: ["return"],
+    category: "Workspace",
+    description: "Reopen a session in a task whose tabs are all closed",
+    hint: { keys: "enter" },
+    presentation: "onePress",
+  },
+  {
     // Rename the active chat tab. F2 is the cross-OS / cross-IDE
     // rename convention (file managers on Windows + Linux, IntelliJ,
     // VS Code etc.) — chosen here because `ctrl+r` is owned by the

--- a/packages/kobe/src/tui/i18n/messages/newTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/newTask.ts
@@ -21,6 +21,14 @@ export const en = {
     folderName: "folder name",
     baseBranch: "base branch",
     adoptFilter: "filter (path glob)",
+    /** Existing tab: task vs project (issue #90) — only for a repo with a main row. */
+    opens: "opens",
+  },
+
+  /** Existing-tab intent labels (issue #90). */
+  intent: {
+    task: "a new task worktree",
+    project: "the project itself",
   },
 
   placeholder: {
@@ -40,6 +48,11 @@ export const en = {
   picker: {
     moreAbove: "↑ {count} more",
     moreBelow: "↓ {count} more",
+  },
+
+  /** "Open the project" failures (issue #90). {error} is the daemon's message. */
+  open: {
+    failed: "Couldn't open the project: {error}",
   },
 
   adopt: {
@@ -97,6 +110,14 @@ export const zh: typeof en = {
     folderName: "文件夹名",
     baseBranch: "基准分支",
     adoptFilter: "过滤（路径 glob）",
+    /** Existing tab: task vs project (issue #90) — only for a repo with a main row. */
+    opens: "打开",
+  },
+
+  /** Existing-tab intent labels (issue #90). */
+  intent: {
+    task: "新建任务 worktree",
+    project: "项目本身",
   },
 
   placeholder: {
@@ -116,6 +137,11 @@ export const zh: typeof en = {
   picker: {
     moreAbove: "↑ 还有 {count} 项",
     moreBelow: "↓ 还有 {count} 项",
+  },
+
+  /** "Open the project" failures (issue #90). {error} is the daemon's message. */
+  open: {
+    failed: "无法打开项目：{error}",
   },
 
   adopt: {

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -12,7 +12,8 @@ export const en = {
   },
   empty: {
     selectTask: "Select a task with a worktree",
-    /** Every tab of this task was closed — the task and its worktree remain. */
+    /** Every tab of this task was closed — the task and its worktree remain.
+     *  Both chords are bound by `EmptyWorkspacePane`, which renders this. */
     noSessions: "No sessions here — press ⏎ or ctrl+e to start one",
   },
   /** Zero-tasks welcome panel (first launch) */

--- a/packages/kobe/src/tui/lib/task-create-flow.ts
+++ b/packages/kobe/src/tui/lib/task-create-flow.ts
@@ -11,7 +11,7 @@ import { availableEngineIds } from "@/engine/account-detect"
 import { errorMessage } from "@/lib/error-message"
 import { addSavedRepo, getSavedRepos } from "@/state/repos"
 import { t } from "@/tui/i18n"
-import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
+import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "@/types/task"
 import type { NewTaskDialogOptions, NewTaskInput } from "../component/new-task-dialog/state"
 import type { TaskActionContext } from "./task-actions"
 
@@ -55,6 +55,20 @@ export interface CreateTaskContext extends TaskActionContext {
 }
 
 /**
+ * Repo roots that have a `main` task, keyed the way the sidebar groups them
+ * (trailing slashes trimmed) so a path typed with one still matches.
+ */
+function mainRepoSet(tasks: readonly Task[]): ReadonlySet<string> {
+  const out = new Set<string>()
+  for (const task of tasks) {
+    if (task.kind !== "main") continue
+    const key = task.repo.trim().replace(/[\\/]+$/, "")
+    if (key) out.add(key)
+  }
+  return out
+}
+
+/**
  * Create (or adopt) a task through the shared NewTaskDialog flow: default
  * repo → dialog →
  * persist vendor + repo choices → `task.create` / `adoptWorktree` → land
@@ -83,6 +97,11 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     defaultVendor,
     availableVendors,
     discoverAdoptable: orch ? (repo) => orch.discoverAdoptableWorktrees(repo) : undefined,
+    // Which repos already own a project checkout — the Existing tab offers
+    // "open the project" only for these (issue #90). Read from the LIVE task
+    // list rather than savedRepos: a saved repo with no main row has no
+    // project to open, and the difference is exactly what the choice turns on.
+    mainRepos: mainRepoSet(ctx.tasks()),
   })
   if (!result) return
   // Auto-save the chosen repo so the saved list self-populates and
@@ -97,6 +116,25 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     // as a success that produced no task.
     ctx.logger.error(`${ctx.logPrefix} no daemon; cannot create task`)
     ctx.notifyError?.(t("tasks.toast.noDaemonWorktree"))
+    return
+  }
+  // "Open the project" (issue #90) — the repo's OWN checkout, not a worktree
+  // branched off it. `ensureMainTask` is idempotent, so this both REVIVES a
+  // project the sidebar hid (its main row and savedRepos entry never went
+  // away — only the row did) and creates the row for a saved repo that has
+  // none yet. Deliberately ahead of the "Creating task…" toast: nothing is
+  // being created, and claiming otherwise for what is really a navigation
+  // would misreport the one path whose whole point is that it adds nothing.
+  if (result.mode === "open") {
+    try {
+      const main = await orch.ensureMainTask(repo)
+      await ctx.reload?.()
+      ctx.selectTask?.(main.id)
+      await ctx.enterTask?.(main.id)
+    } catch (err) {
+      ctx.logger.error(`${ctx.logPrefix} ensureMainTask failed:`, err)
+      ctx.notifyError?.(t("newTask.open.failed", { error: errorMessage(err) }))
+    }
     return
   }
   // The create/adopt awaits a real git-worktree operation with no other

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -174,11 +174,20 @@ export interface TreeInput {
  * checkout, and that checkout's last tab has been closed.
  *
  * Such a project is hidden from the tree (owner call 2026-08-31). Nothing is
- * deleted — the main task and the `savedRepos` entry both stay, so the repo
- * is still there in the new-task picker to open again. This is the whole
- * difference from Forget (`d` on the row → `forgetProject`), which un-saves
- * the repo: closing the last tab is a "I'm done here for now" gesture, not a
- * "remove this from my machine" one.
+ * deleted — the main task and the `savedRepos` entry both stay.
+ *
+ * The way BACK is the new-task dialog's Existing tab: pick the repo and
+ * choose "the project itself" instead of a new task worktree, which submits
+ * `mode: "open"` and routes to `ensureMainTask` (issue #90). That choice
+ * renders only for a repo that already has a main row — which is exactly the
+ * set of repos this rule can hide. Until it existed the promise made here was
+ * false: every submit path went through `createTask`, which always mints a
+ * `kind: "task"`, so picking a hidden repo added a worktree beside the
+ * project and still left no project row.
+ *
+ * This is the whole difference from Forget (`d` on the row →
+ * `forgetProject`), which un-saves the repo: closing the last tab is a "I'm
+ * done here for now" gesture, not a "remove this from my machine" one.
  *
  * Deliberately narrow. It requires:
  *   - exactly one task in the project, and that task is the `main` row, and

--- a/packages/kobe/test/render/empty-workspace-pane.test.tsx
+++ b/packages/kobe/test/render/empty-workspace-pane.test.tsx
@@ -1,0 +1,86 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The keys the no-sessions placeholder advertises (issue #90).
+ *
+ * The copy has always read "press ⏎ or ctrl+e to start one", and neither key
+ * did anything: both are registered inside `TerminalTabs`, which this state
+ * deliberately does NOT mount (its `active` tab is non-null by construction,
+ * so mounting over an empty list would mint a replacement and the close would
+ * never appear to take). The placeholder named an affordance nothing backed.
+ *
+ * So the pane binds them itself, and these pin that: a press REVIVES the
+ * task's tabs. Asserting on `tabsByTask` rather than the frame is deliberate —
+ * the revive is a write to that module map, and the frame after it would show
+ * TerminalTabs, which opens a daemon socket.
+ */
+
+import { describe, expect, it } from "bun:test"
+import { EmptyWorkspacePane } from "../../src/tui-react/workspace/empty-workspace-pane"
+import { tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import { act, renderComponent, settle } from "./harness"
+
+/** A task whose last tab was closed: KNOWN, empty, with the reopen hint the close recorded. */
+function seedEmptied(reopenAs?: { kind: "engine"; vendor?: string } | { kind: "command" }): void {
+  tabsByTask.clear()
+  tabsByTask.set("t1", {
+    tabs: [],
+    activeId: "tab-1",
+    nextOrdinal: 2,
+    ...(reopenAs ? { reopenAs } : {}),
+  } as never)
+}
+
+const render = (focused = true) => renderComponent(<EmptyWorkspacePane taskId="t1" focused={focused} />)
+
+describe("the no-sessions placeholder's keys", () => {
+  it("says which keys to press", async () => {
+    seedEmptied()
+    const { frame } = await render()
+    expect(await frame()).toContain("No sessions here")
+  })
+
+  it("enter reopens a session", async () => {
+    seedEmptied()
+    const { mockInput } = await render()
+    await act(async () => {
+      mockInput.pressEnter()
+    })
+    await settle()
+    expect(tabsByTask.get("t1")?.tabs.length).toBe(1)
+  })
+
+  it("ctrl+e reopens a session too", async () => {
+    seedEmptied()
+    const { mockInput } = await render()
+    await act(async () => {
+      mockInput.pressKey("e", { ctrl: true })
+    })
+    await settle()
+    expect(tabsByTask.get("t1")?.tabs.length).toBe(1)
+  })
+
+  it("reopens the KIND that was closed, not always an engine", async () => {
+    // The close records what went (`reopenAs`); pressing the key here must
+    // route through that, or closing a shell and pressing enter drops the
+    // user into an engine they never asked for.
+    seedEmptied({ kind: "command" })
+    const { mockInput } = await render()
+    await act(async () => {
+      mockInput.pressEnter()
+    })
+    await settle()
+    expect(tabsByTask.get("t1")?.tabs[0]?.kind).toBe("command")
+  })
+
+  it("ignores the keys while the pane is not focused", async () => {
+    // The workspace is one of several panes. An unfocused pane answering
+    // enter would steal it from whatever the user is actually typing into.
+    seedEmptied()
+    const { mockInput } = await render(false)
+    await act(async () => {
+      mockInput.pressEnter()
+    })
+    await settle()
+    expect(tabsByTask.get("t1")?.tabs.length).toBe(0)
+  })
+})

--- a/packages/kobe/test/render/new-task-open-project.test.tsx
+++ b/packages/kobe/test/render/new-task-open-project.test.tsx
@@ -1,0 +1,138 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The Existing tab's "open the project" choice (issue #90), through the real
+ * dialog entry point.
+ *
+ * The flow-level tests (`test/tui/create-task-flow-open-project.test.ts`) pin
+ * what `mode: "open"` DOES once submitted. What they cannot see is whether the
+ * dialog ever produces it: `NewTaskDialog.show` is what wires `mainRepos` from
+ * the caller's options down to the view-model, and a dropped prop there would
+ * leave every one of those tests green while the choice never appeared on
+ * screen. So these drive the mounted dialog and read the frame.
+ *
+ * The repos are real `git init` temp dirs because the tab reads branches and
+ * validates the path synchronously — a fake path renders the error state
+ * instead of the fields.
+ */
+
+import { expect, test } from "bun:test"
+import { execSync } from "node:child_process"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { useEffect, useRef } from "react"
+import { NewTaskDialog } from "../../src/tui-react/component/new-task-dialog"
+import { useDialog } from "../../src/tui-react/ui/dialog"
+import type { NewTaskInput } from "../../src/tui/component/new-task-dialog/state"
+import { act, renderComponent, settle } from "./harness"
+
+function repo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-openproj-"))
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: dir })
+  return dir
+}
+
+/**
+ * Mount the dialog the way a host does — through `NewTaskDialog.show` on a
+ * live dialog stack, which is the wiring under test.
+ */
+function Harness(props: { repo: string; mainRepos?: ReadonlySet<string>; onSubmit: (v: NewTaskInput) => void }) {
+  const dialog = useDialog()
+  const opened = useRef(false)
+  useEffect(() => {
+    if (opened.current) return
+    opened.current = true
+    void NewTaskDialog.show(dialog, props.repo, [props.repo], { mainRepos: props.mainRepos }).then((result) => {
+      if (result) props.onSubmit(result)
+    })
+  }, [dialog, props.repo, props.mainRepos, props.onSubmit])
+  // DialogProvider renders the stack itself; this component only opens it.
+  return <box />
+}
+
+async function mount(dir: string, mainRepos?: ReadonlySet<string>) {
+  const submitted: NewTaskInput[] = []
+  const handle = await renderComponent(
+    <Harness repo={dir} mainRepos={mainRepos} onSubmit={(v) => submitted.push(v)} />,
+    {
+      width: 100,
+      height: 40,
+      providers: { kv: true, dialog: true },
+    },
+  )
+  await settle()
+  return { ...handle, submitted }
+}
+
+test("a repo with a project checkout offers the choice", async () => {
+  const dir = repo()
+  const { frame } = await mount(dir, new Set([dir]))
+  expect(await frame()).toContain("the project itself")
+})
+
+test("a repo with no project checkout does not", async () => {
+  // The second option would resolve to nothing here, so the row is absent
+  // rather than present-and-inert.
+  const dir = repo()
+  const { frame } = await mount(dir, new Set())
+  expect(await frame()).not.toContain("the project itself")
+})
+
+test("omitting mainRepos entirely leaves the tab as it was", async () => {
+  // Every caller that has not been taught about the option keeps the old tab.
+  const dir = repo()
+  const { frame } = await mount(dir)
+  const text = await frame()
+  expect(text).not.toContain("the project itself")
+  expect(text).toContain("from branch")
+})
+
+/** Tab from the opening focus (`tabs`) to the intent row: engine, repo, intent. */
+async function tabToIntent(mockInput: { pressTab: () => void }): Promise<void> {
+  for (let i = 0; i < 3; i++) {
+    await act(async () => {
+      mockInput.pressTab()
+    })
+    await settle()
+  }
+}
+
+test("the intent row is reachable by keyboard, and choosing the project drops the branch field", async () => {
+  // Opening a checkout forks from nothing, so a base branch would be a field
+  // whose value is discarded — worse than absent.
+  //
+  // Driven through Tab + arrow rather than a click: the row was mouse-only at
+  // first (no `Field` stop, so Tab walked straight past it and `right` cycled
+  // the DIALOG tab instead), and a click-driven test passed against that.
+  const dir = repo()
+  const { frame, mockInput } = await mount(dir, new Set([dir]))
+  expect(await frame()).toContain("from branch")
+
+  await tabToIntent(mockInput)
+  await act(async () => {
+    mockInput.pressArrow("right")
+  })
+  await settle()
+
+  const text = await frame()
+  expect(text).not.toContain("from branch")
+  // Still on the Existing tab — `right` must not have cycled the tab strip.
+  expect(text).toContain("the project itself")
+})
+
+test("left returns to the task intent and the branch field comes back", async () => {
+  const dir = repo()
+  const { frame, mockInput } = await mount(dir, new Set([dir]))
+  await tabToIntent(mockInput)
+  await act(async () => {
+    mockInput.pressArrow("right")
+  })
+  await settle()
+  expect(await frame()).not.toContain("from branch")
+
+  await act(async () => {
+    mockInput.pressArrow("left")
+  })
+  await settle()
+  expect(await frame()).toContain("from branch")
+})

--- a/packages/kobe/test/render/new-task-open-project.test.tsx
+++ b/packages/kobe/test/render/new-task-open-project.test.tsx
@@ -36,24 +36,31 @@ function repo(): string {
  * Mount the dialog the way a host does — through `NewTaskDialog.show` on a
  * live dialog stack, which is the wiring under test.
  */
-function Harness(props: { repo: string; mainRepos?: ReadonlySet<string>; onSubmit: (v: NewTaskInput) => void }) {
+function Harness(props: {
+  repo: string
+  saved?: readonly string[]
+  mainRepos?: ReadonlySet<string>
+  onSubmit: (v: NewTaskInput) => void
+}) {
   const dialog = useDialog()
   const opened = useRef(false)
   useEffect(() => {
     if (opened.current) return
     opened.current = true
-    void NewTaskDialog.show(dialog, props.repo, [props.repo], { mainRepos: props.mainRepos }).then((result) => {
-      if (result) props.onSubmit(result)
-    })
-  }, [dialog, props.repo, props.mainRepos, props.onSubmit])
+    void NewTaskDialog.show(dialog, props.repo, props.saved ?? [props.repo], { mainRepos: props.mainRepos }).then(
+      (result) => {
+        if (result) props.onSubmit(result)
+      },
+    )
+  }, [dialog, props.repo, props.saved, props.mainRepos, props.onSubmit])
   // DialogProvider renders the stack itself; this component only opens it.
   return <box />
 }
 
-async function mount(dir: string, mainRepos?: ReadonlySet<string>) {
+async function mount(dir: string, mainRepos?: ReadonlySet<string>, saved?: readonly string[]) {
   const submitted: NewTaskInput[] = []
   const handle = await renderComponent(
-    <Harness repo={dir} mainRepos={mainRepos} onSubmit={(v) => submitted.push(v)} />,
+    <Harness repo={dir} saved={saved} mainRepos={mainRepos} onSubmit={(v) => submitted.push(v)} />,
     {
       width: 100,
       height: 40,
@@ -139,6 +146,45 @@ test("tab from the project intent lands on Create, not the hidden branch field",
   await settle()
   // The focused Create button is the only field marker still on screen.
   expect(await frame()).toContain("▸ [ Create ]")
+})
+
+test("picking a different repo resets the intent back to a task worktree", async () => {
+  // The choice is per-repo, so it must not survive a repo change. Driven
+  // through the PICKER (Enter on the dropdown), which is the route that used
+  // to skip the reset: three call sites wrote `setRepo` directly, so typing
+  // reset the intent and picking did not. Everything goes through
+  // `changeRepo` now.
+  const a = repo()
+  const b = repo()
+  const { frame, mockInput } = await mount(a, new Set([a, b]), [a, b])
+
+  await tabToIntent(mockInput)
+  await act(async () => {
+    mockInput.pressArrow("right")
+  })
+  await settle()
+  expect(await frame()).toContain("▸ the project itself")
+
+  // Back to the repo field (intent → confirm → tabs → engine → repo), then
+  // pick the other saved repo out of the dropdown.
+  for (let i = 0; i < 4; i++) {
+    await act(async () => {
+      mockInput.pressTab()
+    })
+    await settle()
+  }
+  await act(async () => {
+    mockInput.pressArrow("down")
+  })
+  await settle()
+  await act(async () => {
+    mockInput.pressEnter()
+  })
+  await settle()
+
+  const text = await frame()
+  expect(text).toContain("▸ a new task worktree")
+  expect(text).not.toContain("▸ the project itself")
 })
 
 test("left returns to the task intent and the branch field comes back", async () => {

--- a/packages/kobe/test/render/new-task-open-project.test.tsx
+++ b/packages/kobe/test/render/new-task-open-project.test.tsx
@@ -120,6 +120,27 @@ test("the intent row is reachable by keyboard, and choosing the project drops th
   expect(text).toContain("the project itself")
 })
 
+test("tab from the project intent lands on Create, not the hidden branch field", async () => {
+  // The branch field is gone under this intent, so the walk has to skip its
+  // stop too. Without the skip, focus parks on an input that is not on screen
+  // and every following keystroke is typed into nothing — the same class of
+  // dead end as the intent row having no stop at all, one field further on.
+  const dir = repo()
+  const { frame, mockInput } = await mount(dir, new Set([dir]))
+  await tabToIntent(mockInput)
+  await act(async () => {
+    mockInput.pressArrow("right")
+  })
+  await settle()
+
+  await act(async () => {
+    mockInput.pressTab()
+  })
+  await settle()
+  // The focused Create button is the only field marker still on screen.
+  expect(await frame()).toContain("▸ [ Create ]")
+})
+
 test("left returns to the task intent and the branch field comes back", async () => {
   const dir = repo()
   const { frame, mockInput } = await mount(dir, new Set([dir]))

--- a/packages/kobe/test/tui/create-task-flow-open-project.test.ts
+++ b/packages/kobe/test/tui/create-task-flow-open-project.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The way BACK to a project the sidebar hid (issue #90).
+ *
+ * `isClosedDownProject` drops a project whose only row is its main checkout
+ * once that checkout's last tab closes. Nothing is deleted, and the rule's
+ * comment always claimed the repo was "still there in the new-task picker to
+ * open again" — but every submit path went through `createTask`, which mints
+ * a `kind: "task"`. Picking the hidden repo therefore added a worktree beside
+ * the project and still produced no project row. The hiding rule had six
+ * tests; the way back had none, which is why the gap shipped.
+ *
+ * `mode: "open"` is that way back. These pin the half that was missing: the
+ * flow calls `ensureMainTask` (idempotent — it RESOLVES the existing main row
+ * rather than creating a second one), lands on it, and creates no task.
+ */
+
+import { describe, expect, test, vi } from "vitest"
+
+vi.mock("../../src/state/repos", () => ({
+  getSavedRepos: () => ["/repos/codefox"],
+  addSavedRepo: (path: string) => ({ added: false, path, total: 1 }),
+}))
+vi.mock("../../src/engine/account-detect", () => ({
+  availableEngineIds: async () => ["claude"],
+}))
+
+import type { KobeOrchestrator } from "../../src/client/remote-orchestrator"
+import type { NewTaskDialogOptions, NewTaskInput } from "../../src/tui/component/new-task-dialog/state"
+import { type CreateTaskContext, createTaskFlow } from "../../src/tui/lib/task-create-flow"
+import type { Task } from "../../src/types/task"
+
+/** `Task.id` is a branded string; tests name rows with plain literals. */
+const task = (over: { id: string; kind?: string; repo?: string }): Task =>
+  ({ repo: "/repos/codefox", ...over }) as unknown as Task
+
+/** The hidden project's surviving row: a main task whose tabs are all closed. */
+const HIDDEN_MAIN = task({ id: "main-codefox", kind: "main", repo: "/repos/codefox" })
+
+function makeCtx(opts: {
+  submit: NewTaskInput | undefined
+  tasks?: readonly Task[]
+  ensureMainTask?: (repo: string) => Promise<Task>
+}) {
+  const ensureMainTask = vi.fn(opts.ensureMainTask ?? (async () => HIDDEN_MAIN))
+  const createTask = vi.fn(async () => ({ id: "created" }))
+  const notifyInfo = vi.fn()
+  const notifyError = vi.fn()
+  const selectTask = vi.fn()
+  const enterTask = vi.fn(async () => {})
+  const reload = vi.fn(async () => {})
+  const logger = { error: vi.fn() }
+  /** What the dialog was handed — the assertion target for the gating half. */
+  let seenOptions: NewTaskDialogOptions | undefined
+  const ctx: CreateTaskContext = {
+    orch: { ensureMainTask, createTask, discoverAdoptableWorktrees: async () => [] } as unknown as KobeOrchestrator,
+    tasks: () => opts.tasks ?? [HIDDEN_MAIN],
+    confirm: async () => true,
+    promptText: async () => undefined,
+    logger,
+    logPrefix: "[test]",
+    notifyInfo,
+    notifyError,
+    reload,
+    selectTask,
+    enterTask,
+    cursorRepo: () => "/repos/codefox",
+    lastVendor: () => "claude" as never,
+    rememberVendor: vi.fn(),
+    promptNewTask: async (_repo, _repos, options) => {
+      seenOptions = options
+      return opts.submit
+    },
+  }
+  return {
+    ctx,
+    ensureMainTask,
+    createTask,
+    notifyInfo,
+    notifyError,
+    selectTask,
+    enterTask,
+    reload,
+    logger,
+    options: () => seenOptions,
+  }
+}
+
+const OPEN: NewTaskInput = { mode: "open", repo: "/repos/codefox", vendor: "claude" as never }
+
+describe("createTaskFlow — opening a project instead of branching off it", () => {
+  test("resolves the repo's existing main row and enters it", async () => {
+    const h = makeCtx({ submit: OPEN })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.ensureMainTask).toHaveBeenCalledWith("/repos/codefox")
+    // The whole point: the hidden project's OWN row comes back, focused.
+    expect(h.selectTask).toHaveBeenCalledWith("main-codefox")
+    expect(h.enterTask).toHaveBeenCalledWith("main-codefox")
+    expect(h.reload).toHaveBeenCalled()
+  })
+
+  test("creates no task — that is the bug it exists to fix", async () => {
+    // Submitting the same repo through the default path is what used to
+    // happen, and it left the user with an extra worktree and still no
+    // project. Asserting the absence is the only thing that separates the
+    // fix from the bug: both end with a task selected.
+    const h = makeCtx({ submit: OPEN })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.createTask).not.toHaveBeenCalled()
+  })
+
+  test("does not claim it is creating anything", async () => {
+    const h = makeCtx({ submit: OPEN })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.notifyInfo.mock.calls.map((c) => String(c[0])).join(" ")).not.toMatch(/creating/i)
+  })
+
+  test("a failure surfaces instead of closing the dialog on nothing", async () => {
+    const h = makeCtx({
+      submit: OPEN,
+      ensureMainTask: async () => {
+        throw new Error("repo is gone")
+      },
+    })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.notifyError).toHaveBeenCalledTimes(1)
+    expect(String(h.notifyError.mock.calls[0][0])).toContain("repo is gone")
+    expect(h.enterTask).not.toHaveBeenCalled()
+  })
+
+  test("the default submit still creates a task", async () => {
+    // The new mode must not change what the tab does by default — the
+    // "branch a worktree off this repo" verb is still the common case.
+    const h = makeCtx({
+      submit: { repo: "/repos/codefox", baseRef: "main", vendor: "claude" as never },
+    })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.createTask).toHaveBeenCalledTimes(1)
+    expect(h.selectTask).toHaveBeenCalledWith("created")
+  })
+})
+
+describe("which repos the dialog may offer the project choice for", () => {
+  test("names a repo that has a main row", async () => {
+    const h = makeCtx({ submit: undefined })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.options()?.mainRepos?.has("/repos/codefox")).toBe(true)
+  })
+
+  test("omits a repo whose only rows are worktree tasks", async () => {
+    // No main row means no project checkout to open — offering the choice
+    // would put a control on the tab whose second option does nothing.
+    const h = makeCtx({
+      submit: undefined,
+      tasks: [task({ id: "a", kind: "task", repo: "/repos/orphan" })],
+    })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.options()?.mainRepos?.has("/repos/orphan")).toBe(false)
+  })
+
+  test("matches a repo path recorded with a trailing slash", async () => {
+    // The sidebar groups on the slash-trimmed key, so the dialog must too —
+    // otherwise a project stored one way is unreachable from a path typed
+    // the other way.
+    const h = makeCtx({
+      submit: undefined,
+      tasks: [task({ id: "m", kind: "main", repo: "/repos/codefox/" })],
+    })
+
+    await createTaskFlow(h.ctx)
+
+    expect(h.options()?.mainRepos?.has("/repos/codefox")).toBe(true)
+  })
+})

--- a/packages/kobe/test/tui/new-task-dialog/state.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/state.test.ts
@@ -30,6 +30,7 @@ import {
   isBlankText,
   nextDialogTab,
   nextField,
+  offersProjectIntent,
   pickerModeFor,
   prevDialogTab,
   resolveBaseRef,
@@ -133,6 +134,33 @@ describe("splitRepoRow (repo rows lead with the basename)", () => {
 
   it("keeps a repo at the filesystem root identifiable", () => {
     expect(splitRepoRow("/kobe")).toEqual({ base: "kobe", dir: "/" })
+  })
+})
+
+describe("offersProjectIntent (issue #90)", () => {
+  it("offers only for a repo that already has a project checkout", () => {
+    const mains = new Set(["/repos/codefox"])
+    expect(offersProjectIntent("/repos/codefox", mains)).toBe(true)
+    // No main row means nothing to open — `createTask` is what mints one, and
+    // only for a repo the admission gate accepts.
+    expect(offersProjectIntent("/repos/orphan", mains)).toBe(false)
+  })
+
+  it("normalizes the trailing slash the sidebar also trims", () => {
+    // The set is keyed the way `sidebarProjectKey` groups; a path typed with
+    // a slash must still find its own project.
+    expect(offersProjectIntent("/repos/codefox/", new Set(["/repos/codefox"]))).toBe(true)
+  })
+
+  it("never offers for blank or whitespace input", () => {
+    // The repo field starts prefilled but can be cleared; an empty path has
+    // no project, and `""` must not match a set that happens to hold it.
+    expect(offersProjectIntent("", new Set(["/repos/codefox"]))).toBe(false)
+    expect(offersProjectIntent("   ", new Set([""]))).toBe(false)
+  })
+
+  it("offers nothing when the caller passes no projects at all", () => {
+    expect(offersProjectIntent("/repos/codefox", new Set())).toBe(false)
   })
 })
 

--- a/packages/kobe/test/tui/new-task-dialog/state.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/state.test.ts
@@ -145,6 +145,18 @@ describe("nextField / firstFieldFor (per-tab field cycling)", () => {
     expect(nextField("engine", "existing")).toBe("repo")
   })
 
+  it("inserts the intent stop only when that row renders (issue #90)", () => {
+    // The row exists only for a repo that already has a project checkout, so
+    // the walk is TOLD whether it is on screen. Offering the stop
+    // unconditionally parks focus on nothing; omitting it when the row IS
+    // there makes it keyboard-unreachable — which is how it first shipped.
+    expect(nextField("repo", "existing", { intentVisible: true })).toBe("intent")
+    expect(nextField("intent", "existing", { intentVisible: true })).toBe("baseRef")
+    // Default (and explicit false) keep the original chain untouched.
+    expect(nextField("repo", "existing")).toBe("baseRef")
+    expect(nextField("repo", "existing", { intentVisible: false })).toBe("baseRef")
+  })
+
   it("cycles the clone tab through the selectors + all four inputs to confirm and back", () => {
     expect(nextField("engine", "clone")).toBe("cloneUrl")
     expect(nextField("cloneUrl", "clone")).toBe("cloneParent")

--- a/packages/kobe/test/tui/sidebar-tree-core.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-core.test.ts
@@ -422,4 +422,34 @@ describe("a project closed down to nothing (owner call 2026-08-31)", () => {
     const out = rows({ tasks: [mainOf("/repos/codefox")], tabsByTask: new Map([["m", []]]) })
     expect(treeFlatIds(out)).toEqual([])
   })
+
+  // The half that shipped without a guard (issue #90): six tests pinned that
+  // the project GOES, none that it can come back. It could not — the dialog
+  // only ever minted `kind: "task"`. The way back is now `mode: "open"` →
+  // `ensureMainTask` (test/tui/create-task-flow-open-project.test.ts); what
+  // belongs HERE is the tree's side of that round trip.
+  test("the hidden project returns as soon as its main has a tab again", () => {
+    const tasks = [mainOf("/repos/codefox")]
+    const hidden = rows({ tasks, tabsByTask: new Map([["m", []]]) })
+    expect(hidden).toEqual([])
+
+    // What opening the project does: its main row gets a session again.
+    const back = rows({ tasks, tabsByTask: new Map([["m", [tab("t1")]]]) })
+    expect(back.map((r) => r.kind)).toEqual(["project", "worktree", "tab"])
+    // And it is reachable — a row you can see but not move the cursor to
+    // would be the same dead end in a different costume.
+    expect(treeFlatIds(back).length).toBeGreaterThan(0)
+  })
+
+  test("opening the project does not mint a second row for the same repo", () => {
+    // `ensureMainTask` is idempotent, so the revived project must be the
+    // SAME main task. If a second main row appeared, the repo would render
+    // twice under one header — the shape a create-instead-of-open produces.
+    const out = rows({
+      tasks: [mainOf("/repos/codefox")],
+      tabsByTask: new Map([["m", [tab("t1")]]]),
+    })
+    expect(out.filter((r) => r.kind === "project")).toHaveLength(1)
+    expect(out.filter((r) => r.kind === "worktree")).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
Closes #90.

## What was broken

Closing a project's last tab hides it from the sidebar (`isClosedDownProject`, #696). That rule's comment promised the repo was "still there in the new-task picker to open again". It was not — every submit path went through `createTask`, which always mints a `kind: "task"`, so picking the hidden repo added a worktree *beside* the project and still produced no project row. The only real way back was `rove add <path>` in a shell.

The hiding rule shipped with six tests. The way back had none, which is why the gap shipped.

A second, narrower dead end: the "No sessions here — press ⏎ or ctrl+e to start one" placeholder named two keys neither of which had a handler. Both are registered inside `TerminalTabs`, which is deliberately not mounted over an empty tab list.

## What changed

**The dialog can open a project.** For a repo that already has a main row, the For Existing tab shows an extra `opens` row: "a new task worktree" (the default, unchanged) or "the project itself". The second submits `mode: "open"` and routes to `ensureMainTask`, which is idempotent — it resolves the existing checkout instead of creating anything. Under that intent the branch field disappears, since opening a checkout forks from nothing.

The choice renders only for repos with a main row (`mainRepos`, read from the live task list). Elsewhere it would be a control whose second option does nothing, so it is absent rather than disabled. Both the row and the branch field are conditional, so `nextField` is told what is on screen rather than guessing — parking focus on an unrendered stop swallows every keystroke after it.

**The empty pane binds its own keys.** New `EmptyWorkspacePane` owns the placeholder and registers `workspace.reopenSession` (⏎) plus the existing `chat.tab.chooseEngine` (ctrl+e). It reopens the *kind* of tab that was closed, via #710's `reviveEmptiedTabs`.

## Keybinding

`workspace.reopenSession` = plain `return`, workspace scope — **owner sign-off 2026-08-31**, recorded in `docs/design/keybinding-decisions.md`. Safe at that scope because the binding is registered by a pane that holds no input, no tab strip and no terminal: while it is on screen nothing else Enter could mean is present, and when it is not, the binding does not exist. `ctrl+e` is not a new chord — it is the existing one staying answerable in the one state where its usual owner is unmounted.

## Stale descriptions realigned

- `isClosedDownProject`'s doc comment now names the actual route back, and says plainly that the old promise was false.
- `docs/TUI.md` still said "A Task always keeps at least one tab" (untrue since #696) and described the Existing tab without the new choice.
- `docs/KEYBINDINGS.md` gains the `enter` row and its scoping note.
- `workspace.empty.noSessions` copy is unchanged — it now describes real behavior.

## Tests

- `test/tui/create-task-flow-open-project.test.ts` (8) — the missing half: `ensureMainTask` is called, **no task is created** (the assertion that separates fix from bug), no "Creating…" toast, failures surface, the default submit still creates, and the `mainRepos` gating (main row present / absent / trailing slash).
- `test/render/new-task-open-project.test.tsx` (5) — the dialog end to end through `NewTaskDialog.show`, including keyboard reachability of the intent row.
- `test/render/empty-workspace-pane.test.tsx` (5) — ⏎ and ctrl+e each revive, the reopened tab matches the closed kind, and an unfocused pane ignores both.
- `test/tui/sidebar-tree-core.test.ts` — the six existing guards are **untouched**; two round-trip cases added (the project returns once its main has a tab; opening mints no second row).
- `test/tui/new-task-dialog/state.test.ts` — the intent stop's visibility condition, both directions.

### A bug the coverage gate found

The gate failed on `new-task-dialog/index.tsx` (22.6%) — the prop carrying `mainRepos` from a caller's options into the view-model had no render test, so a dropped wire there would leave every flow test green while the choice never rendered. Writing that test surfaced a real defect: the intent row had **no `Field` stop**, so `tab` walked past it and `right` reached the dialog's tab-strip cycle instead. The row was mouse-only, and the first version of the test passed against that because it asserted on a click; the mutation run is what exposed it. Fixed, and the test now drives tab + arrow. 22.6% → 100%.

Mutation-verified at ten sites across the changed files, re-verified after the rebase onto #712.

## Gates

lint ✅ · typecheck ✅ · i18n ✅ (717 × 2 in sync) · render 343 ✅ · coverage gate ✅ locally · changeset (patch) ✅ · every touched file under the 500-line cap.

`bun run test:fast` shows 4 pre-existing failures in `test/state/project-eligibility.test.ts` and `test/cli/open-dir-cmd.test.ts` — the known `~/.rove/worktrees` path-shape artifact. Both files are untouched by this diff and pass on a clean checkout at the same commit.