### PR TITLE
fix: stop the delivery gate reading an unreadable screen as a busy composer

### DIFF
--- a/.changeset/composer-probe-render-window.md
+++ b/.changeset/composer-probe-render-window.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the delivery gate deferring every message to a Claude task, whatever its composer held.
+
+Before pasting a prompt into a running engine, Rove renders that session's screen and looks for an empty composer. Two things had drifted: the throwaway terminal was 12 rows, too short for a real screen — rows overflowed and FUSED, so the composer line no longer existed to match — and Claude now hangs a rule, a status row and a hint row below its composer, putting the prompt four lines from the bottom, outside the two-line window the rule inspected.
+
+A rule that matched nothing was then read as "the composer has text", so every `rove api send` to a Claude task was accepted-and-deferred to the Inbox instead of delivered.
+
+The window now clears Claude's status furniture, the render is tall enough not to fuse rows, and — the part that keeps this from recurring silently — a rule whose anchor is nowhere on screen now answers "I can't see it" rather than "there is text". Not seeing the composer leaves the recent-human-write quiet period as the guard, instead of blocking delivery to that engine indefinitely with no signal.

--- a/packages/kobe/src/engine/claude-code-local/screen.ts
+++ b/packages/kobe/src/engine/claude-code-local/screen.ts
@@ -2,13 +2,24 @@
  * Claude Code screen-state manifest.
  *
  * Claude reports turn state through hooks and its OSC title, so this manifest
- * only covers the delivery gate's composer-empty detection (issue #78). The
- * empty-composer line observed in production is:
+ * only covers the delivery gate's composer-empty detection (issue #78).
  *
- *   "❯                    · ← 8 agents"
+ * The composer is NOT the last thing on screen. Claude draws it inside a box
+ * and hangs its own status furniture below:
  *
- * i.e. the prompt glyph `❯` plus status decoration, with no user text after
- * the prompt.
+ *   ─────────────────────────────────   <- rule
+ *   ❯                                   <- the composer
+ *   ─────────────────────────────────   <- rule
+ *     𖠰 musk | ⎇ branch | Ctx…          <- status row
+ *     ⏵⏵ bypass permissions on …        <- hint row
+ *
+ * so the prompt sits FOUR non-empty lines from the bottom. `bottomLines` has
+ * to clear that furniture; a window that stops short reports every composer
+ * as non-empty, because "no rule matched" is deliberately fail-closed.
+ *
+ * The older one-line form (`❯ · ← 8 agents`) still matches — the regex allows
+ * the trailing decoration, and the wider window is a superset of the narrow
+ * one.
  */
 
 import type { EngineScreenManifest } from "../screen-state.ts"
