### PR TITLE
fix: no "applies on reopen" toast when the picker already opened that engine

### DIFF
--- a/.changeset/silent-engine-pick-toast.md
+++ b/.changeset/silent-engine-pick-toast.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop the ctrl+e engine picker toasting "applies on reopen" over the tab it just opened.
+
+Picking an engine from the new-conversation dialog opens a tab already running that engine, but it raised the same toast as the `v` row chord — which switches a task's engine for its *next* enter. On the picker's path that line was noise and, worse, untrue about what was on screen. The `v` chord keeps its toast: there, nothing visible changes until the task is reopened.
+
+Failures still toast on both paths — a rejected write leaves a tab labelled with an engine the task does not have.

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -48,7 +48,8 @@ export type WorkspaceTaskActions = {
   renameTask: (id: string) => Promise<void>
   renameBranch: (id: string) => Promise<void>
   cycleVendor: (id: string) => Promise<void>
-  /** ctrl+e picker's engine pick — same persist + toasts as `cycleVendor`. */
+  /** ctrl+e picker's engine pick — same persist as `cycleVendor`, but silent
+   *  on success: the tab it opens already shows the result. */
   setVendor: (id: string, vendor: VendorId) => Promise<void>
   togglePin: (id: string) => Promise<void>
   moveTask: (id: string, delta: -1 | 1) => Promise<void>
@@ -121,8 +122,12 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     renameTask: (id) => renameTaskFlow(taskActions, id),
     renameBranch,
     cycleVendor: (id) => cycleVendorFlow(taskActions, id),
+    // The ctrl+e picker's engine pick. Silent on success: the tab it just
+    // opened IS the new engine, so a toast saying the change "applies on
+    // reopen" contradicted what the user was already looking at. Failures
+    // still toast — see applyVendorChange.
     setVendor: async (id, vendor) => {
-      await applyVendorChange(taskActions, id, vendor)
+      await applyVendorChange(taskActions, id, vendor, { silentSuccess: true })
     },
     togglePin,
     moveTask,

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -310,6 +310,16 @@ export async function applyVendorChange(
   ctx: Pick<TaskActionContext, "orch" | "logger" | "logPrefix" | "notifyError" | "notifyInfo">,
   taskId: string,
   next: VendorId,
+  /**
+   * Skip the success toast. For the caller that ALREADY showed the result: the
+   * ctrl+e picker opens a tab running the new engine right there, so the
+   * "applies on reopen" line was both noise and untrue — the tab in front of
+   * you is already the new engine. The failure toast is never optional; a
+   * rejected write there leaves a tab labelled with an engine the task does
+   * not have, which is exactly the divergence this function was added to
+   * surface.
+   */
+  opts: { readonly silentSuccess?: boolean } = {},
 ): Promise<boolean> {
   if (!ctx.orch) return false
   try {
@@ -319,10 +329,11 @@ export async function applyVendorChange(
     ctx.notifyError?.(`Couldn't switch engine: ${errorMessage(err)}`)
     return false
   }
-  // The new vendor only takes effect on the task's NEXT enter (ensureSession
-  // rebuilds the pane when its `@kobe_vendor` tag no longer matches), so the
-  // gesture looks like a no-op. Surface the deferred-rebuild contract.
-  ctx.notifyInfo?.(`Engine → ${engineDisplayName(next)} (applies on reopen)`)
+  // Only for a change with nothing on screen to show it: the new vendor takes
+  // effect on the task's NEXT enter (ensureSession rebuilds the pane when its
+  // `@kobe_vendor` tag no longer matches), so `v` on a row otherwise looks
+  // like a no-op.
+  if (!opts.silentSuccess) ctx.notifyInfo?.(`Engine → ${engineDisplayName(next)} (applies on reopen)`)
   return true
 }
 

--- a/packages/kobe/test/tui/apply-vendor-change.test.ts
+++ b/packages/kobe/test/tui/apply-vendor-change.test.ts
@@ -34,6 +34,26 @@ describe("applyVendorChange", () => {
     expect(said).toContain("applies on reopen")
   })
 
+  test("stays silent on success when the caller already showed the result", async () => {
+    // The ctrl+e picker opens a tab RUNNING the new engine, so the "applies on
+    // reopen" line was both noise and false — the tab in front of you is
+    // already the new engine.
+    const c = ctx(async () => {})
+    await expect(applyVendorChange(c, "t1", "codex", { silentSuccess: true })).resolves.toBe(true)
+    expect(c.notifyInfo).not.toHaveBeenCalled()
+    expect(c.notifyError).not.toHaveBeenCalled()
+  })
+
+  test("still reports a FAILURE even when success is silent", async () => {
+    // The half that must never be optional: a rejected write leaves a tab
+    // labelled with an engine the task does not have.
+    const c = ctx(async () => {
+      throw new Error("daemon refused")
+    })
+    await expect(applyVendorChange(c, "t1", "codex", { silentSuccess: true })).resolves.toBe(false)
+    expect(c.notifyError).toHaveBeenCalled()
+  })
+
   test("a rejected switch reports the failure and the reason", async () => {
     const c = ctx(async () => {
       throw new Error("daemon refused")


### PR DESCRIPTION
Opening a tab from the ctrl+e picker raised `Engine → claude (applies on reopen)`.

`applyVendorChange` is shared by two callers with opposite visibility:

- **`v` on a sidebar row** — persists the engine for the task's *next* enter. Nothing changes on screen, so without the toast the keypress reads as a no-op. The toast is the whole feedback.
- **the ctrl+e picker** — opens a tab that is *already running* the chosen engine. The toast was noise, and it described a delay that had not happened, over a tab visibly contradicting it.

Adds `silentSuccess` for the picker path.

The **failure** toast stays on both paths and is not made optional: the picker adds its tab to local state first, so a rejected `setVendor` leaves a tab rendered under an engine the task does not have — the exact divergence this function was added to surface. The persist call itself is unchanged; only the success announcement is dropped.

Two tests: silent on success under the flag, and still loud on failure under the same flag. Mutation-verified — removing the guard fails the first.

`test/tui` 1173 pass; root lint + typecheck clean.