### PR TITLE
test: expect update.sh's --no-cache bun install

### DIFF
--- a/packages/kobe/test/behavior/cli-update.test.ts
+++ b/packages/kobe/test/behavior/cli-update.test.ts
@@ -107,8 +107,11 @@ describe("scripts/update.sh manager detection (issue #205)", () => {
     expect(r.out).toContain("many sessions. one terminal.")
     expect(r.out).toContain("Thanks for using Rove. Happy building.")
     expect(r.out).toContain("via bun")
-    expect(r.log).toContain("bun install -g @sma1lboy/rove@latest")
-    expect(r.log).not.toContain("npm install")
+    // `--no-cache` since #703: bun's manifest cache served a stale version for
+    // minutes after a publish, so the update reported success and installed
+    // what was already there.
+    expect(r.log).toContain("bun install -g --no-cache @sma1lboy/rove@latest")
+    expect(r.log).not.toContain("npm install -g")
   })
 
   it("any other kobe location updates via npm", async () => {
@@ -208,7 +211,7 @@ describe("scripts/update.sh manager detection (issue #205)", () => {
     const base = join(env.home, "case-bun-noprefix")
     const r = await runUpdateScript(base, join(base, ".bun", "bin"))
     expect(r.code).toBe(0)
-    expect(r.log).toContain("bun install -g @sma1lboy/rove@latest")
+    expect(r.log).toContain("bun install -g --no-cache @sma1lboy/rove@latest")
     expect(r.log).not.toContain("--prefix")
   })
 


### PR DESCRIPTION
`main` has been red since #703. That PR added `--no-cache` to the bun branch of `scripts/update.sh` — bun's manifest cache kept serving a stale version for minutes after a publish, so `rove update` reported success and installed what was already there — but the two behavior assertions that spell out that exact command were not moved with it.

```
- bun install -g @sma1lboy/rove@latest
+ bun install -g --no-cache @sma1lboy/rove@latest
```

Test-only; `update.sh` is untouched. This is the stale half of a real change, not a behavior regression — the script is right and the assertions describe the version before it.

Also narrowed the neighbouring `not.toContain("npm install")` to `not.toContain("npm install -g")`: the bun path legitimately runs `npm view` for the version check, and the loose form would have started failing for the wrong reason the moment anyone looked closely at it.

`test:behavior` for this file: 14 pass.