### PR TITLE
docs: date the Conductor reference and name the occupied runtime layer

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3,8 +3,22 @@
 ## Mission
 
 Give one developer a terminal-native control plane for many parallel AI coding
-tasks. Conductor is the layout reference—task rail, workspace, files/diffs,
+tasks. Conductor's layout is the reference—task rail, workspace, files/diffs,
 status—but Rove is local-first and runs the real interactive engine CLIs.
+
+The reference is the SHAPE, frozen at a date, not a product to follow: Conductor
+left this road on 2026-07-30 (0.78.0, "out with worktrees, in with multiplayer
+cloud workspaces") and now sells cloud microVMs. Reading it as a live ancestor
+would point Rove at a destination its ancestor has already abandoned.
+
+Worktree isolation is likewise no longer a differentiator: Claude Code ships
+`-w` since v2.1.50, and the runtime layer below Rove is occupied — Herdr
+(herdrdev/herdr, Rust, 34k stars, daily builds) already does persistent
+sessions, SSH reattach, agent-to-agent socket calls and first-class worktree
+management. What Rove has that a runtime does not is the PRODUCT layer above
+it: kanban, routines, its own issue store, and a path from a finished branch
+back to `main`. That is the thing to keep sharp. See the issue store (#64,
+#71) for the survey behind this paragraph.
 
 ## Principles
 


### PR DESCRIPTION
Closes the documentation half of issue #71 (which corrects #64).

`DESIGN.md` opened with **"Conductor is the layout reference"** in the present tense. Conductor left this road on 2026-07-30 (0.78.0 — *"out with worktrees, in with multiplayer cloud workspaces"*) and now sells cloud microVMs. Read as a live ancestor, that sentence points Rove at a destination its ancestor has already abandoned.

Two changes, both from the surveys already in the issue store:

**1. The reference is a shape, frozen at a date.** The layout is still the right reference; Conductor-the-product is not something to follow.

**2. Name what is no longer a differentiator, and what is.** Claude Code ships `-w` since v2.1.50, so worktree isolation is table stakes. The runtime layer below Rove is occupied — Herdr (Rust, 34k stars, daily builds) already does persistent sessions, SSH reattach, agent-to-agent socket calls, and first-class worktree management. Verified live rather than taken from #71: `gh api repos/herdrdev/herdr` → 34,095 stars, last push 2026-08-31.

What Rove has that a runtime does not is the product layer: kanban, routines, its own issue store, and the path from a finished branch back to `main`. Writing that down is the point — it is also why #66 (fan-out with no fan-in) reads as a hole in the only moat rather than a rough edge.

Doc-only, and `DESIGN.md` is internal (not in `sync-docs.mjs` SECTIONS), so nothing reaches docs.rove.run. `AGENTS.md` already said "Conductor's multi-task **shape**" and is left alone.

Issue #71's other item — a hands-on Herdr comparison (install it, compare the agent-call protocol, state detection, and plugin contract against ours) — is not this PR; it needs its own task.