### PR TITLE
fix: round the kanban board's column and card borders

### DIFF
--- a/.changeset/kanban-rounded-borders.md
+++ b/.changeset/kanban-rounded-borders.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Frame the Kanban board's columns and cards in rounded corners, like every other panel in the TUI.
+
+The workspace pane, files pane and tab strip all draw `╭╮╰╯`; the board's four columns and the cards inside them drew opentui's default square `┌┐└┘`, so the one page reachable from the rail was framed in a different grammar from the pane it renders inside.

--- a/packages/kobe/src/tui-react/component/kanban-card.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-card.tsx
@@ -69,6 +69,9 @@ export function KanbanCard(props: {
   return (
     <box
       border={true}
+      // Rounded to match the column that holds it — a square card inside a
+      // rounded column reads as two different systems one cell apart.
+      borderStyle="rounded"
       borderColor={selected ? theme.primary : needsAttention ? theme.warning : columnBorder}
       backgroundColor={theme.backgroundElement}
       padding={1}

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -341,6 +341,11 @@ export function KanbanPage(props: {
         flexGrow={1}
         flexBasis={0}
         border={true}
+        // Rounded, like every other framed surface in the TUI (the workspace
+        // pane, the files pane, the tab strip): opentui's default is square,
+        // so a box that only says `border` opts out of the house grammar
+        // without looking like it did.
+        borderStyle="rounded"
         borderColor={columnBorder}
         paddingLeft={1}
         paddingRight={1}

--- a/packages/kobe/test/render/kanban-columns.test.tsx
+++ b/packages/kobe/test/render/kanban-columns.test.tsx
@@ -81,8 +81,38 @@ test("a card pads its title away from its own border", async () => {
   // own — the card's top border is one row further up.
   const above = lines[title - 1] ?? ""
   expect(above).toContain("│")
+  // Rounded corners, like every other framed surface in the TUI — and a
+  // corner on THIS row would mean the title sits flush against the top
+  // border, which is the padding this test exists to hold.
+  expect(above).not.toContain("╭")
   expect(above).not.toContain("┌")
   expect(above.replace(/[│ ]/g, "")).toBe("")
+})
+
+/**
+ * Both framed surfaces on the board — the four columns and the cards inside
+ * them — draw ROUNDED corners, the same grammar the workspace pane, files
+ * pane and tab strip already use.
+ *
+ * Pinned against the frame because opentui's default is SQUARE: a box that
+ * says `border` and nothing else silently opts out of the house style, which
+ * is how the board shipped as the one page framed in `┌┐└┘`. Asserting the
+ * absence of square glyphs is what makes this test fail if either box loses
+ * its `borderStyle` again — a corner-count assertion alone would pass on the
+ * default.
+ */
+test("columns and cards are framed in rounded corners, never square", async () => {
+  const text = await board([issue(1)])
+  expect(text).toContain("╭")
+  expect(text).toContain("╯")
+  expect(text).not.toContain("┌")
+  expect(text).not.toContain("┘")
+  // Four columns plus the one card = five framed boxes, so five of each
+  // corner. Without this a single rounded box beside four square ones would
+  // still satisfy the checks above.
+  const corners = (glyph: string): number => text.split(glyph).length - 1
+  expect(corners("╭")).toBe(5)
+  expect(corners("╰")).toBe(5)
 })
 
 /**

--- a/packages/kobe/test/render/rail-pages-baseline.test.tsx
+++ b/packages/kobe/test/render/rail-pages-baseline.test.tsx
@@ -93,7 +93,9 @@ type RailPage = {
 }
 
 const RAIL_PAGES: readonly RailPage[] = [
-  { title: "Kanban", body: ["kobe", "┌"], overrides: { kanbanOpen: true } },
+  // `╭` anchors the board's first column — its rounded corner, matching every
+  // other framed surface (see kanban-columns.test.tsx, which pins the style).
+  { title: "Kanban", body: ["kobe", "╭"], overrides: { kanbanOpen: true } },
   { title: "ROUTINES", body: ["No routines scheduled."], overrides: { automationsOpen: true } },
   { title: "ISSUES", body: ["No open issues."], overrides: { workItemsOpen: true } },
 ]


### PR DESCRIPTION
The workspace pane, files pane and tab strip are all framed in rounded corners. The Kanban board's four columns — and the cards inside them — took opentui's **square** default, so the one page reachable from the rail was framed in a different grammar from the pane it renders inside.

Before / after, same frame:

```
  ┌─────────────────────┐      ╭─────────────────────╮
  │ Backlog (1)         │      │ Backlog (1)         │
  │ ┌────────────────┐  │  →   │ ╭────────────────╮  │
  │ │ a card     #1  │  │      │ │ a card     #1  │  │
  │ └────────────────┘  │      │ ╰────────────────╯  │
  └─────────────────────┘      ╰─────────────────────╯
```

Both boxes are changed together: rounding only the column would have put a square card inside a rounded column, which reads as two systems one cell apart.

## Test

`kanban-columns.test.tsx` already had an assertion mentioning `┌`, but it only checked corners were *absent* from the row above a card title (that's a padding test) — it passed either way, so it pinned nothing about the style. Added a test that does:

- rounded glyphs present, square glyphs absent;
- exactly 5 of each corner (four columns + one card) — without the count, one rounded box beside four square ones would still satisfy the presence checks.

Mutation-verified at both sites independently: removing `borderStyle` from the card fails it, and removing it from the column fails it.

Root lint + typecheck clean; the file's 7 render tests pass.