@@ -17,7 +28,7 @@ export const CLAUDE_SCREEN_MANIFEST: EngineScreenManifest = {
   rules: [],
   composerEmpty: [
     {
-      bottomLines: 2,
+      bottomLines: 6,
       all: ["❯"],
       lineRegex: ["^\\s*❯\\s*(?:[·•]\\s*(?:←[^\\n]*)?)?$"],
     },

--- a/packages/kobe/src/engine/composer-state.ts
+++ b/packages/kobe/src/engine/composer-state.ts
@@ -15,8 +15,20 @@ import type { ComposerEmptyRule, EngineScreenManifest } from "./screen-state.ts"
 /** Fixed width for composer rendering — see issue #78. Claude's composer
  *  line is stable across 150–236 cols; 150 is enough and cheap. */
 export const COMPOSER_RENDER_COLS = 150
-/** Enough rows to capture the composer line plus a little context. */
-export const COMPOSER_RENDER_ROWS = 12
+/**
+ * Rows the throwaway terminal renders into.
+ *
+ * Must exceed a real engine screen, not just the footer we want to read. At
+ * 12 the ring's own line count overran the buffer and lines CONCATENATED
+ * (`──⏵⏵ bypass permissions on …` — a rule and the hint row fused into one),
+ * so the composer line was not merely off-window, it no longer existed as a
+ * line to match. Every Claude delivery then read as "composer has text" and
+ * deferred, whatever the composer actually held.
+ *
+ * 60 covers a full-screen engine with headroom. The cost is one throwaway
+ * xterm per delivery gate, which is already the price of the render.
+ */
+export const COMPOSER_RENDER_ROWS = 60
 /** Default trailing lines to inspect for the composer prompt. */
 export const COMPOSER_BOTTOM_LINES = 3
 
@@ -49,24 +61,51 @@ function bottomRegion(captureText: string, lines: number): readonly string[] {
   return nonEmpty.slice(-lines)
 }
 
-function ruleMatches(rule: ComposerEmptyRule, region: readonly string[]): boolean {
+/**
+ * How a rule fared against one screen region.
+ *
+ *   `empty`  — the composer is there and holds nothing.
+ *   `text`   — the composer is there and holds something.
+ *   `absent` — its ANCHOR is not on screen at all, so this rule saw no
+ *              composer and has nothing to say about one.
+ *
+ * The third outcome is the one that matters. Collapsing it into `text` is
+ * what turned a Claude layout change into a total delivery outage: the prompt
+ * glyph moved out of the inspected window, no rule matched, and every message
+ * to every Claude task deferred as "composer busy" — including the ones whose
+ * composers were plainly empty. "I could not see it" is not evidence of text.
+ */
+type RuleOutcome = "empty" | "text" | "absent"
+
+function ruleOutcome(rule: ComposerEmptyRule, region: readonly string[]): RuleOutcome {
   const haystack = region.join("\n").toLowerCase()
-  if (rule.all && !rule.all.every((s) => haystack.includes(s.toLowerCase()))) return false
-  if (rule.any && !rule.any.some((s) => haystack.includes(s.toLowerCase()))) return false
+  // `all`/`any` are ANCHORS — the prompt glyph that says "the composer is on
+  // this screen". Missing them means the region does not show the composer.
+  if (rule.all && !rule.all.every((s) => haystack.includes(s.toLowerCase()))) return "absent"
+  if (rule.any && !rule.any.some((s) => haystack.includes(s.toLowerCase()))) return "absent"
+  // Anchored: the line shape decides empty vs typed-into.
   if (rule.lineRegex) {
     const regexes = rule.lineRegex.map((r) => new RegExp(r, "i"))
-    if (!region.some((line) => regexes.some((re) => re.test(line)))) return false
+    if (!region.some((line) => regexes.some((re) => re.test(line)))) return "text"
   }
-  return Boolean(rule.all || rule.any || rule.lineRegex)
+  return rule.all || rule.any || rule.lineRegex ? "empty" : "absent"
 }
 
 /**
  * Determine whether the engine's composer is empty.
  *
  * - `true`  = composer is empty (only prompt glyph + allowed decoration)
- * - `false` = composer has text OR the manifest exists but no rule matched
- *             (fail-closed for engines that declare rules)
- * - `null`  = no manifest / no rules (fail-open; let the A-layer gate decide)
+ * - `false` = the composer is on screen and holds text — fail-closed, do not
+ *             paste over what someone is writing
+ * - `null`  = no manifest / no rules, OR no rule's anchor appeared at all
+ *             (we cannot see the composer; the A-layer quiet period decides)
+ *
+ * The `null`-on-absent case is deliberate and load-bearing. These rules are
+ * coupled to how an engine draws itself TODAY, so a UI change upstream will
+ * eventually stop matching. When it does, the honest answer is "I don't
+ * know", which leaves the A-layer's recent-human-write window as the guard —
+ * not "assume text forever", which silently blocks every delivery to that
+ * engine with no signal that anything is wrong.
  */
 export async function isComposerEmpty(
   ringBytes: Uint8Array,
@@ -74,10 +113,14 @@ export async function isComposerEmpty(
 ): Promise<boolean | null> {
   if (!manifest?.composerEmpty || manifest.composerEmpty.length === 0) return null
   const text = await renderRingToText(ringBytes, COMPOSER_RENDER_COLS, COMPOSER_RENDER_ROWS)
+  let sawComposer = false
   for (const rule of manifest.composerEmpty) {
     const region = bottomRegion(text, rule.bottomLines ?? COMPOSER_BOTTOM_LINES)
     if (region.length === 0) continue
-    if (ruleMatches(rule, region)) return true
+    const outcome = ruleOutcome(rule, region)
+    if (outcome === "empty") return true
+    if (outcome === "text") sawComposer = true
   }
-  return false
+  // Some rule found the composer and read text in it; nobody found it empty.
+  return sawComposer ? false : null
 }

--- a/packages/kobe/test/engine/composer-state.test.ts
+++ b/packages/kobe/test/engine/composer-state.test.ts
@@ -37,6 +37,71 @@ describe("isComposerEmpty", async () => {
     expect(await isComposerEmpty(bytes("❯ · ← 8 agents"), CLAUDE_SCREEN_MANIFEST)).toBe(true)
   })
 
+  /**
+   * The regression that made every Claude delivery defer.
+   *
+   * Claude hangs a rule, a status row and a hint row BELOW its composer, so
+   * the prompt is four non-empty lines off the bottom. The single-line
+   * fixtures above never saw that furniture, which is why they stayed green
+   * while production deferred every peer message: `bottomLines: 2` could not
+   * reach the prompt, no rule matched, and no-match is fail-closed.
+   *
+   * Rendering was the other half. At 12 rows a real screen overran the
+   * buffer and lines FUSED (`──⏵⏵ bypass permissions on …`), so the composer
+   * line did not exist to be matched at any window size.
+   */
+  const RULE = "─".repeat(150)
+  function claudeScreen(composerLine: string): Uint8Array {
+    const body = Array.from({ length: 20 }, (_, i) => `  output line ${i}`).join("\r\n")
+    return bytes(
+      [
+        body,
+        RULE,
+        composerLine,
+        RULE,
+        "  𖠰 musk | ⎇ fix/x | Ctx… | ⚪ pool",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 8 agents",
+      ].join("\r\n"),
+    )
+  }
+
+  it("sees an empty composer through Claude's status furniture", async () => {
+    expect(await isComposerEmpty(claudeScreen("❯ "), CLAUDE_SCREEN_MANIFEST)).toBe(true)
+  })
+
+  it("still sees typed text through that same furniture", async () => {
+    // The complement: widening the window must not turn the gate into a
+    // rubber stamp that reports every screen empty.
+    expect(await isComposerEmpty(claudeScreen("❯ ship the docs"), CLAUDE_SCREEN_MANIFEST)).toBe(false)
+  })
+
+  it("renders enough rows that a full screen's lines do not fuse", async () => {
+    // The other half of the same bug, and it needs REAL cursor positioning to
+    // show up: Claude draws with CUF/CUD (`ESC[2C`, `ESC[1B`), not newlines,
+    // and in a 12-row buffer those wrapped around and fused rows together
+    // (`──⏵⏵ bypass permissions on …` — a rule and the hint row in one line).
+    // A \r\n-joined fixture cannot reproduce it: it renders identically at 12
+    // and 60 rows, which is why the first version of this test passed against
+    // the very constant it was meant to pin.
+    const E = String.fromCharCode(27)
+    const parts: string[] = []
+    for (let i = 0; i < 40; i++) parts.push(`\r${E}[2C${E}[1Boutput line ${i}`)
+    parts.push(`\r${E}[1B${RULE}`)
+    parts.push(`\r${E}[1B❯ `)
+    parts.push(`\r${E}[1B${RULE}`)
+    parts.push(`\r${E}[2C${E}[1B  𖠰 musk | ⎇ fix/x`)
+    parts.push(`\r${E}[2C${E}[1B  ⏵⏵ bypass permissions on (shift+tab to cycle)`)
+    expect(await isComposerEmpty(bytes(parts.join("")), CLAUDE_SCREEN_MANIFEST)).toBe(true)
+  })
+
+  it("answers null — not false — when no rule's anchor is on screen", async () => {
+    // The safety property behind the outage: when the composer cannot be seen
+    // at all, the C layer abstains and the A-layer quiet window decides. The
+    // old code returned false here, so ONE upstream UI change deferred every
+    // message to every Claude task, indefinitely and silently.
+    expect(await isComposerEmpty(bytes("just some output, no prompt glyph"), CLAUDE_SCREEN_MANIFEST)).toBeNull()
+  })
+
   it("returns false when Claude's composer has user text", async () => {
     expect(await isComposerEmpty(bytes("❯ hello"), CLAUDE_SCREEN_MANIFEST)).toBe(false)
     expect(await isComposerEmpty(bytes("❯ fix the bug"), CLAUDE_SCREEN_MANIFEST)).toBe(false)


### PR DESCRIPTION
Every `rove api send` to a Claude task was being deferred to the Inbox instead of delivered, whatever the composer actually held. Owner hit it live: two agent tasks with visibly empty composers, four messages stuck in `deferred-prompts.json`.

## Root cause — two drifts, one amplifier

The C-layer gate renders the target session's screen and looks for an empty composer.

**1. The render buffer was too short.** `COMPOSER_RENDER_ROWS = 12`; a real screen overflows it and rows *fuse*. Captured from a live session:

```
rows=12  ->  "──⏵⏵ bypass permissions on (shift+tab to cycle) · ← 8 agents"   ← a rule + the hint row, one line
rows=60  ->  "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 8 agents"
```

At 12 the composer line does not exist to be matched at *any* window size.

**2. The window no longer reached the prompt.** Claude hangs furniture below its composer:

```
─────────────────────    rule
❯                        the composer
─────────────────────    rule
  𖠰 musk | ⎇ branch …    status row
  ⏵⏵ bypass permissions   hint row
```

The prompt is four non-empty lines up; the rule inspected `bottomLines: 2`. The manifest's own comment documented the *old* single-line form (`❯ · ← 8 agents`), which is what it was written against.

**3. The amplifier.** `isComposerEmpty` returned `false` — "has text" — when no rule matched. So "I could not find the composer" and "the composer has text in it" were the same answer, and one upstream UI change silently blocked delivery to that engine forever.

## Fix

- `COMPOSER_RENDER_ROWS` 12 → 60.
- Claude's `bottomLines` 2 → 6, clearing its status furniture. The old one-line form still matches (the regex already allowed the decoration; the wider window is a superset).
- A rule whose **anchor** is absent now yields `null` (can't see it) instead of `false`. Absence leaves the A-layer recent-human-write window as the guard, rather than blocking that engine indefinitely with no signal. A rule that *does* find the composer and reads text still returns `false` — pasting over someone's half-typed message stays prevented.

## Verification

Against real captured PTY bytes from two live sessions — one with an empty composer, one with `❯ 把这份文档提交,别开 PR` typed in:

| | before | after |
|---|---|---|
| empty composer | `false` (wrong → deferred) | `true` |
| typed-in composer | `false` | `false` |

Three regression tests, mutation-verified **independently**:

- revert `bottomLines` → 2 red
- revert `ROWS` → 1 red
- revert the `null`-on-absent → 1 red

The row test needs real CUF/CUD cursor sequences to bite: a `\r\n`-joined fixture renders identically at 12 and 60 rows, so my first version of it passed against the very constant it was meant to pin. The existing tests in this file were all single-line fixtures (`bytes("❯")`), which is why they stayed green while production was fully broken — none of them had the furniture below the prompt.

`test/engine` 627 pass; full `test:fast` 4038 pass (47 pre-existing failures are the `ROVE_INVOKED_AS` env artefact — zero with `env -u`); root lint + typecheck clean.