### PR TITLE
docs: record the standing authorization to merge a green PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,8 @@ No Linear. Backlog/open issues live in the daemon-owned issue store (web Issues 
 ## Hard rules (non-negotiable)
 
 ### How work lands on `main`
-- **Default: PR.** Feature branch → commits → `gh pr create` → CI green (typecheck/test, behavior, file-size-cap, coverage-cap) → `gh pr merge --squash --delete-branch`. The PR gates are where the hard rules below get enforced, so unattended/agent-driven work always takes this path.
-- **Owner-supervised local iteration may skip the PR**: work in a worktree, get green, then merge/cherry-pick into local `main`. Same quality gates (lint, typecheck, tests, changeset) still apply. Only when the owner is in the loop that turn.
-- A direct push to `main` needs the owner to say so **in that turn** — never inferred, never carried over to the next task.
+- **Default: PR, and merging it needs no fresh approval.** Feature branch → commits → `gh pr create` → CI green (typecheck/test, behavior, file-size-cap, coverage-cap) → `gh pr merge --squash --delete-branch`. Green CI IS the gate; don't stop to ask. Unattended/agent-driven work always takes this path. (Standing authorization, owner 2026-09-01. Does not extend to a release — that still needs the word.)
+- **Skipping the PR** (local merge/cherry-pick into `main`, or a direct push) needs the owner to say so **in that turn** — never inferred, never carried into the next task. Same quality gates (lint, typecheck, tests, changeset) either way.
 - `scripts/release.sh` pushes its own `chore: release — X.Y.Z` commit + tag (see [`docs/RELEASING.md`](./docs/RELEASING.md)).
 - `git fetch` before pushing. Force-push ONLY to rebase your own unmerged PR branch, and only with `--force-with-lease`; never onto `main`, a shared branch, or commits someone has reviewed.
 


### PR DESCRIPTION
Owner, 2026-09-01: *"我等你 pr完毕直接合入就行 不需要等我confirm"*.

Folded into the existing default-PR bullet rather than added as a new one — it is the same rule, with the ambiguity about who presses merge removed. Release is carved out explicitly: `scripts/release.sh` still needs the word in that turn.

To stay inside the file's stated 4k budget (it was at 14,950 of ~15,000 bytes and the new clause pushed it to 15,074), the two skip-the-PR bullets collapse into one. With merging pre-authorized, "owner-supervised local iteration" and "a direct push to main" were the same exception carrying the same condition — say it once:

```
- Skipping the PR (local merge/cherry-pick into main, or a direct push) needs the
  owner to say so in that turn — never inferred, never carried into the next task.
  Same quality gates (lint, typecheck, tests, changeset) either way.
```

Now 14,947 bytes. No rule was dropped, only deduplicated.

`CLAUDE.md` is a symlink to this file, so it follows.