### PR TITLE
fix: lead new-task repo rows with the folder name, path muted behind

### DIFF
--- a/.changeset/newtask-repo-row-basename.md
+++ b/.changeset/newtask-repo-row-basename.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Lead each saved-repo row in the new-task picker with its folder name, and mute the path behind it.
+
+The saved list is a column of absolute paths that mostly share a prefix (`/Users/me/i/kobe`, `/Users/me/i/wisp`, …), so every row opened with the same run of characters and the one word telling them apart sat far right, past the ragged part. The basename now leads at a fixed left edge and its directory trails in muted text — the same string, re-ordered so the identifying half is what the cursor's emphasis lands on. Directory browse rows (typing a `/`) already list bare folder names and are unchanged.

--- a/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
@@ -22,6 +22,14 @@ export type PickerRow = {
   readonly body: string
   /** Non-cursor rows render accent (selected) instead of muted. */
   readonly accent?: boolean
+  /**
+   * Trailing text always painted muted, whatever the row's own state. For a
+   * row whose body is the part that IDENTIFIES the item and whose tail merely
+   * LOCATES it (the repo picker's basename + directory), so the cursor's
+   * bold/primary lands on the name alone instead of dragging a shared path
+   * prefix into the emphasis with it.
+   */
+  readonly dim?: string
 }
 
 export function PickerList(props: {
@@ -47,17 +55,38 @@ export function PickerList(props: {
       {props.rows.map((row, i) => {
         const absoluteIndex = props.window.start + i
         const isCursor = absoluteIndex === props.cursor
+        const fg = isCursor ? theme.primary : row.accent ? theme.accent : theme.textMuted
+        const attributes = isCursor ? TextAttributes.BOLD : undefined
+        // A row with no `dim` stays ONE text node: two nodes in a flex row
+        // measure and clip differently, so splitting every row would change
+        // the layout of the three pickers that pass no tail.
+        if (!row.dim) {
+          return (
+            <text
+              key={row.key}
+              fg={fg}
+              attributes={attributes}
+              wrapMode="none"
+              onMouseUp={() => props.onPick(absoluteIndex)}
+            >
+              {isCursor ? "▸ " : "  "}
+              {row.body}
+            </text>
+          )
+        }
         return (
-          <text
-            key={row.key}
-            fg={isCursor ? theme.primary : row.accent ? theme.accent : theme.textMuted}
-            attributes={isCursor ? TextAttributes.BOLD : undefined}
-            wrapMode="none"
-            onMouseUp={() => props.onPick(absoluteIndex)}
-          >
-            {isCursor ? "▸ " : "  "}
-            {row.body}
-          </text>
+          <box key={row.key} flexDirection="row" onMouseUp={() => props.onPick(absoluteIndex)}>
+            <text fg={fg} attributes={attributes} wrapMode="none" flexShrink={0}>
+              {isCursor ? "▸ " : "  "}
+              {row.body}
+            </text>
+            {/* The tail is the first thing to go on a narrow card: it is the
+                half the row can lose and still be identifiable. */}
+            <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
+              {"  "}
+              {row.dim}
+            </text>
+          </box>
         )
       })}
       {below > 0 ? (

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
@@ -7,6 +7,7 @@
  * All behavior lives in the view-model; this file is JSX only.
  */
 
+import { splitRepoRow } from "../../../tui/component/new-task-dialog/state"
 import { DEFAULT_BASE_REF } from "../../../tui/lib/git-snapshot"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
@@ -19,12 +20,21 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
 
   const repoRows = vm.activeWindow.items.map((name, i) => {
     const isCurrentDir = vm.mode === "saved" && name === vm.defaultRepo
-    const suffix = vm.mode === "browse" ? "/" : ""
     const tag = isCurrentDir ? `  ${t("newTask.hint.currentDir")}` : ""
+    // Browse mode lists SUBDIRECTORY NAMES under the typed path, not full
+    // paths — there is no prefix to demote, so those rows stay whole.
+    if (vm.mode === "browse") {
+      return { key: `${vm.activeWindow.start + i}:${name}`, body: `${name}/${tag}`, accent: false }
+    }
+    // Saved mode lists absolute paths that mostly share a prefix, so the one
+    // word telling them apart is the basename — it leads, and the directory
+    // trails muted (`splitRepoRow`).
+    const { base, dir } = splitRepoRow(name)
     return {
       key: `${vm.activeWindow.start + i}:${name}`,
-      body: `${name}${suffix}${tag}`,
-      accent: vm.mode === "saved" && vm.repo.trim() === name,
+      body: `${base}${tag}`,
+      accent: vm.repo.trim() === name,
+      ...(dir ? { dim: dir } : {}),
     }
   })
 

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -306,6 +306,28 @@ export function computeRepoOptions(defaultRepo: string, savedRepos: readonly str
 }
 
 /**
+ * Split a saved-repo path into the part that IDENTIFIES it and the part that
+ * merely LOCATES it: the basename, and everything before it.
+ *
+ * The saved list is a column of absolute paths that share a prefix
+ * (`/Users/me/i/kobe`, `/Users/me/i/wisp`, …), so the leading run of
+ * characters is identical on every row and the one distinguishing word sits
+ * far right, past the ragged part. Leading with the basename puts the answer
+ * at a fixed left edge and demotes the directory to context the eye can skip.
+ *
+ * `dir` keeps its trailing slash so the two halves concatenate back to the
+ * original path — the row shows the same string, only re-ordered and
+ * re-weighted. A path with no slash (or a trailing one, which names no leaf)
+ * has nothing to split: it comes back whole as `base` with an empty `dir`,
+ * so the row renders exactly as it did before.
+ */
+export function splitRepoRow(path: string): { base: string; dir: string } {
+  const at = path.lastIndexOf("/")
+  if (at < 0 || at === path.length - 1) return { base: path, dir: "" }
+  return { base: path.slice(at + 1), dir: path.slice(0, at + 1) }
+}
+
+/**
  * Case-insensitive substring filter for the repo picker. Empty query
  * returns the full list verbatim.
  */

--- a/packages/kobe/test/tui/new-task-dialog/state.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/state.test.ts
@@ -33,6 +33,7 @@ import {
   pickerModeFor,
   prevDialogTab,
   resolveBaseRef,
+  splitRepoRow,
   stripNewlines,
   windowAround,
 } from "@/tui/component/new-task-dialog/state"
@@ -105,6 +106,33 @@ describe("computeRepoOptions", () => {
   it("dedupes the cwd against the saved list and keeps it first", () => {
     const cwd = "/home/me/proj"
     expect(computeRepoOptions(cwd, [cwd, "/home/me/other"])).toEqual([cwd, "/home/me/other"])
+  })
+})
+
+describe("splitRepoRow (repo rows lead with the basename)", () => {
+  it("splits an absolute path into basename + its directory, keeping the slash", () => {
+    expect(splitRepoRow("/Users/me/i/kobe")).toEqual({ base: "kobe", dir: "/Users/me/i/" })
+  })
+
+  it("round-trips: dir + base is the original path, so the row shows the same string", () => {
+    for (const path of ["/Users/me/i/kobe", "/a/b", "/root", "rel/path"]) {
+      const { base, dir } = splitRepoRow(path)
+      expect(dir + base).toBe(path)
+    }
+  })
+
+  it("leaves a bare name whole — nothing to demote, so the row renders as before", () => {
+    expect(splitRepoRow("kobe")).toEqual({ base: "kobe", dir: "" })
+  })
+
+  it("leaves a trailing-slash path whole: it names no leaf, so a split would blank the row", () => {
+    // `base` empty + `dir` everything would render an EMPTY identifying half
+    // with the whole path muted behind it — the row would read as blank.
+    expect(splitRepoRow("/Users/me/i/")).toEqual({ base: "/Users/me/i/", dir: "" })
+  })
+
+  it("keeps a repo at the filesystem root identifiable", () => {
+    expect(splitRepoRow("/kobe")).toEqual({ base: "kobe", dir: "/" })
   })
 })
 


### PR DESCRIPTION
The saved-repo picker in the new-task dialog listed absolute paths that mostly share a prefix:

```
  ▸ /Users/jacksonc/i/kobe
    /Users/jacksonc/i/wisp
    /Users/jacksonc/i/codefox
```

Every row opens with the same run of characters, so the one word that tells them apart sits far right, past the ragged part. Now:

```
  ▸ kobe     /Users/jacksonc/i/
    wisp     /Users/jacksonc/i/
    codefox  /Users/jacksonc/i/
```

Same string, re-ordered and re-weighted — the basename leads at a fixed left edge and the directory trails muted, so the cursor's bold/primary lands on the name instead of dragging a shared prefix into the emphasis.

## Scope

- `splitRepoRow` (pure, `state.ts`) splits a path into `{ base, dir }`, `dir` keeping its trailing slash so the two halves concatenate back to the original.
- `PickerRow` gains an optional `dim` tail. A row without it stays **one** text node — two nodes in a flex row measure and clip differently, so splitting unconditionally would have changed the layout of the three pickers that pass no tail (branch, clone parent, adopt).
- Browse mode (typing a `/`) lists bare subdirectory names, not full paths. Nothing to demote, so those rows are unchanged.
- The `(current dir)` tag stays attached to the basename rather than drifting into the muted half.

## Verification

Real frame at 100×34, repo field cleared so the saved list shows unfiltered:

```
  repo
  /var/folders/.../kobe-probe-vNDEHS

    ▸ kobe-probe-vNDEHS  (current dir)  /var/folders/dg/bl1p3lg17gzdhr0yc4q_kjzh0000gn/T/
      kobe  /Users/jacksonc/i/
      wisp  /Users/jacksonc/i/
      codefox  /Users/jacksonc/i/
      foxychat  /Users/jacksonc/i/
```

Five unit tests on `splitRepoRow`, mutation-verified at two separate sites:

- dropping the trailing slash from `dir` → 3 red (round-trip, absolute split, filesystem-root case)
- dropping the trailing-slash guard → 1 red (a path like `/Users/me/i/` would otherwise render a blank identifying half with the whole path muted behind it)

`test/tui/new-task-dialog` + `test/tui-react/new-task-pure` (65) and `test/render/new-task-short-terminal` (2) pass; root lint + typecheck clean.