### PR TITLE
fix: keep a deferred prompt's inbox episode out of the activity slot

### DIFF
--- a/.changeset/inbox-deferred-lane.md
+++ b/.changeset/inbox-deferred-lane.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop a deferred prompt's Inbox entry from being erased by the target's own activity.
+
+When the delivery gate holds a message, the daemon stores the text and files a `prompt_deferred` Inbox episode — the only pointer to that stored prompt. The Inbox keeps one episode per task+tab and every write clears that slot first, so the moment the target agent started or finished its next turn, the episode was dropped and the stored message became unreachable: retained on disk for its 24h TTL, released by nothing.
+
+`prompt_deferred` now occupies its own lane, so engine activity and a held message coexist. A newer deferral still replaces an older one for the same tab (the store keeps one prompt per tab either way), and releasing from the Inbox still clears both.

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -197,7 +197,7 @@ export class AttentionInboxStore {
     layer: "recent-human-write" | "composer-not-empty",
   ): Promise<void> {
     await this.enqueue(async () => {
-      const key = attentionInboxItemKey({ taskId, tabId })
+      const key = attentionInboxItemKey({ taskId, tabId, state: "prompt_deferred" })
       const next = new Map(this.items)
       next.delete(key)
       next.set(key, {
@@ -224,11 +224,22 @@ export class AttentionInboxStore {
   /** Nullable tabId addresses legacy task-level data only; new writes require a tab. */
   async deleteEpisode(taskId: string, tabId: string | null, at?: number): Promise<boolean> {
     return await this.enqueue(async () => {
-      const key = attentionInboxItemKey({ taskId, tabId })
-      const item = this.items.get(key)
-      if (!item || (at !== undefined && item.at !== at)) return false
+      // Both lanes for this tab — the activity episode and any deferred-prompt
+      // one. Callers address a TAB ("I dealt with this"), not a lane; making
+      // them name the lane would leave whichever they forgot on screen.
+      const keys = [
+        attentionInboxItemKey({ taskId, tabId }),
+        attentionInboxItemKey({ taskId, tabId, state: "prompt_deferred" }),
+      ]
       const next = new Map(this.items)
-      next.delete(key)
+      let removed = false
+      for (const key of keys) {
+        const item = this.items.get(key)
+        if (!item || (at !== undefined && item.at !== at)) continue
+        next.delete(key)
+        removed = true
+      }
+      if (!removed) return false
       await this.commit(next)
       return true
     })

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -344,8 +344,19 @@ export function isAttentionInboxState(value: unknown): value is AttentionInboxSt
   return typeof value === "string" && (ATTENTION_INBOX_STATES as readonly string[]).includes(value)
 }
 
-export function attentionInboxItemKey(item: { taskId: string | null; tabId: string | null }): string {
-  return `${item.taskId}\0${item.tabId ?? ""}`
+export function attentionInboxItemKey(item: {
+  taskId: string | null
+  tabId: string | null
+  state?: AttentionInboxState
+}): string {
+  // `prompt_deferred` gets its own lane. Every other episode DESCRIBES the
+  // engine, so one-per-tab is right: a fresh turn-complete should replace the
+  // stale one. A deferred prompt is not a description — the daemon is holding
+  // a human's text and this episode is the only pointer to it, so sharing the
+  // tab's single slot meant the target's next turn silently orphaned the
+  // record (observed 2026-09-01: four stored prompts, an empty inbox).
+  const lane = item.state === "prompt_deferred" ? "\0deferred" : ""
+  return `${item.taskId}\0${item.tabId ?? ""}${lane}`
 }
 
 /** One daemon-owned, durable attention episode for a task's engine tab. */

--- a/packages/kobe/test/daemon/inbox-deferred-survives-activity.test.ts
+++ b/packages/kobe/test/daemon/inbox-deferred-survives-activity.test.ts
@@ -1,0 +1,78 @@
+/**
+ * A `prompt_deferred` episode is the ONLY pointer to a stored deferred prompt,
+ * so engine activity must not evict it.
+ *
+ * The inbox keeps one episode per task+tab and every write starts by deleting
+ * that key — the dedupe rule that keeps a queue of stale turn-completes from
+ * piling up. `prompt_deferred` does not belong to that family: the daemon is
+ * holding a human's message and the episode is how a human reaches it. When
+ * the target agent simply carried on (a `turn-start`, then a `turn-complete`),
+ * the episode was dropped and the record in `deferred-prompts.json` became an
+ * orphan — retained for its 24h TTL, reachable from nowhere.
+ *
+ * Observed in production 2026-09-01: four stored prompts, `attention-inbox
+ * .json` holding `items: []`.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { afterEach, describe, expect, it } from "vitest"
+
+describe("a deferred prompt's episode outlives the target's own activity", () => {
+  let dir: string | null = null
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+    dir = null
+  })
+
+  async function store() {
+    dir = await mkdtemp(join(tmpdir(), "kobe-inbox-deferred-"))
+    const s = new AttentionInboxStore(join(dir, "attention-inbox.json"), new DaemonEventBus())
+    await s.init()
+    return s
+  }
+
+  it("survives the target starting a new turn", async () => {
+    const s = await store()
+    await s.recordPromptDeferred("t1", "tab-1", "d1", "composer-not-empty")
+    // The agent carries on with whatever it was doing. That says nothing about
+    // the message waiting for a human.
+    await s.record("t1", "turn-start", undefined, "tab-1")
+    expect(s.snapshot().map((e) => e.state)).toEqual(["prompt_deferred"])
+  })
+
+  it("survives the target completing a turn", async () => {
+    const s = await store()
+    await s.recordPromptDeferred("t1", "tab-1", "d1", "composer-not-empty")
+    await s.record("t1", "turn-complete", undefined, "tab-1")
+    // Both are real: one says the agent finished, the other that a message is
+    // held. Losing the second loses a human's text.
+    const states = s.snapshot().map((e) => e.state)
+    expect(states).toContain("prompt_deferred")
+  })
+
+  it("still lets a NEWER deferral replace the older one for the same tab", async () => {
+    // The dedupe rule is right for two deferrals — the store itself keeps one
+    // prompt per tab, so two episodes would point at one record.
+    const s = await store()
+    await s.recordPromptDeferred("t1", "tab-1", "d1", "composer-not-empty")
+    await s.recordPromptDeferred("t1", "tab-1", "d2", "recent-human-write")
+    const deferred = s.snapshot().filter((e) => e.state === "prompt_deferred")
+    expect(deferred).toHaveLength(1)
+    expect(deferred[0]?.detail?.deferredPrompt?.id).toBe("d2")
+  })
+
+  it("is still removable by the release path", async () => {
+    // Surviving activity must not make it unclearable — the Inbox's open
+    // action resolves the record and deletes the episode.
+    const s = await store()
+    await s.recordPromptDeferred("t1", "tab-1", "d1", "composer-not-empty")
+    await s.record("t1", "turn-complete", undefined, "tab-1")
+    expect(await s.deleteEpisode("t1", "tab-1")).toBe(true)
+    expect(s.snapshot().filter((e) => e.state === "prompt_deferred")).toEqual([])
+  })
+})


### PR DESCRIPTION
Observed live: `deferred-prompts.json` holding four messages, `attention-inbox.json` holding `items: []`. Four prompts stored, reachable from nowhere.

## Mechanism

When the delivery gate blocks a paste, ownership moves to the daemon: it stores the text and files a `prompt_deferred` Inbox episode. The episode is the **only** pointer to that record — the prompt text deliberately never lives in the episode.

The Inbox keys episodes `taskId\0tabId` and every write starts by deleting that key. That dedupe is right for the rest of the family: a fresh `turn-complete` should replace the stale one rather than stack. But `prompt_deferred` is not a description of the engine — it is a human's message being held — and it shared the tab's single slot. So the target agent simply carrying on (`turn-start`, then `turn-complete`) evicted it, and the stored prompt sat out its 24h TTL with nothing able to release it.

## Fix

`prompt_deferred` gets its own lane in the key. Activity episodes and a held message now coexist for the same tab.

- A newer deferral still replaces an older one for that tab — the store itself keeps one prompt per tab, so two episodes would point at one record.
- `deleteEpisode` clears **both** lanes: callers address a tab ("I dealt with this"), not a lane, and making them name it would strand whichever they forgot.

## Test

Four cases in `test/daemon/inbox-deferred-survives-activity.test.ts`, all failing before the change:

- survives the target starting a turn ❌→✅
- survives the target completing a turn ❌→✅
- a newer deferral still replaces the older (guards against over-correcting into two episodes per record)
- still removable by the release path (surviving activity must not make it unclearable)

Mutation-verified: collapsing the lane back fails the first two.

`test/daemon` 664 pass; root lint + typecheck clean.